### PR TITLE
feat(community): admin UI to grant/revoke forum moderator role

### DIFF
--- a/backend/src/routes/admin/users.js
+++ b/backend/src/routes/admin/users.js
@@ -9,7 +9,11 @@ const { escapeRegex } = require('../../utils/sanitize');
 
 const router = express.Router();
 
-const VALID_ROLES = ['user', 'somm', 'admin'];
+// 'moderator' is a forum-specific role: pin/lock/move/delete discussions,
+// see + resolve reports, ban users from the forum. Granted by admins via the
+// PATCH /:id/roles endpoint below — usually surfaced through the
+// /admin/moderators page rather than direct API calls.
+const VALID_ROLES = ['user', 'somm', 'moderator', 'admin'];
 
 // All routes require admin
 router.use(requireAuth, requireRole('admin'));

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -40,6 +40,7 @@ const AdminTaxonomy   = lazy(() => import('./pages/AdminTaxonomy'));
 const AdminImages     = lazy(() => import('./pages/AdminImages'));
 const AdminSupportTickets = lazy(() => import('./pages/AdminSupportTickets'));
 const AdminWineReports    = lazy(() => import('./pages/AdminWineReports'));
+const AdminModerators     = lazy(() => import('./pages/AdminModerators'));
 const SupportPage     = lazy(() => import('./pages/SupportPage'));
 const SuperAdmin      = lazy(() => import('./pages/SuperAdmin'));
 const CommunityDiscussions = lazy(() => import('./pages/CommunityDiscussions'));
