### PR TITLE
chore(release): v1.65.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.64.2",
+  "version": "1.65.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.64.2",
+  "version": "1.65.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump to v1.65.0 (minor — new feature: server-rendered homepage/help/blog index for AI crawlers, #538). Bumps backend + frontend package.json in lockstep. No lockfile changes.