### PR TITLE
chore(release): v1.68.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.68.1",
+  "version": "1.68.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.68.1",
+  "version": "1.68.2",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for the v1.68.2 patch release.

One change since v1.68.1:
- #581 — handle Claude Sonnet 5 thinking blocks: robust text extraction at all 9 Claude call sites + explicit thinking-off for the Sonnet 5 family. Fixes intermittent "Unexpected end of JSON input" failures across label scan, import lookup, maturity/price/profile suggestions, and chat, plus hidden thinking-token billing.

## Deploy notes
Code-only — no compose, env, or migration changes. After deploying, the 25 NZ maturity profiles parked in the somm queue will be re-run automatically (coordinated separately).