### PR TITLE
chore(release): v1.57.5

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.57.4",
+  "version": "1.57.5",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.57.4",
+  "version": "1.57.5",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release v1.57.5.

Bumps backend + frontend to 1.57.5.

**Included since v1.57.4**
- feat(cellar): always group identical bottles; remove the group toggle (#485)