### PR TITLE
fix(import): treat Oeno Rack_Location as shelf number, not cell index

### DIFF
--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -18,30 +18,35 @@ const DEFAULT_ANCHOR = 'top-left';
 
 /**
  * Compute the 1-indexed slot position in Cellarion's internal coordinate
- * system (top-left, row-major), given:
- *   - A sequential `position` from the source system, or
- *   - A (row, col) pair from the source system,
- * plus the rack's dimensions and where the source system's "bottle 1" sits.
+ * system (top-left, row-major), given a source-system position and rack
+ * geometry.
  *
- * For shelf racks with `bottlesPerCell > 1` (e.g. Vintec/Oeno cabinets where
- * each "slot" physically holds a stack of identical bottles), the input
- * position is treated as a CELL index. The output is the FIRST slot of that
- * cell — subsequent bottles claiming the same cell will naturally overflow
- * into the cell's remaining slots via forward-scan placement.
+ * Two distinct interpretations depending on rack type:
  *
- * `anchor` describes the corner where the source data's position 1 (or row 1,
- * col 1) is located:
+ * 1. Grid racks — the source `position` is a SLOT NUMBER. Anchor transforms
+ *    expand the slot into (row, col), flip per anchor, then recompose.
+ *
+ * 2. Shelf racks — the source `position` is a SHELF NUMBER (row). This
+ *    matches how real-world shelf cabinets (Vintec, Transtherm) label
+ *    storage: "M3-11" means "Module 3, shelf 11". Output is the FIRST slot
+ *    of that shelf; multiple bottles claiming the same shelf naturally fan
+ *    out to adjacent cells via placeBottles' forward-scan overflow (front
+ *    cells first, then back cells if backCols > 0). For shelf racks only
+ *    the row component of the anchor matters; left/right is ignored since
+ *    the source position carries no column information.
+ *
+ * `anchor`:
  *   - 'top-left'     : matches Cellarion's internal layout (identity)
- *   - 'top-right'    : column 1 is on the right
- *   - 'bottom-left'  : row 1 is at the bottom (Oeno reading left-to-right)
- *   - 'bottom-right' : row 1 at bottom AND col 1 on the right
+ *   - 'top-right'    : column 1 is on the right (grid only)
+ *   - 'bottom-left'  : row 1 is at the bottom (Oeno/Transtherm convention)
+ *   - 'bottom-right' : row 1 at bottom AND col 1 on the right (grid only)
  *
  * Returns { position } on success or { error } on bad input.
  */
 function computeRackPosition({
   position, row, col,
   rackRows, rackCols,
-  rackType, bottlesPerCell,
+  rackType, bottlesPerCell, backCols,
   anchor = DEFAULT_ANCHOR
 }) {
   if (!VALID_ANCHORS.includes(anchor)) {
@@ -51,20 +56,44 @@ function computeRackPosition({
   const cols = parseInt(rackCols, 10);
   const rows = parseInt(rackRows, 10);
   const bpc = Math.max(1, parseInt(bottlesPerCell, 10) || 1);
-  const isMultiCell = rackType === 'shelf' && bpc > 1;
+  const back = Math.max(0, parseInt(backCols, 10) || 0);
+  const isShelf = rackType === 'shelf';
 
+  // Shelf racks: the source position is a SHELF NUMBER (row), matching how
+  // real-world cabinets (Vintec/Transtherm) label storage. "M3-11" means
+  // "Module 3, shelf 11" — the specific cell within that shelf isn't
+  // recorded by the source app. Output is the FIRST slot of the shelf;
+  // multiple bottles on the same shelf will fan out to adjacent cells via
+  // placeBottles' forward-scan overflow (front cells first, then back).
+  if (isShelf && position !== undefined && position !== null && position !== '') {
+    const p = parseInt(position, 10);
+    if (isNaN(p) || p < 1) return { error: 'Invalid shelf' };
+
+    let effectiveShelf = p;
+    if (anchor === 'bottom-left' || anchor === 'bottom-right') {
+      if (isNaN(rows) || rows < 1) {
+        return { error: 'rackRows is required for bottom-anchored shelf placement' };
+      }
+      if (p > rows) return { error: `shelf ${p} exceeds rackRows ${rows}` };
+      effectiveShelf = rows - p + 1;
+    }
+
+    if (isNaN(cols) || cols < 1) {
+      return { error: 'rackCols is required for shelf placement' };
+    }
+    const slotsPerShelf = (cols + back) * bpc;
+    return { position: (effectiveShelf - 1) * slotsPerShelf + 1 };
+  }
+
+  // Grid rack (or shelf with row+col input): source is a slot or (row, col).
   let srcRow, srcCol;
 
   if (position !== undefined && position !== null && position !== '') {
     const p = parseInt(position, 10);
     if (isNaN(p) || p < 1) return { error: 'Invalid position' };
 
-    // Identity case — no anchor flip needed.
-    if (anchor === 'top-left') {
-      // For shelf cells, the input is a cell index → translate to the
-      // first slot of that cell. For grid, position == slot.
-      return { position: isMultiCell ? (p - 1) * bpc + 1 : p };
-    }
+    // Identity case for grid — no anchor flip needed.
+    if (anchor === 'top-left') return { position: p };
 
     if (isNaN(cols) || cols < 1) {
       return { error: 'rackCols is required to transform position with a non-default anchor' };
@@ -81,8 +110,7 @@ function computeRackPosition({
     if (srcCol > cols) return { error: `col ${srcCol} exceeds rackCols ${cols}` };
   }
 
-  // Apply anchor transforms in CELL-grid space (rows × cols cells), then
-  // expand the resulting cell index to a slot index for multi-cell shelves.
+  // Apply anchor transforms in the cell grid (rows × cols).
   let effectiveRow = srcRow;
   let effectiveCol = srcCol;
 
@@ -100,8 +128,7 @@ function computeRackPosition({
     effectiveCol = cols - srcCol + 1;
   }
 
-  const cellIndex = (effectiveRow - 1) * cols + effectiveCol;
-  return { position: isMultiCell ? (cellIndex - 1) * bpc + 1 : cellIndex };
+  return { position: (effectiveRow - 1) * cols + effectiveCol };
 }
 
 /**
@@ -232,6 +259,7 @@ function placeBottlesInRack(rack, items, anchor) {
       rackCols: rack.cols,
       rackType: rack.type,
       bottlesPerCell: rack.typeConfig?.bottlesPerCell,
+      backCols: rack.typeConfig?.backCols,
       anchor
     });
     if (result.error) {

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -370,13 +370,14 @@ describe('placeBottlesInRack (orchestration)', () => {
     expect(unplaced[0].reason).toMatch(/capacity/);
   });
 
-  test('shelf rack: 3 bottles claiming Oeno cell 11 land in slots 31, 32, 33 (bpc=3)', () => {
-    // Vintec/Oeno cabinet: shelf with 2 rows × 6 cols × 3 bottles/cell = 36 slots.
-    // Oeno "cell 11" = top row, col 5 → Cellarion's first slot of cell 11 = 31.
-    // 3 bottles all claiming cell 11 should naturally pack into slots 31, 32, 33.
+  test('Oeno shelf rack: 3 bottles at M3-11 land on shelf 11 (front cells 1-3)', () => {
+    // Transtherm Espace 1000: 18 shelves per module, 6 front + 5 back per shelf.
+    // Oeno "M3-11" = shelf 11; the source app doesn't track which specific
+    // cell within the shelf, so 3 bottles all land at the front of shelf 11.
+    // Slots per shelf = 6 + 5 = 11. First slot of shelf 11 = (11-1)*11 + 1 = 111.
     const rack = {
-      type: 'shelf', rows: 2, cols: 6, typeConfig: { bottlesPerCell: 3 },
-      slots: [], maxPosition: 36
+      type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 1, backCols: 5 },
+      slots: [], maxPosition: 198
     };
     const items = [
       { item: { rackPosition: 11 }, bottleId: 'chenin-1', sourceIndex: 0 },
@@ -386,52 +387,50 @@ describe('placeBottlesInRack (orchestration)', () => {
     const { placements, unplaced } = placeBottlesInRack(rack, items, 'top-left');
     expect(unplaced).toHaveLength(0);
     const positions = placements.map(p => p.position).sort((a, b) => a - b);
-    expect(positions).toEqual([31, 32, 33]);
+    expect(positions).toEqual([111, 112, 113]);
   });
 
-  test('shelf rack: cell 12 (next cell) gets positions 34-36; cell 1 gets 1-3', () => {
+  test('Oeno shelf rack: bottom-left anchor flips shelf 11 to shelf 8 (Keith real data)', () => {
+    // Keith's cabinet: 18 shelves, bottom-left anchor. Oeno shelf 11 from
+    // bottom = effective shelf 18-11+1 = 8 from top. First slot = (8-1)*11+1 = 78.
     const rack = {
-      type: 'shelf', rows: 2, cols: 6, typeConfig: { bottlesPerCell: 3 },
-      slots: [], maxPosition: 36
+      type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 1, backCols: 5 },
+      slots: [], maxPosition: 198
     };
-    const items = [
-      { item: { rackPosition: 1 }, bottleId: 'a', sourceIndex: 0 },
-      { item: { rackPosition: 12 }, bottleId: 'b', sourceIndex: 1 },
-    ];
-    const { placements } = placeBottlesInRack(rack, items, 'top-left');
-    const posOf = (id) => placements.find(p => p.bottle === id).position;
-    expect(posOf('a')).toBe(1);
-    expect(posOf('b')).toBe(34);
-  });
-
-  test('shelf rack with bottom-left anchor: cell 11 flips through cell-grid math', () => {
-    // 2×6 shelf, bpc=3, anchor=bottom-left.
-    // Oeno cell 11 → cell-grid (row 2, col 5). bottom-left flips row → (row 1, col 5).
-    // Cellarion cell index = (1-1)*6 + 5 = 5. First slot of cell 5 = (5-1)*3 + 1 = 13.
-    const rack = {
-      type: 'shelf', rows: 2, cols: 6, typeConfig: { bottlesPerCell: 3 },
-      slots: [], maxPosition: 36
-    };
-    const items = [
+    const { placements } = placeBottlesInRack(rack, [
       { item: { rackPosition: 11 }, bottleId: 'a', sourceIndex: 0 },
-    ];
-    const { placements } = placeBottlesInRack(rack, items, 'bottom-left');
-    expect(placements[0].position).toBe(13);
+    ], 'bottom-left');
+    expect(placements[0].position).toBe(78);
   });
 
-  test('shelf rack: overflow when cell is full spills into the next cell', () => {
-    // 4 bottles trying to fit into a cell with bpc=3 — the 4th overflows.
+  test('Oeno shelf rack: 11 bottles on the same shelf fill front then back', () => {
+    // A shelf full case: 11 bottles all at shelf 5. Slots 45-55 (front 6 + back 5).
     const rack = {
-      type: 'shelf', rows: 2, cols: 6, typeConfig: { bottlesPerCell: 3 },
-      slots: [], maxPosition: 36
+      type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 1, backCols: 5 },
+      slots: [], maxPosition: 198
     };
-    const items = Array.from({ length: 4 }, (_, i) => ({
-      item: { rackPosition: 11 }, bottleId: `b${i}`, sourceIndex: i
+    const items = Array.from({ length: 11 }, (_, i) => ({
+      item: { rackPosition: 5 }, bottleId: `b${i}`, sourceIndex: i
     }));
     const { placements, unplaced } = placeBottlesInRack(rack, items, 'top-left');
     expect(unplaced).toHaveLength(0);
     const positions = placements.map(p => p.position).sort((a, b) => a - b);
-    expect(positions).toEqual([31, 32, 33, 34]); // 34 is cell 12's first slot
+    expect(positions).toEqual([45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55]);
+  });
+
+  test('Oeno shelf rack: 12th bottle on a full shelf spills into the next shelf', () => {
+    const rack = {
+      type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 1, backCols: 5 },
+      slots: [], maxPosition: 198
+    };
+    const items = Array.from({ length: 12 }, (_, i) => ({
+      item: { rackPosition: 5 }, bottleId: `b${i}`, sourceIndex: i
+    }));
+    const { placements, unplaced } = placeBottlesInRack(rack, items, 'top-left');
+    expect(unplaced).toHaveLength(0);
+    const positions = placements.map(p => p.position).sort((a, b) => a - b);
+    // Shelf 5 holds 11 (positions 45-55); 12th bottle overflows to shelf 6 slot 56
+    expect(positions).toEqual([45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]);
   });
 
   test('end-to-end: row+col coordinates flatten using rack geometry', () => {

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -315,27 +315,27 @@ function ImportBottles() {
 
         // Build per-rack summary + seed editable config with suggestions.
         //
-        // If multiple items share the same (rackName, rackPosition) — the
-        // hallmark of Vintec/Oeno cabinets where each "slot" is actually a
-        // multi-bottle cell — default to shelf type with bottlesPerCell
-        // set to the max observed. Otherwise default to grid (1 bottle/slot).
+        // For Oeno (Vintec/Transtherm) format: their cabinet model is one shelf
+        // = one labelled storage location with 11 bottles (6 front + 5 back).
+        // Their CSV's "M3-11" means "Module 3, shelf 11" — the source position
+        // is a SHELF NUMBER, and Quantity > 1 means multiple bottles on the
+        // SAME shelf (the source app doesn't track which specific cell). So
+        // we default to Open Shelf with cols=6, backCols=5, bottlesPerCell=1,
+        // rows sized to fit the highest shelf number observed.
         //
-        // Users can switch any rack to a different shape in the picker, or
-        // skip the inference entirely for the user-doesn't-own-a-rack case.
+        // For other formats: default to grid where each position is a slot.
+        // Multi-bottle-per-cell stacking is left for the user to opt into
+        // manually if their physical rack works that way.
         const summary = summariseRacks(items);
         const initialConfigs = {};
         for (const [name, info] of Object.entries(summary)) {
-          const bpc = Math.max(1, info.maxPerCell || 1);
-          if (bpc > 1) {
-            // Shelf: size the cell grid to fit the highest cell index seen,
-            // then total slots = rows × cols × bpc.
-            const cells = Math.max(info.maxPosition || 0, 1);
-            const dims = suggestRackDimensions(cells);
+          if (format === 'oeno') {
+            const shelvesObserved = Math.max(info.maxPosition || 0, 1);
             initialConfigs[name] = {
               type: 'shelf',
-              rows: dims.rows,
-              cols: dims.cols,
-              typeConfig: { bottlesPerCell: bpc }
+              rows: Math.min(20, shelvesObserved),
+              cols: 6,
+              typeConfig: { bottlesPerCell: 1, backCols: 5 }
             };
           } else {
             const required = Math.max(info.maxPosition || 0, info.count || 0);
@@ -344,6 +344,11 @@ function ImportBottles() {
         }
         setRackSummary(summary);
         setRackConfigs(initialConfigs);
+        // Oeno cabinets count shelf 1 from the bottom — see Vintec/Transtherm
+        // docs. Default the anchor accordingly so users don't have to flip it.
+        if (format === 'oeno') {
+          setPositionAnchor('bottom-left');
+        }
       } catch (err) {
         setError(`Failed to parse file: ${err.message}`);
       }
@@ -801,8 +806,12 @@ function ImportBottles() {
           <h3>Rack placement</h3>
           {detectedFormat === 'oeno' && (
             <p className="rack-options-hint">
-              Detected an <strong>Oeno (Vintec)</strong> export. Your <code>Rack_Location</code> values
-              like <code>M2-11</code> have been split into rack name + slot number.
+              Detected an <strong>Oeno (Vintec/Transtherm)</strong> export. Each
+              <code>Rack_Location</code> like <code>M3-11</code> maps to{' '}
+              <strong>Module 3, shelf 11</strong>. Defaulted to an Open Shelf
+              layout matching a standard Vintec cabinet (6 front + 5 back per
+              shelf, shelf 1 at the bottom) — adjust rows for each module if
+              your cabinet differs.
             </p>
           )}
           <p className="rack-options-hint">
@@ -832,8 +841,12 @@ function ImportBottles() {
                       <span className="rack-config-existing-badge">Already exists</span>
                       <span className="rack-config-meta">
                         {info.count} bottle{info.count !== 1 ? 's' : ''}
-                        {info.maxPosition > 0 && <>, highest cell {info.maxPosition}</>}
-                        {info.maxPerCell > 1 && <>, up to {info.maxPerCell} per cell</>}
+                        {info.maxPosition > 0 && (
+                          <>, highest {detectedFormat === 'oeno' ? 'shelf' : 'cell'} {info.maxPosition}</>
+                        )}
+                        {info.maxPerCell > 1 && (
+                          <>, up to {info.maxPerCell} on the busiest {detectedFormat === 'oeno' ? 'shelf' : 'cell'}</>
+                        )}
                       </span>
                     </div>
                     <div className="rack-config-existing-note">
@@ -878,8 +891,12 @@ function ImportBottles() {
                     <strong>{name}</strong>
                     <span className="rack-config-meta">
                       {info.count} bottle{info.count !== 1 ? 's' : ''}
-                      {info.maxPosition > 0 && <>, highest cell {info.maxPosition}</>}
-                      {info.maxPerCell > 1 && <>, up to {info.maxPerCell} per cell</>}
+                      {info.maxPosition > 0 && (
+                        <>, highest {detectedFormat === 'oeno' ? 'shelf' : 'cell'} {info.maxPosition}</>
+                      )}
+                      {info.maxPerCell > 1 && (
+                        <>, up to {info.maxPerCell} on the busiest {detectedFormat === 'oeno' ? 'shelf' : 'cell'}</>
+                      )}
                     </span>
                   </div>
                   <div className="rack-config-card-body">
@@ -934,6 +951,16 @@ function ImportBottles() {
                           type="number" min="1" max="20"
                           value={cfg.typeConfig?.bottlesPerCell || 1}
                           onChange={(e) => updateTc('bottlesPerCell', parseInt(e.target.value, 10) || 1)}
+                        />
+                      </label>
+                    )}
+                    {dims.showBackCols && (
+                      <label className="rack-config-field">
+                        <span>Back row</span>
+                        <input
+                          type="number" min="0" max="20"
+                          value={cfg.typeConfig?.backCols ?? 0}
+                          onChange={(e) => updateTc('backCols', parseInt(e.target.value, 10) || 0)}
                         />
                       </label>
                     )}


### PR DESCRIPTION
## Summary

Fixes the Oeno import interpretation after clarification from a real Transtherm Espace 1000 user. In Oeno's data model:

- `M3-11` = **Module 3, shelf 11** (not "cell 11" as v1.50.0 assumed)
- Each shelf holds **11 bottles**: 6 front + 5 back
- `Quantity > 1` = multiple bottles on the **same shelf**, specific cell not recorded
- Shelf 1 is at the **bottom** (Oeno convention)

## What changed

- `computeRackPosition` for shelf type now treats source position as a shelf number (row). Output = first slot of that shelf. Multi-bottle imports for one shelf fan out via existing two-pass overflow (front first, then back).
- Frontend Oeno-format defaults: Open Shelf with cols=6, backCols=5, bottlesPerCell=1, rows=max shelf observed, anchor=bottom-left.
- Missing "Back row" input added to the rack picker so shelf racks can be properly configured (was already in `TYPE_DIMENSIONS` but never rendered).
- Hint text + rack-card meta now use "shelf" terminology for Oeno format.

## Test plan

- [x] 51/51 rackImport tests pass — replaced 4 cell-based shelf tests with Oeno-realistic cases (including Keith's exact data: 3 bottles at M3-11 in an 18×6+5×1 rack with bottom-left anchor → slot 78)
- [x] 507/507 backend, 267/267 frontend tests pass
- [x] Vite production build clean

After merge → patch release v1.50.1.