### PR TITLE
fix(build): install sharp linuxmusl binaries in backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,15 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev \
+ # sharp ships its native binary + libvips as platform-specific optional deps.
+ # The committed lockfile only references the linuxmusl-x64 binaries inside
+ # sharp's optionalDependencies — it has no installable package entries for
+ # them — so `npm ci` leaves sharp unloadable on Alpine/musl. Install the exact
+ # locked versions explicitly so the image can load sharp.
+ && npm install --no-save \
+      @img/sharp-linuxmusl-x64@0.34.5 \
+      @img/sharp-libvips-linuxmusl-x64@1.2.4
 
 COPY . .
 


### PR DESCRIPTION
## Problem

The backend image fails to boot on a fresh build:

```
Error: Could not load the "sharp" module using the linuxmusl-x64 runtime
```

`/app/node_modules/@img/` ends up without the `sharp-linuxmusl-x64` /
`sharp-libvips-linuxmusl-x64` binaries.

## Root cause

The committed `backend/package-lock.json` lists those binaries **only as
references inside sharp's `optionalDependencies`** — there are no installable
top-level package entries for them. So `npm ci --omit=dev` (npm 10) has nothing
to install for the musl platform, and sharp can't load at runtime.

This is a real, current `main` issue — #556 regenerated the lockfiles but the
musl `@img/*` entries still aren't installable, so the Docker build remains
broken until this lands.

## Fix

After `npm ci`, explicitly install the two exact locked versions
(`@img/sharp-linuxmusl-x64@0.34.5`, `@img/sharp-libvips-linuxmusl-x64@1.2.4`)
with `--no-save`. No version drift, no lockfile change.

## Verification

Rebuilt the backend image and confirmed:
- `/app/node_modules/@img/` now contains `sharp-linuxmusl-x64` + `sharp-libvips-linuxmusl-x64`
- `node -e "require('sharp')"` → `sharp OK`
- container reaches **healthy**, `/api/health` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)