### PR TITLE
feat(racks): 3D view — single-rack Canvas wrapping the existing RackMesh

### DIFF
--- a/frontend/src/components/racks/ShelfView3D.css
+++ b/frontend/src/components/racks/ShelfView3D.css
@@ -1,0 +1,31 @@
+.shelf-view-3d {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.shelf-view-3d-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.shelf-view-3d-canvas {
+  width: 100%;
+  /* Use viewport-relative height so the 3D scene gets real room to breathe
+     even on smaller racks, but clamp on huge screens. */
+  height: clamp(420px, 60vh, 720px);
+  background: linear-gradient(180deg, #1A1A1F 0%, #0E0E12 100%);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.shelf-view-3d-active-note {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+}

--- a/frontend/src/components/racks/ShelfView3D.js
+++ b/frontend/src/components/racks/ShelfView3D.js
@@ -1,0 +1,123 @@
+import { Suspense, useMemo, useRef } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import RackMesh from '../room/RackMesh';
+import {
+  CELL_W, CELL_H, RACK_DEPTH, PANEL_THICK, getDisplayDims,
+} from '../../utils/roomConstants';
+import './ShelfView3D.css';
+
+/**
+ * True 3D view of a single rack — wraps the existing RackMesh in its own
+ * Canvas with camera controls, lighting, and an auto-framed default view.
+ *
+ * The same RackMesh that the whole-cellar Room scene uses, so any future
+ * improvements to bottle/shelf geometry flow through to both views.
+ * Click parity with the other views: clicking a bottle or empty slot
+ * fires the parent's onSlotClick exactly like Compact / Shelf view do.
+ */
+export default function ShelfView3D({ rack, activePosition, highlightPos, onSlotClick }) {
+  const orbitRef = useRef();
+
+  // Compute reasonable rack dimensions for camera placement (matches the
+  // formulas RackMesh uses internally so the camera frames the rack tightly).
+  const { displayRows, displayCols } = getDisplayDims(rack);
+  const rackType = rack.type || 'grid';
+  const hasShelfBack = rackType === 'shelf' && (rack.typeConfig?.backCols || 0) > 0;
+  const width  = displayCols * CELL_W + PANEL_THICK * 2;
+  const height = displayRows * CELL_H + PANEL_THICK * 2;
+  const depth  = hasShelfBack ? RACK_DEPTH * 1.7 : RACK_DEPTH;
+
+  // Front-quarter perspective by default — high enough to see shelf tops,
+  // close enough to read bottle labels.
+  const maxDim = Math.max(width, height, depth);
+  const camPos = useMemo(() => ([
+    width  * 0.55,
+    height * 0.85,
+    depth  * 1.6 + maxDim * 1.0,
+  ]), [width, height, depth, maxDim]);
+  const camTarget = [0, height * 0.45, 0];
+
+  // The popup-state in CellarRacks is keyed by SLOT POSITION; RackMesh's
+  // highlight prop uses BOTTLE ID. Convert by looking up the bottle that
+  // currently occupies highlightPos.
+  const highlightBottleId = useMemo(() => {
+    if (highlightPos == null) return null;
+    const slot = (rack.slots || []).find(s => s.position === highlightPos);
+    return slot?.bottle?._id || slot?.bottle || null;
+  }, [highlightPos, rack.slots]);
+
+  return (
+    <div className="shelf-view-3d">
+      <div className="shelf-view-3d-toolbar">
+        <div className="shelf-view-hint">
+          Drag to rotate · scroll to zoom · right-drag to pan
+        </div>
+      </div>
+      <div className="shelf-view-3d-canvas">
+        <Canvas
+          shadows
+          camera={{ position: camPos, fov: 45, near: 0.05, far: 30 }}
+          dpr={[1, 2]}
+          style={{ width: '100%', height: '100%' }}
+        >
+          <Suspense fallback={null}>
+            {/* Soft ambient + a slightly warm key light from above-front */}
+            <ambientLight intensity={1.4} color="#FFFFFF" />
+            <hemisphereLight args={['#FFFFFF', '#D8C8B0', 0.5]} />
+            <directionalLight
+              position={[width * 0.6, height * 2.5, depth * 2.5]}
+              intensity={1.4}
+              color="#FFF8F0"
+              castShadow
+              shadow-mapSize={[1024, 1024]}
+            />
+            <pointLight
+              position={[-width * 0.5, height * 1.5, depth * 1.5]}
+              intensity={0.6}
+              color="#FFFFFF"
+              distance={maxDim * 6}
+              decay={1.3}
+            />
+
+            {/* Soft ground plane catches a hint of shadow */}
+            <mesh
+              rotation={[-Math.PI / 2, 0, 0]}
+              position={[0, -0.01, 0]}
+              receiveShadow
+            >
+              <planeGeometry args={[maxDim * 4, maxDim * 4]} />
+              <meshStandardMaterial color="#1A1A1A" roughness={0.95} metalness={0} />
+            </mesh>
+
+            <RackMesh
+              rack={rack}
+              position={[0, 0, 0]}
+              rotation={0}
+              isEditMode={false}
+              isSelected={false}
+              onBottleClick={(slot) => onSlotClick?.(slot.position, slot)}
+              onEmptySlotClick={(slotPos) => onSlotClick?.(slotPos, null)}
+              highlightBottleId={highlightBottleId}
+            />
+
+            <OrbitControls
+              ref={orbitRef}
+              target={camTarget}
+              enableDamping
+              dampingFactor={0.1}
+              minDistance={Math.max(maxDim * 0.4, 0.3)}
+              maxDistance={maxDim * 6}
+              maxPolarAngle={Math.PI / 2 - 0.05}
+            />
+          </Suspense>
+        </Canvas>
+      </div>
+      {activePosition != null && (
+        <div className="shelf-view-3d-active-note">
+          Slot {activePosition} selected — see the panel for details
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -10,6 +10,7 @@ import { getTotalSlots, getModularTotalSlots } from '../utils/rackLayouts';
 import RackRenderer from '../components/racks/RackRenderer';
 import ShelfView from '../components/racks/ShelfView';
 import ShelfViewIso from '../components/racks/ShelfViewIso';
+import ShelfView3D from '../components/racks/ShelfView3D';
 import RackTypeSelector, { TYPE_DIMENSIONS } from '../components/racks/RackTypeSelector';
 import RatingInput from '../components/RatingInput';
 import WineImage from '../components/WineImage';
@@ -349,39 +350,37 @@ function CellarRacks() {
               >
                 Isometric
               </button>
+              <button
+                role="tab"
+                aria-selected={viewMode === '3d'}
+                className={`view-mode-btn ${viewMode === '3d' ? 'active' : ''}`}
+                onClick={() => setViewMode('3d')}
+              >
+                3D
+              </button>
             </div>
           )}
           <div id={`rack-${rack._id}`}>
-          {rack.type === 'shelf' && !rack.isModular && (viewMode === 'shelf' || viewMode === 'iso') ? (
-            viewMode === 'iso' ? (
-              <ShelfViewIso
-                rack={rack}
-                activePosition={activePopup?.rackId === rack._id ? activePopup.position : null}
-                highlightPos={highlightPos?.rackId === rack._id ? highlightPos.position : null}
-                onSlotClick={(pos, slotData) => {
-                  if (!canEdit && !slotData) return;
-                  if (activePopup?.rackId === rack._id && activePopup?.position === pos) {
-                    setActivePopup(null);
-                  } else {
-                    setActivePopup({ rackId: rack._id, position: pos, slot: slotData || null });
-                  }
-                }}
-              />
-            ) : (
-              <ShelfView
-                rack={rack}
-                activePosition={activePopup?.rackId === rack._id ? activePopup.position : null}
-                highlightPos={highlightPos?.rackId === rack._id ? highlightPos.position : null}
-                onSlotClick={(pos, slotData) => {
-                  if (!canEdit && !slotData) return;
-                  if (activePopup?.rackId === rack._id && activePopup?.position === pos) {
-                    setActivePopup(null);
-                  } else {
-                    setActivePopup({ rackId: rack._id, position: pos, slot: slotData || null });
-                  }
-                }}
-              />
-            )
+          {rack.type === 'shelf' && !rack.isModular && (viewMode === 'shelf' || viewMode === 'iso' || viewMode === '3d') ? (
+            (() => {
+              const handleClick = (pos, slotData) => {
+                if (!canEdit && !slotData) return;
+                if (activePopup?.rackId === rack._id && activePopup?.position === pos) {
+                  setActivePopup(null);
+                } else {
+                  setActivePopup({ rackId: rack._id, position: pos, slot: slotData || null });
+                }
+              };
+              const commonProps = {
+                rack,
+                activePosition: activePopup?.rackId === rack._id ? activePopup.position : null,
+                highlightPos: highlightPos?.rackId === rack._id ? highlightPos.position : null,
+                onSlotClick: handleClick,
+              };
+              if (viewMode === '3d') return <ShelfView3D {...commonProps} />;
+              if (viewMode === 'iso') return <ShelfViewIso {...commonProps} />;
+              return <ShelfView {...commonProps} />;
+            })()
           ) : (
             <RackRenderer
               rack={rack}


### PR DESCRIPTION
Fourth view mode in the rack page: a true 3D rendering of the active rack. Reuses the existing RackMesh used by the whole-cellar Room scene, wrapped in a fresh Canvas with auto-framed camera, lighting, and OrbitControls. Click + highlight + popup parity with the 2D views.