### PR TITLE
Fix analytics hostname guard — was blocking all tracking on prod

### DIFF
--- a/frontend/src/components/Analytics.js
+++ b/frontend/src/components/Analytics.js
@@ -33,11 +33,22 @@ export default function Analytics() {
 
   if (!url || !websiteId) return null;
 
-  // Hostname guard
+  // Hostname guard — compare the base domain (eTLD+1) of the Umami URL against
+  // the current page domain. This ensures the tracker only fires when the site
+  // is running on the same root domain as the analytics instance.
+  //
+  // Example: REACT_APP_UMAMI_URL = "https://analytics.cellarion.app"
+  //   → baseDomain = "cellarion.app"
+  //   → only fires when window.location.hostname ends with "cellarion.app"
+  //   → self-hosters on "their-domain.com" are excluded automatically
   try {
-    const expectedHost = new URL(url).hostname.replace(/^www\./, '');
-    const currentHost = window.location.hostname.replace(/^www\./, '');
-    if (currentHost !== expectedHost) return null;
+    const getBase = (hostname) => {
+      const parts = hostname.replace(/^www\./, '').split('.');
+      return parts.length >= 2 ? parts.slice(-2).join('.') : hostname;
+    };
+    const expectedBase = getBase(new URL(url).hostname);
+    const currentBase = getBase(window.location.hostname);
+    if (currentBase !== expectedBase) return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
The guard introduced in #331 was broken: it compared `analytics.cellarion.app` (the Umami URL hostname) against `cellarion.app` (the current site). These never match, so the tracker returned null on every page — effectively disabling analytics entirely from v1.47.2 onwards.

Fix: compare the base domain (eTLD+1) of both hostnames instead of the full hostname. `analytics.cellarion.app` → `cellarion.app`, `cellarion.app` → `cellarion.app` — they match and tracking resumes. Self-hosters on `their-domain.com` still get `their-domain.com` which doesn't match `cellarion.app`, so the guard still works as intended.