### PR TITLE
chore(release): v1.49.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Patch release bundling the post-v1.49.0 UX fix.

## Changes since v1.49.0

- #395 — fix(prices): empty-state copy reflects opt-in tracking model