### PR TITLE
feat(maturity): per-bottle recalculated drink window for NV wines

### DIFF
--- a/backend/src/models/WineVintageProfile.js
+++ b/backend/src/models/WineVintageProfile.js
@@ -36,17 +36,23 @@ const wineVintageProfileSchema = new mongoose.Schema({
     index: true
   },
 
-  // Phase 1 — Early drinking
-  earlyFrom:  { type: Number, min: 1900, max: 2200 },
-  earlyUntil: { type: Number, min: 1900, max: 2200 },
+  // When true (used for NV / non-vintage wines), the six phase numbers below are
+  // year-OFFSETS after each bottle's purchase year — not absolute calendar years
+  // — so the drink window recalculates per bottle (NV has no vintage to anchor
+  // to). Resolved to absolute years at read time (see utils/maturityUtils).
+  relative: { type: Boolean, default: false },
+
+  // Phase 1 — Early drinking (absolute year, or year-offset when `relative`)
+  earlyFrom:  { type: Number, min: 0, max: 2200 },
+  earlyUntil: { type: Number, min: 0, max: 2200 },
 
   // Phase 2 — Optimal maturity / peak
-  peakFrom:   { type: Number, min: 1900, max: 2200 },
-  peakUntil:  { type: Number, min: 1900, max: 2200 },
+  peakFrom:   { type: Number, min: 0, max: 2200 },
+  peakUntil:  { type: Number, min: 0, max: 2200 },
 
   // Phase 3 — Late maturity / tertiary
-  lateFrom:   { type: Number, min: 1900, max: 2200 },
-  lateUntil:  { type: Number, min: 1900, max: 2200 },
+  lateFrom:   { type: Number, min: 0, max: 2200 },
+  lateUntil:  { type: Number, min: 0, max: 2200 },
 
   // Optional notes from the somm
   sommNotes: {

--- a/backend/src/routes/somm/maturity.js
+++ b/backend/src/routes/somm/maturity.js
@@ -96,14 +96,18 @@ router.put('/:id', requireSommOrAdmin, async (req, res) => {
     }
 
     // Parse all year fields
+    // NV wines store the window as year-offsets after each bottle's purchase
+    // year (relative), since there's no vintage to anchor absolute years to.
+    const isNv = profile.vintage === 'NV';
+    const [lo, hi] = isNv ? [0, 100] : [1900, 2200];
     const years = {};
     for (const field of PHASE_FIELDS) {
       const yr = parseYear(req.body[field]);
       if (yr !== null && isNaN(yr)) {
-        return res.status(400).json({ error: `Invalid year for ${field}` });
+        return res.status(400).json({ error: `Invalid value for ${field}` });
       }
-      if (yr !== null && (yr < 1900 || yr > 2200)) {
-        return res.status(400).json({ error: `Year out of range for ${field}` });
+      if (yr !== null && (yr < lo || yr > hi)) {
+        return res.status(400).json({ error: isNv ? `${field} must be between 0 and 100 years` : `Year out of range for ${field}` });
       }
       years[field] = yr;
     }
@@ -132,6 +136,7 @@ router.put('/:id', requireSommOrAdmin, async (req, res) => {
       profile.sommNotes = req.body.sommNotes ? req.body.sommNotes.trim() : '';
     }
 
+    profile.relative = isNv;
     profile.status = 'reviewed';
     profile.setBy  = req.user.id;
     profile.setAt  = new Date();

--- a/frontend/src/components/bottle/MaturityPhaseTable.js
+++ b/frontend/src/components/bottle/MaturityPhaseTable.js
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { getMaturityPhases, isPhaseActive } from '../../utils/maturityUtils';
 
-function MaturityPhaseTable({ profile }) {
+function MaturityPhaseTable({ profile, anchorYear }) {
   const { t } = useTranslation();
   const CURRENT_YEAR = new Date().getFullYear();
 
@@ -9,7 +9,7 @@ function MaturityPhaseTable({ profile }) {
     early: t('bottleDetail.maturityPhaseEarly'),
     peak:  t('bottleDetail.maturityPhasePeak'),
     late:  t('bottleDetail.maturityPhaseLate'),
-  });
+  }, anchorYear);
 
   if (phases.length === 0) return null;
 

--- a/frontend/src/components/bottle/ViewDetails.js
+++ b/frontend/src/components/bottle/ViewDetails.js
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { getMaturityStatus } from '../../utils/drinkStatus';
+import { bottleAnchorYear } from '../../utils/maturityUtils';
 import { convertAmountHistorical } from '../../utils/currency';
 import { buildRackUrl } from '../../utils/rackNavigation';
 import safeUrl from '../../utils/safeUrl';
@@ -15,7 +16,13 @@ import PriceTrackingToggle from './PriceTrackingToggle';
 function ViewDetails({ bottle, rackInfo, cellarId, vintageProfile, priceHistory, rates, userCurrency, canEdit, hasImage, onEdit, onSuggestGrapes, onRemove, onReportWine }) {
   const { t } = useTranslation();
   const { user } = useAuth();
-  const maturityStatus = getMaturityStatus(vintageProfile);
+  const anchorYear = bottleAnchorYear(bottle);
+  const maturityStatus = getMaturityStatus(vintageProfile, anchorYear);
+  const isNv = bottle.vintage === 'NV';
+  // An NV window is only meaningful once a somm has saved it in relative mode
+  // (offsets from purchase). An old absolute-year NV profile would be stale, so
+  // treat it as still awaiting review rather than showing wrong years.
+  const maturityReviewed = vintageProfile?.status === 'reviewed' && (!isNv || vintageProfile.relative);
   const [showSommNotes, setShowSommNotes] = useState(false);
   const wine = bottle.wineDefinition;
   const grapes = wine?.grapes || [];
@@ -102,7 +109,7 @@ function ViewDetails({ bottle, rackInfo, cellarId, vintageProfile, priceHistory,
           <span className="bd-section-label">{t('bottleDetail.sommMaturity')}</span>
           {!vintageProfile ? (
             <span className="bd-no-dates">{t('bottleDetail.loadingMaturity')}</span>
-          ) : vintageProfile.status === 'pending' ? (
+          ) : !maturityReviewed ? (
             <div className="bd-maturity-pending">
               <span className="maturity-badge maturity-badge--pending">{t('bottleDetail.awaitingSommelier')}</span>
               <span className="bd-maturity-note">
@@ -116,7 +123,7 @@ function ViewDetails({ bottle, rackInfo, cellarId, vintageProfile, priceHistory,
                   {maturityStatus.label}
                 </span>
               )}
-              <MaturityPhaseTable profile={vintageProfile} />
+              <MaturityPhaseTable profile={vintageProfile} anchorYear={anchorYear} />
               {vintageProfile.sommNotes && (
                 <div className="bd-somm-notes-toggle">
                   <button

--- a/frontend/src/components/bottle/ViewDetails.js
+++ b/frontend/src/components/bottle/ViewDetails.js
@@ -95,8 +95,9 @@ function ViewDetails({ bottle, rackInfo, cellarId, vintageProfile, priceHistory,
         )}
       </div>
 
-      {/* Sommelier maturity section — not shown for NV */}
-      {bottle.vintage && bottle.vintage !== 'NV' && (
+      {/* Sommelier maturity section — shown for NV too (somms can set a drink
+          window for non-vintage sparkling); only hidden for unknown vintages */}
+      {bottle.vintage && bottle.vintage !== 'Unknown' && (
         <div className="bd-section">
           <span className="bd-section-label">{t('bottleDetail.sommMaturity')}</span>
           {!vintageProfile ? (

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -106,15 +106,18 @@ function BottleDetail() {
             setCommunityRating(wineObj.communityRating);
           }
         }
-        // Fetch the sommelier maturity profile for this wine+vintage. Skip
-        // for non-vintage / unknown bottles since calendar-year windows
-        // and historical pricing don't apply to them.
+        // Fetch the sommelier maturity profile. NV bottles (non-vintage
+        // Champagne / Cap Classique blends) get a profile too — somms can set a
+        // drink window for them — so we fetch it for NV as well; only truly
+        // unknown vintages are skipped. Price history stays vintage-specific.
         const wine = data.bottle?.wineDefinition;
         const vintage = data.bottle?.vintage;
-        if (wine?._id && vintage && vintage !== 'NV' && vintage !== 'Unknown') {
+        if (wine?._id && vintage && vintage !== 'Unknown') {
           fetchVintageProfile(wine._id, vintage);
-          fetchPriceHistory(wine._id, vintage);
-          fetchRates().then(r => { if (r) setRates(r); });
+          if (vintage !== 'NV') {
+            fetchPriceHistory(wine._id, vintage);
+            fetchRates().then(r => { if (r) setRates(r); });
+          }
         }
       } else {
         setError(data.error || 'Failed to load bottle');

--- a/frontend/src/pages/SommMaturity.js
+++ b/frontend/src/pages/SommMaturity.js
@@ -138,13 +138,17 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
   const [err,       setErr]       = useState(null);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
 
+  // For an NV profile not yet migrated to relative (offset) mode, start the
+  // window blank so the somm enters durations fresh rather than stale years
+  // that would fail the 0–100 offset validation.
+  const seed = (isNv && !profile.relative) ? {} : profile;
   const [form, setForm] = useState({
-    earlyFrom:  profile.earlyFrom  || '',
-    earlyUntil: profile.earlyUntil || '',
-    peakFrom:   profile.peakFrom   || '',
-    peakUntil:  profile.peakUntil  || '',
-    lateFrom:   profile.lateFrom   || '',
-    lateUntil:  profile.lateUntil  || '',
+    earlyFrom:  seed.earlyFrom  || '',
+    earlyUntil: seed.earlyUntil || '',
+    peakFrom:   seed.peakFrom   || '',
+    peakUntil:  seed.peakUntil  || '',
+    lateFrom:   seed.lateFrom   || '',
+    lateUntil:  seed.lateUntil  || '',
     sommNotes:  profile.sommNotes  || ''
   });
 

--- a/frontend/src/pages/SommMaturity.js
+++ b/frontend/src/pages/SommMaturity.js
@@ -42,6 +42,15 @@ function yearsFromVintage(vintageInt, from, until) {
   return `${fYrs} yrs`;
 }
 
+// For NV (relative) profiles the entered numbers ARE years-after-purchase, so
+// show them directly; for vintage wines, compute the span from the vintage.
+function phaseYrs(isNv, vintageInt, from, until) {
+  if (!isNv) return yearsFromVintage(vintageInt, from, until);
+  if (from === '' || from === undefined || from === null) return '';
+  const u = (until === '' || until === undefined || until === null) ? null : until;
+  return u !== null ? `${from}–${u} yrs` : `${from} yrs`;
+}
+
 function SommMaturity() {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
@@ -119,6 +128,7 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
   const { apiFetch } = useAuth();
   const wine       = profile.wineDefinition;
   const vintageInt = parseInt(profile.vintage);
+  const isNv       = profile.vintage === 'NV';
 
   const [expanded,  setExpanded]  = useState(isPending);
   const [saving,    setSaving]    = useState(false);
@@ -215,7 +225,7 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
     }
   };
 
-  const phase = getMaturityPhase(profile);
+  const phase = isNv ? null : getMaturityPhase(profile);
 
   return (
     <div className={`somm-card ${expanded ? 'expanded' : ''}`}>
@@ -252,7 +262,9 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
           <div className="somm-form-hint-row">
             <p className="somm-form-hint">
               {t('somm.maturity.phaseHint')}
-              {!isNaN(vintageInt) && ` (${t('somm.maturity.vintageLabel')} ${vintageInt})`}
+              {isNv
+                ? ` — ${t('somm.maturity.nvHint', 'non-vintage: enter years after purchase')}`
+                : (!isNaN(vintageInt) ? ` (${t('somm.maturity.vintageLabel')} ${vintageInt})` : '')}
             </p>
             <button
               type="button"
@@ -277,14 +289,14 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
               <div className="somm-phase-label somm-phase-label--early">
                 <span className="somm-phase-name">{t('somm.maturity.phaseEarly')}</span>
                 <span className="somm-phase-yrs">
-                  {yearsFromVintage(vintageInt, form.earlyFrom, form.earlyUntil)}
+                  {phaseYrs(isNv, vintageInt, form.earlyFrom, form.earlyUntil)}
                 </span>
               </div>
               <div className="somm-phase-inputs">
                 <div className="somm-range-field">
                   <label>{t('somm.maturity.fromLabel')}</label>
                   <input
-                    type="number" min="1900" max="2200"
+                    type="number" min={isNv ? '0' : '1900'} max={isNv ? '100' : '2200'}
                     placeholder={!isNaN(vintageInt) ? String(vintageInt + 2) : 'Year'}
                     value={form.earlyFrom} onChange={set('earlyFrom')}
                   />
@@ -293,7 +305,7 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
                 <div className="somm-range-field">
                   <label>{t('somm.maturity.untilLabel')}</label>
                   <input
-                    type="number" min="1900" max="2200"
+                    type="number" min={isNv ? '0' : '1900'} max={isNv ? '100' : '2200'}
                     placeholder={!isNaN(vintageInt) ? String(vintageInt + 5) : 'Year'}
                     value={form.earlyUntil} onChange={set('earlyUntil')}
                   />
@@ -306,14 +318,14 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
               <div className="somm-phase-label somm-phase-label--peak">
                 <span className="somm-phase-name">{t('somm.maturity.phasePeak')}</span>
                 <span className="somm-phase-yrs">
-                  {yearsFromVintage(vintageInt, form.peakFrom, form.peakUntil)}
+                  {phaseYrs(isNv, vintageInt, form.peakFrom, form.peakUntil)}
                 </span>
               </div>
               <div className="somm-phase-inputs">
                 <div className="somm-range-field">
                   <label>{t('somm.maturity.fromLabel')}</label>
                   <input
-                    type="number" min="1900" max="2200"
+                    type="number" min={isNv ? '0' : '1900'} max={isNv ? '100' : '2200'}
                     placeholder={!isNaN(vintageInt) ? String(vintageInt + 6) : 'Year'}
                     value={form.peakFrom} onChange={set('peakFrom')}
                   />
@@ -322,7 +334,7 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
                 <div className="somm-range-field">
                   <label>{t('somm.maturity.untilLabel')}</label>
                   <input
-                    type="number" min="1900" max="2200"
+                    type="number" min={isNv ? '0' : '1900'} max={isNv ? '100' : '2200'}
                     placeholder={!isNaN(vintageInt) ? String(vintageInt + 15) : 'Year'}
                     value={form.peakUntil} onChange={set('peakUntil')}
                   />
@@ -335,14 +347,14 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
               <div className="somm-phase-label somm-phase-label--late">
                 <span className="somm-phase-name">{t('somm.maturity.phaseLate')}</span>
                 <span className="somm-phase-yrs">
-                  {yearsFromVintage(vintageInt, form.lateFrom, form.lateUntil)}
+                  {phaseYrs(isNv, vintageInt, form.lateFrom, form.lateUntil)}
                 </span>
               </div>
               <div className="somm-phase-inputs">
                 <div className="somm-range-field">
                   <label>{t('somm.maturity.fromLabel')}</label>
                   <input
-                    type="number" min="1900" max="2200"
+                    type="number" min={isNv ? '0' : '1900'} max={isNv ? '100' : '2200'}
                     placeholder={!isNaN(vintageInt) ? String(vintageInt + 16) : 'Year'}
                     value={form.lateFrom} onChange={set('lateFrom')}
                   />
@@ -351,7 +363,7 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
                 <div className="somm-range-field">
                   <label>{t('somm.maturity.untilLabel')}</label>
                   <input
-                    type="number" min="1900" max="2200"
+                    type="number" min={isNv ? '0' : '1900'} max={isNv ? '100' : '2200'}
                     placeholder={!isNaN(vintageInt) ? String(vintageInt + 22) : 'Year'}
                     value={form.lateUntil} onChange={set('lateUntil')}
                   />
@@ -362,7 +374,7 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
           </div>{/* /.somm-phases */}
 
           {/* Live preview */}
-          <MaturityPreview form={form} vintageInt={vintageInt} />
+          <MaturityPreview form={form} vintageInt={vintageInt} isNv={isNv} />
 
           <div className="form-group" style={{ marginTop: '1rem' }}>
             <label>{t('somm.maturity.sommNotes')} <span className="somm-year-hint">{t('somm.maturity.sommNotesOptional')}</span></label>
@@ -409,8 +421,11 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
 }
 
 // ── Live preview component ────────────────────────────────────────────────────
-function MaturityPreview({ form, vintageInt }) {
+function MaturityPreview({ form, vintageInt, isNv }) {
   const { t } = useTranslation();
+  // NV windows are per-bottle (offsets from purchase), so there's no single
+  // wine-level "status today" to preview here.
+  if (isNv) return null;
   const mock = {
     status:     'reviewed',
     earlyFrom:  form.earlyFrom  ? parseInt(form.earlyFrom)  : null,

--- a/frontend/src/utils/drinkStatus.js
+++ b/frontend/src/utils/drinkStatus.js
@@ -1,12 +1,18 @@
+import { resolveWindow } from './maturityUtils';
+
 const CURRENT_YEAR = new Date().getFullYear();
 
 /**
  * Derive the current maturity phase from a 3-phase reviewed WineVintageProfile.
- * Returns null if the profile is not ready, or an object { status, label }.
+ * For relative (NV) profiles the window is resolved against the bottle's anchor
+ * year first. Returns null if the profile is not ready, or { status, label }.
+ *
+ * @param {object} profile
+ * @param {number} [anchorYear] - the bottle's purchase year (for relative/NV profiles)
  */
-export function getMaturityStatus(profile) {
+export function getMaturityStatus(profile, anchorYear) {
   if (!profile || profile.status !== 'reviewed') return null;
-  const { earlyFrom, earlyUntil, peakFrom, peakUntil, lateFrom, lateUntil } = profile;
+  const { earlyFrom, earlyUntil, peakFrom, peakUntil, lateFrom, lateUntil } = resolveWindow(profile, anchorYear);
 
   // Need at least one window boundary to classify
   if (!earlyFrom && !peakFrom && !peakUntil) return null;

--- a/frontend/src/utils/drinkStatus.test.js
+++ b/frontend/src/utils/drinkStatus.test.js
@@ -117,3 +117,24 @@ describe('getMaturityStatus', () => {
     expect(result.status).toBe('declining');
   });
 });
+
+// ─── getMaturityStatus — relative (NV) profiles ──────────────────────────────
+
+describe('getMaturityStatus — relative (NV) profiles', () => {
+  const CURRENT_YEAR = new Date().getFullYear();
+
+  // Offsets in years after the bottle's anchor: early 0–2, peak 2–4, late 4–6.
+  const nvProfile = {
+    status: 'reviewed',
+    relative: true,
+    earlyFrom: 0, earlyUntil: 2,
+    peakFrom: 2, peakUntil: 4,
+    lateFrom: 4, lateUntil: 6,
+  };
+
+  test('same NV profile classifies differently per bottle anchor (purchase) year', () => {
+    expect(getMaturityStatus(nvProfile, CURRENT_YEAR).status).toBe('early');
+    expect(getMaturityStatus(nvProfile, CURRENT_YEAR - 3).status).toBe('peak');
+    expect(getMaturityStatus(nvProfile, CURRENT_YEAR - 7).status).toBe('declining');
+  });
+});

--- a/frontend/src/utils/maturityUtils.js
+++ b/frontend/src/utils/maturityUtils.js
@@ -1,36 +1,63 @@
+const WINDOW_FIELDS = ['earlyFrom', 'earlyUntil', 'peakFrom', 'peakUntil', 'lateFrom', 'lateUntil'];
+
+/**
+ * Resolve a profile's drink window to absolute calendar years.
+ *
+ * For `relative` profiles (NV / non-vintage wines) the stored numbers are
+ * year-offsets after the bottle's anchor year, so we add the anchor; otherwise
+ * the numbers are already absolute years and the anchor is ignored.
+ *
+ * @param {object} profile - vintage profile (may have `relative: true`)
+ * @param {number} [anchorYear] - the bottle's purchase year (see bottleAnchorYear)
+ * @returns {{earlyFrom, earlyUntil, peakFrom, peakUntil, lateFrom, lateUntil}}
+ */
+export function resolveWindow(profile, anchorYear) {
+  const rel = !!(profile?.relative) && Number.isFinite(anchorYear);
+  const out = {};
+  for (const f of WINDOW_FIELDS) {
+    const v = profile?.[f];
+    out[f] = (v === null || v === undefined) ? v : (rel ? v + anchorYear : v);
+  }
+  return out;
+}
+
+/**
+ * The year a relative (NV) window is measured from for a given bottle: its
+ * purchase year, falling back to when it was added to the cellar.
+ *
+ * @param {object} bottle
+ * @returns {number|null}
+ */
+export function bottleAnchorYear(bottle) {
+  const d = bottle?.purchaseDate || bottle?.createdAt;
+  if (!d) return null;
+  const y = new Date(d).getFullYear();
+  return Number.isFinite(y) ? y : null;
+}
+
 /**
  * Build the array of maturity phases from a vintage profile, filtering out
- * phases that have neither a `from` nor `until` value.
+ * phases that have neither a `from` nor `until` value. Windows are resolved to
+ * absolute years using anchorYear (only relevant for relative/NV profiles).
  *
- * @param {object} profile - Vintage profile with earlyFrom/earlyUntil, peakFrom/peakUntil, lateFrom/lateUntil and vintage
+ * @param {object} profile
  * @param {{ early: string, peak: string, late: string }} labels - Translated phase labels
+ * @param {number} [anchorYear] - the bottle's purchase year (for relative profiles)
  * @returns {Array<{ label: string, cls: string, from: number|undefined, until: number|undefined, vintageInt: number }>}
  */
-export function getMaturityPhases(profile, labels) {
-  const vintageInt = parseInt(profile.vintage);
+export function getMaturityPhases(profile, labels, anchorYear) {
+  const w = resolveWindow(profile, anchorYear);
+  // The "years" column is measured from the anchor for relative (NV) windows,
+  // and from the vintage year for normal vintage wines.
+  const base = profile?.relative ? anchorYear : parseInt(profile.vintage);
 
   const phases = [
-    {
-      label: labels.early,
-      cls:   'early',
-      from:  profile.earlyFrom,
-      until: profile.earlyUntil,
-    },
-    {
-      label: labels.peak,
-      cls:   'peak',
-      from:  profile.peakFrom,
-      until: profile.peakUntil,
-    },
-    {
-      label: labels.late,
-      cls:   'late',
-      from:  profile.lateFrom,
-      until: profile.lateUntil,
-    },
+    { label: labels.early, cls: 'early', from: w.earlyFrom, until: w.earlyUntil },
+    { label: labels.peak,  cls: 'peak',  from: w.peakFrom,  until: w.peakUntil },
+    { label: labels.late,  cls: 'late',  from: w.lateFrom,  until: w.lateUntil },
   ].filter(p => p.from || p.until);
 
-  return phases.map(p => ({ ...p, vintageInt }));
+  return phases.map(p => ({ ...p, vintageInt: base }));
 }
 
 /**


### PR DESCRIPTION
NV wines share one profile with no vintage to anchor absolute years to, so a window set today was wrong for the same wine added later (why NV maturity was hidden). Adds a relative mode: for NV the phase numbers are year-offsets after each bottle's purchase year, resolved per bottle via resolveWindow(profile, anchorYear). Somm editor takes 'years after purchase' for NV; bottle page shows the per-bottle window; old absolute-year NV profiles fall back to 'awaiting sommelier'. Vintage wines unchanged. Includes the prerequisite NV-maturity-display fix.