### PR TITLE
fix: container/nginx/CI security hardening (audit L-21/L-22/L-24/L-25/L-27 + dep hygiene)

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -27,10 +27,19 @@ jobs:
       - name: Prepare variables (lowercase owner + normalized tag)
         id: vars
         shell: bash
+        # Untrusted values reach the shell via env, never via ${{ }} inside
+        # run: — a tag like `v1$(cmd)` would otherwise execute on a runner
+        # holding packages:write (GHCR poisoning). Env vars are inert data.
+        env:
+          TAG_RAW: ${{ github.ref_name }}
+          OWNER_RAW: ${{ github.repository_owner }}
         run: |
-          OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          TAG_RAW="${{ github.ref_name }}"         # e.g. v0.2.1 or 0.2.1
-          TAG="${TAG_RAW#v}"                       # strip leading v if present
+          if [[ ! "$TAG_RAW" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag '$TAG_RAW' does not match vX.Y.Z — refusing to build."
+            exit 1
+          fi
+          OWNER_LOWER=$(echo "$OWNER_RAW" | tr '[:upper:]' '[:lower:]')
+          TAG="${TAG_RAW#v}"                       # strip the leading v
           echo "owner=${OWNER_LOWER}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Cellarion/
 │   │   ├── utils/                  # Frontend helpers
 │   │   └── styles/common.css
 │   ├── nginx.conf                  # nginx config (SPA + /api/ proxy)
-│   └── Dockerfile                  # Multi-stage: Node build → nginx:alpine
+│   └── Dockerfile                  # Multi-stage: Node build → nginx-unprivileged
 ├── rembg/                          # Python background-removal service
 └── docker-compose.yml
 ```
@@ -272,8 +272,11 @@ traefik.enable: "true"
 traefik.docker.network: "web"
 traefik.http.routers.cellarion.rule: "Host(`cellarion.app`)"
 traefik.http.routers.cellarion.entrypoints: "web"
-traefik.http.services.cellarion.loadbalancer.server.port: "80"
+traefik.http.services.cellarion.loadbalancer.server.port: "8080"
 ```
+
+The upstream port is **8080** (not 80): the frontend image is built on
+`nginxinc/nginx-unprivileged`, whose non-root nginx cannot bind ports below 1024.
 
 Update the `Host(...)` rule to match your own domain.
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:20-alpine
 
+# Bake production mode into the image: the refresh-cookie Secure flag and
+# 5xx error redaction key off NODE_ENV, and Express itself runs faster with
+# it set. Self-hosters previously ran with NODE_ENV undefined (audit L-22).
+ENV NODE_ENV=production
+
 WORKDIR /app
 
 COPY package.json package-lock.json ./

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,10 +3,15 @@
 services:
   frontend:
     ports:
-      - "80:80"
+      # Container listens on 8080 (unprivileged nginx); keep localhost:80 outside.
+      - "80:8080"
   backend:
     ports:
-      - "5000:5000"
+      # Loopback-only (audit L-24): publishing :5000 on 0.0.0.0 exposed the raw
+      # Express API to the LAN, where a forged X-Forwarded-For defeats every
+      # IP-keyed rate limiter (trust proxy expects the nginx hop). localhost:5000
+      # keeps working for bare-metal frontend dev.
+      - "127.0.0.1:5000:5000"
   umami:
     ports:
       - "3001:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,23 @@
+# Container hardening (audit L-25): every service drops all Linux capabilities
+# and forbids privilege escalation (no-new-privileges blocks setuid binaries;
+# it does NOT block gosu/su-exec, which use plain setuid() syscalls). Services
+# whose entrypoint starts as root and steps down to a service user get the
+# minimal cap_add set that step-down needs.
 services:
   mongo:
     image: mongo:7
     container_name: cellarion-mongo
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    # Entrypoint starts as root, chowns /data/db, then gosu's down to the
+    # mongodb user — the minimal caps that dance needs.
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
     # WiredTiger cache must stay well under the container limit (512M below) —
     # cache + connection/aggregation overhead beyond the limit gets the
     # container OOM-killed under load. ~50% of the limit is the safe ratio.
@@ -23,6 +38,10 @@ services:
     image: getmeili/meilisearch:v1.45.1
     container_name: cellarion-meilisearch
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     environment:
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
       - MEILI_ENV=production
@@ -42,6 +61,10 @@ services:
     image: qdrant/qdrant:v1.18.1
     container_name: cellarion-qdrant
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     volumes:
       - qdrant-data:/qdrant/storage
     deploy:
@@ -59,7 +82,14 @@ services:
     build: ./backend
     container_name: cellarion-backend
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     environment:
+      # Belt-and-braces with the Dockerfile ENV (audit L-22): secure refresh
+      # cookie + redacted 5xx bodies must not depend on out-of-band config.
+      - NODE_ENV=production
       - MONGO_URI=mongodb://mongo:27017/winecellar
       - JWT_SECRET=${JWT_SECRET}
       - ACCESS_TOKEN_EXPIRES_IN=${ACCESS_TOKEN_EXPIRES_IN:-15m}
@@ -116,6 +146,10 @@ services:
     build: ./rembg
     container_name: cellarion-rembg
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
       interval: 30s
@@ -137,12 +171,18 @@ services:
         VITE_SITE_URL: ${VITE_SITE_URL:-}
     container_name: cellarion-frontend
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     deploy:
       resources:
         limits:
           memory: 64M
+    # 8080: nginxinc/nginx-unprivileged serve stage — non-root nginx cannot
+    # bind :80. Local port 80 mapping lives in docker-compose.override.yml.
     expose:
-      - "80"
+      - "8080"
     networks:
       - web
       - default
@@ -151,7 +191,7 @@ services:
       traefik.docker.network: "web"
       traefik.http.routers.cellarion.rule: "Host(`cellarion.app`)"
       traefik.http.routers.cellarion.entrypoints: "web"
-      traefik.http.services.cellarion.loadbalancer.server.port: "80"
+      traefik.http.services.cellarion.loadbalancer.server.port: "8080"
     depends_on:
       backend:
         condition: service_healthy
@@ -170,6 +210,10 @@ services:
     # profile (an empty password makes Postgres/Umami fail to start — fail-closed,
     # and never a guessable committed default). Matches docker-compose.prod.yml.
     profiles: ["analytics"]
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     environment:
       - DATABASE_URL=postgresql://umami:${UMAMI_DB_PASSWORD}@umami-db:5432/umami
       - DATABASE_TYPE=postgresql
@@ -198,6 +242,18 @@ services:
     container_name: cellarion-umami-db
     restart: unless-stopped
     profiles: ["analytics"]
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    # Entrypoint starts as root, fixes PGDATA ownership/permissions, then
+    # su-exec's down to the postgres user — the minimal caps that needs.
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
     environment:
       - POSTGRES_DB=umami
       - POSTGRES_USER=umami

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,11 +26,19 @@ ENV VITE_UMAMI_URL=$VITE_UMAMI_URL \
 RUN npm run build
 
 # ── Stage 2: serve with nginx ─────────────────────────────────────────────────
-FROM nginx:alpine
+# Unprivileged variant: master + workers run as the non-root `nginx` user
+# (uid 101), so an nginx compromise never holds root in the container (audit
+# L-25). Non-root cannot bind <1024, so the server listens on 8080 — compose
+# and Traefik map onto that port.
+FROM nginxinc/nginx-unprivileged:alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Shared security-header snippet, include'd by every HTML-serving location.
+# Lives outside conf.d/ so nginx does not auto-load it a second time at the
+# http{} level.
+COPY security-headers.conf /etc/nginx/snippets/security-headers.conf
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -34,7 +34,9 @@ map $http_user_agent $is_crawler {
 }
 
 server {
-    listen 80;
+    # 8080, not 80: the serve stage runs on nginxinc/nginx-unprivileged, whose
+    # non-root worker cannot bind ports <1024. Compose/Traefik map onto 8080.
+    listen 8080;
     server_name _;
 
     # Allow large uploads (bottle images)
@@ -99,6 +101,7 @@ server {
         }
         # Real users get the SPA — frontend handles ObjectId→slug replaceState there
         root       /usr/share/nginx/html;
+        include    /etc/nginx/snippets/security-headers.conf;
         try_files  /index.html =404;
     }
 
@@ -108,6 +111,7 @@ server {
             return 418;
         }
         root       /usr/share/nginx/html;
+        include    /etc/nginx/snippets/security-headers.conf;
         try_files  /index.html =404;
     }
 
@@ -128,6 +132,7 @@ server {
             return 418;
         }
         root       /usr/share/nginx/html;
+        include    /etc/nginx/snippets/security-headers.conf;
         try_files  /index.html =404;
     }
 
