### PR TITLE
chore(deps): upgrade Meilisearch -> v1.45.1, Qdrant -> v1.18.1; skip reindex on restart

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.47.12",
+  "version": "1.56.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.47.12",
+      "version": "1.56.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "bcryptjs": "^2.4.3",
@@ -21,7 +21,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "mailgun.js": "^12.7.0",
-        "meilisearch": "^0.37.0",
+        "meilisearch": "^0.58.0",
         "mongoose": "^8.0.3",
         "multer": "^2.1.1",
         "node-cron": "^4.2.1",
@@ -78,6 +78,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1285,6 +1286,7 @@
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1991,6 +1993,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2505,15 +2508,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2984,6 +2978,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4789,12 +4784,12 @@
       }
     },
     "node_modules/meilisearch": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.37.0.tgz",
-      "integrity": "sha512-LdbK6JmRghCawrmWKJSEQF0OiE82md+YqJGE/U2JcCD8ROwlhTx0KM6NX4rQt0u0VpV0QZVG9umYiu3CSSIJAQ==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.58.0.tgz",
+      "integrity": "sha512-MXFlU+JVG2I3tDI4brS3UHxEv2fjOROP24TPP16c8dGHTulb1kxMgXvKP0x4ImvUcsVVJFi4QXP0JNDS/TaWaw==",
       "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^3.1.6"
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/memory-pager": {
@@ -5133,48 +5128,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "mailgun.js": "^12.7.0",
-    "meilisearch": "^0.37.0",
+    "meilisearch": "^0.58.0",
     "mongoose": "^8.0.3",
     "multer": "^2.1.1",
     "node-cron": "^4.2.1",

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -1,4 +1,6 @@
-const { MeiliSearch } = require('meilisearch');
+// meilisearch-js v0.50+ renamed the client export `MeiliSearch` → `Meilisearch`.
+// Alias it back to MeiliSearch locally so the rest of this file is unchanged.
+const { Meilisearch: MeiliSearch } = require('meilisearch');
 const WineDefinition = require('../models/WineDefinition');
 const Bottle = require('../models/Bottle');
 const Discussion = require('../models/Discussion');
@@ -94,12 +96,41 @@ async function initialize() {
     isAvailable = true;
     console.log(`Meilisearch connected: ${url}`);
 
-    await fullSync();
-    await fullSyncBottles();
-    await fullSyncDiscussions();
+    // Only do a full sync when an index is actually empty (first boot, or after
+    // the meili-data volume is wiped). Meilisearch persists documents on its
+    // volume, so on a normal restart the data is already there — re-uploading
+    // the whole catalog every boot is wasteful. Live data changes are kept in
+    // sync incrementally by indexWine/indexBottle/indexDiscussion. Set
+    // MEILI_FORCE_REINDEX=1 to force a rebuild (e.g. after a settings change).
+    await syncIfNeeded(index, fullSync, 'wines');
+    await syncIfNeeded(bottlesIndex, fullSyncBottles, 'bottles');
+    await syncIfNeeded(discussionsIndex, fullSyncDiscussions, 'discussions');
   } catch (err) {
     isAvailable = false;
     console.warn(`Meilisearch unavailable (${url}): ${err.message}. Falling back to MongoDB search.`);
+  }
+}
+
+// Run `syncFn` only if `idx` has no documents yet (or a rebuild is forced).
+const FORCE_REINDEX = process.env.MEILI_FORCE_REINDEX === '1' || process.env.MEILI_FORCE_REINDEX === 'true';
+async function syncIfNeeded(idx, syncFn, label) {
+  try {
+    if (FORCE_REINDEX) {
+      console.log(`Meilisearch: MEILI_FORCE_REINDEX set — rebuilding '${label}'`);
+      await syncFn();
+      return;
+    }
+    const stats = await idx.getStats();
+    if (!stats || stats.numberOfDocuments === 0) {
+      console.log(`Meilisearch: '${label}' index empty — running initial sync`);
+      await syncFn();
+    } else {
+      console.log(`Meilisearch: '${label}' already populated (${stats.numberOfDocuments} docs) — skipping sync`);
+    }
+  } catch (err) {
+    // If the stats check fails for any reason, sync to be safe (correctness > speed).
+    console.warn(`Meilisearch: could not check '${label}' stats (${err.message}) — running sync`);
+    await syncFn();
   }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   meilisearch:
-    image: getmeili/meilisearch:v1.6
+    image: getmeili/meilisearch:v1.45.1
     container_name: cellarion-meilisearch
     restart: unless-stopped
     environment:
@@ -36,7 +36,7 @@ services:
       retries: 5
 
   qdrant:
-    image: qdrant/qdrant:v1.9.0
+    image: qdrant/qdrant:v1.18.1
     container_name: cellarion-qdrant
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary
- **Meilisearch** `v1.6` → **`v1.45.1`** (latest 1.x), **Qdrant** `v1.9.0` → **`v1.18.1`** (latest 1.x).
- **meilisearch JS client** `^0.37` → **`^0.58`**. The client renamed its export `MeiliSearch` → `Meilisearch`; aliased back in `search.js` so the rest of the file is untouched.
- **No more full reindex on every restart.** `search.js` now runs `fullSync` only when an index is empty (`syncIfNeeded` via `getStats`). Meili persists on its volume, so a normal restart skips the re-upload. `MEILI_FORCE_REINDEX=1` forces a rebuild. Live edits stay in sync via the existing incremental `indexWine/indexBottle/indexDiscussion`.

## ⚠️ One-time deploy step
The new engines can't read the old on-disk format, so the **`meili-data` and `qdrant-data` volumes must be wiped once** on deploy. Both rebuild from MongoDB (Meili via `fullSync` on boot; Qdrant via the embedding job). **No core data affected** — Mongo + uploaded images are untouched.

## Why these are safe
Both stores are derived/rebuildable from Mongo by design. No `2.0` exists for either project — these are the current latest 1.x.

## Verification (local, on imported prod data)
- Two real breaking changes caught & fixed: the client export rename, and the old-format volumes being unreadable.
- Clean boot reindexed **1735 wines + 3239 bottles**; a subsequent **restart correctly SKIPPED** the sync (the new behaviour).
- All containers healthy on the new versions. Backend **623/623**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)