### PR TITLE
chore(release): v1.63.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.62.0",
+  "version": "1.63.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.62.0",
+  "version": "1.63.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release **v1.63.0**.

Bumps `backend` and `frontend` `package.json` to 1.63.0.

### Included
- #523 — fix(maturity): relative AI drink-window prompt for non-vintage wines

NV wines now get an offset-based ("years after purchase") AI suggestion instead of vintage-anchored calendar years, fixing the *"AI could not suggest a drink window"* errors and the `2026`-instead-of-`2` results on the maturity queue.

Publishing the GitHub Release `v1.63.0` after merge triggers the production Docker build.