### PR TITLE
feat(admin): SuperAdmin-managed site announcement banner

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,6 +8,7 @@ const cookieParser = require('cookie-parser');
 const { getClientIp } = require('./utils/clientIp');
 const { requireAuth } = require('./middleware/auth');
 const healthRoute = require('./routes/health');
+const siteRoute = require('./routes/site');
 const authRoute = require('./routes/auth');
 const usersRoute = require('./routes/users');
 const winesRoute = require('./routes/wines');
@@ -59,6 +60,7 @@ const taxonomyRoute = require('./routes/taxonomy');
 const stripeRoute = require('./routes/stripe');
 const rateLimitsConfig = require('./config/rateLimits');
 const aiConfig = require('./config/aiConfig');
+const announcementConfig = require('./config/announcement');
 const { logAudit } = require('./services/audit');
 
 const app = express();
@@ -168,6 +170,7 @@ app.use('/api/uploads', (req, res, next) => {
 
 // Routes
 app.use('/api/health', healthRoute);
+app.use('/api/site', siteRoute);
 app.use('/api/auth', authRoute);
 app.use('/api/users', usersRoute);
 app.use('/api/wines', winesRoute);
@@ -244,6 +247,11 @@ rateLimitsConfig.load().catch(err =>
 // Load AI feature-flag configuration from DB on startup
 aiConfig.load().catch(err =>
   console.warn('[aiConfig] Startup load failed, using defaults:', err.message)
+);
+
+// Load the site announcement banner from DB on startup
+announcementConfig.load().catch(err =>
+  console.warn('[announcement] Startup load failed, using defaults:', err.message)
 );
 
 module.exports = app;

--- a/backend/src/config/announcement.js
+++ b/backend/src/config/announcement.js
@@ -1,0 +1,47 @@
+/**
+ * Site announcement banner — SuperAdmin-managed message shown to all users
+ * (e.g. "Maintenance tonight 22:00–22:15"). Stored in SiteConfig under
+ * 'announcement', cached in memory and hot-reloaded on save like rateLimits.
+ *
+ * `updatedAt` doubles as the dismissal version: the frontend remembers which
+ * version a user dismissed, so editing the message re-shows the banner.
+ */
+
+const defaults = {
+  enabled: false,
+  message: '',
+  messageSv: '', // optional Swedish text; falls back to message
+  type: 'info', // info | warning
+  updatedAt: null,
+};
+
+let cache = { ...defaults };
+
+async function load() {
+  try {
+    // Lazy require to avoid circular dependency at module load time
+    const SiteConfig = require('../models/SiteConfig');
+    const doc = await SiteConfig.findOne({ key: 'announcement' });
+    if (doc && doc.value) {
+      cache = {
+        enabled: doc.value.enabled ?? defaults.enabled,
+        message: doc.value.message ?? defaults.message,
+        messageSv: doc.value.messageSv ?? defaults.messageSv,
+        type: ['info', 'warning'].includes(doc.value.type) ? doc.value.type : defaults.type,
+        updatedAt: doc.updatedAt ? doc.updatedAt.toISOString() : null,
+      };
+    }
+  } catch (err) {
+    console.warn('[announcement] Could not load config from DB, using defaults:', err.message);
+  }
+}
+
+function get() {
+  return cache;
+}
+
+function set(value) {
+  cache = { ...defaults, ...value };
+}
+
+module.exports = { load, get, set, defaults };

--- a/backend/src/routes/site.js
+++ b/backend/src/routes/site.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const announcementConfig = require('../config/announcement');
+
+const router = express.Router();
+
+// GET /api/site/announcement — public, read-only. Every client checks this
+// for the SuperAdmin-managed banner (e.g. planned-maintenance notices), so
+// it must stay cheap: in-memory config, 60s edge/browser cache.
+router.get('/announcement', (req, res) => {
+  const a = announcementConfig.get();
+  res.setHeader('Cache-Control', 'public, max-age=60');
+  if (!a.enabled) return res.json({ enabled: false });
+  res.json(a);
+});
+
+module.exports = router;

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -17,6 +17,7 @@ const embeddingJob = require('../services/embeddingJob');
 const enrichmentJob = require('../services/enrichmentJob');
 const vectorStore = require('../services/vectorStore');
 const aiConfig = require('../config/aiConfig');
+const announcementConfig = require('../config/announcement');
 const aiChat = require('../services/aiChat');
 const { updateSiteConfig } = require('../utils/siteConfig');
 const { parsePagination } = require('../utils/pagination');
@@ -813,6 +814,49 @@ router.get('/chat-usage', async (req, res) => {
   } catch (error) {
     console.error('[superadmin] chat-usage error:', error);
     res.status(500).json({ error: 'Failed to load chat usage' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/superadmin/announcement
+// Current site-wide announcement banner config
+// ---------------------------------------------------------------------------
+router.get('/announcement', (req, res) => {
+  res.json({ config: announcementConfig.get() });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/superadmin/announcement
+// Set/clear the banner shown to all users (e.g. planned maintenance notice)
+// ---------------------------------------------------------------------------
+router.patch('/announcement', async (req, res) => {
+  const { enabled, message, messageSv, type } = req.body;
+  if (typeof enabled !== 'boolean') {
+    return res.status(400).json({ error: 'enabled must be a boolean' });
+  }
+  if (typeof message !== 'string' || (enabled && !message.trim())) {
+    return res.status(400).json({ error: 'message is required when the banner is enabled' });
+  }
+  if (message.length > 500 || (typeof messageSv === 'string' && messageSv.length > 500)) {
+    return res.status(400).json({ error: 'messages must be 500 characters or fewer' });
+  }
+  if (!['info', 'warning'].includes(type)) {
+    return res.status(400).json({ error: 'type must be info or warning' });
+  }
+  try {
+    const updated = {
+      enabled,
+      message: message.trim(),
+      messageSv: typeof messageSv === 'string' ? messageSv.trim() : '',
+      type,
+    };
+    const doc = await updateSiteConfig('announcement', updated, req.user.id);
+    // updatedAt doubles as the dismissal version on the client
+    announcementConfig.set({ ...updated, updatedAt: doc.updatedAt.toISOString() });
+    res.json({ config: announcementConfig.get() });
+  } catch (error) {
+    console.error('[superadmin] announcement error:', error);
+    res.status(500).json({ error: 'Failed to save announcement' });
   }
 });
 

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -149,6 +149,17 @@ export const adminImportWines = (apiFetch, body) =>
 export const adminGetSecuritySummary = (apiFetch) =>
   apiFetch('/api/admin/security/summary');
 
+// ── Announcement banner (SuperAdmin) ──────────────────────────────────────────
+export const superadminGetAnnouncement = (apiFetch) =>
+  apiFetch('/api/superadmin/announcement');
+
+export const superadminSaveAnnouncement = (apiFetch, data) =>
+  apiFetch('/api/superadmin/announcement', {
+    method: 'PATCH',
+    headers: J,
+    body: JSON.stringify(data),
+  });
+
 // ── Settings (rate limits — used by SuperAdmin) ───────────────────────────────
 export const adminGetRateLimits = (apiFetch) =>
   apiFetch('/api/admin/settings/rate-limits');

--- a/frontend/src/components/AnnouncementBanner.css
+++ b/frontend/src/components/AnnouncementBanner.css
@@ -1,0 +1,56 @@
+.announcement-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 1rem;
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.announcement-banner.info {
+  background: #e8f1fb;
+  color: #14457c;
+  border-bottom: 1px solid #b8d4f0;
+}
+
+.announcement-banner.warning {
+  background: #fdf3e0;
+  color: #7a4a07;
+  border-bottom: 1px solid #f0d8a8;
+}
+
+[data-theme='dark'] .announcement-banner.info {
+  background: #15293f;
+  color: #aecdf0;
+  border-bottom-color: #2a4a6e;
+}
+
+[data-theme='dark'] .announcement-banner.warning {
+  background: #3a2c10;
+  color: #f0d8a8;
+  border-bottom-color: #6e5520;
+}
+
+.announcement-icon {
+  flex-shrink: 0;
+}
+
+.announcement-text {
+  flex: 1;
+}
+
+.announcement-dismiss {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.1rem 0.35rem;
+  opacity: 0.7;
+}
+
+.announcement-dismiss:hover {
+  opacity: 1;
+}

--- a/frontend/src/components/AnnouncementBanner.js
+++ b/frontend/src/components/AnnouncementBanner.js
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import './AnnouncementBanner.css';
+
+const API_BASE = import.meta.env.VITE_API_URL || '';
+const DISMISS_KEY = 'announcementDismissed';
+const CACHE_TTL = 60 * 1000;
+
+// Module-level cache: Layout remounts on every route change, but the banner
+// endpoint only needs to be asked about once a minute.
+let cached = null;
+let cachedAt = 0;
+
+async function fetchAnnouncement() {
+  if (cached !== null && Date.now() - cachedAt < CACHE_TTL) return cached;
+  try {
+    const res = await fetch(`${API_BASE}/api/site/announcement`);
+    cached = res.ok ? await res.json() : { enabled: false };
+  } catch {
+    cached = { enabled: false };
+  }
+  cachedAt = Date.now();
+  return cached;
+}
+
+/**
+ * Site-wide banner managed from SuperAdmin → Announcement. Used to announce
+ * planned maintenance ahead of time. Dismissal is remembered per message
+ * version (updatedAt), so an edited announcement shows up again.
+ */
+function AnnouncementBanner() {
+  const { t, i18n } = useTranslation();
+  const [announcement, setAnnouncement] = useState(null);
+  const [dismissedVersion, setDismissedVersion] = useState(
+    () => localStorage.getItem(DISMISS_KEY)
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAnnouncement().then(a => { if (!cancelled) setAnnouncement(a); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!announcement?.enabled || !announcement.message) return null;
+  if (announcement.updatedAt && announcement.updatedAt === dismissedVersion) return null;
+
+  const isSwedish = (i18n.language || '').startsWith('sv');
+  const text = (isSwedish && announcement.messageSv) || announcement.message;
+
+  const dismiss = () => {
+    const version = announcement.updatedAt || 'unknown';
+    localStorage.setItem(DISMISS_KEY, version);
+    setDismissedVersion(version);
+  };
+
+  return (
+    <div className={`announcement-banner ${announcement.type === 'warning' ? 'warning' : 'info'}`} role="status">
+      <span className="announcement-icon" aria-hidden="true">
+        {announcement.type === 'warning' ? '⚠️' : 'ℹ️'}
+      </span>
+      <span className="announcement-text">{text}</span>
+      <button
+        className="announcement-dismiss"
+        onClick={dismiss}
+        aria-label={t('announcement.dismiss')}
+        title={t('announcement.dismiss')}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export default AnnouncementBanner;

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -7,6 +7,7 @@ import { PLANS } from '../config/plans';
 import NotificationBell from './NotificationBell';
 import SupportModal from './SupportModal';
 import InstallPrompt from './InstallPrompt';
+import AnnouncementBanner from './AnnouncementBanner';
 import './Layout.css';
 
 const LOGO_LIGHT_WEBP = '/cellarion-logo-light.webp';
@@ -305,6 +306,9 @@ function Layout({ children }) {
           </div>
         )}
       </nav>
+
+      {/* SuperAdmin-managed site announcement (e.g. planned maintenance) */}
+      <AnnouncementBanner />
 
       <main id="main-content" className="main-content" tabIndex={-1}>
         {children}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2121,6 +2121,9 @@
     "cellarSizeOther": "uncategorised",
     "bottleSize": "Bottle size"
   },
+  "announcement": {
+    "dismiss": "Dismiss"
+  },
   "wineLists": {
     "title": "Wine Lists",
     "newWineList": "New Wine List",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2121,6 +2121,9 @@
     "cellarSizeOther": "okategoriserad",
     "bottleSize": "Flaskstorlek"
   },
+  "announcement": {
+    "dismiss": "Stäng"
+  },
   "wineLists": {
     "title": "Vinlistor",
     "newWineList": "Ny vinlista",

--- a/frontend/src/pages/SuperAdmin/TabAnnouncement.js
+++ b/frontend/src/pages/SuperAdmin/TabAnnouncement.js
@@ -1,0 +1,121 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { superadminGetAnnouncement, superadminSaveAnnouncement } from '../../api/admin';
+
+const TEXTAREA_STYLE = {
+  width: '100%',
+  minHeight: 70,
+  background: 'var(--sa-bg)',
+  border: '1px solid var(--sa-border)',
+  color: 'var(--sa-text)',
+  padding: '6px 8px',
+  borderRadius: 3,
+  fontFamily: 'inherit',
+  fontSize: 12,
+  boxSizing: 'border-box',
+  resize: 'vertical',
+};
+
+export default function TabAnnouncement() {
+  const { apiFetch } = useAuth();
+  const [form, setForm] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    superadminGetAnnouncement(apiFetch)
+      .then(r => r.json())
+      .then(d => setForm({
+        enabled: d.config.enabled,
+        message: d.config.message || '',
+        messageSv: d.config.messageSv || '',
+        type: d.config.type || 'info',
+      }))
+      .catch(() => setError('Failed to load announcement'));
+  }, [apiFetch]);
+
+  const save = async () => {
+    setSaving(true); setMsg(null);
+    try {
+      const res = await superadminSaveAnnouncement(apiFetch, form);
+      const d = await res.json();
+      if (!res.ok) setMsg({ ok: false, text: d.error || 'Save failed' });
+      else setMsg({ ok: true, text: form.enabled ? 'Saved — banner is live for all users' : 'Saved — banner is hidden' });
+    } catch { setMsg({ ok: false, text: 'Network error' }); }
+    finally { setSaving(false); }
+  };
+
+  if (error) return <div className="sa-panel" style={{ marginTop: 16, padding: 12, color: 'var(--sa-danger)' }}>{error}</div>;
+  if (!form) return <div className="sa-loading">Loading announcement...</div>;
+
+  return (
+    <div className="sa-panel" style={{ marginTop: 16 }}>
+      <div className="sa-panel-header">
+        <span className="sa-panel-title">Site Announcement Banner</span>
+        <button className="sa-btn" onClick={save} disabled={saving}>{saving ? 'Saving...' : 'Save'}</button>
+      </div>
+      <div className="sa-panel-body">
+        <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 12 }}>
+          Shown at the top of the app for every user — use it to announce planned
+          maintenance in advance. Editing the text re-shows the banner to users
+          who dismissed the previous one. The public maintenance page takes over
+          automatically once the server actually goes down.
+        </div>
+        <div className="sa-kv">
+          <div className="sa-kv-row">
+            <span className="sa-kv-key">Enabled</span>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={form.enabled}
+                onChange={e => setForm(f => ({ ...f, enabled: e.target.checked }))}
+              />
+              <span style={{ fontSize: 11 }}>Show banner to all users</span>
+            </label>
+          </div>
+          <div className="sa-kv-row">
+            <span className="sa-kv-key">Style</span>
+            <select
+              value={form.type}
+              onChange={e => setForm(f => ({ ...f, type: e.target.value }))}
+              style={{ background: 'var(--sa-bg)', border: '1px solid var(--sa-border)', color: 'var(--sa-text)', padding: '2px 6px', borderRadius: 3, fontSize: 12 }}
+            >
+              <option value="info">Info (blue)</option>
+              <option value="warning">Warning (amber)</option>
+            </select>
+          </div>
+          <div className="sa-kv-row" style={{ flexDirection: 'column', alignItems: 'stretch', gap: 4 }}>
+            <span className="sa-kv-key">
+              Message (English)
+              <span style={{ marginLeft: 6, color: 'var(--sa-text-dim)', fontSize: 10 }}>{form.message.length} / 500</span>
+            </span>
+            <textarea
+              value={form.message}
+              maxLength={500}
+              onChange={e => setForm(f => ({ ...f, message: e.target.value }))}
+              placeholder="e.g. Planned maintenance tonight 22:00–22:15 CET — Cellarion will be briefly unavailable."
+              style={TEXTAREA_STYLE}
+            />
+          </div>
+          <div className="sa-kv-row" style={{ flexDirection: 'column', alignItems: 'stretch', gap: 4 }}>
+            <span className="sa-kv-key">
+              Message (Swedish, optional — falls back to English)
+              <span style={{ marginLeft: 6, color: 'var(--sa-text-dim)', fontSize: 10 }}>{form.messageSv.length} / 500</span>
+            </span>
+            <textarea
+              value={form.messageSv}
+              maxLength={500}
+              onChange={e => setForm(f => ({ ...f, messageSv: e.target.value }))}
+              placeholder="t.ex. Planerat underhåll ikväll 22:00–22:15 — Cellarion är otillgängligt en kort stund."
+              style={TEXTAREA_STYLE}
+            />
+          </div>
+        </div>
+        {msg && (
+          <div style={{ marginTop: 10, fontSize: 11, color: msg.ok ? 'var(--sa-accent)' : 'var(--sa-danger)' }}>{msg.text}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SuperAdmin/index.js
+++ b/frontend/src/pages/SuperAdmin/index.js
@@ -13,6 +13,7 @@ import TabAI from './TabAI';
 import TabCellars from './TabCellars';
 import TabImport from './TabImport';
 import TabBackups from './TabBackups';
+import TabAnnouncement from './TabAnnouncement';
 import '../SuperAdmin.css';
 
 const TABS = [
@@ -25,6 +26,7 @@ const TABS = [
   { id: 'cellars',    label: 'Deleted Cellars' },
   { id: 'import',     label: 'Import Wines' },
   { id: 'ai',         label: 'AI & Embeddings' },
+  { id: 'announcement', label: 'Announcement' },
   { id: 'settings',   label: 'Settings' },
 ];
 
@@ -156,6 +158,7 @@ export default function SuperAdmin() {
         {tab === 'cellars'    && <TabCellars />}
         {tab === 'import'     && <TabImport />}
         {tab === 'ai'         && <TabAI />}
+        {tab === 'announcement' && <TabAnnouncement />}
         {tab === 'settings'   && <TabSettings />}
       </div>
 


### PR DESCRIPTION
Companion to the Cloudflare maintenance page: the banner warns users **before** planned maintenance; the decanting page covers the downtime itself.

## What it does

- **SuperAdmin → Announcement** (new tab): enable/disable, info or warning style, English message (required) + optional Swedish, 500-char limits with live counters.
- Every user sees the banner at the top of the app (light + dark theme). Dismissal is remembered **per message version** — editing the text re-shows it to everyone.
- Public read endpoint `GET /api/site/announcement` (in-memory config, 60s cache, returns only `{enabled:false}` when off). Config follows the established `rateLimits` SiteConfig pattern: loaded on boot, hot-reloaded on save.

## Verified

- Backend 691 + frontend 306 tests pass, `vite build` clean.
- Docker smoke test: endpoint returns `{enabled:false}` by default; with a config written it returns the full payload incl. `updatedAt` version stamp and Swedish text; banner config survives restart (boot load).

**docker-compose.prod.yml impact: none** — no new env vars, volumes, services, or ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)