### PR TITLE
feat(auth): forgot/reset password + new-user onboarding prompt

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -70,6 +70,14 @@ const userSchema = new mongoose.Schema({
     type: Date,
     default: null
   },
+  passwordResetTokenHash: {
+    type: String,
+    default: null
+  },
+  passwordResetExpiresAt: {
+    type: Date,
+    default: null
+  },
   createdAt: {
     type: Date,
     default: Date.now
@@ -78,6 +86,7 @@ const userSchema = new mongoose.Schema({
 
 // Sparse index so verify-email lookup is efficient; sparse avoids bloat after verification
 userSchema.index({ emailVerificationTokenHash: 1 }, { sparse: true });
+userSchema.index({ passwordResetTokenHash: 1 }, { sparse: true });
 
 // Hash password before saving
 userSchema.pre('save', async function(next) {
@@ -128,6 +137,22 @@ userSchema.methods.validateEmailVerificationToken = function(candidateToken) {
   return crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(this.emailVerificationTokenHash));
 };
 
+// Generate a raw password-reset token, store its hash, set 1h expiry; returns raw token to email
+userSchema.methods.setPasswordResetToken = function() {
+  const token = crypto.randomBytes(32).toString('hex');
+  this.passwordResetTokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  this.passwordResetExpiresAt = new Date(Date.now() + 60 * 60 * 1000);
+  return token;
+};
+
+// Validate a candidate reset token against the stored hash and expiry
+userSchema.methods.validatePasswordResetToken = function(candidateToken) {
+  if (!this.passwordResetTokenHash || !this.passwordResetExpiresAt) return false;
+  if (Date.now() > this.passwordResetExpiresAt.getTime()) return false;
+  const hash = crypto.createHash('sha256').update(candidateToken).digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(this.passwordResetTokenHash));
+};
+
 // Remove sensitive fields from JSON responses
 userSchema.methods.toJSON = function() {
   const obj = this.toObject();
@@ -135,6 +160,8 @@ userSchema.methods.toJSON = function() {
   delete obj.refreshTokenHash;
   delete obj.emailVerificationTokenHash;
   delete obj.emailVerificationExpiresAt;
+  delete obj.passwordResetTokenHash;
+  delete obj.passwordResetExpiresAt;
   return obj;
 };
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -6,7 +6,7 @@ const User = require('../models/User');
 const { requireAuth } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const rateLimitsConfig = require('../config/rateLimits');
-const { sendVerificationEmail, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
+const { sendVerificationEmail, sendPasswordResetEmail, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
 
 const router = express.Router();
 
@@ -19,6 +19,17 @@ const authLimiter = rateLimit({
   handler: (req, res) => {
     logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'auth', limit: rateLimitsConfig.get().auth.max });
     res.status(429).json({ error: 'Too many attempts, please try again later' });
+  }
+});
+
+// Separate limiter for password reset — 5 per 15 min per IP
+const resetLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    res.status(429).json({ error: 'Too many reset attempts, please try again later' });
   }
 });
 
@@ -313,6 +324,88 @@ router.post('/logout', requireAuth, async (req, res) => {
   } catch (error) {
     console.error('Logout error:', error);
     res.status(500).json({ error: 'Logout failed' });
+  }
+});
+
+// POST /api/auth/forgot-password - Request a password reset email
+router.post('/forgot-password', resetLimiter, async (req, res) => {
+  if (!EMAIL_VERIFICATION_ENABLED) {
+    return res.status(503).json({ error: 'Password reset by email is not available on this instance. Contact your administrator.' });
+  }
+
+  const { email } = req.body;
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+
+  // Always return the same message to prevent email enumeration
+  const genericResponse = { message: 'If that email exists, a reset link has been sent.' };
+
+  try {
+    const user = await User.findOne({ email: email.toLowerCase() });
+    if (!user) {
+      return res.status(200).json(genericResponse);
+    }
+
+    const resetToken = user.setPasswordResetToken();
+    await user.save();
+
+    sendPasswordResetEmail(user.email, user.username, resetToken).catch(err => {
+      console.error('Failed to send password reset email:', err.message);
+    });
+
+    logAudit(req, 'auth.password_reset_requested',
+      { type: 'user', id: user._id },
+      { email: user.email }
+    );
+
+    res.status(200).json(genericResponse);
+  } catch (error) {
+    console.error('Forgot password error:', error);
+    res.status(500).json({ error: 'Failed to process password reset request' });
+  }
+});
+
+// POST /api/auth/reset-password - Reset password using token from email
+router.post('/reset-password', resetLimiter, async (req, res) => {
+  const { token, password } = req.body;
+
+  if (!token || !password) {
+    return res.status(400).json({ error: 'Token and new password are required' });
+  }
+
+  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z\d]).{12,}$/;
+  if (!passwordRegex.test(password)) {
+    return res.status(400).json({
+      error: 'Password must be at least 12 characters and include an uppercase letter, lowercase letter, number, and special character'
+    });
+  }
+
+  try {
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const user = await User.findOne({
+      passwordResetTokenHash: tokenHash,
+      passwordResetExpiresAt: { $gt: new Date() }
+    });
+
+    if (!user || !user.validatePasswordResetToken(token)) {
+      return res.status(400).json({ error: 'Invalid or expired reset token' });
+    }
+
+    user.password = password;
+    user.passwordResetTokenHash = null;
+    user.passwordResetExpiresAt = null;
+    await user.save();
+
+    logAudit(req, 'auth.password_reset',
+      { type: 'user', id: user._id },
+      { username: user.username }
+    );
+
+    res.status(200).json({ message: 'Password reset successfully. You can now log in.' });
+  } catch (error) {
+    console.error('Reset password error:', error);
+    res.status(500).json({ error: 'Failed to reset password' });
   }
 });
 

