### PR TITLE
fix: import-flow UX dead-ends — stale overwrite state, review-trap, partial-add duplicates

### DIFF
--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -54,6 +54,11 @@ function AddBottle() {
   const [uploadedImages, setUploadedImages] = useState([]);
   const [showDetails, setShowDetails] = useState(false);
   const [saving, setSaving] = useState(false);
+  // Bottles already created by earlier attempts of the current submission —
+  // when POST k of N fails, a retry only creates the remaining N−k instead of
+  // duplicating the whole batch. Reset whenever a new wine is selected.
+  const createdBottlesRef = useRef([]);
+  const imagesLinkedRef = useRef(false);
 
   // ── Scan result state ──
   const [scanResult, setScanResult] = useState(null);  // { extracted, match, labelImage }
@@ -92,6 +97,8 @@ function AddBottle() {
   // advance to the bottle-details step. Centralised so all entry paths share
   // the same teardown.
   const applyResolvedWine = useCallback((wine, carriedVintage) => {
+    createdBottlesRef.current = [];
+    imagesLinkedRef.current = false;
     setSelectedWine(wine);
     setBottleData(prev => ({ ...prev, vintage: carriedVintage || '' }));
     setScanResult(null);
@@ -253,8 +260,30 @@ function AddBottle() {
   };
 
   const handleSelectWine = (wine) => {
+    createdBottlesRef.current = [];
+    imagesLinkedRef.current = false;
     setSelectedWine(wine);
     setStep(2);
+  };
+
+  // Link the uploaded images to the first created bottle. Called on full
+  // success and after a partial failure, so bottles that were created keep
+  // their images even when the batch didn't finish.
+  const linkUploadedImages = () => {
+    const first = createdBottlesRef.current[0];
+    if (imagesLinkedRef.current || uploadedImages.length === 0 || !first) return;
+    imagesLinkedRef.current = true;
+    apiFetch('/api/images/link-to-bottle', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        bottleId: first._id,
+        imageIds: uploadedImages.map(img => img._id)
+      })
+    }).catch(err => {
+      imagesLinkedRef.current = false; // let a retry attempt the link again
+      console.error('Failed to link images:', err);
+    });
   };
 
   const handleSubmit = async (e) => {
@@ -265,6 +294,12 @@ function AddBottle() {
     if (saving) return;
     setSaving(true);
     setError(null);
+
+    // A partial failure leaves invisible bottles behind — tell the user
+    // exactly what happened and what a retry will do.
+    const partialError = (msg, done) => done > 0
+      ? `${msg} — ${done} of ${numBottles} bottle${numBottles === 1 ? '' : 's'} ${done === 1 ? 'was' : 'were'} added. Retrying will add only the remaining ${numBottles - done}.`
+      : msg;
 
     try {
       const payload = {
@@ -285,9 +320,11 @@ function AddBottle() {
         } : {})
       };
 
-      // Create N individual bottle records
-      const createdBottles = [];
-      for (let i = 0; i < numBottles; i++) {
+      // Create the bottle records that are still missing. createdBottlesRef
+      // carries the ones a previous, partially-failed attempt already created,
+      // so a retry never duplicates them.
+      const createdBottles = createdBottlesRef.current;
+      for (let i = createdBottles.length; i < numBottles; i++) {
         const res = await apiFetch('/api/bottles', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -296,26 +333,19 @@ function AddBottle() {
 
         const data = await res.json();
         if (!res.ok) {
-          setError(data.error || 'Failed to add bottle');
+          setError(partialError(data.error || 'Failed to add bottle', createdBottles.length));
+          linkUploadedImages();
           return;
         }
         createdBottles.push(data.bottle);
       }
 
       // Link uploaded images to the first bottle
-      if (uploadedImages.length > 0 && createdBottles.length > 0) {
-        apiFetch('/api/images/link-to-bottle', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            bottleId: createdBottles[0]._id,
-            imageIds: uploadedImages.map(img => img._id)
-          })
-        }).catch(err => console.error('Failed to link images:', err));
-      }
+      linkUploadedImages();
       navigate(`/cellars/${cellarId}`);
     } catch (err) {
-      setError('Network error');
+      setError(partialError('Network error', createdBottlesRef.current.length));
+      linkUploadedImages();
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/ExportCellar.js
+++ b/frontend/src/pages/ExportCellar.js
@@ -64,7 +64,13 @@ function ExportCellar() {
       .then(async res => {
         const data = await res.json().catch(() => ({}));
         if (!active) return;
-        if (!res.ok) { setSummary(null); setSummaryError(data.error || 'Could not read this selection'); return; }
+        if (!res.ok) {
+          // The backend reports "no owned cellar in this selection" as a 404
+          // (a brand-new user always hits this) — show the friendly empty
+          // state instead of a raw error.
+          if (res.status === 404) { setSummary({ cellarCount: 0 }); return; }
+          setSummary(null); setSummaryError(data.error || 'Could not read this selection'); return;
+        }
         setSummary(data);
       })
       .catch(() => { if (active) setSummaryError('Could not read this selection'); })
@@ -140,22 +146,24 @@ function ExportCellar() {
           </select>
         </div>
 
-        {/* Total export summary */}
-        <div className="card" style={{ marginTop: '1rem', padding: '1rem', background: 'var(--surface-2, #f7f7f8)' }}>
-          <div style={{ fontWeight: 600, marginBottom: '0.5rem' }}>This export contains</div>
-          {loadingSummary ? (
-            <div className="settings-hint">Calculating…</div>
-          ) : summaryError ? (
-            <div className="alert alert-error">{summaryError}</div>
-          ) : summary ? (
-            <ul style={{ margin: 0, paddingLeft: '1.1rem', lineHeight: 1.8 }}>
-              <li>{summary.cellarCount} cellar{summary.cellarCount === 1 ? '' : 's'} · {summary.bottleCount} bottles · {summary.rackCount} racks</li>
-              <li>{summary.layoutCount > 0 ? `${summary.layoutCount} 3D room layout${summary.layoutCount === 1 ? '' : 's'}` : 'No 3D room layout'}</li>
-              <li>{summary.reviewCount} reviews · {summary.maturityCount} maturity window{summary.maturityCount === 1 ? '' : 's'}</li>
-              <li>{summary.imageCount} of your images{summary.imageCount > 0 ? ` (~${formatBytes(summary.imageBytes)})` : ''}</li>
-            </ul>
-          ) : null}
-        </div>
+        {/* Total export summary (hidden when there is nothing to export yet) */}
+        {!noCellars && (
+          <div className="card" style={{ marginTop: '1rem', padding: '1rem', background: 'var(--surface-2, #f7f7f8)' }}>
+            <div style={{ fontWeight: 600, marginBottom: '0.5rem' }}>This export contains</div>
+            {loadingSummary ? (
+              <div className="settings-hint">Calculating…</div>
+            ) : summaryError ? (
+              <div className="alert alert-error">{summaryError}</div>
+            ) : summary ? (
+              <ul style={{ margin: 0, paddingLeft: '1.1rem', lineHeight: 1.8 }}>
+                <li>{summary.cellarCount} cellar{summary.cellarCount === 1 ? '' : 's'} · {summary.bottleCount} bottles · {summary.rackCount} racks</li>
+                <li>{summary.layoutCount > 0 ? `${summary.layoutCount} 3D room layout${summary.layoutCount === 1 ? '' : 's'}` : 'No 3D room layout'}</li>
+                <li>{summary.reviewCount} reviews · {summary.maturityCount} maturity window{summary.maturityCount === 1 ? '' : 's'}</li>
+                <li>{summary.imageCount} of your images{summary.imageCount > 0 ? ` (~${formatBytes(summary.imageBytes)})` : ''}</li>
+              </ul>
+            ) : null}
+          </div>
+        )}
 
         {noCellars ? (
           <p className="settings-hint" style={{ marginTop: '1rem' }}>

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -219,7 +219,8 @@ function ImportBottles() {
     fuzzy: rs.filter(r => r.status === 'fuzzy').length,
     aiMatch: rs.filter(r => r.status === 'ai_match').length,
     noMatch: rs.filter(r => r.status === 'no_match').length,
-    errors: rs.filter(r => r.status === 'error').length
+    errors: rs.filter(r => r.status === 'error').length,
+    priceWarnings: rs.filter(r => r.priceWarnings?.length).length
   });
 
   // Resume a saved draft session
@@ -664,6 +665,29 @@ function ImportBottles() {
 
   const renderUploadStep = () => (
     <div className="import-upload">
+      {/* Jumped back from review (e.g. via the anchor link) — offer a way
+          back that keeps every match, skip and manual selection instead of
+          forcing a full (AI-spending) re-validation. Also the only path back
+          to review on a resumed session, where parsedItems is empty. */}
+      {results.length > 0 && !validating && (
+        <div className="session-resume-banner">
+          <div className="session-resume-info">
+            <strong>Your matched results are still here</strong>
+            <span className="session-resume-meta">
+              Return to review to keep every match, skip and manual selection.
+              Re-matching below starts the review over.
+            </span>
+          </div>
+          <div className="session-resume-actions">
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={() => setStep('review')}
+            >
+              Return to review
+            </button>
+          </div>
+        </div>
+      )}
       {draftSessions.length > 0 && (
         <div className="session-resume-banner">
           <div className="session-resume-info">

--- a/frontend/src/pages/ImportCellar.js
+++ b/frontend/src/pages/ImportCellar.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { listCellars } from '../api/cellars';
@@ -20,22 +20,27 @@ function ImportCellar() {
   const [preview, setPreview] = useState(null); // { cellars:[...], hasImageFiles }
   const [names, setNames] = useState({});       // sourceName -> target name
   const [confirms, setConfirms] = useState({});  // sourceName -> bool (overwrite confirmed)
+  // Lowercased target names the server refused with 409 "not confirmed" —
+  // forces the confirm checkbox even when our owned-names snapshot is stale.
+  const [forcedOverwrites, setForcedOverwrites] = useState(new Set());
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
   const [result, setResult] = useState(null);
 
-  useEffect(() => {
-    let active = true;
-    listCellars(apiFetch)
-      .then(res => (res.ok ? res.json() : { cellars: [] }))
-      .then(data => {
-        if (!active) return;
-        const owned = (data.cellars || []).filter(c => c.userRole === 'owner');
-        setOwnedNames(new Set(owned.map(c => c.name.toLowerCase())));
-      })
-      .catch(() => {});
-    return () => { active = false; };
+  // Owned cellar names drive the overwrite warnings. Re-fetched after every
+  // successful import and on reset, so re-importing the same file (or a cellar
+  // created in another tab) still shows the confirm checkbox instead of
+  // dead-ending on the backend's 409.
+  const refreshOwnedNames = useCallback(async () => {
+    try {
+      const res = await listCellars(apiFetch);
+      const data = res.ok ? await res.json() : { cellars: [] };
+      const owned = (data.cellars || []).filter(c => c.userRole === 'owner');
+      setOwnedNames(new Set(owned.map(c => c.name.toLowerCase())));
+    } catch { /* keep the previous snapshot */ }
   }, [apiFetch]);
+
+  useEffect(() => { refreshOwnedNames(); }, [refreshOwnedNames]);
 
   const handleFile = async (f) => {
     setFile(f); setError(null); setResult(null); setPreview(null);
@@ -48,7 +53,7 @@ function ImportCellar() {
       setPreview(data);
       const initNames = {}; const initConfirms = {};
       data.cellars.forEach(c => { initNames[c.sourceName] = c.defaultTargetName; initConfirms[c.sourceName] = false; });
-      setNames(initNames); setConfirms(initConfirms);
+      setNames(initNames); setConfirms(initConfirms); setForcedOverwrites(new Set());
     } catch (err) {
       setError(err.message);
     } finally {
@@ -63,12 +68,18 @@ function ImportCellar() {
     return preview.cellars.map(c => {
       const targetName = (names[c.sourceName] ?? c.defaultTargetName ?? '').trim();
       const lc = targetName.toLowerCase();
-      const willOverwrite = !!targetName && ownedNames.has(lc);
+      const willOverwrite = !!targetName && (
+        ownedNames.has(lc) ||
+        forcedOverwrites.has(lc) ||
+        // Server-computed flag from the preview — authoritative for the
+        // unedited default name even if our owned-names snapshot is stale.
+        (!!c.willOverwrite && lc === (c.defaultTargetName || '').trim().toLowerCase())
+      );
       const dup = lc && seen.has(lc);
       if (lc) seen.set(lc, c.sourceName);
       return { ...c, targetName, willOverwrite, dup };
     });
-  }, [preview, names, ownedNames]);
+  }, [preview, names, ownedNames, forcedOverwrites]);
 
   const blocking = useMemo(() => {
     for (const r of rows) {
@@ -86,8 +97,18 @@ function ImportCellar() {
       rows.forEach(r => { targets[r.sourceName] = { targetName: r.targetName, confirmOverwrite: !!confirms[r.sourceName] }; });
       const res = await runCellarImport(apiFetch, file, targets);
       const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Import failed');
+      if (!res.ok) {
+        // Overwrite refused (409): our owned-names snapshot was stale. Force
+        // the confirm checkbox for that target and refresh the snapshot so
+        // the user can confirm and retry instead of dead-ending.
+        if (res.status === 409 && data.needsConfirm) {
+          setForcedOverwrites(prev => new Set(prev).add(String(data.needsConfirm).toLowerCase()));
+          refreshOwnedNames();
+        }
+        throw new Error(data.error || 'Import failed');
+      }
       setResult(data.results || []);
+      refreshOwnedNames();
     } catch (err) {
       setError(err.message);
     } finally {
@@ -95,7 +116,11 @@ function ImportCellar() {
     }
   };
 
-  const reset = () => { setFile(null); setPreview(null); setNames({}); setConfirms({}); setResult(null); setError(null); };
+  const reset = () => {
+    setFile(null); setPreview(null); setNames({}); setConfirms({});
+    setForcedOverwrites(new Set()); setResult(null); setError(null);
+    refreshOwnedNames();
+  };
 
   return (
     <div className="container" style={{ maxWidth: 760, margin: '0 auto', padding: '1.5rem 1rem' }}>


### PR DESCRIPTION
Implements the verified frontend findings MED #28, #30, #33 plus two LOWs from CODE_AUDIT_2026-07-08.md.

## Fixes

### MED #30 — ImportCellar overwrite confirmation dead-ends on stale state
`frontend/src/pages/ImportCellar.js` fetched the owned-cellar-name list once on mount, so after "Import another" (or a cellar created in another tab) re-importing the same file showed "Will create a new cellar" with no confirm checkbox — the backend then 409'd (`Overwrite of "X" not confirmed`) and the flow was stuck until a page reload. Now:
- the row's `willOverwrite` also honors the **server-computed flag from the preview response** (which the frontend previously ignored),
- owned names are **re-fetched after every successful import and on reset**,
- a 409 with `needsConfirm` **forces the confirm checkbox** for the affected target and refreshes the snapshot, so the user can confirm and retry instead of dead-ending.

### MED #33 — ImportBottles "change anchor" link destroys manual matching work
The review step's "change it on the upload step" link did `setStep('upload')`, but the only way forward from there re-ran full validation — re-spending AI lookups and wiping every manual Search-library/skip/request decision (and the auto-save then overwrote the draft session). On a resumed session `parsedItems` is empty, so the upload step was an empty drop zone with review unreachable. Now the upload step shows a **"Return to review"** banner whenever results exist, going straight back to review with all results/selections intact. The re-validate path is still available (and the banner says it starts the review over).

### MED #28 — AddBottle multi-bottle partial failure duplicates on retry
`handleSubmit` created N bottles with N sequential POSTs; if POST k failed, the k−1 created bottles were invisible, images never got linked, and re-clicking Add created N more. Now:
- bottles created by earlier attempts of the same submission are carried in a ref, so a **retry only creates the remaining N−k**,
- the error reads e.g. *"… — 2 of 6 bottles were added. Retrying will add only the remaining 4."*,
- image linking is extracted into a guarded helper called on **both success and partial failure**, so bottles that were created keep their uploaded images. The ref resets whenever a new wine is selected.

### LOW — ImportBottles resume drops the priceWarnings banner
`computeSummary` (used after session resume) omitted the `priceWarnings` count, so the ⚠️ unusual-prices banner and stat vanished on resume. It now includes `priceWarnings`.

### LOW — ExportCellar "no cellars yet" empty state was unreachable
The backend 404s (`No cellar found for that selection`) when the user owns no cellars, so a brand-new user saw a raw error alert instead of the friendly empty state. The summary 404 is now treated as the empty state (and the "This export contains" card is hidden when there's nothing to export).

## Testing
- `cd frontend && npm test` — **13 files, 337 tests, all passing**
- All four changed pages syntax-checked through the esbuild JSX transform

## docker-compose impact
None — frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)