### PR TITLE
feat(community): reply notifications, @mentions, wine cross-linking

### DIFF
--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -5,13 +5,14 @@ const { CATEGORIES } = require('../models/Discussion');
 const DiscussionReply = require('../models/DiscussionReply');
 const DiscussionReplyVote = require('../models/DiscussionReplyVote');
 const DiscussionReport = require('../models/DiscussionReport');
-const Notification = require('../models/Notification');
 const User = require('../models/User');
 const WineDefinition = require('../models/WineDefinition');
 const { stripHtml } = require('../utils/sanitize');
 const { logAudit } = require('../services/audit');
 const { incrementCred } = require('../utils/cellarCred');
 const { submitUrls: submitToIndexNow } = require('../services/indexNow');
+const { createNotification } = require('../services/notifications');
+const { extractMentions } = require('../utils/mentionParser');
 const { parsePagination } = require('../utils/pagination');
 const { isValidId } = require('../utils/validation');
 const { DISCUSSIONS_PER_PAGE, DISCUSSIONS_MAX_PER_PAGE, DISCUSSION_MAX_LENGTHS } = require('../config/constants');
@@ -286,6 +287,22 @@ router.post('/', requireAuth, async (req, res) => {
 
     await discussion.populate('author', 'username displayName roles contribution.tier contribution.specialty');
 
+    // Notify @mentioned users — dispatched after the response would normally be
+    // optimal, but since createNotification is fire-and-forget internally, calling
+    // it before res.json() doesn't add latency.
+    const authorName = discussion.author?.displayName || discussion.author?.username || 'Someone';
+    const link = `/community/discussions/${discussion.slug || discussion._id}`;
+    const mentionedIds = await extractMentions(cleanBody, req.user.id);
+    for (const uid of mentionedIds) {
+      createNotification(
+        uid,
+        'discussion_mention',
+        `${authorName} mentioned you`,
+        `In a new discussion: "${cleanTitle}"`,
+        link
+      );
+    }
+
     res.status(201).json({ discussion });
   } catch (err) {
     console.error('Create discussion error:', err);
@@ -437,6 +454,7 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
 
     // Build quote snapshot if quoting another reply
     let quoteData = {};
+    let quotedAuthorId = null;
     if (quote && quote.replyId && isValidId(quote.replyId)) {
       const quotedReply = await DiscussionReply.findById(quote.replyId).populate('author', 'username displayName');
       if (quotedReply) {
@@ -450,6 +468,9 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
           authorName: quotedName,
           body: snippetBody
         };
+        // Track separately — author is needed for the "you were quoted"
+        // notification, but we don't want to persist it on the reply document.
+        quotedAuthorId = quotedReply.author?._id || null;
       }
     }
 
@@ -480,17 +501,48 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
     // The thread's lastmod just changed — let search engines re-crawl
     submitToIndexNow(`/community/discussions/${discussion.slug || discussion._id}`);
 
-    // Notify the discussion author (if not replying to own thread)
-    if (discussion.author.toString() !== req.user.id) {
-      const replier = await User.findById(req.user.id).select('username displayName');
-      const replierName = replier?.displayName || replier?.username || 'Someone';
-      new Notification({
-        user: discussion.author,
-        type: 'discussion_reply',
-        title: 'New reply to your discussion',
-        message: `${replierName} replied to "${discussion.title}"`,
-        link: `/community/discussions/${discussion.slug || discussion._id}`
-      }).save().catch(() => {});
+    // Notification fan-out: OP, then quoted-author (if different), then any
+    // @mentioned users (deduped). Each user gets at most one notification per
+    // reply event. createNotification handles in-app + web-push.
+    const replier = await User.findById(req.user.id).select('username displayName');
+    const replierName = replier?.displayName || replier?.username || 'Someone';
+    const link = `/community/discussions/${discussion.slug || discussion._id}`;
+    const notified = new Set();
+    const selfId = String(req.user.id);
+
+    if (String(discussion.author) !== selfId) {
+      notified.add(String(discussion.author));
+      createNotification(
+        discussion.author,
+        'discussion_reply',
+        'New reply to your discussion',
+        `${replierName} replied to "${discussion.title}"`,
+        link
+      );
+    }
+
+    if (quotedAuthorId && String(quotedAuthorId) !== selfId && !notified.has(String(quotedAuthorId))) {
+      notified.add(String(quotedAuthorId));
+      createNotification(
+        quotedAuthorId,
+        'discussion_reply',
+        `${replierName} quoted you`,
+        `In "${discussion.title}"`,
+        link
+      );
+    }
+
+    const mentionedIds = await extractMentions(cleanBody, req.user.id);
+    for (const uid of mentionedIds) {
+      if (notified.has(uid)) continue;
+      notified.add(uid);
+      createNotification(
+        uid,
+        'discussion_mention',
+        `${replierName} mentioned you`,
+        `In "${discussion.title}"`,
+        link
+      );
     }
 
     logAudit(req, 'discussion_reply.create', { type: 'discussion_reply', id: reply._id }, { discussion: discussion._id });

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const WineDefinition = require('../models/WineDefinition');
+const Discussion = require('../models/Discussion');
 const searchService = require('../services/search');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, optionalAuth } = require('../middleware/auth');
 const { scanLabelFull, identifyWineFromQuery } = require('../services/labelScan');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
 const { generateWineKey, combinedSimilarity } = require('../utils/normalize');
@@ -357,6 +358,38 @@ router.get('/:id', requireAuth, async (req, res) => {
   } catch (error) {
     console.error('Get wine error:', error);
     res.status(500).json({ error: 'Failed to get wine' });
+  }
+});
+
+// GET /api/wines/:idOrSlug/discussions — Public-readable list of discussions
+// linked to a wine. Used by the WineDetail page's "Discussions about this wine"
+// panel and by future wine-page widgets.
+router.get('/:idOrSlug/discussions', optionalAuth, async (req, res) => {
+  try {
+    const { idOrSlug } = req.params;
+    const filter = isValidId(idOrSlug)
+      ? { _id: idOrSlug }
+      : { slug: String(idOrSlug).toLowerCase() };
+
+    const wine = await WineDefinition.findOne(filter).select('_id');
+    if (!wine) return res.status(404).json({ error: 'Wine not found' });
+
+    const { page, limit, offset: skip } = parsePagination(req.query, { limit: 10, maxLimit: 30 });
+
+    const [discussions, total] = await Promise.all([
+      Discussion.find({ wineDefinition: wine._id })
+        .sort({ isPinned: -1, lastActivityAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .populate('author', 'username displayName roles contribution.tier contribution.specialty')
+        .select('title slug body category replyCount lastActivityAt createdAt isPinned isLocked author wineDefinition'),
+      Discussion.countDocuments({ wineDefinition: wine._id })
+    ]);
+
+    res.json({ discussions, total, page, pages: Math.ceil(total / limit) });
+  } catch (error) {
+    console.error('List wine discussions error:', error);
+    res.status(500).json({ error: 'Failed to list discussions' });
   }
 });
 

--- a/backend/src/utils/mentionParser.js
+++ b/backend/src/utils/mentionParser.js
@@ -1,0 +1,50 @@
+const User = require('../models/User');
+
+// Match @<username> tokens in body text. Allowed username chars mirror the
+// ones the registration flow accepts: letters, digits, dot, hyphen, underscore.
+// Length 3–32 to match the User model. Negative-look-behind on `\w` so we don't
+// match the @ in email addresses (e.g. user@example.com).
+const MENTION_RE = /(?<![\w.])@([a-zA-Z0-9._-]{3,32})/g;
+
+// Hard cap on how many mentions a single post can fan out to. Spam guard —
+// without this, a post could ping every user in the system. 10 is generous
+// for the wine-talk use case (mentioning a few friends in a thread).
+const MAX_MENTIONS_PER_POST = 10;
+
+/**
+ * Extract @username tokens from a post body and resolve them to User IDs.
+ * Case-insensitive on usernames. Returns an array of unique ObjectIds for users
+ * that exist; usernames that don't match any user are silently dropped.
+ *
+ * @param {string} body — the discussion or reply body text
+ * @param {string|null} excludeUserId — optionally exclude this user (e.g. the
+ *   author themselves, so they don't get notified for self-mentions)
+ * @returns {Promise<string[]>} list of user IDs to notify
+ */
+async function extractMentions(body, excludeUserId = null) {
+  if (!body || typeof body !== 'string') return [];
+
+  const usernames = new Set();
+  for (const match of body.matchAll(MENTION_RE)) {
+    usernames.add(match[1].toLowerCase());
+    if (usernames.size >= MAX_MENTIONS_PER_POST) break;
+  }
+  if (usernames.size === 0) return [];
+
+  // Mongoose username field is unique but stored as-typed. Match
+  // case-insensitively via a single $in regex.
+  const regexes = [...usernames].map(u => new RegExp(`^${u.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i'));
+  const users = await User.find({ username: { $in: regexes } }).select('_id').lean();
+
+  const ids = users
+    .map(u => u._id.toString())
+    .filter(id => !excludeUserId || id !== String(excludeUserId));
+
+  return Array.from(new Set(ids));
+}
+
+module.exports = {
+  extractMentions,
+  MENTION_RE,
+  MAX_MENTIONS_PER_POST
+};

--- a/backend/src/utils/mentionParser.test.js
+++ b/backend/src/utils/mentionParser.test.js
@@ -1,0 +1,109 @@
+// Mock the User model before requiring the parser. The parser hits User.find
+// to resolve usernames to ObjectIds; in unit tests we substitute a Map-based
+// fake so the tests don't need a Mongo connection.
+
+jest.mock('../models/User', () => {
+  const fakeUsersByLowerUsername = new Map();
+  return {
+    __setUsers: (list) => {
+      fakeUsersByLowerUsername.clear();
+      for (const u of list) fakeUsersByLowerUsername.set(u.username.toLowerCase(), u);
+    },
+    find: (filter) => {
+      // The parser passes { username: { $in: [/regex/i, ...] } }. We pull the
+      // pattern source out of each regex (it matches `^username$` after escape)
+      // and look it up in the fake map.
+      const regexes = filter?.username?.$in || [];
+      const matched = [];
+      for (const re of regexes) {
+        const lower = re.source.replace(/^\^|\$$/g, '').replace(/\\(.)/g, '$1').toLowerCase();
+        const hit = fakeUsersByLowerUsername.get(lower);
+        if (hit) matched.push(hit);
+      }
+      return {
+        select: () => ({
+          lean: async () => matched
+        })
+      };
+    }
+  };
+});
+
+const User = require('../models/User');
+const { extractMentions, MENTION_RE, MAX_MENTIONS_PER_POST } = require('./mentionParser');
+
+describe('extractMentions', () => {
+  beforeEach(() => {
+    User.__setUsers([
+      { _id: 'a', username: 'alice' },
+      { _id: 'b', username: 'bob.smith' },
+      { _id: 'c', username: 'carol-W' },
+      { _id: 'd', username: 'Dave_99' },
+    ]);
+  });
+
+  test('returns [] for empty/null/non-string input', async () => {
+    expect(await extractMentions('')).toEqual([]);
+    expect(await extractMentions(null)).toEqual([]);
+    expect(await extractMentions(undefined)).toEqual([]);
+    expect(await extractMentions(42)).toEqual([]);
+  });
+
+  test('returns [] when there are no @mentions', async () => {
+    expect(await extractMentions('hey check out this wine')).toEqual([]);
+  });
+
+  test('resolves a single @mention to its user id', async () => {
+    expect(await extractMentions('hi @alice')).toEqual(['a']);
+  });
+
+  test('is case-insensitive on usernames', async () => {
+    expect(await extractMentions('hi @ALICE')).toEqual(['a']);
+    expect(await extractMentions('hi @dave_99')).toEqual(['d']);
+  });
+
+  test('matches usernames with allowed punctuation (dot, hyphen, underscore)', async () => {
+    expect(await extractMentions('@bob.smith and @carol-W')).toEqual(
+      expect.arrayContaining(['b', 'c'])
+    );
+  });
+
+  test('does NOT match the @ inside email addresses', async () => {
+    // The negative-lookbehind on \w means alice@example.com should not match @example
+    expect(await extractMentions('email me at alice@example.com')).toEqual([]);
+  });
+
+  test('drops usernames that do not exist', async () => {
+    expect(await extractMentions('hi @alice and @nobody')).toEqual(['a']);
+  });
+
+  test('dedupes when the same user is mentioned multiple times', async () => {
+    expect(await extractMentions('@alice @alice @ALICE')).toEqual(['a']);
+  });
+
+  test('excludes the author when excludeUserId is passed', async () => {
+    expect(await extractMentions('@alice and @bob.smith', 'a')).toEqual(['b']);
+    expect(await extractMentions('@alice', 'a')).toEqual([]);
+  });
+
+  test('caps the number of mentions per post', async () => {
+    // Build a post with 15 valid mentions; expect only MAX_MENTIONS_PER_POST resolved
+    const lots = Array.from({ length: 15 }, (_, i) => `@alice${i}`).join(' ');
+    User.__setUsers(
+      Array.from({ length: 15 }, (_, i) => ({ _id: `id${i}`, username: `alice${i}` }))
+    );
+    const result = await extractMentions(lots);
+    expect(result.length).toBeLessThanOrEqual(MAX_MENTIONS_PER_POST);
+  });
+
+  test('does not match @ followed by fewer than 3 chars', async () => {
+    expect(await extractMentions('@a @ab')).toEqual([]);
+  });
+});
+
+describe('MENTION_RE', () => {
+  test('exposes the regex for downstream use (e.g. composer highlighting)', () => {
+    expect(MENTION_RE).toBeInstanceOf(RegExp);
+    expect(MENTION_RE.flags).toContain('g');
+  });
+});

--- a/frontend/src/api/wines.js
+++ b/frontend/src/api/wines.js
@@ -52,3 +52,11 @@ export const getAiWineInfo = (apiFetch, query) =>
     headers: JSON_HEADERS,
     body: JSON.stringify({ query }),
   });
+
+/**
+ * Public-readable list of community discussions linked to a wine. Used by the
+ * WineDetail "Discussions about this wine" panel.
+ * Returns: { discussions, total, page, pages }
+ */
+export const getWineDiscussions = (apiFetch, idOrSlug, params = '') =>
+  apiFetch(`/api/wines/${idOrSlug}/discussions${params ? `?${params}` : ''}`);

--- a/frontend/src/components/WineDiscussionsPanel.css
+++ b/frontend/src/components/WineDiscussionsPanel.css
@@ -1,0 +1,46 @@
+.wine-discussions-panel {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border, rgba(0, 0, 0, 0.08));
+}
+
+.wine-discussions-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.wine-discussions-panel__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.wine-discussions-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.wine-discussions-panel__footer {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.wine-discussions-panel__more {
+  font-size: 0.95rem;
+  color: var(--color-primary, inherit);
+  text-decoration: none;
+}
+
+.wine-discussions-panel__more:hover {
+  text-decoration: underline;
+}
+
+.wine-discussions-panel__empty {
+  margin: 0;
+  color: var(--color-text-secondary, inherit);
+  font-style: italic;
+}

--- a/frontend/src/components/WineDiscussionsPanel.js
+++ b/frontend/src/components/WineDiscussionsPanel.js
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import { getWineDiscussions } from '../api/wines';
+import DiscussionCard from './DiscussionCard';
+import './WineDiscussionsPanel.css';
+
+// Bottom-of-page widget on wine detail pages: shows up to 5 most recently
+// active discussions linked to this wine, plus a CTA to start a new one
+// (logged-in users) or a "sign in to join" prompt (anon).
+//
+// Public-readable: anonymous visitors see the panel and can click through to
+// any thread. Writes (the "Start a discussion" action) require auth.
+export default function WineDiscussionsPanel({ wine }) {
+  const { t } = useTranslation();
+  const { apiFetch, user } = useAuth();
+  const [discussions, setDiscussions] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const wineId = wine?.slug || wine?._id;
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!wineId) return undefined;
+
+    (async () => {
+      try {
+        const res = await getWineDiscussions(apiFetch, wineId, 'limit=5');
+        if (!cancelled && res.ok) {
+          const data = await res.json();
+          setDiscussions(data.discussions || []);
+          setTotal(data.total || 0);
+        }
+      } catch {
+        // Network failure → render the empty state quietly.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [apiFetch, wineId]);
+
+  if (loading) return null; // Quiet load — no skeleton, no flash
+  if (!wine) return null;
+
+  const hasDiscussions = discussions.length > 0;
+
+  return (
+    <section className="wine-discussions-panel">
+      <div className="wine-discussions-panel__header">
+        <h2>{t('wineDiscussions.title')}</h2>
+        {user ? (
+          <Link
+            to="/community/discussions"
+            state={{ newDiscussionWine: wine }}
+            className="btn btn-secondary btn-small"
+          >
+            {t('wineDiscussions.startCta')}
+          </Link>
+        ) : (
+          <Link to={`/login?next=/wines/${wineId}`} className="btn btn-secondary btn-small">
+            {t('wineDiscussions.signInToStart')}
+          </Link>
+        )}
+      </div>
+
+      {hasDiscussions ? (
+        <>
+          <div className="wine-discussions-panel__list">
+            {discussions.map(d => (
+              <DiscussionCard key={d._id} discussion={d} />
+            ))}
+          </div>
+          {total > discussions.length && (
+            <div className="wine-discussions-panel__footer">
+              <Link to="/community/discussions" className="wine-discussions-panel__more">
+                {t('wineDiscussions.viewAll', { count: total })}
+              </Link>
+            </div>
+          )}
+        </>
+      ) : (
+        <p className="wine-discussions-panel__empty">{t('wineDiscussions.empty')}</p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1293,6 +1293,13 @@
     "signInToReply": "Sign in to reply to this discussion.",
     "signInToStart": "Sign in to start a discussion."
   },
+  "wineDiscussions": {
+    "title": "Discussions about this wine",
+    "startCta": "Start a discussion",
+    "signInToStart": "Sign in to discuss",
+    "viewAll": "View all {{count}} discussions",
+    "empty": "No discussions yet — be the first to share your thoughts on this wine."
+  },
   "reviewFeed": {
     "community": "Community",
     "reviews": "Reviews",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1293,6 +1293,13 @@
     "signInToReply": "Logga in för att svara på denna diskussion.",
     "signInToStart": "Logga in för att starta en diskussion."
   },
+  "wineDiscussions": {
+    "title": "Diskussioner om detta vin",
+    "startCta": "Starta en diskussion",
+    "signInToStart": "Logga in för att diskutera",
+    "viewAll": "Visa alla {{count}} diskussioner",
+    "empty": "Inga diskussioner än — bli först med att dela dina tankar om detta vin."
+  },
   "reviewFeed": {
     "community": "Gemenskap",
     "reviews": "Omdömen",

--- a/frontend/src/pages/Discussions.js
+++ b/frontend/src/pages/Discussions.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { getDiscussions, createDiscussion } from '../api/discussions';
@@ -16,6 +17,7 @@ const SORT_KEYS = ['active', 'newest', 'most-replies'];
 function Discussions() {
   const { t } = useTranslation();
   const { apiFetch, user } = useAuth();
+  const location = useLocation();
   const [discussions, setDiscussions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
@@ -70,6 +72,19 @@ function Discussions() {
     setDiscussions([]);
     fetchDiscussions(1, true);
   }, [category, sort]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Pre-fill the create modal when the user arrives from a wine page's
+  // "Start a discussion about this wine" CTA. We use route state (not a query
+  // param) so the wine object stays attached without a refetch and the URL
+  // stays clean. Only fires for logged-in users — anon doesn't get the CTA.
+  useEffect(() => {
+    if (user && location.state?.newDiscussionWine) {
+      setLinkedWine(location.state.newDiscussionWine);
+      setShowCreate(true);
+      // Clear the state so a Back-then-Forward doesn't re-open the modal
+      window.history.replaceState({}, '');
+    }
+  }, [user, location.state]);
 
   const handleCreate = async (e) => {
     e.preventDefault();

--- a/frontend/src/pages/WineDetail.js
+++ b/frontend/src/pages/WineDetail.js
@@ -7,6 +7,7 @@ import Layout from '../components/Layout';
 import SEOHead from '../components/SEOHead';
 import SITE_URL from '../config/siteUrl';
 import WineImage from '../components/WineImage';
+import WineDiscussionsPanel from '../components/WineDiscussionsPanel';
 import { getWineImageUrl } from '../utils/wineImageUrl';
 import { API_URL } from '../api/apiConstants';
 import './WineDetail.css';
@@ -213,6 +214,8 @@ export default function WineDetail() {
           </Link>
         </div>
       )}
+
+      <WineDiscussionsPanel wine={wine} />
     </div>
   );
 


### PR DESCRIPTION
## Summary
**Phase 3** of the community forum roadmap — the engagement layer. Replies now drive notifications back to the OP, quoted-author, and any `@mentioned` users. Wine pages surface their discussions, and signed-in users can start a wine-linked thread in one click.

## What's new

### Notifications wired to the existing service
- Reply creation now goes through `createNotification()` (in-app + web-push when VAPID is configured) instead of writing the raw `Notification` model. Anyone with push subscriptions starts getting reply pings for free.
- New: when a reply quotes another reply, the quoted author also gets notified — `"X quoted you in 'thread title'"`. Deduped against the OP fan-out so no user gets two pings per event.

### @Mentions
- New `backend/src/utils/mentionParser.js` extracts `@username` tokens from a body, looks them up case-insensitively, returns the resolved user IDs.
- Hard cap of 10 mentions per post (anti-spam) + negative-lookbehind on `\w` so `alice@example.com` is not interpreted as `@example`.
- Wired into both `POST /api/discussions` (a new thread can mention people) and `POST /api/discussions/:idOrSlug/replies`. Mentions are deduped against the reply/quote fan-out so each user gets at most one notification per event.
- 12 new unit tests covering case-insensitivity, dedupe, email exclusion, missing users, the per-post cap, and `excludeUserId` for self-mentions.

### Wine cross-linking
- New `GET /api/wines/:idOrSlug/discussions` — public, paginated, optionalAuth. Accepts both ObjectId and slug. Sorted pinned-first, then by `lastActivityAt`.
- New `<WineDiscussionsPanel>` at the bottom of `WineDetail`: shows up to 5 most recent threads about the wine.
- Logged-in users see a "Start a discussion" CTA. Clicking it navigates to `/community/discussions` with the wine attached via React Router state — the new-discussion modal pre-opens with the wine linked, no URL query param, no extra fetch.
- Anon visitors get a "Sign in to discuss" link that returns them here after auth.
- New `wineDiscussions.*` i18n namespace (EN + SV).

## Test plan
- [x] `cd backend && npm test` — 412/412 (was 400; +12 mention parser tests).
- [x] `cd frontend && npm test -- --watchAll=false` — 256/256.
- [ ] Smoke-test in Docker:
  - [ ] User A creates a thread → User B replies → User A's bell shows the notification, web-push fires if subscribed.
  - [ ] User C replies with body `Hey @userA what do you think?` → User A receives ONE notification (the dedupe — not separately as both "reply" and "mention").
  - [ ] User D quotes User C's reply → User C receives a "quoted you" notification, OP receives a "new reply" notification, no duplicates.
  - [ ] Visit `/wines/<slug>` (logged-in or anon) → panel renders 5 most recent threads about that wine.
  - [ ] Click "Start a discussion" on a wine page → new-discussion modal opens with the wine pre-linked.
  - [ ] `curl /api/wines/<slug>/discussions` (no auth) → returns 200 with a paginated list.

## Out of scope (deferred)
- **Email opt-in** for reply notifications (`sendDiscussionReplyEmail` + Settings toggle + new preference field). In-app and web-push give the engagement loop already; email can layer on top in a small follow-up after we see whether users actually want it. Mentioned in the original Phase 3 plan but explicitly deferred to keep this PR focused.
- **Mention autocomplete UI in the composer** — that's tied to the TipTap composer in Phase 4. Plain-text `@username` already works; users just type it.

## What's left
- **Phase 4** — TipTap rich-text composer, Meilisearch indexing for in-forum search, trending sort, homepage widget.