### PR TITLE
fix(chat): scope vector search to user + clear sessionStorage on logout (closes #385, #386)

### DIFF
--- a/backend/src/services/aiChat.js
+++ b/backend/src/services/aiChat.js
@@ -338,8 +338,26 @@ async function _prepareChatContext(userId, message, { useQueryExpansion = true, 
     if (!process.env.VOYAGE_API_KEY) {
       throw Object.assign(new Error('VOYAGE_API_KEY is not configured'), { status: 503 });
     }
-    const queryVector = await embedSingle(searchQuery, { model: cfg.embeddingModel });
-    const hits = await vectorStore.searchSimilar(cfg.vectorIndex, queryVector, cfg.chatTopK);
+
+    // Restrict Qdrant search to wines the user actually owns. Without this,
+    // top-K is pulled from the global catalogue and small cellars get filtered
+    // out entirely (see issue #386).
+    const bottleScope = { user: userId, status: 'active' };
+    if (cellarIds?.length) bottleScope.cellar = { $in: cellarIds };
+    const userWineDefIds = await Bottle.distinct('wineDefinition', bottleScope);
+
+    let hits = [];
+    if (userWineDefIds.length) {
+      const queryVector = await embedSingle(searchQuery, { model: cfg.embeddingModel });
+      hits = await vectorStore.searchSimilar(cfg.vectorIndex, queryVector, cfg.chatTopK, {
+        filter: {
+          must: [{
+            key: 'wineDefinitionId',
+            match: { any: userWineDefIds.map(id => id.toString()) }
+          }]
+        }
+      });
+    }
     matches = await filterToUserCellar(userId, hits, cfg.chatMaxResults, { cellarIds });
 
     // Enrich matches with maturity, price, and count data

--- a/backend/src/services/vectorStore.js
+++ b/backend/src/services/vectorStore.js
@@ -89,15 +89,20 @@ async function upsertPoints(indexVersion, points) {
  * @param {string}   indexVersion
  * @param {number[]} vector – query vector
  * @param {number}   topK   – number of results
+ * @param {object}   [options]
+ * @param {object}   [options.filter] – optional Qdrant payload filter (e.g.
+ *   { must: [{ key: 'wineDefinitionId', match: { any: ['…','…'] } }] })
  * @returns {Promise<Array<{ id: string, score: number, payload: object }>>}
  */
-async function searchSimilar(indexVersion, vector, topK = 50) {
+async function searchSimilar(indexVersion, vector, topK = 50, { filter } = {}) {
   const name = collectionName(indexVersion);
-  const result = await qdrantRequest('POST', `/collections/${name}/points/search`, {
+  const body = {
     vector,
     limit: topK,
     with_payload: true
-  });
+  };
+  if (filter) body.filter = filter;
+  const result = await qdrantRequest('POST', `/collections/${name}/points/search`, body);
   return (result.result || []).map(hit => ({
     id: hit.id,
     score: hit.score,

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -100,6 +100,9 @@ export const AuthProvider = ({ children }) => {
     } catch {
       // Best-effort; clear client state regardless
     }
+    // Wipe per-tab user state so chat history etc. don't bleed across logins.
+    // Only sessionStorage — localStorage holds theme / language / persisted token.
+    try { sessionStorage.clear(); } catch { /* noop */ }
     clearToken();
     setUser(null);
   }, []);

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -88,6 +88,7 @@
 
   "settings": {
     "title": "Settings",
+    "signedInAs": "Signed in as",
     "displayPreferences": "Display Preferences",
     "defaultCurrency": "Default Currency",
     "currencyHint": "Used as the default in bottle forms and price fields.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -88,6 +88,7 @@
 
   "settings": {
     "title": "Inställningar",
+    "signedInAs": "Inloggad som",
     "displayPreferences": "Visningsinställningar",
     "defaultCurrency": "Standardvaluta",
     "currencyHint": "Används som standard i flaskformulär och prisfält.",

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -32,6 +32,16 @@
   margin: 0.15rem 0 0.65rem 0;
 }
 
+.settings-email-display {
+  padding: 0.5rem 0.75rem;
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9rem;
+}
+
 .settings-select {
   max-width: 180px;
 }

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -291,6 +291,10 @@ function Settings() {
         <h2 className="settings-section-title">Profile</h2>
         <form onSubmit={handleProfileSave}>
           <div className="form-group">
+            <label>{t('settings.signedInAs', 'Signed in as')}</label>
+            <div className="settings-email-display">{user?.email || '—'}</div>
+          </div>
+          <div className="form-group">
             <label htmlFor="display-name-input">Display Name</label>
             <p className="settings-hint">
               How your name appears to other users. Leave blank to use your username.


### PR DESCRIPTION
Closes #385, #386.

## Summary

Three related fixes for the cellar chat:

### 1. Chat history leaked across logout/login (#385)

`cellarChat.messages` and `cellarChat.context` persist in `sessionStorage` and survived logout. When a second user logged in on the same tab, they saw the previous user's conversation, **and** the frontend shipped that history to Claude with the new user's question — contaminating the prompt with another user's wines.

**Fix:** call `sessionStorage.clear()` in `AuthContext.logout()`. `localStorage` is left alone (token / theme / i18n live there).

### 2. Chat returned "no matching wines" for small cellars (#386)

`vectorStore.searchSimilar` ran an unfiltered top-50 query against Qdrant, then `aiChat` post-filtered to the user's bottles. With ~1,800 wines in the catalogue and small per-user cellars (e.g. 74 bottles), the user's wines rarely made it into the global top 50, so the post-filter returned `[]` and Claude was told "no matches." The user-visible symptom: asking "vin till köttfärsås" with a Barbaresco 2019 in the cellar got back "Sorry, nothing in your cellar fits."

**Fix:** push the filter into Qdrant. Pre-fetch `Bottle.distinct('wineDefinition', { user, status: 'active', cellar? })` and pass it as a Qdrant payload `match.any` filter. Top-K is now drawn from the user's wines only, and the existing `filterToUserCellar` post-filter still runs for cellar-scope + enrichment.

Also short-circuits with `matches = []` when the user owns nothing in scope — saves an unnecessary embedding call.

### 3. Show "Signed in as <email>" on Settings

UX guard against future cross-user mishaps: surfaces the currently-logged-in email at the top of the Profile card. Translated en + sv.

## Files changed (7)

| File | Change |
|---|---|
| [`AuthContext.js`](frontend/src/contexts/AuthContext.js) | `sessionStorage.clear()` on logout |
| [`vectorStore.js`](backend/src/services/vectorStore.js) | `searchSimilar` accepts optional `{ filter }` |
| [`aiChat.js`](backend/src/services/aiChat.js) | Pre-fetch user wineDefIds, pass as Qdrant filter |
| [`Settings.js`](frontend/src/pages/Settings.js) + [`Settings.css`](frontend/src/pages/Settings.css) | "Signed in as" row at top of Profile card |
| `locales/en/translation.json`, `locales/sv/translation.json` | `settings.signedInAs` key |

## Test plan

- [ ] **Session isolation**: log in as User A, send a chat message, log out, log in as User B on the same tab → chat page starts empty
- [ ] **Small cellar finds bottles**: as `johan@cellarion.app` (74 bottles), ask "Vin till köttfärsås" → Barbaresco 2019 (or similar Italian red / Syrah pairing) is returned
- [ ] **Zero-bottle short-circuit**: a brand-new user with no bottles gets an empty wine list without an embed/Qdrant call
- [ ] **Cellar scope still works**: when a cellar filter is selected in the UI, only that cellar's wines are searched
- [ ] **Settings page** shows "Signed in as <email>"
- [ ] All 256 frontend + 435 backend tests still pass (already verified locally)