### PR TITLE
fix(audit): remediate four high-severity findings (digest, import AI cap, Stripe plan, wishlist)

### DIFF
--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const { requireAuth } = require('../middleware/auth');
+const aiBurstLimiter = require('../middleware/aiBurstLimiter');
 const Bottle = require('../models/Bottle');
 const Cellar = require('../models/Cellar');
 const Rack = require('../models/Rack');
@@ -168,7 +169,7 @@ async function findWineMatches(item) {
  * Body: { cellarId, items: [{ wineName, producer, country, ... }] }
  * Response: { results: [{ index, item, status, matches: [{ wine, score }] }] }
  */
-router.post('/validate', async (req, res) => {
+router.post('/validate', aiBurstLimiter, async (req, res) => {
   try {
     const { cellarId, items } = req.body;
 

--- a/backend/src/routes/stripe.js
+++ b/backend/src/routes/stripe.js
@@ -3,6 +3,7 @@ const { requireAuth } = require('../middleware/auth');
 const User = require('../models/User');
 const StripeWebhookEvent = require('../models/StripeWebhookEvent');
 const { logAudit } = require('../services/audit');
+const { PLAN_RANK } = require('../utils/cellarCred');
 
 const router = express.Router();
 
@@ -22,6 +23,39 @@ function planFromPriceId(priceId) {
   if (priceId === process.env.STRIPE_SUPPORTER_PRICE_ID) return 'supporter';
   if (priceId === process.env.STRIPE_PATRON_PRICE_ID) return 'patron';
   return null;
+}
+
+/**
+ * Apply a Stripe-granted plan WITHOUT clobbering a higher-rank or unexpired
+ * non-Stripe grant (admin grants and Cellar-Cred tier rewards write the same
+ * `plan`/`planExpiresAt` fields — see utils/cellarCred.js, which already uses
+ * this max-rank guard). The Stripe subscription id is always recorded so a
+ * later cancellation can be matched to it.
+ *
+ * @returns {object} the audit-friendly { from, to } plan transition
+ */
+async function applyStripePlan(userId, plan, subscriptionId) {
+  const user = await User.findById(userId).select('plan planExpiresAt');
+  if (!user) return null;
+
+  const currentRank = PLAN_RANK[user.plan] ?? 0;
+  const newRank = PLAN_RANK[plan] ?? 0;
+  const planExpired = user.planExpiresAt && new Date(user.planExpiresAt) < new Date();
+
+  const update = { stripeSubscriptionId: subscriptionId };
+  // Only let the paid plan take effect if it's at least as high as the current
+  // plan, or the current (time-limited admin/Cellar-Cred) grant has expired —
+  // never downgrade an existing higher grant just because a lower sub started.
+  if (newRank >= currentRank || planExpired) {
+    update.plan = plan;
+    // Stamp the start only on a real change/re-activation, not on every routine
+    // subscription.updated (renewals, payment-method changes) — planStartedAt
+    // is a display value and shouldn't jump on each webhook.
+    if (plan !== user.plan || planExpired) update.planStartedAt = new Date();
+    update.planExpiresAt = null; // an active subscription has no expiry
+  }
+  await User.findByIdAndUpdate(userId, update);
+  return { from: user.plan, to: update.plan || user.plan };
 }
 
 // ── POST /api/stripe/checkout — Create a Stripe Checkout Session ──
@@ -146,13 +180,12 @@ router.post('/webhook', async (req, res) => {
           const userId = sub.metadata?.userId;
           const plan = sub.metadata?.plan;
           if (userId && plan) {
-            await User.findByIdAndUpdate(userId, {
-              plan,
-              planStartedAt: new Date(),
-              planExpiresAt: null,
-              stripeSubscriptionId: sub.id
-            });
-            console.log(`[stripe] User ${userId} upgraded to ${plan}`);
+            const change = await applyStripePlan(userId, plan, sub.id);
+            if (change) {
+              logAudit(null, 'stripe.plan.changed', { type: 'user', id: userId },
+                { event: 'checkout.session.completed', eventId: event.id, ...change });
+              console.log(`[stripe] User ${userId} subscribed to ${plan} (effective: ${change.to})`);
+            }
           }
         }
         break;
@@ -167,11 +200,16 @@ router.post('/webhook', async (req, res) => {
           const priceId = sub.items?.data?.[0]?.price?.id;
           const plan = planFromPriceId(priceId);
           if (plan) {
-            await User.findByIdAndUpdate(userId, {
-              plan,
-              planExpiresAt: null,
-              stripeSubscriptionId: sub.id
-            });
+            const change = await applyStripePlan(userId, plan, sub.id);
+            if (change) {
+              logAudit(null, 'stripe.plan.changed', { type: 'user', id: userId },
+                { event: 'customer.subscription.updated', eventId: event.id, ...change });
+            }
+          } else {
+            // Active subscription whose price doesn't map to any known plan —
+            // a price-list drift or misconfigured env var. Surface it instead
+            // of silently leaving the user on a stale plan.
+            console.warn(`[stripe] Active subscription ${sub.id} for user ${userId} maps to no known plan (price ${sub.items?.data?.[0]?.price?.id})`);
           }
         } else if (sub.status === 'past_due' || sub.status === 'unpaid') {
           // Keep current plan but log the issue
@@ -183,14 +221,33 @@ router.post('/webhook', async (req, res) => {
       case 'customer.subscription.deleted': {
         const sub = event.data.object;
         const userId = sub.metadata?.userId;
-        if (userId) {
-          await User.findByIdAndUpdate(userId, {
-            plan: 'free',
-            planExpiresAt: null,
-            stripeSubscriptionId: null
-          });
-          console.log(`[stripe] User ${userId} downgraded to free (subscription cancelled)`);
+        if (!userId) break;
+
+        // Reconcile rather than blindly downgrade. Only revoke entitlement when
+        // THIS Stripe subscription is the one currently in effect, and preserve
+        // an unexpired non-Stripe grant (admin / Cellar-Cred set planExpiresAt
+        // in the future; an active Stripe plan keeps it null). This prevents a
+        // cancelled/failed card from wiping an admin-granted or earned plan,
+        // and a stale redelivery after a re-subscribe from downgrading the
+        // newer subscription.
+        const user = await User.findById(userId).select('plan planExpiresAt stripeSubscriptionId');
+        if (!user) break;
+
+        if (user.stripeSubscriptionId !== sub.id) {
+          console.log(`[stripe] Ignoring deletion of ${sub.id} for user ${userId} — current sub is ${user.stripeSubscriptionId || 'none'}`);
+          break;
         }
+
+        const hasUnexpiredGrant = user.planExpiresAt && new Date(user.planExpiresAt) > new Date();
+        const update = { stripeSubscriptionId: null };
+        if (!hasUnexpiredGrant) {
+          update.plan = 'free';
+          update.planExpiresAt = null;
+        }
+        await User.findByIdAndUpdate(userId, update);
+        logAudit(null, 'stripe.plan.changed', { type: 'user', id: userId },
+          { event: 'customer.subscription.deleted', eventId: event.id, from: user.plan, to: update.plan || user.plan });
+        console.log(`[stripe] User ${userId} subscription ${sub.id} cancelled (plan now: ${update.plan || user.plan})`);
         break;
       }
 

--- a/backend/src/services/audit.js
+++ b/backend/src/services/audit.js
@@ -13,7 +13,10 @@ const logger = pino({
 /**
  * Fire-and-forget audit log entry.
  *
- * @param {object} req   - Express request (for actor + userAgent)
+ * @param {object|null} req - Express request (for actor + userAgent). Pass
+ *                            null for system-initiated events with no request
+ *                            (e.g. Stripe webhooks, scheduled jobs) — the actor
+ *                            is then recorded as 'system'.
  * @param {string} action - Dot-separated action name, e.g. 'bottle.add'
  * @param {object} resource - { type, id, cellarId } — what was acted on
  * @param {object} detail   - Action-specific payload (wineName, email, etc.)
@@ -21,14 +24,14 @@ const logger = pino({
 function logAudit(req, action, resource = {}, detail = {}) {
   const entry = {
     actor: {
-      userId:    req.user?.id    || null,
-      role:      req.user?.roles?.[0]  || 'anonymous',
+      userId:    req?.user?.id    || null,
+      role:      req?.user?.roles?.[0]  || (req ? 'anonymous' : 'system'),
       ipAddress: getClientIp(req)
     },
     action,
     resource,
     detail,
-    userAgent: req.headers?.['user-agent']
+    userAgent: req?.headers?.['user-agent']
   };
 
   // Structured stdout log — visible in docker logs

--- a/backend/src/services/drinkWindowNotifier.js
+++ b/backend/src/services/drinkWindowNotifier.js
@@ -18,6 +18,27 @@ const { createNotification } = require('./notifications');
 const { sendDrinkWindowDigest, EMAIL_VERIFICATION_ENABLED } = require('./mailgun');
 
 /**
+ * Whether the daily drink-window email digest should be sent to this user.
+ *
+ * The opt-in lives at `preferences.notifications.drinkWindow.email` — there is
+ * NO top-level `notifications.email` flag (see utils/notifications.js). Reading
+ * the wrong leaf previously evaluated to `undefined` for everyone and silently
+ * disabled the entire digest. Extracted as a pure, testable predicate so that
+ * regression is caught by a unit test rather than only in production.
+ *
+ * @param {object} user  Lean user doc with preferences.notifications + emailVerified
+ * @param {boolean} emailVerificationEnabled  Whether the email channel is configured
+ * @returns {boolean}
+ */
+function shouldSendDigestEmail(user, emailVerificationEnabled = EMAIL_VERIFICATION_ENABLED) {
+  return Boolean(
+    user?.preferences?.notifications?.drinkWindow?.email &&
+    emailVerificationEnabled &&
+    user?.emailVerified
+  );
+}
+
+/**
  * Main entry point — called by the scheduler once daily.
  */
 async function runDrinkWindowCheck() {
@@ -163,8 +184,8 @@ async function processUser(user, isFirstRun) {
     await createNotification(user._id, type, title, message, link);
   }
 
-  // Send email digest if opted in
-  if (user.preferences?.notifications?.email && EMAIL_VERIFICATION_ENABLED && user.emailVerified) {
+  // Send email digest if opted in (preferences.notifications.drinkWindow.email).
+  if (shouldSendDigestEmail(user)) {
     try {
       await sendDrinkWindowDigest(
         user.email,
@@ -207,4 +228,4 @@ function buildNotification(alert) {
   }
 }
 
-module.exports = { runDrinkWindowCheck };
+module.exports = { runDrinkWindowCheck, shouldSendDigestEmail };

--- a/backend/src/services/drinkWindowNotifier.test.js
+++ b/backend/src/services/drinkWindowNotifier.test.js
@@ -1,0 +1,44 @@
+const { shouldSendDigestEmail } = require('./drinkWindowNotifier');
+
+/**
+ * Regression coverage for the "silently dead digest" bug: the email opt-in
+ * lives at preferences.notifications.drinkWindow.email, NOT a top-level
+ * notifications.email flag. Reading the wrong leaf made the predicate
+ * undefined for every user, so the digest never sent.
+ */
+describe('shouldSendDigestEmail', () => {
+  const verified = (drinkWindowEmail) => ({
+    emailVerified: true,
+    preferences: { notifications: { drinkWindow: { enabled: true, email: drinkWindowEmail } } },
+  });
+
+  it('returns true when opted in at drinkWindow.email, verified, and channel enabled', () => {
+    expect(shouldSendDigestEmail(verified(true), true)).toBe(true);
+  });
+
+  it('returns false when the user has not opted in (drinkWindow.email false)', () => {
+    expect(shouldSendDigestEmail(verified(false), true)).toBe(false);
+  });
+
+  it('returns false when the (non-existent) legacy top-level notifications.email is set but drinkWindow.email is not', () => {
+    // This is the exact shape the old buggy code read — must NOT trigger a send.
+    const user = { emailVerified: true, preferences: { notifications: { email: true } } };
+    expect(shouldSendDigestEmail(user, true)).toBe(false);
+  });
+
+  it('returns false when the email channel is not configured (emailVerificationEnabled false)', () => {
+    expect(shouldSendDigestEmail(verified(true), false)).toBe(false);
+  });
+
+  it('returns false when the email is not verified', () => {
+    const user = { emailVerified: false, preferences: { notifications: { drinkWindow: { email: true } } } };
+    expect(shouldSendDigestEmail(user, true)).toBe(false);
+  });
+
+  it('is null-safe for missing preferences / user', () => {
+    expect(shouldSendDigestEmail(undefined, true)).toBe(false);
+    expect(shouldSendDigestEmail({}, true)).toBe(false);
+    expect(shouldSendDigestEmail({ emailVerified: true }, true)).toBe(false);
+    expect(shouldSendDigestEmail({ emailVerified: true, preferences: { notifications: {} } }, true)).toBe(false);
+  });
+});

--- a/backend/src/utils/cellarCred.js
+++ b/backend/src/utils/cellarCred.js
@@ -142,4 +142,4 @@ async function incrementCred(userId, eventType) {
   }
 }
 
-module.exports = { POINT_VALUES, CATEGORY_MAP, TIERS, getTier, getSpecialty, incrementCred };
+module.exports = { POINT_VALUES, CATEGORY_MAP, TIERS, PLAN_RANK, getTier, getSpecialty, incrementCred };

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -102,8 +102,13 @@ function AddToWishlist() {
     let cancelled = false;
     (async () => {
       try {
-        const wine = await getWine(apiFetch, restock.wineId);
-        if (!cancelled && wine) {
+        // getWine returns the raw fetch Response — parse the body and check
+        // res.ok before using it (a Response object is always truthy).
+        const res = await getWine(apiFetch, restock.wineId);
+        if (cancelled || !res.ok) return;
+        const data = await res.json();
+        const wine = data.wine || data;
+        if (!cancelled && wine?._id) {
           setSelectedWine(wine);
           if (restock.vintage) setVintage(restock.vintage);
         }


### PR DESCRIPTION
Remediates High findings 2–5 from the 2026-06-05 full code audit.

## Fixes

### High 2 — drink-window email digest was silently dead
`drinkWindowNotifier` gated the digest on `preferences.notifications.email`, a top-level flag that does not exist in the schema (the opt-in lives at `preferences.notifications.drinkWindow.email`). The condition was always `undefined`, so the entire email digest never sent for any user — and its GDPR one-click unsubscribe link was therefore unreachable. Extracted `shouldSendDigestEmail()` as a pure predicate and added a unit test (incl. a guard asserting the old buggy shape does **not** send).

### High 3 — uncapped import AI fan-out
`POST /api/bottles/import/validate` fans out one Anthropic call per unique wine but was the only AI-backed endpoint without the per-user `aiBurstLimiter` (its own docstring already claimed coverage). Now gated.

### High 4 — Stripe webhook clobbered admin/Cellar-Cred plans
The webhook overwrote `plan`/`planExpiresAt`/`stripeSubscriptionId` blindly, even though admin grants and Cellar-Cred rewards write the same fields. New `applyStripePlan()` applies max-rank semantics (reusing `PLAN_RANK`, now exported from `utils/cellarCred`) so a paid sub never downgrades a higher grant, always records `stripeSubscriptionId`, and only stamps `planStartedAt` on a real change. `customer.subscription.deleted` now only revokes when this sub is the one in effect and preserves an unexpired non-Stripe grant — fixing both the "card-fail wipes admin grant" and "stale redelivery downgrades a re-subscribe" cases. Also: plan changes are now audit-logged, and an active sub with an unmapped price warns instead of silently no-op'ing.

### High 5 — AddToWishlist treated a raw `Response` as the wine
`getWine()` returns the raw fetch `Response`; the restock pre-select used it directly (always truthy), saving a null wine ref. Now checks `res.ok`, parses `res.json()`, and reads `data.wine` (matching `WineReferenceCard`).

## Supporting changes
- Export `PLAN_RANK` from `utils/cellarCred`.
- Make `logAudit(null, ...)` safe so system events (webhooks) record actor `system`.

## Known residual (follow-up, out of scope)
A **permanent** (no-expiry) admin grant coexisting with a Stripe sub still can't be distinguished from the Stripe plan on cancellation. Fully resolving needs a separate "stripe plan vs effective plan" field.

## Tests
- Backend: **629/629** (30 suites; 6 new).
- Frontend: **293/293**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)