### PR TITLE
fix(security): loop stripHtml to prevent nested tag bypass

### DIFF
--- a/backend/src/utils/sanitize.js
+++ b/backend/src/utils/sanitize.js
@@ -3,7 +3,13 @@
  * Returns the original value unchanged if it is null/undefined/empty.
  */
 function stripHtml(str) {
-  return str ? str.replace(/<[^>]*>/g, '').trim() : str;
+  if (!str) return str;
+  let prev;
+  do {
+    prev = str;
+    str = str.replace(/<[^>]*>/g, '');
+  } while (str !== prev);
+  return str.trim();
 }
 
 /**


### PR DESCRIPTION
## Summary
- `stripHtml()` now loops until stable, preventing nested tag bypass (e.g. `<<script>script>`)
- All 13 CodeQL code scanning alerts reviewed and dismissed as false positives (Mongoose ODM flagged as SQL injection, test file flagged for rate limiting, etc.)
- All 4 Dependabot alerts reviewed and dismissed (transitive deps in CRA/d3 toolchain, not user-facing)

## Test plan
- [ ] `cd backend && npm test` passes
- [ ] Manual check: `stripHtml('<<script>script>alert(1)<</script>/script>')` returns `alert(1)`