@@ -148,6 +153,7 @@ server {
             return 418;
         }
         root       /usr/share/nginx/html;
+        include    /etc/nginx/snippets/security-headers.conf;
         try_files  /index.html =404;
     }
 
@@ -168,6 +174,7 @@ server {
             return 418;
         }
         root       /usr/share/nginx/html;
+        include    /etc/nginx/snippets/security-headers.conf;
         try_files  /index.html =404;
     }
 
@@ -190,6 +197,7 @@ server {
             return 418;
         }
         root       /usr/share/nginx/html;
+        include    /etc/nginx/snippets/security-headers.conf;
         try_files  /index.html =404;
     }
 
@@ -199,6 +207,7 @@ server {
             return 418;
         }
         root       /usr/share/nginx/html;
+        include    /etc/nginx/snippets/security-headers.conf;
         try_files  /index.html =404;
     }
 
@@ -231,14 +240,9 @@ server {
         add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header        Pragma                                "no-cache"  always;
         add_header        Expires                               "0"         always;
-        # Security headers on the app shell. nginx does NOT inherit server-level
-        # add_header into a location that sets its own, so they're repeated on
-        # each HTML location. X-Frame-Options stops clickjacking; nosniff stops
-        # MIME confusion; Referrer-Policy limits referer leakage. (HSTS is set
-        # at Cloudflare, the TLS-terminating layer.)
-        add_header        X-Frame-Options                       "DENY"      always;
-        add_header        X-Content-Type-Options                "nosniff"   always;
-        add_header        Referrer-Policy   "strict-origin-when-cross-origin" always;
+        # Security headers on the app shell — shared snippet, see the note in
+        # security-headers.conf about the add_header inheritance quirk.
+        include           /etc/nginx/snippets/security-headers.conf;
         try_files         /index.html =404;
     }
 
