### PR TITLE
fix(3d): harden Room View drag, navigation guard & save validation

### DIFF
--- a/backend/src/routes/cellarLayout.js
+++ b/backend/src/routes/cellarLayout.js
@@ -62,10 +62,14 @@ router.put('/', requireCellarAccess('editor'), async (req, res) => {
     res.json({ layout });
   } catch (err) {
     console.error('Save cellar layout error:', err.message, err.errors ? JSON.stringify(err.errors) : '');
-    const msg = err.name === 'ValidationError'
-      ? `Validation: ${Object.values(err.errors || {}).map(e => e.message).join(', ')}`
-      : 'Failed to save cellar layout';
-    res.status(500).json({ error: msg });
+    // A ValidationError is bad client input (out-of-range position/scale/etc.),
+    // not a server fault — report it as 400 so it isn't counted as a 5xx outage
+    // and clients don't treat it as a retryable transient error.
+    if (err.name === 'ValidationError') {
+      const msg = `Validation: ${Object.values(err.errors || {}).map(e => e.message).join(', ')}`;
+      return res.status(400).json({ error: msg });
+    }
+    res.status(500).json({ error: 'Failed to save cellar layout' });
   }
 });
 

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -139,7 +139,7 @@ function Bottle({ position, wineType, slot, onBottleClick, highlighted, scale = 
         geometry={bottleGeo}
         castShadow
         onClick={handleClick}
-        onPointerOver={(e) => { e.stopPropagation(); document.body.style.cursor = 'pointer'; }}
+        onPointerOver={(e) => { if (onBottleClick) { e.stopPropagation(); document.body.style.cursor = 'pointer'; } }}
         onPointerOut={() => { document.body.style.cursor = ''; }}
       >
         <meshPhysicalMaterial
@@ -572,16 +572,18 @@ export default function RackMesh({
   }, [rack._id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Cleanup drag listeners if component unmounts during an active drag
+  // (e.g. the rack is removed/undone mid-drag). RoomScene also re-enables
+  // OrbitControls on the next pointer release as a safety net.
   useEffect(() => {
-    const domEl = gl.domElement;
     return () => {
       if (dragListenersRef.current) {
-        domEl.removeEventListener('pointermove', dragListenersRef.current.onMove);
-        domEl.removeEventListener('pointerup', dragListenersRef.current.onUp);
+        window.removeEventListener('pointermove', dragListenersRef.current.onMove);
+        window.removeEventListener('pointerup', dragListenersRef.current.onUp);
+        window.removeEventListener('pointercancel', dragListenersRef.current.onUp);
         dragListenersRef.current = null;
       }
     };
-  }, [gl.domElement]);
+  }, []);
 
   const rackType = rack.type || 'grid';
 
@@ -605,7 +607,10 @@ export default function RackMesh({
   const baseInnerW = scaledLayout ? scaledLayout.innerW : displayCols * CELL_W;
   const baseInnerH = scaledLayout ? scaledLayout.innerH : displayRows * CELL_H;
   const defaultWidth = baseInnerW + PANEL_THICK * 2;
-  const width = widthOverride || defaultWidth;
+  // x-rack is square by construction; honouring a stray widthOverride (e.g.
+  // left over from a rack that was switched to x-rack after a width was set)
+  // would stretch the slot grid and X-beams out of alignment, so ignore it.
+  const width = rackType === 'x-rack' ? defaultWidth : (widthOverride || defaultWidth);
   const hasShelfBack = rackType === 'shelf' && (rack.typeConfig?.backCols || 0) > 0;
   const depth = depthOverride || (hasShelfBack ? RACK_DEPTH * 1.7 : RACK_DEPTH);
   const innerW = (width - PANEL_THICK * 2);
@@ -719,20 +724,26 @@ export default function RackMesh({
       if (groupRef.current) {
         onDragEnd?.([groupRef.current.position.x, position[1], groupRef.current.position.z]);
       }
-      gl.domElement.removeEventListener('pointermove', onMove);
-      gl.domElement.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
       dragListenersRef.current = null;
     };
 
     // Remove any stale listeners before adding new ones
     if (dragListenersRef.current) {
-      gl.domElement.removeEventListener('pointermove', dragListenersRef.current.onMove);
-      gl.domElement.removeEventListener('pointerup', dragListenersRef.current.onUp);
+      window.removeEventListener('pointermove', dragListenersRef.current.onMove);
+      window.removeEventListener('pointerup', dragListenersRef.current.onUp);
+      window.removeEventListener('pointercancel', dragListenersRef.current.onUp);
     }
     dragListenersRef.current = { onMove, onUp };
 
-    gl.domElement.addEventListener('pointermove', onMove);
-    gl.domElement.addEventListener('pointerup', onUp);
+    // Listen on window (not the canvas) so a pointer release outside the canvas
+    // — over a side panel, the header, or off-window — still ends the drag.
+    // pointercancel covers touch/pen interruptions.
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
   };
 
   const handleClick = (e) => { if (isEditMode) return; e.stopPropagation(); onClick?.(e.shiftKey); };

--- a/frontend/src/components/room/RoomScene.js
+++ b/frontend/src/components/room/RoomScene.js
@@ -175,17 +175,45 @@ export default function RoomScene({
       if (isGroupMember || isAlsoSelected) {
         const ref = rackRefsMap.current[rpId];
         if (ref) {
-          ref.position.x += dx;
-          ref.position.z += dz;
+          // Clamp each member to the room during the live drag, mirroring the
+          // per-member clamp applied on drop. Without this, members visibly
+          // pass through walls mid-drag and then jump on release.
+          let nx = ref.position.x + dx;
+          let nz = ref.position.z + dz;
+          const rack = rackMap[rpId];
+          if (rack) {
+            const clamped = clampToRoom(nx, nz, rack, rp, roomDimensions);
+            nx = clamped.x;
+            nz = clamped.z;
+          }
+          ref.position.x = nx;
+          ref.position.z = nz;
         }
       }
     });
-  }, [rackPlacements]);
+  }, [rackPlacements, rackMap, roomDimensions]);
 
   const handleDragStart = useCallback(() => {
     setIsDragging(true);
     if (controlsRef.current) controlsRef.current.enabled = false;
   }, []);
