### PR TITLE
chore(release): v1.55.5

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.55.4",
+  "version": "1.55.5",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.55.4",
+  "version": "1.55.5",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Security patch closing audit **HIGH #3** — per-account brute-force protection.

## What's in this release vs v1.55.4

### Security
- **fix(auth):** per-account brute-force lockout (#445). New counter that lives on the User document itself, stacked alongside the existing per-IP `authLimiter`. After 10 failed logins on the same account within 15 min, the account locks for 1 hour. Lockout is SILENT (same generic 401, same latency as wrong password) so credential-stuffing attackers get no feedback signal. Password reset clears the lock — a real user can recover immediately. Lockout email fires once per dedupe window. All thresholds admin-tunable via `config/rateLimits.js`. 20 new tests.

No schema migration (new field is optional + defaulted). No env-var changes.

## Test plan

- [x] Backend tests pass (**590** — 20 new)
- [ ] Smoke-test in Docker: `docker compose up --build` boots
- [ ] On a test account: 10 wrong-password attempts → 11th returns same 401 with same latency → audit log shows `auth.account_locked`
- [ ] Lockout email lands in inbox (if Mailgun is enabled)
- [ ] Click "forgot password" → reset → log in successfully → confirm no longer locked
- [ ] Wait out the lockout duration → confirm login succeeds again