@@ -263,9 +267,7 @@ server {
         add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header        Pragma                                "no-cache"  always;
         add_header        Expires                               "0"         always;
-        add_header        X-Frame-Options                       "DENY"      always;
-        add_header        X-Content-Type-Options                "nosniff"   always;
-        add_header        Referrer-Policy   "strict-origin-when-cross-origin" always;
+        include           /etc/nginx/snippets/security-headers.conf;
         try_files         /index.html =404;
     }
 
@@ -291,9 +293,7 @@ server {
         add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header        Pragma                                "no-cache"  always;
         add_header        Expires                               "0"         always;
-        add_header        X-Frame-Options                       "DENY"      always;
-        add_header        X-Content-Type-Options                "nosniff"   always;
-        add_header        Referrer-Policy   "strict-origin-when-cross-origin" always;
+        include           /etc/nginx/snippets/security-headers.conf;
         try_files         /index.html =404;
     }
 
@@ -311,15 +311,14 @@ server {
         add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header        Pragma                                "no-cache"  always;
         add_header        Expires                               "0"         always;
-        add_header        X-Frame-Options                       "DENY"      always;
-        add_header        X-Content-Type-Options                "nosniff"   always;
-        add_header        Referrer-Policy   "strict-origin-when-cross-origin" always;
+        include           /etc/nginx/snippets/security-headers.conf;
     }
     location = /service-worker.js {
         root              /usr/share/nginx/html;
         add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header        Pragma                                "no-cache"  always;
         add_header        Expires                               "0"         always;
+        include           /etc/nginx/snippets/security-headers.conf;
         try_files         /service-worker.js =404;
     }
 
