### PR TITLE
chore(release): v1.55.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.55.2",
+  "version": "1.55.3",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.55.2",
+  "version": "1.55.3",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Security patch addressing the audit's **CRITICAL #1** — rate-limit bypass via spoofed `CF-Connecting-IP`.

## What's in this release vs v1.55.2

### Security
- **fix(rate-limit):** validate Cloudflare origin before trusting CF-Connecting-IP (#440). `getClientIp` now only honours the header when `req.ip` is itself inside one of Cloudflare's published edge IP ranges. Real users via Cloudflare → real IP (unchanged). Direct attackers with a spoofed header → rate-limited on their actual IP. No new dependencies (uses Node's built-in `net.BlockList`). 26 new tests covering CF range matching (v4 + v6 + dual-stack), the explicit bypass scenario, and graceful handling of malformed inputs.

No schema changes. No env-var changes. No data migration.

## Test plan

- [x] Backend tests pass (558, up from 532 — 26 new)
- [ ] Smoke-test in Docker: `docker compose up --build` boots
- [ ] After deploy, real-user login from a CF-proxied browser → rate-limit counter increments normally
- [ ] After deploy, `curl -H 'CF-Connecting-IP: 1.2.3.4' https://<hetzner-origin-ip>` → backend rate-limits on the curl source IP, NOT on `1.2.3.4` (verify via the next /api/auth/login failed-attempts audit log)