### PR TITLE
feat(community): email opt-in for reply / quote / mention

### DIFF
--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -15,6 +15,7 @@ const { submitUrls: submitToIndexNow } = require('../services/indexNow');
 const { createNotification } = require('../services/notifications');
 const { extractMentions } = require('../utils/mentionParser');
 const searchService = require('../services/search');
+const { sendDiscussionReplyEmail, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
 const { parsePagination } = require('../utils/pagination');
 const { isValidId } = require('../utils/validation');
 const { DISCUSSIONS_PER_PAGE, DISCUSSIONS_MAX_PER_PAGE, DISCUSSION_MAX_LENGTHS } = require('../config/constants');
@@ -569,12 +570,40 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
 
     // Notification fan-out: OP, then quoted-author (if different), then any
     // @mentioned users (deduped). Each user gets at most one notification per
-    // reply event. createNotification handles in-app + web-push.
+    // reply event. createNotification handles in-app + web-push; for users
+    // with preferences.notifications.email = true, also fire an email.
     const replier = await User.findById(req.user.id).select('username displayName');
     const replierName = replier?.displayName || replier?.username || 'Someone';
     const link = `/community/discussions/${discussion.slug || discussion._id}`;
+    const fullUrl = `${process.env.FRONTEND_URL || 'http://localhost:3000'}${link}`;
+    const replyTextPreview = stripHtml(cleanBody).slice(0, 280);
     const notified = new Set();
     const selfId = String(req.user.id);
+
+    // Helper: fire an email if the recipient has community email opt-in.
+    // Fire-and-forget; never blocks the reply create.
+    async function maybeEmail(recipientId, kind) {
+      if (!EMAIL_VERIFICATION_ENABLED) return;
+      try {
+        const recipient = await User.findById(recipientId)
+          .select('email displayName username preferences.notifications.email emailVerified');
+        if (!recipient || !recipient.email || !recipient.emailVerified) return;
+        if (!recipient.preferences?.notifications?.email) return;
+        const recipientName = recipient.displayName || recipient.username || 'there';
+        await sendDiscussionReplyEmail(
+          recipient.email,
+          recipientName,
+          recipientId.toString(),
+          replierName,
+          discussion.title,
+          fullUrl,
+          replyTextPreview,
+          kind
+        );
+      } catch (err) {
+        console.warn(`[email-on-reply] failed for ${recipientId}:`, err.message);
+      }
+    }
 
     if (String(discussion.author) !== selfId) {
       notified.add(String(discussion.author));
@@ -585,6 +614,7 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
         `${replierName} replied to "${discussion.title}"`,
         link
       );
+      maybeEmail(discussion.author, 'reply');
     }
 
     if (quotedAuthorId && String(quotedAuthorId) !== selfId && !notified.has(String(quotedAuthorId))) {
@@ -596,6 +626,7 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
         `In "${discussion.title}"`,
         link
       );
+      maybeEmail(quotedAuthorId, 'quote');
     }
 
     const mentionedIds = await extractMentions(cleanBody, req.user.id);
@@ -609,6 +640,7 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
         `In "${discussion.title}"`,
         link
       );
+      maybeEmail(uid, 'mention');
     }
 
     logAudit(req, 'discussion_reply.create', { type: 'discussion_reply', id: reply._id }, { discussion: discussion._id });

--- a/backend/src/services/mailgun.js
+++ b/backend/src/services/mailgun.js
@@ -320,4 +320,74 @@ async function sendCellarInviteEmail(toEmail, senderName, senderEmail, cellarNam
   });
 }
 
