### PR TITLE
fix: localize main nav and shared components (audit MED #38, part 1)

### DIFF
--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -33,7 +33,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
   const imgSrc = bottle.defaultImageUrl || bottle.wineDefinition?.image || bottle.pendingImageUrl;
   const credit = bottle.defaultImageUrl ? null : bottle.wineDefinition?.imageCredit;
   const isPending = !bottle.wineDefinition && !!bottle.pendingWineRequest;
-  const displayName = bottle.wineDefinition?.name || bottle.pendingWineRequest?.wineName || 'Unknown Wine';
+  const displayName = bottle.wineDefinition?.name || bottle.pendingWineRequest?.wineName || t('common.unknownWine');
   const displayProducer = bottle.wineDefinition?.producer || bottle.pendingWineRequest?.producer;
   const maturityInfo = bottle.maturityStatus ? MATURITY_LABELS[bottle.maturityStatus] : null;
 
@@ -49,7 +49,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
         role="button"
         tabIndex={0}
         onKeyDown={handleKey}
-        title={isGroup ? `${groupCount} identical bottles — click to expand` : undefined}
+        title={isGroup ? t('bottleCard.groupTooltip', { count: groupCount }) : undefined}
       >
         {isGroup && <span className="bottle-count-badge">×{groupCount}</span>}
         <div className="bottle-grid-image-wrap">
@@ -84,7 +84,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
               </span>
             )}
             {isPending && (
-              <span className="pending-wine-badge">Pending review</span>
+              <span className="pending-wine-badge">{t('bottleCard.pendingReview')}</span>
             )}
             {maturityInfo && (
               <span className={`maturity-badge ${maturityInfo.cls}`}>{t(maturityInfo.key)}</span>
@@ -115,7 +115,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
       role="button"
       tabIndex={0}
       onKeyDown={handleKey}
-      title={isGroup ? `${groupCount} identical bottles — click to expand` : undefined}
+      title={isGroup ? t('bottleCard.groupTooltip', { count: groupCount }) : undefined}
     >
       {imgSrc ? (
         <div className="bottle-img-wrap">
@@ -148,7 +148,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
             </span>
           )}
           {isPending && (
-            <span className="pending-wine-badge">Pending review</span>
+            <span className="pending-wine-badge">{t('bottleCard.pendingReview')}</span>
           )}
           {maturityInfo && (
             <span className={`maturity-badge ${maturityInfo.cls}`}>{t(maturityInfo.key)}</span>

--- a/frontend/src/components/ErrorBoundary.js
+++ b/frontend/src/components/ErrorBoundary.js
@@ -1,4 +1,16 @@
 import { Component } from 'react';
+import i18n from '../i18n';
+
+// The boundary must render even if i18n itself failed to initialize —
+// never let a translation lookup throw inside the fallback UI.
+function tSafe(key, fallback) {
+  try {
+    const value = i18n.t(key);
+    return value && value !== key ? value : fallback;
+  } catch {
+    return fallback;
+  }
+}
 
 /**
  * Catches unhandled React render errors and shows a friendly fallback UI
@@ -31,10 +43,10 @@ class ErrorBoundary extends Component {
           textAlign: 'center'
         }}>
           <h1 style={{ fontSize: '1.5rem', color: 'var(--color-danger)', marginBottom: '1rem' }}>
-            Something went wrong
+            {tSafe('errorBoundary.title', 'Something went wrong')}
           </h1>
           <p style={{ color: 'var(--color-text-muted)', marginBottom: '1.5rem' }}>
-            An unexpected error occurred. Please refresh the page to try again.
+            {tSafe('errorBoundary.message', 'An unexpected error occurred. Please refresh the page to try again.')}
           </p>
           <button
             onClick={() => window.location.reload()}
@@ -48,7 +60,7 @@ class ErrorBoundary extends Component {
               fontSize: '1rem'
             }}
           >
-            Refresh Page
+            {tSafe('errorBoundary.refresh', 'Refresh Page')}
           </button>
           {import.meta.env.DEV && this.state.error && (
             <pre style={{

--- a/frontend/src/components/FollowButton.js
+++ b/frontend/src/components/FollowButton.js
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { followUser, unfollowUser } from '../api/follows';
 import './FollowButton.css';
 
 export default function FollowButton({ userId, initialFollowing, onToggle }) {
+  const { t } = useTranslation();
   const { apiFetch } = useAuth();
   const [following, setFollowing] = useState(initialFollowing);
   const [loading, setLoading] = useState(false);
@@ -38,7 +40,7 @@ export default function FollowButton({ userId, initialFollowing, onToggle }) {
       onClick={handleToggle}
       disabled={loading}
     >
-      {following ? 'Following' : 'Follow'}
+      {following ? t('followButton.following') : t('followButton.follow')}
     </button>
   );
 }

--- a/frontend/src/components/GrapePicker.js
+++ b/frontend/src/components/GrapePicker.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import './GrapePicker.css';
 
 /**
@@ -10,6 +11,7 @@ import './GrapePicker.css';
  *   onChange — callback(newSelectedIds[])
  */
 function GrapePicker({ grapes = [], selected = [], onChange }) {
+  const { t } = useTranslation();
   const [search, setSearch] = useState('');
 
   const selectedSet = new Set(selected);
@@ -33,7 +35,7 @@ function GrapePicker({ grapes = [], selected = [], onChange }) {
                 type="button"
                 className="gpw-chip-remove"
                 onClick={() => remove(g._id)}
-                aria-label={`Remove ${g.name}`}
+                aria-label={t('grapePicker.removeGrape', { name: g.name })}
               >
                 ×
               </button>
@@ -46,7 +48,7 @@ function GrapePicker({ grapes = [], selected = [], onChange }) {
       <input
         type="text"
         className="gpw-search"
-        placeholder={`Search ${grapes.length} grape${grapes.length !== 1 ? 's' : ''}…`}
+        placeholder={t('grapePicker.searchPlaceholder', { count: grapes.length })}
         value={search}
         onChange={e => setSearch(e.target.value)}
       />
@@ -55,7 +57,7 @@ function GrapePicker({ grapes = [], selected = [], onChange }) {
       <div className="gpw-options">
         {availableGrapes.length === 0 ? (
           <span className="gpw-empty">
-            {search ? `No grapes match "${search}"` : 'All grapes selected'}
+            {search ? t('grapePicker.noMatch', { search }) : t('grapePicker.allSelected')}
           </span>
         ) : (
           availableGrapes.map(g => (

--- a/frontend/src/components/ImageUpload.js
+++ b/frontend/src/components/ImageUpload.js
@@ -1,10 +1,12 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import AuthImage from './AuthImage';
 import { API_URL } from '../api/apiConstants';
 import './ImageUpload.css';
 
 function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onProcessingComplete }) {
+  const { t } = useTranslation();
   const { apiFetch } = useAuth();
   const [uploading, setUploading] = useState(false);
   const [images, setImages] = useState([]);
@@ -105,11 +107,11 @@ function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onP
         if (onUploadComplete) onUploadComplete(data.image);
         pollImage(data.image._id);
       } else {
-        setError(data.error || 'Upload failed');
+        setError(data.error || t('imageUpload.uploadFailed'));
         URL.revokeObjectURL(localSrc);
       }
     } catch (err) {
-      setError('Network error during upload');
+      setError(t('imageUpload.networkError'));
       URL.revokeObjectURL(localSrc);
     } finally {
       setUploading(false);
@@ -183,14 +185,14 @@ function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onP
       });
     } catch (err) {
       if (err.name === 'NotAllowedError') {
-        setCameraError('Camera access denied. Please allow camera permissions.');
+        setCameraError(t('camera.accessDenied'));
       } else if (err.name === 'NotFoundError') {
-        setCameraError('No camera found on this device.');
+        setCameraError(t('camera.notFound'));
       } else {
-        setCameraError('Could not access camera: ' + err.message);
+        setCameraError(t('camera.accessErrorDetail', { message: err.message }));
       }
     }
-  }, [facingMode]);
+  }, [facingMode, t]);
 
   const switchCamera = useCallback(() => {
     const newMode = facingMode === 'environment' ? 'user' : 'environment';
@@ -241,21 +243,21 @@ function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onP
             {cameraError ? (
               <div className="camera-error-overlay">
                 <p>{cameraError}</p>
-                <button type="button" className="btn btn-secondary" onClick={stopCamera}>Close</button>
+                <button type="button" className="btn btn-secondary" onClick={stopCamera}>{t('common.close')}</button>
               </div>
             ) : (
               <>
                 <video ref={videoRef} autoPlay playsInline muted className="camera-video" />
                 <div className="camera-overlay">
                   <img src="/bottle-overlay.png" alt="" className="bottle-guide" aria-hidden="true" />
-                  <p className="overlay-hint">Place bottle in the center</p>
+                  <p className="overlay-hint">{t('camera.placeBottle')}</p>
                 </div>
                 <div className="camera-controls">
-                  <button type="button" className="camera-btn camera-btn-close" onClick={stopCamera} aria-label="Close camera">✕</button>
-                  <button type="button" className="camera-btn camera-btn-capture" onClick={capturePhoto} aria-label="Take photo">
+                  <button type="button" className="camera-btn camera-btn-close" onClick={stopCamera} aria-label={t('camera.closeCamera')}>✕</button>
+                  <button type="button" className="camera-btn camera-btn-capture" onClick={capturePhoto} aria-label={t('camera.takePhoto')}>
                     <span className="capture-ring" aria-hidden="true"></span>
                   </button>
-                  <button type="button" className="camera-btn camera-btn-switch" onClick={switchCamera} aria-label="Switch camera">⟲</button>
+                  <button type="button" className="camera-btn camera-btn-switch" onClick={switchCamera} aria-label={t('camera.switchCamera')}>⟲</button>
                 </div>
               </>
             )}
@@ -268,7 +270,7 @@ function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onP
       <div className="upload-buttons">
         <button type="button" className="btn btn-upload" onClick={startCamera} disabled={uploading || cameraOpen}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
-          Take Photo
+          {t('camera.takePhotoButton')}
         </button>
 
         <input
@@ -281,11 +283,11 @@ function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onP
         />
         <button type="button" className="btn btn-upload btn-upload-secondary" onClick={() => fileInputRef.current?.click()} disabled={uploading}>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-          Upload
+          {t('imageUpload.upload')}
         </button>
       </div>
 
-      {uploading && <p className="upload-status">Uploading...</p>}
+      {uploading && <p className="upload-status">{t('imageUpload.uploading')}</p>}
       {error && <div className="upload-error">{error}</div>}
 
       {images.length > 0 && (
@@ -296,34 +298,34 @@ function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onP
                 {img.status === 'processed' && img.processedSrc ? (
                   <AuthImage
                     src={img.processedSrc.startsWith('http') ? img.processedSrc : `${API_URL}${img.processedSrc}`}
-                    alt="Processed"
+                    alt={t('imageUpload.processedAlt')}
                     className="preview-img"
                   />
                 ) : (
                   <img
                     src={img.originalSrc}
-                    alt="Original"
+                    alt={t('imageUpload.originalAlt')}
                     className={`preview-img ${img.status === 'processing' ? 'preview-img-dimmed' : ''}`}
                   />
                 )}
                 {img.status === 'processing' && (
                   <div className="preview-overlay">
                     <div className="spinner"></div>
-                    <span>Removing background...</span>
+                    <span>{t('imageUpload.removingBackground')}</span>
                   </div>
                 )}
                 {img.status === 'failed' && (
                   <div className="preview-overlay preview-overlay-failed">
-                    <span>Processing failed</span>
-                    <button type="button" className="btn-retry" onClick={() => retryImage(img.id)}>Retry</button>
+                    <span>{t('imageUpload.processingFailed')}</span>
+                    <button type="button" className="btn-retry" onClick={() => retryImage(img.id)}>{t('imageUpload.retry')}</button>
                   </div>
                 )}
               </div>
               <div className="preview-footer">
-                {img.status === 'processed' && <span className="preview-badge-ok">Ready</span>}
-                {img.status === 'processing' && <span className="preview-badge-processing">Processing</span>}
-                {img.status === 'failed' && <span className="preview-badge-failed">Failed</span>}
-                <button type="button" className="btn-remove" onClick={() => removeImage(img.id)} aria-label="Remove this image">✕ Remove</button>
+                {img.status === 'processed' && <span className="preview-badge-ok">{t('imageUpload.ready')}</span>}
+                {img.status === 'processing' && <span className="preview-badge-processing">{t('imageUpload.processing')}</span>}
+                {img.status === 'failed' && <span className="preview-badge-failed">{t('imageUpload.failed')}</span>}
+                <button type="button" className="btn-remove" onClick={() => removeImage(img.id)} aria-label={t('imageUpload.removeThisImage')}>✕ {t('imageUpload.remove')}</button>
               </div>
             </div>
           ))}

--- a/frontend/src/components/InstallPrompt.js
+++ b/frontend/src/components/InstallPrompt.js
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 function InstallPrompt() {
+  const { t } = useTranslation();
   const [deferredPrompt, setDeferredPrompt] = useState(null);
   const [dismissed, setDismissed] = useState(false);
 
@@ -40,13 +42,13 @@ function InstallPrompt() {
   return (
     <div className="install-prompt">
       <span className="install-prompt-text">
-        Install Cellarion for quick access
+        {t('installPrompt.message')}
       </span>
       <div className="install-prompt-actions">
         <button className="btn btn-primary btn-sm" onClick={handleInstall}>
-          Install
+          {t('installPrompt.install')}
         </button>
-        <button className="install-prompt-dismiss" onClick={handleDismiss} aria-label="Dismiss">
+        <button className="install-prompt-dismiss" onClick={handleDismiss} aria-label={t('installPrompt.dismiss')}>
           &times;
         </button>
       </div>

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -78,35 +78,35 @@ function Layout({ children }) {
                   className={`nav-link ${isActive('/statistics') ? 'active' : ''}`}
                   data-guide="nav-statistics"
                 >
-                  Analytics
+                  {t('nav.analytics')}
                 </Link>
                 <Link
                   to="/restock"
                   className={`nav-link ${isActive('/restock') ? 'active' : ''}`}
                   data-guide="nav-restock"
                 >
-                  Restock
+                  {t('nav.restock')}
                 </Link>
                 <Link
                   to="/wishlist"
                   className={`nav-link ${isActive('/wishlist') ? 'active' : ''}`}
                   data-guide="nav-wishlist"
                 >
-                  Wishlist
+                  {t('nav.wishlist')}
                 </Link>
                 <Link
                   to="/recommendations"
                   className={`nav-link ${isActive('/recommendations') ? 'active' : ''}`}
                   data-guide="nav-recommendations"
                 >
-                  Recommendations
+                  {t('nav.recommendations')}
                 </Link>
                 <Link
                   to="/journal"
                   className={`nav-link ${isActive('/journal') ? 'active' : ''}`}
                   data-guide="nav-journal"
                 >
-                  Journal
+                  {t('nav.journal')}
                 </Link>
                 <Link
                   to="/wine-requests"
@@ -120,14 +120,14 @@ function Layout({ children }) {
                   className={`nav-link ${isActive('/community') ? 'active' : ''}`}
                   data-guide="nav-community"
                 >
-                  Community
+                  {t('nav.community')}
                 </Link>
                 <Link
                   to="/cellar-chat"
                   className={`nav-link ${isActive('/cellar-chat') ? 'active' : ''}`}
                   data-guide="nav-cellar-chat"
                 >
-                  Cellar Chat
+                  {t('nav.cellarChat')}
                 </Link>
                 <Link
                   to="/blog"
@@ -145,7 +145,7 @@ function Layout({ children }) {
                   to="/support"
                   className={`nav-link ${isActive('/support') ? 'active' : ''}`}
                 >
-                  Support
+                  {t('nav.support')}
                 </Link>
 
                 {(roles.includes('somm') || roles.includes('admin')) && (
@@ -172,9 +172,9 @@ function Layout({ children }) {
                     <Link
                       to="/superadmin"
                       className={`nav-link nav-link--admin ${isActive('/superadmin') ? 'active' : ''}`}
-                      title="System Monitor"
+                      title={t('nav.systemMonitor')}
                     >
-                      System Monitor
+                      {t('nav.systemMonitor')}
                     </Link>
                   </>
                 )}
@@ -186,8 +186,8 @@ function Layout({ children }) {
                     <Link to="/admin/requests" className={`nav-link nav-link--admin ${isActive('/admin/requests') ? 'active' : ''}`}>{t('nav.adminRequests')}</Link>
                     <Link to="/admin/taxonomy" className={`nav-link nav-link--admin ${isActive('/admin/taxonomy') ? 'active' : ''}`}>{t('nav.taxonomy')}</Link>
                     <Link to="/admin/images" className={`nav-link nav-link--admin ${isActive('/admin/images') ? 'active' : ''}`}>{t('nav.imageReview')}</Link>
-                    <Link to="/admin/support" className={`nav-link nav-link--admin ${isActive('/admin/support') ? 'active' : ''}`}>Support Tickets</Link>
-                    <Link to="/admin/wine-reports" className={`nav-link nav-link--admin ${isActive('/admin/wine-reports') ? 'active' : ''}`}>Wine Reports</Link>
+                    <Link to="/admin/support" className={`nav-link nav-link--admin ${isActive('/admin/support') ? 'active' : ''}`}>{t('nav.supportTickets')}</Link>
+                    <Link to="/admin/wine-reports" className={`nav-link nav-link--admin ${isActive('/admin/wine-reports') ? 'active' : ''}`}>{t('nav.wineReports')}</Link>
                     <Link to="/admin/moderators" className={`nav-link nav-link--admin ${isActive('/admin/moderators') ? 'active' : ''}`}>{t('nav.moderators')}</Link>
                     <Link to="/admin/blog" className={`nav-link nav-link--admin ${isActive('/admin/blog') ? 'active' : ''}`}>{t('nav.blogAdmin')}</Link>
                     <Link to="/admin/stats" className={`nav-link nav-link--admin ${isActive('/admin/stats') ? 'active' : ''}`}>{t('nav.adminStats')}</Link>
@@ -200,8 +200,8 @@ function Layout({ children }) {
                 <button
                   className="theme-toggle"
                   onClick={toggleTheme}
-                  aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
-                  title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+                  aria-label={theme === 'light' ? t('nav.switchToDark') : t('nav.switchToLight')}
+                  title={theme === 'light' ? t('nav.switchToDark') : t('nav.switchToLight')}
                 >
                   {theme === 'light' ? (
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
@@ -214,7 +214,7 @@ function Layout({ children }) {
                   {user.username}
                   {roles.includes('admin') && <span className="badge badge--admin">{t('nav.badge.admin')}</span>}
                   {roles.includes('somm')  && <span className="badge badge--somm">{t('nav.badge.somm')}</span>}
-                  {roles.includes('moderator') && <span className="badge badge--mod">Mod</span>}
+                  {roles.includes('moderator') && <span className="badge badge--mod">{t('nav.badge.mod')}</span>}
                   <span className={`badge badge--plan badge--plan-${user.plan || 'free'}`}>{planLabel}</span>
                 </span>
                 <Link to="/settings" className={`btn-icon-nav ${isActive('/settings') ? 'active' : ''}`} aria-label={t('nav.settings')} data-guide="nav-settings">
@@ -244,21 +244,21 @@ function Layout({ children }) {
         {user && mobileMenuOpen && (
           <div className="mobile-menu">
             <div className="mobile-menu-section">
-              <Link to="/community/discussions" className={`mobile-menu-link ${isActive('/community') ? 'active' : ''}`} onClick={closeMenu}>Community</Link>
-              <Link to="/wishlist" className={`mobile-menu-link ${isActive('/wishlist') ? 'active' : ''}`} onClick={closeMenu}>Wishlist</Link>
-              <Link to="/recommendations" className={`mobile-menu-link ${isActive('/recommendations') ? 'active' : ''}`} onClick={closeMenu}>Recommendations</Link>
-              <Link to="/journal" className={`mobile-menu-link ${isActive('/journal') ? 'active' : ''}`} onClick={closeMenu}>Journal</Link>
-              <Link to="/restock" className={`mobile-menu-link ${isActive('/restock') ? 'active' : ''}`} onClick={closeMenu}>Restock</Link>
+              <Link to="/community/discussions" className={`mobile-menu-link ${isActive('/community') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.community')}</Link>
+              <Link to="/wishlist" className={`mobile-menu-link ${isActive('/wishlist') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.wishlist')}</Link>
+              <Link to="/recommendations" className={`mobile-menu-link ${isActive('/recommendations') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.recommendations')}</Link>
+              <Link to="/journal" className={`mobile-menu-link ${isActive('/journal') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.journal')}</Link>
+              <Link to="/restock" className={`mobile-menu-link ${isActive('/restock') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.restock')}</Link>
               <Link to="/wine-requests" className={`mobile-menu-link ${isActive('/wine-requests') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.myRequests')}</Link>
-              <Link to="/cellar-chat" className={`mobile-menu-link ${isActive('/cellar-chat') ? 'active' : ''}`} onClick={closeMenu}>Cellar Chat</Link>
+              <Link to="/cellar-chat" className={`mobile-menu-link ${isActive('/cellar-chat') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.cellarChat')}</Link>
               <Link to="/blog" className={`mobile-menu-link ${isActive('/blog') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.blog')}</Link>
               <Link to="/supporter" className={`mobile-menu-link ${isActive('/supporter') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.supporter')}</Link>
-              <Link to="/support" className={`mobile-menu-link ${isActive('/support') ? 'active' : ''}`} onClick={closeMenu}>Support</Link>
+              <Link to="/support" className={`mobile-menu-link ${isActive('/support') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.support')}</Link>
             </div>
 
             {(roles.includes('somm') || roles.includes('admin')) && (
               <div className="mobile-menu-section">
-                <div className="mobile-menu-label">Sommelier</div>
+                <div className="mobile-menu-label">{t('nav.sommelier')}</div>
                 <Link to="/somm/maturity" className={`mobile-menu-link ${isActive('/somm/maturity') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.maturityQueue')}</Link>
                 <Link to="/somm/prices" className={`mobile-menu-link ${isActive('/somm/prices') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.priceQueue')}</Link>
               </div>
@@ -266,13 +266,13 @@ function Layout({ children }) {
 
             {roles.includes('admin') && (
               <div className="mobile-menu-section">
-                <div className="mobile-menu-label">Admin</div>
+                <div className="mobile-menu-label">{t('nav.admin')}</div>
                 <Link to="/admin/wines" className={`mobile-menu-link ${isActive('/admin/wines') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.wineLibrary')}</Link>
                 <Link to="/admin/requests" className={`mobile-menu-link ${isActive('/admin/requests') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.adminRequests')}</Link>
                 <Link to="/admin/taxonomy" className={`mobile-menu-link ${isActive('/admin/taxonomy') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.taxonomy')}</Link>
                 <Link to="/admin/images" className={`mobile-menu-link ${isActive('/admin/images') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.imageReview')}</Link>
-                <Link to="/admin/support" className={`mobile-menu-link ${isActive('/admin/support') ? 'active' : ''}`} onClick={closeMenu}>Support Tickets</Link>
-                <Link to="/admin/wine-reports" className={`mobile-menu-link ${isActive('/admin/wine-reports') ? 'active' : ''}`} onClick={closeMenu}>Wine Reports</Link>
+                <Link to="/admin/support" className={`mobile-menu-link ${isActive('/admin/support') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.supportTickets')}</Link>
+                <Link to="/admin/wine-reports" className={`mobile-menu-link ${isActive('/admin/wine-reports') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.wineReports')}</Link>
                 <Link to="/admin/blog" className={`mobile-menu-link ${isActive('/admin/blog') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.blogAdmin')}</Link>
                 <Link to="/admin/stats" className={`mobile-menu-link ${isActive('/admin/stats') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.adminStats')}</Link>
               </div>
@@ -284,12 +284,12 @@ function Layout({ children }) {
                   {user.username}
                   {roles.includes('admin') && <span className="badge badge--admin">{t('nav.badge.admin')}</span>}
                   {roles.includes('somm')  && <span className="badge badge--somm">{t('nav.badge.somm')}</span>}
-                  {roles.includes('moderator') && <span className="badge badge--mod">Mod</span>}
+                  {roles.includes('moderator') && <span className="badge badge--mod">{t('nav.badge.mod')}</span>}
                   <span className={`badge badge--plan badge--plan-${user.plan || 'free'}`}>{planLabel}</span>
                 </span>
               </div>
               <div className="mobile-menu-actions">
-                <button className="theme-toggle" onClick={toggleTheme} aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}>
+                <button className="theme-toggle" onClick={toggleTheme} aria-label={theme === 'light' ? t('nav.switchToDark') : t('nav.switchToLight')}>
                   {theme === 'light' ? (
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                   ) : (
@@ -314,26 +314,26 @@ function Layout({ children }) {
 
       {/* ── Mobile bottom tab bar ── */}
       {user && (
-        <nav className="bottom-nav" aria-label="Main navigation">
+        <nav className="bottom-nav" aria-label={t('nav.mainNavigation')}>
           <Link to="/cellars" className={`bottom-nav-item ${isActive('/cellars') ? 'active' : ''}`} onClick={closeMenu}>
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-            <span>Cellars</span>
+            <span>{t('nav.cellars')}</span>
           </Link>
           <Link to="/community/discussions" className={`bottom-nav-item ${isActive('/community') ? 'active' : ''}`} onClick={closeMenu}>
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-            <span>Community</span>
+            <span>{t('nav.community')}</span>
           </Link>
           <Link to="/statistics" className={`bottom-nav-item ${isActive('/statistics') ? 'active' : ''}`} onClick={closeMenu}>
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
-            <span>Analytics</span>
+            <span>{t('nav.analytics')}</span>
           </Link>
           <Link to="/settings" className={`bottom-nav-item ${isActive('/settings') ? 'active' : ''}`} onClick={closeMenu}>
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-            <span>Settings</span>
+            <span>{t('nav.settings')}</span>
           </Link>
-          <button className="bottom-nav-item" onClick={() => setMobileMenuOpen(o => !o)} aria-label="More" aria-expanded={mobileMenuOpen}>
+          <button className="bottom-nav-item" onClick={() => setMobileMenuOpen(o => !o)} aria-label={t('nav.more')} aria-expanded={mobileMenuOpen}>
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-            <span>More</span>
+            <span>{t('nav.more')}</span>
           </button>
         </nav>
       )}

--- a/frontend/src/components/PhotoCapture.js
+++ b/frontend/src/components/PhotoCapture.js
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import './ImageUpload.css'; // reuse camera + button styles
 
 /**
@@ -8,6 +9,7 @@ import './ImageUpload.css'; // reuse camera + button styles
  * ever flows in from outside (avoids js/xss-through-dom taint path).
  */
 function PhotoCapture({ onCapture, onRemove, processedUrl, processing }) {
+  const { t } = useTranslation();
   const [capturedFile, setCapturedFile] = useState(null);
   const [capturedUrl, setCapturedUrl] = useState('');
   const [cameraOpen, setCameraOpen] = useState(false);
@@ -70,11 +72,11 @@ function PhotoCapture({ onCapture, onRemove, processedUrl, processing }) {
         if (videoRef.current) videoRef.current.srcObject = stream;
       });
     } catch (err) {
-      if (err.name === 'NotAllowedError') setCameraError('Camera access denied. Please allow camera permissions.');
-      else if (err.name === 'NotFoundError') setCameraError('No camera found on this device.');
-      else setCameraError('Could not access camera.');
+      if (err.name === 'NotAllowedError') setCameraError(t('camera.accessDenied'));
+      else if (err.name === 'NotFoundError') setCameraError(t('camera.notFound'));
+      else setCameraError(t('camera.accessError'));
     }
-  }, [facingMode]);
+  }, [facingMode, t]);
 
   const switchCamera = useCallback(() => {
     const newMode = facingMode === 'environment' ? 'user' : 'environment';
@@ -133,21 +135,21 @@ function PhotoCapture({ onCapture, onRemove, processedUrl, processing }) {
             {cameraError ? (
               <div className="camera-error-overlay">
                 <p>{cameraError}</p>
-                <button type="button" className="btn btn-secondary" onClick={stopCamera}>Close</button>
+                <button type="button" className="btn btn-secondary" onClick={stopCamera}>{t('common.close')}</button>
               </div>
             ) : (
               <>
                 <video ref={videoRef} autoPlay playsInline muted className="camera-video" />
                 <div className="camera-overlay">
                   <img src="/bottle-overlay.png" alt="" className="bottle-guide" aria-hidden="true" />
-                  <p className="overlay-hint">Place bottle in the center</p>
+                  <p className="overlay-hint">{t('camera.placeBottle')}</p>
                 </div>
                 <div className="camera-controls">
-                  <button type="button" className="camera-btn camera-btn-close" onClick={stopCamera} aria-label="Close camera">✕</button>
-                  <button type="button" className="camera-btn camera-btn-capture" onClick={capturePhoto} aria-label="Take photo">
+                  <button type="button" className="camera-btn camera-btn-close" onClick={stopCamera} aria-label={t('camera.closeCamera')}>✕</button>
+                  <button type="button" className="camera-btn camera-btn-capture" onClick={capturePhoto} aria-label={t('camera.takePhoto')}>
                     <span className="capture-ring" aria-hidden="true"></span>
                   </button>
-                  <button type="button" className="camera-btn camera-btn-switch" onClick={switchCamera} aria-label="Switch camera">⟲</button>
+                  <button type="button" className="camera-btn camera-btn-switch" onClick={switchCamera} aria-label={t('camera.switchCamera')}>⟲</button>
                 </div>
               </>
             )}
@@ -159,23 +161,23 @@ function PhotoCapture({ onCapture, onRemove, processedUrl, processing }) {
       {capturedFile ? (
         <div className="upload-preview-wrapper">
           {processedUrl ? (
-            <img src={processedUrl} alt="Preview" className="upload-preview" />
+            <img src={processedUrl} alt={t('photoCapture.previewAlt')} className="upload-preview" />
           ) : (
-            capturedUrl && <img src={capturedUrl} alt="Preview" className={`upload-preview${processing ? ' preview-img-dimmed' : ''}`} />
+            capturedUrl && <img src={capturedUrl} alt={t('photoCapture.previewAlt')} className={`upload-preview${processing ? ' preview-img-dimmed' : ''}`} />
           )}
           {processing && (
             <div className="preview-overlay">
               <div className="spinner"></div>
-              <span>Removing background…</span>
+              <span>{t('photoCapture.removingBackground')}</span>
             </div>
           )}
-          <button type="button" className="btn-remove-image" onClick={handleRemove} aria-label="Remove image">×</button>
+          <button type="button" className="btn-remove-image" onClick={handleRemove} aria-label={t('photoCapture.removeImage')}>×</button>
         </div>
       ) : (
         <div className="upload-buttons">
           <button type="button" className="btn btn-upload" onClick={startCamera} disabled={cameraOpen}>
             <span className="upload-icon" aria-hidden="true">📷</span>
-            Take Photo
+            {t('camera.takePhotoButton')}
           </button>
           <input
             ref={fileInputRef}
@@ -186,7 +188,7 @@ function PhotoCapture({ onCapture, onRemove, processedUrl, processing }) {
           />
           <button type="button" className="btn btn-upload btn-upload-secondary" onClick={() => fileInputRef.current?.click()}>
             <span className="upload-icon" aria-hidden="true">📁</span>
-            Choose File
+            {t('photoCapture.chooseFile')}
           </button>
         </div>
       )}

--- a/frontend/src/components/ReconsentModal.js
+++ b/frontend/src/components/ReconsentModal.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import Modal from './Modal';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -16,6 +17,7 @@ import { useAuth } from '../contexts/AuthContext';
  * the full policy the modal links to without it being covered.
  */
 export default function ReconsentModal() {
+  const { t } = useTranslation();
   const { user, acceptPolicy, logout } = useAuth();
   const location = useLocation();
   const [submitting, setSubmitting] = useState(false);
@@ -30,7 +32,7 @@ export default function ReconsentModal() {
     setError('');
     const res = await acceptPolicy();
     if (!res.success) {
-      setError(res.error || 'Something went wrong. Please try again.');
+      setError(res.error || t('auth.genericError'));
       setSubmitting(false);
     }
     // On success the user refreshes with requiresPolicyReconsent === false and
@@ -38,22 +40,21 @@ export default function ReconsentModal() {
   };
 
   return (
-    <Modal title="We've updated our Privacy Policy" onClose={() => {}} trapFocus>
+    <Modal title={t('reconsent.title')} onClose={() => {}} trapFocus>
       <p>
-        We've updated our Privacy Policy, including the third-party services that help run
-        Cellarion. Please review and acknowledge the update to continue.
+        {t('reconsent.body')}
       </p>
       <p>
-        Read the full policy:{' '}
-        <Link to="/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</Link>.
+        {t('reconsent.readPolicy')}{' '}
+        <Link to="/privacy" target="_blank" rel="noopener noreferrer">{t('reconsent.policyLink')}</Link>.
       </p>
       {error && <p className="error-message" role="alert">{error}</p>}
       <div className="modal-actions">
         <button type="button" className="btn-secondary" onClick={logout} disabled={submitting}>
-          Log out
+          {t('reconsent.logout')}
         </button>
         <button type="button" className="btn-primary" onClick={handleAccept} disabled={submitting}>
-          {submitting ? 'Saving…' : 'I acknowledge the updated policy'}
+          {submitting ? t('common.saving') : t('reconsent.acknowledge')}
         </button>
       </div>
     </Modal>

--- a/frontend/src/components/WineSearchPicker.js
+++ b/frontend/src/components/WineSearchPicker.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { searchWines } from '../api/wines';
 import './WineSearchPicker.css';
@@ -10,7 +11,8 @@ import './WineSearchPicker.css';
  *   onSelect   – callback(wine | null)
  *   placeholder – input placeholder text
  */
-export default function WineSearchPicker({ selected, onSelect, placeholder = 'Search for a wine...' }) {
+export default function WineSearchPicker({ selected, onSelect, placeholder }) {
+  const { t } = useTranslation();
   const { apiFetch } = useAuth();
   const [query, setQuery] = useState('');
   const [results, setResults] = useState([]);
@@ -94,7 +96,7 @@ export default function WineSearchPicker({ selected, onSelect, placeholder = 'Se
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         onFocus={() => results.length > 0 && setOpen(true)}
-        placeholder={placeholder}
+        placeholder={placeholder || t('wineSearchPicker.placeholder')}
       />
       {loading && <span className="wine-search-picker__spinner" />}
       {open && (results.length > 0 || noResults) && (
@@ -116,7 +118,7 @@ export default function WineSearchPicker({ selected, onSelect, placeholder = 'Se
             </li>
           ))}
           {noResults && (
-            <li className="wine-search-picker__no-results">No wines found</li>
+            <li className="wine-search-picker__no-results">{t('wineSearchPicker.noResults')}</li>
           )}
         </ul>
       )}

--- a/frontend/src/hooks/useLabelScanner.js
+++ b/frontend/src/hooks/useLabelScanner.js
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
+import i18n from '../i18n';
 
 /**
  * Custom hook that encapsulates label-scan camera logic.
@@ -60,9 +61,9 @@ export default function useLabelScanner(apiFetch, { onScanSuccess, onScanError }
         if (labelVideoRef.current) labelVideoRef.current.srcObject = stream;
       });
     } catch (err) {
-      let msg = 'Could not access camera.';
-      if (err.name === 'NotAllowedError') msg = 'Camera access denied. Please allow camera permissions.';
-      else if (err.name === 'NotFoundError') msg = 'No camera found on this device.';
+      let msg = i18n.t('camera.accessError');
+      if (err.name === 'NotAllowedError') msg = i18n.t('camera.accessDenied');
+      else if (err.name === 'NotFoundError') msg = i18n.t('camera.notFound');
       setLabelCam({ open: true, error: msg });
     }
   }, [labelFacing]);
@@ -108,7 +109,7 @@ export default function useLabelScanner(apiFetch, { onScanSuccess, onScanError }
 
     canvas.toBlob(async (blob) => {
       if (!blob) {
-        setLabelCam({ open: true, error: 'Capture failed. Please try again.' });
+        setLabelCam({ open: true, error: i18n.t('camera.captureFailed') });
         setLabelScanning(false);
         return;
       }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -71,8 +71,27 @@
     "moderators": "Moderators",
     "badge": {
       "admin": "Admin",
-      "somm": "Somm"
-    }
+      "somm": "Somm",
+      "mod": "Mod"
+    },
+    "analytics": "Analytics",
+    "restock": "Restock",
+    "wishlist": "Wishlist",
+    "recommendations": "Recommendations",
+    "journal": "Journal",
+    "community": "Community",
+    "cellarChat": "Cellar Chat",
+    "support": "Support",
+    "supportTickets": "Support Tickets",
+    "wineReports": "Wine Reports",
+    "sommelier": "Sommelier",
+    "admin": "Admin",
+    "cellars": "Cellars",
+    "more": "More",
+    "systemMonitor": "System Monitor",
+    "mainNavigation": "Main navigation",
+    "switchToDark": "Switch to dark mode",
+    "switchToLight": "Switch to light mode"
   },
 
   "auth": {
@@ -2658,5 +2677,76 @@
     "daysAgo": "{{n}}d ago",
     "monthsAgo": "{{n}}mo ago",
     "yearsAgo": "{{n}}y ago"
+  },
+  "bottleCard": {
+    "pendingReview": "Pending review",
+    "groupTooltip": "{{count}} identical bottles — click to expand"
+  },
+  "followButton": {
+    "follow": "Follow",
+    "following": "Following"
+  },
+  "grapePicker": {
+    "removeGrape": "Remove {{name}}",
+    "searchPlaceholder_one": "Search {{count}} grape…",
+    "searchPlaceholder_other": "Search {{count}} grapes…",
+    "noMatch": "No grapes match \"{{search}}\"",
+    "allSelected": "All grapes selected"
+  },
+  "installPrompt": {
+    "message": "Install Cellarion for quick access",
+    "install": "Install",
+    "dismiss": "Dismiss"
+  },
+  "wineSearchPicker": {
+    "placeholder": "Search for a wine...",
+    "noResults": "No wines found"
+  },
+  "errorBoundary": {
+    "title": "Something went wrong",
+    "message": "An unexpected error occurred. Please refresh the page to try again.",
+    "refresh": "Refresh Page"
+  },
+  "reconsent": {
+    "title": "We've updated our Privacy Policy",
+    "body": "We've updated our Privacy Policy, including the third-party services that help run Cellarion. Please review and acknowledge the update to continue.",
+    "readPolicy": "Read the full policy:",
+    "policyLink": "Privacy Policy",
+    "logout": "Log out",
+    "acknowledge": "I acknowledge the updated policy"
+  },
+  "camera": {
+    "accessDenied": "Camera access denied. Please allow camera permissions.",
+    "notFound": "No camera found on this device.",
+    "accessError": "Could not access camera.",
+    "accessErrorDetail": "Could not access camera: {{message}}",
+    "captureFailed": "Capture failed. Please try again.",
+    "placeBottle": "Place bottle in the center",
+    "closeCamera": "Close camera",
+    "takePhoto": "Take photo",
+    "switchCamera": "Switch camera",
+    "takePhotoButton": "Take Photo"
+  },
+  "photoCapture": {
+    "removingBackground": "Removing background…",
+    "previewAlt": "Preview",
+    "removeImage": "Remove image",
+    "chooseFile": "Choose File"
+  },
+  "imageUpload": {
+    "upload": "Upload",
+    "uploading": "Uploading...",
+    "removingBackground": "Removing background...",
+    "processingFailed": "Processing failed",
+    "retry": "Retry",
+    "ready": "Ready",
+    "processing": "Processing",
+    "failed": "Failed",
+    "remove": "Remove",
+    "removeThisImage": "Remove this image",
+    "uploadFailed": "Upload failed",
+    "networkError": "Network error during upload",
+    "processedAlt": "Processed",
+    "originalAlt": "Original"
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -71,8 +71,27 @@
     "moderators": "Moderatorer",
     "badge": {
       "admin": "Admin",
-      "somm": "Somm"
-    }
+      "somm": "Somm",
+      "mod": "Mod"
+    },
+    "analytics": "Statistik",
+    "restock": "Påfyllning",
+    "wishlist": "Önskelista",
+    "recommendations": "Rekommendationer",
+    "journal": "Vinjournal",
+    "community": "Gemenskap",
+    "cellarChat": "Källarchatt",
+    "support": "Support",
+    "supportTickets": "Supportärenden",
+    "wineReports": "Vinrapporter",
+    "sommelier": "Sommelier",
+    "admin": "Admin",
+    "cellars": "Källare",
+    "more": "Mer",
+    "systemMonitor": "Systemövervakning",
+    "mainNavigation": "Huvudnavigering",
+    "switchToDark": "Byt till mörkt läge",
+    "switchToLight": "Byt till ljust läge"
   },
 
   "auth": {
@@ -2658,5 +2677,76 @@
     "daysAgo": "{{n}}d sedan",
     "monthsAgo": "{{n}}mån sedan",
     "yearsAgo": "{{n}}år sedan"
+  },
+  "bottleCard": {
+    "pendingReview": "Väntar på granskning",
+    "groupTooltip": "{{count}} identiska flaskor — klicka för att visa alla"
+  },
+  "followButton": {
+    "follow": "Följ",
+    "following": "Följer"
+  },
+  "grapePicker": {
+    "removeGrape": "Ta bort {{name}}",
+    "searchPlaceholder_one": "Sök bland {{count}} druva…",
+    "searchPlaceholder_other": "Sök bland {{count}} druvor…",
+    "noMatch": "Inga druvor matchar \"{{search}}\"",
+    "allSelected": "Alla druvor är valda"
+  },
+  "installPrompt": {
+    "message": "Installera Cellarion för snabb åtkomst",
+    "install": "Installera",
+    "dismiss": "Stäng"
+  },
+  "wineSearchPicker": {
+    "placeholder": "Sök efter ett vin...",
+    "noResults": "Inga viner hittades"
+  },
+  "errorBoundary": {
+    "title": "Något gick fel",
+    "message": "Ett oväntat fel inträffade. Ladda om sidan för att försöka igen.",
+    "refresh": "Ladda om sidan"
+  },
+  "reconsent": {
+    "title": "Vi har uppdaterat vår integritetspolicy",
+    "body": "Vi har uppdaterat vår integritetspolicy, bland annat kring de tredjepartstjänster som hjälper till att driva Cellarion. Läs igenom och bekräfta uppdateringen för att fortsätta.",
+    "readPolicy": "Läs hela policyn:",
+    "policyLink": "Integritetspolicy",
+    "logout": "Logga ut",
+    "acknowledge": "Jag bekräftar den uppdaterade policyn"
+  },
+  "camera": {
+    "accessDenied": "Kameraåtkomst nekades. Tillåt kamerabehörighet i din webbläsare.",
+    "notFound": "Ingen kamera hittades på den här enheten.",
+    "accessError": "Det gick inte att komma åt kameran.",
+    "accessErrorDetail": "Det gick inte att komma åt kameran: {{message}}",
+    "captureFailed": "Det gick inte att ta bilden. Försök igen.",
+    "placeBottle": "Placera flaskan i mitten",
+    "closeCamera": "Stäng kameran",
+    "takePhoto": "Ta foto",
+    "switchCamera": "Byt kamera",
+    "takePhotoButton": "Ta foto"
+  },
+  "photoCapture": {
+    "removingBackground": "Tar bort bakgrunden…",
+    "previewAlt": "Förhandsvisning",
+    "removeImage": "Ta bort bild",
+    "chooseFile": "Välj fil"
+  },
+  "imageUpload": {
+    "upload": "Ladda upp",
+    "uploading": "Laddar upp...",
+    "removingBackground": "Tar bort bakgrunden...",
+    "processingFailed": "Bearbetningen misslyckades",
+    "retry": "Försök igen",
+    "ready": "Klar",
+    "processing": "Bearbetar",
+    "failed": "Misslyckades",
+    "remove": "Ta bort",
+    "removeThisImage": "Ta bort den här bilden",
+    "uploadFailed": "Uppladdningen misslyckades",
+    "networkError": "Nätverksfel under uppladdningen",
+    "processedAlt": "Bearbetad",
+    "originalAlt": "Original"
   }
 }


### PR DESCRIPTION
Fixes the shared-components half of audit finding **MED #38** (CODE_AUDIT_2026-07-08.md): hardcoded English strings inside otherwise-translated shared UI are now driven by react-i18next keys, with English and Swedish entries added to both locale files.

## Surfaces localized

| Surface | What changed |
|---|---|
| `Layout.js` | All remaining hardcoded nav labels (desktop navbar, mobile slide-down menu, bottom tab bar): Analytics, Restock, Wishlist, Recommendations, Journal, Community, Cellar Chat, Support, Support Tickets, Wine Reports, Sommelier/Admin section labels, System Monitor, Cellars, More, Mod badge — plus theme-toggle aria-labels/titles and the bottom-nav `aria-label` |
| `BottleCard.js` | "Unknown Wine" (reuses existing `common.unknownWine`), "Pending review", group-stack tooltip (with `{{count}}` interpolation) |
| `GrapePicker.js` | Search placeholder (pluralized `_one`/`_other`), "No grapes match", "All grapes selected", remove-chip aria-label |
| `FollowButton.js` | "Follow" / "Following" |
| `InstallPrompt.js` | PWA install message, Install button, Dismiss aria-label |
| `WineSearchPicker.js` | Default placeholder (moved from prop default into `t()` fallback), "No wines found" |
| `ErrorBoundary.js` | Class component — uses the shared `i18n` instance via a `tSafe()` helper that falls back to the original English string if i18n itself failed, so the boundary always renders |
| `ReconsentModal.js` | Privacy re-consent title, body, policy link, Log out, acknowledge button (reuses `common.saving` and `auth.genericError`) |
| `PhotoCapture.js` / `ImageUpload.js` | Camera error messages, viewfinder hint + aria-labels (shared `camera.*` namespace), Take Photo / Choose File / Upload buttons, upload/processing/retry/remove strings, preview alt texts |
| `hooks/useLabelScanner.js` | The three camera-access error strings + capture-failed error, via the shared `i18n` instance (plain hook, no component context) |

## Key counts

- **70 new keys** added to each locale file (identical structure, symmetric order): 19 `nav.*` additions (incl. `nav.badge.mod`), 2 `bottleCard.*`, 2 `followButton.*`, 5 `grapePicker.*`, 3 `installPrompt.*`, 2 `wineSearchPicker.*`, 3 `errorBoundary.*`, 6 `reconsent.*`, 10 `camera.*`, 4 `photoCapture.*`, 14 `imageUpload.*` (leaf-key totals; pluralized keys counted per suffix)
- Reused existing keys instead of duplicating: `common.unknownWine`, `common.close`, `common.saving`, `nav.settings`, `auth.genericError`
- en = previous hardcoded strings verbatim; sv = natural informal-du Swedish — **native Swedish review to follow** before this is considered final copy
- Symmetry verified: 2432 leaf keys in each file, zero divergence, top-level namespace order identical

## Notes

- Strings only — zero behavior changes. `WineSearchPicker`'s placeholder default moved from a parameter default to `placeholder || t(...)`; no caller currently passes the prop.
- Existing locale content untouched (new keys appended as coherent blocks so concurrent locale PRs merge cleanly).
- Verified: `npm test` (337/337 pass) and a production `vite build`.

## docker-compose impact
None — frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
