### PR TITLE
Fix maturity classification for peak-only profiles

### DIFF
--- a/backend/src/utils/maturityUtils.js
+++ b/backend/src/utils/maturityUtils.js
@@ -17,11 +17,16 @@ function classifyMaturity(bottle, profileMap) {
   if (!profile || profile.status !== 'reviewed') return null;
 
   const { earlyFrom, earlyUntil, peakFrom, peakUntil, lateFrom, lateUntil } = profile;
-  if (!earlyFrom) return null;
+
+  // Need at least one window boundary to classify
+  if (!earlyFrom && !peakFrom && !peakUntil) return null;
 
   const currentYear = new Date().getFullYear();
 
-  if (currentYear < earlyFrom) return 'not-ready';
+  // Before the earliest defined window → not ready
+  const firstYear = earlyFrom || peakFrom;
+  if (firstYear && currentYear < firstYear) return 'not-ready';
+
   if (earlyUntil && currentYear <= earlyUntil) return 'early';
   if (peakFrom && currentYear < peakFrom) return 'early';
   if (peakUntil && currentYear <= peakUntil) return 'peak';
@@ -70,7 +75,7 @@ function maturityLabel(status, profile) {
   if (!status) return null;
   switch (status) {
     case 'not-ready':
-      return `Not ready yet — early drinking from ${profile?.earlyFrom || '?'}`;
+      return `Not ready yet — drinking from ${profile?.earlyFrom || profile?.peakFrom || '?'}`;
     case 'early':
       return profile?.peakFrom
         ? `Early drinking — peak from ${profile.peakFrom}`

--- a/backend/src/utils/maturityUtils.test.js
+++ b/backend/src/utils/maturityUtils.test.js
@@ -70,10 +70,53 @@ describe('classifyMaturity', () => {
     expect(classifyMaturity(bottle, new Map())).toBeNull();
   });
 
-  test('returns null when earlyFrom is missing', () => {
+  test('returns null when no window boundaries are set', () => {
     const bottle = makeBottle(2020);
-    const map = makeMap(2020, { status: 'reviewed', earlyFrom: null });
+    const map = makeMap(2020, { status: 'reviewed' });
     expect(classifyMaturity(bottle, map)).toBeNull();
+  });
+
+  // ── Peak-only profiles (no early window) ──────────────────────────────────
+
+  test('peak-only: returns "not-ready" when currentYear < peakFrom', () => {
+    // currentYear=2026, peakFrom=2028, peakUntil=2030
+    const bottle = makeBottle(2020);
+    const map = makeMap(2020, {
+      status: 'reviewed',
+      peakFrom: 2028, peakUntil: 2030,
+    });
+    expect(classifyMaturity(bottle, map)).toBe('not-ready');
+  });
+
+  test('peak-only: returns "peak" when in peak window', () => {
+    // currentYear=2026, peakFrom=2025, peakUntil=2028
+    const bottle = makeBottle(2020);
+    const map = makeMap(2020, {
+      status: 'reviewed',
+      peakFrom: 2025, peakUntil: 2028,
+    });
+    expect(classifyMaturity(bottle, map)).toBe('peak');
+  });
+
+  test('peak-only: returns "declining" when past peakUntil', () => {
+    // currentYear=2026, peakFrom=2020, peakUntil=2024
+    const bottle = makeBottle(2020);
+    const map = makeMap(2020, {
+      status: 'reviewed',
+      peakFrom: 2020, peakUntil: 2024,
+    });
+    expect(classifyMaturity(bottle, map)).toBe('declining');
+  });
+
+  test('peak-only with late: returns "late" when in late window', () => {
+    // currentYear=2026, peakFrom=2020, peakUntil=2024, lateFrom=2025, lateUntil=2028
+    const bottle = makeBottle(2020);
+    const map = makeMap(2020, {
+      status: 'reviewed',
+      peakFrom: 2020, peakUntil: 2024,
+      lateFrom: 2025, lateUntil: 2028,
+    });
+    expect(classifyMaturity(bottle, map)).toBe('late');
   });
 
   test('returns "not-ready" when currentYear < earlyFrom', () => {
@@ -208,15 +251,21 @@ describe('maturityLabel', () => {
     expect(maturityLabel(undefined)).toBeNull();
   });
 
-  test('returns correct string for "not-ready"', () => {
+  test('returns correct string for "not-ready" with earlyFrom', () => {
     const profile = { earlyFrom: 2028 };
     const label = maturityLabel('not-ready', profile);
-    expect(label).toBe('Not ready yet — early drinking from 2028');
+    expect(label).toBe('Not ready yet — drinking from 2028');
   });
 
-  test('returns correct string for "not-ready" with missing earlyFrom', () => {
+  test('returns correct string for "not-ready" with peakFrom only', () => {
+    const profile = { peakFrom: 2030 };
+    const label = maturityLabel('not-ready', profile);
+    expect(label).toBe('Not ready yet — drinking from 2030');
+  });
+
+  test('returns correct string for "not-ready" with missing windows', () => {
     const label = maturityLabel('not-ready', {});
-    expect(label).toBe('Not ready yet — early drinking from ?');
+    expect(label).toBe('Not ready yet — drinking from ?');
   });
 
   test('returns correct string for "early" with peakFrom', () => {
@@ -269,6 +318,6 @@ describe('maturityLabel', () => {
   test('handles null profile gracefully', () => {
     // Uses optional chaining: profile?.earlyFrom
     const label = maturityLabel('not-ready', null);
-    expect(label).toBe('Not ready yet — early drinking from ?');
+    expect(label).toBe('Not ready yet — drinking from ?');
   });
 });

--- a/frontend/src/pages/SommMaturity.js
+++ b/frontend/src/pages/SommMaturity.js
@@ -11,9 +11,12 @@ const CURRENT_YEAR = new Date().getFullYear();
 function getMaturityPhase(p) {
   if (!p || p.status !== 'reviewed') return null;
   const { earlyFrom, earlyUntil, peakFrom, peakUntil, lateFrom, lateUntil } = p;
-  if (!earlyFrom) return null;
 
-  if (CURRENT_YEAR < earlyFrom)                              return { cls: 'not-ready', label: `Not yet mature — from ${earlyFrom}` };
+  // Need at least one window boundary to classify
+  if (!earlyFrom && !peakFrom && !peakUntil) return null;
+
+  const firstYear = earlyFrom || peakFrom;
+  if (firstYear && CURRENT_YEAR < firstYear)                 return { cls: 'not-ready', label: `Not yet mature — from ${firstYear}` };
   if (earlyUntil && CURRENT_YEAR <= earlyUntil)              return { cls: 'early',     label: 'Early drinking' };
   if (peakFrom   && CURRENT_YEAR <  peakFrom)                return { cls: 'early',     label: `Early drinking — peak from ${peakFrom}` };
   if (peakUntil  && CURRENT_YEAR <= peakUntil)               return { cls: 'peak',      label: 'Optimal maturity ⭐' };

--- a/frontend/src/utils/drinkStatus.js
+++ b/frontend/src/utils/drinkStatus.js
@@ -7,9 +7,12 @@ const CURRENT_YEAR = new Date().getFullYear();
 export function getMaturityStatus(profile) {
   if (!profile || profile.status !== 'reviewed') return null;
   const { earlyFrom, earlyUntil, peakFrom, peakUntil, lateFrom, lateUntil } = profile;
-  if (!earlyFrom) return null;
 
-  if (CURRENT_YEAR < earlyFrom)                              return { status: 'not-ready', label: `Not yet mature — from ${earlyFrom}` };
+  // Need at least one window boundary to classify
+  if (!earlyFrom && !peakFrom && !peakUntil) return null;
+
+  const firstYear = earlyFrom || peakFrom;
+  if (firstYear && CURRENT_YEAR < firstYear)                 return { status: 'not-ready', label: `Not yet mature — from ${firstYear}` };
   if (earlyUntil && CURRENT_YEAR <= earlyUntil)              return { status: 'early',     label: 'Early drinking' };
   if (peakFrom   && CURRENT_YEAR <  peakFrom)                return { status: 'early',     label: `Early drinking — peak from ${peakFrom}` };
   if (peakUntil  && CURRENT_YEAR <= peakUntil)               return { status: 'peak',      label: 'Optimal maturity ⭐' };

--- a/frontend/src/utils/drinkStatus.test.js
+++ b/frontend/src/utils/drinkStatus.test.js
@@ -27,8 +27,35 @@ describe('getMaturityStatus', () => {
     expect(getMaturityStatus({ status: 'pending', earlyFrom: 2020 })).toBeNull();
   });
 
-  test('returns null when earlyFrom is missing', () => {
+  test('returns null when no window boundaries are set', () => {
     expect(getMaturityStatus({ status: 'reviewed' })).toBeNull();
+  });
+
+  test('peak-only: returns not-ready when current year is before peakFrom', () => {
+    const result = getMaturityStatus({
+      status: 'reviewed',
+      peakFrom: CURRENT_YEAR + 2,
+      peakUntil: CURRENT_YEAR + 5,
+    });
+    expect(result.status).toBe('not-ready');
+  });
+
+  test('peak-only: returns peak when in peak window', () => {
+    const result = getMaturityStatus({
+      status: 'reviewed',
+      peakFrom: CURRENT_YEAR - 1,
+      peakUntil: CURRENT_YEAR + 3,
+    });
+    expect(result.status).toBe('peak');
+  });
+
+  test('peak-only: returns declining when past peakUntil', () => {
+    const result = getMaturityStatus({
+      status: 'reviewed',
+      peakFrom: CURRENT_YEAR - 5,
+      peakUntil: CURRENT_YEAR - 2,
+    });
+    expect(result.status).toBe('declining');
   });
 
   test('returns not-ready when current year is before earlyFrom', () => {


### PR DESCRIPTION
Closes #317

## Summary

- Maturity classification (`classifyMaturity` on backend, `getMaturityStatus` on frontend) previously required `earlyFrom` to be set — profiles with only a peak window (e.g. `peakFrom: 2026, peakUntil: 2028`) were skipped entirely and excluded from the cellar health score
- Now requires only **one** window boundary (`earlyFrom`, `peakFrom`, or `peakUntil`) to classify a bottle
- For peak-only profiles: before `peakFrom` → "not-ready", within peak → "peak", after `peakUntil` → "declining"
- Updated `maturityLabel` to show `peakFrom` as fallback when `earlyFrom` is missing

## Files changed

- `backend/src/utils/maturityUtils.js` — relaxed guard, use first available year for "not-ready"
- `frontend/src/utils/drinkStatus.js` — same logic change on frontend
- Both test files updated with peak-only profile scenarios (all pass)

## Test plan

- [x] Backend maturity tests pass (35/35)
- [x] Frontend drinkStatus tests pass (13/13)
- [ ] Smoke-test in Docker with a peak-only WineVintageProfile and verify it appears in cellar health score

@TheRealOwenRees — with this change, your profile (`peakFrom: 2026, peakUntil: 2028`, no early/late) would classify as **"not-ready"** right now (2026 hasn't started for the classification yet, though depending on when you test it may show **"peak"**). Does this behavior match what you'd expect? Or would you prefer that when `earlyFrom` is missing, we default it to the vintage year so those bottles show as "early drinking" instead of "not-ready"?