### PR TITLE
Fix remaining mobile statistics issues

### DIFF
--- a/frontend/src/pages/Statistics.css
+++ b/frontend/src/pages/Statistics.css
@@ -163,7 +163,8 @@
   margin: 0 0 1.25rem;
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.5rem 0.75rem;
+  flex-wrap: wrap;
 }
 
 .stats-card-title-note {
@@ -310,6 +311,7 @@
   border-radius: 4px;
   transition: width 0.5s cubic-bezier(0.25, 1, 0.5, 1);
   opacity: 0.9;
+  min-width: 4px;
 }
 
 .hbar-fill:hover {
@@ -1022,8 +1024,10 @@
 
   /* Horizontal bar charts: narrower labels, hide % to save space */
   .hbar-label {
-    width: 72px;
+    width: 80px;
     font-size: 0.72rem;
+    white-space: normal;
+    line-height: 1.25;
   }
   .hbar-pct {
     display: none;
@@ -1127,7 +1131,7 @@
 
   /* Horizontal bar charts: even narrower */
   .hbar-label {
-    width: 56px;
+    width: 64px;
     font-size: 0.68rem;
   }
 

--- a/frontend/src/pages/Statistics.js
+++ b/frontend/src/pages/Statistics.js
@@ -231,7 +231,7 @@ function RatingChart({ byRating, avg, targetScale }) {
         const pct   = total > 0 ? (count / total) * 100 : 0;
         return (
           <div key={band.key} className="rating-row" title={bandSub(band.key, targetScale)}>
-            <span className="rating-stars" style={{ color: band.color, minWidth: 70, fontSize: '0.8rem' }}>{band.label}</span>
+            <span className="rating-stars" style={{ color: band.color }}>{band.label}</span>
             <div className="rating-track">
               <div className="rating-fill" style={{ width: `${(count / maxVal) * 100}%`, background: band.color }} />
             </div>


### PR DESCRIPTION
## Summary
Follow-up to #107. Fixes issues visible in mobile testing:
- Rating chart labels had inline `minWidth: 70` overriding CSS mobile width — removed
- Bottle size labels ("750ml (Standard)") truncated — labels now wrap on mobile
- Bar fills for small counts (1 bottle) were invisible dots — added `min-width: 4px`
- Card titles with long notes could overflow — added `flex-wrap: wrap`

## Test plan
- [ ] Check bottle sizes chart on mobile — labels should show full text
- [ ] Check rating chart labels fit on small screens
- [ ] Verify no horizontal overflow on any chart