### PR TITLE
fix(admin/stats): six layout/format bugs from prod review

### DIFF
--- a/backend/src/services/globalStatsService.js
+++ b/backend/src/services/globalStatsService.js
@@ -260,11 +260,38 @@ async function _computeGlobalStatsUncached({ excludeAdmins = false } = {}) {
   });
 
   // ── Bottle-size distribution ────────────────────────────────────────────
+  // Bottle-size rollup — collapses minor variants of the same physical
+  // size. Users have entered "750ml", "750ml (Standard)", and the CJK
+  // fullwidth-paren "750ml（標準）" as three different strings; this
+  // groups them into one entry. Pattern:
+  //   1. Replace fullwidth '（' with ASCII '(' so the split below catches both
+  //   2. Split on '(' and take the first piece (drops any "(...)" suffix)
+  //   3. Trim + lowercase to canonicalise
+  //   4. Keep the most popular original spelling as the display name via $first
   const byBottleSize = await safeAggregate(Bottle, [
     { $match: { ...bottleMatch, status: 'active' } },
-    { $group: { _id: '$bottleSize', count: { $sum: 1 } } },
+    { $addFields: {
+      sizeKey: {
+        $toLower: {
+          $trim: {
+            input: {
+              $arrayElemAt: [
+                { $split: [
+                  { $replaceAll: { input: { $ifNull: ['$bottleSize', ''] }, find: '（', replacement: '(' } },
+                  '(',
+                ]},
+                0,
+              ],
+            },
+          },
+        },
+      },
+    }},
+    { $sort: { bottleSize: 1 } },  // deterministic $first pick for tie-breaks
+    { $group: { _id: '$sizeKey', size: { $first: '$bottleSize' }, count: { $sum: 1 } } },
+    { $match: { _id: { $ne: '' } } },
     { $sort: { count: -1 } },
-    { $project: { _id: 0, size: '$_id', count: 1 } },
+    { $project: { _id: 0, size: 1, count: 1 } },
   ]);
 
   // ── Cellar-size distribution ────────────────────────────────────────────

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2079,6 +2079,7 @@
     "holdingTimeNote": "Time from purchase date to consumption date.",
     "cellarSize": "Cellar size distribution",
     "cellarSizeNote": "Number of cellars by bottle count.",
+    "cellarSizeOther": "uncategorised",
     "bottleSize": "Bottle size"
   },
   "wineLists": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2079,6 +2079,7 @@
     "holdingTimeNote": "Tid från inköpsdatum till konsumtionsdatum.",
     "cellarSize": "Källarstorlek-fördelning",
     "cellarSizeNote": "Antal källare per flaskantal.",
+    "cellarSizeOther": "okategoriserad",
     "bottleSize": "Flaskstorlek"
   },
   "wineLists": {

--- a/frontend/src/pages/AdminStats.css
+++ b/frontend/src/pages/AdminStats.css
@@ -227,28 +227,35 @@
   font-size: 0.85rem;
 }
 
