### PR TITLE
Phase 1 Day 2: SEOHead component + Umami self-hosted analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,21 @@ MEILI_MASTER_KEY=change-me-to-a-strong-random-string
 # STRIPE_WEBHOOK_SECRET=whsec_...
 # STRIPE_SUPPORTER_PRICE_ID=price_...
 # STRIPE_PATRON_PRICE_ID=price_...
+
+# Umami self-hosted analytics — optional. Privacy-friendly, no cookies, no consent banner.
+# The umami + umami-db services in docker-compose.yml are inert until these are set.
+# Setup:
+#   1. Set UMAMI_DB_PASSWORD and UMAMI_APP_SECRET to strong random strings.
+#   2. Bring up just umami: `docker compose up -d umami umami-db`
+#   3. Open http://localhost:3001 (dev) or https://analytics.cellarion.app (prod), log in
+#      with admin/umami, change the password, then add a new website (e.g. cellarion.app).
+#   4. Copy the website's UUID and set REACT_APP_UMAMI_WEBSITE_ID below + REACT_APP_UMAMI_URL.
+#   5. Rebuild the frontend so the build-time vars get baked in:
+#      `docker compose build frontend && docker compose up -d frontend`
+# Note: REACT_APP_* vars are read at frontend BUILD time, not runtime — they must be set
+# before `docker compose build`. The CSP in frontend/public/index.html allows
+# https://analytics.cellarion.app — change there too if you self-host on a different domain.
+# UMAMI_DB_PASSWORD=replace-with-a-strong-random-string
+# UMAMI_APP_SECRET=replace-with-a-different-strong-random-string
+# REACT_APP_UMAMI_URL=https://analytics.cellarion.app
+# REACT_APP_UMAMI_WEBSITE_ID=00000000-0000-0000-0000-000000000000

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,3 +7,6 @@ services:
   backend:
     ports:
       - "5000:5000"
+  umami:
+    ports:
+      - "3001:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,8 @@ services:
       context: ./frontend
       args:
         APP_VERSION: ${APP_VERSION:-dev}
+        REACT_APP_UMAMI_URL: ${REACT_APP_UMAMI_URL:-}
+        REACT_APP_UMAMI_WEBSITE_ID: ${REACT_APP_UMAMI_WEBSITE_ID:-}
     container_name: cellarion-frontend
     restart: unless-stopped
     deploy:
@@ -141,11 +143,62 @@ services:
       backend:
         condition: service_healthy
 
+  # Umami — privacy-friendly self-hosted analytics. Only loaded by the frontend when
+  # REACT_APP_UMAMI_URL and REACT_APP_UMAMI_WEBSITE_ID are set at build time, so this
+  # service is optional and inert without those vars.
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    container_name: cellarion-umami
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=postgresql://umami:${UMAMI_DB_PASSWORD:-umami}@umami-db:5432/umami
+      - DATABASE_TYPE=postgresql
+      - APP_SECRET=${UMAMI_APP_SECRET:-replace-with-random-string-in-production}
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    expose:
+      - "3000"
+    networks:
+      - web
+      - default
+    labels:
+      traefik.enable: "true"
+      traefik.docker.network: "web"
+      traefik.http.routers.umami.rule: "Host(`analytics.cellarion.app`)"
+      traefik.http.routers.umami.entrypoints: "web"
+      traefik.http.services.umami.loadbalancer.server.port: "3000"
+    depends_on:
+      umami-db:
+        condition: service_healthy
+
+  umami-db:
+    image: postgres:16-alpine
+    container_name: cellarion-umami-db
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=umami
+      - POSTGRES_USER=umami
+      - POSTGRES_PASSWORD=${UMAMI_DB_PASSWORD:-umami}
+    volumes:
+      - umami-db-data:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U umami -d umami"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 volumes:
   mongo-data:
   meili-data:
   qdrant-data:
   image-data:
+  umami-db-data:
 
 networks:
   web:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,14 @@ RUN npm ci --legacy-peer-deps
 COPY . .
 
 ARG APP_VERSION=
