### PR TITLE
feat(admin): side-by-side compare-and-edit for duplicate clusters

### DIFF
--- a/frontend/src/components/SimilarWinesModal.js
+++ b/frontend/src/components/SimilarWinesModal.js
@@ -1,5 +1,6 @@
 import Modal from './Modal';
 import WineImage from './WineImage';
+import './WineModalThumbs.css';
 
 /**
  * Shown when the backend's find-or-create returns soft-zone candidates —

--- a/frontend/src/components/WineClusterCompareModal.js
+++ b/frontend/src/components/WineClusterCompareModal.js
@@ -6,6 +6,7 @@ import {
   adminGetWine, adminSaveWine, adminMergeWine, adminGetGrapes,
 } from '../api/admin';
 import { WINE_TYPES } from '../config/wineTypes';
+import './WineModalThumbs.css';
 
 /**
  * Side-by-side comparison of every wine in a duplicate cluster, with inline

--- a/frontend/src/components/WineClusterCompareModal.js
+++ b/frontend/src/components/WineClusterCompareModal.js
@@ -1,0 +1,303 @@
+import { useState, useEffect, useCallback } from 'react';
+import Modal from './Modal';
+import WineImage from './WineImage';
+import GrapePicker from './GrapePicker';
+import {
+  adminGetWine, adminSaveWine, adminMergeWine, adminGetGrapes,
+} from '../api/admin';
+import { WINE_TYPES } from '../config/wineTypes';
+
+/**
+ * Side-by-side comparison of every wine in a duplicate cluster, with inline
+ * editing of the simple fields (name, producer, type, appellation, grapes).
+ *
+ * Country/region aren't editable here — if those genuinely differ across the
+ * cluster, the wines probably shouldn't be merged at all. Image is shown
+ * read-only (it survives via the merge endpoint's image-consolidation logic).
+ *
+ * Workflow:
+ *   1. Tidy up data on whichever wines need it (Save per column).
+ *   2. Pick the keeper.
+ *   3. "Merge others into KEEP" — calls the merge endpoint for each non-keeper.
+ */
+function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
+  const [wines, setWines] = useState(null);
+  const [edits, setEdits] = useState({});      // { wineId: { name, producer, type, appellation, grapes: [id] } }
+  const [saving, setSaving] = useState({});    // { wineId: bool }
+  const [savedMsg, setSavedMsg] = useState({});// { wineId: 'Saved' | error string }
+  const [grapesList, setGrapesList] = useState([]);
+  const [keeperId, setKeeperId] = useState(null);
+  const [merging, setMerging] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // Hydrate each cluster wine to its full form (grapes populated, etc).
+        // The cluster summary from /duplicate-clusters only carries a thin
+        // projection — we need the rest for the editable form.
+        const [fullWines, grapesRes] = await Promise.all([
+          Promise.all(cluster.wines.map(w =>
+            adminGetWine(apiFetch, String(w._id))
+              .then(r => r.json())
+              .then(d => ({ ...(d.wine || d), bottleCount: w.bottleCount }))
+          )),
+          adminGetGrapes(apiFetch).then(r => r.json()),
+        ]);
+        if (cancelled) return;
+
+        setWines(fullWines);
+        setGrapesList(Array.isArray(grapesRes) ? grapesRes : (grapesRes.grapes || []));
+
+        const initEdits = {};
+        for (const w of fullWines) {
+          initEdits[String(w._id)] = {
+            name: w.name || '',
+            producer: w.producer || '',
+            appellation: w.appellation || '',
+            type: w.type || 'red',
+            grapes: (w.grapes || []).map(g => g._id || g),
+          };
+        }
+        setEdits(initEdits);
+
+        const sorted = [...fullWines].sort((a, b) => (b.bottleCount || 0) - (a.bottleCount || 0));
+        setKeeperId(String(sorted[0]._id));
+      } catch (err) {
+        if (!cancelled) setError('Failed to load wine details');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [cluster, apiFetch]);
+
+  const updateEdit = (wineId, patch) => {
+    setEdits(prev => ({ ...prev, [wineId]: { ...prev[wineId], ...patch } }));
+    setSavedMsg(prev => ({ ...prev, [wineId]: null }));
+  };
+
+  const isDirty = useCallback((wineId) => {
+    const wine = wines?.find(w => String(w._id) === wineId);
+    if (!wine || !edits[wineId]) return false;
+    const e = edits[wineId];
+    if ((wine.name || '') !== e.name) return true;
+    if ((wine.producer || '') !== e.producer) return true;
+    if ((wine.appellation || '') !== e.appellation) return true;
+    if ((wine.type || 'red') !== e.type) return true;
+    const orig = (wine.grapes || []).map(g => String(g._id || g)).sort().join(',');
+    const next = (e.grapes || []).map(String).sort().join(',');
+    return orig !== next;
+  }, [wines, edits]);
+
+  const saveOne = async (wineId) => {
+    setSaving(s => ({ ...s, [wineId]: true }));
+    setSavedMsg(prev => ({ ...prev, [wineId]: null }));
+    try {
+      const res = await adminSaveWine(apiFetch, edits[wineId], wineId);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setSavedMsg(prev => ({ ...prev, [wineId]: data.error || `Save failed (${res.status})` }));
+        return;
+      }
+      const updated = data.wine || data;
+      setWines(ws => ws.map(w => String(w._id) === wineId ? { ...updated, bottleCount: w.bottleCount } : w));
+      setSavedMsg(prev => ({ ...prev, [wineId]: 'Saved' }));
+    } catch {
+      setSavedMsg(prev => ({ ...prev, [wineId]: 'Network error' }));
+    } finally {
+      setSaving(s => ({ ...s, [wineId]: false }));
+    }
+  };
+
+  const mergeOthersIntoKeeper = async () => {
+    if (!keeperId) return;
+    setMerging(true);
+    setError(null);
+    try {
+      const sources = wines.filter(w => String(w._id) !== keeperId);
+      for (const source of sources) {
+        const res = await adminMergeWine(apiFetch, String(source._id), keeperId);
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          setError(`Merge of "${source.name}" failed: ${data.error || res.status}`);
+          setMerging(false);
+          return;
+        }
+      }
+      onMerged?.(cluster.wines.map(w => String(w._id)));
+      onClose();
+    } catch {
+      setError('Network error during merge');
+      setMerging(false);
+    }
+  };
+
+  if (error && !wines) {
+    return (
+      <Modal title="Compare cluster" onClose={onClose} showClose wide>
+        <div className="alert alert-error">{error}</div>
+      </Modal>
+    );
+  }
+
+  if (!wines) {
+    return (
+      <Modal title="Compare cluster" onClose={onClose} showClose wide>
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
+          Loading…
+        </div>
+      </Modal>
+    );
+  }
+
+  const someDirty = wines.some(w => isDirty(String(w._id)));
+
+  return (
+    <Modal title={`Compare ${wines.length} wines`} onClose={onClose} showClose wide>
+      <p style={{ margin: '0 0 1rem', fontSize: '0.9rem', color: 'var(--text-secondary, #666)' }}>
+        Edit any field where one entry has cleaner data, save that wine, then pick the keeper and merge.
+        Country/region aren't editable here — if they really differ these probably aren't duplicates.
+      </p>
+
+      {error && <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>}
+
+      <div style={{ display: 'flex', gap: 12, overflowX: 'auto', paddingBottom: 8 }}>
+        {wines.map(wine => {
+          const id = String(wine._id);
+          const e = edits[id] || {};
+          const isKeeper = id === keeperId;
+          const dirty = isDirty(id);
+          return (
+            <div
+              key={id}
+              style={{
+                minWidth: 280,
+                flex: '1 1 280px',
+                border: isKeeper ? '2px solid var(--accent, #4a7c4a)' : '1px solid var(--border, #e5e5e5)',
+                background: isKeeper ? 'var(--bg-success-faint, #f0f7f0)' : 'var(--bg-secondary, #fafafa)',
+                borderRadius: 6,
+                padding: 12,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 10,
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: '0.85rem', fontWeight: 600 }}>
+                  <input
+                    type="radio"
+                    name="cluster-keeper"
+                    checked={isKeeper}
+                    onChange={() => setKeeperId(id)}
+                    disabled={merging}
+                  />
+                  {isKeeper ? 'KEEP THIS' : 'Keep this'}
+                </label>
+                <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>
+                  {wine.bottleCount || 0} bottle{(wine.bottleCount || 0) === 1 ? '' : 's'}
+                </span>
+              </div>
+
+              <div style={{ display: 'flex', justifyContent: 'center', padding: '4px 0' }}>
+                <WineImage
+                  image={wine.image}
+                  alt={wine.name}
+                  wineType={wine.type}
+                  className="compare-wine-thumb"
+                  placeholder="compare-wine-placeholder"
+                />
+              </div>
+
+              <Field label="Name">
+                <input type="text" value={e.name} onChange={ev => updateEdit(id, { name: ev.target.value })} />
+              </Field>
+              <Field label="Producer">
+                <input type="text" value={e.producer} onChange={ev => updateEdit(id, { producer: ev.target.value })} />
+              </Field>
+              <Field label="Type">
+                <select value={e.type} onChange={ev => updateEdit(id, { type: ev.target.value })}>
+                  {WINE_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </Field>
+              <Field label="Appellation">
+                <input type="text" value={e.appellation} onChange={ev => updateEdit(id, { appellation: ev.target.value })} />
+              </Field>
+              <Field label="Country">
+                <ReadOnly value={wine.country?.name || '—'} />
+              </Field>
+              <Field label="Region">
+                <ReadOnly value={wine.region?.name || '—'} />
+              </Field>
+              <Field label={`Grapes${e.grapes.length ? ` (${e.grapes.length})` : ''}`}>
+                <GrapePicker
+                  grapes={grapesList}
+                  selected={e.grapes}
+                  onChange={(ids) => updateEdit(id, { grapes: ids })}
+                />
+              </Field>
+
+              <div style={{ marginTop: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  disabled={!dirty || saving[id] || merging}
+                  onClick={() => saveOne(id)}
+                  style={{ flex: 1 }}
+                >
+                  {saving[id] ? 'Saving…' : dirty ? 'Save changes' : 'No changes'}
+                </button>
+              </div>
+              {savedMsg[id] && (
+                <div style={{ fontSize: '0.75rem', color: savedMsg[id] === 'Saved' ? 'var(--accent, #4a7c4a)' : 'var(--danger, #c0392b)' }}>
+                  {savedMsg[id]}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+        <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+          {someDirty && '⚠ Save your edits before merging.'}
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button type="button" className="btn" disabled={merging} onClick={onClose}>Cancel</button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={!keeperId || merging || someDirty || wines.length < 2}
+            onClick={mergeOthersIntoKeeper}
+            title={someDirty ? 'Save edits first' : 'Merge all other wines into the keeper'}
+          >
+            {merging ? 'Merging…' : `Merge ${wines.length - 1} into KEEP`}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function Field({ label, children }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 2, fontSize: '0.75rem', color: 'var(--text-secondary, #666)' }}>
+      {label}
+      {children}
+    </label>
+  );
+}
+
+function ReadOnly({ value }) {
+  return (
+    <div style={{
+      fontSize: '0.85rem',
+      color: 'var(--text-primary, #222)',
+      padding: '4px 6px',
+      background: 'var(--bg, #fff)',
+      border: '1px dashed var(--border, #ddd)',
+      borderRadius: 3,
+    }}>{value}</div>
+  );
+}
+
+export default WineClusterCompareModal;

--- a/frontend/src/components/WineDuplicatesModal.js
+++ b/frontend/src/components/WineDuplicatesModal.js
@@ -3,6 +3,7 @@ import Modal from './Modal';
 import WineImage from './WineImage';
 import WineClusterCompareModal from './WineClusterCompareModal';
 import { adminGetWineDuplicateClusters, adminMergeWine } from '../api/admin';
+import './WineModalThumbs.css';
 
 /**
  * Registry-wide duplicate scanner for admin users. Shows clusters of

--- a/frontend/src/components/WineDuplicatesModal.js
+++ b/frontend/src/components/WineDuplicatesModal.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import Modal from './Modal';
 import WineImage from './WineImage';
+import WineClusterCompareModal from './WineClusterCompareModal';
 import { adminGetWineDuplicateClusters, adminMergeWine } from '../api/admin';
 
 /**
@@ -21,6 +22,7 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
   const [error, setError] = useState(null);
   const [minScore, setMinScore] = useState(0.6);
   const [meta, setMeta] = useState(null);
+  const [compareCluster, setCompareCluster] = useState(null);
 
   const scan = useCallback(async (score = minScore) => {
     setScanning(true);
@@ -54,6 +56,14 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
     setClusters(prev => prev
       .map(c => ({ ...c, wines: c.wines.filter(w => String(w._id) !== sourceId) }))
       .filter(c => c.wines.length >= 2));
+    onMerged?.();
+  };
+
+  // The compare modal merges N-1 wines into the keeper in one go and returns
+  // the full list of cluster wine ids — only the keeper survives.
+  const handleClusterMerged = (allClusterIds) => {
+    const idSet = new Set(allClusterIds.map(String));
+    setClusters(prev => prev.filter(c => !c.wines.some(w => idSet.has(String(w._id)))));
     onMerged?.();
   };
 
@@ -103,15 +113,25 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
               cluster={cluster}
               apiFetch={apiFetch}
               onMerged={handleMerged}
+              onOpenCompare={() => setCompareCluster(cluster)}
             />
           ))}
         </div>
+      )}
+
+      {compareCluster && (
+        <WineClusterCompareModal
+          cluster={compareCluster}
+          apiFetch={apiFetch}
+          onClose={() => setCompareCluster(null)}
+          onMerged={handleClusterMerged}
+        />
       )}
     </Modal>
   );
 }
 
-function ClusterCard({ cluster, apiFetch, onMerged }) {
+function ClusterCard({ cluster, apiFetch, onMerged, onOpenCompare }) {
   const [targetId, setTargetId] = useState(null);
   const [merging, setMerging] = useState(null); // sourceId being merged
   const [error, setError] = useState(null);
@@ -149,11 +169,22 @@ function ClusterCard({ cluster, apiFetch, onMerged }) {
       padding: 12,
       background: 'var(--bg-secondary, #fafafa)',
     }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8, gap: 8 }}>
         <strong>{cluster.wines[0]?.producer}</strong>
-        <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)' }}>
-          {Math.round(cluster.score * 100)}% match
-        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)' }}>
+            {Math.round(cluster.score * 100)}% match
+          </span>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={onOpenCompare}
+            style={{ padding: '0.25rem 0.65rem', fontSize: '0.8rem' }}
+            title="Open side-by-side comparison with all fields editable"
+          >
+            Compare &amp; edit
+          </button>
+        </div>
       </div>
 
       {error && <div className="alert alert-error" style={{ marginBottom: 8 }}>{error}</div>}

--- a/frontend/src/components/WineModalThumbs.css
+++ b/frontend/src/components/WineModalThumbs.css
@@ -1,0 +1,34 @@
+/* Image sizing for the dedup / soft-zone modals. The parent <div> sets the
+   box (e.g. 36x48 in the duplicates list, 48x64 in the soft-zone modal,
+   larger in the compare view). The <img> just fills its box without
+   distorting the aspect ratio. */
+
+.dup-wine-thumb,
+.similar-wine-thumb,
+.compare-wine-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* Compare view: bigger fixed area so the bottle is actually legible */
+.compare-wine-thumb {
+  max-width: 110px;
+  max-height: 140px;
+}
+
+/* Placeholder when a wine has no image — coloured tile sized to the slot */
+.compare-wine-placeholder {
+  width: 80px;
+  height: 110px;
+  border-radius: 4px;
+  background: var(--color-bg-elev, #eee);
+  opacity: 0.4;
+}
+.compare-wine-placeholder.red       { background: #722f37; }
+.compare-wine-placeholder.white     { background: #f0e6c3; }
+.compare-wine-placeholder.rose,
+.compare-wine-placeholder.rosé      { background: #f5b8b2; }
+.compare-wine-placeholder.sparkling { background: #d4d8e1; }
+.compare-wine-placeholder.dessert   { background: #c89c5a; }
+.compare-wine-placeholder.fortified { background: #5a3a2c; }


### PR DESCRIPTION
## Summary
Follow-up to [#457](https://github.com/jagduvi1/Cellarion/pull/457). The cluster summary in the scanner was too thin to make a merge decision — only name, appellation, bottle count. Real-world clusters need:

1. **Full data per wine** side-by-side so the admin can actually compare.
2. **Inline edit** so a wine can be tidied up (e.g. add missing grapes, fix appellation) before merging.

This PR adds a **"Compare & edit"** button on each cluster row that opens a new modal with the wines as columns. Editable per column: name, producer, type, appellation, grapes (full GrapePicker). Read-only: country, region, image (if those genuinely differ these aren't duplicates).

## Workflow
1. Admin opens "Find duplicates" → sees clusters.
2. Clicks "Compare & edit" on a cluster.
3. Tidies any wine that needs fixing → clicks "Save changes" per column.
4. Picks the keeper radio.
5. Clicks "Merge N into KEEP" — merges all non-keepers into the keeper in one go.

Merge button is disabled while any column has unsaved edits, so stale data can't be merged accidentally.

## Local stack already running
I rebuilt the frontend container so you can test at http://localhost right now without waiting for CI / Docker Hub.

## Test plan
- [x] `cd frontend && npm test` — 292 passed
- [ ] Open AdminWines → Find duplicates → pick a cluster → click "Compare & edit". All wines render with full data.
- [ ] Edit grapes on one wine → Save → confirm the value persists (re-open the compare modal, edit reflects).
- [ ] Merge N into KEEP → keeper survives, source wines deleted, bottles re-pointed, cluster disappears from scanner.
- [ ] Image-merge case still works (PR #458): keeper with no image absorbs source's image.