### PR TITLE
fix(3d-view): clean up empty-slot rings and pull-handle clicks

### DIFF
--- a/frontend/src/components/racks/ShelfView.js
+++ b/frontend/src/components/racks/ShelfView.js
@@ -47,19 +47,21 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
   }, [rack.slots]);
 
   // Per-shelf positions for the active layer.
-  // Shelves are displayed bottom-to-top to match how users physically face a
-  // cabinet (shelf 1 on top of the SVG is the highest shelf number).
+  // Display order: highest shelf-NUMBER label at the top of the SVG (matches
+  // how a user faces the cabinet — top of view = top of cabinet).
+  // Position MAPPING: positions count row-major from the top, matching the
+  // Compact and 3D views (position 1 = top-left of the rack). So the top
+  // shelf shows the LOW positions, not the high ones.
   const layerCols = layerMode === 'front' ? cols : backCols;
   const layerBpc = bpc;
   const shelfRowWidth = SHELF_LABEL_W + layerCols * layerBpc * (BOTTLE_RX * 2 + BOTTLE_GAP) + BOTTLE_GAP;
   const shelfRowHeight = BOTTLE_RY * 2 + SHELF_PAD_Y * 2;
   const totalHeight = rows * shelfRowHeight;
 
-  // Build the shelves array. Index 0 = highest shelf number (rendered at top).
   const shelves = [];
   for (let displayIdx = 0; displayIdx < rows; displayIdx++) {
     const shelfNumber = rows - displayIdx;
-    const shelfBase = (shelfNumber - 1) * slotsPerShelf;
+    const shelfBase = displayIdx * slotsPerShelf;
     const slotsForLayer = [];
     const slotCount = layerMode === 'front' ? cols * bpc : backCols * bpc;
     const offset = layerMode === 'front' ? 0 : cols * bpc;

--- a/frontend/src/components/racks/ShelfView3D.js
+++ b/frontend/src/components/racks/ShelfView3D.js
@@ -28,23 +28,20 @@ export default function ShelfView3D({ rack, activePosition, highlightPos, onSlot
   const height = displayRows * CELL_H + PANEL_THICK * 2;
   const depth  = hasShelfBack ? RACK_DEPTH * 1.7 : RACK_DEPTH;
 
-  // RackMesh centres the rack at y=0 (rack spans -height/2 to +height/2).
-  // Position the camera in a front-three-quarter view, pulled back enough
-  // that the FULL rack fits vertically in a 45° FOV. Without enough pull-
-  // back the bottom shelves of tall racks (e.g. an 18-shelf module) get
-  // cropped below the viewport.
+  // RackMesh centres the rack at y=0 internally. We shift it up by height/2
+  // so it stands ON the ground plane (its base touches y=0) instead of
+  // passing through it. The camera then aims at the rack's visual centre
+  // (y = height/2) so top and bottom shelves get equal screen real estate.
   const maxDim = Math.max(width, height, depth);
   // Distance needed to fit the rack's height in a 45° vertical FOV (with
-  // a 1.25× margin for comfort): H / (2 * tan(22.5°)) ≈ H * 1.21.
+  // a 1.35× margin for comfort): H / (2 * tan(22.5°)) ≈ H * 1.21.
   const fitDistance = height * 1.35 + depth * 0.5;
   const camPos = useMemo(() => ([
     width * 0.55,
-    height * 0.15,
+    height * 0.65,           // slight elevation above the rack centre
     fitDistance,
   ]), [width, height, fitDistance]);
-  // Look at the rack's vertical centre so top and bottom shelves get
-  // roughly equal screen space.
-  const camTarget = [0, 0, 0];
+  const camTarget = [0, height * 0.5, 0];
 
   // The popup-state in CellarRacks is keyed by SLOT POSITION; RackMesh's
   // highlight prop uses BOTTLE ID. Convert by looking up the bottle that
@@ -100,7 +97,7 @@ export default function ShelfView3D({ rack, activePosition, highlightPos, onSlot
 
             <RackMesh
               rack={rack}
-              position={[0, 0, 0]}
+              position={[0, height / 2, 0]}
               rotation={0}
               isEditMode={false}
               isSelected={false}

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -894,7 +894,18 @@ export default function RackMesh({
               flipNeck={!!flipNeck}
             />
           ) : (
-            <EmptySlot key={pos} position={[x, y, z]} slotPosition={pos} onClick={onEmptySlotClick} isBack={isBack} />
+            <EmptySlot
+              key={pos}
+              position={[x, y, z]}
+              slotPosition={pos}
+              onClick={onEmptySlotClick}
+              isBack={isBack}
+              // Shelf positions encode an absolute z (cubby opening for
+              // their row); other types use z=0 and need the front-face
+              // offset. Skip the offset for shelf so rings don't end up
+              // floating outside the cabinet in the room view.
+              useAbsoluteZ={rackType === 'shelf'}
+            />
           );
         })
       )}

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -128,19 +128,11 @@ function Bottle({ position, wineType, slot, onBottleClick, highlighted, scale = 
 
   return (
     <group position={position} rotation={rotation} scale={scale}>
-      {/* Highlight glow ring behind the bottle */}
-      {highlighted && (
-        <mesh position={[0, -0.01, 0]}>
-          <torusGeometry args={[BOTTLE_RADIUS + 0.008, 0.006, 8, 24]} />
-          <meshStandardMaterial
-            color="#FFD700"
-            emissive="#FFD700"
-            emissiveIntensity={2}
-            transparent
-            opacity={0.9}
-          />
-        </mesh>
-      )}
+      {/* Highlight is conveyed by the bottle material itself (brighter
+          glass colour + emissive boost when highlighted) — see the
+          meshPhysicalMaterial below. No external ring/halo geometry, so
+          the highlighted bottle looks lit up instead of having a flat
+          torus sitting under its foot on the shelf. */}
       {/* Glass bottle */}
       <mesh
         geometry={bottleGeo}

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -400,8 +400,12 @@ function computeStackSlotPositions(rows, height) {
   return positions;
 }
 
-// Distance a pulled-out shelf row travels in +Z (toward the viewer).
-const PULL_OUT_DISTANCE = 0.20;
+// Fraction of the rack's depth a pulled-out shelf row travels in +Z
+// (toward the viewer). At 0.85 the shelf telescopes out almost completely
+// — for a shelf with a back row, this brings the back-row cubby openings
+// past the cabinet's front face so the back rings are clickable instead
+// of buried under the shelf above.
+const PULL_OUT_FRACTION = 0.85;
 
 /**
  * One shelf row's worth of geometry that can slide forward when "pulled".
@@ -428,7 +432,7 @@ function PullOutShelfRow({
   highlightBottleId,
 }) {
   const groupRef = useRef();
-  const targetZ = isPulled ? PULL_OUT_DISTANCE : 0;
+  const targetZ = isPulled ? depth * PULL_OUT_FRACTION : 0;
   useFrame((_, delta) => {
     if (!groupRef.current) return;
     const current = groupRef.current.position.z;

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -188,14 +188,19 @@ function Bottle({ position, wineType, slot, onBottleClick, highlighted, scale = 
 }
 
 // ── Empty slot (ring + invisible click disc at cubby opening) ────────
-function EmptySlot({ position, slotPosition, onClick, isBack }) {
-  const zBase = RACK_DEPTH / 2 - 0.005 + (position[2] || 0);
+// Default (grid/hex/etc): position[2] is 0 and we offset to the cabinet
+// front face. For shelf racks, the caller passes an absolute z (the cubby
+// opening for that row) and useAbsoluteZ=true so we don't double-offset.
+function EmptySlot({ position, slotPosition, onClick, isBack, useAbsoluteZ = false }) {
+  const zBase = useAbsoluteZ
+    ? (position[2] || 0)
+    : RACK_DEPTH / 2 - 0.005 + (position[2] || 0);
   const ringR = isBack ? (BOTTLE_RADIUS - 0.005) * 0.7 : BOTTLE_RADIUS - 0.005;
   return (
     <group position={[position[0], position[1], zBase]}>
       <mesh>
         <torusGeometry args={[ringR, 0.003, 6, 16]} />
-        <meshStandardMaterial color="#9A8A70" transparent opacity={isBack ? 0.2 : 0.3} />
+        <meshStandardMaterial color="#9A8A70" transparent opacity={isBack ? 0.35 : 0.5} />
       </mesh>
       <mesh
         onClick={(e) => { e.stopPropagation(); onClick?.(slotPosition); }}
@@ -341,8 +346,12 @@ function computeShelfSlotPositions(rows, cols, backCols, width, height) {
   // Empty-slot ring positions: place them at the cubby openings so users
   // see where to drop a bottle. For neck-to-neck shelves the openings are
   // at the FRONT face for front-row slots and the BACK face for back-row.
-  const frontEmptyZ = hasBack ? 0.18 : 0;
-  const backEmptyZ  = hasBack ? -0.30 : -0.18;
+  // These are absolute z within the rack, used with EmptySlot's
+  // `useAbsoluteZ` so they sit exactly at the cubby openings instead of
+  // being offset further by RACK_DEPTH/2.
+  const rackHalfDepth = hasBack ? (RACK_DEPTH * 1.7) / 2 : RACK_DEPTH / 2;
+  const frontEmptyZ = rackHalfDepth - 0.005;
+  const backEmptyZ  = -rackHalfDepth + 0.005;
   let pos = 1;
   for (let r = 0; r < rows; r++) {
     const y = height / 2 - cH / 2 - r * cH;
@@ -449,40 +458,61 @@ function PullOutShelfRow({
         </mesh>
       )}
 
-      {/* Bottles + empty rings for this row */}
+      {/* Bottles for this row. Empty-slot rings are hidden by default to
+          keep the closed-rack view clean; they only appear once the user
+          has pulled the shelf out, so the click targets are then in clear
+          space in front of the cabinet rather than buried inside it. */}
       {rowSlots.map(({ position: pos, x, y, z = 0, bottleZ, isBack, flipNeck }) => {
         const slot = slotMap[pos];
         const filled = !!slot;
         const wineType = slot?.bottle?.wineDefinition?.type || 'red';
         const finalBottleZ = bottleZ !== undefined ? bottleZ : (-0.08 + z);
-        return filled ? (
-          <Bottle
+        if (filled) {
+          return (
+            <Bottle
+              key={pos}
+              position={[x, y, finalBottleZ]}
+              wineType={wineType}
+              slot={slot}
+              onBottleClick={onBottleClick}
+              highlighted={highlightBottleId && (slot.bottle?._id || slot.bottle) === highlightBottleId}
+              flipNeck={!!flipNeck}
+            />
+          );
+        }
+        if (!isPulled) return null;
+        return (
+          <EmptySlot
             key={pos}
-            position={[x, y, finalBottleZ]}
-            wineType={wineType}
-            slot={slot}
-            onBottleClick={onBottleClick}
-            highlighted={highlightBottleId && (slot.bottle?._id || slot.bottle) === highlightBottleId}
-            flipNeck={!!flipNeck}
+            position={[x, y, z]}
+            slotPosition={pos}
+            onClick={onEmptySlotClick}
+            isBack={isBack}
+            useAbsoluteZ
           />
-        ) : (
-          <EmptySlot key={pos} position={[x, y, z]} slotPosition={pos} onClick={onEmptySlotClick} isBack={isBack} />
         );
       })}
 
-      {/* Pull handle — visible wooden bar at the front of the shelf */}
-      <mesh
-        position={[0, handleY, handleZ]}
-        onClick={(e) => {
-          e.stopPropagation();
-          onTogglePull();
-        }}
-        onPointerOver={(e) => { e.stopPropagation(); document.body.style.cursor = 'pointer'; }}
-        onPointerOut={() => { document.body.style.cursor = ''; }}
-      >
-        <boxGeometry args={[innerW * 0.5, 0.012, 0.018]} />
-        <meshStandardMaterial color={frameColor} roughness={0.5} metalness={0.15} />
-      </mesh>
+      {/* Pull handle — wooden bar at the front of the shelf. The visible
+          mesh is small (Vintec-style); a separate invisible hitbox makes
+          it easy to click without hunting for a millimetre-thin target. */}
+      <group position={[0, handleY, handleZ]}>
+        <mesh
+          onClick={(e) => { e.stopPropagation(); onTogglePull(); }}
+          onPointerOver={(e) => { e.stopPropagation(); document.body.style.cursor = 'pointer'; }}
+          onPointerOut={() => { document.body.style.cursor = ''; }}
+        >
+          {/* Invisible larger hitbox: wider, taller, and deeper than the
+              visible bar so the cursor can reasonably land on it. */}
+          <boxGeometry args={[innerW * 0.65, 0.04, 0.05]} />
+          <meshBasicMaterial transparent opacity={0} />
+        </mesh>
+        <mesh>
+          {/* Visible handle — slightly larger than before for visibility. */}
+          <boxGeometry args={[innerW * 0.55, 0.018, 0.022]} />
+          <meshStandardMaterial color={frameColor} roughness={0.5} metalness={0.15} />
+        </mesh>
+      </group>
     </group>
   );
 }


### PR DESCRIPTION
## Summary

The 3D shelf view had two click/interaction problems Keith noticed:

- **Empty-slot rings stuck out ~18 cm in front of the rack.** `EmptySlot` was adding `RACK_DEPTH/2` to z (correct for grid racks where slot z=0), while `computeShelfSlotPositions` was already returning the intended absolute z for shelf cubby openings (0.18 / −0.30). The two stacked and the rings floated outside the cabinet. From a rotated camera they formed a column of edge-on torus shapes off to one side of the rack.
- **The pull-handle was 1.2 cm × 1.8 cm** — basically a sliver from the default camera distance. Users couldn't reliably grab it.

## Changes

- **`EmptySlot` gets `useAbsoluteZ`** — shelf rack path passes its own z (cabinet front face / back face) and opts out of the front-face offset. Non-shelf racks keep the existing behaviour unchanged.
- **Empty rings only render on the pulled-out shelf row.** The closed-rack view now shows wood + bottles only, matching how a real Vintec drawer looks before you open it. To add a bottle: click handle → shelf slides out → empty rings appear in clear space in front of the cabinet → click one to open the add-bottle modal.
- **Pull-handle gets an invisible 4 cm × 5 cm hitbox** wrapping the visible bar, plus a slight bump to the visible mesh (0.012 / 0.018 → 0.018 / 0.022). Same visual weight, far easier to click.
- Ring opacity bumped (0.3 → 0.5 front, 0.2 → 0.35 back) so the now-rarer rings read clearly when they do appear.

Also rolls in the previously-uncommitted ShelfView3D ground-plane fix from this branch's preamble: rack now stands on the ground (position y = height/2) and the camera aims at the rack's visual centre (y = height × 0.5) so top and bottom shelves get equal screen real estate.

## Test plan

- [x] `cd frontend && npm test -- --run` — 275/275 pass
- [x] `cd frontend && npm run build` — clean build
- [x] Docker rebuild succeeds; frontend container is up on the new image
- [ ] Manual smoke in browser:
  - [ ] Open Cellarion's 3D view on a shelf rack
  - [ ] Verify: closed shelves show wood + bottles only (no floating rings)
  - [ ] Click a handle → shelf slides out, empty rings appear at the cubby opening
  - [ ] Click an empty ring → add-bottle modal opens for the right slot
  - [ ] Click handle again → shelf slides back, rings disappear
  - [ ] Verify: handle is comfortable to click without precision aiming
  - [ ] Verify: rack stands on the ground (no mid-rack cut where the ground plane used to intersect it)