### PR TITLE
feat(rate-limits): raise defaults, add audit logging, and admin config UI

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -17,10 +17,13 @@ const adminWineRequestsRoute = require('./routes/admin/wineRequests');
 const adminImagesRoute = require('./routes/admin/images');
 const adminAuditRoute = require('./routes/admin/audit');
 const adminUsersRoute = require('./routes/admin/users');
+const adminSettingsRoute = require('./routes/admin/settings');
 const racksRoute = require('./routes/racks');
 const imagesRoute = require('./routes/images');
 const sommMaturityRoute = require('./routes/somm/maturity');
 const sommPricesRoute  = require('./routes/somm/prices');
+const rateLimitsConfig = require('./config/rateLimits');
+const { logAudit } = require('./services/audit');
 
 const app = express();
 
@@ -45,24 +48,30 @@ app.use(cors({
   allowedHeaders: ['Content-Type', 'Authorization']
 }));
 
-// Global API rate limiter — 100 requests per 15 min per IP
+// Global API rate limiter — default 200 requests per 15 min per IP (admin-configurable)
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
-  message: { error: 'Too many requests, please try again later' },
+  max: () => rateLimitsConfig.get().api.max,
   standardHeaders: true,
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'api', limit: rateLimitsConfig.get().api.max });
+    res.status(429).json({ error: 'Too many requests, please try again later' });
+  }
 });
 app.use('/api/', apiLimiter);
 
-// Stricter limiter for write operations (POST/PUT/DELETE/PATCH)
+// Stricter limiter for write operations (POST/PUT/DELETE/PATCH) — default 60 per 15 min
 const writeLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 30,
-  message: { error: 'Too many write requests, please try again later' },
+  max: () => rateLimitsConfig.get().write.max,
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req) => req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS'
+  skip: (req) => req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS',
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'write', limit: rateLimitsConfig.get().write.max });
+    res.status(429).json({ error: 'Too many write requests, please try again later' });
+  }
 });
 app.use('/api/', writeLimiter);
 
@@ -90,6 +99,7 @@ app.use('/api/admin/wine-requests', adminWineRequestsRoute);
 app.use('/api/admin/images', adminImagesRoute);
 app.use('/api/admin/audit', adminAuditRoute);
 app.use('/api/admin/users', adminUsersRoute);
+app.use('/api/admin/settings', adminSettingsRoute);
 app.use('/api/racks', racksRoute);
 app.use('/api/images', imagesRoute);
 app.use('/api/somm/maturity', sommMaturityRoute);
@@ -99,5 +109,10 @@ app.use('/api/somm/prices',  sommPricesRoute);
 app.use((req, res) => {
   res.status(404).json({ error: 'Route not found' });
 });
+
+// Load rate limit configuration from DB on startup (non-blocking; falls back to defaults)
+rateLimitsConfig.load().catch(err =>
+  console.warn('[rateLimits] Startup load failed, using defaults:', err.message)
+);
 
 module.exports = app;

--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -1,0 +1,44 @@
+/**
+ * In-memory cache for rate limit configuration.
+ * Loaded once from MongoDB on startup; updated instantly when admin saves new values.
+ * Falls back to defaults if the DB is unavailable.
+ */
+
+const defaults = {
+  api:   { max: 200 },
+  write: { max: 60 },
+  auth:  { max: 10 }
+};
+
+let cache = {
+  api:   { max: defaults.api.max },
+  write: { max: defaults.write.max },
+  auth:  { max: defaults.auth.max }
+};
+
+async function load() {
+  try {
+    // Lazy require to avoid circular dependency at module load time
+    const SiteConfig = require('../models/SiteConfig');
+    const doc = await SiteConfig.findOne({ key: 'rateLimits' });
+    if (doc && doc.value) {
+      cache = {
+        api:   { max: doc.value.api?.max   ?? defaults.api.max   },
+        write: { max: doc.value.write?.max ?? defaults.write.max },
+        auth:  { max: doc.value.auth?.max  ?? defaults.auth.max  }
+      };
+    }
+  } catch (err) {
+    console.warn('[rateLimits] Could not load config from DB, using defaults:', err.message);
+  }
+}
+
+function get() {
+  return cache;
+}
+
+function set(value) {
+  cache = value;
+}
+
+module.exports = { load, get, set, defaults };

