### PR TITLE
fix: GDPR retention/erasure gaps + symmetric Cellar-Cred accounting (L-15…L-19)

### DIFF
--- a/backend/src/models/CommunityWinePrice.js
+++ b/backend/src/models/CommunityWinePrice.js
@@ -15,10 +15,13 @@ const mongoose = require('mongoose');
  * within one currency every value is same-currency / same-tax and therefore
  * comparable. See docs/wine-valuation-spec.md.
  *
- * `confidence` is a TRUST label, not a privacy gate. Community prices are
- * published unattributed (like a shared image), so even an `indicative`
- * (1–2 owner) value is shown — just flagged as low-confidence. Data quality is
- * protected by the cross-vintage cleaner in the job, not by withholding values.
+ * Privacy (security audit L-18): a k-anonymity floor of FIRM_MIN_OWNERS (3)
+ * distinct owners is enforced both by the aggregation job (sub-floor vintages
+ * are never stored, and previously stored ones are cleaned up) and by the
+ * read layer (services/communityPrice.js) — a 1–2 owner aggregate would
+ * effectively publish an individual user's exact purchase price on a public
+ * endpoint. `indicative` therefore no longer reaches clients; the enum is kept
+ * for legacy documents until the next job run sweeps them.
  */
 const communityWinePriceSchema = new mongoose.Schema({
   wineDefinition: {
@@ -54,7 +57,8 @@ const communityWinePriceSchema = new mongoose.Schema({
     min: 1
   },
   // 'firm'  → sampleSize >= FIRM_MIN_OWNERS (anonymised, high trust)
-  // 'indicative' → 1–2 owners, curve-validated (shown with a low-confidence label)
+  // 'indicative' → 1–2 owners; NO LONGER stored or served (k-anonymity floor,
+  // L-18) — value kept in the enum only for legacy documents pending cleanup.
   confidence: {
     type: String,
     enum: ['indicative', 'firm'],

--- a/backend/src/models/DiscussionReply.js
+++ b/backend/src/models/DiscussionReply.js
@@ -23,9 +23,14 @@ const discussionReplySchema = new mongoose.Schema({
     // hard ceiling.
     maxlength: [4000, 'Reply too long']
   },
-  // Snapshot of the quoted reply — stored inline so it survives edits/deletes
+  // Snapshot of the quoted reply — stored inline so it survives edits/deletes.
+  // authorId mirrors the quoted reply's author at creation time so GDPR
+  // erasure can anonymise the denormalised authorName snapshot when the quoted
+  // user deletes their account (see userDataRegistry.js). Legacy quotes
+  // (created before authorId existed) are resolved via replyId at purge time.
   quote: {
     replyId: { type: mongoose.Schema.Types.ObjectId, ref: 'DiscussionReply', default: null },
+    authorId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
     authorName: { type: String, default: null },
     body: { type: String, default: null }
   },

--- a/backend/src/models/Recommendation.js
+++ b/backend/src/models/Recommendation.js
@@ -12,6 +12,11 @@ const recommendationSchema = new mongoose.Schema({
     ref: 'User',
     default: null
   },
+  // External (non-user) recipient's address — third-party PII with no account
+  // of its own. Retention is bounded: scrubbed after 90 days by
+  // services/recommendationRetentionJob.js and immediately on sender-account
+  // erasure (services/userDataRegistry.js). Kept until then only so the
+  // sender's "sent" list can show who the recommendation went to.
   recipientEmail: {
     type: String,
     trim: true,

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -14,7 +14,7 @@ const WineDefinition = require('../models/WineDefinition');
 const { stripHtml } = require('../utils/sanitize');
 const { sanitizeForumHtml, visibleTextLength } = require('../utils/sanitizeHtml');
 const { logAudit } = require('../services/audit');
-const { incrementCred } = require('../utils/cellarCred');
+const { incrementCred, decrementCred } = require('../utils/cellarCred');
 const { submitUrls: submitToIndexNow } = require('../services/indexNow');
 const { createNotification, createNotifications } = require('../services/notifications');
 const { extractMentions } = require('../utils/mentionParser');
@@ -499,8 +499,36 @@ router.delete('/:idOrSlug', requireAuth, requireModeratorOrAdmin, async (req, re
     // filed against the discussion itself AND reports against any of its
     // replies (the reply IDs go away in the next step, leaving orphan reports
     // pointing at deleted documents in the moderation queue otherwise).
-    const replyIds = await DiscussionReply.find({ discussion: discussion._id }).select('_id');
+    const replyIds = await DiscussionReply.find({ discussion: discussion._id }).select('_id author isDeleted');
     const replyIdList = replyIds.map(r => r._id);
+
+    // Collect the Cellar-Cred these documents awarded BEFORE deleting them so
+    // the hard delete reverses the awards symmetrically (L-19): +2 to the
+    // discussion author, +1 per live reply to its author, +1 per non-self
+    // reaction to the reacted reply's author. Soft-deleted replies already had
+    // their reply-created point reversed at soft-delete time, so they are
+    // skipped here — but their reactions were never reversed, so those aren't.
+    const credReversals = new Map(); // userId -> { eventType -> count }
+    const addReversal = (userId, eventType, n = 1) => {
+      if (!userId) return;
+      const key = userId.toString();
+      const events = credReversals.get(key) || {};
+      events[eventType] = (events[eventType] || 0) + n;
+      credReversals.set(key, events);
+    };
+    addReversal(discussion.author, 'discussion_created');
+    const authorByReply = new Map();
+    for (const r of replyIds) {
+      authorByReply.set(r._id.toString(), r.author?.toString());
+      if (!r.isDeleted) addReversal(r.author, 'discussion_reply_created');
+    }
+    const reactionRows = await DiscussionReaction.find({ reply: { $in: replyIdList } }).select('reply user').lean();
+    for (const rx of reactionRows) {
+      const replyAuthor = authorByReply.get(rx.reply?.toString());
+      if (replyAuthor && replyAuthor !== rx.user?.toString()) {
+        addReversal(replyAuthor, 'reply_like_received');
+      }
+    }
     // Await the cleanups BEFORE deleting the parent — if one fails the 500
     // leaves the discussion intact so the delete can be retried, instead of
     // permanently orphaning replies/reactions/reports.
@@ -522,6 +550,14 @@ router.delete('/:idOrSlug', requireAuth, requireModeratorOrAdmin, async (req, re
     const deletedId = discussion._id;
     await Discussion.deleteOne({ _id: discussion._id });
     logAudit(req, 'discussion.delete', { type: 'discussion', id: deletedId });
+
+    // Apply the collected reversals now that the deletes succeeded.
+    // Fire-and-forget like every other cred write; decrementCred clamps at 0.
+    for (const [userId, events] of credReversals) {
+      for (const [eventType, count] of Object.entries(events)) {
+        decrementCred(userId, eventType, count).catch(() => {});
+      }
+    }
 
     // Tell crawlers the URL is gone (ping returns 404 on next crawl → drop from index)
     submitToIndexNow(publicPath);
@@ -657,14 +693,16 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
         const snippetBody = quotedPlain.length > 300
           ? quotedPlain.slice(0, 300) + '…'
           : quotedPlain;
+        // authorId is persisted alongside the denormalised name snapshot so
+        // GDPR erasure can find and anonymise quote.authorName on OTHER
+        // users' replies when the quoted author deletes their account (L-17).
+        quotedAuthorId = quotedReply.author?._id || null;
         quoteData = {
           replyId: quotedReply._id,
+          authorId: quotedAuthorId,
           authorName: quotedName,
           body: snippetBody
         };
-        // Track separately — author is needed for the "you were quoted"
-        // notification, but we don't want to persist it on the reply document.
-        quotedAuthorId = quotedReply.author?._id || null;
       }
     }
 
@@ -903,6 +941,13 @@ router.delete('/:discussionId/replies/:replyId', requireAuth, async (req, res) =
     reply.deletedAt = new Date();
     await reply.save();
 
+    // Reverse the +1 the reply's creation awarded (L-19) — a create/delete
+    // cycle nets zero. The isDeleted guard above makes this once-only (there
+    // is no un-delete). Reaction cred is NOT reversed here: reactions stay on
+    // the soft-deleted reply and remain toggleable, so their accounting stays
+    // with the toggle handlers.
+    decrementCred(reply.author.toString(), 'discussion_reply_created').catch(() => {});
+
     logAudit(req, 'discussion_reply.soft_delete', { type: 'discussion_reply', id: reply._id });
 
     // Re-index parent so search drops this reply's content (the index
@@ -965,7 +1010,15 @@ router.post('/:discussionId/replies/:replyId/reactions', requireAuth, async (req
     });
 
     if (existing) {
-      await DiscussionReaction.deleteOne({ _id: existing._id });
+      const del = await DiscussionReaction.deleteOne({ _id: existing._id });
+      // Symmetric cred (L-19): the reaction awarded +1 to the reply author, so
+      // removing it takes the point back — a react/un-react toggle loop nets
+      // zero instead of +1 per cycle (×8 kinds). Guarded by deletedCount so a
+      // concurrent double-un-react can't double-reverse; self-reactions never
+      // awarded cred, so they never reverse it either.
+      if (del.deletedCount > 0 && reply.author.toString() !== req.user.id) {
+        decrementCred(reply.author.toString(), 'reply_like_received').catch(() => {});
+      }
       const counts = await reactionCountsForReply(reply._id);
       return res.json({ reacted: false, kind, reactions: counts });
     }

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -8,7 +8,7 @@ const User = require('../models/User');
 const Follow = require('../models/Follow');
 const { resolveRating } = require('../utils/ratingUtils');
 const { stripHtml } = require('../utils/sanitize');
-const { incrementCred } = require('../utils/cellarCred');
+const { incrementCred, decrementCred } = require('../utils/cellarCred');
 const { logAudit } = require('../services/audit');
 const { updateWineCommunityRating } = require('../services/reviewAggregation');
 const { parsePagination } = require('../utils/pagination');
@@ -336,11 +336,21 @@ router.put('/:id', async (req, res) => {
     }
 
     if (vintage !== undefined) review.vintage = vintage;
+    const wasPublic = review.visibility === 'public';
     if (visibility !== undefined) {
       review.visibility = visibility === 'private' ? 'private' : 'public';
     }
 
     await review.save();
+
+    // Keep Cellar-Cred symmetric across visibility flips (L-19): the +3
+    // "public review" award tracks whether the review IS public, so flipping
+    // public→private reverses it and private→public re-awards it. A flip loop
+    // therefore nets zero, and deleting after going private can't dodge the
+    // reversal (the delete path only reverses currently-public reviews).
+    const isPublic = review.visibility === 'public';
+    if (wasPublic && !isPublic) decrementCred(req.user.id, 'review_created_public').catch(() => {});
+    if (!wasPublic && isPublic) incrementCred(req.user.id, 'review_created_public').catch(() => {});
 
     // Fire-and-forget: recalculate community rating
     updateWineCommunityRating(review.wineDefinition);
@@ -374,6 +384,20 @@ router.delete('/:id', async (req, res) => {
 
     const wineId = review.wineDefinition;
     const authorId = review.author;
+
+    // Reverse the Cellar-Cred this review awarded (L-19) — count the votes
+    // BEFORE they are deleted. The +3 public-review award is only reversed if
+    // the review is currently public (a private review either never earned it
+    // or already had it reversed on the public→private flip); like-cred was
+    // awarded per vote regardless of later visibility flips, so every vote is
+    // reversed. decrementCred clamps at 0.
+    const voteCount = await ReviewVote.countDocuments({ review: review._id });
+    if (review.visibility === 'public') {
+      decrementCred(authorId.toString(), 'review_created_public').catch(() => {});
+    }
+    if (voteCount > 0) {
+      decrementCred(authorId.toString(), 'review_like_received', voteCount).catch(() => {});
+    }
 
     await Review.deleteOne({ _id: review._id });
     // Clean up votes for this review
@@ -417,6 +441,10 @@ router.post('/:id/like', async (req, res) => {
       const del = await ReviewVote.deleteOne({ _id: existing._id });
       if (del.deletedCount > 0) {
         await Review.updateOne({ _id: review._id, likesCount: { $gt: 0 } }, { $inc: { likesCount: -1 } });
+        // Symmetric cred (L-19): the like awarded +1 to the author, so the
+        // unlike takes it back — a like/unlike toggle loop nets zero. Guarded
+        // by deletedCount so a concurrent double-unlike can't double-reverse.
+        decrementCred(review.author.toString(), 'review_like_received').catch(() => {});
       }
       const fresh = await Review.findById(review._id).select('likesCount').lean();
       res.json({ liked: false, likesCount: fresh?.likesCount ?? 0 });

--- a/backend/src/services/audit.js
+++ b/backend/src/services/audit.js
@@ -34,8 +34,24 @@ function logAudit(req, action, resource = {}, detail = {}) {
     userAgent: req?.headers?.['user-agent']
   };
 
-  // Structured stdout log — visible in docker logs
-  logger.info(entry, action);
+  // Structured stdout log — visible in docker logs. REDACTED (L-16): the
+  // container/log-aggregation stream is an independent copy of the audit trail
+  // with no TTL and no erasure path, so it must never carry identifiers. Only
+  // actor userId + role, the action, and the resource type/ids are emitted
+  // (pino stamps the timestamp). actor.ipAddress, the userAgent, and every
+  // detail field (username/email/sharedWith/invitedEmail, …) stay ONLY in the
+  // MongoDB copy below, which is TTL'd and scrubbed on account erasure. The
+  // redacted object is built by explicit field pick — not by deleting keys —
+  // so no nested detail field can leak through a missed path.
+  logger.info({
+    actor: { userId: entry.actor.userId, role: entry.actor.role },
+    action,
+    resource: {
+      type: resource.type ?? null,
+      id: resource.id ?? null,
+      cellarId: resource.cellarId ?? null,
+    },
+  }, action);
 
   // Persist to MongoDB asynchronously — never blocks the response
   AuditLog.create(entry).catch(err =>

--- a/backend/src/services/audit.test.js
+++ b/backend/src/services/audit.test.js
@@ -1,0 +1,83 @@
+/**
+ * Guards the L-16 stdout redaction: the pino stream is an independent copy of
+ * the audit trail with no TTL and no GDPR-erasure path, so it must never carry
+ * identifiers (IP, email, username, invitee addresses, user-agent). The full
+ * entry may only go to the MongoDB AuditLog (TTL'd + scrubbed on erasure).
+ */
+jest.mock('../models/AuditLog', () => ({
+  create: jest.fn().mockResolvedValue({}),
+}));
+
+const AuditLog = require('../models/AuditLog');
+const { logAudit, logger } = require('./audit');
+
+describe('logAudit stdout redaction (L-16)', () => {
+  let infoSpy;
+
+  const req = {
+    ip: '203.0.113.7',
+    user: { id: 'user123', roles: ['user'] },
+    headers: { 'user-agent': 'TestAgent/1.0' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => infoSpy.mockRestore());
+
+  it('emits only actor userId/role, action and resource ids to stdout', () => {
+    logAudit(
+      req,
+      'cellar.share.invite',
+      { type: 'cellar', id: 'c1', cellarId: 'c1' },
+      { invitedEmail: 'friend@example.com', sharedWith: 'friend@example.com', email: 'a@b.c', username: 'alice', role: 'viewer' }
+    );
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const [stdoutObj, msg] = infoSpy.mock.calls[0];
+    expect(msg).toBe('cellar.share.invite');
+    expect(stdoutObj).toEqual({
+      actor: { userId: 'user123', role: 'user' },
+      action: 'cellar.share.invite',
+      resource: { type: 'cellar', id: 'c1', cellarId: 'c1' },
+    });
+
+    // Belt and braces: no identifier can appear anywhere in the stdout line.
+    const serialized = JSON.stringify(stdoutObj);
+    expect(serialized).not.toContain('203.0.113.7');
+    expect(serialized).not.toContain('friend@example.com');
+    expect(serialized).not.toContain('alice');
+    expect(serialized).not.toContain('TestAgent');
+    expect(stdoutObj).not.toHaveProperty('detail');
+    expect(stdoutObj).not.toHaveProperty('userAgent');
+    expect(stdoutObj.actor).not.toHaveProperty('ipAddress');
+  });
+
+  it('still persists the FULL entry (incl. ip + detail) to the DB copy', () => {
+    logAudit(
+      req,
+      'auth.register',
+      { type: 'user', id: 'user123' },
+      { email: 'a@b.c', username: 'alice' }
+    );
+
+    expect(AuditLog.create).toHaveBeenCalledTimes(1);
+    const entry = AuditLog.create.mock.calls[0][0];
+    expect(entry.actor.ipAddress).toBe('203.0.113.7');
+    expect(entry.detail).toEqual({ email: 'a@b.c', username: 'alice' });
+    expect(entry.userAgent).toBe('TestAgent/1.0');
+  });
+
+  it('handles missing resource fields and system (null req) actors', () => {
+    logAudit(null, 'stripe.webhook', {}, { secret: 'nope' });
+
+    const [stdoutObj] = infoSpy.mock.calls[0];
+    expect(stdoutObj).toEqual({
+      actor: { userId: null, role: 'system' },
+      action: 'stripe.webhook',
+      resource: { type: null, id: null, cellarId: null },
+    });
+  });
+});

--- a/backend/src/services/communityPrice.js
+++ b/backend/src/services/communityPrice.js
@@ -4,6 +4,7 @@
  * currency, without ever converting across currencies.
  */
 const CommunityWinePrice = require('../models/CommunityWinePrice');
+const { FIRM_MIN_OWNERS } = require('../utils/communityPricing');
 
 function normCurrency(c) {
   return String(c || 'USD').toUpperCase();
@@ -20,9 +21,15 @@ function vintageDesc(a, b) {
  */
 async function getReleaseCurve(wineId, currency) {
   if (!wineId) return [];
+  // k-anonymity floor (security audit L-18): a vintage backed by fewer than
+  // FIRM_MIN_OWNERS (3) distinct owners would publish what is essentially one
+  // or two identifiable users' exact purchase price on a public, unauthenticated
+  // endpoint. The aggregation job no longer stores such rows, but this read-side
+  // filter also suppresses low-sample rows persisted before the change.
   const docs = await CommunityWinePrice.find({
     wineDefinition: wineId,
     currency: normCurrency(currency),
+    sampleSize: { $gte: FIRM_MIN_OWNERS },
   })
     .select('vintage medianPrice sampleSize confidence p25 p75 currency -_id')
     .lean();

--- a/backend/src/services/communityPriceJob.js
+++ b/backend/src/services/communityPriceJob.js
@@ -14,7 +14,7 @@ const Bottle = require('../models/Bottle');
 const CommunityWinePrice = require('../models/CommunityWinePrice');
 const { CONSUMED_STATUSES } = require('../config/constants');
 const { ABSOLUTE_CAP } = require('../utils/priceValidation');
-const { buildReleaseCurve, median } = require('../utils/communityPricing');
+const { buildReleaseCurve, median, FIRM_MIN_OWNERS } = require('../utils/communityPricing');
 
 /** Per-currency typical-maximum cap, falling back to USD. */
 function capFor(currency) {
@@ -102,7 +102,13 @@ async function runCommunityPriceAggregation() {
     }
 
     const curve = buildReleaseCurve(vintages);
-    const valid = curve.filter((c) => !c.suspect);
+    // Publish only non-suspect vintages with a k-anonymity floor of
+    // FIRM_MIN_OWNERS distinct owners (security audit L-18): a 1–2 owner
+    // "indicative" aggregate is effectively an individual user's exact
+    // purchase price, and CommunityWinePrice feeds a public endpoint.
+    // Sub-floor vintages drop out of validVintages, so the stale-cleanup
+    // below also deletes previously-stored low-sample rows.
+    const valid = curve.filter((c) => !c.suspect && c.sampleSize >= FIRM_MIN_OWNERS);
     const validVintages = valid.map((c) => c.vintage);
 
     if (valid.length > 0) {

--- a/backend/src/services/recommendationRetentionJob.js
+++ b/backend/src/services/recommendationRetentionJob.js
@@ -1,0 +1,39 @@
+/**
+ * Recommendation external-email retention scrub — runs daily via the scheduler.
+ *
+ * `Recommendation.recipientEmail` holds a NON-USER third party's address (the
+ * subject has no account, never consented, and has no Art. 17/21 mechanism of
+ * their own), so it must not be retained indefinitely (security audit L-15,
+ * GDPR data minimisation / storage limitation). After the recommendation email
+ * is dispatched the address serves exactly one purpose: showing the sender who
+ * their "sent" recommendation went to. So instead of deleting the user-visible
+ * recommendation document, this job blanks just the email once the document is
+ * older than the retention window — the same 90 days the PendingShare and
+ * Notification TTLs promise for comparable data.
+ *
+ * The per-user daily send cap in routes/recommendations.js only counts
+ * documents from the last 24 h with a non-null recipientEmail, so a 90-day
+ * scrub never affects it. Sender-account erasure scrubs the field immediately
+ * regardless of age (userDataRegistry.js).
+ */
+const Recommendation = require('../models/Recommendation');
+
+const RECIPIENT_EMAIL_RETENTION_DAYS = 90;
+
+async function runRecommendationEmailScrub() {
+  const cutoff = new Date(Date.now() - RECIPIENT_EMAIL_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+  const result = await Recommendation.updateMany(
+    { recipientEmail: { $ne: null }, createdAt: { $lt: cutoff } },
+    { $unset: { recipientEmail: '' } }
+  );
+  const scrubbed = result.modifiedCount || 0;
+  if (scrubbed > 0) {
+    console.log(
+      `[recommendationRetention] Scrubbed external recipientEmail from ${scrubbed} ` +
+      `recommendation(s) older than ${RECIPIENT_EMAIL_RETENTION_DAYS} days`
+    );
+  }
+  return { scrubbed };
+}
+
+module.exports = { runRecommendationEmailScrub, RECIPIENT_EMAIL_RETENTION_DAYS };

--- a/backend/src/services/recommendationRetentionJob.test.js
+++ b/backend/src/services/recommendationRetentionJob.test.js
@@ -1,0 +1,46 @@
+/**
+ * Guards the L-15 retention promise: external recipientEmail (third-party PII
+ * with no account-based erasure path) is blanked after 90 days while the
+ * user-visible recommendation document itself is kept.
+ */
+jest.mock('../models/Recommendation', () => ({
+  updateMany: jest.fn(),
+}));
+
+const Recommendation = require('../models/Recommendation');
+const {
+  runRecommendationEmailScrub,
+  RECIPIENT_EMAIL_RETENTION_DAYS,
+} = require('./recommendationRetentionJob');
+
+describe('runRecommendationEmailScrub (L-15)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('unsets recipientEmail only on external recs older than the retention window', async () => {
+    Recommendation.updateMany.mockResolvedValue({ modifiedCount: 4 });
+
+    const before = Date.now();
+    const result = await runRecommendationEmailScrub();
+    const after = Date.now();
+
+    expect(Recommendation.updateMany).toHaveBeenCalledTimes(1);
+    const [filter, update] = Recommendation.updateMany.mock.calls[0];
+
+    // Field is blanked, document is NOT deleted
+    expect(update).toEqual({ $unset: { recipientEmail: '' } });
+
+    // Only rows that still carry an email and are past the 90-day cutoff
+    expect(filter.recipientEmail).toEqual({ $ne: null });
+    const windowMs = RECIPIENT_EMAIL_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    expect(RECIPIENT_EMAIL_RETENTION_DAYS).toBe(90);
+    expect(filter.createdAt.$lt.getTime()).toBeGreaterThanOrEqual(before - windowMs);
+    expect(filter.createdAt.$lt.getTime()).toBeLessThanOrEqual(after - windowMs);
+
+    expect(result).toEqual({ scrubbed: 4 });
+  });
+
+  it('reports zero when nothing is old enough', async () => {
+    Recommendation.updateMany.mockResolvedValue({ modifiedCount: 0 });
+    await expect(runRecommendationEmailScrub()).resolves.toEqual({ scrubbed: 0 });
+  });
+});

--- a/backend/src/services/scheduler.js
+++ b/backend/src/services/scheduler.js
@@ -4,6 +4,7 @@ const { runCellarValueSnapshots } = require('./cellarValueSnapshotJob');
 const { runCommunityPriceAggregation } = require('./communityPriceJob');
 const { runUserDeletionJob } = require('./userDeletionJob');
 const { runCellarRetentionPurge } = require('./cellarRetentionJob');
+const { runRecommendationEmailScrub } = require('./recommendationRetentionJob');
 const { runSecurityAlertCheck } = require('./securityAlertJob');
 
 /**
@@ -63,6 +64,18 @@ function startScheduler() {
     }
   });
 
+  // External recipient-email retention scrub: daily at 04:30 UTC (after the
+  // cellar retention purge). Blanks Recommendation.recipientEmail on documents
+  // older than 90 days — third-party PII with no account-based erasure path.
+  cron.schedule('30 4 * * *', async () => {
+    console.log('[scheduler] Running recommendation email retention scrub…');
+    try {
+      await runRecommendationEmailScrub();
+    } catch (err) {
+      console.error('[scheduler] Recommendation email scrub failed:', err);
+    }
+  });
+
   // Security spike check: every 15 minutes. Cheap audit-log query, emails
   // only when thresholds are crossed (with 4h cooldown per spike type).
   cron.schedule('*/15 * * * *', async () => {
@@ -74,7 +87,7 @@ function startScheduler() {
     }
   });
 
-  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, cellar-retention daily 04:00 UTC, security-spike every 15 min)');
+  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, cellar-retention daily 04:00 UTC, recommendation-email-scrub daily 04:30 UTC, security-spike every 15 min)');
 }
 
 module.exports = { startScheduler };

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -263,8 +263,29 @@ const REGISTRY = [
     }),
   },
   {
-    model: DiscussionReply, category: 'shared-content', userFields: ['author'],
-    purge: (ctx) => DiscussionReply.updateMany({ author: ctx.userId }, { $set: { author: ctx.deletedUserId } }),
+    model: DiscussionReply, category: 'shared-content', userFields: ['author', 'quote.authorId'],
+    // Besides re-pointing the user's own replies to the [deleted] sentinel,
+    // scrub the user's display name from quote snapshots on OTHER users'
+    // replies (L-17): quote.authorName is a denormalised string set at
+    // reply-creation that any anonymous visitor can read. Rows are matched by
+    // quote.authorId; legacy rows created before authorId existed are resolved
+    // through quote.replyId → the user's own reply ids (collected BEFORE the
+    // author re-point runs). Residue: a legacy quote whose quoted reply was
+    // since hard-deleted cannot be attributed and keeps its name snapshot.
+    purge: async (ctx) => {
+      const ownReplyIds = await DiscussionReply.distinct('_id', { author: ctx.userId });
+      await Promise.all([
+        DiscussionReply.updateMany({ author: ctx.userId }, { $set: { author: ctx.deletedUserId } }),
+        DiscussionReply.updateMany(
+          { 'quote.authorId': ctx.userId },
+          { $set: { 'quote.authorName': '[deleted]', 'quote.authorId': ctx.deletedUserId } }
+        ),
+        DiscussionReply.updateMany(
+          { 'quote.authorId': null, 'quote.replyId': { $in: ownReplyIds } },
+          { $set: { 'quote.authorName': '[deleted]' } }
+        ),
+      ]);
+    },
     exportFragment: async (ctx) => ({
       discussionReplies: markTrunc(ctx, 'discussionReplies', await DiscussionReply.find({ author: ctx.userId }).select('discussion body quote wineDefinition isDeleted createdAt updatedAt').limit(EXPORT_MAX).lean())
         .map(r => ({ discussion: r.discussion, body: r.body, quote: r.quote, wineDefinition: r.wineDefinition, isDeleted: r.isDeleted, createdAt: r.createdAt, updatedAt: r.updatedAt })),
@@ -592,11 +613,16 @@ const REGISTRY = [
   {
     model: AuditLog, category: 'personal-data', userFields: ['actor.userId'],
     // Also scrub identifier PII the free-form detail can carry — registration/
-    // login events embed { username, email }. $unset only touches docs that
-    // actually have those keys, so it's safe across the heterogeneous detail shapes.
+    // login events embed { username, email }, and cellar-sharing events embed
+    // the invitee's address as { sharedWith } / { invitedEmail } (L-15). $unset
+    // only touches docs that actually have those keys, so it's safe across the
+    // heterogeneous detail shapes.
     purge: (ctx) => AuditLog.updateMany(
       { 'actor.userId': ctx.userId },
-      { $set: { 'actor.userId': null, 'actor.ipAddress': null }, $unset: { 'detail.email': '', 'detail.username': '' } }
+      {
+        $set: { 'actor.userId': null, 'actor.ipAddress': null },
+        $unset: { 'detail.email': '', 'detail.username': '', 'detail.sharedWith': '', 'detail.invitedEmail': '' },
+      }
     ),
     exportFragment: async (ctx) => ({
       activityLog: markTrunc(ctx, 'activityLog', await AuditLog.find({ 'actor.userId': ctx.userId }).sort({ timestamp: -1 }).limit(AUDIT_MAX).lean(), AUDIT_MAX)

--- a/backend/src/services/userDataRegistry.test.js
+++ b/backend/src/services/userDataRegistry.test.js
@@ -16,6 +16,8 @@ jest.mock('./search', () => ({
 const fs = require('fs');
 const path = require('path');
 const { REGISTRY, EXCLUDED, registeredModelNames } = require('./userDataRegistry');
+const DiscussionReply = require('../models/DiscussionReply');
+const AuditLog = require('../models/AuditLog');
 
 describe('userDataRegistry', () => {
   const modelsDir = path.join(__dirname, '..', 'models');
@@ -68,5 +70,81 @@ describe('userDataRegistry', () => {
   test('registry model names are unique', () => {
     const names = registeredModelNames();
     expect(new Set(names).size).toBe(names.length);
+  });
+
+  // L-15: cellar-sharing audit events embed the invitee's email in the
+  // free-form detail — the erasure scrub must blank those too.
+  test('AuditLog purge scrubs detail.sharedWith and detail.invitedEmail (L-15)', async () => {
+    const audit = REGISTRY.find(e => e.model.modelName === 'AuditLog');
+    const updateSpy = jest.spyOn(AuditLog, 'updateMany').mockResolvedValue({});
+
+    try {
+      await audit.purge({ userId: 'u1', deletedUserId: 'del1' });
+      expect(updateSpy).toHaveBeenCalledWith(
+        { 'actor.userId': 'u1' },
+        expect.objectContaining({
+          $set: { 'actor.userId': null, 'actor.ipAddress': null },
+          $unset: expect.objectContaining({
+            'detail.email': '',
+            'detail.username': '',
+            'detail.sharedWith': '',
+            'detail.invitedEmail': '',
+          }),
+        })
+      );
+    } finally {
+      updateSpy.mockRestore();
+    }
+  });
+});
+
+// L-17: a deleted user's display name must not survive erasure inside OTHER
+// users' reply quotes. The purge scrubs quote.authorName by quote.authorId,
+// and resolves legacy quotes (no authorId) through quote.replyId → the user's
+// own reply ids.
+describe('DiscussionReply purge — quote.authorName erasure (L-17)', () => {
+  const entry = REGISTRY.find(e => e.model.modelName === 'DiscussionReply');
+  const ctx = { userId: 'u1', deletedUserId: 'del1' };
+
+  let distinctSpy;
+  let updateSpy;
+
+  beforeEach(() => {
+    distinctSpy = jest.spyOn(DiscussionReply, 'distinct').mockResolvedValue(['r1', 'r2']);
+    updateSpy = jest.spyOn(DiscussionReply, 'updateMany').mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    distinctSpy.mockRestore();
+    updateSpy.mockRestore();
+  });
+
+  test('registers quote.authorId as a user field', () => {
+    expect(entry.userFields).toContain('quote.authorId');
+  });
+
+  test('re-points own replies AND anonymises quotes of the departing user', async () => {
+    await entry.purge(ctx);
+
+    // Own reply ids are collected BEFORE the author re-point (legacy quotes
+    // are resolvable only while author still equals the departing user).
+    expect(distinctSpy).toHaveBeenCalledWith('_id', { author: 'u1' });
+
+    const calls = updateSpy.mock.calls;
+    // 1) own replies re-pointed to the [deleted] sentinel
+    expect(calls).toContainEqual([
+      { author: 'u1' },
+      { $set: { author: 'del1' } },
+    ]);
+    // 2) quotes carrying the user's id: name scrubbed, id re-pointed
+    expect(calls).toContainEqual([
+      { 'quote.authorId': 'u1' },
+      { $set: { 'quote.authorName': '[deleted]', 'quote.authorId': 'del1' } },
+    ]);
+    // 3) legacy quotes (no authorId) resolved via the user's own reply ids
+    expect(calls).toContainEqual([
+      { 'quote.authorId': null, 'quote.replyId': { $in: ['r1', 'r2'] } },
+      { $set: { 'quote.authorName': '[deleted]' } },
+    ]);
   });
 });

--- a/backend/src/utils/cellarCred.js
+++ b/backend/src/utils/cellarCred.js
@@ -86,22 +86,37 @@ function getSpecialty(categories) {
 }
 
 /**
- * Atomically increment a user's contribution score and recompute the
- * tier/specialty badge. Does not touch the subscription plan. Fire-and-forget safe.
+ * Atomically adjust a user's contribution score by a signed multiple of an
+ * event's point value, clamped at 0, and recompute the tier/specialty badge.
+ * Does not touch the subscription plan. Fire-and-forget safe.
+ *
+ * Cred accounting is SYMMETRIC (security audit L-19): every award has a
+ * matching reversal (unlike/un-react toggles, content deletion, visibility
+ * flips), so toggle loops and create/delete cycles net to zero instead of
+ * inflating the publicly-displayed badge. The aggregation-pipeline update
+ * clamps both counters at 0 atomically, so reversing an award that predates
+ * this accounting (or a double reversal race) can never drive a score negative.
  */
-async function incrementCred(userId, eventType) {
+async function adjustCred(userId, eventType, count) {
   const points = POINT_VALUES[eventType];
   const category = CATEGORY_MAP[eventType];
-  if (!points || !category) return;
+  if (!points || !category || !count) return;
 
-  const inc = {
-    'contribution.totalScore': points,
-    [`contribution.categories.${category}`]: points,
-  };
+  const delta = points * count;
+  const catPath = `contribution.categories.${category}`;
 
   const user = await User.findByIdAndUpdate(
     userId,
-    { $inc: inc },
+    [{
+      $set: {
+        'contribution.totalScore': {
+          $max: [0, { $add: [{ $ifNull: ['$contribution.totalScore', 0] }, delta] }],
+        },
+        [catPath]: {
+          $max: [0, { $add: [{ $ifNull: [`$${catPath}`, 0] }, delta] }],
+        },
+      },
+    }],
     { new: true, select: 'contribution' }
   );
   if (!user) return;
@@ -120,4 +135,18 @@ async function incrementCred(userId, eventType) {
   }
 }
 
-module.exports = { POINT_VALUES, CATEGORY_MAP, TIERS, PLAN_RANK, getTier, getSpecialty, incrementCred };
+/** Award one event's points (tier/specialty recomputed, plan untouched). */
+function incrementCred(userId, eventType) {
+  return adjustCred(userId, eventType, 1);
+}
+
+/**
+ * Reverse `count` prior awards of an event (default 1). Used when the action
+ * that earned the points is undone: unlike/un-react, content deletion, or a
+ * public review going private. Clamped at 0 — never goes negative.
+ */
+function decrementCred(userId, eventType, count = 1) {
+  return adjustCred(userId, eventType, -Math.abs(count));
+}
+
+module.exports = { POINT_VALUES, CATEGORY_MAP, TIERS, PLAN_RANK, getTier, getSpecialty, incrementCred, decrementCred };

--- a/backend/src/utils/cellarCred.test.js
+++ b/backend/src/utils/cellarCred.test.js
@@ -4,7 +4,7 @@ jest.mock('../models/User', () => ({
 }));
 
 const User = require('../models/User');
-const { getTier, getSpecialty, POINT_VALUES, CATEGORY_MAP, incrementCred } = require('./cellarCred');
+const { getTier, getSpecialty, POINT_VALUES, CATEGORY_MAP, incrementCred, decrementCred } = require('./cellarCred');
 
 describe('getTier', () => {
   it('returns newcomer for 0', () => expect(getTier(0)).toBe('newcomer'));
@@ -98,5 +98,94 @@ describe('incrementCred — no plan rewards', () => {
     await incrementCred('user123', 'image_approved');
 
     expect(User.updateOne).not.toHaveBeenCalled();
+  });
+});
+
+// Helper: extract { totalDelta, catPath, catDelta } from the aggregation-
+// pipeline update passed to findByIdAndUpdate. The pipeline shape is
+// [{ $set: { 'contribution.totalScore': { $max: [0, { $add: [<ifNull>, delta] }] }, <catPath>: … } }]
+function pipelineDeltas() {
+  const [, update] = User.findByIdAndUpdate.mock.calls[0];
+  expect(Array.isArray(update)).toBe(true); // aggregation pipeline, not $inc
+  const set = update[0].$set;
+  const totalDelta = set['contribution.totalScore'].$max[1].$add[1];
+  const catPath = Object.keys(set).find(k => k.startsWith('contribution.categories.'));
+  const catDelta = set[catPath].$max[1].$add[1];
+  return { totalDelta, catPath, catDelta, set };
+}
+
+describe('symmetric cred accounting (L-19)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const freshContribution = (totalScore, categories, tier, specialty = null) => ({
+    contribution: { totalScore, categories, tier, specialty },
+  });
+
+  it('incrementCred applies +points to total and category, clamped at 0 via $max', async () => {
+    User.findByIdAndUpdate.mockResolvedValue(
+      freshContribution(3, { curator: 0, photographer: 0, critic: 3, community: 0 }, 'newcomer', 'critic')
+    );
+
+    await incrementCred('user123', 'review_created_public');
+
+    const { totalDelta, catPath, catDelta, set } = pipelineDeltas();
+    expect(totalDelta).toBe(POINT_VALUES.review_created_public);
+    expect(catPath).toBe('contribution.categories.critic');
+    expect(catDelta).toBe(POINT_VALUES.review_created_public);
+    // Clamp: both counters are wrapped in $max against 0
+    expect(set['contribution.totalScore'].$max[0]).toBe(0);
+    expect(set[catPath].$max[0]).toBe(0);
+  });
+
+  it('decrementCred reverses exactly what the event awarded', async () => {
+    User.findByIdAndUpdate.mockResolvedValue(
+      freshContribution(0, { curator: 0, photographer: 0, critic: 0, community: 0 }, 'newcomer')
+    );
+
+    await decrementCred('user123', 'reply_like_received');
+
+    const { totalDelta, catPath, catDelta } = pipelineDeltas();
+    expect(totalDelta).toBe(-POINT_VALUES.reply_like_received);
+    expect(catPath).toBe('contribution.categories.community');
+    expect(catDelta).toBe(-POINT_VALUES.reply_like_received);
+  });
+
+  it('decrementCred supports a count multiplier and always subtracts (sign-safe)', async () => {
+    User.findByIdAndUpdate.mockResolvedValue(
+      freshContribution(0, { curator: 0, photographer: 0, critic: 0, community: 0 }, 'newcomer')
+    );
+
+    await decrementCred('user123', 'review_like_received', 7);
+    let deltas = pipelineDeltas();
+    expect(deltas.totalDelta).toBe(-7 * POINT_VALUES.review_like_received);
+
+    jest.clearAllMocks();
+    User.findByIdAndUpdate.mockResolvedValue(
+      freshContribution(0, { curator: 0, photographer: 0, critic: 0, community: 0 }, 'newcomer')
+    );
+    // A negative count must not flip a decrement into an award
+    await decrementCred('user123', 'review_like_received', -7);
+    deltas = pipelineDeltas();
+    expect(deltas.totalDelta).toBe(-7 * POINT_VALUES.review_like_received);
+  });
+
+  it('decrementCred recomputes the tier downward when a threshold is crossed', async () => {
+    // After the reversal the user sits at 24 — back below the contributor line
+    User.findByIdAndUpdate.mockResolvedValue(
+      freshContribution(24, { curator: 0, photographer: 0, critic: 24, community: 0 }, 'contributor', 'critic')
+    );
+    User.updateOne.mockResolvedValue({});
+
+    await decrementCred('user123', 'review_created_public');
+
+    expect(User.updateOne).toHaveBeenCalledTimes(1);
+    const [, updateOp] = User.updateOne.mock.calls[0];
+    expect(updateOp.$set['contribution.tier']).toBe('newcomer');
+  });
+
+  it('is a no-op for unknown events and zero counts', async () => {
+    await decrementCred('user123', 'not_a_real_event');
+    await decrementCred('user123', 'review_like_received', 0);
+    expect(User.findByIdAndUpdate).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/utils/communityPricing.js
+++ b/backend/src/utils/communityPricing.js
@@ -12,8 +12,10 @@
  *    price-stable across vintages, so a single fat-fingered vintage stands out
  *    against its neighbours and is flagged `suspect` (and not published).
  *  - Confidence tier: >= FIRM_MIN_OWNERS distinct owners → 'firm' (median + IQR
- *    trim); 1–2 owners → 'indicative'. This is a trust label, not a privacy
- *    gate — both are shown to users.
+ *    trim); 1–2 owners → 'indicative'. The curve builder stays pure and emits
+ *    both, but FIRM_MIN_OWNERS doubles as the k-anonymity floor (security
+ *    audit L-18): the job and the read layer suppress sub-floor vintages, so
+ *    'indicative' rows are never published.
  */
 
 // >= this many distinct owners promotes a vintage from 'indicative' to 'firm'.

--- a/frontend/src/pages/Recommendations.js
+++ b/frontend/src/pages/Recommendations.js
@@ -153,7 +153,7 @@ export default function Recommendations() {
                       ? <Link to={`/users/${rec.recipient._id}`} className="rec-card__user">
                           {rec.recipient.displayName || rec.recipient.username}
                         </Link>
-                      : <span>{rec.recipientEmail}</span>
+                      : <span>{rec.recipientEmail || '—'}</span>
                     }
                   </span>
                 )}


### PR DESCRIPTION
Fixes the five Low findings **L-15 – L-19** from `SECURITY_AUDIT_2026-07-08.md`.

## L-15 — External `Recommendation.recipientEmail` unbounded retention
`recipientEmail` is a **non-user third party's** address with no account-based Art. 17/21 path. It *is* still needed after dispatch (the sender's "sent" list displays it — `Recommendations.js`), so instead of `$unset` at dispatch time the fix bounds retention:
- New daily job `services/recommendationRetentionJob.js` (04:30 UTC, wired into `scheduler.js`) blanks `recipientEmail` on recommendations **older than 90 days** — same window as the `PendingShare`/`Notification` TTLs. The user-visible recommendation document is kept.
- The 24h send-cap query in `routes/recommendations.js` is unaffected (only looks 24h back); sender-account erasure still scrubs immediately (`userDataRegistry.js`).
- The account-erasure **AuditLog scrub now also `$unset`s `detail.sharedWith` / `detail.invitedEmail`** (cellar-share events from `cellars.js:1489/1520`), alongside the existing email/username scrub.
- Frontend: sent-list falls back to `—` once the email is scrubbed.

## L-16 — PII on the stdout audit stream
`services/audit.js` now emits a **redacted** stdout line built by explicit field pick (not key deletion, so no nested `detail` path can slip through): `actor.userId` + `actor.role`, `action`, `resource.{type,id,cellarId}` (+ pino's timestamp). `actor.ipAddress`, `userAgent`, and the entire `detail` payload (username/email/sharedWith/invitedEmail, …) now exist **only** in the MongoDB `AuditLog` copy, which is TTL'd and erasure-scrubbed. New `audit.test.js` locks this in.

## L-17 — `quote.authorName` survives erasure
- `DiscussionReply.quote` gains **`authorId`** (ref User), set at reply creation from the quoted reply's author — future rows are directly addressable.
- The erasure purge (`userDataRegistry.js`) now, in addition to re-pointing the user's own replies: sets `quote.authorName → '[deleted]'` (+ re-points `quote.authorId` to the sentinel) on all replies quoting the departing user, and resolves **legacy rows without `authorId`** via `quote.replyId ∈ (the user's own reply ids)`, collected *before* the author re-point runs.
- **Honest residue:** a legacy quote whose quoted reply was since hard-deleted (e.g. the whole discussion was moderator-deleted) has no surviving attribution path and keeps its name snapshot. New rows always carry `authorId`, so the residue only shrinks.
- Purge behavior covered by new tests in `userDataRegistry.test.js`.

## L-18 — k-anonymity for community prices
Floor = `FIRM_MIN_OWNERS` (3 distinct owners), enforced in **both** layers:
- Write: `communityPriceJob.js` no longer stores sub-floor vintages, and because they drop out of `validVintages`, the existing stale-cleanup `deleteMany` sweeps previously-stored 1–2-owner rows on the next weekly run.
- Read: `services/communityPrice.js#getReleaseCurve` adds `sampleSize: { $gte: 3 }` — immediately protects the public `GET /api/wines/:idOrSlug/community-prices` endpoint (and the authed bottle-detail `currentRelease`) against rows persisted before the job re-runs.
- `buildReleaseCurve` stays pure/unchanged; comments updated ('indicative' rows are no longer published; enum value kept for legacy docs).

## L-19 — Cellar-Cred inflation (award-only counters)
`utils/cellarCred.js` refactored to a signed `adjustCred` with an **atomic aggregation-pipeline `$max`-clamp at 0** (never negative, even when reversing awards that predate this accounting); exports `decrementCred(userId, event, count)`. Tier/specialty recomputation unchanged (can now also move down). Reversals wired:
- **Review unlike** (`reviews.js`): −1 `review_like_received` to the author, guarded by `deletedCount` (no double-reverse on races) → like/unlike loops net zero.
- **Review delete** (incl. the user-facing own-review delete): reverses +3 `review_created_public` if currently public, and reverses `review_like_received` × vote count (counted before votes are deleted).
- **Review visibility flip** (PUT): public→private reverses +3, private→public awards it — closing the "flip private, then delete" escape and keeping flip loops at net zero.
- **Reaction un-react** (`discussions.js`): −1 `reply_like_received` (deletedCount-guarded; self-reactions never awarded, never reverse) → react/un-react loops net zero across all 8 kinds.
- **Reply soft-delete**: reverses +1 `discussion_reply_created`.
- **Discussion hard-delete** (mod/admin): batch-reverses +2 to the OP, +1 per live reply to its author (soft-deleted replies skipped — already reversed), and +1 per non-self reaction to the reacted reply's author; collected before deletion, applied after.
- **Honest residue:** replies soft-deleted *before* this change never had their +1 reversed and are skipped at discussion delete (can't distinguish) — bounded, pre-existing over-credit only; the clamp prevents any inverse under-flow.
- `cellarCred.test.js` extended (pipeline shape, sign-safety, count multiplier, downward tier recompute, no-op guards).

## Tests
`cd backend && npm test` → **44 suites, 804 tests, all passing** (was ~798; new suites: `audit.test.js`, `recommendationRetentionJob.test.js`, plus extended cred + registry suites).

## Docker Compose impact
**None.** No new env vars, ports, services, or images; the new retention job runs inside the existing backend scheduler. No migration needed — the L-18 legacy-row sweep and L-15 scrub happen automatically on their existing/new cron schedules, and the read-layer filters protect immediately on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)