### PR TITLE
Use user's preferred rating scale as default in consume modal

### DIFF
--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -19,7 +19,7 @@ export default function CellarRoom() {
   const { t } = useTranslation();
   const { id } = useParams();
   const [searchParams] = useSearchParams();
-  const { apiFetch } = useAuth();
+  const { apiFetch, user } = useAuth();
   const focusRackId = searchParams.get('focusRack');
   const highlightBottleId = searchParams.get('highlight');
 
@@ -1178,6 +1178,7 @@ export default function CellarRoom() {
                 <RoomConsumeForm
                   onSubmit={handleConsumeSubmit}
                   onCancel={() => setConsumeModal(null)}
+                  defaultRatingScale={user?.preferences?.ratingScale}
                   t={t}
                 />
               </div>
@@ -1382,11 +1383,11 @@ export default function CellarRoom() {
   );
 }
 
-function RoomConsumeForm({ onSubmit, onCancel, t }) {
+function RoomConsumeForm({ onSubmit, onCancel, defaultRatingScale, t }) {
   const [reason, setReason] = useState('drank');
   const [note, setNote] = useState('');
   const [rating, setRating] = useState('');
-  const [ratingScale, setRatingScale] = useState('5');
+  const [ratingScale, setRatingScale] = useState(defaultRatingScale || '5');
   const [saving, setSaving] = useState(false);
 
   const handleSubmit = async (e) => {


### PR DESCRIPTION
## Summary
- The 3D room consume modal (RoomConsumeForm in CellarRoom.js) hardcoded the rating scale to `5` instead of reading the user's preference
- Now passes `user.preferences.ratingScale` from the auth context, consistent with BottleDetail and CellarRacks consume modals

## Test plan
- [ ] Set your rating preference to something other than 1-5 (e.g. 1-20) in Settings
- [ ] Consume a bottle from the 3D room view — verify the scale dropdown defaults to your preference
- [ ] Consume a bottle from the bottle detail page — verify same behavior (already worked)
- [ ] Run frontend tests: `cd frontend && npm test -- --watchAll=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)