### PR TITLE
fix(bottles): canonical bottle sizes + admin fix-up tab

### DIFF
--- a/backend/src/config/bottleSizes.js
+++ b/backend/src/config/bottleSizes.js
@@ -1,0 +1,75 @@
+/**
+ * Canonical bottle sizes — single source of truth (backend).
+ *
+ * The stored value on `Bottle.bottleSize` is a canonical CODE: the volume in
+ * millilitres followed by "ml" (e.g. '750ml', '1500ml'). Display labels
+ * ("Standard", "Magnum", "1.5 L") are derived in the frontend via i18n — we
+ * never store a localized label, which is what produced the historical mess
+ * ('750ml (Standard)', '750ml（標準）', '1.5L', …).
+ *
+ * Mirror of frontend/src/config/bottleSizes.js (kept in sync by hand, like
+ * config/currencies and config/plans).
+ */
+
+// Named formats. `nameKey` resolves to i18n `bottleSizeNames.<key>` on the UI.
+const BOTTLE_SIZES = [
+  { ml: 187, code: '187ml', nameKey: 'split' },
+  { ml: 375, code: '375ml', nameKey: 'half' },
+  { ml: 500, code: '500ml', nameKey: 'halfLitre' },
+  { ml: 620, code: '620ml', nameKey: 'clavelin' },     // Jura vin jaune
+  { ml: 750, code: '750ml', nameKey: 'standard' },
+  { ml: 1500, code: '1500ml', nameKey: 'magnum' },
+  { ml: 3000, code: '3000ml', nameKey: 'doubleMagnum' },
+  { ml: 6000, code: '6000ml', nameKey: 'imperial' },
+];
+
+const CANONICAL_CODES = new Set(BOTTLE_SIZES.map((s) => s.code));
+const DEFAULT_SIZE = '750ml';
+
+/** A code is canonical if it matches the "<positive integer>ml" shape. */
+function isCanonicalCode(value) {
+  return typeof value === 'string' && /^\d+ml$/.test(value);
+}
+
+/**
+ * Normalize any bottle-size input to a canonical "<ml>ml" code, or null when no
+ * volume can be parsed. Handles localized labels, L/cl/ml units, EU decimal
+ * commas, bare numbers, and trailing label text in any script.
+ *   '750ml (Standard)' → '750ml'   '750ml（標準）' → '750ml'
+ *   '1.5L (Magnum)'    → '1500ml'  '0,75 l'      → '750ml'
+ *   '620ml'            → '620ml'   750            → '750ml'   '1.5' → '1500ml'
+ */
+function normalizeBottleSize(input) {
+  if (input == null) return null;
+
+  if (typeof input === 'number') {
+    if (!isFinite(input) || input <= 0) return null;
+    const ml = input < 20 ? input * 1000 : input; // a bare number < 20 is litres
+    return `${Math.round(ml)}ml`;
+  }
+
+  const s = String(input).trim().toLowerCase().replace(',', '.');
+  const m = s.match(/(\d+(?:\.\d+)?)\s*(ml|cl|cℓ|l|ℓ|litre|liter|litres|liters)?/);
+  if (!m) return null;
+
+  const val = parseFloat(m[1]);
+  if (!isFinite(val) || val <= 0) return null;
+
+  const unit = m[2];
+  let ml;
+  if (unit === 'ml') ml = val;
+  else if (unit === 'cl' || unit === 'cℓ') ml = val * 10;
+  else if (unit) ml = val * 1000; // litre variants
+  else ml = val < 20 ? val * 1000 : val; // unitless: < 20 → litres, else ml
+
+  ml = Math.round(ml);
+  return ml > 0 ? `${ml}ml` : null;
+}
+
+module.exports = {
+  BOTTLE_SIZES,
+  CANONICAL_CODES,
+  DEFAULT_SIZE,
+  isCanonicalCode,
+  normalizeBottleSize,
+};

