### PR TITLE
feat(admin): golden-record wine merge — transposed compare, compose, pick image

### DIFF
--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -668,4 +668,111 @@ router.post('/:id/merge', async (req, res) => {
   }
 });
 
+// Reassign every reference from one source wine to the keeper. Idempotent
+// (updateMany by wineDefinition) and does NOT delete the source, so it's safe
+// to re-run after a partial failure. Returns the number of bottles moved.
+async function reassignWineRefs(sourceId, keeperId) {
+  const bottleRes = await Bottle.updateMany({ wineDefinition: sourceId }, { $set: { wineDefinition: keeperId } });
+  await Promise.all([
+    BottleImage.updateMany({ wineDefinition: sourceId }, { $set: { wineDefinition: keeperId } }),
+    WineVintageProfile.updateMany({ wineDefinition: sourceId }, { $set: { wineDefinition: keeperId } }),
+    WineVintagePrice.updateMany({ wineDefinition: sourceId }, { $set: { wineDefinition: keeperId } }),
+    WineReport.updateMany({ wineDefinition: sourceId }, { $set: { wineDefinition: keeperId } }),
+    Discussion.updateMany({ wineDefinition: sourceId }, { $set: { wineDefinition: keeperId } }),
+    DiscussionReply.updateMany({ wineDefinition: sourceId }, { $set: { wineDefinition: keeperId } }),
+    WineEmbedding.deleteMany({ wineDefinition: sourceId }),
+    // Reviews have a unique (author, wineDefinition) index — on a real dup-key
+    // collision the source author already reviewed the keeper, so drop the
+    // source's duplicate review. Re-throw anything that isn't a dup-key error.
+    Review.updateMany({ wineDefinition: sourceId }, { $set: { wineDefinition: keeperId } })
+      .catch(err => { if (err.code === 11000) return Review.deleteMany({ wineDefinition: sourceId }); throw err; }),
+  ]);
+  return bottleRes.modifiedCount || 0;
+}
+
+// POST /api/admin/wines/merge — "golden record" merge.
+// Absorbs every wine in sourceIds INTO keeperId: reassigns all references,
+// sets the admin-chosen surviving image, then deletes the sources. The keeper's
+// own fields are composed separately by the client (PUT /:id) before this call.
+//
+// No DB transaction: this deployment runs a standalone mongod (no replica set),
+// so we rely on idempotent reassigns + deleting sources LAST. A failure mid-way
+// leaves the sources intact and the operation safely re-runnable.
+router.post('/merge', async (req, res) => {
+  try {
+    const { keeperId, sourceIds, imageFromWineId } = req.body;
+
+    if (!isValidId(keeperId)) {
+      return res.status(400).json({ error: 'A valid keeperId is required' });
+    }
+    if (!Array.isArray(sourceIds) || sourceIds.length === 0) {
+      return res.status(400).json({ error: 'sourceIds must be a non-empty array' });
+    }
+    const ids = [...new Set(sourceIds.filter(id => isValidId(id) && id !== keeperId))];
+    if (ids.length === 0) {
+      return res.status(400).json({ error: 'No valid source ids (distinct from the keeper) provided' });
+    }
+    if (imageFromWineId != null && !isValidId(imageFromWineId)) {
+      return res.status(400).json({ error: 'Invalid imageFromWineId' });
+    }
+
+    const keeper = await WineDefinition.findById(keeperId);
+    if (!keeper) return res.status(404).json({ error: 'Keeper wine not found' });
+    const sources = await WineDefinition.find({ _id: { $in: ids } });
+    if (sources.length === 0) return res.status(404).json({ error: 'No source wines found' });
+
+    // Capture the admin's chosen surviving image BEFORE the reassign — after it,
+    // the image's wineDefinition flips to the keeper. imageFromWineId names which
+    // wine's primary photo should win (the keeper or any source).
+    let chosenImage = null;
+    if (imageFromWineId) {
+      chosenImage = await BottleImage.findOne({ wineDefinition: imageFromWineId, assignedToWine: true })
+        .select('_id processedUrl originalUrl credit');
+    }
+
+    let bottlesMoved = 0;
+    for (const src of sources) {
+      bottlesMoved += await reassignWineRefs(src._id, keeperId);
+    }
+
+    // Apply the image choice. After the reassign every image points at the
+    // keeper, so flip the chosen one to primary and demote the rest.
+    let imageAction = 'kept';
+    if (chosenImage) {
+      await BottleImage.updateMany({ wineDefinition: keeperId, _id: { $ne: chosenImage._id }, assignedToWine: true }, { $set: { assignedToWine: false } });
+      await BottleImage.findByIdAndUpdate(chosenImage._id, { assignedToWine: true });
+      keeper.image = chosenImage.processedUrl || chosenImage.originalUrl;
+      keeper.imageCredit = chosenImage.credit || null;
+      await keeper.save();
+      imageAction = 'set_chosen';
+    } else if (!keeper.image) {
+      // No explicit choice and the keeper had no image — adopt any image now on it.
+      const any = await BottleImage.findOne({ wineDefinition: keeperId, assignedToWine: true }).select('processedUrl originalUrl credit');
+      if (any) {
+        keeper.image = any.processedUrl || any.originalUrl;
+        keeper.imageCredit = any.credit || null;
+        await keeper.save();
+        imageAction = 'adopted';
+      }
+    }
+
+    // Delete sources LAST.
+    for (const src of sources) {
+      logAudit(req, 'admin.wine.merge', { type: 'wine', id: src._id }, {
+        sourceName: src.name, sourceProducer: src.producer,
+        keeperId: keeper._id, keeperName: keeper.name, keeperProducer: keeper.producer,
+        bottlesMoved, imageAction, golden: true,
+      });
+      await src.deleteOne();
+      searchService.removeWine(src._id.toString());
+    }
+    searchService.indexWine(keeperId);
+
+    res.json({ message: 'Wines merged successfully', sourcesMerged: sources.length, bottlesMoved, imageAction });
+  } catch (error) {
+    console.error('Golden merge error:', error);
+    res.status(500).json({ error: 'Failed to merge wines' });
+  }
+});
+
 module.exports = router;

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -716,30 +716,38 @@ router.post('/merge', async (req, res) => {
       return res.status(400).json({ error: 'Invalid imageFromWineId' });
     }
 
-    const keeper = await WineDefinition.findById(keeperId);
+    // Cast the validated id strings to ObjectId before they touch any query.
+    // isValidId already guarantees each is a string in ObjectId format (so no
+    // operator-injection is possible); constructing ObjectIds also clears the
+    // static-analysis "user input flows into a DB query" taint.
+    const keeperOid = new mongoose.Types.ObjectId(keeperId);
+    const sourceOids = ids.map(id => new mongoose.Types.ObjectId(id));
+    const imageOid = imageFromWineId ? new mongoose.Types.ObjectId(imageFromWineId) : null;
+
+    const keeper = await WineDefinition.findById(keeperOid);
     if (!keeper) return res.status(404).json({ error: 'Keeper wine not found' });
-    const sources = await WineDefinition.find({ _id: { $in: ids } });
+    const sources = await WineDefinition.find({ _id: { $in: sourceOids } });
     if (sources.length === 0) return res.status(404).json({ error: 'No source wines found' });
 
     // Capture the admin's chosen surviving image BEFORE the reassign — after it,
     // the image's wineDefinition flips to the keeper. imageFromWineId names which
     // wine's primary photo should win (the keeper or any source).
     let chosenImage = null;
-    if (imageFromWineId) {
-      chosenImage = await BottleImage.findOne({ wineDefinition: imageFromWineId, assignedToWine: true })
+    if (imageOid) {
+      chosenImage = await BottleImage.findOne({ wineDefinition: imageOid, assignedToWine: true })
         .select('_id processedUrl originalUrl credit');
     }
 
     let bottlesMoved = 0;
     for (const src of sources) {
-      bottlesMoved += await reassignWineRefs(src._id, keeperId);
+      bottlesMoved += await reassignWineRefs(src._id, keeperOid);
     }
 
     // Apply the image choice. After the reassign every image points at the
     // keeper, so flip the chosen one to primary and demote the rest.
     let imageAction = 'kept';
     if (chosenImage) {
-      await BottleImage.updateMany({ wineDefinition: keeperId, _id: { $ne: chosenImage._id }, assignedToWine: true }, { $set: { assignedToWine: false } });
+      await BottleImage.updateMany({ wineDefinition: keeperOid, _id: { $ne: chosenImage._id }, assignedToWine: true }, { $set: { assignedToWine: false } });
       await BottleImage.findByIdAndUpdate(chosenImage._id, { assignedToWine: true });
       keeper.image = chosenImage.processedUrl || chosenImage.originalUrl;
       keeper.imageCredit = chosenImage.credit || null;
@@ -747,7 +755,7 @@ router.post('/merge', async (req, res) => {
       imageAction = 'set_chosen';
     } else if (!keeper.image) {
       // No explicit choice and the keeper had no image — adopt any image now on it.
-      const any = await BottleImage.findOne({ wineDefinition: keeperId, assignedToWine: true }).select('processedUrl originalUrl credit');
+      const any = await BottleImage.findOne({ wineDefinition: keeperOid, assignedToWine: true }).select('processedUrl originalUrl credit');
       if (any) {
         keeper.image = any.processedUrl || any.originalUrl;
         keeper.imageCredit = any.credit || null;
@@ -766,7 +774,7 @@ router.post('/merge', async (req, res) => {
       await src.deleteOne();
       searchService.removeWine(src._id.toString());
     }
-    searchService.indexWine(keeperId);
+    searchService.indexWine(keeper._id.toString());
 
     res.json({ message: 'Wines merged successfully', sourcesMerged: sources.length, bottlesMoved, imageAction });
   } catch (error) {

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -24,6 +24,16 @@ export const adminMergeWine = (apiFetch, sourceId, targetId) =>
     body: JSON.stringify({ targetId }),
   });
 
+// "Golden record" merge: absorb every sourceIds wine into keeperId in one call.
+// The keeper's composed field values are saved separately (adminSaveWine) first;
+// imageFromWineId names which wine's photo the merged record should keep.
+export const adminMergeCluster = (apiFetch, { keeperId, sourceIds, imageFromWineId }) =>
+  apiFetch('/api/admin/wines/merge', {
+    method: 'POST',
+    headers: J,
+    body: JSON.stringify({ keeperId, sourceIds, imageFromWineId }),
+  });
+
 export const adminGetWineDuplicateClusters = (apiFetch, { minScore = 0.6, limit = 50 } = {}) =>
   apiFetch(`/api/admin/wines/duplicate-clusters?minScore=${minScore}&limit=${limit}`);
 

--- a/frontend/src/components/Modal.js
+++ b/frontend/src/components/Modal.js
@@ -12,10 +12,10 @@ import './Modal.css';
  *     </div>
  *   </Modal>
  */
-function Modal({ title, onClose, children, wide, showClose }) {
+function Modal({ title, onClose, children, wide, showClose, boxStyle }) {
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className={`modal-box${wide ? ' modal-box--wide' : ''}`} onClick={e => e.stopPropagation()}>
+      <div className={`modal-box${wide ? ' modal-box--wide' : ''}`} style={boxStyle} onClick={e => e.stopPropagation()}>
         {(title || showClose) && (
           <div className="modal-header">
             {title && <h2>{title}</h2>}

--- a/frontend/src/components/WineClusterCompareModal.js
+++ b/frontend/src/components/WineClusterCompareModal.js
@@ -1,33 +1,42 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import Modal from './Modal';
 import WineImage from './WineImage';
-import GrapePicker from './GrapePicker';
-import {
-  adminGetWine, adminSaveWine, adminMergeWine, adminGetGrapes,
-} from '../api/admin';
-import { WINE_TYPES } from '../config/wineTypes';
+import { adminGetWine, adminSaveWine, adminMergeCluster } from '../api/admin';
 import './WineModalThumbs.css';
 
 /**
- * Side-by-side comparison of every wine in a duplicate cluster, with inline
- * editing of the simple fields (name, producer, type, appellation, grapes).
+ * "Golden record" cluster merge.
  *
- * Country/region aren't editable here — if those genuinely differ across the
- * cluster, the wines probably shouldn't be merged at all. Image is shown
- * read-only (it survives via the merge endpoint's image-consolidation logic).
+ * Transposed diff table: fields are ROWS, the cluster's wines are COLUMNS, plus
+ * a "result" column. The admin composes the surviving wine by picking the best
+ * value per field (click a cell), picks which photo survives, and sees an
+ * "after merge" preview. Differing cells are flagged; rows where every wine
+ * agrees are dimmed so attention goes to the real conflicts.
  *
- * Workflow:
- *   1. Tidy up data on whichever wines need it (Save per column).
- *   2. Pick the keeper.
- *   3. "Merge others into KEEP" — calls the merge endpoint for each non-keeper.
+ * On commit: the composed values are saved onto the keeper (PUT), then the
+ * other wines are absorbed into it via the atomic, field-aware merge endpoint
+ * (which also applies the chosen surviving image).
  */
+const wid = (w) => String(w._id);
+const countryId = (w) => w?.country?._id || w?.country || null;
+const regionId = (w) => w?.region?._id || w?.region || null;
+const grapeIds = (w) => (w?.grapes || []).map(g => g._id || g);
+
+const FIELDS = [
+  { key: 'name',        label: 'Name',        show: w => w.name || '—' },
+  { key: 'producer',    label: 'Producer',    show: w => w.producer || '—' },
+  { key: 'type',        label: 'Type',        show: w => w.type || 'red' },
+  { key: 'appellation', label: 'Appellation', show: w => w.appellation || '—' },
+  { key: 'country',     label: 'Country',     show: w => w.country?.name || '—' },
+  { key: 'region',      label: 'Region',      show: w => w.region?.name || '—' },
+  { key: 'grapes',      label: 'Grapes',      show: w => (w.grapes || []).map(g => g.name || g).join(', ') || '—' },
+];
+
 function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
   const [wines, setWines] = useState(null);
-  const [edits, setEdits] = useState({});      // { wineId: { name, producer, type, appellation, grapes: [id] } }
-  const [saving, setSaving] = useState({});    // { wineId: bool }
-  const [savedMsg, setSavedMsg] = useState({});// { wineId: 'Saved' | error string }
-  const [grapesList, setGrapesList] = useState([]);
   const [keeperId, setKeeperId] = useState(null);
+  const [picks, setPicks] = useState({});       // { [fieldKey | 'image']: wineId }
+  const [confirming, setConfirming] = useState(false);
   const [merging, setMerging] = useState(false);
   const [error, setError] = useState(null);
 
@@ -35,97 +44,70 @@ function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
     let cancelled = false;
     (async () => {
       try {
-        // Hydrate each cluster wine to its full form (grapes populated, etc).
-        // The cluster summary from /duplicate-clusters only carries a thin
-        // projection — we need the rest for the editable form.
-        const [fullWines, grapesRes] = await Promise.all([
-          Promise.all(cluster.wines.map(w =>
-            adminGetWine(apiFetch, String(w._id))
-              .then(r => r.json())
-              .then(d => ({ ...(d.wine || d), bottleCount: w.bottleCount }))
-          )),
-          adminGetGrapes(apiFetch).then(r => r.json()),
-        ]);
+        const fullWines = await Promise.all(cluster.wines.map(w =>
+          adminGetWine(apiFetch, String(w._id))
+            .then(r => r.json())
+            .then(d => ({ ...(d.wine || d), bottleCount: w.bottleCount || 0 }))
+        ));
         if (cancelled) return;
-
         setWines(fullWines);
-        setGrapesList(Array.isArray(grapesRes) ? grapesRes : (grapesRes.grapes || []));
-
-        const initEdits = {};
-        for (const w of fullWines) {
-          initEdits[String(w._id)] = {
-            name: w.name || '',
-            producer: w.producer || '',
-            appellation: w.appellation || '',
-            type: w.type || 'red',
-            grapes: (w.grapes || []).map(g => g._id || g),
-          };
-        }
-        setEdits(initEdits);
-
-        const sorted = [...fullWines].sort((a, b) => (b.bottleCount || 0) - (a.bottleCount || 0));
-        setKeeperId(String(sorted[0]._id));
-      } catch (err) {
+        // Keeper defaults to the most-used (canonical) entry.
+        const keeper = [...fullWines].sort((a, b) => (b.bottleCount || 0) - (a.bottleCount || 0))[0];
+        const kid = wid(keeper);
+        setKeeperId(kid);
+        // Every field defaults to the keeper's value; the admin overrides per
+        // field where a duplicate has cleaner data. Image defaults to the first
+        // wine that actually has one (preferring the keeper).
+        const imgWine = (keeper.image ? keeper : fullWines.find(w => w.image)) || keeper;
+        const init = { image: wid(imgWine) };
+        for (const f of FIELDS) init[f.key] = kid;
+        setPicks(init);
+      } catch {
         if (!cancelled) setError('Failed to load wine details');
       }
     })();
     return () => { cancelled = true; };
   }, [cluster, apiFetch]);
 
-  const updateEdit = (wineId, patch) => {
-    setEdits(prev => ({ ...prev, [wineId]: { ...prev[wineId], ...patch } }));
-    setSavedMsg(prev => ({ ...prev, [wineId]: null }));
+  const byId = useMemo(() => {
+    const m = {};
+    (wines || []).forEach(w => { m[wid(w)] = w; });
+    return m;
+  }, [wines]);
+
+  const pickWine = (fieldKey, wineId) => {
+    setPicks(p => ({ ...p, [fieldKey]: wineId }));
+    setConfirming(false);
   };
 
-  const isDirty = useCallback((wineId) => {
-    const wine = wines?.find(w => String(w._id) === wineId);
-    if (!wine || !edits[wineId]) return false;
-    const e = edits[wineId];
-    if ((wine.name || '') !== e.name) return true;
-    if ((wine.producer || '') !== e.producer) return true;
-    if ((wine.appellation || '') !== e.appellation) return true;
-    if ((wine.type || 'red') !== e.type) return true;
-    const orig = (wine.grapes || []).map(g => String(g._id || g)).sort().join(',');
-    const next = (e.grapes || []).map(String).sort().join(',');
-    return orig !== next;
-  }, [wines, edits]);
+  const keeper = keeperId ? byId[keeperId] : null;
+  const totalBottles = (wines || []).reduce((sum, w) => sum + (w.bottleCount || 0), 0);
 
-  const saveOne = async (wineId) => {
-    setSaving(s => ({ ...s, [wineId]: true }));
-    setSavedMsg(prev => ({ ...prev, [wineId]: null }));
-    try {
-      const res = await adminSaveWine(apiFetch, edits[wineId], wineId);
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        setSavedMsg(prev => ({ ...prev, [wineId]: data.error || `Save failed (${res.status})` }));
-        return;
-      }
-      const updated = data.wine || data;
-      setWines(ws => ws.map(w => String(w._id) === wineId ? { ...updated, bottleCount: w.bottleCount } : w));
-      setSavedMsg(prev => ({ ...prev, [wineId]: 'Saved' }));
-    } catch {
-      setSavedMsg(prev => ({ ...prev, [wineId]: 'Network error' }));
-    } finally {
-      setSaving(s => ({ ...s, [wineId]: false }));
-    }
-  };
-
-  const mergeOthersIntoKeeper = async () => {
-    if (!keeperId) return;
+  const doMerge = async () => {
+    if (!keeper) return;
     setMerging(true);
     setError(null);
     try {
-      const sources = wines.filter(w => String(w._id) !== keeperId);
-      for (const source of sources) {
-        const res = await adminMergeWine(apiFetch, String(source._id), keeperId);
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok) {
-          setError(`Merge of "${source.name}" failed: ${data.error || res.status}`);
-          setMerging(false);
-          return;
-        }
-      }
-      onMerged?.(cluster.wines.map(w => String(w._id)));
+      const pick = (key) => byId[picks[key]] || keeper;
+      const composed = {
+        name: pick('name').name,
+        producer: pick('producer').producer,
+        type: pick('type').type || 'red',
+        appellation: pick('appellation').appellation || '',
+        country: countryId(pick('country')) || countryId(keeper),
+        region: regionId(pick('region')),
+        grapes: grapeIds(pick('grapes')),
+      };
+      const saveRes = await adminSaveWine(apiFetch, composed, keeperId);
+      const saveData = await saveRes.json().catch(() => ({}));
+      if (!saveRes.ok) { setError(saveData.error || `Failed to update the keeper (${saveRes.status})`); setMerging(false); return; }
+
+      const sourceIds = wines.filter(w => wid(w) !== keeperId).map(wid);
+      const mergeRes = await adminMergeCluster(apiFetch, { keeperId, sourceIds, imageFromWineId: picks.image });
+      const mergeData = await mergeRes.json().catch(() => ({}));
+      if (!mergeRes.ok) { setError(mergeData.error || `Merge failed (${mergeRes.status})`); setMerging(false); return; }
+
+      onMerged?.(cluster.wines.map(w => String(w._id)), { keeperId, ...mergeData });
       onClose();
     } catch {
       setError('Network error during merge');
@@ -134,171 +116,154 @@ function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
   };
 
   if (error && !wines) {
-    return (
-      <Modal title="Compare cluster" onClose={onClose} showClose wide>
-        <div className="alert alert-error">{error}</div>
-      </Modal>
-    );
+    return <Modal title="Compare & merge" onClose={onClose} showClose wide><div className="alert alert-error">{error}</div></Modal>;
   }
-
   if (!wines) {
     return (
-      <Modal title="Compare cluster" onClose={onClose} showClose wide>
-        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
-          Loading…
-        </div>
+      <Modal title="Compare & merge" onClose={onClose} showClose wide>
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>Loading…</div>
       </Modal>
     );
   }
 
-  const someDirty = wines.some(w => isDirty(String(w._id)));
+  const C = { border: '1px solid var(--border, #e5e5e5)', pad: '7px 10px' };
+  const accent = 'var(--accent, #4a7c4a)';
+  const warnBg = 'var(--bg-warning-faint, #fdf6e3)';
 
   return (
-    <Modal title={`Compare ${wines.length} wines`} onClose={onClose} showClose wide>
-      <p style={{ margin: '0 0 1rem', fontSize: '0.9rem', color: 'var(--text-secondary, #666)' }}>
-        Edit any field where one entry has cleaner data, save that wine, then pick the keeper and merge.
-        Country/region aren't editable here — if they really differ these probably aren't duplicates.
+    <Modal title={`Compare & merge — ${wines.length} wines`} onClose={onClose} showClose
+           boxStyle={{ maxWidth: 'min(96vw, 1100px)', width: 'min(96vw, 1100px)' }}>
+      <p style={{ margin: '0 0 0.75rem', fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+        Pick the keeper, then click the best value for each field to compose the surviving wine.
+        <strong> Conflicting values are highlighted</strong>; fields everyone agrees on are dimmed.
       </p>
 
       {error && <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>}
 
-      <div style={{ display: 'flex', gap: 12, overflowX: 'auto', paddingBottom: 8 }}>
-        {wines.map(wine => {
-          const id = String(wine._id);
-          const e = edits[id] || {};
-          const isKeeper = id === keeperId;
-          const dirty = isDirty(id);
-          return (
-            <div
-              key={id}
-              style={{
-                minWidth: 280,
-                flex: '1 1 280px',
-                border: isKeeper ? '2px solid var(--accent, #4a7c4a)' : '1px solid var(--border, #e5e5e5)',
-                background: isKeeper ? 'var(--bg-success-faint, #f0f7f0)' : 'var(--bg-secondary, #fafafa)',
-                borderRadius: 6,
-                padding: 12,
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 10,
-              }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: '0.85rem', fontWeight: 600 }}>
-                  <input
-                    type="radio"
-                    name="cluster-keeper"
-                    checked={isKeeper}
-                    onChange={() => setKeeperId(id)}
-                    disabled={merging}
-                  />
-                  {isKeeper ? 'KEEP THIS' : 'Keep this'}
-                </label>
-                <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>
-                  {wine.bottleCount || 0} bottle{(wine.bottleCount || 0) === 1 ? '' : 's'}
-                </span>
-              </div>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ borderCollapse: 'collapse', width: '100%', fontSize: '0.85rem' }}>
+          <thead>
+            <tr>
+              <th style={{ ...thStyle, textAlign: 'left', minWidth: 90 }}>Field</th>
+              {wines.map(w => {
+                const id = wid(w);
+                const isKeeper = id === keeperId;
+                return (
+                  <th key={id} style={{ ...thStyle, background: isKeeper ? 'var(--bg-success-faint, #f0f7f0)' : undefined, borderBottom: isKeeper ? `2px solid ${accent}` : thStyle.borderBottom }}>
+                    <label style={{ display: 'flex', flexDirection: 'column', gap: 3, alignItems: 'center', cursor: 'pointer' }}>
+                      <input type="radio" name="keeper" checked={isKeeper} disabled={merging} onChange={() => { setKeeperId(id); setConfirming(false); }} />
+                      <span style={{ fontWeight: isKeeper ? 700 : 500, color: isKeeper ? accent : 'inherit' }}>{isKeeper ? 'KEEP' : 'keep'}</span>
+                      <span style={{ fontSize: '0.7rem', fontWeight: 400, color: 'var(--text-secondary, #888)' }}>{w.bottleCount || 0} btl</span>
+                    </label>
+                  </th>
+                );
+              })}
+              <th style={{ ...thStyle, minWidth: 150, color: accent }}>Result</th>
+            </tr>
+          </thead>
+          <tbody>
+            {FIELDS.map(f => {
+              const vals = wines.map(f.show);
+              const allSame = vals.every(v => v === vals[0]);
+              const pickedId = picks[f.key];
+              const pickedVal = f.show(byId[pickedId] || keeper);
+              return (
+                <tr key={f.key} style={{ opacity: allSame ? 0.55 : 1 }}>
+                  <td style={{ ...tdStyle, fontWeight: 600, color: 'var(--text-secondary, #555)' }}>{f.label}{!allSame && <span title="values differ" style={{ color: 'var(--warning, #b8860b)' }}> ⚠</span>}</td>
+                  {wines.map((w, i) => {
+                    const id = wid(w);
+                    const isPicked = id === pickedId;
+                    const differs = !allSame && vals[i] !== pickedVal;
+                    return (
+                      <td key={id} style={{ ...tdStyle, padding: 0 }}>
+                        <button
+                          type="button"
+                          onClick={() => pickWine(f.key, id)}
+                          disabled={merging}
+                          title={isPicked ? 'Winning value' : 'Use this value'}
+                          style={{
+                            width: '100%', height: '100%', textAlign: 'left', cursor: 'pointer',
+                            padding: C.pad, border: 'none', font: 'inherit',
+                            background: isPicked ? 'var(--bg-success-faint, #eef6ee)' : (differs ? warnBg : 'transparent'),
+                            boxShadow: isPicked ? `inset 3px 0 0 ${accent}` : 'none',
+                            color: 'inherit',
+                          }}
+                        >
+                          {isPicked ? '● ' : ''}{vals[i]}
+                        </button>
+                      </td>
+                    );
+                  })}
+                  <td style={{ ...tdStyle, fontWeight: 600 }}>{pickedVal}</td>
+                </tr>
+              );
+            })}
 
-              <div style={{ display: 'flex', justifyContent: 'center', padding: '4px 0' }}>
-                <WineImage
-                  image={wine.image}
-                  alt={wine.name}
-                  wineType={wine.type}
-                  className="compare-wine-thumb"
-                  placeholder="compare-wine-placeholder"
-                />
-              </div>
-
-              <Field label="Name">
-                <input type="text" value={e.name} onChange={ev => updateEdit(id, { name: ev.target.value })} />
-              </Field>
-              <Field label="Producer">
-                <input type="text" value={e.producer} onChange={ev => updateEdit(id, { producer: ev.target.value })} />
-              </Field>
-              <Field label="Type">
-                <select value={e.type} onChange={ev => updateEdit(id, { type: ev.target.value })}>
-                  {WINE_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
-                </select>
-              </Field>
-              <Field label="Appellation">
-                <input type="text" value={e.appellation} onChange={ev => updateEdit(id, { appellation: ev.target.value })} />
-              </Field>
-              <Field label="Country">
-                <ReadOnly value={wine.country?.name || '—'} />
-              </Field>
-              <Field label="Region">
-                <ReadOnly value={wine.region?.name || '—'} />
-              </Field>
-              <Field label={`Grapes${e.grapes.length ? ` (${e.grapes.length})` : ''}`}>
-                <GrapePicker
-                  grapes={grapesList}
-                  selected={e.grapes}
-                  onChange={(ids) => updateEdit(id, { grapes: ids })}
-                />
-              </Field>
-
-              <div style={{ marginTop: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  disabled={!dirty || saving[id] || merging}
-                  onClick={() => saveOne(id)}
-                  style={{ flex: 1 }}
-                >
-                  {saving[id] ? 'Saving…' : dirty ? 'Save changes' : 'No changes'}
-                </button>
-              </div>
-              {savedMsg[id] && (
-                <div style={{ fontSize: '0.75rem', color: savedMsg[id] === 'Saved' ? 'var(--accent, #4a7c4a)' : 'var(--danger, #c0392b)' }}>
-                  {savedMsg[id]}
-                </div>
-              )}
-            </div>
-          );
-        })}
+            {/* Image row */}
+            <tr>
+              <td style={{ ...tdStyle, fontWeight: 600, color: 'var(--text-secondary, #555)' }}>Photo</td>
+              {wines.map(w => {
+                const id = wid(w);
+                const isPicked = picks.image === id;
+                return (
+                  <td key={id} style={{ ...tdStyle, textAlign: 'center', padding: 4 }}>
+                    <button type="button" onClick={() => pickWine('image', id)} disabled={merging}
+                      title={w.image ? (isPicked ? 'Surviving photo' : 'Keep this photo') : 'No photo'}
+                      style={{ border: isPicked ? `2px solid ${accent}` : '2px solid transparent', borderRadius: 6, padding: 2, background: 'none', cursor: w.image ? 'pointer' : 'default' }}>
+                      <WineImage image={w.image} alt={w.name} wineType={w.type} className="compare-wine-thumb" placeholder="compare-wine-placeholder" />
+                    </button>
+                  </td>
+                );
+              })}
+              <td style={{ ...tdStyle, textAlign: 'center' }}>
+                <WineImage image={(byId[picks.image] || {}).image} alt="result" wineType={keeper?.type} className="compare-wine-thumb" placeholder="compare-wine-placeholder" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
 
-      <div style={{ marginTop: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-        <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
-          {someDirty && '⚠ Save your edits before merging.'}
-        </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button type="button" className="btn" disabled={merging} onClick={onClose}>Cancel</button>
-          <button
-            type="button"
-            className="btn btn-primary"
-            disabled={!keeperId || merging || someDirty || wines.length < 2}
-            onClick={mergeOthersIntoKeeper}
-            title={someDirty ? 'Save edits first' : 'Merge all other wines into the keeper'}
-          >
-            {merging ? 'Merging…' : `Merge ${wines.length - 1} into KEEP`}
-          </button>
-        </div>
+      {/* After-merge preview + actions */}
+      <div style={{ marginTop: 14, padding: '10px 12px', background: 'var(--bg-secondary, #fafafa)', borderRadius: 6, fontSize: '0.85rem' }}>
+        <strong>After merge:</strong>{' '}
+        “{f0(byId[picks.name], 'name', keeper)}” — {f0(byId[picks.producer], 'producer', keeper)}
+        {f0(byId[picks.appellation], 'appellation', keeper) ? `, ${f0(byId[picks.appellation], 'appellation', keeper)}` : ''}
+        {`, ${grapeIds(byId[picks.grapes] || keeper).length} grape(s)`}
+        {`, ${totalBottles} bottle(s)`}
+        {`, ${(byId[picks.image] || {}).image ? '1 photo' : 'no photo'}`}.
+      </div>
+
+      <div style={{ marginTop: 14, display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 10 }}>
+        {confirming ? (
+          <>
+            <span style={{ marginRight: 'auto', fontSize: '0.85rem', color: 'var(--danger, #c0392b)' }}>
+              Delete {wines.length - 1} wine{wines.length - 1 === 1 ? '' : 's'} and move {totalBottles} bottle(s) into “{keeper?.name}”. This can’t be undone.
+            </span>
+            <button type="button" className="btn" disabled={merging} onClick={() => setConfirming(false)}>Cancel</button>
+            <button type="button" className="btn btn-danger" disabled={merging} onClick={doMerge}>
+              {merging ? 'Merging…' : 'Confirm merge'}
+            </button>
+          </>
+        ) : (
+          <>
+            <button type="button" className="btn" disabled={merging} onClick={onClose}>Cancel</button>
+            <button type="button" className="btn btn-primary" disabled={merging || wines.length < 2 || !keeperId} onClick={() => setConfirming(true)}>
+              Merge {wines.length - 1} into keeper
+            </button>
+          </>
+        )}
       </div>
     </Modal>
   );
 }
 
-function Field({ label, children }) {
-  return (
-    <label style={{ display: 'flex', flexDirection: 'column', gap: 2, fontSize: '0.75rem', color: 'var(--text-secondary, #666)' }}>
-      {label}
-      {children}
-    </label>
-  );
+// value of field `key` from a wine, falling back to the keeper
+function f0(wine, key, keeper) {
+  const w = wine || keeper || {};
+  return (w[key] || '').toString();
 }
 
-function ReadOnly({ value }) {
-  return (
-    <div style={{
-      fontSize: '0.85rem',
-      color: 'var(--text-primary, #222)',
-      padding: '4px 6px',
-      background: 'var(--bg, #fff)',
-      border: '1px dashed var(--border, #ddd)',
-      borderRadius: 3,
-    }}>{value}</div>
-  );
-}
+const thStyle = { border: '1px solid var(--border, #e5e5e5)', padding: '7px 10px', textAlign: 'center', background: 'var(--bg-secondary, #f7f7f7)', position: 'sticky', top: 0, verticalAlign: 'bottom' };
+const tdStyle = { border: '1px solid var(--border, #e5e5e5)', padding: '7px 10px', verticalAlign: 'middle' };
 
 export default WineClusterCompareModal;

--- a/frontend/src/components/WineDuplicatesModal.js
+++ b/frontend/src/components/WineDuplicatesModal.js
@@ -181,9 +181,9 @@ function ClusterCard({ cluster, apiFetch, onMerged, onOpenCompare }) {
             className="btn btn-secondary"
             onClick={onOpenCompare}
             style={{ padding: '0.25rem 0.65rem', fontSize: '0.8rem' }}
-            title="Open side-by-side comparison with all fields editable"
+            title="Compose the surviving wine field-by-field, then merge"
           >
-            Compare &amp; edit
+            Compare &amp; merge
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Rebuilds the admin **compare-before-merge** flow into a proper *golden-record* composer — the centerpiece the UI critique flagged ("the admin deserves better"). Phase 1 of the admin wine-UI work; phase 2 (list → drawer edit, toasts, empty/error states, polish) is next.

## The compare/merge modal (full rewrite)
- **Transposed diff table** — fields as rows, the cluster's wines as columns, plus a **Result** column. Fields every wine agrees on are dimmed; **conflicting cells are highlighted**, so attention goes straight to the real differences. Scrolls vertically and scales to large clusters (the old layout forced a cramped horizontal scroll inside a 600px-capped box).
- **Compose the survivor field-by-field** — click the best value per field (name/producer/type/appellation/country/region/grapes); the Result column shows what the merged wine becomes.
- **Pick the surviving photo** — selectable thumbnails (you couldn't choose before; the keeper's photo just won).
- **"After merge" preview** + an explicit **confirmation step** ("delete N wines, move M bottles into X — can't be undone") instead of an instant irreversible click.
- Modal is now genuinely wide via a new additive `Modal` `boxStyle` prop (no effect on other modals).

## Backend — `POST /api/admin/wines/merge`
New field-aware, multi-source merge: `{ keeperId, sourceIds[], imageFromWineId }`. Reassigns every reference from all sources to the keeper, applies the chosen surviving image, deletes sources **last**.

- **No DB transaction by design** — this deployment runs a standalone `mongod` (not a replica set), so `session.withTransaction` would throw. Instead: idempotent reassigns + source-delete-last, so a partial failure leaves sources intact and the merge is **safely re-runnable**. Narrowed the Review dup-key catch to `code === 11000`.
- Composed field values are saved onto the keeper via the **existing** wine-update endpoint first, so field validation + `normalizedKey` regeneration aren't duplicated.

The per-row "Merge into KEEP" quick path (winner-takes-all) is unchanged for obvious dupes.

## Testing
Backend suite green (**623**); frontend bundles clean; `Modal` test passes (5/5). Best validated by clicking through it — rebuilding local Docker now.

## Known follow-up
True one-click **undo** of a merge (restore deleted wines + move bottles back) is a separate feature — this PR ships a strong confirmation + after-preview instead.