### PR TITLE
fix: audit quick-wins + resilient large-import AI handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,20 @@ if (missingEnv.length > 0) {
   process.exit(1);
 }
 
+// Reject weak / placeholder JWT secrets. Every access token is HS256-signed
+// with this single symmetric key, and the project is open-source — so a
+// deployment shipping a short or well-known default secret lets an attacker
+// forge tokens for any user/role. Presence alone is not enough.
+const JWT_PLACEHOLDERS = new Set([
+  'change-me-to-a-strong-random-string',
+  'dev-secret-change-me-in-production',
+  'changeme', 'change-me', 'secret', 'your-secret-key', 'your_jwt_secret',
+]);
+if (process.env.JWT_SECRET.length < 32 || JWT_PLACEHOLDERS.has(process.env.JWT_SECRET.trim().toLowerCase())) {
+  console.error('FATAL: JWT_SECRET is too weak. Use a random string of at least 32 characters, e.g. `openssl rand -hex 32`.');
+  process.exit(1);
+}
+
 if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
   console.warn('Warning: MAILGUN_API_KEY / MAILGUN_DOMAIN not set — email verification disabled.');
 }

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -91,7 +91,10 @@ app.use('/api/admin/wine-requests', express.json({ limit: '5mb' }));
 app.use('/api/wines/scan-label', express.json({ limit: '300kb' }));
 app.use('/api/wines/find-or-create', express.json({ limit: '5mb' }));
 app.use('/api/bottles/import/sessions', express.json({ limit: '5mb' }));
-app.use('/api/bottles/import', express.json({ limit: '2mb' }));
+// /confirm posts the whole selected batch in one request (rack placement is
+// coordinated batch-wide), so the limit must hold a large import — up to
+// MAX_IMPORT_SIZE (2000) items with notes. 8mb leaves comfortable headroom.
+app.use('/api/bottles/import', express.json({ limit: '8mb' }));
 app.use('/api/blog/admin/posts', express.json({ limit: '2mb' }));
 app.use('/api/wine-lists', express.json({ limit: '1mb' }));
 app.use(express.json({ limit: '10kb' }));

--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -24,10 +24,16 @@ const IMPORT_EXACT_THRESHOLD = 0.95;
 // Minimum composite similarity score for a candidate to be considered a fuzzy match
 const IMPORT_FUZZY_THRESHOLD = 0.65;
 
-// Maximum number of items allowed in a single import batch
-const MAX_IMPORT_SIZE = 500;
+// Maximum number of items allowed in a single import. Validation is chunked
+// client-side (VALIDATE_BATCH_SIZE), so this primarily caps the one-shot
+// /confirm request, whose batch-wide rack-placement coordination needs the
+// full set in a single call. Sized for large real-world cellars (1000+).
+const MAX_IMPORT_SIZE = 2000;
 
-// Maximum concurrent AI identification requests during import (stay under rate limits)
+// Maximum concurrent AI identification requests during import. Combined with
+// the SDK's retry/backoff (see labelScan getClient), this keeps us under
+// Anthropic's rate limits while letting throttled calls wait and continue
+// rather than aborting the import.
 const AI_CONCURRENCY = 5;
 
 // ─── Prompt length limits ────────────────────────────────────────────────────

--- a/backend/src/middleware/aiBurstLimiter.js
+++ b/backend/src/middleware/aiBurstLimiter.js
@@ -1,0 +1,28 @@
+const rateLimit = require('express-rate-limit');
+const rateLimitsConfig = require('../config/rateLimits');
+const { logAudit } = require('../services/audit');
+
+/**
+ * Per-user burst limiter for all Anthropic-backed endpoints — the wine AI
+ * routes (/wines/scan-label, /identify-text, /ai-info) and bottle import
+ * (/bottles/import/validate, which fans out one identify call per wine).
+ *
+ * Keyed on req.user.id (not IP) so a scripted attacker rotating IPs can't
+ * bypass it. The per-IP apiLimiter still runs alongside. All consumers share
+ * ONE bucket because they share one Anthropic budget. `max` is read live from
+ * the admin-tunable rate-limit config; requireAuth must run before this so
+ * req.user is populated.
+ */
+const aiBurstLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: () => rateLimitsConfig.get().aiBurst.max,
+  keyGenerator: (req) => String(req.user?.id || ''),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'ai-burst', userId: req.user?.id });
+    res.status(429).json({ error: 'Too many AI requests in a short time. Please wait a minute and try again.' });
+  },
+});
+
+module.exports = aiBurstLimiter;

