### PR TITLE
feat(ai): upgrade embeddings to voyage-4-large @ 2048 dims

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -225,7 +225,7 @@ Rules:
 
 const defaults = {
   chatEnabled: true,
-  embeddingModel: 'voyage-4-lite',
+  embeddingModel: 'voyage-4-large',
   vectorIndex: 'v1',
   chatTopK: 50,
   chatMaxResults: 5,
@@ -281,6 +281,24 @@ async function load() {
         enrichmentPrompt:      doc.value.enrichmentPrompt     ?? defaults.enrichmentPrompt,
         enrichmentModel:       VALID_CHAT_MODELS.includes(doc.value.enrichmentModel) ? doc.value.enrichmentModel : defaults.enrichmentModel,
       };
+
+      // One-time migration: a stored config from before the embedding-quality
+      // upgrade pins the old voyage-4-lite model. Force it to the new default
+      // (voyage-4-large @ 2048 dims) and persist, so every instance self-corrects
+      // on boot instead of silently embedding at the old quality. A full embedding
+      // job then rebuilds the wines_v1 collection at the new dimension.
+      if (cache.embeddingModel === 'voyage-4-lite') {
+        cache.embeddingModel = defaults.embeddingModel; // voyage-4-large
+        try {
+          await SiteConfig.updateOne(
+            { key: 'aiConfig' },
+            { $set: { 'value.embeddingModel': cache.embeddingModel } }
+          );
+          console.log('[aiConfig] Migrated stored embeddingModel to voyage-4-large (run a FULL embedding job to rebuild vectors at 2048 dims)');
+        } catch (e) {
+          console.warn('[aiConfig] Could not persist embedding-model migration:', e.message);
+        }
+      }
     }
   } catch (err) {
     console.warn('[aiConfig] Could not load from DB, using defaults:', err.message);

--- a/backend/src/services/embedding.js
+++ b/backend/src/services/embedding.js
@@ -2,7 +2,11 @@
  * Voyage AI embedding service.
  *
  * Wraps the Voyage AI REST API (/v1/embeddings) using Node's built-in fetch.
- * voyage-4-lite produces 1 024-dimensional vectors.
+ * Default model is voyage-4-large at 2048 dimensions — Voyage's best
+ * general-purpose retrieval quality. The output dimension is requested
+ * explicitly (output_dimension) and must match the Qdrant collection size
+ * (VOYAGE_DIMENSION). Changing either requires a fresh collection / full
+ * re-embed (bump aiConfig.vectorIndex).
  *
  * Throttle strategy
  * -----------------
@@ -13,8 +17,8 @@
  */
 
 const VOYAGE_API_URL = 'https://api.voyageai.com/v1/embeddings';
-const VOYAGE_DIMENSION = 1024;
-const DEFAULT_MODEL = 'voyage-4-lite';
+const VOYAGE_DIMENSION = 2048;
+const DEFAULT_MODEL = 'voyage-4-large';
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -45,7 +49,7 @@ async function embed(texts, { model = DEFAULT_MODEL, maxRetries = 6 } = {}) {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ input: texts, model })
+      body: JSON.stringify({ input: texts, model, output_dimension: VOYAGE_DIMENSION })
     });
 
     if (res.ok) {

--- a/backend/src/services/embeddingJob.js
+++ b/backend/src/services/embeddingJob.js
@@ -126,12 +126,16 @@ async function runJob(cfg) {
     // Ensure the Qdrant collection exists before we start
     await vectorStore.ensureCollection(vectorIndex);
 
-    // Full mode: wipe existing WineEmbedding records for this model+version
+    // Full mode: drop + recreate the Qdrant collection (this also resizes it to
+    // the current VOYAGE_DIMENSION if the embedding model changed), and wipe ALL
+    // WineEmbedding bookkeeping for this index version — across every model, not
+    // just the current one — so stale records from a previous model (e.g. after
+    // switching voyage-4-lite -> voyage-4-large) don't linger as orphans.
     if (job.mode === 'full') {
       await vectorStore.dropCollection(vectorIndex);
       await vectorStore.ensureCollection(vectorIndex);
-      await WineEmbedding.deleteMany({ model, indexVersion: vectorIndex });
-      console.log(`[embeddingJob] Full mode — cleared collection wines_${vectorIndex}`);
+      await WineEmbedding.deleteMany({ indexVersion: vectorIndex });
+      console.log(`[embeddingJob] Full mode — cleared collection wines_${vectorIndex} and all its embedding records`);
     }
 
     const pairs = await collectPairs();

--- a/docs/deploy-v1.57.0.md
+++ b/docs/deploy-v1.57.0.md
@@ -90,23 +90,21 @@ Every row should say `healthy` or `running` (give Meilisearch a minute if it say
 
 Then open **https://cellarion.app** in your browser and try a search — it should work.
 
-## Step 8 — Rebuild the AI vector index (for AI chat / similar wines)
-Qdrant came up empty, so AI features are blank until you rebuild the vectors. In your browser:
+## Step 8 — (Optional but recommended) Generate AI tasting profiles FIRST
+This release adds AI tasting profiles, which also enrich the search vectors. Generate them **before** the embedding job (Step 9) so the vectors include the taste data in a single pass — otherwise you'd embed twice. Costs Claude tokens, so test small first.
 
-1. Log in as the super admin.
-2. Go to **SuperAdmin → AI & Embeddings**.
-3. Under **Embedding Job**, choose **Incremental**, click **Start**.
-4. Wait for it to finish (watch the progress). AI chat / similar-wines work again once it's done.
+1. Log in as the super admin → **SuperAdmin → AI & Embeddings → Wine Enrichment Job**.
+2. Set **max** to `5`, click **Start** — enriches just 5 wines so you can check quality + cost.
+3. Happy? Run it again with **max** blank to enrich the whole catalogue (takes a while — runs in the background on the server).
 
----
+## Step 9 — Rebuild the AI vector index (FULL — required this release)
+Qdrant is empty after the upgrade, **and** this release switched the embedding model to `voyage-4-large` at 2048 dimensions — so you must run a **Full re-embed** (not Incremental). Full mode drops and recreates the Qdrant collection at the new dimension and rebuilds every vector. (Incremental would skip wines that look "already embedded" and leave the collection empty/wrong-sized.)
 
-## (Optional) Step 9 — Generate the new AI tasting profiles
-This release adds AI tasting profiles on wine pages. They don't exist until you generate them (this costs Claude tokens, so test small first):
+1. **SuperAdmin → AI & Embeddings → Embedding Job**.
+2. Choose **Full re-embed**, click **Start**.
+3. Wait for it to finish (watch the progress). AI chat / similar-wines work again once it's done.
 
-1. **SuperAdmin → AI & Embeddings → Wine Enrichment Job**.
-2. Set **max** to `5`, click **Start** — this enriches just 5 wines so you can check the result + cost.
-3. Happy with it? Run it again with **max** blank to do the whole catalog.
-4. Then run an **Incremental Embedding Job** again (step 8) so the new taste data feeds search.
+> After this one-time full rebuild, normal day-to-day use is **Incremental** again — Full is only needed because the model/dimension changed.
 
 ---
 


### PR DESCRIPTION
## Summary
Maximises embedding quality: switches the wine embedding model from **voyage-4-lite (1024)** → **voyage-4-large at 2048 dimensions** — Voyage's best general-purpose retrieval quality. Sharper similarity / AI chat / restock matching. Higher per-call cost, but the catalogue is embedded once.

## Changes
- **embedding.js** — `DEFAULT_MODEL` → `voyage-4-large`; `VOYAGE_DIMENSION` 1024 → 2048; sends `output_dimension` explicitly. Qdrant collection auto-sizes from `VOYAGE_DIMENSION`.
- **aiConfig** — default `embeddingModel` → `voyage-4-large`, plus a **one-time `load()` migration**: a stored config pinned to `voyage-4-lite` is upgraded and persisted, so every instance self-corrects on boot. (Without this, the stored DB value silently overrides the new default — verified that was happening.)
- **embeddingJob (full mode)** — drops + recreates the Qdrant collection (resizes to 2048) and wipes **all** `WineEmbedding` records for the index version (across every model), so stale `voyage-4-lite` bookkeeping doesn't linger. Rebuilds `wines_v1` in place at the new dimension — **no vectorIndex bump**, per the "remove old, create new larger" approach.
- **docs/deploy-v1.57.0.md** — deploy now uses a **Full** embedding job (required since model+dimension changed), and enrichment-before-embedding so vectors include taste data in one pass.

## ⚠️ Deploy note
Requires a **Full** embedding job once (not Incremental) because the model and dimension changed. After that, Incremental is normal again.

## Verification (local, real Voyage API + prod data)
- `voyage-4-large` returns **2048-dim** vectors ✓
- Full job dropped + recreated `wines_v1` at **size 2048** ✓
- Stale `voyage-4-lite` bookkeeping cleared; new vectors written as `voyage-4-large/v1` ✓
- Boot migration upgraded the stored config ✓
- Backend **623/623**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)