### PR TITLE
fix: localize CellarChat, UserProfile, SupportPage + UserProfile modal fixes

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2658,5 +2658,110 @@
     "daysAgo": "{{n}}d ago",
     "monthsAgo": "{{n}}mo ago",
     "yearsAgo": "{{n}}y ago"
+  },
+  "cellarChat": {
+    "title": "Cellar Chat",
+    "newChat": "New chat",
+    "newChatAria": "Start a new conversation",
+    "usagePeriodToday": "today",
+    "usagePeriodWeek": "this week",
+    "allCellars": "All cellars",
+    "selectedCellar": "Selected cellar",
+    "nCellars_one": "{{count}} cellar",
+    "nCellars_other": "{{count}} cellars",
+    "tryAsking": "Try asking…",
+    "categories": {
+      "foodPairing": "Food pairing",
+      "occasion": "Occasion",
+      "cellarCheck": "Cellar check",
+      "moodStyle": "Mood & style"
+    },
+    "prompts": {
+      "food1": "I'm making lamb with rosemary tonight — what should I open?",
+      "food2": "What pairs well with grilled salmon from my cellar?",
+      "food3": "I'm having a cheese board with friends — what do you suggest?",
+      "food4": "What goes with a rich beef stew?",
+      "occasion1": "I need something special for a birthday dinner for two.",
+      "occasion2": "We're celebrating an anniversary — what's the best bottle I have?",
+      "occasion3": "Something easy and relaxed for a summer barbecue.",
+      "occasion4": "What's a good bottle to bring as a gift?",
+      "cellar1": "What's drinking well in my cellar right now?",
+      "cellar2": "Do I have anything that's past its peak and should drink soon?",
+      "cellar3": "What's my most interesting bottle right now?",
+      "cellar4": "Show me something I might have forgotten about.",
+      "mood1": "I want something light and fresh for a weeknight.",
+      "mood2": "Something bold and tannic to go with a steak.",
+      "mood3": "I'm in the mood for something elegant and complex.",
+      "mood4": "What's a good summer evening wine from my cellar?"
+    },
+    "tipLabel": "Tip:",
+    "tipBody": "describe food, occasion, or mood for the best results.",
+    "tipExample": "<1>\"Grilled salmon with herb butter\"</1> works much better than <3>\"white wine\"</3>.",
+    "searchingFor": "Searching for",
+    "thinking": "Thinking…",
+    "searchingCellar": "Searching your cellar…",
+    "errorGeneric": "Something went wrong.",
+    "errorNetwork": "Network error — please try again.",
+    "errorBurst": "Too many chat requests in a short time. Please wait a minute and try again.",
+    "errorQuotaDaily_one": "You've reached your daily limit of {{count}} question. Try again tomorrow.",
+    "errorQuotaDaily_other": "You've reached your daily limit of {{count}} questions. Try again tomorrow.",
+    "errorQuotaWeekly_one": "You've reached your weekly limit of {{count}} question. Try again in a few days.",
+    "errorQuotaWeekly_other": "You've reached your weekly limit of {{count}} questions. Try again in a few days.",
+    "placeholder": "Ask about your cellar… (Enter to send, Shift+Enter for new line)",
+    "placeholderLimitDaily": "Daily limit reached — resets at midnight UTC",
+    "placeholderLimitWeekly": "Weekly limit reached — try again in a few days",
+    "send": "Send"
+  },
+  "userProfile": {
+    "loading": "Loading...",
+    "notFound": "User not found",
+    "failedLoad": "Failed to load profile",
+    "memberSince": "Member since {{date}}",
+    "followers": "Followers",
+    "following": "Following",
+    "reviews": "Reviews",
+    "noReviews": "No reviews yet.",
+    "loadMore": "Load More",
+    "noneYet": "None yet.",
+    "listError": "Couldn't load the list — please try again.",
+    "close": "Close"
+  },
+  "support": {
+    "title": "Support",
+    "newTicket": "+ New Support Ticket",
+    "myTickets": "My Tickets ({{count}})",
+    "myWineReports": "My Wine Reports ({{count}})",
+    "loading": "Loading…",
+    "failedLoad": "Failed to load support history.",
+    "noTickets": "No support tickets yet. Use the button above to get help.",
+    "noReports": "No wine reports yet. Use the \"Report\" button on any wine to flag an issue.",
+    "yourMessage": "Your message",
+    "adminResponse": "Admin response",
+    "awaitingResponse": "Awaiting admin response…",
+    "yourDetails": "Your details",
+    "adminNotes": "Admin notes",
+    "underReview": "Under review…",
+    "category": {
+      "bug": "Bug Report",
+      "help": "Help / Question",
+      "feature": "Feature Request",
+      "other": "Other"
+    },
+    "status": {
+      "open": "Open",
+      "in_progress": "In Progress",
+      "closed": "Closed"
+    },
+    "reason": {
+      "wrong_info": "Wrong Information",
+      "duplicate": "Duplicate Entry",
+      "inappropriate": "Inappropriate Content",
+      "other": "Other"
+    },
+    "reportStatus": {
+      "pending": "Pending",
+      "resolved": "Resolved",
+      "dismissed": "Dismissed"
+    }
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2658,5 +2658,110 @@
     "daysAgo": "{{n}}d sedan",
     "monthsAgo": "{{n}}mån sedan",
     "yearsAgo": "{{n}}år sedan"
+  },
+  "cellarChat": {
+    "title": "Källarchatt",
+    "newChat": "Ny chatt",
+    "newChatAria": "Starta en ny konversation",
+    "usagePeriodToday": "idag",
+    "usagePeriodWeek": "den här veckan",
+    "allCellars": "Alla källare",
+    "selectedCellar": "Vald källare",
+    "nCellars_one": "{{count}} källare",
+    "nCellars_other": "{{count}} källare",
+    "tryAsking": "Prova att fråga…",
+    "categories": {
+      "foodPairing": "Mat & vin",
+      "occasion": "Tillfälle",
+      "cellarCheck": "Källarkoll",
+      "moodStyle": "Humör & stil"
+    },
+    "prompts": {
+      "food1": "Jag gör lamm med rosmarin ikväll — vad ska jag öppna?",
+      "food2": "Vad passar till grillad lax från min källare?",
+      "food3": "Jag ska ha ostbricka med vänner — vad föreslår du?",
+      "food4": "Vad passar till en mustig köttgryta?",
+      "occasion1": "Jag behöver något speciellt till en födelsedagsmiddag för två.",
+      "occasion2": "Vi firar bröllopsdag — vilken är den bästa flaskan jag har?",
+      "occasion3": "Något enkelt och avslappnat till en sommargrillning.",
+      "occasion4": "Vilken flaska passar bra att ta med som present?",
+      "cellar1": "Vad dricker bra i min källare just nu?",
+      "cellar2": "Har jag något som passerat sin topp och borde drickas snart?",
+      "cellar3": "Vilken är min mest intressanta flaska just nu?",
+      "cellar4": "Visa mig något jag kanske har glömt bort.",
+      "mood1": "Jag vill ha något lätt och friskt till en vardagskväll.",
+      "mood2": "Något kraftfullt med strama tanniner till en stek.",
+      "mood3": "Jag är sugen på något elegant och komplext.",
+      "mood4": "Vad är ett bra sommarkvällsvin från min källare?"
+    },
+    "tipLabel": "Tips:",
+    "tipBody": "beskriv maten, tillfället eller stämningen för bästa resultat.",
+    "tipExample": "<1>\"Grillad lax med örtsmör\"</1> fungerar mycket bättre än <3>\"vitt vin\"</3>.",
+    "searchingFor": "Söker efter",
+    "thinking": "Tänker…",
+    "searchingCellar": "Söker i din källare…",
+    "errorGeneric": "Något gick fel.",
+    "errorNetwork": "Nätverksfel — försök igen.",
+    "errorBurst": "För många chattförfrågningar på kort tid. Vänta en minut och försök igen.",
+    "errorQuotaDaily_one": "Du har nått din dagsgräns på {{count}} fråga. Försök igen imorgon.",
+    "errorQuotaDaily_other": "Du har nått din dagsgräns på {{count}} frågor. Försök igen imorgon.",
+    "errorQuotaWeekly_one": "Du har nått din veckogräns på {{count}} fråga. Försök igen om några dagar.",
+    "errorQuotaWeekly_other": "Du har nått din veckogräns på {{count}} frågor. Försök igen om några dagar.",
+    "placeholder": "Fråga om din källare… (Enter för att skicka, Shift+Enter för ny rad)",
+    "placeholderLimitDaily": "Dagsgränsen är nådd — återställs vid midnatt UTC",
+    "placeholderLimitWeekly": "Veckogränsen är nådd — försök igen om några dagar",
+    "send": "Skicka"
+  },
+  "userProfile": {
+    "loading": "Laddar...",
+    "notFound": "Användaren hittades inte",
+    "failedLoad": "Kunde inte ladda profilen",
+    "memberSince": "Medlem sedan {{date}}",
+    "followers": "Följare",
+    "following": "Följer",
+    "reviews": "Recensioner",
+    "noReviews": "Inga recensioner än.",
+    "loadMore": "Ladda fler",
+    "noneYet": "Inga än.",
+    "listError": "Kunde inte ladda listan — försök igen.",
+    "close": "Stäng"
+  },
+  "support": {
+    "title": "Support",
+    "newTicket": "+ Nytt supportärende",
+    "myTickets": "Mina ärenden ({{count}})",
+    "myWineReports": "Mina vinrapporter ({{count}})",
+    "loading": "Laddar…",
+    "failedLoad": "Kunde inte ladda supporthistoriken.",
+    "noTickets": "Inga supportärenden än. Använd knappen ovan för att få hjälp.",
+    "noReports": "Inga vinrapporter än. Använd \"Rapportera\"-knappen på ett vin för att flagga ett problem.",
+    "yourMessage": "Ditt meddelande",
+    "adminResponse": "Svar från admin",
+    "awaitingResponse": "Väntar på svar från admin…",
+    "yourDetails": "Dina detaljer",
+    "adminNotes": "Adminanteckningar",
+    "underReview": "Under granskning…",
+    "category": {
+      "bug": "Buggrapport",
+      "help": "Hjälp / Fråga",
+      "feature": "Funktionsönskemål",
+      "other": "Övrigt"
+    },
+    "status": {
+      "open": "Öppet",
+      "in_progress": "Pågår",
+      "closed": "Stängt"
+    },
+    "reason": {
+      "wrong_info": "Felaktig information",
+      "duplicate": "Dubblett",
+      "inappropriate": "Olämpligt innehåll",
+      "other": "Övrigt"
+    },
+    "reportStatus": {
+      "pending": "Väntar",
+      "resolved": "Åtgärdad",
+      "dismissed": "Avvisad"
+    }
   }
 }

