### PR TITLE
chore(release): v1.55.6

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.55.5",
+  "version": "1.55.6",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.55.5",
+  "version": "1.55.6",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary
Release **v1.55.6** — security hardening cycle wrapping up the post-v1.55.5 audit re-run, plus the SuperAdmin tuning UI.

## Included
- **#447 / HIGH** — Per-user chat burst limit, concurrent SSE stream cap, hardcoded 90s SSE timeout (audit HIGH #4)
- **#449 / HIGH** — Per-user burst limit on Anthropic-backed wine endpoints (`/scan-label`, `/identify-text`, `/ai-info`)
- **#450 / MEDIUM** — Cap `/me/export` collections at 50k rows + `_truncated` flag
- **#451 / LOW** — Scrub Stripe webhook signature error before returning to caller
- **#448 / Feature** — SuperAdmin UI for tuning all rate-limit settings (api/write/auth + account lockout + chat abuse controls)

## Post-merge
- Apply recommended production values in SuperAdmin → Settings: `api 500`, `write 300`, `auth 20` (rest = defaults). See [`memory/project_rate_limits_production.md`](https://github.com/jagduvi1/Cellarion/blob/main/memory/project_rate_limits_production.md) — wait, that file is local-only. Numbers documented in #448's description.

## Test plan
- [ ] CI passes
- [ ] After merge: tag, GH Actions builds Docker images, deploy
- [ ] Smoke on cellarion.app: SuperAdmin → Settings shows the new panels; existing limits unchanged