### PR TITLE
Bump version to 1.17.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
## Summary
- Bump frontend and backend version to 1.17.0

## Changelog (since v1.16.0)
- PWA Play Store readiness: non-blocking font loading, fixed manifest, offline fallback page, service worker improvements
- Comprehensive accessibility fixes across all pages and components (aria-labels, aria-hidden, keyboard support, contrast improvements, touch targets)

## Test plan
- [ ] Verify `package.json` versions are `1.17.0` in both frontend and backend
- [ ] Smoke test in Docker