### PR TITLE
Guard Analytics against cross-domain tracking on self-hosted installs

### DIFF
--- a/frontend/src/components/Analytics.js
+++ b/frontend/src/components/Analytics.js
@@ -7,13 +7,29 @@ import { Helmet } from 'react-helmet-async';
 //   REACT_APP_UMAMI_URL          e.g. https://analytics.cellarion.app
 //   REACT_APP_UMAMI_WEBSITE_ID   uuid from the Umami dashboard
 //
-// If either is missing (e.g. local dev without analytics) the script isn't injected
-// and the component is a no-op. No CSP changes needed for that case.
+// If either is missing the script isn't injected — analytics is fully opt-in.
+//
+// IMPORTANT — hostname guard: these vars are baked into the pre-built GHCR image,
+// so without this check self-hosters running that image on their own domain would
+// send their users' data to cellarion.app's Umami. The guard ensures the tracker
+// only fires on the domain the URL var points to.
 export default function Analytics() {
   const url = process.env.REACT_APP_UMAMI_URL;
   const websiteId = process.env.REACT_APP_UMAMI_WEBSITE_ID;
 
   if (!url || !websiteId) return null;
+
+  // Derive the expected hostname from the configured URL and compare it to the
+  // current page hostname at runtime. This works even after the vars are baked in.
+  try {
+    const expectedHost = new URL(url).hostname
+      .replace(/^www\./, '');
+    const currentHost = window.location.hostname
+      .replace(/^www\./, '');
+    if (currentHost !== expectedHost) return null;
+  } catch {
+    return null;
+  }
 
   return (
     <Helmet>


### PR DESCRIPTION
## Problem

`REACT_APP_UMAMI_URL` and `REACT_APP_UMAMI_WEBSITE_ID` are baked into the pre-built GHCR frontend image. Anyone who pulls `ghcr.io/jagduvi1/cellarion-frontend:latest` for their own self-hosted Cellarion instance would unknowingly send their users' traffic to cellarion.app's Umami dashboard.

## Fix

`Analytics.js` now performs a runtime hostname check before injecting the tracker script:

```js
const expectedHost = new URL(url).hostname.replace(/^www\./, '');
const currentHost  = window.location.hostname.replace(/^www\./, '');
if (currentHost !== expectedHost) return null;
```

This derives the expected production hostname from `REACT_APP_UMAMI_URL` at render time and compares it against `window.location.hostname`. If they don't match (e.g. someone running on `localhost`, `192.168.x.x`, or `their-own-domain.com`), the component returns null and no `<script>` tag is injected.

**Result:** The tracker only ever fires on `cellarion.app` — or whatever domain the instance owner configured as their own Umami URL. Self-hosters using the GHCR image are fully isolated.

## Test

- 256/256 frontend tests pass
- To verify manually: the script should inject on `cellarion.app` and be absent on any other hostname