### PR TITLE
refactor(perf): scale phase 1 — indexes, payload projections, bundle splits

### DIFF
--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -16,6 +16,20 @@ const WINE_POPULATE = [
   { path: 'pendingWineRequest', select: 'wineName producer' }
 ];
 
+// List/stats variant of WINE_POPULATE: excludes the heavy fields no list view
+// or aggregate reads (aiProfile alone is several KB of prose per wine). A page
+// of 30 bottles ships the same card data at a fraction of the payload. Detail
+// routes (GET /api/bottles/:id etc.) keep the full WINE_POPULATE — the bottle
+// page renders aiProfile.
+const WINE_POPULATE_LIST = [
+  {
+    path: 'wineDefinition',
+    select: '-aiProfile -normalizedKey -lwin -productNumber -productNumberShort -createdBy',
+    populate: ['country', 'region', 'grapes']
+  },
+  { path: 'pendingWineRequest', select: 'wineName producer' }
+];
+
 // ─── Import thresholds ───────────────────────────────────────────────────────
 
 // Composite similarity score at or above which a match is considered exact
@@ -70,6 +84,7 @@ module.exports = {
   CONSUMED_STATUSES,
   MS_PER_DAY,
   WINE_POPULATE,
+  WINE_POPULATE_LIST,
   IMPORT_EXACT_THRESHOLD,
   IMPORT_FUZZY_THRESHOLD,
   MAX_IMPORT_SIZE,

--- a/backend/src/models/Bottle.js
+++ b/backend/src/models/Bottle.js
@@ -140,6 +140,12 @@ bottleSchema.index({ cellar: 1, vintage: 1 }); // For filtering by vintage
 bottleSchema.index({ cellar: 1, rating: 1 }); // For filtering by rating
 bottleSchema.index({ user: 1, vintage: 1 }); // For user-wide vintage queries
 bottleSchema.index({ cellar: 1, status: 1 });       // For active/history filtering
+// Serve the default newest-first list sort from the index. The status filter
+// is a $nin (range), so an index ending in createdAt after status cannot serve
+// the sort — cellar/user equality + createdAt order with status as a residual
+// filter avoids a blocking in-memory SORT over every bottle per page view.
+bottleSchema.index({ cellar: 1, createdAt: -1 });
+bottleSchema.index({ user: 1, createdAt: -1 });
 
 // Update timestamp on save
 bottleSchema.pre('save', function(next) {

--- a/backend/src/models/Discussion.js
+++ b/backend/src/models/Discussion.js
@@ -74,6 +74,12 @@ discussionSchema.index({ isPinned: -1, lastActivityAt: -1 });
 discussionSchema.index({ category: 1, isPinned: -1, lastActivityAt: -1 });
 // User's discussions
 discussionSchema.index({ author: 1, createdAt: -1 });
+// "Newest" tab sort
+discussionSchema.index({ isPinned: -1, createdAt: -1 });
+// "Most replies" tab sort
+discussionSchema.index({ isPinned: -1, replyCount: -1, lastActivityAt: -1 });
+// Wine-page discussions panel (public, crawler-visited)
+discussionSchema.index({ wineDefinition: 1, isPinned: -1, lastActivityAt: -1 });
 
 // Generate slug from title + last 6 of ObjectId on insert. The ObjectId suffix
 // gives collision-resistance without needing a uniqueness retry loop.

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -254,6 +254,9 @@ const userSchema = new mongoose.Schema({
 // Sparse index so verify-email lookup is efficient; sparse avoids bloat after verification
 userSchema.index({ emailVerificationTokenHash: 1 }, { sparse: true });
 userSchema.index({ passwordResetTokenHash: 1 }, { sparse: true });
+// Every /api/auth/refresh resolves the session via this hash — without the
+// index it is a full collection scan per token refresh (one per session ~15min)
+userSchema.index({ refreshTokenHash: 1 }, { sparse: true });
 
 // Heal legacy notification-pref shapes before save. Old docs stored
 // `drinkWindow: false` (single boolean); the current schema expects

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -143,6 +143,15 @@ wineDefinitionSchema.index({ country: 1, type: 1 });
 wineDefinitionSchema.index({ country: 1, region: 1 });
 wineDefinitionSchema.index({ type: 1, createdAt: -1 });
 
+// Public taxonomy discovery pages filter by one taxon and sort by name —
+// without these, mongod blocking-sorts every matching wine per page view.
+// The grapes index is multikey; its prefix also serves the taxonomy
+// count queries ({ grapes: id }).
+wineDefinitionSchema.index({ country: 1, name: 1 });
+wineDefinitionSchema.index({ region: 1, name: 1 });
+wineDefinitionSchema.index({ grapes: 1, name: 1 });
+wineDefinitionSchema.index({ type: 1, name: 1 });
+
 // Update timestamp on save
 wineDefinitionSchema.pre('save', function(next) {
   this.updatedAt = Date.now();

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -18,7 +18,7 @@ const { getOrCreateDailySnapshot, getSnapshotForDate } = require('../utils/excha
 const { resolveRating } = require('../utils/ratingUtils');
 const { embedSinglePair } = require('../services/embeddingJob');
 const { enrichWineById } = require('../services/enrichmentJob');
-const { CONSUMED_STATUSES, WINE_POPULATE } = require('../config/constants');
+const { CONSUMED_STATUSES, WINE_POPULATE, WINE_POPULATE_LIST } = require('../config/constants');
 const { checkRestockGap, resolveRestockAlerts } = require('../services/restockChecker');
 const { gatherPriceWarnings } = require('../services/priceWarnings');
 const { getCurrentRelease } = require('../services/communityPrice');
@@ -216,7 +216,7 @@ router.get('/', async (req, res) => {
     const needsInMemoryFilter = !!(search || minRating || maturityFilter);
     const canPaginateInDb = canSortInDb && !needsInMemoryFilter;
 
-    let query = Bottle.find(filter).populate(WINE_POPULATE);
+    let query = Bottle.find(filter).populate(WINE_POPULATE_LIST);
     if (canSortInDb) query = query.sort({ [sortField]: sortDir });
     if (canPaginateInDb) query = query.skip(skip).limit(limit);
     let bottles = await query.lean();

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -16,7 +16,7 @@ const { createNotification } = require('../services/notifications');
 const { sendCellarInviteEmail, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
 const { toNormalized } = require('../utils/ratingUtils');
 const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
-const { CONSUMED_STATUSES, MS_PER_DAY, WINE_POPULATE } = require('../config/constants');
+const { CONSUMED_STATUSES, MS_PER_DAY, WINE_POPULATE_LIST } = require('../config/constants');
 const mongoose = require('mongoose');
 const { parsePagination } = require('../utils/pagination');
 const searchService = require('../services/search');
@@ -304,7 +304,7 @@ router.get('/:id/history', async (req, res) => {
         }
 
         bottles = await Bottle.find({ _id: { $in: matchingIds } })
-          .populate(WINE_POPULATE).lean();
+          .populate(WINE_POPULATE_LIST).lean();
 
         // Preserve Meilisearch sort order
         const idOrder = new Map(matchingIds.map((id, i) => [id, i]));
@@ -320,7 +320,7 @@ router.get('/:id/history', async (req, res) => {
       // cellar with a huge consumed history can't load the entire collection
       // into memory on every request.
       bottles = await Bottle.find(filter)
-        .populate(WINE_POPULATE)
+        .populate(WINE_POPULATE_LIST)
         .sort({ consumedAt: -1 })
         .limit(10000)
         .lean();
@@ -451,6 +451,22 @@ router.get('/:id', async (req, res) => {
       ? String(grapes).split(',').map(g => g.trim()).filter(isValidObjectId)
       : [];
 
+    // Build the exclusion set once for both paths. ?excludePlaced=1 resolves
+    // rack-placed bottles server-side — the slot pickers previously sent every
+    // placed bottle ID in the query string, which overflows the URL length
+    // limit once a few hundred bottles are placed.
+    const excludeSet = new Set(exclude ? String(exclude).split(',').filter(isValidObjectId) : []);
+    if (req.query.excludePlaced === '1' || req.query.excludePlaced === 'true') {
+      const racks = await Rack.find({ cellar: req.params.id, deletedAt: null })
+        .select('slots.bottle')
+        .lean();
+      for (const rack of racks) {
+        for (const slot of rack.slots || []) {
+          if (slot.bottle) excludeSet.add(slot.bottle.toString());
+        }
+      }
+    }
+
     // Whether we need in-memory post-processing that neither Meilisearch nor MongoDB can do
     const needsMaturity = !!(maturityFilter || sortField === 'maturity');
     const MATURITY_RANK = { declining: 0, late: 1, peak: 2, early: 3, 'not-ready': 4 };
@@ -491,14 +507,13 @@ router.get('/:id', async (req, res) => {
 
         // Exclude specific bottle IDs if requested
         let idsToFetch = matchingIds;
-        if (exclude) {
-          const excludeSet = new Set(String(exclude).split(',').filter(isValidObjectId));
+        if (excludeSet.size > 0) {
           idsToFetch = matchingIds.filter(id => !excludeSet.has(id));
         }
 
         // Fetch just the matching bottles from MongoDB (by ID) — much smaller query
         bottles = await Bottle.find({ _id: { $in: idsToFetch } })
-          .populate(WINE_POPULATE)
+          .populate(WINE_POPULATE_LIST)
           .lean();
 
         // Preserve Meilisearch's sort order
@@ -519,9 +534,8 @@ router.get('/:id', async (req, res) => {
         status: { $nin: CONSUMED_STATUSES }
       };
 
-      if (exclude) {
-        const excludeIds = String(exclude).split(',').filter(isValidObjectId);
-        if (excludeIds.length > 0) filter._id = { $nin: excludeIds };
+      if (excludeSet.size > 0) {
+        filter._id = { $nin: [...excludeSet] };
       }
       // Vintage: single or comma-separated
       if (vintage) {
@@ -566,7 +580,7 @@ router.get('/:id', async (req, res) => {
       // duplicates, so it disables DB-level pagination.
       canPaginateInDb = !needsInMemoryFilter && !needsInMemorySort && !grouped;
 
-      let query = Bottle.find(filter).populate(WINE_POPULATE);
+      let query = Bottle.find(filter).populate(WINE_POPULATE_LIST);
       if (canSortInDb_) query = query.sort({ [sortField]: sortDir });
       if (canPaginateInDb) query = query.skip(skip).limit(limit);
       bottles = await query.lean();

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -10,17 +10,33 @@ router.use(requireAuth);
 // GET /api/notifications - fetch the 30 most recent notifications for the current user
 router.get('/', async (req, res) => {
   try {
-    const notifications = await Notification.find({ user: req.user.id })
-      .sort({ createdAt: -1 })
-      .limit(30)
-      .lean();
-
-    const unreadCount = notifications.filter(n => !n.read).length;
+    const [notifications, unreadCount] = await Promise.all([
+      Notification.find({ user: req.user.id })
+        .sort({ createdAt: -1 })
+        .limit(30)
+        .lean(),
+      // Count across ALL rows, not just the returned page — older unread
+      // notifications outside the 30 most recent still count.
+      Notification.countDocuments({ user: req.user.id, read: false }),
+    ]);
 
     res.json({ notifications, unreadCount });
   } catch (error) {
     console.error('Get notifications error:', error);
     res.status(500).json({ error: 'Failed to get notifications' });
+  }
+});
+
+// GET /api/notifications/unread-count - lightweight badge poll. The client
+// polls this instead of the full list so each tick is one indexed count
+// instead of 30 serialized documents.
+router.get('/unread-count', async (req, res) => {
+  try {
+    const unreadCount = await Notification.countDocuments({ user: req.user.id, read: false });
+    res.json({ unreadCount });
+  } catch (error) {
+    console.error('Get unread count error:', error);
+    res.status(500).json({ error: 'Failed to get unread count' });
   }
 });
 

--- a/backend/src/routes/stats.js
+++ b/backend/src/routes/stats.js
@@ -4,7 +4,7 @@ const Cellar = require('../models/Cellar');
 const Bottle = require('../models/Bottle');
 const User = require('../models/User');
 const CellarValueSnapshot = require('../models/CellarValueSnapshot');
-const { CONSUMED_STATUSES, WINE_POPULATE } = require('../config/constants');
+const { CONSUMED_STATUSES, WINE_POPULATE_LIST } = require('../config/constants');
 const { computeOverview, buildEmptyStats } = require('../services/statsService');
 const { getOrCreateDailySnapshot, getSnapshotsForDates, convertCurrency } = require('../utils/exchangeRates');
 
@@ -30,10 +30,10 @@ router.get('/overview', async (req, res) => {
 
     const [activeBottles, consumedBottles] = await Promise.all([
       Bottle.find({ user: req.user.id, cellar: { $in: cellarIds }, status: { $nin: CONSUMED_STATUSES } })
-        .populate(WINE_POPULATE)
+        .populate(WINE_POPULATE_LIST)
         .lean(),
       Bottle.find({ user: req.user.id, cellar: { $in: cellarIds }, status: { $in: CONSUMED_STATUSES } })
-        .populate(WINE_POPULATE)
+        .populate(WINE_POPULATE_LIST)
         .lean(),
     ]);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@ services:
     image: mongo:7
     container_name: cellarion-mongo
     restart: unless-stopped
-    command: ["mongod", "--wiredTigerCacheSizeGB", "0.5"]
+    # WiredTiger cache must stay well under the container limit (512M below) —
+    # cache + connection/aggregation overhead beyond the limit gets the
+    # container OOM-killed under load. ~50% of the limit is the safe ratio.
+    command: ["mongod", "--wiredTigerCacheSizeGB", "0.25"]
     volumes:
       - mongo-data:/data/db
     deploy:
@@ -86,7 +89,11 @@ services:
     deploy:
       resources:
         limits:
-          memory: 384M
+          # Stopgap until the full-cellar-hydration endpoints move to
+          # aggregation: a few concurrent big-cellar page loads peak well
+          # past 384M. Sized for the current 4GB host alongside the other
+          # services' caps.
+          memory: 640M
     depends_on:
       mongo:
         condition: service_healthy

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { buildRackUrl } from '../utils/rackNavigation';
@@ -159,4 +160,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
   );
 }
 
-export default BottleCard;
+// Memoized: CellarDetail accumulates load-more pages into one list, and every
+// search keystroke re-renders the page — without memo, hundreds of cards
+// re-render per keystroke even though their props are unchanged.
+export default memo(BottleCard);

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -163,4 +163,15 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
 // Memoized: CellarDetail accumulates load-more pages into one list, and every
 // search keystroke re-renders the page — without memo, hundreds of cards
 // re-render per keystroke even though their props are unchanged.
-export default memo(BottleCard);
+//
+// onClick is excluded from the comparison: callers pass inline arrows
+// (`onClick={() => toggleGroup(item.key)}`), whose identity changes every
+// parent render and would defeat the memo for exactly the grouped cards it
+// exists for. This is safe because every current onClick closes only over
+// values derived from the OTHER compared props (the bottle/group item) — if a
+// future caller closes over unrelated state, that handler must be stabilized
+// with useCallback instead.
+const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount'];
+export default memo(BottleCard, (prev, next) =>
+  COMPARED_PROPS.every(key => prev[key] === next[key])
+);

--- a/frontend/src/contexts/NotificationContext.js
+++ b/frontend/src/contexts/NotificationContext.js
@@ -92,9 +92,11 @@ export function NotificationProvider({ children }) {
     fetchNotifications();
     intervalRef.current = setInterval(pollUnreadCount, 60_000);
 
-    // Catch up when the tab becomes active again — the interval skips
-    // while document.hidden, so this is the "resume" signal.
-    const handleWake = () => pollUnreadCount();
+    // Full refetch when the tab becomes active again. The count probe alone
+    // can't see net-zero changes (one read on another device while a new
+    // notification arrives keeps the count equal), so waking is the moment
+    // we resynchronize the actual list — same self-heal the old code had.
+    const handleWake = () => { if (!document.hidden) fetchNotifications(); };
     window.addEventListener('focus', handleWake);
     document.addEventListener('visibilitychange', handleWake);
 

--- a/frontend/src/contexts/NotificationContext.js
+++ b/frontend/src/contexts/NotificationContext.js
@@ -12,6 +12,7 @@ export function NotificationProvider({ children }) {
   const [notifications, setNotifications] = useState([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const intervalRef = useRef(null);
+  const lastCountRef = useRef(0);
 
   const fetchNotifications = useCallback(async () => {
     if (!user) return;
@@ -21,11 +22,32 @@ export function NotificationProvider({ children }) {
         const data = await res.json();
         setNotifications(data.notifications);
         setUnreadCount(data.unreadCount);
+        lastCountRef.current = data.unreadCount;
       }
     } catch {
       // Silently ignore — network blip should not break the UI
     }
   }, [user, apiFetch]);
+
+  // Lightweight poll: one indexed count instead of the full list. Only when
+  // the count changes do we refetch the list — and hidden tabs skip entirely,
+  // so N open tabs no longer multiply into N full fetches every 30s.
+  const pollUnreadCount = useCallback(async () => {
+    if (!user || document.hidden) return;
+    try {
+      const res = await apiFetch('/api/notifications/unread-count');
+      if (res.ok) {
+        const data = await res.json();
+        setUnreadCount(data.unreadCount);
+        if (data.unreadCount !== lastCountRef.current) {
+          lastCountRef.current = data.unreadCount;
+          fetchNotifications();
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }, [user, apiFetch, fetchNotifications]);
 
   const markRead = useCallback(async (id) => {
     try {
@@ -35,6 +57,7 @@ export function NotificationProvider({ children }) {
           prev.map(n => n._id === id ? { ...n, read: true } : n)
         );
         setUnreadCount(prev => Math.max(0, prev - 1));
+        lastCountRef.current = Math.max(0, lastCountRef.current - 1);
       }
     } catch {
       // ignore
@@ -47,6 +70,7 @@ export function NotificationProvider({ children }) {
       if (res.ok) {
         setNotifications(prev => prev.map(n => ({ ...n, read: true })));
         setUnreadCount(0);
+        lastCountRef.current = 0;
       }
     } catch {
       // ignore
@@ -66,17 +90,21 @@ export function NotificationProvider({ children }) {
     }
 
     fetchNotifications();
-    intervalRef.current = setInterval(fetchNotifications, 30_000);
+    intervalRef.current = setInterval(pollUnreadCount, 60_000);
 
-    const handleFocus = () => fetchNotifications();
-    window.addEventListener('focus', handleFocus);
+    // Catch up when the tab becomes active again — the interval skips
+    // while document.hidden, so this is the "resume" signal.
+    const handleWake = () => pollUnreadCount();
+    window.addEventListener('focus', handleWake);
+    document.addEventListener('visibilitychange', handleWake);
 
     return () => {
       clearInterval(intervalRef.current);
       intervalRef.current = null;
-      window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('focus', handleWake);
+      document.removeEventListener('visibilitychange', handleWake);
     };
-  }, [user, fetchNotifications]);
+  }, [user, fetchNotifications, pollUnreadCount]);
 
   return (
     <NotificationContext.Provider value={{ notifications, unreadCount, markRead, markAllRead, refresh: fetchNotifications }}>

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -2,8 +2,15 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
+// English is the fallback language and stays statically bundled so first
+// paint never waits on a locale fetch. Other locales are loaded on demand —
+// bundling them all puts every language in the entry chunk every visitor
+// downloads (~100 kB raw per locale).
 import en from './locales/en/translation.json';
-import sv from './locales/sv/translation.json';
+
+const DYNAMIC_LOCALES = {
+  sv: () => import('./locales/sv/translation.json'),
+};
 
 i18n
   .use(LanguageDetector)
@@ -11,8 +18,10 @@ i18n
   .init({
     resources: {
       en: { translation: en },
-      sv: { translation: sv },
     },
+    // Languages outside `resources` are loaded via DYNAMIC_LOCALES below —
+    // don't treat their absence at init as "unsupported".
+    partialBundledLanguages: true,
     fallbackLng: 'en',
     supportedLngs: ['en', 'sv'],
     detection: {
@@ -24,5 +33,25 @@ i18n
       escapeValue: false,
     },
   });
+
+async function ensureLocaleLoaded(lng) {
+  const base = String(lng || '').split('-')[0];
+  const loader = DYNAMIC_LOCALES[base];
+  if (!loader || i18n.hasResourceBundle(base, 'translation')) return;
+  try {
+    const mod = await loader();
+    i18n.addResourceBundle(base, 'translation', mod.default, true, true);
+    // Re-trigger languageChanged so already-mounted components re-render
+    // with the freshly loaded strings instead of the English fallback.
+    if (String(i18n.language || '').split('-')[0] === base) {
+      i18n.changeLanguage(i18n.language);
+    }
+  } catch {
+    // Loading failed (offline?) — English fallback keeps the app usable.
+  }
+}
+
+ensureLocaleLoaded(i18n.language);
+i18n.on('languageChanged', ensureLocaleLoaded);
 
 export default i18n;

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef, lazy, Suspense } from 'react';
 import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -9,7 +9,9 @@ import { getPlacedBottleIds } from '../utils/rackUtils';
 import { getTotalSlots, getModularTotalSlots } from '../utils/rackLayouts';
 import RackRenderer from '../components/racks/RackRenderer';
 import ShelfView from '../components/racks/ShelfView';
-import ShelfView3D from '../components/racks/ShelfView3D';
+// Lazy: ShelfView3D pulls in three.js (~250 kB gzip) — only load it when the
+// user actually switches to the 3D view, not on every visit to the racks page.
+const ShelfView3D = lazy(() => import('../components/racks/ShelfView3D'));
 import RackTypeSelector, { TYPE_DIMENSIONS } from '../components/racks/RackTypeSelector';
 import RatingInput from '../components/RatingInput';
 import WineImage from '../components/WineImage';
@@ -372,7 +374,13 @@ function CellarRacks() {
                 highlightPos: highlightPos?.rackId === rack._id ? highlightPos.position : null,
                 onSlotClick: handleClick,
               };
-              if (viewMode === '3d') return <ShelfView3D {...commonProps} />;
+              if (viewMode === '3d') {
+                return (
+                  <Suspense fallback={<div className="loading">{t('common.loading')}</div>}>
+                    <ShelfView3D {...commonProps} />
+                  </Suspense>
+                );
+              }
               return <ShelfView {...commonProps} />;
             })()
           ) : (
@@ -651,9 +659,9 @@ function EmptySlotContent({ position, apiFetch, cellarId, placedBottleIds, onAss
     try {
       const params = new URLSearchParams({ limit: '30' });
       if (term) params.set('search', term);
-      // Tell backend to exclude placed bottles so the limit applies to unplaced ones
-      const excludeIds = [...placedBottleIds].join(',');
-      if (excludeIds) params.set('exclude', excludeIds);
+      // The backend excludes rack-placed bottles itself — sending every placed
+      // bottle ID in the query string overflows the URL limit on big cellars.
+      params.set('excludePlaced', '1');
       const res = await getCellar(apiFetch, cellarId, params.toString());
       const data = await res.json();
       if (res.ok) {
@@ -661,7 +669,7 @@ function EmptySlotContent({ position, apiFetch, cellarId, placedBottleIds, onAss
       }
     } catch { /* ignore */ }
     setLoading(false);
-  }, [apiFetch, cellarId, placedBottleIds]);
+  }, [apiFetch, cellarId]);
 
   // Load initial results on mount
   useEffect(() => { fetchBottles(''); }, [fetchBottles]);

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -836,9 +836,9 @@ export default function CellarRoom() {
     try {
       const params = new URLSearchParams({ limit: '30' });
       if (term) params.set('search', term);
-      // Tell backend to exclude placed bottles so the limit applies to unplaced ones
-      const excludeIds = [...placedBottleIds].join(',');
-      if (excludeIds) params.set('exclude', excludeIds);
+      // The backend excludes rack-placed bottles itself — sending every placed
+      // bottle ID in the query string overflows the URL limit on big cellars.
+      params.set('excludePlaced', '1');
       const res = await getCellar(apiFetch, id, params.toString());
       const data = await res.json();
       if (res.ok) {
@@ -846,7 +846,7 @@ export default function CellarRoom() {
       }
     } catch { /* ignore */ }
     setSlotLoading(false);
-  }, [apiFetch, id, placedBottleIds]);
+  }, [apiFetch, id]);
 
   // Fetch initial results when slot picker opens
   useEffect(() => {

--- a/frontend/src/pages/DiscussionDetail.js
+++ b/frontend/src/pages/DiscussionDetail.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -16,7 +16,9 @@ import Modal from '../components/Modal';
 import ConfirmModal from '../components/ConfirmModal';
 import CommunityCTA from '../components/CommunityCTA';
 import SEOHead from '../components/SEOHead';
-import DiscussionComposer from '../components/DiscussionComposer';
+// Lazy: the rich-text composer pulls in tiptap/prosemirror (~120 kB gzip) —
+// read-only visitors (and crawlers) should not download an editor.
+const DiscussionComposer = lazy(() => import('../components/DiscussionComposer'));
 import WatchThreadButton from '../components/WatchThreadButton';
 import ParticipantStack from '../components/ParticipantStack';
 import JumpToReplyButton from '../components/JumpToReplyButton';
@@ -462,14 +464,16 @@ function DiscussionDetail() {
           )}
           <form onSubmit={handleSubmitReply}>
             <div ref={replyTextareaRef}>
-              <DiscussionComposer
-                value={replyBody}
-                onChange={setReplyBody}
-                onTextLengthChange={setReplyTextLength}
-                placeholder={t('discussions.replyPlaceholder')}
-                maxVisibleLength={REPLY_VISIBLE_MAX}
-                minHeight={100}
-              />
+              <Suspense fallback={<div className="loading">{t('common.loading')}</div>}>
+                <DiscussionComposer
+                  value={replyBody}
+                  onChange={setReplyBody}
+                  onTextLengthChange={setReplyTextLength}
+                  placeholder={t('discussions.replyPlaceholder')}
+                  maxVisibleLength={REPLY_VISIBLE_MAX}
+                  minHeight={100}
+                />
+              </Suspense>
             </div>
             {replyWine ? (
               <div className="discussion-detail__reply-wine">
@@ -501,13 +505,15 @@ function DiscussionDetail() {
       {editingReply && (
         <Modal title={t('discussions.editReply')} onClose={() => setEditingReply(null)}>
           <form onSubmit={handleEditReply}>
-            <DiscussionComposer
-              value={editBody}
-              onChange={setEditBody}
-              onTextLengthChange={setEditTextLength}
-              maxVisibleLength={REPLY_VISIBLE_MAX}
-              minHeight={140}
-            />
+            <Suspense fallback={<div className="loading">{t('common.loading')}</div>}>
+              <DiscussionComposer
+                value={editBody}
+                onChange={setEditBody}
+                onTextLengthChange={setEditTextLength}
+                maxVisibleLength={REPLY_VISIBLE_MAX}
+                minHeight={140}
+              />
+            </Suspense>
             <div className="discussions__create-actions">
               <button type="button" className="btn btn-secondary" onClick={() => setEditingReply(null)}>{t('common.cancel')}</button>
               <button type="submit" className="btn btn-primary" disabled={editTextLength < 1}>{t('common.save')}</button>

--- a/frontend/src/pages/Discussions.js
+++ b/frontend/src/pages/Discussions.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -6,7 +6,9 @@ import { getDiscussions, createDiscussion } from '../api/discussions';
 import DiscussionCard from '../components/DiscussionCard';
 import CategoryBadge, { CATEGORY_LABELS } from '../components/CategoryBadge';
 import CommunityCTA from '../components/CommunityCTA';
-import DiscussionComposer from '../components/DiscussionComposer';
+// Lazy: the rich-text composer pulls in tiptap/prosemirror (~120 kB gzip) —
+// read-only visitors (and crawlers) should not download an editor.
+const DiscussionComposer = lazy(() => import('../components/DiscussionComposer'));
 import Modal from '../components/Modal';
 import WineSearchPicker from '../components/WineSearchPicker';
 import SEOHead from '../components/SEOHead';
@@ -285,14 +287,16 @@ function Discussions() {
 
             <div className="form-group">
               <label className="form-label">{t('discussions.body')}</label>
-              <DiscussionComposer
-                value={form.body}
-                onChange={(html) => setForm(f => ({ ...f, body: html }))}
-                onTextLengthChange={setBodyTextLength}
-                placeholder={t('discussions.bodyPlaceholder')}
-                maxVisibleLength={BODY_VISIBLE_MAX}
-                minHeight={160}
-              />
+              <Suspense fallback={<div className="loading">{t('common.loading')}</div>}>
+                <DiscussionComposer
+                  value={form.body}
+                  onChange={(html) => setForm(f => ({ ...f, body: html }))}
+                  onTextLengthChange={setBodyTextLength}
+                  placeholder={t('discussions.bodyPlaceholder')}
+                  maxVisibleLength={BODY_VISIBLE_MAX}
+                  minHeight={160}
+                />
+              </Suspense>
             </div>
 
             <div className="form-group">


### PR DESCRIPTION
## What

First batch from [OPTIMIZATION_AUDIT_2026-06-10.md] — the cheap, additive scalability wins. No behavior changes except where noted.

### Database — 10 new indexes
| Model | Index | Why |
|---|---|---|
| Bottle | `{cellar, createdAt: -1}`, `{user, createdAt: -1}` | The default newest-first list sort had no supporting index → blocking in-memory SORT over every bottle of the cellar/user on **every page view** (the status filter is a `$nin` range, so equality+sort-order indexes are the correct shape) |
| User | `{refreshTokenHash}` sparse | Every `/api/auth/refresh` (one per session ≈15min) was a **full collection scan** |
| Discussion | newest tab, most-replies/trending tab, `{wineDefinition, isPinned, lastActivityAt}` | Public forum tabs + the crawler-visited wine-page discussions panel blocking-sorted the whole collection |
| WineDefinition | `{country\|region\|grapes\|type, name}` | Public taxonomy discovery pages sorted entire country/type wine sets in memory; the `grapes` prefix also serves the taxonomy count queries |

Verified live: all 10 built by mongoose autoIndex on boot.

### Payload — `WINE_POPULATE_LIST`
List/stats paths (bottles list, cellar views, history, stats) now populate `wineDefinition` **excluding** `aiProfile` (several KB of prose per wine), `normalizedKey`, `lwin`, `productNumber(s)`, `createdBy`. Verified by grep that no list consumer reads them; detail routes (`GET /api/bottles/:id` etc.) keep the full populate — the bottle page renders `aiProfile`. Smoke-verified: 15 vs ~21 keys per populated wine, card fields intact.

### Slot picker — functional fix 🐛
The rack/room slot pickers sent **every placed bottle ID in the query string** (`?exclude=id,id,…`) — past ~300-600 placed bottles that overflows the URL/header limit and "place a bottle" breaks entirely. New `?excludePlaced=1` resolves placed IDs server-side from the cellar's racks. The old `exclude` param still works for other callers (AddBottle flow).

### Bundle (measured before/after with `vite build`)
- **Entry: 161.9 → 133.9 kB gzip** — Swedish locale now lazy-loads (en stays bundled as the fallback; sv users may see a one-frame English flash on first cold load)
- **three.js (249.5 kB gzip)** no longer loads on the everyday 2D racks page — lazy behind the 3D toggle
- **tiptap composer (119.6 kB gzip)** no longer ships to read-only/anonymous discussion visitors — lazy at the form render sites
- `BottleCard` memoized — CellarDetail's accumulated load-more list re-rendered every card per search keystroke
- Verified in `dist/`: both chunks moved from static import preambles to dynamic-import dep maps

### Notifications
- New lightweight `GET /api/notifications/unread-count` (one indexed count), polled at **60s** instead of the full list at 30s, **skipped while the tab is hidden**; the full list refetches only when the count changes. Per-tab budget impact drops from 30 req/15min to ≤15 cheap req/15min.
- Side-effect fix: the badge previously undercounted (computed from the 30 most recent rows only — audit finding from 2026-06-05); it now counts all unread rows.

### Infra (sized for the current 4GB Hetzner host)
- Mongo WiredTiger cache **0.5 → 0.25 GB**: the cache equalled the whole 512M container limit — an OOM-kill waiting to happen under load
- Backend **384 → 640 MB**: stopgap headroom for full-cellar hydration until those endpoints move to aggregation (phase 2)

## Testing
- ✅ Backend 668/668 (33 suites), frontend 300/300 (9 files)
- ✅ `vite build` clean; chunk movement verified in dist output
- ✅ Docker smoke test against the rebuilt stack: login → `unread-count` works → bottles list has heavy fields stripped + card fields present → `?excludePlaced=1` returns only unplaced bottles (5 of 9 with demo data) → all 10 indexes present in mongo
- ✅ Mongo recreated and running with the 0.25 WT cache flag

## Not in this PR (phase 2+)
Cellar `group=1` full-hydration → aggregation; stats → pipelines; taxonomy N+1 counts; reply fan-out batching; chunked Meili full-sync; job hygiene; worker split/replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)