### PR TITLE
chore(release): v1.55.4

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.55.3",
+  "version": "1.55.4",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.55.3",
+  "version": "1.55.4",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Patch release bundling two related fixes that, together, finally make email unsubscribe work end-to-end (audit CRITICAL #2 / GDPR Article 21).

## What's in this release vs v1.55.3

### Fixes
- **fix(email):** unsubscribe links use FRONTEND_URL (#443). Every notification email shipped with `http://localhost:5000/api/users/unsubscribe?token=...` because `BACKEND_URL` was never set on the standard deployment. Swapped to `FRONTEND_URL` (already required for CORS) so the link resolves to `https://cellarion.app/api/users/unsubscribe?token=...` and Traefik routes it correctly. Tightened the missing-FRONTEND_URL startup warning to mention email links too.
- **fix(unsubscribe):** actually disable every notification category (#442, audit CRITICAL #2). The handler assigned to `user.preferences.notifications.email/push` — paths that don't exist in the schema. Mongoose silently dropped the writes. New `utils/notifications.js` helper walks every category and flips every `email`/`push` leaf with `markModified` on each parent. Adds `user.unsubscribe.all` audit event. 12 new tests covering every category, missing-prefs edge cases, the canonical-category lock-in.

Together: clicking "Unsubscribe from all emails" in any email now reaches a working handler at a working URL.

No schema changes. No env-var changes required.

## Test plan

- [x] Backend tests pass (570 — 12 new)
- [ ] After deploy, click "Unsubscribe from all emails" link in next notification → redirects to `/unsubscribed`
- [ ] Re-fetch the user in Mongo → confirm every `notifications.*.email` and `.push` flag is `false`
- [ ] Trigger a drink-window email job → unsubscribed user should NOT receive
- [ ] Audit log shows `user.unsubscribe.all` entry tied to the user