### PR TITLE
feat: silent image delete with duplicate handover in by-wine curation

### DIFF
--- a/backend/src/routes/admin/images.js
+++ b/backend/src/routes/admin/images.js
@@ -5,7 +5,7 @@ const WineDefinition = require('../../models/WineDefinition');
 const Bottle = require('../../models/Bottle');
 const searchService = require('../../services/search');
 const fs = require('fs');
-const { reprocessAllImages, safeUploadPath } = require('../../services/imageProcessor');
+const { reprocessAllImages, safeUploadPath, unlinkImageFiles } = require('../../services/imageProcessor');
 const { logAudit } = require('../../services/audit');
 const { createNotification } = require('../../services/notifications');
 const { incrementCred } = require('../../utils/cellarCred');
@@ -234,7 +234,9 @@ router.put('/:id/approve', async (req, res) => {
   }
 });
 
-// PUT /api/admin/images/:id/reject
+// PUT /api/admin/images/:id/reject — moderation judgement: the photo itself is
+// unwanted. Notifies the uploader and keeps a rejected tombstone record. For
+// removing redundant duplicates, use DELETE /:id below instead.
 router.put('/:id/reject', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
@@ -261,19 +263,18 @@ router.put('/:id/reject', async (req, res) => {
       }
     }
 
+    // A rejected photo shouldn't stay starred on any bottle — clear the refs so
+    // they fall back to the wine image instead of dangling.
+    await Bottle.updateMany({ defaultImage: image._id }, { $set: { defaultImage: null } });
+
     image.status = 'rejected';
     image.reviewedBy = req.user.id;
     image.reviewedAt = new Date();
 
-    // Delete both original and processed files from disk
-    for (const url of [image.originalUrl, image.processedUrl]) {
-      if (!url) continue;
-      try {
-        fs.unlinkSync(safeUploadPath(url.replace('/api/uploads/', '')));
-      } catch (err) {
-        if (err.code !== 'ENOENT') console.error('Failed to delete image file:', err.message);
-      }
-    }
+    // Delete the files from disk — reference-safe: import dedup can point two
+    // records at the same file, and a shared file must survive for the record
+    // that remains.
+    await unlinkImageFiles(image);
     image.originalUrl = null;
     image.processedUrl = null;
     await image.save();
@@ -306,6 +307,84 @@ router.put('/:id/reject', async (req, res) => {
   } catch (error) {
     console.error('Reject image error:', error);
     res.status(500).json({ error: 'Failed to reject image' });
+  }
+});
+
+// DELETE /api/admin/images/:id — silent housekeeping removal (duplicate cleanup
+// in the by-wine view). Unlike reject, this is not a judgement on the photo:
+// the record is removed entirely, the uploader is NOT notified, and anything
+// still pointing at it — a bottle's starred default image or the wine's
+// official image — is handed over to a byte-identical surviving copy when one
+// exists, so no user visibly loses a photo.
+router.delete('/:id', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const image = await BottleImage.findById(req.params.id);
+    if (!image) {
+      return res.status(404).json({ error: 'Image not found' });
+    }
+
+    // Byte-identical surviving copy (duplicates from imports / re-uploads).
+    // Prefer one by the same uploader — in practice duplicates are the same
+    // user re-importing their cellar.
+    let survivor = null;
+    if (image.contentHash) {
+      const candidates = await BottleImage.find({
+        _id: { $ne: image._id },
+        contentHash: image.contentHash,
+        status: { $ne: 'rejected' },
+        $or: [{ processedUrl: { $ne: null } }, { originalUrl: { $ne: null } }],
+      }).sort({ createdAt: 1 }).lean();
+      survivor = candidates.find(c => String(c.uploadedBy) === String(image.uploadedBy)) || candidates[0] || null;
+    }
+
+    // Hand the official-image assignment over to the identical copy (or clear
+    // it) BEFORE the files go away, so WineDefinition.image never points at a
+    // deleted file.
+    if (image.assignedToWine && image.wineDefinition) {
+      const wineDefId = image.wineDefinition;
+      const imageUrl = image.processedUrl || image.originalUrl;
+      const wine = await WineDefinition.findById(wineDefId);
+      if (wine && wine.image === imageUrl) {
+        if (survivor) {
+          // Mirrors the set-official promotion.
+          await BottleImage.updateOne(
+            { _id: survivor._id },
+            { $set: { wineDefinition: wineDefId, assignedToWine: true, status: 'approved', visibility: 'public' } }
+          );
+          wine.image = survivor.processedUrl || survivor.originalUrl;
+          wine.imageCredit = survivor.credit || null;
+        } else {
+          wine.image = null;
+          wine.imageCredit = null;
+        }
+        await wine.save();
+        searchService.indexWine(wineDefId);
+      }
+    }
+
+    // Repoint bottles whose starred (default) image is this record to the
+    // surviving identical copy — or clear it so it falls back to the wine
+    // image instead of dangling.
+    await Bottle.updateMany(
+      { defaultImage: image._id },
+      { $set: { defaultImage: survivor ? survivor._id : null } }
+    );
+
+    // Remove the files (reference-safe: a file shared with another record via
+    // import dedup survives for that record), then drop the record itself.
+    await unlinkImageFiles(image);
+    await image.deleteOne();
+
+    logAudit(req, 'admin.image.delete',
+      { type: 'image', id: image._id },
+      { wineDefinitionId: image.wineDefinition || null, survivorId: survivor ? survivor._id : null }
+    );
+
+    res.json({ ok: true, survivorId: survivor ? survivor._id : null });
+  } catch (error) {
+    console.error('Delete image error:', error);
+    res.status(500).json({ error: 'Failed to delete image' });
   }
 });
 

