### PR TITLE
Phase 1 Day 1: SEO/AI-search foundations (AI crawler routing + landing FAQ)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,6 @@
 map $http_user_agent $is_crawler {
     default                 0;
+    # Social link-preview bots
     ~*Twitterbot            1;
     ~*facebookexternalhit   1;
     ~*LinkedInBot           1;
@@ -7,9 +8,29 @@ map $http_user_agent $is_crawler {
     ~*Discordbot            1;
     ~*TelegramBot           1;
     ~*Slackbot              1;
+    # Traditional search engines
     ~*Googlebot             1;
     ~*bingbot               1;
     ~*Applebot              1;
+    ~*DuckDuckBot           1;
+    ~*YandexBot             1;
+    # AI crawlers — route to og.js so AI engines see full HTML, JSON-LD, and prose,
+    # not the empty SPA shell. This is the difference between being citable or not.
+    ~*GPTBot                1;
+    ~*ChatGPT-User          1;
+    ~*OAI-SearchBot         1;
+    ~*ClaudeBot             1;
+    ~*anthropic-ai          1;
+    ~*Claude-Web            1;
+    ~*PerplexityBot         1;
+    ~*Perplexity-User       1;
+    ~*Google-Extended       1;
+    ~*Applebot-Extended     1;
+    ~*CCBot                 1;
+    ~*cohere-ai             1;
+    ~*Meta-ExternalAgent    1;
+    ~*Bytespider            1;
+    ~*DuckAssistBot         1;
 }
 
 server {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -33,6 +33,16 @@
 
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' blob: data: https:; connect-src 'self' https://open.er-api.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com;" />
 
+    <!--
+      Search engine webmaster verification.
+      DNS TXT verification is preferred (survives URL changes, no commit needed).
+      If you must use HTML-tag verification, replace the empty content="" values below
+      with the codes from Google Search Console and Bing Webmaster Tools.
+      Leave the tags out (or empty) until you've claimed the site — empty tags are harmless.
+    -->
+    <meta name="google-site-verification" content="" />
+    <meta name="msvalidate.01" content="" />
+
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Cellarion" />

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,4 +1,6 @@
 # https://www.robotstxt.org/robotstxt.html
+
+# Default policy — applies to all crawlers not matched below
 User-agent: *
 Disallow: /admin/
 Disallow: /superadmin
@@ -17,6 +19,50 @@ Disallow: /api/settings/
 Allow: /
 Allow: /blog
 Allow: /blog/*
+Allow: /wines/
+Allow: /help
+Allow: /privacy
+Allow: /api/sitemap.xml
+Allow: /api/blog
+
+# AI crawlers — explicit allow for content discovery and citation.
+# These index for AI assistants (ChatGPT, Claude, Perplexity, Copilot, Gemini, etc.).
+# Same disallow list as the default group: only public marketing/reference surfaces are crawlable.
+# Note: Google-Extended and Applebot-Extended only opt-out of generative-AI training, not search
+# indexing — allowing them is the explicit "we want to be cited" choice.
+User-agent: GPTBot
+User-agent: ChatGPT-User
+User-agent: OAI-SearchBot
+User-agent: ClaudeBot
+User-agent: anthropic-ai
+User-agent: Claude-Web
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+User-agent: Google-Extended
+User-agent: Applebot-Extended
+User-agent: CCBot
+User-agent: cohere-ai
+User-agent: Meta-ExternalAgent
+User-agent: Bytespider
+User-agent: DuckAssistBot
+Disallow: /admin/
+Disallow: /superadmin
+Disallow: /settings
+Disallow: /cellars/
+Disallow: /users/
+Disallow: /api/auth/
+Disallow: /api/bottles/
+Disallow: /api/cellars/
+Disallow: /api/users/
+Disallow: /api/admin/
+Disallow: /api/chat/
+Disallow: /api/notifications/
+Disallow: /api/settings/
+Allow: /
+Allow: /blog
+Allow: /blog/*
+Allow: /wines/
+Allow: /help
 Allow: /privacy
 Allow: /api/sitemap.xml
 Allow: /api/blog

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1788,7 +1788,23 @@
     "openCellar": "Open My Cellar",
     "footerLicense": "AGPL-3.0",
     "footerContributors": "Cellarion contributors",
-    "metaDescription": "Cellarion — the open-source wine cellar manager. Track bottles, visualise racks, get drink-window alerts, and share cellars. Self-hosted or use cellarion.app."
+    "metaDescription": "Cellarion — the open-source wine cellar manager. Track bottles, visualise racks, get drink-window alerts, and share cellars. Self-hosted or use cellarion.app.",
+    "faqTitle": "Frequently asked questions",
+    "faqSub": "Quick answers about Cellarion, wine cellar management, and how to get started.",
+    "faq": {
+      "q1": "What is the best self-hosted wine cellar app?",
+      "a1": "Cellarion is a free, open-source self-hosted wine cellar manager. It runs on your own server with Docker Compose, supports unlimited bottles and cellars, includes drink-window alerts, fuzzy search, label scanning, and a shared wine registry — all under the AGPL-3.0 license with no subscription, vendor lock-in, or data sent to third parties.",
+      "q2": "How do I track my wine collection with Cellarion?",
+      "a2": "You log each bottle with its vintage, producer, region, price, personal rating, and tasting notes. Bottles live inside named cellars and can be placed on customisable racks for visual organisation. Cellarion automatically calculates drink windows, tracks consumption history, and gives you statistics across your whole collection.",
+      "q3": "What is a drink window in wine?",
+      "a3": "A drink window is the period during which a wine is at its best — typically a range of years bracketing the wine's peak maturity. Cellarion classifies every vintage as Not Ready, Early, Peak, Late, or Declining based on producer notes and vintage data, so you know which bottles to drink soon and which to keep cellaring.",
+      "q4": "Is Cellarion free? Is it open-source?",
+      "a4": "Yes. Cellarion is released under the AGPL-3.0 license. You can use the hosted version at cellarion.app for free, or self-host your own instance with Docker Compose. The full source code is on GitHub at github.com/jagduvi1/Cellarion — you can audit it, fork it, and run it on your own hardware.",
+      "q5": "How do I import wines from Vivino or CellarTracker?",
+      "a5": "Cellarion supports CSV import. Export your collection from Vivino, CellarTracker, or any spreadsheet, then upload the CSV in Cellarion's import tool. The shared wine registry deduplicates entries automatically so your data stays clean and consistent across the whole catalogue.",
+      "q6": "Where is my data stored?",
+      "a6": "If you self-host, your data lives entirely on your own server in MongoDB — nothing is sent to third parties. On the hosted version at cellarion.app your data is stored on European infrastructure, you can export everything as JSON at any time, and you can delete your account with a 7-day cooling-off period. Cellarion is GDPR-compliant by design."
+    }
   },
 
   "maturity": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1788,7 +1788,23 @@
     "openCellar": "Öppna min källare",
     "footerLicense": "AGPL-3.0",
     "footerContributors": "Cellarion-bidragsgivare",
-    "metaDescription": "Cellarion — vinsamlingshanteraren med öppen källkod. Spåra flaskor, visualisera ställ, få drickfönster-aviseringar och dela källare. Självhostad eller använd cellarion.app."
+    "metaDescription": "Cellarion — vinsamlingshanteraren med öppen källkod. Spåra flaskor, visualisera ställ, få drickfönster-aviseringar och dela källare. Självhostad eller använd cellarion.app.",
+    "faqTitle": "Vanliga frågor",
+    "faqSub": "Snabba svar om Cellarion, vinsamlingshantering och hur du kommer igång.",
+    "faq": {
+      "q1": "Vilken är den bästa självhostade vinkällar-appen?",
+      "a1": "Cellarion är en gratis självhostad vinkällarhanterare med öppen källkod. Den körs på din egen server med Docker Compose, stöder obegränsat antal flaskor och källare, har drickfönster-aviseringar, fuzzy-sökning, etikettskanning och ett delat vinregister — allt under AGPL-3.0-licensen utan prenumeration, inlåsning eller data som skickas till tredje part.",
+      "q2": "Hur spårar jag min vinsamling med Cellarion?",
+      "a2": "Du loggar varje flaska med årgång, producent, region, pris, personligt betyg och provningsanteckningar. Flaskorna placeras i namngivna källare och kan ställas i anpassningsbara ställ för visuell organisation. Cellarion beräknar automatiskt drickfönster, följer din konsumtionshistorik och ger statistik över hela samlingen.",
+      "q3": "Vad är ett drickfönster för vin?",
+      "a3": "Ett drickfönster är den period då ett vin är som bäst — vanligtvis ett spann av år runt vinets mognadstopp. Cellarion klassar varje årgång som Ej redo, Tidig, Topp, Sen eller Avtagande baserat på producentanteckningar och årgångsdata, så du vet vilka flaskor du bör dricka snart och vilka du kan lagra längre.",
+      "q4": "Är Cellarion gratis? Är det öppen källkod?",
+      "a4": "Ja. Cellarion släpps under AGPL-3.0-licensen. Du kan använda den hostade versionen på cellarion.app gratis, eller självhosta din egen instans med Docker Compose. Hela källkoden finns på GitHub på github.com/jagduvi1/Cellarion — du kan granska den, forka den och köra den på din egen hårdvara.",
+      "q5": "Hur importerar jag viner från Vivino eller CellarTracker?",
+      "a5": "Cellarion stöder CSV-import. Exportera din samling från Vivino, CellarTracker eller något kalkylark, ladda sedan upp CSV-filen i Cellarions importverktyg. Det delade vinregistret deduplicerar poster automatiskt så att din data förblir ren och konsekvent i hela katalogen.",
+      "q6": "Var lagras min data?",
+      "a6": "Om du självhostar finns din data helt på din egen server i MongoDB — inget skickas till tredje part. På den hostade versionen på cellarion.app lagras din data på europeisk infrastruktur, du kan exportera allt som JSON när som helst och du kan radera ditt konto med 7 dagars betänketid. Cellarion är GDPR-kompatibel från grunden."
+    }
   },
 
   "maturity": {

--- a/frontend/src/pages/Blog.js
+++ b/frontend/src/pages/Blog.js
@@ -82,11 +82,22 @@ function Blog() {
         <link rel="alternate" hrefLang="x-default" href={`${SITE_URL}/blog`} />
         <script type="application/ld+json">{JSON.stringify({
           '@context': 'https://schema.org',
-          '@type': 'CollectionPage',
-          name: `${t('blog.title')} — Cellarion`,
-          description: 'News, tips, and updates from the Cellarion team.',
-          url: `${SITE_URL}/blog`,
-          isPartOf: { '@type': 'WebSite', '@id': `${SITE_URL}/#website` }
+          '@graph': [
+            {
+              '@type': 'CollectionPage',
+              name: `${t('blog.title')} — Cellarion`,
+              description: 'News, tips, and updates from the Cellarion team.',
+              url: `${SITE_URL}/blog`,
+              isPartOf: { '@type': 'WebSite', '@id': `${SITE_URL}/#website` }
+            },
+            {
+              '@type': 'BreadcrumbList',
+              itemListElement: [
+                { '@type': 'ListItem', position: 1, name: 'Cellarion', item: SITE_URL },
+                { '@type': 'ListItem', position: 2, name: t('blog.title'), item: `${SITE_URL}/blog` }
+              ]
+            }
+          ]
         })}</script>
       </Helmet>
 

--- a/frontend/src/pages/Help.js
+++ b/frontend/src/pages/Help.js
@@ -60,18 +60,30 @@ function Help() {
     setOpenSection(prev => prev === key ? null : key);
   };
 
-  // FAQPage JSON-LD — uses the first 10 sections as Q&A pairs
-  const faqJsonLd = {
+  // FAQPage + BreadcrumbList JSON-LD. Uses @graph so a single <script> tag
+  // emits both entities, which is what Google's Rich Results Test prefers.
+  const jsonLd = {
     '@context': 'https://schema.org',
-    '@type': 'FAQPage',
-    mainEntity: filtered.slice(0, 10).map(s => ({
-      '@type': 'Question',
-      name: s.title,
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: s.details.length > 0 ? s.details.join(' ') : s.summary,
+    '@graph': [
+      {
+        '@type': 'FAQPage',
+        mainEntity: filtered.slice(0, 10).map(s => ({
+          '@type': 'Question',
+          name: s.title,
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: s.details.length > 0 ? s.details.join(' ') : s.summary,
+          }
+        }))
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Cellarion', item: SITE_URL },
+          { '@type': 'ListItem', position: 2, name: t('help.title'), item: `${SITE_URL}/help` }
+        ]
       }
-    }))
+    ]
   };
 
   return (
@@ -87,7 +99,7 @@ function Help() {
         <link rel="alternate" hrefLang="en" href={`${SITE_URL}/help`} />
         <link rel="alternate" hrefLang="sv" href={`${SITE_URL}/help`} />
         <link rel="alternate" hrefLang="x-default" href={`${SITE_URL}/help`} />
-        <script type="application/ld+json">{JSON.stringify(faqJsonLd)}</script>
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
       </Helmet>
       <div className="help-container">
         <div className="help-header">

--- a/frontend/src/pages/LandingPage.css
+++ b/frontend/src/pages/LandingPage.css
@@ -376,6 +376,71 @@
   margin: 0;
 }
 
+/* ── FAQ ── */
+.landing-faq {
+  padding: 80px 0;
+  border-top: 1px solid var(--color-border-light);
+}
+
+.landing-faq-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+.landing-faq-item {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 18px 22px;
+  box-shadow: var(--shadow-card);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.landing-faq-item[open] {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-card-hover);
+}
+
+.landing-faq-question {
+  font-family: var(--font-heading);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--color-text);
+  cursor: pointer;
+  list-style: none;
+  position: relative;
+  padding-right: 28px;
+}
+
+.landing-faq-question::-webkit-details-marker { display: none; }
+
+.landing-faq-question::after {
+  content: '+';
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.4rem;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+  transition: transform 0.2s;
+  line-height: 1;
+}
+
+.landing-faq-item[open] .landing-faq-question::after {
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.landing-faq-answer {
+  margin: 14px 0 0;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: var(--color-text-secondary);
+}
+
 /* ── Footer ── */
 .landing-footer {
   border-top: 1px solid var(--color-border-light);

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -27,6 +27,17 @@ export default function LandingPage() {
     { icon: '📥', title: t('landing.featureImportTitle'), desc: t('landing.featureImportDesc') },
   ];
 
+  // Visible Q&A on the page MUST match the FAQPage JSON-LD verbatim — Google penalises
+  // schema-only Q&A that doesn't appear on the page.
+  const faqs = [
+    { q: t('landing.faq.q1'), a: t('landing.faq.a1') },
+    { q: t('landing.faq.q2'), a: t('landing.faq.a2') },
+    { q: t('landing.faq.q3'), a: t('landing.faq.a3') },
+    { q: t('landing.faq.q4'), a: t('landing.faq.a4') },
+    { q: t('landing.faq.q5'), a: t('landing.faq.a5') },
+    { q: t('landing.faq.q6'), a: t('landing.faq.a6') },
+  ];
+
   useEffect(() => {
     fetch('/api/settings')
       .then(r => r.ok ? r.json() : null)
@@ -70,6 +81,15 @@ export default function LandingPage() {
           price: '0',
           priceCurrency: 'USD'
         }
+      },
+      {
+        '@type': 'FAQPage',
+        '@id': `${SITE_URL}/#faq`,
+        mainEntity: faqs.map(({ q, a }) => ({
+          '@type': 'Question',
+          name: q,
+          acceptedAnswer: { '@type': 'Answer', text: a }
+        }))
       }
     ]
   };
@@ -222,6 +242,22 @@ export default function LandingPage() {
           >
             {t('landing.ossViewSource')} →
           </a>
+        </div>
+      </section>
+
+      {/* ── FAQ ── */}
+      <section className="landing-faq">
+        <div className="landing-section-inner">
+          <h2 className="landing-section-title">{t('landing.faqTitle')}</h2>
+          <p className="landing-section-sub">{t('landing.faqSub')}</p>
+          <div className="landing-faq-list">
+            {faqs.map(({ q, a }, i) => (
+              <details key={i} className="landing-faq-item">
+                <summary className="landing-faq-question">{q}</summary>
+                <p className="landing-faq-answer">{a}</p>
+              </details>
+            ))}
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

First slice of the SEO + AI-search plan. The single biggest change here is routing AI crawlers (GPTBot, ClaudeBot, PerplexityBot, OAI-SearchBot, anthropic-ai, Google-Extended, etc.) to the existing crawler-detecting `og.js` SSR pipeline so they get full HTML, JSON-LD, and prose instead of the empty SPA shell. They were previously falling through to the SPA shell because the `\$is_crawler` map only listed Googlebot/bingbot/Twitterbot/etc.

Bundle:
- **nginx.conf**: AI crawler user-agents added to `\$is_crawler` map → routes them through `og.js` for wine and blog pages
- **robots.txt**: explicit `User-agent:` groups for AI bots with the same allow/disallow lists as the default policy (clearer signal than fall-through). Notably allows `Google-Extended` and `Applebot-Extended` — those only opt-out of generative-AI training, so allowing them is the explicit \"we want to be cited\" choice
- **index.html**: empty `google-site-verification` / `msvalidate.01` meta tags ready to fill in once Search Console + Bing Webmaster are claimed (DNS TXT verification still preferred and skips this)
- **LandingPage**: 6-question FAQ section targeting AI-search intent queries (\"best self-hosted wine cellar app\", \"what is a drink window\", \"is Cellarion free\", \"how do I import from Vivino/CellarTracker\", \"where is my data stored\"). Visible `<details>/<summary>` markup matches the FAQPage JSON-LD verbatim — Google penalises schema-only Q&A
- **Help.js / Blog.js**: BreadcrumbList JSON-LD added via `@graph` alongside existing FAQPage / CollectionPage
- **locales en + sv**: new `landing.faq.*` namespace

IndexNow trigger audit (Phase 1.8): confirmed already wired correctly on blog publish/update — no change needed.

Plan: \`C:\Users\jagdu\.claude\plans\i-want-the-site-floofy-flask.md\` (Phase 1 Day 1 of 4 phases). Day 2 (Umami self-hosted + SEOHead component) and Phase 2 (wine URL slug migration) are separate PRs.

## Test plan

- [x] Frontend unit tests pass (256/256)
- [x] Locale JSON files parse cleanly (EN + SV)
- [ ] Smoke test in Docker: \`docker-compose up --build\`, then \`curl -A \"ClaudeBot\" http://localhost/wines/<id>\` returns og.js HTML, not SPA shell — proves the nginx routing fix shipped
- [ ] Smoke test: \`curl -A \"GPTBot\" http://localhost/blog/<slug>\` returns og.js HTML
- [ ] Visit \`/\` in browser → FAQ section renders, accordion works, EN/SV switch works
- [ ] Visit \`/help\` and \`/blog\` → no console errors, breadcrumb JSON-LD present in `<script>` tags
- [ ] Google Rich Results Test on landing page → FAQPage valid (after deploy)
- [ ] Submit `https://cellarion.app/sitemap.xml` in Google Search Console + Bing Webmaster Tools after deploy

## Post-merge deployment

```bash
# On prod server
cd /path/to/Cellarion
git pull origin main
docker compose -f docker-compose-prod.yml build frontend
docker compose -f docker-compose-prod.yml up -d frontend
# Verify
curl -A "ClaudeBot" https://cellarion.app/wines/<some-id> | head -20  # should show og.js HTML
```

No backend rebuild, no DB migration, no env vars required for this PR.