### PR TITLE
fix(models): remove dead soft-delete TTL index ($ne unsupported in partial index)

### DIFF
--- a/backend/src/models/Cellar.js
+++ b/backend/src/models/Cellar.js
@@ -59,11 +59,14 @@ const cellarSchema = new mongoose.Schema({
 
 // Compound index: user can't have duplicate active cellar names (deleted cellars are excluded)
 cellarSchema.index({ user: 1, name: 1 }, { unique: true, partialFilterExpression: { deletedAt: null } });
-// TTL: auto-purge soft-deleted cellars after 30 days
-cellarSchema.index(
-  { deletedAt: 1 },
-  { expireAfterSeconds: 30 * 24 * 60 * 60, partialFilterExpression: { deletedAt: { $ne: null } } }
-);
+// NOTE: no TTL auto-purge of soft-deleted cellars. The previous index used
+// partialFilterExpression { deletedAt: { $ne: null } }, which MongoDB rejects
+// ($ne is unsupported in partial indexes), so syncIndexes failed every boot
+// and the index never existed — the purge has never actually run. Re-adding it
+// needs (a) the supported predicate { deletedAt: { $type: 'date' } } AND (b) a
+// purge that re-homes/deletes the cellar's Bottles + CellarLayout together,
+// because TTL deletion runs no application code and would orphan them
+// permanently (CODE_AUDIT_2026-06-10 HIGH: "Cellar TTL purge bypasses cascades").
 // Index for finding cellars shared with a user
 cellarSchema.index({ 'members.user': 1 });
 

--- a/backend/src/models/Rack.js
+++ b/backend/src/models/Rack.js
@@ -49,11 +49,13 @@ const rackSchema = new mongoose.Schema({
 
 rackSchema.index({ cellar: 1, name: 1 }, { unique: true, partialFilterExpression: { deletedAt: null } });
 rackSchema.index({ rfidTag: 1 }, { unique: true, sparse: true });
-// TTL: auto-purge soft-deleted racks after 30 days
-rackSchema.index(
-  { deletedAt: 1 },
-  { expireAfterSeconds: 30 * 24 * 60 * 60, partialFilterExpression: { deletedAt: { $ne: null } } }
-);
+// NOTE: no TTL auto-purge of soft-deleted racks. The previous index used
+// partialFilterExpression { deletedAt: { $ne: null } }, which MongoDB rejects
+// ($ne is unsupported in partial indexes), so syncIndexes failed every boot
+// and the index never existed — the purge has never actually run. Re-adding it
+// needs (a) the supported predicate { deletedAt: { $type: 'date' } } AND (b) a
+// cascade that clears bottle rack references first, or TTL deletion would
+// orphan them (see CODE_AUDIT — same class as the cellar-purge finding).
 
 module.exports = mongoose.model('Rack', rackSchema);
 module.exports.RACK_TYPES = RACK_TYPES;


### PR DESCRIPTION
## Bug

Cellar and Rack each declared a 30-day TTL index to auto-purge soft-deleted docs:

```js
schema.index({ deletedAt: 1 }, { expireAfterSeconds: 30*24*60*60,
  partialFilterExpression: { deletedAt: { $ne: null } } });
```

MongoDB **does not support `$ne` in partial-index filter expressions**, so Mongoose `syncIndexes()` threw on every boot:

```
[db] Rack.syncIndexes failed: Error in specification { ... partialFilterExpression:
{ deletedAt: { $ne: null } } ... } :: caused by :: Expression not supported in partial index: $not
```

The index was therefore **never created** — confirmed against the live DB, neither `racks` nor `cellars` has a `deletedAt` TTL index. The advertised 30-day auto-purge has silently never run. (Only Rack logged the failure; Cellar's threw too but earlier in boot.)

## Fix

**Removed** the broken index from both models rather than correcting the predicate.

Correcting it to the supported `{ deletedAt: { $type: 'date' } }` would make the TTL actually fire — which activates the bottle-orphaning flagged HIGH in CODE_AUDIT_2026-06-10 ("Cellar TTL purge bypasses cascades"): TTL deletion runs no application code, so a purged cellar/rack leaves its `Bottle`s and `CellarLayout` dangling. Enabling a real purge needs that cascade first, so it's deferred — both models now carry a comment with the two requirements (`$type: 'date'` predicate **and** a cascade).

Removing a never-created index is a **behavioral no-op** — it just stops the boot-time error. The separate partial *unique* index on `{ deletedAt: null }` (which works and enforces no-duplicate-active-names) is untouched.

## Testing
- ✅ Backend 668/668
- ✅ Verified against the running stack: the `syncIndexes failed` line is gone from the boot logs after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)