### PR TITLE
feat(admin): wine-list UX — drawer edit, toasts, states, pagination

### DIFF
--- a/frontend/src/components/Drawer.css
+++ b/frontend/src/components/Drawer.css
@@ -1,0 +1,74 @@
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(2px);
+  z-index: 1100;
+  display: flex;
+  justify-content: flex-end;
+  animation: drawer-fade 0.15s ease;
+}
+
+.drawer-panel {
+  width: min(560px, 100vw);
+  max-width: 100vw;
+  height: 100%;
+  background: var(--bg, #fff);
+  box-shadow: -8px 0 28px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  animation: drawer-slide 0.2s ease;
+}
+
+.drawer-header,
+.drawer-footer {
+  flex: 0 0 auto;
+  padding: 1rem 1.25rem;
+  background: var(--bg, #fff);
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--border, #e5e5e5);
+  position: sticky;
+  top: 0;
+}
+
+.drawer-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.drawer-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary, #888);
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+}
+.drawer-close:hover { background: var(--bg-secondary, #f0f0f0); color: var(--text-primary, #222); }
+
+.drawer-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 1.25rem;
+}
+
+.drawer-footer {
+  border-top: 1px solid var(--border, #e5e5e5);
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+@keyframes drawer-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes drawer-slide { from { transform: translateX(24px); opacity: 0.6; } to { transform: translateX(0); opacity: 1; } }
+
+@media (max-width: 640px) {
+  .drawer-panel { width: 100vw; }
+}

--- a/frontend/src/components/Drawer.js
+++ b/frontend/src/components/Drawer.js
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import './Drawer.css';
+
+/**
+ * Right-side slide-in panel. Keeps the page (e.g. the list behind it) visible,
+ * unlike a centered modal. Sticky header + footer with a scrollable body, so
+ * action buttons stay reachable no matter how long the form is. Closes on
+ * Escape or overlay click.
+ *
+ *   <Drawer title="Edit wine" onClose={close} footer={<>…buttons…</>}>
+ *     …form…
+ *   </Drawer>
+ */
+function Drawer({ title, onClose, children, footer, width }) {
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div className="drawer-overlay" onClick={onClose}>
+      <div
+        className="drawer-panel"
+        style={width ? { width } : undefined}
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        <div className="drawer-header">
+          <h2>{title}</h2>
+          <button type="button" className="drawer-close" onClick={onClose} aria-label="Close">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="drawer-body">{children}</div>
+        {footer && <div className="drawer-footer">{footer}</div>}
+      </div>
+    </div>
+  );
+}
+
+export default Drawer;

--- a/frontend/src/pages/AdminWines.css
+++ b/frontend/src/pages/AdminWines.css
@@ -293,3 +293,77 @@
     grid-column: auto !important;
   }
 }
+
+/* ── Phase 2 UX: skeleton, error, pagination, row link, toasts ────────────── */
+.wines-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.wine-skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-light, #eee);
+}
+.skeleton-bar {
+  height: 0.85rem;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #ececec 25%, #f5f5f5 37%, #ececec 63%);
+  background-size: 400% 100%;
+  animation: skeleton-shimmer 1.3s ease-in-out infinite;
+}
+@keyframes skeleton-shimmer { 0% { background-position: 100% 50%; } 100% { background-position: 0 50%; } }
+
+.wine-name-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-weight: 600;
+  color: var(--accent, #4a7c4a);
+  cursor: pointer;
+  text-align: left;
+}
+.wine-name-link:hover { text-decoration: underline; }
+
+/* a little more breathing room so Delete isn't a misclick away from Edit */
+.row-actions { display: flex; gap: 0.75rem; justify-content: flex-end; }
+
+.wines-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+.pagination-range { font-size: 0.85rem; color: var(--text-secondary, #777); }
+.pagination-controls { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.pagination-page { font-size: 0.85rem; color: var(--text-secondary, #777); padding: 0 0.25rem; }
+.page-size select { padding: 2px 4px; }
+
+.toast-stack {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1200;
+}
+.toast {
+  padding: 0.6rem 0.9rem;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.9rem;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+  animation: toast-in 0.18s ease;
+  max-width: 340px;
+}
+.toast--success { background: var(--accent, #4a7c4a); }
+.toast--error { background: var(--danger, #c0392b); }
+@keyframes toast-in { from { transform: translateY(8px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -8,6 +8,7 @@ import {
   adminAssignImageToWine,
 } from '../api/admin';
 import Modal from '../components/Modal';
+import Drawer from '../components/Drawer';
 import WineDuplicatesModal from '../components/WineDuplicatesModal';
 import { WINE_TYPES } from '../config/wineTypes';
 import GrapePicker from '../components/GrapePicker';
@@ -37,7 +38,17 @@ function AdminWines() {
   const [searchInput, setSearchInput] = useState('');
   const [search, setSearch] = useState('');
   const [filters, setFilters] = useState({ type: '', sort: 'name' });
+  const [pageSize, setPageSize] = useState(50);
   const [loading, setLoading] = useState(true);
+  const [listError, setListError] = useState(null);
+
+  // Transient action-feedback toasts (no global toast system in this app).
+  const [toasts, setToasts] = useState([]);
+  const pushToast = useCallback((message, type = 'success') => {
+    const id = Date.now() + Math.random();
+    setToasts(ts => [...ts, { id, message, type }]);
+    setTimeout(() => setToasts(ts => ts.filter(x => x.id !== id)), 3500);
+  }, []);
 
   const [showForm, setShowForm] = useState(false);
   const [editWine, setEditWine] = useState(null);
@@ -87,24 +98,28 @@ function AdminWines() {
 
   const fetchWines = useCallback(async () => {
     setLoading(true);
+    setListError(null);
     try {
-      const params = new URLSearchParams({ page, limit: 50 });
+      const params = new URLSearchParams({ page, limit: pageSize });
       if (search) params.set('search', search);
       if (filters.type) params.set('type', filters.type);
       params.set('sort', filters.sort);
       const res = await adminGetWines(apiFetch, params);
-      const data = await res.json();
+      const data = await res.json().catch(() => ({}));
       if (res.ok) {
-        setWines(data.wines);
-        setTotal(data.total);
-        setPages(data.pages);
+        setWines(data.wines || []);
+        setTotal(data.total || 0);
+        setPages(data.pages || 1);
+      } else {
+        setListError(data.error || `Failed to load wines (${res.status})`);
       }
     } catch (err) {
       console.error('Failed to fetch wines:', err);
+      setListError('Failed to load wines — check your connection and retry.');
     } finally {
       setLoading(false);
     }
-  }, [apiFetch, page, search, filters]);
+  }, [apiFetch, page, search, filters, pageSize]);
 
   useEffect(() => {
     fetchWines();
@@ -218,6 +233,8 @@ function AdminWines() {
       const res = await adminSaveWine(apiFetch, payload, editWine?._id);
       const data = await res.json();
       if (res.ok) {
+        const name = data.wine?.name || payload.name;
+        pushToast(editWine ? `Saved “${name}”` : `Created “${name}”`);
         closeForm();
         fetchWines();
       } else {
@@ -241,6 +258,7 @@ function AdminWines() {
       const res = await adminDeleteWine(apiFetch, deleteCandidate._id);
       const data = await res.json();
       if (res.ok) {
+        pushToast(`Deleted “${deleteCandidate.name}”`);
         setDeleteCandidate(null);
         fetchWines();
       } else if (data.bottleCount) {
@@ -300,6 +318,7 @@ function AdminWines() {
       const res = await adminMergeWine(apiFetch, mergeSource._id, mergeTarget._id);
       const data = await res.json();
       if (res.ok) {
+        pushToast(`Merged into “${mergeTarget.name}”`);
         closeMergeModal();
         fetchWines();
       } else {
@@ -375,12 +394,22 @@ function AdminWines() {
 
       {error && <div className="alert alert-error">{error}</div>}
 
-      {/* Create / Edit form */}
+      {/* Create / Edit drawer */}
       {showForm && (
-        <div className="card wine-form-card">
-          <h2>{editWine ? t('admin.wines.editWineTitle') : t('admin.wines.addWineTitle')}</h2>
+        <Drawer
+          title={editWine ? t('admin.wines.editWineTitle') : t('admin.wines.addWineTitle')}
+          onClose={closeForm}
+          footer={
+            <>
+              <button type="button" className="btn btn-secondary" onClick={closeForm}>{t('common.cancel')}</button>
+              <button type="submit" form="wine-form" className="btn btn-primary" disabled={submitting}>
+                {submitting ? t('common.saving') : editWine ? t('admin.wines.saveBtn') : t('admin.wines.createBtn')}
+              </button>
+            </>
+          }
+        >
           {formError && <div className="alert alert-error">{formError}</div>}
-          <form onSubmit={handleSubmit}>
+          <form id="wine-form" onSubmit={handleSubmit}>
             <div className="wine-form-grid">
               <div className="form-group">
                 <label>{t('admin.wines.nameLabel')}</label>
@@ -389,6 +418,7 @@ function AdminWines() {
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                   required
+                  autoFocus
                 />
               </div>
               <div className="form-group">
@@ -561,20 +591,8 @@ function AdminWines() {
                 </div>
               )}
             </div>
-            <div className="form-actions">
-              <button type="submit" className="btn btn-primary" disabled={submitting}>
-                {submitting
-                  ? t('common.saving')
-                  : editWine
-                    ? t('admin.wines.saveBtn')
-                    : t('admin.wines.createBtn')}
-              </button>
-              <button type="button" className="btn btn-secondary" onClick={closeForm}>
-                {t('common.cancel')}
-              </button>
-            </div>
           </form>
-        </div>
+        </Drawer>
       )}
 
       {/* Wine list */}
@@ -582,10 +600,34 @@ function AdminWines() {
         <span>{t('admin.wines.totalCount', { count: total })}</span>
       </div>
 
+      {listError && !loading && (
+        <div className="alert alert-error wines-error">
+          <span>{listError}</span>
+          <button type="button" className="btn btn-secondary btn-small" onClick={fetchWines}>Retry</button>
+        </div>
+      )}
+
       {loading ? (
-        <div className="loading">{t('common.loading')}</div>
-      ) : wines.length === 0 ? (
-        <div className="empty-state"><p>{t('admin.wines.noWines')}</p></div>
+        <div className="wines-table-wrap">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="wine-skeleton-row" aria-hidden="true">
+              <span className="wine-list-thumb wine-list-thumb--empty" />
+              <span className="skeleton-bar" style={{ flex: 3 }} />
+              <span className="skeleton-bar" style={{ flex: 1 }} />
+            </div>
+          ))}
+        </div>
+      ) : listError ? null : wines.length === 0 ? (
+        <div className="empty-state">
+          {hasActiveFilters ? (
+            <>
+              <p>No wines match your search or filters.</p>
+              <button type="button" className="btn btn-secondary" onClick={clearFilters}>{t('common.clear')}</button>
+            </>
+          ) : (
+            <p>{t('admin.wines.noWines')}</p>
+          )}
+        </div>
       ) : (
         <div className="wines-table-wrap">
           <table className="wines-table">
@@ -611,7 +653,11 @@ function AdminWines() {
                       ? <img src={imgSrc} alt={wine.name} className="wine-list-thumb" />
                       : <span className="wine-list-thumb wine-list-thumb--empty" />}
                   </td>
-                  <td className="wine-name">{wine.name}</td>
+                  <td className="wine-name">
+                    <button type="button" className="wine-name-link" onClick={() => openEdit(wine)} title="Edit this wine">
+                      {wine.name}
+                    </button>
+                  </td>
                   <td>{wine.producer}</td>
                   <td>{wine.country?.name || '—'}</td>
                   <td>{wine.region?.name || '—'}</td>
@@ -644,23 +690,24 @@ function AdminWines() {
       )}
 
       {/* Pagination */}
-      {pages > 1 && (
-        <div className="pagination">
-          <button
-            className="btn btn-secondary"
-            disabled={page <= 1}
-            onClick={() => setPage(p => p - 1)}
-          >
-            {t('common.previous')}
-          </button>
-          <span>{t('admin.audit.page', { current: page, total: pages })}</span>
-          <button
-            className="btn btn-secondary"
-            disabled={page >= pages}
-            onClick={() => setPage(p => p + 1)}
-          >
-            {t('common.next')}
-          </button>
+      {!loading && !listError && total > 0 && (
+        <div className="pagination wines-pagination">
+          <span className="pagination-range">
+            Showing {((page - 1) * pageSize) + 1}–{Math.min(page * pageSize, total)} of {total.toLocaleString()}
+          </span>
+          <div className="pagination-controls">
+            <label className="page-size">
+              Per page{' '}
+              <select value={pageSize} onChange={(e) => { setPageSize(Number(e.target.value)); setPage(1); }}>
+                {[50, 100, 200].map(n => <option key={n} value={n}>{n}</option>)}
+              </select>
+            </label>
+            <button className="btn btn-secondary btn-small" disabled={page <= 1} onClick={() => setPage(1)}>« First</button>
+            <button className="btn btn-secondary btn-small" disabled={page <= 1} onClick={() => setPage(p => p - 1)}>{t('common.previous')}</button>
+            <span className="pagination-page">{t('admin.audit.page', { current: page, total: pages })}</span>
+            <button className="btn btn-secondary btn-small" disabled={page >= pages} onClick={() => setPage(p => p + 1)}>{t('common.next')}</button>
+            <button className="btn btn-secondary btn-small" disabled={page >= pages} onClick={() => setPage(pages)}>Last »</button>
+          </div>
         </div>
       )}
       {/* Delete confirmation modal */}
@@ -765,6 +812,15 @@ function AdminWines() {
           onClose={() => setShowDuplicatesScanner(false)}
           onMerged={fetchWines}
         />
+      )}
+
+      {/* Action-feedback toasts */}
+      {toasts.length > 0 && (
+        <div className="toast-stack" role="status" aria-live="polite">
+          {toasts.map(tt => (
+            <div key={tt.id} className={`toast toast--${tt.type}`}>{tt.message}</div>
+          ))}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Phase 2 of the admin wine-UI work — the **list + inline-edit** and **visual-polish** areas you prioritized. (Phase 1, the golden-record merge, is PR #468; this is independent.)

## Changes
- **Drawer-based edit/create** — a new reusable `Drawer` (right-side slide-in) replaces the form card that rendered *above* the table and scroll-jumped away from the row (the #1 clunky thing the critique found). Sticky header + footer so **Save/Cancel are always reachable** (even past the image section, via `form="wine-form"`), **Escape-to-close**, **autofocus** on Name, and the list stays visible behind it.
- **Toasts** — transient feedback on save/create/delete/merge ("Saved X", "Deleted X", "Merged into Y"). The app had no toast layer, so mutations previously completed *silently*.
- **Load-error state** — a failed fetch now shows an error banner with **Retry** instead of silently leaving stale/empty data.
- **Loading & empty states** — **skeleton rows** (no layout jump on each search keystroke) and a **filter-aware empty** state ("No wines match…" + Clear) distinct from a truly empty registry.
- **Pagination** — "**Showing X–Y of N**", a **per-page selector** (50/100/200), and **First/Prev/Next/Last** instead of prev/next only.
- **Row polish** — the wine **name is a click-to-edit link**; **Delete is spaced away from Edit** to avoid misclicks.

## Testing
Frontend suite green: **292 tests / 8 files** (incl. Modal). `AdminWines` and the new `Drawer` bundle clean.

## Notes
Independent of #468 (different files). Lower-priority leftovers (bulk select, keyboard-first nav, data-quality badges) were intentionally deferred — happy to do them if you want.