### PR TITLE
feat(racks): Oeno-style top-down shelf view for shelf racks

### DIFF
--- a/frontend/src/components/racks/ShelfView.css
+++ b/frontend/src/components/racks/ShelfView.css
@@ -1,0 +1,100 @@
+.shelf-view {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+}
+
+.shelf-view-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.shelf-view-tabs {
+  display: inline-flex;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.2rem;
+}
+
+.shelf-view-tab {
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  transition: background 0.15s, color 0.15s;
+}
+
+.shelf-view-tab:hover {
+  color: var(--color-text);
+}
+
+.shelf-view-tab.active {
+  background: var(--color-primary);
+  color: white;
+}
+
+.shelf-view-hint {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.shelf-view-svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.shelf-view-shelf-label {
+  font-size: 11px;
+  font-weight: 600;
+  fill: var(--color-text-muted);
+}
+
+.shelf-view-vintage {
+  font-size: 9px;
+  font-weight: 600;
+  pointer-events: none;
+}
+
+.shelf-view-empty-num {
+  font-size: 9px;
+  fill: var(--color-text-muted);
+  pointer-events: none;
+}
+
+.shelf-view-bottle {
+  cursor: pointer;
+  outline: none;
+}
+
+.shelf-view-bottle.empty:hover ellipse {
+  stroke: var(--color-primary);
+}
+
+.shelf-view-bottle.filled:hover ellipse:nth-of-type(2) {
+  stroke-width: 2.5;
+}
+
+.shelf-view-bottle.active ellipse:nth-of-type(2),
+.shelf-view-bottle.highlight ellipse:nth-of-type(2) {
+  stroke: var(--color-primary);
+  stroke-width: 3;
+}
+
+.shelf-view-empty {
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-style: italic;
+}

--- a/frontend/src/components/racks/ShelfView.js
+++ b/frontend/src/components/racks/ShelfView.js
@@ -1,0 +1,224 @@
+import { useState, useMemo } from 'react';
+import './ShelfView.css';
+
+const WINE_COLORS = {
+  red:       { fill: '#8A1028', stroke: '#6A0820', text: '#fff' },
+  white:     { fill: '#E8D87A', stroke: '#A09838', text: '#3a3000' },
+  'rosé':    { fill: '#D06888', stroke: '#A04868', text: '#fff' },
+  sparkling: { fill: '#B8C868', stroke: '#688830', text: '#2a3300' },
+  dessert:   { fill: '#A06020', stroke: '#805018', text: '#fff' },
+  fortified: { fill: '#7A3010', stroke: '#5A2008', text: '#fff' },
+};
+
+const BOTTLE_RX = 16; // horizontal radius (oval — top-down silhouette)
+const BOTTLE_RY = 22; // vertical radius (longer axis = bottle length)
+const BOTTLE_GAP = 8;  // gap between bottles in a row
+const SHELF_PAD_Y = 12;
+const SHELF_LABEL_W = 64;
+
+/**
+ * Top-down "shelf view" of a shelf rack. Renders bottles as ovals from above,
+ * one row per shelf, with a Front/Back toggle for racks that have a back row.
+ *
+ * Designed for Oeno-style cabinets but works for any rack with type === 'shelf'.
+ * Falls back to a friendly message for other rack types.
+ */
+export default function ShelfView({ rack, activePosition, highlightPos, onSlotClick }) {
+  const [layerMode, setLayerMode] = useState('front');
+
+  if (rack?.type !== 'shelf') {
+    return (
+      <div className="shelf-view-empty">
+        Shelf view is only available for Open Shelf racks. Switch back to the compact view to see this rack.
+      </div>
+    );
+  }
+
+  const cols = rack.cols || 0;
+  const backCols = rack.typeConfig?.backCols || 0;
+  const bpc = rack.typeConfig?.bottlesPerCell || 1;
+  const rows = rack.rows || 0;
+  const slotsPerShelf = (cols + backCols) * bpc;
+  const hasBack = backCols > 0;
+  const slotMap = useMemo(() => {
+    const m = {};
+    for (const s of (rack.slots || [])) m[s.position] = s;
+    return m;
+  }, [rack.slots]);
+
+  // Per-shelf positions for the active layer.
+  // Shelves are displayed bottom-to-top to match how users physically face a
+  // cabinet (shelf 1 on top of the SVG is the highest shelf number).
+  const layerCols = layerMode === 'front' ? cols : backCols;
+  const layerBpc = bpc;
+  const shelfRowWidth = SHELF_LABEL_W + layerCols * layerBpc * (BOTTLE_RX * 2 + BOTTLE_GAP) + BOTTLE_GAP;
+  const shelfRowHeight = BOTTLE_RY * 2 + SHELF_PAD_Y * 2;
+  const totalHeight = rows * shelfRowHeight;
+
+  // Build the shelves array. Index 0 = highest shelf number (rendered at top).
+  const shelves = [];
+  for (let displayIdx = 0; displayIdx < rows; displayIdx++) {
+    const shelfNumber = rows - displayIdx;
+    const shelfBase = (shelfNumber - 1) * slotsPerShelf;
+    const slotsForLayer = [];
+    const slotCount = layerMode === 'front' ? cols * bpc : backCols * bpc;
+    const offset = layerMode === 'front' ? 0 : cols * bpc;
+    for (let c = 1; c <= slotCount; c++) {
+      const position = shelfBase + offset + c;
+      slotsForLayer.push({ position, slot: slotMap[position] || null });
+    }
+    shelves.push({ number: shelfNumber, slots: slotsForLayer, y: displayIdx * shelfRowHeight });
+  }
+
+  return (
+    <div className="shelf-view">
+      {hasBack && (
+        <div className="shelf-view-toolbar">
+          <div className="shelf-view-tabs" role="tablist">
+            <button
+              role="tab"
+              aria-selected={layerMode === 'front'}
+              className={`shelf-view-tab ${layerMode === 'front' ? 'active' : ''}`}
+              onClick={() => setLayerMode('front')}
+            >
+              Front view
+            </button>
+            <button
+              role="tab"
+              aria-selected={layerMode === 'back'}
+              className={`shelf-view-tab ${layerMode === 'back' ? 'active' : ''}`}
+              onClick={() => setLayerMode('back')}
+            >
+              Back view
+            </button>
+          </div>
+          <div className="shelf-view-hint">
+            Top-down view — bottle necks toward {layerMode === 'front' ? 'you' : 'the back of the rack'}
+          </div>
+        </div>
+      )}
+
+      {layerCols === 0 ? (
+        <div className="shelf-view-empty">This shelf has no {layerMode} cells.</div>
+      ) : (
+        <svg
+          className="shelf-view-svg"
+          viewBox={`0 0 ${shelfRowWidth} ${totalHeight}`}
+          width="100%"
+        >
+          {shelves.map(shelf => (
+            <g key={shelf.number} transform={`translate(0, ${shelf.y})`}>
+              <rect
+                x={SHELF_LABEL_W - 4}
+                y={SHELF_PAD_Y / 2}
+                width={shelfRowWidth - SHELF_LABEL_W}
+                height={shelfRowHeight - SHELF_PAD_Y}
+                rx={6}
+                fill="#D4BA94"
+                stroke="#B89A6E"
+                strokeWidth={1}
+                opacity={0.55}
+              />
+              <text
+                x={SHELF_LABEL_W - 12}
+                y={shelfRowHeight / 2}
+                textAnchor="end"
+                dominantBaseline="central"
+                className="shelf-view-shelf-label"
+              >
+                Shelf {shelf.number}
+              </text>
+              {shelf.slots.map((s, i) => {
+                const cx = SHELF_LABEL_W + BOTTLE_GAP + BOTTLE_RX + i * (BOTTLE_RX * 2 + BOTTLE_GAP);
+                const cy = shelfRowHeight / 2;
+                return (
+                  <BottleOval
+                    key={s.position}
+                    cx={cx}
+                    cy={cy}
+                    slot={s.slot}
+                    position={s.position}
+                    isActive={activePosition === s.position}
+                    isHighlight={highlightPos === s.position}
+                    onClick={() => onSlotClick && onSlotClick(s.position, s.slot || null)}
+                  />
+                );
+              })}
+            </g>
+          ))}
+        </svg>
+      )}
+    </div>
+  );
+}
+
+function BottleOval({ cx, cy, slot, position, isActive, isHighlight, onClick }) {
+  const bottle = slot?.bottle;
+  const wine = bottle?.wineDefinition;
+  const wineType = wine?.type || 'red';
+  const colors = bottle ? (WINE_COLORS[wineType] || WINE_COLORS.red) : null;
+  const filled = !!bottle;
+
+  return (
+    <g
+      onClick={onClick}
+      onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onClick?.()}
+      role="button"
+      tabIndex={0}
+      className={`shelf-view-bottle ${filled ? 'filled' : 'empty'} ${isActive ? 'active' : ''} ${isHighlight ? 'highlight' : ''}`}
+      aria-label={filled ? `${wine?.name || 'Wine'} ${bottle?.vintage || ''}` : `Empty slot ${position}`}
+    >
+      <ellipse
+        cx={cx + 0.5}
+        cy={cy + 1}
+        rx={BOTTLE_RX}
+        ry={BOTTLE_RY}
+        fill="rgba(0,0,0,0.10)"
+        pointerEvents="none"
+      />
+      <ellipse
+        cx={cx}
+        cy={cy}
+        rx={BOTTLE_RX}
+        ry={BOTTLE_RY}
+        fill={filled ? colors.fill : 'transparent'}
+        stroke={filled ? colors.stroke : '#B09060'}
+        strokeWidth={isActive || isHighlight ? 2.5 : 1.5}
+        strokeDasharray={filled ? null : '3 2'}
+      />
+      {filled && (
+        <ellipse
+          cx={cx}
+          cy={cy - BOTTLE_RY * 0.45}
+          rx={BOTTLE_RX * 0.42}
+          ry={BOTTLE_RX * 0.35}
+          fill="rgba(0,0,0,0.35)"
+          pointerEvents="none"
+        />
+      )}
+      {filled && bottle?.vintage && bottle.vintage !== 'NV' && (
+        <text
+          x={cx}
+          y={cy + BOTTLE_RY * 0.15}
+          textAnchor="middle"
+          dominantBaseline="central"
+          className="shelf-view-vintage"
+          fill={colors.text}
+        >
+          {bottle.vintage}
+        </text>
+      )}
+      {!filled && (
+        <text
+          x={cx}
+          y={cy}
+          textAnchor="middle"
+          dominantBaseline="central"
+          className="shelf-view-empty-num"
+        >
+          {position}
+        </text>
+      )}
+    </g>
+  );
+}

