### PR TITLE
feat(ratings): multi-scale wine rating system

### DIFF
--- a/backend/src/utils/ratingUtils.js
+++ b/backend/src/utils/ratingUtils.js
@@ -66,6 +66,27 @@ function convertRating(value, fromScale, toScale) {
 }
 
 /**
+ * Format a normalized rating delta (difference between two normalized 0-100 scores).
+ * Unlike fromNormalized, this does NOT apply the floor offset for the 100-pt scale,
+ * since a delta is a difference, not a point on the scale.
+ */
+function formatDelta(normalizedDelta, scale) {
+  if (normalizedDelta == null || isNaN(normalizedDelta)) return '—';
+  const n = Number(normalizedDelta);
+  let raw;
+  switch (scale) {
+    case '5':   raw = (n / 100) * 5;   break;
+    case '20':  raw = (n / 100) * 20;  break;
+    case '100': raw = (n / 100) * 50;  break; // no +50 floor offset for deltas
+    default:    raw = (n / 100) * 5;   break;
+  }
+  const meta = SCALE_META[scale] || SCALE_META['5'];
+  const precision = meta.step < 1 ? 10 : 1;
+  const rounded = Math.round(raw * precision) / precision;
+  return `${rounded.toFixed(meta.step < 1 ? 1 : 0)}${meta.suffix}`;
+}
+
+/**
  * Validate that a value is within the allowed range for a given scale.
  * Returns true if valid, false otherwise.
  */
@@ -77,4 +98,4 @@ function isValidRating(value, scale) {
   return v >= meta.min && v <= meta.max;
 }
 
-module.exports = { SCALE_META, VALID_SCALES, toNormalized, fromNormalized, convertRating, isValidRating };
+module.exports = { SCALE_META, VALID_SCALES, toNormalized, fromNormalized, convertRating, isValidRating, formatDelta };

--- a/frontend/src/pages/Statistics.js
+++ b/frontend/src/pages/Statistics.js
@@ -4,7 +4,7 @@ import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
 import worldData from 'world-atlas/countries-110m.json';
 import { useAuth } from '../contexts/AuthContext';
 import { NUM_TO_A2 } from '../utils/isoCountryCodes';
-import { fromNormalized, formatRating, SCALE_META } from '../utils/ratingUtils';
+import { fromNormalized, formatRating, formatDelta, SCALE_META } from '../utils/ratingUtils';
 import './Statistics.css';
 
 // ── Color palette ─────────────────────────────────────────────────────────────
