### PR TITLE
fix: infra/env cleanup — dead JWT_EXPIRES_IN, missing compose env, vite proxy, nginx/rembg quick wins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,20 @@ MEILI_MASTER_KEY=change-me-to-a-strong-random-string
 
 # Optional overrides (defaults shown)
 # MONGO_URI=mongodb://mongo:27017/winecellar
-# JWT_EXPIRES_IN=7d
+# ACCESS_TOKEN_EXPIRES_IN=15m          # access-token TTL; sessions are refreshed via a rotating 30-day cookie
 # PORT=5000
 # FRONTEND_URL=http://localhost        # set to your domain in production, e.g. https://cellarion.app
+# BACKEND_URL=                         # absolute backend URL for server-rendered pages; defaults to FRONTEND_URL
 # MEILI_URL=http://meilisearch:7700
+# MEILI_SEARCH_KEY=                    # optional restricted Meilisearch search key (falls back to the master key)
 # REMBG_URL=http://rembg:5000
+# LOG_LEVEL=info                       # pino log level (fatal|error|warn|info|debug|trace)
+# AUDIT_TTL_DAYS=365                   # audit-log retention (TTL index)
+# VITE_SITE_URL=                       # BUILD-time: public site URL for canonical/SEO tags; empty = https://cellarion.app
+
+# IndexNow — optional. Instantly pings Bing/search engines when public content changes.
+# Generate a 32-char hex key; nginx proxies the /<key>.txt verification file to the backend.
+# INDEXNOW_KEY=
 
 # Anthropic — optional. If set, enables the "Scan label" camera button on the Add Bottle page,
 # and powers the AI cellar chat feature.

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Copy `.env.example` to `.env` in the project root and set the required values:
 | `JWT_SECRET` | **Yes** | — | Long random string for signing JWTs |
 | `MEILI_MASTER_KEY` | **Yes** | — | Long random string for Meilisearch auth |
 | `MONGO_URI` | No | `mongodb://mongo:27017/winecellar` | MongoDB connection |
-| `JWT_EXPIRES_IN` | No | `7d` | Token TTL |
+| `ACCESS_TOKEN_EXPIRES_IN` | No | `15m` | Access-token TTL (sessions refresh via a rotating 30-day cookie) |
 | `PORT` | No | `5000` | Backend port |
 | `FRONTEND_URL` | No | `http://localhost` | CORS origin — set to your domain in production |
 | `MEILI_URL` | No | `http://meilisearch:7700` | Meilisearch URL |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,11 +3,13 @@ MONGO_URI=mongodb://mongo:27017/winecellar
 
 # ── JWT Authentication ────────────────────────────────────────────────────────
 JWT_SECRET=dev-secret-change-me-in-production
-JWT_EXPIRES_IN=7d
+ACCESS_TOKEN_EXPIRES_IN=15m
 
 # ── Server ────────────────────────────────────────────────────────────────────
 PORT=5000
-FRONTEND_URL=http://localhost:3000
+# In the Docker setup nginx serves the app on port 80 — use http://localhost.
+# Only bare-metal `npm start` dev serves the frontend on :3000.
+FRONTEND_URL=http://localhost
 BACKEND_URL=http://localhost:5000
 
 # ── Search (Meilisearch) ─────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,12 +62,17 @@ services:
     environment:
       - MONGO_URI=mongodb://mongo:27017/winecellar
       - JWT_SECRET=${JWT_SECRET}
-      - JWT_EXPIRES_IN=7d
+      - ACCESS_TOKEN_EXPIRES_IN=${ACCESS_TOKEN_EXPIRES_IN:-15m}
       - PORT=5000
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost}
+      - BACKEND_URL=${BACKEND_URL:-}
       - MEILI_URL=http://meilisearch:7700
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
+      - MEILI_SEARCH_KEY=${MEILI_SEARCH_KEY:-}
       - REMBG_URL=http://rembg:5000
+      - LOG_LEVEL=${LOG_LEVEL:-}
+      - AUDIT_TTL_DAYS=${AUDIT_TTL_DAYS:-}
+      - INDEXNOW_KEY=${INDEXNOW_KEY:-}
       - MAILGUN_API_KEY=${MAILGUN_API_KEY:-}
       - MAILGUN_DOMAIN=${MAILGUN_DOMAIN:-}
       - MAILGUN_FROM=${MAILGUN_FROM:-}
@@ -129,6 +134,7 @@ services:
         APP_VERSION: ${APP_VERSION:-dev}
         VITE_UMAMI_URL: ${VITE_UMAMI_URL:-}
         VITE_UMAMI_WEBSITE_ID: ${VITE_UMAMI_WEBSITE_ID:-}