--- a/backend/src/config/bottleSizes.test.js
+++ b/backend/src/config/bottleSizes.test.js
@@ -1,0 +1,46 @@
+const { normalizeBottleSize, isCanonicalCode, CANONICAL_CODES } = require('./bottleSizes');
+
+describe('normalizeBottleSize', () => {
+  test.each([
+    ['750ml (Standard)', '750ml'],
+    ['750ml（標準）', '750ml'],   // localized label suffix (Japanese)
+    ['750ml', '750ml'],
+    ['750 ml', '750ml'],
+    ['1.5L (Magnum)', '1500ml'],
+    ['3L (Double Magnum)', '3000ml'],
+    ['1,5 l', '1500ml'],          // EU decimal comma
+    ['0,75L', '750ml'],
+    ['0.375', '375ml'],           // bare litres (< 20)
+    ['620ml', '620ml'],           // Clavelin — kept as-is
+    ['375ml (Half)', '375ml'],
+    ['75cl', '750ml'],            // centilitres
+    [750, '750ml'],               // bare number ml
+    [1.5, '1500ml'],              // bare number litres
+    ['', null],
+    ['n/a', null],
+    [null, null],
+    [undefined, null],
+  ])('%p → %p', (input, expected) => {
+    expect(normalizeBottleSize(input)).toBe(expected);
+  });
+});
+
+describe('isCanonicalCode', () => {
+  test('accepts <int>ml', () => {
+    expect(isCanonicalCode('750ml')).toBe(true);
+    expect(isCanonicalCode('1500ml')).toBe(true);
+  });
+  test('rejects labels and junk', () => {
+    expect(isCanonicalCode('750ml (Standard)')).toBe(false);
+    expect(isCanonicalCode('1.5L')).toBe(false);
+    expect(isCanonicalCode('')).toBe(false);
+    expect(isCanonicalCode(null)).toBe(false);
+  });
+});
+
+test('all canonical codes are themselves canonical and idempotent', () => {
+  for (const code of CANONICAL_CODES) {
+    expect(isCanonicalCode(code)).toBe(true);
+    expect(normalizeBottleSize(code)).toBe(code);
+  }
+});

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -9,6 +9,8 @@ const Appellation = require('../../models/Appellation');
 const searchService = require('../../services/search');
 const { logAudit } = require('../../services/audit');
 const { isValidId } = require('../../utils/validation');
+const { distinctSizes, normalizeAll, remap } = require('../../services/bottleSizeMaintenance');
+const { BOTTLE_SIZES } = require('../../config/bottleSizes');
 
 const router = express.Router();
 
