### PR TITLE
fix: close IDOR gaps (NFC rack resolve, journal refs, assign-to-wine visibility)

### DIFF
--- a/backend/src/routes/admin/images.assign.test.js
+++ b/backend/src/routes/admin/images.assign.test.js
@@ -1,0 +1,163 @@
+/**
+ * Visibility tests for PUT /api/admin/images/:id/assign-to-wine (security
+ * audit 2026-07-08, L-7).
+ *
+ * WHY THIS TEST EXISTS:
+ * assign-to-wine used to set WineDefinition.image without touching
+ * image.visibility, so an approved-but-PRIVATE image could become the public
+ * wine detail / og:image while GET /api/images/wine/:id still hid it. The fix
+ * mirrors the sibling set-official route: publishing an image to the public
+ * wine page implicitly makes it public, so assign-to-wine now flips
+ * visibility to 'public' before saving. The status:'approved' gate is kept.
+ *
+ * The real admin images router is mounted with the real
+ * requireAuth + requireRole('admin') middleware (HS256 test tokens); models
+ * and services are mocked so no MongoDB / Meilisearch / sharp is needed.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../models/BottleImage', () => ({
+  findById: jest.fn(),
+  updateMany: jest.fn(),
+}));
+jest.mock('../../models/WineDefinition', () => ({ findByIdAndUpdate: jest.fn() }));
+jest.mock('../../models/Bottle', () => ({}));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn() }));
+jest.mock('../../services/imageProcessor', () => ({
+  reprocessAllImages: jest.fn(),
+  safeUploadPath: jest.fn(),
+  unlinkImageFiles: jest.fn(),
+}));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/notifications', () => ({ createNotification: jest.fn() }));
+jest.mock('../../utils/cellarCred', () => ({ incrementCred: jest.fn().mockResolvedValue(undefined) }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const BottleImage = require('../../models/BottleImage');
+const WineDefinition = require('../../models/WineDefinition');
+const imagesRouter = require('./images');
+
+const IMAGE_ID = '64b0000000000000000000e1';
+const WINE_ID = '64b0000000000000000000f1';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/images', imagesRouter);
+  return app;
+}
+
+function makeReq(app, method, url, headers = {}) {
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const port = server.address().port;
+      const req = http.request({ port, path: url, method, headers }, (res) => {
+        const chunks = [];
+        res.on('data', c => chunks.push(c));
+        res.on('end', () => {
+          server.close();
+          const text = Buffer.concat(chunks).toString();
+          resolve({ status: res.statusCode, body: text ? JSON.parse(text) : null });
+        });
+      });
+      req.on('error', () => { server.close(); resolve({ status: 0 }); });
+      req.end();
+    });
+  });
+}
+
+const adminToken = () =>
+  jwt.sign({ id: '64b000000000000000000001', roles: ['admin'] }, 'test-secret', {
+    algorithm: 'HS256',
+    expiresIn: '1h',
+  });
+
+const makeImage = (overrides = {}) => ({
+  _id: IMAGE_ID,
+  status: 'approved',
+  visibility: 'private',
+  wineDefinition: WINE_ID,
+  assignedToWine: false,
+  processedUrl: '/api/uploads/abc.png',
+  originalUrl: null,
+  credit: null,
+  uploadedBy: '64b000000000000000000002',
+  save: jest.fn().mockResolvedValue(undefined),
+  populate: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  BottleImage.updateMany.mockResolvedValue({});
+  WineDefinition.findByIdAndUpdate.mockResolvedValue({});
+});
+
+describe('PUT /api/admin/images/:id/assign-to-wine visibility (L-7)', () => {
+  test('assigning an approved-but-PRIVATE image flips it to public before saving', async () => {
+    const image = makeImage({ visibility: 'private' });
+    BottleImage.findById.mockResolvedValue(image);
+
+    const { status } = await makeReq(buildApp(), 'PUT', `/api/admin/images/${IMAGE_ID}/assign-to-wine`, {
+      authorization: `Bearer ${adminToken()}`,
+    });
+
+    expect(status).toBe(200);
+    expect(image.visibility).toBe('public');
+    expect(image.assignedToWine).toBe(true);
+    expect(image.save).toHaveBeenCalled();
+    // the save carrying visibility='public' happens BEFORE the wine page starts
+    // serving the URL
+    expect(image.save.mock.invocationCallOrder[0])
+      .toBeLessThan(WineDefinition.findByIdAndUpdate.mock.invocationCallOrder[0]);
+    expect(WineDefinition.findByIdAndUpdate).toHaveBeenCalledWith(
+      WINE_ID,
+      { image: '/api/uploads/abc.png', imageCredit: null }
+    );
+  });
+
+  test('an already-public image stays public and still assigns', async () => {
+    const image = makeImage({ visibility: 'public' });
+    BottleImage.findById.mockResolvedValue(image);
+
+    const { status } = await makeReq(buildApp(), 'PUT', `/api/admin/images/${IMAGE_ID}/assign-to-wine`, {
+      authorization: `Bearer ${adminToken()}`,
+    });
+
+    expect(status).toBe(200);
+    expect(image.visibility).toBe('public');
+    expect(image.assignedToWine).toBe(true);
+  });
+
+  test('the status gate is kept: a non-approved image is rejected with 400 and left untouched', async () => {
+    const image = makeImage({ status: 'processed', visibility: 'private' });
+    BottleImage.findById.mockResolvedValue(image);
+
+    const { status, body } = await makeReq(buildApp(), 'PUT', `/api/admin/images/${IMAGE_ID}/assign-to-wine`, {
+      authorization: `Bearer ${adminToken()}`,
+    });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/approved/i);
+    expect(image.visibility).toBe('private');
+    expect(image.save).not.toHaveBeenCalled();
+    expect(WineDefinition.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('route stays admin-only: a regular user gets 403', async () => {
+    const userToken = jwt.sign(
+      { id: '64b000000000000000000003', roles: ['user'] },
+      'test-secret',
+      { algorithm: 'HS256', expiresIn: '1h' }
+    );
+    const { status } = await makeReq(buildApp(), 'PUT', `/api/admin/images/${IMAGE_ID}/assign-to-wine`, {
+      authorization: `Bearer ${userToken}`,
+    });
+    expect(status).toBe(403);
+    expect(BottleImage.findById).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/admin/images.js
+++ b/backend/src/routes/admin/images.js
@@ -471,9 +471,14 @@ router.put('/:id/assign-to-wine', async (req, res) => {
       { assignedToWine: false }
     );
 
-    // Set this image as official
+    // Set this image as official. Assigning an image to the public wine page
+    // implicitly publishes it, so flip visibility too — otherwise an
+    // approved-but-private image would be served as the wine detail/og:image
+    // while GET /api/images/wine/:id still hides it (audit L-7; mirrors
+    // set-official below).
     image.assignedToWine = true;
     image.wineDefinition = wineDefId;
+    image.visibility = 'public';
     await image.save();
 
     // Award Cellar Cred for official wine image assignment

--- a/backend/src/routes/journal.js
+++ b/backend/src/routes/journal.js
@@ -8,6 +8,7 @@ const { logAudit } = require('../services/audit');
 const { createNotification } = require('../services/notifications');
 const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { isValidId } = require('../utils/validation');
+const { getCellarRole } = require('../utils/cellarAccess');
 
 const router = express.Router();
 router.use(requireAuth);
@@ -64,6 +65,73 @@ function sanitizeEntry(body) {
   return clean;
 }
 
+/**
+ * Ownership/existence validation for the references sanitizeEntry accepted by
+ * shape alone (audit L-5). Mirrors sanitizeEntry's style: invalid references
+ * are silently dropped (nulled), never a hard 400 — exactly like a malformed
+ * ObjectId already is.
+ *
+ *  - pairings[].bottle must resolve to a bottle the author can access: their
+ *    own bottle, or one in a cellar where they hold any role (getCellarRole,
+ *    same check the bottles routes use). Otherwise a foreign bottle id would
+ *    be populated back as {vintage, wine name/producer/type}.
+ *  - pairings[].wine is a public WineDefinition ref → existence check only.
+ */
+async function validatePairingRefs(clean, userId) {
+  if (!Array.isArray(clean.pairings) || clean.pairings.length === 0) return;
+
+  const bottleIds = [...new Set(clean.pairings.filter(p => p.bottle).map(p => String(p.bottle)))];
+  if (bottleIds.length) {
+    const bottles = await Bottle.find({ _id: { $in: bottleIds } })
+      .select('user cellar')
+      .populate('cellar', 'user members deletedAt')
+      .lean();
+    const accessible = new Set(
+      bottles
+        .filter(b =>
+          String(b.user) === String(userId) ||
+          (b.cellar && !b.cellar.deletedAt && getCellarRole(b.cellar, userId))
+        )
+        .map(b => String(b._id))
+    );
+    for (const p of clean.pairings) {
+      if (p.bottle && !accessible.has(String(p.bottle))) p.bottle = null;
+    }
+  }
+
+  const wineIds = [...new Set(clean.pairings.filter(p => p.wine).map(p => String(p.wine)))];
+  if (wineIds.length) {
+    const wines = await WineDefinition.find({ _id: { $in: wineIds } }).select('_id').lean();
+    const existing = new Set(wines.map(w => String(w._id)));
+    for (const p of clean.pairings) {
+      if (p.wine && !existing.has(String(p.wine))) p.wine = null;
+    }
+  }
+}
+
+/**
+ * Read-time privacy gate for populated people[].user (audit L-5). A private
+ * profile's username/displayName must not be resolvable by tagging its
+ * ObjectId in a journal entry — that would re-open the enumeration oracle
+ * users.js GET /public/:userId closes. Private users (other than the
+ * requester themselves) are reduced to their bare _id; the helper also strips
+ * the profileVisibility field the populate fetched for this decision.
+ * Applied at read time so rows written before this gate are covered too.
+ */
+function redactPeople(entry, requesterId) {
+  if (!entry || !Array.isArray(entry.people)) return entry;
+  entry.people = entry.people.map(p => {
+    const u = p.user;
+    if (!u || typeof u !== 'object' || !u._id) return p;
+    if (u.profileVisibility === 'private' && String(u._id) !== String(requesterId)) {
+      return { ...p, user: { _id: u._id } };
+    }
+    const { profileVisibility, ...visible } = u;
+    return { ...p, user: visible };
+  });
+  return entry;
+}
+
 // GET /api/journal/wine-search — search user's bottles + wine register for the pairing picker
 router.get('/wine-search', async (req, res) => {
   try {
@@ -111,7 +179,9 @@ router.get('/wine-search', async (req, res) => {
 const POPULATE_PAIRINGS = [
   { path: 'pairings.bottle', select: 'vintage wineDefinition', populate: { path: 'wineDefinition', select: 'name producer type' } },
   { path: 'pairings.wine', select: 'name producer type' },
-  { path: 'people.user', select: 'username displayName' }
+  // profileVisibility is fetched ONLY for redactPeople's gate — it is
+  // stripped from every response before send.
+  { path: 'people.user', select: 'username displayName profileVisibility' }
 ];
 
 // GET /api/journal — list the user's own journal entries
@@ -151,7 +221,7 @@ router.get('/', async (req, res) => {
       JournalEntry.countDocuments(query)
     ]);
 
-    res.json({ items, total, limit, skip });
+    res.json({ items: items.map(i => redactPeople(i, req.user.id)), total, limit, skip });
   } catch (err) {
     console.error('Get journal entries error:', err);
     res.status(500).json({ error: 'Failed to load journal entries' });
@@ -166,6 +236,8 @@ router.post('/', async (req, res) => {
     if (!clean.date || isNaN(clean.date.getTime())) {
       return res.status(400).json({ error: 'Valid date is required' });
     }
+
+    await validatePairingRefs(clean, req.user.id);
 
     const entry = await JournalEntry.create({
       user: req.user.id,
@@ -196,7 +268,7 @@ router.post('/', async (req, res) => {
 
     logAudit(req, 'journal.create', { type: 'journal', id: entry._id });
 
-    res.status(201).json({ entry: populated });
+    res.status(201).json({ entry: redactPeople(populated, req.user.id) });
   } catch (err) {
     if (err.status === 400) return res.status(400).json({ error: err.message });
     console.error('Create journal entry error:', err);
@@ -213,6 +285,7 @@ router.put('/:id', async (req, res) => {
     if (!entry) return res.status(404).json({ error: 'Entry not found' });
 
     const clean = sanitizeEntry(req.body);
+    await validatePairingRefs(clean, req.user.id);
     Object.assign(entry, clean);
     await entry.save();
 
@@ -222,7 +295,7 @@ router.put('/:id', async (req, res) => {
 
     logAudit(req, 'journal.update', { type: 'journal', id: entry._id });
 
-    res.json({ entry: populated });
+    res.json({ entry: redactPeople(populated, req.user.id) });
   } catch (err) {
     if (err.status === 400) return res.status(400).json({ error: err.message });
     console.error('Update journal entry error:', err);

--- a/backend/src/routes/journal.refs.test.js
+++ b/backend/src/routes/journal.refs.test.js
@@ -1,0 +1,350 @@
+/**
+ * Reference-validation tests for /api/journal (security audit 2026-07-08, L-5).
+ *
+ * WHY THIS TEST EXISTS:
+ * sanitizeEntry used to accept any well-formed ObjectId for
+ * pairings[].bottle / pairings[].wine / people[].user, and the populate on
+ * create/read would then echo back a FOREIGN bottle's vintage + wine
+ * name/producer, and a private user's username/displayName — re-opening the
+ * private-profile enumeration oracle users.js GET /public/:userId closes.
+ *
+ * The fix (mirroring sanitizeEntry's silently-drop style):
+ *  - write time: pairings[].bottle must resolve to a bottle the author owns
+ *    or can access via a cellar role (getCellarRole); pairings[].wine must
+ *    exist. Inaccessible/unknown refs are nulled, not 400s.
+ *  - read time: populated people[].user with profileVisibility 'private'
+ *    (and not the requester) is reduced to its bare _id; the
+ *    profileVisibility field fetched for the gate is stripped everywhere.
+ *
+ * The real journal router is mounted with the real requireAuth middleware
+ * (HS256 test tokens); models are mocked so no MongoDB is needed.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../models/JournalEntry', () => ({
+  find: jest.fn(),
+  countDocuments: jest.fn(),
+  create: jest.fn(),
+  findById: jest.fn(),
+  findOne: jest.fn(),
+  findOneAndDelete: jest.fn(),
+}));
+jest.mock('../models/Bottle', () => ({ find: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/notifications', () => ({ createNotification: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const JournalEntry = require('../models/JournalEntry');
+const Bottle = require('../models/Bottle');
+const WineDefinition = require('../models/WineDefinition');
+const journalRouter = require('./journal');
+
+const AUTHOR_ID = '64b000000000000000000001';
+const OTHER_ID = '64b000000000000000000002';
+const OWN_BOTTLE = '64b0000000000000000000a1';
+const FOREIGN_BOTTLE = '64b0000000000000000000a2';
+const SHARED_BOTTLE = '64b0000000000000000000a3';
+const KNOWN_WINE = '64b0000000000000000000c1';
+const UNKNOWN_WINE = '64b0000000000000000000c2';
+const PRIVATE_USER = '64b0000000000000000000d1';
+const PUBLIC_USER = '64b0000000000000000000d2';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/journal', journalRouter);
+  return app;
+}
+
+function makeReq(app, method, url, { headers = {}, body } = {}) {
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const port = server.address().port;
+      const payload = body ? JSON.stringify(body) : null;
+      const req = http.request(
+        {
+          port,
+          path: url,
+          method,
+          headers: {
+            ...headers,
+            ...(payload ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) } : {}),
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', c => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            const text = Buffer.concat(chunks).toString();
+            resolve({ status: res.statusCode, body: text ? JSON.parse(text) : null });
+          });
+        }
+      );
+      req.on('error', () => { server.close(); resolve({ status: 0 }); });
+      if (payload) req.write(payload);
+      req.end();
+    });
+  });
+}
+
+const authorToken = () =>
+  jwt.sign({ id: AUTHOR_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+
+// --- chainable query-mock helpers -----------------------------------------
+
+// Bottle.find(...).select(...).populate(...).lean()
+const mockBottleFind = (docs) =>
+  Bottle.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      populate: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(docs) }),
+    }),
+  });
+
+// WineDefinition.find(...).select(...).lean()  — journal only uses this shape
+// inside validatePairingRefs; wine-search adds .limit, unused here.
+const mockWineFind = (docs) =>
+  WineDefinition.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(docs) }),
+  });
+
+// JournalEntry.findById(...).populate(...).lean()
+const mockPopulatedEntry = (doc) =>
+  JournalEntry.findById.mockReturnValue({
+    populate: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) }),
+  });
+
+// JournalEntry.find(...).sort().skip().limit().populate().lean()
+const mockEntryList = (items) => {
+  const chain = {
+    sort: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    populate: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(items),
+  };
+  JournalEntry.find.mockReturnValue(chain);
+  JournalEntry.countDocuments.mockResolvedValue(items.length);
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('POST /api/journal pairing bottle ownership (L-5 write gate)', () => {
+  test('a pairing referencing a FOREIGN bottle is silently dropped; own and shared-cellar bottles are kept', async () => {
+    mockBottleFind([
+      // author's own bottle
+      { _id: OWN_BOTTLE, user: AUTHOR_ID, cellar: null },
+      // someone else's bottle in a cellar the author has NO role in
+      { _id: FOREIGN_BOTTLE, user: OTHER_ID, cellar: { user: OTHER_ID, members: [], deletedAt: null } },
+      // someone else's bottle in a cellar shared with the author (viewer)
+      {
+        _id: SHARED_BOTTLE,
+        user: OTHER_ID,
+        cellar: { user: OTHER_ID, members: [{ user: AUTHOR_ID, role: 'viewer' }], deletedAt: null },
+      },
+    ]);
+    mockWineFind([]);
+    JournalEntry.create.mockResolvedValue({ _id: 'e1' });
+    mockPopulatedEntry({ _id: 'e1', visibility: 'private', people: [], pairings: [] });
+
+    const { status } = await makeReq(buildApp(), 'POST', '/api/journal', {
+      headers: { authorization: `Bearer ${authorToken()}` },
+      body: {
+        date: '2026-07-01',
+        pairings: [
+          { dish: 'Steak', bottle: OWN_BOTTLE },
+          { dish: 'Fish', bottle: FOREIGN_BOTTLE },
+          { dish: 'Cheese', bottle: SHARED_BOTTLE },
+        ],
+      },
+    });
+
+    expect(status).toBe(201);
+    const created = JournalEntry.create.mock.calls[0][0];
+    expect(created.pairings[0].bottle).toBe(OWN_BOTTLE);   // own → kept
+    expect(created.pairings[1].bottle).toBeNull();          // foreign → dropped
+    expect(created.pairings[2].bottle).toBe(SHARED_BOTTLE); // shared cellar → kept
+  });
+
+  test('a pairing referencing a bottle id that does not exist is dropped', async () => {
+    mockBottleFind([]); // lookup resolves nothing
+    mockWineFind([]);
+    JournalEntry.create.mockResolvedValue({ _id: 'e1' });
+    mockPopulatedEntry({ _id: 'e1', visibility: 'private', people: [], pairings: [] });
+
+    const { status } = await makeReq(buildApp(), 'POST', '/api/journal', {
+      headers: { authorization: `Bearer ${authorToken()}` },
+      body: { date: '2026-07-01', pairings: [{ dish: 'Steak', bottle: FOREIGN_BOTTLE }] },
+    });
+
+    expect(status).toBe(201);
+    expect(JournalEntry.create.mock.calls[0][0].pairings[0].bottle).toBeNull();
+  });
+
+  test('pairings[].wine keeps existing registry wines and drops unknown ids', async () => {
+    mockBottleFind([]);
+    mockWineFind([{ _id: KNOWN_WINE }]);
+    JournalEntry.create.mockResolvedValue({ _id: 'e1' });
+    mockPopulatedEntry({ _id: 'e1', visibility: 'private', people: [], pairings: [] });
+
+    const { status } = await makeReq(buildApp(), 'POST', '/api/journal', {
+      headers: { authorization: `Bearer ${authorToken()}` },
+      body: {
+        date: '2026-07-01',
+        pairings: [
+          { dish: 'Steak', wine: KNOWN_WINE },
+          { dish: 'Fish', wine: UNKNOWN_WINE },
+        ],
+      },
+    });
+
+    expect(status).toBe(201);
+    const created = JournalEntry.create.mock.calls[0][0];
+    expect(created.pairings[0].wine).toBe(KNOWN_WINE);
+    expect(created.pairings[1].wine).toBeNull();
+  });
+
+  test('entries with no pairings never hit the Bottle/WineDefinition lookups', async () => {
+    JournalEntry.create.mockResolvedValue({ _id: 'e1' });
+    mockPopulatedEntry({ _id: 'e1', visibility: 'private', people: [], pairings: [] });
+
+    const { status } = await makeReq(buildApp(), 'POST', '/api/journal', {
+      headers: { authorization: `Bearer ${authorToken()}` },
+      body: { date: '2026-07-01', title: 'Quiet night' },
+    });
+
+    expect(status).toBe(201);
+    expect(Bottle.find).not.toHaveBeenCalled();
+    expect(WineDefinition.find).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/journal people populate privacy (L-5 read gate)', () => {
+  test('a PRIVATE tagged user is reduced to a bare _id — no username/displayName', async () => {
+    mockEntryList([
+      {
+        _id: 'e1',
+        people: [
+          {
+            name: 'Anna',
+            user: { _id: PRIVATE_USER, username: 'secretanna', displayName: 'Anna S', profileVisibility: 'private' },
+          },
+        ],
+        pairings: [],
+      },
+    ]);
+
+    const { status, body } = await makeReq(buildApp(), 'GET', '/api/journal', {
+      headers: { authorization: `Bearer ${authorToken()}` },
+    });
+
+    expect(status).toBe(200);
+    const person = body.items[0].people[0];
+    expect(person.user).toEqual({ _id: PRIVATE_USER });
+    expect(JSON.stringify(body)).not.toContain('secretanna');
+    expect(JSON.stringify(body)).not.toContain('Anna S');
+  });
+
+  test('a PUBLIC tagged user keeps username/displayName, with the gate field stripped', async () => {
+    mockEntryList([
+      {
+        _id: 'e1',
+        people: [
+          {
+            name: 'Bob',
+            user: { _id: PUBLIC_USER, username: 'bobwine', displayName: 'Bob W', profileVisibility: 'public' },
+          },
+        ],
+        pairings: [],
+      },
+    ]);
+
+    const { body } = await makeReq(buildApp(), 'GET', '/api/journal', {
+      headers: { authorization: `Bearer ${authorToken()}` },
+    });
+
+    const person = body.items[0].people[0];
+    expect(person.user.username).toBe('bobwine');
+    expect(person.user.displayName).toBe('Bob W');
+    expect(person.user.profileVisibility).toBeUndefined();
+  });
+
+  test('the requester always sees THEMSELVES, even with a private profile', async () => {
+    mockEntryList([
+      {
+        _id: 'e1',
+        people: [
+          {
+            name: 'Me',
+            user: { _id: AUTHOR_ID, username: 'author', displayName: 'The Author', profileVisibility: 'private' },
+          },
+        ],
+        pairings: [],
+      },
+    ]);
+
+    const { body } = await makeReq(buildApp(), 'GET', '/api/journal', {
+      headers: { authorization: `Bearer ${authorToken()}` },
+    });
+
+    expect(body.items[0].people[0].user.username).toBe('author');
+  });
+
+  test('unpopulated (deleted) people.user and plain-name people pass through untouched', async () => {
+    mockEntryList([
+      { _id: 'e1', people: [{ name: 'Ghost', user: null }, { name: 'Plain' }], pairings: [] },
+    ]);
+
+    const { status, body } = await makeReq(buildApp(), 'GET', '/api/journal', {
+      headers: { authorization: `Bearer ${authorToken()}` },
+    });
+
+    expect(status).toBe(200);
+    expect(body.items[0].people[0].user).toBeNull();
+    expect(body.items[0].people[1].name).toBe('Plain');
+  });
+});
+
+describe('POST /api/journal response redaction (old rows / create echo)', () => {
+  test('the create response itself withholds a private tagged user (and still notifies by id)', async () => {
+    const User = require('../models/User');
+    const { createNotification } = require('../services/notifications');
+    mockBottleFind([]);
+    mockWineFind([]);
+    JournalEntry.create.mockResolvedValue({ _id: 'e1' });
+    mockPopulatedEntry({
+      _id: 'e1',
+      title: 'Tasting',
+      visibility: 'public',
+      people: [
+        {
+          name: 'Anna',
+          user: { _id: PRIVATE_USER, username: 'secretanna', displayName: 'Anna S', profileVisibility: 'private' },
+        },
+      ],
+      pairings: [],
+    });
+    User.findById.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue({ username: 'author' }) }),
+    });
+
+    const { status, body } = await makeReq(buildApp(), 'POST', '/api/journal', {
+      headers: { authorization: `Bearer ${authorToken()}` },
+      body: { date: '2026-07-01', visibility: 'public', people: [{ name: 'Anna', user: PRIVATE_USER }] },
+    });
+
+    expect(status).toBe(201);
+    expect(body.entry.people[0].user).toEqual({ _id: PRIVATE_USER });
+    expect(JSON.stringify(body)).not.toContain('secretanna');
+    // the mention notification still reaches the tagged user (by id, no name leak)
+    expect(createNotification).toHaveBeenCalledWith(
+      PRIVATE_USER, 'journal_mention', 'Journal Mention', expect.any(String), expect.any(String)
+    );
+  });
+});

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -55,6 +55,13 @@ router.get('/nfc/:id', requireAuth, async (req, res) => {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
     const rack = await Rack.findOne({ _id: req.params.id, deletedAt: null }).select('cellar');
     if (!rack) return res.status(404).json({ error: 'Rack not found' });
+    // Only members of the rack's cellar may resolve the tag — anyone else gets
+    // the same 404 as a nonexistent rack, so this endpoint is not an existence
+    // oracle for rack IDs or a rack→cellar linkage leak (audit L-4 / I-9).
+    const cellar = await Cellar.findById(rack.cellar).select('user members deletedAt');
+    if (!cellar || cellar.deletedAt || !getCellarRole(cellar, req.user.id)) {
+      return res.status(404).json({ error: 'Rack not found' });
+    }
     // Check if rack is placed in the 3D room layout
     const layout = await CellarLayout.findOne({ cellar: rack.cellar }).lean();
     const inRoom = layout?.rackPlacements?.some(

--- a/backend/src/routes/racks.nfc.test.js
+++ b/backend/src/routes/racks.nfc.test.js
@@ -1,0 +1,160 @@
+/**
+ * IDOR tests for GET /api/racks/nfc/:id (security audit 2026-07-08, L-4 —
+ * re-rated from prior I-9).
+ *
+ * WHY THIS TEST EXISTS:
+ * The NFC resolve endpoint used to return { cellarId, rackId, inRoom } for
+ * ANY rack id to ANY authenticated user, leaking rack existence and the
+ * rack→cellar linkage. The fix requires the requester to hold a role in the
+ * rack's cellar (getCellarRole) and answers 404 — identical to a nonexistent
+ * rack — otherwise, so the endpoint is not an existence oracle. This suite
+ * pins that contract: member (owner/editor/viewer) → 200, non-member → the
+ * same 404 body as a missing rack.
+ *
+ * The real racks router is mounted with the real requireAuth middleware
+ * (HS256 test tokens); models are mocked so no MongoDB is needed.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../models/Rack', () => {
+  const model = { findOne: jest.fn() };
+  model.RACK_TYPES = ['grid', 'x-rack', 'hex', 'triangle', 'stack', 'cube', 'shelf'];
+  return model;
+});
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/Bottle', () => ({}));
+jest.mock('../models/CellarLayout', () => ({ findOne: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Rack = require('../models/Rack');
+const Cellar = require('../models/Cellar');
+const CellarLayout = require('../models/CellarLayout');
+const racksRouter = require('./racks');
+
+const OWNER_ID = '64b000000000000000000001';
+const MEMBER_ID = '64b000000000000000000002';
+const STRANGER_ID = '64b000000000000000000003';
+const RACK_ID = '64b0000000000000000000aa';
+const CELLAR_ID = '64b0000000000000000000bb';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/racks', racksRouter);
+  return app;
+}
+
+function makeReq(app, method, url, headers = {}) {
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const port = server.address().port;
+      const req = http.request({ port, path: url, method, headers }, (res) => {
+        const chunks = [];
+        res.on('data', c => chunks.push(c));
+        res.on('end', () => {
+          server.close();
+          const body = Buffer.concat(chunks).toString();
+          resolve({ status: res.statusCode, body: body ? JSON.parse(body) : null });
+        });
+      });
+      req.on('error', () => { server.close(); resolve({ status: 0 }); });
+      req.end();
+    });
+  });
+}
+
+const tokenFor = (id) =>
+  jwt.sign({ id, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+
+const mockRackFound = () =>
+  Rack.findOne.mockReturnValue({ select: jest.fn().mockResolvedValue({ _id: RACK_ID, cellar: CELLAR_ID }) });
+const mockRackMissing = () =>
+  Rack.findOne.mockReturnValue({ select: jest.fn().mockResolvedValue(null) });
+const mockCellar = (doc) =>
+  Cellar.findById.mockReturnValue({ select: jest.fn().mockResolvedValue(doc) });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  CellarLayout.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+});
+
+describe('GET /api/racks/nfc/:id ownership gate (L-4)', () => {
+  test('cellar owner resolves their own rack → 200 with cellarId/rackId', async () => {
+    mockRackFound();
+    mockCellar({ _id: CELLAR_ID, user: OWNER_ID, members: [], deletedAt: null });
+
+    const { status, body } = await makeReq(buildApp(), 'GET', `/api/racks/nfc/${RACK_ID}`, {
+      authorization: `Bearer ${tokenFor(OWNER_ID)}`,
+    });
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ cellarId: CELLAR_ID, rackId: RACK_ID, inRoom: false });
+  });
+
+  test('cellar member (viewer) resolves the rack → 200', async () => {
+    mockRackFound();
+    mockCellar({
+      _id: CELLAR_ID,
+      user: OWNER_ID,
+      members: [{ user: MEMBER_ID, role: 'viewer' }],
+      deletedAt: null,
+    });
+
+    const { status, body } = await makeReq(buildApp(), 'GET', `/api/racks/nfc/${RACK_ID}`, {
+      authorization: `Bearer ${tokenFor(MEMBER_ID)}`,
+    });
+
+    expect(status).toBe(200);
+    expect(body.cellarId).toBe(CELLAR_ID);
+  });
+
+  test('authenticated NON-member gets 404, not the cellar linkage', async () => {
+    mockRackFound();
+    mockCellar({ _id: CELLAR_ID, user: OWNER_ID, members: [], deletedAt: null });
+
+    const { status, body } = await makeReq(buildApp(), 'GET', `/api/racks/nfc/${RACK_ID}`, {
+      authorization: `Bearer ${tokenFor(STRANGER_ID)}`,
+    });
+
+    expect(status).toBe(404);
+    expect(body).toEqual({ error: 'Rack not found' });
+    expect(body.cellarId).toBeUndefined();
+  });
+
+  test('non-member 404 is byte-identical to the nonexistent-rack 404 (no existence oracle)', async () => {
+    mockRackFound();
+    mockCellar({ _id: CELLAR_ID, user: OWNER_ID, members: [], deletedAt: null });
+    const denied = await makeReq(buildApp(), 'GET', `/api/racks/nfc/${RACK_ID}`, {
+      authorization: `Bearer ${tokenFor(STRANGER_ID)}`,
+    });
+
+    mockRackMissing();
+    const missing = await makeReq(buildApp(), 'GET', `/api/racks/nfc/${RACK_ID}`, {
+      authorization: `Bearer ${tokenFor(STRANGER_ID)}`,
+    });
+
+    expect(denied.status).toBe(missing.status);
+    expect(denied.body).toEqual(missing.body);
+  });
+
+  test('rack in a soft-deleted cellar → 404 even for the owner', async () => {
+    mockRackFound();
+    mockCellar({ _id: CELLAR_ID, user: OWNER_ID, members: [], deletedAt: new Date() });
+
+    const { status } = await makeReq(buildApp(), 'GET', `/api/racks/nfc/${RACK_ID}`, {
+      authorization: `Bearer ${tokenFor(OWNER_ID)}`,
+    });
+
+    expect(status).toBe(404);
+  });
+
+  test('unauthenticated request → 401 (route keeps requireAuth)', async () => {
+    const { status } = await makeReq(buildApp(), 'GET', `/api/racks/nfc/${RACK_ID}`);
+    expect(status).toBe(401);
+  });
+});


### PR DESCRIPTION
Fixes three object-level-authorization findings from **SECURITY_AUDIT_2026-07-08.md** (all Low).

## L-4 — `GET /api/racks/nfc/:id` resolved any rack ID with no ownership check
`backend/src/routes/racks.js`

After loading the rack, the route now resolves its cellar and requires `getCellarRole(cellar, req.user.id)` before answering. Requesters with no role in the cellar (and racks in soft-deleted cellars) get a **404 byte-identical to the nonexistent-rack 404**, so the endpoint is no longer an existence oracle or a rack→cellar linkage leak.

**Behavior change:** NFC scans by authenticated non-members now return 404 — previously they resolved `{cellarId, rackId, inRoom}`. The legitimate flow is unaffected: `frontend/src/pages/NfcRedirect.js` navigates to the rack's cellar page, which already requires membership, so anyone the redirect actually worked for is a cellar member and still gets a 200. Non-members now land on the existing "rack not found" error state instead of a doomed redirect.

## L-5 — Journal pairing/people references stored & populated without ownership validation
`backend/src/routes/journal.js`

- **Write-time** (`validatePairingRefs`, run on create and update): `pairings[].bottle` must resolve to a bottle the author owns or can access via a cellar role (`getCellarRole`, same check the bottles routes use); `pairings[].wine` (public registry ref) must exist. Invalid refs are **silently nulled**, matching `sanitizeEntry`'s existing silently-drop style for malformed ObjectIds — no new 400s.
- **Read-time** (`redactPeople`, applied to every response that populates `people.user` — list, create echo, update echo): a tagged user whose `profileVisibility` is `private` (and who isn't the requester) is reduced to a bare `{_id}`; their `username`/`displayName` are withheld. This closes the private-profile enumeration oracle that `users.js GET /public/:userId` was written to prevent, and covers rows written before this fix. The `profileVisibility` field fetched for the gate is stripped from all responses.
- Journal cards render the free-text `p.name` and link via `p.user._id`, both of which survive redaction — no frontend change needed. Mention notifications still fire (by id, no name leak).

## L-7 — `assign-to-wine` could publish an approved-but-private image as the public wine image
`backend/src/routes/admin/images.js`

`PUT /api/admin/images/:id/assign-to-wine` now sets `image.visibility = 'public'` and saves **before** writing `WineDefinition.image`, mirroring the sibling `set-official` route — an admin publishing an image to the public wine page is implicitly making it public. The `status: 'approved'` gate is unchanged.

## Tests
Three new Jest suites (19 tests) pin the contracts — non-member NFC resolve → 404 identical to missing-rack 404, member/viewer → 200; foreign-bottle pairing dropped while own + shared-cellar bottles kept; unknown wine ref dropped; private tagged user redacted to `{_id}` (self and public users unaffected); assign-to-wine flips visibility, keeps the approved gate, stays admin-only.

Full backend suite: **45 suites, 810 tests, all passing.**

## Ops
- **docker-compose impact: none.** No new env vars, services, ports, or dependencies — backend-only code change, picked up by the normal image rebuild.
- No migration needed: the journal read-time gate covers pre-existing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)