### PR TITLE
fix(audit): Batch 3 — resource limits, Stripe idempotency, refresh-token lifetime

### DIFF
--- a/backend/src/models/StripeWebhookEvent.js
+++ b/backend/src/models/StripeWebhookEvent.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+
+/**
+ * Idempotency ledger for processed Stripe webhook events.
+ *
+ * Stripe delivers events at-least-once and will redeliver on timeout, so the
+ * same `event.id` can arrive more than once. We record each id with a unique
+ * index and treat a duplicate insert as "already handled" — short-circuiting
+ * before the handler runs again. This prevents a redelivered stale event
+ * (e.g. a late `customer.subscription.deleted` after a re-subscribe) from
+ * re-applying a plan change, and stops `checkout.session.completed` from
+ * resetting planStartedAt on every replay.
+ *
+ * A TTL index expires rows after 30 days — long past Stripe's retry window —
+ * so the collection stays small.
+ */
+const stripeWebhookEventSchema = new mongoose.Schema({
+  eventId: {
+    type: String,
+    required: true,
+    unique: true
+  },
+  type: {
+    type: String
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+    expires: 60 * 60 * 24 * 30 // 30-day TTL
+  }
+});
+
+module.exports = mongoose.model('StripeWebhookEvent', stripeWebhookEventSchema);

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -131,6 +131,14 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: null
   },
+  // Absolute session deadline: a refresh token can be rotated only until this
+  // time, after which re-login is forced regardless of activity. Set at session
+  // start (login/register) and preserved across rotations. null = no cap yet
+  // (legacy sessions; backfilled on next refresh).
+  refreshTokenExpiresAt: {
+    type: Date,
+    default: null
+  },
   // Per-account brute-force lockout state. Incremented on each failed login,
   // reset on success or successful password reset. Surfaced via the lockout
   // checks in utils/loginAttempts.js — the login handler treats a locked
