### PR TITLE
Bump package.json versions to 1.46.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.46.1",
+  "version": "1.46.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.46.1",
+  "version": "1.46.2",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^10.7.7",


### PR DESCRIPTION
## Summary
- Bump both backend and frontend package.json versions from 1.46.1 to 1.46.2 for the patron chat limit fix (#322)