### PR TITLE
refactor(perf): scale phase 2a — DB-side grouping, stats cache, taxonomy aggregation

### DIFF
--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -17,6 +17,19 @@ const router = express.Router();
 // All routes require admin role
 router.use(requireAuth, requireRole('admin'));
 
+// Public taxonomy lists are served from a 10-minute server-side cache —
+// drop it after any successful admin mutation so renames/deletions show up
+// immediately instead of after the TTL.
+const { clearTaxonomyListCache } = require('../taxonomy');
+router.use((req, res, next) => {
+  if (req.method !== 'GET') {
+    res.on('finish', () => {
+      if (res.statusCode < 400) clearTaxonomyListCache();
+    });
+  }
+  next();
+});
+
 // ===== COUNTRIES =====
 
 // GET /api/admin/taxonomy/countries - List all countries

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -30,6 +30,86 @@ function getUserColor(cellar, userId) {
   return entry?.color || null;
 }
 
+// Group key parts default like the JS grouping path: missing/empty vintage →
+// 'NV', missing/empty bottleSize → '750ml'. $ifNull alone misses empty strings.
+function groupPartExpr(field, fallback) {
+  return {
+    $let: {
+      vars: { v: { $ifNull: [`$${field}`, fallback] } },
+      in: { $cond: [{ $eq: ['$$v', ''] }, fallback, '$$v'] },
+    },
+  };
+}
+
+/**
+ * DB-side grouping for the default cellar page (?group=1, no filters).
+ *
+ * The JS grouping path must load and populate the ENTIRE cellar to render 30
+ * groups — on every page view and every search keystroke. This groups bottles
+ * by (wine, vintage, bottleSize) and paginates over groups inside MongoDB,
+ * then populates only the returned page's members.
+ *
+ * Aggregation pipelines bypass Mongoose casting, so ids are cast explicitly.
+ */
+async function loadGroupedBottlePage({ cellarId, excludeSet, sortField, sortDir, skip, limit }) {
+  const { ObjectId } = mongoose.Types;
+  const match = {
+    cellar: new ObjectId(String(cellarId)),
+    status: { $nin: CONSUMED_STATUSES },
+  };
+  if (excludeSet.size > 0) {
+    match._id = { $nin: [...excludeSet].map(id => new ObjectId(id)) };
+  }
+  const groupId = {
+    // Bottles without a wine stay singleton groups (keyed by their own _id)
+    wine: { $ifNull: ['$wineDefinition', '$_id'] },
+    vintage: groupPartExpr('vintage', 'NV'),
+    size: groupPartExpr('bottleSize', '750ml'),
+  };
+
+  const [pageGroups, countResult] = await Promise.all([
+    Bottle.aggregate([
+      { $match: match },
+      { $sort: { [sortField]: sortDir } },
+      // $first/$push follow the preceding $sort within each group, so the
+      // group's sortVal is its best-ranked member and members stay sorted.
+      { $group: { _id: groupId, sortVal: { $first: `$${sortField}` }, memberIds: { $push: '$_id' } } },
+      { $sort: { sortVal: sortDir } },
+      { $skip: skip },
+      { $limit: limit },
+    ]).allowDiskUse(true),
+    Bottle.aggregate([
+      { $match: match },
+      { $group: { _id: groupId } },
+      { $count: 'total' },
+    ]).allowDiskUse(true),
+  ]);
+
+  const memberIds = pageGroups.flatMap(g => g.memberIds);
+  const docs = await Bottle.find({ _id: { $in: memberIds } })
+    .populate(WINE_POPULATE_LIST)
+    .lean();
+  const byId = new Map(docs.map(d => [d._id.toString(), d]));
+
+  const groupsForPage = pageGroups.map(g => {
+    const members = g.memberIds.map(id => byId.get(id.toString())).filter(Boolean);
+    const first = members[0];
+    // Key format must match the JS grouping path — the client treats it as
+    // the stable group identity.
+    const wineId = first?.wineDefinition?._id
+      ? first.wineDefinition._id.toString()
+      : (first?.wineDefinition ? String(first.wineDefinition) : `none:${first?._id}`);
+    const key = `${wineId}::${first?.vintage || 'NV'}::${first?.bottleSize || '750ml'}`;
+    return { key, bottles: members };
+  });
+
+  return {
+    groupsForPage,
+    bottles: groupsForPage.flatMap(g => g.bottles),
+    totalCount: countResult[0]?.total || 0,
+  };
+}
+
 // All routes require authentication
 router.use(requireAuth);
 
