### PR TITLE
docs: admin global stats + data-quality guards

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# Cellarion — Architecture Docs
+
+Deep-dive writeups of features that have non-obvious internals. Aimed at a developer who's reading the code and wants the *why* and the *shape* before drilling into specific files.
+
+For top-level project orientation (setup, stack, ports, demo data, GDPR), see [`../CLAUDE.md`](../CLAUDE.md).
+
+## Docs
+
+- **[Cellar Chat Architecture](./cellar-chat-architecture.md)** — RAG pipeline (query expansion → embedding → Qdrant → cellar filter → enrichment → streaming Claude). Covers wine-context round-tripping, SSE event shapes, rate limiting, and session persistence.
+- **[Admin Global Stats](./admin-global-stats-architecture.md)** — How `/admin/stats` builds 14 sections from ~20 Mongo aggregations. Covers the `excludeAdmins` filter chain, 5-minute in-memory caching, the maturity `$switch` pipeline, the `$bucket` empty-row trap, and privacy guards (redaction on small platforms, inline NoSQL-injection sanitisation).
+- **[Data Quality Guards](./data-quality-guards.md)** — The two boundary defences against bad data entry: `parseLocaleNumber` (locale-aware replacement for `parseFloat`, fixes EU/Swedish CSV imports) and the four price-sanity rules (absolute cap, user-median outlier, market-median outlier, possibly-cents heuristic).
+
+## Conventions
+
+Every doc here follows the same shape:
+
+- H1 with em-dash subtitle
+- ASCII flow diagram where the pipeline has more than ~3 stages
+- Tables for mappings (rule → action, code → file role, etc.)
+- "Key Files" footer mapping the doc's concepts back to source paths
+
+If you're adding a new doc, that pattern keeps the directory legible.

