### PR TITLE
chore(release): v1.54.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.54.2",
+  "version": "1.54.3",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.54.2",
+  "version": "1.54.3",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary

Patch release containing **PR #429** — nginx now reliably sends no-cache headers on the SPA shell.

What's in this release vs v1.54.2:

- **fix(nginx):** always send no-cache for the SPA index.html (#429). Without this, browsers held on to a stale \`index.html\` across deploys; the next release's hashed asset bundles then 404'd until a hard refresh. Symptom on v1.54.2 deploy: CSP violation on inline script + 404 on an old \`/assets/index-XXXX.js\`.

Static asset caching (1y / immutable) is unchanged. No data migration.

## Test plan

- [x] \`nginx -t\` validates the config
- [ ] After deploy: \`curl -sI https://cellarion.app/\` shows \`Cache-Control: no-cache, no-store, must-revalidate\`
- [ ] \`curl -sI https://cellarion.app/cellars/123\` (SPA route) shows the same
- [ ] \`curl -sI https://cellarion.app/assets/index-XXXX.js\` still shows \`Cache-Control: public, immutable\`
- [ ] Next deploy after this one: users no longer need to hard-refresh