### PR TITLE
chore(release): v1.56.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Release v1.56.1

Bumps `backend` + `frontend` to **1.56.1**.

### Included
- **#472** Group identical cellar bottles (same wine + vintage + size) into one card with a **×N** badge; click to **split**. Server-side grouping so counts are correct across pagination. Audit log gains a **security-events-only** filter tied to the SuperAdmin badge's action set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)