### PR TITLE
fix(seo): drop self-hosted framing from marketing copy

### DIFF
--- a/backend/src/routes/og.js
+++ b/backend/src/routes/og.js
@@ -361,7 +361,7 @@ router.get('/wines/:idOrSlug', ogLimiter, async (req, res) => {
     const ratingPhrase = hasRating
       ? ` Cellarion users rate it ${fromNormalized(wine.communityRating.averageNormalized, '5').toFixed(1)} out of 5 across ${wine.communityRating.reviewCount} ${wine.communityRating.reviewCount === 1 ? 'review' : 'reviews'}.`
       : '';
-    const proseParagraph = `${wine.name} is a ${typeWord} produced by ${wine.producer}${placeWords ? ` in ${placeWords}` : ''}.${classificationPhrase} ${grapesPhrase}${drinkPhrase}${ratingPhrase} Track this wine and manage your cellar with Cellarion — open-source, self-hostable, free.`.replace(/\s+/g, ' ').trim();
+    const proseParagraph = `${wine.name} is a ${typeWord} produced by ${wine.producer}${placeWords ? ` in ${placeWords}` : ''}.${classificationPhrase} ${grapesPhrase}${drinkPhrase}${ratingPhrase} Track this wine and manage your cellar with Cellarion — the free, open-source wine app at cellarion.app.`.replace(/\s+/g, ' ').trim();
 
     // Per-wine FAQ — only emit a question when the underlying data exists. AI engines
     // love quoting Q&A pairs verbatim; this is what shows up in chat answers.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#FAF8F6" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#121212" media="(prefers-color-scheme: dark)" />
-    <meta name="description" content="Cellarion — the open-source wine cellar manager. Track bottles, visualise racks, get drink-window alerts, and share cellars. Self-hosted or use cellarion.app." />
-    <meta name="keywords" content="wine cellar management, wine tracking, bottle tracker, wine collection, open source wine app, self-hosted wine cellar, drink window, wine rack" />
+    <meta name="description" content="Cellarion — the open-source wine cellar app at cellarion.app. Track bottles, visualise racks, get drink-window alerts, and share cellars with friends." />
+    <meta name="keywords" content="wine cellar management, wine tracking, bottle tracker, wine collection, open source wine app, drink window, wine rack" />
 
     <!-- Preload LCP logo (WebP with PNG fallback) so browser discovers it before React renders -->
     <link rel="preload" as="image" href="/cellarion-logo-light.webp" type="image/webp" media="(prefers-color-scheme: light)" fetchpriority="high" />
@@ -23,12 +23,12 @@
     <!-- Open Graph / Social sharing -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Cellarion — Track & Manage Your Wine Collection" />
-    <meta property="og:description" content="The open-source, self-hosted wine cellar manager. Track bottles, visualise racks, and get drink-window alerts." />
+    <meta property="og:description" content="The open-source wine cellar app. Track bottles, visualise racks, and get drink-window alerts." />
     <meta property="og:image" content="/cellarion-logo.jpg" />
     <meta property="og:url" content="https://cellarion.app" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Cellarion — Track & Manage Your Wine Collection" />
-    <meta name="twitter:description" content="The open-source, self-hosted wine cellar manager. Track bottles, visualise racks, and get drink-window alerts." />
+    <meta name="twitter:description" content="The open-source wine cellar app. Track bottles, visualise racks, and get drink-window alerts." />
     <meta name="twitter:image" content="/cellarion-logo.jpg" />
 
     <!--
@@ -59,7 +59,7 @@
   <body>
     <noscript>
       <h1>Cellarion — Track & Manage Your Wine Collection</h1>
-      <p>The open-source, self-hosted wine cellar manager. Track bottles, visualise racks, get drink-window alerts, and share cellars.</p>
+      <p>The open-source wine cellar app. Track bottles, visualise racks, get drink-window alerts, and share cellars.</p>
     </noscript>
     <!-- SEO: visible h1 for crawlers that don't render JS. React removes #preboot-heading on mount. -->
     <div id="preboot-heading" aria-hidden="true" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">


### PR DESCRIPTION
Repositions public/AEO copy toward the hosted app (cellarion.app) per product direction, while keeping the open-source angle as a selling point.

**Changed**
- `frontend/index.html`: meta description, keywords, og:description, twitter:description, and noscript fallback — removed 'self-hosted', lead with the hosted app, kept 'open-source'.
- `backend/src/routes/og.js`: wine OG prose 'open-source, self-hostable, free' → 'the free, open-source wine app at cellarion.app'.

**Left as-is (intentional)**
- Umami self-hosting code/CSP comments (developer-only, invisible).
- Privacy policy Meilisearch sub-processor row ('Self-hosted' = runs on own infra; factual/legal).

**Also done (not in this PR — live DB edits)**
- 5 prod blog posts reworded to remove self-hosting (3 product posts + 2 new guides), keeping open-source. 0 self-host references remain across all 28 posts.

**Deploy:** frontend + backend images (v1.65.3).