--- a/frontend/src/pages/CellarRacks.css
+++ b/frontend/src/pages/CellarRacks.css
@@ -451,3 +451,31 @@
   }
 }
 
+
+/* View-mode toggle (Compact / Shelf view) for shelf racks */
+.rack-view-mode-toggle {
+  display: inline-flex;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.2rem;
+  margin-bottom: 0.75rem;
+}
+
+.view-mode-btn {
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  transition: background 0.15s, color 0.15s;
+}
+
+.view-mode-btn:hover { color: var(--color-text); }
+
+.view-mode-btn.active {
+  background: var(--color-primary);
+  color: white;
+}

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -8,6 +8,7 @@ import { consumeBottle } from '../api/bottles';
 import { getPlacedBottleIds } from '../utils/rackUtils';
 import { getTotalSlots, getModularTotalSlots } from '../utils/rackLayouts';
 import RackRenderer from '../components/racks/RackRenderer';
+import ShelfView from '../components/racks/ShelfView';
 import RackTypeSelector, { TYPE_DIMENSIONS } from '../components/racks/RackTypeSelector';
 import RatingInput from '../components/RatingInput';
 import WineImage from '../components/WineImage';
@@ -33,6 +34,10 @@ function CellarRacks() {
   const [saving, setSaving]           = useState(false);
   // which rack tab is selected
   const [selectedRackId, setSelectedRackId] = useState(null);
+
+  // View mode for the active rack: 'compact' (default, existing renderer) or
+  // 'shelf' (top-down per-shelf view). Only meaningful for shelf racks.
+  const [viewMode, setViewMode] = useState('compact');
 
   // active popup: { rackId, position, slot: slotData|null } — rendered as fixed modal
   const [activePopup, setActivePopup] = useState(null);
@@ -300,25 +305,61 @@ function CellarRacks() {
               </button>
             ))}
           </div>
