### PR TITLE
feat: honest import reporting + CellarTracker transfer disclosure

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2674,6 +2674,7 @@
       "ctAllPending_other": "All {{count}} bottles in this file are pending (undelivered) purchases — Cellarion doesn't track bottles you haven't received yet."
     },
     "warnings": {
+      "ctTruncatedTitle": "Only 25 rows found — this export may be cut off.",
       "ctTruncated": "This looks like a single-page export (exactly 25 rows). In CellarTracker, choose 'All wines' instead of 'Only wines on this page' before exporting, or your import may be missing most of your cellar.",
       "ctPendingSkipped_one": "{{count}} pending (undelivered) bottle was not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery.",
       "ctPendingSkipped_other": "{{count}} pending (undelivered) bottles were not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery."
@@ -2685,6 +2686,22 @@
       "consumed": "Consumed table",
       "purchase": "Purchase table",
       "pending": "Pending purchases table"
+    },
+    "ctDisclosure": {
+      "title": "Moving from CellarTracker? Here's what transfers",
+      "dismiss": "Dismiss",
+      "carriedTitle": "Comes with you",
+      "carriedBottles": "Bottles and vintages (including non-vintage)",
+      "carriedRatings": "Your personal ratings (MY / MyScore)",
+      "carriedPurchase": "Purchase data — price, date and store",
+      "carriedWindows": "Drink windows, as a personal window on each bottle",
+      "carriedConsumed": "Drinking history (Bottles and Consumed exports)",
+      "carriedLocations": "Locations and bins, as racks or free-text locations",
+      "notCarriedTitle": "Can't come along",
+      "notCarriedNotes": "Community tasting note text — the export only contains note counts",
+      "notCarriedPhotos": "Label photos",
+      "notCarriedWishlist": "Wishlists",
+      "notCarriedWhy": "CellarTracker's export files simply don't include these, so no importer can carry them over."
     },
     "upload": {
       "resumeReviewTitle": "Your matched results are still here",
@@ -2865,6 +2882,17 @@
       "unplacedNote": "These bottles were imported successfully — they just couldn't be assigned a rack slot. You can place them manually from the Cellar page.",
       "viewErrors": "View errors ({{count}})",
       "errorRow": "Row {{row}}: {{reason}}",
+      "reportRow": "Row {{row}} ({{wine}}): {{reason}}",
+      "allImportedNote_one": "Your bottle made it into your cellar.",
+      "allImportedNote_other": "All {{count}} bottles made it into your cellar.",
+      "partialTitle": "{{created}} of {{total}} bottles imported",
+      "partialNote_one": "1 row didn't make it — the full breakdown is below.",
+      "partialNote_other": "{{count}} rows didn't make it — the full breakdown is below.",
+      "unplacedOnlyNote_one": "Every bottle was imported, but 1 couldn't be placed in a rack — details below.",
+      "unplacedOnlyNote_other": "Every bottle was imported, but {{count}} couldn't be placed in a rack — details below.",
+      "skippedSummary": "Skipped rows ({{count}})",
+      "skippedByYou": "Skipped by you during review",
+      "downloadReport": "Download report (CSV)",
       "goToCellar": "Go to Cellar",
       "importMore": "Import More"
     },

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2674,6 +2674,7 @@
       "ctAllPending_other": "Alla {{count}} flaskor i filen är väntande (olevererade) köp — Cellarion hanterar inte flaskor du ännu inte har fått."
     },
     "warnings": {
+      "ctTruncatedTitle": "Bara 25 rader hittades — exporten kan vara avklippt.",
       "ctTruncated": "Det här ser ut som en export av en enda sida (exakt 25 rader). Välj 'All wines' istället för 'Only wines on this page' i CellarTracker innan du exporterar, annars kan större delen av din källare saknas i importen.",
       "ctPendingSkipped_one": "{{count}} väntande (olevererad) flaska importerades inte: {{wines}}. Cellarion hanterar inte flaskor du ännu inte har fått — importera igen efter leverans.",
       "ctPendingSkipped_other": "{{count}} väntande (olevererade) flaskor importerades inte: {{wines}}. Cellarion hanterar inte flaskor du ännu inte har fått — importera igen efter leverans."
@@ -2685,6 +2686,22 @@
       "consumed": "Consumed-tabellen",
       "purchase": "Purchase-tabellen",
       "pending": "Pending-tabellen (väntande köp)"
+    },
+    "ctDisclosure": {
+      "title": "Byter du från CellarTracker? Det här följer med",
+      "dismiss": "Stäng",
+      "carriedTitle": "Följer med dig",
+      "carriedBottles": "Flaskor och årgångar (även utan årgång)",
+      "carriedRatings": "Dina personliga betyg (MY / MyScore)",
+      "carriedPurchase": "Köpdata — pris, datum och butik",
+      "carriedWindows": "Drickfönster, som ett personligt fönster på varje flaska",
+      "carriedConsumed": "Din druckna historik (Bottles- och Consumed-exporter)",
+      "carriedLocations": "Platser och fack, som hyllor eller fritextplatser",
+      "notCarriedTitle": "Kan inte följa med",
+      "notCarriedNotes": "Communityns provningsanteckningar — exporten innehåller bara antal, inte texten",
+      "notCarriedPhotos": "Etikettfoton",
+      "notCarriedWishlist": "Önskelistor",
+      "notCarriedWhy": "CellarTrackers exportfiler innehåller helt enkelt inte det här, så ingen import kan ta med det."
     },
     "upload": {
       "resumeReviewTitle": "Dina matchade resultat finns kvar",
@@ -2865,6 +2882,17 @@
       "unplacedNote": "De här flaskorna importerades korrekt — de kunde bara inte tilldelas en hyllplats. Du kan placera dem manuellt från källarsidan.",
       "viewErrors": "Visa fel ({{count}})",
       "errorRow": "Rad {{row}}: {{reason}}",
+      "reportRow": "Rad {{row}} ({{wine}}): {{reason}}",
+      "allImportedNote_one": "Din flaska kom med i källaren.",
+      "allImportedNote_other": "Alla {{count}} flaskor kom med i din källare.",
+      "partialTitle": "{{created}} av {{total}} flaskor importerade",
+      "partialNote_one": "1 rad kom inte med — hela uppdelningen finns nedan.",
+      "partialNote_other": "{{count}} rader kom inte med — hela uppdelningen finns nedan.",
+      "unplacedOnlyNote_one": "Alla flaskor importerades, men 1 kunde inte placeras i en hylla — detaljer nedan.",
+      "unplacedOnlyNote_other": "Alla flaskor importerades, men {{count}} kunde inte placeras i en hylla — detaljer nedan.",
+      "skippedSummary": "Överhoppade rader ({{count}})",
+      "skippedByYou": "Överhoppad av dig under granskningen",
+      "downloadReport": "Ladda ner rapport (CSV)",
       "goToCellar": "Gå till källaren",
       "importMore": "Importera fler"
     },

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1409,3 +1409,105 @@
   font: inherit;
   text-decoration: underline;
 }
