### PR TITLE
chore(release): v1.55.7

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.55.6",
+  "version": "1.55.7",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.55.6",
+  "version": "1.55.7",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary
Release **v1.55.7** — security hardening followup + admin alerting surface.

## Included
- **#453 / LOW** — Per-user image upload cap (30 / hour / user) — closes disk-fill via scripted uploads
- **#454 / Feature** — Admin security alerting: 24h SuperAdmin nav badge + spike-triggered email (3+ lockouts/hr or 50+ rate-limit hits from one user/hr; 4h cooldown)

## Post-merge
- Verify `contactEmail` is set in SuperAdmin → Settings → Contact Email — that's where spike alerts go.
- On the live site, you'll see a red badge on the Audit Log tab whenever there are security events in the last 24h.

## Test plan
- [ ] CI passes
- [ ] After merge: GH Release tag → Docker build → deploy
- [ ] Smoke: open SuperAdmin, badge renders (or is absent if no events); trigger 3 lockouts in dev, wait for cron tick, confirm one email arrives