### PR TITLE
feat: add change-password UI to Settings

### DIFF
--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,14 @@
+import { JSON_HEADERS } from './apiConstants';
+
+// POST /api/auth/change-password — body: { currentPassword, newPassword }.
+// On success the backend invalidates all other sessions, rotates the refresh
+// cookie for THIS browser and returns a fresh access token, so the current
+// session keeps working via the normal apiFetch auto-refresh flow.
+// Errors: 400 (policy violation / missing fields), 401 (wrong current
+// password), 429 (auth rate limit).
+export const changePassword = (apiFetch, { currentPassword, newPassword }) =>
+  apiFetch('/api/auth/change-password', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ currentPassword, newPassword })
+  });

--- a/frontend/src/api/auth.test.js
+++ b/frontend/src/api/auth.test.js
@@ -1,0 +1,38 @@
+import { changePassword } from './auth';
+
+describe('changePassword', () => {
+  test('POSTs credentials as JSON to /api/auth/change-password', async () => {
+    const apiFetch = vi.fn().mockResolvedValue({ ok: true });
+
+    await changePassword(apiFetch, {
+      currentPassword: 'OldPassw0rd!abc',
+      newPassword: 'NewPassw0rd!abc'
+    });
+
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = apiFetch.mock.calls[0];
+    expect(url).toBe('/api/auth/change-password');
+    expect(options.method).toBe('POST');
+    expect(options.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(options.body)).toEqual({
+      currentPassword: 'OldPassw0rd!abc',
+      newPassword: 'NewPassw0rd!abc'
+    });
+  });
+
+  test('does not leak extra fields into the request body', async () => {
+    const apiFetch = vi.fn().mockResolvedValue({ ok: true });
+
+    await changePassword(apiFetch, {
+      currentPassword: 'a',
+      newPassword: 'b',
+      confirmNewPassword: 'b'
+    });
+
+    const [, options] = apiFetch.mock.calls[0];
+    expect(Object.keys(JSON.parse(options.body)).sort()).toEqual([
+      'currentPassword',
+      'newPassword'
+    ]);
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -196,6 +196,21 @@
       "pushNotConfigured": "Push notifications are not configured on this server.",
       "pushHint": "Push delivers notifications to your device even when Cellarion is closed."
     },
+    "changePassword": {
+      "title": "Change password",
+      "hint": "Choose a strong password: at least 12 characters with an uppercase letter, a lowercase letter, a number, and a special character. Changing your password signs you out on all other devices.",
+      "currentLabel": "Current password",
+      "newLabel": "New password",
+      "confirmLabel": "Confirm new password",
+      "submitBtn": "Change password",
+      "submittingBtn": "Changing…",
+      "successMsg": "Password changed",
+      "errorMismatch": "The new passwords do not match.",
+      "errorPolicy": "Password must be at least 12 characters and include an uppercase letter, lowercase letter, number, and special character.",
+      "errorWrongCurrent": "Your current password is incorrect.",
+      "errorRateLimited": "Too many attempts. Please wait a few minutes and try again.",
+      "errorGeneric": "Failed to change password. Please try again."
+    },
     "defaultRatingScale": "Default Rating Scale",
     "ratingScaleHint": "Choose which rating scale to use by default when adding ratings. You can always override per bottle."
   },

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -196,6 +196,21 @@
       "pushNotConfigured": "Push-aviseringar är inte konfigurerade på denna server.",
       "pushHint": "Push levererar aviseringar till din enhet även när Cellarion är stängt."
     },
+    "changePassword": {
+      "title": "Byt lösenord",
+      "hint": "Välj ett starkt lösenord: minst 12 tecken med en versal, en gemen, en siffra och ett specialtecken. När du byter lösenord loggas du ut på alla andra enheter.",
+      "currentLabel": "Nuvarande lösenord",
+      "newLabel": "Nytt lösenord",
+      "confirmLabel": "Bekräfta nytt lösenord",
+      "submitBtn": "Byt lösenord",
+      "submittingBtn": "Byter…",
+      "successMsg": "Lösenordet har bytts",
+      "errorMismatch": "De nya lösenorden matchar inte.",
+      "errorPolicy": "Lösenordet måste vara minst 12 tecken och innehålla en versal, en gemen, en siffra och ett specialtecken.",
+      "errorWrongCurrent": "Ditt nuvarande lösenord är felaktigt.",
+      "errorRateLimited": "För många försök. Vänta några minuter och försök igen.",
+      "errorGeneric": "Det gick inte att byta lösenord. Försök igen."
+    },
     "defaultRatingScale": "Standardbetygsskala",
     "ratingScaleHint": "Välj vilken betygsskala som används som standard när du sätter betyg. Du kan alltid ändra per flaska."
   },

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import useVersion from '../hooks/useVersion';
 import { updateProfile } from '../api/profiles';
