### PR TITLE
feat(community): make forum publicly readable, keep writes auth-gated

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -42,6 +42,37 @@ const requireAuth = async (req, res, next) => {
   }
 };
 
+// Same JWT decode as requireAuth, but missing/invalid tokens leave req.user = null
+// instead of returning 401. Use this on routes that are public-readable but
+// need to know "who am I, if anyone" — e.g. forum list/detail with personalized
+// flags like `liked`, or future "you have this in your cellar" hints.
+const optionalAuth = async (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    req.user = null;
+    return next();
+  }
+
+  try {
+    const token = authHeader.substring(7);
+    const decoded = jwt.verify(token, process.env.JWT_SECRET, { algorithms: ['HS256'] });
+
+    const roles = decoded.roles || (decoded.role ? [decoded.role] : ['user']);
+    const planExpired = decoded.planExpiresAt && Date.now() > new Date(decoded.planExpiresAt).getTime();
+    const effectivePlan = planExpired ? 'free' : (decoded.plan || 'free');
+
+    req.user = {
+      id: decoded.id,
+      roles,
+      plan: effectivePlan,
+      planExpiresAt: decoded.planExpiresAt || null,
+    };
+  } catch {
+    req.user = null;
+  }
+  next();
+};
+
 // Middleware to check user has a specific role
 const requireRole = (role) => {
   return (req, res, next) => {
@@ -85,6 +116,7 @@ const requireModeratorOrAdmin = (req, res, next) => {
 
 module.exports = {
   requireAuth,
+  optionalAuth,
   requireRole,
   requireSommOrAdmin,
   requireModeratorOrAdmin,

--- a/backend/src/middleware/auth.test.js
+++ b/backend/src/middleware/auth.test.js
@@ -3,7 +3,7 @@ const jwt = require('jsonwebtoken');
 // Use a fixed test secret so we can sign real tokens
 process.env.JWT_SECRET = 'test-secret';
 
-const { requireAuth, requireRole, requireSommOrAdmin } = require('./auth');
+const { requireAuth, optionalAuth, requireRole, requireSommOrAdmin } = require('./auth');
 
 // ─── Helpers ────────────────────────────────────────��────────────────────────
 
@@ -125,6 +125,83 @@ describe('requireAuth', () => {
     const next = jest.fn();
 
     await requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user.plan).toBe('free');
+  });
+});
+
+// ─── optionalAuth ────────────────────────────────────────────────────────────
+
+describe('optionalAuth', () => {
+  test('sets req.user = null and calls next when Authorization header is absent', async () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = jest.fn();
+
+    await optionalAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toBeNull();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('sets req.user = null when header is malformed (no "Bearer " prefix)', async () => {
+    const req = makeReq({ headers: { authorization: 'Token abc' } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await optionalAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toBeNull();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('sets req.user = null for an invalid token (does NOT 401)', async () => {
+    const req = makeReq({ headers: { authorization: 'Bearer not.a.valid.token' } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await optionalAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toBeNull();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('sets req.user = null for an expired token', async () => {
+    const token = signToken({ id: 'u1', roles: ['user'] }, 'test-secret', { expiresIn: -1 });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await optionalAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toBeNull();
+  });
+
+  test('attaches req.user for a valid token', async () => {
+    const token = signToken({ id: 'u1', roles: ['admin'], plan: 'patron' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await optionalAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toMatchObject({ id: 'u1', roles: ['admin'], plan: 'patron' });
+  });
+
+  test('downgrades expired plan to free (matches requireAuth behavior)', async () => {
+    const expired = new Date(Date.now() - 60000).toISOString();
+    const token = signToken({ id: 'u4', roles: ['user'], plan: 'patron', planExpiresAt: expired });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await optionalAuth(req, res, next);
 
     expect(next).toHaveBeenCalled();
     expect(req.user.plan).toBe('free');

--- a/backend/src/routes/discussions.auth.test.js
+++ b/backend/src/routes/discussions.auth.test.js
@@ -1,0 +1,172 @@
+/**
+ * Auth-matrix tests for /api/discussions.
+ *
+ * WHY THIS TEST EXISTS:
+ * Discussions are publicly readable (GET) but writes (POST/PUT/PATCH/DELETE)
+ * require authentication, and moderation actions additionally require the
+ * moderator/admin role. This test documents that contract so it cannot be
+ * accidentally regressed by adding/removing per-route middleware.
+ *
+ * It mounts a tiny stub app that mirrors the middleware composition of
+ * discussions.js — no DB or model code is exercised.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const { requireAuth, optionalAuth, requireModeratorOrAdmin } = require('../middleware/auth');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  // Stub handler: succeeds and reports who (if anyone) the request authenticated as.
+  const ok = (req, res) => res.status(200).json({ uid: req.user?.id || null });
+
+  // Mirror the per-route middleware composition from discussions.js.
+  // Public reads (optionalAuth — no token = anonymous, valid token = personalized).
+  app.get('/api/discussions/categories', optionalAuth, ok);
+  app.get('/api/discussions', optionalAuth, ok);
+  app.get('/api/discussions/:id', optionalAuth, ok);
+  app.get('/api/discussions/:id/replies', optionalAuth, ok);
+
+  // Auth-required writes.
+  app.post('/api/discussions', requireAuth, ok);
+  app.put('/api/discussions/:id', requireAuth, ok);
+  app.post('/api/discussions/:id/replies', requireAuth, ok);
+  app.put('/api/discussions/:id/replies/:replyId', requireAuth, ok);
+  app.delete('/api/discussions/:id/replies/:replyId', requireAuth, ok);
+  app.post('/api/discussions/:id/replies/:replyId/like', requireAuth, ok);
+  app.post('/api/discussions/:id/report', requireAuth, ok);
+  app.post('/api/discussions/:id/replies/:replyId/report', requireAuth, ok);
+
+  // Mod/admin-only.
+  app.delete('/api/discussions/:id', requireAuth, requireModeratorOrAdmin, ok);
+  app.patch('/api/discussions/:id/pin', requireAuth, requireModeratorOrAdmin, ok);
+  app.patch('/api/discussions/:id/lock', requireAuth, requireModeratorOrAdmin, ok);
+  app.patch('/api/discussions/:id/move', requireAuth, requireModeratorOrAdmin, ok);
+  app.get('/api/discussions/moderation/reports', requireAuth, requireModeratorOrAdmin, ok);
+  app.post('/api/discussions/moderation/ban', requireAuth, requireModeratorOrAdmin, ok);
+
+  return app;
+}
+
+function makeReq(app, method, url, headers = {}) {
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const port = server.address().port;
+      const req = http.request({ port, path: url, method, headers }, (res) => {
+        const chunks = [];
+        res.on('data', c => chunks.push(c));
+        res.on('end', () => {
+          server.close();
+          const body = Buffer.concat(chunks).toString();
+          resolve({ status: res.statusCode, body: body ? JSON.parse(body) : null });
+        });
+      });
+      req.on('error', () => { server.close(); resolve({ status: 0 }); });
+      req.end();
+    });
+  });
+}
+
+const tokenFor = (payload) => jwt.sign(payload, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+const userTok = () => tokenFor({ id: 'u-user', roles: ['user'] });
+const modTok  = () => tokenFor({ id: 'u-mod',  roles: ['moderator'] });
+
+const PUBLIC_GETS = [
+  '/api/discussions/categories',
+  '/api/discussions',
+  '/api/discussions/anyid',
+  '/api/discussions/anyid/replies',
+];
+
+describe('Discussion GETs are publicly readable', () => {
+  for (const url of PUBLIC_GETS) {
+    test(`GET ${url} returns 200 without any Authorization header`, async () => {
+      const { status, body } = await makeReq(buildApp(), 'GET', url);
+      expect(status).toBe(200);
+      expect(body.uid).toBeNull();
+    });
+
+    test(`GET ${url} returns 200 with a valid token, attaching req.user`, async () => {
+      const { status, body } = await makeReq(buildApp(), 'GET', url, {
+        authorization: `Bearer ${userTok()}`,
+      });
+      expect(status).toBe(200);
+      expect(body.uid).toBe('u-user');
+    });
+
+    test(`GET ${url} returns 200 even with an invalid token (treated as anonymous)`, async () => {
+      const { status, body } = await makeReq(buildApp(), 'GET', url, {
+        authorization: 'Bearer not.a.valid.token',
+      });
+      expect(status).toBe(200);
+      expect(body.uid).toBeNull();
+    });
+  }
+});
+
+const WRITE_ROUTES = [
+  ['POST',   '/api/discussions'],
+  ['PUT',    '/api/discussions/anyid'],
+  ['POST',   '/api/discussions/anyid/replies'],
+  ['PUT',    '/api/discussions/anyid/replies/r1'],
+  ['DELETE', '/api/discussions/anyid/replies/r1'],
+  ['POST',   '/api/discussions/anyid/replies/r1/like'],
+  ['POST',   '/api/discussions/anyid/report'],
+  ['POST',   '/api/discussions/anyid/replies/r1/report'],
+];
+
+describe('Discussion writes require authentication', () => {
+  for (const [method, url] of WRITE_ROUTES) {
+    test(`${method} ${url} returns 401 without auth`, async () => {
+      const { status } = await makeReq(buildApp(), method, url);
+      expect(status).toBe(401);
+    });
+
+    test(`${method} ${url} returns 200 with a valid user token`, async () => {
+      const { status, body } = await makeReq(buildApp(), method, url, {
+        authorization: `Bearer ${userTok()}`,
+      });
+      expect(status).toBe(200);
+      expect(body.uid).toBe('u-user');
+    });
+  }
+});
+
+const MOD_ROUTES = [
+  ['DELETE', '/api/discussions/anyid'],
+  ['PATCH',  '/api/discussions/anyid/pin'],
+  ['PATCH',  '/api/discussions/anyid/lock'],
+  ['PATCH',  '/api/discussions/anyid/move'],
+  ['GET',    '/api/discussions/moderation/reports'],
+  ['POST',   '/api/discussions/moderation/ban'],
+];
+
+describe('Moderation routes require moderator/admin role', () => {
+  for (const [method, url] of MOD_ROUTES) {
+    test(`${method} ${url} returns 401 without auth`, async () => {
+      const { status } = await makeReq(buildApp(), method, url);
+      expect(status).toBe(401);
+    });
+
+    test(`${method} ${url} returns 403 for a regular user`, async () => {
+      const { status } = await makeReq(buildApp(), method, url, {
+        authorization: `Bearer ${userTok()}`,
+      });
+      expect(status).toBe(403);
+    });
+
+    test(`${method} ${url} returns 200 for a moderator`, async () => {
+      const { status, body } = await makeReq(buildApp(), method, url, {
+        authorization: `Bearer ${modTok()}`,
+      });
+      expect(status).toBe(200);
+      expect(body.uid).toBe('u-mod');
+    });
+  }
+});

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth, requireModeratorOrAdmin } = require('../middleware/auth');
+const { requireAuth, optionalAuth, requireModeratorOrAdmin } = require('../middleware/auth');
 const Discussion = require('../models/Discussion');
 const { CATEGORIES } = require('../models/Discussion');
 const DiscussionReply = require('../models/DiscussionReply');
@@ -17,7 +17,9 @@ const { DISCUSSIONS_PER_PAGE, DISCUSSIONS_MAX_PER_PAGE, DISCUSSION_MAX_LENGTHS }
 
 const router = express.Router();
 
-router.use(requireAuth);
+// Per-route auth: GETs use optionalAuth (public reads with personalization when
+// logged in), writes use requireAuth. Moderation routes additionally require
+// requireModeratorOrAdmin. There is no global requireAuth on the router.
 
 // Check if the requesting user is banned from discussions; returns error response or null
 async function checkDiscussionBan(req, res) {
@@ -33,13 +35,13 @@ async function checkDiscussionBan(req, res) {
   return false;
 }
 
-// GET /api/discussions/categories - Available categories
-router.get('/categories', (req, res) => {
+// GET /api/discussions/categories - Available categories (public)
+router.get('/categories', optionalAuth, (req, res) => {
   res.json({ categories: CATEGORIES });
 });
 
-// GET /api/discussions - List discussions
-router.get('/', async (req, res) => {
+// GET /api/discussions - List discussions (public)
+router.get('/', optionalAuth, async (req, res) => {
   try {
     const { page, limit, offset: skip } = parsePagination(req.query, { limit: DISCUSSIONS_PER_PAGE, maxLimit: DISCUSSIONS_MAX_PER_PAGE });
     const { category, sort } = req.query;
@@ -82,7 +84,7 @@ router.get('/', async (req, res) => {
 // These routes MUST be registered before /:id to avoid "moderation" being treated as an ID.
 
 // GET /api/discussions/moderation/reports - List pending reports
-router.get('/moderation/reports', requireModeratorOrAdmin, async (req, res) => {
+router.get('/moderation/reports', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
     const { page, limit, offset: skip } = parsePagination(req.query, { limit: DISCUSSIONS_PER_PAGE, maxLimit: DISCUSSIONS_MAX_PER_PAGE });
     const VALID_STATUSES = ['pending', 'resolved', 'dismissed'];
@@ -107,7 +109,7 @@ router.get('/moderation/reports', requireModeratorOrAdmin, async (req, res) => {
 });
 
 // PATCH /api/discussions/moderation/reports/:reportId - Resolve a report
-router.patch('/moderation/reports/:reportId', requireModeratorOrAdmin, async (req, res) => {
+router.patch('/moderation/reports/:reportId', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
     if (!isValidId(req.params.reportId)) return res.status(400).json({ error: 'Invalid report ID' });
     const report = await DiscussionReport.findById(req.params.reportId);
@@ -144,7 +146,7 @@ const BAN_DURATIONS = {
 };
 
 // POST /api/discussions/moderation/ban - Ban a user from discussions
-router.post('/moderation/ban', requireModeratorOrAdmin, async (req, res) => {
+router.post('/moderation/ban', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
     const { userId, duration, reason } = req.body;
     if (!userId || !isValidId(userId)) return res.status(400).json({ error: 'Invalid user ID' });
@@ -183,7 +185,7 @@ router.post('/moderation/ban', requireModeratorOrAdmin, async (req, res) => {
 });
 
 // DELETE /api/discussions/moderation/ban/:userId - Unban a user
-router.delete('/moderation/ban/:userId', requireModeratorOrAdmin, async (req, res) => {
+router.delete('/moderation/ban/:userId', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
     if (!isValidId(req.params.userId)) return res.status(400).json({ error: 'Invalid user ID' });
     const targetUser = await User.findById(req.params.userId);
@@ -207,8 +209,8 @@ router.delete('/moderation/ban/:userId', requireModeratorOrAdmin, async (req, re
   }
 });
 
-// GET /api/discussions/:id - Single discussion
-router.get('/:id', async (req, res) => {
+// GET /api/discussions/:id - Single discussion (public)
+router.get('/:id', optionalAuth, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
 
@@ -226,7 +228,7 @@ router.get('/:id', async (req, res) => {
 });
 
 // POST /api/discussions - Create a discussion
-router.post('/', async (req, res) => {
+router.post('/', requireAuth, async (req, res) => {
   try {
     if (await checkDiscussionBan(req, res)) return;
 
@@ -272,7 +274,7 @@ router.post('/', async (req, res) => {
 });
 
 // PUT /api/discussions/:id - Update own discussion (or moderator/admin)
-router.put('/:id', async (req, res) => {
+router.put('/:id', requireAuth, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
     const discussion = await Discussion.findById(req.params.id);
@@ -317,7 +319,7 @@ router.put('/:id', async (req, res) => {
 });
 
 // DELETE /api/discussions/:id - Delete discussion (moderator/admin only)
-router.delete('/:id', requireModeratorOrAdmin, async (req, res) => {
+router.delete('/:id', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
     const discussion = await Discussion.findById(req.params.id);
@@ -342,8 +344,8 @@ router.delete('/:id', requireModeratorOrAdmin, async (req, res) => {
 
 // ─── Replies ────────────────────────────────────────────────────────────────
 
-// GET /api/discussions/:id/replies - List replies for a discussion
-router.get('/:id/replies', async (req, res) => {
+// GET /api/discussions/:id/replies - List replies for a discussion (public)
+router.get('/:id/replies', optionalAuth, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
     const { page, limit, offset: skip } = parsePagination(req.query, { limit: DISCUSSIONS_PER_PAGE, maxLimit: DISCUSSIONS_MAX_PER_PAGE });
@@ -358,16 +360,19 @@ router.get('/:id/replies', async (req, res) => {
       DiscussionReply.countDocuments({ discussion: req.params.id })
     ]);
 
-    // Check which replies the current user has liked
-    const replyIds = replies.map(r => r._id);
-    const userVotes = await DiscussionReplyVote.find({ user: req.user.id, reply: { $in: replyIds } }).select('reply');
-    const likedSet = new Set(userVotes.map(v => v.reply.toString()));
+    // Personalization (only when logged in): mark which replies the user has liked
+    let likedSet = new Set();
+    if (req.user) {
+      const replyIds = replies.map(r => r._id);
+      const userVotes = await DiscussionReplyVote.find({ user: req.user.id, reply: { $in: replyIds } }).select('reply');
+      likedSet = new Set(userVotes.map(v => v.reply.toString()));
+    }
 
-    const isMod = req.user.roles && (req.user.roles.includes('moderator') || req.user.roles.includes('admin'));
+    const isMod = !!req.user && req.user.roles && (req.user.roles.includes('moderator') || req.user.roles.includes('admin'));
     const enriched = replies.map(r => {
       const obj = r.toObject();
       obj.liked = likedSet.has(r._id.toString());
-      // Never leak deletedBody to non-mods
+      // Never leak deletedBody to non-mods (or anonymous viewers)
       if (!isMod) delete obj.deletedBody;
       return obj;
     });
@@ -380,7 +385,7 @@ router.get('/:id/replies', async (req, res) => {
 });
 
 // POST /api/discussions/:id/replies - Create a reply
-router.post('/:id/replies', async (req, res) => {
+router.post('/:id/replies', requireAuth, async (req, res) => {
   try {
     if (await checkDiscussionBan(req, res)) return;
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
@@ -466,7 +471,7 @@ router.post('/:id/replies', async (req, res) => {
 });
 
 // PUT /api/discussions/:discussionId/replies/:replyId - Update own reply
-router.put('/:discussionId/replies/:replyId', async (req, res) => {
+router.put('/:discussionId/replies/:replyId', requireAuth, async (req, res) => {
   try {
     if (!isValidId(req.params.replyId)) return res.status(400).json({ error: 'Invalid reply ID' });
     const reply = await DiscussionReply.findById(req.params.replyId);
@@ -498,7 +503,7 @@ router.put('/:discussionId/replies/:replyId', async (req, res) => {
 });
 
 // DELETE /api/discussions/:discussionId/replies/:replyId - Soft-delete reply (user or mod/admin)
-router.delete('/:discussionId/replies/:replyId', async (req, res) => {
+router.delete('/:discussionId/replies/:replyId', requireAuth, async (req, res) => {
   try {
     if (!isValidId(req.params.replyId)) return res.status(400).json({ error: 'Invalid reply ID' });
     const reply = await DiscussionReply.findById(req.params.replyId);
@@ -528,7 +533,7 @@ router.delete('/:discussionId/replies/:replyId', async (req, res) => {
 });
 
 // GET /api/discussions/:discussionId/replies/:replyId/original - View original text of deleted reply (mod/admin)
-router.get('/:discussionId/replies/:replyId/original', requireModeratorOrAdmin, async (req, res) => {
+router.get('/:discussionId/replies/:replyId/original', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
     if (!isValidId(req.params.replyId)) return res.status(400).json({ error: 'Invalid reply ID' });
     const reply = await DiscussionReply.findById(req.params.replyId).select('deletedBody isDeleted');
@@ -543,7 +548,7 @@ router.get('/:discussionId/replies/:replyId/original', requireModeratorOrAdmin, 
 });
 
 // POST /api/discussions/:discussionId/replies/:replyId/like - Toggle like on reply
-router.post('/:discussionId/replies/:replyId/like', async (req, res) => {
+router.post('/:discussionId/replies/:replyId/like', requireAuth, async (req, res) => {
   try {
     if (!isValidId(req.params.replyId)) return res.status(400).json({ error: 'Invalid reply ID' });
     const reply = await DiscussionReply.findById(req.params.replyId);
@@ -575,7 +580,7 @@ router.post('/:discussionId/replies/:replyId/like', async (req, res) => {
 // ─── Moderation ─────────────────────────────────────────────────────────────
 
 // PATCH /api/discussions/:id/pin - Toggle pin (moderator/admin only)
-router.patch('/:id/pin', requireModeratorOrAdmin, async (req, res) => {
+router.patch('/:id/pin', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
     const discussion = await Discussion.findById(req.params.id);
@@ -593,7 +598,7 @@ router.patch('/:id/pin', requireModeratorOrAdmin, async (req, res) => {
 });
 
 // PATCH /api/discussions/:id/lock - Toggle lock (moderator/admin only)
-router.patch('/:id/lock', requireModeratorOrAdmin, async (req, res) => {
+router.patch('/:id/lock', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
     const discussion = await Discussion.findById(req.params.id);
@@ -611,7 +616,7 @@ router.patch('/:id/lock', requireModeratorOrAdmin, async (req, res) => {
 });
 
 // PATCH /api/discussions/:id/move - Move to different category (moderator/admin only)
-router.patch('/:id/move', requireModeratorOrAdmin, async (req, res) => {
+router.patch('/:id/move', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
     const { category } = req.body;
@@ -637,7 +642,7 @@ router.patch('/:id/move', requireModeratorOrAdmin, async (req, res) => {
 // ─── Reporting ──────────────────────────────────────────────────────────────
 
 // POST /api/discussions/:id/report - Report a discussion
-router.post('/:id/report', async (req, res) => {
+router.post('/:id/report', requireAuth, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
 
@@ -668,7 +673,7 @@ router.post('/:id/report', async (req, res) => {
 });
 
 // POST /api/discussions/:discussionId/replies/:replyId/report - Report a reply
-router.post('/:discussionId/replies/:replyId/report', async (req, res) => {
+router.post('/:discussionId/replies/:replyId/report', requireAuth, async (req, res) => {
   try {
     if (!isValidId(req.params.replyId)) return res.status(400).json({ error: 'Invalid reply ID' });
 

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -377,8 +377,8 @@ router.get('/me/export', requireAuth, async (req, res) => {
       RestockAlert.find({ user: userId }).lean(),
       WineList.find({ user: userId }).select('name cellar structureMode branding layout createdAt updatedAt').lean(),
       PendingShare.find({ invitedBy: userId }).populate('cellar', 'name').lean(),
-      Discussion.find({ author: userId }).select('title category body createdAt').lean(),
-      DiscussionReply.find({ author: userId }).select('discussion body createdAt').lean(),
+      Discussion.find({ author: userId }).select('title category body wineDefinition isPinned isLocked replyCount createdAt updatedAt').lean(),
+      DiscussionReply.find({ author: userId }).select('discussion body quote wineDefinition likesCount isDeleted createdAt updatedAt').lean(),
       ReviewVote.find({ user: userId }).select('review vote createdAt').lean(),
       DiscussionReplyVote.find({ user: userId }).select('reply vote createdAt').lean(),
       Follow.find({ $or: [{ follower: userId }, { following: userId }] })
@@ -479,11 +479,23 @@ router.get('/me/export', requireAuth, async (req, res) => {
       discussions: discussions.map(d => ({
         title: d.title,
         category: d.category,
-        createdAt: d.createdAt
+        body: d.body,
+        wineDefinition: d.wineDefinition,
+        isPinned: d.isPinned,
+        isLocked: d.isLocked,
+        replyCount: d.replyCount,
+        createdAt: d.createdAt,
+        updatedAt: d.updatedAt
       })),
       discussionReplies: discussionReplies.map(r => ({
         discussion: r.discussion,
-        createdAt: r.createdAt
+        body: r.body,
+        quote: r.quote,
+        wineDefinition: r.wineDefinition,
+        likesCount: r.likesCount,
+        isDeleted: r.isDeleted,
+        createdAt: r.createdAt,
+        updatedAt: r.updatedAt
       })),
       votes: {
         reviews: reviewVotes.map(v => ({ review: v.review, vote: v.vote, createdAt: v.createdAt })),

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -233,31 +233,17 @@ function AppRoutes() {
           }
         />
 
-        {/* Community routes */}
+        {/* Community routes — discussions are publicly readable; reply/post requires auth.
+            ReviewFeed (the "Reviews" tab) stays auth-only since its primary value is
+            following users — opening it up is a separate enhancement. */}
         <Route
           path="/community"
           element={
-            <ProtectedRoute>
-              <Layout><ReviewFeed /></Layout>
-            </ProtectedRoute>
+            user ? <Layout><ReviewFeed /></Layout> : <Navigate to="/community/discussions" replace />
           }
         />
-        <Route
-          path="/community/discussions"
-          element={
-            <ProtectedRoute>
-              <Layout><CommunityDiscussions /></Layout>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/community/discussions/:id"
-          element={
-            <ProtectedRoute>
-              <Layout><DiscussionDetail /></Layout>
-            </ProtectedRoute>
-          }
-        />
+        <Route path="/community/discussions" element={<Layout><CommunityDiscussions /></Layout>} />
+        <Route path="/community/discussions/:id" element={<Layout><DiscussionDetail /></Layout>} />
         <Route
           path="/users/:userId"
           element={

--- a/frontend/src/components/CommunityCTA.css
+++ b/frontend/src/components/CommunityCTA.css
@@ -1,0 +1,35 @@
+.community-cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  text-align: center;
+}
+
+.community-cta--inline {
+  flex-direction: row;
+  justify-content: space-between;
+  text-align: left;
+  padding: 0.875rem 1.125rem;
+}
+
+.community-cta__message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-color, inherit);
+}
+
+.community-cta__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+@media (max-width: 600px) {
+  .community-cta--inline {
+    flex-direction: column;
+    text-align: center;
+  }
+}

--- a/frontend/src/components/CommunityCTA.js
+++ b/frontend/src/components/CommunityCTA.js
@@ -1,0 +1,29 @@
+import { Link, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import './CommunityCTA.css';
+
+// "Sign in to join the conversation" banner shown to anonymous users on
+// public community pages. The login link preserves the current path so users
+// land back where they were after authenticating.
+export default function CommunityCTA({ variant = 'banner', message }) {
+  const { t } = useTranslation();
+  const { pathname, search } = useLocation();
+  const next = encodeURIComponent(pathname + search);
+  const loginHref = `/login?next=${next}`;
+
+  return (
+    <div className={`community-cta community-cta--${variant} card`}>
+      <p className="community-cta__message">
+        {message || t('discussions.signInToJoin')}
+      </p>
+      <div className="community-cta__actions">
+        <Link to={loginHref} className="btn btn-primary btn-small">
+          {t('discussions.signIn')}
+        </Link>
+        <Link to="/login?mode=register" className="btn btn-secondary btn-small">
+          {t('discussions.createAccount')}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ReplyCard.css
+++ b/frontend/src/components/ReplyCard.css
@@ -119,6 +119,15 @@
   cursor: default;
 }
 
+.reply-card__likes-readonly {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: #e11d48;
+  font-size: 0.82rem;
+  padding: 0.2rem 0;
+}
+
 .reply-card__action-btn {
   background: none;
   border: none;

--- a/frontend/src/components/ReplyCard.js
+++ b/frontend/src/components/ReplyCard.js
@@ -140,17 +140,26 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
       <div className="reply-card__body">{reply.body}</div>
 
       <div className="reply-card__footer">
-        <button
-          className={`reply-card__like-btn ${liked ? 'liked' : ''}`}
-          onClick={handleLike}
-          disabled={isOwn}
-          title={isOwn ? 'Cannot like your own reply' : (liked ? 'Unlike' : 'Like')}
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill={liked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
-          </svg>
-          {likesCount > 0 && <span>{likesCount}</span>}
-        </button>
+        {user ? (
+          <button
+            className={`reply-card__like-btn ${liked ? 'liked' : ''}`}
+            onClick={handleLike}
+            disabled={isOwn}
+            title={isOwn ? 'Cannot like your own reply' : (liked ? 'Unlike' : 'Like')}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill={liked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+            </svg>
+            {likesCount > 0 && <span>{likesCount}</span>}
+          </button>
+        ) : likesCount > 0 ? (
+          <span className="reply-card__likes-readonly" aria-label={`${likesCount} likes`}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+            </svg>
+            <span>{likesCount}</span>
+          </span>
+        ) : null}
 
         {onReply && (
           <button className="reply-card__action-btn" onClick={() => onReply(reply)}>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1286,7 +1286,12 @@
     "deleteReplyWarning": "The text will be hidden but moderators can still review it.",
     "deleteDiscussion": "Delete Discussion",
     "confirmDeleteDiscussion": "Delete this discussion and all its replies?",
-    "deleteDiscussionWarning": "This action cannot be undone."
+    "deleteDiscussionWarning": "This action cannot be undone.",
+    "signIn": "Sign in",
+    "createAccount": "Create account",
+    "signInToJoin": "Sign in to join the conversation — read freely, write with a Cellarion account.",
+    "signInToReply": "Sign in to reply to this discussion.",
+    "signInToStart": "Sign in to start a discussion."
   },
   "reviewFeed": {
     "community": "Community",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1286,7 +1286,12 @@
     "deleteReplyWarning": "Texten döljs men moderatorer kan fortfarande granska den.",
     "deleteDiscussion": "Ta bort diskussion",
     "confirmDeleteDiscussion": "Ta bort denna diskussion och alla dess svar?",
-    "deleteDiscussionWarning": "Denna åtgärd kan inte ångras."
+    "deleteDiscussionWarning": "Denna åtgärd kan inte ångras.",
+    "signIn": "Logga in",
+    "createAccount": "Skapa konto",
+    "signInToJoin": "Logga in för att vara med i samtalet — läs fritt, skriv med ett Cellarion-konto.",
+    "signInToReply": "Logga in för att svara på denna diskussion.",
+    "signInToStart": "Logga in för att starta en diskussion."
   },
   "reviewFeed": {
     "community": "Gemenskap",

--- a/frontend/src/pages/CommunityDiscussions.js
+++ b/frontend/src/pages/CommunityDiscussions.js
@@ -1,30 +1,36 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
 import Discussions from './Discussions';
 import './ReviewFeed.css';
 
 function CommunityDiscussions() {
   const location = useLocation();
   const { t } = useTranslation();
+  const { user } = useAuth();
 
   return (
     <div className="review-feed-page">
       <div className="review-feed__header">
         <h1>{t('discussions.community')}</h1>
-        <div className="review-feed__section-tabs">
-          <Link
-            to="/community"
-            className={`review-feed__section-tab ${location.pathname === '/community' ? 'active' : ''}`}
-          >
-            {t('discussions.reviews')}
-          </Link>
-          <Link
-            to="/community/discussions"
-            className={`review-feed__section-tab ${location.pathname.startsWith('/community/discussions') ? 'active' : ''}`}
-          >
-            {t('discussions.discussions')}
-          </Link>
-        </div>
+        {/* Reviews tab is hidden for anonymous visitors — that feed is auth-only
+            and would just bounce them back here via /community redirect. */}
+        {user && (
+          <div className="review-feed__section-tabs">
+            <Link
+              to="/community"
+              className={`review-feed__section-tab ${location.pathname === '/community' ? 'active' : ''}`}
+            >
+              {t('discussions.reviews')}
+            </Link>
+            <Link
+              to="/community/discussions"
+              className={`review-feed__section-tab ${location.pathname.startsWith('/community/discussions') ? 'active' : ''}`}
+            >
+              {t('discussions.discussions')}
+            </Link>
+          </div>
+        )}
       </div>
 
       <Discussions />

--- a/frontend/src/pages/DiscussionDetail.js
+++ b/frontend/src/pages/DiscussionDetail.js
@@ -14,6 +14,7 @@ import WineReferenceCard from '../components/WineReferenceCard';
 import WineSearchPicker from '../components/WineSearchPicker';
 import Modal from '../components/Modal';
 import ConfirmModal from '../components/ConfirmModal';
+import CommunityCTA from '../components/CommunityCTA';
 import timeAgo from '../utils/timeAgo';
 import './DiscussionDetail.css';
 
@@ -290,7 +291,7 @@ function DiscussionDetail() {
         <div className="discussion-detail__body">{discussion.body}</div>
 
         <div className="discussion-detail__actions">
-          {!isOwner && (
+          {user && !isOwner && (
             <button className="reply-card__action-btn" onClick={() => setReportTarget({ type: 'discussion', id: discussion._id })}>
               {t('discussions.report')}
             </button>
@@ -325,7 +326,7 @@ function DiscussionDetail() {
               key={reply._id}
               reply={reply}
               discussionId={id}
-              onReply={discussion.isLocked ? null : (r) => {
+              onReply={!user || discussion.isLocked ? null : (r) => {
                 const authorName = r.author?.displayName || r.author?.username || 'Unknown';
                 const snippet = r.body.length > 300 ? r.body.slice(0, 300) + '…' : r.body;
                 setQuoteData({ replyId: r._id, authorName, body: snippet });
@@ -337,9 +338,9 @@ function DiscussionDetail() {
                   }
                 }, 50);
               }}
-              onEdit={(r) => { setEditingReply(r); setEditBody(r.body); }}
-              onDelete={(r) => setConfirmDeleteReply(r)}
-              onReport={(r) => setReportTarget({ type: 'reply', id: r._id })}
+              onEdit={user ? (r) => { setEditingReply(r); setEditBody(r.body); } : null}
+              onDelete={user ? (r) => setConfirmDeleteReply(r) : null}
+              onReport={user ? (r) => setReportTarget({ type: 'reply', id: r._id }) : null}
             />
           ))
         )}
@@ -353,8 +354,10 @@ function DiscussionDetail() {
         )}
       </div>
 
-      {/* Reply form */}
-      {!discussion.isLocked ? (
+      {/* Reply form — anon users see a sign-in CTA, logged-in users get the composer (unless locked) */}
+      {!user ? (
+        <CommunityCTA message={t('discussions.signInToReply')} />
+      ) : !discussion.isLocked ? (
         <div className="discussion-detail__reply-form card">
           {replyError && <div className="alert alert-error">{replyError}</div>}
           {quoteData && (

--- a/frontend/src/pages/Discussions.js
+++ b/frontend/src/pages/Discussions.js
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { getDiscussions, createDiscussion } from '../api/discussions';
 import DiscussionCard from '../components/DiscussionCard';
 import CategoryBadge, { CATEGORY_LABELS } from '../components/CategoryBadge';
+import CommunityCTA from '../components/CommunityCTA';
 import Modal from '../components/Modal';
 import WineSearchPicker from '../components/WineSearchPicker';
 import './Discussions.css';
@@ -13,7 +14,7 @@ const SORT_KEYS = ['active', 'newest', 'most-replies'];
 
 function Discussions() {
   const { t } = useTranslation();
-  const { apiFetch } = useAuth();
+  const { apiFetch, user } = useAuth();
   const [discussions, setDiscussions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
@@ -134,10 +135,14 @@ function Discussions() {
             ))}
           </select>
         </div>
-        <button className="btn btn-primary" data-guide="discussion-create" onClick={() => setShowCreate(true)}>
-          {t('discussions.newDiscussion')}
-        </button>
+        {user ? (
+          <button className="btn btn-primary" data-guide="discussion-create" onClick={() => setShowCreate(true)}>
+            {t('discussions.newDiscussion')}
+          </button>
+        ) : null}
       </div>
+
+      {!user && <CommunityCTA variant="inline" />}
 
       {error && <div className="alert alert-error">{error}</div>}
 
@@ -146,7 +151,7 @@ function Discussions() {
       ) : discussions.length === 0 ? (
         <div className="discussions__empty card">
           <h3>{t('discussions.noDiscussions')}</h3>
-          <p>{t('discussions.noDiscussionsHint')}</p>
+          <p>{user ? t('discussions.noDiscussionsHint') : t('discussions.signInToStart')}</p>
         </div>
       ) : (
         <div className="discussions__list">


### PR DESCRIPTION
## Summary
- **Phase 1** of the [community forum roadmap](https://github.com/jagduvi1/Cellarion/blob/main/CLAUDE.md). Anonymous visitors can now browse discussions and replies; writes still require a verified Cellarion account.
- New `optionalAuth` middleware decodes JWT if present, leaves `req.user = null` otherwise — reusable for any future public-with-personalization endpoint.
- The global `router.use(requireAuth)` in [discussions.js](backend/src/routes/discussions.js) is replaced with per-route middleware. Every write declares `requireAuth` explicitly (verified by the new 46-test auth matrix).
- `<ProtectedRoute>` is removed from `/community/discussions` and `/community/discussions/:id`. Anon visitors landing on `/community` are redirected to `/community/discussions` since `ReviewFeed` stays auth-only.
- New shared `CommunityCTA` component renders a "Sign in / Create account" affordance in place of write UI for anon users.
- GDPR data export now includes discussion body, quote, wineDefinition, and timestamps so users taking their data with them get their actual words. Deletion cascade was already complete.

## What anon users see
- `/community/discussions` — full thread list, category filter, sort tabs, "Sign in to join the conversation" inline CTA in place of "+ New Discussion".
- `/community/discussions/:id` — full thread + replies, read-only like counts, no edit/delete/report/like buttons. "Sign in to reply" CTA where the composer would be.
- Locked threads still display the locked notice for everyone.

## Test plan
- [x] Backend tests: `cd backend && npm test` — 400/400 (was 348; +52 new tests covering `optionalAuth` and the full discussion auth matrix).
- [x] Frontend tests: `cd frontend && npm test -- --watchAll=false` — 256/256.
- [ ] Smoke-test in Docker:
  - [ ] Visit `/community/discussions` in incognito → list renders, click any thread → renders, replies visible, "Sign in to reply" banner present.
  - [ ] `curl -X POST http://localhost:5000/api/discussions -H 'Content-Type: application/json' -d '{}'` without auth → 401.
  - [ ] Click "Sign in to reply" → redirects to `/login?next=...`, post-login lands back on the thread.
  - [ ] Logged-in user sees full composer + Like / Edit / Delete / Report / Mod actions exactly as before.
  - [ ] `GET /api/users/me/export` (logged in) — verify the `discussions` array now contains body/quote/wineDefinition fields.

## Out of scope
- Slug URLs, server-rendered crawler HTML for discussions, sitemap entries, IndexNow, JSON-LD — that's Phase 2 (`feat/community-seo`).
- Reply notifications, @mentions, "discussions about this wine" panel — Phase 3.
- TipTap composer, Meilisearch indexing, trending sort, homepage widget — Phase 4.
- Opening up `ReviewFeed` (the "Reviews" tab at `/community`) — its primary value is the follow-graph, opening it requires backend work on review routes. Tracked as a separate enhancement.