### PR TITLE
Remove dead planConfig code from cellar sharing

### DIFF
--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -940,20 +940,6 @@ router.post('/:id/members', async (req, res) => {
     cellar.members.push({ user: userToAdd._id, role });
     await cellar.save();
 
-    // Re-check member count after save to catch race conditions
-    if (planConfig.maxSharesPerCellar !== -1) {
-      const freshCellar = await Cellar.findById(cellar._id).select('members').lean();
-      if (freshCellar.members.length > planConfig.maxSharesPerCellar) {
-        await Cellar.updateOne({ _id: cellar._id }, { $pull: { members: { user: userToAdd._id } } });
-        return res.status(403).json({
-          error: `Your ${req.user.plan} plan allows a maximum of ${planConfig.maxSharesPerCellar} shared member${planConfig.maxSharesPerCellar === 1 ? '' : 's'} per cellar.`,
-          limitReached: 'shares',
-          limit: planConfig.maxSharesPerCellar,
-          currentPlan: req.user.plan,
-        });
-      }
-    }
-
     const sharingUser = await User.findById(req.user.id).select('username').lean();
     createNotification(
       userToAdd._id,


### PR DESCRIPTION
## Summary
- Remove unreachable `planConfig` block in the cellar member-sharing endpoint
- `planConfig` was never imported, so the post-save member limit check would crash with a `ReferenceError` if reached
- All plans now have unlimited shared members, so this race-condition guard is no longer needed

## Test plan
- [ ] Verify sharing a cellar with a new member still works
- [ ] Verify no `planConfig` references remain in `cellars.js`