### PR TITLE
fix(security): address four real code-scanning alerts

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -35,7 +35,11 @@ app.use(helmet({
   hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
   frameguard: { action: 'deny' },
   referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
-  contentSecurityPolicy: false // Managed separately; CSP breaks React SPA without careful tuning
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'none'"],
+    },
+  }
 }));
 
 // Middleware

--- a/backend/src/routes/admin/users.js
+++ b/backend/src/routes/admin/users.js
@@ -19,7 +19,8 @@ router.get('/', async (req, res) => {
     const filter = {};
 
     if (search) {
-      const re = new RegExp(search.trim(), 'i');
+      const escaped = search.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(escaped, 'i');
       filter.$or = [{ username: re }, { email: re }];
     }
     if (plan && PLAN_NAMES.includes(plan)) {

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -128,7 +128,7 @@ async function search(query, { countryId, regionId, type, grapeIds, limit = 50, 
 
   // Build sort array
   const meiliSort = [];
-  if (sort && sort !== 'relevance') {
+  if (sort && typeof sort === 'string' && sort !== 'relevance') {
     const desc = sort.startsWith('-');
     const field = desc ? sort.slice(1) : sort;
     if (['name', 'producer', 'type', 'createdAt'].includes(field)) {

--- a/rembg/app.py
+++ b/rembg/app.py
@@ -65,5 +65,5 @@ def remove_bg():
             mimetype='image/png',
             download_name='output.png'
         )
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return jsonify({"error": "Image processing failed"}), 500


### PR DESCRIPTION
## Summary

Fixes the four genuine security alerts raised by GitHub code scanning. The remaining 31 alerts are false positives (27× Mongoose queries misidentified as SQL injection, 2× multer-controlled paths flagged as path injection, 1× linear-time regex flagged as polynomial ReDoS) and should be dismissed in the UI.

**Changes:**
- **Regex injection** (`admin/users.js`) — escape all special regex metacharacters in the admin user-search query before passing it to `new RegExp(...)`, preventing a ReDoS attack from a malicious admin payload
- **Type confusion** (`services/search.js`) — add `typeof sort === 'string'` guard before calling `.startsWith('-')` so a query-string object like `?sort[a]=b` cannot cause an uncaught `TypeError`
- **Stack trace exposure** (`rembg/app.py`) — replace `str(e)` in the exception handler with a static `"Image processing failed"` message so internal file paths and library details are never returned to callers
- **Insecure Helmet CSP** (`app.js`) — replace `contentSecurityPolicy: false` with an explicit `{ directives: { defaultSrc: ["'none'"] } }` policy appropriate for a JSON API backend

## Test plan
- [x] All 45 frontend unit tests pass (`npm test -- --watchAll=false`)
- [x] Smoke-test in Docker: admin user search, wine search with sort, image upload