### PR TITLE
fix: outbound AI timeouts + image sanitizer on scan-label and ZIP import

### DIFF
--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -5,6 +5,7 @@ const Discussion = require('../models/Discussion');
 const searchService = require('../services/search');
 const { requireAuth, optionalAuth } = require('../middleware/auth');
 const { scanLabelFull, identifyWineFromQuery } = require('../services/labelScan');
+const { sanitizeImageBuffer, detectImageFormat } = require('../services/imageSanitizer');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
 const { generateWineKey } = require('../utils/normalize');
 const { findBestMatch } = require('../services/wineMatching');
@@ -152,28 +153,44 @@ router.get('/', requireAuth, async (req, res) => {
 // plus any existing registry match (for user confirmation before committing).
 //
 // Body:  { image: base64String, mediaType?: "image/jpeg" | "image/png" | "image/webp" }
+//        (mediaType is accepted for compatibility but ignored — the actual type
+//         is detected from the sanitized bytes, since the declared one can lie)
 // Returns: {
 //   extracted: { name, producer, vintage, country, region, appellation, type, grapes[] },
 //   match: { wine: WineDefinition, confidence: number } | null,
 //   labelImage: "data:image/png;base64,..." (background-removed label, or original as fallback)
 // }
 router.post('/scan-label', requireAuth, aiBurstLimiter, async (req, res) => {
-  const { image, mediaType = 'image/jpeg' } = req.body;
+  const { image } = req.body;
 
   if (!image) {
     return res.status(400).json({ error: 'Image is required' });
   }
 
+  // 0. Fail-closed pixel/format guard + EXIF strip BEFORE anything touches the
+  // bytes. Without it a small compressed payload can decode to a 100M+ pixel
+  // "decompression bomb" on the single-worker rembg service (DoS). Mirrors the
+  // hardened /api/images/remove-bg-preview path. The sanitizer preserves the
+  // DECODED format, so the media type is re-detected from the sanitized bytes
+  // rather than trusting the client-declared mediaType.
+  let safeBuffer;
   try {
-    // 1. Attempt background removal via rembg (non-fatal — falls back to original)
-    let scanImage = image;
-    let scanMediaType = mediaType;
-    let labelImage = `data:${mediaType};base64,${image}`;
+    safeBuffer = await sanitizeImageBuffer(Buffer.from(image, 'base64'));
+  } catch {
+    return res.status(400).json({ error: 'Image is too large or not a valid JPEG, PNG, or WebP' });
+  }
+  const safeMediaType = `image/${detectImageFormat(safeBuffer) || 'jpeg'}`;
+
+  try {
+    // 1. Attempt background removal via rembg (non-fatal — falls back to the
+    //    sanitized original)
+    let scanImage = safeBuffer.toString('base64');
+    let scanMediaType = safeMediaType;
+    let labelImage = `data:${scanMediaType};base64,${scanImage}`;
 
     try {
-      const buf = Buffer.from(image, 'base64');
       const fd = new FormData();
-      fd.append('image', new Blob([buf], { type: mediaType }), 'label.jpg');
+      fd.append('image', new Blob([safeBuffer], { type: safeMediaType }), 'label.jpg');
       const rembgRes = await fetch(`${REMBG_URL}/remove-bg`, {
         method: 'POST',
         body: fd,

--- a/backend/src/routes/wines.scanLabel.test.js
+++ b/backend/src/routes/wines.scanLabel.test.js
@@ -1,0 +1,144 @@
+/**
+ * POST /api/wines/scan-label — fail-closed image sanitization (SECURITY_AUDIT L-9).
+ *
+ * The route must run the decoded base64 buffer through sanitizeImageBuffer()
+ * BEFORE anything (rembg, Claude) touches the bytes: a small compressed payload
+ * can otherwise decode into a 100M+ pixel "decompression bomb" on the
+ * single-worker rembg service. Invalid/oversized input → 400; valid input is
+ * re-encoded (EXIF stripped) and its media type re-detected from the actual
+ * bytes, not the client-declared mediaType.
+ */
+process.env.JWT_SECRET = 'test-secret';
+
+// services/search eagerly requires the ESM-only `meilisearch` package, which
+// Jest can't transform — stub it (matches the repo's unit-test style).
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+}));
+// The Anthropic-backed extractor: never reached in the 400 test; returns a
+// no-match extraction in the happy-path test.
+jest.mock('../services/labelScan', () => ({
+  scanLabelFull: jest.fn(),
+  identifyWineFromQuery: jest.fn(),
+}));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+// Rate limiting is exercised elsewhere; keep this suite about sanitization.
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+
+const http = require('http');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const sharp = require('sharp');
+const winesRouter = require('./wines');
+const { scanLabelFull } = require('../services/labelScan');
+
+sharp.cache(false);
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ limit: '10mb' }));
+  app.use('/api/wines', winesRouter);
+  return app;
+}
+
+function postJson(app, url, body, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            ...headers,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (err) => { server.close(); reject(err); });
+      req.end(payload);
+    });
+  });
+}
+
+function authHeader() {
+  const token = jwt.sign({ id: 'u1', roles: ['user'] }, 'test-secret', {
+    algorithm: 'HS256',
+    expiresIn: '1h',
+  });
+  return { Authorization: `Bearer ${token}` };
+}
+
+describe('POST /api/wines/scan-label sanitization', () => {
+  const realFetch = global.fetch;
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    // rembg unreachable in tests — the route must fall back to the sanitized
+    // original instead of failing.
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    jest.clearAllMocks();
+  });
+
+  test('rejects a non-image payload with 400 before touching rembg or Claude', async () => {
+    const res = await postJson(
+      app,
+      '/api/wines/scan-label',
+      { image: Buffer.from('definitely not an image').toString('base64'), mediaType: 'image/jpeg' },
+      authHeader()
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not a valid JPEG, PNG, or WebP/);
+    expect(global.fetch).not.toHaveBeenCalled();      // never forwarded to rembg
+    expect(scanLabelFull).not.toHaveBeenCalled();     // never forwarded to Claude
+  });
+
+  test('still requires an image', async () => {
+    const res = await postJson(app, '/api/wines/scan-label', {}, authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Image is required');
+  });
+
+  test('valid image passes through sanitized, with the type detected from the bytes', async () => {
+    // A real PNG declared as image/jpeg — the declared type must be ignored.
+    const png = await sharp({
+      create: { width: 6, height: 4, channels: 3, background: { r: 120, g: 0, b: 40 } },
+    }).png().toBuffer();
+    scanLabelFull.mockResolvedValue({ name: null, producer: null });
+
+    const res = await postJson(
+      app,
+      '/api/wines/scan-label',
+      { image: png.toString('base64'), mediaType: 'image/jpeg' },
+      authHeader()
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.match).toBeNull();
+    expect(res.body.labelImage).toMatch(/^data:image\/png;base64,/);
+    // Claude received the sanitized buffer with the DETECTED media type.
+    expect(scanLabelFull).toHaveBeenCalledWith(expect.any(String), 'image/png');
+    const sentBuffer = Buffer.from(scanLabelFull.mock.calls[0][0], 'base64');
+    const meta = await sharp(sentBuffer).metadata();
+    expect(meta.format).toBe('png');
+    expect(meta.width).toBe(6);
+  });
+});

