### PR TITLE
feat(admin): registry-wide duplicate-wine scanner with one-click merge

### DIFF
--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -6,8 +6,10 @@ const {
   calculateSimilarity,
   combinedSimilarity,
   trigramSimilarity,
-  tokenSimilarity
+  tokenSimilarity,
+  normalizeString
 } = require('../../utils/normalize');
+const { scoreWineMatch } = require('../../services/wineMatching');
 const WineDefinition = require('../../models/WineDefinition');
 const Bottle = require('../../models/Bottle');
 const BottleImage = require('../../models/BottleImage');
@@ -165,6 +167,145 @@ router.post('/', async (req, res) => {
 });
 
 // GET /api/admin/wines/duplicates - Find potential duplicates
+// GET /api/admin/wines/duplicate-clusters
+//
+// Registry-wide scan: groups wines by normalised producer (cheap O(N) bucket),
+// then runs pairwise scoring inside each bucket. Any pair scoring >= minScore
+// becomes an edge; connected components form clusters.
+//
+// Producer grouping is the pragmatic pre-filter: real duplicates almost always
+// share a producer (people typo the wine name, not the producer). Cases where
+// the producer itself is typo'd are missed by this scan — a future producer-
+// dedup pass is the right fix there.
+//
+// Query: minScore (default 0.6), limit (default 50, max 200)
+// Returns: { clusters: [{ score, wines: [{ wine, bottleCount }] }], scannedCount }
+router.get('/duplicate-clusters', async (req, res) => {
+  try {
+    const minScore = Math.max(0, Math.min(1, parseFloat(req.query.minScore) || 0.6));
+    const limit = Math.max(1, Math.min(200, parseInt(req.query.limit) || 50));
+
+    // Fetch every wine — small projection so we don't pull the world.
+    // Sort by producer so we can stream-group instead of building a large map.
+    const wines = await WineDefinition.find({})
+      .select('name producer appellation image type country region')
+      .populate('country', 'name')
+      .populate('region', 'name')
+      .lean();
+
+    // Group by normalised producer
+    const byProducer = new Map();
+    for (const wine of wines) {
+      const key = normalizeString(wine.producer || '');
+      if (!key) continue;
+      let group = byProducer.get(key);
+      if (!group) { group = []; byProducer.set(key, group); }
+      group.push(wine);
+    }
+
+    // Union-find over wine _ids
+    const parent = new Map();
+    const find = (id) => {
+      let p = parent.get(id);
+      if (p === id) return id;
+      p = find(p);
+      parent.set(id, p);
+      return p;
+    };
+    const union = (a, b) => {
+      const ra = find(a), rb = find(b);
+      if (ra !== rb) parent.set(ra, rb);
+    };
+
+    // Score pairs within each producer group
+    const edgeScore = new Map(); // "a|b" -> best score (so we can keep cluster score later)
+    for (const group of byProducer.values()) {
+      if (group.length < 2) continue;
+      for (let i = 0; i < group.length; i++) {
+        const a = group[i];
+        const aId = String(a._id);
+        if (!parent.has(aId)) parent.set(aId, aId);
+        for (let j = i + 1; j < group.length; j++) {
+          const b = group[j];
+          const bId = String(b._id);
+          if (!parent.has(bId)) parent.set(bId, bId);
+          const score = scoreWineMatch(
+            { name: a.name, producer: a.producer, appellation: a.appellation },
+            { name: b.name, producer: b.producer, appellation: b.appellation },
+            { redistribute: false }
+          );
+          if (score >= minScore) {
+            union(aId, bId);
+            const key = aId < bId ? `${aId}|${bId}` : `${bId}|${aId}`;
+            edgeScore.set(key, score);
+          }
+        }
+      }
+    }
+
+    // Bucket wines by cluster root
+    const clusters = new Map();
+    for (const id of parent.keys()) {
+      const root = find(id);
+      let bucket = clusters.get(root);
+      if (!bucket) { bucket = { wineIds: [], score: 0 }; clusters.set(root, bucket); }
+      bucket.wineIds.push(id);
+    }
+
+    // Drop singletons (a wine in its own cluster isn't a duplicate)
+    // Compute cluster score = max pairwise score among any edge in the cluster
+    const wineById = new Map(wines.map(w => [String(w._id), w]));
+    const result = [];
+    for (const [, bucket] of clusters) {
+      if (bucket.wineIds.length < 2) continue;
+      let best = 0;
+      for (let i = 0; i < bucket.wineIds.length; i++) {
+        for (let j = i + 1; j < bucket.wineIds.length; j++) {
+          const a = bucket.wineIds[i], b = bucket.wineIds[j];
+          const key = a < b ? `${a}|${b}` : `${b}|${a}`;
+          const s = edgeScore.get(key) || 0;
+          if (s > best) best = s;
+        }
+      }
+      result.push({
+        score: Math.round(best * 100) / 100,
+        wineIds: bucket.wineIds,
+      });
+    }
+
+    // Sort clusters by best score desc and trim
+    result.sort((a, b) => b.score - a.score);
+    const trimmed = result.slice(0, limit);
+
+    // Look up bottle counts in one aggregate
+    const allClusterWineIds = trimmed.flatMap(c => c.wineIds);
+    const bottleCounts = new Map();
+    if (allClusterWineIds.length > 0) {
+      const counts = await Bottle.aggregate([
+        { $match: { wineDefinition: { $in: allClusterWineIds.map(id => new mongoose.Types.ObjectId(id)) } } },
+        { $group: { _id: '$wineDefinition', count: { $sum: 1 } } },
+      ]);
+      for (const c of counts) bottleCounts.set(String(c._id), c.count);
+    }
+
+    res.json({
+      scannedCount: wines.length,
+      producerGroupCount: byProducer.size,
+      totalClusters: result.length,
+      clusters: trimmed.map(c => ({
+        score: c.score,
+        wines: c.wineIds.map(id => {
+          const w = wineById.get(id);
+          return { ...w, bottleCount: bottleCounts.get(id) || 0 };
+        }),
+      })),
+    });
+  } catch (err) {
+    console.error('Duplicate cluster scan error:', err);
+    res.status(500).json({ error: 'Failed to scan for duplicates' });
+  }
+});
+
 router.get('/duplicates', async (req, res) => {
   try {
     const { name, producer, appellation, threshold = 0.75 } = req.query;

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -270,10 +270,17 @@ router.post('/scan-label', requireAuth, aiBurstLimiter, async (req, res) => {
 // taxonomy records (country, region, grapes).
 //
 // Body:  { name, producer, country, region?, appellation?, type?, grapes?: string[],
-//           labelImage?: "data:image/png;base64,..." }
-// Returns: { wine: WineDefinition, created: boolean }
+//           labelImage?: "data:image/png;base64,...", confirmCreate?: boolean }
+// Returns one of:
+//   { wine: WineDefinition, created: false }       — exact or auto-fuzzy match
+//   { candidates: [{ wine, score }, ...] }         — soft-zone: similar wines exist,
+//                                                     UI should ask "did you mean…?"
+//   { wine: WineDefinition, created: true }        — new wine created
+//
+// Pass `confirmCreate: true` after the user has reviewed the soft-zone
+// candidates and explicitly chosen to create a new wine anyway.
 router.post('/find-or-create', requireAuth, async (req, res) => {
-  const { name, producer, country, region, appellation, type, grapes, labelImage } = req.body;
+  const { name, producer, country, region, appellation, type, grapes, labelImage, confirmCreate } = req.body;
 
   if (!name?.trim() || !producer?.trim()) {
     return res.status(400).json({ error: 'name and producer are required' });
@@ -283,11 +290,18 @@ router.post('/find-or-create', requireAuth, async (req, res) => {
   }
 
   try {
-    const { wine, created } = await findOrCreateWine(
+    const result = await findOrCreateWine(
       { name, producer, country, region, appellation, type, grapes: grapes || [] },
-      req.user.id
+      req.user.id,
+      { confirmCreate: !!confirmCreate }
     );
 
+    // Soft-zone: hand the candidates back so the UI can prompt the user
+    if (result.candidates) {
+      return res.status(200).json({ candidates: result.candidates });
+    }
+
+    const { wine, created } = result;
     if (created) submitUrls(`/wines/${wine.slug || wine._id}`);
 
     res.status(created ? 201 : 200).json({ wine, created });

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -16,9 +16,15 @@ const Region = require('../models/Region');
 const Grape = require('../models/Grape');
 const searchService = require('./search');
 const { generateWineKey, normalizeString, resolveGrapeName } = require('../utils/normalize');
-const { findBestMatch } = require('./wineMatching');
+const { scoreAllMatches } = require('./wineMatching');
 
+// Auto-match when combined score >= SIMILARITY_THRESHOLD.
+// In the SOFT_ZONE_MIN..SIMILARITY_THRESHOLD band, surface candidates to the
+// user instead of silently creating a new wine. Below SOFT_ZONE_MIN we trust
+// that none of the existing wines are remotely the same and create.
 const SIMILARITY_THRESHOLD = 0.75;
+const SOFT_ZONE_MIN = 0.50;
+const SOFT_ZONE_TOP_N = 5;
 const POPULATE = ['country', 'region', 'grapes'];
 
 // ── Taxonomy helpers ─────────────────────────────────────────────────────────
@@ -69,11 +75,21 @@ async function findOrCreateGrapes(names, userId) {
 /**
  * Find an existing WineDefinition or create a new one.
  *
+ * Three return shapes:
+ *   { wine, created: false }                   — exact or auto-fuzzy match (>= SIMILARITY_THRESHOLD)
+ *   { wine: null, candidates: [...] }          — soft zone: similar wines exist but not enough to auto-match.
+ *                                                Caller (UI) should show a "did you mean?" prompt.
+ *   { wine, created: true }                    — no match, new wine created
+ *
+ * Pass `confirmCreate: true` to bypass the soft-zone gate and force creation
+ * — used when the user has explicitly confirmed "no, none of those, make a new one".
+ *
  * @param {Object} wineData   - { name, producer, country, region, appellation, type, grapes[] }
  * @param {string} userId     - ObjectId string of the authenticated user (for createdBy)
- * @returns {{ wine: WineDefinition, created: boolean }}
+ * @param {Object} [opts]
+ * @param {boolean} [opts.confirmCreate=false] - Skip soft-zone candidate return and create directly
  */
-async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId) {
+async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false } = {}) {
   const trimmedName = name.trim();
   const trimmedProducer = producer.trim();
 
@@ -109,13 +125,26 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   }
 
   if (candidates.length > 0) {
-    const { bestMatch, bestScore } = findBestMatch(
+    const ranked = scoreAllMatches(
       { name: trimmedName, producer: trimmedProducer, appellation },
       candidates,
       { redistribute: false }
     );
-    if (bestScore >= SIMILARITY_THRESHOLD && bestMatch) {
-      return { wine: bestMatch, created: false };
+
+    // Auto-match: top score is confident enough
+    if (ranked[0].score >= SIMILARITY_THRESHOLD) {
+      return { wine: ranked[0].wine, created: false };
+    }
+
+    // Soft zone: top score is suggestive but not confident. Surface up to N
+    // candidates and let the user choose, unless the caller has already
+    // confirmed they want to create regardless.
+    if (!confirmCreate && ranked[0].score >= SOFT_ZONE_MIN) {
+      const softCandidates = ranked
+        .filter(r => r.score >= SOFT_ZONE_MIN)
+        .slice(0, SOFT_ZONE_TOP_N)
+        .map(r => ({ wine: r.wine, score: Math.round(r.score * 100) / 100 }));
+      return { wine: null, candidates: softCandidates };
     }
   }
 

--- a/backend/src/services/wineMatching.js
+++ b/backend/src/services/wineMatching.js
@@ -69,4 +69,15 @@ function findBestMatch(query, candidates, opts) {
   return { bestMatch, bestScore };
 }
 
-module.exports = { scoreWineMatch, findBestMatch, WEIGHTS };
+/**
+ * Score every candidate and return them ranked by score (descending).
+ * Used by the soft-zone "did you mean?" prompt: we want the top N near-matches
+ * to show the user, not just the single best one.
+ */
+function scoreAllMatches(query, candidates, opts) {
+  return candidates
+    .map(c => ({ wine: c, score: scoreWineMatch(c, query, opts) }))
+    .sort((a, b) => b.score - a.score);
+}
+
+module.exports = { scoreWineMatch, findBestMatch, scoreAllMatches, WEIGHTS };

--- a/backend/src/services/wineMatching.test.js
+++ b/backend/src/services/wineMatching.test.js
@@ -1,4 +1,4 @@
-const { scoreWineMatch, findBestMatch, WEIGHTS } = require('./wineMatching');
+const { scoreWineMatch, findBestMatch, scoreAllMatches, WEIGHTS } = require('./wineMatching');
 
 // ─── scoreWineMatch ──────────────────────────────────────────────────────────
 
@@ -130,6 +130,35 @@ describe('findBestMatch', () => {
     // Both should find the same best match regardless of redistribute
     expect(matchRedist.name).toBe('Merlot');
     expect(matchNoRedist.name).toBe('Merlot');
+  });
+});
+
+// ─── scoreAllMatches ─────────────────────────────────────────────────────────
+
+describe('scoreAllMatches', () => {
+  const candidates = [
+    { name: 'Rosabella Rosato', producer: 'G.D. Vajra' },
+    { name: 'Rosa Bella', producer: 'G.D. Vajra' },
+    { name: 'Opus One', producer: 'Mondavi Rothschild' },
+  ];
+
+  test('returns all candidates with scores, sorted desc', () => {
+    const query = { name: 'Rosabella', producer: 'G.D. Vajra' };
+    const ranked = scoreAllMatches(query, candidates, { redistribute: false });
+    expect(ranked).toHaveLength(3);
+    expect(ranked[0].score).toBeGreaterThanOrEqual(ranked[1].score);
+    expect(ranked[1].score).toBeGreaterThanOrEqual(ranked[2].score);
+    expect(ranked[2].wine.name).toBe('Opus One'); // least similar last
+  });
+
+  test('preserves the candidate object reference on each entry', () => {
+    const query = { name: 'Opus One', producer: 'Mondavi Rothschild' };
+    const ranked = scoreAllMatches(query, candidates);
+    expect(ranked[0].wine).toBe(candidates[2]);
+  });
+
+  test('empty candidates returns empty array', () => {
+    expect(scoreAllMatches({ name: 'X', producer: 'Y' }, [])).toEqual([]);
   });
 });
 

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -24,6 +24,9 @@ export const adminMergeWine = (apiFetch, sourceId, targetId) =>
     body: JSON.stringify({ targetId }),
   });
 
+export const adminGetWineDuplicateClusters = (apiFetch, { minScore = 0.6, limit = 50 } = {}) =>
+  apiFetch(`/api/admin/wines/duplicate-clusters?minScore=${minScore}&limit=${limit}`);
+
 // ── Taxonomy ─────────────────────────────────────────────────────────────────
 export const adminGetTaxonomy = (apiFetch, endpoint) =>
   apiFetch(endpoint);

--- a/frontend/src/components/SimilarWinesModal.js
+++ b/frontend/src/components/SimilarWinesModal.js
@@ -1,0 +1,92 @@
+import Modal from './Modal';
+import WineImage from './WineImage';
+
+/**
+ * Shown when the backend's find-or-create returns soft-zone candidates —
+ * the wine the user is trying to add is similar to existing entries but
+ * not similar enough to auto-match. Asks the user to pick one or confirm
+ * "no, create a new wine".
+ *
+ * Props:
+ *   candidates   — [{ wine, score }] from /api/wines/find-or-create
+ *   queryName    — the name the user was trying to add (shown in the prompt)
+ *   onPick(wine) — user picked an existing wine
+ *   onCreateNew  — user wants to create a new wine anyway
+ *   onCancel     — user wants to back out and re-enter / cancel
+ *   busy         — disables buttons while a follow-up request is in flight
+ */
+function SimilarWinesModal({ candidates, queryName, onPick, onCreateNew, onCancel, busy }) {
+  return (
+    <Modal title="Did you mean one of these?" onClose={onCancel} showClose wide>
+      <p style={{ margin: '0 0 1rem', fontSize: '0.95rem', color: 'var(--text-secondary, #666)' }}>
+        We found wines in the registry that look close to{' '}
+        <strong>{queryName || 'what you entered'}</strong>. Picking an existing
+        wine keeps the registry tidy and lets you share data with other users.
+      </p>
+
+      <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 1.25rem', maxHeight: 380, overflowY: 'auto' }}>
+        {candidates.map(({ wine, score }) => (
+          <li
+            key={wine._id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '0.6rem 0.4rem',
+              borderBottom: '1px solid var(--border, #e5e5e5)',
+            }}
+          >
+            <div style={{ width: 48, height: 64, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <WineImage
+                image={wine.image}
+                alt={wine.name}
+                className="similar-wine-thumb"
+                wineType={wine.type}
+                placeholder="similar-wine-placeholder"
+              />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 600 }}>{wine.name}</div>
+              <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+                {wine.producer}
+                {wine.country?.name ? ` · ${wine.country.name}` : ''}
+                {wine.region?.name ? ` · ${wine.region.name}` : ''}
+              </div>
+              {wine.appellation && (
+                <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)' }}>{wine.appellation}</div>
+              )}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
+              <span
+                title="Similarity score"
+                style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}
+              >
+                {Math.round(score * 100)}% match
+              </span>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={busy}
+                onClick={() => onPick(wine)}
+                style={{ padding: '0.35rem 0.8rem', fontSize: '0.85rem' }}
+              >
+                Use this
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="modal-actions" style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+        <button type="button" className="btn" disabled={busy} onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="button" className="btn btn-secondary" disabled={busy} onClick={onCreateNew}>
+          No, create new wine
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+export default SimilarWinesModal;

--- a/frontend/src/components/WineDuplicatesModal.js
+++ b/frontend/src/components/WineDuplicatesModal.js
@@ -1,0 +1,218 @@
+import { useState, useEffect, useCallback } from 'react';
+import Modal from './Modal';
+import WineImage from './WineImage';
+import { adminGetWineDuplicateClusters, adminMergeWine } from '../api/admin';
+
+/**
+ * Registry-wide duplicate scanner for admin users. Shows clusters of
+ * WineDefinitions that look like they're the same wine. Each cluster is
+ * resolved with a "keep this one" pick → all other wines in the cluster
+ * are merged into it (bottles reassigned, source wine deleted).
+ *
+ * Props:
+ *   apiFetch  — from useAuth()
+ *   onClose() — close the modal
+ *   onMerged() — called after any successful merge so the parent can refresh
+ *                its wine list count
+ */
+function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
+  const [clusters, setClusters] = useState(null); // null = not yet scanned
+  const [scanning, setScanning] = useState(false);
+  const [error, setError] = useState(null);
+  const [minScore, setMinScore] = useState(0.6);
+  const [meta, setMeta] = useState(null);
+
+  const scan = useCallback(async (score = minScore) => {
+    setScanning(true);
+    setError(null);
+    try {
+      const res = await adminGetWineDuplicateClusters(apiFetch, { minScore: score, limit: 50 });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Scan failed');
+        return;
+      }
+      setClusters(data.clusters || []);
+      setMeta({
+        scannedCount: data.scannedCount,
+        producerGroupCount: data.producerGroupCount,
+        totalClusters: data.totalClusters,
+      });
+    } catch {
+      setError('Network error');
+    } finally {
+      setScanning(false);
+    }
+  }, [apiFetch, minScore]);
+
+  // Auto-scan on open
+  useEffect(() => { scan(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // After a successful merge, drop the source from its cluster. If the
+  // cluster collapses to one wine, drop the whole cluster.
+  const handleMerged = (sourceId) => {
+    setClusters(prev => prev
+      .map(c => ({ ...c, wines: c.wines.filter(w => String(w._id) !== sourceId) }))
+      .filter(c => c.wines.length >= 2));
+    onMerged?.();
+  };
+
+  return (
+    <Modal title="Scan registry for duplicate wines" onClose={onClose} showClose wide>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
+        <label style={{ fontSize: '0.9rem' }}>
+          Min similarity:{' '}
+          <input
+            type="range"
+            min="0.5" max="0.85" step="0.05"
+            value={minScore}
+            onChange={e => setMinScore(parseFloat(e.target.value))}
+            style={{ verticalAlign: 'middle' }}
+          />{' '}
+          <strong>{Math.round(minScore * 100)}%</strong>
+        </label>
+        <button type="button" className="btn btn-secondary" onClick={() => scan(minScore)} disabled={scanning}>
+          {scanning ? 'Scanning…' : 'Re-scan'}
+        </button>
+        {meta && !scanning && (
+          <span style={{ fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+            Scanned {meta.scannedCount} wines across {meta.producerGroupCount} producers · {meta.totalClusters} cluster{meta.totalClusters === 1 ? '' : 's'} found
+          </span>
+        )}
+      </div>
+
+      {error && <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>}
+
+      {scanning && !clusters && (
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
+          Scanning registry… this can take a few seconds.
+        </div>
+      )}
+
+      {!scanning && clusters?.length === 0 && (
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
+          No duplicate clusters at this threshold.
+        </div>
+      )}
+
+      {clusters?.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxHeight: 520, overflowY: 'auto' }}>
+          {clusters.map((cluster, i) => (
+            <ClusterCard
+              key={i}
+              cluster={cluster}
+              apiFetch={apiFetch}
+              onMerged={handleMerged}
+            />
+          ))}
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function ClusterCard({ cluster, apiFetch, onMerged }) {
+  const [targetId, setTargetId] = useState(null);
+  const [merging, setMerging] = useState(null); // sourceId being merged
+  const [error, setError] = useState(null);
+
+  // Default the target to the wine with the most bottles (heuristic: that's
+  // usually the "real" entry and the others are typos that got fewer hits).
+  useEffect(() => {
+    if (targetId || cluster.wines.length === 0) return;
+    const sorted = [...cluster.wines].sort((a, b) => (b.bottleCount || 0) - (a.bottleCount || 0));
+    setTargetId(String(sorted[0]._id));
+  }, [cluster, targetId]);
+
+  const doMerge = async (sourceId) => {
+    setError(null);
+    setMerging(sourceId);
+    try {
+      const res = await adminMergeWine(apiFetch, sourceId, targetId);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || `Merge failed (${res.status})`);
+        return;
+      }
+      onMerged(sourceId);
+    } catch {
+      setError('Network error');
+    } finally {
+      setMerging(null);
+    }
+  };
+
+  return (
+    <div style={{
+      border: '1px solid var(--border, #e5e5e5)',
+      borderRadius: 6,
+      padding: 12,
+      background: 'var(--bg-secondary, #fafafa)',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+        <strong>{cluster.wines[0]?.producer}</strong>
+        <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)' }}>
+          {Math.round(cluster.score * 100)}% match
+        </span>
+      </div>
+
+      {error && <div className="alert alert-error" style={{ marginBottom: 8 }}>{error}</div>}
+
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {cluster.wines.map(wine => {
+          const isTarget = String(wine._id) === targetId;
+          return (
+            <li
+              key={wine._id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                padding: '0.5rem',
+                borderTop: '1px solid var(--border, #eee)',
+                background: isTarget ? 'var(--bg-success-faint, #f0f7f0)' : 'transparent',
+              }}
+            >
+              <input
+                type="radio"
+                name={`target-${cluster.wines[0]._id}`}
+                checked={isTarget}
+                onChange={() => setTargetId(String(wine._id))}
+                disabled={!!merging}
+                title="Keep this wine"
+              />
+              <div style={{ width: 36, height: 48, flexShrink: 0 }}>
+                <WineImage image={wine.image} alt={wine.name} wineType={wine.type} className="dup-wine-thumb" />
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontWeight: 600 }}>{wine.name}</div>
+                <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #666)' }}>
+                  {wine.appellation || '—'}
+                  {wine.country?.name ? ` · ${wine.country.name}` : ''}
+                  {' · '}{wine.bottleCount || 0} bottle{(wine.bottleCount || 0) === 1 ? '' : 's'}
+                </div>
+              </div>
+              {isTarget ? (
+                <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent, #4a7c4a)' }}>
+                  KEEP
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  disabled={!targetId || !!merging}
+                  onClick={() => doMerge(String(wine._id))}
+                  style={{ padding: '0.3rem 0.7rem', fontSize: '0.8rem' }}
+                >
+                  {merging === String(wine._id) ? 'Merging…' : 'Merge into KEEP'}
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default WineDuplicatesModal;

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -9,6 +9,7 @@ import { validatePriceSanity } from '../utils/priceValidation';
 import ImageUpload from '../components/ImageUpload';
 import RatingInput from '../components/RatingInput';
 import WineImage from '../components/WineImage';
+import SimilarWinesModal from '../components/SimilarWinesModal';
 import { WINE_TYPES } from '../config/wineTypes';
 import './AddBottle.css';
 
@@ -59,6 +60,14 @@ function AddBottle() {
   const [pendingWineData, setPendingWineData] = useState(null);
   const [findingWine, setFindingWine] = useState(false);
 
+  // ── Soft-zone "did you mean?" state ──
+  // When the backend's find-or-create finds similar (but not auto-matching)
+  // wines, it returns candidates instead of creating. We hold the user's
+  // pending wineData so we can re-fire with confirmCreate: true if the
+  // user picks "No, create new wine".
+  const [softCandidates, setSoftCandidates] = useState(null);
+  const [softPending, setSoftPending] = useState(null); // { wineData, carriedVintage }
+
   // ── Label-scan camera (shared hook) ──
   const handleScanSuccess = useCallback((data) => {
     setScanResult(data);
@@ -76,6 +85,46 @@ function AddBottle() {
     labelVideoRef, labelCanvasRef,
     startCamera: startLabelCamera, stopCamera: stopLabelCamera, capturePhoto: captureLabelPhoto
   } = useLabelScanner(apiFetch, { onScanSuccess: handleScanSuccess, onScanError: handleScanError });
+
+  // Apply a resolved wine (from find-or-create OR from a soft-zone pick) and
+  // advance to the bottle-details step. Centralised so all entry paths share
+  // the same teardown.
+  const applyResolvedWine = useCallback((wine, carriedVintage) => {
+    setSelectedWine(wine);
+    setBottleData(prev => ({ ...prev, vintage: carriedVintage || '' }));
+    setScanResult(null);
+    setLabelImage(null);
+    setShowManualForm(false);
+    setPendingWineData(null);
+    setSoftCandidates(null);
+    setSoftPending(null);
+    setStep(2);
+  }, []);
+
+  // Submit a find-or-create request, handling the three response shapes:
+  // resolved wine, soft-zone candidates, or error.
+  const submitFindOrCreate = useCallback(async (wineData, carriedVintage, { confirmCreate = false } = {}) => {
+    setError(null);
+    setFindingWine(true);
+    try {
+      const res = await findOrCreateWine(apiFetch, { ...wineData, confirmCreate });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || t('addBottle.scanFailedToSaveWine'));
+        return;
+      }
+      if (data.candidates && data.candidates.length > 0) {
+        setSoftCandidates(data.candidates);
+        setSoftPending({ wineData, carriedVintage });
+        return;
+      }
+      applyResolvedWine(data.wine, carriedVintage);
+    } catch {
+      setError(t('addBottle.scanFailedToSaveWine'));
+    } finally {
+      setFindingWine(false);
+    }
+  }, [apiFetch, t, applyResolvedWine]);
 
   // Confirm scan result — find/create the wine, save label image, go to bottle details
   const handleConfirmScan = useCallback(async () => {
@@ -104,25 +153,8 @@ function AddBottle() {
           labelImage: labelImage || undefined
         };
 
-    setError(null);
-    setFindingWine(true);
-    try {
-      const res = await findOrCreateWine(apiFetch, wineData);
-      const data = await res.json();
-      if (!res.ok) { setError(data.error || t('addBottle.scanFailedToSaveWine')); return; }
-      setSelectedWine(data.wine);
-      setBottleData(prev => ({ ...prev, vintage: extracted.vintage || '' }));
-      setScanResult(null);
-      setLabelImage(null);
-      setShowManualForm(false);
-      setPendingWineData(null);
-      setStep(2);
-    } catch {
-      setError(t('addBottle.scanFailedToSaveWine'));
-    } finally {
-      setFindingWine(false);
-    }
-  }, [apiFetch, scanResult, labelImage, t]);
+    await submitFindOrCreate(wineData, extracted.vintage);
+  }, [scanResult, labelImage, submitFindOrCreate]);
 
   // Switch to the editable manual form (user says "not the right wine")
   const handleNotRightWine = useCallback(() => {
@@ -145,32 +177,14 @@ function AddBottle() {
       setError(t('addBottle.scanNameProducerCountryRequired'));
       return;
     }
-    setError(null);
-    setFindingWine(true);
-    try {
-      const grapes = pendingWineData.grapes
-        ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
-        : [];
-      const res = await findOrCreateWine(apiFetch, {
-        ...pendingWineData,
-        grapes,
-        labelImage: labelImage || undefined
-      });
-      const data = await res.json();
-      if (!res.ok) { setError(data.error || t('addBottle.scanFailedToSaveWine')); return; }
-      setSelectedWine(data.wine);
-      setBottleData(prev => ({ ...prev, vintage: scanResult?.extracted?.vintage || '' }));
-      setScanResult(null);
-      setLabelImage(null);
-      setShowManualForm(false);
-      setPendingWineData(null);
-      setStep(2);
-    } catch {
-      setError(t('addBottle.scanFailedToSaveWine'));
-    } finally {
-      setFindingWine(false);
-    }
-  }, [apiFetch, pendingWineData, scanResult, labelImage, t]);
+    const grapes = pendingWineData.grapes
+      ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
+      : [];
+    await submitFindOrCreate(
+      { ...pendingWineData, grapes, labelImage: labelImage || undefined },
+      scanResult?.extracted?.vintage
+    );
+  }, [pendingWineData, scanResult, labelImage, t, submitFindOrCreate]);
 
   // Reset — back to search
   const handleScanReset = useCallback(() => {
@@ -901,6 +915,19 @@ function AddBottle() {
             </div>
           </form>
         </div>
+      )}
+
+      {softCandidates && (
+        <SimilarWinesModal
+          candidates={softCandidates}
+          queryName={softPending?.wineData?.name}
+          busy={findingWine}
+          onPick={(wine) => applyResolvedWine(wine, softPending?.carriedVintage)}
+          onCreateNew={() => softPending && submitFindOrCreate(
+            softPending.wineData, softPending.carriedVintage, { confirmCreate: true }
+          )}
+          onCancel={() => { setSoftCandidates(null); setSoftPending(null); }}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -7,6 +7,7 @@ import { addToWishlist } from '../api/wishlist';
 import '../components/ImageUpload.css';
 import './AddBottle.css';
 import WineImage from '../components/WineImage';
+import SimilarWinesModal from '../components/SimilarWinesModal';
 import { WINE_TYPES } from '../config/wineTypes';
 import './AddToWishlist.css';
 
@@ -33,6 +34,40 @@ function AddToWishlist() {
   const [showManualForm, setShowManualForm] = useState(false);
   const [pendingWineData, setPendingWineData] = useState(null);
   const [findingWine, setFindingWine] = useState(false);
+
+  // ── Soft-zone "did you mean?" state — see AddBottle.js for the design ──
+  const [softCandidates, setSoftCandidates] = useState(null);
+  const [softPending, setSoftPending] = useState(null);
+
+  const applyResolvedWine = useCallback((wine) => {
+    setSelectedWine(wine);
+    setScanResult(null);
+    setLabelImage(null);
+    setShowManualForm(false);
+    setPendingWineData(null);
+    setSoftCandidates(null);
+    setSoftPending(null);
+  }, []);
+
+  const submitFindOrCreate = useCallback(async (wineData, { confirmCreate = false } = {}) => {
+    setError(null);
+    setFindingWine(true);
+    try {
+      const res = await findOrCreateWine(apiFetch, { ...wineData, confirmCreate });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error || 'Failed to save wine'); return; }
+      if (data.candidates && data.candidates.length > 0) {
+        setSoftCandidates(data.candidates);
+        setSoftPending({ wineData });
+        return;
+      }
+      applyResolvedWine(data.wine);
+    } catch {
+      setError('Failed to save wine');
+    } finally {
+      setFindingWine(false);
+    }
+  }, [apiFetch, applyResolvedWine]);
 
   // ── Wishlist item details ──
   const [vintage, setVintage] = useState('');
@@ -104,23 +139,8 @@ function AddToWishlist() {
           labelImage: labelImage || undefined
         };
 
-    setError(null);
-    setFindingWine(true);
-    try {
-      const res = await findOrCreateWine(apiFetch, wineData);
-      const data = await res.json();
-      if (!res.ok) { setError(data.error || 'Failed to save wine'); return; }
-      setSelectedWine(data.wine);
-      setScanResult(null);
-      setLabelImage(null);
-      setShowManualForm(false);
-      setPendingWineData(null);
-    } catch {
-      setError('Failed to save wine');
-    } finally {
-      setFindingWine(false);
-    }
-  }, [apiFetch, scanResult, labelImage]);
+    await submitFindOrCreate(wineData);
+  }, [scanResult, labelImage, submitFindOrCreate]);
 
   const handleNotRightWine = useCallback(() => {
     const { extracted } = scanResult;
@@ -141,30 +161,11 @@ function AddToWishlist() {
       setError('Name, producer, and country are required');
       return;
     }
-    setError(null);
-    setFindingWine(true);
-    try {
-      const grapes = pendingWineData.grapes
-        ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
-        : [];
-      const res = await findOrCreateWine(apiFetch, {
-        ...pendingWineData,
-        grapes,
-        labelImage: labelImage || undefined
-      });
-      const data = await res.json();
-      if (!res.ok) { setError(data.error || 'Failed to save wine'); return; }
-      setSelectedWine(data.wine);
-      setScanResult(null);
-      setLabelImage(null);
-      setShowManualForm(false);
-      setPendingWineData(null);
-    } catch {
-      setError('Failed to save wine');
-    } finally {
-      setFindingWine(false);
-    }
-  }, [apiFetch, pendingWineData, labelImage]);
+    const grapes = pendingWineData.grapes
+      ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
+      : [];
+    await submitFindOrCreate({ ...pendingWineData, grapes, labelImage: labelImage || undefined });
+  }, [pendingWineData, labelImage, submitFindOrCreate]);
 
   const handleScanReset = useCallback(() => {
     setScanResult(null);
@@ -615,6 +616,17 @@ function AddToWishlist() {
             </div>
           </form>
         </div>
+      )}
+
+      {softCandidates && (
+        <SimilarWinesModal
+          candidates={softCandidates}
+          queryName={softPending?.wineData?.name}
+          busy={findingWine}
+          onPick={(wine) => applyResolvedWine(wine)}
+          onCreateNew={() => softPending && submitFindOrCreate(softPending.wineData, { confirmCreate: true })}
+          onCancel={() => { setSoftCandidates(null); setSoftPending(null); }}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -8,6 +8,7 @@ import {
   adminAssignImageToWine,
 } from '../api/admin';
 import Modal from '../components/Modal';
+import WineDuplicatesModal from '../components/WineDuplicatesModal';
 import { WINE_TYPES } from '../config/wineTypes';
 import GrapePicker from '../components/GrapePicker';
 import ImageUpload from '../components/ImageUpload';
@@ -59,6 +60,9 @@ function AdminWines() {
   const [mergeTarget, setMergeTarget] = useState(null);
   const [merging, setMerging] = useState(false);
   const [mergeError, setMergeError] = useState(null);
+
+  // Registry-wide duplicate scanner
+  const [showDuplicatesScanner, setShowDuplicatesScanner] = useState(false);
 
   // Taxonomy
   const [countries, setCountries] = useState([]);
@@ -323,9 +327,14 @@ function AdminWines() {
           <h1>{t('admin.wines.title')}</h1>
           {!loading && <p className="page-subtitle">{total.toLocaleString()} {t('admin.wines.wineDefinitions')}</p>}
         </div>
-        <button className="btn btn-primary" onClick={openCreate}>
-          {t('admin.wines.newWine')}
-        </button>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btn btn-secondary" onClick={() => setShowDuplicatesScanner(true)} title="Scan the wine registry for likely duplicates">
+            Find duplicates
+          </button>
+          <button className="btn btn-primary" onClick={openCreate}>
+            {t('admin.wines.newWine')}
+          </button>
+        </div>
       </div>
 
       {/* Filter bar */}
@@ -748,6 +757,14 @@ function AdminWines() {
             </button>
           </div>
         </Modal>
+      )}
+
+      {showDuplicatesScanner && (
+        <WineDuplicatesModal
+          apiFetch={apiFetch}
+          onClose={() => setShowDuplicatesScanner(false)}
+          onMerged={fetchWines}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Adds a "Find duplicates" button on the Admin Wines page that scans the entire wine registry and surfaces clusters of likely-duplicate WineDefinitions, each with a one-click merge.

The existing `/duplicates` route is per-query (you give it a name + producer, it scores against the registry). There was no way to *discover* already-existing duplicates without paginating by eye — which is why Rosa Bella / Rosabella Rosato sat there unnoticed until a user reported it.

## How it works
**Backend** — new `GET /api/admin/wines/duplicate-clusters`:
1. Fetch every wine with a small projection.
2. Group by **normalised producer** (cheap O(N) pre-filter — real duplicates almost always share a producer; people typo the *wine name*, not the producer).
3. Within each producer group, run pairwise `scoreWineMatch` (the same scorer the soft-zone prompt uses).
4. Pairs with score ≥ `minScore` (default 0.6) form edges; connected components form clusters.
5. Return clusters with bottle counts so the admin knows which wine is the "main" one.

**Frontend** — `WineDuplicatesModal`:
- Each cluster card shows the wines side-by-side with thumbnail, name, appellation, country, bottle count.
- Default keeper is the wine with the most bottles (heuristic: typos accumulate fewer hits).
- Each non-keeper has a "Merge into KEEP" button → calls the existing merge endpoint → cluster live-updates (collapses to nothing when only one wine remains).
- Min-score slider (0.5–0.85) for widening or tightening.

## Base
**Stacked on #456** (soft-zone prompt) for `scoreAllMatches`. If #456 merges first this rebases cleanly; if this merges first the conflict on `wineMatching.js` is additive.

## What's NOT in this PR
- **Image merge** — the existing `/merge` endpoint reassigns bottles + deletes the source wine, but I haven't verified what it does with the source wine's `image` field or with any `BottleImage` records that pointed to the source. That's the next item the user asked for (you'll see I've left a todo on the merge endpoint for image consolidation).

## Test plan
- [x] `cd backend && npm test` — 606 passed
- [x] `cd frontend && npm test` — 292 passed
- [ ] Smoke: with the Rosa Bella / Rosabella Rosato duplicate live, open Admin Wines → click "Find duplicates" → cluster appears → pick keeper → merge → cluster disappears → main wine list updates
- [ ] Slide min-score down to 0.5 → more clusters appear; up to 0.85 → only tightest matches
- [ ] Re-scan after a merge succeeds → that cluster is gone from the new scan