### PR TITLE
feat(community): land on Discussions and show it as the first tab

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -118,7 +118,7 @@ function Layout({ children }) {
                   {t('nav.myRequests')}
                 </Link>
                 <Link
-                  to="/community"
+                  to="/community/discussions"
                   className={`nav-link ${isActive('/community') ? 'active' : ''}`}
                   data-guide="nav-community"
                 >
@@ -246,7 +246,7 @@ function Layout({ children }) {
         {user && mobileMenuOpen && (
           <div className="mobile-menu">
             <div className="mobile-menu-section">
-              <Link to="/community" className={`mobile-menu-link ${isActive('/community') ? 'active' : ''}`} onClick={closeMenu}>Community</Link>
+              <Link to="/community/discussions" className={`mobile-menu-link ${isActive('/community') ? 'active' : ''}`} onClick={closeMenu}>Community</Link>
               <Link to="/wishlist" className={`mobile-menu-link ${isActive('/wishlist') ? 'active' : ''}`} onClick={closeMenu}>Wishlist</Link>
               <Link to="/recommendations" className={`mobile-menu-link ${isActive('/recommendations') ? 'active' : ''}`} onClick={closeMenu}>Recommendations</Link>
               <Link to="/journal" className={`mobile-menu-link ${isActive('/journal') ? 'active' : ''}`} onClick={closeMenu}>Journal</Link>
@@ -321,7 +321,7 @@ function Layout({ children }) {
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
             <span>Cellars</span>
           </Link>
-          <Link to="/community" className={`bottom-nav-item ${isActive('/community') ? 'active' : ''}`} onClick={closeMenu}>
+          <Link to="/community/discussions" className={`bottom-nav-item ${isActive('/community') ? 'active' : ''}`} onClick={closeMenu}>
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
             <span>Community</span>
           </Link>

--- a/frontend/src/pages/CommunityDiscussions.js
+++ b/frontend/src/pages/CommunityDiscussions.js
@@ -18,16 +18,16 @@ function CommunityDiscussions() {
         {user && (
           <div className="review-feed__section-tabs">
             <Link
-              to="/community"
-              className={`review-feed__section-tab ${location.pathname === '/community' ? 'active' : ''}`}
-            >
-              {t('discussions.reviews')}
-            </Link>
-            <Link
               to="/community/discussions"
               className={`review-feed__section-tab ${location.pathname.startsWith('/community/discussions') ? 'active' : ''}`}
             >
               {t('discussions.discussions')}
+            </Link>
+            <Link
+              to="/community"
+              className={`review-feed__section-tab ${location.pathname === '/community' ? 'active' : ''}`}
+            >
+              {t('discussions.reviews')}
             </Link>
           </div>
         )}

--- a/frontend/src/pages/ReviewFeed.js
+++ b/frontend/src/pages/ReviewFeed.js
@@ -85,16 +85,16 @@ function ReviewFeed() {
         <h1>{t('reviewFeed.community')}</h1>
         <div className="review-feed__section-tabs">
           <Link
-            to="/community"
-            className={`review-feed__section-tab ${location.pathname === '/community' ? 'active' : ''}`}
-          >
-            {t('reviewFeed.reviews')}
-          </Link>
-          <Link
             to="/community/discussions"
             className={`review-feed__section-tab ${location.pathname.startsWith('/community/discussions') ? 'active' : ''}`}
           >
             {t('reviewFeed.discussions')}
+          </Link>
+          <Link
+            to="/community"
+            className={`review-feed__section-tab ${location.pathname === '/community' ? 'active' : ''}`}
+          >
+            {t('reviewFeed.reviews')}
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## What

Make **Discussions** the default Community view and the first tab.

- Pressing **Community** (desktop nav, mobile menu, and bottom nav) now opens `/community/discussions` instead of the Reviews feed.
- In the section tab bar, **Discussions** is ordered before **Reviews** in both `ReviewFeed` and `CommunityDiscussions`.
- **Reviews** is unchanged and still reachable as the second tab at `/community`.

## Why

Discussions is the more inviting entry point for the community, so it should be what users land on first.

## Notes

- Frontend-only change. No backend, env var, or `docker-compose` changes — just needs the normal frontend image rebuild (Vite build) on deploy.
- Nav active-highlight still works because `isActive('/community')` matches the `/community` prefix.
- No GDPR impact (navigation/ordering only; no personal data processed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
