### PR TITLE
fix(ai): per-user burst limit on Anthropic-backed wine endpoints

### DIFF
--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -26,6 +26,12 @@ const defaults = {
   // Cap concurrent SSE streams per user. Same protection lens as chatBurst:
   // no human reads two AI streams at once; cap is for script abuse.
   chatConcurrentStreams: { max: 2 },
+  // Per-user burst limit on Anthropic-backed wine endpoints (/wines/scan-label,
+  // /identify-text, /ai-info). Protects Anthropic budget from a scripted loop
+  // by any logged-in user. These share one bucket because they share one
+  // budget. Vision (scan-label) is the costliest, so 10/min is generous for
+  // a human walking through a cellar but still catches scripts.
+  aiBurst: { max: 10, windowMs: 60 * 1000 },
 };
 
 let cache = {
@@ -35,6 +41,7 @@ let cache = {
   accountLockout: { ...defaults.accountLockout },
   chatBurst: { ...defaults.chatBurst },
   chatConcurrentStreams: { ...defaults.chatConcurrentStreams },
+  aiBurst: { ...defaults.aiBurst },
 };
 
 async function load() {
@@ -59,6 +66,10 @@ async function load() {
         },
         chatConcurrentStreams: {
           max: doc.value.chatConcurrentStreams?.max ?? defaults.chatConcurrentStreams.max,
+        },
+        aiBurst: {
+          max:      doc.value.aiBurst?.max      ?? defaults.aiBurst.max,
+          windowMs: doc.value.aiBurst?.windowMs ?? defaults.aiBurst.windowMs,
         },
       };
     }

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
+const rateLimit = require('express-rate-limit');
 const WineDefinition = require('../models/WineDefinition');
 const Discussion = require('../models/Discussion');
 const searchService = require('../services/search');
@@ -10,10 +11,28 @@ const { generateWineKey, combinedSimilarity } = require('../utils/normalize');
 const { parsePagination } = require('../utils/pagination');
 const { isValidId } = require('../utils/validation');
 const { submitUrls } = require('../services/indexNow');
+const rateLimitsConfig = require('../config/rateLimits');
+const { logAudit } = require('../services/audit');
 
 const REMBG_URL = process.env.REMBG_URL || 'http://rembg:5000';
 
 const router = express.Router();
+
+// Per-user burst limiter on Anthropic-backed wine endpoints. Keyed on
+// req.user.id (not IP) so a scripted attacker rotating IPs can't bypass.
+// Per-IP apiLimiter still runs alongside. /scan-label, /identify-text,
+// /ai-info share one bucket because they share one Anthropic budget.
+const aiBurstLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: () => rateLimitsConfig.get().aiBurst.max,
+  keyGenerator: (req) => String(req.user?.id || ''),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'ai-burst', userId: req.user?.id });
+    res.status(429).json({ error: 'Too many AI requests in a short time. Please wait a minute and try again.' });
+  },
+});
 
 const USER_SEARCH_LIMIT = 10;
 
@@ -143,7 +162,7 @@ router.get('/', requireAuth, async (req, res) => {
 //   match: { wine: WineDefinition, confidence: number } | null,
 //   labelImage: "data:image/png;base64,..." (background-removed label, or original as fallback)
 // }
-router.post('/scan-label', requireAuth, async (req, res) => {
+router.post('/scan-label', requireAuth, aiBurstLimiter, async (req, res) => {
   const { image, mediaType = 'image/jpeg' } = req.body;
 
   if (!image) {
@@ -280,7 +299,7 @@ router.post('/find-or-create', requireAuth, async (req, res) => {
 
 // POST /api/wines/identify-text — identify a wine from a free-text query using AI,
 // then find or create it in the registry. Used by the AddBottle manual search fallback.
-router.post('/identify-text', requireAuth, async (req, res) => {
+router.post('/identify-text', requireAuth, aiBurstLimiter, async (req, res) => {
   const query = typeof req.body.query === 'string' ? req.body.query.trim() : '';
   if (!query) return res.status(400).json({ error: 'query is required' });
 
@@ -301,7 +320,7 @@ router.post('/identify-text', requireAuth, async (req, res) => {
 // POST /api/wines/ai-info — query AI for wine info without creating anything in DB.
 // Returns raw AI-identified data (country/region/grapes as name strings, not IDs).
 // Used by the AdminRequests page to pre-fill the Create New Wine form.
-router.post('/ai-info', requireAuth, async (req, res) => {
+router.post('/ai-info', requireAuth, aiBurstLimiter, async (req, res) => {
   const query = typeof req.body.query === 'string' ? req.body.query.trim() : '';
   if (!query) return res.status(400).json({ error: 'query is required' });
 


### PR DESCRIPTION
## Summary
Three endpoints in `routes/wines.js` call the Anthropic API on every request and had only `requireAuth`:
- `POST /api/wines/scan-label` — vision (label OCR)
- `POST /api/wines/identify-text` — text completion (wine identification from a string)
- `POST /api/wines/ai-info` — text completion (admin pre-fill)

A logged-in user could script-loop any of these to burn the Anthropic budget. The per-IP `apiLimiter` doesn't help because IPs rotate; PR #447 already established that real abuse vectors need a per-user key.

This PR adds **`aiBurstLimiter`** — 10 req/min/user, keyed on `req.user.id`, shared across all three endpoints (one bucket because they share one Anthropic budget). 10/min is generous for a human walking a cellar with their phone but kills script abuse.

## Findings audit context
This is the next item from the post-v1.55.5 audit re-run (after CRITICAL #1, CRITICAL #2, HIGH #3, HIGH #4). See `config/rateLimits.js` for the full set of per-user / per-IP / per-account protections now in place.

## Tunability
Defaults live in `config/rateLimits.js` with the same shape as `chatBurst`, so a small follow-up can add it to the SuperAdmin tuning UI (#448) — kept out of this PR to avoid colliding with that one's `admin/settings.js` validator changes.

## Test plan
- [x] `cd backend && npm test` — 603 passed
- [ ] Smoke: hit `/scan-label` 11× in a minute from one user → 11th returns 429; rotate IP (CF-Connecting-IP) and confirm still 429 (key is user, not IP)
- [ ] Confirm audit log entry `system.rate_limit_exceeded` with `limiter: 'ai-burst'`