### PR TITLE
Add missing search and filter styles for cellar history

### DIFF
--- a/frontend/src/pages/CellarHistory.css
+++ b/frontend/src/pages/CellarHistory.css
@@ -58,13 +58,128 @@
   font-size: 1.1rem;
 }
 
-/* ── Search row — reuses .search-row from CellarDetail ── */
+/* ── Search + filter bar (shared pattern with CellarDetail) ── */
 .history-search-row {
+  display: flex;
+  gap: 0.5rem;
   margin: 1rem 0 0.5rem;
 }
 
 .history-search-row .search-input {
   flex: 1;
+  padding: 0.75rem;
+  border: 1px solid var(--color-input-border);
+  border-radius: var(--radius-sm);
+  font-size: 16px;
+  min-height: 44px;
+  background: var(--color-input-bg);
+  color: var(--color-text);
+  transition: border-color var(--transition-fast);
+}
+
+.history-search-row .search-input:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+  box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.08);
+}
+
+.history-search-row .filter-toggle-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 44px;
+  min-height: 44px;
+  border: 1px solid var(--color-input-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-input-bg);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.history-search-row .filter-toggle-btn:hover {
+  border-color: var(--color-border-focus);
+  color: var(--color-text);
+}
+
+.history-search-row .filter-toggle-btn--has-filters {
+  color: var(--color-primary);
+}
+
+.history-search-row .filter-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 16px;
+  height: 16px;
+  border-radius: var(--radius-full);
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 3px;
+}
+
+/* ── Active filter chips ── */
+.cellar-history-page .active-filters-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0 0 0.5rem;
+}
+
+.cellar-history-page .active-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-full);
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+  font-size: 0.8rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.cellar-history-page .active-filter-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-primary);
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cellar-history-page .active-filter-chip-remove:hover {
+  background: rgba(var(--color-primary-rgb), 0.15);
+}
+
+.cellar-history-page .active-filters-clear {
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.cellar-history-page .active-filters-clear:hover {
+  color: var(--color-text);
 }
 
 .history-no-results {


### PR DESCRIPTION
## Summary
- Add CSS for search bar layout, filter toggle button, active filter chips, and clear button on the cellar history page
- These styles were part of the search/filter feature (#296) but weren't committed

## Test plan
- [ ] Verify history page search bar renders correctly
- [ ] Verify filter toggle button and active filter chips are styled properly