### PR TITLE
feat(racks): add front+back depth to shelf rack (closes #383)

### DIFF
--- a/backend/src/models/Rack.js
+++ b/backend/src/models/Rack.js
@@ -16,7 +16,8 @@ const rackModuleSchema = new mongoose.Schema({
     moduleRows: { type: Number, min: 1, max: 10 },
     moduleCols: { type: Number, min: 1, max: 10 },
     bottlesPerCell: { type: Number, min: 1, max: 20 },
-    bottlesPerSection: { type: Number, min: 1, max: 30 }
+    bottlesPerSection: { type: Number, min: 1, max: 30 },
+    backCols: { type: Number, min: 0, max: 20 }
   },
   x:          { type: Number, default: 0 },
   y:          { type: Number, default: 0 },
@@ -34,7 +35,8 @@ const rackSchema = new mongoose.Schema({
     moduleRows: { type: Number, min: 1, max: 10 },
     moduleCols: { type: Number, min: 1, max: 10 },
     bottlesPerCell: { type: Number, min: 1, max: 20 },
-    bottlesPerSection: { type: Number, min: 1, max: 30 }
+    bottlesPerSection: { type: Number, min: 1, max: 30 },
+    backCols: { type: Number, min: 0, max: 20 }
   },
   // Modular rack fields (used when isModular is true)
   isModular: { type: Boolean, default: false },

--- a/backend/src/utils/rackGeometry.js
+++ b/backend/src/utils/rackGeometry.js
@@ -57,8 +57,9 @@ function totalSlots(type, rows, cols, typeConfig) {
     }
 
     case 'shelf': {
-      // Open case storage: rows × cols compartments, each holds bottlesPerCell bottles.
-      const cells = rows * cols;
+      // Open case storage: rows × cols front compartments + optional backCols back row per shelf.
+      const backCols = Math.max(0, typeConfig?.backCols || 0);
+      const cells = rows * (cols + backCols);
       const bpc = typeConfig?.bottlesPerCell || 1;
       return cells * bpc;
     }

--- a/frontend/src/components/racks/RackRenderer.js
+++ b/frontend/src/components/racks/RackRenderer.js
@@ -194,14 +194,14 @@ export default function RackRenderer({
           {/* Slots */}
           {(() => {
             const bpc = layout.bottlesPerCell || 1;
+            const backR = layout.backRadius;
 
             if (bpc === 1) {
-              // Standard: one position per visual circle
-              return layout.slots.map(({ position, cx, cy }) => (
+              return layout.slots.map(({ position, cx, cy, isBack }) => (
                 <SlotCircle
                   key={position}
                   position={position}
-                  cx={cx} cy={cy} R={R}
+                  cx={cx} cy={cy} R={isBack && backR ? backR : R}
                   slot={slotMap[position]}
                   isActive={activePos === position}
                   isHighlight={highlightPos === position}
@@ -215,31 +215,35 @@ export default function RackRenderer({
             const cellMap = {};
             layout.slots.forEach(s => {
               const key = `${s.cx},${s.cy}`;
-              if (!cellMap[key]) cellMap[key] = { cx: s.cx, cy: s.cy, positions: [] };
+              if (!cellMap[key]) cellMap[key] = { cx: s.cx, cy: s.cy, isBack: !!s.isBack, positions: [] };
               cellMap[key].positions.push(s.position);
             });
 
             const subOffsets = getSubOffsets(bpc, R);
             const subR = getSubRadius(bpc, R);
+            const backSubOffsets = backR ? getSubOffsets(bpc, backR) : subOffsets;
+            const backSubR = backR ? getSubRadius(bpc, backR) : subR;
 
-            return Object.values(cellMap).map(cell =>
-              cell.positions.map((pos, idx) => {
-                const off = subOffsets[idx] || { dx: 0, dy: 0 };
+            return Object.values(cellMap).map(cell => {
+              const useOff = cell.isBack ? backSubOffsets : subOffsets;
+              const useR = cell.isBack ? backSubR : subR;
+              return cell.positions.map((pos, idx) => {
+                const off = useOff[idx] || { dx: 0, dy: 0 };
                 return (
                   <SlotCircle
                     key={pos}
                     position={pos}
                     cx={cell.cx + off.dx}
                     cy={cell.cy + off.dy}
-                    R={subR}
+                    R={useR}
                     slot={slotMap[pos]}
                     isActive={activePos === pos}
                     isHighlight={highlightPos === pos}
                     onSlotClick={onSlotClick}
                   />
                 );
-              })
-            );
+              });
+            });
           })()}
         </svg>
       </div>
@@ -290,15 +294,21 @@ function SlotCircle({ position, cx, cy, R, slot, isActive, isHighlight, onSlotCl
 function ShelfLines({ layout, rack, isModular }) {
   if (!layout.slots.length) return null;
 
-  // Group slots by approximate Y coordinate to find row boundaries
   const R = SLOT_RADIUS;
-  const yValues = [...new Set(layout.slots.map(s => Math.round(s.cy)))].sort((a, b) => a - b);
-  if (yValues.length < 2) return null;
+  let lineYs;
+  if (layout.shelfYs && layout.shelfYs.length) {
+    lineYs = layout.shelfYs;
+  } else {
+    const yValues = [...new Set(layout.slots.map(s => Math.round(s.cy)))].sort((a, b) => a - b);
+    if (yValues.length < 2) return null;
+    lineYs = [];
+    for (let i = 0; i < yValues.length - 1; i++) {
+      lineYs.push((yValues[i] + yValues[i + 1]) / 2);
+    }
+  }
 
   const lines = [];
-  for (let i = 0; i < yValues.length - 1; i++) {
-    const midY = (yValues[i] + yValues[i + 1]) / 2;
-    // Shelf plank
+  lineYs.forEach((midY, i) => {
     lines.push(
       <rect
         key={`shelf-${i}`}
@@ -310,7 +320,6 @@ function ShelfLines({ layout, rack, isModular }) {
         rx={1}
       />
     );
-    // Front rail (thin line)
     lines.push(
       <line
         key={`rail-${i}`}
@@ -322,11 +331,12 @@ function ShelfLines({ layout, rack, isModular }) {
         strokeWidth={1}
       />
     );
-  }
+  });
 
-  // Scallop bumps between slots in each row (small vertical ticks)
+  // Scallop bumps between front-row slots only (back row sits above, no plank below it)
   const rowSlots = {};
   layout.slots.forEach(s => {
+    if (s.isBack) return;
     const ry = Math.round(s.cy);
     if (!rowSlots[ry]) rowSlots[ry] = [];
     rowSlots[ry].push(s);

--- a/frontend/src/components/racks/RackTypeSelector.js
+++ b/frontend/src/components/racks/RackTypeSelector.js
@@ -21,7 +21,7 @@ export const TYPE_DIMENSIONS = {
   triangle: { showRows: false, showCols: true,  defaultRows: 1, defaultCols: 5, colLabel: 'racks.baseWidthLabel' },
   stack:    { showRows: true,  showCols: false, defaultRows: 8, defaultCols: 1, rowLabel: 'racks.heightLabel' },
   cube:     { showRows: true,  showCols: true,  defaultRows: 2, defaultCols: 3, showModule: true },
-  shelf:    { showRows: true,  showCols: true,  defaultRows: 3, defaultCols: 2, showBottlesPerCell: true },
+  shelf:    { showRows: true,  showCols: true,  defaultRows: 3, defaultCols: 2, showBottlesPerCell: true, showBackCols: true },
 };
 
 export default function RackTypeSelector({ value, onChange }) {

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -103,7 +103,7 @@ function getBottleGeometry() {
 // ── Clickable bottle (no inline popup — info shown in side panel) ────
 // Rotation [PI/2, 0, 0] maps local Y→Z so bottle points into rack
 // with neck/foil sticking out the front (+Z).
-function Bottle({ position, wineType, slot, onBottleClick, highlighted }) {
+function Bottle({ position, wineType, slot, onBottleClick, highlighted, scale = 1 }) {
   const glassColor = GLASS_COLORS[wineType] || GLASS_COLORS.red;
   const wineColor = WINE_COLORS[wineType] || WINE_COLORS.red;
   const foilColor = FOIL_COLORS[wineType] || FOIL_COLORS.red;
@@ -116,7 +116,7 @@ function Bottle({ position, wineType, slot, onBottleClick, highlighted }) {
   };
 
   return (
-    <group position={position} rotation={[Math.PI / 2, 0, 0]}>
+    <group position={position} rotation={[Math.PI / 2, 0, 0]} scale={scale}>
       {/* Highlight glow ring behind the bottle */}
       {highlighted && (
         <mesh position={[0, -0.01, 0]}>
@@ -177,15 +177,15 @@ function Bottle({ position, wineType, slot, onBottleClick, highlighted }) {
 }
 
 // ── Empty slot (ring + invisible click disc at cubby opening) ────────
-function EmptySlot({ position, slotPosition, onClick }) {
+function EmptySlot({ position, slotPosition, onClick, isBack }) {
+  const zBase = RACK_DEPTH / 2 - 0.005 + (position[2] || 0);
+  const ringR = isBack ? (BOTTLE_RADIUS - 0.005) * 0.7 : BOTTLE_RADIUS - 0.005;
   return (
-    <group position={[position[0], position[1], RACK_DEPTH / 2 - 0.005]}>
-      {/* Visible ring */}
+    <group position={[position[0], position[1], zBase]}>
       <mesh>
-        <torusGeometry args={[BOTTLE_RADIUS - 0.005, 0.003, 6, 16]} />
-        <meshStandardMaterial color="#9A8A70" transparent opacity={0.3} />
+        <torusGeometry args={[ringR, 0.003, 6, 16]} />
+        <meshStandardMaterial color="#9A8A70" transparent opacity={isBack ? 0.2 : 0.3} />
       </mesh>
-      {/* Larger invisible click target covering the full cell area */}
       <mesh
         onClick={(e) => { e.stopPropagation(); onClick?.(slotPosition); }}
         onPointerOver={(e) => { if (onClick) { e.stopPropagation(); document.body.style.cursor = 'pointer'; } }}
@@ -307,6 +307,48 @@ function computeTriangleSlotPositions(cols, width, height) {
   return positions;
 }
 
+// Shelf with optional back row.
+// Standard two-deep storage: both rows at the same shelf height, both with
+// necks toward the viewer; the back row is positioned deeper in the rack and
+// staggered in x so its necks peek between the front bottles.
+function computeShelfSlotPositions(rows, cols, backCols, width, height) {
+  const positions = [];
+  const cW = width / cols;
+  const cH = height / rows;
+  const hasBack = backCols > 0;
+  const frontBottleZ = -0.08;
+  const backBottleZ = -0.26;
+  const frontEmptyZ = 0;
+  const backEmptyZ = -0.18;
+  let pos = 1;
+  for (let r = 0; r < rows; r++) {
+    const y = height / 2 - cH / 2 - r * cH;
+    for (let c = 0; c < cols; c++) {
+      positions.push({
+        position: pos++,
+        x: -width / 2 + cW / 2 + c * cW,
+        y,
+        z: frontEmptyZ,
+        bottleZ: frontBottleZ,
+        isBack: false,
+      });
+    }
+    if (hasBack) {
+      for (let c = 0; c < backCols; c++) {
+        positions.push({
+          position: pos++,
+          x: -width / 2 + cW / 2 + (c + 0.5) * cW,
+          y,
+          z: backEmptyZ,
+          bottleZ: backBottleZ,
+          isBack: true,
+        });
+      }
+    }
+  }
+  return positions;
+}
+
 // Stack: single column
 function computeStackSlotPositions(rows, height) {
   const cH = height / rows;
@@ -378,7 +420,8 @@ export default function RackMesh({
   const rackScale = scaleOverride || 1;
   const defaultWidth = displayCols * CELL_W + PANEL_THICK * 2;
   const width = widthOverride || defaultWidth;
-  const depth = depthOverride || RACK_DEPTH;
+  const hasShelfBack = rackType === 'shelf' && (rack.typeConfig?.backCols || 0) > 0;
+  const depth = depthOverride || (hasShelfBack ? RACK_DEPTH * 1.7 : RACK_DEPTH);
   const height = displayRows * CELL_H + PANEL_THICK * 2;
   const innerW = (width - PANEL_THICK * 2);
   const effectiveCellW = innerW / displayCols;
@@ -408,7 +451,10 @@ export default function RackMesh({
       }
       case 'triangle': { const b = Math.max(1, rack.cols || 1); return (b * (b + 1)) / 2; }
       case 'stack': return rack.rows || 4;
-      case 'shelf': return displayRows * displayCols * bpc;
+      case 'shelf': {
+        const backCols = rack.typeConfig?.backCols || 0;
+        return displayRows * (displayCols + backCols) * bpc;
+      }
       default: return displayRows * displayCols;
     }
   }, [rack.isModular, rack.modules, rack.typeConfig, rackType, rack.rows, rack.cols, displayRows, displayCols]);
@@ -418,8 +464,11 @@ export default function RackMesh({
     if (rackType === 'hex') return computeHexSlotPositions(rack.rows || 4, rack.cols || 4, innerW, innerH);
     if (rackType === 'triangle') return computeTriangleSlotPositions(rack.cols || 1, innerW, innerH);
     if (rackType === 'stack') return computeStackSlotPositions(rack.rows || 4, innerH);
+    if (rackType === 'shelf') return computeShelfSlotPositions(
+      displayRows, displayCols, rack.typeConfig?.backCols || 0, innerW, innerH
+    );
     return computeSlotPositions(displayRows, displayCols, innerW, innerH);
-  }, [rackType, rack.rows, rack.cols, displayRows, displayCols, innerW, innerH]);
+  }, [rackType, rack.rows, rack.cols, displayRows, displayCols, innerW, innerH, rack.typeConfig?.backCols]);
 
   const edgesGeom = useMemo(() => {
     const sw = width * rackScale, sh = height * rackScale, sd = depth * rackScale;
@@ -635,21 +684,22 @@ export default function RackMesh({
       })()}
 
       {/* ── Bottles / empty slots ─────────────────── */}
-      {slotPositions.map(({ position: pos, x, y }) => {
+      {slotPositions.map(({ position: pos, x, y, z = 0, bottleZ, isBack }) => {
         const slot = slotMap[pos];
         const filled = !!slot;
         const wineType = slot?.bottle?.wineDefinition?.type || 'red';
+        const finalBottleZ = bottleZ !== undefined ? bottleZ : (-0.08 + z);
         return filled ? (
           <Bottle
             key={pos}
-            position={[x, y, -0.08]}
+            position={[x, y, finalBottleZ]}
             wineType={wineType}
             slot={slot}
             onBottleClick={onBottleClick}
             highlighted={highlightBottleId && (slot.bottle?._id || slot.bottle) === highlightBottleId}
           />
         ) : (
-          <EmptySlot key={pos} position={[x, y, 0]} slotPosition={pos} onClick={onEmptySlotClick} />
+          <EmptySlot key={pos} position={[x, y, z]} slotPosition={pos} onClick={onEmptySlotClick} isBack={isBack} />
         );
       })}
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -441,6 +441,7 @@
     "typeLabel": "Rack Type",
     "totalSlots": "Total slots",
     "bottlesPerCellLabel": "Bottles per cell",
+    "backColsLabel": "Back row bottles (per shelf)",
     "filled": "filled",
     "type_grid": "Grid",
     "type_x-rack": "X-Rack",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -441,6 +441,7 @@
     "typeLabel": "Hylltyp",
     "totalSlots": "Totala platser",
     "bottlesPerCellLabel": "Flaskor per fack",
+    "backColsLabel": "Bakre rad (flaskor per hylla)",
     "filled": "fyllda",
     "type_grid": "Rutnät",
     "type_x-rack": "X-hylla",

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -149,7 +149,7 @@ function CellarRacks() {
       typeConfig: type === 'cube'
         ? { moduleRows: 2, moduleCols: 2 }
         : type === 'x-rack' ? { bottlesPerSection: 10 }
-        : type === 'shelf' ? { bottlesPerCell: 1 } : {},
+        : type === 'shelf' ? { bottlesPerCell: 1, backCols: 0 } : {},
     }));
   };
 
@@ -479,6 +479,21 @@ function NewRackForm({ newRack, setNewRack, onTypeChange, onSubmit, saving }) {
               onChange={e => setNewRack({
                 ...newRack,
                 typeConfig: { ...newRack.typeConfig, bottlesPerCell: parseInt(e.target.value) || 1 }
+              })}
+            />
+          </div>
+        )}
+
+        {dims.showBackCols && (
+          <div className="form-group">
+            <label>{t('racks.backColsLabel', 'Back row bottles (per shelf)')}</label>
+            <input
+              type="number"
+              min={0} max={20}
+              value={newRack.typeConfig?.backCols ?? 0}
+              onChange={e => setNewRack({
+                ...newRack,
+                typeConfig: { ...newRack.typeConfig, backCols: Math.max(0, parseInt(e.target.value) || 0) }
               })}
             />
           </div>

--- a/frontend/src/utils/rackLayouts.js
+++ b/frontend/src/utils/rackLayouts.js
@@ -230,26 +230,64 @@ function cubeLayout(rows, cols, typeConfig) {
 }
 
 // ── Shelf (open case storage) ────────────────────────────────────────
-// Same grid as 'grid' visually but each compartment holds bottlesPerCell bottles.
+// Grid of compartments; each holds bottlesPerCell bottles.
+// Optional backCols: staggered back row per shelf, dimmed/smaller for depth.
+const BACK_R = SLOT_R * 0.7;
+const BACK_INTRA_GAP = 22;
+
 function shelfLayout(rows, cols, typeConfig) {
   const bpc = typeConfig?.bottlesPerCell || 1;
+  const backCols = Math.max(0, typeConfig?.backCols || 0);
+  const hasBack = backCols > 0;
+
+  const compartmentH = hasBack
+    ? BACK_R * 2 + BACK_INTRA_GAP + CELL
+    : CELL;
+
   const slots = [];
+  const shelfYs = [];
   let pos = 1;
+
   for (let r = 0; r < rows; r++) {
+    const compartmentTopY = PADDING + r * compartmentH;
+    const frontCY = hasBack
+      ? compartmentTopY + BACK_R * 2 + BACK_INTRA_GAP + SLOT_R
+      : compartmentTopY + SLOT_R;
+    const backCY = compartmentTopY + BACK_R;
+
     for (let c = 0; c < cols; c++) {
       const cx = PADDING + SLOT_R + c * CELL;
-      const cy = PADDING + SLOT_R + r * CELL;
       for (let b = 0; b < bpc; b++) {
-        slots.push({ position: pos++, cx, cy });
+        slots.push({ position: pos++, cx, cy: frontCY });
       }
     }
+
+    if (hasBack) {
+      for (let c = 0; c < backCols; c++) {
+        const cx = PADDING + SLOT_R + (c + 0.5) * CELL;
+        for (let b = 0; b < bpc; b++) {
+          slots.push({ position: pos++, cx, cy: backCY, isBack: true });
+        }
+      }
+    }
+
+    if (r < rows - 1) {
+      shelfYs.push(compartmentTopY + compartmentH - SLOT_GAP / 2);
+    }
   }
+
+  const maxRightFront = cols > 0 ? PADDING + SLOT_R + (cols - 1) * CELL + SLOT_R : 0;
+  const maxRightBack = hasBack ? PADDING + SLOT_R + (backCols - 0.5) * CELL + BACK_R : 0;
+  const contentRight = Math.max(maxRightFront, maxRightBack);
+
   return {
     totalSlots: slots.length,
     bottlesPerCell: bpc,
+    backRadius: hasBack ? BACK_R : undefined,
+    shelfYs: hasBack ? shelfYs : undefined,
     viewBox: {
-      width:  PADDING * 2 + cols * CELL - SLOT_GAP,
-      height: PADDING * 2 + rows * CELL - SLOT_GAP,
+      width:  contentRight + PADDING,
+      height: PADDING * 2 + rows * compartmentH - SLOT_GAP,
     },
     slots,
   };
@@ -379,7 +417,8 @@ export function getTotalSlots(type, rows, cols, typeConfig) {
       return rows * cols * mr * mc;
     }
     case 'shelf': {
-      const cells = rows * cols;
+      const backCols = Math.max(0, typeConfig?.backCols || 0);
+      const cells = rows * (cols + backCols);
       const bpc = typeConfig?.bottlesPerCell || 1;
       return cells * bpc;
     }

--- a/frontend/src/utils/roomConstants.js
+++ b/frontend/src/utils/roomConstants.js
@@ -50,6 +50,15 @@ export function getRackHeight(rack) {
 }
 
 /**
+ * Default rack depth in metres. Two-deep shelves need extra depth to fit
+ * front + back bottles end-to-end inside the shelf.
+ */
+export function getDefaultRackDepth(rack) {
+  const hasShelfBack = rack.type === 'shelf' && (rack.typeConfig?.backCols || 0) > 0;
+  return hasShelfBack ? RACK_DEPTH * 1.7 : RACK_DEPTH;
+}
+
+/**
  * Compute world-space half-width/half-depth for a rack, accounting for
  * rotation and width/depth overrides from the placement.
  */
@@ -57,7 +66,7 @@ export function getRackWorldDims(rack, placement) {
   const { displayCols } = getDisplayDims(rack);
   const defaultW = displayCols * CELL_W + PANEL_THICK * 2;
   const w = placement.widthOverride || defaultW;
-  const d = placement.depthOverride || RACK_DEPTH;
+  const d = placement.depthOverride || getDefaultRackDepth(rack);
   const scale = placement.scaleOverride || 1;
   const rot = (placement.rotation || 0) % 360;
   const isRotated = rot === 90 || rot === 270;


### PR DESCRIPTION
## Summary

Closes #383. Adds an optional **back row** to the shelf rack type so users can model standard two-deep wine racks (front row of N bottles + staggered back row of M bottles per shelf). Keith's example layout — 18 shelves × (6 front + 5 back) = 198 bottles — now works out of the box.

## What changed

**Schema** — [`Rack.js`](backend/src/models/Rack.js) gains an optional `backCols` (0..20) field on `typeConfig`. Backward compatible: defaults to 0, existing shelves render unchanged.

**Slot math** — `totalSlots` for shelf is now `rows × (cols + backCols) × bottlesPerCell` on both [backend](backend/src/utils/rackGeometry.js) and [frontend](frontend/src/utils/rackLayouts.js). Slot numbering per row goes front first (1..cols), then back (cols+1..cols+backCols).

**2D rack view** ([`rackLayouts.js`](frontend/src/utils/rackLayouts.js), [`RackRenderer.js`](frontend/src/components/racks/RackRenderer.js)) — each shelf compartment contains the front row at the bottom and the staggered back row above it, rendered with a smaller radius to indicate depth. The renderer uses an explicit `shelfYs` array from the layout to draw the planks correctly between compartments.

**3D room view** ([`RackMesh.js`](frontend/src/components/room/RackMesh.js), [`roomConstants.js`](frontend/src/utils/roomConstants.js)) — rack depth scales 1.7× when `backCols > 0` so two bottles fit end-to-end. Both rows sit at the same shelf height with necks toward the viewer; the back row is staggered in x and positioned deeper in z so its necks peek between the front bottles (physically accurate two-deep storage).

**UI** ([`RackTypeSelector.js`](frontend/src/components/racks/RackTypeSelector.js), [`CellarRacks.js`](frontend/src/pages/CellarRacks.js)) — a new "Back row bottles (per shelf)" input appears under "Bottles per cell" when the shelf type is selected. Translated to Swedish ("Bakre rad (flaskor per hylla)").

## Test plan

- [ ] Existing shelves still render with `backCols = 0` (smoke test in Docker)
- [ ] Create a new shelf rack with Rows=18, Columns=6, Back row=5 → slot count reads 198
- [ ] 2D view shows two rows per shelf compartment, back row staggered and smaller
- [ ] 3D view shows back-row necks peeking between front-row necks at the same shelf height
- [ ] Slot click/assign works for both front- and back-row positions
- [ ] All frontend tests pass (256/256) and backend tests pass (435/435)