### PR TITLE
chore(release): v1.61.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for v1.61.0 — announcement banner (#516) + stricter community price validation (#517).

🤖 Generated with [Claude Code](https://claude.com/claude-code)