### PR TITLE
Link the in-app version to its GitHub release notes

### DIFF
--- a/frontend/src/pages/Login.css
+++ b/frontend/src/pages/Login.css
@@ -163,6 +163,15 @@
   margin-top: 0.5rem;
 }
 
+.login-version a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.login-version a:hover {
+  text-decoration: underline;
+}
+
 .consent-group {
   margin-top: 0.5rem;
 }

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -113,7 +113,15 @@ function Login() {
         <a href="mailto:support@cellarion.app">Contact support</a>.
       </p>
       {appVersion && (
-        <p className="login-version">v{appVersion}</p>
+        <p className="login-version">
+          <a
+            href={`https://github.com/jagduvi1/Cellarion/releases/tag/v${appVersion}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            v{appVersion}
+          </a>
+        </p>
       )}
     </footer>
   );

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -166,6 +166,15 @@
   opacity: 0.6;
 }
 
+.settings-version a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.settings-version a:hover {
+  text-decoration: underline;
+}
+
 .settings-danger-card {
   border: 1px solid var(--color-danger, #c0392b);
 }

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -627,7 +627,16 @@ function Settings() {
       </div>
 
       {appVersion && (
-        <p className="settings-version">Cellarion v{appVersion}</p>
+        <p className="settings-version">
+          Cellarion{' '}
+          <a
+            href={`https://github.com/jagduvi1/Cellarion/releases/tag/v${appVersion}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            v{appVersion}
+          </a>
+        </p>
       )}
     </div>
   );

--- a/frontend/src/pages/SuperAdmin.css
+++ b/frontend/src/pages/SuperAdmin.css
@@ -61,6 +61,15 @@
   letter-spacing: 0;
 }
 
+.sa-topbar-title span a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.sa-topbar-title span a:hover {
+  text-decoration: underline;
+}
+
 .sa-topbar-meta {
   font-size: 11px;
   color: var(--sa-text-dim);

--- a/frontend/src/pages/SuperAdmin/index.js
+++ b/frontend/src/pages/SuperAdmin/index.js
@@ -73,7 +73,18 @@ export default function SuperAdmin() {
       <div className="sa-topbar">
         <div className="sa-topbar-title">
           CELLARION SYSTEM MONITOR
-          <span>v{appVersion || '—'} · {user.email}</span>
+          <span>
+            {appVersion ? (
+              <a
+                href={`https://github.com/jagduvi1/Cellarion/releases/tag/v${appVersion}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                v{appVersion}
+              </a>
+            ) : 'v—'}
+            {' · '}{user.email}
+          </span>
         </div>
         <div className="sa-topbar-meta">
           <span>Last refresh: {lastRefresh.toLocaleTimeString()}</span>


### PR DESCRIPTION
## Summary

Wraps the version string shown in three places (Login footer, Settings, SuperAdmin topbar) in an anchor pointing at the matching GitHub release tag, so users can click the version to see what changed. Format: `https://github.com/jagduvi1/Cellarion/releases/tag/v${version}`. Opens in a new tab with `rel="noopener noreferrer"`.

The link inherits the surrounding muted color and only underlines on hover, so the existing visual treatment is preserved. If a user is running a version that has no GitHub release yet (mid-cycle bump), the link 404s — acceptable per the original ask.

## Test plan

- [x] Frontend: 256 passing
- [ ] Visit /login, /settings, /super-admin and confirm the version is now a clickable link that opens the release notes