### PR TITLE
fix(3d): correct rack-type rendering & layout-fetch data loss in Room View

### DIFF
--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -4,8 +4,9 @@ import { useThree, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import {
   BOTTLE_RADIUS, CELL_W, CELL_H, RACK_DEPTH, WOOD_THICK, PANEL_THICK,
-  getDisplayDims,
+  getDisplayDims, buildScaledLayout,
 } from '../../utils/roomConstants';
+import { getTotalSlots, getModularTotalSlots } from '../../utils/rackLayouts';
 
 // ── Bright, visible wine colors by type ──────────────────
 const GLASS_COLORS = {
@@ -319,58 +320,72 @@ function computeTriangleSlotPositions(cols, width, height) {
 // Standard two-deep storage: both rows at the same shelf height, both with
 // necks toward the viewer; the back row is positioned deeper in the rack and
 // staggered in x so its necks peek between the front bottles.
-function computeShelfSlotPositions(rows, cols, backCols, width, height) {
+//
+// `depth` is the rack's actual frame depth (honours depthOverride) so the
+// bottle bases and empty-ring openings track the cabinet instead of being
+// pinned to the default depth. `bpc` (bottlesPerCell) renders multiple
+// bottles per cubby, stacked slightly in z, matching the backend's
+// 1..cells*bpc slot numbering (rackLayouts.shelfLayout).
+function computeShelfSlotPositions(rows, cols, backCols, width, height, bpc = 1, depth = RACK_DEPTH) {
   const positions = [];
   const cW = width / cols;
   const cH = height / rows;
   const hasBack = backCols > 0;
+  const halfDepth = depth / 2;
   // For a shelf with a back row, bottles lie neck-to-neck at the shelf
   // centerline:
   //   - Front row: BASE near the cabinet front (+Z), NECK pointing -Z toward
   //     the centerline. Rotation flipped via flipNeck=true.
   //   - Back row:  BASE near the cabinet back (-Z), NECK pointing +Z toward
   //     the centerline. Default rotation.
-  // A bottle's local +Y axis has length 0.285 (LatheGeometry). To get its
-  // neck end ~0.025 from the centerline (small gap between rows), the base
-  // sits at ±0.26 give or take.
-  const frontBottleZ = hasBack ? 0.26 : -0.08;
-  const backBottleZ  = -0.26;
-  // Empty-slot ring positions: place them at the cubby openings so users
-  // see where to drop a bottle. For neck-to-neck shelves the openings are
-  // at the FRONT face for front-row slots and the BACK face for back-row.
-  // These are absolute z within the rack, used with EmptySlot's
-  // `useAbsoluteZ` so they sit exactly at the cubby openings instead of
-  // being offset further by RACK_DEPTH/2.
-  const rackHalfDepth = hasBack ? (RACK_DEPTH * 1.7) / 2 : RACK_DEPTH / 2;
-  const frontEmptyZ = rackHalfDepth - 0.005;
-  const backEmptyZ  = -rackHalfDepth + 0.005;
+  // A bottle's local +Y axis has length 0.285 (LatheGeometry); its base sits
+  // ~0.029 in from the cabinet face so the neck stops short of the centerline.
+  const frontBottleZ = hasBack ? (halfDepth - 0.029) : -0.08;
+  const backBottleZ  = -(halfDepth - 0.029);
+  // Empty-slot ring positions sit at the cubby openings (front face for the
+  // front row, back face for the back row) so users see where to drop a
+  // bottle. These are absolute z within the rack, used with EmptySlot's
+  // `useAbsoluteZ`.
+  const frontEmptyZ = halfDepth - 0.005;
+  const backEmptyZ  = -halfDepth + 0.005;
+  // Per-bottle z step when a cubby holds more than one bottle (front-to-back).
+  const Z_STEP = 0.03;
+  // Keep the staggered back row inside the side panels (fixes overflow when
+  // backCols approaches cols).
+  const xLimit = width / 2 - BOTTLE_RADIUS;
   let pos = 1;
   for (let r = 0; r < rows; r++) {
     const y = height / 2 - cH / 2 - r * cH;
     for (let c = 0; c < cols; c++) {
-      positions.push({
-        position: pos++,
-        x: -width / 2 + cW / 2 + c * cW,
-        y,
-        z: frontEmptyZ,
-        bottleZ: frontBottleZ,
-        isBack: false,
-        flipNeck: hasBack, // front-row bottles face into the shelf
-        row: r,
-      });
+      const x = -width / 2 + cW / 2 + c * cW;
+      for (let b = 0; b < bpc; b++) {
+        positions.push({
+          position: pos++,
+          x,
+          y,
+          z: frontEmptyZ - b * Z_STEP,
+          bottleZ: frontBottleZ - b * Z_STEP,
+          isBack: false,
+          flipNeck: hasBack, // front-row bottles face into the shelf
+          row: r,
+        });
+      }
     }
     if (hasBack) {
       for (let c = 0; c < backCols; c++) {
-        positions.push({
-          position: pos++,
-          x: -width / 2 + cW / 2 + (c + 0.5) * cW,
-          y,
-          z: backEmptyZ,
-          bottleZ: backBottleZ,
-          isBack: true,
-          flipNeck: false,
-          row: r,
-        });
+        const x = Math.max(-xLimit, Math.min(xLimit, -width / 2 + cW / 2 + (c + 0.5) * cW));
+        for (let b = 0; b < bpc; b++) {
+          positions.push({
+            position: pos++,
+            x,
+            y,
+            z: backEmptyZ + b * Z_STEP,
+            bottleZ: backBottleZ + b * Z_STEP,
+            isBack: true,
+            flipNeck: false,
+            row: r,
+          });
+        }
       }
     }
   }
@@ -573,17 +588,30 @@ export default function RackMesh({
   // Compute display grid dimensions per type
   const { displayRows, displayCols } = getDisplayDims(rack);
 
+  // Cube and modular racks have irregular internal layouts. Reuse the 2D
+  // layout engine (rackLayouts.js — source of truth for slot numbering) and
+  // scale its coordinates into 3D metres so bottles land in the right cells
+  // and the frame is sized to the true footprint.
+  const useScaled = rack.isModular || rackType === 'cube';
+  const scaledLayout = useMemo(
+    () => (useScaled ? buildScaledLayout(rack) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [useScaled, rack.isModular, rack.modules, rack.type, rack.rows, rack.cols, rack.typeConfig]
+  );
+
   // Default computed size; overrides allow matching real-world dimensions
   // scaleOverride applies uniform scaling via a Three.js group transform
   const rackScale = scaleOverride || 1;
-  const defaultWidth = displayCols * CELL_W + PANEL_THICK * 2;
+  const baseInnerW = scaledLayout ? scaledLayout.innerW : displayCols * CELL_W;
+  const baseInnerH = scaledLayout ? scaledLayout.innerH : displayRows * CELL_H;
+  const defaultWidth = baseInnerW + PANEL_THICK * 2;
   const width = widthOverride || defaultWidth;
   const hasShelfBack = rackType === 'shelf' && (rack.typeConfig?.backCols || 0) > 0;
   const depth = depthOverride || (hasShelfBack ? RACK_DEPTH * 1.7 : RACK_DEPTH);
-  const height = displayRows * CELL_H + PANEL_THICK * 2;
   const innerW = (width - PANEL_THICK * 2);
+  const innerH = baseInnerH;
+  const height = innerH + PANEL_THICK * 2;
   const effectiveCellW = innerW / displayCols;
-  const innerH = displayRows * CELL_H;
   const rotRad = (rotation * Math.PI) / 180;
 
   const woodTex = useMemo(() => getWoodTexture(), []);
@@ -594,39 +622,28 @@ export default function RackMesh({
     return m;
   }, [rack.slots]);
 
-  // Accurate total slot count per type (including bottlesPerCell multiplier)
+  // Accurate total slot count per type — reuses the same helpers the 2D rack
+  // view uses, so the label always matches the backend's real capacity
+  // (handles per-module types, cube, and shelf bottlesPerCell correctly).
   const totalSlots = useMemo(() => {
-    const bpc = rack.typeConfig?.bottlesPerCell || 1;
-    if (rack.isModular) {
-      return (rack.modules || []).reduce((sum, m) => sum + (m.rows || 1) * (m.cols || 1), 0);
-    }
-    switch (rackType) {
-      case 'x-rack': { return 4 * (rack.typeConfig?.bottlesPerSection || 10); }
-      case 'hex': {
-        let t = 0;
-        for (let r = 0; r < (rack.rows || 4); r++) t += (r % 2 === 0) ? (rack.cols || 4) : Math.max(1, (rack.cols || 4) - 1);
-        return t;
-      }
-      case 'triangle': { const b = Math.max(1, rack.cols || 1); return (b * (b + 1)) / 2; }
-      case 'stack': return rack.rows || 4;
-      case 'shelf': {
-        const backCols = rack.typeConfig?.backCols || 0;
-        return displayRows * (displayCols + backCols) * bpc;
-      }
-      default: return displayRows * displayCols;
-    }
-  }, [rack.isModular, rack.modules, rack.typeConfig, rackType, rack.rows, rack.cols, displayRows, displayCols]);
+    if (rack.isModular) return getModularTotalSlots(rack.modules || []);
+    return getTotalSlots(rackType, rack.rows || 4, rack.cols || 4, rack.typeConfig);
+  }, [rack.isModular, rack.modules, rackType, rack.rows, rack.cols, rack.typeConfig]);
 
   const slotPositions = useMemo(() => {
+    if (scaledLayout) return scaledLayout.positions;
     if (rackType === 'x-rack') return computeXRackSlotPositions(rack.typeConfig?.bottlesPerSection || 10, innerW, innerH);
     if (rackType === 'hex') return computeHexSlotPositions(rack.rows || 4, rack.cols || 4, innerW, innerH);
     if (rackType === 'triangle') return computeTriangleSlotPositions(rack.cols || 1, innerW, innerH);
     if (rackType === 'stack') return computeStackSlotPositions(rack.rows || 4, innerH);
     if (rackType === 'shelf') return computeShelfSlotPositions(
-      displayRows, displayCols, rack.typeConfig?.backCols || 0, innerW, innerH
+      displayRows, displayCols, rack.typeConfig?.backCols || 0, innerW, innerH,
+      rack.typeConfig?.bottlesPerCell || 1, depth
     );
     return computeSlotPositions(displayRows, displayCols, innerW, innerH);
-  }, [rackType, rack.rows, rack.cols, displayRows, displayCols, innerW, innerH, rack.typeConfig?.backCols]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scaledLayout, rackType, rack.rows, rack.cols, displayRows, displayCols, innerW, innerH, depth,
+      rack.typeConfig?.backCols, rack.typeConfig?.bottlesPerCell, rack.typeConfig?.bottlesPerSection]);
 
   const edgesGeom = useMemo(() => {
     const sw = width * rackScale, sh = height * rackScale, sd = depth * rackScale;
@@ -753,8 +770,10 @@ export default function RackMesh({
 
       {/* ── Type-specific internal structure ─────────── */}
 
-      {/* Grid / hex / cube / stack / triangle: shelves + scallops + rails */}
-      {rackType !== 'x-rack' && rackType !== 'shelf' && (
+      {/* Grid / hex / stack / triangle: shelves + scallops + rails. Cube and
+          modular racks have irregular internal layouts (driven by the scaled
+          2D layout), so the simple per-row planks/scallops don't apply. */}
+      {rackType !== 'x-rack' && rackType !== 'shelf' && rackType !== 'cube' && !rack.isModular && (
         <>
           {/* Shelves between rows (thin planks) */}
           {Array.from({ length: Math.max(displayRows - 1, 0) }).map((_, i) => {
@@ -896,15 +915,15 @@ export default function RackMesh({
           ) : (
             <EmptySlot
               key={pos}
-              position={[x, y, z]}
+              // Shelf positions encode an absolute z (cubby opening for their
+              // row). Other types use z=0; place their ring at the actual
+              // cabinet front face (depth-aware) so it tracks the opening even
+              // when depthOverride resizes the cabinet.
+              position={[x, y, rackType === 'shelf' ? z : (depth / 2 - 0.005)]}
               slotPosition={pos}
               onClick={onEmptySlotClick}
               isBack={isBack}
-              // Shelf positions encode an absolute z (cubby opening for
-              // their row); other types use z=0 and need the front-face
-              // offset. Skip the offset for shelf so rings don't end up
-              // floating outside the cabinet in the room view.
-              useAbsoluteZ={rackType === 'shelf'}
+              useAbsoluteZ
             />
           );
         })

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -118,10 +118,17 @@ export default function CellarRoom() {
       ]);
 
       const cellarData = await cellarRes.json();
+
+      // Check every response before consuming. A failed racks/layout fetch
+      // must surface an error — NOT fall through to auto-populate, which would
+      // discard the real saved layout and (on a later Save) clobber it.
+      if (!cellarRes.ok) { setError(cellarData.error || 'Failed to load cellar'); return; }
+      if (!racksRes.ok) { setError('Failed to load racks for this cellar'); return; }
+      if (!layoutRes.ok) { setError('Failed to load the room layout'); return; }
+
       const racksData = await racksRes.json();
       const layoutData = await layoutRes.json();
 
-      if (!cellarRes.ok) { setError(cellarData.error); return; }
       setCellar(cellarData.cellar);
       setRacks(racksData.racks || []);
 
@@ -137,13 +144,17 @@ export default function CellarRoom() {
         setLayout(filtered);
         savedLayoutRef.current = JSON.stringify(filtered);
       } else {
-        // Auto-populate: place all racks in a line
-        const autoPlace = (racksData.racks || []).map((r, i) => ({
-          rack: r._id,
-          position: { x: -3 + i * 1.5, y: 0, z: -3 },
-          rotation: 0,
-          wall: 'north',
-        }));
+        // No layout doc yet — auto-populate by placing all racks in a line,
+        // clamped inside the room so none poke through the walls.
+        const autoPlace = (racksData.racks || []).map((r, i) => {
+          const clamped = clampToRoom(-3 + i * 1.5, -3, r, {}, DEFAULT_DIMENSIONS);
+          return {
+            rack: r._id,
+            position: { x: clamped.x, y: 0, z: clamped.z },
+            rotation: 0,
+            wall: 'north',
+          };
+        });
         const autoLayout = {
           cellar: id,
           roomDimensions: DEFAULT_DIMENSIONS,

--- a/frontend/src/utils/roomConstants.js
+++ b/frontend/src/utils/roomConstants.js
@@ -3,6 +3,8 @@
  * Used by CellarRoom, RoomScene, and RackMesh to avoid duplication.
  */
 
+import { computeLayout, computeModularLayout, CELL_SIZE } from './rackLayouts';
+
 // ── Rack physical dimensions (metres) ────────────────────
 export const CELL_W = 0.105;       // cell width
 export const CELL_H = 0.105;       // cell height
@@ -10,6 +12,40 @@ export const RACK_DEPTH = 0.34;    // default rack depth
 export const WOOD_THICK = 0.012;   // internal shelf/beam thickness
 export const PANEL_THICK = 0.018;  // outer frame panel thickness
 export const BOTTLE_RADIUS = 0.037;
+
+// Metres per SVG pixel: one 2D layout cell (CELL_SIZE px, centre-to-centre)
+// maps to one 3D cell (CELL_W metres). Lets us reuse the 2D layout engine
+// for irregular rack types (cube / modular) and stay in sync with it.
+const SVG_TO_M = CELL_W / CELL_SIZE;
+
+/**
+ * Build 3D slot positions for cube / modular racks by reusing the 2D layout
+ * engine (rackLayouts.js — the single source of truth for slot numbering) and
+ * scaling its SVG coordinates into 3D metres, centred on the rack origin with
+ * the SVG y-down axis flipped to 3D y-up.
+ *
+ * Returns { positions: [{ position, x, y, z }], innerW, innerH } in metres.
+ */
+export function buildScaledLayout(rack) {
+  const layout = rack.isModular
+    ? computeModularLayout(rack.modules || [])
+    : computeLayout(rack.type || 'grid', rack.rows || 4, rack.cols || 4, rack.typeConfig);
+  const vbW = layout.viewBox.width || 0;
+  const vbH = layout.viewBox.height || 0;
+  const positions = (layout.slots || []).map(s => ({
+    position: s.position,
+    x: (s.cx - vbW / 2) * SVG_TO_M,
+    y: (vbH / 2 - s.cy) * SVG_TO_M,
+    z: 0,
+  }));
+  return { positions, innerW: vbW * SVG_TO_M, innerH: vbH * SVG_TO_M };
+}
+
+// True for rack types whose internal layout is irregular and therefore driven
+// by the scaled 2D layout rather than the simple rows × cols grid formulas.
+function usesScaledLayout(rack) {
+  return !!rack.isModular || (rack.type || 'grid') === 'cube';
+}
 
 /**
  * Compute display grid dimensions (rows × cols) for any rack type.
@@ -45,6 +81,9 @@ export function getDisplayDims(rack) {
  * Compute full rack height in metres (outer frame included).
  */
 export function getRackHeight(rack) {
+  if (usesScaledLayout(rack)) {
+    return buildScaledLayout(rack).innerH + PANEL_THICK * 2;
+  }
   const { displayRows } = getDisplayDims(rack);
   return displayRows * CELL_H + PANEL_THICK * 2;
 }
@@ -63,8 +102,9 @@ export function getDefaultRackDepth(rack) {
  * rotation and width/depth overrides from the placement.
  */
 export function getRackWorldDims(rack, placement) {
-  const { displayCols } = getDisplayDims(rack);
-  const defaultW = displayCols * CELL_W + PANEL_THICK * 2;
+  const defaultW = usesScaledLayout(rack)
+    ? buildScaledLayout(rack).innerW + PANEL_THICK * 2
+    : getDisplayDims(rack).displayCols * CELL_W + PANEL_THICK * 2;
   const w = placement.widthOverride || defaultW;
   const d = placement.depthOverride || getDefaultRackDepth(rack);
   const scale = placement.scaleOverride || 1;


### PR DESCRIPTION
## Summary

First of three staged PRs fixing bugs found in a thorough multi-agent review of the 3D cellar (Room View) feature. This PR covers the **P0 rendering/data-loss cluster** plus closely-related slot-math bugs. The unifying fix: **reuse the 2D layout engine (`rackLayouts.js`) as the single source of truth for slot numbering in 3D**, so the two views can never disagree.

## Bugs fixed

| # | Bug | Effect before |
|---|-----|---------------|
| #1 | `fetchData` only checked `cellarRes.ok` | A failed layout fetch silently discarded the saved layout and **clobbered it on the next Save** |
| #2 | Modular racks had no 3D slot branch | Bottles in wrong cells, phantom rings, wrong-bottle clicks |
| #4 | Cube racks rendered `rows×cols` not `rows×cols×moduleRows×moduleCols` | ~75% of a cube's bottles vanished in 3D |
| #3 | Shelf `bottlesPerCell>1` ignored | Up to `(bpc-1)/bpc` of bottles invisible/unclickable |
| #8 | Shelf bottle/ring Z hardcoded to default depth | `depthOverride` floated bottles/rings off the cabinet |
| #9 | Empty-ring Z hardcoded to `RACK_DEPTH` | Rings detached from the opening on non-default depth |
| #15 | Modular `totalSlots` summed `rows×cols` | Wrong count label for hex/triangle/x-rack/cube modules |
| #21 | Shelf frame width ignored `backCols` | Back-row bottle clipped the side panel when `backCols ≈ cols` |
| #14 | Auto-populate skipped `clampToRoom` | 7+ racks poked through the wall on first view |

## How

- New `buildScaledLayout(rack)` in `roomConstants.js` maps `computeModularLayout`/`computeLayout` SVG coords → 3D metres. Used for cube + modular slot positions, frame dims, `getRackHeight`, and `getRackWorldDims`.
- `totalSlots` now delegates to `getTotalSlots`/`getModularTotalSlots` (same helpers the 2D view uses).
- `computeShelfSlotPositions` takes `bpc` + `depth`, emits `bpc` positions per cubby (front-to-back z stagger), derives all Z from the real depth, and clamps the back row inside the panels.
- `fetchData` checks all three responses and only auto-populates on a genuine empty layout; auto-placed racks are clamped to the room.

## Verification

- `cd frontend && npm test` → **306 passed**
- `cd frontend && npm run build` (identical to the frontend Docker stage) → **builds clean**
- Numeric parity check confirming 3D slot **counts and 1..N numbering exactly match** the backend for cube (24/16), modular (20/21), and shelf-bpc (12/24/4/18/44) configs — all slots fit inside the frame.

## docker-compose impact

**None.** Frontend-only logic changes — no Dockerfile, compose, env-var, or dependency changes. The `vite build` validated here is exactly what the frontend image builds. Recommended manual check before merge: open the Room View in Docker with a cube/modular/shelf rack to eyeball the geometry.

## Follow-ups (next PRs)
- **PR2** — drag pointer-capture, unsaved-changes nav blocker, save-validation clamps (#5,6,7,10,11,12,13,16,17)
- **PR3** — GPU/memory leaks & visual polish (#18,19,20,22,23,24)