### PR TITLE
fix(ui): improve mobile responsiveness for ordinary users

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -13,6 +13,8 @@ body {
   color: #E8DFD0;
   /* Remove 300ms tap delay on mobile */
   touch-action: manipulation;
+  /* Prevent stray elements from creating a page-wide horizontal scrollbar */
+  overflow-x: hidden;
 }
 
 h1 {
@@ -183,6 +185,12 @@ a {
     min-width: 100px;
     text-align: center;
     white-space: nowrap;
+  }
+
+  /* Overflow menu trigger should never grow — keep it compact */
+  .page-header .header-actions .btn-more {
+    flex: none;
+    min-width: unset;
   }
 
   .grid-2 {

--- a/frontend/src/pages/CellarDetail.css
+++ b/frontend/src/pages/CellarDetail.css
@@ -45,6 +45,15 @@
   flex-shrink: 0;
 }
 
+/* On mobile the global rule stretches .btn inside .header-actions to flex:1.
+   Override that here so the icon buttons stay compact, not wide blocks. */
+@media (max-width: 768px) {
+  .page-header .header-actions .btn {
+    flex: none;
+    min-width: unset;
+  }
+}
+
 /* Hide the text label on small screens, keep icons */
 @media (max-width: 500px) {
   .btn-label { display: none; }
@@ -426,26 +435,25 @@
 @media (max-width: 768px) {
   .filters-bar,
   .filters-bar-5 {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 0.5rem;
-    padding-bottom: 0.5rem;
-    grid-template-columns: unset;
+    overflow: visible;
+    padding-bottom: 0;
+  }
+
+  /* Search input spans the full two-column width */
+  .filters-bar .search-input,
+  .filters-bar-5 .search-input {
+    grid-column: 1 / -1;
   }
 
   .search-input,
   .filter-input,
   .filter-select {
-    flex-shrink: 0;
-    min-width: 140px;
-    max-width: 200px;
-  }
-
-  .search-input {
-    min-width: 180px;
+    min-width: unset;
+    max-width: unset;
+    width: 100%;
   }
 
   .statistics-grid {

--- a/frontend/src/pages/Login.css
+++ b/frontend/src/pages/Login.css
@@ -2,9 +2,11 @@
   min-height: 100vh;
   background: linear-gradient(160deg, #0a0a0a 0%, #0f1a12 60%, #141e17 100%);
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 2rem;
+  gap: 1.5rem;
 }
 
 .login-card {
@@ -92,4 +94,37 @@
 .login-card .form-group input:focus {
   border-color: #7B9E88;
   background: #2a2a2a;
+}
+
+/* ── Open-source footer ── */
+.login-footer {
+  text-align: center;
+  color: #5a5550;
+  font-size: 0.8rem;
+  line-height: 1.7;
+  max-width: 380px;
+}
+
+.login-footer p {
+  margin: 0.2rem 0;
+}
+
+.login-footer a {
+  color: #7B9E88;
+  text-decoration: none;
+}
+
+.login-footer a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 480px) {
+  .login-page {
+    padding: 1rem;
+    gap: 1.25rem;
+  }
+
+  .login-card {
+    padding: 1.5rem 1.25rem;
+  }
 }

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -70,6 +70,26 @@ function Login() {
     setResendStatus(null);
   };
 
+  const footer = (
+    <footer className="login-footer">
+      <p>
+        Cellarion is{' '}
+        <a href="https://github.com/jagduvi1/Cellarion" target="_blank" rel="noopener noreferrer">
+          open source
+        </a>
+        . Have an idea or found a bug?{' '}
+        <a href="https://github.com/jagduvi1/Cellarion/issues" target="_blank" rel="noopener noreferrer">
+          Open an issue on GitHub
+        </a>
+        .
+      </p>
+      <p>
+        Need help with your account?{' '}
+        <a href="mailto:support@cellarion.app">Contact support</a>.
+      </p>
+    </footer>
+  );
+
   if (registered) {
     return (
       <div className="login-page">
@@ -98,6 +118,7 @@ function Login() {
             </button>
           </p>
         </div>
+        {footer}
       </div>
     );
   }
@@ -183,6 +204,7 @@ function Login() {
           </button>
         </form>
       </div>
+      {footer}
     </div>
   );
 }

--- a/frontend/src/pages/WineRequests.css
+++ b/frontend/src/pages/WineRequests.css
@@ -54,3 +54,14 @@
   border-top: 1px solid #2a2a2a;
   color: #9A9484;
 }
+
+@media (max-width: 600px) {
+  .request-card {
+    padding: 1rem;
+  }
+
+  .request-header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary

- **CellarDetail filters** — replaced the horizontal-scroll row of 5 inputs (required sideways swiping on phones) with a 2-column grid: search bar spans full width, the four secondary filters sit in a tidy 2×2 grid below it
- **CellarDetail action buttons** — History / Add Bottle / ⋯ buttons no longer stretch to fill the row on mobile; they stay compact icon-size squares
- **Login page** — reduced card and page padding on screens ≤ 480 px so the form isn't cramped on small phones; added an open-source footer with links to GitHub issues and support email
- **WineRequests** — added a 600 px breakpoint so the request header (wine title + status badge) wraps instead of squeezing onto one line
- **Global** — `overflow-x: hidden` on `body` prevents stray elements from creating a page-wide horizontal scrollbar; the global `⋯` button override keeps the overflow menu trigger compact in all page-headers

## Test plan

- [x] Open the app in browser DevTools at 375 px width (iPhone SE)
- [x] CellarDetail: verify filter bar shows search on top row, 4 filters in 2×2 below — no horizontal scrollbar
- [x] CellarDetail: verify History / ➕ / ⋯ buttons are compact, not stretched
- [x] Login: verify card fits comfortably with the open-source footer visible below it
- [x] WineRequests: verify request header wraps cleanly on small screens
- [x] All existing tests pass (`cd frontend && npm test -- --watchAll=false`)