### PR TITLE
chore(release): v1.56.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.55.8",
+  "version": "1.56.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.55.8",
+  "version": "1.56.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Release v1.56.0 — GDPR hardening, audit remediation, admin wine tooling & backups

Bumps `backend` + `frontend` to **1.56.0**. Covers the 13 commits merged to `main` since v1.55.8.

### Highlights
**Backups (new)**
- #470 restic backup + restore for MongoDB **and** uploaded images, host-isolated systemd timers (nightly + weekly integrity check), SuperAdmin → **Backups** tab with OK/STALE/FAILED alarm.

**Admin — wine tooling**
- #460 side-by-side compare-and-edit for duplicate clusters
- #468 golden-record wine merge — transposed compare, compose, pick image
- #469 wine-list UX overhaul — drawer edit, toasts, empty/error states, pagination

**GDPR**
- #464 single user-data registry driving erasure + export (anti-drift)
- #467 complete erasure — anonymize reviews/recs, keep recipient data, clean contributor refs

**Code-audit remediation**
- #461 three high-severity bug fixes
- #462 audit quick-wins + resilient large-import AI handling (1000+ bottles ride out rate limits)
- #463 batch 3 — resource limits, Stripe idempotency, refresh-token lifetime
- #465 batch 4 — total validation helpers, close validation gaps
- #466 batch 4 — asyncHandler wrapper, close unhandled-rejection gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)