### PR TITLE
fix: expose id on User JSON so frontend ownership checks work

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -388,6 +388,9 @@ userSchema.methods.isDiscussionBanned = function() {
 // Remove sensitive fields from JSON responses
 userSchema.methods.toJSON = function() {
   const obj = this.toObject();
+  // toObject() omits the `id` virtual, but the frontend's ownership checks
+  // compare against `user.id` — expose it as a plain string alongside _id.
+  if (obj._id) obj.id = obj._id.toString();
   delete obj.password;
   delete obj.refreshTokenHash;
   delete obj.refreshTokenExpiresAt;

--- a/backend/src/models/User.test.js
+++ b/backend/src/models/User.test.js
@@ -1,4 +1,22 @@
-const { normalizeLegacyNotifications } = require('./User');
+const User = require('./User');
+const { normalizeLegacyNotifications } = User;
+
+describe('toJSON', () => {
+  it('exposes id as a string copy of _id (frontend ownership checks use user.id)', () => {
+    const user = new User({ username: 'alice', email: 'alice@cellarion.app', password: 'x' });
+    const json = user.toJSON();
+    expect(json.id).toBe(user._id.toString());
+    expect(typeof json.id).toBe('string');
+  });
+
+  it('still strips sensitive fields', () => {
+    const user = new User({ username: 'alice', email: 'alice@cellarion.app', password: 'x' });
+    const json = user.toJSON();
+    expect(json.password).toBeUndefined();
+    expect(json.refreshTokenHash).toBeUndefined();
+    expect(json.stripeCustomerId).toBeUndefined();
+  });
+});
 
 describe('normalizeLegacyNotifications', () => {
   it('returns [] when notif is null/undefined', () => {


### PR DESCRIPTION
## Summary
Audit finding **HIGH #1** (CODE_AUDIT_2026-07-08.md): `User.toJSON()` builds on `toObject()`, which omits Mongoose's `id` virtual — so the client's `user` object only ever had `_id`, while community pages compare against `user.id`. Every own-content check was false:

- Non-moderators never saw **Edit/Delete on their own discussion replies** (the backend allows it)
- Authors got a **Report** button on their own posts
- Your own profile showed a **Follow** button that optimistically flipped, then silently reverted (backend 400s self-follow)

## Change
- `User.toJSON()` now exposes `id` as a plain string copy of `_id` (single normalization point — every frontend `user` object comes from a backend response, so this covers login, `/auth/me`, preferences updates, etc.)
- Added tests: `id` presence/stringness + the existing sensitive-field stripping

## Testing
- `cd backend && npm test` — 823 passed (incl. 2 new)

## docker-compose impact
None — code-only; the backend image just needs its normal rebuild on deploy. No env/compose changes, no prod compose edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)