### PR TITLE
chore(release): v1.57.7

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.57.6",
+  "version": "1.57.7",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.57.6",
+  "version": "1.57.7",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release v1.57.7.

- #489 — fix(restock): count low-frequency grapes/regions instead of showing 0 in stock
- #490 — feat(admin): mark wine clusters as "not duplicates" in the duplicate scanner