### PR TITLE
chore(release): v1.55.8

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.55.7",
+  "version": "1.55.8",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.55.7",
+  "version": "1.55.8",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary
Release **v1.55.8** — wine deduplication: prevention, detection, repair.

## Included
- **#456 / Feature** — "Did you mean?" prompt during bottle add when a fuzzy match is in the soft zone (0.50–0.75 score). Stops silent duplicate creation at the source.
- **#457 / Feature** — Admin "Find duplicates" button on the Wines page. Registry-wide scan groups likely duplicates into clusters with one-click merge.
- **#458 / Fix** — Merge endpoint now consolidates the wine image (adopts source's image if target had none; clears stray `assignedToWine` flags otherwise). Fixes a long-standing gap where the merged wine could lose its image.

## Post-merge — what to test
1. Open Admin → Wines → click **"Find duplicates"** → should show the Rosa Bella / Rosabella Rosato cluster. Pick "Rosabella Rosato" as keeper, merge "Rosa Bella" → confirm target retains/adopts the image and old wine disappears.
2. Try adding a bottle with name "Rosa Bella" by G.D. Vajra → soft-zone modal opens showing the existing match.

## Test plan
- [ ] CI passes
- [ ] After merge: tag → GH Actions builds Docker images → user pulls + restarts