### PR TITLE
fix(seed): fix password length and admin role field in seed-demo.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ This creates:
 
 | Account | Email | Password | Role |
 |---------|-------|----------|------|
-| Admin   | admin@cellarion.app | Admin1234 | admin |
-| Demo user | user@cellarion.app | User1234 | user |
+| Admin   | admin@cellarion.app | Admin1234!demo | admin |
+| Demo user | user@cellarion.app | User1234!demo | user |
 
 …plus 2 countries, 2 regions, 5 grape varieties, 2 wine definitions, and a demo cellar with sample bottles.
 

--- a/backend/src/seed-demo.js
+++ b/backend/src/seed-demo.js
@@ -6,8 +6,8 @@
  *   docker exec cellarion-backend node src/seed-demo.js
  *
  * Default credentials created:
- *   Admin:  admin@cellarion.app / Admin1234
- *   User:   user@cellarion.app  / User1234
+ *   Admin:  admin@cellarion.app / Admin1234!demo
+ *   User:   user@cellarion.app  / User1234!demo
  *
  * Data created:
  *   2 countries  (France, New Zealand)
@@ -43,8 +43,8 @@ async function seed() {
     admin = await User.create({
       username: 'admin',
       email: 'admin@cellarion.app',
-      password: 'Admin1234',
-      role: 'admin'
+      password: 'Admin1234!demo',
+      roles: ['admin']
     });
     console.log('  Created: admin@cellarion.app (admin)');
   } else {
@@ -56,8 +56,8 @@ async function seed() {
     demoUser = await User.create({
       username: 'demouser',
       email: 'user@cellarion.app',
-      password: 'User1234',
-      role: 'user'
+      password: 'User1234!demo',
+      roles: ['user']
     });
     console.log('  Created: user@cellarion.app (user)');
   } else {
@@ -234,8 +234,8 @@ async function seed() {
   }
 
   console.log('\nDemo seed complete!');
-  console.log('  Admin: admin@cellarion.app / Admin1234');
-  console.log('  User:  user@cellarion.app  / User1234');
+  console.log('  Admin: admin@cellarion.app / Admin1234!demo');
+  console.log('  User:  user@cellarion.app  / User1234!demo');
   await mongoose.disconnect();
 }
 


### PR DESCRIPTION
- Passwords were 8-9 chars, below the User schema's 12-char minimum, causing a validation error on every run.
- role: 'admin' was silently ignored because the schema defines roles (plural array); admin users were created as regular users.

Updated passwords to Admin1234!demo / User1234!demo and changed both User.create() calls to use roles: ['admin'] / roles: ['user']. Updated README credentials table to match.