### PR TITLE
fix: forward rack row/col coordinates from import review to confirm

### DIFF
--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -7,6 +7,7 @@ import { getAiBudgetStatus, requestAiBudgetIncrease } from '../api/aiBudget';
 import { searchWines } from '../api/wines';
 import { getRacks } from '../api/racks';
 import { parseAndMap, parseJSON, summariseRacks, getDefaultRackConfig, getDefaultAnchor, decodeImportBuffer } from '../utils/importMappers';
+import { buildImportItem as buildImportItemPayload } from '../utils/importPayload';
 import { describePriceWarning } from '../utils/priceValidation';
 import { summariseImportOutcome, buildImportReportCsv } from '../utils/importReport';
 import { getTotalSlots } from '../utils/rackLayouts';
@@ -764,40 +765,9 @@ function ImportBottles() {
 
   // ── Import ──────────────────────────────────────────────────────────────
 
-  // Build the payload object for a single result row
-  const buildImportItem = (r) => {
-    const sel = selections[r.index];
-    return {
-      wineDefinition: sel !== 'request' ? sel : undefined,
-      requestWine: sel === 'request' ? true : undefined,
-      wineName: r.item.wineName,
-      producer: r.item.producer,
-      vintage: r.item.vintage,
-      price: r.item.price,
-      currency: r.item.currency,
-      bottleSize: r.item.bottleSize,
-      purchaseDate: r.item.purchaseDate,
-      purchaseLocation: r.item.purchaseLocation,
-      location: r.item.location,
-      notes: r.item.notes,
-      rating: r.item.rating,
-      ratingScale: r.item.ratingScale,
-      // CellarTracker imports carry grape varieties and a personal drink
-      // window; the backend importer consumes these when present.
-      grapes: r.item.grapes,
-      drinkFrom: r.item.drinkFrom ?? undefined,
-      drinkTo: r.item.drinkTo ?? undefined,
-      dateAdded: r.item.dateAdded || r.item.purchaseDate,
-      rackName: r.item.rackName,
-      rackPosition: r.item.rackPosition,
-      addToHistory: r.item.addToHistory,
-      consumedReason: r.item.consumedReason,
-      consumedAt: r.item.consumedAt,
-      consumedRating: r.item.consumedRating,
-      consumedRatingScale: r.item.consumedRatingScale,
-      consumedNote: r.item.consumedNote,
-    };
-  };
+  // Build the payload object for a single result row (pure mapping lives in
+  // utils/importPayload.js so the review→confirm field boundary stays tested)
+  const buildImportItem = (r) => buildImportItemPayload(r, selections[r.index]);
 
   // Rows eligible for bulk import: has a real selection and is not skipped
   const isImportableRow = (r) => {

--- a/frontend/src/utils/importPayload.js
+++ b/frontend/src/utils/importPayload.js
@@ -1,0 +1,51 @@
+/**
+ * Builds one /api/bottles/import/confirm item from a review row + the user's
+ * selection. Extracted from ImportBottles so the payload boundary is unit-
+ * testable: every field the parsers emit and the backend consumes must be
+ * forwarded here — a field missing from this mapping silently disappears
+ * between the review screen and the created bottle (that is exactly how the
+ * CellarTracker rack auto-map's row/col placements got lost).
+ */
+export function buildImportItem(r, selection) {
+  return {
+    wineDefinition: selection !== 'request' ? selection : undefined,
+    requestWine: selection === 'request' ? true : undefined,
+    wineName: r.item.wineName,
+    producer: r.item.producer,
+    vintage: r.item.vintage,
+    price: r.item.price,
+    currency: r.item.currency,
+    bottleSize: r.item.bottleSize,
+    purchaseDate: r.item.purchaseDate,
+    purchaseLocation: r.item.purchaseLocation,
+    location: r.item.location,
+    notes: r.item.notes,
+    rating: r.item.rating,
+    ratingScale: r.item.ratingScale,
+    // CellarTracker imports carry grape varieties and a personal drink
+    // window; the backend importer consumes these when present.
+    grapes: r.item.grapes,
+    drinkFrom: r.item.drinkFrom ?? undefined,
+    drinkTo: r.item.drinkTo ?? undefined,
+    dateAdded: r.item.dateAdded || r.item.purchaseDate,
+    // Rack placement — the backend places via rackPosition OR row+col
+    // (grid), layer+slotInLayer (shelf), and sizes auto-created racks from
+    // the per-item rackType/rackRows/rackCols hints (utils/rackImport.js).
+    rackName: r.item.rackName,
+    rackPosition: r.item.rackPosition,
+    row: r.item.row,
+    col: r.item.col,
+    layer: r.item.layer,
+    slotInLayer: r.item.slotInLayer,
+    internalSlot: r.item.internalSlot,
+    rackType: r.item.rackType,
+    rackRows: r.item.rackRows,
+    rackCols: r.item.rackCols,
+    addToHistory: r.item.addToHistory,
+    consumedReason: r.item.consumedReason,
+    consumedAt: r.item.consumedAt,
+    consumedRating: r.item.consumedRating,
+    consumedRatingScale: r.item.consumedRatingScale,
+    consumedNote: r.item.consumedNote,
+  };
+}

--- a/frontend/src/utils/importPayload.test.js
+++ b/frontend/src/utils/importPayload.test.js
@@ -1,0 +1,96 @@
+/**
+ * The review→confirm payload boundary. A field the parsers emit but this
+ * mapping drops silently disappears between the review screen and the created
+ * bottle — that is exactly how the CellarTracker rack auto-map's row/col
+ * placements were lost (racks were created but arrived empty, while
+ * rackPosition-based racks placed fine).
+ *
+ * The full-pipeline test parses a real CT fixture end-to-end (decode →
+ * parseAndMap → buildImportItem) so every future parser field must survive
+ * the payload mapping or fail here.
+ */
+import { readFileSync } from 'fs';
+import { describe, test, expect } from 'vitest';
+import { buildImportItem } from './importPayload';
+import { decodeImportBuffer, parseAndMap } from './importMappers';
+
+const FIXTURE = 'src/utils/__fixtures__/cellartracker/bundle/CellarTracker_Inventory.tsv';
+
+function toArrayBuffer(buf) {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+}
+
+describe('buildImportItem', () => {
+  test('forwards grid row/col placements (CT auto-map regression)', () => {
+    const r = {
+      item: {
+        wineName: 'La Tâche', producer: 'Domaine de la Romanée-Conti',
+        vintage: '2017', rackName: 'Wine Fridge', row: 2, col: 5,
+        rackRows: 2, rackCols: 6,
+      },
+    };
+    const out = buildImportItem(r, 'wine123');
+    expect(out.wineDefinition).toBe('wine123');
+    expect(out.rackName).toBe('Wine Fridge');
+    expect(out.row).toBe(2);
+    expect(out.col).toBe(5);
+    expect(out.rackRows).toBe(2);
+    expect(out.rackCols).toBe(6);
+  });
+
+  test('forwards shelf layer/slotInLayer and rackType', () => {
+    const r = {
+      item: {
+        wineName: 'Barbaresco', producer: 'Gaja', vintage: '2018',
+        rackName: 'Double Deep', rackPosition: 3, layer: 2, slotInLayer: 3,
+        rackType: 'shelf', rackRows: 2, rackCols: 4,
+      },
+    };
+    const out = buildImportItem(r, 'wine456');
+    expect(out.rackPosition).toBe(3);
+    expect(out.layer).toBe(2);
+    expect(out.slotInLayer).toBe(3);
+    expect(out.rackType).toBe('shelf');
+  });
+
+  test('request selection sets requestWine and clears wineDefinition', () => {
+    const out = buildImportItem({ item: { wineName: 'X', producer: 'Y' } }, 'request');
+    expect(out.requestWine).toBe(true);
+    expect(out.wineDefinition).toBeUndefined();
+  });
+
+  test('forwards internalSlot for cellarion round-trips', () => {
+    const out = buildImportItem(
+      { item: { wineName: 'X', producer: 'Y', rackName: 'Hex', rackPosition: 11, internalSlot: true } },
+      'w1'
+    );
+    expect(out.internalSlot).toBe(true);
+    expect(out.rackPosition).toBe(11);
+  });
+
+  test('full pipeline: real CT Inventory fixture placements survive to the payload', () => {
+    const { text } = decodeImportBuffer(toArrayBuffer(readFileSync(FIXTURE)));
+    const parsed = parseAndMap(text);
+
+    const placed = parsed.items.filter((i) => i.rackName);
+    expect(placed.length).toBeGreaterThan(0);
+
+    for (const item of placed) {
+      const payload = buildImportItem({ item }, 'someWineId');
+      // The backend's placement gate: rackPosition OR row+col (import.js).
+      const hasPlacement =
+        payload.rackPosition !== undefined ||
+        (payload.row !== undefined && payload.col !== undefined);
+      expect(hasPlacement).toBe(true);
+      expect(payload.rackName).toBe(item.rackName);
+    }
+
+    // The Wine Fridge group is letter+number bins → row/col placements; they
+    // must reach the payload as numbers, not vanish.
+    const fridge = parsed.items.find((i) => i.rackName === 'Wine Fridge' && i.row !== undefined);
+    expect(fridge).toBeDefined();
+    const fridgePayload = buildImportItem({ item: fridge }, 'w');
+    expect(typeof fridgePayload.row).toBe('number');
+    expect(typeof fridgePayload.col).toBe('number');
+  });
+});


### PR DESCRIPTION
User-found bug (thanks to the first manual test of the 100-bottle CT test file): the CT rack auto-map placed only position-based racks; every row/col-based rack (letter+number bins, RxCy, segmented) was created with the right geometry but arrived EMPTY.

**Root cause:** `buildImportItem` in ImportBottles.js — the mapping from review rows to the `/confirm` payload — forwarded `rackName` + `rackPosition` but dropped `row`, `col`, `layer`, `slotInLayer`, `internalSlot`, `rackType`, `rackRows`, `rackCols`. The backend's placement gate (`import.js:858`: `rackPosition || (row && col)`) then saw no coordinates.

**Why tests missed it:** the parser emits the fields (tested), the backend consumes them (tested), but the payload boundary between them lived as an untestable closure inside the page component — and the e2e smoke built its payload by hand.

**Fix:**
- Extracted the mapping to a pure util `utils/importPayload.js` (byte-identical for all previously-forwarded fields) and forwarded the full rack coordinate set.
- New `importPayload.test.js` (5 tests) including a **full-pipeline regression**: real CT Inventory fixture → decode → parseAndMap → buildImportItem → assert every placed item satisfies the backend's placement gate. Any future parser field dropped at this boundary fails here.

Tests: 19 files / 501 passed. Zero docker-compose impact (frontend-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)