-module.exports = { sendVerificationEmail, sendPasswordResetEmail, sendDrinkWindowDigest, sendRecommendationEmail, sendCellarInviteEmail, EMAIL_VERIFICATION_ENABLED };
+/**
+ * Email a forum participant when someone replies to / quotes / mentions them.
+ * No-ops when Mailgun isn't configured. The recipient is responsible for
+ * having opted in via preferences.notifications.email — the route handler
+ * checks that before calling this function.
+ *
+ * @param {string} toEmail
+ * @param {string} recipientName  display/username of the recipient (greeting)
+ * @param {string} recipientId    user ObjectId (for the unsubscribe token)
+ * @param {string} replierName
+ * @param {string} discussionTitle
+ * @param {string} discussionUrl  full URL to the discussion (incl. anchor)
+ * @param {string} replyText      plain-text reply preview (already sanitized)
+ * @param {string} kind           'reply' | 'quote' | 'mention'
+ */
+async function sendDiscussionReplyEmail(toEmail, recipientName, recipientId, replierName, discussionTitle, discussionUrl, replyText, kind = 'reply') {
+  if (!EMAIL_VERIFICATION_ENABLED) return;
+
+  const { createUnsubscribeToken } = require('../utils/unsubscribe');
+  const unsubToken = createUnsubscribeToken(recipientId);
+  const unsubLink = `${process.env.BACKEND_URL || 'http://localhost:5000'}/api/users/unsubscribe?token=${unsubToken}`;
+
+  const verb = kind === 'quote' ? 'quoted you' : kind === 'mention' ? 'mentioned you' : 'replied to your discussion';
+  const subject = kind === 'quote'
+    ? `${replierName} quoted you in "${discussionTitle}"`
+    : kind === 'mention'
+      ? `${replierName} mentioned you in "${discussionTitle}"`
+      : `${replierName} replied to "${discussionTitle}"`;
+
+  const previewText = (replyText || '').slice(0, 280);
+
+  await mg.messages.create(DOMAIN, {
+    from: FROM,
+    to: [toEmail],
+    subject,
+    text: [
+      `Hello ${recipientName},`,
+      '',
+      `${replierName} ${verb}: "${discussionTitle}".`,
+      '',
+      previewText ? `> ${previewText}` : '',
+      '',
+      `Read and reply: ${discussionUrl}`,
+      '',
+      `To stop receiving these emails: ${unsubLink}`
+    ].filter(Boolean).join('\n'),
+    html: `
+      <div style="font-family:sans-serif;max-width:520px;margin:0 auto;color:#2a2a2a;">
+        <p>Hello <strong>${escapeHtml(recipientName)}</strong>,</p>
+        <p><strong>${escapeHtml(replierName)}</strong> ${verb}:
+           <em>${escapeHtml(discussionTitle)}</em>.</p>
+        ${previewText ? `<blockquote style="border-left:3px solid #D4A373;margin:1rem 0;padding:0.25rem 0.75rem;color:#555;">${escapeHtml(previewText)}</blockquote>` : ''}
+        <p style="margin:1.5rem 0;">
+          <a href="${discussionUrl}"
+             style="background:#7B9E88;color:#0d0d0d;padding:10px 22px;
+                    border-radius:4px;text-decoration:none;font-weight:600;
+                    display:inline-block;">
+            Read and reply
+          </a>
+        </p>
+        <hr style="border:none;border-top:1px solid #ddd;margin:2rem 0;" />
+        <p style="color:#9A9484;font-size:0.85em;">
+          You're getting this because you have community email notifications turned on.
+          <a href="${unsubLink}" style="color:#9A9484;">Unsubscribe</a>.
+        </p>
+      </div>
+    `
+  });
+}
+
+module.exports = { sendVerificationEmail, sendPasswordResetEmail, sendDrinkWindowDigest, sendRecommendationEmail, sendCellarInviteEmail, sendDiscussionReplyEmail, EMAIL_VERIFICATION_ENABLED };

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -364,7 +364,7 @@ function Settings() {
             <span>Email notifications</span>
           </label>
           <p className="settings-hint">
-            Receive a digest email when your bottles have drink-window updates.
+            Receive emails when your bottles have drink-window updates and when someone replies, quotes, or mentions you in a discussion.
           </p>
         </div>
 


### PR DESCRIPTION
**Phase 3 deferred item.** Wires the existing 'Email notifications' Settings toggle to fire emails when someone replies to / quotes / mentions you in a discussion.

Backend:
- New `sendDiscussionReplyEmail` in services/mailgun.js with kind = 'reply' | 'quote' | 'mention' for the right subject + verb
- Wired into routes/discussions.js after each createNotification call. Same dedupe (one email per user per reply event)
- Gated on Mailgun configured + emailVerified + preferences.notifications.email === true
- One-click unsubscribe via existing `createUnsubscribeToken` flow
- Fire-and-forget; never blocks reply create

Frontend:
- Settings hint updated to describe what 'Email notifications' actually covers now

Tests: backend 431/431, frontend 256/256. Verified composer + sanitization (Phase 4b) still work alongside this change.