### PR TITLE
refactor(perf): scale phase 2b — batched fan-out, chunked Meili sync, job hygiene

### DIFF
--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -817,40 +817,47 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
       maybeEmail(quotedAuthorId, 'communityReply', 'quote');
     }
 
-    const mentionedIds = await extractMentions(cleanBody, req.user.id);
-    for (const uid of mentionedIds) {
-      if (notified.has(uid)) continue;
-      notified.add(uid);
-      notificationItems.push({
-        userId: uid,
-        type: 'discussion_mention',
-        title: `${replierName} mentioned you`,
-        message: `In "${discussion.title}"`,
-        link,
-        category: 'communityMention',
-      });
-      maybeEmail(uid, 'communityMention', 'mention');
-    }
+    // Mention/watcher resolution is best-effort: the reply is already saved,
+    // so a failure here must not 500 the request or lose the OP/quote
+    // notifications already collected above.
+    try {
+      const mentionedIds = await extractMentions(cleanBody, req.user.id);
+      for (const uid of mentionedIds) {
+        if (notified.has(uid)) continue;
+        notified.add(uid);
+        notificationItems.push({
+          userId: uid,
+          type: 'discussion_mention',
+          title: `${replierName} mentioned you`,
+          message: `In "${discussion.title}"`,
+          link,
+          category: 'communityMention',
+        });
+        maybeEmail(uid, 'communityMention', 'mention');
+      }
 
-    // Watchers — anyone following this thread who isn't already covered.
-    // Lower-priority notification ("There's a new reply on a thread you
-    // follow") so the title differs from the OP-owns-the-thread case.
-    // Push delivery is gated per-user via the 'communityFollow' category;
-    // no email channel for this category by design (would be too noisy).
-    const watchers = await DiscussionWatch.find({ discussion: discussion._id })
-      .select('user').lean();
-    for (const w of watchers) {
-      const uid = w.user.toString();
-      if (uid === selfId || notified.has(uid)) continue;
-      notified.add(uid);
-      notificationItems.push({
-        userId: uid,
-        type: 'discussion_reply',
-        title: `New reply in "${discussion.title}"`,
-        message: `${replierName} replied — you're following this thread`,
-        link,
-        category: 'communityFollow',
-      });
+      // Watchers — anyone following this thread who isn't already covered.
+      // Lower-priority notification ("There's a new reply on a thread you
+      // follow") so the title differs from the OP-owns-the-thread case.
+      // Push delivery is gated per-user via the 'communityFollow' category;
+      // no email channel for this category by design (would be too noisy).
+      const watchers = await DiscussionWatch.find({ discussion: discussion._id })
+        .select('user').lean();
+      for (const w of watchers) {
+        const uid = w.user.toString();
+        if (uid === selfId || notified.has(uid)) continue;
+        notified.add(uid);
+        notificationItems.push({
+          userId: uid,
+          type: 'discussion_reply',
+          title: `New reply in "${discussion.title}"`,
+          message: `${replierName} replied — you're following this thread`,
+          link,
+          category: 'communityFollow',
+        });
+      }
+    } catch (err) {
+      console.error('[discussions] mention/watcher resolution failed:', err.message);
     }
 
     // Fire-and-forget, same as the old per-recipient calls — delivery must

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -15,7 +15,7 @@ const { sanitizeForumHtml, visibleTextLength } = require('../utils/sanitizeHtml'
 const { logAudit } = require('../services/audit');
 const { incrementCred } = require('../utils/cellarCred');
 const { submitUrls: submitToIndexNow } = require('../services/indexNow');
-const { createNotification } = require('../services/notifications');
+const { createNotification, createNotifications } = require('../services/notifications');
 const { extractMentions } = require('../utils/mentionParser');
 const searchService = require('../services/search');
 const { sendDiscussionReplyEmail, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
@@ -785,29 +785,35 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
       }
     }
 
+    // Collect every recipient first, then deliver in ONE batch — a popular
+    // thread can have hundreds of watchers, and per-recipient
+    // createNotification calls fan out 3 queries + push HTTPS calls each,
+    // all inside this request handler.
+    const notificationItems = [];
+
     if (String(discussion.author) !== selfId) {
       notified.add(String(discussion.author));
-      createNotification(
-        discussion.author,
-        'discussion_reply',
-        'New reply to your discussion',
-        `${replierName} replied to "${discussion.title}"`,
+      notificationItems.push({
+        userId: discussion.author,
+        type: 'discussion_reply',
+        title: 'New reply to your discussion',
+        message: `${replierName} replied to "${discussion.title}"`,
         link,
-        'communityReply'
-      );
+        category: 'communityReply',
+      });
       maybeEmail(discussion.author, 'communityReply', 'reply');
     }
 
     if (quotedAuthorId && String(quotedAuthorId) !== selfId && !notified.has(String(quotedAuthorId))) {
       notified.add(String(quotedAuthorId));
-      createNotification(
-        quotedAuthorId,
-        'discussion_reply',
-        `${replierName} quoted you`,
-        `In "${discussion.title}"`,
+      notificationItems.push({
+        userId: quotedAuthorId,
+        type: 'discussion_reply',
+        title: `${replierName} quoted you`,
+        message: `In "${discussion.title}"`,
         link,
-        'communityReply'
-      );
+        category: 'communityReply',
+      });
       maybeEmail(quotedAuthorId, 'communityReply', 'quote');
     }
 
@@ -815,14 +821,14 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
     for (const uid of mentionedIds) {
       if (notified.has(uid)) continue;
       notified.add(uid);
-      createNotification(
-        uid,
-        'discussion_mention',
-        `${replierName} mentioned you`,
-        `In "${discussion.title}"`,
+      notificationItems.push({
+        userId: uid,
+        type: 'discussion_mention',
+        title: `${replierName} mentioned you`,
+        message: `In "${discussion.title}"`,
         link,
-        'communityMention'
-      );
+        category: 'communityMention',
+      });
       maybeEmail(uid, 'communityMention', 'mention');
     }
 
@@ -837,15 +843,21 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
       const uid = w.user.toString();
       if (uid === selfId || notified.has(uid)) continue;
       notified.add(uid);
-      createNotification(
-        uid,
-        'discussion_reply',
-        `New reply in "${discussion.title}"`,
-        `${replierName} replied — you're following this thread`,
+      notificationItems.push({
+        userId: uid,
+        type: 'discussion_reply',
+        title: `New reply in "${discussion.title}"`,
+        message: `${replierName} replied — you're following this thread`,
         link,
-        'communityFollow'
-      );
+        category: 'communityFollow',
+      });
     }