+
+/* ── Honest reporting: elevated CT truncation warning ────────────────────── */
+
+/* The 25-row page-export case deserves more than a soft note — a user who
+   misses it imports 25 of maybe 2,000 bottles and thinks it worked. */
+.import-parse-warning-strong {
+  background: rgba(191, 138, 46, 0.18);
+  border: 1px solid #bf8a2e;
+  border-left-width: 5px;
+  font-size: 0.95rem;
+  padding: 1rem 1.25rem;
+}
+
+.import-parse-warning-strong strong {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: #bf8a2e;
+}
+
+/* ── CellarTracker "what transfers" disclosure (upload step) ─────────────── */
+
+.ct-disclosure-panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  margin: 0.75rem 0;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.ct-disclosure-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.ct-disclosure-head strong {
+  color: var(--color-text);
+}
+
+.ct-disclosure-dismiss {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+
+.ct-disclosure-cols {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.75rem 2rem;
+}
+
+.ct-disclosure-col-title {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.ct-disclosure-yes { color: var(--color-success); }
+.ct-disclosure-no { color: var(--color-danger); }
+
+.ct-disclosure-col ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--color-text-secondary);
+}
+
+.ct-disclosure-col li {
+  margin: 0.15rem 0;
+}
+
+.ct-disclosure-why {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+/* ── Honest reporting: done-step partial-success state ───────────────────── */
+
+.done-icon-warn {
+  background: rgba(191, 138, 46, 0.15);
+  color: #bf8a2e;
+  font-weight: 700;
+}
+
+.done-subtitle {
+  color: var(--color-text-secondary);
+  margin: -0.75rem 0 1.5rem;
+  font-size: 0.95rem;
+}
+
+.done-partial-note {
+  color: #bf8a2e;
+}

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -7,6 +7,7 @@ import { searchWines } from '../api/wines';
 import { getRacks } from '../api/racks';
 import { parseAndMap, parseJSON, summariseRacks, getDefaultRackConfig, getDefaultAnchor, decodeImportBuffer } from '../utils/importMappers';
 import { describePriceWarning } from '../utils/priceValidation';
+import { summariseImportOutcome, buildImportReportCsv } from '../utils/importReport';
 import { getTotalSlots } from '../utils/rackLayouts';
 import { TYPE_DIMENSIONS } from '../components/racks/RackTypeSelector';
 import AnchorPicker from './import/AnchorPicker';
@@ -128,7 +129,14 @@ function ImportBottles() {
   // Import step
   const [importing, setImporting] = useState(false);
   const [importResult, setImportResult] = useState(null);
+  // Snapshot taken at import time so the done screen / CSV report can map
+  // the confirm response's submitted-array indices back to original file
+  // rows, and account for rows the user skipped at review (never submitted).
+  const [submittedRows, setSubmittedRows] = useState([]);
+  const [userSkippedRows, setUserSkippedRows] = useState([]);
   const [aiSearchingRow, setAiSearchingRow] = useState(null); // index of fuzzy row doing forced AI search
+  // CellarTracker "what transfers" disclosure panel (upload step)
+  const [ctDisclosureDismissed, setCtDisclosureDismissed] = useState(false);
 
   // Session persistence
   const [sessionId, setSessionId] = useState(null);
@@ -350,6 +358,7 @@ function ImportBottles() {
         setDetectedEncoding(encoding);
         setCtTable(parsed.ctTable || null);
         setImportWarnings(parsed.warnings || []);
+        setCtDisclosureDismissed(false); // new file → show the CT disclosure again
         setFileName(file.name);
 
         // Build per-rack summary + seed editable config with format-aware
@@ -677,10 +686,16 @@ function ImportBottles() {
     setError(null);
     setStep('importing');
 
-    // Build items for confirm endpoint — skipped rows are excluded
-    const items = results
-      .filter(isImportableRow)
-      .map(buildImportItem);
+    // Build items for confirm endpoint — skipped rows are excluded.
+    // Keep both halves around: the confirm response indexes into the
+    // submitted array, and user-skipped rows must still show up in the
+    // done-screen accounting (an import that silently forgets them would
+    // read as more successful than it was).
+    const importableRows = results.filter(isImportableRow);
+    const skippedAtReview = results.filter(r => selections[r.index] === 'skip');
+    setSubmittedRows(importableRows);
+    setUserSkippedRows(skippedAtReview);
+    const items = importableRows.map(buildImportItem);
 
     try {
       const res = await confirmImport(apiFetch, { cellarId, items, positionAnchor, rackConfigs, defaultCurrency: importCurrency });
@@ -710,18 +725,72 @@ function ImportBottles() {
 
   // ── Render helpers ──────────────────────────────────────────────────────
 
-  // Non-blocking parse warnings (shown on both upload and review steps)
+  // Non-blocking parse warnings (shown on both upload and review steps).
+  // The CT truncation warning gets elevated styling + a bold headline: a
+  // 25-row page export silently missing 90% of a cellar is the single worst
+  // "looked like it worked" outcome an import can have.
   const renderImportWarnings = () => importWarnings.length > 0 && (
     <div className="import-parse-warnings">
       {importWarnings.map((w, i) => (
-        <div key={i} className="import-parse-warning-banner">
-          {w.code === 'ct-truncated' && t('importBottles.warnings.ctTruncated')}
+        <div
+          key={i}
+          className={`import-parse-warning-banner${w.code === 'ct-truncated' ? ' import-parse-warning-strong' : ''}`}
+          role={w.code === 'ct-truncated' ? 'alert' : undefined}
+        >
+          {w.code === 'ct-truncated' && (
+            <>
+              <strong>{t('importBottles.warnings.ctTruncatedTitle')}</strong>{' '}
+              {t('importBottles.warnings.ctTruncated')}
+            </>
+          )}
           {w.code === 'ct-pending-skipped' && t('importBottles.warnings.ctPendingSkipped', {
             count: w.count,
             wines: (w.wines || []).join(', ')
           })}
         </div>
       ))}
+    </div>
+  );
+
+  // "What transfers from CellarTracker" disclosure — shown once on the upload
+  // step whenever a CT file is detected, before any import happens. Honest up
+  // front: CT's export simply doesn't contain some things, so we can't carry
+  // them, and users deserve to know that before they commit.
+  const renderCtDisclosure = () => detectedFormat === 'cellartracker' && !ctDisclosureDismissed && (
+    <div className="ct-disclosure-panel">
+      <div className="ct-disclosure-head">
+        <strong>{t('importBottles.ctDisclosure.title')}</strong>
+        <button
+          type="button"
+          className="ct-disclosure-dismiss"
+          onClick={() => setCtDisclosureDismissed(true)}
+          aria-label={t('importBottles.ctDisclosure.dismiss')}
+        >
+          &times;
+        </button>
+      </div>
+      <div className="ct-disclosure-cols">
+        <div className="ct-disclosure-col">
+          <span className="ct-disclosure-col-title ct-disclosure-yes">{t('importBottles.ctDisclosure.carriedTitle')}</span>
+          <ul>
+            <li>{t('importBottles.ctDisclosure.carriedBottles')}</li>
+            <li>{t('importBottles.ctDisclosure.carriedRatings')}</li>
+            <li>{t('importBottles.ctDisclosure.carriedPurchase')}</li>
+            <li>{t('importBottles.ctDisclosure.carriedWindows')}</li>
+            <li>{t('importBottles.ctDisclosure.carriedConsumed')}</li>
+            <li>{t('importBottles.ctDisclosure.carriedLocations')}</li>
+          </ul>
+        </div>
+        <div className="ct-disclosure-col">
+          <span className="ct-disclosure-col-title ct-disclosure-no">{t('importBottles.ctDisclosure.notCarriedTitle')}</span>
+          <ul>
+            <li>{t('importBottles.ctDisclosure.notCarriedNotes')}</li>
+            <li>{t('importBottles.ctDisclosure.notCarriedPhotos')}</li>
+            <li>{t('importBottles.ctDisclosure.notCarriedWishlist')}</li>
+          </ul>
+          <p className="ct-disclosure-why">{t('importBottles.ctDisclosure.notCarriedWhy')}</p>
+        </div>
+      </div>
     </div>
   );
 
@@ -841,6 +910,7 @@ function ImportBottles() {
       </div>
 
       {parsedItems.length > 0 && renderImportWarnings()}
+      {parsedItems.length > 0 && renderCtDisclosure()}
 
       {parsedItems.length > 0 && parsedItems.some(i => i.price) && (
         <CurrencyPicker
@@ -1526,10 +1596,78 @@ function ImportBottles() {
     </div>
   );
 
-  const renderDoneStep = () => (
+  // Client-side CSV report of every row that did NOT become a placed bottle
+  // (skipped / error / unplaced) plus a one-line summary — no backend call.
+  const handleDownloadReport = () => {
+    const csv = buildImportReportCsv({
+      importResult,
+      submittedRows,
+      userSkippedRows,
+      userSkippedReason: t('importBottles.done.skippedByYou'),
+    });
+    // BOM so Excel opens the UTF-8 file with accents (Pétrus) intact
+    const blob = new Blob([String.fromCharCode(0xFEFF) + csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'cellarion-import-report.csv';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  // "Row 12 (Pétrus Pomerol): reason" — falls back to a plain row line when
+  // the wine fields are unknown. `row` is a validation-result row (or
+  // undefined), `fallbackIndex` the submitted-array index for safety.
+  const describeReportLine = (row, fallbackIndex, reason) => {
+    const rowNumber = (row?.index ?? fallbackIndex) + 1;
+    const wine = row?.item ? `${row.item.producer || ''} ${row.item.wineName || ''}`.trim() : '';
+    return wine
+      ? t('importBottles.done.reportRow', { row: rowNumber, wine, reason })
+      : t('importBottles.done.errorRow', { row: rowNumber, reason });
+  };
+
+  const renderDoneStep = () => {
+    const { created, totalRows, skippedCount, errorCount, unplacedCount, fullSuccess } =
+      summariseImportOutcome(importResult, userSkippedRows.length);
+
+    // Everything that didn't become a bottle, with per-row reasons: rows the
+    // backend skipped + rows the user skipped at review, in file order.
+    const skippedDetails = [
+      ...(importResult?.skipped || []).map(s => ({
+        row: submittedRows[s.index], fallbackIndex: s.index, reason: s.reason,
+      })),
+      ...userSkippedRows.map(r => ({
+        row: r, fallbackIndex: r.index, reason: t('importBottles.done.skippedByYou'),
+      })),
+    ].sort((a, b) => (a.row?.index ?? a.fallbackIndex) - (b.row?.index ?? b.fallbackIndex));
+
+    return (
     <div className="import-done">
-      <div className="done-icon">&#10003;</div>
-      <h2>{t('importBottles.done.title')}</h2>
+      {/* Honest headline: any skip, error or unplaced bottle means this was
+          NOT a full success, and the headline must say so — never a green
+          "Import complete!" over a partial result. */}
+      {fullSuccess ? (
+        <>
+          <div className="done-icon">&#10003;</div>
+          <h2>{t('importBottles.done.title')}</h2>
+          <p className="done-subtitle">{t('importBottles.done.allImportedNote', { count: created })}</p>
+        </>
+      ) : (
+        <>
+          <div className="done-icon done-icon-warn">!</div>
+          <h2>{t('importBottles.done.partialTitle', {
+            created: created.toLocaleString(),
+            total: totalRows.toLocaleString()
+          })}</h2>
+          <p className="done-subtitle done-partial-note">
+            {errorCount + skippedCount > 0
+              ? t('importBottles.done.partialNote', { count: errorCount + skippedCount })
+              : t('importBottles.done.unplacedOnlyNote', { count: unplacedCount })}
+          </p>
+        </>
+      )}
       {importResult && (
         <div className="done-stats">
           <div className="done-stat">
@@ -1542,15 +1680,15 @@ function ImportBottles() {
               <span>{t('importBottles.done.consumedHistory')}</span>
             </div>
           )}
-          {importResult.skipped.length > 0 && (
+          {skippedCount > 0 && (
             <div className="done-stat">
-              <span className="done-number done-skipped">{importResult.skipped.length}</span>
+              <span className="done-number done-skipped">{skippedCount}</span>
               <span>{t('importBottles.done.skipped')}</span>
             </div>
           )}
-          {importResult.errors.length > 0 && (
+          {errorCount > 0 && (
             <div className="done-stat">
-              <span className="done-number done-errors">{importResult.errors.length}</span>
+              <span className="done-number done-errors">{errorCount}</span>
               <span>{t('importBottles.done.errors')}</span>
             </div>
           )}
@@ -1566,13 +1704,26 @@ function ImportBottles() {
               <span>{t('importBottles.done.placedInRacks')}{importResult.overflowed > 0 ? t('importBottles.done.overflowSuffix', { count: importResult.overflowed }) : ''}</span>
             </div>
           )}
-          {importResult.unplaced?.length > 0 && (
+          {unplacedCount > 0 && (
             <div className="done-stat">
-              <span className="done-number done-errors">{importResult.unplaced.length}</span>
+              <span className="done-number done-errors">{unplacedCount}</span>
               <span>{t('importBottles.done.couldntPlace')}</span>
             </div>
           )}
         </div>
+      )}
+      {skippedDetails.length > 0 && (
+        <details className="done-errors-detail">
+          <summary>{t('importBottles.done.skippedSummary', { count: skippedDetails.length })}</summary>
+          <ul>
+            {skippedDetails.slice(0, 50).map((s, i) => (
+              <li key={i}>{describeReportLine(s.row, s.fallbackIndex, s.reason)}</li>
+            ))}
+            {skippedDetails.length > 50 && (
+              <li><em>{t('importBottles.done.andMore', { count: skippedDetails.length - 50 })}</em></li>
+            )}
+          </ul>
+        </details>
       )}
       {importResult?.racksCreated?.length > 0 && (
         <details className="done-errors-detail">
@@ -1615,7 +1766,7 @@ function ImportBottles() {
           <summary>{t('importBottles.done.viewErrors', { count: importResult.errors.length })}</summary>
           <ul>
             {importResult.errors.map((e, i) => (
-              <li key={i}>{t('importBottles.done.errorRow', { row: e.index + 1, reason: e.reason })}</li>
+              <li key={i}>{describeReportLine(submittedRows[e.index], e.index, e.reason)}</li>
             ))}
           </ul>
         </details>
@@ -1624,6 +1775,11 @@ function ImportBottles() {
         <Link to={`/cellars/${cellarId}`} className="btn btn-primary">
           {t('importBottles.done.goToCellar')}
         </Link>
+        {!fullSuccess && importResult && (
+          <button className="btn btn-secondary" onClick={handleDownloadReport}>
+            {t('importBottles.done.downloadReport')}
+          </button>
+        )}
         <button
           className="btn btn-secondary"
           onClick={() => {
@@ -1634,17 +1790,21 @@ function ImportBottles() {
             setSelections({});
             setManualWines({});
             setImportResult(null);
+            setSubmittedRows([]);
+            setUserSkippedRows([]);
             setFileName('');
             setDetectedEncoding(null);
             setCtTable(null);
             setImportWarnings([]);
+            setCtDisclosureDismissed(false);
           }}
         >
           {t('importBottles.done.importMore')}
         </button>
       </div>
     </div>
-  );
+    );
+  };
 
   // ── Main render ─────────────────────────────────────────────────────────
 

--- a/frontend/src/utils/importReport.js
+++ b/frontend/src/utils/importReport.js
@@ -1,0 +1,115 @@
+// Pure helpers for honest import accounting: the done-screen headline math
+// and the downloadable per-row CSV report.
+//
+// Index spaces (important):
+// - The confirm endpoint receives only the importable rows (user-skipped rows
+//   are filtered out client-side before POST). Its response indices —
+//   `skipped[].index`, `errors[].index`, `unplaced[].sourceIndex` — all point
+//   into that *submitted* array.
+// - `submittedRows` is the same-order array of validation-result rows that
+//   were submitted, so `submittedRows[i].index` recovers the original file
+//   row (0-based) and `submittedRows[i].item` the parsed wine fields.
+// - `userSkippedRows` are validation-result rows the user skipped at review
+//   (never submitted).
+
+/**
+ * Summarise an import outcome for the done screen.
+ *
+ * @param {object|null} importResult  confirm response
+ * @param {number} userSkippedCount   rows skipped by the user at review
+ * @returns {{ created, totalRows, skippedCount, errorCount, unplacedCount,
+ *             missedCount, fullSuccess }}
+ *   - totalRows: everything the user brought to the import (submitted +
+ *     user-skipped) — the honest denominator for "X of Y imported".
+ *   - fullSuccess: true only when every single row became a bottle and every
+ *     placement landed. Any skip, error or unplaced bottle makes it false.
+ */
+export function summariseImportOutcome(importResult, userSkippedCount = 0) {
+  const created = importResult?.created ?? 0;
+  const backendSkipped = importResult?.skipped?.length ?? 0;
+  const errorCount = importResult?.errors?.length ?? 0;
+  const unplacedCount = importResult?.unplaced?.length ?? 0;
+  const totalRows = (importResult?.total ?? 0) + userSkippedCount;
+  const skippedCount = backendSkipped + userSkippedCount;
+  const missedCount = skippedCount + errorCount;
+  return {
+    created,
+    totalRows,
+    skippedCount,
+    errorCount,
+    unplacedCount,
+    missedCount,
+    fullSuccess: Boolean(importResult) && missedCount === 0 && unplacedCount === 0 && created === totalRows,
+  };
+}
+
+// RFC 4180-ish escaping: quote when the value contains a comma, quote or
+// newline, doubling inner quotes.
+export function csvEscape(value) {
+  const s = value === null || value === undefined ? '' : String(value);
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+// Pull display fields from a validation-result row (may be undefined when the
+// index can't be mapped — we still emit the row rather than hide it).
+const rowFields = (row) => ({
+  index: row ? row.index + 1 : '',
+  wineName: row?.item?.wineName || '',
+  producer: row?.item?.producer || '',
+  vintage: row?.item?.vintage || '',
+});
+
+/**
+ * Flatten every non-created outcome into report rows.
+ * Outcomes: 'skipped' (backend + user-skipped), 'error', 'unplaced'
+ * (imported but no rack slot — still worth telling the user about).
+ * Rows are sorted by original file row number.
+ */
+export function buildOutcomeRows({ importResult, submittedRows = [], userSkippedRows = [], userSkippedReason = 'Skipped during review' }) {
+  const rows = [];
+
+  for (const s of importResult?.skipped || []) {
+    rows.push({ ...rowFields(submittedRows[s.index]), outcome: 'skipped', reason: s.reason || '' });
+  }
+  for (const r of userSkippedRows) {
+    rows.push({ ...rowFields(r), outcome: 'skipped', reason: userSkippedReason });
+  }
+  for (const e of importResult?.errors || []) {
+    rows.push({ ...rowFields(submittedRows[e.index]), outcome: 'error', reason: e.reason || '' });
+  }
+  for (const u of importResult?.unplaced || []) {
+    const mapped = u.sourceIndex !== null && u.sourceIndex !== undefined ? submittedRows[u.sourceIndex] : undefined;
+    const where = u.rackName ? `rack "${u.rackName}"` : 'rack';
+    rows.push({
+      ...rowFields(mapped),
+      outcome: 'unplaced',
+      reason: `Imported, but not placed in ${where}: ${u.reason || 'no free slot'}`,
+    });
+  }
+
+  return rows.sort((a, b) => (a.index === '' ? Infinity : a.index) - (b.index === '' ? Infinity : b.index));
+}
+
+/**
+ * Build the downloadable CSV report: one summary line, a header row, then
+ * one row per non-created outcome (skipped / error / unplaced). Created rows
+ * are omitted on purpose — the report is the "what to look at" list.
+ *
+ * @returns {string} CSV text (no BOM; the caller prepends one for Excel)
+ */
+export function buildImportReportCsv({ importResult, submittedRows = [], userSkippedRows = [], userSkippedReason } = {}) {
+  const { created, totalRows, skippedCount, errorCount, unplacedCount } =
+    summariseImportOutcome(importResult, userSkippedRows.length);
+
+  // The summary line is intentionally left unquoted (it's for humans; the
+  // leading '#' marks it as a comment for anyone re-parsing the file).
+  const summary = `# Import report: ${created} of ${totalRows} rows imported (${skippedCount} skipped, ${errorCount} errors, ${unplacedCount} imported but unplaced)`;
+  const header = 'index,wineName,producer,vintage,outcome,reason';
+  const lines = buildOutcomeRows({ importResult, submittedRows, userSkippedRows, userSkippedReason })
+    .map(r => [r.index, r.wineName, r.producer, r.vintage, r.outcome, r.reason].map(csvEscape).join(','));
+
+  return [summary, header, ...lines].join('\r\n') + '\r\n';
+}

--- a/frontend/src/utils/importReport.test.js
+++ b/frontend/src/utils/importReport.test.js
@@ -1,0 +1,169 @@
+import { summariseImportOutcome, csvEscape, buildOutcomeRows, buildImportReportCsv } from './importReport';
+
+// Validation-result row helper (the shape ImportBottles keeps in `results`)
+const row = (index, wineName, producer, vintage) => ({
+  index,
+  item: { wineName, producer, vintage },
+});
+
+describe('summariseImportOutcome', () => {
+  it('reports full success only when every row became a bottle', () => {
+    const out = summariseImportOutcome(
+      { created: 3, total: 3, skipped: [], errors: [], unplaced: [] },
+      0
+    );
+    expect(out.fullSuccess).toBe(true);
+    expect(out.created).toBe(3);
+    expect(out.totalRows).toBe(3);
+    expect(out.missedCount).toBe(0);
+  });
+
+  it('is not full success when the backend skipped a row', () => {
+    const out = summariseImportOutcome(
+      { created: 2, total: 3, skipped: [{ index: 1, reason: 'No wine selected' }], errors: [], unplaced: [] },
+      0
+    );
+    expect(out.fullSuccess).toBe(false);
+    expect(out.skippedCount).toBe(1);
+  });
+
+  it('is not full success when the user skipped rows at review', () => {
+    // 2 submitted + created, but 1 was skipped by hand: 2 of 3 imported
+    const out = summariseImportOutcome(
+      { created: 2, total: 2, skipped: [], errors: [], unplaced: [] },
+      1
+    );
+    expect(out.fullSuccess).toBe(false);
+    expect(out.totalRows).toBe(3);
+    expect(out.skippedCount).toBe(1);
+    expect(out.missedCount).toBe(1);
+  });
+
+  it('is not full success when a bottle imported but could not be placed', () => {
+    const out = summariseImportOutcome(
+      { created: 3, total: 3, skipped: [], errors: [], unplaced: [{ sourceIndex: 0, rackName: 'A', requestedPosition: 4, reason: 'Slot occupied' }] },
+      0
+    );
+    expect(out.fullSuccess).toBe(false);
+    expect(out.unplacedCount).toBe(1);
+    // ...but the miss count (rows that did NOT import) stays 0
+    expect(out.missedCount).toBe(0);
+  });
+
+  it('handles a missing importResult without blowing up', () => {
+    const out = summariseImportOutcome(null, 0);
+    expect(out.fullSuccess).toBe(false);
+    expect(out.created).toBe(0);
+    expect(out.totalRows).toBe(0);
+  });
+});
+
+describe('csvEscape', () => {
+  it('passes plain values through untouched', () => {
+    expect(csvEscape('Margaux')).toBe('Margaux');
+    expect(csvEscape(2015)).toBe('2015');
+  });
+
+  it('quotes commas and doubles inner quotes', () => {
+    expect(csvEscape('Château Margaux, Premier Cru')).toBe('"Château Margaux, Premier Cru"');
+    expect(csvEscape('The "Special" Cuvée')).toBe('"The ""Special"" Cuvée"');
+  });
+
+  it('quotes newlines and renders null/undefined as empty', () => {
+    expect(csvEscape('line1\nline2')).toBe('"line1\nline2"');
+    expect(csvEscape(null)).toBe('');
+    expect(csvEscape(undefined)).toBe('');
+  });
+});
+
+describe('buildOutcomeRows', () => {
+  it('maps backend indices through submittedRows back to original file rows', () => {
+    // Original file rows 0..3; row 1 was user-skipped, so submitted = [0, 2, 3]
+    const submittedRows = [row(0, 'Wine A', 'Prod A', 2018), row(2, 'Wine C', 'Prod C', 2020), row(3, 'Wine D', 'Prod D', null)];
+    const userSkippedRows = [row(1, 'Wine B', 'Prod B', 2019)];
+    const importResult = {
+      created: 1,
+      total: 3,
+      skipped: [{ index: 1, reason: 'No wine selected' }], // submitted idx 1 → file row 2
+      errors: [{ index: 2, reason: 'Invalid vintage' }],   // submitted idx 2 → file row 3
+      unplaced: [],
+    };
+
+    const rows = buildOutcomeRows({ importResult, submittedRows, userSkippedRows });
+    expect(rows).toEqual([
+      { index: 2, wineName: 'Wine B', producer: 'Prod B', vintage: 2019, outcome: 'skipped', reason: 'Skipped during review' },
+      { index: 3, wineName: 'Wine C', producer: 'Prod C', vintage: 2020, outcome: 'skipped', reason: 'No wine selected' },
+      { index: 4, wineName: 'Wine D', producer: 'Prod D', vintage: '', outcome: 'error', reason: 'Invalid vintage' },
+    ]);
+  });
+
+  it('includes unplaced bottles with rack context and honors a custom skip reason', () => {
+    const submittedRows = [row(0, 'Wine A', 'Prod A', 2018)];
+    const importResult = {
+      created: 1,
+      total: 1,
+      skipped: [],
+      errors: [],
+      unplaced: [{ sourceIndex: 0, rackName: 'Cellar Rack', requestedPosition: 12, reason: 'Slot occupied' }],
+    };
+    const rows = buildOutcomeRows({
+      importResult,
+      submittedRows,
+      userSkippedRows: [row(5, 'Wine F', 'Prod F', 2021)],
+      userSkippedReason: 'Överhoppad vid granskning',
+    });
+    expect(rows[0]).toEqual({
+      index: 1, wineName: 'Wine A', producer: 'Prod A', vintage: 2018,
+      outcome: 'unplaced',
+      reason: 'Imported, but not placed in rack "Cellar Rack": Slot occupied',
+    });
+    expect(rows[1].reason).toBe('Överhoppad vid granskning');
+  });
+
+  it('still emits a row when the index cannot be mapped', () => {
+    const importResult = {
+      created: 0, total: 1,
+      skipped: [], errors: [],
+      unplaced: [{ sourceIndex: null, rackName: 'A', requestedPosition: 3, reason: 'Rack save failed' }],
+    };
+    const rows = buildOutcomeRows({ importResult, submittedRows: [] });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].index).toBe('');
+    expect(rows[0].outcome).toBe('unplaced');
+  });
+});
+
+describe('buildImportReportCsv', () => {
+  it('produces the exact summary, header and data lines', () => {
+    const submittedRows = [row(0, 'Wine A', 'Prod A', 2018), row(2, 'Wine C', 'Château "C", Fils', 2020)];
+    const userSkippedRows = [row(1, 'Wine B', 'Prod B', 2019)];
+    const importResult = {
+      created: 1,
+      total: 2,
+      skipped: [],
+      errors: [{ index: 1, reason: 'Invalid vintage' }],
+      unplaced: [],
+    };
+
+    const csv = buildImportReportCsv({ importResult, submittedRows, userSkippedRows });
+    expect(csv.split('\r\n')).toEqual([
+      '# Import report: 1 of 3 rows imported (1 skipped, 1 errors, 0 imported but unplaced)',
+      'index,wineName,producer,vintage,outcome,reason',
+      '2,Wine B,Prod B,2019,skipped,Skipped during review',
+      '3,Wine C,"Château ""C"", Fils",2020,error,Invalid vintage',
+      '',
+    ]);
+  });
+
+  it('on a clean import still emits the summary and header with no data rows', () => {
+    const csv = buildImportReportCsv({
+      importResult: { created: 2, total: 2, skipped: [], errors: [], unplaced: [] },
+      submittedRows: [row(0, 'A', 'P', 2018), row(1, 'B', 'Q', 2019)],
+      userSkippedRows: [],
+    });
+    expect(csv).toBe(
+      '# Import report: 2 of 2 rows imported (0 skipped, 0 errors, 0 imported but unplaced)\r\n' +
+      'index,wineName,producer,vintage,outcome,reason\r\n'
+    );
+  });
+});


### PR DESCRIPTION
## Why

The import flow is a competitive differentiator against CellarTracker — and honesty is the differentiator inside the differentiator. Until now a partial import (skips, per-row errors, unplaced bottles) still rendered a green check + "Import Complete", which is exactly the "looked like it worked" failure mode we criticize elsewhere.

## Done screen: before → after

| | Before | After |
|---|---|---|
| Headline on partial import | Green ✓ "Import Complete" regardless of misses | Amber "!" + **"1,847 of 2,000 bottles imported"** with a warning-toned subtitle ("153 rows didn't make it — the full breakdown is below.") |
| Headline on full success | Green ✓ "Import Complete" | Unchanged celebratory state + "All N bottles made it into your cellar." |
| Denominator | none shown | total = submitted rows **+ rows the user skipped at review** (skipped rows no longer vanish from the accounting) |
| Skipped rows | count only | count **+ per-row reasons** (backend "No wine selected" vs "Skipped by you during review"), collapsible list, capped at 50 |
| Errors list | "Row N: reason" where N was the *submitted-array* index (wrong after skips) | mapped back to the **original file row** + wine name: "Row 12 (Pétrus Pomerol): reason" |
| Unplaced/overflow | already shown | unchanged, but unplaced now blocks the celebratory headline (imported ≠ placed) |
| Error report | none | **Download report (CSV)** button — client-side Blob, no backend call; summary line + one row per non-created outcome (`index,wineName,producer,vintage,outcome,reason`, outcomes `skipped`/`error`/`unplaced`) |

`fullSuccess` is strict: any skip (user or backend), any error, or any unplaced bottle ⇒ warning headline.

## CellarTracker "what transfers" disclosure

When the detected format is `cellartracker`, the upload step shows one dismissible panel, before any import:

- **Comes with you:** bottles + vintages (incl. NV), personal ratings (MY/MyScore), purchase data (price/date/store), drink windows → personal per-bottle window, drinking history (Bottles/Consumed exports), locations/bins as racks or free text.
- **Can't come along:** community tasting-note text (the export only contains note counts), label photos, wishlists — with a one-liner explaining CT's export files simply don't include these.

Placed on the **upload step** (not review) to stay out of the way of the parallel AI-budget banner PR touching the review step.

## 25-row truncation warning

The existing `ct-truncated` parse warning (exactly-25-rows page export) was already rendered on both upload and review steps but styled like a soft note. It now gets a bold headline ("Only 25 rows found — this export may be cut off."), elevated warning styling and `role="alert"`.

## Implementation notes

- New pure util `frontend/src/utils/importReport.js` (`summariseImportOutcome`, `csvEscape`, `buildOutcomeRows`, `buildImportReportCsv`) + 13 hand-written Vitest tests asserting exact CSV lines, index remapping (submitted-array index → original file row), and the full-success predicate.
- Import logic is untouched and additive-only: the confirm payload is byte-identical; the page just snapshots the submitted/user-skipped rows at import time for the accounting.
- i18n: 26 new keys per language under `importBottles.*`, en + sv (informal du), structure identical.
- Tests: `cd frontend && npm test` → **16 files, 452 tests passed** (439 existing + 13 new). `vite build` clean.

## Docker Compose impact

**None.** Frontend-only change (one page, one CSS file, one new util, locales). No backend, env, port or service changes; nothing to update in docker-compose.prod.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
