### PR TITLE
fix(rating): add missing useAuth in ViewDetails

### DIFF
--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -310,6 +310,7 @@ function ContributePrompt({ storageKey, icon, title, message, actionLabel, onAct
 // ── View mode ──
 function ViewDetails({ bottle, rackInfo, cellarId, drinkStatus, vintageProfile, priceHistory, rates, userCurrency, canEdit, hasImage, onEdit, onSuggestGrapes, onRemove, onReportWine }) {
   const { t } = useTranslation();
+  const { user } = useAuth();
   const { plan, hasFeature } = usePlan();
   const hasAgingMaturity = hasFeature('agingMaturity');
   const hasPriceEvolution = hasFeature('priceEvolution');


### PR DESCRIPTION
## Summary
- Fix build error from #85 — `ViewDetails` component used `user` for the `preferredScale` prop but didn't call `useAuth()`. Adds the missing hook call.

## Test plan
- [x] `npm run build` passes
- [x] All tests pass