### PR TITLE
feat(auth): forgot / reset password flow

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -70,6 +70,14 @@ const userSchema = new mongoose.Schema({
     type: Date,
     default: null
   },
+  passwordResetTokenHash: {
+    type: String,
+    default: null
+  },
+  passwordResetExpiresAt: {
+    type: Date,
+    default: null
+  },
   createdAt: {
     type: Date,
     default: Date.now
@@ -78,6 +86,7 @@ const userSchema = new mongoose.Schema({
 
 // Sparse index so verify-email lookup is efficient; sparse avoids bloat after verification
 userSchema.index({ emailVerificationTokenHash: 1 }, { sparse: true });
+userSchema.index({ passwordResetTokenHash: 1 }, { sparse: true });
 
 // Hash password before saving
 userSchema.pre('save', async function(next) {
@@ -128,6 +137,22 @@ userSchema.methods.validateEmailVerificationToken = function(candidateToken) {
   return crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(this.emailVerificationTokenHash));
 };
 
+// Generate a raw password-reset token, store its hash, set 1h expiry; returns raw token to email
+userSchema.methods.setPasswordResetToken = function() {
+  const token = crypto.randomBytes(32).toString('hex');
+  this.passwordResetTokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  this.passwordResetExpiresAt = new Date(Date.now() + 60 * 60 * 1000);
+  return token;
+};
+
+// Validate a password-reset token against the stored hash and expiry
+userSchema.methods.validatePasswordResetToken = function(candidateToken) {
+  if (!this.passwordResetTokenHash || !this.passwordResetExpiresAt) return false;
+  if (Date.now() > this.passwordResetExpiresAt.getTime()) return false;
+  const hash = crypto.createHash('sha256').update(candidateToken).digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(this.passwordResetTokenHash));
+};
+
 // Remove sensitive fields from JSON responses
 userSchema.methods.toJSON = function() {
   const obj = this.toObject();
@@ -135,6 +160,8 @@ userSchema.methods.toJSON = function() {
   delete obj.refreshTokenHash;
   delete obj.emailVerificationTokenHash;
   delete obj.emailVerificationExpiresAt;
+  delete obj.passwordResetTokenHash;
+  delete obj.passwordResetExpiresAt;
   return obj;
 };
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -6,7 +6,7 @@ const User = require('../models/User');
 const { requireAuth } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const rateLimitsConfig = require('../config/rateLimits');
-const { sendVerificationEmail, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
+const { sendVerificationEmail, sendPasswordResetEmail, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
 
 const router = express.Router();
 
@@ -18,6 +18,17 @@ const authLimiter = rateLimit({
   legacyHeaders: false,
   handler: (req, res) => {
     logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'auth', limit: rateLimitsConfig.get().auth.max });
+    res.status(429).json({ error: 'Too many attempts, please try again later' });
+  }
+});
+
+// Separate limiter for forgot-password — 5 per 15 min to prevent abuse
+const forgotLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
     res.status(429).json({ error: 'Too many attempts, please try again later' });
   }
 });
@@ -329,6 +340,84 @@ router.get('/me', requireAuth, async (req, res) => {
   } catch (error) {
     console.error('Get user error:', error);
     res.status(500).json({ error: 'Failed to get user' });
+  }
+});
+
+// POST /api/auth/forgot-password - Request a password reset link
+router.post('/forgot-password', forgotLimiter, async (req, res) => {
+  const { email } = req.body;
+  // Always return the same message to prevent email enumeration
+  const genericResponse = { message: 'If that email exists, a password reset link has been sent.' };
+
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+
+  try {
+    const user = await User.findOne({ email: email.toLowerCase() });
+
+    if (!user) {
+      return res.status(200).json(genericResponse);
+    }
+
+    const resetToken = user.setPasswordResetToken();
+    await user.save();
+
+    if (EMAIL_VERIFICATION_ENABLED) {
+      sendPasswordResetEmail(user.email, user.username, resetToken).catch(err => {
+        console.error('Failed to send password reset email:', err.message);
+      });
+    }
+
+    logAudit(req, 'auth.password_reset_requested',
+      { type: 'user', id: user._id },
+      { email: user.email }
+    );
+
+    res.status(200).json(genericResponse);
+  } catch (error) {
+    console.error('Forgot password error:', error);
+    res.status(500).json({ error: 'Failed to process request' });
+  }
+});
+
+// POST /api/auth/reset-password - Set a new password using a reset token
+router.post('/reset-password', authLimiter, async (req, res) => {
+  const { token, password } = req.body;
+
+  if (!token || !password) {
+    return res.status(400).json({ error: 'Token and new password are required' });
+  }
+
+  try {
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const user = await User.findOne({ passwordResetTokenHash: tokenHash });
+
+    if (!user || !user.validatePasswordResetToken(token)) {
+      return res.status(400).json({ error: 'Invalid or expired reset token' });
+    }
+
+    user.password = password;
+    user.passwordResetTokenHash = null;
+    user.passwordResetExpiresAt = null;
+    user.refreshTokenHash = null; // Invalidate all existing sessions
+
+    await user.save();
+
+    logAudit(req, 'auth.password_reset',
+      { type: 'user', id: user._id },
+      { username: user.username }
+    );
+
+    res.clearCookie('refreshToken', refreshCookieOptions);
+    res.status(200).json({ message: 'Password reset successfully. You can now log in with your new password.' });
+  } catch (error) {
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map(e => e.message);
+      return res.status(400).json({ error: messages.join(', ') });
+    }
+    console.error('Reset password error:', error);
+    res.status(500).json({ error: 'Failed to reset password' });
   }
 });
 

