### PR TITLE
refactor(community): visual polish — neat, discreet forum aesthetic

### DIFF
--- a/frontend/src/components/CategoryBadge.css
+++ b/frontend/src/components/CategoryBadge.css
@@ -1,44 +1,58 @@
+/* Category badge — small, quiet, typography-led. The colour palette is
+   desaturated on purpose: a forum doesn't need fluorescent pastels to
+   distinguish "tasting notes" from "food pairing". A subtle hue + the
+   label itself is enough, and it leaves the wine burgundy as the only
+   loud colour on the page. */
 .category-badge {
-  display: inline-block;
-  padding: 0.15rem 0.5rem;
-  border-radius: 12px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  line-height: 1.4;
-  border: none;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-full);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.5;
+  border: 1px solid transparent;
   cursor: default;
   white-space: nowrap;
+  text-transform: uppercase;
 }
 
 button.category-badge {
   cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 button.category-badge:hover {
-  opacity: 0.85;
+  border-color: currentColor;
 }
 
+/* Tasting notes — soft plum */
 .category-badge--tasting-notes {
-  background: var(--color-wine-light, #f3e8ff);
-  color: var(--color-wine, #7c3aed);
+  background: rgba(120, 70, 130, 0.08);
+  color: #6B3F76;
 }
 
+/* Food pairing — soft amber */
 .category-badge--food-pairing {
-  background: #fef3c7;
-  color: #92400e;
+  background: rgba(180, 130, 50, 0.1);
+  color: #8B6510;
 }
 
+/* Recommendations — soft slate */
 .category-badge--recommendations {
-  background: #dbeafe;
-  color: #1e40af;
+  background: rgba(60, 90, 130, 0.08);
+  color: #3E5A7E;
 }
 
+/* Cellar tips — soft moss */
 .category-badge--cellar-tips {
-  background: #d1fae5;
-  color: #065f46;
+  background: rgba(70, 110, 70, 0.08);
+  color: #406B40;
 }
 
+/* General — neutral */
 .category-badge--general {
-  background: var(--color-bg-secondary, #f3f4f6);
-  color: var(--color-text-secondary, #6b7280);
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
 }

--- a/frontend/src/components/DiscussionCard.css
+++ b/frontend/src/components/DiscussionCard.css
@@ -1,39 +1,38 @@
 /* Two-column list row. Main column carries title + body + OP author;
    side column carries the last-poster preview + reply count — the "is
-   this thread alive?" scanning signal. Pinned threads use a sage-tinted
-   background via [data-pinned] so they read as anchored without losing
-   the standard card hierarchy. */
+   this thread alive?" scanning signal. Pinned threads use a 📌 icon and
+   a subtle accent left-bar so they read as anchored without shouting. */
 .discussion-card {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 1rem;
   text-decoration: none;
   color: inherit;
-  padding: 0.875rem 1.125rem;
-  transition: background 0.12s, border-color 0.15s, box-shadow 0.15s;
+  padding: 1rem 1.125rem;
+  /* Override the heavier .card defaults (1.5rem padding, drop shadow at rest)
+     so the list reads as a calm column of rows, not a stack of standalone
+     cards. Shadow only appears on hover. */
+  box-shadow: none;
+  border-color: var(--color-border-light, var(--color-border));
+  transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
   cursor: pointer;
 }
 
 .discussion-card:hover {
-  border-color: var(--color-primary);
+  border-color: var(--color-border);
   background: var(--color-surface-hover);
   box-shadow: var(--shadow-sm);
 }
 
-/* Pinned: warm cream tint + accent left bar so it visually anchors as a
-   "stuck" thread even when scrolled past in a long list. */
+/* Pinned: 3px accent bar, no tint. The 📌 in the header carries the meaning;
+   we don't need a coloured background on top. */
 .discussion-card[data-pinned="true"] {
-  background: rgba(212, 163, 115, 0.06);
   border-left: 3px solid var(--color-accent);
   padding-left: calc(1.125rem - 3px);
 }
 
-.discussion-card[data-pinned="true"]:hover {
-  background: rgba(212, 163, 115, 0.1);
-}
-
 .discussion-card__main {
-  min-width: 0; /* allow inner text to truncate */
+  min-width: 0;
 }
 
 .discussion-card__side {
@@ -50,70 +49,57 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.5rem;
   flex-wrap: wrap;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
 }
 
+/* Pinned/locked labels: neutral, lower-weight than the category badge —
+   they're modifiers, not identities. */
 .discussion-card__pinned,
 .discussion-card__locked {
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 0.1rem 0.4rem;
-  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--color-text-muted);
 }
 
-.discussion-card__pinned {
-  background: var(--color-accent-light);
-  color: var(--color-accent-hover);
+.discussion-card__locked::before {
+  content: "🔒";
+  font-size: 0.72rem;
 }
 
 /* Unread indicator — small burgundy dot in the meta row when the thread
-   has activity since the user's last visit. Only shows for users who have
-   visited before (first-time visitors don't see "unread" on every card). */
+   has activity since the user's last visit. Static (no pulse) so the page
+   doesn't twitch with motion when several threads are unread. */
 .discussion-card__unread-dot {
   display: inline-block;
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: var(--color-primary);
   flex-shrink: 0;
-  /* Subtle pulse so the dot reads as "fresh" without being aggressive */
-  animation: discussion-card-unread-pulse 2.4s ease-in-out infinite;
-}
-
-@keyframes discussion-card-unread-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.55; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .discussion-card__unread-dot { animation: none; }
-}
-
-.discussion-card__locked {
-  background: #fee2e2;
-  color: #991b1b;
 }
 
 .discussion-card__title {
-  margin: 0 0 0.35rem;
-  font-size: 1.05rem;
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
   font-weight: 600;
-  line-height: 1.3;
+  line-height: 1.4;
+  color: var(--color-text);
 }
 
+/* Wine reference chip on the list row — quiet, mostly text, single-line. */
 .discussion-card__wine-tag {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.35rem;
   font-size: 0.78rem;
-  padding: 0.15rem 0.5rem;
-  background: var(--color-surface-hover, #f5f5f5);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.5rem;
   color: var(--color-text-secondary);
   white-space: nowrap;
   overflow: hidden;
@@ -122,25 +108,25 @@
 }
 
 .discussion-card__wine-dot {
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   flex-shrink: 0;
-  background: var(--color-text-secondary);
+  background: var(--color-text-muted);
 }
 
-.discussion-card__wine-dot.red       { background: #c0392b; }
-.discussion-card__wine-dot.white     { background: #d4ac0d; }
-.discussion-card__wine-dot.rosé      { background: #e91e8c; }
-.discussion-card__wine-dot.sparkling { background: #f39c12; }
-.discussion-card__wine-dot.dessert   { background: #8e44ad; }
-.discussion-card__wine-dot.fortified { background: #27ae60; }
+.discussion-card__wine-dot.red       { background: #8B2635; }
+.discussion-card__wine-dot.white     { background: #C9A646; }
+.discussion-card__wine-dot.rosé      { background: #D17B8F; }
+.discussion-card__wine-dot.sparkling { background: #D4A373; }
+.discussion-card__wine-dot.dessert   { background: #6B3F8B; }
+.discussion-card__wine-dot.fortified { background: #4A7B4A; }
 
 .discussion-card__body {
-  margin: 0 0 0.6rem;
-  font-size: 0.88rem;
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
   color: var(--color-text-secondary);
-  line-height: 1.5;
+  line-height: 1.55;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -150,8 +136,8 @@
 .discussion-card__op {
   display: flex;
   align-items: center;
-  font-size: 0.82rem;
-  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
 }
 
 .discussion-card__author {
@@ -168,7 +154,7 @@
 
 .discussion-card__author-link:hover {
   text-decoration: underline;
-  color: var(--color-primary);
+  color: var(--color-text);
 }
 
 .discussion-card__author-link--deleted {
@@ -188,34 +174,38 @@
 }
 
 .discussion-card__avatar {
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
-  background: var(--color-primary);
-  color: #fff;
+  /* Quieter than the original solid burgundy — a tinted background with
+     the brand colour as foreground reads as "wine-club discreet" rather
+     than "tech-startup loud". */
+  background: var(--color-primary-light);
+  color: var(--color-primary);
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: 0.74rem;
+  font-size: 0.72rem;
   flex-shrink: 0;
 }
 
 .discussion-card__avatar--deleted {
-  background: var(--color-text-muted);
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
 }
 
 .discussion-card__last-poster-meta {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.05rem;
-  line-height: 1.2;
+  gap: 0;
+  line-height: 1.25;
 }
 
 .discussion-card__last-poster-name {
   font-weight: 500;
-  font-size: 0.82rem;
+  font-size: 0.8rem;
   color: var(--color-text);
   max-width: 9rem;
   overflow: hidden;
@@ -223,30 +213,36 @@
 }
 
 .discussion-card__time {
-  color: var(--color-text-secondary);
-  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
 }
 
 .discussion-card__replies {
   display: flex;
   align-items: center;
   gap: 0.3rem;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
 }
 
 .discussion-card__reply-count {
   font-weight: 600;
   font-variant-numeric: tabular-nums;
+  color: var(--color-text-secondary);
 }
 
-.badge--mod {
-  background: #d1fae5;
-  color: #065f46;
-  font-size: 0.65rem;
-  padding: 0.05rem 0.35rem;
-  border-radius: 4px;
+/* Mod/Admin in card header — neutral, mostly typography. The role isn't
+   a personality, just an annotation. */
+.badge--mod,
+.badge--admin {
+  font-size: 0.62rem;
   font-weight: 600;
   text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.05rem 0.35rem;
+  border-radius: 3px;
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
 }
 
 /* ── Mobile (≤ 600px) ──

--- a/frontend/src/components/DiscussionComposer.css
+++ b/frontend/src/components/DiscussionComposer.css
@@ -1,45 +1,54 @@
 .discussion-composer {
-  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.2));
-  border-radius: 6px;
-  background: var(--color-input-bg, #fff);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-input-bg);
+  transition: border-color var(--transition-fast);
+}
+
+.discussion-composer:focus-within {
+  border-color: var(--color-border-focus);
 }
 
 .discussion-composer__toolbar {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.15rem;
   padding: 0.4rem 0.5rem;
-  border-bottom: 1px solid var(--color-border, rgba(0, 0, 0, 0.08));
+  border-bottom: 1px solid var(--color-border-light, var(--color-border));
   flex-wrap: wrap;
+  background: var(--color-surface-hover);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
 }
 
 .discussion-composer__btn {
   background: transparent;
   border: 1px solid transparent;
-  color: var(--color-text, inherit);
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  color: var(--color-text-muted);
+  padding: 0.3rem 0.5rem;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 0.9rem;
   min-width: 1.8rem;
   line-height: 1;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .discussion-composer__btn:hover {
-  background: var(--color-button-hover, rgba(0, 0, 0, 0.05));
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .discussion-composer__btn.is-active {
-  background: var(--color-button-active, rgba(0, 0, 0, 0.1));
-  border-color: var(--color-border, rgba(0, 0, 0, 0.2));
+  background: var(--color-primary-light);
+  color: var(--color-primary);
 }
 
 .discussion-composer__sep {
   display: inline-block;
   width: 1px;
-  height: 1.2rem;
-  background: var(--color-border, rgba(0, 0, 0, 0.15));
-  margin: 0 0.25rem;
+  height: 1.1rem;
+  background: var(--color-border);
+  margin: 0 0.2rem;
 }
 
 .discussion-composer__content {
@@ -86,10 +95,10 @@
 
 .discussion-composer__counter {
   text-align: right;
-  font-size: 0.8rem;
-  color: var(--color-text-secondary, #888);
-  padding: 0.25rem 0.5rem;
-  border-top: 1px solid var(--color-border, rgba(0, 0, 0, 0.05));
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  padding: 0.3rem 0.6rem;
+  border-top: 1px solid var(--color-border-light, var(--color-border));
 }
 
 /* Read-only render styles for sanitized body output. Used wherever forum
@@ -112,11 +121,10 @@
 
 .discussion-body blockquote {
   margin: 1rem 0;
-  padding: 0.6rem 1rem;
-  border-left: 3px solid var(--color-accent);
-  background: var(--color-primary-light);
+  padding: 0.5rem 1rem;
+  border-left: 2px solid var(--color-border);
+  background: var(--color-surface-hover);
   color: var(--color-text-secondary);
-  font-style: italic;
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 

--- a/frontend/src/components/DiscussionsFeedWidget.css
+++ b/frontend/src/components/DiscussionsFeedWidget.css
@@ -9,17 +9,19 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.875rem;
 }
 
 .discussions-feed-widget__header h2 {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .discussions-feed-widget__see-all {
-  font-size: 0.95rem;
-  color: var(--color-primary, inherit);
+  font-size: 0.85rem;
+  color: var(--color-primary);
   text-decoration: none;
 }
 
@@ -33,12 +35,10 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
 }
 
 .discussions-feed-widget__item {
-  border-bottom: 1px solid var(--color-border, rgba(0, 0, 0, 0.08));
-  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border-light, var(--color-border));
 }
 
 .discussions-feed-widget__item:last-child {
@@ -51,19 +51,23 @@
   gap: 0.2rem;
   text-decoration: none;
   color: inherit;
-  padding: 0.4rem 0;
+  padding: 0.6rem 0.25rem;
+  transition: background var(--transition-fast);
+  border-radius: var(--radius-sm);
 }
 
 .discussions-feed-widget__link:hover {
-  background-color: rgba(0, 0, 0, 0.02);
+  background: var(--color-surface-hover);
 }
 
 .discussions-feed-widget__title {
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.95rem;
+  color: var(--color-text);
+  line-height: 1.4;
 }
 
 .discussions-feed-widget__meta {
-  font-size: 0.85rem;
-  color: var(--color-text-secondary, #666);
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
 }

--- a/frontend/src/components/ParticipantStack.css
+++ b/frontend/src/components/ParticipantStack.css
@@ -7,7 +7,7 @@
 
 .participant-stack__label {
   font-size: 0.78rem;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
@@ -19,22 +19,24 @@
   align-items: center;
 }
 
+/* Tinted avatars instead of solid burgundy — reads as "who's in the
+   room" without competing with the reply avatars on the same page. */
 .participant-stack__avatar,
 .participant-stack__overflow {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  background: var(--color-primary);
-  color: #fff;
+  background: var(--color-primary-light);
+  color: var(--color-primary);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: 0.72rem;
-  border: 2px solid var(--color-surface, #fff);
-  margin-left: -8px; /* overlap */
+  font-size: 0.7rem;
+  border: 2px solid var(--color-surface);
+  margin-left: -7px;
   cursor: default;
-  transition: transform 0.12s, z-index 0.12s;
+  transition: transform var(--transition-fast), z-index var(--transition-fast);
   position: relative;
   z-index: 1;
 }
@@ -50,12 +52,13 @@
 }
 
 .participant-stack__avatar--deleted {
-  background: var(--color-text-muted);
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
 }
 
 .participant-stack__overflow {
   background: var(--color-surface-hover);
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   font-weight: 600;
-  font-size: 0.7rem;
+  font-size: 0.68rem;
 }

--- a/frontend/src/components/ReactionPicker.css
+++ b/frontend/src/components/ReactionPicker.css
@@ -3,25 +3,27 @@
   display: inline-block;
 }
 
+/* Toggle: quiet ghost button. The dashed border read as "incomplete" —
+   solid border + neutral colour matches the surrounding action row. */
 .reaction-picker__toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.15rem;
-  padding: 0.2rem 0.5rem;
+  gap: 0.25rem;
+  padding: 0.18rem 0.55rem;
   background: transparent;
-  border: 1px dashed var(--color-border);
-  border-radius: 999px;
-  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  color: var(--color-text-muted);
   cursor: pointer;
   font-size: 0.85rem;
   line-height: 1;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .reaction-picker__toggle:hover:not(:disabled) {
   background: var(--color-surface-hover);
-  border-color: var(--color-primary);
-  color: var(--color-primary);
+  border-color: var(--color-text-muted);
+  color: var(--color-text);
 }
 
 .reaction-picker__toggle:disabled {
@@ -30,7 +32,7 @@
 }
 
 .reaction-picker__plus {
-  font-weight: 700;
+  font-weight: 600;
   font-size: 0.85rem;
 }
 
@@ -39,71 +41,90 @@
   bottom: calc(100% + 0.4rem);
   left: 0;
   z-index: 30;
-  background: var(--color-surface, #fff);
+  background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-md, 10px);
-  padding: 0.35rem;
-  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.08));
+  border-radius: var(--radius-md);
+  padding: 0.4rem;
+  box-shadow: var(--shadow-md);
   display: grid;
-  grid-template-columns: repeat(4, auto);
-  gap: 0.25rem;
-  min-width: 220px;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.15rem;
+  min-width: 240px;
 }
 
 .reaction-picker__option {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.2rem;
-  padding: 0.4rem 0.35rem;
+  gap: 0.15rem;
+  padding: 0.45rem 0.3rem;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm, 6px);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background 0.12s;
-  width: 3rem;
+  transition: background var(--transition-fast);
 }
 
-.reaction-picker__option:hover {
-  background: var(--color-primary-light);
+.reaction-picker__option:hover,
+.reaction-picker__option:focus-visible {
+  background: var(--color-surface-hover);
+  outline: none;
 }
 
 .reaction-picker__emoji {
-  font-size: 1.4rem;
+  font-size: 1.35rem;
   line-height: 1;
 }
 
 .reaction-picker__label {
-  font-size: 0.65rem;
-  color: var(--color-text-secondary);
+  font-size: 0.62rem;
+  color: var(--color-text-muted);
   text-align: center;
   line-height: 1.1;
+  letter-spacing: 0.01em;
 }
 
-/* Reaction chip — used in ReplyCard to render existing reactions inline. */
+/* Reaction chip — used in ReplyCard to render existing reactions inline.
+   Default state is transparent with a neutral border so several chips in
+   a row don't compete with the body text. "is-mine" gets the brand tint
+   so the user's own reactions remain easy to spot. */
 .reaction-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.3rem;
   padding: 0.18rem 0.55rem;
-  background: var(--color-surface-hover);
+  background: transparent;
   border: 1px solid var(--color-border);
-  border-radius: 999px;
-  font-size: 0.8rem;
+  border-radius: var(--radius-full);
+  font-size: 0.78rem;
   line-height: 1;
-  color: var(--color-text);
+  color: var(--color-text-secondary);
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .reaction-chip:hover {
-  background: var(--color-primary-light);
+  background: var(--color-surface-hover);
+  border-color: var(--color-text-muted);
+}
+
+.reaction-chip:disabled {
+  cursor: default;
+}
+
+.reaction-chip:disabled:hover {
+  background: transparent;
+  border-color: var(--color-border);
 }
 
 .reaction-chip.is-mine {
   background: var(--color-primary-light);
-  border-color: var(--color-primary);
+  border-color: var(--color-primary-light);
   color: var(--color-primary);
+}
+
+.reaction-chip.is-mine:hover {
+  border-color: var(--color-primary);
 }
 
 .reaction-chip__emoji {
@@ -113,10 +134,12 @@
 
 .reaction-chip__count {
   font-weight: 600;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
 }
 
-/* Mobile: panel hugs the bottom-left of the chip row instead of its toggle */
+/* Mobile: panel hugs to the bottom-left of the chip row instead of its
+   toggle, keeps the 4-column grid but lets each option breathe. */
 @media (max-width: 600px) {
   .reaction-picker__panel {
     grid-template-columns: repeat(4, 1fr);
@@ -126,7 +149,6 @@
   }
 
   .reaction-picker__option {
-    width: auto;
     min-width: 3rem;
   }
 }

--- a/frontend/src/components/ReplyCard.css
+++ b/frontend/src/components/ReplyCard.css
@@ -1,85 +1,83 @@
+/* Reply rows are dividers in a column, not cards. Dropping the hover
+   background keeps long threads calm — the action row already fades in
+   on hover/focus, that's signal enough. */
 .reply-card {
-  padding: 0.875rem 0;
-  /* Light cushioning on hover so the active reply reads as a discrete unit
-     and the action row's appearance doesn't feel jarring. */
-  border-radius: var(--radius-sm);
-  transition: background 0.12s ease;
-}
-
-.reply-card:hover {
-  background: var(--color-surface-hover, rgba(0, 0, 0, 0.02));
+  padding: 1rem 0;
 }
 
 .reply-card:not(:last-child) {
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border-light, var(--color-border));
 }
 
 .reply-card__header {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-bottom: 0.35rem;
+  margin-bottom: 0.5rem;
   flex-wrap: wrap;
 }
 
 .reply-card__author {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.45rem;
   text-decoration: none;
   color: inherit;
 }
 
 .reply-card__author:hover .reply-card__author-name {
-  text-decoration: underline;
+  color: var(--color-primary);
 }
 
 .reply-card__avatar {
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: var(--color-primary);
-  color: #fff;
+  /* Tinted background, brand colour as the initial. Quieter than a solid
+     burgundy fill — see DiscussionCard for the same treatment. */
+  background: var(--color-primary-light);
+  color: var(--color-primary);
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   flex-shrink: 0;
 }
 
 .reply-card__author-name {
-  font-weight: 500;
-  font-size: 0.88rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-text);
+  transition: color var(--transition-fast);
 }
 
 .reply-card__time {
   font-size: 0.78rem;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
 }
 
 .reply-card__edited {
   font-size: 0.75rem;
-  color: var(--color-text-secondary);
-  font-style: italic;
+  color: var(--color-text-muted);
 }
 
 .reply-card__quote {
-  margin: 0.25rem 0 0.5rem;
-  padding: 0.5rem 0.75rem;
-  border-left: 3px solid var(--color-primary, #6366f1);
-  background: var(--color-bg-secondary, #f9fafb);
+  margin: 0.5rem 0 0.75rem;
+  padding: 0.5rem 0.85rem;
+  border-left: 2px solid var(--color-border);
+  background: var(--color-surface-hover);
   color: var(--color-text-secondary);
-  font-size: 0.85rem;
-  line-height: 1.45;
-  border-radius: 0 4px 4px 0;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 
 .reply-card__quote-author {
   font-weight: 600;
   font-size: 0.78rem;
   margin-bottom: 0.2rem;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
 }
 
 .reply-card__quote-body {
@@ -91,25 +89,32 @@
   word-break: break-word;
 }
 
-/* Action row: Like stays always-visible (it's a count + interaction signal),
-   but the button-y secondary actions (Reply / Edit / Delete / Report / Ban)
-   fade in on hover or focus-within. Less button noise in long threads,
-   keyboard users still get full access via :focus-within. */
+/* Action row: reactions stay always-visible (they're the engagement
+   surface). Secondary actions (Reply / Edit / Delete / Report / Ban)
+   fade in on hover or focus-within so dense threads stay calm.
+   Touch devices skip the fade — see the @media (hover: none) block. */
 .reply-card__footer {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
-  min-height: 1.6rem; /* prevent height shift when actions appear */
+  gap: 0.85rem;
+  margin-top: 0.75rem;
+  min-height: 1.6rem;
 }
 
-/* Scoped to .reply-card so the same .reply-card__action-btn class used on
-   the OP action row stays visible. The OP is rendered inside
-   .discussion-detail__header, never inside .reply-card. */
+.reply-card__reactions {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+/* Scope opacity-fade to .reply-card so the same .reply-card__action-btn
+   class used on the OP action row stays visible. The OP is rendered
+   inside .discussion-detail__header, never inside .reply-card. */
 .reply-card .reply-card__action-btn,
 .reply-card .reply-card__ban-wrapper {
   opacity: 0;
-  transition: opacity 0.12s ease;
+  transition: opacity var(--transition-fast);
 }
 
 .reply-card:hover .reply-card__action-btn,
@@ -119,8 +124,6 @@
   opacity: 1;
 }
 
-/* Touch devices can't hover — always show actions there, otherwise the row
-   becomes invisible and unreachable on mobile. */
 @media (hover: none) {
   .reply-card .reply-card__action-btn,
   .reply-card .reply-card__ban-wrapper {
@@ -128,49 +131,15 @@
   }
 }
 
-.reply-card__like-btn {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  background: none;
-  border: none;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  padding: 0.2rem 0;
-  font-size: 0.82rem;
-  transition: color 0.15s;
-}
-
-.reply-card__like-btn:hover:not(:disabled) {
-  color: var(--color-primary);
-}
-
-.reply-card__like-btn.liked {
-  color: #e11d48;
-}
-
-.reply-card__like-btn:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.reply-card__likes-readonly {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  color: #e11d48;
-  font-size: 0.82rem;
-  padding: 0.2rem 0;
-}
-
 .reply-card__action-btn {
   background: none;
   border: none;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   padding: 0.2rem 0;
   font-size: 0.78rem;
-  transition: color 0.15s;
+  font-weight: 500;
+  transition: color var(--transition-fast);
 }
 
 .reply-card__action-btn:hover {
@@ -178,31 +147,34 @@
 }
 
 .reply-card__action-btn--danger:hover {
-  color: #e11d48;
+  color: var(--color-danger);
 }
 
 /* ── Deleted reply state ── */
 .reply-card--deleted {
-  opacity: 0.65;
+  opacity: 0.7;
 }
 
 .reply-card__avatar--deleted {
-  background: var(--color-text-secondary);
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
 }
 
 .reply-card__body--deleted {
   font-style: italic;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
 }
 
 .reply-card__deleted-badge {
-  font-size: 0.7rem;
+  font-size: 0.62rem;
   font-weight: 600;
   text-transform: uppercase;
+  letter-spacing: 0.05em;
   padding: 0.05rem 0.35rem;
-  border-radius: 4px;
-  background: #fee2e2;
-  color: #991b1b;
+  border-radius: 3px;
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
 }
 
 /* ── Ban menu ── */
@@ -214,13 +186,13 @@
   position: absolute;
   bottom: 100%;
   left: 0;
-  background: var(--color-bg, #fff);
+  background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
   padding: 0.25rem 0;
   z-index: 30;
-  min-width: 120px;
+  min-width: 130px;
 }
 
 .reply-card__ban-option {
@@ -229,36 +201,34 @@
   text-align: left;
   background: none;
   border: none;
-  padding: 0.35rem 0.75rem;
+  padding: 0.4rem 0.85rem;
   font-size: 0.82rem;
   cursor: pointer;
   color: var(--color-text);
 }
 
 .reply-card__ban-option:hover {
-  background: var(--color-bg-secondary, #f5f5f5);
-  color: #e11d48;
+  background: var(--color-surface-hover);
+  color: var(--color-danger);
 }
 
 /* ── Mobile (≤ 600px) ──
-   Touch devices already get always-visible actions via @media (hover: none),
-   but the buttons themselves need bigger tap targets. The action row also
-   uses comma-separated wrapping rather than a tight gap so it doesn't
-   overflow on narrow viewports. */
+   Bigger tap targets on the action row, and the row wraps on tight
+   widths so we don't overflow. Reactions row gets its own line above
+   the secondary actions on small screens by relying on flex-wrap. */
 @media (max-width: 600px) {
   .reply-card {
     padding: 1rem 0;
   }
 
   .reply-card__footer {
-    gap: 0.5rem 1rem;
+    gap: 0.6rem 1rem;
     flex-wrap: wrap;
   }
 
-  .reply-card__like-btn,
   .reply-card .reply-card__action-btn {
     padding: 0.4rem 0;
-    font-size: 0.88rem;
+    font-size: 0.85rem;
     min-height: 1.8rem;
   }
 

--- a/frontend/src/pages/DiscussionDetail.css
+++ b/frontend/src/pages/DiscussionDetail.css
@@ -1,57 +1,60 @@
 .discussion-detail {
-  max-width: 700px;
+  max-width: 760px;
   margin: 0 auto;
-  padding: 1.5rem 1rem;
+  padding: 1.25rem 1rem 2rem;
 }
 
 .discussion-detail__back {
   display: inline-block;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   text-decoration: none;
-  font-size: 0.88rem;
-  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  margin-bottom: 1.25rem;
 }
 
 .discussion-detail__back:hover {
-  color: var(--color-primary);
+  color: var(--color-text);
 }
 
 .discussion-detail__loading {
   text-align: center;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   padding: 2rem 0;
+  font-size: 0.9rem;
 }
 
-/* ── Header card (Original Post) ──
-   The OP gets a burgundy left accent bar so it reads as the "anchor" of the
-   thread — visually distinct from the replies that follow. Slightly more
-   generous padding signals "this is the main post." */
+/* ── Header (Original Post) ──
+   No card chrome, no left-bar, no tinted background — just generous
+   typography and a neutral divider before the replies. The "Original
+   Post" pill in the meta row carries the OP role on its own; doubling up
+   with a coloured stripe was visual stutter. */
 .discussion-detail__header {
-  padding: 1.5rem 1.5rem 1.25rem;
-  margin-bottom: 1.5rem;
-  border-left: 3px solid var(--color-primary);
+  padding: 0 0 1.5rem;
+  margin-bottom: 1.25rem;
+  border-bottom: 1px solid var(--color-border-light, var(--color-border));
 }
 
 .discussion-detail__meta {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
   flex-wrap: wrap;
 }
 
-/* "Original Post" pill — quiet on its own, but anchors the OP visually
-   alongside the category badge. */
+/* "Original Post" pill — neutral typography, no colour. The role is
+   self-evident from layout (it's the top post); the pill exists only to
+   match the visual rhythm with the category badge beside it. */
 .discussion-detail__op-pill {
   display: inline-block;
-  padding: 0.15rem 0.55rem;
-  background: var(--color-primary-light);
-  color: var(--color-primary);
-  font-size: 0.72rem;
+  padding: 0.1rem 0.5rem;
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
 }
 
 .discussion-detail__title-row {
@@ -59,7 +62,7 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.5rem;
 }
 
 .discussion-detail__title-row .discussion-detail__title {
@@ -69,20 +72,22 @@
 }
 
 .discussion-detail__title {
-  margin: 0 0 0.75rem;
-  font-size: 1.5rem;
+  margin: 0 0 0.5rem;
+  font-size: 1.625rem;
+  font-weight: 600;
   line-height: 1.25;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
+  color: var(--color-text);
 }
 
 .discussion-detail__author-line {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
   flex-wrap: wrap;
   font-size: 0.85rem;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
 }
 
 .discussion-detail__author-link {
@@ -90,7 +95,7 @@
   align-items: center;
   gap: 0.4rem;
   text-decoration: none;
-  color: inherit;
+  color: var(--color-text);
   font-weight: 500;
 }
 
@@ -98,27 +103,24 @@
   color: var(--color-primary);
 }
 
-.discussion-detail__time {
-  color: var(--color-text-secondary);
-}
-
+.discussion-detail__time,
 .discussion-detail__reply-count {
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
 }
 
 /* OP body uses the reading-mode .discussion-body styles inherited from
-   DiscussionComposer.css. Width-cap, line-height, blockquote and link styling
-   live there so reply bodies read identically. */
+   DiscussionComposer.css. Width-cap, line-height, blockquote and link
+   styling live there so reply bodies read identically. */
 .discussion-detail__body {
   word-break: break-word;
 }
 
 .discussion-detail__actions {
   display: flex;
-  gap: 0.75rem;
-  margin-top: 1rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--color-border);
+  gap: 0.6rem;
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border-light, var(--color-border));
 }
 
 /* ── Replies section ── */
@@ -127,12 +129,16 @@
 }
 
 .discussion-detail__section-title {
-  font-size: 1rem;
-  margin: 0 0 0.75rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  margin: 0 0 1rem;
 }
 
 .discussion-detail__no-replies {
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   font-size: 0.9rem;
   padding: 1rem 0;
 }
@@ -152,16 +158,16 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: 0.5rem;
+  margin-top: 0.6rem;
 }
 
 /* ── Quote preview above textarea ── */
 .discussion-detail__quote-preview {
-  border-left: 3px solid var(--color-primary, #6366f1);
-  background: var(--color-bg-secondary, #f9fafb);
+  border-left: 2px solid var(--color-border);
+  background: var(--color-surface-hover);
   padding: 0.5rem 0.75rem;
   margin-bottom: 0.75rem;
-  border-radius: 0 4px 4px 0;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   font-size: 0.85rem;
 }
 
@@ -170,14 +176,14 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.25rem;
-  color: var(--color-text-secondary);
-  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
 }
 
 .discussion-detail__quote-remove {
   background: none;
   border: none;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   font-size: 1.1rem;
   padding: 0 0.25rem;
@@ -185,14 +191,14 @@
 }
 
 .discussion-detail__quote-remove:hover {
-  color: var(--color-primary);
+  color: var(--color-text);
 }
 
 .discussion-detail__quote-preview-body {
   color: var(--color-text-secondary);
   white-space: pre-wrap;
   word-break: break-word;
-  line-height: 1.45;
+  line-height: 1.5;
   max-height: 4.5em;
   overflow: hidden;
 }
@@ -206,6 +212,12 @@
   list-style: none;
   cursor: pointer;
   display: inline-block;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.discussion-detail__wine-picker-toggle summary:hover {
+  color: var(--color-text);
 }
 
 .discussion-detail__wine-picker-toggle summary::-webkit-details-marker {
@@ -230,33 +242,31 @@
 
 .discussion-detail__locked-notice {
   padding: 1rem 1.25rem;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   text-align: center;
   font-size: 0.9rem;
+  background: var(--color-surface-hover);
+  border-radius: var(--radius-sm);
 }
 
-/* ── Mobile (≤ 600px) ──
-   Tighter outer padding, smaller title, less generous OP card padding so the
-   layout breathes naturally on phones. The reading-mode 68ch cap on
-   .discussion-body already adapts (viewports < 68ch just fall back to 100%). */
+/* ── Mobile (≤ 600px) ── */
 @media (max-width: 600px) {
   .discussion-detail {
-    padding: 1rem 0.75rem;
+    padding: 1rem 0.75rem 2rem;
   }
 
   .discussion-detail__header {
-    padding: 1.125rem 1rem 1rem;
+    padding-bottom: 1.125rem;
     margin-bottom: 1rem;
   }
 
   .discussion-detail__title {
-    font-size: 1.25rem;
+    font-size: 1.375rem;
     line-height: 1.3;
   }
 
   .discussion-detail__op-pill {
-    font-size: 0.68rem;
-    padding: 0.1rem 0.45rem;
+    font-size: 0.66rem;
   }
 
   .discussion-detail__actions {

--- a/frontend/src/pages/Discussions.css
+++ b/frontend/src/pages/Discussions.css
@@ -1,31 +1,33 @@
 .discussions-page {
-  max-width: 700px;
+  max-width: 760px;
   margin: 0 auto;
-  padding: 0 1rem 1.5rem;
+  padding: 1rem 1rem 2rem;
 }
 
 /* ── Header ── */
 .discussions__header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: 0.6rem;
+  margin-bottom: 1.25rem;
 }
 
 .discussions__header h1 {
   margin: 0;
   font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .discussions__beta-badge {
-  font-size: 0.65rem;
-  font-weight: 700;
+  font-size: 0.6rem;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.15rem 0.45rem;
-  border-radius: 4px;
-  background: var(--color-primary, #6366f1);
-  color: #fff;
+  letter-spacing: 0.06em;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
 }
 
 /* ── Search bar ── */
@@ -45,76 +47,87 @@
 .discussions__controls {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 1rem;
   margin-bottom: 1.25rem;
   flex-wrap: wrap;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--color-border-light, var(--color-border));
 }
 
 .discussions__filters {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
   flex: 1;
   min-width: 0;
 }
 
 .discussions__categories {
   display: flex;
-  gap: 0.35rem;
+  gap: 0.3rem;
   flex-wrap: wrap;
   align-items: center;
 }
 
+/* Filter chips: typography-led, neutral when inactive, brand-tinted when
+   active. No solid burgundy fill — that read as a button-bar which is
+   too loud for a calm filter row. */
 .discussions__cat-btn {
-  background: none;
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: 0.15rem 0.5rem;
-  font-size: 0.75rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  padding: 0.2rem 0.65rem;
+  font-size: 0.78rem;
   font-weight: 500;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .discussions__cat-btn:hover {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
+  color: var(--color-text);
+  background: var(--color-surface-hover);
 }
 
 .discussions__cat-btn.active {
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-  color: #fff;
+  background: var(--color-primary-light);
+  color: var(--color-primary);
 }
 
 .discussions__sort {
   width: auto;
   max-width: 160px;
-  padding: 0.3rem 0.5rem;
+  padding: 0.35rem 0.55rem;
   font-size: 0.82rem;
 }
 
 /* ── Content ── */
 .discussions__loading {
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   text-align: center;
   padding: 2rem 0;
+  font-size: 0.9rem;
 }
 
 .discussions__empty {
   text-align: center;
   padding: 3rem 1.5rem;
+  background: transparent;
+  border: 1px dashed var(--color-border);
+  box-shadow: none;
 }
 
 .discussions__empty h3 {
   margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
 }
 
 .discussions__empty p {
   color: var(--color-text-secondary);
   margin: 0;
+  font-size: 0.9rem;
 }
 
 .discussions__list {
@@ -149,20 +162,18 @@
 
 @media (max-width: 600px) {
   .discussions-page {
-    padding: 0 0.75rem 1.5rem;
+    padding: 0.75rem 0.75rem 2rem;
   }
 
   .discussions__controls {
     flex-direction: column;
+    align-items: stretch;
   }
 
   .discussions__controls .btn-primary {
     width: 100%;
   }
 
-  /* Search row stays inline but the small buttons collapse to icon-padding
-     on tight screens. The submit button retains its label so the meaning is
-     clear without an aria-label. */
   .discussions__search {
     gap: 0.4rem;
   }


### PR DESCRIPTION
## Summary

Pass over the forum's CSS to take the look from \"tech-startup loud\" to \"wine-club discreet\". Same components, calmer paint. Three principles:

1. **Typography does the work** — sizes, weights, and tracking carry hierarchy instead of colour.
2. **Colour is reserved for meaning** — wine burgundy stays as the only loud accent; everything else moves to neutral greys or desaturated category hues.
3. **Dividers replace card chrome** where rows are siblings — list rows and replies stop pretending to be standalone cards.

## What changed

**Colour discipline**
- Category badges: rainbow pastels → desaturated hue-only tints (plum, amber, slate, moss). Smaller, uppercase.
- Mod / Admin / Removed badges: drop green / red, become neutral grey uppercase chips.
- Pinned threads: drop the cream tint, keep only 📌 + accent left-bar.
- Locked threads: drop the red, neutral 🔒 + muted text.

**List page (\`DiscussionCard\`)**
- Rows read as typographic siblings, not standalone cards: no shadow at rest, lighter border, hover-only chrome.
- Avatars: solid burgundy fill → tinted bg with brand-coloured initials.
- Unread-dot pulse animation removed (twitched the page when many threads were unread).

**Thread page (\`DiscussionDetail\`)**
- OP had both a left-bar accent **and** a pill — kept the now-neutral \"ORIGINAL POST\" pill, dropped the burgundy stripe + tinted bg.
- Title bumped to 1.625rem with tighter tracking.
- \"Replies\" heading is now a small-caps section label, like Discourse / GitHub Discussions.
- Page max-width 700 → 760px so long titles have more room.

**Replies (\`ReplyCard\`)**
- Drop the hover-background entirely (was busy on long threads). Replies are dividers in a column.
- Quote blocks: neutral 2px grey bar + soft surface bg, no italics.
- Ban menu uses design-token shadow + radius.

**Reactions (\`ReactionPicker\`)**
- Solid border on the toggle (dashed read as \"incomplete\").
- Reaction chips: transparent with neutral border at rest; brand tint only when \`is-mine\` so your own reactions remain easy to spot.

**\`ParticipantStack\` + \`DiscussionsFeedWidget\` + composer** — same neutral-tint avatar treatment, smaller meta, focus-ring on the composer wrapper.

## Test plan

- [x] Frontend tests: \`npm test -- --watchAll=false\` → 256/256 passing
- [ ] Visual smoke: \`/community/discussions\` looks calmer, badges no longer compete with content
- [ ] Visual smoke: open a thread → OP reads as the anchor without coloured stripes; replies flow as a column with subtle dividers
- [ ] Visual smoke: react to a reply → \`is-mine\` chip is brand-tinted, others are neutral
- [ ] Dark mode: re-check all surfaces; tokens (\`--color-surface-hover\`, \`--color-border-light\`, \`--color-primary-light\`) already adapt

No JS or behaviour changes — purely look.