### PR TITLE
fix: close first-checkout race in Stripe customer creation (audit L-6)

### DIFF
--- a/backend/src/routes/stripe.checkout.test.js
+++ b/backend/src/routes/stripe.checkout.test.js
@@ -1,0 +1,251 @@
+/**
+ * Race tests for POST /api/stripe/checkout — audit 2026-07-08 finding L-6.
+ *
+ * WHY THIS TEST EXISTS:
+ * On a user's FIRST checkout, stripeCustomerId is null. Two concurrent
+ * requests (double-click / two tabs) both used to pass the guard, both
+ * customers.create() a separate Stripe customer, and an unconditional
+ * findByIdAndUpdate let the last write win — a subscription completed on the
+ * overwritten customer became invisible to /portal and immune to the
+ * subscription.deleted reconcile (un-cancellable double billing).
+ *
+ * The fix under test:
+ *   1. atomic conditional claim ({_id, stripeCustomerId: null}) so exactly
+ *      one request persists its customer; the loser converges on the winner's
+ *      customer and best-effort deletes its subscription-less duplicate;
+ *   2. the subscriptions.list "hasLive" guard runs before EVERY
+ *      sessions.create, not only the existing-customer branch;
+ *   3. a user+price+10s-bucket idempotency key on sessions.create so a burst
+ *      replays one session instead of minting two.
+ *
+ * Stripe SDK, User model, auth and audit are all mocked; the real router is
+ * mounted and driven over HTTP so the full handler (including the concurrent
+ * interleaving) is exercised.
+ */
+
+process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
+process.env.STRIPE_SUPPORTER_PRICE_ID = 'price_supporter';
+process.env.STRIPE_PATRON_PRICE_ID = 'price_patron';
+
+// Every request authenticates as the same user — the race is intra-user.
+jest.mock('../middleware/auth', () => ({
+  requireAuth: (req, res, next) => { req.user = { id: 'u1' }; next(); },
+}));
+
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+
+jest.mock('../models/User', () => ({
+  findById: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+}));
+
+// require('stripe')(key) → singleton mock client (getStripe caches it).
+const mockStripe = {
+  customers: { create: jest.fn(), del: jest.fn() },
+  subscriptions: { list: jest.fn() },
+  checkout: { sessions: { create: jest.fn() } },
+  billingPortal: { sessions: { create: jest.fn() } },
+  webhooks: { constructEvent: jest.fn() },
+};
+jest.mock('stripe', () => jest.fn(() => mockStripe));
+
+const express = require('express');
+const http = require('http');
+const User = require('../models/User');
+const stripeRouter = require('./stripe');
+
+// ── In-memory "User collection" (single doc) with atomic-claim semantics ──
+let dbUser;
+const resetDb = (overrides = {}) => {
+  dbUser = {
+    _id: 'u1',
+    email: 'u1@example.com',
+    stripeCustomerId: null,
+    stripeSubscriptionId: null,
+    ...overrides,
+  };
+};
+
+// ── One HTTP server for the suite ──
+let server;
+let port;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stripe', stripeRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { port = server.address().port; done(); });
+});
+
+afterAll((done) => {
+  server.closeAllConnections?.();
+  server.close(() => done()); // swallow close's arg — jest's done() fails on any truthy value
+});
+
+const checkout = (plan = 'supporter') => new Promise((resolve, reject) => {
+  const body = JSON.stringify({ plan });
+  const req = http.request({
+    port,
+    path: '/api/stripe/checkout',
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) },
+  }, (res) => {
+    const chunks = [];
+    res.on('data', (c) => chunks.push(c));
+    res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) }));
+  });
+  req.on('error', reject);
+  req.end(body);
+});
+
+// Freeze Date.now so the 10-second idempotency bucket cannot straddle a
+// boundary mid-test. (Node's timers use the libuv clock, not Date.now.)
+const NOW = 1751000000000;
+const BUCKET = Math.floor(NOW / 10_000);
+let dateNowSpy;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetDb();
+  dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(NOW);
+
+  User.findById.mockImplementation(() => ({
+    select: jest.fn().mockImplementation(async () => (dbUser ? { ...dbUser } : null)),
+  }));
+  // The atomic conditional claim: flips null → id for exactly one caller.
+  User.findOneAndUpdate.mockImplementation(async (filter, update) => {
+    if (!dbUser || filter._id !== dbUser._id) return null;
+    if (filter.stripeCustomerId === null && dbUser.stripeCustomerId == null) {
+      dbUser.stripeCustomerId = update.stripeCustomerId;
+      return { ...dbUser };
+    }
+    return null;
+  });
+
+  mockStripe.subscriptions.list.mockResolvedValue({ data: [] });
+  mockStripe.customers.del.mockResolvedValue({ deleted: true });
+  mockStripe.checkout.sessions.create.mockResolvedValue({ id: 'cs_1', url: 'https://checkout.stripe.test/cs_1' });
+});
+
+afterEach(() => dateNowSpy.mockRestore());
+
+describe('POST /api/stripe/checkout — first-checkout customer race (L-6)', () => {
+  test('two concurrent first checkouts converge on ONE persisted customer; the duplicate is deleted', async () => {
+    // Barrier inside customers.create: neither call resolves until BOTH
+    // requests have read stripeCustomerId === null and asked Stripe for a
+    // customer — the exact interleaving of the audit finding.
+    let created = 0;
+    const release = [];
+    mockStripe.customers.create.mockImplementation(() => {
+      created += 1;
+      const id = `cus_${created}`;
+      return new Promise((resolve) => {
+        release.push(() => resolve({ id }));
+        if (release.length === 2) release.forEach((r) => r());
+      });
+    });
+
+    const [r1, r2] = await Promise.all([checkout(), checkout()]);
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(mockStripe.customers.create).toHaveBeenCalledTimes(2);
+
+    // Exactly one customer id was claimed on the user…
+    const persisted = dbUser.stripeCustomerId;
+    expect(['cus_1', 'cus_2']).toContain(persisted);
+
+    // …and BOTH checkout sessions were created against that one customer
+    // (the loser converged instead of using its own fresh customer).
+    const sessionCustomers = mockStripe.checkout.sessions.create.mock.calls.map(([params]) => params.customer);
+    expect(sessionCustomers).toEqual([persisted, persisted]);
+
+    // The losing request deleted its now-orphaned duplicate — and ONLY that one.
+    const duplicate = persisted === 'cus_1' ? 'cus_2' : 'cus_1';
+    expect(mockStripe.customers.del).toHaveBeenCalledTimes(1);
+    expect(mockStripe.customers.del).toHaveBeenCalledWith(duplicate);
+
+    // The hasLive guard ran before EVERY sessions.create, on the converged id.
+    expect(mockStripe.subscriptions.list).toHaveBeenCalledTimes(2);
+    for (const [args] of mockStripe.subscriptions.list.mock.calls) {
+      expect(args.customer).toBe(persisted);
+    }
+
+    // Both requests carried the SAME idempotency key (user+price+10s bucket),
+    // so Stripe would replay one session rather than mint two.
+    const keys = mockStripe.checkout.sessions.create.mock.calls.map(([, opts]) => opts.idempotencyKey);
+    expect(keys[0]).toBe(`checkout:u1:price_supporter:${BUCKET}`);
+    expect(keys[1]).toBe(keys[0]);
+  });
+
+  test('single first checkout creates, atomically claims and uses one customer', async () => {
+    mockStripe.customers.create.mockResolvedValue({ id: 'cus_1' });
+
+    const r = await checkout();
+
+    expect(r.status).toBe(200);
+    expect(r.body.url).toBe('https://checkout.stripe.test/cs_1');
+    expect(dbUser.stripeCustomerId).toBe('cus_1');
+    expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'u1', stripeCustomerId: null },
+      { stripeCustomerId: 'cus_1' },
+      { new: true }
+    );
+    expect(mockStripe.customers.del).not.toHaveBeenCalled();
+    const [params, opts] = mockStripe.checkout.sessions.create.mock.calls[0];
+    expect(params.customer).toBe('cus_1');
+    expect(opts).toEqual({ idempotencyKey: `checkout:u1:price_supporter:${BUCKET}` });
+  });
+
+  test('hasLive guard now also refuses a live subscription on the just-created-customer path', async () => {
+    mockStripe.customers.create.mockResolvedValue({ id: 'cus_1' });
+    mockStripe.subscriptions.list.mockResolvedValue({ data: [{ status: 'trialing' }] });
+
+    const r = await checkout();
+
+    expect(r.status).toBe(409);
+    expect(r.body.code).toBe('subscription_exists');
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  test('existing customer with a live subscription is still refused (guard not regressed)', async () => {
+    resetDb({ stripeCustomerId: 'cus_9' });
+    mockStripe.subscriptions.list.mockResolvedValue({ data: [{ status: 'canceled' }, { status: 'active' }] });
+
+    const r = await checkout();
+
+    expect(r.status).toBe(409);
+    expect(r.body.code).toBe('subscription_exists');
+    expect(mockStripe.customers.create).not.toHaveBeenCalled();
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  test('a persisted stripeSubscriptionId short-circuits with 409 before touching Stripe', async () => {
+    resetDb({ stripeCustomerId: 'cus_9', stripeSubscriptionId: 'sub_1' });
+
+    const r = await checkout();
+
+    expect(r.status).toBe(409);
+    expect(mockStripe.customers.create).not.toHaveBeenCalled();
+    expect(mockStripe.subscriptions.list).not.toHaveBeenCalled();
+  });
+
+  test('a failed duplicate-customer deletion is best-effort and does not block the checkout', async () => {
+    mockStripe.customers.create.mockResolvedValue({ id: 'cus_dup' });
+    // Simulate losing the race: by the time this request tries to claim,
+    // another request has already persisted cus_winner.
+    User.findOneAndUpdate.mockImplementation(async () => {
+      dbUser.stripeCustomerId = 'cus_winner';
+      return null;
+    });
+    mockStripe.customers.del.mockRejectedValue(new Error('resource_missing'));
+
+    const r = await checkout();
+
+    expect(r.status).toBe(200);
+    expect(mockStripe.customers.del).toHaveBeenCalledWith('cus_dup');
+    expect(mockStripe.checkout.sessions.create.mock.calls[0][0].customer).toBe('cus_winner');
+  });
+});

--- a/backend/src/routes/stripe.js
+++ b/backend/src/routes/stripe.js
@@ -102,35 +102,78 @@ router.post('/checkout', requireAuth, async (req, res) => {
     const s = getStripe();
     const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
 
-    // Reuse existing Stripe customer or create one
+    // Reuse existing Stripe customer or create one. Persisting the fresh
+    // customer uses an atomic conditional claim so two concurrent first
+    // checkouts (double-click / two tabs, both reading stripeCustomerId: null)
+    // converge on ONE Stripe customer instead of the last write orphaning the
+    // first — a subscription completed on an overwritten customer would be
+    // invisible to /portal (scoped to the persisted id) and immune to the
+    // customer.subscription.deleted reconcile, so the user could never cancel
+    // it (audit 2026-07-08, L-6).
     let customerId = user.stripeCustomerId;
     if (!customerId) {
       const customer = await s.customers.create({
         email: user.email,
         metadata: { userId: user._id.toString() }
       });
-      customerId = customer.id;
-      await User.findByIdAndUpdate(req.user.id, { stripeCustomerId: customerId });
-    } else {
-      // Defense-in-depth for the double-click / two-tab race, where the
-      // checkout.session.completed webhook has not yet populated
-      // stripeSubscriptionId: ask Stripe directly whether this customer already
-      // has a live subscription. Best-effort — a transient API error must never
-      // block a legitimate first checkout.
-      try {
-        const existing = await s.subscriptions.list({ customer: customerId, status: 'all', limit: 10 });
-        const hasLive = existing.data.some((sub) =>
-          ['active', 'trialing', 'past_due', 'unpaid'].includes(sub.status));
-        if (hasLive) {
-          return res.status(409).json({
-            error: 'You already have an active subscription. Use the billing portal to change your plan.',
-            code: 'subscription_exists'
-          });
+      // Atomic claim: only one concurrent request can flip null → id.
+      const claimed = await User.findOneAndUpdate(
+        { _id: req.user.id, stripeCustomerId: null },
+        { stripeCustomerId: customer.id },
+        { new: true }
+      );
+      if (claimed) {
+        customerId = customer.id;
+      } else {
+        // Lost the race: converge on the customer the winning request
+        // persisted and discard our duplicate. Deletion is safe — the
+        // duplicate is milliseconds old and cannot have a subscription yet —
+        // and best-effort: a leftover subscription-less customer is harmless.
+        const winner = await User.findById(req.user.id).select('stripeCustomerId');
+        if (winner?.stripeCustomerId) {
+          customerId = winner.stripeCustomerId;
+          try {
+            await s.customers.del(customer.id);
+          } catch (e) {
+            console.warn(`[stripe] could not delete duplicate customer ${customer.id} (harmless, no subscription):`, e.message);
+          }
+        } else {
+          // Claim failed yet no persisted id to converge on (user deleted
+          // mid-request or field cleared) — keep the fresh customer so this
+          // checkout still works; there is no duplicate to clean up.
+          customerId = customer.id;
         }
-      } catch (e) {
-        console.warn('[stripe] could not verify existing subscriptions (proceeding):', e.message);
       }
     }
+
+    // Defense-in-depth for the double-click / two-tab race, where the
+    // checkout.session.completed webhook has not yet populated
+    // stripeSubscriptionId: ask Stripe directly whether this customer already
+    // has a live subscription. Runs before EVERY session creation — including
+    // for a just-created/just-claimed customer, so a request that lost the
+    // claim race is re-checked against the customer it converged on.
+    // Best-effort — a transient API error must never block a legitimate
+    // checkout.
+    try {
+      const existing = await s.subscriptions.list({ customer: customerId, status: 'all', limit: 10 });
+      const hasLive = existing.data.some((sub) =>
+        ['active', 'trialing', 'past_due', 'unpaid'].includes(sub.status));
+      if (hasLive) {
+        return res.status(409).json({
+          error: 'You already have an active subscription. Use the billing portal to change your plan.',
+          code: 'subscription_exists'
+        });
+      }
+    } catch (e) {
+      console.warn('[stripe] could not verify existing subscriptions (proceeding):', e.message);
+    }
+
+    // Stripe idempotency key: a double-click / two-tab burst (same user, same
+    // price, same 10-second bucket) replays the FIRST checkout session instead
+    // of creating a second one, while a genuine retry minutes later gets a
+    // fresh key. Safe because concurrent requests converge on one customerId
+    // above, so the replayed request's params match the original's.
+    const idempotencyKey = `checkout:${user._id}:${priceId}:${Math.floor(Date.now() / 10_000)}`;
 
     const session = await s.checkout.sessions.create({
       customer: customerId,
@@ -141,7 +184,7 @@ router.post('/checkout', requireAuth, async (req, res) => {
       subscription_data: {
         metadata: { userId: user._id.toString(), plan }
       }
-    });
+    }, { idempotencyKey });
 
     logAudit(req, 'stripe.checkout_created', {}, { plan });
     res.json({ url: session.url });


### PR DESCRIPTION
Fixes finding **L-6** from `SECURITY_AUDIT_2026-07-08.md` (Payments / entitlements): the double-subscription guard has a race gap on a user's **first** checkout.

## The race, before

1. User double-clicks "Subscribe" (or has two tabs open) → two concurrent `POST /api/stripe/checkout`.
2. Both requests load the user and see `stripeCustomerId: null` and `stripeSubscriptionId: null`, so both pass the line-95 guard — and the `subscriptions.list` "hasLive" defense ran **only in the existing-customer `else` branch**, so neither request hit it.
3. Both call `stripe.customers.create()` → customers `cus_A` and `cus_B`.
4. Both run an **unconditional** `findByIdAndUpdate` → last write wins; say `cus_B` is persisted.
5. Both Checkout Sessions are created (one on `cus_A`, one on `cus_B`). If the user completes both hosted checkouts, the `cus_A` subscription now lives on a customer id **not stored anywhere**:
   - invisible to `POST /api/stripe/portal` (scoped to the persisted `stripeCustomerId`), and
   - immune to `customer.subscription.deleted` reconciliation (dropped by the `user.stripeSubscriptionId !== sub.id` check at `stripe.js:277`),

   so the user is double-billed on a subscription they can never see or cancel.

## The fix, after (three parts, checkout handler only)

1. **Atomic customer claim** — the fresh customer is persisted with `findOneAndUpdate({ _id, stripeCustomerId: null }, { stripeCustomerId }, { new: true })`. Exactly one concurrent request can flip `null → id`. The loser re-loads the user, **converges on the winner's customer id** for its session, and best-effort deletes its own duplicate (`stripe.customers.del` in try/catch — the duplicate is milliseconds old and cannot have a subscription, so deletion is safe; a failed delete leaves only a harmless subscription-less customer).
2. **`hasLive` before every `sessions.create`** — the `subscriptions.list` guard now runs unconditionally after the customer id is resolved (existing, just-created, or just-converged), instead of only for existing customers.
3. **Idempotency key** — `checkout.sessions.create` is called with `{ idempotencyKey: 'checkout:<userId>:<priceId>:<10s-bucket>' }`. A double-click burst replays the *first* session (params match because both requests converged on one customer id); a genuine retry minutes later lands in a new bucket and gets a fresh session.

Same race, replayed: both requests still `customers.create`, but only one claim wins; the loser deletes its duplicate and both `sessions.create` calls target the **one persisted customer** with the **same idempotency key** → Stripe returns one session, one possible subscription, fully portal-visible.

## Remaining edge cases (noted, not changed)

- If the two clicks straddle a 10-second bucket boundary, two distinct sessions can exist — but both on the **same persisted customer**, so if both are completed the user sees both subscriptions in the billing portal and can self-cancel; the "orphaned, un-cancellable" outcome is gone. The `stripe.js:277` `stripeSubscriptionId !== sub.id` drop-check then behaves correctly: cancelling the non-current sub is ignored (plan stays, backed by the remaining paid sub), cancelling the current one downgrades.
- If the DB claim write itself throws after `customers.create`, the fresh customer leaks in Stripe as a subscription-less customer (pre-existing failure class, harmless clutter, no billing).
- Audit item I-1 (`applyStripePlan` non-atomic, benign) is unchanged and intentionally out of scope.

## No webhook changes, no infra changes

- Webhook handlers are untouched.
- **Zero docker-compose impact**: no new env vars, dependencies, services, or ports; nothing to change in `docker-compose.prod.yml` or prod `.env`.

## Tests

New `backend/src/routes/stripe.checkout.test.js` mounts the real router over HTTP with a mocked Stripe SDK and a barrier inside `customers.create` that forces the exact audit interleaving: asserts one customer persisted, both sessions created on it, the duplicate deleted exactly once, `hasLive` run before every session, and identical idempotency keys. Plus non-race coverage (single first checkout, hasLive on the new-customer path, existing-customer 409, persisted-sub 409, failed duplicate deletion is non-blocking).

`cd backend && npm test` → **43 suites, 797 tests, all passing** (791 pre-existing + 6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
