### PR TITLE
chore(release): v1.63.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release **v1.63.1** (patch — security fixes only).

Bumps `backend` and `frontend` `package.json` to 1.63.1.

### Included
- #525 — fix(security): clear CodeQL high alerts (format-string + NoSQL hardening; 6 path-injection false positives dismissed) and patch the `esbuild` dev-dependency CVEs via an `^0.28.1` override.

Publishing the GitHub Release `v1.63.1` after merge triggers the production Docker build.