### PR TITLE
Bump package.json versions to 1.47.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.47.1",
+  "version": "1.47.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.47.1",
+  "version": "1.47.2",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^10.7.7",


### PR DESCRIPTION
Phase 2 (wine slugs + prose + FAQ schema) + Analytics hostname guard.