### PR TITLE
feat(bottle): declutter price-tracking opt-in on the bottle page

### DIFF
--- a/frontend/src/components/bottle/PriceHistoryTimeline.js
+++ b/frontend/src/components/bottle/PriceHistoryTimeline.js
@@ -10,13 +10,10 @@ function PriceHistoryTimeline({ history, rates, userCurrency }) {
   if (history === null) {
     return <span className="bd-no-dates">{t('bottleDetail.loadingMaturity')}</span>;
   }
+  // No price data: render nothing here — the "Track market price" button below
+  // (PriceTrackingToggle) is the only thing we want to show in the empty state.
   if (history.length === 0) {
-    return (
-      <div className="bd-price-history-empty">
-        <span className="bd-no-dates">{t('bottleDetail.noPriceData')}</span>
-        <span className="bd-maturity-note">{t('bottleDetail.sommelierAddPricing')}</span>
-      </div>
-    );
+    return null;
   }
 
   const latest = history[0];

--- a/frontend/src/components/bottle/PriceTrackingToggle.js
+++ b/frontend/src/components/bottle/PriceTrackingToggle.js
@@ -1,18 +1,23 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
+import Modal from '../Modal';
 
 /**
  * Lets the bottle owner opt in / opt out of sommelier price tracking
  * for the wine+vintage pair this bottle belongs to. Renders nothing for
  * ineligible bottles (NV, missing vintage, missing wineDefinition).
+ *
+ * On the page it shows only a compact pill button; the full explanation
+ * and the request/cancel action live in a popup opened from that button.
  */
-export default function PriceTrackingToggle({ bottleId, vintage, hasHistory }) {
+export default function PriceTrackingToggle({ bottleId, vintage }) {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
   const [status, setStatus] = useState(null);  // { requested, requesterCount, eligible, firstRequestedAt }
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
+  const [open, setOpen] = useState(false);
 
   // Eligibility shortcut — don't even hit the API for NV/unknown
   const eligibleClient = vintage && vintage !== 'NV' && vintage !== 'Unknown';
@@ -57,42 +62,63 @@ export default function PriceTrackingToggle({ bottleId, vintage, hasHistory }) {
 
   const requested = !!status.requested;
 
+  const closeModal = () => {
+    setOpen(false);
+    setError(null);
+  };
+
   return (
-    <div className="price-tracking-toggle">
-      <div className="price-tracking-toggle__row">
-        <div className="price-tracking-toggle__text">
-          <div className="price-tracking-toggle__label">
-            {requested
-              ? t('priceTracking.statusRequested', 'Market price tracking requested')
-              : hasHistory
-                ? t('priceTracking.statusHistoryOnly', 'Price tracking is no longer active')
+    <>
+      <button
+        type="button"
+        className={`price-tracking-trigger${requested ? ' price-tracking-trigger--active' : ''}`}
+        onClick={() => setOpen(true)}
+      >
+        <span className="price-tracking-trigger__icon" aria-hidden="true">{'\u{1F4C8}'}</span>
+        {requested
+          ? t('priceTracking.triggerRequested', 'Tracking requested')
+          : t('priceTracking.trigger', 'Track market price')}
+      </button>
+
+      {open && (
+        <Modal title={t('priceTracking.modalTitle', 'Market price tracking')} onClose={closeModal} showClose>
+          <div className="price-tracking-modal">
+            <div className="price-tracking-modal__label">
+              {requested
+                ? t('priceTracking.statusRequested', 'Market price tracking requested')
                 : t('priceTracking.statusNotRequested', 'Track market price for this wine')}
-          </div>
-          <div className="price-tracking-toggle__hint">
-            {requested
-              ? t('priceTracking.hintRequested', 'A sommelier will research and add a price. You will be notified when it is set.')
-              : t('priceTracking.hintGuidance', 'Only worth requesting for bottles with a real secondary-market value — Bordeaux Premier Cru, Burgundy Grand Cru, age-worthy collectibles. Everyday wines usually do not have reliable market data.')}
-          </div>
-          {requested && status.requesterCount > 1 && (
-            <div className="price-tracking-toggle__count">
-              {t('priceTracking.requesterCount', '{{count}} other user(s) also requested this', { count: status.requesterCount - 1 })}
             </div>
-          )}
-        </div>
-        <button
-          type="button"
-          className={`btn ${requested ? 'btn-secondary' : 'btn-primary'} price-tracking-toggle__btn`}
-          onClick={toggle}
-          disabled={busy}
-        >
-          {busy
-            ? t('priceTracking.saving', 'Saving…')
-            : requested
-              ? t('priceTracking.cancel', 'Cancel request')
-              : t('priceTracking.request', 'Request tracking')}
-        </button>
-      </div>
-      {error && <div className="price-tracking-toggle__error">{error}</div>}
-    </div>
+            <div className="price-tracking-modal__hint">
+              {requested
+                ? t('priceTracking.hintRequested', 'A sommelier will research and add a price. You will be notified when it is set.')
+                : t('priceTracking.hintGuidance', 'Only worth requesting for bottles with a real secondary-market value — Bordeaux Premier Cru, Burgundy Grand Cru, age-worthy collectibles. Everyday wines usually do not have reliable market data.')}
+            </div>
+            {requested && status.requesterCount > 1 && (
+              <div className="price-tracking-modal__count">
+                {t('priceTracking.requesterCount', '{{count}} other user(s) also requested this', { count: status.requesterCount - 1 })}
+              </div>
+            )}
+            {error && <div className="price-tracking-modal__error">{error}</div>}
+          </div>
+          <div className="modal-actions">
+            <button type="button" className="btn btn-secondary" onClick={closeModal}>
+              {t('common.close', 'Close')}
+            </button>
+            <button
+              type="button"
+              className={`btn ${requested ? 'btn-secondary' : 'btn-primary'}`}
+              onClick={toggle}
+              disabled={busy}
+            >
+              {busy
+                ? t('priceTracking.saving', 'Saving…')
+                : requested
+                  ? t('priceTracking.cancel', 'Cancel request')
+                  : t('priceTracking.request', 'Request tracking')}
+            </button>
+          </div>
+        </Modal>
+      )}
+    </>
   );
 }

--- a/frontend/src/components/bottle/ViewDetails.js
+++ b/frontend/src/components/bottle/ViewDetails.js
@@ -188,11 +188,11 @@ function ViewDetails({ bottle, rackInfo, cellarId, vintageProfile, priceHistory,
               {t('bottleDetail.reportPrice')}
             </button>
           )}
-          <PriceTrackingToggle
-            bottleId={bottle._id}
-            vintage={bottle.vintage}
-            hasHistory={!!(priceHistory && priceHistory.length > 0)}
-          />
+          {/* Only offer price tracking while there's no price yet — once a
+              sommelier has set one, the request is moot and we hide the button. */}
+          {!(priceHistory && priceHistory.length > 0) && (
+            <PriceTrackingToggle bottleId={bottle._id} vintage={bottle.vintage} />
+          )}
         </div>
       )}
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -408,8 +408,6 @@
     "noRatingOption": "— no rating —",
     "noteOptional": "Note (optional)",
     "notePlaceholder": "How was it? Any tasting notes?",
-    "noPriceData": "No market price data yet.",
-    "sommelierAddPricing": "Market-price tracking is opt-in — use the toggle below to request it.",
     "reportPrice": "Report incorrect price",
     "maturityPhaseEarly": "Early drinking",
     "maturityPhasePeak": "Optimal maturity ⭐",
@@ -943,8 +941,10 @@
   },
 
   "priceTracking": {
+    "trigger": "Track market price",
+    "triggerRequested": "Tracking requested",
+    "modalTitle": "Market price tracking",
     "statusRequested": "Market price tracking requested",
-    "statusHistoryOnly": "Price tracking is no longer active",
     "statusNotRequested": "Track market price for this wine",
     "hintRequested": "A sommelier will research and add a price. You will be notified when it is set.",
     "hintGuidance": "Only worth requesting for bottles with a real secondary-market value — Bordeaux Premier Cru, Burgundy Grand Cru, age-worthy collectibles. Everyday wines usually don't have reliable market data.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -408,8 +408,6 @@
     "noRatingOption": "— inget betyg —",
     "noteOptional": "Anteckning (valfritt)",
     "notePlaceholder": "Hur smakade det? Några smaknoteringar?",
-    "noPriceData": "Inga marknadsprisdata ännu.",
-    "sommelierAddPricing": "Marknadsprisbevakning är opt-in — använd reglaget nedan för att begära den.",
     "reportPrice": "Rapportera felaktigt pris",
     "maturityPhaseEarly": "Tidig drickning",
     "maturityPhasePeak": "Optimal mognad ⭐",
@@ -943,8 +941,10 @@
   },
 
   "priceTracking": {
+    "trigger": "Bevaka marknadspris",
+    "triggerRequested": "Bevakning begärd",
+    "modalTitle": "Marknadsprisbevakning",
     "statusRequested": "Marknadsprisbevakning begärd",
-    "statusHistoryOnly": "Prisbevakning är inte längre aktiv",
     "statusNotRequested": "Bevaka marknadspris för detta vin",
     "hintRequested": "En sommelier kommer att undersöka och lägga till ett pris. Du meddelas när det är satt.",
     "hintGuidance": "Bara värt att begära för flaskor med riktigt andrahandsvärde — Bordeaux Premier Cru, Burgundy Grand Cru, lagringsvärda samlarviner. Vardagsviner har sällan tillförlitlig marknadsdata.",

--- a/frontend/src/pages/BottleDetail.css
+++ b/frontend/src/pages/BottleDetail.css
@@ -575,12 +575,6 @@
   font-size: 0.77rem;
 }
 
-.bd-price-history-empty {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-}
-
 /* Report wine */
 .bd-report-wine {
   margin-top: 12px;
@@ -1152,46 +1146,55 @@
   justify-content: flex-end;
 }
 
-/* Price-tracking opt-in card inside the Price Evolution section */
-.price-tracking-toggle {
+/* Compact pill that opens the price-tracking popup, inside the Price Evolution section */
+.price-tracking-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   margin-top: 0.75rem;
-  padding: 0.75rem 0.9rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
   background: var(--color-surface-raised);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
-.price-tracking-toggle__row {
-  display: flex;
-  gap: 0.75rem;
-  align-items: flex-start;
-  flex-wrap: wrap;
-}
-.price-tracking-toggle__text {
-  flex: 1 1 220px;
-  min-width: 0;
-}
-.price-tracking-toggle__label {
-  font-weight: 600;
-  font-size: 0.92rem;
+.price-tracking-trigger:hover {
+  background: var(--color-surface-hover);
   color: var(--color-text);
 }
-.price-tracking-toggle__hint {
-  margin-top: 0.25rem;
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-  line-height: 1.35;
+.price-tracking-trigger--active {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
 }
-.price-tracking-toggle__count {
-  margin-top: 0.35rem;
-  font-size: 0.78rem;
+.price-tracking-trigger__icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+/* Body of the price-tracking popup */
+.price-tracking-modal__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+.price-tracking-modal__hint {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  line-height: 1.45;
+}
+.price-tracking-modal__count {
+  margin-top: 0.5rem;
+  font-size: 0.82rem;
   color: var(--color-text-muted);
   font-style: italic;
 }
-.price-tracking-toggle__btn {
-  flex: 0 0 auto;
-}
-.price-tracking-toggle__error {
-  margin-top: 0.5rem;
+.price-tracking-modal__error {
+  margin-top: 0.6rem;
   color: var(--color-danger, #b00);
   font-size: 0.85rem;
 }


### PR DESCRIPTION
## What

Slims down the **price-tracking opt-in** in the *Price Evolution* section of the bottle page, which previously rendered a full card (bold label + long guidance paragraph + button) inline and dominated the section.

### Changes
- **Compact pill + popup** — the opt-in is now a small `📈 Track market price` pill. The status label, guidance text, requester count, and the **Request tracking / Cancel request** action all moved into a popup (shared `Modal`) opened from the pill.
- **No empty-state text** — removed the "No market price data yet." / "Market-price tracking is opt-in…" lines; when there's no price, the pill alone is shown.
- **Hidden once a price exists** — the pill no longer renders when the wine has price history. Once a sommelier has set a price the request is moot, so it disappears. Removed the now-dead `hasHistory` prop and the `statusHistoryOnly` branch + locale keys.

### Behaviour
- **No price yet:** section header + `Track market price` pill.
- **Price set:** header + price/timeline + "Report incorrect price" — no pill.

## Testing
- `npx vitest run` → 292 passed.
- Smoke-tested in Docker (rebuilt frontend, verified both states on a real bottle).

Frontend-only; en + sv locales updated.