### PR TITLE
chore(release): v1.50.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary

Patch release fixing the Oeno (Vintec/Transtherm) import interpretation — `Rack_Location` is now correctly treated as a shelf number, not a cell index. See #399.

## Test plan

- [x] All 507 backend + 267 frontend tests passing
- [x] Frontend build clean