### PR TITLE
fix: maintenance-script batch — cleanup-unused-wines refs, auxerrois, seed-demo search, image-dedup handover

### DIFF
--- a/backend/src/backfill-cred.js
+++ b/backend/src/backfill-cred.js
@@ -79,18 +79,21 @@ async function backfill() {
     const tier = getTier(totalScore);
     const specialty = getSpecialty(categories);
 
+    // Always write — including zero. Skipping totalScore===0 meant users whose
+    // contributions were since deleted/rejected kept a stale nonzero
+    // score/tier/specialty forever, contradicting the idempotency claim.
+    await User.updateOne({ _id: uid }, {
+      $set: {
+        'contribution.totalScore': totalScore,
+        'contribution.categories': categories,
+        'contribution.tier': tier,
+        'contribution.specialty': specialty,
+      }
+    });
     if (totalScore > 0) {
-      await User.updateOne({ _id: uid }, {
-        $set: {
-          'contribution.totalScore': totalScore,
-          'contribution.categories': categories,
-          'contribution.tier': tier,
-          'contribution.specialty': specialty,
-        }
-      });
       console.log(`  ${u.username}: ${totalScore} pts → ${tier}${specialty ? ` (${specialty})` : ''}`);
-      updated++;
     }
+    updated++;
   }
 
   console.log(`\nBackfill complete: ${updated}/${users.length} users updated.`);

