### PR TITLE
Add audit logging to racks, layout, chat, push, wine requests

### DIFF
--- a/backend/src/routes/cellarLayout.js
+++ b/backend/src/routes/cellarLayout.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { requireAuth } = require('../middleware/auth');
 const { requireCellarAccess } = require('../middleware/cellarAccess');
+const { logAudit } = require('../services/audit');
 const CellarLayout = require('../models/CellarLayout');
 const Rack = require('../models/Rack');
 
@@ -57,6 +58,7 @@ router.put('/', requireCellarAccess('editor'), async (req, res) => {
       { upsert: true, new: true, runValidators: true }
     );
 
+    logAudit(req, 'cellarLayout.update', { type: 'cellarLayout', id: layout._id });
     res.json({ layout });
   } catch (err) {
     console.error('Save cellar layout error:', err.message, err.errors ? JSON.stringify(err.errors) : '');

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -19,6 +19,7 @@ const aiConfig = require('../config/aiConfig');
 const ChatUsage = require('../models/ChatUsage');
 const User = require('../models/User');
 const { getPlanConfig } = require('../config/plans');
+const { logAudit } = require('../services/audit');
 
 const router = express.Router();
 
@@ -184,6 +185,7 @@ router.post('/', requireAuth, async (req, res) => {
       ).catch(err => console.warn('[chat] token tracking error:', err.message));
     }
 
+    logAudit(req, 'chat.query', { type: 'chat' });
     res.json({ ...result, used: usedBefore + 1, limit, period });
   } catch (err) {
     await ChatUsage.findOneAndUpdate(
@@ -231,6 +233,8 @@ router.post('/stream', requireAuth, async (req, res) => {
         { $inc: { inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens } }
       ).catch(err => console.warn('[chat] token tracking error:', err.message));
     }
+
+    logAudit(req, 'chat.query', { type: 'chat' });
   } catch (err) {
     // Refund the debit
     await ChatUsage.findOneAndUpdate(

--- a/backend/src/routes/pushSubscriptions.js
+++ b/backend/src/routes/pushSubscriptions.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const PushSubscription = require('../models/PushSubscription');
 const { requireAuth } = require('../middleware/auth');
+const { logAudit } = require('../services/audit');
 
 let webpush;
 const VAPID_CONFIGURED = !!(process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY);
@@ -81,6 +82,7 @@ router.post('/', async (req, res) => {
       { upsert: true, new: true }
     );
 
+    logAudit(req, 'pushSubscription.create', { type: 'pushSubscription' });
     res.json({ ok: true });
   } catch (err) {
     console.error('Save push subscription error:', err);
@@ -97,6 +99,7 @@ router.delete('/', async (req, res) => {
     }
 
     await PushSubscription.deleteOne({ user: req.user.id, endpoint: String(endpoint) });
+    logAudit(req, 'pushSubscription.delete', { type: 'pushSubscription' });
     res.json({ ok: true });
   } catch (err) {
     console.error('Delete push subscription error:', err);

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -9,6 +9,7 @@ const CellarLayout = require('../models/CellarLayout');
 const { getCellarRole } = require('../utils/cellarAccess');
 const { getMaxPosition } = require('../utils/rackGeometry');
 const searchService = require('../services/search');
+const { logAudit } = require('../services/audit');
 
 const router = express.Router();
 
@@ -93,6 +94,7 @@ router.post('/', requireCellarAccess('editor'), async (req, res) => {
     const rack = new Rack(rackData);
 
     await rack.save();
+    logAudit(req, 'rack.create', { type: 'rack', id: rack._id });
     res.status(201).json({ rack });
   } catch (err) {
     if (err.code === 11000) return res.status(409).json({ error: 'A rack with that name already exists in this cellar' });
@@ -156,6 +158,7 @@ router.put('/:id', async (req, res) => {
       populate: { path: 'wineDefinition', populate: ['country', 'region', 'grapes'] }
     });
 
+    logAudit(req, 'rack.update', { type: 'rack', id: rack._id });
     res.json({ rack });
   } catch (err) {
     if (err.code === 11000) return res.status(409).json({ error: 'A rack with that name already exists in this cellar' });
@@ -193,6 +196,7 @@ router.delete('/:id', async (req, res) => {
       { $pull: { rackPlacements: { rack: rack._id } } }
     );
 
+    logAudit(req, 'rack.delete', { type: 'rack', id: rack._id });
     res.json({ message: 'Rack deleted' });
   } catch (err) {
     console.error('Delete rack error:', err);
@@ -236,6 +240,7 @@ router.put('/:id/slots/:position', async (req, res) => {
       populate: { path: 'wineDefinition', populate: ['country', 'region', 'grapes'] }
     });
 
+    logAudit(req, 'rack.slot_assign', { type: 'rack', id: rack._id });
     res.json({ rack });
   } catch (err) {
     if (err.name === 'VersionError') {
@@ -283,6 +288,7 @@ router.post('/:id/slots/:position/consume', async (req, res) => {
       populate: { path: 'wineDefinition', populate: ['country', 'region', 'grapes'] }
     });
 
+    logAudit(req, 'rack.slot_consume', { type: 'rack', id: rack._id });
     res.json({ rack });
   } catch (err) {
     console.error('Consume slot error:', err);
@@ -313,6 +319,7 @@ router.delete('/:id/slots/:position', async (req, res) => {
       populate: { path: 'wineDefinition', populate: ['country', 'region', 'grapes'] }
     });
 
+    logAudit(req, 'rack.slot_clear', { type: 'rack', id: rack._id });
     res.json({ rack });
   } catch (err) {
     console.error('Clear slot error:', err);

--- a/backend/src/routes/wineRequests.js
+++ b/backend/src/routes/wineRequests.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { requireAuth } = require('../middleware/auth');
+const { logAudit } = require('../services/audit');
 const WineRequest = require('../models/WineRequest');
 const WineDefinition = require('../models/WineDefinition');
 
@@ -54,6 +55,7 @@ router.post('/', async (req, res) => {
         status: 'pending'
       });
       await wineRequest.save();
+      logAudit(req, 'wineRequest.create', { type: 'wineRequest', id: wineRequest._id });
       return res.status(201).json({ wineRequest });
     }
 
@@ -71,6 +73,7 @@ router.post('/', async (req, res) => {
       status: 'pending'
     });
     await wineRequest.save();
+    logAudit(req, 'wineRequest.create', { type: 'wineRequest', id: wineRequest._id });
     res.status(201).json({ wineRequest });
   } catch (error) {
     console.error('Create wine request error:', error);


### PR DESCRIPTION
## Summary
- Adds `logAudit()` calls to 5 route files that previously mutated data without audit trails
- Rack CRUD + slot operations (assign, consume, clear)
- Cellar layout updates
- Push subscription register/unregister
- Wine request creation
- AI chat queries (both streaming and non-streaming)

## Test plan
- [ ] Perform rack operations and verify AuditLog entries are created
- [ ] Update a cellar layout and verify audit entry
- [ ] Send a chat query and verify audit entry
- [ ] Run backend tests: `cd backend && npm test`
- [ ] Smoke-test in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)