### PR TITLE
Bump package.json versions to 1.47.11

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.47.10",
+  "version": "1.47.11",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.47.10",
+  "version": "1.47.11",
   "private": true,
   "dependencies": {
     "@react-three/drei": "^10.7.7",


### PR DESCRIPTION
Release v1.47.11 — bundles #350 (clickable in-app version link to GitHub release notes).