### PR TITLE
Bump package.json versions to 1.46.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.42.5",
+  "version": "1.46.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.42.5",
+  "version": "1.46.1",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^10.7.7",


### PR DESCRIPTION
## Summary
- Updates version in both `backend/package.json` and `frontend/package.json` from `1.42.5` to `1.46.1`
- The version shown on the Settings page comes from `backend/package.json` via `/api/health` — it was stuck at 1.42.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)