### PR TITLE
chore(release): v1.55.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.54.3",
+  "version": "1.55.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.54.3",
+  "version": "1.55.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Minor release containing **PR #432** (new feature) and **PR #431** (UI fix).

## What's in this release vs v1.54.3

### Features
- **feat(admin):** platform-wide aggregate stats page for admins (#432). New `/admin/stats` dashboard surfacing anonymised, cross-user statistics in 14 sections — overview, engagement (DAU/WAU/MAU), 30/90-day activity, 12-month bar-chart trends, subscriptions, drink-window maturity distribution, ratings & quality, vintage spread, top countries/regions/grapes/producers, most-collected wines, most expensive bottles, value by currency (avg + median), library health (pending profiles / wine requests / image reviews), holding-time + cellar-size + bottle-size distributions. Includes an **Exclude admin users** toggle that filters every per-user statistic, a 5-minute in-memory cache with `?force=true` bypass on the Refresh button, full English + Swedish i18n, and a privacy disclaimer on the page. No PII surfaced. Admin-only — `requireAuth + requireRole('admin')`.

### Fixes
- **fix(blog):** style tables and attribution boxes in article content (#431). Blog posts can now use `<table>` (bordered, zebra-striped, header highlight, mobile-scrollable) and `<aside class="post-attribution">` (accent-bordered callout). Previously both rendered as unstyled inline text, making reference tables unreadable.

### Schema
- Adds an index on `User.roles` to support the admin-lookup pass when `excludeAdmins=true` is set on the stats endpoint.

No data migration required.

## Test plan

- [ ] `npm test` passes in both `backend/` and `frontend/`
- [ ] Smoke-test in Docker: `docker compose up --build` boots
- [ ] As admin, navigate to `/admin/stats` and confirm all sections render
- [ ] Toggle **Exclude admin users** and confirm numbers drop (indicator shows hidden admin count)
- [ ] Click **Refresh** and confirm the *cached* tag disappears (cache bust)
- [ ] As non-admin, hit `/admin/stats` and confirm 403 / redirect
- [ ] Open any existing blog post and confirm rendering is unchanged
- [ ] Create a draft blog post with a `<table>` (via the Show source toggle in the editor) and confirm header row + borders + zebra striping render
- [ ] Verify the Swedish locale switches all admin-stats labels correctly