--- a/backend/src/services/mailgun.js
+++ b/backend/src/services/mailgun.js
@@ -64,4 +64,52 @@ async function sendVerificationEmail(toEmail, username, token) {
   });
 }
 
-module.exports = { sendVerificationEmail, EMAIL_VERIFICATION_ENABLED };
+/**
+ * Send a password reset link to a user.
+ * @param {string} toEmail  - Recipient email address
+ * @param {string} username - Username for greeting
+ * @param {string} token    - Raw (unhashed) reset token
+ */
+async function sendPasswordResetEmail(toEmail, username, token) {
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  const link = `${frontendUrl}/reset-password?token=${encodeURIComponent(token)}`;
+
+  await mg.messages.create(DOMAIN, {
+    from: FROM,
+    to: [toEmail],
+    subject: 'Reset your Cellarion password',
+    text: [
+      `Hello ${username},`,
+      '',
+      'You requested a password reset. Visit the link below to set a new password.',
+      'This link expires in 1 hour.',
+      '',
+      link,
+      '',
+      'If you did not request a password reset, you can safely ignore this email.'
+    ].join('\n'),
+    html: `
+      <div style="font-family:sans-serif;max-width:480px;margin:0 auto;color:#2a2a2a;">
+        <p>Hello <strong>${username}</strong>,</p>
+        <p>You requested a password reset. Click the button below to set a new password.
+           This link expires in <strong>1 hour</strong>.</p>
+        <p style="margin:2rem 0;">
+          <a href="${link}"
+             style="background:#7B9E88;color:#0d0d0d;padding:12px 28px;
+                    border-radius:4px;text-decoration:none;font-weight:600;
+                    display:inline-block;">
+            Reset Password
+          </a>
+        </p>
+        <p>Or copy this link into your browser:</p>
+        <p style="word-break:break-all;color:#555;font-size:0.85em;">${link}</p>
+        <hr style="border:none;border-top:1px solid #ddd;margin:2rem 0;" />
+        <p style="color:#9A9484;font-size:0.85em;">
+          If you did not request a password reset, you can safely ignore this email.
+        </p>
+      </div>
+    `
+  });
+}
+
+module.exports = { sendVerificationEmail, sendPasswordResetEmail, EMAIL_VERIFICATION_ENABLED };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,6 +23,8 @@ import SommMaturity from './pages/SommMaturity';
 import SommPrices from './pages/SommPrices';
 import Settings from './pages/Settings';
 import VerifyEmail from './pages/VerifyEmail';
