### PR TITLE
fix: harden cross-cellar search endpoints

### DIFF
--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -21,7 +21,7 @@ const { CONSUMED_STATUSES, WINE_POPULATE_LIST } = require('../config/constants')
 const mongoose = require('mongoose');
 const { parsePagination } = require('../utils/pagination');
 const searchService = require('../services/search');
-const { isValidId } = require('../utils/validation');
+const { isValidId, coerceStringQuery } = require('../utils/validation');
 const { mapBottlesForExport } = require('../services/cellarExport');
 
 const router = express.Router();
@@ -146,10 +146,19 @@ async function resolveAccessibleCellars(userId) {
 const MATURITY_RANK_MULTI = { declining: 0, late: 1, peak: 2, early: 3, 'not-ready': 4 };
 
 async function queryBottlesAcrossCellars(req, { cellarIds, statusFilter, paginate = true }) {
-  const {
-    search, type, country, region, grapes, vintage,
-    minRating, maxRating, maturity: maturityFilter, sort = '-createdAt',
-  } = req.query;
+  // Coerce every query param to a string up front: Express turns repeated
+  // (?sort=a&sort=b) or bracketed (?search[$gt]=x) params into arrays/objects,
+  // which would blow up sort.startsWith / search.toLowerCase with a 500.
+  const search = coerceStringQuery(req.query.search);
+  const type = coerceStringQuery(req.query.type);
+  const country = coerceStringQuery(req.query.country);
+  const region = coerceStringQuery(req.query.region);
+  const grapes = coerceStringQuery(req.query.grapes);
+  const vintage = coerceStringQuery(req.query.vintage);
+  const minRating = coerceStringQuery(req.query.minRating);
+  const maxRating = coerceStringQuery(req.query.maxRating);
+  const maturityFilter = coerceStringQuery(req.query.maturity);
+  const sort = coerceStringQuery(req.query.sort) || '-createdAt';
   const { limit, offset: skip } = parsePagination(req.query, { limit: 30, maxLimit: 200 });
   const { isValidObjectId } = mongoose;
   const sortField = sort.startsWith('-') ? sort.substring(1) : sort;
@@ -163,6 +172,23 @@ async function queryBottlesAcrossCellars(req, { cellarIds, statusFilter, paginat
     ? { $in: CONSUMED_STATUSES }
     : { $nin: CONSUMED_STATUSES };
   const objectIds = cellarIds.map(id => new mongoose.Types.ObjectId(id));
+
+  // ── HOT PATH: default view (no search/filters, DB-sortable) ──
+  // Paginate inside MongoDB instead of hydrating up to 10k populated bottles to
+  // slice a 30-item page. Mirrors the single-cellar route's canPaginateInDb;
+  // trivially correct here since the cross-cellar view never groups.
+  const canPaginateInDb = paginate
+    && !hasMeiliFilters
+    && !minRating && !maxRating && !maturityFilter
+    && ['createdAt', 'vintage', 'price', 'rating'].includes(sortField);
+  if (canPaginateInDb) {
+    const filter = { cellar: { $in: objectIds }, status: statusMongo };
+    const [pageDocs, totalCount] = await Promise.all([
+      Bottle.find(filter).populate(WINE_POPULATE_LIST).sort({ [sortField]: sortDir }).skip(skip).limit(limit).lean(),
+      Bottle.countDocuments(filter),
+    ]);
+    return { items: pageDocs, total: totalCount, limit, skip, maturityStatusMap: null };
+  }
 
   let bottles;
   let usedMeili = false;
@@ -460,7 +486,11 @@ router.get('/multi/bottles', async (req, res) => {
     const result = await queryBottlesAcrossCellars(req, { cellarIds, statusFilter: 'active' });
     const { total, limit, skip, maturityStatusMap } = result;
     let items = result.items;
-    const { facets, baseFacets, facetMeta } = await facetsAcrossCellars(req, { cellarIds, statusFilter: 'active' });
+    // Facets only change the filter modal, which the client reads on the first
+    // page only — skip the extra Meili + distinct queries on every Load More.
+    const { facets, baseFacets, facetMeta } = skip === 0
+      ? await facetsAcrossCellars(req, { cellarIds, statusFilter: 'active' })
+      : { facets: null, baseFacets: null, facetMeta: null };
 
     // Match the single-cellar route's per-bottle enrichment (default/pending
     // images), then tag each bottle with the cellar it lives in + maturity.

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -439,6 +439,11 @@ async function searchBottles(query, {
     filters.push(`cellarId = "${cleanScopeIds[0]}"`);
   } else if (cleanScopeIds.length > 1) {
     filters.push(`cellarId IN ["${cleanScopeIds.join('","')}"]`);
+  } else if (scopeIds.length > 0) {
+    // A scope WAS requested but every id stripped to empty — push a filter that
+    // matches nothing rather than no filter at all (which would un-scope the
+    // search and leak across every cellar).
+    filters.push('cellarId = ""');
   }
   // Status filter: active (exclude consumed), consumed (only consumed), or all
   if (statusFilter === 'active') {


### PR DESCRIPTION
Follow-up hardening for the cross-cellar (multi-select) search shipped in v1.70.0 (#586), from a high-effort code review.

- **Param robustness** — the `/multi/*` query engine now coerces `sort`/`search`/filter params to strings, so repeated (`?sort=a&sort=b`) or object-shaped (`?search[$gt]=x`) params return results instead of a 500. Uses the existing `coerceStringQuery` helper.
- **Memory/perf** — added a DB-pagination fast path for the default cross-cellar bottles view (no search/filters, DB-sortable sort): paginate + `countDocuments` in MongoDB instead of hydrating up to 10k populated bottles per request to slice a 30-item page. Mirrors the single-cellar `canPaginateInDb` hot path — matters on the 4GB VM.
- **Redundant work** — skip the facet Meili/`distinct` queries on Load More (`skip > 0`); the client only reads facets on the first page.
- **Defense-in-depth** — `searchBottles` now pushes a never-match filter (instead of no filter) if a cellar scope was requested but every id strips to empty, so the search can never silently un-scope across cellars.

## Testing
Curl against real data: default view uses the fast path (87 total, 30/page, still image-enriched, facets on page 1); Load More returns null facets; malformed `sort`/`search` params → 200; cross-cellar search + history unchanged.

## Docker / compose impact
Backend-only, no compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)