### PR TITLE
Complete GDPR compliance: deletion job, data export, cascades

### DIFF
--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -36,5 +36,6 @@ const notificationSchema = new mongoose.Schema({
 });
 
 notificationSchema.index({ user: 1, createdAt: -1 });
+notificationSchema.index({ createdAt: 1 }, { expireAfterSeconds: 90 * 24 * 60 * 60 }); // 90-day TTL
 
 module.exports = mongoose.model('Notification', notificationSchema);

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -18,6 +18,15 @@ const PushSubscription = require('../models/PushSubscription');
 const CellarValueSnapshot = require('../models/CellarValueSnapshot');
 const WineList = require('../models/WineList');
 const PendingShare = require('../models/PendingShare');
+const Discussion = require('../models/Discussion');
+const DiscussionReply = require('../models/DiscussionReply');
+const DiscussionReplyVote = require('../models/DiscussionReplyVote');
+const DiscussionReport = require('../models/DiscussionReport');
+const ChatUsage = require('../models/ChatUsage');
+const ImportSession = require('../models/ImportSession');
+const SupportTicket = require('../models/SupportTicket');
+const WineReport = require('../models/WineReport');
+const WishlistItem = require('../models/WishlistItem');
 const { requireAuth, requireRole } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const { stripHtml } = require('../utils/sanitize');
