### PR TITLE
fix(notifications): dedup drink-window alerts by (wine, vintage, status)

### DIFF
--- a/backend/src/services/drinkWindowNotifier.js
+++ b/backend/src/services/drinkWindowNotifier.js
@@ -124,7 +124,14 @@ async function processUser(user, isFirstRun) {
     const wineName = bottle.wineDefinition?.name || 'Unknown wine';
     const vintage  = bottle.vintage;
 
-    alerts.push({ bottleId: bottle._id, cellarId: bottle.cellar, name: wineName, vintage, status: notifType });
+    alerts.push({
+      bottleId: bottle._id,
+      cellarId: bottle.cellar,
+      wdId,
+      name: wineName,
+      vintage,
+      status: notifType,
+    });
 
     await Bottle.updateOne(
       { _id: bottle._id },
@@ -134,8 +141,24 @@ async function processUser(user, isFirstRun) {
 
   if (alerts.length === 0) return 0;
 
-  // Create in-app notifications (also triggers push via the notification service)
+  // Dedup at the (wine, vintage, status) level so a user with N bottles of
+  // the same wine vintage gets ONE notification when they all transition
+  // together, not N copies of the same line. Bottle-level prevStatus is
+  // still updated for every bottle above, so a second transition (e.g.
+  // peak → ending) still fires exactly one new notification when it
+  // happens, rather than re-notifying for the same status.
+  const uniqueAlerts = [];
+  const seenKeys = new Set();
   for (const alert of alerts) {
+    const key = `${alert.wdId}:${alert.vintage}:${alert.status}`;
+    if (!seenKeys.has(key)) {
+      seenKeys.add(key);
+      uniqueAlerts.push(alert);
+    }
+  }
+
+  // Create in-app notifications (also triggers push via the notification service)
+  for (const alert of uniqueAlerts) {
     const { title, message, type } = buildNotification(alert);
     const link = `/cellars/${alert.cellarId}?search=${encodeURIComponent(alert.name)}`;
     await createNotification(user._id, type, title, message, link);
@@ -147,14 +170,14 @@ async function processUser(user, isFirstRun) {
       await sendDrinkWindowDigest(
         user.email,
         user.displayName || user.username,
-        alerts
+        uniqueAlerts
       );
     } catch (err) {
       console.error(`[drinkWindowNotifier] Email failed for ${user._id}:`, err.message);
     }
   }
 
-  return alerts.length;
+  return uniqueAlerts.length;
 }
 
 function buildNotification(alert) {

--- a/backend/src/services/drinkWindowNotifier.js
+++ b/backend/src/services/drinkWindowNotifier.js
@@ -110,13 +110,12 @@ async function processUser(user, isFirstRun) {
     }
 
     if (!notifType) {
-      // No transition — update status if changed but don't notify
-      if (prevStatus !== effectiveStatus) {
-        await Bottle.updateOne(
-          { _id: bottle._id },
-          { $set: { drinkWindowNotifiedStatus: effectiveStatus, drinkWindowNotifiedAt: new Date() } }
-        );
-      }
+      // No notifiable transition — leave prevStatus alone. Silently
+      // rewriting it here used to flip a "sticky" marker like 'ending'
+      // back to 'peak' on no-op cron passes (because effectiveStatus
+      // falls back to maturityStatus when notifType is null), which then
+      // let the ending check re-fire the next day and produced duplicate
+      // notifications for the same bottle every other day.
       continue;
     }
 


### PR DESCRIPTION
## Summary

Two related fixes to drink-window notification spam, both in `drinkWindowNotifier.js`.

### Fix 1 — silent-flip bug (root cause of weekly repeats)

A user reported getting an email about the same bottle every other day. The daily cron's no-notification branch was unconditionally writing the bottle's `drinkWindowNotifiedStatus` to `effectiveStatus`, which falls back to `maturityStatus` when `notifType` is null. So a bottle in peak whose marker was correctly `'ending'` from a prior cron pass got the marker silently rewritten back to `'peak'` on the next no-op pass. The cron after that then treated `'ending'` as a fresh transition and re-fired the notification. **Cycle repeats every two days.**

Fix: leave `drinkWindowNotifiedStatus` alone on no-op cron passes. The marker is only meaningful as a dedup signal for the four notifiable transitions (peak / ending / declining / late).

### Fix 2 — dedup by (wine, vintage, status)

If you have N bottles of the same wine vintage (e.g. a case of 6 × Château X 2018), the cron previously fired **N separate notifications** on the day they all transitioned to peak — and N rows in the email digest. Same again at ending, same again at past peak.

Dedup at the `(wine, vintage, status)` level before fanning out to in-app / push / email. Bottle-level `prevStatus` tracking is unchanged — every bottle's `drinkWindowNotifiedStatus` is still updated per cron pass — so a subsequent real transition still fires exactly one fresh notification per status when it actually happens.

### Combined net effect

For a user with a case of N bottles of the same wine vintage: **at most three notifications across the wine's lifetime** (entering peak, peak ending, past peak), regardless of N and without the every-other-day re-fire loop.

No data migration needed.

## Test plan

- [x] Backend: 512/512 tests pass
- [ ] Manually: tomorrow's 06:00 UTC cron should fire at most one notification per unique (wine, vintage, status) — and the bottle that was re-firing every other day should now stay silent until its actual next transition