### PR TITLE
feat: admin "By wine" image curation

### DIFF
--- a/backend/src/routes/admin/images.js
+++ b/backend/src/routes/admin/images.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { requireAuth, requireRole } = require('../../middleware/auth');
 const BottleImage = require('../../models/BottleImage');
 const WineDefinition = require('../../models/WineDefinition');
+const Bottle = require('../../models/Bottle');
 const searchService = require('../../services/search');
 const fs = require('fs');
 const { reprocessAllImages, safeUploadPath } = require('../../services/imageProcessor');
@@ -49,6 +50,97 @@ router.get('/', async (req, res) => {
   } catch (error) {
     console.error('Get admin images error:', error);
     res.status(500).json({ error: 'Failed to get images' });
+  }
+});
+
+// GET /api/admin/images/by-wine — wine-centric curation view.
+// Lists wines that have 2+ non-rejected, file-backed images to choose between,
+// with all of each wine's images so an admin can pick the official one.
+router.get('/by-wine', async (req, res) => {
+  try {
+    const { limit, offset, page } = parsePagination(req.query, { limit: 12, maxLimit: 50 });
+
+    // An image belongs to a wine directly (wineDefinition) or via its bottle.
+    const HAS_FILE = { $or: [{ processedUrl: { $ne: null } }, { originalUrl: { $ne: null } }] };
+    const basePipeline = [
+      { $match: { status: { $ne: 'rejected' }, ...HAS_FILE } },
+      { $lookup: { from: 'bottles', localField: 'bottle', foreignField: '_id', as: '_b' } },
+      { $addFields: { effWine: { $ifNull: ['$wineDefinition', { $arrayElemAt: ['$_b.wineDefinition', 0] }] } } },
+      { $match: { effWine: { $ne: null } } },
+      { $group: {
+        _id: '$effWine',
+        imageCount: { $sum: 1 },
+        hasOfficial: { $max: { $cond: ['$assignedToWine', 1, 0] } },
+      } },
+      { $match: { imageCount: { $gte: 2 } } },
+    ];
+
+    const [countRes] = await BottleImage.aggregate([...basePipeline, { $count: 'total' }]);
+    const total = countRes?.total || 0;
+
+    const groups = await BottleImage.aggregate([
+      ...basePipeline,
+      // Wines still missing an official image first, then the most-contested.
+      { $sort: { hasOfficial: 1, imageCount: -1, _id: 1 } },
+      { $skip: offset },
+      { $limit: limit },
+    ]);
+
+    const wineIds = groups.map(g => g._id);
+    const wines = await WineDefinition.find({ _id: { $in: wineIds } })
+      .select('name producer type image imageCredit')
+      .lean();
+    const wineMap = new Map(wines.map(w => [w._id.toString(), w]));
+
+    // Bottles for these wines: their ids link bottle-only images, and their
+    // count is shown per wine.
+    const bottles = await Bottle.find({ wineDefinition: { $in: wineIds } })
+      .select('_id wineDefinition').lean();
+    const bottleToWine = new Map(bottles.map(b => [b._id.toString(), b.wineDefinition.toString()]));
+    const bottleCount = {};
+    for (const b of bottles) {
+      const w = b.wineDefinition.toString();
+      bottleCount[w] = (bottleCount[w] || 0) + 1;
+    }
+
+    const images = await BottleImage.find({
+      status: { $ne: 'rejected' },
+      $and: [
+        HAS_FILE,
+        { $or: [{ wineDefinition: { $in: wineIds } }, { bottle: { $in: bottles.map(b => b._id) } }] },
+      ],
+    })
+      .populate('uploadedBy', 'username')
+      .sort({ assignedToWine: -1, createdAt: -1 })
+      .lean();
+
+    const imagesByWine = new Map();
+    for (const img of images) {
+      const wid = (img.wineDefinition && img.wineDefinition.toString())
+        || (img.bottle && bottleToWine.get(img.bottle.toString()));
+      if (!wid || !wineMap.has(wid)) continue;
+      if (!imagesByWine.has(wid)) imagesByWine.set(wid, []);
+      imagesByWine.get(wid).push(img);
+    }
+
+    const items = groups
+      // Skip wines that no longer exist (deleted with dangling images) — they'd
+      // render as blank, image-less cards.
+      .filter(g => wineMap.has(g._id.toString()) && (imagesByWine.get(g._id.toString()) || []).length > 0)
+      .map(g => {
+        const wid = g._id.toString();
+        return {
+          wine: wineMap.get(wid),
+          imageCount: g.imageCount,
+          bottleCount: bottleCount[wid] || 0,
+          images: imagesByWine.get(wid),
+        };
+      });
+
+    res.json({ items, total, page, limit });
+  } catch (error) {
+    console.error('Get images by-wine error:', error);
+    res.status(500).json({ error: 'Failed to load wines by image' });
   }
 });
 
