### PR TITLE
feat: admin "Producer in name" cleanup tool

### DIFF
--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -38,6 +38,7 @@ const { submitUrls } = require('../../services/indexNow');
 const { isValidId } = require('../../utils/validation');
 const { escapeRegex } = require('../../utils/sanitize');
 const { parsePagination } = require('../../utils/pagination');
+const { stripProducerPrefix } = require('../../utils/producerPrefix');
 
 const router = express.Router();
 
@@ -487,6 +488,72 @@ router.get('/duplicates', async (req, res) => {
   }
 });
 
+// GET /api/admin/wines/producer-in-name — wines whose name starts with their
+// own producer (e.g. producer "Meerlust", name "Meerlust Chardonnay"). Mostly
+// AI-import artefacts; the registry convention is a producer-free name.
+//
+// A field-to-field prefix comparison needs $expr; there's no index for it, so
+// this is a collection scan — fine at the registry's ~3k-doc size. The char
+// right after the prefix must be a separator so producer "Chateau" doesn't
+// flag "Chateauneuf-du-Pape" (mirrors utils/producerPrefix.js).
+//
+// Returns: { wines: [{ _id, producer, name, proposedName, bottleCount, createdAt }], total, page, pages }
+router.get('/producer-in-name', async (req, res) => {
+  try {
+    const { limit: parsedLimit, offset: skip, page: parsedPage } =
+      parsePagination(req.query, { limit: 50, maxLimit: 200 });
+
+    const producerLen = { $strLenCP: { $ifNull: ['$producer', ''] } };
+    const filter = {
+      $expr: {
+        $and: [
+          { $gt: [producerLen, 0] },
+          { $gt: [{ $strLenCP: '$name' }, { $add: [producerLen, 1] }] },
+          { $eq: [{ $indexOfCP: [{ $toLower: '$name' }, { $toLower: { $ifNull: ['$producer', ''] } }] }, 0] },
+          { $in: [{ $substrCP: ['$name', producerLen, 1] }, [' ', '\t', '-', '–', '—']] },
+        ],
+      },
+    };
+
+    const [wines, total] = await Promise.all([
+      WineDefinition.find(filter)
+        .select('name producer createdAt')
+        .sort({ producer: 1, name: 1 })
+        .skip(skip)
+        .limit(parsedLimit)
+        .lean(),
+      WineDefinition.countDocuments(filter),
+    ]);
+
+    // Bottle counts for the page's rows in one aggregate
+    const bottleCounts = new Map();
+    if (wines.length > 0) {
+      const counts = await Bottle.aggregate([
+        { $match: { wineDefinition: { $in: wines.map(w => w._id) } } },
+        { $group: { _id: '$wineDefinition', count: { $sum: 1 } } },
+      ]);
+      for (const c of counts) bottleCounts.set(String(c._id), c.count);
+    }
+
+    res.json({
+      wines: wines.map(w => ({
+        _id: w._id,
+        producer: w.producer,
+        name: w.name,
+        proposedName: stripProducerPrefix(w.name, w.producer),
+        bottleCount: bottleCounts.get(String(w._id)) || 0,
+        createdAt: w.createdAt,
+      })),
+      total,
+      page: parsedPage,
+      pages: Math.ceil(total / parsedLimit),
+    });
+  } catch (error) {
+    console.error('Producer-in-name scan error:', error);
+    res.status(500).json({ error: 'Failed to scan for producer-in-name wines' });
+  }
+});
+
 // GET /api/admin/wines/:id - Get single wine definition
 router.get('/:id', async (req, res) => {
   try {
@@ -623,6 +690,71 @@ router.delete('/:id', async (req, res) => {
   } catch (error) {
     console.error('Delete wine error:', error);
     res.status(500).json({ error: 'Failed to delete wine' });
+  }
+});
+
+// POST /api/admin/wines/:id/strip-producer — remove the wine's own producer
+// prefix from its name (companion to GET /producer-in-name). Recomputes the
+// prefix check server-side so a stale client row can't rename arbitrarily.
+router.post('/:id/strip-producer', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const wine = await WineDefinition.findById(req.params.id);
+    if (!wine) {
+      return res.status(404).json({ error: 'Wine not found' });
+    }
+
+    const stripped = stripProducerPrefix(wine.name, wine.producer);
+    if (!stripped) {
+      return res.status(400).json({
+        error: 'Wine name does not start with its producer, or nothing would remain after stripping'
+      });
+    }
+
+    // If the same producer already has a wine with the stripped name, renaming
+    // would create the very duplicate the registry avoids — the admin should
+    // resolve that pair via the duplicates tool instead.
+    const conflict = await WineDefinition.findOne({
+      _id: { $ne: wine._id },
+      producer: new RegExp(`^${escapeRegex(wine.producer)}$`, 'i'),
+      name: new RegExp(`^${escapeRegex(stripped)}$`, 'i'),
+    }).select('name producer');
+    if (conflict) {
+      return res.status(409).json({
+        error: `"${conflict.name}" by ${conflict.producer} already exists — merge these via the duplicates tool instead.`,
+        conflictId: conflict._id,
+      });
+    }
+
+    const from = wine.name;
+    wine.name = stripped;
+    // Same denormalised-field maintenance as the PUT rename path: regenerate
+    // the dedup key; the slug is deliberately NOT regenerated (URL stability).
+    wine.normalizedKey = generateWineKey(wine.name, wine.producer, wine.appellation);
+    await wine.save();
+    await wine.populate(['country', 'region', 'grapes']);
+
+    // Sync to search index (fire-and-forget)
+    searchService.indexWine(wine._id);
+
+    logAudit(req, 'admin.wine.strip_producer',
+      { type: 'wine', id: wine._id },
+      { from, to: wine.name }
+    );
+
+    submitUrls(`/wines/${wine._id}`);
+
+    res.json({ wine });
+  } catch (error) {
+    if (error.code === 11000) {
+      // Unique normalizedKey collision the pre-check missed (e.g. differing
+      // appellation normalisation) — same guidance as the explicit conflict.
+      return res.status(409).json({
+        error: 'Another wine already exists with this name, producer, and appellation combination — merge via the duplicates tool instead.'
+      });
+    }
+    console.error('Strip producer error:', error);
+    res.status(500).json({ error: 'Failed to strip producer from name' });
   }
 });
 

