### PR TITLE
Bump version to 1.16.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
## Summary
- Bump frontend and backend version to 1.16.0

## Changelog since v1.15.2
- Fix mobile statistics page: hide complex charts, improve readability (#117)
- Translate Analytics page to Swedish (sv-SE) (#118, closes #50)