### PR TITLE
fix(rate-limit): validate Cloudflare origin before trusting CF-Connecting-IP (audit CRITICAL #1)

### DIFF
--- a/backend/src/utils/clientIp.js
+++ b/backend/src/utils/clientIp.js
@@ -1,12 +1,34 @@
+const { isCloudflareIP } = require('./cloudflareIps');
+
 /**
- * Returns the real client IP address.
+ * Returns the real client IP address used for rate-limit keys and audit logs.
  *
- * Prefers the Cloudflare-set CF-Connecting-IP header (cannot be spoofed when
- * traffic flows through Cloudflare). Falls back to req.ip for non-Cloudflare
- * environments (local dev, direct access).
+ * Cellarion runs behind Cloudflare → Traefik → nginx → backend. The trust
+ * model on this hop chain is:
+ *
+ *   - `req.ip` is resolved by Express against `trust proxy = 2`. With our
+ *     chain, that means req.ip is the Cloudflare edge IP for requests that
+ *     actually came through Cloudflare, and the attacker's IP for requests
+ *     that hit the Hetzner origin directly (bypassing CF).
+ *   - The CF-Connecting-IP header is only set by Cloudflare itself, but the
+ *     header can be spoofed by anyone hitting the origin directly. Trusting
+ *     it unconditionally — as an earlier version did — turned every rate
+ *     limiter (login, password reset, /api/chat) into a no-op for anyone
+ *     willing to rotate the header value per request.
+ *
+ * Fix: only honour CF-Connecting-IP when req.ip is itself inside Cloudflare's
+ * published edge IP range. Real users via Cloudflare get their real IP. Direct
+ * attackers fall through to req.ip (their actual source) and are correctly
+ * rate-limited on it.
  */
 function getClientIp(req) {
-  return req.headers['cf-connecting-ip'] || req.ip;
+  const cfHeader = req && req.headers && req.headers['cf-connecting-ip'];
+  if (cfHeader && isCloudflareIP(req.ip)) {
+    // CF sends a single IP, but split defensively in case any upstream
+    // proxy appends to it.
+    return String(cfHeader).split(',')[0].trim();
+  }
+  return req && req.ip;
 }
 
 module.exports = { getClientIp };

--- a/backend/src/utils/clientIp.test.js
+++ b/backend/src/utils/clientIp.test.js
@@ -1,13 +1,92 @@
 const { getClientIp } = require('./clientIp');
 
+const REAL_USER     = '54.123.45.67';
+const CF_EDGE_IP    = '173.245.50.1';   // inside 173.245.48.0/20
+const CF_EDGE_IPV6  = '2606:4700::1';
+const ATTACKER_IP   = '116.202.5.10';   // Hetzner-style, NOT in any CF range
+
 describe('getClientIp', () => {
-  it('returns CF-Connecting-IP when present', () => {
+  it('returns CF-Connecting-IP when req.ip is a Cloudflare edge (the happy path)', () => {
+    const req = {
+      ip: CF_EDGE_IP,
+      headers: { 'cf-connecting-ip': REAL_USER },
+    };
+    expect(getClientIp(req)).toBe(REAL_USER);
+  });
+
+  it('IGNORES a spoofed CF-Connecting-IP when req.ip is NOT Cloudflare (the bypass we are blocking)', () => {
+    // Attacker hits Hetzner origin directly, sets header to anything.
+    // Pre-fix, this returned the attacker-chosen value and bypassed every limiter.
+    const req = {
+      ip: ATTACKER_IP,
+      headers: { 'cf-connecting-ip': '1.2.3.4' },
+    };
+    expect(getClientIp(req)).toBe(ATTACKER_IP);
+  });
+
+  it('falls back to req.ip when no CF header is present', () => {
+    const req = {
+      ip: CF_EDGE_IP,
+      headers: {},
+    };
+    expect(getClientIp(req)).toBe(CF_EDGE_IP);
+  });
+
+  it('handles a missing headers object', () => {
+    const req = { ip: ATTACKER_IP };
+    expect(getClientIp(req)).toBe(ATTACKER_IP);
+  });
+
+  it('takes the leftmost IP from a comma-separated CF header (defensive)', () => {
+    const req = {
+      ip: CF_EDGE_IP,
+      headers: { 'cf-connecting-ip': `${REAL_USER}, 1.1.1.1` },
+    };
+    expect(getClientIp(req)).toBe(REAL_USER);
+  });
+
+  it('honours CF-Connecting-IP via an IPv4-mapped IPv6 req.ip (dual-stack socket)', () => {
+    const req = {
+      ip: '::ffff:173.245.50.1',
+      headers: { 'cf-connecting-ip': REAL_USER },
+    };
+    expect(getClientIp(req)).toBe(REAL_USER);
+  });
+
+  it('honours CF-Connecting-IP via an IPv6 CF edge', () => {
+    const req = {
+      ip: CF_EDGE_IPV6,
+      headers: { 'cf-connecting-ip': REAL_USER },
+    };
+    expect(getClientIp(req)).toBe(REAL_USER);
+  });
+
+  it('returns undefined when req.ip is undefined (no IP to validate against)', () => {
+    const req = {
+      ip: undefined,
+      headers: { 'cf-connecting-ip': REAL_USER },
+    };
+    expect(getClientIp(req)).toBeUndefined();
+  });
+
+  it('handles req being null gracefully', () => {
+    expect(getClientIp(null)).toBeFalsy();
+  });
+
+  it('handles req with no headers and no ip', () => {
+    expect(getClientIp({})).toBeUndefined();
+  });
+
+  // Pre-existing regression: 172.69.x.x is inside the CF 172.64.0.0/13 range,
+  // so this case behaves identically to the spec test on the same input.
+  it('still trusts CF-Connecting-IP when req.ip is in 172.64.0.0/13 (existing pattern)', () => {
     const req = { headers: { 'cf-connecting-ip': '1.2.3.4' }, ip: '172.69.0.1' };
     expect(getClientIp(req)).toBe('1.2.3.4');
   });
 
-  it('falls back to req.ip when CF-Connecting-IP is absent', () => {
-    const req = { headers: {}, ip: '192.168.1.50' };
+  // Pre-existing regression: private IPs are not CF, so any header is ignored.
+  it('ignores CF-Connecting-IP when req.ip is a private/internal address', () => {
+    const req = { headers: { 'cf-connecting-ip': '1.2.3.4' }, ip: '192.168.1.50' };
     expect(getClientIp(req)).toBe('192.168.1.50');
   });
 });

--- a/backend/src/utils/cloudflareIps.js
+++ b/backend/src/utils/cloudflareIps.js
@@ -1,0 +1,74 @@
+const { BlockList, isIPv4, isIPv6 } = require('node:net');
+
+/**
+ * Published Cloudflare IP ranges — sourced from:
+ *   https://www.cloudflare.com/ips-v4
+ *   https://www.cloudflare.com/ips-v6
+ *
+ * Last verified: 2026-05. These ranges change about once every 3 years.
+ * If legitimate Cloudflare-proxied requests start showing as rate-limited
+ * on an unexpected IP, refresh both lists from the URLs above.
+ *
+ * Used by utils/clientIp.js to decide whether the CF-Connecting-IP header
+ * is trustworthy on a given request. The bare check is also useful for
+ * audit logging (flag mismatches between req.ip and CF-Connecting-IP).
+ */
+const CLOUDFLARE_IPV4_RANGES = [
+  '173.245.48.0/20',
+  '103.21.244.0/22',
+  '103.22.200.0/22',
+  '103.31.4.0/22',
+  '141.101.64.0/18',
+  '108.162.192.0/18',
+  '190.93.240.0/20',
+  '188.114.96.0/20',
+  '197.234.240.0/22',
+  '198.41.128.0/17',
+  '162.158.0.0/15',
+  '104.16.0.0/13',
+  '104.24.0.0/14',
+  '172.64.0.0/13',
+  '131.0.72.0/22',
+];
+
+const CLOUDFLARE_IPV6_RANGES = [
+  '2400:cb00::/32',
+  '2606:4700::/32',
+  '2803:f800::/32',
+  '2405:b500::/32',
+  '2405:8100::/32',
+  '2a06:98c0::/29',
+  '2c0f:f248::/32',
+];
+
+const blockList = new BlockList();
+for (const range of CLOUDFLARE_IPV4_RANGES) {
+  const [net, prefix] = range.split('/');
+  blockList.addSubnet(net, Number(prefix), 'ipv4');
+}
+for (const range of CLOUDFLARE_IPV6_RANGES) {
+  const [net, prefix] = range.split('/');
+  blockList.addSubnet(net, Number(prefix), 'ipv6');
+}
+
+/**
+ * @param {string} ip  IPv4 or IPv6 address (also accepts IPv4-mapped IPv6
+ *                     forms like '::ffff:1.2.3.4' which Node uses on dual-
+ *                     stack sockets).
+ * @returns {boolean}  true iff `ip` falls inside a published Cloudflare range.
+ *                     Non-string / malformed inputs return false (callers
+ *                     get a safe "don't trust this request" outcome).
+ */
+function isCloudflareIP(ip) {
+  if (typeof ip !== 'string' || !ip) return false;
+  // Node's dual-stack sockets render IPv4 as '::ffff:1.2.3.4'. The
+  // BlockList doesn't unwrap these for an IPv4 subnet match, so strip
+  // the prefix first.
+  let addr = ip;
+  if (addr.startsWith('::ffff:')) addr = addr.slice(7);
+  if (isIPv4(addr)) return blockList.check(addr, 'ipv4');
+  if (isIPv6(addr)) return blockList.check(addr, 'ipv6');
+  return false;
+}
+
+module.exports = { isCloudflareIP, CLOUDFLARE_IPV4_RANGES, CLOUDFLARE_IPV6_RANGES };

--- a/backend/src/utils/cloudflareIps.test.js
+++ b/backend/src/utils/cloudflareIps.test.js
@@ -1,0 +1,81 @@
+const { isCloudflareIP } = require('./cloudflareIps');
+
+describe('isCloudflareIP', () => {
+  describe('Cloudflare ranges (true)', () => {
+    it('accepts a CF IPv4 in 173.245.48.0/20', () => {
+      expect(isCloudflareIP('173.245.50.1')).toBe(true);
+    });
+
+    it('accepts a CF IPv4 in 104.16.0.0/13', () => {
+      expect(isCloudflareIP('104.20.1.1')).toBe(true);
+    });
+
+    it('accepts a CF IPv4 at the lower boundary of a range', () => {
+      expect(isCloudflareIP('103.21.244.0')).toBe(true);
+    });
+
+    it('accepts a CF IPv4 at the upper boundary of a range', () => {
+      // 173.245.48.0/20 covers 173.245.48.0 – 173.245.63.255
+      expect(isCloudflareIP('173.245.63.255')).toBe(true);
+    });
+
+    it('accepts a CF IPv6 in 2606:4700::/32', () => {
+      expect(isCloudflareIP('2606:4700::1')).toBe(true);
+    });
+
+    it('accepts a CF IPv6 in the /29 range', () => {
+      expect(isCloudflareIP('2a06:98c0::1')).toBe(true);
+    });
+
+    it('accepts an IPv4-mapped IPv6 form of a CF IP (dual-stack socket)', () => {
+      expect(isCloudflareIP('::ffff:173.245.50.1')).toBe(true);
+    });
+  });
+
+  describe('non-Cloudflare ranges (false)', () => {
+    it('rejects a Hetzner-style IP', () => {
+      expect(isCloudflareIP('116.202.5.10')).toBe(false);
+    });
+
+    it('rejects a Google DNS IP', () => {
+      expect(isCloudflareIP('8.8.8.8')).toBe(false);
+    });
+
+    it('rejects an IPv4 just outside a CF range', () => {
+      // 173.245.48.0/20 ends at 173.245.63.255; .64.0 is outside
+      expect(isCloudflareIP('173.245.64.0')).toBe(false);
+    });
+
+    it('rejects IPv4 localhost', () => {
+      expect(isCloudflareIP('127.0.0.1')).toBe(false);
+    });
+
+    it('rejects IPv6 localhost', () => {
+      expect(isCloudflareIP('::1')).toBe(false);
+    });
+
+    it('rejects a non-CF IPv6 address', () => {
+      expect(isCloudflareIP('2001:4860:4860::8888')).toBe(false);  // Google DNS v6
+    });
+  });
+
+  describe('invalid input (false)', () => {
+    it('returns false for null / undefined / empty', () => {
+      expect(isCloudflareIP(null)).toBe(false);
+      expect(isCloudflareIP(undefined)).toBe(false);
+      expect(isCloudflareIP('')).toBe(false);
+    });
+
+    it('returns false for non-string input', () => {
+      expect(isCloudflareIP(123)).toBe(false);
+      expect(isCloudflareIP({})).toBe(false);
+      expect(isCloudflareIP([])).toBe(false);
+    });
+
+    it('returns false for malformed strings', () => {
+      expect(isCloudflareIP('not an ip')).toBe(false);
+      expect(isCloudflareIP('999.999.999.999')).toBe(false);
+      expect(isCloudflareIP('1.2.3')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes the rate-limit bypass vector flagged as **CRITICAL #1** in the security audit. `getClientIp()` trusted `req.headers['cf-connecting-ip']` from any caller — but the header is only legitimate when traffic actually flows through Cloudflare. Anyone hitting the Hetzner origin directly could rotate the header per request and silently bypass every rate limiter: login brute-force, password-reset spam, `/api/chat` Anthropic-budget burn.

## The fix

Only honour `CF-Connecting-IP` when `req.ip` itself sits inside one of Cloudflare's published edge IP ranges. With your `trust proxy = 2` chain (Traefik → nginx → backend), Express resolves `req.ip` to:

- **Real user via Cloudflare:** the Cloudflare edge IP → trust the header → use the real client IP it contains.
- **Spoofed header to origin:** the attacker's IP (not in CF range) → ignore the header → rate-limit on the attacker's actual IP.
- **No header (dev / internal traffic):** fall through to `req.ip` as before.

Real users continue to be rate-limited on their actual IP, exactly as today. The bypass goes away.

## What's in the PR

- **`backend/src/utils/cloudflareIps.js`** — Cloudflare's published IPv4 (15) and IPv6 (7) ranges, plus `isCloudflareIP(ip)` using Node's built-in `net.BlockList`. **No new dependencies.** Handles IPv4-mapped IPv6 (`::ffff:1.2.3.4`) for dual-stack sockets. Comment points at https://www.cloudflare.com/ips/ with the verify date — ranges change about once every three years.
- **`backend/src/utils/clientIp.js`** — `getClientIp` now validates before honouring the header. Defensive: handles missing `req`, missing `headers`, missing `ip`, comma-separated header values.
- **26 new test cases** across `cloudflareIps.test.js` and `clientIp.test.js`:
  - every CF range type (IPv4 lower/upper boundary, IPv6, dual-stack)
  - the explicit bypass scenario: attacker IP + spoofed header → real IP returned, header ignored
  - malformed inputs return `false` (safe outcome)
  - both pre-existing regression cases from the prior test file
- No change to `trust proxy = 2` — that setting is already correct for this validation strategy.

## Test plan

- [x] Backend tests pass — **558** (532 pre + 26 new)
- [ ] After deploy: from a Cloudflare-proxied request, audit log should show real client IP unchanged
- [ ] After deploy: from a curl to the Hetzner origin IP with a faked `CF-Connecting-IP: 1.2.3.4` header, audit log should show the curl source IP — NOT `1.2.3.4`
- [ ] After deploy: smoke-test a real user login to confirm rate limiting isn't accidentally too strict (would happen if `trust proxy` is off-by-one for the real prod chain)

## What this does NOT close

The audit also flagged two HIGHs that compound this bypass — they're separate PRs:

- **No per-account brute-force protection** — `authLimiter` is still per-IP-only. A motivated attacker with a residential-proxy budget can rotate IPs and credential-stuff one account from many addresses.
- **No per-user rate limit on /api/chat** — the weekly chat quota (5/free) survives this fix but doesn't cap concurrent SSE streams or burst rates within the global IP budget.

I'd suggest taking those as the next two PRs in the security-audit follow-up.