### PR TITLE
chore(release): v1.67.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Security patch release: bump vulnerable dependencies (Dependabot). Publishing the v1.67.1 Release builds & pushes the Docker images.