### PR TITLE
fix: handle Sonnet 5 thinking blocks in Claude response parsing

### DIFF
--- a/backend/src/services/aiChat.js
+++ b/backend/src/services/aiChat.js
@@ -16,6 +16,7 @@
 
 const mongoose = require('mongoose');
 const aiConfig = require('../config/aiConfig');
+const { textFromResponse, thinkingOff } = require('../utils/aiResponse');
 const { embedSingle } = require('./embedding');
 const vectorStore = require('./vectorStore');
 const Bottle = require('../models/Bottle');
@@ -252,8 +253,8 @@ Reply with ONLY these two lines, no explanation. Always reply in English regardl
   };
 
   try {
-    const response = await client.messages.create({ ...callParams, model: cfg.chatModel });
-    const text = response.content[0]?.text?.trim();
+    const response = await client.messages.create({ ...callParams, model: cfg.chatModel, ...thinkingOff(cfg.chatModel) });
+    const text = textFromResponse(response);
     if (!text) return { searchQuery: message, needsNewSearch: true };
     return parseExpandResult(text, message, hasHistory);
   } catch (err) {
@@ -272,8 +273,8 @@ Reply with ONLY these two lines, no explanation. Always reply in English regardl
     });
     if (isRetryable && canFallback) {
       try {
-        const response = await client.messages.create({ ...callParams, model: cfg.chatModelFallback });
-        const text = response.content[0]?.text?.trim();
+        const response = await client.messages.create({ ...callParams, model: cfg.chatModelFallback, ...thinkingOff(cfg.chatModelFallback) });
+        const text = textFromResponse(response);
         _eventLog[_eventLog.length - 1].fallbackResult = 'ok';
         if (!text) return { searchQuery: message, needsNewSearch: true };
         return parseExpandResult(text, message, hasHistory);
@@ -435,7 +436,7 @@ async function chat(userId, message, opts = {}) {
   const client = getClaudeClient();
   let response;
   try {
-    response = await client.messages.create({ ...callParams, model: cfg.chatModel });
+    response = await client.messages.create({ ...callParams, model: cfg.chatModel, ...thinkingOff(cfg.chatModel) });
   } catch (err) {
     const canFallback = cfg.chatModelFallback && cfg.chatModelFallback !== cfg.chatModel;
     const isRetryable = [429, 500, 502, 503, 529].includes(err.status)
@@ -452,7 +453,7 @@ async function chat(userId, message, opts = {}) {
     if (isRetryable && canFallback) {
       console.warn(`[aiChat] Primary model failed (${cfg.chatModel}, status ${err.status}), retrying with fallback: ${cfg.chatModelFallback}`);
       try {
-        response = await client.messages.create({ ...callParams, model: cfg.chatModelFallback });
+        response = await client.messages.create({ ...callParams, model: cfg.chatModelFallback, ...thinkingOff(cfg.chatModelFallback) });
         _eventLog[_eventLog.length - 1].fallbackResult = 'ok';
       } catch (fbErr) {
         _eventLog[_eventLog.length - 1].fallbackResult = 'failed';
@@ -465,7 +466,7 @@ async function chat(userId, message, opts = {}) {
     }
   }
 
-  const answer = response.content[0]?.text ?? '';
+  const answer = textFromResponse(response);
   const usage = {
     inputTokens:  response.usage?.input_tokens  ?? 0,
     outputTokens: response.usage?.output_tokens ?? 0,
@@ -518,7 +519,7 @@ async function chatStream(userId, message, opts, res) {
     let stream;
 
     const runStream = (model, allowFallback) => {
-      stream = client.messages.stream({ ...callParams, model });
+      stream = client.messages.stream({ ...callParams, model, ...thinkingOff(model) });
 
       stream.on('text', (textDelta) => {
         receivedText = true;

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -1,6 +1,7 @@
 const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 const aiConfig = require('../config/aiConfig');
 const { extractFirstJsonObject } = require('../utils/jsonExtract');
+const { textFromResponse, thinkingOff } = require('../utils/aiResponse');
 
 function getClient() {
   const apiKey = process.env.ANTHROPIC_API_KEY;
@@ -75,7 +76,7 @@ async function scanLabel(image, mediaType = 'image/jpeg') {
     }]
   });
 
-  const query = (response.content[0]?.text ?? '').trim();
+  const query = textFromResponse(response);
   if (!query) {
     const err = new Error('Could not read label');
     err.status = 422;
@@ -104,6 +105,7 @@ async function scanLabelFull(image, mediaType = 'image/jpeg') {
   const response = await client.messages.create({
     model: aiConfig.get().labelScanModel,
     max_tokens: 600,
+    ...thinkingOff(aiConfig.get().labelScanModel),
     messages: [
       // Prime the assistant to start with '{' so it can't add preamble
       {
@@ -122,7 +124,7 @@ async function scanLabelFull(image, mediaType = 'image/jpeg') {
     ]
   });
 
-  const raw = (response.content[0]?.text ?? '').trim();
+  const raw = textFromResponse(response);
 
   // Strip any accidental markdown fences just in case
   const stripped = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
@@ -180,6 +182,7 @@ async function callClaudeJson({ client, model, maxTokens, prompt, validate }) {
   const apiParams = {
     model,
     max_tokens: maxTokens,
+    ...thinkingOff(model),
     messages: [
       { role: 'user', content: prompt }
     ]
@@ -189,7 +192,7 @@ async function callClaudeJson({ client, model, maxTokens, prompt, validate }) {
   for (let attempt = 1; attempt <= 2; attempt++) {
     try {
       const response = await client.messages.create(apiParams);
-      raw = (response.content[0]?.text ?? '').trim();
+      raw = textFromResponse(response);
       // Strip code fences, then extract only the first balanced {...} so any
       // trailing explanation text from the model doesn't break JSON.parse.
       const stripped = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();

--- a/backend/src/utils/aiResponse.js
+++ b/backend/src/utils/aiResponse.js
@@ -1,0 +1,31 @@
+/**
+ * Claude response helpers shared by the AI services.
+ *
+ * textFromResponse — Claude Sonnet 5 (and newer families) may emit a
+ * `thinking` block before the text, so `response.content[0].text` silently
+ * returns undefined on exactly the calls where the model reasoned hardest.
+ * Join every text block instead.
+ *
+ * thinkingOff — Claude Sonnet 5 runs adaptive thinking BY DEFAULT when the
+ * `thinking` parameter is omitted; thinking tokens are billed and count
+ * against max_tokens (this truncated 17% of maturity suggestions in prod).
+ * Our extraction and chat tasks don't need extended reasoning, so disable it
+ * explicitly on the Sonnet 5 family. The other allowlisted models (Haiku 4.5,
+ * Sonnet 4.6, Opus 4.x) don't think when the parameter is omitted — send
+ * nothing for them rather than risk an explicit value they might reject.
+ */
+function textFromResponse(response) {
+  return (response?.content || [])
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text)
+    .join('')
+    .trim();
+}
+
+function thinkingOff(model) {
+  return typeof model === 'string' && model.startsWith('claude-sonnet-5')
+    ? { thinking: { type: 'disabled' } }
+    : {};
+}
+
+module.exports = { textFromResponse, thinkingOff };

--- a/backend/src/utils/aiResponse.test.js
+++ b/backend/src/utils/aiResponse.test.js
@@ -1,0 +1,38 @@
+const { textFromResponse, thinkingOff } = require('./aiResponse');
+
+describe('textFromResponse', () => {
+  it('joins text blocks and skips thinking blocks', () => {
+    const response = {
+      content: [
+        { type: 'thinking', thinking: 'internal reasoning' },
+        { type: 'text', text: '{"name":' },
+        { type: 'text', text: '"Blanc de Blancs"}' },
+      ],
+    };
+    expect(textFromResponse(response)).toBe('{"name":"Blanc de Blancs"}');
+  });
+
+  it('returns empty string when there are no text blocks', () => {
+    expect(textFromResponse({ content: [{ type: 'thinking', thinking: 'x' }] })).toBe('');
+    expect(textFromResponse({ content: [] })).toBe('');
+    expect(textFromResponse({})).toBe('');
+    expect(textFromResponse(null)).toBe('');
+  });
+
+  it('trims the joined text', () => {
+    expect(textFromResponse({ content: [{ type: 'text', text: '  hi \n' }] })).toBe('hi');
+  });
+});
+
+describe('thinkingOff', () => {
+  it('disables thinking for the Sonnet 5 family', () => {
+    expect(thinkingOff('claude-sonnet-5')).toEqual({ thinking: { type: 'disabled' } });
+  });
+
+  it('sends nothing for models that do not think by default', () => {
+    expect(thinkingOff('claude-haiku-4-5-20251001')).toEqual({});
+    expect(thinkingOff('claude-sonnet-4-6')).toEqual({});
+    expect(thinkingOff('claude-opus-4-8')).toEqual({});
+    expect(thinkingOff(undefined)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

The 25 NZ maturity suggestions that still failed after #579 exposed the real bug: **Claude Sonnet 5 runs adaptive thinking by default** when the `thinking` parameter is omitted. Responses then start with a `thinking` block — and all six of our call sites read `response.content[0].text`, which is `undefined` precisely on the calls where the model reasoned hardest ("Unexpected end of JSON input"). Thinking tokens also bill and count against `max_tokens`, which is what caused the original truncations.

Every AI feature (label scan, import lookup, text search, maturity, price, enrichment profile, chat, query expansion) has been latently flaky since the Sonnet 5 switch.

## Fix
- New `utils/aiResponse.js`:
  - `textFromResponse()` — joins all `text` blocks instead of assuming `content[0]`
  - `thinkingOff()` — explicit `thinking: {type: "disabled"}` for the **Sonnet 5 family only** (these are extraction/chat tasks that don't need extended reasoning; restores pre-Sonnet-5 latency/cost/budget semantics). Other allowlisted models don't think when the param is omitted, so they get nothing.
- Applied to all 9 Claude call sites across `labelScan.js` and `aiChat.js` (including chat fallback paths and the SSE stream).
- Unit tests for the helper; backend Jest 794 + 7 new, all passing.

## After deploy
Re-run the 25 pending NZ profiles — with parsing fixed they should complete the 248/248 story.

## Deploy / docker-compose impact
None — code-only.