### PR TITLE
chore(release): v1.65.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.65.0",
+  "version": "1.65.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.65.0",
+  "version": "1.65.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release v1.65.1. Bumps backend + frontend `package.json` to 1.65.1 (lockfiles untouched, per release convention).

Includes #541 — Community now lands on the Discussions tab, ordered first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)