### PR TITLE
chore(release): v1.67.7

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.6",
+  "version": "1.67.7",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.67.6",
+  "version": "1.67.7",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for the v1.67.7 patch release.

Contains one change since v1.67.6:
- #570 — 2026-07-06 code-audit remediation: 6 HIGH + ~30 MEDIUM verified bug fixes across backend and frontend. Highlights: aiChat client-disconnect crash + chat-slot leak, restock-alerts revived (dead `planHasFeature` gate removed), price-tracking notifications delivered (Notification enum), single-flight token refresh (random-logout fix), NFC unlink 409, `cleanup-unused-wines` reference-safety + dry-run, shared-cellar photo-loss, soft-deleted-cellar write guard, world-map <100 ISO codes, SuperAdmin draft-preserving refresh, and the full `bottles.*` sv/en i18n namespace. CodeQL clean; backend 785 tests, frontend 308 tests passing.

## Deploy notes
- Code-only — no docker-compose, env, or dependency changes.
- Two idempotent startup migrations run on first backend boot: conditional drop of the legacy cellar name index (previously re-dropped every boot) and `$unset` of explicit-null `rfidTag` values left by the old NFC unlink flow.
- New internal `User.refreshTokenPersistent` field (scrubbed from JSON output) — no migration required; existing sessions keep persistent-cookie behavior until next login.