### PR TITLE
chore(tests): scrub user-specific labels from import test fixtures

### DIFF
--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -162,7 +162,7 @@ describe('planRackCreations', () => {
   });
 
   test('uses suggestRackDimensions when only rackPosition is known', () => {
-    // Mirrors Keith's M3 (positions 4, 10, 11): max 11 → suggestion is 2×6
+    // Realistic Oeno-style scenario: positions 4, 10, 11 → max 11 → 2×6
     const plan = planRackCreations([
       { rackName: 'M3', rackPosition: 11 },
       { rackName: 'M3', rackPosition: 4 },
@@ -194,18 +194,18 @@ describe('planRackCreations', () => {
   });
 
   test('sizes rack by total bottle count when many bottles share a slot', () => {
-    // Mirrors Keith's data: 3 Riesling + 3 Chenin Blanc + 2 Pinot + 1 Ata Rangi
-    // all claim positions in M3 (total 9 bottles), with max position 11.
+    // Realistic Oeno-style scenario: 9 bottles spread across positions 4-11
+    // of rack M3, with several wines doubling up on the same position.
     // Required capacity = max(11, 9) = 11. Suggestion for 11 is 2×6 = 12 slots. ✓
     const plan = planRackCreations([
-      { rackName: 'M3', rackPosition: 11 }, // Chenin 1
-      { rackName: 'M3', rackPosition: 11 }, // Chenin 2
-      { rackName: 'M3', rackPosition: 11 }, // Chenin 3
-      { rackName: 'M3', rackPosition: 10 }, // Riesling 1
-      { rackName: 'M3', rackPosition: 10 }, // Riesling 2
-      { rackName: 'M3', rackPosition: 10 }, // Riesling 3
-      { rackName: 'M3', rackPosition: 4 },  // Ata Rangi 1
-      { rackName: 'M3', rackPosition: 4 },  // Ata Rangi 2
+      { rackName: 'M3', rackPosition: 11 }, // wine A bottle 1
+      { rackName: 'M3', rackPosition: 11 }, // wine A bottle 2
+      { rackName: 'M3', rackPosition: 11 }, // wine A bottle 3
+      { rackName: 'M3', rackPosition: 10 }, // wine B bottle 1
+      { rackName: 'M3', rackPosition: 10 }, // wine B bottle 2
+      { rackName: 'M3', rackPosition: 10 }, // wine B bottle 3
+      { rackName: 'M3', rackPosition: 4 },  // wine C bottle 1
+      { rackName: 'M3', rackPosition: 4 },  // wine C bottle 2
     ]);
     const m3 = plan.get('M3');
     // 2×6 = 12 slots, ≥ max(11, 8) = 11. ✓
@@ -324,7 +324,7 @@ describe('placeBottlesInRack (orchestration)', () => {
   });
 
   test('end-to-end: Oeno-style M3 with Quantity=3 at slot 11 spreads into 11,12,13', () => {
-    // Recreates Keith's scenario for a single rack
+    // Three bottles of one wine all targeting slot 11 of the same rack
     const rack = buildRack({ rows: 4, cols: 6, maxPosition: 24 });
     const items = [
       { item: { rackPosition: 11 }, bottleId: 'chenin-1', sourceIndex: 0 },
@@ -390,9 +390,9 @@ describe('placeBottlesInRack (orchestration)', () => {
     expect(positions).toEqual([111, 112, 113]);
   });
 
-  test('Oeno shelf rack: bottom-left anchor flips shelf 11 to shelf 8 (Keith real data)', () => {
-    // Keith's cabinet: 18 shelves, bottom-left anchor. Oeno shelf 11 from
-    // bottom = effective shelf 18-11+1 = 8 from top. First slot = (8-1)*11+1 = 78.
+  test('Oeno shelf rack: bottom-left anchor flips shelf 11 to shelf 8', () => {
+    // 18-shelf rack, bottom-left anchor. Oeno shelf 11 from bottom =
+    // effective shelf 18 - 11 + 1 = 8 from top. First slot = (8-1)*11 + 1 = 78.
     const rack = {
       type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 1, backCols: 5 },
       slots: [], maxPosition: 198
@@ -434,8 +434,8 @@ describe('placeBottlesInRack (orchestration)', () => {
   });
 
   test('Oeno-export bottle with explicit layer + slotInLayer (front cell)', () => {
-    // Walk-in Module 3 (18 shelves × 6 front + 5 back). Bottle on shelf 18,
-    // front layer, slot 5. With bottom-left anchor → effective shelf 1.
+    // 18-shelf rack (6 front + 5 back). Bottle on shelf 18, front layer,
+    // slot 5. With bottom-left anchor → effective shelf 1.
     // First slot of shelf 1 = 1; front layer slot 5 = position 5.
     const rack = {
       type: 'shelf', rows: 18, cols: 6, typeConfig: { bottlesPerCell: 1, backCols: 5 },

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -432,8 +432,8 @@ describe('parseAndMap', () => {
       // dedicated "Oeno" format detection is reserved for real Oeno
       // two-section exports, not for spreadsheets with Rack_Location columns.
       const csv = 'Producer,Wine,Vintage,Quantity,Rack_Location,type,Size,Price,Country\n' +
-        'Amisfield,Amisfield Chenin Blanc,2019,3,M3-11,White Wine,750,35,New Zealand\n' +
-        'Alexander,Alexander Dusty Road Pinot Noir,2018,1,M2-11,Red Wine,750,35,New Zealand';
+        'Producer A,Test White Wine,2019,3,M3-11,White Wine,750,35,New Zealand\n' +
+        'Producer B,Test Red Wine,2018,1,M2-11,Red Wine,750,35,New Zealand';
       const result = parseAndMap(csv);
       expect(result.format).toBe('generic');
       // Quantity 3 + 1 = 4 bottles
@@ -469,25 +469,25 @@ describe('parseAndMap', () => {
 // Oeno-by-Vintec real two-section export
 // ---------------------------------------------------------------------------
 describe('parseOenoExport', () => {
-  // Minimal fixture mirroring the real export shape: one walk-in cabinet
-  // with two columns, the second cabinet with one column, plus four bottles
-  // covering placed/unshelved and active/consumed paths.
+  // Minimal fixture mirroring the real Oeno-by-Vintec export shape: one
+  // multi-column cabinet, one single-column cabinet, plus four bottles
+  // covering placed / unshelved and active / consumed paths.
   const fixture = [
     'Cabinet ID,Cabinet Label,Cabinet Brand,Cabinet Model,Column Index,Shelf Index,Layer Index,Layer ID,Disabled Slots,Total Slots,Empty Slots,Cabinet Added Date,Cabinet Purchased Date,Unshelved Bottle Count',
-    '34670,Walk-in,TRANSTHERM,ESPACE Walk-in Cellar,3,18,1,662711,"6, 5",702,30,2024-07-05,,0',
-    '34670,Walk-in,TRANSTHERM,ESPACE Walk-in Cellar,3,18,2,662712,0,702,30,2024-07-05,,0',
-    '34670,Walk-in,TRANSTHERM,ESPACE Walk-in Cellar,3,1,1,662713,0,702,30,2024-07-05,,0',
-    '34670,Walk-in,TRANSTHERM,ESPACE Walk-in Cellar,4,13,1,662714,0,702,30,2024-07-05,,0',
-    '35376,Euromaid Fridge,Eurocave,,1,5,1,674241,0,92,23,2024-08-13,,0',
+    '10001,Main Cellar,TRANSTHERM,Espace Cellar,3,18,1,1001,"6, 5",702,30,2024-07-05,,0',
+    '10001,Main Cellar,TRANSTHERM,Espace Cellar,3,18,2,1002,0,702,30,2024-07-05,,0',
+    '10001,Main Cellar,TRANSTHERM,Espace Cellar,3,1,1,1003,0,702,30,2024-07-05,,0',
+    '10001,Main Cellar,TRANSTHERM,Espace Cellar,4,13,1,1004,0,702,30,2024-07-05,,0',
+    '10002,Wine Fridge,Eurocave,,1,5,1,2001,0,92,23,2024-08-13,,0',
     '',
     '',
     'User Bottles Details',
     '',
     'Bottle ID,Cabinet ID,Column ID,Shelf ID,Layer ID,Slot,Bottle Size Liters,Wine Year,Wine Type,Bottle Note,Wine Title,Wine Country,Wine Region,Wine Winery,Purchase Cost,Purchase Currency,Purchase Date,Opened On,Consumed On',
-    '1278283,34670,58810,316374,662711,5,0.75,2018,Red Wine,,The Original Syrah,NZ,Gimblett Gravels,Stonecroft,30.50,NZD,2024-10-30,,',
-    '1281402,35376,59825,321749,674241,1,0.75,2020,Red Wine,,Zinfandel,NZ,Gimblett Gravels,Stonecroft,null,NZD,2024-11-02,,',
-    '1278383,null,null,null,null,null,0.75,2014,Red Wine,,River Run Pinot Noir,NZ,Central Otago,Chard Farm,null,NZD,2024-10-30,,2024-11-26',
-    '1278884,34670,58810,316246,662714,3,0.75,2019,White Wine,Aged on lees,Riesling,NZ,Marlborough,Cloudy Bay,42,NZD,2024-10-30,,'
+    '5001,10001,500,5500,1001,5,0.75,2018,Red Wine,,Test Wine A,NZ,Test Region,Producer A,30.50,NZD,2024-10-30,,',
+    '5002,10002,501,5501,2001,1,0.75,2020,Red Wine,,Test Wine B,NZ,Test Region,Producer B,null,NZD,2024-11-02,,',
+    '5003,null,null,null,null,null,0.75,2014,Red Wine,,Test Wine C,NZ,Test Region,Producer C,null,NZD,2024-10-30,,2024-11-26',
+    '5004,10001,500,5502,1004,3,0.75,2019,White Wine,Aged on lees,Test Wine D,NZ,Test Region,Producer D,42,NZD,2024-10-30,,'
   ].join('\n');
 
   it('detects the two-section boundary at the "Bottle ID" header row', () => {
@@ -505,61 +505,61 @@ describe('parseOenoExport', () => {
   it('builds per-cabinet/column rack specs with shelf + 6 front + 5 back', () => {
     const result = parseOenoExport(fixture);
     expect(result.oenoRackSpecs).toMatchObject({
-      'Walk-in – Module 3': {
+      'Main Cellar – Module 3': {
         type: 'shelf',
         cols: 6,
         typeConfig: { bottlesPerCell: 1, backCols: 5 }
       },
-      'Walk-in – Module 4': {
+      'Main Cellar – Module 4': {
         type: 'shelf',
         cols: 6,
         typeConfig: { bottlesPerCell: 1, backCols: 5 }
       },
-      // Euromaid has only one column, no module suffix
-      'Euromaid Fridge': {
+      // Single-column cabinet keeps just the label (no module suffix)
+      'Wine Fridge': {
         type: 'shelf',
         cols: 6,
         typeConfig: { bottlesPerCell: 1, backCols: 5 }
       }
     });
-    // Walk-in Module 3 has shelves 1 and 18 used → max 18
-    expect(result.oenoRackSpecs['Walk-in – Module 3'].rows).toBe(18);
-    expect(result.oenoRackSpecs['Walk-in – Module 4'].rows).toBe(13);
+    // Module 3 has shelves 1 and 18 referenced → rows = max observed (18)
+    expect(result.oenoRackSpecs['Main Cellar – Module 3'].rows).toBe(18);
+    expect(result.oenoRackSpecs['Main Cellar – Module 4'].rows).toBe(13);
   });
 
   it('maps shelved bottles to rackName + shelfNumber + layer + slotInLayer', () => {
     const result = parseOenoExport(fixture);
-    const syrah = result.items.find(i => i.wineName === 'The Original Syrah');
-    expect(syrah).toMatchObject({
-      rackName: 'Walk-in – Module 3',
+    const wineA = result.items.find(i => i.wineName === 'Test Wine A');
+    expect(wineA).toMatchObject({
+      rackName: 'Main Cellar – Module 3',
       vintage: '2018',
       type: 'red',
       country: 'NZ',
-      region: 'Gimblett Gravels',
-      producer: 'Stonecroft',
+      region: 'Test Region',
+      producer: 'Producer A',
       bottleSize: '750ml',
       price: 30.5,
       currency: 'NZD',
       layer: 1,
       slotInLayer: 5,
     });
-    expect(syrah.rackPosition).toBe(18); // shelf 18
+    expect(wineA.rackPosition).toBe(18); // shelf 18
   });
 
   it('imports unshelved bottles without rack placement', () => {
     const result = parseOenoExport(fixture);
-    const riverRun = result.items.find(i => i.wineName === 'River Run Pinot Noir');
-    expect(riverRun).toBeDefined();
-    expect(riverRun.rackName).toBeUndefined();
-    expect(riverRun.rackPosition).toBeUndefined();
+    const unshelved = result.items.find(i => i.wineName === 'Test Wine C');
+    expect(unshelved).toBeDefined();
+    expect(unshelved.rackName).toBeUndefined();
+    expect(unshelved.rackPosition).toBeUndefined();
   });
 
   it('routes Consumed-On bottles through the addToHistory path', () => {
     const result = parseOenoExport(fixture);
-    const riverRun = result.items.find(i => i.wineName === 'River Run Pinot Noir');
-    expect(riverRun.addToHistory).toBe(true);
-    expect(riverRun.consumedReason).toBe('drank');
-    expect(riverRun.consumedAt).toBe('2024-11-26');
+    const consumed = result.items.find(i => i.wineName === 'Test Wine C');
+    expect(consumed.addToHistory).toBe(true);
+    expect(consumed.consumedReason).toBe('drank');
+    expect(consumed.consumedAt).toBe('2024-11-26');
   });
 
   it('reads per-row currency directly from the CSV', () => {


### PR DESCRIPTION
Test fixtures and comments referenced a specific user's name, cabinet labels, and wines. Replaced with neutral test data. No behavioural change; 787 tests pass.