### PR TITLE
fix: cap and gate cellar-import parsing (audit L-12)

### DIFF
--- a/backend/src/routes/cellarImport.js
+++ b/backend/src/routes/cellarImport.js
@@ -27,11 +27,42 @@ router.use(requireAuth);
 
 // The ZIP can hold many images; cap generously but bound memory (entries are
 // buffered). A data-only JSON is tiny; the cap mainly guards the image ZIP.
-const MAX_UPLOAD_BYTES = 200 * 1024 * 1024; // 200 MB
+// Any real export with images beyond this belongs behind the (prod) nginx
+// 50 MB body cap anyway — 64 MB bounds a directly-exposed backend too.
+const MAX_UPLOAD_BYTES = 64 * 1024 * 1024; // 64 MB
+// data.json alone (uploaded raw or extracted from the ZIP) is byte-capped
+// BEFORE JSON.parse: a 50k-bottle export is ~30 MB of JSON, so 32 MB is
+// generous while keeping the synchronous parse (event-loop block) bounded.
+const MAX_DATA_JSON_BYTES = 32 * 1024 * 1024; // 32 MB
 const MAX_TARGET_NAME = 100;
 // Bound the number of buffered ZIP entries (alongside the total-byte cap) so a
 // crafted archive with a huge count of tiny files can't blow up the entries Map.
 const MAX_ZIP_ENTRIES = 20000;
