### PR TITLE
feat(community): unread-since-last-visit indicator

### DIFF
--- a/backend/src/models/DiscussionRead.js
+++ b/backend/src/models/DiscussionRead.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+
+// Records the last time a user opened a given discussion. Used to drive the
+// "unread since your last visit" indicator on the discussion list. Inserted
+// (or refreshed) lazily when the user fetches a discussion's replies — that's
+// the strongest "I'm actually reading this" signal and keeps the upsert off
+// the listing-endpoint hot path.
+const discussionReadSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true
+  },
+  discussion: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Discussion',
+    required: true,
+    index: true
+  },
+  lastReadAt: {
+    type: Date,
+    default: Date.now
+  }
+}, { timestamps: false });
+
+discussionReadSchema.index({ user: 1, discussion: 1 }, { unique: true });
+
+module.exports = mongoose.model('DiscussionRead', discussionReadSchema);

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -6,6 +6,7 @@ const DiscussionReply = require('../models/DiscussionReply');
 const DiscussionReaction = require('../models/DiscussionReaction');
 const { REACTION_KINDS } = require('../models/DiscussionReaction');
 const DiscussionWatch = require('../models/DiscussionWatch');
+const DiscussionRead = require('../models/DiscussionRead');
 const DiscussionReport = require('../models/DiscussionReport');
 const User = require('../models/User');
 const WineDefinition = require('../models/WineDefinition');
