### PR TITLE
refactor: reduce duplication, fix byRating bug, and harden security

### DIFF
--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -1,0 +1,12 @@
+/**
+ * Shared application-wide constants.
+ * Import from here instead of re-declaring in each file.
+ */
+
+// Bottle statuses that indicate the bottle has been removed from the active cellar
+const CONSUMED_STATUSES = ['drank', 'gifted', 'sold', 'other'];
+
+// Milliseconds in a single day — used for drink-window calculations
+const MS_PER_DAY = 86400000;
+
+module.exports = { CONSUMED_STATUSES, MS_PER_DAY };

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -11,9 +11,8 @@ const { logAudit } = require('../services/audit');
 const { getOrCreateDailySnapshot, getSnapshotForDate } = require('../utils/exchangeRates');
 const { isValidRating, VALID_SCALES } = require('../utils/ratingUtils');
 const { embedSinglePair } = require('../services/embeddingJob');
-
-// Strip HTML tags from user-supplied text to prevent XSS in rendered output
-const stripHtml = (str) => (str ? str.replace(/<[^>]*>/g, '').trim() : str);
+const { CONSUMED_STATUSES } = require('../config/constants');
+const { stripHtml, isSafeUrl } = require('../utils/sanitize');
 
 const router = express.Router();
 
