### PR TITLE
Bump package.json versions to 1.47.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.46.2",
+  "version": "1.47.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.46.2",
+  "version": "1.47.0",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^10.7.7",


### PR DESCRIPTION
Minor bump for the SEO + AI-search Phase 1 work:
- Day 1 (#324): nginx AI crawler routing, robots.txt AI policy, Search Console + Bing verification meta, BreadcrumbList JSON-LD on Help/Blog, FAQ section + FAQPage schema on landing
- Day 2 (#325): SEOHead shared component refactor across 5 public pages, Umami self-hosted analytics scaffolding (opt-in via env vars)

Per the project's release workflow, this PR is for review only — no auto-release/tag.