### PR TITLE
Add consumed bottle rating and fix history search layout

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -78,7 +78,7 @@ app.use(helmet({
 
 // Middleware
 app.use(compression());
-app.use(cookieParser()); // lgtm[js/missing-token-validation] — auth uses JWT Bearer tokens, not cookies; CSRF does not apply
+app.use(cookieParser());
 // Stripe webhook needs the raw body for signature verification — must be before express.json()
 app.use('/api/stripe/webhook', express.raw({ type: 'application/json' }));
 // Routes that accept base64 images need a larger body limit

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -316,6 +316,43 @@ router.put('/:id', requireBottleAccess('editor'), async (req, res) => {
   }
 });
 
+// PUT /api/bottles/:id/consumed-rating - Set or update rating on a consumed bottle
+router.put('/:id/consumed-rating', requireBottleAccess('editor'), async (req, res) => {
+  try {
+    const { bottle } = req;
+    if (!CONSUMED_STATUSES.includes(bottle.status)) {
+      return res.status(400).json({ error: 'Bottle is not consumed' });
+    }
+
+    const { rating, ratingScale, note } = req.body;
+
+    if (rating !== undefined) {
+      const { rating: resolved, ratingScale: resolvedScale, error: ratingError } = resolveRating(rating, ratingScale);
+      if (ratingError) return res.status(400).json({ error: ratingError });
+      bottle.consumedRating = resolved;
+      bottle.consumedRatingScale = resolvedScale;
+    }
+
+    if (note !== undefined) {
+      if (note.length > 1000) return res.status(400).json({ error: 'Note is too long (max 1000 characters)' });
+      bottle.consumedNote = stripHtml(note);
+    }
+
+    await bottle.save();
+    await bottle.populate(WINE_POPULATE);
+
+    logAudit(req, 'bottle.update',
+      { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
+      { changes: { consumedRating: rating, consumedNote: note !== undefined } }
+    );
+
+    res.json({ bottle });
+  } catch (error) {
+    console.error('Update consumed rating error:', error);
+    res.status(500).json({ error: 'Failed to update consumed rating' });
+  }
+});
+
 // PUT /api/bottles/:id/default-image - Set the user's preferred default image for this bottle
 router.put('/:id/default-image', requireBottleAccess('editor'), async (req, res) => {
   try {

--- a/frontend/src/api/bottles.js
+++ b/frontend/src/api/bottles.js
@@ -17,6 +17,13 @@ export const consumeBottle = (apiFetch, id, data) =>
     body: JSON.stringify(data),
   });
 
+export const updateConsumedRating = (apiFetch, id, data) =>
+  apiFetch(`/api/bottles/${id}/consumed-rating`, {
+    method: 'PUT',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(data),
+  });
+
 export const setBottleDefaultImage = (apiFetch, id, imageId) =>
   apiFetch(`/api/bottles/${id}/default-image`, {
     method: 'PUT',

--- a/frontend/src/components/bottle/ConsumedDetails.js
+++ b/frontend/src/components/bottle/ConsumedDetails.js
@@ -1,17 +1,45 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
+import { updateConsumedRating } from '../../api/bottles';
 import RatingDisplay from '../RatingDisplay';
+import RatingInput from '../RatingInput';
 
 const CONSUMED_REASON_ICONS = { drank: '\u{1F377}', gifted: '\u{1F381}', sold: '\u{1F4B0}', other: '\u{1F4E6}' };
 
-function ConsumedDetails({ bottle }) {
+function ConsumedDetails({ bottle, canEdit, onUpdate }) {
   const { t } = useTranslation();
-  const { user } = useAuth();
+  const { user, apiFetch } = useAuth();
   const reason = bottle.consumedReason || bottle.status;
   const icon = CONSUMED_REASON_ICONS[reason] || '\u{1F4E6}';
   const consumedDate = bottle.consumedAt
     ? new Date(bottle.consumedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
     : null;
+
+  const [editing, setEditing] = useState(false);
+  const [rating, setRating] = useState(bottle.consumedRating || null);
+  const [ratingScale, setRatingScale] = useState(bottle.consumedRatingScale || user?.preferences?.ratingScale || '5');
+  const [note, setNote] = useState(bottle.consumedNote || '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await updateConsumedRating(apiFetch, bottle._id, {
+        rating, ratingScale, note
+      });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error || 'Failed to save'); setSaving(false); return; }
+      setEditing(false);
+      if (onUpdate) onUpdate(data.bottle);
+    } catch {
+      setError('Network error');
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <div className={`bd-consumed card bd-consumed--${reason}`}>
@@ -22,14 +50,64 @@ function ConsumedDetails({ bottle }) {
         </span>
         {consumedDate && <span className="bd-consumed__date">{consumedDate}</span>}
       </div>
-      {bottle.consumedRating && (
+
+      {!editing && bottle.consumedRating && (
         <div className="bd-consumed__rating">
           <span className="bd-detail-label">{t('history.atConsumption', 'Rating at consumption')}</span>
-          <RatingDisplay value={bottle.consumedRating} scale={bottle.consumedRatingScale || '5'} preferredScale={user?.preferences?.ratingScale} />
+          <div className="bd-consumed__rating-row">
+            <RatingDisplay value={bottle.consumedRating} scale={bottle.consumedRatingScale || '5'} preferredScale={user?.preferences?.ratingScale} />
+            {canEdit && (
+              <button type="button" className="bd-consumed__edit-btn" onClick={() => setEditing(true)}>
+                {t('common.edit', 'Edit')}
+              </button>
+            )}
+          </div>
         </div>
       )}
-      {bottle.consumedNote && (
+
+      {!editing && !bottle.consumedRating && canEdit && (
+        <button type="button" className="bd-consumed__rate-btn" onClick={() => setEditing(true)}>
+          {t('history.rateThisBottle', 'Rate this bottle')}
+        </button>
+      )}
+
+      {!editing && bottle.consumedNote && (
         <p className="bd-consumed__note">"{bottle.consumedNote}"</p>
+      )}
+
+      {editing && (
+        <div className="bd-consumed__edit-form">
+          <div className="bd-consumed__edit-field">
+            <label className="bd-detail-label">{t('history.atConsumption', 'Rating at consumption')}</label>
+            <RatingInput
+              value={rating}
+              scale={ratingScale}
+              onChange={setRating}
+              onScaleChange={setRatingScale}
+              allowScaleOverride
+            />
+          </div>
+          <div className="bd-consumed__edit-field">
+            <label className="bd-detail-label">{t('history.tastingNote', 'Tasting note')}</label>
+            <textarea
+              className="bd-consumed__note-input"
+              value={note}
+              onChange={e => setNote(e.target.value)}
+              placeholder={t('history.tastingNotePlaceholder', 'How was the wine?')}
+              rows={3}
+              maxLength={1000}
+            />
+          </div>
+          {error && <p className="bd-consumed__error">{error}</p>}
+          <div className="bd-consumed__edit-actions">
+            <button type="button" className="btn btn-secondary" onClick={() => setEditing(false)} disabled={saving}>
+              {t('common.cancel', 'Cancel')}
+            </button>
+            <button type="button" className="btn btn-primary" onClick={handleSave} disabled={saving}>
+              {saving ? t('common.saving', 'Saving…') : t('common.save', 'Save')}
+            </button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -529,6 +529,9 @@
     "vintageLabel": "Vintage:",
     "paidLabel": "Paid:",
     "atConsumption": "at consumption",
+    "rateThisBottle": "Rate this bottle",
+    "tastingNote": "Tasting note",
+    "tastingNotePlaceholder": "How was the wine?",
     "loadingHistory": "Loading history..."
   },
 

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -529,6 +529,9 @@
     "vintageLabel": "Årgång:",
     "paidLabel": "Betalt:",
     "atConsumption": "vid drickning",
+    "rateThisBottle": "Betygsätt denna flaska",
+    "tastingNote": "Smaknotering",
+    "tastingNotePlaceholder": "Hur var vinet?",
     "loadingHistory": "Laddar historik..."
   },
 

--- a/frontend/src/pages/BottleDetail.css
+++ b/frontend/src/pages/BottleDetail.css
@@ -1053,3 +1053,81 @@
   font-size: 0.9rem;
 }
 
+.bd-consumed__rating-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.bd-consumed__edit-btn {
+  border: none;
+  background: transparent;
+  color: var(--color-primary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0.2rem 0.4rem;
+}
+
+.bd-consumed__edit-btn:hover {
+  text-decoration: underline;
+}
+
+.bd-consumed__rate-btn {
+  margin-top: 0.75rem;
+  padding: 0.5rem 1rem;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-primary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.bd-consumed__rate-btn:hover {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.bd-consumed__edit-form {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bd-consumed__edit-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.bd-consumed__note-input {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--color-input-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-input-bg);
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.bd-consumed__note-input:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+  box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.08);
+}
+
+.bd-consumed__error {
+  color: var(--color-danger);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.bd-consumed__edit-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -236,6 +236,7 @@ function BottleDetail() {
   const displayProducer = wine?.producer || bottle?.pendingWineRequest?.producer;
   const isConsumed = bottle?.status && bottle.status !== 'active';
   const canEdit = !isConsumed && (userRole === 'owner' || userRole === 'editor');
+  const canEditConsumed = isConsumed && (userRole === 'owner' || userRole === 'editor');
 
   return (
     <div className="bottle-detail-page">
@@ -315,7 +316,7 @@ function BottleDetail() {
 
       {/* ── Consumption details (history bottles only) ── */}
       {isConsumed && (
-        <ConsumedDetails bottle={bottle} />
+        <ConsumedDetails bottle={bottle} canEdit={canEditConsumed} onUpdate={setBottle} />
       )}
 
       {/* Bottle details or edit form */}

--- a/frontend/src/pages/CellarHistory.css
+++ b/frontend/src/pages/CellarHistory.css
@@ -58,41 +58,13 @@
   font-size: 1.1rem;
 }
 
-/* ── Search ── */
-.history-search {
-  position: relative;
-  display: flex;
-  align-items: center;
-  margin-bottom: 1.5rem;
+/* ── Search row — reuses .search-row from CellarDetail ── */
+.history-search-row {
+  margin: 1rem 0 0.5rem;
 }
 
-.history-search .search-input {
-  padding-left: 2.25rem;
-  padding-right: 2.25rem;
-  width: 100%;
-}
-
-.history-search-icon {
-  position: absolute;
-  left: 0.75rem;
-  color: var(--color-text-muted);
-  pointer-events: none;
-}
-
-.history-search-clear {
-  position: absolute;
-  right: 0.5rem;
-  background: none;
-  border: none;
-  padding: 0.25rem;
-  cursor: pointer;
-  color: var(--color-text-muted);
-  display: flex;
-  align-items: center;
-}
-
-.history-search-clear:hover {
-  color: var(--color-text);
+.history-search-row .search-input {
+  flex: 1;
 }
 
 .history-no-results {

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -169,23 +169,16 @@ function CellarHistory() {
         </div>
       )}
 
-      {/* Search + filter bar */}
-      <div className="search-row" style={{ margin: '1rem 0 0' }}>
-        <div className="history-search" style={{ flex: 1, margin: 0 }}>
-          <svg className="history-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-          <input
-            type="text"
-            className="search-input"
-            placeholder={t('cellarDetail.searchPlaceholder')}
-            value={filters.search}
-            onChange={e => setFilters({ ...filters, search: e.target.value })}
-          />
-          {filters.search && (
-            <button className="history-search-clear" onClick={() => setFilters({ ...filters, search: '' })} aria-label={t('common.clear', 'Clear')}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-            </button>
-          )}
-        </div>
+      {/* Search + filter bar — same layout as cellar bottles tab */}
+      <div className="search-row history-search-row">
+        <input
+          type="text"
+          className="search-input"
+          placeholder={t('cellarDetail.searchPlaceholder')}
+          value={filters.search}
+          onChange={e => setFilters({ ...filters, search: e.target.value })}
+          aria-label={t('cellarDetail.searchPlaceholder')}
+        />
         <button
           type="button"
           className={`filter-toggle-btn${activeChips.length > 0 ? ' filter-toggle-btn--has-filters' : ''}`}


### PR DESCRIPTION
## Summary
- New `PUT /api/bottles/:id/consumed-rating` endpoint to set/update rating on consumed bottles
- "Rate this bottle" dashed button shown on consumed bottles without a rating
- Edit button on existing consumed ratings to update them
- Inline form with RatingInput (supports all scales) + tasting note textarea
- Fix history page search bar layout to match cellar page (was broken with misaligned filter button)

## Test plan
- [ ] Navigate to a consumed bottle without a rating → "Rate this bottle" button visible
- [ ] Click it → rating input + note textarea appear
- [ ] Save a rating → displayed inline, "Edit" link appears
- [ ] Edit an existing consumed rating → updates correctly
- [ ] History page search bar + filter button aligned correctly on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)