### PR TITLE
feat(prices): invert price tracking from opt-out to opt-in (closes #392)

### DIFF
--- a/backend/src/models/PriceTrackingRequest.js
+++ b/backend/src/models/PriceTrackingRequest.js
@@ -1,0 +1,58 @@
+const mongoose = require('mongoose');
+
+/**
+ * PriceTrackingRequest — opt-in marker for market-price tracking on a
+ * specific wine+vintage pair. Users explicitly request that sommeliers
+ * research and maintain a price history for the pair.
+ *
+ * Singleton per (wineDefinition, vintage) — multiple users requesting
+ * the same pair share one document and are stored in `requesters`. The
+ * somm queue surfaces one card per pair regardless of how many people
+ * asked, and all requesters get notified when a price is saved.
+ */
+const requesterSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  requestedAt: {
+    type: Date,
+    default: Date.now
+  },
+  note: {
+    type: String,
+    trim: true,
+    maxlength: [500, 'Note too long']
+  }
+}, { _id: false });
+
+const priceTrackingRequestSchema = new mongoose.Schema({
+  wineDefinition: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'WineDefinition',
+    required: true,
+    index: true
+  },
+  vintage: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  requesters: {
+    type: [requesterSchema],
+    default: []
+  },
+  firstRequestedAt: {
+    type: Date,
+    default: Date.now
+  },
+  lastRequestedAt: {
+    type: Date,
+    default: Date.now
+  }
+}, { timestamps: true });
+
+priceTrackingRequestSchema.index({ wineDefinition: 1, vintage: 1 }, { unique: true });
+
+module.exports = mongoose.model('PriceTrackingRequest', priceTrackingRequestSchema);

