### PR TITLE
fix: CSV import quantity (Cellarion format) + Pending-review donut segment

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -192,9 +192,18 @@ router.get('/', async (req, res) => {
       }
       wdFilter.grapes = grapeIds2.length === 1 ? grapeIds2[0] : { $in: grapeIds2 };
     }
+    // 'unknown' is the stats bucket for bottles WITHOUT a wine definition
+    // (typically pending wine requests from an import) — no WineDefinition
+    // ever has that type, so it must match null-wineDefinition bottles
+    // instead of going into the wd pre-query.
+    let includeNoWine = false;
     if (type) {
       const types = String(type).split(',').map(t => t.trim()).filter(Boolean);
-      wdFilter.type = types.length === 1 ? types[0] : { $in: types };
+      includeNoWine = types.includes('unknown');
+      const realTypes = types.filter(t => t !== 'unknown');
+      if (realTypes.length > 0) {
+        wdFilter.type = realTypes.length === 1 ? realTypes[0] : { $in: realTypes };
+      }
     }
     if (producer) {
       // Producer is a free-text field on WineDefinition; match case-insensitively
@@ -206,10 +215,13 @@ router.get('/', async (req, res) => {
 
     if (Object.keys(wdFilter).length > 0) {
       const wdIds = await WineDefinition.find(wdFilter).distinct('_id');
-      if (wdIds.length === 0) {
+      if (wdIds.length === 0 && !includeNoWine) {
         return res.json({ bottles: { count: 0, total: 0, limit, skip, items: [] } });
       }
-      filter.wineDefinition = { $in: wdIds };
+      // $in with null matches bottles whose wineDefinition is null or absent.
+      filter.wineDefinition = includeNoWine ? { $in: [...wdIds, null] } : { $in: wdIds };
+    } else if (includeNoWine) {
+      filter.wineDefinition = null;
     }
 
     const directSortFields = ['createdAt', 'vintage', 'price', 'rating'];

--- a/frontend/src/components/charts/chartHelpers.js
+++ b/frontend/src/components/charts/chartHelpers.js
@@ -8,7 +8,10 @@ export const TYPE_COLORS = {
   sparkling: '#6EC6C6',
   dessert:   '#D4A070',
   fortified: '#8B6A9A',
-  unknown:   '#6a6a6a',
+  // Bottles without a wine definition (pending review). Must stay clearly
+  // lighter than the donut's #252525 background track or the segment reads
+  // as an unexplained black gap.
+  unknown:   '#B8B2A6',
 };
 
 export const REASON_COLORS = {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1098,7 +1098,7 @@
       "sparkling": "Sparkling",
       "dessert": "Dessert",
       "fortified": "Fortified",
-      "unknown": "Unknown"
+      "unknown": "Pending review"
     },
 
     "ratingBands": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1098,7 +1098,7 @@
       "sparkling": "Mousserande",
       "dessert": "Dessertvin",
       "fortified": "Starkvin",
-      "unknown": "Okänt"
+      "unknown": "Väntar på granskning"
     },
 
     "ratingBands": {

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -498,13 +498,20 @@ function mapGenericRow(row) {
 /**
  * Map a row from Cellarion's own CSV export.
  * Headers are already in master format (camelCase), so pass through directly.
+ *
+ * Cellarion exports are one row per bottle and carry no quantity column, but
+ * hand-written files in this format legitimately use one — honor it like the
+ * other mappers do (parseAndMap expands quantity > 1 into individual items).
  */
 function mapCellarionRow(row) {
   const str = (key) => (row[key] || '').trim();
   const num = (key) => { const n = parseLocaleNumber(row[key]); return isNaN(n) ? undefined : n; };
   const int = (key) => { const n = parseInt(row[key], 10); return isNaN(n) ? undefined : n; };
 
+  const qty = parseInt(row.quantity ?? row.Quantity ?? row.qty ?? row.Qty, 10);
+
   return {
+    quantity: isNaN(qty) || qty < 1 ? 1 : qty,
     wineName: str('wineName'),
     producer: str('producer'),
     vintage: str('vintage') || 'NV',

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -426,6 +426,21 @@ describe('parseAndMap', () => {
     expect(result.items[0].producer).toBe('Chateau Margaux');
   });
 
+  it('expands quantity in Cellarion-format CSV (hand-written files)', () => {
+    const csv = 'wineName,producer,vintage,quantity\nMargaux,Chateau Margaux,2015,3\nOpus One,Opus One Winery,2018,1';
+    const result = parseAndMap(csv);
+    expect(result.format).toBe('cellarion');
+    expect(result.items).toHaveLength(4);
+    expect(result.items.filter(i => i.wineName === 'Margaux')).toHaveLength(3);
+    expect(result.items[0].quantity).toBeUndefined();
+  });
+
+  it('accepts capitalized Quantity header in Cellarion-format CSV', () => {
+    const csv = 'wineName,producer,vintage,Quantity\nMargaux,Chateau Margaux,2015,2';
+    const result = parseAndMap(csv);
+    expect(result.items).toHaveLength(2);
+  });
+
   it('returns empty items for empty CSV (header only)', () => {
     const csv = 'Wine name,Winery,Vintage';
     const result = parseAndMap(csv);


### PR DESCRIPTION
## Summary

Fixes the two bugs from a user report (~800-bottle import):

**1. Quantity ignored in Cellarion-format CSV imports.** `mapCellarionRow` was the only mapper without `quantity` support, and hand-written CSVs using our own camelCase headers (`wineName`/`producer`/`vintage`) are detected as that format — so a `quantity` column was silently dropped and every row imported as a single bottle. Now parsed and expanded exactly like the Vivino/CellarTracker/generic mappers. Additive: Cellarion's own exports are one row per bottle with no quantity column, so real exports are unaffected; all other format mappers untouched.

**2. The "black donut segment" on Statistics.** Bottles with no wine definition (pending wine requests, typically from unmatched import rows) are bucketed as `unknown`: colored `#6a6a6a` — indistinguishable from the donut's `#252525` background track — and clicking it filtered `type=unknown`, which no wine can ever match, so the segment "pointed to nothing."
- Relabeled **Pending review** (en) / **Väntar på granskning** (sv) — the label also flows to the Bottles filter chip, which reuses `statistics.typeLabels.*`.
- Recolored to a visible neutral (`#B8B2A6`).
- Backend: `type=unknown` on `GET /api/bottles` now resolves to bottles whose `wineDefinition` is null (via `$in` with `null`, composable with other type values), so clicking the segment shows exactly those bottles.

## Testing
- Frontend Vitest: **11 files / 310 tests passed** (2 new: quantity expansion + capitalized `Quantity` header in Cellarion-format CSV)
- Backend Jest: **41 suites / 785 tests passed**

## Deploy / docker-compose impact
None — code-only, no migrations, no env or dependency changes.