### PR TITLE
feat(admin): mark wine clusters as "not duplicates" in the duplicate scanner

### DIFF
--- a/backend/src/models/WineNotDuplicate.js
+++ b/backend/src/models/WineNotDuplicate.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+
+/**
+ * An admin-confirmed "these are NOT the same wine" decision for a pair of
+ * WineDefinitions. The duplicate-cluster scanner skips any pair recorded here,
+ * so wines that legitimately look similar (e.g. single-vineyard bottlings from
+ * the same producer) stop resurfacing on every scan.
+ *
+ * The pair is stored canonically with wineA < wineB (by ObjectId hex string) so
+ * it's recorded at most once regardless of argument order; the unique index
+ * enforces that. No user reference is stored — the acting admin is captured in
+ * the AuditLog instead (GDPR data minimisation).
+ */
+const wineNotDuplicateSchema = new mongoose.Schema({
+  wineA: { type: mongoose.Schema.Types.ObjectId, ref: 'WineDefinition', required: true },
+  wineB: { type: mongoose.Schema.Types.ObjectId, ref: 'WineDefinition', required: true },
+  createdAt: { type: Date, default: Date.now },
+}, { versionKey: false });
+
+wineNotDuplicateSchema.index({ wineA: 1, wineB: 1 }, { unique: true });
+
+module.exports = mongoose.model('WineNotDuplicate', wineNotDuplicateSchema);

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -20,6 +20,7 @@ const Review = require('../../models/Review');
 const Discussion = require('../../models/Discussion');
 const DiscussionReply = require('../../models/DiscussionReply');
 const WineEmbedding = require('../../models/WineEmbedding');
+const WineNotDuplicate = require('../../models/WineNotDuplicate');
 const vectorStore = require('../../services/vectorStore');
 const { embedSinglePair } = require('../../services/embeddingJob');
 const searchService = require('../../services/search');
