### PR TITLE
feat: mark rack slots as unusable (disabled positions)

### DIFF
--- a/backend/src/models/Rack.js
+++ b/backend/src/models/Rack.js
@@ -42,6 +42,12 @@ const rackSchema = new mongoose.Schema({
   isModular: { type: Boolean, default: false },
   modules:   { type: [rackModuleSchema], default: [] },
   slots:     [slotSchema],
+  // Positions the user marked as unusable (e.g. Vintec/Oeno cabinets where
+  // bottle shapes mean some shelf positions can't hold a bottle). Stored as
+  // a top-level list of global 1-indexed positions — NOT in slots[] (whose
+  // schema requires a bottle ref) and NOT per-module (global positions cover
+  // modular racks too). Position numbering stays contiguous; these are holes.
+  disabledPositions: { type: [Number], default: [] },
   rfidTag:   { type: String },
   // Soft-delete: set when deleted, null when active
   deletedAt: { type: Date, default: null }

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -431,13 +431,16 @@ router.post('/confirm', async (req, res) => {
       : 'USD';
 
     // Validate user-supplied per-rack configuration.
-    // Shape: { [rackName]: { skip?, type?, rows?, cols?, typeConfig?: {...} } }
+    // Shape: { [rackName]: { skip?, type?, rows?, cols?, typeConfig?: {...}, disabledPositions?: [Number] } }
     // skip — when true, drop this rack from auto-creation AND placement;
     //   bottles referencing it land in the cellar without rack placement
     // type — one of RACK_TYPES (defaults to 'grid' if absent/invalid)
     // rows/cols — clamped to 1..20
     // typeConfig — optional shape config (bottlesPerCell, bottlesPerSection,
     //   moduleRows, moduleCols, backCols), each clamped to model bounds
+    // disabledPositions — global 1-indexed positions marked unusable (e.g.
+    //   Oeno-export cabinets); deduped here, clamped to the created rack's
+    //   capacity at creation time below
     const rackConfigs = {};
     const clampInt = (v, min, max) => {
       const n = parseInt(v, 10);
@@ -475,6 +478,15 @@ router.post('/confirm', async (req, res) => {
           if (bps !== undefined) tc.bottlesPerSection = bps;
           if (bc !== undefined) tc.backCols = bc;
           if (Object.keys(tc).length > 0) entry.typeConfig = tc;
+        }
+
+        if (Array.isArray(cfg.disabledPositions)) {
+          const dp = [...new Set(
+            cfg.disabledPositions
+              .map(p => parseInt(p, 10))
+              .filter(p => !isNaN(p) && p >= 1)
+          )];
+          if (dp.length > 0) entry.disabledPositions = dp;
         }
 
         rackConfigs[String(name)] = entry;
@@ -532,6 +544,12 @@ router.post('/confirm', async (req, res) => {
           };
           if (override?.typeConfig) rackData.typeConfig = override.typeConfig;
           const rack = new Rack(rackData);
+          // Disabled positions beyond the created geometry address cells that
+          // don't exist — drop them rather than storing dead entries.
+          if (override?.disabledPositions?.length) {
+            const rackMax = getMaxPosition(rack);
+            rack.disabledPositions = override.disabledPositions.filter(p => p <= rackMax);
+          }
           await rack.save();
           createdRacks.push({ name, type: safeType, rows, cols, typeConfig: override?.typeConfig });
           logAudit(req, 'rack.create', { type: 'rack', id: rack._id }, { source: 'import', name });
@@ -792,7 +810,8 @@ router.post('/confirm', async (req, res) => {
               // .toObject() shape is what the helper expects.
               typeConfig: rack.typeConfig?.toObject ? rack.typeConfig.toObject() : rack.typeConfig,
               slots: rack.slots,
-              maxPosition: getMaxPosition(rack)
+              maxPosition: getMaxPosition(rack),
+              disabledPositions: rack.disabledPositions
             },
             group,
             positionAnchor

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -158,6 +158,12 @@ router.put('/:id', async (req, res) => {
       });
     }
 
+    // Silently drop disabled positions beyond the new maximum — they address
+    // cells that no longer exist after the resize.
+    if ((rack.disabledPositions || []).some(p => p > newMax)) {
+      rack.disabledPositions = rack.disabledPositions.filter(p => p <= newMax);
+    }
+
     await rack.save();
     await rack.populate({
       path: 'slots.bottle',
@@ -232,6 +238,10 @@ router.put('/:id/slots/:position', async (req, res) => {
     const maxPos = getMaxPosition(rack);
     if (position < 1 || position > maxPos) {
       return res.status(400).json({ error: `Position must be 1–${maxPos}` });
+    }
+
+    if ((rack.disabledPositions || []).includes(position)) {
+      return res.status(400).json({ error: 'This slot is disabled' });
     }
 
     // Verify the bottle belongs to this cellar
@@ -345,6 +355,90 @@ router.delete('/:id/slots/:position', async (req, res) => {
   } catch (err) {
     console.error('Clear slot error:', err);
     res.status(500).json({ error: 'Failed to clear slot' });
+  }
+});
+
+// POST /api/racks/:id/slots/:position/disable  — mark a slot as unusable (owner or editor)
+router.post('/:id/slots/:position/disable', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const position = parseInt(req.params.position, 10);
+    if (isNaN(position)) return res.status(400).json({ error: 'Invalid position' });
+
+    const rack = await Rack.findOne({ _id: req.params.id, deletedAt: null });
+    if (!rack) return res.status(404).json({ error: 'Rack not found' });
+
+    const cellarDoc = await Cellar.findById(rack.cellar);
+    const role = getCellarRole(cellarDoc, req.user.id);
+    if (!role || role === 'viewer') {
+      return res.status(403).json({ error: 'Not authorized to modify rack slots' });
+    }
+
+    const maxPos = getMaxPosition(rack);
+    if (position < 1 || position > maxPos) {
+      return res.status(400).json({ error: `Position must be 1–${maxPos}` });
+    }
+
+    if (rack.slots.some(s => s.position === position)) {
+      return res.status(409).json({ error: 'This slot is occupied. Clear the slot first.' });
+    }
+
+    // $addToSet semantics — no duplicates
+    if (!rack.disabledPositions.includes(position)) {
+      rack.disabledPositions.push(position);
+      await rack.save();
+    }
+
+    await rack.populate({
+      path: 'slots.bottle',
+      populate: { path: 'wineDefinition', populate: ['country', 'region', 'grapes'] }
+    });
+
+    logAudit(req, 'rack.slot_disable', { type: 'rack', id: rack._id });
+    res.json({ rack });
+  } catch (err) {
+    if (err.name === 'VersionError') {
+      return res.status(409).json({ error: 'This rack was modified by another request. Please refresh and try again.' });
+    }
+    console.error('Disable slot error:', err);
+    res.status(500).json({ error: 'Failed to disable slot' });
+  }
+});
+
+// DELETE /api/racks/:id/slots/:position/disable  — make a disabled slot usable again (owner or editor)
+router.delete('/:id/slots/:position/disable', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const position = parseInt(req.params.position, 10);
+    if (isNaN(position)) return res.status(400).json({ error: 'Invalid position' });
+
+    const rack = await Rack.findOne({ _id: req.params.id, deletedAt: null });
+    if (!rack) return res.status(404).json({ error: 'Rack not found' });
+
+    const cellarDoc = await Cellar.findById(rack.cellar);
+    const role = getCellarRole(cellarDoc, req.user.id);
+    if (!role || role === 'viewer') {
+      return res.status(403).json({ error: 'Not authorized to modify rack slots' });
+    }
+
+    if (rack.disabledPositions.includes(position)) {
+      rack.disabledPositions = rack.disabledPositions.filter(p => p !== position);
+      await rack.save();
+    }
+
+    await rack.populate({
+      path: 'slots.bottle',
+      populate: { path: 'wineDefinition', populate: ['country', 'region', 'grapes'] }
+    });
+
+    logAudit(req, 'rack.slot_enable', { type: 'rack', id: rack._id });
+    res.json({ rack });
+  } catch (err) {
+    if (err.name === 'VersionError') {
+      return res.status(409).json({ error: 'This rack was modified by another request. Please refresh and try again.' });
+    }
+    console.error('Enable slot error:', err);
+    res.status(500).json({ error: 'Failed to enable slot' });
   }
 });
 

--- a/backend/src/services/cellarExport.js
+++ b/backend/src/services/cellarExport.js
@@ -360,6 +360,9 @@ async function buildCellarDataExport(userId, scope) {
         rows: r.rows,
         cols: r.cols,
         ...(r.typeConfig ? { typeConfig: r.typeConfig } : {}),
+        ...(Array.isArray(r.disabledPositions) && r.disabledPositions.length > 0
+          ? { disabledPositions: r.disabledPositions }
+          : {}),
       })),
       ...(layout ? { layout } : {}),
       bottles: mapBottlesForExport(

--- a/backend/src/services/cellarImport.js
+++ b/backend/src/services/cellarImport.js
@@ -309,8 +309,18 @@ async function createRacks(cellarId, userId, cellar, items, result) {
       cols: clampDim(spec?.cols || inf.cols, 1),
     };
     if (spec?.typeConfig) rackData.typeConfig = spec.typeConfig;
+    const rackDoc = new Rack(rackData);
+    // Restore disabled (unusable) positions, clamped to the created geometry.
+    if (Array.isArray(spec?.disabledPositions) && spec.disabledPositions.length > 0) {
+      const rackMax = getMaxPosition(rackDoc);
+      rackDoc.disabledPositions = [...new Set(
+        spec.disabledPositions
+          .map((p) => parseInt(p, 10))
+          .filter((p) => !isNaN(p) && p >= 1 && p <= rackMax)
+      )];
+    }
     try {
-      await new Rack(rackData).save();
+      await rackDoc.save();
       result.racksCreated++;
     } catch (err) {
       console.warn(`[cellarImport] rack "${name}" create failed (non-fatal):`, err.message);
@@ -693,6 +703,7 @@ async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, i
           typeConfig: rack.typeConfig?.toObject ? rack.typeConfig.toObject() : rack.typeConfig,
           slots: rack.slots,
           maxPosition: getMaxPosition(rack),
+          disabledPositions: rack.disabledPositions,
         }, group, anchor);
         for (const pl of placements) rack.slots.push({ position: pl.position, bottle: pl.bottle });
         for (const u of unplaced) result.unplaced.push({ ...u, rackName });

--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -278,7 +278,7 @@ function planRackCreations(items) {
  * geometry + existing slots and gets back a list of slot writes + the
  * collection of items that couldn't be placed and why.
  *
- * @param {{type, rows, cols, typeConfig, slots, maxPosition}} rack
+ * @param {{type, rows, cols, typeConfig, slots, maxPosition, disabledPositions?}} rack
  * @param {Array<{item: object, bottleId: any, sourceIndex?: number}>} items
  * @param {string} anchor One of VALID_ANCHORS
  * @returns {{
@@ -320,7 +320,7 @@ function placeBottlesInRack(rack, items, anchor) {
     requests.push({ requestedPosition: result.position, bottleId: it.bottleId, sourceIndex: it.sourceIndex });
   }
 
-  const { placements, unplaced: tooFull } = placeBottles(rack.slots || [], requests, rack.maxPosition);
+  const { placements, unplaced: tooFull } = placeBottles(rack.slots || [], requests, rack.maxPosition, rack.disabledPositions);
 
   for (const t of tooFull) {
     unplaced.push({ sourceIndex: t.sourceIndex, requestedPosition: t.requestedPosition, reason: 'Rack full' });
@@ -354,10 +354,15 @@ function findNextFreeSlot(occupied, requestedPosition, maxPosition) {
  * @param {Array<{requestedPosition: number, bottleId: any, sourceIndex?: number}>} requests
  *        Bottles wanting a slot in this rack, in the order they came from the CSV.
  * @param {number} maxPosition Total addressable slots in this rack.
+ * @param {number[]} [disabledPositions]
+ *        Positions the user marked as unusable. Seeded into the occupied set so
+ *        neither exact placement nor overflow ever lands there — but they are
+ *        NOT placements, so they don't count as bottles placed.
  * @returns {{placements: Array, unplaced: Array}}
  */
-function placeBottles(existingSlots, requests, maxPosition) {
+function placeBottles(existingSlots, requests, maxPosition, disabledPositions) {
   const occupied = new Set((existingSlots || []).map(s => s.position));
+  for (const p of disabledPositions || []) occupied.add(p);
   const placements = [];
   const overflow = [];
 

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -348,6 +348,41 @@ describe('placeBottles', () => {
     ], 5);
     expect(result.placements[0].position).toBe(4);
   });
+
+  test('treats disabled positions as occupied — exact request overflows past them', () => {
+    const result = placeBottles([], [
+      { requestedPosition: 3, bottleId: 'a' },
+    ], 24, [3, 4]);
+    expect(result.placements[0].position).toBe(5);
+    expect(result.placements[0].overflowed).toBe(true);
+  });
+
+  test('overflow scan skips disabled positions', () => {
+    const result = placeBottles([], [
+      { requestedPosition: 1, bottleId: 'a' },
+      { requestedPosition: 1, bottleId: 'b' },
+    ], 24, [2]);
+    const placementOf = (id) => result.placements.find(p => p.bottle === id).position;
+    expect(placementOf('a')).toBe(1);
+    expect(placementOf('b')).toBe(3); // 2 is disabled, not usable for overflow
+  });
+
+  test('disabled positions do not count as bottles placed', () => {
+    const result = placeBottles([], [
+      { requestedPosition: 1, bottleId: 'a' },
+    ], 24, [10, 11, 12]);
+    expect(result.placements).toHaveLength(1);
+    expect(result.placements[0]).toEqual(expect.objectContaining({ position: 1, bottle: 'a' }));
+  });
+
+  test('reports unplaced when only disabled positions remain', () => {
+    const existing = [{ position: 1, bottle: 'pre' }];
+    const result = placeBottles(existing, [
+      { requestedPosition: 2, bottleId: 'a' },
+    ], 3, [2, 3]);
+    expect(result.placements).toHaveLength(0);
+    expect(result.unplaced).toHaveLength(1);
+  });
 });
 
 describe('placeBottlesInRack (orchestration)', () => {
@@ -389,6 +424,16 @@ describe('placeBottlesInRack (orchestration)', () => {
       { item: { rackPosition: 11 }, bottleId: 'a', sourceIndex: 0 },
     ], 'top-left');
     expect(placements[0].position).toBe(12);
+    expect(placements[0].overflowed).toBe(true);
+  });
+
+  test('end-to-end: rack disabledPositions are never assigned', () => {
+    const rack = buildRack({ disabledPositions: [11, 12] });
+    const { placements, unplaced } = placeBottlesInRack(rack, [
+      { item: { rackPosition: 11 }, bottleId: 'a', sourceIndex: 0 },
+    ], 'top-left');
+    expect(unplaced).toHaveLength(0);
+    expect(placements[0].position).toBe(13);
     expect(placements[0].overflowed).toBe(true);
   });
 

--- a/frontend/src/api/racks.js
+++ b/frontend/src/api/racks.js
@@ -16,6 +16,12 @@ export const updateSlot = (apiFetch, rackId, position, data) =>
 export const clearSlot = (apiFetch, rackId, position) =>
   apiFetch(`/api/racks/${rackId}/slots/${position}`, { method: 'DELETE' });
 
+export const disableSlot = (apiFetch, rackId, position) =>
+  apiFetch(`/api/racks/${rackId}/slots/${position}/disable`, { method: 'POST' });
+
+export const enableSlot = (apiFetch, rackId, position) =>
+  apiFetch(`/api/racks/${rackId}/slots/${position}/disable`, { method: 'DELETE' });
+
 export const createRack = (apiFetch, data) =>
   apiFetch('/api/racks', {
     method: 'POST',

--- a/frontend/src/components/racks/RackRenderer.js
+++ b/frontend/src/components/racks/RackRenderer.js
@@ -18,6 +18,10 @@ const ACTIVE_STROKE = '#7A1E2D';
 const WOOD_BG       = '#DCC8A4';
 const WOOD_FRAME    = '#C8AD82';
 const SHELF_COLOR   = '#D4BA94';
+// Disabled (unusable) slots — muted, greyed-out wood tones
+const DISABLED_FILL   = '#BFB09A';
+const DISABLED_STROKE = '#A89880';
+const DISABLED_CROSS  = 'rgba(90, 74, 56, 0.45)';
 
 /** Sub-circle offsets for multi-bottle cells (dx, dy from cell centre) */
 function getSubOffsets(bpc, R) {
@@ -90,6 +94,11 @@ export default function RackRenderer({
     return m;
   }, [rack.slots]);
 
+  const disabledSet = useMemo(
+    () => new Set(rack.disabledPositions || []),
+    [rack.disabledPositions]
+  );
+
   const activePos = activeRackId === rack._id ? activePosition : null;
   const R = SLOT_RADIUS;
 
@@ -104,7 +113,7 @@ export default function RackRenderer({
             ) : rack.type && rack.type !== 'grid' ? (
               <span className="rack-type-badge">{t(`racks.type_${rack.type}`)}</span>
             ) : null}
-            {(rack.slots || []).length}/{layout.totalSlots} {t('racks.filled')}
+            {(rack.slots || []).length}/{layout.totalSlots - disabledSet.size} {t('racks.filled')}
           </span>
         </div>
         <div className="rack-header-actions">
@@ -217,6 +226,7 @@ export default function RackRenderer({
                   position={position}
                   cx={cx} cy={cy} R={isBack && backR ? backR : R}
                   slot={slotMap[position]}
+                  disabled={disabledSet.has(position)}
                   isActive={activePos === position}
                   isHighlight={highlightPos === position}
                   onSlotClick={onSlotClick}
@@ -272,6 +282,7 @@ export default function RackRenderer({
                         cy={cell.cy + off.dy}
                         R={useR}
                         slot={slotMap[pos]}
+                        disabled={disabledSet.has(pos)}
                         isActive={activePos === pos}
                         isHighlight={highlightPos === pos}
                         onSlotClick={onSlotClick}
@@ -289,10 +300,39 @@ export default function RackRenderer({
 }
 
 /** Single slot circle (bpc=1 standard rendering) */
-function SlotCircle({ position, cx, cy, R, slot, isActive, isHighlight, onSlotClick }) {
+function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight, onSlotClick }) {
   const wine = slot?.bottle?.wineDefinition;
   const wineType = wine?.type || 'red';
   const colors = slot ? (WINE_COLORS[wineType] || WINE_COLORS.red) : null;
+
+  // Disabled (unusable) position: greyed circle with a subtle diagonal cross.
+  // Still clickable so editors can re-enable it from the slot popup.
+  if (disabled) {
+    const d = R * 0.5;
+    return (
+      <g
+        className="rack-slot-g disabled"
+        onClick={() => onSlotClick(position, null)}
+        onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onSlotClick(position, null)}
+        role="button"
+        tabIndex={0}
+        aria-label={`Disabled slot ${position}`}
+        style={{ cursor: 'default' }}
+      >
+        <circle
+          cx={cx} cy={cy} r={R}
+          fill={DISABLED_FILL}
+          stroke={DISABLED_STROKE}
+          strokeWidth={1.5}
+          opacity={0.65}
+        />
+        <line x1={cx - d} y1={cy - d} x2={cx + d} y2={cy + d}
+          stroke={DISABLED_CROSS} strokeWidth={1.5} strokeLinecap="round" pointerEvents="none" />
+        <line x1={cx - d} y1={cy + d} x2={cx + d} y2={cy - d}
+          stroke={DISABLED_CROSS} strokeWidth={1.5} strokeLinecap="round" pointerEvents="none" />
+      </g>
+    );
+  }
 
   return (
     <g

--- a/frontend/src/components/racks/ShelfView.js
+++ b/frontend/src/components/racks/ShelfView.js
@@ -33,6 +33,11 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
     return m;
   }, [rack?.slots]);
 
+  const disabledSet = useMemo(
+    () => new Set(rack?.disabledPositions || []),
+    [rack?.disabledPositions]
+  );
+
   if (rack?.type !== 'shelf') {
     return (
       <div className="shelf-view-empty">
@@ -142,6 +147,7 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
                     cy={cy}
                     slot={s.slot}
                     position={s.position}
+                    disabled={disabledSet.has(s.position)}
                     isActive={activePosition === s.position}
                     isHighlight={highlightPos === s.position}
                     onClick={() => onSlotClick && onSlotClick(s.position, s.slot || null)}
@@ -156,12 +162,44 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
   );
 }
 
-function BottleOval({ cx, cy, slot, position, isActive, isHighlight, onClick }) {
+function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, onClick }) {
   const bottle = slot?.bottle;
   const wine = bottle?.wineDefinition;
   const wineType = wine?.type || 'red';
   const colors = bottle ? (WINE_COLORS[wineType] || WINE_COLORS.red) : null;
   const filled = !!bottle;
+
+  // Disabled (unusable) position: greyed oval with a subtle diagonal cross.
+  // Still clickable so editors can re-enable it from the slot popup.
+  if (disabled) {
+    const dx = BOTTLE_RX * 0.5;
+    const dy = BOTTLE_RY * 0.5;
+    return (
+      <g
+        onClick={onClick}
+        onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onClick?.()}
+        role="button"
+        tabIndex={0}
+        className="shelf-view-bottle disabled"
+        aria-label={`Disabled slot ${position}`}
+        style={{ cursor: 'default' }}
+      >
+        <ellipse
+          cx={cx}
+          cy={cy}
+          rx={BOTTLE_RX}
+          ry={BOTTLE_RY}
+          fill="rgba(90, 74, 56, 0.12)"
+          stroke="#A89880"
+          strokeWidth={1.5}
+        />
+        <line x1={cx - dx} y1={cy - dy} x2={cx + dx} y2={cy + dy}
+          stroke="rgba(90, 74, 56, 0.45)" strokeWidth={1.5} strokeLinecap="round" pointerEvents="none" />
+        <line x1={cx - dx} y1={cy + dy} x2={cx + dx} y2={cy - dy}
+          stroke="rgba(90, 74, 56, 0.45)" strokeWidth={1.5} strokeLinecap="round" pointerEvents="none" />
+      </g>
+    );
+  }
 
   return (
     <g

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -217,6 +217,20 @@ function EmptySlot({ position, slotPosition, onClick, isBack, useAbsoluteZ = fal
   );
 }
 
+// ── Disabled slot (small flat dark disc, non-interactive) ────────────
+// Marks a position the user disabled as unusable. Deliberately cheap:
+// one low-segment circle, no ring, no pointer handlers — the hole just
+// reads as intentional. Sized like EmptySlot's ring.
+function DisabledSlotDisc({ position, isBack }) {
+  const r = (isBack ? 0.7 : 1) * (BOTTLE_RADIUS - 0.005);
+  return (
+    <mesh position={position}>
+      <circleGeometry args={[r, 12]} />
+      <meshStandardMaterial color="#3A3229" roughness={0.95} />
+    </mesh>
+  );
+}
+
 // ── Slot positions ───────────────────────────────────────
 function computeSlotPositions(rows, cols, width, height) {
   const positions = [];
@@ -446,6 +460,7 @@ function PullOutShelfRow({
   frameColor,
   rowSlots,
   slotMap,
+  disabledSet,
   onTogglePull,
   onBottleClick,
   onEmptySlotClick,
@@ -495,6 +510,9 @@ function PullOutShelfRow({
         const filled = !!slot;
         const wineType = slot?.bottle?.wineDefinition?.type || 'red';
         const finalBottleZ = bottleZ !== undefined ? bottleZ : (-0.08 + z);
+        if (!filled && disabledSet?.has(pos)) {
+          return <DisabledSlotDisc key={pos} position={[x, y, z]} isBack={isBack} />;
+        }
         if (filled) {
           return (
             <Bottle
@@ -643,6 +661,11 @@ export default function RackMesh({
     (rack.slots || []).forEach(s => { m[s.position] = s; });
     return m;
   }, [rack.slots]);
+
+  const disabledSet = useMemo(
+    () => new Set(rack.disabledPositions || []),
+    [rack.disabledPositions]
+  );
 
   // Accurate total slot count per type — reuses the same helpers the 2D rack
   // view uses, so the label always matches the backend's real capacity
@@ -934,6 +957,7 @@ export default function RackMesh({
               frameColor={frameColor}
               rowSlots={rowSlots}
               slotMap={slotMap}
+              disabledSet={disabledSet}
               onTogglePull={() => setPulledShelfRow(prev => prev === r ? null : r)}
               onBottleClick={onBottleClick}
               onEmptySlotClick={onEmptySlotClick}
@@ -947,6 +971,15 @@ export default function RackMesh({
           const filled = !!slot;
           const wineType = slot?.bottle?.wineDefinition?.type || 'red';
           const finalBottleZ = bottleZ !== undefined ? bottleZ : (-0.08 + z);
+          if (!filled && disabledSet.has(pos)) {
+            return (
+              <DisabledSlotDisc
+                key={pos}
+                position={[x, y, rackType === 'shelf' ? z : (depth / 2 - 0.005)]}
+                isBack={isBack}
+              />
+            );
+          }
           return filled ? (
             <Bottle
               key={pos}
@@ -1010,7 +1043,7 @@ export default function RackMesh({
           }}>
             {rack.name}
             <span style={{ opacity: 0.55, marginLeft: 6, fontSize: '10px', fontWeight: 400 }}>
-              {rack.slots?.length || 0}/{totalSlots}
+              {rack.slots?.length || 0}/{totalSlots - disabledSet.size}
             </span>
           </div>
         </Html>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -548,7 +548,11 @@
     "saveRack": "Save Rack",
     "overlapWarning": "Modules are overlapping. Move them apart before saving.",
     "nfcLink": "NFC Tag",
-    "nfcLinked": "NFC Linked"
+    "nfcLinked": "NFC Linked",
+    "disableSlot": "Disable slot",
+    "enableSlot": "Enable slot",
+    "disabledSlotTitle": "Slot {{position}} — Disabled",
+    "disabledSlotNote": "This slot is marked as unusable — bottles can't be placed here."
   },
 
   "nfc": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -548,7 +548,11 @@
     "saveRack": "Spara hylla",
     "overlapWarning": "Modulerna överlappar. Flytta isär dem innan du sparar.",
     "nfcLink": "NFC-tagg",
-    "nfcLinked": "NFC kopplad"
+    "nfcLinked": "NFC kopplad",
+    "disableSlot": "Inaktivera plats",
+    "enableSlot": "Aktivera plats",
+    "disabledSlotTitle": "Plats {{position}} — Inaktiverad",
+    "disabledSlotNote": "Den här platsen är markerad som oanvändbar — flaskor kan inte placeras här."
   },
 
   "nfc": {

--- a/frontend/src/pages/CellarRacks.css
+++ b/frontend/src/pages/CellarRacks.css
@@ -371,6 +371,14 @@
   margin: 0;
 }
 
+/* ---- Disabled slot popup ---- */
+.slot-disabled-note {
+  padding: 1.25rem 1rem;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
 /* ---- Filled slot: bottle detail ---- */
 .slot-bottle-detail {
   display: flex;

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -3,7 +3,7 @@ import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { getCellar } from '../api/cellars';
-import { getRacks, deleteRack, updateSlot, clearSlot, createRack, updateRack } from '../api/racks';
+import { getRacks, deleteRack, updateSlot, clearSlot, createRack, updateRack, disableSlot, enableSlot } from '../api/racks';
 import { consumeBottle } from '../api/bottles';
 import { getTotalSlots, getModularTotalSlots } from '../utils/rackLayouts';
 import RackRenderer from '../components/racks/RackRenderer';
@@ -219,6 +219,29 @@ function CellarRacks() {
     setActivePopup(null);
   };
 
+  // --- disable / re-enable a slot position ---
+  const handleDisableSlot = async (rackId, position) => {
+    const res = await disableSlot(apiFetch, rackId, position);
+    const data = await res.json();
+    if (res.ok) {
+      setRacks(racks.map(r => r._id === rackId ? data.rack : r));
+    } else {
+      alert(data.error || 'Failed to disable slot');
+    }
+    setActivePopup(null);
+  };
+
+  const handleEnableSlot = async (rackId, position) => {
+    const res = await enableSlot(apiFetch, rackId, position);
+    const data = await res.json();
+    if (res.ok) {
+      setRacks(racks.map(r => r._id === rackId ? data.rack : r));
+    } else {
+      alert(data.error || 'Failed to enable slot');
+    }
+    setActivePopup(null);
+  };
+
   // --- soft-remove bottle via the shared consume endpoint ---
   const handleConsumeSubmit = async (reason, note, rating, consumedRatingScale) => {
     const { bottleId } = consumeModal;
@@ -318,9 +341,10 @@ function CellarRacks() {
               >
                 {r.name}
                 <span className="rack-tab-count">
-                  {r.slots.length}/{r.isModular && r.modules?.length > 0
+                  {r.slots.length}/{(r.isModular && r.modules?.length > 0
                     ? getModularTotalSlots(r.modules)
-                    : getTotalSlots(r.type || 'grid', r.rows, r.cols, r.typeConfig)}
+                    : getTotalSlots(r.type || 'grid', r.rows, r.cols, r.typeConfig))
+                    - (r.disabledPositions?.length || 0)}
                 </span>
               </button>
             ))}
@@ -357,7 +381,9 @@ function CellarRacks() {
           {rack.type === 'shelf' && !rack.isModular && (viewMode === 'shelf' || viewMode === '3d') ? (
             (() => {
               const handleClick = (pos, slotData) => {
-                if (!canEdit && !slotData) return;
+                const isDisabled = (rack.disabledPositions || []).includes(pos);
+                // Viewers can inspect filled or disabled slots, not empty ones
+                if (!canEdit && !slotData && !isDisabled) return;
                 if (activePopup?.rackId === rack._id && activePopup?.position === pos) {
                   setActivePopup(null);
                 } else {
@@ -387,8 +413,9 @@ function CellarRacks() {
               activePosition={activePopup?.position}
               highlightPos={highlightPos?.rackId === rack._id ? highlightPos.position : null}
               onSlotClick={(pos, slotData) => {
-                // Viewers can only inspect filled slots, not interact with empty ones
-                if (!canEdit && !slotData) return;
+                // Viewers can only inspect filled or disabled slots, not interact with empty ones
+                const isDisabled = (rack.disabledPositions || []).includes(pos);
+                if (!canEdit && !slotData && !isDisabled) return;
                 if (activePopup?.rackId === rack._id && activePopup?.position === pos) {
                   setActivePopup(null);
                 } else {
@@ -406,33 +433,47 @@ function CellarRacks() {
       </>}
 
       {/* Page-level fixed slot modal */}
-      {activePopup && (
-        <div className="slot-modal-overlay" onClick={() => setActivePopup(null)} role="dialog" aria-modal="true">
-          <div className="slot-modal" onClick={e => e.stopPropagation()}>
-            {activePopup.slot ? (
-              <FilledSlotContent
-                position={activePopup.position}
-                slot={activePopup.slot}
-                canEdit={canEdit}
-                onRemoveFromRack={() => handleRemoveFromRack(activePopup.rackId, activePopup.position)}
-                onConsume={() => {
-                  setConsumeModal({ bottleId: activePopup.slot.bottle._id });
-                  setActivePopup(null);
-                }}
-                onClose={() => setActivePopup(null)}
-              />
-            ) : (
-              <EmptySlotContent
-                position={activePopup.position}
-                apiFetch={apiFetch}
-                cellarId={id}
-                onAssign={(pos, bottleId) => handleAssign(activePopup.rackId, pos, bottleId)}
-                onClose={() => setActivePopup(null)}
-              />
-            )}
+      {activePopup && (() => {
+        const popupRack = racks.find(r => r._id === activePopup.rackId);
+        const popupDisabled = !activePopup.slot &&
+          (popupRack?.disabledPositions || []).includes(activePopup.position);
+        return (
+          <div className="slot-modal-overlay" onClick={() => setActivePopup(null)} role="dialog" aria-modal="true">
+            <div className="slot-modal" onClick={e => e.stopPropagation()}>
+              {activePopup.slot ? (
+                <FilledSlotContent
+                  position={activePopup.position}
+                  slot={activePopup.slot}
+                  canEdit={canEdit}
+                  onRemoveFromRack={() => handleRemoveFromRack(activePopup.rackId, activePopup.position)}
+                  onConsume={() => {
+                    setConsumeModal({ bottleId: activePopup.slot.bottle._id });
+                    setActivePopup(null);
+                  }}
+                  onClose={() => setActivePopup(null)}
+                />
+              ) : popupDisabled ? (
+                <DisabledSlotContent
+                  position={activePopup.position}
+                  canEdit={canEdit}
+                  onEnable={() => handleEnableSlot(activePopup.rackId, activePopup.position)}
+                  onClose={() => setActivePopup(null)}
+                />
+              ) : (
+                <EmptySlotContent
+                  position={activePopup.position}
+                  apiFetch={apiFetch}
+                  cellarId={id}
+                  canEdit={canEdit}
+                  onAssign={(pos, bottleId) => handleAssign(activePopup.rackId, pos, bottleId)}
+                  onDisable={() => handleDisableSlot(activePopup.rackId, activePopup.position)}
+                  onClose={() => setActivePopup(null)}
+                />
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Consume/remove modal */}
       {consumeModal && (
@@ -641,7 +682,7 @@ function NewRackForm({ newRack, setNewRack, onTypeChange, onSubmit, saving }) {
 }
 
 // ---- Content for empty slot: pick a bottle to place ----
-function EmptySlotContent({ position, apiFetch, cellarId, onAssign, onClose }) {
+function EmptySlotContent({ position, apiFetch, cellarId, canEdit, onAssign, onDisable, onClose }) {
   const { t } = useTranslation();
   const [search, setSearch] = useState('');
   const [results, setResults] = useState([]);
@@ -721,6 +762,34 @@ function EmptySlotContent({ position, apiFetch, cellarId, onAssign, onClose }) {
           ))
         )}
       </div>
+      {canEdit && onDisable && (
+        <div className="slot-popup-actions">
+          <button className="btn btn-secondary btn-small" onClick={onDisable}>
+            {t('racks.disableSlot')}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ---- Content for a disabled (unusable) slot ----
+function DisabledSlotContent({ position, canEdit, onEnable, onClose }) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <div className="slot-popup-header">
+        <span className="slot-popup-title">{t('racks.disabledSlotTitle', { position })}</span>
+        <button className="slot-popup-close" onClick={onClose} aria-label="Close">&times;</button>
+      </div>
+      <p className="slot-disabled-note">{t('racks.disabledSlotNote')}</p>
+      {canEdit && (
+        <div className="slot-popup-actions">
+          <button className="btn btn-secondary btn-small" onClick={onEnable}>
+            {t('racks.enableSlot')}
+          </button>
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -798,15 +798,46 @@ export function parseOenoExport(text) {
 
   // Build per-rack default configs so the picker can pre-fill cabinet shapes
   const oenoRackSpecs = {};
-  for (const [, cab] of cabinetById) {
+  for (const [cabinetId, cab] of cabinetById) {
     const totalColumns = cab.columns.size;
     for (const [columnIndex, col] of cab.columns) {
       const rackName = rackNameFor(cab.label, columnIndex, totalColumns);
+      const rows = Math.min(20, col.maxShelf);
+      const cols = 6;
+      const backCols = 5;
+      const bpc = 1;
+
+      // Convert each layer's disabled slot-in-layer indices to GLOBAL Cellarion
+      // positions, mirroring the backend's computeRackPosition shelf math with
+      // the Oeno bottom-left anchor (shelf 1 = bottom → effectiveShelf =
+      // rows - shelfIndex + 1):
+      //   shelfBase = (effectiveShelf - 1) × (cols + backCols) × bottlesPerCell
+      //   front (layer 1): shelfBase + slotInLayer          (slotInLayer ≤ cols)
+      //   back  (layer 2): shelfBase + cols + slotInLayer   (slotInLayer ≤ backCols)
+      const disabled = new Set();
+      for (const layer of layerById.values()) {
+        if (layer.cabinetId !== cabinetId || layer.columnIndex !== columnIndex) continue;
+        if (layer.disabledSlots.size === 0) continue;
+        // Shelves clamped away by the 20-row cap have no cells to disable
+        if (layer.shelfIndex > rows) continue;
+        const shelfBase = (rows - layer.shelfIndex) * (cols + backCols) * bpc;
+        for (const n of layer.disabledSlots) {
+          if (layer.layerIndex === 1 && n <= cols) {
+            disabled.add(shelfBase + n);
+          } else if (layer.layerIndex === 2 && n <= backCols) {
+            disabled.add(shelfBase + cols + n);
+          }
+        }
+      }
+
       oenoRackSpecs[rackName] = {
         type: 'shelf',
-        rows: Math.min(20, col.maxShelf),
-        cols: 6,
-        typeConfig: { bottlesPerCell: 1, backCols: 5 },
+        rows,
+        cols,
+        typeConfig: { bottlesPerCell: bpc, backCols },
+        ...(disabled.size > 0
+          ? { disabledPositions: [...disabled].sort((a, b) => a - b) }
+          : {}),
       };
     }
   }

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -691,6 +691,29 @@ describe('parseOenoExport', () => {
     expect(result.oenoRackSpecs['Main Cellar – Module 4'].rows).toBe(13);
   });
 
+  it('converts per-layer disabled slots to global positions (bottom-anchored shelf math)', () => {
+    const result = parseOenoExport(fixture);
+    // Layer 1001 = column 3, shelf 18 (top shelf of the 18-row rack →
+    // Cellarion shelf 1, shelfBase 0), front layer, slots 5 & 6 disabled
+    // → global positions 5 and 6.
+    expect(result.oenoRackSpecs['Main Cellar – Module 3'].disabledPositions).toEqual([5, 6]);
+    // Racks without disabled slots don't carry the key at all
+    expect(result.oenoRackSpecs['Main Cellar – Module 4'].disabledPositions).toBeUndefined();
+    expect(result.oenoRackSpecs['Wine Fridge'].disabledPositions).toBeUndefined();
+  });
+
+  it('converts back-layer disabled slots with the cols offset', () => {
+    // Move layer 1002 to shelf 17 (back layer) and disable slots 2 and 4.
+    // Shelf 17 in an 18-row rack → effectiveShelf 2 → shelfBase = 1 × 11 = 11;
+    // back layer adds the 6 front cols: 11 + 6 + 2 = 19 and 11 + 6 + 4 = 21.
+    const withBackDisabled = fixture.replace(
+      '10001,Main Cellar,TRANSTHERM,Espace Cellar,3,18,2,1002,0,702,30,2024-07-05,,0',
+      '10001,Main Cellar,TRANSTHERM,Espace Cellar,3,17,2,1002,"2, 4",702,30,2024-07-05,,0'
+    );
+    const result = parseOenoExport(withBackDisabled);
+    expect(result.oenoRackSpecs['Main Cellar – Module 3'].disabledPositions).toEqual([5, 6, 19, 21]);
+  });
+
   it('maps shelved bottles to rackName + shelfNumber + layer + slotInLayer', () => {
     const result = parseOenoExport(fixture);
     const wineA = result.items.find(i => i.wineName === 'Test Wine A');


### PR DESCRIPTION
## Summary

First of the two rack features from the user-feedback email: some shelves physically can't hold a bottle in every position (bottle shape, cabinet quirks) — editors can now mark individual slots as unusable.

### How it works
- Click an empty slot → **Disable slot**; click a disabled slot → **Enable slot** (editors; viewers see an explanatory note). Disabled slots render greyed-with-a-cross in 2D and as a flat non-interactive disc in 3D (including pull-out shelf rows).
- **Positions never renumber** — disabled slots are holes in the existing 1..maxPosition space, so no existing bottle moves.
- Assignment to a disabled slot is rejected server-side; capacity labels show usable counts; rack resize drops out-of-range disabled positions.
- **Import-aware**: auto-placement never lands bottles on disabled slots (CSV import + cellar-archive import), and cellar exports carry `disabledPositions` for round-trip.
- **Oeno/Vintec bonus**: the importer's per-layer "Disabled Slots" column — parsed but dead until now (audit finding) — converts to global positions and applies to created racks automatically.

### Model
`Rack.disabledPositions: [Number]` (top-level; additive with default `[]`, no migration — existing racks are unaffected).

## Testing
- Backend Jest: 43 suites / **804 tests** (6 new placement tests)
- Frontend Vitest: 11 files / **312 tests** (2 new Oeno conversion tests)
- Docker smoke-test of the rack views planned before release (bundled with the double-height feature).

## Deploy / docker-compose impact
None — code-only, additive schema default, no migrations/env/dependencies.