### PR TITLE
fix(routes): asyncHandler + close unhandled-rejection gaps (Batch 4 pt 3)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -224,6 +224,10 @@ app.use((req, res) => {
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res, next) => {
   console.error(err);
+  // If the response has already started (e.g. an SSE/stream route threw mid-
+  // flight), we can't set a status/body — hand off to Express's default handler
+  // which closes the connection.
+  if (res.headersSent) return next(err);
   const status = err.status || err.statusCode || 500;
   // In production, never leak internal error messages to the client
   const message = process.env.NODE_ENV === 'production' && status >= 500

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -15,6 +15,7 @@ const express = require('express');
 const mongoose = require('mongoose');
 const rateLimit = require('express-rate-limit');
 const { requireAuth } = require('../middleware/auth');
+const asyncHandler = require('../utils/asyncHandler');
 const aiChat = require('../services/aiChat');
 const aiConfig = require('../config/aiConfig');
 const ChatUsage = require('../models/ChatUsage');
@@ -193,7 +194,7 @@ router.get('/usage', requireAuth, async (req, res) => {
 // ---------------------------------------------------------------------------
 // POST /api/chat (non-streaming)
 // ---------------------------------------------------------------------------
-router.post('/', requireAuth, chatBurstLimiter, async (req, res) => {
+router.post('/', requireAuth, chatBurstLimiter, asyncHandler(async (req, res) => {
   const validated = await validateAndCheckLimit(req, res);
   if (!validated) return;
 
@@ -226,12 +227,12 @@ router.post('/', requireAuth, chatBurstLimiter, async (req, res) => {
     console.error('[chat] Error:', err);
     res.status(500).json({ error: 'Failed to generate recommendation' });
   }
-});
+}));
 
 // ---------------------------------------------------------------------------
 // POST /api/chat/stream (streaming SSE)
 // ---------------------------------------------------------------------------
-router.post('/stream', requireAuth, chatBurstLimiter, async (req, res) => {
+router.post('/stream', requireAuth, chatBurstLimiter, asyncHandler(async (req, res) => {
   // ── Concurrency cap ────────────────────────────────────────────────────
   // Reserve a slot BEFORE doing any DB / Anthropic work, so a user at the
   // cap gets a clean 429 instead of triggering a refunded debit. Released
@@ -316,6 +317,6 @@ router.post('/stream', requireAuth, chatBurstLimiter, async (req, res) => {
     clearTimeout(sseTimer);
     streamLimiter.release(req.user.id, streamSlotId);
   }
-});
+}));
 
 module.exports = router;

--- a/backend/src/routes/pushSubscriptions.js
+++ b/backend/src/routes/pushSubscriptions.js
@@ -57,7 +57,9 @@ router.post('/test', async (req, res) => {
     res.json({ ok: true });
   } catch (err) {
     if (err.statusCode === 410 || err.statusCode === 404) {
-      await PushSubscription.deleteOne({ user: req.user.id, endpoint: String(req.body.endpoint) });
+      // Best-effort cleanup of the dead subscription — a failure here must not
+      // turn into an unhandled rejection (this runs inside the catch block).
+      await PushSubscription.deleteOne({ user: req.user.id, endpoint: String(req.body.endpoint) }).catch(() => {});
       return res.status(410).json({ error: 'Subscription expired. Please re-register this device.' });
     }
     console.error('Test push error:', err);

--- a/backend/src/utils/asyncHandler.js
+++ b/backend/src/utils/asyncHandler.js
@@ -1,0 +1,25 @@
+/**
+ * Wrap an async Express route handler so a rejected promise is forwarded to the
+ * centralized error handler (see app.js) via next(err), instead of surfacing as
+ * an unhandledRejection that hangs the request with no response.
+ *
+ * Express 4 does not await route handlers, so an async handler that throws (or
+ * awaits a rejecting promise) outside its own try/catch escapes Express. This
+ * wrapper closes that gap; new routes should use it instead of hand-rolling a
+ * try/catch:
+ *
+ *   router.post('/', asyncHandler(async (req, res) => {
+ *     const doc = await Thing.create(req.body); // a rejection here → 500 via next(err)
+ *     res.status(201).json({ doc });
+ *   }));
+ *
+ * @param {Function} fn async (req, res, next) => Promise
+ * @returns {Function} an Express handler that catches rejections
+ */
+function asyncHandler(fn) {
+  return function wrapped(req, res, next) {
+    return Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+module.exports = asyncHandler;

--- a/backend/src/utils/asyncHandler.test.js
+++ b/backend/src/utils/asyncHandler.test.js
@@ -1,0 +1,37 @@
+const asyncHandler = require('./asyncHandler');
+
+describe('asyncHandler', () => {
+  it('forwards a rejected promise to next(err)', async () => {
+    const err = new Error('boom');
+    const next = jest.fn();
+    await asyncHandler(async () => { throw err; })({}, {}, next);
+    expect(next).toHaveBeenCalledWith(err);
+  });
+
+  it('does not call next on success', async () => {
+    const next = jest.fn();
+    const res = {};
+    await asyncHandler(async (req, r) => { r.ok = true; })({}, res, next);
+    expect(res.ok).toBe(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('forwards a rejection that happens after some awaits', async () => {
+    const err = new Error('late');
+    const next = jest.fn();
+    await asyncHandler(async () => {
+      await Promise.resolve();
+      throw err;
+    })({}, {}, next);
+    expect(next).toHaveBeenCalledWith(err);
+  });
+
+  it('passes (req, res, next) through to the wrapped handler', async () => {
+    const seen = {};
+    const req = { a: 1 }; const res = { b: 2 }; const next = () => {};
+    await asyncHandler(async (q, s, n) => { seen.q = q; seen.s = s; seen.n = n; })(req, res, next);
+    expect(seen.q).toBe(req);
+    expect(seen.s).toBe(res);
+    expect(seen.n).toBe(next);
+  });
+});


### PR DESCRIPTION
## Summary

Batch 4 (part 3): adds a reusable **`asyncHandler`** wrapper and fixes the genuinely unprotected async route handlers a full scan surfaced. Express 4 doesn't await handlers, so an async handler that rejects *outside* its own try/catch becomes an `unhandledRejection` that hangs the request (the same class as the `support.js` bug from Batch 1).

## Method
A 5-agent scan of **all 50 route files** for async handlers lacking try/catch. The result was a short list (most routes already handle errors) — exactly 3 real exposures, all fixed here.

## Changes
- **New [`asyncHandler(fn)`](backend/src/utils/asyncHandler.js)** — `Promise.resolve(fn(req,res,next)).catch(next)`. New routes should use it instead of hand-rolling try/catch.
- **chat `POST /api/chat` & `/api/chat/stream`** — `validateAndCheckLimit()` (which does Mongo awaits) is called *before*/outside a covering try-catch (the stream handler has `try/finally` with no `catch`). A DB rejection there would escape. Wrapped both handlers with `asyncHandler`.
- **push-subscriptions `POST /test`** — the **catch block** itself did an unguarded `await deleteOne(...)` (cleanup of an expired sub). Made it best-effort (`.catch(() => {})`) so a cleanup failure can't crash the request — and the client still gets its `410`.
- **app.js error handler** — now skips when `res.headersSent` (an SSE/stream route that threw mid-flight) and delegates to Express's default handler, so `asyncHandler` is safe on streaming routes.

## Testing
Full backend suite green: **619 tests / 29 suites** (615 + 4 new `asyncHandler` unit tests).