### PR TITLE
Add AI-powered drink window and price suggestions for somm queue

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -80,6 +80,62 @@ Rules:
 - Return {"error":"unknown"} ONLY if the query is completely unrecognisable as a real wine
 - Output ONLY the JSON object. No explanations, no extra text before or after`;
 
+const DEFAULT_MATURITY_SUGGEST_PROMPT =
+`You are a master sommelier with deep knowledge of wine aging potential. Given the wine details below, suggest the optimal drinking window phases (early drinking, peak maturity, late maturity) as calendar years.
+
+Wine: {{name}}
+Producer: {{producer}}
+Vintage: {{vintage}}
+Country: {{country}}
+Region: {{region}}
+Appellation: {{appellation}}
+Type: {{type}}
+Grapes: {{grapes}}
+
+Consider:
+- The wine's appellation and classification — grand cru ages differently from village wine
+- The grape varieties and their aging potential
+- The vintage quality and its effect on aging
+- The producer's style (traditional long-aging vs modern early-drinking)
+- Regional norms for aging (e.g. Barolo needs more time than Beaujolais)
+
+Return ONLY a raw JSON object (no markdown, no code fences, no extra text):
+{"earlyFrom":YYYY,"earlyUntil":YYYY,"peakFrom":YYYY,"peakUntil":YYYY,"lateFrom":YYYY,"lateUntil":YYYY,"sommNotes":"brief explanation of your reasoning","confidence":0.0}
+
+Rules:
+- All values are calendar years (e.g. 2028, not "5 years")
+- earlyFrom should be the first year the wine becomes enjoyable
+- Phases must not overlap: earlyUntil < peakFrom, peakUntil < lateFrom
+- For wines meant to drink young (e.g. Beaujolais Nouveau, most rosé, simple whites), set a short window with only early and peak phases, leave late phase null
+- If a phase does not apply, set both its from and until to null
+- sommNotes: 1-2 sentences explaining your reasoning (aging potential, what to expect)
+- confidence: 1.0 = well-known wine with established aging curves, 0.7 = confident from appellation/grape knowledge, 0.4 = rough estimate
+- Never invent aging data — if you truly cannot estimate, return {"error":"unknown"}`;
+
+const DEFAULT_PRICE_SUGGEST_PROMPT =
+`You are a wine market expert with comprehensive knowledge of wine pricing and investment value. Given the wine details below, suggest the current market price.
+
+Wine: {{name}}
+Producer: {{producer}}
+Vintage: {{vintage}}
+Country: {{country}}
+Region: {{region}}
+Appellation: {{appellation}}
+Type: {{type}}
+Grapes: {{grapes}}
+
+Return ONLY a raw JSON object (no markdown, no code fences, no extra text):
+{"price":NUMBER_OR_NULL,"currency":"USD","source":"AI estimate based on market knowledge","reasoning":"brief explanation","confidence":0.0}
+
+Rules:
+- price is the estimated current retail/market value per bottle in USD
+- If this wine has NO meaningful cellar/collectible value (e.g. everyday table wine, bulk-produced wine, wine that does not appreciate with age, or wine you cannot reliably price), set price to null and explain in reasoning
+- For wines that LOSE value over time (past their prime, not age-worthy), set price to null with reasoning like "past optimal drinking window" or "does not appreciate with cellaring"
+- Only provide a price if you are reasonably confident it reflects real market value
+- confidence: 1.0 = well-known traded wine with reliable auction/retail data, 0.7 = confident estimate from similar wines, 0.4 = rough guess
+- Never invent a price — if uncertain, return null for price
+- Return {"error":"unknown"} ONLY if the wine is completely unrecognisable`;
+
 // Models that are known to work reliably for text chat.
 // Any value stored in DB that isn't in this list falls back to the default.
 const VALID_CHAT_MODELS = [
@@ -116,6 +172,10 @@ const defaults = {
   labelScanModel: 'claude-haiku-4-5-20251001',
   importLookupPrompt: DEFAULT_IMPORT_LOOKUP_PROMPT,
   importLookupModel: 'claude-haiku-4-5-20251001',
+  maturitySuggestPrompt: DEFAULT_MATURITY_SUGGEST_PROMPT,
+  maturitySuggestModel: 'claude-haiku-4-5-20251001',
+  priceSuggestPrompt: DEFAULT_PRICE_SUGGEST_PROMPT,
+  priceSuggestModel: 'claude-haiku-4-5-20251001',
 };
 
 let cache = { ...defaults };
@@ -140,6 +200,10 @@ async function load() {
         labelScanModel:        VALID_CHAT_MODELS.includes(doc.value.labelScanModel) ? doc.value.labelScanModel : defaults.labelScanModel,
         importLookupPrompt:    doc.value.importLookupPrompt   ?? defaults.importLookupPrompt,
         importLookupModel:     VALID_CHAT_MODELS.includes(doc.value.importLookupModel) ? doc.value.importLookupModel : defaults.importLookupModel,
+        maturitySuggestPrompt: doc.value.maturitySuggestPrompt ?? defaults.maturitySuggestPrompt,
+        maturitySuggestModel:  VALID_CHAT_MODELS.includes(doc.value.maturitySuggestModel) ? doc.value.maturitySuggestModel : defaults.maturitySuggestModel,
+        priceSuggestPrompt:    doc.value.priceSuggestPrompt   ?? defaults.priceSuggestPrompt,
+        priceSuggestModel:     VALID_CHAT_MODELS.includes(doc.value.priceSuggestModel) ? doc.value.priceSuggestModel : defaults.priceSuggestModel,
       };
     }
   } catch (err) {
@@ -155,4 +219,4 @@ function set(value) {
   cache = { ...defaults, ...value };
 }
 
-module.exports = { load, get, set, defaults, DEFAULT_SYSTEM_PROMPT, DEFAULT_LABEL_SCAN_PROMPT, DEFAULT_IMPORT_LOOKUP_PROMPT, DEFAULT_TEXT_SEARCH_PROMPT, VALID_CHAT_MODELS };
+module.exports = { load, get, set, defaults, DEFAULT_SYSTEM_PROMPT, DEFAULT_LABEL_SCAN_PROMPT, DEFAULT_IMPORT_LOOKUP_PROMPT, DEFAULT_TEXT_SEARCH_PROMPT, DEFAULT_MATURITY_SUGGEST_PROMPT, DEFAULT_PRICE_SUGGEST_PROMPT, VALID_CHAT_MODELS };

--- a/backend/src/routes/somm/maturity.js
+++ b/backend/src/routes/somm/maturity.js
@@ -2,6 +2,8 @@ const express = require('express');
 const { requireAuth, requireSommOrAdmin } = require('../../middleware/auth');
 const WineVintageProfile = require('../../models/WineVintageProfile');
 
+const { suggestDrinkWindow } = require('../../services/labelScan');
+
 const router = express.Router();
 
 // All routes require authentication
@@ -145,6 +147,53 @@ router.put('/:id', requireSommOrAdmin, async (req, res) => {
   } catch (error) {
     console.error('Update maturity profile error:', error);
     res.status(500).json({ error: 'Failed to update profile' });
+  }
+});
+
+/**
+ * POST /api/somm/maturity/:id/ai-suggest
+ * Ask AI to suggest drink window phases for this wine+vintage. Somm/admin only.
+ * Returns suggested values for the form (not saved until the user confirms).
+ */
+router.post('/:id/ai-suggest', requireSommOrAdmin, async (req, res) => {
+  try {
+    const profile = await WineVintageProfile.findById(req.params.id)
+      .populate({
+        path: 'wineDefinition',
+        select: 'name producer type country region appellation grapes',
+        populate: [
+          { path: 'country', select: 'name' },
+          { path: 'region', select: 'name' },
+          { path: 'grapes', select: 'name' }
+        ]
+      });
+    if (!profile) {
+      return res.status(404).json({ error: 'Profile not found' });
+    }
+
+    const wine = profile.wineDefinition;
+    const result = await suggestDrinkWindow({
+      name: wine?.name,
+      producer: wine?.producer,
+      vintage: profile.vintage,
+      country: wine?.country?.name,
+      region: wine?.region?.name,
+      appellation: wine?.appellation,
+      type: wine?.type,
+      grapes: wine?.grapes?.map(g => g.name)
+    });
+
+    if (!result.data) {
+      return res.status(422).json({
+        error: 'AI could not suggest a drink window for this wine',
+        reason: result.debugReason
+      });
+    }
+
+    res.json({ suggestion: result.data });
+  } catch (error) {
+    console.error('AI maturity suggest error:', error);
+    res.status(500).json({ error: 'Failed to get AI suggestion' });
   }
 });
 

--- a/backend/src/routes/somm/prices.js
+++ b/backend/src/routes/somm/prices.js
@@ -5,6 +5,8 @@ const Bottle = require('../../models/Bottle');
 const WineDefinition = require('../../models/WineDefinition');
 const { getOrCreateDailySnapshot, getSnapshotsForDates } = require('../../utils/exchangeRates');
 
+const { suggestPrice } = require('../../services/labelScan');
+
 const router = express.Router();
 
 router.use(requireAuth);
@@ -146,6 +148,53 @@ router.get('/lookup', async (req, res) => {
   } catch (error) {
     console.error('Price lookup error:', error);
     res.status(500).json({ error: 'Failed to load price history' });
+  }
+});
+
+/**
+ * POST /api/somm/prices/ai-suggest
+ * Ask AI to suggest a market price for a wine+vintage. Somm/admin only.
+ * Body: { wineDefinition, vintage }
+ * Returns suggested values for the form (not saved until the user confirms).
+ */
+router.post('/ai-suggest', requireSommOrAdmin, async (req, res) => {
+  try {
+    const { wineDefinition: wineId, vintage } = req.body;
+    if (!wineId || !vintage) {
+      return res.status(400).json({ error: 'wineDefinition and vintage are required' });
+    }
+
+    const wine = await WineDefinition.findById(wineId)
+      .populate('country', 'name')
+      .populate('region', 'name')
+      .populate('grapes', 'name');
+
+    if (!wine) {
+      return res.status(404).json({ error: 'Wine definition not found' });
+    }
+
+    const result = await suggestPrice({
+      name: wine.name,
+      producer: wine.producer,
+      vintage,
+      country: wine.country?.name,
+      region: wine.region?.name,
+      appellation: wine.appellation,
+      type: wine.type,
+      grapes: wine.grapes?.map(g => g.name)
+    });
+
+    if (!result.data) {
+      return res.status(422).json({
+        error: 'AI could not suggest a price for this wine',
+        reason: result.debugReason
+      });
+    }
+
+    res.json({ suggestion: result.data });
+  } catch (error) {
+    console.error('AI price suggest error:', error);
+    res.status(500).json({ error: 'Failed to get AI suggestion' });
   }
 });
 

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -541,6 +541,98 @@ router.patch('/ai/label-scan-model', async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// PATCH /api/superadmin/ai/maturity-suggest-prompt
+// ---------------------------------------------------------------------------
+router.patch('/ai/maturity-suggest-prompt', async (req, res) => {
+  const { prompt } = req.body;
+  if (typeof prompt !== 'string' || !prompt.trim()) {
+    return res.status(400).json({ error: 'prompt must be a non-empty string' });
+  }
+  if (prompt.length > SCAN_PROMPT_MAX_LENGTH) {
+    return res.status(400).json({ error: `prompt must be ${SCAN_PROMPT_MAX_LENGTH} characters or fewer` });
+  }
+  try {
+    const current = aiConfig.get();
+    const updated = { ...current, maturitySuggestPrompt: prompt.trim() };
+    await updateSiteConfig('aiConfig', updated, req.user.id);
+    aiConfig.set(updated);
+    res.json({ maturitySuggestPrompt: updated.maturitySuggestPrompt });
+  } catch (error) {
+    console.error('[superadmin] maturity-suggest-prompt error:', error);
+    res.status(500).json({ error: 'Failed to save maturity suggest prompt' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/superadmin/ai/maturity-suggest-model
+// ---------------------------------------------------------------------------
+router.patch('/ai/maturity-suggest-model', async (req, res) => {
+  const { model } = req.body;
+  const { VALID_CHAT_MODELS } = aiConfig;
+
+  if (!model || !VALID_CHAT_MODELS.includes(model)) {
+    return res.status(400).json({ error: `model must be one of: ${VALID_CHAT_MODELS.join(', ')}` });
+  }
+
+  try {
+    const current = aiConfig.get();
+    const updated = { ...current, maturitySuggestModel: model };
+    await updateSiteConfig('aiConfig', updated, req.user.id);
+    aiConfig.set(updated);
+    res.json({ maturitySuggestModel: model });
+  } catch (error) {
+    console.error('[superadmin] maturity-suggest-model error:', error);
+    res.status(500).json({ error: 'Failed to save maturity suggest model' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/superadmin/ai/price-suggest-prompt
+// ---------------------------------------------------------------------------
+router.patch('/ai/price-suggest-prompt', async (req, res) => {
+  const { prompt } = req.body;
+  if (typeof prompt !== 'string' || !prompt.trim()) {
+    return res.status(400).json({ error: 'prompt must be a non-empty string' });
+  }
+  if (prompt.length > SCAN_PROMPT_MAX_LENGTH) {
+    return res.status(400).json({ error: `prompt must be ${SCAN_PROMPT_MAX_LENGTH} characters or fewer` });
+  }
+  try {
+    const current = aiConfig.get();
+    const updated = { ...current, priceSuggestPrompt: prompt.trim() };
+    await updateSiteConfig('aiConfig', updated, req.user.id);
+    aiConfig.set(updated);
+    res.json({ priceSuggestPrompt: updated.priceSuggestPrompt });
+  } catch (error) {
+    console.error('[superadmin] price-suggest-prompt error:', error);
+    res.status(500).json({ error: 'Failed to save price suggest prompt' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/superadmin/ai/price-suggest-model
+// ---------------------------------------------------------------------------
+router.patch('/ai/price-suggest-model', async (req, res) => {
+  const { model } = req.body;
+  const { VALID_CHAT_MODELS } = aiConfig;
+
+  if (!model || !VALID_CHAT_MODELS.includes(model)) {
+    return res.status(400).json({ error: `model must be one of: ${VALID_CHAT_MODELS.join(', ')}` });
+  }
+
+  try {
+    const current = aiConfig.get();
+    const updated = { ...current, priceSuggestModel: model };
+    await updateSiteConfig('aiConfig', updated, req.user.id);
+    aiConfig.set(updated);
+    res.json({ priceSuggestModel: model });
+  } catch (error) {
+    console.error('[superadmin] price-suggest-model error:', error);
+    res.status(500).json({ error: 'Failed to save price suggest model' });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // PATCH /api/superadmin/ai/chat-model
 // ---------------------------------------------------------------------------
 router.patch('/ai/chat-model', async (req, res) => {

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -259,4 +259,108 @@ async function identifyWineFromQuery(query) {
   }
 }
 
-module.exports = { scanLabel, scanLabelFull, identifyWineFromText, identifyWineFromQuery };
+/**
+ * Suggest drink window / maturity phases for a wine+vintage using AI.
+ * Returns { data, debugRaw, debugReason } — same shape as identifyWineFromText.
+ *   data — { earlyFrom, earlyUntil, peakFrom, peakUntil, lateFrom, lateUntil, sommNotes, confidence }
+ */
+async function suggestDrinkWindow({ name, producer, vintage, country, region, appellation, type, grapes }) {
+  if (!name || !vintage) return { data: null, debugRaw: null, debugReason: 'missing_fields' };
+
+  let client;
+  try { client = getClient(); } catch { return { data: null, debugRaw: null, debugReason: 'no_api_key' }; }
+
+  const prompt = aiConfig.get().maturitySuggestPrompt
+    .replace('{{name}}', name || '')
+    .replace('{{producer}}', producer || '')
+    .replace('{{vintage}}', vintage || '')
+    .replace('{{country}}', country || '')
+    .replace('{{region}}', region || '')
+    .replace('{{appellation}}', appellation || '')
+    .replace('{{type}}', type || '')
+    .replace('{{grapes}}', Array.isArray(grapes) ? grapes.join(', ') : (grapes || ''));
+
+  const apiParams = {
+    model: aiConfig.get().maturitySuggestModel,
+    max_tokens: 500,
+    messages: [
+      { role: 'user', content: prompt },
+      { role: 'assistant', content: '{' }
+    ]
+  };
+
+  let raw = '';
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      const response = await client.messages.create(apiParams);
+      raw = ('{' + (response.content[0]?.text ?? '')).trim();
+      const stripped = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+      const parsed = JSON.parse(extractFirstJsonObject(stripped));
+
+      if (parsed.error) return { data: null, debugRaw: raw, debugReason: `ai_unknown: ${parsed.error}` };
+      return { data: parsed, debugRaw: raw, debugReason: null };
+    } catch (err) {
+      if (err.status === 429 && attempt === 1) {
+        const waitMs = (parseInt(err.headers?.['retry-after'] ?? '15', 10) + 1) * 1000;
+        await new Promise(r => setTimeout(r, waitMs));
+        continue;
+      }
+      const reason = err.status === 429 ? 'rate_limit_exceeded' : `exception: ${err.message}`;
+      return { data: null, debugRaw: raw || err.message, debugReason: reason };
+    }
+  }
+}
+
+/**
+ * Suggest market price for a wine+vintage using AI.
+ * Returns { data, debugRaw, debugReason }.
+ *   data — { price (number|null), currency, source, reasoning, confidence }
+ */
+async function suggestPrice({ name, producer, vintage, country, region, appellation, type, grapes }) {
+  if (!name || !vintage) return { data: null, debugRaw: null, debugReason: 'missing_fields' };
+
+  let client;
+  try { client = getClient(); } catch { return { data: null, debugRaw: null, debugReason: 'no_api_key' }; }
+
+  const prompt = aiConfig.get().priceSuggestPrompt
+    .replace('{{name}}', name || '')
+    .replace('{{producer}}', producer || '')
+    .replace('{{vintage}}', vintage || '')
+    .replace('{{country}}', country || '')
+    .replace('{{region}}', region || '')
+    .replace('{{appellation}}', appellation || '')
+    .replace('{{type}}', type || '')
+    .replace('{{grapes}}', Array.isArray(grapes) ? grapes.join(', ') : (grapes || ''));
+
+  const apiParams = {
+    model: aiConfig.get().priceSuggestModel,
+    max_tokens: 400,
+    messages: [
+      { role: 'user', content: prompt },
+      { role: 'assistant', content: '{' }
+    ]
+  };
+
+  let raw = '';
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      const response = await client.messages.create(apiParams);
+      raw = ('{' + (response.content[0]?.text ?? '')).trim();
+      const stripped = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+      const parsed = JSON.parse(extractFirstJsonObject(stripped));
+
+      if (parsed.error) return { data: null, debugRaw: raw, debugReason: `ai_unknown: ${parsed.error}` };
+      return { data: parsed, debugRaw: raw, debugReason: null };
+    } catch (err) {
+      if (err.status === 429 && attempt === 1) {
+        const waitMs = (parseInt(err.headers?.['retry-after'] ?? '15', 10) + 1) * 1000;
+        await new Promise(r => setTimeout(r, waitMs));
+        continue;
+      }
+      const reason = err.status === 429 ? 'rate_limit_exceeded' : `exception: ${err.message}`;
+      return { data: null, debugRaw: raw || err.message, debugReason: reason };
+    }
+  }
+}
+
+module.exports = { scanLabel, scanLabelFull, identifyWineFromText, identifyWineFromQuery, suggestDrinkWindow, suggestPrice };

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -721,7 +721,11 @@
       "statusPending": "Pending",
       "statusReviewed": "Reviewed",
       "statusToday": "Status today ({{year}}):",
-      "vintageLabel": "Vintage:"
+      "vintageLabel": "Vintage:",
+      "aiSuggest": "Ask AI",
+      "aiSuggesting": "Asking AI…",
+      "aiSuggestError": "AI could not suggest a drink window",
+      "aiSuggestFilled": "AI suggestion applied — review and save"
     },
     "prices": {
       "title": "Price Queue",
@@ -742,7 +746,13 @@
       "sourceOptional": "(optional)",
       "sourcePlaceholder": "Vivino, Wine-Searcher…",
       "savePrice": "Save price",
-      "priceRequired": "Price is required"
+      "priceRequired": "Price is required",
+      "aiSuggest": "Ask AI",
+      "aiSuggesting": "Asking AI…",
+      "aiSuggestError": "AI could not suggest a price",
+      "aiSuggestFilled": "AI suggestion applied — review and save",
+      "aiNoValue": "AI suggests this wine has no significant market value",
+      "aiReasoning": "AI reasoning:"
     }
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -721,7 +721,11 @@
       "statusPending": "Väntande",
       "statusReviewed": "Granskad",
       "statusToday": "Status idag ({{year}}):",
-      "vintageLabel": "Årgång:"
+      "vintageLabel": "Årgång:",
+      "aiSuggest": "Fråga AI",
+      "aiSuggesting": "Frågar AI…",
+      "aiSuggestError": "AI kunde inte föreslå ett drickfönster",
+      "aiSuggestFilled": "AI-förslag tillämpat — granska och spara"
     },
     "prices": {
       "title": "Priskö",
@@ -742,7 +746,13 @@
       "sourceOptional": "(valfritt)",
       "sourcePlaceholder": "Vivino, Wine-Searcher…",
       "savePrice": "Spara pris",
-      "priceRequired": "Pris krävs"
+      "priceRequired": "Pris krävs",
+      "aiSuggest": "Fråga AI",
+      "aiSuggesting": "Frågar AI…",
+      "aiSuggestError": "AI kunde inte föreslå ett pris",
+      "aiSuggestFilled": "AI-förslag tillämpat — granska och spara",
+      "aiNoValue": "AI bedömer att detta vin inte har något betydande marknadsvärde",
+      "aiReasoning": "AI-resonemang:"
     }
   }
 }

--- a/frontend/src/pages/SommMaturity.css
+++ b/frontend/src/pages/SommMaturity.css
@@ -175,8 +175,16 @@
 .somm-form-hint {
   font-size: 0.85rem;
   color: var(--color-text-muted);
-  margin: 0 0 1rem 0;
+  margin: 0;
   line-height: 1.5;
+}
+
+.somm-form-hint-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
 }
 
 .somm-year-hint {
@@ -319,6 +327,63 @@
   gap: 0.75rem;
   flex-wrap: wrap;
   margin-top: 1rem;
+}
+
+/* ── AI suggestion ── */
+.btn-ai {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.9rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.btn-ai:hover {
+  opacity: 0.88;
+}
+
+.btn-ai:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.somm-ai-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.somm-ai-msg {
+  font-size: 0.82rem;
+  padding: 0.4rem 0.7rem;
+  border-radius: var(--radius-sm);
+  line-height: 1.4;
+}
+
+.somm-ai-msg--ok {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+  border: 1px solid var(--color-success-border);
+}
+
+.somm-ai-msg--err {
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger-border);
+}
+
+.somm-ai-reasoning {
+  margin-top: 0.3rem;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  font-style: italic;
 }
 
 /* ── Mobile ── */

--- a/frontend/src/pages/SommMaturity.js
+++ b/frontend/src/pages/SommMaturity.js
@@ -118,6 +118,8 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
   const [expanded,  setExpanded]  = useState(isPending);
   const [saving,    setSaving]    = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiMsg,     setAiMsg]     = useState(null);
   const [err,       setErr]       = useState(null);
 
   const [form, setForm] = useState({
@@ -174,6 +176,39 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
     }
   };
 
+  const handleAiSuggest = async () => {
+    setAiLoading(true);
+    setAiMsg(null);
+    setErr(null);
+    try {
+      const res = await apiFetch(`/api/somm/maturity/${profile._id}/ai-suggest`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+      const data = await res.json();
+      if (res.ok && data.suggestion) {
+        const s = data.suggestion;
+        setForm(f => ({
+          ...f,
+          earlyFrom:  s.earlyFrom  ?? f.earlyFrom,
+          earlyUntil: s.earlyUntil ?? f.earlyUntil,
+          peakFrom:   s.peakFrom   ?? f.peakFrom,
+          peakUntil:  s.peakUntil  ?? f.peakUntil,
+          lateFrom:   s.lateFrom   ?? f.lateFrom,
+          lateUntil:  s.lateUntil  ?? f.lateUntil,
+          sommNotes:  s.sommNotes  || f.sommNotes
+        }));
+        setAiMsg({ ok: true, text: t('somm.maturity.aiSuggestFilled') });
+      } else {
+        setAiMsg({ ok: false, text: data.error || t('somm.maturity.aiSuggestError') });
+      }
+    } catch {
+      setAiMsg({ ok: false, text: t('somm.maturity.aiSuggestError') });
+    } finally {
+      setAiLoading(false);
+    }
+  };
+
   const phase = getMaturityPhase(profile);
 
   return (
@@ -213,10 +248,25 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
         <form className="somm-form" onSubmit={handleSave}>
           {err && <div className="alert alert-error">{err}</div>}
 
-          <p className="somm-form-hint">
-            {t('somm.maturity.phaseHint')}
-            {!isNaN(vintageInt) && ` (${t('somm.maturity.vintageLabel')} ${vintageInt})`}
-          </p>
+          <div className="somm-form-hint-row">
+            <p className="somm-form-hint">
+              {t('somm.maturity.phaseHint')}
+              {!isNaN(vintageInt) && ` (${t('somm.maturity.vintageLabel')} ${vintageInt})`}
+            </p>
+            <button
+              type="button"
+              className="btn btn-ai"
+              onClick={handleAiSuggest}
+              disabled={aiLoading}
+            >
+              {aiLoading ? t('somm.maturity.aiSuggesting') : t('somm.maturity.aiSuggest')}
+            </button>
+          </div>
+          {aiMsg && (
+            <div className={`somm-ai-msg ${aiMsg.ok ? 'somm-ai-msg--ok' : 'somm-ai-msg--err'}`}>
+              {aiMsg.text}
+            </div>
+          )}
 
           {/* ── Phase rows ── */}
           <div className="somm-phases">

--- a/frontend/src/pages/SommPrices.js
+++ b/frontend/src/pages/SommPrices.js
@@ -98,9 +98,11 @@ function PriceCard({ item, defaultCurrency, userCurrency, rates, onSaved }) {
   const wine  = item.wineDefinition;
   const isNew = !item.latestPrice;
 
-  const [expanded, setExpanded] = useState(isNew); // auto-expand no-history cards
-  const [saving,   setSaving]   = useState(false);
-  const [err,      setErr]      = useState(null);
+  const [expanded,  setExpanded]  = useState(isNew); // auto-expand no-history cards
+  const [saving,    setSaving]    = useState(false);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiMsg,     setAiMsg]     = useState(null);
+  const [err,       setErr]       = useState(null);
 
   const [form, setForm] = useState({
     price:    '',
@@ -109,6 +111,43 @@ function PriceCard({ item, defaultCurrency, userCurrency, rates, onSaved }) {
   });
 
   const set = (field) => (e) => setForm(f => ({ ...f, [field]: e.target.value }));
+
+  const handleAiSuggest = async () => {
+    setAiLoading(true);
+    setAiMsg(null);
+    setErr(null);
+    try {
+      const res = await apiFetch('/api/somm/prices/ai-suggest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          wineDefinition: wine?._id,
+          vintage: item.vintage
+        })
+      });
+      const data = await res.json();
+      if (res.ok && data.suggestion) {
+        const s = data.suggestion;
+        if (s.price != null) {
+          setForm(f => ({
+            ...f,
+            price:    String(s.price),
+            currency: s.currency || f.currency,
+            source:   s.source   || f.source
+          }));
+          setAiMsg({ ok: true, text: t('somm.prices.aiSuggestFilled'), reasoning: s.reasoning });
+        } else {
+          setAiMsg({ ok: false, text: t('somm.prices.aiNoValue'), reasoning: s.reasoning });
+        }
+      } else {
+        setAiMsg({ ok: false, text: data.error || t('somm.prices.aiSuggestError') });
+      }
+    } catch {
+      setAiMsg({ ok: false, text: t('somm.prices.aiSuggestError') });
+    } finally {
+      setAiLoading(false);
+    }
+  };
 
   const handleSave = async (e) => {
     e.preventDefault();
@@ -180,6 +219,27 @@ function PriceCard({ item, defaultCurrency, userCurrency, rates, onSaved }) {
       {expanded && (
         <form className="somm-form" onSubmit={handleSave}>
           {err && <div className="alert alert-error">{err}</div>}
+
+          <div className="somm-ai-row">
+            <button
+              type="button"
+              className="btn btn-ai"
+              onClick={handleAiSuggest}
+              disabled={aiLoading}
+            >
+              {aiLoading ? t('somm.prices.aiSuggesting') : t('somm.prices.aiSuggest')}
+            </button>
+            {aiMsg && (
+              <div className={`somm-ai-msg ${aiMsg.ok ? 'somm-ai-msg--ok' : 'somm-ai-msg--err'}`}>
+                {aiMsg.text}
+                {aiMsg.reasoning && (
+                  <div className="somm-ai-reasoning">
+                    {t('somm.prices.aiReasoning')} {aiMsg.reasoning}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
 
           {item.latestPrice && (() => {
             const prev = item.latestPrice;

--- a/frontend/src/pages/SuperAdmin/TabAI.js
+++ b/frontend/src/pages/SuperAdmin/TabAI.js
@@ -495,6 +495,288 @@ function ImportLookupPromptPanel({ prompt, apiFetch }) {
   );
 }
 
+function MaturitySuggestModelPanel({ currentModel, apiFetch }) {
+  const [selected, setSelected] = useState(currentModel || 'claude-haiku-4-5-20251001');
+  const [saving, setSaving]     = useState(false);
+  const [msg, setMsg]           = useState(null);
+
+  const isDirty = selected !== currentModel;
+
+  const save = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      const res = await apiFetch('/api/superadmin/ai/maturity-suggest-model', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: selected }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setMsg({ ok: false, text: d.error || 'Save failed' });
+      } else {
+        setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+      }
+    } catch {
+      setMsg({ ok: false, text: 'Network error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const tierColor = { economy: 'var(--sa-accent)', standard: 'var(--sa-accent2)', premium: '#c9a84c' };
+
+  return (
+    <div className="sa-panel" style={{ marginTop: 16 }}>
+      <div className="sa-panel-header">
+        <span className="sa-panel-title">Maturity Suggest — AI Model</span>
+        <button className="sa-btn" onClick={save} disabled={saving || !isDirty}>
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+      <div className="sa-panel-body">
+        <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 12 }}>
+          Model used when sommeliers click "Ask AI" on the maturity queue to suggest drink window phases.
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {CHAT_MODELS.map(m => (
+            <label
+              key={m.id}
+              style={{
+                display: 'flex', alignItems: 'flex-start', gap: 10,
+                padding: '8px 12px', borderRadius: 4,
+                border: `1px solid ${selected === m.id ? 'var(--sa-accent)' : 'var(--sa-border)'}`,
+                background: selected === m.id ? 'rgba(123,158,136,0.06)' : 'transparent',
+                cursor: 'pointer',
+              }}
+            >
+              <input
+                type="radio"
+                name="maturitySuggestModel"
+                value={m.id}
+                checked={selected === m.id}
+                onChange={() => setSelected(m.id)}
+                style={{ marginTop: 2, accentColor: 'var(--sa-accent)', flexShrink: 0 }}
+              />
+              <div style={{ flex: 1 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+                  <span style={{ fontWeight: 600, fontSize: 12, color: 'var(--sa-text)' }}>{m.name}</span>
+                  <span style={{ fontSize: 10, color: tierColor[m.tier], border: `1px solid ${tierColor[m.tier]}`, borderRadius: 3, padding: '1px 5px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                    {m.tier}
+                  </span>
+                  {m.id === currentModel && <span style={{ fontSize: 10, color: 'var(--sa-accent)', marginLeft: 'auto' }}>● active</span>}
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 2 }}>{m.description}</div>
+                <div style={{ fontSize: 10, color: 'var(--sa-text-dim)', fontFamily: 'monospace' }}>
+                  Input: {m.inputPrice} / M &nbsp;·&nbsp; Output: {m.outputPrice} / M tokens
+                </div>
+              </div>
+            </label>
+          ))}
+        </div>
+        {msg && (
+          <div style={{ marginTop: 12, fontSize: 11, color: msg.ok ? 'var(--sa-accent)' : 'var(--sa-danger)' }}>{msg.text}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MaturitySuggestPromptPanel({ prompt, apiFetch }) {
+  const [val, setVal] = useState(prompt || '');
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState(null);
+
+  const save = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      const res = await apiFetch('/api/superadmin/ai/maturity-suggest-prompt', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: val }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setMsg({ ok: false, text: d.error || 'Save failed' });
+      } else {
+        setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+      }
+    } catch {
+      setMsg({ ok: false, text: 'Network error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="sa-panel" style={{ marginTop: 16 }}>
+      <div className="sa-panel-header">
+        <span className="sa-panel-title">Maturity Suggest — AI Prompt</span>
+        <button className="sa-btn" onClick={save} disabled={saving || !val.trim()}>{saving ? 'Saving...' : 'Save'}</button>
+      </div>
+      <div className="sa-panel-body">
+        <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 8 }}>
+          Prompt sent to Claude when a sommelier asks AI to suggest drink window phases. Use <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{name}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{producer}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{vintage}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{country}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{region}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{appellation}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{type}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{grapes}}'}</code> placeholders.
+        </div>
+        <textarea
+          value={val}
+          onChange={e => setVal(e.target.value)}
+          rows={14}
+          style={{ width: '100%', background: 'var(--sa-bg)', border: '1px solid var(--sa-border)', color: 'var(--sa-text)', padding: '8px', borderRadius: 3, fontFamily: 'monospace', fontSize: 12, lineHeight: 1.5, resize: 'vertical', boxSizing: 'border-box' }}
+        />
+        <div style={{ marginTop: 6, display: 'flex', gap: 8, alignItems: 'center' }}>
+          <span style={{ fontSize: 11, color: 'var(--sa-text-dim)' }}>{val.length} / 6000 chars</span>
+          {msg && (
+            <span style={{ fontSize: 11, color: msg.ok ? 'var(--sa-accent)' : 'var(--sa-danger)' }}>{msg.text}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PriceSuggestModelPanel({ currentModel, apiFetch }) {
+  const [selected, setSelected] = useState(currentModel || 'claude-haiku-4-5-20251001');
+  const [saving, setSaving]     = useState(false);
+  const [msg, setMsg]           = useState(null);
+
+  const isDirty = selected !== currentModel;
+
+  const save = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      const res = await apiFetch('/api/superadmin/ai/price-suggest-model', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: selected }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setMsg({ ok: false, text: d.error || 'Save failed' });
+      } else {
+        setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+      }
+    } catch {
+      setMsg({ ok: false, text: 'Network error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const tierColor = { economy: 'var(--sa-accent)', standard: 'var(--sa-accent2)', premium: '#c9a84c' };
+
+  return (
+    <div className="sa-panel" style={{ marginTop: 16 }}>
+      <div className="sa-panel-header">
+        <span className="sa-panel-title">Price Suggest — AI Model</span>
+        <button className="sa-btn" onClick={save} disabled={saving || !isDirty}>
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+      <div className="sa-panel-body">
+        <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 12 }}>
+          Model used when sommeliers click "Ask AI" on the price queue to suggest market prices.
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {CHAT_MODELS.map(m => (
+            <label
+              key={m.id}
+              style={{
+                display: 'flex', alignItems: 'flex-start', gap: 10,
+                padding: '8px 12px', borderRadius: 4,
+                border: `1px solid ${selected === m.id ? 'var(--sa-accent)' : 'var(--sa-border)'}`,
+                background: selected === m.id ? 'rgba(123,158,136,0.06)' : 'transparent',
+                cursor: 'pointer',
+              }}
+            >
+              <input
+                type="radio"
+                name="priceSuggestModel"
+                value={m.id}
+                checked={selected === m.id}
+                onChange={() => setSelected(m.id)}
+                style={{ marginTop: 2, accentColor: 'var(--sa-accent)', flexShrink: 0 }}
+              />
+              <div style={{ flex: 1 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+                  <span style={{ fontWeight: 600, fontSize: 12, color: 'var(--sa-text)' }}>{m.name}</span>
+                  <span style={{ fontSize: 10, color: tierColor[m.tier], border: `1px solid ${tierColor[m.tier]}`, borderRadius: 3, padding: '1px 5px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                    {m.tier}
+                  </span>
+                  {m.id === currentModel && <span style={{ fontSize: 10, color: 'var(--sa-accent)', marginLeft: 'auto' }}>● active</span>}
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 2 }}>{m.description}</div>
+                <div style={{ fontSize: 10, color: 'var(--sa-text-dim)', fontFamily: 'monospace' }}>
+                  Input: {m.inputPrice} / M &nbsp;·&nbsp; Output: {m.outputPrice} / M tokens
+                </div>
+              </div>
+            </label>
+          ))}
+        </div>
+        {msg && (
+          <div style={{ marginTop: 12, fontSize: 11, color: msg.ok ? 'var(--sa-accent)' : 'var(--sa-danger)' }}>{msg.text}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PriceSuggestPromptPanel({ prompt, apiFetch }) {
+  const [val, setVal] = useState(prompt || '');
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState(null);
+
+  const save = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      const res = await apiFetch('/api/superadmin/ai/price-suggest-prompt', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: val }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setMsg({ ok: false, text: d.error || 'Save failed' });
+      } else {
+        setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+      }
+    } catch {
+      setMsg({ ok: false, text: 'Network error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="sa-panel" style={{ marginTop: 16 }}>
+      <div className="sa-panel-header">
+        <span className="sa-panel-title">Price Suggest — AI Prompt</span>
+        <button className="sa-btn" onClick={save} disabled={saving || !val.trim()}>{saving ? 'Saving...' : 'Save'}</button>
+      </div>
+      <div className="sa-panel-body">
+        <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 8 }}>
+          Prompt sent to Claude when a sommelier asks AI to suggest a market price. Use <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{name}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{producer}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{vintage}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{country}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{region}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{appellation}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{type}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{grapes}}'}</code> placeholders. If a wine has no cellar value, AI should return null for price.
+        </div>
+        <textarea
+          value={val}
+          onChange={e => setVal(e.target.value)}
+          rows={14}
+          style={{ width: '100%', background: 'var(--sa-bg)', border: '1px solid var(--sa-border)', color: 'var(--sa-text)', padding: '8px', borderRadius: 3, fontFamily: 'monospace', fontSize: 12, lineHeight: 1.5, resize: 'vertical', boxSizing: 'border-box' }}
+        />
+        <div style={{ marginTop: 6, display: 'flex', gap: 8, alignItems: 'center' }}>
+          <span style={{ fontSize: 11, color: 'var(--sa-text-dim)' }}>{val.length} / 6000 chars</span>
+          {msg && (
+            <span style={{ fontSize: 11, color: msg.ok ? 'var(--sa-accent)' : 'var(--sa-danger)' }}>{msg.text}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ChatLimitsPanel({ limits, apiFetch }) {
   const [vals, setVals] = useState({ free: limits.free ?? 4, basic: limits.basic ?? 20, premium: limits.premium ?? 50 });
   const [saving, setSaving] = useState(false);
@@ -762,6 +1044,14 @@ export default function TabAI() {
                 <span className="sa-kv-val">{config.chatModelFallback || '—'}</span>
               </div>
               <div className="sa-kv-row">
+                <span className="sa-kv-key">Maturity suggest model</span>
+                <span className="sa-kv-val">{config.maturitySuggestModel}</span>
+              </div>
+              <div className="sa-kv-row">
+                <span className="sa-kv-key">Price suggest model</span>
+                <span className="sa-kv-val">{config.priceSuggestModel}</span>
+              </div>
+              <div className="sa-kv-row">
                 <span className="sa-kv-key">Embed batch delay</span>
                 <span className="sa-kv-val">{config.embeddingBatchDelayMs}ms</span>
               </div>
@@ -979,6 +1269,10 @@ export default function TabAI() {
       <LabelScanPromptPanel prompt={config.labelScanPrompt || ''} apiFetch={apiFetch} />
       <ImportLookupModelPanel currentModel={config.importLookupModel || 'claude-haiku-4-5-20251001'} apiFetch={apiFetch} />
       <ImportLookupPromptPanel prompt={config.importLookupPrompt || ''} apiFetch={apiFetch} />
+      <MaturitySuggestModelPanel currentModel={config.maturitySuggestModel || 'claude-haiku-4-5-20251001'} apiFetch={apiFetch} />
+      <MaturitySuggestPromptPanel prompt={config.maturitySuggestPrompt || ''} apiFetch={apiFetch} />
+      <PriceSuggestModelPanel currentModel={config.priceSuggestModel || 'claude-haiku-4-5-20251001'} apiFetch={apiFetch} />
+      <PriceSuggestPromptPanel prompt={config.priceSuggestPrompt || ''} apiFetch={apiFetch} />
       <ChatLimitsPanel limits={config.chatDailyLimits || {}} apiFetch={apiFetch} />
       <ChatUsagePanel />
     </>


### PR DESCRIPTION
## Summary
- Sommeliers/admins can click **"Ask AI"** on the Maturity Queue to get Claude-suggested drink window phases (early/peak/late years + sommelier notes) that pre-fill the form
- Same **"Ask AI"** button on the Price Queue suggests market prices; returns null with reasoning for wines that don't appreciate with cellaring
- AI suggestions only pre-fill the form — the user must review and save
- All prompts and models are configurable via the **Super Admin > AI** tab at runtime (4 new panels: Maturity Suggest Model/Prompt, Price Suggest Model/Prompt)

## Changes
- `backend/src/config/aiConfig.js` — New default prompts and model config fields
- `backend/src/services/labelScan.js` — New `suggestDrinkWindow()` and `suggestPrice()` functions
- `backend/src/routes/somm/maturity.js` — New `POST /:id/ai-suggest` endpoint
- `backend/src/routes/somm/prices.js` — New `POST /ai-suggest` endpoint
- `backend/src/routes/superadmin.js` — 4 new PATCH endpoints for prompts/models
- `frontend/src/pages/SommMaturity.js` — AI suggest button + form auto-fill
- `frontend/src/pages/SommPrices.js` — AI suggest button + no-value handling
- `frontend/src/pages/SuperAdmin/TabAI.js` — 4 new config panels
- i18n translations (EN + SV)

## Test plan
- [ ] Click "Ask AI" on a pending maturity profile — verify form fields are populated
- [ ] Click "Ask AI" on a price queue item — verify price is suggested or "no value" message shown
- [ ] Verify AI suggestion does NOT auto-save — user must click Save
- [ ] Test with ANTHROPIC_API_KEY missing — should show error gracefully
- [ ] Super Admin > AI tab: verify new model/prompt panels load and save correctly
- [ ] Smoke test in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)