### PR TITLE
Add keyboard accessibility to clickable div elements

### DIFF
--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -568,7 +568,7 @@ function AddBottle() {
               {!aiResult && !aiSearching && wines.length > 0 && (
                 <div className="wines-list">
                   {wines.map(wine => (
-                    <div key={wine._id} className="wine-row" onClick={() => handleSelectWine(wine)}>
+                    <div key={wine._id} className="wine-row" onClick={() => handleSelectWine(wine)} role="button" tabIndex={0} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelectWine(wine); } }}>
                       <WineImage image={wine.image} alt={wine.name} className="wine-row-image" wrapClass="wine-row-img-wrap" credit={wine.imageCredit} creditClass="wine-row-credit" wineType={wine.type} placeholder="wine-row-placeholder" />
                       <div className="wine-info">
                         <h3>{wine.name}</h3>
@@ -590,7 +590,7 @@ function AddBottle() {
 
               {/* ── "Can't find your wine?" row — appears after search when no AI result is shown ── */}
               {!loading && search.trim() && !aiResult && !aiSearching && (
-                <div className="ai-search-row" onClick={!aiSearching ? handleAiIdentify : undefined}>
+                <div className="ai-search-row" onClick={!aiSearching ? handleAiIdentify : undefined} role="button" tabIndex={0} onKeyDown={e => { if ((e.key === 'Enter' || e.key === ' ') && !aiSearching) { e.preventDefault(); handleAiIdentify(); } }}>
                   <div className="ai-search-row-icon">
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                       <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -504,7 +504,7 @@ function AddToWishlist() {
               {!aiResult && !aiSearching && wines.length > 0 && (
                 <div className="wines-list">
                   {wines.map(wine => (
-                    <div key={wine._id} className="wine-row" onClick={() => handleSelectWine(wine)}>
+                    <div key={wine._id} className="wine-row" onClick={() => handleSelectWine(wine)} role="button" tabIndex={0} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelectWine(wine); } }}>
                       <WineImage image={wine.image} alt={wine.name} className="wine-row-image" wrapClass="wine-row-img-wrap" wineType={wine.type} placeholder="wine-row-placeholder" />
                       <div className="wine-info">
                         <h3>{wine.name}</h3>
@@ -526,7 +526,7 @@ function AddToWishlist() {
 
               {/* Can't find wine? */}
               {!loading && search.trim() && !aiResult && !aiSearching && (
-                <div className="ai-search-row" onClick={!aiSearching ? handleAiIdentify : undefined}>
+                <div className="ai-search-row" onClick={!aiSearching ? handleAiIdentify : undefined} role="button" tabIndex={0} onKeyDown={e => { if ((e.key === 'Enter' || e.key === ' ') && !aiSearching) { e.preventDefault(); handleAiIdentify(); } }}>
                   <div className="ai-search-row-icon">
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                       <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>

--- a/frontend/src/pages/SommMaturity.js
+++ b/frontend/src/pages/SommMaturity.js
@@ -217,7 +217,7 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
   return (
     <div className={`somm-card ${expanded ? 'expanded' : ''}`}>
       {/* ── Card header (click to expand) ── */}
-      <div className="somm-card-header" onClick={() => setExpanded(o => !o)}>
+      <div className="somm-card-header" role="button" tabIndex={0} onClick={() => setExpanded(o => !o)} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setExpanded(o => !o); } }}>
         <div className="somm-card-identity">
           <WineImage image={wine?.image} alt={wine?.name} className="somm-wine-thumb" wineType={wine?.type} placeholder="somm-wine-thumb-placeholder" />
           <div>

--- a/frontend/src/pages/SommPrices.js
+++ b/frontend/src/pages/SommPrices.js
@@ -201,7 +201,7 @@ function PriceCard({ item, defaultCurrency, userCurrency, rates, onSaved }) {
   return (
     <div className={`somm-card ${expanded ? 'expanded' : ''}`}>
       {/* ── Header ── */}
-      <div className="somm-card-header" onClick={() => setExpanded(o => !o)}>
+      <div className="somm-card-header" role="button" tabIndex={0} onClick={() => setExpanded(o => !o)} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setExpanded(o => !o); } }}>
         <div className="somm-card-identity">
           <WineImage image={wine?.image} alt={wine?.name} className="somm-wine-thumb" wineType={wine?.type} placeholder="somm-wine-thumb-placeholder" />
           <div>


### PR DESCRIPTION
## Summary
- Adds `role="button"`, `tabIndex={0}`, and `onKeyDown` handlers (Enter/Space) to interactive divs that were only reachable via mouse click
- SommMaturity.js and SommPrices.js: expandable card headers
- AddBottle.js and AddToWishlist.js: wine selection rows and AI search rows

## Test plan
- [ ] Navigate to Somm Maturity/Prices pages, Tab to card headers, press Enter/Space to expand
- [ ] Navigate to Add Bottle page, Tab to wine rows, press Enter/Space to select
- [ ] Navigate to Add to Wishlist page, same keyboard test
- [ ] Run frontend tests: `cd frontend && npm test -- --watchAll=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)