### PR TITLE
Fix app version display (1.0.0 → 1.12.0)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.0.0",
+  "version": "1.12.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "1.12.0",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
## Summary
- Both `backend/package.json` and `frontend/package.json` had version stuck at `1.0.0` since the project was created
- The `/api/health` endpoint reads from `backend/package.json`, so the app always showed v1.0.0
- Updated both to `1.12.0` to match the current release