### PR TITLE
feat(community): SEO — slugs, crawler HTML, sitemap, IndexNow

### DIFF
--- a/backend/src/models/Discussion.js
+++ b/backend/src/models/Discussion.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { slugify } = require('../utils/normalize');
 
 const CATEGORIES = ['tasting-notes', 'food-pairing', 'recommendations', 'cellar-tips', 'general'];
 
@@ -49,6 +50,18 @@ const discussionSchema = new mongoose.Schema({
   lastActivityAt: {
     type: Date,
     default: Date.now
+  },
+  // Human-readable URL slug. Pinned at create time and never regenerated on
+  // title edit — URLs stay stable forever, old links don't break. Sparse so
+  // existing pre-migration discussions don't violate the unique index until
+  // backfilled.
+  slug: {
+    type: String,
+    trim: true,
+    lowercase: true,
+    unique: true,
+    sparse: true,
+    index: true
   }
 }, { timestamps: true });
 
@@ -58,6 +71,16 @@ discussionSchema.index({ isPinned: -1, lastActivityAt: -1 });
 discussionSchema.index({ category: 1, isPinned: -1, lastActivityAt: -1 });
 // User's discussions
 discussionSchema.index({ author: 1, createdAt: -1 });
+
+// Generate slug from title + last 6 of ObjectId on insert. The ObjectId suffix
+// gives collision-resistance without needing a uniqueness retry loop.
+discussionSchema.pre('save', function(next) {
+  if (this.slug || !this.isNew) return next();
+  const base = slugify(this.title);
+  const suffix = this._id.toString().slice(-6);
+  this.slug = base ? `${base}-${suffix}` : suffix;
+  next();
+});
 
 module.exports = mongoose.model('Discussion', discussionSchema);
 module.exports.CATEGORIES = CATEGORIES;

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -11,6 +11,7 @@ const WineDefinition = require('../models/WineDefinition');
 const { stripHtml } = require('../utils/sanitize');
 const { logAudit } = require('../services/audit');
 const { incrementCred } = require('../utils/cellarCred');
+const { submitUrls: submitToIndexNow } = require('../services/indexNow');
 const { parsePagination } = require('../utils/pagination');
 const { isValidId } = require('../utils/validation');
 const { DISCUSSIONS_PER_PAGE, DISCUSSIONS_MAX_PER_PAGE, DISCUSSION_MAX_LENGTHS } = require('../config/constants');
@@ -20,6 +21,17 @@ const router = express.Router();
 // Per-route auth: GETs use optionalAuth (public reads with personalization when
 // logged in), writes use requireAuth. Moderation routes additionally require
 // requireModeratorOrAdmin. There is no global requireAuth on the router.
+
+// Resolve a URL parameter that may be either an ObjectId or a slug to a Discussion
+// document. The slug form is the canonical SEO URL, so writes triggered from a
+// thread that the user navigated to via slug must still find the discussion.
+async function findDiscussionByIdOrSlug(idOrSlug) {
+  if (!idOrSlug) return null;
+  const filter = isValidId(idOrSlug)
+    ? { _id: idOrSlug }
+    : { slug: String(idOrSlug).toLowerCase() };
+  return Discussion.findOne(filter);
+}
 
 // Check if the requesting user is banned from discussions; returns error response or null
 async function checkDiscussionBan(req, res) {
@@ -209,12 +221,17 @@ router.delete('/moderation/ban/:userId', requireAuth, requireModeratorOrAdmin, a
   }
 });
 