@@ -366,6 +374,7 @@ userSchema.methods.toJSON = function() {
   const obj = this.toObject();
   delete obj.password;
   delete obj.refreshTokenHash;
+  delete obj.refreshTokenExpiresAt;
   delete obj.emailVerificationTokenHash;
   delete obj.emailVerificationExpiresAt;
   delete obj.passwordResetTokenHash;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -122,11 +122,21 @@ const buildCookieOptions = (rememberMe) => {
   return refreshCookieOptions;
 };
 
-// Issue both tokens: access token in body, refresh token in httpOnly cookie
-const issueTokens = async (user, res, { rememberMe } = {}) => {
+// Absolute refresh-token lifetime: a session may be rotated for at most this
+// long before re-login is forced, regardless of refresh activity. Bounds how
+// long a stolen-but-rotated refresh token stays usable.
+const REFRESH_ABSOLUTE_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+// Issue both tokens: access token in body, refresh token in httpOnly cookie.
+// preserveLifetime=true (rotation via /refresh) keeps the existing absolute
+// deadline; otherwise (login/register/re-auth) a fresh 30-day deadline is set.
+const issueTokens = async (user, res, { rememberMe, preserveLifetime = false } = {}) => {
   const accessToken = generateAccessToken(user);
   const refreshToken = generateRefreshToken();
   user.setRefreshToken(refreshToken);
+  if (!preserveLifetime) {
+    user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_ABSOLUTE_LIFETIME_MS);
+  }
   await user.save();
   res.cookie('refreshToken', refreshToken, buildCookieOptions(rememberMe));
   return accessToken;
@@ -421,8 +431,20 @@ router.post('/refresh', refreshLimiter, async (req, res) => {
       return res.status(401).json({ error: 'Invalid or expired refresh token' });
     }
 
-    // Rotate: issue new pair (invalidates the old refresh token hash)
-    const accessToken = await issueTokens(user, res);
+    // Enforce the absolute session deadline. Rotation must NOT extend it, so an
+    // attacker who keeps rotating a stolen token is still cut off after the cap.
+    if (user.refreshTokenExpiresAt && Date.now() > user.refreshTokenExpiresAt.getTime()) {
+      user.refreshTokenHash = null;
+      user.refreshTokenExpiresAt = null;
+      await user.save();
+      res.clearCookie('refreshToken', refreshCookieOptions);
+      return res.status(401).json({ error: 'Session expired, please log in again' });
+    }
+
+    // Rotate: issue new pair (invalidates the old refresh token hash). Preserve
+    // the existing deadline when set; backfill legacy sessions (null) so every
+    // session eventually gets an absolute cap.
+    const accessToken = await issueTokens(user, res, { preserveLifetime: !!user.refreshTokenExpiresAt });
 
     res.json({ token: accessToken });
   } catch (error) {

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -316,9 +316,13 @@ router.get('/:id/history', async (req, res) => {
     }
 
     if (!usedMeili) {
+      // Cap the fallback fetch at the same ceiling as the Meili path (10k) so a
+      // cellar with a huge consumed history can't load the entire collection
+      // into memory on every request.
       bottles = await Bottle.find(filter)
         .populate(WINE_POPULATE)
         .sort({ consumedAt: -1 })
+        .limit(10000)
         .lean();
 
       // In-memory text search fallback
@@ -1046,6 +1050,10 @@ router.get('/:id/export', async (req, res) => {
     const cellar = await Cellar.findOne({ _id: req.params.id, user: req.user.id, deletedAt: null });
     if (!cellar) return res.status(403).json({ error: 'Not authorized — only the cellar owner can export' });
 
+    // Bound worst-case memory: a single response can't materialise more than
+    // CELLAR_EXPORT_MAX bottles. Far above any real cellar; a hit is flagged in
+    // the payload (_truncated) so an outlier knows to contact support.
+    const CELLAR_EXPORT_MAX = 50000;
     const [bottles, racks] = await Promise.all([
       Bottle.find({ cellar: req.params.id })
         .populate({
@@ -1056,6 +1064,7 @@ router.get('/:id/export', async (req, res) => {
           ],
           select: 'name producer type appellation country region'
         })
+        .limit(CELLAR_EXPORT_MAX)
         .lean(),
       Rack.find({ cellar: req.params.id, deletedAt: null }).lean()
     ]);
@@ -1134,7 +1143,12 @@ router.get('/:id/export', async (req, res) => {
 
     logAudit(req, 'cellar.export', { type: 'cellar', id: cellar._id }, { bottleCount: items.length });
 
-    res.json({ cellarName: cellar.name, exportedAt: new Date().toISOString(), bottles: items });
+    const payload = { cellarName: cellar.name, exportedAt: new Date().toISOString(), bottles: items };
+    if (items.length >= CELLAR_EXPORT_MAX) {
+      payload._truncated = CELLAR_EXPORT_MAX;
+      console.warn(`[cellars.export] truncation hit for cellar ${req.params.id} (${CELLAR_EXPORT_MAX})`);
+    }
+    res.json(payload);
   } catch (error) {
     console.error('Export cellar error:', error);
     res.status(500).json({ error: 'Export failed' });

--- a/backend/src/routes/journal.js
+++ b/backend/src/routes/journal.js
@@ -65,28 +65,34 @@ router.get('/wine-search', async (req, res) => {
 
     const regex = new RegExp(escapeRegex(q), 'i');
 
-    // Search user's bottles (via wine definition name)
-    const bottles = await Bottle.find({ user: req.user.id, status: 'active' })
-      .populate({ path: 'wineDefinition', match: { $or: [{ name: regex }, { producer: regex }] }, select: 'name producer type' })
-      .select('vintage wineDefinition')
+    // Resolve matching wine definitions first, then fetch only the user's
+    // bottles for those wines (capped). Avoids the previous pattern of loading
+    // the user's ENTIRE active-bottle collection into memory on every keystroke
+    // just to filter it down to 10.
+    const matchedWines = await WineDefinition.find({ $or: [{ name: regex }, { producer: regex }] })
+      .select('name producer type')
+      .limit(200)
       .lean();
+    const matchedWineIds = matchedWines.map(w => w._id);
+
+    const bottles = matchedWineIds.length
+      ? await Bottle.find({ user: req.user.id, status: 'active', wineDefinition: { $in: matchedWineIds } })
+          .populate({ path: 'wineDefinition', select: 'name producer type' })
+          .select('vintage wineDefinition')
+          .limit(10)
+          .lean()
+      : [];
 
     const matchedBottles = bottles
       .filter(b => b.wineDefinition)
-      .slice(0, 10)
       .map(b => ({
         _id: b._id,
         vintage: b.vintage,
         wine: b.wineDefinition
       }));
 
-    // Search wine register
-    const wines = await WineDefinition.find({
-      $or: [{ name: regex }, { producer: regex }]
-    })
-      .select('name producer type')
-      .limit(10)
-      .lean();
+    // Wine register results (already capped)
+    const wines = matchedWines.slice(0, 10);
 
     res.json({ bottles: matchedBottles, wines });
   } catch (err) {

--- a/backend/src/routes/stripe.js
+++ b/backend/src/routes/stripe.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { requireAuth } = require('../middleware/auth');
 const User = require('../models/User');
+const StripeWebhookEvent = require('../models/StripeWebhookEvent');
 const { logAudit } = require('../services/audit');
 
 const router = express.Router();
@@ -118,6 +119,20 @@ router.post('/webhook', async (req, res) => {
     // part of the verification failed (timestamp tolerance vs. signature
     // mismatch). Log the detail server-side instead.
     return res.status(400).json({ error: 'Invalid webhook' });
+  }
+
+  // Idempotency: claim this event.id via a unique index before handling it.
+  // A duplicate-key error means Stripe already delivered this event and we
+  // processed it — ack with 200 and skip so a redelivery can't re-apply a
+  // plan change. A non-duplicate DB error shouldn't block billing, so we log
+  // it and fall through to handle the event.
+  try {
+    await StripeWebhookEvent.create({ eventId: event.id, type: event.type });
+  } catch (err) {
+    if (err.code === 11000) {
+      return res.json({ received: true, duplicate: true });
+    }
+    console.error('[stripe] idempotency record failed (handling anyway):', err.message);
   }
 
   try {

--- a/backend/src/routes/stripe.js
+++ b/backend/src/routes/stripe.js
@@ -125,9 +125,11 @@ router.post('/webhook', async (req, res) => {
   // A duplicate-key error means Stripe already delivered this event and we
   // processed it — ack with 200 and skip so a redelivery can't re-apply a
   // plan change. A non-duplicate DB error shouldn't block billing, so we log
-  // it and fall through to handle the event.
+  // it and fall through to handle the event (claimed stays false).
+  let claimed = false;
   try {
     await StripeWebhookEvent.create({ eventId: event.id, type: event.type });
+    claimed = true;
   } catch (err) {
     if (err.code === 11000) {
       return res.json({ received: true, duplicate: true });
@@ -198,7 +200,15 @@ router.post('/webhook', async (req, res) => {
     }
   } catch (err) {
     console.error(`[stripe] Error handling ${event.type}:`, err.message);
-    // Still return 200 so Stripe doesn't retry
+    // The handler did not complete (transient Stripe-API or DB error). Roll
+    // back the idempotency claim so a Stripe retry — or a manual dashboard
+    // replay — can reprocess this event, and return 5xx to actually trigger
+    // that retry. Leaving the claim in place + a 200 here would permanently
+    // lose the event (the dedup row would short-circuit every redelivery).
+    if (claimed) {
+      await StripeWebhookEvent.deleteOne({ eventId: event.id }).catch(() => {});
+    }
+    return res.status(500).json({ error: 'Webhook handler failed' });
   }
 
   res.json({ received: true });

--- a/backend/src/utils/pagination.js
+++ b/backend/src/utils/pagination.js
@@ -12,12 +12,14 @@
  * @param {object} [defaults]
  * @param {number} [defaults.limit=50]    - default items per page
  * @param {number} [defaults.maxLimit=200] - upper bound for limit
+ * @param {number} [defaults.maxOffset=100000] - upper bound for offset/skip
  * @returns {{ limit: number, offset: number, page: number }}
  */
 function parsePagination(query, defaults = {}) {
   const {
     limit: defaultLimit = 50,
     maxLimit = 200,
+    maxOffset = 1000000,
   } = defaults;
 
   const limit = Math.min(
@@ -28,13 +30,16 @@ function parsePagination(query, defaults = {}) {
   let page;
   let offset;
 
+  // Clamp offset to maxOffset so a hostile `?page=99999999` / `?offset=2e11`
+  // can't force MongoDB into a multi-billion-doc .skip() scan. The cap is far
+  // above any realistic browse depth, so legitimate pagination is unaffected.
   if (query.page != null) {
     page   = Math.max(parseInt(query.page, 10) || 1, 1);
-    offset = (page - 1) * limit;
+    offset = Math.min((page - 1) * limit, maxOffset);
   } else {
     // Accept both "offset" and "skip" as query param names
     const rawOffset = query.offset != null ? query.offset : query.skip;
-    offset = Math.max(parseInt(rawOffset, 10) || 0, 0);
+    offset = Math.min(Math.max(parseInt(rawOffset, 10) || 0, 0), maxOffset);
     page   = Math.floor(offset / limit) + 1;
   }
 

--- a/backend/src/utils/pagination.test.js
+++ b/backend/src/utils/pagination.test.js
@@ -180,4 +180,20 @@ describe('parsePagination', () => {
     expect(result.page).toBe(10000);
     expect(result.offset).toBe(499950);
   });
+
+  test('pathological page is clamped to maxOffset to avoid huge .skip()', () => {
+    const result = parsePagination({ page: '999999999', limit: '200' });
+    // (page-1)*limit would be ~2e11; clamped to the default maxOffset.
+    expect(result.offset).toBe(1000000);
+  });
+
+  test('pathological offset is clamped to maxOffset', () => {
+    const result = parsePagination({ offset: '200000000000', limit: '50' });
+    expect(result.offset).toBe(1000000);
+  });
+
+  test('custom maxOffset clamps the offset', () => {
+    const result = parsePagination({ offset: '50000', limit: '50' }, { maxOffset: 10000 });
+    expect(result.offset).toBe(10000);
+  });
 });


### PR DESCRIPTION
## Summary

Batch 3 of the audit follow-ups: **correctness & resource limits.** Behavior-preserving for normal use; the caps only bite pathological inputs. Touches auth + payments, so the diff was run through a 2-lens adversarial review (which caught a real bug — see below).

## Changes
- **Pagination offset clamp** ([pagination.js](backend/src/utils/pagination.js)) — clamp `offset`/`page` to `maxOffset` (default 1,000,000) so a hostile `?page=999999999` can't force a multi-billion-doc `.skip()`. Realistic deep pagination is unaffected; **+3 clamp tests**.
- **Stripe webhook idempotency** ([stripe.js](backend/src/routes/stripe.js), new [StripeWebhookEvent](backend/src/models/StripeWebhookEvent.js)) — claim each `event.id` via a unique index (30-day TTL) and skip duplicates, so a redelivered/stale event can't re-apply a plan change. **On handler failure the claim is rolled back and a 5xx returned** so Stripe retries / manual replay works — only a *completed* handler leaves the processed marker.
- **Bounded unbounded fetches:**
  - cellar history MongoDB fallback capped at `.limit(10000)` (matches the Meili path) — [cellars.js](backend/src/routes/cellars.js)
  - cellar `/export` capped at 50k with an additive `_truncated` flag (mirrors the user-data export)
  - journal wine-search resolves matching `WineDefinition`s first, then fetches only those bottles (capped) — no longer loads the user's entire active collection — [journal.js](backend/src/routes/journal.js)
- **30-day absolute refresh-token lifetime** ([auth.js](backend/src/routes/auth.js), [User.js](backend/src/models/User.js)) — `refreshTokenExpiresAt` set at session start, **preserved across rotations** so a rotated stolen token is still cut off after 30 days. Legacy (null) sessions are backfilled on next refresh; field hidden in `toJSON`.

## Review-caught fix
The adversarial review flagged a **high-severity bug in the first idempotency cut**: recording `event.id` *before* handling + the handler's swallow-and-200 meant a transient failure permanently lost the event (no retry, replay blocked as duplicate). Fixed by the rollback-on-failure + 5xx behavior above.

## Deferred (separate PR)
**EXIF/GPS stripping on uploads** — auth-gating `/originals` isn't viable (`<img>` can't send the Bearer token), so it needs a proper metadata-strip approach; scoped as its own investigated PR.

## Testing
Full backend suite green: **609 tests / 27 suites** (606 + 3 new pagination tests). Every changed file `node --check`ed.