### PR TITLE
chore(release): v1.55.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.55.1",
+  "version": "1.55.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.55.1",
+  "version": "1.55.2",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Patch release bundling two related data-quality fixes that fell out of the price-overstating incident on /admin/stats.

## What's in this release vs v1.55.1

### Features
- **feat(price-sanity):** non-blocking warnings on bottle add + import preview (#436). Four sanity rules (absolute per-currency cap, user-median outlier, market-median outlier, possibly-cents heuristic) fire as the user types in the add-bottle form and on each row of the import preview. Nothing is blocked — the user sees a warning, save still works. Pure deterministic rules, no AI. Catches the 100×-too-high-price class of errors that surfaced on /admin/stats. Includes inline NoSQL-injection sanitisation on the resolvers (CodeQL js/sql-injection clean).

### Fixes
- **fix(import):** locale-aware number parsing for EU/Swedish CSV exports (#437). `parseFloat()` silently broke on `1.234,56` (returned 1.234) and `0,75` (returned 0 — bottle size became 0ml). New `parseLocaleNumber()` handles US plain/thousands+decimal, EU plain/thousands+decimal, Swedish space-separated, currency symbols, and trailing currency words. Applied at every CSV-cell parse point in the 5 import mappers (Vivino, CellarTracker, generic, Cellarion native, Oeno).

No schema changes, no data migration.

## Test plan

- [ ] `npm test` passes in both `backend/` (532) and `frontend/` (292)
- [ ] Smoke-test in Docker: `docker compose up --build` boots
- [ ] Add a bottle with price `260000 USD` → see *absolute cap* + *possibly cents* warnings live under the price field
- [ ] Import a Vivino CSV with EU-format prices (e.g. `1.234,56 EUR`) → preview shows `1234.56 EUR`, no longer `1.234 EUR` or `1 EUR`
- [ ] Import an Oeno export with bottle-size `0,75` → preview shows `750ml`, no longer `0ml`
- [ ] Import preview with any flagged rows → see banner above the table + `Price warnings` summary stat + ⚠️ on each affected row
- [ ] Swedish locale still translates all `addBottle.priceWarning.*` keys