+
+    // Fire-and-forget, same as the old per-recipient calls — delivery must
+    // never block or fail the reply create.
+    createNotifications(notificationItems).catch(err =>
+      console.error('[discussions] reply notification batch failed:', err.message)
+    );
 
     logAudit(req, 'discussion_reply.create', { type: 'discussion_reply', id: reply._id }, { discussion: discussion._id });
 

--- a/backend/src/services/communityPriceJob.js
+++ b/backend/src/services/communityPriceJob.js
@@ -77,9 +77,11 @@ async function runCommunityPriceAggregation() {
 
   let upserted = 0;
   let removed = 0;
+  let groups = 0; // rows seen — the cursor has no .length
   const processedPairs = new Set(); // `${wine}|${currency}` recomputed this run
 
   for await (const row of rowCursor) {
+    groups++;
     const { wine, currency } = row._id;
     const cur = String(currency || 'USD').toUpperCase();
     const cap = capFor(cur);
@@ -154,10 +156,10 @@ async function runCommunityPriceAggregation() {
   }
 
   console.log(
-    `[communityPrice] Aggregated ${rows.length} wine/currency group(s): ` +
+    `[communityPrice] Aggregated ${groups} wine/currency group(s): ` +
     `${upserted} price(s) upserted, ${removed} stale removed`
   );
-  return { groups: rows.length, upserted, removed };
+  return { groups, upserted, removed };
 }
 
 module.exports = { runCommunityPriceAggregation };

--- a/backend/src/services/communityPriceJob.js
+++ b/backend/src/services/communityPriceJob.js
@@ -31,7 +31,11 @@ async function runCommunityPriceAggregation() {
   // locales rather than an exact string. Legacy bottles with no size set
   // (Mongoose default is '750ml') are treated as standard.
   const STANDARD_750 = /^\s*750\s*ml/i;
-  const rows = await Bottle.aggregate([
+  // Cursor + allowDiskUse: the nested $push stages accumulate every priced
+  // bottle in the system — without disk use the $group aborts at Mongo's
+  // 100MB stage limit, and materializing all rows at once holds the whole
+  // price universe in Node memory.
+  const rowCursor = Bottle.aggregate([
     {
       $match: {
         status: { $nin: CONSUMED_STATUSES },
@@ -69,13 +73,13 @@ async function runCommunityPriceAggregation() {
         vintages: { $push: { vintage: '$_id.vintage', owners: '$owners' } },
       },
     },
-  ]);
+  ]).allowDiskUse(true).cursor();
 
   let upserted = 0;
   let removed = 0;
   const processedPairs = new Set(); // `${wine}|${currency}` recomputed this run
 
-  for (const row of rows) {
+  for await (const row of rowCursor) {
     const { wine, currency } = row._id;
     const cur = String(currency || 'USD').toUpperCase();
     const cap = capFor(cur);

--- a/backend/src/services/drinkWindowNotifier.js
+++ b/backend/src/services/drinkWindowNotifier.js
@@ -96,6 +96,7 @@ async function processUser(user, isFirstRun) {
 
   const currentYear = new Date().getFullYear();
   const alerts = []; // { bottleId, name, vintage, status, notifType }
+  const seedOps = []; // first-run status seeds, flushed as one bulkWrite
 
   for (const bottle of bottles) {
     const maturityStatus = classifyMaturity(bottle, profileMap);
@@ -122,11 +123,16 @@ async function processUser(user, isFirstRun) {
     const effectiveStatus = notifType === 'ending' ? 'ending' : maturityStatus;
 
     if (isFirstRun) {
-      // Silent seed: record the current status without sending notifications
-      await Bottle.updateOne(
-        { _id: bottle._id },
-        { $set: { drinkWindowNotifiedStatus: effectiveStatus, drinkWindowNotifiedAt: new Date() } }
-      );
+      // Silent seed: record the current status without sending notifications.
+      // Collected into one bulkWrite per user — the first run touches every
+      // bottle in the system, and one awaited updateOne per bottle made the
+      // seed take hours at scale.
+      seedOps.push({
+        updateOne: {
+          filter: { _id: bottle._id },
+          update: { $set: { drinkWindowNotifiedStatus: effectiveStatus, drinkWindowNotifiedAt: new Date() } },
+        },
+      });
       continue;
     }
 
@@ -157,6 +163,10 @@ async function processUser(user, isFirstRun) {
       { _id: bottle._id },
       { $set: { drinkWindowNotifiedStatus: effectiveStatus, drinkWindowNotifiedAt: new Date() } }
     );
+  }
+
+  if (seedOps.length > 0) {
+    await Bottle.bulkWrite(seedOps, { ordered: false });
   }
 
   if (alerts.length === 0) return 0;

--- a/backend/src/services/drinkWindowNotifier.js
+++ b/backend/src/services/drinkWindowNotifier.js
@@ -51,23 +51,33 @@ async function runDrinkWindowCheck() {
   }).select('_id email username displayName preferences.notifications emailVerified').lean();
 
   let totalNotified = 0;
+  let failedUsers = 0;
 
   for (const user of users) {
     try {
       const count = await processUser(user, isFirstRun);
       totalNotified += count;
     } catch (err) {
+      failedUsers++;
       console.error(`[drinkWindowNotifier] Error for user ${user._id}:`, err.message);
     }
   }
 
   if (isFirstRun) {
-    await SiteConfig.findOneAndUpdate(
-      { key: 'drinkWindowNotifierSeeded' },
-      { $set: { key: 'drinkWindowNotifierSeeded', value: new Date().toISOString() } },
-      { upsert: true }
-    );
-    console.log(`[drinkWindowNotifier] First run — seeded ${users.length} users' bottles (no notifications sent)`);
+    // Only persist the seeded marker when EVERY user seeded. A user whose
+    // seed bulkWrite failed has no recorded statuses — marking the run
+    // seeded anyway would treat all their at-peak bottles as fresh
+    // transitions on the next run and spam them with notifications.
+    if (failedUsers === 0) {
+      await SiteConfig.findOneAndUpdate(
+        { key: 'drinkWindowNotifierSeeded' },
+        { $set: { key: 'drinkWindowNotifierSeeded', value: new Date().toISOString() } },
+        { upsert: true }
+      );
+      console.log(`[drinkWindowNotifier] First run — seeded ${users.length} users' bottles (no notifications sent)`);
+    } else {
+      console.error(`[drinkWindowNotifier] First-run seed incomplete (${failedUsers} user(s) failed) — marker not set, will re-seed next run`);
+    }
   } else {
     console.log(`[drinkWindowNotifier] Sent ${totalNotified} notification(s)`);
   }

--- a/backend/src/services/imageProcessor.js
+++ b/backend/src/services/imageProcessor.js
@@ -135,20 +135,29 @@ async function cleanupOrphanedImages() {
     const ORIGINALS_DIR = path.join(UPLOADS_ROOT, 'originals');
     if (!fs.existsSync(ORIGINALS_DIR)) return;
 
-    const files = fs.readdirSync(ORIGINALS_DIR);
-    const dbImages = await BottleImage.find({}, 'originalUrl').lean();
+    // originalUrl is null for approved/rejected images (their file was already
+    // deleted) — path.basename(null) used to throw here, which silently
+    // disabled the orphan sweep forever once any image had been moderated.
+    const files = await fs.promises.readdir(ORIGINALS_DIR);
+    const dbImages = await BottleImage.find({ originalUrl: { $ne: null } }, 'originalUrl').lean();
     const knownFiles = new Set(dbImages.map(img => path.basename(img.originalUrl)));
 
     let removed = 0;
     for (const file of files) {
       if (knownFiles.has(file)) continue;
 
-      // Only remove files older than 1 hour to avoid racing with in-progress uploads
+      // Only remove files older than 1 hour to avoid racing with in-progress
+      // uploads. Async fs — the sync walk held the event loop for the whole
+      // directory scan, freezing the API every hour as uploads accumulate.
       const filePath = path.join(ORIGINALS_DIR, file);
-      const stat = fs.statSync(filePath);
-      if (Date.now() - stat.mtimeMs > 60 * 60 * 1000) {
-        fs.unlinkSync(filePath);
-        removed++;
+      try {
+        const stat = await fs.promises.stat(filePath);
+        if (Date.now() - stat.mtimeMs > 60 * 60 * 1000) {
+          await fs.promises.unlink(filePath);
+          removed++;
+        }
+      } catch {
+        // File vanished mid-sweep (e.g. processed and cleaned) — fine
       }
     }
     if (removed > 0) {

--- a/backend/src/services/notifications.js
+++ b/backend/src/services/notifications.js
@@ -1,6 +1,12 @@
 const Notification = require('../models/Notification');
 const PushSubscription = require('../models/PushSubscription');
 const User = require('../models/User');
+const { runConcurrent } = require('../utils/concurrency');
+
+// Max simultaneous web-push HTTPS calls per batch — a popular thread can have
+// hundreds of watchers; an uncapped burst stampedes the event loop and the
+// push service.
+const PUSH_CONCURRENCY = 10;
 
 let webpush;
 const VAPID_CONFIGURED = !!(process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY);
@@ -42,55 +48,87 @@ const PUSH_PREF_PATH = {
  *   per-category prefs.
  */
 async function createNotification(userId, type, title, message, link = null, category) {
+  return createNotifications([{ userId, type, title, message, link, category }]);
+}
+
+// Push-preference gate: category-specific when the caller named one,
+// otherwise permissive ("any push toggle enabled") so legacy callers that
+// haven't been migrated to pass a category keep working.
+function pushAllowedFor(prefs, category) {
+  if (!prefs) return false;
+  const prefKey = category ? PUSH_PREF_PATH[category] : null;
+  if (prefKey) return !!prefs[prefKey]?.push;
+  return Object.values(PUSH_PREF_PATH).some(k => !!prefs[k]?.push);
+}
+
+async function sendToSubscription(sub, payload) {
   try {
-    await Notification.create({ user: userId, type, title, message, link });
+    await webpush.sendNotification({ endpoint: sub.endpoint, keys: sub.keys }, payload);
   } catch (err) {
-    console.error('[notifications] Failed to create notification:', err.message);
+    // 410 Gone = subscription expired; clean it up
+    if (err.statusCode === 410 || err.statusCode === 404) {
+      await PushSubscription.deleteOne({ _id: sub._id });
+    }
+  }
+}
+
+/**
+ * Batch variant for fan-out callers — one forum reply can notify hundreds of
+ * watchers. One insertMany for the in-app rows, one prefs query and one
+ * subscription query for ALL recipients, and push delivery capped at
+ * PUSH_CONCURRENCY instead of an unbounded burst of per-recipient queries
+ * and HTTPS calls inside the request handler.
+ *
+ * @param {Array<{userId, type, title, message, link?, category?}>} items
+ */
+async function createNotifications(items) {
+  if (!items || items.length === 0) return;
+
+  try {
+    await Notification.insertMany(
+      items.map(i => ({ user: i.userId, type: i.type, title: i.title, message: i.message, link: i.link || null })),
+      { ordered: false }
+    );
+  } catch (err) {
+    console.error('[notifications] Failed to create notifications:', err.message);
   }
 
   // Web push — fire and forget
   if (!VAPID_CONFIGURED) return;
   try {
-    const user = await User.findById(userId).select('preferences.notifications').lean();
-    const prefs = user?.preferences?.notifications;
-    if (!prefs) return;
+    const userIds = [...new Set(items.map(i => String(i.userId)))];
+    const users = await User.find({ _id: { $in: userIds } })
+      .select('preferences.notifications')
+      .lean();
+    const prefsById = new Map(users.map(u => [String(u._id), u.preferences?.notifications]));
 
-    // Category-specific gate when the caller named one — otherwise permissive.
-    let pushAllowed;
-    const prefKey = category ? PUSH_PREF_PATH[category] : null;
-    if (prefKey) {
-      pushAllowed = !!prefs[prefKey]?.push;
-    } else {
-      // Legacy / uncategorised path: fire if any of the known push toggles
-      // are on. Avoids silently dropping notifications for callers that
-      // haven't been migrated to pass a category yet.
-      pushAllowed = Object.values(PUSH_PREF_PATH).some(k => !!prefs[k]?.push);
-    }
-    if (!pushAllowed) return;
+    const allowed = items.filter(i => pushAllowedFor(prefsById.get(String(i.userId)), i.category));
+    if (allowed.length === 0) return;
 
-    const subs = await PushSubscription.find({ user: userId }).lean();
+    const allowedIds = [...new Set(allowed.map(i => String(i.userId)))];
+    const subs = await PushSubscription.find({ user: { $in: allowedIds } }).lean();
     if (subs.length === 0) return;
 
-    const payload = JSON.stringify({ title, message, link, tag: type });
+    const subsByUser = new Map();
+    for (const sub of subs) {
+      const key = String(sub.user);
+      if (!subsByUser.has(key)) subsByUser.set(key, []);
+      subsByUser.get(key).push(sub);
+    }
 
-    await Promise.allSettled(
-      subs.map(async (sub) => {
-        try {
-          await webpush.sendNotification(
-            { endpoint: sub.endpoint, keys: sub.keys },
-            payload
-          );
-        } catch (err) {
-          // 410 Gone = subscription expired; clean it up
-          if (err.statusCode === 410 || err.statusCode === 404) {
-            await PushSubscription.deleteOne({ _id: sub._id });
-          }
-        }
-      })
-    );
+    const tasks = [];
+    for (const item of allowed) {
+      const userSubs = subsByUser.get(String(item.userId));
+      if (!userSubs) continue;
+      const payload = JSON.stringify({ title: item.title, message: item.message, link: item.link || null, tag: item.type });
+      for (const sub of userSubs) {
+        tasks.push(() => sendToSubscription(sub, payload));
+      }
+    }
+    await runConcurrent(tasks, PUSH_CONCURRENCY);
   } catch (err) {
     console.error('[notifications] Push dispatch error:', err.message);
   }
 }
 
-module.exports = { createNotification };
+module.exports = { createNotification, createNotifications };

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -118,28 +118,53 @@ async function initialize() {
   }
 }
 
+// While an index's INITIAL sync is in flight (first boot / wiped volume),
+// searches against it must fail so callers take their MongoDB fallback —
+// callers like the cellar route treat zero Meili hits as authoritative, and
+// a half-built index would confidently return empty results for minutes.
+const initialSyncing = { wines: false, bottles: false, discussions: false };
+
+function assertIndexReady(label) {
+  if (initialSyncing[label]) {
+    throw new Error(`Meilisearch '${label}' index initial sync in progress`);
+  }
+}
+
 // Run `syncFn` only if `idx` has no documents yet (or a rebuild is forced).
 const FORCE_REINDEX = process.env.MEILI_FORCE_REINDEX === '1' || process.env.MEILI_FORCE_REINDEX === 'true';
-async function syncIfNeeded(idx, syncFn, label) {
+const SYNC_CHECK_MAX_RETRIES = 5;
+async function syncIfNeeded(idx, syncFn, label, attempt = 0) {
   try {
     if (FORCE_REINDEX) {
       console.log(`Meilisearch: MEILI_FORCE_REINDEX set — rebuilding '${label}'`);
-      await syncFn();
+      initialSyncing[label] = true;
+      try { await syncFn(); } finally { initialSyncing[label] = false; }
       return;
     }
     const stats = await idx.getStats();
     if (!stats || stats.numberOfDocuments === 0) {
       console.log(`Meilisearch: '${label}' index empty — running initial sync`);
-      await syncFn();
+      initialSyncing[label] = true;
+      try { await syncFn(); } finally { initialSyncing[label] = false; }
     } else {
       console.log(`Meilisearch: '${label}' already populated (${stats.numberOfDocuments} docs) — skipping sync`);
     }
   } catch (err) {
-    // Fail CLOSED: a transient stats error must not trigger a full catalog
-    // re-upload — at scale that is the most expensive operation in the
-    // system, and it used to fire exactly when Meilisearch was struggling.
-    // Incremental indexing continues regardless; force with MEILI_FORCE_REINDEX.
-    console.warn(`Meilisearch: could not check '${label}' stats (${err.message}) — skipping sync (set MEILI_FORCE_REINDEX=1 to force)`);
+    // Fail CLOSED on the stats check: a transient error must not trigger a
+    // full catalog re-upload — at scale that is the most expensive operation
+    // in the system, and it used to fire exactly when Meilisearch was
+    // struggling. But an EMPTY index whose stats keep erroring would stay
+    // empty forever, so retry the check a few times (covers Meili still
+    // warming up at boot) before giving up loudly.
+    if (attempt < SYNC_CHECK_MAX_RETRIES) {
+      const delayMs = 30_000 * (attempt + 1);
+      console.warn(`Meilisearch: could not check '${label}' stats (${err.message}) — retrying in ${delayMs / 1000}s (${attempt + 1}/${SYNC_CHECK_MAX_RETRIES})`);
+      setTimeout(() => {
+        syncIfNeeded(idx, syncFn, label, attempt + 1).catch(() => {});
+      }, delayMs).unref?.();
+    } else {
+      console.error(`Meilisearch: '${label}' stats check failed ${SYNC_CHECK_MAX_RETRIES} times (${err.message}) — giving up; set MEILI_FORCE_REINDEX=1 if the index is empty`);
+    }
   }
 }
 
@@ -236,6 +261,7 @@ async function search(query, { countryId, regionId, type, grapeIds, limit = 50, 
   if (!isAvailable) {
     throw new Error('Meilisearch is not available');
   }
+  assertIndexReady('wines');
 
   // Build filter array using Meilisearch array syntax (each element is ANDed).
   // Validate IDs as hex ObjectIds and type against an allowlist to prevent injection.
@@ -380,6 +406,7 @@ async function searchBottles(query, {
   if (!isAvailable) {
     throw new Error('Meilisearch is not available');
   }
+  assertIndexReady('bottles');
 
   const isObjectId = (v) => /^[a-f0-9]{24}$/i.test(String(v));
   const VALID_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
@@ -601,6 +628,7 @@ async function searchDiscussions(query, { category, limit = 20, offset = 0 } = {
   if (!isAvailable) {
     throw new Error('Meilisearch is not available');
   }
+  assertIndexReady('discussions');
 
   const VALID_CATEGORIES = ['tasting-notes', 'food-pairing', 'recommendations', 'cellar-tips', 'general'];
   const filters = [];

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -102,9 +102,16 @@ async function initialize() {
     // the whole catalog every boot is wasteful. Live data changes are kept in
     // sync incrementally by indexWine/indexBottle/indexDiscussion. Set
     // MEILI_FORCE_REINDEX=1 to force a rebuild (e.g. after a settings change).
-    await syncIfNeeded(index, fullSync, 'wines');
-    await syncIfNeeded(bottlesIndex, fullSyncBottles, 'bottles');
-    await syncIfNeeded(discussionsIndex, fullSyncDiscussions, 'discussions');
+    //
+    // The syncs run in the BACKGROUND: a full catalog upload takes minutes at
+    // scale and initialize() is awaited before app.listen — blocking boot (and
+    // the container healthcheck) on it would make first-boot/recovery deploys
+    // fail. Search may briefly return partial results during an initial sync.
+    (async () => {
+      await syncIfNeeded(index, fullSync, 'wines');
+      await syncIfNeeded(bottlesIndex, fullSyncBottles, 'bottles');
+      await syncIfNeeded(discussionsIndex, fullSyncDiscussions, 'discussions');
+    })().catch(err => console.error(`Meilisearch initial sync failed: ${err.message}`));
   } catch (err) {
     isAvailable = false;
     console.warn(`Meilisearch unavailable (${url}): ${err.message}. Falling back to MongoDB search.`);
@@ -128,9 +135,11 @@ async function syncIfNeeded(idx, syncFn, label) {
       console.log(`Meilisearch: '${label}' already populated (${stats.numberOfDocuments} docs) — skipping sync`);
     }
   } catch (err) {
-    // If the stats check fails for any reason, sync to be safe (correctness > speed).
-    console.warn(`Meilisearch: could not check '${label}' stats (${err.message}) — running sync`);
-    await syncFn();
+    // Fail CLOSED: a transient stats error must not trigger a full catalog
+    // re-upload — at scale that is the most expensive operation in the
+    // system, and it used to fire exactly when Meilisearch was struggling.
+    // Incremental indexing continues regardless; force with MEILI_FORCE_REINDEX.
+    console.warn(`Meilisearch: could not check '${label}' stats (${err.message}) — skipping sync (set MEILI_FORCE_REINDEX=1 to force)`);
   }
 }
 
@@ -152,23 +161,44 @@ function buildDocument(wine) {
   };
 }
 
+// Stream a query through buildDoc into chunked addDocuments calls. Loading a
+// whole collection into one array + one HTTP payload OOMs Node and exceeds
+// Meilisearch's payload limit once the catalog is large; a cursor keeps
+// memory flat at CHUNK documents.
+const SYNC_CHUNK_SIZE = 2000;
+async function syncViaCursor(query, buildDoc, idx, label) {
+  let batch = [];
+  let total = 0;
+  const cursor = query.cursor();
+  for await (const doc of cursor) {
+    batch.push(buildDoc(doc));
+    if (batch.length >= SYNC_CHUNK_SIZE) {
+      await idx.addDocuments(batch, { primaryKey: 'id' });
+      total += batch.length;
+      batch = [];
+    }
+  }
+  if (batch.length > 0) {
+    await idx.addDocuments(batch, { primaryKey: 'id' });
+    total += batch.length;
+  }
+  console.log(`Meilisearch: synced ${total} ${label}`);
+}
+
 async function fullSync() {
   if (!isAvailable) return;
 
   try {
-    const wines = await WineDefinition.find()
-      .populate('country', 'name')
-      .populate('region', 'name')
-      .populate('grapes', 'name')
-      .lean();
-
-    const documents = wines.map(buildDocument);
-
-    if (documents.length > 0) {
-      await index.addDocuments(documents, { primaryKey: 'id' });
-    }
-
-    console.log(`Meilisearch: synced ${documents.length} wines`);
+    await syncViaCursor(
+      WineDefinition.find()
+        .populate('country', 'name')
+        .populate('region', 'name')
+        .populate('grapes', 'name')
+        .lean(),
+      buildDocument,
+      index,
+      'wines'
+    );
   } catch (err) {
     console.error(`Meilisearch full sync failed: ${err.message}`);
   }
@@ -278,17 +308,12 @@ async function fullSyncBottles() {
 
   try {
     // Sync ALL bottles (active + consumed) so history search works too
-    const bottles = await Bottle.find()
-      .populate(WINE_POPULATE)
-      .lean();
-
-    const documents = bottles.map(buildBottleDocument);
-
-    if (documents.length > 0) {
-      await bottlesIndex.addDocuments(documents, { primaryKey: 'id' });
-    }
-
-    console.log(`Meilisearch: synced ${documents.length} bottles`);
+    await syncViaCursor(
+      Bottle.find().populate(WINE_POPULATE).lean(),
+      buildBottleDocument,
+      bottlesIndex,
+      'bottles'
+    );
   } catch (err) {
     console.error(`Meilisearch bottle full sync failed: ${err.message}`);
   }
@@ -491,33 +516,46 @@ async function fullSyncDiscussions() {
   if (!isAvailable) return;
 
   try {
-    const discussions = await Discussion.find()
+    const DiscussionReply = require('../models/DiscussionReply');
+    let batch = [];
+    let total = 0;
+
+    // Per chunk: fetch reply texts for just this chunk's discussions (one
+    // $in query per chunk — batched, not N+1, and never the whole replies
+    // collection in memory at once).
+    const flush = async () => {
+      if (batch.length === 0) return;
+      const ids = batch.map(d => d._id);
+      const replies = await DiscussionReply.find({ discussion: { $in: ids }, isDeleted: { $ne: true } })
+        .sort({ discussion: 1, createdAt: 1 })
+        .select('discussion body')
+        .lean();
+      const repliesByDiscussion = new Map();
+      for (const r of replies) {
+        const key = r.discussion.toString();
+        if (!repliesByDiscussion.has(key)) repliesByDiscussion.set(key, []);
+        repliesByDiscussion.get(key).push(stripHtml(r.body || ''));
+      }
+      const documents = batch.map(d =>
+        buildDiscussionDocument(d, repliesByDiscussion.get(d._id.toString()) || [])
+      );
+      await discussionsIndex.addDocuments(documents, { primaryKey: 'id' });
+      total += documents.length;
+      batch = [];
+    };
+
+    const cursor = Discussion.find()
       .populate('author', 'username displayName')
       .populate({ path: 'wineDefinition', select: 'name producer' })
-      .lean();
-
-    // Bulk-fetch reply texts so we don't hit N+1 on the full sync.
-    const DiscussionReply = require('../models/DiscussionReply');
-    const allReplies = await DiscussionReply.find({ isDeleted: { $ne: true } })
-      .sort({ discussion: 1, createdAt: 1 })
-      .select('discussion body')
-      .lean();
-    const repliesByDiscussion = new Map();
-    for (const r of allReplies) {
-      const key = r.discussion.toString();
-      if (!repliesByDiscussion.has(key)) repliesByDiscussion.set(key, []);
-      repliesByDiscussion.get(key).push(stripHtml(r.body || ''));
+      .lean()
+      .cursor();
+    for await (const d of cursor) {
+      batch.push(d);
+      if (batch.length >= 500) await flush();
     }
+    await flush();
 
-    const documents = discussions.map(d =>
-      buildDiscussionDocument(d, repliesByDiscussion.get(d._id.toString()) || [])
-    );
-
-    if (documents.length > 0) {
-      await discussionsIndex.addDocuments(documents, { primaryKey: 'id' });
-    }
-
-    console.log(`Meilisearch: synced ${documents.length} discussions (with reply content)`);
+    console.log(`Meilisearch: synced ${total} discussions (with reply content)`);
   } catch (err) {
     console.error(`Meilisearch discussion full sync failed: ${err.message}`);
   }


### PR DESCRIPTION
## What

The jobs-and-sync half of Phase 2 from the optimization audit. Branches off main directly — **independent of #506/#507** (disjoint files), mergeable in any order.

### 1. Reply notification fan-out → one batch
One forum reply previously fired **~3 Mongo queries + per-subscription web-push HTTPS calls per watcher**, all un-awaited inside the request handler — a 500-watcher thread ≈ 1,500 concurrent queries stampeding the connection pool.

New `createNotifications(items)` in the notifications service:
- one `insertMany` for all in-app rows,
- **one** prefs query + **one** push-subscription query for all recipients (`$in`),
- push delivery through the existing `runConcurrent` util, capped at 10 in-flight,
- same per-category preference gating (extracted to `pushAllowedFor`, identical semantics including the legacy permissive fallback),
- `createNotification` now delegates to a batch of one → every other caller keeps byte-identical behavior.

### 2. Meilisearch full syncs → cursor + chunks, non-blocking, fail-closed
- `fullSync`/`fullSyncBottles`/`fullSyncDiscussions` previously loaded **entire collections into one array and one HTTP payload** — OOMs Node and exceeds Meili's ~100MB payload cap around 200k bottles. Now streamed via Mongoose cursor into 2,000-doc `addDocuments` chunks (discussions: per-chunk `$in` reply fetch — batched, never the whole replies collection in memory).
- Initial syncs no longer block `app.listen` — a multi-minute catalog upload used to gate boot **and the container healthcheck**, making first-boot/recovery deploys fail at scale. Search may briefly return partial results during a first-boot sync (only then).
- A failed index-stats check now **skips** the sync (fail closed) instead of re-uploading the whole catalog exactly when Meilisearch is struggling. `MEILI_FORCE_REINDEX=1` still forces.

### 3. Job hygiene
- **communityPriceJob**: `allowDiskUse(true)` + cursor iteration — the nested `$push` stages blow Mongo's 100MB stage limit on a big price universe, and `rows` held every price in the system in Node memory.
- **drinkWindowNotifier first-run seed**: collected into one `bulkWrite` per user instead of one awaited `updateOne` per bottle (the seed touches every bottle in the system — hours of sequential writes at scale).
- **cleanupOrphanedImages**: async `fs.promises` (the sync walk froze the event loop for the whole directory scan, hourly), and 🐛 **fixes the audit-verified crash**: `originalUrl` is null for approved/rejected images, `path.basename(null)` threw, and the swallowed error silently disabled the orphan sweep forever once any image had been moderated.

## Testing
- ✅ Backend 668/668
- ✅ Docker smoke: admin creates discussion → user replies → **batch notification delivered end-to-end** (correct title/message, unreadCount 0→1)
- ✅ Boot logs confirm: populated indexes skip sync; the discussions sync ran through the new chunked path; and `[cleanup] Removed 1 orphaned original files` — **the sweep completed and reaped an orphan for the first time** (it had been crashing every hour before)

## Deferred (Phase 3 / audit backlog)
Embedding-job Voyage batching + build-then-swap Qdrant rebuild; per-user drink-window loop parallelism; outbox/queue for email+push; scheduler worker split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)