### PR TITLE
fix(blog): style tables and attribution boxes in article content

### DIFF
--- a/frontend/src/pages/Blog.css
+++ b/frontend/src/pages/Blog.css
@@ -301,6 +301,48 @@
   margin: 2rem 0;
 }
 
+.blog-article-content aside.post-attribution {
+  background: var(--bg-secondary);
+  border-left: 3px solid var(--accent);
+  padding: 0.9rem 1.25rem;
+  margin: 0 0 1.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.blog-article-content aside.post-attribution p {
+  margin: 0;
+}
+
+.blog-article-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+}
+
+.blog-article-content th,
+.blog-article-content td {
+  padding: 0.6rem 0.8rem;
+  border: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.blog-article-content thead th {
+  background: var(--bg-secondary);
+  font-weight: 600;
+}
+
+.blog-article-content tbody tr:nth-child(even) {
+  background: var(--bg-secondary);
+}
+
+.blog-article-content table td[colspan] {
+  background: var(--bg-card);
+  font-size: 1rem;
+}
+
 .blog-post-footer {
   margin-top: 3rem;
   padding-top: 1.5rem;
@@ -320,5 +362,11 @@
 
   .blog-article-content {
     font-size: 1rem;
+  }
+
+  .blog-article-content table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
## Summary

Blog posts can now use `<table>` and `<aside class=\"post-attribution\">` and have them render with proper visual structure — currently both render as unstyled inline text, which makes reference tables (e.g. drink-window tables, comparison tables) unreadable.

**What's added to `Blog.css`:**

- `aside.post-attribution` — accent-bordered callout box for editorial/author attribution at the top of articles
- `<table>` / `<thead>` / `<tbody>` / `<th>` / `<td>` — bordered, zebra-striped, with header-row highlight
- Group-row support via `td[colspan]` — for tables that visually section their rows
- Mobile (< 600px): tables become horizontally scrollable instead of breaking the layout

No JavaScript changes. No new dependencies.

> **Editor note:** TipTap's StarterKit doesn't include a table extension, so pasting HTML with `<table>` into the rich-text view silently strips the tags. To use tables in posts today, switch on the **Show source** toggle in the editor before pasting. A follow-up PR could add `@tiptap/extension-table` so tables also work in the WYSIWYG view.

## Test plan

- [ ] Open an existing blog post and confirm rendering is unchanged
- [ ] Create a draft post with a `<table>` and confirm header row, borders, and zebra striping render
- [ ] Create a draft post with `<aside class=\"post-attribution\">` and confirm the callout box renders with accent border
- [ ] Resize to < 600px and confirm tables scroll horizontally instead of overflowing the page