### PR TITLE
fix: accept cellarion-export@1 JSON in the bottle importer

### DIFF
--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -694,7 +694,7 @@ function ImportBottles() {
         <div className="format-cards">
           <div className="format-card">
             <strong>Cellarion JSON</strong>
-            <p>Export from any cellar via &#8943; &rarr; Export Bottles (JSON)</p>
+            <p>Download from any cellar via &#8943; &rarr; Export (JSON). Bottles from all cellars in the file are imported into the cellar you pick here &mdash; to recreate whole cellars with racks and layout, use Import Cellar in Settings instead.</p>
           </div>
           <div className="format-card">
             <strong>Vivino</strong>

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -572,7 +572,9 @@ function tryParseDate(str) {
  * Parse a Cellarion JSON export (or plain array) into master import format.
  *
  * Accepts:
- *   - Cellarion export object: { cellarName, exportedAt, bottles: [...] }
+ *   - Current cellar export (cellarion-export@1): { schema, cellars: [ { cellarName, bottles: [...] } ] }
+ *     \u2014 bottles from all exported cellars are flattened into one list
+ *   - Legacy single-cellar export object: { cellarName, exportedAt, bottles: [...] }
  *   - Plain array of items already in master format
  *
  * @param {string} text - Raw JSON text
@@ -587,7 +589,12 @@ export function parseJSON(text) {
     throw new Error('Invalid JSON file');
   }
 
-  const raw = Array.isArray(parsed) ? parsed : (Array.isArray(parsed.bottles) ? parsed.bottles : null);
+  let raw = Array.isArray(parsed) ? parsed : (Array.isArray(parsed.bottles) ? parsed.bottles : null);
+  if (!raw && Array.isArray(parsed.cellars)) {
+    // cellarion-export@1 (the "Export cellar data" download): bottles are
+    // nested per cellar; their items are already in master format.
+    raw = parsed.cellars.flatMap((c) => (Array.isArray(c?.bottles) ? c.bottles : []));
+  }
   if (!raw) throw new Error('JSON must be an array or a Cellarion export object with a "bottles" array');
 
   const items = [];

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -313,6 +313,50 @@ describe('parseJSON', () => {
     expect(result.format).toBe('cellarion');
   });
 
+  it('parses a cellarion-export@1 object, flattening bottles across cellars', () => {
+    const json = JSON.stringify({
+      schema: 'cellarion-export@1',
+      exportedAt: '2026-07-01T00:00:00.000Z',
+      scope: 'all',
+      cellarCount: 2,
+      bottleCount: 3,
+      cellars: [
+        {
+          cellarName: 'Main Cellar',
+          racks: [{ name: 'Rack A', type: 'grid', rows: 4, cols: 8 }],
+          bottles: [
+            { wineName: 'Margaux', producer: 'Chateau Margaux', vintage: '2015' },
+            { wineName: 'Opus One', producer: 'Opus One Winery', vintage: '2018' },
+          ],
+        },
+        {
+          cellarName: 'Garage',
+          racks: [],
+          bottles: [
+            { wineName: 'Barolo', producer: 'Conterno', vintage: '2019' },
+          ],
+        },
+      ],
+    });
+    const result = parseJSON(json);
+    expect(result.items).toHaveLength(3);
+    expect(result.items.map(i => i.wineName)).toEqual(['Margaux', 'Opus One', 'Barolo']);
+    expect(result.format).toBe('cellarion');
+  });
+
+  it('handles a cellarion-export@1 cellar with a missing bottles array', () => {
+    const json = JSON.stringify({
+      schema: 'cellarion-export@1',
+      cellars: [
+        { cellarName: 'Empty' },
+        { cellarName: 'Full', bottles: [{ wineName: 'Margaux', producer: 'CM' }] },
+      ],
+    });
+    const result = parseJSON(json);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].wineName).toBe('Margaux');
+  });
+
   it('expands quantity > 1 into individual items', () => {
     const json = JSON.stringify([
       { wineName: 'Margaux', producer: 'Chateau Margaux', quantity: 3 },


### PR DESCRIPTION
## Summary
Audit finding **HIGH #2** (CODE_AUDIT_2026-07-08.md): the "Cellarion JSON" round-trip was broken — `parseJSON` only accepted a plain array or the legacy single-cellar `{ bottles: [...] }` shape, but the export page has produced the `cellarion-export@1` shape (`{ schema, cellars: [ { bottles: [...] } ] }`) since the data-portability feature shipped. Re-importing your own export failed with a format error, and the import page's format card pointed at an "Export Bottles (JSON)" menu item that no longer exists.

## Change
- `parseJSON` additionally flattens `cellars[].bottles` from `cellarion-export@1` files (the bottle items inside are already in master import format) — **additive**: the plain-array and legacy shapes, and all other import formats, are untouched
- Format card copy updated to the real menu path, and points whole-cellar restores (racks + 3D layout) at Import Cellar
- Added tests: multi-cellar flattening + a cellar with a missing `bottles` array

## Testing
- `cd frontend && npm test` — 324 passed (incl. 2 new)

## docker-compose impact
None — frontend-only; the frontend image just needs its normal rebuild on deploy. No env/compose changes, no prod compose edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)