### PR TITLE
fix: mongo DAC_OVERRIDE for existing volumes + cap Meili indexing memory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,13 @@ services:
     cap_drop:
       - ALL
     # Entrypoint starts as root, chowns /data/db, then gosu's down to the
-    # mongodb user — the minimal caps that dance needs.
+    # mongodb user — the minimal caps that dance needs. DAC_OVERRIDE is
+    # required for EXISTING volumes: the root entrypoint must traverse data
+    # files already owned by the mongodb user (0700 dirs), which a capless
+    # root cannot (a fresh volume boots without it; a restart with data fails).
     cap_add:
       - CHOWN
+      - DAC_OVERRIDE
       - SETGID
       - SETUID
     # WiredTiger cache must stay well under the container limit (512M below) —
@@ -45,6 +49,13 @@ services:
     environment:
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
       - MEILI_ENV=production
+      # Meilisearch budgets indexing memory as 2/3 of the HOST's RAM (it cannot
+      # see the cgroup limit) and spawns one indexing thread per host core — on
+      # any machine with real RAM that blows straight through the 256M container
+      # limit and OOM-crash-loops the first full reindex (restore drills, wiped
+      # volume, MEILI_FORCE_REINDEX). Budget must stay well under the limit.
+      - MEILI_MAX_INDEXING_MEMORY=128Mb
+      - MEILI_MAX_INDEXING_THREADS=2
     volumes:
       - meili-data:/meili_data
     deploy:


### PR DESCRIPTION
Two real bugs found by today's backup-restore drill (prod snapshot restored into the local compose stack), both introduced/exposed by the #634 hardening:

1. **mongo: add `DAC_OVERRIDE` to `cap_add`.** The `CHOWN,SETGID,SETUID` set was verified on a FRESH volume, but on an **existing** volume the root entrypoint must traverse `/data/db` files owned by the mongodb user (0700 dirs) — without `DAC_OVERRIDE` a capless root gets `find: Permission denied` and the container crash-loops unhealthy. Any self-hoster upgrading in place (data already present) would have hit this on their first restart after the hardening release; postgres/umami-db already had this cap.

2. **meilisearch: set `MEILI_MAX_INDEXING_MEMORY=128Mb` + `MEILI_MAX_INDEXING_THREADS=2`.** Meilisearch budgets indexing memory as 2/3 of the HOST's RAM (it cannot see the cgroup limit) and spawns one indexing thread per host core — any full reindex (wiped volume, restore drill, `MEILI_FORCE_REINDEX`) blows through the 256M container limit and OOM-crash-loops (observed: exit 137, 22 restarts). With the caps, a full prod-size reindex (2,973 wines + 4,849 bottles + discussions) completed with zero OOMs inside the 256M limit.

**docker-compose / prod impact:** the hand-maintained `docker-compose.prod.yml` should mirror BOTH changes when the hardening flags are copied over — the mongo cap is mandatory there (prod mongo volume is by definition existing data); the Meili env caps protect any future forced reindex on the 4GB VM.

Verified live: full stack rebuilt from scratch, prod snapshot (36k docs, 467MB uploads) restored, mongo healthy on existing data, full Meili reindex green, smoke suite passed (health, auth lifecycle incl. change-password + refresh cookie scope, Meili search, moderation endpoint, GDPR export, image serving, SEO crawler pages, security headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)