### PR TITLE
Auto-promote gallery image when admin clears wine default (v1.47.8)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.47.7",
+  "version": "1.47.8",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -291,7 +291,38 @@ router.put('/:id', async (req, res) => {
     if (appellation !== undefined) wine.appellation = appellation?.trim();
     if (grapes !== undefined) wine.grapes = grapes;
     if (type) wine.type = type;
-    if (image !== undefined) wine.image = image || null;
+
+    // Image handling. When the admin clears the default image, look for an
+    // approved+public gallery image to promote in its place — otherwise the
+    // wine ends up with no image even though candidates exist (the legacy
+    // label-scan URL bug left wines in this state after Remove default image).
+    if (image !== undefined) {
+      if (image) {
+        wine.image = image;
+      } else {
+        const replacement = await BottleImage.findOne({
+          wineDefinition: wine._id,
+          status: 'approved',
+          visibility: 'public'
+        }).sort({ assignedToWine: -1, createdAt: -1 });
+
+        // Clear stale assignedToWine flags so only the new default carries it
+        await BottleImage.updateMany(
+          { wineDefinition: wine._id, assignedToWine: true },
+          { assignedToWine: false }
+        );
+
+        if (replacement) {
+          replacement.assignedToWine = true;
+          await replacement.save();
+          wine.image = replacement.processedUrl || replacement.originalUrl;
+          wine.imageCredit = replacement.credit || null;
+        } else {
+          wine.image = null;
+          wine.imageCredit = null;
+        }
+      }
+    }
 
     // Regenerate normalized key if name, producer, or appellation changed
     if (name || producer || appellation !== undefined) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.47.7",
+  "version": "1.47.8",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^10.7.7",

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -494,7 +494,11 @@ function AdminWines() {
                             try {
                               const res = await adminSaveWine(apiFetch, { image: null }, editWine._id);
                               if (res.ok) {
-                                setEditWine({ ...editWine, image: null });
+                                // Server may auto-promote an approved gallery
+                                // image — use the response value, not null.
+                                const data = await res.json().catch(() => ({}));
+                                setEditWine({ ...editWine, image: data.wine?.image ?? null });
+                                galleryRef.current?.refresh();
                                 fetchWines();
                               } else {
                                 const data = await res.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- When admin clicks **Remove default image** on a wine, the API now looks for an approved+public \`BottleImage\` in the wine's gallery and promotes the most recent one in place of the cleared URL.
- Falls back to \`wine.image = null\` when no candidates exist (preserves prior behavior).
- Stale \`assignedToWine\` flags are cleared in both paths so only the new default carries it.
- Frontend reads \`wine.image\` back from the API response so the edit form reflects whichever image was promoted.

## Why
The legacy label-scan bug (fixed in #335) left many wines with a bad URL in \`WineDefinition.image\` while approved gallery images sat unused. Admins fixing those wines via **Remove default image** (added in #341) cleared the bad URL but left the wine imageless — even though the gallery had a clean replacement. They had to remember to click the star on the gallery image as a separate step. This makes the cleanup one click.

## Test plan
- [ ] On a wine with both \`WineDefinition.image\` set and one or more approved+public gallery images: click **Remove default image** → confirm the wine now shows the most recent gallery image, and that image's star icon is highlighted.
- [ ] On a wine with \`WineDefinition.image\` set but no approved gallery images: click **Remove default image** → confirm wine.image clears to null (current behavior).
- [ ] Bottle list in cellar: bottles of a wine that previously had no image should now show the auto-promoted image without per-bottle starring.