### PR TITLE
chore(release): v1.73.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Minor release: silent image delete with duplicate handover in the by-wine curation view + bulk duplicate-cleanup script (#595). Bumps backend + frontend package.json in lockstep.