### PR TITLE
Add search and advanced filters to cellar history page

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -78,7 +78,7 @@ app.use(helmet({
 
 // Middleware
 app.use(compression());
-app.use(cookieParser()); // lgtm[js/missing-token-validation] — auth uses JWT Bearer tokens, not cookies; CSRF does not apply
+app.use(cookieParser());
 // Stripe webhook needs the raw body for signature verification — must be before express.json()
 app.use('/api/stripe/webhook', express.raw({ type: 'application/json' }));
 // Routes that accept base64 images need a larger body limit

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -230,17 +230,156 @@ router.get('/:id/history', async (req, res) => {
     const role = getCellarRole(cellar, req.user.id);
     if (!role || cellar.deletedAt) return res.status(404).json({ error: 'Cellar not found' });
 
-    const bottles = await Bottle.find({
-      cellar: req.params.id,
-      status: { $in: CONSUMED_STATUSES }
-    })
-      .populate(WINE_POPULATE)
-      .sort({ consumedAt: -1 });
+    const { search, type, country, region, grapes, vintage } = req.query;
+    const { isValidObjectId } = mongoose;
+
+    // Base query: consumed bottles in this cellar
+    const filter = { cellar: req.params.id, status: { $in: CONSUMED_STATUSES } };
+    if (vintage) {
+      const vintages = String(vintage).split(',').map(v => v.trim()).filter(Boolean);
+      filter.vintage = vintages.length === 1 ? vintages[0] : { $in: vintages };
+    }
+
+    // Taxonomy pre-query
+    const wdFilter = {};
+    if (country) {
+      const ids = String(country).split(',').map(c => c.trim()).filter(isValidObjectId);
+      if (ids.length === 1) wdFilter.country = ids[0];
+      else if (ids.length > 1) wdFilter.country = { $in: ids };
+    }
+    if (region) {
+      const ids = String(region).split(',').map(r => r.trim()).filter(isValidObjectId);
+      if (ids.length === 1) wdFilter.region = ids[0];
+      else if (ids.length > 1) wdFilter.region = { $in: ids };
+    }
+    if (type) {
+      const types = String(type).split(',').map(t => t.trim()).filter(Boolean);
+      wdFilter.type = types.length === 1 ? types[0] : { $in: types };
+    }
+    if (grapes) {
+      const grapeIds = String(grapes).split(',').map(g => g.trim()).filter(isValidObjectId);
+      if (grapeIds.length > 0) wdFilter.grapes = { $in: grapeIds };
+    }
+    if (Object.keys(wdFilter).length > 0) {
+      const matchingWdIds = await WineDefinition.find(wdFilter).distinct('_id');
+      if (matchingWdIds.length === 0) {
+        const cellarObj = cellar.toObject();
+        cellarObj.userRole = role;
+        cellarObj.userColor = getUserColor(cellar, req.user.id);
+        return res.json({ cellar: cellarObj, bottles: [], facets: null, baseFacets: null, facetMeta: null });
+      }
+      filter.wineDefinition = { $in: matchingWdIds };
+    }
+
+    const grapeIds = grapes
+      ? String(grapes).split(',').map(g => g.trim()).filter(isValidObjectId)
+      : [];
+    const hasMeiliFilters = !!(search || type || country || region || grapes || vintage);
+
+    // Try Meilisearch for text search (typo tolerance)
+    let usedMeili = false;
+    let bottles;
+    if (searchService.getIsAvailable() && hasMeiliFilters) {
+      try {
+        const meiliResult = await searchService.searchBottles(search || '', {
+          cellarId: req.params.id,
+          type: type || undefined,
+          countryId: country || undefined,
+          regionId: region || undefined,
+          grapeIds: grapeIds.length > 0 ? grapeIds : undefined,
+          vintage: vintage || undefined,
+          statusFilter: 'consumed',
+          limit: 10000, offset: 0
+        });
+
+        const matchingIds = meiliResult.ids;
+        if (matchingIds.length === 0) {
+          const cellarObj = cellar.toObject();
+          cellarObj.userRole = role;
+          cellarObj.userColor = getUserColor(cellar, req.user.id);
+          return res.json({ cellar: cellarObj, bottles: [], facets: meiliResult.facetDistribution || null, baseFacets: null, facetMeta: null });
+        }
+
+        bottles = await Bottle.find({ _id: { $in: matchingIds } })
+          .populate(WINE_POPULATE).lean();
+
+        // Preserve Meilisearch sort order
+        const idOrder = new Map(matchingIds.map((id, i) => [id, i]));
+        bottles.sort((a, b) => (idOrder.get(a._id.toString()) ?? 0) - (idOrder.get(b._id.toString()) ?? 0));
+        usedMeili = true;
+      } catch {
+        // Fall through to MongoDB
+      }
+    }
+
+    if (!usedMeili) {
+      bottles = await Bottle.find(filter)
+        .populate(WINE_POPULATE)
+        .sort({ consumedAt: -1 })
+        .lean();
+
+      // In-memory text search fallback
+      if (search) {
+        const stripAccents = (s) => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+        const words = stripAccents(search.toLowerCase()).split(/\s+/).filter(Boolean);
+        bottles = bottles.filter(b => {
+          const allText = [
+            b.wineDefinition?.name, b.wineDefinition?.producer,
+            b.notes, b.consumedNote,
+            b.wineDefinition?.country?.name, b.wineDefinition?.region?.name,
+            b.wineDefinition?.appellation, b.wineDefinition?.type,
+            ...(b.wineDefinition?.grapes || []).map(g => g.name)
+          ].filter(Boolean).map(s => stripAccents(s.toLowerCase())).join(' ');
+          return words.every(word => allText.includes(word));
+        });
+      }
+    }
+
+    // Facets from Meilisearch
+    let facets = null, baseFacets = null, facetMeta = null;
+    if (searchService.getIsAvailable()) {
+      try {
+        const baseResult = await searchService.searchBottles('', {
+          cellarId: req.params.id, statusFilter: 'consumed', limit: 0, offset: 0
+        });
+        baseFacets = baseResult.facetDistribution || null;
+
+        if (hasMeiliFilters) {
+          const filteredResult = await searchService.searchBottles(search || '', {
+            cellarId: req.params.id, statusFilter: 'consumed',
+            type: type || undefined, countryId: country || undefined,
+            regionId: region || undefined,
+            grapeIds: grapeIds.length > 0 ? grapeIds : undefined,
+            vintage: vintage || undefined,
+            limit: 0, offset: 0
+          });
+          facets = filteredResult.facetDistribution || null;
+        } else {
+          facets = baseFacets;
+        }
+      } catch { /* skip facets */ }
+    }
+
+    // Build facetMeta
+    if (baseFacets || facets) {
+      const wdIds = await Bottle.find({ cellar: req.params.id, status: { $in: CONSUMED_STATUSES } }).distinct('wineDefinition');
+      const wds = await WineDefinition.find({ _id: { $in: wdIds } })
+        .populate('country', 'name').populate('region', 'name').populate('grapes', 'name').lean();
+      const countries = {}, regions = {}, grapesMap = {};
+      for (const wd of wds) {
+        if (wd.country?.name && wd.country._id) countries[wd.country.name] = wd.country._id.toString();
+        if (wd.region?.name && wd.region._id) regions[wd.region.name] = wd.region._id.toString();
+        for (const g of (wd.grapes || [])) {
+          if (g.name && g._id) grapesMap[g.name] = g._id.toString();
+        }
+      }
+      facetMeta = { countries, regions, grapes: grapesMap };
+    }
 
     const cellarObj = cellar.toObject();
     cellarObj.userRole = role;
     cellarObj.userColor = getUserColor(cellar, req.user.id);
-    res.json({ cellar: cellarObj, bottles });
+    res.json({ cellar: cellarObj, bottles, facets, baseFacets, facetMeta });
   } catch (error) {
     console.error('Get cellar history error:', error);
     res.status(500).json({ error: 'Failed to get cellar history' });

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -224,7 +224,8 @@ async function fullSyncBottles() {
   if (!isAvailable) return;
 
   try {
-    const bottles = await Bottle.find({ status: { $nin: CONSUMED_STATUSES } })
+    // Sync ALL bottles (active + consumed) so history search works too
+    const bottles = await Bottle.find()
       .populate(WINE_POPULATE)
       .lean();
 
@@ -250,12 +251,7 @@ async function indexBottle(bottleId) {
 
     if (!bottle) return;
 
-    // If bottle is consumed, remove it from the index instead
-    if (CONSUMED_STATUSES.includes(bottle.status)) {
-      await bottlesIndex.deleteDocument(bottleId.toString());
-      return;
-    }
-
+    // Always re-index (including consumed bottles for history search)
     await bottlesIndex.addDocuments([buildBottleDocument(bottle)], { primaryKey: 'id' });
   } catch (err) {
     console.error(`Meilisearch index bottle ${bottleId} failed: ${err.message}`);
@@ -280,9 +276,7 @@ async function bulkIndexBottles(bottleIds) {
       .populate(WINE_POPULATE)
       .lean();
 
-    const documents = bottles
-      .filter(b => !CONSUMED_STATUSES.includes(b.status))
-      .map(buildBottleDocument);
+    const documents = bottles.map(buildBottleDocument);
 
     if (documents.length > 0) {
       await bottlesIndex.addDocuments(documents, { primaryKey: 'id' });
@@ -301,6 +295,7 @@ async function searchBottles(query, {
   vintage,
   minRating,
   sort,
+  statusFilter = 'active',  // 'active' | 'consumed' | 'all'
   limit = 30,
   offset = 0
 } = {}) {
@@ -312,9 +307,14 @@ async function searchBottles(query, {
   const VALID_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
   const filters = [];
 
-  // Always scope to cellar and active bottles
+  // Scope to cellar
   if (cellarId) filters.push(`cellarId = "${cellarId}"`);
-  filters.push(`status NOT IN ["${CONSUMED_STATUSES.join('","')}"]`);
+  // Status filter: active (exclude consumed), consumed (only consumed), or all
+  if (statusFilter === 'active') {
+    filters.push(`status NOT IN ["${CONSUMED_STATUSES.join('","')}"]`);
+  } else if (statusFilter === 'consumed') {
+    filters.push(`status IN ["${CONSUMED_STATUSES.join('","')}"]`);
+  }
 
   // Type: single or comma-separated multi-select
   if (type) {

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -1,9 +1,10 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import RatingDisplay from '../components/RatingDisplay';
 import WineImage from '../components/WineImage';
+import BottleFilterModal from '../components/BottleFilterModal';
 import './CellarHistory.css';
 
 const REASON_CONFIG = {
@@ -22,20 +23,54 @@ function CellarHistory() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [total, setTotal] = useState(0);
-  const [search, setSearch] = useState('');
+  const [filters, setFilters] = useState({
+    search: '',
+    type: [], country: [], region: [], grapes: [], vintage: [],
+    minRating: '', maturity: ''
+  });
+  const [facets, setFacets] = useState(null);
+  const [baseFacets, setBaseFacets] = useState(null);
+  const [facetMeta, setFacetMeta] = useState(null);
+  const [showFilterModal, setShowFilterModal] = useState(false);
+
+  // Debounce search
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const searchTimer = useRef(null);
+  useEffect(() => {
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    searchTimer.current = setTimeout(() => setDebouncedSearch(filters.search), 350);
+    return () => clearTimeout(searchTimer.current);
+  }, [filters.search]);
+
+  // Serialize filters for dependency
+  const filterKey = [
+    debouncedSearch,
+    filters.type.join(','), filters.country.join(','), filters.region.join(','),
+    filters.grapes.join(','), filters.vintage.join(',')
+  ].join('|');
 
   useEffect(() => {
     fetchHistory();
-  }, [id, apiFetch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, filterKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchHistory = async () => {
     try {
-      const res = await apiFetch(`/api/cellars/${id}/history`);
+      const params = new URLSearchParams();
+      if (debouncedSearch) params.append('search', debouncedSearch);
+      Object.entries(filters).forEach(([key, val]) => {
+        if (key === 'search') return;
+        if (Array.isArray(val) && val.length > 0) params.append(key, val.join(','));
+      });
+      const qs = params.toString();
+      const res = await apiFetch(`/api/cellars/${id}/history${qs ? `?${qs}` : ''}`);
       const data = await res.json();
       if (!res.ok) { setError(data.error || 'Failed to load history'); return; }
 
       setCellar(data.cellar);
       setTotal(data.bottles.length);
+      if (data.facets) setFacets(data.facets);
+      if (data.baseFacets) setBaseFacets(data.baseFacets);
+      if (data.facetMeta) setFacetMeta(data.facetMeta);
 
       // Group by reason
       const groups = { drank: [], gifted: [], sold: [], other: [] };
@@ -61,6 +96,36 @@ function CellarHistory() {
     other:  'history.reasonOther',
   };
 
+  // Build active filter chips
+  const reverseMap = (map) => {
+    const rev = {};
+    if (map) Object.entries(map).forEach(([name, fid]) => { rev[fid] = name; });
+    return rev;
+  };
+  const countryNames = reverseMap(facetMeta?.countries);
+  const regionNames = reverseMap(facetMeta?.regions);
+  const grapeNames = reverseMap(facetMeta?.grapes);
+
+  const activeChips = [];
+  (filters.type || []).forEach(v => activeChips.push({ key: 'type', value: v, label: v.charAt(0).toUpperCase() + v.slice(1) }));
+  (filters.country || []).forEach(v => activeChips.push({ key: 'country', value: v, label: countryNames[v] || v }));
+  (filters.region || []).forEach(v => activeChips.push({ key: 'region', value: v, label: regionNames[v] || v }));
+  (filters.grapes || []).forEach(v => activeChips.push({ key: 'grapes', value: v, label: grapeNames[v] || v }));
+  (filters.vintage || []).forEach(v => activeChips.push({ key: 'vintage', value: v, label: v }));
+
+  const removeChip = (chip) => {
+    setFilters(prev => {
+      const val = prev[chip.key];
+      if (Array.isArray(val)) return { ...prev, [chip.key]: val.filter(v => v !== chip.value) };
+      return { ...prev, [chip.key]: '' };
+    });
+  };
+
+  const clearAll = () => setFilters(prev => ({
+    ...prev, type: [], country: [], region: [], grapes: [], vintage: [],
+    minRating: '', maturity: ''
+  }));
+
   return (
     <div className="cellar-history-page">
       <div className="history-header">
@@ -76,7 +141,7 @@ function CellarHistory() {
               {t('history.title')}
             </h1>
             <p className="page-subtitle">
-              {total === 0
+              {total === 0 && !activeChips.length
                 ? t('history.noHistory')
                 : t('history.bottleCount', { count: total })}
             </p>
@@ -89,7 +154,7 @@ function CellarHistory() {
       ) : <>
 
       {/* Summary row */}
-      {total > 0 && (
+      {total > 0 && !activeChips.length && (
         <div className="history-summary-row">
           {Object.entries(REASON_CONFIG).map(([key, cfg]) => {
             const count = grouped[key]?.length || 0;
@@ -104,46 +169,82 @@ function CellarHistory() {
         </div>
       )}
 
-      {/* Search */}
-      {total > 0 && (
-        <div className="history-search">
+      {/* Search + filter bar */}
+      <div className="search-row" style={{ margin: '1rem 0 0' }}>
+        <div className="history-search" style={{ flex: 1, margin: 0 }}>
           <svg className="history-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
           <input
             type="text"
             className="search-input"
-            placeholder={t('history.searchPlaceholder', 'Search by name, producer, or vintage…')}
-            value={search}
-            onChange={e => setSearch(e.target.value)}
+            placeholder={t('cellarDetail.searchPlaceholder')}
+            value={filters.search}
+            onChange={e => setFilters({ ...filters, search: e.target.value })}
           />
-          {search && (
-            <button className="history-search-clear" onClick={() => setSearch('')} aria-label={t('common.clear', 'Clear')}>
+          {filters.search && (
+            <button className="history-search-clear" onClick={() => setFilters({ ...filters, search: '' })} aria-label={t('common.clear', 'Clear')}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
             </button>
           )}
         </div>
+        <button
+          type="button"
+          className={`filter-toggle-btn${activeChips.length > 0 ? ' filter-toggle-btn--has-filters' : ''}`}
+          onClick={() => setShowFilterModal(true)}
+          aria-label={t('cellarDetail.toggleFilters')}
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path d="M2 4h16M5 10h10M8 16h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+          </svg>
+          {activeChips.length > 0 && (
+            <span className="filter-badge">{activeChips.length}</span>
+          )}
+        </button>
+      </div>
+
+      {/* Active filter chips */}
+      {activeChips.length > 0 && (
+        <div className="active-filters-row">
+          {activeChips.map((chip, i) => (
+            <span key={`${chip.key}-${chip.value}-${i}`} className="active-filter-chip">
+              {chip.label}
+              <button type="button" className="active-filter-chip-remove" onClick={() => removeChip(chip)} aria-label={`Remove ${chip.label}`}>×</button>
+            </span>
+          ))}
+          <button type="button" className="active-filters-clear" onClick={clearAll}>
+            {t('cellarDetail.clearAllFilters')}
+          </button>
+        </div>
       )}
 
-      {total === 0 && (
+      {showFilterModal && (
+        <BottleFilterModal
+          filters={filters}
+          onApply={setFilters}
+          onClose={() => setShowFilterModal(false)}
+          facets={facets}
+          baseFacets={baseFacets}
+          facetMeta={facetMeta}
+          bottlesTotal={total}
+        />
+      )}
+
+      {total === 0 && !activeChips.length && (
         <div className="empty-state">
           <p>{t('history.emptyHistoryHint')}</p>
           <Link to={`/cellars/${id}`} className="btn btn-primary">{t('history.backToCellarBtn')}</Link>
         </div>
       )}
 
-      {(() => {
-        const q = search.toLowerCase().trim();
-        const matchesSearch = (bottle) => {
-          if (!q) return true;
-          const wine = bottle.wineDefinition;
-          const name = (wine?.name || '').toLowerCase();
-          const producer = (wine?.producer || '').toLowerCase();
-          const vintage = String(bottle.vintage || '').toLowerCase();
-          return name.includes(q) || producer.includes(q) || vintage.includes(q);
-        };
+      {total === 0 && activeChips.length > 0 && (
+        <div className="empty-state">
+          <p>{t('cellarDetail.noSearchResults')}</p>
+        </div>
+      )}
 
+      {(() => {
         let anyVisible = false;
         const sections = Object.entries(REASON_CONFIG).map(([key, cfg]) => {
-          const items = (grouped[key] || []).filter(matchesSearch);
+          const items = grouped[key] || [];
           if (items.length === 0) return null;
           anyVisible = true;
           return (
@@ -161,7 +262,7 @@ function CellarHistory() {
           );
         });
 
-        if (q && !anyVisible) {
+        if (filters.search && !anyVisible && total > 0) {
           return <p className="history-no-results">{t('history.noResults', 'No bottles match your search.')}</p>;
         }
         return sections;


### PR DESCRIPTION
## Summary
- Keep consumed bottles in Meilisearch index for typo-tolerant history search
- Add search + filter query params to `GET /api/cellars/:id/history`
- Add filter modal with pill selectors, active filter chips, and debounced search to the history page
- Same UX as the cellar bottles tab: multi-select, cascading facets, "Show more/less"
- `searchBottles()` now accepts `statusFilter` param (`active` / `consumed` / `all`)

## Test plan
- [ ] History page shows search bar + filter button
- [ ] Search works with typo tolerance (e.g. "pino" finds Pinot Noir)
- [ ] Filter modal shows pills for type, country, region, grapes, vintage
- [ ] Multi-select works within categories
- [ ] Active filter chips appear with × to remove
- [ ] Bottles still grouped by reason (drank/gifted/sold/other)

🤖 Generated with [Claude Code](https://claude.com/claude-code)