### PR TITLE
Hotfix/stats map colours

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1050,7 +1050,7 @@
       "top5": "Top 5",
       "vintageDistribution": "Vintage Distribution",
       "collectionOrigins": "Collection Origins",
-      "darkerMoreBottles": "Lighter = more bottles",
+      "lighterMoreBottles": "Lighter = more bottles",
       "topGrapeVarieties": "Top Grape Varieties",
       "topRegions": "Top Regions",
       "topProducers": "Top Producers",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1050,7 +1050,7 @@
       "top5": "Top 5",
       "vintageDistribution": "Vintage Distribution",
       "collectionOrigins": "Collection Origins",
-      "darkerMoreBottles": "Darker = more bottles",
+      "darkerMoreBottles": "Lighter = more bottles",
       "topGrapeVarieties": "Top Grape Varieties",
       "topRegions": "Top Regions",
       "topProducers": "Top Producers",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1050,7 +1050,7 @@
       "top5": "Topp 5",
       "vintageDistribution": "Årgångsfördelning",
       "collectionOrigins": "Samlingens ursprung",
-      "darkerMoreBottles": "Mörkare = fler flaskor",
+      "darkerMoreBottles": "Ljusare = fler flaskor",
       "topGrapeVarieties": "Toppdruvsorter",
       "topRegions": "Toppregioner",
       "topProducers": "Toppproducenter",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1050,7 +1050,7 @@
       "top5": "Topp 5",
       "vintageDistribution": "Årgångsfördelning",
       "collectionOrigins": "Samlingens ursprung",
-      "darkerMoreBottles": "Ljusare = fler flaskor",
+      "lighterMoreBottles": "Ljusare = fler flaskor",
       "topGrapeVarieties": "Toppdruvsorter",
       "topRegions": "Toppregioner",
       "topProducers": "Toppproducenter",

--- a/frontend/src/pages/Statistics.css
+++ b/frontend/src/pages/Statistics.css
@@ -1982,7 +1982,7 @@
 
 .worldmap-info-hint {
   font-size: 0.78rem;
-  color: var(--color-border);
+  color: var(--color-input-placeholder);
   font-style: italic;
 }
 
@@ -2011,7 +2011,7 @@
 }
 
 .worldmap-legend-unit {
-  color: var(--color-border);
+  color: var(--color-input-placeholder);
 }
 
 .worldmap-legend-note {

--- a/frontend/src/pages/Statistics.js
+++ b/frontend/src/pages/Statistics.js
@@ -309,7 +309,7 @@ function Statistics() {
         <div className="stats-card stats-card--full stats-card--desktop-only">
           <h2 className="stats-card-title">
             {t('statistics.sections.collectionOrigins')}
-            <span className="stats-card-title-note">{t('statistics.sections.darkerMoreBottles')}</span>
+            <span className="stats-card-title-note">{t('statistics.sections.lighterMoreBottles')}</span>
           </h2>
           <WorldMapChart byCountry={byCountry} />
         </div>


### PR DESCRIPTION
- changed text from `darker` to `lighter` to reflect that higher quantities of bottles are represented by lighter colours on the map
- renamed the il8n keys to show that the text is now `lighter` and add translations
- changed colours on the stats map legend to allow the text to be more visible in both light and dark mode

<img width="1116" height="658" alt="Screenshot from 2026-04-14 21-30-58" src="https://github.com/user-attachments/assets/cb7ede34-3eb4-42ef-a930-db6c56696b26" />
<img width="1099" height="652" alt="Screenshot from 2026-04-14 21-31-05" src="https://github.com/user-attachments/assets/1c95e082-2f96-4d0e-adc2-2c7d3bd0194e" />
