### PR TITLE
fix: backend MED batch — privacy guard, sitemap/discover perf, upload 4xx, import rating, default-image scope

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -742,14 +742,17 @@ router.put('/:id/default-image', requireBottleAccess('editor'), async (req, res)
       return res.json({ bottle });
     }
 
-    // Verify the image exists and belongs to this bottle or its wine definition
-    const image = await BottleImage.findOne({
-      _id: imageId,
-      $or: [
-        { bottle: bottle._id },
-        { wineDefinition: bottle.wineDefinition, status: 'approved' }
-      ]
-    });
+    // Verify the image exists and belongs to this bottle or its wine
+    // definition. Only add the wine clause when the bottle HAS a wine:
+    // BottleImage.wineDefinition defaults to null, so for a pending-request
+    // bottle (wineDefinition null) the clause would match ANY approved
+    // unattached image in the DB. Also require public visibility, matching
+    // the candidate list the UI offers (images.js /bottle/:bottleId).
+    const orClauses = [{ bottle: bottle._id }];
+    if (bottle.wineDefinition) {
+      orClauses.push({ wineDefinition: bottle.wineDefinition, status: 'approved', visibility: 'public' });
+    }
+    const image = await BottleImage.findOne({ _id: imageId, $or: orClauses });
 
     if (!image) {
       return res.status(404).json({ error: 'Image not found or not associated with this bottle' });

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -742,6 +742,14 @@ router.put('/:id/default-image', requireBottleAccess('editor'), async (req, res)
       return res.json({ bottle });
     }
 
+    // Cast the user-provided id to a real ObjectId before it touches the
+    // query (a junk string would otherwise throw a CastError → 500; the cast
+    // also clears the user-input-in-query taint for static analysis).
+    if (!mongoose.isValidObjectId(imageId)) {
+      return res.status(400).json({ error: 'Invalid image ID' });
+    }
+    const imageOid = new mongoose.Types.ObjectId(String(imageId));
+
     // Verify the image exists and belongs to this bottle or its wine
     // definition. Only add the wine clause when the bottle HAS a wine:
     // BottleImage.wineDefinition defaults to null, so for a pending-request
@@ -752,7 +760,7 @@ router.put('/:id/default-image', requireBottleAccess('editor'), async (req, res)
     if (bottle.wineDefinition) {
       orClauses.push({ wineDefinition: bottle.wineDefinition, status: 'approved', visibility: 'public' });
     }
-    const image = await BottleImage.findOne({ _id: imageId, $or: orClauses });
+    const image = await BottleImage.findOne({ _id: imageOid, $or: orClauses });
 
     if (!image) {
       return res.status(404).json({ error: 'Image not found or not associated with this bottle' });

--- a/backend/src/routes/follows.js
+++ b/backend/src/routes/follows.js
@@ -81,10 +81,23 @@ router.delete('/:userId', async (req, res) => {
   }
 });
 
+// Respect profileVisibility: a private profile's social graph is only
+// viewable by its owner (mirrors GET /api/reviews/user/:userId).
+async function guardProfileVisibility(req, res) {
+  const isOwner = req.user && req.params.userId === req.user.id;
+  const targetUser = await User.findById(req.params.userId).select('profileVisibility');
+  if (!targetUser || (targetUser.profileVisibility !== 'public' && !isOwner)) {
+    res.status(404).json({ error: 'User not found' });
+    return false;
+  }
+  return true;
+}
+
 // GET /api/follows/:userId/followers - List followers
 router.get('/:userId/followers', async (req, res) => {
   try {
     if (!isValidId(req.params.userId)) return res.status(400).json({ error: 'Invalid user ID' });
+    if (!(await guardProfileVisibility(req, res))) return;
     const page = Math.max(1, parseInt(req.query.page, 10) || 1);
     const limit = Math.min(50, Math.max(1, parseInt(req.query.limit, 10) || 20));
     const skip = (page - 1) * limit;
@@ -121,6 +134,7 @@ router.get('/:userId/followers', async (req, res) => {
 router.get('/:userId/following', async (req, res) => {
   try {
     if (!isValidId(req.params.userId)) return res.status(400).json({ error: 'Invalid user ID' });
+    if (!(await guardProfileVisibility(req, res))) return;
     const page = Math.max(1, parseInt(req.query.page, 10) || 1);
     const limit = Math.min(50, Math.max(1, parseInt(req.query.limit, 10) || 20));
     const skip = (page - 1) * limit;

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -155,8 +155,22 @@ function getImageDimensions(filePath) {
 
 const router = express.Router();
 
+// Wrap multer so its errors become 4xx instead of bubbling to the central
+// handler, which returns 500 and masks the reason in production — the user
+// gets zero indication their photo was too big or the wrong format. Same
+// pattern as cellarImport.js's handleUpload.
+function handleImageUpload(req, res, next) {
+  upload.single('image')(req, res, (err) => {
+    if (err) {
+      if (err.code === 'LIMIT_FILE_SIZE') return res.status(413).json({ error: 'Image too large (max 10 MB)' });
+      return res.status(400).json({ error: err.message || 'Invalid image upload' });
+    }
+    next();
+  });
+}
+
 // POST /api/images/upload - Upload image for a bottle or wine definition
-router.post('/upload', requireAuth, imageUploadLimiter, upload.single('image'), async (req, res) => {
+router.post('/upload', requireAuth, imageUploadLimiter, handleImageUpload, async (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'No image file provided' });

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -618,6 +618,17 @@ router.post('/confirm', async (req, res) => {
             pendingRequestCache.set(requestKey, wineRequest);
           }
 
+          // Validate rating if provided — the frontend sends rating/ratingScale
+          // for request-wine rows too; dropping them here silently lost the
+          // user's rating on every imported bottle whose wine had to be
+          // requested (mirrors the matched-wine branch below).
+          const { rating: resolvedRating, ratingScale: resolvedScale, error: ratingError } =
+            resolveRating(item.rating, item.ratingScale);
+          if (ratingError) {
+            errors.push({ index: i, reason: ratingError });
+            continue;
+          }
+
           // Validate consumed rating if adding to history
           const { rating: resolvedConsumedRating, ratingScale: resolvedConsumedScale, error: consumeRatingError } =
             item.addToHistory ? resolveRating(item.consumedRating, item.consumedRatingScale) : { rating: undefined, ratingScale: undefined, error: null };
@@ -645,7 +656,9 @@ router.post('/confirm', async (req, res) => {
             purchaseDate: item.purchaseDate || undefined,
             purchaseLocation: stripHtml(item.purchaseLocation),
             location: stripHtml(item.location),
-            notes: stripHtml(item.notes)
+            notes: stripHtml(item.notes),
+            rating: resolvedRating,
+            ratingScale: resolvedScale
           });
 
           if (item.dateAdded) bottle.createdAt = new Date(item.dateAdded);

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -255,14 +255,29 @@ router.get('/feed', async (req, res) => {
   }
 });
 
+// Cache the public-profile id list: /discover runs on every ReviewFeed view
+// and this was a whole-users-collection scan (hydrated docs) per request.
+// Visibility toggles are rare; a briefly-stale discover feed is acceptable
+// (the reviews themselves are all visibility:'public' regardless).
+let publicIdsCache = null; // { at, ids }
+const PUBLIC_IDS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+async function getPublicUserIds() {
+  if (publicIdsCache && Date.now() - publicIdsCache.at < PUBLIC_IDS_CACHE_TTL_MS) {
+    return publicIdsCache.ids;
+  }
+  const users = await User.find({ profileVisibility: 'public' }).select('_id').lean();
+  const ids = users.map(u => u._id);
+  publicIdsCache = { at: Date.now(), ids };
+  return ids;
+}
+
 // GET /api/reviews/discover - All recent reviews from public profiles
 router.get('/discover', async (req, res) => {
   try {
     const { page, limit, offset: skip } = parsePagination(req.query, { limit: REVIEWS_PER_PAGE, maxLimit: REVIEWS_MAX_PER_PAGE });
 
-    // Find users with public profiles
-    const publicUsers = await User.find({ profileVisibility: 'public' }).select('_id');
-    const publicIds = publicUsers.map(u => u._id);
+    const publicIds = await getPublicUserIds();
 
     const discoverFilter = { author: { $in: publicIds }, visibility: 'public' };
     const [reviews, total] = await Promise.all([

--- a/backend/src/routes/sitemap.js
+++ b/backend/src/routes/sitemap.js
@@ -7,6 +7,7 @@ const Region = require('../models/Region');
 const Grape = require('../models/Grape');
 const Discussion = require('../models/Discussion');
 const { rateLimitKey } = require('../utils/clientIp');
+const { countWinesBy } = require('./taxonomy');
 
 const WINE_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
 const MIN_WINES = 3;
@@ -14,6 +15,12 @@ const MIN_WINES = 3;
 const router = express.Router();
 
 const SITE_URL = process.env.FRONTEND_URL || 'https://cellarion.app';
+
+// Server-side cache: crawlers ignore Cache-Control per-client, and building
+// the sitemap runs several registry-wide aggregations. Content changes slowly
+// (new wines/posts), so an hour-stale sitemap is fine.
+let sitemapCache = null; // { at, xml }
+const SITEMAP_CACHE_TTL_MS = 60 * 60 * 1000;
 
 const sitemapLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -26,6 +33,12 @@ const sitemapLimiter = rateLimit({
 // GET /sitemap.xml — Dynamic XML sitemap for search engines
 router.get('/', sitemapLimiter, async (req, res) => {
   try {
+    if (sitemapCache && Date.now() - sitemapCache.at < SITEMAP_CACHE_TTL_MS) {
+      res.set('Content-Type', 'application/xml');
+      res.set('Cache-Control', 'public, max-age=3600');
+      return res.send(sitemapCache.xml);
+    }
+
     const posts = await BlogPost.find({ status: 'published' })
       .sort({ publishedAt: -1 })
       .select('slug updatedAt publishedAt')
@@ -82,14 +95,20 @@ router.get('/', sitemapLimiter, async (req, res) => {
     // Taxonomy pages — only include entries that meet the minimum wine threshold
     // so we don't submit empty pages to search engines.
 
-    const [countries, regions, grapes] = await Promise.all([
+    // One aggregation per collection instead of one countDocuments per taxon
+    // (same helper the public taxonomy lists use).
+    const [countries, regions, grapes, countByCountry, countByRegion, countByGrape, countByType] = await Promise.all([
       Country.find({ slug: { $exists: true, $ne: null } }).select('slug updatedAt').lean(),
       Region.find({ slug: { $exists: true, $ne: null } }).select('slug updatedAt').lean(),
-      Grape.find({ slug: { $exists: true, $ne: null } }).select('slug updatedAt').lean()
+      Grape.find({ slug: { $exists: true, $ne: null } }).select('slug updatedAt').lean(),
+      countWinesBy('country'),
+      countWinesBy('region'),
+      countWinesBy('grapes', { unwind: true }),
+      countWinesBy('type'),
     ]);
 
     for (const c of countries) {
-      const count = await WineDefinition.countDocuments({ country: c._id });
+      const count = countByCountry.get(String(c._id)) || 0;
       if (count < MIN_WINES) continue;
       const lastmod = c.updatedAt ? c.updatedAt.toISOString().split('T')[0] : '';
       xml += '  <url>\n';
@@ -101,7 +120,7 @@ router.get('/', sitemapLimiter, async (req, res) => {
     }
 
     for (const r of regions) {
-      const count = await WineDefinition.countDocuments({ region: r._id });
+      const count = countByRegion.get(String(r._id)) || 0;
       if (count < MIN_WINES) continue;
       const lastmod = r.updatedAt ? r.updatedAt.toISOString().split('T')[0] : '';
       xml += '  <url>\n';
@@ -113,7 +132,7 @@ router.get('/', sitemapLimiter, async (req, res) => {
     }
 
     for (const g of grapes) {
-      const count = await WineDefinition.countDocuments({ grapes: g._id });
+      const count = countByGrape.get(String(g._id)) || 0;
       if (count < MIN_WINES) continue;
       const lastmod = g.updatedAt ? g.updatedAt.toISOString().split('T')[0] : '';
       xml += '  <url>\n';
@@ -125,7 +144,7 @@ router.get('/', sitemapLimiter, async (req, res) => {
     }
 
     for (const type of WINE_TYPES) {
-      const count = await WineDefinition.countDocuments({ type });
+      const count = countByType.get(type) || 0;
       if (count < MIN_WINES) continue;
       xml += '  <url>\n';
       xml += `    <loc>${SITE_URL}/wines/type/${type}</loc>\n`;
@@ -158,6 +177,7 @@ router.get('/', sitemapLimiter, async (req, res) => {
 
     xml += '</urlset>';
 
+    sitemapCache = { at: Date.now(), xml };
     res.set('Content-Type', 'application/xml');
     res.set('Cache-Control', 'public, max-age=3600');
     res.send(xml);

--- a/backend/src/routes/stats.js
+++ b/backend/src/routes/stats.js
@@ -46,7 +46,9 @@ router.get('/overview', async (req, res) => {
     const cellars = await Cellar.find({ user: req.user.id, deletedAt: null }).lean();
     const cellarIds = cellars.map(c => c._id);
 
-    const targetCurrency    = dbUser.preferences?.currency       || 'USD';
+    // dbUser can be null: requireAuth only verifies the JWT, so a just-deleted
+    // account with a still-valid access token reaches here.
+    const targetCurrency    = dbUser?.preferences?.currency      || 'USD';
     const targetRatingScale = dbUser?.preferences?.ratingScale  || '5';
 
     if (cellarIds.length === 0) {
@@ -102,7 +104,7 @@ router.get('/value-history', async (req, res) => {
     cutoff.setMonth(cutoff.getMonth() - months);
     const cutoffDate = cutoff.toISOString().slice(0, 10);
 
-    const targetCurrency = dbUser.preferences?.currency || 'USD';
+    const targetCurrency = dbUser?.preferences?.currency || 'USD';
 
     const cellars = await Cellar.find({ user: req.user.id, deletedAt: null }).select('_id name').lean();
     const cellarIds = cellars.map(c => c._id);

--- a/backend/src/routes/taxonomy.js
+++ b/backend/src/routes/taxonomy.js
@@ -303,3 +303,5 @@ router.get('/wine-types/:type', async (req, res) => {
 
 module.exports = router;
 module.exports.clearTaxonomyListCache = clearTaxonomyListCache;
+// Shared with sitemap.js — one aggregation instead of one countDocuments per taxon.
+module.exports.countWinesBy = countWinesBy;

--- a/backend/src/routes/wineLists.js
+++ b/backend/src/routes/wineLists.js
@@ -123,6 +123,9 @@ router.post('/', requireAuth, async (req, res) => {
 
     res.status(201).json(wineList);
   } catch (error) {
+    if (error.name === 'ValidationError' || error.name === 'CastError') {
+      return res.status(400).json({ error: error.message });
+    }
     console.error('Create wine list error:', error);
     res.status(500).json({ error: 'Failed to create wine list' });
   }
@@ -314,8 +317,20 @@ router.get('/:id/preview-pdf', requireAuth, async (req, res) => {
   }
 });
 
+// Wrap multer so its errors become 4xx instead of a masked 500 from the
+// central handler (same pattern as cellarImport.js / images.js).
+function handleLogoUpload(req, res, next) {
+  logoUpload.single('logo')(req, res, (err) => {
+    if (err) {
+      if (err.code === 'LIMIT_FILE_SIZE') return res.status(413).json({ error: 'Logo too large (max 5 MB)' });
+      return res.status(400).json({ error: err.message || 'Invalid logo upload' });
+    }
+    next();
+  });
+}
+
 // POST /api/wine-lists/:id/logo — upload restaurant logo
-router.post('/:id/logo', requireAuth, logoUpload.single('logo'), async (req, res) => {
+router.post('/:id/logo', requireAuth, handleLogoUpload, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
     const wineList = await WineList.findOne({ _id: req.params.id, user: req.user.id });


### PR DESCRIPTION
## Summary
Seven backend MEDIUMs/LOWs from CODE_AUDIT_2026-07-08.md (**MED #8, #9, #10, #11, #12, #13** + two LOWs).

## Changes
- **Follows privacy (MED #11)** — `/api/follows/:userId/followers|following` now 404 unless the target profile is public or the requester is the owner (same guard as `GET /reviews/user/:userId`). A private profile's full social graph was enumerable by ObjectId.
- **Sitemap perf (MED #13)** — one `countWinesBy` aggregation per collection (helper now exported from `taxonomy.js`) instead of one `countDocuments` per country/region/grape/type — hundreds of sequential DB round-trips per crawler fetch — plus a 1-hour server-side XML cache (crawlers ignore `Cache-Control`).
- **`/reviews/discover` perf (MED #12)** — the public-profile id list is fetched `.lean()` and cached for 5 minutes; it was a whole-users-collection scan of hydrated documents on every ReviewFeed view. (Trade-off: a user flipping to private can appear in Discover for up to 5 more minutes; their reviews there are all `visibility:'public'` regardless.)
- **Upload errors (MED #9)** — bottle-image and wine-list-logo uploads wrap multer so an oversize file returns **413** and a wrong format **400** with the reason, instead of a production-masked 500 (`cellarImport.js` pattern). Wine-list **create** also maps ValidationError→400 (a 201-char name 500'd while update correctly 400'd).
- **Import rating drop (MED #10)** — "request wine" rows now resolve and store `rating`/`ratingScale` like the matched-wine branch; the frontend sends them for request rows too, so every requested-wine bottle silently lost its rating.
- **Default-image scope (MED #8)** — the wine-definition `$or` clause is only added when the bottle *has* a wine (`BottleImage.wineDefinition` defaults to null, so a pending-request bottle matched **any** approved unattached image) and now requires `visibility: 'public'`, matching the candidate list the UI shows.
- **stats.js null guard (LOW)** — `dbUser?.` on both routes; a just-deleted account with a still-valid access token hit a TypeError 500.

## Testing
- `cd backend && npm test` — 823 passed; all nine touched routers smoke-required cleanly.

## docker-compose impact
None — backend-only, no env/compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)