### PR TITLE
refactor(import): cleanup pass after audit

### DIFF
--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -714,7 +714,9 @@ router.post('/confirm', async (req, res) => {
     searchService.bulkIndexBottles(createdBottleIds);
 
     // Per-rack two-pass placement: for each rack referenced in this import,
-    // assign exact slots first, then overflow extras into nearest empty slots.
+    // assign each item to its requested slot first (or, for shelf racks, the
+    // first slot of the requested shelf), then overflow extras into the
+    // nearest empty slot on the same rack.
     let placedCount = 0;
     let overflowedCount = 0;
     const unplacedDetails = []; // [{ sourceIndex, rackName, requestedPosition, reason }]

--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -210,11 +210,14 @@ function planRackCreations(items) {
     if (!entry.rows) entry.rows = 1;
     if (!entry.cols) entry.cols = 1;
 
-    // Grow capacity to fit if needed (grid + shelf).
+    // Grow capacity to fit if needed (grid + shelf). For shelf racks the
+    // per-row slot count includes back cells × bottlesPerCell; pass the
+    // typeConfig through so totalSlots() computes the right capacity.
     if (entry.type === 'grid' || entry.type === 'shelf') {
-      const capacity = totalSlots(entry.type, entry.rows, entry.cols);
+      const capacity = totalSlots(entry.type, entry.rows, entry.cols, entry.typeConfig);
       if (requiredCapacity > capacity) {
-        entry.rows = Math.ceil(requiredCapacity / entry.cols);
+        const perRow = capacity / entry.rows;
+        entry.rows = Math.ceil(requiredCapacity / Math.max(1, perRow));
       }
     }
 

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -433,6 +433,24 @@ describe('placeBottlesInRack (orchestration)', () => {
     expect(positions).toEqual([45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]);
   });
 
+  test('Oeno shelf rack with bpc=2 (stacked): slot count = (cols+back)*bpc per shelf', () => {
+    // Hypothetical cabinet: 18 shelves, 6 front + 5 back, but each cell
+    // holds 2 bottles stacked. slotsPerShelf = (6+5)*2 = 22.
+    // First slot of shelf 11 (top-left anchor) = (11-1)*22 + 1 = 221.
+    const rack = {
+      type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 2, backCols: 5 },
+      slots: [], maxPosition: 396
+    };
+    const { placements, unplaced } = placeBottlesInRack(rack, [
+      { item: { rackPosition: 11 }, bottleId: 'a', sourceIndex: 0 },
+      { item: { rackPosition: 11 }, bottleId: 'b', sourceIndex: 1 },
+      { item: { rackPosition: 11 }, bottleId: 'c', sourceIndex: 2 },
+    ], 'top-left');
+    expect(unplaced).toHaveLength(0);
+    const positions = placements.map(p => p.position).sort((a, b) => a - b);
+    expect(positions).toEqual([221, 222, 223]);
+  });
+
   test('end-to-end: row+col coordinates flatten using rack geometry', () => {
     const rack = buildRack();
     const { placements } = placeBottlesInRack(rack, [

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -4,10 +4,11 @@ import { useAuth } from '../contexts/AuthContext';
 import { validateImport, confirmImport } from '../api/bottles';
 import { searchWines } from '../api/wines';
 import { getRacks } from '../api/racks';
-import { parseAndMap, parseJSON, suggestRackDimensions, summariseRacks } from '../utils/importMappers';
+import { parseAndMap, parseJSON, summariseRacks, getDefaultRackConfig, getDefaultAnchor } from '../utils/importMappers';
 import { getTotalSlots } from '../utils/rackLayouts';
 import { TYPE_DIMENSIONS } from '../components/racks/RackTypeSelector';
-import { CURRENCIES } from '../config/currencies';
+import AnchorPicker from './import/AnchorPicker';
+import CurrencyPicker from './import/CurrencyPicker';
 import {
   listImportSessions,
   createImportSession,
@@ -59,8 +60,6 @@ function ImportBottles() {
   const { id: cellarId } = useParams();
   const { apiFetch, user } = useAuth();
   const navigate = useNavigate();
-  const isAdmin = user?.roles?.includes('admin');
-
   // Step state
   const [step, setStep] = useState('upload');
   const [error, setError] = useState(null);
@@ -313,42 +312,17 @@ function ImportBottles() {
         setDetectedFormat(format);
         setFileName(file.name);
 
-        // Build per-rack summary + seed editable config with suggestions.
-        //
-        // For Oeno (Vintec/Transtherm) format: their cabinet model is one shelf
-        // = one labelled storage location with 11 bottles (6 front + 5 back).
-        // Their CSV's "M3-11" means "Module 3, shelf 11" — the source position
-        // is a SHELF NUMBER, and Quantity > 1 means multiple bottles on the
-        // SAME shelf (the source app doesn't track which specific cell). So
-        // we default to Open Shelf with cols=6, backCols=5, bottlesPerCell=1,
-        // rows sized to fit the highest shelf number observed.
-        //
-        // For other formats: default to grid where each position is a slot.
-        // Multi-bottle-per-cell stacking is left for the user to opt into
-        // manually if their physical rack works that way.
+        // Build per-rack summary + seed editable config with format-aware
+        // defaults. The format-specific logic (Oeno → shelf, etc.) lives in
+        // getDefaultRackConfig so this page stays format-agnostic.
         const summary = summariseRacks(items);
         const initialConfigs = {};
         for (const [name, info] of Object.entries(summary)) {
-          if (format === 'oeno') {
-            const shelvesObserved = Math.max(info.maxPosition || 0, 1);
-            initialConfigs[name] = {
-              type: 'shelf',
-              rows: Math.min(20, shelvesObserved),
-              cols: 6,
-              typeConfig: { bottlesPerCell: 1, backCols: 5 }
-            };
-          } else {
-            const required = Math.max(info.maxPosition || 0, info.count || 0);
-            initialConfigs[name] = { type: 'grid', ...suggestRackDimensions(required), typeConfig: {} };
-          }
+          initialConfigs[name] = getDefaultRackConfig(format, info);
         }
         setRackSummary(summary);
         setRackConfigs(initialConfigs);
-        // Oeno cabinets count shelf 1 from the bottom — see Vintec/Transtherm
-        // docs. Default the anchor accordingly so users don't have to flip it.
-        if (format === 'oeno') {
-          setPositionAnchor('bottom-left');
-        }
+        setPositionAnchor(getDefaultAnchor(format));
       } catch (err) {
         setError(`Failed to parse file: ${err.message}`);
       }
@@ -783,22 +757,12 @@ function ImportBottles() {
       </div>
 
       {parsedItems.length > 0 && parsedItems.some(i => i.price) && (
-        <div className="import-currency-block">
-          <label className="import-currency-label">
-            <strong>Currency for prices</strong>
-            <select
-              value={importCurrency}
-              onChange={(e) => setImportCurrency(e.target.value)}
-            >
-              {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
-            </select>
-          </label>
-          <p className="import-currency-hint">
-            {parsedItems.some(i => i.currency)
-              ? <>Applied to rows that don't already have a Currency column. Defaulted to your profile setting ({user?.preferences?.currency || 'USD'}).</>
-              : <>Your file has prices but no Currency column. All imported bottles will be tagged with this currency. Defaulted to your profile setting ({user?.preferences?.currency || 'USD'}).</>}
-          </p>
-        </div>
+        <CurrencyPicker
+          value={importCurrency}
+          onChange={setImportCurrency}
+          profileCurrency={user?.preferences?.currency}
+          anyRowHasCurrency={parsedItems.some(i => i.currency)}
+        />
       )}
 
       {parsedItems.length > 0 && Object.keys(rackSummary).length > 0 && (
@@ -808,10 +772,10 @@ function ImportBottles() {
             <p className="rack-options-hint">
               Detected an <strong>Oeno (Vintec/Transtherm)</strong> export. Each
               <code>Rack_Location</code> like <code>M3-11</code> maps to{' '}
-              <strong>Module 3, shelf 11</strong>. Defaulted to an Open Shelf
-              layout matching a standard Vintec cabinet (6 front + 5 back per
-              shelf, shelf 1 at the bottom) — adjust rows for each module if
-              your cabinet differs.
+              <strong>Module 3, shelf 11</strong>. Defaulted each rack to an Open Shelf
+              with the typical Vintec layout (6 front + 5 back per shelf, shelf 1 at
+              the bottom). Adjust rows, cols, or back-row count below to match your
+              specific cabinet model.
             </p>
           )}
           <p className="rack-options-hint">
@@ -862,6 +826,14 @@ function ImportBottles() {
                     {tooSmall && (
                       <div className="rack-config-warn rack-config-existing-warn">
                         Capacity ({existingCapacity}) is below {required} bottles — extras will be reported as unplaced.
+                      </div>
+                    )}
+                    {detectedFormat === 'oeno' && existing.type !== 'shelf' && !existing.isModular && (
+                      <div className="rack-config-warn rack-config-existing-warn">
+                        Oeno positions are <strong>shelf numbers</strong>, but this rack is a
+                        <code> {existing.type}</code>, so positions will be interpreted as
+                        slot indexes instead. Your bottles may land in the wrong physical
+                        location. Delete the rack to recreate it with the Oeno-aware layout.
                       </div>
                     )}
                   </div>
@@ -1008,28 +980,7 @@ function ImportBottles() {
             })}
           </div>
 
-          <div className="anchor-picker">
-            <div className="anchor-picker-label">Where does slot 1 sit in your physical rack?</div>
-            <div className="anchor-picker-grid">
-              {[
-                { value: 'top-left', label: 'Top-left', sub: 'Default for most apps' },
-                { value: 'top-right', label: 'Top-right', sub: '' },
-                { value: 'bottom-left', label: 'Bottom-left', sub: 'Oeno / Vintec' },
-                { value: 'bottom-right', label: 'Bottom-right', sub: '' },
-              ].map(opt => (
-                <button
-                  key={opt.value}
-                  type="button"
-                  className={`anchor-btn anchor-btn-${opt.value} ${positionAnchor === opt.value ? 'active' : ''}`}
-                  onClick={() => setPositionAnchor(opt.value)}
-                >
-                  <span className="anchor-dot" aria-hidden="true" />
-                  <span className="anchor-label">{opt.label}</span>
-                  {opt.sub && <span className="anchor-sub">{opt.sub}</span>}
-                </button>
-              ))}
-            </div>
-          </div>
+          <AnchorPicker value={positionAnchor} onChange={setPositionAnchor} />
         </div>
       )}
 

--- a/frontend/src/pages/import/AnchorPicker.js
+++ b/frontend/src/pages/import/AnchorPicker.js
@@ -1,0 +1,28 @@
+const ANCHOR_OPTIONS = [
+  { value: 'top-left',     label: 'Top-left',     sub: 'Default for most apps' },
+  { value: 'top-right',    label: 'Top-right',    sub: '' },
+  { value: 'bottom-left',  label: 'Bottom-left',  sub: 'Oeno / Vintec' },
+  { value: 'bottom-right', label: 'Bottom-right', sub: '' },
+];
+
+export default function AnchorPicker({ value, onChange }) {
+  return (
+    <div className="anchor-picker">
+      <div className="anchor-picker-label">Where does slot 1 sit in your physical rack?</div>
+      <div className="anchor-picker-grid">
+        {ANCHOR_OPTIONS.map(opt => (
+          <button
+            key={opt.value}
+            type="button"
+            className={`anchor-btn anchor-btn-${opt.value} ${value === opt.value ? 'active' : ''}`}
+            onClick={() => onChange(opt.value)}
+          >
+            <span className="anchor-dot" aria-hidden="true" />
+            <span className="anchor-label">{opt.label}</span>
+            {opt.sub && <span className="anchor-sub">{opt.sub}</span>}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/import/CurrencyPicker.js
+++ b/frontend/src/pages/import/CurrencyPicker.js
@@ -1,0 +1,21 @@
+import { CURRENCIES } from '../../config/currencies';
+
+export default function CurrencyPicker({ value, onChange, profileCurrency, anyRowHasCurrency }) {
+  return (
+    <div className="import-currency-block">
+      <label className="import-currency-label">
+        <strong>Currency for prices</strong>
+        <select value={value} onChange={(e) => onChange(e.target.value)}>
+          {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
+        </select>
+      </label>
+      <p className="import-currency-hint">
+        {anyRowHasCurrency ? (
+          <>Applied to rows that don't already have a Currency column. Defaulted to your profile setting ({profileCurrency || 'USD'}).</>
+        ) : (
+          <>Your file has prices but no Currency column. All imported bottles will be tagged with this currency. Defaulted to your profile setting ({profileCurrency || 'USD'}).</>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -171,10 +171,11 @@ export function suggestRackDimensions(maxPosition) {
  * Summarise rack usage in a parsed-items batch:
  *   { [rackName]: { count, maxPosition, maxPerCell, observedPositions: number[] } }
  *
- * `maxPerCell` is the highest number of items sharing the same rackPosition
- * within a single rack. For Vintec/Oeno-style cabinets where each "Rack_
- * Location" is a multi-bottle cell (3 Chenin Blancs all stored at M3-11),
- * this is the bottlesPerCell value that an auto-created shelf rack needs.
+ * `maxPerCell` tracks the highest number of items sharing the same
+ * rackPosition within a single rack — for Oeno-format imports this is the
+ * "max bottles on the busiest shelf" stat shown in the picker's meta line.
+ * Always returned for diagnostics; the rack-default chooser
+ * (`getDefaultRackConfig`) decides what to do with it per format.
  */
 export function summariseRacks(items) {
   const summary = {};
@@ -588,4 +589,41 @@ export function parseAndMap(text, forceFormat) {
   }
 
   return { items, format, headers };
+}
+
+/**
+ * Pick a sensible default rack configuration for the picker based on the
+ * detected source format and per-rack stats. Format-specific knowledge
+ * lives here so the page component doesn't have to know about it.
+ *
+ * Currently:
+ *   - oeno (Vintec/Transtherm-style): Open Shelf with the typical 6 front
+ *     + 5 back layout, one bottle per cell, rows = max shelf observed.
+ *     This matches Vintec V155/V190/V198 cabinets; users with non-standard
+ *     models can adjust in the picker.
+ *   - everything else: Grid with rows/cols sized to fit the data.
+ *
+ * To add a default for a new format, add a case here — the picker will
+ * pick it up automatically.
+ */
+export function getDefaultRackConfig(format, info) {
+  if (format === 'oeno') {
+    const shelvesObserved = Math.max(info.maxPosition || 0, 1);
+    return {
+      type: 'shelf',
+      rows: Math.min(20, shelvesObserved),
+      cols: 6,
+      typeConfig: { bottlesPerCell: 1, backCols: 5 }
+    };
+  }
+  const required = Math.max(info.maxPosition || 0, info.count || 0);
+  return { type: 'grid', ...suggestRackDimensions(required), typeConfig: {} };
+}
+
+/**
+ * Format-specific default for the slot-1 anchor. Oeno labels shelf 1 at
+ * the bottom of the cabinet; most other apps put slot 1 at the top.
+ */
+export function getDefaultAnchor(format) {
+  return format === 'oeno' ? 'bottom-left' : 'top-left';
 }


### PR DESCRIPTION
## Summary

Five focused fixes + improvements identified by a post-release code audit of the v1.50.x rack-aware importer.

### Fixes

- **Existing-rack type-mismatch warning** — when a CSV import targets a cellar that already has a same-named rack of a different type, the picker now calls out that bottles may land in the wrong physical location, not just "your config will be ignored."
- **planRackCreations capacity calc** now uses the shared `totalSlots()` helper so shelf racks with back rows are sized correctly (latent issue — frontend overrides always won, but the plan's own math was wrong).

### Refactors

- `getDefaultRackConfig(format, info)` + `getDefaultAnchor(format)` extracted to `importMappers.js`. Format-specific knowledge (Oeno → shelf + bottom-left) no longer lives in the page component.
- `AnchorPicker` and `CurrencyPicker` extracted as small components under `pages/import/`.
- Removed dead `isAdmin` local.
- Stale comments + Vintec wording cleaned up.

### Tests

- New: shelf-rack with `bottlesPerCell > 1` (previously uncovered).
- All 508 backend + 267 frontend tests pass.

After merge → patch release v1.50.2.