-RUN export REACT_APP_VERSION="${APP_VERSION:-$(node -p "require('./package.json').version")}" && npm run build
+# Umami analytics (optional): if these are set at build time, the Analytics component
+# injects the tracker script. Empty values are a no-op (no script, no CSP impact).
+ARG REACT_APP_UMAMI_URL=
+ARG REACT_APP_UMAMI_WEBSITE_ID=
+RUN export REACT_APP_VERSION="${APP_VERSION:-$(node -p "require('./package.json').version")}" \
+    REACT_APP_UMAMI_URL="${REACT_APP_UMAMI_URL}" \
+    REACT_APP_UMAMI_WEBSITE_ID="${REACT_APP_UMAMI_WEBSITE_ID}" \
+ && npm run build
 
 # ── Stage 2: serve with nginx ─────────────────────────────────────────────────
 FROM nginx:alpine

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -31,7 +31,12 @@
     <meta name="twitter:description" content="The open-source, self-hosted wine cellar manager. Track bottles, visualise racks, and get drink-window alerts." />
     <meta name="twitter:image" content="%PUBLIC_URL%/cellarion-logo.jpg" />
 
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' blob: data: https:; connect-src 'self' https://open.er-api.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com;" />
+    <!--
+      CSP additions for Umami analytics: script-src and connect-src include
+      https://analytics.cellarion.app so the self-hosted tracker can load and POST.
+      If you self-host Umami at a different subdomain, update both lists.
+    -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://analytics.cellarion.app; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' blob: data: https:; connect-src 'self' https://open.er-api.com https://analytics.cellarion.app; frame-src https://www.youtube.com https://www.youtube-nocookie.com;" />
 
     <!--
       Search engine webmaster verification.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import { NotificationProvider } from './contexts/NotificationContext';
 import { ThemeProvider } from './contexts/ThemeContext';
 import Layout from './components/Layout';
 import ProtectedRoute from './components/ProtectedRoute';
+import Analytics from './components/Analytics';
 import './styles/common.css';
 
 // Lazy-load all pages so each route gets its own chunk.
@@ -440,6 +441,7 @@ function App() {
         <BrowserRouter>
           <AuthProvider>
             <NotificationProvider>
+                <Analytics />
                 <AppRoutes />
             </NotificationProvider>
           </AuthProvider>

--- a/frontend/src/components/Analytics.js
+++ b/frontend/src/components/Analytics.js
@@ -1,0 +1,28 @@
+import { Helmet } from 'react-helmet-async';
+
+// Self-hosted Umami tracker. Mounted at app root (App.js) so the script loads once
+// per session and Umami's built-in History API listener handles SPA route changes.
+//
+// Configured via build-time env vars:
+//   REACT_APP_UMAMI_URL          e.g. https://analytics.cellarion.app
+//   REACT_APP_UMAMI_WEBSITE_ID   uuid from the Umami dashboard
+//
+// If either is missing (e.g. local dev without analytics) the script isn't injected
+// and the component is a no-op. No CSP changes needed for that case.
+export default function Analytics() {
+  const url = process.env.REACT_APP_UMAMI_URL;
+  const websiteId = process.env.REACT_APP_UMAMI_WEBSITE_ID;
+
+  if (!url || !websiteId) return null;
+
+  return (
+    <Helmet>
+      <script
+        async
+        defer
+        src={`${url.replace(/\/$/, '')}/script.js`}
+        data-website-id={websiteId}
+      />
+    </Helmet>
+  );
+}

--- a/frontend/src/components/SEOHead.js
+++ b/frontend/src/components/SEOHead.js
@@ -1,0 +1,61 @@
+import { Helmet } from 'react-helmet-async';
+import SITE_URL from '../config/siteUrl';
+
+const DEFAULT_IMAGE = `${SITE_URL}/cellarion-logo.jpg`;
+
+// Single source of truth for public-page SEO meta. Each public page passes its variable
+// bits and gets a complete Helmet block (canonical, OG, Twitter, hreflang, JSON-LD) with
+// no opportunity to forget a tag.
+//
+// Auth-only pages must not use this — they aren't crawler-reachable and adding canonicals
+// to them would leak personal-data URLs to anyone who scrapes the rendered HTML.
+export default function SEOHead({
+  title,
+  description,
+  path = '/',
+  image,
+  ogType = 'website',
+  twitterCard = 'summary_large_image',
+  jsonLd,
+  language,
+  hreflang = 'public',
+  articleMeta,
+}) {
+  const url = path.startsWith('http') ? path : `${SITE_URL}${path}`;
+  const imageUrl = image || DEFAULT_IMAGE;
+
+  return (
+    <Helmet>
+      {language && <html lang={language} />}
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <meta property="og:type" content={ogType} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={imageUrl} />
+      <meta property="og:url" content={url} />
+      <meta property="og:site_name" content="Cellarion" />
+      <meta name="twitter:card" content={twitterCard} />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={imageUrl} />
+      <link rel="canonical" href={url} />
+      {hreflang === 'public' && (
+        <>
+          <link rel="alternate" hrefLang="en" href={url} />
+          <link rel="alternate" hrefLang="sv" href={url} />
+          <link rel="alternate" hrefLang="x-default" href={url} />
+        </>
+      )}
+      {articleMeta?.publishedTime && (
+        <meta property="article:published_time" content={articleMeta.publishedTime} />
+      )}
+      {articleMeta?.modifiedTime && (
+        <meta property="article:modified_time" content={articleMeta.modifiedTime} />
+      )}
+      {jsonLd && (
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      )}
+    </Helmet>
+  );
+}

--- a/frontend/src/pages/Blog.js
+++ b/frontend/src/pages/Blog.js
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Helmet } from 'react-helmet-async';
 import { getBlogPosts, getBlogTags } from '../api/blog';
 import { useAuth } from '../contexts/AuthContext';
