### PR TITLE
fix(deploy): stop serving a stale SPA shell after deploy (404 + CSP block)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,6 +48,7 @@
     <meta name="google-site-verification" content="" />
     <meta name="msvalidate.01" content="" />
 
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Cellarion" />

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -222,6 +222,32 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    # index.html and the service worker must NEVER be cached. index.html maps to
+    # build-hashed bundles (a stale copy 404s after the next deploy) and a stale
+    # SW keeps serving an old shell. Exact-match locations so the bare `/`, a
+    # direct `/index.html`, and `/service-worker.js` all get no-store — the
+    # @spa_shell fallback below only covers client-side routes, not these.
+    location = / {
+        root              /usr/share/nginx/html;
+        add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header        Pragma                                "no-cache"  always;
+        add_header        Expires                               "0"         always;
+        try_files         /index.html =404;
+    }
+    location = /index.html {
+        root              /usr/share/nginx/html;
+        add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header        Pragma                                "no-cache"  always;
+        add_header        Expires                               "0"         always;
+    }
+    location = /service-worker.js {
+        root              /usr/share/nginx/html;
+        add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header        Pragma                                "no-cache"  always;
+        add_header        Expires                               "0"         always;
+        try_files         /service-worker.js =404;
+    }
+
     # Serve the React SPA — fall back to index.html for client-side routing.
     # The SPA shell goes through a named-location fallback so the no-cache
     # header reliably applies, even when /index.html is served as the result

--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,12 +1,13 @@
 /* eslint-disable no-restricted-globals */
 
-const CACHE_NAME = 'cellarion-v3';
+const CACHE_NAME = 'cellarion-v4';
 const API_CACHE_NAME = 'cellarion-api-v1';
 
 // App shell files to pre-cache on install
+// Only truly static, un-hashed assets are precached. The HTML shell ('/' and
+// '/index.html') is deliberately NOT precached — it maps to build-hashed
+// bundles, so a frozen shell would request deleted assets (404) after a deploy.
 const PRECACHE_URLS = [
-  '/',
-  '/index.html',
   '/offline.html',
   '/manifest.json'
 ];
@@ -110,18 +111,12 @@ self.addEventListener('fetch', (event) => {
   // Skip other API requests — always go to network
   if (url.pathname.startsWith('/api/')) return;
 
-  // Navigation requests (HTML pages): network-first with offline fallback
+  // Navigation requests (HTML pages): always network-first, NEVER cached. The
+  // SPA shell references build-hashed bundles, so a cached shell would request
+  // deleted assets (404) after a deploy. Fall back to offline.html only offline.
   if (request.mode === 'navigate') {
     event.respondWith(
-      fetch(request)
-        .then((response) => {
-          if (response.ok) {
-            const clone = response.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
-          }
-          return response;
-        })
-        .catch(() => caches.match('/offline.html'))
+      fetch(request).catch(() => caches.match('/offline.html'))
     );
     return;
   }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -16,6 +16,11 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    // Don't inline Vite's modulePreload polyfill — it's emitted as an inline
+    // <script>, which the strict CSP in index.html (script-src 'self' …, with
+    // no 'unsafe-inline'/hash/nonce) would block. All target browsers support
+    // <link rel="modulepreload"> natively, so the polyfill is unnecessary.
+    modulePreload: { polyfill: false },
   },
   esbuild: {
     loader: 'jsx',


### PR DESCRIPTION
A stale index.html (service worker + edge/browser cache) kept referencing the previous build's hashed bundle (404) and an old inline modulePreload-polyfill script the strict CSP blocks. Hardens every layer: nginx no-store for /, /index.html, /service-worker.js; SW stops precaching/caching the HTML shell + cache version bump; vite modulePreload.polyfill=false (no inline script); + the standard mobile-web-app-capable meta. (Also set Cloudflare to not cache HTML.)