--- a/backend/src/models/SiteConfig.js
+++ b/backend/src/models/SiteConfig.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const siteConfigSchema = new mongoose.Schema({
+  key:       { type: String, required: true, unique: true },
+  value:     { type: mongoose.Schema.Types.Mixed, required: true },
+  updatedAt: { type: Date, default: Date.now },
+  updatedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null }
+}, { versionKey: false });
+
+module.exports = mongoose.model('SiteConfig', siteConfigSchema);

--- a/backend/src/routes/admin/settings.js
+++ b/backend/src/routes/admin/settings.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const { requireAuth, requireRole } = require('../../middleware/auth');
+const SiteConfig = require('../../models/SiteConfig');
+const rateLimitsConfig = require('../../config/rateLimits');
+const { logAudit } = require('../../services/audit');
+
+const router = express.Router();
+
+// All routes require admin
+router.use(requireAuth, requireRole('admin'));
+
+// GET /api/admin/settings/rate-limits
+router.get('/rate-limits', async (req, res) => {
+  try {
+    res.json({
+      config:   rateLimitsConfig.get(),
+      defaults: rateLimitsConfig.defaults
+    });
+  } catch (err) {
+    console.error('Admin get rate-limits error:', err);
+    res.status(500).json({ error: 'Failed to load rate limit settings' });
+  }
+});
+
+// PATCH /api/admin/settings/rate-limits
+router.patch('/rate-limits', async (req, res) => {
+  try {
+    const { api, write, auth } = req.body;
+
+    const previous = { ...rateLimitsConfig.get() };
+
+    // Validate provided fields
+    const incoming = { api, write, auth };
+    for (const [name, val] of Object.entries(incoming)) {
+      if (val !== undefined) {
+        if (!Number.isInteger(val.max) || val.max < 1 || val.max > 10000) {
+          return res.status(400).json({
+            error: `${name}.max must be an integer between 1 and 10000`
+          });
+        }
+      }
+    }
+
+    const updated = {
+      api:   { max: api?.max   ?? previous.api.max   },
+      write: { max: write?.max ?? previous.write.max },
+      auth:  { max: auth?.max  ?? previous.auth.max  }
+    };
+
+    await SiteConfig.findOneAndUpdate(
+      { key: 'rateLimits' },
+      { key: 'rateLimits', value: updated, updatedAt: new Date(), updatedBy: req.user.id },
+      { upsert: true, new: true }
+    );
+
+    rateLimitsConfig.set(updated);
+
+    logAudit(req, 'admin.settings.rate_limits.update', {}, { from: previous, to: updated });
+
+    res.json({ config: updated });
+  } catch (err) {
+    console.error('Admin update rate-limits error:', err);
+    res.status(500).json({ error: 'Failed to update rate limit settings' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -5,16 +5,20 @@ const rateLimit = require('express-rate-limit');
 const User = require('../models/User');
 const { requireAuth } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
+const rateLimitsConfig = require('../config/rateLimits');
 
 const router = express.Router();
 
-// Rate limiter for auth endpoints
+// Rate limiter for auth endpoints — default 10 per 15 min (admin-configurable)
 const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 10, // 10 attempts per window per IP
-  message: { error: 'Too many attempts, please try again later' },
+  windowMs: 15 * 60 * 1000,
+  max: () => rateLimitsConfig.get().auth.max,
   standardHeaders: true,
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'auth', limit: rateLimitsConfig.get().auth.max });
+    res.status(429).json({ error: 'Too many attempts, please try again later' });
+  }
 });
 
 // Generate short-lived access token (default 15 min)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import AdminTaxonomy from './pages/AdminTaxonomy';
 import AdminImages from './pages/AdminImages';
 import AdminAudit from './pages/AdminAudit';
 import AdminUsers from './pages/AdminUsers';
+import AdminSettings from './pages/AdminSettings';
 import CellarAudit from './pages/CellarAudit';
 import CellarRacks from './pages/CellarRacks';
 import DrinkAlerts from './pages/DrinkAlerts';
