### PR TITLE
fix: raise AI max_tokens — Sonnet 5 responses were truncating

### DIFF
--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -261,7 +261,7 @@ async function identifyWineFromText({ name, producer, vintage, country }) {
   return callClaudeJson({
     client,
     model: aiConfig.get().importLookupModel,
-    maxTokens: 400,
+    maxTokens: 800,
     prompt,
     validate: validateWineIdentity,
   });
@@ -283,7 +283,7 @@ async function identifyWineFromQuery(query) {
   return callClaudeJson({
     client,
     model: aiConfig.get().importLookupModel,
-    maxTokens: 400,
+    maxTokens: 800,
     prompt,
     validate: validateWineIdentity,
   });
@@ -324,7 +324,7 @@ async function suggestDrinkWindow({ name, producer, vintage, country, region, ap
   return callClaudeJson({
     client,
     model: aiConfig.get().maturitySuggestModel,
-    maxTokens: 500,
+    maxTokens: 1200,
     prompt,
   });
 }
@@ -357,7 +357,7 @@ async function suggestPrice({ name, producer, vintage, country, region, appellat
   return callClaudeJson({
     client,
     model: aiConfig.get().priceSuggestModel,
-    maxTokens: 400,
+    maxTokens: 800,
     prompt,
   });
 }
@@ -390,7 +390,7 @@ async function suggestProfile({ name, producer, vintage, country, region, appell
   return callClaudeJson({
     client,
     model: aiConfig.get().enrichmentModel,
-    maxTokens: 700,
+    maxTokens: 1400,
     prompt,
     validate: (parsed) => {
       // Normalise arrays so the caller can store them directly.


### PR DESCRIPTION
Found during the NZ maturity re-queue: `suggestDrinkWindow`'s 500-token cap truncated the AI's JSON on **43 of 248 real calls (17%)** after the Sonnet 5 upgrade — denser tokenizer + more thorough sommNotes. Those 43 profiles are parked in the somm queue awaiting this fix.

`max_tokens` is a ceiling, not a cost (billing is actual output), so all five wine-AI calls get headroom:

| Call | Before | After |
|---|---|---|
| identifyWineFromText (import lookup) | 400 | 800 |
| identifyWineFromQuery (text search) | 400 | 800 |
| suggestDrinkWindow (maturity) | 500 | **1200** |
| suggestPrice | 400 | 800 |
| suggestProfile (enrichment tasting profile) | 700 | 1400 |

Backend Jest: 794/794. Code-only; after deploy the 43 parked NZ profiles can be re-run.