### PR TITLE
chore: stop Cellar Cred from granting plan upgrades

### DIFF
--- a/backend/src/utils/cellarCred.js
+++ b/backend/src/utils/cellarCred.js
@@ -2,8 +2,13 @@
  * Cellar Cred — contribution score and badge system.
  *
  * Users earn points for approved contributions (wine requests, images,
- * reviews, forum activity). Points accumulate into tiers that unlock
- * temporary plan upgrades and display badges on profiles and posts.
+ * reviews, forum activity). Points accumulate into tiers that display
+ * badges on profiles and posts.
+ *
+ * Cellar Cred does NOT change a user's subscription plan. Every feature is
+ * free for all tiers, so contribution no longer grants supporter/patron — the
+ * tiers below are purely cosmetic badges. Plans are set only via Stripe
+ * (routes/stripe.js) or an admin grant (routes/admin/users.js).
  */
 
 const User = require('../models/User');
@@ -45,12 +50,9 @@ const TIERS = [
   { name: 'newcomer',     threshold:   0 },
 ];
 
-// ── Plan rewards per tier (one-time) ────────────────────────────────────────
-const TIER_REWARDS = {
-  contributor: { plan: 'supporter', durationDays: 30 },
-  connoisseur: { plan: 'patron',   durationDays: 30 },
-};
-
+// Plan ranking — retained because routes/stripe.js imports it to compare an
+// incoming Stripe plan against the user's current grant. Cellar Cred itself no
+// longer grants plans (see module header).
 const PLAN_RANK = { free: 0, supporter: 1, patron: 2 };
 
 /** Return the tier name for a given total score. */
