### PR TITLE
fix(restock): count low-frequency grapes/regions instead of showing 0 in stock

### DIFF
--- a/backend/src/services/statsService.js
+++ b/backend/src/services/statsService.js
@@ -355,6 +355,12 @@ async function computeOverview({ activeBottles, consumedBottles, cellars, target
     pace,
     topProducers: Object.entries(byProducer).sort((a, b) => b[1] - a[1]).slice(0, 10).map(([name, count]) => ({ name, count })),
     allProducers: Object.entries(byProducer).sort((a, b) => b[1] - a[1]).map(([name, count]) => ({ name, count })),
+    // Full (untruncated) grape/region breakdowns. byGrape/byRegion above are
+    // capped at the top 15 for the Statistics charts; Smart Restock needs the
+    // complete list so low-count categories with consumption history report
+    // their real stock instead of 0 (mirrors topProducers vs allProducers).
+    allGrapes: Object.entries(byGrape).sort((a, b) => b[1] - a[1]).map(([name, count]) => ({ name, count })),
+    allRegions: Object.entries(byRegion).sort((a, b) => b[1] - a[1]).map(([name, count]) => ({ name, count })),
   };
 }
 
@@ -380,7 +386,7 @@ function buildEmptyStats(currency) {
     joyPerDollar: [],
     regretSignal: { surprises: [], disappointments: [], avgDelta: null, count: 0 },
     pace: { avgIntakePerYear: 0, avgOutputPerYear: 0, netPerYear: 0, runway: null },
-    topProducers: [],
+    topProducers: [], allProducers: [], allGrapes: [], allRegions: [],
   };
 }
 

--- a/frontend/src/pages/Restock.js
+++ b/frontend/src/pages/Restock.js
@@ -9,7 +9,7 @@ import './Restock.css';
 function computeRestock(stats) {
   if (!stats) return [];
 
-  const { overview, byType, byRegion, byCountry, byGrape, allProducers, consumedByType, consumedByRegion, consumedByCountry, consumedByGrape, consumedByProducer, pace } = stats;
+  const { overview, byType, byRegion, byCountry, byGrape, allGrapes, allRegions, allProducers, consumedByType, consumedByRegion, consumedByCountry, consumedByGrape, consumedByProducer, pace } = stats;
 
   // Estimate months of consumption data (from pace or fallback to 12)
   const consumptionMonths = pace?.avgOutputPerYear > 0
@@ -37,10 +37,12 @@ function computeRestock(stats) {
     }
   }
 
-  // By region
-  if (byRegion && consumedByRegion) {
+  // By region — use the full (untruncated) region list so low-count regions
+  // with consumption history report real stock instead of 0.
+  const regionList = allRegions || byRegion;
+  if (regionList && consumedByRegion) {
     const regionStock = {};
-    for (const r of byRegion) regionStock[r.name] = r.count;
+    for (const r of regionList) regionStock[r.name] = r.count;
 
     for (const [name, consumed] of Object.entries(consumedByRegion)) {
       const stock = regionStock[name] || 0;
@@ -81,10 +83,13 @@ function computeRestock(stats) {
     }
   }
 
-  // By grape
-  if (byGrape && consumedByGrape) {
+  // By grape — use the full (untruncated) grape list so low-count grapes with
+  // consumption history report real stock instead of 0 (the bug where a newly
+  // added bottle of an uncommon grape still showed "out of stock").
+  const grapeList = allGrapes || byGrape;
+  if (grapeList && consumedByGrape) {
     const grapeStock = {};
-    for (const g of byGrape) grapeStock[g.name] = g.count;
+    for (const g of grapeList) grapeStock[g.name] = g.count;
 
     for (const [name, consumed] of Object.entries(consumedByGrape)) {
       const stock = grapeStock[name] || 0;


### PR DESCRIPTION
## Problem

Smart Restock cross-references the **full** `consumedByGrape`/`consumedByRegion` maps against `byGrape`/`byRegion` for stock counts — but those breakdowns are truncated to the **top 15** by `sortDesc` (for the Statistics charts). Any grape/region outside a user's top 15 by stock gets dropped from the stock list, so it reads **"0 in stock / out of stock"** despite having active bottles.

Reproduced on live data: a just-added Malbec bottle (Malbec ranked **27th of 27** grapes) showed 0 in stock; the backend genuinely had `byGrape['Malbec'] = 1`. Not a caching issue (ruled out service worker, nginx, browser cache).

## Fix

Expose full `allGrapes`/`allRegions` (mirroring the existing `topProducers` vs `allProducers` split already added for the same reason) and use them for restock stock lookups. `byGrape`/`byRegion` stay capped at 15 for the Statistics page. Frontend falls back to the truncated lists if the full ones are absent (staggered-deploy safety).

## Testing
- Backend `npm test` → 623 passed; frontend parses.
- Verified against live data: Malbec now reports 1 in stock and moves to Well Stocked.