@@ -330,6 +422,63 @@ router.put('/:id/assign-to-wine', async (req, res) => {
   } catch (error) {
     console.error('Assign image error:', error);
     res.status(500).json({ error: 'Failed to assign image to wine' });
+  }
+});
+
+// PUT /api/admin/images/:id/set-official — one-click "make this the wine's image".
+// Unlike assign-to-wine, this promotes ANY non-rejected image (approving +
+// making it public in the same step), so an admin can curate directly from the
+// by-wine view without a separate approval pass.
+router.put('/:id/set-official', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const image = await BottleImage.findById(req.params.id).populate('bottle', 'wineDefinition');
+    if (!image) return res.status(404).json({ error: 'Image not found' });
+    if (image.status === 'rejected') {
+      return res.status(400).json({ error: 'Rejected images cannot be set as official' });
+    }
+
+    const imageUrl = image.processedUrl || image.originalUrl;
+    if (!imageUrl) return res.status(400).json({ error: 'Image has no file to use' });
+
+    const wineDefId = image.wineDefinition || image.bottle?.wineDefinition;
+    if (!wineDefId) return res.status(400).json({ error: 'Image is not linked to a wine' });
+
+    // Demote the wine's current official image, if any (and not this one).
+    await BottleImage.updateMany(
+      { wineDefinition: wineDefId, assignedToWine: true, _id: { $ne: image._id } },
+      { assignedToWine: false }
+    );
+
+    const wasOfficial = image.assignedToWine;
+    image.wineDefinition = wineDefId;
+    image.assignedToWine = true;
+    image.status = 'approved';
+    image.visibility = 'public';
+    if (!image.reviewedBy) {
+      image.reviewedBy = req.user.id;
+      image.reviewedAt = new Date();
+    }
+    // Drop the now-redundant original once a processed version exists, same as
+    // the approve path — imageUrl was resolved above before this nulls it.
+    deleteOriginalFile(image);
+    await image.save();
+
+    await WineDefinition.findByIdAndUpdate(wineDefId, { image: imageUrl, imageCredit: image.credit || null });
+    searchService.indexWine(wineDefId);
+
+    // Reward the uploader the first time their image becomes official.
+    if (!wasOfficial) incrementCred(image.uploadedBy, 'image_assigned_official').catch(() => {});
+
+    logAudit(req, 'admin.image.setOfficial',
+      { type: 'image', id: image._id },
+      { wineDefinitionId: wineDefId }
+    );
+
+    res.json({ ok: true });
+  } catch (error) {
+    console.error('Set official image error:', error);
+    res.status(500).json({ error: 'Failed to set official image' });
   }
 });
 

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -149,6 +149,13 @@ export const adminAssignImageToWine = (apiFetch, id, data) =>
     body: JSON.stringify(data),
   });
 