--- a/backend/src/routes/support.js
+++ b/backend/src/routes/support.js
@@ -9,37 +9,42 @@ const VALID_CATEGORIES = ['bug', 'help', 'feature', 'other'];
 
 // POST /api/support — submit a support ticket
 router.post('/', requireAuth, async (req, res) => {
-  const { category, subject, message } = req.body;
+  try {
+    const { category, subject, message } = req.body;
 
-  if (!VALID_CATEGORIES.includes(category)) {
-    return res.status(400).json({ error: 'Invalid category' });
-  }
-  if (!subject || !subject.trim()) {
-    return res.status(400).json({ error: 'Subject is required' });
-  }
-  if (!message || !message.trim()) {
-    return res.status(400).json({ error: 'Message is required' });
-  }
-  if (subject.trim().length > 200) {
-    return res.status(400).json({ error: 'Subject must be 200 characters or fewer' });
-  }
-  if (message.trim().length > 5000) {
-    return res.status(400).json({ error: 'Message must be 5000 characters or fewer' });
-  }
+    if (!VALID_CATEGORIES.includes(category)) {
+      return res.status(400).json({ error: 'Invalid category' });
+    }
+    if (!subject || !subject.trim()) {
+      return res.status(400).json({ error: 'Subject is required' });
+    }
+    if (!message || !message.trim()) {
+      return res.status(400).json({ error: 'Message is required' });
+    }
+    if (subject.trim().length > 200) {
+      return res.status(400).json({ error: 'Subject must be 200 characters or fewer' });
+    }
+    if (message.trim().length > 5000) {
+      return res.status(400).json({ error: 'Message must be 5000 characters or fewer' });
+    }
 
-  const ticket = await SupportTicket.create({
-    user: req.user.id,
-    category,
-    subject: stripHtml(subject),
-    message: stripHtml(message)
-  });
+    const ticket = await SupportTicket.create({
+      user: req.user.id,
+      category,
+      subject: stripHtml(subject),
+      message: stripHtml(message)
+    });
 
-  logAudit(req, 'support.ticket.created', { type: 'SupportTicket', id: ticket._id }, {
-    category,
-    subject: subject.trim()
-  });
+    logAudit(req, 'support.ticket.created', { type: 'SupportTicket', id: ticket._id }, {
+      category,
+      subject: subject.trim()
+    });
 
-  res.status(201).json({ ticket });
+    res.status(201).json({ ticket });
+  } catch (err) {
+    console.error('Create support ticket error:', err);
+    res.status(500).json({ error: 'Failed to submit support ticket' });
+  }
 });
 
 // GET /api/support/my — list the authenticated user's own tickets

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -29,6 +29,8 @@ const ImportSession = require('../models/ImportSession');
 const SupportTicket = require('../models/SupportTicket');
 const WineReport = require('../models/WineReport');
 const WishlistItem = require('../models/WishlistItem');
+const PriceTrackingRequest = require('../models/PriceTrackingRequest');
+const PriceTrackingSkip = require('../models/PriceTrackingSkip');
 const { requireAuth, requireRole } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const { stripHtml, escapeRegex } = require('../utils/sanitize');
