### PR TITLE
feat(security): require auth on /api/wines and restrict regular users…

### DIFF
--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -1,8 +1,11 @@
 const express = require('express');
 const WineDefinition = require('../models/WineDefinition');
 const searchService = require('../services/search');
+const { requireAuth } = require('../middleware/auth');
 
 const router = express.Router();
+
+const USER_SEARCH_LIMIT = 10;
 
 // MongoDB fallback search (used when Meilisearch is unavailable)
 async function mongoSearch(filter, sort, limit, offset, search) {
@@ -39,22 +42,32 @@ async function mongoSearch(filter, sort, limit, offset, search) {
   return { wines, total };
 }
 
-// GET /api/wines - Search/list wines (public, no auth required)
-router.get('/', async (req, res) => {
+// GET /api/wines - Search/list wines (auth required)
+// Regular users: search term mandatory, results capped at USER_SEARCH_LIMIT.
+// Admin / somm: full browse and unlimited results.
+router.get('/', requireAuth, async (req, res) => {
   try {
+    const isPrivileged = req.user.roles.includes('admin') || req.user.roles.includes('somm');
+
     const {
       country,
       region,
       grapes,
       type,
       search,
-      limit = 50,
+      limit = isPrivileged ? 50 : USER_SEARCH_LIMIT,
       offset = 0,
       sort = 'name'
     } = req.query;
 
-    const parsedLimit = parseInt(limit);
-    const parsedOffset = parseInt(offset);
+    if (!isPrivileged && !search) {
+      return res.status(400).json({ error: 'A search term is required' });
+    }
+
+    const parsedLimit = isPrivileged
+      ? parseInt(limit, 10)
+      : Math.min(parseInt(limit, 10) || USER_SEARCH_LIMIT, USER_SEARCH_LIMIT);
+    const parsedOffset = parseInt(offset, 10);
     const grapeIds = grapes ? grapes.split(',') : [];
 
     // Build MongoDB filter (used for non-search queries and as fallback)
@@ -113,8 +126,8 @@ router.get('/', async (req, res) => {
   }
 });
 
-// GET /api/wines/:id - Get single wine definition
-router.get('/:id', async (req, res) => {
+// GET /api/wines/:id - Get single wine definition (auth required)
+router.get('/:id', requireAuth, async (req, res) => {
   try {
     const wine = await WineDefinition.findById(req.params.id)
       .populate(['country', 'region', 'grapes']);

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -32,36 +32,20 @@ function AddBottle() {
   });
   const [uploadedImages, setUploadedImages] = useState([]);
 
-  // Load recent wines on mount so list isn't blank before typing
-  useEffect(() => {
-    loadRecentWines();
-  }, []);
-
   useEffect(() => {
     if (search.length > 0) {
       searchWines();
     } else {
-      loadRecentWines();
+      setWines([]);
     }
   }, [search]);
-
-  const loadRecentWines = async () => {
-    setLoading(true);
-    try {
-      const res = await fetch('/api/wines?sort=-createdAt&limit=12');
-      const data = await res.json();
-      if (res.ok) setWines(data.wines);
-    } catch (err) {
-      console.error('Failed to load recent wines:', err);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const searchWines = async () => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/wines?search=${encodeURIComponent(search)}&limit=20`);
+      const res = await fetch(`/api/wines?search=${encodeURIComponent(search)}&limit=10`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
       const data = await res.json();
       if (res.ok) {
         setWines(data.wines);
@@ -179,15 +163,12 @@ function AddBottle() {
 
           {!loading && wines.length === 0 && (
             <div className="empty-state">
-              <p>{search.length > 2 ? 'No wines matched your search.' : 'No wines in the registry yet.'}</p>
+              <p>{search.length > 0 ? 'No wines matched your search.' : 'Start typing to search for a wine.'}</p>
             </div>
           )}
 
           {wines.length > 0 && (
             <>
-              {search.length <= 2 && (
-                <p className="wines-list-label">Recently added wines — or start typing to search</p>
-              )}
               <div className="wines-list">
                 {wines.map(wine => (
                   <div key={wine._id} className="wine-row" onClick={() => handleSelectWine(wine)}>

--- a/frontend/src/pages/Wines.js
+++ b/frontend/src/pages/Wines.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useAuth } from '../contexts/AuthContext';
 import ImageGallery from '../components/ImageGallery';
 import './Wines.css';
 
@@ -41,8 +42,11 @@ function WineCardImage({ wine }) {
 }
 
 function Wines() {
+  const { token, user } = useAuth();
+  const isPrivileged = user?.roles?.includes('admin') || user?.roles?.includes('somm');
+
   const [wines, setWines] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState('');
   const [filters, setFilters] = useState({
     type: '',
@@ -50,7 +54,11 @@ function Wines() {
   });
 
   useEffect(() => {
-    fetchWines();
+    if (search.length > 0 || isPrivileged) {
+      fetchWines();
+    } else {
+      setWines([]);
+    }
   }, [search, filters]);
 
   const fetchWines = async () => {
@@ -62,7 +70,9 @@ function Wines() {
       params.append('sort', filters.sort);
       params.append('limit', '50');
 
-      const res = await fetch(`/api/wines?${params}`);
+      const res = await fetch(`/api/wines?${params}`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
       const data = await res.json();
       if (res.ok) {
         setWines(data.wines);
@@ -122,7 +132,7 @@ function Wines() {
         <div className="loading">Loading wines...</div>
       ) : wines.length === 0 ? (
         <div className="empty-state">
-          <p>No wines found matching your criteria</p>
+          <p>{search.length === 0 && !isPrivileged ? 'Enter a search term to browse wines.' : 'No wines found matching your criteria.'}</p>
         </div>
       ) : (
         <div className="wines-grid">


### PR DESCRIPTION
… to search-only

- Both GET /api/wines and GET /api/wines/:id now require a valid JWT
- Regular users must provide a search term; results are capped at 10 hits
- Admin and somm roles retain full browse and unlimited result access
- AddBottle: removes unauthenticated recent-wines load on mount, adds auth header to search requests, caps results at 10
- Wines page: adds auth header, defers fetching until search is entered for regular users (admins/somms still load on mount)