### PR TITLE
chore(release): v1.72.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.71.0",
+  "version": "1.72.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.71.0",
+  "version": "1.72.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Minor release: admin image-duplicate cleanup — by-wine visibility badges, duplicate flags + per-image remove (#592), and import-time dedup of identical images (#593). Bumps backend + frontend package.json in lockstep.