--- a/backend/src/services/cellarImport.js
+++ b/backend/src/services/cellarImport.js
@@ -41,6 +41,7 @@ const WineVintageProfile = require('../models/WineVintageProfile');
 const searchService = require('./search');
 const { findOrCreateWine } = require('./findOrCreateWine');
 const { unlinkImageFiles, safeUploadPath } = require('./imageProcessor');
+const { sanitizeImageBuffer, detectImageFormat } = require('./imageSanitizer');
 const { ORIGINALS_DIR, PROCESSED_DIR } = require('../config/upload');
 const { planRackCreations, placeBottlesInRack, DEFAULT_ANCHOR } = require('../utils/rackImport');
 const { getMaxPosition } = require('../utils/rackGeometry');
@@ -408,7 +409,7 @@ function buildBottle({ cellarId, ownerId, item, canonicalVintage, wineDefinition
  *  the processed file when it exists and keep an original ONLY when there is no
  *  processed version — we never re-introduce a pre-crop original alongside a
  *  cropped one. Older exports that still carry both are normalised the same way. */
-async function attachImages(bottle, images, userId, getFileBuffer, result, dedupCache) {
+async function attachImages(bottle, images, userId, getFileBuffer, result, dedupCache, sourceIndex) {
   if (!Array.isArray(images) || images.length === 0) return;
   let firstImageId = null;
   let count = 0;
@@ -425,6 +426,9 @@ async function attachImages(bottle, images, userId, getFileBuffer, result, dedup
     const primaryBuf = procBuf || origBuf;
     if (!primaryBuf) continue;
 
+    // Hash the bytes AS EXPORTED (pre-sanitization): dedup must keep matching
+    // both existing BottleImage.contentHash values and repeat imports of the
+    // same archive, and sanitization re-encodes (bytes change on every run).
     const hash = crypto.createHash('sha256').update(primaryBuf).digest('hex');
 
     // Same photo already attached to this wine earlier in THIS import (e.g.
@@ -453,16 +457,33 @@ async function attachImages(bottle, images, userId, getFileBuffer, result, dedup
       originalUrl = fileOnDisk(existing.originalUrl) ? existing.originalUrl : null;
       deduped = true;
     } else {
+      // ZIP bytes are attacker-controlled: run them through the same fail-closed
+      // sanitizer as the live upload path (magic-byte/format check, decoded-pixel
+      // cap, EXIF/GPS strip) before anything reaches disk. An image that fails to
+      // decode is skipped and recorded — the import itself continues. The
+      // sanitizer preserves the decoded format, so the file extension is derived
+      // from the sanitized bytes (the archive filename / export field can lie).
+      let safeBuf;
+      try {
+        safeBuf = await sanitizeImageBuffer(primaryBuf);
+      } catch {
+        result.imagesSkipped++;
+        result.errors.push({
+          index: sourceIndex,
+          reason: `Image "${procArchive || origArchive}" skipped: not a valid JPEG, PNG, or WebP, or too large`,
+        });
+        continue;
+      }
       const uuid = crypto.randomUUID();
+      const ext = { jpeg: '.jpg', png: '.png', webp: '.webp' }[detectImageFormat(safeBuf)] || '.jpg';
       if (procBuf) {
-        const procName = `${uuid}.png`;
-        fs.writeFileSync(path.join(PROCESSED_DIR, procName), procBuf);
+        const procName = `${uuid}${ext}`;
+        fs.writeFileSync(path.join(PROCESSED_DIR, procName), safeBuf);
         processedUrl = `/api/uploads/processed/${procName}`;
       } else {
         // Original-only image (never cropped) — keep it so the photo isn't lost.
-        const ext = (path.extname(origArchive) || '.jpg').toLowerCase();
         const origName = `${uuid}${ext}`;
-        fs.writeFileSync(path.join(ORIGINALS_DIR, origName), origBuf);
+        fs.writeFileSync(path.join(ORIGINALS_DIR, origName), safeBuf);
         originalUrl = `/api/uploads/originals/${origName}`;
       }
     }
@@ -673,7 +694,7 @@ async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, i
       result.bottlesCreated++;
       if (bottle.status === 'active') createdActiveIds.push(bottle._id);
 
-      await attachImages(bottle, imagesByIndex[i], userId, getFileBuffer, result, wineImageDedup);
+      await attachImages(bottle, imagesByIndex[i], userId, getFileBuffer, result, wineImageDedup, i);
       await attachReviews(bottle, item.reviews, userId, wine.wineDefinitionId, result);
       await attachMaturity(item.maturity, wine.wineDefinitionId, canonicalVintage, result, seenMaturity);
 
@@ -753,6 +774,7 @@ async function importCellar(userId, cellar, opts) {
     racksCreated: 0,
     imagesAttached: 0,
     imagesDeduped: 0,
+    imagesSkipped: 0,
     winesCreated: 0,
     wineRequests: 0,
     reviewsCreated: 0,
@@ -830,6 +852,7 @@ module.exports = {
   resolveTargets,
   exportBottleToItem,
   attachMaturity,
+  attachImages,
   importCellar,
   clearCellarContents,
   EXPORT_SCHEMA,

--- a/backend/src/services/cellarImport.test.js
+++ b/backend/src/services/cellarImport.test.js
@@ -18,17 +18,32 @@ jest.mock('../models/WineVintageProfile', () => ({
   create: jest.fn(),
 }));
 
+// attachImages: mock the model so the sanitize/skip/write logic can be
+// asserted without a live MongoDB; disk writes are spied on instead of
+// hitting /app/uploads (which doesn't exist outside the container).
+jest.mock('../models/BottleImage', () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+}));
+
+const fs = require('fs');
+const sharp = require('sharp');
+
 const {
   parseCellarExport,
   archivePathToUrl,
   resolveTargets,
   exportBottleToItem,
   attachMaturity,
+  attachImages,
   EXPORT_SCHEMA,
   MAX_IMPORT_CELLARS,
   MAX_IMPORT_BOTTLES,
 } = require('./cellarImport');
 const WineVintageProfile = require('../models/WineVintageProfile');
+const BottleImage = require('../models/BottleImage');
+
+sharp.cache(false);
 
 describe('parseCellarExport', () => {
   test('accepts the cellar-nested cellarion-export@1 format', () => {
@@ -261,5 +276,120 @@ describe('attachMaturity', () => {
     await attachMaturity({ peakFrom: 2026 }, 'w1', '2018', result, seen); // same key → no-op
     expect(WineVintageProfile.create).toHaveBeenCalledTimes(1);
     expect(result.maturityCreated).toBe(1);
+  });
+});
+
+describe('attachImages sanitization (SECURITY_AUDIT L-13)', () => {
+  // ZIP-extracted bytes are attacker-controlled: every buffer must pass
+  // through sanitizeImageBuffer() (magic-byte check, pixel cap, EXIF/GPS
+  // strip) before fs.writeFileSync — and a bad image must be SKIPPED with a
+  // recorded warning, never fail the import.
+  let writeSpy;
+
+  const freshResult = () => ({
+    imagesAttached: 0, imagesDeduped: 0, imagesSkipped: 0, errors: [],
+  });
+  const freshBottle = () => ({ _id: 'b1', wineDefinition: null, save: jest.fn() });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    writeSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    // No byte-identical image on record → always take the write path.
+    BottleImage.findOne.mockReturnValue({ select: () => ({ lean: () => Promise.resolve(null) }) });
+    BottleImage.create.mockImplementation(async (doc) => ({ _id: 'img1', ...doc }));
+  });
+
+  afterEach(() => writeSpy.mockRestore());
+
+  async function jpegWithExif() {
+    return sharp({
+      create: { width: 8, height: 4, channels: 3, background: { r: 10, g: 20, b: 30 } },
+    })
+      .jpeg()
+      .withMetadata({
+        exif: { IFD0: { Make: 'TestCam' }, GPS: { GPSLatitudeRef: 'N', GPSLongitudeRef: 'E' } },
+      })
+      .toBuffer();
+  }
+
+  test('a bad image is skipped with a per-image warning; the good one is still written', async () => {
+    const good = await jpegWithExif();
+    const files = {
+      'images/good.jpg': good,
+      'images/bad.png': Buffer.from('definitely not an image'),
+    };
+    const result = freshResult();
+
+    await attachImages(
+      freshBottle(),
+      [{ original: 'images/bad.png' }, { original: 'images/good.jpg' }],
+      'u1',
+      (p) => files[p] || null,
+      result,
+      new Map(),
+      3 // sourceIndex of the bottle in the import
+    );
+
+    expect(result.imagesAttached).toBe(1);
+    expect(result.imagesSkipped).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({ index: 3 });
+    expect(result.errors[0].reason).toMatch(/images\/bad\.png/);
+    expect(writeSpy).toHaveBeenCalledTimes(1);       // only the good image reached disk
+    expect(BottleImage.create).toHaveBeenCalledTimes(1);
+  });
+
+  test('the written buffer is sanitized (EXIF/GPS stripped) — not the raw ZIP bytes', async () => {
+    const good = await jpegWithExif();
+    expect((await sharp(good).metadata()).exif).toBeDefined(); // raw bytes DO carry EXIF
+
+    const result = freshResult();
+    await attachImages(
+      freshBottle(), [{ original: 'images/gps.jpg' }], 'u1',
+      () => good, result, new Map(), 0
+    );
+
+    const [writtenPath, writtenBuf] = writeSpy.mock.calls[0];
+    expect(writtenBuf).not.toEqual(good);
+    const meta = await sharp(writtenBuf).metadata();
+    expect(meta.exif).toBeUndefined();
+    expect(meta.format).toBe('jpeg');
+    expect(String(writtenPath)).toMatch(/\.jpg$/);
+  });
+
+  test('the file extension follows the actual bytes, not the archive filename', async () => {
+    // A real JPEG smuggled under a "processed …png" archive name must be
+    // written as .jpg (the sanitizer preserves the decoded format).
+    const jpeg = await jpegWithExif();
+    const result = freshResult();
+
+    await attachImages(
+      freshBottle(), [{ processed: 'images/liar.png' }], 'u1',
+      () => jpeg, result, new Map(), 0
+    );
+
+    const [writtenPath] = writeSpy.mock.calls[0];
+    expect(String(writtenPath)).toMatch(/\.jpg$/);
+    expect(BottleImage.create).toHaveBeenCalledWith(
+      expect.objectContaining({ processedUrl: expect.stringMatching(/\.jpg$/) })
+    );
+    expect(result.imagesAttached).toBe(1);
+  });
+
+  test('all images bad → nothing written, import result still sane', async () => {
+    const result = freshResult();
+    const bottle = freshBottle();
+
+    await attachImages(
+      bottle, [{ original: 'a.jpg' }, { original: 'b.jpg' }], 'u1',
+      () => Buffer.from('junk bytes that are not an image'), result, new Map(), 5
+    );
+
+    expect(result.imagesAttached).toBe(0);
+    expect(result.imagesSkipped).toBe(2);
+    expect(result.errors).toHaveLength(2);
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(BottleImage.create).not.toHaveBeenCalled();
+    expect(bottle.save).not.toHaveBeenCalled(); // no defaultImage to set
   });
 });

--- a/backend/src/services/embedding.js
+++ b/backend/src/services/embedding.js
@@ -19,6 +19,10 @@
 const VOYAGE_API_URL = 'https://api.voyageai.com/v1/embeddings';
 const VOYAGE_DIMENSION = 2048;
 const DEFAULT_MODEL = 'voyage-4-large';
+// Outbound timeout: Node fetch has no application-level timeout, so a stalled
+// Voyage connection would park callers (notably the /api/chat RAG path) until
+// undici's ~300 s default fires. Same AbortSignal pattern as imageProcessor.js.
+const VOYAGE_TIMEOUT_MS = 15000;
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -43,14 +47,25 @@ async function embed(texts, { model = DEFAULT_MODEL, maxRetries = 6 } = {}) {
   let delay = 2000; // ms — initial backoff
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const res = await fetch(VOYAGE_API_URL, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${apiKey}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ input: texts, model, output_dimension: VOYAGE_DIMENSION })
-    });
+    let res;
+    try {
+      res = await fetch(VOYAGE_API_URL, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ input: texts, model, output_dimension: VOYAGE_DIMENSION }),
+        signal: AbortSignal.timeout(VOYAGE_TIMEOUT_MS)
+      });
+    } catch (err) {
+      // Surface timeouts as the same plain-Error shape callers already handle
+      // for Voyage failures (no .status → generic 500 degrade path).
+      if (err.name === 'TimeoutError' || err.name === 'AbortError') {
+        throw new Error(`Voyage AI request timed out after ${VOYAGE_TIMEOUT_MS}ms`);
+      }
+      throw err;
+    }
 
     if (res.ok) {
       const json = await res.json();

--- a/backend/src/services/embedding.test.js
+++ b/backend/src/services/embedding.test.js
@@ -1,0 +1,55 @@
+/**
+ * Voyage embedding client — outbound-timeout contract (SECURITY_AUDIT L-8).
+ *
+ * Node fetch has no application-level timeout; a stalled Voyage connection
+ * would park the /api/chat RAG path until undici's ~300 s default fires.
+ * These tests pin two behaviours:
+ *   1. every Voyage fetch carries an AbortSignal (the timeout),
+ *   2. a timeout abort surfaces as the same plain-Error shape callers
+ *      already handle for Voyage failures (graceful degrade, no retry loop).
+ */
+const { embed } = require('./embedding');
+
+describe('embed (Voyage fetch)', () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.VOYAGE_API_KEY = 'test-key';
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    delete process.env.VOYAGE_API_KEY;
+    global.fetch = realFetch;
+  });
+
+  test('passes an abort (timeout) signal to fetch', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ index: 0, embedding: [0.1, 0.2] }] }),
+    });
+
+    const vectors = await embed(['hello']);
+
+    expect(vectors).toEqual([[0.1, 0.2]]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const opts = global.fetch.mock.calls[0][1];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('a timed-out fetch rejects with a plain Error (no retry loop, no crash shape)', async () => {
+    const timeoutErr = Object.assign(new Error('The operation was aborted due to timeout'), {
+      name: 'TimeoutError',
+    });
+    global.fetch.mockRejectedValue(timeoutErr);
+
+    await expect(embed(['hello'])).rejects.toThrow(/Voyage AI request timed out/);
+    // Timeouts are not retried like 429s — one attempt only.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('non-timeout network errors propagate unchanged', async () => {
+    global.fetch.mockRejectedValue(new TypeError('fetch failed'));
+    await expect(embed(['hello'])).rejects.toThrow('fetch failed');
+  });
+});

