### PR TITLE
fix(drink-window): restrict drink window input to year and month only

### DIFF
--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { CURRENCIES } from '../config/currencies';
+import { monthToLastDay } from '../utils/drinkStatus';
 import ImageUpload from '../components/ImageUpload';
 import './AddBottle.css';
 
@@ -87,7 +88,9 @@ function AddBottle() {
         wineDefinition: selectedWine._id,
         ...bottleData,
         price: bottleData.price ? parseFloat(bottleData.price) : undefined,
-        rating: bottleData.rating ? parseInt(bottleData.rating) : undefined
+        rating: bottleData.rating ? parseInt(bottleData.rating) : undefined,
+        drinkFrom:   bottleData.drinkFrom   ? `${bottleData.drinkFrom}-01`          : undefined,
+        drinkBefore: bottleData.drinkBefore ? monthToLastDay(bottleData.drinkBefore) : undefined,
       };
 
       // Create N individual bottle records
@@ -363,7 +366,7 @@ function AddBottle() {
                 <div>
                   <label className="sublabel">Drink From</label>
                   <input
-                    type="date"
+                    type="month"
                     value={bottleData.drinkFrom}
                     onChange={(e) => setBottleData({ ...bottleData, drinkFrom: e.target.value })}
                   />
@@ -371,7 +374,7 @@ function AddBottle() {
                 <div>
                   <label className="sublabel">Drink Before</label>
                   <input
-                    type="date"
+                    type="month"
                     value={bottleData.drinkBefore}
                     onChange={(e) => setBottleData({ ...bottleData, drinkBefore: e.target.value })}
                   />

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useAuth, usePlan } from '../contexts/AuthContext';
-import { getDrinkStatus, formatDrinkDate, toInputDate } from '../utils/drinkStatus';
+import { getDrinkStatus, formatDrinkDate, toInputDate, toMonthInput, monthToLastDay } from '../utils/drinkStatus';
 import { fetchRates, convertAmount } from '../utils/currency';
 import './BottleDetail.css';
 
@@ -385,8 +385,8 @@ function EditForm({ bottle, token, onSaved, onCancel }) {
   const [form, setForm] = useState({
     vintage:          bottle.vintage || '',
     rating:           bottle.rating  || '',
-    drinkFrom:        toInputDate(bottle.drinkFrom),
-    drinkBefore:      toInputDate(bottle.drinkBefore),
+    drinkFrom:        toMonthInput(bottle.drinkFrom),
+    drinkBefore:      toMonthInput(bottle.drinkBefore),
     notes:            bottle.notes   || '',
     price:            bottle.price   || '',
     currency:         bottle.currency || 'USD',
@@ -412,8 +412,8 @@ function EditForm({ bottle, token, onSaved, onCancel }) {
           ...form,
           price:  form.price  ? parseFloat(form.price)  : null,
           rating: form.rating ? parseInt(form.rating)   : null,
-          drinkFrom:    form.drinkFrom    || null,
-          drinkBefore:  form.drinkBefore  || null,
+          drinkFrom:    form.drinkFrom   ? `${form.drinkFrom}-01`         : null,
+          drinkBefore:  form.drinkBefore ? monthToLastDay(form.drinkBefore) : null,
           purchaseDate: form.purchaseDate || null,
         })
       });
@@ -486,11 +486,11 @@ function EditForm({ bottle, token, onSaved, onCancel }) {
         <div className="drink-window-fields">
           <div>
             <label className="sublabel">Drink From</label>
-            <input type="date" value={form.drinkFrom} onChange={set('drinkFrom')} />
+            <input type="month" value={form.drinkFrom} onChange={set('drinkFrom')} />
           </div>
           <div>
             <label className="sublabel">Drink Before</label>
-            <input type="date" value={form.drinkBefore} onChange={set('drinkBefore')} />
+            <input type="month" value={form.drinkBefore} onChange={set('drinkBefore')} />
           </div>
         </div>
       </div>

--- a/frontend/src/utils/drinkStatus.js
+++ b/frontend/src/utils/drinkStatus.js
@@ -53,14 +53,31 @@ export function getGroupWorstStatus(bottles) {
   return null;
 }
 
-/** Format a date string for display (e.g. "Mar 15, 2027") */
+/** Format a date string for display (e.g. "Mar 2027") */
 export function formatDrinkDate(dateStr) {
   if (!dateStr) return '';
-  return new Date(dateStr).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  return new Date(dateStr).toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
 }
 
 /** Convert a Date or ISO string to yyyy-mm-dd for date input value */
 export function toInputDate(dateStr) {
   if (!dateStr) return '';
   return new Date(dateStr).toISOString().slice(0, 10);
+}
+
+/** Convert a Date or ISO string to yyyy-mm for month input value */
+export function toMonthInput(dateStr) {
+  if (!dateStr) return '';
+  return new Date(dateStr).toISOString().slice(0, 7);
+}
+
+/**
+ * Convert a yyyy-mm month string to the last day of that month (yyyy-mm-dd).
+ * Used when storing drinkBefore so the full month is included in the window.
+ */
+export function monthToLastDay(yearMonth) {
+  if (!yearMonth) return null;
+  const [year, month] = yearMonth.split('-').map(Number);
+  const lastDay = new Date(year, month, 0).getDate();
+  return `${yearMonth}-${String(lastDay).padStart(2, '0')}`;
 }


### PR DESCRIPTION
Replace type="date" with type="month" on both drinkFrom and drinkBefore inputs in AddBottle and BottleDetail. Add toMonthInput() and monthToLastDay() helpers so drinkFrom is stored as the 1st of the selected month and drinkBefore as the last day. Update formatDrinkDate() to display month + year without the day.