### PR TITLE
chore(release): v1.67.3

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.2",
+  "version": "1.67.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.67.2",
+      "version": "1.67.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "archiver": "^7.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.2",
+  "version": "1.67.3",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.67.2",
+  "version": "1.67.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.67.2",
+      "version": "1.67.3",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.67.2",
+  "version": "1.67.3",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## v1.67.3

Ships the two features merged since v1.67.2:

- **feat(blog): HowTo JSON-LD schema + "How to track a wine collection" cornerstone (#559)** — the blog crawler renderer now emits schema.org `HowTo` for step-style posts. (The article itself is already live in prod; this deploy activates its HowTo schema.)
- **feat(admin-stats): returning-user retention + maturity coverage cards + exclude-admins-by-default (#562)** — new `/admin/stats` retention section (2+/4+ day tiers, login figures from the audit log — no new PII), maturity have/miss cards, admins excluded by default.

Version bumped in both `package.json` + both `package-lock.json` (in sync).

## docker-compose impact
None — image rebuild only. Deploy = pull + recreate `backend` + `frontend`.