### PR TITLE
feat(ops): restic backup + restore for MongoDB and uploaded images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 # Shell scripts must always check out with LF endings — CRLF breaks the
 # shebang and `set` parsing when they run on the Linux server.
 *.sh text eol=lf
+
+# systemd unit files are deployed on the Linux host; force LF so the
+# directives parse cleanly.
+*.service text eol=lf
+*.timer   text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must always check out with LF endings — CRLF breaks the
+# shebang and `set` parsing when they run on the Linux server.
+*.sh text eol=lf

--- a/backend/src/models/BackupStatus.js
+++ b/backend/src/models/BackupStatus.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+
+/**
+ * Status report written by the backup job (scripts/backup/backup.sh) after each
+ * run. A single document (_id: 'latest'). The app only READS this so SuperAdmin
+ * can show that backups exist and are fresh — it deliberately never touches the
+ * backup repository or its credentials (backups stay isolated from the app).
+ */
+const backupStatusSchema = new mongoose.Schema({
+  _id: { type: String, default: 'latest' },
+  status: { type: String, enum: ['ok', 'failed'] },
+  lastRunAt: { type: Date },
+  durationSec: { type: Number },
+  snapshotCount: { type: Number },
+  latestSnapshotTime: { type: Date },
+  repoSizeBytes: { type: Number },
+  host: { type: String },
+  repo: { type: String },         // sanitized repo label (no secrets)
+  error: { type: String },
+}, { collection: 'backupstatuses', strict: false, versionKey: false });
+
+module.exports = mongoose.model('BackupStatus', backupStatusSchema);

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -12,6 +12,7 @@ const WineRequest = require('../models/WineRequest');
 const Rack = require('../models/Rack');
 const WineEmbedding = require('../models/WineEmbedding');
 const ChatUsage = require('../models/ChatUsage');
+const BackupStatus = require('../models/BackupStatus');
 const embeddingJob = require('../services/embeddingJob');
 const vectorStore = require('../services/vectorStore');
 const aiConfig = require('../config/aiConfig');
