### PR TITLE
feat: group identical cellar bottles + audit security-event filter

### DIFF
--- a/backend/src/routes/admin/audit.js
+++ b/backend/src/routes/admin/audit.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { requireAuth, requireRole } = require('../../middleware/auth');
 const AuditLog = require('../../models/AuditLog');
 const { parsePagination } = require('../../utils/pagination');
+const { SECURITY_EVENT_ACTIONS } = require('../../services/securityAlertJob');
 
 const router = express.Router();
 
@@ -12,12 +13,18 @@ router.use(requireAuth, requireRole('admin'));
 // GET /api/admin/audit - Full audit log with filtering and pagination
 router.get('/', async (req, res) => {
   try {
-    const { action, userId, from, to } = req.query;
+    const { action, userId, from, to, security } = req.query;
     const { limit, offset, page } = parsePagination(req.query, { limit: 50, maxLimit: 200 });
 
     const filter = {};
 
-    if (action) {
+    // `security=1` restricts to the exact set of security-relevant actions that
+    // drive the SuperAdmin nav badge (failed logins, account lockouts, rate-limit
+    // hits). Single source of truth: SECURITY_EVENT_ACTIONS. Takes precedence
+    // over the free-text `action` filter so the toggle is unambiguous.
+    if (security === '1' || security === 'true') {
+      filter.action = { $in: SECURITY_EVENT_ACTIONS };
+    } else if (action) {
       if (typeof action !== 'string' || !/^[\w.]+$/.test(action)) {
         return res.status(400).json({ error: 'Invalid action filter' });
       }

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -436,6 +436,12 @@ router.get('/:id', async (req, res) => {
     // Pagination — default 30, max 200; skip defaults to 0
     const { limit, offset: skip } = parsePagination(req.query, { limit: 30, maxLimit: 200 });
 
+    // Optional grouping: collapse identical bottles (same wine + same vintage)
+    // into one entry. Paginates over GROUPS and nests the member bottles so the
+    // client can expand ("split") a group without another request. Opt-in via
+    // ?group=1 so existing callers (add-bottle exclude flow, etc.) are unaffected.
+    const grouped = req.query.group === '1' || req.query.group === 'true';
+
     const { isValidObjectId } = mongoose;
     const sortField = sort.startsWith('-') ? sort.substring(1) : sort;
     const sortDir = sort.startsWith('-') ? -1 : 1;
@@ -556,7 +562,9 @@ router.get('/:id', async (req, res) => {
       const canSortInDb_ = directSortFields.includes(sortField);
       const needsInMemoryFilter = !!(search || minRating || maxRating || maturityFilter);
       const needsInMemorySort = !canSortInDb_;
-      canPaginateInDb = !needsInMemoryFilter && !needsInMemorySort;
+      // Grouping needs every matching bottle in memory before it can collapse
+      // duplicates, so it disables DB-level pagination.
+      canPaginateInDb = !needsInMemoryFilter && !needsInMemorySort && !grouped;
 
       let query = Bottle.find(filter).populate(WINE_POPULATE);
       if (canSortInDb_) query = query.sort({ [sortField]: sortDir });
@@ -653,8 +661,28 @@ router.get('/:id', async (req, res) => {
       }
     }
 
-    // Paginate (for paths that didn't paginate in DB)
-    if (!canPaginateInDb) {
+    // Group identical bottles (same wine + vintage), or paginate normally.
+    // `bottles` is fully filtered + sorted here; grouping preserves that order.
+    let groupsForPage = null;
+    if (grouped) {
+      const groupMap = new Map();
+      const order = [];
+      for (const b of bottles) {
+        const wineId = b.wineDefinition?._id
+          ? b.wineDefinition._id.toString()
+          : (b.wineDefinition ? b.wineDefinition.toString() : `none:${b._id}`);
+        // Group by wine + vintage + bottle size, so a magnum and a 750ml of the
+        // same wine/vintage stay as separate groups.
+        const key = `${wineId}::${b.vintage || 'NV'}::${b.bottleSize || '750ml'}`;
+        let arr = groupMap.get(key);
+        if (!arr) { arr = []; groupMap.set(key, arr); order.push(key); }
+        arr.push(b);
+      }
+      totalCount = order.length;                      // total = number of groups
+      const pageKeys = order.slice(skip, skip + limit);
+      groupsForPage = pageKeys.map(key => ({ key, bottles: groupMap.get(key) }));
+      bottles = groupsForPage.flatMap(g => g.bottles); // flatten so image attach below works
+    } else if (!canPaginateInDb) {
       totalCount = bottles.length;
       bottles = bottles.slice(skip, skip + limit);
     }
@@ -694,6 +722,17 @@ router.get('/:id', async (req, res) => {
       defaultImageUrl: b.defaultImage ? (defaultImageMap[b.defaultImage.toString()] || null) : null,
       ...(maturityStatusMap ? { maturityStatus: maturityStatusMap.get(b._id.toString()) || null } : {})
     }));
+
+    // When grouping, re-nest the image-resolved bottles into their groups so the
+    // response is one entry per (wine + vintage) carrying its member bottles.
+    let responseItems = bottleItems;
+    if (grouped && groupsForPage) {
+      const itemById = new Map(bottleItems.map(it => [it._id.toString(), it]));
+      responseItems = groupsForPage.map(g => {
+        const members = g.bottles.map(b => itemById.get(b._id.toString())).filter(Boolean);
+        return { key: g.key, count: members.length, bottles: members };
+      });
+    }
 
     // ── Facets: two queries for smart cascading ──
     // 1. baseFacets: unfiltered — shows ALL options so users can always add more selections
@@ -766,10 +805,11 @@ router.get('/:id', async (req, res) => {
       cellar: { ...cellar, userRole: role, userColor: getUserColor(cellar, req.user.id) },
       bottles: {
         total: totalCount,
-        count: bottleItems.length,
+        count: responseItems.length,
         limit,
         skip,
-        items: bottleItems
+        grouped,
+        items: responseItems
       },
       ...(facets ? { facets, baseFacets, facetMeta } : {})
     });

--- a/frontend/src/components/BottleCard.css
+++ b/frontend/src/components/BottleCard.css
@@ -200,6 +200,7 @@
 
 /* ── Card grid-mode ── */
 .bottle-grid-card {
+  position: relative;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -287,4 +288,51 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* ── Grouped identical bottles (same wine + vintage) ── */
+/* Count badge — overlaid (card grid) and inline (list). */
+.bottle-count-badge {
+  position: absolute;
+  top: 0.4rem;
+  left: 0.4rem;
+  z-index: 2;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--radius-full);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+.bottle-count-pill {
+  display: inline-block;
+  margin-left: 0.4rem;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.02rem 0.4rem;
+  border-radius: var(--radius-full);
+  vertical-align: middle;
+}
+/* "Stacked" shadow so a collapsed group reads as several bottles. box-shadow
+   isn't affected by overflow:hidden, so this survives the card clipping. */
+.bottle-grid-card--stacked {
+  box-shadow:
+    3px 3px 0 0 var(--color-surface), 3px 3px 0 1px var(--color-border),
+    6px 6px 0 0 var(--color-surface), 6px 6px 0 1px var(--color-border),
+    var(--shadow-card);
+}
+.bottle-grid-card--stacked:hover {
+  box-shadow:
+    3px 3px 0 0 var(--color-surface), 3px 3px 0 1px var(--color-border),
+    6px 6px 0 0 var(--color-surface), 6px 6px 0 1px var(--color-border),
+    var(--shadow-card-hover);
+}
+.bottle-card--stacked {
+  box-shadow:
+    2px 2px 0 0 var(--color-surface), 2px 2px 0 1px var(--color-border),
+    4px 4px 0 0 var(--color-surface), 4px 4px 0 1px var(--color-border),
+    var(--shadow-sm);
 }

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -17,11 +17,14 @@ const MATURITY_LABELS = {
  * Renders a single bottle in either list or card (grid) view.
  * Props: bottle, rackMap, cellarId, viewMode ('list' | 'card')
  */
-function BottleCard({ bottle, rackMap, cellarId, viewMode }) {
+function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const rackInfo = rackMap.get(bottle._id);
+  const isGroup = groupCount > 1;
+  // A collapsed group spans multiple bottles (possibly in different racks), so a
+  // single rack badge would be misleading — suppress it until the group expands.
+  const rackInfo = isGroup ? null : rackMap?.get(bottle._id);
   const rackNavPref = user?.preferences?.rackNavigation || 'auto';
   const imgSrc = bottle.defaultImageUrl || bottle.wineDefinition?.image || bottle.pendingImageUrl;
   const credit = bottle.defaultImageUrl ? null : bottle.wineDefinition?.imageCredit;
@@ -30,18 +33,21 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode }) {
   const displayProducer = bottle.wineDefinition?.producer || bottle.pendingWineRequest?.producer;
   const maturityInfo = bottle.maturityStatus ? MATURITY_LABELS[bottle.maturityStatus] : null;
 
-  const handleClick = () => navigate(`/cellars/${cellarId}/bottles/${bottle._id}`);
+  // onClick overrides navigation — used to expand a collapsed group instead.
+  const handleClick = onClick || (() => navigate(`/cellars/${cellarId}/bottles/${bottle._id}`));
   const handleKey = e => e.key === 'Enter' && handleClick();
 
   if (viewMode === 'card') {
     return (
       <div
-        className="bottle-grid-card"
+        className={`bottle-grid-card${isGroup ? ' bottle-grid-card--stacked' : ''}`}
         onClick={handleClick}
         role="button"
         tabIndex={0}
         onKeyDown={handleKey}
+        title={isGroup ? `${groupCount} identical bottles — click to expand` : undefined}
       >
+        {isGroup && <span className="bottle-count-badge">×{groupCount}</span>}
         <div className="bottle-grid-image-wrap">
           {imgSrc ? (
             <>
@@ -95,11 +101,12 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode }) {
   // list view (default)
   return (
     <div
-      className="bottle-card"
+      className={`bottle-card${isGroup ? ' bottle-card--stacked' : ''}`}
       onClick={handleClick}
       role="button"
       tabIndex={0}
       onKeyDown={handleKey}
+      title={isGroup ? `${groupCount} identical bottles — click to expand` : undefined}
     >
       {imgSrc ? (
         <div className="bottle-img-wrap">
@@ -117,7 +124,10 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode }) {
       )}
 
       <div className="bottle-info">
-        <div className="bottle-name">{displayName}</div>
+        <div className="bottle-name">
+          {displayName}
+          {isGroup && <span className="bottle-count-pill">×{groupCount}</span>}
+        </div>
         <div className="bottle-meta">
           <span className="bottle-producer">{displayProducer}</span>
           {bottle.vintage && <span className="bottle-vintage">{bottle.vintage}</span>}
@@ -144,7 +154,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode }) {
         </div>
       </div>
 
-      <span className="bottle-chevron" aria-hidden="true">›</span>
+      <span className="bottle-chevron" aria-hidden="true">{isGroup ? '⊕' : '›'}</span>
     </div>
   );
 }

--- a/frontend/src/pages/CellarDetail.css
+++ b/frontend/src/pages/CellarDetail.css
@@ -632,6 +632,62 @@
   background: var(--color-primary-light);
 }
 
+/* ── Group-identical toggle (sits left of the view toggles) ── */
+.group-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  height: 32px;
+  padding: 0 0.6rem;
+  margin-right: auto;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  font-family: var(--font-body);
+  transition: border-color var(--transition-fast), color var(--transition-fast);
+}
+.group-toggle-btn:hover {
+  border-color: var(--color-text-secondary);
+  color: var(--color-text-secondary);
+}
+.group-toggle-btn.active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+/* ── Expanded bottle-group header (full-width across the grid/list) ── */
+.bottle-group-bar {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-primary-light);
+  border-left: 3px solid var(--color-primary);
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+.bottle-group-collapse {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.2rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  font-family: var(--font-body);
+  color: var(--color-text);
+}
+.bottle-group-collapse:hover {
+  background: var(--color-primary-light);
+}
+
 /* ── Image credit tooltip ── */
 .bottle-img-wrap,
 .bottle-grid-image-wrap {

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, lazy, Suspense } from 'react';
+import { useState, useEffect, useRef, lazy, Suspense, Fragment } from 'react';
 import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -54,6 +54,12 @@ function CellarDetail() {
   const [facets, setFacets] = useState(null);
   const [baseFacets, setBaseFacets] = useState(null);
   const [facetMeta, setFacetMeta] = useState(null);
+  // Collapse identical bottles (same wine + vintage) into one card. Defaults on;
+  // persisted per browser. Server-side grouped (see ?group=1) so counts are
+  // correct across pagination.
+  const [grouped, setGrouped] = useState(() => {
+    try { return localStorage.getItem('cellarion_bottle_group') !== '0'; } catch { return true; }
+  });
 
   // Debounce the search input — only send the API call after the user stops typing
   const [debouncedSearch, setDebouncedSearch] = useState(filters.search);
@@ -81,7 +87,7 @@ function CellarDetail() {
 
   useEffect(() => {
     fetchCellarData(0);
-  }, [id, filterKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, filterKey, grouped]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     fetchStatistics();
@@ -105,6 +111,7 @@ function CellarDetail() {
       });
       params.set('limit', BOTTLES_PER_PAGE);
       params.set('skip', skip);
+      if (grouped) params.set('group', '1');
       const res = await getCellar(apiFetch, id, params);
       const data = await res.json();
       if (res.ok) {
@@ -131,6 +138,14 @@ function CellarDetail() {
   };
 
   const loadMore = () => fetchCellarData(bottles.length);
+
+  const toggleGrouped = () => {
+    setGrouped(g => {
+      const next = !g;
+      try { localStorage.setItem('cellarion_bottle_group', next ? '1' : '0'); } catch {}
+      return next;
+    });
+  };
 
   const fetchStatistics = async () => {
     try {
@@ -581,6 +596,8 @@ function CellarDetail() {
               hasMore={bottles.length < bottlesTotal}
               loadingMore={bottlesLoading}
               onLoadMore={loadMore}
+              grouped={grouped}
+              onToggleGrouped={toggleGrouped}
             />
           )}
         </div>
@@ -636,20 +653,38 @@ function CellarDetail() {
 }
 
 // ── Bottle list (list or card view) ──
-function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore }) {
+function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore, grouped, onToggleGrouped }) {
   const { t } = useTranslation();
   const [viewMode, setViewMode] = useState(() => {
     try { return localStorage.getItem('cellarion_bottle_view') || 'list'; } catch { return 'list'; }
   });
+  const [expandedGroups, setExpandedGroups] = useState(() => new Set());
 
   const setView = (mode) => {
     setViewMode(mode);
     try { localStorage.setItem('cellarion_bottle_view', mode); } catch {}
   };
 
+  const toggleGroup = (key) => {
+    setExpandedGroups(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
   return (
     <>
       <div className="bottles-view-toggle">
+        <button
+          type="button"
+          className={`group-toggle-btn ${grouped ? 'active' : ''}`}
+          onClick={onToggleGrouped}
+          title="Group identical bottles (same wine & vintage) into one card"
+          aria-pressed={grouped}
+        >
+          {grouped ? '▣ Grouped' : '▢ Group'}
+        </button>
         <button
           className={`view-toggle-btn ${viewMode === 'list' ? 'active' : ''}`}
           onClick={() => setView('list')}
@@ -669,15 +704,48 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
       </div>
 
       <div className={viewMode === 'list' ? 'bottles-list' : 'bottles-grid'}>
-        {bottles.map(bottle => (
-          <BottleCard
-            key={bottle._id}
-            bottle={bottle}
-            rackMap={rackMap}
-            cellarId={cellarId}
-            viewMode={viewMode}
-          />
-        ))}
+        {bottles.map(item => {
+          // Grouped response: item = { key, count, bottles: [...] }
+          if (grouped && item && Array.isArray(item.bottles)) {
+            const rep = item.bottles[0];
+            if (item.count === 1) {
+              return (
+                <BottleCard key={rep._id} bottle={rep} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} />
+              );
+            }
+            if (!expandedGroups.has(item.key)) {
+              return (
+                <BottleCard
+                  key={item.key}
+                  bottle={rep}
+                  rackMap={rackMap}
+                  cellarId={cellarId}
+                  viewMode={viewMode}
+                  groupCount={item.count}
+                  onClick={() => toggleGroup(item.key)}
+                />
+              );
+            }
+            const wineName = rep.wineDefinition?.name || rep.pendingWineRequest?.wineName || 'Unknown Wine';
+            return (
+              <Fragment key={item.key}>
+                <div className="bottle-group-bar">
+                  <span><strong>{wineName}</strong> · {rep.vintage || 'NV'} · {item.count} bottles</span>
+                  <button type="button" className="bottle-group-collapse" onClick={() => toggleGroup(item.key)}>
+                    Collapse ▲
+                  </button>
+                </div>
+                {item.bottles.map(b => (
+                  <BottleCard key={b._id} bottle={b} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} />
+                ))}
+              </Fragment>
+            );
+          }
+          // Ungrouped response: item = bottle
+          return (
+            <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} />
+          );
+        })}
       </div>
 
       {hasMore && (

--- a/frontend/src/pages/SuperAdmin/TabAudit.js
+++ b/frontend/src/pages/SuperAdmin/TabAudit.js
@@ -16,22 +16,35 @@ const ACTION_OPTIONS = [
   'superadmin.access',
 ];
 
+// Security-relevant actions — keep in sync with SECURITY_EVENT_ACTIONS on the
+// backend (services/securityAlertJob.js). Drives the "Security events only"
+// toggle and highlights these rows in the table.
+const SECURITY_ACTIONS = new Set([
+  'system.rate_limit_exceeded',
+  'auth.account_locked',
+  'auth.login.failed',
+]);
+
 export default function TabAudit() {
   const { apiFetch } = useAuth();
   const [actionFilter, setActionFilter] = useState('');
   const [fromDate, setFromDate] = useState('');
   const [toDate, setToDate] = useState('');
+  const [securityOnly, setSecurityOnly] = useState(false);
   const [page, setPage] = useState(0);
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const load = useCallback(async (action, from, to, p) => {
+  const load = useCallback(async (action, from, to, p, secOnly) => {
     setLoading(true);
     setError(null);
     try {
       const params = new URLSearchParams({ limit: PAGE_SIZE, offset: p * PAGE_SIZE });
-      if (action) params.set('action', action);
+      // Security toggle overrides the action filter (backend ignores `action`
+      // when `security=1`), so don't send both.
+      if (secOnly) params.set('security', '1');
+      else if (action) params.set('action', action);
       if (from)   params.set('from', from);
       if (to)     params.set('to', to);
       const res = await apiFetch(`/api/admin/audit?${params}`);
@@ -47,31 +60,49 @@ export default function TabAudit() {
     }
   }, [apiFetch]);
 
-  useEffect(() => { load(actionFilter, fromDate, toDate, page); }, [page]); // eslint-disable-line
+  useEffect(() => { load(actionFilter, fromDate, toDate, page, securityOnly); }, [page]); // eslint-disable-line
 
   const handleSearch = (e) => {
     e.preventDefault();
     setPage(0);
-    load(actionFilter, fromDate, toDate, 0);
+    load(actionFilter, fromDate, toDate, 0, securityOnly);
+  };
+
+  const toggleSecurity = () => {
+    const next = !securityOnly;
+    setSecurityOnly(next);
+    setPage(0);
+    load(actionFilter, fromDate, toDate, 0, next);
   };
 
   const clearFilters = () => {
     setActionFilter('');
     setFromDate('');
     setToDate('');
+    setSecurityOnly(false);
     setPage(0);
-    load('', '', '', 0);
+    load('', '', '', 0, false);
   };
 
-  const hasFilters = actionFilter || fromDate || toDate;
+  const hasFilters = actionFilter || fromDate || toDate || securityOnly;
 
   return (
     <>
       <form className="sa-filter-row" onSubmit={handleSearch}>
+        <button
+          type="button"
+          className={`sa-btn ${securityOnly ? 'active' : ''}`}
+          onClick={toggleSecurity}
+          title="Show only failed logins, account lockouts and rate-limit hits"
+        >
+          {securityOnly ? '🛡 Security only: ON' : '🛡 Security events only'}
+        </button>
         <select
           className="sa-input"
-          style={{ width: 'auto' }}
+          style={{ width: 'auto', opacity: securityOnly ? 0.5 : 1 }}
           value={actionFilter}
+          disabled={securityOnly}
+          title={securityOnly ? 'Disabled while “Security events only” is on' : undefined}
           onChange={e => setActionFilter(e.target.value)}
         >
           <option value="">All actions</option>
@@ -125,10 +156,14 @@ export default function TabAudit() {
                   </tr>
                 </thead>
                 <tbody>
-                  {(data?.logs || []).map(log => (
-                    <tr key={log._id}>
+                  {(data?.logs || []).map(log => {
+                    const isSecurity = SECURITY_ACTIONS.has(log.action);
+                    return (
+                    <tr key={log._id} style={isSecurity ? { background: 'rgba(192,57,43,0.10)' } : undefined}>
                       <td className="mono">{fmtDate(log.timestamp)}</td>
-                      <td className={`mono ${actionClass(log.action)}`}>{log.action}</td>
+                      <td className={`mono ${actionClass(log.action)}`} style={isSecurity ? { color: 'var(--sa-danger, #c0392b)', fontWeight: 600 } : undefined}>
+                        {isSecurity && '⚠ '}{log.action}
+                      </td>
                       <td className="mono">
                         {log.actor?.userId?.username || log.actor?.userId?.email || '—'}
                         {log.actor?.role && log.actor.role !== 'anonymous' && (
@@ -140,9 +175,10 @@ export default function TabAudit() {
                         {log.detail ? JSON.stringify(log.detail).slice(0, 120) : ''}
                       </td>
                     </tr>
-                  ))}
+                    );
+                  })}
                   {(!data?.logs?.length) && (
-                    <tr><td colSpan={5}><div className="sa-empty">No entries found</div></td></tr>
+                    <tr><td colSpan={5}><div className="sa-empty">{securityOnly ? 'No security events found' : 'No entries found'}</div></td></tr>
                   )}
                 </tbody>
               </table>


### PR DESCRIPTION
## Summary
Two independent UX improvements, tested against imported production data.

### 1. Cellar list — group identical bottles
Bottles with the same **wine + vintage + bottle size** collapse into one card with a **×N** badge; clicking **expands ("splits")** the group into the individual bottles. A **Grouped** toggle (persisted per browser, default on) turns it off.

- **Server-side** (`GET /api/cellars/:id?group=1`): grouping runs *after* all filtering/sorting, then paginates over **groups**, so ×N counts are correct across pagination — even for 1000+ bottle cellars. Each group nests its member bottles so "split" needs no extra request. Existing callers unaffected (opt-in flag).
- Collapsed groups suppress the rack badge (members may live in different racks); expand to see each bottle's rack.

### 2. Audit log — security-event filter
- `GET /api/admin/audit?security=1` restricts to the exact `SECURITY_EVENT_ACTIONS` set behind the SuperAdmin badge (failed logins, account lockouts, rate-limit hits) — **single source of truth**, so the filter and the red badge count can't drift.
- Audit tab: **🛡 Security events only** toggle; those rows highlighted red with ⚠ even in the unfiltered list.

## Verification
- Real data: **474 bottles → 425 groups**; per group `count == distinct ids == nested length` (no double-count / orphan).
- Access control unaffected (non-owner still 404s).
- Backend **623/623**, frontend **292/292**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)