### PR TITLE
feat: per-bottle drink window (drinkFrom/drinkTo) + grapes on import

### DIFF
--- a/backend/src/models/Bottle.js
+++ b/backend/src/models/Bottle.js
@@ -102,6 +102,38 @@ const bottleSchema = new mongoose.Schema({
     enum: ['5', '20', '100'],
     default: '5'
   },
+  // Personal per-bottle drink window (calendar years) — the USER'S OWN intent,
+  // set by hand or imported (e.g. CellarTracker BeginConsume/EndConsume).
+  // Deliberately bottle-level: the shared registry's WineVintageProfile stays
+  // sommelier-curated and is never written by imports.
+  drinkFrom: {
+    type: Number,
+    min: [1900, 'Drink-from year must be 1900 or later'],
+    max: [2200, 'Drink-from year must be 2200 or earlier'],
+    validate: {
+      validator: v => v == null || Number.isInteger(v),
+      message: 'Drink-from must be a whole year'
+    }
+  },
+  drinkTo: {
+    type: Number,
+    min: [1900, 'Drink-to year must be 1900 or later'],
+    max: [2200, 'Drink-to year must be 2200 or earlier'],
+    validate: [
+      {
+        validator: v => v == null || Number.isInteger(v),
+        message: 'Drink-to must be a whole year'
+      },
+      {
+        // Cross-field: runs on save (full-document validation), so it also
+        // catches a drinkFrom edit that would invert an existing window.
+        validator: function(v) {
+          return v == null || this.drinkFrom == null || v >= this.drinkFrom;
+        },
+        message: 'Drink-to year cannot be before drink-from'
+      }
+    ]
+  },
   // Bottle lifecycle — 'active' until the user consumes/gifts/sells it
   status: {
     type: String,

--- a/backend/src/models/Bottle.test.js
+++ b/backend/src/models/Bottle.test.js
@@ -1,0 +1,65 @@
+/**
+ * Bottle schema — personal drink-window fields (drinkFrom/drinkTo).
+ *
+ * These are the user's OWN per-bottle drink window (hand-set or imported from
+ * CellarTracker BeginConsume/EndConsume) — deliberately bottle-level, so the
+ * shared registry's WineVintageProfile stays sommelier-curated. The schema is
+ * the last line of defence behind the route/import validation: integer years
+ * 1900–2200, and drinkTo may not precede drinkFrom.
+ *
+ * validateSync() only — no MongoDB needed.
+ */
+
+const mongoose = require('mongoose');
+const Bottle = require('./Bottle');
+
+function makeBottle(fields = {}) {
+  return new Bottle({
+    cellar: new mongoose.Types.ObjectId(),
+    user: new mongoose.Types.ObjectId(),
+    ...fields,
+  });
+}
+
+describe('Bottle.drinkFrom / drinkTo schema validation', () => {
+  test('bottle without a drink window validates (additive regression)', () => {
+    expect(makeBottle().validateSync()).toBeUndefined();
+  });
+
+  test('valid window validates', () => {
+    expect(makeBottle({ drinkFrom: 2018, drinkTo: 2046 }).validateSync()).toBeUndefined();
+  });
+
+  test('single-sided windows validate', () => {
+    expect(makeBottle({ drinkFrom: 2025 }).validateSync()).toBeUndefined();
+    expect(makeBottle({ drinkTo: 2035 }).validateSync()).toBeUndefined();
+  });
+
+  test('null values validate (clearing the window)', () => {
+    expect(makeBottle({ drinkFrom: null, drinkTo: null }).validateSync()).toBeUndefined();
+  });
+
+  test('bounds 1900–2200 are enforced on both fields', () => {
+    expect(makeBottle({ drinkFrom: 1899 }).validateSync().errors.drinkFrom).toBeDefined();
+    expect(makeBottle({ drinkTo: 2201 }).validateSync().errors.drinkTo).toBeDefined();
+    // Boundary years are fine
+    expect(makeBottle({ drinkFrom: 1900, drinkTo: 2200 }).validateSync()).toBeUndefined();
+  });
+
+  test('non-integer years are rejected', () => {
+    expect(makeBottle({ drinkFrom: 2020.5 }).validateSync().errors.drinkFrom.message)
+      .toMatch(/whole year/);
+    expect(makeBottle({ drinkTo: 2030.25 }).validateSync().errors.drinkTo.message)
+      .toMatch(/whole year/);
+  });
+
+  test('drinkTo before drinkFrom is rejected (cross-field)', () => {
+    const err = makeBottle({ drinkFrom: 2046, drinkTo: 2018 }).validateSync();
+    expect(err.errors.drinkTo.message).toMatch(/cannot be before/);
+  });
+
+  test('cross-field check passes when either side is missing', () => {
+    expect(makeBottle({ drinkFrom: 2046 }).validateSync()).toBeUndefined();
+    expect(makeBottle({ drinkTo: 2018 }).validateSync()).toBeUndefined();
+  });
+});

--- a/backend/src/routes/bottles.drinkWindow.test.js
+++ b/backend/src/routes/bottles.drinkWindow.test.js
@@ -1,0 +1,244 @@
+/**
+ * POST /api/bottles + PUT /api/bottles/:id — personal drink window fields.
+ *
+ * WHY THIS TEST EXISTS:
+ * drinkFrom/drinkTo are the user's own per-bottle drink window (integer years
+ * 1900–2200, from <= to). Unlike the import pipeline (which drops invalid
+ * values silently), the interactive bottle routes must answer 400 when an
+ * explicitly provided value is invalid — including a PARTIAL update whose new
+ * value would invert the window against the bottle's stored other half.
+ * Bottles without the fields must behave exactly as before (additive).
+ *
+ * Real router + real requireAuth/requireBottleAccess (HS256 test tokens);
+ * models and side-effect services are mocked so no MongoDB is needed.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+// services/search eagerly requires the ESM-only `meilisearch` package — stub.
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexBottle: jest.fn(),
+  removeBottle: jest.fn(),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/restockChecker', () => ({
+  checkRestockGap: jest.fn().mockResolvedValue(null),
+  resolveRestockAlerts: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../services/priceWarnings', () => ({ gatherPriceWarnings: jest.fn().mockResolvedValue([]) }));
+jest.mock('../services/communityPrice', () => ({ getCurrentRelease: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+  getSnapshotForDate: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+
+// ── Model mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => ({ updateMany: jest.fn() }));
+jest.mock('../models/Country', () => ({}));
+jest.mock('../models/Region', () => ({}));
+jest.mock('../models/Grape', () => ({}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('../models/PriceTrackingRequest', () => ({}));
+jest.mock('../models/BottleImage', () => ({}));
+jest.mock('../models/WineRequest', () => ({}));
+
+jest.mock('../models/Bottle', () => {
+  const instances = [];
+  function Bottle(data) {
+    Object.assign(this, data);
+    this._id = `bottle-${instances.length}`;
+    this.save = jest.fn().mockResolvedValue(this);
+    this.populate = jest.fn().mockResolvedValue(this);
+    instances.push(this);
+  }
+  Bottle.__instances = instances;
+  Bottle.findById = jest.fn();
+  return Bottle;
+});
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const WineDefinition = require('../models/WineDefinition');
+const Bottle = require('../models/Bottle');
+const bottlesRouter = require('./bottles');
+
+const USER_ID = '64b000000000000000000001';
+const CELLAR_ID = '64b0000000000000000000bb';
+const WINE_ID = '64b0000000000000000000cc';
+const BOTTLE_ID = '64b0000000000000000000dd';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles', bottlesRouter);
+  return app;
+}
+
+function request(app, method, url, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = body !== undefined ? JSON.stringify(body) : null;
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+            ...(payload ? { 'Content-Length': Buffer.byteLength(payload) } : {}),
+            authorization: `Bearer ${jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' })}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      if (payload) req.write(payload);
+      req.end();
+    });
+  });
+}
+
+const create = (body) => request(buildApp(), 'POST', '/api/bottles', body);
+const update = (body) => request(buildApp(), 'PUT', `/api/bottles/${BOTTLE_ID}`, body);
+
+let storedBottle;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Bottle.__instances.length = 0;
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, name: 'Main', user: USER_ID, members: [], deletedAt: null });
+  WineDefinition.findById.mockResolvedValue({ _id: WINE_ID, name: 'Test Wine' });
+  // Existing bottle for PUT — carries a stored window half for the
+  // partial-update inversion checks.
+  storedBottle = {
+    _id: BOTTLE_ID,
+    cellar: CELLAR_ID,
+    user: USER_ID,
+    vintage: '2018',
+    ratingScale: '5',
+    drinkFrom: 2020,
+    drinkTo: 2040,
+    save: jest.fn().mockImplementation(function () { return Promise.resolve(this); }),
+    populate: jest.fn().mockImplementation(function () { return Promise.resolve(this); }),
+  };
+  Bottle.findById.mockResolvedValue(storedBottle);
+});
+
+// ── POST /api/bottles ────────────────────────────────────────────────────────
+
+describe('POST /api/bottles drink window', () => {
+  const base = { cellar: CELLAR_ID, wineDefinition: WINE_ID, vintage: '2018' };
+
+  test('creates without the fields exactly as before (additive regression)', async () => {
+    const { status } = await create(base);
+    expect(status).toBe(201);
+    expect(Bottle.__instances).toHaveLength(1);
+    expect(Bottle.__instances[0].drinkFrom).toBeUndefined();
+    expect(Bottle.__instances[0].drinkTo).toBeUndefined();
+  });
+
+  test('accepts a valid window', async () => {
+    const { status, body } = await create({ ...base, drinkFrom: 2022, drinkTo: 2035 });
+    expect(status).toBe(201);
+    expect(Bottle.__instances[0].drinkFrom).toBe(2022);
+    expect(Bottle.__instances[0].drinkTo).toBe(2035);
+    expect(body.bottle.drinkFrom).toBe(2022);
+  });
+
+  test('accepts a single-sided window', async () => {
+    const { status } = await create({ ...base, drinkTo: 2035 });
+    expect(status).toBe(201);
+    expect(Bottle.__instances[0].drinkFrom).toBeUndefined();
+    expect(Bottle.__instances[0].drinkTo).toBe(2035);
+  });
+
+  test('400 when drinkFrom is after drinkTo', async () => {
+    const { status, body } = await create({ ...base, drinkFrom: 2040, drinkTo: 2020 });
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/drinkFrom cannot be after drinkTo/);
+    expect(Bottle.__instances).toHaveLength(0);
+  });
+
+  test('400 on out-of-range or non-integer years', async () => {
+    expect((await create({ ...base, drinkFrom: 1899 })).status).toBe(400);
+    expect((await create({ ...base, drinkTo: 9999 })).status).toBe(400);
+    expect((await create({ ...base, drinkFrom: 2020.5 })).status).toBe(400);
+    expect((await create({ ...base, drinkTo: 'soonish' })).status).toBe(400);
+    expect(Bottle.__instances).toHaveLength(0);
+  });
+});
+
+// ── PUT /api/bottles/:id ─────────────────────────────────────────────────────
+
+describe('PUT /api/bottles/:id drink window', () => {
+  test('updates both fields', async () => {
+    const { status } = await update({ drinkFrom: 2025, drinkTo: 2045 });
+    expect(status).toBe(200);
+    expect(storedBottle.drinkFrom).toBe(2025);
+    expect(storedBottle.drinkTo).toBe(2045);
+    expect(storedBottle.save).toHaveBeenCalled();
+  });
+
+  test('update without the fields leaves the stored window untouched (additive regression)', async () => {
+    const { status } = await update({ notes: 'just a note' });
+    expect(status).toBe(200);
+    expect(storedBottle.drinkFrom).toBe(2020);
+    expect(storedBottle.drinkTo).toBe(2040);
+  });
+
+  test('clears the window with nulls', async () => {
+    const { status } = await update({ drinkFrom: null, drinkTo: null });
+    expect(status).toBe(200);
+    expect(storedBottle.drinkFrom).toBeNull();
+    expect(storedBottle.drinkTo).toBeNull();
+  });
+
+  test('400 when the provided pair is inverted', async () => {
+    const { status, body } = await update({ drinkFrom: 2045, drinkTo: 2025 });
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/drinkFrom cannot be after drinkTo/);
+    expect(storedBottle.save).not.toHaveBeenCalled();
+  });
+
+  test('400 when a partial update inverts the window against the stored half', async () => {
+    // stored drinkFrom = 2020 — new drinkTo before it
+    expect((await update({ drinkTo: 2010 })).status).toBe(400);
+    // stored drinkTo = 2040 — new drinkFrom after it
+    expect((await update({ drinkFrom: 2050 })).status).toBe(400);
+    expect(storedBottle.save).not.toHaveBeenCalled();
+  });
+
+  test('partial update passes when the stored other half was cleared first', async () => {
+    storedBottle.drinkFrom = null;
+    const { status } = await update({ drinkTo: 2010 });
+    expect(status).toBe(200);
+    expect(storedBottle.drinkTo).toBe(2010);
+  });
+
+  test('400 on out-of-range years', async () => {
+    expect((await update({ drinkFrom: 1001 })).status).toBe(400);
+    expect((await update({ drinkTo: 9999 })).status).toBe(400);
+    expect(storedBottle.save).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -24,7 +24,7 @@ const { unlinkImageFiles } = require('../services/imageProcessor');
 const { gatherPriceWarnings } = require('../services/priceWarnings');
 const { getCurrentRelease } = require('../services/communityPrice');
 const { stripHtml, isSafeUrl, escapeRegex } = require('../utils/sanitize');
-const { parseAndValidateVintage } = require('../utils/validation');
+const { parseAndValidateVintage, parseDrinkYear } = require('../utils/validation');
 const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
 const { toNormalized } = require('../utils/ratingUtils');
 const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
@@ -361,6 +361,8 @@ router.post('/', async (req, res) => {
       notes,
       rating,
       ratingScale,
+      drinkFrom,
+      drinkTo,
       // Migration helpers — let users backdate bottles or add directly to history
       dateAdded,
       addToHistory,
@@ -389,6 +391,16 @@ router.post('/', async (req, res) => {
 
     const { rating: resolvedRating, ratingScale: resolvedRatingScale, error: ratingError } = resolveRating(rating, ratingScale);
     if (ratingError) return res.status(400).json({ error: ratingError });
+
+    // Personal per-bottle drink window — explicitly provided invalid values
+    // are a 400 (unlike the import pipeline, which drops them silently).
+    const drinkFromCheck = parseDrinkYear(drinkFrom, 'drinkFrom');
+    if (!drinkFromCheck.ok) return res.status(400).json({ error: drinkFromCheck.error });
+    const drinkToCheck = parseDrinkYear(drinkTo, 'drinkTo');
+    if (!drinkToCheck.ok) return res.status(400).json({ error: drinkToCheck.error });
+    if (drinkFromCheck.value !== undefined && drinkToCheck.value !== undefined && drinkFromCheck.value > drinkToCheck.value) {
+      return res.status(400).json({ error: 'drinkFrom cannot be after drinkTo' });
+    }
 
     // Validate add-to-history fields
     if (addToHistory) {
@@ -447,7 +459,9 @@ router.post('/', async (req, res) => {
       location: stripHtml(location),
       notes: stripHtml(notes),
       rating: resolvedRating,
-      ratingScale: resolvedRatingScale
+      ratingScale: resolvedRatingScale,
+      drinkFrom: drinkFromCheck.value,
+      drinkTo: drinkToCheck.value
     });
 
     // Allow backdating the "added" date for cellar migration
@@ -611,11 +625,29 @@ router.put('/:id', requireBottleAccess('editor'), async (req, res) => {
       req.body.bottleSize = normalizeBottleSize(req.body.bottleSize) || DEFAULT_SIZE;
     }
 
+    // Validate the personal drink-window years before the generic field-diff
+    // loop assigns them. Explicitly provided invalid values → 400; null/''
+    // clears the field. The from<=to check uses effective values so a partial
+    // update can't invert a window against the bottle's stored other half.
+    for (const field of ['drinkFrom', 'drinkTo']) {
+      if (field in req.body) {
+        const check = parseDrinkYear(req.body[field], field);
+        if (!check.ok) return res.status(400).json({ error: check.error });
+        req.body[field] = check.value ?? null;
+      }
+    }
+    const effDrinkFrom = 'drinkFrom' in req.body ? req.body.drinkFrom : bottle.drinkFrom;
+    const effDrinkTo = 'drinkTo' in req.body ? req.body.drinkTo : bottle.drinkTo;
+    if (effDrinkFrom != null && effDrinkTo != null && effDrinkFrom > effDrinkTo) {
+      return res.status(400).json({ error: 'drinkFrom cannot be after drinkTo' });
+    }
+
     // Update allowed fields — diff old vs new for the audit log
     const updateFields = [
       'vintage', 'price', 'currency', 'bottleSize',
       'purchaseDate', 'purchaseLocation', 'purchaseUrl',
-      'location', 'notes', 'rating', 'ratingScale'
+      'location', 'notes', 'rating', 'ratingScale',
+      'drinkFrom', 'drinkTo'
     ];
 
     // Normalize a value to a comparable string (handles Date objects vs ISO strings)

--- a/backend/src/routes/import.confirm.test.js
+++ b/backend/src/routes/import.confirm.test.js
@@ -1,0 +1,303 @@
+/**
+ * POST /api/bottles/import/confirm — additive grapes + drink-window fields.
+ *
+ * WHY THIS TEST EXISTS:
+ * The bottle-import confirm pipeline accepts two optional per-item fields
+ * emitted for CellarTracker imports: `grapes` (grape-name strings) and
+ * `drinkFrom`/`drinkTo` (integer years, the user's own per-bottle drink
+ * window). The import contract is ADDITIVE-ONLY:
+ *   - items WITHOUT the fields must behave exactly as before (regression),
+ *   - a matched registry wine is NEVER mutated (registry integrity — grapes
+ *     only flow into NEW wines, via WineRequest.suggestedGrapes on the
+ *     request-wine path),
+ *   - drinkFrom/drinkTo land on the created Bottle document itself — never on
+ *     the shared WineVintageProfile registry — and invalid values are
+ *     silently dropped, never failing the row.
+ *
+ * The real import router runs with the real requireAuth (HS256 test tokens)
+ * and the real parseDrinkYear validation; models are mocked so no MongoDB is
+ * needed (the full round-trip is covered by the Docker smoke test).
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+// services/search eagerly requires the ESM-only `meilisearch` package, which
+// Jest can't transform — stub it (matches the repo's unit-test style).
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexWine: () => {},
+  bulkIndexBottles: jest.fn(),
+}));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+
+// ── Model mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn(), find: jest.fn() }));
+jest.mock('../models/Country', () => ({ findOne: jest.fn() }));
+jest.mock('../models/ImportSession', () => ({}));
+
+jest.mock('../models/Rack', () => {
+  const model = { find: jest.fn() };
+  model.RACK_TYPES = ['grid', 'x-rack', 'hex', 'triangle', 'stack', 'cube', 'shelf'];
+  return model;
+});
+
+// Constructor mocks capture every instance so tests can inspect what the
+// route persisted without a live DB.
+jest.mock('../models/Bottle', () => {
+  const instances = [];
+  function Bottle(data) {
+    Object.assign(this, data);
+    this._id = `bottle-${instances.length}`;
+    this.save = jest.fn().mockResolvedValue(this);
+    instances.push(this);
+  }
+  Bottle.__instances = instances;
+  return Bottle;
+});
+
+jest.mock('../models/WineRequest', () => {
+  const instances = [];
+  function WineRequest(data) {
+    Object.assign(this, data);
+    this._id = `winereq-${instances.length}`;
+    this.save = jest.fn().mockResolvedValue(this);
+    instances.push(this);
+  }
+  WineRequest.__instances = instances;
+  return WineRequest;
+});
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const WineDefinition = require('../models/WineDefinition');
+const Bottle = require('../models/Bottle');
+const WineRequest = require('../models/WineRequest');
+const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
+const importRouter = require('./import');
+
+const USER_ID = '64b000000000000000000001';
+const CELLAR_ID = '64b0000000000000000000bb';
+const WINE_ID = '64b0000000000000000000cc';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles/import', importRouter);
+  return app;
+}
+
+function postJson(app, url, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' })}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.write(payload);
+      req.end();
+    });
+  });
+}
+
+const confirm = (items) => postJson(buildApp(), '/api/bottles/import/confirm', { cellarId: CELLAR_ID, items });
+
+let wineDoc;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Bottle.__instances.length = 0;
+  WineRequest.__instances.length = 0;
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, name: 'Main', user: USER_ID, members: [], deletedAt: null });
+  wineDoc = { _id: WINE_ID, name: 'Test Wine', producer: 'Test Prod', grapes: ['g-existing'] };
+  WineDefinition.findById.mockResolvedValue(wineDoc);
+});
+
+// ── Regression: items without the new fields ────────────────────────────────
+
+describe('additive regression (items without grapes/drink windows)', () => {
+  test('behaves as before: bottle created, pending profile seeded, no new fields set', async () => {
+    const { status, body } = await confirm([{ wineDefinition: WINE_ID, vintage: '2018', notes: 'plain row' }]);
+
+    expect(status).toBe(200);
+    // Response shape unchanged
+    expect(body).toEqual({
+      created: 1,
+      createdActive: 1,
+      createdHistory: 0,
+      skipped: [],
+      errors: [],
+      total: 1,
+      racksCreated: [],
+      placed: 0,
+      overflowed: 0,
+      unplaced: [],
+    });
+
+    expect(Bottle.__instances).toHaveLength(1);
+    const bottle = Bottle.__instances[0];
+    expect(bottle.save).toHaveBeenCalled();
+    expect(bottle.drinkFrom).toBeUndefined();
+    expect(bottle.drinkTo).toBeUndefined();
+    expect(ensurePendingVintageProfile).toHaveBeenCalledWith(WINE_ID, '2018');
+    expect(WineRequest.__instances).toHaveLength(0);
+  });
+
+  test('request-wine row without grapes creates a WineRequest without suggestedGrapes', async () => {
+    const { status, body } = await confirm([{ requestWine: true, wineName: 'Mystery', producer: 'Someone', vintage: '2019' }]);
+    expect(status).toBe(200);
+    expect(body.created).toBe(1);
+    expect(WineRequest.__instances).toHaveLength(1);
+    expect(WineRequest.__instances[0]).not.toHaveProperty('suggestedGrapes');
+  });
+});
+
+// ── Grapes ───────────────────────────────────────────────────────────────────
+
+describe('item.grapes', () => {
+  test('matched registry wine is NEVER mutated by import grapes', async () => {
+    const { status, body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', grapes: ['Syrah', 'Grenache'] },
+    ]);
+
+    expect(status).toBe(200);
+    expect(body.created).toBe(1);
+    expect(body.errors).toEqual([]);
+    // Registry integrity: the shared wine's grapes are untouched
+    expect(wineDoc.grapes).toEqual(['g-existing']);
+    expect(WineRequest.__instances).toHaveLength(0);
+  });
+
+  test('request-wine path carries sanitized grapes as WineRequest.suggestedGrapes', async () => {
+    const { status, body } = await confirm([
+      {
+        requestWine: true,
+        wineName: 'Mystery Red',
+        producer: 'Unknown Estate',
+        vintage: '2019',
+        // 7 entries incl. junk — sanitizer trims, drops empties, caps at 5
+        grapes: ['  Syrah  ', '', 'Grenache', 'Mourvèdre', 'Cinsault', 'Counoise', 'Carignan'],
+      },
+    ]);
+
+    expect(status).toBe(200);
+    expect(body.created).toBe(1);
+    expect(WineRequest.__instances).toHaveLength(1);
+    expect(WineRequest.__instances[0].suggestedGrapes)
+      .toEqual(['Syrah', 'Grenache', 'Mourvèdre', 'Cinsault', 'Counoise']);
+    expect(WineRequest.__instances[0].status).toBe('pending');
+  });
+});
+
+// ── Drink windows (per-bottle personal fields) ───────────────────────────────
+
+describe('item.drinkFrom / item.drinkTo', () => {
+  test('valid window lands on the created bottle (matched-wine path)', async () => {
+    const { status, body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', drinkFrom: 2018, drinkTo: 2046 },
+    ]);
+
+    expect(status).toBe(200);
+    expect(body.created).toBe(1);
+    expect(Bottle.__instances[0].drinkFrom).toBe(2018);
+    expect(Bottle.__instances[0].drinkTo).toBe(2046);
+    // Somm queue seeding still runs as before — registry untouched otherwise
+    expect(ensurePendingVintageProfile).toHaveBeenCalledWith(WINE_ID, '2018');
+  });
+
+  test('valid window lands on the created bottle (request-wine path)', async () => {
+    const { body } = await confirm([
+      { requestWine: true, wineName: 'Mystery', producer: 'Someone', vintage: '2019', drinkFrom: 2022, drinkTo: 2030 },
+    ]);
+
+    expect(body.created).toBe(1);
+    expect(Bottle.__instances[0].drinkFrom).toBe(2022);
+    expect(Bottle.__instances[0].drinkTo).toBe(2030);
+  });
+
+  test('numeric strings are accepted (CSV-sourced values)', async () => {
+    const { body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', drinkFrom: '2020', drinkTo: '2035' },
+    ]);
+    expect(body.created).toBe(1);
+    expect(Bottle.__instances[0].drinkFrom).toBe(2020);
+    expect(Bottle.__instances[0].drinkTo).toBe(2035);
+  });
+
+  test('single-sided window keeps the provided side', async () => {
+    const { body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', drinkFrom: 2025 },
+    ]);
+    expect(body.created).toBe(1);
+    expect(Bottle.__instances[0].drinkFrom).toBe(2025);
+    expect(Bottle.__instances[0].drinkTo).toBeUndefined();
+  });
+
+  test('from > to is silently dropped whole — the row still imports', async () => {
+    const { body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', drinkFrom: 2046, drinkTo: 2018 },
+    ]);
+
+    expect(body.created).toBe(1);
+    expect(body.errors).toEqual([]);
+    expect(Bottle.__instances[0].drinkFrom).toBeUndefined();
+    expect(Bottle.__instances[0].drinkTo).toBeUndefined();
+  });
+
+  test('sentinel years 1001/9999 are re-guarded server-side and dropped', async () => {
+    const { body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', drinkFrom: 1001, drinkTo: 2030 },
+      { wineDefinition: WINE_ID, vintage: '2018', drinkFrom: 2018, drinkTo: 9999 },
+    ]);
+
+    expect(body.created).toBe(2);
+    expect(body.errors).toEqual([]);
+    // Invalid side dropped, valid side kept
+    expect(Bottle.__instances[0].drinkFrom).toBeUndefined();
+    expect(Bottle.__instances[0].drinkTo).toBe(2030);
+    expect(Bottle.__instances[1].drinkFrom).toBe(2018);
+    expect(Bottle.__instances[1].drinkTo).toBeUndefined();
+  });
+
+  test('non-integer junk is dropped without failing the row', async () => {
+    const { body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', drinkFrom: 'soonish', drinkTo: 2030.5 },
+    ]);
+
+    expect(body.created).toBe(1);
+    expect(Bottle.__instances[0].drinkFrom).toBeUndefined();
+    expect(Bottle.__instances[0].drinkTo).toBeUndefined();
+  });
+});

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -24,8 +24,8 @@ const {
   MAX_IMPORT_SIZE,
   AI_CONCURRENCY,
 } = require('../config/constants');
-const { stripHtml, escapeRegex } = require('../utils/sanitize');
-const { parseAndValidateVintage } = require('../utils/validation');
+const { stripHtml, escapeRegex, sanitizeGrapeNames } = require('../utils/sanitize');
+const { parseAndValidateVintage, parseDrinkYear } = require('../utils/validation');
 const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
 const { extractAiExplanation } = require('../utils/jsonExtract');
 const { getMaxPosition } = require('../utils/rackGeometry');
@@ -271,7 +271,17 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
         else pr.aiWineError = cached.error;
       } else {
         try {
-          const { wine, created } = await findOrCreateWine(pr.aiIdentified, req.user.id);
+          // Import-supplied grape names (optional `item.grapes`, e.g. from a
+          // CellarTracker export) supplement the AI identification only when
+          // the AI returned no grapes of its own. findOrCreateWine resolves
+          // grape taxonomy (synonyms, find-or-create) and only applies grapes
+          // when it CREATES a wine — matched registry wines are never mutated.
+          const importGrapes = sanitizeGrapeNames(pr.item.grapes);
+          const aiHasGrapes = Array.isArray(pr.aiIdentified.grapes) && pr.aiIdentified.grapes.length > 0;
+          const wineData = (importGrapes.length > 0 && !aiHasGrapes)
+            ? { ...pr.aiIdentified, grapes: importGrapes }
+            : pr.aiIdentified;
+          const { wine, created } = await findOrCreateWine(wineData, req.user.id);
           createdWineCache.set(key, { wine, created });
           pr.aiWine = wine;
           pr.aiWineCreated = created;
@@ -401,6 +411,14 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
  * Each item must have a confirmed wineDefinition ID.
  *
  * Body: { cellarId, items: [{ wineDefinition, vintage, price, currency, ... }] }
+ * Optional per-item fields (additive — items without them behave as before):
+ *   grapes          — array of grape-name strings; suggestions for NEW wines
+ *                     only (request-wine path → WineRequest.suggestedGrapes);
+ *                     matched registry wines are never mutated
+ *   drinkFrom/drinkTo — integer years (1900–2200, from <= to); stored as the
+ *                     user's own per-bottle drink window (Bottle.drinkFrom/
+ *                     drinkTo — never the shared registry). Invalid values
+ *                     are silently dropped, never failing the row.
  * Response: { created, skipped, errors[] }
  */
 router.post('/confirm', async (req, res) => {
@@ -596,6 +614,21 @@ router.post('/confirm', async (req, res) => {
       try {
         let wineDoc = null;
 
+        // Optional personal drink window (drinkFrom/drinkTo years, e.g.
+        // CellarTracker BeginConsume/EndConsume) — stored on the bottle
+        // itself, never on the shared registry. Invalid values are silently
+        // dropped: a bad imported year must never fail the row. An inverted
+        // pair (from > to) is dropped whole — we can't tell which side is
+        // wrong. undefined fields are simply omitted from the document.
+        const fromCheck = parseDrinkYear(item.drinkFrom, 'drinkFrom');
+        const toCheck = parseDrinkYear(item.drinkTo, 'drinkTo');
+        let drinkFrom = fromCheck.ok ? fromCheck.value : undefined;
+        let drinkTo = toCheck.ok ? toCheck.value : undefined;
+        if (drinkFrom !== undefined && drinkTo !== undefined && drinkFrom > drinkTo) {
+          drinkFrom = undefined;
+          drinkTo = undefined;
+        }
+
         if (item.requestWine) {
           // No match — create a pending WineRequest and bottle without wineDefinition
           if (!item.wineName && !item.producer) {
@@ -607,12 +640,18 @@ router.post('/confirm', async (req, res) => {
           let wineRequest = pendingRequestCache.get(requestKey);
 
           if (!wineRequest) {
+            // Optional import-supplied grape names ride along as suggestions —
+            // the admin sees them when resolving the request and decides which
+            // taxonomy grapes the new wine definition gets (registry integrity:
+            // imports never write taxonomy directly on this path).
+            const suggestedGrapes = sanitizeGrapeNames(item.grapes);
             wineRequest = new WineRequest({
               requestType: 'new_wine',
               wineName: (item.wineName || item.producer || '').trim(),
               producer: (item.producer || '').trim() || undefined,
               user: req.user.id,
-              status: 'pending'
+              status: 'pending',
+              ...(suggestedGrapes.length > 0 ? { suggestedGrapes } : {})
             });
             await wineRequest.save();
             pendingRequestCache.set(requestKey, wineRequest);
@@ -658,7 +697,9 @@ router.post('/confirm', async (req, res) => {
             location: stripHtml(item.location),
             notes: stripHtml(item.notes),
             rating: resolvedRating,
-            ratingScale: resolvedScale
+            ratingScale: resolvedScale,
+            drinkFrom,
+            drinkTo
           });
 
           if (item.dateAdded) bottle.createdAt = new Date(item.dateAdded);
@@ -748,7 +789,9 @@ router.post('/confirm', async (req, res) => {
           location: stripHtml(item.location),
           notes: stripHtml(item.notes),
           rating: resolvedRating,
-          ratingScale: resolvedScale
+          ratingScale: resolvedScale,
+          drinkFrom,
+          drinkTo
         });
 
         // Allow backdating

--- a/backend/src/utils/sanitize.js
+++ b/backend/src/utils/sanitize.js
@@ -60,4 +60,32 @@ function escapeRegex(str) {
   return String(str ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-module.exports = { stripHtml, isSafeUrl, escapeRegex };
+/**
+ * Sanitizes a user-supplied array of grape-name strings from a bottle import.
+ *
+ * Additive import contract (CellarTracker `item.grapes`): entries are already
+ * trimmed client-side, but re-guard server-side — drop non-strings and empties,
+ * strip HTML, cap each name at `maxLen` chars, dedupe case-insensitively and
+ * keep at most `max` entries. Non-array input yields [] so callers never throw.
+ *
+ * Returns plain strings — taxonomy resolution (synonym mapping, find-or-create)
+ * stays in services/findOrCreateWine.findOrCreateGrapes.
+ */
+function sanitizeGrapeNames(raw, { max = 5, maxLen = 100 } = {}) {
+  if (!Array.isArray(raw)) return [];
+  const out = [];
+  const seen = new Set();
+  for (const entry of raw) {
+    if (out.length >= max) break;
+    if (typeof entry !== 'string') continue;
+    const name = (stripHtml(entry) || '').trim().slice(0, maxLen);
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(name);
+  }
+  return out;
+}
+
+module.exports = { stripHtml, isSafeUrl, escapeRegex, sanitizeGrapeNames };

--- a/backend/src/utils/sanitize.test.js
+++ b/backend/src/utils/sanitize.test.js
@@ -1,4 +1,41 @@
-const { stripHtml, isSafeUrl } = require('./sanitize');
+const { stripHtml, isSafeUrl, sanitizeGrapeNames } = require('./sanitize');
+
+// ─── sanitizeGrapeNames ──────────────────────────────────────────────────────
+
+describe('sanitizeGrapeNames', () => {
+  test('non-array input yields [] (never throws)', () => {
+    expect(sanitizeGrapeNames(undefined)).toEqual([]);
+    expect(sanitizeGrapeNames(null)).toEqual([]);
+    expect(sanitizeGrapeNames('Syrah')).toEqual([]);
+    expect(sanitizeGrapeNames({ length: 1e12 })).toEqual([]);
+  });
+
+  test('trims entries and drops empties and non-strings', () => {
+    expect(sanitizeGrapeNames(['  Syrah  ', '', '   ', 42, null, 'Grenache']))
+      .toEqual(['Syrah', 'Grenache']);
+  });
+
+  test('strips HTML from grape names', () => {
+    expect(sanitizeGrapeNames(['<b>Syrah</b>', '<script>x</script>Merlot']))
+      .toEqual(['Syrah', 'xMerlot']);
+  });
+
+  test('caps at 5 grapes by default', () => {
+    const many = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+    expect(sanitizeGrapeNames(many)).toEqual(['A', 'B', 'C', 'D', 'E']);
+  });
+
+  test('caps each name at 100 chars', () => {
+    const long = 'x'.repeat(250);
+    const [out] = sanitizeGrapeNames([long]);
+    expect(out).toHaveLength(100);
+  });
+
+  test('dedupes case-insensitively, keeps first casing', () => {
+    expect(sanitizeGrapeNames(['Syrah', 'syrah', 'SYRAH', 'Merlot']))
+      .toEqual(['Syrah', 'Merlot']);
+  });
+});
 
 // ─── stripHtml ───────────────────────────────────────────────────────────────
 

--- a/backend/src/utils/validation.js
+++ b/backend/src/utils/validation.js
@@ -81,4 +81,41 @@ function parseAndValidateVintage(raw, { now = new Date() } = {}) {
   return { ok: true, value: String(year) };
 }
 
-module.exports = { isValidId, coerceStringQuery, parseAndValidateVintage, MIN_VINTAGE_YEAR };
+// Bounds for the personal per-bottle drink window (Bottle.drinkFrom/drinkTo).
+// Must match the Bottle schema's min/max. The lower bound also re-guards the
+// CellarTracker "unknown" sentinel 1001, the upper bound the sentinel 9999,
+// in case a client didn't strip them.
+const DRINK_YEAR_MIN = 1900;
+const DRINK_YEAR_MAX = 2200;
+
+/**
+ * Parse an optional drink-window boundary year (drinkFrom / drinkTo).
+ *
+ * Returns one of:
+ *   { ok: true,  value: undefined } — not provided (undefined/null/'')
+ *   { ok: true,  value: 2035 }      — valid integer year in bounds
+ *   { ok: false, error: '...' }     — provided but not a whole year in
+ *                                     [DRINK_YEAR_MIN, DRINK_YEAR_MAX]
+ *
+ * Callers decide severity: the bottle routes answer 400 on an explicitly
+ * provided invalid value; the import pipeline drops it silently (a bad
+ * imported year must never fail the row).
+ *
+ * Accepts numbers and numeric strings (CSV-sourced values).
+ */
+function parseDrinkYear(raw, label = 'Drink year') {
+  if (raw === undefined || raw === null || raw === '') return { ok: true, value: undefined };
+  // Only scalar inputs — Number([2020]) coerces to 2020, so an array/object
+  // body value (e.g. ?x[$gt]= shapes) must not sneak through as a year.
+  if (typeof raw !== 'number' && typeof raw !== 'string') {
+    return { ok: false, error: `${label} must be a whole year` };
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return { ok: false, error: `${label} must be a whole year` };
+  if (n < DRINK_YEAR_MIN || n > DRINK_YEAR_MAX) {
+    return { ok: false, error: `${label} ${n} is out of range (${DRINK_YEAR_MIN}–${DRINK_YEAR_MAX})` };
+  }
+  return { ok: true, value: n };
+}
+
+module.exports = { isValidId, coerceStringQuery, parseAndValidateVintage, parseDrinkYear, MIN_VINTAGE_YEAR, DRINK_YEAR_MIN, DRINK_YEAR_MAX };

--- a/backend/src/utils/validation.test.js
+++ b/backend/src/utils/validation.test.js
@@ -105,3 +105,38 @@ describe('parseAndValidateVintage', () => {
     expect(parseAndValidateVintage('two thousand', { now }).ok).toBe(false);
   });
 });
+
+describe('parseDrinkYear', () => {
+  const { parseDrinkYear } = require('./validation');
+
+  it('treats undefined/null/empty as "not provided"', () => {
+    expect(parseDrinkYear(undefined)).toEqual({ ok: true, value: undefined });
+    expect(parseDrinkYear(null)).toEqual({ ok: true, value: undefined });
+    expect(parseDrinkYear('')).toEqual({ ok: true, value: undefined });
+  });
+
+  it('accepts integer years in 1900-2200, incl. numeric strings', () => {
+    expect(parseDrinkYear(2035)).toEqual({ ok: true, value: 2035 });
+    expect(parseDrinkYear('2035')).toEqual({ ok: true, value: 2035 });
+    expect(parseDrinkYear(1900)).toEqual({ ok: true, value: 1900 });
+    expect(parseDrinkYear(2200)).toEqual({ ok: true, value: 2200 });
+  });
+
+  it('rejects out-of-range years, incl. the CellarTracker sentinels 1001/9999', () => {
+    expect(parseDrinkYear(1001).ok).toBe(false);
+    expect(parseDrinkYear(9999).ok).toBe(false);
+    expect(parseDrinkYear(1899).ok).toBe(false);
+    expect(parseDrinkYear(2201).ok).toBe(false);
+  });
+
+  it('rejects non-integer values', () => {
+    expect(parseDrinkYear(2020.5).ok).toBe(false);
+    expect(parseDrinkYear('soonish').ok).toBe(false);
+    expect(parseDrinkYear({ evil: true }).ok).toBe(false);
+    expect(parseDrinkYear([2020]).ok).toBe(false);
+  });
+
+  it('labels the error with the field name', () => {
+    expect(parseDrinkYear(9999, 'drinkTo').error).toMatch(/drinkTo/);
+  });
+});


### PR DESCRIPTION
## What

Two additive per-item fields for the bottle-import confirm pipeline (emitted by the parallel CellarTracker-import frontend PR), plus first-class support for a personal per-bottle drink window in the normal bottle routes.

### Interface contract (agreed with the frontend PR)

- `item.grapes` — optional array of grape-name strings (already trimmed client-side; may contain names not in the taxonomy).
- `item.drinkFrom` / `item.drinkTo` — optional integer years (e.g. 2018 / 2046), null/absent when unknown. The CellarTracker sentinels (1001/9999) are stripped client-side but **re-guarded server-side** via the 1900–2200 bounds.

### Design decision: bottle-level, not registry-level

`drinkFrom`/`drinkTo` are new fields on the **Bottle** schema — the user's own drink window (imported from CellarTracker BeginConsume/EndConsume or set by hand). They deliberately do **not** touch `WineVintageProfile`: the registry's vintage profiles remain sommelier-curated data and are never written by imports (registry integrity). The existing `ensurePendingVintageProfile` somm-queue seeding is unchanged.

### Changes

- **`models/Bottle.js`** — `drinkFrom`/`drinkTo`: Number, integer-validated, 1900–2200, cross-field validator rejects `drinkTo < drinkFrom` (runs on save, so a `drinkFrom` edit can't invert an existing window either).
- **`routes/import.js` (confirm)** — maps `item.drinkFrom`/`drinkTo` onto the created bottle in **both** branches (matched wine and request-wine). Invalid values are dropped **silently** per side (an inverted pair is dropped whole — we can't tell which side is wrong); a bad imported year never fails the row. Response shape unchanged.
- **`routes/import.js` (grapes)** —
  - request-wine path: sanitized grapes ride along as `WineRequest.suggestedGrapes`, so the admin sees them when resolving and decides what the new wine definition gets.
  - AI path (`/validate`): import grapes supplement `findOrCreateWine` **only when the AI returned no grapes of its own**; `findOrCreateWine` already resolves grape taxonomy (synonyms, find-or-create) and only applies grapes when it **creates** a wine — matched registry wines are never mutated.
  - Sanitizer (`utils/sanitize.sanitizeGrapeNames`): max 5, each trimmed/HTML-stripped/≤100 chars, empties dropped, case-insensitive dedupe.
- **`routes/bottles.js`** — POST create and PUT update accept `drinkFrom`/`drinkTo` with strict validation (400 on out-of-range/non-integer/inverted, matching the routes' existing style — unlike the import's silent drop). PUT supports clearing with `null` and checks inversion against *effective* values, so a partial update can't invert the stored other half. Shared validation lives in `utils/validation.parseDrinkYear`.
- Edits kept tightly scoped to `drinkFrom`/`drinkTo` in the shared schema/route spots so the parallel `occasion` PR merges cleanly.

### GDPR

These fields are covered with no registry change needed: bottle export in `services/userDataRegistry.js` returns whole `Bottle` documents (`.find(...).lean()`, no projection), so `drinkFrom`/`drinkTo` are automatically included in `GET /api/users/me/export`, and the existing Bottle deletion cascade removes them on account deletion. `grapes` never persist as user data — they land either on the shared wine definition (registry data) or as `WineRequest.suggestedGrapes` (already registered via WineRequest). No new personal-data category, no consent change.

### Tests

New suites (mocked models, no MongoDB): `models/Bottle.test.js`, `routes/import.confirm.test.js`, `routes/bottles.drinkWindow.test.js`, plus `parseDrinkYear` and `sanitizeGrapeNames` unit tests. Cover: new-wine grapes flow, matched-wine grapes NOT mutated, window mapped onto the bottle on both import branches, invalid/inverted/sentinel windows dropped silently on import vs 400 on the bottle routes, partial-update inversion, and byte-identical behavior for items without the fields.

**Full backend suite: 56 suites, 916 tests, all green.**

### Docker / compose impact

None — backend-only code change, no new env vars, no new services, no schema migration needed (new fields are optional; existing bottles simply lack them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)