### PR TITLE
fix: backend LOW batch — ~20 audit fixes across 14 route files

### DIFF
--- a/backend/src/routes/blog.js
+++ b/backend/src/routes/blog.js
@@ -178,7 +178,6 @@ router.put('/admin/posts/:id', requireAuth, requireRole('admin'), async (req, re
 
     const { title, content, excerpt, coverImage, tags, status, metaTitle, metaDescription } = req.body;
 
-    const oldTitle = post.title;
     if (title !== undefined) post.title = title;
     if (content !== undefined) post.content = content;
     if (excerpt !== undefined) post.excerpt = excerpt;
@@ -197,13 +196,9 @@ router.put('/admin/posts/:id', requireAuth, requireRole('admin'), async (req, re
       post.status = status;
     }
 
-    // Regenerate slug if title changed
-    if (title && title !== oldTitle) {
-      let newSlug = generateSlug(title);
-      const existing = await BlogPost.findOne({ slug: newSlug, _id: { $ne: post._id } });
-      if (existing) newSlug = `${newSlug}-${Date.now().toString(36)}`;
-      post.slug = newSlug;
-    }
+    // The slug is pinned at creation and NEVER regenerated on title edits —
+    // published URLs are indexed and backlinked, and changing the slug 404s
+    // them with no redirect (Discussion pins its slug for the same reason).
 
     await post.save();
     await post.populate('author', 'username');
@@ -234,6 +229,12 @@ router.delete('/admin/posts/:id', requireAuth, requireRole('admin'), async (req,
     if (!post) return res.status(404).json({ error: 'Post not found' });
 
     logAudit(req, 'blog.delete', { type: 'blogPost', id: post._id }, { title: post.title });
+
+    // Ping IndexNow so engines recrawl the dead URL and drop it, instead of
+    // serving the stale entry until an organic recrawl (discussions do this).
+    if (post.status === 'published') {
+      submitUrls(`/blog/${post.slug}`);
+    }
 
     res.json({ message: 'Post deleted' });
   } catch (err) {

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -20,6 +20,7 @@ const { embedSinglePair } = require('../services/embeddingJob');
 const { enrichWineById } = require('../services/enrichmentJob');
 const { CONSUMED_STATUSES, WINE_POPULATE, WINE_POPULATE_LIST } = require('../config/constants');
 const { checkRestockGap, resolveRestockAlerts } = require('../services/restockChecker');
+const { unlinkImageFiles } = require('../services/imageProcessor');
 const { gatherPriceWarnings } = require('../services/priceWarnings');
 const { getCurrentRelease } = require('../services/communityPrice');
 const { stripHtml, isSafeUrl, escapeRegex } = require('../utils/sanitize');
@@ -627,6 +628,13 @@ router.put('/:id', requireBottleAccess('editor'), async (req, res) => {
       return String(v);
     };
 
+    // A scale change without a rating value would leave the stored rating
+    // meaningless on the new scale (e.g. a 4/5 persisted as 4 on the 100
+    // scale, later clamped to 0 by toNormalized) — require both together.
+    if ('ratingScale' in req.body && !('rating' in req.body) && bottle.rating != null) {
+      return res.status(400).json({ error: 'Send rating together with ratingScale when changing the rating scale' });
+    }
+
     const htmlFields = new Set(['purchaseLocation', 'location', 'notes']);
     const changes = {};
     updateFields.forEach(field => {
@@ -809,7 +817,8 @@ router.post('/:id/consume', requireBottleAccess('editor'), async (req, res) => {
     // failed save doesn't leave an active bottle already pulled from its rack
     await removeFromRacks(bottle._id);
 
-    // Remove from Meilisearch (consumed bottles are excluded)
+    // Re-index so search reflects the consumed status (consumed bottles stay
+    // in the index for history search; they're filtered at query time)
     searchService.indexBottle(bottle._id);
 
     logAudit(req, 'bottle.consume',
@@ -931,8 +940,14 @@ router.post('/:id/undo', requireBottleAccess('editor'), async (req, res) => {
     await removeFromRacks(bottleId);
     searchService.removeBottle(bottleId);
 
-    // Bottle-only images go away. Images promoted to a WineDefinition (e.g.
-    // approved community photos) stay, but lose their link back to this bottle.
+    // Bottle-only images go away — files first: the docs hold the only disk
+    // reference, and the hourly orphan sweep only reconciles originals/, so a
+    // processed PNG whose doc was deleted would leak forever. Images promoted
+    // to a WineDefinition (e.g. approved community photos) stay, but lose
+    // their link back to this bottle.
+    const ownImages = await BottleImage.find({ bottle: bottleId, assignedToWine: false })
+      .select('originalUrl processedUrl').lean();
+    for (const img of ownImages) await unlinkImageFiles(img);
     await BottleImage.deleteMany({ bottle: bottleId, assignedToWine: false });
     await BottleImage.updateMany(
       { bottle: bottleId, assignedToWine: true },
@@ -961,15 +976,31 @@ router.post('/:id/undo', requireBottleAccess('editor'), async (req, res) => {
 });
 
 // DELETE /api/bottles/:id - Delete bottle (owner or editor)
+// No frontend caller today (the UI uses consume + /undo), but API clients can
+// reach it — so it runs the same image/wine-request cleanup as /undo instead
+// of orphaning BottleImage docs and pending requests.
 router.delete('/:id', requireBottleAccess('editor'), async (req, res) => {
   try {
     const { bottle } = req;
+    const pendingRequestId = bottle.pendingWineRequest || null;
 
     // Remove bottle from any rack slot that references it
     await removeFromRacks(bottle._id);
 
     // Remove from Meilisearch before deleting
     searchService.removeBottle(bottle._id);
+
+    const ownImages = await BottleImage.find({ bottle: bottle._id, assignedToWine: false })
+      .select('originalUrl processedUrl').lean();
+    for (const img of ownImages) await unlinkImageFiles(img);
+    await BottleImage.deleteMany({ bottle: bottle._id, assignedToWine: false });
+    await BottleImage.updateMany(
+      { bottle: bottle._id, assignedToWine: true },
+      { $set: { bottle: null } }
+    );
+    if (pendingRequestId) {
+      await WineRequest.deleteOne({ _id: pendingRequestId, status: 'pending' });
+    }
 
     logAudit(req, 'bottle.delete',
       { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -560,14 +560,14 @@ router.get('/:id/statistics', async (req, res) => {
       return res.status(404).json({ error: 'Cellar not found' });
     }
 
-    // Only count active bottles in statistics
+    // Only count active bottles in statistics. Lean + the list projection:
+    // this handler only reads scalar fields (wine _id, country.name, type),
+    // so hydrating full documents with the multi-KB aiProfile made this the
+    // heaviest per-request allocation in the file on large cellars.
     const bottles = await Bottle.find({
       cellar: req.params.id,
       status: { $nin: CONSUMED_STATUSES }
-    }).populate({
-      path: 'wineDefinition',
-      populate: ['country', 'region', 'grapes']
-    });
+    }).populate(WINE_POPULATE_LIST).lean();
 
     // Batch-load historical rate snapshots for all priceSetAt dates (one DB query)
     const targetCurrency = req.query.currency || null;
@@ -1368,7 +1368,9 @@ router.patch('/:id/color', async (req, res) => {
     const { color } = req.body; // hex string or null/empty to clear
     const cellar = await Cellar.findById(req.params.id);
     const role = getCellarRole(cellar, req.user.id);
-    if (!role) return res.status(404).json({ error: 'Cellar not found' });
+    // deletedAt: soft-deleted cellars are frozen until restore, like the
+    // sibling PUT/DELETE routes enforce.
+    if (!role || cellar.deletedAt) return res.status(404).json({ error: 'Cellar not found' });
 
     const idx = cellar.userColors.findIndex(
       uc => uc.user.toString() === req.user.id.toString()
@@ -1445,7 +1447,9 @@ router.post('/:id/members', async (req, res) => {
       return res.status(400).json({ error: 'role must be viewer or editor' });
     }
 
-    const cellar = await Cellar.findOne({ _id: req.params.id, user: req.user.id });
+    // deletedAt: null — inviting to a soft-deleted cellar fired invite
+    // emails/notifications pointing at a cellar the invitee can never see.
+    const cellar = await Cellar.findOne({ _id: req.params.id, user: req.user.id, deletedAt: null });
     if (!cellar) return res.status(404).json({ error: 'Cellar not found' });
 
     const normalizedEmail = email.toLowerCase().trim();
@@ -1538,7 +1542,7 @@ router.put('/:id/members/:userId', async (req, res) => {
       return res.status(400).json({ error: 'role must be viewer or editor' });
     }
 
-    const cellar = await Cellar.findOne({ _id: req.params.id, user: req.user.id });
+    const cellar = await Cellar.findOne({ _id: req.params.id, user: req.user.id, deletedAt: null });
     if (!cellar) return res.status(404).json({ error: 'Cellar not found' });
 
     const member = cellar.members.find(m => m.user.toString() === req.params.userId);
@@ -1599,8 +1603,14 @@ router.delete('/:id/members/:userId', async (req, res) => {
 router.get('/:id/export', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
-    const cellar = await Cellar.findOne({ _id: req.params.id, user: req.user.id, deletedAt: null });
-    if (!cellar) return res.status(403).json({ error: 'Not authorized — only the cellar owner can export' });
+    // Distinguish 404 (no such active cellar) from 403 (exists, not owner) —
+    // the single combined lookup told members/stale-id callers it was a
+    // permissions problem either way.
+    const cellar = await Cellar.findOne({ _id: req.params.id, deletedAt: null });
+    if (!cellar) return res.status(404).json({ error: 'Cellar not found' });
+    if (cellar.user.toString() !== req.user.id.toString()) {
+      return res.status(403).json({ error: 'Not authorized — only the cellar owner can export' });
+    }
 
     // Bound worst-case memory: a single response can't materialise more than
     // CELLAR_EXPORT_MAX bottles. Far above any real cellar; a hit is flagged in
@@ -1645,8 +1655,14 @@ router.get('/:id/export', async (req, res) => {
 router.get('/:id/audit', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
-    const cellar = await Cellar.findOne({ _id: req.params.id, user: req.user.id });
-    if (!cellar) return res.status(403).json({ error: 'Not authorized' });
+    // 404 for missing/deleted cellars, 403 only when it exists and the
+    // requester isn't the owner (audit log stays owner-only, and frozen
+    // while soft-deleted like the other cellar views).
+    const cellar = await Cellar.findOne({ _id: req.params.id, deletedAt: null });
+    if (!cellar) return res.status(404).json({ error: 'Cellar not found' });
+    if (cellar.user.toString() !== req.user.id.toString()) {
+      return res.status(403).json({ error: 'Not authorized' });
+    }
 
     const logs = await AuditLog.find({ 'resource.cellarId': req.params.id })
       .sort({ timestamp: -1 })

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const mongoose = require('mongoose');
 const { requireAuth, optionalAuth, requireModeratorOrAdmin, isModerator } = require('../middleware/auth');
 const Discussion = require('../models/Discussion');
 const { CATEGORIES } = require('../models/Discussion');

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -424,6 +424,13 @@ router.post('/', requireAuth, async (req, res) => {
     if (wineDefinition && !isValidId(wineDefinition)) {
       return res.status(400).json({ error: 'Invalid wine definition ID' });
     }
+    // Verify the wine actually exists (the reply path does the same) — a
+    // stale picker id would create a thread whose wine chip silently never
+    // renders and whose og page omits the wine link.
+    if (wineDefinition) {
+      const wineExists = await WineDefinition.exists({ _id: wineDefinition });
+      if (!wineExists) return res.status(400).json({ error: 'Wine not found' });
+    }
 
     const cleanTitle = stripHtml(title);
     const cleanBody = sanitizeForumHtml(body);
@@ -1169,7 +1176,7 @@ router.post('/:idOrSlug/report', requireAuth, async (req, res) => {
       user: req.user.id,
       discussion: discussion._id,
       reason: String(reason),
-      details: details ? stripHtml(details) : undefined
+      details: details ? stripHtml(String(details)).slice(0, 1000) : undefined
     });
 
     await report.save();
@@ -1200,7 +1207,7 @@ router.post('/:discussionId/replies/:replyId/report', requireAuth, async (req, r
       user: req.user.id,
       reply: reply._id,
       reason: String(reason),
-      details: details ? stripHtml(details) : undefined
+      details: details ? stripHtml(String(details)).slice(0, 1000) : undefined
     });
 
     await report.save();

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -426,9 +426,11 @@ router.post('/', requireAuth, async (req, res) => {
     }
     // Verify the wine actually exists (the reply path does the same) — a
     // stale picker id would create a thread whose wine chip silently never
-    // renders and whose og page omits the wine link.
-    if (wineDefinition) {
-      const wineExists = await WineDefinition.exists({ _id: wineDefinition });
+    // renders and whose og page omits the wine link. Cast the validated id
+    // to a real ObjectId before it touches the query (clears taint tracking).
+    const wineOid = wineDefinition ? new mongoose.Types.ObjectId(String(wineDefinition)) : null;
+    if (wineOid) {
+      const wineExists = await WineDefinition.exists({ _id: wineOid });
       if (!wineExists) return res.status(400).json({ error: 'Wine not found' });
     }
 

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -475,6 +475,9 @@ router.post('/link-to-bottle', requireAuth, async (req, res) => {
     if (!bottleId || !imageIds || !Array.isArray(imageIds)) {
       return res.status(400).json({ error: 'bottleId and imageIds array are required' });
     }
+    if (imageIds.length > MAX_IMAGES_PER_BOTTLE) {
+      return res.status(400).json({ error: `Maximum of ${MAX_IMAGES_PER_BOTTLE} images per bottle` });
+    }
     if (!isValidId(bottleId) || !imageIds.every(id => isValidId(id))) {
       return res.status(400).json({ error: 'Invalid ID' });
     }
@@ -492,6 +495,13 @@ router.post('/link-to-bottle', requireAuth, async (req, res) => {
     const cellarRole = getCellarRole(cellar, req.user.id);
     if (!cellarRole || cellarRole === 'viewer') {
       return res.status(403).json({ error: 'Not authorized to link images to this bottle' });
+    }
+
+    // Enforce the same per-bottle cap /upload applies — the normal AddBottle
+    // flow uploads bottleless images then links here, which used to bypass it.
+    const existingCount = await BottleImage.countDocuments({ bottle: bottleId });
+    if (existingCount + imageIds.length > MAX_IMAGES_PER_BOTTLE) {
+      return res.status(400).json({ error: `Maximum of ${MAX_IMAGES_PER_BOTTLE} images per bottle reached` });
     }
 
     await BottleImage.updateMany(

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -663,6 +663,12 @@ router.post('/confirm', async (req, res) => {
 
           if (item.dateAdded) bottle.createdAt = new Date(item.dateAdded);
 
+          // Seed the cellar journey like POST /api/bottles does — honours a
+          // backdated dateAdded so the journey timeline and time-in-cellar
+          // stats start at the real added date, not the import date.
+          bottle.addedToCellarAt = bottle.createdAt || new Date();
+          bottle.cellarHistory = [{ cellar: cellar._id, cellarName: cellar.name, enteredAt: bottle.addedToCellarAt }];
+
           if (item.addToHistory) {
             const reason = item.consumedReason || 'drank';
             bottle.status = reason;
@@ -748,6 +754,11 @@ router.post('/confirm', async (req, res) => {
         // Allow backdating
         if (item.dateAdded) bottle.createdAt = new Date(item.dateAdded);
 
+        // Seed the cellar journey like POST /api/bottles does (see the
+        // requestWine branch above for the rationale).
+        bottle.addedToCellarAt = bottle.createdAt || new Date();
+        bottle.cellarHistory = [{ cellar: cellar._id, cellarName: cellar.name, enteredAt: bottle.addedToCellarAt }];
+
         // Allow adding directly to history
         if (item.addToHistory) {
           const reason = item.consumedReason || 'drank';
@@ -832,15 +843,28 @@ router.post('/confirm', async (req, res) => {
 
           for (const pl of placements) {
             rack.slots.push({ position: pl.position, bottle: pl.bottle });
-            placedCount++;
-            if (pl.overflowed) overflowedCount++;
           }
           for (const u of unplaced) {
             unplacedDetails.push({ ...u, rackName });
           }
 
+          // Count placements only AFTER the save succeeds — a swallowed save
+          // failure (e.g. VersionError from a concurrent rack edit) used to
+          // report bottles as placed that never persisted.
           if (placements.length > 0) {
-            await rack.save().catch(err => console.error(`Failed to save rack ${rackName} during import:`, err.message));
+            try {
+              await rack.save();
+              for (const pl of placements) {
+                placedCount++;
+                if (pl.overflowed) overflowedCount++;
+              }
+            } catch (err) {
+              console.error(`Failed to save rack ${rackName} during import:`, err.message);
+              for (const pl of placements) {
+                const src = group.find(p => String(p.bottleId) === String(pl.bottle));
+                unplacedDetails.push({ sourceIndex: src?.sourceIndex ?? null, rackName, requestedPosition: pl.position, reason: `Rack save failed: ${err.message}` });
+              }
+            }
           }
         } catch (err) {
           console.error(`Failed placement for rack ${rackName}:`, err.message);

--- a/backend/src/routes/journal.js
+++ b/backend/src/routes/journal.js
@@ -28,8 +28,14 @@ function sanitizeEntry(body) {
   if (occasion && OCCASIONS.includes(occasion)) clean.occasion = occasion;
   if (mood != null) {
     const m = parseInt(mood, 10);
-    if (m >= 1 && m <= 5) clean.mood = m;
-    else clean.mood = null;
+    if (Number.isInteger(m) && m >= 1 && m <= 5) clean.mood = m;
+    else {
+      // Reject instead of silently nulling — a PUT with mood: 7 used to
+      // erase the stored value without any indication.
+      const err = new Error('Mood must be a whole number between 1 and 5');
+      err.status = 400;
+      throw err;
+    }
   }
   if (notes != null) clean.notes = stripHtml(String(notes)).slice(0, 2000);
   if (visibility && ['private', 'public'].includes(visibility)) clean.visibility = visibility;
@@ -108,7 +114,7 @@ const POPULATE_PAIRINGS = [
   { path: 'people.user', select: 'username displayName' }
 ];
 
-// GET /api/journal — list journal entries (own + public from following)
+// GET /api/journal — list the user's own journal entries
 router.get('/', async (req, res) => {
   try {
     const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 20, 1), 50);
@@ -215,6 +221,7 @@ router.post('/', async (req, res) => {
 
     res.status(201).json({ entry: populated });
   } catch (err) {
+    if (err.status === 400) return res.status(400).json({ error: err.message });
     console.error('Create journal entry error:', err);
     res.status(500).json({ error: 'Failed to create journal entry' });
   }
@@ -240,6 +247,7 @@ router.put('/:id', async (req, res) => {
 
     res.json({ entry: populated });
   } catch (err) {
+    if (err.status === 400) return res.status(400).json({ error: err.message });
     console.error('Update journal entry error:', err);
     res.status(500).json({ error: 'Failed to update journal entry' });
   }

--- a/backend/src/routes/recommendations.js
+++ b/backend/src/routes/recommendations.js
@@ -178,13 +178,14 @@ router.post('/', async (req, res) => {
       ).catch(err => console.error('[recommendations] Email send failed:', err.message));
     }
 
-    logAudit(req, 'recommendation.send', {
-      type: 'recommendation',
-      id: rec._id,
-      wineId,
-      recipientId: recipientUser?._id || null,
-      recipientEmail: recipientUser ? null : recipientEmail
-    });
+    // wineId/recipient go in the detail arg — AuditLog.resource is a strict
+    // {type,id,cellarId} subdoc that silently dropped the extra keys. The
+    // recipient EMAIL is deliberately not logged (external-party PII with a
+    // 90-day audit retention; it already lives on the Recommendation doc).
+    logAudit(req, 'recommendation.send',
+      { type: 'recommendation', id: rec._id },
+      { wineId, recipientId: recipientUser?._id || null, externalEmail: !recipientUser }
+    );
 
     res.status(201).json({ recommendation: populated });
   } catch (err) {
@@ -235,11 +236,10 @@ router.delete('/:id', async (req, res) => {
 
     if (!rec) return res.status(404).json({ error: 'Recommendation not found' });
 
-    logAudit(req, 'recommendation.delete', {
-      type: 'recommendation',
-      id: rec._id,
-      wineId: rec.wine
-    });
+    logAudit(req, 'recommendation.delete',
+      { type: 'recommendation', id: rec._id },
+      { wineId: rec.wine }
+    );
 
     res.json({ success: true });
   } catch (err) {

--- a/backend/src/routes/restockAlerts.js
+++ b/backend/src/routes/restockAlerts.js
@@ -11,10 +11,14 @@ router.get('/', async (req, res) => {
   try {
     const VALID_STATUSES = ['active', 'dismissed', 'resolved'];
     const requestedStatus = String(req.query.status || 'active');
+    // 400 on unknown values ('all' is the explicit everything selector) —
+    // a typo used to silently return every status mixed together.
+    if (requestedStatus !== 'all' && !VALID_STATUSES.includes(requestedStatus)) {
+      return res.status(400).json({ error: `status must be one of: ${VALID_STATUSES.join(', ')}, all` });
+    }
     const query = { user: req.user.id };
-    const validStatus = VALID_STATUSES.find(s => s === requestedStatus);
-    if (validStatus) {
-      query.status = validStatus;
+    if (requestedStatus !== 'all') {
+      query.status = VALID_STATUSES.find(s => s === requestedStatus);
     }
 
     const alerts = await RestockAlert.find(query)

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -435,14 +435,28 @@ router.post('/:id/like', async (req, res) => {
     const existing = await ReviewVote.findOne({ user: req.user.id, review: review._id });
 
     if (existing) {
-      await ReviewVote.deleteOne({ _id: existing._id });
-      await Review.updateOne({ _id: review._id }, { $inc: { likesCount: -1 } });
-      res.json({ liked: false, likesCount: Math.max(0, review.likesCount - 1) });
+      // Only decrement when THIS request actually removed the vote — two
+      // concurrent unlikes both matched `existing` and double-decremented,
+      // driving likesCount negative. The $gt filter clamps at zero.
+      const del = await ReviewVote.deleteOne({ _id: existing._id });
+      if (del.deletedCount > 0) {
+        await Review.updateOne({ _id: review._id, likesCount: { $gt: 0 } }, { $inc: { likesCount: -1 } });
+      }
+      const fresh = await Review.findById(review._id).select('likesCount').lean();
+      res.json({ liked: false, likesCount: fresh?.likesCount ?? 0 });
     } else {
-      await new ReviewVote({ user: req.user.id, review: review._id }).save();
+      try {
+        await new ReviewVote({ user: req.user.id, review: review._id }).save();
+      } catch (err) {
+        // Concurrent duplicate like — treat as already-liked, don't 500.
+        if (err.code !== 11000) throw err;
+        const dup = await Review.findById(review._id).select('likesCount').lean();
+        return res.json({ liked: true, likesCount: dup?.likesCount ?? review.likesCount });
+      }
       await Review.updateOne({ _id: review._id }, { $inc: { likesCount: 1 } });
       incrementCred(review.author.toString(), 'review_like_received').catch(() => {});
-      res.json({ liked: true, likesCount: review.likesCount + 1 });
+      const fresh = await Review.findById(review._id).select('likesCount').lean();
+      res.json({ liked: true, likesCount: fresh?.likesCount ?? review.likesCount + 1 });
     }
   } catch (err) {
     console.error('Toggle like error:', err);

--- a/backend/src/routes/somm/maturity.js
+++ b/backend/src/routes/somm/maturity.js
@@ -4,6 +4,7 @@ const { requireAuth, requireSommOrAdmin } = require('../../middleware/auth');
 const WineVintageProfile = require('../../models/WineVintageProfile');
 const { isValidId } = require('../../utils/validation');
 const { parsePagination } = require('../../utils/pagination');
+const { logAudit } = require('../../services/audit');
 
 const { suggestDrinkWindow } = require('../../services/labelScan');
 
@@ -149,7 +150,8 @@ router.put('/:id', requireSommOrAdmin, async (req, res) => {
       }
     }
     if (req.body.sommNotes !== undefined) {
-      profile.sommNotes = req.body.sommNotes ? req.body.sommNotes.trim() : '';
+      // String() coercion: a truthy non-string threw on .trim() → 500.
+      profile.sommNotes = req.body.sommNotes ? String(req.body.sommNotes).trim() : '';
     }
 
     profile.relative = isNv;
@@ -169,6 +171,13 @@ router.put('/:id', requireSommOrAdmin, async (req, res) => {
       },
       { path: 'setBy', select: 'username' }
     ]);
+
+    // Shared-data mutation visible to every user of this wine+vintage —
+    // audit like the comparable admin mutations do.
+    logAudit(req, 'somm.maturity.review',
+      { type: 'wine', id: profile.wineDefinition?._id || profile.wineDefinition },
+      { vintage: profile.vintage, relative: profile.relative }
+    );
 
     res.json({ profile });
   } catch (error) {
@@ -247,6 +256,12 @@ router.delete('/:id/reset', requireSommOrAdmin, async (req, res) => {
     profile.setAt     = null;
 
     await profile.save();
+
+    logAudit(req, 'somm.maturity.reset',
+      { type: 'wine', id: profile.wineDefinition },
+      { vintage: profile.vintage }
+    );
+
     res.json({ profile });
   } catch (error) {
     console.error('Reset maturity profile error:', error);

--- a/backend/src/routes/somm/prices.js
+++ b/backend/src/routes/somm/prices.js
@@ -7,6 +7,8 @@ const Bottle = require('../../models/Bottle');
 const WineDefinition = require('../../models/WineDefinition');
 const { getOrCreateDailySnapshot, getSnapshotsForDates } = require('../../utils/exchangeRates');
 const { createNotification } = require('../../services/notifications');
+const { logAudit } = require('../../services/audit');
+const { SUPPORTED_CURRENCIES } = require('../../config/currencies');
 
 const { suggestPrice } = require('../../services/labelScan');
 
@@ -45,6 +47,9 @@ router.get('/queue', requireSommOrAdmin, async (req, res) => {
     // $last is only meaningful with a defined input order — sort by setAt
     // first, or "latest" is whatever natural order happens to yield.
     const latestPrices = await WineVintagePrice.aggregate([
+      // Only the requested pairs' snapshots — without this $match the $group
+      // scanned every price ever recorded on every queue load.
+      { $match: { wineDefinition: { $in: validRequests.map(r => r.wineDefinition._id) } } },
       { $sort: { setAt: 1 } },
       { $group: {
           _id: { wineDefinition: '$wineDefinition', vintage: '$vintage' },
@@ -251,18 +256,30 @@ router.post('/', requireSommOrAdmin, async (req, res) => {
     // time-anchored conversions later. Non-fatal if the API call fails.
     await getOrCreateDailySnapshot();
 
+    // String() coercion: a truthy non-string (number/object) used to throw
+    // TypeError on .trim() → 500 instead of a validation response.
+    const safeCurrency = String(currency || 'USD').toUpperCase();
+    if (!SUPPORTED_CURRENCIES.includes(safeCurrency)) {
+      return res.status(400).json({ error: `Unsupported currency (use one of: ${SUPPORTED_CURRENCIES.join(', ')})` });
+    }
+
     const entry = new WineVintagePrice({
       wineDefinition: wineDefId,
       vintage: safeVintage,
       price: priceNum,
-      currency: currency || 'USD',
-      source: source ? source.trim() : undefined,
-      sommNotes: sommNotes ? sommNotes.trim() : undefined,
+      currency: safeCurrency,
+      source: source ? String(source).trim() : undefined,
+      sommNotes: sommNotes ? String(sommNotes).trim() : undefined,
       setBy: req.user.id
     });
 
     await entry.save();
     await entry.populate('setBy', 'username');
+
+    logAudit(req, 'somm.price.add',
+      { type: 'wine', id: wineDefId },
+      { vintage: safeVintage, price: priceNum, currency: safeCurrency }
+    );
 
     // Notify everyone who requested tracking for this pair (best-effort,
     // never block the response on it).
@@ -316,6 +333,12 @@ router.delete('/requests/:requestId', requireSommOrAdmin, async (req, res) => {
     }
 
     await request.deleteOne();
+
+    logAudit(req, 'somm.price.decline',
+      { type: 'wine', id: request.wineDefinition?._id || null },
+      { vintage: request.vintage, requesters: request.requesters.length }
+    );
+
     res.json({ message: 'Tracking request declined' });
   } catch (error) {
     console.error('Decline tracking request error:', error);

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -415,6 +415,11 @@ router.get('/me/data-export', requireAuth, async (req, res) => {
 router.get('/me/full-export', requireAuth, async (req, res) => {
   const scope = parseExportScope(req, res);
   if (scope === null) return;
+  // Claim bookkeeping hoisted out of the try so the catch can refund: a
+  // transient build failure used to consume the weekly allowance and lock
+  // the user out of full export for 7 days.
+  let claimStamp = null;
+  let claimedPrior;
   try {
     // Atomically CLAIM the weekly allowance before the expensive build, so two
     // concurrent requests (double-click / refresh) can't both pass a check and
@@ -437,6 +442,8 @@ router.get('/me/full-export', requireAuth, async (req, res) => {
         nextAvailableAt: new Date(new Date(u.lastImageExportAt).getTime() + IMAGE_EXPORT_COOLDOWN_MS),
       });
     }
+    claimStamp = now;
+    claimedPrior = claimed.lastImageExportAt;
 
     const result = await buildCellarDataExport(req.user.id, scope);
 
@@ -487,6 +494,14 @@ router.get('/me/full-export', requireAuth, async (req, res) => {
     await archive.finalize();
   } catch (error) {
     console.error('Full export error:', error);
+    // Refund the claimed allowance — guarded on our own timestamp so a later
+    // legitimate claim is never clobbered (same guard as the empty-refund).
+    if (claimStamp) {
+      await User.updateOne(
+        { _id: req.user.id, lastImageExportAt: claimStamp },
+        { $set: { lastImageExportAt: claimedPrior ?? null } }
+      ).catch(err => console.error('[full-export] refund failed:', err.message));
+    }
     if (!res.headersSent) res.status(500).json({ error: 'Failed to export' });
   }
 });

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -82,10 +82,19 @@ router.get('/', requireAuth, async (req, res) => {
     const { limit: parsedLimit, offset: parsedOffset } = parsePagination(req.query, paginationOpts);
     const grapeIds = grapes ? String(grapes).split(',').filter(id => mongoose.isValidObjectId(id)) : [];
 
-    // Build MongoDB filter (used for non-search queries and as fallback)
+    // Build MongoDB filter (used for non-search queries and as fallback).
+    // Invalid country/region ids are a 400 — the old `? id : undefined`
+    // assignment made Mongoose drop the condition and silently return the
+    // UNFILTERED list for e.g. ?country=France.
     const filter = {};
-    if (country) filter.country = mongoose.isValidObjectId(String(country)) ? String(country) : undefined;
-    if (region) filter.region = mongoose.isValidObjectId(String(region)) ? String(region) : undefined;
+    if (country) {
+      if (!mongoose.isValidObjectId(String(country))) return res.status(400).json({ error: 'Invalid country ID' });
+      filter.country = String(country);
+    }
+    if (region) {
+      if (!mongoose.isValidObjectId(String(region))) return res.status(400).json({ error: 'Invalid region ID' });
+      filter.region = String(region);
+    }
     if (type) filter.type = String(type);
     if (grapeIds.length > 0) filter.grapes = { $in: grapeIds };
 


### PR DESCRIPTION
## Summary
The remaining backend LOWs from CODE_AUDIT_2026-07-08.md, in one reviewable batch (each fix is small and independent; the commit message itemizes all of them).

## Highlights by theme
- **Data integrity:** bottle `/undo` + `DELETE` unlink image files before deleting their docs (processed PNGs leaked forever — the sweep only reconciles `originals/`); imported bottles get the `addedToCellarAt`/`cellarHistory` seed; import rack placements only count after the save succeeds; review like/unlike race can no longer drive `likesCount` negative (and returns the real post-update count).
- **Validation/status codes:** `ratingScale` without `rating` is rejected (silent rating corruption); journal `mood: 7` is a 400 instead of silently erasing the value; `?country=France` on the wine registry is a 400 instead of silently returning the unfiltered list; discussion-report details capped at schema length (was a 500); somm routes coerce strings and allowlist currency; `link-to-bottle` enforces the 20-image cap the two-step AddBottle flow bypassed.
- **Consistency/retention:** cellar member/color mutations respect `deletedAt` (no more invites to soft-deleted cellars); export/audit routes distinguish 404 from 403; cellar statistics drops full-document hydration (`.lean()` + list projection — the aiProfile was loaded per bottle per request); blog slugs are pinned on title edits (published URLs 404'd) and deletes ping IndexNow; somm mutations write audit logs; the somm prices queue stops scanning every price snapshot per load; recommendation audit rows keep their wineId/recipient (recipient *email* deliberately excluded — external-party PII in a 90-day log); full-export refunds the weekly allowance on build failure.

## Testing
- `cd backend && npm test` — 823 passed; all 14 touched routers smoke-required cleanly.

## docker-compose impact
None — backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)