### PR TITLE
chore(release): v1.48.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.47.12",
+  "version": "1.48.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.47.12",
+  "version": "1.48.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Bumps both `package.json` files from `1.47.12` → `1.48.0` in preparation for the v1.48.0 release.

## Changes since v1.47.12

- #381 — refactor(frontend): migrate Create React App → Vite + Vitest
- #384 — feat(racks): add front+back depth to shelf rack type (closes #383)
- #387 — fix(chat): scope vector search to user's cellar + clear sessionStorage on logout (closes #385, #386)

Why minor bump (1.47 → 1.48):
- New user-facing feature (two-deep shelf storage).
- Toolchain refactor (Vite). Build/test paths change for contributors.
- Privacy bug fix (chat session leak) worth flagging in release notes.

## Test plan

- [x] All 256 frontend (Vitest) + 435 backend (Jest) tests pass
- [x] `docker compose build frontend` succeeds with the Vite-based Dockerfile
- [ ] GitHub Release workflow builds + publishes Docker images after the release is published
- [ ] `docker compose pull && up -d` on the VM picks up the new images