### PR TITLE
fix(stripe): scrub webhook signature error before returning to caller

### DIFF
--- a/backend/src/routes/stripe.js
+++ b/backend/src/routes/stripe.js
@@ -114,7 +114,10 @@ router.post('/webhook', async (req, res) => {
     event = getStripe().webhooks.constructEvent(req.body, sig, endpointSecret);
   } catch (err) {
     console.error('[stripe] Webhook signature verification failed:', err.message);
-    return res.status(400).json({ error: `Webhook Error: ${err.message}` });
+    // Generic message to caller — Stripe's own error strings can leak which
+    // part of the verification failed (timestamp tolerance vs. signature
+    // mismatch). Log the detail server-side instead.
+    return res.status(400).json({ error: 'Invalid webhook' });
   }
 
   try {


### PR DESCRIPTION
## Summary
`POST /api/stripe/webhook` returned ``Webhook Error: ${err.message}`` to the caller on signature failure. Stripe's error strings (e.g. *Timestamp outside the tolerance zone*, *No signatures found matching the expected signature for payload*) tell a probing attacker which part of verification failed.

Return generic `Invalid webhook` with 400. Detail still goes to `console.error`.

## Audit context
LOW from the post-v1.55.5 re-audit. Two-line change, no functional impact on legitimate Stripe deliveries.

## Test plan
- [ ] Smoke: send a request to `/api/stripe/webhook` without a valid signature → 400 with `{error: 'Invalid webhook'}`, server log shows the underlying Stripe error message