### PR TITLE
fix: paginate the somm maturity queue

### DIFF
--- a/backend/src/routes/somm/maturity.js
+++ b/backend/src/routes/somm/maturity.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { requireAuth, requireSommOrAdmin } = require('../../middleware/auth');
 const WineVintageProfile = require('../../models/WineVintageProfile');
 const { isValidId } = require('../../utils/validation');
+const { parsePagination } = require('../../utils/pagination');
 
 const { suggestDrinkWindow } = require('../../services/labelScan');
 
@@ -24,6 +25,11 @@ function parseYear(val) {
  * GET /api/somm/maturity
  * List vintage profiles. Somm/admin only.
  * Query: ?status=pending|reviewed  (default: all)
+ *        ?limit / ?offset — pagination (default 100, max 500)
+ *
+ * Paginated + lean: every added/imported bottle seeds a pending profile, so
+ * this collection grows one row per wine+vintage forever — unpaginated it
+ * deep-populated the whole set into one response per queue visit.
  */
 router.get('/', requireSommOrAdmin, async (req, res) => {
   try {
@@ -31,20 +37,27 @@ router.get('/', requireSommOrAdmin, async (req, res) => {
     if (req.query.status === 'pending' || req.query.status === 'reviewed') {
       filter.status = req.query.status;
     }
+    const { limit, offset } = parsePagination(req.query, { limit: 100, maxLimit: 500 });
 
-    const profiles = await WineVintageProfile.find(filter)
-      .populate({
-        path: 'wineDefinition',
-        select: 'name producer type image country region',
-        populate: [
-          { path: 'country', select: 'name' },
-          { path: 'region', select: 'name' }
-        ]
-      })
-      .populate({ path: 'setBy', select: 'username' })
-      .sort({ status: 1, createdAt: -1 }); // pending first, then newest
+    const [profiles, total] = await Promise.all([
+      WineVintageProfile.find(filter)
+        .populate({
+          path: 'wineDefinition',
+          select: 'name producer type image country region',
+          populate: [
+            { path: 'country', select: 'name' },
+            { path: 'region', select: 'name' }
+          ]
+        })
+        .populate({ path: 'setBy', select: 'username' })
+        .sort({ status: 1, createdAt: -1 }) // pending first, then newest
+        .skip(offset)
+        .limit(limit)
+        .lean(),
+      WineVintageProfile.countDocuments(filter),
+    ]);
 
-    res.json({ profiles });
+    res.json({ profiles, total, limit, offset });
   } catch (error) {
     console.error('List maturity profiles error:', error);
     res.status(500).json({ error: 'Failed to load profiles' });

--- a/backend/src/routes/somm/maturity.js
+++ b/backend/src/routes/somm/maturity.js
@@ -33,10 +33,12 @@ function parseYear(val) {
  */
 router.get('/', requireSommOrAdmin, async (req, res) => {
   try {
+    // Assign literals, not the request value: the status is allowlisted
+    // either way, but assigning the literal keeps user input out of the
+    // query object entirely (and clears static-analysis taint tracking).
     const filter = {};
-    if (req.query.status === 'pending' || req.query.status === 'reviewed') {
-      filter.status = req.query.status;
-    }
+    if (req.query.status === 'pending') filter.status = 'pending';
+    else if (req.query.status === 'reviewed') filter.status = 'reviewed';
     const { limit, offset } = parsePagination(req.query, { limit: 100, maxLimit: 500 });
 
     const [profiles, total] = await Promise.all([

--- a/frontend/src/pages/SommMaturity.js
+++ b/frontend/src/pages/SommMaturity.js
@@ -55,28 +55,39 @@ function SommMaturity() {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
   const [profiles, setProfiles] = useState([]);
+  const [total, setTotal] = useState(0);
   const [tab, setTab] = useState('pending');
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
 
   // Latest-wins guard: a slow response for the previous tab must not
   // overwrite the list for the tab the user is now viewing.
   const fetchSeq = useRef(0);
 
-  const fetchProfiles = useCallback(async () => {
+  const PAGE_SIZE = 100;
+
+  // The queue grows one profile per wine+vintage forever, so the backend
+  // paginates (limit/offset + total) — offset 0 replaces the list, higher
+  // offsets append (Load more).
+  const fetchProfiles = useCallback(async (offset = 0) => {
     const seq = ++fetchSeq.current;
-    setLoading(true);
+    if (offset === 0) setLoading(true); else setLoadingMore(true);
     setError(null);
     try {
-      const res = await apiFetch(`/api/somm/maturity?status=${tab}`);
+      const res = await apiFetch(`/api/somm/maturity?status=${tab}&limit=${PAGE_SIZE}&offset=${offset}`);
       const data = await res.json();
       if (seq !== fetchSeq.current) return;
-      if (res.ok) setProfiles(data.profiles);
-      else setError(data.error || 'Failed to load profiles');
+      if (res.ok) {
+        setProfiles(prev => (offset === 0 ? data.profiles : [...prev, ...data.profiles]));
+        setTotal(data.total ?? data.profiles.length);
+      } else {
+        setError(data.error || 'Failed to load profiles');
+      }
     } catch {
       if (seq === fetchSeq.current) setError('Network error');
     } finally {
-      if (seq === fetchSeq.current) setLoading(false);
+      if (seq === fetchSeq.current) { setLoading(false); setLoadingMore(false); }
     }
   }, [apiFetch, tab]);
 
@@ -119,17 +130,32 @@ function SommMaturity() {
           {tab === 'pending' ? t('somm.maturity.noPending') : t('somm.maturity.noReviewed')}
         </div>
       ) : (
-        <div className="somm-list">
-          {profiles.map(profile => (
-            <ProfileCard
-              key={profile._id}
-              profile={profile}
-              isPending={tab === 'pending'}
-              onSaved={handleSaved}
-              onReset={handleReset}
-            />
-          ))}
-        </div>
+        <>
+          <div className="somm-list">
+            {profiles.map(profile => (
+              <ProfileCard
+                key={profile._id}
+                profile={profile}
+                isPending={tab === 'pending'}
+                onSaved={handleSaved}
+                onReset={handleReset}
+              />
+            ))}
+          </div>
+          {profiles.length < total && (
+            <div style={{ textAlign: 'center', margin: '1rem 0' }}>
+              <button
+                className="btn btn-secondary"
+                onClick={() => fetchProfiles(profiles.length)}
+                disabled={loadingMore}
+              >
+                {loadingMore
+                  ? t('somm.maturity.loadingProfiles')
+                  : `${t('somm.maturity.loadMore', 'Load more')} (${profiles.length}/${total})`}
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
CODE_AUDIT_2026-07-08.md **MED #14** / SECURITY_AUDIT_2026-07-08.md **L-11**: `GET /api/somm/maturity` returned the **entire** `WineVintageProfile` collection with a two-level populate and no limit. The collection grows one row per wine+vintage forever (every add-bottle/import seeds a pending profile), so each somm/admin queue visit deep-populated the full set into one multi-MB response on the 4 GB VM.

## Changes
- **Backend**: `parsePagination` (default 100, max 500) + `.lean()` + `total` in the response — same pattern as the reviews/wineRequests lists.
- **Frontend**: `SommMaturity` appends pages via a "Load more (n/total)" button; tab switches reset to page one through the existing latest-wins fetch guard. The button label uses an inline-default key (`somm.maturity.loadMore`) to avoid colliding with the two in-flight i18n locale PRs — it'll be picked up by the key sweep.

## Testing
- `cd backend && npm test` — 823 passed. `cd frontend && npm test` — 337 passed.

## docker-compose impact
None — code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)