### PR TITLE
chore(release): v1.74.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for v1.74.0 (both package.json). This release carries PRs #598–#636:

- **Full non-security audit remediation** (CODE_AUDIT_2026-07-08): 3 HIGHs, ~31 MEDIUMs, LOW batches, shelf-rack import stride fix
- **Complete app-wide i18n** (en/sv, ~750 new keys — sv machine-authored)
- **Three new features**: change-password in Settings, admin/moderator moderation-reports screen, delete-own-review
- **Dead-code cleanup**: 15 dead endpoints removed, dead files/deps/exports, ~250 dead i18n keys, scripts archived
- **Full security-audit remediation** (SECURITY_AUDIT_2026-07-08): M-3 rating forgery, L-1..L-27 batches (auth/crypto, IDOR, DoS/upload, GDPR/integrity, Stripe race, container/nginx/CI hardening)
- **Compose fixes from the restore drill**: mongo DAC_OVERRIDE, Meili indexing-memory caps

**Deploy notes (prod):** Traefik frontend port label must flip 80→8080 in the same deploy (unprivileged nginx); prod .env: drop JWT_EXPIRES_IN; mirror hardening flags incl. mongo DAC_OVERRIDE + Meili caps into docker-compose.prod.yml; run migrate-wine-list-entries.js after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)