### PR TITLE
feat(racks): Preview toggle on the new-rack form

### DIFF
--- a/frontend/src/pages/CellarRacks.css
+++ b/frontend/src/pages/CellarRacks.css
@@ -479,3 +479,39 @@
   background: var(--color-primary);
   color: white;
 }
+
+/* New-rack-form preview */
+.new-rack-preview-toggle {
+  margin-right: 0.5rem;
+}
+
+.new-rack-preview-toggle.active {
+  background: var(--color-info-bg, rgba(0, 100, 200, 0.1));
+}
+
+.new-rack-preview-panel {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: var(--color-bg);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.new-rack-preview-label {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-bottom: 0.6rem;
+  font-style: italic;
+}
+
+.new-rack-preview-canvas {
+  max-width: 100%;
+  overflow-x: auto;
+  display: flex;
+  justify-content: center;
+}
+
+.new-rack-preview-canvas .rack-actions,
+.new-rack-preview-canvas .rack-meta {
+  display: none;
+}

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -455,6 +455,19 @@ function CellarRacks() {
 function NewRackForm({ newRack, setNewRack, onTypeChange, onSubmit, saving }) {
   const { t } = useTranslation();
   const dims = TYPE_DIMENSIONS[newRack.type] || TYPE_DIMENSIONS.grid;
+  const [showPreview, setShowPreview] = useState(false);
+
+  // Synthetic rack for the preview renderer — empty slots, just the geometry.
+  const previewRack = {
+    _id: 'preview',
+    name: newRack.name || t('racks.namePlaceholder', 'Preview'),
+    type: newRack.type,
+    rows: newRack.rows,
+    cols: newRack.cols,
+    typeConfig: newRack.typeConfig,
+    slots: [],
+    isModular: false,
+  };
 
   return (
     <form className="card new-rack-form" onSubmit={onSubmit}>
@@ -572,6 +585,13 @@ function NewRackForm({ newRack, setNewRack, onTypeChange, onSubmit, saving }) {
           </div>
         )}
 
+        <button
+          type="button"
+          className={`btn btn-secondary new-rack-preview-toggle ${showPreview ? 'active' : ''}`}
+          onClick={() => setShowPreview(p => !p)}
+        >
+          {showPreview ? t('racks.hidePreview', 'Hide preview') : t('racks.preview', 'Preview')}
+        </button>
         <button type="submit" className="btn btn-primary" disabled={saving}>
           {saving ? t('racks.creating') : t('racks.createRack')}
         </button>
@@ -580,6 +600,21 @@ function NewRackForm({ newRack, setNewRack, onTypeChange, onSubmit, saving }) {
       <div className="new-rack-preview-hint">
         {t('racks.totalSlots')}: {getTotalSlots(newRack.type, newRack.rows, newRack.cols, newRack.typeConfig)}
       </div>
+
+      {showPreview && (
+        <div className="new-rack-preview-panel">
+          <div className="new-rack-preview-label">
+            {t('racks.previewLabel', 'Preview — this is how the rack will look once created')}
+          </div>
+          <div className="new-rack-preview-canvas">
+            <RackRenderer
+              rack={previewRack}
+              canEdit={false}
+              onSlotClick={() => {}}
+            />
+          </div>
+        </div>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
Adds a Preview button next to Create rack that renders an empty version of the in-progress rack so users can sanity-check the shape (especially shelves with back rows) before saving.