### PR TITLE
feat: Sonnet 5 defaults for registry-feeding AI + prompt hardening (ghost wines, producer-in-name, NZ maturity)

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -31,12 +31,13 @@ Use all available information — text on the label, your knowledge of real wine
 - Infer the wine type and grapes from all available clues — appellation rules, producer style, label design, bottle shape, language
 
 Respond with ONLY a raw JSON object (no markdown, no code fences, no extra text):
-{"name":"wine name without vintage year","producer":"producer or winery name","vintage":"4-digit year or null","country":"country","region":"wine region","appellation":"appellation/AOC/DOC/IGT/AVA or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
+{"name":"wine name WITHOUT the vintage year and WITHOUT the producer name","producer":"producer or winery name","vintage":"4-digit year or null","country":"country","region":"wine region","appellation":"appellation/AOC/DOC/IGT/AVA or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
 
 confidence: 1.0 = label clearly readable and matches a wine you know well, 0.7 = some fields inferred from appellation/producer knowledge, 0.4 = mostly inferred from limited clues, 0.2 = very uncertain.
 
 Important rules:
 - Never invent a wine that does not exist. If you can read a producer name or label text, use it exactly — do not guess or substitute a similar-sounding wine.
+- The name field must contain ONLY the wine's own cuvée/vineyard/variety name — never repeat the producer in it (producer "Chard Farm" + name "River Run Pinot Noir", NOT name "Chard Farm River Run Pinot Noir").
 - Do not hallucinate appellation names, producer names, or grape varieties. Only use names you are confident are real and match what is visible on the label or your knowledge of that specific producer/appellation.
 - If a field is genuinely unknown and cannot be reliably inferred, set it to null rather than guessing.
 - Only return {"error":"cannot read label"} if the image contains no wine label at all.`;
@@ -53,6 +54,8 @@ Return ONLY a raw JSON object (no markdown, no code fences):
 
 Rules:
 - Use the wine name and producer exactly as given (correct only obvious typos)
+- The name field must contain ONLY the wine's own cuvée/vineyard/variety name — never prepend or repeat the producer in it. If the given name starts with the producer name, strip that prefix (producer "Penfolds" + name "Penfolds Bin 407" → name "Bin 407")
+- NEVER change the wine into a different wine: do not add a grape variety, cuvée, or vineyard to the name that the given data does not mention, and do not substitute another wine from the same producer. If the given name does not match a wine this producer actually makes, keep the name as given rather than "correcting" it to a similar-sounding wine
 - Fill in country, region, appellation, type, and grapes from your wine knowledge
 - Country is REQUIRED — always provide a country name; it is never acceptable to return null for country
 - For any other field you are unsure about, use null — do NOT omit the field
@@ -72,6 +75,8 @@ Return ONLY a raw JSON object (no markdown, no code fences, no extra text):
 
 Rules:
 - Extract the wine name and producer from the query
+- The name field must contain ONLY the wine's own cuvée/vineyard/variety name — never prepend or repeat the producer in it (producer "Penfolds" + name "Bin 407", NOT name "Penfolds Bin 407")
+- Do not add a grape variety or cuvée to the name that the query does not mention, and do not substitute a different wine from the same producer
 - Fill in country, region, appellation, type, and grapes from your wine knowledge
 - Country is REQUIRED — always provide a country name; it is never acceptable to return null for country
 - For any other unknown field use null; use [] for unknown grapes, never null
@@ -102,13 +107,15 @@ Consider:
 - The vintage quality and its effect on aging (structure vs approachability)
 - The producer's known style ONLY if the producer is well-established
 - Regional norms, but do NOT assume prestige based on region alone
+- The likely closure: screw caps (the norm in New Zealand and Australia) age wine reliably and slightly more slowly than cork — never shorten a window because of a screw cap; these wines often reward MORE patience, not less
 
 Critical rules:
-- If the wine is NOT explicitly classified (e.g. Grand Cru, Premier Cru, Cru Classé, Cru Bourgeois officially recognized) AND is not a single-vineyard bottling, assume conservative aging potential and bias strongly toward early drinking.
+- The classification rules below apply to wines from regions WITH formal classification systems (mainly Europe). New World regions (New Zealand, Australia, South Africa, the Americas) have no Grand Cru/Cru Classé system — for these, the ABSENCE of a classification does NOT imply entry-level or early drinking. Judge New World wines by producer reputation, single-vineyard/reserve designations, and realistic regional norms instead: quality New Zealand Pinot Noir (e.g. Central Otago, Martinborough) typically peaks 5–10 years after vintage; quality Australian Cabernet and Shiraz 8–15 years; Hunter Valley Semillon and quality Australian/NZ Riesling can age for decades.
+- If a EUROPEAN wine is NOT explicitly classified (e.g. Grand Cru, Premier Cru, Cru Classé, Cru Bourgeois officially recognized) AND is not a single-vineyard bottling, assume conservative aging potential and bias strongly toward early drinking.
 - Unclassified or entry-level wines rarely exceed 8–10 years total aging.
 - Single-vineyard wines may justify moderately longer aging (10–15 years) even without a formal classification.
 - Do NOT infer Cru Bourgeois, Médoc structure, or long-aging capability unless explicitly stated.
-- If total estimated aging exceeds 15 years, sommNotes MUST explicitly justify why this wine qualifies (quality tier, single vineyard, producer reputation, structure).
+- If total estimated aging exceeds 15 years, sommNotes MUST explicitly justify why this wine qualifies (quality tier, single vineyard, producer reputation, structure, regional track record).
 - If you cannot confidently estimate without making assumptions, return {"error":"unknown"}.
 
 Return ONLY a raw JSON object (no markdown, no code fences, no extra text):
@@ -248,7 +255,9 @@ Rules:
 const VALID_CHAT_MODELS = [
   'claude-haiku-4-5-20251001',
   'claude-sonnet-4-6',
+  'claude-sonnet-5',
   'claude-opus-4-6',
+  'claude-opus-4-8',
 ];
 
 const DEFAULT_SYSTEM_PROMPT =
@@ -282,21 +291,27 @@ const defaults = {
   embeddingBatchDelayMs: 500,
   chatDailyLimit: 50,
   chatModel: 'claude-haiku-4-5-20251001',
-  chatModelFallback: null,
+  // Retry model for 429/529 on the chat path (Sonnet 5: near-Opus quality,
+  // different capacity pool than Haiku).
+  chatModelFallback: 'claude-sonnet-5',
   chatSystemPrompt: DEFAULT_SYSTEM_PROMPT,
+  // Wine identification (label scan / import lookup / text search / maturity)
+  // defaults to Sonnet 5: these results are written into the SHARED registry,
+  // where a hallucinated wine or misnamed entry pollutes every user's search.
+  // The quality gap over Haiku is what keeps ghost wines out.
   labelScanPrompt: DEFAULT_LABEL_SCAN_PROMPT,
-  labelScanModel: 'claude-haiku-4-5-20251001',
+  labelScanModel: 'claude-sonnet-5',
   importLookupPrompt: DEFAULT_IMPORT_LOOKUP_PROMPT,
-  importLookupModel: 'claude-haiku-4-5-20251001',
+  importLookupModel: 'claude-sonnet-5',
   maturitySuggestPrompt: DEFAULT_MATURITY_SUGGEST_PROMPT,
   maturitySuggestPromptNv: DEFAULT_MATURITY_SUGGEST_PROMPT_NV,
-  maturitySuggestModel: 'claude-haiku-4-5-20251001',
+  maturitySuggestModel: 'claude-sonnet-5',
   priceSuggestPrompt: DEFAULT_PRICE_SUGGEST_PROMPT,
   priceSuggestModel: 'claude-haiku-4-5-20251001',
   // Wine enrichment (AI tasting/style profile). Defaults to Sonnet because this
   // is a knowledge-recall task where the quality gap over Haiku is meaningful.
   enrichmentPrompt: DEFAULT_ENRICHMENT_PROMPT,
-  enrichmentModel: 'claude-sonnet-4-6',
+  enrichmentModel: 'claude-sonnet-5',
 };
 
 let cache = { ...defaults };

--- a/frontend/src/pages/SuperAdmin/TabAI.js
+++ b/frontend/src/pages/SuperAdmin/TabAI.js
@@ -11,24 +11,32 @@ const CHAT_MODELS = [
     id: 'claude-haiku-4-5-20251001',
     name: 'Claude Haiku 4.5',
     description: 'Fast & affordable — recommended for Cellar Chat',
-    inputPrice: '$0.80',
-    outputPrice: '$4.00',
+    inputPrice: '$1.00',
+    outputPrice: '$5.00',
     tier: 'economy',
   },
   {
     id: 'claude-sonnet-4-6',
     name: 'Claude Sonnet 4.6',
-    description: 'Latest Sonnet — high quality at standard price',
+    description: 'Previous-generation Sonnet — high quality at standard price',
     inputPrice: '$3.00',
     outputPrice: '$15.00',
     tier: 'standard',
   },
   {
-    id: 'claude-opus-4-6',
-    name: 'Claude Opus 4.6',
+    id: 'claude-sonnet-5',
+    name: 'Claude Sonnet 5',
+    description: 'Near-Opus quality — recommended for wine identification & profiles ($2/$10 intro until Aug 2026)',
+    inputPrice: '$3.00',
+    outputPrice: '$15.00',
+    tier: 'standard',
+  },
+  {
+    id: 'claude-opus-4-8',
+    name: 'Claude Opus 4.8',
     description: 'Most capable — best for complex palate matching',
-    inputPrice: '$15.00',
-    outputPrice: '$75.00',
+    inputPrice: '$5.00',
+    outputPrice: '$25.00',
     tier: 'premium',
   },
 ];
@@ -409,7 +417,7 @@ function EnrichmentModelPanel({ currentModel, apiFetch }) {
       groupName="enrichmentModel"
       intro="Model used to generate each wine's AI tasting/style profile (body, tannin, flavours, food pairings, description). This is a knowledge-recall task — Sonnet is recommended over Haiku for richer, more accurate profiles."
       currentModel={currentModel}
-      defaultModel="claude-sonnet-4-6"
+      defaultModel="claude-sonnet-5"
       successMsg="Saved — takes effect on next enrichment run"
       apiFetch={apiFetch}
     />
@@ -1089,16 +1097,16 @@ export default function TabAI() {
       )}
       <ChatModelPanel currentModel={config.chatModel} currentFallback={config.chatModelFallback || null} apiFetch={apiFetch} />
       <SystemPromptPanel prompt={config.chatSystemPrompt || ''} apiFetch={apiFetch} />
-      <LabelScanModelPanel currentModel={config.labelScanModel || 'claude-haiku-4-5-20251001'} apiFetch={apiFetch} />
+      <LabelScanModelPanel currentModel={config.labelScanModel || 'claude-sonnet-5'} apiFetch={apiFetch} />
       <LabelScanPromptPanel prompt={config.labelScanPrompt || ''} apiFetch={apiFetch} />
-      <ImportLookupModelPanel currentModel={config.importLookupModel || 'claude-haiku-4-5-20251001'} apiFetch={apiFetch} />
+      <ImportLookupModelPanel currentModel={config.importLookupModel || 'claude-sonnet-5'} apiFetch={apiFetch} />
       <ImportLookupPromptPanel prompt={config.importLookupPrompt || ''} apiFetch={apiFetch} />
-      <MaturitySuggestModelPanel currentModel={config.maturitySuggestModel || 'claude-haiku-4-5-20251001'} apiFetch={apiFetch} />
+      <MaturitySuggestModelPanel currentModel={config.maturitySuggestModel || 'claude-sonnet-5'} apiFetch={apiFetch} />
       <MaturitySuggestPromptPanel prompt={config.maturitySuggestPrompt || ''} apiFetch={apiFetch} />
       <MaturitySuggestPromptNvPanel prompt={config.maturitySuggestPromptNv || ''} apiFetch={apiFetch} />
       <PriceSuggestModelPanel currentModel={config.priceSuggestModel || 'claude-haiku-4-5-20251001'} apiFetch={apiFetch} />
       <PriceSuggestPromptPanel prompt={config.priceSuggestPrompt || ''} apiFetch={apiFetch} />
-      <EnrichmentModelPanel currentModel={config.enrichmentModel || 'claude-sonnet-4-6'} apiFetch={apiFetch} />
+      <EnrichmentModelPanel currentModel={config.enrichmentModel || 'claude-sonnet-5'} apiFetch={apiFetch} />
       <EnrichmentPromptPanel prompt={config.enrichmentPrompt || ''} apiFetch={apiFetch} />
       <ChatLimitPanel limit={config.chatDailyLimit ?? 50} apiFetch={apiFetch} />
       <ChatUsagePanel />


### PR DESCRIPTION
## Summary

Follow-up to the registry-pollution investigation (ghost "River Run Riesling", 526 producer-in-name entries) and user feedback that NZ/Australian drink windows are far too young.

### Model upgrades
- **Allowlist**: adds `claude-sonnet-5` and `claude-opus-4-8` (existing values stay valid, so stored admin overrides keep working).
- **New defaults**: label scan, import lookup, maturity suggest, and enrichment move from Haiku 4.5 / Sonnet 4.6 to **Claude Sonnet 5** — these tasks write into the shared registry, where a hallucinated or misnamed wine pollutes every user's search. Sonnet 5 is near-Opus quality and on introductory pricing ($2/$10 per MTok) until Aug 31, 2026.
- **Chat stays on Haiku 4.5** (volume-sensitive at 50 msgs/user/day) but now has a **Sonnet 5 fallback** for 429/529 — previously `null`, so the fallback path we fixed in #570 had nothing to fall back to.
- TabAI picker updated accordingly (adds the two models, corrects stale prices). No request-shape changes needed — our calls use no `temperature`/`top_p`/prefills, which Sonnet 5 rejects.

### Prompt hardening (defaults only — SiteConfig admin overrides untouched)
- **Producer-in-name** (all three identification prompts): the `name` field must never contain the producer — the systemic cause of the 526 misnamed registry entries.
- **No wine substitution** (import lookup + text search): never add a grape variety or cuvée the source data doesn't mention, never "correct" to a similar wine from the same producer — the exact failure that created the "River Run Riesling" ghost.
- **New World maturity windows**: the classification-based conservatism now explicitly applies to European wines only. NZ/Australia have no cru system, so "unclassified" there no longer forces "drink young"; adds realistic regional norms (quality NZ Pinot Noir peaks 5–10 yrs, Australian Cab/Shiraz 8–15, Hunter Semillon decades) and screw-cap guidance (ages reliably and slower — never shorten a window for it).

### Notes for existing data
- Prompt/model changes affect **future** suggestions. Existing too-young NZ profiles stay until re-suggested or somm-reviewed — the somm maturity queue can re-run suggestion per wine; a bulk re-queue for NZ/Aus profiles can be a follow-up if wanted.
- If prod's SiteConfig has admin-saved prompt overrides, they win over these new defaults — check the SuperAdmin AI tab after deploying and reset any overridden prompt to pick up the new text.

## Testing
- Backend Jest: 41 suites / 785 tests passed
- Frontend Vitest: 11 files / 308 tests passed

## Deploy / docker-compose impact
None — code-only, no env or dependency changes. Anthropic API cost profile shifts slightly (identification tasks 2× Haiku token price under intro pricing; tiny absolute cost per call at ~600 output tokens).