### PR TITLE
chore(release): v1.57.4

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.57.3",
+  "version": "1.57.4",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.57.3",
+  "version": "1.57.4",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump **1.57.3 -> 1.57.4** in `frontend/package.json` and `backend/package.json`.

Releases the price-tracking opt-in declutter merged in #483 (compact pill + popup, empty-state text removed, pill hidden once a price exists).

No publishing of the GitHub Release in this PR — that step (which builds & pushes the Docker images via `release-docker.yml`) is left for manual review.