@@ -196,6 +197,14 @@ function AppRoutes() {
         element={
           <ProtectedRoute requireAdmin>
             <Layout><AdminUsers /></Layout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/admin/settings"
+        element={
+          <ProtectedRoute requireAdmin>
+            <Layout><AdminSettings /></Layout>
           </ProtectedRoute>
         }
       />

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -136,6 +136,13 @@ function Layout({ children }) {
                 >
                   {t('nav.users')}
                 </Link>
+                <Link
+                  to="/admin/settings"
+                  className={`admin-link ${isActive('/admin/settings') ? 'active' : ''}`}
+                  onClick={closeMenu}
+                >
+                  {t('nav.adminSettings')}
+                </Link>
               </>
             )}
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -51,6 +51,7 @@
     "imageReview": "Image Review",
     "auditLog": "Audit Log",
     "users": "Users",
+    "adminSettings": "Settings",
     "settings": "Settings",
     "logout": "Logout",
     "toggleNav": "Toggle navigation",
@@ -496,6 +497,22 @@
       "page": "Page {{current}} of {{total}}",
       "previousBtn": "Previous",
       "nextBtn": "Next"
+    },
+    "settings": {
+      "title": "Admin: Settings",
+      "loading": "Loading settings…",
+      "rateLimits": "Rate Limits",
+      "rateLimitsHint": "Maximum number of requests per IP address per 15-minute window. Changes take effect immediately without a server restart.",
+      "apiLimiter": "Global API Limiter",
+      "writeLimiter": "Write Operations Limiter",
+      "authLimiter": "Auth Limiter",
+      "perWindow": "req / 15 min",
+      "default": "Default: {{count}}",
+      "save": "Save",
+      "saving": "Saving…",
+      "saved": "Settings saved",
+      "errorLoad": "Failed to load settings",
+      "errorSave": "Failed to save settings"
     }
   },
 

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -51,6 +51,7 @@
     "imageReview": "Bildgranskning",
     "auditLog": "Aktivitetslogg",
     "users": "Användare",
+    "adminSettings": "Inställningar",
     "settings": "Inställningar",
     "logout": "Logga ut",
     "toggleNav": "Växla navigering",
@@ -496,6 +497,22 @@
       "page": "Sida {{current}} av {{total}}",
       "previousBtn": "Föregående",
       "nextBtn": "Nästa"
+    },
+    "settings": {
+      "title": "Admin: Inställningar",
+      "loading": "Laddar inställningar…",
+      "rateLimits": "Hastighetsbegränsningar",
+      "rateLimitsHint": "Maximalt antal förfrågningar per IP-adress per 15-minutersfönster. Ändringar träder i kraft omedelbart utan omstart av servern.",
+      "apiLimiter": "Globalt API-begränsare",
+      "writeLimiter": "Skrivoperationsbegränsare",
+      "authLimiter": "Autentiseringsbegränsare",
+      "perWindow": "förfr. / 15 min",
+      "default": "Standard: {{count}}",
+      "save": "Spara",
+      "saving": "Sparar…",
+      "saved": "Inställningar sparade",
+      "errorLoad": "Det gick inte att läsa in inställningar",
+      "errorSave": "Det gick inte att spara inställningar"
     }
   },
 

--- a/frontend/src/pages/AdminAudit.css
+++ b/frontend/src/pages/AdminAudit.css
@@ -80,6 +80,7 @@
 .audit-row--bottle  { background: rgba(107, 158, 120, 0.03); }
 .audit-row--cellar  { background: rgba(200, 168, 126, 0.03); }
 .audit-row--admin   { background: rgba(123, 158, 136, 0.04); }
+.audit-row--system  { background: rgba(180, 100,  60, 0.03); }
 
 .audit-row:hover td { background: rgba(255,255,255,0.03); }
 
