### PR TITLE
feat(rating): expert-aligned scale conversion and preferred-scale display

### DIFF
--- a/backend/src/utils/ratingUtils.js
+++ b/backend/src/utils/ratingUtils.js
@@ -6,10 +6,9 @@
  *  '20'  — Davis 20-Point    (1–20,  step 0.1)  UC Davis / Jancis Robinson / UK wine trade
  *  '100' — Parker 100-Point  (50–100, step 1)   Wine Advocate / Wine Spectator / Decanter
  *
- * Normalization maps every scale to a 0–100 float for cross-scale aggregation:
- *   5-star:  normalized = (value / 5)           * 100
- *   20-pt:   normalized = (value / 20)          * 100
- *   100-pt:  normalized = ((value - 50) / 50)   * 100   (floor = 50)
+ * Conversion uses piecewise-linear interpolation based on wine-expert consensus
+ * anchor points (Wine Advocate descriptors, Jancis Robinson, UC Davis).
+ * All scales map to a shared 0–100 normalized range for aggregation.
  */
 
 const SCALE_META = {
@@ -21,18 +20,54 @@ const SCALE_META = {
 const VALID_SCALES = Object.keys(SCALE_META);
 
 /**
+ * Expert-consensus anchor points mapping quality tiers across scales.
+ * Each row: [5-star, 20-point, Parker 100-point, normalized 0–100].
+ * Between anchors we interpolate linearly so the "interesting" ranges of
+ * each scale align: e.g. Parker 82-100 maps to Stars 3.0-5.0, not 3.6-5.0.
+ */
+const ANCHORS = [
+  // star, davis, parker, normalized
+  [1.0,   8.0,   60,     0],
+  [2.0,  12.0,   75,    25],
+  [3.0,  14.5,   82,    50],
+  [3.5,  16.0,   86,    62.5],
+  [4.0,  17.5,   91,    75],
+  [4.5,  19.0,   96,    87.5],
+  [5.0,  20.0,  100,   100],
+];
+
+// Column indices into ANCHORS
+const COL = { '5': 0, '20': 1, '100': 2, norm: 3 };
+
+/**
+ * Piecewise-linear interpolation: given value in column `fromCol`,
+ * return the corresponding value in column `toCol`.
+ */
+function piecewise(value, fromCol, toCol) {
+  // Clamp below first / above last anchor
+  if (value <= ANCHORS[0][fromCol]) return ANCHORS[0][toCol];
+  if (value >= ANCHORS[ANCHORS.length - 1][fromCol]) return ANCHORS[ANCHORS.length - 1][toCol];
+  for (let i = 0; i < ANCHORS.length - 1; i++) {
+    const lo = ANCHORS[i][fromCol];
+    const hi = ANCHORS[i + 1][fromCol];
+    if (value >= lo && value <= hi) {
+      const t = (value - lo) / (hi - lo);
+      return ANCHORS[i][toCol] + t * (ANCHORS[i + 1][toCol] - ANCHORS[i][toCol]);
+    }
+  }
+  return ANCHORS[0][toCol]; // fallback (shouldn't reach)
+}
+
+/**
  * Convert a raw rating value + scale to a 0–100 normalized score.
  * Returns null if value is null/undefined/invalid.
  */
 function toNormalized(value, scale) {
   if (value == null || isNaN(value)) return null;
   const v = Number(value);
-  switch (scale) {
-    case '5':   return (v / 5)          * 100;
-    case '20':  return (v / 20)         * 100;
-    case '100': return ((v - 50) / 50)  * 100;
-    default:    return (v / 5)          * 100; // treat unknown as 5-star
-  }
+  const col = COL[scale];
+  if (col == null) return piecewise(v, COL['5'], COL.norm); // unknown → 5-star
+  return piecewise(v, col, COL.norm);
 }
 
 /**
@@ -42,15 +77,9 @@ function toNormalized(value, scale) {
 function fromNormalized(normalized, targetScale) {
   if (normalized == null || isNaN(normalized)) return null;
   const n = Number(normalized);
-  let raw;
-  switch (targetScale) {
-    case '5':   raw = (n / 100) * 5;           break;
-    case '20':  raw = (n / 100) * 20;          break;
-    case '100': raw = (n / 100) * 50 + 50;     break;
-    default:    raw = (n / 100) * 5;           break;
-  }
+  const col = COL[targetScale];
+  const raw = col != null ? piecewise(n, COL.norm, col) : piecewise(n, COL.norm, COL['5']);
   const meta = SCALE_META[targetScale] || SCALE_META['5'];
-  // Round to 1 decimal for 5 and 20; whole number for 100
   const precision = meta.step < 1 ? 10 : 1;
   return Math.round(raw * precision) / precision;
 }
@@ -66,20 +95,20 @@ function convertRating(value, fromScale, toScale) {
 }
 
 /**
- * Format a normalized rating delta (difference between two normalized 0-100 scores).
- * Unlike fromNormalized, this does NOT apply the floor offset for the 100-pt scale,
- * since a delta is a difference, not a point on the scale.
+ * Format a normalized rating delta (difference between two normalized 0-100 scores)
+ * in the user's preferred scale.
+ *
+ * Because the piecewise mapping is non-linear, we convert a delta by mapping
+ * two points around the midpoint (50) through the curve and taking their difference.
+ * This gives a representative scale-unit size for the delta.
  */
 function formatDelta(normalizedDelta, scale) {
   if (normalizedDelta == null || isNaN(normalizedDelta)) return '—';
   const n = Number(normalizedDelta);
-  let raw;
-  switch (scale) {
-    case '5':   raw = (n / 100) * 5;   break;
-    case '20':  raw = (n / 100) * 20;  break;
-    case '100': raw = (n / 100) * 50;  break; // no +50 floor offset for deltas
-    default:    raw = (n / 100) * 5;   break;
-  }
+  const mid = 50;
+  const hi = fromNormalized(Math.min(100, mid + Math.abs(n) / 2), scale);
+  const lo = fromNormalized(Math.max(0,   mid - Math.abs(n) / 2), scale);
+  const raw = (hi - lo) * Math.sign(n);
   const meta = SCALE_META[scale] || SCALE_META['5'];
   const precision = meta.step < 1 ? 10 : 1;
   const rounded = Math.round(raw * precision) / precision;

--- a/backend/src/utils/ratingUtils.test.js
+++ b/backend/src/utils/ratingUtils.test.js
@@ -11,15 +11,23 @@ describe('toNormalized', () => {
   test('null → null', () => expect(toNormalized(null, '5')).toBeNull());
   test('undefined → null', () => expect(toNormalized(undefined, '5')).toBeNull());
 
+  // Anchor points (exact)
   test('5-star: 5 → 100', () => expect(toNormalized(5, '5')).toBe(100));
-  test('5-star: 2.5 → 50', () => expect(toNormalized(2.5, '5')).toBe(50));
+  test('5-star: 1 → 0', () => expect(toNormalized(1, '5')).toBe(0));
+  test('5-star: 3 → 50', () => expect(toNormalized(3, '5')).toBe(50));
+  test('5-star: 4 → 75', () => expect(toNormalized(4, '5')).toBe(75));
 
   test('20-pt: 20 → 100', () => expect(toNormalized(20, '20')).toBe(100));
-  test('20-pt: 10 → 50', () => expect(toNormalized(10, '20')).toBe(50));
+  test('20-pt: 8 → 0', () => expect(toNormalized(8, '20')).toBe(0));
+  test('20-pt: 14.5 → 50', () => expect(toNormalized(14.5, '20')).toBe(50));
 
   test('100-pt: 100 → 100', () => expect(toNormalized(100, '100')).toBe(100));
-  test('100-pt: 50 → 0', () => expect(toNormalized(50, '100')).toBe(0));
-  test('100-pt: 75 → 50', () => expect(toNormalized(75, '100')).toBe(50));
+  test('100-pt: 60 → 0', () => expect(toNormalized(60, '100')).toBe(0));
+  test('100-pt: 82 → 50', () => expect(toNormalized(82, '100')).toBe(50));
+  test('100-pt: 91 → 75', () => expect(toNormalized(91, '100')).toBe(75));
+
+  // Below min clamps to 0
+  test('100-pt: 50 clamps to 0', () => expect(toNormalized(50, '100')).toBe(0));
 
   test('unknown scale falls back to 5-star', () => {
     expect(toNormalized(5, 'unknown')).toBe(100);
@@ -30,10 +38,13 @@ describe('toNormalized', () => {
 describe('fromNormalized', () => {
   test('null → null', () => expect(fromNormalized(null, '5')).toBeNull());
 
-  test('100-pt floor: 0 → 50', () => expect(fromNormalized(0, '100')).toBe(50));
+  test('100-pt floor: 0 → 60', () => expect(fromNormalized(0, '100')).toBe(60));
   test('100-pt ceiling: 100 → 100', () => expect(fromNormalized(100, '100')).toBe(100));
+  test('100-pt midpoint: 50 → 82', () => expect(fromNormalized(50, '100')).toBe(82));
   test('5-star: 100 → 5', () => expect(fromNormalized(100, '5')).toBe(5));
-  test('20-pt: 50 → 10', () => expect(fromNormalized(50, '20')).toBe(10));
+  test('5-star: 0 → 1', () => expect(fromNormalized(0, '5')).toBe(1));
+  test('20-pt: 50 → 14.5', () => expect(fromNormalized(50, '20')).toBe(14.5));
+  test('20-pt: 0 → 8', () => expect(fromNormalized(0, '20')).toBe(8));
 });
 
 // ── convertRating ──────────────────────────────────────────────────────────────
@@ -44,16 +55,38 @@ describe('convertRating', () => {
 
   test('null → null', () => expect(convertRating(null, '5', '100')).toBeNull());
 
+  // Expert-aligned conversions
   test('5-star 5 → 100-pt 100', () => {
     expect(convertRating(5, '5', '100')).toBe(100);
   });
 
-  test('5-star 2.5 → 100-pt 75', () => {
-    expect(convertRating(2.5, '5', '100')).toBe(75);
+  test('5-star 4 → 100-pt 91 (outstanding)', () => {
+    expect(convertRating(4, '5', '100')).toBe(91);
   });
 
-  test('100-pt 75 → 5-star 2.5', () => {
-    expect(convertRating(75, '100', '5')).toBe(2.5);
+  test('5-star 3 → 100-pt 82 (good)', () => {
+    expect(convertRating(3, '5', '100')).toBe(82);
+  });
+
+  test('5-star 2 → 100-pt 75 (average)', () => {
+    expect(convertRating(2, '5', '100')).toBe(75);
+  });
+
+  test('100-pt 92 → 5-star 4.1', () => {
+    expect(convertRating(92, '100', '5')).toBe(4.1);
+  });
+
+  test('100-pt 75 → 5-star 2.0', () => {
+    expect(convertRating(75, '100', '5')).toBe(2);
+  });
+
+  // Round-trip: anchor points should survive losslessly
+  test('round-trip 4★ → Parker → ★', () => {
+    expect(convertRating(convertRating(4, '5', '100'), '100', '5')).toBe(4);
+  });
+
+  test('round-trip 17.5/20 → Parker → /20', () => {
+    expect(convertRating(convertRating(17.5, '20', '100'), '100', '20')).toBe(17.5);
   });
 });
 

--- a/frontend/src/components/RatingDisplay.css
+++ b/frontend/src/components/RatingDisplay.css
@@ -43,6 +43,14 @@
   font-variant-numeric: tabular-nums;
 }
 
+.rating-display__preferred {
+  font-weight: 500;
+  font-size: 0.88rem;
+  color: var(--color-accent);
+  margin-left: 2px;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Secondary scale row */
 .rating-display__all-scales {
   display: flex;

--- a/frontend/src/components/RatingDisplay.js
+++ b/frontend/src/components/RatingDisplay.js
@@ -1,18 +1,20 @@
 import React from 'react';
-import { allScales, SCALE_META } from '../utils/ratingUtils';
+import { allScales, convertRating, formatRating, SCALE_META } from '../utils/ratingUtils';
 import './RatingDisplay.css';
 
 /**
  * RatingDisplay — shows a wine rating in all three scales.
  *
- * The original recorded value is shown prominently. All three scale
- * equivalents (Star, Davis 20-Point, Parker 100-Point) are shown inline.
+ * The original recorded value is shown prominently. When a preferredScale
+ * is provided and differs from the stored scale, the converted value in the
+ * user's preferred scale is shown alongside the original so both are visible.
  *
  * Props:
- *   value  {number} — raw rating value as stored
- *   scale  {string} — scale used when stored: '5', '20', or '100'
+ *   value          {number} — raw rating value as stored
+ *   scale          {string} — scale used when stored: '5', '20', or '100'
+ *   preferredScale {string} — viewer's preferred scale (from user preferences)
  */
-export default function RatingDisplay({ value, scale }) {
+export default function RatingDisplay({ value, scale, preferredScale }) {
   if (value == null || isNaN(value)) return <span className="rating-display rating-display--empty">—</span>;
 
   const resolvedScale = SCALE_META[scale] ? scale : '5';
@@ -28,6 +30,13 @@ export default function RatingDisplay({ value, scale }) {
   const starNorm = scales.normalized;
   const starFill = Math.max(0, Math.min(100, starNorm));
 
+  // Determine if we need to show a preferred-scale conversion
+  const prefScale = SCALE_META[preferredScale] ? preferredScale : null;
+  const showPreferred = prefScale && prefScale !== resolvedScale;
+  const preferredFormatted = showPreferred
+    ? formatRating(convertRating(numVal, resolvedScale, prefScale), prefScale)
+    : null;
+
   return (
     <span className="rating-display">
       <span className="rating-display__original" title={`Recorded as ${meta.label}`}>
@@ -38,6 +47,11 @@ export default function RatingDisplay({ value, scale }) {
           </span>
         )}
         <span className="rating-display__value">{originalFormatted}</span>
+        {showPreferred && (
+          <span className="rating-display__preferred" title={`Your scale: ${SCALE_META[prefScale].label}`}>
+            ({preferredFormatted})
+          </span>
+        )}
       </span>
       <span className="rating-display__all-scales">
         {resolvedScale !== '5'   && <span title="Star Rating">{scales.star}</span>}

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -334,7 +334,7 @@ function ViewDetails({ bottle, rackInfo, cellarId, drinkStatus, vintageProfile, 
           <div className="bd-detail-item">
             <span className="bd-detail-label">{t('bottleDetail.ratingLabel')}</span>
             <span className="bd-detail-value">
-              <RatingDisplay value={bottle.rating} scale={bottle.ratingScale || '5'} />
+              <RatingDisplay value={bottle.rating} scale={bottle.ratingScale || '5'} preferredScale={user?.preferences?.ratingScale} />
             </span>
           </div>
         )}

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
+import RatingDisplay from '../components/RatingDisplay';
 import './CellarHistory.css';
 
 const REASON_CONFIG = {
@@ -14,7 +15,7 @@ const REASON_CONFIG = {
 function CellarHistory() {
   const { t } = useTranslation();
   const { id } = useParams();
-  const { apiFetch } = useAuth();
+  const { apiFetch, user } = useAuth();
   const [cellar, setCellar] = useState(null);
   const [grouped, setGrouped] = useState({});
   const [loading, setLoading] = useState(true);
@@ -122,6 +123,7 @@ function CellarHistory() {
 
 function HistoryBottleCard({ bottle }) {
   const { t } = useTranslation();
+  const { user } = useAuth();
   const wine = bottle.wineDefinition;
   const consumedDate = bottle.consumedAt
     ? new Date(bottle.consumedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
@@ -153,7 +155,7 @@ function HistoryBottleCard({ bottle }) {
       <div className="history-bottle-details">
         {bottle.consumedRating && (
           <div className="history-rating">
-            {'⭐'.repeat(bottle.consumedRating)}
+            <RatingDisplay value={bottle.consumedRating} scale={bottle.consumedRatingScale || '5'} preferredScale={user?.preferences?.ratingScale} />
             <span className="rating-label">{t('history.atConsumption')}</span>
           </div>
         )}

--- a/frontend/src/utils/ratingUtils.js
+++ b/frontend/src/utils/ratingUtils.js
@@ -6,7 +6,9 @@
  *  '20'  — Davis 20-Point    (1–20,   step 0.1)  UC Davis / Jancis Robinson / UK wine trade
  *  '100' — Parker 100-Point  (50–100, step 1)    Wine Advocate / Wine Spectator / Decanter
  *
- * Normalization maps every scale to a 0–100 float for cross-scale aggregation.
+ * Conversion uses piecewise-linear interpolation based on wine-expert consensus
+ * anchor points (Wine Advocate descriptors, Jancis Robinson, UC Davis).
+ * All scales map to a shared 0–100 normalized range for aggregation.
  */
 
 export const SCALE_META = {
@@ -18,18 +20,53 @@ export const SCALE_META = {
 export const VALID_SCALES = Object.keys(SCALE_META);
 
 /**
+ * Expert-consensus anchor points mapping quality tiers across scales.
+ * Each row: [5-star, 20-point, Parker 100-point, normalized 0–100].
+ * Between anchors we interpolate linearly so the "interesting" ranges of
+ * each scale align: e.g. Parker 82-100 maps to Stars 3.0-5.0, not 3.6-5.0.
+ */
+const ANCHORS = [
+  // star, davis, parker, normalized
+  [1.0,   8.0,   60,     0],
+  [2.0,  12.0,   75,    25],
+  [3.0,  14.5,   82,    50],
+  [3.5,  16.0,   86,    62.5],
+  [4.0,  17.5,   91,    75],
+  [4.5,  19.0,   96,    87.5],
+  [5.0,  20.0,  100,   100],
+];
+
+// Column indices into ANCHORS
+const COL = { '5': 0, '20': 1, '100': 2, norm: 3 };
+
+/**
+ * Piecewise-linear interpolation: given value in column `fromCol`,
+ * return the corresponding value in column `toCol`.
+ */
+function piecewise(value, fromCol, toCol) {
+  if (value <= ANCHORS[0][fromCol]) return ANCHORS[0][toCol];
+  if (value >= ANCHORS[ANCHORS.length - 1][fromCol]) return ANCHORS[ANCHORS.length - 1][toCol];
+  for (let i = 0; i < ANCHORS.length - 1; i++) {
+    const lo = ANCHORS[i][fromCol];
+    const hi = ANCHORS[i + 1][fromCol];
+    if (value >= lo && value <= hi) {
+      const t = (value - lo) / (hi - lo);
+      return ANCHORS[i][toCol] + t * (ANCHORS[i + 1][toCol] - ANCHORS[i][toCol]);
+    }
+  }
+  return ANCHORS[0][toCol];
+}
+
+/**
  * Convert a raw rating value + scale to a 0–100 normalized score.
  * Returns null if value is null/undefined/invalid.
  */
 export function toNormalized(value, scale) {
   if (value == null || isNaN(value)) return null;
   const v = Number(value);
-  switch (scale) {
-    case '5':   return (v / 5)          * 100;
-    case '20':  return (v / 20)         * 100;
-    case '100': return ((v - 50) / 50)  * 100;
-    default:    return (v / 5)          * 100;
-  }
+  const col = COL[scale];
+  if (col == null) return piecewise(v, COL['5'], COL.norm);
+  return piecewise(v, col, COL.norm);
 }
 
 /**
@@ -39,13 +76,8 @@ export function toNormalized(value, scale) {
 export function fromNormalized(normalized, targetScale) {
   if (normalized == null || isNaN(normalized)) return null;
   const n = Number(normalized);
-  let raw;
-  switch (targetScale) {
-    case '5':   raw = (n / 100) * 5;         break;
-    case '20':  raw = (n / 100) * 20;        break;
-    case '100': raw = (n / 100) * 50 + 50;   break;
-    default:    raw = (n / 100) * 5;         break;
-  }
+  const col = COL[targetScale];
+  const raw = col != null ? piecewise(n, COL.norm, col) : piecewise(n, COL.norm, COL['5']);
   const meta = SCALE_META[targetScale] || SCALE_META['5'];
   const precision = meta.step < 1 ? 10 : 1;
   return Math.round(raw * precision) / precision;
@@ -77,9 +109,6 @@ export function formatRating(value, scale) {
 /**
  * Return a display object with the rating shown in all three scales.
  * Input is the stored raw value + its scale.
- *
- * allScales(4.6, '5')  → { star: '4.6★', davis: '18.4/20', parker: '92pts', normalized: 92 }
- * allScales(92, '100') → { star: '4.6★', davis: '18.4/20', parker: '92pts', normalized: 84 }
  */
 export function allScales(value, scale) {
   if (value == null || isNaN(value)) return null;
@@ -95,24 +124,19 @@ export function allScales(value, scale) {
 }
 
 /**
- * Format a normalized rating delta (difference between two normalized 0-100 scores).
- * Unlike fromNormalized, this does NOT apply the floor offset for the 100-pt scale,
- * since a delta is a difference, not a point on the scale.
+ * Format a normalized rating delta (difference between two normalized 0-100 scores)
+ * in the user's preferred scale.
  *
- *   formatDelta(20, '5')   → "1.0★"   (+1 star delta)
- *   formatDelta(20, '20')  → "4.0/20" (+4 points delta)
- *   formatDelta(20, '100') → "10pts"  (+10 points delta, not 60pts)
+ * Because the piecewise mapping is non-linear, we convert a delta by mapping
+ * two points around the midpoint (50) through the curve and taking their difference.
  */
 export function formatDelta(normalizedDelta, scale) {
   if (normalizedDelta == null || isNaN(normalizedDelta)) return '—';
   const n = Number(normalizedDelta);
-  let raw;
-  switch (scale) {
-    case '5':   raw = (n / 100) * 5;   break;
-    case '20':  raw = (n / 100) * 20;  break;
-    case '100': raw = (n / 100) * 50;  break; // no +50 floor offset for deltas
-    default:    raw = (n / 100) * 5;   break;
-  }
+  const mid = 50;
+  const hi = fromNormalized(Math.min(100, mid + Math.abs(n) / 2), scale);
+  const lo = fromNormalized(Math.max(0,   mid - Math.abs(n) / 2), scale);
+  const raw = (hi - lo) * Math.sign(n);
   const meta = SCALE_META[scale] || SCALE_META['5'];
   const precision = meta.step < 1 ? 10 : 1;
   const rounded = Math.round(raw * precision) / precision;


### PR DESCRIPTION
## Summary
- **Expert wine rating conversion**: Replace naive linear scale mapping with piecewise-linear interpolation using 7 anchor points from wine-expert consensus (Wine Advocate descriptors, Jancis Robinson, UC Davis). Key improvement: 4★ now correctly maps to 91pts Parker (not 90), and 2★ maps to 75pts (not 70), matching how sommeliers actually cross-reference scores.
- **Preferred scale display**: `RatingDisplay` now accepts a `preferredScale` prop — when another user's rating is in a different scale, you see both the original value and your preferred conversion prominently (e.g. `92pts (4.1★)`).
- **CellarHistory bug fix**: Consumed ratings were rendered with `'⭐'.repeat(rating)` which produced 92 emojis for a Parker 100-point rating. Now uses `RatingDisplay` with proper multi-scale support.

## Expert anchor points
| Quality Tier | 5-Star | Davis 20pt | Parker 100pt |
|---|---|---|---|
| Perfect | 5.0 | 20.0 | 100 |
| Extraordinary | 4.5 | 19.0 | 96 |
| Outstanding | 4.0 | 17.5 | 91 |
| Very Good | 3.5 | 16.0 | 86 |
| Good | 3.0 | 14.5 | 82 |
| Average | 2.0 | 12.0 | 75 |
| Poor | 1.0 | 8.0 | 60 |

## Files changed
- `backend/src/utils/ratingUtils.js` — piecewise conversion engine
- `frontend/src/utils/ratingUtils.js` — frontend mirror
- `frontend/src/components/RatingDisplay.js` — new `preferredScale` prop
- `frontend/src/components/RatingDisplay.css` — preferred badge styling
- `frontend/src/pages/BottleDetail.js` — pass user's preferred scale
- `frontend/src/pages/CellarHistory.js` — fix broken emoji rating, use RatingDisplay
- `backend/src/utils/ratingUtils.test.js` — updated for new conversion values (52 tests)

## Test plan
- [x] Backend rating utils: 52 tests pass
- [x] Frontend tests: 50 tests pass
- [ ] Smoke test in Docker: verify bottle detail shows preferred scale conversion
- [ ] Verify CellarHistory displays consumed ratings correctly
- [ ] Verify Statistics page aggregates correctly with new normalization
- [ ] Test changing preferred scale in Settings and confirming display updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)