### PR TITLE
refactor(community): correctness fixes from full forum audit

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -114,10 +114,24 @@ const requireModeratorOrAdmin = (req, res, next) => {
   next();
 };
 
+/**
+ * Convenience predicate used by handlers to branch on "is the requester a
+ * forum moderator OR admin?". Centralised here so the four+ inline copies
+ * across route handlers stop drifting (one of them used to forget admin).
+ *
+ * @param {{roles?: string[]}|null} user — typically req.user from optionalAuth
+ * @returns {boolean}
+ */
+function isModerator(user) {
+  if (!user || !Array.isArray(user.roles)) return false;
+  return user.roles.includes('moderator') || user.roles.includes('admin');
+}
+
 module.exports = {
   requireAuth,
   optionalAuth,
   requireRole,
   requireSommOrAdmin,
   requireModeratorOrAdmin,
+  isModerator,
 };

--- a/backend/src/models/DiscussionReply.js
+++ b/backend/src/models/DiscussionReply.js
@@ -35,10 +35,6 @@ const discussionReplySchema = new mongoose.Schema({
     ref: 'WineDefinition',
     default: null
   },
-  likesCount: {
-    type: Number,
-    default: 0
-  },
   // Soft-delete: body is replaced with placeholder; original stored for mod review
   isDeleted: {
     type: Boolean,

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth, optionalAuth, requireModeratorOrAdmin } = require('../middleware/auth');
+const { requireAuth, optionalAuth, requireModeratorOrAdmin, isModerator } = require('../middleware/auth');
 const Discussion = require('../models/Discussion');
 const { CATEGORIES } = require('../models/Discussion');
 const DiscussionReply = require('../models/DiscussionReply');
@@ -464,7 +464,8 @@ router.post('/', requireAuth, async (req, res) => {
         'discussion_mention',
         `${authorName} mentioned you`,
         `In a new discussion: "${cleanTitle}"`,
-        link
+        link,
+        'communityMention'
       );
     }
 
@@ -482,7 +483,7 @@ router.put('/:idOrSlug', requireAuth, async (req, res) => {
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
     const isOwner = discussion.author.toString() === req.user.id;
-    const isMod = req.user.roles && (req.user.roles.includes('moderator') || req.user.roles.includes('admin'));
+    const isMod = isModerator(req.user);
     if (!isOwner && !isMod) {
       return res.status(403).json({ error: 'You can only edit your own discussions' });
     }
@@ -529,12 +530,20 @@ router.delete('/:idOrSlug', requireAuth, requireModeratorOrAdmin, async (req, re
     const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
-    // Clean up replies, reactions, watches, reports
+    // Clean up replies, reactions, watches, reads, and reports — both reports
+    // filed against the discussion itself AND reports against any of its
+    // replies (the reply IDs go away in the next step, leaving orphan reports
+    // pointing at deleted documents in the moderation queue otherwise).
     const replyIds = await DiscussionReply.find({ discussion: discussion._id }).select('_id');
     const replyIdList = replyIds.map(r => r._id);
     DiscussionReaction.deleteMany({ reply: { $in: replyIdList } }).catch(() => {});
     DiscussionReply.deleteMany({ discussion: discussion._id }).catch(() => {});
-    DiscussionReport.deleteMany({ discussion: discussion._id }).catch(() => {});
+    DiscussionReport.deleteMany({
+      $or: [
+        { discussion: discussion._id },
+        { reply: { $in: replyIdList } }
+      ]
+    }).catch(() => {});
     DiscussionWatch.deleteMany({ discussion: discussion._id }).catch(() => {});
     DiscussionRead.deleteMany({ discussion: discussion._id }).catch(() => {});
 
@@ -615,7 +624,7 @@ router.get('/:idOrSlug/replies', optionalAuth, async (req, res) => {
       }
     }
 
-    const isMod = !!req.user && req.user.roles && (req.user.roles.includes('moderator') || req.user.roles.includes('admin'));
+    const isMod = isModerator(req.user);
     const enriched = replies.map(r => {
       const obj = r.toObject();
       const replyKey = r._id.toString();
@@ -779,7 +788,8 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
         'discussion_reply',
         'New reply to your discussion',
         `${replierName} replied to "${discussion.title}"`,
-        link
+        link,
+        'communityReply'
       );
       maybeEmail(discussion.author, 'communityReply', 'reply');
     }
@@ -791,7 +801,8 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
         'discussion_reply',
         `${replierName} quoted you`,
         `In "${discussion.title}"`,
-        link
+        link,
+        'communityReply'
       );
       maybeEmail(quotedAuthorId, 'communityReply', 'quote');
     }
@@ -805,7 +816,8 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
         'discussion_mention',
         `${replierName} mentioned you`,
         `In "${discussion.title}"`,
-        link
+        link,
+        'communityMention'
       );
       maybeEmail(uid, 'communityMention', 'mention');
     }
@@ -813,6 +825,8 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
     // Watchers — anyone following this thread who isn't already covered.
     // Lower-priority notification ("There's a new reply on a thread you
     // follow") so the title differs from the OP-owns-the-thread case.
+    // Push delivery is gated per-user via the 'communityFollow' category;
+    // no email channel for this category by design (would be too noisy).
     const watchers = await DiscussionWatch.find({ discussion: discussion._id })
       .select('user').lean();
     for (const w of watchers) {
@@ -824,9 +838,9 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
         'discussion_reply',
         `New reply in "${discussion.title}"`,
         `${replierName} replied — you're following this thread`,
-        link
+        link,
+        'communityFollow'
       );
-      // No email for follow-watchers — would be the noisiest channel.
     }
 
     logAudit(req, 'discussion_reply.create', { type: 'discussion_reply', id: reply._id }, { discussion: discussion._id });