--- a/backend/src/services/imageSanitizer.js
+++ b/backend/src/services/imageSanitizer.js
@@ -116,6 +116,21 @@ async function sanitizeImageBuffer(input) {
 }
 
 /**
+ * Detect the actual format of an image buffer from its magic bytes.
+ * Returns 'jpeg' | 'png' | 'webp' | null. sanitizeImageBuffer() preserves the
+ * DECODED format (it never converts), so callers that persist or label its
+ * output use this to pick a file extension / MIME type that matches the real
+ * bytes rather than trusting a client-declared type or archive filename.
+ */
+function detectImageFormat(buf) {
+  if (!Buffer.isBuffer(buf) || buf.length < 12) return null;
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpeg';
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png';
+  if (buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') return 'webp';
+  return null;
+}
+
+/**
  * True when the file carries metadata worth stripping. Used by the backfill
  * script to skip already-clean files — re-encoding is lossy for JPEG, so a
  * re-run must not put clean files through another generation.
@@ -126,4 +141,4 @@ async function hasStrippableMetadata(filePath) {
   return !!(meta.exif || meta.xmp || meta.iptc || (meta.orientation && meta.orientation !== 1));
 }
 
-module.exports = { stripImageMetadata, sanitizeImageBuffer, hasStrippableMetadata, MAX_PIXELS };
+module.exports = { stripImageMetadata, sanitizeImageBuffer, detectImageFormat, hasStrippableMetadata, MAX_PIXELS };

--- a/backend/src/services/imageSanitizer.test.js
+++ b/backend/src/services/imageSanitizer.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const sharp = require('sharp');
-const { stripImageMetadata, hasStrippableMetadata } = require('./imageSanitizer');
+const { stripImageMetadata, hasStrippableMetadata, sanitizeImageBuffer, detectImageFormat } = require('./imageSanitizer');
 
 // sharp caches open file descriptors, which blocks the temp-dir cleanup on
 // Windows (EBUSY on unlink). The cache is irrelevant for these tests.
@@ -123,5 +123,35 @@ describe('stripImageMetadata', () => {
 
     await stripImageMetadata(file);
     expect(await hasStrippableMetadata(file)).toBe(false);
+  });
+});
+
+describe('detectImageFormat', () => {
+  async function make(format) {
+    const pipeline = sharp({
+      create: { width: 4, height: 4, channels: 3, background: { r: 1, g: 2, b: 3 } },
+    });
+    if (format === 'jpeg') return pipeline.jpeg().toBuffer();
+    if (format === 'png') return pipeline.png().toBuffer();
+    return pipeline.webp().toBuffer();
+  }
+
+  it('identifies jpeg, png and webp from magic bytes', async () => {
+    expect(detectImageFormat(await make('jpeg'))).toBe('jpeg');
+    expect(detectImageFormat(await make('png'))).toBe('png');
+    expect(detectImageFormat(await make('webp'))).toBe('webp');
+  });
+
+  it('returns null for non-image or too-short input', () => {
+    expect(detectImageFormat(Buffer.from('not an image at all'))).toBeNull();
+    expect(detectImageFormat(Buffer.from('hi'))).toBeNull();
+    expect(detectImageFormat('string')).toBeNull();
+  });
+
+  it('matches the format sanitizeImageBuffer actually produced (format is preserved)', async () => {
+    for (const format of ['jpeg', 'png', 'webp']) {
+      const out = await sanitizeImageBuffer(await make(format));
+      expect(detectImageFormat(out)).toBe(format);
+    }
   });
 });

--- a/backend/src/services/vectorStore.js
+++ b/backend/src/services/vectorStore.js
@@ -15,6 +15,11 @@
 
 const { VOYAGE_DIMENSION } = require('./embedding');
 
+// Outbound timeout: Node fetch has no application-level timeout, so a stalled
+// Qdrant connection would park callers (notably the /api/chat RAG path) until
+// undici's ~300 s default fires. Same AbortSignal pattern as imageProcessor.js.
+const QDRANT_TIMEOUT_MS = 8000;
+
 function qdrantBase() {
   return (process.env.QDRANT_URL || 'http://localhost:6333').replace(/\/$/, '');
 }
@@ -27,11 +32,22 @@ async function qdrantRequest(method, path, body) {
   const url = `${qdrantBase()}${path}`;
   const opts = {
     method,
-    headers: { 'Content-Type': 'application/json' }
+    headers: { 'Content-Type': 'application/json' },
+    signal: AbortSignal.timeout(QDRANT_TIMEOUT_MS)
   };
   if (body !== undefined) opts.body = JSON.stringify(body);
 
-  const res = await fetch(url, opts);
+  let res;
+  try {
+    res = await fetch(url, opts);
+  } catch (err) {
+    // Surface timeouts as the same plain-Error shape callers already handle
+    // for Qdrant connection failures (no .status → generic degrade path).
+    if (err.name === 'TimeoutError' || err.name === 'AbortError') {
+      throw new Error(`Qdrant ${method} ${path} timed out after ${QDRANT_TIMEOUT_MS}ms`);
+    }
+    throw err;
+  }
   const json = await res.json().catch(() => ({}));
 
   if (!res.ok) {

--- a/backend/src/services/vectorStore.test.js
+++ b/backend/src/services/vectorStore.test.js
@@ -1,0 +1,54 @@
+/**
+ * Qdrant client — outbound-timeout contract (SECURITY_AUDIT L-8).
+ *
+ * Same rationale as embedding.test.js: every Qdrant fetch must carry an
+ * AbortSignal so a stalled connection can't park the chat route, and a
+ * timeout must surface as the same plain-Error shape callers already handle
+ * for Qdrant connection failures (graceful degrade).
+ */
+const vectorStore = require('./vectorStore');
+
+describe('qdrant fetches', () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  test('searchSimilar passes an abort (timeout) signal to fetch', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: [{ id: 'p1', score: 0.9, payload: { vintage: '2019' } }] }),
+    });
+
+    const hits = await vectorStore.searchSimilar('v1', [0.1, 0.2], 5);
+
+    expect(hits).toEqual([{ id: 'p1', score: 0.9, payload: { vintage: '2019' } }]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const opts = global.fetch.mock.calls[0][1];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('upsertPoints passes an abort (timeout) signal to fetch', async () => {
+    global.fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    await vectorStore.upsertPoints('v1', [{ id: 'p1', vector: [0.1], payload: {} }]);
+
+    const opts = global.fetch.mock.calls[0][1];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('a timed-out fetch rejects with a plain Error naming the request', async () => {
+    const timeoutErr = Object.assign(new Error('The operation was aborted due to timeout'), {
+      name: 'TimeoutError',
+    });
+    global.fetch.mockRejectedValue(timeoutErr);
+
+    await expect(vectorStore.searchSimilar('v1', [0.1], 5))
+      .rejects.toThrow(/Qdrant POST .* timed out/);
+  });
+});


### PR DESCRIPTION
Fixes three findings from **SECURITY_AUDIT_2026-07-08.md** (all LOW, DoS/upload-hardening cluster).

## L-8 — Voyage + Qdrant fetches lacked outbound timeouts
- `services/embedding.js`: the Voyage `/v1/embeddings` fetch now carries `signal: AbortSignal.timeout(15000)`, matching the rembg pattern in `imageProcessor.js` / `wines.js`.
- `services/vectorStore.js`: `qdrantRequest()` — the single fetch funnel for **all** Qdrant calls (ensure/upsert/search/get/delete/drop/info) — now carries `AbortSignal.timeout(8000)`.
- Timeouts are rethrown as the same plain-`Error` shape callers already handle for Voyage/Qdrant connection failures (no `.status`), so a stalled upstream degrades exactly like any other AI-backend failure on the `/api/chat` RAG path instead of parking the handler for undici's ~300 s default. Voyage timeouts are **not** fed into the 429 retry loop.

## L-9 — `scan-label` forwarded the raw base64 image to single-worker rembg
- `routes/wines.js`: the decoded buffer now goes through the shared `sanitizeImageBuffer()` (magic-byte/format check, 64 M decoded-pixel cap, EXIF strip) **before** anything touches it — fail-closed `400` on rejection, mirroring the hardened `/api/images/remove-bg-preview` sibling.
- The sanitized buffer is what gets forwarded to rembg *and* Claude, and the media type is re-detected from the actual bytes (`detectImageFormat()`) instead of trusting the client-declared `mediaType` (still accepted for compatibility, now ignored).

## L-13 — Cellar ZIP import wrote attacker-controlled image bytes straight to disk
- `services/cellarImport.js` `attachImages()`: every ZIP-extracted buffer is routed through the same `sanitizeImageBuffer()` before `fs.writeFileSync`, and the **sanitized** bytes are what land on disk. Images that fail sanitization are skipped and recorded (`result.imagesSkipped` + a per-image entry in the existing `result.errors` warnings list, keyed to the bottle's source index) — the import itself still succeeds.
- The file extension is derived from the sanitized bytes (the sanitizer preserves the decoded format), so a JPEG smuggled under a `.png` archive name is written as `.jpg`.
- Dedup hashing stays on the bytes-as-exported so `contentHash` matching against existing images and repeat imports keeps working.
- **Privacy angle:** this closes the EXIF/GPS leak the ZIP importer had reopened — imported phone photos previously kept the GPS coordinates of where the owner stores their wine, the exact leak PR #505 was built to prevent. Import/upload now share one sanitisation contract.
- Import logic is untouched otherwise — the sanitization step is purely additive inside the existing write branch (dedup, overwrite staging, multi-format importers all unchanged).

## Tests
New/extended suites (all green, `cd backend && npm test` → **45 suites / 807 tests passed**):
- `routes/wines.scanLabel.test.js` (new): non-image payload → 400 before rembg/Claude are touched; valid image passes through sanitized with byte-detected media type.
- `services/cellarImport.test.js`: bad ZIP image skipped + warned while the good one is written; written buffer verified EXIF-free; extension-follows-bytes; all-bad-images case.
- `services/embedding.test.js` / `services/vectorStore.test.js` (new): abort signal present on every fetch; timeout rejections surface as the documented plain-Error shape.
- `services/imageSanitizer.test.js`: `detectImageFormat()` magic-byte coverage + format-preservation contract with `sanitizeImageBuffer()`.

## Deployment
- **Zero docker-compose impact** — no new env vars, services, ports, or volumes; backend image rebuild only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)