+// Wine-centric curation: wines with 2+ images, and one-click set-official.
+export const adminGetImagesByWine = (apiFetch, params) =>
+  apiFetch(`/api/admin/images/by-wine?${params}`);
+
+export const adminSetOfficialImage = (apiFetch, id) =>
+  apiFetch(`/api/admin/images/${id}/set-official`, { method: 'PUT' });
+
 // ── Import ────────────────────────────────────────────────────────────────────
 export const adminImportWines = (apiFetch, body) =>
   apiFetch('/api/admin/import/wines', { method: 'POST', body });

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -912,7 +912,20 @@
       "assigning": "Assigning...",
       "assignBtn": "Assign as Official Image",
       "enterWineId": "Please enter a wine definition ID",
-      "unapprove": "Unapprove"
+      "unapprove": "Unapprove",
+      "tabQueue": "Status queue",
+      "tabByWine": "By wine",
+      "byWineEmpty": "No wines have 2 or more images to choose between yet.",
+      "byWineCount_one": "{{count}} wine with multiple images",
+      "byWineCount_other": "{{count}} wines with multiple images",
+      "bottleCount_one": "{{count}} bottle",
+      "bottleCount_other": "{{count}} bottles",
+      "imageCountLabel_one": "{{count}} image",
+      "imageCountLabel_other": "{{count}} images",
+      "official": "Official",
+      "officialSet": "Official set",
+      "noOfficial": "No official",
+      "setOfficial": "Set as official"
     },
     "audit": {
       "title": "Audit Log",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -912,7 +912,20 @@
       "assigning": "Tilldelar...",
       "assignBtn": "Tilldela som officiell bild",
       "enterWineId": "Ange ett vindefinitions-ID",
-      "unapprove": "Ångra godkännande"
+      "unapprove": "Ångra godkännande",
+      "tabQueue": "Statuskö",
+      "tabByWine": "Per vin",
+      "byWineEmpty": "Inga viner har två eller fler bilder att välja mellan ännu.",
+      "byWineCount_one": "{{count}} vin med flera bilder",
+      "byWineCount_other": "{{count}} viner med flera bilder",
+      "bottleCount_one": "{{count}} flaska",
+      "bottleCount_other": "{{count}} flaskor",
+      "imageCountLabel_one": "{{count}} bild",
+      "imageCountLabel_other": "{{count}} bilder",
+      "official": "Officiell",
+      "officialSet": "Officiell vald",
+      "noOfficial": "Ingen officiell",
+      "setOfficial": "Välj som officiell"
     },
     "audit": {
       "title": "Aktivitetslogg",

--- a/frontend/src/pages/AdminImages.css
+++ b/frontend/src/pages/AdminImages.css
@@ -3,6 +3,129 @@
   margin: 0 auto;
 }
 
