### PR TITLE
chore(release): v1.70.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump to v1.70.0 for the wishlist-from-history + cross-cellar search features (#586). Bumps backend + frontend package.json in lockstep.