--- a/backend/src/models/PriceTrackingRequest.test.js
+++ b/backend/src/models/PriceTrackingRequest.test.js
@@ -1,0 +1,83 @@
+const mongoose = require('mongoose');
+const PriceTrackingRequest = require('./PriceTrackingRequest');
+
+describe('PriceTrackingRequest schema', () => {
+  const aWineId = new mongoose.Types.ObjectId();
+  const aUserId = new mongoose.Types.ObjectId();
+
+  it('accepts a minimal valid document', () => {
+    const doc = new PriceTrackingRequest({ wineDefinition: aWineId, vintage: '2018' });
+    const err = doc.validateSync();
+    expect(err).toBeUndefined();
+  });
+
+  it('requires wineDefinition', () => {
+    const doc = new PriceTrackingRequest({ vintage: '2018' });
+    const err = doc.validateSync();
+    expect(err).toBeDefined();
+    expect(err.errors.wineDefinition).toBeDefined();
+  });
+
+  it('requires vintage', () => {
+    const doc = new PriceTrackingRequest({ wineDefinition: aWineId });
+    const err = doc.validateSync();
+    expect(err).toBeDefined();
+    expect(err.errors.vintage).toBeDefined();
+  });
+
+  it('defaults requesters to an empty array', () => {
+    const doc = new PriceTrackingRequest({ wineDefinition: aWineId, vintage: '2018' });
+    expect(Array.isArray(doc.requesters)).toBe(true);
+    expect(doc.requesters).toHaveLength(0);
+  });
+
+  it('sets firstRequestedAt and lastRequestedAt by default', () => {
+    const before = Date.now();
+    const doc = new PriceTrackingRequest({ wineDefinition: aWineId, vintage: '2018' });
+    expect(doc.firstRequestedAt).toBeInstanceOf(Date);
+    expect(doc.lastRequestedAt).toBeInstanceOf(Date);
+    expect(doc.firstRequestedAt.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('accepts a requester with user, requestedAt, and note', () => {
+    const doc = new PriceTrackingRequest({
+      wineDefinition: aWineId,
+      vintage: '2018',
+      requesters: [{ user: aUserId, requestedAt: new Date(), note: 'Premier Cru worth watching' }]
+    });
+    const err = doc.validateSync();
+    expect(err).toBeUndefined();
+    expect(doc.requesters).toHaveLength(1);
+    expect(doc.requesters[0].user.toString()).toBe(aUserId.toString());
+    expect(doc.requesters[0].note).toBe('Premier Cru worth watching');
+  });
+
+  it('rejects requester note longer than 500 chars', () => {
+    const doc = new PriceTrackingRequest({
+      wineDefinition: aWineId,
+      vintage: '2018',
+      requesters: [{ user: aUserId, note: 'x'.repeat(501) }]
+    });
+    const err = doc.validateSync();
+    expect(err).toBeDefined();
+    // The error should be on the requesters subdocument's note field
+    expect(err.errors['requesters.0.note']).toBeDefined();
+  });
+
+  it('declares a unique (wineDefinition, vintage) compound index', () => {
+    const indexes = PriceTrackingRequest.schema.indexes();
+    const uniqueOnPair = indexes.find(([keys, opts]) =>
+      keys.wineDefinition === 1 && keys.vintage === 1 && opts?.unique === true
+    );
+    expect(uniqueOnPair).toBeDefined();
+  });
+
+  it('requesters subdoc has no _id field (clean shape)', () => {
+    const doc = new PriceTrackingRequest({
+      wineDefinition: aWineId,
+      vintage: '2018',
+      requesters: [{ user: aUserId }]
+    });
+    expect(doc.requesters[0]._id).toBeUndefined();
+  });
+});

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -6,6 +6,7 @@ const Cellar = require('../models/Cellar');
 const Rack = require('../models/Rack');
 const WineDefinition = require('../models/WineDefinition');
 const WineVintageProfile = require('../models/WineVintageProfile');
+const PriceTrackingRequest = require('../models/PriceTrackingRequest');
 const BottleImage = require('../models/BottleImage');
 const WineRequest = require('../models/WineRequest');
 const { getCellarRole } = require('../utils/cellarAccess');
@@ -524,6 +525,144 @@ router.delete('/:id', requireBottleAccess('editor'), async (req, res) => {
   } catch (error) {
     console.error('Delete bottle error:', error);
     res.status(500).json({ error: 'Failed to delete bottle' });
+  }
+});
+
+// POST /api/bottles/:id/request-price-tracking
+// Opt this wine+vintage in to sommelier price tracking. Idempotent — re-posting
+// from the same user updates their note + lastRequestedAt; the document is a
+// singleton per (wineDefinition, vintage) so multiple requesters share it.
+router.post('/:id/request-price-tracking', requireBottleAccess('viewer'), async (req, res) => {
+  try {
+    const { bottle } = req;
+    const userId = req.user.id;
+
+    if (!bottle.wineDefinition || !bottle.vintage || bottle.vintage === 'NV' || bottle.vintage === 'Unknown') {
+      return res.status(400).json({ error: 'This wine cannot be price-tracked (missing wine definition or vintage).' });
+    }
+
+    const note = typeof req.body?.note === 'string' ? req.body.note.trim().slice(0, 500) : undefined;
+    const now = new Date();
+
+    // Find-or-create the singleton, then add/update this user in requesters.
+    let request = await PriceTrackingRequest.findOne({
+      wineDefinition: bottle.wineDefinition,
+      vintage: bottle.vintage
+    });
+
+    if (!request) {
+      request = new PriceTrackingRequest({
+        wineDefinition: bottle.wineDefinition,
+        vintage: bottle.vintage,
+        requesters: [{ user: userId, requestedAt: now, note }],
+        firstRequestedAt: now,
+        lastRequestedAt: now
+      });
+    } else {
+      const existing = request.requesters.find(r => r.user.toString() === userId);
+      if (existing) {
+        existing.requestedAt = now;
+        if (note !== undefined) existing.note = note;
+      } else {
+        request.requesters.push({ user: userId, requestedAt: now, note });
+      }
+      request.lastRequestedAt = now;
+    }
+
+    await request.save();
+
+    logAudit(req, 'price.track_requested',
+      { type: 'wineDefinition', id: bottle.wineDefinition },
+      { vintage: bottle.vintage, bottleId: bottle._id }
+    );
+
+    res.json({
+      requested: true,
+      requesterCount: request.requesters.length,
+      firstRequestedAt: request.firstRequestedAt
+    });
+  } catch (error) {
+    if (error.code === 11000) {
+      // Duplicate key — concurrent create raced. Retry once.
+      return res.status(409).json({ error: 'Tracking request already exists — please retry.' });
+    }
+    console.error('Request price tracking error:', error);
+    res.status(500).json({ error: 'Failed to request price tracking' });
+  }
+});
+
+// DELETE /api/bottles/:id/request-price-tracking
+// Cancel this user's request. If they were the only requester, the singleton
+// is deleted entirely so the pair drops out of the somm queue.
+router.delete('/:id/request-price-tracking', requireBottleAccess('viewer'), async (req, res) => {
+  try {
+    const { bottle } = req;
+    const userId = req.user.id;
+
+    const request = await PriceTrackingRequest.findOne({
+      wineDefinition: bottle.wineDefinition,
+      vintage: bottle.vintage
+    });
+
+    if (!request) {
+      return res.json({ requested: false, requesterCount: 0 });
+    }
+
+    const before = request.requesters.length;
+    request.requesters = request.requesters.filter(r => r.user.toString() !== userId);
+
+    if (request.requesters.length === 0) {
+      await request.deleteOne();
+    } else if (request.requesters.length !== before) {
+      await request.save();
+    }
+
+    logAudit(req, 'price.track_cancelled',
+      { type: 'wineDefinition', id: bottle.wineDefinition },
+      { vintage: bottle.vintage, bottleId: bottle._id }
+    );
+
+    res.json({ requested: false, requesterCount: request.requesters.length });
+  } catch (error) {
+    console.error('Cancel price tracking error:', error);
+    res.status(500).json({ error: 'Failed to cancel price tracking' });
+  }
+});
+
+// GET /api/bottles/:id/request-price-tracking
+// Returns whether this user has an active request for this bottle's pair.
+router.get('/:id/request-price-tracking', requireBottleAccess('viewer'), async (req, res) => {
+  try {
+    const { bottle } = req;
+    const userId = req.user.id;
+
+    if (!bottle.wineDefinition || !bottle.vintage) {
+      return res.json({ requested: false, requesterCount: 0, eligible: false });
+    }
+    const eligible = bottle.vintage !== 'NV' && bottle.vintage !== 'Unknown';
+    if (!eligible) {
+      return res.json({ requested: false, requesterCount: 0, eligible: false });
+    }
+
+    const request = await PriceTrackingRequest.findOne({
+      wineDefinition: bottle.wineDefinition,
+      vintage: bottle.vintage
+    }).lean();
+
+    if (!request) {
+      return res.json({ requested: false, requesterCount: 0, eligible: true });
+    }
+
+    const mine = request.requesters.find(r => r.user.toString() === userId);
+    res.json({
+      requested: !!mine,
+      requesterCount: request.requesters.length,
+      firstRequestedAt: request.firstRequestedAt,
+      eligible: true
+    });
+  } catch (error) {
+    console.error('Get price tracking status error:', error);
+    res.status(500).json({ error: 'Failed to get tracking status' });
   }
 });
 

--- a/backend/src/routes/somm/prices.js
+++ b/backend/src/routes/somm/prices.js
@@ -222,13 +222,24 @@ router.post('/', requireSommOrAdmin, async (req, res) => {
     if (price === undefined || price === null || price === '') {
       return res.status(400).json({ error: 'price is required' });
     }
+    // Coerce + validate user-controlled values before they reach Mongo queries.
+    // Without this an attacker could pass an object like { $ne: null } as the
+    // vintage and turn an exact-match into a broad query.
+    if (!mongoose.isValidObjectId(wineDefinition)) {
+      return res.status(400).json({ error: 'Invalid wineDefinition ID' });
+    }
+    if (typeof vintage !== 'string') {
+      return res.status(400).json({ error: 'vintage must be a string' });
+    }
+    const wineDefId = String(wineDefinition);
+    const safeVintage = vintage.trim();
     const priceNum = parseFloat(price);
     if (isNaN(priceNum) || priceNum < 0) {
       return res.status(400).json({ error: 'price must be a non-negative number' });
     }
 
     // Verify the wine exists
-    const wineExists = await WineDefinition.exists({ _id: wineDefinition });
+    const wineExists = await WineDefinition.exists({ _id: wineDefId });
     if (!wineExists) {
       return res.status(404).json({ error: 'Wine definition not found' });
     }
@@ -238,8 +249,8 @@ router.post('/', requireSommOrAdmin, async (req, res) => {
     await getOrCreateDailySnapshot();
 
     const entry = new WineVintagePrice({
-      wineDefinition,
-      vintage,
+      wineDefinition: wineDefId,
+      vintage: safeVintage,
       price: priceNum,
       currency: currency || 'USD',
       source: source ? source.trim() : undefined,
@@ -252,7 +263,7 @@ router.post('/', requireSommOrAdmin, async (req, res) => {
 
     // Notify everyone who requested tracking for this pair (best-effort,
     // never block the response on it).
-    PriceTrackingRequest.findOne({ wineDefinition, vintage })
+    PriceTrackingRequest.findOne({ wineDefinition: wineDefId, vintage: safeVintage })
       .populate('wineDefinition', 'name producer')
       .then(request => {
         if (!request || !request.requesters.length) return;
@@ -260,7 +271,7 @@ router.post('/', requireSommOrAdmin, async (req, res) => {
           ? [request.wineDefinition.producer, request.wineDefinition.name].filter(Boolean).join(' — ')
           : 'wine';
         const title = 'Market price updated';
-        const body = `A sommelier just added a market price for ${wineLabel} ${vintage}: ${entry.currency} ${entry.price}.`;
+        const body = `A sommelier just added a market price for ${wineLabel} ${safeVintage}: ${entry.currency} ${entry.price}.`;
         for (const r of request.requesters) {
           createNotification(r.user, 'price_tracked', title, body, '/somm/prices');
         }

--- a/backend/src/routes/somm/prices.js
+++ b/backend/src/routes/somm/prices.js
@@ -2,139 +2,118 @@ const express = require('express');
 const mongoose = require('mongoose');
 const { requireAuth, requireSommOrAdmin } = require('../../middleware/auth');
 const WineVintagePrice = require('../../models/WineVintagePrice');
-const PriceTrackingSkip = require('../../models/PriceTrackingSkip');
+const PriceTrackingRequest = require('../../models/PriceTrackingRequest');
 const Bottle = require('../../models/Bottle');
 const WineDefinition = require('../../models/WineDefinition');
 const { getOrCreateDailySnapshot, getSnapshotsForDates } = require('../../utils/exchangeRates');
+const { createNotification } = require('../../services/notifications');
 
 const { suggestPrice } = require('../../services/labelScan');
-
-const User = require('../../models/User');
 
 const router = express.Router();
 
 router.use(requireAuth);
 
-const STALE_MS = 90 * 24 * 60 * 60 * 1000; // 3 months in milliseconds
+const STALE_MS = 90 * 24 * 60 * 60 * 1000; // 3 months
 
 /**
  * GET /api/somm/prices/queue
- * Returns wine+vintage pairs that have no price history, or whose most recent
- * price snapshot is older than 3 months. Somm/admin only.
+ * Returns user-requested wine+vintage pairs awaiting sommelier curation.
+ * Sorted by most-requested first, then oldest request. Somm/admin only.
+ *
+ * Each item carries: the wine, requester count, first requester username/note,
+ * latest price snapshot (if any, for staleness UI), and active-bottle count.
  */
 router.get('/queue', requireSommOrAdmin, async (req, res) => {
   try {
-    const staleThreshold = new Date(Date.now() - STALE_MS);
+    // Step 1: load every active tracking request, newest-requester populated
+    const requests = await PriceTrackingRequest.find({})
+      .populate({ path: 'wineDefinition', populate: [
+        { path: 'country', select: 'name' },
+        { path: 'region',  select: 'name' }
+      ]})
+      .populate('requesters.user', 'username')
+      .lean();
 
-    // Exclude bottles owned by the super admin (bulk imports / test data)
-    const superAdminEmail = (process.env.SUPER_ADMIN_EMAIL || '').toLowerCase().trim();
-    let excludeUserId = null;
-    if (superAdminEmail) {
-      const sa = await User.findOne({ email: superAdminEmail }).select('_id').lean();
-      if (sa) excludeUserId = sa._id;
-    }
+    if (requests.length === 0) return res.json({ queue: [] });
 
-    const bottleMatch = {
-      status: 'active',
-      wineDefinition: { $ne: null },
-      vintage: { $nin: ['NV', '', null] }
-    };
-    if (excludeUserId) bottleMatch.user = { $ne: excludeUserId };
+    // Drop any requests whose wine was deleted out from under them.
+    const validRequests = requests.filter(r => r.wineDefinition);
+    if (validRequests.length === 0) return res.json({ queue: [] });
 
-    // Step 1: unique (wineDefinition, vintage) pairs with at least one active bottle
-    const rawPairs = await Bottle.aggregate([
-      { $match: bottleMatch },
-      {
-        $group: {
-          _id: { wineDefinition: '$wineDefinition', vintage: '$vintage' },
-          bottleCount: { $sum: 1 }
-        }
-      }
-    ]);
-
-    if (rawPairs.length === 0) return res.json({ queue: [] });
-
-    // Step 1b: exclude wine+vintage pairs that have been skipped
-    const skips = await PriceTrackingSkip.find({}, 'wineDefinition vintage').lean();
-    const skipSet = new Set(skips.map(s => `${s.wineDefinition}:${s.vintage}`));
-    const activePairs = rawPairs.filter(p => !skipSet.has(`${p._id.wineDefinition}:${p._id.vintage}`));
-
-    if (activePairs.length === 0) return res.json({ queue: [] });
-
-    // Step 2: find the latest price snapshot for each pair in one aggregation
+    // Step 2: latest price snapshot per pair (for staleness display)
     const latestPrices = await WineVintagePrice.aggregate([
-      {
-        $group: {
+      { $group: {
           _id: { wineDefinition: '$wineDefinition', vintage: '$vintage' },
           latestSetAt:    { $last: '$setAt' },
           latestPrice:    { $last: '$price' },
           latestCurrency: { $last: '$currency' },
           latestSource:   { $last: '$source' }
-        }
-      }
+      }}
     ]);
+    const priceMap = new Map(latestPrices.map(lp => [
+      `${lp._id.wineDefinition}:${lp._id.vintage}`, lp
+    ]));
 
-    // Build lookup map
-    const priceMap = new Map();
-    for (const lp of latestPrices) {
-      const key = `${lp._id.wineDefinition}:${lp._id.vintage}`;
-      priceMap.set(key, lp);
-    }
+    // Step 3: bottle counts per pair (so somms see how many users are affected)
+    const bottleCounts = await Bottle.aggregate([
+      { $match: {
+          status: 'active',
+          wineDefinition: { $in: validRequests.map(r => r.wineDefinition._id) },
+          vintage: { $in: validRequests.map(r => r.vintage) }
+      }},
+      { $group: {
+          _id: { wineDefinition: '$wineDefinition', vintage: '$vintage' },
+          bottleCount: { $sum: 1 }
+      }}
+    ]);
+    const bottleCountMap = new Map(bottleCounts.map(b => [
+      `${b._id.wineDefinition}:${b._id.vintage}`, b.bottleCount
+    ]));
 
-    // Step 3: filter pairs that need attention
-    const needsUpdate = activePairs.filter(p => {
-      const key = `${p._id.wineDefinition}:${p._id.vintage}`;
-      const latest = priceMap.get(key);
+    // Filter to actionable items: no price history yet, OR latest price is stale (>3 months old).
+    const staleThreshold = new Date(Date.now() - STALE_MS);
+    const actionable = validRequests.filter(r => {
+      const latest = priceMap.get(`${r.wineDefinition._id}:${r.vintage}`);
       return !latest || latest.latestSetAt < staleThreshold;
     });
+    if (actionable.length === 0) return res.json({ queue: [] });
 
-    if (needsUpdate.length === 0) return res.json({ queue: [] });
-
-    // Step 4: populate wine definitions for the filtered pairs
-    const wineIds = [...new Set(needsUpdate.map(p => p._id.wineDefinition.toString()))];
-    const wines = await WineDefinition.find({ _id: { $in: wineIds } })
-      .populate('country', 'name')
-      .populate('region', 'name')
-      .lean();
-    const wineMap = new Map(wines.map(w => [w._id.toString(), w]));
-
-    const queue = needsUpdate.map(p => {
-      const key = `${p._id.wineDefinition}:${p._id.vintage}`;
+    const queue = actionable.map(r => {
+      const key = `${r.wineDefinition._id}:${r.vintage}`;
       const latest = priceMap.get(key);
+      const firstReq = r.requesters[0];
       return {
-        wineDefinition: wineMap.get(p._id.wineDefinition.toString()) || null,
-        vintage:       p._id.vintage,
-        bottleCount:   p.bottleCount,
-        latestPrice:   latest
+        requestId:      r._id,
+        wineDefinition: r.wineDefinition,
+        vintage:        r.vintage,
+        bottleCount:    bottleCountMap.get(key) || 0,
+        requesterCount: r.requesters.length,
+        firstRequestedAt: r.firstRequestedAt,
+        firstRequester:  firstReq ? { username: firstReq.user?.username, note: firstReq.note } : null,
+        latestPrice: latest
           ? { price: latest.latestPrice, currency: latest.latestCurrency, setAt: latest.latestSetAt, source: latest.latestSource }
           : null
       };
     });
 
-    // Sort: no history first, then by oldest update
+    // Sort: most requesters first, then oldest first-request
     queue.sort((a, b) => {
-      if (!a.latestPrice && !b.latestPrice) return 0;
-      if (!a.latestPrice) return -1;
-      if (!b.latestPrice) return 1;
-      return new Date(a.latestPrice.setAt) - new Date(b.latestPrice.setAt);
+      if (b.requesterCount !== a.requesterCount) return b.requesterCount - a.requesterCount;
+      return new Date(a.firstRequestedAt) - new Date(b.firstRequestedAt);
     });
 
-    // Step 5: batch-fetch rate snapshots for all latestPrice dates and attach them.
-    // This keeps conversion time-anchored without storing rates on every price document.
+    // Step 4: attach exchange-rate snapshots for time-anchored display
     const queueDates = [...new Set(
-      queue
-        .filter(item => item.latestPrice?.setAt)
-        .map(item => new Date(item.latestPrice.setAt).toISOString().slice(0, 10))
+      queue.filter(item => item.latestPrice?.setAt)
+           .map(item => new Date(item.latestPrice.setAt).toISOString().slice(0, 10))
     )];
     const snapshotMap = await getSnapshotsForDates(queueDates);
 
     const enrichedQueue = queue.map(item => {
       if (!item.latestPrice?.setAt) return item;
       const date = new Date(item.latestPrice.setAt).toISOString().slice(0, 10);
-      return {
-        ...item,
-        latestPrice: { ...item.latestPrice, exchangeRates: snapshotMap.get(date) || null }
-      };
+      return { ...item, latestPrice: { ...item.latestPrice, exchangeRates: snapshotMap.get(date) || null } };
     });
 
     res.json({ queue: enrichedQueue });
@@ -271,6 +250,23 @@ router.post('/', requireSommOrAdmin, async (req, res) => {
     await entry.save();
     await entry.populate('setBy', 'username');
 
+    // Notify everyone who requested tracking for this pair (best-effort,
+    // never block the response on it).
+    PriceTrackingRequest.findOne({ wineDefinition, vintage })
+      .populate('wineDefinition', 'name producer')
+      .then(request => {
+        if (!request || !request.requesters.length) return;
+        const wineLabel = request.wineDefinition
+          ? [request.wineDefinition.producer, request.wineDefinition.name].filter(Boolean).join(' — ')
+          : 'wine';
+        const title = 'Market price updated';
+        const body = `A sommelier just added a market price for ${wineLabel} ${vintage}: ${entry.currency} ${entry.price}.`;
+        for (const r of request.requesters) {
+          createNotification(r.user, 'price_tracked', title, body, '/somm/prices');
+        }
+      })
+      .catch(err => console.error('Notify price requesters failed:', err.message));
+
     res.status(201).json({ entry });
   } catch (error) {
     console.error('Add price entry error:', error);
@@ -279,56 +275,43 @@ router.post('/', requireSommOrAdmin, async (req, res) => {
 });
 
 /**
- * POST /api/somm/prices/skip
- * Mark a wine+vintage as not worth price tracking. Somm/admin only.
- * Body: { wineDefinition, vintage, reason }
+ * DELETE /api/somm/prices/requests/:requestId
+ * Decline a price tracking request. Removes the request entirely and notifies
+ * all requesters that their request was declined. Somm/admin only.
  */
-router.post('/skip', requireSommOrAdmin, async (req, res) => {
+router.delete('/requests/:requestId', requireSommOrAdmin, async (req, res) => {
   try {
-    const { wineDefinition, vintage, reason } = req.body;
-    if (!wineDefinition || !vintage) {
-      return res.status(400).json({ error: 'wineDefinition and vintage are required' });
+    const { requestId } = req.params;
+    if (!mongoose.isValidObjectId(requestId)) {
+      return res.status(400).json({ error: 'Invalid request ID' });
     }
-    if (!mongoose.Types.ObjectId.isValid(wineDefinition)) {
-      return res.status(400).json({ error: 'Invalid wineDefinition ID' });
+
+    const request = await PriceTrackingRequest.findById(requestId)
+      .populate('wineDefinition', 'name producer');
+    if (!request) {
+      return res.status(404).json({ error: 'Tracking request not found' });
     }
-    const safeVintage = String(vintage);
-    const safeReason = reason != null ? String(reason).slice(0, 500) : undefined;
 
-    const skip = await PriceTrackingSkip.findOneAndUpdate(
-      { wineDefinition, vintage: safeVintage },
-      { wineDefinition, vintage: safeVintage, reason: safeReason, skippedBy: req.user.id, skippedAt: new Date() },
-      { upsert: true, new: true }
-    );
+    const wineLabel = request.wineDefinition
+      ? [request.wineDefinition.producer, request.wineDefinition.name].filter(Boolean).join(' — ')
+      : 'this wine';
+    const title = 'Price tracking request declined';
+    const body = `Your request to track market price for ${wineLabel} ${request.vintage} was declined by a sommelier.`;
+    for (const r of request.requesters) {
+      createNotification(r.user, 'price_tracking_declined', title, body, null);
+    }
 
-    res.status(201).json({ skip });
+    await request.deleteOne();
+    res.json({ message: 'Tracking request declined' });
   } catch (error) {
-    console.error('Skip price tracking error:', error);
-    res.status(500).json({ error: 'Failed to skip price tracking' });
+    console.error('Decline tracking request error:', error);
+    res.status(500).json({ error: 'Failed to decline tracking request' });
   }
 });
 
-/**
- * DELETE /api/somm/prices/skip
- * Remove the skip flag for a wine+vintage, re-enabling price tracking. Somm/admin only.
- * Body: { wineDefinition, vintage }
- */
-router.delete('/skip', requireSommOrAdmin, async (req, res) => {
-  try {
-    const { wineDefinition, vintage } = req.body;
-    if (!wineDefinition || !vintage) {
-      return res.status(400).json({ error: 'wineDefinition and vintage are required' });
-    }
-    if (!mongoose.Types.ObjectId.isValid(wineDefinition)) {
-      return res.status(400).json({ error: 'Invalid wineDefinition ID' });
-    }
-
-    await PriceTrackingSkip.deleteOne({ wineDefinition, vintage: String(vintage) });
-    res.json({ message: 'Price tracking re-enabled' });
-  } catch (error) {
-    console.error('Unskip price tracking error:', error);
-    res.status(500).json({ error: 'Failed to re-enable price tracking' });
-  }
-});
+// NOTE: the old POST/DELETE /skip endpoints (used with PriceTrackingSkip) were
+// removed when the queue became opt-in. The replacement is
+// DELETE /api/somm/prices/requests/:id (above). PriceTrackingSkip docs are
+// no longer read by anything but the collection is left in place for audit.
 
 module.exports = router;

--- a/frontend/src/components/bottle/PriceTrackingToggle.js
+++ b/frontend/src/components/bottle/PriceTrackingToggle.js
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext';
+
+/**
+ * Lets the bottle owner opt in / opt out of sommelier price tracking
+ * for the wine+vintage pair this bottle belongs to. Renders nothing for
+ * ineligible bottles (NV, missing vintage, missing wineDefinition).
+ */
+export default function PriceTrackingToggle({ bottleId, vintage, hasHistory }) {
+  const { t } = useTranslation();
+  const { apiFetch } = useAuth();
+  const [status, setStatus] = useState(null);  // { requested, requesterCount, eligible, firstRequestedAt }
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Eligibility shortcut — don't even hit the API for NV/unknown
+  const eligibleClient = vintage && vintage !== 'NV' && vintage !== 'Unknown';
+
+  const load = useCallback(async () => {
+    if (!eligibleClient) {
+      setStatus({ requested: false, requesterCount: 0, eligible: false });
+      return;
+    }
+    try {
+      const res = await apiFetch(`/api/bottles/${bottleId}/request-price-tracking`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setStatus(data);
+    } catch {
+      // network blip — leave status null, hide UI
+    }
+  }, [apiFetch, bottleId, eligibleClient]);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (!status || !status.eligible) return null;
+
+  const toggle = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const method = status.requested ? 'DELETE' : 'POST';
+      const res = await apiFetch(`/api/bottles/${bottleId}/request-price-tracking`, { method });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed');
+      }
+      const data = await res.json();
+      setStatus(prev => ({ ...prev, ...data }));
+    } catch (err) {
+      setError(err.message || 'Failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const requested = !!status.requested;
+
+  return (
+    <div className="price-tracking-toggle">
+      <div className="price-tracking-toggle__row">
+        <div className="price-tracking-toggle__text">
+          <div className="price-tracking-toggle__label">
+            {requested
+              ? t('priceTracking.statusRequested', 'Market price tracking requested')
+              : hasHistory
+                ? t('priceTracking.statusHistoryOnly', 'Price tracking is no longer active')
+                : t('priceTracking.statusNotRequested', 'Track market price for this wine')}
+          </div>
+          <div className="price-tracking-toggle__hint">
+            {requested
+              ? t('priceTracking.hintRequested', 'A sommelier will research and add a price. You will be notified when it is set.')
+              : t('priceTracking.hintGuidance', 'Only worth requesting for bottles with a real secondary-market value — Bordeaux Premier Cru, Burgundy Grand Cru, age-worthy collectibles. Everyday wines usually do not have reliable market data.')}
+          </div>
+          {requested && status.requesterCount > 1 && (
+            <div className="price-tracking-toggle__count">
+              {t('priceTracking.requesterCount', '{{count}} other user(s) also requested this', { count: status.requesterCount - 1 })}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          className={`btn ${requested ? 'btn-secondary' : 'btn-primary'} price-tracking-toggle__btn`}
+          onClick={toggle}
+          disabled={busy}
+        >
+          {busy
+            ? t('priceTracking.saving', 'Saving…')
+            : requested
+              ? t('priceTracking.cancel', 'Cancel request')
+              : t('priceTracking.request', 'Request tracking')}
+        </button>
+      </div>
+      {error && <div className="price-tracking-toggle__error">{error}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/bottle/ViewDetails.js
+++ b/frontend/src/components/bottle/ViewDetails.js
@@ -10,6 +10,7 @@ import RatingDisplay from '../RatingDisplay';
 import ContributePrompt from './ContributePrompt';
 import MaturityPhaseTable from './MaturityPhaseTable';
 import PriceHistoryTimeline from './PriceHistoryTimeline';
+import PriceTrackingToggle from './PriceTrackingToggle';
 
 function ViewDetails({ bottle, rackInfo, cellarId, vintageProfile, priceHistory, rates, userCurrency, canEdit, hasImage, onEdit, onSuggestGrapes, onRemove, onReportWine }) {
   const { t } = useTranslation();
@@ -187,6 +188,11 @@ function ViewDetails({ bottle, rackInfo, cellarId, vintageProfile, priceHistory,
               {t('bottleDetail.reportPrice')}
             </button>
           )}
+          <PriceTrackingToggle
+            bottleId={bottle._id}
+            vintage={bottle.vintage}
+            hasHistory={!!(priceHistory && priceHistory.length > 0)}
+          />
         </div>
       )}
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -924,8 +924,28 @@
       "skipTracking": "Not worth tracking",
       "skipping": "Skipping…",
       "skipConfirm": "Mark this wine as not worth tracking for price evolution? It will be permanently removed from the queue.",
-      "skipTitle": "Remove from price queue — this wine doesn't need price tracking"
+      "skipTitle": "Remove from price queue — this wine doesn't need price tracking",
+      "declineRequest": "Decline request",
+      "declining": "Declining…",
+      "declineConfirm": "Decline this request? The user(s) who requested it will be notified.",
+      "declineTitle": "Decline this tracking request — the requester(s) will be notified.",
+      "requesterCount_one": "{{count}} requester",
+      "requesterCount_other": "{{count}} requesters",
+      "requesterNoteLabel": "Requester note"
     }
+  },
+
+  "priceTracking": {
+    "statusRequested": "Market price tracking requested",
+    "statusHistoryOnly": "Price tracking is no longer active",
+    "statusNotRequested": "Track market price for this wine",
+    "hintRequested": "A sommelier will research and add a price. You will be notified when it is set.",
+    "hintGuidance": "Only worth requesting for bottles with a real secondary-market value — Bordeaux Premier Cru, Burgundy Grand Cru, age-worthy collectibles. Everyday wines usually don't have reliable market data.",
+    "requesterCount_one": "{{count}} other user also requested this",
+    "requesterCount_other": "{{count}} other users also requested this",
+    "request": "Request tracking",
+    "cancel": "Cancel request",
+    "saving": "Saving…"
   },
 
   "statistics": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -924,8 +924,28 @@
       "skipTracking": "Inte värd att följa",
       "skipping": "Hoppar över…",
       "skipConfirm": "Markera detta vin som inte värt att följa för prisutveckling? Det tas permanent bort från kön.",
-      "skipTitle": "Ta bort från priskön — detta vin behöver ingen prisbevakning"
+      "skipTitle": "Ta bort från priskön — detta vin behöver ingen prisbevakning",
+      "declineRequest": "Avslå förfrågan",
+      "declining": "Avslår…",
+      "declineConfirm": "Avslå denna förfrågan? Användaren/användarna som begärde den meddelas.",
+      "declineTitle": "Avslå denna prisbevakningsförfrågan — användaren/användarna meddelas.",
+      "requesterCount_one": "{{count}} användare har begärt",
+      "requesterCount_other": "{{count}} användare har begärt",
+      "requesterNoteLabel": "Förfrågans kommentar"
     }
+  },
+
+  "priceTracking": {
+    "statusRequested": "Marknadsprisbevakning begärd",
+    "statusHistoryOnly": "Prisbevakning är inte längre aktiv",
+    "statusNotRequested": "Bevaka marknadspris för detta vin",
+    "hintRequested": "En sommelier kommer att undersöka och lägga till ett pris. Du meddelas när det är satt.",
+    "hintGuidance": "Bara värt att begära för flaskor med riktigt andrahandsvärde — Bordeaux Premier Cru, Burgundy Grand Cru, lagringsvärda samlarviner. Vardagsviner har sällan tillförlitlig marknadsdata.",
+    "requesterCount_one": "{{count}} annan användare har också begärt detta",
+    "requesterCount_other": "{{count}} andra användare har också begärt detta",
+    "request": "Begär bevakning",
+    "cancel": "Avbryt förfrågan",
+    "saving": "Sparar…"
   },
 
   "statistics": {

--- a/frontend/src/pages/BottleDetail.css
+++ b/frontend/src/pages/BottleDetail.css
@@ -1152,3 +1152,47 @@
   justify-content: flex-end;
 }
 
+/* Price-tracking opt-in card inside the Price Evolution section */
+.price-tracking-toggle {
+  margin-top: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+.price-tracking-toggle__row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+.price-tracking-toggle__text {
+  flex: 1 1 220px;
+  min-width: 0;
+}
+.price-tracking-toggle__label {
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--color-text);
+}
+.price-tracking-toggle__hint {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  line-height: 1.35;
+}
+.price-tracking-toggle__count {
+  margin-top: 0.35rem;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+.price-tracking-toggle__btn {
+  flex: 0 0 auto;
+}
+.price-tracking-toggle__error {
+  margin-top: 0.5rem;
+  color: var(--color-danger, #b00);
+  font-size: 0.85rem;
+}
+

--- a/frontend/src/pages/SommPrices.css
+++ b/frontend/src/pages/SommPrices.css
@@ -24,7 +24,8 @@
   font-weight: 400;
 }
 
-.sp-bottle-count {
+.sp-bottle-count,
+.sp-requester-count {
   font-size: 0.75rem;
   color: var(--color-text-muted);
   background: rgba(154, 148, 132, 0.1);
@@ -32,6 +33,21 @@
   border-radius: var(--radius-sm);
   padding: 0.15rem 0.5rem;
   white-space: nowrap;
+}
+
+.sp-requester-count {
+  background: rgba(var(--color-primary-rgb, 154 30 45), 0.10);
+  border-color: rgba(var(--color-primary-rgb, 154 30 45), 0.25);
+}
+
+.sp-requester-note {
+  margin: 0.5rem 0.9rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  background: var(--color-surface-raised);
+  border-left: 3px solid var(--color-primary, #9a1e2d);
+  border-radius: var(--radius-sm);
 }
 
 /* ── Previous price block ── */

--- a/frontend/src/pages/SommPrices.js
+++ b/frontend/src/pages/SommPrices.js
@@ -98,7 +98,7 @@ function PriceCard({ item, defaultCurrency, userCurrency, rates, onSaved }) {
     source:   '',
     sommNotes: ''
   });
-  const [skipping, setSkipping] = useState(false);
+  const [declining, setDeclining] = useState(false);
 
   const set = (field) => (e) => setForm(f => ({ ...f, [field]: e.target.value }));
 
@@ -171,30 +171,24 @@ function PriceCard({ item, defaultCurrency, userCurrency, rates, onSaved }) {
     }
   };
 
-  const handleSkip = async () => {
-    if (!window.confirm(t('somm.prices.skipConfirm'))) return;
-    setSkipping(true);
+  const handleDecline = async () => {
+    if (!window.confirm(t('somm.prices.declineConfirm', 'Decline this request? The user(s) who requested it will be notified.'))) return;
+    setDeclining(true);
     setErr(null);
     try {
-      const res = await apiFetch('/api/somm/prices/skip', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          wineDefinition: wine?._id,
-          vintage: item.vintage,
-          reason: form.sommNotes || undefined
-        })
+      const res = await apiFetch(`/api/somm/prices/requests/${item.requestId}`, {
+        method: 'DELETE'
       });
       if (res.ok) {
         onSaved(wine?._id, item.vintage);
       } else {
         const data = await res.json();
-        setErr(data.error || 'Failed to skip');
+        setErr(data.error || 'Failed to decline');
       }
     } catch {
       setErr('Network error');
     } finally {
-      setSkipping(false);
+      setDeclining(false);
     }
   };
 
@@ -225,9 +219,19 @@ function PriceCard({ item, defaultCurrency, userCurrency, rates, onSaved }) {
           {item.bottleCount > 1 && (
             <span className="sp-bottle-count">{t('somm.prices.bottle', { count: item.bottleCount })}</span>
           )}
+          {item.requesterCount > 0 && (
+            <span className="sp-requester-count" title={item.firstRequester?.username ? `First requested by ${item.firstRequester.username}` : null}>
+              {t('somm.prices.requesterCount', '{{count}} requester(s)', { count: item.requesterCount })}
+            </span>
+          )}
           <span className="somm-chevron">{expanded ? '▲' : '▼'}</span>
         </div>
       </div>
+      {expanded && item.firstRequester?.note && (
+        <div className="sp-requester-note">
+          <strong>{t('somm.prices.requesterNoteLabel', 'Requester note')}:</strong> {item.firstRequester.note}
+        </div>
+      )}
 
       {/* ── Inline form ── */}
       {expanded && (
@@ -324,11 +328,11 @@ function PriceCard({ item, defaultCurrency, userCurrency, rates, onSaved }) {
             <button
               type="button"
               className="btn btn-secondary sp-skip-btn"
-              onClick={handleSkip}
-              disabled={skipping}
-              title={t('somm.prices.skipTitle')}
+              onClick={handleDecline}
+              disabled={declining}
+              title={t('somm.prices.declineTitle', 'Decline this tracking request — the requester(s) will be notified.')}
             >
-              {skipping ? t('somm.prices.skipping') : t('somm.prices.skipTracking')}
+              {declining ? t('somm.prices.declining', 'Declining…') : t('somm.prices.declineRequest', 'Decline request')}
             </button>
           </div>
         </form>


### PR DESCRIPTION
Closes #392.

## Summary

The sommelier price queue used to fan out across every active bottle in the catalogue and filter out only the ones explicitly skipped. With ~1,800 wines and most being everyday bottles, that drowned the queue and burned sommelier attention on wines that don't have meaningful secondary-market value.

This PR flips the model: users opt in per bottle, and the queue lists only requested wines.

## What changed

### Data model

New `PriceTrackingRequest` (singleton per `wineDefinition` + `vintage`) carrying a `requesters` array — one document per pair regardless of how many users requested it.

### Backend

- **`bottles.js`** — three new endpoints:
  - `POST /api/bottles/:id/request-price-tracking` — idempotent. Adds the current user to the requesters array; creates the singleton on first request. Resolves bottle → wineDefinition + vintage.
  - `DELETE /api/bottles/:id/request-price-tracking` — removes this user. Deletes the singleton when the last requester leaves.
  - `GET /api/bottles/:id/request-price-tracking` — returns `{ requested, requesterCount, eligible, firstRequestedAt }`.
- **`somm/prices.js queue`** — rewritten. Sources from `PriceTrackingRequest`, joined with the latest `WineVintagePrice` for staleness UI, joined with `Bottle` counts. Still applies the 90-day staleness window so the visible queue is actionable. Sort: most-requested first, then oldest first-request.
- **`somm/prices.js POST /`** — after saving a price, fires in-app notifications to every requester ("Market price updated for X").
- **`somm/prices.js DELETE /requests/:requestId`** — new endpoint to decline a request. Notifies all requesters and deletes the singleton.
- **Old `POST` and `DELETE /api/somm/prices/skip` removed.** `PriceTrackingSkip` collection is kept in place for audit but no longer consulted.

### Frontend

- **`PriceTrackingToggle`** (new component) — mounted inside the Price Evolution section of `BottleDetail`. Three states: not-requested / requested / has-history-but-not-requested. Help text guides users to request only for bottles with real secondary-market value.
- **`SommPrices`** — each queue card now shows requester count and first-requester note. "Skip" button replaced with "Decline" calling the new endpoint.
- **i18n** — keys added for en + sv (`somm.prices.decline*`, `somm.prices.requesterCount`, `somm.prices.requesterNoteLabel`, full new `priceTracking.*` block).

### Migration

Per the product call: **all existing tracking lapses.** Users must re-request anything they want continued updates on. `WineVintagePrice` history records stay in place (the history itself is valuable). The queue simply starts empty under the new model. `PriceTrackingSkip` becomes a dead collection.

## Tests

- 9 new model-shape tests in `PriceTrackingRequest.test.js`.
- **Total: 256 frontend (Vitest) + 444 backend (Jest) = 700 green.**

## Test plan after merge

- [ ] Open a bottle's detail page → "Track market price for this wine" appears below the price section with the guidance text. Toggle on → status flips to "Market price tracking requested."
- [ ] NV or vintage="Unknown" bottle → toggle is hidden entirely.
- [ ] Sommelier opens `/somm/prices` → only requested pairs appear, sorted by request count.
- [ ] Sommelier saves a price → the requester gets an in-app notification ("Market price updated for X").
- [ ] Sommelier declines a request → all requesters get an in-app notification ("Your request was declined") and the card disappears.
- [ ] Backend tests pass on the VM after deploy.