### PR TITLE
fix(csp): add blob: to img-src so authenticated images display

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,7 +25,7 @@
     <meta name="twitter:description" content="The open-source, self-hosted wine cellar manager. Track bottles, visualise racks, and get drink-window alerts." />
     <meta name="twitter:image" content="%PUBLIC_URL%/cellarion-logo.jpg" />
 
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://open.er-api.com;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' blob: data: https:; connect-src 'self' https://open.er-api.com;" />
 
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />


### PR DESCRIPTION
## Summary
- The CSP meta tag added in the security audit (#88) was missing `blob:` from the `img-src` directive
- `AuthImage` fetches protected uploads via `apiFetch` (with auth headers) and renders them as `blob:` object URLs — the missing directive caused the browser to block these, showing broken image icons
- Adds `blob:` to `img-src` to restore image display while maintaining security

## Test plan
- [ ] Upload a wine photo on the Add Bottle page — verify the processed preview displays correctly
- [ ] Check existing bottle images display on the Bottle Detail page
- [ ] Verify no CSP violations in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)