@@ -84,8 +86,8 @@ function getSpecialty(categories) {
 }
 
 /**
- * Atomically increment a user's contribution score and recompute tier/specialty.
- * Grants one-time plan rewards on tier-up. Fire-and-forget safe.
+ * Atomically increment a user's contribution score and recompute the
+ * tier/specialty badge. Does not touch the subscription plan. Fire-and-forget safe.
  */
 async function incrementCred(userId, eventType) {
   const points = POINT_VALUES[eventType];
@@ -100,45 +102,21 @@ async function incrementCred(userId, eventType) {
   const user = await User.findByIdAndUpdate(
     userId,
     { $inc: inc },
-    { new: true, select: 'contribution plan planExpiresAt' }
+    { new: true, select: 'contribution' }
   );
   if (!user) return;
 
   const newTier = getTier(user.contribution.totalScore);
   const newSpecialty = getSpecialty(user.contribution.categories);
 
+  // Recompute the cosmetic badge fields only. Cellar Cred no longer grants
+  // plan upgrades — crossing a tier changes the badge, not the subscription.
   const updates = {};
   if (newTier !== user.contribution.tier) updates['contribution.tier'] = newTier;
   if (newSpecialty !== user.contribution.specialty) updates['contribution.specialty'] = newSpecialty;
 
-  // Check for all unclaimed tier rewards (handles tier-jumping, e.g. 0 → 100 skips contributor)
-  const granted = user.contribution.rewardsGranted || [];
-  const rewardTiers = Object.keys(TIER_REWARDS);
-  for (const rewardTier of rewardTiers) {
-    if (granted.includes(rewardTier)) continue;
-    const tierThreshold = TIERS.find(t => t.name === rewardTier)?.threshold || Infinity;
-    if (user.contribution.totalScore < tierThreshold) continue;
-
-    const reward = TIER_REWARDS[rewardTier];
-    const currentRank = PLAN_RANK[updates.plan || user.plan] || 0;
-    const rewardRank = PLAN_RANK[reward.plan] || 0;
-    const planExpired = user.planExpiresAt && new Date(user.planExpiresAt) < new Date();
-
-    if (rewardRank > currentRank || planExpired) {
-      updates.plan = reward.plan;
-      updates.planStartedAt = new Date();
-      updates.planExpiresAt = new Date(Date.now() + reward.durationDays * 24 * 60 * 60 * 1000);
-    }
-    if (!updates.$addToSet) updates.$addToSet = { 'contribution.rewardsGranted': { $each: [] } };
-    updates.$addToSet['contribution.rewardsGranted'].$each.push(rewardTier);
-  }
-
   if (Object.keys(updates).length > 0) {
-    const { $addToSet, ...setFields } = updates;
-    const updateOp = {};
-    if (Object.keys(setFields).length > 0) updateOp.$set = setFields;
-    if ($addToSet) updateOp.$addToSet = $addToSet;
-    await User.updateOne({ _id: userId }, updateOp);
+    await User.updateOne({ _id: userId }, { $set: updates });
   }
 }
 

--- a/backend/src/utils/cellarCred.test.js
+++ b/backend/src/utils/cellarCred.test.js
@@ -1,4 +1,10 @@
-const { getTier, getSpecialty, POINT_VALUES, CATEGORY_MAP } = require('./cellarCred');
+jest.mock('../models/User', () => ({
+  findByIdAndUpdate: jest.fn(),
+  updateOne: jest.fn(),
+}));
+
+const User = require('../models/User');
+const { getTier, getSpecialty, POINT_VALUES, CATEGORY_MAP, incrementCred } = require('./cellarCred');
 
 describe('getTier', () => {
   it('returns newcomer for 0', () => expect(getTier(0)).toBe('newcomer'));
@@ -42,5 +48,57 @@ describe('constants', () => {
     for (const cat of Object.values(CATEGORY_MAP)) {
       expect(validCategories).toContain(cat);
     }
+  });
+});
+
+describe('incrementCred — no plan rewards', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('recomputes the badge tier but never grants a plan when crossing a threshold', async () => {
+    // User who, after this increment, has crossed the connoisseur threshold (>=300)
+    User.findByIdAndUpdate.mockResolvedValue({
+      contribution: {
+        totalScore: 305,
+        categories: { curator: 0, photographer: 305, critic: 0, community: 0 },
+        tier: 'enthusiast',        // stale — should be bumped to connoisseur
+        specialty: 'photographer', // unchanged
+        rewardsGranted: [],
+      },
+      plan: 'free',
+      planExpiresAt: null,
+    });
+    User.updateOne.mockResolvedValue({});
+
+    await incrementCred('user123', 'image_approved');
+
+    expect(User.updateOne).toHaveBeenCalledTimes(1);
+    const [, updateOp] = User.updateOne.mock.calls[0];
+    const set = updateOp.$set || {};
+
+    // Badge still recomputed
+    expect(set['contribution.tier']).toBe('connoisseur');
+    // But the subscription is left completely alone
+    expect(set).not.toHaveProperty('plan');
+    expect(set).not.toHaveProperty('planStartedAt');
+    expect(set).not.toHaveProperty('planExpiresAt');
+    expect(updateOp).not.toHaveProperty('$addToSet'); // no rewardsGranted writes
+  });
+
+  it('is a no-op write when neither tier nor specialty changes', async () => {
+    User.findByIdAndUpdate.mockResolvedValue({
+      contribution: {
+        totalScore: 40,
+        categories: { curator: 0, photographer: 40, critic: 0, community: 0 },
+        tier: 'contributor',
+        specialty: 'photographer',
+        rewardsGranted: [],
+      },
+      plan: 'free',
+      planExpiresAt: null,
+    });
+
+    await incrementCred('user123', 'image_approved');
+
+    expect(User.updateOne).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What & why

Cellar Cred used to auto-grant a **subscription plan** when a user crossed a contribution threshold:

| Contribution tier | Reward (before) |
|---|---|
| Contributor (25 pts) | `supporter` for 30 days |
| Connoisseur (300 pts) | `patron` for 30 days |

Since every feature is now free on all tiers, earning a plan through contributions no longer serves a purpose. Worse, this grant path was the **only** plan-change route that wrote no `AuditLog` entry, so these upgrades were invisible in the audit trail (this came up while investigating how a user reached `patron` with no Stripe sub and no admin grant — the answer was a Connoisseur reward).

## Change

- `incrementCred` now recomputes **only** the cosmetic `contribution.tier` / `contribution.specialty` badge. It no longer touches `plan`, `planStartedAt`, `planExpiresAt`, or `rewardsGranted`.
- Removed the `TIER_REWARDS` table.
- `PLAN_RANK` is **kept** and still exported — `routes/stripe.js` imports it to compare an incoming Stripe plan against the current grant.

## Unchanged

- Scoring, point values, tier thresholds, and the profile badges (`CellarCredBadge`) — purely cosmetic gamification, untouched.
- `backfill-cred.js` (only ever wrote score/tier/specialty, never plans).
- Plans are still set via Stripe checkout/webhook or an admin grant.

## Existing earned grants

Left to **expire naturally** — every Cellar-Cred grant was time-limited to 30 days and reverts to `free` at request time once `planExpiresAt` passes (`middleware/auth.js`). No data migration in this PR.

## Docker-compose impact

**None** — pure backend code change. No new services, env vars, or image changes.

## Tests

Full backend suite green: **701 passed / 37 suites**. Added 2 regression tests asserting `incrementCred` writes no plan fields (badge still recomputed; no `$addToSet`).