### PR TITLE
feat: wishlist-from-history + cross-cellar search

### DIFF
--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -128,6 +128,258 @@ async function loadGroupedBottlePage({ cellarId, excludeSet, sortField, sortDir,
   };
 }
 
+// ── Cross-cellar (multi-select) query engine ──────────────────────────────
+// Powers the "search across several cellars at once" views. Given a set of
+// already-access-checked cellar ids, it mirrors the single-cellar bottle/history
+// routes' search/filter/sort/maturity semantics, MINUS grouping and rack
+// exclusion (both single-cellar concepts). Returns a flat, paginated list; the
+// caller tags each bottle with which cellar it lives in.
+
+// Resolve every cellar the user can read (owned + shared), as lean docs.
+async function resolveAccessibleCellars(userId) {
+  return Cellar.find({
+    $or: [{ user: userId }, { 'members.user': userId }],
+    deletedAt: null,
+  }).lean();
+}
+
+const MATURITY_RANK_MULTI = { declining: 0, late: 1, peak: 2, early: 3, 'not-ready': 4 };
+
+async function queryBottlesAcrossCellars(req, { cellarIds, statusFilter, paginate = true }) {
+  const {
+    search, type, country, region, grapes, vintage,
+    minRating, maxRating, maturity: maturityFilter, sort = '-createdAt',
+  } = req.query;
+  const { limit, offset: skip } = parsePagination(req.query, { limit: 30, maxLimit: 200 });
+  const { isValidObjectId } = mongoose;
+  const sortField = sort.startsWith('-') ? sort.substring(1) : sort;
+  const sortDir = sort.startsWith('-') ? -1 : 1;
+  const grapeIds = grapes
+    ? String(grapes).split(',').map(g => g.trim()).filter(isValidObjectId)
+    : [];
+  const hasMeiliFilters = !!(search || type || country || region || grapes || vintage);
+  const needsMaturity = statusFilter !== 'consumed' && !!(maturityFilter || sortField === 'maturity');
+  const statusMongo = statusFilter === 'consumed'
+    ? { $in: CONSUMED_STATUSES }
+    : { $nin: CONSUMED_STATUSES };
+  const objectIds = cellarIds.map(id => new mongoose.Types.ObjectId(id));
+
+  let bottles;
+  let usedMeili = false;
+
+  // ── PRIMARY: Meilisearch across the cellar set (typo tolerance) ──
+  if (searchService.getIsAvailable() && hasMeiliFilters) {
+    try {
+      const meiliResult = await searchService.searchBottles(search || '', {
+        cellarIds,
+        type: type || undefined,
+        countryId: country || undefined,
+        regionId: region || undefined,
+        grapeIds: grapeIds.length > 0 ? grapeIds : undefined,
+        vintage: vintage || undefined,
+        statusFilter,
+        sort,
+        limit: 10000,
+        offset: 0,
+      });
+      const ids = meiliResult.ids;
+      if (ids.length === 0) {
+        bottles = [];
+      } else {
+        bottles = await Bottle.find({ _id: { $in: ids } }).populate(WINE_POPULATE_LIST).lean();
+        const order = new Map(ids.map((id, i) => [id, i]));
+        bottles.sort((a, b) => (order.get(a._id.toString()) ?? 0) - (order.get(b._id.toString()) ?? 0));
+      }
+      usedMeili = true;
+    } catch {
+      // fall through to MongoDB
+    }
+  }
+
+  // ── FALLBACK: MongoDB + in-memory (Meili unavailable or errored) ──
+  if (!usedMeili) {
+    const filter = { cellar: { $in: objectIds }, status: statusMongo };
+    if (vintage) {
+      const vs = String(vintage).split(',').map(v => v.trim()).filter(Boolean);
+      filter.vintage = vs.length === 1 ? vs[0] : { $in: vs };
+    }
+    const wdFilter = {};
+    if (country) {
+      const ids = String(country).split(',').map(c => c.trim()).filter(isValidObjectId);
+      if (ids.length === 1) wdFilter.country = ids[0];
+      else if (ids.length > 1) wdFilter.country = { $in: ids };
+    }
+    if (region) {
+      const ids = String(region).split(',').map(r => r.trim()).filter(isValidObjectId);
+      if (ids.length === 1) wdFilter.region = ids[0];
+      else if (ids.length > 1) wdFilter.region = { $in: ids };
+    }
+    if (type) {
+      const types = String(type).split(',').map(t => t.trim()).filter(Boolean);
+      wdFilter.type = types.length === 1 ? types[0] : { $in: types };
+    }
+    if (grapeIds.length > 0) wdFilter.grapes = { $in: grapeIds };
+    if (Object.keys(wdFilter).length > 0) {
+      const matchingWdIds = await WineDefinition.find(wdFilter).distinct('_id');
+      if (matchingWdIds.length === 0) return { items: [], total: 0, limit, skip, maturityStatusMap: null };
+      filter.wineDefinition = { $in: matchingWdIds };
+    }
+    bottles = await Bottle.find(filter)
+      .populate(WINE_POPULATE_LIST)
+      // Cap on the field we ultimately order by, so a >10k set keeps the right
+      // slice: newest-consumed for history, newest-added for active bottles.
+      .sort(statusFilter === 'consumed' ? { consumedAt: -1 } : { createdAt: -1 })
+      .limit(10000)
+      .lean();
+    if (search) {
+      const stripAccents = (s) => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+      const words = stripAccents(search.toLowerCase()).split(/\s+/).filter(Boolean);
+      bottles = bottles.filter(b => {
+        const allText = [
+          b.wineDefinition?.name, b.wineDefinition?.producer, b.notes, b.location, b.consumedNote,
+          b.wineDefinition?.country?.name, b.wineDefinition?.region?.name,
+          b.wineDefinition?.appellation, b.wineDefinition?.type,
+          ...(b.wineDefinition?.grapes || []).map(g => g.name),
+        ].filter(Boolean).map(s => stripAccents(s.toLowerCase())).join(' ');
+        return words.every(word => allText.includes(word));
+      });
+    }
+  }
+
+  // ── Shared post-filters (rating + maturity), applied to both paths ──
+  if (minRating) {
+    const min = parseFloat(minRating);
+    bottles = bottles.filter(b => b.rating && toNormalized(b.rating, b.ratingScale || '5') >= min);
+  }
+  if (maxRating) {
+    const max = parseFloat(maxRating);
+    bottles = bottles.filter(b => b.rating && toNormalized(b.rating, b.ratingScale || '5') <= max);
+  }
+  let maturityStatusMap;
+  if (needsMaturity) {
+    const profileMap = await buildProfileMap(bottles);
+    maturityStatusMap = new Map();
+    for (const b of bottles) maturityStatusMap.set(b._id.toString(), classifyMaturity(b, profileMap));
+  }
+  if (maturityFilter && maturityStatusMap) {
+    bottles = maturityFilter === 'none'
+      ? bottles.filter(b => maturityStatusMap.get(b._id.toString()) == null)
+      : bottles.filter(b => maturityStatusMap.get(b._id.toString()) === maturityFilter);
+  }
+
+  // ── Sort ──
+  if (statusFilter === 'consumed') {
+    // History is a chronological view — newest-consumed first, always.
+    bottles.sort((a, b) => new Date(b.consumedAt || 0) - new Date(a.consumedAt || 0));
+  } else if (sortField === 'name') {
+    bottles.sort((a, b) => {
+      const av = (a.wineDefinition?.name || '').toLowerCase();
+      const bv = (b.wineDefinition?.name || '').toLowerCase();
+      return av < bv ? -sortDir : av > bv ? sortDir : 0;
+    });
+  } else if (sortField === 'maturity' && maturityStatusMap) {
+    bottles.sort((a, b) => {
+      const av = maturityStatusMap.get(a._id.toString());
+      const bv = maturityStatusMap.get(b._id.toString());
+      return ((av != null ? MATURITY_RANK_MULTI[av] : 5) - (bv != null ? MATURITY_RANK_MULTI[bv] : 5)) * sortDir;
+    });
+  } else if (!usedMeili) {
+    // Meili already sorted its supported fields; the Mongo path sorts here.
+    bottles.sort((a, b) => {
+      const av = a[sortField] ?? 0;
+      const bv = b[sortField] ?? 0;
+      return av < bv ? -sortDir : av > bv ? sortDir : 0;
+    });
+  }
+
+  const total = bottles.length;
+  const items = paginate ? bottles.slice(skip, skip + limit) : bottles;
+  return { items, total, limit, skip, maturityStatusMap };
+}
+
+// Attach the same per-bottle image fields the single-cellar /:id route adds, so
+// the cross-cellar bottle list honours user-chosen default images and the
+// uploader's own not-yet-approved photos (BottleCard reads defaultImageUrl /
+// pendingImageUrl). Returns a new array; input bottles are lean.
+async function attachBottleImageUrls(bottles, userId) {
+  if (!bottles.length) return bottles;
+  const bottleIds = bottles.map(b => b._id);
+
+  const pendingImages = await BottleImage.find({
+    bottle: { $in: bottleIds },
+    uploadedBy: userId,
+    status: { $in: ['uploaded', 'processing', 'processed'] },
+  }).sort({ createdAt: -1 }).lean();
+  const pendingByBottle = {};
+  for (const img of pendingImages) {
+    const key = img.bottle.toString();
+    if (!pendingByBottle[key]) pendingByBottle[key] = img.processedUrl || img.originalUrl;
+  }
+
+  const defaultImageIds = bottles.filter(b => b.defaultImage).map(b => b.defaultImage);
+  const defaultImages = defaultImageIds.length > 0
+    ? await BottleImage.find({ _id: { $in: defaultImageIds } }).lean()
+    : [];
+  const defaultImageMap = {};
+  for (const img of defaultImages) {
+    defaultImageMap[img._id.toString()] = img.processedUrl || img.originalUrl;
+  }
+
+  return bottles.map(b => ({
+    ...b,
+    pendingImageUrl: pendingByBottle[b._id.toString()] || null,
+    defaultImageUrl: b.defaultImage ? (defaultImageMap[b.defaultImage.toString()] || null) : null,
+  }));
+}
+
+// Facets + facetMeta across the cellar set, for the shared filter modal.
+async function facetsAcrossCellars(req, { cellarIds, statusFilter }) {
+  const { search, type, country, region, grapes, vintage } = req.query;
+  const { isValidObjectId } = mongoose;
+  const grapeIds = grapes
+    ? String(grapes).split(',').map(g => g.trim()).filter(isValidObjectId)
+    : [];
+  const hasMeiliFilters = !!(search || type || country || region || grapes || vintage);
+  const statusMongo = statusFilter === 'consumed'
+    ? { $in: CONSUMED_STATUSES }
+    : { $nin: CONSUMED_STATUSES };
+
+  let facets = null, baseFacets = null, facetMeta = null;
+  if (searchService.getIsAvailable()) {
+    try {
+      const baseResult = await searchService.searchBottles('', { cellarIds, statusFilter, limit: 0, offset: 0 });
+      baseFacets = baseResult.facetDistribution || null;
+      if (hasMeiliFilters) {
+        const filteredResult = await searchService.searchBottles(search || '', {
+          cellarIds, statusFilter,
+          type: type || undefined, countryId: country || undefined, regionId: region || undefined,
+          grapeIds: grapeIds.length > 0 ? grapeIds : undefined, vintage: vintage || undefined,
+          limit: 0, offset: 0,
+        });
+        facets = filteredResult.facetDistribution || null;
+      } else {
+        facets = baseFacets;
+      }
+    } catch { /* skip facets */ }
+  }
+  if (baseFacets || facets) {
+    const objectIds = cellarIds.map(id => new mongoose.Types.ObjectId(id));
+    const wdIds = await Bottle.find({ cellar: { $in: objectIds }, status: statusMongo }).distinct('wineDefinition');
+    const wds = await WineDefinition.find({ _id: { $in: wdIds } })
+      .populate('country', 'name').populate('region', 'name').populate('grapes', 'name').lean();
+    const countries = {}, regions = {}, grapesMap = {};
+    for (const wd of wds) {
+      if (wd.country?.name && wd.country._id) countries[wd.country.name] = wd.country._id.toString();
+      if (wd.region?.name && wd.region._id) regions[wd.region.name] = wd.region._id.toString();
+      for (const g of (wd.grapes || [])) {
+        if (g.name && g._id) grapesMap[g.name] = g._id.toString();
+      }
+    }
+    facetMeta = { countries, regions, grapes: grapesMap };
+  }
+  return { facets, baseFacets, facetMeta };
+}
+
 // All routes require authentication
 router.use(requireAuth);
 
