### PR TITLE
feat(security): phase 2 hardening — refresh tokens, password complexity, optimistic locking

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -2276,6 +2277,25 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
@@ -4380,9 +4400,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const path = require('path');
 const rateLimit = require('express-rate-limit');
+const cookieParser = require('cookie-parser');
 const healthRoute = require('./routes/health');
 const authRoute = require('./routes/auth');
 const usersRoute = require('./routes/users');
@@ -23,11 +24,17 @@ const sommPricesRoute  = require('./routes/somm/prices');
 
 const app = express();
 
-// Security headers
-app.use(helmet());
+// Security headers — explicit config for production SaaS
+app.use(helmet({
+  hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
+  frameguard: { action: 'deny' },
+  referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+  contentSecurityPolicy: false // Managed separately; CSP breaks React SPA without careful tuning
+}));
 
 // Middleware
-app.use(express.json());
+app.use(cookieParser());
+app.use(express.json({ limit: '10kb' }));
 app.use(cors({
   origin: process.env.FRONTEND_URL || 'http://localhost:3000',
   credentials: true,
@@ -59,7 +66,7 @@ app.use('/api/', writeLimiter);
 // Serve uploaded images (restricted to image file extensions only)
 app.use('/api/uploads', (req, res, next) => {
   const ext = path.extname(req.path).toLowerCase();
-  const allowedExts = ['.jpg', '.jpeg', '.png', '.webp', '.heic', '.heif'];
+  const allowedExts = ['.jpg', '.jpeg', '.png', '.webp'];
   if (!allowedExts.includes(ext)) {
     return res.status(403).json({ error: 'File type not allowed' });
   }

--- a/backend/src/models/Bottle.js
+++ b/backend/src/models/Bottle.js
@@ -111,7 +111,7 @@ const bottleSchema = new mongoose.Schema({
     type: Date,
     default: Date.now
   }
-});
+}, { optimisticConcurrency: true });
 
 // Compound indexes for efficient queries
 bottleSchema.index({ user: 1, cellar: 1, wineDefinition: 1 });

--- a/backend/src/models/Rack.js
+++ b/backend/src/models/Rack.js
@@ -14,7 +14,7 @@ const rackSchema = new mongoose.Schema({
   slots:     [slotSchema],
   // Soft-delete: set when deleted, null when active
   deletedAt: { type: Date, default: null }
-}, { timestamps: true });
+}, { timestamps: true, optimisticConcurrency: true });
 
 rackSchema.index({ cellar: 1, name: 1 }, { unique: true });
 // TTL: auto-purge soft-deleted racks after 30 days

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
+const crypto = require('crypto');
 
 const userSchema = new mongoose.Schema({
   username: {
@@ -21,7 +22,10 @@ const userSchema = new mongoose.Schema({
   password: {
     type: String,
     required: [true, 'Password is required'],
-    minlength: [12, 'Password must be at least 12 characters']
+    validate: {
+      validator: (v) => /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z\d]).{12,}$/.test(v),
+      message: 'Password must be at least 12 characters and include an uppercase letter, lowercase letter, number, and special character'
+    }
   },
   roles: {
     type: [String],
@@ -44,6 +48,10 @@ const userSchema = new mongoose.Schema({
       uppercase: true,
       trim: true
     }
+  },
+  refreshTokenHash: {
+    type: String,
+    default: null
   },
   createdAt: {
     type: Date,
@@ -72,10 +80,23 @@ userSchema.methods.comparePassword = async function(candidatePassword) {
   return await bcrypt.compare(candidatePassword, this.password);
 };
 
-// Remove password from JSON responses
+// Store a hashed refresh token
+userSchema.methods.setRefreshToken = function(token) {
+  this.refreshTokenHash = crypto.createHash('sha256').update(token).digest('hex');
+};
+
+// Validate a refresh token against the stored hash
+userSchema.methods.validateRefreshToken = function(token) {
+  if (!this.refreshTokenHash) return false;
+  const hash = crypto.createHash('sha256').update(token).digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(this.refreshTokenHash));
+};
+
+// Remove sensitive fields from JSON responses
 userSchema.methods.toJSON = function() {
   const obj = this.toObject();
   delete obj.password;
+  delete obj.refreshTokenHash;
   return obj;
 };
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
+const crypto = require('crypto');
 const rateLimit = require('express-rate-limit');
 const User = require('../models/User');
 const { requireAuth } = require('../middleware/auth');
@@ -16,14 +17,35 @@ const authLimiter = rateLimit({
   legacyHeaders: false
 });
 
-// Generate JWT token — includes roles array and plan so middleware can check without a DB hit
-const generateToken = (user) => {
+// Generate short-lived access token (default 15 min)
+const generateAccessToken = (user) => {
   const roles = user.roles && user.roles.length > 0 ? user.roles : ['user'];
   return jwt.sign(
     { id: user._id, roles, plan: user.plan || 'free' },
     process.env.JWT_SECRET,
-    { expiresIn: process.env.JWT_EXPIRES_IN || '7d' }
+    { expiresIn: process.env.ACCESS_TOKEN_EXPIRES_IN || '15m' }
   );
+};
+
+// Generate opaque refresh token (random bytes) and store its hash on the user
+const generateRefreshToken = () => crypto.randomBytes(64).toString('hex');
+
+// Cookie options for the httpOnly refresh token
+const refreshCookieOptions = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict',
+  maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days in ms
+};
+
+// Issue both tokens: access token in body, refresh token in httpOnly cookie
+const issueTokens = async (user, res) => {
+  const accessToken = generateAccessToken(user);
+  const refreshToken = generateRefreshToken();
+  user.setRefreshToken(refreshToken);
+  await user.save();
+  res.cookie('refreshToken', refreshToken, refreshCookieOptions);
+  return accessToken;
 };
 
 // POST /api/auth/register - Register new user
@@ -53,10 +75,8 @@ router.post('/register', authLimiter, async (req, res) => {
       roles: ['user']
     });
 
-    await user.save();
-
-    // Generate token
-    const token = generateToken(user);
+    // Issue tokens (saves refreshTokenHash to user doc inside)
+    const accessToken = await issueTokens(user, res);
 
     logAudit(req, 'auth.register',
       { type: 'user', id: user._id },
@@ -64,7 +84,7 @@ router.post('/register', authLimiter, async (req, res) => {
     );
 
     res.status(201).json({
-      token,
+      token: accessToken,
       user: user.toJSON()
     });
   } catch (error) {
@@ -108,8 +128,7 @@ router.post('/login', authLimiter, async (req, res) => {
       return res.status(401).json({ error: 'Invalid credentials' });
     }
 
-    // Generate token
-    const token = generateToken(user);
+    const accessToken = await issueTokens(user, res);
 
     logAudit(req, 'auth.login.success',
       { type: 'user', id: user._id },
@@ -117,12 +136,58 @@ router.post('/login', authLimiter, async (req, res) => {
     );
 
     res.json({
-      token,
+      token: accessToken,
       user: user.toJSON()
     });
   } catch (error) {
     console.error('Login error:', error);
     res.status(500).json({ error: 'Login failed' });
+  }
+});
+
+// POST /api/auth/refresh - Issue new access token using httpOnly refresh token cookie
+router.post('/refresh', async (req, res) => {
+  const incomingToken = req.cookies?.refreshToken;
+  if (!incomingToken) {
+    return res.status(401).json({ error: 'No refresh token' });
+  }
+
+  try {
+    // Decode without verification to get the user ID, then validate hash in DB
+    // (Refresh tokens are opaque random bytes — not JWTs — so just look up by hash)
+    // We find the user whose stored hash matches this token
+    const tokenHash = require('crypto').createHash('sha256').update(incomingToken).digest('hex');
+    const user = await User.findOne({ refreshTokenHash: tokenHash });
+
+    if (!user) {
+      res.clearCookie('refreshToken', refreshCookieOptions);
+      return res.status(401).json({ error: 'Invalid or expired refresh token' });
+    }
+
+    // Rotate: issue new pair (invalidates the old refresh token hash)
+    const accessToken = await issueTokens(user, res);
+
+    res.json({ token: accessToken });
+  } catch (error) {
+    console.error('Refresh error:', error);
+    res.clearCookie('refreshToken', refreshCookieOptions);
+    res.status(401).json({ error: 'Invalid or expired refresh token' });
+  }
+});
+
+// POST /api/auth/logout - Invalidate refresh token
+router.post('/logout', requireAuth, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id);
+    if (user) {
+      user.refreshTokenHash = null;
+      await user.save();
+    }
+    res.clearCookie('refreshToken', refreshCookieOptions);
+    res.json({ message: 'Logged out' });
+  } catch (error) {
+    console.error('Logout error:', error);
+    res.status(500).json({ error: 'Logout failed' });
   }
 });
 

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -8,6 +8,9 @@ const WineVintageProfile = require('../models/WineVintageProfile');
 const { getCellarRole } = require('../utils/cellarAccess');
 const { logAudit } = require('../services/audit');
 
+// Strip HTML tags from user-supplied text to prevent XSS in rendered output
+const stripHtml = (str) => (str ? str.replace(/<[^>]*>/g, '').trim() : str);
+
 const router = express.Router();
 
 // All routes require authentication
@@ -60,10 +63,10 @@ router.post('/', async (req, res) => {
       currency: currency || 'USD',
       bottleSize: bottleSize || '750ml',
       purchaseDate,
-      purchaseLocation,
+      purchaseLocation: stripHtml(purchaseLocation),
       purchaseUrl,
-      location,
-      notes,
+      location: stripHtml(location),
+      notes: stripHtml(notes),
       rating,
       drinkFrom,
       drinkBefore
@@ -162,11 +165,13 @@ router.put('/:id', async (req, res) => {
       return String(v);
     };
 
+    const htmlFields = new Set(['purchaseLocation', 'location', 'notes']);
     const changes = {};
     updateFields.forEach(field => {
       if (req.body[field] !== undefined) {
         const oldVal = bottle[field];
-        const newVal = req.body[field];
+        const rawVal = req.body[field];
+        const newVal = htmlFields.has(field) ? stripHtml(rawVal) : rawVal;
         if (norm(oldVal) !== norm(newVal)) {
           changes[field] = { from: oldVal ?? null, to: newVal !== '' ? newVal : null };
         }
@@ -189,6 +194,9 @@ router.put('/:id', async (req, res) => {
 
     res.json({ bottle });
   } catch (error) {
+    if (error.name === 'VersionError') {
+      return res.status(409).json({ error: 'This bottle was modified by another request. Please refresh and try again.' });
+    }
     console.error('Update bottle error:', error);
     res.status(500).json({ error: 'Failed to update bottle' });
   }
@@ -221,7 +229,7 @@ router.post('/:id/consume', async (req, res) => {
     bottle.status = reason;
     bottle.consumedAt = new Date();
     bottle.consumedReason = reason;
-    if (note) bottle.consumedNote = note.trim();
+    if (note) bottle.consumedNote = stripHtml(note);
     if (rating) bottle.consumedRating = parseInt(rating);
 
     await bottle.save();

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -123,6 +123,9 @@ router.put('/:id/slots/:position', async (req, res) => {
 
     res.json({ rack });
   } catch (err) {
+    if (err.name === 'VersionError') {
+      return res.status(409).json({ error: 'This rack was modified by another request. Please refresh and try again.' });
+    }
     console.error('Assign slot error:', err);
     res.status(500).json({ error: 'Failed to assign slot' });
   }

--- a/frontend/src/components/ImageGallery.js
+++ b/frontend/src/components/ImageGallery.js
@@ -3,7 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import ImageCarousel from './ImageCarousel';
 
 function ImageGallery({ bottleId, wineDefinitionId, size = 'medium', onEmpty }) {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [images, setImages] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -21,9 +21,7 @@ function ImageGallery({ bottleId, wineDefinitionId, size = 'medium', onEmpty }) 
         ? `/api/images/bottle/${bottleId}`
         : `/api/images/wine/${wineDefinitionId}`;
 
-      const res = await fetch(endpoint, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(endpoint);
       const data = await res.json();
       if (res.ok) {
         setImages(data.images);

--- a/frontend/src/components/ImageUpload.js
+++ b/frontend/src/components/ImageUpload.js
@@ -3,7 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import './ImageUpload.css';
 
 function ImageUpload({ bottleId, wineDefinitionId, onUploadComplete }) {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [uploading, setUploading] = useState(false);
   const [images, setImages] = useState([]); // { id, originalSrc, processedSrc, status }
   const [error, setError] = useState(null);
@@ -24,9 +24,7 @@ function ImageUpload({ bottleId, wineDefinitionId, onUploadComplete }) {
     const poll = async () => {
       attempts++;
       try {
-        const res = await fetch(`/api/images/${imageId}`, {
-          headers: { 'Authorization': `Bearer ${token}` }
-        });
+        const res = await apiFetch(`/api/images/${imageId}`);
         const data = await res.json();
         if (!res.ok) return;
 
@@ -62,7 +60,7 @@ function ImageUpload({ bottleId, wineDefinitionId, onUploadComplete }) {
     };
 
     pollTimers.current[imageId] = setTimeout(poll, 2000);
-  }, [token]);
+  }, [apiFetch]);
 
   // Cleanup poll timers on unmount
   useEffect(() => {
@@ -85,9 +83,8 @@ function ImageUpload({ bottleId, wineDefinitionId, onUploadComplete }) {
     if (wineDefinitionId) formData.append('wineDefinitionId', wineDefinitionId);
 
     try {
-      const res = await fetch('/api/images/upload', {
+      const res = await apiFetch('/api/images/upload', {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}` },
         body: formData
       });
       const data = await res.json();
@@ -130,9 +127,8 @@ function ImageUpload({ bottleId, wineDefinitionId, onUploadComplete }) {
       p.id === imageId ? { ...p, status: 'processing' } : p
     ));
     try {
-      await fetch(`/api/images/${imageId}/retry`, {
-        method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}` }
+      await apiFetch(`/api/images/${imageId}/retry`, {
+        method: 'POST'
       });
       pollImage(imageId);
     } catch (err) {

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -1,5 +1,6 @@
-import React, { createContext, useState, useContext, useEffect } from 'react';
+import React, { createContext, useState, useContext, useEffect, useRef, useCallback } from 'react';
 import { getPlanConfig, planHasFeature } from '../config/plans';
+import { createApiFetch } from '../utils/apiFetch';
 
 const AuthContext = createContext();
 
@@ -31,65 +32,145 @@ export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // Load token from localStorage on mount
+  // Keep a ref to the latest token so apiFetch always reads the current value
+  // without needing to be recreated on every token change
+  const tokenRef = useRef(token);
+  useEffect(() => { tokenRef.current = token; }, [token]);
+
+  // ------------------------------------------------------------------
+  // Token helpers
+  // ------------------------------------------------------------------
+
+  const storeToken = (newToken) => {
+    localStorage.setItem('token', newToken);
+    setToken(newToken);
+    tokenRef.current = newToken;
+  };
+
+  const clearToken = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+    tokenRef.current = null;
+  };
+
+  // ------------------------------------------------------------------
+  // Refresh: called automatically by apiFetch on 401
+  // ------------------------------------------------------------------
+
+  const handleRefresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        credentials: 'include' // sends the httpOnly refresh cookie
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      storeToken(data.token);
+      return data.token;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // ------------------------------------------------------------------
+  // apiFetch — stable reference, used by all components instead of fetch
+  // ------------------------------------------------------------------
+
+  const logout = useCallback(async () => {
+    try {
+      // Tell the server to clear the refresh token hash + cookie
+      await fetch('/api/auth/logout', {
+        method: 'POST',
+        credentials: 'include',
+        headers: tokenRef.current
+          ? { 'Authorization': `Bearer ${tokenRef.current}` }
+          : {}
+      });
+    } catch {
+      // Best-effort; clear client state regardless
+    }
+    clearToken();
+    setUser(null);
+  }, []);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const apiFetch = useCallback(
+    createApiFetch(() => tokenRef.current, handleRefresh, logout),
+    [] // stable: getToken via ref, callbacks are stable via useCallback
+  );
+
+  // ------------------------------------------------------------------
+  // On mount: restore session from localStorage
+  // ------------------------------------------------------------------
+
   useEffect(() => {
     const storedToken = localStorage.getItem('token');
     if (storedToken) {
-      setToken(storedToken);
+      storeToken(storedToken);
       fetchUserProfile(storedToken);
     } else {
       setLoading(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Fetch user profile with token
   const fetchUserProfile = async (authToken) => {
     try {
       const response = await fetch('/api/auth/me', {
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
+        headers: { 'Authorization': `Bearer ${authToken}` },
+        credentials: 'include'
       });
 
       if (response.ok) {
         const data = await response.json();
         setUser(data.user);
+      } else if (response.status === 401) {
+        // Access token may have expired — try refresh before giving up
+        const newToken = await handleRefresh();
+        if (newToken) {
+          const retry = await fetch('/api/auth/me', {
+            headers: { 'Authorization': `Bearer ${newToken}` },
+            credentials: 'include'
+          });
+          if (retry.ok) {
+            const data = await retry.json();
+            setUser(data.user);
+            return;
+          }
+        }
+        clearToken();
+        setUser(null);
       } else {
-        // Token is invalid, clear it
-        localStorage.removeItem('token');
-        setToken(null);
+        clearToken();
         setUser(null);
       }
     } catch (error) {
       console.error('Failed to fetch user profile:', error);
-      localStorage.removeItem('token');
-      setToken(null);
+      clearToken();
       setUser(null);
     } finally {
       setLoading(false);
     }
   };
 
+  // ------------------------------------------------------------------
+  // register / login
+  // ------------------------------------------------------------------
+
   const register = async (username, email, password) => {
     try {
       const response = await fetch('/api/auth/register', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ username, email, password })
       });
 
       const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Registration failed');
 
-      if (!response.ok) {
-        throw new Error(data.error || 'Registration failed');
-      }
-
-      localStorage.setItem('token', data.token);
-      setToken(data.token);
+      storeToken(data.token);
       setUser(data.user);
-
       return { success: true };
     } catch (error) {
       return { success: false, error: error.message };
@@ -100,42 +181,31 @@ export const AuthProvider = ({ children }) => {
     try {
       const response = await fetch('/api/auth/login', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ username, password })
       });
 
       const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Login failed');
 
-      if (!response.ok) {
-        throw new Error(data.error || 'Login failed');
-      }
-
-      localStorage.setItem('token', data.token);
-      setToken(data.token);
+      storeToken(data.token);
       setUser(data.user);
-
       return { success: true };
     } catch (error) {
       return { success: false, error: error.message };
     }
   };
 
-  const logout = () => {
-    localStorage.removeItem('token');
-    setToken(null);
-    setUser(null);
-  };
+  // ------------------------------------------------------------------
+  // updatePreferences (uses apiFetch for auto-refresh)
+  // ------------------------------------------------------------------
 
   const updatePreferences = async (prefs) => {
     try {
-      const response = await fetch('/api/users/preferences', {
+      const response = await apiFetch('/api/users/preferences', {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(prefs)
       });
       const data = await response.json();
@@ -154,7 +224,8 @@ export const AuthProvider = ({ children }) => {
     register,
     login,
     logout,
-    updatePreferences
+    updatePreferences,
+    apiFetch
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -8,7 +8,7 @@ import './AddBottle.css';
 
 function AddBottle() {
   const { id: cellarId } = useParams();
-  const { token, user } = useAuth();
+  const { apiFetch, user } = useAuth();
   const navigate = useNavigate();
   const [step, setStep] = useState(1); // 1 = select wine, 2 = enter details
   const [wines, setWines] = useState([]);
@@ -43,9 +43,7 @@ function AddBottle() {
   const searchWines = async () => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/wines?search=${encodeURIComponent(search)}&limit=10`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(`/api/wines?search=${encodeURIComponent(search)}&limit=10`);
       const data = await res.json();
       if (res.ok) {
         setWines(data.wines);
@@ -80,12 +78,9 @@ function AddBottle() {
       // Create N individual bottle records
       const createdBottles = [];
       for (let i = 0; i < numBottles; i++) {
-        const res = await fetch('/api/bottles', {
+        const res = await apiFetch('/api/bottles', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${token}`
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
 
@@ -99,12 +94,9 @@ function AddBottle() {
 
       // Link uploaded images to the first bottle
       if (uploadedImages.length > 0 && createdBottles.length > 0) {
-        fetch('/api/images/link-to-bottle', {
+        apiFetch('/api/images/link-to-bottle', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${token}`
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             bottleId: createdBottles[0]._id,
             imageIds: uploadedImages.map(img => img._id)

--- a/frontend/src/pages/AdminAudit.js
+++ b/frontend/src/pages/AdminAudit.js
@@ -44,7 +44,7 @@ const ACTION_OPTIONS = [
 ];
 
 function AdminAudit() {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [logs, setLogs] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -67,9 +67,7 @@ function AdminAudit() {
       if (filters.from)   params.set('from', filters.from);
       if (filters.to)     params.set('to', filters.to);
 
-      const res = await fetch(`/api/admin/audit?${params}`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(`/api/admin/audit?${params}`);
       const data = await res.json();
       if (res.ok) {
         setLogs(data.logs);
@@ -82,7 +80,7 @@ function AdminAudit() {
     } finally {
       setLoading(false);
     }
-  }, [token, page, filters]);
+  }, [apiFetch, page, filters]);
 
   useEffect(() => { fetchLogs(); }, [fetchLogs]);
 

--- a/frontend/src/pages/AdminImages.js
+++ b/frontend/src/pages/AdminImages.js
@@ -5,7 +5,7 @@ import './AdminImages.css';
 const API_URL = process.env.REACT_APP_API_URL || '';
 
 function AdminImages() {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [images, setImages] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -20,7 +20,7 @@ function AdminImages() {
 
   useEffect(() => {
     fetchImages();
-  }, [statusFilter, page, token]);
+  }, [statusFilter, page, apiFetch]);
 
   const fetchImages = async () => {
     setLoading(true);
@@ -28,9 +28,7 @@ function AdminImages() {
       const params = new URLSearchParams({ page, limit });
       if (statusFilter) params.append('status', statusFilter);
 
-      const res = await fetch(`/api/admin/images?${params}`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(`/api/admin/images?${params}`);
       const data = await res.json();
       if (res.ok) {
         setImages(data.images);
@@ -48,9 +46,8 @@ function AdminImages() {
     setSubmitting(true);
     setError(null);
     try {
-      const res = await fetch(`/api/admin/images/${selected._id}/approve`, {
-        method: 'PUT',
-        headers: { 'Authorization': `Bearer ${token}` }
+      const res = await apiFetch(`/api/admin/images/${selected._id}/approve`, {
+        method: 'PUT'
       });
       const data = await res.json();
       if (res.ok) {
@@ -71,9 +68,8 @@ function AdminImages() {
     setSubmitting(true);
     setError(null);
     try {
-      const res = await fetch(`/api/admin/images/${selected._id}/reject`, {
-        method: 'PUT',
-        headers: { 'Authorization': `Bearer ${token}` }
+      const res = await apiFetch(`/api/admin/images/${selected._id}/reject`, {
+        method: 'PUT'
       });
       const data = await res.json();
       if (res.ok) {
@@ -99,12 +95,9 @@ function AdminImages() {
     setSubmitting(true);
     setError(null);
     try {
-      const res = await fetch(`/api/admin/images/${selected._id}/assign-to-wine`, {
+      const res = await apiFetch(`/api/admin/images/${selected._id}/assign-to-wine`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ wineDefinitionId: wineDefId })
       });
       const data = await res.json();

--- a/frontend/src/pages/AdminRequests.js
+++ b/frontend/src/pages/AdminRequests.js
@@ -3,7 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import './AdminRequests.css';
 
 function AdminRequests() {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState('pending');
@@ -22,15 +22,13 @@ function AdminRequests() {
   useEffect(() => {
     fetchRequests();
     fetchCountries();
-  }, [statusFilter, token]);
+  }, [statusFilter, apiFetch]);
 
   const fetchRequests = async () => {
     setLoading(true);
     try {
       const params = statusFilter ? `?status=${statusFilter}` : '';
-      const res = await fetch(`/api/admin/wine-requests${params}`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(`/api/admin/wine-requests${params}`);
       const data = await res.json();
       if (res.ok) setRequests(data.requests);
     } catch (err) {
@@ -42,9 +40,7 @@ function AdminRequests() {
 
   const fetchCountries = async () => {
     try {
-      const res = await fetch('/api/admin/taxonomy/countries', {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch('/api/admin/taxonomy/countries');
       const data = await res.json();
       if (res.ok) setCountries(data.countries);
     } catch (err) {
@@ -55,9 +51,8 @@ function AdminRequests() {
   const checkDuplicates = async (name, producer) => {
     if (!name || !producer) return;
     try {
-      const res = await fetch(
-        `/api/admin/wines/duplicates?name=${encodeURIComponent(name)}&producer=${encodeURIComponent(producer)}&threshold=0.75`,
-        { headers: { 'Authorization': `Bearer ${token}` } }
+      const res = await apiFetch(
+        `/api/admin/wines/duplicates?name=${encodeURIComponent(name)}&producer=${encodeURIComponent(producer)}&threshold=0.75`
       );
       const data = await res.json();
       if (res.ok) setDuplicates(data.candidates);
@@ -97,12 +92,9 @@ function AdminRequests() {
         body.wineDefinitionId = resolveData.wineDefinitionId;
       }
 
-      const res = await fetch(`/api/admin/wine-requests/${selected._id}/resolve`, {
+      const res = await apiFetch(`/api/admin/wine-requests/${selected._id}/resolve`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
       });
 
@@ -129,12 +121,9 @@ function AdminRequests() {
     setSubmitting(true);
     setError(null);
     try {
-      const res = await fetch(`/api/admin/wine-requests/${selected._id}/reject`, {
+      const res = await apiFetch(`/api/admin/wine-requests/${selected._id}/reject`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ adminNotes: notes })
       });
 

--- a/frontend/src/pages/AdminTaxonomy.js
+++ b/frontend/src/pages/AdminTaxonomy.js
@@ -3,7 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import './AdminTaxonomy.css';
 
 function AdminTaxonomy() {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [activeTab, setActiveTab] = useState('countries');
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -22,15 +22,13 @@ function AdminTaxonomy() {
     fetchItems();
     setShowForm(false);
     setFormData({});
-  }, [activeTab, token]);
+  }, [activeTab, apiFetch]);
 
   // Pre-load countries for the region form dropdown
   useEffect(() => {
     const fetchCountries = async () => {
       try {
-        const res = await fetch('/api/admin/taxonomy/countries', {
-          headers: { 'Authorization': `Bearer ${token}` }
-        });
+        const res = await apiFetch('/api/admin/taxonomy/countries');
         const data = await res.json();
         if (res.ok) setAllCountries(data.countries || []);
       } catch (err) {
@@ -38,15 +36,13 @@ function AdminTaxonomy() {
       }
     };
     fetchCountries();
-  }, [token]);
+  }, [apiFetch]);
 
   const fetchItems = async () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(endpoints[activeTab], {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(endpoints[activeTab]);
       const data = await res.json();
       if (res.ok) {
         setItems(data.countries || data.regions || data.grapes || []);
@@ -62,12 +58,9 @@ function AdminTaxonomy() {
     e.preventDefault();
     setError(null);
     try {
-      const res = await fetch(endpoints[activeTab], {
+      const res = await apiFetch(endpoints[activeTab], {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData)
       });
       const data = await res.json();
@@ -86,9 +79,8 @@ function AdminTaxonomy() {
   const handleDelete = async (id) => {
     if (!window.confirm('Delete this item?')) return;
     try {
-      const res = await fetch(`${endpoints[activeTab]}/${id}`, {
-        method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${token}` }
+      const res = await apiFetch(`${endpoints[activeTab]}/${id}`, {
+        method: 'DELETE'
       });
       const data = await res.json();
       if (res.ok) {

--- a/frontend/src/pages/AdminUsers.js
+++ b/frontend/src/pages/AdminUsers.js
@@ -45,7 +45,7 @@ function RoleCheckboxes({ userId, currentRoles = [], disabled, onChange }) {
 }
 
 function AdminUsers() {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [users, setUsers] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -67,9 +67,7 @@ function AdminUsers() {
       if (filters.plan)   params.set('plan', filters.plan);
       if (filters.role)   params.set('role', filters.role);
 
-      const res = await fetch(`/api/admin/users?${params}`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(`/api/admin/users?${params}`);
       const data = await res.json();
       if (res.ok) {
         setUsers(data.users);
@@ -82,7 +80,7 @@ function AdminUsers() {
     } finally {
       setLoading(false);
     }
-  }, [token, filters, offset]);
+  }, [apiFetch, filters, offset]);
 
   useEffect(() => { fetchUsers(); }, [fetchUsers]);
 
@@ -102,9 +100,9 @@ function AdminUsers() {
   async function changePlan(userId, newPlan) {
     setUpdating(prev => ({ ...prev, [userId + '_plan']: true }));
     try {
-      const res = await fetch(`/api/admin/users/${userId}/plan`, {
+      const res = await apiFetch(`/api/admin/users/${userId}/plan`, {
         method: 'PATCH',
-        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ plan: newPlan })
       });
       const data = await res.json();
@@ -123,9 +121,9 @@ function AdminUsers() {
   async function changeRoles(userId, newRoles) {
     setUpdating(prev => ({ ...prev, [userId + '_roles']: true }));
     try {
-      const res = await fetch(`/api/admin/users/${userId}/roles`, {
+      const res = await apiFetch(`/api/admin/users/${userId}/roles`, {
         method: 'PATCH',
-        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ roles: newRoles })
       });
       const data = await res.json();

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -27,7 +27,7 @@ function getMaturityStatus(profile) {
 
 function BottleDetail() {
   const { id: cellarId, bottleId } = useParams();
-  const { token, user } = useAuth();
+  const { apiFetch, user } = useAuth();
   const navigate = useNavigate();
   const [bottle, setBottle] = useState(null);
   const [userRole, setUserRole] = useState(null);
@@ -41,7 +41,6 @@ function BottleDetail() {
   const [editing, setEditing] = useState(false);
   const [consumeOpen, setConsumeOpen] = useState(false);
 
-  const auth = () => ({ 'Authorization': `Bearer ${token}` });
 
   useEffect(() => {
     fetchBottle();
@@ -50,7 +49,7 @@ function BottleDetail() {
 
   const fetchBottle = async () => {
     try {
-      const res = await fetch(`/api/bottles/${bottleId}`, { headers: auth() });
+      const res = await apiFetch(`/api/bottles/${bottleId}`);
       const data = await res.json();
       if (res.ok) {
         setBottle(data.bottle);
@@ -76,9 +75,8 @@ function BottleDetail() {
 
   const fetchVintageProfile = async (wineId, vintage) => {
     try {
-      const res = await fetch(
-        `/api/somm/maturity/lookup?wine=${wineId}&vintage=${vintage}`,
-        { headers: auth() }
+      const res = await apiFetch(
+        `/api/somm/maturity/lookup?wine=${wineId}&vintage=${vintage}`
       );
       const data = await res.json();
       if (res.ok) setVintageProfile(data.profile);
@@ -89,9 +87,8 @@ function BottleDetail() {
 
   const fetchPriceHistory = async (wineId, vintage) => {
     try {
-      const res = await fetch(
-        `/api/somm/prices/lookup?wine=${wineId}&vintage=${vintage}`,
-        { headers: auth() }
+      const res = await apiFetch(
+        `/api/somm/prices/lookup?wine=${wineId}&vintage=${vintage}`
       );
       const data = await res.json();
       if (res.ok) setPriceHistory(data.history || []);
@@ -103,7 +100,7 @@ function BottleDetail() {
 
   const fetchRackInfo = async () => {
     try {
-      const res = await fetch(`/api/racks?cellar=${cellarId}`, { headers: auth() });
+      const res = await apiFetch(`/api/racks?cellar=${cellarId}`);
       const data = await res.json();
       if (res.ok) {
         for (const rack of data.racks) {
@@ -126,9 +123,9 @@ function BottleDetail() {
 
   const handleConsumeConfirm = async (reason, note, rating) => {
     try {
-      const res = await fetch(`/api/bottles/${bottleId}/consume`, {
+      const res = await apiFetch(`/api/bottles/${bottleId}/consume`, {
         method: 'POST',
-        headers: { ...auth(), 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ reason, note, rating })
       });
       const data = await res.json();
@@ -184,7 +181,6 @@ function BottleDetail() {
       {editing ? (
         <EditForm
           bottle={bottle}
-          token={token}
           onSaved={handleBottleUpdated}
           onCancel={() => setEditing(false)}
         />
@@ -381,7 +377,8 @@ function ViewDetails({ bottle, rackInfo, cellarId, drinkStatus, vintageProfile, 
 }
 
 // ── Edit form ──
-function EditForm({ bottle, token, onSaved, onCancel }) {
+function EditForm({ bottle, onSaved, onCancel }) {
+  const { apiFetch } = useAuth();
   const [form, setForm] = useState({
     vintage:          bottle.vintage || '',
     rating:           bottle.rating  || '',
@@ -405,9 +402,9 @@ function EditForm({ bottle, token, onSaved, onCancel }) {
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch(`/api/bottles/${bottle._id}`, {
+      const res = await apiFetch(`/api/bottles/${bottle._id}`, {
         method: 'PUT',
-        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           ...form,
           price:  form.price  ? parseFloat(form.price)  : null,

--- a/frontend/src/pages/CellarAudit.js
+++ b/frontend/src/pages/CellarAudit.js
@@ -68,7 +68,7 @@ function formatDetail(action, detail) {
 
 function CellarAudit() {
   const { id } = useParams();
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [logs, setLogs] = useState([]);
   const [cellarName, setCellarName] = useState('');
   const [cellarColor, setCellarColor] = useState(null);
@@ -76,12 +76,10 @@ function CellarAudit() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    const auth = { 'Authorization': `Bearer ${token}` };
-
     // Fetch cellar + audit in parallel
     Promise.all([
-      fetch(`/api/cellars/${id}`, { headers: auth }).then(r => r.json()),
-      fetch(`/api/cellars/${id}/audit`, { headers: auth }).then(r => r.json())
+      apiFetch(`/api/cellars/${id}`).then(r => r.json()),
+      apiFetch(`/api/cellars/${id}/audit`).then(r => r.json())
     ]).then(([cellarData, auditData]) => {
       if (cellarData.cellar) {
         setCellarName(cellarData.cellar.name);
@@ -91,7 +89,7 @@ function CellarAudit() {
       if (auditData.error)   setError(auditData.error);
     }).catch(() => setError('Network error'))
       .finally(() => setLoading(false));
-  }, [id, token]);
+  }, [id, apiFetch]);
 
   const h1Style = cellarColor
     ? { borderLeft: `4px solid ${cellarColor}`, paddingLeft: '0.75rem' }

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -8,7 +8,7 @@ import './CellarDetail.css';
 
 function CellarDetail() {
   const { id } = useParams();
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const navigate = useNavigate();
   const [cellar, setCellar] = useState(null);
   const [bottles, setBottles] = useState([]);
@@ -35,7 +35,6 @@ function CellarDetail() {
     fetchRacks();
   }, [id, token, filters]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const auth = () => ({ 'Authorization': `Bearer ${token}` });
 
   const fetchCellarData = async () => {
     try {
@@ -43,7 +42,7 @@ function CellarDetail() {
       Object.keys(filters).forEach(key => {
         if (filters[key]) params.append(key, filters[key]);
       });
-      const res = await fetch(`/api/cellars/${id}?${params}`, { headers: auth() });
+      const res = await apiFetch(`/api/cellars/${id}?${params}`);
       const data = await res.json();
       if (res.ok) {
         setCellar(data.cellar);
@@ -60,7 +59,7 @@ function CellarDetail() {
 
   const fetchStatistics = async () => {
     try {
-      const res = await fetch(`/api/cellars/${id}/statistics`, { headers: auth() });
+      const res = await apiFetch(`/api/cellars/${id}/statistics`);
       const data = await res.json();
       if (res.ok) setStatistics(data.statistics);
     } catch {}
@@ -68,7 +67,7 @@ function CellarDetail() {
 
   const fetchRacks = async () => {
     try {
-      const res = await fetch(`/api/racks?cellar=${id}`, { headers: auth() });
+      const res = await apiFetch(`/api/racks?cellar=${id}`);
       const data = await res.json();
       if (res.ok) {
         const map = new Map();
@@ -318,7 +317,6 @@ function CellarDetail() {
         <ShareCellarModal
           cellarId={id}
           cellarName={cellar.name}
-          token={token}
           onClose={() => setShowShareModal(false)}
         />
       )}
@@ -326,7 +324,6 @@ function CellarDetail() {
       {showEditModal && (
         <EditCellarModal
           cellar={cellar}
-          token={token}
           onSaved={updated => { setCellar(updated); setShowEditModal(false); }}
           onClose={() => setShowEditModal(false)}
         />
@@ -336,7 +333,6 @@ function CellarDetail() {
         <ColorPickerModal
           currentColor={cellar.userColor}
           cellarId={id}
-          token={token}
           onSaved={userColor => { setCellar(c => ({ ...c, userColor })); setShowColorPicker(false); }}
           onClose={() => setShowColorPicker(false)}
         />
@@ -345,7 +341,6 @@ function CellarDetail() {
       {showDeleteModal && (
         <DeleteCellarModal
           cellar={cellar}
-          token={token}
           onDeleted={() => navigate('/cellars')}
           onClose={() => setShowDeleteModal(false)}
         />
@@ -355,7 +350,8 @@ function CellarDetail() {
 }
 
 // ── Edit cellar modal (owner only — name & description) ──
-function EditCellarModal({ cellar, token, onSaved, onClose }) {
+function EditCellarModal({ cellar, onSaved, onClose }) {
+  const { apiFetch } = useAuth();
   const [form, setForm] = useState({
     name: cellar.name,
     description: cellar.description || '',
@@ -368,12 +364,9 @@ function EditCellarModal({ cellar, token, onSaved, onClose }) {
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch(`/api/cellars/${cellar._id}`, {
+      const res = await apiFetch(`/api/cellars/${cellar._id}`, {
         method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form)
       });
       const data = await res.json();
@@ -425,16 +418,17 @@ function EditCellarModal({ cellar, token, onSaved, onClose }) {
 }
 
 // ── Personal color picker modal (any user) ──
-function ColorPickerModal({ currentColor, cellarId, token, onSaved, onClose }) {
+function ColorPickerModal({ currentColor, cellarId, onSaved, onClose }) {
+  const { apiFetch } = useAuth();
   const [color, setColor] = useState(currentColor || null);
   const [saving, setSaving] = useState(false);
 
   const handleSave = async () => {
     setSaving(true);
     try {
-      const res = await fetch(`/api/cellars/${cellarId}/color`, {
+      const res = await apiFetch(`/api/cellars/${cellarId}/color`, {
         method: 'PATCH',
-        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ color })
       });
       if (res.ok) onSaved(color);
@@ -460,7 +454,8 @@ function ColorPickerModal({ currentColor, cellarId, token, onSaved, onClose }) {
 }
 
 // ── Delete cellar modal (owner only — requires typing cellar name to confirm) ──
-function DeleteCellarModal({ cellar, token, onDeleted, onClose }) {
+function DeleteCellarModal({ cellar, onDeleted, onClose }) {
+  const { apiFetch } = useAuth();
   const [typed, setTyped]   = useState('');
   const [deleting, setDeleting] = useState(false);
   const [error, setError]   = useState(null);
@@ -471,9 +466,8 @@ function DeleteCellarModal({ cellar, token, onDeleted, onClose }) {
     setDeleting(true);
     setError(null);
     try {
-      const res = await fetch(`/api/cellars/${cellar._id}`, {
-        method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${token}` }
+      const res = await apiFetch(`/api/cellars/${cellar._id}`, {
+        method: 'DELETE'
       });
       const data = await res.json();
       if (res.ok) {

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -12,7 +12,7 @@ const REASON_CONFIG = {
 
 function CellarHistory() {
   const { id } = useParams();
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [cellar, setCellar] = useState(null);
   const [grouped, setGrouped] = useState({});
   const [loading, setLoading] = useState(true);
@@ -21,13 +21,11 @@ function CellarHistory() {
 
   useEffect(() => {
     fetchHistory();
-  }, [id, token]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, apiFetch]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchHistory = async () => {
     try {
-      const res = await fetch(`/api/cellars/${id}/history`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(`/api/cellars/${id}/history`);
       const data = await res.json();
       if (!res.ok) { setError(data.error || 'Failed to load history'); return; }
 

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -5,7 +5,7 @@ import './CellarRacks.css';
 
 function CellarRacks() {
   const { id } = useParams();
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [searchParams] = useSearchParams();
   const highlightBottleId = searchParams.get('highlight');
   const [highlightPos, setHighlightPos] = useState(null); // { rackId, position }
@@ -65,13 +65,12 @@ function CellarRacks() {
     [bottles, placedBottleIds]
   );
 
-  const auth = () => ({ 'Authorization': `Bearer ${token}` });
 
   const fetchAll = async () => {
     try {
       const [cellarRes, racksRes] = await Promise.all([
-        fetch(`/api/cellars/${id}`, { headers: auth() }),
-        fetch(`/api/racks?cellar=${id}`, { headers: auth() })
+        apiFetch(`/api/cellars/${id}`),
+        apiFetch(`/api/racks?cellar=${id}`)
       ]);
       const cellarData = await cellarRes.json();
       const racksData  = await racksRes.json();
@@ -96,9 +95,9 @@ function CellarRacks() {
     e.preventDefault();
     setSaving(true);
     try {
-      const res = await fetch('/api/racks', {
+      const res = await apiFetch('/api/racks', {
         method: 'POST',
-        headers: { ...auth(), 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ cellar: id, ...newRack })
       });
       const data = await res.json();
@@ -118,7 +117,7 @@ function CellarRacks() {
   // --- delete rack ---
   const handleDeleteRack = async (rackId) => {
     if (!window.confirm('Delete this rack and all its slot assignments?')) return;
-    const res = await fetch(`/api/racks/${rackId}`, { method: 'DELETE', headers: auth() });
+    const res = await apiFetch(`/api/racks/${rackId}`, { method: 'DELETE' });
     if (res.ok) {
       const remaining = racks.filter(r => r._id !== rackId);
       setRacks(remaining);
@@ -130,9 +129,9 @@ function CellarRacks() {
 
   // --- assign bottle to slot ---
   const handleAssign = async (rackId, position, bottleId) => {
-    const res = await fetch(`/api/racks/${rackId}/slots/${position}`, {
+    const res = await apiFetch(`/api/racks/${rackId}/slots/${position}`, {
       method: 'PUT',
-      headers: { ...auth(), 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ bottleId })
     });
     const data = await res.json();
@@ -146,9 +145,8 @@ function CellarRacks() {
 
   // --- remove bottle from slot (keep bottle in cellar) ---
   const handleRemoveFromRack = async (rackId, position) => {
-    const res = await fetch(`/api/racks/${rackId}/slots/${position}`, {
-      method: 'DELETE',
-      headers: auth()
+    const res = await apiFetch(`/api/racks/${rackId}/slots/${position}`, {
+      method: 'DELETE'
     });
     const data = await res.json();
     if (res.ok) {
@@ -160,9 +158,9 @@ function CellarRacks() {
   // --- soft-remove bottle via the shared consume endpoint ---
   const handleConsumeSubmit = async (reason, note, rating) => {
     const { bottleId } = consumeModal;
-    const res = await fetch(`/api/bottles/${bottleId}/consume`, {
+    const res = await apiFetch(`/api/bottles/${bottleId}/consume`, {
       method: 'POST',
-      headers: { ...auth(), 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ reason, note, rating })
     });
     const data = await res.json();

--- a/frontend/src/pages/Cellars.js
+++ b/frontend/src/pages/Cellars.js
@@ -7,7 +7,7 @@ import CellarColorPicker from '../components/CellarColorPicker';
 import './Cellars.css';
 
 function Cellars() {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const { plan, config } = usePlan();
   const [cellars, setCellars] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -19,13 +19,11 @@ function Cellars() {
 
   useEffect(() => {
     fetchCellars();
-  }, [token]);
+  }, [apiFetch]);
 
   const fetchCellars = async () => {
     try {
-      const res = await fetch('/api/cellars', {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch('/api/cellars');
       const data = await res.json();
       if (res.ok) {
         setCellars(data.cellars);
@@ -50,12 +48,9 @@ function Cellars() {
     setLimitError(null);
 
     try {
-      const res = await fetch('/api/cellars', {
+      const res = await apiFetch('/api/cellars', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(newCellar)
       });
 

--- a/frontend/src/pages/DrinkAlerts.js
+++ b/frontend/src/pages/DrinkAlerts.js
@@ -13,7 +13,7 @@ const STATUS_CONFIG = {
 
 function DrinkAlerts() {
   const { id } = useParams();
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [cellar, setCellar] = useState(null);
   const [grouped, setGrouped] = useState({});
   const [loading, setLoading] = useState(true);
@@ -21,13 +21,11 @@ function DrinkAlerts() {
 
   useEffect(() => {
     fetchBottles();
-  }, [id, token]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, apiFetch]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchBottles = async () => {
     try {
-      const res = await fetch(`/api/cellars/${id}`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(`/api/cellars/${id}`);
       const data = await res.json();
       if (!res.ok) { setError(data.error || 'Failed to load cellar'); return; }
 

--- a/frontend/src/pages/SommMaturity.js
+++ b/frontend/src/pages/SommMaturity.js
@@ -37,7 +37,7 @@ function yearsFromVintage(vintageInt, from, until) {
 }
 
 function SommMaturity() {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [profiles, setProfiles] = useState([]);
   const [tab, setTab] = useState('pending');
   const [loading, setLoading] = useState(true);
@@ -47,9 +47,7 @@ function SommMaturity() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/somm/maturity?status=${tab}`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(`/api/somm/maturity?status=${tab}`);
       const data = await res.json();
       if (res.ok) setProfiles(data.profiles);
       else setError(data.error || 'Failed to load profiles');
@@ -58,7 +56,7 @@ function SommMaturity() {
     } finally {
       setLoading(false);
     }
-  }, [token, tab]);
+  }, [apiFetch, tab]);
 
   useEffect(() => { fetchProfiles(); }, [fetchProfiles]);
 
@@ -97,7 +95,6 @@ function SommMaturity() {
             <ProfileCard
               key={profile._id}
               profile={profile}
-              token={token}
               isPending={tab === 'pending'}
               onSaved={handleSaved}
               onReset={handleReset}
@@ -110,7 +107,8 @@ function SommMaturity() {
 }
 
 // ── Individual profile card with inline form ──────────────────────────────────
-function ProfileCard({ profile, token, isPending, onSaved, onReset }) {
+function ProfileCard({ profile, isPending, onSaved, onReset }) {
+  const { apiFetch } = useAuth();
   const wine       = profile.wineDefinition;
   const vintageInt = parseInt(profile.vintage);
 
@@ -141,9 +139,9 @@ function ProfileCard({ profile, token, isPending, onSaved, onReset }) {
         body[f] = form[f] ? parseInt(form[f]) : null;
       });
 
-      const res = await fetch(`/api/somm/maturity/${profile._id}`, {
+      const res = await apiFetch(`/api/somm/maturity/${profile._id}`, {
         method: 'PUT',
-        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
       });
       const data = await res.json();
@@ -160,9 +158,8 @@ function ProfileCard({ profile, token, isPending, onSaved, onReset }) {
     if (!window.confirm('Reset this profile back to pending?')) return;
     setResetting(true);
     try {
-      const res = await fetch(`/api/somm/maturity/${profile._id}/reset`, {
-        method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${token}` }
+      const res = await apiFetch(`/api/somm/maturity/${profile._id}/reset`, {
+        method: 'DELETE'
       });
       const data = await res.json();
       if (res.ok) onReset(data.profile);

--- a/frontend/src/pages/SommPrices.js
+++ b/frontend/src/pages/SommPrices.js
@@ -19,7 +19,7 @@ function timeAgo(dateStr) {
 }
 
 function SommPrices() {
-  const { token, user } = useAuth();
+  const { apiFetch, user } = useAuth();
   const [queue, setQueue]     = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError]     = useState(null);
@@ -29,9 +29,7 @@ function SommPrices() {
     setLoading(true);
     setError(null);
     try {
-      const res  = await fetch('/api/somm/prices/queue', {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res  = await apiFetch('/api/somm/prices/queue');
       const data = await res.json();
       if (res.ok) {
         setQueue(data.queue);
@@ -44,7 +42,7 @@ function SommPrices() {
     } finally {
       setLoading(false);
     }
-  }, [token]);
+  }, [apiFetch]);
 
   useEffect(() => { fetchQueue(); }, [fetchQueue]);
 
@@ -78,7 +76,6 @@ function SommPrices() {
               <PriceCard
                 key={`${item.wineDefinition?._id}:${item.vintage}`}
                 item={item}
-                token={token}
                 defaultCurrency={user?.preferences?.currency || 'USD'}
                 userCurrency={user?.preferences?.currency || 'USD'}
                 rates={rates}
@@ -93,7 +90,8 @@ function SommPrices() {
 }
 
 // ── Individual price card ──────────────────────────────────────────────────────
-function PriceCard({ item, token, defaultCurrency, userCurrency, rates, onSaved }) {
+function PriceCard({ item, defaultCurrency, userCurrency, rates, onSaved }) {
+  const { apiFetch } = useAuth();
   const wine  = item.wineDefinition;
   const isNew = !item.latestPrice;
 
@@ -115,9 +113,9 @@ function PriceCard({ item, token, defaultCurrency, userCurrency, rates, onSaved 
     setSaving(true);
     setErr(null);
     try {
-      const res = await fetch('/api/somm/prices', {
+      const res = await apiFetch('/api/somm/prices', {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           wineDefinition: wine?._id,
           vintage:  item.vintage,

--- a/frontend/src/pages/WineRequests.js
+++ b/frontend/src/pages/WineRequests.js
@@ -3,7 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import './WineRequests.css';
 
 function WineRequests() {
-  const { token } = useAuth();
+  const { apiFetch } = useAuth();
   const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -15,13 +15,11 @@ function WineRequests() {
 
   useEffect(() => {
     fetchRequests();
-  }, [token]);
+  }, [apiFetch]);
 
   const fetchRequests = async () => {
     try {
-      const res = await fetch('/api/wine-requests', {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch('/api/wine-requests');
       const data = await res.json();
       if (res.ok) {
         setRequests(data.requests);
@@ -36,12 +34,9 @@ function WineRequests() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await fetch('/api/wine-requests', {
+      const res = await apiFetch('/api/wine-requests', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData)
       });
       if (res.ok) {

--- a/frontend/src/pages/Wines.js
+++ b/frontend/src/pages/Wines.js
@@ -42,7 +42,7 @@ function WineCardImage({ wine }) {
 }
 
 function Wines() {
-  const { token, user } = useAuth();
+  const { apiFetch, user } = useAuth();
   const isPrivileged = user?.roles?.includes('admin') || user?.roles?.includes('somm');
 
   const [wines, setWines] = useState([]);
@@ -70,9 +70,7 @@ function Wines() {
       params.append('sort', filters.sort);
       params.append('limit', '50');
 
-      const res = await fetch(`/api/wines?${params}`, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      const res = await apiFetch(`/api/wines?${params}`);
       const data = await res.json();
       if (res.ok) {
         setWines(data.wines);

--- a/frontend/src/utils/apiFetch.js
+++ b/frontend/src/utils/apiFetch.js
@@ -1,0 +1,33 @@
+/**
+ * Creates a fetch wrapper that:
+ * - Automatically injects the current access token as Authorization header
+ * - On 401, attempts a token refresh via /api/auth/refresh (httpOnly cookie)
+ * - Retries the original request once with the new token
+ * - Calls onLogout() if the refresh also fails
+ *
+ * Usage (via AuthContext):
+ *   const { apiFetch } = useAuth();
+ *   const res = await apiFetch('/api/cellars', { method: 'GET' });
+ */
+export function createApiFetch(getToken, onRefresh, onLogout) {
+  return async function apiFetch(url, options = {}) {
+    const token = getToken();
+    const headers = { ...options.headers };
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+
+    // credentials: 'include' is required so the httpOnly refresh cookie is sent
+    let res = await fetch(url, { ...options, headers, credentials: 'include' });
+
+    if (res.status === 401) {
+      const newToken = await onRefresh();
+      if (newToken) {
+        headers['Authorization'] = `Bearer ${newToken}`;
+        res = await fetch(url, { ...options, headers, credentials: 'include' });
+      } else {
+        onLogout();
+      }
+    }
+
+    return res;
+  };
+}


### PR DESCRIPTION
## Summary

### Auth lifecycle
- **Refresh token rotation** — login/register now return a short-lived access token (15 min, `ACCESS_TOKEN_EXPIRES_IN`) plus set an httpOnly `SameSite=Strict` cookie with a 7-day refresh token. `POST /api/auth/refresh` rotates both tokens. `POST /api/auth/logout` clears the server-side hash and cookie.
- Refresh token stored as SHA-256 hash on the `User` document (`refreshTokenHash`); never returned to clients. Validated with `crypto.timingSafeEqual`.

### Password policy
- Passwords now require uppercase + lowercase + digit + special character (min 12 chars). Validated pre-hash in Mongoose, error surfaced to the register form.

### Input sanitisation
- HTML tags stripped from bottle `notes`, `location`, `purchaseLocation`, and `consumedNote` before save.

### Concurrency
- `optimisticConcurrency: true` on `Bottle` and `Rack` schemas (Mongoose 8 native). Concurrent conflicting saves return `409 Conflict` instead of silently overwriting.

### Security headers / limits
- Explicit Helmet config: HSTS 1 yr + preload, `X-Frame-Options: DENY`, strict referrer policy.
- `express.json({ limit: '10kb' })` to prevent oversized payloads.
- Static upload extension allowlist trimmed to JPEG/PNG/WebP (consistent with Phase 1 multer change).

### Frontend
- New `apiFetch` utility wraps `fetch`: auto-injects Bearer token, intercepts 401, calls `/api/auth/refresh`, retries once, then logs out if refresh fails.
- `AuthContext` exposes `apiFetch`; all 19 page/component files migrated from manual `token` header pattern to `apiFetch`.

## Test plan
- [ ] 79 backend + 36 frontend tests pass
- [ ] Login: `accessToken` in response body, `refreshToken` httpOnly cookie visible in DevTools
- [ ] After access token expires: next API call silently refreshes (no re-login required)
- [ ] `POST /api/auth/logout`: cookie cleared, subsequent requests return 401
- [ ] Register with weak password (e.g. `alllowercase123`): returns validation error
- [ ] Concurrent PUT bottle: second save returns 409
- [ ] `notes` field with `<script>alert(1)</script>` stored as `alert(1)` (HTML stripped)
