### PR TITLE
feat(admin): upgrade Wine Library — search, filters, image upload & credits

### DIFF
--- a/backend/src/models/BottleImage.js
+++ b/backend/src/models/BottleImage.js
@@ -33,6 +33,11 @@ const bottleImageSchema = new mongoose.Schema({
     default: 'uploaded',
     index: true
   },
+  credit: {
+    type: String,
+    default: null,
+    trim: true
+  },
   reviewedBy: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -25,37 +25,81 @@ router.use(requireAuth, requireRole('admin'));
 // GET /api/admin/wines - List wine definitions
 router.get('/', async (req, res) => {
   try {
-    const { search, page = 1, limit = 50 } = req.query;
+    const { search, type, sort, page = 1, limit = 50 } = req.query;
+    const parsedLimit = parseInt(limit);
+    const parsedPage = parseInt(page);
+    const skip = (parsedPage - 1) * parsedLimit;
 
-    let query = {};
-    if (search) {
-      const escaped = escapeRegex(search);
-      query = {
-        $or: [
-          { name: new RegExp(escaped, 'i') },
-          { producer: new RegExp(escaped, 'i') }
-        ]
-      };
+    const sortMap = {
+      'name': { name: 1 },
+      '-name': { name: -1 },
+      'producer': { producer: 1 },
+      '-createdAt': { createdAt: -1 }
+    };
+    const sortObj = sortMap[sort] || { name: 1 };
+
+    // Try Meilisearch for text queries (fuzzy, searches name/producer/appellation/region/country/grapes)
+    if (search && searchService.getIsAvailable()) {
+      try {
+        const { ids, estimatedTotalHits } = await searchService.search(search, {
+          type: type || undefined,
+          limit: parsedLimit,
+          offset: skip,
+          sort: sort && sort !== 'name' ? sort : undefined
+        });
+
+        const wines = await WineDefinition.find({ _id: { $in: ids } })
+          .populate('country', 'name')
+          .populate('region', 'name')
+          .populate('grapes', 'name');
+
+        // Preserve Meilisearch relevance order
+        const idOrder = new Map(ids.map((id, i) => [id, i]));
+        wines.sort((a, b) => idOrder.get(a._id.toString()) - idOrder.get(b._id.toString()));
+
+        return res.json({
+          wines,
+          total: estimatedTotalHits,
+          page: parsedPage,
+          pages: Math.ceil(estimatedTotalHits / parsedLimit)
+        });
+      } catch (err) {
+        console.warn('Meilisearch unavailable, falling back to MongoDB:', err.message);
+      }
     }
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
+    // MongoDB fallback: $text index when searching (name + producer), regex otherwise
+    const conditions = [];
+    if (search) {
+      conditions.push({ $text: { $search: search } });
+    }
+    if (type) {
+      conditions.push({ type });
+    }
+    const query = conditions.length === 0 ? {}
+      : conditions.length === 1 ? conditions[0]
+      : { $and: conditions };
+
+    // When using $text, sort by relevance score first
+    const mongoSort = search ? { score: { $meta: 'textScore' }, ...sortObj } : sortObj;
 
     const [wines, total] = await Promise.all([
       WineDefinition.find(query)
+        .select(search ? { score: { $meta: 'textScore' } } : {})
         .populate('country', 'name')
         .populate('region', 'name')
         .populate('grapes', 'name')
-        .sort({ name: 1 })
+        .sort(mongoSort)
         .skip(skip)
-        .limit(parseInt(limit)),
+        .limit(parsedLimit),
       WineDefinition.countDocuments(query)
     ]);
 
     res.json({
       wines,
       total,
-      page: parseInt(page),
-      pages: Math.ceil(total / parseInt(limit))
+      page: parsedPage,
+      pages: Math.ceil(total / parsedLimit)
     });
   } catch (error) {
     console.error('List wines error:', error);

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -31,7 +31,7 @@ function validateImageMagicBytes(filePath) {
 
 const router = express.Router();
 
-// POST /api/images/upload - Upload image for a bottle
+// POST /api/images/upload - Upload image for a bottle or wine definition
 router.post('/upload', requireAuth, upload.single('image'), async (req, res) => {
   try {
     if (!req.file) {
@@ -44,7 +44,7 @@ router.post('/upload', requireAuth, upload.single('image'), async (req, res) => 
       return res.status(400).json({ error: 'File content does not match a supported image format (JPEG, PNG, or WebP)' });
     }
 
-    const { bottleId, wineDefinitionId } = req.body;
+    const { bottleId, wineDefinitionId, credit } = req.body;
 
     // Verify bottle ownership if bottleId is provided
     if (bottleId) {
@@ -54,12 +54,19 @@ router.post('/upload', requireAuth, upload.single('image'), async (req, res) => 
       }
     }
 
+    // Only admins can set image credits (wine library images)
+    const isAdmin = req.user.roles && req.user.roles.includes('admin');
+    const sanitizedCredit = (isAdmin && credit && typeof credit === 'string')
+      ? credit.trim().slice(0, 200)
+      : null;
+
     const image = new BottleImage({
       bottle: bottleId || null,
       wineDefinition: wineDefinitionId || null,
       uploadedBy: req.user.id,
       originalUrl: `/api/uploads/originals/${req.file.filename}`,
-      status: 'uploaded'
+      status: 'uploaded',
+      credit: sanitizedCredit || null
     });
 
     await image.save();

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,9 @@
+# Local development overrides — not used in production (Traefik handles routing there).
+# Docker Compose picks this file up automatically alongside docker-compose.yml.
+services:
+  frontend:
+    ports:
+      - "80:80"
+  backend:
+    ports:
+      - "5000:5000"

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,7 +7,6 @@ import Login from './pages/Login';
 import Cellars from './pages/Cellars';
 import CellarDetail from './pages/CellarDetail';
 import AddBottle from './pages/AddBottle';
-import Wines from './pages/Wines';
 import WineRequests from './pages/WineRequests';
 import AdminRequests from './pages/AdminRequests';
 import AdminTaxonomy from './pages/AdminTaxonomy';
@@ -119,14 +118,6 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <Layout><CellarAudit /></Layout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/wines"
-        element={
-          <ProtectedRoute requireAdmin>
-            <Layout><Wines /></Layout>
           </ProtectedRoute>
         }
       />

--- a/frontend/src/components/ImageCarousel.css
+++ b/frontend/src/components/ImageCarousel.css
@@ -51,6 +51,28 @@
   padding: 2px;
 }
 
+/* Credit overlay — visible on hover */
+.carousel-credit {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.35rem 0.6rem;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.68rem;
+  font-style: italic;
+  letter-spacing: 0.01em;
+  text-align: right;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.image-carousel:hover .carousel-credit {
+  opacity: 1;
+}
+
 /* Navigation buttons */
 .carousel-btn {
   position: absolute;
@@ -116,5 +138,10 @@
     opacity: 0.7;
     width: 32px;
     height: 32px;
+  }
+
+  /* Always show credit on touch devices since hover doesn't work */
+  .carousel-credit {
+    opacity: 1;
   }
 }

--- a/frontend/src/components/ImageCarousel.js
+++ b/frontend/src/components/ImageCarousel.js
@@ -32,6 +32,9 @@ function ImageCarousel({ images, size = 'medium' }) {
         {currentImage.status === 'processing' && (
           <div className="carousel-processing">Processing...</div>
         )}
+        {currentImage.credit && (
+          <div className="carousel-credit">© {currentImage.credit}</div>
+        )}
       </div>
 
       {images.length > 1 && (

--- a/frontend/src/components/ImageUpload.js
+++ b/frontend/src/components/ImageUpload.js
@@ -4,7 +4,7 @@ import './ImageUpload.css';
 
 const API_URL = process.env.REACT_APP_API_URL || '';
 
-function ImageUpload({ bottleId, wineDefinitionId, onUploadComplete, onProcessingComplete }) {
+function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onProcessingComplete }) {
   const { apiFetch } = useAuth();
   const [uploading, setUploading] = useState(false);
   const [images, setImages] = useState([]);
@@ -85,6 +85,7 @@ function ImageUpload({ bottleId, wineDefinitionId, onUploadComplete, onProcessin
     formData.append('image', file);
     if (bottleId) formData.append('bottleId', bottleId);
     if (wineDefinitionId) formData.append('wineDefinitionId', wineDefinitionId);
+    if (credit && credit.trim()) formData.append('credit', credit.trim());
 
     try {
       const res = await apiFetch('/api/images/upload', { method: 'POST', body: formData });

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -62,15 +62,6 @@ function Layout({ children }) {
             >
               {t('nav.myCellars')}
             </Link>
-            {roles.includes('admin') && (
-              <Link
-                to="/wines"
-                className={isActive('/wines') ? 'active' : ''}
-                onClick={closeMenu}
-              >
-                {t('nav.wineRegistry')}
-              </Link>
-            )}
             <Link
               to="/statistics"
               className={isActive('/statistics') ? 'active' : ''}

--- a/frontend/src/pages/AdminWines.css
+++ b/frontend/src/pages/AdminWines.css
@@ -8,15 +8,46 @@
   margin: 0.25rem 0 0 0;
 }
 
-.wines-search {
+.wines-filter-bar {
   display: flex;
   gap: 0.5rem;
   margin: 1.5rem 0;
+  flex-wrap: wrap;
 }
 
 .wines-search-input {
   flex: 1;
-  min-width: 0;
+  min-width: 200px;
+}
+
+.wines-filter-select {
+  min-width: 130px;
+}
+
+.wine-image-section {
+  border-top: 1px solid #2a2a2a;
+  padding-top: 1rem;
+  margin-top: 0.5rem;
+}
+
+.wine-image-existing {
+  margin-bottom: 1rem;
+}
+
+.image-credit-field {
+  margin-bottom: 0.75rem;
+}
+
+.image-credit-label {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.image-credit-hint {
+  font-size: 0.78rem;
+  color: #6b6458;
+  font-weight: 400;
 }
 
 .wines-meta {
@@ -122,6 +153,14 @@
 }
 
 @media (max-width: 768px) {
+  .wines-filter-bar {
+    flex-direction: column;
+  }
+
+  .wines-filter-select {
+    min-width: unset;
+  }
+
   .wine-form-grid {
     grid-template-columns: 1fr;
   }

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import GrapePicker from '../components/GrapePicker';
+import ImageUpload from '../components/ImageUpload';
+import ImageGallery from '../components/ImageGallery';
 import './AdminWines.css';
 
 const WINE_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
@@ -25,16 +27,18 @@ function AdminWines() {
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [pages, setPages] = useState(1);
-  const [search, setSearch] = useState('');
   const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [filters, setFilters] = useState({ type: '', sort: 'name' });
   const [loading, setLoading] = useState(true);
 
   const [showForm, setShowForm] = useState(false);
-  const [editWine, setEditWine] = useState(null); // null = create, object = edit
+  const [editWine, setEditWine] = useState(null);
   const [formData, setFormData] = useState(emptyForm);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
   const [formError, setFormError] = useState(null);
+  const [imageCredit, setImageCredit] = useState('');
 
   // Taxonomy
   const [countries, setCountries] = useState([]);
@@ -42,11 +46,28 @@ function AdminWines() {
   const [appellations, setAppellations] = useState([]);
   const [grapes, setGrapes] = useState([]);
 
+  // Debounce search input → search state (only fires when empty or ≥2 chars)
+  useEffect(() => {
+    if (searchInput.length === 1) return;
+    const timer = setTimeout(() => {
+      setSearch(searchInput);
+      setPage(1);
+    }, 600);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  // Reset page when filters change
+  useEffect(() => {
+    setPage(1);
+  }, [filters]);
+
   const fetchWines = useCallback(async () => {
     setLoading(true);
     try {
       const params = new URLSearchParams({ page, limit: 50 });
       if (search) params.set('search', search);
+      if (filters.type) params.set('type', filters.type);
+      params.set('sort', filters.sort);
       const res = await apiFetch(`/api/admin/wines?${params}`);
       const data = await res.json();
       if (res.ok) {
@@ -59,7 +80,7 @@ function AdminWines() {
     } finally {
       setLoading(false);
     }
-  }, [apiFetch, page, search]);
+  }, [apiFetch, page, search, filters]);
 
   useEffect(() => {
     fetchWines();
@@ -106,24 +127,19 @@ function AdminWines() {
     }
   };
 
-  const handleSearch = (e) => {
-    e.preventDefault();
-    setSearch(searchInput);
-    setPage(1);
-  };
-
   const openCreate = () => {
     setEditWine(null);
     setFormData(emptyForm);
     setRegions([]);
     setAppellations([]);
     setFormError(null);
+    setImageCredit('');
     setShowForm(true);
   };
 
   const openEdit = async (wine) => {
     setFormError(null);
-    // Fetch full wine so we have ObjectId arrays for grapes
+    setImageCredit('');
     try {
       const res = await apiFetch(`/api/admin/wines/${wine._id}`);
       const data = await res.json();
@@ -158,6 +174,7 @@ function AdminWines() {
     setEditWine(null);
     setFormData(emptyForm);
     setFormError(null);
+    setImageCredit('');
   };
 
   const handleSubmit = async (e) => {
@@ -176,9 +193,7 @@ function AdminWines() {
         image: formData.image.trim() || null
       };
 
-      const url = editWine
-        ? `/api/admin/wines/${editWine._id}`
-        : '/api/admin/wines';
+      const url = editWine ? `/api/admin/wines/${editWine._id}` : '/api/admin/wines';
       const method = editWine ? 'PUT' : 'POST';
 
       const res = await apiFetch(url, {
@@ -215,6 +230,14 @@ function AdminWines() {
     }
   };
 
+  const clearFilters = () => {
+    setSearchInput('');
+    setFilters({ type: '', sort: 'name' });
+    setPage(1);
+  };
+
+  const hasActiveFilters = searchInput || filters.type || filters.sort !== 'name';
+
   return (
     <div className="admin-wines-page">
       <div className="page-header">
@@ -227,8 +250,8 @@ function AdminWines() {
         </button>
       </div>
 
-      {/* Search bar */}
-      <form className="wines-search" onSubmit={handleSearch}>
+      {/* Filter bar */}
+      <div className="wines-filter-bar">
         <input
           type="text"
           value={searchInput}
@@ -236,13 +259,32 @@ function AdminWines() {
           placeholder={t('admin.wines.searchPlaceholder')}
           className="wines-search-input"
         />
-        <button type="submit" className="btn btn-secondary">{t('common.search')}</button>
-        {search && (
-          <button type="button" className="btn btn-secondary" onClick={() => { setSearch(''); setSearchInput(''); setPage(1); }}>
+        <select
+          value={filters.type}
+          onChange={(e) => setFilters(f => ({ ...f, type: e.target.value }))}
+          className="wines-filter-select"
+        >
+          <option value="">{t('wines.allTypes')}</option>
+          {WINE_TYPES.map(type => (
+            <option key={type} value={type}>{type}</option>
+          ))}
+        </select>
+        <select
+          value={filters.sort}
+          onChange={(e) => setFilters(f => ({ ...f, sort: e.target.value }))}
+          className="wines-filter-select"
+        >
+          <option value="name">{t('wines.sortNameAZ')}</option>
+          <option value="-name">{t('wines.sortNameZA')}</option>
+          <option value="producer">{t('wines.sortProducerAZ')}</option>
+          <option value="-createdAt">{t('wines.sortRecentlyAdded')}</option>
+        </select>
+        {hasActiveFilters && (
+          <button type="button" className="btn btn-secondary" onClick={clearFilters}>
             {t('common.clear')}
           </button>
         )}
-      </form>
+      </div>
 
       {error && <div className="alert alert-error">{error}</div>}
 
@@ -324,7 +366,6 @@ function AdminWines() {
                   disabled={!formData.country}
                 >
                   <option value="">{t('admin.wines.selectAppellation')}</option>
-                  {/* Show current value even if it isn't in the taxonomy (e.g. from bulk import) */}
                   {formData.appellation && !appellations.some(a => a.name === formData.appellation) && (
                     <option value={formData.appellation}>{formData.appellation}</option>
                   )}
@@ -354,6 +395,34 @@ function AdminWines() {
                     grapes={grapes}
                     selected={formData.grapes}
                     onChange={(ids) => setFormData({ ...formData, grapes: ids })}
+                  />
+                </div>
+              )}
+
+              {/* Image upload — only available when editing an existing wine */}
+              {editWine && (
+                <div className="form-group wine-image-section" style={{ gridColumn: '1 / -1' }}>
+                  <label>Wine Images</label>
+                  <div className="wine-image-existing">
+                    <ImageGallery wineDefinitionId={editWine._id} size="medium" />
+                  </div>
+                  <div className="form-group image-credit-field">
+                    <label className="image-credit-label">
+                      Image credit
+                      <span className="image-credit-hint">Added to all images uploaded below</span>
+                    </label>
+                    <input
+                      type="text"
+                      value={imageCredit}
+                      onChange={(e) => setImageCredit(e.target.value)}
+                      placeholder="e.g. Courtesy of Vinifera Imports"
+                      maxLength={200}
+                    />
+                  </div>
+                  <ImageUpload
+                    wineDefinitionId={editWine._id}
+                    credit={imageCredit}
+                    onUploadComplete={() => {}}
                   />
                 </div>
               )}


### PR DESCRIPTION
## Summary

- **Replaced Wine Registry** (`/wines`) with an improved admin Wine Library — the registry nav link and route are removed; Wine Library now covers everything
- **Better search**: uses Meilisearch (fuzzy, searches name/producer/appellation/region/country/grapes) with MongoDB `$text` fallback; previously only did a regex on name+producer
- **Filter bar**: type dropdown (red/white/rosé/sparkling/dessert/fortified) + sort dropdown (name A→Z, Z→A, producer, recently added) + live debounced search (600ms, ignores single-char input to reduce queries)
- **Image upload in edit form**: admins can take a photo or choose a file directly from the Wine Library edit form
- **Image credits**: admin can enter a credit string before uploading; stored on `BottleImage.credit`; displayed as a subtle hover overlay (`© Credit text`) on `ImageCarousel` everywhere in the app — always visible on mobile
- **`docker-compose.override.yml`**: maps ports 80 and 5000 to the host for local development (Traefik handles routing in production without this file)

## Test plan

- [x] Search for a wine by name, producer, appellation, and grape — verify more hits than before
- [x] Filter by type; combine with search
- [x] Sort by each option
- [x] Edit a wine → image section appears → upload a file and take a photo
- [x] Fill in credit before uploading → hover the image in the carousel → credit overlay appears
- [x] Confirm Wine Registry nav link and `/wines` route are gone
- [x] `docker-compose up` works locally on `localhost:80`

🤖 Generated with [Claude Code](https://claude.com/claude-code)