### PR TITLE
chore(release): v1.65.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.65.2",
+  "version": "1.65.3",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.65.2",
+  "version": "1.65.3",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump to v1.65.3 (patch). Removes self-hosted framing from marketing/AEO copy (#545), leading with the hosted app while keeping the open-source angle. Bumps backend + frontend package.json in lockstep.