### PR TITLE
chore(release): v1.68.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.67.7",
+  "version": "1.68.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.67.7",
+  "version": "1.68.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for the v1.68.0 minor release.

Changes since v1.67.7:
- #573 — CSV import honors `quantity` in Cellarion-format files; Statistics "Unknown" donut segment becomes a visible, clickable **Pending review** bucket.
- #574 — Registry-feeding AI (label scan, import lookup, maturity, enrichment) upgraded to Claude Sonnet 5; chat gains a fallback model; identification prompts hardened against producer-in-name and wine-substitution errors; maturity prompt now handles New World/screw-cap wines realistically (NZ Pinot 5–10 yrs etc.).
- #575 — New admin "Producer in name" cleanup tool on the Wines page (~431 affected registry entries), with strip-prefix and delete actions.

## Deploy notes
- Code-only: no docker-compose, env, or dependency changes; no migrations.
- AI model defaults change on deploy — future wine identifications/suggestions use Sonnet 5 (intro pricing until Aug 31, 2026). Admin-saved model/prompt overrides in SiteConfig take precedence; check the SuperAdmin AI tab after deploying and clear stale overrides if you want the new prompts.
- Existing NZ/Aus maturity profiles keep their old windows until re-suggested/somm-reviewed.