### PR TITLE
chore(release): v1.49.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Bumps both `package.json` files from `1.48.0` → `1.49.0`.

## Changes since v1.48.0

- #391 — fix(auth): self-heal legacy notification shapes on User save (closes #390)
- #393 — feat(prices): invert price tracking from opt-out to opt-in (closes #392)
  - Includes the inline fix for CodeQL alert #153 (validate user input before Mongo queries)

Minor bump rationale: one new user-facing feature (opt-in price tracking with per-bottle toggle and sommelier-side flow), one defensive fix worth flagging in the release notes.