### PR TITLE
chore(release): v1.66.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.65.3",
+  "version": "1.66.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.65.3",
+  "version": "1.66.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump to v1.66.0 for the release (cellar data portability, GDPR re-consent, audit fixes & AEO — #547). Publishing the v1.66.0 GitHub Release builds & pushes the Docker images.