### PR TITLE
feat(community): in-forum search, trending sort, landing widget

### DIFF
--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -13,6 +13,7 @@ const { incrementCred } = require('../utils/cellarCred');
 const { submitUrls: submitToIndexNow } = require('../services/indexNow');
 const { createNotification } = require('../services/notifications');
 const { extractMentions } = require('../utils/mentionParser');
+const searchService = require('../services/search');
 const { parsePagination } = require('../utils/pagination');
 const { isValidId } = require('../utils/validation');
 const { DISCUSSIONS_PER_PAGE, DISCUSSIONS_MAX_PER_PAGE, DISCUSSION_MAX_LENGTHS } = require('../config/constants');
@@ -54,14 +55,53 @@ router.get('/categories', optionalAuth, (req, res) => {
 });
 
 // GET /api/discussions - List discussions (public)
+//
+// When `q` is provided we route through Meilisearch for fuzzy text matching;
+// otherwise we use a MongoDB filter+sort. Either path returns the same response
+// shape, so the frontend doesn't have to special-case search results.
 router.get('/', optionalAuth, async (req, res) => {
   try {
     const { page, limit, offset: skip } = parsePagination(req.query, { limit: DISCUSSIONS_PER_PAGE, maxLimit: DISCUSSIONS_MAX_PER_PAGE });
-    const { category, sort } = req.query;
+    const { category, sort, q } = req.query;
+    const query = (q || '').toString().trim();
 
     const filter = {};
     if (category && CATEGORIES.includes(category)) {
       filter.category = category;
+    }
+
+    // Meilisearch path: fuzzy match on title/body/authorName/wineName,
+    // hydrate hits from MongoDB to keep the response shape consistent.
+    if (query && searchService.getIsAvailable()) {
+      try {
+        const { ids, estimatedTotalHits } = await searchService.searchDiscussions(query, {
+          category: filter.category,
+          limit,
+          offset: skip
+        });
+
+        if (ids.length === 0) {
+          return res.json({ discussions: [], total: estimatedTotalHits, page, pages: Math.ceil(estimatedTotalHits / limit) });
+        }
+
+        const docs = await Discussion.find({ _id: { $in: ids } })
+          .populate('author', 'username displayName roles contribution.tier contribution.specialty')
+          .populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } });
+
+        // Preserve Meilisearch relevance ordering
+        const byId = new Map(docs.map(d => [d._id.toString(), d]));
+        const ordered = ids.map(id => byId.get(id)).filter(Boolean);
+
+        return res.json({
+          discussions: ordered,
+          total: estimatedTotalHits,
+          page,
+          pages: Math.ceil(estimatedTotalHits / limit)
+        });
+      } catch (searchErr) {
+        // Fall through to MongoDB path on Meilisearch failure
+        console.warn('[discussions] search fallback to MongoDB:', searchErr.message);
+      }
     }
 
     let sortObj;
