### PR TITLE
Fix mobile statistics page layout and readability

### DIFF
--- a/frontend/src/pages/Statistics.css
+++ b/frontend/src/pages/Statistics.css
@@ -528,7 +528,7 @@
   display: flex;
   align-items: flex-end;
   gap: 4px;
-  height: 152px;
+  height: 164px;
   padding-bottom: 24px;
   overflow-x: auto;
   position: relative;
@@ -559,6 +559,13 @@
   width: 100%;
   flex-shrink: 0;
   min-height: 1px;
+}
+
+.consumption-bar-count {
+  font-size: 0.6rem;
+  color: var(--color-text-muted);
+  min-height: 12px;
+  text-align: center;
 }
 
 .consumption-year-label {
@@ -1022,6 +1029,11 @@
     padding: 1.1rem;
   }
 
+  /* Hide desktop-only charts on mobile */
+  .stats-card--desktop-only {
+    display: none;
+  }
+
   /* Horizontal bar charts: narrower labels, hide % to save space */
   .hbar-label {
     width: 80px;
@@ -1033,14 +1045,33 @@
     display: none;
   }
 
-  /* Vintage / Purchase bar charts: bigger count labels on bars */
+  /* Consumption stacked bars: show count above bars */
+  .consumption-bar-count {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  /* Horizontal bar chart counts: bolder for readability */
+  .hbar-count {
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  /* Vintage / Purchase bar charts: bigger count labels, rotated year labels */
   .vintage-bar-count {
     font-size: 0.72rem;
     font-weight: 600;
     color: var(--color-text);
   }
+  .vintage-bars {
+    padding-bottom: 36px;
+  }
   .vintage-bar-label {
     font-size: 0.62rem;
+    transform: rotate(-45deg);
+    transform-origin: top center;
+    bottom: -2px;
   }
 
   /* Forecast chart: bigger count labels */
@@ -1145,6 +1176,10 @@
   .vintage-bars {
     height: 170px;
     gap: 2px;
+    padding-bottom: 40px;
+  }
+  .vintage-bar-label {
+    font-size: 0.56rem;
   }
 
   /* Forecast: tighter */
@@ -1218,6 +1253,9 @@
   }
   .consumption-bar-stack {
     width: 16px;
+  }
+  .consumption-bar-count {
+    font-size: 0.62rem;
   }
   .consumption-legend {
     gap: 0.5rem;

--- a/frontend/src/pages/Statistics.js
+++ b/frontend/src/pages/Statistics.js
@@ -685,6 +685,7 @@ function ConsumptionChart({ consumptionByYear, consumptionByReason }) {
           const yearTotal = reasons.reduce((s, r) => s + (d[r] || 0), 0);
           return (
             <div key={i} className="consumption-year-col">
+              <div className="consumption-bar-count">{yearTotal > 0 ? yearTotal : ''}</div>
               <div className="consumption-bar-stack" style={{ height: `${BAR_H}px` }}
                 title={`${d.year}: ${yearTotal} bottle${yearTotal !== 1 ? 's' : ''}`}>
                 {reasons.map(r => {
@@ -1273,8 +1274,8 @@ function Statistics() {
         {/* ── BASIC+ sections ── */}
         {isBasic && (
           <>
-            {/* World Map — BASIC */}
-            <div className="stats-card stats-card--full">
+            {/* World Map — BASIC (desktop only, hover-based) */}
+            <div className="stats-card stats-card--full stats-card--desktop-only">
               <h2 className="stats-card-title">
                 Collection Origins
                 <span className="stats-card-title-note">Darker = more bottles</span>
@@ -1326,9 +1327,9 @@ function Statistics() {
               </div>
             )}
 
-            {/* Purchase History — BASIC */}
+            {/* Purchase History — BASIC (desktop only, scrolling bar chart) */}
             {hasPurchaseDates && (
-              <div className="stats-card">
+              <div className="stats-card stats-card--desktop-only">
                 <h2 className="stats-card-title">Purchases by Year</h2>
                 <PurchaseHistoryChart byPurchaseYear={byPurchaseYear} />
               </div>
@@ -1363,9 +1364,9 @@ function Statistics() {
               <UpgradeCard plan="premium" fullWidth features={PREMIUM_FEATURES} />
             ) : (
               <>
-                {/* Maturity Forecast — PREMIUM */}
+                {/* Maturity Forecast — PREMIUM (desktop only, many columns) */}
                 {hasForecast && (
-                  <div className="stats-card stats-card--full">
+                  <div className="stats-card stats-card--full stats-card--desktop-only">
                     <h2 className="stats-card-title">
                       Maturity Forecast
                       <span className="stats-card-title-note">Bottles in window by year</span>
@@ -1403,9 +1404,9 @@ function Statistics() {
                   <JoyPerDollarChart data={joyPerDollar} currency={currency} targetScale={targetScale} />
                 </div>
 
-                {/* Regret Signal — PREMIUM */}
+                {/* Regret Signal — PREMIUM (desktop only, complex two-column layout) */}
                 {hasConsumption && (
-                  <div className="stats-card stats-card--full">
+                  <div className="stats-card stats-card--full stats-card--desktop-only">
                     <h2 className="stats-card-title">
                       Expectation vs Reality
                       <span className="stats-card-title-note">When wines surprised or disappointed you</span>


### PR DESCRIPTION
## Summary
- Hide charts that don't work well on mobile (world map, purchase history, maturity forecast, expectation vs reality) — shown only on desktop
- Add visible count labels above consumption stacked bars for easier reading
- Rotate vintage distribution year labels (-45°) to prevent overlap on small screens
- Make horizontal bar chart counts bolder on mobile

## Test plan
- [ ] Open Statistics page on mobile viewport (< 768px) — complex charts should be hidden
- [ ] Consumption chart shows total count above each stacked bar
- [ ] Vintage distribution year labels are angled and readable without overlap
- [ ] All charts display correctly on desktop (no regressions)
- [ ] Frontend tests pass: `cd frontend && npm test -- --watchAll=false`