### PR TITLE
fix(nginx): always send no-cache for the SPA index.html

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -222,17 +222,27 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
-    # Serve the React SPA — fall back to index.html for client-side routing
+    # Serve the React SPA — fall back to index.html for client-side routing.
+    # The SPA shell goes through a named-location fallback so the no-cache
+    # header reliably applies, even when /index.html is served as the result
+    # of an internal try_files redirect from /cellars/123 / /bottles / etc.
     location / {
         root       /usr/share/nginx/html;
         index      index.html;
-        try_files  $uri $uri/ /index.html;
+        try_files  $uri $uri/ @spa_shell;
+    }
 
-        # index.html must never be cached — it references hashed JS/CSS
-        # bundles that change on every build
-        location = /index.html {
-            add_header Cache-Control "no-cache, no-store, must-revalidate";
-        }
+    # The SPA shell (index.html) references hashed JS/CSS bundles that
+    # change on every build. Without no-cache, a browser that hangs on to
+    # a stale index.html after a deploy will request asset hashes that no
+    # longer exist (404) — observed after v1.54.2. `always` ensures the
+    # header is emitted even on 304/non-2xx responses.
+    location @spa_shell {
+        root              /usr/share/nginx/html;
+        add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header        Pragma                                "no-cache"  always;
+        add_header        Expires                               "0"         always;
+        try_files         /index.html =404;
     }
 
     # Long-lived cache for hashed static assets


### PR DESCRIPTION
## Why

A user reported these errors after deploying v1.54.2 to production:

> \`(index):84 Executing inline script violates CSP …\`
> \`GET https://cellarion.app/assets/index-w1OeoJ4R.js net::ERR_ABORTED 404\`

Both come from the browser holding on to a **stale \`index.html\`** across deploys. The cached HTML references the old build's hashed asset bundles (which no longer exist in v1.54.2) and contains older inline script that the current CSP no longer allows.

## Root cause

Our nginx config tried to set \`Cache-Control: no-cache\` on \`index.html\`, but the rule lived inside a nested \`location = /index.html\` block:

\`\`\`nginx
location / {
    try_files $uri $uri/ /index.html;     # SPA fallback
    location = /index.html {
        add_header Cache-Control "no-cache, no-store, must-revalidate";
    }
}
\`\`\`

When a user visits \`/cellars/123\` or any client-side route, nginx serves the SPA shell via the try_files fallback. The internal redirect to \`/index.html\` did not reliably match the nested exact-path location, so the no-cache header was skipped on most page loads. Browsers cached the HTML; the next deploy broke for them until a hard refresh.

## Fix

Switch to a named-location fallback (\`@spa_shell\`). Every SPA route now flows through it; the headers are guaranteed to apply. Also adds \`Pragma\` + \`Expires\` for older proxies that don't honour \`Cache-Control\`, and \`always\` so the header is emitted on 304/non-2xx responses too.

Static asset cache headers (1y / immutable) are untouched.

## Test plan

- [x] \`nginx -t\` validates the config syntax
- [ ] After deploy: \`curl -sI https://cellarion.app/\` shows \`Cache-Control: no-cache, no-store, must-revalidate\`
- [ ] \`curl -sI https://cellarion.app/cellars/123\` shows the same
- [ ] \`curl -sI https://cellarion.app/assets/index-XXXX.js\` still shows \`Cache-Control: public, immutable\`
- [ ] Next deploy: users no longer need to hard-refresh