### PR TITLE
Extract shared escapeRegex() utility, remove 13 inline duplicates

### DIFF
--- a/backend/src/routes/admin/cellars.js
+++ b/backend/src/routes/admin/cellars.js
@@ -6,6 +6,7 @@ const Bottle = require('../../models/Bottle');
 const { logAudit } = require('../../services/audit');
 const { parsePagination } = require('../../utils/pagination');
 const { isValidId } = require('../../utils/validation');
+const { escapeRegex } = require('../../utils/sanitize');
 
 const router = express.Router();
 router.use(requireAuth, requireRole('admin'));
@@ -20,7 +21,7 @@ router.get('/deleted', async (req, res) => {
 
     const filter = { deletedAt: { $ne: null } };
     if (req.query.search) {
-      const escaped = req.query.search.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const escaped = escapeRegex(req.query.search.trim());
       filter.name = new RegExp(escaped, 'i');
     }
 

--- a/backend/src/routes/admin/users.js
+++ b/backend/src/routes/admin/users.js
@@ -5,6 +5,7 @@ const { PLAN_NAMES } = require('../../config/plans');
 const { logAudit } = require('../../services/audit');
 const { parsePagination } = require('../../utils/pagination');
 const { isValidId } = require('../../utils/validation');
+const { escapeRegex } = require('../../utils/sanitize');
 
 const router = express.Router();
 
@@ -22,7 +23,7 @@ router.get('/', async (req, res) => {
     const filter = {};
 
     if (typeof search === 'string' && search) {
-      const escaped = search.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const escaped = escapeRegex(search.trim());
       const re = new RegExp(escaped, 'i');
       filter.$or = [{ username: re }, { email: re }];
     }

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -22,11 +22,7 @@ const searchService = require('../../services/search');
 const { logAudit } = require('../../services/audit');
 const { submitUrls } = require('../../services/indexNow');
 const { isValidId } = require('../../utils/validation');
-
-// Escape special regex characters to prevent ReDoS / NoSQL injection
-function escapeRegex(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
+const { escapeRegex } = require('../../utils/sanitize');
 
 const router = express.Router();
 

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -23,7 +23,7 @@ const {
   MAX_IMPORT_SIZE,
   AI_CONCURRENCY,
 } = require('../config/constants');
-const { stripHtml } = require('../utils/sanitize');
+const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { extractAiExplanation } = require('../utils/jsonExtract');
 const { getMaxPosition } = require('../utils/rackGeometry');
 const { runConcurrent } = require('../utils/concurrency');
@@ -127,8 +127,8 @@ async function findWineMatches(item) {
 
     const directMatches = await WineDefinition.find({
       $or: [
-        { normalizedKey: { $regex: `^${normalizedProducer.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:` } },
-        { normalizedKey: { $regex: `:${normalizedName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:` } }
+        { normalizedKey: { $regex: `^${escapeRegex(normalizedProducer)}:` } },
+        { normalizedKey: { $regex: `:${escapeRegex(normalizedName)}:` } }
       ]
     })
       .populate(['country', 'region', 'grapes'])

--- a/backend/src/routes/journal.js
+++ b/backend/src/routes/journal.js
@@ -5,7 +5,7 @@ const Bottle = require('../models/Bottle');
 const WineDefinition = require('../models/WineDefinition');
 const { logAudit } = require('../services/audit');
 const { createNotification } = require('../services/notifications');
-const { stripHtml } = require('../utils/sanitize');
+const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { isValidId } = require('../utils/validation');
 
 const router = express.Router();
@@ -63,7 +63,7 @@ router.get('/wine-search', async (req, res) => {
     const q = String(req.query.q || '').trim();
     if (!q || q.length < 2) return res.json({ bottles: [], wines: [] });
 
-    const regex = new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    const regex = new RegExp(escapeRegex(q), 'i');
 
     // Search user's bottles (via wine definition name)
     const bottles = await Bottle.find({ user: req.user.id, status: 'active' })
@@ -117,7 +117,7 @@ router.get('/', async (req, res) => {
     }
 
     if (search) {
-      const regex = new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+      const regex = new RegExp(escapeRegex(search), 'i');
       query.$or = [
         { title: regex },
         { notes: regex },

--- a/backend/src/routes/recommendations.js
+++ b/backend/src/routes/recommendations.js
@@ -9,6 +9,7 @@ const { createNotification } = require('../services/notifications');
 const { sendRecommendationEmail, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
 const { parsePagination } = require('../utils/pagination');
 const { isValidId } = require('../utils/validation');
+const { escapeRegex } = require('../utils/sanitize');
 
 const router = express.Router();
 router.use(requireAuth);
@@ -232,7 +233,7 @@ router.get('/friends', async (req, res) => {
 
     const filter = { _id: { $in: followingIds } };
     if (q) {
-      const regex = new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+      const regex = new RegExp(escapeRegex(q), 'i');
       filter.$or = [{ username: regex }, { displayName: regex }];
     }
 

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -18,6 +18,7 @@ const aiConfig = require('../config/aiConfig');
 const aiChat = require('../services/aiChat');
 const { updateSiteConfig } = require('../utils/siteConfig');
 const { parsePagination } = require('../utils/pagination');
+const { escapeRegex } = require('../utils/sanitize');
 const { SYSTEM_PROMPT_MAX_LENGTH, SCAN_PROMPT_MAX_LENGTH } = require('../config/constants');
 
 const router = express.Router();
@@ -294,7 +295,7 @@ router.get('/audit', async (req, res) => {
     const { limit, offset } = parsePagination(req.query, { limit: 100, maxLimit: 500 });
     const filter = {};
     if (req.query.action) {
-      const escaped = req.query.action.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const escaped = escapeRegex(req.query.action);
       filter.action = new RegExp(escaped, 'i');
     }
 
@@ -325,7 +326,7 @@ router.get('/users', async (req, res) => {
     const filter = {};
 
     if (req.query.search) {
-      const escaped = req.query.search.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const escaped = escapeRegex(req.query.search.trim());
       const re = new RegExp(escaped, 'i');
       filter.$or = [{ username: re }, { email: re }];
     }

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -29,7 +29,7 @@ const WineReport = require('../models/WineReport');
 const WishlistItem = require('../models/WishlistItem');
 const { requireAuth, requireRole } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
-const { stripHtml } = require('../utils/sanitize');
+const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { isValidId } = require('../utils/validation');
 
 const router = express.Router();
@@ -236,7 +236,7 @@ router.get('/search', requireAuth, async (req, res) => {
       return res.status(400).json({ error: 'Search query must be at least 2 characters' });
     }
 
-    const regex = new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    const regex = new RegExp(escapeRegex(q), 'i');
     const users = await User.find({
       profileVisibility: 'public',
       $or: [{ username: regex }, { displayName: regex }]
@@ -316,7 +316,7 @@ router.get('/all', requireAuth, requireRole('admin'), async (req, res) => {
 
     const filter = {};
     if (search) {
-      const escaped = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const escaped = escapeRegex(search);
       filter.$or = [
         { username: { $regex: escaped, $options: 'i' } },
         { email: { $regex: escaped, $options: 'i' } }

--- a/backend/src/routes/wishlist.js
+++ b/backend/src/routes/wishlist.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { requireAuth } = require('../middleware/auth');
 const WishlistItem = require('../models/WishlistItem');
 const { logAudit } = require('../services/audit');
+const { escapeRegex } = require('../utils/sanitize');
 
 const router = express.Router();
 
@@ -90,7 +91,7 @@ router.get('/', async (req, res) => {
 
     // Free-text search on wine name or producer
     if (search && search.trim()) {
-      const escaped = search.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const escaped = escapeRegex(search.trim());
       pipeline.push({
         $match: {
           $or: [

--- a/backend/src/utils/sanitize.js
+++ b/backend/src/utils/sanitize.js
@@ -41,4 +41,12 @@ function isSafeUrl(url) {
   }
 }
 
-module.exports = { stripHtml, isSafeUrl };
+/**
+ * Escapes special regex characters in a user-supplied string so it can
+ * be safely used inside `new RegExp(...)` for literal matching.
+ */
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = { stripHtml, isSafeUrl, escapeRegex };


### PR DESCRIPTION
## Summary
- Adds `escapeRegex()` to `utils/sanitize.js` as a shared utility
- Replaces 13 identical inline regex escape patterns across 9 route files
- Removes the local `escapeRegex` function from `admin/wines.js` in favor of the shared one
- Reduces maintenance risk and ensures consistency

## Test plan
- [ ] Verify search functionality works across all pages that use regex search (wines, cellars, users, journal, wishlist, recommendations)
- [ ] Run backend tests: `cd backend && npm test`
- [ ] Smoke-test in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)