### PR TITLE
chore(release): v1.57.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Release v1.57.1

Bumps `backend` + `frontend` to **1.57.1**.

### Included
- **#477 — Best-quality embeddings**: wine embeddings upgraded from `voyage-4-lite` (1024-dim) to **`voyage-4-large` (2048-dim)** for sharper similarity / AI chat / restock matching.

### ⚠️ Deploy note
Requires a **one-time FULL embedding job** (SuperAdmin → AI → Embedding Job → **Full re-embed**) because both the model and the vector dimension changed. A boot migration auto-upgrades any stored config still pinned to `voyage-4-lite`. After this one full rebuild, Incremental is normal again. See `docs/deploy-v1.57.0.md` (updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)