--- a/docs/admin-global-stats-architecture.md
+++ b/docs/admin-global-stats-architecture.md
@@ -1,0 +1,169 @@
+# Admin Global Stats — How It Works
+
+The `/admin/stats` page surfaces platform-wide, anonymised statistics across every Cellarion user in a single dashboard. It's the answer to questions like *"how many bottles are tracked?"*, *"where are people losing trial subscriptions?"*, and *"what's our drink-window-coverage rate?"* — without writing ad-hoc Mongo queries.
+
+The page is admin-only, has zero per-user PII in its responses, and exists so the same numbers can feed blog posts, press, and product reporting from one source of truth.
+
+---
+
+## High-Level Flow
+
+```
+Admin opens /admin/stats
+    │
+    ▼
+┌────────────────────────────────┐
+│  GET /api/admin/stats/global   │  requireAuth + requireRole('admin')
+│    ?excludeAdmins=true|false   │
+│    ?force=true|false           │
+└──────────────┬─────────────────┘
+               │
+               ▼
+┌────────────────────────────────┐
+│   In-memory cache lookup       │  Key: 'true' | 'false' (excludeAdmins)
+│   TTL: 5 minutes               │  force=true bypasses
+└─────┬──────────────────────────┘
+      │ miss
+      ▼
+┌────────────────────────────────┐
+│   Resolve admin filter chain   │  If excludeAdmins, fetch admin user IDs
+│   (one User.find at the top)   │  + admin cellar IDs, build $nin filters
+└──────────────┬─────────────────┘
+               │
+               ▼
+┌────────────────────────────────┐
+│   Run ~20 aggregations in      │  Bottle, Cellar, User, WineDefinition,
+│   parallel (Promise.all)       │  WineVintageProfile, WineRequest,
+│                                │  BottleImage, Rack
+└──────────────┬─────────────────┘
+               │
+               ▼
+┌────────────────────────────────┐
+│   Cache the payload, return    │  fromCache=false on the first hit;
+│   { ...stats, fromCache: bool }│  true for every subsequent caller
+└────────────────────────────────┘
+```
+
+---
+
+## Sections (14)
+
+The payload is structured so the frontend can render each section independently.
+
+| Section | What it shows | Source |
+|---|---|---|
+| **Overview** | Users, cellars, bottle counts (active / consumed / drank / gifted / sold / other), avg per user, avg per cellar, unique WineDefinitions | `Bottle.countDocuments` + `Cellar.countDocuments` + `User.countDocuments` |
+| **Engagement** | Active users 24h / 7d / 30d / 90d (added or consumed a bottle in the window) | `Bottle.aggregate $group` per window |
+| **Recent activity** | New users + bottles added + bottles consumed in 30d / 90d | Date-filter counts |
+| **12-month trends** | Monthly series (back-filled to always emit 12 entries) for bottles added, consumed, new users, new cellars | `$dateToString` group, then JS back-fill |
+| **Subscriptions** | Plan distribution, paid users, trial-eligible, plans expiring in 7d/30d, Stripe-customer count | `User.aggregate $group` on `plan` |
+| **Drink-window maturity** | Bottles classified peak / early / not-ready / late / declining via `$lookup` → `$switch` against the current year. Plus profile-coverage %. | See *Maturity classification* below |
+| **Quality & ratings** | Avg rating normalised to 0–100, distribution histogram, avg by wine type | `$switch` for cross-scale normalisation |
+| **Vintage** | Avg vintage age, oldest/newest, by-decade distribution | `$convert: to: 'int'` + `$bucket`-style group |
+| **Composition** | Top 15 countries / regions / grapes / producers + by-type breakdown | `$lookup` chains over WineDefinition |
+| **Most-collected wines** | Top 10 wines by bottle count | `$group` on `wineDefinition` |
+| **Most expensive bottles** | Top 10 individual bottles by price, **anonymised + redacted on small platforms** | See *Privacy guards* below |
+| **Value by currency** | Count / avg / median / total / max grouped by currency (no cross-rate noise) | `$group` per currency + JS median |
+| **Library health** | Wine-definition coverage, profiles total/reviewed/pending, pending wine requests + image reviews, total images + racks | Misc counts on `WineDefinition`, `WineVintageProfile`, `WineRequest`, `BottleImage`, `Rack` |
+| **Patterns** | Holding-time distribution, cellar-size distribution, bottle-size distribution (with rollup of `750ml` variants) | `$bucket` on derived day-diffs + cellar size |
+
+---
+
+## Maturity Classification
+
+Bottle maturity is the Cellarion USP made visible. The pipeline joins active bottles with their reviewed `WineVintageProfile` and runs the same classifier as `utils/maturityUtils.js#classifyMaturity` — *in Mongo* — via a pipeline-side `$switch`.
+
+```
+{ $match: { status: 'active', ...bottleMatch } }
+    │
+    ▼
+{ $lookup: 'winevintageprofiles'  (sub-pipeline matches wd+vintage+reviewed) }
+    │
+    ▼
+{ $unwind: { preserveNullAndEmptyArrays: true } }
+    │
+    ▼
+{ $addFields: { maturity: $cond + $switch } }
+    │
+    ▼
+{ $group: { _id: '$maturity', count: $sum 1 } }
+```
+
+The classifier has two guard branches before the switch:
+
+1. **`profile == null`** → `noProfile` (no review yet)
+2. **Reviewed profile with all `earlyFrom` / `peakFrom` / `peakUntil` null** → `noProfile`. Partial profiles are real (every year field is optional on `WineVintageProfile`), and earlier versions defaulted these into `peak` and inflated the bucket.
+
+The default fall-through is `'early'`, matching `classifyMaturity`'s final `return 'early'`. **This is load-bearing** — an earlier version defaulted to `'peak'` and reported peak counts that were 5-30 % too high in the test data.
+
+---
+
+## `excludeAdmins` filter chain
+
+When set via `?excludeAdmins=true`, admin-owned data is filtered out of every per-user statistic. Useful for a customer-only view that ignores test/admin data.
+
+Resolution happens **once** at the top of the request, then the same `$nin` clauses thread through every aggregation:
+
+```
+admins = User.find({ roles: 'admin' }).distinct('_id')
+    │
+    ▼
+adminCellarIds = Cellar.find({ user: $in: admins }).distinct('_id')
+    │
+    ▼
+┌─ userMatch    = { roles: $nin: ['admin'] }
+├─ bottleMatch  = { user:   $nin: adminIds }
+├─ cellarMatch  = { user:   $nin: adminIds }
+├─ imageMatch   = { uploadedBy: $nin: adminIds }
+├─ requestMatch = { user:   $nin: adminIds }
+└─ rackMatch    = { cellar: $nin: adminCellarIds }   ← indirect chain
+```
+
+`WineDefinition` and `WineVintageProfile` are **not filtered** — they're shared platform reference data, curated by admins by design.
+
+The response echoes `excludeAdmins` and `adminsExcludedCount` so the UI can show *"3 admins hidden"* next to the toggle.
+
+---
+
+## Caching
+
+`computeGlobalStats` wraps an in-memory `Map` cache:
+
+- Key: `String(excludeAdmins)` → `'true'` or `'false'` (two slots only)
+- TTL: 5 minutes
+- Returns `{ ...payload, fromCache, cachedAt }` so the UI can show a *"cached"* tag next to the timestamp
+- `?force=true` bypasses the cache and recomputes fresh. The page's **Refresh** button sends this flag
+
+**Why bother?** Each call runs ~20 aggregations plus an in-memory median sort per currency. Admin traffic is low, but a curious admin holding Cmd-R would otherwise hammer Mongo and inflate the median-resort cost (an O(n log n) sort of every priced bottle per currency).
+
+---
+
+## `$bucket` label trap
+
+`$bucket` only emits buckets that contain at least one document — empty middle buckets are silently omitted. The first version of the service mapped results by array index, which meant an empty `1–2yr` bucket would shift every later label down (the real `2–5yr` count appeared labelled `1–2yr`).
+
+Now: every bucket-using section (`holdingTime`, `cellarSizeDistribution`, `ratingDistribution`) defines a `[{ id, label }]` table and looks up rows by `_id` (the lower-boundary value) rather than by index.
+
+Rows with `count: 0` are filtered out on the frontend so the page doesn't show `0%` clutter.
+
+---
+
+## Privacy guards
+
+- **No PII** is ever in the response. All figures are counts, averages, or distributions.
+- **Most-expensive-bottles** could fingerprint a single owner on small platforms. When `usersWithBottles < 25`, the wine name + producer + vintage are redacted; only the price + currency are shown. The frontend renders *"(hidden — small user base)"* with a banner explaining why.
+- **Inline `String()` + `HEX24` sanitisation** on every value that comes from `req.body` before it reaches a Mongo `$match`. Defuses NoSQL operator injection at the resolver boundary (`computeUserMediansByCurrency`, `findUserMedian`, `findMarketMedian`).
+
+---
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `backend/src/services/globalStatsService.js` | All 20 aggregations + cache wrapper + admin-exclude resolver |
+| `backend/src/routes/admin/stats.js` | `GET /api/admin/stats/global`, `requireAuth + requireRole('admin')`, query-param parsing |
+| `backend/src/utils/maturityUtils.js` | Canonical `classifyMaturity` — the maturity `$switch` mirrors this |
+| `frontend/src/pages/AdminStats.js` | Section-based dashboard, `excludeAdmins` toggle, force-refresh, bar charts |
+| `frontend/src/pages/AdminStats.css` | Stat cards, bar charts, horizontal bars, warn/ok accents |
+| `frontend/src/api/admin.js` | `adminGetGlobalStats({ excludeAdmins, force })` client |
+| `frontend/src/locales/{en,sv}/translation.json` | `adminStats.*` namespace |