+
+// ── Import-parse concurrency gate ────────────────────────────────────────────
+// JSON.parse of a multi-MB export blocks the event loop and the buffered file
+// sits in memory for the whole request; don't let concurrent uploads stack.
+// Tiny in-process gate: at most MAX_GLOBAL_IMPORTS import/preview requests in
+// flight overall, and 1 per user. Excess requests get an immediate 429 (with a
+// retry hint) rather than queueing forever. In-process state is fine here: the
+// backend runs as a single container/process.
+const MAX_GLOBAL_IMPORTS = 2;
+let globalImports = 0;
+const userImports = new Set(); // user ids with an import/preview in flight
+
+function acquireImportSlot(userId) {
+  if (userImports.has(userId) || globalImports >= MAX_GLOBAL_IMPORTS) return null;
+  userImports.add(userId);
+  globalImports++;
+  return () => { userImports.delete(userId); globalImports--; };
+}
+
+function importBusy(res) {
+  res.set('Retry-After', '10');
+  return res.status(429).json({
+    error: 'Another import is already being processed — please retry in a few seconds',
+  });
+}
 
 const uploadImport = multer({
   storage: multer.memoryStorage(),
@@ -50,7 +81,7 @@ const uploadImport = multer({
 function handleUpload(req, res, next) {
   uploadImport.single('file')(req, res, (err) => {
     if (err) {
-      const msg = err.code === 'LIMIT_FILE_SIZE' ? 'File too large (max 200 MB)' : err.message;
+      const msg = err.code === 'LIMIT_FILE_SIZE' ? 'File too large (max 64 MB)' : err.message;
       return res.status(400).json({ error: msg });
     }
     if (!req.file) return res.status(400).json({ error: 'No file uploaded' });
@@ -100,6 +131,18 @@ function readExportZip(buffer) {
   });
 }
 
+// data.json must be byte-capped BEFORE the synchronous JSON.parse — the
+// count caps inside parseCellarExport only run after a parse has already
+// paid the memory + event-loop cost (SECURITY_AUDIT_2026-07-08 L-12).
+function assertDataJsonSize(byteLength) {
+  if (byteLength > MAX_DATA_JSON_BYTES) {
+    throw Object.assign(
+      new Error(`Export data is too large (${Math.round(byteLength / (1024 * 1024))} MB of JSON; max 32 MB)`),
+      { status: 413 }
+    );
+  }
+}
+
 // Returns { parsed, getFileBuffer, hasImageFiles } from the uploaded file.
 async function loadUpload(file) {
   const isZip = file.buffer.length >= 4 && file.buffer[0] === 0x50 && file.buffer[1] === 0x4b; // 'PK'
@@ -107,10 +150,12 @@ async function loadUpload(file) {
     const entries = await readExportZip(file.buffer);
     const dataJson = entries.get('data.json');
     if (!dataJson) throw Object.assign(new Error('Archive has no data.json (not a Cellarion export ZIP)'), { status: 400 });
+    assertDataJsonSize(dataJson.length);
     const parsed = parseCellarExport(dataJson.toString('utf8'));
     const hasImageFiles = [...entries.keys()].some((k) => k.startsWith('images/'));
     return { parsed, getFileBuffer: (p) => entries.get(p) || null, hasImageFiles };
   }
+  assertDataJsonSize(file.buffer.length);
   const parsed = parseCellarExport(file.buffer.toString('utf8'));
   return { parsed, getFileBuffer: () => null, hasImageFiles: false };
 }
@@ -122,6 +167,8 @@ async function activeCellarNamesLc(userId) {
 
 // POST /api/cellar-import/preview — parse only, report what would happen.
 router.post('/preview', handleUpload, async (req, res) => {
+  const release = acquireImportSlot(req.user.id);
+  if (!release) return importBusy(res);
   try {
     const { parsed, hasImageFiles } = await loadUpload(req.file);
     const existing = await activeCellarNamesLc(req.user.id);
@@ -150,15 +197,19 @@ router.post('/preview', handleUpload, async (req, res) => {
 
     res.json({ cellars, hasImageFiles });
   } catch (err) {
-    if (err.status === 400) return res.status(400).json({ error: err.message });
+    if (err.status === 400 || err.status === 413) return res.status(err.status).json({ error: err.message });
     console.error('Cellar import preview error:', err);
     res.status(500).json({ error: 'Failed to read export' });
+  } finally {
+    release();
   }
 });
 
 // POST /api/cellar-import — run the import.
 // Body (multipart text field): targets = JSON { [sourceName]: { targetName, confirmOverwrite } }
 router.post('/', handleUpload, async (req, res) => {
+  const release = acquireImportSlot(req.user.id);
+  if (!release) return importBusy(res);
   try {
     const user = await User.findById(req.user.id).select('preferences.currency');
     const { parsed, getFileBuffer } = await loadUpload(req.file);
@@ -211,9 +262,11 @@ router.post('/', handleUpload, async (req, res) => {
 
     res.json({ results });
   } catch (err) {
-    if (err.status === 400) return res.status(400).json({ error: err.message });
+    if (err.status === 400 || err.status === 413) return res.status(err.status).json({ error: err.message });
     console.error('Cellar import error:', err);
     res.status(500).json({ error: 'Import failed' });
+  } finally {
+    release();
   }
 });
 

--- a/backend/src/routes/cellarImport.limits.test.js
+++ b/backend/src/routes/cellarImport.limits.test.js
@@ -1,0 +1,248 @@
+/**
+ * /api/cellar-import — upload size cap + parse concurrency gate (SECURITY_AUDIT
+ * 2026-07-08 L-12).
+ *
+ * The importer buffers the upload in memory (multer memoryStorage) and
+ * synchronously JSON.parses data.json. These tests pin the guards added around
+ * that critical section:
+ *   - data.json larger than 32 MB → 413 BEFORE JSON.parse is ever reached
+ *   - a second concurrent import for the same user → 429 (not queued)
+ *   - a third concurrent import overall (global cap 2) → 429
+ *   - a valid small import still behaves exactly as before (regression)
+ */
+process.env.JWT_SECRET = 'test-secret';
+
+// services/search eagerly requires the ESM-only `meilisearch` package, which
+// Jest can't transform — stub it (matches the repo's unit-test style).
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  syncWine: async () => {},
+}));
+
+// Wrap the real service so parseCellarExport is a spy over the REAL parser:
+// the 413 test must prove the parse was never reached, and the regression
+// test must exercise the real parsing/validation logic.
+jest.mock('../services/cellarImport', () => {
+  const actual = jest.requireActual('../services/cellarImport');
+  return {
+    ...actual,
+    parseCellarExport: jest.fn((...args) => actual.parseCellarExport(...args)),
+    importCellar: jest.fn(),
+  };
+});
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/Cellar', () => ({ find: jest.fn() }));
+
+const http = require('http');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const cellarImportRouter = require('./cellarImport');
+const { parseCellarExport, importCellar } = require('../services/cellarImport');
+const User = require('../models/User');
+const Cellar = require('../models/Cellar');
+
+function buildApp() {
+  const app = express();
+  app.use('/api/cellar-import', cellarImportRouter);
+  return app;
+}
+
+function authHeader(userId = 'u1') {
+  const token = jwt.sign({ id: userId, roles: ['user'] }, 'test-secret', {
+    algorithm: 'HS256',
+    expiresIn: '1h',
+  });
+  return { Authorization: `Bearer ${token}` };
+}
+
+// Minimal multipart/form-data encoder (a single "file" part).
+function multipartUpload(buffer, filename = 'data.json') {
+  const boundary = '----jest-boundary-4d7f1c2e';
+  const head = Buffer.from(
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+    'Content-Type: application/json\r\n\r\n'
+  );
+  const tail = Buffer.from(`\r\n--${boundary}--\r\n`);
+  return {
+    body: Buffer.concat([head, buffer, tail]),
+    contentType: `multipart/form-data; boundary=${boundary}`,
+  };
+}
+
+function postUpload(app, url, buffer, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const { body, contentType } = multipartUpload(buffer);
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': contentType,
+            'Content-Length': body.length,
+            ...headers,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({
+              status: res.statusCode,
+              headers: res.headers,
+              body: JSON.parse(Buffer.concat(chunks).toString()),
+            });
+          });
+        }
+      );
+      req.on('error', (err) => { server.close(); reject(err); });
+      req.end(body);
+    });
+  });
+}
+
+async function waitFor(cond, ms = 2000) {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > ms) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+const VALID_EXPORT = Buffer.from(JSON.stringify({
+  schema: 'cellarion-export@1',
+  cellars: [{ cellarName: 'Kitchen', description: '', racks: [], bottles: [] }],
+}));
+
+const IMPORT_RESULT = {
+  sourceName: 'Kitchen',
+  targetName: 'Kitchen',
+  mode: 'create',
+  bottlesCreated: 0,
+  racksCreated: 0,
+  imagesAttached: 0,
+  imagesDeduped: 0,
+  imagesSkipped: 0,
+  winesCreated: 0,
+  wineRequests: 0,
+  reviewsCreated: 0,
+  reviewsSkipped: 0,
+  maturityCreated: 0,
+  maturitySkipped: 0,
+  layoutImported: false,
+  errors: [],
+  unplaced: [],
+};
+
+describe('/api/cellar-import size cap + concurrency gate', () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    jest.clearAllMocks();
+    User.findById.mockReturnValue({
+      select: jest.fn().mockResolvedValue({ preferences: { currency: 'EUR' } }),
+    });
+    Cellar.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+    });
+    importCellar.mockResolvedValue(IMPORT_RESULT);
+  });
+
+  test('data.json over 32 MB → 413 before JSON.parse is reached', async () => {
+    // 32 MB + 1 byte of (would-be) JSON. The route must reject on byte length
+    // alone — the parser spy proves the payload was never parsed.
+    const oversized = Buffer.alloc(32 * 1024 * 1024 + 1, 0x61); // 'a'
+
+    const res = await postUpload(app, '/api/cellar-import/preview', oversized, authHeader());
+
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/too large/i);
+    expect(res.body.error).toMatch(/32 MB/);
+    expect(parseCellarExport).not.toHaveBeenCalled();
+  });
+
+  test('second concurrent import for the same user → 429 with retry hint', async () => {
+    // Park the first request inside the critical section.
+    let releaseImport;
+    importCellar.mockImplementationOnce(
+      () => new Promise((resolve) => { releaseImport = () => resolve(IMPORT_RESULT); })
+    );
+
+    const first = postUpload(app, '/api/cellar-import', VALID_EXPORT, authHeader('u1'));
+    await waitFor(() => importCellar.mock.calls.length === 1);
+
+    const second = await postUpload(app, '/api/cellar-import', VALID_EXPORT, authHeader('u1'));
+    expect(second.status).toBe(429);
+    expect(second.body.error).toMatch(/retry/i);
+    expect(second.headers['retry-after']).toBe('10');
+
+    releaseImport();
+    const firstRes = await first;
+    expect(firstRes.status).toBe(200);
+
+    // The slot is released after completion — the same user can import again.
+    const third = await postUpload(app, '/api/cellar-import', VALID_EXPORT, authHeader('u1'));
+    expect(third.status).toBe(200);
+  });
+
+  test('global gate: two imports in flight → a third user gets 429', async () => {
+    const resolvers = [];
+    importCellar.mockImplementation(
+      () => new Promise((resolve) => { resolvers.push(() => resolve(IMPORT_RESULT)); })
+    );
+
+    const first = postUpload(app, '/api/cellar-import', VALID_EXPORT, authHeader('u1'));
+    const second = postUpload(app, '/api/cellar-import', VALID_EXPORT, authHeader('u2'));
+    await waitFor(() => importCellar.mock.calls.length === 2);
+
+    const third = await postUpload(app, '/api/cellar-import', VALID_EXPORT, authHeader('u3'));
+    expect(third.status).toBe(429);
+
+    resolvers.forEach((r) => r());
+    expect((await first).status).toBe(200);
+    expect((await second).status).toBe(200);
+  });
+
+  test('regression: a valid small import is unchanged', async () => {
+    const res = await postUpload(app, '/api/cellar-import', VALID_EXPORT, authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0]).toMatchObject({ targetName: 'Kitchen', mode: 'create', bottlesCreated: 0 });
+    expect(parseCellarExport).toHaveBeenCalledTimes(1);
+    expect(importCellar).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ cellarName: 'Kitchen' }),
+      expect.objectContaining({ targetName: 'Kitchen', mode: 'create', defaultCurrency: 'EUR' })
+    );
+  });
+
+  test('regression: preview of a valid export is unchanged', async () => {
+    const res = await postUpload(app, '/api/cellar-import/preview', VALID_EXPORT, authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body.cellars).toEqual([
+      expect.objectContaining({
+        sourceName: 'Kitchen',
+        defaultTargetName: 'Kitchen',
+        willOverwrite: false,
+        bottleCount: 0,
+      }),
+    ]);
+    expect(res.body.hasImageFiles).toBe(false);
+  });
+
+  test('invalid JSON under the cap still fails with the parser 400 (cap does not mask it)', async () => {
+    const res = await postUpload(app, '/api/cellar-import/preview', Buffer.from('{nope'), authHeader());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not valid JSON/i);
+    expect(parseCellarExport).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **L-12 from SECURITY_AUDIT_2026-07-08.md**: the cellar-export importer (`/api/cellar-import` + `/preview`) buffered up to 200 MB in memory (multer `memoryStorage`) and synchronously `JSON.parse`d `data.json` before any size gate — the bottle/cellar count caps only ran *after* the parse had already paid the memory + event-loop cost.

Import behavior for valid files is **unchanged** (additive-only rule): same routes, same responses, same parser, same importer.

## Before / after limits

| Limit | Before | After |
|---|---|---|
| Upload size (multer, JSON or ZIP) | 200 MB | **64 MB** (400, `File too large (max 64 MB)`) |
| ZIP extracted-contents total | 200 MB | **64 MB** (follows `MAX_UPLOAD_BYTES`) |
| `data.json` bytes **before** `JSON.parse` | none (parse first, count caps after) | **32 MB → 413** before the parser is ever reached |
| Concurrent import/preview parses (global) | unbounded | **2** → excess get **429** + `Retry-After: 10` |
| Concurrent import/preview parses (per user) | unbounded | **1** → **429** + `Retry-After: 10` |

Why these numbers: a 50k-bottle export (the existing `MAX_IMPORT_BOTTLES` cap) is ~30 MB of JSON, so 32 MB is generous for any legitimate `data.json`; anything larger with images is a ZIP, and prod nginx already caps bodies at 50 MB (`client_max_body_size 50m`) — 64 MB now also bounds a directly-exposed `:5000`. Excess concurrent requests fail fast with a retry hint instead of queueing forever.

## Why memoryStorage stays

The audit's fourth suggestion — streaming the upload to disk — is a larger refactor (multer disk storage + yauzl `fromFd` + cleanup lifecycle across both routes and the ZIP image path) and is **explicitly out of scope** here. With the upload capped at 64 MB and at most 2 parses in flight, worst-case transient buffering is ~128 MB, well inside the 640 MB container limit.

## User-facing copy

The only copy that mentioned the old limit was the backend `File too large (max 200 MB)` message (updated to 64 MB). Frontend `ImportCellar` page and en/sv locales carry no size number for this importer — nothing else to update (grepped `200 MB` repo-wide: no hits).

## Tests

New `backend/src/routes/cellarImport.limits.test.js` (6 tests, real router + real parser via spy wrapper):
- 32 MB + 1 `data.json` → **413**, and the `parseCellarExport` spy proves the parse was never reached
- second concurrent import, same user → **429** with `Retry-After`; slot released after completion (follow-up import succeeds)
- global gate: two users in flight → third user **429**
- regression: valid small import → 200 with unchanged result shape; preview unchanged; invalid JSON under the cap still gets the parser's 400

Full backend suite: **57 suites, 937 tests, all passing.**

## docker-compose impact

**None.** No env vars, ports, services, or images change — code + tests only. Nothing to touch in `docker-compose.prod.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)