@@ -330,6 +329,7 @@ server {
     location / {
         root       /usr/share/nginx/html;
         index      index.html;
+        include    /etc/nginx/snippets/security-headers.conf;
         try_files  $uri $uri/ @spa_shell;
     }
 
@@ -343,9 +343,7 @@ server {
         add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header        Pragma                                "no-cache"  always;
         add_header        Expires                               "0"         always;
-        add_header        X-Frame-Options                       "DENY"      always;
-        add_header        X-Content-Type-Options                "nosniff"   always;
-        add_header        Referrer-Policy   "strict-origin-when-cross-origin" always;
+        include           /etc/nginx/snippets/security-headers.conf;
         try_files         /index.html =404;
     }
 

--- a/frontend/security-headers.conf
+++ b/frontend/security-headers.conf
@@ -1,0 +1,19 @@
+# Shared security headers for every location that can serve the SPA shell
+# (or other first-party documents/scripts).
+#
+# nginx `add_header` quirk: a location that sets ANY add_header of its own
+# stops inheriting server-level add_header directives entirely. Including
+# this snippet in each HTML-serving location (instead of relying on a
+# server-level header) makes the set identical everywhere and immune to
+# that inheritance trap.
+#
+# - X-Frame-Options SAMEORIGIN: stops cross-origin clickjacking/framing.
+# - X-Content-Type-Options nosniff: stops MIME-type confusion.
+# - Referrer-Policy: limits referer leakage to third parties.
+# - Permissions-Policy: denies geolocation/microphone outright; camera is
+#   allowed for self only — the label-scan feature uses getUserMedia.
+# (HSTS is set at Cloudflare, the TLS-terminating layer.)
+add_header X-Frame-Options        "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff"    always;
+add_header Referrer-Policy        "strict-origin-when-cross-origin"              always;
+add_header Permissions-Policy     "geolocation=(), microphone=(), camera=(self)" always;

--- a/rembg/requirements.txt
+++ b/rembg/requirements.txt
@@ -1,7 +1,12 @@
 flask==3.1.3
 rembg[cpu]==2.0.75
-pillow>=10.0.0
+# Pinned (was >=10.0.0): pillow decodes untrusted image bytes, so builds must
+# not silently float to an unvetted release. Must stay inside rembg 2.0.75's
+# own constraint (pillow >=12.1,<13).
+pillow==12.3.0
 # app.py imports numpy directly (transparency pre-check) — pin it explicitly
 # instead of relying on it staying a transitive dependency of rembg.
 numpy>=1.26,<3
-gunicorn==22.0.0
+# >=23 fixes CVE-2024-6827 (request smuggling; unreachable here — rembg is
+# internal-only with no fronting proxy — bumped for hygiene).
+gunicorn>=23.0.0


### PR DESCRIPTION
Fixes the infra half of [SECURITY_AUDIT_2026-07-08](../blob/main/SECURITY_AUDIT_2026-07-08.md): **L-21, L-22 (image half), L-24, L-25, L-27 + dependency hygiene**. L-26 (digest pinning) is deliberately deferred. The COOKIE_SECURE code override half of L-22 lands in a separate PR — `auth.js` is untouched here.

## ⚠️ docker-compose / prod impact (docker-compose.prod.yml on the VM is hand-maintained — mirror these)

1. **Frontend upstream port changes 80 → 8080** (only once the new frontend image ships). The image is now `nginxinc/nginx-unprivileged` and nginx listens on **8080** as non-root. On prod you MUST update, in the same deploy as the image pull:
   - `expose: "8080"` (was `"80"`)
   - `traefik.http.services.cellarion.loadbalancer.server.port: "8080"` (was `"80"`) — **this changes the Traefik upstream port**; an old label + new image = 502s.
2. **`NODE_ENV=production`** — now baked into the backend image (`ENV`) *and* set in the compose backend env. Prod already injects it out-of-band, so this is a no-op there, but verify the prod compose/env still sets it (or simply rely on the new image ENV); do **not** remove any existing prod setting.
3. **`security_opt: [no-new-privileges:true]` + `cap_drop: [ALL]` on every service** — recommended to mirror on prod. Two services need minimal `cap_add` because their entrypoints start as root and step down:
   - `mongo`: `CHOWN, SETGID, SETUID`
   - `umami-db` (postgres): `CHOWN, DAC_OVERRIDE, FOWNER, SETGID, SETUID`
   Both were runtime-verified under exactly these flags (mongod reaches "Waiting for connections" + mongosh ping OK; postgres reaches "ready to accept connections" + `pg_isready` OK). meilisearch/qdrant/backend/rembg/frontend/umami need no caps.
4. **Dev-only (`docker-compose.override.yml`, not merged on prod):** backend now binds `127.0.0.1:5000:5000` (loopback-only, L-24) and frontend maps `80:8080`. Self-hosters using the repo compose get both automatically; `http://localhost` and `http://localhost:5000` keep working.
5. **rembg image contents change** (gunicorn ≥23, pillow pinned 12.3.0) — normal image pull, no compose edit.

## Findings fixed

### L-21 — nginx security headers on every HTML route + Permissions-Policy
- New `frontend/security-headers.conf` snippet (COPY'd to `/etc/nginx/snippets/`, outside `conf.d/` so it isn't auto-loaded twice), `include`'d in **every** HTML-serving location — including the previously uncovered public SEO routes (`/wines/*`, `/wines/type/*`, `/blog/<slug>`, `/regions|countries|grapes/*`, `/community/discussions[/*]`) and the already-covered ones (same snippet, no drift). The per-location include sidesteps the `add_header` inheritance quirk (any local `add_header` discards inherited ones).
- Headers: `X-Frame-Options SAMEORIGIN`, `X-Content-Type-Options nosniff`, `Referrer-Policy strict-origin-when-cross-origin`, **new** `Permissions-Policy "geolocation=(), microphone=(), camera=(self)"` (`camera=self` because label-scan uses getUserMedia).
- Note: X-Frame-Options moves `DENY` → `SAMEORIGIN` (uniform, per the remediation spec). The audit's dead duplicate `/wines` location was already removed in #606.
- Runtime-verified with curl against the built image: all four headers present on `/`, `/wines/<slug>`, `/blog/<slug>`, `/regions/<slug>`, `/community/discussions`, and the `@spa_shell` fallback; cache headers intact; crawler UA still routes into the `@*_og` proxy.

### L-22 (image half) — NODE_ENV
- `ENV NODE_ENV=production` in `backend/Dockerfile` + `NODE_ENV: production` in the compose backend env. Self-hosters on plain HTTP (non-localhost) will get a `Secure` refresh cookie until the COOKIE_SECURE override PR lands — known, accepted interim tradeoff (browsers exempt `http://localhost`).

### L-24 — loopback-only dev backend port
- `docker-compose.override.yml`: `127.0.0.1:5000:5000`, closing the LAN-reachable raw-Express X-Forwarded-For rate-limiter bypass.

### L-25 — non-root nginx + container hardening
- `FROM nginxinc/nginx-unprivileged:alpine`, `listen 8080`, `EXPOSE 8080`, compose/Traefik/README updated; `security_opt`/`cap_drop` across all services as above.

### L-27 — CI script-injection
- `release-docker.yml`: `github.ref_name`/`github.repository_owner` now enter the shell via `env:` (inert data) instead of `${{ }}` interpolation, and the tag is validated against `^v[0-9]+\.[0-9]+\.[0-9]+$` (exit 1 otherwise). No other run-block interpolations exist in either workflow.

### Dependency hygiene (rembg)
- `gunicorn>=23.0.0` (CVE-2024-6827, unreachable here but bumped) and `pillow` pinned to **12.3.0** (was floating `>=10.0.0`; must be ≥12.1 for rembg 2.0.75 — resolution verified with a pip dry-run in `python:3.11-slim`). numpy pin kept.

## Verification
- `docker compose config` (default + `--profile analytics`): OK
- `docker build frontend/` + `docker build backend/`: OK
- Frontend image booted with `--cap-drop ALL --security-opt no-new-privileges:true`: runs as `nginx` (non-root), `nginx -t` passes, headers verified per-route (see L-21)
- `mongo:7` and `postgres:16-alpine` booted under the exact hardened flag sets: fully healthy
- Tests: backend Jest **791 passed** (42 suites), frontend Vitest **339 passed** (14 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)