### PR TITLE
chore(release): v1.57.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.57.1",
+  "version": "1.57.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.57.1",
+  "version": "1.57.2",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Bumps to **1.57.2**. Includes **#479** — fixes the SuperAdmin embedding job ignoring the selected mode (missing Content-Type header), which blocked the required Full re-embed for the voyage-4-large/2048 upgrade. Pure code fix — VM deploy is just `pull` + `up -d`, then run **Embedding Job → Full re-embed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)