@@ -849,7 +863,7 @@ router.put('/:discussionId/replies/:replyId', requireAuth, async (req, res) => {
     if (!reply) return res.status(404).json({ error: 'Reply not found' });
 
     const isOwner = reply.author.toString() === req.user.id;
-    const isMod = req.user.roles && (req.user.roles.includes('moderator') || req.user.roles.includes('admin'));
+    const isMod = isModerator(req.user);
     if (!isOwner && !isMod) {
       return res.status(403).json({ error: 'You can only edit your own replies' });
     }
@@ -887,7 +901,7 @@ router.delete('/:discussionId/replies/:replyId', requireAuth, async (req, res) =
     if (reply.isDeleted) return res.status(400).json({ error: 'Reply already deleted' });
 
     const isOwner = reply.author.toString() === req.user.id;
-    const isMod = req.user.roles && (req.user.roles.includes('moderator') || req.user.roles.includes('admin'));
+    const isMod = isModerator(req.user);
     if (!isOwner && !isMod) {
       return res.status(403).json({ error: 'You can only delete your own replies' });
     }
@@ -904,6 +918,11 @@ router.delete('/:discussionId/replies/:replyId', requireAuth, async (req, res) =
     // Re-index parent so search drops this reply's content (the index
     // helper filters out isDeleted replies).
     searchService.indexDiscussion(reply.discussion);
+
+    // Soft-deleted replies still hold their reactions for moderator review,
+    // but reports filed AGAINST a since-deleted reply lose their value (the
+    // mod queue would point at "[This reply has been removed]"). Drop them.
+    DiscussionReport.deleteMany({ reply: reply._id }).catch(() => {});
 
     res.json({ message: 'Reply deleted', reply: reply.toObject() });
   } catch (err) {
@@ -997,11 +1016,14 @@ router.post('/:idOrSlug/watch', requireAuth, async (req, res) => {
     const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
-    await DiscussionWatch.updateOne(
+    const result = await DiscussionWatch.updateOne(
       { user: req.user.id, discussion: discussion._id },
       { $setOnInsert: { user: req.user.id, discussion: discussion._id } },
       { upsert: true }
     );
+    if (result.upsertedCount > 0) {
+      logAudit(req, 'discussion.watch', { type: 'discussion', id: discussion._id });
+    }
     res.json({ watching: true });
   } catch (err) {
     console.error('Watch discussion error:', err);
@@ -1014,7 +1036,10 @@ router.delete('/:idOrSlug/watch', requireAuth, async (req, res) => {
     const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
 
-    await DiscussionWatch.deleteOne({ user: req.user.id, discussion: discussion._id });
+    const result = await DiscussionWatch.deleteOne({ user: req.user.id, discussion: discussion._id });
+    if (result.deletedCount > 0) {
+      logAudit(req, 'discussion.unwatch', { type: 'discussion', id: discussion._id });
+    }
     res.json({ watching: false });
   } catch (err) {
     console.error('Unwatch discussion error:', err);
@@ -1033,6 +1058,10 @@ router.patch('/:idOrSlug/pin', requireAuth, requireModeratorOrAdmin, async (req,
     discussion.isPinned = !discussion.isPinned;
     await discussion.save();
     logAudit(req, 'discussion.pin', { type: 'discussion', id: discussion._id }, { isPinned: discussion.isPinned });
+
+    // Re-index so the search filter on `isPinned` and the trending/active sort
+    // ordering reflect the toggle. Without this the search index goes stale.
+    searchService.indexDiscussion(discussion._id);
 
     res.json({ discussion });
   } catch (err) {
@@ -1053,6 +1082,8 @@ router.patch('/:idOrSlug/lock', requireAuth, requireModeratorOrAdmin, async (req
 
     // Locking changes the page meaning — re-ping crawlers to refresh their snapshot
     submitToIndexNow(`/community/discussions/${discussion.slug || discussion._id}`);
+    // Re-index so the search filter on `isLocked` reflects the toggle.
+    searchService.indexDiscussion(discussion._id);
 
     res.json({ discussion });
   } catch (err) {
@@ -1076,6 +1107,9 @@ router.patch('/:idOrSlug/move', requireAuth, requireModeratorOrAdmin, async (req
     discussion.category = category;
     await discussion.save();
     logAudit(req, 'discussion.move', { type: 'discussion', id: discussion._id }, { from: oldCategory, to: category });
+
+    // Re-index so the search filter on `category` reflects the move.
+    searchService.indexDiscussion(discussion._id);
 
     res.json({ discussion });
   } catch (err) {

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -22,6 +22,7 @@ const Discussion = require('../models/Discussion');
 const DiscussionReply = require('../models/DiscussionReply');
 const DiscussionReaction = require('../models/DiscussionReaction');
 const DiscussionWatch = require('../models/DiscussionWatch');
+const DiscussionRead = require('../models/DiscussionRead');
 const DiscussionReport = require('../models/DiscussionReport');
 const ChatUsage = require('../models/ChatUsage');
 const ImportSession = require('../models/ImportSession');
@@ -378,7 +379,7 @@ router.get('/me/export', requireAuth, async (req, res) => {
       images, recommendationsSent, recommendationsReceived, journalEntries,
       restockAlerts, wineLists, pendingSharesSent,
       discussions, discussionReplies, reviewVotes, discussionReactions, discussionWatches,
-      follows, chatUsage, importSessions, supportTickets,
+      discussionReads, follows, chatUsage, importSessions, supportTickets,
       discussionReports, wineReports, wishlistItems
     ] = await Promise.all([
       Bottle.find({ user: userId }).lean(),
@@ -396,10 +397,11 @@ router.get('/me/export', requireAuth, async (req, res) => {
       WineList.find({ user: userId }).select('name cellar structureMode branding layout createdAt updatedAt').lean(),
       PendingShare.find({ invitedBy: userId }).populate('cellar', 'name').lean(),
       Discussion.find({ author: userId }).select('title category body wineDefinition isPinned isLocked replyCount createdAt updatedAt').lean(),
-      DiscussionReply.find({ author: userId }).select('discussion body quote wineDefinition likesCount isDeleted createdAt updatedAt').lean(),
+      DiscussionReply.find({ author: userId }).select('discussion body quote wineDefinition isDeleted createdAt updatedAt').lean(),
       ReviewVote.find({ user: userId }).select('review vote createdAt').lean(),
       DiscussionReaction.find({ user: userId }).select('reply kind createdAt').lean(),
       DiscussionWatch.find({ user: userId }).select('discussion createdAt').lean(),
+      DiscussionRead.find({ user: userId }).select('discussion lastReadAt').lean(),
       Follow.find({ $or: [{ follower: userId }, { following: userId }] })
         .populate('follower', 'username').populate('following', 'username').lean(),
       ChatUsage.find({ userId: userId }).select('date promptTokens completionTokens').lean(),
@@ -511,7 +513,6 @@ router.get('/me/export', requireAuth, async (req, res) => {
         body: r.body,
         quote: r.quote,
         wineDefinition: r.wineDefinition,
-        likesCount: r.likesCount,
         isDeleted: r.isDeleted,
         createdAt: r.createdAt,
         updatedAt: r.updatedAt
@@ -519,6 +520,7 @@ router.get('/me/export', requireAuth, async (req, res) => {
       reviewVotes: reviewVotes.map(v => ({ review: v.review, vote: v.vote, createdAt: v.createdAt })),
       discussionReactions: discussionReactions.map(r => ({ reply: r.reply, kind: r.kind, createdAt: r.createdAt })),
       discussionWatches: discussionWatches.map(w => ({ discussion: w.discussion, createdAt: w.createdAt })),
+      discussionReads: discussionReads.map(r => ({ discussion: r.discussion, lastReadAt: r.lastReadAt })),
       social: {
         following: follows.filter(f => f.follower?._id?.toString() === userId || f.follower?.toString() === userId)
           .map(f => ({ username: f.following?.username, createdAt: f.createdAt })),

--- a/backend/src/services/notifications.js
+++ b/backend/src/services/notifications.js
@@ -13,13 +13,35 @@ if (VAPID_CONFIGURED) {
   );
 }
 
+// Map a notification category → which `preferences.notifications.<cat>.push`
+// flag gates web-push delivery. New community categories (Phase 5) read
+// per-category prefs; older subsystems pass undefined and fall back to a
+// permissive "any push enabled" check so they keep working.
+const PUSH_PREF_PATH = {
+  drinkWindow: 'drinkWindow',
+  communityReply: 'communityReply',
+  communityMention: 'communityMention',
+  communityFollow: 'communityFollow'
+};
+
 /**
  * Creates an in-app notification for a user, and dispatches a web-push
  * notification if the user has opted in and has active subscriptions.
  * Errors are caught and logged so a notification failure never breaks
  * the calling operation.
+ *
+ * @param {string} userId
+ * @param {string} type   — Notification.type enum
+ * @param {string} title
+ * @param {string} message
+ * @param {string} [link]
+ * @param {string} [category] — preference category that gates push delivery
+ *   ('drinkWindow' | 'communityReply' | 'communityMention' | 'communityFollow').
+ *   When omitted, falls back to "any push toggle enabled" — covers legacy
+ *   callers (recommendations, restock checker, etc.) that don't yet have
+ *   per-category prefs.
  */
-async function createNotification(userId, type, title, message, link = null) {
+async function createNotification(userId, type, title, message, link = null, category) {
   try {
     await Notification.create({ user: userId, type, title, message, link });
   } catch (err) {
@@ -30,7 +52,21 @@ async function createNotification(userId, type, title, message, link = null) {
   if (!VAPID_CONFIGURED) return;
   try {
     const user = await User.findById(userId).select('preferences.notifications').lean();
-    if (!user?.preferences?.notifications?.push) return;
+    const prefs = user?.preferences?.notifications;
+    if (!prefs) return;
+
+    // Category-specific gate when the caller named one — otherwise permissive.
+    let pushAllowed;
+    const prefKey = category ? PUSH_PREF_PATH[category] : null;
+    if (prefKey) {
+      pushAllowed = !!prefs[prefKey]?.push;
+    } else {
+      // Legacy / uncategorised path: fire if any of the known push toggles
+      // are on. Avoids silently dropping notifications for callers that
+      // haven't been migrated to pass a category yet.
+      pushAllowed = Object.values(PUSH_PREF_PATH).some(k => !!prefs[k]?.push);
+    }
+    if (!pushAllowed) return;
 
     const subs = await PushSubscription.find({ user: userId }).lean();
     if (subs.length === 0) return;

--- a/frontend/src/pages/PrivacyPolicy.js
+++ b/frontend/src/pages/PrivacyPolicy.js
@@ -49,6 +49,7 @@ function PrivacyPolicy() {
           <li><strong>Account information:</strong> email address, username, and password (stored as a bcrypt hash — we never store your plain-text password).</li>
           <li><strong>Profile information:</strong> optional display name, bio, and profile visibility preference.</li>
           <li><strong>Cellar data:</strong> bottles, cellars, racks, tasting notes, ratings, purchase information, and wine images you add to your account.</li>
+          <li><strong>Community / forum data:</strong> discussions and replies you post, reactions you add to other users' replies, threads you subscribe to ("watch"), and read-state markers tracking which threads you've opened (used to drive the unread indicator).</li>
           <li><strong>Activity logs:</strong> actions you take in the app (e.g. adding a bottle, logging in) are logged with your user ID, IP address, and browser user-agent for security and service maintenance purposes.</li>
           <li><strong>Consent records:</strong> timestamps of when you accepted this privacy policy and consented to data processing.</li>
         </ul>
@@ -112,7 +113,7 @@ function PrivacyPolicy() {
           <li><strong>Account data:</strong> retained for as long as your account is active.</li>
           <li><strong>Activity logs:</strong> automatically deleted after 90 days.</li>
           <li><strong>Deleted cellars/racks:</strong> soft-deleted and permanently removed after 30 days.</li>
-          <li><strong>Account deletion:</strong> when you request account deletion, there is a 7-day cooling-off period. After that, your personal data (account, cellar, bottles, journal, settings, reactions, watches, reports) is permanently and irreversibly deleted.</li>
+          <li><strong>Account deletion:</strong> when you request account deletion, there is a 7-day cooling-off period. After that, your personal data (account, cellar, bottles, journal, settings, forum reactions, thread subscriptions, read-state markers, reports) is permanently and irreversibly deleted.</li>
           <li><strong>Forum content (discussions and replies):</strong> to preserve multi-party conversations for other users, your forum posts are <em>anonymised</em> rather than hard-deleted — your authorship is replaced with "[Deleted user]" and the personal-data link is severed (GDPR Art. 17 compliant). The post text remains visible. If you need a specific post fully removed, contact support before requesting account deletion.</li>
         </ul>
 


### PR DESCRIPTION
## Summary

Full audit of the community/forum surface after the engagement-v2 merge surfaced one silent functional bug and a handful of consistency / correctness gaps. This PR is the **backend correctness pass**; a follow-up will do frontend i18n + UX polish.

### The big one — broken push notifications

Engagement-v2 replaced the flat \`notifications.push\` flag with per-category preferences (\`notifications.communityReply.push\`, \`.communityMention.push\`, \`.communityFollow.push\`, \`.drinkWindow.push\`). The notification service was never updated, so it kept reading the now-nonexistent flat flag. Effect: **every forum push notification was silently dropped** since engagement-v2 shipped, and drink-window push was relying on the legacy fallback.

Fix: \`createNotification(userId, type, title, message, link, category)\` now takes a category, looks up the right per-category \`.push\` flag, and falls back to \"any push toggle on\" only when no category is supplied (covers legacy callers that haven't migrated yet — recommendations, restock, etc.).

Threaded the category through all 5 forum call sites: mentions in new discussions, replies-to-OP, quote-replies, mentions in replies, and watcher fan-out.

### Other findings

- **isModerator(user) helper** in middleware/auth.js. Replaces 4 inline \`req.user.roles && req.user.roles.includes('moderator') || .includes('admin')\` copies — one of which had previously forgotten the admin clause.
- **Re-index search on pin/lock/move.** Without this, toggling pin/lock or moving categories left the search index stale, so the trending sort and category filters returned wrong results until the next reply.
- **DiscussionReport cascade.** On reply soft-delete and discussion hard-delete, also delete reports against the affected documents — otherwise the mod queue accumulates reports pointing at \"[This reply has been removed]\" / 404'd discussions.
- **GDPR export gap.** DiscussionRead was in the deletion cascade but not in /api/users/me/export. Added (Art. 20 portability).
- **Dead field.** Removed DiscussionReply.likesCount — replaced by the reactions collection in engagement-v2, never read since. Also dropped from the export schema.
- **Audit log on watch/unwatch.** Explicit subscription mutations get logged. Reactions deliberately NOT logged (vote-equivalent — ReviewVote isn't logged either). Read markers deliberately NOT logged (fire automatically on every thread open — would 100x audit log volume).
- **PrivacyPolicy §3.** Added explicit mention of community / forum data (reactions, thread subscriptions, read-state markers).

## Test plan

- [x] Backend tests: \`npm test\` → 435/435 passing
- [x] Frontend tests: \`npm test -- --watchAll=false\` → 256/256 passing
- [ ] Smoke: subscribe to push, post a discussion as user A, reply from user B → user A receives push (was previously broken)
- [ ] Smoke: as moderator, pin a thread → search filter reflects pinned state immediately
- [ ] Smoke: hard-delete a discussion that has reports against its replies → mod queue is clean
- [ ] Export your own data → \`discussionReads\` array present