### PR TITLE
feat(plans): add 30-day premium trial with admin reset

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -49,6 +49,10 @@ const userSchema = new mongoose.Schema({
     type: Date,
     default: null   // null = no expiry (indefinite)
   },
+  trialEligible: {
+    type: Boolean,
+    default: true   // admin can reset to true to allow another trial
+  },
   preferences: {
     currency: {
       type: String,

--- a/backend/src/routes/admin/users.js
+++ b/backend/src/routes/admin/users.js
@@ -33,7 +33,7 @@ router.get('/', async (req, res) => {
 
     const [users, total] = await Promise.all([
       User.find(filter)
-        .select('username email roles plan planStartedAt planExpiresAt createdAt')
+        .select('username email roles plan planStartedAt planExpiresAt trialEligible createdAt')
         .sort({ createdAt: -1 })
         .skip(Number(offset))
         .limit(Number(limit)),
@@ -95,6 +95,39 @@ router.patch('/:id/plan', async (req, res) => {
   } catch (error) {
     console.error('Admin change plan error:', error);
     res.status(500).json({ error: 'Failed to change plan' });
+  }
+});
+
+// PATCH /api/admin/users/:id/trial-eligible - Reset trial eligibility so the user can start another trial
+router.patch('/:id/trial-eligible', async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id)
+      .select('username email roles plan planStartedAt planExpiresAt trialEligible');
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    user.trialEligible = true;
+    await user.save();
+
+    logAudit(req, 'admin.user.trial.reset',
+      { type: 'user', id: user._id },
+      { username: user.username }
+    );
+
+    res.json({
+      user: {
+        _id: user._id,
+        username: user.username,
+        email: user.email,
+        roles: user.roles,
+        plan: user.plan,
+        planStartedAt: user.planStartedAt,
+        planExpiresAt: user.planExpiresAt,
+        trialEligible: user.trialEligible,
+      }
+    });
+  } catch (error) {
+    console.error('Reset trial eligibility error:', error);
+    res.status(500).json({ error: 'Failed to reset trial eligibility' });
   }
 });
 

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const User = require('../models/User');
 const { requireAuth, requireRole } = require('../middleware/auth');
+const { logAudit } = require('../services/audit');
 
 const router = express.Router();
 
@@ -59,6 +60,38 @@ router.patch('/preferences', requireAuth, async (req, res) => {
   } catch (error) {
     console.error('Update preferences error:', error);
     res.status(500).json({ error: 'Failed to update preferences' });
+  }
+});
+
+// POST /api/users/trial - Activate the 30-day Premium trial (one-time per user)
+router.post('/trial', requireAuth, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    if (!user.trialEligible) {
+      return res.status(400).json({ error: 'Trial already used' });
+    }
+
+    const planActive = user.plan === 'premium' &&
+      (!user.planExpiresAt || Date.now() < new Date(user.planExpiresAt).getTime());
+    if (planActive) {
+      return res.status(400).json({ error: 'Already on Premium plan' });
+    }
+
+    const now = new Date();
+    user.plan = 'premium';
+    user.planStartedAt = now;
+    user.planExpiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+    user.trialEligible = false;
+    await user.save();
+
+    logAudit(req, 'user.trial.start', { type: 'user', id: user._id }, { endsAt: user.planExpiresAt });
+
+    res.json({ user: user.toJSON() });
+  } catch (error) {
+    console.error('Start trial error:', error);
+    res.status(500).json({ error: 'Failed to start trial' });
   }
 });
 

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -244,6 +244,18 @@ export const AuthProvider = ({ children }) => {
   // updatePreferences (uses apiFetch for auto-refresh)
   // ------------------------------------------------------------------
 
+  const startTrial = async () => {
+    try {
+      const response = await apiFetch('/api/users/trial', { method: 'POST' });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Failed to start trial');
+      setUser(data.user);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  };
+
   const updatePreferences = async (prefs) => {
     try {
       const response = await apiFetch('/api/users/preferences', {
@@ -269,6 +281,7 @@ export const AuthProvider = ({ children }) => {
     logout,
     verifyEmail,
     updatePreferences,
+    startTrial,
     apiFetch
   };
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -106,7 +106,8 @@
     "noExpiry": "No expiry (indefinite)",
     "expired": "Expired",
     "currentTag": "Your plan",
-    "adminManaged": "Plans are managed by your administrator."
+    "adminManaged": "Plans are managed by your administrator.",
+    "tryPremium": "Try Premium free for 30 days"
   },
 
   "cellars": {
@@ -562,6 +563,9 @@
       "colEmail": "Email",
       "colPlan": "Plan",
       "colExpiry": "Expiry",
+      "colTrial": "Trial",
+      "trialAvailable": "Available",
+      "resetTrialBtn": "Reset trial",
       "colRoles": "Roles",
       "colJoined": "Joined",
       "expiryNever": "Never",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -106,7 +106,8 @@
     "noExpiry": "Inget utgångsdatum",
     "expired": "Utgånget",
     "currentTag": "Ditt abonnemang",
-    "adminManaged": "Abonnemang hanteras av din administratör."
+    "adminManaged": "Abonnemang hanteras av din administratör.",
+    "tryPremium": "Prova Premium gratis i 30 dagar"
   },
 
   "cellars": {
@@ -562,6 +563,9 @@
       "colEmail": "E-post",
       "colPlan": "Plan",
       "colExpiry": "Utgångsdatum",
+      "colTrial": "Provperiod",
+      "trialAvailable": "Tillgänglig",
+      "resetTrialBtn": "Återställ provperiod",
       "colRoles": "Roller",
       "colJoined": "Gick med",
       "expiryNever": "Aldrig",

--- a/frontend/src/pages/AdminUsers.css
+++ b/frontend/src/pages/AdminUsers.css
@@ -228,6 +228,16 @@
   font-weight: 600;
 }
 
+.users-trial-cell {
+  white-space: nowrap;
+}
+
+.users-trial-badge--available {
+  font-size: 0.75rem;
+  color: #7BAF7B;
+  font-weight: 500;
+}
+
 .users-expiry--soon {
   color: #C8A87E;
 }

--- a/frontend/src/pages/AdminUsers.js
+++ b/frontend/src/pages/AdminUsers.js
@@ -223,6 +223,29 @@ function AdminUsers() {
     }
   }
 
+  async function resetTrial(userId) {
+    setUpdating(prev => ({ ...prev, [userId + '_trial']: true }));
+    try {
+      const res = await apiFetch(`/api/admin/users/${userId}/trial-eligible`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setUsers(prev => prev.map(u => u._id === userId
+          ? { ...u, trialEligible: data.user.trialEligible }
+          : u
+        ));
+      } else {
+        alert(data.error || 'Failed to reset trial');
+      }
+    } catch {
+      alert('Network error');
+    } finally {
+      setUpdating(prev => ({ ...prev, [userId + '_trial']: false }));
+    }
+  }
+
   async function changeRoles(userId, newRoles) {
     setUpdating(prev => ({ ...prev, [userId + '_roles']: true }));
     try {
@@ -305,6 +328,7 @@ function AdminUsers() {
                   <th>{t('admin.users.colEmail')}</th>
                   <th>{t('admin.users.colPlan')}</th>
                   <th>{t('admin.users.colExpiry')}</th>
+                  <th>{t('admin.users.colTrial')}</th>
                   <th>{t('admin.users.colRoles')}</th>
                   <th>{t('admin.users.colJoined')}</th>
                 </tr>
@@ -324,6 +348,20 @@ function AdminUsers() {
                     </td>
                     <td>
                       <ExpiryBadge planExpiresAt={u.planExpiresAt} t={t} />
+                    </td>
+                    <td className="users-trial-cell">
+                      {u.trialEligible
+                        ? <span className="users-trial-badge users-trial-badge--available">{t('admin.users.trialAvailable')}</span>
+                        : (
+                          <button
+                            className="btn btn-secondary btn-xs"
+                            disabled={updating[u._id + '_trial']}
+                            onClick={() => resetTrial(u._id)}
+                          >
+                            {t('admin.users.resetTrialBtn')}
+                          </button>
+                        )
+                      }
                     </td>
                     <td>
                       <div className="users-roles-cell">

--- a/frontend/src/pages/Plans.css
+++ b/frontend/src/pages/Plans.css
@@ -160,6 +160,25 @@
   margin-top: 0.05rem;
 }
 
+/* ── Trial CTA ── */
+.plans-trial-wrap {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.plans-trial-btn {
+  width: 100%;
+}
+
+.plans-trial-error {
+  font-size: 0.8rem;
+  color: #E07060;
+  margin: 0;
+}
+
 /* ── Admin note ── */
 .plans-admin-note {
   text-align: center;

--- a/frontend/src/pages/Plans.js
+++ b/frontend/src/pages/Plans.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { PLANS, PLAN_NAMES } from '../config/plans';
@@ -5,11 +6,24 @@ import './Plans.css';
 
 function Plans() {
   const { t } = useTranslation();
-  const { user } = useAuth();
+  const { user, startTrial } = useAuth();
+  const [trialLoading, setTrialLoading] = useState(false);
+  const [trialError, setTrialError] = useState(null);
 
   const userPlan = user?.plan || 'free';
   const userExpiresAt = user?.planExpiresAt || null;
   const planExpired = userExpiresAt && Date.now() > new Date(userExpiresAt).getTime();
+
+  const isPremiumActive = userPlan === 'premium' && !planExpired;
+  const canTrial = !isPremiumActive && user?.trialEligible === true;
+
+  async function handleStartTrial() {
+    setTrialLoading(true);
+    setTrialError(null);
+    const result = await startTrial();
+    setTrialLoading(false);
+    if (!result.success) setTrialError(result.error);
+  }
 
   function formatExpiry(expiresAt) {
     if (!expiresAt) return t('plans.noExpiry');
@@ -63,6 +77,19 @@ function Plans() {
                   </li>
                 ))}
               </ul>
+
+              {planKey === 'premium' && canTrial && (
+                <div className="plans-trial-wrap">
+                  <button
+                    className="btn btn-primary plans-trial-btn"
+                    onClick={handleStartTrial}
+                    disabled={trialLoading}
+                  >
+                    {trialLoading ? t('common.saving') : t('plans.tryPremium')}
+                  </button>
+                  {trialError && <p className="plans-trial-error">{trialError}</p>}
+                </div>
+              )}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- Adds a `trialEligible` field to the User model (defaults to `true` for all users)
- Users see a **"Try Premium free for 30 days"** button on the Premium card in the Plans page — only shown when they are not already on an active Premium plan and haven't used their trial
- Clicking it activates Premium with a 30-day expiry and sets `trialEligible = false` so it can't be used again
- Admins can reset `trialEligible` back to `true` per user via the Admin Users panel, enabling campaign-style re-grants
- Admin Users table has a new **Trial** column: shows "Available" in green if eligible, or a **Reset trial** button if the trial has been used

## API changes
- `POST /api/users/trial` — starts the trial for the authenticated user
- `PATCH /api/admin/users/:id/trial-eligible` — admin resets eligibility
- `GET /api/admin/users` — now includes `trialEligible` in the response

## Test plan
- [ ] New user (or existing user with `trialEligible: true`) sees the trial button on the Premium card
- [ ] Clicking the button upgrades the user to Premium with a 30-day expiry and hides the button immediately
- [ ] User who has used their trial does not see the button
- [ ] Admin can click "Reset trial" in the Users panel to restore the button for a user
- [ ] User already on active Premium does not see the trial button