@@ -352,6 +353,27 @@ router.get('/users', async (req, res) => {
   } catch (error) {
     console.error('[superadmin] users error:', error);
     res.status(500).json({ error: 'Failed to load users' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/superadmin/backups
+// Backup health as REPORTED by the backup job (scripts/backup/backup.sh).
+// The app only reads this report — it never accesses the backup repo or its
+// credentials, so a compromise of the app can't reach the backups.
+// ---------------------------------------------------------------------------
+router.get('/backups', async (req, res) => {
+  try {
+    const doc = await BackupStatus.findById('latest').lean();
+    if (!doc) return res.json({ configured: false });
+    const lastRunAt = doc.lastRunAt ? new Date(doc.lastRunAt) : null;
+    const ageHours = lastRunAt ? (Date.now() - lastRunAt.getTime()) / 3600000 : null;
+    // Daily schedule → never-run or older than ~26h counts as stale.
+    const stale = ageHours == null || ageHours > 26;
+    res.json({ configured: true, stale, ageHours, ...doc });
+  } catch (error) {
+    console.error('[superadmin] backups error:', error);
+    res.status(500).json({ error: 'Failed to load backup status' });
   }
 });
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -68,16 +68,53 @@ restic -r "$RESTIC_REPOSITORY" snapshots   # verify a snapshot exists
 
 ---
 
-## Schedule it (nightly)
+## Schedule it (systemd timer — recommended)
 
-**cron** (`crontab -e`) — every night at 03:30:
+Backups run on the **host** (not in a container), so the backup credentials and
+the restic encryption key never live inside the app stack — a compromise of the
+app can't reach or delete your backups. A **systemd timer** is the most robust
+way to schedule it: proper logging (`journalctl`), status (`systemctl status`),
+it won't overlap runs, and it catches up a missed run after a reboot.
+
+The unit files are versioned in [`scripts/backup/systemd/`](../scripts/backup/systemd):
+`cellarion-backup.{service,timer}` (nightly) and `cellarion-backup-check.{service,timer}` (weekly `restic check`).
+
+```bash
+cd scripts/backup/systemd
+
+# 1. Point the units at your checkout path (edit /opt/cellarion if you cloned elsewhere)
+#    The two .service files contain WorkingDirectory= and ExecStart= lines to fix.
+sed -i "s#/opt/cellarion#$(cd ../../.. && pwd)#g" cellarion-backup.service cellarion-backup-check.service
+
+# 2. Install + enable
+sudo cp cellarion-backup.service cellarion-backup.timer \
+        cellarion-backup-check.service cellarion-backup-check.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now cellarion-backup.timer cellarion-backup-check.timer
+
+# 3. Verify
+systemctl list-timers 'cellarion-*'          # next/last run times
+sudo systemctl start cellarion-backup.service # run one now (optional)
+journalctl -u cellarion-backup.service -n 50  # see the log
 ```
-30 3 * * * /path/to/cellarion/scripts/backup/backup.sh >> /var/log/cellarion-backup.log 2>&1
+
+> Runs as `root` by default (needed for `docker exec`). To run as a non-root user,
+> add them to the `docker` group and change `User=` in both `.service` files.
+
+<details>
+<summary>Alternative: plain cron (less robust, no integrity check)</summary>
+
+```bash
+crontab -e
+# nightly backup at 03:30
+30 3 * * * /opt/cellarion/scripts/backup/backup.sh >> /var/log/cellarion-backup.log 2>&1
+# weekly integrity check, Sundays 04:30
+30 4 * * 0 /opt/cellarion/scripts/backup/check.sh  >> /var/log/cellarion-backup.log 2>&1
 ```
-Or a **systemd timer** if you prefer (see `man systemd.timer`).
+</details>
 
 ### Get alerted on failure (do this)
-A silently-broken backup is how people discover they had none. Create a free check at [healthchecks.io](https://healthchecks.io), set its ping URL as `HEALTHCHECK_URL` in `backup.env`, and it emails/Slacks you if a nightly run misses or fails.
+A silently-broken backup is how people discover they had none. Create a free check at [healthchecks.io](https://healthchecks.io), set its ping URL as `HEALTHCHECK_URL` in `backup.env`, and it emails/Slacks you if a nightly run misses or fails. (Add a second check and set `HEALTHCHECK_CHECK_URL` to get alerted if the weekly integrity check finds corruption.)
 
 ---
 
@@ -99,7 +136,7 @@ restic -r "$RESTIC_REPOSITORY" snapshots
 
 ## Recommended extras
 
-- **Weekly integrity check** (catches silent bit-rot): `restic -r "$RESTIC_REPOSITORY" check` — add a weekly cron line.
+- **Weekly integrity check** (catches silent bit-rot): handled by `check.sh` + the `cellarion-backup-check.timer` installed above — it runs `restic check` weekly and alerts via `HEALTHCHECK_CHECK_URL`.
 - **Off-provider 2nd copy** (true 3-2-1): set `B2_*` in `backup.env` (e.g. a Backblaze B2 bucket); `backup.sh` will `restic copy` each snapshot there so a Hetzner-account problem can't wipe everything.
 - **Hetzner Cloud Backups** (the +20% VM-image feature) as a bonus "whole-machine undo" — convenient, but treat it as secondary: it's a crash-consistent disk image (riskier for a live DB) stored at the same provider, so it does **not** replace these logical backups.
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -20,9 +20,10 @@ The tooling (`scripts/backup/`) uses [**restic**](https://restic.net): **encrypt
 
 ### 1. Install restic
 ```bash
-sudo apt-get update && sudo apt-get install -y restic curl
+sudo apt-get update && sudo apt-get install -y restic curl jq
 restic self-update   # get the latest
 ```
+(`jq` is used to record the backup-status report that SuperAdmin reads.)
 
 ### 2. Give the VM SSH access to the Storage Box
 Storage Boxes speak SSH/SFTP on **port 23**. Create a key and register it:
@@ -101,6 +102,24 @@ restic -r "$RESTIC_REPOSITORY" snapshots
 - **Weekly integrity check** (catches silent bit-rot): `restic -r "$RESTIC_REPOSITORY" check` — add a weekly cron line.
 - **Off-provider 2nd copy** (true 3-2-1): set `B2_*` in `backup.env` (e.g. a Backblaze B2 bucket); `backup.sh` will `restic copy` each snapshot there so a Hetzner-account problem can't wipe everything.
 - **Hetzner Cloud Backups** (the +20% VM-image feature) as a bonus "whole-machine undo" — convenient, but treat it as secondary: it's a crash-consistent disk image (riskier for a live DB) stored at the same provider, so it does **not** replace these logical backups.
+
+## Seeing backups in the app (SuperAdmin → Backups)
+
+After each run, `backup.sh` writes a small **status report into Mongo** (last run,
+ok/failed, snapshot count, latest snapshot time, repo size). **SuperAdmin → Backups**
+shows it with a green **OK** / amber **STALE** / red **FAILED** badge, so you can
+confirm at a glance that backups exist and are fresh.
+
+By design the **app only reads this report** — it has no access to the backup
+repository or its credentials. That keeps backups isolated from the app, so a
+compromise of the app can't read or delete them. (The report is a side-channel,
+not repo access.)
+
+You get **two** layers of failure alerting:
+1. **In-app** — the SuperAdmin badge turns red/amber on a failed or stale backup.
+2. **Push** — `HEALTHCHECK_URL` (healthchecks.io) emails/Slacks you if a run fails
+   *or is missed entirely* (cron didn't fire). Set it up — the in-app badge only
+   helps if someone looks.
 
 ## Notes & security
 - `backup.env` holds secrets → it's gitignored, `chmod 600`, never committed.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,108 @@
+# Backups & disaster recovery
+
+Cellarion keeps **two** stores of irreplaceable data, and a good backup must cover **both**:
+
+| Store | Where | Backed up? |
+|-------|-------|-----------|
+| **MongoDB** (users, cellars, bottles, wines) | `mongo-data` volume | ✅ yes — `mongodump` |
+| **Uploaded images** (bottle/label photos) | `image-data` volume → `/app/uploads` | ✅ yes — **these are on disk, NOT in Mongo** |
+| Meilisearch index | `meili-data` | ❌ skipped — rebuilt from Mongo |
+| Qdrant vectors (AI) | `qdrant-data` | ❌ skipped — rebuilt from Mongo |
+| Umami analytics | `umami-db-data` | ❌ optional — analytics only |
+
+The tooling (`scripts/backup/`) uses [**restic**](https://restic.net): **encrypted, deduplicated, incremental** snapshots with retention, pushed to a **Hetzner Storage Box** over SFTP (and, optionally, a second off-provider copy).
+
+> **The golden rule:** the backup must live **off the VM**. A copy on the same server dies with it. The Storage Box is separate storage; an optional Backblaze B2 copy adds protection against a Hetzner-account-level loss (true 3-2-1).
+
+---
+
+## One-time setup (on the VM)
+
+### 1. Install restic
+```bash
+sudo apt-get update && sudo apt-get install -y restic curl
+restic self-update   # get the latest
+```
+
+### 2. Give the VM SSH access to the Storage Box
+Storage Boxes speak SSH/SFTP on **port 23**. Create a key and register it:
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/storagebox -N ''
+# Upload the public key to the box (uXXXXXX = your Storage Box user):
+cat ~/.ssh/storagebox.pub | ssh -p23 uXXXXXX@uXXXXXX.your-storagebox.de install-ssh-key
+```
+Add a host alias so restic doesn't need the port/key inline — `~/.ssh/config`:
+```
+Host storagebox
+    HostName uXXXXXX.your-storagebox.de
+    User uXXXXXX
+    Port 23
+    IdentityFile ~/.ssh/storagebox
+```
+Create the backup directory once:
+```bash
+ssh storagebox "mkdir -p backups/cellarion"
+```
+
+### 3. Configure the backup
+```bash
+cd scripts/backup
+cp backup.env.example backup.env
+chmod 600 backup.env
+# Edit backup.env:
+#   RESTIC_REPOSITORY="sftp:storagebox:/backups/cellarion"
+#   RESTIC_PASSWORD=<a long random passphrase>
+```
+Generate the passphrase and **store a copy off the server** (a password manager):
+```bash
+openssl rand -base64 32      # paste into RESTIC_PASSWORD and save it elsewhere
+```
+> ⚠️ `RESTIC_PASSWORD` is the **only** key that decrypts your backups. If you lose it, the backups are gone. Keep it somewhere that survives the VM dying.
+
+### 4. Initialise + first run
+```bash
+./backup.sh        # auto-inits the repo, dumps Mongo + images, uploads, prunes
+restic -r "$RESTIC_REPOSITORY" snapshots   # verify a snapshot exists
+```
+
+---
+
+## Schedule it (nightly)
+
+**cron** (`crontab -e`) — every night at 03:30:
+```
+30 3 * * * /path/to/cellarion/scripts/backup/backup.sh >> /var/log/cellarion-backup.log 2>&1
+```
+Or a **systemd timer** if you prefer (see `man systemd.timer`).
+
+### Get alerted on failure (do this)
+A silently-broken backup is how people discover they had none. Create a free check at [healthchecks.io](https://healthchecks.io), set its ping URL as `HEALTHCHECK_URL` in `backup.env`, and it emails/Slacks you if a nightly run misses or fails.
+
+---
+
+## Restore (and drill it)
+
+```bash
+cd scripts/backup
+./restore.sh latest        # or ./restore.sh <snapshotID>
+docker compose restart backend   # so Meili/Qdrant re-index from the restored Mongo
+```
+`restore.sh` drops + reloads the database and copies the images back. **Run a real restore drill monthly** (ideally onto a throwaway VM) — an untested backup is not a backup.
+
+List what's available:
+```bash
+restic -r "$RESTIC_REPOSITORY" snapshots
+```
+
+---
+
+## Recommended extras
+
+- **Weekly integrity check** (catches silent bit-rot): `restic -r "$RESTIC_REPOSITORY" check` — add a weekly cron line.
+- **Off-provider 2nd copy** (true 3-2-1): set `B2_*` in `backup.env` (e.g. a Backblaze B2 bucket); `backup.sh` will `restic copy` each snapshot there so a Hetzner-account problem can't wipe everything.
+- **Hetzner Cloud Backups** (the +20% VM-image feature) as a bonus "whole-machine undo" — convenient, but treat it as secondary: it's a crash-consistent disk image (riskier for a live DB) stored at the same provider, so it does **not** replace these logical backups.
+
+## Notes & security
+- `backup.env` holds secrets → it's gitignored, `chmod 600`, never committed.
+- Backups contain **user PII** → encryption (restic) + a locked-down Storage Box are required for GDPR. Retention here is 7 daily / 4 weekly / 6 monthly.
+- Retention is enforced by `restic forget --prune` inside `backup.sh`.

--- a/frontend/src/pages/SuperAdmin/TabBackups.js
+++ b/frontend/src/pages/SuperAdmin/TabBackups.js
@@ -1,0 +1,68 @@
+import { bytes, fmtDate, ago, StatusDot, useApi } from './helpers';
+
+/**
+ * Backup health. Reads the status report written by the backup job
+ * (scripts/backup/backup.sh) — the app never touches the backup repo itself.
+ * Shows a clear OK / STALE / FAILED state plus snapshot count, latest snapshot,
+ * and repo size so an operator can confirm backups exist and are fresh.
+ */
+export default function TabBackups() {
+  const { data, loading, error, reload } = useApi('/api/superadmin/backups');
+
+  if (loading) return <div className="sa-loading">Loading backup status…</div>;
+  if (error) return <div className="sa-error">Error: {error}</div>;
+  if (!data) return null;
+
+  if (!data.configured) {
+    return (
+      <div className="sa-section">
+        <StatusDot status="warn" />{' '}
+        No backup has reported yet. Set up the backup job (see <code>docs/backup.md</code>);
+        once it runs, its status appears here.
+      </div>
+    );
+  }
+
+  const failed = data.status === 'failed';
+  const health = failed ? 'error' : data.stale ? 'warn' : 'ok';
+  const headline = failed ? 'Last backup FAILED' : data.stale ? 'Backup is STALE — no recent successful run' : 'Backups healthy';
+
+  const rows = [
+    ['Last run', `${fmtDate(data.lastRunAt)} (${ago(data.lastRunAt)})`],
+    ['Result', data.status || '—'],
+    ['Snapshots stored', data.snapshotCount != null ? data.snapshotCount : '—'],
+    ['Latest snapshot', fmtDate(data.latestSnapshotTime)],
+    ['Repository size', data.repoSizeBytes != null ? bytes(data.repoSizeBytes) : '—'],
+    ['Repository', data.repo || '—'],
+    ['Host', data.host || '—'],
+    ['Duration', data.durationSec != null ? `${data.durationSec}s` : '—'],
+  ];
+
+  return (
+    <>
+      <div className="sa-section" style={{ display: 'flex', alignItems: 'center', gap: 8, fontWeight: 600 }}>
+        <StatusDot status={health} /> {headline}
+      </div>
+
+      {failed && data.error && <div className="sa-error" style={{ marginBottom: 12 }}>{data.error}</div>}
+      {(failed || data.stale) && (
+        <div className="sa-error" style={{ marginBottom: 12 }}>
+          ⚠ Check the backup job and its alert (healthchecks.io) — backups may not be current.
+        </div>
+      )}
+
+      <table className="sa-table">
+        <tbody>
+          {rows.map(([k, v]) => (
+            <tr key={k}><td style={{ fontWeight: 600, paddingRight: 16 }}>{k}</td><td>{v}</td></tr>
+          ))}
+        </tbody>
+      </table>
+
+      <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)', marginTop: 12 }}>
+        Reported by the backup job — the app reads this status only and never accesses the backup repository.
+      </p>
+      <button className="sa-btn" onClick={reload} style={{ marginTop: 8 }}>Refresh</button>
+    </>
+  );
+}

--- a/frontend/src/pages/SuperAdmin/index.js
+++ b/frontend/src/pages/SuperAdmin/index.js
@@ -12,12 +12,14 @@ import TabSettings from './TabSettings';
 import TabAI from './TabAI';
 import TabCellars from './TabCellars';
 import TabImport from './TabImport';
+import TabBackups from './TabBackups';
 import '../SuperAdmin.css';
 
 const TABS = [
   { id: 'overview',   label: 'Overview' },
   { id: 'services',   label: 'Services' },
   { id: 'database',   label: 'Database' },
+  { id: 'backups',    label: 'Backups' },
   { id: 'users',      label: 'Users' },
   { id: 'audit',      label: 'Audit Log' },
   { id: 'cellars',    label: 'Deleted Cellars' },
@@ -148,6 +150,7 @@ export default function SuperAdmin() {
         {tab === 'overview'   && <TabOverview />}
         {tab === 'services'   && <TabServices />}
         {tab === 'database'   && <TabDatabase />}
+        {tab === 'backups'    && <TabBackups />}
         {tab === 'users'      && <TabUsers />}
         {tab === 'audit'      && <TabAudit />}
         {tab === 'cellars'    && <TabCellars />}

--- a/scripts/backup/backup.env.example
+++ b/scripts/backup/backup.env.example
@@ -30,6 +30,10 @@ KEEP_MONTHLY=6
 # silently-broken backup is the classic way to discover you had none.
 HEALTHCHECK_URL=""
 
+# Separate ping URL for the WEEKLY integrity check (check.sh). Optional — use a
+# second healthchecks.io check so a corrupt repo alerts you independently.
+HEALTHCHECK_CHECK_URL=""
+
 # ── Optional second, OFF-PROVIDER copy (true 3-2-1) ───────────────────────────
 # Survives a Hetzner-account-level loss. Leave blank to skip for now.
 # Example for Backblaze B2: b2:your-bucket:cellarion

--- a/scripts/backup/backup.env.example
+++ b/scripts/backup/backup.env.example
@@ -1,0 +1,38 @@
+# Cellarion backup config — copy to backup.env (gitignored) and fill in.
+# backup.env holds secrets; keep it 0600 and NEVER commit it.
+
+# ── restic repository (primary) ───────────────────────────────────────────────
+# Hetzner Storage Box over SFTP. Define a host alias in ~/.ssh/config (see
+# docs/backup.md) so restic doesn't need the port/key inline, then:
+#   RESTIC_REPOSITORY="sftp:storagebox:/backups/cellarion"
+# (or the full form: sftp:uXXXXXX@uXXXXXX.your-storagebox.de:/backups/cellarion)
+export RESTIC_REPOSITORY="sftp:storagebox:/backups/cellarion"
+
+# The encryption passphrase for the restic repo. THIS IS THE ONLY KEY THAT CAN
+# DECRYPT YOUR BACKUPS — generate a long random one and store a copy somewhere
+# safe and OFF this server (a password manager). Lose it and the backups are
+# unrecoverable.
+export RESTIC_PASSWORD="CHANGE-ME-to-a-long-random-passphrase"
+
+# ── Containers / database ─────────────────────────────────────────────────────
+MONGO_CONTAINER="cellarion-mongo"
+BACKEND_CONTAINER="cellarion-backend"
+MONGO_DB="winecellar"
+
+# ── Retention (grandfather-father-son) ────────────────────────────────────────
+KEEP_DAILY=7
+KEEP_WEEKLY=4
+KEEP_MONTHLY=6
+
+# ── Monitoring (recommended) ──────────────────────────────────────────────────
+# A healthchecks.io (or similar) ping URL. The script pings it on success and
+# <url>/fail on error, so you get ALERTED if a backup misses or fails — a
+# silently-broken backup is the classic way to discover you had none.
+HEALTHCHECK_URL=""
+
+# ── Optional second, OFF-PROVIDER copy (true 3-2-1) ───────────────────────────
+# Survives a Hetzner-account-level loss. Leave blank to skip for now.
+# Example for Backblaze B2: b2:your-bucket:cellarion
+B2_RESTIC_REPOSITORY=""
+B2_ACCOUNT_ID=""
+B2_ACCOUNT_KEY=""

--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -40,23 +40,42 @@ ping_fail() {
 
 # Write a one-document status report into Mongo so SuperAdmin can show backup
 # health (the app reads this; it never touches the repo). Scalars only. Needs jq.
+#
+# The document is built with `jq` (which safely JSON-encodes every value) and
+# handed to mongosh as DATA through an env var. The --eval script below is a
+# CONSTANT string with no shell expansion, so no value is ever concatenated into
+# a command — there is no shell/command-injection surface.
 record_status() {
-  local status="$1" err="${2:-}" now count latest size latestJs errClean
+  local status="$1" err="${2:-}" now count latest size doc
   now="$(date -Is)"
   count="$(restic snapshots --json 2>/dev/null | jq 'length' 2>/dev/null || echo null)"
   latest="$(restic snapshots --json 2>/dev/null | jq -r 'sort_by(.time)|last|.time // empty' 2>/dev/null || echo '')"
   size="$(restic stats --json --mode raw-data 2>/dev/null | jq '.total_size // null' 2>/dev/null || echo null)"
-  latestJs="null"; [ -n "$latest" ] && latestJs="new Date('$latest')"
-  errClean="$(printf '%s' "$err" | tr -d "'\"\\\\" | head -c 300)"
-  docker exec -i "$MONGO_CONTAINER" mongosh "$MONGO_DB" --quiet --eval "
-    db.backupstatuses.replaceOne({ _id: 'latest' }, {
-      _id: 'latest', status: '$status', lastRunAt: new Date('$now'),
-      durationSec: ${SECONDS}, snapshotCount: ${count:-null},
-      latestSnapshotTime: ${latestJs}, repoSizeBytes: ${size:-null},
-      host: '$(hostname | tr -d "'")', repo: '$(printf '%s' "$RESTIC_REPOSITORY" | tr -d "'")',
-      error: '$errClean'
-    }, { upsert: true });
-  " >/dev/null 2>&1 || log "warning: could not record backup status to Mongo"
+
+  doc="$(jq -n \
+    --arg     status            "$status" \
+    --arg     lastRunAt         "$now" \
+    --argjson durationSec       "${SECONDS:-0}" \
+    --argjson snapshotCount     "${count:-null}" \
+    --arg     latestSnapshotTime "$latest" \
+    --argjson repoSizeBytes     "${size:-null}" \
+    --arg     host              "$(hostname)" \
+    --arg     repo              "$RESTIC_REPOSITORY" \
+    --arg     error             "$err" \
+    '{status:$status, lastRunAt:$lastRunAt, durationSec:$durationSec,
+      snapshotCount:$snapshotCount, latestSnapshotTime:$latestSnapshotTime,
+      repoSizeBytes:$repoSizeBytes, host:$host, repo:$repo,
+      error:($error[0:300])}' 2>/dev/null)" \
+    || { log "warning: could not build status document (is jq installed?)"; return 0; }
+
+  STATUS_JSON="$doc" docker exec -i -e STATUS_JSON "$MONGO_CONTAINER" \
+    mongosh "$MONGO_DB" --quiet --eval '
+      const s = JSON.parse(process.env.STATUS_JSON);
+      s._id = "latest";
+      s.lastRunAt = s.lastRunAt ? new Date(s.lastRunAt) : new Date();
+      s.latestSnapshotTime = s.latestSnapshotTime ? new Date(s.latestSnapshotTime) : null;
+      db.backupstatuses.replaceOne({ _id: "latest" }, s, { upsert: true });
+    ' >/dev/null 2>&1 || log "warning: could not record backup status to Mongo"
 }
 
 on_err() {

--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -37,10 +37,36 @@ log() { echo "[backup] $(date -Is) $*"; }
 ping_fail() {
   [ -n "$HEALTHCHECK_URL" ] && curl -fsS -m 10 --retry 3 "${HEALTHCHECK_URL%/}/fail" >/dev/null 2>&1 || true
 }
-trap 'ping_fail' ERR
+
+# Write a one-document status report into Mongo so SuperAdmin can show backup
+# health (the app reads this; it never touches the repo). Scalars only. Needs jq.
+record_status() {
+  local status="$1" err="${2:-}" now count latest size latestJs errClean
+  now="$(date -Is)"
+  count="$(restic snapshots --json 2>/dev/null | jq 'length' 2>/dev/null || echo null)"
+  latest="$(restic snapshots --json 2>/dev/null | jq -r 'sort_by(.time)|last|.time // empty' 2>/dev/null || echo '')"
+  size="$(restic stats --json --mode raw-data 2>/dev/null | jq '.total_size // null' 2>/dev/null || echo null)"
+  latestJs="null"; [ -n "$latest" ] && latestJs="new Date('$latest')"
+  errClean="$(printf '%s' "$err" | tr -d "'\"\\\\" | head -c 300)"
+  docker exec -i "$MONGO_CONTAINER" mongosh "$MONGO_DB" --quiet --eval "
+    db.backupstatuses.replaceOne({ _id: 'latest' }, {
+      _id: 'latest', status: '$status', lastRunAt: new Date('$now'),
+      durationSec: ${SECONDS}, snapshotCount: ${count:-null},
+      latestSnapshotTime: ${latestJs}, repoSizeBytes: ${size:-null},
+      host: '$(hostname | tr -d "'")', repo: '$(printf '%s' "$RESTIC_REPOSITORY" | tr -d "'")',
+      error: '$errClean'
+    }, { upsert: true });
+  " >/dev/null 2>&1 || log "warning: could not record backup status to Mongo"
+}
+
+on_err() {
+  trap - ERR   # prevent re-entry if a call below also fails
+  record_status failed "backup.sh failed — check the backup log"
+  ping_fail
+}
 
 STAGE="$(mktemp -d)"
-trap 'rm -rf "$STAGE"; ping_fail' ERR
+trap 'on_err' ERR
 trap 'rm -rf "$STAGE"' EXIT
 
 log "dumping MongoDB '$MONGO_DB' from $MONGO_CONTAINER…"
@@ -71,6 +97,9 @@ if [ -n "${B2_RESTIC_REPOSITORY:-}" ]; then
   restic -r "$B2_RESTIC_REPOSITORY" copy --from-repo "$RESTIC_REPOSITORY" --tag cellarion
   restic -r "$B2_RESTIC_REPOSITORY" forget --tag cellarion --keep-daily "$KEEP_DAILY" --keep-weekly "$KEEP_WEEKLY" --keep-monthly "$KEEP_MONTHLY" --prune
 fi
+
+log "recording status for SuperAdmin…"
+record_status ok
 
 log "backup complete."
 [ -n "$HEALTHCHECK_URL" ] && curl -fsS -m 10 --retry 3 "${HEALTHCHECK_URL%/}" >/dev/null 2>&1 || true

--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Nightly backup of Cellarion's irreplaceable data to a restic repository
+# (e.g. a Hetzner Storage Box over SFTP): the MongoDB dump AND the uploaded
+# images (which live on disk in /app/uploads, NOT in Mongo). restic encrypts,
+# deduplicates and retains. Meilisearch/Qdrant are intentionally skipped — the
+# app rebuilds them from Mongo.
+#
+# Usage:  ./backup.sh            (reads ./backup.env)
+#         BACKUP_ENV=/path/env ./backup.sh
+# Run it from cron/systemd on the VM host — see docs/backup.md.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${BACKUP_ENV:-$SCRIPT_DIR/backup.env}"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "[backup] Missing config: $ENV_FILE — copy backup.env.example and fill it in." >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+: "${RESTIC_REPOSITORY:?set RESTIC_REPOSITORY in $ENV_FILE}"
+: "${RESTIC_PASSWORD:?set RESTIC_PASSWORD in $ENV_FILE}"
+export RESTIC_REPOSITORY RESTIC_PASSWORD
+
+MONGO_CONTAINER="${MONGO_CONTAINER:-cellarion-mongo}"
+BACKEND_CONTAINER="${BACKEND_CONTAINER:-cellarion-backend}"
+MONGO_DB="${MONGO_DB:-winecellar}"
+KEEP_DAILY="${KEEP_DAILY:-7}"
+KEEP_WEEKLY="${KEEP_WEEKLY:-4}"
+KEEP_MONTHLY="${KEEP_MONTHLY:-6}"
+HEALTHCHECK_URL="${HEALTHCHECK_URL:-}"
+
+log() { echo "[backup] $(date -Is) $*"; }
+ping_fail() {
+  [ -n "$HEALTHCHECK_URL" ] && curl -fsS -m 10 --retry 3 "${HEALTHCHECK_URL%/}/fail" >/dev/null 2>&1 || true
+}
+trap 'ping_fail' ERR
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"; ping_fail' ERR
+trap 'rm -rf "$STAGE"' EXIT
+
+log "dumping MongoDB '$MONGO_DB' from $MONGO_CONTAINER…"
+mkdir -p "$STAGE/mongo" "$STAGE/uploads"
+docker exec "$MONGO_CONTAINER" mongodump --db "$MONGO_DB" --archive --gzip > "$STAGE/mongo/$MONGO_DB.archive.gz"
+
+log "copying uploaded images from $BACKEND_CONTAINER:/app/uploads…"
+# Copy as plain files (not a single tarball) so restic deduplicates unchanged
+# images across runs — only new/changed photos are uploaded each night.
+docker cp "$BACKEND_CONTAINER:/app/uploads/." "$STAGE/uploads/"
+
+log "ensuring restic repository exists…"
+restic snapshots >/dev/null 2>&1 || restic init
+
+log "uploading encrypted snapshot to $RESTIC_REPOSITORY…"
+restic backup --tag cellarion --host cellarion "$STAGE"
+
+log "pruning (keep ${KEEP_DAILY}d / ${KEEP_WEEKLY}w / ${KEEP_MONTHLY}m)…"
+restic forget --tag cellarion --keep-daily "$KEEP_DAILY" --keep-weekly "$KEEP_WEEKLY" --keep-monthly "$KEEP_MONTHLY" --prune
+
+# Optional second, off-provider copy (e.g. Backblaze B2) so a Hetzner-account
+# level loss can't wipe everything. Enable by setting B2_* in backup.env.
+if [ -n "${B2_RESTIC_REPOSITORY:-}" ]; then
+  export B2_ACCOUNT_ID="${B2_ACCOUNT_ID:-}" B2_ACCOUNT_KEY="${B2_ACCOUNT_KEY:-}"
+  log "copying snapshots to off-provider repo $B2_RESTIC_REPOSITORY…"
+  restic -r "$B2_RESTIC_REPOSITORY" snapshots >/dev/null 2>&1 \
+    || restic -r "$B2_RESTIC_REPOSITORY" init --copy-chunker-params --from-repo "$RESTIC_REPOSITORY"
+  restic -r "$B2_RESTIC_REPOSITORY" copy --from-repo "$RESTIC_REPOSITORY" --tag cellarion
+  restic -r "$B2_RESTIC_REPOSITORY" forget --tag cellarion --keep-daily "$KEEP_DAILY" --keep-weekly "$KEEP_WEEKLY" --keep-monthly "$KEEP_MONTHLY" --prune
+fi
+
+log "backup complete."
+[ -n "$HEALTHCHECK_URL" ] && curl -fsS -m 10 --retry 3 "${HEALTHCHECK_URL%/}" >/dev/null 2>&1 || true

--- a/scripts/backup/check.sh
+++ b/scripts/backup/check.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Weekly integrity check of the restic backup repository — catches silent
+# bit-rot / corruption before you need the backups. Run by the
+# cellarion-backup-check.timer (see systemd/). Pings HEALTHCHECK_CHECK_URL
+# (if set) so a failed check alerts you.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${BACKUP_ENV:-$SCRIPT_DIR/backup.env}"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "[check] Missing config: $ENV_FILE" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+: "${RESTIC_REPOSITORY:?set RESTIC_REPOSITORY in $ENV_FILE}"
+: "${RESTIC_PASSWORD:?set RESTIC_PASSWORD in $ENV_FILE}"
+export RESTIC_REPOSITORY RESTIC_PASSWORD
+HEALTHCHECK_CHECK_URL="${HEALTHCHECK_CHECK_URL:-}"
+
+echo "[check] $(date -Is) verifying repository (metadata + 5% of data)…"
+if restic check --read-data-subset=5%; then
+  echo "[check] repository OK"
+  [ -n "$HEALTHCHECK_CHECK_URL" ] && curl -fsS -m 10 --retry 3 "${HEALTHCHECK_CHECK_URL%/}" >/dev/null 2>&1 || true
+else
+  rc=$?
+  echo "[check] repository check FAILED (exit $rc)" >&2
+  [ -n "$HEALTHCHECK_CHECK_URL" ] && curl -fsS -m 10 --retry 3 "${HEALTHCHECK_CHECK_URL%/}/fail" >/dev/null 2>&1 || true
+  exit "$rc"
+fi

--- a/scripts/backup/restore.sh
+++ b/scripts/backup/restore.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Restore Cellarion's MongoDB + uploaded images from a restic snapshot.
+# DESTRUCTIVE: replaces the current database (mongorestore --drop) and copies
+# the snapshot's images back into the backend container.
+#
+# Usage:  ./restore.sh [snapshotID|latest]
+# Run a DRILL of this periodically — an untested backup is not a backup.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${BACKUP_ENV:-$SCRIPT_DIR/backup.env}"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "[restore] Missing config: $ENV_FILE" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+: "${RESTIC_REPOSITORY:?set RESTIC_REPOSITORY in $ENV_FILE}"
+: "${RESTIC_PASSWORD:?set RESTIC_PASSWORD in $ENV_FILE}"
+export RESTIC_REPOSITORY RESTIC_PASSWORD
+
+MONGO_CONTAINER="${MONGO_CONTAINER:-cellarion-mongo}"
+BACKEND_CONTAINER="${BACKEND_CONTAINER:-cellarion-backend}"
+MONGO_DB="${MONGO_DB:-winecellar}"
+SNAPSHOT="${1:-latest}"
+
+echo "About to RESTORE snapshot '$SNAPSHOT' from $RESTIC_REPOSITORY."
+echo "This DROPS and reloads the '$MONGO_DB' database and overwrites uploaded images."
+read -rp "Type 'restore' to proceed: " confirm
+[ "$confirm" = "restore" ] || { echo "Aborted."; exit 1; }
+
+DEST="$(mktemp -d)"
+trap 'rm -rf "$DEST"' EXIT
+
+echo "[restore] fetching snapshot $SNAPSHOT…"
+restic restore "$SNAPSHOT" --target "$DEST"
+
+ARCHIVE="$(find "$DEST" -name "$MONGO_DB.archive.gz" | head -1)"
+UPLOADS_DIR="$(find "$DEST" -type d -name uploads | head -1)"
+[ -n "$ARCHIVE" ] || { echo "[restore] mongo archive not found in snapshot" >&2; exit 1; }
+
+echo "[restore] restoring MongoDB (drop + reload)…"
+docker exec -i "$MONGO_CONTAINER" mongorestore --archive --gzip --drop < "$ARCHIVE"
+
+if [ -n "$UPLOADS_DIR" ] && [ -n "$(ls -A "$UPLOADS_DIR" 2>/dev/null)" ]; then
+  echo "[restore] restoring uploaded images…"
+  docker cp "$UPLOADS_DIR/." "$BACKEND_CONTAINER:/app/uploads/"
+fi
+
+echo "[restore] done."
+echo "Next: Meilisearch and Qdrant rebuild from Mongo — restart the backend"
+echo "(docker compose restart backend) so search/AI indexes re-sync."

--- a/scripts/backup/systemd/cellarion-backup-check.service
+++ b/scripts/backup/systemd/cellarion-backup-check.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Cellarion weekly backup integrity check (restic check)
+Documentation=https://github.com/jagduvi1/Cellarion/blob/main/docs/backup.md
+After=docker.service
+
+[Service]
+Type=oneshot
+# --- EDIT THIS PATH --- must match cellarion-backup.service.
+WorkingDirectory=/opt/cellarion/scripts/backup
+ExecStart=/opt/cellarion/scripts/backup/check.sh
+User=root
+TimeoutStartSec=2h
+Nice=15
+IOSchedulingClass=idle

--- a/scripts/backup/systemd/cellarion-backup-check.timer
+++ b/scripts/backup/systemd/cellarion-backup-check.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly Cellarion backup integrity check
+
+[Timer]
+# Sundays at 04:30 local time (after the nightly backup has run).
+OnCalendar=Sun *-*-* 04:30:00
+RandomizedDelaySec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/backup/systemd/cellarion-backup.service
+++ b/scripts/backup/systemd/cellarion-backup.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Cellarion nightly backup (MongoDB + uploaded images -> restic/Storage Box)
+Documentation=https://github.com/jagduvi1/Cellarion/blob/main/docs/backup.md
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# --- EDIT THIS PATH --- to wherever you checked out Cellarion on the VM.
+# (The same path appears in cellarion-backup-check.service.)
+WorkingDirectory=/opt/cellarion/scripts/backup
+ExecStart=/opt/cellarion/scripts/backup/backup.sh
+# backup.sh runs `docker exec`, so it needs Docker access. Root is simplest;
+# alternatively set this to a user that is a member of the `docker` group.
+User=root
+# Don't let a slow upload hang forever — fail (and alert) after 2h instead.
+TimeoutStartSec=2h
+Nice=10
+IOSchedulingClass=idle

--- a/scripts/backup/systemd/cellarion-backup.timer
+++ b/scripts/backup/systemd/cellarion-backup.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run the Cellarion backup nightly
+
+[Timer]
+# Every night at 03:30 local time.
+OnCalendar=*-*-* 03:30:00
+# Spread load / avoid the exact-minute thundering herd.
+RandomizedDelaySec=15min
+# If the VM was off at 03:30, run as soon as it's back up (don't skip a day).
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Adds backup/restore tooling so a server loss isn't catastrophic. Backs up the **two** irreplaceable stores — **MongoDB** *and* the **uploaded images** in `/app/uploads` (which live on disk, **not** in Mongo, so a DB-only backup would lose every photo) — to a [restic](https://restic.net) repository: **encrypted, deduplicated, retained**, on a **Hetzner Storage Box** over SFTP, with an optional off-provider second copy (Backblaze B2) for true 3-2-1.

## What's included (`scripts/backup/` + `docs/backup.md`)
- **`backup.sh`** — `mongodump` + copy `/app/uploads` → `restic backup` → `forget --prune` (7 daily / 4 weekly / 6 monthly). Pings a healthcheck URL on success and `…/fail` on error so a broken backup *alerts* you.
- **`restore.sh`** — `restic restore` → `mongorestore --drop` + copy images back; reminds you to restart the backend so Meilisearch/Qdrant re-index.
- **`backup.env.example`** — config template. Real `backup.env` is gitignored (via `*.env`); the `RESTIC_PASSWORD` (the only decryption key) is documented to be stored off-server.
- **`docs/backup.md`** — Hetzner Storage Box SSH/SFTP setup, cron/systemd schedule, healthchecks.io alerting, restore **drill**, weekly `restic check`, optional B2 second copy, and the "Hetzner Cloud Backups as a bonus, not a substitute" note.
- **`.gitattributes`** — `*.sh text eol=lf` so the scripts always check out with LF on the Linux VM.

## Decisions (documented)
- **Meilisearch/Qdrant not backed up** — the app rebuilds them from Mongo.
- **No PITR** — standalone `mongod` (no replica set/oplog), so daily logical dumps (up-to-24h RPO). Noted in docs; a replica set or Atlas is the upgrade path if tighter RPO is needed.
- These run **on the VM** (verified `mongodump`/`mongorestore` exist in the `mongo:7` container; restic runs on the host).

## Testing
`bash -n` clean on both scripts; `backup.env` confirmed git-ignored; example committable. (Live run happens on the VM with the Storage Box creds.)