### PR TITLE
chore: apiJson response helper + mentionParser regex cleanup

### DIFF
--- a/backend/src/utils/mentionParser.js
+++ b/backend/src/utils/mentionParser.js
@@ -1,4 +1,5 @@
 const User = require('../models/User');
+const { escapeRegex } = require('./sanitize');
 
 // Match @<username> tokens in body text. Allowed username chars mirror the
 // ones the registration flow accepts: letters, digits, dot, hyphen, underscore.
@@ -33,7 +34,7 @@ async function extractMentions(body, excludeUserId = null) {
 
   // Mongoose username field is unique but stored as-typed. Match
   // case-insensitively via a single $in regex.
-  const regexes = [...usernames].map(u => new RegExp(`^${u.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i'));
+  const regexes = [...usernames].map(u => new RegExp(`^${escapeRegex(u)}$`, 'i'));
   const users = await User.find({ username: { $in: regexes } }).select('_id').lean();
 
   const ids = users

--- a/frontend/src/pages/AdminBlogEditor.js
+++ b/frontend/src/pages/AdminBlogEditor.js
@@ -11,6 +11,7 @@ import Underline from '@tiptap/extension-underline';
 import TextAlign from '@tiptap/extension-text-align';
 import Placeholder from '@tiptap/extension-placeholder';
 import { getAdminBlogPost, createBlogPost, updateBlogPost } from '../api/blog';
+import { apiJson } from '../utils/apiJson';
 import './AdminBlogEditor.css';
 
 function AdminBlogEditor() {
@@ -97,11 +98,10 @@ function AdminBlogEditor() {
 
     try {
       if (isNew) {
-        const res = await createBlogPost(apiFetch, data);
-        const result = await res.json();
+        const result = await apiJson(createBlogPost(apiFetch, data));
         navigate(`/admin/blog/${result.post._id}`);
       } else {
-        await updateBlogPost(apiFetch, id, data);
+        await apiJson(updateBlogPost(apiFetch, id, data));
       }
       if (publishOverride === 'published') {
         alert(t('blog.editor.published'));

--- a/frontend/src/utils/apiJson.js
+++ b/frontend/src/utils/apiJson.js
@@ -1,0 +1,39 @@
+/**
+ * Resolve an apiFetch (or src/api/* client) call to its parsed JSON body,
+ * throwing on a non-2xx response.
+ *
+ * `apiFetch` — and the typed helpers in src/api/* that wrap it — resolve to a
+ * raw `Response` and only reject on a network failure. Callers therefore have
+ * to remember to check `res.ok` and call `res.json()` themselves; forgetting
+ * either is silent, because a `Response` is always truthy. That footgun has
+ * caused real bugs (e.g. treating the Response as the parsed body, or navigating
+ * after a failed save). Pass the call's Response — or, more conveniently, its
+ * Promise — here to get the body back or a thrown Error.
+ *
+ *   const { post } = await apiJson(createBlogPost(apiFetch, data));
+ *   const data = await apiJson(apiFetch('/api/foo'));
+ *
+ * On a non-2xx response the thrown Error's message is taken from the body's
+ * `error`/`message` field (falling back to the status code), and the Error
+ * carries `.status` and `.body` for callers that need to branch on them.
+ *
+ * @param {Response|Promise<Response>} resOrPromise - an apiFetch call or its result
+ * @returns {Promise<any>} parsed JSON body (null when the body is empty/invalid)
+ * @throws {Error} on a non-2xx response; `.status` and `.body` are attached
+ */
+export async function apiJson(resOrPromise) {
+  const res = await resOrPromise;
+  // A 204 or an empty/invalid body shouldn't crash the caller — treat as null.
+  const body = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    const message =
+      (body && (body.error || body.message)) || `Request failed (${res.status})`;
+    const err = new Error(message);
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+
+  return body;
+}

--- a/frontend/src/utils/apiJson.test.js
+++ b/frontend/src/utils/apiJson.test.js
@@ -1,0 +1,56 @@
+import { apiJson } from './apiJson';
+
+// Minimal stand-in for a fetch Response with just the bits apiJson uses.
+const makeRes = (ok, status, jsonImpl) => ({
+  ok,
+  status,
+  json: jsonImpl ?? (async () => ({})),
+});
+
+describe('apiJson', () => {
+  test('returns the parsed body on a 2xx response', async () => {
+    const res = makeRes(true, 200, async () => ({ post: { _id: 'abc' } }));
+    await expect(apiJson(res)).resolves.toEqual({ post: { _id: 'abc' } });
+  });
+
+  test('accepts a Promise<Response>, not just a Response', async () => {
+    const res = makeRes(true, 201, async () => ({ ok: 1 }));
+    await expect(apiJson(Promise.resolve(res))).resolves.toEqual({ ok: 1 });
+  });
+
+  test('throws on a non-2xx response, using body.error as the message', async () => {
+    const res = makeRes(false, 400, async () => ({ error: 'Bad input' }));
+    await expect(apiJson(res)).rejects.toThrow('Bad input');
+  });
+
+  test('falls back to body.message, then to a status-code message', async () => {
+    const withMessage = makeRes(false, 403, async () => ({ message: 'Forbidden' }));
+    await expect(apiJson(withMessage)).rejects.toThrow('Forbidden');
+
+    const noBodyText = makeRes(false, 500, async () => ({}));
+    await expect(apiJson(noBodyText)).rejects.toThrow('Request failed (500)');
+  });
+
+  test('attaches status and body to the thrown error', async () => {
+    const res = makeRes(false, 409, async () => ({ error: 'Conflict' }));
+    await expect(apiJson(res)).rejects.toMatchObject({
+      message: 'Conflict',
+      status: 409,
+      body: { error: 'Conflict' },
+    });
+  });
+
+  test('treats an empty/invalid JSON body as null on success', async () => {
+    const res = makeRes(true, 204, async () => {
+      throw new SyntaxError('Unexpected end of JSON input');
+    });
+    await expect(apiJson(res)).resolves.toBeNull();
+  });
+
+  test('still throws on a non-2xx with an unparseable body', async () => {
+    const res = makeRes(false, 502, async () => {
+      throw new SyntaxError('Unexpected end of JSON input');
+    });
+    await expect(apiJson(res)).rejects.toThrow('Request failed (502)');
+  });
+});


### PR DESCRIPTION
Two small, independent cleanups that were sitting uncommitted in the tree.

**`apiJson()` response helper** ([apiJson.js](frontend/src/utils/apiJson.js) + 7 tests)
`apiFetch`/`src/api/*` resolve to a raw `Response` and only reject on network failure, so callers must remember `res.ok` + `res.json()` — forgetting either fails silently (a `Response` is always truthy). `apiJson()` resolves a call to its parsed body and **throws on non-2xx** (message from `body.error`/`message`, `.status` + `.body` attached). Adopted in **AdminBlogEditor**''s save path.

**`mentionParser` escapeRegex** — reuse the shared `escapeRegex` from `utils/sanitize` instead of an inline regex-escape. Functionally identical, de-duplicated.

Verified: apiJson 7/7 tests pass; full backend suite green (mentionParser change exercised); frontend build compiles AdminBlogEditor. Both are pure refactors, no behaviour change beyond apiJson''s throw-on-error (only the adopted call site uses it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)