@@ -386,7 +388,8 @@ router.get('/me/export', requireAuth, async (req, res) => {
       restockAlerts, wineLists, pendingSharesSent,
       discussions, discussionReplies, reviewVotes, discussionReactions, discussionWatches,
       discussionReads, follows, chatUsage, importSessions, supportTickets,
-      discussionReports, wineReports, wishlistItems
+      discussionReports, wineReports, wishlistItems,
+      priceTrackingRequests, priceTrackingSkips
     ] = await Promise.all([
       Bottle.find({ user: userId }).limit(EXPORT_MAX).lean(),
       Cellar.find({ $or: [{ user: userId }, { 'members.user': userId }], deletedAt: null }).limit(EXPORT_MAX).lean(),
@@ -412,10 +415,12 @@ router.get('/me/export', requireAuth, async (req, res) => {
         .populate('follower', 'username').populate('following', 'username').lean(),
       ChatUsage.find({ userId: userId }).select('date promptTokens completionTokens').limit(EXPORT_MAX).lean(),
       ImportSession.find({ user: userId }).select('cellar status results positionAnchor rackConfigs defaultCurrency createdAt').limit(EXPORT_MAX).lean(),
-      SupportTicket.find({ user: userId }).select('category subject status createdAt').limit(EXPORT_MAX).lean(),
+      SupportTicket.find({ user: userId }).select('category subject message status adminResponse respondedAt createdAt').limit(EXPORT_MAX).lean(),
       DiscussionReport.find({ user: userId }).select('discussion reply reason createdAt').limit(EXPORT_MAX).lean(),
       WineReport.find({ user: userId }).select('wineDefinition reason status createdAt').limit(EXPORT_MAX).lean(),
-      WishlistItem.find({ user: userId }).limit(EXPORT_MAX).lean()
+      WishlistItem.find({ user: userId }).limit(EXPORT_MAX).lean(),
+      PriceTrackingRequest.find({ 'requesters.user': userId }).select('wineDefinition vintage requesters createdAt').limit(EXPORT_MAX).lean(),
+      PriceTrackingSkip.find({ skippedBy: userId }).select('wineDefinition vintage reason skippedAt').limit(EXPORT_MAX).lean()
     ]);
 
     // Note which collections hit the cap so the user (and ops) know it happened.
@@ -429,7 +434,7 @@ router.get('/me/export', requireAuth, async (req, res) => {
       restockAlerts, wineLists, pendingSharesSent, discussions, discussionReplies,
       reviewVotes, discussionReactions, discussionWatches, discussionReads,
       follows, chatUsage, importSessions, supportTickets, discussionReports,
-      wineReports, wishlistItems,
+      wineReports, wishlistItems, priceTrackingRequests, priceTrackingSkips,
     })) {
       if (arr.length >= EXPORT_MAX) truncated[name] = EXPORT_MAX;
     }
@@ -570,9 +575,31 @@ router.get('/me/export', requireAuth, async (req, res) => {
       supportTickets: supportTickets.map(t => ({
         category: t.category,
         subject: t.subject,
+        message: t.message,
         status: t.status,
+        adminResponse: t.adminResponse,
+        respondedAt: t.respondedAt,
         createdAt: t.createdAt
       })),
+      priceTracking: {
+        // Only this user's requester entry is included — the shared doc may
+        // hold other users' notes, which are not this user's personal data.
+        requests: priceTrackingRequests.map(pt => {
+          const mine = (pt.requesters || []).find(r => (r.user?.toString?.() || r.user) === userId);
+          return {
+            wineDefinition: pt.wineDefinition,
+            vintage: pt.vintage,
+            note: mine?.note,
+            requestedAt: mine?.requestedAt
+          };
+        }),
+        skips: priceTrackingSkips.map(s => ({
+          wineDefinition: s.wineDefinition,
+          vintage: s.vintage,
+          reason: s.reason,
+          skippedAt: s.skippedAt
+        }))
+      },
       reports: {
         discussions: discussionReports.map(r => ({ reason: r.reason, createdAt: r.createdAt })),
         wines: wineReports.map(r => ({ reason: r.reason, status: r.status, createdAt: r.createdAt }))

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const mongoose = require('mongoose');
-const rateLimit = require('express-rate-limit');
 const WineDefinition = require('../models/WineDefinition');
 const Discussion = require('../models/Discussion');
 const searchService = require('../services/search');
@@ -11,28 +10,11 @@ const { generateWineKey, combinedSimilarity } = require('../utils/normalize');
 const { parsePagination } = require('../utils/pagination');
 const { isValidId } = require('../utils/validation');
 const { submitUrls } = require('../services/indexNow');
-const rateLimitsConfig = require('../config/rateLimits');
-const { logAudit } = require('../services/audit');
+const aiBurstLimiter = require('../middleware/aiBurstLimiter');
 
 const REMBG_URL = process.env.REMBG_URL || 'http://rembg:5000';
 
 const router = express.Router();
-
-// Per-user burst limiter on Anthropic-backed wine endpoints. Keyed on
-// req.user.id (not IP) so a scripted attacker rotating IPs can't bypass.
-// Per-IP apiLimiter still runs alongside. /scan-label, /identify-text,
-// /ai-info share one bucket because they share one Anthropic budget.
-const aiBurstLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: () => rateLimitsConfig.get().aiBurst.max,
-  keyGenerator: (req) => String(req.user?.id || ''),
-  standardHeaders: true,
-  legacyHeaders: false,
-  handler: (req, res) => {
-    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'ai-burst', userId: req.user?.id });
-    res.status(429).json({ error: 'Too many AI requests in a short time. Please wait a minute and try again.' });
-  },
-});
 
 const USER_SEARCH_LIMIT = 10;
 

--- a/backend/src/services/drinkWindowNotifier.js
+++ b/backend/src/services/drinkWindowNotifier.js
@@ -169,7 +169,8 @@ async function processUser(user, isFirstRun) {
       await sendDrinkWindowDigest(
         user.email,
         user.displayName || user.username,
-        uniqueAlerts
+        uniqueAlerts,
+        user._id
       );
     } catch (err) {
       console.error(`[drinkWindowNotifier] Email failed for ${user._id}:`, err.message);

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -11,7 +11,13 @@ function getClient() {
   }
   const sdk = require('@anthropic-ai/sdk');
   const Anthropic = sdk.default ?? sdk;
-  return new Anthropic({ apiKey });
+  // maxRetries lets the SDK transparently wait out 429 / 529 (overloaded) /
+  // 5xx with exponential backoff that honors the `retry-after` header, instead
+  // of failing the call. This is what keeps a large bottle import (1000+) going
+  // when Anthropic briefly rate-limits us — each AI call waits and continues
+  // rather than aborting. The per-call wait stays bounded so a single import
+  // chunk request can't hang indefinitely.
+  return new Anthropic({ apiKey, maxRetries: 4 });
 }
 
 /**

--- a/backend/src/services/mailgun.js
+++ b/backend/src/services/mailgun.js
@@ -127,6 +127,10 @@ async function sendPasswordResetEmail(toEmail, username, token) {
  */
 async function sendDrinkWindowDigest(toEmail, username, bottles, userId) {
   if (!EMAIL_VERIFICATION_ENABLED || !bottles.length) return;
+  // userId is required to build a working one-click unsubscribe link (GDPR
+  // right to object). Fail loudly rather than ship an email whose unsubscribe
+  // token resolves to "undefined" and is rejected by the unsubscribe route.
+  if (!userId) throw new Error('sendDrinkWindowDigest: userId is required for the unsubscribe link');
 
   const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
   const { createUnsubscribeToken } = require('../utils/unsubscribe');

--- a/backend/src/services/userDeletionJob.js
+++ b/backend/src/services/userDeletionJob.js
@@ -23,6 +23,7 @@ const JournalEntry = require('../models/JournalEntry');
 const Notification = require('../models/Notification');
 const PendingShare = require('../models/PendingShare');
 const PriceTrackingSkip = require('../models/PriceTrackingSkip');
+const PriceTrackingRequest = require('../models/PriceTrackingRequest');
 const PushSubscription = require('../models/PushSubscription');
 const Rack = require('../models/Rack');
 const Recommendation = require('../models/Recommendation');
@@ -100,6 +101,15 @@ async function purgeUserData(userId, userEmail) {
     CellarValueSnapshot.deleteMany({ user: userId }),
     PriceTrackingSkip.deleteMany({ skippedBy: userId }),
 
+    // Price-tracking opt-in requests are a shared per-(wine,vintage) singleton;
+    // pull just this user's requester entry (with their free-text note) out of
+    // the shared doc rather than deleting the whole record. Empty docs left
+    // behind are cleaned up after this batch (see below).
+    PriceTrackingRequest.updateMany(
+      { 'requesters.user': userId },
+      { $pull: { requesters: { user: userId } } }
+    ),
+
     // Invites (sent and received by email)
     PendingShare.deleteMany({ $or: [{ invitedBy: userId }, { email: userEmail }] }),
 
@@ -122,6 +132,10 @@ async function purgeUserData(userId, userEmail) {
       { $set: { 'actor.userId': null, 'actor.ip': null } }
     ),
   ]);
+
+  // A PriceTrackingRequest with no requesters left is an orphan (a valid one
+  // always has ≥1). Sequenced after the $pull above so it sees the result.
+  await PriceTrackingRequest.deleteMany({ requesters: { $size: 0 } });
 }
 
 async function runUserDeletionJob() {

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -361,19 +361,42 @@ function ImportBottles() {
     const allResults = [];
     let combinedSummary = null;
 
+    // Validate one chunk, riding out transient failures and rate limits
+    // (HTTP 429 / 5xx) with capped exponential backoff rather than aborting the
+    // whole import. Honors a Retry-After header when present. Resolves with the
+    // parsed JSON on success and only throws after retries are exhausted or on a
+    // non-retryable error — so a 1000+ bottle import waits through brief AI rate
+    // limits and continues instead of failing mid-way.
+    const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+    const validateBatch = async (batch) => {
+      const MAX_RETRIES = 5;
+      for (let attempt = 0; ; attempt++) {
+        let res;
+        try {
+          res = await validateImport(apiFetch, { cellarId, items: batch });
+        } catch (netErr) {
+          if (attempt >= MAX_RETRIES) throw netErr;
+          await sleep(Math.min(1000 * 2 ** attempt, 15000));
+          continue;
+        }
+        if (res.ok) return res.json();
+        if ((res.status === 429 || res.status >= 500) && attempt < MAX_RETRIES) {
+          const retryAfter = parseInt(res.headers.get('retry-after') || '', 10);
+          const waitMs = Number.isNaN(retryAfter) ? Math.min(1000 * 2 ** attempt, 15000) : retryAfter * 1000;
+          await sleep(waitMs);
+          continue;
+        }
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Validation failed (HTTP ${res.status})`);
+      }
+    };
+
     try {
       for (let offset = 0; offset < total; offset += VALIDATE_BATCH_SIZE) {
         // Re-index each batch so indices match their position in parsedItems
         const batch = parsedItems.slice(offset, offset + VALIDATE_BATCH_SIZE);
 
-        const res = await validateImport(apiFetch, { cellarId, items: batch });
-        const data = await res.json();
-
-        if (!res.ok) {
-          setError(data.error || 'Validation failed');
-          setValidating(false);
-          return;
-        }
+        const data = await validateBatch(batch);
 
         // Shift batch-local indices back to global indices
         const shifted = data.results.map(r => ({ ...r, index: r.index + offset }));
@@ -404,7 +427,7 @@ function ImportBottles() {
       setSelections(autoSelections);
       setStep('review');
     } catch (err) {
-      setError('Network error during validation');
+      setError(err.message || 'Network error during validation');
     } finally {
       setValidating(false);
     }


### PR DESCRIPTION
## Summary

Batch 1 of the code-audit follow-ups, plus a redesign of the import AI handling so the importer scales to **1000+ bottles** and rides out Anthropic rate limits instead of aborting.

## Security / correctness
- **JWT_SECRET strength check at startup** ([server.js](backend/server.js)) — reject `<32` chars or a known placeholder, not just absence. A forgeable default secret lets anyone mint admin tokens.
- **support.js try/catch** ([support.js](backend/src/routes/support.js)) — a DB error now returns 500 instead of an unhandled promise rejection that hangs the request.

## GDPR
- **Digest unsubscribe link** ([drinkWindowNotifier.js](backend/src/services/drinkWindowNotifier.js), [mailgun.js](backend/src/services/mailgun.js)) — pass `user._id` so the one-click opt-out works (right to object); `sendDrinkWindowDigest` now throws if `userId` is missing so the regression can't return silently.
- **Account deletion** ([userDeletionJob.js](backend/src/services/userDeletionJob.js)) — `$pull` the user's entry (incl. free-text note) from the shared `PriceTrackingRequest.requesters`, then drop orphaned empty docs.
- **Data export** ([users.js](backend/src/routes/users.js)) — add `PriceTrackingRequest` (this user's requester entry only — no other users' data), `PriceTrackingSkip`, and `SupportTicket` message/adminResponse/respondedAt.

## Large imports (1000+) + AI rate limits
The original Fix 5 (a per-request AI burst limiter on `/validate`) was **wrong**: validation is chunked client-side (25/batch), so a per-request 429 would abort a large import. Redesigned:
- **No aborting limiter on import** — extracted the shared `aiBurstLimiter` to [middleware/](backend/src/middleware/aiBurstLimiter.js) and kept it only on the single-shot wines AI routes, where per-request limiting is correct.
- **Wait-and-continue on rate limits** — [labelScan `getClient`](backend/src/services/labelScan.js) sets Anthropic SDK `maxRetries`, so 429/overloaded/5xx are waited out with exponential backoff (honoring `retry-after`) instead of dropping a wine to no-match.
- **Resilient chunk loop** ([ImportBottles.js](frontend/src/pages/ImportBottles.js)) — each validation chunk retries with capped exponential backoff (honoring `Retry-After`) on 429/5xx/network rather than aborting the whole import.
- **Size headroom** — `MAX_IMPORT_SIZE` 500 → 2000 and the `/api/bottles/import` body limit 2mb → 8mb so a 1000–2000 bottle one-shot `/confirm` (rack placement is coordinated batch-wide, so it can't be chunked) is accepted.

## Testing
- Full backend suite green: **606 tests / 27 suites**.
- `node --check` on every changed backend file; `esbuild` bundle of `ImportBottles.js` parses clean.
- Adversarial 3-lens review of the diff (correctness / GDPR-security / API-contract) — the one finding (limiter didn't bound the import fan-out) is exactly what this redesign addresses.

## Note
Per-user AI **cost** on import is now bounded by the global write limiter + unique-wine dedup + `AI_CONCURRENCY`, not a hard per-user AI quota. A true per-user AI budget that *throttles rather than aborts* would need a job queue — flagged as a future item.