### PR TITLE
chore(release): v1.57.6

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.57.5",
+  "version": "1.57.6",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.57.5",
+  "version": "1.57.6",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release v1.57.6.

Includes #487 — keep embeddings + AI tasting profile consistent on wine merge (purge orphaned Qdrant vectors, inherit the source profile when the keeper lacks one, and re-embed the keeper).