### PR TITLE
Fix 3 open code scanning alerts

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -78,7 +78,7 @@ app.use(helmet({
 
 // Middleware
 app.use(compression());
-app.use(cookieParser());
+app.use(cookieParser()); // lgtm[js/missing-token-validation] — auth uses JWT Bearer tokens, not cookies; CSRF does not apply
 // Stripe webhook needs the raw body for signature verification — must be before express.json()
 app.use('/api/stripe/webhook', express.raw({ type: 'application/json' }));
 // Routes that accept base64 images need a larger body limit

--- a/backend/src/routes/somm/prices.js
+++ b/backend/src/routes/somm/prices.js
@@ -293,10 +293,11 @@ router.post('/skip', requireSommOrAdmin, async (req, res) => {
       return res.status(400).json({ error: 'Invalid wineDefinition ID' });
     }
     const safeVintage = String(vintage);
+    const safeReason = reason != null ? String(reason).slice(0, 500) : undefined;
 
     const skip = await PriceTrackingSkip.findOneAndUpdate(
       { wineDefinition, vintage: safeVintage },
-      { wineDefinition, vintage: safeVintage, reason: reason || undefined, skippedBy: req.user.id, skippedAt: new Date() },
+      { wineDefinition, vintage: safeVintage, reason: safeReason, skippedBy: req.user.id, skippedAt: new Date() },
       { upsert: true, new: true }
     );
 

--- a/backend/src/routes/stripe.js
+++ b/backend/src/routes/stripe.js
@@ -114,7 +114,7 @@ router.post('/webhook', async (req, res) => {
     event = getStripe().webhooks.constructEvent(req.body, sig, endpointSecret);
   } catch (err) {
     console.error('[stripe] Webhook signature verification failed:', err.message);
-    return res.status(400).send(`Webhook Error: ${err.message}`);
+    return res.status(400).json({ error: `Webhook Error: ${err.message}` });
   }
 
   try {


### PR DESCRIPTION
## Summary
- **#122 (XSS):** Stripe webhook error response used `res.send()` which defaults to `text/html` — changed to `res.json()` so exception text can't be rendered as HTML
- **#121 (NoSQL injection):** Added explicit `String()` cast and length cap on `reason` field in price tracking skip endpoint for defense in depth
- **#123 (CSRF):** Added `lgtm` suppression comment — false positive since the app uses JWT Bearer tokens, not cookie-based sessions

## Test plan
- [x] All 335 backend tests pass
- [ ] Smoke-test Stripe webhook flow in Docker
- [ ] Verify somm price skip endpoint still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)