### PR TITLE
feat(import): real Oeno-by-Vintec two-section export parser

### DIFF
--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -47,6 +47,7 @@ function computeRackPosition({
   position, row, col,
   rackRows, rackCols,
   rackType, bottlesPerCell, backCols,
+  layer, slotInLayer,
   anchor = DEFAULT_ANCHOR
 }) {
   if (!VALID_ANCHORS.includes(anchor)) {
@@ -60,11 +61,14 @@ function computeRackPosition({
   const isShelf = rackType === 'shelf';
 
   // Shelf racks: the source position is a SHELF NUMBER (row), matching how
-  // real-world cabinets (Vintec/Transtherm) label storage. "M3-11" means
-  // "Module 3, shelf 11" — the specific cell within that shelf isn't
-  // recorded by the source app. Output is the FIRST slot of the shelf;
-  // multiple bottles on the same shelf will fan out to adjacent cells via
+  // real-world cabinets (Vintec/Transtherm) label storage. Output is the
+  // FIRST slot of the shelf when only the shelf number is known; multiple
+  // bottles on the same shelf will fan out to adjacent cells via
   // placeBottles' forward-scan overflow (front cells first, then back).
+  //
+  // Oeno's real two-section export additionally provides `layer` (1=front,
+  // 2=back) and `slotInLayer`, which let us compute the EXACT Cellarion
+  // slot for each bottle.
   if (isShelf && position !== undefined && position !== null && position !== '') {
     const p = parseInt(position, 10);
     if (isNaN(p) || p < 1) return { error: 'Invalid shelf' };
@@ -82,7 +86,27 @@ function computeRackPosition({
       return { error: 'rackCols is required for shelf placement' };
     }
     const slotsPerShelf = (cols + back) * bpc;
-    return { position: (effectiveShelf - 1) * slotsPerShelf + 1 };
+    const shelfBase = (effectiveShelf - 1) * slotsPerShelf;
+
+    const layerNum = parseInt(layer, 10);
+    const slotNum = parseInt(slotInLayer, 10);
+    if (!isNaN(layerNum) && !isNaN(slotNum) && slotNum >= 1) {
+      if (layerNum === 1) {
+        if (slotNum > cols) {
+          return { error: `front slot ${slotNum} exceeds cols ${cols}` };
+        }
+        return { position: shelfBase + slotNum };
+      }
+      if (layerNum === 2) {
+        if (slotNum > back) {
+          return { error: `back slot ${slotNum} exceeds backCols ${back}` };
+        }
+        return { position: shelfBase + cols + slotNum };
+      }
+      return { error: `invalid layer ${layerNum} (expected 1 or 2)` };
+    }
+
+    return { position: shelfBase + 1 };
   }
 
   // Grid rack (or shelf with row+col input): source is a slot or (row, col).
@@ -258,6 +282,8 @@ function placeBottlesInRack(rack, items, anchor) {
       position: it.item.rackPosition,
       row: it.item.row,
       col: it.item.col,
+      layer: it.item.layer,
+      slotInLayer: it.item.slotInLayer,
       rackRows: rack.rows,
       rackCols: rack.cols,
       rackType: rack.type,

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -433,6 +433,44 @@ describe('placeBottlesInRack (orchestration)', () => {
     expect(positions).toEqual([45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]);
   });
 
+  test('Oeno-export bottle with explicit layer + slotInLayer (front cell)', () => {
+    // Walk-in Module 3 (18 shelves × 6 front + 5 back). Bottle on shelf 18,
+    // front layer, slot 5. With bottom-left anchor → effective shelf 1.
+    // First slot of shelf 1 = 1; front layer slot 5 = position 5.
+    const rack = {
+      type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 1, backCols: 5 },
+      slots: [], maxPosition: 198
+    };
+    const { placements } = placeBottlesInRack(rack, [
+      { item: { rackPosition: 18, layer: 1, slotInLayer: 5 }, bottleId: 'syrah', sourceIndex: 0 },
+    ], 'bottom-left');
+    expect(placements[0].position).toBe(5);
+  });
+
+  test('Oeno-export bottle with layer=2 (back) maps to slot cols + slotInLayer', () => {
+    // Shelf 18, layer 2 (back), slot 3 → back slots start at cols+1 (=7).
+    // With bottom-left: effective shelf 1, base slot 0, back slot 3 = position 9.
+    const rack = {
+      type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 1, backCols: 5 },
+      slots: [], maxPosition: 198
+    };
+    const { placements } = placeBottlesInRack(rack, [
+      { item: { rackPosition: 18, layer: 2, slotInLayer: 3 }, bottleId: 'b', sourceIndex: 0 },
+    ], 'bottom-left');
+    expect(placements[0].position).toBe(9); // 0 + 6 + 3
+  });
+
+  test('Oeno-export bottle: top-left anchor maps shelf 1 layer 1 slot 1 → position 1', () => {
+    const rack = {
+      type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 1, backCols: 5 },
+      slots: [], maxPosition: 198
+    };
+    const { placements } = placeBottlesInRack(rack, [
+      { item: { rackPosition: 1, layer: 1, slotInLayer: 1 }, bottleId: 'a', sourceIndex: 0 },
+    ], 'top-left');
+    expect(placements[0].position).toBe(1);
+  });
+
   test('Oeno shelf rack with bpc=2 (stacked): slot count = (cols+back)*bpc per shelf', () => {
     // Hypothetical cabinet: 18 shelves, 6 front + 5 back, but each cell
     // holds 2 bottles stacked. slotsPerShelf = (6+5)*2 = 22.

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -25,7 +25,7 @@ const FORMAT_LABELS = {
   cellarion: 'Cellarion',
   vivino: 'Vivino',
   cellartracker: 'CellarTracker',
-  oeno: 'Oeno (Vintec)',
+  'oeno-export': 'Oeno by Vintec',
   generic: 'CSV'
 };
 
@@ -301,9 +301,10 @@ function ImportBottles() {
     const reader = new FileReader();
     reader.onload = (e) => {
       try {
-        const { items, format } = isJson
+        const parsed = isJson
           ? parseJSON(e.target.result)
           : parseAndMap(e.target.result);
+        const { items, format, oenoRackSpecs } = parsed;
         if (items.length === 0) {
           setError('No valid items found in the file.');
           return;
@@ -313,11 +314,15 @@ function ImportBottles() {
         setFileName(file.name);
 
         // Build per-rack summary + seed editable config with format-aware
-        // defaults. The format-specific logic (Oeno → shelf, etc.) lives in
-        // getDefaultRackConfig so this page stays format-agnostic.
+        // defaults. For Oeno-export, the cabinet metadata in the CSV gives
+        // us the exact shape of each rack (one per cabinet-column); pass
+        // that through to the picker via info.oenoRackSpec.
         const summary = summariseRacks(items);
         const initialConfigs = {};
         for (const [name, info] of Object.entries(summary)) {
+          if (oenoRackSpecs && oenoRackSpecs[name]) {
+            info.oenoRackSpec = oenoRackSpecs[name];
+          }
           initialConfigs[name] = getDefaultRackConfig(format, info);
         }
         setRackSummary(summary);
@@ -715,8 +720,8 @@ function ImportBottles() {
             <p>Export from CellarTracker via My Cellar &rarr; Download</p>
           </div>
           <div className="format-card">
-            <strong>Oeno (Vintec)</strong>
-            <p>CSV with Producer, Wine, Vintage, Quantity, Rack_Location columns</p>
+            <strong>Oeno by Vintec</strong>
+            <p>Real Oeno-by-Vintec export — two-section CSV with cabinet definitions + bottles. Cabinets, shelves, and bottle history all import automatically.</p>
           </div>
           <div className="format-card">
             <strong>Generic CSV</strong>
@@ -768,14 +773,13 @@ function ImportBottles() {
       {parsedItems.length > 0 && Object.keys(rackSummary).length > 0 && (
         <div className="import-rack-options">
           <h3>Rack placement</h3>
-          {detectedFormat === 'oeno' && (
+          {detectedFormat === 'oeno-export' && (
             <p className="rack-options-hint">
-              Detected an <strong>Oeno (Vintec/Transtherm)</strong> export. Each
-              <code>Rack_Location</code> like <code>M3-11</code> maps to{' '}
-              <strong>Module 3, shelf 11</strong>. Defaulted each rack to an Open Shelf
-              with the typical Vintec layout (6 front + 5 back per shelf, shelf 1 at
-              the bottom). Adjust rows, cols, or back-row count below to match your
-              specific cabinet model.
+              Detected an <strong>Oeno by Vintec</strong> export. Cabinets and per-column
+              modules from your CSV have been mapped to one Open Shelf rack each
+              (6 front + 5 back per shelf, shelf 1 at the bottom). Each bottle's
+              exact slot is preserved — adjust shelf counts below only if a cabinet
+              has more shelves than the file shows.
             </p>
           )}
           <p className="rack-options-hint">
@@ -806,10 +810,10 @@ function ImportBottles() {
                       <span className="rack-config-meta">
                         {info.count} bottle{info.count !== 1 ? 's' : ''}
                         {info.maxPosition > 0 && (
-                          <>, highest {detectedFormat === 'oeno' ? 'shelf' : 'cell'} {info.maxPosition}</>
+                          <>, highest {detectedFormat === 'oeno-export' ? 'shelf' : 'cell'} {info.maxPosition}</>
                         )}
                         {info.maxPerCell > 1 && (
-                          <>, up to {info.maxPerCell} on the busiest {detectedFormat === 'oeno' ? 'shelf' : 'cell'}</>
+                          <>, up to {info.maxPerCell} on the busiest {detectedFormat === 'oeno-export' ? 'shelf' : 'cell'}</>
                         )}
                       </span>
                     </div>
@@ -828,7 +832,7 @@ function ImportBottles() {
                         Capacity ({existingCapacity}) is below {required} bottles — extras will be reported as unplaced.
                       </div>
                     )}
-                    {detectedFormat === 'oeno' && existing.type !== 'shelf' && !existing.isModular && (
+                    {detectedFormat === 'oeno-export' && existing.type !== 'shelf' && !existing.isModular && (
                       <div className="rack-config-warn rack-config-existing-warn">
                         Oeno positions are <strong>shelf numbers</strong>, but this rack is a
                         <code> {existing.type}</code>, so positions will be interpreted as
@@ -877,10 +881,10 @@ function ImportBottles() {
                     <span className="rack-config-meta">
                       {info.count} bottle{info.count !== 1 ? 's' : ''}
                       {info.maxPosition > 0 && (
-                        <>, highest {detectedFormat === 'oeno' ? 'shelf' : 'cell'} {info.maxPosition}</>
+                        <>, highest {detectedFormat === 'oeno-export' ? 'shelf' : 'cell'} {info.maxPosition}</>
                       )}
                       {info.maxPerCell > 1 && (
-                        <>, up to {info.maxPerCell} on the busiest {detectedFormat === 'oeno' ? 'shelf' : 'cell'}</>
+                        <>, up to {info.maxPerCell} on the busiest {detectedFormat === 'oeno-export' ? 'shelf' : 'cell'}</>
                       )}
                     </span>
                     <label className="rack-config-skip-toggle">

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -107,7 +107,12 @@ export function parseCSV(text, delimiter = ',') {
 
 /**
  * Detect the source format from CSV headers.
- * Returns: 'cellarion' | 'vivino' | 'cellartracker' | 'oeno' | 'generic'
+ * Returns: 'cellarion' | 'vivino' | 'cellartracker' | 'oeno-export' | 'generic'
+ *
+ * Note: real Oeno-by-Vintec exports use a two-section CSV (cabinet defs +
+ * bottles) detected by `detectOenoExport` against the raw text, not by
+ * single-row headers. This function only sees the headers of section 2 (or
+ * a single-section file), so Oeno-export detection happens at parse time.
  */
 export function detectFormat(headers) {
   const h = new Set(headers.map(s => s.toLowerCase().trim()));
@@ -115,9 +120,6 @@ export function detectFormat(headers) {
 
   // Cellarion's own CSV export uses camelCase headers
   if (raw.has('wineName') && raw.has('producer') && raw.has('vintage')) return 'cellarion';
-
-  // Oeno (Vintec) export — distinctive columns
-  if (h.has('rack_location') || h.has('mastervarietal')) return 'oeno';
 
   // Vivino export headers
   if (h.has('wine name') || h.has('winery')) return 'vivino';
@@ -127,6 +129,20 @@ export function detectFormat(headers) {
   if (h.has('wine') && h.has('vintage') && (h.has('locale') || h.has('bin'))) return 'cellartracker';
 
   return 'generic';
+}
+
+/**
+ * Detect Oeno-by-Vintec's real two-section export by scanning for the
+ * "User Bottles Details" marker separating the cabinet definitions from
+ * the bottle records. Returns the row index of the bottle-section header
+ * row, or -1 if the file isn't an Oeno export.
+ */
+export function detectOenoExportBoundary(rows) {
+  for (let i = 0; i < rows.length; i++) {
+    const firstCell = (rows[i].split(',')[0] || '').trim();
+    if (firstCell === 'Bottle ID') return i;
+  }
+  return -1;
 }
 
 /**
@@ -386,54 +402,6 @@ function mapGenericRow(row) {
   };
 }
 
-// ── Oeno (Vintec) Mapper ────────────────────────────────────────────────────
-
-/**
- * Map a row from an Oeno / Vintec CSV export. Distinctive columns:
- *   - Rack_Location: combined "<rackName>-<position>" string (e.g. "M2-11")
- *   - MasterVarietal / Varietal2 / Varietal3: grape varieties
- *   - type: "Red Wine" / "White Wine" / etc.
- *   - Size: bare number in millilitres
- *   - BeginConsume / EndConsume: drink window (not yet imported)
- *   - Location: typically the cellar name (e.g. "Cellar") — preserved as
- *     the free-text bottle location field
- */
-function mapOenoRow(row) {
-  const get = (keys) => {
-    for (const k of keys) {
-      const val = row[k] || row[k.toLowerCase()];
-      if (val) return val.trim();
-    }
-    return '';
-  };
-
-  const price = parseFloat(get(['Price', 'price']));
-  const qty = parseInt(get(['Quantity', 'quantity', 'Qty', 'Count']), 10);
-
-  // Oeno encodes rack + position together as e.g. "M2-11"
-  const combined = get(['Rack_Location', 'Rack Location', 'RackLocation']);
-  const parsed = parseCombinedRackLocation(combined);
-
-  return {
-    wineName: get(['Wine', 'wine']),
-    producer: get(['Producer', 'producer']),
-    vintage: get(['Vintage', 'vintage', 'Year']) || 'NV',
-    country: get(['Country', 'country']),
-    region: get(['Region', 'region']),
-    appellation: get(['Appellation', 'appellation', 'SubRegion']),
-    type: mapWineType(get(['type', 'Type', 'Wine Type'])),
-    price: isNaN(price) ? undefined : price,
-    bottleSize: normaliseBottleSize(get(['Size', 'size', 'Bottle Size'])) || '750ml',
-    quantity: isNaN(qty) || qty < 1 ? 1 : qty,
-    notes: get(['Notes', 'notes', 'Note', 'Comments']),
-    // Oeno's "Location" column is the cellar name (e.g. "Cellar"), preserved
-    // as a free-text label on the bottle since cellar selection happens in the UI.
-    location: get(['Location', 'location']),
-    rackName: parsed?.rackName || get(['Rack', 'rack', 'Rack Name']) || undefined,
-    rackPosition: parsed?.rackPosition || parseInt(get(['Rack Position', 'Position', 'Slot']), 10) || undefined,
-  };
-}
-
 // ── Cellarion CSV Mapper ─────────────────────────────────────────────────────
 
 /**
@@ -538,6 +506,239 @@ export function parseJSON(text) {
   return { items, format: 'cellarion', headers };
 }
 
+// \u2500\u2500 Oeno-by-Vintec export (real) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+
+/**
+ * Parse Oeno's real two-section CSV export.
+ *
+ * The file is structured as:
+ *   1. Cabinet/layer definitions \u2014 one row per (cabinet, column, shelf,
+ *      layer-front-back). Includes "Disabled Slots" so we know which
+ *      positions are unusable. Total/Empty Slots are cabinet-level stats.
+ *   2. A blank-row separator + literal "User Bottles Details" marker.
+ *   3. Bottle records \u2014 one row per individual bottle, joining to a
+ *      specific layer via Layer ID and indicating its slot within that
+ *      layer. Cabinet fields can all be "null" for unshelved bottles.
+ *
+ * The parser maps each (cabinet, column) pair into a Cellarion shelf rack
+ * sized for that column's shelves with cols=6, backCols=5, bpc=1 (Vintec/
+ * Transtherm standard \u2014 users can override in the picker). Each bottle
+ * carries an explicit shelf number, layer (1=front, 2=back), and
+ * slotInLayer; the backend's computeRackPosition uses those to compute
+ * the exact Cellarion slot.
+ *
+ * Consumed bottles (Consumed On set) come in via the existing
+ * addToHistory path. Unshelved bottles (Cabinet ID = null) skip rack
+ * placement.
+ *
+ * @param {string} text - Raw CSV text
+ * @returns {{ items: object[], format: 'oeno-export', headers: string[], oenoRackSpecs: object }}
+ *   `oenoRackSpecs` is keyed by rack name and used by the picker's
+ *   default-rack-config helper to pre-fill cabinet shapes.
+ */
+export function parseOenoExport(text) {
+  const cleaned = text.replace(/^\uFEFF/, '');
+  const lines = cleaned.split(/\r?\n/);
+  const boundary = detectOenoExportBoundary(lines);
+  if (boundary === -1) {
+    return null;
+  }
+
+  // \u2500\u2500 Section 1: cabinet/layer definitions \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+  // Lookup map: Layer ID (string) \u2192 { cabinetId, cabinetLabel, cabinetBrand,
+  //   cabinetModel, columnIndex, shelfIndex, layerIndex, disabledSlots:Set }
+  const layerById = new Map();
+  // Per-cabinet metadata for the rack-spec output
+  const cabinetById = new Map();
+
+  // Section 1 has a header row at index 0
+  for (let i = 1; i < boundary; i++) {
+    const cells = splitCSVLine(lines[i]);
+    if (!cells[0] || !cells[0].trim()) continue;
+    const cabinetId = cells[0].trim();
+    if (!cabinetId) continue;
+
+    const cabinetLabel = (cells[1] || '').trim();
+    const cabinetBrand = (cells[2] || '').trim();
+    const cabinetModel = (cells[3] || '').trim();
+    const columnIndex = parseInt(cells[4], 10);
+    const shelfIndex = parseInt(cells[5], 10);
+    const layerIndex = parseInt(cells[6], 10);
+    const layerId = (cells[7] || '').trim();
+
+    if (!layerId || isNaN(columnIndex) || isNaN(shelfIndex) || isNaN(layerIndex)) continue;
+
+    // "Disabled Slots" is a comma-separated list inside the field (which is
+    // itself comma-separated). The CSV parser already handles the quoting,
+    // so cells[8] is a raw string like "6, 5" or "0" (meaning none disabled)
+    // or "1, 2, 3" etc.
+    const disabledRaw = (cells[8] || '').trim();
+    const disabledSlots = new Set();
+    if (disabledRaw && disabledRaw !== '0') {
+      for (const part of disabledRaw.split(',')) {
+        const n = parseInt(part.trim(), 10);
+        if (!isNaN(n) && n > 0) disabledSlots.add(n);
+      }
+    }
+
+    layerById.set(layerId, {
+      cabinetId, cabinetLabel, cabinetBrand, cabinetModel,
+      columnIndex, shelfIndex, layerIndex, disabledSlots
+    });
+
+    if (!cabinetById.has(cabinetId)) {
+      cabinetById.set(cabinetId, {
+        label: cabinetLabel,
+        brand: cabinetBrand,
+        model: cabinetModel,
+        columns: new Map(), // columnIndex \u2192 { maxShelf }
+      });
+    }
+    const cab = cabinetById.get(cabinetId);
+    if (!cab.columns.has(columnIndex)) {
+      cab.columns.set(columnIndex, { maxShelf: 0 });
+    }
+    const col = cab.columns.get(columnIndex);
+    if (shelfIndex > col.maxShelf) col.maxShelf = shelfIndex;
+  }
+
+  // \u2500\u2500 Section 2: bottle records \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+  const bottleHeaders = splitCSVLine(lines[boundary]);
+  const headerIndex = (name) => bottleHeaders.findIndex(h => h.trim() === name);
+  const idx = {
+    bottleId: headerIndex('Bottle ID'),
+    cabinetId: headerIndex('Cabinet ID'),
+    layerId: headerIndex('Layer ID'),
+    slot: headerIndex('Slot'),
+    size: headerIndex('Bottle Size Liters'),
+    year: headerIndex('Wine Year'),
+    type: headerIndex('Wine Type'),
+    note: headerIndex('Bottle Note'),
+    title: headerIndex('Wine Title'),
+    country: headerIndex('Wine Country'),
+    region: headerIndex('Wine Region'),
+    winery: headerIndex('Wine Winery'),
+    cost: headerIndex('Purchase Cost'),
+    currency: headerIndex('Purchase Currency'),
+    purchase: headerIndex('Purchase Date'),
+    consumed: headerIndex('Consumed On'),
+  };
+
+  const items = [];
+  const rackNameFor = (cabinetLabel, columnIndex, totalColumns) =>
+    totalColumns > 1 ? `${cabinetLabel} \u2013 Module ${columnIndex}` : cabinetLabel;
+
+  for (let i = boundary + 1; i < lines.length; i++) {
+    const cells = splitCSVLine(lines[i]);
+    if (!cells[idx.bottleId] || !cells[idx.bottleId].trim()) continue;
+
+    const cabinetIdRaw = (cells[idx.cabinetId] || '').trim();
+    const layerIdRaw = (cells[idx.layerId] || '').trim();
+    const slotRaw = (cells[idx.slot] || '').trim();
+    const isUnshelved = !cabinetIdRaw || cabinetIdRaw === 'null';
+
+    const sizeLitres = parseFloat(cells[idx.size]);
+    const bottleSize = isNaN(sizeLitres) ? '750ml' : `${Math.round(sizeLitres * 1000)}ml`;
+    const cost = parseFloat(cells[idx.cost]);
+    const consumedAt = (cells[idx.consumed] || '').trim();
+
+    const baseItem = {
+      wineName: (cells[idx.title] || '').trim(),
+      producer: (cells[idx.winery] || '').trim(),
+      vintage: (cells[idx.year] || '').trim() || 'NV',
+      country: (cells[idx.country] || '').trim(),
+      region: (cells[idx.region] || '').trim(),
+      type: mapWineType((cells[idx.type] || '').trim()),
+      bottleSize,
+      notes: (cells[idx.note] || '').trim(),
+      price: isNaN(cost) ? undefined : cost,
+      currency: (cells[idx.currency] || '').trim() || undefined,
+      purchaseDate: (cells[idx.purchase] || '').trim() || undefined,
+    };
+
+    if (consumedAt) {
+      baseItem.addToHistory = true;
+      baseItem.consumedAt = consumedAt;
+      baseItem.consumedReason = 'drank';
+    }
+
+    if (isUnshelved) {
+      items.push(baseItem);
+      continue;
+    }
+
+    const layer = layerById.get(layerIdRaw);
+    if (!layer) {
+      // Layer ID references a layer we don't know \u2014 still import as unshelved
+      items.push(baseItem);
+      continue;
+    }
+
+    const totalColumns = cabinetById.get(layer.cabinetId)?.columns.size || 1;
+    items.push({
+      ...baseItem,
+      rackName: rackNameFor(layer.cabinetLabel, layer.columnIndex, totalColumns),
+      // For shelf racks the backend interprets rackPosition as the shelf
+      // number (row). layer + slotInLayer pin down the exact cell.
+      rackPosition: layer.shelfIndex,
+      layer: layer.layerIndex,
+      slotInLayer: parseInt(slotRaw, 10) || undefined,
+    });
+  }
+
+  // Build per-rack default configs so the picker can pre-fill cabinet shapes
+  const oenoRackSpecs = {};
+  for (const [, cab] of cabinetById) {
+    const totalColumns = cab.columns.size;
+    for (const [columnIndex, col] of cab.columns) {
+      const rackName = rackNameFor(cab.label, columnIndex, totalColumns);
+      oenoRackSpecs[rackName] = {
+        type: 'shelf',
+        rows: Math.min(20, col.maxShelf),
+        cols: 6,
+        typeConfig: { bottlesPerCell: 1, backCols: 5 },
+      };
+    }
+  }
+
+  return {
+    items,
+    format: 'oeno-export',
+    headers: bottleHeaders,
+    oenoRackSpecs,
+  };
+}
+
+/**
+ * Split one CSV line respecting double-quoted fields (which may contain
+ * commas). Same logic as parseCSV's inner splitLine but exposed for the
+ * Oeno-export parser to use on individual lines.
+ */
+function splitCSVLine(line, delimiter = ',') {
+  if (!line) return [];
+  const fields = [];
+  let field = '';
+  let inQ = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (c === '"') {
+      if (inQ && line[i + 1] === '"') {
+        field += '"';
+        i++;
+      } else {
+        inQ = !inQ;
+      }
+    } else if (c === delimiter && !inQ) {
+      fields.push(field);
+      field = '';
+    } else {
+      field += c;
+    }
+  }
+  fields.push(field);
+  return fields;
+}
+
 /**
  * Main entry: parse a file and return mapped items in master format.
  *
@@ -548,6 +749,16 @@ export function parseJSON(text) {
 export function parseAndMap(text, forceFormat) {
   // Strip BOM
   const cleaned = text.replace(/^\uFEFF/, '');
+
+  // Oeno's real export has a distinctive two-section structure that single-
+  // row header detection can't pick up; try the Oeno-export parser first.
+  if (!forceFormat || forceFormat === 'oeno-export') {
+    const lines = cleaned.split(/\r?\n/);
+    if (detectOenoExportBoundary(lines) !== -1) {
+      const parsed = parseOenoExport(text);
+      if (parsed) return parsed;
+    }
+  }
 
   const delimiter = detectDelimiter(cleaned);
   const rows = parseCSV(cleaned, delimiter);
@@ -561,13 +772,11 @@ export function parseAndMap(text, forceFormat) {
 
   const mapper = format === 'cellarion'
     ? mapCellarionRow
-    : format === 'oeno'
-      ? mapOenoRow
-      : format === 'vivino'
+    : format === 'vivino'
       ? mapVivinoRow
-      : format === 'cellartracker'
-        ? mapCellarTrackerRow
-        : mapGenericRow;
+    : format === 'cellartracker'
+      ? mapCellarTrackerRow
+      : mapGenericRow;
 
   // Map rows and expand quantity > 1 into individual items
   const items = [];
@@ -597,33 +806,27 @@ export function parseAndMap(text, forceFormat) {
  * lives here so the page component doesn't have to know about it.
  *
  * Currently:
- *   - oeno (Vintec/Transtherm-style): Open Shelf with the typical 6 front
- *     + 5 back layout, one bottle per cell, rows = max shelf observed.
- *     This matches Vintec V155/V190/V198 cabinets; users with non-standard
- *     models can adjust in the picker.
- *   - everything else: Grid with rows/cols sized to fit the data.
- *
- * To add a default for a new format, add a case here — the picker will
- * pick it up automatically.
+ *   - oeno-export: rack defaults come from the cabinet metadata inside the
+ *     CSV itself (cabinet brand/model → shelf layout). Per-rack overrides
+ *     are written directly during parsing, so this function returns a
+ *     conservative shelf fallback for any rack that slips through.
+ *   - everything else: Grid with rows/cols sized to fit the data. No
+ *     auto-inferred multi-bottle stacking; users opt in via the picker.
  */
 export function getDefaultRackConfig(format, info) {
-  if (format === 'oeno') {
-    const shelvesObserved = Math.max(info.maxPosition || 0, 1);
-    return {
-      type: 'shelf',
-      rows: Math.min(20, shelvesObserved),
-      cols: 6,
-      typeConfig: { bottlesPerCell: 1, backCols: 5 }
-    };
+  if (format === 'oeno-export' && info.oenoRackSpec) {
+    // Cabinet/column-specific spec set during oeno-export parsing.
+    return info.oenoRackSpec;
   }
   const required = Math.max(info.maxPosition || 0, info.count || 0);
   return { type: 'grid', ...suggestRackDimensions(required), typeConfig: {} };
 }
 
 /**
- * Format-specific default for the slot-1 anchor. Oeno labels shelf 1 at
- * the bottom of the cabinet; most other apps put slot 1 at the top.
+ * Format-specific default for the slot-1 anchor.
+ *   - oeno-export: shelf 1 is at the bottom of the cabinet (Oeno convention)
+ *   - everything else: top-left (most apps)
  */
 export function getDefaultAnchor(format) {
-  return format === 'oeno' ? 'bottom-left' : 'top-left';
+  return format === 'oeno-export' ? 'bottom-left' : 'top-left';
 }

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -5,6 +5,8 @@ import {
   parseJSON,
   parseAndMap,
   parseCombinedRackLocation,
+  parseOenoExport,
+  detectOenoExportBoundary,
 } from './importMappers';
 
 // ---------------------------------------------------------------------------
@@ -425,12 +427,15 @@ describe('parseAndMap', () => {
       expect(result.items[0].row).toBeUndefined();
     });
 
-    it('parses Oeno-style Rack_Location "M2-11" into rackName + rackPosition', () => {
+    it('parses Rack_Location "M2-11" into rackName + rackPosition (generic format)', () => {
+      // Rack_Location is parsed by the generic mapper as a fallback; the
+      // dedicated "Oeno" format detection is reserved for real Oeno
+      // two-section exports, not for spreadsheets with Rack_Location columns.
       const csv = 'Producer,Wine,Vintage,Quantity,Rack_Location,type,Size,Price,Country\n' +
         'Amisfield,Amisfield Chenin Blanc,2019,3,M3-11,White Wine,750,35,New Zealand\n' +
         'Alexander,Alexander Dusty Road Pinot Noir,2018,1,M2-11,Red Wine,750,35,New Zealand';
       const result = parseAndMap(csv);
-      expect(result.format).toBe('oeno');
+      expect(result.format).toBe('generic');
       // Quantity 3 + 1 = 4 bottles
       expect(result.items).toHaveLength(4);
       const m3 = result.items[0];
@@ -457,5 +462,115 @@ describe('parseAndMap', () => {
         expect(item.rackName).toBe('Cabinet');
       });
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Oeno-by-Vintec real two-section export
+// ---------------------------------------------------------------------------
+describe('parseOenoExport', () => {
+  // Minimal fixture mirroring the real export shape: one walk-in cabinet
+  // with two columns, the second cabinet with one column, plus four bottles
+  // covering placed/unshelved and active/consumed paths.
+  const fixture = [
+    'Cabinet ID,Cabinet Label,Cabinet Brand,Cabinet Model,Column Index,Shelf Index,Layer Index,Layer ID,Disabled Slots,Total Slots,Empty Slots,Cabinet Added Date,Cabinet Purchased Date,Unshelved Bottle Count',
+    '34670,Walk-in,TRANSTHERM,ESPACE Walk-in Cellar,3,18,1,662711,"6, 5",702,30,2024-07-05,,0',
+    '34670,Walk-in,TRANSTHERM,ESPACE Walk-in Cellar,3,18,2,662712,0,702,30,2024-07-05,,0',
+    '34670,Walk-in,TRANSTHERM,ESPACE Walk-in Cellar,3,1,1,662713,0,702,30,2024-07-05,,0',
+    '34670,Walk-in,TRANSTHERM,ESPACE Walk-in Cellar,4,13,1,662714,0,702,30,2024-07-05,,0',
+    '35376,Euromaid Fridge,Eurocave,,1,5,1,674241,0,92,23,2024-08-13,,0',
+    '',
+    '',
+    'User Bottles Details',
+    '',
+    'Bottle ID,Cabinet ID,Column ID,Shelf ID,Layer ID,Slot,Bottle Size Liters,Wine Year,Wine Type,Bottle Note,Wine Title,Wine Country,Wine Region,Wine Winery,Purchase Cost,Purchase Currency,Purchase Date,Opened On,Consumed On',
+    '1278283,34670,58810,316374,662711,5,0.75,2018,Red Wine,,The Original Syrah,NZ,Gimblett Gravels,Stonecroft,30.50,NZD,2024-10-30,,',
+    '1281402,35376,59825,321749,674241,1,0.75,2020,Red Wine,,Zinfandel,NZ,Gimblett Gravels,Stonecroft,null,NZD,2024-11-02,,',
+    '1278383,null,null,null,null,null,0.75,2014,Red Wine,,River Run Pinot Noir,NZ,Central Otago,Chard Farm,null,NZD,2024-10-30,,2024-11-26',
+    '1278884,34670,58810,316246,662714,3,0.75,2019,White Wine,Aged on lees,Riesling,NZ,Marlborough,Cloudy Bay,42,NZD,2024-10-30,,'
+  ].join('\n');
+
+  it('detects the two-section boundary at the "Bottle ID" header row', () => {
+    const lines = fixture.split('\n');
+    const idx = detectOenoExportBoundary(lines);
+    expect(lines[idx].startsWith('Bottle ID')).toBe(true);
+  });
+
+  it('returns format=oeno-export with one item per bottle (no quantity expansion)', () => {
+    const result = parseOenoExport(fixture);
+    expect(result.format).toBe('oeno-export');
+    expect(result.items).toHaveLength(4);
+  });
+
+  it('builds per-cabinet/column rack specs with shelf + 6 front + 5 back', () => {
+    const result = parseOenoExport(fixture);
+    expect(result.oenoRackSpecs).toMatchObject({
+      'Walk-in – Module 3': {
+        type: 'shelf',
+        cols: 6,
+        typeConfig: { bottlesPerCell: 1, backCols: 5 }
+      },
+      'Walk-in – Module 4': {
+        type: 'shelf',
+        cols: 6,
+        typeConfig: { bottlesPerCell: 1, backCols: 5 }
+      },
+      // Euromaid has only one column, no module suffix
+      'Euromaid Fridge': {
+        type: 'shelf',
+        cols: 6,
+        typeConfig: { bottlesPerCell: 1, backCols: 5 }
+      }
+    });
+    // Walk-in Module 3 has shelves 1 and 18 used → max 18
+    expect(result.oenoRackSpecs['Walk-in – Module 3'].rows).toBe(18);
+    expect(result.oenoRackSpecs['Walk-in – Module 4'].rows).toBe(13);
+  });
+
+  it('maps shelved bottles to rackName + shelfNumber + layer + slotInLayer', () => {
+    const result = parseOenoExport(fixture);
+    const syrah = result.items.find(i => i.wineName === 'The Original Syrah');
+    expect(syrah).toMatchObject({
+      rackName: 'Walk-in – Module 3',
+      vintage: '2018',
+      type: 'red',
+      country: 'NZ',
+      region: 'Gimblett Gravels',
+      producer: 'Stonecroft',
+      bottleSize: '750ml',
+      price: 30.5,
+      currency: 'NZD',
+      layer: 1,
+      slotInLayer: 5,
+    });
+    expect(syrah.rackPosition).toBe(18); // shelf 18
+  });
+
+  it('imports unshelved bottles without rack placement', () => {
+    const result = parseOenoExport(fixture);
+    const riverRun = result.items.find(i => i.wineName === 'River Run Pinot Noir');
+    expect(riverRun).toBeDefined();
+    expect(riverRun.rackName).toBeUndefined();
+    expect(riverRun.rackPosition).toBeUndefined();
+  });
+
+  it('routes Consumed-On bottles through the addToHistory path', () => {
+    const result = parseOenoExport(fixture);
+    const riverRun = result.items.find(i => i.wineName === 'River Run Pinot Noir');
+    expect(riverRun.addToHistory).toBe(true);
+    expect(riverRun.consumedReason).toBe('drank');
+    expect(riverRun.consumedAt).toBe('2024-11-26');
+  });
+
+  it('reads per-row currency directly from the CSV', () => {
+    const result = parseOenoExport(fixture);
+    result.items.forEach(item => expect(item.currency).toBe('NZD'));
+  });
+
+  it('parseAndMap routes Oeno-export text through parseOenoExport automatically', () => {
+    const result = parseAndMap(fixture);
+    expect(result.format).toBe('oeno-export');
+    expect(result.items.length).toBe(4);
+    expect(result.oenoRackSpecs).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

The previous "Oeno" import was built around a sample that turned out not to be from Oeno. Keith sent us a **real Oeno export** — it's a two-section CSV: cabinet/layer definitions followed by per-bottle records, separated by a `User Bottles Details` marker.

## What's new

- `parseOenoExport()` reads the two-section structure, joins bottles to their layer by `Layer ID`, and emits items with explicit `rackName` (per cabinet-column), `rackPosition` (shelf), `layer` (1=front / 2=back), and `slotInLayer`.
- Backend `computeRackPosition` extended for shelf racks: when `layer` + `slotInLayer` are present, computes the exact Cellarion slot inside the shelf. Otherwise falls back to first-slot + overflow.
- One Cellarion rack per Oeno (cabinet, column) — Walk-in becomes `Walk-in – Module 1/2/3/4`; single-column cabinets keep their label.
- Per-cabinet rack defaults built from the CSV's actual structure (rows = shelves in that column, cols=6, backCols=5, bpc=1, anchor=bottom-left).
- Consumed bottles (`Consumed On` set) route through `addToHistory` with `consumedReason='drank'`.
- Unshelved bottles (`Cabinet ID=null`) import without placement.
- Per-row currency from the CSV's `Purchase Currency`.

## What's removed

- The fake-Oeno format detection (based on `Rack_Location` / `MasterVarietal` columns) is gone. Keith's old test spreadsheets now import as plain `generic` — Rack_Location parsing still works via the generic mapper's fallback, but no Vintec-specific auto-defaults.
- `mapOenoRow` deleted.

## Test plan

- [x] 512 backend tests pass (3 new layer+slot placement cases)
- [x] 275 frontend tests pass (8 new oeno-export parser cases including Keith-style fixture)
- [x] Vite build clean
- [x] Smoke-tested boundary detection against real Oeno CSV (167-line section 1, 17 bottle records)