--- a/frontend/src/pages/CellarChat.js
+++ b/frontend/src/pages/CellarChat.js
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation, Trans } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
 import { useAuth } from '../contexts/AuthContext';
@@ -10,44 +11,24 @@ import './CellarChat.css';
 const SESSION_MESSAGES_KEY = 'cellarChat.messages';
 const SESSION_CONTEXT_KEY = 'cellarChat.wineContext';
 
-// ── Starter prompts by category ──────────────────────────────────────────────
+// ── Starter prompts by category (i18n keys under cellarChat.*) ───────────────
 
 const PROMPT_CATEGORIES = [
   {
-    label: 'Food pairing',
-    prompts: [
-      "I'm making lamb with rosemary tonight — what should I open?",
-      "What pairs well with grilled salmon from my cellar?",
-      "I'm having a cheese board with friends — what do you suggest?",
-      "What goes with a rich beef stew?",
-    ],
+    key: 'foodPairing',
+    promptKeys: ['food1', 'food2', 'food3', 'food4'],
   },
   {
-    label: 'Occasion',
-    prompts: [
-      "I need something special for a birthday dinner for two.",
-      "We're celebrating an anniversary — what's the best bottle I have?",
-      "Something easy and relaxed for a summer barbecue.",
-      "What's a good bottle to bring as a gift?",
-    ],
+    key: 'occasion',
+    promptKeys: ['occasion1', 'occasion2', 'occasion3', 'occasion4'],
   },
   {
-    label: 'Cellar check',
-    prompts: [
-      "What's drinking well in my cellar right now?",
-      "Do I have anything that's past its peak and should drink soon?",
-      "What's my most interesting bottle right now?",
-      "Show me something I might have forgotten about.",
-    ],
+    key: 'cellarCheck',
+    promptKeys: ['cellar1', 'cellar2', 'cellar3', 'cellar4'],
   },
   {
-    label: 'Mood & style',
-    prompts: [
-      "I want something light and fresh for a weeknight.",
-      "Something bold and tannic to go with a steak.",
-      "I'm in the mood for something elegant and complex.",
-      "What's a good summer evening wine from my cellar?",
-    ],
+    key: 'moodStyle',
+    promptKeys: ['mood1', 'mood2', 'mood3', 'mood4'],
   },
 ];
 
