### PR TITLE
fix(import): locale-aware number parsing for EU/Swedish CSV exports

### DIFF
--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -34,8 +34,86 @@
  */
 
 /**
+ * Robust locale-aware number parser. Handles:
+ *   "1234.56"   → 1234.56   (US plain)
+ *   "1234,56"   → 1234.56   (EU plain)
+ *   "1,234.56"  → 1234.56   (US with thousands separator)
+ *   "1.234,56"  → 1234.56   (EU with thousands separator)
+ *   "1 234,56"  → 1234.56   (Swedish with space)
+ *   "$25.00"    → 25        (currency symbol stripped)
+ *   "€25,00"    → 25
+ *   "25 kr"    → 25         (trailing currency word stripped)
+ *   "0,75"      → 0.75      (EU bottle-size decimal)
+ *   "260,00"    → 260       (EU price)
+ *
+ * Ambiguous edge case: a single comma followed by exactly 3 digits
+ * ("1,234") is treated as a US thousands separator → 1234. A real EU
+ * decimal almost never has 3 fractional digits in wine pricing, and
+ * Vivino/CellarTracker CSV exports use this format heavily.
+ *
+ * Returns NaN for empty / unparseable input — drop-in safe replacement
+ * for parseFloat on any caller that already handles NaN.
+ */
+export function parseLocaleNumber(input) {
+  if (input == null) return NaN;
+  let s = String(input).trim();
+  if (!s) return NaN;
+
+  // Strip currency symbols and surrounding whitespace
+  s = s.replace(/[$€£¥¢฿₹₽₺]/g, '');
+  // Strip trailing currency words (kr, USD, EUR, etc.) and leading sign words
+  s = s.replace(/^[+-]?\s*/, m => m.replace(/\s+/g, ''));
+  s = s.replace(/\s*[a-zA-Z]+\s*$/, '');
+  // Collapse internal whitespace (common in Swedish thousands: "1 234,56")
+  s = s.replace(/\s+/g, '');
+  if (!s || s === '-' || s === '+') return NaN;
+
+  const hasComma  = s.includes(',');
+  const hasPeriod = s.includes('.');
+
+  if (hasComma && hasPeriod) {
+    // Both separators present — the LAST one is the decimal.
+    if (s.lastIndexOf(',') > s.lastIndexOf('.')) {
+      // EU: "1.234.567,89" → strip periods, swap comma
+      s = s.replace(/\./g, '').replace(',', '.');
+    } else {
+      // US: "1,234,567.89" → strip commas
+      s = s.replace(/,/g, '');
+    }
+  } else if (hasComma) {
+    const parts = s.split(',');
+    if (parts.length > 2) {
+      // Multiple commas = thousands separators (US: "1,234,567")
+      s = s.replace(/,/g, '');
+    } else if (parts[1].length === 3 && parts[0].length >= 1 && parts[0] !== '0') {
+      // "1,234" or "12,345" — exactly 3 digits after comma AND integer part
+      // > 0 → US thousands. Wine prices in EU rarely have 3 decimal places,
+      // and Vivino/CT exports use this format extensively for unquoted
+      // numbers. "0,375" with leading zero is treated as EU decimal because
+      // it's almost certainly a bottle size in litres (375ml).
+      s = s.replace(/,/g, '');
+    } else {
+      // 1 or 2 digits after, or ≥4 digits → EU decimal
+      s = s.replace(',', '.');
+    }
+  } else if (hasPeriod) {
+    const parts = s.split('.');
+    if (parts.length > 2) {
+      // Multiple periods = EU thousands ("1.234.567"). Drop them all.
+      s = s.replace(/\./g, '');
+    }
+    // Single period = US decimal — parseFloat handles it.
+  }
+
+  const n = parseFloat(s);
+  return isNaN(n) ? NaN : n;
+}
+
+/**
  * Parse CSV text into an array of row objects.
  * Handles quoted fields, embedded commas, and newlines within quotes.
+ * Production callers should pre-detect the delimiter via detectDelimiter()
+ * before calling this (see parseAndMap below).
  */
 export function parseCSV(text, delimiter = ',') {
   const lines = [];
@@ -265,8 +343,8 @@ function mapVivinoRow(row) {
     return '';
   };
 
-  const rating = parseFloat(get(['Rating', 'My Rating', 'rating']));
-  const price = parseFloat(get(['Price', 'price', 'Purchase Price']));
+  const rating = parseLocaleNumber(get(['Rating', 'My Rating', 'rating']));
+  const price = parseLocaleNumber(get(['Price', 'price', 'Purchase Price']));
   const qty = parseInt(get(['Quantity', 'quantity', 'Qty', 'Count']), 10);
 
   return {
@@ -323,9 +401,9 @@ function mapCellarTrackerRow(row) {
     }
   }
 
-  const price = parseFloat(get(['Price', 'price', 'Cost']));
+  const price = parseLocaleNumber(get(['Price', 'price', 'Cost']));
   const qty = parseInt(get(['Quantity', 'quantity', 'Qty', 'Count']), 10);
-  const ctRating = parseFloat(get(['MyCTRating', 'CT Rating', 'My Rating', 'Rating']));
+  const ctRating = parseLocaleNumber(get(['MyCTRating', 'CT Rating', 'My Rating', 'Rating']));
 
   return {
     wineName: get(['Wine', 'wine', 'WineName']),
@@ -366,8 +444,8 @@ function mapGenericRow(row) {
     return '';
   };
 
-  const price = parseFloat(get(['Price', 'price', 'Cost', 'cost']));
-  const rating = parseFloat(get(['Rating', 'rating', 'Score', 'score']));
+  const price = parseLocaleNumber(get(['Price', 'price', 'Cost', 'cost']));
+  const rating = parseLocaleNumber(get(['Rating', 'rating', 'Score', 'score']));
   const qty = parseInt(get(['Quantity', 'quantity', 'Qty', 'qty', 'Count', 'count']), 10);
 
   // Combined rack+position columns like Oeno's "Rack_Location" = "M2-11"
@@ -410,7 +488,7 @@ function mapGenericRow(row) {
  */
 function mapCellarionRow(row) {
   const str = (key) => (row[key] || '').trim();
-  const num = (key) => { const n = parseFloat(row[key]); return isNaN(n) ? undefined : n; };
+  const num = (key) => { const n = parseLocaleNumber(row[key]); return isNaN(n) ? undefined : n; };
   const int = (key) => { const n = parseInt(row[key], 10); return isNaN(n) ? undefined : n; };
 
   return {
@@ -637,9 +715,9 @@ export function parseOenoExport(text) {
     const slotRaw = (cells[idx.slot] || '').trim();
     const isUnshelved = !cabinetIdRaw || cabinetIdRaw === 'null';
 
-    const sizeLitres = parseFloat(cells[idx.size]);
+    const sizeLitres = parseLocaleNumber(cells[idx.size]);
     const bottleSize = isNaN(sizeLitres) ? '750ml' : `${Math.round(sizeLitres * 1000)}ml`;
-    const cost = parseFloat(cells[idx.cost]);
+    const cost = parseLocaleNumber(cells[idx.cost]);
     const consumedAt = (cells[idx.consumed] || '').trim();
 
     const baseItem = {

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -7,6 +7,7 @@ import {
   parseCombinedRackLocation,
   parseOenoExport,
   detectOenoExportBoundary,
+  parseLocaleNumber,
 } from './importMappers';
 
 // ---------------------------------------------------------------------------
@@ -150,6 +151,137 @@ describe('detectDelimiter', () => {
   it('prefers tab over semicolon when both are present on first line', () => {
     // Tab is checked first, so it wins
     expect(detectDelimiter('Name\tVintage;Country')).toBe('\t');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLocaleNumber — locale-aware replacement for parseFloat in CSV imports.
+// Catches the EU-decimal bug where parseFloat('1.234,56') returned 1.234.
+// ---------------------------------------------------------------------------
+describe('parseLocaleNumber', () => {
+  describe('invalid input', () => {
+    it('returns NaN for null/undefined/empty/whitespace', () => {
+      expect(parseLocaleNumber(null)).toBeNaN();
+      expect(parseLocaleNumber(undefined)).toBeNaN();
+      expect(parseLocaleNumber('')).toBeNaN();
+      expect(parseLocaleNumber('   ')).toBeNaN();
+    });
+
+    it('returns NaN for non-numeric strings', () => {
+      expect(parseLocaleNumber('abc')).toBeNaN();
+      expect(parseLocaleNumber('-')).toBeNaN();
+      expect(parseLocaleNumber('+')).toBeNaN();
+    });
+  });
+
+  describe('plain numbers (no separator)', () => {
+    it('parses positive integers', () => {
+      expect(parseLocaleNumber('260')).toBe(260);
+      expect(parseLocaleNumber('0')).toBe(0);
+      expect(parseLocaleNumber('1')).toBe(1);
+    });
+
+    it('accepts numeric input directly', () => {
+      expect(parseLocaleNumber(260)).toBe(260);
+      expect(parseLocaleNumber(0.75)).toBe(0.75);
+    });
+  });
+
+  describe('US format (period decimal, comma thousands)', () => {
+    it('parses simple US decimals', () => {
+      expect(parseLocaleNumber('1234.56')).toBe(1234.56);
+      expect(parseLocaleNumber('0.75')).toBe(0.75);
+      expect(parseLocaleNumber('260.00')).toBe(260);
+    });
+
+    it('parses US thousands+decimal', () => {
+      expect(parseLocaleNumber('1,234.56')).toBe(1234.56);
+      expect(parseLocaleNumber('1,234,567.89')).toBe(1234567.89);
+    });
+
+    it('parses US thousands only (3 digits after comma)', () => {
+      expect(parseLocaleNumber('1,234')).toBe(1234);
+      expect(parseLocaleNumber('12,345')).toBe(12345);
+      expect(parseLocaleNumber('1,234,567')).toBe(1234567);
+    });
+  });
+
+  describe('EU format (comma decimal, period thousands)', () => {
+    it('parses simple EU decimals — the production bug case', () => {
+      // parseFloat('1234,56') returned 1234 — losing the .56
+      expect(parseLocaleNumber('1234,56')).toBe(1234.56);
+      // parseFloat('0,75') returned 0 — bottle size was wrong
+      expect(parseLocaleNumber('0,75')).toBe(0.75);
+      // parseFloat('260,00') accidentally returned 260, which was right
+      expect(parseLocaleNumber('260,00')).toBe(260);
+    });
+
+    it('parses EU thousands+decimal', () => {
+      // parseFloat('1.234,56') returned 1.234 — 1000x too low
+      expect(parseLocaleNumber('1.234,56')).toBe(1234.56);
+      expect(parseLocaleNumber('1.234.567,89')).toBe(1234567.89);
+    });
+
+    it('parses Swedish space-separated thousands', () => {
+      expect(parseLocaleNumber('1 234,56')).toBe(1234.56);
+      expect(parseLocaleNumber('1 234 567,89')).toBe(1234567.89);
+    });
+
+    it('treats "0,375" with leading zero as bottle-size decimal, not thousands', () => {
+      expect(parseLocaleNumber('0,375')).toBe(0.375);  // 375ml in litres
+      expect(parseLocaleNumber('0,75')).toBe(0.75);    // 750ml in litres
+    });
+
+    it('parses EU thousands when no decimal is present', () => {
+      // Multiple periods unambiguously = EU thousands
+      expect(parseLocaleNumber('1.234.567')).toBe(1234567);
+    });
+
+    it('keeps a single period as US-style decimal (asymmetric to comma)', () => {
+      // "1.234" is ambiguous (could be 1.234 US-decimal or 1234 EU-thousands).
+      // We pick US-decimal because bottle sizes like "0.375" / "1.5" are
+      // common in litres, and the multi-period case handles real EU
+      // thousands ("1.234.567") correctly.
+      expect(parseLocaleNumber('1.234')).toBe(1.234);
+      expect(parseLocaleNumber('1.5')).toBe(1.5);
+      expect(parseLocaleNumber('0.375')).toBe(0.375);
+    });
+  });
+
+  describe('currency symbols and trailing words', () => {
+    it('strips $ € £ ¥ and similar leading symbols', () => {
+      expect(parseLocaleNumber('$25.00')).toBe(25);
+      expect(parseLocaleNumber('€25,00')).toBe(25);
+      expect(parseLocaleNumber('£1,234.56')).toBe(1234.56);
+      expect(parseLocaleNumber('¥1000')).toBe(1000);
+    });
+
+    it('strips trailing currency words', () => {
+      expect(parseLocaleNumber('25 kr')).toBe(25);
+      expect(parseLocaleNumber('260 USD')).toBe(260);
+      expect(parseLocaleNumber('1234,56 EUR')).toBe(1234.56);
+    });
+  });
+
+  describe('drop-in replacement compatibility', () => {
+    it('matches parseFloat behaviour on plain US numbers', () => {
+      const cases = ['25.00', '260', '0.75', '1234.56', '0'];
+      for (const c of cases) {
+        expect(parseLocaleNumber(c)).toBe(parseFloat(c));
+      }
+    });
+
+    it('FIXES the parseFloat bugs that broke EU imports', () => {
+      // These are the EU-format inputs that parseFloat got wrong
+      expect(parseFloat('1.234,56')).toBe(1.234);   // bug: should be 1234.56
+      expect(parseLocaleNumber('1.234,56')).toBe(1234.56);
+
+      expect(parseFloat('0,75')).toBe(0);           // bug: bottle size → 0ml
+      expect(parseLocaleNumber('0,75')).toBe(0.75);
+
+      expect(parseFloat('1,234.56')).toBe(1);       // bug: US thousands lost everything
+      expect(parseLocaleNumber('1,234.56')).toBe(1234.56);
+    });
   });
 });
 


### PR DESCRIPTION
The follow-up to the import-side of the price-sanity investigation: `parseFloat()` only understands US format, and the import path was calling it directly on every price, rating, and bottle-size cell. EU-format CSVs (Vivino exports from Swedish/German users, Systembolaget-style price lists, Oeno-by-Vintec exports in EU locale) were getting **systematically under-counted prices and 0ml bottle sizes** without any error.

## The bug, in four assertions

```js
parseFloat('1.234,56')  // returns 1.234     ← should be 1234.56 (1000× too low)
parseFloat('1,234.56')  // returns 1         ← should be 1234.56 (everything past the comma lost)
parseFloat('0,75')      // returns 0         ← Bottle size becomes 0ml
parseFloat('260,00')    // returns 260       ← accidentally right (comma is just a terminator)
```

All four are now locked-in regression assertions in the test file.

## What's in the PR

### `parseLocaleNumber()` helper

Drop-in safe replacement for `parseFloat` — returns `NaN` for unparseable input so every existing `isNaN(...)` guard keeps working. Covers:

| Input | Returns |
|---|---|
| `'1234.56'` | `1234.56` (US) |
| `'1234,56'` | `1234.56` (EU) |
| `'1,234.56'` | `1234.56` (US thousands+decimal) |
| `'1.234,56'` | `1234.56` (EU thousands+decimal) |
| `'1 234,56'` | `1234.56` (Swedish space-separated) |
| `'$25.00'` / `'€25,00'` / `'25 kr'` | `25` (currency stripped) |
| `'0,75'` / `'0,375'` | `0.75` / `0.375` (bottle-size litres, EU decimal) |
| `'0.75'` / `'0.375'` | `0.75` / `0.375` (US decimal) |

Two ambiguity rules worth calling out:
- **`'1,234'` → `1234`** — exactly 3 digits after a comma + non-zero integer part is treated as US thousands. Vivino and CellarTracker CSV exports use this format heavily for unquoted numbers.
- **`'0,375'` → `0.375`** — leading-zero integer part is treated as EU decimal regardless, because it's almost certainly a bottle size in litres.

### Applied everywhere prices and sizes come from CSV cells

Five call sites in `frontend/src/utils/importMappers.js`:

| Mapper | What now uses `parseLocaleNumber` |
|---|---|
| Vivino    | `price`, `rating` |
| CellarTracker | `price`, `rating` |
| Generic CSV | `price`, `rating` |
| Cellarion native (round-trip) | every numeric field via the `num()` helper |
| Oeno-by-Vintec | `Bottle Size Liters`, `Purchase Cost` |

Integer fields (`Quantity`, rack positions, etc.) keep using `parseInt` — they're always whole numbers and don't have separator ambiguity.

### What's NOT in this PR (intentional)

- **`detectDelimiter` was already there** and already handles `\t` / `;` / `,` — and `parseAndMap` already calls it before `parseCSV`. So the EU-semicolon-delimited path was already fine; only the cell parsing was broken.
- **`parseCSV` default delimiter stays `,`** — changing it would alter behaviour for direct test callers that don't pass a delimiter. Production goes through `parseAndMap` which auto-detects, so no real-world change.

## Test plan

- [x] Frontend tests pass — **292 / 292**, of which 17 are new on this change
- [x] Backend tests pass — 512 unchanged (no backend touch in this PR)
- [ ] Drop a Vivino CSV with EU-format prices (e.g. `1.234,56 EUR`) into the import flow → verify the preview shows `1234.56 EUR` not `1.234 EUR` or `1 EUR`
- [ ] Drop an Oeno-export with `Bottle Size Liters` column using `0,75` → verify the preview shows `750ml` not `0ml`
- [ ] Existing Vivino/CellarTracker imports with US format keep working unchanged