+        VITE_SITE_URL: ${VITE_SITE_URL:-}
     container_name: cellarion-frontend
     restart: unless-stopped
     deploy:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,5 +1,5 @@
 node_modules
-build
+dist
 .env
 .env.*
 *.test.js

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,8 +16,12 @@ ARG APP_VERSION=
 # injects the tracker script. Empty values are a no-op (no script, no CSP impact).
 ARG VITE_UMAMI_URL=
 ARG VITE_UMAMI_WEBSITE_ID=
+# Public site URL baked into canonical/SEO meta tags (config/siteUrl.js).
+# Empty falls back to https://cellarion.app — self-hosters set their own domain.
+ARG VITE_SITE_URL=
 ENV VITE_UMAMI_URL=$VITE_UMAMI_URL \
-    VITE_UMAMI_WEBSITE_ID=$VITE_UMAMI_WEBSITE_ID
+    VITE_UMAMI_WEBSITE_ID=$VITE_UMAMI_WEBSITE_ID \
+    VITE_SITE_URL=$VITE_SITE_URL
 
 RUN npm run build
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -121,16 +121,6 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
-    # Wine detail pages — slug form
-    location ~ "^/wines/([a-z0-9]+(?:-[a-z0-9]+)*)$" {
-        error_page 418 = @wine_og;
-        if ($is_crawler) {
-            return 418;
-        }
-        root       /usr/share/nginx/html;
-        try_files  /index.html =404;
-    }
-
     # Wine type pages — /wines/type/<type>
     location ~ "^/wines/type/[a-z]+$" {
         error_page 418 = @wine_type_og;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,7 +11,10 @@ export default defineConfig({
     port: 3000,
     host: true,
     proxy: {
-      '/api': 'http://backend:5000',
+      // Bare-metal dev: the backend publishes localhost:5000 (also via the
+      // compose override). Override with BACKEND_PROXY when the backend runs
+      // elsewhere, e.g. BACKEND_PROXY=http://backend:5000 inside a container.
+      '/api': process.env.BACKEND_PROXY || 'http://localhost:5000',
     },
   },
   build: {

--- a/rembg/requirements.txt
+++ b/rembg/requirements.txt
@@ -1,4 +1,7 @@
 flask==3.1.3
 rembg[cpu]==2.0.75
 pillow>=10.0.0
+# app.py imports numpy directly (transparency pre-check) — pin it explicitly
+# instead of relying on it staying a transitive dependency of rembg.
+numpy>=1.26,<3
 gunicorn==22.0.0


### PR DESCRIPTION
## Summary
Infra/docs findings from CODE_AUDIT_2026-07-08.md (**MED #40, #41, #42, #44** + three infra LOWs).

## Changes
- **Dead `JWT_EXPIRES_IN` removed everywhere** (compose, both `.env.example`s, README) — grep-verified nothing reads it. The real knob, `ACCESS_TOKEN_EXPIRES_IN` (default `15m`, `auth.js:100`), is now forwarded by compose and documented.
- **Compose now forwards `INDEXNOW_KEY`, `LOG_LEVEL`, `AUDIT_TTL_DAYS`, `BACKEND_URL`, `MEILI_SEARCH_KEY`** — all read by backend code (nginx even ships a dedicated IndexNow proxy location), but setting them in `.env` had no effect in the shipped compose. Root `.env.example` documents them; `backend/.env.example` aligned (its `FRONTEND_URL=http://localhost:3000` was wrong for the Docker setup).
- **`VITE_SITE_URL` build arg** (Dockerfile + compose + `.env.example`) — self-hosted instances no longer bake `cellarion.app` canonical/SEO URLs into their frontend build; empty keeps today's default.
- **Vite dev proxy** now defaults to `http://localhost:5000` (the documented bare-metal `npm start` flow got ENOTFOUND on the compose-only `backend` hostname); `BACKEND_PROXY` env overrides for anyone running the dev server inside a container.
- **Quick wins:** removed nginx.conf's byte-identical duplicate wine-slug `location` block (unreachable — first regex match wins); `frontend/.dockerignore` now ignores Vite's `dist/` instead of CRA's `build/`; rembg pins `numpy` explicitly (app.py imports it directly, previously only a transitive dep).

## Testing
- `docker compose config --quiet` parses clean.
- `cd frontend && npm test` — 324 passed (vitest reads vite.config.js).

## docker-compose impact
**This PR edits the repo docker-compose.yml** (new backend env passthroughs, `VITE_SITE_URL` build arg, `JWT_EXPIRES_IN` dropped). All new vars default to empty/current behavior, so existing `.env` files keep working unchanged. **The hand-maintained prod compose** should get the same treatment when convenient: drop `JWT_EXPIRES_IN`, and add the five backend env passthroughs if you want to use them (prod already sets some directly). Nothing breaks if it's left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)