### PR TITLE
Select quantity field content on focus when adding bottle (v1.47.9)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.47.8",
+  "version": "1.47.9",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.47.8",
+  "version": "1.47.9",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^10.7.7",

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -669,6 +669,7 @@ function AddBottle() {
                   type="number"
                   value={numBottles}
                   onChange={(e) => setNumBottles(Math.max(1, parseInt(e.target.value) || 1))}
+                  onFocus={(e) => e.target.select()}
                   min="1"
                   required
                 />


### PR DESCRIPTION
## Summary
- The Number of Bottles input defaulted to \`1\`. The cursor landed after that \`1\` on focus, so typing \`4\` produced \`14\` and the user ended up adding 14 bottles instead of 4.
- Adding \`onFocus={(e) => e.target.select()}\` selects the existing value on focus so the next keypress replaces it.

## Test plan
- [ ] Open Add Bottle, click into Number of Bottles → existing value highlights, typing replaces it cleanly.
- [ ] Tab into the field with the keyboard → same select-all behavior.
- [ ] Manually editing (e.g. arrow keys, backspace) still works as expected after focus.