### PR TITLE
Add 'Remove default image' button to admin wine edit form

### DIFF
--- a/frontend/src/pages/AdminWines.css
+++ b/frontend/src/pages/AdminWines.css
@@ -220,6 +220,39 @@
   flex-wrap: wrap;
 }
 
+/* ── Current default image in edit form ── */
+.wine-image-current {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px;
+  margin-bottom: 16px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 8px);
+}
+
+.wine-image-current-thumb {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.wine-image-current-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wine-image-current-label {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
 /* ── Wine image thumbnail in list ── */
 .col-img {
   width: 44px;

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -473,6 +473,44 @@ function AdminWines() {
                 <div className="form-group wine-image-section" style={{ gridColumn: '1 / -1' }}>
                   <label>Wine Images</label>
                   <p className="wine-image-hint">{t('admin.wines.defaultImageHint', 'Click the star to set the default image for this wine.')}</p>
+
+                  {/* Current default image with explicit remove button. The
+                      WineDefinition.image field can hold a URL that doesn't
+                      correspond to a WineImage record (legacy auto-saved
+                      label scans), so the gallery alone can't clear it. */}
+                  {editWine.image && (
+                    <div className="wine-image-current">
+                      <img
+                        src={getWineImageUrl(editWine.image)}
+                        alt={editWine.name}
+                        className="wine-image-current-thumb"
+                      />
+                      <div className="wine-image-current-info">
+                        <p className="wine-image-current-label">Current default image</p>
+                        <button
+                          type="button"
+                          className="btn btn-danger btn-small"
+                          onClick={async () => {
+                            try {
+                              const res = await adminSaveWine(apiFetch, { image: null }, editWine._id);
+                              if (res.ok) {
+                                setEditWine({ ...editWine, image: null });
+                                fetchWines();
+                              } else {
+                                const data = await res.json().catch(() => ({}));
+                                setFormError(data.error || 'Failed to remove image');
+                              }
+                            } catch {
+                              setFormError('Network error while removing image');
+                            }
+                          }}
+                        >
+                          Remove default image
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
                   <div className="wine-image-existing">
                     <ImageGallery
                       ref={galleryRef}


### PR DESCRIPTION
Fixes a gap in the admin UI: when a WineDefinition has an image URL that doesn't correspond to a record in the WineImage gallery (e.g. the legacy auto-saved label scans from the bug fixed in #335), there's no way to clear it from the edit form.

This adds an explicit "Current default image" block above the gallery showing the actual image with a Remove button. The button calls the existing admin PUT endpoint with `{ image: null }` — only clears WineDefinition.image, leaves user bottle photos in the BottleImage collection untouched.

Result for the user who originally scanned the label: they still see their own photo on their bottle detail page (BottleImage record unchanged). Result for everyone else: the public wine page no longer shows that user's personal photo.