+import { changePassword } from '../api/auth';
 import { CURRENCIES } from '../config/currencies';
 import { PLANS } from '../config/plans';
 import { SCALE_META, VALID_SCALES } from '../utils/ratingUtils';
@@ -32,6 +33,14 @@ function Settings() {
   const [profileSaving, setProfileSaving] = useState(false);
   const [profileSaved, setProfileSaved] = useState(false);
   const [profileError, setProfileError] = useState(null);
+
+  // Change password state
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmNewPassword, setConfirmNewPassword] = useState('');
+  const [passwordSaving, setPasswordSaving] = useState(false);
+  const [passwordSaved, setPasswordSaved] = useState(false);
+  const [passwordError, setPasswordError] = useState(null);
 
   // Notification preferences — per-category × per-channel grid. The state
   // mirrors the User schema shape so updatePreferences just passes through.
@@ -198,6 +207,53 @@ function Settings() {
     }
   };
 
+  // Mirrors the backend password policy (backend/src/models/User.js):
+  // min 12 chars with an uppercase letter, lowercase letter, number and
+  // special character. Checked client-side for instant feedback; the
+  // backend re-validates and returns 400 if it disagrees.
+  const PASSWORD_POLICY = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z\d]).{12,}$/;
+
+  const handleChangePassword = async (e) => {
+    e.preventDefault();
+    setPasswordError(null);
+    setPasswordSaved(false);
+
+    if (newPassword !== confirmNewPassword) {
+      setPasswordError(t('settings.changePassword.errorMismatch'));
+      return;
+    }
+    if (!PASSWORD_POLICY.test(newPassword)) {
+      setPasswordError(t('settings.changePassword.errorPolicy'));
+      return;
+    }
+
+    setPasswordSaving(true);
+    try {
+      const res = await changePassword(apiFetch, { currentPassword, newPassword });
+      if (res.ok) {
+        // Backend rotated this browser's refresh cookie and invalidated all
+        // other sessions — this session continues via apiFetch auto-refresh.
+        setCurrentPassword('');
+        setNewPassword('');
+        setConfirmNewPassword('');
+        setPasswordSaved(true);
+        setTimeout(() => setPasswordSaved(false), 5000);
+      } else if (res.status === 401) {
+        setPasswordError(t('settings.changePassword.errorWrongCurrent'));
+      } else if (res.status === 429) {
+        setPasswordError(t('settings.changePassword.errorRateLimited'));
+      } else if (res.status === 400) {
+        setPasswordError(t('settings.changePassword.errorPolicy'));
+      } else {
+        setPasswordError(t('settings.changePassword.errorGeneric'));
+      }
+    } catch {
+      setPasswordError(t('settings.changePassword.errorGeneric'));
+    } finally {
+      setPasswordSaving(false);
+    }
+  };
+
   const handleSave = async (e) => {
     e.preventDefault();
     setSaving(true);
@@ -348,6 +404,68 @@ function Settings() {
               {profileSaving ? t('settings.savingBtn') : t('settings.saveBtn')}
             </button>
             {profileSaved && <span className="settings-saved">{t('settings.savedMsg')}</span>}
+          </div>
+        </form>
+      </div>
+
+      {/* ── Change password card ── */}
+      <div className="card settings-card">
+        <h2 className="settings-section-title">{t('settings.changePassword.title')}</h2>
+        <p className="settings-hint">{t('settings.changePassword.hint')}</p>
+        <form onSubmit={handleChangePassword}>
+          {/* Hidden username field so password managers associate the new
+              credentials with the right account */}
+          <input
+            type="text"
+            autoComplete="username"
+            value={user?.username || ''}
+            readOnly
+            hidden
+          />
+          <div className="form-group">
+            <label htmlFor="current-password-input">{t('settings.changePassword.currentLabel')}</label>
+            <input
+              id="current-password-input"
+              type="password"
+              className="input"
+              autoComplete="current-password"
+              value={currentPassword}
+              onChange={e => setCurrentPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="new-password-input">{t('settings.changePassword.newLabel')}</label>
+            <input
+              id="new-password-input"
+              type="password"
+              className="input"
+              autoComplete="new-password"
+              value={newPassword}
+              onChange={e => setNewPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="confirm-password-input">{t('settings.changePassword.confirmLabel')}</label>
+            <input
+              id="confirm-password-input"
+              type="password"
+              className="input"
+              autoComplete="new-password"
+              value={confirmNewPassword}
+              onChange={e => setConfirmNewPassword(e.target.value)}
+              required
+            />
+          </div>
+
+          {passwordError && <div className="alert alert-error">{passwordError}</div>}
+
+          <div className="settings-actions">
+            <button type="submit" className="btn btn-primary" disabled={passwordSaving}>
+              {passwordSaving ? t('settings.changePassword.submittingBtn') : t('settings.changePassword.submitBtn')}
+            </button>
+            {passwordSaved && <span className="settings-saved">{t('settings.changePassword.successMsg')}</span>}
           </div>
         </form>
       </div>


### PR DESCRIPTION
## What

Adds a **Change password** card to the Settings page. `POST /api/auth/change-password` has existed on the backend (requireAuth + authLimiter) but no UI ever called it — CODE_AUDIT_2026-07-08.md flagged it as a dead endpoint. This builds the missing UI; the backend route is untouched.

## How

- **New api module** `frontend/src/api/auth.js` — `changePassword(apiFetch, { currentPassword, newPassword })`, following the existing typed-api-module pattern (+ a small unit test `auth.test.js`).
- **Settings.js** — new card between Profile and Plan with current / new / confirm fields (`type=password`, `autocomplete="current-password"` / `"new-password"`, plus a hidden `autocomplete="username"` field so password managers associate the credential correctly). Reuses the existing card/form-group/alert/settings-actions patterns — no new CSS.
- **Client-side validation** mirrors the backend policy from `backend/src/models/User.js` (min 12 chars with uppercase, lowercase, digit, special character) plus a confirm-match check, so most errors never hit the rate-limited endpoint.
- **Error mapping**: 401 → "current password is incorrect", 400 → policy message, 429 → "too many attempts", anything else → generic. Fields are cleared and a success message shown on 200.
- **Session handling**: the backend invalidates all other sessions and rotates this browser's refresh cookie + returns a fresh access token, so the current session continues seamlessly via the normal apiFetch auto-refresh flow. The card's hint tells the user other devices will be signed out.
- **i18n**: 13 new keys under `settings.changePassword.*` in both `en` and `sv` (identical structure). *Note: the Swedish strings are machine-authored, pending native review.*

## Testing

- `cd frontend && npm test` — 339 tests / 14 files, all passing (includes the new `api/auth.test.js`)
- `npm run build` — production build succeeds
- Verified error-path mapping against the actual backend route responses (401 wrong current password, 400 Mongoose ValidationError join, 429 authLimiter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
