### PR TITLE
Bump version to 1.20.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
## Summary
- Bump version to 1.20.0 in both backend and frontend package.json

## Changelog since 1.19.0
- Add default cellar preference with auto-redirect (#122)