### PR TITLE
feat(a11y): skip-to-content link + visible keyboard focus rings

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -39,6 +39,10 @@ function Layout({ children }) {
 
   return (
     <div className="layout">
+      {/* Skip-to-content link — visible only on keyboard focus. Lets users
+          who tab through the page jump past the navbar to the main content,
+          which is the WCAG 2.4.1 'Bypass Blocks' requirement. */}
+      <a href="#main-content" className="skip-link">{t('common.skipToContent')}</a>
       <InstallPrompt />
       {/* ── Top navbar ── */}
       <nav className="navbar">
@@ -299,7 +303,7 @@ function Layout({ children }) {
         )}
       </nav>
 
-      <main className="main-content">
+      <main id="main-content" className="main-content" tabIndex={-1}>
         {children}
       </main>
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -30,6 +30,7 @@
     "by": "by",
     "unknown": "Unknown",
     "deletedUser": "[Deleted user]",
+    "skipToContent": "Skip to main content",
     "unknownWine": "Unknown Wine",
     "vintage": "Vintage",
     "source": "Source",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -30,6 +30,7 @@
     "by": "av",
     "unknown": "Okänd",
     "deletedUser": "[Borttagen användare]",
+    "skipToContent": "Hoppa till huvudinnehållet",
     "unknownWine": "Okänt vin",
     "vintage": "Årgång",
     "source": "Källa",

--- a/frontend/src/styles/common.css
+++ b/frontend/src/styles/common.css
@@ -351,3 +351,47 @@
   color: var(--color-primary);
   margin-left: 0.25rem;
 }
+
+/* ── Accessibility ────────────────────────────────────────────────────────── */
+
+/* Skip-to-content link — visually hidden until focused. Lets keyboard users
+   bypass the navbar (WCAG 2.4.1 'Bypass Blocks'). The 'visible on focus'
+   pattern is preferred over a permanent visible link because it doesn't
+   clutter the layout for sighted mouse users. */
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  padding: 0.6rem 1rem;
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: 0 0 var(--radius-sm, 6px) var(--radius-sm, 6px);
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.08));
+  z-index: 1000;
+  transition: transform 0.18s;
+}
+
+.skip-link:focus {
+  transform: translate(-50%, 0);
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* Visible focus rings for keyboard users on every interactive element.
+   :focus-visible (vs plain :focus) excludes mouse-click focus, so the
+   ring only appears when actually navigating with the keyboard. */
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: inherit;
+}
+
+/* When the main-content gets programmatic focus from skip-link, don't show
+   a ring on the whole content area — it's a focus target, not interactive. */
+#main-content:focus,
+#main-content:focus-visible {
+  outline: none;
+}


### PR DESCRIPTION
Two table-stakes accessibility improvements from the polish backlog.

## Skip-to-content link
- New 'Skip to main content' / 'Hoppa till huvudinnehållet' anchor at the top of Layout, visually hidden by default and slides into view on `:focus`
- Targets `<main id="main-content" tabIndex={-1}>` so the skip-link's hash navigation moves keyboard focus there programmatically
- Satisfies WCAG 2.4.1 'Bypass Blocks' — keyboard users can jump past the navbar without tabbing through every nav link

## Visible focus rings (`:focus-visible`)
- Global rule: 2px solid `var(--color-primary)` + 2px offset
- `:focus-visible` (not plain `:focus`) excludes mouse-click focus, so the ring only appears when actually keyboard-navigating
- `#main-content` gets focus from the skip-link but doesn't show a ring (it's a programmatic target, not interactive)

## Test plan
- [x] Frontend 256/256
- [ ] Smoke-test:
  - [ ] Open any page → press Tab → first focusable thing should be the 'Skip to main content' link sliding into view at the top centre
  - [ ] Press Enter → focus jumps to the main content area
  - [ ] Tab through buttons/links → each gets a visible burgundy outline
  - [ ] Click a button with the mouse → no focus ring (mouse-click focus excluded by `:focus-visible`)