+
+  // Safety net: whenever a drag is active, the next pointer release anywhere
+  // re-enables camera controls — even if the rack's own pointerup never fired
+  // (released off-canvas) or the rack unmounted mid-drag.
+  useEffect(() => {
+    if (!isDragging) return;
+    const reenable = () => {
+      setIsDragging(false);
+      if (controlsRef.current) controlsRef.current.enabled = true;
+    };
+    window.addEventListener('pointerup', reenable);
+    window.addEventListener('pointercancel', reenable);
+    return () => {
+      window.removeEventListener('pointerup', reenable);
+      window.removeEventListener('pointercancel', reenable);
+    };
+  }, [isDragging]);
 
   // Keep a ref to rackPlacements so drag-end reads current positions
   const rackPlacementsRef = useRef(rackPlacements);
@@ -401,8 +429,11 @@ export default function RoomScene({
             onDragStart={handleDragStart}
             onDragEnd={(newPos) => handleDragEnd(rack._id, newPos)}
             onSnapPosition={(px, pz) => computeSnapPosition(rack._id, px, pz)}
-            onBottleClick={(slot) => onBottleClick?.(rack._id, slot)}
-            onEmptySlotClick={(slotPos) => onEmptySlotClick?.(rack._id, slotPos)}
+            // Keep these undefined when the parent passes no handler so the
+            // bottle/empty-slot cursor + click affordance is suppressed
+            // (no dead clicks in edit mode or for read-only viewers).
+            onBottleClick={onBottleClick ? (slot) => onBottleClick(rack._id, slot) : undefined}
+            onEmptySlotClick={onEmptySlotClick ? (slotPos) => onEmptySlotClick(rack._id, slotPos) : undefined}
             highlightBottleId={highlightBottleId}
           />
         );

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -15,6 +15,15 @@ import './CellarRoom.css';
 
 const DEFAULT_DIMENSIONS = { width: 10, depth: 10, height: 3 };
 
+// True when a keyboard event originates from an editable field, so global
+// shortcuts (arrow-move, Ctrl+Z/Y) don't hijack typing in the room's inputs.
+function isTypingTarget(e) {
+  const el = e.target;
+  if (!el) return false;
+  const tag = el.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
+}
+
 export default function CellarRoom() {
   const { t } = useTranslation();
   const { id } = useParams();
@@ -176,29 +185,38 @@ export default function CellarRoom() {
     setSaving(true);
     setSaveError(null);
     try {
-      // Sanitize placements: ensure rack is a plain ID string, strip unknown fields
+      // Clamp a value to the schema range (a single out-of-range field would
+      // otherwise fail server validation and block the whole layout save).
+      const clamp = (v, lo, hi, fallback = 0) => {
+        const n = Number(v);
+        if (!Number.isFinite(n)) return fallback;
+        return Math.max(lo, Math.min(hi, n));
+      };
+
+      // Sanitize placements: ensure rack is a plain ID string, strip unknown
+      // fields, and clamp every numeric field to its CellarLayout schema range.
       const cleanPlacements = layout.rackPlacements.map(rp => {
         const clean = {
           rack: rp.rack?._id || rp.rack,
           position: {
-            x: Number(rp.position?.x) || 0,
-            y: Number(rp.position?.y) || 0,
-            z: Number(rp.position?.z) || 0,
+            x: clamp(rp.position?.x, -100, 100),
+            y: clamp(rp.position?.y, -10, 50),
+            z: clamp(rp.position?.z, -100, 100),
           },
           rotation: rp.rotation || 0,
           wall: rp.wall || 'none',
         };
-        if (rp.group) clean.group = rp.group;
-        if (rp.widthOverride) clean.widthOverride = Number(rp.widthOverride);
-        if (rp.depthOverride) clean.depthOverride = Number(rp.depthOverride);
-        if (rp.scaleOverride) clean.scaleOverride = Number(rp.scaleOverride);
+        if (rp.group) clean.group = String(rp.group).slice(0, 50);
+        if (rp.widthOverride) clean.widthOverride = clamp(rp.widthOverride, 0.1, 5, 1);
+        if (rp.depthOverride) clean.depthOverride = clamp(rp.depthOverride, 0.1, 2, 1);
+        if (rp.scaleOverride) clean.scaleOverride = clamp(rp.scaleOverride, 0.5, 5, 1);
         return clean;
       });
 
       const cleanDims = {
-        width: Number(layout.roomDimensions?.width) || 10,
-        depth: Number(layout.roomDimensions?.depth) || 10,
-        height: Number(layout.roomDimensions?.height) || 3,
+        width: clamp(layout.roomDimensions?.width, 2, 50, 10),
+        depth: clamp(layout.roomDimensions?.depth, 2, 50, 10),
+        height: clamp(layout.roomDimensions?.height, 2, 10, 3),
       };
 
       const res = await saveCellarLayout(apiFetch, {
@@ -272,7 +290,12 @@ export default function CellarRoom() {
 
   const handleDimensionChange = useCallback((field, value) => {
     setLayoutWithHistory(prev => {
-      const newDims = { ...prev.roomDimensions, [field]: Math.max(2, Math.min(50, Number(value) || 2)) };
+      // Clamp to the schema's per-field range (height caps at 10, width/depth
+      // at 50). Typed/pasted values bypass the input's HTML max, so without
+      // this an out-of-range height fails server validation and blocks the
+      // entire layout save.
+      const maxForField = field === 'height' ? 10 : 50;
+      const newDims = { ...prev.roomDimensions, [field]: Math.max(2, Math.min(maxForField, Number(value) || 2)) };
       // Clamp all racks that would end up outside the new room boundaries
       const clampedPlacements = prev.rackPlacements.map(rp => {
         const rpId = rp.rack?._id || rp.rack;
@@ -609,6 +632,7 @@ export default function CellarRoom() {
         case 'ArrowDown':  dz = STEP; break;
         default: return;
       }
+      if (isTypingTarget(e)) return; // don't move racks while typing in a field
       e.preventDefault();
       setLayoutWithHistory(prev => {
         // Collect all IDs to move: selected + their group members
@@ -653,6 +677,7 @@ export default function CellarRoom() {
   useEffect(() => {
     const handleUndoRedo = (e) => {
       if (!isEditMode) return;
+      if (isTypingTarget(e)) return; // let inputs keep native text undo/redo
       const isUndo = (e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey;
       const isRedo = (e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey));
       if (!isUndo && !isRedo) return;
@@ -709,22 +734,34 @@ export default function CellarRoom() {
     if (!hasUnsavedChanges) return;
 
     const currentPath = window.location.pathname + window.location.search;
+    // Normalize any URL form (relative path, absolute path, or full href) to
+    // pathname+search so the comparison is apples-to-apples.
+    const toPath = (url) => {
+      try {
+        const u = new URL(url, window.location.origin);
+        return u.pathname + u.search;
+      } catch {
+        return String(url);
+      }
+    };
 
     // Monkey-patch pushState to intercept all client-side navigation
     const origPushState = window.history.pushState.bind(window.history);
     window.history.pushState = function (state, title, url) {
-      if (hasUnsavedRef.current && url && url !== currentPath) {
-        setPendingNavPath(url);
+      const target = url != null ? toPath(url) : currentPath;
+      if (hasUnsavedRef.current && url != null && target !== currentPath) {
+        setPendingNavPath(target);
         return; // Block the navigation
       }
       origPushState(state, title, url);
     };
 
-    // Intercept browser back/forward
-    window.history.pushState(null, '', window.location.href);
+    // Seed a sentinel history entry via the NATIVE pushState (not the patched
+    // one — otherwise it blocks its own seed and pops a spurious dialog).
+    origPushState(null, '', window.location.href);
     const handlePopState = () => {
       if (hasUnsavedRef.current) {
-        window.history.pushState(null, '', window.location.href);
+        origPushState(null, '', window.location.href);
         setPendingNavPath('__back__');
       }
     };
@@ -1015,8 +1052,12 @@ export default function CellarRoom() {
                   }
                 }}
                 onRackDragEnd={handleRackDragEnd}
-                onBottleClick={handleBottleClick}
-                onEmptySlotClick={handleEmptySlotClick}
+                // Pass undefined when the click would be a no-op so bottles /
+                // empty rings don't show a pointer cursor or swallow clicks:
+                // bottles are non-interactive in edit mode; empty rings only
+                // for editors in view mode.
+                onBottleClick={isEditMode ? undefined : handleBottleClick}
+                onEmptySlotClick={(!canEdit || isEditMode) ? undefined : handleEmptySlotClick}
                 focusTarget={focusTarget}
                 highlightBottleId={highlightBottleId}
               />


### PR DESCRIPTION
Re-opened replacement for #532 (auto-closed when its stacked base branch was deleted on #531 merge). Same content, now based on `main`.

Hardens 3D cellar Room View interaction:
- Drag listeners on `window` + `pointercancel` so off-canvas release ends the drag; OrbitControls safety net (#5)
- Group members clamped during live drag (#10)
- Unsaved-changes guard seeds sentinel via native pushState + normalizes URLs (#6)
- Field-aware height clamp + handleSave clamps; PUT returns 400 for ValidationError (#7, #12, #11)
- x-rack ignores stray widthOverride (#13); dead-click cursor gating (#16, #17); key handlers ignore typing in inputs

Verified: 306 frontend + 692 backend tests, clean build. No docker-compose/dependency impact.