### PR TITLE
Add missing indexes, TTLs, and defaults to data models

### DIFF
--- a/backend/src/models/CellarLayout.js
+++ b/backend/src/models/CellarLayout.js
@@ -22,7 +22,7 @@ const cellarLayoutSchema = new mongoose.Schema({
     depth:  { type: Number, default: 10, min: 2, max: 50 },
     height: { type: Number, default: 3,  min: 2, max: 10 },
   },
-  rackPlacements: [rackPlacementSchema],
+  rackPlacements: { type: [rackPlacementSchema], default: [] },
 }, { timestamps: true });
 
 module.exports = mongoose.model('CellarLayout', cellarLayoutSchema);

--- a/backend/src/models/DiscussionReplyVote.js
+++ b/backend/src/models/DiscussionReplyVote.js
@@ -20,5 +20,7 @@ const discussionReplyVoteSchema = new mongoose.Schema({
 
 // Prevent double-likes
 discussionReplyVoteSchema.index({ user: 1, reply: 1 }, { unique: true });
+// Allow efficient lookup of all votes by a user (GDPR export/deletion)
+discussionReplyVoteSchema.index({ user: 1 });
 
 module.exports = mongoose.model('DiscussionReplyVote', discussionReplyVoteSchema);

--- a/backend/src/models/ImportSession.js
+++ b/backend/src/models/ImportSession.js
@@ -33,4 +33,10 @@ const importSessionSchema = new mongoose.Schema({
   }
 }, { timestamps: true });
 
+// Auto-purge abandoned draft sessions after 7 days
+importSessionSchema.index({ updatedAt: 1 }, {
+  expireAfterSeconds: 7 * 24 * 60 * 60,
+  partialFilterExpression: { status: 'draft' }
+});
+
 module.exports = mongoose.model('ImportSession', importSessionSchema);

--- a/backend/src/models/ReviewVote.js
+++ b/backend/src/models/ReviewVote.js
@@ -20,5 +20,7 @@ const reviewVoteSchema = new mongoose.Schema({
 
 // Prevent double-likes
 reviewVoteSchema.index({ user: 1, review: 1 }, { unique: true });
+// Allow efficient lookup of all votes by a user (GDPR export/deletion)
+reviewVoteSchema.index({ user: 1 });
 
 module.exports = mongoose.model('ReviewVote', reviewVoteSchema);

--- a/backend/src/models/WineList.js
+++ b/backend/src/models/WineList.js
@@ -191,6 +191,7 @@ const wineListSchema = new mongoose.Schema({
 
 // Indexes
 wineListSchema.index({ user: 1, cellar: 1 });
+wineListSchema.index({ user: 1 });
 
 // Update timestamp on save
 wineListSchema.pre('save', function(next) {


### PR DESCRIPTION
## Summary
- Add single-field `user` index on ReviewVote, DiscussionReplyVote, and WineList for efficient GDPR export/deletion queries
- Add 7-day TTL on ImportSession draft documents to auto-purge abandoned imports
- Add `default: []` for CellarLayout.rackPlacements to prevent undefined array on new documents

## Test plan
- [ ] Verify indexes are created on MongoDB startup (check with `db.collection.getIndexes()`)
- [ ] Create a draft ImportSession and verify it auto-deletes after 7 days (or test with a shorter TTL)
- [ ] Create a new CellarLayout and verify `rackPlacements` defaults to `[]`
- [ ] Run backend tests: `cd backend && npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)