--- a/backend/src/scripts/cleanup-duplicate-images.js
+++ b/backend/src/scripts/cleanup-duplicate-images.js
@@ -1,0 +1,128 @@
+/**
+ * One-time cleanup of duplicate wine images.
+ *
+ * Imports and re-uploads historically created several BottleImage records for
+ * the SAME photo (identical contentHash) on the same wine — cluttering the
+ * admin by-wine curation view and the wine's gallery. New imports no longer do
+ * this (import-time dedup), and admins can delete stragglers by hand; this
+ * script clears the existing backlog in one pass.
+ *
+ * For every (wine, contentHash, uploader) group with more than one
+ * non-rejected, file-backed record, it keeps ONE copy and deletes the rest,
+ * using the same handover rules as DELETE /api/admin/images/:id:
+ *   - keeper preference: official (assignedToWine) → matches WineDefinition.image
+ *     → approved+public → approved → oldest
+ *   - bottles whose starred defaultImage was a deleted record are repointed to
+ *     the keeper (byte-identical photo — nothing visibly changes for the user)
+ *   - if WineDefinition.image pointed at a deleted record's file, it is updated
+ *     to the keeper's file
+ *   - file removal is reference-safe (a file shared with a surviving record is
+ *     kept); records are hard-deleted, no notifications
+ *
+ * Only same-uploader duplicates are touched: distinct users who happened to
+ * upload the same photo keep their own records (none exist today, but the
+ * script must stay safe if they ever do).
+ *
+ * Usage (inside the backend container):
+ *   node src/scripts/cleanup-duplicate-images.js           # dry-run (default)
+ *   node src/scripts/cleanup-duplicate-images.js --apply   # actually delete
+ */
+const mongoose = require('mongoose');
+const Bottle = require('../models/Bottle');
+const BottleImage = require('../models/BottleImage');
+const WineDefinition = require('../models/WineDefinition');
+const { unlinkImageFiles } = require('../services/imageProcessor');
+
+const APPLY = process.argv.includes('--apply');
+
+function keeperScore(img, wine) {
+  let s = 0;
+  if (img.assignedToWine) s += 100;
+  const url = img.processedUrl || img.originalUrl;
+  if (wine && wine.image && url === wine.image) s += 50;
+  if (img.status === 'approved' && img.visibility === 'public') s += 20;
+  else if (img.status === 'approved') s += 10;
+  return s;
+}
+
+async function main() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log(`Mode: ${APPLY ? 'APPLY (deleting)' : 'DRY-RUN (no changes; pass --apply to execute)'}\n`);
+
+  // Duplicate groups: same effective wine + same photo bytes + same uploader.
+  const groups = await BottleImage.aggregate([
+    { $match: {
+      status: { $ne: 'rejected' },
+      contentHash: { $ne: null },
+      $or: [{ processedUrl: { $ne: null } }, { originalUrl: { $ne: null } }],
+    } },
+    { $lookup: { from: 'bottles', localField: 'bottle', foreignField: '_id', as: '_b' } },
+    { $addFields: { effWine: { $ifNull: ['$wineDefinition', { $arrayElemAt: ['$_b.wineDefinition', 0] }] } } },
+    { $match: { effWine: { $ne: null } } },
+    { $group: {
+      _id: { wine: '$effWine', hash: '$contentHash', uploader: '$uploadedBy' },
+      ids: { $push: '$_id' },
+      n: { $sum: 1 },
+    } },
+    { $match: { n: { $gt: 1 } } },
+  ]).allowDiskUse(true);
+
+  const totals = { groups: 0, deleted: 0, repointedBottles: 0, winesUpdated: 0 };
+
+  for (const g of groups) {
+    const wine = await WineDefinition.findById(g._id.wine).select('name producer image imageCredit');
+    if (!wine) continue; // wine deleted out from under its images — leave for manual review
+    const imgs = await BottleImage.find({ _id: { $in: g.ids } });
+    if (imgs.length < 2) continue;
+
+    const sorted = imgs.slice().sort((a, b) =>
+      keeperScore(b, wine) - keeperScore(a, wine) || new Date(a.createdAt) - new Date(b.createdAt));
+    const keeper = sorted[0];
+    const losers = sorted.slice(1);
+    const keeperUrl = keeper.processedUrl || keeper.originalUrl;
+
+    totals.groups++;
+    console.log(`${wine.name} (${wine.producer}) — photo ${g._id.hash.slice(0, 10)}…: keep ${keeper._id}, delete ${losers.length}`);
+    if (!APPLY) { totals.deleted += losers.length; continue; }
+
+    for (const loser of losers) {
+      // Starred handover: bottles pointing at the deleted record get the keeper.
+      const rp = await Bottle.updateMany(
+        { defaultImage: loser._id },
+        { $set: { defaultImage: keeper._id } }
+      );
+      totals.repointedBottles += rp.modifiedCount || 0;
+
+      // Official handover: if the wine's image is this record's file, move it
+      // to the keeper (keeper preference makes this rare, but a stale URL or a
+      // drifted assignedToWine flag can still hit it).
+      const loserUrl = loser.processedUrl || loser.originalUrl;
+      if (wine.image && wine.image === loserUrl && keeperUrl) {
+        wine.image = keeperUrl;
+        wine.imageCredit = keeper.credit || null;
+        await wine.save();
+        if (!keeper.assignedToWine) {
+          keeper.assignedToWine = true;
+          keeper.wineDefinition = wine._id;
+          keeper.status = 'approved';
+          keeper.visibility = 'public';
+          await keeper.save();
+        }
+        totals.winesUpdated++;
+        // Search reindex intentionally skipped (script runs without Meili
+        // init); the wine doc URL change is picked up on the next full sync.
+      }
+
+      await unlinkImageFiles(loser); // reference-safe: shared files survive
+      await loser.deleteOne();
+      totals.deleted++;
+    }
+  }
+
+  console.log(`\n${APPLY ? 'Done' : 'Would do'}: ${totals.groups} duplicate groups, ` +
+    `${totals.deleted} records deleted, ${totals.repointedBottles} bottle stars repointed, ` +
+    `${totals.winesUpdated} wine images updated.`);
+  await mongoose.disconnect();
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -136,6 +136,11 @@ export const adminApproveImage = (apiFetch, id, data = {}) =>
 export const adminRejectImage = (apiFetch, id) =>
   apiFetch(`/api/admin/images/${id}/reject`, { method: 'PUT' });
 
