### PR TITLE
feat(bottles): allow backdating and adding directly to history

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -46,7 +46,15 @@ router.post('/', async (req, res) => {
       rating,
       ratingScale,
       drinkFrom,
-      drinkBefore
+      drinkBefore,
+      // Migration helpers — let users backdate bottles or add directly to history
+      dateAdded,
+      addToHistory,
+      consumedAt,
+      consumedReason,
+      consumedNote,
+      consumedRating,
+      consumedRatingScale
     } = req.body;
 
     if (!cellar || !wineDefinition) {
@@ -59,6 +67,16 @@ router.post('/', async (req, res) => {
 
     const { rating: resolvedRating, ratingScale: resolvedRatingScale, error: ratingError } = resolveRating(rating, ratingScale);
     if (ratingError) return res.status(400).json({ error: ratingError });
+
+    // Validate add-to-history fields
+    if (addToHistory) {
+      if (consumedReason && !CONSUMED_STATUSES.includes(consumedReason)) {
+        return res.status(400).json({ error: 'Invalid consumed reason' });
+      }
+    }
+    const { rating: resolvedConsumedRating, ratingScale: resolvedConsumedScale, error: consumeRatingError } =
+      addToHistory ? resolveRating(consumedRating, consumedRatingScale) : { rating: undefined, ratingScale: undefined, error: null };
+    if (consumeRatingError) return res.status(400).json({ error: consumeRatingError });
 
     // Verify user has editor/owner access to this cellar
     const cellarDoc = await Cellar.findById(cellar);
@@ -101,6 +119,22 @@ router.post('/', async (req, res) => {
       drinkBefore
     });
 
+    // Allow backdating the "added" date for cellar migration
+    if (dateAdded) bottle.createdAt = new Date(dateAdded);
+
+    // Allow creating bottles directly as consumed (add to history)
+    if (addToHistory) {
+      const reason = consumedReason || 'drank';
+      bottle.status = reason;
+      bottle.consumedReason = reason;
+      bottle.consumedAt = consumedAt ? new Date(consumedAt) : new Date();
+      if (consumedNote) bottle.consumedNote = stripHtml(consumedNote);
+      if (resolvedConsumedRating !== undefined) {
+        bottle.consumedRating = resolvedConsumedRating;
+        bottle.consumedRatingScale = resolvedConsumedScale;
+      }
+    }
+
     await bottle.save();
     await bottle.populate(WINE_POPULATE);
 
@@ -120,7 +154,7 @@ router.post('/', async (req, res) => {
       }
     }
 
-    logAudit(req, 'bottle.add',
+    logAudit(req, addToHistory ? 'bottle.addToHistory' : 'bottle.add',
       { type: 'bottle', id: bottle._id, cellarId: cellarDoc._id },
       { wineName: bottle.wineDefinition?.name, vintage: bottle.vintage }
     );

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -225,7 +225,17 @@
     "bottlePhotos": "Bottle Photos",
     "photosHint": "Take a photo or upload an image. Background will be automatically removed.",
     "photosNotice": "Images are reviewed by an admin before being added to the shared wine registry, where they will be visible to all Cellarion users.",
-    "addBottleBtn": "Add Bottle to Cellar"
+    "addBottleBtn": "Add Bottle to Cellar",
+    "dateAdded": "Date Added",
+    "dateAddedHint": "When this bottle was added to your cellar. Defaults to today.",
+    "addToHistory": "Add to History",
+    "addToHistoryHint": "Add this bottle directly to your history (already consumed, gifted, or sold).",
+    "consumedDate": "Date",
+    "consumedReason": "Reason",
+    "consumedNote": "Note",
+    "consumedNotePlaceholder": "Tasting notes, occasion, etc.",
+    "consumedRating": "Rating at Consumption",
+    "addToHistoryBtn": "Add to History"
   },
 
   "bottleDetail": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -225,7 +225,17 @@
     "bottlePhotos": "Flaskfoton",
     "photosHint": "Ta ett foto eller ladda upp en bild. Bakgrunden tas bort automatiskt.",
     "photosNotice": "Bilder granskas av en administratör innan de läggs till i det delade vinregistret, där de visas för alla Cellarion-användare.",
-    "addBottleBtn": "Lägg till flaska i källaren"
+    "addBottleBtn": "Lägg till flaska i källaren",
+    "dateAdded": "Datum tillagd",
+    "dateAddedHint": "När denna flaska lades till i din källare. Standard är idag.",
+    "addToHistory": "Lägg till i historik",
+    "addToHistoryHint": "Lägg till denna flaska direkt i din historik (redan drucken, bortskänkt eller såld).",
+    "consumedDate": "Datum",
+    "consumedReason": "Anledning",
+    "consumedNote": "Anteckning",
+    "consumedNotePlaceholder": "Smaknoteringar, tillfälle, etc.",
+    "consumedRating": "Betyg vid konsumtion",
+    "addToHistoryBtn": "Lägg till i historik"
   },
 
   "bottleDetail": {

--- a/frontend/src/pages/AddBottle.css
+++ b/frontend/src/pages/AddBottle.css
@@ -330,6 +330,36 @@
   line-height: 1.4;
 }
 
+/* ── Add to History ── */
+.add-to-history-section {
+  background: #1a1a2e;
+  border: 1px solid #2a2a4a;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: #E8DFD0;
+}
+
+.toggle-label input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: #7B9E88;
+  cursor: pointer;
+}
+
+.history-fields {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #2a2a4a;
+}
+
 /* ── Mobile ── */
 @media (max-width: 768px) {
   .step span {

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -33,7 +33,16 @@ function AddBottle() {
     rating: '',
     ratingScale: user?.preferences?.ratingScale || '5',
     drinkFrom: '',
-    drinkBefore: ''
+    drinkBefore: '',
+    dateAdded: ''
+  });
+  const [addToHistory, setAddToHistory] = useState(false);
+  const [historyData, setHistoryData] = useState({
+    consumedAt: '',
+    consumedReason: 'drank',
+    consumedNote: '',
+    consumedRating: '',
+    consumedRatingScale: user?.preferences?.ratingScale || '5'
   });
   const [uploadedImages, setUploadedImages] = useState([]);
 
@@ -178,6 +187,15 @@ function AddBottle() {
         ratingScale: bottleData.ratingScale || '5',
         drinkFrom:   bottleData.drinkFrom   ? `${bottleData.drinkFrom}-01`          : undefined,
         drinkBefore: bottleData.drinkBefore ? monthToLastDay(bottleData.drinkBefore) : undefined,
+        dateAdded: bottleData.dateAdded || undefined,
+        addToHistory: addToHistory || undefined,
+        ...(addToHistory ? {
+          consumedAt: historyData.consumedAt || undefined,
+          consumedReason: historyData.consumedReason,
+          consumedNote: historyData.consumedNote || undefined,
+          consumedRating: historyData.consumedRating ? parseFloat(historyData.consumedRating) : undefined,
+          consumedRatingScale: historyData.consumedRatingScale || '5'
+        } : {})
       };
 
       // Create N individual bottle records
@@ -474,6 +492,16 @@ function AddBottle() {
                   placeholder="https://..."
                 />
               </div>
+
+              <div className="form-group">
+                <label>{t('addBottle.dateAdded')}</label>
+                <input
+                  type="date"
+                  value={bottleData.dateAdded}
+                  onChange={(e) => setBottleData({ ...bottleData, dateAdded: e.target.value })}
+                />
+                <p className="help-text">{t('addBottle.dateAddedHint')}</p>
+              </div>
             </div>
 
             <div className="form-group">
@@ -511,6 +539,67 @@ function AddBottle() {
               </div>
             </div>
 
+            <div className="form-group add-to-history-section">
+              <label className="toggle-label">
+                <input
+                  type="checkbox"
+                  checked={addToHistory}
+                  onChange={(e) => setAddToHistory(e.target.checked)}
+                />
+                <span>{t('addBottle.addToHistory')}</span>
+              </label>
+              <p className="help-text">{t('addBottle.addToHistoryHint')}</p>
+
+              {addToHistory && (
+                <div className="history-fields">
+                  <div className="grid-2">
+                    <div className="form-group">
+                      <label>{t('addBottle.consumedReason')}</label>
+                      <select
+                        value={historyData.consumedReason}
+                        onChange={(e) => setHistoryData({ ...historyData, consumedReason: e.target.value })}
+                      >
+                        <option value="drank">{t('history.reasonDrank')}</option>
+                        <option value="gifted">{t('history.reasonGifted')}</option>
+                        <option value="sold">{t('history.reasonSold')}</option>
+                        <option value="other">{t('history.reasonOther')}</option>
+                      </select>
+                    </div>
+
+                    <div className="form-group">
+                      <label>{t('addBottle.consumedDate')}</label>
+                      <input
+                        type="date"
+                        value={historyData.consumedAt}
+                        onChange={(e) => setHistoryData({ ...historyData, consumedAt: e.target.value })}
+                      />
+                    </div>
+
+                    <div className="form-group">
+                      <label>{t('addBottle.consumedRating')}</label>
+                      <RatingInput
+                        value={historyData.consumedRating}
+                        scale={historyData.consumedRatingScale}
+                        onChange={v => setHistoryData({ ...historyData, consumedRating: v ?? '' })}
+                        onScaleChange={s => setHistoryData({ ...historyData, consumedRatingScale: s, consumedRating: '' })}
+                        allowScaleOverride
+                      />
+                    </div>
+                  </div>
+
+                  <div className="form-group">
+                    <label>{t('addBottle.consumedNote')}</label>
+                    <textarea
+                      value={historyData.consumedNote}
+                      onChange={(e) => setHistoryData({ ...historyData, consumedNote: e.target.value })}
+                      placeholder={t('addBottle.consumedNotePlaceholder')}
+                      rows="3"
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+
             <div className="form-group">
               <label>{t('addBottle.bottlePhotos')}</label>
               <p className="help-text">
@@ -530,7 +619,7 @@ function AddBottle() {
 
             <div className="form-actions">
               <button type="submit" className="btn btn-success">
-                {t('addBottle.addBottleBtn')}
+                {addToHistory ? t('addBottle.addToHistoryBtn') : t('addBottle.addBottleBtn')}
               </button>
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- **Date Added field**: users can set a custom date when adding bottles, so migrated bottles show the original acquisition date instead of today
- **Add to History toggle**: users can create bottles directly as consumed/gifted/sold with date, reason, rating, and notes — no need to add to cellar first and then consume
- Backend validates all new fields (consumed reason, rating) and distinguishes `bottle.addToHistory` in audit logs
- EN + SV translations added for all new UI elements

## Test plan
- [ ] Add a bottle with a past "Date Added" — verify `createdAt` reflects the chosen date
- [ ] Add a bottle with "Add to History" checked — verify it appears in cellar history, not active bottles
- [ ] Verify consumed reason, date, rating, and note are saved correctly
- [ ] Verify the form works normally when neither field is used (no regression)
- [ ] Check Swedish translations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)