### PR TITLE
chore(release): v1.69.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.68.2",
+  "version": "1.69.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.68.2",
+  "version": "1.69.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for the v1.69.0 minor release.

Changes since v1.68.2:
- #583 — **Disabled rack slots**: mark individual positions as unusable; import-aware (incl. automatic Oeno/Vintec disabled-slot import), export round-trip, 2D+3D rendering.
- #584 — **Double-height rows** on grid racks: per-row top layer of N−1 bottles resting in the gaps, appended position numbering (existing bottles never move), staggered 2D+3D rendering, create-form input.

## Compatibility
Verified against all 166 real racks in a prod data copy: byte-identical capacity, positions, and render coordinates when the new fields are absent. Both fields are additive with defaults — no migration.

## Deploy notes
Code-only — no compose, env, or migration changes.