### PR TITLE
fix: frontend correctness batch — refresh race, sanitizer allowlist, price mirror, camera leak

### DIFF
--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -75,18 +75,31 @@ export const AuthProvider = ({ children }) => {
   // the access token expires) must therefore share one in-flight refresh.
   const refreshInFlightRef = useRef(null);
 
+  // The ref only guards THIS tab, but the refresh cookie is browser-wide and
+  // the backend stores a single rotating token hash — two tabs refreshing at
+  // once (typical after browser session-restore reopens several Cellarion
+  // tabs) race the rotation and the loser is spuriously logged out. The Web
+  // Locks API serializes across tabs of the same origin: the waiter re-runs
+  // with the cookie its predecessor just rotated in, which is valid.
+  const doRefresh = async () => {
+    const res = await fetch('/api/auth/refresh', {
+      method: 'POST',
+      credentials: 'include' // sends the httpOnly refresh cookie
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    storeToken(data.token);
+    return data.token;
+  };
+
   const handleRefresh = useCallback(() => {
     if (refreshInFlightRef.current) return refreshInFlightRef.current;
     refreshInFlightRef.current = (async () => {
       try {
-        const res = await fetch('/api/auth/refresh', {
-          method: 'POST',
-          credentials: 'include' // sends the httpOnly refresh cookie
-        });
-        if (!res.ok) return null;
-        const data = await res.json();
-        storeToken(data.token);
-        return data.token;
+        if (navigator.locks?.request) {
+          return await navigator.locks.request('cellarion-token-refresh', doRefresh);
+        }
+        return await doRefresh(); // pre-Web-Locks browsers: per-tab guard only
       } catch {
         return null;
       } finally {
@@ -94,6 +107,7 @@ export const AuthProvider = ({ children }) => {
       }
     })();
     return refreshInFlightRef.current;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // ------------------------------------------------------------------

--- a/frontend/src/hooks/useLabelScanner.js
+++ b/frontend/src/hooks/useLabelScanner.js
@@ -26,7 +26,14 @@ export default function useLabelScanner(apiFetch, { onScanSuccess, onScanError }
   onSuccessRef.current = onScanSuccess;
   onErrorRef.current = onScanError;
 
+  // Mirrors PhotoCapture/ImageUpload's cameraOpenRef guard: getUserMedia can
+  // resolve AFTER the user dismissed the viewfinder (the permission prompt
+  // was up) — without the check the just-acquired stream is stored but never
+  // stopped and the camera light stays on until page unload.
+  const camOpenRef = useRef(false);
+
   const stopCamera = useCallback(() => {
+    camOpenRef.current = false;
     if (labelStreamRef.current) {
       labelStreamRef.current.getTracks().forEach(t => t.stop());
       labelStreamRef.current = null;
@@ -36,11 +43,18 @@ export default function useLabelScanner(apiFetch, { onScanSuccess, onScanError }
 
   const startCamera = useCallback(async () => {
     setLabelCam({ open: true, error: null });
+    camOpenRef.current = true;
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: { facingMode: labelFacing, width: { ideal: 1280 }, height: { ideal: 720 } },
         audio: false
       });
+      if (!camOpenRef.current) {
+        stream.getTracks().forEach(t => t.stop());
+        return;
+      }
+      // Replace (never leak) a previous stream, e.g. after a camera switch.
+      if (labelStreamRef.current) labelStreamRef.current.getTracks().forEach(t => t.stop());
       labelStreamRef.current = stream;
       requestAnimationFrame(() => {
         if (labelVideoRef.current) labelVideoRef.current.srcObject = stream;

--- a/frontend/src/utils/priceValidation.js
+++ b/frontend/src/utils/priceValidation.js
@@ -19,7 +19,15 @@ export const ABSOLUTE_CAP = {
 
 export const USER_MEDIAN_MULTIPLE   = 50;
 export const MARKET_MEDIAN_MULTIPLE = 5;
-export const CENTS_HEURISTIC_FLOOR  = 10000;
+// Cents-heuristic floor is derived PER CURRENCY (cap ÷ divisor, never below
+// the minimum) — a flat 10,000 floor made ordinary JPY (>¥10k ≈ $66) and SEK
+// bottles constantly trip the "did you mean ÷100?" hint. Mirrors the backend.
+export const CENTS_HEURISTIC_FLOOR       = 10000;
+export const CENTS_HEURISTIC_CAP_DIVISOR = 5;
+
+export function centsHeuristicFloor(cap) {
+  return Math.max(CENTS_HEURISTIC_FLOOR, cap / CENTS_HEURISTIC_CAP_DIVISOR);
+}
 
 /**
  * Pure function — same signature as the backend so the two can never drift
@@ -67,7 +75,7 @@ export function validatePriceSanity({
     }
   }
 
-  if (price >= CENTS_HEURISTIC_FLOOR && price % 100 === 0) {
+  if (price >= centsHeuristicFloor(cap) && price % 100 === 0) {
     warnings.push({
       code: 'possiblyCents',
       severity: 'info',

--- a/frontend/src/utils/priceValidation.test.js
+++ b/frontend/src/utils/priceValidation.test.js
@@ -1,0 +1,37 @@
+import { validatePriceSanity, centsHeuristicFloor, ABSOLUTE_CAP } from './priceValidation';
+
+const codes = (warnings) => warnings.map(w => w.code);
+
+describe('centsHeuristicFloor', () => {
+  it('is the legacy 10,000 for USD/EUR-magnitude currencies', () => {
+    expect(centsHeuristicFloor(ABSOLUTE_CAP.USD)).toBe(10000);
+    expect(centsHeuristicFloor(ABSOLUTE_CAP.EUR)).toBe(10000);
+  });
+
+  it('scales with the currency cap for high-denomination currencies', () => {
+    expect(centsHeuristicFloor(ABSOLUTE_CAP.SEK)).toBe(100000);
+    expect(centsHeuristicFloor(ABSOLUTE_CAP.JPY)).toBe(1500000);
+  });
+});
+
+describe('validatePriceSanity cents heuristic (per-currency floor)', () => {
+  it('still flags a round USD price at 10,000+', () => {
+    expect(codes(validatePriceSanity({ price: 10000, currency: 'USD' }))).toContain('possiblyCents');
+  });
+
+  it('no longer flags ordinary SEK and JPY prices the backend accepts', () => {
+    // Regression: the flat 10,000 floor tripped on every round SEK >= 10 000 kr
+    // and JPY >= ¥10,000 while the backend (fixed first) stayed silent.
+    expect(codes(validatePriceSanity({ price: 12000, currency: 'SEK' }))).not.toContain('possiblyCents');
+    expect(codes(validatePriceSanity({ price: 50000, currency: 'JPY' }))).not.toContain('possiblyCents');
+  });
+
+  it('flags SEK/JPY prices above their scaled floors', () => {
+    expect(codes(validatePriceSanity({ price: 100000, currency: 'SEK' }))).toContain('possiblyCents');
+    expect(codes(validatePriceSanity({ price: 1500000, currency: 'JPY' }))).toContain('possiblyCents');
+  });
+
+  it('keeps the absolute-cap warning independent of the cents floor', () => {
+    expect(codes(validatePriceSanity({ price: 600000, currency: 'SEK' }))).toContain('absoluteCap');
+  });
+});

--- a/frontend/src/utils/sanitizeForumRender.js
+++ b/frontend/src/utils/sanitizeForumRender.js
@@ -11,10 +11,16 @@ import DOMPurify from 'dompurify';
 const ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 's', 'u', 'blockquote', 'ul', 'ol', 'li', 'a'];
 const ALLOWED_ATTR = ['href', 'title', 'target', 'rel'];
 
+// Dedicated DOMPurify instance: the link-policy hook below is forum policy
+// (forced target=_blank + nofollow). Registering it on the shared singleton
+// would leak it into every other DOMPurify consumer (e.g. BlogPost, where
+// nofollow on internal links is SEO-hostile) depending on module load order.
+const forumPurify = DOMPurify(window);
+
 // Hook: enforce safe link targets. The backend already does this on save
 // (sanitize-html simpleTransform), but we set it again here so any link that
 // somehow bypassed the backend still gets the safety attrs at render time.
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+forumPurify.addHook('afterSanitizeAttributes', (node) => {
   if (node.tagName === 'A') {
     node.setAttribute('target', '_blank');
     node.setAttribute('rel', 'noopener noreferrer nofollow');
@@ -25,14 +31,17 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
  * Sanitize HTML for safe `dangerouslySetInnerHTML` rendering. Returns the
  * cleaned HTML string. Use exclusively with content authored through the
  * DiscussionComposer — never with arbitrary user input from elsewhere.
+ *
+ * No USE_PROFILES here: DOMPurify documents that USE_PROFILES REPLACES an
+ * explicit ALLOWED_TAGS/ALLOWED_ATTR config, which would silently disable
+ * this allowlist (the exact bug this comment is guarding against).
  */
 export function sanitizeForumRender(html) {
   if (typeof html !== 'string' || !html) return '';
-  return DOMPurify.sanitize(html, {
+  return forumPurify.sanitize(html, {
     ALLOWED_TAGS,
     ALLOWED_ATTR,
-    ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
-    USE_PROFILES: { html: true }
+    ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i
   });
 }
 
@@ -48,7 +57,7 @@ export function sanitizeForumRender(html) {
  */
 export function extractForumPlainText(html) {
   if (typeof html !== 'string' || !html) return '';
-  const stripped = DOMPurify.sanitize(html, { ALLOWED_TAGS: [], KEEP_CONTENT: true });
+  const stripped = forumPurify.sanitize(html, { ALLOWED_TAGS: [], KEEP_CONTENT: true });
   return stripped.replace(/\s+/g, ' ').trim();
 }
 

--- a/frontend/src/utils/sanitizeForumRender.test.js
+++ b/frontend/src/utils/sanitizeForumRender.test.js
@@ -1,0 +1,45 @@
+import { sanitizeForumRender, extractForumPlainText } from './sanitizeForumRender';
+
+describe('sanitizeForumRender', () => {
+  it('keeps allowlisted forum markup', () => {
+    const html = '<p>Hello <strong>world</strong> <em>wine</em></p><ul><li>one</li></ul>';
+    expect(sanitizeForumRender(html)).toBe(html);
+  });
+
+  it('strips HTML-profile tags outside the forum allowlist (img, h1, table)', () => {
+    // Regression: USE_PROFILES:{html:true} used to override ALLOWED_TAGS,
+    // letting any HTML-profile markup through the defense-in-depth layer.
+    const out = sanitizeForumRender('<h1>t</h1><img src="x.png"><table><tr><td>c</td></tr></table><p>ok</p>');
+    expect(out).not.toContain('<img');
+    expect(out).not.toContain('<h1');
+    expect(out).not.toContain('<table');
+    expect(out).toContain('<p>ok</p>');
+  });
+
+  it('strips non-allowlisted attributes (style, class)', () => {
+    const out = sanitizeForumRender('<p style="color:red" class="x">ok</p>');
+    expect(out).toBe('<p>ok</p>');
+  });
+
+  it('forces target=_blank and rel on links', () => {
+    const out = sanitizeForumRender('<a href="https://example.com">link</a>');
+    expect(out).toContain('target="_blank"');
+    expect(out).toContain('rel="noopener noreferrer nofollow"');
+  });
+
+  it('returns empty string for non-string input', () => {
+    expect(sanitizeForumRender(null)).toBe('');
+    expect(sanitizeForumRender(undefined)).toBe('');
+    expect(sanitizeForumRender(42)).toBe('');
+  });
+});
+
+describe('extractForumPlainText', () => {
+  it('strips all markup and collapses whitespace', () => {
+    expect(extractForumPlainText('<p>Hello  <strong>world</strong></p>\n<p>two</p>')).toBe('Hello world two');
+  });
+
+  it('handles malformed input safely', () => {
+    expect(extractForumPlainText('<script>alert(1)</script>ok')).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary
Four frontend MEDIUMs from CODE_AUDIT_2026-07-08.md (**MED #22, #23, #24, #25**), batched since each is small and independent.

## Changes
1. **Multi-tab token-refresh race (MED #22)** — `AuthContext` now serializes refreshes across tabs with the Web Locks API (`navigator.locks`). The existing single-flight ref only guarded one tab; the refresh cookie is browser-wide and the backend rotates a single token hash, so browser session-restore reopening several Cellarion tabs raced the rotation and spuriously logged out the losers. Waiters re-run with the cookie their predecessor rotated in, which is valid. Pre-Web-Locks browsers keep today's per-tab behavior.
2. **Inert forum sanitizer allowlist (MED #23)** — removed `USE_PROFILES: { html: true }`, which DOMPurify documents as *replacing* explicit `ALLOWED_TAGS`/`ALLOWED_ATTR` — the 11-tag defense-in-depth allowlist was never applied (any HTML-profile markup rendered). Also moved the forced `target=_blank`/`nofollow` link hook onto a dedicated DOMPurify instance so forum link policy stops leaking into BlogPost rendering (SEO-hostile `nofollow` on internal blog links, load-order dependent).
3. **priceValidation mirror drift (MED #24)** — ported the backend's per-currency `centsHeuristicFloor` into the frontend mirror. The flat 10,000 floor made AddBottle live-warn "looks like cents" on every round SEK ≥ 10 000 kr / JPY ≥ ¥10 000 price the backend (fixed in v1.67.7) accepts silently.
4. **Camera-stream leak (MED #25)** — `useLabelScanner` gets the `cameraOpenRef` race guard PhotoCapture/ImageUpload already have: dismissing the scan modal while the permission prompt was up stored the resolved stream without ever stopping it — camera light on until page unload.

## Testing
- `cd frontend && npm test` — **337 passed**, including two new suites: `sanitizeForumRender.test.js` (pins that `<img>/<h1>/<table>`/`style` are actually stripped — the exact regression) and `priceValidation.test.js` (pins the per-currency floor for USD/SEK/JPY).

## docker-compose impact
None — frontend-only; normal image rebuild on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)