--- a/docs/data-quality-guards.md
+++ b/docs/data-quality-guards.md
@@ -1,0 +1,205 @@
+# Data Quality Guards at the Bottle-Entry Boundary
+
+Cellarion's data is only as good as what users enter. Two guard rails sit at the moments a price (or any number) crosses into the database:
+
+1. **`parseLocaleNumber`** — locale-aware number parser used by every CSV import path. Replaces `parseFloat` to fix systematic under-counting on EU/Swedish exports.
+2. **Price sanity warnings** — four deterministic rules surfaced as non-blocking warnings on the add-bottle form and the import preview. Catches 100×-too-high fat-finger errors before they pollute the dataset.
+
+Both ship as **Tier 1** of the data-quality plan: no AI, no external service, pure rules. The plan tracks Tier 2 (LLM batch validation) and Tier 3 (real-time LLM-in-the-loop) as additive layers if rule-based ever stops being enough.
+
+---
+
+## Why this exists
+
+A single user added 27 bottles with prices ranging from $14,000 to $260,000 USD — all exactly 100× too high (Opus One at $50k, Chevalier-Montrachet GC at $260k). It dragged the global avg USD bottle price to $7,731 and made the /admin/stats *"most expensive"* leaderboard read like a Sotheby's catalogue.
+
+Investigation showed two distinct failure modes:
+
+| Mode | Cause | Visible symptom |
+|---|---|---|
+| **Over-counting** | Manual entry slip (extra zero) or unit mismatch | $260,000 for a $2,600 wine |
+| **Under-counting** | `parseFloat('1.234,56')` returns `1.234` on EU CSV exports | Bottle sizes show as `0ml`, prices off by 1000× |
+
+The two fixes attack each mode at the source.
+
+---
+
+## `parseLocaleNumber` — Locale-aware number parsing
+
+### The bug
+
+`parseFloat` understands US format only and silently stops at the first non-numeric character:
+
+| Input | `parseFloat` returns | Should be |
+|---|---|---|
+| `'1234.56'` | 1234.56 ✓ | 1234.56 |
+| `'1,234.56'` | **1** ✗ | 1234.56 |
+| `'1.234,56'` | **1.234** ✗ | 1234.56 |
+| `'1 234,56'` | **1** ✗ | 1234.56 |
+| `'0,75'` | **0** ✗ | 0.75 (a 750ml bottle in litres) |
+| `'$25.00'` | **NaN** ✗ | 25 |
+
+Every Vivino export from a Swedish/German user, every Systembolaget price list, every Oeno-by-Vintec export in EU locale was silently mis-parsing prices and bottle sizes — without any error.
+
+### The rules
+
+```
+Input → trim, strip currency symbols + whitespace
+    │
+    ▼
+┌────────────────────────────────┐
+│  Has both ',' and '.' ?         │
+│   yes → last one is the decimal │
+│         (US "1,234.56"  or EU "1.234,56") │
+│   no  → continue                          │
+└──────────┬─────────────────────┘
+           │
+           ▼
+┌────────────────────────────────┐
+│  Has ',' only ?                            │
+│   parts.length > 2  → US thousands         │
+│   one comma, 3 digits after, integer > 0   │
+│                     → US thousands ("1,234" → 1234) │
+│   otherwise         → EU decimal           │
+└──────────┬─────────────────────┘
+           │
+           ▼
+┌────────────────────────────────┐
+│  Has '.' only ?                            │
+│   parts.length > 2  → EU thousands         │
+│                       ("1.234.567" → 1234567) │
+│   one period        → US decimal (parseFloat handles) │
+└────────────────────────────────┘
+```
+
+### Two ambiguity rules worth knowing
+
+| Input | Treated as | Why |
+|---|---|---|
+| `'1,234'` | US thousands → **1234** | Vivino/CellarTracker exports use this format extensively for unquoted numbers. EU decimals with three fractional digits are rare in wine pricing. |
+| `'0,375'` | EU decimal → **0.375** | Leading zero means it's almost certainly a bottle size in litres (375ml). The thousands interpretation makes no sense. |
+
+The leading-zero check on commas protects the bottle-size import path without giving up the more common Vivino case.
+
+### Applied where
+
+Five call sites in `frontend/src/utils/importMappers.js`:
+
+| Mapper | What now uses `parseLocaleNumber` |
+|---|---|
+| Vivino | `price`, `rating` |
+| CellarTracker | `price`, `rating` |
+| Generic CSV | `price`, `rating` |
+| Cellarion native | every numeric field via the `num()` helper |
+| Oeno-by-Vintec | `Bottle Size Liters`, `Purchase Cost` |
+
+Integer fields (`Quantity`, rack positions) keep using `parseInt` — always whole, no separator ambiguity.
+
+### Locked-in regression tests
+
+Each of the four parseFloat bugs is now an explicit assertion in `frontend/src/utils/importMappers.test.js`:
+
+```js
+expect(parseFloat('1.234,56')).toBe(1.234);     // bug locked in
+expect(parseLocaleNumber('1.234,56')).toBe(1234.56);
+
+expect(parseFloat('0,75')).toBe(0);             // bug locked in
+expect(parseLocaleNumber('0,75')).toBe(0.75);
+```
+
+If anyone ever swaps `parseLocaleNumber` back for `parseFloat`, these tests fail loudly.
+
+---
+
+## Price Sanity Warnings — Four Rules
+
+Non-blocking warnings shown to the user as a price is being entered. Saves always succeed; the warning is a hint that something might be off.
+
+### The four rules
+
+| Rule | Severity | Fires when | Caught the incident? |
+|---|---|---|---|
+| `absoluteCap` | warning | price > typical per-currency max ($50k USD, 500k SEK, etc.) | ✓ (caught the $260k Chevalier-Montrachet) |
+| `userOutlier` | warning | price ≥ 50× user's own median in same currency (sample ≥ 5) | ✓ (Opus One $50k when user median is ~$500) |
+| `aboveMarket` | warning | price ≥ 5× recorded WineVintagePrice for this wine+vintage in same currency | ✓ (when somm-curated price exists) |
+| `possiblyCents` | info | price ≥ 10,000 AND divisible by 100 — hints user may have entered cents | ✓ (informational nudge) |
+
+Multiple rules can fire on one bottle. The Chevalier-Montrachet case stacks all four.
+
+### Where they fire
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Add Bottle form                                          │
+│   User types in the price field                           │
+│   → frontend/src/utils/priceValidation.js                 │
+│   → warnings under the price input update LIVE            │
+│   → no round-trip needed (rules are pure)                 │
+└──────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────┐
+│  Import preview                                           │
+│   POST /api/bottles/import/validate                       │
+│   → backend computes per-currency user medians ONCE       │
+│     (single Mongo aggregation, no N+1)                    │
+│   → annotates each result row with priceWarnings[]        │
+│   → summary stat 'Price warnings' + banner at top         │
+│   → ⚠️ on each affected price detail-tag, hover for why    │
+└──────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────┐
+│  POST /api/bottles (single bottle save)                   │
+│   → backend gathers warnings with user + market context   │
+│   → returns { bottle, priceWarnings } — never blocks save │
+└──────────────────────────────────────────────────────────┘
+```
+
+The frontend rules are a **mirror** of the backend rules in the same repo. Keep both in sync — they live in `backend/src/utils/priceValidation.js` and `frontend/src/utils/priceValidation.js`.
+
+### Why pure rules, not AI
+
+For Tier 1 the answer is *because we don't need AI*:
+
+- Rules are deterministic, instantly testable, zero ongoing cost
+- 20 unit tests cover every rule + every edge case + the production-incident scenario
+- A 100× price error is mechanically catchable without semantic understanding
+- AI would buy nothing extra at this level
+
+The tiered plan is:
+
+| Tier | What | Status |
+|---|---|---|
+| **1** | Pure rule-based warnings (this PR) | Shipped |
+| **2** | Nightly LLM batch validation of suspect entries — surfaces findings to admin queue | Deferred until Tier 1 misses enough to justify it |
+| **3** | Real-time LLM-in-the-loop with Wine-Searcher comparison | Overkill at current scale |
+
+---
+
+## NoSQL injection guard
+
+`priceWarnings.js` resolvers are reachable from `req.body` (the `wineDefinition`, `vintage`, `currency` fields on the bottle-add request). Every value reaching a Mongo `$match` is sanitised **inline** with `String()` coercion + a `HEX24` regex check for ObjectId fields:
+
+```js
+const cur     = String(currency || 'USD').toUpperCase();
+const wdStr   = wineDefinitionId == null ? '' : String(wineDefinitionId);
+const wdOk    = /^[a-f0-9]{24}$/i.test(wdStr);
+// ... only if wdOk does the findOne run
+```
+
+An injected operator object like `{ $ne: null }` stringifies to `"[object Object]"` — fails the HEX24 regex (for ObjectIds) or simply doesn't match any document (for currency / vintage strings). CodeQL's `js/sql-injection` analyser recognises the inline `String()` + regex pattern; an earlier refactor that extracted these into a helper hid the sanitiser from the static analysis.
+
+---
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `frontend/src/utils/importMappers.js` | `parseLocaleNumber`, applied across all 5 import mappers |
+| `frontend/src/utils/importMappers.test.js` | Regression tests pinning the parseFloat bugs |
+| `backend/src/utils/priceValidation.js` | The four pure sanity rules + their constants |
+| `backend/src/utils/priceValidation.test.js` | 20-test suite — each rule + the prod incident |
+| `backend/src/services/priceWarnings.js` | DB-backed wrapper: user-median, market-median, NoSQL-injection guards |
+| `frontend/src/utils/priceValidation.js` | Frontend mirror of the rules + `describePriceWarning()` for non-i18n contexts |
+| `frontend/src/pages/AddBottle.js` | Live warnings under the price input |
+| `frontend/src/pages/ImportBottles.js` | ⚠️ per row, summary stat, banner at top |
+| `frontend/src/locales/{en,sv}/translation.json` | `addBottle.priceWarning.*` namespace |


### PR DESCRIPTION
Adds architecture writeups for the features shipped in v1.55.x and a small README index for the `/docs` directory.

## What's added

| File | Covers |
|---|---|
| `docs/admin-global-stats-architecture.md` | Flow diagram + section list (14), `excludeAdmins` filter chain, 5-minute in-memory cache, the maturity \`\$switch\` pipeline (`noProfile` guard + `default: 'early'` decisions), the `\$bucket` empty-row trap, privacy guards (small-platform redaction + inline NoSQL-injection sanitisation) |
| `docs/data-quality-guards.md` | The two boundary defences: `parseLocaleNumber` (locale-aware replacement for `parseFloat` — covers the EU/Swedish CSV bug table) and the four price-sanity rules (absolute cap, user-median outlier, market-median outlier, possibly-cents). Includes the leading-zero ambiguity rule for `'0,375'`. |
| `docs/README.md` | Tiny index linking all three docs + the shape convention so future additions stay consistent |

Style mirrors the existing `cellar-chat-architecture.md`: H1 with em-dash subtitle, ASCII flow diagrams where the pipeline has more than ~3 stages, tables for mappings, "Key Files" footer.

## Test plan

- [ ] Render each doc on github.com — confirm ASCII diagrams + tables render correctly
- [ ] All file links from `docs/README.md` resolve to existing files
- [ ] Verify the "Key Files" tables in both new docs point to real paths