### PR TITLE
Phase 2: wine URL slugs + prose body + per-wine FAQ schema

### DIFF
--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { generateWineSlug } = require('../utils/normalize');
 
 const wineDefinitionSchema = new mongoose.Schema({
   name: {
@@ -89,6 +90,18 @@ const wineDefinitionSchema = new mongoose.Schema({
     unique: true,
     index: true
   },
+  // Vintage-neutral, human-readable slug used in public URLs (/wines/:slug).
+  // Sparse so older docs without a slug don't violate the unique index until
+  // the migration runs. Once set, never auto-regenerated on rename — URLs are
+  // stable forever; renames must be a deliberate admin action.
+  slug: {
+    type: String,
+    trim: true,
+    lowercase: true,
+    unique: true,
+    sparse: true,
+    index: true
+  },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',
@@ -115,6 +128,23 @@ wineDefinitionSchema.index({ type: 1, createdAt: -1 });
 // Update timestamp on save
 wineDefinitionSchema.pre('save', function(next) {
   this.updatedAt = Date.now();
+  next();
+});
+
+// Auto-generate slug for new wines when missing. On collision the caller (the
+// findOrCreateWine flow) appends a -2/-3 suffix; the migration script does the
+// same when backfilling. Existing slugs are never overwritten — URL stability.
+wineDefinitionSchema.pre('save', async function(next) {
+  if (this.slug || !this.isNew) return next();
+  const base = generateWineSlug(this.name, this.producer);
+  if (!base) return next();
+  let candidate = base;
+  for (let i = 2; i < 100; i++) {
+    const collision = await this.constructor.findOne({ slug: candidate }).select('_id').lean();
+    if (!collision) break;
+    candidate = `${base}-${i}`;
+  }
+  this.slug = candidate;
   next();
 });
 

--- a/backend/src/routes/og.js
+++ b/backend/src/routes/og.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const rateLimit = require('express-rate-limit');
 const WineDefinition = require('../models/WineDefinition');
+const WineVintageProfile = require('../models/WineVintageProfile');
 const BlogPost = require('../models/BlogPost');
 const { fromNormalized } = require('../utils/ratingUtils');
 const { isValidId } = require('../utils/validation');
@@ -17,19 +18,33 @@ const ogLimiter = rateLimit({
 const SITE_URL = process.env.FRONTEND_URL || 'https://cellarion.app';
 const API_URL = process.env.BACKEND_URL || process.env.FRONTEND_URL || 'https://cellarion.app';
 
-// GET /og/wines/:id — Full server-rendered HTML for search engine crawlers.
+// GET /og/wines/:idOrSlug — Full server-rendered HTML for search engine crawlers.
 // Nginx routes crawler user-agents here; real users get the SPA.
-router.get('/wines/:id', ogLimiter, async (req, res) => {
+// Accepts both ObjectId and slug. When given an ObjectId for a wine that has a slug,
+// returns 301 to the slug URL — that's how link equity transfers and how external links
+// to old ObjectId URLs keep working forever.
+router.get('/wines/:idOrSlug', ogLimiter, async (req, res) => {
   try {
-    if (!isValidId(req.params.id)) return res.status(404).send('Not found');
-    const wine = await WineDefinition.findById(req.params.id)
+    const { idOrSlug } = req.params;
+    const isId = isValidId(idOrSlug);
+    const filter = isId ? { _id: idOrSlug } : { slug: String(idOrSlug).toLowerCase() };
+
+    const wine = await WineDefinition.findOne(filter)
       .populate(['country', 'region', 'grapes'])
-      .select('name producer country region appellation classification grapes type image communityRating')
+      .select('name producer slug country region appellation classification grapes type image communityRating')
       .lean();
 
     if (!wine) {
       return res.status(404).send('Not found');
     }
+
+    // Canonicalise to slug URL when one exists. 301 means crawlers + browsers
+    // both follow and any link equity earned by the ObjectId URL transfers.
+    if (isId && wine.slug) {
+      return res.redirect(301, `${SITE_URL}/wines/${wine.slug}`);
+    }
+
+    const slugOrId = wine.slug || wine._id;
 
     // Keep title under 60 chars for SEO — drop " — Cellarion" suffix if needed
     const fullTitle = `${wine.name} — ${wine.producer}`;
@@ -44,13 +59,74 @@ router.get('/wines/:id', ogLimiter, async (req, res) => {
     // Keep meta description under 160 chars
     const fullDesc = `${fullTitle}. ${details}. Discover, track, and manage your wine cellar with Cellarion.`;
     const description = fullDesc.length > 160 ? fullDesc.slice(0, 157) + '...' : fullDesc;
-    const pageUrl = `${SITE_URL}/wines/${wine._id}`;
+    const pageUrl = `${SITE_URL}/wines/${slugOrId}`;
     const imageUrl = wine.image
       ? (wine.image.startsWith('/api/') || wine.image.startsWith('http') ? `${API_URL}${wine.image}` : `${API_URL}/api/uploads/${wine.image}`)
       : `${SITE_URL}/cellarion-logo.jpg`;
 
     const grapeNames = (wine.grapes || []).map(g => g.name).filter(Boolean);
     const hasRating = wine.communityRating?.reviewCount > 0;
+
+    // Pull the most authoritative vintage profile so we can include real drink-window
+    // dates in the prose and FAQ. Prefer reviewed profiles, then most recent vintage.
+    let profile = null;
+    try {
+      profile = await WineVintageProfile.findOne({
+        wineDefinition: wine._id,
+        status: 'reviewed'
+      }).sort({ vintage: -1 }).select('vintage peakFrom peakUntil earlyFrom earlyUntil lateFrom lateUntil').lean();
+    } catch (e) {
+      // Profile is optional — failure here shouldn't break the page render.
+    }
+    const peakFrom = profile?.peakFrom;
+    const peakUntil = profile?.peakUntil;
+    const peakKnown = peakFrom && peakUntil;
+
+    // Generate a prose paragraph (template, not LLM) — AI engines extract from prose,
+    // not from key-value lists. ~80–150 words including drink-window text when known.
+    const typeWord = wine.type ? wine.type.toLowerCase() : 'wine';
+    const placeWords = [wine.appellation, wine.region?.name, wine.country?.name].filter(Boolean).join(', ');
+    const grapesPhrase = grapeNames.length === 0
+      ? ''
+      : grapeNames.length === 1
+        ? `Made from ${grapeNames[0]}.`
+        : `Made from ${grapeNames.slice(0, -1).join(', ')} and ${grapeNames[grapeNames.length - 1]}.`;
+    const classificationPhrase = wine.classification
+      ? ` Classified as ${wine.classification}.`
+      : '';
+    const drinkPhrase = peakKnown
+      ? (profile.vintage
+          ? ` The ${profile.vintage} vintage is at peak maturity from ${peakFrom} to ${peakUntil}.`
+          : ` Peak maturity is from ${peakFrom} to ${peakUntil}.`)
+      : '';
+    const ratingPhrase = hasRating
+      ? ` Cellarion users rate it ${fromNormalized(wine.communityRating.averageNormalized, '5').toFixed(1)} out of 5 across ${wine.communityRating.reviewCount} ${wine.communityRating.reviewCount === 1 ? 'review' : 'reviews'}.`
+      : '';
+    const proseParagraph = `${wine.name} is a ${typeWord} produced by ${wine.producer}${placeWords ? ` in ${placeWords}` : ''}.${classificationPhrase} ${grapesPhrase}${drinkPhrase}${ratingPhrase} Track this wine and manage your cellar with Cellarion — open-source, self-hostable, free.`.replace(/\s+/g, ' ').trim();
+
+    // Per-wine FAQ — only emit a question when the underlying data exists. AI engines
+    // love quoting Q&A pairs verbatim; this is what shows up in chat answers.
+    const faqs = [];
+    if (peakKnown) {
+      faqs.push({
+        q: `When should I drink ${wine.name}?`,
+        a: `${wine.name}${profile.vintage ? ` ${profile.vintage}` : ''} reaches peak maturity between ${peakFrom} and ${peakUntil}. Outside that window, expect either underdeveloped tannins (too early) or fading fruit (too late).`
+      });
+    }
+    if (placeWords) {
+      faqs.push({
+        q: `Where is ${wine.name} from?`,
+        a: `${wine.name} is produced by ${wine.producer} in ${placeWords}.`
+      });
+    }
+    if (grapeNames.length > 0) {
+      faqs.push({
+        q: `What grapes are in ${wine.name}?`,
+        a: grapeNames.length === 1
+          ? `${wine.name} is made from ${grapeNames[0]}.`
+          : `${wine.name} is a blend of ${grapeNames.slice(0, -1).join(', ')} and ${grapeNames[grapeNames.length - 1]}.`
+      });
+    }
 
     // JSON-LD structured data — only use Product type when we have aggregateRating,
     // otherwise Google flags it as invalid (requires offers, review, or aggregateRating).
@@ -78,20 +154,28 @@ router.get('/wines/:id', ogLimiter, async (req, res) => {
           url: pageUrl
         };
 
-    const jsonLd = {
-      '@context': 'https://schema.org',
-      '@graph': [
-        mainEntity,
-        {
-          '@type': 'BreadcrumbList',
-          itemListElement: [
-            { '@type': 'ListItem', position: 1, name: 'Cellarion', item: SITE_URL },
-            { '@type': 'ListItem', position: 2, name: 'Wines', item: `${SITE_URL}/wines` },
-            { '@type': 'ListItem', position: 3, name: wine.name, item: pageUrl }
-          ]
-        }
-      ]
-    };
+    const graph = [
+      mainEntity,
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Cellarion', item: SITE_URL },
+          { '@type': 'ListItem', position: 2, name: 'Wines', item: `${SITE_URL}/wines` },
+          { '@type': 'ListItem', position: 3, name: wine.name, item: pageUrl }
+        ]
+      }
+    ];
+    if (faqs.length > 0) {
+      graph.push({
+        '@type': 'FAQPage',
+        mainEntity: faqs.map(({ q, a }) => ({
+          '@type': 'Question',
+          name: q,
+          acceptedAnswer: { '@type': 'Answer', text: a }
+        }))
+      });
+    }
+    const jsonLd = { '@context': 'https://schema.org', '@graph': graph };
 
     const html = `<!DOCTYPE html>
 <html lang="en">
@@ -118,14 +202,17 @@ router.get('/wines/:id', ogLimiter, async (req, res) => {
     <p>${esc(wine.producer)}</p>
   </header>
   <main>
+    <p>${esc(proseParagraph)}</p>
     ${wine.type ? `<p><strong>Type:</strong> ${esc(wine.type.charAt(0).toUpperCase() + wine.type.slice(1))}</p>` : ''}
     ${wine.appellation ? `<p><strong>Appellation:</strong> ${esc(wine.appellation)}</p>` : ''}
     ${wine.classification ? `<p><strong>Classification:</strong> ${esc(wine.classification)}</p>` : ''}
     ${wine.region?.name ? `<p><strong>Region:</strong> ${esc(wine.region.name)}</p>` : ''}
     ${wine.country?.name ? `<p><strong>Country:</strong> ${esc(wine.country.name)}</p>` : ''}
     ${grapeNames.length > 0 ? `<p><strong>Grapes:</strong> ${esc(grapeNames.join(', '))}</p>` : ''}
+    ${peakKnown ? `<p><strong>Drink window:</strong> ${peakFrom}–${peakUntil}${profile.vintage ? ` (${esc(profile.vintage)} vintage)` : ''}</p>` : ''}
     ${hasRating && ratingOn5 != null ? `<p><strong>Community rating:</strong> ${ratingOn5.toFixed(1)}/5 from ${wine.communityRating.reviewCount} ${wine.communityRating.reviewCount === 1 ? 'review' : 'reviews'}</p>` : ''}
     ${wine.image ? `<img src="${esc(imageUrl)}" alt="${esc(wine.name)}" width="300" />` : ''}
+    ${faqs.length > 0 ? `<section><h2>Frequently asked questions</h2>${faqs.map(({ q, a }) => `<h3>${esc(q)}</h3><p>${esc(a)}</p>`).join('')}</section>` : ''}
   </main>
   <footer>
     <p>Discover, track, and manage your wine cellar with <a href="${esc(SITE_URL)}">Cellarion</a>.</p>

--- a/backend/src/routes/sitemap.js
+++ b/backend/src/routes/sitemap.js
@@ -52,17 +52,19 @@ router.get('/', sitemapLimiter, async (req, res) => {
       xml += '  </url>\n';
     }
 
-    // Wine pages — public wine detail pages
+    // Wine pages — public wine detail pages. Prefer slug URLs when available
+    // (human-readable, AI-citable); fall back to ObjectId for any wine that
+    // hasn't been migrated yet so the sitemap stays complete.
     const wines = await WineDefinition.find()
       .sort({ updatedAt: -1 })
-      .select('_id updatedAt')
+      .select('_id slug updatedAt')
       .limit(5000)
       .lean();
 
     for (const wine of wines) {
       const lastmod = (wine.updatedAt || wine._id.getTimestamp()).toISOString().split('T')[0];
       xml += '  <url>\n';
-      xml += `    <loc>${SITE_URL}/wines/${wine._id}</loc>\n`;
+      xml += `    <loc>${SITE_URL}/wines/${wine.slug || wine._id}</loc>\n`;
       xml += `    <lastmod>${lastmod}</lastmod>\n`;
       xml += '    <changefreq>monthly</changefreq>\n';
       xml += '    <priority>0.5</priority>\n';

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -293,7 +293,7 @@ router.post('/find-or-create', requireAuth, async (req, res) => {
       }
     }
 
-    if (created) submitUrls(`/wines/${wine._id}`);
+    if (created) submitUrls(`/wines/${wine.slug || wine._id}`);
 
     res.status(created ? 201 : 200).json({ wine, created });
   } catch (err) {
@@ -341,16 +341,20 @@ router.post('/ai-info', requireAuth, async (req, res) => {
   }
 });
 
-// GET /api/wines/:id - Get single wine definition (auth required)
-// GET /api/wines/:id/public — Public wine detail (no auth required)
-// Used for shared links and social media previews.
-router.get('/:id/public', async (req, res) => {
-  try {
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+// GET /api/wines/:idOrSlug/public — Public wine detail (no auth required)
+// Accepts both ObjectId and slug. Used for shared links and social previews.
+const PUBLIC_PROJECTION = 'name producer slug country region appellation grapes type image communityRating classification';
 
-    const wine = await WineDefinition.findById(req.params.id)
+router.get('/:idOrSlug/public', async (req, res) => {
+  try {
+    const { idOrSlug } = req.params;
+    const filter = isValidId(idOrSlug)
+      ? { _id: idOrSlug }
+      : { slug: String(idOrSlug).toLowerCase() };
+
+    const wine = await WineDefinition.findOne(filter)
       .populate(['country', 'region', 'grapes'])
-      .select('name producer country region appellation grapes type image communityRating classification');
+      .select(PUBLIC_PROJECTION);
 
     if (!wine) {
       return res.status(404).json({ error: 'Wine not found' });

--- a/backend/src/scripts/migrate-wine-slugs.js
+++ b/backend/src/scripts/migrate-wine-slugs.js
@@ -1,0 +1,104 @@
+/**
+ * Backfill `slug` on all WineDefinition documents that don't have one yet.
+ *
+ * Idempotent — running it twice is safe (it skips docs that already have a slug).
+ * Run inside the backend container:
+ *   docker exec cellarion-backend node src/scripts/migrate-wine-slugs.js
+ *
+ * Logs collisions so you can audit ugly fallbacks (`-2`, `-3`) before the next deploy.
+ */
+
+const mongoose = require('mongoose');
+const connectDB = require('../config/db');
+const WineDefinition = require('../models/WineDefinition');
+const { generateWineSlug } = require('../utils/normalize');
+
+(async () => {
+  await connectDB();
+
+  // Ensure the new sparse-unique slug index exists in Mongo before we start writing.
+  // Without this, the bulk update can briefly allow duplicate slugs.
+  await WineDefinition.syncIndexes();
+
+  const total = await WineDefinition.countDocuments({});
+  const missing = await WineDefinition.countDocuments({ slug: { $exists: false } });
+  console.log(`[migrate-wine-slugs] ${total} total wines, ${missing} need a slug`);
+
+  if (missing === 0) {
+    console.log('[migrate-wine-slugs] nothing to do');
+    await mongoose.disconnect();
+    return;
+  }
+
+  // In-memory set of slugs we've claimed in this run, plus existing slugs from DB.
+  // Prevents duplicate slug assignment across the batch without 5000 round-trips.
+  const taken = new Set(
+    (await WineDefinition.find({ slug: { $exists: true, $ne: null } })
+      .select('slug')
+      .lean()).map(d => d.slug)
+  );
+
+  const cursor = WineDefinition.find({ slug: { $exists: false } })
+    .select('_id name producer')
+    .cursor();
+
+  const ops = [];
+  const collisions = [];
+  let updated = 0;
+  let empty = 0;
+
+  for (let doc = await cursor.next(); doc != null; doc = await cursor.next()) {
+    const base = generateWineSlug(doc.name, doc.producer);
+    if (!base) {
+      empty++;
+      continue;
+    }
+
+    let candidate = base;
+    let suffix = 2;
+    while (taken.has(candidate)) {
+      candidate = `${base}-${suffix}`;
+      suffix++;
+    }
+    if (candidate !== base) {
+      collisions.push({ id: doc._id.toString(), name: doc.name, producer: doc.producer, slug: candidate });
+    }
+    taken.add(candidate);
+
+    ops.push({
+      updateOne: {
+        filter: { _id: doc._id },
+        update: { $set: { slug: candidate } }
+      }
+    });
+    updated++;
+
+    if (ops.length >= 500) {
+      await WineDefinition.bulkWrite(ops, { ordered: false });
+      ops.length = 0;
+    }
+  }
+
+  if (ops.length > 0) {
+    await WineDefinition.bulkWrite(ops, { ordered: false });
+  }
+
+  console.log(`[migrate-wine-slugs] updated ${updated} docs`);
+  if (empty > 0) {
+    console.log(`[migrate-wine-slugs] WARNING: ${empty} docs had unsluggable name/producer — left unchanged`);
+  }
+  if (collisions.length > 0) {
+    console.log(`[migrate-wine-slugs] ${collisions.length} slug collisions resolved with numeric suffix:`);
+    for (const c of collisions.slice(0, 20)) {
+      console.log(`  - ${c.slug}  (${c.producer} / ${c.name})  _id=${c.id}`);
+    }
+    if (collisions.length > 20) {
+      console.log(`  …and ${collisions.length - 20} more (full list in DB by querying for slugs ending in -N)`);
+    }
+  }
+
+  await mongoose.disconnect();
+})().catch(err => {
+  console.error('[migrate-wine-slugs] FAILED:', err);
+  process.exit(1);
+});

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -289,10 +289,41 @@ const resolveGrapeName = (name) => {
   return GRAPE_SYNONYMS[key] || name.trim();
 };
 
+/**
+ * Convert any string to a URL-safe slug (lowercase, hyphenated, ASCII-only).
+ * Builds on normalizeString (which already strips diacritics and punctuation).
+ */
+const slugify = (str) => {
+  if (!str) return '';
+  return normalizeString(str)
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 80);
+};
+
+/**
+ * Build a vintage-neutral slug for a WineDefinition. If the wine name already
+ * starts with the producer name, we don't duplicate the producer ("Cloudy Bay
+ * Sauvignon Blanc" produced by "Cloudy Bay" → "cloudy-bay-sauvignon-blanc",
+ * not "cloudy-bay-cloudy-bay-sauvignon-blanc").
+ */
+const generateWineSlug = (name, producer) => {
+  const nName = normalizeString(name);
+  const nProducer = normalizeString(producer);
+  if (!nName) return slugify(producer);
+  if (!nProducer || nName === nProducer || nName.startsWith(nProducer + ' ')) {
+    return slugify(name);
+  }
+  return slugify(`${producer} ${name}`);
+};
+
 module.exports = {
   normalizeString,
   tokenize,
   generateWineKey,
+  generateWineSlug,
+  slugify,
   resolveGrapeName,
   levenshteinDistance,
   calculateSimilarity,

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -89,13 +89,24 @@ server {
     # structured data (JSON-LD), and meta tags from the backend OG endpoints.
     # Real users get the SPA as usual. Uses $is_crawler map variable.
 
-    # Wine detail pages — /wines/<ObjectId>
+    # Wine detail pages — accepts both /wines/<ObjectId> AND /wines/<slug>.
+    # The og.js endpoint 301-redirects ObjectId URLs to their slug form when
+    # one exists, preserving link equity from any external links to old URLs.
     location ~ "^/wines/([a-f0-9]{24})$" {
         error_page 418 = @wine_og;
         if ($is_crawler) {
             return 418;
         }
-        # Real users get the SPA
+        # Real users get the SPA — frontend handles ObjectId→slug replaceState there
+        root       /usr/share/nginx/html;
+        try_files  /index.html =404;
+    }
+
+    location ~ "^/wines/([a-z0-9]+(?:-[a-z0-9]+)*)$" {
+        error_page 418 = @wine_og;
+        if ($is_crawler) {
+            return 418;
+        }
         root       /usr/share/nginx/html;
         try_files  /index.html =404;
     }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -328,7 +328,7 @@ function AppRoutes() {
         />
 
         {/* Public content — no auth required */}
-        <Route path="/wines/:id" element={<WineDetail />} />
+        <Route path="/wines/:idOrSlug" element={<WineDetail />} />
         <Route path="/blog" element={<Layout><Blog /></Layout>} />
         <Route path="/blog/:slug" element={<Layout><BlogPost /></Layout>} />
         <Route path="/help" element={<Layout><Help /></Layout>} />

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -297,7 +297,7 @@ function BottleDetail() {
                 <ShareButton
                   title={displayName}
                   text={`Check out ${displayName}${displayProducer ? ` by ${displayProducer}` : ''} on Cellarion`}
-                  url={`${SITE_URL}/wines/${wine._id}`}
+                  url={`${SITE_URL}/wines/${wine.slug || wine._id}`}
                   onRecommend={() => setRecommendOpen(true)}
                   variant="icon"
                 />

--- a/frontend/src/pages/WineDetail.js
+++ b/frontend/src/pages/WineDetail.js
@@ -11,9 +11,13 @@ import { getWineImageUrl } from '../utils/wineImageUrl';
 import { API_URL } from '../api/apiConstants';
 import './WineDetail.css';
 
+// Same regex used by the backend's isValidId — 24 hex chars = ObjectId, anything
+// else is treated as a slug.
+const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
+
 export default function WineDetail() {
   const { t } = useTranslation();
-  const { id } = useParams();
+  const { idOrSlug } = useParams();
   const { user } = useAuth();
   const [wine, setWine] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -22,10 +26,16 @@ export default function WineDetail() {
   useEffect(() => {
     const fetchWine = async () => {
       try {
-        const res = await fetch(`${API_URL}/api/wines/${id}/public`);
+        const res = await fetch(`${API_URL}/api/wines/${encodeURIComponent(idOrSlug)}/public`);
         if (res.ok) {
           const data = await res.json();
           setWine(data.wine);
+          // If we landed on an ObjectId URL but the wine has a slug, transparently
+          // upgrade the URL bar to the slug so users see + share the pretty form.
+          // replaceState avoids a navigation event and preserves history.
+          if (OBJECT_ID_RE.test(idOrSlug) && data.wine?.slug) {
+            window.history.replaceState(null, '', `/wines/${data.wine.slug}`);
+          }
         } else {
           setError(t('wineDetail.wineNotFound'));
         }
@@ -35,7 +45,7 @@ export default function WineDetail() {
       setLoading(false);
     };
     fetchWine();
-  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [idOrSlug]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading) return <div className="wd-loading">Loading...</div>;
   if (error || !wine) {
@@ -50,6 +60,9 @@ export default function WineDetail() {
 
   const fullTitle = `${wine.name} — ${wine.producer}`;
   const titleTag = fullTitle.length > 47 ? fullTitle.slice(0, 57) : `${fullTitle} — Cellarion`;
+  // Canonical URL: prefer slug whenever the wine has one. ObjectId is the fallback
+  // for any wine not yet migrated.
+  const winePath = `/wines/${wine.slug || wine._id}`;
   const description = [
     wine.type && wine.type.charAt(0).toUpperCase() + wine.type.slice(1),
     wine.appellation,
@@ -58,7 +71,7 @@ export default function WineDetail() {
   ].filter(Boolean).join(' · ');
   const fullDesc = `${fullTitle}. ${description}. Discover, track, and manage your wine cellar with Cellarion.`;
   const metaDescription = fullDesc.length > 160 ? fullDesc.slice(0, 157) + '...' : fullDesc;
-  const pageUrl = `${SITE_URL}/wines/${wine._id}`;
+  const pageUrl = `${SITE_URL}${winePath}`;
   const wineImageSrc = getWineImageUrl(wine.image);
   const imageUrl = wineImageSrc || `${SITE_URL}/cellarion-logo.jpg`;
   const grapeNames = wine.grapes?.map(g => g.name).filter(Boolean) || [];
@@ -112,7 +125,7 @@ export default function WineDetail() {
       <SEOHead
         title={titleTag}
         description={metaDescription}
-        path={`/wines/${wine._id}`}
+        path={winePath}
         image={imageUrl}
         ogType={hasRating ? 'product' : 'website'}
         jsonLd={jsonLd}


### PR DESCRIPTION
## Summary

The single biggest remaining AI-citation lever after Phase 1 made the site crawlable. AI engines preferentially cite human-readable URLs and quote prose / Q&A pairs verbatim — neither was happening before this change.

`/wines/507f1f77bcf86cd799439011` → `/wines/chateau-margaux` (with a 301 from the old URL so external links keep working forever).

## What's in it

### Slugs

- New `slug` field on `WineDefinition` (sparse-unique, indexed) with a pre-save hook that auto-generates from name + producer for new wines, with `-2`/`-3` collision suffixes
- New `utils/normalize.js` helpers: `slugify()` and `generateWineSlug()` (smart enough to not duplicate the producer when the wine name already starts with it — "Cloudy Bay Sauvignon Blanc" by "Cloudy Bay" → `cloudy-bay-sauvignon-blanc`, not the redundant doubled form)
- Idempotent migration script `backend/src/scripts/migrate-wine-slugs.js` — populates slugs for existing wines, logs collisions, runs `syncIndexes()` first for unique-index enforcement

### Backwards-compat routing

- `og.js` accepts both ObjectId and slug. When an ObjectId comes in for a wine that has a slug, returns 301 to the slug URL — link equity transfers, external links to old URLs keep working
- Public API `/api/wines/:idOrSlug/public` accepts both forms; the response includes `slug` so the frontend can canonicalise
- Nginx adds a second location for slug-shaped paths alongside the existing ObjectId one
- `WineDetail.js`: when landing on an ObjectId URL, fetches by it, then `replaceState` to the slug URL — real users see the pretty form without a navigation event
- Sitemap, IndexNow submissions, and the share button on `BottleDetail` all emit slug URLs (with ObjectId fallback for wines not yet migrated)

### Content depth in `og.js` wine renderer

- **Generated prose paragraph** (deterministic template, NOT LLM): producer, type, region/country, grapes, classification, drink-window when a reviewed `WineVintageProfile` exists. 80–150 words, AI-extractable
- **Per-wine FAQ** — emitted only when underlying data exists (no empty questions). "When should I drink X?" / "Where is X from?" / "What grapes are in X?". Visible in HTML body AND mirrored verbatim in `FAQPage` JSON-LD (Google penalises schema-only Q&A)

## Test plan

- [x] 256 frontend + 340 backend tests pass
- [x] `docker compose up --build` produces a clean working stack
- [x] Migration runs successfully against the seeded DB (324 wines, 1 collision resolved with `-2` suffix)
- [x] `curl -A "ClaudeBot" /wines/chateau-margaux` returns og.js HTML with prose paragraph + visible FAQ section + FAQPage JSON-LD with matching Q&A
- [x] `curl -A "ClaudeBot" /wines/<oldObjectId>` returns `HTTP/1.1 301 Moved Permanently` to the slug URL
- [x] `curl -L -A "ClaudeBot" /wines/<oldObjectId>` follows the 301 and lands on the slug body
- [x] `curl -A "Mozilla Chrome" /wines/chateau-margaux` returns the SPA shell (real users unaffected)
- [x] `sitemap.xml` emits slug URLs
- [ ] Browser: visit `/wines/<oldObjectId>` → URL bar should auto-update to `/wines/<slug>` without a full navigation
- [ ] Google Rich Results Test on a deployed wine page → Product (or WebPage) + BreadcrumbList + FAQPage all valid

## Post-merge deployment

```bash
ssh prod
cd /path/to/Cellarion
git pull origin main

# Pull or rebuild — depends on your prod setup
docker compose -f docker-compose-prod.yml pull       # if using GHCR images
# or:
docker compose -f docker-compose-prod.yml build frontend backend  # if building locally

docker compose -f docker-compose-prod.yml up -d frontend backend

# REQUIRED: backfill slugs for existing wines
docker exec cellarion-backend node src/scripts/migrate-wine-slugs.js

# Verify
docker exec cellarion-mongo mongosh winecellar --quiet --eval 'db.winedefinitions.countDocuments({slug: {$exists: true}})'
# Should equal total wine count (324 in seed; whatever you have in prod)

# Critical post-deploy verification
curl -A "ClaudeBot" https://cellarion.app/wines/chateau-margaux | head -30
# Should show prose paragraph + <h1> + JSON-LD with FAQPage

curl -I -A "ClaudeBot" https://cellarion.app/wines/<some-old-objectid>
# Should return 301 to /wines/<slug>
```

The migration is idempotent — running it twice is safe (it skips docs that already have a slug). It picks up any new wines added between deploy + migration.

After deploy, GSC will see ~5000 new URLs + 5000 redirects appear. This settles in 2–4 weeks and IndexNow accelerates indexing for Bing.

## Risks & mitigations

- **Link rot** from external sites linking to old ObjectId URLs → mitigated by the 301 redirect in og.js and the SPA's replaceState. Verified working in smoke tests.
- **Slug collisions** → migration logs them with full producer/name context. Visual review the log after running. Default `-2` suffix is acceptable; you can manually rename via Mongo if you want a cleaner slug.
- **Sitemap churn** for AI engines → expected, settles quickly. IndexNow already wired and pushes new URLs to Bing immediately.

Plan: `C:\Users\jagdu\.claude\plans\i-want-the-site-floofy-flask.md` — Phase 2 of 4.