### PR TITLE
Fix price queue crash on null wineDefinition

### DIFF
--- a/backend/src/routes/somm/prices.js
+++ b/backend/src/routes/somm/prices.js
@@ -24,7 +24,7 @@ router.get('/queue', requireSommOrAdmin, async (req, res) => {
 
     // Step 1: unique (wineDefinition, vintage) pairs with at least one active bottle
     const rawPairs = await Bottle.aggregate([
-      { $match: { status: 'active', vintage: { $nin: ['NV', '', null] } } },
+      { $match: { status: 'active', wineDefinition: { $ne: null }, vintage: { $nin: ['NV', '', null] } } },
       {
         $group: {
           _id: { wineDefinition: '$wineDefinition', vintage: '$vintage' },


### PR DESCRIPTION
## Summary
- Bottles with no `wineDefinition` (null) caused `toString()` to crash in the price queue aggregation
- Added `wineDefinition: { $ne: null }` filter to the `$match` stage

## Test plan
- Load the price queue with bottles that have no wineDefinition in the database