### PR TITLE
chore(release): v1.67.2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.1",
+  "version": "1.67.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.67.1",
+      "version": "1.67.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "archiver": "^7.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.1",
+  "version": "1.67.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.67.1",
+  "version": "1.67.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.67.1",
+      "version": "1.67.2",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.67.1",
+  "version": "1.67.2",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## v1.67.2

Patch release. Rolls up what's merged to `main` since v1.67.1 and **fixes the broken v1.67.1 backend image**.

- **fix(build): sharp Linux/musl binaries restored in backend lockfile (#560)** — v1.67.1's image silently shipped without sharp's native binary, breaking image processing (label scan, upload/crop) on Alpine. Now fixed; verified `require('sharp')` loads in a clean build.
- **feat: flat daily Cellar Chat limit + donation-only Supporter page (#557)**
- Carries forward the v1.67.1 security dep patches (dompurify, multer, form-data, vite).

Version bumped in both `package.json` + both `package-lock.json` (kept in sync).

## docker-compose impact
None — image rebuild only. Deploy = pull + recreate `backend` + `frontend`.