### PR TITLE
fix: shared AI budget + registry-first matching cascade (audit M-2/L-14)

### DIFF
--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -32,6 +32,27 @@ const defaults = {
   // budget. Vision (scan-label) is the costliest, so 10/min is generous for
   // a human walking through a cellar but still catches scripts.
   aiBurst: { max: 10, windowMs: 60 * 1000 },
+  // Shared per-user DAILY budget of actual Anthropic calls across import
+  // identify, scan-label, identify-text, ai-info, and user-triggered wine
+  // enrichment (SECURITY_AUDIT_2026-07-08 M-2/L-14). aiBurst is the speed
+  // limit; this is the spend cap — chat keeps its own separate quota
+  // (aiConfig.chatDailyLimit). Sized so a legitimate 2,000-bottle import
+  // (~350 AI lookups after dedup + registry-first matching) fits in one day
+  // with headroom. 0 = unlimited. Enforced by services/aiBudget.js; when
+  // exhausted, imports degrade gracefully to fuzzy matching (never error)
+  // and the single-shot AI endpoints return 429 ai_budget_exhausted.
+  aiDailyBudget: { max: 500 },
+  // Cap on AI identify calls a single POST /api/bottles/import/validate
+  // request may fan out (M-2: one request used to mean up to 2,000 Sonnet
+  // calls). The frontend validates in batches of 25 items, so legitimate
+  // clients never come near this. Excess unique wines in one request fall
+  // through to fuzzy matching with aiSkipped: true.
+  aiImportPerRequestCap: { max: 50 },
+  // Site-wide daily kill-switch: total Anthropic calls per UTC day across all
+  // users (tracked as a singleton AiUsage row). Bounds the worst case of many
+  // abusive accounts. 0 = disabled. Same graceful degradation as the per-user
+  // budget when tripped.
+  aiGlobalDailyCap: { max: 20000 },
   // Per-user rolling cap on /api/images/upload. Each upload is up to 10MB and
   // stored on disk; without this cap a logged-in user could script a loop and
   // fill the disk. The per-bottle MAX_IMAGES_PER_BOTTLE cap limits per-resource
@@ -49,6 +70,9 @@ let cache = {
   chatBurst: { ...defaults.chatBurst },
   chatConcurrentStreams: { ...defaults.chatConcurrentStreams },
   aiBurst: { ...defaults.aiBurst },
+  aiDailyBudget: { ...defaults.aiDailyBudget },
+  aiImportPerRequestCap: { ...defaults.aiImportPerRequestCap },
+  aiGlobalDailyCap: { ...defaults.aiGlobalDailyCap },
   imageUploadBurst: { ...defaults.imageUploadBurst },
 };
 
@@ -78,6 +102,15 @@ async function load() {
         aiBurst: {
           max:      doc.value.aiBurst?.max      ?? defaults.aiBurst.max,
           windowMs: doc.value.aiBurst?.windowMs ?? defaults.aiBurst.windowMs,
+        },
+        aiDailyBudget: {
+          max: doc.value.aiDailyBudget?.max ?? defaults.aiDailyBudget.max,
+        },
+        aiImportPerRequestCap: {
+          max: doc.value.aiImportPerRequestCap?.max ?? defaults.aiImportPerRequestCap.max,
+        },
+        aiGlobalDailyCap: {
+          max: doc.value.aiGlobalDailyCap?.max ?? defaults.aiGlobalDailyCap.max,
         },
         imageUploadBurst: {
           max:      doc.value.imageUploadBurst?.max      ?? defaults.imageUploadBurst.max,

--- a/backend/src/models/AiUsage.js
+++ b/backend/src/models/AiUsage.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+
+/**
+ * Tracks daily Anthropic-backed AI usage per user (SECURITY_AUDIT_2026-07-08
+ * M-2 / L-14). One document per (userId, date) pair, mirroring ChatUsage.
+ *
+ * `count` is the number of actual Anthropic calls debited that UTC day across
+ * import identify, scan-label, identify-text, ai-info, and user-triggered
+ * wine enrichment. Chat keeps its own separate quota (ChatUsage).
+ *
+ * The site-wide daily kill-switch (rateLimits.aiGlobalDailyCap) is tracked as
+ * a singleton row per day with `userId: null` — not personal data.
+ *
+ * Auto-expires after 90 days (set by services/aiBudget.js) — same retention
+ * window as ChatUsage. GDPR: usage counters only, no content; purged with the
+ * account via services/userDataRegistry.js.
+ */
+const aiUsageSchema = new mongoose.Schema({
+  userId:    { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null }, // null = global site-wide counter
+  date:      { type: String, required: true }, // 'YYYY-MM-DD' UTC
+  count:     { type: Number, default: 0 },
+  expiresAt: { type: Date, required: true },   // TTL field — purged automatically
+}, { versionKey: false });
+
+aiUsageSchema.index({ userId: 1, date: 1 }, { unique: true });
+aiUsageSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+module.exports = mongoose.model('AiUsage', aiUsageSchema);

--- a/backend/src/routes/admin/settings.js
+++ b/backend/src/routes/admin/settings.js
@@ -34,7 +34,7 @@ router.get('/rate-limits', async (req, res) => {
 // accountLockout.threshold to 9999 effectively turns lockout off).
 router.patch('/rate-limits', async (req, res) => {
   try {
-    const { api, write, auth, accountLockout, chatBurst, chatConcurrentStreams } = req.body;
+    const { api, write, auth, accountLockout, chatBurst, chatConcurrentStreams, aiDailyBudget, aiImportPerRequestCap, aiGlobalDailyCap } = req.body;
 
     const previous = { ...rateLimitsConfig.get() };
 
@@ -75,6 +75,21 @@ router.patch('/rate-limits', async (req, res) => {
       requireIntInRange('chatConcurrentStreams.max', chatConcurrentStreams.max, 1, 50);
     }
 
+    // Shared per-user daily Anthropic-call budget (0 = unlimited)
+    if (aiDailyBudget !== undefined) {
+      requireIntInRange('aiDailyBudget.max', aiDailyBudget.max, 0, 1_000_000);
+    }
+
+    // AI identify fan-out cap per /import/validate request (frontend batches at 25)
+    if (aiImportPerRequestCap !== undefined) {
+      requireIntInRange('aiImportPerRequestCap.max', aiImportPerRequestCap.max, 1, 2000);
+    }
+
+    // Site-wide daily Anthropic-call kill-switch (0 = disabled)
+    if (aiGlobalDailyCap !== undefined) {
+      requireIntInRange('aiGlobalDailyCap.max', aiGlobalDailyCap.max, 0, 10_000_000);
+    }
+
     if (errors.length > 0) {
       return res.status(400).json({ error: errors[0], errors });
     }
@@ -99,6 +114,15 @@ router.patch('/rate-limits', async (req, res) => {
       },
       chatConcurrentStreams: {
         max: chatConcurrentStreams?.max ?? previous.chatConcurrentStreams.max,
+      },
+      aiDailyBudget: {
+        max: aiDailyBudget?.max ?? previous.aiDailyBudget?.max ?? rateLimitsConfig.defaults.aiDailyBudget.max,
+      },
+      aiImportPerRequestCap: {
+        max: aiImportPerRequestCap?.max ?? previous.aiImportPerRequestCap?.max ?? rateLimitsConfig.defaults.aiImportPerRequestCap.max,
+      },
+      aiGlobalDailyCap: {
+        max: aiGlobalDailyCap?.max ?? previous.aiGlobalDailyCap?.max ?? rateLimitsConfig.defaults.aiGlobalDailyCap.max,
       },
     };
 

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -509,7 +509,7 @@ router.post('/', async (req, res) => {
     // new wine the user just created), generate one — which also re-embeds the
     // wine so Qdrant carries the taste data. No-op if already enriched / a batch
     // enrichment job is running / AI isn't configured.
-    enrichWineById(wineDefinition).catch(() => {});
+    enrichWineById(wineDefinition, { budgetUserId: req.user.id }).catch(() => {});
 
     // Fire-and-forget: auto-resolve any restock alerts for this wine
     resolveRestockAlerts(req.user.id, wineDefinition, bottle._id).catch(() => {});

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -16,7 +16,10 @@ const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
 const searchService = require('../services/search');
 const { identifyWineFromText } = require('../services/labelScan');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
-const { scoreWineMatch } = require('../services/wineMatching');
+const { scoreWineMatchVariants, stripProducerPrefix } = require('../services/wineMatching');
+const { tryDebitAi, isRefundableFailure } = require('../services/aiBudget');
+const rateLimitsConfig = require('../config/rateLimits');
+const { generateWineKey } = require('../utils/normalize');
 const {
   CONSUMED_STATUSES,
   IMPORT_EXACT_THRESHOLD,
@@ -46,14 +49,33 @@ const FUZZY_THRESHOLD = IMPORT_FUZZY_THRESHOLD;
 
 /**
  * Score a WineDefinition candidate against an import item.
- * Delegates to the shared wineMatching service.
+ * Delegates to the shared wineMatching service. Variant-aware: import rows
+ * often embed the producer inside the wine name (CellarTracker has no
+ * Producer column), so the scorer takes the max over producer-embedded name
+ * variants — strictly monotonic (only ever raises the score), so existing
+ * matches keep their score and known wines stop being missed.
  */
 function scoreCandidate(candidate, item) {
-  return scoreWineMatch(candidate, {
+  return scoreWineMatchVariants(candidate, {
     name: item.wineName,
     producer: item.producer,
     appellation: item.appellation
   });
+}
+
+/**
+ * Registry-first exact lookup for an import item — step (a) of the AI-saving
+ * cascade. Tries the raw normalizedKey and, when the wine name embeds the
+ * producer as a prefix, the prefix-stripped variant key. One indexed query,
+ * zero AI.
+ */
+async function findExactRegistryWine(item) {
+  if (!item.wineName || !item.producer) return null;
+  const keys = [generateWineKey(item.wineName, item.producer, item.appellation)];
+  const stripped = stripProducerPrefix(item.wineName, item.producer);
+  if (stripped) keys.push(generateWineKey(stripped, item.producer, item.appellation));
+  return WineDefinition.findOne({ normalizedKey: { $in: keys } })
+    .populate(['country', 'region', 'grapes']);
 }
 
 /**
@@ -198,23 +220,26 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     }
 
     // Build preResults array and validate required fields. `forceAi` is a
-    // client-side hint sent by the per-row "Look up" button; the pipeline
-    // below already runs AI for every eligible row, so the flag is stripped
-    // here only to keep it out of the stored/echoed item.
+    // client-side hint sent by the per-row "Look up" button: it bypasses the
+    // registry-first cascade below so an explicit user request always gets an
+    // AI attempt (subject to the daily budget). It is stripped from the item
+    // to keep it out of the stored/echoed row.
     const preResults = [];
     for (let i = 0; i < items.length; i++) {
       const { forceAi, ...item } = items[i];
       if (!item.wineName && !item.producer) {
         preResults.push({ index: i, item, errorMsg: 'Wine name or producer is required' });
       } else {
-        preResults.push({ index: i, item, matches: [] });
+        preResults.push({ index: i, item, matches: [], forceAi: forceAi === true });
       }
     }
 
-    // Pass 1: AI identification FIRST for all valid items (deduplicated).
-    // AI is better at distinguishing similar wines (e.g. single vineyard vs
-    // generic Barolo) so it runs before fuzzy matching to produce accurate
-    // wine identity data that the DB match can then use.
+    // Pass 1: AI identification for all valid items (deduplicated), preceded
+    // by a registry-first cascade. AI is better at distinguishing similar
+    // wines (e.g. single vineyard vs generic Barolo), but for wines the
+    // registry ALREADY knows, the AI's canonicalized result would dedup to
+    // the same registry wine anyway — so a confident registry match skips the
+    // AI call with an outcome-identical result (audit M-2 cost defense).
     const aiEligible = process.env.ANTHROPIC_API_KEY
       ? preResults.filter(pr => !pr.errorMsg && pr.item.wineName && pr.item.producer)
       : [];
@@ -224,32 +249,102 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     for (const pr of aiEligible) {
       const key = `${normalizeString(pr.item.wineName)}:${normalizeString(pr.item.producer)}`;
       if (!aiKeyMap.has(key)) aiKeyMap.set(key, pr);
+      if (pr.forceAi) aiKeyMap.get(key).forceAi = true; // any row's Look-up button forces the key
+    }
+    const uniquePrs = [...aiKeyMap.values()];
+
+    // ── Pass 1a: registry-first cascade (zero AI for known wines) ──────────
+    // (a) exact normalizedKey match (raw + producer-prefix-stripped variant);
+    // (b) existing fuzzy scorer at the exact threshold (>= 0.95) — at that
+    //     score the AI path's findOrCreateWine would auto-match the same
+    //     registry wine, so skipping AI is outcome-identical;
+    // (c) everything else goes to AI exactly as before.
+    for (const pr of uniquePrs) {
+      if (pr.forceAi) continue;
+      const exactWine = await findExactRegistryWine(pr.item);
+      if (exactWine) {
+        pr.registryWine = { wine: exactWine, score: 1 };
+        continue;
+      }
+      const matches = await findWineMatches(pr.item);
+      pr.preMatches = matches; // reused by Pass 3 if this row ends up on the fuzzy path
+      if (matches.length > 0 && matches[0].score >= EXACT_THRESHOLD) {
+        pr.registryWine = { wine: matches[0].wine, score: matches[0].score };
+      }
     }
 
-    // One AI call per unique wine, throttled to AI_CONCURRENCY at a time
-    const uniquePrs = [...aiKeyMap.values()];
+    // ── Pass 1b: AI fan-out for the remaining unique wines ─────────────────
+    // Guarded by (audit M-2): a per-request fan-out cap, the shared per-user
+    // daily AI budget + global daily cap (debited per actual Anthropic call,
+    // refunded on transport failure), and a client-disconnect check that
+    // stops LAUNCHING new calls once the requester has gone away. All three
+    // degrade gracefully to the fuzzy path (aiSkipped: true) — never an error.
+    const needAi = uniquePrs.filter(pr => !pr.registryWine);
+    const perRequestCap = rateLimitsConfig.get().aiImportPerRequestCap?.max
+      ?? rateLimitsConfig.defaults.aiImportPerRequestCap.max;
+    const aiRun = needAi.slice(0, perRequestCap);
+    for (const pr of needAi.slice(perRequestCap)) pr.aiSkipped = true;
+
+    let aiBudgetExhausted = false;
+    let clientDisconnected = false;
+    // res 'close' fires when the underlying connection closes; writableEnded
+    // distinguishes a premature client disconnect from normal completion.
+    // (req 'close' fires on message completion in Node >= 15, so it can't be
+    // used for disconnect detection here.)
+    res.on('close', () => { if (!res.writableEnded) clientDisconnected = true; });
+
+    const AI_SKIPPED = Symbol('aiSkipped');
     const aiSettled = await runConcurrent(
-      uniquePrs.map(pr => () => identifyWineFromText({
-        name: pr.item.wineName,
-        producer: pr.item.producer,
-        vintage: pr.item.vintage,
-        country: pr.item.country
-      })),
+      aiRun.map(pr => async () => {
+        // Checked at launch time: in-flight calls finish, new ones stop.
+        if (clientDisconnected || aiBudgetExhausted) {
+          pr.aiSkipped = true;
+          return AI_SKIPPED;
+        }
+        const debit = await tryDebitAi(req.user.id);
+        if (!debit.ok) {
+          aiBudgetExhausted = true;
+          pr.aiSkipped = true;
+          return AI_SKIPPED;
+        }
+        try {
+          const result = await identifyWineFromText({
+            name: pr.item.wineName,
+            producer: pr.item.producer,
+            vintage: pr.item.vintage,
+            country: pr.item.country
+          });
+          // A transport-level failure never produced a billable completion —
+          // give the debit back so failed calls don't burn the user's budget.
+          if (!result.data && isRefundableFailure(result.debugReason)) await debit.refund();
+          return result;
+        } catch (err) {
+          await debit.refund();
+          throw err;
+        }
+      }),
       AI_CONCURRENCY
     );
 
-    // Build a key -> AI result lookup
+    // Build a key -> AI result lookup (only wines that actually went to AI)
     const aiByKey = new Map();
-    for (let j = 0; j < uniquePrs.length; j++) {
-      const key = `${normalizeString(uniquePrs[j].item.wineName)}:${normalizeString(uniquePrs[j].item.producer)}`;
+    for (let j = 0; j < aiRun.length; j++) {
+      const key = `${normalizeString(aiRun[j].item.wineName)}:${normalizeString(aiRun[j].item.producer)}`;
       aiByKey.set(key, aiSettled[j]);
     }
 
-    // Attach the shared AI result to every eligible preResult with that key
+    // Attach the shared cascade/AI result to every eligible preResult with
+    // that key (duplicates share the representative's outcome, as before).
     for (const pr of aiEligible) {
       const key = `${normalizeString(pr.item.wineName)}:${normalizeString(pr.item.producer)}`;
+      const rep = aiKeyMap.get(key);
+      if (rep.registryWine) { pr.registryWine = rep.registryWine; continue; }
+      if (rep.preMatches && !pr.preMatches) pr.preMatches = rep.preMatches;
+      if (rep.aiSkipped) { pr.aiSkipped = true; continue; }
       const settled = aiByKey.get(key);
+      if (!settled) continue;
       if (settled.status === 'fulfilled') {
+        if (settled.value === AI_SKIPPED) { pr.aiSkipped = true; continue; }
         pr.aiIdentified = settled.value.data;
         pr.aiDebugRaw    = settled.value.debugRaw;
         pr.aiDebugReason = settled.value.debugReason;
@@ -263,7 +358,7 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     // name/producer, which is more accurate than matching raw import data.
     const createdWineCache = new Map(); // normalizedKey -> { wine, created } | { error }
     for (const pr of preResults) {
-      if (!pr.aiIdentified) continue;
+      if (pr.registryWine || !pr.aiIdentified) continue;
       const key = `${normalizeString(pr.aiIdentified.name)}:${normalizeString(pr.aiIdentified.producer)}`;
       if (createdWineCache.has(key)) {
         const cached = createdWineCache.get(key);
@@ -293,10 +388,12 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     }
 
     // Pass 3: fuzzy matching fallback for items without AI results
-    // (API key not set, AI failed, or missing name/producer for AI)
+    // (API key not set, AI failed or was budget/cap/disconnect-skipped, or
+    // missing name/producer for AI). Cascade matches from Pass 1a are reused
+    // instead of re-querying.
     for (const pr of preResults) {
-      if (pr.errorMsg || pr.aiWine) continue; // skip errors and AI-matched items
-      const matches = await findWineMatches(pr.item);
+      if (pr.errorMsg || pr.aiWine || pr.registryWine) continue; // skip errors and matched items
+      const matches = pr.preMatches ?? await findWineMatches(pr.item);
       pr.matches = matches;
     }
 
@@ -310,7 +407,24 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
 
       let status, resultMatches, aiDebug = null;
 
-      if (pr.aiWine) {
+      if (pr.registryWine) {
+        // Registry-first cascade hit (exact key or >= EXACT_THRESHOLD fuzzy):
+        // the registry already knows this wine, so no AI was needed. Treated
+        // as an exact match — same wineId the AI path would have resolved to.
+        const { wine, score } = pr.registryWine;
+        status = 'exact';
+        resultMatches = [{
+          wineId: wine._id,
+          name: wine.name,
+          producer: wine.producer,
+          country: wine.country?.name || null,
+          region: wine.region?.name || null,
+          appellation: wine.appellation || null,
+          type: wine.type,
+          image: wine.image || null,
+          score: Math.round(score * 100) / 100
+        }];
+      } else if (pr.aiWine) {
         // AI successfully identified and found/created the wine
         status = 'ai_match';
         resultMatches = [{
@@ -349,8 +463,9 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
         status = 'no_match';
         resultMatches = [];
 
-        // Include AI debug info when AI was attempted but failed
-        if (process.env.ANTHROPIC_API_KEY && (pr.item.wineName || pr.item.producer)) {
+        // Include AI debug info when AI was attempted but failed (not when it
+        // was skipped by budget/cap/disconnect — those rows carry aiSkipped)
+        if (!pr.aiSkipped && process.env.ANTHROPIC_API_KEY && (pr.item.wineName || pr.item.producer)) {
           const aiStatus = pr.aiError || pr.aiDebugReason === 'rate_limit_exceeded' ||
             (pr.aiDebugReason && pr.aiDebugReason.startsWith('exception'))
             ? 'failed' : (pr.aiWineError ? 'create_failed' : 'searched');
@@ -363,6 +478,10 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
 
       const result = { index: pr.index, item: pr.item, status, matches: resultMatches };
       if (aiDebug) result.aiDebug = aiDebug;
+      // Flag rows whose AI identify was skipped (daily budget exhausted,
+      // per-request cap, or client disconnect) — they fell through to the
+      // fuzzy path above. Informational only; the row itself never errors.
+      if (pr.aiSkipped) result.aiSkipped = true;
       results.push(result);
     }
 
@@ -395,7 +514,11 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
         aiMatch: results.filter(r => r.status === 'ai_match').length,
         noMatch: results.filter(r => r.status === 'no_match').length,
         errors: results.filter(r => r.status === 'error').length,
-        priceWarnings: results.filter(r => r.priceWarnings?.length).length
+        priceWarnings: results.filter(r => r.priceWarnings?.length).length,
+        // Present only when the shared daily AI budget (or the global cap)
+        // ran out mid-import: remaining rows were matched fuzzily instead of
+        // via AI (aiSkipped: true per row). The import still succeeds.
+        ...(aiBudgetExhausted && { aiBudgetExhausted: true })
       }
     });
   } catch (error) {

--- a/backend/src/routes/import.validate.aiBudget.test.js
+++ b/backend/src/routes/import.validate.aiBudget.test.js
@@ -1,0 +1,526 @@
+/**
+ * POST /api/bottles/import/validate — registry-first cascade + shared AI
+ * budget (SECURITY_AUDIT_2026-07-08 M-2 + L-14).
+ *
+ * WHY THIS TEST EXISTS:
+ * The guiding product constraint is that a legitimate 2,000-bottle import
+ * must NEVER break or degrade below the pre-change quality — only abusive
+ * spend gets capped. That means:
+ *
+ *   1. CASCADE — wines the registry already knows resolve WITHOUT an AI call
+ *      (exact normalizedKey, or fuzzy score >= 0.95 where the AI's
+ *      canonicalized result would dedup to the same registry wine anyway),
+ *      with the same wineId the AI path would have produced. Unknown wines
+ *      still get AI — match quality for messy input is unchanged. The
+ *      cascade must survive producer-embedded wine names (CellarTracker has
+ *      no Producer column).
+ *   2. BUDGET/CAP/DISCONNECT — when the shared daily budget (or global cap,
+ *      or per-request fan-out cap) stops AI mid-import, the remaining rows
+ *      fall through to the existing fuzzy path with aiSkipped: true and a
+ *      summary-level aiBudgetExhausted flag — never an error.
+ *   3. REGRESSION — without budget pressure, responses carry no new fields
+ *      and the AI path is byte-identical to before.
+ *
+ * Real router + real requireAuth (HS256 test tokens) + the REAL aiBudget
+ * service and rateLimits config; models and the Anthropic layer are mocked.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+process.env.ANTHROPIC_API_KEY = 'test-key';
+
+// services/search eagerly requires the ESM-only `meilisearch` package —
+// stub it (matches the repo's unit-test style). Meilisearch "unavailable"
+// exercises the MongoDB fallback strategies in findWineMatches.
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexWine: () => {},
+  bulkIndexBottles: jest.fn(),
+}));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/priceWarnings', () => ({
+  computeUserMediansByCurrency: jest.fn().mockResolvedValue({}),
+}));
+
+// ── Model mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/Country', () => ({ findOne: jest.fn() }));
+jest.mock('../models/ImportSession', () => ({}));
+jest.mock('../models/Bottle', () => function Bottle() {});
+jest.mock('../models/WineRequest', () => function WineRequest() {});
+jest.mock('../models/Rack', () => {
+  const model = { find: jest.fn() };
+  model.RACK_TYPES = ['grid'];
+  return model;
+});
+
+// Registry mock: exact normalizedKey lookups + the two MongoDB fallback
+// candidate searches used by findWineMatches ($text, normalizedKey regex).
+jest.mock('../models/WineDefinition', () => {
+  const state = { exactByKey: new Map(), candidates: [] };
+  const chain = (docs) => {
+    const c = { populate: () => c, sort: () => c, limit: () => c, lean: async () => docs };
+    return c;
+  };
+  const model = {
+    findOne: jest.fn((filter) => ({
+      populate: async () => {
+        const keys = filter?.normalizedKey?.$in ?? [filter?.normalizedKey];
+        for (const k of keys) {
+          if (state.exactByKey.has(k)) return state.exactByKey.get(k);
+        }
+        return null;
+      },
+    })),
+    find: jest.fn(() => chain(state.candidates)),
+    findById: jest.fn(),
+    __state: state,
+  };
+  return model;
+});
+
+// In-memory AiUsage so the REAL aiBudget debit/refund logic runs without Mongo.
+jest.mock('../models/AiUsage', () => {
+  const store = new Map();
+  return {
+    findOneAndUpdate: jest.fn(async (filter, update) => {
+      const k = `${filter.userId}|${filter.date}`;
+      if (!store.has(k)) store.set(k, { userId: filter.userId, date: filter.date, count: 0 });
+      const doc = store.get(k);
+      if (update.$inc && typeof update.$inc.count === 'number') doc.count += update.$inc.count;
+      return { ...doc };
+    }),
+    __store: store,
+  };
+});
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const WineDefinition = require('../models/WineDefinition');
+const AiUsage = require('../models/AiUsage');
+const { identifyWineFromText } = require('../services/labelScan');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const rateLimitsConfig = require('../config/rateLimits');
+const { todayUTC } = require('../services/aiBudget');
+const importRouter = require('./import');
+
+const USER_ID = '64b000000000000000000001';
+const CELLAR_ID = '64b0000000000000000000bb';
+
+// Registry wines — producer and name stored SEPARATELY (registry convention)
+const LA_TACHE = {
+  _id: '64b0000000000000000000c1',
+  name: 'La Tâche',
+  producer: 'Domaine de la Romanée-Conti',
+  appellation: null,
+  type: 'red',
+  image: null,
+  country: { name: 'France' },
+  region: { name: 'Burgundy' },
+  normalizedKey: 'domaine de la romaneeconti:la tache:', // normalizeString drops hyphens without padding
+};
+const ROMANEE_CONTI = {
+  _id: '64b0000000000000000000c2',
+  name: 'Romanée-Conti',
+  producer: 'Domaine de la Romanée-Conti',
+  appellation: null,
+  type: 'red',
+  image: null,
+  country: { name: 'France' },
+  region: { name: 'Burgundy' },
+  normalizedKey: 'domaine de la romaneeconti:romaneeconti:',
+};
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles/import', importRouter);
+  return app;
+}
+
+function authToken() {
+  return jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+}
+
+function postJson(app, url, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${authToken()}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.write(payload);
+      req.end();
+    });
+  });
+}
+
+const validate = (items) => postJson(buildApp(), '/api/bottles/import/validate', { cellarId: CELLAR_ID, items });
+
+const userDebits = () => AiUsage.__store.get(`${USER_ID}|${todayUTC()}`)?.count ?? 0;
+const globalDebits = () => AiUsage.__store.get(`null|${todayUTC()}`)?.count ?? 0;
+
+function setLimits(overrides = {}) {
+  rateLimitsConfig.set({
+    ...JSON.parse(JSON.stringify(rateLimitsConfig.defaults)),
+    ...overrides,
+  });
+}
+
+// Default AI behaviour: identify any "Mystery N" wine as a distinct new wine
+// that findOrCreateWine then creates.
+function mockAiIdentifiesEverything() {
+  identifyWineFromText.mockImplementation(async ({ name, producer }) => ({
+    data: { name, producer, country: 'France', type: 'red', grapes: [], confidence: 0.9 },
+    debugRaw: 'raw',
+    debugReason: null,
+  }));
+  findOrCreateWine.mockImplementation(async (wineData) => ({
+    wine: {
+      _id: `created-${wineData.name}`,
+      name: wineData.name,
+      producer: wineData.producer,
+      appellation: null,
+      type: 'red',
+      image: null,
+      country: { name: 'France' },
+      region: null,
+    },
+    created: true,
+  }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  AiUsage.__store.clear();
+  WineDefinition.__state.exactByKey.clear();
+  WineDefinition.__state.candidates = [];
+  setLimits();
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, user: USER_ID, deletedAt: null, members: [] });
+  mockAiIdentifiesEverything();
+});
+
+afterAll(() => {
+  rateLimitsConfig.set(JSON.parse(JSON.stringify(rateLimitsConfig.defaults)));
+});
+
+// ── 1. Registry-first cascade ────────────────────────────────────────────────
+
+describe('registry-first cascade (zero AI for known wines)', () => {
+  beforeEach(() => {
+    WineDefinition.__state.exactByKey.set(LA_TACHE.normalizedKey, LA_TACHE);
+    WineDefinition.__state.candidates = [LA_TACHE, ROMANEE_CONTI];
+  });
+
+  test('exact normalizedKey match resolves without AI, same wineId as the AI path', async () => {
+    const res = await validate([
+      { wineName: 'La Tâche', producer: 'Domaine de la Romanée-Conti', vintage: '2018' },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].status).toBe('exact');
+    expect(res.body.results[0].matches[0].wineId).toBe(LA_TACHE._id);
+    expect(res.body.results[0].matches[0].score).toBe(1);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(userDebits()).toBe(0); // zero AI = zero budget spend
+  });
+
+  test('(iii) diacritic-free row hits the exact key (normalizeString strips accents)', async () => {
+    const res = await validate([
+      { wineName: 'La Tache', producer: 'Domaine de la Romanee-Conti', vintage: '2018' },
+    ]);
+
+    expect(res.body.results[0].status).toBe('exact');
+    expect(res.body.results[0].matches[0].wineId).toBe(LA_TACHE._id);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+  });
+
+  test('(ii) producer-embedded wine name hits the prefix-stripped exact key', async () => {
+    const res = await validate([
+      { wineName: 'Domaine de la Romanée-Conti La Tâche', producer: 'Domaine de la Romanée-Conti', vintage: '2018' },
+    ]);
+
+    expect(res.body.results[0].status).toBe('exact');
+    expect(res.body.results[0].matches[0].wineId).toBe(LA_TACHE._id);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+    // The lookup must have offered BOTH the raw and the stripped key
+    const filter = WineDefinition.findOne.mock.calls[0][0];
+    expect(filter.normalizedKey.$in).toContain('domaine de la romaneeconti:la tache:');
+  });
+
+  test('(i) full display name with NO producer resolves via variant fuzzy at >= 0.95 (no AI eligible anyway)', async () => {
+    const res = await validate([
+      { wineName: 'Domaine de la Romanée-Conti La Tâche', producer: '', vintage: '2018' },
+    ]);
+
+    expect(res.body.results[0].status).toBe('exact');
+    expect(res.body.results[0].matches[0].wineId).toBe(LA_TACHE._id);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+    // Negative: the sibling grand cru must not cross-match at exact level
+    const siblingMatch = res.body.results[0].matches.find(m => m.wineId === ROMANEE_CONTI._id);
+    if (siblingMatch) expect(siblingMatch.score).toBeLessThan(0.95);
+  });
+
+  test('fuzzy >= 0.95 without an exact key still skips AI (outcome-identical shortcut)', async () => {
+    // No exact key registered — only candidates for the fuzzy scorer
+    WineDefinition.__state.exactByKey.clear();
+    const res = await validate([
+      { wineName: 'La Tâche', producer: 'Domaine de la Romanée-Conti', vintage: '2018' },
+    ]);
+
+    expect(res.body.results[0].status).toBe('exact');
+    expect(res.body.results[0].matches[0].wineId).toBe(LA_TACHE._id);
+    expect(res.body.results[0].matches[0].score).toBeGreaterThanOrEqual(0.95);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+    expect(userDebits()).toBe(0);
+  });
+
+  test('unknown wine still gets AI — quality below the exact threshold is unchanged', async () => {
+    const res = await validate([
+      { wineName: 'Mystery Cuvée', producer: 'Unknown Estate', vintage: '2020' },
+    ]);
+
+    expect(identifyWineFromText).toHaveBeenCalledTimes(1);
+    expect(res.body.results[0].status).toBe('ai_match');
+    expect(res.body.results[0].matches[0].aiIdentified).toBe(true);
+    expect(userDebits()).toBe(1);
+    expect(globalDebits()).toBe(1);
+  });
+
+  test('forceAi (per-row Look up button) bypasses the cascade and always reaches AI', async () => {
+    const res = await validate([
+      { wineName: 'La Tâche', producer: 'Domaine de la Romanée-Conti', vintage: '2018', forceAi: true },
+    ]);
+
+    expect(identifyWineFromText).toHaveBeenCalledTimes(1);
+    expect(res.body.results[0].status).toBe('ai_match');
+    expect(userDebits()).toBe(1);
+  });
+
+  test('duplicate rows of one unknown wine share a single AI call and a single debit', async () => {
+    const row = { wineName: 'Mystery Cuvée', producer: 'Unknown Estate', vintage: '2019' };
+    const res = await validate([row, { ...row, vintage: '2020' }, { ...row, vintage: '2021' }]);
+
+    expect(identifyWineFromText).toHaveBeenCalledTimes(1);
+    expect(res.body.results).toHaveLength(3);
+    for (const r of res.body.results) expect(r.status).toBe('ai_match');
+    expect(userDebits()).toBe(1);
+  });
+});
+
+// ── 2. Budget / cap / degradation ────────────────────────────────────────────
+
+describe('shared daily AI budget and caps (graceful degradation, never an error)', () => {
+  const mysteries = (n) =>
+    Array.from({ length: n }, (_, i) => ({ wineName: `Mystery ${i}`, producer: `Estate ${i}`, vintage: '2020' }));
+
+  test('budget exhaustion MID-import: remaining rows degrade to fuzzy with aiSkipped, response is 200', async () => {
+    setLimits({ aiDailyBudget: { max: 2 } });
+
+    const res = await validate(mysteries(4));
+
+    expect(res.status).toBe(200);
+    expect(identifyWineFromText).toHaveBeenCalledTimes(2); // debit gate stopped the rest
+    const aiRows = res.body.results.filter(r => r.status === 'ai_match');
+    const skippedRows = res.body.results.filter(r => r.aiSkipped === true);
+    expect(aiRows).toHaveLength(2);
+    expect(skippedRows).toHaveLength(2);
+    for (const r of skippedRows) {
+      expect(r.status).toBe('no_match'); // fuzzy path found nothing for these
+      expect(r.error).toBeUndefined();
+    }
+    expect(res.body.summary.aiBudgetExhausted).toBe(true);
+    expect(userDebits()).toBe(2); // overshoot refunded
+  });
+
+  test('budget already exhausted BEFORE the import: all rows degrade, none error', async () => {
+    setLimits({ aiDailyBudget: { max: 1 } });
+    AiUsage.__store.set(`${USER_ID}|${todayUTC()}`, { userId: USER_ID, date: todayUTC(), count: 1 });
+
+    const res = await validate(mysteries(3));
+
+    expect(res.status).toBe(200);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+    expect(res.body.results.every(r => r.aiSkipped === true)).toBe(true);
+    expect(res.body.summary.aiBudgetExhausted).toBe(true);
+  });
+
+  test('per-request fan-out cap: excess unique wines are aiSkipped WITHOUT the budget flag', async () => {
+    setLimits({ aiImportPerRequestCap: { max: 1 } });
+
+    const res = await validate(mysteries(3));
+
+    expect(res.status).toBe(200);
+    expect(identifyWineFromText).toHaveBeenCalledTimes(1);
+    expect(res.body.results.filter(r => r.aiSkipped === true)).toHaveLength(2);
+    expect(res.body.summary.aiBudgetExhausted).toBeUndefined(); // cap ≠ budget exhaustion
+    expect(userDebits()).toBe(1); // capped wines were never debited
+  });
+
+  test('global daily kill-switch trips with the same degradation', async () => {
+    setLimits({ aiGlobalDailyCap: { max: 1 } });
+
+    const res = await validate(mysteries(2));
+
+    expect(res.status).toBe(200);
+    expect(identifyWineFromText).toHaveBeenCalledTimes(1);
+    expect(res.body.results.filter(r => r.aiSkipped === true)).toHaveLength(1);
+    expect(res.body.summary.aiBudgetExhausted).toBe(true);
+    expect(globalDebits()).toBe(1);
+  });
+
+  test('cascade-known wines resolve even when the budget is exhausted (zero AI needed)', async () => {
+    setLimits({ aiDailyBudget: { max: 1 } });
+    AiUsage.__store.set(`${USER_ID}|${todayUTC()}`, { userId: USER_ID, date: todayUTC(), count: 1 });
+    WineDefinition.__state.exactByKey.set(LA_TACHE.normalizedKey, LA_TACHE);
+
+    const res = await validate([
+      { wineName: 'La Tâche', producer: 'Domaine de la Romanée-Conti', vintage: '2018' },
+    ]);
+
+    expect(res.body.results[0].status).toBe('exact');
+    expect(res.body.results[0].matches[0].wineId).toBe(LA_TACHE._id);
+    expect(res.body.results[0].aiSkipped).toBeUndefined(); // full-quality outcome, not degradation
+    expect(res.body.summary.aiBudgetExhausted).toBeUndefined();
+  });
+
+  test('a transport failure refunds the debit (failed calls never burn budget)', async () => {
+    identifyWineFromText.mockResolvedValue({ data: null, debugRaw: 'boom', debugReason: 'exception: socket hang up' });
+
+    const res = await validate(mysteries(1));
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].status).toBe('no_match');
+    expect(res.body.results[0].aiSkipped).toBeUndefined(); // AI was attempted, not skipped
+    expect(userDebits()).toBe(0);
+    expect(globalDebits()).toBe(0);
+  });
+});
+
+// ── 3. Regression: no budget pressure ⇒ byte-identical behaviour ────────────
+
+describe('regression — imports without budget pressure', () => {
+  test('AI-path rows carry exactly the pre-change fields (no aiSkipped, no summary flag)', async () => {
+    const res = await validate([
+      { wineName: 'Mystery Cuvée', producer: 'Unknown Estate', vintage: '2020' },
+    ]);
+
+    expect(res.status).toBe(200);
+    const row = res.body.results[0];
+    expect(Object.keys(row).sort()).toEqual(['index', 'item', 'matches', 'status']);
+    expect(row.status).toBe('ai_match');
+    expect(Object.keys(row.matches[0]).sort()).toEqual(
+      ['aiIdentified', 'appellation', 'country', 'image', 'name', 'producer', 'region', 'score', 'type', 'wineId'].sort()
+    );
+    expect(Object.keys(res.body.summary)).toEqual(
+      ['total', 'exact', 'fuzzy', 'aiMatch', 'noMatch', 'errors', 'priceWarnings']
+    );
+    expect(res.body.summary.aiBudgetExhausted).toBeUndefined();
+  });
+
+  test('a 25-item batch (frontend VALIDATE_BATCH_SIZE) of unknown wines never hits the per-request cap', async () => {
+    const items = Array.from({ length: 25 }, (_, i) => ({
+      wineName: `Wine ${i}`, producer: `Producer ${i}`, vintage: '2020',
+    }));
+    const res = await validate(items);
+
+    expect(res.status).toBe(200);
+    expect(identifyWineFromText).toHaveBeenCalledTimes(25);
+    expect(res.body.results.every(r => r.status === 'ai_match')).toBe(true);
+    expect(res.body.results.some(r => r.aiSkipped)).toBe(false);
+  });
+});
+
+// ── 4. Client disconnect stops NEW launches ──────────────────────────────────
+
+describe('client disconnect', () => {
+  async function waitFor(cond, timeoutMs = 3000) {
+    const start = Date.now();
+    while (!cond()) {
+      if (Date.now() - start > timeoutMs) throw new Error('waitFor timeout');
+      await new Promise(r => setTimeout(r, 10));
+    }
+  }
+
+  test('disconnecting mid-fan-out stops launching new AI identifies (and debits)', async () => {
+    // 10 unknown unique wines; AI_CONCURRENCY=5 → first wave of 5 launches and
+    // blocks; after the client disconnects, the remaining 5 must never launch.
+    const resolvers = [];
+    identifyWineFromText.mockImplementation(() => new Promise((resolve) => {
+      resolvers.push(() => resolve({ data: null, debugRaw: 'x', debugReason: 'ai_unknown: nope' }));
+    }));
+
+    const app = buildApp();
+    const server = http.createServer(app);
+    await new Promise(r => server.listen(0, r));
+
+    const items = Array.from({ length: 10 }, (_, i) => ({
+      wineName: `Ghost ${i}`, producer: `Phantom ${i}`, vintage: '2020',
+    }));
+    const payload = JSON.stringify({ cellarId: CELLAR_ID, items });
+    const req = http.request({
+      port: server.address().port,
+      path: '/api/bottles/import/validate',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        authorization: `Bearer ${authToken()}`,
+      },
+    });
+    req.on('error', () => {}); // ECONNRESET from our own destroy
+    req.on('response', (r) => r.resume());
+    req.write(payload);
+    req.end();
+
+    try {
+      // First concurrency wave in flight
+      await waitFor(() => resolvers.length === 5);
+      req.destroy();
+      // Let the server observe the close event
+      await new Promise(r => setTimeout(r, 100));
+      // Release the in-flight calls; the workers then pull the remaining
+      // tasks, see the disconnect, and skip them.
+      for (const fn of resolvers.splice(0)) fn();
+      await new Promise(r => setTimeout(r, 200));
+
+      expect(identifyWineFromText).toHaveBeenCalledTimes(5);
+      // Debits stopped with the launches (ai_unknown is a completed call — kept)
+      expect(userDebits()).toBe(5);
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  });
+});

--- a/backend/src/routes/wines.aiBudget.test.js
+++ b/backend/src/routes/wines.aiBudget.test.js
@@ -1,0 +1,256 @@
+/**
+ * Shared daily AI budget on the Anthropic-backed wine endpoints
+ * (SECURITY_AUDIT_2026-07-08 L-14): scan-label / identify-text / ai-info.
+ *
+ * Unlike the import pipeline (which degrades to fuzzy matching), these
+ * endpoints have no non-AI fallback — over budget they must return
+ * 429 { code: 'ai_budget_exhausted' } with a Retry-After pointing at the
+ * next UTC midnight, without ever reaching rembg or Claude. Successful calls
+ * debit once; transport failures refund.
+ *
+ * Real router + real aiBudget service; AiUsage and the Anthropic layer are
+ * mocked (no MongoDB).
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+}));
+jest.mock('../services/labelScan', () => ({
+  scanLabelFull: jest.fn(),
+  identifyWineFromQuery: jest.fn(),
+}));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+
+// In-memory AiUsage so the REAL debit/refund logic runs without Mongo.
+jest.mock('../models/AiUsage', () => {
+  const store = new Map();
+  return {
+    findOneAndUpdate: jest.fn(async (filter, update) => {
+      const k = `${filter.userId}|${filter.date}`;
+      if (!store.has(k)) store.set(k, { userId: filter.userId, date: filter.date, count: 0 });
+      const doc = store.get(k);
+      if (update.$inc && typeof update.$inc.count === 'number') doc.count += update.$inc.count;
+      return { ...doc };
+    }),
+    __store: store,
+  };
+});
+
+const http = require('http');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const sharp = require('sharp');
+const AiUsage = require('../models/AiUsage');
+const rateLimitsConfig = require('../config/rateLimits');
+const { todayUTC } = require('../services/aiBudget');
+const { scanLabelFull, identifyWineFromQuery } = require('../services/labelScan');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const winesRouter = require('./wines');
+
+sharp.cache(false);
+
+const USER_ID = 'u1';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ limit: '10mb' }));
+  app.use('/api/wines', winesRouter);
+  return app;
+}
+
+function postJson(app, url, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' })}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, headers: res.headers, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end(payload);
+    });
+  });
+}
+
+const userDebits = () => AiUsage.__store.get(`${USER_ID}|${todayUTC()}`)?.count ?? 0;
+
+function setLimits(overrides = {}) {
+  rateLimitsConfig.set({
+    ...JSON.parse(JSON.stringify(rateLimitsConfig.defaults)),
+    ...overrides,
+  });
+}
+
+function exhaustUserBudget(max) {
+  setLimits({ aiDailyBudget: { max } });
+  AiUsage.__store.set(`${USER_ID}|${todayUTC()}`, { userId: USER_ID, date: todayUTC(), count: max });
+}
+
+let app;
+const realFetch = global.fetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  AiUsage.__store.clear();
+  setLimits();
+  app = buildApp();
+  // rembg unreachable — scan-label falls back to the sanitized original
+  global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+});
+
+afterEach(() => {
+  global.fetch = realFetch;
+});
+
+afterAll(() => {
+  rateLimitsConfig.set(JSON.parse(JSON.stringify(rateLimitsConfig.defaults)));
+});
+
+describe('POST /api/wines/scan-label — daily AI budget', () => {
+  async function validImage() {
+    const buf = await sharp({
+      create: { width: 8, height: 8, channels: 3, background: { r: 120, g: 30, b: 40 } },
+    }).png().toBuffer();
+    return buf.toString('base64');
+  }
+
+  test('over budget → 429 ai_budget_exhausted with Retry-After, before rembg or Claude', async () => {
+    exhaustUserBudget(3);
+
+    const res = await postJson(app, '/api/wines/scan-label', { image: await validImage() });
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe('ai_budget_exhausted');
+    expect(res.body.scope).toBe('user_budget');
+    expect(res.body.retryAfterSeconds).toBeGreaterThan(0);
+    expect(res.body.retryAfterSeconds).toBeLessThanOrEqual(24 * 3600);
+    expect(Number(res.headers['retry-after'])).toBe(res.body.retryAfterSeconds);
+    expect(global.fetch).not.toHaveBeenCalled();      // never reached rembg
+    expect(scanLabelFull).not.toHaveBeenCalled();     // never reached Claude
+    expect(userDebits()).toBe(3);                     // overshoot refunded
+  });
+
+  test('within budget: the scan debits exactly once', async () => {
+    // No producer → the route skips the registry-match block (which would
+    // need MongoDB); this test is about the budget debit only.
+    scanLabelFull.mockResolvedValue({ name: 'Wine', producer: null, grapes: [] });
+
+    const res = await postJson(app, '/api/wines/scan-label', { image: await validImage() });
+
+    expect(res.status).toBe(200);
+    expect(scanLabelFull).toHaveBeenCalledTimes(1);
+    expect(userDebits()).toBe(1);
+  });
+
+  test('a failed scan refunds the debit', async () => {
+    const err = new Error('Could not read label');
+    err.status = 422;
+    scanLabelFull.mockRejectedValue(err);
+
+    const res = await postJson(app, '/api/wines/scan-label', { image: await validImage() });
+
+    expect(res.status).toBe(422);
+    expect(userDebits()).toBe(0);
+  });
+});
+
+describe('POST /api/wines/identify-text — daily AI budget', () => {
+  test('over budget → 429 ai_budget_exhausted, Claude never called', async () => {
+    exhaustUserBudget(5);
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'Albert Bichot Fixin 2019' });
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe('ai_budget_exhausted');
+    expect(Number(res.headers['retry-after'])).toBeGreaterThan(0);
+    expect(identifyWineFromQuery).not.toHaveBeenCalled();
+  });
+
+  test('global kill-switch tripped → 429 with global_cap scope, user debit refunded', async () => {
+    setLimits({ aiGlobalDailyCap: { max: 10 } });
+    AiUsage.__store.set(`null|${todayUTC()}`, { userId: null, date: todayUTC(), count: 10 });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'anything' });
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe('ai_budget_exhausted');
+    expect(res.body.scope).toBe('global_cap');
+    expect(userDebits()).toBe(0); // user debit rolled back when the global cap tripped
+    expect(identifyWineFromQuery).not.toHaveBeenCalled();
+  });
+
+  test('successful identify debits once', async () => {
+    identifyWineFromQuery.mockResolvedValue({
+      data: { name: 'Fixin', producer: 'Albert Bichot', country: 'France', grapes: [] },
+      debugRaw: 'raw',
+      debugReason: null,
+    });
+    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1', name: 'Fixin', producer: 'Albert Bichot' }, created: true });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'Albert Bichot Fixin 2019' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.wine.name).toBe('Fixin');
+    expect(userDebits()).toBe(1);
+  });
+
+  test('a transport failure refunds; an ai_unknown answer stays debited', async () => {
+    identifyWineFromQuery.mockResolvedValueOnce({ data: null, debugRaw: 'x', debugReason: 'exception: boom' });
+    let res = await postJson(app, '/api/wines/identify-text', { query: 'whatever' });
+    expect(res.status).toBe(200);
+    expect(res.body.wine).toBeNull();
+    expect(userDebits()).toBe(0); // refunded
+
+    identifyWineFromQuery.mockResolvedValueOnce({ data: null, debugRaw: 'x', debugReason: 'ai_unknown: no idea' });
+    res = await postJson(app, '/api/wines/identify-text', { query: 'whatever' });
+    expect(res.status).toBe(200);
+    expect(userDebits()).toBe(1); // a completed Anthropic call — kept
+  });
+});
+
+describe('POST /api/wines/ai-info — daily AI budget', () => {
+  test('over budget → 429 ai_budget_exhausted', async () => {
+    exhaustUserBudget(2);
+
+    const res = await postJson(app, '/api/wines/ai-info', { query: 'Chateau Margaux 2015' });
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe('ai_budget_exhausted');
+    expect(identifyWineFromQuery).not.toHaveBeenCalled();
+  });
+
+  test('within budget: debits once and returns the AI data', async () => {
+    identifyWineFromQuery.mockResolvedValue({
+      data: { name: 'Château Margaux', producer: 'Château Margaux', country: 'France', grapes: [] },
+      debugRaw: 'raw',
+      debugReason: null,
+    });
+
+    const res = await postJson(app, '/api/wines/ai-info', { query: 'Chateau Margaux 2015' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.wine.name).toBe('Château Margaux');
+    expect(userDebits()).toBe(1);
+  });
+});

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -14,10 +14,28 @@ const { isValidId } = require('../utils/validation');
 const { submitUrls } = require('../services/indexNow');
 const { getReleaseCurve } = require('../services/communityPrice');
 const aiBurstLimiter = require('../middleware/aiBurstLimiter');
+const { tryDebitAi, isRefundableFailure } = require('../services/aiBudget');
 
 const REMBG_URL = process.env.REMBG_URL || 'http://rembg:5000';
 
 const router = express.Router();
+
+/**
+ * 429 for the Anthropic-backed endpoints when the shared per-user daily AI
+ * budget (or the site-wide daily cap) is exhausted. These endpoints have no
+ * non-AI fallback, unlike the import pipeline (which degrades to fuzzy
+ * matching instead). Retry-After points at the next UTC midnight, when the
+ * daily window resets.
+ */
+function sendAiBudgetExhausted(res, debit) {
+  res.set('Retry-After', String(debit.retryAfterSeconds));
+  return res.status(429).json({
+    error: 'Daily AI budget reached. AI features reset at midnight UTC.',
+    code: 'ai_budget_exhausted',
+    scope: debit.reason, // 'user_budget' | 'global_cap'
+    retryAfterSeconds: debit.retryAfterSeconds,
+  });
+}
 
 const USER_SEARCH_LIMIT = 10;
 
@@ -181,6 +199,12 @@ router.post('/scan-label', requireAuth, aiBurstLimiter, async (req, res) => {
   }
   const safeMediaType = `image/${detectImageFormat(safeBuffer) || 'jpeg'}`;
 
+  // Debit the shared daily AI budget BEFORE any expensive work (rembg + the
+  // Claude vision call); refunded below if the scan fails (mirrors chat's
+  // debit-before / refund-on-error pattern).
+  const debit = await tryDebitAi(req.user.id);
+  if (!debit.ok) return sendAiBudgetExhausted(res, debit);
+
   try {
     // 1. Attempt background removal via rembg (non-fatal — falls back to the
     //    sanitized original)
@@ -266,6 +290,7 @@ router.post('/scan-label', requireAuth, aiBurstLimiter, async (req, res) => {
 
     res.json({ extracted, match, labelImage });
   } catch (err) {
+    await debit.refund();
     console.error('Label scan error:', err.message);
     res.status(err.status || 500).json({ error: err.message || 'Label scan failed' });
   }
@@ -333,15 +358,21 @@ router.post('/identify-text', requireAuth, aiBurstLimiter, async (req, res) => {
   const query = typeof req.body.query === 'string' ? req.body.query.trim() : '';
   if (!query) return res.status(400).json({ error: 'query is required' });
 
+  const debit = await tryDebitAi(req.user.id);
+  if (!debit.ok) return sendAiBudgetExhausted(res, debit);
+
   try {
     const result = await identifyWineFromQuery(query);
     if (!result.data) {
+      // Transport-level failures never produced a billable completion
+      if (isRefundableFailure(result.debugReason)) await debit.refund();
       return res.json({ wine: null, reason: result.debugReason });
     }
 
     const { wine, created } = await findOrCreateWine(result.data, req.user.id);
     return res.json({ wine: wine.toObject ? wine.toObject() : wine, created });
   } catch (err) {
+    await debit.refund();
     console.error('Identify text error:', err);
     return res.status(500).json({ error: err.message || 'Failed to identify wine' });
   }
@@ -354,13 +385,19 @@ router.post('/ai-info', requireAuth, aiBurstLimiter, async (req, res) => {
   const query = typeof req.body.query === 'string' ? req.body.query.trim() : '';
   if (!query) return res.status(400).json({ error: 'query is required' });
 
+  const debit = await tryDebitAi(req.user.id);
+  if (!debit.ok) return sendAiBudgetExhausted(res, debit);
+
   try {
     const result = await identifyWineFromQuery(query);
     if (!result.data) {
+      // Transport-level failures never produced a billable completion
+      if (isRefundableFailure(result.debugReason)) await debit.refund();
       return res.json({ wine: null, reason: result.debugReason });
     }
     return res.json({ wine: result.data });
   } catch (err) {
+    await debit.refund();
     console.error('AI info error:', err);
     return res.status(500).json({ error: err.message || 'Failed to get AI wine info' });
   }

--- a/backend/src/routes/wines.scanLabel.test.js
+++ b/backend/src/routes/wines.scanLabel.test.js
@@ -25,6 +25,12 @@ jest.mock('../services/labelScan', () => ({
 jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
 // Rate limiting is exercised elsewhere; keep this suite about sanitization.
 jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+// The daily AI budget (services/aiBudget) hits MongoDB — mocked out here; the
+// budget behaviour itself is covered by wines.aiBudget.test.js.
+jest.mock('../services/aiBudget', () => ({
+  tryDebitAi: jest.fn().mockResolvedValue({ ok: true, refund: jest.fn() }),
+  isRefundableFailure: jest.fn().mockReturnValue(false),
+}));
 
 const http = require('http');
 const express = require('express');

--- a/backend/src/services/aiBudget.js
+++ b/backend/src/services/aiBudget.js
@@ -1,0 +1,134 @@
+/**
+ * Shared per-user daily AI budget + site-wide daily kill-switch.
+ * (SECURITY_AUDIT_2026-07-08 M-2 / L-14.)
+ *
+ * One debit per actual Anthropic call across: import identify (per unique
+ * wine that reaches the AI step), scan-label, identify-text, ai-info, and
+ * user-triggered wine enrichment (enrichWineById with a budgetUserId).
+ * Chat keeps its own separate quota (ChatUsage / aiConfig.chatDailyLimit).
+ *
+ * Debit/refund semantics mirror routes/chat.js exactly:
+ *   - debit BEFORE the call, atomically ($inc is the gate — N concurrent
+ *     requests at the limit can't all pass a check-then-increment),
+ *   - refund on overshoot,
+ *   - refund on Anthropic transport failure (thrown error, rate-limit, or an
+ *     `exception:`/`no_api_key` debugReason from services/labelScan) — a call
+ *     that completed but answered "unknown wine" stays debited.
+ *
+ * Knobs (admin-tunable via PATCH /api/admin/settings/rate-limits, cached in
+ * config/rateLimits.js):
+ *   aiDailyBudget.max     – per-user Anthropic calls per UTC day (0 = unlimited)
+ *   aiGlobalDailyCap.max  – site-wide Anthropic calls per UTC day (0 = disabled)
+ *
+ * The global counter is a singleton AiUsage row per day with userId: null.
+ */
+
+const AiUsage = require('../models/AiUsage');
+const rateLimitsConfig = require('../config/rateLimits');
+
+// Same retention window as ChatUsage — keeps the usage history inspectable
+// without retaining per-user metadata indefinitely (TTL index on expiresAt).
+const RETENTION_DAYS = 90;
+
+// Returns today's UTC date string 'YYYY-MM-DD'
+function todayUTC() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function expiresAt() {
+  return new Date(Date.now() + RETENTION_DAYS * 24 * 60 * 60 * 1000);
+}
+
+// Seconds until the next UTC midnight — the budget window resets then.
+// Used for the Retry-After header on 429 responses.
+function secondsUntilMidnightUTC(now = new Date()) {
+  const next = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1);
+  return Math.max(1, Math.ceil((next - now.getTime()) / 1000));
+}
+
+/**
+ * Atomic upsert-increment on the (userId, date) usage row.
+ * A concurrent first-of-the-day upsert can lose the unique-index race with
+ * E11000 — one retry then hits the existing document (same as chat.js).
+ */
+async function incUsage(userId, date, n) {
+  try {
+    return await AiUsage.findOneAndUpdate(
+      { userId, date },
+      { $inc: { count: n }, $setOnInsert: { expiresAt: expiresAt() } },
+      { upsert: true, new: true }
+    );
+  } catch (err) {
+    if (err.code !== 11000) throw err;
+    return AiUsage.findOneAndUpdate({ userId, date }, { $inc: { count: n } }, { new: true });
+  }
+}
+
+/**
+ * Debit one Anthropic call against the user's daily budget AND the global
+ * daily cap. The increment itself is the gate; overshoot is refunded.
+ *
+ * Returns:
+ *   { ok: true,  refund }                                   — call may proceed
+ *   { ok: false, reason: 'user_budget' | 'global_cap',
+ *     retryAfterSeconds }                                    — over budget
+ *
+ * `refund()` is idempotent and reverses exactly what was debited — call it
+ * when the Anthropic call fails at the transport level so a failed call
+ * doesn't consume budget.
+ */
+async function tryDebitAi(userId) {
+  const cfg = rateLimitsConfig.get();
+  const budget    = cfg.aiDailyBudget?.max    ?? rateLimitsConfig.defaults.aiDailyBudget.max;
+  const globalCap = cfg.aiGlobalDailyCap?.max ?? rateLimitsConfig.defaults.aiGlobalDailyCap.max;
+  const date = todayUTC();
+  const debited = { user: false, global: false };
+
+  const refund = async () => {
+    const u = debited.user;
+    const g = debited.global;
+    debited.user = false;
+    debited.global = false;
+    try {
+      if (u) await incUsage(userId, date, -1);
+      if (g) await incUsage(null, date, -1);
+    } catch (err) {
+      console.warn('[aiBudget] refund failed:', err.message);
+    }
+  };
+
+  if (budget > 0) {
+    const usage = await incUsage(userId, date, 1);
+    debited.user = true;
+    if (usage.count > budget) {
+      await refund();
+      return { ok: false, reason: 'user_budget', retryAfterSeconds: secondsUntilMidnightUTC() };
+    }
+  }
+
+  if (globalCap > 0) {
+    const global = await incUsage(null, date, 1);
+    debited.global = true;
+    if (global.count > globalCap) {
+      await refund(); // reverses the global AND any user debit above
+      return { ok: false, reason: 'global_cap', retryAfterSeconds: secondsUntilMidnightUTC() };
+    }
+  }
+
+  return { ok: true, refund };
+}
+
+/**
+ * True when a null-data result from services/labelScan represents a failure
+ * that never produced a billable Anthropic completion — the debit should be
+ * refunded. `ai_unknown:*` (the model answered but couldn't identify the
+ * wine) is a real completed call and stays debited.
+ */
+function isRefundableFailure(debugReason) {
+  if (!debugReason) return false;
+  return debugReason === 'no_api_key'
+    || debugReason === 'rate_limit_exceeded'
+    || debugReason.startsWith('exception');
+}
+
+module.exports = { tryDebitAi, isRefundableFailure, todayUTC, secondsUntilMidnightUTC };

--- a/backend/src/services/aiBudget.test.js
+++ b/backend/src/services/aiBudget.test.js
@@ -1,0 +1,129 @@
+/**
+ * services/aiBudget — shared per-user daily AI budget + global kill-switch
+ * (SECURITY_AUDIT_2026-07-08 M-2/L-14).
+ *
+ * Debit/refund semantics mirror routes/chat.js: the atomic $inc IS the gate
+ * (no check-then-increment race), overshoot is refunded, and a transport-
+ * level failure refunds the debit. The global cap is a singleton row with
+ * userId: null.
+ */
+
+jest.mock('../models/AiUsage', () => {
+  const store = new Map(); // `${userId}|${date}` -> { userId, date, count }
+  const model = {
+    findOneAndUpdate: jest.fn(async (filter, update) => {
+      const k = `${filter.userId}|${filter.date}`;
+      if (!store.has(k)) store.set(k, { userId: filter.userId, date: filter.date, count: 0 });
+      const doc = store.get(k);
+      if (update.$inc && typeof update.$inc.count === 'number') doc.count += update.$inc.count;
+      return { ...doc };
+    }),
+    __store: store,
+  };
+  return model;
+});
+
+const AiUsage = require('../models/AiUsage');
+const rateLimitsConfig = require('../config/rateLimits');
+const { tryDebitAi, isRefundableFailure, todayUTC, secondsUntilMidnightUTC } = require('./aiBudget');
+
+const USER = 'u1';
+const userCount = () => AiUsage.__store.get(`${USER}|${todayUTC()}`)?.count ?? 0;
+const globalCount = () => AiUsage.__store.get(`null|${todayUTC()}`)?.count ?? 0;
+
+function setLimits({ budget, globalCap }) {
+  rateLimitsConfig.set({
+    ...JSON.parse(JSON.stringify(rateLimitsConfig.defaults)),
+    aiDailyBudget: { max: budget },
+    aiGlobalDailyCap: { max: globalCap },
+  });
+}
+
+beforeEach(() => {
+  AiUsage.__store.clear();
+  jest.clearAllMocks();
+  setLimits({ budget: 500, globalCap: 20000 });
+});
+
+afterAll(() => {
+  rateLimitsConfig.set(JSON.parse(JSON.stringify(rateLimitsConfig.defaults)));
+});
+
+describe('tryDebitAi', () => {
+  test('debits one user + one global unit per call', async () => {
+    const res = await tryDebitAi(USER);
+    expect(res.ok).toBe(true);
+    expect(userCount()).toBe(1);
+    expect(globalCount()).toBe(1);
+  });
+
+  test('the increment is the gate: over-budget call is rejected and refunded', async () => {
+    setLimits({ budget: 2, globalCap: 20000 });
+    expect((await tryDebitAi(USER)).ok).toBe(true);
+    expect((await tryDebitAi(USER)).ok).toBe(true);
+
+    const third = await tryDebitAi(USER);
+    expect(third.ok).toBe(false);
+    expect(third.reason).toBe('user_budget');
+    expect(third.retryAfterSeconds).toBeGreaterThan(0);
+    expect(third.retryAfterSeconds).toBeLessThanOrEqual(24 * 3600);
+    // Overshoot refunded — usage stays at the budget, global untouched by the overshoot
+    expect(userCount()).toBe(2);
+    expect(globalCount()).toBe(2);
+  });
+
+  test('global cap trips independently of the user budget and refunds the user debit', async () => {
+    setLimits({ budget: 500, globalCap: 1 });
+    expect((await tryDebitAi(USER)).ok).toBe(true);
+
+    const second = await tryDebitAi('another-user');
+    expect(second.ok).toBe(false);
+    expect(second.reason).toBe('global_cap');
+    // Both the global overshoot AND the other user's debit were refunded
+    expect(globalCount()).toBe(1);
+    expect(AiUsage.__store.get(`another-user|${todayUTC()}`).count).toBe(0);
+  });
+
+  test('0 disables: budget 0 = unlimited, global 0 = kill-switch off (no rows written)', async () => {
+    setLimits({ budget: 0, globalCap: 0 });
+    const res = await tryDebitAi(USER);
+    expect(res.ok).toBe(true);
+    expect(AiUsage.__store.size).toBe(0);
+    await res.refund(); // must be a harmless no-op
+    expect(AiUsage.__store.size).toBe(0);
+  });
+
+  test('refund reverses the debit and is idempotent', async () => {
+    const res = await tryDebitAi(USER);
+    expect(userCount()).toBe(1);
+    expect(globalCount()).toBe(1);
+    await res.refund();
+    expect(userCount()).toBe(0);
+    expect(globalCount()).toBe(0);
+    await res.refund(); // second call must not double-refund
+    expect(userCount()).toBe(0);
+    expect(globalCount()).toBe(0);
+  });
+});
+
+describe('isRefundableFailure', () => {
+  test('transport-level failures are refundable', () => {
+    expect(isRefundableFailure('rate_limit_exceeded')).toBe(true);
+    expect(isRefundableFailure('exception: socket hang up')).toBe(true);
+    expect(isRefundableFailure('no_api_key')).toBe(true);
+  });
+
+  test('a completed call that answered "unknown" stays debited', () => {
+    expect(isRefundableFailure('ai_unknown: not a real wine')).toBe(false);
+    expect(isRefundableFailure('missing_name_or_producer_in_response')).toBe(false);
+    expect(isRefundableFailure(null)).toBe(false);
+  });
+});
+
+describe('secondsUntilMidnightUTC', () => {
+  test('points at the next UTC midnight', () => {
+    const s = secondsUntilMidnightUTC(new Date('2026-07-09T23:59:30Z'));
+    expect(s).toBe(30);
+    expect(secondsUntilMidnightUTC(new Date('2026-07-09T00:00:00Z'))).toBe(24 * 3600);
+  });
+});

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -22,6 +22,7 @@
 
 const mongoose = require('mongoose');
 const aiConfig = require('../config/aiConfig');
+const { tryDebitAi, isRefundableFailure } = require('./aiBudget');
 const { suggestProfile } = require('./labelScan');
 const { embedSinglePair } = require('./embeddingJob');
 const { isValidId } = require('../utils/validation');
@@ -239,9 +240,18 @@ async function enrichWine(wine, model) {
  * waiting for the next batch run. Skips silently if the wine already has a
  * profile or AI isn't configured. Never throws.
  *
+ * When triggered by a user action (bottle-add), pass `budgetUserId` so the
+ * Anthropic call is debited against that user's shared daily AI budget
+ * (SECURITY_AUDIT_2026-07-08 L-14). Over budget → skip silently (the profile
+ * arrives with the next admin batch run instead — graceful degradation, the
+ * user's own action still succeeds). The admin-run batch job calls
+ * enrichWine() directly and is exempt.
+ *
  * @param {string|object} wineDefId
+ * @param {object}  [opts]
+ * @param {string}  [opts.budgetUserId] – user to debit for this AI call
  */
-async function enrichWineById(wineDefId) {
+async function enrichWineById(wineDefId, { budgetUserId } = {}) {
   // Validate + cast the (caller-supplied) id to a real ObjectId before it touches
   // the query, so a non-id value can never shape the database lookup. The cast
   // value (idStr/oid), never the raw input, is used everywhere below.
@@ -264,7 +274,26 @@ async function enrichWineById(wineDefId) {
       .lean();
     if (!wine) return;
     if (wine.aiProfile && wine.aiProfile.description) return; // already enriched
-    await enrichWine(wine, aiConfig.get().enrichmentModel);
+
+    if (budgetUserId) {
+      const debit = await tryDebitAi(String(budgetUserId));
+      if (!debit.ok) {
+        // Over the shared daily AI budget — skip silently; the next admin
+        // batch run picks the wine up. The triggering action never fails.
+        console.warn('[enrichmentJob] enrichWineById skipped (%s): ai budget exhausted (%s)', idStr, debit.reason);
+        return;
+      }
+      try {
+        const { result, reason } = await enrichWine(wine, aiConfig.get().enrichmentModel);
+        // A transport-level failure never produced a billable completion
+        if (result === 'skipped' && isRefundableFailure(reason)) await debit.refund();
+      } catch (err) {
+        await debit.refund();
+        throw err; // handled by the outer catch below
+      }
+    } else {
+      await enrichWine(wine, aiConfig.get().enrichmentModel);
+    }
     console.log('[enrichmentJob] Auto-enriched new wine: %s', wine.name);
   } catch (err) {
     console.warn('[enrichmentJob] enrichWineById failed (%s): %s', idStr, err.message);

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -25,6 +25,7 @@
  *         AUDIT_MAX, truncated }
  */
 const User = require('../models/User');
+const AiUsage = require('../models/AiUsage');
 const Bottle = require('../models/Bottle');
 const BottleImage = require('../models/BottleImage');
 const Cellar = require('../models/Cellar');
@@ -465,6 +466,17 @@ const REGISTRY = [
     exportFragment: async (ctx) => ({
       importSessions: markTrunc(ctx, 'importSessions', await ImportSession.find({ user: ctx.userId }).select('cellar status results positionAnchor rackConfigs defaultCurrency createdAt').limit(EXPORT_MAX).lean())
         .map(s => ({ cellar: s.cellar, status: s.status, rowCount: s.results?.length || 0, positionAnchor: s.positionAnchor, rackConfigs: s.rackConfigs, defaultCurrency: s.defaultCurrency, createdAt: s.createdAt })),
+    }),
+  },
+  {
+    // Same handling as ChatUsage: per-user daily AI-call counters (90-day
+    // TTL). The site-wide kill-switch row has userId: null and is not
+    // personal data — untouched by the per-user purge, as intended.
+    model: AiUsage, category: 'personal-data', userFields: ['userId'],
+    purge: (ctx) => AiUsage.deleteMany({ userId: ctx.userId }),
+    exportFragment: async (ctx) => ({
+      aiUsage: markTrunc(ctx, 'aiUsage', await AiUsage.find({ userId: ctx.userId }).select('date count').limit(EXPORT_MAX).lean())
+        .map(u => ({ date: u.date, count: u.count })),
     }),
   },
   {

--- a/backend/src/services/wineMatching.js
+++ b/backend/src/services/wineMatching.js
@@ -7,7 +7,7 @@
  * Composite score = name × 0.45 + producer × 0.45 + appellation × 0.10
  */
 
-const { combinedSimilarity } = require('../utils/normalize');
+const { combinedSimilarity, normalizeString } = require('../utils/normalize');
 
 const WEIGHTS = { name: 0.45, producer: 0.45, appellation: 0.10 };
 
@@ -46,6 +46,88 @@ function scoreWineMatch(candidate, query, { redistribute = true } = {}) {
   return score;
 }
 
+// ── Producer-embedded name variants (import path) ───────────────────────────
+//
+// The registry stores producer and wine name SEPARATELY, but import rows often
+// embed the producer inside the wine name (CellarTracker's Bottles/Consumed
+// tables have no Producer column — the Wine value is the full display name,
+// e.g. "Domaine de la Romanée-Conti La Tâche"). Without variant handling those
+// rows score poorly against their own registry wine, missing known wines.
+
+/**
+ * Normalized full display name: producer + name, deduped when the name
+ * already embeds the producer as a prefix (same guard as generateWineSlug).
+ * Makes producer placement irrelevant for equality comparison.
+ */
+function concatNormalized(producer, name) {
+  const nName = normalizeString(name);
+  const nProducer = normalizeString(producer);
+  if (!nName) return nProducer;
+  if (!nProducer || nName === nProducer || nName.startsWith(nProducer + ' ')) return nName;
+  return `${nProducer} ${nName}`;
+}
+
+/**
+ * If `name` starts with the tokens of `producer` (normalized comparison),
+ * return the normalized remainder — else null. The remainder is safe to feed
+ * back into the scorers/generateWineKey: normalizeString is idempotent.
+ */
+function stripProducerPrefix(name, producer) {
+  const nName = normalizeString(name);
+  const nProducer = normalizeString(producer);
+  if (!nProducer || !nName.startsWith(nProducer + ' ')) return null;
+  const remainder = nName.slice(nProducer.length + 1).trim();
+  return remainder || null;
+}
+
+/**
+ * Variant-aware scorer for the import path: the max of scoreWineMatch over
+ * producer-embedded name variants. Strictly monotonic relative to
+ * scoreWineMatch — the raw comparison is always included and max() only ever
+ * raises the score — so it is safe to substitute wherever a higher score for
+ * the same registry wine is desirable (import matching). Non-import callers
+ * keep using scoreWineMatch unchanged.
+ *
+ * Variants:
+ *   1. Raw (query.producer, query.name) — today's comparison.
+ *   2. Concatenated equality: normalize(producer + ' ' + name) on both sides
+ *      (deduped when the name embeds the producer) — equality is treated as
+ *      an exact match (score 1).
+ *   3. Query-producer strip: query.name starts with query.producer → also try
+ *      the remainder as the name.
+ *   4. Candidate-producer strip: query.name starts with the CANDIDATE's
+ *      producer → try (candidate.producer, remainder); covers rows whose
+ *      producer column is empty or a parser guess while the full display
+ *      name is right.
+ */
+function scoreWineMatchVariants(candidate, query, opts) {
+  let best = scoreWineMatch(candidate, query, opts);
+  if (best >= 1) return best;
+
+  // 2. Concatenated-normalized equality — producer placement irrelevant.
+  const queryFull = concatNormalized(query.producer, query.name);
+  if (queryFull && queryFull === concatNormalized(candidate.producer, candidate.name)) {
+    return 1;
+  }
+
+  // 3. Strip the query's own producer prefix off the query name.
+  const strippedByQuery = stripProducerPrefix(query.name, query.producer);
+  if (strippedByQuery) {
+    best = Math.max(best, scoreWineMatch(candidate, { ...query, name: strippedByQuery }, opts));
+  }
+
+  // 4. Strip the candidate's producer prefix off the query name.
+  const strippedByCandidate = stripProducerPrefix(query.name, candidate.producer);
+  if (strippedByCandidate && strippedByCandidate !== strippedByQuery) {
+    best = Math.max(
+      best,
+      scoreWineMatch(candidate, { ...query, name: strippedByCandidate, producer: candidate.producer }, opts)
+    );
+  }
+
+  return best;
+}
+
 /**
  * Find the best match among a list of candidates.
  *
@@ -80,4 +162,12 @@ function scoreAllMatches(query, candidates, opts) {
     .sort((a, b) => b.score - a.score);
 }
 
-module.exports = { scoreWineMatch, findBestMatch, scoreAllMatches, WEIGHTS };
+module.exports = {
+  scoreWineMatch,
+  scoreWineMatchVariants,
+  concatNormalized,
+  stripProducerPrefix,
+  findBestMatch,
+  scoreAllMatches,
+  WEIGHTS,
+};

--- a/backend/src/services/wineMatching.variants.test.js
+++ b/backend/src/services/wineMatching.variants.test.js
@@ -1,0 +1,103 @@
+/**
+ * Producer-embedded name variants (scoreWineMatchVariants).
+ *
+ * WHY THIS TEST EXISTS:
+ * The registry stores producer and wine name SEPARATELY, but import rows
+ * often embed the producer inside the wine name — CellarTracker's Bottles/
+ * Consumed tables have no Producer column, so the Wine value is the full
+ * display name ("Domaine de la Romanée-Conti La Tâche") and the client-side
+ * parser can only guess the producer. The registry-first import cascade
+ * (audit M-2) relies on these rows still reaching the exact threshold
+ * (>= 0.95) against their own registry wine — otherwise known wines are
+ * missed and AI is called unnecessarily.
+ *
+ * The variant scorer must also be MONOTONIC (never lower than the raw
+ * scorer) and must NOT cross-match sibling wines from the same producer.
+ */
+
+const {
+  scoreWineMatch,
+  scoreWineMatchVariants,
+  concatNormalized,
+  stripProducerPrefix,
+} = require('./wineMatching');
+
+const EXACT = 0.95;
+
+// Registry wine — producer and name stored separately, per registry convention
+const LA_TACHE = { name: 'La Tâche', producer: 'Domaine de la Romanée-Conti', appellation: '' };
+// Sibling grand cru from the SAME producer — must never cross-match
+const ROMANEE_CONTI = { name: 'Romanée-Conti', producer: 'Domaine de la Romanée-Conti', appellation: '' };
+
+describe('scoreWineMatchVariants — producer-embedded import rows', () => {
+  test('(i) empty producer + full display name reaches exact threshold', () => {
+    const row = { name: 'Domaine de la Romanée-Conti La Tâche', producer: '', appellation: '' };
+    expect(scoreWineMatchVariants(LA_TACHE, row)).toBeGreaterThanOrEqual(EXACT);
+  });
+
+  test('(ii) producer set AND embedded in the name reaches exact threshold', () => {
+    const row = {
+      name: 'Domaine de la Romanée-Conti La Tâche',
+      producer: 'Domaine de la Romanée-Conti',
+      appellation: '',
+    };
+    expect(scoreWineMatchVariants(LA_TACHE, row)).toBeGreaterThanOrEqual(EXACT);
+  });
+
+  test('(iii) diacritic-free row matches the accented registry wine exactly', () => {
+    const row = { name: 'La Tache', producer: 'Domaine de la Romanee-Conti', appellation: '' };
+    expect(scoreWineMatchVariants(LA_TACHE, row)).toBeGreaterThanOrEqual(EXACT);
+  });
+
+  test('negative: sibling wines from the same producer do NOT cross-match', () => {
+    // Full display name of La Tâche scored against the Romanée-Conti sibling —
+    // the concatenated signal must not treat them as the same wine.
+    const row = { name: 'Domaine de la Romanée-Conti La Tâche', producer: '', appellation: '' };
+    expect(scoreWineMatchVariants(ROMANEE_CONTI, row)).toBeLessThan(EXACT);
+
+    // And with the producer split out correctly, still no sibling cross-match.
+    const cleanRow = { name: 'La Tâche', producer: 'Domaine de la Romanée-Conti', appellation: '' };
+    expect(scoreWineMatchVariants(ROMANEE_CONTI, cleanRow)).toBeLessThan(EXACT);
+  });
+
+  test('monotonic: variant score is never below the raw scoreWineMatch', () => {
+    const rows = [
+      { name: 'La Tâche', producer: 'Domaine de la Romanée-Conti', appellation: '' },
+      { name: 'Domaine de la Romanée-Conti La Tâche', producer: '', appellation: '' },
+      { name: 'Barolo Riserva', producer: 'Giacomo Conterno', appellation: 'Barolo DOCG' },
+      { name: 'Completely Unrelated', producer: 'Someone Else', appellation: '' },
+    ];
+    for (const row of rows) {
+      for (const candidate of [LA_TACHE, ROMANEE_CONTI]) {
+        expect(scoreWineMatchVariants(candidate, row))
+          .toBeGreaterThanOrEqual(scoreWineMatch(candidate, row));
+      }
+    }
+  });
+
+  test('unrelated wines still score low', () => {
+    const row = { name: 'Sauvignon Blanc', producer: 'Cloudy Bay', appellation: '' };
+    expect(scoreWineMatchVariants(LA_TACHE, row)).toBeLessThan(0.5);
+  });
+});
+
+describe('helpers', () => {
+  test('concatNormalized dedups an embedded producer prefix', () => {
+    // normalizeString drops punctuation without padding: 'Romanée-Conti' → 'romaneeconti'
+    expect(concatNormalized('Domaine de la Romanée-Conti', 'Domaine de la Romanée-Conti La Tâche'))
+      .toBe('domaine de la romaneeconti la tache');
+    expect(concatNormalized('Domaine de la Romanée-Conti', 'La Tâche'))
+      .toBe('domaine de la romaneeconti la tache');
+    expect(concatNormalized('', 'Domaine de la Romanée-Conti La Tâche'))
+      .toBe('domaine de la romaneeconti la tache');
+  });
+
+  test('stripProducerPrefix returns the normalized remainder or null', () => {
+    expect(stripProducerPrefix('Domaine de la Romanée-Conti La Tâche', 'Domaine de la Romanee-Conti'))
+      .toBe('la tache');
+    expect(stripProducerPrefix('La Tâche', 'Domaine de la Romanée-Conti')).toBeNull();
+    // Name identical to the producer — nothing left to strip
+    expect(stripProducerPrefix('Cloudy Bay', 'Cloudy Bay')).toBeNull();
+    expect(stripProducerPrefix('Anything', '')).toBeNull();
+  });
+});

--- a/frontend/src/pages/SuperAdmin/TabSettings.js
+++ b/frontend/src/pages/SuperAdmin/TabSettings.js
@@ -282,6 +282,75 @@ function ChatLimitsPanel({ apiFetch, config, defaults, error }) {
   );
 }
 
+function AiBudgetPanel({ apiFetch, config, defaults, error }) {
+  const [form,   setForm]   = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [msg,    setMsg]    = useState(null);
+
+  useEffect(() => {
+    if (config?.aiDailyBudget && config?.aiImportPerRequestCap && config?.aiGlobalDailyCap) {
+      setForm({
+        daily:      String(config.aiDailyBudget.max),
+        importCap:  String(config.aiImportPerRequestCap.max),
+        globalCap:  String(config.aiGlobalDailyCap.max),
+      });
+    }
+  }, [config]);
+
+  const save = async () => {
+    setSaving(true); setMsg(null);
+    try {
+      const res = await adminSaveRateLimits(apiFetch, {
+        aiDailyBudget:         { max: Number(form.daily) },
+        aiImportPerRequestCap: { max: Number(form.importCap) },
+        aiGlobalDailyCap:      { max: Number(form.globalCap) },
+      });
+      if (!res.ok) { const d = await res.json(); setMsg({ ok: false, text: d.error || 'Save failed' }); }
+      else setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+    } catch { setMsg({ ok: false, text: 'Network error' }); }
+    finally { setSaving(false); }
+  };
+
+  if (error) return null;
+  if (!form) return null;
+
+  return (
+    <PanelShell
+      title="AI daily budget (spend cap)"
+      intro="Shared Anthropic-call budget across label scan, text identify, AI info, import lookups and wine enrichment (chat has its own quota). When a user's budget runs out, imports degrade to fuzzy matching (never fail) and the single-shot AI endpoints return 429 until midnight UTC."
+      saving={saving} onSave={save} msg={msg}
+    >
+      <NumberField
+        label="Per-user daily AI calls"
+        unit="calls / day"
+        hint="0 = unlimited"
+        value={form.daily}
+        defaultValue={defaults?.aiDailyBudget?.max}
+        onChange={v => setForm(f => ({ ...f, daily: v }))}
+        min={0} max={1000000}
+      />
+      <NumberField
+        label="AI lookups per import request"
+        unit="calls / request"
+        hint="frontend validates in batches of 25, so legit clients never hit this"
+        value={form.importCap}
+        defaultValue={defaults?.aiImportPerRequestCap?.max}
+        onChange={v => setForm(f => ({ ...f, importCap: v }))}
+        min={1} max={2000}
+      />
+      <NumberField
+        label="Site-wide daily kill-switch"
+        unit="calls / day"
+        hint="total across all users; 0 = disabled"
+        value={form.globalCap}
+        defaultValue={defaults?.aiGlobalDailyCap?.max}
+        onChange={v => setForm(f => ({ ...f, globalCap: v }))}
+        min={0} max={10000000}
+      />
+    </PanelShell>
+  );
+}
+
 function ContactEmailPanel({ apiFetch }) {
   const [value, setValue] = useState('');
   const [saving, setSaving] = useState(false);
@@ -350,6 +419,7 @@ export default function TabSettings() {
       <PerIpLimitsPanel apiFetch={apiFetch} {...rateLimits} />
       <AccountLockoutPanel apiFetch={apiFetch} {...rateLimits} />
       <ChatLimitsPanel apiFetch={apiFetch} {...rateLimits} />
+      <AiBudgetPanel apiFetch={apiFetch} {...rateLimits} />
     </>
   );
 }


### PR DESCRIPTION
Closes the AI cost-exhaustion findings of SECURITY_AUDIT_2026-07-08: **M-2** (import /validate fans one request out to ~2,000 Sonnet calls) and **L-14** (scan-label/identify/ai-info/enrichment have burst caps but no daily ceiling).

**Guiding principle:** a legitimate 2,000-bottle import never breaks or degrades below today's quality — only abusive spend gets capped.

## 1. Registry-first cascade in `POST /import/validate` (cost ↓, quality =)

For each unique wine (existing name:producer dedup), **before** any AI call:

1. **(a) Exact `normalizedKey` lookup** — raw key + producer-prefix-stripped variant key (one indexed query) → `status: 'exact'`, zero AI.
2. **(b) Existing fuzzy scorer at the exact threshold (≥ 0.95)** → use it, zero AI. At ≥ 0.95 the AI's canonicalized result would dedup (via `findOrCreateWine`'s own 0.95 auto-match) to the same registry wine anyway, so skipping AI is **outcome-identical** — asserted in tests (same wineId, auto-accepted status).
3. **(c) Otherwise AI identify exactly as today** — match quality for unknown/messy wines is unchanged. The per-row "Look up" button (`forceAi`) still bypasses the cascade and always reaches AI.

**Producer-embedded wine names** (CellarTracker has no Producer column — the Wine value is the full display name): steps (a)/(b) compare using name variants and take the best score — raw, query-producer prefix strip, candidate-producer prefix strip, and concatenated-normalized equality (producer placement becomes irrelevant; equality = exact). Implemented as `scoreWineMatchVariants` in `services/wineMatching.js`, used **only by the import path**; it is provably monotonic (max over variants including the raw comparison — can only ever raise the best score), so no existing match gets worse. Sibling wines from the same producer are covered by a negative test (La Tâche vs Romanée-Conti do not cross-match).

## 2. Shared per-user daily AI budget (`AiUsage` + `services/aiBudget.js`)

New `AiUsage` model mirroring `ChatUsage` (per user, per UTC day, 90-day TTL). One debit per **actual Anthropic call** across: import identify (per unique wine reaching step c), scan-label, identify-text, ai-info, and `enrichWineById` when triggered by a user's bottle-add (`budgetUserId`). Chat keeps its own separate quota.

Debit/refund mirrors chat exactly: atomic `$inc` **is** the gate (debit before the call), overshoot refunded, refund on Anthropic transport failure (thrown error, `rate_limit_exceeded`, `exception:*`, `no_api_key`). A completed call that answers "unknown wine" stays debited.

## 3. Knobs (admin-tunable, DB-config via SuperAdmin → Settings)

| Knob | Default | Meaning |
|---|---|---|
| `aiDailyBudget.max` | **500** | Per-user Anthropic calls per UTC day (0 = unlimited) |
| `aiImportPerRequestCap.max` | **50** | AI identifies per `/import/validate` request (frontend batches at 25 — legit clients never hit this) |
| `aiGlobalDailyCap.max` | **20000** | Site-wide daily kill-switch, singleton `AiUsage` row with `userId: null` (0 = disabled) |

All three live in `config/rateLimits.js` (same cache/load as existing limits), are exposed in `GET/PATCH /api/admin/settings/rate-limits` with bounded validation, and have a new "AI daily budget" panel in SuperAdmin → Settings (same PanelShell pattern; the SuperAdmin console is English-only/not i18n'd, so no translation keys were needed).

## 4. Degradation semantics

| Surface | Over budget / global cap | Effect |
|---|---|---|
| `POST /import/validate` | remaining unique wines fall through to the existing fuzzy path | rows carry `aiSkipped: true`, response `summary.aiBudgetExhausted: true` — **never an error**, import continues; cascade-known wines still resolve at full quality (zero AI needed) |
| per-request fan-out cap | excess unique wines → fuzzy path | `aiSkipped: true` per row, **no** `aiBudgetExhausted` flag (cap ≠ budget) |
| client disconnect mid-fan-out | `res.on('close')` (with `writableEnded` guard) stops **launching** new identify calls; in-flight ones finish | unprocessed rows return as fuzzy/no_match; debits stop with the launches |
| scan-label / identify-text / ai-info | no non-AI fallback | `429 { code: 'ai_budget_exhausted', scope, retryAfterSeconds }` + `Retry-After` header (next UTC midnight) |
| bottle-add enrichment | skip silently | wine picked up by the next admin batch run; the bottle-add itself always succeeds |

Without budget pressure, `/validate` responses are byte-identical for the AI path (no new fields) — regression-tested.

## 5. GDPR

`AiUsage` registered in `services/userDataRegistry.js` exactly like `ChatUsage` (already present there): purged on account deletion, exported (`date` + `count`) in `GET /api/users/me/export`. The global kill-switch row has `userId: null` and is not personal data.

## 6. Tests

`cd backend && npm test` → **60 suites, 973 tests, all pass** (35 new). `cd frontend && npm test` → 439 pass. New suites:
- `services/wineMatching.variants.test.js` — DRC producer-embedded variants (i)/(ii)/(iii) reach ≥ 0.95, sibling negative, monotonicity
- `services/aiBudget.test.js` — atomic gate, overshoot refund, global-cap refund of the user debit, 0 = disabled, idempotent refund
- `routes/import.validate.aiBudget.test.js` — cascade skips AI with identical outcomes; unknown wines still get AI; mid-import exhaustion degrades gracefully; per-request cap; global cap; transport-failure refund; duplicate-row single debit; `forceAi` bypass; **disconnect stops new launches**; byte-identical regression + 25-item batch
- `routes/wines.aiBudget.test.js` — 429 shape/headers on all three endpoints, global-cap scope, debit-once, refund semantics

## Docker-compose impact

**None.** No new services, ports, or env vars — all knobs are DB-config (SiteConfig `rateLimits`), tunable live from SuperAdmin without redeploy. The new `AiUsage` collection and its TTL index are created automatically by Mongoose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
