### PR TITLE
fix(maturity): relative AI drink-window prompt for non-vintage wines

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -127,6 +127,53 @@ Rules:
   - 0.4 = rough estimate
 - Never invent aging data`;
 
+// Non-vintage variant. NV wines have no vintage to anchor calendar years to —
+// their drink window is stored as whole-year OFFSETS after each bottle's
+// purchase year (see WineVintageProfile.relative). This prompt must therefore
+// ask for offsets ("years after purchase"), never calendar years, or the
+// suggestion is unusable for the maturity queue's NV form.
+const DEFAULT_MATURITY_SUGGEST_PROMPT_NV =
+`You are a master sommelier with deep knowledge of wine aging potential. The wine below is NON-VINTAGE (it has no vintage year), so express the drinking window as WHOLE YEARS AFTER THE OWNER ACQUIRES THE BOTTLE — not as calendar years. 0 means "drink on release / right after purchase", 3 means "three years after purchase".
+
+Wine: {{name}}
+Producer: {{producer}}
+Country: {{country}}
+Region: {{region}}
+Appellation: {{appellation}}
+Type: {{type}}
+Grapes: {{grapes}}
+QualityTier: {{qualityTier}}
+# (one of: unclassified, entry-level, mid-tier, prestige)
+
+Consider:
+- The wine style and type — most non-vintage wines (NV Champagne, NV sparkling, everyday blends) are made for early, consistent drinking and are released ready to drink.
+- The grape varieties and their realistic aging potential in this style.
+- The quality tier and any single-vineyard or prestige signal in the name — a prestige NV cuvée may hold and improve for a few extra years; an entry-level NV wine should be drunk young.
+- Regional norms, but do NOT assume prestige based on region alone.
+
+Critical rules:
+- This is a NON-VINTAGE wine. Do NOT output calendar years. Every value is a whole number of years after purchase (0–100).
+- Most non-vintage wines are best within 0–3 years of purchase. Bias strongly toward early drinking.
+- Only extend the window beyond ~5 years after purchase if the style genuinely supports it (e.g. prestige NV Champagne, tawny or other NV fortified, serious vin-de-garde blends) AND sommNotes justifies why.
+- You can almost always estimate a sensible window for a non-vintage wine from its type and style. Return {"error":"unknown"} ONLY if you cannot tell what kind of wine this is at all.
+
+Return ONLY a raw JSON object (no markdown, no code fences, no extra text):
+{"earlyFrom":N,"earlyUntil":N,"peakFrom":N,"peakUntil":N,"lateFrom":N,"lateUntil":N,"sommNotes":"brief explanation of your reasoning","confidence":0.0}
+
+Rules:
+- All values are WHOLE YEARS AFTER PURCHASE (e.g. 0, 2, 5 — never a calendar year like 2026)
+- earlyFrom is the first year after purchase the wine is enjoyable — usually 0 for non-vintage wines
+- Phases must not overlap: earlyUntil < peakFrom, peakUntil < lateFrom
+- For wines meant to drink young, use short windows and set the late phase to null
+- If a phase does not apply, set both its from and until to null
+- sommNotes: 1–2 sentences, factual and conservative
+- confidence:
+  - 1.0 = well-known non-vintage wine with an established house style
+  - 0.7 = known producer / known style
+  - 0.5 = type/grape knowledge only
+  - 0.4 = rough estimate
+- Never invent aging data`;
+
 const DEFAULT_PRICE_SUGGEST_PROMPT =
 `You are a wine market expert specialising in the European wine market. Given the wine details below, estimate its current market value.
 
