### PR TITLE
Stop auto-saving user label scan images to shared wine registry

### DIFF
--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -1,5 +1,3 @@
-const fs = require('fs');
-const path = require('path');
 const express = require('express');
 const mongoose = require('mongoose');
 const WineDefinition = require('../models/WineDefinition');
@@ -8,7 +6,6 @@ const { requireAuth } = require('../middleware/auth');
 const { scanLabelFull, identifyWineFromQuery } = require('../services/labelScan');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
 const { generateWineKey, combinedSimilarity } = require('../utils/normalize');
-const { PROCESSED_DIR } = require('../config/upload');
 const { parsePagination } = require('../utils/pagination');
 const { isValidId } = require('../utils/validation');
 const { submitUrls } = require('../services/indexNow');
@@ -270,28 +267,6 @@ router.post('/find-or-create', requireAuth, async (req, res) => {
       { name, producer, country, region, appellation, type, grapes: grapes || [] },
       req.user.id
     );
-
-    // Save label image as wine's registry image if:
-    //   - a labelImage was provided, AND
-    //   - the wine has no image yet (don't overwrite an existing one)
-    if (labelImage && !wine.image) {
-      try {
-        // labelImage is a data URL: "data:<type>;base64,<data>"
-        const matches = labelImage.match(/^data:([^;]+);base64,(.+)$/);
-        if (matches) {
-          const ext = matches[1] === 'image/png' ? '.png' : '.jpg';
-          const buf = Buffer.from(matches[2], 'base64');
-          const filename = `wine-label-${wine._id}-${Date.now()}${ext}`;
-          const filepath = path.join(PROCESSED_DIR, filename);
-          fs.writeFileSync(filepath, buf);
-          wine.image = `/api/uploads/processed/${filename}`;
-          await WineDefinition.findByIdAndUpdate(wine._id, { image: wine.image });
-          searchService.indexWine(wine._id); // keep search index in sync
-        }
-      } catch (imgErr) {
-        console.warn('Failed to save wine label image:', imgErr.message);
-      }
-    }
 
     if (created) submitUrls(`/wines/${wine.slug || wine._id}`);
 


### PR DESCRIPTION
## Problem

When a user scanned a bottle label on a wine that had no image yet, the label photo was automatically saved to `WineDefinition.image` and became the public registry image for that wine — visible to all users, including on the public `/wines/:slug` page which requires no login.

This means a user's personal label photo (which may be low quality, badly cropped, or show identifying information) was being promoted to the shared wine registry without any admin review.

## Fix

Removed the 12-line block from `POST /api/wines/find-or-create` that saved `labelImage` to `WineDefinition`. The `labelImage` argument is now silently ignored in that endpoint.

Also removed the now-unused `fs`, `path`, and `PROCESSED_DIR` imports.

## What's unaffected

- Admin image management (`/api/admin/images`) — admins can still set/approve wine registry images
- User bottle images (`BottleImage` model) — per-bottle user photos are unaffected
- Label scanning itself — the scan still works, extracted wine data still flows through, only the auto-promotion of the photo to the shared registry is removed

## Existing data

Wines that already have user-uploaded images via this flow (like `chateau-montelena-cabernet-sauvignon` in prod) will continue showing their existing image. To clean those up, an admin can clear the image via `/admin/wines` → edit wine → remove image. There's no automated cleanup script — manual admin action per affected wine.

340/340 backend tests pass.