### PR TITLE
chore(release): v1.57.8

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.57.7",
+  "version": "1.57.8",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.57.7",
+  "version": "1.57.8",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release v1.57.8.

- #493 feat(bottle): report an incorrect AI tasting profile
- #494 chore(plans): remove the support-plan trial
- #495 fix(wines): only prompt 'did you mean?' for close matches (>=85%)
- #496 feat(maturity): per-bottle recalculated drink window for NV wines
- #497 fix(ai): enrich + embed new wines on add even during a batch job
- #498 fix(deploy): stop serving a stale SPA shell after deploy (404 + CSP)