### PR TITLE
feat(plans): gate aging & maturity behind premium plan

### DIFF
--- a/backend/src/config/plans.js
+++ b/backend/src/config/plans.js
@@ -13,6 +13,7 @@ const PLANS = {
     maxCellars: 1,
     maxSharesPerCellar: 1,
     features: {
+      agingMaturity: false,
       priceEvolution: false,
     },
     featureList: [
@@ -29,6 +30,7 @@ const PLANS = {
     maxCellars: 5,
     maxSharesPerCellar: 1,
     features: {
+      agingMaturity: false,
       priceEvolution: false,
     },
     featureList: [
@@ -42,11 +44,13 @@ const PLANS = {
     maxCellars: -1,
     maxSharesPerCellar: -1,
     features: {
+      agingMaturity: true,
       priceEvolution: true,
     },
     featureList: [
       'Unlimited cellars',
       'Unlimited shared members per cellar',
+      'Aging & maturity profiles',
       'Price evolution tracking',
       'Everything in Basic',
     ],

--- a/frontend/src/config/plans.js
+++ b/frontend/src/config/plans.js
@@ -10,6 +10,7 @@ export const PLANS = {
     maxCellars: 1,
     maxSharesPerCellar: 1,
     features: {
+      agingMaturity: false,
       priceEvolution: false,
     },
     featureList: [
@@ -27,6 +28,7 @@ export const PLANS = {
     maxCellars: 5,
     maxSharesPerCellar: 1,
     features: {
+      agingMaturity: false,
       priceEvolution: false,
     },
     featureList: [
@@ -41,11 +43,13 @@ export const PLANS = {
     maxCellars: -1,  // -1 = unlimited
     maxSharesPerCellar: -1,
     features: {
+      agingMaturity: true,
       priceEvolution: true,
     },
     featureList: [
       'Unlimited cellars',
       'Unlimited shared members per cellar',
+      'Aging & maturity profiles',
       'Price evolution tracking',
       'Everything in Basic',
     ],

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -246,6 +246,7 @@
     "priceEvolution": "Price Evolution",
     "premiumFeature": "Premium feature",
     "premiumFeatureDesc": "Track how the market value of this wine changes over time. Available on the Premium plan.",
+    "agingMaturityPremiumDesc": "See expert aging windows and maturity phases for this vintage. Available on the Premium plan.",
     "editDetails": "✏️ Edit Details",
     "removeBottle": "🍷 Remove Bottle",
     "editBottleTitle": "Edit Bottle Details",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -246,6 +246,7 @@
     "priceEvolution": "Prisutveckling",
     "premiumFeature": "Premiumfunktion",
     "premiumFeatureDesc": "Följ hur marknadsvärdet på detta vin förändras över tid. Tillgänglig i Premium-planen.",
+    "agingMaturityPremiumDesc": "Se expertens lagringsfönster och mognadsfaser för denna årgång. Tillgänglig i Premium-planen.",
     "editDetails": "✏️ Redigera detaljer",
     "removeBottle": "🍷 Ta bort flaska",
     "editBottleTitle": "Redigera flaskdetaljer",

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -232,6 +232,7 @@ function BottleDetail() {
 function ViewDetails({ bottle, rackInfo, cellarId, drinkStatus, vintageProfile, priceHistory, rates, userCurrency, canEdit, onEdit, onRemove }) {
   const { t } = useTranslation();
   const { plan, hasFeature } = usePlan();
+  const hasAgingMaturity = hasFeature('agingMaturity');
   const hasPriceEvolution = hasFeature('priceEvolution');
   const maturityStatus = getMaturityStatus(vintageProfile);
 
@@ -273,39 +274,40 @@ function ViewDetails({ bottle, rackInfo, cellarId, drinkStatus, vintageProfile, 
         )}
       </div>
 
-      {/* Sommelier maturity section — shown when a profile exists for this wine+vintage */}
+      {/* Sommelier maturity section — premium feature, not shown for NV */}
       {bottle.vintage && bottle.vintage !== 'NV' && (
         <div className="bd-section">
           <span className="bd-section-label">{t('bottleDetail.sommMaturity')}</span>
-          {!vintageProfile ? (
-            <span className="bd-no-dates">{t('bottleDetail.loadingMaturity')}</span>
-          ) : vintageProfile.status === 'pending' ? (
-            <div className="bd-maturity-pending">
-              <span className="maturity-badge maturity-badge--pending">{t('bottleDetail.awaitingSommelier')}</span>
-              <span className="bd-maturity-note">
-                {t('bottleDetail.sommelierWillSet')}
-              </span>
-            </div>
+          {hasAgingMaturity ? (
+            !vintageProfile ? (
+              <span className="bd-no-dates">{t('bottleDetail.loadingMaturity')}</span>
+            ) : vintageProfile.status === 'pending' ? (
+              <div className="bd-maturity-pending">
+                <span className="maturity-badge maturity-badge--pending">{t('bottleDetail.awaitingSommelier')}</span>
+                <span className="bd-maturity-note">
+                  {t('bottleDetail.sommelierWillSet')}
+                </span>
+              </div>
+            ) : (
+              <div className="bd-maturity-reviewed">
+                {maturityStatus && (
+                  <span className={`maturity-badge maturity-badge--${maturityStatus.status}`}>
+                    {maturityStatus.label}
+                  </span>
+                )}
+                <MaturityPhaseTable profile={vintageProfile} />
+                {vintageProfile.sommNotes && (
+                  <p className="bd-maturity-notes">{vintageProfile.sommNotes}</p>
+                )}
+              </div>
+            )
           ) : (
-            <div className="bd-maturity-reviewed">
-              {/* Current status badge */}
-              {maturityStatus && (
-                <span className={`maturity-badge maturity-badge--${maturityStatus.status}`}>
-                  {maturityStatus.label}
-                </span>
-              )}
-
-              {/* Phase table */}
-              <MaturityPhaseTable profile={vintageProfile} />
-
-              {vintageProfile.sommNotes && (
-                <p className="bd-maturity-notes">{vintageProfile.sommNotes}</p>
-              )}
-              {vintageProfile.setBy && (
-                <span className="bd-maturity-attribution">
-                  — {vintageProfile.setBy.username}
-                </span>
-              )}
+            <div className="bd-price-evolution bd-price-evolution--locked">
+              <span className="bd-price-evolution__icon">🔒</span>
+              <div>
+                <strong>{t('bottleDetail.premiumFeature')}</strong>
+                <p>{t('bottleDetail.agingMaturityPremiumDesc')}</p>
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Adds `agingMaturity` feature flag (premium only) to both backend and frontend plan configs
- Gates the **Aging & Maturity** section on Bottle Detail behind the new flag — non-premium users see a 🔒 locked state matching the existing Price Evolution style
- Removes the `setBy` attribution that was exposing the username of whoever set the maturity profile
- Adds `agingMaturityPremiumDesc` translation key in EN and SV

## Test plan
- [ ] Free/Basic user viewing a bottle detail should see a locked premium block in the Aging & Maturity section
- [ ] Premium user should see the full maturity phase table as before
- [ ] No "— admin" (or any username) attribution visible anywhere in the maturity section
- [ ] Plans page lists "Aging & maturity profiles" under Premium only