### PR TITLE
feat(ai): auto-enrich + re-embed wines on creation and after enrichment

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -17,6 +17,7 @@ const { logAudit } = require('../services/audit');
 const { getOrCreateDailySnapshot, getSnapshotForDate } = require('../utils/exchangeRates');
 const { resolveRating } = require('../utils/ratingUtils');
 const { embedSinglePair } = require('../services/embeddingJob');
+const { enrichWineById } = require('../services/enrichmentJob');
 const { CONSUMED_STATUSES, WINE_POPULATE } = require('../config/constants');
 const { checkRestockGap, resolveRestockAlerts } = require('../services/restockChecker');
 const { gatherPriceWarnings } = require('../services/priceWarnings');
@@ -458,6 +459,12 @@ router.post('/', async (req, res) => {
 
     // Fire-and-forget: embed this (wine, vintage) pair for AI chat
     embedSinglePair(wineDefinition, bottle.vintage).catch(err => console.error('Failed to embed wine-vintage pair after bottle creation:', err.message));
+
+    // Fire-and-forget: if this wine has no AI tasting profile yet (e.g. a brand-
+    // new wine the user just created), generate one — which also re-embeds the
+    // wine so Qdrant carries the taste data. No-op if already enriched / a batch
+    // enrichment job is running / AI isn't configured.
+    enrichWineById(wineDefinition).catch(() => {});
 
     // Fire-and-forget: auto-resolve any restock alerts for this wine
     resolveRestockAlerts(req.user.id, wineDefinition, bottle._id).catch(() => {});

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -20,9 +20,11 @@
  * embedSinglePair means this only does real work when the text actually changed.
  */
 
+const mongoose = require('mongoose');
 const aiConfig = require('../config/aiConfig');
 const { suggestProfile } = require('./labelScan');
 const { embedSinglePair } = require('./embeddingJob');
+const { isValidId } = require('../utils/validation');
 const WineDefinition = require('../models/WineDefinition');
 const Bottle = require('../models/Bottle');
 
@@ -235,10 +237,16 @@ async function enrichWine(wine, model) {
  * @param {string|object} wineDefId
  */
 async function enrichWineById(wineDefId) {
+  // Validate + cast the (caller-supplied) id to a real ObjectId before it touches
+  // the query, so a non-id value can never shape the database lookup. The cast
+  // value (idStr/oid), never the raw input, is used everywhere below.
+  const idStr = String(wineDefId);
+  if (!isValidId(idStr)) return;
+  const oid = new mongoose.Types.ObjectId(idStr);
   try {
     if (!process.env.ANTHROPIC_API_KEY) return;
     if (job.status === 'running') return; // batch job will handle it
-    const wine = await WineDefinition.findById(wineDefId)
+    const wine = await WineDefinition.findById(oid)
       .populate('country', 'name')
       .populate('region', 'name')
       .populate('grapes', 'name')
@@ -246,9 +254,9 @@ async function enrichWineById(wineDefId) {
     if (!wine) return;
     if (wine.aiProfile && wine.aiProfile.description) return; // already enriched
     await enrichWine(wine, aiConfig.get().enrichmentModel);
-    console.log(`[enrichmentJob] Auto-enriched new wine: ${wine.name}`);
+    console.log('[enrichmentJob] Auto-enriched new wine: %s', wine.name);
   } catch (err) {
-    console.warn(`[enrichmentJob] enrichWineById failed (${wineDefId}):`, err.message);
+    console.warn('[enrichmentJob] enrichWineById failed (%s): %s', idStr, err.message);
   }
 }
 

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -14,14 +14,17 @@
  * incremental (default) – only enrich wines that have no aiProfile yet
  * full                  – re-enrich every wine, overwriting existing profiles
  *
- * Note: enrichment does NOT re-embed. After it runs, the next embedding job
- * (incremental) detects the changed embedding text via textHash and re-embeds
- * the affected wines automatically.
+ * After a profile is written, the wine's active (wine, vintage) pairs are
+ * re-embedded immediately (embedSinglePair) so the new taste data reaches Qdrant
+ * without a separate manual embedding job. The textHash check inside
+ * embedSinglePair means this only does real work when the text actually changed.
  */
 
 const aiConfig = require('../config/aiConfig');
 const { suggestProfile } = require('./labelScan');
+const { embedSinglePair } = require('./embeddingJob');
 const WineDefinition = require('../models/WineDefinition');
+const Bottle = require('../models/Bottle');
 
 // ── In-memory job state ────────────────────────────────────────────────────
 
@@ -132,47 +135,9 @@ async function runJob(cfg) {
       }
 
       try {
-        const { data, debugReason } = await suggestProfile({
-          name: wine.name,
-          producer: wine.producer,
-          vintage: 'NV', // vintage-neutral profile
-          country: wine.country?.name,
-          region: wine.region?.name,
-          appellation: wine.appellation,
-          classification: wine.classification,
-          type: wine.type,
-          grapes: (wine.grapes || []).map(g => g.name).filter(Boolean),
-        });
-
-        if (!data) {
-          // ai_unknown / no_api_key / rate_limit / exception — count, keep going
-          job.skipped++;
-          if (debugReason && !debugReason.startsWith('ai_unknown')) {
-            job.lastError = debugReason;
-          }
-        } else {
-          await WineDefinition.updateOne(
-            { _id: wine._id },
-            {
-              $set: {
-                aiProfile: {
-                  body:         data.body ?? null,
-                  tannin:       data.tannin ?? null,
-                  acidity:      data.acidity ?? null,
-                  sweetness:    data.sweetness ?? null,
-                  flavors:      Array.isArray(data.flavors) ? data.flavors.slice(0, 10) : [],
-                  foodPairings: Array.isArray(data.foodPairings) ? data.foodPairings.slice(0, 8) : [],
-                  description:  typeof data.description === 'string' ? data.description.trim() : null,
-                  confidence:   typeof data.confidence === 'number' ? data.confidence : null,
-                  model:        job.model,
-                  generatedAt:  new Date(),
-                },
-                updatedAt: new Date(),
-              },
-            }
-          );
-          job.enriched++;
-        }
+        const result = await enrichWine(wine, job.model);
+        if (result === 'enriched') job.enriched++;
+        else job.skipped++;
       } catch (err) {
         job.errors++;
         job.lastError = err.message;
@@ -194,4 +159,97 @@ async function runJob(cfg) {
   }
 }
 
-module.exports = { start, requestStop, getStatus };
+// ── Single-wine enrichment (shared by the batch loop + bottle-add hook) ──────
+
+/**
+ * Enrich one wine: ask Claude for a vintage-neutral tasting profile, store it on
+ * the WineDefinition, then re-embed the wine's active vintages so the new taste
+ * data reaches Qdrant immediately.
+ *
+ * @param {object} wine   – populated WineDefinition (country/region/grapes names)
+ * @param {string} model  – embedding/enrichment model label to stamp on the profile
+ * @returns {'enriched'|'skipped'}
+ */
+async function enrichWine(wine, model) {
+  const { data, debugReason } = await suggestProfile({
+    name: wine.name,
+    producer: wine.producer,
+    vintage: 'NV', // vintage-neutral profile
+    country: wine.country?.name,
+    region: wine.region?.name,
+    appellation: wine.appellation,
+    classification: wine.classification,
+    type: wine.type,
+    grapes: (wine.grapes || []).map(g => g.name).filter(Boolean),
+  });
+
+  if (!data) {
+    // ai_unknown / no_api_key / rate_limit / exception — surface non-trivial reasons
+    if (debugReason && !debugReason.startsWith('ai_unknown')) job.lastError = debugReason;
+    return 'skipped';
+  }
+
+  await WineDefinition.updateOne(
+    { _id: wine._id },
+    {
+      $set: {
+        aiProfile: {
+          body:         data.body ?? null,
+          tannin:       data.tannin ?? null,
+          acidity:      data.acidity ?? null,
+          sweetness:    data.sweetness ?? null,
+          flavors:      Array.isArray(data.flavors) ? data.flavors.slice(0, 10) : [],
+          foodPairings: Array.isArray(data.foodPairings) ? data.foodPairings.slice(0, 8) : [],
+          description:  typeof data.description === 'string' ? data.description.trim() : null,
+          confidence:   typeof data.confidence === 'number' ? data.confidence : null,
+          model:        model || aiConfig.get().enrichmentModel,
+          generatedAt:  new Date(),
+        },
+        updatedAt: new Date(),
+      },
+    }
+  );
+
+  // Re-embed this wine's active vintages so the new profile reaches Qdrant
+  // immediately. embedSinglePair is a no-op when the text/hash is unchanged and
+  // self-skips during a batch embedding job. Best-effort — never fail enrichment.
+  try {
+    const vintages = await Bottle.distinct('vintage', { wineDefinition: wine._id, status: 'active' });
+    for (const v of vintages) {
+      await embedSinglePair(wine._id, v).catch(() => {});
+    }
+  } catch (embedErr) {
+    console.warn(`[enrichmentJob] re-embed after enrich failed (${wine._id}):`, embedErr.message);
+  }
+
+  return 'enriched';
+}
+
+/**
+ * Fire-and-forget enrichment for a single wine by id — used when a brand-new
+ * wine is created so it gets a tasting profile (and updated embedding) without
+ * waiting for the next batch run. Skips silently if the wine already has a
+ * profile, AI isn't configured, or a batch enrichment job is currently running
+ * (that job will cover it). Never throws.
+ *
+ * @param {string|object} wineDefId
+ */
+async function enrichWineById(wineDefId) {
+  try {
+    if (!process.env.ANTHROPIC_API_KEY) return;
+    if (job.status === 'running') return; // batch job will handle it
+    const wine = await WineDefinition.findById(wineDefId)
+      .populate('country', 'name')
+      .populate('region', 'name')
+      .populate('grapes', 'name')
+      .lean();
+    if (!wine) return;
+    if (wine.aiProfile && wine.aiProfile.description) return; // already enriched
+    await enrichWine(wine, aiConfig.get().enrichmentModel);
+    console.log(`[enrichmentJob] Auto-enriched new wine: ${wine.name}`);
+  } catch (err) {
+    console.warn(`[enrichmentJob] enrichWineById failed (${wineDefId}):`, err.message);
+  }
+}
+
+module.exports = { start, requestStop, getStatus, enrichWineById };


### PR DESCRIPTION
## Summary
Closes the loop so AI tasting profiles and their Qdrant embeddings stay current **without manual job runs**.

Previously: adding a brand-new wine embedded it (facts-only), but never generated a tasting profile — and enrichment didn't re-embed. So new wines were never taste-aware until someone manually ran enrichment **and** a re-embed.

Now:
- **On bottle creation** → if the wine has no profile, fire-and-forget `enrichWineById`: Claude writes the profile **and** re-embeds the wine → fully taste-aware automatically.
- **In the batch enrichment job** → each enriched wine is re-embedded immediately (shared `enrichWine` path), so a separate embedding job is no longer required afterward.

## Changes
- `enrichmentJob`: extracted `enrichWine(wine, model)` (Claude → store profile → `embedSinglePair` the wine's active vintages). Batch loop uses it.
- New export `enrichWineById(id)` — fire-and-forget; skips if already enriched / AI not configured / a batch job is running.
- `bottles.js`: after the existing `embedSinglePair`, calls `enrichWineById(wineDefinition)`.

## Verification (live, real API + Claude + Voyage)
Added a new wine via the API → logs showed `Auto-enriched new wine` + `Real-time embedded`; the wine ended with a Sonnet `aiProfile` (full-bodied Barolo: dried rose/tar/dark cherry) and a `voyage-4-large` embedding (status ok). No circular-import issues. Backend **623/623**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)