### PR TITLE
chore(release): v1.55.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.55.0",
+  "version": "1.55.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.55.0",
+  "version": "1.55.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Patch release containing **PR #434** — six layout/format fixes on the `/admin/stats` page after v1.55.0 went live.

## What's in this release vs v1.55.0

### Fixes
- **fix(admin/stats):** six layout/format bugs from prod review (#434).
  1. 12-month BarChart bars rendered at 0px height (flex sizing bug).
  2. Bar values required hovering to see — now always visible.
  3. Vintage years showed thousands separators (`1,973` → `1973`).
  4. Empty bucket rows were always rendered (holding time / cellar size / rating distribution); now hidden when count is zero.
  5. "other bottles" label in cellar-size distribution → "uncategorised" via new i18n key.
  6. `X (0%)` when X > 0 → `<1%` via new `fmtPct()` helper.

### Bonus
- **Bottle-size variant rollup**: `750ml`, `750ml (Standard)` and CJK fullwidth `750ml（標準）` now collapse into a single row in the admin stats aggregation.

No schema changes. No data migration.

## Test plan

- [ ] `npm test` passes in both `backend/` and `frontend/`
- [ ] After deploy: `/admin/stats` 12-month trend bars render correctly with always-visible values
- [ ] Vintage section shows `1973` / `2026` without commas
- [ ] Holding time + cellar size tables only show rows with non-zero data
- [ ] Maturity "Not ready" with a non-zero count shows `<1%` instead of `0%`
- [ ] Bottle size table collapses 750ml variants into a single entry