### PR TITLE
fix(prices): empty-state copy reflects opt-in tracking model

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -402,7 +402,7 @@
     "noteOptional": "Note (optional)",
     "notePlaceholder": "How was it? Any tasting notes?",
     "noPriceData": "No market price data yet.",
-    "sommelierAddPricing": "Our staff will add pricing data for this vintage soon.",
+    "sommelierAddPricing": "Market-price tracking is opt-in — use the toggle below to request it.",
     "reportPrice": "Report incorrect price",
     "maturityPhaseEarly": "Early drinking",
     "maturityPhasePeak": "Optimal maturity ⭐",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -402,7 +402,7 @@
     "noteOptional": "Anteckning (valfritt)",
     "notePlaceholder": "Hur smakade det? Några smaknoteringar?",
     "noPriceData": "Inga marknadsprisdata ännu.",
-    "sommelierAddPricing": "Vår personal kommer snart att lägga till prisdata för denna årgång.",
+    "sommelierAddPricing": "Marknadsprisbevakning är opt-in — använd reglaget nedan för att begära den.",
     "reportPrice": "Rapportera felaktigt pris",
     "maturityPhaseEarly": "Tidig drickning",
     "maturityPhasePeak": "Optimal mognad ⭐",


### PR DESCRIPTION
Closes a UX glitch noticed during smoke testing v1.49.0.

## What

The bottle-detail empty price state currently reads:

> No market price data yet.
> Our staff will add pricing data for this vintage soon.

That second sentence was true under the old auto-track model but is now a false promise — under the opt-in model from #393, staff only research wines users have explicitly requested. The PriceTrackingToggle that sits directly below the timeline already explains the new flow.

## How

Updates the i18n value of `bottleDetail.sommelierAddPricing` in en + sv to point users at the toggle below instead. Key stays the same, no code changes.