### PR TITLE
chore(release): v1.67.5

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.4",
+  "version": "1.67.5",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.67.4",
+  "version": "1.67.5",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Release v1.67.5.

Bumps backend + frontend `package.json` to 1.67.5 (kept in lockstep).

Includes #566 — fix: show Move-to-cellar button in mobile action bar.