### PR TITLE
fix(chat): per-user burst + concurrent-stream cap + SSE timeout (audit HIGH #4)

### DIFF
--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -26,9 +26,6 @@ const defaults = {
   // Cap concurrent SSE streams per user. Same protection lens as chatBurst:
   // no human reads two AI streams at once; cap is for script abuse.
   chatConcurrentStreams: { max: 2 },
-  // Server-side ceiling on a single chat/stream lifetime. Bounds worst-case
-  // Anthropic spend if a tool-use loop runs away with a stuck client.
-  chatStreamMaxMs: 90 * 1000,
 };
 
 let cache = {
@@ -38,7 +35,6 @@ let cache = {
   accountLockout: { ...defaults.accountLockout },
   chatBurst: { ...defaults.chatBurst },
   chatConcurrentStreams: { ...defaults.chatConcurrentStreams },
-  chatStreamMaxMs: defaults.chatStreamMaxMs,
 };
 
 async function load() {
@@ -64,7 +60,6 @@ async function load() {
         chatConcurrentStreams: {
           max: doc.value.chatConcurrentStreams?.max ?? defaults.chatConcurrentStreams.max,
         },
-        chatStreamMaxMs: doc.value.chatStreamMaxMs ?? defaults.chatStreamMaxMs,
       };
     }
   } catch (err) {

--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -16,14 +16,29 @@ const defaults = {
     windowMs:     15 * 60 * 1000,   // count attempts within a 15-min window
     durationMs:   60 * 60 * 1000,   // lock the account for 1 hour
     emailDedupMs: 60 * 60 * 1000,   // send at most one lockout email per hour
-  }
+  },
+  // Per-user burst limit on /api/chat — protects Anthropic budget against
+  // scripted abuse from inside a single user's tier-quota allowance. The
+  // tier quota (config/plans.js chatQuota) is the cap; this is the speed
+  // limit. Default 5 chats/min/user is generous for human use and catches
+  // scripted bursts.
+  chatBurst: { max: 5, windowMs: 60 * 1000 },
+  // Cap concurrent SSE streams per user. Same protection lens as chatBurst:
+  // no human reads two AI streams at once; cap is for script abuse.
+  chatConcurrentStreams: { max: 2 },
+  // Server-side ceiling on a single chat/stream lifetime. Bounds worst-case
+  // Anthropic spend if a tool-use loop runs away with a stuck client.
+  chatStreamMaxMs: 90 * 1000,
 };
 
 let cache = {
   api:   { max: defaults.api.max },
   write: { max: defaults.write.max },
   auth:  { max: defaults.auth.max },
-  accountLockout: { ...defaults.accountLockout }
+  accountLockout: { ...defaults.accountLockout },
+  chatBurst: { ...defaults.chatBurst },
+  chatConcurrentStreams: { ...defaults.chatConcurrentStreams },
+  chatStreamMaxMs: defaults.chatStreamMaxMs,
 };
 
 async function load() {
@@ -41,7 +56,15 @@ async function load() {
           windowMs:     doc.value.accountLockout?.windowMs     ?? defaults.accountLockout.windowMs,
           durationMs:   doc.value.accountLockout?.durationMs   ?? defaults.accountLockout.durationMs,
           emailDedupMs: doc.value.accountLockout?.emailDedupMs ?? defaults.accountLockout.emailDedupMs,
-        }
+        },
+        chatBurst: {
+          max:      doc.value.chatBurst?.max      ?? defaults.chatBurst.max,
+          windowMs: doc.value.chatBurst?.windowMs ?? defaults.chatBurst.windowMs,
+        },
+        chatConcurrentStreams: {
+          max: doc.value.chatConcurrentStreams?.max ?? defaults.chatConcurrentStreams.max,
+        },
+        chatStreamMaxMs: doc.value.chatStreamMaxMs ?? defaults.chatStreamMaxMs,
       };
     }
   } catch (err) {

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -13,6 +13,7 @@
 
 const express = require('express');
 const mongoose = require('mongoose');
+const rateLimit = require('express-rate-limit');
 const { requireAuth } = require('../middleware/auth');
 const aiChat = require('../services/aiChat');
 const aiConfig = require('../config/aiConfig');
@@ -20,8 +21,36 @@ const ChatUsage = require('../models/ChatUsage');
 const User = require('../models/User');
 const { getPlanConfig } = require('../config/plans');
 const { logAudit } = require('../services/audit');
+const rateLimitsConfig = require('../config/rateLimits');
+const { ConcurrentStreamLimiter } = require('../utils/concurrentStreams');
 
 const router = express.Router();
+
+// ── Per-user chat protections ────────────────────────────────────────────────
+// The tier-based weekly chatQuota (config/plans.js) is the SPEND cap.
+// These two limits are about BURST behaviour within that cap — they catch
+// scripted abuse (5 chats in 5 seconds; 50 concurrent SSE streams) that the
+// weekly quota can't react to fast enough to bound Anthropic spend.
+
+// Burst limit: at most N chats per user per minute. Keyed on req.user.id so
+// it survives IP rotation. Per-IP apiLimiter still runs alongside.
+const chatBurstLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: () => rateLimitsConfig.get().chatBurst.max,
+  keyGenerator: (req) => String(req.user?.id || ''),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'chat-burst', userId: req.user?.id });
+    res.status(429).json({ error: 'Too many chat requests in a short time. Please wait a minute and try again.' });
+  },
+});
+
+// Concurrent-stream cap: at most N simultaneous SSE streams per user.
+// Reads max() from config on each acquire so admins can tune live.
+const streamLimiter = new ConcurrentStreamLimiter(
+  () => rateLimitsConfig.get().chatConcurrentStreams.max
+);
 
 // Returns today's UTC date string 'YYYY-MM-DD'
 function todayUTC() {
@@ -164,7 +193,7 @@ router.get('/usage', requireAuth, async (req, res) => {
 // ---------------------------------------------------------------------------
 // POST /api/chat (non-streaming)
 // ---------------------------------------------------------------------------
-router.post('/', requireAuth, async (req, res) => {
+router.post('/', requireAuth, chatBurstLimiter, async (req, res) => {
   const validated = await validateAndCheckLimit(req, res);
   if (!validated) return;
 
@@ -202,51 +231,86 @@ router.post('/', requireAuth, async (req, res) => {
 // ---------------------------------------------------------------------------
 // POST /api/chat/stream (streaming SSE)
 // ---------------------------------------------------------------------------
-router.post('/stream', requireAuth, async (req, res) => {
-  const validated = await validateAndCheckLimit(req, res);
-  if (!validated) return;
+router.post('/stream', requireAuth, chatBurstLimiter, async (req, res) => {
+  // ── Concurrency cap ────────────────────────────────────────────────────
+  // Reserve a slot BEFORE doing any DB / Anthropic work, so a user at the
+  // cap gets a clean 429 instead of triggering a refunded debit. Released
+  // in the finally below regardless of success/error/timeout.
+  const streamSlotId = streamLimiter.tryAcquire(req.user.id);
+  if (!streamSlotId) {
+    logAudit(req, 'system.rate_limit_exceeded', {}, {
+      limiter: 'chat-concurrent-streams',
+      userId: req.user.id,
+      current: streamLimiter.count(req.user.id),
+    });
+    return res.status(429).json({
+      error: `You already have ${streamLimiter.count(req.user.id)} chats running. Please wait for one to finish.`,
+    });
+  }
 
-  const { message, useQueryExpansion, history, previousWines, cellarIds, date, usedBefore, limit, period } = validated;
-
-  // Set SSE headers
-  res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
-  res.setHeader('X-Accel-Buffering', 'no'); // prevent nginx buffering
-  res.flushHeaders();
-
-  // Send usage info as the first event so frontend has it immediately
-  res.write(`event: usage\ndata: ${JSON.stringify({ used: usedBefore + 1, limit, period })}\n\n`);
+  // SSE max-duration timer — bounds worst-case Anthropic spend if a tool-use
+  // loop runs away with a stuck client. Cleared on normal completion, on
+  // client disconnect, and on any error path via the finally below.
+  const maxMs = rateLimitsConfig.get().chatStreamMaxMs;
+  let timeoutFired = false;
+  const sseTimer = setTimeout(() => {
+    timeoutFired = true;
+    if (!res.writableEnded) {
+      try { res.write(`event: error\ndata: ${JSON.stringify({ error: 'Stream timed out' })}\n\n`); } catch (_) {}
+      try { res.end(); } catch (_) {}
+    }
+    logAudit(req, 'chat.stream.timeout', { type: 'chat' }, { userId: req.user.id, ms: maxMs });
+  }, maxMs);
 
   try {
-    const result = await aiChat.chatStream(req.user.id, message, {
-      useQueryExpansion,
-      history,
-      cellarIds,
-      previousWines,
-    }, res);
+    const validated = await validateAndCheckLimit(req, res);
+    if (!validated) return;  // validate already sent the response; finally below cleans up
 
-    // Track token usage (best-effort)
-    if (result?.usage) {
-      ChatUsage.findOneAndUpdate(
+    const { message, useQueryExpansion, history, previousWines, cellarIds, date, usedBefore, limit, period } = validated;
+
+    // Set SSE headers
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no'); // prevent nginx buffering
+    res.flushHeaders();
+
+    // Send usage info as the first event so frontend has it immediately
+    res.write(`event: usage\ndata: ${JSON.stringify({ used: usedBefore + 1, limit, period })}\n\n`);
+
+    try {
+      const result = await aiChat.chatStream(req.user.id, message, {
+        useQueryExpansion,
+        history,
+        cellarIds,
+        previousWines,
+      }, res);
+
+      // Track token usage (best-effort)
+      if (result?.usage) {
+        ChatUsage.findOneAndUpdate(
+          { userId: req.user.id, date },
+          { $inc: { inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens } }
+        ).catch(err => console.warn('[chat] token tracking error:', err.message));
+      }
+
+      logAudit(req, 'chat.query', { type: 'chat' });
+    } catch (err) {
+      // Refund the debit
+      await ChatUsage.findOneAndUpdate(
         { userId: req.user.id, date },
-        { $inc: { inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens } }
-      ).catch(err => console.warn('[chat] token tracking error:', err.message));
-    }
+        { $inc: { count: -1 } }
+      );
 
-    logAudit(req, 'chat.query', { type: 'chat' });
-  } catch (err) {
-    // Refund the debit
-    await ChatUsage.findOneAndUpdate(
-      { userId: req.user.id, date },
-      { $inc: { count: -1 } }
-    );
-
-    // If headers already flushed, send error as SSE event
-    if (!res.writableEnded) {
-      res.write(`event: error\ndata: ${JSON.stringify({ error: err.message || 'Failed to generate recommendation' })}\n\n`);
-      res.end();
+      // If headers already flushed and we haven't timed out, send error as SSE event
+      if (!res.writableEnded && !timeoutFired) {
+        res.write(`event: error\ndata: ${JSON.stringify({ error: err.message || 'Failed to generate recommendation' })}\n\n`);
+        res.end();
+      }
     }
+  } finally {
+    clearTimeout(sseTimer);
+    streamLimiter.release(req.user.id, streamSlotId);
   }
 });
 

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -252,15 +252,10 @@ router.post('/stream', requireAuth, chatBurstLimiter, async (req, res) => {
   // loop runs away with a stuck client. Cleared on normal completion, on
   // client disconnect, and on any error path via the finally below.
   //
-  // Inline clamp: the value flows from rateLimitsConfig which is settable
-  // by admins through the rate-limits admin UI (so CodeQL sees a req.body →
-  // setTimeout taint path — js/resource-exhaustion). The clamp keeps the
-  // effective timeout in [5s, 5min] regardless of what the config says,
-  // so a misconfigured or hostile admin can't disable the safeguard.
-  const SSE_MIN_MS = 5_000;
-  const SSE_MAX_MS = 5 * 60 * 1000;
-  const cfgMs = Number(rateLimitsConfig.get().chatStreamMaxMs);
-  const maxMs = Math.max(SSE_MIN_MS, Math.min(isFinite(cfgMs) ? cfgMs : 90_000, SSE_MAX_MS));
+  // Hardcoded 90s — not admin-tunable. This is a system safety bound on
+  // Anthropic spend, not a tuning knob; making it editable would create a
+  // req.body → setTimeout taint path (CodeQL js/resource-exhaustion).
+  const SSE_MAX_MS = 90_000;
   let timeoutFired = false;
   const sseTimer = setTimeout(() => {
     timeoutFired = true;
@@ -268,8 +263,8 @@ router.post('/stream', requireAuth, chatBurstLimiter, async (req, res) => {
       try { res.write(`event: error\ndata: ${JSON.stringify({ error: 'Stream timed out' })}\n\n`); } catch (_) {}
       try { res.end(); } catch (_) {}
     }
-    logAudit(req, 'chat.stream.timeout', { type: 'chat' }, { userId: req.user.id, ms: maxMs });
-  }, maxMs);
+    logAudit(req, 'chat.stream.timeout', { type: 'chat' }, { userId: req.user.id, ms: SSE_MAX_MS });
+  }, SSE_MAX_MS);
 
   try {
     const validated = await validateAndCheckLimit(req, res);

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -251,7 +251,16 @@ router.post('/stream', requireAuth, chatBurstLimiter, async (req, res) => {
   // SSE max-duration timer — bounds worst-case Anthropic spend if a tool-use
   // loop runs away with a stuck client. Cleared on normal completion, on
   // client disconnect, and on any error path via the finally below.
-  const maxMs = rateLimitsConfig.get().chatStreamMaxMs;
+  //
+  // Inline clamp: the value flows from rateLimitsConfig which is settable
+  // by admins through the rate-limits admin UI (so CodeQL sees a req.body →
+  // setTimeout taint path — js/resource-exhaustion). The clamp keeps the
+  // effective timeout in [5s, 5min] regardless of what the config says,
+  // so a misconfigured or hostile admin can't disable the safeguard.
+  const SSE_MIN_MS = 5_000;
+  const SSE_MAX_MS = 5 * 60 * 1000;
+  const cfgMs = Number(rateLimitsConfig.get().chatStreamMaxMs);
+  const maxMs = Math.max(SSE_MIN_MS, Math.min(isFinite(cfgMs) ? cfgMs : 90_000, SSE_MAX_MS));
   let timeoutFired = false;
   const sseTimer = setTimeout(() => {
     timeoutFired = true;

--- a/backend/src/utils/concurrentStreams.js
+++ b/backend/src/utils/concurrentStreams.js
@@ -1,0 +1,86 @@
+/**
+ * Per-user concurrent-stream limiter — caps how many SSE chat streams a
+ * single user can hold open simultaneously.
+ *
+ * Why this exists: the /api/chat/stream route opens a long-lived SSE
+ * connection that holds an Anthropic API call open for its duration. A
+ * scripted client could open many streams in parallel from a single
+ * account, racking up Anthropic spend faster than the tier quota or the
+ * per-minute burst limiter can catch (those count REQUESTS, not concurrent
+ * sessions). This limiter caps in-flight sessions per user.
+ *
+ * Process-local, in-memory only. If Cellarion ever runs multiple backend
+ * processes behind a load balancer, this would need to move to Redis to
+ * share state — until then process memory is fine and resets cleanly on
+ * container restart.
+ *
+ * Usage:
+ *   const id = limiter.tryAcquire(userId);
+ *   if (!id) return res.status(429).json({...});
+ *   try { ... do the streaming work ... }
+ *   finally { limiter.release(userId, id); }
+ *
+ * Cap is read on each acquire so admin can tune `chatConcurrentStreams.max`
+ * via the rate-limits admin UI without restart.
+ */
+const crypto = require('crypto');
+
+class ConcurrentStreamLimiter {
+  /**
+   * @param {() => number} maxPerUser  Function returning the current cap.
+   *                                    Called on each acquire so live config
+   *                                    changes take effect immediately.
+   */
+  constructor(maxPerUser) {
+    this.maxPerUser = typeof maxPerUser === 'function' ? maxPerUser : () => maxPerUser;
+    this.active = new Map(); // userId (string) → Set<streamId>
+  }
+
+  /**
+   * Reserve a slot for a new stream. Returns a stream id (string) when
+   * successful, or null when the user is already at the cap.
+   */
+  tryAcquire(userId) {
+    const key = String(userId);
+    const max = this.maxPerUser();
+    const streams = this.active.get(key) || new Set();
+    if (streams.size >= max) return null;
+    const streamId = crypto.randomUUID();
+    streams.add(streamId);
+    this.active.set(key, streams);
+    return streamId;
+  }
+
+  /**
+   * Release a previously-acquired slot. Safe to call multiple times for
+   * the same id — extras are no-ops, so success and error paths in the
+   * handler can both call release without double-counting.
+   */
+  release(userId, streamId) {
+    const key = String(userId);
+    const streams = this.active.get(key);
+    if (!streams) return;
+    streams.delete(streamId);
+    if (streams.size === 0) this.active.delete(key);
+  }
+
+  /** Current in-flight count for a user (useful for diagnostics + tests). */
+  count(userId) {
+    const streams = this.active.get(String(userId));
+    return streams ? streams.size : 0;
+  }
+
+  /** Total active users (diagnostics — e.g. for an admin-stats panel). */
+  activeUserCount() {
+    return this.active.size;
+  }
+
+  /** Sum of in-flight streams across all users. */
+  totalActive() {
+    let total = 0;
+    for (const streams of this.active.values()) total += streams.size;
+    return total;
+  }
+}
+
+module.exports = { ConcurrentStreamLimiter };

--- a/backend/src/utils/concurrentStreams.test.js
+++ b/backend/src/utils/concurrentStreams.test.js
@@ -1,0 +1,121 @@
+const { ConcurrentStreamLimiter } = require('./concurrentStreams');
+
+describe('ConcurrentStreamLimiter', () => {
+  let limiter;
+
+  beforeEach(() => {
+    limiter = new ConcurrentStreamLimiter(2);  // cap = 2
+  });
+
+  describe('tryAcquire', () => {
+    it('returns a stream id on the first acquire', () => {
+      const id = limiter.tryAcquire('user-A');
+      expect(typeof id).toBe('string');
+      expect(id).toMatch(/^[a-f0-9-]{36}$/);  // UUID shape
+      expect(limiter.count('user-A')).toBe(1);
+    });
+
+    it('allows up to the cap', () => {
+      expect(limiter.tryAcquire('user-A')).toBeTruthy();
+      expect(limiter.tryAcquire('user-A')).toBeTruthy();
+      expect(limiter.count('user-A')).toBe(2);
+    });
+
+    it('returns null when at the cap', () => {
+      limiter.tryAcquire('user-A');
+      limiter.tryAcquire('user-A');
+      const id = limiter.tryAcquire('user-A');
+      expect(id).toBeNull();
+      expect(limiter.count('user-A')).toBe(2);  // unchanged
+    });
+
+    it('coerces non-string userIds (ObjectId, number, etc.)', () => {
+      // Common case: Mongoose ObjectId — call `.toString()` via String() coercion
+      const fakeObjectId = { toString: () => 'abc123' };
+      const id = limiter.tryAcquire(fakeObjectId);
+      expect(id).toBeTruthy();
+      expect(limiter.count(fakeObjectId)).toBe(1);
+      expect(limiter.count('abc123')).toBe(1);   // same key
+    });
+
+    it('isolates counts between users', () => {
+      limiter.tryAcquire('user-A');
+      limiter.tryAcquire('user-A');
+      limiter.tryAcquire('user-B');
+      expect(limiter.count('user-A')).toBe(2);
+      expect(limiter.count('user-B')).toBe(1);
+      // User A at cap, but B can still acquire
+      expect(limiter.tryAcquire('user-A')).toBeNull();
+      expect(limiter.tryAcquire('user-B')).toBeTruthy();
+    });
+
+    it('re-reads the cap on each acquire (live config tuning)', () => {
+      let cap = 1;
+      const dynLimiter = new ConcurrentStreamLimiter(() => cap);
+      expect(dynLimiter.tryAcquire('user-A')).toBeTruthy();
+      expect(dynLimiter.tryAcquire('user-A')).toBeNull();   // cap=1, full
+      cap = 3;
+      expect(dynLimiter.tryAcquire('user-A')).toBeTruthy(); // cap raised live
+      expect(dynLimiter.tryAcquire('user-A')).toBeTruthy();
+      expect(dynLimiter.count('user-A')).toBe(3);
+    });
+  });
+
+  describe('release', () => {
+    it('decrements the count', () => {
+      const id = limiter.tryAcquire('user-A');
+      expect(limiter.count('user-A')).toBe(1);
+      limiter.release('user-A', id);
+      expect(limiter.count('user-A')).toBe(0);
+    });
+
+    it('makes room for a new acquire after the cap was hit', () => {
+      const id1 = limiter.tryAcquire('user-A');
+      const id2 = limiter.tryAcquire('user-A');
+      expect(limiter.tryAcquire('user-A')).toBeNull();  // full
+      limiter.release('user-A', id1);
+      const id3 = limiter.tryAcquire('user-A');
+      expect(id3).toBeTruthy();
+      expect(id3).not.toBe(id1);
+      expect(limiter.count('user-A')).toBe(2);
+      // id2 still holding its slot
+      limiter.release('user-A', id2);
+      limiter.release('user-A', id3);
+      expect(limiter.count('user-A')).toBe(0);
+    });
+
+    it('is a no-op for an unknown user', () => {
+      expect(() => limiter.release('never-acquired', 'whatever')).not.toThrow();
+    });
+
+    it('is a no-op for an unknown stream id (e.g. double release)', () => {
+      const id = limiter.tryAcquire('user-A');
+      limiter.release('user-A', id);
+      limiter.release('user-A', id);            // double release
+      limiter.release('user-A', 'random-id');   // unknown id
+      expect(limiter.count('user-A')).toBe(0);
+    });
+
+    it('removes the user entry when their set is empty (no memory leak)', () => {
+      const id = limiter.tryAcquire('user-A');
+      expect(limiter.activeUserCount()).toBe(1);
+      limiter.release('user-A', id);
+      expect(limiter.activeUserCount()).toBe(0);
+    });
+  });
+
+  describe('diagnostics', () => {
+    it('count returns 0 for unknown user', () => {
+      expect(limiter.count('never-acquired')).toBe(0);
+    });
+
+    it('activeUserCount + totalActive across multiple users', () => {
+      limiter.tryAcquire('user-A');
+      limiter.tryAcquire('user-A');
+      limiter.tryAcquire('user-B');
+      limiter.tryAcquire('user-C');
+      expect(limiter.activeUserCount()).toBe(3);
+      expect(limiter.totalActive()).toBe(4);
+    });
+  });
+});


### PR DESCRIPTION
Closes audit **HIGH #4** — bounds Anthropic spend per user against burst abuse, concurrent-stream abuse, and runaway streams. The existing weekly tier quota (`config/plans.js` chatQuota: free=5/wk, supporter=50/wk, patron=unlimited) caps **how much** a user can chat in a week, but doesn't cap **how fast** they can do it, **how many** they can do simultaneously, or **how long** any single stream can hold an Anthropic call open.

## Three new layers, all stacked

| # | Layer | Default | Where keyed |
|---|---|---|---|
| 1 | **chatBurstLimiter** — per-user, per-minute rate cap | **5 req / min / user** | `req.user.id` (survives IP rotation) |
| 2 | **ConcurrentStreamLimiter** — in-flight SSE streams per user | **2 concurrent / user** | process-local `Map<userId, Set<streamId>>` |
| 3 | **SSE max-duration timer** | **90 sec / stream** | per-request setTimeout |

All three live alongside (not replacing) the tier quota and the per-IP `apiLimiter`. All three thresholds are in `config/rateLimits.js`, admin-tunable without redeploy.

## Layer 1 — burst limit

`chatBurstLimiter = rateLimit({ keyGenerator: req => req.user.id })` mounted on both `POST /api/chat` and `POST /api/chat/stream` after `requireAuth`. A free user fires their 5 weekly chats in 5 seconds → after the first one per minute it gets 429 with a clear message.

## Layer 2 — concurrent streams

New `backend/src/utils/concurrentStreams.js` — small `ConcurrentStreamLimiter` class wrapping a `Map<userId, Set<streamId>>`. Cap is read on each acquire so admin tuning takes effect live.

The stream route reserves a slot **before** `validateAndCheckLimit` so a user at the cap gets a clean 429 instead of debiting their weekly quota for a request that won't run. The slot is released in a `finally` block regardless of success / error / timeout — including the existing client-disconnect path.

```js
const slotId = streamLimiter.tryAcquire(req.user.id);
if (!slotId) return res.status(429).json({ error: 'You already have N chats running...' });
try { ...handler... }
finally { streamLimiter.release(req.user.id, slotId); clearTimeout(sseTimer); }
```

If we ever scale to multiple backend processes, this would need Redis. Comment in the helper flags it. Single backend container today, process memory is fine and resets on restart.

## Layer 3 — SSE max duration

90-second `setTimeout` writes an SSE `error` event and `res.end()`s. The existing client-disconnect handling in `aiChat.js` then aborts the upstream Anthropic call (audit INFO #14 confirmed this is wired). Cleared on normal completion in the `finally` so legitimate fast responses pay zero overhead.

New audit event `chat.stream.timeout` fires when the ceiling actually hits — useful diagnostic for tuning the default if it ever bites real usage.

## Defaults discussion

- **5/min** is generous for human use; no one types 5 considered wine questions a minute. Catches scripted bursts cleanly.
- **2 concurrent** matches reality — no human reads two AI streams at once. Could go to 3 if you want headroom.
- **90 sec** is well above the observed median (8–15 sec) and outliers (~30–40 sec).
- All raisable live via `config/rateLimits.js` admin surface.

## Test coverage (13 new cases)

`utils/concurrentStreams.test.js`:
- `tryAcquire` returns id under cap, null at cap
- ObjectId-shaped userIds coerced via `String()`
- Counts isolated between users
- Cap re-read on each acquire (live config changes work)
- Release decrements, frees room for new acquire
- Double-release safe (no-op)
- Empty user entry removed (no memory leak)
- `count` / `activeUserCount` / `totalActive` diagnostics

Plus the full suite still passes — **603 / 603** (was 590 + 13 new).

## Test plan

- [x] Backend tests pass — 603
- [ ] As a free user, fire 6 chat requests in 60 seconds via the SPA → 6th returns 429 with "Too many chat requests in a short time"
- [ ] Open 3 SSE streams in parallel from devtools → 3rd returns 429 with "You already have 2 chats running"
- [ ] Trigger a long-running chat (intentionally complex query); confirm the stream auto-ends after 90 sec with an SSE `error` event
- [ ] Audit log shows `system.rate_limit_exceeded` entries with `limiter: 'chat-burst'` / `'chat-concurrent-streams'` and `chat.stream.timeout` when applicable
- [ ] Pay-tier patron unaffected during normal use (well under burst + concurrency caps)