### PR TITLE
fix(auth): per-account brute-force lockout (audit HIGH #3)

### DIFF
--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -7,13 +7,23 @@
 const defaults = {
   api:   { max: 200 },
   write: { max: 60 },
-  auth:  { max: 10 }
+  auth:  { max: 10 },
+  // Per-account brute-force protection. Tracks failed login attempts on the
+  // User document so a credential-stuffing attacker rotating IPs can't bypass
+  // the per-IP authLimiter. See utils/loginAttempts.js for the enforcement.
+  accountLockout: {
+    threshold:    10,               // failed attempts before lockout
+    windowMs:     15 * 60 * 1000,   // count attempts within a 15-min window
+    durationMs:   60 * 60 * 1000,   // lock the account for 1 hour
+    emailDedupMs: 60 * 60 * 1000,   // send at most one lockout email per hour
+  }
 };
 
 let cache = {
   api:   { max: defaults.api.max },
   write: { max: defaults.write.max },
-  auth:  { max: defaults.auth.max }
+  auth:  { max: defaults.auth.max },
+  accountLockout: { ...defaults.accountLockout }
 };
 
 async function load() {
@@ -25,7 +35,13 @@ async function load() {
       cache = {
         api:   { max: doc.value.api?.max   ?? defaults.api.max   },
         write: { max: doc.value.write?.max ?? defaults.write.max },
-        auth:  { max: doc.value.auth?.max  ?? defaults.auth.max  }
+        auth:  { max: doc.value.auth?.max  ?? defaults.auth.max  },
+        accountLockout: {
+          threshold:    doc.value.accountLockout?.threshold    ?? defaults.accountLockout.threshold,
+          windowMs:     doc.value.accountLockout?.windowMs     ?? defaults.accountLockout.windowMs,
+          durationMs:   doc.value.accountLockout?.durationMs   ?? defaults.accountLockout.durationMs,
+          emailDedupMs: doc.value.accountLockout?.emailDedupMs ?? defaults.accountLockout.emailDedupMs,
+        }
       };
     }
   } catch (err) {

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -131,6 +131,17 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: null
   },
+  // Per-account brute-force lockout state. Incremented on each failed login,
+  // reset on success or successful password reset. Surfaced via the lockout
+  // checks in utils/loginAttempts.js — the login handler treats a locked
+  // account exactly like a wrong password (same generic 401, same latency)
+  // so an attacker can't tell when they've tripped a lockout.
+  failedLoginAttempts: {
+    count:              { type: Number, default: 0 },
+    firstFailedAt:      { type: Date,   default: null },
+    lockedUntil:        { type: Date,   default: null },
+    lockoutEmailSentAt: { type: Date,   default: null },  // dedupes the alert email
+  },
   emailVerified: {
     type: Boolean,
     default: false

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -8,7 +8,8 @@ const { requireAuth } = require('../middleware/auth');
 const { checkIsSuperAdmin } = require('../middleware/superAdmin');
 const { logAudit } = require('../services/audit');
 const rateLimitsConfig = require('../config/rateLimits');
-const { sendVerificationEmail, sendPasswordResetEmail, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
+const { sendVerificationEmail, sendPasswordResetEmail, sendAccountLockoutAlert, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
+const { isAccountLocked, recordLoginFailure, resetLoginAttempts } = require('../utils/loginAttempts');
 const PendingShare = require('../models/PendingShare');
 const Cellar = require('../models/Cellar');
 const { createNotification } = require('../services/notifications');
@@ -231,12 +232,40 @@ router.post('/login', authLimiter, async (req, res) => {
     const DUMMY_HASH = '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy';
     const isMatch = await bcrypt.compare(password, user ? user.password : DUMMY_HASH);
 
+    // Per-account brute-force protection. A locked account behaves IDENTICALLY
+    // to a wrong-password response — same 401, same generic message, same
+    // latency (bcrypt already ran above). This deprives a credential-stuffing
+    // attacker of any feedback signal about whether they've tripped the lock.
+    if (user && isAccountLocked(user)) {
+      logAudit(req, 'auth.login.locked',
+        { type: 'user', id: user._id },
+        { username: user.username }
+      );
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+
     if (!user) {
       logAudit(req, 'auth.login.failed', {}, { identifier: username });
       return res.status(401).json({ error: 'Invalid credentials' });
     }
 
     if (!isMatch) {
+      // Record failure, check if it crossed the lockout threshold, fire alert
+      // email (deduped) if this is a new lockout event. Non-blocking: any
+      // failure in the email path is logged but doesn't affect the response.
+      const { lockedNow, shouldSendEmail } = recordLoginFailure(user);
+      try { await user.save(); } catch (err) { console.warn('Failed to persist login-failure counter:', err.message); }
+      if (lockedNow) {
+        logAudit(req, 'auth.account_locked',
+          { type: 'user', id: user._id },
+          { username: user.username, threshold: rateLimitsConfig.get().accountLockout.threshold }
+        );
+      }
+      if (shouldSendEmail) {
+        sendAccountLockoutAlert(user.email, user.username).catch(err =>
+          console.warn('Failed to send account-lockout alert:', err.message)
+        );
+      }
       logAudit(req, 'auth.login.failed',
         { type: 'user', id: user._id },
         { username: user.username }
@@ -255,6 +284,12 @@ router.post('/login', authLimiter, async (req, res) => {
         code: 'EMAIL_NOT_VERIFIED',
         email: user.email
       });
+    }
+
+    // Successful login: clear any failed-attempt counter the user had built up.
+    // Save errors here are non-fatal — the login itself succeeded.
+    if (resetLoginAttempts(user)) {
+      try { await user.save(); } catch (err) { console.warn('Failed to reset login-attempt counter:', err.message); }
     }
 
     const accessToken = await issueTokens(user, res, { rememberMe: rememberMe !== false });
@@ -539,6 +574,10 @@ router.post('/reset-password', authLimiter, async (req, res) => {
     user.passwordResetTokenHash = null;
     user.passwordResetExpiresAt = null;
     user.refreshTokenHash = null; // Invalidate all existing sessions
+    // Successful password reset is the user's explicit recovery signal —
+    // clear any brute-force lockout state too. Otherwise a locked user
+    // would still be locked after resetting their password.
+    resetLoginAttempts(user);
 
     await user.save();
 

--- a/backend/src/services/mailgun.js
+++ b/backend/src/services/mailgun.js
@@ -398,4 +398,64 @@ async function sendDiscussionReplyEmail(toEmail, recipientName, recipientId, rep
   });
 }
 
-module.exports = { sendVerificationEmail, sendPasswordResetEmail, sendDrinkWindowDigest, sendRecommendationEmail, sendCellarInviteEmail, sendDiscussionReplyEmail, EMAIL_VERIFICATION_ENABLED };
+/**
+ * Notify a user that their account just got locked after too many failed
+ * login attempts (per-account brute-force protection). Deliberately vague
+ * about source IPs — those are usually rotating residential proxies and
+ * say nothing useful to an end user. The CTA is "reset your password if
+ * it wasn't you" because that's the recovery path that also clears the
+ * lockout.
+ *
+ * Dedupe is handled upstream in utils/loginAttempts.js — this function is
+ * only called once per dedupe window.
+ *
+ * @param {string} toEmail
+ * @param {string} username
+ */
+async function sendAccountLockoutAlert(toEmail, username) {
+  if (!EMAIL_VERIFICATION_ENABLED) return;
+
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  const resetUrl = `${frontendUrl}/forgot-password`;
+
+  await mg.messages.create(DOMAIN, {
+    from: FROM,
+    to: [toEmail],
+    subject: 'Cellarion: suspicious login activity on your account',
+    text: [
+      `Hello ${username},`,
+      '',
+      'We noticed a high number of failed login attempts on your Cellarion account in a short window of time. As a precaution, the account has been temporarily locked.',
+      '',
+      'If this was you (forgotten password, typing the wrong one), you can wait the cooldown period and try again — or reset your password right away to regain access immediately:',
+      '',
+      resetUrl,
+      '',
+      'If this was NOT you, someone may be trying to guess your password. We strongly recommend resetting it via the link above. The reset link will also clear the lock immediately.',
+      '',
+      'You do not need to take any action if you recognise the attempts as your own.',
+    ].join('\n'),
+    html: `
+      <div style="font-family:sans-serif;max-width:520px;margin:0 auto;color:#2a2a2a;">
+        <p>Hello <strong>${escapeHtml(username)}</strong>,</p>
+        <p>We noticed a <strong>high number of failed login attempts</strong> on your Cellarion account in a short window of time. As a precaution, the account has been temporarily locked.</p>
+        <p>If this was you (forgotten password, typing the wrong one), you can wait the cooldown period and try again — or reset your password right away to regain access immediately.</p>
+        <p style="margin:2rem 0;">
+          <a href="${resetUrl}"
+             style="background:#7B9E88;color:#0d0d0d;padding:12px 28px;
+                    border-radius:4px;text-decoration:none;font-weight:600;
+                    display:inline-block;">
+            Reset password
+          </a>
+        </p>
+        <p>If this was <strong>NOT</strong> you, someone may be trying to guess your password. We strongly recommend resetting it via the link above. The reset link will also clear the lock immediately.</p>
+        <hr style="border:none;border-top:1px solid #ddd;margin:2rem 0;" />
+        <p style="color:#9A9484;font-size:0.85em;">
+          You do not need to take any action if you recognise the attempts as your own.
+        </p>
+      </div>
+    `
+  });
+}
+
+module.exports = { sendVerificationEmail, sendPasswordResetEmail, sendDrinkWindowDigest, sendRecommendationEmail, sendCellarInviteEmail, sendDiscussionReplyEmail, sendAccountLockoutAlert, EMAIL_VERIFICATION_ENABLED };

--- a/backend/src/utils/loginAttempts.js
+++ b/backend/src/utils/loginAttempts.js
@@ -1,0 +1,132 @@
+/**
+ * Per-account brute-force protection — credential-stuffing kill switch.
+ *
+ * Why this exists: the per-IP authLimiter (10 failed logins / 15 min / IP)
+ * does nothing against a credential-stuffing attacker rotating residential
+ * proxies — each IP gets a fresh 10-attempt budget against the same account.
+ * This module adds a SECOND counter that lives on the User document itself.
+ * After N failed attempts within a window the account is locked for a fixed
+ * duration; the lock is silent (same generic 401 + same latency as a normal
+ * wrong-password response) so the attacker can't tell they've tripped it.
+ *
+ * Decay: the counter window slides — if no failure happens for `windowMs`,
+ * the next failure starts a fresh count rather than building on stale data.
+ *
+ * Reset paths:
+ *   - successful login            → counter cleared
+ *   - successful password reset   → counter cleared (user's explicit recovery signal)
+ *
+ * Lockout-email dedupe: at most one alert email per `emailDedupMs` window.
+ * Otherwise a sustained attack would flood the legitimate user's inbox.
+ */
+const rateLimitsConfig = require('../config/rateLimits');
+
+/**
+ * @param {object}  user
+ * @param {number}  [nowMs]  Override for tests (defaults to Date.now())
+ * @returns {boolean} true iff `lockedUntil` is in the future.
+ *                    Tolerates a missing failedLoginAttempts subdoc — old
+ *                    User documents created before this field was added
+ *                    behave as "never locked".
+ */
+function isAccountLocked(user, nowMs = Date.now()) {
+  const lockedUntil = user?.failedLoginAttempts?.lockedUntil;
+  if (!lockedUntil) return false;
+  return lockedUntil.getTime() > nowMs;
+}
+
+/**
+ * Record a failed login attempt and (if the threshold is crossed) lock the
+ * account. Caller MUST `await user.save()` afterwards. Returns a small
+ * status object that lets the caller decide whether to fire a lockout-alert
+ * email — exactly once per dedupe window.
+ *
+ *   { lockedNow, alreadyLocked, shouldSendEmail }
+ *
+ * @param {object}   user         Mongoose User document (with markModified)
+ * @param {number}   [nowMs]      Override for tests (defaults to Date.now())
+ * @returns {{ lockedNow: boolean, alreadyLocked: boolean, shouldSendEmail: boolean }}
+ */
+function recordLoginFailure(user, nowMs = Date.now()) {
+  if (!user) return { lockedNow: false, alreadyLocked: false, shouldSendEmail: false };
+
+  // Initialise the subdoc lazily so legacy User documents start with a clean slate.
+  if (!user.failedLoginAttempts) {
+    user.failedLoginAttempts = { count: 0, firstFailedAt: null, lockedUntil: null, lockoutEmailSentAt: null };
+  }
+  const attempts = user.failedLoginAttempts;
+
+  // If the account is currently locked, don't increment further and don't
+  // re-send the email — just report the state to the caller.
+  const alreadyLocked = attempts.lockedUntil && attempts.lockedUntil.getTime() > nowMs;
+  if (alreadyLocked) {
+    return { lockedNow: false, alreadyLocked: true, shouldSendEmail: false };
+  }
+
+  const { threshold, windowMs, durationMs, emailDedupMs } = rateLimitsConfig.get().accountLockout;
+
+  // Reset the count if the previous failure was outside the rolling window
+  // (the "decay" behaviour — old failures don't haunt the user forever).
+  const firstAt = attempts.firstFailedAt?.getTime();
+  if (!firstAt || nowMs - firstAt > windowMs) {
+    attempts.count = 1;
+    attempts.firstFailedAt = new Date(nowMs);
+  } else {
+    attempts.count = (attempts.count || 0) + 1;
+  }
+
+  let lockedNow = false;
+  let shouldSendEmail = false;
+  if (attempts.count >= threshold) {
+    attempts.lockedUntil = new Date(nowMs + durationMs);
+    lockedNow = true;
+
+    // Send the alert email at most once per dedupe window — sustained attacks
+    // shouldn't spam the user's inbox.
+    const lastEmailAt = attempts.lockoutEmailSentAt?.getTime();
+    if (!lastEmailAt || nowMs - lastEmailAt > emailDedupMs) {
+      shouldSendEmail = true;
+      attempts.lockoutEmailSentAt = new Date(nowMs);
+    }
+  }
+
+  if (typeof user.markModified === 'function') {
+    user.markModified('failedLoginAttempts');
+  }
+
+  return { lockedNow, alreadyLocked: false, shouldSendEmail };
+}
+
+/**
+ * Clear the failed-attempt counter and lockout state. Called on:
+ *   - successful login
+ *   - successful password reset (the user's explicit recovery signal)
+ *
+ * Caller is responsible for `await user.save()`. The `lockoutEmailSentAt`
+ * is intentionally NOT cleared — a malicious actor's lockout activity stays
+ * dedupable across the next failure burst until the dedupe window expires
+ * naturally. Avoids a lockout-then-spam pattern where each unsuccessful
+ * recovery emits a fresh email.
+ *
+ * @param {object} user
+ * @returns {boolean} true iff state was actually cleared (useful for tests).
+ */
+function resetLoginAttempts(user) {
+  if (!user) return false;
+  if (!user.failedLoginAttempts) return false;
+  const had = user.failedLoginAttempts.count > 0 || user.failedLoginAttempts.lockedUntil;
+  if (!had) return false;
+  user.failedLoginAttempts.count = 0;
+  user.failedLoginAttempts.firstFailedAt = null;
+  user.failedLoginAttempts.lockedUntil = null;
+  if (typeof user.markModified === 'function') {
+    user.markModified('failedLoginAttempts');
+  }
+  return true;
+}
+
+module.exports = {
+  isAccountLocked,
+  recordLoginFailure,
+  resetLoginAttempts,
+};

--- a/backend/src/utils/loginAttempts.test.js
+++ b/backend/src/utils/loginAttempts.test.js
@@ -1,0 +1,252 @@
+const {
+  isAccountLocked,
+  recordLoginFailure,
+  resetLoginAttempts,
+} = require('./loginAttempts');
+const rateLimitsConfig = require('../config/rateLimits');
+
+// Snapshot + restore the in-memory config so tests can tweak thresholds
+// without affecting the order they run in.
+const originalConfig = JSON.parse(JSON.stringify(rateLimitsConfig.get()));
+afterEach(() => rateLimitsConfig.set(JSON.parse(JSON.stringify(originalConfig))));
+
+function makeUser(failedLoginAttempts) {
+  return {
+    failedLoginAttempts,
+    markModified: jest.fn(),
+  };
+}
+
+function setLockoutConfig(overrides) {
+  const cfg = rateLimitsConfig.get();
+  rateLimitsConfig.set({
+    ...cfg,
+    accountLockout: { ...cfg.accountLockout, ...overrides },
+  });
+}
+
+const HOUR = 60 * 60 * 1000;
+const MIN  = 60 * 1000;
+
+describe('isAccountLocked', () => {
+  it('returns false when failedLoginAttempts is missing', () => {
+    expect(isAccountLocked({})).toBe(false);
+    expect(isAccountLocked(null)).toBe(false);
+    expect(isAccountLocked(undefined)).toBe(false);
+  });
+
+  it('returns false when lockedUntil is null', () => {
+    expect(isAccountLocked(makeUser({ count: 0, lockedUntil: null }))).toBe(false);
+  });
+
+  it('returns false when lockedUntil is in the past', () => {
+    const past = new Date(Date.now() - HOUR);
+    expect(isAccountLocked(makeUser({ count: 12, lockedUntil: past }))).toBe(false);
+  });
+
+  it('returns true when lockedUntil is in the future', () => {
+    const future = new Date(Date.now() + HOUR);
+    expect(isAccountLocked(makeUser({ count: 12, lockedUntil: future }))).toBe(true);
+  });
+});
+
+describe('recordLoginFailure', () => {
+  it('initialises the subdoc on a legacy user with no failedLoginAttempts field', () => {
+    const user = { markModified: jest.fn() };
+    const result = recordLoginFailure(user, 1_000_000);
+    expect(user.failedLoginAttempts).toBeDefined();
+    expect(user.failedLoginAttempts.count).toBe(1);
+    expect(user.failedLoginAttempts.firstFailedAt).toEqual(new Date(1_000_000));
+    expect(result).toEqual({ lockedNow: false, alreadyLocked: false, shouldSendEmail: false });
+  });
+
+  it('increments the counter on successive failures within the window', () => {
+    const user = makeUser({ count: 0, firstFailedAt: null, lockedUntil: null, lockoutEmailSentAt: null });
+    recordLoginFailure(user, 1_000_000);
+    recordLoginFailure(user, 1_000_000 + 10);
+    recordLoginFailure(user, 1_000_000 + 20);
+    expect(user.failedLoginAttempts.count).toBe(3);
+    expect(user.failedLoginAttempts.firstFailedAt).toEqual(new Date(1_000_000));
+  });
+
+  it('resets the counter when the previous failure is outside the rolling window (decay)', () => {
+    setLockoutConfig({ windowMs: 15 * MIN });
+    const user = makeUser({
+      count: 5,
+      firstFailedAt: new Date(1_000_000),
+      lockedUntil: null,
+      lockoutEmailSentAt: null,
+    });
+    // 20 minutes later, well past the 15-minute window
+    const nowMs = 1_000_000 + 20 * MIN;
+    recordLoginFailure(user, nowMs);
+    expect(user.failedLoginAttempts.count).toBe(1);
+    expect(user.failedLoginAttempts.firstFailedAt).toEqual(new Date(nowMs));
+  });
+
+  it('locks the account exactly at the threshold', () => {
+    setLockoutConfig({ threshold: 3, durationMs: HOUR });
+    const user = makeUser({ count: 0, firstFailedAt: null, lockedUntil: null, lockoutEmailSentAt: null });
+    recordLoginFailure(user, 1_000_000);
+    recordLoginFailure(user, 1_000_000 + 10);
+    const result = recordLoginFailure(user, 1_000_000 + 20);
+    expect(result.lockedNow).toBe(true);
+    expect(user.failedLoginAttempts.lockedUntil).toEqual(new Date(1_000_000 + 20 + HOUR));
+  });
+
+  it('does NOT increment further once already locked', () => {
+    setLockoutConfig({ threshold: 3 });
+    const future = new Date(2_000_000);
+    const user = makeUser({
+      count: 3,
+      firstFailedAt: new Date(1_000_000),
+      lockedUntil: future,
+      lockoutEmailSentAt: null,
+    });
+    const result = recordLoginFailure(user, 1_500_000);
+    expect(result.alreadyLocked).toBe(true);
+    expect(result.lockedNow).toBe(false);
+    expect(result.shouldSendEmail).toBe(false);
+    expect(user.failedLoginAttempts.count).toBe(3);  // unchanged
+  });
+
+  it('reports shouldSendEmail=true on the first lock event', () => {
+    setLockoutConfig({ threshold: 2 });
+    const user = makeUser({ count: 0, firstFailedAt: null, lockedUntil: null, lockoutEmailSentAt: null });
+    recordLoginFailure(user, 1_000_000);
+    const result = recordLoginFailure(user, 1_000_000 + 10);
+    expect(result.lockedNow).toBe(true);
+    expect(result.shouldSendEmail).toBe(true);
+    expect(user.failedLoginAttempts.lockoutEmailSentAt).toEqual(new Date(1_000_000 + 10));
+  });
+
+  it('does NOT re-send the email within the dedupe window', () => {
+    setLockoutConfig({ threshold: 2, windowMs: 1000, durationMs: 500, emailDedupMs: HOUR });
+    const user = makeUser({
+      count: 0,
+      firstFailedAt: null,
+      lockedUntil: null,
+      lockoutEmailSentAt: new Date(1_000_000),
+    });
+    // Lock expires at 1_500. Two new failures right after that re-trigger a lock.
+    recordLoginFailure(user, 1_000_600);
+    const result = recordLoginFailure(user, 1_000_700);
+    expect(result.lockedNow).toBe(true);
+    expect(result.shouldSendEmail).toBe(false);   // dedupe still in effect
+    // lockoutEmailSentAt unchanged
+    expect(user.failedLoginAttempts.lockoutEmailSentAt).toEqual(new Date(1_000_000));
+  });
+
+  it('DOES send another email after the dedupe window expires', () => {
+    setLockoutConfig({ threshold: 2, windowMs: 1000, durationMs: 500, emailDedupMs: 100 });
+    const user = makeUser({
+      count: 0,
+      firstFailedAt: null,
+      lockedUntil: null,
+      lockoutEmailSentAt: new Date(1_000_000),
+    });
+    recordLoginFailure(user, 1_001_000);
+    const result = recordLoginFailure(user, 1_001_010);
+    expect(result.lockedNow).toBe(true);
+    expect(result.shouldSendEmail).toBe(true);
+  });
+
+  it('marks the parent path as modified so Mongoose actually persists nested changes', () => {
+    const user = makeUser({ count: 0, firstFailedAt: null, lockedUntil: null, lockoutEmailSentAt: null });
+    recordLoginFailure(user, 1_000_000);
+    expect(user.markModified).toHaveBeenCalledWith('failedLoginAttempts');
+  });
+});
+
+describe('resetLoginAttempts', () => {
+  it('clears the counter and lockedUntil', () => {
+    const user = makeUser({
+      count: 5,
+      firstFailedAt: new Date(1_000_000),
+      lockedUntil: new Date(Date.now() + HOUR),
+      lockoutEmailSentAt: new Date(1_000_000),
+    });
+    const cleared = resetLoginAttempts(user);
+    expect(cleared).toBe(true);
+    expect(user.failedLoginAttempts.count).toBe(0);
+    expect(user.failedLoginAttempts.firstFailedAt).toBeNull();
+    expect(user.failedLoginAttempts.lockedUntil).toBeNull();
+    expect(user.markModified).toHaveBeenCalledWith('failedLoginAttempts');
+  });
+
+  it('preserves lockoutEmailSentAt so post-recovery dedupe still works', () => {
+    const emailSent = new Date(1_000_000);
+    const user = makeUser({
+      count: 5,
+      firstFailedAt: new Date(1_000_000),
+      lockedUntil: new Date(Date.now() + HOUR),
+      lockoutEmailSentAt: emailSent,
+    });
+    resetLoginAttempts(user);
+    expect(user.failedLoginAttempts.lockoutEmailSentAt).toEqual(emailSent);
+  });
+
+  it('is a no-op when nothing to clear', () => {
+    const user = makeUser({ count: 0, firstFailedAt: null, lockedUntil: null, lockoutEmailSentAt: null });
+    const cleared = resetLoginAttempts(user);
+    expect(cleared).toBe(false);
+    expect(user.markModified).not.toHaveBeenCalled();
+  });
+
+  it('handles missing failedLoginAttempts subdoc', () => {
+    const user = { markModified: jest.fn() };
+    expect(resetLoginAttempts(user)).toBe(false);
+    expect(user.markModified).not.toHaveBeenCalled();
+  });
+
+  it('handles null/undefined user gracefully', () => {
+    expect(resetLoginAttempts(null)).toBe(false);
+    expect(resetLoginAttempts(undefined)).toBe(false);
+  });
+});
+
+describe('integration — full lifecycle', () => {
+  it('threshold trip → silent rejection while locked → unlock after duration → fresh counter past window', () => {
+    // Tight numbers to make the timeline easy to follow:
+    //   threshold 3, window 100ms, lock duration 500ms, email dedupe 10s
+    setLockoutConfig({ threshold: 3, windowMs: 100, durationMs: 500, emailDedupMs: 10_000 });
+    const user = makeUser({ count: 0, firstFailedAt: null, lockedUntil: null, lockoutEmailSentAt: null });
+
+    // t=1000..1020: 3 failures → locked until t=1520
+    recordLoginFailure(user, 1000);
+    recordLoginFailure(user, 1010);
+    const lockResult = recordLoginFailure(user, 1020);
+    expect(lockResult.lockedNow).toBe(true);
+    expect(isAccountLocked(user, 1100)).toBe(true);  // still locked at t=1100
+
+    // During lock → no-op, alreadyLocked reported
+    const duringLock = recordLoginFailure(user, 1100);
+    expect(duringLock.alreadyLocked).toBe(true);
+    expect(user.failedLoginAttempts.count).toBe(3);  // counter not incremented during lock
+
+    // Past lock + past window (firstFailedAt=1000, window=100 → expired at 1100;
+    // we're at 1600). Counter should reset to 1.
+    const after = recordLoginFailure(user, 1600);
+    expect(after.alreadyLocked).toBe(false);
+    expect(after.lockedNow).toBe(false);
+    expect(user.failedLoginAttempts.count).toBe(1);
+    expect(user.failedLoginAttempts.firstFailedAt).toEqual(new Date(1600));
+  });
+
+  it('successful login mid-burst clears everything', () => {
+    setLockoutConfig({ threshold: 3 });
+    const user = makeUser({ count: 0, firstFailedAt: null, lockedUntil: null, lockoutEmailSentAt: null });
+    recordLoginFailure(user, 1000);
+    recordLoginFailure(user, 1010);
+    expect(user.failedLoginAttempts.count).toBe(2);
+
+    resetLoginAttempts(user);
+
+    expect(user.failedLoginAttempts.count).toBe(0);
+    expect(isAccountLocked(user)).toBe(false);
+
+    // Future failure starts fresh
+    recordLoginFailure(user, 2000);
+    expect(user.failedLoginAttempts.count).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes audit **HIGH #3** — the per-IP `authLimiter` did nothing against credential-stuffing attackers rotating residential proxies, because each fresh IP got a fresh 10-attempt budget against the same account. Cellarion never noticed an account was under sustained attack.

## The fix

A **second** counter that lives on the User document itself, alongside the existing per-IP limiter. Stacked defence:

- **Failed login** → increment `failedLoginAttempts.count`, stamp `firstFailedAt`
- **Count reaches threshold within `windowMs`** → lock account for `durationMs`
- **Successful login** → counter cleared
- **Successful password reset** → counter cleared (the user's explicit recovery signal)

### The lockout is silent

A locked account returns the **same generic 401 with the same latency** as a wrong password (bcrypt always runs *before* the lock check). An attacker can't tell when they've tripped the lock, so credential-stuffing has no feedback signal to optimise against. Same defensive principle as the existing dummy-bcrypt-compare for unknown users.

### Defaults (admin-tunable via `config/rateLimits.js`)

| | |
|---|---|
| `threshold`    | 10 failed attempts |
| `windowMs`     | 15 minutes (sliding — counter resets after a quiet period) |
| `durationMs`   | 1 hour |
| `emailDedupMs` | 1 hour (at most one lockout email per hour, even under sustained attack) |

## Lockout-DoS mitigations

Three stacked safeguards against an attacker maliciously locking real users out:

1. **Time decay** — counter resets after `windowMs` of quiet, no permanent lockout
2. **Password reset always clears the lock** — locked user can recover instantly by clicking forgot-password
3. **Silent lockout** — no feedback signal means lockout-as-DoS has no optimisation surface

## Email

`sendAccountLockoutAlert` fires **once per dedupe window** when an account first locks. Vague about source IPs (rotating proxies say nothing useful); CTA is "reset your password" which also clears the lock immediately. Skipped entirely when Mailgun is disabled (dev / staging without email config).

## Audit events

- `auth.login.locked` — login attempt while account is locked
- `auth.account_locked` — threshold tripped, account just got locked

## Test coverage (20 new cases in `loginAttempts.test.js`)

- Threshold tripping + window decay
- Silent rejection while locked (counter NOT incremented during lock)
- Email dedupe (no spam during sustained attack)
- Email DOES re-send after dedupe window expires
- Reset on success + reset preserves `lockoutEmailSentAt`
- Lifecycle integration test: lock → silent reject during lock → unlock → fresh window → fresh count
- Legacy User docs (no `failedLoginAttempts` subdoc) behave as "never locked"
- `markModified` called on the parent path so Mongoose persists nested changes
- Null/undefined user handled gracefully

## Test plan

- [x] Backend tests pass — **590** (was 558 + 12 from unsubscribe = 570 + 20 new)
- [ ] After deploy, on a test account: fail login 10 times → 11th attempt returns same 401 ("Invalid credentials") with same latency → check audit log for `auth.account_locked` event
- [ ] Lockout email lands in inbox (if Mailgun is enabled)
- [ ] Click "forgot password" → reset → log in successfully → confirm no longer locked
- [ ] Audit log shows `auth.login.locked` for attempts during the lock window
- [ ] Wait out the `durationMs` (or shorten it temporarily via admin config) → confirm login succeeds again