### PR TITLE
feat(community): polish pass 1 — OP styling, reading-mode typography, hover-reveal actions

### DIFF
--- a/frontend/src/components/DiscussionComposer.css
+++ b/frontend/src/components/DiscussionComposer.css
@@ -93,25 +93,56 @@
 }
 
 /* Read-only render styles for sanitized body output. Used wherever forum
-   bodies are rendered with dangerouslySetInnerHTML. */
+   bodies are rendered with dangerouslySetInnerHTML. Reading-mode typography:
+   capped line length, generous line-height, distinct blockquote/link styling
+   so wine-talk threads read like long-form prose, not like chat messages. */
+.discussion-body {
+  max-width: 68ch;
+  font-size: 1.0625rem;
+  line-height: 1.7;
+  color: var(--color-text);
+}
+
 .discussion-body p {
-  margin: 0 0 0.5rem;
+  margin: 0 0 1rem;
 }
 .discussion-body p:last-child {
   margin-bottom: 0;
 }
+
 .discussion-body blockquote {
-  border-left: 3px solid var(--color-border, rgba(0, 0, 0, 0.15));
-  margin: 0.5rem 0;
-  padding-left: 0.75rem;
-  color: var(--color-text-secondary, #666);
+  margin: 1rem 0;
+  padding: 0.6rem 1rem;
+  border-left: 3px solid var(--color-accent);
+  background: var(--color-primary-light);
+  color: var(--color-text-secondary);
+  font-style: italic;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
+
 .discussion-body ul,
 .discussion-body ol {
-  margin: 0.5rem 0;
+  margin: 0.75rem 0;
   padding-left: 1.5rem;
 }
+.discussion-body li {
+  margin: 0.25rem 0;
+}
+
 .discussion-body a {
-  color: var(--color-primary, inherit);
+  color: var(--color-primary);
   text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+}
+.discussion-body a:hover {
+  text-decoration-thickness: 2px;
+}
+
+/* Reply bodies sit inside narrower cards with their own padding — drop the
+   width cap there so the existing card edges define line length. */
+.reply-card .discussion-body {
+  max-width: none;
+  font-size: 1rem;
+  line-height: 1.65;
 }

--- a/frontend/src/components/ReplyCard.css
+++ b/frontend/src/components/ReplyCard.css
@@ -1,5 +1,13 @@
 .reply-card {
-  padding: 0.75rem 0;
+  padding: 0.875rem 0;
+  /* Light cushioning on hover so the active reply reads as a discrete unit
+     and the action row's appearance doesn't feel jarring. */
+  border-radius: var(--radius-sm);
+  transition: background 0.12s ease;
+}
+
+.reply-card:hover {
+  background: var(--color-surface-hover, rgba(0, 0, 0, 0.02));
 }
 
 .reply-card:not(:last-child) {
@@ -80,17 +88,44 @@
 }
 
 .reply-card__body {
-  font-size: 0.92rem;
-  line-height: 1.55;
-  white-space: pre-wrap;
   word-break: break-word;
 }
 
+/* Action row: Like stays always-visible (it's a count + interaction signal),
+   but the button-y secondary actions (Reply / Edit / Delete / Report / Ban)
+   fade in on hover or focus-within. Less button noise in long threads,
+   keyboard users still get full access via :focus-within. */
 .reply-card__footer {
   display: flex;
   align-items: center;
   gap: 0.75rem;
   margin-top: 0.5rem;
+  min-height: 1.6rem; /* prevent height shift when actions appear */
+}
+
+/* Scoped to .reply-card so the same .reply-card__action-btn class used on
+   the OP action row stays visible. The OP is rendered inside
+   .discussion-detail__header, never inside .reply-card. */
+.reply-card .reply-card__action-btn,
+.reply-card .reply-card__ban-wrapper {
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.reply-card:hover .reply-card__action-btn,
+.reply-card:focus-within .reply-card__action-btn,
+.reply-card:hover .reply-card__ban-wrapper,
+.reply-card:focus-within .reply-card__ban-wrapper {
+  opacity: 1;
+}
+
+/* Touch devices can't hover — always show actions there, otherwise the row
+   becomes invisible and unreachable on mobile. */
+@media (hover: none) {
+  .reply-card .reply-card__action-btn,
+  .reply-card .reply-card__ban-wrapper {
+    opacity: 1;
+  }
 }
 
 .reply-card__like-btn {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1239,6 +1239,7 @@
     "link": "Link",
     "linkUrl": "Link URL (https:// or mailto:)",
     "composerToolbar": "Formatting toolbar",
+    "originalPost": "Original Post",
     "newDiscussion": "New Discussion",
     "noDiscussions": "No discussions yet",
     "noDiscussionsHint": "Start a conversation! Click \"New Discussion\" to create the first thread.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1239,6 +1239,7 @@
     "link": "Länk",
     "linkUrl": "Länkadress (https:// eller mailto:)",
     "composerToolbar": "Formateringsverktyg",
+    "originalPost": "Ursprungligt inlägg",
     "newDiscussion": "Ny diskussion",
     "noDiscussions": "Inga diskussioner ännu",
     "noDiscussionsHint": "Starta en konversation! Klicka på \"Ny diskussion\" för att skapa den första tråden.",

--- a/frontend/src/pages/DiscussionDetail.css
+++ b/frontend/src/pages/DiscussionDetail.css
@@ -22,10 +22,14 @@
   padding: 2rem 0;
 }
 
-/* ── Header card ── */
+/* ── Header card (Original Post) ──
+   The OP gets a burgundy left accent bar so it reads as the "anchor" of the
+   thread — visually distinct from the replies that follow. Slightly more
+   generous padding signals "this is the main post." */
 .discussion-detail__header {
-  padding: 1.25rem;
-  margin-bottom: 1.25rem;
+  padding: 1.5rem 1.5rem 1.25rem;
+  margin-bottom: 1.5rem;
+  border-left: 3px solid var(--color-primary);
 }
 
 .discussion-detail__meta {
@@ -36,10 +40,25 @@
   flex-wrap: wrap;
 }
 
+/* "Original Post" pill — quiet on its own, but anchors the OP visually
+   alongside the category badge. */
+.discussion-detail__op-pill {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  border-radius: var(--radius-sm);
+}
+
 .discussion-detail__title {
   margin: 0 0 0.75rem;
-  font-size: 1.3rem;
-  line-height: 1.3;
+  font-size: 1.5rem;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
 }
 
 .discussion-detail__author-line {
@@ -73,10 +92,10 @@
   color: var(--color-text-secondary);
 }
 
+/* OP body uses the reading-mode .discussion-body styles inherited from
+   DiscussionComposer.css. Width-cap, line-height, blockquote and link styling
+   live there so reply bodies read identically. */
 .discussion-detail__body {
-  font-size: 0.95rem;
-  line-height: 1.65;
-  white-space: pre-wrap;
   word-break: break-word;
 }
 

--- a/frontend/src/pages/DiscussionDetail.js
+++ b/frontend/src/pages/DiscussionDetail.js
@@ -316,6 +316,7 @@ function DiscussionDetail() {
       <div className="discussion-detail__header card">
         <div className="discussion-detail__meta">
           <CategoryBadge category={discussion.category} />
+          <span className="discussion-detail__op-pill">{t('discussions.originalPost')}</span>
           {discussion.isPinned && <span className="discussion-card__pinned">{t('discussions.pinned')}</span>}
           {discussion.isLocked && <span className="discussion-card__locked">{t('discussions.locked')}</span>}
         </div>


### PR DESCRIPTION
**Forum visual refresh, pass 1.** Three pure-CSS changes that reframe the experience without touching structure. Based on patterns from Discourse, GitHub Discussions, Linear and Slack threads.

## What changes

### 1. Original Post differentiation
- 3px burgundy left border on the OP card → reads as the thread anchor
- New `Original Post` pill in the meta row (alongside the category badge)
- Title bumped to 1.5rem with tighter letter-spacing

### 2. Reading-mode typography for body content
- `.discussion-body` capped at 68ch with 1.7 line-height and 1.0625rem text
- Blockquotes: accent-coloured left bar + soft burgundy tint, italic, rounded
- Links: burgundy with underline-offset; underline thickens on hover
- Reply bodies opt out of the width cap (cards already constrain them)

### 3. Hover-revealed reply actions
- Like + read-only like count always visible
- Reply / Edit / Delete / Report / Ban fade in on hover or focus-within
- `@media (hover: none)` keeps them visible on touch devices
- Subtle hover background on `.reply-card` so the active reply reads as a unit
- Scoped to `.reply-card` descendants so the OP action row (same class) stays visible

## Test plan
- [x] `cd frontend && npm test -- --watchAll=false` — 256/256
- [ ] Smoke-test: open a thread → OP visually distinct from replies, body reads at comfortable width, hover a reply → action row appears, mobile (devtools touch emulation) shows actions always