### PR TITLE
Stats cards margins fix

### DIFF
--- a/frontend/src/pages/Statistics.css
+++ b/frontend/src/pages/Statistics.css
@@ -150,6 +150,7 @@
   grid-template-columns: 1fr 1fr;
   gap: 1.25rem;
   max-width: 100%;
+  margin-bottom: 1.25rem;
 }
 
 .stats-card {


### PR DESCRIPTION
Added `margin-bottom: 1.25rem` to the stats cards, so that the margin will apply to those cards that exist outside of the grid system.

Fixes https://github.com/jagduvi1/Cellarion/issues/320

<img width="1486" height="525" alt="Screenshot from 2026-04-17 10-29-50" src="https://github.com/user-attachments/assets/231a9b8e-2643-4c9f-930f-4149224873b9" />
