### PR TITLE
fix(images): per-user upload cap on /api/images/upload

### DIFF
--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -32,6 +32,13 @@ const defaults = {
   // budget. Vision (scan-label) is the costliest, so 10/min is generous for
   // a human walking through a cellar but still catches scripts.
   aiBurst: { max: 10, windowMs: 60 * 1000 },
+  // Per-user rolling cap on /api/images/upload. Each upload is up to 10MB and
+  // stored on disk; without this cap a logged-in user could script a loop and
+  // fill the disk. The per-bottle MAX_IMAGES_PER_BOTTLE cap limits per-resource
+  // growth but doesn't stop a user creating bottles + uploading in a loop.
+  // Default 30/hour bounds worst-case to ~7 GB/day per user — generous for
+  // real use (a session of adding bottles rarely exceeds 30 uploads).
+  imageUploadBurst: { max: 30, windowMs: 60 * 60 * 1000 },
 };
 
 let cache = {
@@ -42,6 +49,7 @@ let cache = {
   chatBurst: { ...defaults.chatBurst },
   chatConcurrentStreams: { ...defaults.chatConcurrentStreams },
   aiBurst: { ...defaults.aiBurst },
+  imageUploadBurst: { ...defaults.imageUploadBurst },
 };
 
 async function load() {
@@ -70,6 +78,10 @@ async function load() {
         aiBurst: {
           max:      doc.value.aiBurst?.max      ?? defaults.aiBurst.max,
           windowMs: doc.value.aiBurst?.windowMs ?? defaults.aiBurst.windowMs,
+        },
+        imageUploadBurst: {
+          max:      doc.value.imageUploadBurst?.max      ?? defaults.imageUploadBurst.max,
+          windowMs: doc.value.imageUploadBurst?.windowMs ?? defaults.imageUploadBurst.windowMs,
         },
       };
     }

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -13,6 +13,8 @@ const { getCellarRole } = require('../utils/cellarAccess');
 const { processImage } = require('../services/imageProcessor');
 const { stripHtml } = require('../utils/sanitize');
 const { isValidId } = require('../utils/validation');
+const rateLimitsConfig = require('../config/rateLimits');
+const { logAudit } = require('../services/audit');
 
 /**
  * Safely remove an uploaded file, but only if it resides within the expected
@@ -40,6 +42,24 @@ const bgRemovalLimiter = rateLimit({
   legacyHeaders: false,
   handler: (req, res) => {
     res.status(429).json({ error: 'Too many background removal requests, please try again later' });
+  }
+});
+
+// Per-user upload cap on /upload. The per-bottle MAX_IMAGES_PER_BOTTLE limits
+// per-resource growth, but doesn't stop a user creating bottles + uploading
+// in a loop to fill the disk. Keyed on req.user.id (not IP) so an attacker
+// rotating IPs can't bypass.
+const imageUploadLimiter = rateLimit({
+  // windowMs is read once at limiter creation (express-rate-limit doesn't
+  // support a functional windowMs in v7). Matches the chatBurst pattern.
+  windowMs: 60 * 60 * 1000,
+  max:      () => rateLimitsConfig.get().imageUploadBurst.max,
+  keyGenerator: (req) => String(req.user?.id || ''),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'image-upload', userId: req.user?.id });
+    res.status(429).json({ error: 'Too many image uploads. Please wait and try again later.' });
   }
 });
 
@@ -135,7 +155,7 @@ function getImageDimensions(filePath) {
 const router = express.Router();
 
 // POST /api/images/upload - Upload image for a bottle or wine definition
-router.post('/upload', requireAuth, upload.single('image'), async (req, res) => {
+router.post('/upload', requireAuth, imageUploadLimiter, upload.single('image'), async (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'No image file provided' });


### PR DESCRIPTION
## Summary
A logged-in user could fill the disk by scripting image uploads. Each upload is up to 10 MB; `MAX_IMAGES_PER_BOTTLE` (20) limits per-resource growth but doesn't stop a `create-bottle + upload` loop. The per-IP `writeLimiter` doesn't help because IPs rotate.

This adds `imageUploadLimiter` — default **30 uploads / hour / user**, keyed on `req.user.id`. Placed **before multer** in the middleware chain so a rejected request never writes the file to disk.

Worst-case bound: 30 × 10 MB × 24 h ≈ 7.2 GB/day per user — well above any realistic human session.

## Audit context
LOW from the post-v1.55.5 re-audit. Last item from the verified shortlist worth shipping in the current security cycle; remaining items (admin reprocess-all concurrency, $regex search limits, cron O(N²) at scale) are either trust-boundary or scale-future concerns.

## Tunability
`imageUploadBurst.max` lives in `config/rateLimits.js` with the same shape as `chatBurst`/`aiBurst`. A small follow-up can add it to the SuperAdmin UI alongside the other AI/upload buckets. Note that `windowMs` in the rate-limit config isn't actually wired to the limiter at runtime (express-rate-limit v7 doesn't accept a functional `windowMs`) — a pre-existing pattern, called out in the commit for a future cleanup.

## Test plan
- [x] \`cd backend && npm test\` — 603 passed
- [ ] Smoke: hit \`/api/images/upload\` 31× in an hour from one user → 31st returns 429 before multer fires (check no extra file in /app/uploads/originals)
- [ ] Confirm audit log entry \`system.rate_limit_exceeded\` with \`limiter: 'image-upload'\`