### PR TITLE
Prevent browser caching of index.html after deploys

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -114,6 +114,12 @@ server {
         root       /usr/share/nginx/html;
         index      index.html;
         try_files  $uri $uri/ /index.html;
+
+        # index.html must never be cached — it references hashed JS/CSS
+        # bundles that change on every build
+        location = /index.html {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+        }
     }
 
     # Long-lived cache for hashed static assets


### PR DESCRIPTION
## Summary
- Adds `Cache-Control: no-cache, no-store, must-revalidate` header to `index.html`
- `index.html` references hashed JS/CSS bundles that change on every build — without this, browsers/proxies can serve stale HTML pointing to deleted bundles, causing 404s and a broken app after deploys

## Test plan
- [ ] Deploy, check `curl -I https://cellarion.app/` shows `Cache-Control: no-cache` header
- [ ] Deploy a new version and verify the app loads without needing a hard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)