### PR TITLE
fix: resolve HIGH + MEDIUM findings from the 2026-07-06 code audit

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -41,6 +41,14 @@ if (!process.env.MAILGUN_API_KEY || !process.env.MAILGUN_DOMAIN) {
   console.warn('Warning: MAILGUN_API_KEY / MAILGUN_DOMAIN not set — email verification disabled.');
 }
 
+// Backstop: log unhandled rejections instead of letting Node's default policy
+// kill the process. Individual code paths should still settle their promises —
+// this exists so one missed edge (e.g. an SDK emitting an unlistened event)
+// can't take the whole backend down.
+process.on('unhandledRejection', (reason) => {
+  console.error('[unhandledRejection]', reason);
+});
+
 const fs = require('fs');
 const app = require('./src/app');
 const connectDB = require('./src/config/db');
@@ -58,13 +66,34 @@ const PORT = process.env.PORT || 5000;
 // Connect to MongoDB, initialize search, then start server
 connectDB().then(async () => {
   // Migration: drop old non-partial cellar name index so Mongoose can create the
-  // updated partial one (user_1_name_1 with partialFilterExpression: {deletedAt: null})
+  // updated partial one (user_1_name_1 with partialFilterExpression: {deletedAt: null}).
+  // Only drop when the existing index actually lacks the partial filter — the new
+  // index has the same auto-generated name, so an unconditional drop would remove
+  // and rebuild it on every boot (and briefly lose duplicate-name protection).
   try {
     const mongoose = require('mongoose');
-    await mongoose.connection.collection('cellars').dropIndex('user_1_name_1');
-    console.log('[migration] Dropped old cellar name index — partial index will be created by Mongoose');
+    const cellarIndexes = await mongoose.connection.collection('cellars').indexes();
+    const nameIdx = cellarIndexes.find(i => i.name === 'user_1_name_1');
+    if (nameIdx && !nameIdx.partialFilterExpression) {
+      await mongoose.connection.collection('cellars').dropIndex('user_1_name_1');
+      console.log('[migration] Dropped old cellar name index — partial index will be created by Mongoose');
+    }
   } catch {
-    // Index doesn't exist (first deploy) or already migrated — nothing to do
+    // Collection doesn't exist yet (first deploy) — nothing to do
+  }
+
+  // Migration: remove explicit rfidTag nulls written by the old unlink flow.
+  // The unique sparse index indexes explicit nulls, so a second null would
+  // fail with E11000; the unlink route now $unsets the field instead.
+  try {
+    const mongoose = require('mongoose');
+    const res = await mongoose.connection.collection('racks')
+      .updateMany({ rfidTag: { $type: 'null' } }, { $unset: { rfidTag: 1 } });
+    if (res.modifiedCount > 0) {
+      console.log(`[migration] Unset explicit null rfidTag on ${res.modifiedCount} rack(s)`);
+    }
+  } catch {
+    // Collection doesn't exist yet — nothing to do
   }
 
   try {

--- a/backend/src/data/helpContent.js
+++ b/backend/src/data/helpContent.js
@@ -145,7 +145,7 @@ const sections = [
     details: [
       'Ask for food pairings, what to drink tonight, or wine suggestions from your collection.',
       'The sommelier knows all your bottles, ratings, and notes.',
-      'Usage limits depend on your plan (Free: 4/week, Basic: 20/day, Premium: 50/day).',
+      'Everyone gets the same daily allowance of questions (50 per day by default) — it does not depend on any plan.',
     ],
     tourId: 'use-cellar-chat',
   },
@@ -159,7 +159,7 @@ const sections = [
       'World map showing where your wines come from.',
       'Drink window overview: wines that are ready, still aging, or past peak.',
       'Export your stats as a shareable card image.',
-      'Premium feature — available on the Premium plan.',
+      'Free for everyone — like every Cellarion feature, no paid plan is required.',
     ],
     tourId: 'view-statistics',
   },
@@ -206,7 +206,7 @@ const sections = [
     details: [
       'Currency preference (used for prices and value calculations).',
       'Language selection.',
-      'Rating scale: 5-star, 10-point, 20-point, or 100-point.',
+      'Rating scale: 5-star, 20-point (Davis), or 100-point (Parker).',
       'Push notification preferences and device management.',
       'Profile: username and email.',
     ],
@@ -230,7 +230,7 @@ const sections = [
     summary: 'Blog, plans, support, and NFC tags.',
     details: [
       'Blog (/blog): wine articles and guides.',
-      'Plans (/plans): subscription tiers — Free, Basic, Premium.',
+      'Plans (/plans): supporter tiers — Enthusiast (free), Supporter, and Patron. All tiers are functionally identical: every feature is free for everyone, and the paid tiers are purely voluntary contributions that fund development.',
       'Support (/support): submit support tickets for help.',
       'NFC tags: attach NFC tags to racks — scan with your phone to open the rack directly.',
     ],

--- a/backend/src/middleware/bottleAccess.js
+++ b/backend/src/middleware/bottleAccess.js
@@ -24,6 +24,10 @@ function requireBottleAccess(minRole = 'viewer') {
       if (!bottle) return res.status(404).json({ error: 'Bottle not found' });
 
       const cellar = await Cellar.findById(bottle.cellar);
+      // A soft-deleted cellar is treated as missing (same response as a
+      // missing cellar, no existence oracle) — its bottles are frozen until
+      // restore/purge.
+      if (cellar && cellar.deletedAt) return res.status(404).json({ error: 'Bottle not found' });
       const role = getCellarRole(cellar, req.user.id);
 
       if (!role) return res.status(404).json({ error: 'Bottle not found' });

--- a/backend/src/middleware/cellarAccess.js
+++ b/backend/src/middleware/cellarAccess.js
@@ -32,7 +32,9 @@ function requireCellarAccess(minRole = 'viewer') {
       }
 
       const cellar = await Cellar.findById(cellarId);
-      if (!cellar) {
+      // A soft-deleted cellar is treated as missing (same response, no
+      // existence oracle) — its contents are frozen until restore/purge.
+      if (!cellar || cellar.deletedAt) {
         return res.status(404).json({ error: 'Cellar not found' });
       }
 

--- a/backend/src/models/Bottle.js
+++ b/backend/src/models/Bottle.js
@@ -75,23 +75,23 @@ const bottleSchema = new mongoose.Schema({
   purchaseLocation: {
     type: String,
     trim: true,
-    maxlength: [200, 'Purchase location too long']
+    maxlength: [500, 'Purchase location too long (max 500 characters)']
   },
   purchaseUrl: {
     type: String,
     trim: true,
-    maxlength: [500, 'Purchase URL too long']
+    maxlength: [2048, 'Purchase URL too long (max 2048 characters)']
   },
   // Cellar management
   location: {
     type: String,
     trim: true,
-    maxlength: [200, 'Location too long']
+    maxlength: [500, 'Location too long (max 500 characters)']
   },
   notes: {
     type: String,
     trim: true,
-    maxlength: [2000, 'Notes too long']
+    maxlength: [5000, 'Notes too long (max 5000 characters)']
   },
   rating: {
     type: Number

--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -24,7 +24,9 @@ const notificationSchema = new mongoose.Schema({
       'drink_window_past',
       'wine_recommendation',
       'journal_mention',
-      'restock_alert'
+      'restock_alert',
+      'price_tracked',
+      'price_tracking_declined'
     ],
     required: true
   },

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -136,6 +136,14 @@ const userSchema = new mongoose.Schema({
     type: Date,
     default: null
   },
+  // Whether the session's refresh cookie is persistent (remember-me) or a
+  // browser-session cookie. Set at login and read on rotation paths so
+  // /refresh doesn't silently upgrade a session cookie to persistent.
+  // null = legacy session (treated as persistent).
+  refreshTokenPersistent: {
+    type: Boolean,
+    default: null
+  },
   // Per-account brute-force lockout state. Incremented on each failed login,
   // reset on success or successful password reset. Surfaced via the lockout
   // checks in utils/loginAttempts.js — the login handler treats a locked
@@ -383,6 +391,7 @@ userSchema.methods.toJSON = function() {
   delete obj.password;
   delete obj.refreshTokenHash;
   delete obj.refreshTokenExpiresAt;
+  delete obj.refreshTokenPersistent;
   delete obj.emailVerificationTokenHash;
   delete obj.emailVerificationExpiresAt;
   delete obj.passwordResetTokenHash;

--- a/backend/src/routes/admin/images.js
+++ b/backend/src/routes/admin/images.js
@@ -151,6 +151,24 @@ router.put('/:id/reject', async (req, res) => {
       return res.status(404).json({ error: 'Image not found' });
     }
 
+    // If image was assigned to a wine, remove the assignment BEFORE the file
+    // URLs are nulled below — otherwise WineDefinition.image keeps pointing
+    // at the deleted file (same block as the unapprove route).
+    if (image.assignedToWine && image.wineDefinition) {
+      const wineDefId = image.wineDefinition;
+      image.assignedToWine = false;
+
+      // Clear the wine definition's image if it matches this image
+      const imageUrl = image.processedUrl || image.originalUrl;
+      const wine = await WineDefinition.findById(wineDefId);
+      if (wine && wine.image === imageUrl) {
+        wine.image = null;
+        wine.imageCredit = null;
+        await wine.save();
+        searchService.indexWine(wineDefId);
+      }
+    }
+
     image.status = 'rejected';
     image.reviewedBy = req.user.id;
     image.reviewedAt = new Date();

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -6,6 +6,7 @@ const Country = require('../../models/Country');
 const Region = require('../../models/Region');
 const Grape = require('../../models/Grape');
 const Appellation = require('../../models/Appellation');
+const WineDefinition = require('../../models/WineDefinition');
 const searchService = require('../../services/search');
 const { logAudit } = require('../../services/audit');
 const { isValidId } = require('../../utils/validation');
@@ -98,6 +99,10 @@ router.put('/countries/:id', async (req, res) => {
     if (description !== undefined) country.description = description;
 
     await country.save();
+    logAudit(req, 'admin.taxonomy.update',
+      { type: 'country', id: country._id },
+      { name: country.name }
+    );
 
     // Resync search index if name changed (denormalized data)
     if (name) searchService.fullSync();
@@ -123,6 +128,14 @@ router.delete('/countries/:id', async (req, res) => {
     if (regionCount > 0) {
       return res.status(400).json({
         error: `Cannot delete country. ${regionCount} region(s) reference it.`
+      });
+    }
+
+    // Check if any wines reference this country
+    const wineCount = await WineDefinition.countDocuments({ country: req.params.id });
+    if (wineCount > 0) {
+      return res.status(400).json({
+        error: `Cannot delete country. ${wineCount} wine(s) reference it.`
       });
     }
 
@@ -274,6 +287,10 @@ router.put('/regions/:id', async (req, res) => {
     await region.populate('country', 'name');
     await region.populate('typicalGrapes', 'name');
     await region.populate('permittedGrapes', 'name');
+    logAudit(req, 'admin.taxonomy.update',
+      { type: 'region', id: region._id },
+      { name: region.name }
+    );
 
     // Resync search index if name changed (denormalized data)
     if (name) searchService.fullSync();
@@ -292,6 +309,22 @@ router.delete('/regions/:id', async (req, res) => {
     const region = await Region.findById(req.params.id);
     if (!region) {
       return res.status(404).json({ error: 'Region not found' });
+    }
+
+    // Check if any wines reference this region
+    const wineCount = await WineDefinition.countDocuments({ region: req.params.id });
+    if (wineCount > 0) {
+      return res.status(400).json({
+        error: `Cannot delete region. ${wineCount} wine(s) reference it.`
+      });
+    }
+
+    // Check if any regions have this region as their parent
+    const childCount = await Region.countDocuments({ parentRegion: req.params.id });
+    if (childCount > 0) {
+      return res.status(400).json({
+        error: `Cannot delete region. ${childCount} region(s) reference it as parent.`
+      });
     }
 
     logAudit(req, 'admin.taxonomy.delete',
@@ -382,6 +415,10 @@ router.put('/grapes/:id', async (req, res) => {
     if (description !== undefined) grape.description = description;
 
     await grape.save();
+    logAudit(req, 'admin.taxonomy.update',
+      { type: 'grape', id: grape._id },
+      { name: grape.name }
+    );
 
     // Resync search index if name changed (denormalized data)
     if (name) searchService.fullSync();
@@ -400,6 +437,24 @@ router.delete('/grapes/:id', async (req, res) => {
     const grape = await Grape.findById(req.params.id);
     if (!grape) {
       return res.status(404).json({ error: 'Grape not found' });
+    }
+
+    // Check if any wines reference this grape
+    const wineCount = await WineDefinition.countDocuments({ grapes: req.params.id });
+    if (wineCount > 0) {
+      return res.status(400).json({
+        error: `Cannot delete grape. ${wineCount} wine(s) reference it.`
+      });
+    }
+
+    // Check if any regions list this grape as typical or permitted
+    const regionCount = await Region.countDocuments({
+      $or: [{ typicalGrapes: req.params.id }, { permittedGrapes: req.params.id }]
+    });
+    if (regionCount > 0) {
+      return res.status(400).json({
+        error: `Cannot delete grape. ${regionCount} region(s) reference it.`
+      });
     }
 
     logAudit(req, 'admin.taxonomy.delete',
@@ -503,6 +558,10 @@ router.put('/appellations/:id', async (req, res) => {
     await appellation.save();
     await appellation.populate('country', 'name');
     await appellation.populate('region', 'name');
+    logAudit(req, 'admin.taxonomy.update',
+      { type: 'appellation', id: appellation._id },
+      { name: appellation.name }
+    );
 
     res.json({ appellation });
   } catch (error) {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -138,6 +138,14 @@ const issueTokens = async (user, res, { rememberMe, preserveLifetime = false } =
   if (!preserveLifetime) {
     user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_ABSOLUTE_LIFETIME_MS);
   }
+  // Persist the remember-me choice at session start so rotation paths
+  // (/refresh, /change-password) reissue the same cookie kind instead of
+  // silently upgrading a session cookie to a persistent one.
+  if (rememberMe !== undefined) {
+    user.refreshTokenPersistent = rememberMe;
+  } else {
+    rememberMe = user.refreshTokenPersistent === false ? false : true;
+  }
   await user.save();
   res.cookie('refreshToken', refreshToken, buildCookieOptions(rememberMe));
   return accessToken;

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -754,11 +754,12 @@ router.post('/:id/consume', requireBottleAccess('editor'), async (req, res) => {
       return res.status(400).json({ error: 'Invalid reason' });
     }
 
+    if (note && (typeof note !== 'string' || note.length > 1000)) {
+      return res.status(400).json({ error: 'Note is too long (max 1000 characters)' });
+    }
+
     const { rating: resolvedConsumedRating, ratingScale: resolvedConsumedScale, error: consumeRatingError } = resolveRating(rating, consumedRatingScale);
     if (consumeRatingError) return res.status(400).json({ error: consumeRatingError });
-
-    // Remove from any rack slot so the slot is freed up
-    await removeFromRacks(bottle._id);
 
     bottle.status = reason;
     bottle.consumedAt = new Date();
@@ -770,6 +771,10 @@ router.post('/:id/consume', requireBottleAccess('editor'), async (req, res) => {
     }
 
     await bottle.save();
+
+    // Remove from any rack slot so the slot is freed up — after the save, so a
+    // failed save doesn't leave an active bottle already pulled from its rack
+    await removeFromRacks(bottle._id);
 
     // Remove from Meilisearch (consumed bottles are excluded)
     searchService.indexBottle(bottle._id);
@@ -786,6 +791,9 @@ router.post('/:id/consume', requireBottleAccess('editor'), async (req, res) => {
 
     res.json({ bottle });
   } catch (error) {
+    if (error.name === 'ValidationError') {
+      return res.status(400).json({ error: error.message });
+    }
     console.error('Consume bottle error:', error);
     res.status(500).json({ error: 'Failed to consume bottle' });
   }

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -544,16 +544,21 @@ router.delete('/:idOrSlug', requireAuth, requireModeratorOrAdmin, async (req, re
     // pointing at deleted documents in the moderation queue otherwise).
     const replyIds = await DiscussionReply.find({ discussion: discussion._id }).select('_id');
     const replyIdList = replyIds.map(r => r._id);
-    DiscussionReaction.deleteMany({ reply: { $in: replyIdList } }).catch(() => {});
-    DiscussionReply.deleteMany({ discussion: discussion._id }).catch(() => {});
-    DiscussionReport.deleteMany({
-      $or: [
-        { discussion: discussion._id },
-        { reply: { $in: replyIdList } }
-      ]
-    }).catch(() => {});
-    DiscussionWatch.deleteMany({ discussion: discussion._id }).catch(() => {});
-    DiscussionRead.deleteMany({ discussion: discussion._id }).catch(() => {});
+    // Await the cleanups BEFORE deleting the parent — if one fails the 500
+    // leaves the discussion intact so the delete can be retried, instead of
+    // permanently orphaning replies/reactions/reports.
+    await Promise.all([
+      DiscussionReaction.deleteMany({ reply: { $in: replyIdList } }),
+      DiscussionReply.deleteMany({ discussion: discussion._id }),
+      DiscussionReport.deleteMany({
+        $or: [
+          { discussion: discussion._id },
+          { reply: { $in: replyIdList } }
+        ]
+      }),
+      DiscussionWatch.deleteMany({ discussion: discussion._id }),
+      DiscussionRead.deleteMany({ discussion: discussion._id })
+    ]);
 
     // Capture the public URL before deletion so we can ping IndexNow afterwards.
     const publicPath = `/community/discussions/${discussion.slug || discussion._id}`;
@@ -888,6 +893,7 @@ router.put('/:discussionId/replies/:replyId', requireAuth, async (req, res) => {
     if (!isValidId(req.params.replyId)) return res.status(400).json({ error: 'Invalid reply ID' });
     const reply = await DiscussionReply.findById(req.params.replyId);
     if (!reply) return res.status(404).json({ error: 'Reply not found' });
+    if (reply.isDeleted) return res.status(400).json({ error: 'Reply has been deleted' });
 
     const isOwner = reply.author.toString() === req.user.id;
     const isMod = isModerator(req.user);

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -461,11 +461,23 @@ router.post('/link-to-bottle', requireAuth, async (req, res) => {
     if (!bottleId || !imageIds || !Array.isArray(imageIds)) {
       return res.status(400).json({ error: 'bottleId and imageIds array are required' });
     }
+    if (!isValidId(bottleId) || !imageIds.every(id => isValidId(id))) {
+      return res.status(400).json({ error: 'Invalid ID' });
+    }
 
-    // Verify bottle ownership
-    const bottle = await Bottle.findOne({ _id: bottleId, user: req.user.id });
+    // Verify cellar access — bottles are owned by the cellar owner, so shared-cellar
+    // editors must be allowed to link the images they uploaded (mirrors /upload).
+    const bottle = await Bottle.findById(bottleId);
     if (!bottle) {
       return res.status(404).json({ error: 'Bottle not found' });
+    }
+    const cellar = await Cellar.findById(bottle.cellar);
+    if (!cellar) {
+      return res.status(404).json({ error: 'Bottle not found' });
+    }
+    const cellarRole = getCellarRole(cellar, req.user.id);
+    if (!cellarRole || cellarRole === 'viewer') {
+      return res.status(403).json({ error: 'Not authorized to link images to this bottle' });
     }
 
     await BottleImage.updateMany(

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -144,7 +144,10 @@ router.put('/:id', async (req, res) => {
     if (rows !== undefined) rack.rows = rows;
     if (cols !== undefined) rack.cols = cols;
     if (typeConfig !== undefined) rack.typeConfig = typeConfig;
-    if (rfidTag !== undefined) rack.rfidTag = rfidTag || null;
+    // Unlink must $unset the field, not store null: the unique sparse index on
+    // rfidTag still indexes explicit nulls, so two unlinked racks anywhere in
+    // the DB would collide with E11000.
+    if (rfidTag !== undefined) rack.rfidTag = rfidTag || undefined;
 
     // Validate that existing slots still fit within new dimensions
     const newMax = getMaxPosition(rack);

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -167,9 +167,17 @@ router.get('/user/:userId', async (req, res) => {
     if (!isValidId(req.params.userId)) return res.status(400).json({ error: 'Invalid user ID' });
     const { page, limit, offset: skip } = parsePagination(req.query, { limit: REVIEWS_PER_PAGE, maxLimit: REVIEWS_MAX_PER_PAGE });
 
+    // Respect profileVisibility: a private profile's reviews are only viewable
+    // by their owner (mirrors GET /api/users/public/:userId)
+    const isOwner = req.user && req.params.userId === req.user.id;
+    const targetUser = await User.findById(req.params.userId).select('profileVisibility');
+    if (!targetUser || (targetUser.profileVisibility !== 'public' && !isOwner)) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
     // If viewing own profile, show all reviews; otherwise only public
     const filter = { author: req.params.userId };
-    if (req.params.userId !== req.user.id) {
+    if (!isOwner) {
       filter.visibility = 'public';
     }
 

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -551,16 +551,19 @@ router.patch('/ai/chat-model', async (req, res) => {
   if (fallbackModel !== undefined && fallbackModel !== null && !VALID_CHAT_MODELS.includes(fallbackModel)) {
     return res.status(400).json({ error: `fallbackModel must be one of: ${VALID_CHAT_MODELS.join(', ')} or null` });
   }
-  if (fallbackModel !== null && fallbackModel === model) {
-    return res.status(400).json({ error: 'fallbackModel must be different from the primary model' });
-  }
 
   try {
     const current = aiConfig.get();
+    // Validate the invariant against the EFFECTIVE pair — an omitted
+    // fallbackModel keeps the stored one, which must not equal the new model.
+    const effectiveFallback = fallbackModel !== undefined ? fallbackModel : current.chatModelFallback;
+    if (effectiveFallback !== null && effectiveFallback !== undefined && effectiveFallback === model) {
+      return res.status(400).json({ error: 'fallbackModel must be different from the primary model' });
+    }
     const updated = {
       ...current,
       chatModel: model,
-      chatModelFallback: fallbackModel !== undefined ? fallbackModel : current.chatModelFallback,
+      chatModelFallback: effectiveFallback,
     };
     await updateSiteConfig('aiConfig', updated, req.user.id);
     aiConfig.set(updated);

--- a/backend/src/scripts/cleanup-unused-wines.js
+++ b/backend/src/scripts/cleanup-unused-wines.js
@@ -1,29 +1,48 @@
 /**
  * cleanup-unused-wines.js
  *
- * Deletes all WineDefinition records that have no bottles referencing them,
- * then removes orphaned taxonomy entries (Grapes, Regions, Appellations).
+ * Deletes all WineDefinition records that nothing references anymore, then
+ * removes orphaned taxonomy entries (Grapes, Regions, Appellations).
  * Bottles and user data are never touched.
  *
- * Also cleans up:
- *   - WineVintageProfile records for the deleted wines
- *   - Meilisearch index entries for the deleted wines
- *   - Grape documents not referenced by any remaining wine
- *   - Region documents not referenced by any remaining wine
- *   - Appellation documents whose name is not used by any remaining wine
+ * "Unused" means no reference from ANY of: Bottle, WishlistItem, WineList
+ * entries (sections + auto), Discussion, RestockAlert, JournalEntry,
+ * Recommendation, Review, BottleImage, PriceTrackingRequest. A wine on a
+ * wishlist is by definition not owned as a bottle — checking bottles alone
+ * would delete exactly those wines and orphan the wishlist entries.
+ *
+ * For genuinely unused wines, also cascades:
+ *   - WineVintageProfile / WineVintagePrice records
+ *   - WineEmbedding rows (vector search)
+ *   - CommunityWinePrice rows
+ *   - WineNotDuplicate pairs involving the wine
+ *   - Meilisearch index entries
+ *
+ * DRY-RUN BY DEFAULT — prints what would be deleted. Pass --apply to delete.
  *
  * Usage (containers must be running):
  *   docker exec cellarion-backend node src/scripts/cleanup-unused-wines.js
- *
- * Or locally (requires .env):
- *   cd backend && node src/scripts/cleanup-unused-wines.js
+ *   docker exec cellarion-backend node src/scripts/cleanup-unused-wines.js --apply
  */
 
 require('dotenv').config();
 const mongoose = require('mongoose');
 const WineDefinition = require('../models/WineDefinition');
 const WineVintageProfile = require('../models/WineVintageProfile');
+const WineVintagePrice = require('../models/WineVintagePrice');
+const WineEmbedding = require('../models/WineEmbedding');
+const CommunityWinePrice = require('../models/CommunityWinePrice');
+const WineNotDuplicate = require('../models/WineNotDuplicate');
+const PriceTrackingRequest = require('../models/PriceTrackingRequest');
 const Bottle = require('../models/Bottle');
+const WishlistItem = require('../models/WishlistItem');
+const WineList = require('../models/WineList');
+const Discussion = require('../models/Discussion');
+const RestockAlert = require('../models/RestockAlert');
+const JournalEntry = require('../models/JournalEntry');
+const Recommendation = require('../models/Recommendation');
+const Review = require('../models/Review');
+const BottleImage = require('../models/BottleImage');
 const Grape = require('../models/Grape');
 const Region = require('../models/Region');
 const Appellation = require('../models/Appellation');
@@ -32,42 +51,71 @@ require('../models/Country');
 const searchService = require('../services/search');
 
 const MONGO_URI = process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar';
+const APPLY = process.argv.includes('--apply');
+
+/** All (model, path) pairs that hold a live reference to a WineDefinition. */
+const WINE_REF_SOURCES = [
+  [Bottle, 'wineDefinition'],
+  [WishlistItem, 'wineDefinition'],
+  [WineList, 'sections.entries.wine'],
+  [WineList, 'autoGroupEntries.wine'],
+  [Discussion, 'wineDefinition'],
+  [RestockAlert, 'wine'],
+  [JournalEntry, 'wine'],
+  [Recommendation, 'wine'],
+  [Review, 'wineDefinition'],
+  [BottleImage, 'wineDefinition'],
+  [PriceTrackingRequest, 'wineDefinition'],
+];
 
 async function run() {
   console.log('Connecting to MongoDB…');
   await mongoose.connect(MONGO_URI);
-  console.log('Connected.\n');
+  console.log(`Connected. Mode: ${APPLY ? 'APPLY' : 'DRY-RUN (pass --apply to delete)'}\n`);
 
   // ── Phase 1: Unused wine definitions ──────────────────────────────────────
 
   const allWineIds = await WineDefinition.distinct('_id');
   console.log(`Wine definitions total:  ${allWineIds.length}`);
 
-  const usedIds = await Bottle.distinct('wineDefinition', {
-    wineDefinition: { $in: allWineIds }
-  });
-  const usedSet = new Set(usedIds.map(id => id.toString()));
+  const usedSet = new Set();
+  for (const [Model, path] of WINE_REF_SOURCES) {
+    const ids = await Model.distinct(path);
+    for (const id of ids) {
+      if (id) usedSet.add(id.toString());
+    }
+  }
   const unusedIds = allWineIds.filter(id => !usedSet.has(id.toString()));
-  console.log(`Wines with no bottles:   ${unusedIds.length}`);
+  console.log(`Referenced anywhere:     ${usedSet.size}`);
+  console.log(`Unreferenced wines:      ${unusedIds.length}`);
 
-  if (unusedIds.length > 0) {
-    const profileResult = await WineVintageProfile.deleteMany({
-      wineDefinition: { $in: unusedIds }
-    });
-    console.log(`Deleted vintage profiles: ${profileResult.deletedCount}`);
+  if (unusedIds.length > 0 && APPLY) {
+    const cascade = [
+      [WineVintageProfile, { wineDefinition: { $in: unusedIds } }, 'vintage profiles'],
+      [WineVintagePrice, { wineDefinition: { $in: unusedIds } }, 'vintage prices'],
+      [WineEmbedding, { wineDefinition: { $in: unusedIds } }, 'embeddings'],
+      [CommunityWinePrice, { wineDefinition: { $in: unusedIds } }, 'community prices'],
+      [WineNotDuplicate, { $or: [{ wineA: { $in: unusedIds } }, { wineB: { $in: unusedIds } }] }, 'not-duplicate pairs'],
+    ];
+    for (const [Model, filter, label] of cascade) {
+      const r = await Model.deleteMany(filter);
+      console.log(`Deleted ${label}: ${r.deletedCount}`);
+    }
 
     const wineResult = await WineDefinition.deleteMany({ _id: { $in: unusedIds } });
     console.log(`Deleted wine definitions: ${wineResult.deletedCount}`);
 
-    try {
-      await searchService.initialize();
+    await searchService.initialize();
+    if (searchService.getIsAvailable?.() === false) {
+      console.warn('Meilisearch unavailable — deleted wines remain in the index until it is rebuilt.');
+    } else {
       for (const id of unusedIds) {
         await searchService.removeWine(id);
       }
       console.log('Removed deleted wines from Meilisearch index.');
-    } catch (err) {
-      console.warn(`Meilisearch cleanup skipped: ${err.message}`);
     }
+  } else if (unusedIds.length > 0) {
+    console.log('[dry-run] Would delete these wines and their profile/price/embedding/community-price rows.');
   } else {
     console.log('No unused wine definitions — skipping wine cleanup.');
   }
@@ -75,26 +123,29 @@ async function run() {
   // ── Phase 2: Orphaned taxonomy ────────────────────────────────────────────
   console.log('');
 
-  // Grapes — ObjectId refs in WineDefinition.grapes
-  const usedGrapeIds = new Set(
-    (await WineDefinition.distinct('grapes')).map(id => id.toString())
-  );
+  // Grapes — referenced by WineDefinition.grapes and Region typical/permitted lists
+  const usedGrapeIds = new Set([
+    ...(await WineDefinition.distinct('grapes')).map(id => id.toString()),
+    ...(await Region.distinct('typicalGrapes')).map(id => id.toString()),
+    ...(await Region.distinct('permittedGrapes')).map(id => id.toString()),
+  ]);
   const allGrapes = await Grape.distinct('_id');
   const unusedGrapeIds = allGrapes.filter(id => !usedGrapeIds.has(id.toString()));
   console.log(`Grapes total:            ${allGrapes.length}  unused: ${unusedGrapeIds.length}`);
-  if (unusedGrapeIds.length > 0) {
+  if (unusedGrapeIds.length > 0 && APPLY) {
     const r = await Grape.deleteMany({ _id: { $in: unusedGrapeIds } });
     console.log(`Deleted grapes:          ${r.deletedCount}`);
   }
 
-  // Regions — ObjectId ref in WineDefinition.region
-  const usedRegionIds = new Set(
-    (await WineDefinition.distinct('region')).filter(Boolean).map(id => id.toString())
-  );
+  // Regions — referenced by WineDefinition.region and as parentRegion of other regions
+  const usedRegionIds = new Set([
+    ...(await WineDefinition.distinct('region')).filter(Boolean).map(id => id.toString()),
+    ...(await Region.distinct('parentRegion')).filter(Boolean).map(id => id.toString()),
+  ]);
   const allRegions = await Region.distinct('_id');
   const unusedRegionIds = allRegions.filter(id => !usedRegionIds.has(id.toString()));
   console.log(`Regions total:           ${allRegions.length}  unused: ${unusedRegionIds.length}`);
-  if (unusedRegionIds.length > 0) {
+  if (unusedRegionIds.length > 0 && APPLY) {
     const r = await Region.deleteMany({ _id: { $in: unusedRegionIds } });
     console.log(`Deleted regions:         ${r.deletedCount}`);
   }
@@ -111,12 +162,12 @@ async function run() {
     .filter(a => !usedAppellationNames.has(a.name.toLowerCase()))
     .map(a => a._id);
   console.log(`Appellations total:      ${allAppellations.length}  unused: ${unusedAppellationIds.length}`);
-  if (unusedAppellationIds.length > 0) {
+  if (unusedAppellationIds.length > 0 && APPLY) {
     const r = await Appellation.deleteMany({ _id: { $in: unusedAppellationIds } });
     console.log(`Deleted appellations:    ${r.deletedCount}`);
   }
 
-  console.log('\nDone.');
+  console.log(APPLY ? '\nDone.' : '\nDry-run complete — nothing deleted. Re-run with --apply to delete.');
   await mongoose.disconnect();
 }
 

--- a/backend/src/scripts/dedup-post-import.js
+++ b/backend/src/scripts/dedup-post-import.js
@@ -17,6 +17,9 @@
 require('dotenv').config();
 const mongoose = require('mongoose');
 const WineDefinition = require('../models/WineDefinition');
+const WineVintageProfile = require('../models/WineVintageProfile');
+const Bottle = require('../models/Bottle');
+const searchService = require('../services/search');
 const { normalizeString } = require('../utils/normalize');
 
 const APPLY = process.argv.includes('--apply');
@@ -158,8 +161,36 @@ async function run() {
 
   console.log('\nDeleting LWIN duplicates...');
   const ids = toDelete.map(d => d.lwinId);
-  const result = await WineDefinition.deleteMany({ _id: { $in: ids } });
+
+  // Never delete a wine that bottles still reference — that would leave the
+  // bottles pointing at a nonexistent WineDefinition.
+  const referenced = await Bottle.distinct('wineDefinition', { wineDefinition: { $in: ids } });
+  const referencedSet = new Set(referenced.map(id => id.toString()));
+  const deletableIds = ids.filter(id => !referencedSet.has(id.toString()));
+  if (referencedSet.size > 0) {
+    console.log(`Skipping ${referencedSet.size} LWIN wine(s) that still have bottles referencing them.`);
+  }
+
+  const result = await WineDefinition.deleteMany({ _id: { $in: deletableIds } });
   console.log(`Deleted ${result.deletedCount} LWIN wines.`);
+
+  // Clean up the deleted wines' vintage profiles — nothing else removes them.
+  const profileResult = await WineVintageProfile.deleteMany({ wineDefinition: { $in: deletableIds } });
+  if (profileResult.deletedCount > 0) {
+    console.log(`Deleted ${profileResult.deletedCount} WineVintageProfile row(s) for the removed wines.`);
+  }
+
+  // Remove the deleted wines from Meilisearch — there is no automatic resync,
+  // so skipping this leaves ghost entries in the search index.
+  await searchService.initialize();
+  if (searchService.getIsAvailable()) {
+    for (const id of deletableIds) {
+      await searchService.removeWine(id); // logs + swallows per-doc errors itself
+    }
+    console.log(`Removed ${deletableIds.length} wine(s) from the search index.`);
+  } else {
+    console.warn('WARNING: Meilisearch is unavailable — the search index will keep ghost entries for the deleted wines until a manual full sync is run.');
+  }
 
   const remaining = await WineDefinition.countDocuments();
   console.log(`Wines remaining in DB: ${remaining}`);

--- a/backend/src/scripts/purge-user-bottles.js
+++ b/backend/src/scripts/purge-user-bottles.js
@@ -49,6 +49,10 @@ async function main() {
   const searchService = require('../services/search');
   const { safeUploadPath } = require('../services/imageProcessor');
 
+  // Connect Meilisearch too — without initialize() every removeBottle call
+  // below is a silent no-op (the service's isAvailable flag stays false).
+  await searchService.initialize();
+
   const user = await User.findOne({
     $or: [{ email: userArg.toLowerCase() }, { username: userArg }],
   }).select('username email');
@@ -109,9 +113,16 @@ async function main() {
   );
   console.log(`[purge-user-bottles] Images: ${imgRes.deletedCount} doc(s) + ${filesRemoved} file(s) deleted, ${sharedRes.modifiedCount} shared image(s) detached`);
 
-  // 3. Meilisearch (fire-and-forget per bottle, same as the API route)
-  for (const id of ids) {
-    try { searchService.removeBottle(id); } catch { /* index sync will heal */ }
+  // 3. Meilisearch — awaited per bottle. There is NO automatic index resync:
+  // anything skipped here stays in the index as a ghost entry until someone
+  // runs a manual full sync.
+  if (searchService.getIsAvailable()) {
+    for (const id of ids) {
+      await searchService.removeBottle(id); // logs + swallows per-doc errors itself
+    }
+    console.log(`[purge-user-bottles] Removed ${ids.length} bottle(s) from the search index`);
+  } else {
+    console.warn('[purge-user-bottles] WARNING: Meilisearch is unavailable — the search index will keep ghost entries for these bottles until a manual full sync is run.');
   }
 
   // 4. The bottles themselves

--- a/backend/src/scripts/seed-comparison-article.js
+++ b/backend/src/scripts/seed-comparison-article.js
@@ -68,7 +68,7 @@ const CONTENT = `
     <tr><td>AI label scanning</td><td>Yes</td><td>Limited</td><td>Yes (its core strength)</td><td>Yes</td></tr>
     <tr><td>Community ratings / discovery</td><td>Community + your own notes</td><td>Large community tasting-note database</td><td>Massive crowd ratings</td><td>Curated</td></tr>
     <tr><td>Buy wine (marketplace)</td><td>No</td><td>Price &amp; where-to-buy info</td><td>Yes — built-in marketplace</td><td>Some</td></tr>
-    <tr><td>Data export / no lock-in</td><td>Yes — CSV + full JSON/ZIP, one click</td><td>CSV export</td><td>Limited</td><td>Limited</td></tr>
+    <tr><td>Data export / no lock-in</td><td>Yes — full JSON/ZIP export, one click (CSV import supported)</td><td>CSV export</td><td>Limited</td><td>Limited</td></tr>
     <tr><td>Open source</td><td>Yes (AGPL-3.0)</td><td>No</td><td>No</td><td>No</td></tr>
     <tr><td>Privacy / GDPR</td><td>EU-hosted, GDPR-first, no ads</td><td>Varies</td><td>Ad/marketplace-funded</td><td>Varies</td></tr>
     <tr><td>Self-hostable</td><td>Yes (optional)</td><td>No</td><td>No</td><td>No</td></tr>
@@ -78,7 +78,7 @@ const CONTENT = `
 
 <h2>Cellarion — best free, privacy-first cellar manager</h2>
 <p><a href="/">Cellarion</a> is a modern wine cellar app focused on tracking and organising the collection you own. You log every bottle (vintage, producer, region, price, rating, tasting notes), arrange them across cellars and customisable racks, and see your cellar as an interactive grid or a to-scale <strong>3D room view</strong>. It sends <a href="/help">drink-window alerts</a> when a wine nears its peak, scans labels with AI, and includes a grounded AI cellar chat that recommends bottles you actually have in stock.</p>
-<p>Its stand-out is openness: it is <strong>free</strong>, <strong>open-source (AGPL-3.0)</strong>, GDPR-compliant and EU-hosted, and it lets you export everything — CSV plus a full JSON/ZIP archive with your images — in one click, so there is no lock-in. You can even self-host it. Cellarion runs in any browser and as an <a href="https://play.google.com/store/apps/details?id=app.cellarion.twa">Android app on Google Play</a>; iPhone users can install it to the home screen as a web app (PWA). The main trade-off is that it is a younger product than CellarTracker, so its community of tasting notes is smaller, and there is no separate native iOS app yet.</p>
+<p>Its stand-out is openness: it is <strong>free</strong>, <strong>open-source (AGPL-3.0)</strong>, GDPR-compliant and EU-hosted, and it lets you export everything — a full JSON/ZIP archive including your images — in one click, so there is no lock-in. You can even self-host it. Cellarion runs in any browser and as an <a href="https://play.google.com/store/apps/details?id=app.cellarion.twa">Android app on Google Play</a>; iPhone users can install it to the home screen as a web app (PWA). The main trade-off is that it is a younger product than CellarTracker, so its community of tasting notes is smaller, and there is no separate native iOS app yet.</p>
 <p><strong>Choose Cellarion if</strong> you want a clean, free, private way to track and visualise your own cellar — and the ability to take your data with you. <a href="/blog">More guides on the Cellarion blog →</a></p>
 
 <h2>CellarTracker — best for serious collectors and tasting notes</h2>
@@ -111,10 +111,10 @@ const CONTENT = `
 <p>Yes. Cellarion is free for all core features at cellarion.app — bottle tracking, cellars and racks, drink-window alerts, label scanning and data export — with no ads and no credit card required. CellarTracker is also free to use, with optional paid tiers, and Vivino is free but earns through its marketplace.</p>
 
 <h3>What is the best free alternative to CellarTracker?</h3>
-<p>Cellarion is the closest free, modern alternative to CellarTracker for cellar management. It offers bottle and rack inventory, drink-window alerts and statistics like CellarTracker, adds a 3D cellar view and AI label scanning, and is open-source with one-click CSV and JSON/ZIP export so you are never locked in. You can import an existing CellarTracker CSV into Cellarion to switch.</p>
+<p>Cellarion is the closest free, modern alternative to CellarTracker for cellar management. It offers bottle and rack inventory, drink-window alerts and statistics like CellarTracker, adds a 3D cellar view and AI label scanning, and is open-source with one-click JSON/ZIP export so you are never locked in. You can import an existing CellarTracker CSV into Cellarion to switch.</p>
 
 <h3>Can I export my wine collection and move it to another app?</h3>
-<p>It depends on the app. Cellarion gives you a one-click export of everything as CSV and as a full JSON/ZIP archive (including your images), and is open-source and self-hostable, so there is no lock-in. CellarTracker offers CSV export. Vivino and InVintory have more limited export. If portability matters, Cellarion is the safest choice.</p>
+<p>It depends on the app. Cellarion gives you a one-click export of everything as a full JSON/ZIP archive (including your images), supports CSV import from other apps, and is open-source and self-hostable, so there is no lock-in. CellarTracker offers CSV export. Vivino and InVintory have more limited export. If portability matters, Cellarion is the safest choice.</p>
 
 <h3>Which wine apps have a 3D cellar view?</h3>
 <p>Among these four, Cellarion and InVintory offer a 3D cellar/rack view. Cellarion includes a to-scale 3D room view for free; InVintory offers a 3D virtual cellar on its premium tiers. CellarTracker and Vivino do not have a 3D view.</p>
@@ -145,7 +145,9 @@ async function run() {
     tags: ['wine apps', 'cellar management', 'comparison', 'cellartracker', 'vivino', 'invintory'],
     metaTitle: META_TITLE,
     metaDescription: META_DESCRIPTION,
-    status: PUBLISH ? 'published' : 'draft',
+    // Without --publish, keep an already-published post published (re-running
+    // the seed must never silently flip it back to draft).
+    status: PUBLISH ? 'published' : (existing?.status || 'draft'),
   };
 
   if (existing) {

--- a/backend/src/scripts/seed-howto-article.js
+++ b/backend/src/scripts/seed-howto-article.js
@@ -151,7 +151,9 @@ async function run() {
     tags: ['wine collection', 'cellar management', 'how to', 'wine tracking', 'getting started'],
     metaTitle: META_TITLE,
     metaDescription: META_DESCRIPTION,
-    status: PUBLISH ? 'published' : 'draft',
+    // Without --publish, keep an already-published post published (re-running
+    // the seed must never silently flip it back to draft).
+    status: PUBLISH ? 'published' : (existing?.status || 'draft'),
   };
 
   if (existing) {

--- a/backend/src/services/aiChat.js
+++ b/backend/src/services/aiChat.js
@@ -552,6 +552,15 @@ async function chatStream(userId, message, opts, res) {
         }
         reject(err);
       });
+
+      // An aborted stream emits 'abort' — NOT 'error' — and with no listener
+      // the SDK turns it into an unhandled promise rejection (process-fatal
+      // under Node's default policy). It also means neither 'finalMessage'
+      // nor 'error' fires, so without this the promise never settles and the
+      // caller's finally (concurrency-slot release) never runs.
+      stream.on('abort', () => {
+        resolve({ usage: null, aborted: true });
+      });
     };
 
     res.on('close', () => {

--- a/backend/src/services/globalStatsService.js
+++ b/backend/src/services/globalStatsService.js
@@ -447,10 +447,14 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
 
   // ── Maturity (drink-window phase distribution) ──────────────────────────
   // Joins active bottles to reviewed WineVintageProfile and classifies each
-  // bottle against the current year. Bottles without a reviewed profile, or
-  // with NV vintage, fall into 'noProfile'.
+  // bottle against the current year. NV bottles are EXCLUDED up front (same
+  // filter as the vintage aggregations above): their reviewed profiles store
+  // RELATIVE offsets from each bottle's purchase year (0–100), which cannot
+  // be compared against absolute calendar years — including them misclassified
+  // every somm-reviewed NV bottle as 'declining'. Bottles without a reviewed
+  // profile fall into 'noProfile'.
   const maturityRaw = await safeAggregate(Bottle, [
-    { $match: { ...bottleMatch, status: 'active' } },
+    { $match: { ...bottleMatch, status: 'active', vintage: { $nin: ['NV', null, ''] } } },
     { $lookup: {
       from: 'winevintageprofiles',
       let: { wdId: '$wineDefinition', v: '$vintage' },
@@ -468,6 +472,9 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
     { $addFields: {
       maturity: {
         // Mirror utils/maturityUtils.js#classifyMaturity exactly:
+        //   - NV bottles return null there; here they are excluded by the
+        //     pipeline's vintage $nin filter instead (their profiles hold
+        //     purchase-relative offsets, not calendar years)
         //   - No profile, or a reviewed profile with no window boundaries
         //     defined, → 'noProfile' (NOT 'peak' — every window boundary in
         //     WineVintageProfile is optional, so partial profiles are real)

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -201,8 +201,12 @@ async function callClaudeJson({ client, model, maxTokens, prompt, validate }) {
       return { data: parsed, debugRaw: raw, debugReason: null };
     } catch (err) {
       if (err.status === 429 && attempt === 1) {
-        // Rate limited — wait for retry-after header (or 15 s) then retry once
-        const waitMs = (parseInt(err.headers?.['retry-after'] ?? '15', 10) + 1) * 1000;
+        // Rate limited — wait for retry-after header (or 15 s) then retry once.
+        // The SDK exposes err.headers as a fetch Headers instance, so read it
+        // via .get(); keep the plain-object lookup as a fallback for SDK
+        // versions/errors that attach a plain map.
+        const retryAfter = err.headers?.get?.('retry-after') ?? err.headers?.['retry-after'];
+        const waitMs = (parseInt(retryAfter ?? '15', 10) + 1) * 1000;
         await new Promise(r => setTimeout(r, waitMs));
         continue;
       }

--- a/backend/src/services/restockChecker.js
+++ b/backend/src/services/restockChecker.js
@@ -1,9 +1,7 @@
 const Bottle = require('../models/Bottle');
-const WineDefinition = require('../models/WineDefinition');
 const WineEmbedding = require('../models/WineEmbedding');
 const RestockAlert = require('../models/RestockAlert');
 const User = require('../models/User');
-const { planHasFeature } = require('../config/plans');
 const { createNotification } = require('./notifications');
 const { CONSUMED_STATUSES } = require('../config/constants');
 
@@ -20,7 +18,6 @@ const TOP_K = 10;
 
 /**
  * Background check after a bottle is consumed.
- * If the user is on a paid plan with restockAlerts enabled:
  *  1. Get the consumed wine's embedding
  *  2. Search for similar wines in Qdrant
  *  3. Check if the user still has any similar bottles in their cellar
@@ -34,13 +31,8 @@ async function checkRestockGap(userId, bottleId, cellarId) {
     if (!embedding || !vectorStore) return;
     if (!process.env.VOYAGE_API_KEY) return;
 
-    // Check user plan and preferences
-    const user = await User.findById(userId).select('plan planExpiresAt username displayName preferences.restockScope').lean();
+    const user = await User.findById(userId).select('username displayName preferences.restockScope').lean();
     if (!user) return;
-
-    const planExpired = user.planExpiresAt && Date.now() > new Date(user.planExpiresAt).getTime();
-    const effectivePlan = planExpired ? 'free' : (user.plan || 'free');
-    if (!planHasFeature(effectivePlan, 'restockAlerts')) return;
 
     // Get the consumed bottle with wine definition
     const bottle = await Bottle.findById(bottleId)

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -136,6 +136,13 @@ const REGISTRY = [
       const bottleIds = await Bottle.find({ user: ctx.userId }).distinct('_id');
       await Bottle.deleteMany({ user: ctx.userId });
       await searchService.removeBottles(bottleIds);
+      // The Rack entry below only purges racks in the user's OWN cellars, so a
+      // deleted bottle placed in ANOTHER owner's cellar would leave a dangling
+      // slot ref in that cellar's racks — pull those slots too.
+      await Rack.updateMany(
+        { 'slots.bottle': { $in: bottleIds } },
+        { $pull: { slots: { bottle: { $in: bottleIds } } } }
+      );
     },
     exportFragment: async (ctx) => ({ bottles: markTrunc(ctx, 'bottles', await Bottle.find({ user: ctx.userId }).limit(EXPORT_MAX).lean()) }),
   },
@@ -171,13 +178,35 @@ const REGISTRY = [
   },
   {
     model: Cellar, category: 'personal-data', userFields: ['user', 'members.user', 'userColors.user'],
-    purge: (ctx) => [
-      Cellar.deleteMany({ user: ctx.userId }),
-      // Remove the user from cellars OWNED BY OTHERS that they were a member of.
-      Cellar.updateMany({ 'members.user': ctx.userId }, { $pull: { members: { user: ctx.userId } } }),
-      // GAP FIX: also pull the matching userColors entry (was left dangling).
-      Cellar.updateMany({ 'userColors.user': ctx.userId }, { $pull: { userColors: { user: ctx.userId } } }),
-    ],
+    purge: async (ctx) => {
+      // GAP FIX: bottles inside the user's cellars that are OWNED BY OTHERS
+      // (legacy data — bottle.user is set to the cellar owner on every current
+      // creation path, but older/moved rows can differ) are missed by the
+      // user-scoped Bottle purge and would survive pointing at a deleted
+      // cellar. Delete them too, cleaning their images + search docs the same
+      // reference-safe way as the Bottle/BottleImage entries: ids collected
+      // before deleteMany, files unlinked before their only referencing docs
+      // go, shared (assignedToWine) images kept with the bottle ref detached.
+      const orphanIds = await Bottle.find({ cellar: { $in: ctx.cellarIds }, user: { $ne: ctx.userId } }).distinct('_id');
+      if (orphanIds.length > 0) {
+        const imgs = await BottleImage.find({ bottle: { $in: orphanIds }, assignedToWine: { $ne: true } })
+          .select('originalUrl processedUrl').lean();
+        for (const img of imgs) await unlinkImageFiles(img);
+        await Promise.all([
+          BottleImage.deleteMany({ bottle: { $in: orphanIds }, assignedToWine: { $ne: true } }),
+          BottleImage.updateMany({ bottle: { $in: orphanIds }, assignedToWine: true }, { $unset: { bottle: '' } }),
+          Bottle.deleteMany({ _id: { $in: orphanIds } }),
+        ]);
+        await searchService.removeBottles(orphanIds);
+      }
+      await Promise.all([
+        Cellar.deleteMany({ user: ctx.userId }),
+        // Remove the user from cellars OWNED BY OTHERS that they were a member of.
+        Cellar.updateMany({ 'members.user': ctx.userId }, { $pull: { members: { user: ctx.userId } } }),
+        // GAP FIX: also pull the matching userColors entry (was left dangling).
+        Cellar.updateMany({ 'userColors.user': ctx.userId }, { $pull: { userColors: { user: ctx.userId } } }),
+      ]);
+    },
     exportFragment: async (ctx) => ({
       cellars: markTrunc(ctx, 'cellars', await Cellar.find({ $or: [{ user: ctx.userId }, { 'members.user': ctx.userId }], deletedAt: null }).limit(EXPORT_MAX).lean()),
     }),

--- a/backend/src/utils/mentionParser.js
+++ b/backend/src/utils/mentionParser.js
@@ -1,5 +1,4 @@
 const User = require('../models/User');
-const { escapeRegex } = require('./sanitize');
 
 // Match @<username> tokens in body text. Allowed username chars mirror the
 // ones the registration flow accepts: letters, digits, dot, hyphen, underscore.
@@ -27,15 +26,22 @@ async function extractMentions(body, excludeUserId = null) {
 
   const usernames = new Set();
   for (const match of body.matchAll(MENTION_RE)) {
-    usernames.add(match[1].toLowerCase());
+    const name = match[1].toLowerCase();
+    usernames.add(name);
+    // The regex greedily swallows trailing sentence punctuation that is also a
+    // valid username char ("thanks @alice." captures "alice."). Also try the
+    // variant with trailing [._-] stripped so the intended user still resolves;
+    // whichever form actually exists in the DB matches below.
+    const stripped = name.replace(/[._-]+$/, '');
+    if (stripped !== name && stripped.length >= 3) usernames.add(stripped);
     if (usernames.size >= MAX_MENTIONS_PER_POST) break;
   }
   if (usernames.size === 0) return [];
 
-  // Mongoose username field is unique but stored as-typed. Match
-  // case-insensitively via a single $in regex.
-  const regexes = [...usernames].map(u => new RegExp(`^${escapeRegex(u)}$`, 'i'));
-  const users = await User.find({ username: { $in: regexes } }).select('_id').lean();
+  // The User schema stores usernames lowercased (lowercase: true) and unique;
+  // extractMentions lowercases too, so a plain string $in matches exactly and
+  // uses the unique index (a case-insensitive regex $in would defeat it).
+  const users = await User.find({ username: { $in: [...usernames] } }).select('_id').lean();
 
   const ids = users
     .map(u => u._id.toString())

--- a/backend/src/utils/mentionParser.test.js
+++ b/backend/src/utils/mentionParser.test.js
@@ -10,14 +10,13 @@ jest.mock('../models/User', () => {
       for (const u of list) fakeUsersByLowerUsername.set(u.username.toLowerCase(), u);
     },
     find: (filter) => {
-      // The parser passes { username: { $in: [/regex/i, ...] } }. We pull the
-      // pattern source out of each regex (it matches `^username$` after escape)
-      // and look it up in the fake map.
-      const regexes = filter?.username?.$in || [];
+      // The parser passes { username: { $in: ['name', ...] } } with plain
+      // lowercased strings (the schema stores usernames lowercased), so we
+      // look each one up in the fake map directly.
+      const names = filter?.username?.$in || [];
       const matched = [];
-      for (const re of regexes) {
-        const lower = re.source.replace(/^\^|\$$/g, '').replace(/\\(.)/g, '$1').toLowerCase();
-        const hit = fakeUsersByLowerUsername.get(lower);
+      for (const name of names) {
+        const hit = fakeUsersByLowerUsername.get(String(name).toLowerCase());
         if (hit) matched.push(hit);
       }
       return {
@@ -75,6 +74,24 @@ describe('extractMentions', () => {
 
   test('drops usernames that do not exist', async () => {
     expect(await extractMentions('hi @alice and @nobody')).toEqual(['a']);
+  });
+
+  test('resolves a mention followed by sentence punctuation', async () => {
+    // The regex captures "alice." — the trailing-punctuation-stripped variant
+    // must also be tried so the intended user still resolves.
+    expect(await extractMentions('thanks @alice.')).toEqual(['a']);
+    expect(await extractMentions('was it @alice_ or someone else')).toEqual(['a']);
+    expect(await extractMentions('ping @alice-')).toEqual(['a']);
+  });
+
+  test('still resolves usernames that legitimately end in punctuation chars', async () => {
+    User.__setUsers([{ _id: 'p', username: 'trailing.' }]);
+    expect(await extractMentions('hi @trailing.')).toEqual(['p']);
+  });
+
+  test('resolves dotted usernames without dropping their inner punctuation', async () => {
+    // "@bob.smith." → capture "bob.smith." → stripped variant "bob.smith" matches
+    expect(await extractMentions('cc @bob.smith.')).toEqual(['b']);
   });
 
   test('dedupes when the same user is mentioned multiple times', async () => {

--- a/backend/src/utils/priceValidation.js
+++ b/backend/src/utils/priceValidation.js
@@ -29,7 +29,18 @@ const ABSOLUTE_CAP = {
 // trigger on obvious mistakes but not on legitimate trophy bottles.
 const USER_MEDIAN_MULTIPLE   = 50;  // price > 50× user's own median
 const MARKET_MEDIAN_MULTIPLE = 5;   // price > 5× known WineVintagePrice
-const CENTS_HEURISTIC_FLOOR  = 10000; // only suggest cents above this
+
+// Cents-heuristic floor is derived PER CURRENCY (cap ÷ divisor, never below
+// the minimum) so it scales with the currency's magnitude the same way the
+// absolute cap does. A flat 10,000 floor made ordinary JPY (>¥10k ≈ $66) and
+// SEK bottles constantly trip the "did you mean ÷100?" hint. For USD/EUR/GBP/
+// CHF (cap 50,000) the derived floor is exactly the historical 10,000.
+const CENTS_HEURISTIC_FLOOR       = 10000; // minimum floor, and legacy flat value
+const CENTS_HEURISTIC_CAP_DIVISOR = 5;     // floor = max(FLOOR, cap / 5)
+
+function centsHeuristicFloor(cap) {
+  return Math.max(CENTS_HEURISTIC_FLOOR, cap / CENTS_HEURISTIC_CAP_DIVISOR);
+}
 
 /**
  * @param {object} input
@@ -105,8 +116,9 @@ function validatePriceSanity({
 
   // ── Rule 4: looks like cents-as-units (round to 100, large) ─────────────
   // Helpful hint, not a hard signal — many real bottles also satisfy this.
-  // Only fires above 10,000 to suppress noise.
-  if (price >= CENTS_HEURISTIC_FLOOR && price % 100 === 0) {
+  // Only fires above the currency-scaled floor to suppress noise (10,000 for
+  // USD/EUR-magnitude currencies, proportionally higher for JPY/SEK/etc.).
+  if (price >= centsHeuristicFloor(cap) && price % 100 === 0) {
     warnings.push({
       code: 'possiblyCents',
       severity: 'info',
@@ -124,4 +136,6 @@ module.exports = {
   USER_MEDIAN_MULTIPLE,
   MARKET_MEDIAN_MULTIPLE,
   CENTS_HEURISTIC_FLOOR,
+  CENTS_HEURISTIC_CAP_DIVISOR,
+  centsHeuristicFloor,
 };

--- a/backend/src/utils/priceValidation.test.js
+++ b/backend/src/utils/priceValidation.test.js
@@ -3,6 +3,7 @@ const {
   ABSOLUTE_CAP,
   USER_MEDIAN_MULTIPLE,
   MARKET_MEDIAN_MULTIPLE,
+  centsHeuristicFloor,
 } = require('./priceValidation');
 
 describe('validatePriceSanity', () => {
@@ -159,6 +160,32 @@ describe('validatePriceSanity', () => {
     it('does NOT flag large prices with cents/decimals', () => {
       const w = validatePriceSanity({ price: 25099, currency: 'USD' });
       expect(w.find(x => x.code === 'possiblyCents')).toBeUndefined();
+    });
+
+    it('scales the floor per currency — ordinary JPY/SEK prices do not trip it', () => {
+      // ¥20,000 (~$130) and 15,000 SEK are normal bottle prices, round to 100.
+      // Under the old flat 10,000 floor both fired constantly.
+      const jpy = validatePriceSanity({ price: 20000, currency: 'JPY' });
+      expect(jpy.find(x => x.code === 'possiblyCents')).toBeUndefined();
+      const sek = validatePriceSanity({ price: 15000, currency: 'SEK' });
+      expect(sek.find(x => x.code === 'possiblyCents')).toBeUndefined();
+    });
+
+    it('still flags genuinely huge round JPY/SEK prices', () => {
+      // JPY floor = 7,500,000 / 5 = 1,500,000; SEK floor = 500,000 / 5 = 100,000
+      const jpy = validatePriceSanity({ price: 2000000, currency: 'JPY' });
+      expect(jpy.find(x => x.code === 'possiblyCents')).toBeDefined();
+      const sek = validatePriceSanity({ price: 150000, currency: 'SEK' });
+      expect(sek.find(x => x.code === 'possiblyCents')).toBeDefined();
+    });
+
+    it('keeps the historical 10,000 floor for USD/EUR-magnitude currencies', () => {
+      expect(centsHeuristicFloor(ABSOLUTE_CAP.USD)).toBe(10000);
+      expect(centsHeuristicFloor(ABSOLUTE_CAP.EUR)).toBe(10000);
+      const usd = validatePriceSanity({ price: 10000, currency: 'USD' });
+      expect(usd.find(x => x.code === 'possiblyCents')).toBeDefined();
+      const eur = validatePriceSanity({ price: 9900, currency: 'EUR' });
+      expect(eur.find(x => x.code === 'possiblyCents')).toBeUndefined();
     });
   });
 

--- a/backend/src/utils/sanitize.js
+++ b/backend/src/utils/sanitize.js
@@ -7,16 +7,21 @@ const STRIP_HTML_MAX_LEN = 10_000;
 
 function stripHtml(str) {
   if (!str) return str;
+  // Routes pass raw body values, so a non-string here can be a crafted object
+  // (e.g. { length: 1e12 }) whose .length would make the scan loop unbounded.
+  if (typeof str !== 'string') return '';
   // Bound the scan to prevent CPU exhaustion (loop bound injection). Process
   // only the first STRIP_HTML_MAX_LEN chars and drop the rest — never throw:
   // routes call this on raw body fields BEFORE their length validation, so a
   // throw here would turn an oversized paste into a generic 500 instead of
   // the per-field 400 the downstream length checks produce.
-  const bounded = str.length > STRIP_HTML_MAX_LEN ? str.slice(0, STRIP_HTML_MAX_LEN) : str;
   let result = '';
   let depth = 0;
-  for (let i = 0; i < bounded.length; i++) {
-    const ch = bounded[i];
+  // Loop bound is the literal constant (not str.length) so the scan is
+  // provably bounded regardless of the input's length.
+  for (let i = 0; i < STRIP_HTML_MAX_LEN; i++) {
+    if (i >= str.length) break;
+    const ch = str[i];
     if (ch === '<') {
       depth++;
     } else if (ch === '>') {

--- a/backend/src/utils/sanitize.js
+++ b/backend/src/utils/sanitize.js
@@ -7,14 +7,16 @@ const STRIP_HTML_MAX_LEN = 10_000;
 
 function stripHtml(str) {
   if (!str) return str;
-  // Reject excessively long strings to prevent CPU exhaustion (loop bound injection)
-  if (str.length > STRIP_HTML_MAX_LEN) {
-    throw new Error(`Input exceeds maximum allowed length of ${STRIP_HTML_MAX_LEN} characters`);
-  }
+  // Bound the scan to prevent CPU exhaustion (loop bound injection). Process
+  // only the first STRIP_HTML_MAX_LEN chars and drop the rest — never throw:
+  // routes call this on raw body fields BEFORE their length validation, so a
+  // throw here would turn an oversized paste into a generic 500 instead of
+  // the per-field 400 the downstream length checks produce.
+  const bounded = str.length > STRIP_HTML_MAX_LEN ? str.slice(0, STRIP_HTML_MAX_LEN) : str;
   let result = '';
   let depth = 0;
-  for (let i = 0; i < str.length; i++) {
-    const ch = str[i];
+  for (let i = 0; i < bounded.length; i++) {
+    const ch = bounded[i];
     if (ch === '<') {
       depth++;
     } else if (ch === '>') {

--- a/backend/src/utils/sanitize.test.js
+++ b/backend/src/utils/sanitize.test.js
@@ -51,12 +51,20 @@ describe('stripHtml', () => {
     expect(stripHtml('<a href="http://evil.com" onclick="steal()">Click me</a>')).toBe('Click me');
   });
 
-  test('throws on strings exceeding 10000 characters', () => {
+  test('truncates strings exceeding 10000 characters instead of throwing', () => {
     const longStr = 'x'.repeat(10_001);
-    expect(() => stripHtml(longStr)).toThrow('exceeds maximum allowed length');
+    expect(() => stripHtml(longStr)).not.toThrow();
+    // Only the first 10,000 chars are processed; the rest is dropped so the
+    // downstream per-field length checks produce their normal 400s.
+    expect(stripHtml(longStr)).toBe('x'.repeat(10_000));
   });
 
-  test('does not throw for strings at exactly 10000 characters', () => {
+  test('drops tags in the truncated tail beyond 10000 characters', () => {
+    const longStr = 'x'.repeat(10_000) + '<script>alert(1)</script>';
+    expect(stripHtml(longStr)).toBe('x'.repeat(10_000));
+  });
+
+  test('handles strings at exactly 10000 characters unchanged', () => {
     const exactStr = 'x'.repeat(10_000);
     expect(() => stripHtml(exactStr)).not.toThrow();
     expect(stripHtml(exactStr)).toBe(exactStr);

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -68,19 +68,32 @@ export const AuthProvider = ({ children }) => {
   // Refresh: called automatically by apiFetch on 401
   // ------------------------------------------------------------------
 
-  const handleRefresh = useCallback(async () => {
-    try {
-      const res = await fetch('/api/auth/refresh', {
-        method: 'POST',
-        credentials: 'include' // sends the httpOnly refresh cookie
-      });
-      if (!res.ok) return null;
-      const data = await res.json();
-      storeToken(data.token);
-      return data.token;
-    } catch {
-      return null;
-    }
+  // Single-flight: the backend ROTATES the refresh token on every /refresh,
+  // so two concurrent calls race — the first rotation invalidates the cookie
+  // and the loser gets a 401, which apiFetch treats as "session dead" and
+  // logs the user out. Parallel 401s (any page firing several requests after
+  // the access token expires) must therefore share one in-flight refresh.
+  const refreshInFlightRef = useRef(null);
+
+  const handleRefresh = useCallback(() => {
+    if (refreshInFlightRef.current) return refreshInFlightRef.current;
+    refreshInFlightRef.current = (async () => {
+      try {
+        const res = await fetch('/api/auth/refresh', {
+          method: 'POST',
+          credentials: 'include' // sends the httpOnly refresh cookie
+        });
+        if (!res.ok) return null;
+        const data = await res.json();
+        storeToken(data.token);
+        return data.token;
+      } catch {
+        return null;
+      } finally {
+        refreshInFlightRef.current = null;
+      }
+    })();
+    return refreshInFlightRef.current;
   }, []);
 
   // ------------------------------------------------------------------

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -462,6 +462,40 @@
     "suggestGrapesConfirm": "Your suggestion has been submitted for review. Our team will add the verified varieties to the wine registry."
   },
 
+  "bottles": {
+    "title": "All bottles",
+    "loading": "Loading…",
+    "summary": "{{count}} of {{total}} bottles",
+    "backToStats": "← Back to Statistics",
+    "removeFilter": "Remove this filter",
+    "clearAll": "Clear all",
+    "noneForFilters": "No bottles match those filters.",
+    "noneInCellar": "No bottles in your cellars yet.",
+    "prev": "Previous",
+    "next": "Next",
+    "pageOf": "Page {{page}} of {{total}}",
+    "chipType": "Type: {{value}}",
+    "chipCountry": "Country: {{value}}",
+    "chipRegion": "Region: {{value}}",
+    "chipGrape": "Grape: {{value}}",
+    "chipVintage": "Vintage: {{value}}",
+    "chipProducer": "Producer: {{value}}",
+    "chipSize": "Size: {{value}}",
+    "chipRating": "Rating: {{value}}+",
+    "chipMaturity": "Maturity: {{value}}",
+    "chipSearch": "Search: \"{{value}}\"",
+    "chipPurchased": "Purchased: {{value}}",
+    "chipConsumed": "Consumed: {{value}}",
+    "chipStatus": "Status: {{value}}",
+    "status_active": "Active",
+    "status_consumed": "Consumed",
+    "status_all": "All",
+    "status_drank": "Drunk",
+    "status_gifted": "Gifted",
+    "status_sold": "Sold",
+    "status_other": "Other"
+  },
+
   "racks": {
     "title": "Storage Racks",
     "backToCellar": "← Back to Cellar",
@@ -1576,7 +1610,11 @@
     "statusSeen": "Seen",
     "statusAddedToWishlist": "Added to wishlist",
     "delete": "Delete",
-    "confirmDelete": "Delete this recommendation?"
+    "confirmDelete": "Delete this recommendation?",
+    "loadMore": "Load more",
+    "alreadyOnWishlist": "This wine is already on your wishlist.",
+    "addFailed": "Could not add to wishlist. Please try again.",
+    "wineRemoved": "This wine is no longer in the registry"
   },
   "wineDetail": {
     "appellation": "Appellation",
@@ -1671,7 +1709,8 @@
     "promptText": "Would you like to capture this moment in your wine journal?",
     "yesAddEntry": "Yes, add journal entry",
     "notNow": "Not now",
-    "dontAskAgain": "Don't ask again"
+    "dontAskAgain": "Don't ask again",
+    "loadMore": "Load more"
   },
   "restock": {
     "title": "Smart Restock",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -462,6 +462,40 @@
     "suggestGrapesConfirm": "Ditt förslag har skickats in för granskning. Vårt team lägger till de verifierade sorterna i vinregistret."
   },
 
+  "bottles": {
+    "title": "Alla flaskor",
+    "loading": "Laddar…",
+    "summary": "{{count}} av {{total}} flaskor",
+    "backToStats": "← Tillbaka till statistik",
+    "removeFilter": "Ta bort det här filtret",
+    "clearAll": "Rensa alla",
+    "noneForFilters": "Inga flaskor matchar de filtren.",
+    "noneInCellar": "Inga flaskor i dina källare ännu.",
+    "prev": "Föregående",
+    "next": "Nästa",
+    "pageOf": "Sida {{page}} av {{total}}",
+    "chipType": "Typ: {{value}}",
+    "chipCountry": "Land: {{value}}",
+    "chipRegion": "Region: {{value}}",
+    "chipGrape": "Druva: {{value}}",
+    "chipVintage": "Årgång: {{value}}",
+    "chipProducer": "Producent: {{value}}",
+    "chipSize": "Storlek: {{value}}",
+    "chipRating": "Betyg: {{value}}+",
+    "chipMaturity": "Mognad: {{value}}",
+    "chipSearch": "Sökning: \"{{value}}\"",
+    "chipPurchased": "Köpt: {{value}}",
+    "chipConsumed": "Konsumerad: {{value}}",
+    "chipStatus": "Status: {{value}}",
+    "status_active": "Aktiva",
+    "status_consumed": "Konsumerade",
+    "status_all": "Alla",
+    "status_drank": "Druckna",
+    "status_gifted": "Bortskänkta",
+    "status_sold": "Sålda",
+    "status_other": "Övriga"
+  },
+
   "racks": {
     "title": "Förvaringshyllor",
     "backToCellar": "← Tillbaka till källare",
@@ -1576,7 +1610,11 @@
     "statusSeen": "Sedd",
     "statusAddedToWishlist": "Tillagd i önskelistan",
     "delete": "Ta bort",
-    "confirmDelete": "Ta bort denna rekommendation?"
+    "confirmDelete": "Ta bort denna rekommendation?",
+    "loadMore": "Ladda fler",
+    "alreadyOnWishlist": "Det här vinet finns redan på din önskelista.",
+    "addFailed": "Kunde inte lägga till på önskelistan. Försök igen.",
+    "wineRemoved": "Det här vinet finns inte längre i registret"
   },
   "wineDetail": {
     "appellation": "Appellation",
@@ -1671,7 +1709,8 @@
     "promptText": "Vill du spara detta ögonblick i din vinjournal?",
     "yesAddEntry": "Ja, lägg till anteckning",
     "notNow": "Inte nu",
-    "dontAskAgain": "Fråga inte igen"
+    "dontAskAgain": "Fråga inte igen",
+    "loadMore": "Ladda fler"
   },
   "restock": {
     "title": "Smart påfyllning",

--- a/frontend/src/pages/AdminModerators.js
+++ b/frontend/src/pages/AdminModerators.js
@@ -82,13 +82,19 @@ export default function AdminModerators() {
 
   const promote = async (target) => {
     setPending(target._id);
+    setError(null);
     try {
       const newRoles = Array.from(new Set([...(target.roles || ['user']), 'moderator']));
       const res = await adminChangeUserRoles(apiFetch, target._id, newRoles);
+      const data = await res.json().catch(() => ({}));
       if (res.ok) {
         await fetchModerators();
         if (searchQuery) runSearch(searchQuery);
+      } else {
+        setError(data.error || t('adminModerators.failedChange', 'Failed to change role.'));
       }
+    } catch {
+      setError(t('adminModerators.failedChange', 'Failed to change role.'));
     } finally {
       setPending(null);
     }
@@ -96,16 +102,22 @@ export default function AdminModerators() {
 
   const revoke = async (target) => {
     setPending(target._id);
+    setError(null);
     try {
       const newRoles = (target.roles || []).filter(r => r !== 'moderator');
       // The backend requires a non-empty array — fall back to ['user'] if
       // moderator was somehow the only role they had.
       const finalRoles = newRoles.length > 0 ? newRoles : ['user'];
       const res = await adminChangeUserRoles(apiFetch, target._id, finalRoles);
+      const data = await res.json().catch(() => ({}));
       if (res.ok) {
         await fetchModerators();
         if (searchQuery) runSearch(searchQuery);
+      } else {
+        setError(data.error || t('adminModerators.failedChange', 'Failed to change role.'));
       }
+    } catch {
+      setError(t('adminModerators.failedChange', 'Failed to change role.'));
     } finally {
       setPending(null);
       setConfirmRevoke(null);
@@ -113,7 +125,7 @@ export default function AdminModerators() {
   };
 
   const renderUserRow = (u, { isModerator }) => {
-    const isSelf = String(u._id) === String(user.id);
+    const isSelf = String(u._id) === String(user._id);
     const displayName = u.displayName || u.username;
     return (
       <li key={u._id} className="admin-mods__row">

--- a/frontend/src/pages/AdminRequests.js
+++ b/frontend/src/pages/AdminRequests.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import {
@@ -34,6 +34,21 @@ function AdminRequests() {
   const [linkResults, setLinkResults] = useState([]);
   const [linkSearching, setLinkSearching] = useState(false);
   const [aiLookup, setAiLookup] = useState({ loading: false, error: null });
+
+  // Tracks the currently selected request id so slow async chains
+  // (AI lookup, duplicate check) can detect the selection changed
+  // mid-flight and discard their results instead of overwriting the
+  // newly selected request's form.
+  const selectedIdRef = useRef(null);
+  useEffect(() => {
+    selectedIdRef.current = selected?._id ?? null;
+  }, [selected]);
+
+  // Debounce timer + monotonic request id for the duplicate check, so
+  // per-keystroke requests are coalesced and stale responses discarded.
+  const dupTimerRef = useRef(null);
+  const dupReqIdRef = useRef(0);
+  useEffect(() => () => clearTimeout(dupTimerRef.current), []);
 
   useEffect(() => {
     fetchRequests();
@@ -122,17 +137,22 @@ function AdminRequests() {
     }
   };
 
-  const checkDuplicates = async (name, producer) => {
+  const checkDuplicates = (name, producer) => {
+    clearTimeout(dupTimerRef.current);
     if (!name || !producer) return;
-    try {
-      const res = await apiFetch(
-        `/api/admin/wines/duplicates?name=${encodeURIComponent(name)}&producer=${encodeURIComponent(producer)}&threshold=0.75`
-      );
-      const data = await res.json();
-      if (res.ok) setDuplicates(data.candidates);
-    } catch (err) {
-      console.error('Duplicate check failed:', err);
-    }
+    dupTimerRef.current = setTimeout(async () => {
+      const reqId = ++dupReqIdRef.current;
+      try {
+        const res = await apiFetch(
+          `/api/admin/wines/duplicates?name=${encodeURIComponent(name)}&producer=${encodeURIComponent(producer)}&threshold=0.75`
+        );
+        const data = await res.json();
+        if (reqId !== dupReqIdRef.current) return; // stale — a newer check superseded this one
+        if (res.ok) setDuplicates(data.candidates);
+      } catch (err) {
+        console.error('Duplicate check failed:', err);
+      }
+    }, 350);
   };
 
   const handleSelectRequest = (request) => {
@@ -154,6 +174,9 @@ function AdminRequests() {
         image: (request.image && !request.image.startsWith('data:')) ? request.image : ''
       }
     });
+    // Cancel any pending/in-flight duplicate check from the previous request
+    clearTimeout(dupTimerRef.current);
+    dupReqIdRef.current += 1;
     setDuplicates([]);
     setError(null);
     setLinkSearch('');
@@ -162,11 +185,17 @@ function AdminRequests() {
   };
 
   const handleAiLookup = async () => {
+    // Capture the request this lookup was started for — if the admin selects
+    // a different request while the AI chain is in flight, bail silently
+    // instead of overwriting the new request's form with the old data.
+    const requestId = selected._id;
+    const stale = () => selectedIdRef.current !== requestId;
     const query = [selected.wineName, selected.producer].filter(Boolean).join(' ');
     setAiLookup({ loading: true, error: null });
     try {
       const res = await getAiWineInfo(apiFetch, query);
       const data = await res.json();
+      if (stale()) return;
       if (!res.ok || !data.wine) {
         setAiLookup({ loading: false, error: 'Could not identify this wine' });
         return;
@@ -184,6 +213,7 @@ function AdminRequests() {
         newWineData.country = country._id;
         const regRes = await adminGetRegions(apiFetch, country._id);
         const regData = await regRes.json();
+        if (stale()) return;
         if (regRes.ok) {
           setRegions(regData.regions);
           const region = regData.regions.find(r => r.name.toLowerCase() === wine.region?.toLowerCase());
@@ -192,6 +222,7 @@ function AdminRequests() {
           if (region) appParams.set('region', region._id);
           const appRes = await adminGetAppellations(apiFetch, appParams);
           const appData = await appRes.json();
+          if (stale()) return;
           if (appRes.ok) setAppellations(appData.appellations || []);
         }
       }
@@ -207,6 +238,7 @@ function AdminRequests() {
       checkDuplicates(newWineData.name, newWineData.producer);
       setAiLookup({ loading: false, error: null });
     } catch {
+      if (stale()) return;
       setAiLookup({ loading: false, error: 'Network error during lookup' });
     }
   };

--- a/frontend/src/pages/AdminTaxonomy.js
+++ b/frontend/src/pages/AdminTaxonomy.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import {
@@ -74,20 +74,30 @@ function AdminTaxonomy() {
     }
   };
 
+  // Monotonic fetch id: each fetch (tab switch, create/update/delete refresh)
+  // invalidates any still in-flight response, so a slow response for the
+  // previous tab can't render its documents under the new tab.
+  const fetchSeqRef = useRef(0);
+
   const fetchItems = async () => {
+    const seq = ++fetchSeqRef.current;
     if (activeTab === 'bottleSizes') { setItems([]); setLoading(false); return; }
     setLoading(true);
     setError(null);
     try {
       const res = await adminGetTaxonomy(apiFetch, endpoints[activeTab]);
       const data = await res.json();
+      if (seq !== fetchSeqRef.current) return; // stale — a newer fetch superseded this one
       if (res.ok) {
-        setItems(data.countries || data.regions || data.grapes || data.appellations || []);
+        // Index by the tab's expected key so a mismatched response shape
+        // can't populate the list with another tab's documents.
+        setItems(data[activeTab] || []);
       }
     } catch (err) {
+      if (seq !== fetchSeqRef.current) return;
       setError('Failed to load data');
     } finally {
-      setLoading(false);
+      if (seq === fetchSeqRef.current) setLoading(false);
     }
   };
 

--- a/frontend/src/pages/Bottles.js
+++ b/frontend/src/pages/Bottles.js
@@ -12,6 +12,8 @@ const FILTER_KEYS = [
   'purchaseYear', 'consumedYear', 'status',
 ];
 
+// English fallbacks — the displayed labels come from the locale files
+// (statistics.typeLabels.* / bottles.status_*) via t() in chipLabels below.
 const TYPE_LABELS = {
   red: 'Red', white: 'White', 'rosé': 'Rosé', sparkling: 'Sparkling',
   dessert: 'Dessert', fortified: 'Fortified',
@@ -116,16 +118,21 @@ function Bottles() {
   // received, so we don't need an extra taxonomy fetch.
   const chipLabels = useMemo(() => {
     const labels = {};
-    if (filters.type) labels.type = `Type: ${TYPE_LABELS[filters.type] || filters.type}`;
+    if (filters.type) {
+      // Reuse the Statistics page's type labels so the chip matches the
+      // chart segment the user clicked.
+      const typeName = t(`statistics.typeLabels.${filters.type}`, TYPE_LABELS[filters.type] || filters.type);
+      labels.type = t('bottles.chipType', 'Type: {{value}}', { value: typeName });
+    }
     if (filters.country) {
       const name = data.items.find(b => b.wineDefinition?.country?._id === filters.country)
         ?.wineDefinition?.country?.name;
-      labels.country = `Country: ${name || filters.country}`;
+      labels.country = t('bottles.chipCountry', 'Country: {{value}}', { value: name || filters.country });
     }
     if (filters.region) {
       const name = data.items.find(b => b.wineDefinition?.region?._id === filters.region)
         ?.wineDefinition?.region?.name;
-      labels.region = `Region: ${name || filters.region}`;
+      labels.region = t('bottles.chipRegion', 'Region: {{value}}', { value: name || filters.region });
     }
     if (filters.grapes) {
       const ids = String(filters.grapes).split(',');
@@ -136,19 +143,22 @@ function Bottles() {
         }
         return id;
       });
-      labels.grapes = `Grape: ${names.join(', ')}`;
+      labels.grapes = t('bottles.chipGrape', 'Grape: {{value}}', { value: names.join(', ') });
     }
-    if (filters.vintage) labels.vintage = `Vintage: ${filters.vintage}`;
-    if (filters.producer) labels.producer = `Producer: ${filters.producer}`;
-    if (filters.bottleSize) labels.bottleSize = `Size: ${filters.bottleSize}`;
-    if (filters.minRating) labels.minRating = `Rating: ${filters.minRating}+`;
-    if (filters.maturity) labels.maturity = `Maturity: ${filters.maturity}`;
-    if (filters.search) labels.search = `Search: "${filters.search}"`;
-    if (filters.purchaseYear) labels.purchaseYear = `Purchased: ${filters.purchaseYear}`;
-    if (filters.consumedYear) labels.consumedYear = `Consumed: ${filters.consumedYear}`;
-    if (filters.status) labels.status = `Status: ${STATUS_LABELS[filters.status] || filters.status}`;
+    if (filters.vintage) labels.vintage = t('bottles.chipVintage', 'Vintage: {{value}}', { value: filters.vintage });
+    if (filters.producer) labels.producer = t('bottles.chipProducer', 'Producer: {{value}}', { value: filters.producer });
+    if (filters.bottleSize) labels.bottleSize = t('bottles.chipSize', 'Size: {{value}}', { value: filters.bottleSize });
+    if (filters.minRating) labels.minRating = t('bottles.chipRating', 'Rating: {{value}}+', { value: filters.minRating });
+    if (filters.maturity) labels.maturity = t('bottles.chipMaturity', 'Maturity: {{value}}', { value: filters.maturity });
+    if (filters.search) labels.search = t('bottles.chipSearch', 'Search: "{{value}}"', { value: filters.search });
+    if (filters.purchaseYear) labels.purchaseYear = t('bottles.chipPurchased', 'Purchased: {{value}}', { value: filters.purchaseYear });
+    if (filters.consumedYear) labels.consumedYear = t('bottles.chipConsumed', 'Consumed: {{value}}', { value: filters.consumedYear });
+    if (filters.status) {
+      const statusName = t(`bottles.status_${filters.status}`, STATUS_LABELS[filters.status] || filters.status);
+      labels.status = t('bottles.chipStatus', 'Status: {{value}}', { value: statusName });
+    }
     return labels;
-  }, [filters, data.items]);
+  }, [filters, data.items, t]);
 
   const chips = Object.entries(chipLabels);
   const total = data.total ?? 0;

--- a/frontend/src/pages/Journal.js
+++ b/frontend/src/pages/Journal.js
@@ -8,6 +8,8 @@ import './Journal.css';
 
 const JournalEntryForm = lazy(() => import('../components/JournalEntryForm'));
 
+const PAGE_SIZE = 50; // backend caps journal pages at 50
+
 const OCCASION_ICONS = {
   dinner: '🍽',
   tasting: '🍷',
@@ -18,18 +20,22 @@ const OCCASION_ICONS = {
   other: '📝'
 };
 
+// Entry dates are date-only values stored as UTC midnight, so format and
+// group them in UTC — local-time methods would show the previous day for
+// users west of UTC.
 function formatDate(dateStr) {
   return new Date(dateStr).toLocaleDateString(undefined, {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
-    day: 'numeric'
+    day: 'numeric',
+    timeZone: 'UTC'
   });
 }
 
 function getMonthKey(dateStr) {
   const d = new Date(dateStr);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
 function formatMonth(key) {
@@ -43,6 +49,7 @@ export default function Journal() {
   const [entries, setEntries] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [formOpen, setFormOpen] = useState(false);
   const [editEntry, setEditEntry] = useState(null);
   const [search, setSearch] = useState('');
@@ -65,23 +72,29 @@ export default function Journal() {
     fetchEntries();
   }, [debouncedSearch, occasion]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const fetchEntries = async () => {
+  const fetchEntries = async (loadMore = false) => {
     const seq = ++fetchSeq.current;
-    setLoading(true);
+    if (loadMore) setLoadingMore(true); else setLoading(true);
     try {
       const params = new URLSearchParams();
       if (debouncedSearch) params.set('q', debouncedSearch);
       if (occasion) params.set('occasion', occasion);
-      params.set('limit', '50');
+      params.set('limit', String(PAGE_SIZE));
+      // Append the next page after what's already shown; entries.length stays
+      // a correct offset even after local deletions shift the server list.
+      if (loadMore) params.set('skip', String(entries.length));
 
       const res = await getJournalEntries(apiFetch, params.toString());
       if (res.ok && seq === fetchSeq.current) {
         const data = await res.json();
-        setEntries(data.items || []);
+        setEntries(prev => loadMore ? [...prev, ...(data.items || [])] : (data.items || []));
         setTotal(data.total || 0);
       }
     } catch { /* ignore */ }
-    if (seq === fetchSeq.current) setLoading(false);
+    if (seq === fetchSeq.current) {
+      setLoading(false);
+      setLoadingMore(false);
+    }
   };
 
   const handleDelete = async (id) => {
@@ -238,6 +251,14 @@ export default function Journal() {
               </div>
             </div>
           ))}
+
+          {entries.length < total && (
+            <div className="journal-load-more" style={{ textAlign: 'center', marginTop: '1rem' }}>
+              <button className="btn btn-secondary" onClick={() => fetchEntries(true)} disabled={loadingMore}>
+                {loadingMore ? t('common.loading') : t('journal.loadMore', 'Load more')}
+              </button>
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/pages/Recommendations.js
+++ b/frontend/src/pages/Recommendations.js
@@ -10,6 +10,8 @@ import WineImage from '../components/WineImage';
 import ConfirmModal from '../components/ConfirmModal';
 import timeAgo from '../utils/timeAgo';
 
+const PAGE_SIZE = 50; // backend caps recommendation pages at 50
+
 export default function Recommendations() {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
@@ -17,6 +19,8 @@ export default function Recommendations() {
   const [items, setItems] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [message, setMessage] = useState(null); // { type: 'info' | 'error', text }
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
 
   useEffect(() => {
@@ -27,19 +31,27 @@ export default function Recommendations() {
   // overwrite the list for the tab the user is now viewing.
   const fetchSeq = useRef(0);
 
-  const fetchItems = async () => {
+  const fetchItems = async (loadMore = false) => {
     const seq = ++fetchSeq.current;
-    setLoading(true);
+    if (loadMore) setLoadingMore(true); else setLoading(true);
     try {
       const fetcher = tab === 'received' ? getRecommendations : getSentRecommendations;
-      const res = await fetcher(apiFetch);
+      // Request pages explicitly — without a limit the backend serves its
+      // default (20) while the tab badge shows the full total.
+      const params = new URLSearchParams();
+      params.set('limit', String(PAGE_SIZE));
+      if (loadMore) params.set('skip', String(items.length));
+      const res = await fetcher(apiFetch, params.toString());
       if (res.ok && seq === fetchSeq.current) {
         const data = await res.json();
-        setItems(data.items || []);
+        setItems(prev => loadMore ? [...prev, ...(data.items || [])] : (data.items || []));
         setTotal(data.total || 0);
       }
     } catch { /* ignore */ }
-    if (seq === fetchSeq.current) setLoading(false);
+    if (seq === fetchSeq.current) {
+      setLoading(false);
+      setLoadingMore(false);
+    }
   };
 
   const handleMarkSeen = async (id) => {
@@ -61,13 +73,21 @@ export default function Recommendations() {
   };
 
   const handleAddToWishlist = async (rec) => {
+    if (!rec.wine?._id) return; // wine was deleted from the registry
+    setMessage(null);
     try {
       const res = await addToWishlist(apiFetch, { wineDefinitionId: rec.wine._id });
       if (res.ok) {
         await updateRecommendationStatus(apiFetch, rec._id, 'added-to-wishlist');
         setItems((prev) => prev.map((r) => r._id === rec._id ? { ...r, status: 'added-to-wishlist' } : r));
+      } else if (res.status === 409) {
+        setMessage({ type: 'info', text: t('recommendations.alreadyOnWishlist', 'This wine is already on your wishlist.') });
+      } else {
+        setMessage({ type: 'error', text: t('recommendations.addFailed', 'Could not add to wishlist. Please try again.') });
       }
-    } catch { /* ignore */ }
+    } catch {
+      setMessage({ type: 'error', text: t('recommendations.addFailed', 'Could not add to wishlist. Please try again.') });
+    }
   };
 
   return (
@@ -88,6 +108,10 @@ export default function Recommendations() {
           {t('recommendations.sent')} {tab === 'sent' && total > 0 ? `(${total})` : ''}
         </button>
       </div>
+
+      {message && (
+        <div className={`alert ${message.type === 'error' ? 'alert-error' : 'alert-info'}`}>{message.text}</div>
+      )}
 
       {loading ? (
         <p className="rec-loading">{t('recommendations.loading')}</p>
@@ -154,6 +178,8 @@ export default function Recommendations() {
                     <button
                       className="btn btn-small btn-primary"
                       onClick={() => handleAddToWishlist(rec)}
+                      disabled={!rec.wine?._id}
+                      title={!rec.wine?._id ? t('recommendations.wineRemoved', 'This wine is no longer in the registry') : undefined}
                     >
                       {t('recommendations.addToWishlist')}
                     </button>
@@ -180,6 +206,14 @@ export default function Recommendations() {
             </li>
           ))}
         </ul>
+      )}
+
+      {!loading && items.length < total && (
+        <div className="rec-load-more" style={{ textAlign: 'center', marginTop: '1rem' }}>
+          <button className="btn btn-secondary" onClick={() => fetchItems(true)} disabled={loadingMore}>
+            {loadingMore ? t('common.loading') : t('recommendations.loadMore', 'Load more')}
+          </button>
+        </div>
       )}
 
       {confirmDeleteId && (

--- a/frontend/src/pages/StatsCard.js
+++ b/frontend/src/pages/StatsCard.js
@@ -59,9 +59,13 @@ export default function StatsCard() {
         title: t('statsCard.shareTitle', 'My Cellarion Stats'),
         files: [file],
       });
-    } catch {
-      // User cancelled or not supported — try download as fallback
-      handleDownload();
+    } catch (err) {
+      // AbortError means the user dismissed the share sheet — that's not a
+      // failure, so don't punish the cancel with a surprise PNG download.
+      if (err?.name !== 'AbortError') {
+        // Sharing genuinely failed / not supported — try download as fallback
+        handleDownload();
+      }
     }
     setExporting(false);
   };

--- a/frontend/src/pages/SuperAdmin/TabAI.js
+++ b/frontend/src/pages/SuperAdmin/TabAI.js
@@ -668,8 +668,11 @@ export default function TabAI() {
     finally { setEnrichBusy(false); }
   }
 
+  // Only block on loading/error before the first successful load — background
+  // reloads (job start/stop, shell refresh) keep the panels mounted so
+  // unsaved prompt drafts aren't wiped.
   if (loading) return <div className="sa-loading">Loading AI pipeline stats...</div>;
-  if (error)   return <div className="sa-error">Error: {error}</div>;
+  if (error && !data) return <div className="sa-error">Error: {error}</div>;
   if (!data)   return null;
 
   const { configured, config, job, collection, embeddings } = data;
@@ -689,6 +692,12 @@ export default function TabAI() {
 
   return (
     <>
+      {error && (
+        <div className="sa-error" style={{ marginBottom: 12, fontSize: 11 }}>
+          Refresh failed: {error} — showing last loaded data
+        </div>
+      )}
+
       {/* API keys configured */}
       <div className="sa-services-grid" style={{ marginBottom: 16 }}>
         {[

--- a/frontend/src/pages/SuperAdmin/helpers.js
+++ b/frontend/src/pages/SuperAdmin/helpers.js
@@ -1,5 +1,10 @@
-import { useState, useEffect, useCallback } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
+
+// Bumped by the SuperAdmin shell on manual Refresh / 30s auto-refresh so tabs
+// re-fetch their data in place instead of being remounted (a remount would
+// wipe unsaved edits — half-typed prompts, drafts, rate-limit changes).
+export const RefreshContext = createContext(0);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -96,13 +101,22 @@ export function Sparkline({ data }) {
 
 export function useApi(path, { skip = false } = {}) {
   const { apiFetch } = useAuth();
+  const refreshKey = useContext(RefreshContext);
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState(null);
+  const loadedPathRef = useRef(null);
 
   const load = useCallback(async () => {
     if (skip) return;
-    setLoading(true);
+    // Re-fetching the same path is a background refresh: keep the previous
+    // data on screen (so panels stay mounted and unsaved edits survive) and
+    // only flip `refreshing`. The initial load — or a new path — shows the
+    // blocking `loading` state as before.
+    const isBackground = loadedPathRef.current === path;
+    if (isBackground) setRefreshing(true);
+    else setLoading(true);
     setError(null);
     try {
       const res = await apiFetch(path);
@@ -111,14 +125,17 @@ export function useApi(path, { skip = false } = {}) {
         throw new Error(body.error || `HTTP ${res.status}`);
       }
       setData(await res.json());
+      loadedPathRef.current = path;
     } catch (e) {
       setError(e.message);
     } finally {
       setLoading(false);
+      setRefreshing(false);
     }
-  }, [apiFetch, path, skip]);
+    // refreshKey bump (shell Refresh / auto-refresh) recreates load → re-fetch
+  }, [apiFetch, path, skip, refreshKey]);
 
   useEffect(() => { load(); }, [load]);
 
-  return { data, loading, error, reload: load };
+  return { data, loading, refreshing, error, reload: load };
 }

--- a/frontend/src/pages/SuperAdmin/index.js
+++ b/frontend/src/pages/SuperAdmin/index.js
@@ -14,6 +14,7 @@ import TabCellars from './TabCellars';
 import TabImport from './TabImport';
 import TabBackups from './TabBackups';
 import TabAnnouncement from './TabAnnouncement';
+import { RefreshContext } from './helpers';
 import '../SuperAdmin.css';
 
 const TABS = [
@@ -29,6 +30,14 @@ const TABS = [
   { id: 'announcement', label: 'Announcement' },
   { id: 'settings',   label: 'Settings' },
 ];
+
+// Tabs that refresh in place (useApi re-fetches via RefreshContext) or hold
+// unsaved drafts (announcement, settings) — never remounted by a refresh.
+// The remaining list tabs (users, audit, cellars, import) manage their own
+// fetching and hold no drafts, so they keep the remount-on-refresh behavior.
+const IN_PLACE_REFRESH_TABS = new Set([
+  'overview', 'services', 'database', 'backups', 'ai', 'announcement', 'settings',
+]);
 
 export default function SuperAdmin() {
   const { user, logout, apiFetch } = useAuth();
@@ -147,20 +156,22 @@ export default function SuperAdmin() {
         ))}
       </div>
 
-      {/* Tab content — refreshKey forces remount on manual/auto refresh */}
-      <div className="sa-content" key={`${tab}-${refreshKey}`}>
-        {tab === 'overview'   && <TabOverview />}
-        {tab === 'services'   && <TabServices />}
-        {tab === 'database'   && <TabDatabase />}
-        {tab === 'backups'    && <TabBackups />}
-        {tab === 'users'      && <TabUsers />}
-        {tab === 'audit'      && <TabAudit />}
-        {tab === 'cellars'    && <TabCellars />}
-        {tab === 'import'     && <TabImport />}
-        {tab === 'ai'         && <TabAI />}
-        {tab === 'announcement' && <TabAnnouncement />}
-        {tab === 'settings'   && <TabSettings />}
-      </div>
+      {/* Tab content — see IN_PLACE_REFRESH_TABS for the remount rules. */}
+      <RefreshContext.Provider value={refreshKey}>
+        <div className="sa-content" key={IN_PLACE_REFRESH_TABS.has(tab) ? tab : `${tab}-${refreshKey}`}>
+          {tab === 'overview'   && <TabOverview />}
+          {tab === 'services'   && <TabServices />}
+          {tab === 'database'   && <TabDatabase />}
+          {tab === 'backups'    && <TabBackups />}
+          {tab === 'users'      && <TabUsers />}
+          {tab === 'audit'      && <TabAudit />}
+          {tab === 'cellars'    && <TabCellars />}
+          {tab === 'import'     && <TabImport />}
+          {tab === 'ai'         && <TabAI />}
+          {tab === 'announcement' && <TabAnnouncement />}
+          {tab === 'settings'   && <TabSettings />}
+        </div>
+      </RefreshContext.Provider>
 
       {/* Footer */}
       <div className="sa-footer">

--- a/frontend/src/pages/Wishlist.js
+++ b/frontend/src/pages/Wishlist.js
@@ -34,6 +34,10 @@ function Wishlist() {
   const [saving, setSaving] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(null);
 
+  // Per-item in-flight guard for the Bought/Undo toggle: a double-click would
+  // otherwise send two PUTs and decrement the total twice.
+  const [togglingIds, setTogglingIds] = useState(() => new Set());
+
   // Reset pagination when filters change. The reset lands one render later,
   // so derive the effective skip for the current render — otherwise a filter
   // change fires a request with the stale offset whose slow response can
@@ -78,12 +82,23 @@ function Wishlist() {
 
   useEffect(() => { fetchItems(); }, [fetchItems]);
 
+  // When the last item of a page is removed (delete / status toggle) but
+  // earlier pages still exist, step back one page instead of stranding the
+  // user on an empty page.
+  useEffect(() => {
+    if (!loading && items.length === 0 && total > 0 && skip > 0) {
+      setSkip(s => Math.max(0, s - LIMIT));
+    }
+  }, [loading, items.length, total, skip]);
+
   const handleSearchSubmit = (e) => {
     e.preventDefault();
     setSearch(searchInput);
   };
 
   const handleToggleStatus = async (item) => {
+    if (togglingIds.has(item._id)) return;
+    setTogglingIds(prev => new Set(prev).add(item._id));
     const newStatus = item.status === 'wanted' ? 'bought' : 'wanted';
     try {
       const res = await updateWishlistItem(apiFetch, item._id, { status: newStatus });
@@ -98,6 +113,12 @@ function Wishlist() {
       }
     } catch {
       setError('Failed to update status');
+    } finally {
+      setTogglingIds(prev => {
+        const next = new Set(prev);
+        next.delete(item._id);
+        return next;
+      });
     }
   };
 
@@ -204,7 +225,7 @@ function Wishlist() {
       {/* List */}
       {loading && items.length === 0 ? (
         <div className="wishlist-loading">Loading...</div>
-      ) : items.length === 0 ? (
+      ) : total === 0 ? (
         <div className="wishlist-empty">
           <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
@@ -246,6 +267,7 @@ function Wishlist() {
                     <button
                       className={`btn btn-small ${item.status === 'wanted' ? 'btn-success' : 'btn-secondary'}`}
                       onClick={() => handleToggleStatus(item)}
+                      disabled={togglingIds.has(item._id)}
                       title={item.status === 'wanted' ? 'Mark as bought' : 'Move back to wanted'}
                     >
                       {item.status === 'wanted' ? 'Bought' : 'Undo'}

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -547,6 +547,11 @@ function tryParseDate(str) {
   if (/^\d{4}$/.test(str.trim())) {
     return `${str.trim()}-01-01`;
   }
+  // Already ISO (date-only or full timestamp): keep the calendar date as-is.
+  // Date-only ISO strings parse as UTC midnight, so round-tripping them
+  // through Date would shift the day for users west of UTC.
+  const iso = String(str).trim().match(/^(\d{4}-\d{2}-\d{2})(?:[T\s]|$)/);
+  if (iso) return iso[1];
   const d = new Date(str);
   if (isNaN(d.getTime())) return undefined;
   // Format from LOCAL date parts. Non-ISO strings ("10/30/2024") parse as
@@ -749,12 +754,14 @@ export function parseOenoExport(text) {
       notes: (cells[idx.note] || '').trim(),
       price: isNaN(cost) ? undefined : cost,
       currency: (cells[idx.currency] || '').trim() || undefined,
-      purchaseDate: (cells[idx.purchase] || '').trim() || undefined,
+      purchaseDate: tryParseDate((cells[idx.purchase] || '').trim()),
     };
 
     if (consumedAt) {
       baseItem.addToHistory = true;
-      baseItem.consumedAt = consumedAt;
+      // Normalise like the CSV/JSON paths do — parseOenoExport returns
+      // directly from parseAndMap, so its dates skip the shared fix-up loop.
+      baseItem.consumedAt = tryParseDate(consumedAt);
       baseItem.consumedReason = 'drank';
     }
 
@@ -879,8 +886,10 @@ export function parseAndMap(text, forceFormat) {
   for (const row of rows) {
     const mapped = mapper(row);
 
-    // Fix dates
+    // Normalise dates (mirror parseJSON)
     if (mapped.purchaseDate) mapped.purchaseDate = tryParseDate(mapped.purchaseDate);
+    if (mapped.consumedAt)   mapped.consumedAt   = tryParseDate(mapped.consumedAt);
+    if (mapped.dateAdded)    mapped.dateAdded    = tryParseDate(mapped.dateAdded);
 
     // Skip rows with no wine name and no producer
     if (!mapped.wineName && !mapped.producer) continue;

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -492,6 +492,23 @@ describe('parseAndMap', () => {
     expect(result.items[0].bottleSize).toBe('750ml');
   });
 
+  it('normalises purchaseDate, consumedAt and dateAdded to ISO dates', () => {
+    const csv = 'wineName,producer,vintage,purchaseDate,consumedAt,dateAdded\n' +
+      'Margaux,Chateau Margaux,2015,10/30/2024,11/26/2024,2024-01-05';
+    const result = parseAndMap(csv);
+    expect(result.items[0].purchaseDate).toBe('2024-10-30');
+    expect(result.items[0].consumedAt).toBe('2024-11-26');
+    expect(result.items[0].dateAdded).toBe('2024-01-05');
+  });
+
+  it('keeps the calendar date of full ISO timestamps (no timezone day-shift)', () => {
+    const json = JSON.stringify([
+      { wineName: 'Margaux', producer: 'CM', consumedAt: '2024-11-26T23:30:00.000Z' },
+    ]);
+    const result = parseJSON(json);
+    expect(result.items[0].consumedAt).toBe('2024-11-26');
+  });
+
   it('maps wine type from Vivino type field', () => {
     const csv = 'Wine name,Winery,Wine type\nBubbly,Domaine,Sparkling';
     const result = parseAndMap(csv);

--- a/frontend/src/utils/isoCountryCodes.js
+++ b/frontend/src/utils/isoCountryCodes.js
@@ -1,7 +1,8 @@
 /**
  * ISO 3166-1 alpha-2 → numeric code lookup.
- * Numeric codes are stored without leading zeros to match the world-atlas
- * TopoJSON feature IDs (which are JSON numbers, e.g. 250 for France, 4 for Afghanistan).
+ * Numeric codes are stored here without leading zeros; NUM_TO_A2 below also
+ * carries the zero-padded 3-character form used by world-atlas TopoJSON
+ * feature IDs (e.g. "004" for Afghanistan, "250" for France).
  *
  * Used by the WorldMapChart to correlate country ISO alpha-2 codes from the
  * stats API with the topology geometry IDs from world-atlas/countries-110m.json.
@@ -52,11 +53,15 @@ const A2_TO_NUM = {
 
 /**
  * Reverse lookup: ISO numeric string → alpha-2.
- * Keys match the string representation of world-atlas TopoJSON feature IDs.
- * e.g. "250" → "FR", "4" → "AF"
+ * world-atlas TopoJSON feature IDs are zero-padded 3-character strings
+ * ("004" for Afghanistan, "032" for Argentina), while the table above stores
+ * codes without leading zeros — so the map carries BOTH forms as keys
+ * ("4" → "AF" and "004" → "AF") and any consumer spelling resolves.
  */
-export const NUM_TO_A2 = Object.fromEntries(
-  Object.entries(A2_TO_NUM).map(([a2, num]) => [num, a2])
-);
+export const NUM_TO_A2 = Object.entries(A2_TO_NUM).reduce((map, [a2, num]) => {
+  map[num] = a2;
+  map[num.padStart(3, '0')] = a2;
+  return map;
+}, {});
 
 export default A2_TO_NUM;


### PR DESCRIPTION
## Summary

Fixes all 6 HIGH and ~30 MEDIUM findings from the 2026-07-06 full-codebase audit (10 parallel review streams over v1.67.6, every finding verified against `main` before fixing).

### HIGH
- **aiChat**: client disconnect mid-SSE-stream raised an unhandled `APIUserAbortError` (process-fatal under Node 20) and permanently leaked a chat-concurrency slot — added the missing `abort` handler + a process-level `unhandledRejection` log backstop.
- **restockChecker**: `planHasFeature` no longer exists (plan-grants removal) — every restock check threw and was swallowed; the feature was 100% dead. Gate removed (all features are free).
- **Notification**: enum was missing `price_tracked`/`price_tracking_declined` — price-tracking notifications silently never sent.
- **AuthContext**: token refresh is now single-flight — concurrent 401s each rotated the refresh token, and the losers logged the user out ("random logout" bug).
- **Rack NFC**: unlink stored an explicit `null` under a unique-sparse index — the second unlink ever failed with a misleading 409. Now `$unset`s + startup migration cleans existing nulls.
- **cleanup-unused-wines**: deleted wines still referenced by wishlists/wine lists/discussions/etc. with no dry-run — now checks all 11 referencing collections, cascades side collections, and is dry-run by default.

### MEDIUM (highlights — full list in the commit messages)
- Shared-cellar editors' photos silently lost on link-to-bottle; private-profile review leak; "remember me = off" cookies upgraded to persistent on refresh; soft-deleted cellars fully writable by direct id; consume-with-long-note leaving bottles derackled; discussions delete cascade orphaning replies.
- `stripHtml` 500s on >10k pastes; JPY/SEK false "cents?" price warnings; sentence-final `@mentions` never notifying; NV bottles misclassified in global stats; GDPR purge dangling refs; stale help content misinforming the AI assistant; Meilisearch ghost entries from two scripts; seed scripts unpublishing live articles + false CSV-export marketing claims.
- World map missing every country with ISO code <100; import dates off-by-one across timezones; SuperAdmin refresh wiping unsaved prompt/announcement/settings drafts; AdminRequests AI-lookup writing the previous request's data onto a new one; Wishlist/Journal/Recommendations pagination and double-click bugs; full `bottles.*` sv+en i18n namespace (page was English-only for Swedish users).

### Not in this PR
LOW/quality findings (dead code, duplication, comment drift, a11y) — deferred to a follow-up cleanup PR to keep this reviewable.

## Testing
- Backend Jest: **41 suites / 785 tests passed** (7 new tests: stripHtml truncation, per-currency price floors, mention punctuation, import date normalization)
- Frontend Vitest: **11 files / 308 tests passed** (2 new)

## Deploy / docker-compose impact
- **None** to compose files, images, env vars, or dependencies — code-only.
- Two idempotent startup migrations run on first boot: conditional drop of the legacy cellar name index (no longer re-drops every boot) and `$unset` of explicit-null `rfidTag` values.
- New `User.refreshTokenPersistent` field (internal, scrubbed from JSON) — no migration needed; existing sessions keep persistent-cookie behavior until next login.