### PR TITLE
chore(release): v1.64.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.64.0",
+  "version": "1.64.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.64.0",
+  "version": "1.64.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release v1.64.1 — security hardening batch 2 (#529).

Non-root rembg container; GDPR PII scrub on erasure (audit-log detail + recommendation recipient email); Stripe webhook exempt from per-IP limiters; WineRequest route caps; CSV import $literal hardening.

Bumps backend + frontend package.json to 1.64.1.