### PR TITLE
fix(email): unsubscribe links use FRONTEND_URL (was localhost in prod)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -96,7 +96,7 @@ app.use('/api/wine-lists', express.json({ limit: '1mb' }));
 app.use(express.json({ limit: '10kb' }));
 const corsOrigin = process.env.FRONTEND_URL || (process.env.NODE_ENV === 'production' ? false : 'http://localhost:3000');
 if (process.env.NODE_ENV === 'production' && !process.env.FRONTEND_URL) {
-  console.warn('[security] FRONTEND_URL is not set — CORS will block all cross-origin requests in production');
+  console.warn('[security] FRONTEND_URL is not set — CORS will block all cross-origin requests, AND every email unsubscribe / verification / password-reset link will point at http://localhost:3000');
 }
 app.use(cors({
   origin: corsOrigin,

--- a/backend/src/services/mailgun.js
+++ b/backend/src/services/mailgun.js
@@ -131,7 +131,13 @@ async function sendDrinkWindowDigest(toEmail, username, bottles, userId) {
   const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
   const { createUnsubscribeToken } = require('../utils/unsubscribe');
   const unsubToken = createUnsubscribeToken(userId);
-  const unsubLink = `${process.env.BACKEND_URL || 'http://localhost:5000'}/api/users/unsubscribe?token=${unsubToken}`;
+  // Use FRONTEND_URL — the unsubscribe endpoint lives on the backend but is
+  // routed through the same public host as the SPA via Traefik (/api/* → backend).
+  // Using BACKEND_URL was a footgun: it isn't set on the standard deployment
+  // and silently fell back to http://localhost:5000, shipping broken links in
+  // every email. FRONTEND_URL is already required for CORS so it's guaranteed
+  // present in any working production setup.
+  const unsubLink = `${frontendUrl}/api/users/unsubscribe?token=${unsubToken}`;
 
   const statusLabel = (s) =>
     s === 'peak'      ? 'Entered peak — drink now'
@@ -340,7 +346,9 @@ async function sendDiscussionReplyEmail(toEmail, recipientName, recipientId, rep
 
   const { createUnsubscribeToken } = require('../utils/unsubscribe');
   const unsubToken = createUnsubscribeToken(recipientId);
-  const unsubLink = `${process.env.BACKEND_URL || 'http://localhost:5000'}/api/users/unsubscribe?token=${unsubToken}`;
+  // See sendDrinkWindowDigest for why this uses FRONTEND_URL not BACKEND_URL.
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  const unsubLink = `${frontendUrl}/api/users/unsubscribe?token=${unsubToken}`;
 
   const verb = kind === 'quote' ? 'quoted you' : kind === 'mention' ? 'mentioned you' : 'replied to your discussion';
   const subject = kind === 'quote'


### PR DESCRIPTION
Fixes the production bug Johan caught from a phone screenshot: the "Unsubscribe from all emails" link in every notification email resolves to `http://localhost:5000/api/users/unsubscribe?token=...`.

## Cause

Both unsubscribe-URL builders in `backend/src/services/mailgun.js` (lines 134 and 343) used `process.env.BACKEND_URL` with a fallback to `http://localhost:5000`:

\`\`\`js
const unsubLink = \`\${process.env.BACKEND_URL || 'http://localhost:5000'}/api/users/unsubscribe?token=\${unsubToken}\`;
\`\`\`

`BACKEND_URL` is never set on the standard deployment — every other URL in that file uses `FRONTEND_URL`. The fallback then quietly produced a localhost URL that resolved to nothing on the user's phone, so the link did nothing visible (and the underlying unsubscribe handler never even saw the request, separate from the GDPR no-op fix in #442).

## Fix

Swap `BACKEND_URL` for `FRONTEND_URL` in both call sites. The unsubscribe endpoint lives on the backend but is reachable via the same public host as the SPA because Traefik routes `/api/*` to backend. Real prod URL becomes `https://cellarion.app/api/users/unsubscribe?token=...` — clickable, routable, works.

Why `FRONTEND_URL` is the right pick:
- It's already required for CORS, so it's guaranteed present in any working production setup.
- One fewer env var to forget.
- Same pattern the other 5 URL builders in `mailgun.js` already use.

Also tightens the existing `FRONTEND_URL`-missing startup warning so it mentions email links break too, not just CORS — better breadcrumb for the next person who skips setting it.

## Test plan

- [x] Backend tests pass (558, unchanged)
- [ ] After deploy, click the "Unsubscribe from all emails" link in the next notification email → resolves to `https://cellarion.app/api/users/unsubscribe?token=...` → redirects to `/unsubscribed`
- [ ] Combined with #442 (which makes that handler actually flip every notification flag), unsubscribe links finally work end-to-end

## Order of operations on prod

1. Merge this PR
2. Merge #442 (the GDPR-Article-21 unsubscribe-handler fix)
3. Cut a single release bundling both (v1.55.4)
4. Standard `docker compose pull && up -d`