### PR TITLE
chore(release): v1.57.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.57.2",
+  "version": "1.57.3",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.57.2",
+  "version": "1.57.3",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Bumps to 1.57.3. #481 — new wines auto-get an AI tasting profile + voyage-4-large embedding; batch enrichment re-embeds each wine. Pure code; VM deploy is pull + up.