### PR TITLE
fix(auth): self-heal legacy notification shapes on User save (closes #390)

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -239,6 +239,43 @@ const userSchema = new mongoose.Schema({
 userSchema.index({ emailVerificationTokenHash: 1 }, { sparse: true });
 userSchema.index({ passwordResetTokenHash: 1 }, { sparse: true });
 
+// Heal legacy notification-pref shapes before save. Old docs stored
+// `drinkWindow: false` (single boolean); the current schema expects
+// `{ enabled, email, push }`. Without this, Mongoose generates dotted $set
+// sub-paths and MongoDB throws "Cannot create field 'email' in element
+// {drinkWindow: false}". See issue #390.
+//
+// Mutates `notif` in place. Returns the list of top-level keys that were
+// rewritten so the caller can markModified() each parent path — this forces
+// Mongoose to write a whole-object replacement instead of dotted sub-paths.
+function normalizeLegacyNotifications(notif) {
+  if (!notif) return [];
+  const changed = [];
+  if (typeof notif.drinkWindow === 'boolean') {
+    notif.drinkWindow = { enabled: notif.drinkWindow, email: false, push: false };
+    changed.push('drinkWindow');
+  }
+  for (const key of ['communityReply', 'communityMention', 'communityFollow']) {
+    if (typeof notif[key] === 'boolean') {
+      const truthy = notif[key];
+      notif[key] = key === 'communityFollow'
+        ? { push: truthy }
+        : { email: false, push: truthy };
+      changed.push(key);
+    }
+  }
+  return changed;
+}
+
+userSchema.pre('save', function(next) {
+  const notif = this.preferences && this.preferences.notifications;
+  const changed = normalizeLegacyNotifications(notif);
+  for (const key of changed) {
+    this.markModified('preferences.notifications.' + key);
+  }
+  next();
+});
+
 // Hash password before saving
 userSchema.pre('save', async function(next) {
   // Only hash if password is modified or new
@@ -326,3 +363,4 @@ userSchema.methods.toJSON = function() {
 };
 
 module.exports = mongoose.model('User', userSchema);
+module.exports.normalizeLegacyNotifications = normalizeLegacyNotifications;

--- a/backend/src/models/User.test.js
+++ b/backend/src/models/User.test.js
@@ -1,0 +1,101 @@
+const { normalizeLegacyNotifications } = require('./User');
+
+describe('normalizeLegacyNotifications', () => {
+  it('returns [] when notif is null/undefined', () => {
+    expect(normalizeLegacyNotifications(null)).toEqual([]);
+    expect(normalizeLegacyNotifications(undefined)).toEqual([]);
+  });
+
+  it('returns [] when notif has no fields', () => {
+    expect(normalizeLegacyNotifications({})).toEqual([]);
+  });
+
+  it('returns [] when all four fields are already objects (no migration needed)', () => {
+    const notif = {
+      drinkWindow:      { enabled: true,  email: false, push: false },
+      communityReply:   { email: false, push: true },
+      communityMention: { email: false, push: true },
+      communityFollow:  { push: true }
+    };
+    const before = JSON.parse(JSON.stringify(notif));
+    expect(normalizeLegacyNotifications(notif)).toEqual([]);
+    expect(notif).toEqual(before); // unchanged
+  });
+
+  describe('drinkWindow: bool → object', () => {
+    it('preserves a false value as enabled=false', () => {
+      const notif = { drinkWindow: false };
+      const changed = normalizeLegacyNotifications(notif);
+      expect(changed).toEqual(['drinkWindow']);
+      expect(notif.drinkWindow).toEqual({ enabled: false, email: false, push: false });
+    });
+
+    it('preserves a true value as enabled=true', () => {
+      const notif = { drinkWindow: true };
+      normalizeLegacyNotifications(notif);
+      expect(notif.drinkWindow).toEqual({ enabled: true, email: false, push: false });
+    });
+  });
+
+  describe('community fields: bool → object', () => {
+    it('communityReply: true → { email: false, push: true }', () => {
+      const notif = { communityReply: true };
+      expect(normalizeLegacyNotifications(notif)).toEqual(['communityReply']);
+      expect(notif.communityReply).toEqual({ email: false, push: true });
+    });
+
+    it('communityReply: false → { email: false, push: false }', () => {
+      const notif = { communityReply: false };
+      normalizeLegacyNotifications(notif);
+      expect(notif.communityReply).toEqual({ email: false, push: false });
+    });
+
+    it('communityMention: true → { email: false, push: true }', () => {
+      const notif = { communityMention: true };
+      normalizeLegacyNotifications(notif);
+      expect(notif.communityMention).toEqual({ email: false, push: true });
+    });
+
+    it('communityFollow: true → { push: true } (no email channel)', () => {
+      const notif = { communityFollow: true };
+      normalizeLegacyNotifications(notif);
+      expect(notif.communityFollow).toEqual({ push: true });
+    });
+
+    it('communityFollow: false → { push: false }', () => {
+      const notif = { communityFollow: false };
+      normalizeLegacyNotifications(notif);
+      expect(notif.communityFollow).toEqual({ push: false });
+    });
+  });
+
+  it('migrates all four fields when all are bools, returns each key', () => {
+    const notif = {
+      drinkWindow: false,
+      communityReply: true,
+      communityMention: false,
+      communityFollow: true
+    };
+    const changed = normalizeLegacyNotifications(notif);
+    expect(changed.sort()).toEqual([
+      'communityFollow', 'communityMention', 'communityReply', 'drinkWindow'
+    ]);
+    expect(notif.drinkWindow).toEqual({ enabled: false, email: false, push: false });
+    expect(notif.communityReply).toEqual({ email: false, push: true });
+    expect(notif.communityMention).toEqual({ email: false, push: false });
+    expect(notif.communityFollow).toEqual({ push: true });
+  });
+
+  it('only migrates the bool fields when mixed with already-object fields', () => {
+    const notif = {
+      drinkWindow: false,                                      // bool — should migrate
+      communityReply: { email: true, push: true },             // already object — preserve
+      communityMention: false,                                 // bool — should migrate
+      communityFollow: { push: false }                         // already object — preserve
+    };
+    const changed = normalizeLegacyNotifications(notif);
+    expect(changed.sort()).toEqual(['communityMention', 'drinkWindow']);
+    expect(notif.communityReply).toEqual({ email: true, push: true });
+    expect(notif.communityFollow).toEqual({ push: false });
+  });
+});


### PR DESCRIPTION
Closes #390.

## Summary

Pre-refactor user documents stored `preferences.notifications.drinkWindow` as a single boolean. The current schema declares it as `{ enabled, email, push }` with sub-field defaults. On login, `issueTokens()` → `user.save()` made Mongoose generate dotted `\$set` sub-paths for those defaults, and MongoDB rejected them because the existing value was a primitive — crashing every affected login with `500 Cannot create field 'email' in element {drinkWindow: false}`.

The production data was already healed via a one-time aggregation-update on the VM. **This PR prevents recurrence** by making the model self-heal on save.

## What changed

[`backend/src/models/User.js`](backend/src/models/User.js):

- Added a `normalizeLegacyNotifications(notif)` helper (exported for test). When it detects any of the four notification fields stored as a boolean, it rewrites the field in place to the current object shape and returns the list of mutated keys. Value preservation:
  - `drinkWindow: <bool>` → `{ enabled: <bool>, email: false, push: false }`
  - `communityReply: <bool>` → `{ email: false, push: <bool> }`
  - `communityMention: <bool>` → `{ email: false, push: <bool> }`
  - `communityFollow: <bool>` → `{ push: <bool> }` (no email channel by design)
- Added a new `pre('save')` hook that calls the helper and `markModified()`s each rewritten parent path. The `markModified` is the key bit — it forces Mongoose to write a whole-object replacement instead of dotted sub-paths, which is what blew up before.

[`backend/src/models/User.test.js`](backend/src/models/User.test.js) (new):

12 cases — null/undefined input, empty object, all-already-objects (no-op idempotency), each field boolean→object, value preservation (true vs false), and mixed shapes where some fields are bools and others are already objects.

## Why a `pre('save')` hook and not a one-time script

The one-time migration is already done in production. This hook protects against:
- Future imports that might write legacy shapes.
- Schema additions that introduce the same migration trap (a new sub-field with a default).
- Restoring from an old backup.

It's defensive code, not the primary fix.

## Tests

- Backend: **435 → 447** (12 new), all green.
- Frontend: unaffected, no changes.

## Test plan

- [x] `npm test` in `backend/` — 447/447 pass
- [ ] A login attempt for a user whose document has been manually re-set to `drinkWindow: false` succeeds and the document is upgraded.
- [ ] Existing users with the correct object shape see no behavioural change.