### PR TITLE
feat(super-admin): tune every rate-limit setting from the UI

### DIFF
--- a/backend/src/routes/admin/settings.js
+++ b/backend/src/routes/admin/settings.js
@@ -24,28 +24,78 @@ router.get('/rate-limits', async (req, res) => {
 });
 
 // PATCH /api/admin/settings/rate-limits
+//
+// Partial update: any group/field that isn't sent is left at its current value,
+// so the UI can split the editor into multiple panels each with its own Save.
+//
+// Bounded ranges per field are enforced server-side. Admin tuning is a trusted
+// surface (requireRole('admin')), but the bounds also serve as guardrails
+// against typos that would silently disable a safety mechanism (e.g. setting
+// accountLockout.threshold to 9999 effectively turns lockout off).
 router.patch('/rate-limits', async (req, res) => {
   try {
-    const { api, write, auth } = req.body;
+    const { api, write, auth, accountLockout, chatBurst, chatConcurrentStreams } = req.body;
 
     const previous = { ...rateLimitsConfig.get() };
 
-    // Validate provided fields
-    const incoming = { api, write, auth };
-    for (const [name, val] of Object.entries(incoming)) {
-      if (val !== undefined) {
-        if (!Number.isInteger(val.max) || val.max < 1 || val.max > 10000) {
-          return res.status(400).json({
-            error: `${name}.max must be an integer between 1 and 10000`
-          });
-        }
+    const errors = [];
+
+    const requireIntInRange = (path, val, min, max) => {
+      if (val === undefined) return true;
+      if (!Number.isInteger(val) || val < min || val > max) {
+        errors.push(`${path} must be an integer between ${min} and ${max}`);
+        return false;
       }
+      return true;
+    };
+
+    // Per-IP request caps (api/write/auth share the same {max} shape)
+    for (const [name, group] of Object.entries({ api, write, auth })) {
+      if (group !== undefined) {
+        requireIntInRange(`${name}.max`, group.max, 1, 10000);
+      }
+    }
+
+    // Account lockout — threshold attempts within windowMs, locks for durationMs
+    if (accountLockout !== undefined) {
+      requireIntInRange('accountLockout.threshold',    accountLockout.threshold,    3,           1000);
+      requireIntInRange('accountLockout.windowMs',     accountLockout.windowMs,     60_000,      24 * 60 * 60 * 1000);
+      requireIntInRange('accountLockout.durationMs',   accountLockout.durationMs,   60_000,      30 * 24 * 60 * 60 * 1000);
+      requireIntInRange('accountLockout.emailDedupMs', accountLockout.emailDedupMs, 0,           30 * 24 * 60 * 60 * 1000);
+    }
+
+    // Chat burst limiter — max requests per user per windowMs
+    if (chatBurst !== undefined) {
+      requireIntInRange('chatBurst.max',      chatBurst.max,      1,      1000);
+      requireIntInRange('chatBurst.windowMs', chatBurst.windowMs, 10_000, 60 * 60 * 1000);
+    }
+
+    // Concurrent SSE streams cap per user
+    if (chatConcurrentStreams !== undefined) {
+      requireIntInRange('chatConcurrentStreams.max', chatConcurrentStreams.max, 1, 50);
+    }
+
+    if (errors.length > 0) {
+      return res.status(400).json({ error: errors[0], errors });
     }
 
     const updated = {
       api:   { max: api?.max   ?? previous.api.max   },
       write: { max: write?.max ?? previous.write.max },
-      auth:  { max: auth?.max  ?? previous.auth.max  }
+      auth:  { max: auth?.max  ?? previous.auth.max  },
+      accountLockout: {
+        threshold:    accountLockout?.threshold    ?? previous.accountLockout.threshold,
+        windowMs:     accountLockout?.windowMs     ?? previous.accountLockout.windowMs,
+        durationMs:   accountLockout?.durationMs   ?? previous.accountLockout.durationMs,
+        emailDedupMs: accountLockout?.emailDedupMs ?? previous.accountLockout.emailDedupMs,
+      },
+      chatBurst: {
+        max:      chatBurst?.max      ?? previous.chatBurst.max,
+        windowMs: chatBurst?.windowMs ?? previous.chatBurst.windowMs,
+      },
+      chatConcurrentStreams: {
+        max: chatConcurrentStreams?.max ?? previous.chatConcurrentStreams.max,
+      },
     };
 
     await updateSiteConfig('rateLimits', updated, req.user.id);

--- a/frontend/src/pages/SuperAdmin/TabSettings.js
+++ b/frontend/src/pages/SuperAdmin/TabSettings.js
@@ -2,93 +2,285 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { adminGetRateLimits, adminSaveRateLimits, adminGetContactEmail, adminSaveContactEmail } from '../../api/admin';
 
-function RateLimitsPanel({ apiFetch }) {
-  const LIMITERS = [
-    { key: 'api',   label: 'General API',  hint: 'requests / 15 min per IP' },
-    { key: 'write', label: 'Write actions', hint: 'requests / 15 min per IP' },
-    { key: 'auth',  label: 'Auth / login',  hint: 'requests / 15 min per IP' },
-  ];
+const INPUT_STYLE = {
+  width: 90,
+  background: 'var(--sa-bg)',
+  border: '1px solid var(--sa-border)',
+  color: 'var(--sa-text)',
+  padding: '2px 6px',
+  borderRadius: 3,
+  fontFamily: 'monospace',
+  fontSize: 12,
+};
 
-  const [form,     setForm]     = useState(null);
-  const [defaults, setDefaults] = useState(null);
-  const [saving,   setSaving]   = useState(false);
-  const [msg,      setMsg]      = useState(null);
+// ms <-> minutes helpers — config stores ms; UI shows minutes for human-friendly editing
+const msToMin = (ms) => String(Math.round(Number(ms) / 60000));
+const minToMs = (min) => Math.round(Number(min) * 60000);
 
-  useEffect(() => {
-    adminGetRateLimits(apiFetch)
-      .then(r => r.json())
-      .then(d => {
-        setForm({ api: String(d.config.api.max), write: String(d.config.write.max), auth: String(d.config.auth.max) });
-        setDefaults(d.defaults);
-      })
-      .catch(() => setMsg({ ok: false, text: 'Failed to load' }));
-  }, [apiFetch]);
+function NumberField({ label, hint, value, defaultValue, onChange, min, max, unit }) {
+  return (
+    <div className="sa-kv-row">
+      <span className="sa-kv-key">
+        {label}
+        {defaultValue !== undefined && (
+          <span style={{ marginLeft: 6, color: 'var(--sa-text-dim)', fontSize: 10 }}>
+            (default: {defaultValue})
+          </span>
+        )}
+      </span>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <input
+          type="number"
+          min={min}
+          max={max}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          style={INPUT_STYLE}
+        />
+        <span style={{ fontSize: 10, color: 'var(--sa-text-dim)' }}>{unit}{hint ? ` — ${hint}` : ''}</span>
+      </div>
+    </div>
+  );
+}
 
-  const save = async () => {
-    setSaving(true);
-    setMsg(null);
-    try {
-      const body = {
-        api:   { max: Number(form.api)   },
-        write: { max: Number(form.write) },
-        auth:  { max: Number(form.auth)  },
-      };
-      const res = await adminSaveRateLimits(apiFetch, body);
-      if (!res.ok) {
-        const d = await res.json();
-        setMsg({ ok: false, text: d.error || 'Save failed' });
-      } else {
-        setMsg({ ok: true, text: 'Saved — takes effect immediately' });
-      }
-    } catch {
-      setMsg({ ok: false, text: 'Network error' });
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  if (!form) return <div className="sa-loading">Loading rate limits...</div>;
-
+function PanelShell({ title, intro, saving, onSave, msg, children }) {
   return (
     <div className="sa-panel" style={{ marginTop: 16 }}>
       <div className="sa-panel-header">
-        <span className="sa-panel-title">Rate Limits</span>
-        <button className="sa-btn" onClick={save} disabled={saving}>{saving ? 'Saving...' : 'Save'}</button>
+        <span className="sa-panel-title">{title}</span>
+        <button className="sa-btn" onClick={onSave} disabled={saving}>{saving ? 'Saving...' : 'Save'}</button>
       </div>
       <div className="sa-panel-body">
-        <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 12 }}>
-          Maximum requests per 15-minute window per IP address.
-        </div>
-        <div className="sa-kv">
-          {LIMITERS.map(({ key, label, hint }) => (
-            <div className="sa-kv-row" key={key}>
-              <span className="sa-kv-key">
-                {label}
-                {defaults && (
-                  <span style={{ marginLeft: 6, color: 'var(--sa-text-dim)', fontSize: 10 }}>
-                    (default: {defaults[key].max})
-                  </span>
-                )}
-              </span>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                <input
-                  type="number"
-                  min="1"
-                  max="10000"
-                  value={form[key]}
-                  onChange={e => setForm(v => ({ ...v, [key]: e.target.value }))}
-                  style={{ width: 80, background: 'var(--sa-bg)', border: '1px solid var(--sa-border)', color: 'var(--sa-text)', padding: '2px 6px', borderRadius: 3, fontFamily: 'monospace', fontSize: 12 }}
-                />
-                <span style={{ fontSize: 10, color: 'var(--sa-text-dim)' }}>{hint}</span>
-              </div>
-            </div>
-          ))}
-        </div>
+        {intro && (
+          <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 12 }}>{intro}</div>
+        )}
+        <div className="sa-kv">{children}</div>
         {msg && (
           <div style={{ marginTop: 10, fontSize: 11, color: msg.ok ? 'var(--sa-accent)' : 'var(--sa-danger)' }}>{msg.text}</div>
         )}
       </div>
     </div>
+  );
+}
+
+// All three rate-limit panels load from /rate-limits and PATCH only their own
+// fields, so each Save button is independent. The backend's partial-update
+// behaviour means an unsent group is left untouched.
+function useRateLimits(apiFetch) {
+  const [config,   setConfig]   = useState(null);
+  const [defaults, setDefaults] = useState(null);
+  const [error,    setError]    = useState(null);
+
+  useEffect(() => {
+    adminGetRateLimits(apiFetch)
+      .then(r => r.json())
+      .then(d => { setConfig(d.config); setDefaults(d.defaults); })
+      .catch(() => setError('Failed to load'));
+  }, [apiFetch]);
+
+  return { config, defaults, error };
+}
+
+function PerIpLimitsPanel({ apiFetch }) {
+  const LIMITERS = [
+    { key: 'api',   label: 'General API'  },
+    { key: 'write', label: 'Write actions' },
+    { key: 'auth',  label: 'Auth / login'  },
+  ];
+  const { config, defaults, error } = useRateLimits(apiFetch);
+  const [form,   setForm]   = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [msg,    setMsg]    = useState(null);
+
+  useEffect(() => {
+    if (config) {
+      setForm({ api: String(config.api.max), write: String(config.write.max), auth: String(config.auth.max) });
+    }
+  }, [config]);
+
+  const save = async () => {
+    setSaving(true); setMsg(null);
+    try {
+      const res = await adminSaveRateLimits(apiFetch, {
+        api:   { max: Number(form.api)   },
+        write: { max: Number(form.write) },
+        auth:  { max: Number(form.auth)  },
+      });
+      if (!res.ok) { const d = await res.json(); setMsg({ ok: false, text: d.error || 'Save failed' }); }
+      else setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+    } catch { setMsg({ ok: false, text: 'Network error' }); }
+    finally { setSaving(false); }
+  };
+
+  if (error)  return <div className="sa-panel" style={{ marginTop: 16, padding: 12, color: 'var(--sa-danger)' }}>{error}</div>;
+  if (!form)  return <div className="sa-loading">Loading rate limits...</div>;
+
+  return (
+    <PanelShell
+      title="Per-IP rate limits"
+      intro="Maximum requests per 15-minute window per source IP. Behind Cloudflare the limit is keyed on the real visitor IP."
+      saving={saving} onSave={save} msg={msg}
+    >
+      {LIMITERS.map(({ key, label }) => (
+        <NumberField
+          key={key}
+          label={label}
+          unit="req / 15 min"
+          value={form[key]}
+          defaultValue={defaults?.[key]?.max}
+          onChange={v => setForm(f => ({ ...f, [key]: v }))}
+          min={1} max={10000}
+        />
+      ))}
+    </PanelShell>
+  );
+}
+
+function AccountLockoutPanel({ apiFetch }) {
+  const { config, defaults, error } = useRateLimits(apiFetch);
+  const [form,   setForm]   = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [msg,    setMsg]    = useState(null);
+
+  useEffect(() => {
+    if (config?.accountLockout) {
+      setForm({
+        threshold:    String(config.accountLockout.threshold),
+        windowMin:    msToMin(config.accountLockout.windowMs),
+        durationMin:  msToMin(config.accountLockout.durationMs),
+        emailDedupMin:msToMin(config.accountLockout.emailDedupMs),
+      });
+    }
+  }, [config]);
+
+  const save = async () => {
+    setSaving(true); setMsg(null);
+    try {
+      const res = await adminSaveRateLimits(apiFetch, {
+        accountLockout: {
+          threshold:    Number(form.threshold),
+          windowMs:     minToMs(form.windowMin),
+          durationMs:   minToMs(form.durationMin),
+          emailDedupMs: minToMs(form.emailDedupMin),
+        },
+      });
+      if (!res.ok) { const d = await res.json(); setMsg({ ok: false, text: d.error || 'Save failed' }); }
+      else setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+    } catch { setMsg({ ok: false, text: 'Network error' }); }
+    finally { setSaving(false); }
+  };
+
+  if (error) return null; // Per-IP panel already showed the error
+  if (!form) return null;
+
+  return (
+    <PanelShell
+      title="Account brute-force lockout"
+      intro="Per-account counter — blocks credential-stuffing attacks that rotate IPs to bypass the per-IP auth limiter. Lockout is silent (no error revealing the lock to the attacker)."
+      saving={saving} onSave={save} msg={msg}
+    >
+      <NumberField
+        label="Failed attempts before lockout"
+        unit="attempts"
+        value={form.threshold}
+        defaultValue={defaults?.accountLockout?.threshold}
+        onChange={v => setForm(f => ({ ...f, threshold: v }))}
+        min={3} max={1000}
+      />
+      <NumberField
+        label="Counting window"
+        unit="minutes"
+        hint="attempts older than this don't count"
+        value={form.windowMin}
+        defaultValue={defaults?.accountLockout?.windowMs ? msToMin(defaults.accountLockout.windowMs) : undefined}
+        onChange={v => setForm(f => ({ ...f, windowMin: v }))}
+        min={1} max={1440}
+      />
+      <NumberField
+        label="Lockout duration"
+        unit="minutes"
+        value={form.durationMin}
+        defaultValue={defaults?.accountLockout?.durationMs ? msToMin(defaults.accountLockout.durationMs) : undefined}
+        onChange={v => setForm(f => ({ ...f, durationMin: v }))}
+        min={1} max={43200}
+      />
+      <NumberField
+        label="Email notification dedupe"
+        unit="minutes"
+        hint="at most one lockout email per account per window (0 to disable dedupe)"
+        value={form.emailDedupMin}
+        defaultValue={defaults?.accountLockout?.emailDedupMs ? msToMin(defaults.accountLockout.emailDedupMs) : undefined}
+        onChange={v => setForm(f => ({ ...f, emailDedupMin: v }))}
+        min={0} max={43200}
+      />
+    </PanelShell>
+  );
+}
+
+function ChatLimitsPanel({ apiFetch }) {
+  const { config, defaults, error } = useRateLimits(apiFetch);
+  const [form,   setForm]   = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [msg,    setMsg]    = useState(null);
+
+  useEffect(() => {
+    if (config?.chatBurst && config?.chatConcurrentStreams) {
+      setForm({
+        burstMax:      String(config.chatBurst.max),
+        burstWindowMs: String(config.chatBurst.windowMs),
+        concurrent:    String(config.chatConcurrentStreams.max),
+      });
+    }
+  }, [config]);
+
+  const save = async () => {
+    setSaving(true); setMsg(null);
+    try {
+      const res = await adminSaveRateLimits(apiFetch, {
+        chatBurst:             { max: Number(form.burstMax), windowMs: Number(form.burstWindowMs) },
+        chatConcurrentStreams: { max: Number(form.concurrent) },
+      });
+      if (!res.ok) { const d = await res.json(); setMsg({ ok: false, text: d.error || 'Save failed' }); }
+      else setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+    } catch { setMsg({ ok: false, text: 'Network error' }); }
+    finally { setSaving(false); }
+  };
+
+  if (error) return null;
+  if (!form) return null;
+
+  return (
+    <PanelShell
+      title="Cellar Chat abuse controls"
+      intro="Per-user throttles on /api/chat — guards Anthropic spend against scripted bursts inside a single user's tier quota. The SSE per-stream timeout is hardcoded at 90s (not editable) as a system safety bound."
+      saving={saving} onSave={save} msg={msg}
+    >
+      <NumberField
+        label="Burst limit — requests"
+        unit="requests per window"
+        value={form.burstMax}
+        defaultValue={defaults?.chatBurst?.max}
+        onChange={v => setForm(f => ({ ...f, burstMax: v }))}
+        min={1} max={1000}
+      />
+      <NumberField
+        label="Burst limit — window"
+        unit="milliseconds"
+        hint="e.g. 60000 = 1 minute"
+        value={form.burstWindowMs}
+        defaultValue={defaults?.chatBurst?.windowMs}
+        onChange={v => setForm(f => ({ ...f, burstWindowMs: v }))}
+        min={10000} max={3600000}
+      />
+      <NumberField
+        label="Max concurrent SSE streams per user"
+        unit="streams"
+        value={form.concurrent}
+        defaultValue={defaults?.chatConcurrentStreams?.max}
+        onChange={v => setForm(f => ({ ...f, concurrent: v }))}
+        min={1} max={50}
+      />
+    </PanelShell>
   );
 }
 
@@ -155,7 +347,9 @@ export default function TabSettings() {
   return (
     <>
       <ContactEmailPanel apiFetch={apiFetch} />
-      <RateLimitsPanel apiFetch={apiFetch} />
+      <PerIpLimitsPanel apiFetch={apiFetch} />
+      <AccountLockoutPanel apiFetch={apiFetch} />
+      <ChatLimitsPanel apiFetch={apiFetch} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Extends `PATCH /api/admin/settings/rate-limits` to accept `accountLockout`, `chatBurst`, and `chatConcurrentStreams` (previously only `api`/`write`/`auth`).
- Each new field validated server-side against bounded ranges so a typo can't silently disable a safety mechanism (e.g. lockout threshold `9999` ≈ off).
- Adds 3 independent panels to `SuperAdmin > Settings`: **Per-IP rate limits**, **Account brute-force lockout**, **Cellar Chat abuse controls** — each with its own Save (partial-update on the backend).
- Lockout times shown in minutes in the UI; backend continues to store ms.

The SSE per-stream timeout stays hardcoded at 90s — it's a safety bound on Anthropic spend, not a tuning knob, and making it editable created a CodeQL `js/resource-exhaustion` taint path (see #447).

## Why now
Previously the only way to tune the brute-force lockout window, the per-user chat burst, or the concurrent-stream cap was to hand-edit the `SiteConfig` document in MongoDB. With those defaults shipped in v1.55.5 / v1.55.6, ops needs a UI for the same reasons we have one for the per-IP caps.

## Test plan
- [x] `cd backend && npm test` — 603 passed
- [x] `cd frontend && npm test` — 292 passed
- [ ] Smoke in Docker: open `/super-admin > Settings`, change a value in each of the three panels, confirm `audit.log` shows `admin.settings.rate_limits.update` with the right before/after diff
- [ ] Submit out-of-range value, confirm 400 with bounded-range error message
- [ ] Confirm partial-update: saving the Lockout panel leaves Per-IP values untouched in the DB