+import SEOHead from '../components/SEOHead';
 import SITE_URL from '../config/siteUrl';
 import './Blog.css';
 
@@ -67,39 +67,34 @@ function Blog() {
     });
   };
 
+  const blogJsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'CollectionPage',
+        name: `${t('blog.title')} — Cellarion`,
+        description: 'News, tips, and updates from the Cellarion team.',
+        url: `${SITE_URL}/blog`,
+        isPartOf: { '@type': 'WebSite', '@id': `${SITE_URL}/#website` }
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Cellarion', item: SITE_URL },
+          { '@type': 'ListItem', position: 2, name: t('blog.title'), item: `${SITE_URL}/blog` }
+        ]
+      }
+    ]
+  };
+
   return (
     <div className="blog-page">
-      <Helmet>
-        <title>{t('blog.title')} — Cellarion</title>
-        <meta name="description" content="News, tips, and updates from the Cellarion team. Learn about wine cellar management, drink windows, and getting the most from your collection." />
-        <meta property="og:title" content={`${t('blog.title')} — Cellarion`} />
-        <meta property="og:description" content="News, tips, and updates from the Cellarion team." />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content={`${SITE_URL}/blog`} />
-        <link rel="canonical" href={`${SITE_URL}/blog`} />
-        <link rel="alternate" hrefLang="en" href={`${SITE_URL}/blog`} />
-        <link rel="alternate" hrefLang="sv" href={`${SITE_URL}/blog`} />
-        <link rel="alternate" hrefLang="x-default" href={`${SITE_URL}/blog`} />
-        <script type="application/ld+json">{JSON.stringify({
-          '@context': 'https://schema.org',
-          '@graph': [
-            {
-              '@type': 'CollectionPage',
-              name: `${t('blog.title')} — Cellarion`,
-              description: 'News, tips, and updates from the Cellarion team.',
-              url: `${SITE_URL}/blog`,
-              isPartOf: { '@type': 'WebSite', '@id': `${SITE_URL}/#website` }
-            },
-            {
-              '@type': 'BreadcrumbList',
-              itemListElement: [
-                { '@type': 'ListItem', position: 1, name: 'Cellarion', item: SITE_URL },
-                { '@type': 'ListItem', position: 2, name: t('blog.title'), item: `${SITE_URL}/blog` }
-              ]
-            }
-          ]
-        })}</script>
-      </Helmet>
+      <SEOHead
+        title={`${t('blog.title')} — Cellarion`}
+        description="News, tips, and updates from the Cellarion team. Learn about wine cellar management, drink windows, and getting the most from your collection."
+        path="/blog"
+        jsonLd={blogJsonLd}
+      />
 
       <header className="blog-header">
         <h1>{t('blog.title')}</h1>

--- a/frontend/src/pages/BlogPost.js
+++ b/frontend/src/pages/BlogPost.js
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Helmet } from 'react-helmet-async';
 import DOMPurify from 'dompurify';
 import { getBlogPost } from '../api/blog';
 import { useAuth } from '../contexts/AuthContext';
