### PR TITLE
feat(cellar): always group identical bottles; remove group toggle

### DIFF
--- a/frontend/src/pages/CellarDetail.css
+++ b/frontend/src/pages/CellarDetail.css
@@ -632,33 +632,6 @@
   background: var(--color-primary-light);
 }
 
-/* ── Group-identical toggle (sits left of the view toggles) ── */
-.group-toggle-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  height: 32px;
-  padding: 0 0.6rem;
-  margin-right: auto;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  color: var(--color-text-muted);
-  font-size: 0.8rem;
-  font-family: var(--font-body);
-  transition: border-color var(--transition-fast), color var(--transition-fast);
-}
-.group-toggle-btn:hover {
-  border-color: var(--color-text-secondary);
-  color: var(--color-text-secondary);
-}
-.group-toggle-btn.active {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
-  background: var(--color-primary-light);
-}
-
 /* ── Expanded bottle-group header (full-width across the grid/list) ── */
 .bottle-group-bar {
   grid-column: 1 / -1;

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -54,12 +54,8 @@ function CellarDetail() {
   const [facets, setFacets] = useState(null);
   const [baseFacets, setBaseFacets] = useState(null);
   const [facetMeta, setFacetMeta] = useState(null);
-  // Collapse identical bottles (same wine + vintage) into one card. Defaults on;
-  // persisted per browser. Server-side grouped (see ?group=1) so counts are
-  // correct across pagination.
-  const [grouped, setGrouped] = useState(() => {
-    try { return localStorage.getItem('cellarion_bottle_group') !== '0'; } catch { return true; }
-  });
+  // Identical bottles (same wine + vintage + size) are always collapsed into one
+  // card. Server-side grouped (see ?group=1) so counts are correct across pagination.
 
   // Debounce the search input — only send the API call after the user stops typing
   const [debouncedSearch, setDebouncedSearch] = useState(filters.search);
@@ -87,7 +83,7 @@ function CellarDetail() {
 
   useEffect(() => {
     fetchCellarData(0);
-  }, [id, filterKey, grouped]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, filterKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     fetchStatistics();
@@ -111,7 +107,7 @@ function CellarDetail() {
       });
       params.set('limit', BOTTLES_PER_PAGE);
       params.set('skip', skip);
-      if (grouped) params.set('group', '1');
+      params.set('group', '1');
       const res = await getCellar(apiFetch, id, params);
       const data = await res.json();
       if (res.ok) {
@@ -138,14 +134,6 @@ function CellarDetail() {
   };
 
   const loadMore = () => fetchCellarData(bottles.length);
-
-  const toggleGrouped = () => {
-    setGrouped(g => {
-      const next = !g;
-      try { localStorage.setItem('cellarion_bottle_group', next ? '1' : '0'); } catch {}
-      return next;
-    });
-  };
 
   const fetchStatistics = async () => {
     try {
@@ -596,8 +584,6 @@ function CellarDetail() {
               hasMore={bottles.length < bottlesTotal}
               loadingMore={bottlesLoading}
               onLoadMore={loadMore}
-              grouped={grouped}
-              onToggleGrouped={toggleGrouped}
             />
           )}
         </div>
@@ -653,7 +639,7 @@ function CellarDetail() {
 }
 
 // ── Bottle list (list or card view) ──
-function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore, grouped, onToggleGrouped }) {
+function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore }) {
   const { t } = useTranslation();
   const [viewMode, setViewMode] = useState(() => {
     try { return localStorage.getItem('cellarion_bottle_view') || 'list'; } catch { return 'list'; }
@@ -677,15 +663,6 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
     <>
       <div className="bottles-view-toggle">
         <button
-          type="button"
-          className={`group-toggle-btn ${grouped ? 'active' : ''}`}
-          onClick={onToggleGrouped}
-          title="Group identical bottles (same wine & vintage) into one card"
-          aria-pressed={grouped}
-        >
-          {grouped ? '▣ Grouped' : '▢ Group'}
-        </button>
-        <button
           className={`view-toggle-btn ${viewMode === 'list' ? 'active' : ''}`}
           onClick={() => setView('list')}
           aria-label="List view"
@@ -706,7 +683,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
       <div className={viewMode === 'list' ? 'bottles-list' : 'bottles-grid'}>
         {bottles.map(item => {
           // Grouped response: item = { key, count, bottles: [...] }
-          if (grouped && item && Array.isArray(item.bottles)) {
+          if (item && Array.isArray(item.bottles)) {
             const rep = item.bottles[0];
             if (item.count === 1) {
               return (
@@ -741,7 +718,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
               </Fragment>
             );
           }
-          // Ungrouped response: item = bottle
+          // Defensive fallback: a plain bottle item (responses are always grouped)
           return (
             <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} />
           );


### PR DESCRIPTION
## What
Removes the `▣ Grouped / ▢ Group` toggle from the cellar wine list and **always** groups identical bottles (same wine + vintage + size) into a single card.

## Why
The toggle added clutter for little value — grouping is the sensible default for everyone. Stacked cards still expand/collapse to show member bottles.

## Changes
- Drop the `grouped` state, `toggleGrouped` handler, and `cellarion_bottle_group` localStorage persistence
- Always send `?group=1` to the cellar bottle endpoint
- Remove the toggle button and its now-unused `.group-toggle-btn` CSS
- Simplify the list render to the grouped path (defensive fallback kept)

## Scope
Frontend only. Backend grouping stays **opt-in** by design — other callers (e.g. the add-bottle exclude flow) rely on the ungrouped default.

## Testing
- ✅ 292 frontend tests pass (`npm test` / vitest)
- ✅ Production build compiles
- ✅ Verified in Docker at http://localhost