@@ -182,6 +434,91 @@ router.post('/', async (req, res) => {
     }
     console.error('Create cellar error:', error);
     res.status(500).json({ error: 'Failed to create cellar' });
+  }
+});
+
+// ── Cross-cellar (multi-select) views ──────────────────────────────────────
+// NOTE: these MUST be declared before the "/:id*" routes below, otherwise
+// Express would treat "multi" as an :id. Access is enforced server-side: only
+// cellars the user owns or is a member of are ever searched, so an unknown or
+// unauthorized id in ?cellars is silently dropped (never leaks another user's
+// bottles).
+
+// GET /api/cellars/multi/bottles?cellars=id1,id2,...&search=&type=&...
+// Active bottles across the selected cellars (flat list, no grouping/racks).
+router.get('/multi/bottles', async (req, res) => {
+  try {
+    const requested = String(req.query.cellars || '')
+      .split(',').map(s => s.trim()).filter(isValidId);
+    if (requested.length === 0) return res.status(400).json({ error: 'No cellars selected' });
+
+    const accessible = await resolveAccessibleCellars(req.user.id);
+    const accessibleMap = new Map(accessible.map(c => [c._id.toString(), c]));
+    const cellarIds = [...new Set(requested)].filter(id => accessibleMap.has(id));
+    if (cellarIds.length === 0) return res.status(403).json({ error: 'No accessible cellars selected' });
+
+    const result = await queryBottlesAcrossCellars(req, { cellarIds, statusFilter: 'active' });
+    const { total, limit, skip, maturityStatusMap } = result;
+    let items = result.items;
+    const { facets, baseFacets, facetMeta } = await facetsAcrossCellars(req, { cellarIds, statusFilter: 'active' });
+
+    // Match the single-cellar route's per-bottle enrichment (default/pending
+    // images), then tag each bottle with the cellar it lives in + maturity.
+    items = await attachBottleImageUrls(items, req.user.id);
+    for (const b of items) {
+      if (maturityStatusMap) b.maturityStatus = maturityStatusMap.get(b._id.toString()) || null;
+      const c = accessibleMap.get(String(b.cellar));
+      b.cellarName = c?.name || null;
+      b.cellarColor = c ? getUserColor(c, req.user.id) : null;
+    }
+
+    res.json({
+      cellars: cellarIds.map(id => {
+        const c = accessibleMap.get(id);
+        return { _id: id, name: c.name, userColor: getUserColor(c, req.user.id) };
+      }),
+      bottles: { count: items.length, total, limit, skip, items },
+      facets, baseFacets, facetMeta,
+    });
+  } catch (error) {
+    console.error('Multi-cellar bottles error:', error);
+    res.status(500).json({ error: 'Failed to load bottles' });
+  }
+});
+
+// GET /api/cellars/multi/history?cellars=id1,id2,...&search=&type=&...
+// Consumed/gifted/sold bottles across the selected cellars (newest first).
+router.get('/multi/history', async (req, res) => {
+  try {
+    const requested = String(req.query.cellars || '')
+      .split(',').map(s => s.trim()).filter(isValidId);
+    if (requested.length === 0) return res.status(400).json({ error: 'No cellars selected' });
+
+    const accessible = await resolveAccessibleCellars(req.user.id);
+    const accessibleMap = new Map(accessible.map(c => [c._id.toString(), c]));
+    const cellarIds = [...new Set(requested)].filter(id => accessibleMap.has(id));
+    if (cellarIds.length === 0) return res.status(403).json({ error: 'No accessible cellars selected' });
+
+    const { items } = await queryBottlesAcrossCellars(req, { cellarIds, statusFilter: 'consumed', paginate: false });
+    const { facets, baseFacets, facetMeta } = await facetsAcrossCellars(req, { cellarIds, statusFilter: 'consumed' });
+
+    for (const b of items) {
+      const c = accessibleMap.get(String(b.cellar));
+      b.cellarName = c?.name || null;
+      b.cellarColor = c ? getUserColor(c, req.user.id) : null;
+    }
+
+    res.json({
+      cellars: cellarIds.map(id => {
+        const c = accessibleMap.get(id);
+        return { _id: id, name: c.name, userColor: getUserColor(c, req.user.id) };
+      }),
+      bottles: items,
+      facets, baseFacets, facetMeta,
+    });
+  } catch (error) {
+    console.error('Multi-cellar history error:', error);
+    res.status(500).json({ error: 'Failed to load history' });
   }
 });
 

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -404,6 +404,7 @@ async function bulkIndexBottles(bottleIds) {
 
 async function searchBottles(query, {
   cellarId,
+  cellarIds,
   type,
   countryId,
   regionId,
@@ -424,11 +425,21 @@ async function searchBottles(query, {
   const VALID_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
   const filters = [];
 
-  // Scope to cellar. cellarId is server-set/access-checked, but strip any
-  // double-quote defensively so it can never break out of the filter string.
-  // (We strip rather than drop on invalid input — dropping would un-scope the
-  // search and leak across cellars.)
-  if (cellarId) filters.push(`cellarId = "${String(cellarId).replace(/"/g, '')}"`);
+  // Scope to cellar(s). cellarId / cellarIds are server-set/access-checked, but
+  // strip any double-quote defensively so a value can never break out of the
+  // filter string. (We strip rather than drop on invalid input — dropping would
+  // un-scope the search and leak across cellars.)
+  // `cellarIds` (array) scopes across a set of cellars for the cross-cellar view;
+  // `cellarId` (single) is kept for the per-cellar callers.
+  const scopeIds = Array.isArray(cellarIds) && cellarIds.length > 0
+    ? cellarIds
+    : (cellarId ? [cellarId] : []);
+  const cleanScopeIds = scopeIds.map(id => String(id).replace(/"/g, '')).filter(Boolean);
+  if (cleanScopeIds.length === 1) {
+    filters.push(`cellarId = "${cleanScopeIds[0]}"`);
+  } else if (cleanScopeIds.length > 1) {
+    filters.push(`cellarId IN ["${cleanScopeIds.join('","')}"]`);
+  }
   // Status filter: active (exclude consumed), consumed (only consumed), or all
   if (statusFilter === 'active') {
     filters.push(`status NOT IN ["${CONSUMED_STATUSES.join('","')}"]`);

--- a/frontend/src/api/cellars.js
+++ b/frontend/src/api/cellars.js
@@ -14,6 +14,14 @@ export const getCellarAudit = (apiFetch, id) =>
 export const getCellarHistory = (apiFetch, id) =>
   apiFetch(`/api/cellars/${id}/history`);
 
+// Cross-cellar (multi-select) views. `params` is a URLSearchParams string that
+// must include `cellars=id1,id2,...` plus any search/filter params.
+export const getMultiCellarBottles = (apiFetch, params = '') =>
+  apiFetch(`/api/cellars/multi/bottles${params ? `?${params}` : ''}`);
+
+export const getMultiCellarHistory = (apiFetch, params = '') =>
+  apiFetch(`/api/cellars/multi/history${params ? `?${params}` : ''}`);
+
 export const updateCellar = (apiFetch, id, data) =>
   apiFetch(`/api/cellars/${id}`, {
     method: 'PUT',

--- a/frontend/src/components/BottleCard.css
+++ b/frontend/src/components/BottleCard.css
@@ -136,6 +136,31 @@
   background: rgba(var(--color-accent-rgb), 0.18);
 }
 
+/* Cross-cellar view: which cellar this bottle lives in. */
+.cellar-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  padding: 1px 8px 1px 6px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cellar-badge-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--cellar-badge-color, var(--color-text-muted));
+  flex-shrink: 0;
+}
+
 .pending-wine-badge {
   display: inline-block;
   font-size: 0.7rem;

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -18,11 +18,14 @@ const MATURITY_LABELS = {
  * Renders a single bottle in either list or card (grid) view.
  * Props: bottle, rackMap, cellarId, viewMode ('list' | 'card')
  */
-function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick }) {
+function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick, showCellarBadge = false }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { user } = useAuth();
   const isGroup = groupCount > 1;
+  // Cross-cellar views tag each bottle with the cellar it lives in.
+  const cellarBadge = showCellarBadge && bottle.cellarName ? bottle.cellarName : null;
+  const cellarBadgeColor = bottle.cellarColor || null;
   // A collapsed group spans multiple bottles (possibly in different racks), so a
   // single rack badge would be misleading — suppress it until the group expands.
   const rackInfo = isGroup ? null : rackMap?.get(bottle._id);
@@ -75,6 +78,11 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
             )}
           </div>
           <div className="bottle-badges">
+            {cellarBadge && (
+              <span className="cellar-badge" style={cellarBadgeColor ? { '--cellar-badge-color': cellarBadgeColor } : undefined}>
+                <span className="cellar-badge-dot" aria-hidden="true" /> {cellarBadge}
+              </span>
+            )}
             {isPending && (
               <span className="pending-wine-badge">Pending review</span>
             )}
@@ -134,6 +142,11 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
           {bottle.vintage && <span className="bottle-vintage">{bottle.vintage}</span>}
         </div>
         <div className="bottle-badges">
+          {cellarBadge && (
+            <span className="cellar-badge" style={cellarBadgeColor ? { '--cellar-badge-color': cellarBadgeColor } : undefined}>
+              <span className="cellar-badge-dot" aria-hidden="true" /> {cellarBadge}
+            </span>
+          )}
           {isPending && (
             <span className="pending-wine-badge">Pending review</span>
           )}
@@ -171,7 +184,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
 // values derived from the OTHER compared props (the bottle/group item) — if a
 // future caller closes over unrelated state, that handler must be stabilized
 // with useCallback instead.
-const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount'];
+const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount', 'showCellarBadge'];
 export default memo(BottleCard, (prev, next) =>
   COMPARED_PROPS.every(key => prev[key] === next[key])
 );

--- a/frontend/src/components/CellarScopePicker.css
+++ b/frontend/src/components/CellarScopePicker.css
@@ -1,0 +1,143 @@
+.cellar-scope {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.cellar-scope-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  height: 44px;
+  padding: 0 0.65rem;
+  border: 1px solid var(--color-input-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-input-bg);
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color var(--transition-fast), color var(--transition-fast);
+}
+.cellar-scope-btn:hover {
+  border-color: var(--color-border-focus);
+  color: var(--color-text);
+}
+.cellar-scope-btn--active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+.cellar-scope-label {
+  max-width: 12ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cellar-scope-caret {
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+.cellar-scope-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+
+.cellar-scope-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 41;
+  min-width: 240px;
+  max-width: 320px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+}
+
+.cellar-scope-quick {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+}
+.cellar-scope-quick button {
+  flex: 1;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), color var(--transition-fast);
+}
+.cellar-scope-quick button:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+.cellar-scope-quick button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.cellar-scope-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.cellar-scope-item {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.5rem 0.55rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.88rem;
+  color: var(--color-text);
+}
+.cellar-scope-item:hover {
+  background: var(--color-primary-light);
+}
+.cellar-scope-item.locked {
+  cursor: default;
+}
+.cellar-scope-item input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--color-primary);
+  flex-shrink: 0;
+  cursor: inherit;
+}
+.cellar-scope-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-text-muted);
+  flex-shrink: 0;
+}
+.cellar-scope-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cellar-scope-current {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-text-muted);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  padding: 0.1rem 0.4rem;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/CellarScopePicker.js
+++ b/frontend/src/components/CellarScopePicker.js
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import './CellarScopePicker.css';
+
+/**
+ * Multi-select "which cellars am I looking at" control. Lets the user combine
+ * several cellars into one searchable view (bottles + history). Default is the
+ * cellar they're currently in; "Select all" / "This cellar only" are one-click
+ * shortcuts. At least one cellar always stays selected.
+ *
+ * Props:
+ *   cellars          – [{ _id, name, userColor }] all accessible cellars
+ *   value            – string[] currently-selected cellar ids
+ *   currentCellarId  – the cellar the user navigated into
+ *   onChange(ids)    – called with the new selection (order follows `cellars`)
+ */
+export default function CellarScopePicker({ cellars, value, currentCellarId, onChange }) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const selected = new Set(value);
+  const total = cellars.length;
+  const isThisCellarOnly = value.length === 1 && value[0] === currentCellarId;
+  const allSelected = total > 0 && value.length === total;
+
+  const label = isThisCellarOnly
+    ? t('cellarScope.thisCellar')
+    : allSelected
+      ? t('cellarScope.allCellars')
+      : t('cellarScope.nCellars', { count: value.length });
+
+  const emit = (idSet) => onChange(cellars.filter(c => idSet.has(c._id)).map(c => c._id));
+
+  const toggle = (id) => {
+    const next = new Set(selected);
+    if (next.has(id)) {
+      if (next.size === 1) return; // keep at least one selected
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    emit(next);
+  };
+
+  const selectAll = () => onChange(cellars.map(c => c._id));
+  const thisOnly = () => onChange([currentCellarId]);
+
+  return (
+    <div className="cellar-scope">
+      <button
+        type="button"
+        className={`cellar-scope-btn${!isThisCellarOnly ? ' cellar-scope-btn--active' : ''}`}
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={t('cellarScope.title')}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/>
+        </svg>
+        <span className="cellar-scope-label">{label}</span>
+        <svg className="cellar-scope-caret" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+
+      {open && (
+        <>
+          <div className="cellar-scope-backdrop" onClick={() => setOpen(false)} aria-hidden="true" />
+          <div className="cellar-scope-dropdown" role="menu">
+            <div className="cellar-scope-quick">
+              <button type="button" onClick={selectAll} disabled={allSelected}>
+                {t('cellarScope.selectAll')}
+              </button>
+              <button type="button" onClick={thisOnly} disabled={isThisCellarOnly}>
+                {t('cellarScope.thisCellarOnly')}
+              </button>
+            </div>
+            <ul className="cellar-scope-list">
+              {cellars.map(c => {
+                const checked = selected.has(c._id);
+                const lockOff = checked && selected.size === 1;
+                return (
+                  <li key={c._id}>
+                    <label className={`cellar-scope-item${checked ? ' checked' : ''}${lockOff ? ' locked' : ''}`}>
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={lockOff}
+                        onChange={() => toggle(c._id)}
+                      />
+                      <span
+                        className="cellar-scope-dot"
+                        style={c.userColor ? { background: c.userColor } : undefined}
+                        aria-hidden="true"
+                      />
+                      <span className="cellar-scope-name">{c.name}</span>
+                      {c._id === currentCellarId && (
+                        <span className="cellar-scope-current">{t('cellarScope.current')}</span>
+                      )}
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -672,7 +672,23 @@
     "rateThisBottle": "Rate this bottle",
     "tastingNote": "Tasting note",
     "tastingNotePlaceholder": "How was the wine?",
-    "loadingHistory": "Loading history..."
+    "loadingHistory": "Loading history...",
+    "addToWishlist": "Wishlist",
+    "addingToWishlist": "Adding…",
+    "onWishlist": "On wishlist",
+    "wishlistError": "Try again",
+    "viewBottleAria": "View {{name}}"
+  },
+
+  "cellarScope": {
+    "title": "Choose which cellars to show",
+    "thisCellar": "This cellar",
+    "allCellars": "All cellars",
+    "nCellars_one": "{{count}} cellar",
+    "nCellars_other": "{{count}} cellars",
+    "selectAll": "Select all",
+    "thisCellarOnly": "This cellar only",
+    "current": "Current"
   },
 
   "cellarAudit": {

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -672,7 +672,23 @@
     "rateThisBottle": "Betygsätt denna flaska",
     "tastingNote": "Smaknotering",
     "tastingNotePlaceholder": "Hur var vinet?",
-    "loadingHistory": "Laddar historik..."
+    "loadingHistory": "Laddar historik...",
+    "addToWishlist": "Önskelista",
+    "addingToWishlist": "Lägger till…",
+    "onWishlist": "På önskelistan",
+    "wishlistError": "Försök igen",
+    "viewBottleAria": "Visa {{name}}"
+  },
+
+  "cellarScope": {
+    "title": "Välj vilka källare som visas",
+    "thisCellar": "Denna källare",
+    "allCellars": "Alla källare",
+    "nCellars_one": "{{count}} källare",
+    "nCellars_other": "{{count}} källare",
+    "selectAll": "Välj alla",
+    "thisCellarOnly": "Endast denna källare",
+    "current": "Aktuell"
   },
 
   "cellarAudit": {

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -2,12 +2,17 @@ import { useState, useEffect, useRef, lazy, Suspense, Fragment } from 'react';
 import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
-import { getCellar, getCellarStatistics } from '../api/cellars';
+import { getCellar, getCellarStatistics, listCellars, getMultiCellarBottles } from '../api/cellars';
 import { getRacks } from '../api/racks';
 import { getCellarLayout } from '../api/cellarLayout';
 import BottleCard from '../components/BottleCard';
 import BottleFilterModal from '../components/BottleFilterModal';
+import CellarScopePicker from '../components/CellarScopePicker';
 import './CellarDetail.css';
+
+// Stable empty rack map for the cross-cellar view (rack placement is per-cellar,
+// so it doesn't apply when several cellars are combined).
+const EMPTY_RACKMAP = new Map();
 
 // Lazy-load modals — they are heavy and only needed on user interaction
 const ShareCellarModal = lazy(() => import('../components/ShareCellarModal'));
@@ -56,6 +61,30 @@ function CellarDetail() {
   // Identical bottles (same wine + vintage + size) are always collapsed into one
   // card. Server-side grouped (see ?group=1) so counts are correct across pagination.
 
+  // ── Cross-cellar scope: which cellars this view spans (default: this one) ──
+  const [allCellars, setAllCellars] = useState([]);
+  const [scopeIds, setScopeIds] = useState([id]);
+  const scopeKey = scopeIds.join(',');
+  // Shape of the bottles CURRENTLY in state (grouped vs flat). Tracked separately
+  // from the live scope selection so a scope change never renders the just-loaded
+  // (old-shape) list through the wrong BottlesList branch before the refetch lands.
+  const [dataIsMulti, setDataIsMulti] = useState(false);
+  // Monotonic fetch token: only the most-recently-started fetch may commit its
+  // result. Guards against out-of-order responses when the scope/filter changes
+  // (or Load More fires) faster than the network replies — a stale response
+  // must never overwrite newer data or append the wrong-shaped page.
+  const fetchSeq = useRef(0);
+
+  useEffect(() => {
+    listCellars(apiFetch)
+      .then(r => r.json())
+      .then(d => setAllCellars(d.cellars || []))
+      .catch(() => {});
+  }, [apiFetch]);
+
+  // Reset scope to just this cellar when navigating to another cellar.
+  useEffect(() => { setScopeIds([id]); }, [id]);
+
   // Debounce the search input — only send the API call after the user stops typing
   const [debouncedSearch, setDebouncedSearch] = useState(filters.search);
   const searchTimer = useRef(null);
@@ -80,9 +109,13 @@ function CellarDetail() {
     filters.minRating, filters.maturity, filters.sort
   ].join('|');
 
+  // Refetch on cellar id, filters, or scope change. `id` is included so an
+  // in-place navigation to another cellar whose scope key happens to match the
+  // current one still refetches; the fetch-seq guard drops the transient
+  // stale-scope response that the id→scope-reset produces.
   useEffect(() => {
     fetchCellarData(0);
-  }, [id, filterKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, filterKey, scopeKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     fetchStatistics();
@@ -91,6 +124,7 @@ function CellarDetail() {
 
 
   const fetchCellarData = async (skip) => {
+    const seq = ++fetchSeq.current;
     try {
       if (skip > 0) setBottlesLoading(true);
       const params = new URLSearchParams();
@@ -106,14 +140,27 @@ function CellarDetail() {
       });
       params.set('limit', BOTTLES_PER_PAGE);
       params.set('skip', skip);
-      params.set('group', '1');
-      const res = await getCellar(apiFetch, id, params);
+      const multi = !(scopeIds.length === 1 && scopeIds[0] === id);
+      let res;
+      if (multi) {
+        params.set('cellars', scopeIds.join(','));
+        res = await getMultiCellarBottles(apiFetch, params.toString());
+      } else {
+        params.set('group', '1');
+        res = await getCellar(apiFetch, id, params);
+      }
       const data = await res.json();
+      // A newer fetch started while this one was in flight — drop this response
+      // so it can't overwrite newer data or append a wrong-shaped page.
+      if (seq !== fetchSeq.current) return;
       if (res.ok) {
-        setCellar(data.cellar);
+        if (data.cellar) setCellar(data.cellar);
         setBottlesTotal(data.bottles.total);
         if (skip === 0) {
+          // Set the data + its shape together so BottlesList never sees a
+          // shape/flag mismatch (grouped items rendered as flat, or vice-versa).
           setBottles(data.bottles.items);
+          setDataIsMulti(multi);
           // Update facets on every fetch so cascading filters work
           if (data.facets) setFacets(data.facets);
           if (data.baseFacets) setBaseFacets(data.baseFacets);
@@ -125,10 +172,12 @@ function CellarDetail() {
         setError(data.error || 'Failed to load cellar');
       }
     } catch {
-      setError('Network error');
+      if (seq === fetchSeq.current) setError('Network error');
     } finally {
-      setLoading(false);
-      setBottlesLoading(false);
+      if (seq === fetchSeq.current) {
+        setLoading(false);
+        setBottlesLoading(false);
+      }
     }
   };
 
@@ -484,6 +533,14 @@ function CellarDetail() {
                     <option value="-price">{t('cellarDetail.sortPriceHigh')}</option>
                     <option value="maturity">{t('cellarDetail.sortMaturity')}</option>
                   </select>
+                  {allCellars.length > 1 && (
+                    <CellarScopePicker
+                      cellars={allCellars}
+                      value={scopeIds}
+                      currentCellarId={id}
+                      onChange={setScopeIds}
+                    />
+                  )}
                 </div>
 
                 {activeChips.length > 0 && (
@@ -542,11 +599,12 @@ function CellarDetail() {
           ) : (
             <BottlesList
               bottles={bottles}
-              rackMap={rackMap}
+              rackMap={dataIsMulti ? EMPTY_RACKMAP : rackMap}
               cellarId={id}
               hasMore={bottles.length < bottlesTotal}
               loadingMore={bottlesLoading}
               onLoadMore={loadMore}
+              multi={dataIsMulti}
             />
           )}
         </div>
@@ -602,7 +660,10 @@ function CellarDetail() {
 }
 
 // ── Bottle list (list or card view) ──
-function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore }) {
+// `multi` = cross-cellar view: `bottles` is a flat list (no grouping), each item
+// carries its own `cellar` id + `cellarName` so it links to and is badged with
+// the right cellar.
+function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore, multi = false }) {
   const { t } = useTranslation();
   const [viewMode, setViewMode] = useState(() => {
     try { return localStorage.getItem('cellarion_bottle_view') || 'list'; } catch { return 'list'; }
@@ -645,6 +706,19 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
 
       <div className={viewMode === 'list' ? 'bottles-list' : 'bottles-grid'}>
         {bottles.map(item => {
+          // Cross-cellar view: flat bottles, each linked to + badged with its cellar.
+          if (multi) {
+            return (
+              <BottleCard
+                key={item._id}
+                bottle={item}
+                rackMap={rackMap}
+                cellarId={item.cellar || cellarId}
+                viewMode={viewMode}
+                showCellarBadge
+              />
+            );
+          }
           // Grouped response: item = { key, count, bottles: [...] }
           if (item && Array.isArray(item.bottles)) {
             const rep = item.bottles[0];

--- a/frontend/src/pages/CellarHistory.css
+++ b/frontend/src/pages/CellarHistory.css
@@ -228,6 +228,7 @@
 }
 
 .history-bottle-card {
+  position: relative;
   display: block;
   text-decoration: none;
   color: inherit;
@@ -250,6 +251,20 @@
 .history-bottle-card.sold   { border-left-color: #27ae60; }
 .history-bottle-card.other  { border-left-color: var(--color-border); }
 
+/* Stretched-link overlay — makes the whole card an openable anchor while the
+   wishlist button sits above it as a real, separate control (no <button>
+   nested inside an <a>). */
+.history-bottle-card__overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+}
+.history-bottle-card__overlay:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}
+
 .history-bottle-main {
   display: flex;
   align-items: center;
@@ -257,9 +272,67 @@
   margin-bottom: 0.5rem;
 }
 
-.history-bottle-chevron {
+.history-bottle-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.history-bottle-main-right {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   flex-shrink: 0;
+}
+
+/* Add-to-wishlist button — lifted above the stretched-link overlay so it
+   captures its own clicks. */
+.history-add-wishlist-btn {
+  position: relative;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.history-add-wishlist-btn:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+.history-add-wishlist-btn:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}
+.history-add-wishlist-btn.is-saving {
+  cursor: default;
+  opacity: 0.7;
+}
+.history-add-wishlist-btn.is-added {
+  border-color: var(--color-success-border);
+  color: var(--color-success);
+  background: var(--color-success-bg);
+  cursor: default;
+}
+.history-add-wishlist-btn.is-error {
+  border-color: var(--color-danger-border);
+  color: var(--color-danger);
+  background: var(--color-danger-bg);
+}
+
+.history-bottle-chevron {
+  flex-shrink: 0;
+  pointer-events: none;
   color: var(--color-text-muted);
   opacity: 0.5;
 }
@@ -296,6 +369,32 @@
   flex-wrap: wrap;
 }
 
+/* Cross-cellar view: which cellar this consumed bottle came from. */
+.history-cellar-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 0.35rem;
+  max-width: 100%;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  padding: 1px 8px 1px 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.history-cellar-badge-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
 /* ── Consumption details ── */
 .history-bottle-details {
   padding-left: 0;
@@ -326,5 +425,13 @@
   }
   .history-bottle-card {
     padding: 0.75rem 1rem;
+  }
+  /* Compact, icon-only wishlist button on narrow screens — the button colour
+     (added = green, error = red) still conveys state without the label. */
+  .history-add-wishlist-label {
+    display: none;
+  }
+  .history-add-wishlist-btn {
+    padding: 0.4rem;
   }
 }

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -5,6 +5,9 @@ import { useAuth } from '../contexts/AuthContext';
 import RatingDisplay from '../components/RatingDisplay';
 import WineImage from '../components/WineImage';
 import BottleFilterModal from '../components/BottleFilterModal';
+import { addToWishlist } from '../api/wishlist';
+import { listCellars, getMultiCellarHistory } from '../api/cellars';
+import CellarScopePicker from '../components/CellarScopePicker';
 import './CellarDetail.css';
 import './CellarHistory.css';
 
@@ -34,6 +37,27 @@ function CellarHistory() {
   const [facetMeta, setFacetMeta] = useState(null);
   const [showFilterModal, setShowFilterModal] = useState(false);
 
+  // ── Cross-cellar scope: which cellars this history view spans (default: this one) ──
+  const [allCellars, setAllCellars] = useState([]);
+  const [scopeIds, setScopeIds] = useState([id]);
+  const scopeKey = scopeIds.join(',');
+  const isMulti = !(scopeIds.length === 1 && scopeIds[0] === id);
+
+  useEffect(() => {
+    listCellars(apiFetch)
+      .then(r => r.json())
+      .then(d => setAllCellars(d.cellars || []))
+      .catch(() => {});
+  }, [apiFetch]);
+
+  // Reset the scope to just this cellar whenever the user navigates to a
+  // different cellar's history.
+  useEffect(() => { setScopeIds([id]); }, [id]);
+
+  // Monotonic fetch token — only the most-recent fetch commits its result, so an
+  // out-of-order response from a superseded scope/filter can't overwrite newer data.
+  const fetchSeq = useRef(0);
+
   // Debounce search
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const searchTimer = useRef(null);
@@ -50,11 +74,15 @@ function CellarHistory() {
     filters.grapes.join(','), filters.vintage.join(',')
   ].join('|');
 
+  // `id` is included so navigating to another cellar whose scope key matches the
+  // current one still refetches; the fetch-seq guard drops the transient
+  // stale-scope response produced by the id→scope-reset.
   useEffect(() => {
     fetchHistory();
-  }, [id, filterKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, filterKey, scopeKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchHistory = async () => {
+    const seq = ++fetchSeq.current;
     try {
       const params = new URLSearchParams();
       if (debouncedSearch) params.append('search', debouncedSearch);
@@ -62,12 +90,21 @@ function CellarHistory() {
         if (key === 'search') return;
         if (Array.isArray(val) && val.length > 0) params.append(key, val.join(','));
       });
-      const qs = params.toString();
-      const res = await apiFetch(`/api/cellars/${id}/history${qs ? `?${qs}` : ''}`);
+      const multi = !(scopeIds.length === 1 && scopeIds[0] === id);
+      let res;
+      if (multi) {
+        params.append('cellars', scopeIds.join(','));
+        res = await getMultiCellarHistory(apiFetch, params.toString());
+      } else {
+        const qs = params.toString();
+        res = await apiFetch(`/api/cellars/${id}/history${qs ? `?${qs}` : ''}`);
+      }
       const data = await res.json();
+      // Superseded by a newer fetch — drop this response.
+      if (seq !== fetchSeq.current) return;
       if (!res.ok) { setError(data.error || 'Failed to load history'); return; }
 
-      setCellar(data.cellar);
+      if (data.cellar) setCellar(data.cellar);
       setTotal(data.bottles.length);
       if (data.facets) setFacets(data.facets);
       if (data.baseFacets) setBaseFacets(data.baseFacets);
@@ -82,9 +119,9 @@ function CellarHistory() {
       });
       setGrouped(groups);
     } catch {
-      setError('Network error');
+      if (seq === fetchSeq.current) setError('Network error');
     } finally {
-      setLoading(false);
+      if (seq === fetchSeq.current) setLoading(false);
     }
   };
 
@@ -193,6 +230,14 @@ function CellarHistory() {
             <span className="filter-badge">{activeChips.length}</span>
           )}
         </button>
+        {allCellars.length > 1 && (
+          <CellarScopePicker
+            cellars={allCellars}
+            value={scopeIds}
+            currentCellarId={id}
+            onChange={setScopeIds}
+          />
+        )}
       </div>
 
       {/* Active filter chips */}
@@ -250,7 +295,7 @@ function CellarHistory() {
               </div>
               <div className="history-bottles">
                 {items.map(bottle => (
-                  <HistoryBottleCard key={bottle._id} bottle={bottle} cellarId={id} />
+                  <HistoryBottleCard key={bottle._id} bottle={bottle} cellarId={id} showCellarBadge={isMulti} />
                 ))}
               </div>
             </section>
@@ -268,20 +313,59 @@ function CellarHistory() {
   );
 }
 
-function HistoryBottleCard({ bottle, cellarId }) {
+function HistoryBottleCard({ bottle, cellarId, showCellarBadge = false }) {
   const { t } = useTranslation();
-  const { user } = useAuth();
+  const { apiFetch, user } = useAuth();
   const wine = bottle.wineDefinition;
+  // In the cross-cellar view each row belongs to its own cellar; fall back to
+  // the page's cellar id for the single-cellar view.
+  const linkCellarId = bottle.cellar || cellarId;
+  const cellarBadge = showCellarBadge && bottle.cellarName ? bottle.cellarName : null;
   const consumedDate = bottle.consumedAt
     ? new Date(bottle.consumedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
     : null;
 
+  // One-tap add-to-wishlist: 'idle' → 'saving' → 'added' | 'error'.
+  const [wishState, setWishState] = useState('idle');
+
+  const handleAddToWishlist = async (e) => {
+    // The button is a sibling of the stretched-link overlay (not nested), but
+    // stop the event anyway so a stray bubble can never trigger navigation.
+    e.preventDefault();
+    e.stopPropagation();
+    if (!wine?._id || wishState === 'saving' || wishState === 'added') return;
+    setWishState('saving');
+    try {
+      const res = await addToWishlist(apiFetch, {
+        wineDefinitionId: wine._id,
+        vintage: bottle.vintage || undefined,
+      });
+      // 201 = created, 409 = already on the wishlist — both mean "it's there".
+      setWishState(res.ok || res.status === 409 ? 'added' : 'error');
+    } catch {
+      setWishState('error');
+    }
+  };
+
+  const wishLabel = wishState === 'added'
+    ? t('history.onWishlist')
+    : wishState === 'saving'
+      ? t('history.addingToWishlist')
+      : wishState === 'error'
+        ? t('history.wishlistError')
+        : t('history.addToWishlist');
+
   return (
-    <Link
-      to={`/cellars/${cellarId}/bottles/${bottle._id}`}
-      state={{ fromHistory: true }}
-      className={`history-bottle-card ${bottle.consumedReason || bottle.status}`}
-    >
+    <div className={`history-bottle-card ${bottle.consumedReason || bottle.status}`}>
+      {/* Stretched link: keeps the whole card an openable anchor while the
+          wishlist button lives beside it (no <button> nested inside an <a>). */}
+      <Link
+        to={`/cellars/${linkCellarId}/bottles/${bottle._id}`}
+        state={{ fromHistory: true }}
+        className="history-bottle-card__overlay"
+        aria-label={t('history.viewBottleAria', { name: wine?.name || t('common.unknownWine') })}
+      />
+
       <div className="history-bottle-main">
         <WineImage image={wine?.image} alt={wine?.name} className="history-bottle-image" />
         <div className="history-bottle-info">
@@ -292,8 +376,36 @@ function HistoryBottleCard({ bottle, cellarId }) {
             {consumedDate && <span>· {consumedDate}</span>}
             {bottle.price && <span>· {t('history.paidLabel')} {bottle.price} {bottle.currency}</span>}
           </div>
+          {cellarBadge && (
+            <span className="history-cellar-badge">
+              <span
+                className="history-cellar-badge-dot"
+                style={bottle.cellarColor ? { background: bottle.cellarColor } : undefined}
+                aria-hidden="true"
+              />
+              {cellarBadge}
+            </span>
+          )}
         </div>
-        <svg className="history-bottle-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+        <div className="history-bottle-main-right">
+          {wine?._id && (
+            <button
+              type="button"
+              className={`history-add-wishlist-btn is-${wishState}`}
+              onClick={handleAddToWishlist}
+              disabled={wishState === 'saving' || wishState === 'added'}
+              title={wishState === 'added' ? t('history.onWishlist') : t('history.addToWishlist')}
+            >
+              {wishState === 'added' ? (
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+              ) : (
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+              )}
+              <span className="history-add-wishlist-label">{wishLabel}</span>
+            </button>
+          )}
+          <svg className="history-bottle-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+        </div>
       </div>
 
       {/* Consumption details */}
@@ -308,7 +420,7 @@ function HistoryBottleCard({ bottle, cellarId }) {
           <p className="history-note">"{bottle.consumedNote}"</p>
         )}
       </div>
-    </Link>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
Two cellar-view enhancements:

**1. Add-to-wishlist from History** — a one-tap **Wishlist** button on every consumed wine in a cellar's History. Carries the vintage, dedupes (409-aware), turns into a green ✓, icon-only on mobile. The card stays an openable link via a stretched-link overlay. EN/SV.

**2. Cross-cellar search (multi-select)** — a **"cellars shown"** picker (checklist + *Select all* / *This cellar only*) in the search bar on **both** the Bottles tab and History. Search/filter span the selected cellars (owned + shared); each result shows a **cellar badge**.
- Backend: `searchBottles` extended to scope across a set of cellars (Meili `cellarId IN [...]`); new access-checked endpoints `GET /api/cellars/multi/bottles` and `/multi/history` (foreign/unknown cellar ids are silently dropped — no cross-user leak). Cross-cellar items get the same default/pending-image + maturity enrichment as the single-cellar route.
- Frontend: shared `CellarScopePicker`, per-bottle cellar badge + navigation, and a fetch-generation guard so out-of-order responses can't clobber newer data.

## Testing
- Backend endpoints exercised via curl against real data (87 active / 69 consumed across a 5-cellar user; cross-cellar text search; access-control rejects foreign cellar ids).
- Full `vite build` + `node --check`; smoke-tested in local Docker.
- Reviewed at high effort; the two confirmed race bugs (out-of-order scope swap, Load-More shape mismatch) and the missed-refetch edge are fixed via the fetch-generation guard.

## Docker / compose impact
Code-only — no `docker-compose.yml` changes, no new services/ports/env vars. Prod deploy is the standard `backend` + `frontend` image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)