### PR TITLE
refactor(validation): total helpers + close validation gaps (Batch 4 pt 2)

### DIFF
--- a/backend/src/routes/admin/cellars.js
+++ b/backend/src/routes/admin/cellars.js
@@ -5,7 +5,7 @@ const Rack = require('../../models/Rack');
 const Bottle = require('../../models/Bottle');
 const { logAudit } = require('../../services/audit');
 const { parsePagination } = require('../../utils/pagination');
-const { isValidId } = require('../../utils/validation');
+const { isValidId, coerceStringQuery } = require('../../utils/validation');
 const { escapeRegex } = require('../../utils/sanitize');
 
 const router = express.Router();
@@ -20,9 +20,9 @@ router.get('/deleted', async (req, res) => {
     const { limit, offset } = parsePagination(req.query, { limit: 50, maxLimit: 200 });
 
     const filter = { deletedAt: { $ne: null } };
-    if (req.query.search) {
-      const escaped = escapeRegex(req.query.search.trim());
-      filter.name = new RegExp(escaped, 'i');
+    const search = coerceStringQuery(req.query.search).trim();
+    if (search) {
+      filter.name = new RegExp(escapeRegex(search), 'i');
     }
 
     const [cellars, total] = await Promise.all([

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -19,6 +19,7 @@ const aiChat = require('../services/aiChat');
 const { updateSiteConfig } = require('../utils/siteConfig');
 const { parsePagination } = require('../utils/pagination');
 const { escapeRegex } = require('../utils/sanitize');
+const { coerceStringQuery } = require('../utils/validation');
 const { SYSTEM_PROMPT_MAX_LENGTH, SCAN_PROMPT_MAX_LENGTH } = require('../config/constants');
 
 const router = express.Router();
@@ -294,9 +295,9 @@ router.get('/audit', async (req, res) => {
   try {
     const { limit, offset } = parsePagination(req.query, { limit: 100, maxLimit: 500 });
     const filter = {};
-    if (req.query.action) {
-      const escaped = escapeRegex(req.query.action);
-      filter.action = new RegExp(escaped, 'i');
+    const action = coerceStringQuery(req.query.action).trim();
+    if (action) {
+      filter.action = new RegExp(escapeRegex(action), 'i');
     }
 
     const [logs, total] = await Promise.all([
@@ -325,9 +326,9 @@ router.get('/users', async (req, res) => {
     const { limit, offset } = parsePagination(req.query, { limit: 100, maxLimit: 500 });
     const filter = {};
 
-    if (req.query.search) {
-      const escaped = escapeRegex(req.query.search.trim());
-      const re = new RegExp(escaped, 'i');
+    const search = coerceStringQuery(req.query.search).trim();
+    if (search) {
+      const re = new RegExp(escapeRegex(search), 'i');
       filter.$or = [{ username: re }, { email: re }];
     }
     if (req.query.plan) {

--- a/backend/src/routes/wineReports.js
+++ b/backend/src/routes/wineReports.js
@@ -20,6 +20,11 @@ router.post('/', requireAuth, async (req, res) => {
     if (!VALID_REASONS.includes(reason)) {
       return res.status(400).json({ error: 'Invalid reason' });
     }
+    // duplicateOfId is optional, but if supplied it must be a valid ObjectId —
+    // otherwise it was persisted unchecked (CastError 500 + a dangling ref).
+    if (duplicateOfId != null && duplicateOfId !== '' && !mongoose.Types.ObjectId.isValid(duplicateOfId)) {
+      return res.status(400).json({ error: 'Invalid duplicateOfId' });
+    }
     if (details && details.trim().length > 2000) {
       return res.status(400).json({ error: 'Details must be 2000 characters or fewer' });
     }
@@ -44,7 +49,7 @@ router.post('/', requireAuth, async (req, res) => {
       wineDefinition: wineDefinitionId,
       reason,
       details: details ? stripHtml(details) : undefined,
-      duplicateOf: duplicateOfId || undefined
+      duplicateOf: (duplicateOfId && mongoose.Types.ObjectId.isValid(duplicateOfId)) ? duplicateOfId : undefined
     });
 
     logAudit(req, 'wine.report.created', { type: 'WineReport', id: report._id }, {

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -329,8 +329,11 @@ async function searchBottles(query, {
   const VALID_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
   const filters = [];
 
-  // Scope to cellar
-  if (cellarId) filters.push(`cellarId = "${cellarId}"`);
+  // Scope to cellar. cellarId is server-set/access-checked, but strip any
+  // double-quote defensively so it can never break out of the filter string.
+  // (We strip rather than drop on invalid input — dropping would un-scope the
+  // search and leak across cellars.)
+  if (cellarId) filters.push(`cellarId = "${String(cellarId).replace(/"/g, '')}"`);
   // Status filter: active (exclude consumed), consumed (only consumed), or all
   if (statusFilter === 'active') {
     filters.push(`status NOT IN ["${CONSUMED_STATUSES.join('","')}"]`);
@@ -361,9 +364,11 @@ async function searchBottles(query, {
     if (validIds.length === 1) filters.push(`grapeIds = "${validIds[0]}"`);
     else if (validIds.length > 1) filters.push(`grapeIds IN ["${validIds.join('","')}"]`);
   }
-  // Vintage: single or comma-separated
+  // Vintage: single or comma-separated. Only alphanumeric tokens (years / NV /
+  // Unknown) are allowed — this drops anything containing a double-quote or
+  // other special char that could inject into the Meili filter string.
   if (vintage) {
-    const vintages = String(vintage).split(',').map(v => v.trim()).filter(Boolean);
+    const vintages = String(vintage).split(',').map(v => v.trim()).filter(v => /^[A-Za-z0-9]+$/.test(v));
     if (vintages.length === 1) filters.push(`vintage = "${vintages[0]}"`);
     else if (vintages.length > 1) filters.push(`vintage IN ["${vintages.join('","')}"]`);
   }

--- a/backend/src/utils/sanitize.js
+++ b/backend/src/utils/sanitize.js
@@ -44,9 +44,13 @@ function isSafeUrl(url) {
 /**
  * Escapes special regex characters in a user-supplied string so it can
  * be safely used inside `new RegExp(...)` for literal matching.
+ *
+ * Total by design: coerces non-strings (including the object/array shapes
+ * Express produces for `?x[$gt]=` query params) to a string first, so callers
+ * can't crash it with a 500. null/undefined become ''.
  */
 function escapeRegex(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return String(str ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 module.exports = { stripHtml, isSafeUrl, escapeRegex };

--- a/backend/src/utils/validation.js
+++ b/backend/src/utils/validation.js
@@ -13,6 +13,21 @@ function isValidId(id) {
   return typeof id === 'string' && mongoose.isValidObjectId(id);
 }
 
+/**
+ * Coerce a query/body value that is meant to be a string into one.
+ *
+ * Express query params can arrive as arrays or objects (e.g. `?search[$gt]=`
+ * yields `{ $gt: '' }`). Calling `.trim()` / `escapeRegex()` on those throws a
+ * 500. This returns the value only when it is genuinely a string, otherwise ''
+ * — so a malformed param simply behaves like "no value" instead of crashing.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+function coerceStringQuery(value) {
+  return typeof value === 'string' ? value : '';
+}
+
 // Lower bound: oldest plausible drinkable vintage. Tightening this to ~1900
 // keeps obvious typos like "1001" out of the maturity queue without
 // excluding fortified/aged wines that occasionally surface from old cellars.
@@ -66,4 +81,4 @@ function parseAndValidateVintage(raw, { now = new Date() } = {}) {
   return { ok: true, value: String(year) };
 }
 
-module.exports = { isValidId, parseAndValidateVintage, MIN_VINTAGE_YEAR };
+module.exports = { isValidId, coerceStringQuery, parseAndValidateVintage, MIN_VINTAGE_YEAR };

--- a/backend/src/utils/validation.test.js
+++ b/backend/src/utils/validation.test.js
@@ -1,4 +1,33 @@
-const { isValidId, parseAndValidateVintage } = require('./validation');
+const { isValidId, coerceStringQuery, parseAndValidateVintage } = require('./validation');
+const { escapeRegex } = require('./sanitize');
+
+describe('coerceStringQuery', () => {
+  it('returns the string unchanged', () => {
+    expect(coerceStringQuery('hello')).toBe('hello');
+    expect(coerceStringQuery('')).toBe('');
+  });
+  it('returns "" for the object/array shapes Express produces for ?x[$gt]=', () => {
+    expect(coerceStringQuery({ $gt: '' })).toBe('');
+    expect(coerceStringQuery(['a', 'b'])).toBe('');
+    expect(coerceStringQuery(undefined)).toBe('');
+    expect(coerceStringQuery(null)).toBe('');
+    expect(coerceStringQuery(123)).toBe('');
+  });
+});
+
+describe('escapeRegex (total)', () => {
+  it('escapes regex metacharacters', () => {
+    expect(escapeRegex('a.b*c')).toBe('a\\.b\\*c');
+    expect(escapeRegex('(x)[y]')).toBe('\\(x\\)\\[y\\]');
+  });
+  it('never throws on non-string input (coerces to "")', () => {
+    expect(escapeRegex(undefined)).toBe('');
+    expect(escapeRegex(null)).toBe('');
+    // String({...}) is '[object Object]' — the [ and ] get escaped like any literal.
+    expect(escapeRegex({ $gt: '' })).toBe('\\[object Object\\]');
+    expect(() => escapeRegex(['a'])).not.toThrow();
+  });
+});
 
 describe('isValidId', () => {
   it('accepts a valid 24-char hex string', () => {


### PR DESCRIPTION
## Summary

Batch 4 (part 2): make the shared validation helpers **total** and apply them uniformly, so malformed input returns a clean 400 / no-op instead of a 500. Closes several Low findings from the audit.

## Changes
- **`escapeRegex` is now total** ([sanitize.js](backend/src/utils/sanitize.js)) — coerces non-strings (incl. the `{ $gt: '' }` object Express makes for `?x[$gt]=`) so callers can't crash it.
- **New `coerceStringQuery(value)`** ([validation.js](backend/src/utils/validation.js)) — returns the value only when it's genuinely a string, else `''`, so list/search endpoints treat a malformed param as "no value."
- **superadmin `/audit` + `/users`, admin/cellars `/deleted`** — route `search`/`action` query params through `coerceStringQuery` before `.trim()`/`escapeRegex` (previously a **500** on `?search[$gt]=`).
- **wineReports** — validate optional `duplicateOfId` as an ObjectId (was persisted unchecked → CastError 500 + dangling ref).
- **search (Meili)** — restrict vintage filter tokens to alphanumeric and strip any double-quote from the interpolated `cellarId`, closing a filter-injection gap **without** dropping the access-scoping `cellarId` (dropping it would un-scope the search).

## Deferred
Routing rack `typeConfig`/`modules` writes through the shared `clampInt` — a bigger change, tracked separately.

## Testing
Full backend suite green: **619 tests / 28 suites** (615 + 4 new for `coerceStringQuery` and total `escapeRegex`).