@@ -373,6 +374,14 @@ function AppRoutes() {
           element={
             <ProtectedRoute requireAdmin>
               <Layout><AdminWineReports /></Layout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/admin/moderators"
+          element={
+            <ProtectedRoute requireAdmin>
+              <Layout><AdminModerators /></Layout>
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -189,6 +189,7 @@ function Layout({ children }) {
                     <Link to="/admin/images" className={`nav-link nav-link--admin ${isActive('/admin/images') ? 'active' : ''}`}>{t('nav.imageReview')}</Link>
                     <Link to="/admin/support" className={`nav-link nav-link--admin ${isActive('/admin/support') ? 'active' : ''}`}>Support Tickets</Link>
                     <Link to="/admin/wine-reports" className={`nav-link nav-link--admin ${isActive('/admin/wine-reports') ? 'active' : ''}`}>Wine Reports</Link>
+                    <Link to="/admin/moderators" className={`nav-link nav-link--admin ${isActive('/admin/moderators') ? 'active' : ''}`}>{t('nav.moderators')}</Link>
                     <Link to="/admin/blog" className={`nav-link nav-link--admin ${isActive('/admin/blog') ? 'active' : ''}`}>{t('nav.blogAdmin')}</Link>
                   </>
                 )}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -64,6 +64,7 @@
     "supporter": "Support Us",
     "blog": "Blog",
     "blogAdmin": "Blog",
+    "moderators": "Moderators",
     "badge": {
       "admin": "Admin",
       "somm": "Somm"
@@ -127,6 +128,24 @@
       "pushNotConfigured": "Push notifications are not configured on this server.",
       "pushHint": "Push delivers notifications to your device even when Cellarion is closed."
     }
+  },
+  "adminModerators": {
+    "title": "Forum Moderators",
+    "intro": "Moderators can pin / lock / move discussions, delete posts, view + resolve reports, and ban users from the forum. Promote trusted community members; revoke when no longer needed. Admins always have moderator powers — this list shows users with the dedicated moderator role.",
+    "currentMods_one": "{{count}} current moderator",
+    "currentMods_other": "{{count}} current moderators",
+    "currentMods": "Current moderators ({{count}})",
+    "noMods": "No moderators yet. Search for a user below to promote one.",
+    "findUser": "Find a user",
+    "searchPlaceholder": "Search by username or email…",
+    "noResults": "No users matched that search.",
+    "promote": "Promote to moderator",
+    "revoke": "Revoke",
+    "revokeTitle": "Revoke moderator role",
+    "revokeConfirm": "Remove moderator privileges from {{name}}?",
+    "revokeWarning": "They will lose the ability to pin, lock, move or delete discussions, see reports, or ban users.",
+    "you": "(you)",
+    "failedLoad": "Failed to load moderators."
   },
   "reactions": {
     "addReaction": "Add reaction",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -64,6 +64,7 @@
     "supporter": "Stöd oss",
     "blog": "Blogg",
     "blogAdmin": "Blogg",
+    "moderators": "Moderatorer",
     "badge": {
       "admin": "Admin",
       "somm": "Somm"
@@ -127,6 +128,24 @@
       "pushNotConfigured": "Push-aviseringar är inte konfigurerade på denna server.",
       "pushHint": "Push levererar aviseringar till din enhet även när Cellarion är stängt."
     }
+  },
+  "adminModerators": {
+    "title": "Forum-moderatorer",
+    "intro": "Moderatorer kan fästa/låsa/flytta diskussioner, ta bort inlägg, se och hantera rapporter samt blockera användare från forumet. Befordra betrodda medlemmar; återkalla när det inte längre behövs. Administratörer har alltid moderatorbehörighet — listan här visar användare med den dedikerade moderatorrollen.",
+    "currentMods_one": "{{count}} aktiv moderator",
+    "currentMods_other": "{{count}} aktiva moderatorer",
+    "currentMods": "Aktiva moderatorer ({{count}})",
+    "noMods": "Inga moderatorer än. Sök efter en användare nedan för att befordra en.",
+    "findUser": "Hitta en användare",
+    "searchPlaceholder": "Sök på användarnamn eller e-post…",
+    "noResults": "Inga användare matchade sökningen.",
+    "promote": "Befordra till moderator",
+    "revoke": "Återkalla",
+    "revokeTitle": "Återkalla moderatorroll",
+    "revokeConfirm": "Ta bort moderatorbehörighet från {{name}}?",
+    "revokeWarning": "Hen förlorar möjligheten att fästa, låsa, flytta eller ta bort diskussioner, se rapporter eller blockera användare.",
+    "you": "(du)",
+    "failedLoad": "Kunde inte ladda moderatorerna."
   },
   "reactions": {
     "addReaction": "Lägg till reaktion",

--- a/frontend/src/pages/AdminModerators.css
+++ b/frontend/src/pages/AdminModerators.css
@@ -1,0 +1,165 @@
+.admin-mods {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+}
+
+.admin-mods__header h1 {
+  margin: 0 0 0.4rem;
+  font-size: 1.6rem;
+}
+
+.admin-mods__intro {
+  margin: 0 0 1.5rem;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.admin-mods__section {
+  margin-bottom: 2rem;
+}
+
+.admin-mods__section-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.admin-mods__loading,
+.admin-mods__empty {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  padding: 0.75rem 0;
+}
+
+.admin-mods__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-surface);
+}
+
+.admin-mods__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border-light, var(--color-border));
+}
+
+.admin-mods__row:last-child {
+  border-bottom: none;
+}
+
+.admin-mods__user {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.admin-mods__avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.admin-mods__user-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.admin-mods__name {
+  font-weight: 600;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.admin-mods__email {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.admin-mods__role-badges {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.admin-mods__role-badge {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.45rem;
+  border-radius: 4px;
+  background: var(--color-surface-hover);
+  color: var(--color-text-secondary);
+}
+
+.admin-mods__role-badge--moderator {
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+}
+
+.admin-mods__role-badge--admin {
+  background: var(--color-accent-light);
+  color: var(--color-accent-hover);
+}
+
+.admin-mods__role-badge--somm {
+  background: rgba(45, 122, 69, 0.1);
+  color: var(--color-success);
+}
+
+.admin-mods__actions {
+  flex-shrink: 0;
+}
+
+.admin-mods__self-label {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.admin-mods__search {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.admin-mods__search-input {
+  flex: 1;
+  min-width: 0;
+}
+
+@media (max-width: 600px) {
+  .admin-mods__row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .admin-mods__actions .btn {
+    width: 100%;
+  }
+}

--- a/frontend/src/pages/AdminModerators.js
+++ b/frontend/src/pages/AdminModerators.js
@@ -1,0 +1,231 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import { adminGetUsers, adminChangeUserRoles } from '../api/admin';
+import ConfirmModal from '../components/ConfirmModal';
+import './AdminModerators.css';
+
+// Admin-only page for promoting / demoting forum moderators.
+//
+// Surfaces the existing PATCH /api/admin/users/:id/roles endpoint behind a
+// purpose-built UI. Admins can:
+//   - See current moderators (filtered list of users with the role)
+//   - Search the user base by username/email
+//   - One-click promote a regular user to moderator
+//   - One-click revoke an existing moderator's role (with confirm)
+//
+// Self-protection: the backend prevents admins changing their own roles, so
+// the UI hides the action buttons on the current admin's row.
+export default function AdminModerators() {
+  const { t } = useTranslation();
+  const { apiFetch, user } = useAuth();
+
+  const [moderators, setModerators] = useState([]);
+  const [searchInput, setSearchInput] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState(null);
+  const [searching, setSearching] = useState(false);
+
+  const [loadingMods, setLoadingMods] = useState(true);
+  const [error, setError] = useState(null);
+  const [pending, setPending] = useState(null); // userId currently being promoted/demoted
+  const [confirmRevoke, setConfirmRevoke] = useState(null); // user pending revocation
+
+  const fetchModerators = useCallback(async () => {
+    setLoadingMods(true);
+    setError(null);
+    try {
+      const res = await adminGetUsers(apiFetch, 'role=moderator&limit=200');
+      const data = await res.json();
+      if (res.ok) {
+        setModerators(data.users || []);
+      } else {
+        setError(data.error || t('adminModerators.failedLoad'));
+      }
+    } catch {
+      setError(t('adminModerators.failedLoad'));
+    } finally {
+      setLoadingMods(false);
+    }
+  }, [apiFetch, t]);
+
+  useEffect(() => { fetchModerators(); }, [fetchModerators]);
+
+  const runSearch = async (q) => {
+    if (!q || q.length < 2) {
+      setSearchResults(null);
+      return;
+    }
+    setSearching(true);
+    try {
+      const res = await adminGetUsers(apiFetch, `search=${encodeURIComponent(q)}&limit=20`);
+      const data = await res.json();
+      if (res.ok) setSearchResults(data.users || []);
+    } catch {
+      // silent
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleSearchSubmit = (e) => {
+    e.preventDefault();
+    setSearchQuery(searchInput.trim());
+    runSearch(searchInput.trim());
+  };
+
+  const clearSearch = () => {
+    setSearchInput('');
+    setSearchQuery('');
+    setSearchResults(null);
+  };
+
+  const promote = async (target) => {
+    setPending(target._id);
+    try {
+      const newRoles = Array.from(new Set([...(target.roles || ['user']), 'moderator']));
+      const res = await adminChangeUserRoles(apiFetch, target._id, newRoles);
+      if (res.ok) {
+        await fetchModerators();
+        if (searchQuery) runSearch(searchQuery);
+      }
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const revoke = async (target) => {
+    setPending(target._id);
+    try {
+      const newRoles = (target.roles || []).filter(r => r !== 'moderator');
+      // The backend requires a non-empty array — fall back to ['user'] if
+      // moderator was somehow the only role they had.
+      const finalRoles = newRoles.length > 0 ? newRoles : ['user'];
+      const res = await adminChangeUserRoles(apiFetch, target._id, finalRoles);
+      if (res.ok) {
+        await fetchModerators();
+        if (searchQuery) runSearch(searchQuery);
+      }
+    } finally {
+      setPending(null);
+      setConfirmRevoke(null);
+    }
+  };
+
+  const renderUserRow = (u, { isModerator }) => {
+    const isSelf = String(u._id) === String(user.id);
+    const displayName = u.displayName || u.username;
+    return (
+      <li key={u._id} className="admin-mods__row">
+        <div className="admin-mods__user">
+          <span className="admin-mods__avatar">{displayName.charAt(0).toUpperCase()}</span>
+          <div className="admin-mods__user-meta">
+            <span className="admin-mods__name">{displayName}</span>
+            <span className="admin-mods__email">{u.email}</span>
+          </div>
+          <div className="admin-mods__role-badges">
+            {(u.roles || []).filter(r => r !== 'user').map(r => (
+              <span key={r} className={`admin-mods__role-badge admin-mods__role-badge--${r}`}>{r}</span>
+            ))}
+          </div>
+        </div>
+        <div className="admin-mods__actions">
+          {isSelf ? (
+            <span className="admin-mods__self-label">{t('adminModerators.you')}</span>
+          ) : isModerator ? (
+            <button
+              className="btn btn-secondary btn-small"
+              onClick={() => setConfirmRevoke(u)}
+              disabled={pending === u._id}
+            >
+              {pending === u._id ? t('common.saving') : t('adminModerators.revoke')}
+            </button>
+          ) : (
+            <button
+              className="btn btn-primary btn-small"
+              onClick={() => promote(u)}
+              disabled={pending === u._id}
+            >
+              {pending === u._id ? t('common.saving') : t('adminModerators.promote')}
+            </button>
+          )}
+        </div>
+      </li>
+    );
+  };
+
+  return (
+    <div className="admin-mods">
+      <header className="admin-mods__header">
+        <h1>{t('adminModerators.title')}</h1>
+        <p className="admin-mods__intro">{t('adminModerators.intro')}</p>
+      </header>
+
+      {error && <div className="alert alert-error">{error}</div>}
+
+      <section className="admin-mods__section">
+        <h2 className="admin-mods__section-title">
+          {t('adminModerators.currentMods', { count: moderators.length })}
+        </h2>
+        {loadingMods ? (
+          <p className="admin-mods__loading">{t('common.loading')}</p>
+        ) : moderators.length === 0 ? (
+          <p className="admin-mods__empty">{t('adminModerators.noMods')}</p>
+        ) : (
+          <ul className="admin-mods__list">
+            {moderators.map(u => renderUserRow(u, { isModerator: true }))}
+          </ul>
+        )}
+      </section>
+
+      <section className="admin-mods__section">
+        <h2 className="admin-mods__section-title">{t('adminModerators.findUser')}</h2>
+        <form className="admin-mods__search" onSubmit={handleSearchSubmit} role="search">
+          <input
+            type="search"
+            className="input admin-mods__search-input"
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            placeholder={t('adminModerators.searchPlaceholder')}
+            aria-label={t('adminModerators.searchPlaceholder')}
+            minLength={2}
+          />
+          {searchQuery && (
+            <button type="button" className="btn btn-secondary btn-small" onClick={clearSearch}>
+              {t('common.clear')}
+            </button>
+          )}
+          <button type="submit" className="btn btn-primary btn-small" disabled={searching}>
+            {searching ? t('common.loading') : t('common.search')}
+          </button>
+        </form>
+
+        {searchResults !== null && (
+          searchResults.length === 0 ? (
+            <p className="admin-mods__empty">{t('adminModerators.noResults')}</p>
+          ) : (
+            <ul className="admin-mods__list">
+              {searchResults.map(u => renderUserRow(u, {
+                isModerator: (u.roles || []).includes('moderator')
+              }))}
+            </ul>
+          )
+        )}
+      </section>
+
+      {confirmRevoke && (
+        <ConfirmModal
+          title={t('adminModerators.revokeTitle')}
+          message={t('adminModerators.revokeConfirm', {
+            name: confirmRevoke.displayName || confirmRevoke.username
+          })}
+          warning={t('adminModerators.revokeWarning')}
+          confirmLabel={t('adminModerators.revoke')}
+          confirmClass="btn btn-warning"
+          onConfirm={() => revoke(confirmRevoke)}
+          onCancel={() => setConfirmRevoke(null)}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Surfaces the existing moderator-role management through a purpose-built admin page so non-admins can be promoted to forum mods without an MD shell. The `moderator` role itself was already wired end-to-end (pin/lock/move/delete discussions, see + resolve reports, ban users, 'Mod' badge on author lines) — this just adds the UI to manage it.

## Backend
- `backend/src/routes/admin/users.js`: `'moderator'` added to `VALID_ROLES` so the existing `PATCH /:id/roles` endpoint accepts it. Self-protection + audit logging were already in place. One-line change.

## Frontend
- New `/admin/moderators` page (admin-only, lazy-loaded). Two sections: **Current moderators** + **Find a user** (search by username/email, promote inline)
- Confirm dialog before revocation; warning copy spells out what they'll lose
- Admin can't promote/demote themselves — backend blocks it; UI hides action buttons on the current admin's row with a '(you)' label
- Role badges (admin / moderator / somm) on every row so admins can see at a glance
- Linked from the existing admin nav row in Layout.js, between Wine Reports and Blog
- Full i18n: `nav.moderators` + `adminModerators.*` namespace (EN + SV)

## Test plan
- [x] Backend 435/435, frontend 256/256
- [ ] Smoke-test:
  - [ ] Visit `/admin/moderators` as admin — current mods empty (you've never promoted anyone). Search for a user (e.g. 'user@cellarion.app'), find them, click Promote.
  - [ ] Reload — that user appears in the Current moderators list with a 'moderator' badge.
  - [ ] Log in as that user — visit any thread — they now see Pin / Lock / Move / Delete and the moderation reports queue.
  - [ ] Back as admin → click Revoke on that user → confirm. They drop out of the list.
  - [ ] Try to revoke yourself — backend returns 'You cannot change your own roles'; UI shows '(you)' instead of the action.

## Why no new role
'moderator' already existed end-to-end. Adding a separate 'forum_moderator' role would have been duplication for no real-world distinction (currently the moderator role is only used by the forum anyway).