### PR TITLE
fix(security): typeof guard on search param (CodeQL NoSQL-injection)

### DIFF
--- a/backend/src/routes/admin/users.js
+++ b/backend/src/routes/admin/users.js
@@ -18,7 +18,7 @@ router.get('/', async (req, res) => {
 
     const filter = {};
 
-    if (search) {
+    if (typeof search === 'string' && search) {
       const escaped = search.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const re = new RegExp(escaped, 'i');
       filter.$or = [{ username: re }, { email: re }];


### PR DESCRIPTION
## Summary

- Adds `typeof search === 'string'` guard in `GET /api/admin/users` before the search string is regex-escaped and used as a MongoDB query filter
- Express's query-string parser can coerce `?search[$gt]=x` into an object; calling `.trim()` on an object throws (try/catch swallows it as 500), but the explicit type check is cleaner and closes the CodeQL `js/sql-injection` finding (#43)

## Why this is not a real vulnerability (but worth fixing)

The existing code already validates `plan` and `role` against hard-coded allow-lists, and sanitises `search` via regex-escaping before wrapping it in a `RegExp` object — so no operator injection was possible. The `typeof` guard removes the ambiguity that CodeQL flags.

## Test plan

- [ ] `GET /api/admin/users?search=chardonnay` still returns filtered results
- [ ] `GET /api/admin/users?search[%24gt]=a` returns an empty/unfiltered list instead of 500
- [ ] `cd frontend && npm test -- --watchAll=false` passes

Closes CodeQL alert #43.