### PR TITLE
feat(bottle): report an incorrect AI tasting profile

### DIFF
--- a/backend/src/models/WineReport.js
+++ b/backend/src/models/WineReport.js
@@ -15,7 +15,7 @@ const wineReportSchema = new mongoose.Schema({
   },
   reason: {
     type: String,
-    enum: ['wrong_info', 'duplicate', 'inappropriate', 'wrong_price', 'other'],
+    enum: ['wrong_info', 'duplicate', 'inappropriate', 'wrong_price', 'wrong_tasting_profile', 'other'],
     required: true,
     index: true
   },

--- a/backend/src/routes/wineReports.js
+++ b/backend/src/routes/wineReports.js
@@ -7,7 +7,7 @@ const { requireAuth } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const { stripHtml } = require('../utils/sanitize');
 
-const VALID_REASONS = ['wrong_info', 'duplicate', 'inappropriate', 'wrong_price', 'other'];
+const VALID_REASONS = ['wrong_info', 'duplicate', 'inappropriate', 'wrong_price', 'wrong_tasting_profile', 'other'];
 
 // POST /api/wine-reports — report a wine
 router.post('/', requireAuth, async (req, res) => {

--- a/backend/src/routes/wineReports.js
+++ b/backend/src/routes/wineReports.js
@@ -34,14 +34,17 @@ router.post('/', requireAuth, async (req, res) => {
       return res.status(404).json({ error: 'Wine not found' });
     }
 
-    // Prevent duplicate reports from the same user for the same wine
+    // Prevent duplicate reports of the SAME issue from the same user, but allow
+    // separate pending reports for different reasons on the same wine (e.g. a
+    // wrong price AND an incorrect tasting profile).
     const existing = await WineReport.findOne({
       user: req.user.id,
       wineDefinition: wineDefinitionId,
+      reason,
       status: 'pending'
     });
     if (existing) {
-      return res.status(409).json({ error: 'You already have a pending report for this wine' });
+      return res.status(409).json({ error: 'You already have a pending report of this type for this wine' });
     }
 
     const report = await WineReport.create({

--- a/frontend/src/components/ReportWineModal.js
+++ b/frontend/src/components/ReportWineModal.js
@@ -8,6 +8,7 @@ const REASONS = [
   { value: 'wrong_info', label: 'Wrong information (name, producer, region, etc.)' },
   { value: 'duplicate', label: 'Duplicate wine entry' },
   { value: 'wrong_price', label: 'Wrong or inaccurate market price' },
+  { value: 'wrong_tasting_profile', label: 'Incorrect tasting profile (structure, flavours, pairings)' },
   { value: 'inappropriate', label: 'Inappropriate content' },
   { value: 'other', label: 'Other' },
 ];

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -409,6 +409,7 @@
     "noteOptional": "Note (optional)",
     "notePlaceholder": "How was it? Any tasting notes?",
     "reportPrice": "Report incorrect price",
+    "reportTastingProfile": "Report tasting profile",
     "maturityPhaseEarly": "Early drinking",
     "maturityPhasePeak": "Optimal maturity ⭐",
     "maturityPhaseLate": "Late maturity",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -409,6 +409,7 @@
     "noteOptional": "Anteckning (valfritt)",
     "notePlaceholder": "Hur smakade det? Några smaknoteringar?",
     "reportPrice": "Rapportera felaktigt pris",
+    "reportTastingProfile": "Rapportera smakprofil",
     "maturityPhaseEarly": "Tidig drickning",
     "maturityPhasePeak": "Optimal mognad ⭐",
     "maturityPhaseLate": "Sen mognad",

--- a/frontend/src/pages/AdminWineReports.js
+++ b/frontend/src/pages/AdminWineReports.js
@@ -6,6 +6,8 @@ import './AdminWineReports.css';
 const REASON_LABELS = {
   wrong_info: 'Wrong Info',
   duplicate: 'Duplicate',
+  wrong_price: 'Wrong Price',
+  wrong_tasting_profile: 'Tasting Profile',
   inappropriate: 'Inappropriate',
   other: 'Other',
 };

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -424,6 +424,16 @@ function BottleDetail() {
               {wine.aiProfile.foodPairings.join(' · ')}
             </div>
           )}
+
+          <div className="bd-report-wine">
+            <button
+              type="button"
+              className="btn-report-wine"
+              onClick={() => { setReportDefaultReason('wrong_tasting_profile'); setReportWineOpen(true); }}
+            >
+              {t('bottleDetail.reportTastingProfile', 'Report tasting profile')}
+            </button>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
Adds a 'Report tasting profile' link on the Tasting profile card (reuses the existing wine-report pipeline via a new wrong_tasting_profile reason). Also relaxes the report dedup to one pending report per reason (so a tasting-profile report can coexist with e.g. a price report).