### PR TITLE
fix(chat): broaden fallback to all transient errors + add error log

### DIFF
--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -15,6 +15,7 @@ const ChatUsage = require('../models/ChatUsage');
 const embeddingJob = require('../services/embeddingJob');
 const vectorStore = require('../services/vectorStore');
 const aiConfig = require('../config/aiConfig');
+const aiChat = require('../services/aiChat');
 
 const router = express.Router();
 
@@ -387,6 +388,7 @@ router.get('/ai', async (req, res) => {
         })),
         lastEmbeddedAt: latestEmbedding?.embeddedAt || null,
       },
+      chatEventLog: aiChat.getEventLog(),
     });
   } catch (error) {
     console.error('[superadmin] ai error:', error);

--- a/backend/src/services/aiChat.js
+++ b/backend/src/services/aiChat.js
@@ -32,6 +32,19 @@ function getClaudeClient() {
   return _claudeClient;
 }
 
+// ── In-memory event log (ring buffer, survives until restart) ─────────────
+const MAX_LOG_ENTRIES = 100;
+const _eventLog = [];
+
+function logEvent(entry) {
+  _eventLog.push({ ...entry, timestamp: new Date().toISOString() });
+  if (_eventLog.length > MAX_LOG_ENTRIES) _eventLog.shift();
+}
+
+function getEventLog() {
+  return _eventLog.slice().reverse(); // newest first
+}
+
 // ── Wine matching ──────────────────────────────────────────────────────────
 
 /**
@@ -128,17 +141,44 @@ function formatWineList(matches) {
  * fails (so the pipeline always continues).
  */
 async function expandQuery(message) {
+  const cfg = aiConfig.get();
+  const client = getClaudeClient();
+  const callParams = {
+    max_tokens: 120,
+    system: `You are a wine search assistant. Rewrite the user's question into rich wine-search terminology: wine style, body, tannins, acidity, typical grape varieties, regions, and food context. Reply with ONLY the expanded search terms as a single line, no explanation, no labels. Always reply in English regardless of the language the user wrote in.`,
+    messages: [{ role: 'user', content: message }]
+  };
   try {
-    const client = getClaudeClient();
-    const response = await client.messages.create({
-      model: aiConfig.get().chatModel,
-      max_tokens: 120,
-      system: `You are a wine search assistant. Rewrite the user's question into rich wine-search terminology: wine style, body, tannins, acidity, typical grape varieties, regions, and food context. Reply with ONLY the expanded search terms as a single line, no explanation, no labels. Always reply in English regardless of the language the user wrote in.`,
-      messages: [{ role: 'user', content: message }]
-    });
+    const response = await client.messages.create({ ...callParams, model: cfg.chatModel });
     const expanded = response.content[0]?.text?.trim();
     return expanded || message;
-  } catch {
+  } catch (err) {
+    // If primary failed and a fallback is configured, try the fallback
+    const canFallback = cfg.chatModelFallback && cfg.chatModelFallback !== cfg.chatModel;
+    const isRetryable = [429, 500, 502, 503, 529].includes(err.status)
+      || err.error?.type === 'overloaded_error';
+    logEvent({
+      phase: 'query-expansion',
+      primaryModel: cfg.chatModel,
+      status: err.status || null,
+      errorType: err.error?.type || null,
+      errorMessage: err.message || null,
+      fallbackAttempted: isRetryable && canFallback,
+      fallbackModel: canFallback ? cfg.chatModelFallback : null,
+    });
+    if (isRetryable && canFallback) {
+      try {
+        const response = await client.messages.create({ ...callParams, model: cfg.chatModelFallback });
+        const expanded = response.content[0]?.text?.trim();
+        _eventLog[_eventLog.length - 1].fallbackResult = 'ok';
+        return expanded || message;
+      } catch (fbErr) {
+        _eventLog[_eventLog.length - 1].fallbackResult = 'failed';
+        _eventLog[_eventLog.length - 1].fallbackStatus = fbErr.status || null;
+        _eventLog[_eventLog.length - 1].fallbackError = fbErr.message || null;
+        return message;
+      }
+    }
     // Expansion is best-effort — fall back to original question
     return message;
   }
@@ -183,7 +223,7 @@ async function chat(userId, message, { useQueryExpansion = true } = {}) {
 
   const userMessage = `${message}\n\n---\n${wineSection}`;
 
-  // 5. Call Claude (retry with fallback model on 529 overloaded)
+  // 5. Call Claude (retry with fallback model on transient API errors)
   const client = getClaudeClient();
   const callParams = {
     max_tokens: 600,
@@ -195,10 +235,29 @@ async function chat(userId, message, { useQueryExpansion = true } = {}) {
   try {
     response = await client.messages.create({ ...callParams, model: cfg.chatModel });
   } catch (err) {
-    const isOverloaded = err.status === 529 || err.error?.type === 'overloaded_error';
-    if (isOverloaded && cfg.chatModelFallback && cfg.chatModelFallback !== cfg.chatModel) {
-      console.warn(`[aiChat] Primary model overloaded (${cfg.chatModel}), retrying with fallback: ${cfg.chatModelFallback}`);
-      response = await client.messages.create({ ...callParams, model: cfg.chatModelFallback });
+    const canFallback = cfg.chatModelFallback && cfg.chatModelFallback !== cfg.chatModel;
+    const isRetryable = [429, 500, 502, 503, 529].includes(err.status)
+      || err.error?.type === 'overloaded_error';
+    logEvent({
+      phase: 'chat',
+      primaryModel: cfg.chatModel,
+      status: err.status || null,
+      errorType: err.error?.type || null,
+      errorMessage: err.message || null,
+      fallbackAttempted: isRetryable && canFallback,
+      fallbackModel: canFallback ? cfg.chatModelFallback : null,
+    });
+    if (isRetryable && canFallback) {
+      console.warn(`[aiChat] Primary model failed (${cfg.chatModel}, status ${err.status}), retrying with fallback: ${cfg.chatModelFallback}`);
+      try {
+        response = await client.messages.create({ ...callParams, model: cfg.chatModelFallback });
+        _eventLog[_eventLog.length - 1].fallbackResult = 'ok';
+      } catch (fbErr) {
+        _eventLog[_eventLog.length - 1].fallbackResult = 'failed';
+        _eventLog[_eventLog.length - 1].fallbackStatus = fbErr.status || null;
+        _eventLog[_eventLog.length - 1].fallbackError = fbErr.message || null;
+        throw fbErr;
+      }
     } else {
       throw err;
     }
@@ -227,4 +286,4 @@ async function chat(userId, message, { useQueryExpansion = true } = {}) {
   return { answer, wines, expandedQuery: useQueryExpansion ? searchQuery : null, usage };
 }
 
-module.exports = { chat };
+module.exports = { chat, getEventLog };

--- a/frontend/src/pages/SuperAdmin.js
+++ b/frontend/src/pages/SuperAdmin.js
@@ -1503,6 +1503,54 @@ function TabAI() {
           </div>
         </div>
       </div>
+      {/* Chat event log (errors / fallbacks) */}
+      {data.chatEventLog?.length > 0 && (
+        <div className="sa-panel" style={{ marginBottom: 16 }}>
+          <div className="sa-panel-header">
+            <span className="sa-panel-title">Chat Error Log</span>
+            <span style={{ fontSize: 11, color: 'var(--sa-text-dim)' }}>Last {data.chatEventLog.length} events (in-memory, resets on restart)</span>
+          </div>
+          <div className="sa-panel-body">
+            <div className="sa-table-wrap">
+              <table className="sa-table">
+                <thead>
+                  <tr>
+                    <th>Time</th>
+                    <th>Phase</th>
+                    <th>Primary model</th>
+                    <th>Status</th>
+                    <th>Error</th>
+                    <th>Fallback</th>
+                    <th>Result</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.chatEventLog.map((e, i) => (
+                    <tr key={i}>
+                      <td style={{ whiteSpace: 'nowrap' }}>{ago(e.timestamp)}</td>
+                      <td>{e.phase}</td>
+                      <td style={{ fontSize: 11 }}>{e.primaryModel}</td>
+                      <td className={e.status >= 500 ? 'danger' : ''}>{e.status || '—'}</td>
+                      <td style={{ fontSize: 11, maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={e.errorMessage || ''}>
+                        {e.errorType || e.errorMessage || '—'}
+                      </td>
+                      <td style={{ fontSize: 11 }}>
+                        {e.fallbackAttempted ? e.fallbackModel : <span style={{ color: 'var(--sa-text-dim)' }}>none</span>}
+                      </td>
+                      <td>
+                        {e.fallbackResult === 'ok' && <span className="accent">OK</span>}
+                        {e.fallbackResult === 'failed' && <span className="danger">FAILED</span>}
+                        {!e.fallbackAttempted && <span style={{ color: 'var(--sa-text-dim)' }}>no fallback</span>}
+                        {e.fallbackAttempted && !e.fallbackResult && <span style={{ color: 'var(--sa-text-dim)' }}>—</span>}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
       <ChatModelPanel currentModel={config.chatModel} currentFallback={config.chatModelFallback || null} apiFetch={apiFetch} />
       <SystemPromptPanel prompt={config.chatSystemPrompt || ''} apiFetch={apiFetch} />
       <ChatLimitsPanel limits={config.chatDailyLimits || {}} apiFetch={apiFetch} />


### PR DESCRIPTION
## Summary
- **Broadened model fallback** from only 529 (overloaded) to also cover 429, 500, 502, 503 — the secondary model now actually kicks in when the primary fails for rate limits or server errors
- **Added fallback to query expansion** — previously silently failed when the primary model was down, degrading search quality
- **Added in-memory error log** (last 100 events) to the SuperAdmin AI tab showing: timestamp, phase, model, HTTP status, error type, fallback model used, and outcome

## Test plan
- [x] Backend tests pass (132/132)
- [x] Frontend tests pass (50/50)
- [ ] Smoke-test in Docker: trigger chat with Haiku as primary + Opus as fallback
- [ ] Verify error log appears in SuperAdmin > AI & Embeddings tab after a failure


🤖 Generated with [Claude Code](https://claude.com/claude-code)