### PR TITLE
fix: cap the GET /api/bottles fallback query at 10k documents

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -231,7 +231,17 @@ router.get('/', async (req, res) => {
 
     let query = Bottle.find(filter).populate(WINE_POPULATE_LIST);
     if (canSortInDb) query = query.sort({ [sortField]: sortDir });
-    if (canPaginateInDb) query = query.skip(skip).limit(limit);
+    if (canPaginateInDb) {
+      query = query.skip(skip).limit(limit);
+    } else {
+      // Fallback (text search / min-rating / maturity filters, or in-memory
+      // sorts) hydrates the set for in-memory processing — cap it like the
+      // cellars.js fallbacks so one request can't load an unbounded
+      // collection. When there's no DB sort to cap on, anchor on newest-added
+      // so the >10k slice is at least deterministic.
+      if (!canSortInDb) query = query.sort({ createdAt: -1 });
+      query = query.limit(10000);
+    }
     let bottles = await query.lean();
     let totalCount = canPaginateInDb ? await Bottle.countDocuments(filter) : null;
 


### PR DESCRIPTION
## Summary
Audit finding **MED #5** (CODE_AUDIT_2026-07-08.md): when `search`, `minRating`, or `maturity` filters — or an in-memory sort (`name`, `maturity`) — are active, `GET /api/bottles` loaded **every** active bottle across all owned cellars with a deep populate, per request. The equivalent fallback paths in `cellars.js` cap at 10,000 for exactly this reason; on the Bottles page this fires per search keystroke.

## Change
Add the same 10,000-document cap to the fallback path, anchored on the DB sort when one exists and on newest-added otherwise, so the over-cap slice is deterministic. Response semantics for collections under 10k bottles (virtually all users) are completely unchanged.

## Testing
- `cd backend && npm test` — 823 passed.

## docker-compose impact
None — backend-only, no env/compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)