--- a/backend/src/models/ChatUsage.js
+++ b/backend/src/models/ChatUsage.js
@@ -2,7 +2,10 @@ const mongoose = require('mongoose');
 
 /**
  * Tracks daily Cellar Chat usage per user.
- * One document per (userId, date) pair. Auto-expires after 3 days.
+ * One document per (userId, date) pair. Auto-expires after 90 days (set by
+ * the writer in routes/chat.js) — retained that long so the SuperAdmin chat
+ * usage panel can show a meaningful history window. GDPR: usage counters +
+ * token totals only, no message content; purged with the account.
  */
 const chatUsageSchema = new mongoose.Schema({
   userId:       { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },

--- a/backend/src/scripts/cleanup-duplicate-images.js
+++ b/backend/src/scripts/cleanup-duplicate-images.js
@@ -32,6 +32,7 @@ const Bottle = require('../models/Bottle');
 const BottleImage = require('../models/BottleImage');
 const WineDefinition = require('../models/WineDefinition');
 const { unlinkImageFiles } = require('../services/imageProcessor');
+const searchService = require('../services/search');
 
 const APPLY = process.argv.includes('--apply');
 
@@ -48,6 +49,15 @@ function keeperScore(img, wine) {
 async function main() {
   await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
   console.log(`Mode: ${APPLY ? 'APPLY (deleting)' : 'DRY-RUN (no changes; pass --apply to execute)'}\n`);
+  if (APPLY) {
+    // Without initialize() every indexWine below is a silent no-op and the
+    // wines index keeps serving deleted image URLs (no full sync ever runs
+    // against a non-empty index).
+    await searchService.initialize();
+    if (searchService.getIsAvailable?.() === false) {
+      console.warn('Meilisearch unavailable — wine image handovers will not be re-indexed.');
+    }
+  }
 
   // Duplicate groups: same effective wine + same photo bytes + same uploader.
   const groups = await BottleImage.aggregate([
@@ -93,11 +103,12 @@ async function main() {
       );
       totals.repointedBottles += rp.modifiedCount || 0;
 
-      // Official handover: if the wine's image is this record's file, move it
-      // to the keeper (keeper preference makes this rare, but a stale URL or a
-      // drifted assignedToWine flag can still hit it).
-      const loserUrl = loser.processedUrl || loser.originalUrl;
-      if (wine.image && wine.image === loserUrl && keeperUrl) {
+      // Official handover: if the wine's image is EITHER of this record's
+      // files, move it to the keeper. Checking only the preferred URL missed
+      // a wine.image pointing at the loser's originalUrl when a processedUrl
+      // also existed — the file was then deleted, leaving wine.image dangling.
+      const loserUrls = [loser.processedUrl, loser.originalUrl].filter(Boolean);
+      if (wine.image && loserUrls.includes(wine.image) && keeperUrl) {
         wine.image = keeperUrl;
         wine.imageCredit = keeper.credit || null;
         await wine.save();
@@ -109,8 +120,10 @@ async function main() {
           await keeper.save();
         }
         totals.winesUpdated++;
-        // Search reindex intentionally skipped (script runs without Meili
-        // init); the wine doc URL change is picked up on the next full sync.
+        // The wines search index embeds `image` and no full sync ever runs
+        // against a non-empty index — re-index so search stops serving the
+        // deleted file as a broken thumbnail.
+        await searchService.indexWine(wine._id);
       }
 
       await unlinkImageFiles(loser); // reference-safe: shared files survive

--- a/backend/src/scripts/cleanup-unused-wines.js
+++ b/backend/src/scripts/cleanup-unused-wines.js
@@ -38,6 +38,7 @@ const Bottle = require('../models/Bottle');
 const WishlistItem = require('../models/WishlistItem');
 const WineList = require('../models/WineList');
 const Discussion = require('../models/Discussion');
+const DiscussionReply = require('../models/DiscussionReply');
 const RestockAlert = require('../models/RestockAlert');
 const JournalEntry = require('../models/JournalEntry');
 const Recommendation = require('../models/Recommendation');
@@ -49,6 +50,7 @@ const Appellation = require('../models/Appellation');
 // Register remaining schemas so Mongoose doesn't complain about unknown refs
 require('../models/Country');
 const searchService = require('../services/search');
+const vectorStore = require('../services/vectorStore');
 
 const MONGO_URI = process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar';
 const APPLY = process.argv.includes('--apply');
@@ -60,13 +62,43 @@ const WINE_REF_SOURCES = [
   [WineList, 'sections.entries.wine'],
   [WineList, 'autoGroupEntries.wine'],
   [Discussion, 'wineDefinition'],
+  [DiscussionReply, 'wineDefinition'],
   [RestockAlert, 'wine'],
-  [JournalEntry, 'wine'],
+  [RestockAlert, 'similarWineIds'],
+  // The ref lives at pairings[].wine — distinct() on a nonexistent top-level
+  // 'wine' path returns [], which silently marked every journal-paired wine
+  // as unused.
+  [JournalEntry, 'pairings.wine'],
   [Recommendation, 'wine'],
   [Review, 'wineDefinition'],
   [BottleImage, 'wineDefinition'],
   [PriceTrackingRequest, 'wineDefinition'],
 ];
+
+/**
+ * Delete the unused wines' Qdrant points BEFORE the WineEmbedding rows go —
+ * the rows hold the only qdrantPointIds, so deleting them first would orphan
+ * the live vectors and the deleted wines would keep surfacing in AI
+ * similarity search forever (same pattern as admin merge's purgeSourceVectors).
+ */
+async function purgeQdrantPoints(wineIds) {
+  try {
+    const embs = await WineEmbedding.find({ wineDefinition: { $in: wineIds } })
+      .select('qdrantPointId indexVersion').lean();
+    const byIndex = new Map();
+    for (const e of embs) {
+      if (!e.qdrantPointId) continue;
+      if (!byIndex.has(e.indexVersion)) byIndex.set(e.indexVersion, []);
+      byIndex.get(e.indexVersion).push(e.qdrantPointId);
+    }
+    for (const [indexVersion, ids] of byIndex) {
+      await vectorStore.deletePoints(indexVersion, ids).catch(() => {});
+    }
+    console.log(`Purged Qdrant points: ${[...byIndex.values()].reduce((n, a) => n + a.length, 0)}`);
+  } catch (err) {
+    console.warn('Qdrant point purge failed (embedding rows will still be deleted):', err.message);
+  }
+}
 
 async function run() {
   console.log('Connecting to MongoDB…');
@@ -90,6 +122,8 @@ async function run() {
   console.log(`Unreferenced wines:      ${unusedIds.length}`);
 
   if (unusedIds.length > 0 && APPLY) {
+    await purgeQdrantPoints(unusedIds);
+
     const cascade = [
       [WineVintageProfile, { wineDefinition: { $in: unusedIds } }, 'vintage profiles'],
       [WineVintagePrice, { wineDefinition: { $in: unusedIds } }, 'vintage prices'],

--- a/backend/src/scripts/list-users.js
+++ b/backend/src/scripts/list-users.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 const mongoose = require('mongoose');
 
 async function run() {
-  await mongoose.connect(process.env.MONGO_URI || 'mongodb://localhost:27017/wine_cellar');
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
   const users = mongoose.connection.db.collection('users');
   const all = await users.find({}, { projection: { username: 1, email: 1, roles: 1, role: 1 } }).toArray();
   console.log('Users in DB:', JSON.stringify(all, null, 2));

--- a/backend/src/scripts/migrate-roles.js
+++ b/backend/src/scripts/migrate-roles.js
@@ -10,7 +10,7 @@ require('dotenv').config();
 const mongoose = require('mongoose');
 
 async function run() {
-  await mongoose.connect(process.env.MONGO_URI || 'mongodb://localhost:27017/wine_cellar');
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
   console.log('Connected to MongoDB');
 
   const db = mongoose.connection.db;

--- a/backend/src/seed-demo.js
+++ b/backend/src/seed-demo.js
@@ -238,6 +238,26 @@ async function seed() {
     }
   }
 
+  // Index the seeded data into Meilisearch. The backend's boot-time full sync
+  // already ran against the then-empty DB and only re-fires when the index is
+  // empty — without this, registry and cellar search return zero hits for the
+  // demo data until a backend restart.
+  const searchService = require('./services/search');
+  await searchService.initialize();
+  if (searchService.getIsAvailable?.() === false) {
+    console.warn('\nMeilisearch unavailable — restart the backend to index the demo data for search.');
+  } else {
+    const WineDef = require('./models/WineDefinition');
+    const BottleModel = require('./models/Bottle');
+    const [wineIds, bottleIds] = await Promise.all([
+      WineDef.distinct('_id'),
+      BottleModel.distinct('_id'),
+    ]);
+    for (const id of wineIds) await searchService.indexWine(id);
+    await searchService.bulkIndexBottles(bottleIds);
+    console.log(`\nIndexed ${wineIds.length} wines + ${bottleIds.length} bottles into Meilisearch.`);
+  }
+
   console.log('\nDemo seed complete!');
   console.log('  Admin: admin@cellarion.app / Admin1234!demo');
   console.log('  User:  user@cellarion.app  / User1234!demo');

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -228,9 +228,12 @@ const GRAPE_SYNONYMS = {
   'grenache gris':        'Grenache Gris',
 
   // Malbec / Côt
+  // NOTE: 'auxerrois' is deliberately NOT mapped. It is a Malbec synonym only
+  // in Cahors; in Alsace/Lorraine (where the name is far more common on
+  // labels) Auxerrois is a distinct white grape — the mapping silently
+  // corrupted every Alsace Auxerrois auto-created via label scan / AI import.
   'cot':                  'Malbec',
   'cote':                 'Malbec',
-  'auxerrois':            'Malbec',
   'malbeck':              'Malbec',
 
   // Tempranillo synonyms


### PR DESCRIPTION
## Summary
Maintenance-script findings from CODE_AUDIT_2026-07-08.md (**MED #15, #17, #18, #19, #20, #21** + two LOW carry-overs).

## Changes
- **cleanup-unused-wines (MED #15)** — the JournalEntry reference used the wrong path (`wine` instead of `pairings.wine`; `distinct` on a missing path returns `[]`, so every journal-paired wine counted as unused and would be deleted with `--apply`). Added `DiscussionReply.wineDefinition` and `RestockAlert.similarWineIds` to the used set, and unused wines' **Qdrant points are now purged** before their WineEmbedding rows (previously orphaned vectors kept surfacing deleted wines in AI similarity search).
- **`auxerrois` → Malbec synonym removed (MED #17)** — valid only in Cahors; on the live auto-create path (label scan / AI import) it silently stored every Alsace/Lorraine Auxerrois (a distinct white grape) as Malbec. Documented in place so it doesn't get re-added.
- **seed-demo indexes into Meilisearch (MED #18)** — boot full-sync only fires on an empty index, so demo search returned zero hits until a backend restart; the seeder now indexes the seeded wines/bottles (with a clear warning if Meili is down).
- **cleanup-duplicate-images (MED #19)** — the official-image handover now matches `wine.image` against **both** of the loser's URLs (a `wine.image` pointing at the originalUrl was missed when a processedUrl existed → file deleted, `wine.image` dangling), and updated wines are re-indexed (`searchService.initialize()` added — the "next full sync" the old comment relied on never runs).
- **backfill-cred (MED #20)** — always writes the recomputed score including zero; users whose contributions were since deleted kept a stale score/tier/specialty forever, contradicting the script's idempotency claim.
- **ChatUsage retention comment (MED #21)** — the model claimed 3-day expiry while the writer sets 90 days; documented the actual 90 days with rationale (SuperAdmin usage-panel history; counters + token totals only, no message content). If you'd rather shorten actual retention instead, that's a one-line change in `routes/chat.js` — flagging for your call.
- **list-users / migrate-roles (LOW)** — default connection fixed from `localhost:27017/wine_cellar` to `mongo:27017/winecellar`, matching every other script (the bare defaults silently queried an empty database in-container).

## Testing
- `cd backend && npm test` — 823 passed; all touched scripts syntax-checked (vm compile).
- Note: these are operational scripts — the cleanup scripts remain **dry-run by default** and were not executed against any database here.

## docker-compose impact
None — script/model-comment changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)