### PR TITLE
fix(security): address CodeQL findings — fast-uri override + discussions $eq guard

### DIFF
--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -71,8 +71,12 @@ router.get('/', optionalAuth, async (req, res) => {
     const query = (q || '').toString().trim();
 
     const filter = {};
+    // $eq forces literal-value comparison even though `category` is already
+    // gated by an allowlist (CATEGORIES.includes). CodeQL doesn't recognise
+    // Array.includes() as a taint cleanser, so the `$eq` keeps the
+    // `js/sql-injection` rule satisfied without changing behaviour.
     if (category && CATEGORIES.includes(category)) {
-      filter.category = category;
+      filter.category = { $eq: category };
     }
 
     // Meilisearch path: fuzzy match on title/body/authorName/wineName,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9196,9 +9196,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
   "overrides": {
     "yaml": "2.8.3",
     "serialize-javascript": "7.0.5",
-    "postcss": "8.5.10"
+    "postcss": "8.5.10",
+    "fast-uri": "3.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- Pin `fast-uri` to `3.1.2` via npm `overrides` to clear a transitive-dep CVE flagged by CodeQL / Dependabot.
- Wrap the discussions list-route category filter in `{ \$eq: category }` so CodeQL's `js/sql-injection` rule recognises the existing `CATEGORIES.includes()` allowlist as safe. **Runtime behaviour is unchanged** — the value was already gated.

## Test plan
- [ ] `cd frontend && npm install` — lockfile resolves cleanly with the new override.
- [ ] `cd backend && npm test` — existing route tests still pass.
- [ ] Smoke: `docker compose up --build`, hit `/api/discussions?category=general`, confirm results return as before.
- [ ] Re-run CodeQL on this branch; the two findings should clear.