### PR TITLE
fix(security): hardening batch 2 — non-root rembg, GDPR PII scrub, limiter + input caps

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -127,6 +127,12 @@ if (indexNowKey) {
   });
 }
 
+// The Stripe webhook authenticates via signature + idempotency and is delivered
+// from Stripe's small IP pool, so per-IP limiting only risks 429-ing legitimate
+// billing bursts (or a dashboard "resend all"). Exempt it — same spirit as the
+// sitemap/OG/public-wine-list routes that are mounted before the limiters.
+const isStripeWebhook = (req) => req.originalUrl.split('?')[0] === '/api/stripe/webhook';
+
 // Global API rate limiter — default 200 requests per 15 min per IP (admin-configurable)
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -134,6 +140,7 @@ const apiLimiter = rateLimit({
   keyGenerator: (req) => rateLimitKey(req),
   standardHeaders: true,
   legacyHeaders: false,
+  skip: isStripeWebhook,
   handler: (req, res) => {
     logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'api', limit: rateLimitsConfig.get().api.max });
     res.status(429).json({ error: 'Too many requests, please try again later' });
@@ -148,7 +155,7 @@ const writeLimiter = rateLimit({
   keyGenerator: (req) => rateLimitKey(req),
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req) => req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS',
+  skip: (req) => isStripeWebhook(req) || req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS',
   handler: (req, res) => {
     logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'write', limit: rateLimitsConfig.get().write.max });
     res.status(429).json({ error: 'Too many write requests, please try again later' });

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -265,21 +265,25 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
         ? { $or: [{ normalizedKey }, { 'lwin.lwin7': mapped.lwin7 }] }
         : { normalizedKey };
 
+      // Wrap user-derived CSV values in $literal: in an aggregation update
+      // pipeline a string beginning with '$' is otherwise evaluated as a field
+      // path / system variable (the code itself relies on $$NOW), so a crafted
+      // cell like "$createdBy" could copy another field's value into name/etc.
       const setFields = {
-        name: { $ifNull: ['$name', mapped.name] },
-        producer: { $ifNull: ['$producer', mapped.producer] },
+        name: { $ifNull: ['$name', { $literal: mapped.name }] },
+        producer: { $ifNull: ['$producer', { $literal: mapped.producer }] },
         country: { $ifNull: ['$country', countryId] },
-        type: { $ifNull: ['$type', mapped.type] },
-        normalizedKey: { $ifNull: ['$normalizedKey', normalizedKey] },
+        type: { $ifNull: ['$type', { $literal: mapped.type }] },
+        normalizedKey: { $ifNull: ['$normalizedKey', { $literal: normalizedKey }] },
         createdBy: { $ifNull: ['$createdBy', userId] },
         createdAt: { $ifNull: ['$createdAt', '$$NOW'] },
         updatedAt: '$$NOW',
       };
 
       if (regionId) setFields.region = { $ifNull: ['$region', regionId] };
-      if (mapped.appellation) setFields.appellation = { $ifNull: ['$appellation', mapped.appellation] };
-      if (mapped.classification) setFields.classification = { $ifNull: ['$classification', mapped.classification] };
-      if (mapped.lwin7) setFields['lwin.lwin7'] = { $ifNull: ['$lwin.lwin7', mapped.lwin7] };
+      if (mapped.appellation) setFields.appellation = { $ifNull: ['$appellation', { $literal: mapped.appellation }] };
+      if (mapped.classification) setFields.classification = { $ifNull: ['$classification', { $literal: mapped.classification }] };
+      if (mapped.lwin7) setFields['lwin.lwin7'] = { $ifNull: ['$lwin.lwin7', { $literal: mapped.lwin7 }] };
 
       return {
         updateOne: {

--- a/backend/src/routes/wineRequests.js
+++ b/backend/src/routes/wineRequests.js
@@ -65,11 +65,22 @@ router.post('/', async (req, res) => {
     const urlErr = validateUrl(sourceUrl);
     if (urlErr) return res.status(400).json({ error: urlErr });
 
+    // Bound the free-text/image fields so a single request can't persist a
+    // multi-MB string (the route's body limit is 5mb) and bloat the admin queue.
+    const trimmedName = wineName.trim();
+    const trimmedImage = image ? String(image).trim() : '';
+    if (trimmedName.length > 300) {
+      return res.status(400).json({ error: 'Wine name must be 300 characters or fewer' });
+    }
+    if (trimmedImage.length > 500000) {
+      return res.status(400).json({ error: 'Image reference is too large' });
+    }
+
     const wineRequest = new WineRequest({
       requestType: 'new_wine',
-      wineName: wineName.trim(),
+      wineName: trimmedName,
       sourceUrl: sourceUrl.trim(),
-      image: image?.trim() || null,
+      image: trimmedImage || null,
       user: req.user.id,
       status: 'pending'
     });

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -308,7 +308,9 @@ const REGISTRY = [
     // party keeps the recommendation: a recipient keeps a from-[deleted] rec,
     // and a sender keeps a to-[deleted] entry in their sent list.
     purge: (ctx) => [
-      Recommendation.updateMany({ sender: ctx.userId }, { $set: { sender: ctx.deletedUserId } }),
+      // Scrub the external recipient's email (third-party PII the departing user
+      // supplied) while anonymising the sender side.
+      Recommendation.updateMany({ sender: ctx.userId }, { $set: { sender: ctx.deletedUserId }, $unset: { recipientEmail: '' } }),
       Recommendation.updateMany({ recipient: ctx.userId }, { $set: { recipient: ctx.deletedUserId } }),
     ],
     exportFragment: async (ctx) => {
@@ -544,7 +546,13 @@ const REGISTRY = [
   // ── Audit log: keep for compliance, anonymise the actor ─────────────────
   {
     model: AuditLog, category: 'personal-data', userFields: ['actor.userId'],
-    purge: (ctx) => AuditLog.updateMany({ 'actor.userId': ctx.userId }, { $set: { 'actor.userId': null, 'actor.ipAddress': null } }),
+    // Also scrub identifier PII the free-form detail can carry — registration/
+    // login events embed { username, email }. $unset only touches docs that
+    // actually have those keys, so it's safe across the heterogeneous detail shapes.
+    purge: (ctx) => AuditLog.updateMany(
+      { 'actor.userId': ctx.userId },
+      { $set: { 'actor.userId': null, 'actor.ipAddress': null }, $unset: { 'detail.email': '', 'detail.username': '' } }
+    ),
     exportFragment: async (ctx) => ({
       activityLog: markTrunc(ctx, 'activityLog', await AuditLog.find({ 'actor.userId': ctx.userId }).sort({ timestamp: -1 }).limit(AUDIT_MAX).lean(), AUDIT_MAX)
         .map(a => ({ action: a.action, timestamp: a.timestamp, detail: a.detail })),

--- a/rembg/Dockerfile
+++ b/rembg/Dockerfile
@@ -7,13 +7,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1 libglib2.0-0 curl \
     && rm -rf /var/lib/apt/lists/*
 
+# Run as a non-root user. rembg decodes untrusted user images (Pillow), so a
+# decoder RCE must not land as root in-container. gunicorn binds :5000 (a
+# non-privileged port), so no extra capability is needed.
+RUN useradd --create-home --uid 10001 appuser
+ENV U2NET_HOME=/home/appuser/.u2net
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Pre-download the u2net model so container startup is fast
-RUN python -c "from rembg import new_session; new_session('u2net')"
+# Pre-download the u2net model so container startup is fast. Land it in the
+# non-root user's model dir (U2NET_HOME) so it is readable at runtime.
+RUN mkdir -p $U2NET_HOME && python -c "from rembg import new_session; new_session('u2net')"
 
 COPY app.py .
+
+# Hand /app and the model cache to the runtime user, then drop privileges.
+RUN chown -R appuser:appuser /app $U2NET_HOME
+USER appuser
 
 EXPOSE 5000
 


### PR DESCRIPTION
## Summary
Follow-up to the 2026-06-13 audit. Scope (your selection): **container non-root (P-2)** + **GDPR retention / small Lows**. Skips the admin data-integrity cascade and behaviour-changing items.

✅ backend **692/692** · ✅ non-root rembg **built + run-verified** (`uid=10001`, `/health` 200) · ✅ syntax-checked.

## Changes
- **P-2 — rembg non-root** (`rembg/Dockerfile`): runs as `appuser` (uid 10001); the u2net model is pre-baked into `U2NET_HOME` so startup stays fast. rembg decodes untrusted user images (Pillow), so a decoder RCE no longer lands as root in-container.
- **GDPR PII scrub** (`userDataRegistry.js`): on erasure, `$unset` the identifier keys the AuditLog `detail` can carry (`username`/`email` from register/login events), and clear the external `Recommendation.recipientEmail` when anonymising the sender side.
- **L-8** (`app.js`): exempt `/api/stripe/webhook` from the per-IP api/write limiters (it's signature- + idempotency-authenticated and arrives from Stripe's IP pool — limiting only risks 429-ing legitimate billing bursts).
- **L-15** (`wineRequests.js`): cap `wineName` (300) and `image` (500k) **at the route** so one request can't persist a multi-MB string. Route-level on purpose — a schema `maxlength` would re-introduce the legacy-row re-save regression we caught in #527.
- **L-13** (`admin/import.js`): wrap user-derived CSV cell values in `$literal` in the aggregation update pipeline so a cell starting with `$` can't be evaluated as a field path.

## Deferred (with reasons)
- **Frontend non-root:** nginx already runs its *workers* as non-root; making the master non-root requires switching to port 8080 + updating `nginx.conf`, the base compose, the dev override's `80:80` mapping, **and** the out-of-repo `docker-compose.prod.yml` Traefik label — a prod-routing change with full-outage risk, for little marginal gain. Not worth bundling.
- **Somm-queue pagination (L-9):** adding a limit would silently truncate the somm review queue without a frontend paging change.
- Base-image digest pinning, audit-log `detail` deep-scrub beyond known keys, wine merge/delete cascade, `stripHtml`/consume-idempotency — left per scope.

No prod-compose impact. The rembg change ships with the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
