### PR TITLE
Pass Umami analytics build args to frontend GHCR image

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           context: ./frontend
           push: true
+          build-args: |
+            APP_VERSION=${{ steps.vars.outputs.tag }}
+            REACT_APP_UMAMI_URL=${{ vars.REACT_APP_UMAMI_URL }}
+            REACT_APP_UMAMI_WEBSITE_ID=${{ vars.REACT_APP_UMAMI_WEBSITE_ID }}
           tags: |
             ghcr.io/${{ steps.vars.outputs.owner }}/cellarion-frontend:${{ steps.vars.outputs.tag }}
             ghcr.io/${{ steps.vars.outputs.owner }}/cellarion-frontend:latest


### PR DESCRIPTION
Adds `REACT_APP_UMAMI_URL` and `REACT_APP_UMAMI_WEBSITE_ID` as build args to the frontend Docker build step in the release workflow.

These are CRA build-time vars that get baked into the JavaScript bundle by webpack — they cannot be injected at runtime. Previously, GHCR images were built without them, so the `Analytics.js` component was always a no-op on prod even when env vars were set on the server.

After this PR, any release image will include the Umami tracker if the two variables are set in **GitHub → Settings → Secrets and variables → Actions → Variables** (not Secrets — they appear in the page source anyway).

## Setup required before next release

1. Go to https://github.com/jagduvi1/Cellarion/settings/variables/actions
2. Click **New repository variable** — add:
   - `REACT_APP_UMAMI_URL` = `https://analytics.cellarion.app`
   - `REACT_APP_UMAMI_WEBSITE_ID` = `<UUID from your Umami dashboard>`
3. Cut a new release (or manually re-run the release workflow) — the GHCR image will have the tracker baked in.

If the variables are not set, `vars.REACT_APP_UMAMI_URL` resolves to an empty string, `Analytics.js` renders nothing, and the build proceeds normally. Fully backwards-compatible.