+/* ── Queue / By-wine tabs ── */
+.admin-images-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.75rem;
+}
+
+/* ── By-wine curation view ── */
+.by-wine-count {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+}
+.by-wine-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+}
+.by-wine-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.9rem;
+}
+.by-wine-title h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--color-text);
+}
+.by-wine-producer {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+.by-wine-stats {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+.by-wine-tag {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  padding: 0.12rem 0.5rem;
+  border-radius: var(--radius-full);
+  border: 1px solid transparent;
+}
+.by-wine-tag--ok {
+  color: var(--color-success);
+  background: var(--color-success-bg);
+  border-color: var(--color-success-border);
+}
+.by-wine-tag--warn {
+  color: var(--color-warning);
+  background: var(--color-warning-bg);
+  border-color: var(--color-warning-border);
+}
+.by-wine-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+.by-wine-img {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.by-wine-img.is-official {
+  border-color: var(--color-success);
+  box-shadow: 0 0 0 1px var(--color-success);
+}
+.by-wine-thumb {
+  position: relative;
+  aspect-ratio: 3 / 4;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.by-wine-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+.by-wine-star {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  color: #f5c518;
+  font-size: 1.1rem;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+.by-wine-img-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+}
+.by-wine-uploader {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.by-wine-set {
+  width: 100%;
+}
+
 .admin-images-page .page-header {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/AdminImages.js
+++ b/frontend/src/pages/AdminImages.js
@@ -4,11 +4,13 @@ import { useAuth } from '../contexts/AuthContext';
 import { adminGetImages, adminApproveImage, adminRejectImage, adminUnapproveImage, adminAssignImageToWine, adminSetImageVisibility } from '../api/admin';
 import AuthImage from '../components/AuthImage';
 import { API_URL } from '../api/apiConstants';
+import AdminImagesByWine from './AdminImagesByWine';
 import './AdminImages.css';
 
 function AdminImages() {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
+  const [view, setView] = useState('queue'); // 'queue' | 'byWine'
   const [images, setImages] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -163,9 +165,27 @@ function AdminImages() {
     <div className="admin-images-page">
       <div className="page-header">
         <h1>{t('admin.images.title')}</h1>
-        <span className="image-count">{t('admin.images.image', { count: total })}</span>
+        {view === 'queue' && <span className="image-count">{t('admin.images.image', { count: total })}</span>}
       </div>
 
+      <div className="admin-images-tabs">
+        <button
+          className={`filter-btn ${view === 'queue' ? 'active' : ''}`}
+          onClick={() => setView('queue')}
+        >
+          {t('admin.images.tabQueue')}
+        </button>
+        <button
+          className={`filter-btn ${view === 'byWine' ? 'active' : ''}`}
+          onClick={() => setView('byWine')}
+        >
+          {t('admin.images.tabByWine')}
+        </button>
+      </div>
+
+      {view === 'byWine' ? (
+        <AdminImagesByWine />
+      ) : (
       <div className="admin-layout">
         {/* Left panel: image list */}
         <div className="images-panel">
@@ -395,6 +415,7 @@ function AdminImages() {
           )}
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/AdminImagesByWine.js
+++ b/frontend/src/pages/AdminImagesByWine.js
@@ -1,0 +1,150 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import { adminGetImagesByWine, adminSetOfficialImage } from '../api/admin';
+import AuthImage from '../components/AuthImage';
+import { API_URL } from '../api/apiConstants';
+
+const LIMIT = 12;
+
+// Wine-centric image curation: wines that have 2+ images to choose between,
+// each shown with all its images so an admin can pick the official one.
+export default function AdminImagesByWine() {
+  const { t } = useTranslation();
+  const { apiFetch } = useAuth();
+  const [items, setItems] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState(null);
+  const [error, setError] = useState(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ page: String(page), limit: String(LIMIT) });
+      const res = await adminGetImagesByWine(apiFetch, params);
+      const data = await res.json();
+      if (res.ok) {
+        setItems(data.items || []);
+        setTotal(data.total || 0);
+      } else {
+        setError(data.error || 'Failed to load');
+      }
+    } catch {
+      setError('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch, page]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  // An image is the wine's official one if it's flagged assignedToWine, or its
+  // file URL matches the wine's stored image (belt-and-suspenders).
+  const isOfficial = (wine, img) => {
+    if (img.assignedToWine) return true;
+    if (!wine.image) return false;
+    return wine.image === img.processedUrl || wine.image === img.originalUrl;
+  };
+
+  const setOfficial = async (img) => {
+    setBusyId(img._id);
+    setError(null);
+    try {
+      const res = await adminSetOfficialImage(apiFetch, img._id);
+      const data = await res.json();
+      if (res.ok) await fetchData();
+      else setError(data.error || 'Failed to set official image');
+    } catch {
+      setError('Network error');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const totalPages = Math.ceil(total / LIMIT);
+
+  if (loading) return <div className="loading">{t('common.loading')}</div>;
+
+  return (
+    <div className="by-wine">
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {items.length === 0 ? (
+        <div className="empty-state"><p>{t('admin.images.byWineEmpty')}</p></div>
+      ) : (
+        <>
+          <p className="by-wine-count">{t('admin.images.byWineCount', { count: total })}</p>
+
+          {items.map(({ wine, images, imageCount, bottleCount }) => {
+            const hasOfficial = images.some(img => isOfficial(wine, img));
+            return (
+              <div key={wine._id} className="by-wine-card">
+                <div className="by-wine-head">
+                  <div className="by-wine-title">
+                    <h3>{wine.name}</h3>
+                    <span className="by-wine-producer">{wine.producer}</span>
+                  </div>
+                  <div className="by-wine-stats">
+                    {wine.type && <span className={`wine-type-pill ${wine.type}`}>{wine.type}</span>}
+                    <span>{t('admin.images.bottleCount', { count: bottleCount })}</span>
+                    <span>{t('admin.images.imageCountLabel', { count: imageCount })}</span>
+                    {hasOfficial
+                      ? <span className="by-wine-tag by-wine-tag--ok">{t('admin.images.officialSet')}</span>
+                      : <span className="by-wine-tag by-wine-tag--warn">{t('admin.images.noOfficial')}</span>}
+                  </div>
+                </div>
+
+                <div className="by-wine-gallery">
+                  {images.map(img => {
+                    const official = isOfficial(wine, img);
+                    return (
+                      <div key={img._id} className={`by-wine-img${official ? ' is-official' : ''}`}>
+                        <div className="by-wine-thumb">
+                          <AuthImage
+                            src={`${API_URL}${img.processedUrl || img.originalUrl}`}
+                            alt={wine.name}
+                            onError={(e) => { e.target.style.display = 'none'; }}
+                          />
+                          {official && <span className="by-wine-star" title={t('admin.images.official')}>★</span>}
+                        </div>
+                        <div className="by-wine-img-meta">
+                          <span className="by-wine-uploader" title={img.uploadedBy?.username || ''}>
+                            {img.uploadedBy?.username || '—'}
+                          </span>
+                          <span className={`status-badge status-${img.status}`}>{img.status}</span>
+                        </div>
+                        <button
+                          type="button"
+                          className="btn btn-small btn-primary by-wine-set"
+                          onClick={() => setOfficial(img)}
+                          disabled={official || busyId === img._id}
+                        >
+                          {official
+                            ? t('admin.images.official')
+                            : busyId === img._id
+                              ? t('admin.images.processing')
+                              : t('admin.images.setOfficial')}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+
+          {totalPages > 1 && (
+            <div className="pagination">
+              <button disabled={page <= 1} onClick={() => setPage(p => p - 1)}>Previous</button>
+              <span>Page {page} of {totalPages}</span>
+              <button disabled={page >= totalPages} onClick={() => setPage(p => p + 1)}>Next</button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
A new **"By wine"** tab on the admin **Image Review** page (`/admin/images`) for curating registry images. It lists wines that have **2+ uploaded images** and shows every image side by side, so an admin can pick the official one in a single click.

- Wines that don't have an official image yet are surfaced first.
- Each card shows the wine, bottle count, image count, and an "Official set / No official" tag; each image shows its uploader + status and a **Set as official** button (the current official is starred and disabled).

## Endpoints (both admin-gated under the existing `router.use(requireAuth, requireRole('admin'))`)
- `GET /api/admin/images/by-wine` — aggregates BottleImages by their effective wine (direct `wineDefinition`, or the bottle's), keeps wines with ≥2 non-rejected file-backed images, paginates over wines. Skips wines deleted out from under dangling images.
- `PUT /api/admin/images/:id/set-official` — promotes **any** non-rejected image to the wine's official image (approves + makes public + updates `WineDefinition.image`/`imageCredit` + reindexes search), demoting the previous official. Reuses the existing `assignedToWine` invariant.

The one-click "make official" builds on the pre-existing `assign-to-wine` mechanism but works on any image (not just already-approved ones), which is what the by-wine curation flow needs.

## Testing
Verified via curl against real data: `by-wine` returns 86 wines with 2+ images, correct counts, uploaders, official-first sort, and every row has a valid wine + images. `set-official` round-trip promotes the image (wine.image updated, image approved+public+assigned) — tested and restored. Reviewed at high effort; two LOW findings (ghost card for deleted wine, redundant original file) fixed.

## Docker / compose impact
Code-only — no compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)