### PR TITLE
fix: SuperAdmin/Somm state-loss + styling cluster

### DIFF
--- a/frontend/src/pages/AdminImagesByWine.js
+++ b/frontend/src/pages/AdminImagesByWine.js
@@ -43,6 +43,15 @@ export default function AdminImagesByWine() {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
+  // When a delete / set-official empties the last page but earlier pages still
+  // exist, step back one page instead of stranding the admin on an empty page
+  // (the pagination controls only render in the non-empty branch).
+  useEffect(() => {
+    if (!loading && items.length === 0 && total > 0 && page > 1) {
+      setPage(p => Math.max(1, p - 1));
+    }
+  }, [loading, items.length, total, page]);
+
   // An image is the wine's official one if it's flagged assignedToWine, or its
   // file URL matches the wine's stored image (belt-and-suspenders).
   const isOfficial = (wine, img) => {

--- a/frontend/src/pages/SommMaturity.js
+++ b/frontend/src/pages/SommMaturity.js
@@ -82,7 +82,14 @@ function SommMaturity() {
 
   useEffect(() => { fetchProfiles(); }, [fetchProfiles]);
 
-  const handleSaved  = (updated) => setProfiles(prev => prev.filter(p => p._id !== updated._id));
+  // Saving flips a pending profile to reviewed, so it leaves the Pending tab;
+  // on the Reviewed tab it stays reviewed and must remain visible — update it
+  // in place instead of dropping it.
+  const handleSaved  = (updated) => setProfiles(prev => (
+    tab === 'reviewed'
+      ? prev.map(p => (p._id === updated._id ? updated : p))
+      : prev.filter(p => p._id !== updated._id)
+  ));
   const handleReset  = (updated) => setProfiles(prev => prev.filter(p => p._id !== updated._id));
 
   return (

--- a/frontend/src/pages/SuperAdmin.css
+++ b/frontend/src/pages/SuperAdmin.css
@@ -12,6 +12,11 @@
   --sa-accent2: #60a5fa;
   --sa-warn: #facc15;
   --sa-danger: var(--color-danger);
+  /* Semantic aliases used by inline styles in the tab components */
+  --sa-green: var(--sa-accent);
+  --sa-red: var(--sa-danger);
+  --sa-blue: var(--sa-accent2);
+  --sa-gold: var(--sa-warn);
   --sa-muted: var(--color-text-muted);
   --sa-text: var(--color-text);
   --sa-text-dim: var(--color-text-secondary);
@@ -413,6 +418,38 @@
   color: var(--sa-danger);
   font-size: 12px;
   margin-bottom: 12px;
+}
+
+/* ── Success ── */
+.sa-success {
+  padding: 16px;
+  background: var(--color-success-bg);
+  border: 1px solid var(--sa-green);
+  border-radius: var(--sa-radius);
+  color: var(--sa-green);
+  font-size: 12px;
+  margin-bottom: 12px;
+}
+
+/* ── Generic section block (TabBackups) ── */
+.sa-section {
+  margin-top: 16px;
+}
+
+/* ── Big stat tiles (TabImport results) ── */
+.sa-big-number {
+  font-size: 26px;
+  font-weight: bold;
+  font-family: var(--sa-font);
+  color: var(--sa-text);
+  line-height: 1.2;
+}
+.sa-big-label {
+  font-size: 10px;
+  color: var(--sa-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-top: 2px;
 }
 
 /* ── Logout bar ── */

--- a/frontend/src/pages/SuperAdmin/TabAI.js
+++ b/frontend/src/pages/SuperAdmin/TabAI.js
@@ -630,9 +630,9 @@ export default function TabAI() {
         body: JSON.stringify({ mode: jobMode }),
       });
       const body = await res.json().catch(() => ({}));
-      setJobMsg(body.message || body.error || 'Job started');
+      setJobMsg({ ok: res.ok && !body.error, text: body.message || body.error || 'Job started' });
       reload();
-    } catch (e) { setJobMsg(e.message || 'Error'); }
+    } catch (e) { setJobMsg({ ok: false, text: e.message || 'Error' }); }
     finally { setJobBusy(false); }
   }
 
@@ -641,9 +641,9 @@ export default function TabAI() {
     try {
       const res = await apiFetch('/api/admin/ai/embed/stop', { method: 'POST' });
       const body = await res.json().catch(() => ({}));
-      setJobMsg(body.message || 'Stop requested');
+      setJobMsg({ ok: res.ok && !body.error, text: body.message || body.error || 'Stop requested' });
       reload();
-    } catch (e) { setJobMsg(e.message || 'Error'); }
+    } catch (e) { setJobMsg({ ok: false, text: e.message || 'Error' }); }
     finally { setJobBusy(false); }
   }
 
@@ -659,9 +659,9 @@ export default function TabAI() {
         body: JSON.stringify(payload),
       });
       const body = await res.json().catch(() => ({}));