@@ -43,6 +42,10 @@ router.post('/', async (req, res) => {
 
     if (!cellar || !wineDefinition) {
       return res.status(400).json({ error: 'Cellar and wine definition are required' });
+    }
+
+    if (purchaseUrl && !isSafeUrl(purchaseUrl)) {
+      return res.status(400).json({ error: 'purchaseUrl must be a valid http or https URL' });
     }
 
     const resolvedRatingScale = ratingScale && VALID_SCALES.includes(ratingScale) ? ratingScale : '5';
@@ -195,6 +198,10 @@ router.put('/:id', async (req, res) => {
       return res.status(403).json({ error: 'Not authorized to edit this bottle' });
     }
 
+    if (req.body.purchaseUrl && !isSafeUrl(req.body.purchaseUrl)) {
+      return res.status(400).json({ error: 'purchaseUrl must be a valid http or https URL' });
+    }
+
     // Update allowed fields — diff old vs new for the audit log
     const updateFields = [
       'vintage', 'price', 'currency', 'bottleSize',
@@ -294,8 +301,7 @@ router.post('/:id/consume', async (req, res) => {
     }
 
     const { reason = 'drank', note, rating, consumedRatingScale } = req.body;
-    const validReasons = ['drank', 'gifted', 'sold', 'other'];
-    if (!validReasons.includes(reason)) {
+    if (!CONSUMED_STATUSES.includes(reason)) {
       return res.status(400).json({ error: 'Invalid reason' });
     }
 

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -6,12 +6,14 @@ const Rack = require('../models/Rack');
 const User = require('../models/User');
 const AuditLog = require('../models/AuditLog');
 const BottleImage = require('../models/BottleImage');
+const WineDefinition = require('../models/WineDefinition');
 const { getCellarRole } = require('../utils/cellarAccess');
 const { logAudit } = require('../services/audit');
-const { getSnapshotsForDates, getOrCreateDailySnapshot } = require('../utils/exchangeRates');
+const { getSnapshotsForDates, getOrCreateDailySnapshot, convertCurrency } = require('../utils/exchangeRates');
 const { createNotification } = require('../services/notifications');
 const { getPlanConfig } = require('../config/plans');
 const { toNormalized } = require('../utils/ratingUtils');
+const { CONSUMED_STATUSES, MS_PER_DAY } = require('../config/constants');
 
 const router = express.Router();
 
@@ -20,9 +22,6 @@ function getUserColor(cellar, userId) {
   const entry = cellar.userColors?.find(uc => uc.user.toString() === userId.toString());
   return entry?.color || null;
 }
-
-// Statuses that mean a bottle has been removed from the active cellar
-const CONSUMED_STATUSES = ['drank', 'gifted', 'sold', 'other'];
 
 // All routes require authentication
 router.use(requireAuth);
@@ -129,16 +128,6 @@ router.get('/:id/statistics', async (req, res) => {
       todaySnapshot = await getOrCreateDailySnapshot();
     }
 
-    // Helper: convert amount from one currency to another using USD-based rates.
-    // Returns null if conversion is not possible.
-    function convertWithRates(amount, from, to, rates) {
-      if (!rates || !from || !to || from === to) return null;
-      const fromRate = rates[from];
-      const toRate = rates[to];
-      if (!fromRate || !toRate) return null;
-      return (amount / fromRate) * toRate;
-    }
-
     // Calculate statistics
     const stats = {
       totalBottles: bottles.length,
@@ -184,7 +173,7 @@ router.get('/:id/statistics', async (req, res) => {
               : null;
             const rates = (dateKey && snapshotMap.get(dateKey))
               || (todaySnapshot ? todaySnapshot.rates : null);
-            const converted = convertWithRates(bottle.price, currency, targetCurrency, rates);
+            const converted = convertCurrency(bottle.price, currency, targetCurrency, rates);
             if (converted !== null) {
               convertedSum += converted;
               convertedCount++;
@@ -231,11 +220,10 @@ router.get('/:id/statistics', async (req, res) => {
     // Drink window summary counts
     const now = new Date();
     now.setHours(0, 0, 0, 0);
-    const msPerDay = 86400000;
     let drinkOverdue = 0, drinkSoon = 0;
     bottles.forEach(bottle => {
       if (!bottle.drinkBefore) return;
-      const daysLeft = Math.round((new Date(bottle.drinkBefore) - now) / msPerDay);
+      const daysLeft = Math.round((new Date(bottle.drinkBefore) - now) / MS_PER_DAY);
       if (daysLeft < 0) drinkOverdue++;
       else if (daysLeft <= 90) drinkSoon++;
     });
@@ -303,12 +291,6 @@ router.get('/:id', async (req, res) => {
       return res.status(404).json({ error: 'Cellar not found' });
     }
 
-    // Base filter: only active bottles
-    const filter = {
-      cellar: req.params.id,
-      status: { $nin: CONSUMED_STATUSES }
-    };
-
     const {
       country,
       region,
@@ -321,39 +303,57 @@ router.get('/:id', async (req, res) => {
       sort = '-createdAt'
     } = req.query;
 
-    // Get all active bottles with wine definitions for filtering
+    // Base MongoDB filter for Bottle (direct fields only)
+    const filter = {
+      cellar: req.params.id,
+      status: { $nin: CONSUMED_STATUSES }
+    };
+
+    // Push vintage directly into the DB query — it's a scalar field on Bottle
+    if (vintage) filter.vintage = vintage;
+
+    // Push taxonomy filters (country, region, grapes) down via a WineDefinition pre-query.
+    // This avoids loading every bottle in the cellar just to discard most of them.
+    const wdFilter = {};
+    if (country) wdFilter.country = country;
+    if (region)  wdFilter.region  = region;
+    if (grapes) {
+      // $all ensures every requested grape is present in the wine's grapes array
+      wdFilter.grapes = { $all: grapes.split(',') };
+    }
+
+    if (Object.keys(wdFilter).length > 0) {
+      const matchingWdIds = await WineDefinition.find(wdFilter).distinct('_id');
+      if (matchingWdIds.length === 0) {
+        // No wines match the taxonomy filter — short-circuit with empty result
+        const cellarObj = cellar.toObject();
+        cellarObj.userRole = role;
+        cellarObj.userColor = getUserColor(cellar, req.user.id);
+        return res.json({ cellar: cellarObj, bottles: { count: 0, items: [] } });
+      }
+      filter.wineDefinition = { $in: matchingWdIds };
+    }
+
+    // Fetch the filtered set from DB (much smaller than fetching everything first)
     let bottles = await Bottle.find(filter).populate({
       path: 'wineDefinition',
       populate: ['country', 'region', 'grapes']
     });
 
-    // Apply filters on populated data
-    if (country) {
-      bottles = bottles.filter(b =>
-        b.wineDefinition && b.wineDefinition.country &&
-        b.wineDefinition.country._id.toString() === country
-      );
-    }
+    // ── In-memory filters for cases that can't be expressed cleanly in Mongo ──
 
-    if (region) {
-      bottles = bottles.filter(b =>
-        b.wineDefinition && b.wineDefinition.region &&
-        b.wineDefinition.region._id.toString() === region
-      );
-    }
-
-    if (grapes) {
-      const grapeIds = grapes.split(',');
+    if (search) {
+      const searchLower = search.toLowerCase();
       bottles = bottles.filter(b => {
-        if (!b.wineDefinition || !b.wineDefinition.grapes) return false;
-        return grapeIds.every(grapeId =>
-          b.wineDefinition.grapes.some(g => g._id.toString() === grapeId)
-        );
+        const wineName = b.wineDefinition?.name?.toLowerCase() || '';
+        const producer = b.wineDefinition?.producer?.toLowerCase() || '';
+        const notes = b.notes?.toLowerCase() || '';
+        const location = b.location?.toLowerCase() || '';
+        return wineName.includes(searchLower) ||
+               producer.includes(searchLower) ||
+               notes.includes(searchLower) ||
+               location.includes(searchLower);
       });
-    }
-
-    if (vintage) {
-      bottles = bottles.filter(b => b.vintage === vintage);
     }
 
     if (minRating) {
@@ -373,31 +373,16 @@ router.get('/:id', async (req, res) => {
       });
     }
 
-    if (search) {
-      const searchLower = search.toLowerCase();
-      bottles = bottles.filter(b => {
-        const wineName = b.wineDefinition?.name?.toLowerCase() || '';
-        const producer = b.wineDefinition?.producer?.toLowerCase() || '';
-        const notes = b.notes?.toLowerCase() || '';
-        const location = b.location?.toLowerCase() || '';
-        return wineName.includes(searchLower) ||
-               producer.includes(searchLower) ||
-               notes.includes(searchLower) ||
-               location.includes(searchLower);
-      });
-    }
-
     // Filter by drink window status
     if (drinkStatus) {
       const now = new Date();
       now.setHours(0, 0, 0, 0);
-      const msPerDay = 86400000;
       bottles = bottles.filter(b => {
         const before = b.drinkBefore ? new Date(b.drinkBefore) : null;
         const from = b.drinkFrom ? new Date(b.drinkFrom) : null;
         if (!before && !from) return false; // no dates set — excluded from all named statuses
         if (before) {
-          const daysLeft = Math.round((before - now) / msPerDay);
+          const daysLeft = Math.round((before - now) / MS_PER_DAY);
           if (daysLeft < 0) return drinkStatus === 'overdue';
           if (daysLeft <= 90) return drinkStatus === 'soon';
         }

--- a/backend/src/routes/stats.js
+++ b/backend/src/routes/stats.js
@@ -4,13 +4,12 @@ const Cellar = require('../models/Cellar');
 const Bottle = require('../models/Bottle');
 const User = require('../models/User');
 const WineVintageProfile = require('../models/WineVintageProfile');
-const { getOrCreateDailySnapshot } = require('../utils/exchangeRates');
+const { getOrCreateDailySnapshot, convertCurrency } = require('../utils/exchangeRates');
 const { toNormalized } = require('../utils/ratingUtils');
+const { CONSUMED_STATUSES, MS_PER_DAY } = require('../config/constants');
 
 const router = express.Router();
 router.use(requireAuth);
-
-const CONSUMED_STATUSES = ['drank', 'gifted', 'sold', 'other'];
 
 /**
  * Effective drink window: user-set per-bottle takes priority,
@@ -37,10 +36,10 @@ function getEffectiveDrinkWindow(bottle, profileMap) {
   return { from: null, before: null, source: 'none' };
 }
 
-function classifyWindow(from, before, now, msPerDay) {
+function classifyWindow(from, before, now) {
   if (!from && !before) return 'noWindow';
   if (before) {
-    const dl = Math.round((before - now) / msPerDay);
+    const dl = Math.round((before - now) / MS_PER_DAY);
     if (dl < 0)   return 'overdue';
     if (dl <= 90)  return 'soon';
     if (!from || now >= from) return 'inWindow';
@@ -114,18 +113,14 @@ router.get('/overview', async (req, res) => {
       todayRates = snap?.rates || null;
     } catch (_) {}
 
+    // Best-effort conversion: falls back to the original amount when rates are unavailable
     function toTarget(amount, fromCurrency) {
       if (!amount || !fromCurrency) return null;
-      if (!todayRates || fromCurrency === targetCurrency) return amount;
-      const from = todayRates[fromCurrency];
-      const to   = todayRates[targetCurrency];
-      if (!from || !to) return amount;
-      return (amount / from) * to;
+      return convertCurrency(amount, fromCurrency, targetCurrency, todayRates) ?? amount;
     }
 
     const now        = new Date();
     now.setHours(0, 0, 0, 0);
-    const msPerDay   = 86400000;
     const currentYear = now.getFullYear();
 
     // ── Active-bottle accumulators ────────────────────────────────────────────
@@ -140,7 +135,7 @@ router.get('/overview', async (req, res) => {
     const byRegion      = {};
     const byGrape       = {};
     const byVintage     = {};
-    const byRating      = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+    const byRating      = { '0-20': 0, '21-40': 0, '41-60': 0, '61-80': 0, '81-100': 0 };
     const byBottleSize  = {};
     const byPurchaseYear = {};
     const byProducer    = {};
@@ -220,7 +215,7 @@ router.get('/overview', async (req, res) => {
 
       // ── Effective drink window ──────────────────────────────────────────────
       const { from, before, source } = getEffectiveDrinkWindow(b, profileMap);
-      const cls = classifyWindow(from, before, now, msPerDay);
+      const cls = classifyWindow(from, before, now);
       drinkWindow[cls]++;
 
       if (source === 'user')      windowCoverage.userSet++;
@@ -253,7 +248,7 @@ router.get('/overview', async (req, res) => {
           vintage:       b.vintage     || 'NV',
           type:          wd?.type      || 'unknown',
           price:         priceCvt != null ? Math.round(priceCvt * 100) / 100 : null,
-          daysRemaining: before ? Math.round((before - now) / msPerDay) : null,
+          daysRemaining: before ? Math.round((before - now) / MS_PER_DAY) : null,
           status:        cls,
           source,
         });
@@ -326,7 +321,7 @@ router.get('/overview', async (req, res) => {
       // Holding time analysis
       const anchor = b.purchaseDate || b.createdAt;
       if (b.consumedAt && anchor) {
-        const daysHeld = (new Date(b.consumedAt) - new Date(anchor)) / msPerDay;
+        const daysHeld = (new Date(b.consumedAt) - new Date(anchor)) / MS_PER_DAY;
         const bucket =
           daysHeld < 365  ? '<1yr'   :
           daysHeld < 730  ? '1–2yr'  :

--- a/backend/src/services/aiChat.js
+++ b/backend/src/services/aiChat.js
@@ -20,11 +20,16 @@ const vectorStore = require('./vectorStore');
 const Bottle = require('../models/Bottle');
 
 // ── Claude client (reuse the @anthropic-ai/sdk already in package.json) ────
+// Lazily instantiated so the module can load even when ANTHROPIC_API_KEY is not set yet.
 
+let _claudeClient = null;
 function getClaudeClient() {
-  const sdk = require('@anthropic-ai/sdk');
-  const Anthropic = sdk.default ?? sdk;
-  return new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  if (!_claudeClient) {
+    const sdk = require('@anthropic-ai/sdk');
+    const Anthropic = sdk.default ?? sdk;
+    _claudeClient = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  }
+  return _claudeClient;
 }
 
 // ── Wine matching ──────────────────────────────────────────────────────────

--- a/backend/src/utils/exchangeRates.js
+++ b/backend/src/utils/exchangeRates.js
@@ -64,4 +64,23 @@ async function getSnapshotsForDates(dates) {
   return new Map(snapshots.map(s => [s.date, s.rates]));
 }
 
-module.exports = { fetchExchangeRates, getOrCreateDailySnapshot, getSnapshotForDate, getSnapshotsForDates };
+/**
+ * Converts an amount from one currency to another using a USD-based rates map.
+ * Returns null if the conversion is not possible (missing rates, same currency is handled as a no-op).
+ *
+ * @param {number} amount
+ * @param {string} from  - ISO currency code of the source amount
+ * @param {string} to    - ISO currency code of the target
+ * @param {object} rates - plain rates map { USD: 1, EUR: 0.92, ... }
+ * @returns {number|null}
+ */
+function convertCurrency(amount, from, to, rates) {
+  if (!amount || !from || !to || !rates) return null;
+  if (from === to) return amount;
+  const fromRate = rates[from];
+  const toRate   = rates[to];
+  if (!fromRate || !toRate) return null;
+  return (amount / fromRate) * toRate;
+}
+
+module.exports = { fetchExchangeRates, getOrCreateDailySnapshot, getSnapshotForDate, getSnapshotsForDates, convertCurrency };

--- a/backend/src/utils/sanitize.js
+++ b/backend/src/utils/sanitize.js
@@ -1,0 +1,24 @@
+/**
+ * Strips all HTML tags from a user-supplied string to prevent XSS in rendered output.
+ * Returns the original value unchanged if it is null/undefined/empty.
+ */
+function stripHtml(str) {
+  return str ? str.replace(/<[^>]*>/g, '').trim() : str;
+}
+
+/**
+ * Returns true if the URL uses only an http or https scheme.
+ * Rejects javascript:, data:, and other potentially dangerous schemes.
+ * Returns false for null/undefined/empty values.
+ */
+function isSafeUrl(url) {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { stripHtml, isSafeUrl };

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -55,6 +55,18 @@ export const AuthProvider = ({ children }) => {
   };
 
   // ------------------------------------------------------------------
+  // Shared session helper — stores token, sets user, applies language
+  // ------------------------------------------------------------------
+
+  const applySession = (token, userData) => {
+    storeToken(token);
+    setUser(userData);
+    if (userData?.preferences?.language) {
+      i18n.changeLanguage(userData.preferences.language);
+    }
+  };
+
+  // ------------------------------------------------------------------
   // Refresh: called automatically by apiFetch on 401
   // ------------------------------------------------------------------
 
@@ -124,10 +136,7 @@ export const AuthProvider = ({ children }) => {
 
       if (response.ok) {
         const data = await response.json();
-        setUser(data.user);
-        if (data.user?.preferences?.language) {
-          i18n.changeLanguage(data.user.preferences.language);
-        }
+        applySession(authToken, data.user);
       } else if (response.status === 401) {
         // Access token may have expired — try refresh before giving up
         const newToken = await handleRefresh();
@@ -138,10 +147,7 @@ export const AuthProvider = ({ children }) => {
           });
           if (retry.ok) {
             const data = await retry.json();
-            setUser(data.user);
-            if (data.user?.preferences?.language) {
-              i18n.changeLanguage(data.user.preferences.language);
-            }
+            applySession(newToken, data.user);
             return;
           }
         }
@@ -178,11 +184,7 @@ export const AuthProvider = ({ children }) => {
 
       if (data.token) {
         // Verification disabled — logged in immediately
-        storeToken(data.token);
-        setUser(data.user);
-        if (data.user?.preferences?.language) {
-          i18n.changeLanguage(data.user.preferences.language);
-        }
+        applySession(data.token, data.user);
         return { success: true };
       }
 
@@ -210,11 +212,7 @@ export const AuthProvider = ({ children }) => {
         throw err;
       }
 
-      storeToken(data.token);
-      setUser(data.user);
-      if (data.user?.preferences?.language) {
-        i18n.changeLanguage(data.user.preferences.language);
-      }
+      applySession(data.token, data.user);
       return { success: true };
     } catch (error) {
       return { success: false, error: error.message, code: error.code, email: error.email };
@@ -229,11 +227,7 @@ export const AuthProvider = ({ children }) => {
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Verification failed');
 
-      storeToken(data.token);
-      setUser(data.user);
-      if (data.user?.preferences?.language) {
-        i18n.changeLanguage(data.user.preferences.language);
-      }
+      applySession(data.token, data.user);
       return { success: true };
     } catch (error) {
       return { success: false, error: error.message };

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -32,11 +32,15 @@ function CellarDetail() {
     sort: '-createdAt'
   });
 
+  // Bottles list re-fetches when filters change; statistics and racks only need to reload when the cellar ID changes
   useEffect(() => {
     fetchCellarData();
+  }, [id, filters]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
     fetchStatistics();
     fetchRacks();
-  }, [id, filters]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
 
 
   const fetchCellarData = async () => {


### PR DESCRIPTION
## Summary

- **Bug fix:** `byRating` in `stats.js` was initialised with numeric keys (`1,2,3,4,5`) but written with string band keys (`'0-20'`, `'21-40'`, …), causing the API to return both sets of keys — inconsistent with the empty-stats shape and potentially rendering phantom zero-entries in charts
- **Security:** Added `isSafeUrl()` validation on `purchaseUrl` in bottle create/update routes to block `javascript:` and `data:` URI injection
- **Performance:** Taxonomy filters (`country`, `region`, `grapes`) and `vintage` in `GET /api/cellars/:id` are now pushed into a MongoDB WineDefinition pre-query instead of loading all bottles and filtering in-memory; empty taxonomy results short-circuit immediately
- **Deduplication:** Extracted `CONSUMED_STATUSES` and `MS_PER_DAY` into `config/constants.js` (were defined in 3+ separate files); `convertCurrency` into `exchangeRates.js` (replacing `convertWithRates` and `toTarget` closures); `stripHtml` and `isSafeUrl` into `utils/sanitize.js`; `applySession` helper in `AuthContext.js` (replaces 4 identical copies of token+user+i18n setup)
- **Frontend:** Split `CellarDetail.js` `useEffect` so statistics and rack data only reload when the cellar ID changes, not on every filter update (was causing 3× redundant network requests per filter change)
- **AI:** Anthropic client in `aiChat.js` is now a lazy module-level singleton instead of being re-instantiated on every `expandQuery` and `chat` call

## Test plan

- [x] All 79 backend tests pass (`npm test -- --forceExit`)
- [x] All 45 frontend tests pass (`npm test -- --watchAll=false`)
- [ ] Smoke-test in Docker: filter bottles by country/region/grape in a cellar and confirm results are correct
- [ ] Confirm `purchaseUrl` with a `javascript:` scheme is rejected with 400
- [ ] Check Statistics page renders rating chart with correct band labels only