### PR TITLE
Show image thumbnail in admin wine list

### DIFF
--- a/frontend/src/pages/AdminWines.css
+++ b/frontend/src/pages/AdminWines.css
@@ -220,6 +220,27 @@
   flex-wrap: wrap;
 }
 
+/* ── Wine image thumbnail in list ── */
+.col-img {
+  width: 44px;
+  padding-right: 0;
+}
+
+.wine-list-thumb {
+  display: block;
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.wine-list-thumb--empty {
+  background: var(--color-border-light, #e8e4e0);
+  border: 1px dashed var(--color-border);
+}
+
 @media (max-width: 768px) {
   .wines-filter-bar {
     flex-direction: column;

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -12,6 +12,7 @@ import { WINE_TYPES } from '../config/wineTypes';
 import GrapePicker from '../components/GrapePicker';
 import ImageUpload from '../components/ImageUpload';
 import ImageGallery from '../components/ImageGallery';
+import { getWineImageUrl } from '../utils/wineImageUrl';
 import './AdminWines.css';
 
 const emptyForm = {
@@ -539,6 +540,7 @@ function AdminWines() {
           <table className="wines-table">
             <thead>
               <tr>
+                <th className="col-img"></th>
                 <th>{t('admin.wines.nameLabel')}</th>
                 <th>{t('admin.wines.producerLabel')}</th>
                 <th>{t('admin.wines.countryLabel')}</th>
@@ -549,8 +551,15 @@ function AdminWines() {
               </tr>
             </thead>
             <tbody>
-              {wines.map(wine => (
+              {wines.map(wine => {
+                const imgSrc = getWineImageUrl(wine.image);
+                return (
                 <tr key={wine._id} className={editWine?._id === wine._id ? 'row-editing' : ''}>
+                  <td className="col-img">
+                    {imgSrc
+                      ? <img src={imgSrc} alt={wine.name} className="wine-list-thumb" />
+                      : <span className="wine-list-thumb wine-list-thumb--empty" />}
+                  </td>
                   <td className="wine-name">{wine.name}</td>
                   <td>{wine.producer}</td>
                   <td>{wine.country?.name || '—'}</td>
@@ -576,7 +585,8 @@ function AdminWines() {
                     </button>
                   </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
Adds a 40×40 thumbnail as the first column in the admin wine library. Wines with an image show the photo; wines without show a dashed grey placeholder. Makes it immediately obvious which wines have user-uploaded registry images (the bug introduced before #335 fixed it) so the admin can quickly find and clear them without opening each wine individually.