### PR TITLE
chore(release): v1.68.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.68.0",
+  "version": "1.68.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.68.0",
+  "version": "1.68.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for the v1.68.1 patch release.

Changes since v1.68.0:
- #577 — production-method terms (Méthode Cap Classique etc.) go in the appellation field, not the wine name.
- #578 — brand-crest founder names (e.g. "Desiderius" above "Pongrácz") are producer identity, not wine name.
- #579 — raised AI response token caps: Sonnet 5 maturity suggestions were truncating at 17% (500→1200 for drink windows; all five wine-AI calls get headroom).

## Deploy notes
- Code-only, no compose/env/migrations.
- After deploying: (1) the two prompt overrides hot-applied to prod SiteConfig (labelScanPrompt, importLookupPrompt) become stale copies of these defaults and should be cleared; (2) the 43 NZ maturity profiles parked in the somm queue can be re-run now that suggestions no longer truncate.