### PR TITLE
chore(release): v1.67.4

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.3",
+  "version": "1.67.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.67.3",
+      "version": "1.67.4",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "archiver": "^7.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.3",
+  "version": "1.67.4",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.67.3",
+  "version": "1.67.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.67.3",
+      "version": "1.67.4",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.67.3",
+  "version": "1.67.4",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release v1.67.4 — bumps backend + frontend (and lockfiles) to 1.67.4.

Ships the changes merged in #564:
- Seed the sommelier maturity queue from every bottle-add path (hand-add, matched import, no-match import → admin approval, cellar JSON/ZIP import, demo seeder).
- Harden wine merge: reconcile unique-index refs (maturity profiles, price-tracking) and re-point every previously-orphaned WineDefinition reference (wishlist, journal pairings, recommendations, restock alerts, community prices, wine reports, wine requests).
- New `scripts/backfill-maturity-profiles.js` for wines imported before the fix.

Verified: 778 unit tests + Docker smoke (15/15 merge assertions, maturity-seeding 4/4).