### PR TITLE
chore(release): v1.65.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.65.1",
+  "version": "1.65.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.65.1",
+  "version": "1.65.2",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump to v1.65.2 (patch). Includes blog crawler-rendering fix #542 (structured content + FAQ schema) on top of v1.65.1 (community land-on-Discussions). Bumps backend + frontend package.json in lockstep; no lockfile changes.