### PR TITLE
Add default cellar preference with auto-redirect

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -69,6 +69,11 @@ const userSchema = new mongoose.Schema({
       type: String,
       enum: ['5', '20', '100'],
       default: '5'
+    },
+    defaultCellarId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Cellar',
+      default: null
     }
   },
   refreshTokenHash: {

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,5 +1,7 @@
 const express = require('express');
+const mongoose = require('mongoose');
 const User = require('../models/User');
+const Cellar = require('../models/Cellar');
 const Follow = require('../models/Follow');
 const { requireAuth, requireRole } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
@@ -30,7 +32,7 @@ const ALLOWED_RATING_SCALES = ['5', '20', '100'];
 
 router.patch('/preferences', requireAuth, async (req, res) => {
   try {
-    const { currency, language, ratingScale } = req.body;
+    const { currency, language, ratingScale, defaultCellarId } = req.body;
     const update = {};
 
     if (currency !== undefined) {
@@ -52,6 +54,25 @@ router.patch('/preferences', requireAuth, async (req, res) => {
         return res.status(400).json({ error: `Invalid rating scale. Allowed: ${ALLOWED_RATING_SCALES.join(', ')}` });
       }
       update['preferences.ratingScale'] = String(ratingScale);
+    }
+
+    if (defaultCellarId !== undefined) {
+      if (defaultCellarId === null) {
+        update['preferences.defaultCellarId'] = null;
+      } else {
+        if (!mongoose.Types.ObjectId.isValid(defaultCellarId)) {
+          return res.status(400).json({ error: 'Invalid cellar ID' });
+        }
+        const cellar = await Cellar.findOne({
+          _id: defaultCellarId,
+          deletedAt: null,
+          $or: [{ user: req.user.id }, { 'members.user': req.user.id }]
+        });
+        if (!cellar) {
+          return res.status(400).json({ error: 'Cellar not found or not accessible' });
+        }
+        update['preferences.defaultCellarId'] = defaultCellarId;
+      }
     }
 
     if (Object.keys(update).length === 0) {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -127,6 +127,8 @@
     "emptyCellars": "You don't have any cellars yet.",
     "emptyCallToAction": "Create your first cellar to start tracking your wine collection!",
     "viewCellar": "View Cellar →",
+    "setDefault": "Set as default cellar",
+    "removeDefault": "Remove as default cellar",
     "editRole": "Edit",
     "viewRole": "View"
   },

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -127,6 +127,8 @@
     "emptyCellars": "Du har inga källare ännu.",
     "emptyCallToAction": "Skapa din första källare för att börja spåra din vinsamling!",
     "viewCellar": "Visa källare →",
+    "setDefault": "Ange som standardkällare",
+    "removeDefault": "Ta bort som standardkällare",
     "editRole": "Redigera",
     "viewRole": "Visa"
   },

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -109,7 +109,7 @@ function CellarDetail() {
       {/* ── Clean header ── */}
       <div className="cellar-header">
         <div className="cellar-header-top">
-          <Link to="/cellars" className="back-link">
+          <Link to="/cellars?all=1" className="back-link">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
             {t('cellarDetail.backToCellars')}
           </Link>

--- a/frontend/src/pages/Cellars.css
+++ b/frontend/src/pages/Cellars.css
@@ -96,6 +96,29 @@
   flex: 1;
 }
 
+/* Default-cellar star toggle */
+.cellar-default-btn {
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: color var(--transition-fast);
+}
+
+.cellar-default-btn:hover {
+  color: var(--color-accent);
+}
+
+.cellar-default-btn--active {
+  color: var(--color-accent);
+}
+
 .role-badge {
   font-size: 0.7rem;
   font-weight: 600;

--- a/frontend/src/pages/Cellars.js
+++ b/frontend/src/pages/Cellars.js
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { useState, useEffect, useCallback } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { usePlan } from '../contexts/AuthContext';
@@ -9,8 +9,10 @@ import './Cellars.css';
 
 function Cellars() {
   const { t } = useTranslation();
-  const { apiFetch } = useAuth();
+  const { user, apiFetch, updatePreferences } = useAuth();
   const { plan, config } = usePlan();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [cellars, setCellars] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -18,6 +20,9 @@ function Cellars() {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [newCellar, setNewCellar] = useState({ name: '', description: '', color: null });
   const [creating, setCreating] = useState(false);
+
+  const showAll = searchParams.get('all') === '1';
+  const defaultCellarId = user?.preferences?.defaultCellarId || null;
 
   useEffect(() => {
     fetchCellars();
@@ -38,6 +43,27 @@ function Cellars() {
       setLoading(false);
     }
   };
+
+  // Auto-redirect: single cellar or default cellar set
+  useEffect(() => {
+    if (loading || showAll || cellars.length === 0) return;
+
+    if (cellars.length === 1) {
+      navigate(`/cellars/${cellars[0]._id}`, { replace: true });
+      return;
+    }
+
+    if (defaultCellarId && cellars.some(c => c._id === defaultCellarId)) {
+      navigate(`/cellars/${defaultCellarId}`, { replace: true });
+    }
+  }, [loading, cellars, defaultCellarId, showAll, navigate]);
+
+  const toggleDefault = useCallback(async (e, cellarId) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const newId = defaultCellarId === cellarId ? null : cellarId;
+    await updatePreferences({ defaultCellarId: newId });
+  }, [defaultCellarId, updatePreferences]);
 
   // Number of owned cellars (not shared ones)
   const ownedCellars = cellars.filter(c => c.userRole === 'owner');
@@ -179,6 +205,18 @@ function Cellars() {
             >
               <div className="cellar-card-header">
                 <h3>{cellar.name}</h3>
+                {cellars.length > 1 && (
+                  <button
+                    className={`cellar-default-btn${defaultCellarId === cellar._id ? ' cellar-default-btn--active' : ''}`}
+                    onClick={(e) => toggleDefault(e, cellar._id)}
+                    title={defaultCellarId === cellar._id ? t('cellars.removeDefault') : t('cellars.setDefault')}
+                    aria-label={defaultCellarId === cellar._id ? t('cellars.removeDefault') : t('cellars.setDefault')}
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill={defaultCellarId === cellar._id ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                    </svg>
+                  </button>
+                )}
                 {cellar.userRole && cellar.userRole !== 'owner' && (
                   <span className={`role-badge role-badge--${cellar.userRole}`}>
                     {cellar.userRole === 'editor' ? t('cellars.editRole') : t('cellars.viewRole')}


### PR DESCRIPTION
## Summary
- Adds `defaultCellarId` to user preferences (backend model + API)
- Star icon on cellar cards to toggle the default cellar
- Auto-redirect: single cellar skips the list; default cellar auto-opens on visit
- "Back to Cellars" uses `?all=1` to bypass redirect and show the full list
- Translation keys added for EN and SV

Closes #122