@@ -506,6 +508,48 @@ router.delete('/appellations/:id', async (req, res) => {
   } catch (error) {
     console.error('Delete appellation error:', error);
     res.status(500).json({ error: 'Failed to delete appellation' });
+  }
+});
+
+// ===== BOTTLE SIZES =====
+
+// GET /api/admin/taxonomy/bottle-sizes - Distinct stored sizes + counts,
+// plus the canonical reference list for the UI.
+router.get('/bottle-sizes', async (req, res) => {
+  try {
+    const sizes = await distinctSizes();
+    res.json({ sizes, canonical: BOTTLE_SIZES });
+  } catch (error) {
+    console.error('List bottle sizes error:', error);
+    res.status(500).json({ error: 'Failed to list bottle sizes' });
+  }
+});
+
+// POST /api/admin/taxonomy/bottle-sizes/remap - Bulk-remap one stored value
+// to a canonical code. Body: { from, to }
+router.post('/bottle-sizes/remap', async (req, res) => {
+  try {
+    const result = await remap(req.body.from, req.body.to);
+    logAudit(req, 'admin.bottleSize.remap',
+      { from: result.from, to: result.to },
+      { modified: result.modified }
+    );
+    res.json(result);
+  } catch (error) {
+    res.status(400).json({ error: error.message || 'Remap failed' });
+  }
+});
+
+// POST /api/admin/taxonomy/bottle-sizes/normalize-all - Normalize every bottle
+// to its canonical code in one pass.
+router.post('/bottle-sizes/normalize-all', async (req, res) => {
+  try {
+    const result = await normalizeAll();
+    logAudit(req, 'admin.bottleSize.normalizeAll', {}, result);
+    res.json(result);
+  } catch (error) {
+    console.error('Normalize bottle sizes error:', error);
+    res.status(500).json({ error: 'Failed to normalize bottle sizes' });
   }
 });
 

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -23,6 +23,7 @@ const { checkRestockGap, resolveRestockAlerts } = require('../services/restockCh
 const { gatherPriceWarnings } = require('../services/priceWarnings');
 const { stripHtml, isSafeUrl } = require('../utils/sanitize');
 const { parseAndValidateVintage } = require('../utils/validation');
+const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
 const { toNormalized } = require('../utils/ratingUtils');
 const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
 const { parsePagination } = require('../utils/pagination');
@@ -403,7 +404,7 @@ router.post('/', async (req, res) => {
       price,
       currency: currency || 'USD',
       priceSetAt,
-      bottleSize: bottleSize || '750ml',
+      bottleSize: normalizeBottleSize(bottleSize) || DEFAULT_SIZE,
       purchaseDate: purchaseDate || new Date(),
       purchaseLocation: stripHtml(purchaseLocation),
       purchaseUrl,
@@ -560,6 +561,11 @@ router.put('/:id', requireBottleAccess('editor'), async (req, res) => {
       const vintageCheck = parseAndValidateVintage(req.body.vintage);
       if (!vintageCheck.ok) return res.status(400).json({ error: vintageCheck.error });
       req.body.vintage = vintageCheck.value;
+    }
+
+    // Canonicalize bottle size on the way in (e.g. '1.5L (Magnum)' → '1500ml').
+    if (req.body.bottleSize !== undefined) {
+      req.body.bottleSize = normalizeBottleSize(req.body.bottleSize) || DEFAULT_SIZE;
     }
 
     // Update allowed fields — diff old vs new for the audit log

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -13,6 +13,7 @@ const { logAudit } = require('../services/audit');
 const { getOrCreateDailySnapshot } = require('../utils/exchangeRates');
 const { resolveRating } = require('../utils/ratingUtils');
 const { normalizeString } = require('../utils/normalize');
+const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
 const searchService = require('../services/search');
 const { identifyWineFromText } = require('../services/labelScan');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
@@ -621,7 +622,7 @@ router.post('/confirm', async (req, res) => {
             price: item.price || undefined,
             currency: item.currency || defaultCurrency,
             priceSetAt,
-            bottleSize: item.bottleSize || '750ml',
+            bottleSize: normalizeBottleSize(item.bottleSize) || DEFAULT_SIZE,
             purchaseDate: item.purchaseDate || undefined,
             purchaseLocation: stripHtml(item.purchaseLocation),
             location: stripHtml(item.location),
@@ -703,7 +704,7 @@ router.post('/confirm', async (req, res) => {
           price: item.price || undefined,
           currency: item.currency || defaultCurrency,
           priceSetAt,
-          bottleSize: item.bottleSize || '750ml',
+          bottleSize: normalizeBottleSize(item.bottleSize) || DEFAULT_SIZE,
           purchaseDate: item.purchaseDate || undefined,
           purchaseLocation: stripHtml(item.purchaseLocation),
           location: stripHtml(item.location),

--- a/backend/src/runNormalizeBottleSizes.js
+++ b/backend/src/runNormalizeBottleSizes.js
@@ -1,0 +1,29 @@
+/**
+ * One-off / on-demand backfill: normalize every bottle's size to a canonical
+ * code ('750ml (Standard)' → '750ml', '1.5L (Magnum)' → '1500ml', …).
+ * Idempotent. Also runnable from the admin Bottle Sizes tab.
+ *
+ * Run via:
+ *   docker exec cellarion-backend node src/runNormalizeBottleSizes.js
+ */
+'use strict';
+
+const mongoose = require('mongoose');
+const { normalizeAll } = require('./services/bottleSizeMaintenance');
+
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/winecellar';
+
+async function main() {
+  await mongoose.connect(MONGO_URI);
+  const result = await normalizeAll();
+  console.log(`[normalizeBottleSizes] ${result.changed} bottle(s) normalized.`);
+  if (result.unparseable.length) {
+    console.log('[normalizeBottleSizes] needs manual remap:', JSON.stringify(result.unparseable));
+  }
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error('[normalizeBottleSizes] Failed:', err);
+  process.exit(1);
+});

--- a/backend/src/services/bottleSizeMaintenance.js
+++ b/backend/src/services/bottleSizeMaintenance.js
@@ -1,0 +1,56 @@
+/**
+ * Bottle-size data maintenance — list distinct stored sizes, bulk-remap one
+ * value to another, and normalize the whole collection to canonical codes.
+ *
+ * Used by the admin "Bottle Sizes" tab and by runNormalizeBottleSizes.js.
+ */
+const Bottle = require('../models/Bottle');
+const { normalizeBottleSize, isCanonicalCode, DEFAULT_SIZE } = require('../config/bottleSizes');
+
+/** Distinct bottleSize values in use, with counts + canonical flag + suggestion. */
+async function distinctSizes() {
+  const rows = await Bottle.aggregate([
+    { $group: { _id: '$bottleSize', count: { $sum: 1 } } },
+    { $sort: { count: -1 } },
+  ]);
+  return rows.map((r) => ({
+    value: r._id ?? null,
+    count: r.count,
+    canonical: isCanonicalCode(r._id),
+    // What normalize-all / remap would turn this into (DEFAULT for empty,
+    // null when it can't be parsed → needs a manual remap decision).
+    suggested: r._id == null || r._id === '' ? DEFAULT_SIZE : normalizeBottleSize(r._id),
+  }));
+}
+
+/** Normalize every bottle's size to its canonical code in bulk. Idempotent. */
+async function normalizeAll() {
+  const rows = await distinctSizes();
+  let changed = 0;
+  const unparseable = [];
+  for (const r of rows) {
+    const from = r.value;
+    const to = from == null || from === '' ? DEFAULT_SIZE : normalizeBottleSize(from);
+    if (to == null) {
+      unparseable.push({ value: from, count: r.count }); // leave for manual remap
+      continue;
+    }
+    if (to !== from) {
+      const filter = from == null ? { bottleSize: null } : { bottleSize: from };
+      const res = await Bottle.updateMany(filter, { $set: { bottleSize: to } });
+      changed += res.modifiedCount || 0;
+    }
+  }
+  return { changed, unparseable };
+}
+
+/** Bulk-remap one stored value to a canonical code (admin manual fix). */
+async function remap(from, to) {
+  if (typeof from !== 'string' || from === '') throw new Error('"from" value is required');
+  const target = normalizeBottleSize(to);
+  if (!target) throw new Error('"to" must be a valid size (e.g. 750ml or 1.5L)');
+  const res = await Bottle.updateMany({ bottleSize: from }, { $set: { bottleSize: target } });
+  return { from, to: target, modified: res.modifiedCount || 0 };
+}
+
+module.exports = { distinctSizes, normalizeAll, remap };

--- a/frontend/src/components/BottleSizesAdmin.js
+++ b/frontend/src/components/BottleSizesAdmin.js
@@ -1,0 +1,136 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { bottleSizeLabel } from '../config/bottleSizes';
+
+/**
+ * Admin panel (rendered as a tab inside AdminTaxonomy) for auditing and fixing
+ * the bottle-size values stored on bottles: lists distinct values + counts,
+ * flags non-canonical ones, and lets an admin remap a value to a canonical
+ * code or normalize the whole collection in one click.
+ */
+export default function BottleSizesAdmin({ apiFetch }) {
+  const { t } = useTranslation();
+  const [sizes, setSizes] = useState([]);
+  const [canonical, setCanonical] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState(null);
+  const [targets, setTargets] = useState({}); // stored value -> chosen target code
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch('/api/admin/taxonomy/bottle-sizes');
+      const data = await res.json();
+      if (res.ok) {
+        setSizes(data.sizes || []);
+        setCanonical(data.canonical || []);
+      }
+    } catch { /* ignore */ } finally {
+      setLoading(false);
+    }
+  }, [apiFetch]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const normalizeAll = async () => {
+    setBusy(true); setMsg(null);
+    try {
+      const res = await apiFetch('/api/admin/taxonomy/bottle-sizes/normalize-all', { method: 'POST' });
+      const data = await res.json();
+      if (res.ok) {
+        setMsg(t('admin.bottleSizes.normalized', { defaultValue: '{{count}} bottle(s) normalized.', count: data.changed }));
+        await load();
+      }
+    } catch { /* ignore */ } finally {
+      setBusy(false);
+    }
+  };
+
+  const remap = async (from) => {
+    const to = targets[from];
+    if (!to) return;
+    setBusy(true); setMsg(null);
+    try {
+      const res = await apiFetch('/api/admin/taxonomy/bottle-sizes/remap', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ from, to }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setMsg(t('admin.bottleSizes.remapped', { defaultValue: '{{count}} bottle(s) remapped.', count: data.modified }));
+        await load();
+      } else {
+        setMsg(data.error || 'Remap failed');
+      }
+    } catch { /* ignore */ } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) return <div className="loading">{t('common.loading')}</div>;
+
+  const nonCanonical = sizes.filter((s) => !s.canonical).length;
+
+  return (
+    <div className="bottle-sizes-admin">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, marginBottom: 12 }}>
+        <p style={{ margin: 0, color: '#9A9484' }}>
+          {t('admin.bottleSizes.intro', { defaultValue: '{{count}} non-standard value(s) in use.', count: nonCanonical })}
+        </p>
+        <button className="btn btn-primary btn-small" onClick={normalizeAll} disabled={busy || nonCanonical === 0}>
+          {t('admin.bottleSizes.normalizeAll', 'Normalize all')}
+        </button>
+      </div>
+
+      {msg && <div className="alert alert-success">{msg}</div>}
+
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr style={{ textAlign: 'left', color: '#9A9484', fontSize: 13 }}>
+            <th style={{ padding: '6px 8px' }}>{t('admin.bottleSizes.stored', 'Stored value')}</th>
+            <th style={{ padding: '6px 8px' }}>{t('admin.bottleSizes.count', 'Bottles')}</th>
+            <th style={{ padding: '6px 8px' }}>{t('admin.bottleSizes.status', 'Status')}</th>
+            <th style={{ padding: '6px 8px' }}>{t('admin.bottleSizes.remapTo', 'Remap to')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sizes.map((s) => (
+            <tr key={s.value == null ? '(empty)' : s.value} style={{ borderTop: '1px solid #252525' }}>
+              <td style={{ padding: '6px 8px', fontFamily: 'monospace' }}>
+                {s.value == null ? <em>(empty)</em> : s.value}
+              </td>
+              <td style={{ padding: '6px 8px' }}>{s.count}</td>
+              <td style={{ padding: '6px 8px' }}>
+                {s.canonical
+                  ? `✓ ${bottleSizeLabel(s.value, t)}`
+                  : s.suggested
+                    ? `→ ${bottleSizeLabel(s.suggested, t)}`
+                    : t('admin.bottleSizes.unrecognized', 'unrecognized')}
+              </td>
+              <td style={{ padding: '6px 8px' }}>
+                {!s.canonical && s.value != null && (
+                  <span style={{ display: 'inline-flex', gap: 6 }}>
+                    <select
+                      value={targets[s.value] || s.suggested || ''}
+                      onChange={(e) => setTargets({ ...targets, [s.value]: e.target.value })}
+                    >
+                      <option value="" disabled>{t('admin.bottleSizes.choose', 'Choose…')}</option>
+                      {canonical.map((c) => (
+                        <option key={c.code} value={c.code}>{bottleSizeLabel(c.code, t)}</option>
+                      ))}
+                    </select>
+                    <button className="btn btn-secondary btn-small" disabled={busy} onClick={() => remap(s.value)}>
+                      {t('admin.bottleSizes.apply', 'Apply')}
+                    </button>
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/bottle/EditForm.js
+++ b/frontend/src/components/bottle/EditForm.js
@@ -5,6 +5,7 @@ import { updateBottle, setBottleDefaultImage } from '../../api/bottles';
 import { toInputDate } from '../../utils/drinkStatus';
 import { API_URL } from '../../api/apiConstants';
 import { CURRENCIES } from '../../config/currencies';
+import { BOTTLE_SIZES, bottleSizeLabel, normalizeBottleSize } from '../../config/bottleSizes';
 import RatingInput from '../RatingInput';
 
 const ImageUpload = lazy(() => import('../ImageUpload'));
@@ -23,7 +24,7 @@ function EditForm({ bottle, onSaved, onCancel, onImageUploaded }) {
     // If bottle has a price, keep stored currency (price and currency must stay in sync).
     // If no price yet, default to user's preference so they don't have to change it every time.
     currency:         bottle.price ? (bottle.currency || 'USD') : (user?.preferences?.currency || bottle.currency || 'USD'),
-    bottleSize:       bottle.bottleSize || '750ml',
+    bottleSize:       normalizeBottleSize(bottle.bottleSize) || bottle.bottleSize || '750ml',
     purchaseDate:     toInputDate(bottle.purchaseDate),
     purchaseLocation: bottle.purchaseLocation || '',
     purchaseUrl:      bottle.purchaseUrl || '',
@@ -100,10 +101,12 @@ function EditForm({ bottle, onSaved, onCancel, onImageUploaded }) {
         <div className="form-group">
           <label>{t('addBottle.bottleSize')}</label>
           <select value={form.bottleSize} onChange={set('bottleSize')}>
-            <option>375ml (Half)</option>
-            <option>750ml (Standard)</option>
-            <option>1.5L (Magnum)</option>
-            <option>3L (Double Magnum)</option>
+            {!BOTTLE_SIZES.some((s) => s.code === form.bottleSize) && form.bottleSize && (
+              <option value={form.bottleSize}>{bottleSizeLabel(form.bottleSize, t)}</option>
+            )}
+            {BOTTLE_SIZES.map((s) => (
+              <option key={s.code} value={s.code}>{bottleSizeLabel(s.code, t)}</option>
+            ))}
           </select>
         </div>
 

--- a/frontend/src/components/bottle/ViewDetails.js
+++ b/frontend/src/components/bottle/ViewDetails.js
@@ -5,6 +5,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { getMaturityStatus } from '../../utils/drinkStatus';
 import { bottleAnchorYear } from '../../utils/maturityUtils';
 import { convertAmountHistorical } from '../../utils/currency';
+import { bottleSizeLabel } from '../../config/bottleSizes';
 import { buildRackUrl } from '../../utils/rackNavigation';
 import safeUrl from '../../utils/safeUrl';
 import RatingDisplay from '../RatingDisplay';
@@ -37,7 +38,7 @@ function ViewDetails({ bottle, rackInfo, cellarId, vintageProfile, priceHistory,
         {bottle.bottleSize && (
           <div className="bd-detail-item">
             <span className="bd-detail-label">{t('bottleDetail.size')}</span>
-            <span className="bd-detail-value">{bottle.bottleSize}</span>
+            <span className="bd-detail-value">{bottleSizeLabel(bottle.bottleSize, t)}</span>
           </div>
         )}
         {bottle.rating && (

--- a/frontend/src/config/bottleSizes.js
+++ b/frontend/src/config/bottleSizes.js
@@ -1,0 +1,72 @@
+/**
+ * Canonical bottle sizes (frontend) — mirror of backend/src/config/bottleSizes.js.
+ *
+ * Stored value is a canonical CODE ('<ml>ml', e.g. '750ml'). Display labels
+ * ("Standard", "1.5 L (Magnum)") are derived here via i18n — never stored.
+ */
+
+export const BOTTLE_SIZES = [
+  { ml: 187, code: '187ml', nameKey: 'split' },
+  { ml: 375, code: '375ml', nameKey: 'half' },
+  { ml: 500, code: '500ml', nameKey: 'halfLitre' },
+  { ml: 620, code: '620ml', nameKey: 'clavelin' },
+  { ml: 750, code: '750ml', nameKey: 'standard' },
+  { ml: 1500, code: '1500ml', nameKey: 'magnum' },
+  { ml: 3000, code: '3000ml', nameKey: 'doubleMagnum' },
+  { ml: 6000, code: '6000ml', nameKey: 'imperial' },
+];
+
+export const DEFAULT_SIZE = '750ml';
+
+export function isCanonicalCode(value) {
+  return typeof value === 'string' && /^\d+ml$/.test(value);
+}
+
+/** Volume in ml from a canonical code, or null. */
+export function mlFromCode(code) {
+  const m = /^(\d+)ml$/.exec(code || '');
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/** Format ml as a friendly volume: 750 → "750 ml", 1500 → "1.5 L". */
+export function formatVolume(ml) {
+  if (!isFinite(ml) || ml <= 0) return '';
+  return ml >= 1000 ? `${+(ml / 1000).toFixed(3)} L` : `${ml} ml`;
+}
+
+/** Display label for a code, e.g. "1.5 L (Magnum)" or "900 ml" for unnamed. */
+export function bottleSizeLabel(code, t) {
+  const ml = mlFromCode(code);
+  if (ml == null) return code || '';
+  const named = BOTTLE_SIZES.find((s) => s.code === code);
+  const vol = formatVolume(ml);
+  return named ? `${vol} (${t(`bottleSizeNames.${named.nameKey}`)})` : vol;
+}
+
+/** Normalize any input to a canonical "<ml>ml" code, or null. (Mirror of backend.) */
+export function normalizeBottleSize(input) {
+  if (input == null) return null;
+
+  if (typeof input === 'number') {
+    if (!isFinite(input) || input <= 0) return null;
+    const ml = input < 20 ? input * 1000 : input;
+    return `${Math.round(ml)}ml`;
+  }
+
+  const s = String(input).trim().toLowerCase().replace(',', '.');
+  const m = s.match(/(\d+(?:\.\d+)?)\s*(ml|cl|cℓ|l|ℓ|litre|liter|litres|liters)?/);
+  if (!m) return null;
+
+  const val = parseFloat(m[1]);
+  if (!isFinite(val) || val <= 0) return null;
+
+  const unit = m[2];
+  let ml;
+  if (unit === 'ml') ml = val;
+  else if (unit === 'cl' || unit === 'cℓ') ml = val * 10;
+  else if (unit) ml = val * 1000;
+  else ml = val < 20 ? val * 1000 : val;
+
+  ml = Math.round(ml);
+  return ml > 0 ? `${ml}ml` : null;
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -657,12 +657,26 @@
       "applyGrapesNote": "Select the grape varieties to add to this wine. Unrecognised names can be added to the taxonomy first.",
       "applyGrapesLabel": "Grapes to add"
     },
+    "bottleSizes": {
+      "normalizeAll": "Normalize all",
+      "stored": "Stored value",
+      "count": "Bottles",
+      "status": "Status",
+      "remapTo": "Remap to",
+      "choose": "Choose…",
+      "apply": "Apply",
+      "unrecognized": "unrecognized",
+      "intro": "{{count}} non-standard value(s) in use.",
+      "normalized": "{{count}} bottle(s) normalized.",
+      "remapped": "{{count}} bottle(s) remapped."
+    },
     "taxonomy": {
       "title": "Admin: Taxonomy Management",
       "countries": "Countries",
       "regions": "Regions",
       "appellations": "Appellations",
       "grapes": "Grapes",
+      "bottleSizes": "Bottle Sizes",
       "addCountry": "+ Add country",
       "addRegion": "+ Add region",
       "addAppellation": "+ Add appellation",
@@ -955,6 +969,16 @@
     "saving": "Saving…"
   },
 
+  "bottleSizeNames": {
+    "split": "Split",
+    "half": "Half",
+    "halfLitre": "Half-litre",
+    "clavelin": "Clavelin",
+    "standard": "Standard",
+    "magnum": "Magnum",
+    "doubleMagnum": "Double Magnum",
+    "imperial": "Imperial"
+  },
   "statistics": {
     "title": "Collection Analytics",
     "subtitleFull": "Complete insights across {{cellars}} cellar · {{countries}} countries · {{grapes}} grape varieties",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -657,12 +657,26 @@
       "applyGrapesNote": "Välj de druvsorter som ska läggas till för det här vinet. Okända namn kan läggas till i taxonomin först.",
       "applyGrapesLabel": "Druvor att lägga till"
     },
+    "bottleSizes": {
+      "normalizeAll": "Normalisera alla",
+      "stored": "Lagrat värde",
+      "count": "Flaskor",
+      "status": "Status",
+      "remapTo": "Mappa om till",
+      "choose": "Välj…",
+      "apply": "Tillämpa",
+      "unrecognized": "okänt",
+      "intro": "{{count}} icke-standardvärde(n) används.",
+      "normalized": "{{count}} flaska/flaskor normaliserade.",
+      "remapped": "{{count}} flaska/flaskor ommappade."
+    },
     "taxonomy": {
       "title": "Admin: Taxonomihantering",
       "countries": "Länder",
       "regions": "Regioner",
       "appellations": "Appellationer",
       "grapes": "Druvor",
+      "bottleSizes": "Flaskstorlekar",
       "addCountry": "+ Lägg till land",
       "addRegion": "+ Lägg till region",
       "addAppellation": "+ Lägg till appellation",
@@ -955,6 +969,16 @@
     "saving": "Sparar…"
   },
 
+  "bottleSizeNames": {
+    "split": "Split",
+    "half": "Halvflaska",
+    "halfLitre": "Halvliter",
+    "clavelin": "Clavelin",
+    "standard": "Standard",
+    "magnum": "Magnum",
+    "doubleMagnum": "Dubbelmagnum",
+    "imperial": "Imperial"
+  },
   "statistics": {
     "title": "Samlingsanalys",
     "subtitleFull": "Fullständig överblick över {{cellars}} källare · {{countries}} länder · {{grapes}} druvsorter",

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { searchWines, findOrCreateWine, identifyWineByText } from '../api/wines';
 import useLabelScanner from '../hooks/useLabelScanner';
 import { CURRENCIES } from '../config/currencies';
+import { BOTTLE_SIZES, bottleSizeLabel } from '../config/bottleSizes';
 import { validatePriceSanity } from '../utils/priceValidation';
 import ImageUpload from '../components/ImageUpload';
 import RatingInput from '../components/RatingInput';
@@ -33,7 +34,7 @@ function AddBottle() {
     vintage: '',
     price: '',
     currency: user?.preferences?.currency || 'USD',
-    bottleSize: '750ml (Standard)',
+    bottleSize: '750ml',
     purchaseDate: '',
     purchaseLocation: '',
     purchaseUrl: '',
@@ -736,10 +737,9 @@ function AddBottle() {
                   value={bottleData.bottleSize}
                   onChange={(e) => setBottleData({ ...bottleData, bottleSize: e.target.value })}
                 >
-                  <option>375ml (Half)</option>
-                  <option>750ml (Standard)</option>
-                  <option>1.5L (Magnum)</option>
-                  <option>3L (Double Magnum)</option>
+                  {BOTTLE_SIZES.map((s) => (
+                    <option key={s.code} value={s.code}>{bottleSizeLabel(s.code, t)}</option>
+                  ))}
                 </select>
               </div>
 

--- a/frontend/src/pages/AdminTaxonomy.js
+++ b/frontend/src/pages/AdminTaxonomy.js
@@ -7,6 +7,7 @@ import {
 } from '../api/admin';
 import GrapePicker from '../components/GrapePicker';
 import ConfirmModal from '../components/ConfirmModal';
+import BottleSizesAdmin from '../components/BottleSizesAdmin';
 import './AdminTaxonomy.css';
 
 function AdminTaxonomy() {
@@ -74,6 +75,7 @@ function AdminTaxonomy() {
   };
 
   const fetchItems = async () => {
+    if (activeTab === 'bottleSizes') { setItems([]); setLoading(false); return; }
     setLoading(true);
     setError(null);
     try {
@@ -591,11 +593,13 @@ function AdminTaxonomy() {
 
   const isEditing = !!editItem;
 
+  const isBottleSizes = activeTab === 'bottleSizes';
+
   return (
     <div className="admin-taxonomy-page">
       <div className="page-header">
         <h1>{t('admin.taxonomy.title')}</h1>
-        {!isEditing && (
+        {!isEditing && !isBottleSizes && (
           <button onClick={() => { setShowForm(!showForm); setFormData({}); }} className="btn btn-primary">
             {showForm ? t('common.cancel') : addBtnLabel}
           </button>
@@ -603,7 +607,7 @@ function AdminTaxonomy() {
       </div>
 
       <div className="tabs">
-        {['countries', 'regions', 'appellations', 'grapes'].map(tab => (
+        {['countries', 'regions', 'appellations', 'grapes', 'bottleSizes'].map(tab => (
           <button
             key={tab}
             className={`tab ${activeTab === tab ? 'active' : ''}`}
@@ -616,7 +620,9 @@ function AdminTaxonomy() {
 
       {error && <div className="alert alert-error">{error}</div>}
 
-      {showForm && !isEditing && (
+      {isBottleSizes && <BottleSizesAdmin apiFetch={apiFetch} />}
+
+      {!isBottleSizes && showForm && !isEditing && (
         <div className="card create-form">
           <h2>{addBtnLabel}</h2>
           <form onSubmit={handleCreate}>
@@ -629,7 +635,7 @@ function AdminTaxonomy() {
         </div>
       )}
 
-      {isEditing && (
+      {!isBottleSizes && isEditing && (
         <div className="card create-form">
           <h2>{t('admin.taxonomy.editTitle', { name: editItem.name })}</h2>
           <form onSubmit={handleUpdate}>
@@ -642,7 +648,7 @@ function AdminTaxonomy() {
         </div>
       )}
 
-      {loading ? (
+      {!isBottleSizes && (loading ? (
         <div className="loading">{t('common.loading')}</div>
       ) : (
         <div className="items-list">
@@ -670,7 +676,7 @@ function AdminTaxonomy() {
             ))
           )}
         </div>
-      )}
+      ))}
 
       {confirmDelete && (
         <ConfirmModal


### PR DESCRIPTION
## Problem
Bottle sizes were stored as **localized display labels** — `750ml (Standard)`, `750ml（標準）` (Japanese), `1.5L (Magnum)`, `1.5L`, `3000ml (Jeroboam)` … — because the size `<option>`s in AddBottle/EditForm had **no `value` attribute**, so the option *text* (whatever locale rendered it) became the stored value. This polluted grouping, filtering and the community-price median (sizes weren''t comparable).

## Fix
Standardize on a canonical **`<ml>ml` code** (`750ml`, `1500ml`, …); derive friendly labels ("1.5 L (Magnum)") via i18n. Never store a label again.

- **`config/bottleSizes`** (backend + frontend, mirrored): canonical size list keyed by volume + `normalizeBottleSize()` that maps any input → canonical code (localized labels, L/cl/ml units, EU decimal commas, CJK label suffixes, bare numbers). **21 unit tests.**
- **Server-side enforcement:** `bottleSize` is normalized on bottle **create, update, and both import paths** — any client or API stays canonical.
- **Input forms:** AddBottle/EditForm dropdowns now use real `value=code` options with localized labels; EditForm preserves a bottle''s current value if it''s off-list. Bottle detail shows the friendly label.
- **Admin "Bottle Sizes" tab** (AdminTaxonomy): lists distinct stored values + counts, flags non-canonical ones, lets an admin **remap** a value → canonical or **Normalize all** in one click. Audit-logged via `admin.bottleSize.*`.
- **Backfill:** `runNormalizeBottleSizes.js` for an on-demand/one-off run (`docker exec cellarion-backend node src/runNormalizeBottleSizes.js`), sharing the same maintenance service as the admin endpoint.

## Testing
- ✅ 21 normalizer tests + full backend suite (650) pass; frontend build compiles; translation JSON valid.
- ✅ **Read-only dry-run against real data** (no mutation): every existing value maps correctly — `750ml (Standard)` (1903) + `750ml` (1290) + `750ml（標準）` (16) → **750ml**; `1.5L (Magnum)` + `1.5L` → **1500ml**; `375ml (Half)` → **375ml**; `3000ml (Jeroboam)` → **3000ml**; `620ml`/`500ml` recognized as canonical (Clavelin / half-litre). **10 distinct → ~6 canonical, zero unrecognized.**

## Rollout
Merge, then run the backfill once (admin "Normalize all" button or the script) to canonicalize existing rows. Independent of the community-pricing PR (#501).

🤖 Generated with [Claude Code](https://claude.com/claude-code)