+// Silent hard-delete (duplicate cleanup) — no uploader notification; starred /
+// official references are handed to an identical surviving copy server-side.
+export const adminDeleteImage = (apiFetch, id) =>
+  apiFetch(`/api/admin/images/${id}`, { method: 'DELETE' });
+
 export const adminSetImageVisibility = (apiFetch, id, visibility) =>
   apiFetch(`/api/admin/images/${id}/visibility`, { method: 'PUT', headers: J, body: JSON.stringify({ visibility }) });
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -932,7 +932,8 @@
       "duplicateHint": "This exact photo appears more than once for this wine — remove the extras.",
       "duplicateCount_one": "{{count}} duplicate",
       "duplicateCount_other": "{{count}} duplicates",
-      "removeConfirm": "Remove this image? The uploader is notified.",
+      "removeConfirm": "Delete this image? If a bottle uses it, an identical copy takes its place when one exists.",
+      "deleteImage": "Delete",
       "removeYes": "Remove",
       "removing": "Removing…",
       "reject": "Reject"

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -932,7 +932,8 @@
       "duplicateHint": "Exakt samma foto förekommer flera gånger för detta vin – ta bort dubbletterna.",
       "duplicateCount_one": "{{count}} dubblett",
       "duplicateCount_other": "{{count}} dubbletter",
