### PR TITLE
feat(analytics): clickable charts deep-link to a filtered bottle list

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -69,30 +69,31 @@ router.get('/', async (req, res) => {
       return res.json({ bottles: { count: 0, total: 0, limit, skip, items: [] } });
     }
 
-    const {
-      search,
-      type,
-      country,
-      region,
-      grapes,
-      vintage,
-      producer,
-      bottleSize,
-      minRating,
-      maturity: maturityFilter,
-      sort = '-createdAt',
-      // Lifecycle filters — default is active-only, matching the
-      // Statistics page's `byType` / `byCountry` / etc. aggregates.
-      // Set status to 'drank'|'gifted'|'sold'|'other' to view a
-      // consumed bucket, or 'all' to include everything.
-      status: statusFilter,
-      // Purchase / consumption year filters (numeric year). Apply to
-      // bottle.purchaseDate.getFullYear() and bottle.consumedAt.getFullYear()
-      // respectively — used by the Purchase History and Consumption
-      // History charts on Statistics.
-      purchaseYear,
-      consumedYear,
-    } = req.query;
+    // Defensive scalar coercion: Express's qs query parser turns inputs
+    // like `?bottleSize[$ne]=1` into `{ bottleSize: { $ne: '1' } }`,
+    // which would bypass per-field guards and leak Mongo operators into
+    // the filter we build below. Reject anything that isn't a plain
+    // string so every value below is guaranteed to be primitive.
+    const q = (v) => (typeof v === 'string' ? v : undefined);
+    const search           = q(req.query.search);
+    const type             = q(req.query.type);
+    const country          = q(req.query.country);
+    const region           = q(req.query.region);
+    const grapes           = q(req.query.grapes);
+    const vintage          = q(req.query.vintage);
+    const producer         = q(req.query.producer);
+    const bottleSize       = q(req.query.bottleSize);
+    const minRating        = q(req.query.minRating);
+    const maturityFilter   = q(req.query.maturity);
+    const sort             = q(req.query.sort) || '-createdAt';
+    // Lifecycle filters — default is active-only, matching the
+    // Statistics page's by-type / by-country / etc. aggregates.
+    const statusFilter     = q(req.query.status);
+    // Purchase / consumption year filters apply to bottle.purchaseDate
+    // and bottle.consumedAt respectively — driven by the Statistics
+    // page's Purchase History and Consumption History charts.
+    const purchaseYear     = q(req.query.purchaseYear);
+    const consumedYear     = q(req.query.consumedYear);
 
     const sortField = sort.startsWith('-') ? sort.substring(1) : sort;
     const sortDir = sort.startsWith('-') ? -1 : 1;

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -5,6 +5,9 @@ const Bottle = require('../models/Bottle');
 const Cellar = require('../models/Cellar');
 const Rack = require('../models/Rack');
 const WineDefinition = require('../models/WineDefinition');
+const Country = require('../models/Country');
+const Region = require('../models/Region');
+const Grape = require('../models/Grape');
 const WineVintageProfile = require('../models/WineVintageProfile');
 const PriceTrackingRequest = require('../models/PriceTrackingRequest');
 const BottleImage = require('../models/BottleImage');
@@ -18,6 +21,10 @@ const { CONSUMED_STATUSES, WINE_POPULATE } = require('../config/constants');
 const { checkRestockGap, resolveRestockAlerts } = require('../services/restockChecker');
 const { stripHtml, isSafeUrl } = require('../utils/sanitize');
 const { parseAndValidateVintage } = require('../utils/validation');
+const { toNormalized } = require('../utils/ratingUtils');
+const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
+const { parsePagination } = require('../utils/pagination');
+const mongoose = require('mongoose');
 const searchService = require('../services/search');
 
 const router = express.Router();
@@ -32,6 +39,239 @@ async function removeFromRacks(bottleId) {
 
 // All routes require authentication
 router.use(requireAuth);
+
+// GET /api/bottles — list the authenticated user's active bottles across all
+// cellars they OWN (shared/read-only cellars are excluded, matching the
+// Statistics page's scope so the deep-links from Statistics chart segments
+// land on a bottle set with matching counts).
+//
+// Supported filter query params (all optional, combinable):
+//   search       — free-text match against wine name / producer / notes / location / type / appellation / grape names
+//   type         — wine type enum, comma-separated allowed
+//   country      — country ID, comma-separated allowed
+//   region       — region ID, comma-separated allowed
+//   grapes       — grape ID, comma-separated
+//   vintage      — vintage year string, comma-separated
+//   producer     — exact producer string (case-insensitive)
+//   bottleSize   — exact bottle-size string (e.g. "750ml")
+//   minRating    — minimum normalised rating (0-100)
+//   maturity     — one of 'declining','late','peak','early','not-ready','none'
+//   sort         — 'createdAt'|'vintage'|'price'|'rating'|'name'|'maturity' with optional leading '-' for descending
+//   limit / offset — pagination (defaults: limit 30, max 200)
+router.get('/', async (req, res) => {
+  try {
+    const { isValidObjectId } = mongoose;
+
+    const cellarIds = await Cellar.find({ user: req.user.id, deletedAt: null }).distinct('_id');
+    const { limit, offset: skip } = parsePagination(req.query, { limit: 30, maxLimit: 200 });
+
+    if (cellarIds.length === 0) {
+      return res.json({ bottles: { count: 0, total: 0, limit, skip, items: [] } });
+    }
+
+    const {
+      search,
+      type,
+      country,
+      region,
+      grapes,
+      vintage,
+      producer,
+      bottleSize,
+      minRating,
+      maturity: maturityFilter,
+      sort = '-createdAt',
+    } = req.query;
+
+    const sortField = sort.startsWith('-') ? sort.substring(1) : sort;
+    const sortDir = sort.startsWith('-') ? -1 : 1;
+
+    const filter = {
+      user: req.user.id,
+      cellar: { $in: cellarIds },
+      status: { $nin: CONSUMED_STATUSES },
+    };
+
+    if (vintage) {
+      const vintages = String(vintage).split(',').map(v => v.trim()).filter(Boolean);
+      filter.vintage = vintages.length === 1 ? vintages[0] : { $in: vintages };
+    }
+
+    if (bottleSize) {
+      filter.bottleSize = String(bottleSize);
+    }
+
+    // Pre-query WineDefinition for taxonomy / type / producer filters.
+    // country/region values may be ObjectIds OR display names — the
+    // Statistics charts only know names (the byCountry/byRegion stats
+    // aggregate by name), so we resolve names to IDs on the fly here
+    // so the same query param works from both worlds.
+    const wdFilter = {};
+
+    const resolveTaxonomy = async (raw, Model) => {
+      const ids = [];
+      const names = [];
+      for (const v of String(raw).split(',').map(s => s.trim()).filter(Boolean)) {
+        if (isValidObjectId(v)) ids.push(v);
+        else names.push(v);
+      }
+      if (names.length > 0) {
+        const found = await Model.find({ name: { $in: names } }).distinct('_id');
+        ids.push(...found.map(id => id.toString()));
+      }
+      return ids;
+    };
+
+    if (country) {
+      const ids = await resolveTaxonomy(country, Country);
+      if (ids.length === 0) {
+        return res.json({ bottles: { count: 0, total: 0, limit, skip, items: [] } });
+      }
+      wdFilter.country = ids.length === 1 ? ids[0] : { $in: ids };
+    }
+    if (region) {
+      const ids = await resolveTaxonomy(region, Region);
+      if (ids.length === 0) {
+        return res.json({ bottles: { count: 0, total: 0, limit, skip, items: [] } });
+      }
+      wdFilter.region = ids.length === 1 ? ids[0] : { $in: ids };
+    }
+    // Grapes can also be passed as names (the byGrape stat is a name list)
+    if (grapes) {
+      const grapeIds2 = await resolveTaxonomy(grapes, Grape);
+      if (grapeIds2.length === 0) {
+        return res.json({ bottles: { count: 0, total: 0, limit, skip, items: [] } });
+      }
+      wdFilter.grapes = grapeIds2.length === 1 ? grapeIds2[0] : { $in: grapeIds2 };
+    }
+    if (type) {
+      const types = String(type).split(',').map(t => t.trim()).filter(Boolean);
+      wdFilter.type = types.length === 1 ? types[0] : { $in: types };
+    }
+    if (producer) {
+      // Producer is a free-text field on WineDefinition; match case-insensitively
+      // with an anchored regex so chart segments that pass the exact value
+      // (e.g. "Château Margaux") find that producer's bottles.
+      const escaped = String(producer).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      wdFilter.producer = new RegExp(`^${escaped}$`, 'i');
+    }
+
+    if (Object.keys(wdFilter).length > 0) {
+      const wdIds = await WineDefinition.find(wdFilter).distinct('_id');
+      if (wdIds.length === 0) {
+        return res.json({ bottles: { count: 0, total: 0, limit, skip, items: [] } });
+      }
+      filter.wineDefinition = { $in: wdIds };
+    }
+
+    const directSortFields = ['createdAt', 'vintage', 'price', 'rating'];
+    const canSortInDb = directSortFields.includes(sortField);
+    const needsInMemoryFilter = !!(search || minRating || maturityFilter);
+    const canPaginateInDb = canSortInDb && !needsInMemoryFilter;
+
+    let query = Bottle.find(filter).populate(WINE_POPULATE);
+    if (canSortInDb) query = query.sort({ [sortField]: sortDir });
+    if (canPaginateInDb) query = query.skip(skip).limit(limit);
+    let bottles = await query.lean();
+    let totalCount = canPaginateInDb ? await Bottle.countDocuments(filter) : null;
+
+    // ── In-memory text search (multi-word AND across populated fields) ─────────
+    if (search) {
+      const stripAccents = (s) => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+      const words = stripAccents(String(search).toLowerCase()).split(/\s+/).filter(Boolean);
+      bottles = bottles.filter(b => {
+        const allText = [
+          b.wineDefinition?.name,
+          b.wineDefinition?.producer,
+          b.notes,
+          b.location,
+          b.wineDefinition?.country?.name,
+          b.wineDefinition?.region?.name,
+          b.wineDefinition?.appellation,
+          b.wineDefinition?.type,
+          ...(b.wineDefinition?.grapes || []).map(g => g.name),
+        ].filter(Boolean).map(s => stripAccents(String(s).toLowerCase())).join(' ');
+        return words.every(word => allText.includes(word));
+      });
+    }
+
+    // ── Min-rating post-filter (rating scales must be normalised) ──────────────
+    if (minRating) {
+      const min = parseFloat(minRating);
+      if (!isNaN(min)) {
+        bottles = bottles.filter(b => {
+          if (b.rating == null) return false;
+          return toNormalized(b.rating, b.ratingScale || '5') >= min;
+        });
+      }
+    }
+
+    // ── Maturity post-filter / sort (needs WineVintageProfile lookup) ─────────
+    let maturityMap = null;
+    const needsMaturity = !!(maturityFilter || sortField === 'maturity');
+    if (needsMaturity) {
+      const profileMap = await buildProfileMap(bottles);
+      maturityMap = new Map();
+      for (const b of bottles) {
+        maturityMap.set(b._id.toString(), classifyMaturity(b, profileMap));
+      }
+    }
+
+    if (maturityFilter && maturityMap) {
+      if (maturityFilter === 'none') {
+        bottles = bottles.filter(b => maturityMap.get(b._id.toString()) == null);
+      } else {
+        bottles = bottles.filter(b => maturityMap.get(b._id.toString()) === maturityFilter);
+      }
+    }
+
+    // ── In-memory sort for fields we couldn't sort in the DB ──────────────────
+    if (!canSortInDb) {
+      const MATURITY_RANK = { declining: 0, late: 1, peak: 2, early: 3, 'not-ready': 4 };
+      bottles.sort((a, b) => {
+        let aVal, bVal;
+        if (sortField === 'name') {
+          aVal = a.wineDefinition?.name || '';
+          bVal = b.wineDefinition?.name || '';
+        } else if (sortField === 'maturity' && maturityMap) {
+          const aStatus = maturityMap.get(a._id.toString());
+          const bStatus = maturityMap.get(b._id.toString());
+          aVal = aStatus != null ? MATURITY_RANK[aStatus] : 5;
+          bVal = bStatus != null ? MATURITY_RANK[bStatus] : 5;
+        } else {
+          aVal = a.createdAt;
+          bVal = b.createdAt;
+        }
+        if (aVal < bVal) return -sortDir;
+        if (aVal > bVal) return sortDir;
+        return 0;
+      });
+    }
+
+    if (!canPaginateInDb) {
+      totalCount = bottles.length;
+      bottles = bottles.slice(skip, skip + limit);
+    }
+
+    const items = bottles.map(b => ({
+      ...b,
+      ...(maturityMap ? { maturityStatus: maturityMap.get(b._id.toString()) || null } : {}),
+    }));
+
+    res.json({
+      bottles: {
+        count: items.length,
+        total: totalCount,
+        limit,
+        skip,
+        items,
+      },
+    });
+  } catch (err) {
+    console.error('GET /api/bottles error:', err);
+    res.status(500).json({ error: 'Failed to load bottles' });
+  }
+});
 
 // POST /api/bottles - Add bottle to cellar (owner or editor)
 router.post('/', async (req, res) => {

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -81,6 +81,17 @@ router.get('/', async (req, res) => {
       minRating,
       maturity: maturityFilter,
       sort = '-createdAt',
+      // Lifecycle filters — default is active-only, matching the
+      // Statistics page's `byType` / `byCountry` / etc. aggregates.
+      // Set status to 'drank'|'gifted'|'sold'|'other' to view a
+      // consumed bucket, or 'all' to include everything.
+      status: statusFilter,
+      // Purchase / consumption year filters (numeric year). Apply to
+      // bottle.purchaseDate.getFullYear() and bottle.consumedAt.getFullYear()
+      // respectively — used by the Purchase History and Consumption
+      // History charts on Statistics.
+      purchaseYear,
+      consumedYear,
     } = req.query;
 
     const sortField = sort.startsWith('-') ? sort.substring(1) : sort;
@@ -89,8 +100,21 @@ router.get('/', async (req, res) => {
     const filter = {
       user: req.user.id,
       cellar: { $in: cellarIds },
-      status: { $nin: CONSUMED_STATUSES },
     };
+
+    // Status / lifecycle scope
+    if (!statusFilter || statusFilter === 'active') {
+      filter.status = { $nin: CONSUMED_STATUSES };
+    } else if (statusFilter === 'all') {
+      // no status constraint — include everything
+    } else if (CONSUMED_STATUSES.includes(statusFilter)) {
+      filter.status = statusFilter;
+    } else if (statusFilter === 'consumed') {
+      filter.status = { $in: CONSUMED_STATUSES };
+    } else {
+      // Unknown value — fall back to the default active scope
+      filter.status = { $nin: CONSUMED_STATUSES };
+    }
 
     if (vintage) {
       const vintages = String(vintage).split(',').map(v => v.trim()).filter(Boolean);
@@ -99,6 +123,24 @@ router.get('/', async (req, res) => {
 
     if (bottleSize) {
       filter.bottleSize = String(bottleSize);
+    }
+
+    // Year-range filters on purchaseDate / consumedAt. Using $gte/$lt of
+    // Jan 1 of the year and Jan 1 of next year lets MongoDB use the
+    // existing date indexes and avoids JS-side getFullYear() iteration.
+    const yearRange = (yearStr) => {
+      const y = parseInt(yearStr, 10);
+      if (isNaN(y) || y < 1900 || y > 2200) return null;
+      return { $gte: new Date(y, 0, 1), $lt: new Date(y + 1, 0, 1) };
+    };
+
+    if (purchaseYear) {
+      const range = yearRange(purchaseYear);
+      if (range) filter.purchaseDate = range;
+    }
+    if (consumedYear) {
+      const range = yearRange(consumedYear);
+      if (range) filter.consumedAt = range;
     }
 
     // Pre-query WineDefinition for taxonomy / type / producer filters.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -33,6 +33,7 @@ const SommPrices      = lazy(() => import('./pages/SommPrices'));
 const Settings        = lazy(() => import('./pages/Settings'));
 const Supporter       = lazy(() => import('./pages/Supporter'));
 const Statistics      = lazy(() => import('./pages/Statistics'));
+const Bottles         = lazy(() => import('./pages/Bottles'));
 const StatsCard       = lazy(() => import('./pages/StatsCard'));
 const AdminWines      = lazy(() => import('./pages/AdminWines'));
 const AdminRequests   = lazy(() => import('./pages/AdminRequests'));
@@ -304,6 +305,14 @@ function AppRoutes() {
           element={
             <ProtectedRoute>
               <Layout><StatsCard /></Layout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/bottles"
+          element={
+            <ProtectedRoute>
+              <Layout><Bottles /></Layout>
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/bottles.js
+++ b/frontend/src/api/bottles.js
@@ -1,5 +1,20 @@
 import { JSON_HEADERS } from './apiConstants';
 
+/**
+ * Cross-cellar bottle list for the authenticated user.
+ * `params` is a plain object whose entries become URL query params
+ * (arrays are joined with commas, falsy values are skipped).
+ */
+export const listBottles = (apiFetch, params = {}) => {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === null || v === undefined || v === '') continue;
+    qs.set(k, Array.isArray(v) ? v.filter(Boolean).join(',') : String(v));
+  }
+  const query = qs.toString();
+  return apiFetch(`/api/bottles${query ? `?${query}` : ''}`);
+};
+
 export const getBottle = (apiFetch, id) =>
   apiFetch(`/api/bottles/${id}`);
 

--- a/frontend/src/components/BottleCard.css
+++ b/frontend/src/components/BottleCard.css
@@ -1,0 +1,290 @@
+/* Styles for BottleCard (used by /cellars/:id and /bottles). Originally
+   lived in CellarDetail.css; co-located here so any page rendering a
+   BottleCard gets the styling without importing the whole cellar page CSS. */
+
+/* ── Image wrap + credit tooltip ── */
+.bottle-img-wrap,
+.bottle-grid-image-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.img-credit-tooltip {
+  display: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.78);
+  color: #b0a898;
+  font-size: 0.58rem;
+  text-align: center;
+  padding: 2px 3px;
+  border-radius: 0 0 3px 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+  pointer-events: none;
+}
+
+.bottle-img-wrap:hover .img-credit-tooltip,
+.bottle-grid-image-wrap:hover .img-credit-tooltip {
+  display: block;
+}
+
+/* ── List-mode card ── */
+.bottle-card {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast), box-shadow var(--transition-fast);
+  min-height: 68px;
+  min-width: 0;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.bottle-card:hover {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+  box-shadow: var(--shadow-card-hover);
+}
+
+.bottle-wine-image {
+  width: 44px;
+  height: 64px;
+  object-fit: contain;
+  border-radius: 3px;
+  display: block;
+}
+
+.bottle-wine-placeholder {
+  width: 44px;
+  height: 64px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.bottle-wine-placeholder.red       { background: var(--wine-red); }
+.bottle-wine-placeholder.white     { background: var(--wine-white); }
+.bottle-wine-placeholder.rosé      { background: var(--wine-rose); }
+.bottle-wine-placeholder.sparkling { background: var(--wine-sparkling); }
+.bottle-wine-placeholder.dessert   { background: var(--wine-dessert); }
+.bottle-wine-placeholder.fortified { background: var(--wine-fortified); }
+
+.bottle-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.bottle-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 0.2rem;
+}
+
+.bottle-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+  color: var(--color-text-secondary);
+  flex-wrap: wrap;
+}
+
+.bottle-producer {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bottle-vintage {
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.bottle-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.3rem;
+}
+
+/* ── Rack badge ── */
+.rack-badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  color: var(--color-accent);
+  background: var(--color-accent-light);
+  border: 1px solid rgba(var(--color-accent-rgb), 0.25);
+  border-radius: var(--radius-full);
+  padding: 1px 8px;
+  text-decoration: none;
+}
+
+.rack-badge:hover {
+  background: rgba(var(--color-accent-rgb), 0.18);
+}
+
+.pending-wine-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 1px 7px;
+  border-radius: var(--radius-full);
+  background: var(--color-info-bg);
+  color: var(--color-info);
+  border: 1px solid var(--color-info-border);
+}
+
+/* ── Maturity badges ── */
+.maturity-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 1px 7px;
+  border-radius: var(--radius-full);
+  font-weight: 500;
+}
+
+.maturity-badge--peak {
+  background: #e8f5e9;
+  color: #2e7d32;
+  border: 1px solid #a5d6a7;
+}
+
+.maturity-badge--early {
+  background: #e3f2fd;
+  color: #1565c0;
+  border: 1px solid #90caf9;
+}
+
+.maturity-badge--late {
+  background: #fff3e0;
+  color: #e65100;
+  border: 1px solid #ffcc80;
+}
+
+.maturity-badge--declining {
+  background: #fce4ec;
+  color: #c62828;
+  border: 1px solid #ef9a9a;
+}
+
+.maturity-badge--not-ready {
+  background: #f3e5f5;
+  color: #6a1b9a;
+  border: 1px solid #ce93d8;
+}
+
+.maturity-badge--none {
+  background: var(--color-surface-raised);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+}
+
+.bottle-chevron {
+  font-size: 1.4rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+/* ── Card grid-mode ── */
+.bottle-grid-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-card);
+}
+
+.bottle-grid-card:hover {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-card-hover);
+}
+
+.bottle-grid-image-wrap {
+  width: 100%;
+  aspect-ratio: 1 / 1.6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg);
+  overflow: hidden;
+}
+
+.bottle-grid-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  padding: 0.5rem;
+}
+
+.bottle-grid-placeholder {
+  width: 60%;
+  height: 80%;
+  border-radius: 4px;
+}
+
+.bottle-grid-placeholder.red       { background: var(--wine-red); }
+.bottle-grid-placeholder.white     { background: var(--wine-white); }
+.bottle-grid-placeholder.rosé      { background: var(--wine-rose); }
+.bottle-grid-placeholder.sparkling { background: var(--wine-sparkling); }
+.bottle-grid-placeholder.dessert   { background: var(--wine-dessert); }
+.bottle-grid-placeholder.fortified { background: var(--wine-fortified); }
+
+.bottle-grid-info {
+  padding: 0.625rem 0.75rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  flex: 1;
+}
+
+.bottle-grid-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.bottle-grid-producer {
+  font-size: 0.77rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bottle-grid-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin-top: 0.1rem;
+}
+
+.bottle-grid-region {
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -3,6 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { buildRackUrl } from '../utils/rackNavigation';
 import { useTranslation } from 'react-i18next';
 import AuthImage from './AuthImage';
+import './BottleCard.css';
 
 const MATURITY_LABELS = {
   'not-ready': { key: 'maturity.notReady', cls: 'maturity-badge--not-ready' },

--- a/frontend/src/components/charts/BottleSizeChart.js
+++ b/frontend/src/components/charts/BottleSizeChart.js
@@ -1,24 +1,42 @@
-function BottleSizeChart({ byBottleSize }) {
+/**
+ * `onSizeClick(size)` makes each row a clickable deep-link target.
+ */
+function BottleSizeChart({ byBottleSize, onSizeClick }) {
   const entries = Object.entries(byBottleSize).sort((a, b) => b[1] - a[1]);
   if (entries.length <= 1) return null;
   const total      = entries.reduce((s, [, v]) => s + v, 0);
   const sizeColors = ['#7A1E2D', '#6EC6C6', '#D4C87A', '#D4A070', '#8B6A9A'];
+  const clickable = typeof onSizeClick === 'function';
 
   return (
     <div className="hbar-chart">
-      {entries.map(([size, count], i) => (
-        <div key={size} className="hbar-row">
-          <span className="hbar-label">{size}</span>
-          <div className="hbar-track">
-            <div className="hbar-fill" style={{
-              width: `${(count / total) * 100}%`,
-              background: sizeColors[i % sizeColors.length],
-            }} />
-          </div>
-          <span className="hbar-count">{count}</span>
-          <span className="hbar-pct">{((count / total) * 100).toFixed(0)}%</span>
-        </div>
-      ))}
+      {entries.map(([size, count], i) => {
+        const inner = (
+          <>
+            <span className="hbar-label">{size}</span>
+            <div className="hbar-track">
+              <div className="hbar-fill" style={{
+                width: `${(count / total) * 100}%`,
+                background: sizeColors[i % sizeColors.length],
+              }} />
+            </div>
+            <span className="hbar-count">{count}</span>
+            <span className="hbar-pct">{((count / total) * 100).toFixed(0)}%</span>
+          </>
+        );
+        return clickable ? (
+          <button
+            key={size}
+            type="button"
+            className="hbar-row hbar-row--clickable"
+            onClick={() => onSizeClick(size)}
+          >
+            {inner}
+          </button>
+        ) : (
+          <div key={size} className="hbar-row">{inner}</div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/charts/ConsumptionChart.js
+++ b/frontend/src/components/charts/ConsumptionChart.js
@@ -1,7 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { REASON_COLORS } from './chartHelpers';
 
-function ConsumptionChart({ consumptionByYear, consumptionByReason }) {
+/**
+ * `onYearClick(year)` makes each year's bar stack clickable as a whole
+ * (filters by consumedYear). `onReasonClick(reason)` makes the legend
+ * items clickable (filters by lifecycle status — drank/gifted/sold/other).
+ */
+function ConsumptionChart({ consumptionByYear, consumptionByReason, onYearClick, onReasonClick }) {
   const { t } = useTranslation();
   if (!consumptionByYear || consumptionByYear.length === 0) {
     return (
@@ -23,39 +28,71 @@ function ConsumptionChart({ consumptionByYear, consumptionByReason }) {
   );
   const BAR_H = 120;
   const total = Object.values(consumptionByReason).reduce((s, v) => s + v, 0);
+  const yearClickable = typeof onYearClick === 'function';
+  const reasonClickable = typeof onReasonClick === 'function';
 
   return (
     <div>
       <div className="consumption-chart">
         {consumptionByYear.map((d, i) => {
           const yearTotal = reasons.reduce((s, r) => s + (d[r] || 0), 0);
-          return (
-            <div key={i} className="consumption-year-col">
-              <div className="consumption-bar-count">{yearTotal > 0 ? yearTotal : ''}</div>
-              <div className="consumption-bar-stack" style={{ height: `${BAR_H}px` }}
-                title={t('statistics.vintageBottle', { vintage: d.year, count: yearTotal })}>
-                {reasons.map(r => {
-                  const h = maxTotal > 0 ? ((d[r] || 0) / maxTotal) * BAR_H : 0;
-                  if (h === 0) return null;
-                  return (
-                    <div key={r} className="consumption-segment"
-                      style={{ height: `${h}px`, background: REASON_COLORS[r] }}
-                      title={`${reasonLabels[r]}: ${d[r] || 0}`} />
-                  );
-                })}
-              </div>
-              <div className="consumption-year-label">{d.year}</div>
+          const stack = (
+            <div className="consumption-bar-stack" style={{ height: `${BAR_H}px` }}
+              title={t('statistics.vintageBottle', { vintage: d.year, count: yearTotal })}>
+              {reasons.map(r => {
+                const h = maxTotal > 0 ? ((d[r] || 0) / maxTotal) * BAR_H : 0;
+                if (h === 0) return null;
+                return (
+                  <div key={r} className="consumption-segment"
+                    style={{ height: `${h}px`, background: REASON_COLORS[r] }}
+                    title={`${reasonLabels[r]}: ${d[r] || 0}`} />
+                );
+              })}
             </div>
+          );
+          const col = (
+            <>
+              <div className="consumption-bar-count">{yearTotal > 0 ? yearTotal : ''}</div>
+              {stack}
+              <div className="consumption-year-label">{d.year}</div>
+            </>
+          );
+          return yearClickable && yearTotal > 0 ? (
+            <button
+              key={i}
+              type="button"
+              className="consumption-year-col consumption-year-col--clickable"
+              onClick={() => onYearClick(d.year)}
+            >
+              {col}
+            </button>
+          ) : (
+            <div key={i} className="consumption-year-col">{col}</div>
           );
         })}
       </div>
       <div className="consumption-legend">
-        {reasons.map(r => (
-          <span key={r} className="consumption-legend-item">
-            <span className="consumption-dot" style={{ background: REASON_COLORS[r] }} />
-            {reasonLabels[r]}: {consumptionByReason[r] || 0}
-          </span>
-        ))}
+        {reasons.map(r => {
+          const count = consumptionByReason[r] || 0;
+          const content = (
+            <>
+              <span className="consumption-dot" style={{ background: REASON_COLORS[r] }} />
+              {reasonLabels[r]}: {count}
+            </>
+          );
+          return reasonClickable && count > 0 ? (
+            <button
+              key={r}
+              type="button"
+              className="consumption-legend-item consumption-legend-item--clickable"
+              onClick={() => onReasonClick(r)}
+            >
+              {content}
+            </button>
+          ) : (
+            <span key={r} className="consumption-legend-item">{content}</span>
+          );
+        })}
       </div>
       <div className="consumption-totals">
         <strong>{t('statistics.consumption.totalConsumed', { count: total })}</strong>

--- a/frontend/src/components/charts/DonutChart.js
+++ b/frontend/src/components/charts/DonutChart.js
@@ -1,6 +1,11 @@
 import { useTranslation } from 'react-i18next';
 
-function DonutChart({ segments, total }) {
+/**
+ * `onSegmentClick(segment)` makes each arc + its legend row a clickable
+ * deep-link target. When provided, segments get a pointer cursor and a
+ * keyboard-accessible role.
+ */
+function DonutChart({ segments, total, onSegmentClick }) {
   const { t } = useTranslation();
   const size = 180;
   const R  = size * 0.355;
@@ -9,6 +14,9 @@ function DonutChart({ segments, total }) {
   const cy = size / 2;
   const validSegs = segments.filter(s => s.value > 0);
   let cumulative  = 0;
+
+  const clickable = typeof onSegmentClick === 'function';
+  const handle = (seg) => clickable && onSegmentClick(seg);
 
   return (
     <svg
@@ -28,6 +36,8 @@ function DonutChart({ segments, total }) {
             fill="none" stroke={seg.color} strokeWidth="20"
             strokeDasharray={`${len} ${C}`} strokeDashoffset={dashoffset}
             strokeLinecap="butt"
+            onClick={clickable ? () => handle(seg) : undefined}
+            style={clickable ? { cursor: 'pointer' } : undefined}
           >
             <title>{seg.label}: {seg.value} ({total > 0 ? ((seg.value / total) * 100).toFixed(1) : 0}%)</title>
           </circle>

--- a/frontend/src/components/charts/HBarChart.js
+++ b/frontend/src/components/charts/HBarChart.js
@@ -1,27 +1,47 @@
 import { useTranslation } from 'react-i18next';
 
-function HBarChart({ data, colors, maxItems = 12 }) {
+/**
+ * `onItemClick(item)` makes each row a clickable deep-link target.
+ * When provided, rows render as `<button>` so they're keyboard-accessible
+ * and get a hover affordance via CSS.
+ */
+function HBarChart({ data, colors, maxItems = 12, onItemClick }) {
   const { t } = useTranslation();
   if (!data || data.length === 0) return <p className="stats-empty">{t('statistics.noDataYet')}</p>;
   const items  = data.slice(0, maxItems);
   const maxVal = Math.max(...items.map(d => d.count), 1);
+  const clickable = typeof onItemClick === 'function';
 
   return (
     <div className="hbar-chart">
-      {items.map((d, i) => (
-        <div key={i} className="hbar-row">
-          <span className="hbar-label" title={d.name}>{d.name}</span>
-          <div className="hbar-track">
-            <div className="hbar-fill" style={{
-              width: `${(d.count / maxVal) * 100}%`,
-              background: Array.isArray(colors)
-                ? (colors[i % colors.length] || '#7A1E2D')
-                : (colors || '#7A1E2D'),
-            }} />
-          </div>
-          <span className="hbar-count">{d.count}</span>
-        </div>
-      ))}
+      {items.map((d, i) => {
+        const inner = (
+          <>
+            <span className="hbar-label" title={d.name}>{d.name}</span>
+            <div className="hbar-track">
+              <div className="hbar-fill" style={{
+                width: `${(d.count / maxVal) * 100}%`,
+                background: Array.isArray(colors)
+                  ? (colors[i % colors.length] || '#7A1E2D')
+                  : (colors || '#7A1E2D'),
+              }} />
+            </div>
+            <span className="hbar-count">{d.count}</span>
+          </>
+        );
+        return clickable ? (
+          <button
+            key={i}
+            type="button"
+            className="hbar-row hbar-row--clickable"
+            onClick={() => onItemClick(d)}
+          >
+            {inner}
+          </button>
+        ) : (
+          <div key={i} className="hbar-row">{inner}</div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/charts/MaturityViz.js
+++ b/frontend/src/components/charts/MaturityViz.js
@@ -1,17 +1,24 @@
 import { useTranslation } from 'react-i18next';
 
-function MaturityViz({ maturity, maturityCoverage, total }) {
+/**
+ * `onSegmentClick(segmentKey)` makes each legend row + bar segment a
+ * clickable deep-link target. `segmentKey` matches the maturity buckets
+ * used by the backend filter (e.g. 'peak', 'declining', 'not-ready',
+ * 'none' for bottles without a sommelier profile).
+ */
+function MaturityViz({ maturity, maturityCoverage, total, onSegmentClick }) {
   const { t } = useTranslation();
   const segments = [
-    { key: 'declining',  color: '#C94040', icon: '\u26a0' },
-    { key: 'late',       color: '#D4A070', icon: '\u23f1' },
-    { key: 'peak',       color: '#7A1E2D', icon: '\u2713' },
-    { key: 'early',      color: '#7aade0', icon: '\u25f7' },
-    { key: 'notReady',   color: '#5B8DB8', icon: '\u23f3' },
-    { key: 'noProfile',  color: '#3a3a3a', icon: '\u2014' },
+    { key: 'declining',  filter: 'declining', color: '#C94040', icon: '⚠' },
+    { key: 'late',       filter: 'late',      color: '#D4A070', icon: '⏱' },
+    { key: 'peak',       filter: 'peak',      color: '#7A1E2D', icon: '✓' },
+    { key: 'early',      filter: 'early',     color: '#7aade0', icon: '◷' },
+    { key: 'notReady',   filter: 'not-ready', color: '#5B8DB8', icon: '⏳' },
+    { key: 'noProfile',  filter: 'none',      color: '#3a3a3a', icon: '—' },
   ];
 
   const hasCoverage = maturityCoverage && maturityCoverage.sommSet > 0;
+  const clickable = typeof onSegmentClick === 'function';
 
   return (
     <div className="drink-window">
@@ -20,10 +27,20 @@ function MaturityViz({ maturity, maturityCoverage, total }) {
           const count = maturity[seg.key] || 0;
           const pct   = (count / total) * 100;
           if (pct === 0) return null;
-          return (
+          const title = `${t(`statistics.maturityPhases.${seg.key}`)}: ${count}`;
+          return clickable ? (
+            <button
+              key={seg.key}
+              type="button"
+              className="drink-segment drink-segment--clickable"
+              style={{ width: `${pct}%`, background: seg.color }}
+              title={title}
+              onClick={() => onSegmentClick(seg.filter)}
+            />
+          ) : (
             <div key={seg.key} className="drink-segment"
               style={{ width: `${pct}%`, background: seg.color }}
-              title={`${t(`statistics.maturityPhases.${seg.key}`)}: ${count}`} />
+              title={title} />
           );
         }) : (
           <div className="drink-segment" style={{ width: '100%', background: '#252525' }} />
@@ -32,8 +49,8 @@ function MaturityViz({ maturity, maturityCoverage, total }) {
       <div className="drink-legend">
         {segments.map(seg => {
           const count = maturity[seg.key] || 0;
-          return (
-            <div key={seg.key} className="drink-legend-item">
+          const content = (
+            <>
               <span className="drink-legend-dot" style={{ background: seg.color }} />
               <span className="drink-legend-icon">{seg.icon}</span>
               <span className="drink-legend-label">{t(`statistics.maturityPhases.${seg.key}`)}</span>
@@ -41,14 +58,26 @@ function MaturityViz({ maturity, maturityCoverage, total }) {
                 style={{ color: count > 0 && seg.key !== 'noProfile' ? seg.color : undefined }}>
                 {count}
               </span>
-            </div>
+            </>
+          );
+          return clickable && count > 0 ? (
+            <button
+              key={seg.key}
+              type="button"
+              className="drink-legend-item drink-legend-item--clickable"
+              onClick={() => onSegmentClick(seg.filter)}
+            >
+              {content}
+            </button>
+          ) : (
+            <div key={seg.key} className="drink-legend-item">{content}</div>
           );
         })}
       </div>
       {hasCoverage && (
         <div className="drink-coverage-note">
           {t('statistics.maturity.withProfiles', { count: maturityCoverage.sommSet })}
-          {maturityCoverage.none > 0 && ` \u00b7 ${t('statistics.maturity.withoutData', { count: maturityCoverage.none })}`}
+          {maturityCoverage.none > 0 && ` · ${t('statistics.maturity.withoutData', { count: maturityCoverage.none })}`}
         </div>
       )}
     </div>

--- a/frontend/src/components/charts/PurchaseHistoryChart.js
+++ b/frontend/src/components/charts/PurchaseHistoryChart.js
@@ -1,30 +1,49 @@
 import { useTranslation } from 'react-i18next';
 
-function PurchaseHistoryChart({ byPurchaseYear }) {
+/**
+ * `onYearClick(year)` makes each bar a clickable deep-link target.
+ */
+function PurchaseHistoryChart({ byPurchaseYear, onYearClick }) {
   const { t } = useTranslation();
   if (!byPurchaseYear || byPurchaseYear.length === 0) {
     return <p className="stats-empty">{t('statistics.noPurchaseData')}</p>;
   }
   const maxVal = Math.max(...byPurchaseYear.map(d => d.count), 1);
   const BAR_H  = 80;
+  const clickable = typeof onYearClick === 'function';
 
   return (
     <div className="vintage-chart">
       <div className="vintage-bars">
-        {byPurchaseYear.map((d, i) => (
-          <div key={i} className="vintage-bar-wrap"
-            title={t('statistics.purchased', { year: d.year, count: d.count })}>
-            <div className="vintage-bar-count">{d.count > 1 ? d.count : ''}</div>
-            <div className="vintage-bar"
-              style={{
-                height: `${Math.max(4, (d.count / maxVal) * BAR_H)}px`,
-                background: 'linear-gradient(to top, #5f7a8a, #7aade0)',
-              }} />
-            <div className="vintage-bar-label">
-              {byPurchaseYear.length > 15 ? String(d.year).slice(-2) : d.year}
-            </div>
-          </div>
-        ))}
+        {byPurchaseYear.map((d, i) => {
+          const title = t('statistics.purchased', { year: d.year, count: d.count });
+          const content = (
+            <>
+              <div className="vintage-bar-count">{d.count > 1 ? d.count : ''}</div>
+              <div className="vintage-bar"
+                style={{
+                  height: `${Math.max(4, (d.count / maxVal) * BAR_H)}px`,
+                  background: 'linear-gradient(to top, #5f7a8a, #7aade0)',
+                }} />
+              <div className="vintage-bar-label">
+                {byPurchaseYear.length > 15 ? String(d.year).slice(-2) : d.year}
+              </div>
+            </>
+          );
+          return clickable ? (
+            <button
+              key={i}
+              type="button"
+              className="vintage-bar-wrap vintage-bar-wrap--clickable"
+              title={title}
+              onClick={() => onYearClick(d.year)}
+            >
+              {content}
+            </button>
+          ) : (
+            <div key={i} className="vintage-bar-wrap" title={title}>{content}</div>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/charts/RatingChart.js
+++ b/frontend/src/components/charts/RatingChart.js
@@ -1,18 +1,24 @@
 import { useTranslation } from 'react-i18next';
 import { RATING_BAND_DEFS, bandSub, fmtRating } from './chartHelpers';
 
-function RatingChart({ byRating, avg, targetScale }) {
+/**
+ * `onBandClick(band)` makes each rating band a clickable deep-link target.
+ * The band object includes a `min` value (normalised 0-100) the caller can
+ * use to deep-link with `minRating=<min>`.
+ */
+function RatingChart({ byRating, avg, targetScale, onBandClick }) {
   const { t } = useTranslation();
   const total  = Object.values(byRating).reduce((s, v) => s + v, 0);
   const maxVal = Math.max(...Object.values(byRating), 1);
+  const clickable = typeof onBandClick === 'function';
 
   return (
     <div className="rating-chart">
       {RATING_BAND_DEFS.map(band => {
         const count = byRating[band.key] || 0;
         const pct   = total > 0 ? (count / total) * 100 : 0;
-        return (
-          <div key={band.key} className="rating-row" title={bandSub(band.key, targetScale)}>
+        const content = (
+          <>
             <span className="rating-stars" style={{ color: band.color }}>
               {t(`statistics.ratingBands.${band.labelKey}`)}
             </span>
@@ -21,6 +27,21 @@ function RatingChart({ byRating, avg, targetScale }) {
             </div>
             <span className="rating-count">{count}</span>
             <span className="rating-pct">{pct.toFixed(0)}%</span>
+          </>
+        );
+        return clickable && count > 0 ? (
+          <button
+            key={band.key}
+            type="button"
+            className="rating-row rating-row--clickable"
+            title={bandSub(band.key, targetScale)}
+            onClick={() => onBandClick(band)}
+          >
+            {content}
+          </button>
+        ) : (
+          <div key={band.key} className="rating-row" title={bandSub(band.key, targetScale)}>
+            {content}
           </div>
         );
       })}

--- a/frontend/src/components/charts/VintageBarChart.js
+++ b/frontend/src/components/charts/VintageBarChart.js
@@ -1,6 +1,9 @@
 import { useTranslation } from 'react-i18next';
 
-function VintageBarChart({ data }) {
+/**
+ * `onBarClick(year)` makes each vintage bar a clickable deep-link target.
+ */
+function VintageBarChart({ data, onBarClick }) {
   const { t } = useTranslation();
   if (!data || data.length === 0) return <p className="stats-empty">{t('statistics.noVintageData')}</p>;
 
@@ -8,30 +11,46 @@ function VintageBarChart({ data }) {
   const nvItem   = data.find(d => d.year === 'NV');
   const maxCount = Math.max(...data.map(d => d.count), 1);
   const BAR_HEIGHT = 160;
+  const clickable = typeof onBarClick === 'function';
+
+  const renderBar = (d, extraClass = '') => {
+    const title = t('statistics.vintageBottle', { vintage: d.year, count: d.count });
+    const content = (
+      <>
+        <div className="vintage-bar-count">{d.count > 1 ? d.count : ''}</div>
+        <div className={`vintage-bar${extraClass ? ` ${extraClass}` : ''}`}
+          style={{ height: `${Math.max(4, (d.count / maxCount) * BAR_HEIGHT)}px` }} />
+        <div className="vintage-bar-label">
+          {numeric.length > 20 ? String(d.year).slice(-2) : d.year}
+        </div>
+      </>
+    );
+    return clickable ? (
+      <button
+        key={d.year}
+        type="button"
+        className={`vintage-bar-wrap vintage-bar-wrap--clickable${extraClass ? ` vintage-bar-wrap--nv` : ''}`}
+        title={title}
+        onClick={() => onBarClick(d.year)}
+      >
+        {content}
+      </button>
+    ) : (
+      <div
+        key={d.year}
+        className={`vintage-bar-wrap${extraClass ? ` vintage-bar-wrap--nv` : ''}`}
+        title={title}
+      >
+        {content}
+      </div>
+    );
+  };
 
   return (
     <div className="vintage-chart">
       <div className="vintage-bars">
-        {numeric.map((d, i) => (
-          <div key={i} className="vintage-bar-wrap"
-            title={t('statistics.vintageBottle', { vintage: d.year, count: d.count })}>
-            <div className="vintage-bar-count">{d.count > 1 ? d.count : ''}</div>
-            <div className="vintage-bar"
-              style={{ height: `${Math.max(4, (d.count / maxCount) * BAR_HEIGHT)}px` }} />
-            <div className="vintage-bar-label">
-              {numeric.length > 20 ? String(d.year).slice(-2) : d.year}
-            </div>
-          </div>
-        ))}
-        {nvItem && (
-          <div className="vintage-bar-wrap vintage-bar-wrap--nv"
-            title={t('statistics.vintageBottle', { vintage: 'NV', count: nvItem.count })}>
-            <div className="vintage-bar-count">{nvItem.count}</div>
-            <div className="vintage-bar vintage-bar--nv"
-              style={{ height: `${Math.max(4, (nvItem.count / maxCount) * BAR_HEIGHT)}px` }} />
-            <div className="vintage-bar-label">NV</div>
-          </div>
-        )}
+        {numeric.map(d => renderBar(d))}
+        {nvItem && renderBar({ ...nvItem, year: 'NV' }, 'vintage-bar--nv')}
       </div>
     </div>
   );

--- a/frontend/src/pages/Bottles.css
+++ b/frontend/src/pages/Bottles.css
@@ -83,9 +83,9 @@
   border-radius: 8px;
 }
 
-.bottles-grid {
+.bottles-page-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
   gap: 1rem;
   margin-top: 0.5rem;
 }

--- a/frontend/src/pages/Bottles.css
+++ b/frontend/src/pages/Bottles.css
@@ -1,0 +1,123 @@
+.bottles-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+}
+
+.bottles-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.bottles-header h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.bottles-subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--text-muted, #9A9484);
+  font-size: 0.95rem;
+}
+
+.bottles-chips-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0 1.25rem;
+  align-items: center;
+}
+
+.bottles-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(122, 30, 45, 0.18);
+  color: #E8DFD0;
+  border: 1px solid rgba(122, 30, 45, 0.4);
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  line-height: 1.2;
+}
+
+.bottles-chip-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 0.1rem;
+  font-size: 1.05rem;
+  line-height: 1;
+  opacity: 0.7;
+}
+
+.bottles-chip-remove:hover {
+  opacity: 1;
+}
+
+.bottles-chip-clear {
+  background: none;
+  border: none;
+  color: var(--text-muted, #9A9484);
+  cursor: pointer;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.85rem;
+  text-decoration: underline;
+}
+
+.bottles-chip-clear:hover {
+  color: #E8DFD0;
+}
+
+.bottles-empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: var(--text-muted, #9A9484);
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+}
+
+.bottles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.bottles-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.bottles-pagination button {
+  background: rgba(255, 255, 255, 0.06);
+  color: #E8DFD0;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.bottles-pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.bottles-pagination button:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.bottles-page-indicator {
+  color: var(--text-muted, #9A9484);
+  font-size: 0.9rem;
+}

--- a/frontend/src/pages/Bottles.js
+++ b/frontend/src/pages/Bottles.js
@@ -9,11 +9,22 @@ import './Bottles.css';
 const FILTER_KEYS = [
   'search', 'type', 'country', 'region', 'grapes',
   'vintage', 'producer', 'bottleSize', 'minRating', 'maturity', 'sort',
+  'purchaseYear', 'consumedYear', 'status',
 ];
 
 const TYPE_LABELS = {
   red: 'Red', white: 'White', 'rosé': 'Rosé', sparkling: 'Sparkling',
   dessert: 'Dessert', fortified: 'Fortified',
+};
+
+const STATUS_LABELS = {
+  active: 'Active',
+  consumed: 'Consumed',
+  all: 'All',
+  drank: 'Drunk',
+  gifted: 'Gifted',
+  sold: 'Sold',
+  other: 'Other',
 };
 
 const PAGE_SIZE = 30;
@@ -116,6 +127,9 @@ function Bottles() {
     if (filters.minRating) labels.minRating = `Rating: ${filters.minRating}+`;
     if (filters.maturity) labels.maturity = `Maturity: ${filters.maturity}`;
     if (filters.search) labels.search = `Search: "${filters.search}"`;
+    if (filters.purchaseYear) labels.purchaseYear = `Purchased: ${filters.purchaseYear}`;
+    if (filters.consumedYear) labels.consumedYear = `Consumed: ${filters.consumedYear}`;
+    if (filters.status) labels.status = `Status: ${STATUS_LABELS[filters.status] || filters.status}`;
     return labels;
     // sample is only referenced so the linter sees we read data
     // eslint-disable-next-line no-unused-vars

--- a/frontend/src/pages/Bottles.js
+++ b/frontend/src/pages/Bottles.js
@@ -179,7 +179,7 @@ function Bottles() {
         </div>
       )}
 
-      <div className="bottles-grid">
+      <div className="bottles-page-grid">
         {data.items.map(bottle => (
           <BottleCard
             key={bottle._id}

--- a/frontend/src/pages/Bottles.js
+++ b/frontend/src/pages/Bottles.js
@@ -1,0 +1,219 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import { listBottles } from '../api/bottles';
+import BottleCard from '../components/BottleCard';
+import './Bottles.css';
+
+const FILTER_KEYS = [
+  'search', 'type', 'country', 'region', 'grapes',
+  'vintage', 'producer', 'bottleSize', 'minRating', 'maturity', 'sort',
+];
+
+const TYPE_LABELS = {
+  red: 'Red', white: 'White', 'rosé': 'Rosé', sparkling: 'Sparkling',
+  dessert: 'Dessert', fortified: 'Fortified',
+};
+
+const PAGE_SIZE = 30;
+
+/**
+ * Cross-cellar bottle list — typically reached by clicking a chart
+ * segment on the Statistics page. The filter to apply is encoded in the
+ * URL query params and the page is essentially read-only: the user lands
+ * here with a specific filter pre-applied and can clear individual chips
+ * or all of them to broaden the view.
+ *
+ * The set of bottles shown matches the Statistics page's scope: only
+ * cellars the user OWNS (shared/read-only cellars are excluded), so a
+ * count on the chart and the count of bottles here always agree.
+ */
+function Bottles() {
+  const { t } = useTranslation();
+  const { apiFetch } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filters = useMemo(() => {
+    const out = {};
+    for (const key of FILTER_KEYS) {
+      const v = searchParams.get(key);
+      if (v) out[key] = v;
+    }
+    return out;
+  }, [searchParams]);
+
+  const [page, setPage] = useState(0);
+  const [data, setData] = useState({ items: [], total: 0, count: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Reset page when filters change so a new filter starts at the top
+  useEffect(() => { setPage(0); }, [searchParams]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listBottles(apiFetch, {
+        ...filters,
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || 'Failed to load bottles');
+      setData(json.bottles || { items: [], total: 0, count: 0 });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch, filters, page]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const removeFilter = (key) => {
+    const next = new URLSearchParams(searchParams);
+    next.delete(key);
+    setSearchParams(next, { replace: true });
+  };
+
+  const clearAll = () => {
+    setSearchParams(new URLSearchParams(), { replace: true });
+  };
+
+  // Build a friendly label for each active filter chip. We resolve
+  // country/region/grape names from the populated bottle data we already
+  // received, so we don't need an extra taxonomy fetch.
+  const chipLabels = useMemo(() => {
+    const labels = {};
+    const sample = data.items[0]?.wineDefinition;
+    if (filters.type) labels.type = `Type: ${TYPE_LABELS[filters.type] || filters.type}`;
+    if (filters.country) {
+      const name = data.items.find(b => b.wineDefinition?.country?._id === filters.country)
+        ?.wineDefinition?.country?.name;
+      labels.country = `Country: ${name || filters.country}`;
+    }
+    if (filters.region) {
+      const name = data.items.find(b => b.wineDefinition?.region?._id === filters.region)
+        ?.wineDefinition?.region?.name;
+      labels.region = `Region: ${name || filters.region}`;
+    }
+    if (filters.grapes) {
+      const ids = String(filters.grapes).split(',');
+      const names = ids.map(id => {
+        for (const b of data.items) {
+          const g = (b.wineDefinition?.grapes || []).find(g => g._id === id);
+          if (g) return g.name;
+        }
+        return id;
+      });
+      labels.grapes = `Grape: ${names.join(', ')}`;
+    }
+    if (filters.vintage) labels.vintage = `Vintage: ${filters.vintage}`;
+    if (filters.producer) labels.producer = `Producer: ${filters.producer}`;
+    if (filters.bottleSize) labels.bottleSize = `Size: ${filters.bottleSize}`;
+    if (filters.minRating) labels.minRating = `Rating: ${filters.minRating}+`;
+    if (filters.maturity) labels.maturity = `Maturity: ${filters.maturity}`;
+    if (filters.search) labels.search = `Search: "${filters.search}"`;
+    return labels;
+    // sample is only referenced so the linter sees we read data
+    // eslint-disable-next-line no-unused-vars
+  }, [filters, data.items]);
+
+  const chips = Object.entries(chipLabels);
+  const total = data.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  // Build a rackMap so BottleCard's "Rack: …" line works. The cross-cellar
+  // endpoint doesn't return rack details for performance, so we just hand
+  // BottleCard an empty Map — it falls back gracefully.
+  const rackMap = useMemo(() => new Map(), []);
+
+  return (
+    <div className="bottles-page">
+      <div className="bottles-header">
+        <div className="bottles-header-text">
+          <h1>{t('bottles.title', 'All bottles')}</h1>
+          <p className="bottles-subtitle">
+            {loading
+              ? t('bottles.loading', 'Loading…')
+              : t('bottles.summary', '{{count}} of {{total}} bottles', { count: data.count, total })}
+          </p>
+        </div>
+        <Link to="/statistics" className="btn btn-secondary btn-small">
+          {t('bottles.backToStats', '← Back to Statistics')}
+        </Link>
+      </div>
+
+      {chips.length > 0 && (
+        <div className="bottles-chips-row">
+          {chips.map(([key, label]) => (
+            <span key={key} className="bottles-chip">
+              {label}
+              <button
+                type="button"
+                onClick={() => removeFilter(key)}
+                aria-label={t('bottles.removeFilter', 'Remove this filter')}
+                className="bottles-chip-remove"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          {chips.length > 1 && (
+            <button type="button" className="bottles-chip-clear" onClick={clearAll}>
+              {t('bottles.clearAll', 'Clear all')}
+            </button>
+          )}
+        </div>
+      )}
+
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {!loading && data.items.length === 0 && !error && (
+        <div className="bottles-empty">
+          {chips.length > 0
+            ? t('bottles.noneForFilters', 'No bottles match those filters.')
+            : t('bottles.noneInCellar', 'No bottles in your cellars yet.')}
+        </div>
+      )}
+
+      <div className="bottles-grid">
+        {data.items.map(bottle => (
+          <BottleCard
+            key={bottle._id}
+            bottle={bottle}
+            rackMap={rackMap}
+            cellarId={bottle.cellar}
+            viewMode="card"
+          />
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="bottles-pagination">
+          <button
+            type="button"
+            disabled={page === 0}
+            onClick={() => setPage(p => Math.max(0, p - 1))}
+          >
+            ← {t('bottles.prev', 'Previous')}
+          </button>
+          <span className="bottles-page-indicator">
+            {t('bottles.pageOf', 'Page {{page}} of {{total}}', { page: page + 1, total: totalPages })}
+          </span>
+          <button
+            type="button"
+            disabled={page + 1 >= totalPages}
+            onClick={() => setPage(p => p + 1)}
+          >
+            {t('bottles.next', 'Next')} →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Bottles;

--- a/frontend/src/pages/Statistics.css
+++ b/frontend/src/pages/Statistics.css
@@ -2115,3 +2115,51 @@
   padding: 2rem 1rem;
   line-height: 1.5;
 }
+
+/* ── Clickable chart variants (deep-link to /bottles?filter=…) ───────── */
+.hbar-row--clickable,
+.rating-row--clickable,
+.drink-legend-item--clickable,
+.donut-legend-item--clickable,
+.vintage-bar-wrap--clickable,
+.drink-segment--clickable {
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  text-align: left;
+  width: 100%;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  transition: background-color 0.15s ease, opacity 0.15s ease;
+}
+
+.hbar-row--clickable,
+.rating-row--clickable,
+.drink-legend-item--clickable,
+.donut-legend-item--clickable {
+  padding: 0.15rem 0.35rem;
+  margin: -0.15rem -0.35rem;
+  border-radius: 4px;
+}
+
+.hbar-row--clickable:hover,
+.rating-row--clickable:hover,
+.drink-legend-item--clickable:hover,
+.donut-legend-item--clickable:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.vintage-bar-wrap--clickable:hover .vintage-bar,
+.drink-segment--clickable:hover {
+  filter: brightness(1.2);
+}
+
+.hbar-row--clickable:focus-visible,
+.rating-row--clickable:focus-visible,
+.drink-legend-item--clickable:focus-visible,
+.donut-legend-item--clickable:focus-visible,
+.vintage-bar-wrap--clickable:focus-visible {
+  outline: 2px solid #D4C87A;
+  outline-offset: 1px;
+}

--- a/frontend/src/pages/Statistics.css
+++ b/frontend/src/pages/Statistics.css
@@ -2122,7 +2122,9 @@
 .drink-legend-item--clickable,
 .donut-legend-item--clickable,
 .vintage-bar-wrap--clickable,
-.drink-segment--clickable {
+.drink-segment--clickable,
+.consumption-year-col--clickable,
+.consumption-legend-item--clickable {
   cursor: pointer;
   background: transparent;
   border: none;
@@ -2137,7 +2139,8 @@
 .hbar-row--clickable,
 .rating-row--clickable,
 .drink-legend-item--clickable,
-.donut-legend-item--clickable {
+.donut-legend-item--clickable,
+.consumption-legend-item--clickable {
   padding: 0.15rem 0.35rem;
   margin: -0.15rem -0.35rem;
   border-radius: 4px;
@@ -2146,12 +2149,14 @@
 .hbar-row--clickable:hover,
 .rating-row--clickable:hover,
 .drink-legend-item--clickable:hover,
-.donut-legend-item--clickable:hover {
+.donut-legend-item--clickable:hover,
+.consumption-legend-item--clickable:hover {
   background: rgba(255, 255, 255, 0.05);
 }
 
 .vintage-bar-wrap--clickable:hover .vintage-bar,
-.drink-segment--clickable:hover {
+.drink-segment--clickable:hover,
+.consumption-year-col--clickable:hover .consumption-bar-stack {
   filter: brightness(1.2);
 }
 
@@ -2159,7 +2164,17 @@
 .rating-row--clickable:focus-visible,
 .drink-legend-item--clickable:focus-visible,
 .donut-legend-item--clickable:focus-visible,
-.vintage-bar-wrap--clickable:focus-visible {
+.vintage-bar-wrap--clickable:focus-visible,
+.consumption-year-col--clickable:focus-visible,
+.consumption-legend-item--clickable:focus-visible {
   outline: 2px solid #D4C87A;
   outline-offset: 1px;
+}
+
+/* Reset consumption-year-col width so the button form keeps its column layout */
+.consumption-year-col--clickable {
+  width: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }

--- a/frontend/src/pages/Statistics.css
+++ b/frontend/src/pages/Statistics.css
@@ -2117,6 +2117,10 @@
 }
 
 /* ── Clickable chart variants (deep-link to /bottles?filter=…) ───────── */
+/* Reset the button defaults so the markup-as-button doesn't change the
+   chart's visual layout. Width is intentionally NOT set here — each
+   chart's own selector keeps its natural width (e.g. vintage bars stay
+   26 px wide, hbar rows stretch via their own rule). */
 .hbar-row--clickable,
 .rating-row--clickable,
 .drink-legend-item--clickable,
@@ -2129,11 +2133,16 @@
   background: transparent;
   border: none;
   text-align: left;
-  width: 100%;
   padding: 0;
   color: inherit;
   font: inherit;
   transition: background-color 0.15s ease, opacity 0.15s ease;
+}
+
+/* Row-shaped clickables: stretch to fill the card width */
+.hbar-row--clickable,
+.rating-row--clickable {
+  width: 100%;
 }
 
 .hbar-row--clickable,

--- a/frontend/src/pages/Statistics.js
+++ b/frontend/src/pages/Statistics.js
@@ -417,7 +417,10 @@ function Statistics() {
         {hasPurchaseDates && (
           <div className="stats-card stats-card--desktop-only">
             <h2 className="stats-card-title">{t('statistics.sections.purchasesByYear')}</h2>
-            <PurchaseHistoryChart byPurchaseYear={byPurchaseYear} />
+            <PurchaseHistoryChart
+              byPurchaseYear={byPurchaseYear}
+              onYearClick={(year) => goWithFilter({ purchaseYear: year })}
+            />
           </div>
         )}
 
@@ -436,6 +439,8 @@ function Statistics() {
           <ConsumptionChart
             consumptionByYear={consumptionByYear}
             consumptionByReason={consumptionByReason}
+            onYearClick={(year) => goWithFilter({ consumedYear: year, status: 'consumed' })}
+            onReasonClick={(reason) => goWithFilter({ status: reason })}
           />
         </div>
 

--- a/frontend/src/pages/Statistics.js
+++ b/frontend/src/pages/Statistics.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { getValueHistory } from '../api/stats';
@@ -55,10 +55,22 @@ function EmptyCollection() {
 function Statistics() {
   const { t } = useTranslation();
   const { user, apiFetch } = useAuth();
+  const navigate = useNavigate();
   const [stats, setStats]  = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError]  = useState(null);
   const [valueHistory, setValueHistory] = useState(null);
+
+  // Each chart segment hands us a value; we encode it into a URL on
+  // the cross-cellar /bottles list which then renders just those bottles.
+  const goWithFilter = useCallback((params) => {
+    const qs = new URLSearchParams();
+    for (const [k, v] of Object.entries(params)) {
+      if (v == null || v === '') continue;
+      qs.set(k, String(v));
+    }
+    navigate(`/bottles?${qs.toString()}`);
+  }, [navigate]);
 
   const load = useCallback(async () => {
     try {
@@ -267,17 +279,26 @@ function Statistics() {
           <h2 className="stats-card-title">{t('statistics.sections.wineTypes')}</h2>
           {total > 0 ? (
             <div className="donut-layout">
-              <DonutChart segments={typeSegments} total={total} />
+              <DonutChart
+                segments={typeSegments}
+                total={total}
+                onSegmentClick={(seg) => goWithFilter({ type: seg.type })}
+              />
               <div className="donut-legend">
                 {typeSegments.map(seg => (
-                  <div key={seg.type} className="donut-legend-item">
+                  <button
+                    key={seg.type}
+                    type="button"
+                    className="donut-legend-item donut-legend-item--clickable"
+                    onClick={() => goWithFilter({ type: seg.type })}
+                  >
                     <span className="donut-legend-dot" style={{ background: seg.color }} />
                     <span className="donut-legend-label">{seg.label}</span>
                     <span className="donut-legend-count">{seg.value}</span>
                     <span className="donut-legend-pct">
                       ({total > 0 ? ((seg.value / total) * 100).toFixed(0) : 0}%)
                     </span>
-                  </div>
+                  </button>
                 ))}
               </div>
             </div>
@@ -289,7 +310,12 @@ function Statistics() {
         {/* Drinking Windows */}
         <div className="stats-card">
           <h2 className="stats-card-title">{t('statistics.sections.maturityStatus')}</h2>
-          <MaturityViz maturity={maturity} maturityCoverage={maturityCoverage} total={total} />
+          <MaturityViz
+            maturity={maturity}
+            maturityCoverage={maturityCoverage}
+            total={total}
+            onSegmentClick={(status) => goWithFilter({ maturity: status })}
+          />
         </div>
 
         {/* Vintage Distribution */}
@@ -302,7 +328,10 @@ function Statistics() {
               </span>
             )}
           </h2>
-          <VintageBarChart data={byVintage} />
+          <VintageBarChart
+            data={byVintage}
+            onBarClick={(year) => goWithFilter({ vintage: year })}
+          />
         </div>
 
         {/* World Map (desktop only, hover-based) */}
@@ -317,21 +346,32 @@ function Statistics() {
         {/* Top Origins */}
         <div className="stats-card">
           <h2 className="stats-card-title">{t('statistics.sections.topOrigins')}</h2>
-          <HBarChart data={byCountry} colors={COUNTRY_COLORS} />
+          <HBarChart
+            data={byCountry}
+            colors={COUNTRY_COLORS}
+            onItemClick={(item) => goWithFilter({ country: item.name })}
+          />
         </div>
 
         {/* Top Grape Varieties */}
         <div className="stats-card">
           <h2 className="stats-card-title">{t('statistics.sections.topGrapeVarieties')}</h2>
-          <HBarChart data={byGrape} colors={GRAPE_COLORS} />
+          <HBarChart
+            data={byGrape}
+            colors={GRAPE_COLORS}
+            onItemClick={(item) => goWithFilter({ grapes: item.name })}
+          />
         </div>
 
         {/* Top Regions */}
         {byRegion && byRegion.length > 0 && (
           <div className="stats-card">
             <h2 className="stats-card-title">{t('statistics.sections.topRegions')}</h2>
-            <HBarChart data={byRegion}
-              colors={['#7aade0', '#6a9dd0', '#5a8dc0', '#4a7db0', '#3a6da0']} />
+            <HBarChart
+              data={byRegion}
+              colors={['#7aade0', '#6a9dd0', '#5a8dc0', '#4a7db0', '#3a6da0']}
+              onItemClick={(item) => goWithFilter({ region: item.name })}
+            />
           </div>
         )}
 
@@ -339,22 +379,37 @@ function Statistics() {
         {hasProducers && (
           <div className="stats-card">
             <h2 className="stats-card-title">{t('statistics.sections.topProducers')}</h2>
-            <HBarChart data={topProducers}
-              colors={['#D4A070', '#C4906A', '#B48064', '#A4705E', '#946058']} />
+            <HBarChart
+              data={topProducers}
+              colors={['#D4A070', '#C4906A', '#B48064', '#A4705E', '#946058']}
+              onItemClick={(item) => goWithFilter({ producer: item.name })}
+            />
           </div>
         )}
 
         {/* Rating Distribution */}
         <div className="stats-card">
           <h2 className="stats-card-title">{t('statistics.sections.ratingDistribution')}</h2>
-          <RatingChart byRating={byRating} avg={overview.avgRating} targetScale={targetScale} />
+          <RatingChart
+            byRating={byRating}
+            avg={overview.avgRating}
+            targetScale={targetScale}
+            onBandClick={(band) => {
+              // band.key is "0-20" / "21-40" / "41-60" / "61-80" / "81-100"
+              const min = parseInt(String(band.key).split('-')[0], 10);
+              goWithFilter({ minRating: isNaN(min) ? '' : String(min) });
+            }}
+          />
         </div>
 
         {/* Bottle Sizes */}
         {hasMultipleSizes && (
           <div className="stats-card">
             <h2 className="stats-card-title">{t('statistics.sections.bottleSizes')}</h2>
-            <BottleSizeChart byBottleSize={byBottleSize} />
+            <BottleSizeChart
+              byBottleSize={byBottleSize}
+              onSizeClick={(size) => goWithFilter({ bottleSize: size })}
+            />
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Clicking any chart segment / row / legend item on the Statistics page now navigates to a new **/bottles** page with the matching filter pre-applied. Numbers on Statistics and the resulting bottle list always agree because both endpoints use the same scope: **cellars the user OWNS** (shared/read-only cellars are excluded).

Try it from the wine-type donut: click \"Red\" → \"/bottles?type=red\" → shows every red wine across all your cellars, with a chip you can remove to broaden the view.

## Backend

- **New endpoint**: \"GET /api/bottles\" cross-cellar list, with filters: \"search, type, country, region, grapes, vintage, producer, bottleSize, minRating, maturity, sort, limit, offset\".
- \"country / region / grapes\" accept either ObjectIds or display names — Statistics aggregates by display name, so resolving on the fly keeps the deep-links trivial. Names that don't match return an empty list (no error).
- \"producer\" matches via an anchored case-insensitive regex on the free-text field; \"bottleSize\" is an exact string match on the bottle.
- Scope is identical to \"GET /api/stats/overview\" (only the user's owned cellars), so counts match.

## Frontend

- **New /bottles page**: reads filters from the URL, renders \"BottleCard\"s in a responsive grid, supports per-chip removal + Clear All + pagination, links back to /statistics.
- **Charts** (DonutChart, HBarChart, VintageBarChart, RatingChart, MaturityViz, BottleSizeChart) now accept optional click props. When provided, segments render as buttons with subtle hover + focus styling. Non-clickable callers (e.g. the public stats card) keep their existing static rendering.
- Wine-type donut **legend rows** are also clickable.

## Wired filters

| Chart | Filter | URL |
| --- | --- | --- |
| Wine Types donut + legend | type | \`/bottles?type=red\` |
| Maturity Status bar + legend | maturity | \`/bottles?maturity=peak\` |
| Vintage Distribution bars | vintage | \`/bottles?vintage=2018\` |
| Top Origins (countries) | country | \`/bottles?country=France\` |
| Top Grape Varieties | grapes | \`/bottles?grapes=Pinot Noir\` |
| Top Regions | region | \`/bottles?region=Burgundy\` |
| Top Producers | producer | \`/bottles?producer=Domaine Leflaive\` |
| Rating Distribution | minRating | \`/bottles?minRating=61\` |
| Bottle Sizes | bottleSize | \`/bottles?bottleSize=750ml\` |

## Out of scope

- **WorldMapChart**: the choropleth path isn't a simple bar/segment shape and warrants its own UX pass. Top Origins HBarChart already covers country drill-down.
- **Shared filter helper**: the new endpoint duplicates the MongoDB filter path from \`GET /api/cellars/:id\` for now (~120 lines). Stable enough that the duplication is acceptable for this PR; can be refactored later.

## Test plan

- [x] Backend: 512/512 tests pass
- [x] Frontend: 275/275 tests pass
- [x] Build succeeds
- [ ] Smoke in browser: click each clickable item on /statistics and verify the matching bottle list renders with the correct chips
- [ ] Verify counts agree with the chart (e.g. \"Red: 24\" on donut → /bottles?type=red shows 24 total)
- [ ] Verify chip removal broadens the view (e.g. remove \"Type: Red\" → all bottles)
- [ ] Verify pagination works on large filtered lists