### PR TITLE
feat(price-sanity): non-blocking warnings on bottle add + import preview (Tier 1)

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -19,6 +19,7 @@ const { resolveRating } = require('../utils/ratingUtils');
 const { embedSinglePair } = require('../services/embeddingJob');
 const { CONSUMED_STATUSES, WINE_POPULATE } = require('../config/constants');
 const { checkRestockGap, resolveRestockAlerts } = require('../services/restockChecker');
+const { gatherPriceWarnings } = require('../services/priceWarnings');
 const { stripHtml, isSafeUrl } = require('../utils/sanitize');
 const { parseAndValidateVintage } = require('../utils/validation');
 const { toNormalized } = require('../utils/ratingUtils');
@@ -461,7 +462,25 @@ router.post('/', async (req, res) => {
     // Fire-and-forget: auto-resolve any restock alerts for this wine
     resolveRestockAlerts(req.user.id, wineDefinition, bottle._id).catch(() => {});
 
-    res.status(201).json({ bottle });
+    // Non-blocking sanity warnings on the entered price. Surfaced in the
+    // response so the form can highlight a likely mistake (100×, cents-as-
+    // units, etc.) without rejecting the save. See utils/priceValidation.
+    let priceWarnings = [];
+    if (typeof price === 'number' && price > 0) {
+      try {
+        priceWarnings = await gatherPriceWarnings({
+          price,
+          currency: currency || 'USD',
+          userId: cellarDoc.user,
+          wineDefinitionId: wineDefinition,
+          vintage: canonicalVintage,
+        });
+      } catch (err) {
+        console.warn('Price-warning gather failed (non-fatal):', err.message);
+      }
+    }
+
+    res.status(201).json({ bottle, priceWarnings });
   } catch (error) {
     console.error('Create bottle error:', error);
     res.status(500).json({ error: 'Failed to create bottle' });

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -29,6 +29,8 @@ const { extractAiExplanation } = require('../utils/jsonExtract');
 const { getMaxPosition } = require('../utils/rackGeometry');
 const { planRackCreations, placeBottlesInRack, VALID_ANCHORS, DEFAULT_ANCHOR } = require('../utils/rackImport');
 const { RACK_TYPES } = require('../models/Rack');
+const { validatePriceSanity } = require('../utils/priceValidation');
+const { computeUserMediansByCurrency } = require('../services/priceWarnings');
 const { runConcurrent } = require('../utils/concurrency');
 const WineRequest = require('../models/WineRequest');
 const ImportSession = require('../models/ImportSession');
@@ -351,6 +353,25 @@ router.post('/validate', async (req, res) => {
       results.push(result);
     }
 
+    // ── Per-item price sanity warnings (non-blocking) ────────────────────────
+    // Computes the user's per-currency median ONCE from the active cellar
+    // and reuses it for every row, instead of querying per-bottle.
+    // Wine-vintage market price is skipped here (matches resolve later when
+    // the user picks a candidate). See utils/priceValidation.
+    const userMedians = await computeUserMediansByCurrency(cellar.user);
+    for (const r of results) {
+      const price = Number(r.item?.price);
+      if (!isFinite(price) || price <= 0) continue;
+      const currency = (r.item?.currency || 'USD').toUpperCase();
+      const m = userMedians[currency];
+      r.priceWarnings = validatePriceSanity({
+        price,
+        currency,
+        userMedianPrice:  m?.median ?? null,
+        userMedianSample: m?.sample ?? 0,
+      });
+    }
+
     res.json({
       cellarId,
       results,
@@ -360,7 +381,8 @@ router.post('/validate', async (req, res) => {
         fuzzy: results.filter(r => r.status === 'fuzzy').length,
         aiMatch: results.filter(r => r.status === 'ai_match').length,
         noMatch: results.filter(r => r.status === 'no_match').length,
-        errors: results.filter(r => r.status === 'error').length
+        errors: results.filter(r => r.status === 'error').length,
+        priceWarnings: results.filter(r => r.priceWarnings?.length).length
       }
     });
   } catch (error) {

--- a/backend/src/services/priceWarnings.js
+++ b/backend/src/services/priceWarnings.js
@@ -47,10 +47,29 @@ async function gatherPriceWarnings({
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+// Coerce a possibly-user-supplied id to either a plain hex string ObjectId
+// or a real Mongoose ObjectId instance. Anything else (an injected operator
+// object, a non-hex string) returns null, which short-circuits the query.
+// Used to defuse CodeQL js/sql-injection on req.body values that reach $match.
+function safeObjectIdLike(v) {
+  if (v == null) return null;
+  if (typeof v === 'string') return /^[a-f0-9]{24}$/i.test(v) ? v : null;
+  // Mongoose ObjectId / BSON ObjectId
+  if (typeof v === 'object' && typeof v.toHexString === 'function') return v;
+  return null;
+}
+
+function safeString(v) {
+  if (v == null) return null;
+  return typeof v === 'string' ? v : null;
+}
+
 async function resolveUserMedian(userId, currency) {
-  if (!userId) return { median: null, sample: 0 };
+  const uid = safeObjectIdLike(userId);
+  const cur = safeString(currency);
+  if (!uid || !cur) return { median: null, sample: 0 };
   const rows = await Bottle
-    .find({ user: userId, currency, price: { $gt: 0 } })
+    .find({ user: uid, currency: cur, price: { $gt: 0 } })
     .select('price')
     .sort({ price: 1 })
     .lean();
@@ -62,9 +81,12 @@ async function resolveUserMedian(userId, currency) {
 }
 
 async function resolveMarketMedian(wineDefinitionId, vintage, currency) {
-  if (!wineDefinitionId || !vintage || vintage === 'NV' || vintage === 'Unknown') return null;
+  const wd  = safeObjectIdLike(wineDefinitionId);
+  const v   = safeString(vintage);
+  const cur = safeString(currency);
+  if (!wd || !v || !cur || v === 'NV' || v === 'Unknown') return null;
   const snapshot = await WineVintagePrice
-    .findOne({ wineDefinition: wineDefinitionId, vintage, currency })
+    .findOne({ wineDefinition: wd, vintage: v, currency: cur })
     .sort({ setAt: -1 })
     .lean();
   return snapshot?.price ?? null;
@@ -78,9 +100,10 @@ async function resolveMarketMedian(wineDefinitionId, vintage, currency) {
  * Returns `{ USD: { median, sample }, EUR: { median, sample }, ... }`.
  */
 async function computeUserMediansByCurrency(userId) {
-  if (!userId) return {};
+  const uid = safeObjectIdLike(userId);
+  if (!uid) return {};
   const rows = await Bottle.aggregate([
-    { $match: { user: userId, price: { $gt: 0 } } },
+    { $match: { user: uid, price: { $gt: 0 } } },
     { $sort: { currency: 1, price: 1 } },
     { $group: {
       _id: '$currency',

--- a/backend/src/services/priceWarnings.js
+++ b/backend/src/services/priceWarnings.js
@@ -1,0 +1,99 @@
+/**
+ * Thin DB-backed wrapper around the pure validatePriceSanity helper —
+ * resolves the user's median bottle price + the latest WineVintagePrice
+ * for this wine+vintage, then runs the sanity rules.
+ *
+ * Used by POST /api/bottles and the import preview/confirm endpoints to
+ * surface non-blocking warnings at the moment a price is being entered.
+ */
+const Bottle = require('../models/Bottle');
+const WineVintagePrice = require('../models/WineVintagePrice');
+const { validatePriceSanity } = require('../utils/priceValidation');
+
+/**
+ * @param {object} input
+ * @param {number}        input.price
+ * @param {string}        [input.currency='USD']
+ * @param {ObjectId|null} [input.userId]
+ * @param {ObjectId|null} [input.wineDefinitionId]
+ * @param {string|null}   [input.vintage]
+ * @returns {Promise<Array>}
+ */
+async function gatherPriceWarnings({
+  price,
+  currency = 'USD',
+  userId = null,
+  wineDefinitionId = null,
+  vintage = null,
+} = {}) {
+  // Cheap exit — no price, no warnings to gather, no DB queries.
+  if (typeof price !== 'number' || !isFinite(price) || price <= 0) return [];
+
+  const cur = (currency || 'USD').toUpperCase();
+
+  const [userMedian, marketPrice] = await Promise.all([
+    resolveUserMedian(userId, cur),
+    resolveMarketMedian(wineDefinitionId, vintage, cur),
+  ]);
+
+  return validatePriceSanity({
+    price,
+    currency: cur,
+    userMedianPrice:   userMedian.median,
+    userMedianSample:  userMedian.sample,
+    marketMedianPrice: marketPrice,
+  });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function resolveUserMedian(userId, currency) {
+  if (!userId) return { median: null, sample: 0 };
+  const rows = await Bottle
+    .find({ user: userId, currency, price: { $gt: 0 } })
+    .select('price')
+    .sort({ price: 1 })
+    .lean();
+  if (rows.length === 0) return { median: null, sample: 0 };
+  return {
+    median: rows[Math.floor(rows.length / 2)].price,
+    sample: rows.length,
+  };
+}
+
+async function resolveMarketMedian(wineDefinitionId, vintage, currency) {
+  if (!wineDefinitionId || !vintage || vintage === 'NV' || vintage === 'Unknown') return null;
+  const snapshot = await WineVintagePrice
+    .findOne({ wineDefinition: wineDefinitionId, vintage, currency })
+    .sort({ setAt: -1 })
+    .lean();
+  return snapshot?.price ?? null;
+}
+
+/**
+ * Bulk-fetch the user's per-currency median bottle price + sample size in a
+ * single Mongo aggregation. Used by the import preview to avoid running
+ * resolveUserMedian once per row (an N+1 against a potentially-large cellar).
+ *
+ * Returns `{ USD: { median, sample }, EUR: { median, sample }, ... }`.
+ */
+async function computeUserMediansByCurrency(userId) {
+  if (!userId) return {};
+  const rows = await Bottle.aggregate([
+    { $match: { user: userId, price: { $gt: 0 } } },
+    { $sort: { currency: 1, price: 1 } },
+    { $group: {
+      _id: '$currency',
+      prices: { $push: '$price' },
+    }},
+  ]);
+  const out = {};
+  for (const row of rows) {
+    const cur = (row._id || 'USD').toUpperCase();
+    const n = row.prices.length;
+    out[cur] = { median: row.prices[Math.floor(n / 2)], sample: n };
+  }
+  return out;
+}
+
+module.exports = { gatherPriceWarnings, computeUserMediansByCurrency };

--- a/backend/src/services/priceWarnings.js
+++ b/backend/src/services/priceWarnings.js
@@ -5,10 +5,21 @@
  *
  * Used by POST /api/bottles and the import preview/confirm endpoints to
  * surface non-blocking warnings at the moment a price is being entered.
+ *
+ * Security note (CodeQL js/sql-injection): callers may pass values that
+ * originate in req.body. Every value used in a $match / find / findOne
+ * argument is coerced via String() and (for ObjectIds) checked against a
+ * 24-hex regex INLINE before reaching the Mongo query — operator objects
+ * like {$ne: null} stringify to "[object Object]" which can't match any
+ * legitimate document. The inline pattern is what CodeQL's taint analysis
+ * recognises as sanitisation; extracting it into a helper hid the
+ * sanitiser from the static analyser.
  */
 const Bottle = require('../models/Bottle');
 const WineVintagePrice = require('../models/WineVintagePrice');
 const { validatePriceSanity } = require('../utils/priceValidation');
+
+const HEX24 = /^[a-f0-9]{24}$/i;
 
 /**
  * @param {object} input
@@ -29,11 +40,24 @@ async function gatherPriceWarnings({
   // Cheap exit — no price, no warnings to gather, no DB queries.
   if (typeof price !== 'number' || !isFinite(price) || price <= 0) return [];
 
-  const cur = (currency || 'USD').toUpperCase();
+  // ── Inline sanitisation (CodeQL js/sql-injection sanitiser) ─────────────
+  // String() forces primitive output. The regex guards an ObjectId-shaped
+  // string. Non-string values become "[object Object]" / "undefined" and
+  // either fail the regex (ObjectId case) or simply don't match any
+  // legitimate document (currency / vintage case).
+  const cur     = String(currency || 'USD').toUpperCase();
+  const uidStr  = userId == null ? '' : String(userId);
+  const wdStr   = wineDefinitionId == null ? '' : String(wineDefinitionId);
+  const vinStr  = vintage == null ? '' : String(vintage);
+  const uidOk   = HEX24.test(uidStr);
+  const wdOk    = HEX24.test(wdStr);
 
+  // ── Resolve the two reference prices in parallel ────────────────────────
   const [userMedian, marketPrice] = await Promise.all([
-    resolveUserMedian(userId, cur),
-    resolveMarketMedian(wineDefinitionId, vintage, cur),
+    uidOk ? findUserMedian(uidStr, cur) : Promise.resolve({ median: null, sample: 0 }),
+    (wdOk && vinStr && vinStr !== 'NV' && vinStr !== 'Unknown')
+      ? findMarketMedian(wdStr, vinStr, cur)
+      : Promise.resolve(null),
   ]);
 
   return validatePriceSanity({
@@ -45,31 +69,13 @@ async function gatherPriceWarnings({
   });
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Resolvers (inputs already sanitised by the caller) ───────────────────────
 
-// Coerce a possibly-user-supplied id to either a plain hex string ObjectId
-// or a real Mongoose ObjectId instance. Anything else (an injected operator
-// object, a non-hex string) returns null, which short-circuits the query.
-// Used to defuse CodeQL js/sql-injection on req.body values that reach $match.
-function safeObjectIdLike(v) {
-  if (v == null) return null;
-  if (typeof v === 'string') return /^[a-f0-9]{24}$/i.test(v) ? v : null;
-  // Mongoose ObjectId / BSON ObjectId
-  if (typeof v === 'object' && typeof v.toHexString === 'function') return v;
-  return null;
-}
-
-function safeString(v) {
-  if (v == null) return null;
-  return typeof v === 'string' ? v : null;
-}
-
-async function resolveUserMedian(userId, currency) {
-  const uid = safeObjectIdLike(userId);
-  const cur = safeString(currency);
-  if (!uid || !cur) return { median: null, sample: 0 };
+async function findUserMedian(userIdHex, currency) {
+  // Inputs were String()'d + regex-validated by the caller; safe to use
+  // directly in the query without further conversion.
   const rows = await Bottle
-    .find({ user: uid, currency: cur, price: { $gt: 0 } })
+    .find({ user: userIdHex, currency, price: { $gt: 0 } })
     .select('price')
     .sort({ price: 1 })
     .lean();
@@ -80,13 +86,9 @@ async function resolveUserMedian(userId, currency) {
   };
 }
 
-async function resolveMarketMedian(wineDefinitionId, vintage, currency) {
-  const wd  = safeObjectIdLike(wineDefinitionId);
-  const v   = safeString(vintage);
-  const cur = safeString(currency);
-  if (!wd || !v || !cur || v === 'NV' || v === 'Unknown') return null;
+async function findMarketMedian(wineDefinitionIdHex, vintage, currency) {
   const snapshot = await WineVintagePrice
-    .findOne({ wineDefinition: wd, vintage: v, currency: cur })
+    .findOne({ wineDefinition: wineDefinitionIdHex, vintage, currency })
     .sort({ setAt: -1 })
     .lean();
   return snapshot?.price ?? null;
@@ -95,15 +97,17 @@ async function resolveMarketMedian(wineDefinitionId, vintage, currency) {
 /**
  * Bulk-fetch the user's per-currency median bottle price + sample size in a
  * single Mongo aggregation. Used by the import preview to avoid running
- * resolveUserMedian once per row (an N+1 against a potentially-large cellar).
+ * findUserMedian once per row (an N+1 against a potentially-large cellar).
  *
  * Returns `{ USD: { median, sample }, EUR: { median, sample }, ... }`.
  */
 async function computeUserMediansByCurrency(userId) {
-  const uid = safeObjectIdLike(userId);
-  if (!uid) return {};
+  if (userId == null) return {};
+  // Inline String() + HEX24 sanitisation — same pattern as gatherPriceWarnings.
+  const uidStr = String(userId);
+  if (!HEX24.test(uidStr)) return {};
   const rows = await Bottle.aggregate([
-    { $match: { user: uid, price: { $gt: 0 } } },
+    { $match: { user: uidStr, price: { $gt: 0 } } },
     { $sort: { currency: 1, price: 1 } },
     { $group: {
       _id: '$currency',

--- a/backend/src/utils/priceValidation.js
+++ b/backend/src/utils/priceValidation.js
@@ -1,0 +1,127 @@
+/**
+ * Price sanity checks — non-blocking warnings surfaced at bottle add /
+ * import time to catch fat-finger errors (100× too high, cents-as-units,
+ * outliers vs the user's normal collection).
+ *
+ * These never reject a save — they return an array of warnings the UI
+ * shows so the user can confirm or correct. A pure function so it's easy
+ * to test and to reuse from both the single-add and import code paths.
+ */
+
+// Typical maximum bottle price per currency. Few real bottles exceed
+// these on the secondary market (DRC, top Bordeaux 1945, etc.). When a
+// user-entered value crosses this, prompt for confirmation.
+const ABSOLUTE_CAP = {
+  USD:  50000,
+  EUR:  50000,
+  GBP:  50000,
+  CHF:  50000,
+  CAD:  70000,
+  AUD:  75000,
+  NZD:  75000,
+  SEK: 500000,
+  NOK: 500000,
+  DKK: 350000,
+  JPY: 7500000,
+};
+
+// Soft outlier multipliers — non-blocking heuristics, picked so they
+// trigger on obvious mistakes but not on legitimate trophy bottles.
+const USER_MEDIAN_MULTIPLE   = 50;  // price > 50× user's own median
+const MARKET_MEDIAN_MULTIPLE = 5;   // price > 5× known WineVintagePrice
+const CENTS_HEURISTIC_FLOOR  = 10000; // only suggest cents above this
+
+/**
+ * @param {object} input
+ * @param {number} input.price                Price as entered by the user (in the currency's natural unit, e.g. 260 = €260)
+ * @param {string} [input.currency='USD']     ISO 4217 code
+ * @param {number} [input.userMedianPrice]    Median of the user's other bottles in the same currency (optional)
+ * @param {number} [input.userMedianSample]   How many bottles contributed to that median (skip the user-median rule below ~5 for stability)
+ * @param {number} [input.marketMedianPrice]  Latest WineVintagePrice for this wine+vintage in same currency (optional)
+ * @returns {Array<{code: string, severity: 'info'|'warning', context: object}>}
+ *          Each warning is i18n-key friendly: the UI looks up
+ *          `bottles.priceWarning.<code>` and interpolates the context fields.
+ */
+function validatePriceSanity({
+  price,
+  currency = 'USD',
+  userMedianPrice = null,
+  userMedianSample = 0,
+  marketMedianPrice = null,
+} = {}) {
+  const warnings = [];
+
+  // Skip everything if price isn't a positive number — the model's own
+  // validation will reject zero/negative; nothing to warn about.
+  if (typeof price !== 'number' || !isFinite(price) || price <= 0) return warnings;
+
+  const cur = (currency || 'USD').toUpperCase();
+
+  // ── Rule 1: above absolute typical-maximum cap ──────────────────────────
+  const cap = ABSOLUTE_CAP[cur] ?? ABSOLUTE_CAP.USD;
+  if (price > cap) {
+    warnings.push({
+      code: 'absoluteCap',
+      severity: 'warning',
+      context: { price, currency: cur, cap },
+    });
+  }
+
+  // ── Rule 2: far outlier vs user's own normal range ──────────────────────
+  // Only trigger if we have a representative sample; otherwise a user with
+  // 2 bottles where one is 10× the other would always trip the warning.
+  if (userMedianPrice && userMedianPrice > 0 && userMedianSample >= 5) {
+    const ratio = price / userMedianPrice;
+    if (ratio >= USER_MEDIAN_MULTIPLE) {
+      warnings.push({
+        code: 'userOutlier',
+        severity: 'warning',
+        context: {
+          price,
+          currency: cur,
+          ratio: Math.round(ratio),
+          median: Math.round(userMedianPrice),
+        },
+      });
+    }
+  }
+
+  // ── Rule 3: far outlier vs known market price for this wine+vintage ─────
+  if (marketMedianPrice && marketMedianPrice > 0) {
+    const ratio = price / marketMedianPrice;
+    if (ratio >= MARKET_MEDIAN_MULTIPLE) {
+      warnings.push({
+        code: 'aboveMarket',
+        severity: 'warning',
+        context: {
+          price,
+          currency: cur,
+          ratio: Math.round(ratio),
+          marketPrice: Math.round(marketMedianPrice),
+        },
+      });
+    }
+  }
+
+  // ── Rule 4: looks like cents-as-units (round to 100, large) ─────────────
+  // Helpful hint, not a hard signal — many real bottles also satisfy this.
+  // Only fires above 10,000 to suppress noise.
+  if (price >= CENTS_HEURISTIC_FLOOR && price % 100 === 0) {
+    warnings.push({
+      code: 'possiblyCents',
+      severity: 'info',
+      context: { price, currency: cur, ifCents: price / 100 },
+    });
+  }
+
+  return warnings;
+}
+
+module.exports = {
+  validatePriceSanity,
+  // Exported for tests + the rare caller that wants to surface the limits.
+  ABSOLUTE_CAP,
+  USER_MEDIAN_MULTIPLE,
+  MARKET_MEDIAN_MULTIPLE,
+  CENTS_HEURISTIC_FLOOR,
+};

--- a/backend/src/utils/priceValidation.test.js
+++ b/backend/src/utils/priceValidation.test.js
@@ -1,0 +1,191 @@
+const {
+  validatePriceSanity,
+  ABSOLUTE_CAP,
+  USER_MEDIAN_MULTIPLE,
+  MARKET_MEDIAN_MULTIPLE,
+} = require('./priceValidation');
+
+describe('validatePriceSanity', () => {
+  describe('input validation', () => {
+    it('returns no warnings for a typical price', () => {
+      expect(validatePriceSanity({ price: 25, currency: 'EUR' })).toEqual([]);
+    });
+
+    it('returns no warnings for null/undefined/NaN/zero/negative', () => {
+      expect(validatePriceSanity({ price: null })).toEqual([]);
+      expect(validatePriceSanity({ price: undefined })).toEqual([]);
+      expect(validatePriceSanity({ price: NaN })).toEqual([]);
+      expect(validatePriceSanity({ price: 0 })).toEqual([]);
+      expect(validatePriceSanity({ price: -100, currency: 'USD' })).toEqual([]);
+    });
+
+    it('returns no warnings when price is not a number', () => {
+      expect(validatePriceSanity({ price: '100' })).toEqual([]);
+    });
+  });
+
+  describe('rule: absolute cap per currency', () => {
+    it('warns when USD price exceeds the typical maximum', () => {
+      const w = validatePriceSanity({ price: ABSOLUTE_CAP.USD + 1, currency: 'USD' });
+      expect(w.find(x => x.code === 'absoluteCap')).toBeDefined();
+      expect(w[0].severity).toBe('warning');
+      expect(w[0].context.cap).toBe(ABSOLUTE_CAP.USD);
+    });
+
+    it('uses currency-specific caps', () => {
+      // 100,000 SEK is fine (under SEK cap), 100,000 USD is not (over USD cap)
+      const sekOk  = validatePriceSanity({ price: 100000, currency: 'SEK' });
+      const usdHit = validatePriceSanity({ price: 100000, currency: 'USD' });
+      expect(sekOk.find(x => x.code === 'absoluteCap')).toBeUndefined();
+      expect(usdHit.find(x => x.code === 'absoluteCap')).toBeDefined();
+    });
+
+    it('falls back to USD cap for unknown currencies', () => {
+      const w = validatePriceSanity({ price: ABSOLUTE_CAP.USD + 1, currency: 'XYZ' });
+      expect(w.find(x => x.code === 'absoluteCap')).toBeDefined();
+    });
+
+    it('is case-insensitive on currency', () => {
+      const w = validatePriceSanity({ price: 100000, currency: 'usd' });
+      expect(w.find(x => x.code === 'absoluteCap')).toBeDefined();
+    });
+  });
+
+  describe("rule: outlier vs user's own median", () => {
+    it('warns when price >= 50× user median (with enough sample)', () => {
+      const w = validatePriceSanity({
+        price: 5000,
+        currency: 'EUR',
+        userMedianPrice: 100,
+        userMedianSample: 20,
+      });
+      const outlier = w.find(x => x.code === 'userOutlier');
+      expect(outlier).toBeDefined();
+      expect(outlier.context.ratio).toBe(50);
+      expect(outlier.context.median).toBe(100);
+    });
+
+    it('does NOT warn for small sample sizes', () => {
+      const w = validatePriceSanity({
+        price: 5000,
+        currency: 'EUR',
+        userMedianPrice: 100,
+        userMedianSample: 3,  // below the 5-bottle threshold
+      });
+      expect(w.find(x => x.code === 'userOutlier')).toBeUndefined();
+    });
+
+    it('does NOT warn within the expected range', () => {
+      const w = validatePriceSanity({
+        price: 200,
+        currency: 'EUR',
+        userMedianPrice: 100,
+        userMedianSample: 20,
+      });
+      expect(w.find(x => x.code === 'userOutlier')).toBeUndefined();
+    });
+
+    it('uses the configured multiplier', () => {
+      // Exactly at threshold = warn
+      const at = validatePriceSanity({
+        price: 100 * USER_MEDIAN_MULTIPLE,
+        currency: 'EUR',
+        userMedianPrice: 100,
+        userMedianSample: 10,
+      });
+      expect(at.find(x => x.code === 'userOutlier')).toBeDefined();
+      // Just below = no warn
+      const below = validatePriceSanity({
+        price: 100 * USER_MEDIAN_MULTIPLE - 1,
+        currency: 'EUR',
+        userMedianPrice: 100,
+        userMedianSample: 10,
+      });
+      expect(below.find(x => x.code === 'userOutlier')).toBeUndefined();
+    });
+  });
+
+  describe('rule: outlier vs known market price', () => {
+    it('warns when price >= 5× market median', () => {
+      const w = validatePriceSanity({
+        price: 1000,
+        currency: 'USD',
+        marketMedianPrice: 100,
+      });
+      const above = w.find(x => x.code === 'aboveMarket');
+      expect(above).toBeDefined();
+      expect(above.context.ratio).toBe(10);
+      expect(above.context.marketPrice).toBe(100);
+    });
+
+    it('does NOT warn within the expected market range', () => {
+      const w = validatePriceSanity({
+        price: 200,
+        currency: 'USD',
+        marketMedianPrice: 100,
+      });
+      expect(w.find(x => x.code === 'aboveMarket')).toBeUndefined();
+    });
+
+    it('uses the configured multiplier exactly', () => {
+      const at = validatePriceSanity({
+        price: 100 * MARKET_MEDIAN_MULTIPLE,
+        currency: 'USD',
+        marketMedianPrice: 100,
+      });
+      expect(at.find(x => x.code === 'aboveMarket')).toBeDefined();
+    });
+
+    it('does NOT warn when marketMedianPrice is missing', () => {
+      const w = validatePriceSanity({ price: 1000, currency: 'USD' });
+      expect(w.find(x => x.code === 'aboveMarket')).toBeUndefined();
+    });
+  });
+
+  describe('rule: possibly-cents heuristic', () => {
+    it('flags suspiciously round large prices as possibly cents', () => {
+      const w = validatePriceSanity({ price: 260000, currency: 'USD' });
+      const cents = w.find(x => x.code === 'possiblyCents');
+      expect(cents).toBeDefined();
+      expect(cents.severity).toBe('info');
+      expect(cents.context.ifCents).toBe(2600);
+    });
+
+    it('does NOT flag round prices below the floor', () => {
+      const w = validatePriceSanity({ price: 5000, currency: 'USD' });
+      expect(w.find(x => x.code === 'possiblyCents')).toBeUndefined();
+    });
+
+    it('does NOT flag large prices with cents/decimals', () => {
+      const w = validatePriceSanity({ price: 25099, currency: 'USD' });
+      expect(w.find(x => x.code === 'possiblyCents')).toBeUndefined();
+    });
+  });
+
+  describe('combined behaviour', () => {
+    it('stacks multiple warnings on the production-incident case', () => {
+      // The Chevalier-Montrachet $260k row from the live audit
+      const w = validatePriceSanity({
+        price: 260000,
+        currency: 'USD',
+        userMedianPrice: 690,
+        userMedianSample: 27,
+        marketMedianPrice: 2600,
+      });
+      const codes = w.map(x => x.code).sort();
+      expect(codes).toEqual(['aboveMarket', 'absoluteCap', 'possiblyCents', 'userOutlier']);
+    });
+
+    it('returns no warnings on the median bottle in the dataset', () => {
+      // Median active USD bottle from /admin/stats is around $24
+      const w = validatePriceSanity({
+        price: 24,
+        currency: 'USD',
+        userMedianPrice: 20,
+        userMedianSample: 150,
+        marketMedianPrice: 25,
+      });
+      expect(w).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -288,6 +288,12 @@
   "addBottle": {
     "title": "Add Bottle",
     "backToCellar": "← Back to Cellar",
+    "priceWarning": {
+      "absoluteCap": "Unusually high — above the typical maximum of {{cap}} {{currency}} per bottle. Double-check before saving.",
+      "userOutlier": "{{ratio}}× higher than your typical bottle ({{median}} {{currency}}). Looks like a typo?",
+      "aboveMarket": "{{ratio}}× the recorded market price ({{marketPrice}} {{currency}}) for this wine and vintage.",
+      "possiblyCents": "Looks like cents — if you meant {{ifCents}} {{currency}}, divide by 100."
+    },
     "stepSelectWine": "Select Wine",
     "stepBottleDetails": "Bottle Details",
     "searchForWine": "Search for a Wine",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -288,6 +288,12 @@
   "addBottle": {
     "title": "Lägg till flaska",
     "backToCellar": "← Tillbaka till källare",
+    "priceWarning": {
+      "absoluteCap": "Ovanligt högt — över det normala maxpriset {{cap}} {{currency}} per flaska. Dubbelkolla innan du sparar.",
+      "userOutlier": "{{ratio}}× högre än din typiska flaska ({{median}} {{currency}}). Felskrivning?",
+      "aboveMarket": "{{ratio}}× det registrerade marknadspriset ({{marketPrice}} {{currency}}) för detta vin och denna årgång.",
+      "possiblyCents": "Ser ut som cent — om du menade {{ifCents}} {{currency}}, dividera med 100."
+    },
     "stepSelectWine": "Välj vin",
     "stepBottleDetails": "Flaskdetaljer",
     "searchForWine": "Sök efter ett vin",

--- a/frontend/src/pages/AddBottle.css
+++ b/frontend/src/pages/AddBottle.css
@@ -920,3 +920,38 @@
     overflow: hidden;
   }
 }
+
+/* Non-blocking price sanity warnings rendered under the price input */
+.price-warnings {
+  list-style: none;
+  padding: 0;
+  margin: 0.4rem 0 0;
+}
+
+.price-warning {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 4px;
+  margin-top: 0.25rem;
+  line-height: 1.35;
+}
+
+.price-warning--warning {
+  background: rgba(191, 138, 46, 0.12);
+  color: #8a5a00;
+  border-left: 3px solid #bf8a2e;
+}
+
+.price-warning--info {
+  background: rgba(0, 99, 199, 0.08);
+  color: #1a4d80;
+  border-left: 3px solid #4c8edf;
+}
+
+[data-theme="dark"] .price-warning--warning {
+  color: #e0a850;
+}
+
+[data-theme="dark"] .price-warning--info {
+  color: #6fa6e6;
+}

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { searchWines, findOrCreateWine, identifyWineByText } from '../api/wines';
 import useLabelScanner from '../hooks/useLabelScanner';
 import { CURRENCIES } from '../config/currencies';
+import { validatePriceSanity } from '../utils/priceValidation';
 import ImageUpload from '../components/ImageUpload';
 import RatingInput from '../components/RatingInput';
 import WineImage from '../components/WineImage';
@@ -687,6 +688,22 @@ function AddBottle() {
                   onChange={(e) => setBottleData({ ...bottleData, price: e.target.value })}
                   placeholder="0.00"
                 />
+                {(() => {
+                  const warns = validatePriceSanity({
+                    price: parseFloat(bottleData.price),
+                    currency: bottleData.currency || 'USD',
+                  });
+                  if (warns.length === 0) return null;
+                  return (
+                    <ul className="price-warnings">
+                      {warns.map(w => (
+                        <li key={w.code} className={`price-warning price-warning--${w.severity}`}>
+                          {t(`addBottle.priceWarning.${w.code}`, w.context)}
+                        </li>
+                      ))}
+                    </ul>
+                  );
+                })()}
               </div>
 
               <div className="form-group">

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -601,6 +601,33 @@
   margin: 0.1rem 0.15rem;
 }
 
+/* Price-sanity warning highlight on the detail tag itself */
+.detail-tag--warn {
+  background: rgba(191, 138, 46, 0.15);
+  color: #8a5a00;
+  border: 1px solid rgba(191, 138, 46, 0.4);
+  cursor: help;
+}
+
+[data-theme="dark"] .detail-tag--warn {
+  color: #e0a850;
+}
+
+/* Banner above the review table when any rows have price warnings */
+.import-price-warning-banner {
+  background: rgba(191, 138, 46, 0.1);
+  border-left: 3px solid #bf8a2e;
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0 1rem;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.summary-number.summary-warn {
+  color: #bf8a2e;
+}
+
 /* Action buttons */
 .action-buttons {
   display: flex;

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -5,6 +5,7 @@ import { validateImport, confirmImport } from '../api/bottles';
 import { searchWines } from '../api/wines';
 import { getRacks } from '../api/racks';
 import { parseAndMap, parseJSON, summariseRacks, getDefaultRackConfig, getDefaultAnchor } from '../utils/importMappers';
+import { describePriceWarning } from '../utils/priceValidation';
 import { getTotalSlots } from '../utils/rackLayouts';
 import { TYPE_DIMENSIONS } from '../components/racks/RackTypeSelector';
 import AnchorPicker from './import/AnchorPicker';
@@ -1137,7 +1138,21 @@ function ImportBottles() {
               <span className="summary-label">Imported</span>
             </div>
           )}
+          {(summary?.priceWarnings || 0) > 0 && (
+            <div className="summary-stat">
+              <span className="summary-number summary-warn">{summary.priceWarnings}</span>
+              <span className="summary-label">Price warnings</span>
+            </div>
+          )}
         </div>
+
+        {/* Price sanity banner — surfaces fat-finger / 100×-too-high / cents-as-units mistakes */}
+        {(summary?.priceWarnings || 0) > 0 && (
+          <div className="import-price-warning-banner">
+            <strong>⚠️ {summary.priceWarnings} bottle{summary.priceWarnings === 1 ? '' : 's'} have unusual prices.</strong>
+            {' '}Hover the highlighted price tags below to see why. Common causes: typing extra zeros, prices entered in cents, or wrong currency.
+          </div>
+        )}
 
         {/* Bulk actions */}
         <div className="review-actions">
@@ -1296,7 +1311,17 @@ function ImportBottles() {
                       )}
                     </td>
                     <td className="col-details">
-                      {r.item.price && <span className="detail-tag">{r.item.price} {r.item.currency}</span>}
+                      {r.item.price && (
+                        <span
+                          className={`detail-tag${r.priceWarnings?.length ? ' detail-tag--warn' : ''}`}
+                          title={r.priceWarnings?.length
+                            ? r.priceWarnings.map(describePriceWarning).join('\n')
+                            : undefined}
+                        >
+                          {r.priceWarnings?.length ? '⚠️ ' : ''}
+                          {r.item.price} {r.item.currency}
+                        </span>
+                      )}
                       {r.item.rating && <span className="detail-tag">Rating: {r.item.rating}</span>}
                       {r.item.bottleSize && r.item.bottleSize !== '750ml' && (
                         <span className="detail-tag">{r.item.bottleSize}</span>

--- a/frontend/src/utils/priceValidation.js
+++ b/frontend/src/utils/priceValidation.js
@@ -1,0 +1,102 @@
+// Mirror of backend/src/utils/priceValidation.js so the add-bottle form can
+// surface sanity warnings as the user types — no round-trip required.
+// Keep these constants in sync with the backend (they live in the same
+// repository so drift is easy to spot in code review).
+
+export const ABSOLUTE_CAP = {
+  USD:  50000,
+  EUR:  50000,
+  GBP:  50000,
+  CHF:  50000,
+  CAD:  70000,
+  AUD:  75000,
+  NZD:  75000,
+  SEK: 500000,
+  NOK: 500000,
+  DKK: 350000,
+  JPY: 7500000,
+};
+
+export const USER_MEDIAN_MULTIPLE   = 50;
+export const MARKET_MEDIAN_MULTIPLE = 5;
+export const CENTS_HEURISTIC_FLOOR  = 10000;
+
+/**
+ * Pure function — same signature as the backend so the two can never drift
+ * silently in either direction. The frontend usually only has access to
+ * `price` and `currency` (no user median, no market price) and that's fine;
+ * the absolute-cap and possibly-cents rules already catch the bulk of
+ * obvious mistakes.
+ */
+export function validatePriceSanity({
+  price,
+  currency = 'USD',
+  userMedianPrice = null,
+  userMedianSample = 0,
+  marketMedianPrice = null,
+} = {}) {
+  const warnings = [];
+  if (typeof price !== 'number' || !isFinite(price) || price <= 0) return warnings;
+
+  const cur = (currency || 'USD').toUpperCase();
+
+  const cap = ABSOLUTE_CAP[cur] ?? ABSOLUTE_CAP.USD;
+  if (price > cap) {
+    warnings.push({ code: 'absoluteCap', severity: 'warning', context: { price, currency: cur, cap } });
+  }
+
+  if (userMedianPrice && userMedianPrice > 0 && userMedianSample >= 5) {
+    const ratio = price / userMedianPrice;
+    if (ratio >= USER_MEDIAN_MULTIPLE) {
+      warnings.push({
+        code: 'userOutlier',
+        severity: 'warning',
+        context: { price, currency: cur, ratio: Math.round(ratio), median: Math.round(userMedianPrice) },
+      });
+    }
+  }
+
+  if (marketMedianPrice && marketMedianPrice > 0) {
+    const ratio = price / marketMedianPrice;
+    if (ratio >= MARKET_MEDIAN_MULTIPLE) {
+      warnings.push({
+        code: 'aboveMarket',
+        severity: 'warning',
+        context: { price, currency: cur, ratio: Math.round(ratio), marketPrice: Math.round(marketMedianPrice) },
+      });
+    }
+  }
+
+  if (price >= CENTS_HEURISTIC_FLOOR && price % 100 === 0) {
+    warnings.push({
+      code: 'possiblyCents',
+      severity: 'info',
+      context: { price, currency: cur, ifCents: price / 100 },
+    });
+  }
+
+  return warnings;
+}
+
+/**
+ * Plain-English description of a single warning — used in import preview
+ * tooltips and other contexts where i18n's `t()` isn't wired up.
+ * AddBottle uses `t('bottles.priceWarning.<code>', context)` instead so the
+ * messages translate. Keep the wording here close to the en.json copy.
+ */
+export function describePriceWarning(w) {
+  const fmt = (n) => Number(n).toLocaleString();
+  const { code, context: c = {} } = w;
+  switch (code) {
+    case 'absoluteCap':
+      return `Unusually high — above the typical maximum of ${fmt(c.cap)} ${c.currency} per bottle.`;
+    case 'userOutlier':
+      return `${c.ratio}× higher than your typical bottle (${fmt(c.median)} ${c.currency}).`;
+    case 'aboveMarket':
+      return `${c.ratio}× the recorded market price (${fmt(c.marketPrice)} ${c.currency}) for this wine and vintage.`;
+    case 'possiblyCents':
+      return `Looks like cents — if you meant ${fmt(c.ifCents)} ${c.currency}, divide by 100.`;
+    default:
+      return code;
+  }
+}


### PR DESCRIPTION
Tier 1 of the price-sanity work discussed after the prod incident where one user's 27 bottles all carried 100×-too-high USD prices ($260,000 Chevalier-Montrachet, $50,000 Opus One, etc.) and dragged the global average up to $7,731.

This PR adds **rule-based sanity checks** at the two moments a price is entered — single bottle add and CSV import preview. **Nothing is blocked**: a save always succeeds; the user just sees a warning. Pure deterministic rules, no AI, no external service.

## The four rules

| Code | Severity | Fires when |
|---|---|---|
| `absoluteCap`   | warning | price > typical per-currency max (\$50k USD, 500k SEK, etc.) — would have caught the $260k Chevalier-Montrachet |
| `userOutlier`   | warning | price ≥ 50× user's own median in the same currency (sample ≥ 5) — would have caught Opus One $50k when the user's median is ~$500 |
| `aboveMarket`   | warning | price ≥ 5× the recorded `WineVintagePrice` for this wine+vintage |
| `possiblyCents` | info    | price ≥ 10,000 and divisible by 100 — hints the user may have entered cents |

Multiple rules can fire on one bottle. The Chevalier-Montrachet case stacks all four.

## What's in the PR

### Backend
- **`utils/priceValidation.js`** — pure function + 20-test suite (covers each rule individually, edge cases for sample size + currency case-insensitivity, plus the production-incident case as an assertion).
- **`services/priceWarnings.js`** — DB-backed wrapper:
  - `gatherPriceWarnings({ price, currency, userId, wineDefinitionId, vintage })` for single-bottle add
  - `computeUserMediansByCurrency(userId)` returning `{ USD: { median, sample }, EUR: { ... } }` in **one** Mongo aggregation, used by the import preview to avoid an N+1 query
- **`routes/bottles.js`** — `POST /api/bottles` now returns `{ bottle, priceWarnings }`. Bottle still saves even if warnings fire.
- **`routes/import.js`** — `POST /api/bottles/import/validate` annotates each result with `priceWarnings: []` and adds a `priceWarnings` count to the summary block.

### Frontend
- **`utils/priceValidation.js`** — mirror of the backend rules so the form can warn as the user types (no round-trip). Also exports `describePriceWarning(w)` for places where i18n's `t()` isn't wired up (the import preview's hover-tooltip).
- **`pages/AddBottle.js`** — warnings rendered under the price input. Yellow border-left for `warning`, blue for `info`. Updates live as the user types.
- **`pages/ImportBottles.js`** — three additions:
  - `⚠️` prefix on the price detail-tag for flagged rows, with hover-text reasons.
  - Banner above the review table when any rows flag, with plain-language explanation of common causes.
  - New summary stat 'Price warnings' alongside the existing Matched / Fuzzy / etc.
- CSS in both `AddBottle.css` and `ImportBottles.css`, with dark-mode variants.

### i18n
- `addBottle.priceWarning.{absoluteCap, userOutlier, aboveMarket, possiblyCents}` in `en` and `sv`, with named interpolations matching each rule's context object.

## Test plan

- [x] Backend tests pass (532 — adds 20 new priceValidation tests)
- [x] Frontend tests pass (275, unchanged)
- [ ] **Add bottle manually**:
  - Enter `260000 USD` → see absoluteCap + possiblyCents warnings under the price field
  - Enter `25 EUR` → no warnings
  - Save bottle with warnings present → save succeeds, navigates to cellar (warnings don't block)
- [ ] **Import**:
  - Drag a CSV containing a row with `price: 260000` → after validate, that row shows the ⚠️ tag and the page shows the banner + summary stat
  - Hover the ⚠️ price tag → see the warning reasons
- [ ] Switch to Swedish locale → warnings translate
- [ ] Dark mode → warning colours still readable

## Out of scope (deferred)

- **Tier 2** (LLM batch validation of suspect entries) — implement only if Tier 1 generates too many false-misses
- **Tier 3** (real-time LLM-in-the-loop with Wine-Searcher comparison) — overkill at current scale
- **EU-decimal `parseFloat` import bug** — separate problem, will be its own PR
- **Cleanup of the existing $260k bottles** — separate one-off `updateMany`, owner-confirmation flow