@@ -70,6 +110,15 @@ router.get('/', optionalAuth, async (req, res) => {
         sortObj = { isPinned: -1, createdAt: -1 };
         break;
       case 'most-replies':
+        sortObj = { isPinned: -1, replyCount: -1, lastActivityAt: -1 };
+        break;
+      case 'trending':
+        // Threads with recent activity, ranked by recent reply volume. The
+        // 7-day window keeps the tab feeling fresh; pinned threads still float.
+        // A truer trending score (replies-in-last-7d × 2 + likes + recency) is
+        // a future refinement; this simple proxy already differentiates from
+        // "most-replies" (which surfaces all-time-popular threads).
+        filter.lastActivityAt = { $gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) };
         sortObj = { isPinned: -1, replyCount: -1, lastActivityAt: -1 };
         break;
       default: // 'active' - default sort
@@ -284,6 +333,8 @@ router.post('/', requireAuth, async (req, res) => {
 
     // Notify search engines about the new public-readable URL
     submitToIndexNow(`/community/discussions/${discussion.slug || discussion._id}`);
+    // Index in Meilisearch for in-forum search (fire-and-forget)
+    searchService.indexDiscussion(discussion._id);
 
     await discussion.populate('author', 'username displayName roles contribution.tier contribution.specialty');
 
@@ -346,6 +397,9 @@ router.put('/:idOrSlug', requireAuth, async (req, res) => {
     await discussion.save();
     logAudit(req, 'discussion.update', { type: 'discussion', id: discussion._id });
 
+    // Re-index after edit so search results reflect the new title/body
+    searchService.indexDiscussion(discussion._id);
+
     await discussion.populate('author', 'username displayName roles contribution.tier contribution.specialty');
     res.json({ discussion });
   } catch (err) {
@@ -369,11 +423,14 @@ router.delete('/:idOrSlug', requireAuth, requireModeratorOrAdmin, async (req, re
 
     // Capture the public URL before deletion so we can ping IndexNow afterwards.
     const publicPath = `/community/discussions/${discussion.slug || discussion._id}`;
+    const deletedId = discussion._id;
     await Discussion.deleteOne({ _id: discussion._id });
-    logAudit(req, 'discussion.delete', { type: 'discussion', id: discussion._id });
+    logAudit(req, 'discussion.delete', { type: 'discussion', id: deletedId });
 
     // Tell crawlers the URL is gone (ping returns 404 on next crawl → drop from index)
     submitToIndexNow(publicPath);
+    // Drop from Meilisearch so search results don't show ghost threads
+    searchService.removeDiscussion(deletedId);
 
     res.json({ message: 'Discussion deleted' });
   } catch (err) {
@@ -500,6 +557,8 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
 
     // The thread's lastmod just changed — let search engines re-crawl
     submitToIndexNow(`/community/discussions/${discussion.slug || discussion._id}`);
+    // Re-index so the trending/active sort and search reflect new replyCount/lastActivityAt
+    searchService.indexDiscussion(discussion._id);
 
     // Notification fan-out: OP, then quoted-author (if different), then any
     // @mentioned users (deduped). Each user gets at most one notification per

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -1,14 +1,17 @@
 const { MeiliSearch } = require('meilisearch');
 const WineDefinition = require('../models/WineDefinition');
 const Bottle = require('../models/Bottle');
+const Discussion = require('../models/Discussion');
 const { WINE_POPULATE, CONSUMED_STATUSES } = require('../config/constants');
 
 const INDEX_NAME = 'wines';
 const BOTTLES_INDEX_NAME = 'bottles';
+const DISCUSSIONS_INDEX_NAME = 'discussions';
 
 let client = null;
 let index = null;
 let bottlesIndex = null;
+let discussionsIndex = null;
 let isAvailable = false;
 
 async function initialize() {
@@ -70,11 +73,23 @@ async function initialize() {
       pagination: { maxTotalHits: 10000 }
     });
 
+    // ── Discussions index ──
+    discussionsIndex = client.index(DISCUSSIONS_INDEX_NAME);
+
+    await discussionsIndex.updateSettings({
+      searchableAttributes: ['title', 'body', 'authorName', 'wineName'],
+      filterableAttributes: ['category', 'isLocked', 'wineDefinitionId'],
+      sortableAttributes: ['lastActivityAt', 'createdAt', 'replyCount'],
+      separatorTokens: ['.'],
+      pagination: { maxTotalHits: 5000 }
+    });
+
     isAvailable = true;
     console.log(`Meilisearch connected: ${url}`);
 
     await fullSync();
     await fullSyncBottles();
+    await fullSyncDiscussions();
   } catch (err) {
     isAvailable = false;
     console.warn(`Meilisearch unavailable (${url}): ${err.message}. Falling back to MongoDB search.`);
@@ -374,6 +389,107 @@ async function searchBottles(query, {
   };
 }
 
+// ── Discussion index helpers ─────────────────────────────────────────────────
+
+function buildDiscussionDocument(discussion) {
+  const author = discussion.author || {};
+  const wine = discussion.wineDefinition || {};
+  return {
+    id: discussion._id.toString(),
+    slug: discussion.slug || '',
+    title: discussion.title || '',
+    body: discussion.body || '',
+    category: discussion.category || '',
+    isLocked: !!discussion.isLocked,
+    isPinned: !!discussion.isPinned,
+    replyCount: discussion.replyCount || 0,
+    authorId: (author._id || author).toString?.() || '',
+    authorName: author.displayName || author.username || '',
+    wineDefinitionId: (wine._id || wine || '').toString?.() || '',
+    wineName: wine.name ? `${wine.name}${wine.producer ? ' ' + wine.producer : ''}` : '',
+    lastActivityAt: discussion.lastActivityAt
+      ? Math.floor(new Date(discussion.lastActivityAt).getTime() / 1000)
+      : 0,
+    createdAt: discussion.createdAt
+      ? Math.floor(new Date(discussion.createdAt).getTime() / 1000)
+      : 0
+  };
+}
+
+async function fullSyncDiscussions() {
+  if (!isAvailable) return;
+
+  try {
+    const discussions = await Discussion.find()
+      .populate('author', 'username displayName')
+      .populate({ path: 'wineDefinition', select: 'name producer' })
+      .lean();
+
+    const documents = discussions.map(buildDiscussionDocument);
+
+    if (documents.length > 0) {
+      await discussionsIndex.addDocuments(documents, { primaryKey: 'id' });
+    }
+
+    console.log(`Meilisearch: synced ${documents.length} discussions`);
+  } catch (err) {
+    console.error(`Meilisearch discussion full sync failed: ${err.message}`);
+  }
+}
+
+async function indexDiscussion(discussionId) {
+  if (!isAvailable) return;
+
+  try {
+    const discussion = await Discussion.findById(discussionId)
+      .populate('author', 'username displayName')
+      .populate({ path: 'wineDefinition', select: 'name producer' })
+      .lean();
+
+    if (!discussion) return;
+
+    await discussionsIndex.addDocuments([buildDiscussionDocument(discussion)], { primaryKey: 'id' });
+  } catch (err) {
+    console.error(`Meilisearch index discussion ${discussionId} failed: ${err.message}`);
+  }
+}
+
+async function removeDiscussion(discussionId) {
+  if (!isAvailable) return;
+
+  try {
+    await discussionsIndex.deleteDocument(discussionId.toString());
+  } catch (err) {
+    console.error(`Meilisearch remove discussion ${discussionId} failed: ${err.message}`);
+  }
+}
+
+// Search discussions by free-text query. Returns ordered IDs so the route
+// handler can hydrate them from MongoDB and keep the API response shape
+// consistent with the non-search list view.
+async function searchDiscussions(query, { category, limit = 20, offset = 0 } = {}) {
+  if (!isAvailable) {
+    throw new Error('Meilisearch is not available');
+  }
+
+  const VALID_CATEGORIES = ['tasting-notes', 'food-pairing', 'recommendations', 'cellar-tips', 'general'];
+  const filters = [];
+  if (category && VALID_CATEGORIES.includes(String(category))) {
+    filters.push(`category = "${category}"`);
+  }
+
+  const result = await discussionsIndex.search(query || '', {
+    filter: filters.length > 0 ? filters : undefined,
+    limit,
+    offset
+  });
+
+  return {
+    ids: result.hits.map(hit => hit.id),
+    estimatedTotalHits: result.estimatedTotalHits || 0
+  };
+}
+
 function getIsAvailable() {
   return isAvailable;
 }
@@ -382,6 +498,7 @@ module.exports = {
   initialize,
   fullSync,
   fullSyncBottles,
+  fullSyncDiscussions,
   indexWine,
   removeWine,
   search,
@@ -389,5 +506,8 @@ module.exports = {
   removeBottle,
   bulkIndexBottles,
   searchBottles,
+  indexDiscussion,
+  removeDiscussion,
+  searchDiscussions,
   getIsAvailable
 };

--- a/frontend/src/components/DiscussionsFeedWidget.css
+++ b/frontend/src/components/DiscussionsFeedWidget.css
@@ -1,0 +1,69 @@
+.discussions-feed-widget {
+  margin: 2rem auto;
+  max-width: 720px;
+  padding: 0 1rem;
+}
+
+.discussions-feed-widget__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.discussions-feed-widget__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.discussions-feed-widget__see-all {
+  font-size: 0.95rem;
+  color: var(--color-primary, inherit);
+  text-decoration: none;
+}
+
+.discussions-feed-widget__see-all:hover {
+  text-decoration: underline;
+}
+
+.discussions-feed-widget__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.discussions-feed-widget__item {
+  border-bottom: 1px solid var(--color-border, rgba(0, 0, 0, 0.08));
+  padding-bottom: 0.5rem;
+}
+
+.discussions-feed-widget__item:last-child {
+  border-bottom: none;
+}
+
+.discussions-feed-widget__link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  text-decoration: none;
+  color: inherit;
+  padding: 0.4rem 0;
+}
+
+.discussions-feed-widget__link:hover {
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.discussions-feed-widget__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.discussions-feed-widget__meta {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary, #666);
+}

--- a/frontend/src/components/DiscussionsFeedWidget.js
+++ b/frontend/src/components/DiscussionsFeedWidget.js
@@ -1,0 +1,68 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import timeAgo from '../utils/timeAgo';
+import './DiscussionsFeedWidget.css';
+
+// Compact "latest from the community" widget for the landing page and similar
+// surfaces. Public-readable: fetches via plain fetch (no auth header) so anon
+// visitors see real content and SSR-style crawler renders work.
+//
+// Quiet load: renders nothing while fetching, hides itself if the feed is
+// empty or the API errors. The landing page mustn't show a broken widget
+// to first-time visitors.
+export default function DiscussionsFeedWidget({ limit = 5, sort = 'active' }) {
+  const { t } = useTranslation();
+  const [discussions, setDiscussions] = useState(null); // null = loading
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const params = new URLSearchParams({ limit: String(limit), sort });
+        const res = await fetch(`/api/discussions?${params}`);
+        if (!cancelled && res.ok) {
+          const data = await res.json();
+          setDiscussions(data.discussions || []);
+        } else if (!cancelled) {
+          setDiscussions([]);
+        }
+      } catch {
+        if (!cancelled) setDiscussions([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [limit, sort]);
+
+  // Hide the widget entirely while loading or when there's nothing to show —
+  // a landing page deserves a polished empty state, not a stub.
+  if (discussions === null || discussions.length === 0) return null;
+
+  return (
+    <section className="discussions-feed-widget">
+      <div className="discussions-feed-widget__header">
+        <h2>{t('discussionsWidget.title')}</h2>
+        <Link to="/community/discussions" className="discussions-feed-widget__see-all">
+          {t('discussionsWidget.seeAll')}
+        </Link>
+      </div>
+      <ul className="discussions-feed-widget__list">
+        {discussions.map(d => {
+          const author = d.author || {};
+          const authorName = author.displayName || author.username || 'Anonymous';
+          const slugOrId = d.slug || d._id;
+          return (
+            <li key={d._id} className="discussions-feed-widget__item">
+              <Link to={`/community/discussions/${slugOrId}`} className="discussions-feed-widget__link">
+                <span className="discussions-feed-widget__title">{d.title}</span>
+                <span className="discussions-feed-widget__meta">
+                  {authorName} · {d.replyCount || 0} {d.replyCount === 1 ? t('discussions.reply') : t('discussions.replies')} · {timeAgo(d.lastActivityAt)}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1224,8 +1224,11 @@
     "discussions": "Discussions",
     "all": "All",
     "sortMostActive": "Most Active",
+    "sortTrending": "Trending",
     "sortNewest": "Newest",
     "sortMostReplies": "Most Replies",
+    "search": "Search",
+    "searchPlaceholder": "Search discussions…",
     "newDiscussion": "New Discussion",
     "noDiscussions": "No discussions yet",
     "noDiscussionsHint": "Start a conversation! Click \"New Discussion\" to create the first thread.",
@@ -1299,6 +1302,10 @@
     "signInToStart": "Sign in to discuss",
     "viewAll": "View all {{count}} discussions",
     "empty": "No discussions yet — be the first to share your thoughts on this wine."
+  },
+  "discussionsWidget": {
+    "title": "Latest from the community",
+    "seeAll": "See all"
   },
   "reviewFeed": {
     "community": "Community",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1224,8 +1224,11 @@
     "discussions": "Diskussioner",
     "all": "Alla",
     "sortMostActive": "Mest aktiva",
+    "sortTrending": "Trendar",
     "sortNewest": "Nyaste",
     "sortMostReplies": "Flest svar",
+    "search": "Sök",
+    "searchPlaceholder": "Sök diskussioner…",
     "newDiscussion": "Ny diskussion",
     "noDiscussions": "Inga diskussioner ännu",
     "noDiscussionsHint": "Starta en konversation! Klicka på \"Ny diskussion\" för att skapa den första tråden.",
@@ -1299,6 +1302,10 @@
     "signInToStart": "Logga in för att diskutera",
     "viewAll": "Visa alla {{count}} diskussioner",
     "empty": "Inga diskussioner än — bli först med att dela dina tankar om detta vin."
+  },
+  "discussionsWidget": {
+    "title": "Senast från gemenskapen",
+    "seeAll": "Visa alla"
   },
   "reviewFeed": {
     "community": "Gemenskap",

--- a/frontend/src/pages/Discussions.css
+++ b/frontend/src/pages/Discussions.css
@@ -28,6 +28,19 @@
   color: #fff;
 }
 
+/* ── Search bar ── */
+.discussions__search {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  align-items: center;
+}
+
+.discussions__search-input {
+  flex: 1;
+  min-width: 0;
+}
+
 /* ── Controls ── */
 .discussions__controls {
   display: flex;

--- a/frontend/src/pages/Discussions.js
+++ b/frontend/src/pages/Discussions.js
@@ -12,7 +12,7 @@ import SEOHead from '../components/SEOHead';
 import './Discussions.css';
 
 const CATEGORIES = Object.keys(CATEGORY_LABELS);
-const SORT_KEYS = ['active', 'newest', 'most-replies'];
+const SORT_KEYS = ['active', 'trending', 'newest', 'most-replies'];
 
 function Discussions() {
   const { t } = useTranslation();
@@ -27,6 +27,8 @@ function Discussions() {
 
   const [category, setCategory] = useState('');
   const [sort, setSort] = useState('active');
+  const [searchInput, setSearchInput] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
 
   // Create modal state
   const [showCreate, setShowCreate] = useState(false);
@@ -37,6 +39,7 @@ function Discussions() {
 
   const sortLabels = {
     'active': t('discussions.sortMostActive'),
+    'trending': t('discussions.sortTrending'),
     'newest': t('discussions.sortNewest'),
     'most-replies': t('discussions.sortMostReplies')
   };
@@ -48,6 +51,7 @@ function Discussions() {
 
       const params = new URLSearchParams({ page: p, limit: 20, sort });
       if (category) params.set('category', category);
+      if (searchQuery) params.set('q', searchQuery);
 
       const res = await getDiscussions(apiFetch, params.toString());
       const data = await res.json();
@@ -66,12 +70,22 @@ function Discussions() {
       setLoading(false);
       setLoadingMore(false);
     }
-  }, [apiFetch, category, sort, t]);
+  }, [apiFetch, category, sort, searchQuery, t]);
 
   useEffect(() => {
     setDiscussions([]);
     fetchDiscussions(1, true);
-  }, [category, sort]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [category, sort, searchQuery]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSearchSubmit = (e) => {
+    e.preventDefault();
+    setSearchQuery(searchInput.trim());
+  };
+
+  const clearSearch = () => {
+    setSearchInput('');
+    setSearchQuery('');
+  };
 
   // Pre-fill the create modal when the user arrives from a wine page's
   // "Start a discussion about this wine" CTA. We use route state (not a query
@@ -147,6 +161,26 @@ function Discussions() {
         <h1>{t('discussions.community')}</h1>
         <span className="discussions__beta-badge">{t('discussions.beta')}</span>
       </div>
+
+      <form className="discussions__search" onSubmit={handleSearchSubmit} role="search">
+        <input
+          type="search"
+          className="input discussions__search-input"
+          value={searchInput}
+          onChange={e => setSearchInput(e.target.value)}
+          placeholder={t('discussions.searchPlaceholder')}
+          aria-label={t('discussions.searchPlaceholder')}
+        />
+        {searchQuery && (
+          <button type="button" className="btn btn-secondary btn-small" onClick={clearSearch}>
+            {t('common.cancel')}
+          </button>
+        )}
+        <button type="submit" className="btn btn-primary btn-small">
+          {t('discussions.search')}
+        </button>
+      </form>
+
       <div className="discussions__controls">
         <div className="discussions__filters">
           <div className="discussions__categories">

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import SEOHead from '../components/SEOHead';
+import DiscussionsFeedWidget from '../components/DiscussionsFeedWidget';
 import SITE_URL from '../config/siteUrl';
 import './LandingPage.css';
 
@@ -237,6 +238,9 @@ export default function LandingPage() {
           )}
         </div>
       </section>
+
+      {/* ── Latest community activity — public-readable forum teaser ── */}
+      <DiscussionsFeedWidget limit={5} sort="active" />
 
       {/* ── Footer ── */}
       <footer className="landing-footer">


### PR DESCRIPTION
## Summary
**Phase 4a** of the community forum roadmap — discoverability inside and outside the forum.

The forum is now **searchable**, sortable by what's currently hot, and surfaced on the public landing page so first-time visitors see real conversation instead of an empty hero.

This PR is **Phase 4a**; the TipTap rich-text composer + HTML sanitization originally bundled into Phase 4 was split out as Phase 4b — see "Out of scope" below.

## What's new

### In-forum search (Meilisearch)
- New `discussions` Meilisearch index with searchable attrs `title / body / authorName / wineName`, filterable by `category`.
- Built + synced on app boot via `fullSyncDiscussions()`. `indexDiscussion()` / `removeDiscussion()` fire on create, update, delete, and on every reply (so the search/trending/active ordering reflects the freshest `replyCount` + `lastActivityAt`).
- `GET /api/discussions?q=...` routes through Meilisearch when present and available; hits are hydrated from MongoDB with relevance order preserved. Silent fallback to MongoDB filter+sort if Meilisearch is offline.

### Trending sort
- `?sort=trending` filters to threads with `lastActivityAt` in the last 7 days and ranks by `replyCount` (pinned floats). Simple but meaningfully different from `most-replies` (which is all-time popular). Time-decay scoring is a follow-up refinement.
- New "Trending" option in the sort dropdown on `Discussions.js`.

### Landing-page surfacing
- New `<DiscussionsFeedWidget>` — compact 5-item list of the most active threads. Public-readable, fetched without auth, hides itself silently when empty or on error so the landing page never shows a stub.
- Wired into `LandingPage` just above the footer. Logged-out visitors see real conversation happening and have an obvious path into the community.

### Search bar in Discussions
- New search input above the sort tabs. Submitting fires `?q=`; clearing the input resets the list.

### i18n
- 7 new keys (`sortTrending`, `search`, `searchPlaceholder`, `discussionsWidget.*`) added to both EN and SV in the existing `discussions` namespace.

## Test plan
- [x] `cd backend && npm test` — 412/412.
- [x] `cd frontend && npm test -- --watchAll=false` — 256/256.
- [ ] Smoke-test in Docker:
  - [ ] On boot, backend logs `Meilisearch: synced N discussions`.
  - [ ] Type a word that appears in some thread titles into the search bar → results filter to those threads, ranked by relevance.
  - [ ] Switch sort to "Trending" → only threads from the last 7 days show, sorted by reply count.
  - [ ] Visit `/` (landing page, incognito) → "Latest from the community" section shows 5 most-active threads, each clickable through to a public discussion.
  - [ ] Stop the Meilisearch container, refresh the discussions page, search → list still loads (silent fallback to MongoDB), but you'll see a console warning. Restart and verify search works again.

## Out of scope (Phase 4b)
- **TipTap rich-text composer** + HTML sanitization (`sanitize-html` allowlist + DOMPurify on render + plain-text → `<br>` migration). Larger change with XSS surface; kept separate so this PR can ship and bake first.
- **Reply-content searchable**. Discussion title/body covers most "what was that thread about" searches; we can index `DiscussionReply` separately later if traffic warrants.