@@ -219,6 +220,11 @@ router.get('/duplicate-clusters', async (req, res) => {
       if (ra !== rb) parent.set(ra, rb);
     };
 
+    // Pairs an admin has confirmed are NOT the same wine — skip these edges so
+    // they stop resurfacing on every scan. Keyed canonically as "smaller|larger".
+    const notDup = await WineNotDuplicate.find({}).select('wineA wineB').lean();
+    const dismissed = new Set(notDup.map(d => `${d.wineA}|${d.wineB}`));
+
     // Score pairs within each producer group
     const edgeScore = new Map(); // "a|b" -> best score (so we can keep cluster score later)
     for (const group of byProducer.values()) {
@@ -231,6 +237,8 @@ router.get('/duplicate-clusters', async (req, res) => {
           const b = group[j];
           const bId = String(b._id);
           if (!parent.has(bId)) parent.set(bId, bId);
+          const key = aId < bId ? `${aId}|${bId}` : `${bId}|${aId}`;
+          if (dismissed.has(key)) continue; // admin marked these as not duplicates
           const score = scoreWineMatch(
             { name: a.name, producer: a.producer, appellation: a.appellation },
             { name: b.name, producer: b.producer, appellation: b.appellation },
@@ -238,7 +246,6 @@ router.get('/duplicate-clusters', async (req, res) => {
           );
           if (score >= minScore) {
             union(aId, bId);
-            const key = aId < bId ? `${aId}|${bId}` : `${bId}|${aId}`;
             edgeScore.set(key, score);
           }
         }
@@ -305,6 +312,64 @@ router.get('/duplicate-clusters', async (req, res) => {
   } catch (err) {
     console.error('Duplicate cluster scan error:', err);
     res.status(500).json({ error: 'Failed to scan for duplicates' });
+  }
+});
+
+// All canonical unordered pairs (wineA < wineB by hex) from a set of wine ids,
+// as ObjectIds — used to record / remove "not duplicate" decisions.
+function buildWinePairs(ids) {
+  const pairs = [];
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      const [a, b] = ids[i] < ids[j] ? [ids[i], ids[j]] : [ids[j], ids[i]];
+      pairs.push({ wineA: new mongoose.Types.ObjectId(a), wineB: new mongoose.Types.ObjectId(b) });
+    }
+  }
+  return pairs;
+}
+
+// POST /api/admin/wines/dismiss-duplicates — mark a cluster's wines as NOT the
+// same wine. Records every pair so the duplicate scanner stops surfacing them.
+// Body: { wineIds: [id, id, ...] } (the cluster's wine ids)
+router.post('/dismiss-duplicates', async (req, res) => {
+  try {
+    const ids = [...new Set((Array.isArray(req.body?.wineIds) ? req.body.wineIds : []).filter(isValidId))];
+    if (ids.length < 2) {
+      return res.status(400).json({ error: 'wineIds must contain at least 2 valid, distinct ids' });
+    }
+    const pairs = buildWinePairs(ids);
+    await WineNotDuplicate.bulkWrite(
+      pairs.map(p => ({
+        updateOne: {
+          filter: { wineA: p.wineA, wineB: p.wineB },
+          update: { $setOnInsert: { wineA: p.wineA, wineB: p.wineB } },
+          upsert: true,
+        },
+      })),
+      { ordered: false }
+    );
+    logAudit(req, 'admin.wine.dismissDuplicates', { type: 'wine', id: ids[0] }, { wineIds: ids, pairs: pairs.length });
+    res.json({ message: 'Marked as not duplicates', pairsRecorded: pairs.length });
+  } catch (error) {
+    console.error('Dismiss duplicates error:', error);
+    res.status(500).json({ error: 'Failed to mark as not duplicates' });
+  }
+});
+
+// DELETE /api/admin/wines/dismiss-duplicates — undo the above for a cluster.
+// Body: { wineIds: [id, id, ...] }
+router.delete('/dismiss-duplicates', async (req, res) => {
+  try {
+    const ids = [...new Set((Array.isArray(req.body?.wineIds) ? req.body.wineIds : []).filter(isValidId))];
+    if (ids.length < 2) {
+      return res.status(400).json({ error: 'wineIds must contain at least 2 valid, distinct ids' });
+    }
+    const result = await WineNotDuplicate.deleteMany({ $or: buildWinePairs(ids) });
+    logAudit(req, 'admin.wine.undismissDuplicates', { type: 'wine', id: ids[0] }, { wineIds: ids });
+    res.json({ message: 'Restored', pairsRemoved: result.deletedCount || 0 });
+  } catch (error) {
+    console.error('Undismiss duplicates error:', error);
+    res.status(500).json({ error: 'Failed to restore' });
   }
 });
 
@@ -528,6 +593,8 @@ router.delete('/:id', async (req, res) => {
 
     // Remove from search index (fire-and-forget)
     searchService.removeWine(req.params.id);
+    // Drop any "not duplicate" decisions referencing this wine (fire-and-forget)
+    WineNotDuplicate.deleteMany({ $or: [{ wineA: req.params.id }, { wineB: req.params.id }] }).catch(() => {});
 
     res.json({ message: 'Wine deleted successfully' });
   } catch (error) {
@@ -611,6 +678,8 @@ router.post('/:id/merge', async (req, res) => {
       // Delete the source's vectors from Qdrant + WineEmbedding (deleting the
       // bookkeeping rows alone would orphan the actual vectors in Qdrant).
       purgeSourceVectors(sourceId),
+      // Drop any "not duplicate" decisions referencing the disappearing source.
+      WineNotDuplicate.deleteMany({ $or: [{ wineA: sourceId }, { wineB: sourceId }] }),
     ]);
 
     const bottlesMoved = results[0].modifiedCount || 0;
@@ -752,6 +821,8 @@ async function reassignWineRefs(sourceId, keeperId) {
     DiscussionReply.updateMany({ wineDefinition: sourceId }, { $set: { wineDefinition: keeperId } }),
     // Delete the source's vectors from Qdrant too, not just the bookkeeping rows.
     purgeSourceVectors(sourceId),
+    // Drop any "not duplicate" decisions referencing the disappearing source.
+    WineNotDuplicate.deleteMany({ $or: [{ wineA: sourceId }, { wineB: sourceId }] }),
     // Reviews have a unique (author, wineDefinition) index — on a real dup-key
     // collision the source author already reviewed the keeper, so drop the
     // source's duplicate review. Re-throw anything that isn't a dup-key error.

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -86,6 +86,7 @@ const EXCLUDED = {
   ExchangeRateSnapshot: 'no user reference (daily FX rates)',
   StripeWebhookEvent: 'no user reference (idempotency ledger, TTL)',
   WineEmbedding: 'no user reference (references WineDefinition only)',
+  WineNotDuplicate: 'no user reference (admin-confirmed distinct wine pairs; actor in AuditLog)',
 };
 
 const REGISTRY = [

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -37,6 +37,22 @@ export const adminMergeCluster = (apiFetch, { keeperId, sourceIds, imageFromWine
 export const adminGetWineDuplicateClusters = (apiFetch, { minScore = 0.6, limit = 50 } = {}) =>
   apiFetch(`/api/admin/wines/duplicate-clusters?minScore=${minScore}&limit=${limit}`);
 
+// Mark a cluster's wines as NOT the same wine, so the scanner stops surfacing
+// them. adminUndismiss… reverses it (the undo).
+export const adminDismissDuplicateCluster = (apiFetch, wineIds) =>
+  apiFetch('/api/admin/wines/dismiss-duplicates', {
+    method: 'POST',
+    headers: J,
+    body: JSON.stringify({ wineIds }),
+  });
+
+export const adminUndismissDuplicateCluster = (apiFetch, wineIds) =>
+  apiFetch('/api/admin/wines/dismiss-duplicates', {
+    method: 'DELETE',
+    headers: J,
+    body: JSON.stringify({ wineIds }),
+  });
+
 // ── Taxonomy ─────────────────────────────────────────────────────────────────
 export const adminGetTaxonomy = (apiFetch, endpoint) =>
   apiFetch(endpoint);

--- a/frontend/src/components/WineDuplicatesModal.js
+++ b/frontend/src/components/WineDuplicatesModal.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import Modal from './Modal';
 import WineImage from './WineImage';
 import WineClusterCompareModal from './WineClusterCompareModal';
-import { adminGetWineDuplicateClusters, adminMergeWine } from '../api/admin';
+import { adminGetWineDuplicateClusters, adminMergeWine, adminDismissDuplicateCluster, adminUndismissDuplicateCluster } from '../api/admin';
 import './WineModalThumbs.css';
 
 /**
@@ -24,10 +24,12 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
   const [minScore, setMinScore] = useState(0.6);
   const [meta, setMeta] = useState(null);
   const [compareCluster, setCompareCluster] = useState(null);
+  const [pendingUndo, setPendingUndo] = useState(null); // last "not duplicates" action, for one-level undo
 
   const scan = useCallback(async (score = minScore) => {
     setScanning(true);
     setError(null);
+    setPendingUndo(null);
     try {
       const res = await adminGetWineDuplicateClusters(apiFetch, { minScore: score, limit: 50 });
       const data = await res.json();
@@ -68,6 +70,35 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
     onMerged?.();
   };
 
+  // Stable identity for a cluster (its set of wine ids) — used to add/remove it
+  // from the list without relying on array index or object reference.
+  const clusterKey = (c) => c.wines.map(w => String(w._id)).sort().join(',');
+
+  // "Not duplicates": persist the decision, drop the cluster, offer one undo.
+  const handleDismiss = async (cluster) => {
+    const wineIds = cluster.wines.map(w => String(w._id));
+    setError(null);
+    setClusters(prev => prev.filter(c => clusterKey(c) !== clusterKey(cluster))); // optimistic
+    try {
+      const res = await adminDismissDuplicateCluster(apiFetch, wineIds);
+      if (!res.ok) throw new Error();
+      setPendingUndo({ cluster, wineIds });
+      setMeta(m => m ? { ...m, totalClusters: Math.max(0, (m.totalClusters || 0) - 1) } : m);
+    } catch {
+      setClusters(prev => [cluster, ...prev]); // restore on failure
+      setError('Failed to mark as not duplicates');
+    }
+  };
+
+  const handleUndo = async () => {
+    if (!pendingUndo) return;
+    const { cluster, wineIds } = pendingUndo;
+    setPendingUndo(null);
+    setClusters(prev => [cluster, ...prev]);
+    setMeta(m => m ? { ...m, totalClusters: (m.totalClusters || 0) + 1 } : m);
+    try { await adminUndismissDuplicateCluster(apiFetch, wineIds); } catch { /* re-scan reflects truth */ }
+  };
+
   return (
     <Modal title="Scan registry for duplicate wines" onClose={onClose} showClose wide>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
@@ -94,6 +125,27 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
 
       {error && <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>}
 
+      {pendingUndo && (
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8,
+          padding: '0.5rem 0.75rem', marginBottom: 12, borderRadius: 6,
+          background: 'var(--bg-secondary, #f4f4f4)', border: '1px solid var(--border, #e5e5e5)',
+          fontSize: '0.85rem',
+        }}>
+          <span>
+            Marked <strong>{pendingUndo.cluster.wines[0]?.producer}</strong> as not duplicates — it won’t reappear in future scans.
+          </span>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={handleUndo}
+            style={{ padding: '0.25rem 0.65rem', fontSize: '0.8rem', flexShrink: 0 }}
+          >
+            Undo
+          </button>
+        </div>
+      )}
+
       {scanning && !clusters && (
         <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
           Scanning registry… this can take a few seconds.
@@ -115,6 +167,7 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
               apiFetch={apiFetch}
               onMerged={handleMerged}
               onOpenCompare={() => setCompareCluster(cluster)}
+              onDismiss={() => handleDismiss(cluster)}
             />
           ))}
         </div>
@@ -132,7 +185,7 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
   );
 }
 
-function ClusterCard({ cluster, apiFetch, onMerged, onOpenCompare }) {
+function ClusterCard({ cluster, apiFetch, onMerged, onOpenCompare, onDismiss }) {
   const [targetId, setTargetId] = useState(null);
   const [merging, setMerging] = useState(null); // sourceId being merged
   const [error, setError] = useState(null);
@@ -176,6 +229,16 @@ function ClusterCard({ cluster, apiFetch, onMerged, onOpenCompare }) {
           <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)' }}>
             {Math.round(cluster.score * 100)}% match
           </span>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={onDismiss}
+            disabled={!!merging}
+            style={{ padding: '0.25rem 0.65rem', fontSize: '0.8rem' }}
+            title="These are different wines — stop showing this cluster in future scans"
+          >
+            Not duplicates
+          </button>
           <button
             type="button"
             className="btn btn-secondary"


### PR DESCRIPTION
## What

Adds a per-cluster **"Not duplicates"** action to the registry duplicate scanner so admins can dismiss false-positive clusters (e.g. single-vineyard bottlings from the same producer — Garys' Vineyard vs Rosella's Vineyard). Dismissed pairs are skipped on future scans, with one-level **Undo**.

## How

- **New model** `WineNotDuplicate` — canonical `wineA < wineB` pair, unique index. No user field (the acting admin is captured in the AuditLog — GDPR data-minimisation), so it needs no deletion cascade; declared in the GDPR registry's `EXCLUDED` alongside `WineEmbedding`.
- **Scan suppression** — dismissed pairs are loaded into a Set and their edges skipped, so the connected-component clustering never forms them.
- **Endpoints** — `POST`/`DELETE /api/admin/wines/dismiss-duplicates` (record / undo), both audit-logged.
- **Cleanup** — dismissal rows are dropped when a referenced wine is merged or deleted (no orphan accumulation).
- **Frontend** — the button, optimistic removal, undo banner, and live cluster-count updates in `WineDuplicatesModal`.

"Not duplicates" dismisses the whole cluster (records every pair); for a mixed 3+ cluster you'd merge the real dupes first, then dismiss what's left.

## Testing
- Backend `npm test` → 623 passed (incl. the GDPR completeness test); frontend parses.