### PR TITLE
feat(import): rack-aware CSV importer with Oeno/Vintec support

### DIFF
--- a/backend/src/models/ImportSession.js
+++ b/backend/src/models/ImportSession.js
@@ -30,6 +30,8 @@ const importSessionSchema = new mongoose.Schema({
   positionAnchor: { type: String, default: 'top-left' },
   // Per-rack dimension overrides: { [rackName]: { type, rows, cols, typeConfig } }
   rackConfigs: { type: mongoose.Schema.Types.Mixed, default: {} },
+  // Currency applied to bottles whose CSV row has no Currency column.
+  defaultCurrency: { type: String, default: 'USD', uppercase: true, trim: true },
   status: {
     type: String,
     enum: ['draft', 'completed'],

--- a/backend/src/models/ImportSession.js
+++ b/backend/src/models/ImportSession.js
@@ -25,6 +25,11 @@ const importSessionSchema = new mongoose.Schema({
   selections: { type: mongoose.Schema.Types.Mixed, default: {} },
   // Wines found via manual search modal: { [index]: wineObject }
   manualWines: { type: mongoose.Schema.Types.Mixed, default: {} },
+  // User's chosen 4-corner anchor for translating source-system positions
+  // into Cellarion's top-left/row-major space.
+  positionAnchor: { type: String, default: 'top-left' },
+  // Per-rack dimension overrides: { [rackName]: { type, rows, cols, typeConfig } }
+  rackConfigs: { type: mongoose.Schema.Types.Mixed, default: {} },
   status: {
     type: String,
     enum: ['draft', 'completed'],

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -27,6 +27,8 @@ const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { parseAndValidateVintage } = require('../utils/validation');
 const { extractAiExplanation } = require('../utils/jsonExtract');
 const { getMaxPosition } = require('../utils/rackGeometry');
+const { computeRackPosition, planRackCreations, VALID_ROW_ORIGINS } = require('../utils/rackImport');
+const { RACK_TYPES } = require('../models/Rack');
 const { runConcurrent } = require('../utils/concurrency');
 const WineRequest = require('../models/WineRequest');
 const ImportSession = require('../models/ImportSession');
@@ -378,7 +380,7 @@ router.post('/validate', async (req, res) => {
  */
 router.post('/confirm', async (req, res) => {
   try {
-    const { cellarId, items } = req.body;
+    const { cellarId, items, rowOrigin: rawRowOrigin } = req.body;
 
     if (!cellarId) {
       return res.status(400).json({ error: 'cellarId is required' });
@@ -392,6 +394,8 @@ router.post('/confirm', async (req, res) => {
     if (items.length > MAX_IMPORT_SIZE) {
       return res.status(400).json({ error: `Maximum ${MAX_IMPORT_SIZE} items per import` });
     }
+
+    const rowOrigin = rawRowOrigin && VALID_ROW_ORIGINS.includes(rawRowOrigin) ? rawRowOrigin : 'top';
 
     // Verify cellar access
     const cellar = await Cellar.findById(cellarId);
@@ -407,6 +411,40 @@ router.post('/confirm', async (req, res) => {
     const hasPrice = items.some(i => i.price != null && i.price !== '');
     if (hasPrice) {
       await getOrCreateDailySnapshot().catch(err => console.error('Failed to fetch daily exchange rate snapshot:', err.message));
+    }
+
+    // Auto-create any racks referenced in the import that don't already exist
+    // in this cellar. Runs once up-front so the bottle-placement step below
+    // can rely on every rack being present.
+    const createdRacks = [];
+    try {
+      const rackPlan = planRackCreations(items);
+      if (rackPlan.size > 0) {
+        const existing = await Rack.find({
+          cellar: cellarId,
+          name: { $in: Array.from(rackPlan.keys()) },
+          deletedAt: null
+        }).select('name').lean();
+        const existingNames = new Set(existing.map(r => r.name));
+
+        for (const [name, spec] of rackPlan.entries()) {
+          if (existingNames.has(name)) continue;
+          const safeType = RACK_TYPES.includes(spec.type) ? spec.type : 'grid';
+          const rack = new Rack({
+            cellar: cellarId,
+            user: cellar.user,
+            name,
+            type: safeType,
+            rows: spec.rows,
+            cols: spec.cols
+          });
+          await rack.save();
+          createdRacks.push({ name, type: safeType, rows: spec.rows, cols: spec.cols });
+          logAudit(req, 'rack.create', { type: 'rack', id: rack._id }, { source: 'import', name });
+        }
+      }
+    } catch (err) {
+      console.error('Failed to auto-create racks during import (non-fatal):', err.message);
     }
 
     let created = 0;
@@ -581,18 +619,30 @@ router.post('/confirm', async (req, res) => {
         created++;
         if (!item.addToHistory) createdBottleIds.push(bottle._id);
 
-        // Place bottle in rack if rackName + rackPosition provided (active bottles only)
-        if (item.rackName && item.rackPosition && bottle.status === 'active') {
+        // Place bottle in rack if rackName + (rackPosition or row+col) provided
+        // (active bottles only). Falls back silently when the rack doesn't
+        // exist or the slot is occupied — import doesn't fail over placement.
+        const hasPlacement = item.rackName && (item.rackPosition || (item.row && item.col));
+        if (hasPlacement && bottle.status === 'active') {
           try {
-            const position = parseInt(item.rackPosition, 10);
-            if (!isNaN(position) && position >= 1) {
-              const rack = await Rack.findOne({ cellar: cellarId, name: String(item.rackName), deletedAt: null });
-              if (rack && position <= getMaxPosition(rack)) {
-                // Only place if slot is empty
-                const occupied = rack.slots.some(s => s.position === position);
-                if (!occupied) {
-                  rack.slots.push({ position, bottle: bottle._id });
-                  await rack.save().catch(err => console.error('Failed to save rack slot during import:', err.message));
+            const rack = await Rack.findOne({ cellar: cellarId, name: String(item.rackName), deletedAt: null });
+            if (rack) {
+              const positionResult = computeRackPosition({
+                position: item.rackPosition,
+                row: item.row,
+                col: item.col,
+                rackRows: rack.rows,
+                rackCols: rack.cols,
+                rowOrigin
+              });
+              if (!positionResult.error) {
+                const { position } = positionResult;
+                if (position <= getMaxPosition(rack)) {
+                  const occupied = rack.slots.some(s => s.position === position);
+                  if (!occupied) {
+                    rack.slots.push({ position, bottle: bottle._id });
+                    await rack.save().catch(err => console.error('Failed to save rack slot during import:', err.message));
+                  }
                 }
               }
             }
@@ -624,14 +674,16 @@ router.post('/confirm', async (req, res) => {
       created,
       skipped: skipped.length,
       errors: errors.length,
-      total: items.length
+      total: items.length,
+      racksCreated: createdRacks.length
     });
 
     res.json({
       created,
       skipped,
       errors,
-      total: items.length
+      total: items.length,
+      racksCreated: createdRacks
     });
   } catch (error) {
     console.error('Import confirm error:', error);

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -397,17 +397,44 @@ router.post('/confirm', async (req, res) => {
 
     const positionAnchor = VALID_ANCHORS.includes(rawAnchor) ? rawAnchor : DEFAULT_ANCHOR;
 
-    // Validate user-supplied per-rack dimensions (rows/cols clamped to 1..20)
-    // rackConfigs shape: { [rackName]: { rows: number, cols: number } }
+    // Validate user-supplied per-rack configuration.
+    // Shape: { [rackName]: { type?, rows?, cols?, typeConfig?: {...} } }
+    // type — one of RACK_TYPES (defaults to 'grid' if absent/invalid)
+    // rows/cols — clamped to 1..20
+    // typeConfig — optional shape config (bottlesPerCell, bottlesPerSection,
+    //   moduleRows, moduleCols, backCols), each clamped to model bounds
     const rackConfigs = {};
+    const clampInt = (v, min, max) => {
+      const n = parseInt(v, 10);
+      if (isNaN(n)) return undefined;
+      return Math.max(min, Math.min(max, n));
+    };
     if (rawRackConfigs && typeof rawRackConfigs === 'object') {
       for (const [name, cfg] of Object.entries(rawRackConfigs)) {
         if (!cfg || typeof cfg !== 'object') continue;
-        const rows = parseInt(cfg.rows, 10);
-        const cols = parseInt(cfg.cols, 10);
-        if (rows >= 1 && rows <= 20 && cols >= 1 && cols <= 20) {
-          rackConfigs[String(name)] = { rows, cols };
+        const rows = clampInt(cfg.rows, 1, 20);
+        const cols = clampInt(cfg.cols, 1, 20);
+        if (!rows || !cols) continue;
+
+        const entry = { rows, cols };
+        if (cfg.type && RACK_TYPES.includes(cfg.type)) entry.type = cfg.type;
+
+        if (cfg.typeConfig && typeof cfg.typeConfig === 'object') {
+          const tc = {};
+          const mr = clampInt(cfg.typeConfig.moduleRows, 1, 10);
+          const mc = clampInt(cfg.typeConfig.moduleCols, 1, 10);
+          const bpc = clampInt(cfg.typeConfig.bottlesPerCell, 1, 20);
+          const bps = clampInt(cfg.typeConfig.bottlesPerSection, 1, 30);
+          const bc = clampInt(cfg.typeConfig.backCols, 0, 20);
+          if (mr !== undefined) tc.moduleRows = mr;
+          if (mc !== undefined) tc.moduleCols = mc;
+          if (bpc !== undefined) tc.bottlesPerCell = bpc;
+          if (bps !== undefined) tc.bottlesPerSection = bps;
+          if (bc !== undefined) tc.backCols = bc;
+          if (Object.keys(tc).length > 0) entry.typeConfig = tc;
         }
+
+        rackConfigs[String(name)] = entry;
       }
     }
 
@@ -447,17 +474,20 @@ router.post('/confirm', async (req, res) => {
           const override = rackConfigs[name];
           const rows = override?.rows || spec.rows;
           const cols = override?.cols || spec.cols;
-          const safeType = RACK_TYPES.includes(spec.type) ? spec.type : 'grid';
-          const rack = new Rack({
+          const chosenType = override?.type || spec.type;
+          const safeType = RACK_TYPES.includes(chosenType) ? chosenType : 'grid';
+          const rackData = {
             cellar: cellarId,
             user: cellar.user,
             name,
             type: safeType,
             rows,
             cols
-          });
+          };
+          if (override?.typeConfig) rackData.typeConfig = override.typeConfig;
+          const rack = new Rack(rackData);
           await rack.save();
-          createdRacks.push({ name, type: safeType, rows, cols });
+          createdRacks.push({ name, type: safeType, rows, cols, typeConfig: override?.typeConfig });
           logAudit(req, 'rack.create', { type: 'rack', id: rack._id }, { source: 'import', name });
         }
       }

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -741,7 +741,9 @@ router.post('/confirm', async (req, res) => {
               type: rack.type,
               rows: rack.rows,
               cols: rack.cols,
-              typeConfig: rack.typeConfig,
+              // Pass typeConfig as a plain object — for Mongoose subdocs the
+              // .toObject() shape is what the helper expects.
+              typeConfig: rack.typeConfig?.toObject ? rack.typeConfig.toObject() : rack.typeConfig,
               slots: rack.slots,
               maxPosition: getMaxPosition(rack)
             },

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -27,7 +27,7 @@ const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { parseAndValidateVintage } = require('../utils/validation');
 const { extractAiExplanation } = require('../utils/jsonExtract');
 const { getMaxPosition } = require('../utils/rackGeometry');
-const { computeRackPosition, planRackCreations, placeBottles, VALID_ANCHORS, DEFAULT_ANCHOR } = require('../utils/rackImport');
+const { planRackCreations, placeBottlesInRack, VALID_ANCHORS, DEFAULT_ANCHOR } = require('../utils/rackImport');
 const { RACK_TYPES } = require('../models/Rack');
 const { runConcurrent } = require('../utils/concurrency');
 const WineRequest = require('../models/WineRequest');
@@ -727,32 +727,19 @@ router.post('/confirm', async (req, res) => {
             }
             continue;
           }
-          const maxPos = getMaxPosition(rack);
 
-          // Translate each bottle's source-system position into Cellarion's
-          // internal top-left/row-major coordinate before placement.
-          const requests = [];
-          for (const p of group) {
-            const result = computeRackPosition({
-              position: p.item.rackPosition,
-              row: p.item.row,
-              col: p.item.col,
-              rackRows: rack.rows,
-              rackCols: rack.cols,
-              anchor: positionAnchor
-            });
-            if (result.error) {
-              unplacedDetails.push({ sourceIndex: p.sourceIndex, rackName, requestedPosition: null, reason: result.error });
-              continue;
-            }
-            if (result.position > maxPos) {
-              unplacedDetails.push({ sourceIndex: p.sourceIndex, rackName, requestedPosition: result.position, reason: `Slot ${result.position} exceeds rack capacity (${maxPos})` });
-              continue;
-            }
-            requests.push({ requestedPosition: result.position, bottleId: p.bottleId, sourceIndex: p.sourceIndex });
-          }
-
-          const { placements, unplaced } = placeBottles(rack.slots, requests, maxPos);
+          const { placements, unplaced } = placeBottlesInRack(
+            {
+              type: rack.type,
+              rows: rack.rows,
+              cols: rack.cols,
+              typeConfig: rack.typeConfig,
+              slots: rack.slots,
+              maxPosition: getMaxPosition(rack)
+            },
+            group,
+            positionAnchor
+          );
 
           for (const pl of placements) {
             rack.slots.push({ position: pl.position, bottle: pl.bottle });
@@ -760,7 +747,7 @@ router.post('/confirm', async (req, res) => {
             if (pl.overflowed) overflowedCount++;
           }
           for (const u of unplaced) {
-            unplacedDetails.push({ sourceIndex: u.sourceIndex, rackName, requestedPosition: u.requestedPosition, reason: 'Rack full' });
+            unplacedDetails.push({ ...u, rackName });
           }
 
           if (placements.length > 0) {
@@ -819,7 +806,7 @@ router.post('/confirm', async (req, res) => {
  */
 router.post('/sessions', async (req, res) => {
   try {
-    const { cellarId, fileName, detectedFormat, results, selections, manualWines } = req.body;
+    const { cellarId, fileName, detectedFormat, results, selections, manualWines, positionAnchor, rackConfigs } = req.body;
 
     if (!cellarId || !mongoose.Types.ObjectId.isValid(cellarId)) {
       return res.status(400).json({ error: 'Valid cellarId is required' });
@@ -847,7 +834,9 @@ router.post('/sessions', async (req, res) => {
       detectedFormat,
       results,
       selections: selections || {},
-      manualWines: manualWines || {}
+      manualWines: manualWines || {},
+      positionAnchor: positionAnchor || 'top-left',
+      rackConfigs: rackConfigs || {}
     });
     await session.save();
 
@@ -971,9 +960,11 @@ router.put('/sessions/:id', async (req, res) => {
       return res.status(403).json({ error: 'Not authorized' });
     }
 
-    const { selections, manualWines } = req.body;
+    const { selections, manualWines, positionAnchor, rackConfigs } = req.body;
     if (selections !== undefined) session.selections = selections;
     if (manualWines !== undefined) session.manualWines = manualWines;
+    if (positionAnchor !== undefined) session.positionAnchor = positionAnchor;
+    if (rackConfigs !== undefined) session.rackConfigs = rackConfigs;
     await session.save();
 
     res.json({ ok: true });

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -380,7 +380,7 @@ router.post('/validate', async (req, res) => {
  */
 router.post('/confirm', async (req, res) => {
   try {
-    const { cellarId, items, positionAnchor: rawAnchor, rackConfigs: rawRackConfigs } = req.body;
+    const { cellarId, items, positionAnchor: rawAnchor, rackConfigs: rawRackConfigs, defaultCurrency: rawDefaultCurrency } = req.body;
 
     if (!cellarId) {
       return res.status(400).json({ error: 'cellarId is required' });
@@ -396,6 +396,14 @@ router.post('/confirm', async (req, res) => {
     }
 
     const positionAnchor = VALID_ANCHORS.includes(rawAnchor) ? rawAnchor : DEFAULT_ANCHOR;
+
+    // Currency to apply when an import item has no Currency column of its own.
+    // We accept any 3-letter ISO code here so the user's profile preference
+    // (or a future addition to the frontend CURRENCIES list) flows through
+    // without backend changes. Falls back to USD when no preference is set.
+    const defaultCurrency = (typeof rawDefaultCurrency === 'string' && /^[A-Z]{3}$/i.test(rawDefaultCurrency))
+      ? rawDefaultCurrency.toUpperCase()
+      : 'USD';
 
     // Validate user-supplied per-rack configuration.
     // Shape: { [rackName]: { type?, rows?, cols?, typeConfig?: {...} } }
@@ -570,7 +578,7 @@ router.post('/confirm', async (req, res) => {
             pendingWineRequest: wineRequest._id,
             vintage: canonicalVintage,
             price: item.price || undefined,
-            currency: item.currency || 'USD',
+            currency: item.currency || defaultCurrency,
             priceSetAt,
             bottleSize: item.bottleSize || '750ml',
             purchaseDate: item.purchaseDate || undefined,
@@ -647,7 +655,7 @@ router.post('/confirm', async (req, res) => {
           wineDefinition: item.wineDefinition,
           vintage: canonicalVintage,
           price: item.price || undefined,
-          currency: item.currency || 'USD',
+          currency: item.currency || defaultCurrency,
           priceSetAt,
           bottleSize: item.bottleSize || '750ml',
           purchaseDate: item.purchaseDate || undefined,
@@ -806,7 +814,7 @@ router.post('/confirm', async (req, res) => {
  */
 router.post('/sessions', async (req, res) => {
   try {
-    const { cellarId, fileName, detectedFormat, results, selections, manualWines, positionAnchor, rackConfigs } = req.body;
+    const { cellarId, fileName, detectedFormat, results, selections, manualWines, positionAnchor, rackConfigs, defaultCurrency } = req.body;
 
     if (!cellarId || !mongoose.Types.ObjectId.isValid(cellarId)) {
       return res.status(400).json({ error: 'Valid cellarId is required' });
@@ -836,7 +844,8 @@ router.post('/sessions', async (req, res) => {
       selections: selections || {},
       manualWines: manualWines || {},
       positionAnchor: positionAnchor || 'top-left',
-      rackConfigs: rackConfigs || {}
+      rackConfigs: rackConfigs || {},
+      defaultCurrency: defaultCurrency || 'USD'
     });
     await session.save();
 
@@ -960,11 +969,12 @@ router.put('/sessions/:id', async (req, res) => {
       return res.status(403).json({ error: 'Not authorized' });
     }
 
-    const { selections, manualWines, positionAnchor, rackConfigs } = req.body;
+    const { selections, manualWines, positionAnchor, rackConfigs, defaultCurrency } = req.body;
     if (selections !== undefined) session.selections = selections;
     if (manualWines !== undefined) session.manualWines = manualWines;
     if (positionAnchor !== undefined) session.positionAnchor = positionAnchor;
     if (rackConfigs !== undefined) session.rackConfigs = rackConfigs;
+    if (defaultCurrency !== undefined) session.defaultCurrency = defaultCurrency;
     await session.save();
 
     res.json({ ok: true });

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -27,7 +27,7 @@ const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { parseAndValidateVintage } = require('../utils/validation');
 const { extractAiExplanation } = require('../utils/jsonExtract');
 const { getMaxPosition } = require('../utils/rackGeometry');
-const { computeRackPosition, planRackCreations, VALID_ROW_ORIGINS } = require('../utils/rackImport');
+const { computeRackPosition, planRackCreations, VALID_ANCHORS, DEFAULT_ANCHOR } = require('../utils/rackImport');
 const { RACK_TYPES } = require('../models/Rack');
 const { runConcurrent } = require('../utils/concurrency');
 const WineRequest = require('../models/WineRequest');
@@ -380,7 +380,7 @@ router.post('/validate', async (req, res) => {
  */
 router.post('/confirm', async (req, res) => {
   try {
-    const { cellarId, items, rowOrigin: rawRowOrigin } = req.body;
+    const { cellarId, items, positionAnchor: rawAnchor, rackConfigs: rawRackConfigs } = req.body;
 
     if (!cellarId) {
       return res.status(400).json({ error: 'cellarId is required' });
@@ -395,7 +395,21 @@ router.post('/confirm', async (req, res) => {
       return res.status(400).json({ error: `Maximum ${MAX_IMPORT_SIZE} items per import` });
     }
 
-    const rowOrigin = rawRowOrigin && VALID_ROW_ORIGINS.includes(rawRowOrigin) ? rawRowOrigin : 'top';
+    const positionAnchor = VALID_ANCHORS.includes(rawAnchor) ? rawAnchor : DEFAULT_ANCHOR;
+
+    // Validate user-supplied per-rack dimensions (rows/cols clamped to 1..20)
+    // rackConfigs shape: { [rackName]: { rows: number, cols: number } }
+    const rackConfigs = {};
+    if (rawRackConfigs && typeof rawRackConfigs === 'object') {
+      for (const [name, cfg] of Object.entries(rawRackConfigs)) {
+        if (!cfg || typeof cfg !== 'object') continue;
+        const rows = parseInt(cfg.rows, 10);
+        const cols = parseInt(cfg.cols, 10);
+        if (rows >= 1 && rows <= 20 && cols >= 1 && cols <= 20) {
+          rackConfigs[String(name)] = { rows, cols };
+        }
+      }
+    }
 
     // Verify cellar access
     const cellar = await Cellar.findById(cellarId);
@@ -414,8 +428,9 @@ router.post('/confirm', async (req, res) => {
     }
 
     // Auto-create any racks referenced in the import that don't already exist
-    // in this cellar. Runs once up-front so the bottle-placement step below
-    // can rely on every rack being present.
+    // in this cellar. User-supplied rackConfigs take precedence over inferred
+    // dimensions. Runs once up-front so the bottle-placement step below can
+    // rely on every rack being present.
     const createdRacks = [];
     try {
       const rackPlan = planRackCreations(items);
@@ -429,17 +444,20 @@ router.post('/confirm', async (req, res) => {
 
         for (const [name, spec] of rackPlan.entries()) {
           if (existingNames.has(name)) continue;
+          const override = rackConfigs[name];
+          const rows = override?.rows || spec.rows;
+          const cols = override?.cols || spec.cols;
           const safeType = RACK_TYPES.includes(spec.type) ? spec.type : 'grid';
           const rack = new Rack({
             cellar: cellarId,
             user: cellar.user,
             name,
             type: safeType,
-            rows: spec.rows,
-            cols: spec.cols
+            rows,
+            cols
           });
           await rack.save();
-          createdRacks.push({ name, type: safeType, rows: spec.rows, cols: spec.cols });
+          createdRacks.push({ name, type: safeType, rows, cols });
           logAudit(req, 'rack.create', { type: 'rack', id: rack._id }, { source: 'import', name });
         }
       }
@@ -633,7 +651,7 @@ router.post('/confirm', async (req, res) => {
                 col: item.col,
                 rackRows: rack.rows,
                 rackCols: rack.cols,
-                rowOrigin
+                anchor: positionAnchor
               });
               if (!positionResult.error) {
                 const { position } = positionResult;

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -27,7 +27,7 @@ const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { parseAndValidateVintage } = require('../utils/validation');
 const { extractAiExplanation } = require('../utils/jsonExtract');
 const { getMaxPosition } = require('../utils/rackGeometry');
-const { computeRackPosition, planRackCreations, VALID_ANCHORS, DEFAULT_ANCHOR } = require('../utils/rackImport');
+const { computeRackPosition, planRackCreations, placeBottles, VALID_ANCHORS, DEFAULT_ANCHOR } = require('../utils/rackImport');
 const { RACK_TYPES } = require('../models/Rack');
 const { runConcurrent } = require('../utils/concurrency');
 const WineRequest = require('../models/WineRequest');
@@ -471,6 +471,11 @@ router.post('/confirm', async (req, res) => {
     const createdBottleIds = []; // Track IDs for Meilisearch bulk sync
     // Dedup map: "wineName|producer" -> WineRequest doc created in this batch
     const pendingRequestCache = new Map();
+    // Collected rack-placement intents from this batch; processed per-rack
+    // after the main loop so multiple bottles claiming the same slot can
+    // overflow cleanly into adjacent free slots.
+    // Shape: [{ rackName, item, bottleId, sourceIndex }]
+    const pendingPlacements = [];
 
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
@@ -561,6 +566,12 @@ router.post('/confirm', async (req, res) => {
           await bottle.save();
           created++;
           if (!item.addToHistory) createdBottleIds.push(bottle._id);
+
+          // Queue rack placement for unmatched bottles too
+          const hasPlacement = item.rackName && (item.rackPosition || (item.row && item.col));
+          if (hasPlacement && bottle.status === 'active') {
+            pendingPlacements.push({ rackName: String(item.rackName), item, bottleId: bottle._id, sourceIndex: i });
+          }
           continue;
         }
 
@@ -637,36 +648,12 @@ router.post('/confirm', async (req, res) => {
         created++;
         if (!item.addToHistory) createdBottleIds.push(bottle._id);
 
-        // Place bottle in rack if rackName + (rackPosition or row+col) provided
-        // (active bottles only). Falls back silently when the rack doesn't
-        // exist or the slot is occupied — import doesn't fail over placement.
+        // Queue rack placement — actual slot assignment runs per-rack after
+        // the bottle loop so multiple bottles claiming the same slot can
+        // overflow into adjacent free slots instead of being silently dropped.
         const hasPlacement = item.rackName && (item.rackPosition || (item.row && item.col));
         if (hasPlacement && bottle.status === 'active') {
-          try {
-            const rack = await Rack.findOne({ cellar: cellarId, name: String(item.rackName), deletedAt: null });
-            if (rack) {
-              const positionResult = computeRackPosition({
-                position: item.rackPosition,
-                row: item.row,
-                col: item.col,
-                rackRows: rack.rows,
-                rackCols: rack.cols,
-                anchor: positionAnchor
-              });
-              if (!positionResult.error) {
-                const { position } = positionResult;
-                if (position <= getMaxPosition(rack)) {
-                  const occupied = rack.slots.some(s => s.position === position);
-                  if (!occupied) {
-                    rack.slots.push({ position, bottle: bottle._id });
-                    await rack.save().catch(err => console.error('Failed to save rack slot during import:', err.message));
-                  }
-                }
-              }
-            }
-          } catch (err) {
-            console.error('Failed to place bottle in rack during import (non-fatal):', err.message);
-          }
+          pendingPlacements.push({ rackName: String(item.rackName), item, bottleId: bottle._id, sourceIndex: i });
         }
 
         // Auto-create pending WineVintageProfile for every bottle except
@@ -688,12 +675,85 @@ router.post('/confirm', async (req, res) => {
     // Bulk-index created bottles in Meilisearch (fire-and-forget)
     searchService.bulkIndexBottles(createdBottleIds);
 
+    // Per-rack two-pass placement: for each rack referenced in this import,
+    // assign exact slots first, then overflow extras into nearest empty slots.
+    let placedCount = 0;
+    let overflowedCount = 0;
+    const unplacedDetails = []; // [{ sourceIndex, rackName, requestedPosition, reason }]
+    if (pendingPlacements.length > 0) {
+      // Group by rackName
+      const byRack = new Map();
+      for (const p of pendingPlacements) {
+        if (!byRack.has(p.rackName)) byRack.set(p.rackName, []);
+        byRack.get(p.rackName).push(p);
+      }
+
+      for (const [rackName, group] of byRack.entries()) {
+        try {
+          const rack = await Rack.findOne({ cellar: cellarId, name: rackName, deletedAt: null });
+          if (!rack) {
+            for (const p of group) {
+              unplacedDetails.push({ sourceIndex: p.sourceIndex, rackName, requestedPosition: null, reason: 'Rack not found' });
+            }
+            continue;
+          }
+          const maxPos = getMaxPosition(rack);
+
+          // Translate each bottle's source-system position into Cellarion's
+          // internal top-left/row-major coordinate before placement.
+          const requests = [];
+          for (const p of group) {
+            const result = computeRackPosition({
+              position: p.item.rackPosition,
+              row: p.item.row,
+              col: p.item.col,
+              rackRows: rack.rows,
+              rackCols: rack.cols,
+              anchor: positionAnchor
+            });
+            if (result.error) {
+              unplacedDetails.push({ sourceIndex: p.sourceIndex, rackName, requestedPosition: null, reason: result.error });
+              continue;
+            }
+            if (result.position > maxPos) {
+              unplacedDetails.push({ sourceIndex: p.sourceIndex, rackName, requestedPosition: result.position, reason: `Slot ${result.position} exceeds rack capacity (${maxPos})` });
+              continue;
+            }
+            requests.push({ requestedPosition: result.position, bottleId: p.bottleId, sourceIndex: p.sourceIndex });
+          }
+
+          const { placements, unplaced } = placeBottles(rack.slots, requests, maxPos);
+
+          for (const pl of placements) {
+            rack.slots.push({ position: pl.position, bottle: pl.bottle });
+            placedCount++;
+            if (pl.overflowed) overflowedCount++;
+          }
+          for (const u of unplaced) {
+            unplacedDetails.push({ sourceIndex: u.sourceIndex, rackName, requestedPosition: u.requestedPosition, reason: 'Rack full' });
+          }
+
+          if (placements.length > 0) {
+            await rack.save().catch(err => console.error(`Failed to save rack ${rackName} during import:`, err.message));
+          }
+        } catch (err) {
+          console.error(`Failed placement for rack ${rackName}:`, err.message);
+          for (const p of group) {
+            unplacedDetails.push({ sourceIndex: p.sourceIndex, rackName, requestedPosition: null, reason: err.message });
+          }
+        }
+      }
+    }
+
     logAudit(req, 'bottle.import', { type: 'cellar', id: cellarId }, {
       created,
       skipped: skipped.length,
       errors: errors.length,
       total: items.length,
-      racksCreated: createdRacks.length
+      racksCreated: createdRacks.length,
+      placed: placedCount,
+      overflowed: overflowedCount,
+      unplaced: unplacedDetails.length
     });
 
     res.json({
@@ -701,7 +761,10 @@ router.post('/confirm', async (req, res) => {
       skipped,
       errors,
       total: items.length,
-      racksCreated: createdRacks
+      racksCreated: createdRacks,
+      placed: placedCount,
+      overflowed: overflowedCount,
+      unplaced: unplacedDetails
     });
   } catch (error) {
     console.error('Import confirm error:', error);

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -405,7 +405,7 @@ router.get('/me/export', requireAuth, async (req, res) => {
       Follow.find({ $or: [{ follower: userId }, { following: userId }] })
         .populate('follower', 'username').populate('following', 'username').lean(),
       ChatUsage.find({ userId: userId }).select('date promptTokens completionTokens').lean(),
-      ImportSession.find({ user: userId }).select('cellar status rows createdAt').lean(),
+      ImportSession.find({ user: userId }).select('cellar status results positionAnchor rackConfigs defaultCurrency createdAt').lean(),
       SupportTicket.find({ user: userId }).select('category subject status createdAt').lean(),
       DiscussionReport.find({ user: userId }).select('discussion reply reason createdAt').lean(),
       WineReport.find({ user: userId }).select('wineDefinition reason status createdAt').lean(),
@@ -535,7 +535,10 @@ router.get('/me/export', requireAuth, async (req, res) => {
       importSessions: importSessions.map(s => ({
         cellar: s.cellar,
         status: s.status,
-        rowCount: s.rows?.length || 0,
+        rowCount: s.results?.length || 0,
+        positionAnchor: s.positionAnchor,
+        rackConfigs: s.rackConfigs,
+        defaultCurrency: s.defaultCurrency,
         createdAt: s.createdAt
       })),
       supportTickets: supportTickets.map(t => ({

--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -109,14 +109,19 @@ function planRackCreations(items) {
   }
 
   // Finalise each entry: ensure rows/cols are at least 1, and that the rack's
-  // capacity covers the highest position we'll try to place into.
+  // capacity covers the highest position we'll try to place into. When only a
+  // sequential `rackPosition` is known (no row/col coordinates), fall back to
+  // a typical wine-rack width of 6 columns so the auto-created rack matches
+  // common physical layouts instead of becoming a 1-wide column.
   for (const entry of plan.values()) {
+    if (!entry.rows && !entry.cols && entry.maxPosition > 0) {
+      entry.cols = 6;
+      entry.rows = Math.max(4, Math.ceil(entry.maxPosition / entry.cols));
+    }
     if (!entry.rows) entry.rows = 1;
     if (!entry.cols) entry.cols = 1;
 
-    // If only `rackPosition` was used (no row/col), grow rows so capacity fits.
-    // Grid capacity = rows * cols. Prefer growing rows so a stack-of-positions
-    // import stays narrow.
+    // Grow capacity to fit the highest position if needed (grid + shelf).
     if (entry.type === 'grid' || entry.type === 'shelf') {
       const capacity = totalSlots(entry.type, entry.rows, entry.cols);
       if (entry.maxPosition > capacity) {

--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -1,0 +1,143 @@
+/**
+ * Rack-aware import helpers.
+ *
+ * Translates the (rackName, row, col) / rackPosition shape used in CSV exports
+ * from other cellar apps (Oeno/Vintec, CellarTracker, Vivino, …) into the
+ * single 1-indexed `position` Cellarion stores on a rack's slots.
+ *
+ * Also derives a "plan" for auto-creating racks that don't yet exist in the
+ * target cellar, inferring dimensions from the rack's own rows when not given
+ * explicitly in the CSV.
+ */
+
+const { totalSlots } = require('./rackGeometry');
+
+const DEFAULT_RACK_TYPE = 'grid';
+const VALID_ROW_ORIGINS = ['top', 'bottom'];
+
+/**
+ * Compute the 1-indexed sequential position for a rack slot, given either
+ * an explicit position or a (row, col) pair plus the rack's row/col count.
+ *
+ * Supports `rowOrigin = 'bottom'` for apps (like Oeno) where row 1 is the
+ * physical bottom of the rack. The default is 'top' which matches how
+ * Cellarion's grid renders.
+ *
+ * Returns:
+ *   { position: number }            on success
+ *   { error: string }               when the inputs can't produce a position
+ *
+ * Only meaningful for grid-shaped racks (grid, shelf). For other types we
+ * still fall back to a row-major formula but consumers should generally
+ * pass an explicit `position` when working with hex/triangle/x-rack/cube.
+ */
+function computeRackPosition({ position, row, col, rackRows, rackCols, rowOrigin = 'top' }) {
+  if (!VALID_ROW_ORIGINS.includes(rowOrigin)) {
+    return { error: `Invalid rowOrigin: ${rowOrigin}` };
+  }
+
+  // Explicit position wins — used as-is.
+  if (position !== undefined && position !== null && position !== '') {
+    const p = parseInt(position, 10);
+    if (isNaN(p) || p < 1) return { error: 'Invalid position' };
+    return { position: p };
+  }
+
+  // Otherwise we need row + col + rackCols at minimum.
+  const r = parseInt(row, 10);
+  const c = parseInt(col, 10);
+  const rows = parseInt(rackRows, 10);
+  const cols = parseInt(rackCols, 10);
+
+  if (isNaN(r) || r < 1) return { error: 'Invalid row' };
+  if (isNaN(c) || c < 1) return { error: 'Invalid col' };
+  if (isNaN(cols) || cols < 1) return { error: 'rackCols is required to compute position from row/col' };
+  if (c > cols) return { error: `col ${c} exceeds rackCols ${cols}` };
+
+  let effectiveRow = r;
+  if (rowOrigin === 'bottom') {
+    if (isNaN(rows) || rows < 1) {
+      return { error: 'rackRows is required when rowOrigin is "bottom"' };
+    }
+    if (r > rows) return { error: `row ${r} exceeds rackRows ${rows}` };
+    effectiveRow = rows - r + 1;
+  }
+
+  return { position: (effectiveRow - 1) * cols + c };
+}
+
+/**
+ * Build a plan of racks to auto-create from a batch of import items.
+ *
+ * For each unique rackName seen in items, infer:
+ *   - type        — from item.rackType, else 'grid'
+ *   - rows, cols  — from explicit rackRows/rackCols on any item, else inferred
+ *                   from the max row/col observed; falls back to capacity that
+ *                   covers the highest position seen
+ *
+ * Returns a Map keyed by rackName so the caller can `findOne` and skip the
+ * plan entry if the rack already exists in the cellar.
+ */
+function planRackCreations(items) {
+  const plan = new Map(); // rackName -> { type, rows, cols, maxPosition }
+
+  for (const item of items) {
+    if (!item || !item.rackName) continue;
+    const name = String(item.rackName).trim();
+    if (!name) continue;
+
+    let entry = plan.get(name);
+    if (!entry) {
+      entry = { type: DEFAULT_RACK_TYPE, rows: 0, cols: 0, maxPosition: 0 };
+      plan.set(name, entry);
+    }
+
+    if (item.rackType) entry.type = String(item.rackType).trim().toLowerCase();
+
+    const declaredRows = parseInt(item.rackRows, 10);
+    const declaredCols = parseInt(item.rackCols, 10);
+    if (!isNaN(declaredRows) && declaredRows > entry.rows) entry.rows = declaredRows;
+    if (!isNaN(declaredCols) && declaredCols > entry.cols) entry.cols = declaredCols;
+
+    const row = parseInt(item.row, 10);
+    const col = parseInt(item.col, 10);
+    if (!isNaN(row) && row > entry.rows) entry.rows = row;
+    if (!isNaN(col) && col > entry.cols) entry.cols = col;
+
+    const pos = parseInt(item.rackPosition, 10);
+    if (!isNaN(pos) && pos > entry.maxPosition) entry.maxPosition = pos;
+  }
+
+  // Finalise each entry: ensure rows/cols are at least 1, and that the rack's
+  // capacity covers the highest position we'll try to place into.
+  for (const entry of plan.values()) {
+    if (!entry.rows) entry.rows = 1;
+    if (!entry.cols) entry.cols = 1;
+
+    // If only `rackPosition` was used (no row/col), grow rows so capacity fits.
+    // Grid capacity = rows * cols. Prefer growing rows so a stack-of-positions
+    // import stays narrow.
+    if (entry.type === 'grid' || entry.type === 'shelf') {
+      const capacity = totalSlots(entry.type, entry.rows, entry.cols);
+      if (entry.maxPosition > capacity) {
+        entry.rows = Math.ceil(entry.maxPosition / entry.cols);
+      }
+    }
+
+    // Clamp to the Mongoose schema's max of 20 — anything bigger and the rack
+    // will need to be created manually as a modular rack instead.
+    if (entry.rows > 20) entry.rows = 20;
+    if (entry.cols > 20) entry.cols = 20;
+
+    delete entry.maxPosition;
+  }
+
+  return plan;
+}
+
+module.exports = {
+  computeRackPosition,
+  planRackCreations,
+  DEFAULT_RACK_TYPE,
+  VALID_ROW_ORIGINS,
+};

--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -13,57 +13,91 @@
 const { totalSlots } = require('./rackGeometry');
 
 const DEFAULT_RACK_TYPE = 'grid';
-const VALID_ROW_ORIGINS = ['top', 'bottom'];
+const VALID_ANCHORS = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+const DEFAULT_ANCHOR = 'top-left';
 
 /**
- * Compute the 1-indexed sequential position for a rack slot, given either
- * an explicit position or a (row, col) pair plus the rack's row/col count.
+ * Compute the 1-indexed sequential position for a slot in Cellarion's internal
+ * coordinate system (top-left, row-major), given:
+ *   - A sequential `position` from the source system, or
+ *   - A (row, col) pair from the source system,
+ * plus the rack's dimensions and where the source system's "bottle 1" sits.
  *
- * Supports `rowOrigin = 'bottom'` for apps (like Oeno) where row 1 is the
- * physical bottom of the rack. The default is 'top' which matches how
- * Cellarion's grid renders.
+ * `anchor` describes the corner where the source data's position 1 (or row 1,
+ * col 1) is located:
+ *   - 'top-left'     : matches Cellarion's internal layout (identity)
+ *   - 'top-right'    : column 1 is on the right
+ *   - 'bottom-left'  : row 1 is at the bottom (Oeno reading left-to-right)
+ *   - 'bottom-right' : row 1 at bottom AND col 1 on the right
  *
- * Returns:
- *   { position: number }            on success
- *   { error: string }               when the inputs can't produce a position
- *
- * Only meaningful for grid-shaped racks (grid, shelf). For other types we
- * still fall back to a row-major formula but consumers should generally
- * pass an explicit `position` when working with hex/triangle/x-rack/cube.
+ * Returns { position } on success or { error } on bad input.
  */
-function computeRackPosition({ position, row, col, rackRows, rackCols, rowOrigin = 'top' }) {
-  if (!VALID_ROW_ORIGINS.includes(rowOrigin)) {
-    return { error: `Invalid rowOrigin: ${rowOrigin}` };
+function computeRackPosition({ position, row, col, rackRows, rackCols, anchor = DEFAULT_ANCHOR }) {
+  if (!VALID_ANCHORS.includes(anchor)) {
+    return { error: `Invalid anchor: ${anchor}` };
   }
 
-  // Explicit position wins — used as-is.
+  const cols = parseInt(rackCols, 10);
+  const rows = parseInt(rackRows, 10);
+
+  let srcRow, srcCol;
+
   if (position !== undefined && position !== null && position !== '') {
     const p = parseInt(position, 10);
     if (isNaN(p) || p < 1) return { error: 'Invalid position' };
-    return { position: p };
-  }
 
-  // Otherwise we need row + col + rackCols at minimum.
-  const r = parseInt(row, 10);
-  const c = parseInt(col, 10);
-  const rows = parseInt(rackRows, 10);
-  const cols = parseInt(rackCols, 10);
+    // Identity case — no dimensions needed when nothing to flip.
+    if (anchor === 'top-left') return { position: p };
 
-  if (isNaN(r) || r < 1) return { error: 'Invalid row' };
-  if (isNaN(c) || c < 1) return { error: 'Invalid col' };
-  if (isNaN(cols) || cols < 1) return { error: 'rackCols is required to compute position from row/col' };
-  if (c > cols) return { error: `col ${c} exceeds rackCols ${cols}` };
-
-  let effectiveRow = r;
-  if (rowOrigin === 'bottom') {
-    if (isNaN(rows) || rows < 1) {
-      return { error: 'rackRows is required when rowOrigin is "bottom"' };
+    if (isNaN(cols) || cols < 1) {
+      return { error: 'rackCols is required to transform position with a non-default anchor' };
     }
-    if (r > rows) return { error: `row ${r} exceeds rackRows ${rows}` };
-    effectiveRow = rows - r + 1;
+    srcRow = Math.ceil(p / cols);
+    srcCol = ((p - 1) % cols) + 1;
+  } else {
+    srcRow = parseInt(row, 10);
+    srcCol = parseInt(col, 10);
+    if (isNaN(srcRow) || srcRow < 1) return { error: 'Invalid row' };
+    if (isNaN(srcCol) || srcCol < 1) return { error: 'Invalid col' };
+    if (isNaN(cols) || cols < 1) return { error: 'rackCols is required to compute position from row/col' };
+    if (srcCol > cols) return { error: `col ${srcCol} exceeds rackCols ${cols}` };
   }
 
-  return { position: (effectiveRow - 1) * cols + c };
+  // Apply anchor transforms to land in Cellarion's top-left, row-major space.
+  let effectiveRow = srcRow;
+  let effectiveCol = srcCol;
+
+  if (anchor === 'bottom-left' || anchor === 'bottom-right') {
+    if (isNaN(rows) || rows < 1) {
+      return { error: 'rackRows is required for bottom-anchored placement' };
+    }
+    if (srcRow > rows) return { error: `row ${srcRow} exceeds rackRows ${rows}` };
+    effectiveRow = rows - srcRow + 1;
+  }
+  if (anchor === 'top-right' || anchor === 'bottom-right') {
+    if (isNaN(cols) || cols < 1) {
+      return { error: 'rackCols is required for right-anchored placement' };
+    }
+    effectiveCol = cols - srcCol + 1;
+  }
+
+  return { position: (effectiveRow - 1) * cols + effectiveCol };
+}
+
+/**
+ * Suggest reasonable rack dimensions given a max position observed in import
+ * data. Bias toward common physical wine-rack widths (6 or 12 columns) so
+ * the auto-created rack matches what users typically own.
+ */
+function suggestRackDimensions(maxPosition) {
+  const p = Math.max(1, parseInt(maxPosition, 10) || 1);
+  if (p <= 6)  return { rows: 1, cols: p };
+  if (p <= 12) return { rows: 2, cols: 6 };
+  if (p <= 24) return { rows: 4, cols: 6 };
+  if (p <= 72) return { rows: 6, cols: 12 };
+  const cols = 12;
+  const rows = Math.min(20, Math.ceil(p / cols));
+  return { rows, cols };
 }
 
 /**
@@ -110,13 +144,14 @@ function planRackCreations(items) {
 
   // Finalise each entry: ensure rows/cols are at least 1, and that the rack's
   // capacity covers the highest position we'll try to place into. When only a
-  // sequential `rackPosition` is known (no row/col coordinates), fall back to
-  // a typical wine-rack width of 6 columns so the auto-created rack matches
-  // common physical layouts instead of becoming a 1-wide column.
+  // sequential `rackPosition` is known (no row/col coordinates), use
+  // suggestRackDimensions() so the auto-created rack matches typical
+  // physical layouts instead of becoming a 1-wide column.
   for (const entry of plan.values()) {
     if (!entry.rows && !entry.cols && entry.maxPosition > 0) {
-      entry.cols = 6;
-      entry.rows = Math.max(4, Math.ceil(entry.maxPosition / entry.cols));
+      const suggestion = suggestRackDimensions(entry.maxPosition);
+      entry.rows = suggestion.rows;
+      entry.cols = suggestion.cols;
     }
     if (!entry.rows) entry.rows = 1;
     if (!entry.cols) entry.cols = 1;
@@ -143,6 +178,8 @@ function planRackCreations(items) {
 module.exports = {
   computeRackPosition,
   planRackCreations,
+  suggestRackDimensions,
   DEFAULT_RACK_TYPE,
-  VALID_ROW_ORIGINS,
+  DEFAULT_ANCHOR,
+  VALID_ANCHORS,
 };

--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -17,11 +17,17 @@ const VALID_ANCHORS = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
 const DEFAULT_ANCHOR = 'top-left';
 
 /**
- * Compute the 1-indexed sequential position for a slot in Cellarion's internal
- * coordinate system (top-left, row-major), given:
+ * Compute the 1-indexed slot position in Cellarion's internal coordinate
+ * system (top-left, row-major), given:
  *   - A sequential `position` from the source system, or
  *   - A (row, col) pair from the source system,
  * plus the rack's dimensions and where the source system's "bottle 1" sits.
+ *
+ * For shelf racks with `bottlesPerCell > 1` (e.g. Vintec/Oeno cabinets where
+ * each "slot" physically holds a stack of identical bottles), the input
+ * position is treated as a CELL index. The output is the FIRST slot of that
+ * cell — subsequent bottles claiming the same cell will naturally overflow
+ * into the cell's remaining slots via forward-scan placement.
  *
  * `anchor` describes the corner where the source data's position 1 (or row 1,
  * col 1) is located:
@@ -32,13 +38,20 @@ const DEFAULT_ANCHOR = 'top-left';
  *
  * Returns { position } on success or { error } on bad input.
  */
-function computeRackPosition({ position, row, col, rackRows, rackCols, anchor = DEFAULT_ANCHOR }) {
+function computeRackPosition({
+  position, row, col,
+  rackRows, rackCols,
+  rackType, bottlesPerCell,
+  anchor = DEFAULT_ANCHOR
+}) {
   if (!VALID_ANCHORS.includes(anchor)) {
     return { error: `Invalid anchor: ${anchor}` };
   }
 
   const cols = parseInt(rackCols, 10);
   const rows = parseInt(rackRows, 10);
+  const bpc = Math.max(1, parseInt(bottlesPerCell, 10) || 1);
+  const isMultiCell = rackType === 'shelf' && bpc > 1;
 
   let srcRow, srcCol;
 
@@ -46,12 +59,17 @@ function computeRackPosition({ position, row, col, rackRows, rackCols, anchor = 
     const p = parseInt(position, 10);
     if (isNaN(p) || p < 1) return { error: 'Invalid position' };
 
-    // Identity case — no dimensions needed when nothing to flip.
-    if (anchor === 'top-left') return { position: p };
+    // Identity case — no anchor flip needed.
+    if (anchor === 'top-left') {
+      // For shelf cells, the input is a cell index → translate to the
+      // first slot of that cell. For grid, position == slot.
+      return { position: isMultiCell ? (p - 1) * bpc + 1 : p };
+    }
 
     if (isNaN(cols) || cols < 1) {
       return { error: 'rackCols is required to transform position with a non-default anchor' };
     }
+    // Expand the source position into (row, col) of its CELL grid.
     srcRow = Math.ceil(p / cols);
     srcCol = ((p - 1) % cols) + 1;
   } else {
@@ -63,7 +81,8 @@ function computeRackPosition({ position, row, col, rackRows, rackCols, anchor = 
     if (srcCol > cols) return { error: `col ${srcCol} exceeds rackCols ${cols}` };
   }
 
-  // Apply anchor transforms to land in Cellarion's top-left, row-major space.
+  // Apply anchor transforms in CELL-grid space (rows × cols cells), then
+  // expand the resulting cell index to a slot index for multi-cell shelves.
   let effectiveRow = srcRow;
   let effectiveCol = srcCol;
 
@@ -81,7 +100,8 @@ function computeRackPosition({ position, row, col, rackRows, rackCols, anchor = 
     effectiveCol = cols - srcCol + 1;
   }
 
-  return { position: (effectiveRow - 1) * cols + effectiveCol };
+  const cellIndex = (effectiveRow - 1) * cols + effectiveCol;
+  return { position: isMultiCell ? (cellIndex - 1) * bpc + 1 : cellIndex };
 }
 
 /**
@@ -210,6 +230,8 @@ function placeBottlesInRack(rack, items, anchor) {
       col: it.item.col,
       rackRows: rack.rows,
       rackCols: rack.cols,
+      rackType: rack.type,
+      bottlesPerCell: rack.typeConfig?.bottlesPerCell,
       anchor
     });
     if (result.error) {

--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -113,7 +113,7 @@ function suggestRackDimensions(maxPosition) {
  * plan entry if the rack already exists in the cellar.
  */
 function planRackCreations(items) {
-  const plan = new Map(); // rackName -> { type, rows, cols, maxPosition }
+  const plan = new Map(); // rackName -> { type, rows, cols, maxPosition, totalBottles }
 
   for (const item of items) {
     if (!item || !item.rackName) continue;
@@ -122,9 +122,14 @@ function planRackCreations(items) {
 
     let entry = plan.get(name);
     if (!entry) {
-      entry = { type: DEFAULT_RACK_TYPE, rows: 0, cols: 0, maxPosition: 0 };
+      entry = { type: DEFAULT_RACK_TYPE, rows: 0, cols: 0, maxPosition: 0, totalBottles: 0 };
       plan.set(name, entry);
     }
+
+    // Every item in the (already quantity-expanded) batch counts as one bottle
+    // that will claim a slot in this rack — needed so we size the rack big
+    // enough to hold them all, not just to cover the highest slot number used.
+    entry.totalBottles += 1;
 
     if (item.rackType) entry.type = String(item.rackType).trim().toLowerCase();
 
@@ -142,25 +147,27 @@ function planRackCreations(items) {
     if (!isNaN(pos) && pos > entry.maxPosition) entry.maxPosition = pos;
   }
 
-  // Finalise each entry: ensure rows/cols are at least 1, and that the rack's
-  // capacity covers the highest position we'll try to place into. When only a
-  // sequential `rackPosition` is known (no row/col coordinates), use
-  // suggestRackDimensions() so the auto-created rack matches typical
-  // physical layouts instead of becoming a 1-wide column.
+  // Finalise each entry: pick row/col so the rack has capacity for *both* the
+  // highest slot number referenced AND the total number of bottles claiming
+  // it (the latter matters when multiple bottles want the same slot — e.g.
+  // Oeno's "Quantity: 3, Rack_Location: M3-11" expands to 3 bottles all
+  // pointing at slot 11; they need to spill into 2 more slots).
   for (const entry of plan.values()) {
-    if (!entry.rows && !entry.cols && entry.maxPosition > 0) {
-      const suggestion = suggestRackDimensions(entry.maxPosition);
+    const requiredCapacity = Math.max(entry.maxPosition || 0, entry.totalBottles || 0);
+
+    if (!entry.rows && !entry.cols && requiredCapacity > 0) {
+      const suggestion = suggestRackDimensions(requiredCapacity);
       entry.rows = suggestion.rows;
       entry.cols = suggestion.cols;
     }
     if (!entry.rows) entry.rows = 1;
     if (!entry.cols) entry.cols = 1;
 
-    // Grow capacity to fit the highest position if needed (grid + shelf).
+    // Grow capacity to fit if needed (grid + shelf).
     if (entry.type === 'grid' || entry.type === 'shelf') {
       const capacity = totalSlots(entry.type, entry.rows, entry.cols);
-      if (entry.maxPosition > capacity) {
-        entry.rows = Math.ceil(entry.maxPosition / entry.cols);
+      if (requiredCapacity > capacity) {
+        entry.rows = Math.ceil(requiredCapacity / entry.cols);
       }
     }
 
@@ -170,15 +177,76 @@ function planRackCreations(items) {
     if (entry.cols > 20) entry.cols = 20;
 
     delete entry.maxPosition;
+    delete entry.totalBottles;
   }
 
   return plan;
+}
+
+/**
+ * Find the closest free position to `requestedPosition` within [1, maxPosition].
+ * Scans forward first, then backward. Returns null if the rack is full.
+ */
+function findNextFreeSlot(occupied, requestedPosition, maxPosition) {
+  for (let p = requestedPosition + 1; p <= maxPosition; p++) {
+    if (!occupied.has(p)) return p;
+  }
+  for (let p = requestedPosition - 1; p >= 1; p--) {
+    if (!occupied.has(p)) return p;
+  }
+  return null;
+}
+
+/**
+ * Two-pass placement: bottles get their exact requested slot when free
+ * (pass 1, first-come-first-served), then unplaced bottles overflow into
+ * the nearest empty slot (pass 2). Returns the list of placements to add
+ * to the rack plus any bottles that couldn't fit.
+ *
+ * @param {Array<{position: number, bottle: any}>} existingSlots
+ *        Slots already on the rack (their positions are off-limits).
+ * @param {Array<{requestedPosition: number, bottleId: any, sourceIndex?: number}>} requests
+ *        Bottles wanting a slot in this rack, in the order they came from the CSV.
+ * @param {number} maxPosition Total addressable slots in this rack.
+ * @returns {{placements: Array, unplaced: Array}}
+ */
+function placeBottles(existingSlots, requests, maxPosition) {
+  const occupied = new Set((existingSlots || []).map(s => s.position));
+  const placements = [];
+  const overflow = [];
+
+  // Pass 1: exact placement, first request to a slot wins.
+  for (const req of requests) {
+    const pos = parseInt(req.requestedPosition, 10);
+    if (!isNaN(pos) && pos >= 1 && pos <= maxPosition && !occupied.has(pos)) {
+      placements.push({ position: pos, bottle: req.bottleId, request: req });
+      occupied.add(pos);
+    } else {
+      overflow.push(req);
+    }
+  }
+
+  // Pass 2: overflow into nearest empty slot.
+  const unplaced = [];
+  for (const req of overflow) {
+    const target = findNextFreeSlot(occupied, parseInt(req.requestedPosition, 10) || 1, maxPosition);
+    if (target !== null) {
+      placements.push({ position: target, bottle: req.bottleId, request: req, overflowed: true });
+      occupied.add(target);
+    } else {
+      unplaced.push(req);
+    }
+  }
+
+  return { placements, unplaced };
 }
 
 module.exports = {
   computeRackPosition,
   planRackCreations,
   suggestRackDimensions,
+  findNextFreeSlot,
+  placeBottles,
   DEFAULT_RACK_TYPE,
   DEFAULT_ANCHOR,
   VALID_ANCHORS,

--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -184,6 +184,59 @@ function planRackCreations(items) {
 }
 
 /**
+ * End-to-end placement orchestration for a single rack: translate each item's
+ * (source-system) position via the anchor, then run the two-pass algorithm.
+ *
+ * Pure function — does not touch Mongo. The caller passes in the rack's
+ * geometry + existing slots and gets back a list of slot writes + the
+ * collection of items that couldn't be placed and why.
+ *
+ * @param {{type, rows, cols, typeConfig, slots, maxPosition}} rack
+ * @param {Array<{item: object, bottleId: any, sourceIndex?: number}>} items
+ * @param {string} anchor One of VALID_ANCHORS
+ * @returns {{
+ *   placements: Array<{position: number, bottle: any, overflowed?: boolean}>,
+ *   unplaced: Array<{sourceIndex?: number, requestedPosition: number|null, reason: string}>
+ * }}
+ */
+function placeBottlesInRack(rack, items, anchor) {
+  const requests = [];
+  const unplaced = [];
+
+  for (const it of items) {
+    const result = computeRackPosition({
+      position: it.item.rackPosition,
+      row: it.item.row,
+      col: it.item.col,
+      rackRows: rack.rows,
+      rackCols: rack.cols,
+      anchor
+    });
+    if (result.error) {
+      unplaced.push({ sourceIndex: it.sourceIndex, requestedPosition: null, reason: result.error });
+      continue;
+    }
+    if (result.position > rack.maxPosition) {
+      unplaced.push({
+        sourceIndex: it.sourceIndex,
+        requestedPosition: result.position,
+        reason: `Slot ${result.position} exceeds rack capacity (${rack.maxPosition})`
+      });
+      continue;
+    }
+    requests.push({ requestedPosition: result.position, bottleId: it.bottleId, sourceIndex: it.sourceIndex });
+  }
+
+  const { placements, unplaced: tooFull } = placeBottles(rack.slots || [], requests, rack.maxPosition);
+
+  for (const t of tooFull) {
+    unplaced.push({ sourceIndex: t.sourceIndex, requestedPosition: t.requestedPosition, reason: 'Rack full' });
+  }
+
+  return { placements, unplaced };
+}
+
+/**
  * Find the closest free position to `requestedPosition` within [1, maxPosition].
  * Scans forward first, then backward. Returns null if the rack is full.
  */
@@ -247,6 +300,7 @@ module.exports = {
   suggestRackDimensions,
   findNextFreeSlot,
   placeBottles,
+  placeBottlesInRack,
   DEFAULT_RACK_TYPE,
   DEFAULT_ANCHOR,
   VALID_ANCHORS,

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -1,8 +1,8 @@
-const { computeRackPosition, planRackCreations } = require('./rackImport');
+const { computeRackPosition, planRackCreations, suggestRackDimensions } = require('./rackImport');
 
 describe('computeRackPosition', () => {
   describe('explicit position', () => {
-    test('returns the position when given a valid number', () => {
+    test('returns the position unchanged with default top-left anchor', () => {
       expect(computeRackPosition({ position: 7 })).toEqual({ position: 7 });
     });
 
@@ -20,21 +20,13 @@ describe('computeRackPosition', () => {
     });
   });
 
-  describe('row + col with rowOrigin=top (default)', () => {
+  describe('row + col with default top-left anchor', () => {
     test('maps (row=1, col=1) to position 1 in a 6-wide grid', () => {
       expect(computeRackPosition({ row: 1, col: 1, rackCols: 6 })).toEqual({ position: 1 });
     });
 
-    test('maps (row=1, col=6) to position 6', () => {
-      expect(computeRackPosition({ row: 1, col: 6, rackCols: 6 })).toEqual({ position: 6 });
-    });
-
     test('maps (row=2, col=1) to position 7 in a 6-wide grid', () => {
       expect(computeRackPosition({ row: 2, col: 1, rackCols: 6 })).toEqual({ position: 7 });
-    });
-
-    test('maps (row=3, col=4) to position 16 in a 6-wide grid', () => {
-      expect(computeRackPosition({ row: 3, col: 4, rackCols: 6 })).toEqual({ position: 16 });
     });
 
     test('rejects when rackCols is missing', () => {
@@ -46,61 +38,110 @@ describe('computeRackPosition', () => {
     });
   });
 
-  describe('row + col with rowOrigin=bottom (Oeno-style)', () => {
-    test('maps (row=1, col=1) at bottom to last row first slot in an 18×6 rack', () => {
-      // Bottom row 1 -> effectiveRow 18 -> position (18-1)*6 + 1 = 103
-      expect(computeRackPosition({ row: 1, col: 1, rackRows: 18, rackCols: 6, rowOrigin: 'bottom' }))
+  describe('anchor=bottom-left (row+col)', () => {
+    test('flips row only in an 18×6 rack', () => {
+      // Bottom row 1 → effective row 18 → position (18-1)*6 + 1 = 103
+      expect(computeRackPosition({ row: 1, col: 1, rackRows: 18, rackCols: 6, anchor: 'bottom-left' }))
         .toEqual({ position: 103 });
     });
 
-    test('maps (row=18, col=6) at bottom to position 6 (top-right)', () => {
-      // Top row 18 -> effectiveRow 1 -> position (1-1)*6 + 6 = 6
-      expect(computeRackPosition({ row: 18, col: 6, rackRows: 18, rackCols: 6, rowOrigin: 'bottom' }))
-        .toEqual({ position: 6 });
-    });
-
-    test('maps (row=9, col=3) at bottom in 18×6 to position 64', () => {
-      // effectiveRow = 18 - 9 + 1 = 10 -> position (10-1)*6 + 3 = 57 + 3 = 57? recompute: (10-1)*6=54; 54+3=57
-      // Wait: 18-9+1 = 10. (10-1)*6 = 54. 54+3 = 57. Adjust expectation.
-      expect(computeRackPosition({ row: 9, col: 3, rackRows: 18, rackCols: 6, rowOrigin: 'bottom' }))
-        .toEqual({ position: 57 });
-    });
-
-    test('rejects when rackRows missing and rowOrigin=bottom', () => {
-      expect(computeRackPosition({ row: 1, col: 1, rackCols: 6, rowOrigin: 'bottom' }).error)
+    test('rejects when rackRows missing', () => {
+      expect(computeRackPosition({ row: 1, col: 1, rackCols: 6, anchor: 'bottom-left' }).error)
         .toMatch(/rackRows/);
     });
 
     test('rejects when row exceeds rackRows', () => {
-      expect(computeRackPosition({ row: 19, col: 1, rackRows: 18, rackCols: 6, rowOrigin: 'bottom' }).error)
+      expect(computeRackPosition({ row: 19, col: 1, rackRows: 18, rackCols: 6, anchor: 'bottom-left' }).error)
         .toMatch(/exceeds/);
     });
   });
 
-  test('rejects invalid rowOrigin', () => {
-    expect(computeRackPosition({ row: 1, col: 1, rackCols: 6, rowOrigin: 'left' }).error)
-      .toMatch(/rowOrigin/);
+  describe('anchor=top-right (row+col)', () => {
+    test('flips col only', () => {
+      // (row=1, col=1) anchored top-right in a 6-wide rack → col 6 → position 6
+      expect(computeRackPosition({ row: 1, col: 1, rackCols: 6, anchor: 'top-right' }))
+        .toEqual({ position: 6 });
+    });
+  });
+
+  describe('anchor=bottom-right (row+col)', () => {
+    test('flips both row and col', () => {
+      // (row=1, col=1) bottom-right in 18×6 → effective (18, 6) → position (18-1)*6 + 6 = 108
+      expect(computeRackPosition({ row: 1, col: 1, rackRows: 18, rackCols: 6, anchor: 'bottom-right' }))
+        .toEqual({ position: 108 });
+    });
+  });
+
+  describe('explicit position with non-default anchor', () => {
+    test('flips row when anchor is bottom-left in a 4×6 grid', () => {
+      // Oeno position 11 in a 4-row × 6-col rack:
+      // srcRow = ceil(11/6) = 2, srcCol = ((11-1) % 6) + 1 = 5
+      // bottom-left flips row: effectiveRow = 4 - 2 + 1 = 3
+      // cellarion position = (3-1)*6 + 5 = 17
+      expect(computeRackPosition({ position: 11, rackRows: 4, rackCols: 6, anchor: 'bottom-left' }))
+        .toEqual({ position: 17 });
+    });
+
+    test('flips col when anchor is top-right in a 4×6 grid', () => {
+      // srcRow=2, srcCol=5, top-right flips col: effectiveCol = 6 - 5 + 1 = 2
+      // cellarion = (2-1)*6 + 2 = 8
+      expect(computeRackPosition({ position: 11, rackRows: 4, rackCols: 6, anchor: 'top-right' }))
+        .toEqual({ position: 8 });
+    });
+
+    test('flips both with bottom-right', () => {
+      // srcRow=2, srcCol=5, bottom-right: effectiveRow=3, effectiveCol=2
+      // cellarion = (3-1)*6 + 2 = 14
+      expect(computeRackPosition({ position: 11, rackRows: 4, rackCols: 6, anchor: 'bottom-right' }))
+        .toEqual({ position: 14 });
+    });
+
+    test('rejects non-default anchor without rackCols', () => {
+      expect(computeRackPosition({ position: 11, anchor: 'bottom-left' }).error)
+        .toMatch(/rackCols/);
+    });
+  });
+
+  test('rejects invalid anchor', () => {
+    expect(computeRackPosition({ row: 1, col: 1, rackCols: 6, anchor: 'sideways' }).error)
+      .toMatch(/anchor/);
+  });
+});
+
+describe('suggestRackDimensions', () => {
+  test('single row for tiny racks (≤ 6)', () => {
+    expect(suggestRackDimensions(5)).toEqual({ rows: 1, cols: 5 });
+    expect(suggestRackDimensions(6)).toEqual({ rows: 1, cols: 6 });
+  });
+
+  test('2×6 for small wine racks (7–12)', () => {
+    expect(suggestRackDimensions(11)).toEqual({ rows: 2, cols: 6 });
+    expect(suggestRackDimensions(12)).toEqual({ rows: 2, cols: 6 });
+  });
+
+  test('4×6 for medium racks (13–24)', () => {
+    expect(suggestRackDimensions(20)).toEqual({ rows: 4, cols: 6 });
+    expect(suggestRackDimensions(24)).toEqual({ rows: 4, cols: 6 });
+  });
+
+  test('6×12 for larger racks (25–72)', () => {
+    expect(suggestRackDimensions(48)).toEqual({ rows: 6, cols: 12 });
+  });
+
+  test('scales rows when max position exceeds 72, capped at 20', () => {
+    expect(suggestRackDimensions(120)).toEqual({ rows: 10, cols: 12 });
+    expect(suggestRackDimensions(500)).toEqual({ rows: 20, cols: 12 });
   });
 });
 
 describe('planRackCreations', () => {
-  test('returns empty map when no items have rackName', () => {
-    const plan = planRackCreations([
-      { wineName: 'Wine A' },
-      { wineName: 'Wine B', rackName: '' },
-    ]);
-    expect(plan.size).toBe(0);
-  });
-
   test('groups items by rackName', () => {
     const plan = planRackCreations([
-      { rackName: 'Rack A', row: 1, col: 1 },
-      { rackName: 'Rack A', row: 2, col: 3 },
-      { rackName: 'Rack B', row: 1, col: 1 },
+      { rackName: 'A', row: 1, col: 1 },
+      { rackName: 'A', row: 2, col: 3 },
+      { rackName: 'B', row: 1, col: 1 },
     ]);
     expect(plan.size).toBe(2);
-    expect(plan.has('Rack A')).toBe(true);
-    expect(plan.has('Rack B')).toBe(true);
   });
 
   test('infers rows/cols from max observed row/col', () => {
@@ -120,31 +161,14 @@ describe('planRackCreations', () => {
     expect(plan.get('A')).toMatchObject({ rows: 18, cols: 6 });
   });
 
-  test('grows rows to fit a rackPosition that exceeds rows*cols capacity', () => {
-    const plan = planRackCreations([
-      { rackName: 'A', rackPosition: 95, rackCols: 6 },
-    ]);
-    // cols=6, position=95, need rows >= ceil(95/6) = 16
-    expect(plan.get('A')).toMatchObject({ cols: 6, rows: 16 });
-  });
-
-  test('Oeno-style: uses 6-col default and 4-row minimum when only rackPosition is known', () => {
-    // Matches Keith's CSV: M3-11 → rackName=M3, rackPosition=11, no row/col,
-    // no rackRows/rackCols. We want a sensible default rack shape, not a 1-wide column.
+  test('uses suggestRackDimensions when only rackPosition is known', () => {
+    // Mirrors Keith's M3 (positions 4, 10, 11): max 11 → suggestion is 2×6
     const plan = planRackCreations([
       { rackName: 'M3', rackPosition: 11 },
       { rackName: 'M3', rackPosition: 4 },
       { rackName: 'M3', rackPosition: 10 },
     ]);
-    expect(plan.get('M3')).toMatchObject({ cols: 6, rows: 4, type: 'grid' });
-  });
-
-  test('Oeno-style: grows rows when max position exceeds 4 rows at 6 cols', () => {
-    const plan = planRackCreations([
-      { rackName: 'BigRack', rackPosition: 50 },
-    ]);
-    // 6 cols × 4 rows = 24 < 50 → rows = ceil(50/6) = 9
-    expect(plan.get('BigRack')).toMatchObject({ cols: 6, rows: 9 });
+    expect(plan.get('M3')).toMatchObject({ cols: 6, rows: 2, type: 'grid' });
   });
 
   test('respects rackType override', () => {
@@ -160,13 +184,6 @@ describe('planRackCreations', () => {
     ]);
     expect(plan.get('Huge').rows).toBe(20);
     expect(plan.get('Huge').cols).toBe(20);
-  });
-
-  test('defaults to rows=1, cols=1 when no positional info present', () => {
-    const plan = planRackCreations([
-      { rackName: 'Bare' },
-    ]);
-    expect(plan.get('Bare')).toMatchObject({ rows: 1, cols: 1, type: 'grid' });
   });
 
   test('skips empty/whitespace rackName', () => {

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -1,4 +1,4 @@
-const { computeRackPosition, planRackCreations, suggestRackDimensions, findNextFreeSlot, placeBottles } = require('./rackImport');
+const { computeRackPosition, planRackCreations, suggestRackDimensions, findNextFreeSlot, placeBottles, placeBottlesInRack } = require('./rackImport');
 
 describe('computeRackPosition', () => {
   describe('explicit position', () => {
@@ -314,5 +314,68 @@ describe('placeBottles', () => {
       { requestedPosition: 5, bottleId: 'a' },
     ], 5);
     expect(result.placements[0].position).toBe(4);
+  });
+});
+
+describe('placeBottlesInRack (orchestration)', () => {
+  const buildRack = (overrides = {}) => ({
+    type: 'grid', rows: 4, cols: 6, typeConfig: undefined,
+    slots: [], maxPosition: 24, ...overrides
+  });
+
+  test('end-to-end: Oeno-style M3 with Quantity=3 at slot 11 spreads into 11,12,13', () => {
+    // Recreates Keith's scenario for a single rack
+    const rack = buildRack({ rows: 4, cols: 6, maxPosition: 24 });
+    const items = [
+      { item: { rackPosition: 11 }, bottleId: 'chenin-1', sourceIndex: 0 },
+      { item: { rackPosition: 11 }, bottleId: 'chenin-2', sourceIndex: 1 },
+      { item: { rackPosition: 11 }, bottleId: 'chenin-3', sourceIndex: 2 },
+    ];
+    const { placements, unplaced } = placeBottlesInRack(rack, items, 'top-left');
+    expect(unplaced).toHaveLength(0);
+    const placementOf = (id) => placements.find(p => p.bottle === id).position;
+    expect(placementOf('chenin-1')).toBe(11);
+    expect(placementOf('chenin-2')).toBe(12);
+    expect(placementOf('chenin-3')).toBe(13);
+  });
+
+  test('end-to-end: anchor=bottom-left flips row before placement', () => {
+    // Slot 11 in a 4×6 anchored bottom-left → Cellarion position 17
+    const rack = buildRack();
+    const { placements } = placeBottlesInRack(rack, [
+      { item: { rackPosition: 11 }, bottleId: 'a', sourceIndex: 0 },
+    ], 'bottom-left');
+    expect(placements[0].position).toBe(17);
+  });
+
+  test('end-to-end: existing slots block placement, force overflow', () => {
+    const rack = buildRack({
+      slots: [{ position: 11, bottle: 'pre' }]
+    });
+    const { placements } = placeBottlesInRack(rack, [
+      { item: { rackPosition: 11 }, bottleId: 'a', sourceIndex: 0 },
+    ], 'top-left');
+    expect(placements[0].position).toBe(12);
+    expect(placements[0].overflowed).toBe(true);
+  });
+
+  test('end-to-end: reports unplaced when slot exceeds capacity', () => {
+    const rack = buildRack({ rows: 2, cols: 6, maxPosition: 12 });
+    const { placements, unplaced } = placeBottlesInRack(rack, [
+      { item: { rackPosition: 25 }, bottleId: 'a', sourceIndex: 4 },
+    ], 'top-left');
+    expect(placements).toHaveLength(0);
+    expect(unplaced).toHaveLength(1);
+    expect(unplaced[0]).toMatchObject({ sourceIndex: 4, requestedPosition: 25 });
+    expect(unplaced[0].reason).toMatch(/capacity/);
+  });
+
+  test('end-to-end: row+col coordinates flatten using rack geometry', () => {
+    const rack = buildRack();
+    const { placements } = placeBottlesInRack(rack, [
+      { item: { row: 2, col: 3 }, bottleId: 'a', sourceIndex: 0 },
+    ], 'top-left');
+    // row 2 col 3 in a 6-col grid → position (2-1)*6 + 3 = 9
+    expect(placements[0].position).toBe(9);
   });
 });

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -370,6 +370,70 @@ describe('placeBottlesInRack (orchestration)', () => {
     expect(unplaced[0].reason).toMatch(/capacity/);
   });
 
+  test('shelf rack: 3 bottles claiming Oeno cell 11 land in slots 31, 32, 33 (bpc=3)', () => {
+    // Vintec/Oeno cabinet: shelf with 2 rows × 6 cols × 3 bottles/cell = 36 slots.
+    // Oeno "cell 11" = top row, col 5 → Cellarion's first slot of cell 11 = 31.
+    // 3 bottles all claiming cell 11 should naturally pack into slots 31, 32, 33.
+    const rack = {
+      type: 'shelf', rows: 2, cols: 6, typeConfig: { bottlesPerCell: 3 },
+      slots: [], maxPosition: 36
+    };
+    const items = [
+      { item: { rackPosition: 11 }, bottleId: 'chenin-1', sourceIndex: 0 },
+      { item: { rackPosition: 11 }, bottleId: 'chenin-2', sourceIndex: 1 },
+      { item: { rackPosition: 11 }, bottleId: 'chenin-3', sourceIndex: 2 },
+    ];
+    const { placements, unplaced } = placeBottlesInRack(rack, items, 'top-left');
+    expect(unplaced).toHaveLength(0);
+    const positions = placements.map(p => p.position).sort((a, b) => a - b);
+    expect(positions).toEqual([31, 32, 33]);
+  });
+
+  test('shelf rack: cell 12 (next cell) gets positions 34-36; cell 1 gets 1-3', () => {
+    const rack = {
+      type: 'shelf', rows: 2, cols: 6, typeConfig: { bottlesPerCell: 3 },
+      slots: [], maxPosition: 36
+    };
+    const items = [
+      { item: { rackPosition: 1 }, bottleId: 'a', sourceIndex: 0 },
+      { item: { rackPosition: 12 }, bottleId: 'b', sourceIndex: 1 },
+    ];
+    const { placements } = placeBottlesInRack(rack, items, 'top-left');
+    const posOf = (id) => placements.find(p => p.bottle === id).position;
+    expect(posOf('a')).toBe(1);
+    expect(posOf('b')).toBe(34);
+  });
+
+  test('shelf rack with bottom-left anchor: cell 11 flips through cell-grid math', () => {
+    // 2×6 shelf, bpc=3, anchor=bottom-left.
+    // Oeno cell 11 → cell-grid (row 2, col 5). bottom-left flips row → (row 1, col 5).
+    // Cellarion cell index = (1-1)*6 + 5 = 5. First slot of cell 5 = (5-1)*3 + 1 = 13.
+    const rack = {
+      type: 'shelf', rows: 2, cols: 6, typeConfig: { bottlesPerCell: 3 },
+      slots: [], maxPosition: 36
+    };
+    const items = [
+      { item: { rackPosition: 11 }, bottleId: 'a', sourceIndex: 0 },
+    ];
+    const { placements } = placeBottlesInRack(rack, items, 'bottom-left');
+    expect(placements[0].position).toBe(13);
+  });
+
+  test('shelf rack: overflow when cell is full spills into the next cell', () => {
+    // 4 bottles trying to fit into a cell with bpc=3 — the 4th overflows.
+    const rack = {
+      type: 'shelf', rows: 2, cols: 6, typeConfig: { bottlesPerCell: 3 },
+      slots: [], maxPosition: 36
+    };
+    const items = Array.from({ length: 4 }, (_, i) => ({
+      item: { rackPosition: 11 }, bottleId: `b${i}`, sourceIndex: i
+    }));
+    const { placements, unplaced } = placeBottlesInRack(rack, items, 'top-left');
+    expect(unplaced).toHaveLength(0);
+    const positions = placements.map(p => p.position).sort((a, b) => a - b);
+    expect(positions).toEqual([31, 32, 33, 34]); // 34 is cell 12's first slot
+  });
+
   test('end-to-end: row+col coordinates flatten using rack geometry', () => {
     const rack = buildRack();
     const { placements } = placeBottlesInRack(rack, [

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -1,0 +1,159 @@
+const { computeRackPosition, planRackCreations } = require('./rackImport');
+
+describe('computeRackPosition', () => {
+  describe('explicit position', () => {
+    test('returns the position when given a valid number', () => {
+      expect(computeRackPosition({ position: 7 })).toEqual({ position: 7 });
+    });
+
+    test('parses a numeric string', () => {
+      expect(computeRackPosition({ position: '12' })).toEqual({ position: 12 });
+    });
+
+    test('rejects zero or negative', () => {
+      expect(computeRackPosition({ position: 0 }).error).toBeDefined();
+      expect(computeRackPosition({ position: -3 }).error).toBeDefined();
+    });
+
+    test('rejects non-numeric strings', () => {
+      expect(computeRackPosition({ position: 'abc' }).error).toBeDefined();
+    });
+  });
+
+  describe('row + col with rowOrigin=top (default)', () => {
+    test('maps (row=1, col=1) to position 1 in a 6-wide grid', () => {
+      expect(computeRackPosition({ row: 1, col: 1, rackCols: 6 })).toEqual({ position: 1 });
+    });
+
+    test('maps (row=1, col=6) to position 6', () => {
+      expect(computeRackPosition({ row: 1, col: 6, rackCols: 6 })).toEqual({ position: 6 });
+    });
+
+    test('maps (row=2, col=1) to position 7 in a 6-wide grid', () => {
+      expect(computeRackPosition({ row: 2, col: 1, rackCols: 6 })).toEqual({ position: 7 });
+    });
+
+    test('maps (row=3, col=4) to position 16 in a 6-wide grid', () => {
+      expect(computeRackPosition({ row: 3, col: 4, rackCols: 6 })).toEqual({ position: 16 });
+    });
+
+    test('rejects when rackCols is missing', () => {
+      expect(computeRackPosition({ row: 1, col: 1 }).error).toBeDefined();
+    });
+
+    test('rejects when col exceeds rackCols', () => {
+      expect(computeRackPosition({ row: 1, col: 7, rackCols: 6 }).error).toMatch(/exceeds/);
+    });
+  });
+
+  describe('row + col with rowOrigin=bottom (Oeno-style)', () => {
+    test('maps (row=1, col=1) at bottom to last row first slot in an 18×6 rack', () => {
+      // Bottom row 1 -> effectiveRow 18 -> position (18-1)*6 + 1 = 103
+      expect(computeRackPosition({ row: 1, col: 1, rackRows: 18, rackCols: 6, rowOrigin: 'bottom' }))
+        .toEqual({ position: 103 });
+    });
+
+    test('maps (row=18, col=6) at bottom to position 6 (top-right)', () => {
+      // Top row 18 -> effectiveRow 1 -> position (1-1)*6 + 6 = 6
+      expect(computeRackPosition({ row: 18, col: 6, rackRows: 18, rackCols: 6, rowOrigin: 'bottom' }))
+        .toEqual({ position: 6 });
+    });
+
+    test('maps (row=9, col=3) at bottom in 18×6 to position 64', () => {
+      // effectiveRow = 18 - 9 + 1 = 10 -> position (10-1)*6 + 3 = 57 + 3 = 57? recompute: (10-1)*6=54; 54+3=57
+      // Wait: 18-9+1 = 10. (10-1)*6 = 54. 54+3 = 57. Adjust expectation.
+      expect(computeRackPosition({ row: 9, col: 3, rackRows: 18, rackCols: 6, rowOrigin: 'bottom' }))
+        .toEqual({ position: 57 });
+    });
+
+    test('rejects when rackRows missing and rowOrigin=bottom', () => {
+      expect(computeRackPosition({ row: 1, col: 1, rackCols: 6, rowOrigin: 'bottom' }).error)
+        .toMatch(/rackRows/);
+    });
+
+    test('rejects when row exceeds rackRows', () => {
+      expect(computeRackPosition({ row: 19, col: 1, rackRows: 18, rackCols: 6, rowOrigin: 'bottom' }).error)
+        .toMatch(/exceeds/);
+    });
+  });
+
+  test('rejects invalid rowOrigin', () => {
+    expect(computeRackPosition({ row: 1, col: 1, rackCols: 6, rowOrigin: 'left' }).error)
+      .toMatch(/rowOrigin/);
+  });
+});
+
+describe('planRackCreations', () => {
+  test('returns empty map when no items have rackName', () => {
+    const plan = planRackCreations([
+      { wineName: 'Wine A' },
+      { wineName: 'Wine B', rackName: '' },
+    ]);
+    expect(plan.size).toBe(0);
+  });
+
+  test('groups items by rackName', () => {
+    const plan = planRackCreations([
+      { rackName: 'Rack A', row: 1, col: 1 },
+      { rackName: 'Rack A', row: 2, col: 3 },
+      { rackName: 'Rack B', row: 1, col: 1 },
+    ]);
+    expect(plan.size).toBe(2);
+    expect(plan.has('Rack A')).toBe(true);
+    expect(plan.has('Rack B')).toBe(true);
+  });
+
+  test('infers rows/cols from max observed row/col', () => {
+    const plan = planRackCreations([
+      { rackName: 'A', row: 1, col: 2 },
+      { rackName: 'A', row: 5, col: 1 },
+      { rackName: 'A', row: 3, col: 8 },
+    ]);
+    expect(plan.get('A')).toMatchObject({ type: 'grid', rows: 5, cols: 8 });
+  });
+
+  test('honours explicit rackRows/rackCols when larger than observed', () => {
+    const plan = planRackCreations([
+      { rackName: 'A', row: 1, col: 1, rackRows: 18, rackCols: 6 },
+      { rackName: 'A', row: 2, col: 2 },
+    ]);
+    expect(plan.get('A')).toMatchObject({ rows: 18, cols: 6 });
+  });
+
+  test('grows rows to fit a rackPosition that exceeds rows*cols capacity', () => {
+    const plan = planRackCreations([
+      { rackName: 'A', rackPosition: 95, rackCols: 6 },
+    ]);
+    // cols=6, position=95, need rows >= ceil(95/6) = 16
+    expect(plan.get('A')).toMatchObject({ cols: 6, rows: 16 });
+  });
+
+  test('respects rackType override', () => {
+    const plan = planRackCreations([
+      { rackName: 'Honeycomb', row: 1, col: 1, rackType: 'hex' },
+    ]);
+    expect(plan.get('Honeycomb').type).toBe('hex');
+  });
+
+  test('clamps rows/cols to schema max of 20', () => {
+    const plan = planRackCreations([
+      { rackName: 'Huge', row: 25, col: 30 },
+    ]);
+    expect(plan.get('Huge').rows).toBe(20);
+    expect(plan.get('Huge').cols).toBe(20);
+  });
+
+  test('defaults to rows=1, cols=1 when no positional info present', () => {
+    const plan = planRackCreations([
+      { rackName: 'Bare' },
+    ]);
+    expect(plan.get('Bare')).toMatchObject({ rows: 1, cols: 1, type: 'grid' });
+  });
+
+  test('skips empty/whitespace rackName', () => {
+    const plan = planRackCreations([
+      { rackName: '   ', row: 1, col: 1 },
+    ]);
+    expect(plan.size).toBe(0);
+  });
+});

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -128,6 +128,25 @@ describe('planRackCreations', () => {
     expect(plan.get('A')).toMatchObject({ cols: 6, rows: 16 });
   });
 
+  test('Oeno-style: uses 6-col default and 4-row minimum when only rackPosition is known', () => {
+    // Matches Keith's CSV: M3-11 → rackName=M3, rackPosition=11, no row/col,
+    // no rackRows/rackCols. We want a sensible default rack shape, not a 1-wide column.
+    const plan = planRackCreations([
+      { rackName: 'M3', rackPosition: 11 },
+      { rackName: 'M3', rackPosition: 4 },
+      { rackName: 'M3', rackPosition: 10 },
+    ]);
+    expect(plan.get('M3')).toMatchObject({ cols: 6, rows: 4, type: 'grid' });
+  });
+
+  test('Oeno-style: grows rows when max position exceeds 4 rows at 6 cols', () => {
+    const plan = planRackCreations([
+      { rackName: 'BigRack', rackPosition: 50 },
+    ]);
+    // 6 cols × 4 rows = 24 < 50 → rows = ceil(50/6) = 9
+    expect(plan.get('BigRack')).toMatchObject({ cols: 6, rows: 9 });
+  });
+
   test('respects rackType override', () => {
     const plan = planRackCreations([
       { rackName: 'Honeycomb', row: 1, col: 1, rackType: 'hex' },

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -1,4 +1,4 @@
-const { computeRackPosition, planRackCreations, suggestRackDimensions } = require('./rackImport');
+const { computeRackPosition, planRackCreations, suggestRackDimensions, findNextFreeSlot, placeBottles } = require('./rackImport');
 
 describe('computeRackPosition', () => {
   describe('explicit position', () => {
@@ -191,5 +191,128 @@ describe('planRackCreations', () => {
       { rackName: '   ', row: 1, col: 1 },
     ]);
     expect(plan.size).toBe(0);
+  });
+
+  test('sizes rack by total bottle count when many bottles share a slot', () => {
+    // Mirrors Keith's data: 3 Riesling + 3 Chenin Blanc + 2 Pinot + 1 Ata Rangi
+    // all claim positions in M3 (total 9 bottles), with max position 11.
+    // Required capacity = max(11, 9) = 11. Suggestion for 11 is 2×6 = 12 slots. ✓
+    const plan = planRackCreations([
+      { rackName: 'M3', rackPosition: 11 }, // Chenin 1
+      { rackName: 'M3', rackPosition: 11 }, // Chenin 2
+      { rackName: 'M3', rackPosition: 11 }, // Chenin 3
+      { rackName: 'M3', rackPosition: 10 }, // Riesling 1
+      { rackName: 'M3', rackPosition: 10 }, // Riesling 2
+      { rackName: 'M3', rackPosition: 10 }, // Riesling 3
+      { rackName: 'M3', rackPosition: 4 },  // Ata Rangi 1
+      { rackName: 'M3', rackPosition: 4 },  // Ata Rangi 2
+    ]);
+    const m3 = plan.get('M3');
+    // 2×6 = 12 slots, ≥ max(11, 8) = 11. ✓
+    expect(m3.rows * m3.cols).toBeGreaterThanOrEqual(11);
+    expect(m3.rows * m3.cols).toBeGreaterThanOrEqual(8); // bottle count
+  });
+
+  test('grows capacity when total bottle count exceeds max position', () => {
+    // Edge case: many bottles all claim slot 3 → capacity needs >= count
+    const items = Array.from({ length: 15 }, () => ({ rackName: 'Big', rackPosition: 3 }));
+    const plan = planRackCreations(items);
+    const big = plan.get('Big');
+    expect(big.rows * big.cols).toBeGreaterThanOrEqual(15);
+  });
+});
+
+describe('findNextFreeSlot', () => {
+  test('returns next forward slot when forward slot is free', () => {
+    const occupied = new Set([5]);
+    expect(findNextFreeSlot(occupied, 5, 24)).toBe(6);
+  });
+
+  test('skips occupied slots forward', () => {
+    const occupied = new Set([5, 6, 7]);
+    expect(findNextFreeSlot(occupied, 5, 24)).toBe(8);
+  });
+
+  test('falls back to backward search when forward is exhausted', () => {
+    const occupied = new Set([5, 6, 7, 8, 9, 10, 11, 12]);
+    expect(findNextFreeSlot(occupied, 7, 12)).toBe(4);
+  });
+
+  test('returns null when the rack is full', () => {
+    const occupied = new Set([1, 2, 3, 4, 5]);
+    expect(findNextFreeSlot(occupied, 3, 5)).toBeNull();
+  });
+});
+
+describe('placeBottles', () => {
+  test('places single bottles at their exact requested positions', () => {
+    const result = placeBottles([], [
+      { requestedPosition: 4, bottleId: 'a' },
+      { requestedPosition: 10, bottleId: 'b' },
+      { requestedPosition: 11, bottleId: 'c' },
+    ], 24);
+    expect(result.placements).toEqual([
+      expect.objectContaining({ position: 4, bottle: 'a' }),
+      expect.objectContaining({ position: 10, bottle: 'b' }),
+      expect.objectContaining({ position: 11, bottle: 'c' }),
+    ]);
+    expect(result.unplaced).toHaveLength(0);
+  });
+
+  test('overflows multiple bottles claiming the same slot into adjacent slots', () => {
+    // 3 bottles all want slot 11 in a 24-slot rack
+    const result = placeBottles([], [
+      { requestedPosition: 11, bottleId: 'a' },
+      { requestedPosition: 11, bottleId: 'b' },
+      { requestedPosition: 11, bottleId: 'c' },
+    ], 24);
+    const positions = result.placements.map(p => p.position).sort((a, b) => a - b);
+    expect(positions).toEqual([11, 12, 13]);
+    const overflowedFlags = result.placements.map(p => p.overflowed);
+    expect(overflowedFlags.filter(Boolean)).toHaveLength(2);
+    expect(result.unplaced).toHaveLength(0);
+  });
+
+  test('keeps exact slot for the first arrival even when others request the same', () => {
+    // Bottle wanting slot 12 (which is free) should NOT be displaced
+    // by overflow from slot-11 requests in pass 1.
+    const result = placeBottles([], [
+      { requestedPosition: 11, bottleId: 'a' },
+      { requestedPosition: 11, bottleId: 'b' },
+      { requestedPosition: 12, bottleId: 'c' },
+    ], 24);
+    const placementOf = (id) => result.placements.find(p => p.bottle === id).position;
+    expect(placementOf('a')).toBe(11);   // exact
+    expect(placementOf('c')).toBe(12);   // exact (not stolen by overflow)
+    expect(placementOf('b')).toBe(13);   // overflowed past taken 12
+  });
+
+  test('respects existing occupied slots', () => {
+    const existing = [{ position: 11, bottle: 'pre' }];
+    const result = placeBottles(existing, [
+      { requestedPosition: 11, bottleId: 'a' },
+    ], 24);
+    expect(result.placements[0].position).toBe(12);
+    expect(result.placements[0].overflowed).toBe(true);
+  });
+
+  test('reports unplaced bottles when the rack is full', () => {
+    // 5-slot rack, all pre-occupied
+    const existing = [1, 2, 3, 4, 5].map(p => ({ position: p, bottle: `pre-${p}` }));
+    const result = placeBottles(existing, [
+      { requestedPosition: 3, bottleId: 'overflow' },
+    ], 5);
+    expect(result.placements).toHaveLength(0);
+    expect(result.unplaced).toHaveLength(1);
+    expect(result.unplaced[0].bottleId).toBe('overflow');
+  });
+
+  test('falls back to backward search when forward space is exhausted', () => {
+    // 5-slot rack, slot 5 taken, requests at slot 5
+    const existing = [{ position: 5, bottle: 'pre' }];
+    const result = placeBottles(existing, [
+      { requestedPosition: 5, bottleId: 'a' },
+    ], 5);
+    expect(result.placements[0].position).toBe(4);
   });
 });

--- a/frontend/src/components/racks/RackRenderer.js
+++ b/frontend/src/components/racks/RackRenderer.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { computeLayout, computeModularLayout, SLOT_RADIUS } from '../../utils/rackLayouts';
+import { computeLayout, computeModularLayout, SLOT_RADIUS, CELL_SIZE } from '../../utils/rackLayouts';
 import './RackRenderer.css';
 
 const WINE_COLORS = {
@@ -21,10 +21,18 @@ const SHELF_COLOR   = '#D4BA94';
 
 /** Sub-circle offsets for multi-bottle cells (dx, dy from cell centre) */
 function getSubOffsets(bpc, R) {
-  const g = R * 0.48;
+  const g = R * 0.42;
   switch (bpc) {
     case 2: return [{ dx: -g, dy: 0 }, { dx: g, dy: 0 }];
-    case 3: return [{ dx: 0, dy: -g * 0.7 }, { dx: -g, dy: g * 0.5 }, { dx: g, dy: g * 0.5 }];
+    case 3: {
+      // Equilateral triangle, slightly tighter so the cluster reads as one unit
+      const t = R * 0.38;
+      return [
+        { dx: 0,             dy: -t * 0.85 },
+        { dx: -t * 0.85,     dy:  t * 0.55 },
+        { dx:  t * 0.85,     dy:  t * 0.55 },
+      ];
+    }
     case 4: return [{ dx: -g, dy: -g }, { dx: g, dy: -g }, { dx: -g, dy: g }, { dx: g, dy: g }];
     default: {
       // General grid arrangement
@@ -48,9 +56,13 @@ function getSubOffsets(bpc, R) {
 /** Sub-circle radius for multi-bottle cells */
 function getSubRadius(bpc, R) {
   if (bpc <= 2) return R * 0.45;
-  if (bpc <= 4) return R * 0.38;
+  if (bpc <= 4) return R * 0.40;
   return R * 0.3;
 }
+
+/** Wood-tone cell tray colour — slightly darker than the rack background */
+const CELL_TRAY_FILL = '#C8AD82';
+const CELL_TRAY_STROKE = '#A89070';
 
 export default function RackRenderer({
   rack,
@@ -211,7 +223,9 @@ export default function RackRenderer({
             }
 
             // Multi-bottle cells: group positions sharing the same (cx,cy),
-            // then render each as an individual smaller circle in a sub-grid
+            // then render a wood-tone "tray" behind each cell so the cluster
+            // of sub-circles visually reads as a single cell, then each
+            // bottle as an individual smaller circle in a sub-grid.
             const cellMap = {};
             layout.slots.forEach(s => {
               const key = `${s.cx},${s.cy}`;
@@ -224,25 +238,46 @@ export default function RackRenderer({
             const backSubOffsets = backR ? getSubOffsets(bpc, backR) : subOffsets;
             const backSubR = backR ? getSubRadius(bpc, backR) : subR;
 
+            const trayPad = 3;
+            const traySize = CELL_SIZE - trayPad * 2;
+            const backTraySize = backR ? backR * 2 + 4 : traySize;
+
             return Object.values(cellMap).map(cell => {
               const useOff = cell.isBack ? backSubOffsets : subOffsets;
               const useR = cell.isBack ? backSubR : subR;
-              return cell.positions.map((pos, idx) => {
-                const off = useOff[idx] || { dx: 0, dy: 0 };
-                return (
-                  <SlotCircle
-                    key={pos}
-                    position={pos}
-                    cx={cell.cx + off.dx}
-                    cy={cell.cy + off.dy}
-                    R={useR}
-                    slot={slotMap[pos]}
-                    isActive={activePos === pos}
-                    isHighlight={highlightPos === pos}
-                    onSlotClick={onSlotClick}
+              const sz = cell.isBack ? backTraySize : traySize;
+              return (
+                <g key={`cell-${cell.cx},${cell.cy}`}>
+                  <rect
+                    x={cell.cx - sz / 2}
+                    y={cell.cy - sz / 2}
+                    width={sz}
+                    height={sz}
+                    rx={5}
+                    fill={CELL_TRAY_FILL}
+                    stroke={CELL_TRAY_STROKE}
+                    strokeWidth={0.75}
+                    opacity={0.7}
+                    pointerEvents="none"
                   />
-                );
-              });
+                  {cell.positions.map((pos, idx) => {
+                    const off = useOff[idx] || { dx: 0, dy: 0 };
+                    return (
+                      <SlotCircle
+                        key={pos}
+                        position={pos}
+                        cx={cell.cx + off.dx}
+                        cy={cell.cy + off.dy}
+                        R={useR}
+                        slot={slotMap[pos]}
+                        isActive={activePos === pos}
+                        isHighlight={highlightPos === pos}
+                        onSlotClick={onSlotClick}
+                      />
+                    );
+                  })}
+                </g>
+              );
             });
           })()}
         </svg>

--- a/frontend/src/config/currencies.js
+++ b/frontend/src/config/currencies.js
@@ -1,2 +1,9 @@
-export const CURRENCIES = ['USD', 'EUR', 'GBP', 'SEK', 'NOK', 'DKK', 'CHF', 'CAD', 'AUD'];
+export const CURRENCIES = [
+  'USD', 'EUR', 'GBP',
+  'SEK', 'NOK', 'DKK',
+  'CHF',
+  'CAD', 'AUD', 'NZD',
+  'JPY', 'HKD', 'SGD',
+  'ZAR'
+];
 export const DEFAULT_CURRENCY = 'USD';

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1099,32 +1099,28 @@
 .rack-config-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
   margin: 0.75rem 0 1rem;
 }
 
-.rack-config-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
+.rack-config-card {
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
+  padding: 0.6rem 0.8rem;
+}
+
+.rack-config-card-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
   flex-wrap: wrap;
 }
 
-.rack-config-name {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  min-width: 8rem;
-}
-
-.rack-config-name strong {
+.rack-config-card-head strong {
   color: var(--color-text);
-  font-size: 0.9rem;
+  font-size: 0.95rem;
 }
 
 .rack-config-meta {
@@ -1132,25 +1128,24 @@
   color: var(--color-text-muted);
 }
 
-.rack-config-dims {
+.rack-config-card-body {
   display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.85rem;
-  color: var(--color-text);
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  align-items: flex-end;
 }
 
-.rack-config-dims label {
+.rack-config-field {
   display: flex;
   flex-direction: column;
+  gap: 0.1rem;
   font-size: 0.7rem;
   color: var(--color-text-muted);
-  gap: 0.1rem;
 }
 
-.rack-config-dims input[type="number"] {
-  width: 3.5rem;
-  padding: 0.25rem 0.4rem;
+.rack-config-field input[type="number"] {
+  width: 3.8rem;
+  padding: 0.3rem 0.4rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-surface);
@@ -1158,17 +1153,20 @@
   font-size: 0.85rem;
 }
 
-.rack-config-times {
-  color: var(--color-text-muted);
-  margin: 0 0.1rem;
-  align-self: flex-end;
-  padding-bottom: 0.3rem;
+.rack-config-field select {
+  padding: 0.3rem 0.4rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  min-width: 12rem;
 }
 
-.rack-config-capacity {
-  font-size: 0.75rem;
+.rack-config-capacity-line {
+  margin-top: 0.45rem;
+  font-size: 0.78rem;
   color: var(--color-text-muted);
-  margin-left: 0.4rem;
 }
 
 .rack-config-warn {

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1089,46 +1089,179 @@
   color: var(--color-text-muted);
 }
 
-.row-origin-toggle {
+.rack-options-hint code {
+  background: var(--color-bg);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+}
+
+.rack-config-list {
   display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0.75rem 0 1rem;
+}
+
+.rack-config-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   flex-wrap: wrap;
 }
 
-.row-origin-toggle label {
+.rack-config-name {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 8rem;
+}
+
+.rack-config-name strong {
+  color: var(--color-text);
+  font-size: 0.9rem;
+}
+
+.rack-config-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.rack-config-dims {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+
+.rack-config-dims label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  gap: 0.1rem;
+}
+
+.rack-config-dims input[type="number"] {
+  width: 3.5rem;
+  padding: 0.25rem 0.4rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.85rem;
+}
+
+.rack-config-times {
+  color: var(--color-text-muted);
+  margin: 0 0.1rem;
+  align-self: flex-end;
+  padding-bottom: 0.3rem;
+}
+
+.rack-config-capacity {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin-left: 0.4rem;
+}
+
+.rack-config-warn {
+  color: var(--color-danger, #c0392b);
+}
+
+.anchor-picker {
+  margin-top: 0.75rem;
+}
+
+.anchor-picker-label {
+  font-size: 0.85rem;
+  color: var(--color-text);
+  margin-bottom: 0.5rem;
+}
+
+.anchor-picker-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.4rem;
+  max-width: 28rem;
+}
+
+.anchor-btn {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.6rem 0.8rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg);
   cursor: pointer;
   font-size: 0.85rem;
   color: var(--color-text);
+  text-align: left;
   transition: border-color 0.15s, background 0.15s;
+  position: relative;
 }
 
-.row-origin-toggle label:hover {
+.anchor-btn:hover {
   border-color: var(--color-primary);
 }
 
-.row-origin-toggle label.active {
+.anchor-btn.active {
   border-color: var(--color-primary);
   background: var(--color-info-bg);
 }
 
-.row-origin-toggle input[type="radio"] {
-  margin: 0;
+.anchor-dot {
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  background: var(--color-surface);
+  flex-shrink: 0;
+  position: relative;
+  background-image: radial-gradient(circle 4px at var(--dot-x, 6px) var(--dot-y, 6px), var(--color-primary) 100%, transparent 100%);
 }
 
-.row-origin-toggle-review {
-  margin-bottom: 0.75rem;
-  align-items: center;
+.anchor-btn-top-left    .anchor-dot { --dot-x: 6px;  --dot-y: 6px; }
+.anchor-btn-top-right   .anchor-dot { --dot-x: 18px; --dot-y: 6px; }
+.anchor-btn-bottom-left .anchor-dot { --dot-x: 6px;  --dot-y: 18px; }
+.anchor-btn-bottom-right .anchor-dot { --dot-x: 18px; --dot-y: 18px; }
+
+.anchor-label {
+  display: block;
+  font-weight: 500;
 }
 
-.row-origin-label {
-  font-size: 0.85rem;
+.anchor-sub {
+  display: block;
+  font-size: 0.7rem;
   color: var(--color-text-muted);
-  margin-right: 0.25rem;
+  margin-top: 0.1rem;
+}
+
+.anchor-btn .anchor-label,
+.anchor-btn .anchor-sub {
+  display: block;
+}
+
+.review-anchor-note {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  margin: 0 0 0.5rem;
+}
+
+.review-anchor-note .link-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-primary);
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
 }

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1173,6 +1173,38 @@
   color: var(--color-danger, #c0392b);
 }
 
+.rack-config-existing {
+  background: var(--color-info-bg, rgba(0, 100, 200, 0.05));
+  border-color: var(--color-info-border, var(--color-border));
+}
+
+.rack-config-existing-badge {
+  display: inline-block;
+  background: var(--color-info, #5a7fa3);
+  color: white;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.rack-config-existing-note {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  margin-top: 0.3rem;
+  line-height: 1.4;
+}
+
+.rack-config-existing-note strong {
+  color: var(--color-text);
+}
+
+.rack-config-existing-warn {
+  margin-top: 0.4rem;
+  font-size: 0.78rem;
+}
+
 .anchor-picker {
   margin-top: 0.75rem;
 }

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1069,6 +1069,38 @@
   background: var(--color-info-bg);
 }
 
+.import-currency-block {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1.25rem;
+  margin: 1rem 0;
+}
+
+.import-currency-label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.import-currency-label select {
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.9rem;
+  min-width: 6rem;
+}
+
+.import-currency-hint {
+  margin: 0.4rem 0 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
 .import-rack-options {
   background: var(--color-surface);
   border: 1px solid var(--color-border);

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1068,3 +1068,67 @@
 .btn-retry-ai:hover:not(:disabled) {
   background: var(--color-info-bg);
 }
+
+.import-rack-options {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  margin: 1rem 0 1.5rem;
+}
+
+.import-rack-options h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: var(--color-text);
+}
+
+.rack-options-hint {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.row-origin-toggle {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.row-origin-toggle label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.row-origin-toggle label:hover {
+  border-color: var(--color-primary);
+}
+
+.row-origin-toggle label.active {
+  border-color: var(--color-primary);
+  background: var(--color-info-bg);
+}
+
+.row-origin-toggle input[type="radio"] {
+  margin: 0;
+}
+
+.row-origin-toggle-review {
+  margin-bottom: 0.75rem;
+  align-items: center;
+}
+
+.row-origin-label {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-right: 0.25rem;
+}

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -4,6 +4,8 @@ import { useAuth } from '../contexts/AuthContext';
 import { validateImport, confirmImport } from '../api/bottles';
 import { searchWines } from '../api/wines';
 import { parseAndMap, parseJSON, suggestRackDimensions, summariseRacks } from '../utils/importMappers';
+import { getTotalSlots } from '../utils/rackLayouts';
+import { TYPE_DIMENSIONS } from '../components/racks/RackTypeSelector';
 import {
   listImportSessions,
   createImportSession,
@@ -260,11 +262,15 @@ function ImportBottles() {
         setDetectedFormat(format);
         setFileName(file.name);
 
-        // Build per-rack summary + seed editable dimensions with suggestions
+        // Build per-rack summary + seed editable config with suggestions.
+        // Default type = 'grid' (1 bottle per slot) — users can change to
+        // shelf, stack, etc. if their physical rack has multi-bottle cells
+        // or a different shape (or if they don't have a physical rack at all).
         const summary = summariseRacks(items);
         const initialConfigs = {};
         for (const [name, info] of Object.entries(summary)) {
-          initialConfigs[name] = suggestRackDimensions(info.maxPosition);
+          const required = Math.max(info.maxPosition || 0, info.count || 0);
+          initialConfigs[name] = { type: 'grid', ...suggestRackDimensions(required), typeConfig: {} };
         }
         setRackSummary(summary);
         setRackConfigs(initialConfigs);
@@ -719,50 +725,126 @@ function ImportBottles() {
 
           <div className="rack-config-list">
             {Object.entries(rackSummary).map(([name, info]) => {
-              const cfg = rackConfigs[name] || { rows: 1, cols: 1 };
+              const cfg = rackConfigs[name] || { type: 'grid', rows: 1, cols: 1, typeConfig: {} };
+              const dims = TYPE_DIMENSIONS[cfg.type] || TYPE_DIMENSIONS.grid;
+              const capacity = getTotalSlots(cfg.type, cfg.rows, cfg.cols, cfg.typeConfig);
+              const required = Math.max(info.maxPosition || 0, info.count || 0);
+              const tooSmall = capacity < required;
+
+              const updateCfg = (patch) => setRackConfigs(prev => ({
+                ...prev,
+                [name]: { ...prev[name], ...patch }
+              }));
+              const updateTc = (key, value) => setRackConfigs(prev => ({
+                ...prev,
+                [name]: {
+                  ...prev[name],
+                  typeConfig: { ...(prev[name]?.typeConfig || {}), [key]: value }
+                }
+              }));
+
               return (
-                <div key={name} className="rack-config-row">
-                  <div className="rack-config-name">
+                <div key={name} className="rack-config-card">
+                  <div className="rack-config-card-head">
                     <strong>{name}</strong>
                     <span className="rack-config-meta">
                       {info.count} bottle{info.count !== 1 ? 's' : ''}
                       {info.maxPosition > 0 && <>, highest slot {info.maxPosition}</>}
                     </span>
                   </div>
-                  <div className="rack-config-dims">
-                    <label>
-                      Rows
-                      <input
-                        type="number"
-                        min="1"
-                        max="20"
-                        value={cfg.rows}
-                        onChange={(e) => setRackConfigs(prev => ({
-                          ...prev,
-                          [name]: { ...prev[name], rows: parseInt(e.target.value, 10) || 1 }
-                        }))}
-                      />
+                  <div className="rack-config-card-body">
+                    <label className="rack-config-field">
+                      <span>Type</span>
+                      <select
+                        value={cfg.type}
+                        onChange={(e) => {
+                          const newType = e.target.value;
+                          const newDims = TYPE_DIMENSIONS[newType] || TYPE_DIMENSIONS.grid;
+                          updateCfg({
+                            type: newType,
+                            rows: newDims.defaultRows,
+                            cols: newDims.defaultCols
+                          });
+                        }}
+                      >
+                        <option value="grid">Grid (1 bottle per slot)</option>
+                        <option value="shelf">Open Shelf (multi-bottle cells)</option>
+                        <option value="stack">Stack (single column)</option>
+                        <option value="hex">Honeycomb</option>
+                        <option value="triangle">A-Frame (triangle)</option>
+                        <option value="x-rack">X-Rack</option>
+                        <option value="cube">Modular Cube</option>
+                      </select>
                     </label>
-                    <span className="rack-config-times">×</span>
-                    <label>
-                      Cols
-                      <input
-                        type="number"
-                        min="1"
-                        max="20"
-                        value={cfg.cols}
-                        onChange={(e) => setRackConfigs(prev => ({
-                          ...prev,
-                          [name]: { ...prev[name], cols: parseInt(e.target.value, 10) || 1 }
-                        }))}
-                      />
-                    </label>
-                    <span className="rack-config-capacity">
-                      = {cfg.rows * cfg.cols} slots
-                      {info.maxPosition > cfg.rows * cfg.cols && (
-                        <span className="rack-config-warn"> (too small for slot {info.maxPosition})</span>
-                      )}
-                    </span>
+
+                    {dims.showRows && (
+                      <label className="rack-config-field">
+                        <span>{dims.rowLabel === 'racks.heightLabel' ? 'Height' : 'Rows'}</span>
+                        <input
+                          type="number" min="1" max="20"
+                          value={cfg.rows}
+                          onChange={(e) => updateCfg({ rows: parseInt(e.target.value, 10) || 1 })}
+                        />
+                      </label>
+                    )}
+                    {dims.showCols && (
+                      <label className="rack-config-field">
+                        <span>{dims.colLabel === 'racks.baseWidthLabel' ? 'Base width' : 'Cols'}</span>
+                        <input
+                          type="number" min="1" max="20"
+                          value={cfg.cols}
+                          onChange={(e) => updateCfg({ cols: parseInt(e.target.value, 10) || 1 })}
+                        />
+                      </label>
+                    )}
+                    {dims.showBottlesPerCell && (
+                      <label className="rack-config-field">
+                        <span>Per cell</span>
+                        <input
+                          type="number" min="1" max="20"
+                          value={cfg.typeConfig?.bottlesPerCell || 1}
+                          onChange={(e) => updateTc('bottlesPerCell', parseInt(e.target.value, 10) || 1)}
+                        />
+                      </label>
+                    )}
+                    {dims.showBottlesPerSection && (
+                      <label className="rack-config-field">
+                        <span>Per section</span>
+                        <input
+                          type="number" min="1" max="30"
+                          value={cfg.typeConfig?.bottlesPerSection || 10}
+                          onChange={(e) => updateTc('bottlesPerSection', parseInt(e.target.value, 10) || 10)}
+                        />
+                      </label>
+                    )}
+                    {dims.showModule && (
+                      <>
+                        <label className="rack-config-field">
+                          <span>Module rows</span>
+                          <input
+                            type="number" min="1" max="10"
+                            value={cfg.typeConfig?.moduleRows || 2}
+                            onChange={(e) => updateTc('moduleRows', parseInt(e.target.value, 10) || 2)}
+                          />
+                        </label>
+                        <label className="rack-config-field">
+                          <span>Module cols</span>
+                          <input
+                            type="number" min="1" max="10"
+                            value={cfg.typeConfig?.moduleCols || 2}
+                            onChange={(e) => updateTc('moduleCols', parseInt(e.target.value, 10) || 2)}
+                          />
+                        </label>
+                      </>
+                    )}
+                  </div>
+                  <div className="rack-config-capacity-line">
+                    = {capacity} slots
+                    {tooSmall && (
+                      <span className="rack-config-warn">
+                        {' '}— too small for {required} bottles
+                      </span>
+                    )}
                   </div>
                 </div>
               );

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -20,6 +20,7 @@ const FORMAT_LABELS = {
   cellarion: 'Cellarion',
   vivino: 'Vivino',
   cellartracker: 'CellarTracker',
+  oeno: 'Oeno (Vintec)',
   generic: 'CSV'
 };
 
@@ -645,6 +646,10 @@ function ImportBottles() {
             <p>Export from CellarTracker via My Cellar &rarr; Download</p>
           </div>
           <div className="format-card">
+            <strong>Oeno (Vintec)</strong>
+            <p>CSV with Producer, Wine, Vintage, Quantity, Rack_Location columns</p>
+          </div>
+          <div className="format-card">
             <strong>Generic CSV</strong>
             <p>Any CSV with Wine, Producer, Vintage columns</p>
           </div>
@@ -685,13 +690,23 @@ function ImportBottles() {
       {parsedItems.length > 0 && parsedItems.some(i => i.rackName) && (
         <div className="import-rack-options">
           <h3>Rack placement</h3>
-          <p className="rack-options-hint">
-            Your file references racks ({new Set(parsedItems.map(i => i.rackName).filter(Boolean)).size} unique).
-            Racks that don't exist in this cellar yet will be created automatically.
-            {parsedItems.some(i => i.row && i.col) && (
-              <> Your file uses <strong>row</strong> + <strong>col</strong> coordinates — pick which end "row 1" sits at:</>
-            )}
-          </p>
+          {detectedFormat === 'oeno' ? (
+            <p className="rack-options-hint">
+              Detected an <strong>Oeno (Vintec)</strong> export. Your <code>Rack_Location</code> values
+              like <code>M2-11</code> will be split into rack <strong>M2</strong>, slot <strong>11</strong>.
+              Found <strong>{new Set(parsedItems.map(i => i.rackName).filter(Boolean)).size}</strong> unique
+              racks — any that don't exist in this cellar will be created automatically with a typical 6-wide grid layout.
+              You can adjust their shape after import from the Cellar page.
+            </p>
+          ) : (
+            <p className="rack-options-hint">
+              Your file references racks ({new Set(parsedItems.map(i => i.rackName).filter(Boolean)).size} unique).
+              Racks that don't exist in this cellar yet will be created automatically.
+              {parsedItems.some(i => i.row && i.col) && (
+                <> Your file uses <strong>row</strong> + <strong>col</strong> coordinates — pick which end "row 1" sits at:</>
+              )}
+            </p>
+          )}
           {parsedItems.some(i => i.row && i.col) && (
             <div className="row-origin-toggle">
               <label className={rowOrigin === 'top' ? 'active' : ''}>

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -65,6 +65,8 @@ function ImportBottles() {
   const [detectedFormat, setDetectedFormat] = useState(null);
   const [fileName, setFileName] = useState('');
   const [dragOver, setDragOver] = useState(false);
+  // 'top' (most apps) or 'bottom' (Oeno-style: row 1 is at the bottom of the rack)
+  const [rowOrigin, setRowOrigin] = useState('top');
 
   // Review step
   const [results, setResults] = useState([]);
@@ -547,7 +549,7 @@ function ImportBottles() {
     if (rowImporting !== null || importing) return;
     setRowImporting(r.index);
     try {
-      const res = await confirmImport(apiFetch, { cellarId, items: [buildImportItem(r)] });
+      const res = await confirmImport(apiFetch, { cellarId, items: [buildImportItem(r)], rowOrigin });
       const data = await res.json();
       if (res.ok && data.created > 0) {
         // Mark as imported — auto-save will persist this to the session
@@ -573,7 +575,7 @@ function ImportBottles() {
       .map(buildImportItem);
 
     try {
-      const res = await confirmImport(apiFetch, { cellarId, items });
+      const res = await confirmImport(apiFetch, { cellarId, items, rowOrigin });
       const data = await res.json();
 
       if (!res.ok) {
@@ -679,6 +681,43 @@ function ImportBottles() {
           </div>
         )}
       </div>
+
+      {parsedItems.length > 0 && parsedItems.some(i => i.rackName) && (
+        <div className="import-rack-options">
+          <h3>Rack placement</h3>
+          <p className="rack-options-hint">
+            Your file references racks ({new Set(parsedItems.map(i => i.rackName).filter(Boolean)).size} unique).
+            Racks that don't exist in this cellar yet will be created automatically.
+            {parsedItems.some(i => i.row && i.col) && (
+              <> Your file uses <strong>row</strong> + <strong>col</strong> coordinates — pick which end "row 1" sits at:</>
+            )}
+          </p>
+          {parsedItems.some(i => i.row && i.col) && (
+            <div className="row-origin-toggle">
+              <label className={rowOrigin === 'top' ? 'active' : ''}>
+                <input
+                  type="radio"
+                  name="rowOrigin"
+                  value="top"
+                  checked={rowOrigin === 'top'}
+                  onChange={() => setRowOrigin('top')}
+                />
+                Row 1 is at the <strong>top</strong> (most apps)
+              </label>
+              <label className={rowOrigin === 'bottom' ? 'active' : ''}>
+                <input
+                  type="radio"
+                  name="rowOrigin"
+                  value="bottom"
+                  checked={rowOrigin === 'bottom'}
+                  onChange={() => setRowOrigin('bottom')}
+                />
+                Row 1 is at the <strong>bottom</strong> (Oeno / Vintec style)
+              </label>
+            </div>
+          )}
+        </div>
+      )}
 
       {parsedItems.length > 0 && (
         <div className="import-preview">
@@ -1056,6 +1095,31 @@ function ImportBottles() {
               {unresolved} item{unresolved !== 1 ? 's' : ''} still need a selection or to be skipped
             </p>
           )}
+          {results.some(r => r.item?.row && r.item?.col) && (
+            <div className="row-origin-toggle row-origin-toggle-review">
+              <span className="row-origin-label">Row 1 is at the:</span>
+              <label className={rowOrigin === 'top' ? 'active' : ''}>
+                <input
+                  type="radio"
+                  name="rowOriginReview"
+                  value="top"
+                  checked={rowOrigin === 'top'}
+                  onChange={() => setRowOrigin('top')}
+                />
+                top
+              </label>
+              <label className={rowOrigin === 'bottom' ? 'active' : ''}>
+                <input
+                  type="radio"
+                  name="rowOriginReview"
+                  value="bottom"
+                  checked={rowOrigin === 'bottom'}
+                  onChange={() => setRowOrigin('bottom')}
+                />
+                bottom (Oeno / Vintec)
+              </label>
+            </div>
+          )}
           <button
             className="btn btn-primary btn-import"
             onClick={handleImport}
@@ -1100,7 +1164,25 @@ function ImportBottles() {
               <span>Errors</span>
             </div>
           )}
+          {importResult.racksCreated?.length > 0 && (
+            <div className="done-stat">
+              <span className="done-number">{importResult.racksCreated.length}</span>
+              <span>Rack{importResult.racksCreated.length !== 1 ? 's' : ''} created</span>
+            </div>
+          )}
         </div>
+      )}
+      {importResult?.racksCreated?.length > 0 && (
+        <details className="done-errors-detail">
+          <summary>Auto-created racks ({importResult.racksCreated.length})</summary>
+          <ul>
+            {importResult.racksCreated.map((r, i) => (
+              <li key={i}>
+                <strong>{r.name}</strong> — {r.type} {r.rows}×{r.cols}
+              </li>
+            ))}
+          </ul>
+        </details>
       )}
       {importResult?.errors.length > 0 && (
         <details className="done-errors-detail">

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -7,6 +7,7 @@ import { getRacks } from '../api/racks';
 import { parseAndMap, parseJSON, suggestRackDimensions, summariseRacks } from '../utils/importMappers';
 import { getTotalSlots } from '../utils/rackLayouts';
 import { TYPE_DIMENSIONS } from '../components/racks/RackTypeSelector';
+import { CURRENCIES } from '../config/currencies';
 import {
   listImportSessions,
   createImportSession,
@@ -80,6 +81,10 @@ function ImportBottles() {
   // warn the user that their picker config will be ignored for those names).
   // Shape: { [name]: { type, rows, cols, typeConfig, _id } }
   const [existingRacks, setExistingRacks] = useState({});
+  // Default currency applied to imported bottles whose CSV row has no
+  // currency column. Seeded from the user's profile preference, but can be
+  // overridden per-import via the picker.
+  const [importCurrency, setImportCurrency] = useState(user?.preferences?.currency || 'USD');
 
   // Review step
   const [results, setResults] = useState([]);
@@ -156,7 +161,7 @@ function ImportBottles() {
   saveDataRef.current = {
     apiFetch, cellarId, fileName, detectedFormat,
     results, selections, manualWines, sessionId,
-    positionAnchor, rackConfigs
+    positionAnchor, rackConfigs, importCurrency
   };
 
   // Auto-save whenever selections or manualWines change while in review step
@@ -171,7 +176,7 @@ function ImportBottles() {
       const {
         apiFetch: af, cellarId: cid, fileName: fn, detectedFormat: df,
         results: rs, selections: sels, manualWines: mw, sessionId: sid,
-        positionAnchor: pa, rackConfigs: rc
+        positionAnchor: pa, rackConfigs: rc, importCurrency: ic
       } = saveDataRef.current;
 
       try {
@@ -180,7 +185,7 @@ function ImportBottles() {
           const res = await createImportSession(af, {
             cellarId: cid, fileName: fn, detectedFormat: df,
             results: rs, selections: sels, manualWines: mw,
-            positionAnchor: pa, rackConfigs: rc
+            positionAnchor: pa, rackConfigs: rc, defaultCurrency: ic
           });
           const data = await res.json();
           if (res.ok) {
@@ -194,7 +199,7 @@ function ImportBottles() {
           // Subsequent saves
           const res = await updateImportSession(af, sid, {
             selections: sels, manualWines: mw,
-            positionAnchor: pa, rackConfigs: rc
+            positionAnchor: pa, rackConfigs: rc, defaultCurrency: ic
           });
           setSaveStatus(res.ok ? 'saved' : 'error');
         }
@@ -204,7 +209,7 @@ function ImportBottles() {
     }, 1500);
 
     return () => clearTimeout(saveTimerRef.current);
-  }, [step, selections, manualWines, positionAnchor, rackConfigs]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [step, selections, manualWines, positionAnchor, rackConfigs, importCurrency]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Recompute summary from a results array (used after resume + refresh)
   const computeSummary = (rs) => ({
@@ -260,6 +265,7 @@ function ImportBottles() {
       setDraftSessions([]);
       // Restore the user's picker choices so they don't have to redo them
       if (s.positionAnchor) setPositionAnchor(s.positionAnchor);
+      if (s.defaultCurrency) setImportCurrency(s.defaultCurrency);
       if (s.rackConfigs && Object.keys(s.rackConfigs).length > 0) {
         setRackConfigs(s.rackConfigs);
         // Rebuild rackSummary from the saved results so the review-step note
@@ -615,7 +621,7 @@ function ImportBottles() {
     if (rowImporting !== null || importing) return;
     setRowImporting(r.index);
     try {
-      const res = await confirmImport(apiFetch, { cellarId, items: [buildImportItem(r)], positionAnchor, rackConfigs });
+      const res = await confirmImport(apiFetch, { cellarId, items: [buildImportItem(r)], positionAnchor, rackConfigs, defaultCurrency: importCurrency });
       const data = await res.json();
       if (res.ok && data.created > 0) {
         // Mark as imported — auto-save will persist this to the session
@@ -641,7 +647,7 @@ function ImportBottles() {
       .map(buildImportItem);
 
     try {
-      const res = await confirmImport(apiFetch, { cellarId, items, positionAnchor, rackConfigs });
+      const res = await confirmImport(apiFetch, { cellarId, items, positionAnchor, rackConfigs, defaultCurrency: importCurrency });
       const data = await res.json();
 
       if (!res.ok) {
@@ -751,6 +757,25 @@ function ImportBottles() {
           </div>
         )}
       </div>
+
+      {parsedItems.length > 0 && parsedItems.some(i => i.price) && (
+        <div className="import-currency-block">
+          <label className="import-currency-label">
+            <strong>Currency for prices</strong>
+            <select
+              value={importCurrency}
+              onChange={(e) => setImportCurrency(e.target.value)}
+            >
+              {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
+            </select>
+          </label>
+          <p className="import-currency-hint">
+            {parsedItems.some(i => i.currency)
+              ? <>Applied to rows that don't already have a Currency column. Defaulted to your profile setting ({user?.preferences?.currency || 'USD'}).</>
+              : <>Your file has prices but no Currency column. All imported bottles will be tagged with this currency. Defaulted to your profile setting ({user?.preferences?.currency || 'USD'}).</>}
+          </p>
+        </div>
+      )}
 
       {parsedItems.length > 0 && Object.keys(rackSummary).length > 0 && (
         <div className="import-rack-options">

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { validateImport, confirmImport } from '../api/bottles';
 import { searchWines } from '../api/wines';
+import { getRacks } from '../api/racks';
 import { parseAndMap, parseJSON, suggestRackDimensions, summariseRacks } from '../utils/importMappers';
 import { getTotalSlots } from '../utils/rackLayouts';
 import { TYPE_DIMENSIONS } from '../components/racks/RackTypeSelector';
@@ -75,6 +76,10 @@ function ImportBottles() {
   const [rackConfigs, setRackConfigs] = useState({});
   // Rack summary built from parsed items: { [name]: { count, maxPosition, observedPositions } }
   const [rackSummary, setRackSummary] = useState({});
+  // Existing racks in the target cellar (so we can show them as read-only and
+  // warn the user that their picker config will be ignored for those names).
+  // Shape: { [name]: { type, rows, cols, typeConfig, _id } }
+  const [existingRacks, setExistingRacks] = useState({});
 
   // Review step
   const [results, setResults] = useState([]);
@@ -122,10 +127,36 @@ function ImportBottles() {
       .catch(() => {});
   }, [apiFetch, cellarId]);
 
+  // Load the cellar's existing racks so the import picker can show which
+  // rack names collide with already-created racks (we can't reshape those
+  // mid-import without risking the bottles already in them).
+  useEffect(() => {
+    getRacks(apiFetch, cellarId)
+      .then(r => r.ok ? r.json() : null)
+      .then(d => {
+        if (!d?.racks) return;
+        const byName = {};
+        for (const rack of d.racks) {
+          byName[rack.name] = {
+            _id: rack._id,
+            type: rack.type,
+            rows: rack.rows,
+            cols: rack.cols,
+            typeConfig: rack.typeConfig,
+            isModular: rack.isModular,
+            modules: rack.modules
+          };
+        }
+        setExistingRacks(byName);
+      })
+      .catch(() => {});
+  }, [apiFetch, cellarId]);
+
   // Keep saveDataRef current so the debounced save always uses latest values
   saveDataRef.current = {
     apiFetch, cellarId, fileName, detectedFormat,
-    results, selections, manualWines, sessionId
+    results, selections, manualWines, sessionId,
+    positionAnchor, rackConfigs
   };
 
   // Auto-save whenever selections or manualWines change while in review step
@@ -139,7 +170,8 @@ function ImportBottles() {
       setSaveStatus('saving');
       const {
         apiFetch: af, cellarId: cid, fileName: fn, detectedFormat: df,
-        results: rs, selections: sels, manualWines: mw, sessionId: sid
+        results: rs, selections: sels, manualWines: mw, sessionId: sid,
+        positionAnchor: pa, rackConfigs: rc
       } = saveDataRef.current;
 
       try {
@@ -147,7 +179,8 @@ function ImportBottles() {
           // First save for this review session — create a new session
           const res = await createImportSession(af, {
             cellarId: cid, fileName: fn, detectedFormat: df,
-            results: rs, selections: sels, manualWines: mw
+            results: rs, selections: sels, manualWines: mw,
+            positionAnchor: pa, rackConfigs: rc
           });
           const data = await res.json();
           if (res.ok) {
@@ -158,8 +191,11 @@ function ImportBottles() {
             setSaveStatus('error');
           }
         } else {
-          // Subsequent saves — just update selections/manualWines
-          const res = await updateImportSession(af, sid, { selections: sels, manualWines: mw });
+          // Subsequent saves
+          const res = await updateImportSession(af, sid, {
+            selections: sels, manualWines: mw,
+            positionAnchor: pa, rackConfigs: rc
+          });
           setSaveStatus(res.ok ? 'saved' : 'error');
         }
       } catch {
@@ -168,7 +204,7 @@ function ImportBottles() {
     }, 1500);
 
     return () => clearTimeout(saveTimerRef.current);
-  }, [step, selections, manualWines]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [step, selections, manualWines, positionAnchor, rackConfigs]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Recompute summary from a results array (used after resume + refresh)
   const computeSummary = (rs) => ({
@@ -222,6 +258,15 @@ function ImportBottles() {
       setSummary(computeSummary(updatedResults));
       setSessionId(s._id);
       setDraftSessions([]);
+      // Restore the user's picker choices so they don't have to redo them
+      if (s.positionAnchor) setPositionAnchor(s.positionAnchor);
+      if (s.rackConfigs && Object.keys(s.rackConfigs).length > 0) {
+        setRackConfigs(s.rackConfigs);
+        // Rebuild rackSummary from the saved results so the review-step note
+        // and the (re-shown) picker on jump-back have the bottle counts.
+        const rs = updatedResults.map(r => r.item).filter(Boolean);
+        setRackSummary(summariseRacks(rs));
+      }
       setStep('review');
     } catch {
       // If load fails, just stay on upload step
@@ -725,10 +770,49 @@ function ImportBottles() {
 
           <div className="rack-config-list">
             {Object.entries(rackSummary).map(([name, info]) => {
+              const existing = existingRacks[name];
+              const required = Math.max(info.maxPosition || 0, info.count || 0);
+
+              // Existing rack — read-only summary. The user's picker config
+              // would be ignored on the backend (we don't reshape live racks),
+              // so showing editable fields would be misleading.
+              if (existing) {
+                const existingCapacity = existing.isModular
+                  ? null
+                  : getTotalSlots(existing.type, existing.rows, existing.cols, existing.typeConfig);
+                const tooSmall = existingCapacity !== null && existingCapacity < required;
+                return (
+                  <div key={name} className="rack-config-card rack-config-existing">
+                    <div className="rack-config-card-head">
+                      <strong>{name}</strong>
+                      <span className="rack-config-existing-badge">Already exists</span>
+                      <span className="rack-config-meta">
+                        {info.count} bottle{info.count !== 1 ? 's' : ''}
+                        {info.maxPosition > 0 && <>, highest slot {info.maxPosition}</>}
+                      </span>
+                    </div>
+                    <div className="rack-config-existing-note">
+                      Using the rack's current layout:{' '}
+                      <strong>
+                        {existing.isModular
+                          ? `Modular (${(existing.modules || []).length} modules)`
+                          : `${existing.type} ${existing.rows}×${existing.cols}${existing.typeConfig?.bottlesPerCell > 1 ? ` × ${existing.typeConfig.bottlesPerCell}/cell` : ''}`}
+                      </strong>
+                      {existingCapacity !== null && <> — {existingCapacity} slots</>}.
+                      {' '}To reshape it, delete the rack first from the Cellar page.
+                    </div>
+                    {tooSmall && (
+                      <div className="rack-config-warn rack-config-existing-warn">
+                        Capacity ({existingCapacity}) is below {required} bottles — extras will be reported as unplaced.
+                      </div>
+                    )}
+                  </div>
+                );
+              }
+
               const cfg = rackConfigs[name] || { type: 'grid', rows: 1, cols: 1, typeConfig: {} };
               const dims = TYPE_DIMENSIONS[cfg.type] || TYPE_DIMENSIONS.grid;
               const capacity = getTotalSlots(cfg.type, cfg.rows, cfg.cols, cfg.typeConfig);
-              const required = Math.max(info.maxPosition || 0, info.count || 0);
               const tooSmall = capacity < required;
 
               const updateCfg = (patch) => setRackConfigs(prev => ({

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -3,7 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { validateImport, confirmImport } from '../api/bottles';
 import { searchWines } from '../api/wines';
-import { parseAndMap, parseJSON } from '../utils/importMappers';
+import { parseAndMap, parseJSON, suggestRackDimensions, summariseRacks } from '../utils/importMappers';
 import {
   listImportSessions,
   createImportSession,
@@ -66,8 +66,13 @@ function ImportBottles() {
   const [detectedFormat, setDetectedFormat] = useState(null);
   const [fileName, setFileName] = useState('');
   const [dragOver, setDragOver] = useState(false);
-  // 'top' (most apps) or 'bottom' (Oeno-style: row 1 is at the bottom of the rack)
-  const [rowOrigin, setRowOrigin] = useState('top');
+  // Where bottle 1 (or row 1, col 1) sits in the source system's rack:
+  // 'top-left' (default), 'top-right', 'bottom-left' (Oeno), 'bottom-right'
+  const [positionAnchor, setPositionAnchor] = useState('top-left');
+  // Per-rack dimension overrides: { [rackName]: { rows, cols } }
+  const [rackConfigs, setRackConfigs] = useState({});
+  // Rack summary built from parsed items: { [name]: { count, maxPosition, observedPositions } }
+  const [rackSummary, setRackSummary] = useState({});
 
   // Review step
   const [results, setResults] = useState([]);
@@ -254,6 +259,15 @@ function ImportBottles() {
         setParsedItems(items);
         setDetectedFormat(format);
         setFileName(file.name);
+
+        // Build per-rack summary + seed editable dimensions with suggestions
+        const summary = summariseRacks(items);
+        const initialConfigs = {};
+        for (const [name, info] of Object.entries(summary)) {
+          initialConfigs[name] = suggestRackDimensions(info.maxPosition);
+        }
+        setRackSummary(summary);
+        setRackConfigs(initialConfigs);
       } catch (err) {
         setError(`Failed to parse file: ${err.message}`);
       }
@@ -550,7 +564,7 @@ function ImportBottles() {
     if (rowImporting !== null || importing) return;
     setRowImporting(r.index);
     try {
-      const res = await confirmImport(apiFetch, { cellarId, items: [buildImportItem(r)], rowOrigin });
+      const res = await confirmImport(apiFetch, { cellarId, items: [buildImportItem(r)], positionAnchor, rackConfigs });
       const data = await res.json();
       if (res.ok && data.created > 0) {
         // Mark as imported — auto-save will persist this to the session
@@ -576,7 +590,7 @@ function ImportBottles() {
       .map(buildImportItem);
 
     try {
-      const res = await confirmImport(apiFetch, { cellarId, items, rowOrigin });
+      const res = await confirmImport(apiFetch, { cellarId, items, positionAnchor, rackConfigs });
       const data = await res.json();
 
       if (!res.ok) {
@@ -687,50 +701,96 @@ function ImportBottles() {
         )}
       </div>
 
-      {parsedItems.length > 0 && parsedItems.some(i => i.rackName) && (
+      {parsedItems.length > 0 && Object.keys(rackSummary).length > 0 && (
         <div className="import-rack-options">
           <h3>Rack placement</h3>
-          {detectedFormat === 'oeno' ? (
+          {detectedFormat === 'oeno' && (
             <p className="rack-options-hint">
               Detected an <strong>Oeno (Vintec)</strong> export. Your <code>Rack_Location</code> values
-              like <code>M2-11</code> will be split into rack <strong>M2</strong>, slot <strong>11</strong>.
-              Found <strong>{new Set(parsedItems.map(i => i.rackName).filter(Boolean)).size}</strong> unique
-              racks — any that don't exist in this cellar will be created automatically with a typical 6-wide grid layout.
-              You can adjust their shape after import from the Cellar page.
-            </p>
-          ) : (
-            <p className="rack-options-hint">
-              Your file references racks ({new Set(parsedItems.map(i => i.rackName).filter(Boolean)).size} unique).
-              Racks that don't exist in this cellar yet will be created automatically.
-              {parsedItems.some(i => i.row && i.col) && (
-                <> Your file uses <strong>row</strong> + <strong>col</strong> coordinates — pick which end "row 1" sits at:</>
-              )}
+              like <code>M2-11</code> have been split into rack name + slot number.
             </p>
           )}
-          {parsedItems.some(i => i.row && i.col) && (
-            <div className="row-origin-toggle">
-              <label className={rowOrigin === 'top' ? 'active' : ''}>
-                <input
-                  type="radio"
-                  name="rowOrigin"
-                  value="top"
-                  checked={rowOrigin === 'top'}
-                  onChange={() => setRowOrigin('top')}
-                />
-                Row 1 is at the <strong>top</strong> (most apps)
-              </label>
-              <label className={rowOrigin === 'bottom' ? 'active' : ''}>
-                <input
-                  type="radio"
-                  name="rowOrigin"
-                  value="bottom"
-                  checked={rowOrigin === 'bottom'}
-                  onChange={() => setRowOrigin('bottom')}
-                />
-                Row 1 is at the <strong>bottom</strong> (Oeno / Vintec style)
-              </label>
+          <p className="rack-options-hint">
+            Found <strong>{Object.keys(rackSummary).length}</strong> unique
+            rack{Object.keys(rackSummary).length !== 1 ? 's' : ''} in your file.
+            We've guessed sensible dimensions from the highest slot number used — adjust them to match
+            your physical rack if you know better.
+          </p>
+
+          <div className="rack-config-list">
+            {Object.entries(rackSummary).map(([name, info]) => {
+              const cfg = rackConfigs[name] || { rows: 1, cols: 1 };
+              return (
+                <div key={name} className="rack-config-row">
+                  <div className="rack-config-name">
+                    <strong>{name}</strong>
+                    <span className="rack-config-meta">
+                      {info.count} bottle{info.count !== 1 ? 's' : ''}
+                      {info.maxPosition > 0 && <>, highest slot {info.maxPosition}</>}
+                    </span>
+                  </div>
+                  <div className="rack-config-dims">
+                    <label>
+                      Rows
+                      <input
+                        type="number"
+                        min="1"
+                        max="20"
+                        value={cfg.rows}
+                        onChange={(e) => setRackConfigs(prev => ({
+                          ...prev,
+                          [name]: { ...prev[name], rows: parseInt(e.target.value, 10) || 1 }
+                        }))}
+                      />
+                    </label>
+                    <span className="rack-config-times">×</span>
+                    <label>
+                      Cols
+                      <input
+                        type="number"
+                        min="1"
+                        max="20"
+                        value={cfg.cols}
+                        onChange={(e) => setRackConfigs(prev => ({
+                          ...prev,
+                          [name]: { ...prev[name], cols: parseInt(e.target.value, 10) || 1 }
+                        }))}
+                      />
+                    </label>
+                    <span className="rack-config-capacity">
+                      = {cfg.rows * cfg.cols} slots
+                      {info.maxPosition > cfg.rows * cfg.cols && (
+                        <span className="rack-config-warn"> (too small for slot {info.maxPosition})</span>
+                      )}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="anchor-picker">
+            <div className="anchor-picker-label">Where does slot 1 sit in your physical rack?</div>
+            <div className="anchor-picker-grid">
+              {[
+                { value: 'top-left', label: 'Top-left', sub: 'Default for most apps' },
+                { value: 'top-right', label: 'Top-right', sub: '' },
+                { value: 'bottom-left', label: 'Bottom-left', sub: 'Oeno / Vintec' },
+                { value: 'bottom-right', label: 'Bottom-right', sub: '' },
+              ].map(opt => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`anchor-btn anchor-btn-${opt.value} ${positionAnchor === opt.value ? 'active' : ''}`}
+                  onClick={() => setPositionAnchor(opt.value)}
+                >
+                  <span className="anchor-dot" aria-hidden="true" />
+                  <span className="anchor-label">{opt.label}</span>
+                  {opt.sub && <span className="anchor-sub">{opt.sub}</span>}
+                </button>
+              ))}
             </div>
-          )}
+          </div>
         </div>
       )}
 
@@ -1110,30 +1170,11 @@ function ImportBottles() {
               {unresolved} item{unresolved !== 1 ? 's' : ''} still need a selection or to be skipped
             </p>
           )}
-          {results.some(r => r.item?.row && r.item?.col) && (
-            <div className="row-origin-toggle row-origin-toggle-review">
-              <span className="row-origin-label">Row 1 is at the:</span>
-              <label className={rowOrigin === 'top' ? 'active' : ''}>
-                <input
-                  type="radio"
-                  name="rowOriginReview"
-                  value="top"
-                  checked={rowOrigin === 'top'}
-                  onChange={() => setRowOrigin('top')}
-                />
-                top
-              </label>
-              <label className={rowOrigin === 'bottom' ? 'active' : ''}>
-                <input
-                  type="radio"
-                  name="rowOriginReview"
-                  value="bottom"
-                  checked={rowOrigin === 'bottom'}
-                  onChange={() => setRowOrigin('bottom')}
-                />
-                bottom (Oeno / Vintec)
-              </label>
-            </div>
+          {Object.keys(rackSummary).length > 0 && (
+            <p className="review-anchor-note">
+              Slot 1 anchor: <strong>{positionAnchor.replace('-', ' ')}</strong>
+              {' '}— change it on the <button type="button" className="link-btn" onClick={() => setStep('upload')}>upload step</button> if needed.
+            </p>
           )}
           <button
             className="btn btn-primary btn-import"

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -1226,6 +1226,18 @@ function ImportBottles() {
               <span>Rack{importResult.racksCreated.length !== 1 ? 's' : ''} created</span>
             </div>
           )}
+          {importResult.placed > 0 && (
+            <div className="done-stat">
+              <span className="done-number">{importResult.placed}</span>
+              <span>Placed in racks{importResult.overflowed > 0 ? ` (${importResult.overflowed} into adjacent slots)` : ''}</span>
+            </div>
+          )}
+          {importResult.unplaced?.length > 0 && (
+            <div className="done-stat">
+              <span className="done-number done-errors">{importResult.unplaced.length}</span>
+              <span>Couldn't place</span>
+            </div>
+          )}
         </div>
       )}
       {importResult?.racksCreated?.length > 0 && (
@@ -1238,6 +1250,26 @@ function ImportBottles() {
               </li>
             ))}
           </ul>
+        </details>
+      )}
+      {importResult?.unplaced?.length > 0 && (
+        <details className="done-errors-detail">
+          <summary>Bottles that couldn't be placed in a rack ({importResult.unplaced.length})</summary>
+          <ul>
+            {importResult.unplaced.slice(0, 50).map((u, i) => (
+              <li key={i}>
+                Row {u.sourceIndex + 1} → rack <strong>{u.rackName}</strong>
+                {u.requestedPosition !== null && <> (slot {u.requestedPosition})</>}
+                : {u.reason}
+              </li>
+            ))}
+            {importResult.unplaced.length > 50 && (
+              <li><em>…and {importResult.unplaced.length - 50} more</em></li>
+            )}
+          </ul>
+          <p className="done-note">
+            These bottles were imported successfully — they just couldn't be assigned a rack slot. You can place them manually from the Cellar page.
+          </p>
         </details>
       )}
       {importResult?.errors.length > 0 && (

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -314,14 +314,33 @@ function ImportBottles() {
         setFileName(file.name);
 
         // Build per-rack summary + seed editable config with suggestions.
-        // Default type = 'grid' (1 bottle per slot) — users can change to
-        // shelf, stack, etc. if their physical rack has multi-bottle cells
-        // or a different shape (or if they don't have a physical rack at all).
+        //
+        // If multiple items share the same (rackName, rackPosition) — the
+        // hallmark of Vintec/Oeno cabinets where each "slot" is actually a
+        // multi-bottle cell — default to shelf type with bottlesPerCell
+        // set to the max observed. Otherwise default to grid (1 bottle/slot).
+        //
+        // Users can switch any rack to a different shape in the picker, or
+        // skip the inference entirely for the user-doesn't-own-a-rack case.
         const summary = summariseRacks(items);
         const initialConfigs = {};
         for (const [name, info] of Object.entries(summary)) {
-          const required = Math.max(info.maxPosition || 0, info.count || 0);
-          initialConfigs[name] = { type: 'grid', ...suggestRackDimensions(required), typeConfig: {} };
+          const bpc = Math.max(1, info.maxPerCell || 1);
+          if (bpc > 1) {
+            // Shelf: size the cell grid to fit the highest cell index seen,
+            // then total slots = rows × cols × bpc.
+            const cells = Math.max(info.maxPosition || 0, 1);
+            const dims = suggestRackDimensions(cells);
+            initialConfigs[name] = {
+              type: 'shelf',
+              rows: dims.rows,
+              cols: dims.cols,
+              typeConfig: { bottlesPerCell: bpc }
+            };
+          } else {
+            const required = Math.max(info.maxPosition || 0, info.count || 0);
+            initialConfigs[name] = { type: 'grid', ...suggestRackDimensions(required), typeConfig: {} };
+          }
         }
         setRackSummary(summary);
         setRackConfigs(initialConfigs);
@@ -813,7 +832,8 @@ function ImportBottles() {
                       <span className="rack-config-existing-badge">Already exists</span>
                       <span className="rack-config-meta">
                         {info.count} bottle{info.count !== 1 ? 's' : ''}
-                        {info.maxPosition > 0 && <>, highest slot {info.maxPosition}</>}
+                        {info.maxPosition > 0 && <>, highest cell {info.maxPosition}</>}
+                        {info.maxPerCell > 1 && <>, up to {info.maxPerCell} per cell</>}
                       </span>
                     </div>
                     <div className="rack-config-existing-note">
@@ -858,7 +878,8 @@ function ImportBottles() {
                     <strong>{name}</strong>
                     <span className="rack-config-meta">
                       {info.count} bottle{info.count !== 1 ? 's' : ''}
-                      {info.maxPosition > 0 && <>, highest slot {info.maxPosition}</>}
+                      {info.maxPosition > 0 && <>, highest cell {info.maxPosition}</>}
+                      {info.maxPerCell > 1 && <>, up to {info.maxPerCell} per cell</>}
                     </span>
                   </div>
                   <div className="rack-config-card-body">

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -22,6 +22,15 @@
  *   rating        - Numeric rating
  *   ratingScale   - '5' | '20' | '100'
  *   location      - Physical location in cellar
+ *   rackName      - Name of rack to place into (auto-created if missing)
+ *   rackPosition  - 1-indexed slot number (used directly if provided)
+ *   row, col      - Alternative to rackPosition: row and column in the rack.
+ *                   The importer flattens (row, col) → position using the
+ *                   rack's geometry and the user-selected rowOrigin.
+ *   rackRows, rackCols - Rack dimensions (used when auto-creating racks
+ *                   and for row-origin math). Optional — also inferred from
+ *                   max observed (row, col) per rack.
+ *   rackType      - Optional rack type (grid|shelf|hex|triangle|stack|x-rack|cube)
  */
 
 /**
@@ -178,6 +187,11 @@ function mapVivinoRow(row) {
     location: get(['Location', 'location', 'Bin', 'bin']),
     rackName: get(['Rack', 'rack', 'Rack Name', 'rackName']) || undefined,
     rackPosition: parseInt(get(['Rack Position', 'rackPosition', 'Position', 'Slot']), 10) || undefined,
+    row: parseInt(get(['Row', 'row', 'Bin Row', 'BinRow', 'Rack Row']), 10) || undefined,
+    col: parseInt(get(['Col', 'col', 'Column', 'column', 'Bin Col', 'BinCol', 'Rack Col']), 10) || undefined,
+    rackRows: parseInt(get(['Rack Rows', 'RackRows', 'rackRows', 'Rack Height']), 10) || undefined,
+    rackCols: parseInt(get(['Rack Cols', 'RackCols', 'rackCols', 'Rack Columns', 'Rack Width']), 10) || undefined,
+    rackType: get(['Rack Type', 'RackType', 'rackType']) || undefined,
   };
 }
 
@@ -231,6 +245,11 @@ function mapCellarTrackerRow(row) {
     location: get(['Location', 'location', 'Bin', 'bin']),
     rackName: get(['Rack', 'rack', 'Rack Name', 'rackName']) || undefined,
     rackPosition: parseInt(get(['Rack Position', 'rackPosition', 'Position', 'Slot']), 10) || undefined,
+    row: parseInt(get(['Row', 'row', 'Bin Row', 'BinRow', 'Rack Row']), 10) || undefined,
+    col: parseInt(get(['Col', 'col', 'Column', 'column', 'Bin Col', 'BinCol', 'Rack Col']), 10) || undefined,
+    rackRows: parseInt(get(['Rack Rows', 'RackRows', 'rackRows', 'Rack Height']), 10) || undefined,
+    rackCols: parseInt(get(['Rack Cols', 'RackCols', 'rackCols', 'Rack Columns', 'Rack Width']), 10) || undefined,
+    rackType: get(['Rack Type', 'RackType', 'rackType']) || undefined,
   };
 }
 
@@ -269,6 +288,11 @@ function mapGenericRow(row) {
     location: get(['Location', 'location', 'Bin', 'bin']),
     rackName: get(['Rack', 'rack', 'Rack Name', 'rackName']) || undefined,
     rackPosition: parseInt(get(['Rack Position', 'rackPosition', 'Position', 'Slot']), 10) || undefined,
+    row: parseInt(get(['Row', 'row', 'Bin Row', 'BinRow', 'Rack Row']), 10) || undefined,
+    col: parseInt(get(['Col', 'col', 'Column', 'column', 'Bin Col', 'BinCol', 'Rack Col']), 10) || undefined,
+    rackRows: parseInt(get(['Rack Rows', 'RackRows', 'rackRows', 'Rack Height']), 10) || undefined,
+    rackCols: parseInt(get(['Rack Cols', 'RackCols', 'rackCols', 'Rack Columns', 'Rack Width']), 10) || undefined,
+    rackType: get(['Rack Type', 'RackType', 'rackType']) || undefined,
   };
 }
 
@@ -303,6 +327,11 @@ function mapCellarionRow(row) {
     ratingScale: str('ratingScale') || undefined,
     rackName: str('rackName') || undefined,
     rackPosition: int('rackPosition'),
+    row: int('row'),
+    col: int('col'),
+    rackRows: int('rackRows'),
+    rackCols: int('rackCols'),
+    rackType: str('rackType') || undefined,
     dateAdded: str('dateAdded') || undefined,
     addToHistory: str('addToHistory') || undefined,
     consumedReason: str('consumedReason') || undefined,

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -107,7 +107,7 @@ export function parseCSV(text, delimiter = ',') {
 
 /**
  * Detect the source format from CSV headers.
- * Returns: 'vivino' | 'cellartracker' | 'generic'
+ * Returns: 'cellarion' | 'vivino' | 'cellartracker' | 'oeno' | 'generic'
  */
 export function detectFormat(headers) {
   const h = new Set(headers.map(s => s.toLowerCase().trim()));
@@ -115,6 +115,9 @@ export function detectFormat(headers) {
 
   // Cellarion's own CSV export uses camelCase headers
   if (raw.has('wineName') && raw.has('producer') && raw.has('vintage')) return 'cellarion';
+
+  // Oeno (Vintec) export — distinctive columns
+  if (h.has('rack_location') || h.has('mastervarietal')) return 'oeno';
 
   // Vivino export headers
   if (h.has('wine name') || h.has('winery')) return 'vivino';
@@ -124,6 +127,40 @@ export function detectFormat(headers) {
   if (h.has('wine') && h.has('vintage') && (h.has('locale') || h.has('bin'))) return 'cellartracker';
 
   return 'generic';
+}
+
+/**
+ * Parse a combined rack-location string like "M2-11" or "Cabinet 1-15" into
+ * a rack name + 1-indexed position. Splits on the LAST hyphen so rack names
+ * containing hyphens still work. Returns null when the right side isn't a
+ * positive integer.
+ */
+export function parseCombinedRackLocation(value) {
+  if (!value) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  const lastDash = trimmed.lastIndexOf('-');
+  if (lastDash < 1 || lastDash === trimmed.length - 1) return null;
+  const left = trimmed.slice(0, lastDash).trim();
+  const right = trimmed.slice(lastDash + 1).trim();
+  if (!left) return null;
+  // Right side must be a pure positive integer (allow leading zeros: "04")
+  if (!/^\d+$/.test(right)) return null;
+  const pos = parseInt(right, 10);
+  if (pos < 1) return null;
+  return { rackName: left, rackPosition: pos };
+}
+
+/**
+ * Normalise a bottle-size value. Accepts strings like "750ml", "1.5L", or a
+ * bare number ("750" / 750) which is treated as millilitres.
+ */
+function normaliseBottleSize(value) {
+  if (value === undefined || value === null || value === '') return undefined;
+  const s = String(value).trim();
+  if (!s) return undefined;
+  if (/^\d+(\.\d+)?$/.test(s)) return `${s}ml`;
+  return s;
 }
 
 /**
@@ -268,6 +305,10 @@ function mapGenericRow(row) {
   const rating = parseFloat(get(['Rating', 'rating', 'Score', 'score']));
   const qty = parseInt(get(['Quantity', 'quantity', 'Qty', 'qty', 'Count', 'count']), 10);
 
+  // Combined rack+position columns like Oeno's "Rack_Location" = "M2-11"
+  const combined = get(['Rack_Location', 'Rack Location', 'RackLocation', 'Bin Location', 'BinLocation']);
+  const parsedRack = parseCombinedRackLocation(combined);
+
   return {
     wineName: get(['Wine', 'wine', 'Wine Name', 'WineName', 'Name', 'name']),
     producer: get(['Producer', 'producer', 'Winery', 'winery', 'Maker', 'maker']),
@@ -278,7 +319,7 @@ function mapGenericRow(row) {
     type: mapWineType(get(['Type', 'type', 'Color', 'Colour', 'Category', 'category'])),
     price: isNaN(price) ? undefined : price,
     currency: get(['Currency', 'currency']) || undefined,
-    bottleSize: get(['Size', 'size', 'Bottle Size', 'BottleSize']) || '750ml',
+    bottleSize: normaliseBottleSize(get(['Size', 'size', 'Bottle Size', 'BottleSize'])) || '750ml',
     quantity: isNaN(qty) || qty < 1 ? 1 : qty,
     purchaseDate: get(['Purchase Date', 'PurchaseDate', 'Date', 'date']),
     purchaseLocation: get(['Store', 'store', 'Purchase Location', 'Vendor', 'vendor']),
@@ -286,13 +327,61 @@ function mapGenericRow(row) {
     rating: isNaN(rating) ? undefined : rating,
     ratingScale: rating > 20 ? '100' : rating > 5 ? '20' : '5',
     location: get(['Location', 'location', 'Bin', 'bin']),
-    rackName: get(['Rack', 'rack', 'Rack Name', 'rackName']) || undefined,
-    rackPosition: parseInt(get(['Rack Position', 'rackPosition', 'Position', 'Slot']), 10) || undefined,
+    rackName: parsedRack?.rackName || get(['Rack', 'rack', 'Rack Name', 'rackName']) || undefined,
+    rackPosition: parsedRack?.rackPosition || parseInt(get(['Rack Position', 'rackPosition', 'Position', 'Slot']), 10) || undefined,
     row: parseInt(get(['Row', 'row', 'Bin Row', 'BinRow', 'Rack Row']), 10) || undefined,
     col: parseInt(get(['Col', 'col', 'Column', 'column', 'Bin Col', 'BinCol', 'Rack Col']), 10) || undefined,
     rackRows: parseInt(get(['Rack Rows', 'RackRows', 'rackRows', 'Rack Height']), 10) || undefined,
     rackCols: parseInt(get(['Rack Cols', 'RackCols', 'rackCols', 'Rack Columns', 'Rack Width']), 10) || undefined,
     rackType: get(['Rack Type', 'RackType', 'rackType']) || undefined,
+  };
+}
+
+// ── Oeno (Vintec) Mapper ────────────────────────────────────────────────────
+
+/**
+ * Map a row from an Oeno / Vintec CSV export. Distinctive columns:
+ *   - Rack_Location: combined "<rackName>-<position>" string (e.g. "M2-11")
+ *   - MasterVarietal / Varietal2 / Varietal3: grape varieties
+ *   - type: "Red Wine" / "White Wine" / etc.
+ *   - Size: bare number in millilitres
+ *   - BeginConsume / EndConsume: drink window (not yet imported)
+ *   - Location: typically the cellar name (e.g. "Cellar") — preserved as
+ *     the free-text bottle location field
+ */
+function mapOenoRow(row) {
+  const get = (keys) => {
+    for (const k of keys) {
+      const val = row[k] || row[k.toLowerCase()];
+      if (val) return val.trim();
+    }
+    return '';
+  };
+
+  const price = parseFloat(get(['Price', 'price']));
+  const qty = parseInt(get(['Quantity', 'quantity', 'Qty', 'Count']), 10);
+
+  // Oeno encodes rack + position together as e.g. "M2-11"
+  const combined = get(['Rack_Location', 'Rack Location', 'RackLocation']);
+  const parsed = parseCombinedRackLocation(combined);
+
+  return {
+    wineName: get(['Wine', 'wine']),
+    producer: get(['Producer', 'producer']),
+    vintage: get(['Vintage', 'vintage', 'Year']) || 'NV',
+    country: get(['Country', 'country']),
+    region: get(['Region', 'region']),
+    appellation: get(['Appellation', 'appellation', 'SubRegion']),
+    type: mapWineType(get(['type', 'Type', 'Wine Type'])),
+    price: isNaN(price) ? undefined : price,
+    bottleSize: normaliseBottleSize(get(['Size', 'size', 'Bottle Size'])) || '750ml',
+    quantity: isNaN(qty) || qty < 1 ? 1 : qty,
+    notes: get(['Notes', 'notes', 'Note', 'Comments']),
+    // Oeno's "Location" column is the cellar name (e.g. "Cellar"), preserved
+    // as a free-text label on the bottle since cellar selection happens in the UI.
+    location: get(['Location', 'location']),
+    rackName: parsed?.rackName || get(['Rack', 'rack', 'Rack Name']) || undefined,
+    rackPosition: parsed?.rackPosition || parseInt(get(['Rack Position', 'Position', 'Slot']), 10) || undefined,
   };
 }
 
@@ -423,7 +512,9 @@ export function parseAndMap(text, forceFormat) {
 
   const mapper = format === 'cellarion'
     ? mapCellarionRow
-    : format === 'vivino'
+    : format === 'oeno'
+      ? mapOenoRow
+      : format === 'vivino'
       ? mapVivinoRow
       : format === 'cellartracker'
         ? mapCellarTrackerRow

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -169,20 +169,31 @@ export function suggestRackDimensions(maxPosition) {
 
 /**
  * Summarise rack usage in a parsed-items batch:
- *   { [rackName]: { count, maxPosition, observedPositions: number[] } }
+ *   { [rackName]: { count, maxPosition, maxPerCell, observedPositions: number[] } }
+ *
+ * `maxPerCell` is the highest number of items sharing the same rackPosition
+ * within a single rack. For Vintec/Oeno-style cabinets where each "Rack_
+ * Location" is a multi-bottle cell (3 Chenin Blancs all stored at M3-11),
+ * this is the bottlesPerCell value that an auto-created shelf rack needs.
  */
 export function summariseRacks(items) {
   const summary = {};
+  const positionCounts = {}; // { [rackName]: { [position]: count } }
   for (const item of items) {
     if (!item?.rackName) continue;
     const name = String(item.rackName).trim();
     if (!name) continue;
-    if (!summary[name]) summary[name] = { count: 0, maxPosition: 0, observedPositions: [] };
+    if (!summary[name]) summary[name] = { count: 0, maxPosition: 0, maxPerCell: 1, observedPositions: [] };
     summary[name].count += 1;
     const pos = parseInt(item.rackPosition, 10);
     if (!isNaN(pos)) {
       summary[name].observedPositions.push(pos);
       if (pos > summary[name].maxPosition) summary[name].maxPosition = pos;
+      if (!positionCounts[name]) positionCounts[name] = {};
+      positionCounts[name][pos] = (positionCounts[name][pos] || 0) + 1;
+      if (positionCounts[name][pos] > summary[name].maxPerCell) {
+        summary[name].maxPerCell = positionCounts[name][pos];
+      }
     }
   }
   return summary;

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -152,6 +152,43 @@ export function parseCombinedRackLocation(value) {
 }
 
 /**
+ * Suggest reasonable rack dimensions given a max position observed in import
+ * data. Mirrors the backend helper of the same name. Biases toward common
+ * physical wine-rack widths (6 or 12 columns).
+ */
+export function suggestRackDimensions(maxPosition) {
+  const p = Math.max(1, parseInt(maxPosition, 10) || 1);
+  if (p <= 6)  return { rows: 1, cols: p };
+  if (p <= 12) return { rows: 2, cols: 6 };
+  if (p <= 24) return { rows: 4, cols: 6 };
+  if (p <= 72) return { rows: 6, cols: 12 };
+  const cols = 12;
+  const rows = Math.min(20, Math.ceil(p / cols));
+  return { rows, cols };
+}
+
+/**
+ * Summarise rack usage in a parsed-items batch:
+ *   { [rackName]: { count, maxPosition, observedPositions: number[] } }
+ */
+export function summariseRacks(items) {
+  const summary = {};
+  for (const item of items) {
+    if (!item?.rackName) continue;
+    const name = String(item.rackName).trim();
+    if (!name) continue;
+    if (!summary[name]) summary[name] = { count: 0, maxPosition: 0, observedPositions: [] };
+    summary[name].count += 1;
+    const pos = parseInt(item.rackPosition, 10);
+    if (!isNaN(pos)) {
+      summary[name].observedPositions.push(pos);
+      if (pos > summary[name].maxPosition) summary[name].maxPosition = pos;
+    }
+  }
+  return summary;
+}
+
+/**
  * Normalise a bottle-size value. Accepts strings like "750ml", "1.5L", or a
  * bare number ("750" / 750) which is treated as millilitres.
  */

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -362,4 +362,50 @@ describe('parseAndMap', () => {
     const result = parseAndMap(csv);
     expect(result.items[0].type).toBe('sparkling');
   });
+
+  describe('rack columns (row/col/rackRows/rackCols/rackType)', () => {
+    it('maps Row, Col, Rack Rows, Rack Cols, Rack Type for generic CSV', () => {
+      const csv = 'Wine,Producer,Vintage,Rack,Row,Col,Rack Rows,Rack Cols,Rack Type\n' +
+        'Margaux,Chateau Margaux,2015,Main Cabinet,3,2,18,6,grid';
+      const result = parseAndMap(csv);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        rackName: 'Main Cabinet',
+        row: 3,
+        col: 2,
+        rackRows: 18,
+        rackCols: 6,
+        rackType: 'grid',
+      });
+    });
+
+    it('maps Bin Row / Bin Col aliases', () => {
+      const csv = 'Wine,Producer,Vintage,Rack,Bin Row,Bin Col\n' +
+        'Margaux,Chateau Margaux,2015,Cabinet A,5,3';
+      const result = parseAndMap(csv);
+      expect(result.items[0]).toMatchObject({ row: 5, col: 3 });
+    });
+
+    it('preserves rackPosition when row/col absent', () => {
+      const csv = 'Wine,Producer,Vintage,Rack,Position\n' +
+        'Margaux,Chateau Margaux,2015,Cabinet A,42';
+      const result = parseAndMap(csv);
+      expect(result.items[0]).toMatchObject({ rackName: 'Cabinet A', rackPosition: 42 });
+      expect(result.items[0].row).toBeUndefined();
+    });
+
+    it('expands quantity while preserving row/col on each generated bottle', () => {
+      const csv = 'Wine,Producer,Vintage,Quantity,Rack,Row,Col,Rack Rows,Rack Cols\n' +
+        'Margaux,Chateau Margaux,2015,3,Cabinet,1,1,18,6';
+      const result = parseAndMap(csv);
+      expect(result.items).toHaveLength(3);
+      result.items.forEach(item => {
+        expect(item.row).toBe(1);
+        expect(item.col).toBe(1);
+        expect(item.rackRows).toBe(18);
+        expect(item.rackCols).toBe(6);
+        expect(item.rackName).toBe('Cabinet');
+      });
+    });
+  });
 });

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -4,6 +4,7 @@ import {
   detectDelimiter,
   parseJSON,
   parseAndMap,
+  parseCombinedRackLocation,
 } from './importMappers';
 
 // ---------------------------------------------------------------------------
@@ -363,6 +364,36 @@ describe('parseAndMap', () => {
     expect(result.items[0].type).toBe('sparkling');
   });
 
+  describe('parseCombinedRackLocation', () => {
+    it('parses "M2-11" into { rackName: "M2", rackPosition: 11 }', () => {
+      expect(parseCombinedRackLocation('M2-11')).toEqual({ rackName: 'M2', rackPosition: 11 });
+    });
+
+    it('handles leading-zero positions like "M3-04"', () => {
+      expect(parseCombinedRackLocation('M3-04')).toEqual({ rackName: 'M3', rackPosition: 4 });
+    });
+
+    it('splits on the LAST hyphen so rack names with hyphens still work', () => {
+      expect(parseCombinedRackLocation('Cabinet-A-15')).toEqual({ rackName: 'Cabinet-A', rackPosition: 15 });
+    });
+
+    it('returns null for missing or empty input', () => {
+      expect(parseCombinedRackLocation('')).toBeNull();
+      expect(parseCombinedRackLocation(null)).toBeNull();
+      expect(parseCombinedRackLocation(undefined)).toBeNull();
+    });
+
+    it('returns null when right side is not a positive integer', () => {
+      expect(parseCombinedRackLocation('M2-AB')).toBeNull();
+      expect(parseCombinedRackLocation('M2-0')).toBeNull();
+      expect(parseCombinedRackLocation('M2-')).toBeNull();
+    });
+
+    it('returns null when there is no hyphen', () => {
+      expect(parseCombinedRackLocation('M2')).toBeNull();
+    });
+  });
+
   describe('rack columns (row/col/rackRows/rackCols/rackType)', () => {
     it('maps Row, Col, Rack Rows, Rack Cols, Rack Type for generic CSV', () => {
       const csv = 'Wine,Producer,Vintage,Rack,Row,Col,Rack Rows,Rack Cols,Rack Type\n' +
@@ -392,6 +423,25 @@ describe('parseAndMap', () => {
       const result = parseAndMap(csv);
       expect(result.items[0]).toMatchObject({ rackName: 'Cabinet A', rackPosition: 42 });
       expect(result.items[0].row).toBeUndefined();
+    });
+
+    it('parses Oeno-style Rack_Location "M2-11" into rackName + rackPosition', () => {
+      const csv = 'Producer,Wine,Vintage,Quantity,Rack_Location,type,Size,Price,Country\n' +
+        'Amisfield,Amisfield Chenin Blanc,2019,3,M3-11,White Wine,750,35,New Zealand\n' +
+        'Alexander,Alexander Dusty Road Pinot Noir,2018,1,M2-11,Red Wine,750,35,New Zealand';
+      const result = parseAndMap(csv);
+      expect(result.format).toBe('oeno');
+      // Quantity 3 + 1 = 4 bottles
+      expect(result.items).toHaveLength(4);
+      const m3 = result.items[0];
+      expect(m3.rackName).toBe('M3');
+      expect(m3.rackPosition).toBe(11);
+      expect(m3.type).toBe('white');
+      expect(m3.bottleSize).toBe('750ml');
+      const m2 = result.items[3];
+      expect(m2.rackName).toBe('M2');
+      expect(m2.rackPosition).toBe(11);
+      expect(m2.type).toBe('red');
     });
 
     it('expands quantity while preserving row/col on each generated bottle', () => {


### PR DESCRIPTION
## Summary

A near-complete overhaul of the bottle importer to handle migrations from defunct apps like **Oeno (Vintec)**, on top of the existing Cellarion/Vivino/CellarTracker support.

### New capabilities

- **Native Oeno format detection** — recognises CSVs with `Rack_Location`, `MasterVarietal`, `type: Red Wine`, bare-number `Size: 750`, etc. The combined `M3-11` column is split into rack name + slot.
- **Auto-create racks** during import — any rack name referenced in the CSV that doesn't exist in the target cellar is created with a layout the user picks (or accepts an inferred default for).
- **Per-rack type picker** with all 7 Cellarion rack types (Grid, Open Shelf, Stack, Honeycomb, A-Frame, X-Rack, Modular Cube). Each card shows live capacity and a red warning when capacity is below the bottles going in.
- **Vintec shelf model** — when the CSV has multiple bottles claiming the same Rack_Location (e.g. `Quantity: 3, Rack_Location: M3-11`), the picker defaults to **Open Shelf** with `bottlesPerCell` set to the max observed. Position is interpreted as cell index, not slot index.
- **4-corner slot-1 anchor picker** (top-left / top-right / bottom-left / bottom-right) with visual corner indicators. Anchor transforms operate on the cell grid for shelves.
- **Two-pass overflow placement** — bottles get their exact slot first (FCFS), then unplaced bottles spill into the nearest empty slot. A bottle requesting a free slot is never displaced by overflow.
- **Per-import currency picker** (defaulting to the user's profile preference). Added NZD, JPY, HKD, SGD, ZAR to the supported list. CSV-level Currency column still wins per-row.
- **Existing-rack collision handling** — if the target cellar already has a rack with the same name, the picker shows it as read-only with a capacity warning.
- **Session resume persistence** — `positionAnchor`, `rackConfigs`, `defaultCurrency` saved with the draft so resume restores the full picker state.
- **Done-screen detail** — surfaces auto-created racks, placed count, overflow count, and any bottles that couldn't be placed (with row + rack + slot + reason).

### Visual polish

- Multi-bottle cells now render with a wood-tone "tray" background so the cluster reads as one cell, not three loose dots.
- `bpc=3` triangle tightened into an equilateral cluster.

### Compliance / safety

- **GDPR**: new `ImportSession` fields included in `GET /api/users/me/export`; also fixed a pre-existing typo where `rowCount` was always 0 due to `rows` vs `results` mismatch.
- **Audit logging**: `bottle.import` includes placed/overflowed/unplaced counts; `rack.create` tagged with `source: 'import'`.
- **Security review**: passed automated `/security-review` — no HIGH/MEDIUM findings. All user-supplied inputs are validated against allowlists or clamped to model bounds; rack names stringified before flowing into Mongo queries.

### Tests

507 backend / 267 frontend tests passing. New tests cover:
- `parseCombinedRackLocation` edge cases
- `computeRackPosition` across all 4 anchors and grid + shelf rack types
- `placeBottles` exact + overflow + no-displacement + backward fallback
- `planRackCreations` sizing by `max(maxPosition, totalBottles)`
- `placeBottlesInRack` end-to-end orchestration (anchor + group + two-pass)
- Shelf cell-based placement (3 bottles → cell 11 → slots 31/32/33)
- Oeno mapper integration (Rack_Location split, Size normalisation)

## Test plan

- [x] Backend unit tests
- [x] Frontend unit tests
- [x] Vite production build
- [x] Smoke-tested in Docker against `C:\tmp\oeno-test.csv` (5 sample rows mirroring Keith's data)
- [ ] Wait for Keith to validate against his full ~800-bottle CSV before announcing