+import ForgotPassword from './pages/ForgotPassword';
+import ResetPassword from './pages/ResetPassword';
 import './styles/common.css';
 
 function AppRoutes() {
@@ -41,6 +43,8 @@ function AppRoutes() {
       {/* Public routes */}
       <Route path="/login" element={user ? <Navigate to="/cellars" replace /> : <Login />} />
       <Route path="/verify-email" element={<VerifyEmail />} />
+      <Route path="/forgot-password" element={user ? <Navigate to="/cellars" replace /> : <ForgotPassword />} />
+      <Route path="/reset-password" element={user ? <Navigate to="/cellars" replace /> : <ResetPassword />} />
 
       {/* Protected routes wrapped in Layout */}
       <Route

--- a/frontend/src/pages/ForgotPassword.js
+++ b/frontend/src/pages/ForgotPassword.js
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import CellarionLogo from '../components/CellarionLogo';
+import './Login.css';
+
+function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState('idle'); // 'idle' | 'loading' | 'sent' | 'error'
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus('loading');
+    setErrorMessage('');
+
+    try {
+      const res = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+
+      const data = await res.json();
+
+      if (res.status === 503) {
+        setErrorMessage(data.error || 'Password reset is not available on this server.');
+        setStatus('error');
+      } else if (!res.ok) {
+        setErrorMessage(data.error || 'Something went wrong. Please try again.');
+        setStatus('error');
+      } else {
+        setStatus('sent');
+      }
+    } catch {
+      setErrorMessage('Network error. Please try again.');
+      setStatus('error');
+    }
+  };
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <div className="login-header">
+          <CellarionLogo size={90} color="#7B9E88" showText />
+          <p>Reset your password</p>
+        </div>
+
+        {status === 'sent' ? (
+          <div className="alert alert-success">
+            If that email exists in our system, we've sent a reset link. Check your inbox.
+          </div>
+        ) : (
+          <>
+            {status === 'error' && (
+              <div className="alert alert-error">{errorMessage}</div>
+            )}
+            <form onSubmit={handleSubmit}>
+              <div className="form-group">
+                <label>Email address</label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  autoFocus
+                  placeholder="your@email.com"
+                />
+              </div>
+              <button
+                type="submit"
+                className="btn btn-primary btn-full"
+                disabled={status === 'loading'}
+              >
+                {status === 'loading' ? 'Sending...' : 'Send reset link'}
+              </button>
+            </form>
+          </>
+        )}
+
+        <p style={{ textAlign: 'center', marginTop: '1.25rem', fontSize: '0.9rem', color: '#9A9484' }}>
+          <Link to="/login" style={{ color: '#7B9E88' }}>Back to login</Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default ForgotPassword;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import CellarionLogo from '../components/CellarionLogo';
 import './Login.css';
@@ -37,6 +37,8 @@ function Login() {
       if (result.requiresVerification) {
         setRegisteredEmail(result.email);
         setRegistered(true);
+      } else if (mode === 'register') {
+        navigate('/settings?welcome=1');
       } else {
         navigate('/cellars');
       }
@@ -199,6 +201,13 @@ function Login() {
               required
             />
           </div>
+          {mode === 'login' && (
+            <div style={{ textAlign: 'right', marginTop: '-0.5rem', marginBottom: '1rem' }}>
+              <Link to="/forgot-password" style={{ fontSize: '0.85rem', color: '#7B9E88' }}>
+                Forgot password?
+              </Link>
+            </div>
+          )}
           <button type="submit" className="btn btn-primary btn-full" disabled={loading}>
             {loading ? 'Loading...' : mode === 'login' ? 'Login' : 'Create Account'}
           </button>

--- a/frontend/src/pages/ResetPassword.js
+++ b/frontend/src/pages/ResetPassword.js
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import CellarionLogo from '../components/CellarionLogo';
+import './Login.css';
+
+function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get('token') || '';
+
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [status, setStatus] = useState('idle'); // 'idle' | 'loading' | 'success' | 'error'
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setErrorMessage('');
+
+    if (password !== confirm) {
+      setErrorMessage('Passwords do not match.');
+      return;
+    }
+
+    setStatus('loading');
+
+    try {
+      const res = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password })
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setErrorMessage(data.error || 'Something went wrong. Please try again.');
+        setStatus('error');
+      } else {
+        setStatus('success');
+        setTimeout(() => navigate('/login', { replace: true }), 2000);
+      }
+    } catch {
+      setErrorMessage('Network error. Please try again.');
+      setStatus('error');
+    }
+  };
+
+  if (!token) {
+    return (
+      <div className="login-page">
+        <div className="login-card">
+          <div className="login-header">
+            <CellarionLogo size={90} color="#7B9E88" showText />
+          </div>
+          <div className="alert alert-error">
+            No reset token found. Please use the link from your email.
+          </div>
+          <p style={{ textAlign: 'center', marginTop: '1rem', fontSize: '0.9rem' }}>
+            <Link to="/forgot-password" style={{ color: '#7B9E88' }}>Request a new reset link</Link>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <div className="login-header">
+          <CellarionLogo size={90} color="#7B9E88" showText />
+          <p>Set a new password</p>
+        </div>
+
+        {status === 'success' ? (
+          <div className="alert alert-success">
+            Password reset! Redirecting you to login...
+          </div>
+        ) : (
+          <>
+            {errorMessage && (
+              <div className="alert alert-error">
+                {errorMessage}
+                {status === 'error' && (
+                  <span>
+                    {' '}
+                    <Link to="/forgot-password" style={{ color: 'inherit', textDecoration: 'underline' }}>
+                      Request a new link
+                    </Link>
+                    .
+                  </span>
+                )}
+              </div>
+            )}
+            <form onSubmit={handleSubmit}>
+              <div className="form-group">
+                <label>New password</label>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  autoFocus
+                  minLength={12}
+                />
+              </div>
+              <div className="form-group">
+                <label>Confirm new password</label>
+                <input
+                  type="password"
+                  value={confirm}
+                  onChange={(e) => setConfirm(e.target.value)}
+                  required
+                  minLength={12}
+                />
+              </div>
+              <p style={{ fontSize: '0.8rem', color: '#9A9484', marginBottom: '1rem' }}>
+                Minimum 12 characters with uppercase, lowercase, number, and special character.
+              </p>
+              <button
+                type="submit"
+                className="btn btn-primary btn-full"
+                disabled={status === 'loading'}
+              >
+                {status === 'loading' ? 'Resetting...' : 'Reset password'}
+              </button>
+            </form>
+          </>
+        )}
+
+        <p style={{ textAlign: 'center', marginTop: '1.25rem', fontSize: '0.9rem', color: '#9A9484' }}>
+          <Link to="/login" style={{ color: '#7B9E88' }}>Back to login</Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default ResetPassword;

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -41,3 +41,26 @@
   font-size: 0.85rem;
   color: #6B9E78;
 }
+
+.settings-welcome {
+  position: relative;
+  margin-bottom: 1.25rem;
+}
+
+.settings-welcome-dismiss {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+  opacity: 0.7;
+}
+
+.settings-welcome-dismiss:hover {
+  opacity: 1;
+}

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { CURRENCIES } from '../config/currencies';
@@ -7,6 +8,10 @@ import './Settings.css';
 function Settings() {
   const { t, i18n } = useTranslation();
   const { user, updatePreferences } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const isWelcome = searchParams.get('welcome') === '1';
+
   const [currency, setCurrency] = useState(user?.preferences?.currency || 'USD');
   const [language, setLanguage] = useState(user?.preferences?.language || i18n.language?.split('-')[0] || 'en');
   const [saving, setSaving] = useState(false);
@@ -24,6 +29,7 @@ function Settings() {
       i18n.changeLanguage(language);
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
+      if (isWelcome) navigate('/settings', { replace: true });
     } else {
       setError(result.error);
     }
@@ -32,6 +38,19 @@ function Settings() {
   return (
     <div className="settings-page">
       <h1>{t('settings.title')}</h1>
+
+      {isWelcome && (
+        <div className="alert alert-info settings-welcome">
+          <strong>Welcome to Cellarion!</strong> Set your preferred currency and language before you start.
+          <button
+            className="settings-welcome-dismiss"
+            onClick={() => navigate('/settings', { replace: true })}
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       <div className="card settings-card">
         <h2 className="settings-section-title">{t('settings.displayPreferences')}</h2>

--- a/frontend/src/pages/VerifyEmail.js
+++ b/frontend/src/pages/VerifyEmail.js
@@ -25,7 +25,7 @@ function VerifyEmail() {
     verifyEmail(token).then(result => {
       if (result.success) {
         setStatus('success');
-        setTimeout(() => navigate('/cellars', { replace: true }), 1500);
+        setTimeout(() => navigate('/settings?welcome=1', { replace: true }), 1500);
       } else {
         setStatus('error');
         setErrorMessage(result.error || 'Verification failed. The link may have expired.');


### PR DESCRIPTION
## Summary
- **Forgot/reset password**: new `POST /api/auth/forgot-password` and `POST /api/auth/reset-password` endpoints with 5/15min rate limiting, no email enumeration, and a clear 503 response when Mailgun is not configured. Adds `passwordResetTokenHash` / `passwordResetExpiresAt` to the User model (1-hour expiry, same crypto pattern as email verification). New `ForgotPassword` and `ResetPassword` pages reuse the existing login card styles. A "Forgot password?" link is added to the login form.
- **New-user onboarding**: after registration (email verification disabled) or after clicking the verification link, users are redirected to `/settings?welcome=1` instead of straight to `/cellars`. The Settings page shows a dismissible banner prompting them to set their preferred currency and language.

## Test plan
- [ ] Register a new user (no Mailgun) → lands on `/settings?welcome=1` with welcome banner; banner dismisses via × or on save
- [ ] Register with Mailgun enabled → verify email link → lands on `/settings?welcome=1`
- [ ] "Forgot password?" link visible on login form (not on register tab)
- [ ] Submit forgot-password form → generic success message regardless of whether email exists
- [ ] Click reset link from email → enter new password meeting requirements → redirected to login → login succeeds with new password
- [ ] Reuse the same reset link → "Invalid or expired reset token"
- [ ] When Mailgun not configured, forgot-password returns 503 with descriptive message
- [ ] `cd frontend && npm test -- --watchAll=false` passes (45 tests)