@@ -477,8 +557,23 @@ router.get('/:id', async (req, res) => {
     let bottles;
     let totalCount;
     let canPaginateInDb;
+    let groupsForPage = null;
 
-    if (searchService.getIsAvailable() && hasMeiliFilters) {
+    // ── HOT PATH: the default grouped cellar page (no filters, DB-sortable) ──
+    // Group + paginate inside MongoDB instead of hydrating the whole cellar.
+    const groupedInDb = grouped
+      && !hasMeiliFilters
+      && !minRating && !maxRating && !maturityFilter
+      && ['createdAt', 'vintage', 'price', 'rating'].includes(sortField);
+    if (groupedInDb) {
+      ({ groupsForPage, bottles, totalCount } = await loadGroupedBottlePage({
+        cellarId: req.params.id, excludeSet, sortField, sortDir, skip, limit,
+      }));
+      usedMeili = false;
+      canPaginateInDb = false;
+    }
+
+    if (!groupedInDb && searchService.getIsAvailable() && hasMeiliFilters) {
       // ── PRIMARY PATH: Meilisearch handles search + filters ──
       try {
         const meiliResult = await searchService.searchBottles(search || '', {
@@ -527,7 +622,7 @@ router.get('/:id', async (req, res) => {
       }
     }
 
-    if (!usedMeili) {
+    if (!usedMeili && !groupedInDb) {
       // ── FALLBACK PATH: MongoDB + in-memory (when Meilisearch unavailable) ──
       const filter = {
         cellar: req.params.id,
@@ -677,8 +772,8 @@ router.get('/:id', async (req, res) => {
 
     // Group identical bottles (same wine + vintage), or paginate normally.
     // `bottles` is fully filtered + sorted here; grouping preserves that order.
-    let groupsForPage = null;
-    if (grouped) {
+    // (Skipped when the DB-grouped hot path already produced groupsForPage.)
+    if (grouped && !groupsForPage) {
       const groupMap = new Map();
       const order = [];
       for (const b of bottles) {
@@ -696,7 +791,7 @@ router.get('/:id', async (req, res) => {
       const pageKeys = order.slice(skip, skip + limit);
       groupsForPage = pageKeys.map(key => ({ key, bottles: groupMap.get(key) }));
       bottles = groupsForPage.flatMap(g => g.bottles); // flatten so image attach below works
-    } else if (!canPaginateInDb) {
+    } else if (!canPaginateInDb && !groupsForPage) {
       totalCount = bottles.length;
       bottles = bottles.slice(skip, skip + limit);
     }

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -73,8 +73,21 @@ async function loadGroupedBottlePage({ cellarId, excludeSet, sortField, sortDir,
       { $sort: { [sortField]: sortDir } },
       // $first/$push follow the preceding $sort within each group, so the
       // group's sortVal is its best-ranked member and members stay sorted.
-      { $group: { _id: groupId, sortVal: { $first: `$${sortField}` }, memberIds: { $push: '$_id' } } },
-      { $sort: { sortVal: sortDir } },
+      // wineRef keeps the RAW reference (null when absent) so the group key
+      // below can distinguish "no wine" from a real (possibly dangling) ref.
+      {
+        $group: {
+          _id: groupId,
+          sortVal: { $first: `$${sortField}` },
+          wineRef: { $first: '$wineDefinition' },
+          memberIds: { $push: '$_id' },
+        },
+      },
+      // _id as tiebreaker: $skip/$limit pagination over groups re-runs this
+      // pipeline per page, and tied sortVals (e.g. sort=rating where most
+      // groups are unrated) have no stable order without it — pages would
+      // show duplicate groups and silently skip others.
+      { $sort: { sortVal: sortDir, _id: 1 } },
       { $skip: skip },
       { $limit: limit },
     ]).allowDiskUse(true),
@@ -91,17 +104,20 @@ async function loadGroupedBottlePage({ cellarId, excludeSet, sortField, sortDir,
     .lean();
   const byId = new Map(docs.map(d => [d._id.toString(), d]));
 
-  const groupsForPage = pageGroups.map(g => {
-    const members = g.memberIds.map(id => byId.get(id.toString())).filter(Boolean);
-    const first = members[0];
-    // Key format must match the JS grouping path — the client treats it as
-    // the stable group identity.
-    const wineId = first?.wineDefinition?._id
-      ? first.wineDefinition._id.toString()
-      : (first?.wineDefinition ? String(first.wineDefinition) : `none:${first?._id}`);
-    const key = `${wineId}::${first?.vintage || 'NV'}::${first?.bottleSize || '750ml'}`;
-    return { key, bottles: members };
-  });
+  const groupsForPage = pageGroups
+    .map(g => {
+      const members = g.memberIds.map(id => byId.get(id.toString())).filter(Boolean);
+      // Key format matches the JS grouping path and is built from the GROUP
+      // identity (not a populated member, which can be missing if a bottle
+      // was deleted between the aggregation and the populate): vintage/size
+      // in g._id already carry the NV/750ml defaults.
+      const wineId = g.wineRef ? String(g.wineRef) : `none:${String(g.memberIds[0])}`;
+      const key = `${wineId}::${g._id.vintage}::${g._id.size}`;
+      return { key, bottles: members };
+    })
+    // A group can lose all members to the populate race above — emitting it
+    // empty would hand the client a card with no bottle to render.
+    .filter(g => g.bottles.length > 0);
 
   return {
     groupsForPage,

--- a/backend/src/routes/stats.js
+++ b/backend/src/routes/stats.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const mongoose = require('mongoose');
 const { requireAuth } = require('../middleware/auth');
 const Cellar = require('../models/Cellar');
 const Bottle = require('../models/Bottle');
@@ -13,12 +14,27 @@ router.use(requireAuth);
 
 // Short server-side cache for the overview. Computing it loads the user's
 // entire bottle set, so without a cache every page visit recomputes from
-// scratch. Two cheap indexed counts act as the invalidation probe — adds,
-// deletes, consumes and undos all change one of them, so only pure edits
-// (price/rating tweaks) can be served stale, bounded by the TTL.
-const overviewCache = new Map(); // userId -> { at, key, totalCount, activeCount, stats }
+// scratch. The invalidation probe is one cheap indexed aggregation producing
+// a per-cellar {count, max(updatedAt)} signature: adds, deletes, consumes,
+// edits (pre-save bumps updatedAt) and bottle moves between cellars all
+// change it. Residual staleness (≤TTL): writes that bypass save() middleware,
+// and cellar renames.
+const overviewCache = new Map(); // userId -> { at, key, signature, stats }
 const OVERVIEW_TTL_MS = 2 * 60 * 1000;
 const OVERVIEW_CACHE_MAX_ENTRIES = 5000;
+
+// Per-cellar bottle signature for cache invalidation. Aggregation pipelines
+// bypass Mongoose casting, so the user id is cast explicitly (cellarIds are
+// already ObjectIds from Cellar.find).
+async function bottleSignature(userId, cellarIds) {
+  const rows = await Bottle.aggregate([
+    { $match: { user: new mongoose.Types.ObjectId(String(userId)), cellar: { $in: cellarIds } } },
+    { $group: { _id: '$cellar', n: { $sum: 1 }, u: { $max: '$updatedAt' } } },
+    { $sort: { _id: 1 } },
+  ]);
+  const cellarPart = cellarIds.map(String).sort().join(',');
+  return `${cellarPart}|${rows.map(r => `${r._id}:${r.n}:${r.u ? new Date(r.u).getTime() : 0}`).join(';')}`;
+}
 
 // GET /api/stats/overview — collection analytics (all authenticated users)
 router.get('/overview', async (req, res) => {
@@ -40,12 +56,10 @@ router.get('/overview', async (req, res) => {
     const scope = { user: req.user.id, cellar: { $in: cellarIds } };
     const cacheKey = `${targetCurrency}:${targetRatingScale}`;
     const cached = overviewCache.get(req.user.id);
+    let signature = null;
     if (cached && cached.key === cacheKey && Date.now() - cached.at < OVERVIEW_TTL_MS) {
-      const [totalCount, activeCount] = await Promise.all([
-        Bottle.countDocuments(scope),
-        Bottle.countDocuments({ ...scope, status: { $nin: CONSUMED_STATUSES } }),
-      ]);
-      if (totalCount === cached.totalCount && activeCount === cached.activeCount) {
+      signature = await bottleSignature(req.user.id, cellarIds);
+      if (signature === cached.signature) {
         return res.json({ stats: cached.stats });
       }
     }
@@ -65,8 +79,7 @@ router.get('/overview', async (req, res) => {
     overviewCache.set(req.user.id, {
       at: Date.now(),
       key: cacheKey,
-      totalCount: activeBottles.length + consumedBottles.length,
-      activeCount: activeBottles.length,
+      signature: signature || await bottleSignature(req.user.id, cellarIds),
       stats,
     });
 

--- a/backend/src/routes/stats.js
+++ b/backend/src/routes/stats.js
@@ -11,6 +11,15 @@ const { getOrCreateDailySnapshot, getSnapshotsForDates, convertCurrency } = requ
 const router = express.Router();
 router.use(requireAuth);
 
+// Short server-side cache for the overview. Computing it loads the user's
+// entire bottle set, so without a cache every page visit recomputes from
+// scratch. Two cheap indexed counts act as the invalidation probe — adds,
+// deletes, consumes and undos all change one of them, so only pure edits
+// (price/rating tweaks) can be served stale, bounded by the TTL.
+const overviewCache = new Map(); // userId -> { at, key, totalCount, activeCount, stats }
+const OVERVIEW_TTL_MS = 2 * 60 * 1000;
+const OVERVIEW_CACHE_MAX_ENTRIES = 5000;
+
 // GET /api/stats/overview — collection analytics (all authenticated users)
 router.get('/overview', async (req, res) => {
   try {
@@ -28,16 +37,39 @@ router.get('/overview', async (req, res) => {
       return res.json({ stats: buildEmptyStats(targetCurrency) });
     }
 
+    const scope = { user: req.user.id, cellar: { $in: cellarIds } };
+    const cacheKey = `${targetCurrency}:${targetRatingScale}`;
+    const cached = overviewCache.get(req.user.id);
+    if (cached && cached.key === cacheKey && Date.now() - cached.at < OVERVIEW_TTL_MS) {
+      const [totalCount, activeCount] = await Promise.all([
+        Bottle.countDocuments(scope),
+        Bottle.countDocuments({ ...scope, status: { $nin: CONSUMED_STATUSES } }),
+      ]);
+      if (totalCount === cached.totalCount && activeCount === cached.activeCount) {
+        return res.json({ stats: cached.stats });
+      }
+    }
+
     const [activeBottles, consumedBottles] = await Promise.all([
-      Bottle.find({ user: req.user.id, cellar: { $in: cellarIds }, status: { $nin: CONSUMED_STATUSES } })
+      Bottle.find({ ...scope, status: { $nin: CONSUMED_STATUSES } })
         .populate(WINE_POPULATE_LIST)
         .lean(),
-      Bottle.find({ user: req.user.id, cellar: { $in: cellarIds }, status: { $in: CONSUMED_STATUSES } })
+      Bottle.find({ ...scope, status: { $in: CONSUMED_STATUSES } })
         .populate(WINE_POPULATE_LIST)
         .lean(),
     ]);
 
     const stats = await computeOverview({ activeBottles, consumedBottles, cellars, targetCurrency, targetRatingScale });
+
+    if (overviewCache.size >= OVERVIEW_CACHE_MAX_ENTRIES) overviewCache.clear();
+    overviewCache.set(req.user.id, {
+      at: Date.now(),
+      key: cacheKey,
+      totalCount: activeBottles.length + consumedBottles.length,
+      activeCount: activeBottles.length,
+      stats,
+    });
+
     res.json({ stats });
   } catch (error) {
     console.error('Stats overview error:', error);

--- a/backend/src/routes/taxonomy.js
+++ b/backend/src/routes/taxonomy.js
@@ -28,6 +28,28 @@ const limiter = rateLimit({
 });
 router.use(limiter);
 
+// Server-side cache for the list endpoints. They aggregate wine counts over
+// the whole registry and only change on admin taxonomy/wine edits; clients
+// already get Cache-Control max-age=3600, this stops each cold client from
+// re-running the aggregation.
+const listCache = new Map(); // key -> { at, body }
+const LIST_CACHE_TTL_MS = 10 * 60 * 1000;
+
+function getCachedList(key) {
+  const entry = listCache.get(key);
+  return entry && Date.now() - entry.at < LIST_CACHE_TTL_MS ? entry.body : null;
+}
+
+/** Count wines per value of `field` in one aggregation (vs one countDocuments per taxon). */
+async function countWinesBy(field, { unwind = false } = {}) {
+  const pipeline = [
+    ...(unwind ? [{ $unwind: `$${field}` }] : [{ $match: { [field]: { $ne: null } } }]),
+    { $group: { _id: `$${field}`, count: { $sum: 1 } } },
+  ];
+  const rows = await WineDefinition.aggregate(pipeline);
+  return new Map(rows.map(r => [String(r._id), r.count]));
+}
+
 // Shared wine projection for public lists
 const WINE_PROJECTION = 'name producer slug type appellation region country image communityRating';
 
@@ -36,19 +58,27 @@ const WINE_PROJECTION = 'name producer slug type appellation region country imag
 // GET /api/taxonomy/countries — list all countries that have ≥MIN_WINES wines
 router.get('/countries', async (req, res) => {
   try {
-    const countries = await Country.find({ slug: { $exists: true, $ne: null } })
-      .select('name slug code description')
-      .sort({ name: 1 })
-      .lean();
+    res.set('Cache-Control', 'public, max-age=3600');
+    const cached = getCachedList('countries');
+    if (cached) return res.json(cached);
+
+    const [countries, countByCountry] = await Promise.all([
+      Country.find({ slug: { $exists: true, $ne: null } })
+        .select('name slug code description')
+        .sort({ name: 1 })
+        .lean(),
+      countWinesBy('country'),
+    ]);
 
     const result = [];
     for (const c of countries) {
-      const count = await WineDefinition.countDocuments({ country: c._id });
+      const count = countByCountry.get(String(c._id)) || 0;
       if (count >= MIN_WINES) result.push({ ...c, wineCount: count });
     }
 
-    res.set('Cache-Control', 'public, max-age=3600');
-    res.json({ countries: result, total: result.length });
+    const body = { countries: result, total: result.length };
+    listCache.set('countries', { at: Date.now(), body });
+    res.json(body);
   } catch (err) {
     console.error('[taxonomy] countries list error:', err);
     res.status(500).json({ error: 'Failed to fetch countries' });
@@ -96,20 +126,28 @@ router.get('/countries/:slug', async (req, res) => {
 // GET /api/taxonomy/regions — list all regions with ≥MIN_WINES wines
 router.get('/regions', async (req, res) => {
   try {
-    const regions = await Region.find({ slug: { $exists: true, $ne: null } })
-      .select('name slug description country')
-      .populate('country', 'name slug')
-      .sort({ name: 1 })
-      .lean();
+    res.set('Cache-Control', 'public, max-age=3600');
+    const cached = getCachedList('regions');
+    if (cached) return res.json(cached);
+
+    const [regions, countByRegion] = await Promise.all([
+      Region.find({ slug: { $exists: true, $ne: null } })
+        .select('name slug description country')
+        .populate('country', 'name slug')
+        .sort({ name: 1 })
+        .lean(),
+      countWinesBy('region'),
+    ]);
 
     const result = [];
     for (const r of regions) {
-      const count = await WineDefinition.countDocuments({ region: r._id });
+      const count = countByRegion.get(String(r._id)) || 0;
       if (count >= MIN_WINES) result.push({ ...r, wineCount: count });
     }
 
-    res.set('Cache-Control', 'public, max-age=3600');
-    res.json({ regions: result, total: result.length });
+    const body = { regions: result, total: result.length };
+    listCache.set('regions', { at: Date.now(), body });
+    res.json(body);
   } catch (err) {
     console.error('[taxonomy] regions list error:', err);
     res.status(500).json({ error: 'Failed to fetch regions' });
@@ -156,19 +194,27 @@ router.get('/regions/:slug', async (req, res) => {
 // GET /api/taxonomy/grapes — list all grapes with ≥MIN_WINES wines
 router.get('/grapes', async (req, res) => {
   try {
-    const grapes = await Grape.find({ slug: { $exists: true, $ne: null } })
-      .select('name slug color description')
-      .sort({ name: 1 })
-      .lean();
+    res.set('Cache-Control', 'public, max-age=3600');
+    const cached = getCachedList('grapes');
+    if (cached) return res.json(cached);
+
+    const [grapes, countByGrape] = await Promise.all([
+      Grape.find({ slug: { $exists: true, $ne: null } })
+        .select('name slug color description')
+        .sort({ name: 1 })
+        .lean(),
+      countWinesBy('grapes', { unwind: true }),
+    ]);
 
     const result = [];
     for (const g of grapes) {
-      const count = await WineDefinition.countDocuments({ grapes: g._id });
+      const count = countByGrape.get(String(g._id)) || 0;
       if (count >= MIN_WINES) result.push({ ...g, wineCount: count });
     }
 
-    res.set('Cache-Control', 'public, max-age=3600');
-    res.json({ grapes: result, total: result.length });
+    const body = { grapes: result, total: result.length };
+    listCache.set('grapes', { at: Date.now(), body });
+    res.json(body);
   } catch (err) {
     console.error('[taxonomy] grapes list error:', err);
     res.status(500).json({ error: 'Failed to fetch grapes' });

--- a/backend/src/routes/taxonomy.js
+++ b/backend/src/routes/taxonomy.js
@@ -42,12 +42,30 @@ function getCachedList(key) {
 
 /** Count wines per value of `field` in one aggregation (vs one countDocuments per taxon). */
 async function countWinesBy(field, { unwind = false } = {}) {
-  const pipeline = [
-    ...(unwind ? [{ $unwind: `$${field}` }] : [{ $match: { [field]: { $ne: null } } }]),
-    { $group: { _id: `$${field}`, count: { $sum: 1 } } },
-  ];
+  const pipeline = unwind
+    ? [
+        // $setUnion dedups the array first: the old countDocuments({grapes: id})
+        // counted a wine once however many times the grape appeared in its
+        // array; a bare $unwind would count every occurrence.
+        { $project: { values: { $setUnion: [`$${field}`, []] } } },
+        { $unwind: '$values' },
+        { $group: { _id: '$values', count: { $sum: 1 } } },
+      ]
+    : [
+        { $match: { [field]: { $ne: null } } },
+        { $group: { _id: `$${field}`, count: { $sum: 1 } } },
+      ];
   const rows = await WineDefinition.aggregate(pipeline);
   return new Map(rows.map(r => [String(r._id), r.count]));
+}
+
+/**
+ * Drop the cached list bodies. Called by the admin taxonomy routes after any
+ * mutation so renames/deletions don't keep serving on the public lists for
+ * the full cache TTL.
+ */
+function clearTaxonomyListCache() {
+  listCache.clear();
 }
 
 // Shared wine projection for public lists
@@ -284,3 +302,4 @@ router.get('/wine-types/:type', async (req, res) => {
 });
 
 module.exports = router;
+module.exports.clearTaxonomyListCache = clearTaxonomyListCache;


### PR DESCRIPTION
## ⚠ Stacked on #506

Base branch is `refactor/scale-phase1` — **merge #506 first**, then retarget/rebase this onto main (I can do the rebase on request). Stacked because both touch the same code in `cellars.js`.

## What

The structural request-path work from the optimization audit — kills the three biggest per-request scalability problems.

### 1. Cellar page grouping → MongoDB aggregation (the #1 finding)
`GET /api/cellars/:id?group=1` — the **default cellar page** — previously set `canPaginateInDb=false`, loaded **every bottle in the cellar** with full populate (≈6 docs per bottle), grouped them in JS, and sliced 30 groups. That ran on every page view *and every search keystroke*: a 2,000-bottle cellar ≈ 12k documents and 25-50MB heap per request.

New `loadGroupedBottlePage()`:
- groups by (wine, vintage, bottleSize) **inside MongoDB** (`$sort → $group → $sort → $skip/$limit`, `allowDiskUse`),
- then populates **only the returned page's members** (≤ ~30 groups),
- group keys + member order are **byte-identical** to the JS algorithm — `$first`/`$push` follow the pipeline's `$sort`, and empty-string vintage/size normalize exactly like the JS path (`'' → 'NV'/'750ml'`).
- Applies to the hot path only (no filters, DB-sortable sort). Filtered/maturity/minRating views keep the existing paths — they need cross-document context the DB can't compute (rating-scale normalization, maturity profiles).
- Aggregation pipelines bypass Mongoose casting, so `cellar`/exclude ids are cast to ObjectId explicitly (the audit found a real bug of this exact class in priceWarnings).

### 2. Stats overview — server-side cache with count-probe invalidation
`GET /api/stats/overview` loads the user's entire bottle set (active + consumed, populated) per request. Now cached **2 minutes per user**, with an invalidation probe of two cheap indexed `countDocuments` — add/delete/consume/undo all change one of the counts and bust the cache immediately; only pure field edits (price/rating tweaks) can be served ≤2min stale. Bounded cache (5k entries, cleared on overflow).

### 3. Taxonomy counts → one `$group` per endpoint
`/api/taxonomy/{countries,regions,grapes}` ran **one `countDocuments` per taxon, sequentially** — the grapes list was hundreds of full-registry scans per request (no `grapes` index until #506). Each list is now a single aggregation (`$unwind + $group` for grapes) + a 10-minute server-side cache (clients already get `max-age=3600`).

## Testing
- ✅ Backend 668/668
- ✅ Docker smoke with **seeded parity fixture**: 3× same wine/vintage/size (multi-member group) + different vintage + 1.5L magnum + NV bottle → aggregation output vs the JS grouping algorithm replicated client-side: **6/6 groups, keys match, member order matches**
- ✅ Stats: consecutive calls byte-identical (cached, 8-11ms); taxonomy lists consistent with counts present

## Deferred (noted in audit)
- `/api/bottles` search via Meilisearch: the bottles index has no user field — needs a full re-index to add; separate change.
- `/history` fallback and Meili-path grouped views (rarer paths) keep in-memory behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)