### PR TITLE
fix: show Move-to-cellar button in mobile action bar

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -417,7 +417,9 @@
     "premiumFeatureDesc": "Track how the market value of this wine changes over time. Available on the Premium plan.",
     "agingMaturityPremiumDesc": "See expert aging windows and maturity phases for this vintage. Available on the Premium plan.",
     "editDetails": "Edit Details",
+    "editDetailsShort": "Edit",
     "removeBottle": "Remove Bottle",
+    "removeBottleShort": "Remove",
     "mistakeLink": "Added by mistake?",
     "mistakeTitle": "Remove as a mistake?",
     "mistakeBody": "This will permanently remove the bottle as if it had never been added. It will not appear in your stats, history, or search. This cannot be undone.",
@@ -654,6 +656,7 @@
 
   "moveBottle": {
     "action": "Move to another cellar",
+    "actionShort": "Move",
     "title": "Move to another cellar",
     "intro": "Choose a cellar to move this bottle to. All its details and history are kept — it will arrive unplaced.",
     "destinationLabel": "Destination cellar",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -417,7 +417,9 @@
     "premiumFeatureDesc": "Följ hur marknadsvärdet på detta vin förändras över tid. Tillgänglig i Premium-planen.",
     "agingMaturityPremiumDesc": "Se expertens lagringsfönster och mognadsfaser för denna årgång. Tillgänglig i Premium-planen.",
     "editDetails": "Redigera detaljer",
+    "editDetailsShort": "Redigera",
     "removeBottle": "Ta bort flaska",
+    "removeBottleShort": "Ta bort",
     "mistakeLink": "Tillagd av misstag?",
     "mistakeTitle": "Ta bort som misstag?",
     "mistakeBody": "Detta tar permanent bort flaskan som om den aldrig lagts till. Den syns inte i statistik, historik eller sökning. Detta kan inte ångras.",
@@ -654,6 +656,7 @@
 
   "moveBottle": {
     "action": "Flytta till en annan källare",
+    "actionShort": "Flytta",
     "title": "Flytta till en annan källare",
     "intro": "Välj en källare att flytta den här flaskan till. Alla detaljer och historik behålls — den hamnar oplacerad.",
     "destinationLabel": "Målkällare",

--- a/frontend/src/pages/BottleDetail.css
+++ b/frontend/src/pages/BottleDetail.css
@@ -99,6 +99,16 @@
   background: #7d3c98;
 }
 
+.bd-mobile-action-move {
+  background: var(--color-surface-raised);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.bd-mobile-action-move:hover {
+  background: var(--color-primary-light);
+}
+
 /* ── Wine header card ── */
 .bd-wine-header {
   margin-bottom: 1rem;

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -549,12 +549,18 @@ function BottleDetail() {
         <div className="bd-mobile-actions">
           <button className="bd-mobile-action-btn bd-mobile-action-edit" onClick={() => setEditing(true)}>
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-            {t('bottleDetail.editDetails')}
+            {t('bottleDetail.editDetailsShort')}
           </button>
           <button className="bd-mobile-action-btn bd-mobile-action-consume" onClick={() => setConsumeOpen(true)}>
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M8 2h8l4 10H4L8 2z"/><path d="M12 12v6"/><path d="M8 22h8"/></svg>
-            {t('bottleDetail.removeBottle')}
+            {t('bottleDetail.removeBottleShort')}
           </button>
+          {canMove && (
+            <button className="bd-mobile-action-btn bd-mobile-action-move" onClick={() => setMoveOpen(true)}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M5 9l-3 3 3 3"/><path d="M9 5l3-3 3 3"/><path d="M15 19l-3 3-3-3"/><path d="M19 9l3 3-3 3"/><path d="M2 12h20"/><path d="M12 2v20"/></svg>
+              {t('moveBottle.actionShort')}
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Problem

The **Move to another cellar** button only existed in the desktop `.bd-header-actions` row, which is hidden on mobile (`@media max-width: 768px` → `display: none`). The mobile sticky action bar (`.bd-mobile-actions`) only contained **Edit** and **Remove**, so cellar owners had no way to move a bottle from a phone.

## Fix

- Add the Move button to the mobile action bar in `BottleDetail.js`, gated by the same `canMove` condition (`!isConsumed && userRole === 'owner'`) used on desktop — editors who can't move bottles still don't see it.
- Add `.bd-mobile-action-move` styling (neutral look matching the Edit button).
- With three buttons sharing the bar, the long labels no longer fit, so the mobile bar now uses short single-word labels (`Edit` / `Remove` / `Move`, Swedish `Redigera` / `Ta bort` / `Flytta`). **Desktop labels are unchanged.**

## Testing

- `npm test` (frontend): 306 passing.
- Both `en` and `sv` translation JSON files validated.

## Docker / prod impact

Frontend-only (JSX + CSS + locale strings). No backend, env, or compose changes — picked up by a normal `frontend` image rebuild. No migration needed.
