### PR TITLE
fix(superadmin): embed/enrich job mode ignored (missing Content-Type)

### DIFF
--- a/frontend/src/pages/SuperAdmin/TabAI.js
+++ b/frontend/src/pages/SuperAdmin/TabAI.js
@@ -1103,8 +1103,16 @@ export default function TabAI() {
   async function startJob() {
     setJobBusy(true); setJobMsg(null);
     try {
-      const res = await apiFetch('/api/admin/ai/embed/start', { method: 'POST', body: JSON.stringify({ mode: jobMode }) });
-      setJobMsg(res.message || 'Job started');
+      // Content-Type header is required — without it Express's express.json()
+      // skips parsing the body, so req.body.mode is undefined and the backend
+      // silently defaults to 'incremental' regardless of the dropdown.
+      const res = await apiFetch('/api/admin/ai/embed/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: jobMode }),
+      });
+      const body = await res.json().catch(() => ({}));
+      setJobMsg(body.message || body.error || 'Job started');
       reload();
     } catch (e) { setJobMsg(e.message || 'Error'); }
     finally { setJobBusy(false); }
@@ -1114,7 +1122,8 @@ export default function TabAI() {
     setJobBusy(true); setJobMsg(null);
     try {
       const res = await apiFetch('/api/admin/ai/embed/stop', { method: 'POST' });
-      setJobMsg(res.message || 'Stop requested');
+      const body = await res.json().catch(() => ({}));
+      setJobMsg(body.message || 'Stop requested');
       reload();
     } catch (e) { setJobMsg(e.message || 'Error'); }
     finally { setJobBusy(false); }
@@ -1126,7 +1135,11 @@ export default function TabAI() {
       const limitNum = parseInt(enrichLimit, 10);
       const payload = { mode: enrichMode };
       if (Number.isInteger(limitNum) && limitNum > 0) payload.limit = limitNum;
-      const res = await apiFetch('/api/admin/ai/enrich/start', { method: 'POST', body: JSON.stringify(payload) });
+      const res = await apiFetch('/api/admin/ai/enrich/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
       const body = await res.json().catch(() => ({}));
       setEnrichMsg(body.message || body.error || 'Job started');
       reload();


### PR DESCRIPTION
## The bug
The SuperAdmin **Embedding Job** Start sent a JSON body **without** a `Content-Type: application/json` header. Express's `express.json()` then skips parsing, so `req.body.mode` is `undefined` and the backend defaults to **`incremental`** — no matter what the dropdown says.

After the voyage-4-large/2048 upgrade this made **"Full re-embed" impossible from the UI**: incremental can't resize the Qdrant collection from 1024→2048, so every vector insert failed with `expected dim: 1024, got 2048`. (This is the error Johan hit on the live VM.)

## Fix
- `embed/start` **and** `enrich/start` now send `Content-Type: application/json`, so `mode` (and the enrichment `limit`) reach the server.
- `startJob`/`stopJob` now read the response via `res.json()` like the enrich handlers did (they previously read `.message` off the raw `Response`, so the status/error message never showed).

## Verification
Frontend build clean; tests **292/292**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)