### PR TITLE
feat(ai): AI cellar chat with RAG pipeline (Voyage + Qdrant + Claude)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,18 @@ MEILI_MASTER_KEY=change-me-to-a-strong-random-string
 # MEILI_URL=http://meilisearch:7700
 # REMBG_URL=http://rembg:5000
 
-# Anthropic — optional. If set, enables the "Scan label" camera button on the Add Bottle page.
+# Anthropic — optional. If set, enables the "Scan label" camera button on the Add Bottle page,
+# and powers the AI cellar chat feature.
 # Get your key at https://console.anthropic.com/
 # ANTHROPIC_API_KEY=sk-ant-...
+
+# Voyage AI — optional. Required for AI cellar chat (wine embeddings).
+# Get your key at https://dash.voyageai.com/
+# VOYAGE_API_KEY=pa-...
+
+# Qdrant — optional. Required for AI cellar chat (vector search).
+# In Docker Compose this is set automatically; override only if using an external Qdrant instance.
+# QDRANT_URL=http://qdrant:6333
 
 # Mailgun — optional. If unset, email verification is skipped (users log in immediately after registration).
 # MAILGUN_API_KEY=your-mailgun-api-key

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -25,7 +25,10 @@ const sommMaturityRoute = require('./routes/somm/maturity');
 const sommPricesRoute  = require('./routes/somm/prices');
 const notificationsRoute = require('./routes/notifications');
 const statsRoute = require('./routes/stats');
+const chatRoute = require('./routes/chat');
+const adminAiRoute = require('./routes/admin/ai');
 const rateLimitsConfig = require('./config/rateLimits');
+const aiConfig = require('./config/aiConfig');
 const { logAudit } = require('./services/audit');
 
 const app = express();
@@ -119,6 +122,8 @@ app.use('/api/somm/maturity', sommMaturityRoute);
 app.use('/api/somm/prices',  sommPricesRoute);
 app.use('/api/notifications', notificationsRoute);
 app.use('/api/stats', statsRoute);
