### PR TITLE
Fix Cellarion CSV export not recognized on re-import

### DIFF
--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -17,7 +17,7 @@ import './ImportBottles.css';
 const STEPS = ['upload', 'review', 'importing', 'done'];
 
 const FORMAT_LABELS = {
-  cellarion: 'Cellarion JSON',
+  cellarion: 'Cellarion',
   vivino: 'Vivino',
   cellartracker: 'CellarTracker',
   generic: 'CSV'

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -104,6 +104,10 @@ export function parseCSV(text, delimiter = ',') {
  */
 export function detectFormat(headers) {
   const h = new Set(headers.map(s => s.toLowerCase().trim()));
+  const raw = new Set(headers.map(s => s.trim()));
+
+  // Cellarion's own CSV export uses camelCase headers
+  if (raw.has('wineName') && raw.has('producer') && raw.has('vintage')) return 'cellarion';
 
   // Vivino export headers
   if (h.has('wine name') || h.has('winery')) return 'vivino';
@@ -278,6 +282,49 @@ function mapGenericRow(row) {
   };
 }
 
+// ── Cellarion CSV Mapper ─────────────────────────────────────────────────────
+
+/**
+ * Map a row from Cellarion's own CSV export.
+ * Headers are already in master format (camelCase), so pass through directly.
+ */
+function mapCellarionRow(row) {
+  const str = (key) => (row[key] || '').trim();
+  const num = (key) => { const n = parseFloat(row[key]); return isNaN(n) ? undefined : n; };
+  const int = (key) => { const n = parseInt(row[key], 10); return isNaN(n) ? undefined : n; };
+
+  return {
+    wineName: str('wineName'),
+    producer: str('producer'),
+    vintage: str('vintage') || 'NV',
+    country: str('country'),
+    region: str('region'),
+    appellation: str('appellation'),
+    type: mapWineType(str('type')),
+    price: num('price'),
+    currency: str('currency') || undefined,
+    bottleSize: str('bottleSize') || '750ml',
+    purchaseDate: str('purchaseDate'),
+    purchaseLocation: str('purchaseLocation'),
+    purchaseUrl: str('purchaseUrl') || undefined,
+    location: str('location'),
+    notes: str('notes'),
+    rating: num('rating'),
+    ratingScale: str('ratingScale') || undefined,
+    drinkFrom: str('drinkFrom') || undefined,
+    drinkBefore: str('drinkBefore') || undefined,
+    rackName: str('rackName') || undefined,
+    rackPosition: int('rackPosition'),
+    dateAdded: str('dateAdded') || undefined,
+    addToHistory: str('addToHistory') || undefined,
+    consumedReason: str('consumedReason') || undefined,
+    consumedAt: str('consumedAt') || undefined,
+    consumedNote: str('consumedNote') || undefined,
+    consumedRating: num('consumedRating'),
+    consumedRatingScale: str('consumedRatingScale') || undefined,
+  };
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function tryParseDate(str) {
@@ -359,11 +406,13 @@ export function parseAndMap(text, forceFormat) {
   const headers = Object.keys(rows[0]);
   const format = forceFormat || detectFormat(headers);
 
-  const mapper = format === 'vivino'
-    ? mapVivinoRow
-    : format === 'cellartracker'
-      ? mapCellarTrackerRow
-      : mapGenericRow;
+  const mapper = format === 'cellarion'
+    ? mapCellarionRow
+    : format === 'vivino'
+      ? mapVivinoRow
+      : format === 'cellartracker'
+        ? mapCellarTrackerRow
+        : mapGenericRow;
 
   // Map rows and expand quantity > 1 into individual items
   const items = [];


### PR DESCRIPTION
## Summary
- Fixes #99
- The CSV export uses camelCase headers (`wineName`, `bottleSize`, etc.) but the import parser detected this as `generic` format, which doesn't recognize those headers — the wine name ended up empty for every row, causing "No Match" on all bottles
- Added Cellarion CSV format detection in `detectFormat()` and a dedicated `mapCellarionRow()` mapper that passes through all camelCase fields correctly

## Test plan
- [ ] Export a cellar to CSV
- [ ] Import the CSV into another cellar
- [ ] Verify bottles are matched (exact or fuzzy) instead of "No Match"
- [ ] Verify Vivino, CellarTracker, and generic CSV imports still work
- [ ] `cd frontend && npm test -- --watchAll=false` passes