### PR TITLE
feat(bottles): move a bottle to another cellar + per-bottle journey

### DIFF
--- a/backend/src/models/Bottle.js
+++ b/backend/src/models/Bottle.js
@@ -1,5 +1,14 @@
 const mongoose = require('mongoose');
 
+// One entry per cellar the bottle has lived in, in chronological order. The
+// cellar name is snapshotted so the journey survives a later rename/delete of
+// that cellar. _id disabled — these are value records, not addressable docs.
+const cellarHistorySchema = new mongoose.Schema({
+  cellar:     { type: mongoose.Schema.Types.ObjectId, ref: 'Cellar' },
+  cellarName: { type: String, trim: true },
+  enteredAt:  { type: Date, default: Date.now }
+}, { _id: false });
+
 const bottleSchema = new mongoose.Schema({
   cellar: {
     type: mongoose.Schema.Types.ObjectId,
@@ -123,6 +132,12 @@ const bottleSchema = new mongoose.Schema({
   // Drink-window notification tracking — set by the daily notifier job
   drinkWindowNotifiedStatus: { type: String, default: null },
   drinkWindowNotifiedAt:     { type: Date,   default: null },
+  // When the bottle entered its CURRENT cellar (updated when it's moved between
+  // cellars). createdAt stays the original acquisition/added date.
+  addedToCellarAt: { type: Date, default: Date.now },
+  // Append-only journey across cellars (see cellarHistorySchema). Powers the
+  // per-bottle history timeline; each move pushes a new entry.
+  cellarHistory: { type: [cellarHistorySchema], default: [] },
   createdAt: {
     type: Date,
     default: Date.now

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -809,7 +809,14 @@ router.post('/:id/move', requireBottleAccess('owner'), async (req, res) => {
     }
 
     // Destination must be an active cellar the user OWNS (v1: own cellars only).
-    const destCellar = await Cellar.findOne({ _id: toCellarId, user: req.user.id, deletedAt: null });
+    // Cast the (already isValidObjectId-checked) id to an ObjectId so the query
+    // value can never be a user-supplied operator object (defence-in-depth + keeps
+    // static NoSQL-injection analysis happy).
+    const destCellar = await Cellar.findOne({
+      _id: new mongoose.Types.ObjectId(String(toCellarId)),
+      user: req.user.id,
+      deletedAt: null,
+    });
     if (!destCellar) return res.status(404).json({ error: 'Destination cellar not found' });
 
     const now = new Date();

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -418,6 +418,10 @@ router.post('/', async (req, res) => {
     // Allow backdating the "added" date for cellar migration
     if (dateAdded) bottle.createdAt = new Date(dateAdded);
 
+    // Seed the cellar journey: the bottle enters this cellar at its added date.
+    bottle.addedToCellarAt = bottle.createdAt;
+    bottle.cellarHistory = [{ cellar: cellarDoc._id, cellarName: cellarDoc.name, enteredAt: bottle.createdAt }];
+
     // Allow creating bottles directly as consumed (add to history)
     if (addToHistory) {
       const reason = consumedReason || 'drank';
@@ -781,6 +785,76 @@ router.post('/:id/consume', requireBottleAccess('editor'), async (req, res) => {
   } catch (error) {
     console.error('Consume bottle error:', error);
     res.status(500).json({ error: 'Failed to consume bottle' });
+  }
+});
+
+// POST /api/bottles/:id/move - Move an active bottle to another cellar you own.
+// v1: own-cellars-only + active bottles only; the bottle lands UNPLACED in the
+// destination (freed from any source rack slot). All bottle data is kept —
+// createdAt (acquisition date) is preserved; addedToCellarAt + cellarHistory are
+// updated. requireBottleAccess('owner') enforces you own the SOURCE cellar.
+router.post('/:id/move', requireBottleAccess('owner'), async (req, res) => {
+  try {
+    const { bottle, cellar: sourceCellar } = req;
+    const { toCellarId } = req.body;
+
+    if (!toCellarId || !mongoose.isValidObjectId(toCellarId)) {
+      return res.status(400).json({ error: 'Invalid destination cellar' });
+    }
+    if (String(toCellarId) === String(sourceCellar._id)) {
+      return res.status(400).json({ error: 'Bottle is already in that cellar' });
+    }
+    if (bottle.status !== 'active') {
+      return res.status(400).json({ error: 'Only active bottles can be moved' });
+    }
+
+    // Destination must be an active cellar the user OWNS (v1: own cellars only).
+    const destCellar = await Cellar.findOne({ _id: toCellarId, user: req.user.id, deletedAt: null });
+    if (!destCellar) return res.status(404).json({ error: 'Destination cellar not found' });
+
+    const now = new Date();
+    // Backfill the origin entry for bottles created before cellarHistory existed
+    // (or imported), so the journey reads "added → moved", not just "moved".
+    if (bottle.cellarHistory.length === 0) {
+      bottle.cellarHistory.push({
+        cellar: sourceCellar._id, cellarName: sourceCellar.name,
+        enteredAt: bottle.addedToCellarAt || bottle.createdAt
+      });
+    }
+    bottle.cellar = destCellar._id;
+    bottle.addedToCellarAt = now;
+    bottle.cellarHistory.push({ cellar: destCellar._id, cellarName: destCellar.name, enteredAt: now });
+    // Commit the move FIRST — if it hits an optimistic-concurrency conflict the
+    // source rack is still untouched, so we never orphan a slot.
+    await bottle.save();
+
+    // Now free the bottle from its old rack slot — it arrives unplaced. A failure
+    // here would only leave a stale slot that self-heals on the next rack render,
+    // never a bottle knocked out of its rack while still in the old cellar.
+    await removeFromRacks(bottle._id);
+
+    // Re-index so search reflects the new cellar.
+    searchService.indexBottle(bottle._id);
+    await bottle.populate(WINE_POPULATE);
+
+    // Audit BOTH cellars so the move is followable from either side's audit log.
+    const wineName = bottle.wineDefinition?.name;
+    logAudit(req, 'bottle.move.out',
+      { type: 'bottle', id: bottle._id, cellarId: sourceCellar._id },
+      { toCellarId: destCellar._id, toCellarName: destCellar.name, wineName, vintage: bottle.vintage }
+    );
+    logAudit(req, 'bottle.move.in',
+      { type: 'bottle', id: bottle._id, cellarId: destCellar._id },
+      { fromCellarId: sourceCellar._id, fromCellarName: sourceCellar.name, wineName, vintage: bottle.vintage }
+    );
+
+    res.json({ bottle });
+  } catch (error) {
+    if (error.name === 'VersionError') {
+      return res.status(409).json({ error: 'This bottle was modified by another request. Please refresh and try again.' });
+    }
+    console.error('Move bottle error:', error);
+    res.status(500).json({ error: 'Failed to move bottle' });
   }
 });
 

--- a/backend/src/scripts/backfill-cellar-history.js
+++ b/backend/src/scripts/backfill-cellar-history.js
@@ -1,0 +1,76 @@
+/**
+ * backfill-cellar-history.js
+ *
+ * One-off backfill for the "move bottles between cellars" feature: seed
+ * Bottle.cellarHistory (and addedToCellarAt) for bottles that predate the field.
+ *
+ * Each such bottle gets a single journey entry for its current cellar, dated at
+ * its added date (we can't reconstruct past moves), so the per-bottle history
+ * timeline reads "Added to <cellar> on <date>" instead of being empty. The move
+ * endpoint also backfills the origin entry on first move, so this migration is a
+ * convenience, not a correctness requirement.
+ *
+ * Behaviour:
+ *   - DRY-RUN by default; pass --apply to write.
+ *   - Idempotent: only touches bottles whose cellarHistory is missing/empty.
+ *
+ * Usage (containers must be running):
+ *   docker exec cellarion-backend node src/scripts/backfill-cellar-history.js          # dry run
+ *   docker exec cellarion-backend node src/scripts/backfill-cellar-history.js --apply
+ */
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const Bottle = require('../models/Bottle');
+const Cellar = require('../models/Cellar');
+
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar';
+const APPLY = new Set(process.argv.slice(2)).has('--apply');
+
+const FILTER = { $or: [{ cellarHistory: { $exists: false } }, { cellarHistory: { $size: 0 } }] };
+
+async function flush(ops) {
+  if (!ops.length || !APPLY) return 0;
+  const r = await Bottle.bulkWrite(ops, { ordered: false });
+  return r.modifiedCount || 0;
+}
+
+async function run() {
+  console.log('Connecting to MongoDB…');
+  await mongoose.connect(MONGO_URI);
+  console.log('Connected.\n');
+  console.log(APPLY ? 'Mode: APPLY (cellarHistory will be written)' : 'Mode: DRY RUN (no changes)');
+
+  const total = await Bottle.countDocuments(FILTER);
+  console.log(`Bottles needing a cellarHistory seed: ${total}`);
+  if (total === 0) { console.log('\nNothing to do.'); await mongoose.disconnect(); return; }
+
+  // cellarId -> name (include soft-deleted so the journey keeps a real name).
+  const cellars = await Cellar.find({}, 'name').lean();
+  const nameById = new Map(cellars.map((c) => [c._id.toString(), c.name]));
+
+  let processed = 0, updated = 0, ops = [];
+  const cursor = Bottle.find(FILTER).select('_id cellar createdAt addedToCellarAt').lean().cursor();
+  for (let b = await cursor.next(); b != null; b = await cursor.next()) {
+    processed++;
+    const enteredAt = b.addedToCellarAt || b.createdAt || new Date();
+    const cellarName = nameById.get(b.cellar?.toString()) || '';
+    ops.push({
+      updateOne: {
+        filter: { _id: b._id },
+        update: { $set: { addedToCellarAt: enteredAt, cellarHistory: [{ cellar: b.cellar, cellarName, enteredAt }] } },
+      },
+    });
+    if (ops.length >= 500) { updated += await flush(ops); ops = []; }
+    if (processed % 2000 === 0) console.log(`  …scanned ${processed}/${total}`);
+  }
+  updated += await flush(ops);
+
+  console.log(`\nScanned:                 ${processed}`);
+  console.log(`${APPLY ? 'Updated' : 'Would update'}:  ${APPLY ? updated : processed}`);
+  if (!APPLY) console.log('\n(dry run — pass --apply to write)');
+  console.log('\nDone.');
+  await mongoose.disconnect();
+}
+
+run().catch((err) => { console.error('Backfill failed:', err); process.exit(1); });

--- a/backend/src/services/cellarExport.js
+++ b/backend/src/services/cellarExport.js
@@ -91,6 +91,17 @@ function mapBottlesForExport(bottles, racks, imagesByBottle = new Map(), reviews
       dateAdded: b.createdAt ? b.createdAt.toISOString().slice(0, 10) : undefined,
     };
 
+    // Cellar journey (added → moved between cellars). Cellar names + dates only —
+    // the cellar ObjectIds are instance-local and don't transfer — so the
+    // per-bottle history survives an export → import round-trip.
+    if (b.addedToCellarAt) item.addedToCellarAt = b.addedToCellarAt.toISOString();
+    if (Array.isArray(b.cellarHistory) && b.cellarHistory.length) {
+      item.cellarHistory = b.cellarHistory.map((h) => ({
+        cellarName: h.cellarName || '',
+        enteredAt: h.enteredAt ? h.enteredAt.toISOString() : undefined,
+      }));
+    }
+
     // User-entered pricing
     if (b.price != null) {
       item.price = b.price;

--- a/backend/src/services/cellarExport.test.js
+++ b/backend/src/services/cellarExport.test.js
@@ -75,6 +75,30 @@ describe('mapBottlesForExport', () => {
     expect(item).not.toHaveProperty('rackCol');
   });
 
+  test('exports the cellar journey (names + dates only) and addedToCellarAt', () => {
+    const bottles = [{
+      _id: oid('b1'), vintage: 'NV', wineDefinition: { name: 'W' },
+      addedToCellarAt: new Date('2026-03-05T00:00:00Z'),
+      cellarHistory: [
+        { cellar: oid('cA'), cellarName: 'Cellar A', enteredAt: new Date('2026-01-02T00:00:00Z') },
+        { cellar: oid('cB'), cellarName: 'Cellar B', enteredAt: new Date('2026-03-05T00:00:00Z') },
+      ],
+    }];
+    const [item] = mapBottlesForExport(bottles, []);
+    expect(item.addedToCellarAt).toBe('2026-03-05T00:00:00.000Z');
+    expect(item.cellarHistory).toEqual([
+      { cellarName: 'Cellar A', enteredAt: '2026-01-02T00:00:00.000Z' },
+      { cellarName: 'Cellar B', enteredAt: '2026-03-05T00:00:00.000Z' },
+    ]);
+    expect(item.cellarHistory[0]).not.toHaveProperty('cellar'); // instance-local id is dropped
+  });
+
+  test('omits journey fields when the bottle has none', () => {
+    const [item] = mapBottlesForExport([{ _id: oid('b1'), vintage: 'NV', wineDefinition: { name: 'W' } }], []);
+    expect(item).not.toHaveProperty('cellarHistory');
+    expect(item).not.toHaveProperty('addedToCellarAt');
+  });
+
   test('flags consumed bottles for the history importer', () => {
     const bottles = [{
       _id: oid('b1'),

--- a/backend/src/services/cellarImport.js
+++ b/backend/src/services/cellarImport.js
@@ -173,6 +173,8 @@ function exportBottleToItem(b) {
     rating: b.rating,
     ratingScale: b.ratingScale,
     dateAdded: b.dateAdded,
+    addedToCellarAt: b.addedToCellarAt,
+    cellarHistory: Array.isArray(b.cellarHistory) ? b.cellarHistory : undefined,
     addToHistory: !!b.addToHistory,
     consumedReason: b.consumedReason,
     consumedAt: b.consumedAt,
@@ -374,10 +376,17 @@ function buildBottle({ cellarId, ownerId, item, canonicalVintage, wineDefinition
     notes: stripHtml(item.notes),
   });
   if (item.dateAdded) bottle.createdAt = new Date(item.dateAdded);
-  // "In this cellar since" = the added date. cellarHistory is seeded by the
-  // backfill migration / on first move (avoids re-keying it through the
-  // overwrite staging-swap).
-  bottle.addedToCellarAt = bottle.createdAt;
+  // Restore the cellar journey from the export when present (names + dates only —
+  // no live cellar refs, which is all the timeline needs, and keeps it clear of
+  // the overwrite staging-swap). Otherwise seed "in this cellar since = added date";
+  // cellarHistory is then filled by the first move / the backfill migration.
+  if (item.addedToCellarAt) bottle.addedToCellarAt = new Date(item.addedToCellarAt);
+  else bottle.addedToCellarAt = bottle.createdAt;
+  if (Array.isArray(item.cellarHistory) && item.cellarHistory.length) {
+    bottle.cellarHistory = item.cellarHistory
+      .filter((h) => h && h.cellarName)
+      .map((h) => ({ cellarName: String(h.cellarName).slice(0, 200), enteredAt: h.enteredAt ? new Date(h.enteredAt) : undefined }));
+  }
   return bottle;
 }
 

--- a/backend/src/services/cellarImport.js
+++ b/backend/src/services/cellarImport.js
@@ -374,6 +374,10 @@ function buildBottle({ cellarId, ownerId, item, canonicalVintage, wineDefinition
     notes: stripHtml(item.notes),
   });
   if (item.dateAdded) bottle.createdAt = new Date(item.dateAdded);
+  // "In this cellar since" = the added date. cellarHistory is seeded by the
+  // backfill migration / on first move (avoids re-keying it through the
+  // overwrite staging-swap).
+  bottle.addedToCellarAt = bottle.createdAt;
   return bottle;
 }
 

--- a/backend/src/services/cellarImport.test.js
+++ b/backend/src/services/cellarImport.test.js
@@ -198,6 +198,14 @@ describe('exportBottleToItem', () => {
     expect(item.reviews).toEqual(reviews);
   });
 
+  test('carries the cellar journey through (addedToCellarAt + cellarHistory)', () => {
+    const cellarHistory = [{ cellarName: 'A', enteredAt: '2026-01-02T00:00:00.000Z' }, { cellarName: 'B', enteredAt: '2026-03-05T00:00:00.000Z' }];
+    const item = exportBottleToItem({ wineName: 'W', addedToCellarAt: '2026-03-05T00:00:00.000Z', cellarHistory });
+    expect(item.addedToCellarAt).toBe('2026-03-05T00:00:00.000Z');
+    expect(item.cellarHistory).toEqual(cellarHistory);
+    expect(exportBottleToItem({ wineName: 'W' }).cellarHistory).toBeUndefined();
+  });
+
   test('carries the maturity window through, defaulting to null when absent', () => {
     const maturity = { peakFrom: 2026, peakUntil: 2032, sommNotes: 'hold' };
     expect(exportBottleToItem({ wineName: 'W', maturity }).maturity).toEqual(maturity);

--- a/frontend/src/api/bottles.js
+++ b/frontend/src/api/bottles.js
@@ -37,6 +37,13 @@ export const undoBottle = (apiFetch, id) =>
     method: 'POST',
   });
 
+export const moveBottle = (apiFetch, id, toCellarId) =>
+  apiFetch(`/api/bottles/${id}/move`, {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ toCellarId }),
+  });
+
 export const updateConsumedRating = (apiFetch, id, data) =>
   apiFetch(`/api/bottles/${id}/consumed-rating`, {
     method: 'PUT',

--- a/frontend/src/components/BottleJourney.js
+++ b/frontend/src/components/BottleJourney.js
@@ -1,0 +1,61 @@
+import { useTranslation } from 'react-i18next';
+
+function fmtDate(d) {
+  if (!d) return '';
+  return new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+const CONSUMED_LABEL_KEYS = {
+  drank:  'history.reasonDrank',
+  gifted: 'history.reasonGifted',
+  sold:   'history.reasonSold',
+  other:  'history.reasonOther',
+};
+
+/**
+ * Per-bottle journey timeline: "Added to A → Moved to B → Drank". Built from the
+ * bottle's cellarHistory (seeded on add, appended on each move) plus the consumed
+ * fields. Falls back to a single "added" entry when history isn't seeded yet.
+ */
+export default function BottleJourney({ bottle }) {
+  const { t } = useTranslation();
+  if (!bottle) return null;
+
+  const history = Array.isArray(bottle.cellarHistory) && bottle.cellarHistory.length
+    ? bottle.cellarHistory
+    : [{ cellarName: bottle.cellar?.name || bottle.cellarName, enteredAt: bottle.addedToCellarAt || bottle.createdAt }];
+
+  const items = history.map((h, i) => ({
+    key: `c${i}`,
+    icon: i === 0 ? '➕' : '📦',
+    text: i === 0
+      ? t('history.journey.added', { cellar: h.cellarName || '—' })
+      : t('history.journey.moved', { cellar: h.cellarName || '—' }),
+    date: h.enteredAt,
+  }));
+
+  if (bottle.status && bottle.status !== 'active') {
+    const reasonKey = CONSUMED_LABEL_KEYS[bottle.consumedReason] || CONSUMED_LABEL_KEYS[bottle.status];
+    items.push({
+      key: 'consumed',
+      icon: '🍷',
+      text: reasonKey ? t(reasonKey) : bottle.status,
+      date: bottle.consumedAt,
+    });
+  }
+
+  return (
+    <section className="bottle-journey">
+      <h3 className="bottle-journey-title">{t('history.journey.title')}</h3>
+      <ul className="bottle-journey-list">
+        {items.map((it) => (
+          <li key={it.key} className="bottle-journey-item">
+            <span className="bottle-journey-icon" aria-hidden="true">{it.icon}</span>
+            <span className="bottle-journey-text">{it.text}</span>
+            {it.date && <span className="bottle-journey-date">{fmtDate(it.date)}</span>}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/BottleJourney.test.js
+++ b/frontend/src/components/BottleJourney.test.js
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import BottleJourney from './BottleJourney';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, opts) => {
+      if (key === 'history.journey.title') return 'History';
+      if (key === 'history.journey.added') return `Added to ${opts.cellar}`;
+      if (key === 'history.journey.moved') return `Moved to ${opts.cellar}`;
+      if (key === 'history.reasonDrank') return 'Drank';
+      return key;
+    },
+  }),
+}));
+
+describe('BottleJourney', () => {
+  test('renders the added → moved timeline from cellarHistory', () => {
+    const bottle = {
+      status: 'active',
+      cellarHistory: [
+        { cellarName: 'Cellar A', enteredAt: '2026-01-02' },
+        { cellarName: 'Cellar B', enteredAt: '2026-03-05' },
+      ],
+    };
+    render(<BottleJourney bottle={bottle} />);
+    expect(screen.getByText('Added to Cellar A')).toBeInTheDocument();
+    expect(screen.getByText('Moved to Cellar B')).toBeInTheDocument();
+  });
+
+  test('appends a consumed entry for history bottles', () => {
+    const bottle = {
+      status: 'drank', consumedReason: 'drank', consumedAt: '2026-06-01',
+      cellarHistory: [{ cellarName: 'Cellar A', enteredAt: '2026-01-02' }],
+    };
+    render(<BottleJourney bottle={bottle} />);
+    expect(screen.getByText('Added to Cellar A')).toBeInTheDocument();
+    expect(screen.getByText('Drank')).toBeInTheDocument();
+  });
+
+  test('falls back to a single added entry when history is empty', () => {
+    const bottle = { status: 'active', cellarHistory: [], createdAt: '2026-01-02', cellar: { name: 'Cellar X' } };
+    render(<BottleJourney bottle={bottle} />);
+    expect(screen.getByText('Added to Cellar X')).toBeInTheDocument();
+  });
+
+  test('renders nothing without a bottle', () => {
+    const { container } = render(<BottleJourney bottle={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/MoveBottleModal.js
+++ b/frontend/src/components/MoveBottleModal.js
@@ -1,0 +1,112 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import { listCellars } from '../api/cellars';
+import { moveBottle } from '../api/bottles';
+import Modal from './Modal';
+
+/**
+ * Move a single active bottle to another cellar the user OWNS (v1). The bottle's
+ * data and history are kept; it arrives unplaced in the destination. Calls
+ * onMoved(destCellarId) on success so the caller can navigate to the new home.
+ */
+export default function MoveBottleModal({ bottleId, currentCellarId, wineLabel, onClose, onMoved }) {
+  const { t } = useTranslation();
+  const { apiFetch } = useAuth();
+  const [cellars, setCellars] = useState(null); // null while loading
+  const [target, setTarget] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [movedTo, setMovedTo] = useState(null); // dest cellar name once the move succeeds
+
+  useEffect(() => {
+    let active = true;
+    listCellars(apiFetch)
+      .then((r) => r.json())
+      .then((data) => {
+        if (!active) return;
+        // v1: only cellars the user owns, excluding the current one and any soft-deleted.
+        const owned = (data.cellars || []).filter(
+          (c) => c.userRole === 'owner' && c.deletedAt == null && String(c._id) !== String(currentCellarId)
+        );
+        setCellars(owned);
+      })
+      .catch(() => { if (active) { setCellars([]); setError(t('moveBottle.loadError')); } });
+    return () => { active = false; };
+  }, [apiFetch, currentCellarId, t]);
+
+  const handleMove = async () => {
+    if (!target || submitting) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const res = await moveBottle(apiFetch, bottleId, target);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || t('moveBottle.moveError'));
+      // Show a brief confirmation instead of jumping to the destination cellar.
+      const destName = (cellars || []).find((c) => String(c._id) === String(target))?.name || '';
+      setMovedTo(destName);
+    } catch (e) {
+      setError(e.message || t('moveBottle.moveError'));
+      setSubmitting(false);
+    }
+  };
+
+  // Success view — confirm the move, then return to the cellar we came from.
+  if (movedTo !== null) {
+    return (
+      <Modal title={t('moveBottle.movedTitle')} onClose={onMoved} showClose trapFocus>
+        <p className="move-bottle-success">{t('moveBottle.movedInfo', { cellar: movedTo })}</p>
+        <div className="modal-actions">
+          <button type="button" className="btn btn-primary" onClick={onMoved}>
+            {t('moveBottle.backToCellar')}
+          </button>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal title={t('moveBottle.title')} onClose={onClose} showClose trapFocus>
+      {wineLabel && <p className="move-bottle-wine"><strong>{wineLabel}</strong></p>}
+      <p>{t('moveBottle.intro')}</p>
+
+      {cellars === null ? (
+        <p className="loading">{t('moveBottle.loading')}</p>
+      ) : cellars.length === 0 ? (
+        <p className="empty-state">{t('moveBottle.noOtherCellars')}</p>
+      ) : (
+        <label className="move-bottle-field">
+          <span>{t('moveBottle.destinationLabel')}</span>
+          <select
+            className="form-select"
+            value={target}
+            onChange={(e) => setTarget(e.target.value)}
+            disabled={submitting}
+          >
+            <option value="">{t('moveBottle.selectCellar')}</option>
+            {cellars.map((c) => (
+              <option key={c._id} value={c._id}>{c.name}</option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {error && <p className="error-message" role="alert">{error}</p>}
+
+      <div className="modal-actions">
+        <button type="button" className="btn btn-secondary" onClick={onClose} disabled={submitting}>
+          {t('common.cancel')}
+        </button>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={handleMove}
+          disabled={submitting || !target}
+        >
+          {submitting ? t('moveBottle.moving') : t('moveBottle.moveButton')}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -597,6 +597,11 @@
     "reasonGifted": "Gifted",
     "reasonSold": "Sold",
     "reasonOther": "Other",
+    "journey": {
+      "title": "History",
+      "added": "Added to {{cellar}}",
+      "moved": "Moved to {{cellar}}"
+    },
     "vintageLabel": "Vintage:",
     "paidLabel": "Paid:",
     "atConsumption": "at consumption",
@@ -617,11 +622,30 @@
       "bottleUpdate": "Updated bottle",
       "bottleConsume": "Consumed bottle",
       "bottleDelete": "Deleted bottle",
+      "bottleMoveOut": "Moved bottle out",
+      "bottleMoveIn": "Moved bottle in",
       "cellarDelete": "Deleted cellar",
       "cellarShareAdd": "Shared cellar",
       "cellarShareUpdate": "Changed share role",
       "cellarShareRemove": "Removed share"
     }
+  },
+
+  "moveBottle": {
+    "action": "Move to another cellar",
+    "title": "Move to another cellar",
+    "intro": "Choose a cellar to move this bottle to. All its details and history are kept — it will arrive unplaced.",
+    "destinationLabel": "Destination cellar",
+    "selectCellar": "Select a cellar…",
+    "noOtherCellars": "You don't have another cellar to move this to.",
+    "moveButton": "Move bottle",
+    "moving": "Moving…",
+    "loading": "Loading cellars…",
+    "loadError": "Couldn't load your cellars.",
+    "moveError": "Couldn't move the bottle. Please try again.",
+    "movedTitle": "Bottle moved",
+    "movedInfo": "This bottle was moved to {{cellar}}.",
+    "backToCellar": "Back to cellar"
   },
 
   "admin": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -597,6 +597,11 @@
     "reasonGifted": "Bortgiven",
     "reasonSold": "Såld",
     "reasonOther": "Övrigt",
+    "journey": {
+      "title": "Historik",
+      "added": "Tillagd i {{cellar}}",
+      "moved": "Flyttad till {{cellar}}"
+    },
     "vintageLabel": "Årgång:",
     "paidLabel": "Betalt:",
     "atConsumption": "vid drickning",
@@ -617,11 +622,30 @@
       "bottleUpdate": "Flaska uppdaterad",
       "bottleConsume": "Flaska konsumerad",
       "bottleDelete": "Flaska borttagen",
+      "bottleMoveOut": "Flaska flyttad ut",
+      "bottleMoveIn": "Flaska flyttad in",
       "cellarDelete": "Källare borttagen",
       "cellarShareAdd": "Källare delad",
       "cellarShareUpdate": "Delningsroll ändrad",
       "cellarShareRemove": "Delning borttagen"
     }
+  },
+
+  "moveBottle": {
+    "action": "Flytta till en annan källare",
+    "title": "Flytta till en annan källare",
+    "intro": "Välj en källare att flytta den här flaskan till. Alla detaljer och historik behålls — den hamnar oplacerad.",
+    "destinationLabel": "Målkällare",
+    "selectCellar": "Välj en källare…",
+    "noOtherCellars": "Du har ingen annan källare att flytta den till.",
+    "moveButton": "Flytta flaska",
+    "moving": "Flyttar…",
+    "loading": "Laddar källare…",
+    "loadError": "Kunde inte ladda dina källare.",
+    "moveError": "Kunde inte flytta flaskan. Försök igen.",
+    "movedTitle": "Flaska flyttad",
+    "movedInfo": "Den här flaskan flyttades till {{cellar}}.",
+    "backToCellar": "Tillbaka till källaren"
   },
 
   "admin": {

--- a/frontend/src/pages/BottleDetail.css
+++ b/frontend/src/pages/BottleDetail.css
@@ -1287,3 +1287,42 @@
   margin-right: 0.35rem;
 }
 
+
+/* ── Bottle journey: discreet history footer at the bottom of the bottle info ── */
+.bottle-journey {
+  max-width: 640px;
+  margin: 0.5rem auto 1.5rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--color-border-light, var(--color-border, #eee));
+}
+.bottle-journey-title {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted, #999);
+  margin: 0 0 0.6rem;
+}
+.bottle-journey-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.bottle-journey-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+.bottle-journey-icon { font-size: 0.78rem; opacity: 0.7; flex-shrink: 0; }
+.bottle-journey-text { color: var(--color-text-secondary, #666); }
+.bottle-journey-date {
+  margin-left: auto;
+  font-size: 0.74rem;
+  color: var(--color-text-muted, #999);
+  white-space: nowrap;
+}

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -18,10 +18,12 @@ import HeroImage from '../components/bottle/HeroImage';
 import ConsumedDetails from '../components/bottle/ConsumedDetails';
 import EditForm from '../components/bottle/EditForm';
 import ViewDetails from '../components/bottle/ViewDetails';
+import BottleJourney from '../components/BottleJourney';
 import './BottleDetail.css';
 
 // Lazy-load heavy components only needed on user interaction
 const ReportWineModal = lazy(() => import('../components/ReportWineModal'));
+const MoveBottleModal = lazy(() => import('../components/MoveBottleModal'));
 const ReviewForm = lazy(() => import('../components/ReviewForm'));
 const ConsumeModal = lazy(() => import('../components/ConsumeModal').then(m => ({ default: m.ConsumeModal })));
 const SuggestGrapesModal = lazy(() => import('../components/SuggestGrapesModal').then(m => ({ default: m.SuggestGrapesModal })));
@@ -48,6 +50,7 @@ function BottleDetail() {
   const [error, setError] = useState(null);
   const [editing, setEditing] = useState(false);
   const [consumeOpen, setConsumeOpen] = useState(false);
+  const [moveOpen, setMoveOpen] = useState(false);
   const [mistakeOpen, setMistakeOpen] = useState(false);
   const [mistakeBusy, setMistakeBusy] = useState(false);
   const [suggestGrapesOpen, setSuggestGrapesOpen] = useState(false);
@@ -266,6 +269,13 @@ function BottleDetail() {
   const isConsumed = bottle?.status && bottle.status !== 'active';
   const canEdit = !isConsumed && (userRole === 'owner' || userRole === 'editor');
   const canEditConsumed = isConsumed && (userRole === 'owner' || userRole === 'editor');
+  // v1: move only active bottles, and only between cellars you own.
+  const canMove = !isConsumed && userRole === 'owner';
+
+  const handleMoved = () => {
+    setMoveOpen(false);
+    navigate(`/cellars/${cellarId}`); // stay with the source cellar — back to its list
+  };
 
   return (
     <div className="bottle-detail-page">
@@ -289,6 +299,12 @@ function BottleDetail() {
                     <span className="bd-btn-label">{t('bottleDetail.removeBottle')}</span>
                   </button>
                 </>
+              )}
+              {canMove && (
+                <button className="btn btn-secondary btn-small" onClick={() => setMoveOpen(true)}>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M5 9l-3 3 3 3"/><path d="M9 5l3-3 3 3"/><path d="M15 19l-3 3-3-3"/><path d="M19 9l3 3-3 3"/><path d="M2 12h20"/><path d="M12 2v20"/></svg>
+                  <span className="bd-btn-label">{t('moveBottle.action')}</span>
+                </button>
               )}
             </div>
           )}
@@ -571,6 +587,9 @@ function BottleDetail() {
         </div>
       )}
 
+      {/* ── Cellar journey: discreet history footer (added → moved → consumed) ── */}
+      {!editing && <BottleJourney bottle={bottle} />}
+
       <Suspense fallback={null}>
         {consumeOpen && (
           <ConsumeModal
@@ -578,6 +597,16 @@ function BottleDetail() {
             defaultRatingScale={user?.preferences?.ratingScale || '5'}
             onConfirm={handleConsumeConfirm}
             onCancel={() => setConsumeOpen(false)}
+          />
+        )}
+
+        {moveOpen && bottle && (
+          <MoveBottleModal
+            bottleId={bottle._id}
+            currentCellarId={cellarId}
+            wineLabel={displayName}
+            onClose={() => setMoveOpen(false)}
+            onMoved={handleMoved}
           />
         )}
 

--- a/frontend/src/pages/CellarAudit.js
+++ b/frontend/src/pages/CellarAudit.js
@@ -16,6 +16,8 @@ const ACTION_LABEL_KEYS = {
   'bottle.update':       'cellarAudit.actions.bottleUpdate',
   'bottle.consume':      'cellarAudit.actions.bottleConsume',
   'bottle.delete':       'cellarAudit.actions.bottleDelete',
+  'bottle.move.out':     'cellarAudit.actions.bottleMoveOut',
+  'bottle.move.in':      'cellarAudit.actions.bottleMoveIn',
   'cellar.delete':       'cellarAudit.actions.cellarDelete',
   'cellar.share.add':    'cellarAudit.actions.cellarShareAdd',
   'cellar.share.update': 'cellarAudit.actions.cellarShareUpdate',
@@ -27,6 +29,8 @@ const ACTION_ICONS = {
   'bottle.update':       '✏️',
   'bottle.consume':      '🍷',
   'bottle.delete':       '🗑️',
+  'bottle.move.out':     '📤',
+  'bottle.move.in':      '📥',
   'cellar.delete':       '🗑️',
   'cellar.share.add':    '🔗',
   'cellar.share.update': '🔄',
@@ -50,6 +54,12 @@ function formatDetail(action, detail) {
   }
   if (action === 'bottle.consume' && detail.reason) {
     return detail.reason;
+  }
+  if (action === 'bottle.move.out' || action === 'bottle.move.in') {
+    const wine = detail.wineName ? `${detail.wineName}${detail.vintage ? ` · ${detail.vintage}` : ''} ` : '';
+    return action === 'bottle.move.out'
+      ? `${wine}→ ${detail.toCellarName || '—'}`
+      : `${wine}← ${detail.fromCellarName || '—'}`;
   }
   if (action === 'cellar.share.add') {
     return `${detail.sharedWith} as ${detail.role}`;


### PR DESCRIPTION
## Summary
Move a single **active** bottle to **another cellar you own** (v1), keeping all its data, plus a per-bottle journey timeline. Built and verified end-to-end in Docker; reviewed adversarially (findings folded in).

## What it does
- **Move endpoint** `POST /api/bottles/:id/move` — `requireBottleAccess('owner')`; destination must be an active cellar you own; **active bottles only**. The bottle arrives **unplaced** (freed from its source rack slot). `createdAt` is preserved; `addedToCellarAt` + a new `cellarHistory[]` are updated.
- **Audited in both cellars** — `bottle.move.out` (source) and `bottle.move.in` (destination), so the move shows in each cellar's **Audit** log with labels/icons/detail.
- **BottleDetail UI** — owner-only "Move to another cellar" button → destination picker. On success it shows a confirmation and **returns you to the cellar you came from** (does not jump to the destination).
- **Per-bottle journey** — a discreet "History" timeline (*added → moved → consumed*) at the bottom of the bottle page.
- **Data model** — `cellarHistory` seeded on create and import; `backfill-cellar-history.js` migration for existing bottles. Bilingual (en/sv). Unit test for the journey.

## Review fixes baked in
- Save the move **before** freeing the rack slot (a concurrency conflict can't orphan a slot); `VersionError → 409` (parity with the edit endpoint).
- Journey i18n keys corrected (`history.journey.*` / `history.reason*`).

## Verified (Docker)
- Move A→B: cellar updated, `cellarHistory` = `[A, B]`, purchase data kept, `createdAt` preserved while `addedToCellarAt` advanced, rack slot freed, `move.out`/`move.in` in the respective audits.
- Rejections: same-cellar 400, non-owned 404, invalid 400, missing 400, **consumed 400**.
- Migration backfilled existing bottles. Backend suite 764 green; journey unit test 4/4.

## Post-deploy
Run `node src/scripts/backfill-cellar-history.js --apply` so existing bottles get an "Added to …" entry.

## Out of scope (v2)
Multi-select bulk move; moving into shared cellars / ownership transfer; round-tripping the journey through cellar export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
