### PR TITLE
fix(racks): remove stale token dep from CellarRacks useEffect

### DIFF
--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -34,7 +34,7 @@ function CellarRacks() {
 
   useEffect(() => {
     fetchAll();
-  }, [id, token]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // When racks load and a highlight param is set, find and select that slot
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Removes `token` from the `useEffect` dependency array on line 37 of `CellarRacks.js`
- `token` was never declared in this component, causing `ReferenceError: token is not defined` on mount and crashing the `/cellars/:id/racks` page
- The same stale reference was previously fixed in `CellarDetail` — this applies the same fix to `CellarRacks`
- The effect only needs to re-run when `id` changes, which is the remaining dependency

## Test plan

- [x] Navigate to `/cellars/:id/racks` — page loads without error
- [x] `cd frontend && npm test -- --watchAll=false` — all tests pass