### PR TITLE
chore(release): v1.54.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary

Patch release rolling up PR #424 (3D-view UX fixes).

Changes since v1.54.0:

- **fix(3d-view):** clean up empty-slot rings and pull-handle clicks (#424)
  - Empty rings sit at the cubby opening instead of floating 18 cm in front of the cabinet
  - Empty rings only show on the shelf row that's currently pulled out (closed view is clean wood + bottles, like a real Vintec)
  - Shelves telescope out 85% of their depth (was a fixed 20 cm), so the back row of two-deep shelves becomes reachable
  - Pull-handle gets a 4 × 5 cm invisible hitbox so it's clickable without aiming
  - Highlighted bottles brighten via their own material instead of being ringed by a stray torus on the shelf
  - Shelf view's position mapping now aligns with 3D and Compact (position 1 lands on the top shelf in all three views)
  - Also fixes the same EmptySlot z-offset regression in the room view (RoomScene's non-pull-out shelf path)

No data or API changes.

## Test plan

- [x] Backend tests: 512/512 pass
- [x] Frontend tests: 275/275 pass
- [x] Docker rebuild succeeds; both containers up on the new image