### PR TITLE
feat: allow users to delete their own reviews from the UI

### DIFF
--- a/frontend/src/components/ReviewCard.css
+++ b/frontend/src/components/ReviewCard.css
@@ -147,6 +147,24 @@
   opacity: 0.5;
 }
 
+.review-card__delete-btn {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  padding: 0.3rem 0.5rem;
+  border-radius: var(--radius-sm);
+  transition: all var(--transition-fast);
+}
+
+.review-card__delete-btn:hover {
+  background: var(--color-bg);
+  color: var(--color-danger);
+}
+
 .review-card__private-badge {
   font-size: 0.75rem;
   color: var(--color-text-muted);

--- a/frontend/src/components/ReviewCard.js
+++ b/frontend/src/components/ReviewCard.js
@@ -1,17 +1,23 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import RatingDisplay from './RatingDisplay';
-import { toggleLike } from '../api/reviews';
+import { toggleLike, deleteReview } from '../api/reviews';
 import CellarCredBadge from './CellarCredBadge';
+import Modal from './Modal';
 import timeAgo from '../utils/timeAgo';
 import './ReviewCard.css';
 
-export default function ReviewCard({ review, showWine = true, onUpdate }) {
+export default function ReviewCard({ review, showWine = true, onUpdate, onDelete }) {
+  const { t } = useTranslation();
   const { apiFetch, user } = useAuth();
   const [liked, setLiked] = useState(review.liked || false);
   const [likesCount, setLikesCount] = useState(review.likesCount || 0);
   const [expanded, setExpanded] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState(false);
 
   const author = review.author || {};
   const wine = review.wineDefinition || {};
@@ -40,6 +46,24 @@ export default function ReviewCard({ review, showWine = true, onUpdate }) {
     } catch {
       setLiked(prevLiked);
       setLikesCount(prevCount);
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setDeleteError(false);
+    try {
+      const res = await deleteReview(apiFetch, review._id);
+      if (res.ok) {
+        setConfirmDelete(false);
+        if (onDelete) onDelete(review._id);
+      } else {
+        setDeleteError(true);
+      }
+    } catch {
+      setDeleteError(true);
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -114,7 +138,52 @@ export default function ReviewCard({ review, showWine = true, onUpdate }) {
           </svg>
           <span>{likesCount}</span>
         </button>
+        {isOwnReview && onDelete && (
+          <button
+            className="review-card__delete-btn"
+            onClick={() => { setDeleteError(false); setConfirmDelete(true); }}
+            title={t('reviews.deleteReview', 'Delete review')}
+            aria-label={t('reviews.deleteReview', 'Delete review')}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+              <line x1="10" y1="11" x2="10" y2="17" />
+              <line x1="14" y1="11" x2="14" y2="17" />
+            </svg>
+          </button>
+        )}
       </div>
+
+      {confirmDelete && (
+        <Modal
+          title={t('reviews.deleteTitle', 'Delete review?')}
+          onClose={() => !deleting && setConfirmDelete(false)}
+        >
+          <p>{t('reviews.deleteBody', 'This will permanently delete your review. This cannot be undone.')}</p>
+          {deleteError && (
+            <p className="alert alert-error">{t('reviews.deleteError', 'Failed to delete the review — please try again.')}</p>
+          )}
+          <div className="modal-actions">
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setConfirmDelete(false)}
+              disabled={deleting}
+            >
+              {t('common.cancel', 'Cancel')}
+            </button>
+            <button
+              type="button"
+              className="btn btn-danger"
+              onClick={handleDelete}
+              disabled={deleting}
+            >
+              {deleting ? t('reviews.deleting', 'Deleting…') : t('common.delete', 'Delete')}
+            </button>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1630,7 +1630,12 @@
     "visibilityPublicHint": "Visible to all users",
     "visibilityPrivateHint": "Only you can see this review",
     "overallImpression": "Overall Impression",
-    "privateBadge": "Private"
+    "privateBadge": "Private",
+    "deleteReview": "Delete review",
+    "deleteTitle": "Delete review?",
+    "deleteBody": "This will permanently delete your review. This cannot be undone.",
+    "deleteError": "Failed to delete the review — please try again.",
+    "deleting": "Deleting…"
   },
   "discussions": {
     "community": "Community",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1630,7 +1630,12 @@
     "visibilityPublicHint": "Synlig för alla användare",
     "visibilityPrivateHint": "Bara du kan se detta omdöme",
     "overallImpression": "Helhetsintryck",
-    "privateBadge": "Privat"
+    "privateBadge": "Privat",
+    "deleteReview": "Ta bort omdöme",
+    "deleteTitle": "Ta bort omdömet?",
+    "deleteBody": "Detta tar bort ditt omdöme permanent. Det går inte att ångra.",
+    "deleteError": "Det gick inte att ta bort omdömet — försök igen.",
+    "deleting": "Tar bort…"
   },
   "discussions": {
     "community": "Gemenskap",

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -515,7 +515,17 @@ function BottleDetail() {
           </div>
           {wineReviews.length > 0 ? (
             wineReviews.map(review => (
-              <ReviewCard key={review._id} review={review} showWine={false} />
+              <ReviewCard
+                key={review._id}
+                review={review}
+                showWine={false}
+                onDelete={() => {
+                  // Same refresh as after saving a review: refetch the list and
+                  // drop the (now stale) community aggregate.
+                  fetchWineReviews(wine._id);
+                  setCommunityRating(null);
+                }}
+              />
             ))
           ) : (
             <p className="bd-reviews__empty">{t('reviews.noReviews', 'No reviews yet. Be the first to review this wine!')}</p>

--- a/frontend/src/pages/ReviewFeed.js
+++ b/frontend/src/pages/ReviewFeed.js
@@ -188,7 +188,12 @@ function ReviewFeed() {
       ) : (
         <div className="review-feed__list">
           {reviews.map(review => (
-            <ReviewCard key={review._id} review={review} showWine />
+            <ReviewCard
+              key={review._id}
+              review={review}
+              showWine
+              onDelete={id => setReviews(prev => prev.filter(r => r._id !== id))}
+            />
           ))}
         </div>
       )}

--- a/frontend/src/pages/UserProfile.js
+++ b/frontend/src/pages/UserProfile.js
@@ -177,7 +177,15 @@ function UserProfile() {
           <p className="user-profile__no-reviews">{t('userProfile.noReviews')}</p>
         ) : (
           reviews.map(review => (
-            <ReviewCard key={review._id} review={review} showWine />
+            <ReviewCard
+              key={review._id}
+              review={review}
+              showWine
+              onDelete={id => {
+                setReviews(prev => prev.filter(r => r._id !== id));
+                setProfile(prev => prev ? { ...prev, reviewCount: Math.max(0, (prev.reviewCount || 0) - 1) } : prev);
+              }}
+            />
           ))
         )}
 


### PR DESCRIPTION
## What / why

The 2026-07-08 audit (CODE_AUDIT_2026-07-08.md) flagged that `DELETE /api/reviews/:id` and the `deleteReview` export in `frontend/src/api/reviews.js` were dead code — the backend fully supported review deletion (owner or admin), but the UI offered no way to delete a review. Users who wrote a review were stuck with it forever.

This PR wires up the existing (unmodified) backend route and the existing `deleteReview` API function into the UI. No backend changes.

## Changes

- **`ReviewCard`** (shared renderer): a small trash icon button now appears in the card footer on the user's own reviews (`author._id === user.id`), styled to match the existing like button. Clicking it opens a confirmation dialog using the shared `Modal` component (deletion is destructive); confirm calls `deleteReview` and invokes a new optional `onDelete(reviewId)` callback prop, consistent with the existing `onUpdate` callback API. Inline error message on failure.

## Surfaces covered

- **Review Feed** (`ReviewFeed.js`) — removes the review from the local feed list
- **User Profile** (`UserProfile.js`) — removes the review from the list and decrements the visible review-count stat
- **Bottle Detail** (`BottleDetail.js`) — refetches the wine's review list and drops the stale community-rating aggregate (same refresh path as after saving a review)

The delete button only renders when the review is the viewer's own **and** the consumer passes `onDelete`, so read-only embeds are unaffected.

## i18n

Fully bilingual: 5 new keys under the existing `reviews.*` namespace in both `en` and `sv` (`deleteReview`, `deleteTitle`, `deleteBody`, `deleteError`, `deleting`); confirm/cancel buttons reuse `common.delete` / `common.cancel`. **Note:** the Swedish strings are machine-authored (informal "du") and pending native review.

## Testing

- `cd frontend && npm test` — 13 files, 337 tests, all pass
- Both translation JSON files validated as parseable JSON
- Backend route untouched; ownership enforcement remains server-side (owner or admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)