--- a/backend/src/services/mailgun.js
+++ b/backend/src/services/mailgun.js
@@ -64,4 +64,53 @@ async function sendVerificationEmail(toEmail, username, token) {
   });
 }
 
-module.exports = { sendVerificationEmail, EMAIL_VERIFICATION_ENABLED };
+/**
+ * Send a password-reset link to a user.
+ * @param {string} toEmail  - Recipient email address
+ * @param {string} username - Username for greeting
+ * @param {string} token    - Raw (unhashed) reset token
+ */
+async function sendPasswordResetEmail(toEmail, username, token) {
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  const link = `${frontendUrl}/reset-password?token=${encodeURIComponent(token)}`;
+
+  await mg.messages.create(DOMAIN, {
+    from: FROM,
+    to: [toEmail],
+    subject: 'Reset your Cellarion password',
+    text: [
+      `Hello ${username},`,
+      '',
+      'We received a request to reset the password for your Cellarion account.',
+      'Click the link below to set a new password. This link expires in 1 hour.',
+      '',
+      link,
+      '',
+      'If you did not request a password reset, you can safely ignore this email.'
+    ].join('\n'),
+    html: `
+      <div style="font-family:sans-serif;max-width:480px;margin:0 auto;color:#2a2a2a;">
+        <p>Hello <strong>${username}</strong>,</p>
+        <p>We received a request to reset the password for your Cellarion account.
+           Click the button below to set a new password.
+           This link expires in <strong>1 hour</strong>.</p>
+        <p style="margin:2rem 0;">
+          <a href="${link}"
+             style="background:#7B9E88;color:#0d0d0d;padding:12px 28px;
+                    border-radius:4px;text-decoration:none;font-weight:600;
+                    display:inline-block;">
+            Reset Password
+          </a>
+        </p>
+        <p>Or copy this link into your browser:</p>
+        <p style="word-break:break-all;color:#555;font-size:0.85em;">${link}</p>
+        <hr style="border:none;border-top:1px solid #ddd;margin:2rem 0;" />
+        <p style="color:#9A9484;font-size:0.85em;">
+          If you did not request a password reset, you can safely ignore this email.
+        </p>
+      </div>
+    `
+  });
+}
+
+module.exports = { sendVerificationEmail, sendPasswordResetEmail, EMAIL_VERIFICATION_ENABLED };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,6 +24,7 @@ import SommMaturity from './pages/SommMaturity';
 import SommPrices from './pages/SommPrices';
 import Settings from './pages/Settings';
 import VerifyEmail from './pages/VerifyEmail';
