### PR TITLE
fix(ai): enrich + embed new wines on add even during a batch job

### DIFF
--- a/backend/src/services/embeddingJob.js
+++ b/backend/src/services/embeddingJob.js
@@ -274,15 +274,15 @@ async function runJob(cfg) {
  * Skips silently when:
  *  - VOYAGE_API_KEY is not configured
  *  - the pair already has an up-to-date embedding (same textHash + status ok)
- *  - a batch job is currently running (it will cover the pair itself)
  *
  * @param {string|object} wineDefId  – WineDefinition _id (string or ObjectId)
  * @param {string}        vintage    – e.g. '2019' or 'NV'
  */
 async function embedSinglePair(wineDefId, vintage) {
   if (!process.env.VOYAGE_API_KEY) return;
-  // Let the running batch job handle it to avoid concurrent Voyage calls
-  if (job.status === 'running') return;
+  // Intentionally NOT skipped while a batch job runs: a batch snapshots its
+  // (wine, vintage) list at start, so a just-added pair isn't covered by it.
+  // The textHash check below makes a redundant re-embed a cheap no-op.
 
   const cfg = aiConfig.get();
   if (!cfg.chatEnabled) return;

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -231,8 +231,7 @@ async function enrichWine(wine, model) {
  * Fire-and-forget enrichment for a single wine by id — used when a brand-new
  * wine is created so it gets a tasting profile (and updated embedding) without
  * waiting for the next batch run. Skips silently if the wine already has a
- * profile, AI isn't configured, or a batch enrichment job is currently running
- * (that job will cover it). Never throws.
+ * profile or AI isn't configured. Never throws.
  *
  * @param {string|object} wineDefId
  */
@@ -244,8 +243,14 @@ async function enrichWineById(wineDefId) {
   if (!isValidId(idStr)) return;
   const oid = new mongoose.Types.ObjectId(idStr);
   try {
-    if (!process.env.ANTHROPIC_API_KEY) return;
-    if (job.status === 'running') return; // batch job will handle it
+    if (!process.env.ANTHROPIC_API_KEY) {
+      console.warn('[enrichmentJob] enrichWineById skipped: ANTHROPIC_API_KEY not configured');
+      return;
+    }
+    // Intentionally NOT skipped while a batch job runs: a batch snapshots its
+    // wine list at start, so a just-created wine isn't covered by it — skipping
+    // here would leave new wines permanently un-enriched. The already-enriched
+    // guard below prevents redundant work.
     const wine = await WineDefinition.findById(oid)
       .populate('country', 'name')
       .populate('region', 'name')


### PR DESCRIPTION
enrichWineById/embedSinglePair bailed out while a batch job ran, assuming the batch would cover the wine - false for a just-created wine (batch snapshots its list at start), leaving new wines un-enriched. Removes that guard; logs a missing ANTHROPIC_API_KEY instead of failing silently.