### PR TITLE
ci(codeql): exclude test files from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+name: "Cellarion CodeQL Config"
+
+# Exclude test files from analysis. The js/missing-rate-limiting query is a
+# CodeQL "security-extended" rule that flags any Express-style route handler
+# without a rate limiter. Our test files build stub Express apps to verify
+# middleware composition (e.g. backend/src/routes/discussions.auth.test.js
+# mounts requireAuth, requireModeratorOrAdmin and a no-op handler against
+# every route shape) — those are fixtures, not production routes, and have
+# no need for a rate limiter.
+#
+# This config is picked up automatically by GitHub's CodeQL default setup
+# when present at `.github/codeql/codeql-config.yml`.
+paths-ignore:
+  - "**/*.test.js"
+  - "**/__tests__/**"
+  - "**/__mocks__/**"


### PR DESCRIPTION
## Summary
PR #360 (Phase 4b composer) is blocked by 18 CodeQL alerts on [backend/src/routes/discussions.auth.test.js](backend/src/routes/discussions.auth.test.js) — all the same rule (\`js/missing-rate-limiting\`) flagging stub Express handlers inside the test file.

The file is test infrastructure: it builds a tiny stub app (\`app.post('/api/discussions', requireAuth, ok)\`) for each route shape to verify middleware composition without booting Mongo. CodeQL doesn't differentiate stubs from production routes; it sees \`app.post()\` and demands a rate limiter.

## Fix
Add \`.github/codeql/codeql-config.yml\` excluding test paths (\`*.test.js\`, \`__tests__/\`, \`__mocks__/\`). GitHub's CodeQL default setup picks this up automatically — no workflow file needed.

## Why this is the right fix
- The flagged code isn't running in production; it's never reachable.
- It doesn't affect Phase 1's already-merged version of the same file (those alerts were silently ingested into main earlier; only PR #360 surfaced them as a merge blocker).
- It prevents the same false positive on every future test file.

## Test plan
- [x] No code changes — config-only.
- [ ] After merge, PR #360's next CodeQL run picks up the new config and the 18 alerts auto-close.

Once this lands, PR #360 should be unblocked.