+app.use('/api/chat', chatRoute);
+app.use('/api/admin/ai', adminAiRoute);
 
 // 404 handler
 app.use((req, res) => {
@@ -128,6 +133,11 @@ app.use((req, res) => {
 // Load rate limit configuration from DB on startup (non-blocking; falls back to defaults)
 rateLimitsConfig.load().catch(err =>
   console.warn('[rateLimits] Startup load failed, using defaults:', err.message)
+);
+
+// Load AI feature-flag configuration from DB on startup
+aiConfig.load().catch(err =>
+  console.warn('[aiConfig] Startup load failed, using defaults:', err.message)
 );
 
 module.exports = app;

--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -1,0 +1,57 @@
+/**
+ * Feature flags and operational settings for the AI chat pipeline.
+ *
+ * Persisted in SiteConfig (key: 'aiConfig') so admins can change them at
+ * runtime without a restart. Kept in an in-memory cache — same pattern as
+ * rateLimits.js.
+ *
+ * Fields
+ * -------
+ * chatEnabled          – master switch; false blocks POST /api/chat
+ * embeddingModel       – Voyage AI model name used for new embeddings
+ * vectorIndex          – active Qdrant collection version suffix ('v1', 'v2', …)
+ * chatTopK             – how many Qdrant results to retrieve before filtering to user's cellar
+ * chatMaxResults       – max wines shown in the final AI answer
+ * embeddingBatchDelayMs– ms to sleep between embedding calls during batch jobs
+ *                        (helps stay within Voyage free-tier 3 RPM)
+ */
+
+const defaults = {
+  chatEnabled: true,
+  embeddingModel: 'voyage-4-lite',
+  vectorIndex: 'v1',
+  chatTopK: 50,
+  chatMaxResults: 5,
+  embeddingBatchDelayMs: 500
+};
+
+let cache = { ...defaults };
+
+async function load() {
+  try {
+    const SiteConfig = require('../models/SiteConfig');
+    const doc = await SiteConfig.findOne({ key: 'aiConfig' });
+    if (doc && doc.value) {
+      cache = {
+        chatEnabled:           doc.value.chatEnabled          ?? defaults.chatEnabled,
+        embeddingModel:        doc.value.embeddingModel       ?? defaults.embeddingModel,
+        vectorIndex:           doc.value.vectorIndex          ?? defaults.vectorIndex,
+        chatTopK:              doc.value.chatTopK             ?? defaults.chatTopK,
+        chatMaxResults:        doc.value.chatMaxResults       ?? defaults.chatMaxResults,
+        embeddingBatchDelayMs: doc.value.embeddingBatchDelayMs ?? defaults.embeddingBatchDelayMs
+      };
+    }
+  } catch (err) {
+    console.warn('[aiConfig] Could not load from DB, using defaults:', err.message);
+  }
+}
+
+function get() {
+  return cache;
+}
+
+function set(value) {
+  cache = { ...defaults, ...value };
+}
+
+module.exports = { load, get, set, defaults };

--- a/backend/src/models/WineEmbedding.js
+++ b/backend/src/models/WineEmbedding.js
@@ -1,0 +1,69 @@
+const mongoose = require('mongoose');
+
+/**
+ * Tracks which (WineDefinition, vintage) pairs have been embedded and where
+ * the vectors live in Qdrant. One document per unique combination of
+ * (wineDefinition, vintage, model, indexVersion).
+ *
+ * The qdrantPointId is the UUID used as the Qdrant point ID.
+ * textHash is SHA-256 of the text that was embedded — used to detect when a
+ * wine's metadata changed so the vector can be refreshed.
+ */
+const wineEmbeddingSchema = new mongoose.Schema({
+  wineDefinition: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'WineDefinition',
+    required: true,
+    index: true
+  },
+  vintage: {
+    type: String,
+    required: true,
+    trim: true,
+    default: 'NV'
+  },
+  // Which embedding model produced this vector (e.g. 'voyage-4-lite')
+  model: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  // Active index version at embedding time (e.g. 'v1', 'v2')
+  indexVersion: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  // UUID used as the point ID in Qdrant
+  qdrantPointId: {
+    type: String,
+    required: true,
+    unique: true
+  },
+  // SHA-256 of the embedded text — for staleness detection
+  textHash: {
+    type: String,
+    required: true
+  },
+  embeddedAt: {
+    type: Date,
+    default: Date.now
+  },
+  status: {
+    type: String,
+    enum: ['ok', 'error'],
+    default: 'ok'
+  },
+  errorMessage: {
+    type: String,
+    default: null
+  }
+}, { versionKey: false });
+
+// Primary lookup key
+wineEmbeddingSchema.index(
+  { wineDefinition: 1, vintage: 1, model: 1, indexVersion: 1 },
+  { unique: true }
+);
+
+module.exports = mongoose.model('WineEmbedding', wineEmbeddingSchema);

--- a/backend/src/routes/admin/ai.js
+++ b/backend/src/routes/admin/ai.js
@@ -1,0 +1,128 @@
+/**
+ * Admin routes for the AI chat system.
+ *
+ * GET  /api/admin/ai/config          – read feature flags
+ * PATCH /api/admin/ai/config         – update feature flags
+ * GET  /api/admin/ai/embed/status    – current job status + Qdrant collection info
+ * POST /api/admin/ai/embed/start     – start (or restart) a batch embedding job
+ * POST /api/admin/ai/embed/stop      – request graceful job stop
+ */
+
+const express = require('express');
+const { requireAuth, requireRole } = require('../../middleware/auth');
+const SiteConfig = require('../../models/SiteConfig');
+const aiConfig = require('../../config/aiConfig');
+const embeddingJob = require('../../services/embeddingJob');
+const vectorStore = require('../../services/vectorStore');
+const { logAudit } = require('../../services/audit');
+
+const router = express.Router();
+
+router.use(requireAuth, requireRole('admin'));
+
+// ── Feature-flag config ────────────────────────────────────────────────────
+
+// GET /api/admin/ai/config
+router.get('/config', async (req, res) => {
+  try {
+    res.json({ config: aiConfig.get(), defaults: aiConfig.defaults });
+  } catch (err) {
+    console.error('[admin/ai] GET config error:', err);
+    res.status(500).json({ error: 'Failed to load AI config' });
+  }
+});
+
+// PATCH /api/admin/ai/config
+router.patch('/config', async (req, res) => {
+  try {
+    const allowed = ['chatEnabled', 'embeddingModel', 'vectorIndex', 'chatTopK', 'chatMaxResults', 'embeddingBatchDelayMs'];
+    const incoming = {};
+    for (const key of allowed) {
+      if (req.body[key] !== undefined) incoming[key] = req.body[key];
+    }
+
+    // Validate
+    if (incoming.chatEnabled !== undefined && typeof incoming.chatEnabled !== 'boolean') {
+      return res.status(400).json({ error: 'chatEnabled must be boolean' });
+    }
+    if (incoming.chatTopK !== undefined && (!Number.isInteger(incoming.chatTopK) || incoming.chatTopK < 1 || incoming.chatTopK > 200)) {
+      return res.status(400).json({ error: 'chatTopK must be an integer 1–200' });
+    }
+    if (incoming.chatMaxResults !== undefined && (!Number.isInteger(incoming.chatMaxResults) || incoming.chatMaxResults < 1 || incoming.chatMaxResults > 20)) {
+      return res.status(400).json({ error: 'chatMaxResults must be an integer 1–20' });
+    }
+    if (incoming.embeddingBatchDelayMs !== undefined && (!Number.isInteger(incoming.embeddingBatchDelayMs) || incoming.embeddingBatchDelayMs < 0)) {
+      return res.status(400).json({ error: 'embeddingBatchDelayMs must be a non-negative integer' });
+    }
+
+    const previous = aiConfig.get();
+    const updated = { ...previous, ...incoming };
+
+    await SiteConfig.findOneAndUpdate(
+      { key: 'aiConfig' },
+      { key: 'aiConfig', value: updated, updatedAt: new Date(), updatedBy: req.user.id },
+      { upsert: true, new: true }
+    );
+    aiConfig.set(updated);
+
+    logAudit(req, 'admin.ai.config.update', {}, { from: previous, to: updated });
+
+    res.json({ config: updated });
+  } catch (err) {
+    console.error('[admin/ai] PATCH config error:', err);
+    res.status(500).json({ error: 'Failed to update AI config' });
+  }
+});
+
+// ── Embedding job ──────────────────────────────────────────────────────────
+
+// GET /api/admin/ai/embed/status
+router.get('/embed/status', async (req, res) => {
+  try {
+    const jobStatus = embeddingJob.getStatus();
+    const cfg = aiConfig.get();
+
+    // Also fetch Qdrant collection stats
+    let collectionInfo = null;
+    try {
+      collectionInfo = await vectorStore.collectionInfo(cfg.vectorIndex);
+    } catch (_) {
+      collectionInfo = { exists: false, vectorCount: 0, name: `wines_${cfg.vectorIndex}` };
+    }
+
+    res.json({ job: jobStatus, collection: collectionInfo, config: cfg });
+  } catch (err) {
+    console.error('[admin/ai] GET embed/status error:', err);
+    res.status(500).json({ error: 'Failed to fetch embedding status' });
+  }
+});
+
+// POST /api/admin/ai/embed/start
+router.post('/embed/start', async (req, res) => {
+  try {
+    const mode = req.body.mode === 'full' ? 'full' : 'incremental';
+    await embeddingJob.start({ mode });
+    logAudit(req, 'admin.ai.embed.start', {}, { mode });
+    res.json({ message: `Embedding job started (${mode} mode)`, status: embeddingJob.getStatus() });
+  } catch (err) {
+    if (err.message === 'A job is already running') {
+      return res.status(409).json({ error: err.message });
+    }
+    console.error('[admin/ai] POST embed/start error:', err);
+    res.status(500).json({ error: 'Failed to start embedding job' });
+  }
+});
+
+// POST /api/admin/ai/embed/stop
+router.post('/embed/stop', async (req, res) => {
+  try {
+    embeddingJob.requestStop();
+    logAudit(req, 'admin.ai.embed.stop', {}, {});
+    res.json({ message: 'Stop requested', status: embeddingJob.getStatus() });
+  } catch (err) {
+    console.error('[admin/ai] POST embed/stop error:', err);
+    res.status(500).json({ error: 'Failed to stop embedding job' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -10,6 +10,7 @@ const { getCellarRole } = require('../utils/cellarAccess');
 const { logAudit } = require('../services/audit');
 const { getOrCreateDailySnapshot, getSnapshotForDate } = require('../utils/exchangeRates');
 const { isValidRating, VALID_SCALES } = require('../utils/ratingUtils');
+const { embedSinglePair } = require('../services/embeddingJob');
 
 // Strip HTML tags from user-supplied text to prevent XSS in rendered output
 const stripHtml = (str) => (str ? str.replace(/<[^>]*>/g, '').trim() : str);
@@ -118,6 +119,9 @@ router.post('/', async (req, res) => {
       { type: 'bottle', id: bottle._id, cellarId: cellarDoc._id },
       { wineName: bottle.wineDefinition?.name, vintage: bottle.vintage }
     );
+
+    // Fire-and-forget: embed this (wine, vintage) pair for AI chat
+    embedSinglePair(wineDefinition, bottle.vintage).catch(() => {});
 
     res.status(201).json({ bottle });
   } catch (error) {
@@ -259,6 +263,12 @@ router.put('/:id', async (req, res) => {
         { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
         { changes }
       );
+    }
+
+    // If vintage changed, the old (wine, oldVintage) embedding is still in Qdrant
+    // but won't match this bottle anymore (user changed the year). Embed the new pair.
+    if (changes.vintage) {
+      embedSinglePair(bottle.wineDefinition._id || bottle.wineDefinition, bottle.vintage).catch(() => {});
     }
 
     res.json({ bottle });

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -1,0 +1,65 @@
+/**
+ * POST /api/chat
+ *
+ * Accepts a natural-language question from the authenticated user and returns
+ * an AI-generated wine recommendation drawn exclusively from their cellar.
+ *
+ * Rate limiting
+ * -------------
+ * A dedicated per-user limiter (keyed by user ID, not IP) allows 10 questions
+ * per hour. This sits on top of the global API limiter in app.js.
+ */
+
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+const { requireAuth } = require('../middleware/auth');
+const aiChat = require('../services/aiChat');
+const aiConfig = require('../config/aiConfig');
+
+const router = express.Router();
+
+// 10 requests per hour per authenticated user
+const chatLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  keyGenerator: (req) => req.user?.id || req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    res.status(429).json({ error: 'Chat rate limit reached — you can ask up to 10 questions per hour.' });
+  }
+});
+
+// POST /api/chat
+router.post('/', requireAuth, chatLimiter, async (req, res) => {
+  const cfg = aiConfig.get();
+  if (!cfg.chatEnabled) {
+    return res.status(503).json({ error: 'AI chat is currently disabled.' });
+  }
+
+  const { message } = req.body;
+  if (!message || typeof message !== 'string') {
+    return res.status(400).json({ error: 'message is required' });
+  }
+  const trimmed = message.trim();
+  if (!trimmed) {
+    return res.status(400).json({ error: 'message must not be empty' });
+  }
+  if (trimmed.length > 1000) {
+    return res.status(400).json({ error: 'message must be 1000 characters or fewer' });
+  }
+
+  try {
+    const result = await aiChat.chat(req.user.id, trimmed);
+    res.json(result);
+  } catch (err) {
+    const status = err.status || 500;
+    if (status === 503) {
+      return res.status(503).json({ error: err.message });
+    }
+    console.error('[chat] Error:', err);
+    res.status(500).json({ error: 'Failed to generate recommendation' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/services/aiChat.js
+++ b/backend/src/services/aiChat.js
@@ -1,0 +1,187 @@
+/**
+ * AI cellar chat — RAG pipeline.
+ *
+ * Flow
+ * ----
+ * 1. Embed the user's question with Voyage AI.
+ * 2. Query Qdrant for the most similar wine vectors (active index version).
+ * 3. Cross-reference with the user's active Bottle collection to keep only
+ *    wines they actually own, and enrich with bottle metadata (vintage, notes).
+ * 4. Build a grounded prompt and call Claude to generate the recommendation.
+ * 5. Return the Claude answer plus the matched wine list.
+ *
+ * If no matching wines are found in the user's cellar, Claude is told to say
+ * so — it never invents wines the user doesn't own.
+ */
+
+const aiConfig = require('../config/aiConfig');
+const { embedSingle } = require('./embedding');
+const vectorStore = require('./vectorStore');
+const Bottle = require('../models/Bottle');
+
+// ── Claude client (reuse the @anthropic-ai/sdk already in package.json) ────
+
+function getClaudeClient() {
+  const sdk = require('@anthropic-ai/sdk');
+  const Anthropic = sdk.default ?? sdk;
+  return new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+}
+
+// ── Wine matching ──────────────────────────────────────────────────────────
+
+/**
+ * Given Qdrant hits (each carrying wineDefinitionId + vintage in payload),
+ * return the subset that the user actually owns as active bottles.
+ * Preserves Qdrant score ordering.
+ *
+ * @param {string} userId
+ * @param {Array<{ id, score, payload }>} hits
+ * @param {number} maxResults
+ * @returns {Promise<Array>}
+ */
+async function filterToUserCellar(userId, hits, maxResults) {
+  if (!hits.length) return [];
+
+  // Build lookup: "wineDefinitionId|vintage" → qdrant score
+  const scoreMap = new Map();
+  const wineDefIds = [];
+  for (const hit of hits) {
+    const key = `${hit.payload.wineDefinitionId}|${hit.payload.vintage}`;
+    if (!scoreMap.has(key)) {
+      scoreMap.set(key, hit.score);
+      wineDefIds.push(hit.payload.wineDefinitionId);
+    }
+  }
+
+  // Fetch active bottles the user owns for those wine definitions
+  const bottles = await Bottle.find({
+    user: userId,
+    status: 'active',
+    wineDefinition: { $in: wineDefIds }
+  })
+    .populate('wineDefinition', 'name producer type appellation region country grapes')
+    .populate('wineDefinition.region', 'name')
+    .populate('wineDefinition.country', 'name')
+    .lean();
+
+  if (!bottles.length) return [];
+
+  // Attach Qdrant score and sort by score descending
+  const scored = bottles.map(b => {
+    const key = `${b.wineDefinition._id}|${b.vintage}`;
+    return { bottle: b, score: scoreMap.get(key) ?? 0 };
+  });
+  scored.sort((a, b) => b.score - a.score);
+
+  // Deduplicate by (wineDefinition, vintage) — keep highest-scored bottle per pair
+  const seen = new Set();
+  const deduplicated = [];
+  for (const { bottle, score } of scored) {
+    const key = `${bottle.wineDefinition._id}|${bottle.vintage}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduplicated.push({ bottle, score });
+    }
+    if (deduplicated.length >= maxResults) break;
+  }
+
+  return deduplicated;
+}
+
+// ── Prompt builder ─────────────────────────────────────────────────────────
+
+function buildSystemPrompt() {
+  return `You are a sommelier assistant for Cellarion, a personal wine cellar app.
+Your job is to recommend wines from the user's own cellar based on their question.
+
+Rules:
+- Recommend ONLY wines from the list provided below the user's question.
+- If none of the listed wines suit the question, say so clearly and briefly.
+- Keep the answer concise: 2–3 sentences per wine, explaining why it matches.
+- Do not invent or mention wines that are not in the list.
+- Use a friendly, knowledgeable tone — as if speaking to the cellar owner.`;
+}
+
+function formatWineList(matches) {
+  return matches.map(({ bottle, score }, i) => {
+    const w = bottle.wineDefinition;
+    const regionStr = w.region?.name || w.appellation || '';
+    const grapeStr = (w.grapes || []).filter(g => g.name).map(g => g.name).join(', ');
+    const noteStr = bottle.notes ? `\n   Notes: "${bottle.notes}"` : '';
+    const scoreStr = `(relevance: ${(score * 100).toFixed(0)}%)`;
+    return [
+      `${i + 1}. ${w.name} ${bottle.vintage} — ${w.producer}`,
+      regionStr ? `   Region: ${regionStr}` : null,
+      grapeStr ? `   Grapes: ${grapeStr}` : null,
+      w.type ? `   Style: ${w.type}` : null,
+      `   ${scoreStr}${noteStr}`
+    ].filter(Boolean).join('\n');
+  }).join('\n\n');
+}
+
+// ── Main entry point ───────────────────────────────────────────────────────
+
+/**
+ * Answer the user's wine question using only their cellar.
+ *
+ * @param {string} userId  – MongoDB ObjectId string
+ * @param {string} message – natural-language question from the user
+ * @returns {Promise<{ answer: string, wines: object[] }>}
+ */
+async function chat(userId, message) {
+  const cfg = aiConfig.get();
+
+  if (!cfg.chatEnabled) {
+    throw Object.assign(new Error('AI chat is currently disabled'), { status: 503 });
+  }
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw Object.assign(new Error('ANTHROPIC_API_KEY is not configured'), { status: 503 });
+  }
+  if (!process.env.VOYAGE_API_KEY) {
+    throw Object.assign(new Error('VOYAGE_API_KEY is not configured'), { status: 503 });
+  }
+
+  // 1. Embed the question
+  const queryVector = await embedSingle(message, { model: cfg.embeddingModel });
+
+  // 2. Vector search
+  const hits = await vectorStore.searchSimilar(cfg.vectorIndex, queryVector, cfg.chatTopK);
+
+  // 3. Filter to user's cellar
+  const matches = await filterToUserCellar(userId, hits, cfg.chatMaxResults);
+
+  // 4. Build prompt
+  const wineSection = matches.length
+    ? `Available wines from the user's cellar:\n\n${formatWineList(matches)}`
+    : 'The user has no wines in their cellar that match this query.';
+
+  const userMessage = `${message}\n\n---\n${wineSection}`;
+
+  // 5. Call Claude
+  const client = getClaudeClient();
+  const response = await client.messages.create({
+    model: 'claude-haiku-4-5',
+    max_tokens: 600,
+    system: buildSystemPrompt(),
+    messages: [{ role: 'user', content: userMessage }]
+  });
+
+  const answer = response.content[0]?.text ?? '';
+
+  // 6. Shape the wine list for the frontend (strip internal score)
+  const wines = matches.map(({ bottle }) => ({
+    bottleId: bottle._id,
+    wineDefinitionId: bottle.wineDefinition._id,
+    name: bottle.wineDefinition.name,
+    producer: bottle.wineDefinition.producer,
+    type: bottle.wineDefinition.type,
+    vintage: bottle.vintage,
+    region: bottle.wineDefinition.region?.name || bottle.wineDefinition.appellation || null,
+    grapes: (bottle.wineDefinition.grapes || []).filter(g => g.name).map(g => g.name),
+    notes: bottle.notes || null
+  }));
+
+  return { answer, wines };
+}
+
+module.exports = { chat };

--- a/backend/src/services/embedding.js
+++ b/backend/src/services/embedding.js
@@ -1,0 +1,120 @@
+/**
+ * Voyage AI embedding service.
+ *
+ * Wraps the Voyage AI REST API (/v1/embeddings) using Node's built-in fetch.
+ * voyage-4-lite produces 1 024-dimensional vectors.
+ *
+ * Throttle strategy
+ * -----------------
+ * The free tier allows 3 requests per minute. Any 429 response is retried
+ * with truncated exponential backoff + jitter (initial 2 s, doubles each
+ * attempt, capped at 64 s). A Retry-After header is honoured when present.
+ * Permanent errors (4xx other than 429, 5xx after max retries) are thrown.
+ */
+
+const VOYAGE_API_URL = 'https://api.voyageai.com/v1/embeddings';
+const VOYAGE_DIMENSION = 1024;
+const DEFAULT_MODEL = 'voyage-4-lite';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Embed one or more texts. Returns an array of float[] vectors in the same
+ * order as the input array.
+ *
+ * @param {string[]} texts
+ * @param {object}   opts
+ * @param {string}   [opts.model]      – override the embedding model
+ * @param {number}   [opts.maxRetries] – retry budget for 429 responses (default 6)
+ * @returns {Promise<number[][]>}
+ */
+async function embed(texts, { model = DEFAULT_MODEL, maxRetries = 6 } = {}) {
+  const apiKey = process.env.VOYAGE_API_KEY;
+  if (!apiKey) {
+    throw new Error('VOYAGE_API_KEY is not configured');
+  }
+
+  let delay = 2000; // ms — initial backoff
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const res = await fetch(VOYAGE_API_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ input: texts, model })
+    });
+
+    if (res.ok) {
+      const json = await res.json();
+      // Sort by index to guarantee order matches input
+      const sorted = json.data.slice().sort((a, b) => a.index - b.index);
+      return sorted.map(d => d.embedding);
+    }
+
+    if (res.status === 429 && attempt < maxRetries) {
+      // Honour Retry-After if present; otherwise use exponential backoff + jitter
+      const retryAfter = res.headers.get('retry-after');
+      let waitMs = retryAfter
+        ? parseInt(retryAfter, 10) * 1000
+        : delay + Math.floor(Math.random() * 500);
+
+      console.warn(`[embedding] 429 rate-limited — waiting ${waitMs}ms (attempt ${attempt + 1}/${maxRetries})`);
+      await sleep(waitMs);
+      delay = Math.min(delay * 2, 64000);
+      continue;
+    }
+
+    // Non-retryable error
+    let body = '';
+    try { body = await res.text(); } catch (_) { /* ignore */ }
+    throw Object.assign(
+      new Error(`Voyage AI error ${res.status}: ${body}`),
+      { status: res.status }
+    );
+  }
+
+  throw new Error(`Voyage AI: exceeded ${maxRetries} retries due to rate limiting`);
+}
+
+/**
+ * Convenience wrapper — embed a single string, return its vector.
+ *
+ * @param {string} text
+ * @param {object} opts – forwarded to embed()
+ * @returns {Promise<number[]>}
+ */
+async function embedSingle(text, opts = {}) {
+  const [vector] = await embed([text], opts);
+  return vector;
+}
+
+/**
+ * Build the canonical text representation of a (WineDefinition, vintage) pair
+ * that will be embedded. Changing this format invalidates existing embeddings
+ * (detected via textHash in WineEmbedding).
+ *
+ * @param {object} wine    – populated WineDefinition (country.name, region.name, grapes[].name)
+ * @param {string} vintage – e.g. '2019' or 'NV'
+ * @returns {string}
+ */
+function buildEmbeddingText(wine, vintage) {
+  const lines = [
+    `Name: ${wine.name}`,
+    `Producer: ${wine.producer}`,
+    `Type: ${wine.type || 'unknown'}`,
+    `Vintage: ${vintage}`
+  ];
+  if (wine.region?.name)   lines.push(`Region: ${wine.region.name}`);
+  if (wine.country?.name)  lines.push(`Country: ${wine.country.name}`);
+  const grapeNames = (wine.grapes || []).filter(g => g.name).map(g => g.name).join(', ');
+  if (grapeNames)          lines.push(`Grapes: ${grapeNames}`);
+  if (wine.appellation)    lines.push(`Appellation: ${wine.appellation}`);
+  if (wine.classification) lines.push(`Classification: ${wine.classification}`);
+  return lines.join('\n');
+}
+
+module.exports = { embed, embedSingle, buildEmbeddingText, VOYAGE_DIMENSION };

--- a/backend/src/services/embeddingJob.js
+++ b/backend/src/services/embeddingJob.js
@@ -1,0 +1,343 @@
+/**
+ * Background batch embedding job.
+ *
+ * Scans every unique (WineDefinition, vintage) pair that exists in the Bottle
+ * collection and creates / refreshes its embedding in Qdrant + WineEmbedding.
+ *
+ * Only one job can run at a time. The job state is kept in memory and exposed
+ * via getStatus() for the admin dashboard.
+ *
+ * Modes
+ * ------
+ * incremental (default) – skip pairs that already have an up-to-date embedding
+ *                         (same model, indexVersion, and textHash)
+ * full                  – wipe the target Qdrant collection and re-embed everything
+ *
+ * Throttle
+ * ---------
+ * embeddingBatchDelayMs from aiConfig is slept between each Voyage AI call to
+ * stay within the free-tier 3 RPM limit. The embedding service itself retries
+ * on 429, providing a second line of defence.
+ */
+
+const crypto = require('crypto');
+const { randomUUID } = require('crypto');
+const aiConfig = require('../config/aiConfig');
+const { embedSingle, buildEmbeddingText } = require('./embedding');
+const vectorStore = require('./vectorStore');
+const WineEmbedding = require('../models/WineEmbedding');
+const Bottle = require('../models/Bottle');
+const WineDefinition = require('../models/WineDefinition');
+
+// ── In-memory job state ────────────────────────────────────────────────────
+
+let job = {
+  status: 'idle',       // 'idle' | 'running' | 'stopping' | 'done' | 'error'
+  mode: null,
+  model: null,
+  indexVersion: null,
+  total: 0,
+  done: 0,
+  skipped: 0,
+  errors: 0,
+  startedAt: null,
+  finishedAt: null,
+  lastError: null
+};
+
+let stopRequested = false;
+
+function getStatus() {
+  return { ...job };
+}
+
+function requestStop() {
+  if (job.status === 'running') {
+    stopRequested = true;
+    job.status = 'stopping';
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Gather every unique (wineDefinitionId, vintage) pair from active Bottle docs.
+ */
+async function collectPairs() {
+  const rows = await Bottle.aggregate([
+    { $match: { status: 'active' } },
+    { $group: { _id: { wineDefinition: '$wineDefinition', vintage: '$vintage' } } },
+    { $project: { _id: 0, wineDefinition: '$_id.wineDefinition', vintage: '$_id.vintage' } }
+  ]);
+  return rows;
+}
+
+// ── Main job logic ─────────────────────────────────────────────────────────
+
+/**
+ * Start the batch embedding job.
+ *
+ * @param {object} opts
+ * @param {'incremental'|'full'} [opts.mode='incremental']
+ */
+async function start({ mode = 'incremental' } = {}) {
+  if (job.status === 'running' || job.status === 'stopping') {
+    throw new Error('A job is already running');
+  }
+
+  const cfg = aiConfig.get();
+
+  stopRequested = false;
+  job = {
+    status: 'running',
+    mode,
+    model: cfg.embeddingModel,
+    indexVersion: cfg.vectorIndex,
+    total: 0,
+    done: 0,
+    skipped: 0,
+    errors: 0,
+    startedAt: new Date().toISOString(),
+    finishedAt: null,
+    lastError: null
+  };
+
+  // Run asynchronously — don't await here so the HTTP response returns immediately
+  runJob(cfg).catch(err => {
+    job.status = 'error';
+    job.lastError = err.message;
+    job.finishedAt = new Date().toISOString();
+    console.error('[embeddingJob] Unexpected error:', err);
+  });
+}
+
+async function runJob(cfg) {
+  const { embeddingModel: model, vectorIndex, embeddingBatchDelayMs } = cfg;
+
+  try {
+    // Ensure the Qdrant collection exists before we start
+    await vectorStore.ensureCollection(vectorIndex);
+
+    // Full mode: wipe existing WineEmbedding records for this model+version
+    if (job.mode === 'full') {
+      await vectorStore.dropCollection(vectorIndex);
+      await vectorStore.ensureCollection(vectorIndex);
+      await WineEmbedding.deleteMany({ model, indexVersion: vectorIndex });
+      console.log(`[embeddingJob] Full mode — cleared collection wines_${vectorIndex}`);
+    }
+
+    const pairs = await collectPairs();
+    job.total = pairs.length;
+    console.log(`[embeddingJob] Starting ${job.mode} job: ${job.total} pairs, model=${model}, index=${vectorIndex}`);
+
+    for (const { wineDefinition: wineDefId, vintage } of pairs) {
+      if (stopRequested) {
+        job.status = 'idle';
+        job.finishedAt = new Date().toISOString();
+        console.log('[embeddingJob] Stopped by request');
+        return;
+      }
+
+      try {
+        // Fetch the WineDefinition with populated refs
+        const wine = await WineDefinition.findById(wineDefId)
+          .populate('country', 'name')
+          .populate('region', 'name')
+          .populate('grapes', 'name')
+          .lean();
+
+        if (!wine) {
+          job.skipped++;
+          job.done++;
+          continue;
+        }
+
+        const text = buildEmbeddingText(wine, vintage);
+        const textHash = sha256(text);
+
+        // In incremental mode, skip if embedding is already current
+        if (job.mode === 'incremental') {
+          const existing = await WineEmbedding.findOne({
+            wineDefinition: wineDefId,
+            vintage,
+            model,
+            indexVersion: vectorIndex
+          });
+          if (existing && existing.textHash === textHash && existing.status === 'ok') {
+            job.skipped++;
+            job.done++;
+            continue;
+          }
+        }
+
+        // Embed
+        const vector = await embedSingle(text, { model });
+
+        // Upsert into Qdrant
+        const pointId = randomUUID();
+        await vectorStore.upsertPoints(vectorIndex, [{
+          id: pointId,
+          vector,
+          payload: {
+            wineDefinitionId: wineDefId.toString(),
+            vintage,
+            name: wine.name,
+            producer: wine.producer,
+            type: wine.type || 'unknown'
+          }
+        }]);
+
+        // Save / update WineEmbedding record
+        await WineEmbedding.findOneAndUpdate(
+          { wineDefinition: wineDefId, vintage, model, indexVersion: vectorIndex },
+          {
+            wineDefinition: wineDefId,
+            vintage,
+            model,
+            indexVersion: vectorIndex,
+            qdrantPointId: pointId,
+            textHash,
+            embeddedAt: new Date(),
+            status: 'ok',
+            errorMessage: null
+          },
+          { upsert: true, new: true }
+        );
+
+        job.done++;
+      } catch (err) {
+        job.errors++;
+        job.done++;
+        job.lastError = err.message;
+        console.error(`[embeddingJob] Error embedding (${wineDefId}, ${vintage}):`, err.message);
+
+        // Mark as error in DB so admins can see which ones failed
+        try {
+          await WineEmbedding.findOneAndUpdate(
+            { wineDefinition: wineDefId, vintage, model, indexVersion: vectorIndex },
+            {
+              wineDefinition: wineDefId,
+              vintage,
+              model,
+              indexVersion: vectorIndex,
+              qdrantPointId: randomUUID(),
+              textHash: '',
+              embeddedAt: new Date(),
+              status: 'error',
+              errorMessage: err.message
+            },
+            { upsert: true }
+          );
+        } catch (_) { /* non-critical */ }
+      }
+
+      // Throttle between calls to respect Voyage free-tier RPM
+      await sleep(embeddingBatchDelayMs);
+    }
+
+    job.status = 'done';
+    job.finishedAt = new Date().toISOString();
+    console.log(`[embeddingJob] Finished: ${job.done} processed, ${job.skipped} skipped, ${job.errors} errors`);
+  } catch (err) {
+    job.status = 'error';
+    job.lastError = err.message;
+    job.finishedAt = new Date().toISOString();
+    throw err;
+  }
+}
+
+// ── Real-time single-pair embedding ───────────────────────────────────────
+
+/**
+ * Embed a single (wineDefinition, vintage) pair immediately.
+ * Designed to be called fire-and-forget from the bottle creation / update
+ * routes — errors are caught and logged, never thrown to the caller.
+ *
+ * Skips silently when:
+ *  - VOYAGE_API_KEY is not configured
+ *  - the pair already has an up-to-date embedding (same textHash + status ok)
+ *  - a batch job is currently running (it will cover the pair itself)
+ *
+ * @param {string|object} wineDefId  – WineDefinition _id (string or ObjectId)
+ * @param {string}        vintage    – e.g. '2019' or 'NV'
+ */
+async function embedSinglePair(wineDefId, vintage) {
+  if (!process.env.VOYAGE_API_KEY) return;
+  // Let the running batch job handle it to avoid concurrent Voyage calls
+  if (job.status === 'running') return;
+
+  const cfg = aiConfig.get();
+  if (!cfg.chatEnabled) return;
+
+  const { embeddingModel: model, vectorIndex } = cfg;
+
+  try {
+    const wine = await WineDefinition.findById(wineDefId)
+      .populate('country', 'name')
+      .populate('region', 'name')
+      .populate('grapes', 'name')
+      .lean();
+
+    if (!wine) return;
+
+    const text = buildEmbeddingText(wine, vintage);
+    const textHash = sha256(text);
+
+    // Skip if already embedded and current
+    const existing = await WineEmbedding.findOne({
+      wineDefinition: wineDefId,
+      vintage,
+      model,
+      indexVersion: vectorIndex
+    });
+    if (existing && existing.textHash === textHash && existing.status === 'ok') return;
+
+    await vectorStore.ensureCollection(vectorIndex);
+
+    const vector = await embedSingle(text, { model });
+    const pointId = randomUUID();
+
+    await vectorStore.upsertPoints(vectorIndex, [{
+      id: pointId,
+      vector,
+      payload: {
+        wineDefinitionId: wineDefId.toString(),
+        vintage,
+        name: wine.name,
+        producer: wine.producer,
+        type: wine.type || 'unknown'
+      }
+    }]);
+
+    await WineEmbedding.findOneAndUpdate(
+      { wineDefinition: wineDefId, vintage, model, indexVersion: vectorIndex },
+      {
+        wineDefinition: wineDefId,
+        vintage,
+        model,
+        indexVersion: vectorIndex,
+        qdrantPointId: pointId,
+        textHash,
+        embeddedAt: new Date(),
+        status: 'ok',
+        errorMessage: null
+      },
+      { upsert: true, new: true }
+    );
+
+    console.log(`[embeddingJob] Real-time embedded: ${wine.name} ${vintage}`);
+  } catch (err) {
+    // Non-fatal — the batch job will retry on next run
+    console.warn(`[embeddingJob] Real-time embed failed (${wineDefId}, ${vintage}):`, err.message);
+  }
+}
+
+module.exports = { start, requestStop, getStatus, embedSinglePair };

--- a/backend/src/services/vectorStore.js
+++ b/backend/src/services/vectorStore.js
@@ -1,0 +1,163 @@
+/**
+ * Qdrant vector-store client.
+ *
+ * Wraps the Qdrant REST API using Node's built-in fetch. No SDK dependency —
+ * the relevant endpoints are straightforward enough to call directly.
+ *
+ * Collection naming: wines_<indexVersion>  (e.g. wines_v1)
+ *
+ * Point payload stored alongside each vector:
+ *   { wineDefinitionId, vintage, name, producer, type }
+ *
+ * This module is the only place in the codebase that talks to Qdrant, which
+ * makes index migrations (v1 → v2) easy to reason about.
+ */
+
+const { VOYAGE_DIMENSION } = require('./embedding');
+
+function qdrantBase() {
+  return (process.env.QDRANT_URL || 'http://localhost:6333').replace(/\/$/, '');
+}
+
+function collectionName(indexVersion) {
+  return `wines_${indexVersion}`;
+}
+
+async function qdrantRequest(method, path, body) {
+  const url = `${qdrantBase()}${path}`;
+  const opts = {
+    method,
+    headers: { 'Content-Type': 'application/json' }
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+
+  const res = await fetch(url, opts);
+  const json = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    throw Object.assign(
+      new Error(`Qdrant ${method} ${path} → ${res.status}: ${JSON.stringify(json)}`),
+      { status: res.status }
+    );
+  }
+  return json;
+}
+
+/**
+ * Create the collection if it doesn't already exist.
+ * Safe to call multiple times — idempotent.
+ */
+async function ensureCollection(indexVersion) {
+  const name = collectionName(indexVersion);
+
+  // Check if collection exists
+  try {
+    await qdrantRequest('GET', `/collections/${name}`);
+    return; // already exists
+  } catch (err) {
+    if (err.status !== 404) throw err;
+  }
+
+  // Create it
+  await qdrantRequest('PUT', `/collections/${name}`, {
+    vectors: {
+      size: VOYAGE_DIMENSION,
+      distance: 'Cosine'
+    }
+  });
+
+  console.log(`[vectorStore] Created Qdrant collection: ${name}`);
+}
+
+/**
+ * Upsert points into the collection. Each point: { id, vector, payload }.
+ *
+ * @param {string} indexVersion
+ * @param {Array<{ id: string, vector: number[], payload: object }>} points
+ */
+async function upsertPoints(indexVersion, points) {
+  if (!points.length) return;
+  const name = collectionName(indexVersion);
+  await qdrantRequest('PUT', `/collections/${name}/points`, {
+    points
+  });
+}
+
+/**
+ * Vector similarity search.
+ *
+ * @param {string}   indexVersion
+ * @param {number[]} vector – query vector
+ * @param {number}   topK   – number of results
+ * @returns {Promise<Array<{ id: string, score: number, payload: object }>>}
+ */
+async function searchSimilar(indexVersion, vector, topK = 50) {
+  const name = collectionName(indexVersion);
+  const result = await qdrantRequest('POST', `/collections/${name}/points/search`, {
+    vector,
+    limit: topK,
+    with_payload: true
+  });
+  return (result.result || []).map(hit => ({
+    id: hit.id,
+    score: hit.score,
+    payload: hit.payload || {}
+  }));
+}
+
+/**
+ * Delete points by their Qdrant IDs (UUIDs).
+ *
+ * @param {string}   indexVersion
+ * @param {string[]} ids
+ */
+async function deletePoints(indexVersion, ids) {
+  if (!ids.length) return;
+  const name = collectionName(indexVersion);
+  await qdrantRequest('POST', `/collections/${name}/points/delete`, {
+    points: ids
+  });
+}
+
+/**
+ * Delete an entire collection (used when wiping and rebuilding an index version).
+ *
+ * @param {string} indexVersion
+ */
+async function dropCollection(indexVersion) {
+  const name = collectionName(indexVersion);
+  try {
+    await qdrantRequest('DELETE', `/collections/${name}`);
+    console.log(`[vectorStore] Dropped Qdrant collection: ${name}`);
+  } catch (err) {
+    if (err.status !== 404) throw err;
+  }
+}
+
+/**
+ * Return basic stats about a collection (count of vectors).
+ */
+async function collectionInfo(indexVersion) {
+  const name = collectionName(indexVersion);
+  try {
+    const res = await qdrantRequest('GET', `/collections/${name}`);
+    return {
+      exists: true,
+      vectorCount: res.result?.vectors_count ?? 0,
+      name
+    };
+  } catch (err) {
+    if (err.status === 404) return { exists: false, vectorCount: 0, name };
+    throw err;
+  }
+}
+
+module.exports = {
+  ensureCollection,
+  upsertPoints,
+  searchSimilar,
+  deletePoints,
+  dropCollection,
+  collectionInfo,
+  collectionName
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,17 @@ services:
       timeout: 5s
       retries: 5
 
+  qdrant:
+    image: qdrant/qdrant:v1.9.0
+    container_name: cellarion-qdrant
+    volumes:
+      - qdrant-data:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:6333/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   backend:
     build: ./backend
     container_name: cellarion-backend
@@ -41,12 +52,16 @@ services:
       - MAILGUN_FROM=${MAILGUN_FROM:-}
       - MAILGUN_API_URL=${MAILGUN_API_URL:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - VOYAGE_API_KEY=${VOYAGE_API_KEY:-}
+      - QDRANT_URL=http://qdrant:6333
     volumes:
       - image-data:/app/uploads
     depends_on:
       mongo:
         condition: service_healthy
       meilisearch:
+        condition: service_healthy
+      qdrant:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/api/health"]
@@ -89,6 +104,7 @@ services:
 volumes:
   mongo-data:
   meili-data:
+  qdrant-data:
   image-data:
 
 networks:


### PR DESCRIPTION
## Summary

- **`POST /api/chat`** — authenticated users ask food-pairing / wine questions; Claude answers using only wines from their own cellar
- **RAG pipeline**: Voyage AI `voyage-4-lite` embeddings → Qdrant vector search → ownership filter (active bottles only) → grounded Claude `haiku-4-5` prompt
- **Batch embedding job** with incremental and full modes, admin-controlled via new admin routes; progress tracked in memory
- **Real-time hook**: new bottles are embedded async immediately on creation (and on vintage change), so they appear in chat without waiting for a job run
- **Feature flags** (`aiConfig`) stored in `SiteConfig`: master switch, active model, active index version, top-K, max results, batch delay — hot-reloaded at runtime, no restart needed
- **Voyage free-tier throttle handling**: exponential backoff with jitter (2 s → 64 s cap), `Retry-After` header honoured; configurable `embeddingBatchDelayMs` delay between batch calls
- **Index migration path**: bump `vectorIndex` to `v2` in config, run full job on `v2` while `v1` stays live, switch instantly by saving the flag

## New files

| File | Purpose |
|---|---|
| `backend/src/models/WineEmbedding.js` | Tracks `(wineDefinition, vintage, model, indexVersion)` → Qdrant point ID + textHash |
| `backend/src/config/aiConfig.js` | Feature-flag cache (same pattern as `rateLimits.js`) |
| `backend/src/services/embedding.js` | Voyage AI REST client + `buildEmbeddingText()` |
| `backend/src/services/vectorStore.js` | Qdrant REST client (ensure, upsert, search, delete, info) |
| `backend/src/services/embeddingJob.js` | Batch job + `embedSinglePair()` for real-time hook |
| `backend/src/services/aiChat.js` | RAG orchestration |
| `backend/src/routes/chat.js` | `POST /api/chat` with per-user 10 req/hr limiter |
| `backend/src/routes/admin/ai.js` | Admin config + job lifecycle endpoints |

## Modified files

| File | Change |
|---|---|
| `docker-compose.yml` | Added `qdrant` service + `qdrant-data` volume; `VOYAGE_API_KEY` + `QDRANT_URL` env vars |
| `.env.example` | Documented new variables |
| `backend/src/app.js` | Registered routes; loads `aiConfig` on startup |
| `backend/src/routes/bottles.js` | Fire-and-forget `embedSinglePair()` on bottle create / vintage update |

## Test plan

- [ ] `VOYAGE_API_KEY` and `ANTHROPIC_API_KEY` not set → `POST /api/chat` returns 503 with clear message
- [ ] `chatEnabled: false` → `POST /api/chat` returns 503
- [ ] Missing / empty message → 400
- [ ] Message over 1000 chars → 400
- [ ] Valid question with wines in cellar → answer + wine list returned
- [ ] Valid question with no matching wines → Claude says so, empty wine list
- [ ] Add a bottle → embedding fires async, wine appears in next chat query
- [ ] `POST /api/admin/ai/embed/start` (incremental) → job runs, status updates
- [ ] `POST /api/admin/ai/embed/stop` → job stops gracefully
- [ ] Start job while one is running → 409
- [ ] `PATCH /api/admin/ai/config` → config updates live without restart
- [ ] `docker-compose up --build` → Qdrant starts, backend waits for it to be healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)