### PR TITLE
chore(release): v1.66.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Patch release: fix currency allowlist drift (NZD/JPY/HKD/SGD/ZAR now accepted in preferences — #550). Publishing the v1.66.1 Release builds & pushes the Docker images.