### PR TITLE
docs: stop claiming CSV export — the app exports JSON/ZIP only

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is the primary way to use Cellarion. Create an account and start using the 
 - **Smart search** — Meilisearch-powered fuzzy search with deduplication
 - **AI cellar chat** — Ask questions about your collection — food pairings, occasion picks, cellar checks (powered by Claude + Voyage embeddings + Qdrant)
 - **Label scanning** — Snap a photo of a wine label and let AI fill in the details (Anthropic Vision API)
-- **Import & export** — Bring collections from Vivino, CellarTracker, or generic CSV; export as JSON/CSV
+- **Import & export** — Bring collections from Vivino, CellarTracker, or generic CSV; export as JSON (or ZIP with images)
 - **Cellar sharing** — Invite others to browse or co-manage a cellar with role-based access
 - **Dark mode** — Full light/dark theme with system preference detection
 - **Notifications** — In-app notification bell for wine requests, image approvals, shared cellars, and more
@@ -527,9 +527,9 @@ To import directly into history (already consumed bottles), add:
 }
 ```
 
-### Bottle Export
+### Cellar Export
 
-Cellar owners can export all bottles via the overflow menu (⋯ → Export Bottles). Available in JSON and CSV. The export includes rack placement (`rackName`, `rackPosition`, `rackRow`, `rackCol`) but excludes images and staff-curated data (sommelier drink windows, pricing). The JSON format is directly re-importable.
+Cellar owners can export their data via a cellar's overflow menu (⋯ → Export) or Settings. Available as JSON, or as a ZIP that also includes your uploaded bottle images. The export covers bottles with rack placement (`rackName`, `rackPosition`), rack geometry, the 3D room layout, and your own reviews. The JSON format is directly re-importable.
 
 ---
 

--- a/backend/src/routes/og.js
+++ b/backend/src/routes/og.js
@@ -73,7 +73,7 @@ const LANDING = {
   whyTitle: 'Why wine lovers choose Cellarion',
   why: [
     ['Free to use', 'All core features are free at cellarion.app — no credit card, no trial, no upsell pop-ups. We don\'t sell ads either.'],
-    ['No lock-in', 'Your collection is yours. Export everything to JSON or CSV with one click, any time. If you ever leave, you walk out with all your data.'],
+    ['No lock-in', 'Your collection is yours. Export everything as JSON — or a ZIP with your images — with one click, any time. If you ever leave, you walk out with all your data.'],
     ['Private by design', 'No third-party trackers, no data sold to wine merchants. Just a clean app that stays out of your way.'],
     ['GDPR-compliant', 'Hosted on European infrastructure. Full data export, account deletion, and a one-click email opt-out built in from day one.'],
   ],
@@ -85,7 +85,7 @@ const LANDING = {
     ['What is a drink window in wine?', 'A drink window is the period during which a wine is at its best — typically a range of years bracketing the wine\'s peak maturity. Cellarion classifies every vintage as Not Ready, Early, Peak, Late, or Declining based on producer notes and vintage data, so you know which bottles to drink soon and which to keep cellaring.'],
     ['Is Cellarion really free?', 'Yes. All core features at cellarion.app are free — track unlimited bottles, organise cellars, get drink-window alerts, share with friends, and export your data anytime. There are no credit-card prompts, no premium tiers gating basic functionality, and we don\'t sell ads or your data.'],
     ['How do I import wines from Vivino or CellarTracker?', 'Cellarion supports CSV import. Export your collection from Vivino, CellarTracker, or any spreadsheet, then upload the CSV in Cellarion\'s import tool. The shared wine registry deduplicates entries automatically so your data stays clean and consistent across the whole catalogue.'],
-    ['Can I export my data and leave any time?', 'Yes — your data is yours. Cellarion includes a one-click data export that gives you everything as JSON, plus CSV import and export for bottles. You can delete your account from Settings with a 7-day cooling-off window. Hosted data lives on European infrastructure under GDPR.'],
+    ['Can I export my data and leave any time?', 'Yes — your data is yours. Cellarion includes a one-click data export that gives you everything as JSON (or a ZIP including your uploaded images), plus CSV import for bottles. You can delete your account from Settings with a 7-day cooling-off window. Hosted data lives on European infrastructure under GDPR.'],
   ],
 };
 

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -17,7 +17,7 @@
 ## Key facts
 - Platforms: a web app that runs in any browser, plus an Android app on Google Play (https://play.google.com/store/apps/details?id=app.cellarion.twa). iPhone users can install it to the home screen as a web app.
 - Free to use: all core features are free at cellarion.app — no credit card, no ads, no selling of data.
-- No lock-in: export your entire collection to JSON or CSV at any time.
+- No lock-in: export your entire collection to JSON (or a ZIP including your images) at any time.
 - Open source: https://github.com/jagduvi1/Cellarion (AGPL-3.0).
 - Privacy: GDPR-compliant, European hosting, cookieless analytics. See https://cellarion.app/privacy.
 - Compares to: Vivino, CellarTracker, InVintory — Cellarion is free, open-source, privacy-first, and exports your data without lock-in.

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2109,7 +2109,7 @@
     "whyFreeTitle": "Free to use",
     "whyFreeDesc": "All core features are free at cellarion.app — no credit card, no trial, no upsell pop-ups. We don't sell ads either.",
     "whyExportTitle": "No lock-in",
-    "whyExportDesc": "Your collection is yours. Export everything to JSON or CSV with one click, any time. If you ever leave, you walk out with all your data.",
+    "whyExportDesc": "Your collection is yours. Export everything as JSON — or a ZIP with your images — with one click, any time. If you ever leave, you walk out with all your data.",
     "whyPrivacyTitle": "Private by design",
     "whyPrivacyDesc": "No third-party trackers, no data sold to wine merchants. Just a clean app that stays out of your way.",
     "whyGdprTitle": "GDPR-compliant",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2109,7 +2109,7 @@
     "whyFreeTitle": "Gratis att använda",
     "whyFreeDesc": "Alla grundfunktioner är gratis på cellarion.app — inget kreditkort, ingen testperiod, inga merförsäljningspopup-fönster. Vi säljer inte heller annonser.",
     "whyExportTitle": "Ingen inlåsning",
-    "whyExportDesc": "Din samling är din. Exportera allt till JSON eller CSV med ett klick, när som helst. Om du någonsin lämnar går du därifrån med all din data.",
+    "whyExportDesc": "Din samling är din. Exportera allt som JSON — eller en ZIP med dina bilder — med ett klick, när som helst. Om du någonsin lämnar går du därifrån med all din data.",
     "whyPrivacyTitle": "Privat från grunden",
     "whyPrivacyDesc": "Inga tredjeparts-spårare, ingen data säljs till vinhandlare. Bara en ren app som håller sig ur vägen.",
     "whyGdprTitle": "GDPR-kompatibel",


### PR DESCRIPTION
## Summary
Audit finding **HIGH #3** (CODE_AUDIT_2026-07-08.md) / the long-standing CSV gotcha: CSV is **import-only**, but seven user-facing surfaces promised CSV *export* — including the server-rendered crawler landing page and FAQPage JSON-LD that AI engines quote verbatim.

## Change
All seven spots now say "JSON — or a ZIP with your images":
- `frontend/public/llms.txt`
- `landing.whyExportDesc` in **en** + **sv** `translation.json` (visible landing page)
- `backend/src/routes/og.js` — "No lock-in" card + FAQ answer (crawler landing + JSON-LD)
- `README.md` feature bullet + the Bottle Export section, which also described a removed "⋯ → Export Bottles" menu item — rewritten to match the current cellar export (JSON or ZIP with images, racks, layout, reviews)

All CSV **import** claims (Vivino/CellarTracker/generic) are kept — they're true.

## Testing
- `cd frontend && npm test` — 322 passed (locale JSON validity covered)
- `cd backend && npm test` — 821 passed

## docker-compose impact
None — copy-only changes in both images; normal rebuild on deploy. No env/compose changes, no prod compose edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)