+          {rack.type === 'shelf' && !rack.isModular && (
+            <div className="rack-view-mode-toggle" role="tablist">
+              <button
+                role="tab"
+                aria-selected={viewMode === 'compact'}
+                className={`view-mode-btn ${viewMode === 'compact' ? 'active' : ''}`}
+                onClick={() => setViewMode('compact')}
+              >
+                Compact
+              </button>
+              <button
+                role="tab"
+                aria-selected={viewMode === 'shelf'}
+                className={`view-mode-btn ${viewMode === 'shelf' ? 'active' : ''}`}
+                onClick={() => setViewMode('shelf')}
+              >
+                Shelf view
+              </button>
+            </div>
+          )}
           <div id={`rack-${rack._id}`}>
-          <RackRenderer
-            rack={rack}
-            canEdit={canEdit}
-            activeRackId={activePopup?.rackId}
-            activePosition={activePopup?.position}
-            highlightPos={highlightPos?.rackId === rack._id ? highlightPos.position : null}
-            onSlotClick={(pos, slotData) => {
-              // Viewers can only inspect filled slots, not interact with empty ones
-              if (!canEdit && !slotData) return;
-              if (activePopup?.rackId === rack._id && activePopup?.position === pos) {
-                setActivePopup(null);
-              } else {
-                setActivePopup({ rackId: rack._id, position: pos, slot: slotData || null });
-              }
-            }}
-            onDelete={() => setDeleteConfirm(rack._id)}
-            onNfcLink={() => setNfcModal({ rackId: rack._id })}
-          />
+          {rack.type === 'shelf' && !rack.isModular && viewMode === 'shelf' ? (
+            <ShelfView
+              rack={rack}
+              activePosition={activePopup?.rackId === rack._id ? activePopup.position : null}
+              highlightPos={highlightPos?.rackId === rack._id ? highlightPos.position : null}
+              onSlotClick={(pos, slotData) => {
+                if (!canEdit && !slotData) return;
+                if (activePopup?.rackId === rack._id && activePopup?.position === pos) {
+                  setActivePopup(null);
+                } else {
+                  setActivePopup({ rackId: rack._id, position: pos, slot: slotData || null });
+                }
+              }}
+            />
+          ) : (
+            <RackRenderer
+              rack={rack}
+              canEdit={canEdit}
+              activeRackId={activePopup?.rackId}
+              activePosition={activePopup?.position}
+              highlightPos={highlightPos?.rackId === rack._id ? highlightPos.position : null}
+              onSlotClick={(pos, slotData) => {
+                // Viewers can only inspect filled slots, not interact with empty ones
+                if (!canEdit && !slotData) return;
+                if (activePopup?.rackId === rack._id && activePopup?.position === pos) {
+                  setActivePopup(null);
+                } else {
+                  setActivePopup({ rackId: rack._id, position: pos, slot: slotData || null });
+                }
+              }}
+              onDelete={() => setDeleteConfirm(rack._id)}
+              onNfcLink={() => setNfcModal({ rackId: rack._id })}
+            />
+          )}
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary

Adds a second view mode for shelf racks: a top-down per-shelf rendering modelled on Oeno's app.

- Bottles drawn as ovals (top-down silhouettes), one row per shelf, stacked vertically with the highest shelf number on top
- Empty slots show the position number; filled slots show the vintage year in the wine's colour
- Front view / Back view toggle for racks with backCols > 0
- View-mode toggle ([Compact] [Shelf view]) above the canvas — only renders for non-modular shelf racks
- Same data + click + highlight behaviour as the existing renderer; pure render swap

First step of the visual roadmap. Isometric depth and full 3D cabinets stay on the followup list — both can plug in beside this without touching the data layer.

## Test plan

- [x] 275 frontend tests pass
- [x] Vite build clean