-      setEnrichMsg(body.message || body.error || 'Job started');
+      setEnrichMsg({ ok: res.ok && !body.error, text: body.message || body.error || 'Job started' });
       reload();
-    } catch (e) { setEnrichMsg(e.message || 'Error'); }
+    } catch (e) { setEnrichMsg({ ok: false, text: e.message || 'Error' }); }
     finally { setEnrichBusy(false); }
   }
 
@@ -670,9 +670,9 @@ export default function TabAI() {
     try {
       const res = await apiFetch('/api/admin/ai/enrich/stop', { method: 'POST' });
       const body = await res.json().catch(() => ({}));
-      setEnrichMsg(body.message || 'Stop requested');
+      setEnrichMsg({ ok: res.ok && !body.error, text: body.message || body.error || 'Stop requested' });
       reload();
-    } catch (e) { setEnrichMsg(e.message || 'Error'); }
+    } catch (e) { setEnrichMsg({ ok: false, text: e.message || 'Error' }); }
     finally { setEnrichBusy(false); }
   }
 
@@ -834,7 +834,7 @@ export default function TabAI() {
             </div>
           </div>
           <div className="sa-panel-body">
-            {jobMsg && <div className={`sa-error`} style={{ marginBottom: 8, fontSize: 11 }}>{jobMsg}</div>}
+            {jobMsg && <div className={jobMsg.ok ? 'sa-success' : 'sa-error'} style={{ marginBottom: 8, fontSize: 11 }}>{jobMsg.text}</div>}
             <div className="sa-kv">
               <div className="sa-kv-row">
                 <span className="sa-kv-key">Status</span>
@@ -973,7 +973,7 @@ export default function TabAI() {
             </div>
           </div>
           <div className="sa-panel-body">
-            {enrichMsg && <div className="sa-error" style={{ marginBottom: 8, fontSize: 11 }}>{enrichMsg}</div>}
+            {enrichMsg && <div className={enrichMsg.ok ? 'sa-success' : 'sa-error'} style={{ marginBottom: 8, fontSize: 11 }}>{enrichMsg.text}</div>}
             <div className="sa-kv">
               <div className="sa-kv-row">
                 <span className="sa-kv-key">Status</span>

--- a/frontend/src/pages/SuperAdmin/TabSettings.js
+++ b/frontend/src/pages/SuperAdmin/TabSettings.js
@@ -63,9 +63,10 @@ function PanelShell({ title, intro, saving, onSave, msg, children }) {
   );
 }
 
-// All three rate-limit panels load from /rate-limits and PATCH only their own
-// fields, so each Save button is independent. The backend's partial-update
-// behaviour means an unsent group is left untouched.
+// All three rate-limit panels share one /rate-limits load (fetched once in
+// TabSettings and passed down) but PATCH only their own fields, so each Save
+// button is independent. The backend's partial-update behaviour means an
+// unsent group is left untouched.
 function useRateLimits(apiFetch) {
   const [config,   setConfig]   = useState(null);
   const [defaults, setDefaults] = useState(null);
@@ -81,13 +82,12 @@ function useRateLimits(apiFetch) {
   return { config, defaults, error };
 }
 
-function PerIpLimitsPanel({ apiFetch }) {
+function PerIpLimitsPanel({ apiFetch, config, defaults, error }) {
   const LIMITERS = [
     { key: 'api',   label: 'General API'  },
     { key: 'write', label: 'Write actions' },
     { key: 'auth',  label: 'Auth / login'  },
   ];
-  const { config, defaults, error } = useRateLimits(apiFetch);
   const [form,   setForm]   = useState(null);
   const [saving, setSaving] = useState(false);
   const [msg,    setMsg]    = useState(null);
@@ -136,8 +136,7 @@ function PerIpLimitsPanel({ apiFetch }) {
   );
 }
 
-function AccountLockoutPanel({ apiFetch }) {
-  const { config, defaults, error } = useRateLimits(apiFetch);
+function AccountLockoutPanel({ apiFetch, config, defaults, error }) {
   const [form,   setForm]   = useState(null);
   const [saving, setSaving] = useState(false);
   const [msg,    setMsg]    = useState(null);
@@ -217,8 +216,7 @@ function AccountLockoutPanel({ apiFetch }) {
   );
 }
 
-function ChatLimitsPanel({ apiFetch }) {
-  const { config, defaults, error } = useRateLimits(apiFetch);
+function ChatLimitsPanel({ apiFetch, config, defaults, error }) {
   const [form,   setForm]   = useState(null);
   const [saving, setSaving] = useState(false);
   const [msg,    setMsg]    = useState(null);
@@ -344,12 +342,14 @@ function ContactEmailPanel({ apiFetch }) {
 
 export default function TabSettings() {
   const { apiFetch } = useAuth();
+  // Single /rate-limits fetch shared by the three rate-limit panels below.
+  const rateLimits = useRateLimits(apiFetch);
   return (
     <>
       <ContactEmailPanel apiFetch={apiFetch} />
-      <PerIpLimitsPanel apiFetch={apiFetch} />
-      <AccountLockoutPanel apiFetch={apiFetch} />
-      <ChatLimitsPanel apiFetch={apiFetch} />
+      <PerIpLimitsPanel apiFetch={apiFetch} {...rateLimits} />
+      <AccountLockoutPanel apiFetch={apiFetch} {...rateLimits} />
+      <ChatLimitsPanel apiFetch={apiFetch} {...rateLimits} />
     </>
   );
 }

--- a/frontend/src/pages/SuperAdmin/TabUsers.js
+++ b/frontend/src/pages/SuperAdmin/TabUsers.js
@@ -263,7 +263,7 @@ export default function TabUsers() {
                     </tr>
                   ))}
                   {(!data?.users?.length) && (
-                    <tr><td colSpan={8}><div className="sa-empty">No users found</div></td></tr>
+                    <tr><td colSpan={7}><div className="sa-empty">No users found</div></td></tr>
                   )}
                 </tbody>
               </table>

--- a/frontend/src/pages/SuperAdmin/index.js
+++ b/frontend/src/pages/SuperAdmin/index.js
@@ -32,11 +32,13 @@ const TABS = [
 ];
 
 // Tabs that refresh in place (useApi re-fetches via RefreshContext) or hold
-// unsaved drafts (announcement, settings) — never remounted by a refresh.
-// The remaining list tabs (users, audit, cellars, import) manage their own
-// fetching and hold no drafts, so they keep the remount-on-refresh behavior.
+// in-flight work / unsaved drafts (announcement, settings, import) — never
+// remounted by a refresh. Import fetches nothing on mount and holds a selected
+// file, upload progress and result stats, so a remount would only lose state.
+// The remaining list tabs (users, audit, cellars) manage their own fetching
+// and hold no drafts, so they keep the remount-on-refresh behavior.
 const IN_PLACE_REFRESH_TABS = new Set([
-  'overview', 'services', 'database', 'backups', 'ai', 'announcement', 'settings',
+  'overview', 'services', 'database', 'backups', 'import', 'ai', 'announcement', 'settings',
 ]);
 
 export default function SuperAdmin() {


### PR DESCRIPTION
Implements the verified findings from CODE_AUDIT_2026-07-08.md — MED #35 plus the related LOW findings. Frontend-only.

## Fixes

1. **TabImport remount wipes in-flight import state (MED #35)** — `SuperAdmin/index.js`: the Import tab was keyed on `refreshKey`, so the 30s auto-refresh (or manual Refresh) remounted `TabImport`, discarding the selected file, upload-in-progress state and result stats while the server-side import kept running. TabImport fetches nothing on mount, so the remount bought nothing. Added `import` to `IN_PLACE_REFRESH_TABS` and corrected the stale comment. Users/audit/cellars keep the remount-on-refresh behavior by design.

2. **SommMaturity: saving from the Reviewed tab made the card vanish** — `handleSaved` unconditionally filtered the profile out of the list. Correct on Pending (status flips to reviewed), wrong on Reviewed — the PUT keeps status `reviewed` and returns the populated profile. Now the Reviewed tab replaces the item in place with the save response; Pending behavior unchanged.

3. **TabSettings fired 3 identical rate-limit GETs** — each of `PerIpLimitsPanel`, `AccountLockoutPanel`, `ChatLimitsPanel` called `useRateLimits`, so mounting the tab hit `/api/admin/settings/rate-limits` three times. The hook is now called once in `TabSettings` and `config`/`defaults`/`error` are passed down as props. Each panel still PATCHes only its own fields.

4. **Undefined CSS variables + missing classes** — `--sa-green`, `--sa-red`, `--sa-blue`, `--sa-gold` were referenced (TabSettings, TabUsers, TabImport) but never defined, silently dropping success/error colors and the expiring-plan gold highlight. Added them to `.sa-root` as aliases of the existing palette (`--sa-accent`, `--sa-danger`, `--sa-accent2`, `--sa-warn`). Also added the missing `sa-big-number` / `sa-big-label` (TabImport stat tiles) and `sa-section` (TabBackups) rules.

5. **LOW: TabAI job/enrich success messages rendered in the error style** — `jobMsg`/`enrichMsg` now track `{ ok, text }` like the panels elsewhere in the file, and success renders in a new `sa-success` class (mirrors `sa-error` with the success palette).

6. **LOW: TabUsers empty-state `colSpan={8}` on a 7-column table** — corrected to 7 (verified against the `<th>` count).

7. **LOW: AdminImagesByWine stranded the admin on an empty last page** — after a delete/set-official empties page N>1, the empty state rendered with the pagination controls unreachable. Added the same step-back effect as Wishlist.js: if `items.length === 0 && total > 0 && page > 1`, decrement the page.

## Testing

- `cd frontend && npm test` — 13 files, **337 tests passed**, 0 failed
- All edited files syntax-checked with esbuild (JSX loader)

## docker-compose impact
None — frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)