### PR TITLE
fix: shelf-rack import stride for back columns and multi-bottle cells

### DIFF
--- a/backend/src/utils/rackImport.js
+++ b/backend/src/utils/rackImport.js
@@ -101,20 +101,23 @@ function computeRackPosition({
     const slotsPerShelf = (cols + back) * bpc;
     const shelfBase = (effectiveShelf - 1) * slotsPerShelf;
 
+    // Layer capacities follow ShelfView's canonical numbering: the front
+    // layer spans cols*bpc positions, the back layer starts at cols*bpc.
+    // (With the default bpc=1 these reduce to the plain cols/back forms.)
     const layerNum = parseInt(layer, 10);
     const slotNum = parseInt(slotInLayer, 10);
     if (!isNaN(layerNum) && !isNaN(slotNum) && slotNum >= 1) {
       if (layerNum === 1) {
-        if (slotNum > cols) {
-          return { error: `front slot ${slotNum} exceeds cols ${cols}` };
+        if (slotNum > cols * bpc) {
+          return { error: `front slot ${slotNum} exceeds front capacity ${cols * bpc}` };
         }
         return { position: shelfBase + slotNum };
       }
       if (layerNum === 2) {
-        if (slotNum > back) {
-          return { error: `back slot ${slotNum} exceeds backCols ${back}` };
+        if (slotNum > back * bpc) {
+          return { error: `back slot ${slotNum} exceeds back capacity ${back * bpc}` };
         }
-        return { position: shelfBase + cols + slotNum };
+        return { position: shelfBase + cols * bpc + slotNum };
       }
       return { error: `invalid layer ${layerNum} (expected 1 or 2)` };
     }
@@ -123,7 +126,15 @@ function computeRackPosition({
   }
 
   // Grid rack (or shelf with row+col input): source is a slot or (row, col).
-  let srcRow, srcCol;
+  //
+  // Row STRIDE differs for shelf racks with back columns / multi-bottle
+  // cells: each shelf row spans (cols + backCols) * bpc positions (ShelfView's
+  // canonical numbering), not `cols` — using `cols` put every row ≥ 2 on the
+  // wrong shelf. Row/col input addresses the FRONT layer, whose width is
+  // cols * bpc. For plain grids both reduce to `cols` (unchanged behavior).
+  const rowStride = isShelf ? (cols + back) * bpc : cols;
+  const frontWidth = isShelf ? cols * bpc : cols;
+  let srcRow, srcCol, colWidth;
 
   if (position !== undefined && position !== null && position !== '') {
     const p = parseInt(position, 10);
@@ -135,16 +146,20 @@ function computeRackPosition({
     if (isNaN(cols) || cols < 1) {
       return { error: 'rackCols is required to transform position with a non-default anchor' };
     }
-    // Expand the source position into (row, col) of its CELL grid.
-    srcRow = Math.ceil(p / cols);
-    srcCol = ((p - 1) % cols) + 1;
+    // Expand the source position into (row, col) of its CELL grid. For a raw
+    // position the col spans the whole stride (front + back), so the mirror
+    // width below is the stride, keeping back-layer slots inside their layer.
+    srcRow = Math.ceil(p / rowStride);
+    srcCol = ((p - 1) % rowStride) + 1;
+    colWidth = rowStride;
   } else {
     srcRow = parseInt(row, 10);
     srcCol = parseInt(col, 10);
     if (isNaN(srcRow) || srcRow < 1) return { error: 'Invalid row' };
     if (isNaN(srcCol) || srcCol < 1) return { error: 'Invalid col' };
     if (isNaN(cols) || cols < 1) return { error: 'rackCols is required to compute position from row/col' };
-    if (srcCol > cols) return { error: `col ${srcCol} exceeds rackCols ${cols}` };
+    if (srcCol > frontWidth) return { error: `col ${srcCol} exceeds row width ${frontWidth}` };
+    colWidth = frontWidth;
   }
 
   // Apply anchor transforms in the cell grid (rows × cols).
@@ -162,10 +177,10 @@ function computeRackPosition({
     if (isNaN(cols) || cols < 1) {
       return { error: 'rackCols is required for right-anchored placement' };
     }
-    effectiveCol = cols - srcCol + 1;
+    effectiveCol = colWidth - srcCol + 1;
   }
 
-  return { position: (effectiveRow - 1) * cols + effectiveCol };
+  return { position: (effectiveRow - 1) * rowStride + effectiveCol };
 }
 
 /**

--- a/backend/src/utils/rackImport.test.js
+++ b/backend/src/utils/rackImport.test.js
@@ -607,3 +607,63 @@ describe('placeBottlesInRack (orchestration)', () => {
     expect(placements[0].position).toBe(9);
   });
 });
+
+// ── Shelf stride with bottlesPerCell > 1 / back columns (audit MED #16) ─────
+// Canonical numbering (ShelfView): each shelf spans (cols + backCols) * bpc
+// positions; the front layer covers the first cols*bpc, the back layer starts
+// at cols*bpc. These pin the importer to that contract.
+describe('shelf racks with bottlesPerCell > 1', () => {
+  const shelf = { rackType: 'shelf', rackRows: 10, rackCols: 6, backCols: 5, bottlesPerCell: 2 };
+  const stride = (6 + 5) * 2; // 22 positions per shelf
+
+  test('front layer slot lands within the front span of its shelf', () => {
+    // shelf 1 (top-anchored), front slot 8 → base 0 + 8
+    expect(computeRackPosition({ ...shelf, position: 1, layer: 1, slotInLayer: 8 }))
+      .toEqual({ position: 8 });
+    // front capacity is cols*bpc = 12, not cols = 6
+    expect(computeRackPosition({ ...shelf, position: 1, layer: 1, slotInLayer: 12 }))
+      .toEqual({ position: 12 });
+    expect(computeRackPosition({ ...shelf, position: 1, layer: 1, slotInLayer: 13 }).error).toBeDefined();
+  });
+
+  test('back layer starts after cols*bpc, not after cols', () => {
+    // shelf 1, back slot 1 → 0 + 6*2 + 1 = 13 (the old math returned 7 — a FRONT cell)
+    expect(computeRackPosition({ ...shelf, position: 1, layer: 2, slotInLayer: 1 }))
+      .toEqual({ position: 13 });
+    // back capacity is backCols*bpc = 10
+    expect(computeRackPosition({ ...shelf, position: 1, layer: 2, slotInLayer: 10 }))
+      .toEqual({ position: 22 });
+    expect(computeRackPosition({ ...shelf, position: 1, layer: 2, slotInLayer: 11 }).error).toBeDefined();
+  });
+
+  test('shelf 2 uses the full (cols+backCols)*bpc stride', () => {
+    expect(computeRackPosition({ ...shelf, position: 2, layer: 1, slotInLayer: 1 }))
+      .toEqual({ position: stride + 1 });
+    expect(computeRackPosition({ ...shelf, position: 2, layer: 2, slotInLayer: 1 }))
+      .toEqual({ position: stride + 12 + 1 });
+  });
+
+  test('row/col input on a shelf rack uses the shelf stride, front-layer width', () => {
+    // row 2, col 3 → (2-1)*22 + 3 = 25 (the old math returned (2-1)*6 + 3 = 9 — shelf 1's back layer)
+    expect(computeRackPosition({ ...shelf, row: 2, col: 3 }))
+      .toEqual({ position: 25 });
+    // col bounded by front width (12)
+    expect(computeRackPosition({ ...shelf, row: 1, col: 12 })).toEqual({ position: 12 });
+    expect(computeRackPosition({ ...shelf, row: 1, col: 13 }).error).toBeDefined();
+  });
+
+  test('bpc=1 shelves keep the historical numbering (regression guard)', () => {
+    const oeno = { rackType: 'shelf', rackRows: 18, rackCols: 6, backCols: 5 };
+    // shelf 11 top-anchored: base (11-1)*11 = 110; front 3 → 113; back 2 → 110+6+2 = 118
+    expect(computeRackPosition({ ...oeno, position: 11, layer: 1, slotInLayer: 3 }))
+      .toEqual({ position: 113 });
+    expect(computeRackPosition({ ...oeno, position: 11, layer: 2, slotInLayer: 2 }))
+      .toEqual({ position: 118 });
+  });
+
+  test('plain grids are untouched by the stride change', () => {
+    expect(computeRackPosition({ row: 2, col: 3, rackCols: 6 })).toEqual({ position: 9 });
+    expect(computeRackPosition({ position: 9, rackCols: 6, rackRows: 4, anchor: 'bottom-left' }))
+      .toEqual({ position: (4 - 2) * 6 + 3 });
+  });
+});


### PR DESCRIPTION
## Summary
Audit finding **MED #16** (CODE_AUDIT_2026-07-08.md): `computeRackPosition` disagreed with ShelfView's canonical slot numbering in three previously-untested combinations:

- **Back-layer slots** were computed as `shelfBase + cols + slot` instead of `shelfBase + cols*bpc + slot` — with `bottlesPerCell: 2`, every back-layer bottle landed in a **front** cell.
- **Front-layer capacity** was capped at `cols` instead of `cols*bpc`, making half the front unreachable.
- **Row/col-addressed items** on shelf racks used the grid stride (`cols`) instead of `(cols + backCols) * bpc`, so every row ≥ 2 landed on the wrong shelf.

## Change
Stride and layer offsets now mirror `ShelfView.js`'s numbering exactly. Plain grids and `bpc=1` shelves (the Oeno/Vintec import default) reduce to the old formulas — no behavior change on any path exercised today.

## Testing
- 6 new test suites pin the fixed math (bpc=2 front/back placement, shelf-stride row/col, per-layer capacity bounds) **and** the historical bpc=1 + plain-grid numbering as regression guards.
- `cd backend && npm test` — 829 passed (823 + 6 new).

## docker-compose impact
None — backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)