### PR TITLE
fix: enforce 30-day retention for soft-deleted cellars/racks with a full purge cascade

### DIFF
--- a/backend/src/models/Rack.js
+++ b/backend/src/models/Rack.js
@@ -68,13 +68,10 @@ const rackSchema = new mongoose.Schema({
 
 rackSchema.index({ cellar: 1, name: 1 }, { unique: true, partialFilterExpression: { deletedAt: null } });
 rackSchema.index({ rfidTag: 1 }, { unique: true, sparse: true });
-// NOTE: no TTL auto-purge of soft-deleted racks. The previous index used
-// partialFilterExpression { deletedAt: { $ne: null } }, which MongoDB rejects
-// ($ne is unsupported in partial indexes), so syncIndexes failed every boot
-// and the index never existed — the purge has never actually run. Re-adding it
-// needs (a) the supported predicate { deletedAt: { $type: 'date' } } AND (b) a
-// cascade that clears bottle rack references first, or TTL deletion would
-// orphan them (see CODE_AUDIT — same class as the cellar-purge finding).
+// NOTE: no TTL index for purging soft-deleted racks — a TTL delete can't run
+// the required cascade. The 30-day purge is done by the daily retention job
+// (services/cellarRetentionJob.js), which also frees rfidTags still held by
+// soft-deleted racks (the unique index above has no deletedAt filter).
 
 module.exports = mongoose.model('Rack', rackSchema);
 module.exports.RACK_TYPES = RACK_TYPES;

--- a/backend/src/routes/admin/cellars.js
+++ b/backend/src/routes/admin/cellars.js
@@ -2,8 +2,7 @@ const express = require('express');
 const { requireAuth, requireRole } = require('../../middleware/auth');
 const Cellar = require('../../models/Cellar');
 const Rack = require('../../models/Rack');
-const Bottle = require('../../models/Bottle');
-const CellarLayout = require('../../models/CellarLayout');
+const { purgeCellarPermanently } = require('../../services/cellarPurge');
 const { logAudit } = require('../../services/audit');
 const { parsePagination } = require('../../utils/pagination');
 const { isValidId, coerceStringQuery } = require('../../utils/validation');
@@ -89,24 +88,17 @@ router.delete('/:id', async (req, res) => {
       return res.status(404).json({ error: 'Deleted cellar not found' });
     }
 
-    const [rackResult, bottleResult] = await Promise.all([
-      Rack.deleteMany({ cellar: cellar._id }),
-      Bottle.deleteMany({ cellar: cellar._id }),
-      // Hard-delete the 3D room layout here (the permanent path) so it isn't
-      // orphaned; the reversible soft-delete leaves it intact for restore.
-      CellarLayout.deleteMany({ cellar: cellar._id }),
-    ]);
-
-    await cellar.deleteOne();
+    // Full cascade (bottles + images + search docs + layout/snapshots/
+    // sessions/shares/wine lists) — shared with the 30-day retention job.
+    const counts = await purgeCellarPermanently(cellar._id);
 
     logAudit(req, 'cellar.permanent_delete', { cellarId: cellar._id }, {
       name: cellar.name,
       owner: cellar.user,
-      racksDeleted: rackResult.deletedCount,
-      bottlesDeleted: bottleResult.deletedCount,
+      ...counts,
     });
 
-    res.json({ deleted: true, racksDeleted: rackResult.deletedCount, bottlesDeleted: bottleResult.deletedCount });
+    res.json({ deleted: true, ...counts });
   } catch (error) {
     console.error('[admin/cellars] permanent delete error:', error);
     res.status(500).json({ error: 'Failed to permanently delete cellar' });

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -7,8 +7,6 @@ const User = require('../models/User');
 const AuditLog = require('../models/AuditLog');
 const BottleImage = require('../models/BottleImage');
 const WineDefinition = require('../models/WineDefinition');
-const WineList = require('../models/WineList');
-const { deleteLogoFilesFor } = require('../services/wineListLogos');
 const PendingShare = require('../models/PendingShare');
 const { getCellarRole } = require('../utils/cellarAccess');
 const { logAudit } = require('../services/audit');
@@ -1414,16 +1412,12 @@ router.delete('/:id', async (req, res) => {
     // Cascade soft-delete to all racks in this cellar
     await Rack.updateMany({ cellar: cellar._id }, { deletedAt: now });
 
-    // Delete wine lists for this cellar (hard delete — no soft-delete for
-    // wine lists). Unlink their uploaded logo files first: the docs hold the
-    // only references, and orphaned logos would stay publicly fetchable.
-    await deleteLogoFilesFor(WineList, { cellar: cellar._id });
-    await WineList.deleteMany({ cellar: cellar._id });
-
-    // The 3D room layout is intentionally NOT removed here: this is a
-    // reversible soft-delete (restorable for 30 days) and CellarLayout has no
-    // soft-delete, so deleting it would lose the user's rack arrangement on
-    // restore. It is hard-deleted on the permanent-delete path instead.
+    // Wine lists and the 3D room layout are intentionally NOT removed here:
+    // this is a reversible soft-delete (restorable for 30 days), so curated
+    // lists (incl. their logo files) and the rack arrangement must survive
+    // for restore. Both are hard-deleted by the permanent-delete cascade
+    // (services/cellarPurge.js) — and the public wine-list routes 404 while
+    // the cellar is soft-deleted, so nothing stays reachable meanwhile.
 
     // Bottles are preserved — they remain in history via their status field
 

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -222,7 +222,15 @@ router.put('/:id', async (req, res) => {
     logAudit(req, 'rack.update', { type: 'rack', id: rack._id });
     res.json({ rack });
   } catch (err) {
-    if (err.code === 11000) return res.status(409).json({ error: 'A rack with that name already exists in this cellar' });
+    if (err.code === 11000) {
+      // Two unique indexes can throw here — report the right conflict.
+      const isTagConflict = err.keyPattern?.rfidTag || /rfidTag/.test(err.message || '');
+      return res.status(409).json({
+        error: isTagConflict
+          ? 'That NFC tag is already linked to another rack. Unlink it there first.'
+          : 'A rack with that name already exists in this cellar'
+      });
+    }
     if (err.name === 'VersionError') {
       return res.status(409).json({ error: 'This rack was modified by another request. Please refresh and try again.' });
     }
@@ -248,6 +256,12 @@ router.delete('/:id', async (req, res) => {
     if (rack.slots.length > 0) {
       rack.slots = [];
     }
+
+    // Free the NFC tag: the unique rfidTag index has no deletedAt filter, so
+    // a tag left on a soft-deleted rack would block linking it to any new
+    // rack until the retention purge. (Restoring the cellar therefore brings
+    // the rack back without its tag — re-link via NFC settings.)
+    rack.rfidTag = undefined;
 
     rack.deletedAt = new Date();
     await rack.save();

--- a/backend/src/routes/wineListPublic.js
+++ b/backend/src/routes/wineListPublic.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const rateLimit = require('express-rate-limit');
 const WineList = require('../models/WineList');
+const Cellar = require('../models/Cellar');
 const { generateWineListPdf, buildSections } = require('../services/wineListPdf');
 const { loadWineMap } = require('../services/wineListData');
 const { rateLimitKey } = require('../utils/clientIp');
@@ -21,6 +22,14 @@ const publicPdfLimiter = rateLimit({
 
 router.use(publicPdfLimiter);
 
+// Wine lists survive their cellar's reversible soft-delete (restorable for
+// 30 days), but the public menu must go dark for that window — a deleted
+// cellar's list staying live would leak data the owner asked to remove.
+async function cellarIsActive(wineList) {
+  const cellar = await Cellar.findById(wineList.cellar).select('deletedAt').lean();
+  return !!cellar && !cellar.deletedAt;
+}
+
 // GET /api/wine-lists/public/:shareToken — published list as JSON for the
 // public web menu (/menu/:shareToken). Strips inventory data: guests see the
 // menu, not the stock counts.
@@ -31,6 +40,7 @@ router.get('/:shareToken', async (req, res) => {
       isPublished: true,
     }).lean();
     if (!wineList) return res.status(404).json({ error: 'Wine list not found or not published' });
+    if (!(await cellarIsActive(wineList))) return res.status(404).json({ error: 'Wine list not found or not published' });
 
     const wineMap = await loadWineMap(wineList);
     const sections = buildSections(wineList, wineMap).map(s => ({
@@ -83,6 +93,7 @@ router.get('/:shareToken/pdf', async (req, res) => {
       isPublished: true,
     });
     if (!wineList) return res.status(404).json({ error: 'Wine list not found or not published' });
+    if (!(await cellarIsActive(wineList))) return res.status(404).json({ error: 'Wine list not found or not published' });
 
     const wineMap = await loadWineMap(wineList);
 

--- a/backend/src/services/cellarPurge.js
+++ b/backend/src/services/cellarPurge.js
@@ -1,0 +1,78 @@
+/**
+ * Permanent cellar deletion — the single cascade used by BOTH the admin
+ * permanent-delete route and the 30-day retention job, so the two paths can
+ * never diverge.
+ *
+ * Cascade order matters:
+ *  - bottle ids are collected BEFORE deleteMany so their Meilisearch documents
+ *    (which carry the owner's free-text notes/location) can be removed — there
+ *    is no scheduled resync, so skipping this leaves ghost bottles in search
+ *    indefinitely (full-sync only runs against an empty index).
+ *  - image files are unlinked BEFORE their BottleImage docs are deleted (the
+ *    docs hold the only reference to the files on disk). Shared registry
+ *    images (assignedToWine) are kept — only their dead bottle ref is
+ *    detached — matching the userDataRegistry pattern.
+ *  - wine lists are deleted HERE, not on soft-delete: the soft delete is
+ *    reversible, so curated lists (and their uploaded logo files) must
+ *    survive until the retention window closes.
+ */
+const Bottle = require('../models/Bottle');
+const BottleImage = require('../models/BottleImage');
+const Rack = require('../models/Rack');
+const CellarLayout = require('../models/CellarLayout');
+const CellarValueSnapshot = require('../models/CellarValueSnapshot');
+const ImportSession = require('../models/ImportSession');
+const PendingShare = require('../models/PendingShare');
+const WineList = require('../models/WineList');
+const Cellar = require('../models/Cellar');
+const { deleteLogoFilesFor } = require('./wineListLogos');
+const { unlinkImageFiles } = require('./imageProcessor');
+const searchService = require('./search');
+
+/**
+ * Hard-delete a cellar and everything that only exists because of it.
+ * The caller is responsible for authorization and for verifying the cellar
+ * is soft-deleted; this function just executes the cascade.
+ *
+ * @param {import('mongoose').Types.ObjectId|string} cellarId
+ * @returns {{ racksDeleted: number, bottlesDeleted: number, imagesDeleted: number }}
+ */
+async function purgeCellarPermanently(cellarId) {
+  const bottleIds = await Bottle.find({ cellar: cellarId }).distinct('_id');
+
+  let imagesDeleted = 0;
+  if (bottleIds.length > 0) {
+    const own = await BottleImage.find({ bottle: { $in: bottleIds }, assignedToWine: { $ne: true } })
+      .select('originalUrl processedUrl').lean();
+    for (const img of own) await unlinkImageFiles(img);
+    const [delResult] = await Promise.all([
+      BottleImage.deleteMany({ bottle: { $in: bottleIds }, assignedToWine: { $ne: true } }),
+      BottleImage.updateMany({ bottle: { $in: bottleIds }, assignedToWine: true }, { $unset: { bottle: '' } }),
+    ]);
+    imagesDeleted = delResult.deletedCount;
+  }
+
+  await deleteLogoFilesFor(WineList, { cellar: cellarId });
+
+  const [rackResult, bottleResult] = await Promise.all([
+    Rack.deleteMany({ cellar: cellarId }),
+    Bottle.deleteMany({ cellar: cellarId }),
+    CellarLayout.deleteMany({ cellar: cellarId }),
+    CellarValueSnapshot.deleteMany({ cellar: cellarId }),
+    ImportSession.deleteMany({ cellar: cellarId }),
+    PendingShare.deleteMany({ cellar: cellarId }),
+    WineList.deleteMany({ cellar: cellarId }),
+  ]);
+
+  await searchService.removeBottles(bottleIds);
+
+  await Cellar.deleteOne({ _id: cellarId });
+
+  return {
+    racksDeleted: rackResult.deletedCount,
+    bottlesDeleted: bottleResult.deletedCount,
+    imagesDeleted,
+  };
+}
+
+module.exports = { purgeCellarPermanently };

--- a/backend/src/services/cellarRetentionJob.js
+++ b/backend/src/services/cellarRetentionJob.js
@@ -1,0 +1,62 @@
+/**
+ * 30-day retention purge for soft-deleted cellars and racks.
+ *
+ * The DELETE routes promise "data retained 30 days" — this job is what makes
+ * that true (GDPR storage limitation). Runs daily; hard-deletes:
+ *  - cellars soft-deleted more than RETENTION_DAYS ago, via the same
+ *    purgeCellarPermanently cascade the admin permanent-delete route uses
+ *  - individually soft-deleted racks (their cellar is still active) past the
+ *    same window — these have no restore path, only the retention grace
+ *
+ * It also frees NFC tags still held by soft-deleted racks inside the window:
+ * the unique index on rfidTag has no deletedAt filter, so a tag stays claimed
+ * by a deleted rack and can't be linked to a new one until the field is unset.
+ */
+const Cellar = require('../models/Cellar');
+const Rack = require('../models/Rack');
+const { purgeCellarPermanently } = require('./cellarPurge');
+const { logAudit } = require('./audit');
+
+const RETENTION_DAYS = 30;
+
+async function runCellarRetentionPurge() {
+  const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000);
+
+  // Free NFC tags on ALL soft-deleted racks (also self-heals racks deleted
+  // before the soft-delete route started unsetting the tag).
+  const tagResult = await Rack.updateMany(
+    { deletedAt: { $type: 'date' }, rfidTag: { $exists: true } },
+    { $unset: { rfidTag: '' } }
+  );
+
+  // Expired cellars — full cascade per cellar so a failure on one doesn't
+  // block the rest.
+  const expired = await Cellar.find({ deletedAt: { $type: 'date', $lt: cutoff } })
+    .select('name user deletedAt').lean();
+  let cellarsPurged = 0;
+  for (const cellar of expired) {
+    try {
+      const counts = await purgeCellarPermanently(cellar._id);
+      cellarsPurged++;
+      logAudit(null, 'cellar.retention_purge', { type: 'cellar', id: cellar._id, cellarId: cellar._id }, {
+        name: cellar.name,
+        owner: cellar.user,
+        deletedAt: cellar.deletedAt,
+        ...counts,
+      });
+    } catch (err) {
+      console.error(`[cellarRetention] purge failed for cellar ${cellar._id}:`, err);
+    }
+  }
+
+  // Expired individually-deleted racks (cellar-cascaded ones are gone above).
+  const rackResult = await Rack.deleteMany({ deletedAt: { $type: 'date', $lt: cutoff } });
+
+  if (cellarsPurged > 0 || rackResult.deletedCount > 0 || tagResult.modifiedCount > 0) {
+    console.log(`[cellarRetention] purged ${cellarsPurged} cellar(s), ${rackResult.deletedCount} rack(s); freed ${tagResult.modifiedCount} NFC tag(s)`);
+  }
+
+  return { cellarsPurged, racksPurged: rackResult.deletedCount, tagsFreed: tagResult.modifiedCount };
+}
+
+module.exports = { runCellarRetentionPurge, RETENTION_DAYS };

--- a/backend/src/services/scheduler.js
+++ b/backend/src/services/scheduler.js
@@ -3,6 +3,7 @@ const { runDrinkWindowCheck } = require('./drinkWindowNotifier');
 const { runCellarValueSnapshots } = require('./cellarValueSnapshotJob');
 const { runCommunityPriceAggregation } = require('./communityPriceJob');
 const { runUserDeletionJob } = require('./userDeletionJob');
+const { runCellarRetentionPurge } = require('./cellarRetentionJob');
 const { runSecurityAlertCheck } = require('./securityAlertJob');
 
 /**
@@ -51,6 +52,17 @@ function startScheduler() {
     }
   });
 
+  // Cellar/rack retention purge: daily at 04:00 UTC (after user deletion).
+  // Hard-deletes soft-deleted cellars/racks past the promised 30-day window.
+  cron.schedule('0 4 * * *', async () => {
+    console.log('[scheduler] Running cellar retention purge…');
+    try {
+      await runCellarRetentionPurge();
+    } catch (err) {
+      console.error('[scheduler] Cellar retention purge failed:', err);
+    }
+  });
+
   // Security spike check: every 15 minutes. Cheap audit-log query, emails
   // only when thresholds are crossed (with 4h cooldown per spike type).
   cron.schedule('*/15 * * * *', async () => {
@@ -62,7 +74,7 @@ function startScheduler() {
     }
   });
 
-  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, security-spike every 15 min)');
+  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, cellar-retention daily 04:00 UTC, security-spike every 15 min)');
 }
 
 module.exports = { startScheduler };


### PR DESCRIPTION
## Summary
Audit findings **MED #1, #2, #6, #7** (CODE_AUDIT_2026-07-08.md). The DELETE routes promised "data retained 30 days" but no purge job existed — deleted cellars, their bottles (incl. free-text notes), racks, and Meilisearch documents persisted forever (GDPR storage-limitation gap). The admin permanent-delete cascade was also incomplete, a reversible cellar delete irreversibly destroyed wine lists, and NFC tags on soft-deleted racks were locked forever behind a misleading error.

## Changes
- **`services/cellarPurge.js` (new)** — one shared permanent-delete cascade: bottles + their images (disk files unlinked first; shared registry images kept, bottle ref detached) + Meilisearch bottle docs + 3D layout + value snapshots + import sessions + pending shares + wine lists (incl. logo files). Used by **both** the admin permanent-delete route and the new job, so the two paths can't diverge.
- **`services/cellarRetentionJob.js` (new) + scheduler** — daily 04:00 UTC job: purges cellars/racks soft-deleted >30 days ago and frees NFC tags still held by soft-deleted racks (self-heals racks deleted before this fix).
- **`routes/racks.js`** — soft-delete now unsets `rfidTag` (the unique index has no `deletedAt` filter, so a deleted rack blocked its tag until a hard delete that never came); the E11000 handler now reports tag conflicts as *"That NFC tag is already linked to another rack"* instead of the bogus name-conflict message.
- **`routes/cellars.js` + `routes/wineListPublic.js`** — wine lists are no longer hard-deleted during the *reversible* soft delete; they survive for restore and are purged by the permanent cascade. While the cellar is soft-deleted, the public menu/PDF routes 404 so nothing stays reachable.

## Behavior notes
- Restoring a cellar now brings its wine lists back (previously lost forever). Racks restored via admin restore come back **without** their NFC tag (re-link via NFC settings) — a deliberate trade-off so tags are never blocked.
- First job run on prod will purge every cellar/rack already soft-deleted >30 days ago — this is the promised retention finally being enforced. Each purge writes a `cellar.retention_purge` audit entry (system actor).

## Testing
- `cd backend && npm test` — 823 passed; all touched modules smoke-required cleanly.

## docker-compose impact
None — backend-only, no env/compose changes; the job runs inside the existing backend container via node-cron. No prod compose edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)