### PR TITLE
Fix mobile search layout and add modal close button

### DIFF
--- a/frontend/src/components/BottleFilterModal.js
+++ b/frontend/src/components/BottleFilterModal.js
@@ -99,7 +99,7 @@ function BottleFilterModal({ filters, onApply, onClose, facets, baseFacets, face
   };
 
   return (
-    <Modal title={t('cellarDetail.filterModalTitle')} onClose={onClose} wide>
+    <Modal title={t('cellarDetail.filterModalTitle')} onClose={onClose} wide showClose>
       <div className="bfm-content">
         {/* Wine Type */}
         {allFacets?.type && Object.keys(allFacets.type).length > 0 && (() => {

--- a/frontend/src/components/Modal.js
+++ b/frontend/src/components/Modal.js
@@ -12,11 +12,22 @@ import './Modal.css';
  *     </div>
  *   </Modal>
  */
-function Modal({ title, onClose, children, wide }) {
+function Modal({ title, onClose, children, wide, showClose }) {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className={`modal-box${wide ? ' modal-box--wide' : ''}`} onClick={e => e.stopPropagation()}>
-        {title && <h2>{title}</h2>}
+        {(title || showClose) && (
+          <div className="modal-header">
+            {title && <h2>{title}</h2>}
+            {showClose && (
+              <button type="button" className="modal-close-btn" onClick={onClose} aria-label="Close">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            )}
+          </div>
+        )}
         {children}
       </div>
     </div>

--- a/frontend/src/pages/CellarDetail.css
+++ b/frontend/src/pages/CellarDetail.css
@@ -975,9 +975,18 @@
     width: 100%;
   }
 
+  .search-row {
+    flex-wrap: wrap;
+  }
+
+  .search-row .search-input {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+
   .sort-select {
     min-width: 0;
-    width: 100%;
+    flex: 1;
   }
 
   .active-filters-row {

--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -270,6 +270,37 @@
   max-width: 600px;
 }
 
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.modal-header h2 {
+  margin: 0;
+}
+
+.modal-close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.modal-close-btn:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
 .modal-box h2,
 .modal-box h3 {
   color: var(--color-text);


### PR DESCRIPTION
## Summary
- Search input gets full width on mobile (filter button + sort wrap to second row)
- Add X close button to modal header (opt-in via `showClose` prop)
- Used in the filter modal for easy dismissal on mobile

## Test plan
- [ ] On mobile: search input takes full width, filter button + sort wrap below
- [ ] Filter modal has X button in top-right corner
- [ ] X button closes the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)