@@ -98,6 +99,7 @@
 .audit-action-badge--bottle { background: rgba(107,158,120,0.15); color: #6B9E78; }
 .audit-action-badge--cellar { background: rgba(200,168,126,0.15); color: #C8A87E; }
 .audit-action-badge--admin  { background: rgba(123,158,136,0.15); color: #7B9E88; }
+.audit-action-badge--system { background: rgba(180,100,60,0.15);  color: #C47840; }
 .audit-action-badge--other  { background: rgba(224,112,96,0.15);  color: #E07060; }
 
 /* ── Cells ── */

--- a/frontend/src/pages/AdminAudit.js
+++ b/frontend/src/pages/AdminAudit.js
@@ -5,10 +5,11 @@ import './AdminAudit.css';
 
 // Color category for each action prefix
 const ACTION_CATEGORY = {
-  'auth':  'auth',
+  'auth':   'auth',
   'bottle': 'bottle',
   'cellar': 'cellar',
-  'admin':  'admin'
+  'admin':  'admin',
+  'system': 'system'
 };
 
 function getCategory(action) {
@@ -41,7 +42,8 @@ const ACTION_OPTIONS = [
   'admin.wine.create', 'admin.wine.update', 'admin.wine.delete',
   'admin.request.resolve', 'admin.request.reject',
   'admin.taxonomy.create', 'admin.taxonomy.delete',
-  'admin.image.approve', 'admin.image.reject', 'admin.image.assign'
+  'admin.image.approve', 'admin.image.reject', 'admin.image.assign',
+  'system.rate_limit_exceeded'
 ];
 
 function AdminAudit() {

--- a/frontend/src/pages/AdminSettings.css
+++ b/frontend/src/pages/AdminSettings.css
@@ -1,0 +1,105 @@
+.admin-settings-page {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.page-header h1 {
+  margin: 0;
+}
+
+/* ── Section ── */
+.settings-section {
+  background: #141414;
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.settings-section h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+  color: #E8DFD0;
+}
+
+.settings-hint {
+  margin: 0 0 1.25rem;
+  font-size: 0.85rem;
+  color: #9A9484;
+}
+
+/* ── Limiter rows ── */
+.settings-limiters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.limiter-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.limiter-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  flex: 1;
+}
+
+.limiter-name {
+  font-size: 0.9rem;
+  color: #E8DFD0;
+}
+
+.limiter-default {
+  font-size: 0.75rem;
+  color: #9A9484;
+}
+
+.limiter-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.limiter-input-wrap input[type="number"] {
+  width: 90px;
+  text-align: right;
+}
+
+.limiter-unit {
+  font-size: 0.8rem;
+  color: #9A9484;
+  white-space: nowrap;
+}
+
+/* ── Actions ── */
+.settings-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.settings-saved {
+  font-size: 0.85rem;
+  color: #6B9E78;
+}
+
+/* ── Mobile ── */
+@media (max-width: 600px) {
+  .limiter-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/AdminSettings.js
+++ b/frontend/src/pages/AdminSettings.js
@@ -1,0 +1,136 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import './AdminSettings.css';
+
+const LIMITERS = [
+  { key: 'api',   labelKey: 'admin.settings.apiLimiter'   },
+  { key: 'write', labelKey: 'admin.settings.writeLimiter' },
+  { key: 'auth',  labelKey: 'admin.settings.authLimiter'  }
+];
+
+function AdminSettings() {
+  const { t } = useTranslation();
+  const { apiFetch } = useAuth();
+
+  const [config,   setConfig]   = useState(null);
+  const [defaults, setDefaults] = useState(null);
+  const [form,     setForm]     = useState({ api: '', write: '', auth: '' });
+  const [loading,  setLoading]  = useState(true);
+  const [error,    setError]    = useState(null);
+  const [saving,   setSaving]   = useState(false);
+  const [saved,    setSaved]    = useState(false);
+
+  const fetchConfig = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res  = await apiFetch('/api/admin/settings/rate-limits');
+      const data = await res.json();
+      if (res.ok) {
+        setConfig(data.config);
+        setDefaults(data.defaults);
+        setForm({
+          api:   String(data.config.api.max),
+          write: String(data.config.write.max),
+          auth:  String(data.config.auth.max)
+        });
+      } else {
+        setError(data.error || t('admin.settings.errorLoad'));
+      }
+    } catch {
+      setError(t('admin.settings.errorLoad'));
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch, t]);
+
+  useEffect(() => { fetchConfig(); }, [fetchConfig]);
+
+  async function handleSave(e) {
+    e.preventDefault();
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      const body = {
+        api:   { max: Number(form.api)   },
+        write: { max: Number(form.write) },
+        auth:  { max: Number(form.auth)  }
+      };
+      const res  = await apiFetch('/api/admin/settings/rate-limits', {
+        method:  'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(body)
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setConfig(data.config);
+        setSaved(true);
+        setTimeout(() => setSaved(false), 3000);
+      } else {
+        setError(data.error || t('admin.settings.errorSave'));
+      }
+    } catch {
+      setError(t('admin.settings.errorSave'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="admin-settings-page">
+      <div className="page-header">
+        <h1>{t('admin.settings.title')}</h1>
+      </div>
+
+      {error && <div className="error-message">{error}</div>}
+
+      {loading ? (
+        <div className="loading-spinner">{t('admin.settings.loading')}</div>
+      ) : (
+        <form className="settings-form" onSubmit={handleSave}>
+          <section className="settings-section">
+            <h2>{t('admin.settings.rateLimits')}</h2>
+            <p className="settings-hint">{t('admin.settings.rateLimitsHint')}</p>
+
+            <div className="settings-limiters">
+              {LIMITERS.map(({ key, labelKey }) => (
+                <div className="limiter-row" key={key}>
+                  <div className="limiter-label">
+                    <span className="limiter-name">{t(labelKey)}</span>
+                    {defaults && (
+                      <span className="limiter-default">
+                        {t('admin.settings.default', { count: defaults[key].max })}
+                      </span>
+                    )}
+                  </div>
+                  <div className="limiter-input-wrap">
+                    <input
+                      type="number"
+                      min="1"
+                      max="10000"
+                      value={form[key]}
+                      onChange={e => setForm(prev => ({ ...prev, [key]: e.target.value }))}
+                      required
+                    />
+                    <span className="limiter-unit">{t('admin.settings.perWindow')}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <div className="settings-actions">
+            <button type="submit" className="btn btn-primary" disabled={saving}>
+              {saving ? t('admin.settings.saving') : t('admin.settings.save')}
+            </button>
+            {saved && <span className="settings-saved">{t('admin.settings.saved')}</span>}
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+export default AdminSettings;


### PR DESCRIPTION
## Summary

- **Higher defaults** — Global API limit raised from 100 → 200 req/15 min; write limit from 30 → 60 req/15 min, so normal users no longer hit 429 under ordinary use
- **Audit logging on 429** — Every rate limit hit now creates a `system.rate_limit_exceeded` AuditLog entry (limiter name + current limit), visible in Admin → Audit Log with an orange badge
- **Live admin configuration** — New Admin → Settings page lets admins adjust all three limits (API, Write, Auth) from the UI; changes persist to MongoDB and take effect immediately without a server restart

## What changed

| Area | Files |
|------|-------|
| New model | `backend/src/models/SiteConfig.js` |
| New config cache | `backend/src/config/rateLimits.js` |
| New admin route | `backend/src/routes/admin/settings.js` |
| New frontend page | `frontend/src/pages/AdminSettings.{js,css}` |
| Modified | `backend/src/app.js`, `backend/src/routes/auth.js` |
| Modified | `frontend/src/App.js`, `frontend/src/components/Layout.js` |
| Modified | `frontend/src/pages/AdminAudit.{js,css}` |
| Modified | `frontend/src/locales/{en,sv}/translation.json` |

## Test plan

- [x] `cd frontend && npm test -- --watchAll=false` — all 45 tests pass
- [x] `docker-compose up --build` — smoke test; confirm app loads and no startup errors
- [x] Log in as a regular user and verify the 429 no longer triggers under normal browsing
- [x] Log in as admin, navigate to Admin → Settings, change API max to 5, confirm requests are blocked at 5, restore default
- [x] Trigger a 429 and verify a `system.rate_limit_exceeded` entry appears in Admin → Audit Log with an orange badge