### PR TITLE
feat: flat daily Cellar Chat limit + donation-only Supporter page

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ The AI chat feature requires three services working together:
 
 When all three are configured, users can ask natural-language questions about their collection (food pairings, occasion picks, cellar insights). The system only surfaces wines the user actually owns — no hallucinated recommendations.
 
-Daily usage quotas are configurable per subscription plan.
+A single daily usage quota — the same for every user, regardless of plan — is configurable by SuperAdmins (default 50 questions/day).
 
 ### Email Verification
 

--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -14,7 +14,8 @@
  * chatMaxResults       – max wines shown in the final AI answer
  * embeddingBatchDelayMs– ms to sleep between embedding calls during batch jobs
  *                        (helps stay within Voyage free-tier 3 RPM)
- * chatDailyLimits      – max questions per user per day, keyed by plan name
+ * chatDailyLimit       – max Cellar Chat questions per user per day (applies to
+ *                        everyone; -1 = unlimited)
  * chatSystemPrompt     – system prompt sent to Claude on every chat request
  * chatModelFallback    – model to retry with on 529 overloaded (null = no fallback)
  */
@@ -279,7 +280,7 @@ const defaults = {
   chatMaxTokens: 800,
   chatMaxHistoryTurns: 10,
   embeddingBatchDelayMs: 500,
-  chatDailyLimits: { free: 5, supporter: 50, patron: -1 },
+  chatDailyLimit: 50,
   chatModel: 'claude-haiku-4-5-20251001',
   chatModelFallback: null,
   chatSystemPrompt: DEFAULT_SYSTEM_PROMPT,
@@ -314,7 +315,7 @@ async function load() {
         chatMaxTokens:         doc.value.chatMaxTokens        ?? defaults.chatMaxTokens,
         chatMaxHistoryTurns:   doc.value.chatMaxHistoryTurns  ?? defaults.chatMaxHistoryTurns,
         embeddingBatchDelayMs: doc.value.embeddingBatchDelayMs ?? defaults.embeddingBatchDelayMs,
-        chatDailyLimits:       doc.value.chatDailyLimits      ?? defaults.chatDailyLimits,
+        chatDailyLimit:        doc.value.chatDailyLimit       ?? defaults.chatDailyLimit,
         chatModel:             VALID_CHAT_MODELS.includes(doc.value.chatModel) ? doc.value.chatModel : defaults.chatModel,
         chatModelFallback:     VALID_CHAT_MODELS.includes(doc.value.chatModelFallback) ? doc.value.chatModelFallback : defaults.chatModelFallback,
         chatSystemPrompt:      doc.value.chatSystemPrompt     ?? defaults.chatSystemPrompt,

--- a/backend/src/config/plans.js
+++ b/backend/src/config/plans.js
@@ -1,20 +1,18 @@
 /**
  * Supporter tier definitions for Cellarion.
  *
- * All tiers have full access to every feature. The only difference is
- * the Cellar Chat quota.
+ * Every tier is functionally identical — all features (including the daily
+ * Cellar Chat allowance, see aiConfig.chatDailyLimit) are free for everyone.
+ * The paid tiers are purely voluntary donations to fund development; they
+ * unlock nothing extra.
  *
- * chatQuota:  max chat questions per rolling window; -1 = unlimited
- * chatPeriod: 'daily' | 'weekly' — rolling window size for the quota
- * price:      monthly price in USD (0 = free)
+ * price: monthly price in USD (0 = free)
  */
 const PLANS = {
   free: {
     label: 'Enthusiast',
     description: 'Full access to every feature — completely free.',
     price: 0,
-    chatQuota: 5,
-    chatPeriod: 'weekly',
     featureList: [
       'Unlimited cellars & shared members',
       'Bottle tracking (vintages, ratings, notes)',
@@ -26,31 +24,27 @@ const PLANS = {
       'Drink-window alerts',
       'Rack management',
       'Wine requests',
-      'Cellar Chat (5 questions / week)',
+      'Cellar Chat',
     ],
   },
   supporter: {
     label: 'Supporter',
-    description: 'Support Cellarion and get more Cellar Chat.',
+    description: 'Chip in to help fund development — no extra features, just our thanks.',
     price: 1.5,
-    chatQuota: 50,
-    chatPeriod: 'daily',
     featureList: [
-      'Everything in Enthusiast',
-      'Cellar Chat (50 questions / day)',
+      'Everything in Enthusiast (all features are free)',
       'Support independent development',
+      'Our heartfelt thanks',
     ],
   },
   patron: {
     label: 'Patron',
-    description: 'Maximum support with unlimited Cellar Chat.',
+    description: 'Support Cellarion at a higher level — no extra features, just bigger thanks.',
     price: 5.5,
-    chatQuota: -1,
-    chatPeriod: 'daily',
     featureList: [
-      'Everything in Supporter',
-      'Cellar Chat (unlimited)',
-      'Priority support',
+      'Everything in Enthusiast (all features are free)',
+      'Support independent development even more',
+      'Our heartfelt thanks',
     ],
   },
 };

--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -18,8 +18,8 @@ const defaults = {
     emailDedupMs: 60 * 60 * 1000,   // send at most one lockout email per hour
   },
   // Per-user burst limit on /api/chat — protects Anthropic budget against
-  // scripted abuse from inside a single user's tier-quota allowance. The
-  // tier quota (config/plans.js chatQuota) is the cap; this is the speed
+  // scripted abuse from inside a single user's daily-quota allowance. The
+  // daily quota (aiConfig.chatDailyLimit) is the cap; this is the speed
   // limit. Default 5 chats/min/user is generous for human use and catches
   // scripted bursts.
   chatBurst: { max: 5, windowMs: 60 * 1000 },

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -1,14 +1,13 @@
 /**
  * Cellar Chat routes.
  *
- * POST /api/chat         – ask a question (non-streaming); rate-limited by supporter tier quota
+ * POST /api/chat         – ask a question (non-streaming); rate-limited by the daily quota
  * POST /api/chat/stream  – ask a question (streaming SSE); same rate limiting
  * GET  /api/chat/usage   – return current usage + limit for the current user
  *
- * All tiers use a rolling 7-day window:
- *   Enthusiast (free): 5 questions / week
- *   Supporter:         50 questions / week
- *   Patron:            unlimited
+ * Every user gets the same daily allowance, regardless of plan: a single global
+ * limit (aiConfig.chatDailyLimit, default 50/day, -1 = unlimited) over a rolling
+ * UTC-day window. Tuned by SuperAdmin via PATCH /api/superadmin/ai/chat-limit.
  */
 
 const express = require('express');
@@ -20,7 +19,6 @@ const aiChat = require('../services/aiChat');
 const aiConfig = require('../config/aiConfig');
 const ChatUsage = require('../models/ChatUsage');
 const User = require('../models/User');
-const { getPlanConfig } = require('../config/plans');
 const { logAudit } = require('../services/audit');
 const rateLimitsConfig = require('../config/rateLimits');
 const { ConcurrentStreamLimiter } = require('../utils/concurrentStreams');
@@ -28,10 +26,10 @@ const { ConcurrentStreamLimiter } = require('../utils/concurrentStreams');
 const router = express.Router();
 
 // ── Per-user chat protections ────────────────────────────────────────────────
-// The tier-based weekly chatQuota (config/plans.js) is the SPEND cap.
+// The global daily chat limit (aiConfig.chatDailyLimit) is the SPEND cap.
 // These two limits are about BURST behaviour within that cap — they catch
 // scripted abuse (5 chats in 5 seconds; 50 concurrent SSE streams) that the
-// weekly quota can't react to fast enough to bound Anthropic spend.
+// daily quota can't react to fast enough to bound Anthropic spend.
 
 // Burst limit: at most N chats per user per minute. Keyed on req.user.id so
 // it survives IP rotation. Per-IP apiLimiter still runs alongside.
@@ -58,32 +56,23 @@ function todayUTC() {
   return new Date().toISOString().slice(0, 10);
 }
 
-// Returns the UTC date string for N days ago
-function daysAgoUTC(n) {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() - n);
-  return d.toISOString().slice(0, 10);
-}
-
 // Returns a Date set to 90 days from now (retained for usage reporting)
 function expiresAt() {
   return new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
 }
 
 /**
- * Returns { limit, used, period } for the given plan.
- * Window size depends on the plan's chatPeriod ('daily' or 'weekly').
- * Patron (-1) = unlimited.
+ * Returns { limit, used, period } for the current user.
+ * The same global daily limit applies to everyone (aiConfig.chatDailyLimit;
+ * -1 = unlimited) over a rolling UTC-day window.
  */
-async function getUsageForPlan(userId, plan) {
-  const config = getPlanConfig(plan);
-  const limit = config.chatQuota; // -1 = unlimited
-  const period = config.chatPeriod || 'weekly';
+async function getChatUsage(userId) {
+  const limit = aiConfig.get().chatDailyLimit; // -1 = unlimited
+  const period = 'daily';
 
-  const startDate = period === 'daily' ? daysAgoUTC(0) : daysAgoUTC(6);
   const docs = await ChatUsage.find({
     userId,
-    date: { $gte: startDate },
+    date: { $gte: todayUTC() },
   }).lean();
   const used = docs.reduce((sum, d) => sum + (d.count || 0), 0);
   return { limit, used, period };
@@ -129,9 +118,9 @@ async function validateAndCheckLimit(req, res) {
   const plan = req.user.plan || 'free';
   const date = todayUTC();
 
-  const { limit, used: usedBefore, period } = await getUsageForPlan(req.user.id, plan);
+  const { limit, used: usedBefore, period } = await getChatUsage(req.user.id);
 
-  // limit === -1 means unlimited (patron tier)
+  // limit === -1 means unlimited
   if (limit !== -1 && usedBefore >= limit) {
     res.status(429).json({
       error: `You've reached your ${period} limit of ${limit} question${limit === 1 ? '' : 's'}. Try again ${period === 'daily' ? 'tomorrow' : 'in a few days'}.`,
@@ -182,9 +171,8 @@ async function validateAndCheckLimit(req, res) {
 // ---------------------------------------------------------------------------
 router.get('/usage', requireAuth, async (req, res) => {
   try {
-    const plan = req.user.plan || 'free';
-    const { limit, used, period } = await getUsageForPlan(req.user.id, plan);
-    res.json({ used, limit, plan, period });
+    const { limit, used, period } = await getChatUsage(req.user.id);
+    res.json({ used, limit, plan: req.user.plan || 'free', period });
   } catch (err) {
     console.error('[chat] usage error:', err);
     res.status(500).json({ error: 'Failed to load usage' });

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -445,25 +445,24 @@ router.get('/ai', async (req, res) => {
 
 
 // ---------------------------------------------------------------------------
-// PATCH /api/superadmin/ai/chat-limits
-// Update per-plan daily chat limits stored in aiConfig
+// PATCH /api/superadmin/ai/chat-limit
+// Update the global daily Cellar Chat limit (questions per user per day).
+// Applies to every user regardless of plan. -1 = unlimited.
 // ---------------------------------------------------------------------------
-router.patch('/ai/chat-limits', async (req, res) => {
-  const { free, supporter, patron } = req.body;
-  const parse = (v) => parseInt(v, 10);
-  const vals = { free: parse(free), supporter: parse(supporter), patron: parse(patron) };
-  if (Object.values(vals).some(v => isNaN(v) || v < 0)) {
-    return res.status(400).json({ error: 'Each limit must be a non-negative integer' });
+router.patch('/ai/chat-limit', async (req, res) => {
+  const limit = parseInt(req.body.limit, 10);
+  if (!Number.isInteger(limit) || limit < -1) {
+    return res.status(400).json({ error: 'limit must be an integer of -1 (unlimited) or greater' });
   }
   try {
     const current = aiConfig.get();
-    const updated = { ...current, chatDailyLimits: vals };
+    const updated = { ...current, chatDailyLimit: limit };
     await updateSiteConfig('aiConfig', updated, req.user.id);
     aiConfig.set(updated);
-    res.json({ chatDailyLimits: vals });
+    res.json({ chatDailyLimit: limit });
   } catch (error) {
-    console.error('[superadmin] chat-limits error:', error);
-    res.status(500).json({ error: 'Failed to save chat limits' });
+    console.error('[superadmin] chat-limit error:', error);
+    res.status(500).json({ error: 'Failed to save chat limit' });
   }
 });
 

--- a/frontend/src/config/plans.js
+++ b/frontend/src/config/plans.js
@@ -3,16 +3,15 @@
  * Used to gate UI elements without extra API calls.
  * Keep in sync with the backend config.
  *
- * All tiers have full access to every feature. The only difference is
- * the Cellar Chat quota.
+ * Every tier is functionally identical — all features (including the daily
+ * Cellar Chat allowance) are free for everyone. The paid tiers are purely
+ * voluntary donations to fund development; they unlock nothing extra.
  */
 export const PLANS = {
   free: {
     label: 'Enthusiast',
     description: 'Full access to every feature — completely free.',
     price: 0,
-    chatQuota: 5,
-    chatPeriod: 'weekly',
     featureList: [
       'Unlimited cellars & shared members',
       'Bottle tracking (vintages, ratings, notes)',
@@ -24,31 +23,27 @@ export const PLANS = {
       'Drink-window alerts',
       'Rack management',
       'Wine requests',
-      'Cellar Chat (5 questions / week)',
+      'Cellar Chat',
     ],
   },
   supporter: {
     label: 'Supporter',
-    description: 'Support Cellarion and get more Cellar Chat.',
+    description: 'Chip in to help fund development — no extra features, just our thanks.',
     price: 1.5,
-    chatQuota: 50,
-    chatPeriod: 'daily',
     featureList: [
-      'Everything in Enthusiast',
-      'Cellar Chat (50 questions / day)',
+      'Everything in Enthusiast (all features are free)',
       'Support independent development',
+      'Our heartfelt thanks',
     ],
   },
   patron: {
     label: 'Patron',
-    description: 'Maximum support with unlimited Cellar Chat.',
+    description: 'Support Cellarion at a higher level — no extra features, just bigger thanks.',
     price: 5.5,
-    chatQuota: -1,
-    chatPeriod: 'daily',
     featureList: [
-      'Everything in Supporter',
-      'Cellar Chat (unlimited)',
-      'Priority support',
+      'Everything in Enthusiast (all features are free)',
+      'Support independent development even more',
+      'Our heartfelt thanks',
     ],
   },
 };
@@ -58,13 +53,4 @@ export const PLAN_NAMES = Object.keys(PLANS);
 /** Returns the plan config for the given plan name, falling back to 'free'. */
 export function getPlanConfig(plan) {
   return PLANS[plan] || PLANS.free;
-}
-
-/**
- * Returns a human-readable chat quota string.
- * e.g. formatChatQuota(5) => "5 / week", formatChatQuota(-1) => "Unlimited"
- */
-export function formatChatQuota(n, period = 'weekly') {
-  if (n === -1) return 'Unlimited';
-  return `${n} / ${period === 'daily' ? 'day' : 'week'}`;
 }

--- a/frontend/src/config/plans.test.js
+++ b/frontend/src/config/plans.test.js
@@ -2,7 +2,6 @@ import {
   PLANS,
   PLAN_NAMES,
   getPlanConfig,
-  formatChatQuota,
 } from './plans';
 
 // ---------------------------------------------------------------------------
@@ -27,21 +26,18 @@ describe('getPlanConfig', () => {
     const config = getPlanConfig('free');
     expect(config.label).toBe('Enthusiast');
     expect(config.price).toBe(0);
-    expect(config.chatQuota).toBe(5);
   });
 
   it('returns correct config for supporter tier', () => {
     const config = getPlanConfig('supporter');
     expect(config.label).toBe('Supporter');
     expect(config.price).toBe(1.5);
-    expect(config.chatQuota).toBe(50);
   });
 
   it('returns correct config for patron tier', () => {
     const config = getPlanConfig('patron');
     expect(config.label).toBe('Patron');
     expect(config.price).toBe(5.5);
-    expect(config.chatQuota).toBe(-1);
   });
 
   it('falls back to free for unknown plan', () => {
@@ -73,27 +69,5 @@ describe('getPlanConfig', () => {
       expect(typeof config.description).toBe('string');
       expect(config.description.length).toBeGreaterThan(0);
     });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// formatChatQuota
-// ---------------------------------------------------------------------------
-describe('formatChatQuota', () => {
-  it('returns "Unlimited" for -1', () => {
-    expect(formatChatQuota(-1)).toBe('Unlimited');
-  });
-
-  it('returns "5 / week" for 5 with weekly period', () => {
-    expect(formatChatQuota(5)).toBe('5 / week');
-    expect(formatChatQuota(5, 'weekly')).toBe('5 / week');
-  });
-
-  it('returns "50 / day" for 50 with daily period', () => {
-    expect(formatChatQuota(50, 'daily')).toBe('50 / day');
-  });
-
-  it('defaults to weekly when period omitted', () => {
-    expect(formatChatQuota(50)).toBe('50 / week');
   });
 });

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -174,8 +174,8 @@
   },
 
   "supporter": {
-    "title": "Support Cellarion",
-    "subtitle": "Cellarion is free and open-source — every feature is available to everyone. If you enjoy it, you can chip in to help fund development.",
+    "title": "Cellarion is free, and open-source. Here's what keeps it running.",
+    "subtitle": "Every feature is free for everyone, forever — no paywalls, nothing locked. But the servers and AI behind the app cost real money. If Cellarion has earned a place in your cellar, you're warmly invited to help split the tab.",
     "yourTier": "Your current tier:",
     "expires": "Valid until:",
     "noExpiry": "No expiry (indefinite)",
@@ -189,11 +189,27 @@
     "portalError": "Could not open subscription management. Please try again.",
     "free": "Free",
     "month": "month",
-    "everythingFree": "Everything is free. There are no paywalled features — everyone gets all analytics, unlimited cellars, Cellar Chat, and every other feature.",
-    "donateExplain": "Supporting Cellarion doesn't unlock anything extra. You'd be doing it simply because you enjoy the app and want to help keep it running and improving. You get our heartfelt thanks — nothing more, nothing less.",
-    "alreadySupporting": "You're currently supporting Cellarion — thank you! 💛 You can change or cancel your contribution anytime.",
-    "supportAmount": "Support {{amount}}/mo",
-    "openSourceNote": "Cellarion is open-source (AGPL-3.0). Your support funds hosting, development, and new features."
+    "licenseChip": "AGPL-3.0",
+    "viewSource": "View source on GitHub",
+    "freeHeading": "No paywall. Nothing to upsell.",
+    "freeBody": "Cellarion is open-source under the AGPL-3.0 license, and every feature is free for everyone — unlimited cellars, all the stats, drink-window alerts, and 50 Cellar Chat questions a day. Supporting unlocks nothing extra, because nothing is locked: supporters and free users get the exact same app.",
+    "costsHeading": "What your support actually pays for",
+    "costsBody": "Behind the scenes there's a server running around the clock, the cellarion.app domain, and the paid AI that powers Cellar Chat — Anthropic Claude answers your questions and Voyage handles the wine-matching behind them. Those bills arrive every month and grow as more people pour a glass and start chatting.",
+    "whereEyebrow": "Where your support goes",
+    "whereHosting": "Hosting",
+    "whereHostingDesc": "Server + domain, online 24/7",
+    "whereAI": "AI",
+    "whereAIDesc": "Claude + Voyage power Cellar Chat",
+    "whereDev": "Development",
+    "whereDevDesc": "Bug fixes & what's next",
+    "whereCaption": "Honest, qualitative buckets — no tier buys anything different.",
+    "donateLead": "Want to help split the tab?",
+    "donateBody": "Same app, same features either way — just our genuine thanks.",
+    "supporterCta": "Support · {{amount}}/mo",
+    "patronCta": "Become a Patron · {{amount}}/mo",
+    "reassure": "Cancel anytime · same app either way 💛",
+    "alreadySupporting": "💛 You're supporting Cellarion — thank you! You can change or cancel anytime.",
+    "donateNote": "Payments are handled securely by Stripe. Cellarion stays free and open whether you support or not."
   },
 
   "cellars": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -175,20 +175,25 @@
 
   "supporter": {
     "title": "Support Cellarion",
-    "subtitle": "Every tier gets full access to all features. Supporters help keep Cellarion free and get more Cellar Chat.",
+    "subtitle": "Cellarion is free and open-source — every feature is available to everyone. If you enjoy it, you can chip in to help fund development.",
     "yourTier": "Your current tier:",
     "expires": "Valid until:",
     "noExpiry": "No expiry (indefinite)",
     "expired": "Expired",
     "currentTag": "Your tier",
-    "allFeaturesNote": "All features are available on every tier. Supporter tiers unlock more Cellar Chat questions and help fund development.",
+    "allFeaturesNote": "All features are free for everyone. Supporting is a voluntary donation that unlocks nothing extra — it simply funds development.",
     "subscribe": "Subscribe",
     "changePlan": "Change plan",
     "manageSubscription": "Manage Subscription",
     "checkoutError": "Could not start checkout. Please try again.",
     "portalError": "Could not open subscription management. Please try again.",
     "free": "Free",
-    "month": "month"
+    "month": "month",
+    "everythingFree": "Everything is free. There are no paywalled features — everyone gets all analytics, unlimited cellars, Cellar Chat, and every other feature.",
+    "donateExplain": "Supporting Cellarion doesn't unlock anything extra. You'd be doing it simply because you enjoy the app and want to help keep it running and improving. You get our heartfelt thanks — nothing more, nothing less.",
+    "alreadySupporting": "You're currently supporting Cellarion — thank you! 💛 You can change or cancel your contribution anytime.",
+    "supportAmount": "Support {{amount}}/mo",
+    "openSourceNote": "Cellarion is open-source (AGPL-3.0). Your support funds hosting, development, and new features."
   },
 
   "cellars": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -175,20 +175,25 @@
 
   "supporter": {
     "title": "Stöd Cellarion",
-    "subtitle": "Alla nivåer ger full tillgång till alla funktioner. Supportrar hjälper till att hålla Cellarion gratis och får mer Cellar Chat.",
+    "subtitle": "Cellarion är gratis och öppen källkod — alla funktioner är tillgängliga för alla. Om du gillar appen kan du bidra för att hjälpa till att finansiera utvecklingen.",
     "yourTier": "Din nuvarande nivå:",
     "expires": "Giltigt till:",
     "noExpiry": "Inget utgångsdatum",
     "expired": "Utgånget",
     "currentTag": "Din nivå",
-    "allFeaturesNote": "Alla funktioner är tillgängliga på varje nivå. Supporternivåer låser upp fler Cellar Chat-frågor och hjälper till att finansiera utvecklingen.",
+    "allFeaturesNote": "Alla funktioner är gratis för alla. Att stödja är en frivillig donation som inte låser upp något extra — den finansierar bara utvecklingen.",
     "subscribe": "Prenumerera",
     "changePlan": "Byt plan",
     "manageSubscription": "Hantera prenumeration",
     "checkoutError": "Kunde inte starta betalningen. Försök igen.",
     "portalError": "Kunde inte öppna prenumerationshantering. Försök igen.",
     "free": "Gratis",
-    "month": "månad"
+    "month": "månad",
+    "everythingFree": "Allt är gratis. Det finns inga betalspärrade funktioner — alla får all statistik, obegränsade källare, Cellar Chat och alla andra funktioner.",
+    "donateExplain": "Att stödja Cellarion låser inte upp något extra. Du gör det helt enkelt för att du gillar appen och vill hjälpa till att hålla den igång och förbättra den. Du får vårt varma tack — varken mer eller mindre.",
+    "alreadySupporting": "Du stödjer Cellarion just nu — tack! 💛 Du kan ändra eller avsluta ditt bidrag när som helst.",
+    "supportAmount": "Stöd {{amount}}/mån",
+    "openSourceNote": "Cellarion är öppen källkod (AGPL-3.0). Ditt stöd finansierar drift, utveckling och nya funktioner."
   },
 
   "cellars": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -174,8 +174,8 @@
   },
 
   "supporter": {
-    "title": "Stöd Cellarion",
-    "subtitle": "Cellarion är gratis och öppen källkod — alla funktioner är tillgängliga för alla. Om du gillar appen kan du bidra för att hjälpa till att finansiera utvecklingen.",
+    "title": "Cellarion är gratis och öppen källkod. Här är vad som håller det igång.",
+    "subtitle": "Varje funktion är gratis för alla, för alltid — inga betalväggar, inget låst. Men servrarna och AI:n bakom appen kostar riktiga pengar. Om Cellarion har förtjänat en plats i din källare är du varmt välkommen att hjälpa till att dela på notan.",
     "yourTier": "Din nuvarande nivå:",
     "expires": "Giltigt till:",
     "noExpiry": "Inget utgångsdatum",
@@ -189,11 +189,27 @@
     "portalError": "Kunde inte öppna prenumerationshantering. Försök igen.",
     "free": "Gratis",
     "month": "månad",
-    "everythingFree": "Allt är gratis. Det finns inga betalspärrade funktioner — alla får all statistik, obegränsade källare, Cellar Chat och alla andra funktioner.",
-    "donateExplain": "Att stödja Cellarion låser inte upp något extra. Du gör det helt enkelt för att du gillar appen och vill hjälpa till att hålla den igång och förbättra den. Du får vårt varma tack — varken mer eller mindre.",
-    "alreadySupporting": "Du stödjer Cellarion just nu — tack! 💛 Du kan ändra eller avsluta ditt bidrag när som helst.",
-    "supportAmount": "Stöd {{amount}}/mån",
-    "openSourceNote": "Cellarion är öppen källkod (AGPL-3.0). Ditt stöd finansierar drift, utveckling och nya funktioner."
+    "licenseChip": "AGPL-3.0",
+    "viewSource": "Visa källkoden på GitHub",
+    "freeHeading": "Ingen betalvägg. Inget att sälja på.",
+    "freeBody": "Cellarion är öppen källkod under AGPL-3.0-licensen, och varje funktion är gratis för alla — obegränsade källare, all statistik, dricksfönster-varningar och 50 Cellar Chat-frågor om dagen. Att stödja låser inte upp något extra, eftersom inget är låst: supportrar och gratisanvändare får exakt samma app.",
+    "costsHeading": "Vad ditt stöd faktiskt betalar för",
+    "costsBody": "Bakom kulisserna finns en server som är igång dygnet runt, domänen cellarion.app och den betalda AI:n som driver Cellar Chat — Anthropic Claude svarar på dina frågor och Voyage sköter vinmatchningen bakom dem. De räkningarna kommer varje månad och växer ju fler som häller upp ett glas och börjar chatta.",
+    "whereEyebrow": "Vart ditt stöd går",
+    "whereHosting": "Drift",
+    "whereHostingDesc": "Server + domän, online dygnet runt",
+    "whereAI": "AI",
+    "whereAIDesc": "Claude + Voyage driver Cellar Chat",
+    "whereDev": "Utveckling",
+    "whereDevDesc": "Buggfixar & nästa steg",
+    "whereCaption": "Ärliga, ungefärliga kategorier — ingen nivå ger något annat.",
+    "donateLead": "Vill du hjälpa till att dela på notan?",
+    "donateBody": "Samma app, samma funktioner oavsett — bara vårt uppriktiga tack.",
+    "supporterCta": "Stöd · {{amount}}/mån",
+    "patronCta": "Bli Patron · {{amount}}/mån",
+    "reassure": "Avsluta när som helst · samma app oavsett 💛",
+    "alreadySupporting": "💛 Du stödjer Cellarion — tack! Du kan ändra eller avsluta när som helst.",
+    "donateNote": "Betalningar hanteras säkert av Stripe. Cellarion förblir gratis och öppet oavsett om du stödjer eller inte."
   },
 
   "cellars": {

--- a/frontend/src/pages/Plans.css
+++ b/frontend/src/pages/Plans.css
@@ -1,5 +1,5 @@
 .plans-page {
-  max-width: 900px;
+  max-width: 720px;
   margin: 0 auto;
 }
 
@@ -209,13 +209,21 @@
 
 /* ── Donation card ── */
 .donate-card {
-  max-width: 560px;
-  margin: 0 auto;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   padding: 1.75rem;
   background: var(--color-bg);
   text-align: center;
+}
+
+/* Warm accent rule on the focal CTA card */
+.donate-card--accent {
+  border-top: 3px solid var(--color-accent);
+}
+
+/* Top CTA — the support buttons shown directly under the header */
+.donate-top {
+  margin: 0.5rem 0 1.75rem;
 }
 
 .donate-lead {
@@ -256,4 +264,161 @@
   font-size: 0.78rem;
   color: var(--color-input-placeholder);
   line-height: 1.5;
+}
+
+.donate-reassure {
+  margin: 0.75rem 0 0;
+  text-align: center;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+/* ── Support page: header open-source chips ── */
+.support-emoji {
+  font-style: normal;
+}
+
+.support-subtitle {
+  max-width: 62ch;
+  line-height: 1.5;
+}
+
+.support-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.support-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 20px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.support-chip--license {
+  background: rgba(var(--color-primary-rgb), 0.12);
+  color: var(--color-primary);
+}
+
+.support-chip--link {
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.support-chip--link:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.support-chip-glyph {
+  font-family: monospace;
+}
+
+/* ── Support page: prose card ── */
+.support-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  padding: 1.75rem;
+  margin: 1.5rem 0;
+  text-align: left;
+}
+
+.support-h2 {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.support-h2:not(:first-child) {
+  margin-top: 1.5rem;
+}
+
+.support-h2-icon {
+  flex-shrink: 0;
+  width: 1.6em;
+  text-align: center;
+}
+
+.support-p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  line-height: 1.55;
+}
+
+/* ── Support page: where your support goes ── */
+.support-eyebrow {
+  margin: 2rem 0 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.support-goes {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.support-goes-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+  padding: 0.85rem 1rem;
+  transition: background 0.15s;
+}
+
+.support-goes-row + .support-goes-row {
+  border-top: 1px solid var(--color-border);
+}
+
+.support-goes-row:hover {
+  background: rgba(var(--color-primary-rgb), 0.04);
+}
+
+.support-goes-icon {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--color-primary-rgb), 0.08);
+  border-radius: var(--radius-md);
+  font-size: 1rem;
+}
+
+.support-goes-label {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.support-goes-desc {
+  margin-left: auto;
+  font-size: 0.82rem;
+  color: var(--color-text-secondary);
+}
+
+.support-goes-caption {
+  margin: 0.5rem 0 0;
+  font-size: 0.78rem;
+  color: var(--color-input-placeholder);
 }

--- a/frontend/src/pages/Plans.css
+++ b/frontend/src/pages/Plans.css
@@ -206,3 +206,54 @@
   color: var(--color-input-placeholder);
   margin: 0;
 }
+
+/* ── Donation card ── */
+.donate-card {
+  max-width: 560px;
+  margin: 0 auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  background: var(--color-bg);
+  text-align: center;
+}
+
+.donate-lead {
+  margin: 0 0 0.9rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.45;
+}
+
+.donate-body {
+  margin: 0 0 1.5rem;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  line-height: 1.55;
+}
+
+.donate-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.donate-btn {
+  min-width: 160px;
+}
+
+.donate-thanks {
+  margin: 0 0 0.5rem;
+  font-size: 0.92rem;
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+.donate-note {
+  margin: 1.5rem 0 0;
+  font-size: 0.78rem;
+  color: var(--color-input-placeholder);
+  line-height: 1.5;
+}

--- a/frontend/src/pages/SuperAdmin/TabAI.js
+++ b/frontend/src/pages/SuperAdmin/TabAI.js
@@ -972,8 +972,8 @@ function EnrichmentPromptPanel({ prompt, apiFetch }) {
   );
 }
 
-function ChatLimitsPanel({ limits, apiFetch }) {
-  const [vals, setVals] = useState({ free: limits.free ?? 5, supporter: limits.supporter ?? 50, patron: limits.patron ?? -1 });
+function ChatLimitPanel({ limit, apiFetch }) {
+  const [val, setVal] = useState(limit ?? 50);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState(null);
 
@@ -981,10 +981,10 @@ function ChatLimitsPanel({ limits, apiFetch }) {
     setSaving(true);
     setMsg(null);
     try {
-      const res = await apiFetch('/api/superadmin/ai/chat-limits', {
+      const res = await apiFetch('/api/superadmin/ai/chat-limit', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(vals),
+        body: JSON.stringify({ limit: parseInt(val, 10) }),
       });
       if (!res.ok) {
         const d = await res.json();
@@ -1002,27 +1002,25 @@ function ChatLimitsPanel({ limits, apiFetch }) {
   return (
     <div className="sa-panel" style={{ marginTop: 16 }}>
       <div className="sa-panel-header">
-        <span className="sa-panel-title">Cellar Chat — Weekly Limits</span>
+        <span className="sa-panel-title">Cellar Chat — Daily Limit</span>
         <button className="sa-btn" onClick={save} disabled={saving}>{saving ? 'Saving...' : 'Save'}</button>
       </div>
       <div className="sa-panel-body">
         <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 12 }}>
-          Max questions per user per rolling 7-day window. Use -1 for unlimited.
+          Max Cellar Chat questions per user per UTC day. Applies to everyone, regardless of plan. Use -1 for unlimited.
         </div>
         <div className="sa-kv">
-          {[['free', 'Enthusiast (free)'], ['supporter', 'Supporter ($1.50)'], ['patron', 'Patron ($5.50)']].map(([key, label]) => (
-            <div className="sa-kv-row" key={key}>
-              <span className="sa-kv-key">{label}</span>
-              <input
-                type="number"
-                min="0"
-                max="999"
-                value={vals[key]}
-                onChange={e => setVals(v => ({ ...v, [key]: e.target.value }))}
-                style={{ width: 70, background: 'var(--sa-bg)', border: '1px solid var(--sa-border)', color: 'var(--sa-text)', padding: '2px 6px', borderRadius: 3, fontFamily: 'monospace', fontSize: 12 }}
-              />
-            </div>
-          ))}
+          <div className="sa-kv-row">
+            <span className="sa-kv-key">Questions / day</span>
+            <input
+              type="number"
+              min="-1"
+              max="9999"
+              value={val}
+              onChange={e => setVal(e.target.value)}
+              style={{ width: 70, background: 'var(--sa-bg)', border: '1px solid var(--sa-border)', color: 'var(--sa-text)', padding: '2px 6px', borderRadius: 3, fontFamily: 'monospace', fontSize: 12 }}
+            />
+          </div>
         </div>
         {msg && (
           <div style={{ marginTop: 10, fontSize: 11, color: msg.ok ? 'var(--sa-accent)' : 'var(--sa-danger)' }}>{msg.text}</div>
@@ -1635,7 +1633,7 @@ export default function TabAI() {
       <PriceSuggestPromptPanel prompt={config.priceSuggestPrompt || ''} apiFetch={apiFetch} />
       <EnrichmentModelPanel currentModel={config.enrichmentModel || 'claude-sonnet-4-6'} apiFetch={apiFetch} />
       <EnrichmentPromptPanel prompt={config.enrichmentPrompt || ''} apiFetch={apiFetch} />
-      <ChatLimitsPanel limits={config.chatDailyLimits || {}} apiFetch={apiFetch} />
+      <ChatLimitPanel limit={config.chatDailyLimit ?? 50} apiFetch={apiFetch} />
       <ChatUsagePanel />
     </>
   );

--- a/frontend/src/pages/SuperAdmin/TabSettings.js
+++ b/frontend/src/pages/SuperAdmin/TabSettings.js
@@ -252,7 +252,7 @@ function ChatLimitsPanel({ apiFetch }) {
   return (
     <PanelShell
       title="Cellar Chat abuse controls"
-      intro="Per-user throttles on /api/chat — guards Anthropic spend against scripted bursts inside a single user's tier quota. The SSE per-stream timeout is hardcoded at 90s (not editable) as a system safety bound."
+      intro="Per-user throttles on /api/chat — guards Anthropic spend against scripted bursts inside a single user's daily quota. The SSE per-stream timeout is hardcoded at 90s (not editable) as a system safety bound."
       saving={saving} onSave={save} msg={msg}
     >
       <NumberField

--- a/frontend/src/pages/Supporter.js
+++ b/frontend/src/pages/Supporter.js
@@ -1,9 +1,13 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
-import { PLANS, PLAN_NAMES, formatChatQuota } from '../config/plans';
+import { PLANS } from '../config/plans';
 import { createCheckout, createPortal } from '../api/stripe';
 import './Plans.css';
+
+// Donation tiers, in ascending order. Everything in Cellarion is free — these
+// are voluntary contributions that unlock nothing extra.
+const DONATE_TIERS = ['supporter', 'patron'];
 
 function Supporter() {
   const { t } = useTranslation();
@@ -11,9 +15,6 @@ function Supporter() {
   const [actionError, setActionError] = useState(null);
   const [checkoutLoading, setCheckoutLoading] = useState(null);
 
-  const userPlan = user?.plan || 'free';
-  const userExpiresAt = user?.planExpiresAt || null;
-  const planExpired = userExpiresAt && Date.now() > new Date(userExpiresAt).getTime();
   const hasStripeSubscription = !!user?.stripeSubscriptionId;
 
   async function handleCheckout(plan) {
@@ -24,7 +25,7 @@ function Supporter() {
       if (data.url) {
         window.location.href = data.url;
       } else if (data.code === 'subscription_exists') {
-        // Already subscribed — send them to the portal to change/cancel rather
+        // Already supporting — send them to the portal to change/cancel rather
         // than creating a second subscription (the backend blocks that with 409).
         setCheckoutLoading(null);
         handleManageSubscription();
@@ -48,19 +49,6 @@ function Supporter() {
     }
   }
 
-  function formatExpiry(expiresAt) {
-    if (!expiresAt) return t('supporter.noExpiry');
-    if (Date.now() > new Date(expiresAt).getTime()) return t('supporter.expired');
-    return new Date(expiresAt).toLocaleDateString(undefined, {
-      year: 'numeric', month: 'long', day: 'numeric'
-    });
-  }
-
-  function formatPrice(price) {
-    if (price === 0) return t('supporter.free');
-    return `$${price.toFixed(2)} / ${t('supporter.month')}`;
-  }
-
   return (
     <div className="plans-page">
       <div className="plans-header">
@@ -68,77 +56,40 @@ function Supporter() {
         <p className="plans-subtitle">{t('supporter.subtitle')}</p>
       </div>
 
-      {/* Current tier banner */}
-      <div className={`plans-current-banner plans-current-banner--${userPlan}`}>
-        <span className="plans-current-label">{t('supporter.yourTier')}</span>
-        <span className={`plans-badge plans-badge--${userPlan}`}>{PLANS[userPlan]?.label || userPlan}</span>
-        <span className="plans-current-expiry">
-          {planExpired
-            ? <span className="plans-expiry--expired">{t('supporter.expired')}</span>
-            : <>{t('supporter.expires')} {formatExpiry(userExpiresAt)}</>
-          }
-        </span>
-      </div>
+      <div className="donate-card">
+        <p className="donate-lead">{t('supporter.everythingFree')}</p>
+        <p className="donate-body">{t('supporter.donateExplain')}</p>
 
-      {/* Comparison table */}
-      <div className="plans-grid">
-        {PLAN_NAMES.map(planKey => {
-          const plan = PLANS[planKey];
-          const isCurrent = userPlan === planKey && !planExpired;
-          return (
-            <div
-              key={planKey}
-              className={`plans-card ${isCurrent ? 'plans-card--current' : ''}`}
-            >
-              {isCurrent && (
-                <div className="plans-card-current-tag">{t('supporter.currentTag')}</div>
-              )}
-              <div className="plans-card-header">
-                <h2 className={`plans-card-name plans-card-name--${planKey}`}>{plan.label}</h2>
-                <p className="plans-card-price">{formatPrice(plan.price)}</p>
-                <p className="plans-card-desc">{plan.description}</p>
-                <p className="plans-card-chat">
-                  Cellar Chat: <strong>{formatChatQuota(plan.chatQuota, plan.chatPeriod)}</strong>
-                </p>
-              </div>
-              <ul className="plans-feature-list">
-                {plan.featureList.map((feature, i) => (
-                  <li key={i} className="plans-feature-item">
-                    <span className="plans-feature-check">{'✓'}</span>
-                    {feature}
-                  </li>
-                ))}
-              </ul>
-
-              {planKey !== 'free' && !isCurrent && (
-                <div className="plans-trial-wrap">
-                  <button
-                    className="btn btn-primary plans-trial-btn"
-                    onClick={() => hasStripeSubscription ? handleManageSubscription() : handleCheckout(planKey)}
-                    disabled={checkoutLoading === planKey}
-                  >
-                    {checkoutLoading === planKey
-                      ? t('common.saving')
-                      : hasStripeSubscription ? t('supporter.changePlan') : t('supporter.subscribe')}
-                  </button>
-                </div>
-              )}
-
-              {actionError && isCurrent && <p className="plans-trial-error">{actionError}</p>}
+        {hasStripeSubscription ? (
+          <>
+            <p className="donate-thanks">{t('supporter.alreadySupporting')}</p>
+            <div className="plans-manage-wrap">
+              <button className="btn btn-secondary" onClick={handleManageSubscription}>
+                {t('supporter.manageSubscription')}
+              </button>
             </div>
-          );
-        })}
+          </>
+        ) : (
+          <div className="donate-buttons">
+            {DONATE_TIERS.map(key => (
+              <button
+                key={key}
+                className="btn btn-primary donate-btn"
+                onClick={() => handleCheckout(key)}
+                disabled={checkoutLoading === key}
+              >
+                {checkoutLoading === key
+                  ? t('common.saving')
+                  : t('supporter.supportAmount', { amount: `$${PLANS[key].price.toFixed(2)}` })}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {actionError && <p className="plans-trial-error">{actionError}</p>}
+
+        <p className="donate-note">{t('supporter.openSourceNote')}</p>
       </div>
-
-      {hasStripeSubscription && (
-        <div className="plans-manage-wrap">
-          <button className="btn btn-secondary" onClick={handleManageSubscription}>
-            {t('supporter.manageSubscription')}
-          </button>
-        </div>
-      )}
-
-      <p className="plans-admin-note">{t('supporter.allFeaturesNote')}</p>
     </div>
   );
 }

--- a/frontend/src/pages/Supporter.js
+++ b/frontend/src/pages/Supporter.js
@@ -5,9 +5,54 @@ import { PLANS } from '../config/plans';
 import { createCheckout, createPortal } from '../api/stripe';
 import './Plans.css';
 
-// Donation tiers, in ascending order. Everything in Cellarion is free — these
-// are voluntary contributions that unlock nothing extra.
-const DONATE_TIERS = ['supporter', 'patron'];
+const GITHUB_URL = 'https://github.com/jagduvi1/Cellarion';
+
+/**
+ * Shared support call-to-action — rendered both at the top (compact, the first
+ * thing you see) and inside the bottom donate card (the last thing you see).
+ * `compact` drops the reassurance line so the top instance stays punchy.
+ */
+function DonateActions({ compact, hasStripeSubscription, checkoutLoading, onCheckout, onManage, actionError, t }) {
+  if (hasStripeSubscription) {
+    return (
+      <>
+        <p className="donate-thanks">{t('supporter.alreadySupporting')}</p>
+        <div className="plans-manage-wrap">
+          <button className="btn btn-secondary" onClick={onManage}>
+            {t('supporter.manageSubscription')}
+          </button>
+        </div>
+        {actionError && <p className="plans-trial-error">{actionError}</p>}
+      </>
+    );
+  }
+  return (
+    <>
+      <div className="donate-buttons">
+        <button
+          className="btn btn-primary donate-btn"
+          onClick={() => onCheckout('supporter')}
+          disabled={checkoutLoading === 'supporter'}
+        >
+          {checkoutLoading === 'supporter'
+            ? t('common.saving')
+            : t('supporter.supporterCta', { amount: `$${PLANS.supporter.price.toFixed(2)}` })}
+        </button>
+        <button
+          className="btn btn-secondary donate-btn"
+          onClick={() => onCheckout('patron')}
+          disabled={checkoutLoading === 'patron'}
+        >
+          {checkoutLoading === 'patron'
+            ? t('common.saving')
+            : t('supporter.patronCta', { amount: `$${PLANS.patron.price.toFixed(2)}` })}
+        </button>
+      </div>
+      {!compact && <p className="donate-reassure">{t('supporter.reassure')}</p>}
+      {actionError && <p className="plans-trial-error">{actionError}</p>}
+    </>
+  );
+}
 
 function Supporter() {
   const { t } = useTranslation();
@@ -49,46 +94,83 @@ function Supporter() {
     }
   }
 
+  // Qualitative "where your support goes" buckets — no tier buys anything different.
+  const buckets = [
+    { icon: '🖥️', label: t('supporter.whereHosting'), desc: t('supporter.whereHostingDesc') },
+    { icon: '✨', label: t('supporter.whereAI'), desc: t('supporter.whereAIDesc') },
+    { icon: '🛠️', label: t('supporter.whereDev'), desc: t('supporter.whereDevDesc') },
+  ];
+
+  const actionProps = {
+    hasStripeSubscription,
+    checkoutLoading,
+    onCheckout: handleCheckout,
+    onManage: handleManageSubscription,
+    actionError,
+    t,
+  };
+
   return (
     <div className="plans-page">
       <div className="plans-header">
-        <h1>{t('supporter.title')}</h1>
-        <p className="plans-subtitle">{t('supporter.subtitle')}</p>
+        <h1>
+          <span className="support-emoji" aria-hidden="true">🍷 </span>
+          {t('supporter.title')}
+        </h1>
+        <p className="plans-subtitle support-subtitle">{t('supporter.subtitle')}</p>
+        <div className="support-chips">
+          <span className="support-chip support-chip--license">{t('supporter.licenseChip')}</span>
+          <a
+            className="support-chip support-chip--link"
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="support-chip-glyph" aria-hidden="true">{'</>'}</span>
+            {t('supporter.viewSource')} →
+          </a>
+        </div>
       </div>
 
-      <div className="donate-card">
-        <p className="donate-lead">{t('supporter.everythingFree')}</p>
-        <p className="donate-body">{t('supporter.donateExplain')}</p>
+      {/* Top CTA — the first thing you see */}
+      <div className="donate-top">
+        <DonateActions compact {...actionProps} />
+      </div>
 
-        {hasStripeSubscription ? (
-          <>
-            <p className="donate-thanks">{t('supporter.alreadySupporting')}</p>
-            <div className="plans-manage-wrap">
-              <button className="btn btn-secondary" onClick={handleManageSubscription}>
-                {t('supporter.manageSubscription')}
-              </button>
-            </div>
-          </>
-        ) : (
-          <div className="donate-buttons">
-            {DONATE_TIERS.map(key => (
-              <button
-                key={key}
-                className="btn btn-primary donate-btn"
-                onClick={() => handleCheckout(key)}
-                disabled={checkoutLoading === key}
-              >
-                {checkoutLoading === key
-                  ? t('common.saving')
-                  : t('supporter.supportAmount', { amount: `$${PLANS[key].price.toFixed(2)}` })}
-              </button>
-            ))}
+      {/* Prose: free + costs */}
+      <div className="support-card">
+        <h2 className="support-h2">
+          <span className="support-h2-icon" aria-hidden="true">🔓</span>
+          {t('supporter.freeHeading')}
+        </h2>
+        <p className="support-p">{t('supporter.freeBody')}</p>
+
+        <h2 className="support-h2">
+          <span className="support-h2-icon" aria-hidden="true">🧾</span>
+          {t('supporter.costsHeading')}
+        </h2>
+        <p className="support-p">{t('supporter.costsBody')}</p>
+      </div>
+
+      {/* Where your support goes */}
+      <p className="support-eyebrow">{t('supporter.whereEyebrow')}</p>
+      <div className="support-goes">
+        {buckets.map((b, i) => (
+          <div className="support-goes-row" key={i}>
+            <span className="support-goes-icon" aria-hidden="true">{b.icon}</span>
+            <span className="support-goes-label">{b.label}</span>
+            <span className="support-goes-desc">{b.desc}</span>
           </div>
-        )}
+        ))}
+      </div>
+      <p className="support-goes-caption">{t('supporter.whereCaption')}</p>
 
-        {actionError && <p className="plans-trial-error">{actionError}</p>}
-
-        <p className="donate-note">{t('supporter.openSourceNote')}</p>
+      {/* Bottom donate card — the last thing you see */}
+      <div className="donate-card donate-card--accent">
+        <p className="donate-lead">{t('supporter.donateLead')}</p>
+        <p className="donate-body">{t('supporter.donateBody')}</p>
+        <DonateActions {...actionProps} />
+        <p className="donate-note">{t('supporter.donateNote')}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Two related product changes:

### 1. Cellar Chat is no longer a per-plan perk
Every user now gets the **same daily allowance**, controlled by a single SuperAdmin field — `aiConfig.chatDailyLimit` (default **50/day**, `-1` = unlimited). Supporting unlocks nothing extra.

- **Bug fixed:** the old SuperAdmin "chat limits" panel wrote `aiConfig.chatDailyLimits`, but the enforcement in `chat.js` only read `plans.js` and ignored it — so that panel never did anything. Enforcement now reads the single global value, and the panel is collapsed to one "Questions / day" field that actually takes effect.
- This also closes the `GRAND_AUDIT` note about a stuck `patron` plan getting unlimited chat while paying the supporter price.
- Dropped the now-dead `chatQuota`/`chatPeriod`/`formatChatQuota` from `plans.js` (BE + FE).

### 2. Supporter page redesigned as a donation page
Since supporting no longer unlocks features, the page is now an honest, polished donation page:

- Leads with **free & open-source** (AGPL-3.0 chip + GitHub source link).
- **Transparent about real costs:** hosting, domain, and the paid AI (Anthropic Claude + Voyage) behind Cellar Chat — kept qualitative, no invented figures.
- A **"Where your support goes"** breakdown (Hosting / AI / Development).
- Support **CTA at the top and bottom** (first and last thing you see), via a shared component.
- Two equal-sibling tiers (Supporter \$1.50 / Patron \$5.50) — no upsell; everything stays free for everyone.
- EN + SV copy.

## Tests
- Backend: `767 passed` (Jest). Frontend: `306 passed` (Vitest). Smoke-tested in Docker.

## Deploy notes
- **No `docker-compose` changes**, no new env vars, no DB migration.
- On deploy, the saved `aiConfig` doc (old `chatDailyLimits` object, no `chatDailyLimit`) cleanly falls back to the **50/day** default for everyone; the stale object is ignored.
- Existing **Patrons drop from unlimited → 50/day** chat — intended ("nothing extra for supporters").
- Frontend needs a rebuild (Supporter page + copy are build-time); backend rebuild + restart.

> ⚠️ The backend Docker image currently fails to build on `main` due to a pre-existing `sharp` / `npm ci` optional-dependency bug (unrelated to this feature). Fixed separately in a `fix/docker-sharp-musl` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)