@@ -59,6 +59,30 @@ function fmtRating(normalized, targetScale) {
   const scale = SCALE_META[targetScale] ? targetScale : '5';
   const converted = fromNormalized(normalized, scale);
   return formatRating(converted, scale);
+}
+
+/**
+ * Format a normalized delta for display in the user's preferred scale.
+ * Uses formatDelta (no floor offset) rather than fromNormalized.
+ */
+function fmtDelta(normalizedDelta, targetScale) {
+  if (normalizedDelta == null) return '—';
+  const scale = SCALE_META[targetScale] ? targetScale : '5';
+  return formatDelta(normalizedDelta, scale);
+}
+
+/**
+ * Return a tooltip string for a rating band in the user's preferred scale.
+ * E.g. bandSub('81-100', '100') → "91–100pts"
+ */
+function bandSub(bandKey, targetScale) {
+  const scale = SCALE_META[targetScale] ? targetScale : '5';
+  const [lo, hi] = bandKey.split('-').map(Number);
+  const meta = SCALE_META[scale];
+  const prec = meta.step < 1 ? 1 : 0;
+  const loVal = fromNormalized(lo, scale);
+  const hiVal = fromNormalized(hi, scale);
+  return `${loVal.toFixed(prec)}–${hiVal.toFixed(prec)}${meta.suffix}`;
 }
 
 function fmtCurrency(amount, currency) {
@@ -189,11 +213,11 @@ function VintageBarChart({ data }) {
 // ── Rating Distribution ───────────────────────────────────────────────────────
 // Bands are normalized 0-100 keys; labels show descriptive quality tier
 const RATING_BANDS = [
-  { key: '81-100', label: 'Excellent', sub: '4.1–5★ · 16–20/20 · 91–100pts', color: '#7B9E88' },
-  { key: '61-80',  label: 'Very Good', sub: '3.1–4★ · 12–16/20 · 81–90pts',  color: '#D4C87A' },
-  { key: '41-60',  label: 'Good',      sub: '2.1–3★ · 8–12/20 · 71–80pts',   color: '#D4A070' },
-  { key: '21-40',  label: 'Fair',      sub: '1.1–2★ · 4–8/20 · 61–70pts',    color: '#C08050' },
-  { key: '0-20',   label: 'Poor',      sub: '1★ · 1–4/20 · 50–60pts',        color: '#C0504D' },
+  { key: '81-100', label: 'Excellent', color: '#7B9E88' },
+  { key: '61-80',  label: 'Very Good', color: '#D4C87A' },
+  { key: '41-60',  label: 'Good',      color: '#D4A070' },
+  { key: '21-40',  label: 'Fair',      color: '#C08050' },
+  { key: '0-20',   label: 'Poor',      color: '#C0504D' },
 ];
 
 function RatingChart({ byRating, avg, targetScale }) {
@@ -206,7 +230,7 @@ function RatingChart({ byRating, avg, targetScale }) {
         const count = byRating[band.key] || 0;
         const pct   = total > 0 ? (count / total) * 100 : 0;
         return (
-          <div key={band.key} className="rating-row" title={band.sub}>
+          <div key={band.key} className="rating-row" title={bandSub(band.key, targetScale)}>
             <span className="rating-stars" style={{ color: band.color, minWidth: 70, fontSize: '0.8rem' }}>{band.label}</span>
             <div className="rating-track">
               <div className="rating-fill" style={{ width: `${(count / maxVal) * 100}%`, background: band.color }} />
@@ -545,7 +569,7 @@ function RegretSignalCard({ regretSignal, targetScale }) {
       {avgDelta !== null && (
         <div className="regret-signal-avg">
           Avg delta: <strong style={{ color: avgDelta >= 0 ? '#7B9E88' : '#E07060' }}>
-            {avgDelta >= 0 ? '+' : ''}{fmtRating(Math.abs(avgDelta), targetScale)}
+            {avgDelta >= 0 ? '+' : ''}{fmtDelta(Math.abs(avgDelta), targetScale)}
           </strong> across {count} bottle{count !== 1 ? 's' : ''}
         </div>
       )}
@@ -563,7 +587,7 @@ function RegretSignalCard({ regretSignal, targetScale }) {
                   <div className="rs-name">{b.name}</div>
                   <div className="rs-vintage">{b.vintage}</div>
                 </div>
-                <div className="rs-delta rs-delta--positive">+{fmtRating(b.delta, targetScale)}</div>
+                <div className="rs-delta rs-delta--positive">+{fmtDelta(b.delta, targetScale)}</div>
                 <div className="rs-ratings">{fmtRating(b.rating, targetScale)} → {fmtRating(b.consumedRating, targetScale)}</div>
               </div>
             ))}
@@ -581,7 +605,7 @@ function RegretSignalCard({ regretSignal, targetScale }) {
                   <div className="rs-name">{b.name}</div>
                   <div className="rs-vintage">{b.vintage}</div>
                 </div>
-                <div className="rs-delta rs-delta--negative">{fmtRating(b.delta, targetScale)}</div>
+                <div className="rs-delta rs-delta--negative">{fmtDelta(b.delta, targetScale)}</div>
                 <div className="rs-ratings">{fmtRating(b.rating, targetScale)} → {fmtRating(b.consumedRating, targetScale)}</div>
               </div>
             ))}

--- a/frontend/src/utils/ratingUtils.js
+++ b/frontend/src/utils/ratingUtils.js
@@ -95,6 +95,31 @@ export function allScales(value, scale) {
 }
 
 /**
+ * Format a normalized rating delta (difference between two normalized 0-100 scores).
+ * Unlike fromNormalized, this does NOT apply the floor offset for the 100-pt scale,
+ * since a delta is a difference, not a point on the scale.
+ *
+ *   formatDelta(20, '5')   → "1.0★"   (+1 star delta)
+ *   formatDelta(20, '20')  → "4.0/20" (+4 points delta)
+ *   formatDelta(20, '100') → "10pts"  (+10 points delta, not 60pts)
+ */
+export function formatDelta(normalizedDelta, scale) {
+  if (normalizedDelta == null || isNaN(normalizedDelta)) return '—';
+  const n = Number(normalizedDelta);
+  let raw;
+  switch (scale) {
+    case '5':   raw = (n / 100) * 5;   break;
+    case '20':  raw = (n / 100) * 20;  break;
+    case '100': raw = (n / 100) * 50;  break; // no +50 floor offset for deltas
+    default:    raw = (n / 100) * 5;   break;
+  }
+  const meta = SCALE_META[scale] || SCALE_META['5'];
+  const precision = meta.step < 1 ? 10 : 1;
+  const rounded = Math.round(raw * precision) / precision;
+  return `${rounded.toFixed(meta.step < 1 ? 1 : 0)}${meta.suffix}`;
+}
+
+/**
  * Validate that a value is within the allowed range for a given scale.
  */
 export function isValidRating(value, scale) {


### PR DESCRIPTION
## Summary

- Adds support for three rating scales: ★ (1–5), /20, and pts (50–100)
- Users can set their preferred scale in profile settings; all ratings display in that scale across the app
- Scale-aware delta formatting via new `formatDelta()` helper — avoids applying the 100-pt floor offset when displaying differences (e.g. regret signal avg delta)
- Rating distribution band tooltips in Statistics now dynamically show the range in the user's preferred scale instead of hardcoded multi-scale strings

## Test plan

- [ ] Set profile to each of the three scales and verify ratings display correctly on bottle cards, detail pages, and statistics
- [ ] Check regret signal avg delta shows a sensible value (e.g. +0.3★, not +50pts) in all three scales
- [ ] Verify rating band tooltips in Statistics update to match the selected scale
- [ ] Run frontend tests: `cd frontend && npm test -- --watchAll=false`