### PR TITLE
Fix duplicate + prefix in New Cellar/Rack/Request buttons

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -113,7 +113,7 @@
 
   "cellars": {
     "title": "My Cellars",
-    "newCellar": "+ New Cellar",
+    "newCellar": "New Cellar",
     "createTitle": "Create New Cellar",
     "cellarName": "Cellar Name *",
     "cellarNamePlaceholder": "e.g., Main Cellar",
@@ -354,7 +354,7 @@
   "racks": {
     "title": "Storage Racks",
     "backToCellar": "← Back to Cellar",
-    "newRack": "+ New Rack",
+    "newRack": "New Rack",
     "newRackTitle": "New Rack",
     "nameLabel": "Name",
     "namePlaceholder": "e.g. Rack A",
@@ -402,7 +402,7 @@
 
   "wineRequests": {
     "title": "My Wine Requests",
-    "newRequest": "+ New Request",
+    "newRequest": "New Request",
     "requestTitle": "Request a New Wine",
     "wineNameLabel": "Wine Name *",
     "wineNamePlaceholder": "Full wine name",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -113,7 +113,7 @@
 
   "cellars": {
     "title": "Mina källare",
-    "newCellar": "+ Ny källare",
+    "newCellar": "Ny källare",
     "createTitle": "Skapa ny källare",
     "cellarName": "Källarnamn *",
     "cellarNamePlaceholder": "t.ex. Huvudkällaren",
@@ -354,7 +354,7 @@
   "racks": {
     "title": "Förvaringshyllor",
     "backToCellar": "← Tillbaka till källare",
-    "newRack": "+ Ny hylla",
+    "newRack": "Ny hylla",
     "newRackTitle": "Ny hylla",
     "nameLabel": "Namn",
     "namePlaceholder": "t.ex. Hylla A",
@@ -402,7 +402,7 @@
 
   "wineRequests": {
     "title": "Mina vinförfrågningar",
-    "newRequest": "+ Ny förfrågan",
+    "newRequest": "Ny förfrågan",
     "requestTitle": "Begär ett nytt vin",
     "wineNameLabel": "Vinnamn *",
     "wineNamePlaceholder": "Fullt vinnamn",

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -193,7 +193,7 @@ function CellarRacks() {
         </div>
         {canEdit && (
           <button className="btn btn-primary" onClick={() => setShowNewRack(v => !v)}>
-            {showNewRack ? t('common.cancel') : t('racks.newRack')}
+            {showNewRack ? t('common.cancel') : `+ ${t('racks.newRack')}`}
           </button>
         )}
       </div>

--- a/frontend/src/pages/WineRequests.js
+++ b/frontend/src/pages/WineRequests.js
@@ -117,7 +117,7 @@ function WineRequests() {
       <div className="winerequest-header">
         <h1>{t('wineRequests.title')}</h1>
         <button onClick={() => setShowForm(!showForm)} className="btn btn-primary winerequest-desktop-create">
-          {showForm ? t('common.cancel') : t('wineRequests.newRequest')}
+          {showForm ? t('common.cancel') : `+ ${t('wineRequests.newRequest')}`}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
Translation strings had `+` prefixes (e.g. `"+ New Cellar"`) while the JSX also prepended `+`, showing `+ + New Cellar`. Removed prefixes from translations in EN and SV, and ensured the JSX adds `+` consistently.

Affected: New Cellar, New Rack, New Request buttons.

## Test plan
- [ ] Cellars page button shows `+ New Cellar` (not `+ + New Cellar`)
- [ ] Racks page button shows `+ New Rack`
- [ ] Wine Requests page button shows `+ New Request`
- [ ] Switch to Swedish and verify same fix