### PR TITLE
chore(release): v1.70.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.70.0",
+  "version": "1.70.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.70.0",
+  "version": "1.70.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Patch release: cross-cellar search hardening (#588) — param coercion, DB-pagination fast path, facet skip on Load More, un-scope guard. Bumps backend + frontend package.json in lockstep.