+import ResetPassword from './pages/ResetPassword';
 import './styles/common.css';
 
 function AppRoutes() {
@@ -42,6 +43,7 @@ function AppRoutes() {
       {/* Public routes */}
       <Route path="/login" element={user ? <Navigate to="/cellars" replace /> : <Login />} />
       <Route path="/verify-email" element={<VerifyEmail />} />
+      <Route path="/reset-password" element={<ResetPassword />} />
 
       {/* Protected routes wrapped in Layout */}
       <Route

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -13,6 +13,8 @@ function Login() {
   const [registeredEmail, setRegisteredEmail] = useState('');
   const [pendingVerificationEmail, setPendingVerificationEmail] = useState(null);
   const [resendStatus, setResendStatus] = useState(null); // null | 'sending' | 'sent' | 'error'
+  const [forgotEmail, setForgotEmail] = useState('');
+  const [forgotStatus, setForgotStatus] = useState(null); // null | 'sending' | 'sent' | 'error'
 
   const { login, register } = useAuth();
   const navigate = useNavigate();
@@ -63,11 +65,28 @@ function Login() {
     }
   };
 
+  const handleForgot = async (e) => {
+    e.preventDefault();
+    setForgotStatus('sending');
+    try {
+      const res = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: forgotEmail })
+      });
+      setForgotStatus(res.ok ? 'sent' : 'error');
+    } catch {
+      setForgotStatus('error');
+    }
+  };
+
   const switchMode = (newMode) => {
     setMode(newMode);
     setError(null);
     setPendingVerificationEmail(null);
     setResendStatus(null);
+    setForgotEmail('');
+    setForgotStatus(null);
   };
 
   const footer = (
@@ -89,6 +108,69 @@ function Login() {
       </p>
     </footer>
   );
+
+  if (mode === 'forgot') {
+    return (
+      <div className="login-page">
+        <div className="login-card">
+          <div className="login-header">
+            <CellarionLogo size={90} color="#7B9E88" showText />
+            <p>Reset your password</p>
+          </div>
+
+          {forgotStatus === 'sent' ? (
+            <>
+              <div className="alert alert-success">
+                If that email exists, a reset link has been sent. Check your inbox.
+              </div>
+              <button
+                className="btn btn-secondary btn-full"
+                style={{ marginTop: '1rem' }}
+                onClick={() => switchMode('login')}
+              >
+                Back to login
+              </button>
+            </>
+          ) : (
+            <form onSubmit={handleForgot}>
+              <p style={{ color: '#9A9484', fontSize: '0.9rem', marginBottom: '1.25rem' }}>
+                Enter your email address and we&apos;ll send you a link to reset your password.
+              </p>
+              <div className="form-group">
+                <label>Email</label>
+                <input
+                  type="email"
+                  value={forgotEmail}
+                  onChange={(e) => setForgotEmail(e.target.value)}
+                  required
+                  autoFocus
+                />
+              </div>
+              {forgotStatus === 'error' && (
+                <div className="alert alert-error">Something went wrong. Please try again.</div>
+              )}
+              <button
+                type="submit"
+                className="btn btn-primary btn-full"
+                disabled={forgotStatus === 'sending'}
+              >
+                {forgotStatus === 'sending' ? 'Sending...' : 'Send reset link'}
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary btn-full"
+                style={{ marginTop: '0.75rem' }}
+                onClick={() => switchMode('login')}
+              >
+                Back to login
+              </button>
+            </form>
+          )}
+        </div>
+        {footer}
+      </div>
+    );
+  }
 
   if (registered) {
     return (
@@ -199,6 +281,24 @@ function Login() {
               required
             />
           </div>
+          {mode === 'login' && (
+            <div style={{ textAlign: 'right', marginTop: '-0.75rem', marginBottom: '1rem' }}>
+              <button
+                type="button"
+                onClick={() => switchMode('forgot')}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: '#7B9E88',
+                  cursor: 'pointer',
+                  fontSize: '0.85rem',
+                  padding: 0
+                }}
+              >
+                Forgot password?
+              </button>
+            </div>
+          )}
           <button type="submit" className="btn btn-primary btn-full" disabled={loading}>
             {loading ? 'Loading...' : mode === 'login' ? 'Login' : 'Create Account'}
           </button>

--- a/frontend/src/pages/ResetPassword.js
+++ b/frontend/src/pages/ResetPassword.js
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import CellarionLogo from '../components/CellarionLogo';
+import './Login.css';
+
+function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [status, setStatus] = useState('idle'); // 'idle' | 'submitting' | 'success' | 'error'
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const token = searchParams.get('token');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (password !== confirm) {
+      setErrorMessage('Passwords do not match.');
+      return;
+    }
+    setStatus('submitting');
+    setErrorMessage('');
+    try {
+      const res = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setStatus('success');
+        setTimeout(() => navigate('/login', { replace: true }), 2000);
+      } else {
+        setStatus('error');
+        setErrorMessage(data.error || 'Failed to reset password. The link may have expired.');
+      }
+    } catch {
+      setStatus('error');
+      setErrorMessage('Something went wrong. Please try again.');
+    }
+  };
+
+  if (!token) {
+    return (
+      <div className="login-page">
+        <div className="login-card">
+          <div className="login-header">
+            <CellarionLogo size={90} color="#7B9E88" showText />
+            <p>Reset Password</p>
+          </div>
+          <div className="alert alert-error">No reset token found in the URL.</div>
+          <button
+            className="btn btn-secondary btn-full"
+            style={{ marginTop: '1rem' }}
+            onClick={() => navigate('/login')}
+          >
+            Back to login
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <div className="login-header">
+          <CellarionLogo size={90} color="#7B9E88" showText />
+          <p>Set a new password</p>
+        </div>
+
+        {status === 'success' ? (
+          <div className="alert alert-success">
+            Password reset successfully! Redirecting to login...
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            {errorMessage && <div className="alert alert-error">{errorMessage}</div>}
+            <div className="form-group">
+              <label>New password</label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label>Confirm password</label>
+              <input
+                type="password"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                required
+              />
+            </div>
+            <p style={{ color: '#9A9484', fontSize: '0.8rem', marginBottom: '1rem' }}>
+              Must be at least 12 characters with uppercase, lowercase, number, and special character.
+            </p>
+            <button
+              type="submit"
+              className="btn btn-primary btn-full"
+              disabled={status === 'submitting'}
+            >
+              {status === 'submitting' ? 'Resetting...' : 'Reset password'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ResetPassword;


### PR DESCRIPTION
## Summary

- Adds a complete self-service password reset flow using the existing Mailgun integration
- User clicks **Forgot password?** on the login page → enters email → receives a one-time link (1-hour expiry)
- `/reset-password?token=...` page validates the token, enforces the existing password rules, and invalidates all active sessions on success
- Anti-enumeration: the forgot-password endpoint always returns the same generic response regardless of whether the email exists

## Changes

### Backend
- **`User` model** — `passwordResetTokenHash` + `passwordResetExpiresAt` fields, sparse index, `setPasswordResetToken()` / `validatePasswordResetToken()` methods (mirrors email-verification pattern), fields stripped from `toJSON()`
- **`mailgun.js`** — `sendPasswordResetEmail()` — silent no-op when Mailgun is not configured (same as email verification)
- **`auth.js`** — `POST /api/auth/forgot-password` (5 req / 15 min limiter) and `POST /api/auth/reset-password`; successful reset invalidates all refresh tokens

### Frontend
- **`Login.js`** — `'forgot'` mode with email form; **Forgot password?** link below the password field in login mode
- **`ResetPassword.js`** — new page at `/reset-password?token=...`; client-side confirm-password check; redirects to login on success
- **`App.js`** — `/reset-password` registered as a public route

## Test plan

- [ ] Click **Forgot password?** on the login page — forgot form appears
- [ ] Submit with a valid email — generic success message shown (no enumeration)
- [ ] Submit with an unknown email — same generic message
- [ ] Follow the reset link in the email — `ResetPassword` page loads
- [ ] Submit mismatched passwords — client-side error shown
- [ ] Submit a password that fails the strength rules — backend validation error shown
- [ ] Submit a valid new password — success message, redirected to login, can log in with new password
- [ ] Verify old sessions are invalidated after reset (refresh token cleared)
- [ ] Submit the same reset link a second time — "Invalid or expired reset token" error
- [ ] Without Mailgun configured — endpoint returns 200, no email sent, no crash