### PR TITLE
Fix cellar sharing and rack name reuse after delete

### DIFF
--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -4,6 +4,13 @@ const connectDB = async () => {
   try {
     await mongoose.connect(process.env.MONGO_URI);
     console.log('MongoDB Connected');
+
+    // Sync indexes for models whose index definitions changed (drops stale, creates new).
+    // Non-blocking — failures log a warning but don't prevent startup.
+    const Rack = require('../models/Rack');
+    Rack.syncIndexes().catch(err =>
+      console.warn('[db] Rack.syncIndexes failed:', err.message)
+    );
   } catch (error) {
     console.error('MongoDB Connection Error');
     process.exit(1);

--- a/backend/src/models/Rack.js
+++ b/backend/src/models/Rack.js
@@ -16,7 +16,7 @@ const rackSchema = new mongoose.Schema({
   deletedAt: { type: Date, default: null }
 }, { timestamps: true, optimisticConcurrency: true });
 
-rackSchema.index({ cellar: 1, name: 1 }, { unique: true });
+rackSchema.index({ cellar: 1, name: 1 }, { unique: true, partialFilterExpression: { deletedAt: null } });
 // TTL: auto-purge soft-deleted racks after 30 days
 rackSchema.index(
   { deletedAt: 1 },

--- a/frontend/src/components/ShareCellarModal.js
+++ b/frontend/src/components/ShareCellarModal.js
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
-import { usePlan } from '../contexts/AuthContext';
+import { useAuth, usePlan } from '../contexts/AuthContext';
 import { formatLimit } from '../config/plans';
 import './ShareCellarModal.css';
 
-function ShareCellarModal({ cellarId, cellarName, token, onClose }) {
+function ShareCellarModal({ cellarId, cellarName, onClose }) {
+  const { apiFetch } = useAuth();
   const { plan, config } = usePlan();
   const [members, setMembers] = useState([]);
   const [email, setEmail] = useState('');
@@ -13,15 +14,13 @@ function ShareCellarModal({ cellarId, cellarName, token, onClose }) {
   const [limitError, setLimitError] = useState(null);
   const [success, setSuccess] = useState(null);
 
-  const auth = () => ({ 'Authorization': `Bearer ${token}` });
-
   useEffect(() => {
     fetchMembers();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchMembers = async () => {
     try {
-      const res = await fetch(`/api/cellars/${cellarId}/members`, { headers: auth() });
+      const res = await apiFetch(`/api/cellars/${cellarId}/members`);
       const data = await res.json();
       if (res.ok) setMembers(data.members);
     } catch {}
@@ -37,9 +36,9 @@ function ShareCellarModal({ cellarId, cellarName, token, onClose }) {
     setSuccess(null);
 
     try {
-      const res = await fetch(`/api/cellars/${cellarId}/members`, {
+      const res = await apiFetch(`/api/cellars/${cellarId}/members`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...auth() },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: email.trim(), role })
       });
       const data = await res.json();
@@ -62,9 +61,9 @@ function ShareCellarModal({ cellarId, cellarName, token, onClose }) {
   const handleRoleChange = async (userId, newRole) => {
     setError(null);
     try {
-      const res = await fetch(`/api/cellars/${cellarId}/members/${userId}`, {
+      const res = await apiFetch(`/api/cellars/${cellarId}/members/${userId}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json', ...auth() },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ role: newRole })
       });
       const data = await res.json();
@@ -78,9 +77,8 @@ function ShareCellarModal({ cellarId, cellarName, token, onClose }) {
   const handleRemove = async (userId) => {
     setError(null);
     try {
-      const res = await fetch(`/api/cellars/${cellarId}/members/${userId}`, {
-        method: 'DELETE',
-        headers: auth()
+      const res = await apiFetch(`/api/cellars/${cellarId}/members/${userId}`, {
+        method: 'DELETE'
       });
       if (res.ok) {
         setMembers(prev => prev.filter(m => m.user._id !== userId));


### PR DESCRIPTION
## Summary
- **Fix #110 — Sharing cellar fails with "Invalid token":** `ShareCellarModal` expected a `token` prop that `CellarDetail` never passed, causing all API calls to send `Bearer undefined`. Refactored to use `useAuth()`/`apiFetch` (consistent with `EditCellarModal`, `ColorPickerModal`, etc.) so the auth header is injected automatically with token refresh support.
- **Fix #111 — Rack name not released after delete:** The unique index on `{cellar, name}` did not exclude soft-deleted racks, so re-creating a rack with a previously deleted name hit a duplicate-key error. Added `partialFilterExpression: { deletedAt: null }` to scope uniqueness to active racks only. Added `Rack.syncIndexes()` on DB startup to migrate existing databases.

## Test plan
- [ ] Open a cellar → click Share → enter an email → verify member is added (no "Invalid token" error)
- [ ] Change a shared member's role and remove a member — both should work
- [ ] Create a rack, delete it, then create a new rack with the same name — should succeed
- [ ] Existing racks remain unaffected after the index migration
- [ ] All 169 existing tests pass (frontend: 34, backend: 135)