### PR TITLE
feat(import): support Cellarion JSON export as import source

### DIFF
--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -3,13 +3,14 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { validateImport, confirmImport } from '../api/bottles';
 import { searchWines } from '../api/wines';
-import { parseAndMap } from '../utils/importMappers';
+import { parseAndMap, parseJSON } from '../utils/importMappers';
 import Modal from '../components/Modal';
 import './ImportBottles.css';
 
 const STEPS = ['upload', 'review', 'importing', 'done'];
 
 const FORMAT_LABELS = {
+  cellarion: 'Cellarion JSON',
   vivino: 'Vivino',
   cellartracker: 'CellarTracker',
   generic: 'CSV'
@@ -77,10 +78,10 @@ function ImportBottles() {
 
     if (!file) return;
 
-    const validExtensions = ['.csv', '.tsv', '.txt'];
+    const validExtensions = ['.csv', '.tsv', '.txt', '.json'];
     const ext = file.name.toLowerCase().slice(file.name.lastIndexOf('.'));
     if (!validExtensions.includes(ext)) {
-      setError('Please upload a CSV, TSV, or TXT file');
+      setError('Please upload a CSV, TSV, TXT, or JSON file');
       return;
     }
 
@@ -89,12 +90,15 @@ function ImportBottles() {
       return;
     }
 
+    const isJson = ext === '.json';
     const reader = new FileReader();
     reader.onload = (e) => {
       try {
-        const { items, format } = parseAndMap(e.target.result);
+        const { items, format } = isJson
+          ? parseJSON(e.target.result)
+          : parseAndMap(e.target.result);
         if (items.length === 0) {
-          setError('No valid rows found in the file. Check that it has headers and data rows.');
+          setError('No valid items found in the file.');
           return;
         }
         setParsedItems(items);
@@ -293,6 +297,10 @@ function ImportBottles() {
         <h3>Supported Formats</h3>
         <div className="format-cards">
           <div className="format-card">
+            <strong>Cellarion JSON</strong>
+            <p>Export from any cellar via &#8943; &rarr; Export Bottles (JSON)</p>
+          </div>
+          <div className="format-card">
             <strong>Vivino</strong>
             <p>Export your collection from Vivino app settings</p>
           </div>
@@ -317,7 +325,7 @@ function ImportBottles() {
         <input
           id="import-file-input"
           type="file"
-          accept=".csv,.tsv,.txt"
+          accept=".csv,.tsv,.txt,.json"
           onChange={handleFileInput}
           style={{ display: 'none' }}
         />
@@ -332,8 +340,8 @@ function ImportBottles() {
         ) : (
           <div className="drop-zone-empty">
             <span className="drop-zone-icon">&#8686;</span>
-            <p>Drop your CSV file here or click to browse</p>
-            <span className="drop-zone-hint">CSV, TSV, or TXT — max 10 MB</span>
+            <p>Drop your file here or click to browse</p>
+            <span className="drop-zone-hint">JSON, CSV, TSV, or TXT — max 10 MB</span>
           </div>
         )}
       </div>

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -291,6 +291,54 @@ function tryParseDate(str) {
 }
 
 /**
+ * Parse a Cellarion JSON export (or plain array) into master import format.
+ *
+ * Accepts:
+ *   - Cellarion export object: { cellarName, exportedAt, bottles: [...] }
+ *   - Plain array of items already in master format
+ *
+ * @param {string} text - Raw JSON text
+ * @returns {{ items: object[], format: string, headers: string[] }}
+ */
+export function parseJSON(text) {
+  const cleaned = text.replace(/^\uFEFF/, '');
+  let parsed;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    throw new Error('Invalid JSON file');
+  }
+
+  const raw = Array.isArray(parsed) ? parsed : (Array.isArray(parsed.bottles) ? parsed.bottles : null);
+  if (!raw) throw new Error('JSON must be an array or a Cellarion export object with a "bottles" array');
+
+  const items = [];
+  for (const row of raw) {
+    if (!row.wineName && !row.producer) continue;
+
+    const item = { ...row };
+
+    // Normalise dates
+    if (item.purchaseDate) item.purchaseDate = tryParseDate(item.purchaseDate);
+    if (item.drinkFrom)    item.drinkFrom    = tryParseDate(item.drinkFrom);
+    if (item.drinkBefore)  item.drinkBefore  = tryParseDate(item.drinkBefore);
+    if (item.consumedAt)   item.consumedAt   = tryParseDate(item.consumedAt);
+    if (item.dateAdded)    item.dateAdded    = tryParseDate(item.dateAdded);
+
+    // Expand quantity (if present)
+    const qty = item.quantity || 1;
+    delete item.quantity;
+
+    for (let q = 0; q < qty; q++) {
+      items.push({ ...item });
+    }
+  }
+
+  const headers = items.length > 0 ? Object.keys(items[0]) : [];
+  return { items, format: 'cellarion', headers };
+}
+
+/**
  * Main entry: parse a file and return mapped items in master format.
  *
  * @param {string} text - Raw CSV/TSV text content


### PR DESCRIPTION
## Summary

- Add `parseJSON()` to `importMappers.js` that handles both the Cellarion export envelope (`{ cellarName, exportedAt, bottles: [...] }`) and plain arrays — no remapping needed since items are already in master format
- Dates are normalised and `quantity` is expanded the same way as CSV imports
- `ImportBottles` now accepts `.json` files, detects them by extension, routes to `parseJSON` instead of `parseAndMap`, and shows **Cellarion JSON** as the detected format label
- Drop zone hint and format cards updated to include the new option

## Test plan

- [ ] Export bottles from a cellar (⋯ → Export Bottles (JSON))
- [ ] Import the exported `.json` file into a different cellar — all bottles should parse and match correctly
- [ ] Verify plain array JSON (e.g. the master format examples from the README) also works
- [ ] Confirm CSV imports (Vivino, CellarTracker, generic) are unaffected