--- a/backend/src/utils/producerPrefix.js
+++ b/backend/src/utils/producerPrefix.js
@@ -1,0 +1,31 @@
+/**
+ * Detect and strip a redundant producer prefix from a wine name.
+ *
+ * AI import lookups often store names like "Meerlust Chardonnay" for producer
+ * "Meerlust" — the registry convention is a producer-free name ("Chardonnay").
+ *
+ * The prefix only counts when it is followed by a separator (whitespace or a
+ * hyphen/dash), so producer "Chateau" does NOT flag "Chateauneuf-du-Pape".
+ *
+ * @param {string} name     - the wine's current name
+ * @param {string} producer - the wine's producer
+ * @returns {string|null} the cleaned name, or null when the name doesn't start
+ *   with the producer (case-insensitive) or nothing meaningful would remain.
+ */
+function stripProducerPrefix(name, producer) {
+  const n = typeof name === 'string' ? name.trim() : '';
+  const p = typeof producer === 'string' ? producer.trim() : '';
+  if (!n || !p) return null;
+  if (n.length <= p.length + 1) return null;
+  if (!n.toLowerCase().startsWith(p.toLowerCase())) return null;
+
+  const rest = n.slice(p.length);
+  // The character right after the prefix must be a separator, otherwise the
+  // producer is merely a substring of a longer word.
+  if (!/^[\s\-–—]/.test(rest)) return null;
+
+  const remainder = rest.replace(/^[\s\-–—]+/, '').trim();
+  return remainder.length > 0 ? remainder : null;
+}
+
+module.exports = { stripProducerPrefix };

