### PR TITLE
fix: re-index bottle search docs after wine edit/merge and taxonomy renames

### DIFF
--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -104,8 +104,10 @@ router.put('/countries/:id', async (req, res) => {
       { name: country.name }
     );
 
-    // Resync search index if name changed (denormalized data)
-    if (name) searchService.fullSync();
+    // Resync search indexes if name changed (denormalized data). Bottle
+    // documents denormalize taxonomy names too — fullSync() alone rebuilds
+    // only the wines index, leaving cellar search matching the old name.
+    if (name) { searchService.fullSync(); searchService.fullSyncBottles(); }
 
     res.json({ country });
   } catch (error) {
@@ -292,8 +294,10 @@ router.put('/regions/:id', async (req, res) => {
       { name: region.name }
     );
 
-    // Resync search index if name changed (denormalized data)
-    if (name) searchService.fullSync();
+    // Resync search indexes if name changed (denormalized data). Bottle
+    // documents denormalize taxonomy names too — fullSync() alone rebuilds
+    // only the wines index, leaving cellar search matching the old name.
+    if (name) { searchService.fullSync(); searchService.fullSyncBottles(); }
 
     res.json({ region });
   } catch (error) {
@@ -420,8 +424,10 @@ router.put('/grapes/:id', async (req, res) => {
       { name: grape.name }
     );
 
-    // Resync search index if name changed (denormalized data)
-    if (name) searchService.fullSync();
+    // Resync search indexes if name changed (denormalized data). Bottle
+    // documents denormalize taxonomy names too — fullSync() alone rebuilds
+    // only the wines index, leaving cellar search matching the old name.
+    if (name) { searchService.fullSync(); searchService.fullSyncBottles(); }
 
     res.json({ grape });
   } catch (error) {

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -634,8 +634,18 @@ router.put('/:id', async (req, res) => {
     await wine.save();
     await wine.populate(['country', 'region', 'grapes']);
 
-    // Sync to search index (fire-and-forget)
+    // Sync to search index (fire-and-forget). Bottle documents denormalize
+    // wineName/producer/country/region/grape names — without re-indexing
+    // them, cellar search keeps matching the old values indefinitely (no
+    // scheduled resync exists; full-sync only runs on an empty index).
     searchService.indexWine(wine._id);
+    if (name !== undefined || producer !== undefined || country !== undefined ||
+        region !== undefined || appellation !== undefined || grapes !== undefined ||
+        type !== undefined) {
+      Bottle.distinct('_id', { wineDefinition: wine._id })
+        .then(ids => searchService.bulkIndexBottles(ids))
+        .catch(err => console.error('Bottle re-index after wine update failed:', err.message));
+    }
 
     logAudit(req, 'admin.wine.update',
       { type: 'wine', id: wine._id },
@@ -1171,6 +1181,14 @@ router.post('/merge', async (req, res) => {
       searchService.removeWine(src._id.toString());
     }
     searchService.indexWine(keeper._id.toString());
+
+    // Re-index the keeper's bottles: reassignWineRefs re-pointed the sources'
+    // bottles, but their search documents still carry the DELETED source
+    // wine's denormalized name/producer/taxonomy — without this, cellar
+    // search keeps matching/faceting them under the old wine forever.
+    Bottle.distinct('_id', { wineDefinition: keeperOid })
+      .then(ids => searchService.bulkIndexBottles(ids))
+      .catch(err => console.error('Bottle re-index after merge failed:', err.message));
 
     // Re-embed the keeper's vintages so semantic search reflects the merged wine.
     reembedKeeper(keeper._id);


### PR DESCRIPTION
## Summary
Audit finding **MED #4** (CODE_AUDIT_2026-07-08.md): bottle documents in Meilisearch denormalize `wineName`, `producer`, country/region names and grape names, but nothing refreshed them after registry-side changes. After a wine **merge** (bottles re-pointed at the keeper, source deleted), cellar search kept matching and faceting the moved bottles under the deleted wine's name **forever** — there is no scheduled resync, and full-sync only runs against an empty index. Wine **edits** had the same staleness, and taxonomy **renames** called `fullSync()`, which rebuilds only the wines index.

## Changes
- **Wine update** (`PUT /api/admin/wines/:id`): when any denormalized field changed (name/producer/country/region/appellation/grapes/type), bulk re-index that wine's bottles (fire-and-forget, matching the existing `indexWine` style).
- **Merge** (`POST /api/admin/wines/merge`): bulk re-index the keeper's bottles after `reassignWineRefs`.
- **Taxonomy renames** (country/region/grape): also run `fullSyncBottles()` — cursor-based and memory-safe; renames are rare admin operations.

Note: this branch touches different regions of `admin/wines.js` than #602 (wine-delete cascade); both are based on main and merge cleanly in either order.

## Testing
- `cd backend && npm test` — 823 passed; both routers smoke-required cleanly.

## docker-compose impact
None — backend-only, no env/compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)