### PR TITLE
fix: surface fetch/mutation errors instead of dead-ending pages and forms

### DIFF
--- a/frontend/src/pages/CellarChat.js
+++ b/frontend/src/pages/CellarChat.js
@@ -252,8 +252,13 @@ export default function CellarChat() {
       if (!res.ok) {
         setMessages(prev => prev.filter(m => !m.thinking));
         setError(data.error || 'Something went wrong.');
-        if (res.status === 429) {
-          setUsage(prev => prev ? { ...prev, used: prev.limit } : null);
+        // Two kinds of 429: the daily/period quota carries used/limit in its
+        // body; the per-minute burst limiter doesn't. Only lock the composer
+        // for a real quota exhaustion — burst 429s just show the error above.
+        if (res.status === 429 && data.limit != null && data.used != null) {
+          setUsage(prev => prev
+            ? { ...prev, used: Math.max(data.used, data.limit), limit: data.limit, period: data.period || prev.period }
+            : null);
         }
         return;
       }

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -125,6 +125,7 @@ function CellarDetail() {
 
   const fetchCellarData = async (skip) => {
     const seq = ++fetchSeq.current;
+    setError(null);
     try {
       if (skip > 0) setBottlesLoading(true);
       const params = new URLSearchParams();
@@ -217,7 +218,9 @@ function CellarDetail() {
 
   const canEdit = cellar?.userRole === 'owner' || cellar?.userRole === 'editor';
 
-  if (error) return <div className="alert alert-error">{error}</div>;
+  // Only replace the whole page when we have nothing to show yet; once the
+  // cellar is loaded, transient fetch failures render as an inline banner.
+  if (error && !cellar) return <div className="alert alert-error">{error}</div>;
 
   const h1Style = cellar?.userColor
     ? { '--cellar-color': cellar.userColor }
@@ -226,6 +229,19 @@ function CellarDetail() {
 
   return (
     <div className="cellar-detail-page">
+      {error && (
+        <div className="alert alert-error" role="alert">
+          {error}
+          <button
+            type="button"
+            className="btn btn-small btn-secondary"
+            style={{ marginLeft: '0.75rem' }}
+            onClick={() => setError(null)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
       {/* ── Header — shell renders immediately, details fill in after load ── */}
       <div className="cellar-header">
         <div className="cellar-header-top">

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -83,6 +83,7 @@ function CellarHistory() {
 
   const fetchHistory = async () => {
     const seq = ++fetchSeq.current;
+    setError(null);
     try {
       const params = new URLSearchParams();
       if (debouncedSearch) params.append('search', debouncedSearch);
@@ -125,7 +126,10 @@ function CellarHistory() {
     }
   };
 
-  if (error) return <div className="alert alert-error">{error}</div>;
+  // Only replace the whole page when nothing has loaded yet; after a successful
+  // load, transient fetch failures render as an inline banner instead.
+  const hasLoadedContent = Object.keys(grouped).length > 0;
+  if (error && !hasLoadedContent) return <div className="alert alert-error">{error}</div>;
 
   const REASON_LABEL_KEYS = {
     drank:  'history.reasonDrank',
@@ -166,6 +170,19 @@ function CellarHistory() {
 
   return (
     <div className="cellar-history-page">
+      {error && (
+        <div className="alert alert-error" role="alert">
+          {error}
+          <button
+            type="button"
+            className="btn btn-small btn-secondary"
+            style={{ marginLeft: '0.75rem' }}
+            onClick={() => setError(null)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
       <div className="history-header">
         <Link to={`/cellars/${id}`} className="back-link">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"/></svg>

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -254,31 +254,43 @@ function CellarRacks() {
   // --- soft-remove bottle via the shared consume endpoint ---
   const handleConsumeSubmit = async (reason, note, rating, consumedRatingScale) => {
     const { bottleId } = consumeModal;
-    const res = await consumeBottle(apiFetch, bottleId, { reason, note, rating, consumedRatingScale });
-    const data = await res.json();
-    if (res.ok) {
-      // Server already cleared the rack slot; update local racks state
-      setRacks(prev => prev.map(r => ({
-        ...r,
-        slots: r.slots.filter(s => {
-          const bid = s.bottle?._id || s.bottle;
-          return bid?.toString() !== bottleId;
-        })
-      })));
-      setConsumeModal(null);
-    } else {
-      alert(data.error || 'Failed to remove bottle');
+    try {
+      const res = await consumeBottle(apiFetch, bottleId, { reason, note, rating, consumedRatingScale });
+      const data = await res.json();
+      if (res.ok) {
+        // Server already cleared the rack slot; update local racks state
+        setRacks(prev => prev.map(r => ({
+          ...r,
+          slots: r.slots.filter(s => {
+            const bid = s.bottle?._id || s.bottle;
+            return bid?.toString() !== bottleId;
+          })
+        })));
+        setConsumeModal(null);
+      } else {
+        alert(data.error || 'Failed to remove bottle');
+      }
+    } catch {
+      // Don't rethrow — ConsumeModal awaits this and must reach setSaving(false)
+      alert('Network error — please try again.');
     }
   };
 
   // --- NFC: save or clear rfidTag on rack ---
   const handleNfcSave = async (rackId, rfidTag) => {
-    const res = await updateRack(apiFetch, rackId, { rfidTag });
-    const data = await res.json();
-    if (res.ok) {
-      setRacks(racks.map(r => r._id === rackId ? { ...r, rfidTag: data.rack.rfidTag } : r));
+    try {
+      const res = await updateRack(apiFetch, rackId, { rfidTag });
+      const data = await res.json();
+      if (res.ok) {
+        setRacks(racks.map(r => r._id === rackId ? { ...r, rfidTag: data.rack.rfidTag } : r));
+        setNfcModal(null);
+      } else {
+        // Keep the modal open so the user can retry instead of silently losing the tag
+        alert(data.error || 'Failed to save NFC tag');
+      }
+    } catch {
+      alert('Network error — please try again.');
     }
-    setNfcModal(null);
   };
 
   if (error) return <div className="alert alert-error">{error}</div>;
@@ -908,8 +920,13 @@ function ConsumeModal({ defaultRatingScale, onSubmit, onCancel }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSaving(true);
-    await onSubmit(reason, note || undefined, rating || undefined, ratingScale);
-    setSaving(false);
+    try {
+      await onSubmit(reason, note || undefined, rating || undefined, ratingScale);
+    } finally {
+      // Always re-enable the button — a rejected onSubmit must not leave the
+      // modal stuck on "Saving...".
+      setSaving(false);
+    }
   };
 
   return (

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -853,11 +853,17 @@ export default function CellarRoom() {
   const handleAssignBottle = useCallback(async (bottleId) => {
     if (!emptySlotTarget) return;
     const { rackId, position } = emptySlotTarget;
-    const res = await updateSlot(apiFetch, rackId, position, { bottleId });
-    const data = await res.json();
-    if (res.ok) {
-      setRacks(prev => prev.map(r => r._id === rackId ? data.rack : r));
-      setEmptySlotTarget(null);
+    try {
+      const res = await updateSlot(apiFetch, rackId, position, { bottleId });
+      const data = await res.json();
+      if (res.ok) {
+        setRacks(prev => prev.map(r => r._id === rackId ? data.rack : r));
+        setEmptySlotTarget(null);
+      } else {
+        alert(data.error || 'Failed to assign');
+      }
+    } catch {
+      alert('Network error — please try again.');
     }
   }, [emptySlotTarget, apiFetch]);
 
@@ -865,31 +871,43 @@ export default function CellarRoom() {
   const handleRemoveFromRack = useCallback(async () => {
     if (!selectedBottle) return;
     const { rackId, slot } = selectedBottle;
-    const res = await clearSlot(apiFetch, rackId, slot.position);
-    const data = await res.json();
-    if (res.ok) {
-      setRacks(prev => prev.map(r => r._id === rackId ? data.rack : r));
-      setSelectedBottle(null);
+    try {
+      const res = await clearSlot(apiFetch, rackId, slot.position);
+      const data = await res.json();
+      if (res.ok) {
+        setRacks(prev => prev.map(r => r._id === rackId ? data.rack : r));
+        setSelectedBottle(null);
+      } else {
+        alert(data.error || 'Failed to remove bottle');
+      }
+    } catch {
+      alert('Network error — please try again.');
     }
   }, [selectedBottle, apiFetch]);
 
   // Consume bottle
   const handleConsumeSubmit = useCallback(async (reason, note, rating, ratingScale) => {
     if (!consumeModal) return;
-    const res = await consumeBottle(apiFetch, consumeModal.bottleId, {
-      reason, note, rating, consumedRatingScale: ratingScale,
-    });
-    const data = await res.json();
-    if (res.ok) {
-      setRacks(prev => prev.map(r => ({
-        ...r,
-        slots: r.slots.filter(s => {
-          const bid = s.bottle?._id || s.bottle;
-          return bid?.toString() !== consumeModal.bottleId;
-        }),
-      })));
-      setConsumeModal(null);
-      setSelectedBottle(null);
+    try {
+      const res = await consumeBottle(apiFetch, consumeModal.bottleId, {
+        reason, note, rating, consumedRatingScale: ratingScale,
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setRacks(prev => prev.map(r => ({
+          ...r,
+          slots: r.slots.filter(s => {
+            const bid = s.bottle?._id || s.bottle;
+            return bid?.toString() !== consumeModal.bottleId;
+          }),
+        })));
+        setConsumeModal(null);
+        setSelectedBottle(null);
+      } else {
+        alert(data.error || 'Failed to remove bottle');
+      }
+    } catch {
+      alert('Network error — please try again.');
     }
   }, [consumeModal, apiFetch]);
 
@@ -1447,8 +1465,13 @@ function RoomConsumeForm({ onSubmit, onCancel, defaultRatingScale, t }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSaving(true);
-    await onSubmit(reason, note || undefined, rating || undefined, ratingScale);
-    setSaving(false);
+    try {
+      await onSubmit(reason, note || undefined, rating || undefined, ratingScale);
+    } finally {
+      // Always re-enable the button — a rejected onSubmit must not leave the
+      // form stuck on "Saving...".
+      setSaving(false);
+    }
   };
 
   return (

--- a/frontend/src/pages/CountryDetail.js
+++ b/frontend/src/pages/CountryDetail.js
@@ -26,6 +26,7 @@ export default function CountryDetail() {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setError(null);
     fetch(`${API_URL}/api/taxonomy/countries/${encodeURIComponent(slug)}?limit=${limit}&offset=${(page - 1) * limit}`)
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then(d => { if (!cancelled) { setData(d); setLoading(false); } })

--- a/frontend/src/pages/GrapeDetail.js
+++ b/frontend/src/pages/GrapeDetail.js
@@ -26,6 +26,7 @@ export default function GrapeDetail() {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setError(null);
     fetch(`${API_URL}/api/taxonomy/grapes/${encodeURIComponent(slug)}?limit=${limit}&offset=${(page - 1) * limit}`)
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then(d => { if (!cancelled) { setData(d); setLoading(false); } })

--- a/frontend/src/pages/RegionDetail.js
+++ b/frontend/src/pages/RegionDetail.js
@@ -26,6 +26,7 @@ export default function RegionDetail() {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setError(null);
     fetch(`${API_URL}/api/taxonomy/regions/${encodeURIComponent(slug)}?limit=${limit}&offset=${(page - 1) * limit}`)
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then(d => { if (!cancelled) { setData(d); setLoading(false); } })

--- a/frontend/src/pages/WineTypeDetail.js
+++ b/frontend/src/pages/WineTypeDetail.js
@@ -35,6 +35,7 @@ export default function WineTypeDetail() {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setError(null);
     fetch(`${API_URL}/api/taxonomy/wine-types/${encodeURIComponent(type)}?limit=${limit}&offset=${(page - 1) * limit}`)
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
       .then(d => { if (!cancelled) { setData(d); setLoading(false); } })


### PR DESCRIPTION
Implements four verified findings from CODE_AUDIT_2026-07-08.md (MED #29, #31, #32).

## Fixes

### 1. Transient fetch errors no longer permanently replace whole pages (MED #29)
- **CellarDetail / CellarHistory**: the fetch functions now clear `error` at the start of each fetch, and the `if (error) return` early-out only replaces the page when nothing has loaded yet. Once content exists, the error renders as a dismissible inline `alert alert-error` banner above the page — a single network blip during search typing or Load More no longer discards the rendered page forever.
- **GrapeDetail / RegionDetail / CountryDetail / WineTypeDetail**: the fetch effect now does `setError(null)` alongside `setLoading(true)`, so one failed fetch no longer shows "not found." forever after a later fetch succeeded.

### 2. CellarChat no longer treats every 429 as daily-quota exhaustion (MED #31)
The backend has two 429s: the per-minute burst limiter (no `used`/`limit` in body, `backend/src/routes/chat.js`) and the real daily quota (body carries `used`/`limit`/`period`). The composer is now only locked with "Daily limit reached" when the body actually carries `used`/`limit` (using those values); burst 429s just surface the error message.

### 3 & 4. CellarRoom / CellarRacks mutations no longer swallow failures or hang forms (MED #32)
- **CellarRoom**: `handleAssignBottle`, `handleRemoveFromRack`, `handleConsumeSubmit` now surface the backend `error` via `alert(data.error || '…')` (matching the CellarRacks pattern) and catch network failures; `RoomConsumeForm.handleSubmit` wraps `onSubmit` in try/finally so the Confirm button can't stick on "Saving...".
- **CellarRacks**: `handleConsumeSubmit` gets the same try/catch (and `ConsumeModal.handleSubmit` a try/finally); `handleNfcSave` now surfaces errors and keeps the modal open for retry instead of silently closing.

## Testing
- `cd frontend && npm test` — 13 test files, **337 tests, all passing**.
- All changed files syntax-checked (esbuild JSX parse); no hooks moved or made conditional — early returns remain after all hook calls.

## docker-compose impact
None — frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)