### PR TITLE
fix: localize remaining hardcoded strings in translated pages

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -282,7 +282,12 @@
     "removeDefault": "Remove as default cellar",
     "editRole": "Edit",
     "viewRole": "View",
-    "import": "Import"
+    "import": "Import",
+    "importTooltip": "Import a cellar export (.json or .zip)",
+    "ownedCount_one": "{{count}} owned",
+    "ownedCount_other": "{{count}} owned",
+    "sharedCount_one": "{{count}} shared",
+    "sharedCount_other": "{{count}} shared"
   },
 
   "cellarDetail": {
@@ -356,7 +361,19 @@
     "roomView": "Room View",
     "roomViewDesc": "3D cellar layout",
     "wineLists": "Wine Lists",
-    "wineListsDesc": "Restaurant menus & PDF"
+    "wineListsDesc": "Restaurant menus & PDF",
+    "importBottles": "Import Bottles",
+    "export": "Export",
+    "tabBottles": "Bottles",
+    "tabOverview": "Overview",
+    "viewRackLayout": "View rack layout",
+    "consumedBottles": "Consumed bottles",
+    "beta": "Beta",
+    "sortBottlesAria": "Sort bottles",
+    "removeFilterAria": "Remove {{label}}",
+    "groupBottleCount_one": "{{count}} bottle",
+    "groupBottleCount_other": "{{count}} bottles",
+    "collapseGroup": "Collapse ▲"
   },
 
   "addBottle": {
@@ -445,7 +462,12 @@
     "useCameraInstead": "Use camera instead",
     "searchManuallyInstead": "No camera? Search manually instead →",
     "searchBtn": "Search",
-    "searchHint": "Be as specific as possible — include the wine name and producer. We'll check our library first; if no match is found, we'll identify and add the wine."
+    "searchHint": "Be as specific as possible — include the wine name and producer. We'll check our library first; if no match is found, we'll identify and add the wine.",
+    "identifyFailed": "Identification failed",
+    "identifyNetworkError": "Network error during identification.",
+    "addFailed": "Failed to add bottle",
+    "partialAdded_one": "{{msg}} — {{count}} of {{total}} bottles was added. Retrying will add only the remaining {{remaining}}.",
+    "partialAdded_other": "{{msg}} — {{count}} of {{total}} bottles were added. Retrying will add only the remaining {{remaining}}."
   },
 
   "bottleDetail": {
@@ -526,7 +548,8 @@
     "tastingProfile": "Tasting profile",
     "structure": "Structure",
     "flavours": "Flavours",
-    "pairsWith": "Pairs with"
+    "pairsWith": "Pairs with",
+    "consumeError": "Failed to remove bottle"
   },
 
   "bottles": {
@@ -625,7 +648,11 @@
     "disabledSlotNote": "This slot is marked as unusable — bottles can't be placed here.",
     "preview": "Preview",
     "hidePreview": "Hide preview",
-    "previewLabel": "Preview — this is how the rack will look once created"
+    "previewLabel": "Preview — this is how the rack will look once created",
+    "viewCompact": "Compact",
+    "viewShelf": "Shelf view",
+    "view3d": "3D",
+    "consumeNotePlaceholder": "How was it?"
   },
 
   "nfc": {
@@ -798,7 +825,10 @@
       "cellarShareAdd": "Shared cellar",
       "cellarShareUpdate": "Changed share role",
       "cellarShareRemove": "Removed share"
-    }
+    },
+    "anonymous": "anonymous",
+    "sharedAs": "{{user}} as {{role}}",
+    "roleChanged": "Role changed: {{from}} → {{to}}"
   },
 
   "moveBottle": {
@@ -1259,6 +1289,8 @@
     "noCellars": "No cellars found",
     "noRatedBottles": "No rated bottles yet",
     "noneYet": "None yet",
+    "valueSeedStarted": "Value tracking has started. Your first data point will appear after the weekly snapshot runs.",
+    "valueSeedFirst": "Your first snapshot is recorded. Trend data will appear after next week's snapshot.",
 
     "typeLabels": {
       "red": "Red",
@@ -1815,6 +1847,21 @@
     "flavours": "Flavours",
     "pairsWith": "Pairs with"
   },
+  "taxonomy": {
+    "loading": "Loading…",
+    "grapeNotFound": "Grape not found.",
+    "regionNotFound": "Region not found.",
+    "countryNotFound": "Country not found.",
+    "wineTypeNotFound": "Wine type not found.",
+    "home": "Home",
+    "noWines": "No wines found.",
+    "alsoKnownAs": "Also known as:",
+    "agingPotential": "Aging potential:",
+    "typicalGrapes": "Typical grapes",
+    "regions": "Regions",
+    "prev": "← Prev",
+    "next": "Next →"
+  },
   "statsCard": {
     "title": "Your Cellar Card",
     "subtitle": "A snapshot of your wine collection — download or share it.",
@@ -1891,7 +1938,9 @@
     "yesAddEntry": "Yes, add journal entry",
     "notNow": "Not now",
     "dontAskAgain": "Don't ask again",
-    "loadMore": "Load more"
+    "loadMore": "Load more",
+    "dish": "Dish",
+    "wine": "Wine"
   },
   "restock": {
     "title": "Smart Restock",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -282,7 +282,12 @@
     "removeDefault": "Ta bort som standardkällare",
     "editRole": "Redigera",
     "viewRole": "Visa",
-    "import": "Importera"
+    "import": "Importera",
+    "importTooltip": "Importera en källarexport (.json eller .zip)",
+    "ownedCount_one": "{{count}} egen",
+    "ownedCount_other": "{{count}} egna",
+    "sharedCount_one": "{{count}} delad",
+    "sharedCount_other": "{{count}} delade"
   },
 
   "cellarDetail": {
@@ -356,7 +361,19 @@
     "roomView": "Rumsvy",
     "roomViewDesc": "3D-källarlayout",
     "wineLists": "Vinlistor",
-    "wineListsDesc": "Restaurangmenyer & PDF"
+    "wineListsDesc": "Restaurangmenyer & PDF",
+    "importBottles": "Importera flaskor",
+    "export": "Exportera",
+    "tabBottles": "Flaskor",
+    "tabOverview": "Översikt",
+    "viewRackLayout": "Visa hyllayout",
+    "consumedBottles": "Konsumerade flaskor",
+    "beta": "Beta",
+    "sortBottlesAria": "Sortera flaskor",
+    "removeFilterAria": "Ta bort {{label}}",
+    "groupBottleCount_one": "{{count}} flaska",
+    "groupBottleCount_other": "{{count}} flaskor",
+    "collapseGroup": "Fäll ihop ▲"
   },
 
   "addBottle": {
@@ -445,7 +462,12 @@
     "useCameraInstead": "Använd kameran istället",
     "searchManuallyInstead": "Ingen kamera? Sök manuellt istället →",
     "searchBtn": "Sök",
-    "searchHint": "Var så specifik som möjligt — ange både vinnamn och producent. Vi söker först i vårt bibliotek; om ingen träff hittas identifierar vi vinet och lägger till det."
+    "searchHint": "Var så specifik som möjligt — ange både vinnamn och producent. Vi söker först i vårt bibliotek; om ingen träff hittas identifierar vi vinet och lägger till det.",
+    "identifyFailed": "Identifieringen misslyckades",
+    "identifyNetworkError": "Nätverksfel under identifieringen.",
+    "addFailed": "Kunde inte lägga till flaskan",
+    "partialAdded_one": "{{msg}} — {{count}} av {{total}} flaskor lades till. Vid nytt försök läggs bara de återstående {{remaining}} till.",
+    "partialAdded_other": "{{msg}} — {{count}} av {{total}} flaskor lades till. Vid nytt försök läggs bara de återstående {{remaining}} till."
   },
 
   "bottleDetail": {
@@ -526,7 +548,8 @@
     "tastingProfile": "Smakprofil",
     "structure": "Struktur",
     "flavours": "Smaker",
-    "pairsWith": "Passar till"
+    "pairsWith": "Passar till",
+    "consumeError": "Kunde inte ta bort flaskan"
   },
 
   "bottles": {
@@ -625,7 +648,11 @@
     "disabledSlotNote": "Den här platsen är markerad som oanvändbar — flaskor kan inte placeras här.",
     "preview": "Förhandsgranska",
     "hidePreview": "Dölj förhandsgranskning",
-    "previewLabel": "Förhandsgranskning — så här kommer hyllan att se ut när den skapats"
+    "previewLabel": "Förhandsgranskning — så här kommer hyllan att se ut när den skapats",
+    "viewCompact": "Kompakt",
+    "viewShelf": "Hyllvy",
+    "view3d": "3D",
+    "consumeNotePlaceholder": "Hur var det?"
   },
 
   "nfc": {
@@ -798,7 +825,10 @@
       "cellarShareAdd": "Källare delad",
       "cellarShareUpdate": "Delningsroll ändrad",
       "cellarShareRemove": "Delning borttagen"
-    }
+    },
+    "anonymous": "anonym",
+    "sharedAs": "{{user}} som {{role}}",
+    "roleChanged": "Roll ändrad: {{from}} → {{to}}"
   },
 
   "moveBottle": {
@@ -1259,6 +1289,8 @@
     "noCellars": "Inga källare hittades",
     "noRatedBottles": "Inga betygsatta flaskor ännu",
     "noneYet": "Inga ännu",
+    "valueSeedStarted": "Värdespårningen har startat. Din första datapunkt visas efter att veckans ögonblicksbild har körts.",
+    "valueSeedFirst": "Din första ögonblicksbild är sparad. Trenddata visas efter nästa veckas ögonblicksbild.",
 
     "typeLabels": {
       "red": "Rött",
@@ -1815,6 +1847,21 @@
     "flavours": "Smaker",
     "pairsWith": "Passar till"
   },
+  "taxonomy": {
+    "loading": "Laddar…",
+    "grapeNotFound": "Druvan hittades inte.",
+    "regionNotFound": "Regionen hittades inte.",
+    "countryNotFound": "Landet hittades inte.",
+    "wineTypeNotFound": "Vintypen hittades inte.",
+    "home": "Hem",
+    "noWines": "Inga viner hittades.",
+    "alsoKnownAs": "Även känd som:",
+    "agingPotential": "Lagringspotential:",
+    "typicalGrapes": "Typiska druvor",
+    "regions": "Regioner",
+    "prev": "← Föregående",
+    "next": "Nästa →"
+  },
   "statsCard": {
     "title": "Ditt källarkort",
     "subtitle": "En ögonblicksbild av din vinsamling — ladda ner eller dela den.",
@@ -1891,7 +1938,9 @@
     "yesAddEntry": "Ja, lägg till anteckning",
     "notNow": "Inte nu",
     "dontAskAgain": "Fråga inte igen",
-    "loadMore": "Ladda fler"
+    "loadMore": "Ladda fler",
+    "dish": "Maträtt",
+    "wine": "Vin"
   },
   "restock": {
     "title": "Smart påfyllning",

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -245,11 +245,11 @@ function AddBottle() {
     try {
       const res = await identifyWineByText(apiFetch, search.trim());
       const data = await res.json();
-      if (!res.ok) { setAiSearchError(data.error || 'Identification failed'); return; }
+      if (!res.ok) { setAiSearchError(data.error || t('addBottle.identifyFailed')); return; }
       if (!data.wine) { setAiSearchError(t('addBottle.aiCouldNotIdentify')); return; }
       setAiResult(data.wine);
     } catch {
-      setAiSearchError('Network error during identification.');
+      setAiSearchError(t('addBottle.identifyNetworkError'));
     } finally {
       setAiSearching(false);
     }
@@ -298,7 +298,7 @@ function AddBottle() {
     // A partial failure leaves invisible bottles behind — tell the user
     // exactly what happened and what a retry will do.
     const partialError = (msg, done) => done > 0
-      ? `${msg} — ${done} of ${numBottles} bottle${numBottles === 1 ? '' : 's'} ${done === 1 ? 'was' : 'were'} added. Retrying will add only the remaining ${numBottles - done}.`
+      ? t('addBottle.partialAdded', { msg, count: done, total: numBottles, remaining: numBottles - done })
       : msg;
 
     try {
@@ -333,7 +333,7 @@ function AddBottle() {
 
         const data = await res.json();
         if (!res.ok) {
-          setError(partialError(data.error || 'Failed to add bottle', createdBottles.length));
+          setError(partialError(data.error || t('addBottle.addFailed'), createdBottles.length));
           linkUploadedImages();
           return;
         }
@@ -344,7 +344,7 @@ function AddBottle() {
       linkUploadedImages();
       navigate(`/cellars/${cellarId}`);
     } catch (err) {
-      setError(partialError('Network error', createdBottlesRef.current.length));
+      setError(partialError(t('common.networkError'), createdBottlesRef.current.length));
       linkUploadedImages();
     } finally {
       setSaving(false);

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -257,14 +257,19 @@ function BottleDetail() {
           navigate(`/cellars/${cellarId}`);
         }
       } else {
-        alert(data.error || 'Failed to remove bottle');
+        // Close the modal so the inline error banner is visible behind it.
+        setConsumeOpen(false);
+        setError(data.error || t('bottleDetail.consumeError'));
       }
     } catch {
-      alert('Network error');
+      setConsumeOpen(false);
+      setError(t('common.networkError'));
     }
   };
 
-  if (error) return <div className="alert alert-error">{error}</div>;
+  // Only replace the whole page when nothing has loaded yet; once the bottle
+  // is loaded, action failures render as a dismissible inline banner instead.
+  if (error && !bottle) return <div className="alert alert-error">{error}</div>;
 
   const wine = bottle?.wineDefinition;
   const isPending = !wine && !!bottle?.pendingWineRequest;
@@ -283,6 +288,19 @@ function BottleDetail() {
 
   return (
     <div className="bottle-detail-page">
+      {error && (
+        <div className="alert alert-error" role="alert">
+          {error}
+          <button
+            type="button"
+            className="btn btn-small btn-secondary"
+            style={{ marginLeft: '0.75rem' }}
+            onClick={() => setError(null)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
       {/* ── Clean header ── */}
       <div className="bd-page-header">
         <div className="bd-header-top">

--- a/frontend/src/pages/CellarAudit.js
+++ b/frontend/src/pages/CellarAudit.js
@@ -47,7 +47,7 @@ function fmtVal(val) {
   return String(val);
 }
 
-function formatDetail(action, detail) {
+function formatDetail(action, detail, t) {
   if (!detail || Object.keys(detail).length === 0) return null;
   if (action === 'bottle.add' && detail.wineName) {
     return `${detail.wineName}${detail.vintage ? ` · ${detail.vintage}` : ''}`;
@@ -62,10 +62,10 @@ function formatDetail(action, detail) {
       : `${wine}← ${detail.fromCellarName || '—'}`;
   }
   if (action === 'cellar.share.add') {
-    return `${detail.sharedWith} as ${detail.role}`;
+    return t('cellarAudit.sharedAs', { user: detail.sharedWith, role: detail.role });
   }
   if (action === 'cellar.share.update') {
-    return `Role changed: ${detail.from} → ${detail.to}`;
+    return t('cellarAudit.roleChanged', { from: detail.from, to: detail.to });
   }
   if (action === 'bottle.update' && detail.changes) {
     const entries = Object.entries(detail.changes);
@@ -127,7 +127,7 @@ function CellarAudit() {
       ) : (
         <div className="cellar-audit-list">
           {logs.map(log => {
-            const detail = formatDetail(log.action, log.detail);
+            const detail = formatDetail(log.action, log.detail, t);
             return (
               <div key={log._id} className="cellar-audit-item">
                 <div className="cellar-audit-icon">
@@ -144,7 +144,7 @@ function CellarAudit() {
                   </div>
                   <div className="cellar-audit-meta">
                     <span className="cellar-audit-user">
-                      {log.actor?.userId?.username || 'anonymous'}
+                      {log.actor?.userId?.username || t('cellarAudit.anonymous')}
                     </span>
                     <span className="cellar-audit-sep">·</span>
                     <span className="cellar-audit-time">

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -262,7 +262,7 @@ function CellarDetail() {
                   className="btn btn-secondary btn-small btn-more"
                   data-guide="more-menu-btn"
                   onClick={() => setMoreOpen(o => !o)}
-                  aria-label="More actions"
+                  aria-label={t('cellarDetail.moreActions')}
                   aria-haspopup="menu"
                   aria-expanded={moreOpen}
                 >
@@ -327,7 +327,7 @@ function CellarDetail() {
                           data-guide="cellar-import"
                           onClick={() => setMoreOpen(false)}
                         >
-                          <span aria-hidden="true">📥</span> Import Bottles
+                          <span aria-hidden="true">📥</span> {t('cellarDetail.importBottles')}
                         </Link>
                       )}
                       {cellar.userRole === 'owner' && (
@@ -336,7 +336,7 @@ function CellarDetail() {
                           className="more-menu-item"
                           onClick={() => setMoreOpen(false)}
                         >
-                          <span aria-hidden="true">📤</span> Export
+                          <span aria-hidden="true">📤</span> {t('cellarDetail.export')}
                         </Link>
                       )}
                       {cellar.userRole === 'owner' && (
@@ -393,7 +393,7 @@ function CellarDetail() {
           onClick={() => setActiveTab('bottles')}
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-          Bottles
+          {t('cellarDetail.tabBottles')}
           {statistics && <span className="tab-count">{statistics.totalBottles}</span>}
         </button>
         <button
@@ -401,7 +401,7 @@ function CellarDetail() {
           onClick={() => setActiveTab('overview')}
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
-          Overview
+          {t('cellarDetail.tabOverview')}
         </button>
       </div>
 
@@ -435,14 +435,14 @@ function CellarDetail() {
               <span className="overview-link-icon" aria-hidden="true">🗄️</span>
               <div>
                 <strong>{t('cellarDetail.racks')}</strong>
-                <span>View rack layout</span>
+                <span>{t('cellarDetail.viewRackLayout')}</span>
               </div>
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
             </Link>
             <Link to={`/cellars/${id}/room`} className="overview-link-card" data-guide="cellar-room">
               <span className="overview-link-icon" aria-hidden="true">🏠</span>
               <div>
-                <strong>{t('cellarDetail.roomView', 'Room View')} <span className="overview-beta-badge">Beta</span></strong>
+                <strong>{t('cellarDetail.roomView', 'Room View')} <span className="overview-beta-badge">{t('cellarDetail.beta')}</span></strong>
                 <span>{t('cellarDetail.roomViewDesc', '3D cellar layout')}</span>
               </div>
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
@@ -461,7 +461,7 @@ function CellarDetail() {
               <span className="overview-link-icon" aria-hidden="true">📖</span>
               <div>
                 <strong>{t('cellarDetail.history')}</strong>
-                <span>Consumed bottles</span>
+                <span>{t('cellarDetail.consumedBottles')}</span>
               </div>
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
             </Link>
@@ -537,7 +537,7 @@ function CellarDetail() {
                     value={filters.sort}
                     onChange={e => setFilters({ ...filters, sort: e.target.value })}
                     className="filter-select sort-select"
-                    aria-label="Sort bottles"
+                    aria-label={t('cellarDetail.sortBottlesAria')}
                   >
                     <option value="-createdAt">{t('cellarDetail.sortNewest')}</option>
                     <option value="createdAt">{t('cellarDetail.sortOldest')}</option>
@@ -568,7 +568,7 @@ function CellarDetail() {
                           type="button"
                           className="active-filter-chip-remove"
                           onClick={() => removeChip(chip)}
-                          aria-label={`Remove ${chip.label}`}
+                          aria-label={t('cellarDetail.removeFilterAria', { label: chip.label })}
                         >×</button>
                       </span>
                     ))}
@@ -756,13 +756,13 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                 />
               );
             }
-            const wineName = rep.wineDefinition?.name || rep.pendingWineRequest?.wineName || 'Unknown Wine';
+            const wineName = rep.wineDefinition?.name || rep.pendingWineRequest?.wineName || t('common.unknownWine');
             return (
               <Fragment key={item.key}>
                 <div className="bottle-group-bar">
-                  <span><strong>{wineName}</strong> · {rep.vintage || 'NV'} · {item.count} bottles</span>
+                  <span><strong>{wineName}</strong> · {rep.vintage || 'NV'} · {t('cellarDetail.groupBottleCount', { count: item.count })}</span>
                   <button type="button" className="bottle-group-collapse" onClick={() => toggleGroup(item.key)}>
-                    Collapse ▲
+                    {t('cellarDetail.collapseGroup')}
                   </button>
                 </div>
                 {item.bottles.map(b => (

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -263,7 +263,7 @@ function CellarHistory() {
           {activeChips.map((chip, i) => (
             <span key={`${chip.key}-${chip.value}-${i}`} className="active-filter-chip">
               {chip.label}
-              <button type="button" className="active-filter-chip-remove" onClick={() => removeChip(chip)} aria-label={`Remove ${chip.label}`}>×</button>
+              <button type="button" className="active-filter-chip-remove" onClick={() => removeChip(chip)} aria-label={t('cellarDetail.removeFilterAria', { label: chip.label })}>×</button>
             </span>
           ))}
           <button type="button" className="active-filters-clear" onClick={clearAll}>
@@ -320,7 +320,7 @@ function CellarHistory() {
         });
 
         if (filters.search && !anyVisible && total > 0) {
-          return <p className="history-no-results">{t('history.noResults', 'No bottles match your search.')}</p>;
+          return <p className="history-no-results">{t('history.noResults')}</p>;
         }
         return sections;
       })()}
@@ -339,7 +339,7 @@ function HistoryBottleCard({ bottle, cellarId, showCellarBadge = false }) {
   const linkCellarId = bottle.cellar || cellarId;
   const cellarBadge = showCellarBadge && bottle.cellarName ? bottle.cellarName : null;
   const consumedDate = bottle.consumedAt
-    ? new Date(bottle.consumedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+    ? new Date(bottle.consumedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
     : null;
 
   // One-tap add-to-wishlist: 'idle' → 'saving' → 'added' | 'error'.

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -378,7 +378,7 @@ function CellarRacks() {
                 className={`view-mode-btn ${viewMode === 'compact' ? 'active' : ''}`}
                 onClick={() => setViewMode('compact')}
               >
-                Compact
+                {t('racks.viewCompact')}
               </button>
               <button
                 role="tab"
@@ -386,7 +386,7 @@ function CellarRacks() {
                 className={`view-mode-btn ${viewMode === 'shelf' ? 'active' : ''}`}
                 onClick={() => setViewMode('shelf')}
               >
-                Shelf view
+                {t('racks.viewShelf')}
               </button>
               <button
                 role="tab"
@@ -394,7 +394,7 @@ function CellarRacks() {
                 className={`view-mode-btn ${viewMode === '3d' ? 'active' : ''}`}
                 onClick={() => setViewMode('3d')}
               >
-                3D
+                {t('racks.view3d')}
               </button>
             </div>
           )}
@@ -821,7 +821,7 @@ function EmptySlotContent({ position, apiFetch, cellarId, canEdit, onAssign, onD
             >
               <span className={`slot-bottle-type-dot type-${b.wineDefinition?.type || 'red'}`} aria-hidden="true" />
               <div className="slot-bottle-info">
-                <strong>{b.wineDefinition?.name || 'Unknown'}</strong>
+                <strong>{b.wineDefinition?.name || t('common.unknown')}</strong>
                 <span className="slot-bottle-meta">
                   {b.wineDefinition?.producer} &middot; {b.vintage}
                   {b.wineDefinition?.country?.name ? ` \u00B7 ${b.wineDefinition.country.name}` : ''}
@@ -879,7 +879,7 @@ function FilledSlotContent({ position, slot, canEdit, onRemoveFromRack, onConsum
       <div className="slot-bottle-detail">
         <WineImage image={wine?.image} alt={wine?.name} className="slot-detail-img" />
         <div className="slot-detail-info">
-          <h4>{wine?.name || 'Unknown'}</h4>
+          <h4>{wine?.name || t('common.unknown')}</h4>
           {wine?.producer && <p className="slot-detail-producer">{wine.producer}</p>}
           <p className="slot-detail-meta">
             <span className={`slot-bottle-type-dot type-${wine?.type || 'red'}`} />
@@ -964,7 +964,7 @@ function ConsumeModal({ defaultRatingScale, onSubmit, onCancel }) {
               value={note}
               onChange={e => setNote(e.target.value)}
               rows={2}
-              placeholder="How was it?"
+              placeholder={t('racks.consumeNotePlaceholder')}
             />
           </div>
           <div className="consume-modal-actions">

--- a/frontend/src/pages/Cellars.js
+++ b/frontend/src/pages/Cellars.js
@@ -105,7 +105,7 @@ function Cellars() {
             <Link
               to="/import-cellar"
               className="btn btn-secondary btn-small cellars-desktop-create"
-              title="Import a cellar export (.json or .zip)"
+              title={t('cellars.importTooltip')}
             >
               {t('cellars.import', 'Import')}
             </Link>
@@ -123,7 +123,7 @@ function Cellars() {
         </div>
         {cellars.length > 0 && (
           <p className="cellars-subtitle">
-            {ownedCellars.length} owned{cellars.length > ownedCellars.length ? `, ${cellars.length - ownedCellars.length} shared` : ''}
+            {t('cellars.ownedCount', { count: ownedCellars.length })}{cellars.length > ownedCellars.length ? `, ${t('cellars.sharedCount', { count: cellars.length - ownedCellars.length })}` : ''}
           </p>
         )}
       </div>

--- a/frontend/src/pages/CountryDetail.js
+++ b/frontend/src/pages/CountryDetail.js
@@ -34,8 +34,8 @@ export default function CountryDetail() {
     return () => { cancelled = true; };
   }, [slug, page]);
 
-  if (loading) return wrap(<div className="taxonomy-loading">Loading…</div>);
-  if (error || !data) return wrap(<div className="taxonomy-error"><p>Country not found.</p><Link to="/" className="btn btn-secondary">Home</Link></div>);
+  if (loading) return wrap(<div className="taxonomy-loading">{t('taxonomy.loading')}</div>);
+  if (error || !data) return wrap(<div className="taxonomy-error"><p>{t('taxonomy.countryNotFound')}</p><Link to="/" className="btn btn-secondary">{t('taxonomy.home')}</Link></div>);
 
   const { country, regions, wines, total } = data;
   const pages = Math.ceil(total / limit);
@@ -83,7 +83,7 @@ export default function CountryDetail() {
 
       {regions?.length > 0 && (
         <>
-          <h2 className="taxonomy-section-title">Regions</h2>
+          <h2 className="taxonomy-section-title">{t('taxonomy.regions')}</h2>
           <div className="taxonomy-related-list">
             {regions.map(r => (
               <Link key={r._id} to={`/regions/${r.slug}`} className="taxonomy-related-chip">
@@ -99,7 +99,7 @@ export default function CountryDetail() {
       </h2>
 
       {wines.length === 0 ? (
-        <p className="taxonomy-empty">No wines found.</p>
+        <p className="taxonomy-empty">{t('taxonomy.noWines')}</p>
       ) : (
         <div className="taxonomy-wine-grid">
           {wines.map(wine => (
@@ -114,9 +114,9 @@ export default function CountryDetail() {
 
       {pages > 1 && (
         <div className="taxonomy-pagination">
-          <button className="btn btn-secondary" disabled={page <= 1} onClick={() => setSearchParams({ page: page - 1 })}>← Prev</button>
+          <button className="btn btn-secondary" disabled={page <= 1} onClick={() => setSearchParams({ page: page - 1 })}>{t('taxonomy.prev')}</button>
           <span className="taxonomy-pagination-info">{page} / {pages}</span>
-          <button className="btn btn-secondary" disabled={page >= pages} onClick={() => setSearchParams({ page: page + 1 })}>Next →</button>
+          <button className="btn btn-secondary" disabled={page >= pages} onClick={() => setSearchParams({ page: page + 1 })}>{t('taxonomy.next')}</button>
         </div>
       )}
     </div>

--- a/frontend/src/pages/GrapeDetail.js
+++ b/frontend/src/pages/GrapeDetail.js
@@ -34,8 +34,8 @@ export default function GrapeDetail() {
     return () => { cancelled = true; };
   }, [slug, page]);
 
-  if (loading) return wrap(<div className="taxonomy-loading">Loading…</div>);
-  if (error || !data) return wrap(<div className="taxonomy-error"><p>Grape not found.</p><Link to="/" className="btn btn-secondary">Home</Link></div>);
+  if (loading) return wrap(<div className="taxonomy-loading">{t('taxonomy.loading')}</div>);
+  if (error || !data) return wrap(<div className="taxonomy-error"><p>{t('taxonomy.grapeNotFound')}</p><Link to="/" className="btn btn-secondary">{t('taxonomy.home')}</Link></div>);
 
   const { grape, wines, total } = data;
   const pages = Math.ceil(total / limit);
@@ -93,13 +93,13 @@ export default function GrapeDetail() {
 
       {grape.synonyms?.length > 0 && (
         <p className="taxonomy-description" style={{ fontSize: '0.88rem' }}>
-          Also known as: {grape.synonyms.join(', ')}
+          {t('taxonomy.alsoKnownAs')} {grape.synonyms.join(', ')}
         </p>
       )}
 
       {grape.agingPotential && (
         <p className="taxonomy-description" style={{ fontSize: '0.88rem' }}>
-          Aging potential: {grape.agingPotential}
+          {t('taxonomy.agingPotential')} {grape.agingPotential}
         </p>
       )}
 
@@ -108,7 +108,7 @@ export default function GrapeDetail() {
       </h2>
 
       {wines.length === 0 ? (
-        <p className="taxonomy-empty">No wines found.</p>
+        <p className="taxonomy-empty">{t('taxonomy.noWines')}</p>
       ) : (
         <div className="taxonomy-wine-grid">
           {wines.map(wine => (
@@ -123,9 +123,9 @@ export default function GrapeDetail() {
 
       {pages > 1 && (
         <div className="taxonomy-pagination">
-          <button className="btn btn-secondary" disabled={page <= 1} onClick={() => setSearchParams({ page: page - 1 })}>← Prev</button>
+          <button className="btn btn-secondary" disabled={page <= 1} onClick={() => setSearchParams({ page: page - 1 })}>{t('taxonomy.prev')}</button>
           <span className="taxonomy-pagination-info">{page} / {pages}</span>
-          <button className="btn btn-secondary" disabled={page >= pages} onClick={() => setSearchParams({ page: page + 1 })}>Next →</button>
+          <button className="btn btn-secondary" disabled={page >= pages} onClick={() => setSearchParams({ page: page + 1 })}>{t('taxonomy.next')}</button>
         </div>
       )}
     </div>

--- a/frontend/src/pages/Journal.js
+++ b/frontend/src/pages/Journal.js
@@ -206,11 +206,11 @@ export default function Journal() {
                             <div key={i}>
                               <div className="journal-card__pairing">
                                 <div className="journal-card__pairing-dish">
-                                  <span className="journal-card__pairing-icon">Dish</span>
+                                  <span className="journal-card__pairing-icon">{t('journal.dish', 'Dish')}</span>
                                   <span className="journal-card__pairing-text">{p.dish || '—'}</span>
                                 </div>
                                 <div className="journal-card__pairing-wine">
-                                  <span className="journal-card__pairing-icon">Wine</span>
+                                  <span className="journal-card__pairing-icon">{t('journal.wine', 'Wine')}</span>
                                   <span className="journal-card__pairing-text">
                                     {wineName || '—'}{vintage ? ` ${vintage}` : ''}
                                   </span>

--- a/frontend/src/pages/RegionDetail.js
+++ b/frontend/src/pages/RegionDetail.js
@@ -34,8 +34,8 @@ export default function RegionDetail() {
     return () => { cancelled = true; };
   }, [slug, page]);
 
-  if (loading) return wrap(<div className="taxonomy-loading">Loading…</div>);
-  if (error || !data) return wrap(<div className="taxonomy-error"><p>Region not found.</p><Link to="/" className="btn btn-secondary">Home</Link></div>);
+  if (loading) return wrap(<div className="taxonomy-loading">{t('taxonomy.loading')}</div>);
+  if (error || !data) return wrap(<div className="taxonomy-error"><p>{t('taxonomy.regionNotFound')}</p><Link to="/" className="btn btn-secondary">{t('taxonomy.home')}</Link></div>);
 
   const { region, wines, total } = data;
   const pages = Math.ceil(total / limit);
@@ -89,7 +89,7 @@ export default function RegionDetail() {
 
       {region.typicalGrapes?.length > 0 && (
         <>
-          <h2 className="taxonomy-section-title">Typical grapes</h2>
+          <h2 className="taxonomy-section-title">{t('taxonomy.typicalGrapes')}</h2>
           <div className="taxonomy-related-list">
             {region.typicalGrapes.map(g => (
               <Link key={g._id} to={`/grapes/${g.slug}`} className="taxonomy-related-chip">
@@ -105,7 +105,7 @@ export default function RegionDetail() {
       </h2>
 
       {wines.length === 0 ? (
-        <p className="taxonomy-empty">No wines found.</p>
+        <p className="taxonomy-empty">{t('taxonomy.noWines')}</p>
       ) : (
         <div className="taxonomy-wine-grid">
           {wines.map(wine => (
@@ -120,9 +120,9 @@ export default function RegionDetail() {
 
       {pages > 1 && (
         <div className="taxonomy-pagination">
-          <button className="btn btn-secondary" disabled={page <= 1} onClick={() => setSearchParams({ page: page - 1 })}>← Prev</button>
+          <button className="btn btn-secondary" disabled={page <= 1} onClick={() => setSearchParams({ page: page - 1 })}>{t('taxonomy.prev')}</button>
           <span className="taxonomy-pagination-info">{page} / {pages}</span>
-          <button className="btn btn-secondary" disabled={page >= pages} onClick={() => setSearchParams({ page: page + 1 })}>Next →</button>
+          <button className="btn btn-secondary" disabled={page >= pages} onClick={() => setSearchParams({ page: page + 1 })}>{t('taxonomy.next')}</button>
         </div>
       )}
     </div>

--- a/frontend/src/pages/Statistics.js
+++ b/frontend/src/pages/Statistics.js
@@ -283,8 +283,8 @@ function Statistics() {
             </h2>
             <p className="value-chart-seed-msg">
               {valueHistory.snapshots.length === 0
-                ? 'Value tracking has started. Your first data point will appear after the weekly snapshot runs.'
-                : 'Your first snapshot is recorded. Trend data will appear after next week\'s snapshot.'}
+                ? t('statistics.valueSeedStarted')
+                : t('statistics.valueSeedFirst')}
             </p>
           </div>
         </div>

--- a/frontend/src/pages/WineTypeDetail.js
+++ b/frontend/src/pages/WineTypeDetail.js
@@ -43,8 +43,8 @@ export default function WineTypeDetail() {
     return () => { cancelled = true; };
   }, [type, page]);
 
-  if (loading) return wrap(<div className="taxonomy-loading">Loading…</div>);
-  if (error || !data) return wrap(<div className="taxonomy-error"><p>Wine type not found.</p><Link to="/" className="btn btn-secondary">Home</Link></div>);
+  if (loading) return wrap(<div className="taxonomy-loading">{t('taxonomy.loading')}</div>);
+  if (error || !data) return wrap(<div className="taxonomy-error"><p>{t('taxonomy.wineTypeNotFound')}</p><Link to="/" className="btn btn-secondary">{t('taxonomy.home')}</Link></div>);
 
   const { wines, total } = data;
   const pages = Math.ceil(total / limit);
@@ -91,7 +91,7 @@ export default function WineTypeDetail() {
       </h2>
 
       {wines.length === 0 ? (
-        <p className="taxonomy-empty">No wines found.</p>
+        <p className="taxonomy-empty">{t('taxonomy.noWines')}</p>
       ) : (
         <div className="taxonomy-wine-grid">
           {wines.map(wine => (
@@ -108,9 +108,9 @@ export default function WineTypeDetail() {
 
       {pages > 1 && (
         <div className="taxonomy-pagination">
-          <button className="btn btn-secondary" disabled={page <= 1} onClick={() => setSearchParams({ page: page - 1 })}>← Prev</button>
+          <button className="btn btn-secondary" disabled={page <= 1} onClick={() => setSearchParams({ page: page - 1 })}>{t('taxonomy.prev')}</button>
           <span className="taxonomy-pagination-info">{page} / {pages}</span>
-          <button className="btn btn-secondary" disabled={page >= pages} onClick={() => setSearchParams({ page: page + 1 })}>Next →</button>
+          <button className="btn btn-secondary" disabled={page >= pages} onClick={() => setSearchParams({ page: page + 1 })}>{t('taxonomy.next')}</button>
         </div>
       )}
     </div>


### PR DESCRIPTION
Fixes audit finding **MED #38 — part 2: page-level partial strings** (CODE_AUDIT_2026-07-08.md). These pages were mostly translated but still contained leftover hardcoded English.

## Surfaces fixed

| Page | What was localized |
|---|---|
| **CellarDetail** | "Import Bottles" / "Export" menu items, "Bottles"/"Overview" tab labels, "View rack layout", "Consumed bottles", "Beta" badge, "{n} bottles" group bar (plural-aware) + "Collapse ▲", aria-labels "More actions" (reuses existing key) / "Sort bottles" / "Remove {label}" chip, "Unknown Wine" fallback (reuses `common.unknownWine`) |
| **Cellars** | Import tooltip, "X owned, Y shared" subtitle (plural-aware `ownedCount`/`sharedCount`) |
| **CellarHistory** | `toLocaleDateString('en-US', …)` → locale-neutral `undefined` (matches Journal/CellarAudit), "Remove {label}" chip aria, dropped inline fallback for already-existing `history.noResults` |
| **CellarRacks** | "Compact"/"Shelf view"/"3D" view toggles, "How was it?" placeholder, 'Unknown' fallbacks (reuse `common.unknown`) |
| **CellarAudit** | Sentence fragments restructured into interpolated keys: `sharedAs` ("{{user}} as {{role}}"), `roleChanged` ("Role changed: {{from}} → {{to}}"), plus 'anonymous' fallback — `formatDetail()` now takes `t` |
| **Statistics** | Both value-history seed messages → `statistics.valueSeedStarted` / `valueSeedFirst` |
| **BottleDetail** | Consume-failure `alert()`s replaced with the page's dismissible inline error banner (same pattern as CellarDetail/CellarHistory) + localized; full-page error now only when the bottle never loaded |
| **AddBottle** | Error fallbacks: "Identification failed", "Network error during identification.", "Failed to add bottle", "Network error" (reuses `common.networkError`), and the partial-batch retry message → plural-aware `partialAdded` |
| **Journal** | "Dish" / "Wine" pairing labels |
| **Taxonomy pages** (Grape/Region/Country/WineType Detail) | Shared new `taxonomy.*` namespace: "Loading…", "<X> not found.", "Home", "No wines found.", "Also known as:", "Aging potential:", "Typical grapes", "Regions", "← Prev", "Next →" |

## Locale keys

- **48 new keys** added to each locale file (en + sv), incl. the new top-level `taxonomy` namespace (13 keys) shared by the four taxonomy pages.
- en = previous hardcoded strings verbatim; sv = natural informal-"du" Swedish — **please native-review the Swedish strings** (notably `ownedCount`/`sharedCount` plural forms, "ögonblicksbild" for snapshot, "Fäll ihop" for Collapse).
- en/sv verified structurally identical (2409 flattened keys each, zero asymmetries); existing content untouched — only coherent appended blocks.

## Behavior changes (only where specified)

- BottleDetail: consume failure no longer uses `alert()` — shows dismissible inline error banner and closes the modal.
- CellarHistory: consumed date now formats in the browser locale instead of forced `en-US`.

## Testing

- `cd frontend && npm test` — 13 files, **337 tests passed**.
- en/sv key-symmetry check passed.

## docker-compose impact
None — frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)