### PR TITLE
refactor(community): frontend consistency — i18n, race fix, a11y

### DIFF
--- a/frontend/src/components/DiscussionCard.js
+++ b/frontend/src/components/DiscussionCard.js
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import CategoryBadge from './CategoryBadge';
 import CellarCredBadge from './CellarCredBadge';
 import { extractForumPlainText } from '../utils/sanitizeForumRender';
-import { isDeletedUser } from '../utils/deletedUser';
+import { isDeletedUser, authorDisplayName } from '../utils/deletedUser';
 import timeAgo from '../utils/timeAgo';
 import './DiscussionCard.css';
 
@@ -15,9 +15,7 @@ export default function DiscussionCard({ discussion }) {
   const { t } = useTranslation();
   const author = discussion.author || {};
   const authorIsDeleted = isDeletedUser(author);
-  const authorName = authorIsDeleted
-    ? t('common.deletedUser')
-    : (author.displayName || author.username || 'Unknown');
+  const authorName = authorDisplayName(author, t, t('common.unknown'));
 
   const bodyPlain = extractForumPlainText(discussion.body);
   const preview = bodyPlain.length > 140 ? bodyPlain.slice(0, 140) + '…' : bodyPlain;
@@ -27,9 +25,7 @@ export default function DiscussionCard({ discussion }) {
   const lastReply = discussion.lastReply;
   const lastPoster = lastReply?.author || author;
   const lastPosterIsDeleted = isDeletedUser(lastPoster);
-  const lastPosterName = lastPosterIsDeleted
-    ? t('common.deletedUser')
-    : (lastPoster?.displayName || lastPoster?.username || 'Unknown');
+  const lastPosterName = authorDisplayName(lastPoster, t, t('common.unknown'));
   const lastPosterInitial = lastPosterIsDeleted ? '?' : lastPosterName.charAt(0).toUpperCase();
   const lastPosterIsOP = !lastReply;
 
@@ -76,8 +72,8 @@ export default function DiscussionCard({ discussion }) {
                 {authorName}
               </Link>
             )}
-            {!authorIsDeleted && author.roles?.includes('moderator') && <span className="badge badge--mod">Mod</span>}
-            {!authorIsDeleted && author.roles?.includes('admin') && <span className="badge badge--admin">Admin</span>}
+            {!authorIsDeleted && author.roles?.includes('moderator') && <span className="badge badge--mod">{t('discussions.mod')}</span>}
+            {!authorIsDeleted && author.roles?.includes('admin') && <span className="badge badge--admin">{t('discussions.admin')}</span>}
             {!authorIsDeleted && <CellarCredBadge tier={author.contribution?.tier} specialty={author.contribution?.specialty} />}
           </span>
         </div>

--- a/frontend/src/components/DiscussionsFeedWidget.js
+++ b/frontend/src/components/DiscussionsFeedWidget.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { authorDisplayName } from '../utils/deletedUser';
 import timeAgo from '../utils/timeAgo';
 import './DiscussionsFeedWidget.css';
 
@@ -49,7 +50,7 @@ export default function DiscussionsFeedWidget({ limit = 5, sort = 'active' }) {
       <ul className="discussions-feed-widget__list">
         {discussions.map(d => {
           const author = d.author || {};
-          const authorName = author.displayName || author.username || 'Anonymous';
+          const authorName = authorDisplayName(author, t, t('discussions.anonymous'));
           const slugOrId = d.slug || d._id;
           return (
             <li key={d._id} className="discussions-feed-widget__item">

--- a/frontend/src/components/ParticipantStack.js
+++ b/frontend/src/components/ParticipantStack.js
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { isDeletedUser } from '../utils/deletedUser';
+import { isDeletedUser, authorDisplayName } from '../utils/deletedUser';
 import './ParticipantStack.css';
 
 // Overlapping avatar stack used on the discussion-detail header to show who
@@ -20,9 +20,7 @@ export default function ParticipantStack({ participants, total }) {
       <ul className="participant-stack__list">
         {participants.map(p => {
           const deleted = isDeletedUser(p);
-          const name = deleted
-            ? t('common.deletedUser')
-            : (p.displayName || p.username || 'Unknown');
+          const name = authorDisplayName(p, t, t('common.unknown'));
           const initial = deleted ? '?' : name.charAt(0).toUpperCase();
           return (
             <li

--- a/frontend/src/components/ReactionPicker.js
+++ b/frontend/src/components/ReactionPicker.js
@@ -24,11 +24,18 @@ export const EMOJI_BY_KIND = Object.fromEntries(REACTIONS.map(r => [r.kind, r.em
 /**
  * Floating "+" button that opens the 8-reaction picker. Calls onPick with
  * the chosen kind. Closes on outside click or Escape.
+ *
+ * Keyboard nav (WAI-ARIA menu pattern): when the panel opens, focus jumps
+ * to the first option. Arrow Up/Down cycles within the panel; Home/End
+ * jump to the ends; Escape closes and returns focus to the toggle.
  */
 export default function ReactionPicker({ onPick, disabled }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
   const wrapRef = useRef(null);
+  const toggleRef = useRef(null);
+  const optionRefs = useRef([]);
 
   useEffect(() => {
     if (!open) return undefined;
@@ -44,34 +51,84 @@ export default function ReactionPicker({ onPick, disabled }) {
     };
   }, [open]);
 
+  // Focus first option on open; restore focus to toggle on close.
+  useEffect(() => {
+    if (open) {
+      setActiveIdx(0);
+      // Defer focus until after the panel has mounted.
+      const id = requestAnimationFrame(() => {
+        optionRefs.current[0]?.focus();
+      });
+      return () => cancelAnimationFrame(id);
+    } else if (toggleRef.current && document.activeElement && wrapRef.current?.contains(document.activeElement)) {
+      // Only restore focus if we owned focus when closing — avoids stealing
+      // focus when the user clicked outside to dismiss.
+      toggleRef.current.focus();
+    }
+    return undefined;
+  }, [open]);
+
   const choose = (kind) => {
     onPick?.(kind);
     setOpen(false);
   };
 
+  const handlePanelKey = (e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = (activeIdx + 1) % REACTIONS.length;
+      setActiveIdx(next);
+      optionRefs.current[next]?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const next = (activeIdx - 1 + REACTIONS.length) % REACTIONS.length;
+      setActiveIdx(next);
+      optionRefs.current[next]?.focus();
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setActiveIdx(0);
+      optionRefs.current[0]?.focus();
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      const last = REACTIONS.length - 1;
+      setActiveIdx(last);
+      optionRefs.current[last]?.focus();
+    }
+  };
+
   return (
     <div className="reaction-picker" ref={wrapRef}>
       <button
+        ref={toggleRef}
         type="button"
         className="reaction-picker__toggle"
         onClick={() => setOpen(o => !o)}
         disabled={disabled}
         aria-label={t('reactions.addReaction')}
         aria-expanded={open}
+        aria-haspopup="menu"
         title={t('reactions.addReaction')}
       >
         <span aria-hidden="true">😊</span>
         <span aria-hidden="true" className="reaction-picker__plus">+</span>
       </button>
       {open && (
-        <div className="reaction-picker__panel" role="menu">
-          {REACTIONS.map(r => (
+        <div
+          className="reaction-picker__panel"
+          role="menu"
+          aria-label={t('reactions.addReaction')}
+          onKeyDown={handlePanelKey}
+        >
+          {REACTIONS.map((r, idx) => (
             <button
               key={r.kind}
+              ref={el => { optionRefs.current[idx] = el; }}
               type="button"
               role="menuitem"
+              tabIndex={idx === activeIdx ? 0 : -1}
               className="reaction-picker__option"
               onClick={() => choose(r.kind)}
+              onFocus={() => setActiveIdx(idx)}
               title={t(r.labelKey)}
             >
               <span className="reaction-picker__emoji" aria-hidden="true">{r.emoji}</span>

--- a/frontend/src/components/ReplyCard.js
+++ b/frontend/src/components/ReplyCard.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -6,17 +6,20 @@ import { toggleReaction, getReplyOriginal, banUser } from '../api/discussions';
 import WineReferenceCard from './WineReferenceCard';
 import CellarCredBadge from './CellarCredBadge';
 import ConfirmModal from './ConfirmModal';
-import ReactionPicker, { REACTIONS, EMOJI_BY_KIND } from './ReactionPicker';
+import ReactionPicker, { REACTIONS } from './ReactionPicker';
 import { sanitizeForumRender } from '../utils/sanitizeForumRender';
-import { isDeletedUser } from '../utils/deletedUser';
+import { isDeletedUser, authorDisplayName } from '../utils/deletedUser';
 import timeAgo from '../utils/timeAgo';
 import './ReplyCard.css';
 
 function QuoteBlock({ quote }) {
+  const { t } = useTranslation();
   if (!quote || !quote.body) return null;
   return (
     <div className="reply-card__quote">
-      <div className="reply-card__quote-author">{quote.authorName || 'Unknown'} wrote:</div>
+      <div className="reply-card__quote-author">
+        {t('discussions.quoteAttribution', { name: quote.authorName || t('common.unknown') })}
+      </div>
       <div className="reply-card__quote-body">{quote.body}</div>
     </div>
   );
@@ -35,12 +38,15 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
   const [loadingOriginal, setLoadingOriginal] = useState(false);
   const [showBanMenu, setShowBanMenu] = useState(false);
   const [confirmBan, setConfirmBan] = useState(null); // { duration, label }
+  // Monotonic counter for in-flight reaction toggles. Used to discard
+  // rollbacks from older requests when the user has already fired a newer
+  // toggle — without this, a slow first-click failure can stomp on the
+  // already-applied second click.
+  const reactionRequestRef = useRef(0);
 
   const author = reply.author || {};
   const authorDeleted = isDeletedUser(author);
-  const authorName = authorDeleted
-    ? t('common.deletedUser')
-    : (author.displayName || author.username || 'Unknown');
+  const authorName = authorDisplayName(author, t, t('common.unknown'));
   const isOwn = user && author._id === user.id;
   const isMod = user && (user.roles?.includes('moderator') || user.roles?.includes('admin'));
   const authorIsMod = !authorDeleted && (author.roles?.includes('moderator') || author.roles?.includes('admin'));
@@ -61,9 +67,16 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
   // Toggle a reaction kind. Optimistic: flip locally first, reconcile from
   // the server response. Self-reactions are allowed (Slack/Discord/GitHub
   // model — let authors react to their own posts).
+  //
+  // Rapid double-click safety: a per-toggle token guards rollback paths so a
+  // slow earlier-failed call can't undo an already-applied later call. The
+  // server is the single source of truth; only the *latest* response wins.
   const handleReact = async (kind) => {
-    const had = myReactions.has(kind);
-    const nextMine = new Set(myReactions);
+    const token = ++reactionRequestRef.current;
+    const prevMine = myReactions;
+    const prevCounts = reactionCounts;
+    const had = prevMine.has(kind);
+    const nextMine = new Set(prevMine);
     if (had) nextMine.delete(kind); else nextMine.add(kind);
     setMyReactions(nextMine);
     setReactionCounts(prev => {
@@ -77,6 +90,7 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
 
     try {
       const res = await toggleReaction(apiFetch, discussionId, reply._id, kind);
+      if (token !== reactionRequestRef.current) return; // a newer toggle owns state
       if (res.ok) {
         const data = await res.json();
         // Reconcile authoritative counts; mirror the optimistic mine flip
@@ -84,13 +98,13 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
         // the requester and we already know).
         setReactionCounts(data.reactions || {});
       } else {
-        // Roll back optimistic update
-        setMyReactions(myReactions);
-        setReactionCounts(reactionCounts);
+        setMyReactions(prevMine);
+        setReactionCounts(prevCounts);
       }
     } catch {
-      setMyReactions(myReactions);
-      setReactionCounts(reactionCounts);
+      if (token !== reactionRequestRef.current) return;
+      setMyReactions(prevMine);
+      setReactionCounts(prevCounts);
     }
   };
 
@@ -124,7 +138,7 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
             <span className="reply-card__author-name">{authorName}</span>
           </Link>
           <span className="reply-card__time">{timeAgo(reply.createdAt)}</span>
-          <span className="reply-card__deleted-badge">Removed</span>
+          <span className="reply-card__deleted-badge">{t('discussions.removed')}</span>
         </div>
 
         <div className="reply-card__body reply-card__body--deleted">
@@ -140,7 +154,7 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
         {isMod && (
           <div className="reply-card__footer">
             <button className="reply-card__action-btn" onClick={handleViewOriginal} disabled={loadingOriginal}>
-              {loadingOriginal ? 'Loading...' : (showOriginal ? 'Hide Original' : 'View Original')}
+              {loadingOriginal ? t('common.loading') : (showOriginal ? t('discussions.hideOriginal') : t('discussions.viewOriginal'))}
             </button>
           </div>
         )}
@@ -164,12 +178,12 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
             <span className="reply-card__author-name">{authorName}</span>
           </Link>
         )}
-        {!authorDeleted && author.roles?.includes('moderator') && <span className="badge badge--mod">Mod</span>}
-        {!authorDeleted && author.roles?.includes('admin') && <span className="badge badge--admin">Admin</span>}
+        {!authorDeleted && author.roles?.includes('moderator') && <span className="badge badge--mod">{t('discussions.mod')}</span>}
+        {!authorDeleted && author.roles?.includes('admin') && <span className="badge badge--admin">{t('discussions.admin')}</span>}
         {!authorDeleted && <CellarCredBadge tier={author.contribution?.tier} specialty={author.contribution?.specialty} />}
         <span className="reply-card__time">{timeAgo(reply.createdAt)}</span>
         {reply.updatedAt !== reply.createdAt && (
-          <span className="reply-card__edited">(edited)</span>
+          <span className="reply-card__edited">{t('discussions.editedSuffix')}</span>
         )}
       </div>
 
@@ -209,37 +223,43 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
 
         {onReply && (
           <button className="reply-card__action-btn" onClick={() => onReply(reply)}>
-            Reply
+            {t('discussions.replyShort')}
           </button>
         )}
 
         {isOwn && onEdit && (
           <button className="reply-card__action-btn" onClick={() => onEdit(reply)}>
-            Edit
+            {t('common.edit')}
           </button>
         )}
 
         {(isOwn || isMod) && onDelete && (
           <button className="reply-card__action-btn reply-card__action-btn--danger" onClick={() => onDelete(reply)}>
-            Delete
+            {t('common.delete')}
           </button>
         )}
 
         {/* Self-reactions are allowed; reporting yourself is not. */}
         {!isOwn && onReport && (
           <button className="reply-card__action-btn" onClick={() => onReport(reply)}>
-            Report
+            {t('discussions.report')}
           </button>
         )}
 
         {isMod && !isOwn && !authorIsMod && (
           <div className="reply-card__ban-wrapper">
             <button className="reply-card__action-btn reply-card__action-btn--danger" onClick={() => setShowBanMenu(!showBanMenu)}>
-              Ban
+              {t('discussions.ban')}
             </button>
             {showBanMenu && (
               <div className="reply-card__ban-menu">
-                {[['10m', '10 minutes'], ['1h', '1 hour'], ['1d', '1 day'], ['1w', '1 week'], ['permanent', 'permanently']].map(([val, label]) => (
+                {[
+                  ['10m', t('discussions.banDuration.10m')],
+                  ['1h', t('discussions.banDuration.1h')],
+                  ['1d', t('discussions.banDuration.1d')],
+                  ['1w', t('discussions.banDuration.1w')],
+                  ['permanent', t('discussions.banDuration.permanent')]
+                ].map(([val, label]) => (
                   <button key={val} className="reply-card__ban-option" onClick={() => setConfirmBan({ duration: val, label })}>{label}</button>
                 ))}
               </div>
@@ -250,9 +270,9 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
 
       {confirmBan && (
         <ConfirmModal
-          title="Ban User"
-          message={`Ban ${authorName} from discussions for ${confirmBan.label}?`}
-          confirmLabel="Ban"
+          title={t('discussions.banUserTitle')}
+          message={t('discussions.confirmBan', { name: authorName, duration: confirmBan.label })}
+          confirmLabel={t('discussions.ban')}
           confirmClass="btn btn-warning btn-small"
           onConfirm={() => handleBan(confirmBan.duration, confirmBan.label)}
           onCancel={() => setConfirmBan(null)}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1362,7 +1362,23 @@
     "createAccount": "Create account",
     "signInToJoin": "Sign in to join the conversation — read freely, write with a Cellarion account.",
     "signInToReply": "Sign in to reply to this discussion.",
-    "signInToStart": "Sign in to start a discussion."
+    "signInToStart": "Sign in to start a discussion.",
+    "removed": "Removed",
+    "viewOriginal": "View Original",
+    "hideOriginal": "Hide Original",
+    "editedSuffix": "(edited)",
+    "quoteAttribution": "{{name}} wrote:",
+    "anonymous": "Anonymous",
+    "ban": "Ban",
+    "banUserTitle": "Ban User",
+    "confirmBan": "Ban {{name}} from discussions for {{duration}}?",
+    "banDuration": {
+      "10m": "10 minutes",
+      "1h": "1 hour",
+      "1d": "1 day",
+      "1w": "1 week",
+      "permanent": "permanently"
+    }
   },
   "wineDiscussions": {
     "title": "Discussions about this wine",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1362,7 +1362,23 @@
     "createAccount": "Skapa konto",
     "signInToJoin": "Logga in för att vara med i samtalet — läs fritt, skriv med ett Cellarion-konto.",
     "signInToReply": "Logga in för att svara på denna diskussion.",
-    "signInToStart": "Logga in för att starta en diskussion."
+    "signInToStart": "Logga in för att starta en diskussion.",
+    "removed": "Borttaget",
+    "viewOriginal": "Visa original",
+    "hideOriginal": "Dölj original",
+    "editedSuffix": "(redigerad)",
+    "quoteAttribution": "{{name}} skrev:",
+    "anonymous": "Anonym",
+    "ban": "Stäng av",
+    "banUserTitle": "Stäng av användare",
+    "confirmBan": "Stäng av {{name}} från diskussioner i {{duration}}?",
+    "banDuration": {
+      "10m": "10 minuter",
+      "1h": "1 timme",
+      "1d": "1 dag",
+      "1w": "1 vecka",
+      "permanent": "permanent"
+    }
   },
   "wineDiscussions": {
     "title": "Diskussioner om detta vin",

--- a/frontend/src/pages/DiscussionDetail.js
+++ b/frontend/src/pages/DiscussionDetail.js
@@ -21,7 +21,7 @@ import WatchThreadButton from '../components/WatchThreadButton';
 import ParticipantStack from '../components/ParticipantStack';
 import JumpToReplyButton from '../components/JumpToReplyButton';
 import { sanitizeForumRender, extractForumPlainText } from '../utils/sanitizeForumRender';
-import { isDeletedUser } from '../utils/deletedUser';
+import { isDeletedUser, authorDisplayName } from '../utils/deletedUser';
 import timeAgo from '../utils/timeAgo';
 import './DiscussionDetail.css';
 
@@ -278,9 +278,7 @@ function DiscussionDetail() {
 
   const author = discussion.author || {};
   const authorDeleted = isDeletedUser(author);
-  const authorName = authorDeleted
-    ? t('common.deletedUser')
-    : (author.displayName || author.username || 'Unknown');
+  const authorName = authorDisplayName(author, t, t('common.unknown'));
 
   const slugOrId = discussion.slug || discussion._id;
   const canonicalPath = `/community/discussions/${slugOrId}`;
@@ -411,7 +409,7 @@ function DiscussionDetail() {
               reply={reply}
               discussionId={id}
               onReply={!user || discussion.isLocked ? null : (r) => {
-                const authorName = r.author?.displayName || r.author?.username || 'Unknown';
+                const authorName = authorDisplayName(r.author, t, t('common.unknown'));
                 // r.body is HTML — strip to plain text for the quote preview.
                 // The backend independently rebuilds the persisted snapshot
                 // from the server-side body, so this is preview-only.


### PR DESCRIPTION
## Summary

Frontend half of the community audit (#375 was the backend half). Three concerns surfaced — all small, but consistent across the surface.

### 1. Hardcoded English in forum components

ReplyCard had ~12 literal strings (\`Mod\`, \`Admin\`, \`Removed\`, \`Loading...\`, \`View Original\`, \`Hide Original\`, \`Reply\`, \`Edit\`, \`Delete\`, \`Ban\`, \`{{name}} wrote:\`, \`(edited)\`, \`Ban User\`, ban duration labels, ban confirm message). DiscussionCard had the Mod/Admin badges on the same hardcoded path.

Most keys already existed in the \`discussions\` namespace; added 11 new ones for the missing copy. Swedish translations added in lock-step.

### 2. authorDisplayName consistently applied

\`utils/deletedUser.js\` ships an \`authorDisplayName(user, t, fallback)\` helper that handles:
- the sentinel \`__deleted__\` username (returns localised \`[Deleted user]\`)
- the \`displayName || username || fallback\` chain

But it was only used in one place. Five components were each rolling their own version:
- DiscussionCard (×2 — author and last-poster)
- ReplyCard
- ParticipantStack
- DiscussionDetail (×2 — main author and quoted-reply author)
- DiscussionsFeedWidget (used \`'Anonymous'\` literal)

All migrated. Inconsistency was visible: DiscussionsFeedWidget displayed deleted users as their literal sentinel username \`__deleted__\` because it skipped the deleted-user check.

### 3. ReactionPicker — accessibility + race condition

**Keyboard nav.** Standard WAI-ARIA menu pattern was missing:
- Opening the panel now focuses the first option
- Arrow Up/Down cycle through reactions
- Home / End jump to first / last
- Escape closes and restores focus to the toggle (only when focus is inside the picker — avoids stealing focus when dismissed by outside-click)
- Toggle gained \`aria-haspopup=\"menu\"\`

**Double-click race in ReplyCard.handleReact.** The rollback path closed over the original \`myReactions\` / \`reactionCounts\` snapshots from when the function was called. If a user rapid-fired two toggles and the first request lost the race (slow, failed), it would roll back to a state from before the second toggle had been applied — visible glitch where the user saw their reaction flicker off after they had already clicked it on.

Fixed with a monotonic request token (\`useRef\` counter). Each toggle increments the counter; on response, the rollback path no-ops if a newer toggle has fired. Server is the single source of truth for the final state.

## Test plan

- [x] Frontend tests: \`npm test -- --watchAll=false\` → 256/256 passing
- [x] Build clean (warning count: 47 → 46 — also removed a pre-existing dead \`EMOJI_BY_KIND\` import sitting in ReplyCard)
- [ ] Smoke: switch language to Swedish, open a thread → all moderator/badge labels translated
- [ ] Smoke: tab into the reaction picker, hit Space to open → first option is focused, arrows cycle, Esc returns focus to the +
- [ ] Smoke: rapid-double-click a reaction with throttled network → no flicker, final state matches server