### PR TITLE
chore(release): v1.64.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.63.1",
+  "version": "1.64.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.63.1",
+  "version": "1.64.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release v1.64.0 — security audit remediation (#527).

Highlights: Stripe double-billing guard, wine-field DoS caps, GDPR erasure (image files + Stripe customer), FX/server timeouts, and a batch of hardening (MEILI key check, IPv6 /64 rate-limit keying, JSON-LD escaping, Umami opt-in profile, image decompression-bomb guard).

Bumps backend + frontend package.json to 1.64.0.