-// GET /api/discussions/:id - Single discussion (public)
-router.get('/:id', optionalAuth, async (req, res) => {
+// GET /api/discussions/:idOrSlug - Single discussion (public). Accepts both
+// ObjectId and human-readable slug. The frontend swaps the URL to the slug form
+// via history.replaceState() once it has the response.
+router.get('/:idOrSlug', optionalAuth, async (req, res) => {
   try {
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
+    const { idOrSlug } = req.params;
+    const filter = isValidId(idOrSlug)
+      ? { _id: idOrSlug }
+      : { slug: String(idOrSlug).toLowerCase() };
 
-    const discussion = await Discussion.findById(req.params.id)
+    const discussion = await Discussion.findOne(filter)
       .populate('author', 'username displayName roles contribution.tier contribution.specialty')
       .populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } });
 
@@ -264,6 +281,9 @@ router.post('/', requireAuth, async (req, res) => {
     incrementCred(req.user.id, 'discussion_created').catch(() => {});
     logAudit(req, 'discussion.create', { type: 'discussion', id: discussion._id }, { title: cleanTitle, category });
 
+    // Notify search engines about the new public-readable URL
+    submitToIndexNow(`/community/discussions/${discussion.slug || discussion._id}`);
+
     await discussion.populate('author', 'username displayName roles contribution.tier contribution.specialty');
 
     res.status(201).json({ discussion });
@@ -273,11 +293,10 @@ router.post('/', requireAuth, async (req, res) => {
   }
 });
 
-// PUT /api/discussions/:id - Update own discussion (or moderator/admin)
-router.put('/:id', requireAuth, async (req, res) => {
+// PUT /api/discussions/:idOrSlug - Update own discussion (or moderator/admin)
+router.put('/:idOrSlug', requireAuth, async (req, res) => {
   try {
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
-    const discussion = await Discussion.findById(req.params.id);
+    const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
     const isOwner = discussion.author.toString() === req.user.id;
@@ -318,11 +337,10 @@ router.put('/:id', requireAuth, async (req, res) => {
   }
 });
 
-// DELETE /api/discussions/:id - Delete discussion (moderator/admin only)
-router.delete('/:id', requireAuth, requireModeratorOrAdmin, async (req, res) => {
+// DELETE /api/discussions/:idOrSlug - Delete discussion (moderator/admin only)
+router.delete('/:idOrSlug', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
-    const discussion = await Discussion.findById(req.params.id);
+    const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
     // Clean up replies and votes
@@ -332,8 +350,13 @@ router.delete('/:id', requireAuth, requireModeratorOrAdmin, async (req, res) => 
     DiscussionReply.deleteMany({ discussion: discussion._id }).catch(() => {});
     DiscussionReport.deleteMany({ discussion: discussion._id }).catch(() => {});
 
+    // Capture the public URL before deletion so we can ping IndexNow afterwards.
+    const publicPath = `/community/discussions/${discussion.slug || discussion._id}`;
     await Discussion.deleteOne({ _id: discussion._id });
     logAudit(req, 'discussion.delete', { type: 'discussion', id: discussion._id });
+
+    // Tell crawlers the URL is gone (ping returns 404 on next crawl → drop from index)
+    submitToIndexNow(publicPath);
 
     res.json({ message: 'Discussion deleted' });
   } catch (err) {
@@ -344,20 +367,30 @@ router.delete('/:id', requireAuth, requireModeratorOrAdmin, async (req, res) => 
 
 // ─── Replies ────────────────────────────────────────────────────────────────
 
-// GET /api/discussions/:id/replies - List replies for a discussion (public)
-router.get('/:id/replies', optionalAuth, async (req, res) => {
+// GET /api/discussions/:idOrSlug/replies - List replies for a discussion (public).
+// :idOrSlug accepts both ObjectId and slug; we resolve it to an ObjectId before
+// querying replies (which always reference the discussion by ObjectId).
+router.get('/:idOrSlug/replies', optionalAuth, async (req, res) => {
   try {
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
+    const { idOrSlug } = req.params;
+    let discussionId;
+    if (isValidId(idOrSlug)) {
+      discussionId = idOrSlug;
+    } else {
+      const discussion = await Discussion.findOne({ slug: String(idOrSlug).toLowerCase() }).select('_id');
+      if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
+      discussionId = discussion._id;
+    }
     const { page, limit, offset: skip } = parsePagination(req.query, { limit: DISCUSSIONS_PER_PAGE, maxLimit: DISCUSSIONS_MAX_PER_PAGE });
 
     const [replies, total] = await Promise.all([
-      DiscussionReply.find({ discussion: req.params.id })
+      DiscussionReply.find({ discussion: discussionId })
         .sort({ createdAt: 1 })
         .skip(skip)
         .limit(limit)
         .populate('author', 'username displayName roles contribution.tier contribution.specialty')
         .populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } }),
-      DiscussionReply.countDocuments({ discussion: req.params.id })
+      DiscussionReply.countDocuments({ discussion: discussionId })
     ]);
 
     // Personalization (only when logged in): mark which replies the user has liked
@@ -384,13 +417,12 @@ router.get('/:id/replies', optionalAuth, async (req, res) => {
   }
 });
 
-// POST /api/discussions/:id/replies - Create a reply
-router.post('/:id/replies', requireAuth, async (req, res) => {
+// POST /api/discussions/:idOrSlug/replies - Create a reply
+router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
   try {
     if (await checkDiscussionBan(req, res)) return;
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
 
-    const discussion = await Discussion.findById(req.params.id);
+    const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
     if (discussion.isLocked) {
       return res.status(403).json({ error: 'This discussion is locked' });
@@ -445,6 +477,9 @@ router.post('/:id/replies', requireAuth, async (req, res) => {
       { $inc: { replyCount: 1 }, $set: { lastActivityAt: new Date() } }
     ).catch(() => {});
 
+    // The thread's lastmod just changed — let search engines re-crawl
+    submitToIndexNow(`/community/discussions/${discussion.slug || discussion._id}`);
+
     // Notify the discussion author (if not replying to own thread)
     if (discussion.author.toString() !== req.user.id) {
       const replier = await User.findById(req.user.id).select('username displayName');
@@ -454,7 +489,7 @@ router.post('/:id/replies', requireAuth, async (req, res) => {
         type: 'discussion_reply',
         title: 'New reply to your discussion',
         message: `${replierName} replied to "${discussion.title}"`,
-        link: `/community/discussions/${discussion._id}`
+        link: `/community/discussions/${discussion.slug || discussion._id}`
       }).save().catch(() => {});
     }
 
@@ -579,11 +614,10 @@ router.post('/:discussionId/replies/:replyId/like', requireAuth, async (req, res
 
 // ─── Moderation ─────────────────────────────────────────────────────────────
 
-// PATCH /api/discussions/:id/pin - Toggle pin (moderator/admin only)
-router.patch('/:id/pin', requireAuth, requireModeratorOrAdmin, async (req, res) => {
+// PATCH /api/discussions/:idOrSlug/pin - Toggle pin (moderator/admin only)
+router.patch('/:idOrSlug/pin', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
-    const discussion = await Discussion.findById(req.params.id);
+    const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
     discussion.isPinned = !discussion.isPinned;
@@ -597,16 +631,18 @@ router.patch('/:id/pin', requireAuth, requireModeratorOrAdmin, async (req, res) 
   }
 });
 
-// PATCH /api/discussions/:id/lock - Toggle lock (moderator/admin only)
-router.patch('/:id/lock', requireAuth, requireModeratorOrAdmin, async (req, res) => {
+// PATCH /api/discussions/:idOrSlug/lock - Toggle lock (moderator/admin only)
+router.patch('/:idOrSlug/lock', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
-    const discussion = await Discussion.findById(req.params.id);
+    const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
     discussion.isLocked = !discussion.isLocked;
     await discussion.save();
     logAudit(req, 'discussion.lock', { type: 'discussion', id: discussion._id }, { isLocked: discussion.isLocked });
+
+    // Locking changes the page meaning — re-ping crawlers to refresh their snapshot
+    submitToIndexNow(`/community/discussions/${discussion.slug || discussion._id}`);
 
     res.json({ discussion });
   } catch (err) {
@@ -615,16 +651,15 @@ router.patch('/:id/lock', requireAuth, requireModeratorOrAdmin, async (req, res)
   }
 });
 
-// PATCH /api/discussions/:id/move - Move to different category (moderator/admin only)
-router.patch('/:id/move', requireAuth, requireModeratorOrAdmin, async (req, res) => {
+// PATCH /api/discussions/:idOrSlug/move - Move to different category (moderator/admin only)
+router.patch('/:idOrSlug/move', requireAuth, requireModeratorOrAdmin, async (req, res) => {
   try {
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
     const { category } = req.body;
     if (!category || !CATEGORIES.includes(category)) {
       return res.status(400).json({ error: 'Invalid category' });
     }
 
-    const discussion = await Discussion.findById(req.params.id);
+    const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
     const oldCategory = discussion.category;
@@ -641,12 +676,10 @@ router.patch('/:id/move', requireAuth, requireModeratorOrAdmin, async (req, res)
 
 // ─── Reporting ──────────────────────────────────────────────────────────────
 
-// POST /api/discussions/:id/report - Report a discussion
-router.post('/:id/report', requireAuth, async (req, res) => {
+// POST /api/discussions/:idOrSlug/report - Report a discussion
+router.post('/:idOrSlug/report', requireAuth, async (req, res) => {
   try {
-    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid discussion ID' });
-
-    const discussion = await Discussion.findById(req.params.id);
+    const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
     const VALID_REASONS = ['spam', 'harassment', 'off_topic', 'inappropriate', 'other'];

--- a/backend/src/routes/og.js
+++ b/backend/src/routes/og.js
@@ -6,6 +6,8 @@ const BlogPost = require('../models/BlogPost');
 const Country = require('../models/Country');
 const Region = require('../models/Region');
 const Grape = require('../models/Grape');
+const Discussion = require('../models/Discussion');
+const DiscussionReply = require('../models/DiscussionReply');
 const { fromNormalized } = require('../utils/ratingUtils');
 const { isValidId } = require('../utils/validation');
 
@@ -630,6 +632,214 @@ router.get('/wine-types/:type', ogLimiter, async (req, res) => {
     res.send(html);
   } catch (err) {
     console.error('[og] wine-type error:', err.message);
+    res.status(500).send('Error generating page');
+  }
+});
+
+// Human-readable labels for the 5 discussion categories — used in crawler HTML.
+const DISCUSSION_CATEGORY_LABELS = {
+  'tasting-notes': 'Tasting Notes',
+  'food-pairing': 'Food Pairing',
+  'recommendations': 'Recommendations',
+  'cellar-tips': 'Cellar Tips',
+  'general': 'General'
+};
+
+// GET /og/community/discussions — Crawler-visible list of recent discussions.
+router.get('/community/discussions', ogLimiter, async (req, res) => {
+  try {
+    const discussions = await Discussion.find({})
+      .sort({ isPinned: -1, lastActivityAt: -1 })
+      .select('title slug body category replyCount lastActivityAt createdAt')
+      .limit(50)
+      .lean();
+
+    const pageUrl = `${SITE_URL}/community/discussions`;
+    const title = 'Wine Discussions — Cellarion Community';
+    const metaDescription = 'Public wine discussion forum: tasting notes, food pairing, cellar tips, and recommendations from Cellarion users.';
+
+    const jsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'CollectionPage',
+      name: title,
+      description: metaDescription,
+      url: pageUrl,
+      isPartOf: { '@type': 'WebSite', '@id': `${SITE_URL}/#website` },
+      mainEntity: {
+        '@type': 'ItemList',
+        numberOfItems: discussions.length,
+        itemListElement: discussions.map((d, i) => ({
+          '@type': 'ListItem',
+          position: i + 1,
+          url: `${SITE_URL}/community/discussions/${d.slug || d._id}`,
+          name: d.title
+        }))
+      }
+    };
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${esc(title)}</title>
+  <meta name="description" content="${esc(metaDescription)}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="${esc(title)}" />
+  <meta property="og:description" content="${esc(metaDescription)}" />
+  <meta property="og:url" content="${esc(pageUrl)}" />
+  <meta property="og:site_name" content="Cellarion" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${esc(title)}" />
+  <meta name="twitter:description" content="${esc(metaDescription)}" />
+  <link rel="canonical" href="${esc(pageUrl)}" />
+  <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+</head>
+<body>
+  <header><h1>Wine Discussions</h1></header>
+  <main>
+    <p>${esc(metaDescription)}</p>
+    ${discussions.length === 0 ? '<p>No discussions yet — be the first to start one.</p>' : `<ul>${discussions.map(d => {
+      const url = `${SITE_URL}/community/discussions/${d.slug || d._id}`;
+      const preview = (d.body || '').slice(0, 160);
+      const cat = DISCUSSION_CATEGORY_LABELS[d.category] || d.category;
+      return `<li><a href="${esc(url)}"><strong>${esc(d.title)}</strong></a> — ${esc(cat)} · ${d.replyCount || 0} ${d.replyCount === 1 ? 'reply' : 'replies'}<br/><small>${esc(preview)}${d.body && d.body.length > 160 ? '…' : ''}</small></li>`;
+    }).join('')}</ul>`}
+  </main>
+  <footer>
+    <p>Join the conversation on <a href="${esc(SITE_URL)}">Cellarion</a> — track your cellar, get drink-window recommendations, and share notes with other wine drinkers.</p>
+  </footer>
+</body>
+</html>`;
+
+    res.set('Content-Type', 'text/html; charset=utf-8');
+    res.set('Cache-Control', 'public, max-age=600');
+    res.send(html);
+  } catch (err) {
+    console.error('[og] community discussions list error:', err.message);
+    res.status(500).send('Error generating page');
+  }
+});
+
+// GET /og/community/discussions/:idOrSlug — Crawler-visible single discussion thread.
+// 301-redirects ObjectId URLs to the slug form when one exists, so link equity
+// transfers to the canonical URL.
+router.get('/community/discussions/:idOrSlug', ogLimiter, async (req, res) => {
+  try {
+    const { idOrSlug } = req.params;
+    const isId = isValidId(idOrSlug);
+    const filter = isId ? { _id: idOrSlug } : { slug: String(idOrSlug).toLowerCase() };
+
+    const discussion = await Discussion.findOne(filter)
+      .populate('author', 'username displayName')
+      .populate({ path: 'wineDefinition', select: 'name producer slug' })
+      .lean();
+
+    if (!discussion) {
+      return res.status(404).send('Not found');
+    }
+
+    if (isId && discussion.slug) {
+      return res.redirect(301, `${SITE_URL}/community/discussions/${discussion.slug}`);
+    }
+
+    const slugOrId = discussion.slug || discussion._id;
+    const pageUrl = `${SITE_URL}/community/discussions/${slugOrId}`;
+    const authorName = discussion.author?.displayName || discussion.author?.username || 'Anonymous';
+    const cat = DISCUSSION_CATEGORY_LABELS[discussion.category] || discussion.category;
+
+    // Pull the top-level replies (up to 30) for the schema's `comment` array
+    // and the visible thread.
+    const replies = await DiscussionReply.find({ discussion: discussion._id, isDeleted: { $ne: true } })
+      .sort({ createdAt: 1 })
+      .limit(30)
+      .populate('author', 'username displayName')
+      .select('body author createdAt')
+      .lean();
+
+    const fullDesc = `${discussion.body || ''}`.slice(0, 160);
+    const metaDescription = fullDesc.length > 0 ? fullDesc : `${discussion.title} — Cellarion wine discussion`;
+    const datePublished = discussion.createdAt ? new Date(discussion.createdAt).toISOString() : '';
+    const dateModified = discussion.lastActivityAt
+      ? new Date(discussion.lastActivityAt).toISOString()
+      : (discussion.updatedAt ? new Date(discussion.updatedAt).toISOString() : datePublished);
+
+    const jsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'DiscussionForumPosting',
+      headline: discussion.title,
+      articleBody: discussion.body,
+      datePublished,
+      dateModified,
+      url: pageUrl,
+      mainEntityOfPage: { '@type': 'WebPage', '@id': pageUrl },
+      author: { '@type': 'Person', name: authorName },
+      publisher: {
+        '@type': 'Organization',
+        name: 'Cellarion',
+        url: SITE_URL,
+        logo: { '@type': 'ImageObject', url: `${SITE_URL}/cellarion-logo.jpg` }
+      },
+      interactionStatistic: {
+        '@type': 'InteractionCounter',
+        interactionType: 'https://schema.org/CommentAction',
+        userInteractionCount: discussion.replyCount || 0
+      },
+      ...(replies.length > 0 ? {
+        comment: replies.map(r => ({
+          '@type': 'Comment',
+          text: r.body,
+          datePublished: r.createdAt ? new Date(r.createdAt).toISOString() : undefined,
+          author: { '@type': 'Person', name: r.author?.displayName || r.author?.username || 'Anonymous' }
+        }))
+      } : {})
+    };
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${esc(discussion.title)} — Cellarion</title>
+  <meta name="description" content="${esc(metaDescription)}" />
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="${esc(discussion.title)}" />
+  <meta property="og:description" content="${esc(metaDescription)}" />
+  <meta property="og:url" content="${esc(pageUrl)}" />
+  <meta property="og:site_name" content="Cellarion" />
+  <meta property="og:image" content="${esc(SITE_URL)}/cellarion-logo.jpg" />
+  ${datePublished ? `<meta property="article:published_time" content="${esc(datePublished)}" />` : ''}
+  ${dateModified ? `<meta property="article:modified_time" content="${esc(dateModified)}" />` : ''}
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${esc(discussion.title)}" />
+  <meta name="twitter:description" content="${esc(metaDescription)}" />
+  <link rel="canonical" href="${esc(pageUrl)}" />
+  <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+</head>
+<body>
+  <nav><a href="${esc(SITE_URL)}/community/discussions">Discussions</a> / ${esc(cat)}</nav>
+  <article>
+    <header>
+      <h1>${esc(discussion.title)}</h1>
+      <p>By ${esc(authorName)}${datePublished ? ` · <time datetime="${esc(datePublished)}">${esc(datePublished.split('T')[0])}</time>` : ''}</p>
+      ${discussion.wineDefinition ? `<p>About: <a href="${esc(SITE_URL)}/wines/${esc(discussion.wineDefinition.slug || discussion.wineDefinition._id)}">${esc(discussion.wineDefinition.name)}${discussion.wineDefinition.producer ? ` — ${esc(discussion.wineDefinition.producer)}` : ''}</a></p>` : ''}
+    </header>
+    <div>${esc(discussion.body)}</div>
+    ${replies.length > 0 ? `<section><h2>${replies.length} ${replies.length === 1 ? 'reply' : 'replies'}</h2>${replies.map(r => {
+      const rname = r.author?.displayName || r.author?.username || 'Anonymous';
+      const rdate = r.createdAt ? new Date(r.createdAt).toISOString().split('T')[0] : '';
+      return `<div><p><strong>${esc(rname)}</strong>${rdate ? ` <time datetime="${esc(rdate)}">${esc(rdate)}</time>` : ''}</p><p>${esc(r.body)}</p></div>`;
+    }).join('')}</section>` : ''}
+  </article>
+  <footer>
+    <p><a href="${esc(SITE_URL)}/community/discussions">More discussions</a> · <a href="${esc(SITE_URL)}">Cellarion</a> — your wine cellar in the cloud.</p>
+  </footer>
+</body>
+</html>`;
+
+    res.set('Content-Type', 'text/html; charset=utf-8');
+    res.set('Cache-Control', 'public, max-age=600');
+    res.send(html);
+  } catch (err) {
+    console.error('[og] community discussion error:', err.message);
     res.status(500).send('Error generating page');
   }
 });

--- a/backend/src/routes/sitemap.js
+++ b/backend/src/routes/sitemap.js
@@ -5,6 +5,7 @@ const WineDefinition = require('../models/WineDefinition');
 const Country = require('../models/Country');
 const Region = require('../models/Region');
 const Grape = require('../models/Grape');
+const Discussion = require('../models/Discussion');
 const { getClientIp } = require('../utils/clientIp');
 
 const WINE_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
@@ -33,6 +34,7 @@ router.get('/', sitemapLimiter, async (req, res) => {
     const staticPages = [
       { loc: '/', priority: '1.0', changefreq: 'weekly' },
       { loc: '/blog', priority: '0.8', changefreq: 'daily' },
+      { loc: '/community/discussions', priority: '0.8', changefreq: 'daily' },
       { loc: '/help', priority: '0.6', changefreq: 'monthly' },
       { loc: '/privacy', priority: '0.3', changefreq: 'yearly' },
     ];
@@ -129,6 +131,28 @@ router.get('/', sitemapLimiter, async (req, res) => {
       xml += `    <loc>${SITE_URL}/wines/type/${type}</loc>\n`;
       xml += '    <changefreq>monthly</changefreq>\n';
       xml += '    <priority>0.5</priority>\n';
+      xml += '  </url>\n';
+    }
+
+    // Community discussions — only non-locked threads (locked threads can't accept
+    // new replies, so their content is stable but their value-as-a-destination is
+    // weaker). Capped at 5000 to stay well under the 50 000 sitemap.xml limit.
+    const discussions = await Discussion.find({ isLocked: { $ne: true } })
+      .sort({ lastActivityAt: -1 })
+      .select('_id slug lastActivityAt replyCount')
+      .limit(5000)
+      .lean();
+
+    for (const d of discussions) {
+      const lastmod = d.lastActivityAt
+        ? d.lastActivityAt.toISOString().split('T')[0]
+        : d._id.getTimestamp().toISOString().split('T')[0];
+      const priority = (d.replyCount || 0) > 10 ? '0.6' : '0.4';
+      xml += '  <url>\n';
+      xml += `    <loc>${SITE_URL}/community/discussions/${d.slug || d._id}</loc>\n`;
+      xml += `    <lastmod>${lastmod}</lastmod>\n`;
+      xml += '    <changefreq>weekly</changefreq>\n';
+      xml += `    <priority>${priority}</priority>\n`;
       xml += '  </url>\n';
     }
 

--- a/backend/src/scripts/migrate-discussion-slugs.js
+++ b/backend/src/scripts/migrate-discussion-slugs.js
@@ -1,0 +1,68 @@
+/**
+ * Backfill `slug` on Discussion documents that don't have one yet.
+ *
+ * Idempotent — safe to run twice. Each slug is `slugify(title) + '-' + last6(_id)`
+ * which makes collisions effectively impossible (the ObjectId suffix is the
+ * collision-resistance mechanism, not a numeric "-2" retry loop).
+ *
+ * Run inside the backend container:
+ *   docker exec cellarion-backend node src/scripts/migrate-discussion-slugs.js
+ */
+
+const mongoose = require('mongoose');
+const connectDB = require('../config/db');
+const Discussion = require('../models/Discussion');
+const { slugify } = require('../utils/normalize');
+
+(async () => {
+  await connectDB();
+
+  // Ensure the new sparse-unique slug index exists before we start writing.
+  await Discussion.syncIndexes();
+
+  const total = await Discussion.countDocuments({});
+  const missing = await Discussion.countDocuments({ slug: { $exists: false } });
+  console.log(`[migrate-discussion-slugs] ${total} total discussions, ${missing} need a slug`);
+
+  if (missing === 0) {
+    console.log('[migrate-discussion-slugs] nothing to do');
+    await mongoose.disconnect();
+    return;
+  }
+
+  const cursor = Discussion.find({ slug: { $exists: false } })
+    .select('_id title')
+    .cursor();
+
+  const ops = [];
+  let updated = 0;
+
+  for (let doc = await cursor.next(); doc != null; doc = await cursor.next()) {
+    const base = slugify(doc.title);
+    const suffix = doc._id.toString().slice(-6);
+    const slug = base ? `${base}-${suffix}` : suffix;
+
+    ops.push({
+      updateOne: {
+        filter: { _id: doc._id },
+        update: { $set: { slug } }
+      }
+    });
+    updated++;
+
+    if (ops.length >= 500) {
+      await Discussion.bulkWrite(ops, { ordered: false });
+      ops.length = 0;
+    }
+  }
+
+  if (ops.length > 0) {
+    await Discussion.bulkWrite(ops, { ordered: false });
+  }
+
+  console.log(`[migrate-discussion-slugs] updated ${updated} docs`);
+  await mongoose.disconnect();
+})().catch(err => {
+  console.error('[migrate-discussion-slugs] FAILED:', err);
+  process.exit(1);
+});

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -191,6 +191,37 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    # Community discussions — public forum. Crawlers get server-rendered HTML
+    # with DiscussionForumPosting JSON-LD; real users get the SPA.
+    # Matches /community/discussions and /community/discussions/<slug-or-id>.
+    location = /community/discussions {
+        error_page 418 = @community_og;
+        if ($is_crawler) {
+            return 418;
+        }
+        root       /usr/share/nginx/html;
+        try_files  /index.html =404;
+    }
+
+    location ~ "^/community/discussions/[A-Za-z0-9_-]+$" {
+        error_page 418 = @community_og;
+        if ($is_crawler) {
+            return 418;
+        }
+        root       /usr/share/nginx/html;
+        try_files  /index.html =404;
+    }
+
+    location @community_og {
+        rewrite ^(.*)$ /api/og$1 break;
+        proxy_pass         http://backend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     # Serve the React SPA — fall back to index.html for client-side routing
     location / {
         root       /usr/share/nginx/html;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -243,7 +243,7 @@ function AppRoutes() {
           }
         />
         <Route path="/community/discussions" element={<Layout><CommunityDiscussions /></Layout>} />
-        <Route path="/community/discussions/:id" element={<Layout><DiscussionDetail /></Layout>} />
+        <Route path="/community/discussions/:idOrSlug" element={<Layout><DiscussionDetail /></Layout>} />
         <Route
           path="/users/:userId"
           element={

--- a/frontend/src/components/DiscussionCard.js
+++ b/frontend/src/components/DiscussionCard.js
@@ -9,7 +9,7 @@ export default function DiscussionCard({ discussion }) {
   const authorName = author.displayName || author.username || 'Unknown';
 
   return (
-    <Link to={`/community/discussions/${discussion._id}`} className="discussion-card card">
+    <Link to={`/community/discussions/${discussion.slug || discussion._id}`} className="discussion-card card">
       <div className="discussion-card__header">
         <div className="discussion-card__meta">
           <CategoryBadge category={discussion.category} />

--- a/frontend/src/pages/DiscussionDetail.js
+++ b/frontend/src/pages/DiscussionDetail.js
@@ -15,16 +15,20 @@ import WineSearchPicker from '../components/WineSearchPicker';
 import Modal from '../components/Modal';
 import ConfirmModal from '../components/ConfirmModal';
 import CommunityCTA from '../components/CommunityCTA';
+import SEOHead from '../components/SEOHead';
 import timeAgo from '../utils/timeAgo';
 import './DiscussionDetail.css';
 
 const CATEGORIES = Object.keys(CATEGORY_LABELS);
 
 function DiscussionDetail() {
-  const { id } = useParams();
+  const { idOrSlug } = useParams();
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { apiFetch, user } = useAuth();
+  // Once the discussion has loaded, prefer its canonical _id for write actions
+  // — the URL might be a slug, but the API expects an ObjectId for writes.
+  const id = idOrSlug;
 
   const [discussion, setDiscussion] = useState(null);
   const [replies, setReplies] = useState([]);
@@ -65,18 +69,24 @@ function DiscussionDetail() {
 
   const fetchDiscussion = useCallback(async () => {
     try {
-      const res = await getDiscussion(apiFetch, id);
+      const res = await getDiscussion(apiFetch, idOrSlug);
       const data = await res.json();
       if (res.ok) {
         setDiscussion(data.discussion);
         setError(null);
+        // Canonicalise the URL: if the user landed on the ObjectId form but the
+        // discussion has a slug, swap to the slug URL via history.replaceState
+        // (no navigation, no extra render). Same trick WineDetail uses.
+        if (data.discussion?.slug && data.discussion.slug !== idOrSlug) {
+          window.history.replaceState({}, '', `/community/discussions/${data.discussion.slug}`);
+        }
       } else {
         setError(data.error || t('discussions.failedLoadDiscussion'));
       }
     } catch {
       setError(t('discussions.failedLoadDiscussion'));
     }
-  }, [apiFetch, id, t]);
+  }, [apiFetch, idOrSlug, t]);
 
   const fetchReplies = useCallback(async (p, replace = false) => {
     try {
@@ -259,8 +269,41 @@ function DiscussionDetail() {
   const author = discussion.author || {};
   const authorName = author.displayName || author.username || 'Unknown';
 
+  const slugOrId = discussion.slug || discussion._id;
+  const canonicalPath = `/community/discussions/${slugOrId}`;
+  const seoDescription = (discussion.body || '').slice(0, 160);
+
   return (
     <div className="discussion-detail">
+      <SEOHead
+        title={`${discussion.title} — Cellarion`}
+        description={seoDescription || `${discussion.title} — Cellarion wine discussion`}
+        path={canonicalPath}
+        ogType="article"
+        articleMeta={{
+          publishedTime: discussion.createdAt,
+          modifiedTime: discussion.lastActivityAt || discussion.updatedAt
+        }}
+        jsonLd={{
+          '@context': 'https://schema.org',
+          '@type': 'DiscussionForumPosting',
+          headline: discussion.title,
+          articleBody: discussion.body,
+          datePublished: discussion.createdAt,
+          dateModified: discussion.lastActivityAt || discussion.updatedAt,
+          author: { '@type': 'Person', name: authorName },
+          publisher: {
+            '@type': 'Organization',
+            name: 'Cellarion',
+            url: 'https://cellarion.app'
+          },
+          interactionStatistic: {
+            '@type': 'InteractionCounter',
+            interactionType: 'https://schema.org/CommentAction',
+            userInteractionCount: discussion.replyCount || 0
+          }
+        }}
+      />
       <Link to="/community/discussions" className="discussion-detail__back">{t('discussions.backToDiscussions')}</Link>
 
       {/* Discussion header */}

--- a/frontend/src/pages/Discussions.js
+++ b/frontend/src/pages/Discussions.js
@@ -7,6 +7,7 @@ import CategoryBadge, { CATEGORY_LABELS } from '../components/CategoryBadge';
 import CommunityCTA from '../components/CommunityCTA';
 import Modal from '../components/Modal';
 import WineSearchPicker from '../components/WineSearchPicker';
+import SEOHead from '../components/SEOHead';
 import './Discussions.css';
 
 const CATEGORIES = Object.keys(CATEGORY_LABELS);
@@ -104,6 +105,29 @@ function Discussions() {
 
   return (
     <div className="discussions-page">
+      <SEOHead
+        title="Wine Discussions — Cellarion Community"
+        description="Public wine discussion forum: tasting notes, food pairing, cellar tips, and recommendations from Cellarion users."
+        path="/community/discussions"
+        jsonLd={{
+          '@context': 'https://schema.org',
+          '@type': 'CollectionPage',
+          name: 'Wine Discussions — Cellarion Community',
+          description: 'Public wine discussion forum: tasting notes, food pairing, cellar tips, and recommendations from Cellarion users.',
+          ...(discussions.length > 0 ? {
+            mainEntity: {
+              '@type': 'ItemList',
+              numberOfItems: discussions.length,
+              itemListElement: discussions.slice(0, 20).map((d, i) => ({
+                '@type': 'ListItem',
+                position: i + 1,
+                url: `https://cellarion.app/community/discussions/${d.slug || d._id}`,
+                name: d.title
+              }))
+            }
+          } : {})
+        }}
+      />
       <div className="discussions__header">
         <h1>{t('discussions.community')}</h1>
         <span className="discussions__beta-badge">{t('discussions.beta')}</span>


### PR DESCRIPTION
## Summary
**Phase 2** of the community forum roadmap. After Phase 1 made discussions publicly readable, this PR makes them **discoverable**: human-readable slug URLs, server-rendered HTML for search engines and AI assistants (with proper schema.org structured data), sitemap inclusion, and IndexNow pings on every meaningful change.

## What's new

### Slug URLs
- New sparse-unique `slug` field on `Discussion`, generated on create as `slugify(title) + '-' + last6(_id)` (e.g. `best-temperature-for-cellaring-bordeaux-abc123`).
- Pinned at create time, never regenerated on title edit — URLs stay stable forever.
- API resolves both forms: `GET /api/discussions/:idOrSlug` works whether the URL is a slug or an ObjectId. Writes use the same resolution helper, so a user posting a reply from a slug URL also works.
- `migrate-discussion-slugs.js` backfills slugs for existing threads. Idempotent.

### Crawler HTML for /community/discussions/*
- Two new `og.js` routes mirror the wine/blog pattern:
  - `/og/community/discussions` — list view with `ItemList` JSON-LD.
  - `/og/community/discussions/:idOrSlug` — detail view with `DiscussionForumPosting` JSON-LD including up to 30 nested `Comment` entities, full OG + Twitter card meta, canonical link. ObjectId URLs 301 to the slug form so external link equity transfers.
- `nginx.conf` routes crawler user-agents (Googlebot, GPTBot, ClaudeBot, …) to these endpoints; real users still get the SPA.

### Sitemap
- Top-level `/community/discussions` added to the static section (priority 0.8, daily).
- Up to 5000 non-locked discussions included, sorted by `lastActivityAt`. Priority 0.6 if replyCount > 10, else 0.4.

### IndexNow
- Pinged on discussion create, on every reply (lastmod changes), on lock, and on delete (so search engines drop the URL quickly).
- Fire-and-forget; silent no-op when `INDEXNOW_KEY` is unset.

### Frontend SEO
- `Discussions` and `DiscussionDetail` now render `<SEOHead>` with canonical / OG / Twitter / hreflang / JSON-LD that mirrors the crawler HTML — SPA and crawler agree on metadata.
- `DiscussionDetail` swaps an ObjectId URL for the slug form via `history.replaceState()` on first render (same trick `WineDetail` uses) — bookmarked old URLs still work but become slug URLs in the address bar.
- `DiscussionCard` and notification deep-links use slugs when present.

## Test plan
- [x] `cd backend && npm test` — 400/400 pass.
- [x] `cd frontend && npm test -- --watchAll=false` — 256/256 pass.
- [ ] Smoke-test in Docker:
  - [ ] Run `docker exec cellarion-backend node src/scripts/migrate-discussion-slugs.js` — see "updated N docs" log.
  - [ ] Visit `/community/discussions/<old-objectid>` in a browser → URL replaces with slug form, content unchanged.
  - [ ] `curl -A "Googlebot/2.1" http://localhost/community/discussions` → returns server-rendered HTML with `<script type="application/ld+json">` block, NOT the SPA shell.
  - [ ] `curl -A "Googlebot/2.1" http://localhost/community/discussions/<some-slug>` → returns `DiscussionForumPosting` JSON-LD with nested `Comment` array.
  - [ ] `curl http://localhost/sitemap.xml | grep community/discussions` → finds the list URL plus per-thread entries.
  - [ ] Set `INDEXNOW_KEY` env var, create a new discussion, check backend logs for IndexNow ping (or a `[indexnow]` warning if the key is invalid).
  - [ ] Logged-in user posts a reply from a slug URL → succeeds (backend resolves the slug to find the discussion).

## Out of scope
- Reply notifications, @mentions, "discussions about this wine" panel — Phase 3.
- TipTap composer, Meilisearch indexing, trending sort, homepage widget — Phase 4.

## Verification commands (after merge)
```bash
# Backfill slugs on existing discussions
docker exec cellarion-backend node src/scripts/migrate-discussion-slugs.js

# Spot-check crawler view
curl -A "Googlebot/2.1" https://cellarion.app/community/discussions | head -50
```