### PR TITLE
feat(import): per-rack Skip toggle

### DIFF
--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -406,7 +406,9 @@ router.post('/confirm', async (req, res) => {
       : 'USD';
 
     // Validate user-supplied per-rack configuration.
-    // Shape: { [rackName]: { type?, rows?, cols?, typeConfig?: {...} } }
+    // Shape: { [rackName]: { skip?, type?, rows?, cols?, typeConfig?: {...} } }
+    // skip — when true, drop this rack from auto-creation AND placement;
+    //   bottles referencing it land in the cellar without rack placement
     // type — one of RACK_TYPES (defaults to 'grid' if absent/invalid)
     // rows/cols — clamped to 1..20
     // typeConfig — optional shape config (bottlesPerCell, bottlesPerSection,
@@ -420,6 +422,14 @@ router.post('/confirm', async (req, res) => {
     if (rawRackConfigs && typeof rawRackConfigs === 'object') {
       for (const [name, cfg] of Object.entries(rawRackConfigs)) {
         if (!cfg || typeof cfg !== 'object') continue;
+
+        // skip:true short-circuits — no rows/cols required since the rack
+        // won't be created and no bottles will be placed.
+        if (cfg.skip === true) {
+          rackConfigs[String(name)] = { skip: true };
+          continue;
+        }
+
         const rows = clampInt(cfg.rows, 1, 20);
         const cols = clampInt(cfg.cols, 1, 20);
         if (!rows || !cols) continue;
@@ -480,6 +490,9 @@ router.post('/confirm', async (req, res) => {
         for (const [name, spec] of rackPlan.entries()) {
           if (existingNames.has(name)) continue;
           const override = rackConfigs[name];
+          // User opted out of creating this rack — bottles will be imported
+          // into the cellar without placement (handled in the placement loop).
+          if (override?.skip) continue;
           const rows = override?.rows || spec.rows;
           const cols = override?.cols || spec.cols;
           const chosenType = override?.type || spec.type;
@@ -607,7 +620,7 @@ router.post('/confirm', async (req, res) => {
 
           // Queue rack placement for unmatched bottles too
           const hasPlacement = item.rackName && (item.rackPosition || (item.row && item.col));
-          if (hasPlacement && bottle.status === 'active') {
+          if (hasPlacement && bottle.status === 'active' && !rackConfigs[String(item.rackName)]?.skip) {
             pendingPlacements.push({ rackName: String(item.rackName), item, bottleId: bottle._id, sourceIndex: i });
           }
           continue;
@@ -690,7 +703,7 @@ router.post('/confirm', async (req, res) => {
         // the bottle loop so multiple bottles claiming the same slot can
         // overflow into adjacent free slots instead of being silently dropped.
         const hasPlacement = item.rackName && (item.rackPosition || (item.row && item.col));
-        if (hasPlacement && bottle.status === 'active') {
+        if (hasPlacement && bottle.status === 'active' && !rackConfigs[String(item.rackName)]?.skip) {
           pendingPlacements.push({ rackName: String(item.rackName), item, bottleId: bottle._id, sourceIndex: i });
         }
 

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -451,6 +451,16 @@ describe('placeBottlesInRack (orchestration)', () => {
     expect(positions).toEqual([221, 222, 223]);
   });
 
+  test('skip flag is honoured at the route level (helper level: pass an empty group)', () => {
+    // placeBottlesInRack itself doesn't know about `skip` — that's the route's
+    // responsibility. Verify the contract: when the route filters out skipped
+    // racks, the helper sees an empty items array and returns empty arrays.
+    const rack = buildRack();
+    const { placements, unplaced } = placeBottlesInRack(rack, [], 'top-left');
+    expect(placements).toEqual([]);
+    expect(unplaced).toEqual([]);
+  });
+
   test('end-to-end: row+col coordinates flatten using rack geometry', () => {
     const rack = buildRack();
     const { placements } = placeBottlesInRack(rack, [

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1205,6 +1205,42 @@
   color: var(--color-danger, #c0392b);
 }
 
+.rack-config-skip-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.rack-config-skip-toggle input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
+}
+
+.rack-config-skipped {
+  opacity: 0.65;
+  background: var(--color-bg);
+}
+
+.rack-config-skipped-note {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin-top: 0.3rem;
+  padding: 0.4rem 0.6rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
+}
+
+.rack-config-skipped-note strong {
+  font-style: normal;
+  color: var(--color-text);
+}
+
 .rack-config-existing {
   background: var(--color-info-bg, rgba(0, 100, 200, 0.05));
   border-color: var(--color-info-border, var(--color-border));

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -836,6 +836,17 @@ function ImportBottles() {
                         location. Delete the rack to recreate it with the Oeno-aware layout.
                       </div>
                     )}
+                    <label className="rack-config-skip-toggle">
+                      <input
+                        type="checkbox"
+                        checked={!!rackConfigs[name]?.skip}
+                        onChange={(e) => setRackConfigs(prev => ({
+                          ...prev,
+                          [name]: { ...prev[name], skip: e.target.checked }
+                        }))}
+                      />
+                      <span>Skip — don't place bottles into this existing rack</span>
+                    </label>
                   </div>
                 );
               }
@@ -857,8 +868,10 @@ function ImportBottles() {
                 }
               }));
 
+              const isSkipped = !!cfg.skip;
+
               return (
-                <div key={name} className="rack-config-card">
+                <div key={name} className={`rack-config-card ${isSkipped ? 'rack-config-skipped' : ''}`}>
                   <div className="rack-config-card-head">
                     <strong>{name}</strong>
                     <span className="rack-config-meta">
@@ -870,8 +883,21 @@ function ImportBottles() {
                         <>, up to {info.maxPerCell} on the busiest {detectedFormat === 'oeno' ? 'shelf' : 'cell'}</>
                       )}
                     </span>
+                    <label className="rack-config-skip-toggle">
+                      <input
+                        type="checkbox"
+                        checked={isSkipped}
+                        onChange={(e) => updateCfg({ skip: e.target.checked })}
+                      />
+                      <span>Skip — import bottles without a rack</span>
+                    </label>
                   </div>
-                  <div className="rack-config-card-body">
+                  {isSkipped && (
+                    <div className="rack-config-skipped-note">
+                      The {info.count} bottle{info.count !== 1 ? 's' : ''} for this rack will be imported into the cellar without rack placement. No rack named <strong>{name}</strong> will be created.
+                    </div>
+                  )}
+                  <div className="rack-config-card-body" style={{ display: isSkipped ? 'none' : undefined }}>
                     <label className="rack-config-field">
                       <span>Type</span>
                       <select
@@ -967,14 +993,16 @@ function ImportBottles() {
                       </>
                     )}
                   </div>
-                  <div className="rack-config-capacity-line">
-                    = {capacity} slots
-                    {tooSmall && (
-                      <span className="rack-config-warn">
-                        {' '}— too small for {required} bottles
-                      </span>
-                    )}
-                  </div>
+                  {!isSkipped && (
+                    <div className="rack-config-capacity-line">
+                      = {capacity} slots
+                      {tooSmall && (
+                        <span className="rack-config-warn">
+                          {' '}— too small for {required} bottles
+                        </span>
+                      )}
+                    </div>
+                  )}
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary

Each rack referenced in a CSV import now has a **Skip** checkbox in its picker card. Checked = the rack isn't auto-created and the bottles for that rack land in the cellar without placement.

Useful for users migrating bottle data from apps like Oeno who don't want to recreate the cabinet structure in Cellarion. Also works on existing-rack cards (skip placement into an existing same-named rack).

## Test plan

- [x] 509 backend + 267 frontend tests pass
- [x] Vite build clean