### PR TITLE
chore(release): v1.67.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Move a bottle between your cellars + per-bottle journey (#552). Publishing the v1.67.0 Release builds & pushes the Docker images.