@@ -241,6 +288,7 @@ const defaults = {
   importLookupPrompt: DEFAULT_IMPORT_LOOKUP_PROMPT,
   importLookupModel: 'claude-haiku-4-5-20251001',
   maturitySuggestPrompt: DEFAULT_MATURITY_SUGGEST_PROMPT,
+  maturitySuggestPromptNv: DEFAULT_MATURITY_SUGGEST_PROMPT_NV,
   maturitySuggestModel: 'claude-haiku-4-5-20251001',
   priceSuggestPrompt: DEFAULT_PRICE_SUGGEST_PROMPT,
   priceSuggestModel: 'claude-haiku-4-5-20251001',
@@ -275,6 +323,7 @@ async function load() {
         importLookupPrompt:    doc.value.importLookupPrompt   ?? defaults.importLookupPrompt,
         importLookupModel:     VALID_CHAT_MODELS.includes(doc.value.importLookupModel) ? doc.value.importLookupModel : defaults.importLookupModel,
         maturitySuggestPrompt: doc.value.maturitySuggestPrompt ?? defaults.maturitySuggestPrompt,
+        maturitySuggestPromptNv: doc.value.maturitySuggestPromptNv ?? defaults.maturitySuggestPromptNv,
         maturitySuggestModel:  VALID_CHAT_MODELS.includes(doc.value.maturitySuggestModel) ? doc.value.maturitySuggestModel : defaults.maturitySuggestModel,
         priceSuggestPrompt:    doc.value.priceSuggestPrompt   ?? defaults.priceSuggestPrompt,
         priceSuggestModel:     VALID_CHAT_MODELS.includes(doc.value.priceSuggestModel) ? doc.value.priceSuggestModel : defaults.priceSuggestModel,
@@ -313,4 +362,4 @@ function set(value) {
   cache = { ...defaults, ...value };
 }
 
-module.exports = { load, get, set, defaults, DEFAULT_SYSTEM_PROMPT, DEFAULT_LABEL_SCAN_PROMPT, DEFAULT_IMPORT_LOOKUP_PROMPT, DEFAULT_TEXT_SEARCH_PROMPT, DEFAULT_MATURITY_SUGGEST_PROMPT, DEFAULT_PRICE_SUGGEST_PROMPT, DEFAULT_ENRICHMENT_PROMPT, VALID_CHAT_MODELS };
+module.exports = { load, get, set, defaults, DEFAULT_SYSTEM_PROMPT, DEFAULT_LABEL_SCAN_PROMPT, DEFAULT_IMPORT_LOOKUP_PROMPT, DEFAULT_TEXT_SEARCH_PROMPT, DEFAULT_MATURITY_SUGGEST_PROMPT, DEFAULT_MATURITY_SUGGEST_PROMPT_NV, DEFAULT_PRICE_SUGGEST_PROMPT, DEFAULT_ENRICHMENT_PROMPT, VALID_CHAT_MODELS };

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -608,6 +608,31 @@ router.patch('/ai/maturity-suggest-prompt', async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// PATCH /api/superadmin/ai/maturity-suggest-prompt-nv
+// Non-vintage variant of the maturity suggest prompt (asks for year-offsets
+// after purchase instead of calendar years).
+// ---------------------------------------------------------------------------
+router.patch('/ai/maturity-suggest-prompt-nv', async (req, res) => {
+  const { prompt } = req.body;
+  if (typeof prompt !== 'string' || !prompt.trim()) {
+    return res.status(400).json({ error: 'prompt must be a non-empty string' });
+  }
+  if (prompt.length > SCAN_PROMPT_MAX_LENGTH) {
+    return res.status(400).json({ error: `prompt must be ${SCAN_PROMPT_MAX_LENGTH} characters or fewer` });
+  }
+  try {
+    const current = aiConfig.get();
+    const updated = { ...current, maturitySuggestPromptNv: prompt.trim() };
+    await updateSiteConfig('aiConfig', updated, req.user.id);
+    aiConfig.set(updated);
+    res.json({ maturitySuggestPromptNv: updated.maturitySuggestPromptNv });
+  } catch (error) {
+    console.error('[superadmin] maturity-suggest-prompt-nv error:', error);
+    res.status(500).json({ error: 'Failed to save NV maturity suggest prompt' });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // PATCH /api/superadmin/ai/maturity-suggest-model
 // ---------------------------------------------------------------------------
 router.patch('/ai/maturity-suggest-model', async (req, res) => {

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -289,7 +289,15 @@ async function suggestDrinkWindow({ name, producer, vintage, country, region, ap
 
   const qualityTier = classifyQualityTier({ name, appellation });
 
-  const prompt = aiConfig.get().maturitySuggestPrompt
+  // NV wines have no vintage to anchor calendar years to — their window is
+  // stored as offsets after each bottle's purchase year. Use the offset-based
+  // prompt so the suggestion matches the NV form (years after purchase), not
+  // absolute calendar years. The {{vintage}} token is absent from the NV
+  // template, so leaving it in the replace chain is a harmless no-op.
+  const isNv = vintage === 'NV';
+  const template = isNv ? aiConfig.get().maturitySuggestPromptNv : aiConfig.get().maturitySuggestPrompt;
+
+  const prompt = template
     .replace('{{name}}', name || '')
     .replace('{{producer}}', producer || '')
     .replace('{{vintage}}', vintage || '')

--- a/frontend/src/pages/SommMaturity.js
+++ b/frontend/src/pages/SommMaturity.js
@@ -161,7 +161,11 @@ function ProfileCard({ profile, isPending, onSaved, onReset }) {
     try {
       const body = { sommNotes: form.sommNotes };
       ['earlyFrom', 'earlyUntil', 'peakFrom', 'peakUntil', 'lateFrom', 'lateUntil'].forEach(f => {
-        body[f] = form[f] ? parseInt(form[f]) : null;
+        // Treat 0 as a real value — for NV wines an offset of 0 means "drink
+        // from purchase", which is common. A plain `form[f] ? … : null` would
+        // drop a numeric 0 (e.g. from an AI suggestion) to null.
+        const v = form[f];
+        body[f] = (v === '' || v === null || v === undefined) ? null : parseInt(v);
       });
 
       const res = await apiFetch(`/api/somm/maturity/${profile._id}`, {

--- a/frontend/src/pages/SuperAdmin/TabAI.js
+++ b/frontend/src/pages/SuperAdmin/TabAI.js
@@ -636,6 +636,60 @@ function MaturitySuggestPromptPanel({ prompt, apiFetch }) {
   );
 }
 
+function MaturitySuggestPromptNvPanel({ prompt, apiFetch }) {
+  const [val, setVal] = useState(prompt || '');
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState(null);
+
+  const save = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      const res = await apiFetch('/api/superadmin/ai/maturity-suggest-prompt-nv', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: val }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setMsg({ ok: false, text: d.error || 'Save failed' });
+      } else {
+        setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+      }
+    } catch {
+      setMsg({ ok: false, text: 'Network error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="sa-panel" style={{ marginTop: 16 }}>
+      <div className="sa-panel-header">
+        <span className="sa-panel-title">Maturity Suggest (Non-Vintage) — AI Prompt</span>
+        <button className="sa-btn" onClick={save} disabled={saving || !val.trim()}>{saving ? 'Saving...' : 'Save'}</button>
+      </div>
+      <div className="sa-panel-body">
+        <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 8 }}>
+          Used instead of the prompt above when the wine is <strong>non-vintage (NV)</strong>. It must ask for the window as <strong>whole years after purchase</strong> (offsets like 0, 2, 5), not calendar years — that's how NV drink windows are stored. Use <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{name}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{producer}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{country}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{region}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{appellation}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{type}}'}</code>, <code style={{ background: 'var(--sa-bg)', padding: '1px 4px', borderRadius: 2 }}>{'{{grapes}}'}</code> placeholders ({'{{vintage}}'} is not used for NV).
+        </div>
+        <textarea
+          value={val}
+          onChange={e => setVal(e.target.value)}
+          rows={14}
+          style={{ width: '100%', background: 'var(--sa-bg)', border: '1px solid var(--sa-border)', color: 'var(--sa-text)', padding: '8px', borderRadius: 3, fontFamily: 'monospace', fontSize: 12, lineHeight: 1.5, resize: 'vertical', boxSizing: 'border-box' }}
+        />
+        <div style={{ marginTop: 6, display: 'flex', gap: 8, alignItems: 'center' }}>
+          <span style={{ fontSize: 11, color: 'var(--sa-text-dim)' }}>{val.length} / 6000 chars</span>
+          {msg && (
+            <span style={{ fontSize: 11, color: msg.ok ? 'var(--sa-accent)' : 'var(--sa-danger)' }}>{msg.text}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function PriceSuggestModelPanel({ currentModel, apiFetch }) {
   const [selected, setSelected] = useState(currentModel || 'claude-haiku-4-5-20251001');
   const [saving, setSaving]     = useState(false);
@@ -1576,6 +1630,7 @@ export default function TabAI() {
       <ImportLookupPromptPanel prompt={config.importLookupPrompt || ''} apiFetch={apiFetch} />
       <MaturitySuggestModelPanel currentModel={config.maturitySuggestModel || 'claude-haiku-4-5-20251001'} apiFetch={apiFetch} />
       <MaturitySuggestPromptPanel prompt={config.maturitySuggestPrompt || ''} apiFetch={apiFetch} />
+      <MaturitySuggestPromptNvPanel prompt={config.maturitySuggestPromptNv || ''} apiFetch={apiFetch} />
       <PriceSuggestModelPanel currentModel={config.priceSuggestModel || 'claude-haiku-4-5-20251001'} apiFetch={apiFetch} />
       <PriceSuggestPromptPanel prompt={config.priceSuggestPrompt || ''} apiFetch={apiFetch} />
       <EnrichmentModelPanel currentModel={config.enrichmentModel || 'claude-sonnet-4-6'} apiFetch={apiFetch} />


### PR DESCRIPTION
## Problem

On the **Maturity queue**, clicking **Suggest** for a non-vintage (NV) wine often returned *"AI could not suggest a drink window for this wine"*, and when it did return data it gave calendar years like `2026` instead of an offset like `2`.

NV drink windows are stored as **whole-year offsets after each bottle's purchase year** (`WineVintageProfile.relative`, resolved per-bottle in `resolveWindow`). But the AI Suggest path passed `vintage: 'NV'` straight into the vintage prompt, which is built entirely around absolute calendar years anchored to a vintage:

- With no vintage to anchor to, the model obeyed the prompt's *"return `{"error":"unknown"}` if you can't estimate"* rule → the 422 the somm sees.
- When it did answer, it returned calendar years (the prompt demands *"All values are calendar years (e.g. 2028, not '5 years')"*), which don't fit the NV "years after purchase" form and fail the `0–100` save validation.

The NV/relative model was wired through the save route, the form, and the per-bottle resolver — but the AI suggest path was never given an NV branch.

## Fix

- **New NV prompt** (`maturitySuggestPromptNv` in `aiConfig`) that asks for whole-year **offsets after purchase** (0 = drink from purchase), never calendar years, and only bails to `unknown` if it can't tell what kind of wine it is.
- **Branch `suggestDrinkWindow()`** on `vintage === 'NV'` to select that prompt.
- **Expose the NV prompt** in the SuperAdmin → AI tab (editable like every other prompt).
- **Frontend save bug:** a numeric `0` offset (common for NV — "drink from purchase") was dropped to `null` by a `form[f] ? … : null` truthiness check. Now treats `0` as a real value.

The new config key falls back to its default via `??`, so existing stored `aiConfig` documents pick it up with **no migration**.

## docker-compose / prod impact

Code + default-config change only — no schema change, no migration. A normal image rebuild deploys it. Because prod uses Claude **Sonnet 4.6** for `maturitySuggestModel` and stores `aiConfig` in `SiteConfig`, the new `maturitySuggestPromptNv` key isn't present in the stored doc and resolves to the new default automatically; the existing (vintage) prompt is untouched.

## Testing

- Backend Jest: **692 passed**
- Frontend Vitest: **306 passed**
- Frontend production build: clean
- Vintage-wine suggestions are unchanged (same prompt, same path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)