### PR TITLE
feat(wines): 'did you mean?' prompt for soft-zone fuzzy matches

### DIFF
--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -270,10 +270,17 @@ router.post('/scan-label', requireAuth, aiBurstLimiter, async (req, res) => {
 // taxonomy records (country, region, grapes).
 //
 // Body:  { name, producer, country, region?, appellation?, type?, grapes?: string[],
-//           labelImage?: "data:image/png;base64,..." }
-// Returns: { wine: WineDefinition, created: boolean }
+//           labelImage?: "data:image/png;base64,...", confirmCreate?: boolean }
+// Returns one of:
+//   { wine: WineDefinition, created: false }       — exact or auto-fuzzy match
+//   { candidates: [{ wine, score }, ...] }         — soft-zone: similar wines exist,
+//                                                     UI should ask "did you mean…?"
+//   { wine: WineDefinition, created: true }        — new wine created
+//
+// Pass `confirmCreate: true` after the user has reviewed the soft-zone
+// candidates and explicitly chosen to create a new wine anyway.
 router.post('/find-or-create', requireAuth, async (req, res) => {
-  const { name, producer, country, region, appellation, type, grapes, labelImage } = req.body;
+  const { name, producer, country, region, appellation, type, grapes, labelImage, confirmCreate } = req.body;
 
   if (!name?.trim() || !producer?.trim()) {
     return res.status(400).json({ error: 'name and producer are required' });
@@ -283,11 +290,18 @@ router.post('/find-or-create', requireAuth, async (req, res) => {
   }
 
   try {
-    const { wine, created } = await findOrCreateWine(
+    const result = await findOrCreateWine(
       { name, producer, country, region, appellation, type, grapes: grapes || [] },
-      req.user.id
+      req.user.id,
+      { confirmCreate: !!confirmCreate }
     );
 
+    // Soft-zone: hand the candidates back so the UI can prompt the user
+    if (result.candidates) {
+      return res.status(200).json({ candidates: result.candidates });
+    }
+
+    const { wine, created } = result;
     if (created) submitUrls(`/wines/${wine.slug || wine._id}`);
 
     res.status(created ? 201 : 200).json({ wine, created });

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -16,9 +16,15 @@ const Region = require('../models/Region');
 const Grape = require('../models/Grape');
 const searchService = require('./search');
 const { generateWineKey, normalizeString, resolveGrapeName } = require('../utils/normalize');
-const { findBestMatch } = require('./wineMatching');
+const { scoreAllMatches } = require('./wineMatching');
 
+// Auto-match when combined score >= SIMILARITY_THRESHOLD.
+// In the SOFT_ZONE_MIN..SIMILARITY_THRESHOLD band, surface candidates to the
+// user instead of silently creating a new wine. Below SOFT_ZONE_MIN we trust
+// that none of the existing wines are remotely the same and create.
 const SIMILARITY_THRESHOLD = 0.75;
+const SOFT_ZONE_MIN = 0.50;
+const SOFT_ZONE_TOP_N = 5;
 const POPULATE = ['country', 'region', 'grapes'];
 
 // ── Taxonomy helpers ─────────────────────────────────────────────────────────
@@ -69,11 +75,21 @@ async function findOrCreateGrapes(names, userId) {
 /**
  * Find an existing WineDefinition or create a new one.
  *
+ * Three return shapes:
+ *   { wine, created: false }                   — exact or auto-fuzzy match (>= SIMILARITY_THRESHOLD)
+ *   { wine: null, candidates: [...] }          — soft zone: similar wines exist but not enough to auto-match.
+ *                                                Caller (UI) should show a "did you mean?" prompt.
+ *   { wine, created: true }                    — no match, new wine created
+ *
+ * Pass `confirmCreate: true` to bypass the soft-zone gate and force creation
+ * — used when the user has explicitly confirmed "no, none of those, make a new one".
+ *
  * @param {Object} wineData   - { name, producer, country, region, appellation, type, grapes[] }
  * @param {string} userId     - ObjectId string of the authenticated user (for createdBy)
- * @returns {{ wine: WineDefinition, created: boolean }}
+ * @param {Object} [opts]
+ * @param {boolean} [opts.confirmCreate=false] - Skip soft-zone candidate return and create directly
  */
-async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId) {
+async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false } = {}) {
   const trimmedName = name.trim();
   const trimmedProducer = producer.trim();
 
@@ -109,13 +125,26 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   }
 
   if (candidates.length > 0) {
-    const { bestMatch, bestScore } = findBestMatch(
+    const ranked = scoreAllMatches(
       { name: trimmedName, producer: trimmedProducer, appellation },
       candidates,
       { redistribute: false }
     );
-    if (bestScore >= SIMILARITY_THRESHOLD && bestMatch) {
-      return { wine: bestMatch, created: false };
+
+    // Auto-match: top score is confident enough
+    if (ranked[0].score >= SIMILARITY_THRESHOLD) {
+      return { wine: ranked[0].wine, created: false };
+    }
+
+    // Soft zone: top score is suggestive but not confident. Surface up to N
+    // candidates and let the user choose, unless the caller has already
+    // confirmed they want to create regardless.
+    if (!confirmCreate && ranked[0].score >= SOFT_ZONE_MIN) {
+      const softCandidates = ranked
+        .filter(r => r.score >= SOFT_ZONE_MIN)
+        .slice(0, SOFT_ZONE_TOP_N)
+        .map(r => ({ wine: r.wine, score: Math.round(r.score * 100) / 100 }));
+      return { wine: null, candidates: softCandidates };
     }
   }
 

--- a/backend/src/services/wineMatching.js
+++ b/backend/src/services/wineMatching.js
@@ -69,4 +69,15 @@ function findBestMatch(query, candidates, opts) {
   return { bestMatch, bestScore };
 }
 
-module.exports = { scoreWineMatch, findBestMatch, WEIGHTS };
+/**
+ * Score every candidate and return them ranked by score (descending).
+ * Used by the soft-zone "did you mean?" prompt: we want the top N near-matches
+ * to show the user, not just the single best one.
+ */
+function scoreAllMatches(query, candidates, opts) {
+  return candidates
+    .map(c => ({ wine: c, score: scoreWineMatch(c, query, opts) }))
+    .sort((a, b) => b.score - a.score);
+}
+
+module.exports = { scoreWineMatch, findBestMatch, scoreAllMatches, WEIGHTS };

--- a/backend/src/services/wineMatching.test.js
+++ b/backend/src/services/wineMatching.test.js
@@ -1,4 +1,4 @@
-const { scoreWineMatch, findBestMatch, WEIGHTS } = require('./wineMatching');
+const { scoreWineMatch, findBestMatch, scoreAllMatches, WEIGHTS } = require('./wineMatching');
 
 // ─── scoreWineMatch ──────────────────────────────────────────────────────────
 
@@ -130,6 +130,35 @@ describe('findBestMatch', () => {
     // Both should find the same best match regardless of redistribute
     expect(matchRedist.name).toBe('Merlot');
     expect(matchNoRedist.name).toBe('Merlot');
+  });
+});
+
+// ─── scoreAllMatches ─────────────────────────────────────────────────────────
+
+describe('scoreAllMatches', () => {
+  const candidates = [
+    { name: 'Rosabella Rosato', producer: 'G.D. Vajra' },
+    { name: 'Rosa Bella', producer: 'G.D. Vajra' },
+    { name: 'Opus One', producer: 'Mondavi Rothschild' },
+  ];
+
+  test('returns all candidates with scores, sorted desc', () => {
+    const query = { name: 'Rosabella', producer: 'G.D. Vajra' };
+    const ranked = scoreAllMatches(query, candidates, { redistribute: false });
+    expect(ranked).toHaveLength(3);
+    expect(ranked[0].score).toBeGreaterThanOrEqual(ranked[1].score);
+    expect(ranked[1].score).toBeGreaterThanOrEqual(ranked[2].score);
+    expect(ranked[2].wine.name).toBe('Opus One'); // least similar last
+  });
+
+  test('preserves the candidate object reference on each entry', () => {
+    const query = { name: 'Opus One', producer: 'Mondavi Rothschild' };
+    const ranked = scoreAllMatches(query, candidates);
+    expect(ranked[0].wine).toBe(candidates[2]);
+  });
+
+  test('empty candidates returns empty array', () => {
+    expect(scoreAllMatches({ name: 'X', producer: 'Y' }, [])).toEqual([]);
   });
 });
 

--- a/frontend/src/components/SimilarWinesModal.js
+++ b/frontend/src/components/SimilarWinesModal.js
@@ -1,0 +1,92 @@
+import Modal from './Modal';
+import WineImage from './WineImage';
+
+/**
+ * Shown when the backend's find-or-create returns soft-zone candidates —
+ * the wine the user is trying to add is similar to existing entries but
+ * not similar enough to auto-match. Asks the user to pick one or confirm
+ * "no, create a new wine".
+ *
+ * Props:
+ *   candidates   — [{ wine, score }] from /api/wines/find-or-create
+ *   queryName    — the name the user was trying to add (shown in the prompt)
+ *   onPick(wine) — user picked an existing wine
+ *   onCreateNew  — user wants to create a new wine anyway
+ *   onCancel     — user wants to back out and re-enter / cancel
+ *   busy         — disables buttons while a follow-up request is in flight
+ */
+function SimilarWinesModal({ candidates, queryName, onPick, onCreateNew, onCancel, busy }) {
+  return (
+    <Modal title="Did you mean one of these?" onClose={onCancel} showClose wide>
+      <p style={{ margin: '0 0 1rem', fontSize: '0.95rem', color: 'var(--text-secondary, #666)' }}>
+        We found wines in the registry that look close to{' '}
+        <strong>{queryName || 'what you entered'}</strong>. Picking an existing
+        wine keeps the registry tidy and lets you share data with other users.
+      </p>
+
+      <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 1.25rem', maxHeight: 380, overflowY: 'auto' }}>
+        {candidates.map(({ wine, score }) => (
+          <li
+            key={wine._id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '0.6rem 0.4rem',
+              borderBottom: '1px solid var(--border, #e5e5e5)',
+            }}
+          >
+            <div style={{ width: 48, height: 64, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <WineImage
+                image={wine.image}
+                alt={wine.name}
+                className="similar-wine-thumb"
+                wineType={wine.type}
+                placeholder="similar-wine-placeholder"
+              />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 600 }}>{wine.name}</div>
+              <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+                {wine.producer}
+                {wine.country?.name ? ` · ${wine.country.name}` : ''}
+                {wine.region?.name ? ` · ${wine.region.name}` : ''}
+              </div>
+              {wine.appellation && (
+                <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)' }}>{wine.appellation}</div>
+              )}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
+              <span
+                title="Similarity score"
+                style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}
+              >
+                {Math.round(score * 100)}% match
+              </span>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={busy}
+                onClick={() => onPick(wine)}
+                style={{ padding: '0.35rem 0.8rem', fontSize: '0.85rem' }}
+              >
+                Use this
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="modal-actions" style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+        <button type="button" className="btn" disabled={busy} onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="button" className="btn btn-secondary" disabled={busy} onClick={onCreateNew}>
+          No, create new wine
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+export default SimilarWinesModal;

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -9,6 +9,7 @@ import { validatePriceSanity } from '../utils/priceValidation';
 import ImageUpload from '../components/ImageUpload';
 import RatingInput from '../components/RatingInput';
 import WineImage from '../components/WineImage';
+import SimilarWinesModal from '../components/SimilarWinesModal';
 import { WINE_TYPES } from '../config/wineTypes';
 import './AddBottle.css';
 
@@ -59,6 +60,14 @@ function AddBottle() {
   const [pendingWineData, setPendingWineData] = useState(null);
   const [findingWine, setFindingWine] = useState(false);
 
+  // ── Soft-zone "did you mean?" state ──
+  // When the backend's find-or-create finds similar (but not auto-matching)
+  // wines, it returns candidates instead of creating. We hold the user's
+  // pending wineData so we can re-fire with confirmCreate: true if the
+  // user picks "No, create new wine".
+  const [softCandidates, setSoftCandidates] = useState(null);
+  const [softPending, setSoftPending] = useState(null); // { wineData, carriedVintage }
+
   // ── Label-scan camera (shared hook) ──
   const handleScanSuccess = useCallback((data) => {
     setScanResult(data);
@@ -76,6 +85,46 @@ function AddBottle() {
     labelVideoRef, labelCanvasRef,
     startCamera: startLabelCamera, stopCamera: stopLabelCamera, capturePhoto: captureLabelPhoto
   } = useLabelScanner(apiFetch, { onScanSuccess: handleScanSuccess, onScanError: handleScanError });
+
+  // Apply a resolved wine (from find-or-create OR from a soft-zone pick) and
+  // advance to the bottle-details step. Centralised so all entry paths share
+  // the same teardown.
+  const applyResolvedWine = useCallback((wine, carriedVintage) => {
+    setSelectedWine(wine);
+    setBottleData(prev => ({ ...prev, vintage: carriedVintage || '' }));
+    setScanResult(null);
+    setLabelImage(null);
+    setShowManualForm(false);
+    setPendingWineData(null);
+    setSoftCandidates(null);
+    setSoftPending(null);
+    setStep(2);
+  }, []);
+
+  // Submit a find-or-create request, handling the three response shapes:
+  // resolved wine, soft-zone candidates, or error.
+  const submitFindOrCreate = useCallback(async (wineData, carriedVintage, { confirmCreate = false } = {}) => {
+    setError(null);
+    setFindingWine(true);
+    try {
+      const res = await findOrCreateWine(apiFetch, { ...wineData, confirmCreate });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || t('addBottle.scanFailedToSaveWine'));
+        return;
+      }
+      if (data.candidates && data.candidates.length > 0) {
+        setSoftCandidates(data.candidates);
+        setSoftPending({ wineData, carriedVintage });
+        return;
+      }
+      applyResolvedWine(data.wine, carriedVintage);
+    } catch {
+      setError(t('addBottle.scanFailedToSaveWine'));
+    } finally {
+      setFindingWine(false);
+    }
+  }, [apiFetch, t, applyResolvedWine]);
 
   // Confirm scan result — find/create the wine, save label image, go to bottle details
   const handleConfirmScan = useCallback(async () => {
@@ -104,25 +153,8 @@ function AddBottle() {
           labelImage: labelImage || undefined
         };
 
-    setError(null);
-    setFindingWine(true);
-    try {
-      const res = await findOrCreateWine(apiFetch, wineData);
-      const data = await res.json();
-      if (!res.ok) { setError(data.error || t('addBottle.scanFailedToSaveWine')); return; }
-      setSelectedWine(data.wine);
-      setBottleData(prev => ({ ...prev, vintage: extracted.vintage || '' }));
-      setScanResult(null);
-      setLabelImage(null);
-      setShowManualForm(false);
-      setPendingWineData(null);
-      setStep(2);
-    } catch {
-      setError(t('addBottle.scanFailedToSaveWine'));
-    } finally {
-      setFindingWine(false);
-    }
-  }, [apiFetch, scanResult, labelImage, t]);
+    await submitFindOrCreate(wineData, extracted.vintage);
+  }, [scanResult, labelImage, submitFindOrCreate]);
 
   // Switch to the editable manual form (user says "not the right wine")
   const handleNotRightWine = useCallback(() => {
@@ -145,32 +177,14 @@ function AddBottle() {
       setError(t('addBottle.scanNameProducerCountryRequired'));
       return;
     }
-    setError(null);
-    setFindingWine(true);
-    try {
-      const grapes = pendingWineData.grapes
-        ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
-        : [];
-      const res = await findOrCreateWine(apiFetch, {
-        ...pendingWineData,
-        grapes,
-        labelImage: labelImage || undefined
-      });
-      const data = await res.json();
-      if (!res.ok) { setError(data.error || t('addBottle.scanFailedToSaveWine')); return; }
-      setSelectedWine(data.wine);
-      setBottleData(prev => ({ ...prev, vintage: scanResult?.extracted?.vintage || '' }));
-      setScanResult(null);
-      setLabelImage(null);
-      setShowManualForm(false);
-      setPendingWineData(null);
-      setStep(2);
-    } catch {
-      setError(t('addBottle.scanFailedToSaveWine'));
-    } finally {
-      setFindingWine(false);
-    }
-  }, [apiFetch, pendingWineData, scanResult, labelImage, t]);
+    const grapes = pendingWineData.grapes
+      ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
+      : [];
+    await submitFindOrCreate(
+      { ...pendingWineData, grapes, labelImage: labelImage || undefined },
+      scanResult?.extracted?.vintage
+    );
+  }, [pendingWineData, scanResult, labelImage, t, submitFindOrCreate]);
 
   // Reset — back to search
   const handleScanReset = useCallback(() => {
@@ -901,6 +915,19 @@ function AddBottle() {
             </div>
           </form>
         </div>
+      )}
+
+      {softCandidates && (
+        <SimilarWinesModal
+          candidates={softCandidates}
+          queryName={softPending?.wineData?.name}
+          busy={findingWine}
+          onPick={(wine) => applyResolvedWine(wine, softPending?.carriedVintage)}
+          onCreateNew={() => softPending && submitFindOrCreate(
+            softPending.wineData, softPending.carriedVintage, { confirmCreate: true }
+          )}
+          onCancel={() => { setSoftCandidates(null); setSoftPending(null); }}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -7,6 +7,7 @@ import { addToWishlist } from '../api/wishlist';
 import '../components/ImageUpload.css';
 import './AddBottle.css';
 import WineImage from '../components/WineImage';
+import SimilarWinesModal from '../components/SimilarWinesModal';
 import { WINE_TYPES } from '../config/wineTypes';
 import './AddToWishlist.css';
 
@@ -33,6 +34,40 @@ function AddToWishlist() {
   const [showManualForm, setShowManualForm] = useState(false);
   const [pendingWineData, setPendingWineData] = useState(null);
   const [findingWine, setFindingWine] = useState(false);
+
+  // ── Soft-zone "did you mean?" state — see AddBottle.js for the design ──
+  const [softCandidates, setSoftCandidates] = useState(null);
+  const [softPending, setSoftPending] = useState(null);
+
+  const applyResolvedWine = useCallback((wine) => {
+    setSelectedWine(wine);
+    setScanResult(null);
+    setLabelImage(null);
+    setShowManualForm(false);
+    setPendingWineData(null);
+    setSoftCandidates(null);
+    setSoftPending(null);
+  }, []);
+
+  const submitFindOrCreate = useCallback(async (wineData, { confirmCreate = false } = {}) => {
+    setError(null);
+    setFindingWine(true);
+    try {
+      const res = await findOrCreateWine(apiFetch, { ...wineData, confirmCreate });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error || 'Failed to save wine'); return; }
+      if (data.candidates && data.candidates.length > 0) {
+        setSoftCandidates(data.candidates);
+        setSoftPending({ wineData });
+        return;
+      }
+      applyResolvedWine(data.wine);
+    } catch {
+      setError('Failed to save wine');
+    } finally {
+      setFindingWine(false);
+    }
+  }, [apiFetch, applyResolvedWine]);
 
   // ── Wishlist item details ──
   const [vintage, setVintage] = useState('');
@@ -104,23 +139,8 @@ function AddToWishlist() {
           labelImage: labelImage || undefined
         };
 
-    setError(null);
-    setFindingWine(true);
-    try {
-      const res = await findOrCreateWine(apiFetch, wineData);
-      const data = await res.json();
-      if (!res.ok) { setError(data.error || 'Failed to save wine'); return; }
-      setSelectedWine(data.wine);
-      setScanResult(null);
-      setLabelImage(null);
-      setShowManualForm(false);
-      setPendingWineData(null);
-    } catch {
-      setError('Failed to save wine');
-    } finally {
-      setFindingWine(false);
-    }
-  }, [apiFetch, scanResult, labelImage]);
+    await submitFindOrCreate(wineData);
+  }, [scanResult, labelImage, submitFindOrCreate]);
 
   const handleNotRightWine = useCallback(() => {
     const { extracted } = scanResult;
@@ -141,30 +161,11 @@ function AddToWishlist() {
       setError('Name, producer, and country are required');
       return;
     }
-    setError(null);
-    setFindingWine(true);
-    try {
-      const grapes = pendingWineData.grapes
-        ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
-        : [];
-      const res = await findOrCreateWine(apiFetch, {
-        ...pendingWineData,
-        grapes,
-        labelImage: labelImage || undefined
-      });
-      const data = await res.json();
-      if (!res.ok) { setError(data.error || 'Failed to save wine'); return; }
-      setSelectedWine(data.wine);
-      setScanResult(null);
-      setLabelImage(null);
-      setShowManualForm(false);
-      setPendingWineData(null);
-    } catch {
-      setError('Failed to save wine');
-    } finally {
-      setFindingWine(false);
-    }
-  }, [apiFetch, pendingWineData, labelImage]);
+    const grapes = pendingWineData.grapes
+      ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
+      : [];
+    await submitFindOrCreate({ ...pendingWineData, grapes, labelImage: labelImage || undefined });
+  }, [pendingWineData, labelImage, submitFindOrCreate]);
 
   const handleScanReset = useCallback(() => {
     setScanResult(null);
@@ -615,6 +616,17 @@ function AddToWishlist() {
             </div>
           </form>
         </div>
+      )}
+
+      {softCandidates && (
+        <SimilarWinesModal
+          candidates={softCandidates}
+          queryName={softPending?.wineData?.name}
+          busy={findingWine}
+          onPick={(wine) => applyResolvedWine(wine)}
+          onCreateNew={() => softPending && submitFindOrCreate(softPending.wineData, { confirmCreate: true })}
+          onCancel={() => { setSoftCandidates(null); setSoftPending(null); }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Closes the dedup gap that produced the duplicate "Rosa Bella" / "Rosabella Rosato" earlier today.

Before this PR, `find-or-create` made a binary decision: combined score ≥ 0.75 → match an existing wine, else create new. Names that *humans* read as the same wine but that tokenize differently fell into the gap. Example: `Rosa Bella` vs `Rosabella Rosato` scored **0.34** on name alone (token Jaccard 0; trigram + Levenshtein only reached 0.47). Even with a perfect producer + appellation match, composite hit ~0.70 — below threshold, so a duplicate got created silently.

This PR adds a **soft zone** between 0.50 and 0.75 where the backend returns the top candidates instead of creating, and the UI shows a "Did you mean…?" modal so the user picks or explicitly confirms a new wine.

## Flow
1. User adds a bottle. Backend runs find-or-create.
2. If best score ≥ 0.75 → auto-match, behaviour unchanged.
3. If best score in **[0.50, 0.75)** → returns `{ candidates: [...] }` (no wine created).
4. UI shows the modal:
   - **Use this** → use the picked candidate, no extra round-trip
   - **No, create new wine** → re-fires find-or-create with `confirmCreate: true`, bypassing the soft zone
   - **Cancel** → modal closes, user can edit and retry
5. If best score < 0.50 → straight to create (no realistic confusion).

## Backend
- `services/wineMatching.js` — new `scoreAllMatches()` returning ranked candidates.
- `services/findOrCreateWine.js` — three-way return shape; `confirmCreate` opts back to the old auto-create behaviour.
- `routes/wines.js` — `/find-or-create` passes `confirmCreate` through, returns `{ candidates }` when present.
- 3 new tests for `scoreAllMatches`.

## Frontend
- `components/SimilarWinesModal.js` — shared modal with thumbnail + match % per candidate.
- `pages/AddBottle.js` & `pages/AddToWishlist.js` — both call sites consolidated into a single `submitFindOrCreate` helper that handles the three response shapes.

## Test plan
- [x] `cd backend && npm test` — 606 passed
- [x] `cd frontend && npm test` — 292 passed
- [ ] Smoke: in a cellar with existing wine "Rosabella Rosato" by G.D. Vajra, try to add a bottle with name "Rosa Bella" + same producer → modal appears showing Rosabella Rosato as a candidate
- [ ] Pick "Use this" → bottle uses the existing wine, no new WineDefinition row
- [ ] Try same flow, click "No, create new" → new WineDefinition row created
- [ ] Smoke same flow from the wishlist add page