### PR TITLE
fix: guard null taxonomy refs in cleanup-unused-wines dry-run

### DIFF
--- a/backend/src/scripts/cleanup-unused-wines.js
+++ b/backend/src/scripts/cleanup-unused-wines.js
@@ -125,9 +125,9 @@ async function run() {
 
   // Grapes — referenced by WineDefinition.grapes and Region typical/permitted lists
   const usedGrapeIds = new Set([
-    ...(await WineDefinition.distinct('grapes')).map(id => id.toString()),
-    ...(await Region.distinct('typicalGrapes')).map(id => id.toString()),
-    ...(await Region.distinct('permittedGrapes')).map(id => id.toString()),
+    ...(await WineDefinition.distinct('grapes')).filter(Boolean).map(id => id.toString()),
+    ...(await Region.distinct('typicalGrapes')).filter(Boolean).map(id => id.toString()),
+    ...(await Region.distinct('permittedGrapes')).filter(Boolean).map(id => id.toString()),
   ]);
   const allGrapes = await Grape.distinct('_id');
   const unusedGrapeIds = allGrapes.filter(id => !usedGrapeIds.has(id.toString()));


### PR DESCRIPTION
Follow-up to #570. Running the hardened `cleanup-unused-wines.js` dry-run live against v1.67.7 surfaced a crash in the taxonomy phase:

```
Cleanup failed: TypeError: Cannot read properties of undefined (reading 'toString')
    at .../cleanup-unused-wines.js:128
```

`WineDefinition.distinct('grapes')` and `Region.distinct('typicalGrapes'/'permittedGrapes')` can return arrays containing `null`, and the grape-usage set mapped `id.toString()` without the `.filter(Boolean)` guard the region lookups already have.

The dry-run failed safe (deleted nothing, exit 1) — this just lets it complete. Verified live: dry-run now finishes cleanly (Grapes 0 unused, Regions 2 unused, Appellations 0 unused) and deletes nothing.

Script-only change — no runtime, compose, or dependency impact; no new release needed.