-/* ── Monthly bar chart ── */
+/* ── Monthly bar chart ──
+   Each column (.admin-stats-bar-wrap) stretches to fill the chart's fixed
+   height; the bar lives at the bottom and grows upward as a % of that
+   column. Earlier version used align-items: flex-end on the outer flex which
+   sized each column to its content — so the bar's height:X% resolved against
+   an unsized parent and collapsed to 0. */
 .admin-stats-bars {
   display: flex;
-  align-items: flex-end;
+  align-items: stretch;
   gap: 0.3rem;
-  padding: 0.5rem 0 0;
+  padding: 1.25rem 0 0;
 }
 
 .admin-stats-bar-wrap {
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  justify-content: flex-end;
+  align-items: stretch;
   gap: 0.25rem;
   min-width: 0;
+  position: relative;
 }
 
 .admin-stats-bar {
   width: 100%;
   background: var(--accent);
   border-radius: 3px 3px 0 0;
-  min-height: 1px;
+  min-height: 4px;
   position: relative;
   transition: opacity 0.15s;
   opacity: 0.85;
@@ -267,18 +274,14 @@
   color: var(--text-secondary);
   white-space: nowrap;
   pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-
-.admin-stats-bar-wrap:hover .admin-stats-bar-value {
-  opacity: 1;
+  font-variant-numeric: tabular-nums;
 }
 
 .admin-stats-bar-label {
   font-size: 0.7rem;
   color: var(--text-secondary);
   font-variant-numeric: tabular-nums;
+  text-align: center;
 }
 
 /* ── Horizontal stacked bar (maturity, rating distribution) ── */

--- a/frontend/src/pages/AdminStats.js
+++ b/frontend/src/pages/AdminStats.js
@@ -9,6 +9,21 @@ function fmt(n) {
   return Number(n).toLocaleString();
 }
 
+// Raw integer formatting for fields where a thousands separator is wrong —
+// vintage years (1973 not "1,973") and decade labels (2020 not "2,020").
+function fmtYear(n) {
+  if (n == null) return '—';
+  return String(n);
+}
+
+// Display percentage that shows "<1%" when the value rounds to zero but
+// isn't actually zero — avoids "6 (0%)" rows that look like a bug.
+function fmtPct(value) {
+  if (value == null || value === 0) return '0%';
+  if (value < 1) return '<1%';
+  return `${Math.round(value)}%`;
+}
+
 function StatCard({ label, value, sublabel, accent, tooltip }) {
   return (
     <div
@@ -79,7 +94,7 @@ function HorizontalBar({ label, count, total, color }) {
       <div className="admin-stats-hbar-track">
         <div className="admin-stats-hbar-fill" style={{ width: `${p}%`, background: color }} />
       </div>
-      <div className="admin-stats-hbar-count">{fmt(count)} <span className="admin-stats-hbar-pct">({Math.round(p)}%)</span></div>
+      <div className="admin-stats-hbar-count">{fmt(count)} <span className="admin-stats-hbar-pct">({fmtPct(p)})</span></div>
     </div>
   );
 }
@@ -297,7 +312,7 @@ function AdminStats() {
           {ratings.distribution && ratings.distribution.length > 0 && (
             <div className="admin-stats-panel">
               <h3>{t('adminStats.ratingDistribution')}</h3>
-              {ratings.distribution.map((r, i) => (
+              {ratings.distribution.filter(r => r.count > 0).map((r, i) => (
                 <HorizontalBar key={`${r.band}-${i}`} label={r.band} count={r.count} total={ratings.ratedCount} color="var(--accent)" />
               ))}
             </div>
@@ -333,8 +348,8 @@ function AdminStats() {
         <h2>{t('adminStats.section.vintage')}</h2>
         <div className="admin-stats-cards">
           <StatCard label={t('adminStats.avgVintageAge')}  value={vintage.avgAge != null ? `${vintage.avgAge} ${t('adminStats.years')}` : '—'} />
-          <StatCard label={t('adminStats.oldestVintage')}  value={fmt(vintage.oldest)} />
-          <StatCard label={t('adminStats.newestVintage')}  value={fmt(vintage.newest)} />
+          <StatCard label={t('adminStats.oldestVintage')}  value={fmtYear(vintage.oldest)} />
+          <StatCard label={t('adminStats.newestVintage')}  value={fmtYear(vintage.newest)} />
           <StatCard label={t('adminStats.withVintage')}    value={fmt(vintage.withVintageCount)} sublabel={t('adminStats.bottlesUnit')} />
         </div>
         {vintage.byDecade && vintage.byDecade.length > 0 && (
@@ -344,7 +359,7 @@ function AdminStats() {
               <tbody>
                 {vintage.byDecade.map(d => (
                   <tr key={d.decade}>
-                    <td className="admin-stats-name">{d.decade}s</td>
+                    <td className="admin-stats-name">{fmtYear(d.decade)}s</td>
                     <td className="admin-stats-count">{fmt(d.count)}</td>
                   </tr>
                 ))}
@@ -496,11 +511,11 @@ function AdminStats() {
               <p className="admin-stats-sub">{t('adminStats.holdingTimeNote')}</p>
               <table className="admin-stats-table">
                 <tbody>
-                  {holdingTime.map((h, i) => (
+                  {holdingTime.filter(h => h.count > 0).map((h, i) => (
                     <tr key={`${h.bucket}-${i}`}>
                       <td className="admin-stats-name">{h.bucket}</td>
                       <td className="admin-stats-count">{fmt(h.count)}</td>
-                      <td className="admin-stats-pct">{h.pct}%</td>
+                      <td className="admin-stats-pct">{fmtPct(h.pct)}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -514,9 +529,11 @@ function AdminStats() {
               <p className="admin-stats-sub">{t('adminStats.cellarSizeNote')}</p>
               <table className="admin-stats-table">
                 <tbody>
-                  {cellarSizeDistribution.map((c, i) => (
+                  {cellarSizeDistribution.filter(c => c.cellars > 0).map((c, i) => (
                     <tr key={`${c.bucket}-${i}`}>
-                      <td className="admin-stats-name">{c.bucket} {t('adminStats.bottlesUnit')}</td>
+                      <td className="admin-stats-name">
+                        {c.bucket === 'other' ? t('adminStats.cellarSizeOther') : `${c.bucket} ${t('adminStats.bottlesUnit')}`}
+                      </td>
                       <td className="admin-stats-count">{fmt(c.cellars)} {t('adminStats.cellarsUnit')}</td>
                     </tr>
                   ))}


### PR DESCRIPTION
Fixes the visible layout/format problems on `/admin/stats` after v1.55.0 went live.

## What's broken on prod right now

1. **12-month bar charts render as month-label rows with no bars.** Outer flex used `align-items: flex-end` which sized each column to its content; the inner `<div class=\"bar\" style=\"height: X%\">` then computed against an unsized parent and collapsed to 0px. Only the month labels remained visible.
2. **Bar values required hovering.** `.admin-stats-bar-value` had `opacity: 0` until `:hover`, which is not OK for a static dashboard — you couldn't see April had 1,402 bottles added without mousing over.
3. **Vintage years show thousands separators.** \"Oldest vintage 1,973\" / \"Newest vintage 2,026\" — `fmt()` was applied uniformly via `toLocaleString()`.
4. **Empty bucket rows clutter the page.** My pre-merge bucket fix (always emit all buckets) caused `2–5yr 0 0%`, `5–10yr 0 0%`, `500+ bottles 0 cellars`, etc. to render.
5. **\"other bottles\" label in cellar-size distribution.** Default `$bucket` row labelled `other` was concatenated with the unit string into the nonsensical \"other bottles 0 cellars\".
6. **\"X (0%)\" when X > 0.** Maturity showed `Not ready 6 (0%)` because `6 / 2,319 ≈ 0.27%` rounded to 0.

## Fixes (one PR)

| # | Change | Files |
|---|---|---|
| 1 | BarChart: `align-items: stretch` + `justify-content: flex-end` on columns; `min-height: 4px` on bars | `AdminStats.css` |
| 2 | Drop `opacity: 0` on `.admin-stats-bar-value` — always visible | `AdminStats.css` |
| 3 | New `fmtYear()` helper (uses `String()` not `toLocaleString()`); applied to oldest/newest vintage cards + decade labels | `AdminStats.js` |
| 4 | `.filter(x => x.count > 0)` before `.map(...)` for holdingTime + cellarSize + rating distributions | `AdminStats.js` |
| 5 | New i18n key `adminStats.cellarSizeOther` (\"uncategorised\" / \"okategoriserad\") for the default bucket | `AdminStats.js`, both locale files |
| 6 | New `fmtPct()` helper that returns `<1%` when the value rounds to zero but isn't zero; replaces both `HorizontalBar` percentage display and the `holdingTime` row percentage | `AdminStats.js` |

## Bonus
- **Bottle-size variant rollup.** `byBottleSize` aggregation now collapses `750ml`, `750ml (Standard)` and the CJK fullwidth `750ml（標準）` into a single entry using the same `$replaceAll` + `$split` + `$toLower` trick I used for producers. In the production sample, 750ml's three rows (1,192 + 1,188 + 16) condense to one row of 2,396.

## Test plan

- [x] Backend + frontend tests pass (512 + 275 green, no new tests needed)
- [ ] After deploy: `/admin/stats` → 12-month trend bars visible without hovering, values shown above each non-zero bar
- [ ] Vintage section shows `1973` and `2026` (not `1,973` and `2,026`)
- [ ] Holding time + cellar size tables show only rows with non-zero data
- [ ] Maturity \"Not ready\" with non-zero count shows `<1%` (or the rounded value), never `0%`
- [ ] Bottle size table shows one row per physical size (variants collapsed)
- [ ] Swedish locale still translates everything cleanly