@@ -75,9 +56,10 @@ function WineCard({ wine }) {
 }
 
 function ExpandedQueryHint({ text }) {
+  const { t } = useTranslation();
   return (
     <div className="cellar-chat__expanded-query">
-      <span className="cellar-chat__expanded-query-label">Searching for</span>
+      <span className="cellar-chat__expanded-query-label">{t('cellarChat.searchingFor')}</span>
       <span className="cellar-chat__expanded-query-text">{text}</span>
     </div>
   );
@@ -106,30 +88,31 @@ function Message({ msg }) {
 }
 
 function StarterPrompts({ onSelect, disabled }) {
+  const { t } = useTranslation();
   const [openCategory, setOpenCategory] = useState(null);
 
   return (
     <div className="cellar-chat__starters">
-      <div className="cellar-chat__starters-title">Try asking…</div>
+      <div className="cellar-chat__starters-title">{t('cellarChat.tryAsking')}</div>
       <div className="cellar-chat__starters-categories">
         {PROMPT_CATEGORIES.map((cat) => (
-          <div key={cat.label} className="cellar-chat__starter-cat">
+          <div key={cat.key} className="cellar-chat__starter-cat">
             <button
-              className={`cellar-chat__starter-cat-btn${openCategory === cat.label ? ' open' : ''}`}
-              onClick={() => setOpenCategory(openCategory === cat.label ? null : cat.label)}
+              className={`cellar-chat__starter-cat-btn${openCategory === cat.key ? ' open' : ''}`}
+              onClick={() => setOpenCategory(openCategory === cat.key ? null : cat.key)}
             >
-              {cat.label}
+              {t(`cellarChat.categories.${cat.key}`)}
             </button>
-            {openCategory === cat.label && (
+            {openCategory === cat.key && (
               <div className="cellar-chat__starter-prompts">
-                {cat.prompts.map((p) => (
+                {cat.promptKeys.map((p) => (
                   <button
                     key={p}
                     className="cellar-chat__prompt-chip"
-                    onClick={() => { onSelect(p); setOpenCategory(null); }}
+                    onClick={() => { onSelect(t(`cellarChat.prompts.${p}`)); setOpenCategory(null); }}
                     disabled={disabled}
                   >
-                    {p}
+                    {t(`cellarChat.prompts.${p}`)}
                   </button>
                 ))}
               </div>
@@ -138,9 +121,9 @@ function StarterPrompts({ onSelect, disabled }) {
         ))}
       </div>
       <div className="cellar-chat__tip">
-        <strong>Tip:</strong> describe food, occasion, or mood for the best results.
+        <strong>{t('cellarChat.tipLabel')}</strong> {t('cellarChat.tipBody')}
         <br />
-        <em>"Grilled salmon with herb butter"</em> works much better than <em>"white wine"</em>.
+        <Trans i18nKey="cellarChat.tipExample" components={{ 1: <em />, 3: <em /> }} />
       </div>
     </div>
   );
@@ -149,6 +132,7 @@ function StarterPrompts({ onSelect, disabled }) {
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function CellarChat() {
+  const { t } = useTranslation();
   const { apiFetch, user } = useAuth();
   const defaultCellarId = user?.preferences?.defaultCellarId || null;
 
@@ -230,8 +214,8 @@ export default function CellarChat() {
     setLoading(true);
 
     const thinkingText = hasHistory && wineContext
-      ? 'Thinking…'
-      : 'Searching your cellar…';
+      ? t('cellarChat.thinking')
+      : t('cellarChat.searchingCellar');
     setMessages(prev => [...prev, { role: 'assistant', text: thinkingText, thinking: true }]);
 
     try {
@@ -251,14 +235,21 @@ export default function CellarChat() {
 
       if (!res.ok) {
         setMessages(prev => prev.filter(m => !m.thinking));
-        setError(data.error || 'Something went wrong.');
         // Two kinds of 429: the daily/period quota carries used/limit in its
         // body; the per-minute burst limiter doesn't. Only lock the composer
         // for a real quota exhaustion — burst 429s just show the error above.
         if (res.status === 429 && data.limit != null && data.used != null) {
+          setError(t(
+            data.period === 'weekly' ? 'cellarChat.errorQuotaWeekly' : 'cellarChat.errorQuotaDaily',
+            { count: data.limit }
+          ));
           setUsage(prev => prev
             ? { ...prev, used: Math.max(data.used, data.limit), limit: data.limit, period: data.period || prev.period }
             : null);
+        } else if (res.status === 429) {
+          setError(t('cellarChat.errorBurst'));
+        } else {
+          setError(data.error || t('cellarChat.errorGeneric'));
         }
         return;
       }
@@ -281,7 +272,7 @@ export default function CellarChat() {
       ]);
     } catch {
       setMessages(prev => prev.filter(m => !m.thinking));
-      setError('Network error — please try again.');
+      setError(t('cellarChat.errorNetwork'));
     } finally {
       setLoading(false);
     }
@@ -305,7 +296,9 @@ export default function CellarChat() {
     setError(null);
   };
 
-  const usagePeriodLabel = usage?.period === 'weekly' ? 'this week' : 'today';
+  const usagePeriodLabel = usage?.period === 'weekly'
+    ? t('cellarChat.usagePeriodWeek')
+    : t('cellarChat.usagePeriodToday');
   const usageLabel = usage
     ? (usage.limit === -1 ? null : `${usage.used} / ${usage.limit} ${usagePeriodLabel}`)
     : null;
@@ -313,16 +306,16 @@ export default function CellarChat() {
   return (
     <div className="cellar-chat">
       <div className="cellar-chat__header">
-        <h1 className="cellar-chat__title">Cellar Chat</h1>
+        <h1 className="cellar-chat__title">{t('cellarChat.title')}</h1>
         <div className="cellar-chat__header-controls">
           {messages.length > 0 && (
             <button
               className="cellar-chat__new-chat"
               onClick={startNewChat}
               disabled={loading}
-              aria-label="Start a new conversation"
+              aria-label={t('cellarChat.newChatAria')}
             >
-              New chat
+              {t('cellarChat.newChat')}
             </button>
           )}
           {usageLabel && (
@@ -345,10 +338,10 @@ export default function CellarChat() {
               <path d="M2 4h16M5 10h10M8 16h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
             </svg>
             {selectedCellarIds.length === 0
-              ? 'All cellars'
+              ? t('cellarChat.allCellars')
               : selectedCellarIds.length === 1
-                ? (cellars.find(c => c._id === selectedCellarIds[0])?.name || 'Selected cellar')
-                : `${selectedCellarIds.length} cellars`}
+                ? (cellars.find(c => c._id === selectedCellarIds[0])?.name || t('cellarChat.selectedCellar'))
+                : t('cellarChat.nCellars', { count: selectedCellarIds.length })}
           </button>
           {cellarPickerOpen && (
             <div className="cellar-chat__scope-dropdown">
@@ -358,7 +351,7 @@ export default function CellarChat() {
                   checked={selectedCellarIds.length === 0}
                   onChange={() => setSelectedCellarIds([])}
                 />
-                <span>All cellars</span>
+                <span>{t('cellarChat.allCellars')}</span>
               </label>
               {cellars.map(c => (
                 <label key={c._id} className="cellar-chat__scope-option">
@@ -399,8 +392,8 @@ export default function CellarChat() {
           className="cellar-chat__input"
           data-guide="chat-input"
           placeholder={atLimit
-            ? (usage?.period === 'weekly' ? 'Weekly limit reached — try again in a few days' : 'Daily limit reached — resets at midnight UTC')
-            : 'Ask about your cellar… (Enter to send, Shift+Enter for new line)'}
+            ? (usage?.period === 'weekly' ? t('cellarChat.placeholderLimitWeekly') : t('cellarChat.placeholderLimitDaily'))
+            : t('cellarChat.placeholder')}
           value={input}
           onChange={e => setInput(e.target.value)}
           onKeyDown={handleKey}
@@ -411,7 +404,7 @@ export default function CellarChat() {
           type="submit"
           className="cellar-chat__send"
           disabled={loading || !input.trim() || atLimit}
-          aria-label="Send"
+          aria-label={t('cellarChat.send')}
         >
           ↑
         </button>

--- a/frontend/src/pages/SupportPage.js
+++ b/frontend/src/pages/SupportPage.js
@@ -1,36 +1,12 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { getMySupportTickets, getMyWineReports } from '../api/support';
 import SupportModal from '../components/SupportModal';
 import './SupportPage.css';
 
-const CATEGORY_LABELS = {
-  bug: 'Bug Report',
-  help: 'Help / Question',
-  feature: 'Feature Request',
-  other: 'Other',
-};
-
-const STATUS_LABELS = {
-  open: 'Open',
-  in_progress: 'In Progress',
-  closed: 'Closed',
-};
-
-const REASON_LABELS = {
-  wrong_info: 'Wrong Information',
-  duplicate: 'Duplicate Entry',
-  inappropriate: 'Inappropriate Content',
-  other: 'Other',
-};
-
-const REPORT_STATUS_LABELS = {
-  pending: 'Pending',
-  resolved: 'Resolved',
-  dismissed: 'Dismissed',
-};
-
 function SupportPage() {
+  const { t } = useTranslation();
   const { apiFetch } = useAuth();
   const [tab, setTab] = useState('tickets');
   const [tickets, setTickets] = useState([]);
@@ -57,7 +33,7 @@ function SupportPage() {
       if (ticketRes.ok) setTickets(ticketData.tickets || []);
       if (reportRes.ok) setWineReports(reportData.reports || []);
     } catch {
-      setError('Failed to load support history.');
+      setError(t('support.failedLoad'));
     } finally {
       setLoading(false);
     }
@@ -68,9 +44,9 @@ function SupportPage() {
   return (
     <div className="support-page">
       <div className="support-header">
-        <h1>Support</h1>
+        <h1>{t('support.title')}</h1>
         <button className="btn-primary" onClick={() => setShowModal(true)}>
-          + New Support Ticket
+          {t('support.newTicket')}
         </button>
       </div>
 
@@ -79,23 +55,23 @@ function SupportPage() {
           className={tab === 'tickets' ? 'active' : ''}
           onClick={() => setTab('tickets')}
         >
-          My Tickets ({tickets.length})
+          {t('support.myTickets', { count: tickets.length })}
         </button>
         <button
           className={tab === 'reports' ? 'active' : ''}
           onClick={() => setTab('reports')}
         >
-          My Wine Reports ({wineReports.length})
+          {t('support.myWineReports', { count: wineReports.length })}
         </button>
       </div>
 
-      {loading && <p className="support-loading">Loading…</p>}
+      {loading && <p className="support-loading">{t('support.loading')}</p>}
       {error && <p className="support-error">{error}</p>}
 
       {!loading && tab === 'tickets' && (
         <div className="support-list">
           {tickets.length === 0 ? (
-            <p className="support-empty">No support tickets yet. Use the button above to get help.</p>
+            <p className="support-empty">{t('support.noTickets')}</p>
           ) : (
             tickets.map(ticket => (
               <div key={ticket._id} className="support-card">
@@ -108,9 +84,9 @@ function SupportPage() {
                 >
                   <div className="support-card-meta">
                     <span className={`support-badge status-${ticket.status}`}>
-                      {STATUS_LABELS[ticket.status]}
+                      {t(`support.status.${ticket.status}`, ticket.status)}
                     </span>
-                    <span className="support-badge category">{CATEGORY_LABELS[ticket.category]}</span>
+                    <span className="support-badge category">{t(`support.category.${ticket.category}`, ticket.category)}</span>
                     <strong className="support-subject">{ticket.subject}</strong>
                   </div>
                   <span className="support-date">
@@ -121,12 +97,12 @@ function SupportPage() {
                 {expanded === ticket._id && (
                   <div className="support-card-body">
                     <div className="support-message">
-                      <h4>Your message</h4>
+                      <h4>{t('support.yourMessage')}</h4>
                       <p>{ticket.message}</p>
                     </div>
                     {ticket.adminResponse && (
                       <div className="support-response">
-                        <h4>Admin response</h4>
+                        <h4>{t('support.adminResponse')}</h4>
                         <p>{ticket.adminResponse}</p>
                         <span className="support-response-date">
                           {ticket.respondedAt
@@ -136,7 +112,7 @@ function SupportPage() {
                       </div>
                     )}
                     {!ticket.adminResponse && (
-                      <p className="support-awaiting">Awaiting admin response…</p>
+                      <p className="support-awaiting">{t('support.awaitingResponse')}</p>
                     )}
                   </div>
                 )}
@@ -149,7 +125,7 @@ function SupportPage() {
       {!loading && tab === 'reports' && (
         <div className="support-list">
           {wineReports.length === 0 ? (
-            <p className="support-empty">No wine reports yet. Use the "Report" button on any wine to flag an issue.</p>
+            <p className="support-empty">{t('support.noReports')}</p>
           ) : (
             wineReports.map(report => (
               <div key={report._id} className="support-card">
@@ -162,9 +138,9 @@ function SupportPage() {
                 >
                   <div className="support-card-meta">
                     <span className={`support-badge status-${report.status}`}>
-                      {REPORT_STATUS_LABELS[report.status]}
+                      {t(`support.reportStatus.${report.status}`, report.status)}
                     </span>
-                    <span className="support-badge category">{REASON_LABELS[report.reason]}</span>
+                    <span className="support-badge category">{t(`support.reason.${report.reason}`, report.reason)}</span>
                     <strong className="support-subject">
                       {report.wineDefinition?.name}
                       {report.wineDefinition?.producer ? ` — ${report.wineDefinition.producer}` : ''}
@@ -179,18 +155,18 @@ function SupportPage() {
                   <div className="support-card-body">
                     {report.details && (
                       <div className="support-message">
-                        <h4>Your details</h4>
+                        <h4>{t('support.yourDetails')}</h4>
                         <p>{report.details}</p>
                       </div>
                     )}
                     {report.adminNotes && (
                       <div className="support-response">
-                        <h4>Admin notes</h4>
+                        <h4>{t('support.adminNotes')}</h4>
                         <p>{report.adminNotes}</p>
                       </div>
                     )}
                     {report.status === 'pending' && !report.adminNotes && (
-                      <p className="support-awaiting">Under review…</p>
+                      <p className="support-awaiting">{t('support.underReview')}</p>
                     )}
                   </div>
                 )}

--- a/frontend/src/pages/UserProfile.js
+++ b/frontend/src/pages/UserProfile.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { getPublicProfile } from '../api/profiles';
 import { getUserReviews } from '../api/reviews';
@@ -11,6 +12,7 @@ import CellarCredBadge from '../components/CellarCredBadge';
 import './UserProfile.css';
 
 function UserProfile() {
+  const { t } = useTranslation();
   const { userId } = useParams();
   const { apiFetch, user: currentUser } = useAuth();
   const [profile, setProfile] = useState(null);
@@ -25,10 +27,15 @@ function UserProfile() {
   const [listModal, setListModal] = useState(null); // 'followers' | 'following' | null
   const [listUsers, setListUsers] = useState([]);
   const [listLoading, setListLoading] = useState(false);
+  const [listError, setListError] = useState(false);
 
   const isOwnProfile = currentUser?.id === userId;
 
   useEffect(() => {
+    // Reset stale state when navigating between profiles client-side,
+    // otherwise a previously-errored view stays stuck.
+    setLoading(true);
+    setError(null);
     fetchProfile();
     fetchReviews(1, true);
   }, [userId]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -40,10 +47,10 @@ function UserProfile() {
       if (res.ok) {
         setProfile(data.user);
       } else {
-        setError(data.error || 'Failed to load profile');
+        setError(data.error || t('userProfile.failedLoad'));
       }
     } catch {
-      setError('Failed to load profile');
+      setError(t('userProfile.failedLoad'));
     } finally {
       setLoading(false);
     }
@@ -70,6 +77,7 @@ function UserProfile() {
     setListModal(type);
     setListLoading(true);
     setListUsers([]);
+    setListError(false);
 
     try {
       const fetcher = type === 'followers' ? getFollowers : getFollowing;
@@ -77,9 +85,11 @@ function UserProfile() {
       const data = await res.json();
       if (res.ok) {
         setListUsers(data.users);
+      } else {
+        setListError(true);
       }
     } catch {
-      // silently fail
+      setListError(true);
     } finally {
       setListLoading(false);
     }
@@ -98,7 +108,7 @@ function UserProfile() {
   if (loading) {
     return (
       <div className="user-profile-page">
-        <p className="user-profile__loading">Loading...</p>
+        <p className="user-profile__loading">{t('userProfile.loading')}</p>
       </div>
     );
   }
@@ -106,7 +116,7 @@ function UserProfile() {
   if (error || !profile) {
     return (
       <div className="user-profile-page">
-        <div className="alert alert-error">{error || 'User not found'}</div>
+        <div className="alert alert-error">{error || t('userProfile.notFound')}</div>
       </div>
     );
   }
@@ -132,7 +142,7 @@ function UserProfile() {
               <p className="user-profile__username">@{profile.username}</p>
             )}
             {profile.bio && <p className="user-profile__bio">{profile.bio}</p>}
-            <p className="user-profile__joined">Member since {memberSince}</p>
+            <p className="user-profile__joined">{t('userProfile.memberSince', { date: memberSince })}</p>
           </div>
           {!isOwnProfile && (
             <div className="user-profile__actions">
@@ -148,23 +158,23 @@ function UserProfile() {
         <div className="user-profile__stats">
           <button className="user-profile__stat" onClick={() => openList('followers')}>
             <span className="user-profile__stat-value">{profile.followersCount}</span>
-            <span className="user-profile__stat-label">Followers</span>
+            <span className="user-profile__stat-label">{t('userProfile.followers')}</span>
           </button>
           <button className="user-profile__stat" onClick={() => openList('following')}>
             <span className="user-profile__stat-value">{profile.followingCount}</span>
-            <span className="user-profile__stat-label">Following</span>
+            <span className="user-profile__stat-label">{t('userProfile.following')}</span>
           </button>
           <div className="user-profile__stat">
             <span className="user-profile__stat-value">{profile.reviewCount}</span>
-            <span className="user-profile__stat-label">Reviews</span>
+            <span className="user-profile__stat-label">{t('userProfile.reviews')}</span>
           </div>
         </div>
       </div>
 
       <div className="user-profile__reviews">
-        <h2>Reviews</h2>
+        <h2>{t('userProfile.reviews')}</h2>
         {reviews.length === 0 ? (
-          <p className="user-profile__no-reviews">No reviews yet.</p>
+          <p className="user-profile__no-reviews">{t('userProfile.noReviews')}</p>
         ) : (
           reviews.map(review => (
             <ReviewCard key={review._id} review={review} showWine />
@@ -178,7 +188,7 @@ function UserProfile() {
               onClick={() => fetchReviews(reviewPage + 1)}
               disabled={loadingMore}
             >
-              {loadingMore ? 'Loading...' : 'Load More'}
+              {loadingMore ? t('userProfile.loading') : t('userProfile.loadMore')}
             </button>
           </div>
         )}
@@ -186,25 +196,31 @@ function UserProfile() {
 
       {listModal && (
         <Modal
-          title={listModal === 'followers' ? 'Followers' : 'Following'}
+          title={listModal === 'followers' ? t('userProfile.followers') : t('userProfile.following')}
           onClose={() => setListModal(null)}
         >
           {listLoading ? (
-            <p>Loading...</p>
+            <p>{t('userProfile.loading')}</p>
+          ) : listError ? (
+            <p className="alert alert-error">{t('userProfile.listError')}</p>
           ) : listUsers.length === 0 ? (
-            <p>None yet.</p>
+            <p>{t('userProfile.noneYet')}</p>
           ) : (
             <div className="user-profile__user-list">
               {listUsers.map(u => (
                 <div key={u._id} className="user-profile__user-item">
-                  <a href={`/users/${u._id}`} className="user-profile__user-link">
+                  <Link
+                    to={`/users/${u._id}`}
+                    className="user-profile__user-link"
+                    onClick={() => setListModal(null)}
+                  >
                     <span className="user-profile__user-avatar">
                       {(u.displayName || u.username || '?').charAt(0).toUpperCase()}
                     </span>
                     <span className="user-profile__user-name">
                       {u.displayName || u.username}
                     </span>
-                  </a>
+                  </Link>
                   {u._id !== currentUser?.id && (
                     <FollowButton userId={u._id} initialFollowing={u.isFollowing} />
                   )}
@@ -213,7 +229,7 @@ function UserProfile() {
             </div>
           )}
           <div className="modal-actions">
-            <button className="btn btn-secondary" onClick={() => setListModal(null)}>Close</button>
+            <button className="btn btn-secondary" onClick={() => setListModal(null)}>{t('userProfile.close')}</button>
           </div>
         </Modal>
       )}


### PR DESCRIPTION
Part of audit finding MED #36 (CODE_AUDIT_2026-07-08.md): three more pages fully localized under react-i18next, plus three LOW fixes in UserProfile.

## Surfaces localized

- **CellarChat.js** → `cellarChat.*` (47 keys): title, composer placeholder (incl. daily/weekly limit-reached variants), usage meter period labels, cellar-scope picker, all 4 starter-prompt categories + 16 prompts, tip block (`<Trans>` for the emphasized example), thinking/searching bubbles, error strings — the 429 quota messages are now client-rendered with `_one`/`_other` plurals (daily/weekly) and the burst 429 gets its own localized message instead of the raw backend English; aria-labels (New chat, Send).
- **UserProfile.js** → `userProfile.*` (12 keys): Loading..., Followers, Following, Reviews, Member since (interpolated date), No reviews yet., Load More, None yet., Close, User not found, failed-load + new modal error string.
- **SupportPage.js** → `support.*` (28 keys): header, tabs (with counts), empty/loading/error states, ticket + report card bodies, and the CATEGORY/STATUS/REASON/REPORT_STATUS label maps converted to `support.category.<slug>` / `support.status.<slug>` / `support.reason.<slug>` / `support.reportStatus.<slug>` lookups (with slug fallback for unknown values).

**87 new keys** appended to both `en/translation.json` and `sv/translation.json`; the two files remain structurally identical (symmetry-checked, 2449 keys each).

## UserProfile fixes (audit LOWs)

1. Followers/following modal user rows used raw `<a href>` causing a full app reload — now react-router `<Link>` that also closes the modal on click (matches ReviewFeed.js).
2. `getFollowers`/`getFollowing` failures were silently swallowed, leaving the modal showing "None yet." — the modal now shows an error state instead.
3. On client-side `userId` route changes, `loading`/`error` were never reset, so a previously-errored view stayed stuck — both are now reset in the `userId` effect.

## Notes

- Swedish strings are natural informal-"du" style matching the existing file; a native sv review pass is still recommended before release.
- `cd frontend && npm test`: 13 files, 337 tests, all passing.

## docker-compose impact
None — frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)