--- a/backend/src/utils/producerPrefix.test.js
+++ b/backend/src/utils/producerPrefix.test.js
@@ -1,0 +1,48 @@
+const { stripProducerPrefix } = require('./producerPrefix');
+
+describe('stripProducerPrefix', () => {
+  test('strips a plain producer prefix separated by a space', () => {
+    expect(stripProducerPrefix('Meerlust Chardonnay', 'Meerlust')).toBe('Chardonnay');
+  });
+
+  test('is case-insensitive on the prefix match', () => {
+    expect(stripProducerPrefix('MEERLUST Chardonnay', 'Meerlust')).toBe('Chardonnay');
+    expect(stripProducerPrefix('meerlust Rubicon', 'Meerlust')).toBe('Rubicon');
+  });
+
+  test('strips hyphen and dash separators (with surrounding whitespace)', () => {
+    expect(stripProducerPrefix('Meerlust - Chardonnay', 'Meerlust')).toBe('Chardonnay');
+    expect(stripProducerPrefix('Meerlust – Rubicon', 'Meerlust')).toBe('Rubicon');
+    expect(stripProducerPrefix('Meerlust—Rubicon', 'Meerlust')).toBe('Rubicon');
+  });
+
+  test('handles multi-word producers', () => {
+    expect(stripProducerPrefix('Château Margaux Pavillon Rouge', 'Château Margaux'))
+      .toBe('Pavillon Rouge');
+  });
+
+  test('returns null when the name does not start with the producer', () => {
+    expect(stripProducerPrefix('Rubicon', 'Meerlust')).toBeNull();
+    expect(stripProducerPrefix('Grand Meerlust Rubicon', 'Meerlust')).toBeNull();
+  });
+
+  test('returns null when the producer is only a substring of a longer word', () => {
+    // "Chateau" is a prefix of "Chateauneuf" but not a redundant producer prefix
+    expect(stripProducerPrefix('Chateauneuf-du-Pape', 'Chateau')).toBeNull();
+  });
+
+  test('returns null when the name equals the producer', () => {
+    expect(stripProducerPrefix('Meerlust', 'Meerlust')).toBeNull();
+  });
+
+  test('returns null when nothing meaningful remains after stripping', () => {
+    expect(stripProducerPrefix('Meerlust -', 'Meerlust')).toBeNull();
+  });
+
+  test('returns null for empty or non-string inputs', () => {
+    expect(stripProducerPrefix('', 'Meerlust')).toBeNull();
+    expect(stripProducerPrefix('Meerlust Chardonnay', '')).toBeNull();
+    expect(stripProducerPrefix(null, 'Meerlust')).toBeNull();
+    expect(stripProducerPrefix('Meerlust Chardonnay', undefined)).toBeNull();
+  });
+});

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -53,6 +53,14 @@ export const adminUndismissDuplicateCluster = (apiFetch, wineIds) =>
     body: JSON.stringify({ wineIds }),
   });
 
+// Wines whose name starts with their own producer (AI-import artefacts).
+export const adminGetProducerInNameWines = (apiFetch, params) =>
+  apiFetch(`/api/admin/wines/producer-in-name?${params}`);
+
+// Remove the wine's own producer prefix from its name.
+export const adminStripProducerFromName = (apiFetch, id) =>
+  apiFetch(`/api/admin/wines/${id}/strip-producer`, { method: 'POST' });
+
 // ── Taxonomy ─────────────────────────────────────────────────────────────────
 export const adminGetTaxonomy = (apiFetch, endpoint) =>
   apiFetch(endpoint);

