### PR TITLE
fix: three high-severity bugs from full code audit

### DIFF
--- a/backend/src/routes/admin/settings.js
+++ b/backend/src/routes/admin/settings.js
@@ -80,6 +80,10 @@ router.patch('/rate-limits', async (req, res) => {
     }
 
     const updated = {
+      // Spread previous first so groups not exposed by this handler
+      // (aiBurst, imageUploadBurst, and any future groups) survive the
+      // wholesale rateLimitsConfig.set() below instead of being dropped.
+      ...previous,
       api:   { max: api?.max   ?? previous.api.max   },
       write: { max: write?.max ?? previous.write.max },
       auth:  { max: auth?.max  ?? previous.auth.max  },

--- a/backend/src/routes/recommendations.js
+++ b/backend/src/routes/recommendations.js
@@ -19,7 +19,7 @@ router.get('/', async (req, res) => {
   try {
     const { limit, offset: skip } = parsePagination(req.query, { limit: 20, maxLimit: 50 });
 
-    const query = { recipient: new mongoose.Types.ObjectId(req.user.id) };
+    const query = { recipient: req.user.id };
 
     const [items, total] = await Promise.all([
       Recommendation.find(query)
@@ -44,7 +44,7 @@ router.get('/sent', async (req, res) => {
   try {
     const { limit, offset: skip } = parsePagination(req.query, { limit: 20, maxLimit: 50 });
 
-    const query = { sender: new mongoose.Types.ObjectId(req.user.id) };
+    const query = { sender: req.user.id };
 
     const [items, total] = await Promise.all([
       Recommendation.find(query)

--- a/backend/src/services/userDeletionJob.js
+++ b/backend/src/services/userDeletionJob.js
@@ -119,7 +119,7 @@ async function purgeUserData(userId, userEmail) {
     // Audit log — keep for compliance but anonymise actor
     AuditLog.updateMany(
       { 'actor.userId': userId },
-      { $set: { 'actor.userId': null, 'actor.ip': null } }
+      { $set: { 'actor.userId': null, 'actor.ipAddress': null } }
     ),
   ]);
 }


### PR DESCRIPTION
## Summary

Fixes the three **High**-severity findings surfaced by a full multi-agent code audit of the codebase. All three are deterministic, independently verified bugs (one runtime-reproduced).

## Fixes

### 1. Recommendations endpoints 500 for every user (`correctness`)
`GET /api/recommendations` and `GET /api/recommendations/sent` referenced `mongoose` without importing it → `ReferenceError` on every request, caught and returned as a generic 500. Both the received and sent recommendation lists were completely non-functional.
**Fix:** use `req.user.id` directly in the query (Mongoose casts the hex string), matching the POST/PUT/DELETE pattern already used in the same file. No new import needed.
`backend/src/routes/recommendations.js`

### 2. Admin "save rate-limits" drops `aiBurst` & `imageUploadBurst` (`correctness`/`security`)
`PATCH /api/admin/settings/rate-limits` rebuilt the config object from scratch with only six groups and called `rateLimitsConfig.set()` (a wholesale cache replace), silently dropping `aiBurst` and `imageUploadBurst`. Their limiter callbacks then dereferenced `undefined.max`, turning `/wines/scan-label`, `/identify-text`, `/ai-info` and `/images/upload` into 500s **and** removing their Anthropic-budget / disk-fill abuse protection until the next process restart.
**Fix:** spread the previous config first so any group the handler doesn't expose survives a partial save.
`backend/src/routes/admin/settings.js`

### 3. Account deletion fails to erase user IP from audit logs (`gdpr`)
The audit-log anonymisation step in the deletion job `$set` `actor.ip: null` — a field that does not exist. The IP is stored in `actor.ipAddress`, so a deleted user's IP survived "erasure" until the `AuditLog` TTL expired (up to 90 days), missing the right-to-erasure obligation at deletion time.
**Fix:** corrected the field name to `actor.ipAddress`.
`backend/src/services/userDeletionJob.js`

## Testing

- `node --check` clean on all three files
- **Full backend suite green: 606 tests / 27 suites, no regressions**
- Runtime-verified the rate-limits merge now preserves `aiBurst` + `imageUploadBurst` while still applying the `api` update
- Grep-confirmed zero remaining `mongoose` references in recommendations.js and that `actor.ipAddress` is the correct schema field

## Follow-ups (not in this PR)
DB-backed regression tests (the current harness intentionally avoids a live DB) and the Medium-tier audit findings (broken digest unsubscribe link, `PriceTrackingRequest` GDPR gap, `JWT_SECRET` strength check).