+import SEOHead from '../components/SEOHead';
 import SITE_URL from '../config/siteUrl';
 import './Blog.css';
 
@@ -101,25 +101,18 @@ function BlogPost() {
 
   return (
     <div className="blog-post-page">
-      <Helmet>
-        <title>{metaTitle} — Cellarion Blog</title>
-        <meta name="description" content={metaDescription} />
-        <meta property="og:type" content="article" />
-        <meta property="og:title" content={metaTitle} />
-        <meta property="og:description" content={metaDescription} />
-        {post.coverImage && <meta property="og:image" content={post.coverImage} />}
-        <meta property="og:url" content={postUrl} />
-        <meta property="article:published_time" content={post.publishedAt} />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={metaTitle} />
-        <meta name="twitter:description" content={metaDescription} />
-        {post.coverImage && <meta name="twitter:image" content={post.coverImage} />}
-        <link rel="canonical" href={postUrl} />
-        <link rel="alternate" hrefLang="en" href={postUrl} />
-        <link rel="alternate" hrefLang="sv" href={postUrl} />
-        <link rel="alternate" hrefLang="x-default" href={postUrl} />
-        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-      </Helmet>
+      <SEOHead
+        title={`${metaTitle} — Cellarion Blog`}
+        description={metaDescription}
+        path={`/blog/${post.slug}`}
+        image={post.coverImage || undefined}
+        ogType="article"
+        jsonLd={jsonLd}
+        articleMeta={{
+          publishedTime: post.publishedAt,
+          modifiedTime: post.updatedAt,
+        }}
+      />
 
       <nav className="blog-breadcrumb">
         <Link to="/blog">{t('blog.title')}</Link>

--- a/frontend/src/pages/Help.js
+++ b/frontend/src/pages/Help.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Helmet } from 'react-helmet-async';
 import { getHelpContent } from '../api/help';
+import SEOHead from '../components/SEOHead';
 import SITE_URL from '../config/siteUrl';
 import './Help.css';
 
@@ -88,19 +88,12 @@ function Help() {
 
   return (
     <div className="help-page">
-      <Helmet>
-        <title>{t('help.title')} — Cellarion</title>
-        <meta name="description" content={t('help.subtitle')} />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content={`${t('help.title')} — Cellarion`} />
-        <meta property="og:description" content={t('help.subtitle')} />
-        <meta property="og:url" content={`${SITE_URL}/help`} />
-        <link rel="canonical" href={`${SITE_URL}/help`} />
-        <link rel="alternate" hrefLang="en" href={`${SITE_URL}/help`} />
-        <link rel="alternate" hrefLang="sv" href={`${SITE_URL}/help`} />
-        <link rel="alternate" hrefLang="x-default" href={`${SITE_URL}/help`} />
-        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-      </Helmet>
+      <SEOHead
+        title={`${t('help.title')} — Cellarion`}
+        description={t('help.subtitle')}
+        path="/help"
+        jsonLd={jsonLd}
+      />
       <div className="help-container">
         <div className="help-header">
           <h1>{t('help.title')}</h1>

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Helmet } from 'react-helmet-async';
 import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
+import SEOHead from '../components/SEOHead';
 import SITE_URL from '../config/siteUrl';
 import './LandingPage.css';
 
@@ -96,26 +96,13 @@ export default function LandingPage() {
 
   return (
     <div className="landing">
-      <Helmet>
-        <html lang={lang} />
-        <title>Cellarion — Track & Manage Your Wine Collection | Free Open-Source Wine Cellar App</title>
-        <meta name="description" content={t('landing.metaDescription')} />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="Cellarion — Track & Manage Your Wine Collection" />
-        <meta property="og:description" content={t('landing.metaDescription')} />
-        <meta property="og:url" content={SITE_URL} />
-        <meta property="og:image" content={`${SITE_URL}/cellarion-logo.jpg`} />
-        <meta property="og:site_name" content="Cellarion" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Cellarion — Track & Manage Your Wine Collection" />
-        <meta name="twitter:description" content={t('landing.metaDescription')} />
-        <meta name="twitter:image" content={`${SITE_URL}/cellarion-logo.jpg`} />
-        <link rel="canonical" href={SITE_URL} />
-        <link rel="alternate" hrefLang="en" href={SITE_URL} />
-        <link rel="alternate" hrefLang="sv" href={SITE_URL} />
-        <link rel="alternate" hrefLang="x-default" href={SITE_URL} />
-        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-      </Helmet>
+      <SEOHead
+        title="Cellarion — Track & Manage Your Wine Collection | Free Open-Source Wine Cellar App"
+        description={t('landing.metaDescription')}
+        path="/"
+        language={lang}
+        jsonLd={jsonLd}
+      />
 
       {/* ── Nav ── */}
       <nav className="landing-nav">

--- a/frontend/src/pages/WineDetail.js
+++ b/frontend/src/pages/WineDetail.js
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { fromNormalized } from '../utils/ratingUtils';
 import Layout from '../components/Layout';
+import SEOHead from '../components/SEOHead';
 import SITE_URL from '../config/siteUrl';
 import WineImage from '../components/WineImage';
 import { getWineImageUrl } from '../utils/wineImageUrl';
@@ -49,8 +49,7 @@ export default function WineDetail() {
   }
 
   const fullTitle = `${wine.name} — ${wine.producer}`;
-  const pageTitle = fullTitle.length > 47 ? fullTitle.slice(0, 57) : fullTitle;
-  const titleTag = pageTitle.length > 47 ? pageTitle : `${pageTitle} — Cellarion`;
+  const titleTag = fullTitle.length > 47 ? fullTitle.slice(0, 57) : `${fullTitle} — Cellarion`;
   const description = [
     wine.type && wine.type.charAt(0).toUpperCase() + wine.type.slice(1),
     wine.appellation,
@@ -110,25 +109,14 @@ export default function WineDetail() {
 
   const page = (
     <div className="wine-detail-page">
-      <Helmet>
-        <title>{titleTag}</title>
-        <meta name="description" content={metaDescription} />
-        <meta property="og:type" content="product" />
-        <meta property="og:title" content={pageTitle} />
-        <meta property="og:description" content={metaDescription} />
-        <meta property="og:image" content={imageUrl} />
-        <meta property="og:url" content={pageUrl} />
-        <meta property="og:site_name" content="Cellarion" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={pageTitle} />
-        <meta name="twitter:description" content={metaDescription} />
-        <meta name="twitter:image" content={imageUrl} />
-        <link rel="canonical" href={pageUrl} />
-        <link rel="alternate" hrefLang="en" href={pageUrl} />
-        <link rel="alternate" hrefLang="sv" href={pageUrl} />
-        <link rel="alternate" hrefLang="x-default" href={pageUrl} />
-        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-      </Helmet>
+      <SEOHead
+        title={titleTag}
+        description={metaDescription}
+        path={`/wines/${wine._id}`}
+        image={imageUrl}
+        ogType={hasRating ? 'product' : 'website'}
+        jsonLd={jsonLd}
+      />
 
       <div className="wd-card">
         <WineImage image={wine.image} alt={wine.name} className="wd-image" wrapClass="wd-image-wrap" />


### PR DESCRIPTION
## Summary

Day 2 of the SEO/AI-search plan. Two changes that ship together because they touch overlapping files (CSP, frontend build).

**SEOHead component** — `frontend/src/components/SEOHead.js` consolidates the Helmet boilerplate that was duplicated across LandingPage, Help, Blog, BlogPost, and WineDetail. Each page now passes `{title, description, path, image, ogType, jsonLd, articleMeta}` and gets a complete Helmet block (canonical, OG, Twitter, hreflang en/sv/x-default, JSON-LD) with no opportunity to forget a tag. Net diff is +95/-79 across the 5 pages — same rendered HTML, less duplication.

WineDetail also gains canonical and hreflang on the CSR side — they were only emitted by the og.js crawler renderer before, so real users with browsers that share the URL would lose canonical context. Now both paths emit them.

**Umami self-hosted analytics** — privacy-friendly, no cookies, no consent banner. Why Umami over Plausible/GA4 was already discussed in the plan — short version: lighter than Plausible CE (just Postgres, not Postgres + ClickHouse), and the strict `script-src 'self'` CSP plus the GDPR-aware tone in `PrivacyPolicy.js` make GA4 a bad fit.

- `umami` + `umami-db` services in `docker-compose.yml` with Traefik labels for `analytics.cellarion.app` on prod
- `docker-compose.override.yml` maps `3001:3000` for local dev access
- `frontend/Dockerfile` accepts `REACT_APP_UMAMI_URL` + `REACT_APP_UMAMI_WEBSITE_ID` build args — when unset, `Analytics.js` renders nothing (analytics fully opt-in)
- CSP at `frontend/public/index.html` allows `https://analytics.cellarion.app` in `script-src` and `connect-src`
- `.env.example` documents all 4 new env vars with step-by-step setup

## Test plan

- [x] Frontend unit tests pass (256/256)
- [x] `docker compose config` validates the YAML
- [x] Docker build completes; all 8 containers come up healthy (mongo, meili, qdrant, backend, rembg, frontend, umami, umami-db)
- [x] AI crawler routing still works after refactor: `curl -A \"ClaudeBot\" http://localhost/wines/<id>` returns og.js HTML with title + JSON-LD + `<h1>`
- [x] Static `index.html` ships updated CSP with `analytics.cellarion.app`
- [x] Umami responding at `http://localhost:3001`
- [x] `robots.txt` and `sitemap.xml` still 200
- [ ] Browser: visit `/`, `/help`, `/blog`, `/blog/<slug>`, `/wines/<id>` — view source and confirm Helmet emits canonical, hreflang, OG, Twitter, JSON-LD via SEOHead (Helmet inserts these client-side)
- [ ] Browser: confirm no console errors after refactor
- [ ] Optional: set Umami env vars and rebuild frontend; verify pageviews land in Umami dashboard

## Post-merge deployment

```bash
# On prod server
cd /path/to/Cellarion
git pull origin main

# If skipping Umami for now: just rebuild frontend (analytics is opt-in via env)
docker compose -f docker-compose-prod.yml build frontend
docker compose -f docker-compose-prod.yml up -d frontend

# If enabling Umami:
# 1. Add A record: analytics.cellarion.app -> server IP
# 2. Set in .env: UMAMI_DB_PASSWORD, UMAMI_APP_SECRET (random strings)
# 3. Bring up umami first to get a website ID:
docker compose -f docker-compose-prod.yml up -d umami umami-db
# 4. Visit https://analytics.cellarion.app, log in (admin/umami), change password,
#    add website 'cellarion.app', copy the UUID
# 5. Set in .env: REACT_APP_UMAMI_URL=https://analytics.cellarion.app
#                 REACT_APP_UMAMI_WEBSITE_ID=<uuid from step 4>
# 6. Rebuild frontend so build args bake in:
docker compose -f docker-compose-prod.yml build frontend
docker compose -f docker-compose-prod.yml up -d frontend
```

No DB migration. No Traefik config edits beyond the new label set in compose.