--- a/frontend/src/components/WineProducerInNameModal.js
+++ b/frontend/src/components/WineProducerInNameModal.js
@@ -1,0 +1,292 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import Modal from './Modal';
+import {
+  adminGetProducerInNameWines,
+  adminStripProducerFromName,
+  adminDeleteWine,
+} from '../api/admin';
+
+const PAGE_SIZE = 50;
+
+/**
+ * Admin cleanup tool for wines whose name starts with their own producer
+ * (e.g. producer "Meerlust", name "Meerlust Chardonnay" — should be just
+ * "Chardonnay"). Mostly AI-import artefacts. Sibling of WineDuplicatesModal.
+ *
+ * Props:
+ *   apiFetch    — from useAuth()
+ *   onClose()   — close the modal
+ *   onChanged() — called after any successful strip/delete so the parent can
+ *                 refresh its wine list
+ */
+function WineProducerInNameModal({ apiFetch, onClose, onChanged }) {
+  const { t } = useTranslation();
+
+  const [wines, setWines] = useState(null); // null = not yet loaded
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pages, setPages] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [rowErrors, setRowErrors] = useState({}); // wineId -> message
+  const [pending, setPending] = useState(null); // wineId with an action in flight
+  const [deleteCandidate, setDeleteCandidate] = useState(null);
+  const [successMsg, setSuccessMsg] = useState(null);
+  const successTimer = useRef(null);
+
+  const showSuccess = (msg) => {
+    clearTimeout(successTimer.current);
+    setSuccessMsg(msg);
+    successTimer.current = setTimeout(() => setSuccessMsg(null), 3500);
+  };
+  useEffect(() => () => clearTimeout(successTimer.current), []);
+
+  const fetchPage = useCallback(async (p) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ page: p, limit: PAGE_SIZE });
+      const res = await adminGetProducerInNameWines(apiFetch, params);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || `Failed to load (${res.status})`);
+        return;
+      }
+      setWines(data.wines || []);
+      setTotal(data.total || 0);
+      setPages(data.pages || 1);
+      setRowErrors({});
+    } catch {
+      setError('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch]);
+
+  useEffect(() => { fetchPage(page); }, [fetchPage, page]);
+
+  // Drop a resolved row from the list. If the page empties while more results
+  // remain, step back a page (or refetch page 1) so the admin isn't stranded
+  // on an empty page.
+  const removeRow = (wineId) => {
+    const remaining = (wines || []).filter(w => w._id !== wineId);
+    const newTotal = Math.max(0, total - 1);
+    setWines(remaining);
+    setTotal(newTotal);
+    setRowErrors(prev => { const { [wineId]: _drop, ...rest } = prev; return rest; });
+    if (remaining.length === 0 && newTotal > 0) {
+      if (page > 1) setPage(p => p - 1); // triggers refetch via effect
+      else fetchPage(1);
+    }
+    onChanged?.();
+  };
+
+  const setRowError = (wineId, message) =>
+    setRowErrors(prev => ({ ...prev, [wineId]: message }));
+
+  const handleStrip = async (wine) => {
+    if (pending) return;
+    setPending(wine._id);
+    setRowError(wine._id, null);
+    try {
+      const res = await adminStripProducerFromName(apiFetch, wine._id);
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        showSuccess(t('admin.wines.producerInName.stripped', {
+          from: wine.name,
+          to: data.wine?.name || wine.proposedName,
+        }));
+        removeRow(wine._id);
+      } else {
+        setRowError(wine._id, data.error || `Failed (${res.status})`);
+      }
+    } catch {
+      setRowError(wine._id, t('admin.wines.producerInName.networkError'));
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const confirmDelete = async () => {
+    const wine = deleteCandidate;
+    if (!wine || pending) return;
+    setPending(wine._id);
+    try {
+      const res = await adminDeleteWine(apiFetch, wine._id);
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        showSuccess(t('admin.wines.producerInName.deleted', { name: wine.name }));
+        removeRow(wine._id);
+      } else {
+        // Blocked deletes (bottles reference the wine) surface the backend error
+        setRowError(wine._id, data.error || `Failed (${res.status})`);
+      }
+    } catch {
+      setRowError(wine._id, t('admin.wines.producerInName.networkError'));
+    } finally {
+      setPending(null);
+      setDeleteCandidate(null);
+    }
+  };
+
+  const thStyle = {
+    textAlign: 'left',
+    padding: '0.4rem 0.5rem',
+    fontSize: '0.8rem',
+    color: 'var(--text-secondary, #666)',
+    borderBottom: '1px solid var(--border, #e5e5e5)',
+    whiteSpace: 'nowrap',
+  };
+  const tdStyle = {
+    padding: '0.45rem 0.5rem',
+    borderBottom: '1px solid var(--border, #eee)',
+    verticalAlign: 'top',
+  };
+
+  return (
+    <Modal title={t('admin.wines.producerInName.title')} onClose={onClose} showClose wide>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+          {t('admin.wines.producerInName.intro')}
+        </span>
+        {wines !== null && !loading && (
+          <span
+            style={{
+              fontSize: '0.8rem',
+              fontWeight: 600,
+              padding: '0.15rem 0.6rem',
+              borderRadius: 999,
+              background: 'var(--bg-secondary, #f4f4f4)',
+              border: '1px solid var(--border, #e5e5e5)',
+              flexShrink: 0,
+            }}
+          >
+            {t('admin.wines.producerInName.found', { count: total })}
+          </span>
+        )}
+      </div>
+
+      {error && <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>}
+      {successMsg && (
+        <div className="alert alert-success" role="status" style={{ marginBottom: 12 }}>
+          {successMsg}
+        </div>
+      )}
+
+      {loading && !wines && (
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
+          {t('common.loading')}
+        </div>
+      )}
+
+      {!loading && wines?.length === 0 && (
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
+          {t('admin.wines.producerInName.empty')}
+        </div>
+      )}
+
+      {wines?.length > 0 && (
+        <div style={{ maxHeight: 480, overflowY: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+            <thead>
+              <tr>
+                <th style={thStyle}>{t('admin.wines.producerInName.producerCol')}</th>
+                <th style={thStyle}>{t('admin.wines.producerInName.currentNameCol')}</th>
+                <th style={thStyle}>{t('admin.wines.producerInName.proposedNameCol')}</th>
+                <th style={{ ...thStyle, textAlign: 'right' }}>{t('admin.wines.producerInName.bottlesCol')}</th>
+                <th style={thStyle}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {wines.map(wine => (
+                <tr key={wine._id} style={{ opacity: pending && pending !== wine._id ? 0.6 : 1 }}>
+                  <td style={tdStyle}>{wine.producer}</td>
+                  <td style={tdStyle}>{wine.name}</td>
+                  <td style={{ ...tdStyle, fontWeight: 600 }}>
+                    {wine.proposedName || '—'}
+                    {rowErrors[wine._id] && (
+                      <div className="alert alert-error" style={{ marginTop: 6, fontSize: '0.8rem', padding: '0.35rem 0.5rem' }}>
+                        {rowErrors[wine._id]}
+                      </div>
+                    )}
+                  </td>
+                  <td style={{ ...tdStyle, textAlign: 'right' }}>{wine.bottleCount}</td>
+                  <td style={{ ...tdStyle, whiteSpace: 'nowrap', textAlign: 'right' }}>
+                    <button
+                      type="button"
+                      className="btn btn-secondary btn-small"
+                      disabled={!!pending || !wine.proposedName}
+                      onClick={() => handleStrip(wine)}
+                      title={t('admin.wines.producerInName.stripTitle')}
+                    >
+                      {pending === wine._id
+                        ? t('admin.wines.producerInName.stripping')
+                        : t('admin.wines.producerInName.stripBtn')}
+                    </button>{' '}
+                    <button
+                      type="button"
+                      className="btn btn-danger btn-small"
+                      disabled={!!pending}
+                      onClick={() => setDeleteCandidate(wine)}
+                    >
+                      {t('common.delete')}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {wines !== null && pages > 1 && (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8, marginTop: 12 }}>
+          <button
+            type="button"
+            className="btn btn-secondary btn-small"
+            disabled={page <= 1 || loading || !!pending}
+            onClick={() => setPage(p => p - 1)}
+          >
+            {t('common.previous')}
+          </button>
+          <span style={{ fontSize: '0.85rem' }}>{t('admin.audit.page', { current: page, total: pages })}</span>
+          <button
+            type="button"
+            className="btn btn-secondary btn-small"
+            disabled={page >= pages || loading || !!pending}
+            onClick={() => setPage(p => p + 1)}
+          >
+            {t('common.next')}
+          </button>
+        </div>
+      )}
+
+      {/* Delete confirmation — same pattern as the AdminWines page */}
+      {deleteCandidate && (
+        <Modal title={t('admin.wines.deleteTitle')} onClose={() => setDeleteCandidate(null)}>
+          <p>{t('admin.wines.deleteConfirm', { name: deleteCandidate.name })}</p>
+          <div className="modal-actions">
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setDeleteCandidate(null)}
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              type="button"
+              className="btn btn-danger"
+              disabled={!!pending}
+              onClick={confirmDelete}
+            >
+              {pending ? t('common.saving') : t('common.delete')}
+            </button>
+          </div>
+        </Modal>
+      )}
+    </Modal>
+  );
+}
+
+export default WineProducerInNameModal;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -836,7 +836,26 @@
       "mergeInfo": "\"{{name}}\" has {{count}} bottle(s) referencing it. Choose another wine to reassign them to before deleting.",
       "mergeSearchLabel": "Search for target wine",
       "mergeTarget": "Reassign bottles to:",
-      "mergeBtn": "Merge & Delete"
+      "mergeBtn": "Merge & Delete",
+      "producerInName": {
+        "button": "Producer in name",
+        "buttonTitle": "Find wines whose name starts with their own producer",
+        "title": "Producer in wine name",
+        "intro": "These wines repeat their producer at the start of the name — usually an AI-import artefact. Strip the prefix or delete the entry.",
+        "found_one": "{{count}} wine found",
+        "found_other": "{{count}} wines found",
+        "producerCol": "Producer",
+        "currentNameCol": "Current name",
+        "proposedNameCol": "New name",
+        "bottlesCol": "Bottles",
+        "stripBtn": "Strip",
+        "stripTitle": "Rename the wine to the proposed name",
+        "stripping": "Stripping…",
+        "stripped": "Renamed \"{{from}}\" to \"{{to}}\"",
+        "deleted": "Deleted \"{{name}}\"",
+        "empty": "No wines have their producer in the name.",
+        "networkError": "Network error"
+      }
     },
     "images": {
       "title": "Admin: Image Review",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -836,7 +836,26 @@
       "mergeInfo": "\"{{name}}\" har {{count}} flaska/flaskor som refererar till det. Välj ett annat vin att flytta dem till innan borttagning.",
       "mergeSearchLabel": "Sök efter målvin",
       "mergeTarget": "Flytta flaskor till:",
-      "mergeBtn": "Slå ihop & ta bort"
+      "mergeBtn": "Slå ihop & ta bort",
+      "producerInName": {
+        "button": "Producent i namnet",
+        "buttonTitle": "Hitta viner vars namn börjar med producentens namn",
+        "title": "Producent i vinnamnet",
+        "intro": "Dessa viner upprepar producenten i början av vinnamnet — oftast en artefakt från AI-import. Ta bort prefixet eller radera posten.",
+        "found_one": "{{count}} vin hittat",
+        "found_other": "{{count}} viner hittade",
+        "producerCol": "Producent",
+        "currentNameCol": "Nuvarande namn",
+        "proposedNameCol": "Nytt namn",
+        "bottlesCol": "Flaskor",
+        "stripBtn": "Ta bort prefix",
+        "stripTitle": "Byt namn på vinet till det föreslagna namnet",
+        "stripping": "Tar bort…",
+        "stripped": "Bytte namn från \"{{from}}\" till \"{{to}}\"",
+        "deleted": "Tog bort \"{{name}}\"",
+        "empty": "Inga viner har producenten i namnet.",
+        "networkError": "Nätverksfel"
+      }
     },
     "images": {
       "title": "Admin: Bildgranskning",

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -10,6 +10,7 @@ import {
 import Modal from '../components/Modal';
 import Drawer from '../components/Drawer';
 import WineDuplicatesModal from '../components/WineDuplicatesModal';
+import WineProducerInNameModal from '../components/WineProducerInNameModal';
 import { WINE_TYPES } from '../config/wineTypes';
 import GrapePicker from '../components/GrapePicker';
 import ImageUpload from '../components/ImageUpload';
@@ -74,6 +75,9 @@ function AdminWines() {
 
   // Registry-wide duplicate scanner
   const [showDuplicatesScanner, setShowDuplicatesScanner] = useState(false);
+
+  // Producer-in-name cleanup tool
+  const [showProducerInName, setShowProducerInName] = useState(false);
 
   // Taxonomy
   const [countries, setCountries] = useState([]);
@@ -349,6 +353,9 @@ function AdminWines() {
         <div style={{ display: 'flex', gap: 8 }}>
           <button className="btn btn-secondary" onClick={() => setShowDuplicatesScanner(true)} title="Scan the wine registry for likely duplicates">
             Find duplicates
+          </button>
+          <button className="btn btn-secondary" onClick={() => setShowProducerInName(true)} title={t('admin.wines.producerInName.buttonTitle')}>
+            {t('admin.wines.producerInName.button')}
           </button>
           <button className="btn btn-primary" onClick={openCreate}>
             {t('admin.wines.newWine')}
@@ -811,6 +818,14 @@ function AdminWines() {
           apiFetch={apiFetch}
           onClose={() => setShowDuplicatesScanner(false)}
           onMerged={fetchWines}
+        />
+      )}
+
+      {showProducerInName && (
+        <WineProducerInNameModal
+          apiFetch={apiFetch}
+          onClose={() => setShowProducerInName(false)}
+          onChanged={fetchWines}
         />
       )}
 


### PR DESCRIPTION
## Summary

New admin tool on the Wines page (next to "Find duplicates") for the ~430+ registry entries whose name starts with their own producer — e.g. producer **Meerlust**, name **Meerlust Chardonnay** (convention is a producer-free name). Mostly AI-import artefacts; companion to the prompt hardening in #574 that stops new ones being created.

### Backend
- `GET /api/admin/wines/producer-in-name` — paginated `$expr` scan (name starts with producer + separator, so producer "Chateau" doesn't flag "Chateauneuf-du-Pape"), returns proposed cleaned name + bottle count per row.
- `POST /api/admin/wines/:id/strip-producer` — revalidates server-side, renames with the same denormalized-key maintenance as the existing PUT rename path, reindexes Meilisearch, audit-logs `{from, to}`. If the producer already has a wine with the cleaned name → **409** naming it and pointing to the duplicates tool (that pair needs a merge, not a rename).
- Shared `utils/producerPrefix.js` helper with unit tests.

### Frontend
- "Producer in name" launcher + modal: count badge, paginated table (Producer | Current | Proposed | Bottles), per-row **Strip** / **Delete** with inline error surfacing, in-flight guards, empty-page step-back. Delete reuses the existing guarded admin delete. All strings i18n'd (en + sv).

### Verified
- Backend Jest 794/794 (9 new), frontend Vitest 308/308.
- The `$expr` query was cross-checked live against the dev DB (prod copy): 431 matches, 0 disagreements between the Mongo filter and the JS helper, proposed names and bottle counts spot-checked.

## Deploy / docker-compose impact
None — code-only, no migrations, env, or dependency changes.