### PR TITLE
Fix patron plan blocked from Cellar Chat

### DIFF
--- a/frontend/src/pages/CellarChat.js
+++ b/frontend/src/pages/CellarChat.js
@@ -207,7 +207,7 @@ export default function CellarChat() {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const atLimit = usage && usage.used >= usage.limit;
+  const atLimit = usage && usage.limit !== -1 && usage.used >= usage.limit;
 
   // Build conversation history from messages state (text only, no wine cards / thinking)
   const buildHistory = useCallback(() =>
@@ -301,7 +301,9 @@ export default function CellarChat() {
   };
 
   const usagePeriodLabel = usage?.period === 'weekly' ? 'this week' : 'today';
-  const usageLabel = usage ? `${usage.used} / ${usage.limit} ${usagePeriodLabel}` : null;
+  const usageLabel = usage
+    ? (usage.limit === -1 ? null : `${usage.used} / ${usage.limit} ${usagePeriodLabel}`)
+    : null;
 
   return (
     <div className="cellar-chat">


### PR DESCRIPTION
## Summary
- Patron users (unlimited plan) were completely locked out of Cellar Chat because the frontend `atLimit` check (`used >= limit`) treated `-1` (unlimited) as a real limit — `0 >= -1` is always `true`
- Now skips the limit check when `limit === -1`, matching the backend behavior
- Hides the usage counter for unlimited plans instead of showing `0 / -1 today`

## Test plan
- [ ] Verify patron users can send messages in Cellar Chat
- [ ] Verify the `0 / -1 today` counter no longer appears for patron users
- [ ] Verify free and supporter plans still see their usage counter and get correctly rate-limited
- [ ] Run `cd frontend && npm test -- --watchAll=false` — all 256 tests pass