@@ -96,9 +97,10 @@ router.get('/', optionalAuth, async (req, res) => {
         const byId = new Map(docs.map(d => [d._id.toString(), d]));
         const ordered = ids.map(id => byId.get(id)).filter(Boolean);
         const enrichedSearch = await attachLastReply(ordered);
+        const withUnreadSearch = await attachUnreadStatus(enrichedSearch, req.user);
 
         return res.json({
-          discussions: enrichedSearch,
+          discussions: withUnreadSearch,
           total: estimatedTotalHits,
           page,
           pages: Math.ceil(estimatedTotalHits / limit)
@@ -141,12 +143,40 @@ router.get('/', optionalAuth, async (req, res) => {
     ]);
 
     const enriched = await attachLastReply(discussions);
-    res.json({ discussions: enriched, total, page, pages: Math.ceil(total / limit) });
+    const withUnread = await attachUnreadStatus(enriched, req.user);
+    res.json({ discussions: withUnread, total, page, pages: Math.ceil(total / limit) });
   } catch (err) {
     console.error('List discussions error:', err);
     res.status(500).json({ error: 'Failed to list discussions' });
   }
 });
+
+// Helper: tag each discussion with `hasUnread: bool` based on whether the
+// requester has visited it before AND there's been activity since their
+// last visit. Threads they've never opened don't get the unread flag —
+// otherwise every list item would buzz on a first-time visitor.
+//
+// Anonymous users get hasUnread = false on every item (no read history to
+// compare against).
+async function attachUnreadStatus(discussions, user) {
+  if (!user || !discussions || discussions.length === 0) {
+    return (discussions || []).map(d => ({ ...d, hasUnread: false }));
+  }
+  const ids = discussions.map(d => d._id);
+  const reads = await DiscussionRead.find({ user: user.id, discussion: { $in: ids } })
+    .select('discussion lastReadAt')
+    .lean();
+  const lastReadByDiscussion = new Map();
+  for (const r of reads) lastReadByDiscussion.set(r.discussion.toString(), r.lastReadAt);
+  return discussions.map(d => {
+    const lastRead = lastReadByDiscussion.get(d._id.toString());
+    const lastActivity = d.lastActivityAt || d.createdAt;
+    return {
+      ...d,
+      hasUnread: !!lastRead && new Date(lastActivity) > new Date(lastRead)
+    };
+  });
+}
 
 // Helper: attach a `lastReply: { author, createdAt }` snippet to each
 // discussion in the list. Two queries: aggregate the most-recent non-deleted
@@ -506,6 +536,7 @@ router.delete('/:idOrSlug', requireAuth, requireModeratorOrAdmin, async (req, re
     DiscussionReply.deleteMany({ discussion: discussion._id }).catch(() => {});
     DiscussionReport.deleteMany({ discussion: discussion._id }).catch(() => {});
     DiscussionWatch.deleteMany({ discussion: discussion._id }).catch(() => {});
+    DiscussionRead.deleteMany({ discussion: discussion._id }).catch(() => {});
 
     // Capture the public URL before deletion so we can ping IndexNow afterwards.
     const publicPath = `/community/discussions/${discussion.slug || discussion._id}`;
@@ -594,6 +625,18 @@ router.get('/:idOrSlug/replies', optionalAuth, async (req, res) => {
       if (!isMod) delete obj.deletedBody;
       return obj;
     });
+
+    // Mark this thread as read for the current user. Fire-and-forget upsert
+    // — the response doesn't depend on it, and a transient failure shouldn't
+    // surface to the caller. Reading replies is the strongest "I've seen
+    // this thread" signal (the user is actively scrolling content).
+    if (req.user) {
+      DiscussionRead.findOneAndUpdate(
+        { user: req.user.id, discussion: discussionId },
+        { $set: { lastReadAt: new Date() } },
+        { upsert: true }
+      ).catch(() => {});
+    }
 
     res.json({ replies: enriched, total, page, pages: Math.ceil(total / limit) });
   } catch (err) {

--- a/backend/src/services/userDeletionJob.js
+++ b/backend/src/services/userDeletionJob.js
@@ -15,6 +15,7 @@ const Discussion = require('../models/Discussion');
 const DiscussionReply = require('../models/DiscussionReply');
 const DiscussionReaction = require('../models/DiscussionReaction');
 const DiscussionWatch = require('../models/DiscussionWatch');
+const DiscussionRead = require('../models/DiscussionRead');
 const DiscussionReport = require('../models/DiscussionReport');
 const Follow = require('../models/Follow');
 const ImportSession = require('../models/ImportSession');
@@ -73,6 +74,7 @@ async function purgeUserData(userId, userEmail) {
     // Personal-data-only forum collections: hard-delete
     DiscussionReaction.deleteMany({ user: userId }),
     DiscussionWatch.deleteMany({ user: userId }),
+    DiscussionRead.deleteMany({ user: userId }),
 
     // Social & engagement (non-forum)
     ReviewVote.deleteMany({ user: userId }),

--- a/frontend/src/components/DiscussionCard.css
+++ b/frontend/src/components/DiscussionCard.css
@@ -69,6 +69,29 @@
   color: var(--color-accent-hover);
 }
 
+/* Unread indicator — small burgundy dot in the meta row when the thread
+   has activity since the user's last visit. Only shows for users who have
+   visited before (first-time visitors don't see "unread" on every card). */
+.discussion-card__unread-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  flex-shrink: 0;
+  /* Subtle pulse so the dot reads as "fresh" without being aggressive */
+  animation: discussion-card-unread-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes discussion-card-unread-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .discussion-card__unread-dot { animation: none; }
+}
+
 .discussion-card__locked {
   background: #fee2e2;
   color: #991b1b;

--- a/frontend/src/components/DiscussionCard.js
+++ b/frontend/src/components/DiscussionCard.js
@@ -42,6 +42,9 @@ export default function DiscussionCard({ discussion }) {
       <div className="discussion-card__main">
         <div className="discussion-card__header">
           <CategoryBadge category={discussion.category} />
+          {discussion.hasUnread && (
+            <span className="discussion-card__unread-dot" title={t('discussions.hasUnread')} aria-label={t('discussions.hasUnread')} />
+          )}
           {discussion.isPinned && <span className="discussion-card__pinned" title={t('discussions.pinned')}>📌 {t('discussions.pinned')}</span>}
           {discussion.isLocked && <span className="discussion-card__locked" title={t('discussions.locked')}>{t('discussions.locked')}</span>}
         </div>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1274,6 +1274,7 @@
     "alsoTalking": "Also talking:",
     "participants": "{{count}} people in this thread",
     "moreParticipants": "{{count}} more participants",
+    "hasUnread": "New activity since your last visit",
     "newDiscussion": "New Discussion",
     "noDiscussions": "No discussions yet",
     "noDiscussionsHint": "Start a conversation! Click \"New Discussion\" to create the first thread.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1274,6 +1274,7 @@
     "alsoTalking": "Pratar också:",
     "participants": "{{count}} personer i denna tråd",
     "moreParticipants": "{{count}} fler deltagare",
+    "hasUnread": "Ny aktivitet sedan ditt senaste besök",
     "newDiscussion": "Ny diskussion",
     "noDiscussions": "Inga diskussioner ännu",
     "noDiscussionsHint": "Starta en konversation! Klicka på \"Ny diskussion\" för att skapa den första tråden.",


### PR DESCRIPTION
Small burgundy dot next to threads with new activity since your last visit. Threads you've never opened don't show the indicator (Discourse / GitHub convention — otherwise every card would buzz on a first-time visitor).

## Backend
- New `DiscussionRead { user, discussion, lastReadAt }` model, unique on (user, discussion)
- GET /api/discussions/:idOrSlug/replies upserts the read row when an authed user fetches replies — fire-and-forget; that's the strongest 'I'm reading this' signal
- `attachUnreadStatus` helper joins reads onto the list response. Anon users get `hasUnread=false` on every item.
- Wired through both MongoDB list path AND Meilisearch search path
- Discussion mod-delete + user-account-close hard-delete the relevant read rows

## Frontend
- DiscussionCard shows an 8px pulsing burgundy dot when `discussion.hasUnread === true`
- `prefers-reduced-motion` disables the pulse
- aria-label + title surface meaning to assistive tech

## Test plan
- [x] Backend 435/435, frontend 256/256
- [ ] Smoke-test: open a thread (any thread) → reload list → no dot (you just read it). Have another user reply → reload list → dot appears next to that thread. Open it → reload → dot gone again.

## What's next
- Inline composer + mobile sticky 'Reply' CTA — separate PR coming next