@@ -342,10 +351,19 @@ router.get('/me/export', requireAuth, async (req, res) => {
     const user = await User.findById(userId);
     if (!user) return res.status(404).json({ error: 'User not found' });
 
-    const [bottles, cellars, racks, wineRequests, reviews, notifications, auditLogs, images, recommendationsSent, recommendationsReceived, journalEntries, restockAlerts, wineLists, pendingSharesSent] = await Promise.all([
+    const cellarIds = await Cellar.distinct('_id', { user: userId });
+
+    const [
+      bottles, cellars, racks, wineRequests, reviews, notifications, auditLogs,
+      images, recommendationsSent, recommendationsReceived, journalEntries,
+      restockAlerts, wineLists, pendingSharesSent,
+      discussions, discussionReplies, reviewVotes, discussionReplyVotes,
+      follows, chatUsage, importSessions, supportTickets,
+      discussionReports, wineReports, wishlistItems
+    ] = await Promise.all([
       Bottle.find({ user: userId }).lean(),
       Cellar.find({ $or: [{ user: userId }, { 'members.user': userId }], deletedAt: null }).lean(),
-      Rack.find({ cellar: { $in: await Cellar.distinct('_id', { user: userId }) }, deletedAt: null }).lean(),
+      Rack.find({ cellar: { $in: cellarIds }, deletedAt: null }).lean(),
       WineRequest.find({ user: userId }).lean(),
       Review.find({ author: userId }).lean(),
       Notification.find({ user: userId }).lean(),
@@ -356,7 +374,19 @@ router.get('/me/export', requireAuth, async (req, res) => {
       JournalEntry.find({ user: userId }).lean(),
       RestockAlert.find({ user: userId }).lean(),
       WineList.find({ user: userId }).select('name cellar structureMode branding layout createdAt updatedAt').lean(),
-      PendingShare.find({ invitedBy: userId }).populate('cellar', 'name').lean()
+      PendingShare.find({ invitedBy: userId }).populate('cellar', 'name').lean(),
+      Discussion.find({ author: userId }).select('title category body createdAt').lean(),
+      DiscussionReply.find({ author: userId }).select('discussion body createdAt').lean(),
+      ReviewVote.find({ user: userId }).select('review vote createdAt').lean(),
+      DiscussionReplyVote.find({ user: userId }).select('reply vote createdAt').lean(),
+      Follow.find({ $or: [{ follower: userId }, { following: userId }] })
+        .populate('follower', 'username').populate('following', 'username').lean(),
+      ChatUsage.find({ userId: userId }).select('date promptTokens completionTokens').lean(),
+      ImportSession.find({ user: userId }).select('cellar status rows createdAt').lean(),
+      SupportTicket.find({ user: userId }).select('category subject status createdAt').lean(),
+      DiscussionReport.find({ user: userId }).select('discussion reply reason createdAt').lean(),
+      WineReport.find({ user: userId }).select('wineDefinition reason status createdAt').lean(),
+      WishlistItem.find({ user: userId }).lean()
     ]);
 
     const exportData = {
@@ -443,7 +473,48 @@ router.get('/me/export', requireAuth, async (req, res) => {
         cellarName: ps.cellar?.name,
         role: ps.role,
         createdAt: ps.createdAt
-      }))
+      })),
+      discussions: discussions.map(d => ({
+        title: d.title,
+        category: d.category,
+        createdAt: d.createdAt
+      })),
+      discussionReplies: discussionReplies.map(r => ({
+        discussion: r.discussion,
+        createdAt: r.createdAt
+      })),
+      votes: {
+        reviews: reviewVotes.map(v => ({ review: v.review, vote: v.vote, createdAt: v.createdAt })),
+        discussionReplies: discussionReplyVotes.map(v => ({ reply: v.reply, vote: v.vote, createdAt: v.createdAt }))
+      },
+      social: {
+        following: follows.filter(f => f.follower?._id?.toString() === userId || f.follower?.toString() === userId)
+          .map(f => ({ username: f.following?.username, createdAt: f.createdAt })),
+        followers: follows.filter(f => f.following?._id?.toString() === userId || f.following?.toString() === userId)
+          .map(f => ({ username: f.follower?.username, createdAt: f.createdAt }))
+      },
+      chatUsage: chatUsage.map(c => ({
+        date: c.date,
+        promptTokens: c.promptTokens,
+        completionTokens: c.completionTokens
+      })),
+      importSessions: importSessions.map(s => ({
+        cellar: s.cellar,
+        status: s.status,
+        rowCount: s.rows?.length || 0,
+        createdAt: s.createdAt
+      })),
+      supportTickets: supportTickets.map(t => ({
+        category: t.category,
+        subject: t.subject,
+        status: t.status,
+        createdAt: t.createdAt
+      })),
+      reports: {
+        discussions: discussionReports.map(r => ({ reason: r.reason, createdAt: r.createdAt })),
+        wines: wineReports.map(r => ({ reason: r.reason, status: r.status, createdAt: r.createdAt }))
+      },
+      wishlist: wishlistItems
     };
 
     res.setHeader('Content-Disposition', `attachment; filename="cellarion-data-export-${user.username}.json"`);

--- a/backend/src/services/scheduler.js
+++ b/backend/src/services/scheduler.js
@@ -1,6 +1,7 @@
 const cron = require('node-cron');
 const { runDrinkWindowCheck } = require('./drinkWindowNotifier');
 const { runCellarValueSnapshots } = require('./cellarValueSnapshotJob');
+const { runUserDeletionJob } = require('./userDeletionJob');
 
 /**
  * Start all scheduled cron jobs.
@@ -27,7 +28,17 @@ function startScheduler() {
     }
   });
 
-  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC)');
+  // User account deletion: daily at 03:00 UTC (after 7-day cooling-off)
+  cron.schedule('0 3 * * *', async () => {
+    console.log('[scheduler] Running user deletion job…');
+    try {
+      await runUserDeletionJob();
+    } catch (err) {
+      console.error('[scheduler] User deletion job failed:', err);
+    }
+  });
+
+  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, user-deletion daily 03:00 UTC)');
 }
 
 module.exports = { startScheduler };

--- a/backend/src/services/userDeletionJob.js
+++ b/backend/src/services/userDeletionJob.js
@@ -1,0 +1,133 @@
+/**
+ * User deletion job — runs daily via the scheduler.
+ *
+ * Finds users whose 7-day cooling-off period has expired and permanently
+ * deletes their accounts along with all user-linked data across every model.
+ */
+const User = require('../models/User');
+const Bottle = require('../models/Bottle');
+const BottleImage = require('../models/BottleImage');
+const Cellar = require('../models/Cellar');
+const CellarLayout = require('../models/CellarLayout');
+const CellarValueSnapshot = require('../models/CellarValueSnapshot');
+const ChatUsage = require('../models/ChatUsage');
+const Discussion = require('../models/Discussion');
+const DiscussionReply = require('../models/DiscussionReply');
+const DiscussionReplyVote = require('../models/DiscussionReplyVote');
+const DiscussionReport = require('../models/DiscussionReport');
+const Follow = require('../models/Follow');
+const ImportSession = require('../models/ImportSession');
+const JournalEntry = require('../models/JournalEntry');
+const Notification = require('../models/Notification');
+const PendingShare = require('../models/PendingShare');
+const PriceTrackingSkip = require('../models/PriceTrackingSkip');
+const PushSubscription = require('../models/PushSubscription');
+const Rack = require('../models/Rack');
+const Recommendation = require('../models/Recommendation');
+const RestockAlert = require('../models/RestockAlert');
+const Review = require('../models/Review');
+const ReviewVote = require('../models/ReviewVote');
+const SupportTicket = require('../models/SupportTicket');
+const WineList = require('../models/WineList');
+const WineReport = require('../models/WineReport');
+const WineRequest = require('../models/WineRequest');
+const WineVintagePrice = require('../models/WineVintagePrice');
+const WineVintageProfile = require('../models/WineVintageProfile');
+const WishlistItem = require('../models/WishlistItem');
+const AuditLog = require('../models/AuditLog');
+const BlogPost = require('../models/BlogPost');
+
+/**
+ * Delete all data linked to a single user.
+ * Called after the 7-day cooling-off period has expired.
+ */
+async function purgeUserData(userId, userEmail) {
+  // Get cellar IDs for cascade cleanup
+  const cellarIds = await Cellar.distinct('_id', { user: userId });
+
+  await Promise.all([
+    // Core wine data
+    Bottle.deleteMany({ user: userId }),
+    BottleImage.deleteMany({ uploadedBy: userId }),
+    Cellar.deleteMany({ user: userId }),
+    Rack.deleteMany({ cellar: { $in: cellarIds } }),
+    CellarLayout.deleteMany({ cellar: { $in: cellarIds } }),
+    WineList.deleteMany({ user: userId }),
+    WishlistItem.deleteMany({ user: userId }),
+
+    // Social & engagement
+    Discussion.deleteMany({ author: userId }),
+    DiscussionReply.deleteMany({ author: userId }),
+    DiscussionReplyVote.deleteMany({ user: userId }),
+    ReviewVote.deleteMany({ user: userId }),
+    Review.deleteMany({ author: userId }),
+    Follow.deleteMany({ $or: [{ follower: userId }, { following: userId }] }),
+    Recommendation.deleteMany({ $or: [{ sender: userId }, { recipient: userId }] }),
+
+    // Journal & alerts
+    JournalEntry.deleteMany({ user: userId }),
+    RestockAlert.deleteMany({ user: userId }),
+    Notification.deleteMany({ user: userId }),
+
+    // Requests & reports
+    WineRequest.deleteMany({ user: userId }),
+    WineReport.deleteMany({ user: userId }),
+    DiscussionReport.deleteMany({ user: userId }),
+    SupportTicket.deleteMany({ user: userId }),
+
+    // Import & usage
+    ImportSession.deleteMany({ user: userId }),
+    ChatUsage.deleteMany({ userId: userId }),
+    PushSubscription.deleteMany({ user: userId }),
+    CellarValueSnapshot.deleteMany({ user: userId }),
+    PriceTrackingSkip.deleteMany({ skippedBy: userId }),
+
+    // Invites (sent and received by email)
+    PendingShare.deleteMany({ $or: [{ invitedBy: userId }, { email: userEmail }] }),
+
+    // Remove user from shared cellars
+    Cellar.updateMany(
+      { 'members.user': userId },
+      { $pull: { members: { user: userId } } }
+    ),
+
+    // Clear user references on somm-contributed data (preserve the data itself)
+    WineVintagePrice.updateMany({ setBy: userId }, { $unset: { setBy: '', sommNotes: '' } }),
+    WineVintageProfile.updateMany({ setBy: userId }, { $unset: { setBy: '', setAt: '' } }),
+
+    // Reassign blog posts to null author (preserve published content)
+    BlogPost.updateMany({ author: userId }, { $unset: { author: '' } }),
+
+    // Audit log — keep for compliance but anonymise actor
+    AuditLog.updateMany(
+      { 'actor.userId': userId },
+      { $set: { 'actor.userId': null, 'actor.ip': null } }
+    ),
+  ]);
+}
+
+async function runUserDeletionJob() {
+  const now = new Date();
+
+  const usersToDelete = await User.find({
+    deletionScheduledFor: { $lte: now, $ne: null }
+  }).select('_id email').lean();
+
+  if (usersToDelete.length === 0) return;
+
+  console.log(`[user-deletion] Processing ${usersToDelete.length} scheduled deletion(s)…`);
+
+  for (const user of usersToDelete) {
+    try {
+      await purgeUserData(user._id, user.email);
+      await User.deleteOne({ _id: user._id });
+      console.log(`[user-deletion] Deleted user ${user._id}`);
+    } catch (err) {
+      console.error(`[user-deletion] Failed to delete user ${user._id}:`, err);
+    }
+  }
+
+  console.log(`[user-deletion] Completed ${usersToDelete.length} deletion(s)`);
+}
+
+module.exports = { runUserDeletionJob, purgeUserData };


### PR DESCRIPTION
## Summary
- Adds a daily cron job (03:00 UTC) that executes scheduled account deletions after the 7-day cooling-off period, cascading cleanup across all 30+ user-linked models
- Completes the data export endpoint (`GET /api/users/me/export`) with 11 previously missing models: Discussion, DiscussionReply, ReviewVote, DiscussionReplyVote, Follow, ChatUsage, ImportSession, SupportTicket, DiscussionReport, WineReport, WishlistItem
- Adds a 90-day TTL index on the Notification model to prevent unbounded growth
- Anonymises audit logs on deletion (preserves compliance trail) and clears user references on somm-contributed data (preserves community content)

## Test plan
- [ ] Verify the scheduler registers the new user-deletion cron job on startup
- [ ] Create a test user, schedule deletion, set `deletionScheduledFor` to the past, and confirm the cron job purges all linked data
- [ ] Verify `GET /api/users/me/export` includes all new data sections (discussions, votes, follows, chatUsage, wishlist, etc.)
- [ ] Verify existing export sections still work correctly
- [ ] Confirm Notification TTL index is created on Mongo startup
- [ ] Smoke-test in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)