### PR TITLE
fix: add ~67 missing i18n keys to en+sv locales

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -40,7 +40,10 @@
     "price": "Price",
     "currency": "Currency",
     "rating": "Rating",
-    "reason": "Reason"
+    "reason": "Reason",
+    "error": "An error occurred",
+    "optional": "optional",
+    "or": "or"
   },
 
   "nav": {
@@ -129,7 +132,9 @@
       "pushBlocked": "Push notifications are blocked. Enable them in your browser settings.",
       "pushNotConfigured": "Push notifications are not configured on this server.",
       "pushHint": "Push delivers notifications to your device even when Cellarion is closed."
-    }
+    },
+    "defaultRatingScale": "Default Rating Scale",
+    "ratingScaleHint": "Choose which rating scale to use by default when adding ratings. You can always override per bottle."
   },
   "adminModerators": {
     "title": "Forum Moderators",
@@ -147,7 +152,8 @@
     "revokeConfirm": "Remove moderator privileges from {{name}}?",
     "revokeWarning": "They will lose the ability to pin, lock, move or delete discussions, see reports, or ban users.",
     "you": "(you)",
-    "failedLoad": "Failed to load moderators."
+    "failedLoad": "Failed to load moderators.",
+    "failedChange": "Failed to change role."
   },
   "reactions": {
     "addReaction": "Add reaction",
@@ -231,7 +237,8 @@
     "setDefault": "Set as default cellar",
     "removeDefault": "Remove as default cellar",
     "editRole": "Edit",
-    "viewRole": "View"
+    "viewRole": "View",
+    "import": "Import"
   },
 
   "cellarDetail": {
@@ -387,7 +394,14 @@
     "requestWineInstead": "Request a wine",
     "aiCouldNotIdentify": "Could not identify this wine. You can submit a request instead.",
     "aiSearching": "Searching for your wine…",
-    "submitWineRequest": "Submit a wine request"
+    "submitWineRequest": "Submit a wine request",
+    "scanPromptTitle": "Scan the wine label",
+    "scanPromptHint": "Take a photo of the label — we'll identify the wine and add it to the registry if it doesn't exist yet.",
+    "startCamera": "Start Camera",
+    "useCameraInstead": "Use camera instead",
+    "searchManuallyInstead": "No camera? Search manually instead →",
+    "searchBtn": "Search",
+    "searchHint": "Be as specific as possible — include the wine name and producer. We'll check our library first; if no match is found, we'll identify and add the wine."
   },
 
   "bottleDetail": {
@@ -459,7 +473,16 @@
     "suggestGrapesHint": "Separate multiple varieties with commas",
     "suggestGrapesSubmit": "Submit suggestion",
     "suggestGrapesThankYou": "Thanks for contributing!",
-    "suggestGrapesConfirm": "Your suggestion has been submitted for review. Our team will add the verified varieties to the wine registry."
+    "suggestGrapesConfirm": "Your suggestion has been submitted for review. Our team will add the verified varieties to the wine registry.",
+    "addWineImage": "Wine Photo",
+    "backToHistory": "Back to history",
+    "defaultImageHint": "Click the star to choose which image is shown first.",
+    "imageNotice": "Images are reviewed by an admin before being added to the shared wine registry, where they will be visible to all Cellarion users.",
+    "pendingReview": "Pending review",
+    "tastingProfile": "Tasting profile",
+    "structure": "Structure",
+    "flavours": "Flavours",
+    "pairsWith": "Pairs with"
   },
 
   "bottles": {
@@ -555,7 +578,10 @@
     "disableSlot": "Disable slot",
     "enableSlot": "Enable slot",
     "disabledSlotTitle": "Slot {{position}} — Disabled",
-    "disabledSlotNote": "This slot is marked as unusable — bottles can't be placed here."
+    "disabledSlotNote": "This slot is marked as unusable — bottles can't be placed here.",
+    "preview": "Preview",
+    "hidePreview": "Hide preview",
+    "previewLabel": "Preview — this is how the rack will look once created"
   },
 
   "nfc": {
@@ -602,7 +628,23 @@
     "rackWidth": "Width (m)",
     "rackDepth": "Depth (m)",
     "rackScale": "Scale",
-    "removeFromRoom": "Remove"
+    "removeFromRoom": "Remove",
+    "inRack": "In rack",
+    "slot": "slot",
+    "racksSelected": "racks selected",
+    "clearSelection": "Clear",
+    "linkSelected": "Link Selected",
+    "rotateAll": "Rotate All",
+    "shiftClickHint": "Shift+click to add/remove racks",
+    "undo": "Undo (Ctrl+Z)",
+    "redo": "Redo (Ctrl+Y)",
+    "unsavedChangesTitle": "Unsaved Changes",
+    "unsavedChangesMessage": "You have unsaved changes to the room layout. Are you sure you want to leave?",
+    "stayOnPage": "Stay",
+    "leaveWithoutSaving": "Leave",
+    "loadCellarError": "Failed to load cellar",
+    "loadRacksError": "Failed to load racks for this cellar",
+    "loadLayoutError": "Failed to load the room layout"
   },
 
   "wines": {
@@ -646,7 +688,10 @@
     "adminNotes": "Admin Notes:",
     "submitted": "Submitted {{date}}",
     "grapeSuggestion": "Grape suggestion",
-    "suggestedGrapes": "Suggested"
+    "suggestedGrapes": "Suggested",
+    "imageLabel": "Image",
+    "imageUrlPlaceholder": "Paste image URL…",
+    "imageNotice": "Images are reviewed by an admin before being added to the shared wine registry, where they will be visible to all Cellarion users."
   },
 
   "history": {
@@ -677,7 +722,8 @@
     "addingToWishlist": "Adding…",
     "onWishlist": "On wishlist",
     "wishlistError": "Try again",
-    "viewBottleAria": "View {{name}}"
+    "viewBottleAria": "View {{name}}",
+    "noResults": "No bottles match your search."
   },
 
   "cellarScope": {
@@ -770,7 +816,10 @@
       "typeGrapeSuggestion": "Grape suggestion",
       "suggestedGrapes": "Suggested varieties",
       "applyGrapesNote": "Select the grape varieties to add to this wine. Unrecognised names can be added to the taxonomy first.",
-      "applyGrapesLabel": "Grapes to add"
+      "applyGrapesLabel": "Grapes to add",
+      "linkSearchLabel": "Search Wine Registry",
+      "linkSearchPlaceholder": "Search by name or producer…",
+      "selectedId": "Selected ID:"
     },
     "bottleSizes": {
       "normalizeAll": "Normalize all",
@@ -878,7 +927,8 @@
         "deleted": "Deleted \"{{name}}\"",
         "empty": "No wines have their producer in the name.",
         "networkError": "Network error"
-      }
+      },
+      "defaultImageHint": "Click the star to set the default image for this wine."
     },
     "images": {
       "title": "Admin: Image Review",
@@ -936,7 +986,15 @@
       "deleteImage": "Delete",
       "removeYes": "Remove",
       "removing": "Removing…",
-      "reject": "Reject"
+      "reject": "Reject",
+      "approvePublic": "Approve for all",
+      "approvePrivate": "Approve for uploader only",
+      "makePublic": "Make public",
+      "makePrivate": "Make uploader only",
+      "private": "private",
+      "visibilityLabel": "Visibility:",
+      "visibilityPublic": "Public",
+      "visibilityPrivate": "Uploader only"
     },
     "audit": {
       "title": "Audit Log",
@@ -1067,7 +1125,8 @@
       "aiSuggest": "Suggest",
       "aiSuggesting": "Suggesting…",
       "aiSuggestError": "Could not suggest a drink window",
-      "aiSuggestFilled": "Suggestion applied — review and save"
+      "aiSuggestFilled": "Suggestion applied — review and save",
+      "nvHint": "non-vintage: enter years after purchase"
     },
     "prices": {
       "title": "Price Queue",
@@ -1343,7 +1402,8 @@
       "ratingVsPrice": "Rating vs price by type",
       "expectationVsReality": "Expectation vs Reality",
       "surprisedOrDisappointed": "When wines surprised or disappointed you",
-      "mostValuableBottles": "Most Valuable Bottles"
+      "mostValuableBottles": "Most Valuable Bottles",
+      "valueOverTime": "Collection Value Over Time"
     },
 
     "kpi": {
@@ -1698,7 +1758,11 @@
     "backToCellars": "Back to Cellars",
     "wineNotFound": "Wine not found",
     "goToCellarion": "Go to Cellarion",
-    "wines": "Wines"
+    "wines": "Wines",
+    "tastingProfile": "Tasting profile",
+    "structure": "Structure",
+    "flavours": "Flavours",
+    "pairsWith": "Pairs with"
   },
   "statsCard": {
     "title": "Your Cellar Card",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -40,7 +40,10 @@
     "price": "Pris",
     "currency": "Valuta",
     "rating": "Betyg",
-    "reason": "Anledning"
+    "reason": "Anledning",
+    "error": "Ett fel uppstod",
+    "optional": "valfritt",
+    "or": "eller"
   },
 
   "nav": {
@@ -129,7 +132,9 @@
       "pushBlocked": "Push-aviseringar är blockerade. Aktivera dem i webbläsarens inställningar.",
       "pushNotConfigured": "Push-aviseringar är inte konfigurerade på denna server.",
       "pushHint": "Push levererar aviseringar till din enhet även när Cellarion är stängt."
-    }
+    },
+    "defaultRatingScale": "Standardbetygsskala",
+    "ratingScaleHint": "Välj vilken betygsskala som används som standard när du sätter betyg. Du kan alltid ändra per flaska."
   },
   "adminModerators": {
     "title": "Forum-moderatorer",
@@ -147,7 +152,8 @@
     "revokeConfirm": "Ta bort moderatorbehörighet från {{name}}?",
     "revokeWarning": "Hen förlorar möjligheten att fästa, låsa, flytta eller ta bort diskussioner, se rapporter eller blockera användare.",
     "you": "(du)",
-    "failedLoad": "Kunde inte ladda moderatorerna."
+    "failedLoad": "Kunde inte ladda moderatorerna.",
+    "failedChange": "Kunde inte ändra rollen."
   },
   "reactions": {
     "addReaction": "Lägg till reaktion",
@@ -231,7 +237,8 @@
     "setDefault": "Ange som standardkällare",
     "removeDefault": "Ta bort som standardkällare",
     "editRole": "Redigera",
-    "viewRole": "Visa"
+    "viewRole": "Visa",
+    "import": "Importera"
   },
 
   "cellarDetail": {
@@ -387,7 +394,14 @@
     "requestWineInstead": "Begär ett vin",
     "aiCouldNotIdentify": "Kunde inte identifiera detta vin. Du kan skicka en förfrågan istället.",
     "aiSearching": "Söker efter ditt vin…",
-    "submitWineRequest": "Skicka vinförfrågan"
+    "submitWineRequest": "Skicka vinförfrågan",
+    "scanPromptTitle": "Skanna vinetiketten",
+    "scanPromptHint": "Ta ett foto av etiketten — vi identifierar vinet och lägger till det i registret om det inte redan finns.",
+    "startCamera": "Starta kameran",
+    "useCameraInstead": "Använd kameran istället",
+    "searchManuallyInstead": "Ingen kamera? Sök manuellt istället →",
+    "searchBtn": "Sök",
+    "searchHint": "Var så specifik som möjligt — ange både vinnamn och producent. Vi söker först i vårt bibliotek; om ingen träff hittas identifierar vi vinet och lägger till det."
   },
 
   "bottleDetail": {
@@ -459,7 +473,16 @@
     "suggestGrapesHint": "Separera flera sorter med kommatecken",
     "suggestGrapesSubmit": "Skicka förslag",
     "suggestGrapesThankYou": "Tack för ditt bidrag!",
-    "suggestGrapesConfirm": "Ditt förslag har skickats in för granskning. Vårt team lägger till de verifierade sorterna i vinregistret."
+    "suggestGrapesConfirm": "Ditt förslag har skickats in för granskning. Vårt team lägger till de verifierade sorterna i vinregistret.",
+    "addWineImage": "Vinfoto",
+    "backToHistory": "Tillbaka till historiken",
+    "defaultImageHint": "Klicka på stjärnan för att välja vilken bild som visas först.",
+    "imageNotice": "Bilder granskas av en administratör innan de läggs till i det delade vinregistret, där de visas för alla Cellarion-användare.",
+    "pendingReview": "Väntar på granskning",
+    "tastingProfile": "Smakprofil",
+    "structure": "Struktur",
+    "flavours": "Smaker",
+    "pairsWith": "Passar till"
   },
 
   "bottles": {
@@ -555,7 +578,10 @@
     "disableSlot": "Inaktivera plats",
     "enableSlot": "Aktivera plats",
     "disabledSlotTitle": "Plats {{position}} — Inaktiverad",
-    "disabledSlotNote": "Den här platsen är markerad som oanvändbar — flaskor kan inte placeras här."
+    "disabledSlotNote": "Den här platsen är markerad som oanvändbar — flaskor kan inte placeras här.",
+    "preview": "Förhandsgranska",
+    "hidePreview": "Dölj förhandsgranskning",
+    "previewLabel": "Förhandsgranskning — så här kommer hyllan att se ut när den skapats"
   },
 
   "nfc": {
@@ -602,7 +628,23 @@
     "rackWidth": "Bredd (m)",
     "rackDepth": "Djup (m)",
     "rackScale": "Skala",
-    "removeFromRoom": "Ta bort"
+    "removeFromRoom": "Ta bort",
+    "inRack": "I hylla",
+    "slot": "plats",
+    "racksSelected": "hyllor valda",
+    "clearSelection": "Rensa",
+    "linkSelected": "Länka valda",
+    "rotateAll": "Rotera alla",
+    "shiftClickHint": "Shift+klicka för att lägga till/ta bort hyllor",
+    "undo": "Ångra (Ctrl+Z)",
+    "redo": "Gör om (Ctrl+Y)",
+    "unsavedChangesTitle": "Osparade ändringar",
+    "unsavedChangesMessage": "Du har osparade ändringar i rumslayouten. Är du säker på att du vill lämna sidan?",
+    "stayOnPage": "Stanna",
+    "leaveWithoutSaving": "Lämna",
+    "loadCellarError": "Kunde inte ladda källaren",
+    "loadRacksError": "Kunde inte ladda hyllorna för denna källare",
+    "loadLayoutError": "Kunde inte ladda rumslayouten"
   },
 
   "wines": {
@@ -646,7 +688,10 @@
     "adminNotes": "Adminanteckningar:",
     "submitted": "Skickad {{date}}",
     "grapeSuggestion": "Druvförslag",
-    "suggestedGrapes": "Föreslagna"
+    "suggestedGrapes": "Föreslagna",
+    "imageLabel": "Bild",
+    "imageUrlPlaceholder": "Klistra in bild-URL…",
+    "imageNotice": "Bilder granskas av en administratör innan de läggs till i det delade vinregistret, där de visas för alla Cellarion-användare."
   },
 
   "history": {
@@ -677,7 +722,8 @@
     "addingToWishlist": "Lägger till…",
     "onWishlist": "På önskelistan",
     "wishlistError": "Försök igen",
-    "viewBottleAria": "Visa {{name}}"
+    "viewBottleAria": "Visa {{name}}",
+    "noResults": "Inga flaskor matchar din sökning."
   },
 
   "cellarScope": {
@@ -770,7 +816,10 @@
       "typeGrapeSuggestion": "Druvförslag",
       "suggestedGrapes": "Föreslagna sorter",
       "applyGrapesNote": "Välj de druvsorter som ska läggas till för det här vinet. Okända namn kan läggas till i taxonomin först.",
-      "applyGrapesLabel": "Druvor att lägga till"
+      "applyGrapesLabel": "Druvor att lägga till",
+      "linkSearchLabel": "Sök i vinregistret",
+      "linkSearchPlaceholder": "Sök på namn eller producent…",
+      "selectedId": "Valt ID:"
     },
     "bottleSizes": {
       "normalizeAll": "Normalisera alla",
@@ -878,7 +927,8 @@
         "deleted": "Tog bort \"{{name}}\"",
         "empty": "Inga viner har producenten i namnet.",
         "networkError": "Nätverksfel"
-      }
+      },
+      "defaultImageHint": "Klicka på stjärnan för att välja standardbild för detta vin."
     },
     "images": {
       "title": "Admin: Bildgranskning",
@@ -936,7 +986,15 @@
       "deleteImage": "Ta bort",
       "removeYes": "Ta bort",
       "removing": "Tar bort…",
-      "reject": "Avvisa"
+      "reject": "Avvisa",
+      "approvePublic": "Godkänn för alla",
+      "approvePrivate": "Godkänn endast för uppladdaren",
+      "makePublic": "Gör publik",
+      "makePrivate": "Gör endast för uppladdaren",
+      "private": "privat",
+      "visibilityLabel": "Synlighet:",
+      "visibilityPublic": "Publik",
+      "visibilityPrivate": "Endast uppladdare"
     },
     "audit": {
       "title": "Aktivitetslogg",
@@ -1067,7 +1125,8 @@
       "aiSuggest": "Föreslå",
       "aiSuggesting": "Föreslår…",
       "aiSuggestError": "Kunde inte föreslå ett drickfönster",
-      "aiSuggestFilled": "Förslag tillämpat — granska och spara"
+      "aiSuggestFilled": "Förslag tillämpat — granska och spara",
+      "nvHint": "utan årgång: ange antal år efter inköp"
     },
     "prices": {
       "title": "Priskö",
@@ -1343,7 +1402,8 @@
       "ratingVsPrice": "Betyg kontra pris per typ",
       "expectationVsReality": "Förväntning kontra verklighet",
       "surprisedOrDisappointed": "När viner överraskade eller besvikade dig",
-      "mostValuableBottles": "Mest värdefulla flaskor"
+      "mostValuableBottles": "Mest värdefulla flaskor",
+      "valueOverTime": "Samlingens värde över tid"
     },
 
     "kpi": {
@@ -1698,7 +1758,11 @@
     "backToCellars": "Tillbaka till källare",
     "wineNotFound": "Vin hittades inte",
     "goToCellarion": "Gå till Cellarion",
-    "wines": "Viner"
+    "wines": "Viner",
+    "tastingProfile": "Smakprofil",
+    "structure": "Struktur",
+    "flavours": "Smaker",
+    "pairsWith": "Passar till"
   },
   "statsCard": {
     "title": "Ditt källarkort",


### PR DESCRIPTION
## What

Audit finding **MED #37** (CODE_AUDIT_2026-07-08.md): 64 translation keys were used in code with inline English defaults but existed in **neither** locale file — Swedish users always saw English for them, and translators couldn't see the keys at all.

This PR adds all 64 keys to **both** `en/translation.json` and `sv/translation.json`:

- **en**: exactly the inline default from the `t()` call in code — zero visual change for English users.
- **sv**: idiomatic informal-"du" Swedish matching the tone/terminology of neighbouring keys (hylla, källare, vinregistret, …). **Native review of the Swedish welcome** — translations were written to match existing style but should get a once-over.

Affected namespaces: `room.*` (16 — CellarRoom), `bottleDetail.*` (9), `admin.images.*` (8), `addBottle.scanPrompt*/search*` (7), `wineDetail.*` (4), `wineRequests.image*` (3), `racks.preview*` (3), `admin.requests.*` (3), `common.error/optional/or` (3), `settings.defaultRatingScale/ratingScaleHint` (2), plus `cellars.import`, `history.noResults`, `somm.maturity.nvHint`, `statistics.sections.valueOverTime`, `admin.wines.defaultImageHint`, `adminModerators.failedChange`.

## How extracted

A throwaway Node script (not committed) scanned `frontend/src/**/*.js` for static `t('key', 'default')` / `t('key', { defaultValue })` / `i18nKey=` literals, flattened both locale JSONs, and diffed — excluding dynamic keys and i18next plural-suffix false positives (`key_one`/`key_other`). The single remaining "missing" hit after the fix is a JSDoc comment in `utils/priceValidation.js` mentioning `t('bottles.priceWarning.<code>')` — not a real call (the runtime key is dynamic `addBottle.priceWarning.${code}`, which already exists in both locales).

## Counts

| | before | after |
|---|---|---|
| en keys | 2132 | 2196 |
| sv keys | 2132 | 2196 |
| keys missing from both locales | 64 | 0 |
| en/sv asymmetry | 0 | 0 |

## Verification

- `cd frontend && npm test` — 13 files, **337 tests passed** (locale JSONs load in the i18n test setup, so JSON errors would fail).
- Extraction script re-run: zero remaining missing static keys, en/sv key sets exactly symmetric (2196 = 2196).
- No `.js` source files touched — locale files only; inline defaults in code remain as fallbacks.

## docker-compose impact
None — locale files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)