-      "removeConfirm": "Ta bort denna bild? Uppladdaren meddelas.",
+      "removeConfirm": "Ta bort denna bild? Om en flaska använder den ersätts den med en identisk kopia om en finns.",
+      "deleteImage": "Ta bort",
       "removeYes": "Ta bort",
       "removing": "Tar bort…",
       "reject": "Avvisa"

--- a/frontend/src/pages/AdminImagesByWine.js
+++ b/frontend/src/pages/AdminImagesByWine.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
-import { adminGetImagesByWine, adminSetOfficialImage, adminRejectImage } from '../api/admin';
+import { adminGetImagesByWine, adminSetOfficialImage, adminDeleteImage } from '../api/admin';
 import AuthImage from '../components/AuthImage';
 import { API_URL } from '../api/apiConstants';
 
@@ -66,17 +66,19 @@ export default function AdminImagesByWine() {
     }
   };
 
-  const rejectImage = async (img) => {
+  // Silent housekeeping delete (no uploader notification) — the backend hands
+  // starred/official references over to an identical surviving copy.
+  const deleteImage = async (img) => {
     setBusyId(img._id);
     setError(null);
     try {
-      const res = await adminRejectImage(apiFetch, img._id);
+      const res = await adminDeleteImage(apiFetch, img._id);
       if (res.ok) {
         setConfirmRejectId(null);
         await fetchData();
       } else {
         const data = await res.json();
-        setError(data.error || 'Failed to remove image');
+        setError(data.error || 'Failed to delete image');
       }
     } catch {
       setError('Network error');
@@ -169,7 +171,7 @@ export default function AdminImagesByWine() {
                                 <button
                                   type="button"
                                   className="btn btn-small btn-danger"
-                                  onClick={() => rejectImage(img)}
+                                  onClick={() => deleteImage(img)}
                                   disabled={busy}
                                 >
                                   {busy ? t('admin.images.removing') : t('admin.images.removeYes')}
@@ -204,7 +206,7 @@ export default function AdminImagesByWine() {
                                 onClick={() => { setConfirmRejectId(img._id); setError(null); }}
                                 disabled={busy}
                               >
-                                {t('admin.images.reject')}
+                                {t('admin.images.deleteImage')}
                               </button>
                             </>
                           )}


### PR DESCRIPTION
## Problem
The by-wine **Remove** action reused the moderation *reject*: it notified the uploader (wrong for housekeeping), left a rejected tombstone, and had two real data hazards:
1. **Starred images went dangling** — if a user had the removed image starred as their bottle's preferred image, the reference dangled and their choice was silently lost, even when a byte-identical duplicate survived.
2. **Shared files could be deleted** — import dedup can point two image records at the *same file*; the raw unlink deleted it for the surviving record too.

## Fix
New **`DELETE /api/admin/images/:id`** (admin-gated, audit-logged) used by the by-wine Delete button:
- **Silent** — no uploader notification (per product decision: duplicate cleanup is not a judgement on the upload).
- **Starred handover** — bottles whose `defaultImage` was the removed record are repointed to a **byte-identical surviving copy** (same `contentHash`, same uploader preferred), or cleared to fall back to the wine image. Never dangling.
- **Official handover** — if the removed image was the wine's official image, official status transfers to the identical survivor (mirrors set-official) instead of leaving the wine imageless.
- **Reference-safe file removal** via the existing `unlinkImageFiles`; the record is hard-deleted (no tombstone).

The **status-queue Reject keeps its moderation semantics** (notification + tombstone) but gains the same reference-safe unlink + starred-image cleanup, fixing the identical hazards there.

## Testing
E2E against the running backend (throwaway data, cleaned up): 14/14 assertions across 3 scenarios — starred repoint (2 bottles), official transfer + survivor promotion, deleted file gone + survivor file intact, **no notification created**, shared-file survival, no-survivor case clears to null.

## Docker / compose impact
Code-only — no compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)