### PR TITLE
chore(release): v1.58.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.57.8",
+  "version": "1.58.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.57.8",
+  "version": "1.58.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release **v1.58.0**. Bumps backend + frontend `package.json` from 1.57.8.

Ships the work merged since v1.57.8:
- **#501** — community release-price + replacement value (Statistics chart paid-vs-replacement, per-bottle "current release" + paid-vs-now)
- **#502** — canonical bottle sizes (`<ml>ml` codes) + admin Bottle Sizes tab + normalize migration
- **#503** — `apiJson()` response helper + `mentionParser` escapeRegex cleanup

**Post-deploy step:** run the bottle-size normalization once on production (Admin → Taxonomy → Bottle Sizes → **Normalize all**, or `docker exec cellarion-backend node src/runNormalizeBottleSizes.js`) to canonicalize existing rows. New bottles are normalized on write; community-price + replacement snapshots populate via the weekly scheduler.

Merge this, then **publish GitHub Release `v1.58.0`** to trigger the Docker build/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)