### PR TITLE
chore(release): v1.67.6

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.5",
+  "version": "1.67.6",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.67.5",
+  "version": "1.67.6",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for the v1.67.6 patch release.

Contains one change since v1.67.5:
- #568 — code-audit remediation: verified backend/frontend bug fixes (AuditLog TTL index repair via syncIndexes, rack slot dedup, wine-requests status filter, auth type guards, +40 more) and behavior-preserving dedup refactors (SuperAdmin AI routes, TabAI panels, labelScan, Restock, importMappers). Security-reviewed and Docker-verified end-to-end.

Deploy note: on first backend start, syncIndexes replaces the stale plain `auditlogs.timestamp` index with the TTL index, so audit entries older than `AUDIT_TTL_DAYS` (default 90) are purged. Set the env var higher before deploying if longer retention is wanted.