### PR TITLE
fix: drink-window integrity (notifier reset, export round-trip, AI-chat label, stats)

### DIFF
--- a/backend/src/routes/bottles.drinkWindow.test.js
+++ b/backend/src/routes/bottles.drinkWindow.test.js
@@ -241,4 +241,57 @@ describe('PUT /api/bottles/:id drink window', () => {
     expect((await update({ drinkTo: 9999 })).status).toBe(400);
     expect(storedBottle.save).not.toHaveBeenCalled();
   });
+
+  // ── BUG 1: editing the personal window must reset the notifier marker ────────
+  // The daily notifier only rewrites drinkWindowNotifiedStatus on a notifiable
+  // transition, so a stale marker (e.g. 'peak' from the old window) would
+  // permanently suppress the alert for the new window. A window edit must clear
+  // both marker fields so the next notifier run re-evaluates cleanly.
+  test('changing drinkFrom clears the stale notifier marker', async () => {
+    storedBottle.drinkWindowNotifiedStatus = 'peak';
+    storedBottle.drinkWindowNotifiedAt = new Date('2026-01-01T00:00:00Z');
+    const { status } = await update({ drinkFrom: 2030 });
+    expect(status).toBe(200);
+    expect(storedBottle.drinkFrom).toBe(2030);
+    expect(storedBottle.drinkWindowNotifiedStatus).toBeNull();
+    expect(storedBottle.drinkWindowNotifiedAt).toBeNull();
+  });
+
+  test('changing drinkTo clears the stale notifier marker', async () => {
+    storedBottle.drinkWindowNotifiedStatus = 'ending';
+    storedBottle.drinkWindowNotifiedAt = new Date('2026-01-01T00:00:00Z');
+    const { status } = await update({ drinkTo: 2050 });
+    expect(status).toBe(200);
+    expect(storedBottle.drinkTo).toBe(2050);
+    expect(storedBottle.drinkWindowNotifiedStatus).toBeNull();
+    expect(storedBottle.drinkWindowNotifiedAt).toBeNull();
+  });
+
+  test('clearing the window (nulls) also resets the notifier marker', async () => {
+    storedBottle.drinkWindowNotifiedStatus = 'declining';
+    storedBottle.drinkWindowNotifiedAt = new Date('2026-01-01T00:00:00Z');
+    const { status } = await update({ drinkFrom: null, drinkTo: null });
+    expect(status).toBe(200);
+    expect(storedBottle.drinkWindowNotifiedStatus).toBeNull();
+    expect(storedBottle.drinkWindowNotifiedAt).toBeNull();
+  });
+
+  test('an update that does NOT touch the window leaves the notifier marker intact', async () => {
+    storedBottle.drinkWindowNotifiedStatus = 'peak';
+    storedBottle.drinkWindowNotifiedAt = new Date('2026-01-01T00:00:00Z');
+    const { status } = await update({ notes: 'just a note' });
+    expect(status).toBe(200);
+    expect(storedBottle.drinkWindowNotifiedStatus).toBe('peak');
+    expect(storedBottle.drinkWindowNotifiedAt).toEqual(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  test('a no-op window write (same value) does not reset the notifier marker', async () => {
+    // stored drinkFrom is 2020 — resending 2020 is not a real change.
+    storedBottle.drinkWindowNotifiedStatus = 'peak';
+    storedBottle.drinkWindowNotifiedAt = new Date('2026-01-01T00:00:00Z');
+    const { status } = await update({ drinkFrom: 2020 });
+    expect(status).toBe(200);
+    expect(storedBottle.drinkWindowNotifiedStatus).toBe('peak');
+    expect(storedBottle.drinkWindowNotifiedAt).toEqual(new Date('2026-01-01T00:00:00Z'));
+  });
 });

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -704,6 +704,19 @@ router.put('/:id', requireBottleAccess('editor'), async (req, res) => {
       }
     }
 
+    // A changed personal drink window invalidates the drink-window notifier's
+    // "already notified" marker: the notifier only rewrites the marker on a
+    // notifiable transition, so a stale status (e.g. 'peak' from the old window)
+    // would permanently suppress the alert for the NEW window (e.g. drinkFrom
+    // pushed out to 2030 → not-ready now, but 'peak' marker blocks the 2030
+    // peak alert forever). Clear it so the next notifier run re-evaluates from a
+    // clean slate. Only when a window bound actually changed (changes[field] is
+    // set only on a real value diff).
+    if (changes.drinkFrom || changes.drinkTo) {
+      bottle.drinkWindowNotifiedStatus = null;
+      bottle.drinkWindowNotifiedAt = null;
+    }
+
     await bottle.save();
     await bottle.populate(WINE_POPULATE);
 

--- a/backend/src/services/aiChat.js
+++ b/backend/src/services/aiChat.js
@@ -143,10 +143,12 @@ function formatWineList(matches, { profileMap, countMap, priceMap } = {}) {
     const count = countMap?.get(key);
     const countStr = count ? `   Bottles: ${count}` : null;
 
-    // Enrichment: maturity status
+    // Enrichment: maturity status. Pass the bottle so the label quotes the
+    // PERSONAL drink-window years when that window governs the status (else the
+    // profile years would contradict a personal not-ready/peak/declining).
     const profile = profileMap?.get(key);
     const maturityStatus = profileMap ? classifyMaturity(bottle, profileMap) : null;
-    const maturityStr = maturityLabel(maturityStatus, profile);
+    const maturityStr = maturityLabel(maturityStatus, profile, bottle);
 
     // Enrichment: user's purchase price
     const purchaseStr = bottle.price ? `   Your price: ${bottle.currency || 'USD'} ${bottle.price}` : null;

--- a/backend/src/services/cellarExport.js
+++ b/backend/src/services/cellarExport.js
@@ -115,6 +115,15 @@ function mapBottlesForExport(bottles, racks, imagesByBottle = new Map(), reviews
     if (b.location) item.location = b.location;
     if (b.notes) item.notes = b.notes;
 
+    // Personal per-bottle drink window (the USER'S own intent, distinct from the
+    // sommelier `maturity` window below) + the occasion note. Additive fields the
+    // importer already consumes — emitted only when present so a bottle without
+    // them round-trips to the same (absent) state. Omitting these dropped the
+    // user's drink window on every export → import round-trip.
+    if (b.drinkFrom != null) item.drinkFrom = b.drinkFrom;
+    if (b.drinkTo != null) item.drinkTo = b.drinkTo;
+    if (b.occasion) item.occasion = b.occasion;
+
     // User-entered rating
     if (b.rating != null) {
       item.rating = b.rating;

--- a/backend/src/services/cellarExport.test.js
+++ b/backend/src/services/cellarExport.test.js
@@ -62,6 +62,34 @@ describe('mapBottlesForExport', () => {
     expect(item).not.toHaveProperty('images');
   });
 
+  test('emits the personal drink window + occasion when the bottle has them (BUG 2)', () => {
+    // Without these, an export → import round-trip silently dropped the user's
+    // own drink window and occasion note.
+    const bottles = [{
+      _id: oid('b1'), vintage: '2018', wineDefinition: { name: 'W' },
+      drinkFrom: 2030, drinkTo: 2040, occasion: 'For my 50th',
+    }];
+    const [item] = mapBottlesForExport(bottles, []);
+    expect(item.drinkFrom).toBe(2030);
+    expect(item.drinkTo).toBe(2040);
+    expect(item.occasion).toBe('For my 50th');
+  });
+
+  test('emits a single-sided drink window and omits the absent half', () => {
+    const bottles = [{ _id: oid('b1'), vintage: 'NV', wineDefinition: { name: 'W' }, drinkTo: 2035 }];
+    const [item] = mapBottlesForExport(bottles, []);
+    expect(item).not.toHaveProperty('drinkFrom');
+    expect(item.drinkTo).toBe(2035);
+  });
+
+  test('omits drink-window / occasion keys when the bottle has none', () => {
+    const bottles = [{ _id: oid('b1'), vintage: 'NV', wineDefinition: { name: 'W' } }];
+    const [item] = mapBottlesForExport(bottles, []);
+    expect(item).not.toHaveProperty('drinkFrom');
+    expect(item).not.toHaveProperty('drinkTo');
+    expect(item).not.toHaveProperty('occasion');
+  });
+
   test('emits rackPosition for a shelf rack but NOT the (grid-only) row/col', () => {
     // For non-grid racks the cols-based row/col math is wrong, so the export must
     // only carry rackPosition (the internal slot) and let the importer round-trip

--- a/backend/src/services/cellarImport.js
+++ b/backend/src/services/cellarImport.js
@@ -48,7 +48,7 @@ const { getMaxPosition } = require('../utils/rackGeometry');
 const { resolveRating } = require('../utils/ratingUtils');
 const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
 const { stripHtml } = require('../utils/sanitize');
-const { parseAndValidateVintage } = require('../utils/validation');
+const { parseAndValidateVintage, parseDrinkYear } = require('../utils/validation');
 const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
 const { CONSUMED_STATUSES } = require('../config/constants');
 
@@ -172,6 +172,11 @@ function exportBottleToItem(b) {
     purchaseUrl: b.purchaseUrl,
     location: b.location,
     notes: b.notes,
+    occasion: b.occasion,
+    // Personal per-bottle drink window (user intent) — sanitized in buildBottle
+    // like routes/import.js does, so a bad imported year never fails the bottle.
+    drinkFrom: b.drinkFrom,
+    drinkTo: b.drinkTo,
     rating: b.rating,
     ratingScale: b.ratingScale,
     dateAdded: b.dateAdded,
@@ -372,6 +377,20 @@ async function resolveWine(item, userId, cache, result) {
 /** Build (but don't save) a Bottle from an export item — mirrors routes/import.js. */
 function buildBottle({ cellarId, ownerId, item, canonicalVintage, wineDefinitionId, pendingWineRequestId, defaultCurrency }) {
   const priceSetAt = (item.price != null && item.price !== '') ? new Date() : undefined;
+
+  // Personal drink window (drinkFrom/drinkTo years) — sanitized exactly like
+  // routes/import.js: invalid values are silently dropped so a bad imported year
+  // never fails the bottle, and an inverted pair (from > to) is dropped whole
+  // (we can't tell which side is wrong). undefined omits the field entirely.
+  const fromCheck = parseDrinkYear(item.drinkFrom, 'drinkFrom');
+  const toCheck = parseDrinkYear(item.drinkTo, 'drinkTo');
+  let drinkFrom = fromCheck.ok ? fromCheck.value : undefined;
+  let drinkTo = toCheck.ok ? toCheck.value : undefined;
+  if (drinkFrom !== undefined && drinkTo !== undefined && drinkFrom > drinkTo) {
+    drinkFrom = undefined;
+    drinkTo = undefined;
+  }
+
   const bottle = new Bottle({
     cellar: cellarId,
     user: ownerId,
@@ -386,6 +405,9 @@ function buildBottle({ cellarId, ownerId, item, canonicalVintage, wineDefinition
     purchaseUrl: item.purchaseUrl || undefined,
     location: stripHtml(item.location),
     notes: stripHtml(item.notes),
+    occasion: stripHtml(item.occasion),
+    drinkFrom,
+    drinkTo,
   });
   if (item.dateAdded) bottle.createdAt = new Date(item.dateAdded);
   // Restore the cellar journey from the export when present (names + dates only —
@@ -851,6 +873,7 @@ module.exports = {
   archivePathToUrl,
   resolveTargets,
   exportBottleToItem,
+  buildBottle,
   attachMaturity,
   attachImages,
   importCellar,

--- a/backend/src/services/cellarImport.test.js
+++ b/backend/src/services/cellarImport.test.js
@@ -34,14 +34,23 @@ const {
   archivePathToUrl,
   resolveTargets,
   exportBottleToItem,
+  buildBottle,
   attachMaturity,
   attachImages,
   EXPORT_SCHEMA,
   MAX_IMPORT_CELLARS,
   MAX_IMPORT_BOTTLES,
 } = require('./cellarImport');
+const { mapBottlesForExport } = require('./cellarExport');
 const WineVintageProfile = require('../models/WineVintageProfile');
 const BottleImage = require('../models/BottleImage');
+
+// Valid 24-hex ObjectIds so buildBottle's `new Bottle({...})` casts cleanly.
+const OID = {
+  cellar: '64b0000000000000000000bb',
+  owner: '64b000000000000000000001',
+  wine: '64b0000000000000000000cc',
+};
 
 sharp.cache(false);
 
@@ -226,6 +235,60 @@ describe('exportBottleToItem', () => {
     expect(exportBottleToItem({ wineName: 'W', maturity }).maturity).toEqual(maturity);
     expect(exportBottleToItem({ wineName: 'W' }).maturity).toBeNull();
     expect(exportBottleToItem({ wineName: 'W', maturity: 'x' }).maturity).toBeNull();
+  });
+
+  test('carries the personal drink window + occasion through (BUG 2)', () => {
+    const item = exportBottleToItem({ wineName: 'W', drinkFrom: 2030, drinkTo: 2040, occasion: 'For my 50th' });
+    expect(item.drinkFrom).toBe(2030);
+    expect(item.drinkTo).toBe(2040);
+    expect(item.occasion).toBe('For my 50th');
+  });
+});
+
+// ── BUG 2: personal drink window + occasion survive a full export → import ─────
+describe('buildBottle drink window + occasion', () => {
+  const build = (item) => buildBottle({
+    cellarId: OID.cellar, ownerId: OID.owner, item, canonicalVintage: item.vintage || '2018',
+    wineDefinitionId: OID.wine, defaultCurrency: 'USD',
+  });
+
+  test('applies a valid personal window and occasion to the built bottle', () => {
+    const bottle = build({ vintage: '2018', drinkFrom: 2030, drinkTo: 2040, occasion: 'For my 50th' });
+    expect(bottle.drinkFrom).toBe(2030);
+    expect(bottle.drinkTo).toBe(2040);
+    expect(bottle.occasion).toBe('For my 50th');
+  });
+
+  test('drops an inverted window whole (mirrors routes/import.js)', () => {
+    const bottle = build({ vintage: '2018', drinkFrom: 2040, drinkTo: 2030 });
+    expect(bottle.drinkFrom).toBeUndefined();
+    expect(bottle.drinkTo).toBeUndefined();
+  });
+
+  test('silently drops an out-of-range year without failing the bottle', () => {
+    const bottle = build({ vintage: '2018', drinkFrom: 1899, drinkTo: 2040 });
+    expect(bottle.drinkFrom).toBeUndefined();
+    expect(bottle.drinkTo).toBe(2040);
+  });
+
+  test('leaves the window unset when the export carries none', () => {
+    const bottle = build({ vintage: '2018' });
+    expect(bottle.drinkFrom).toBeUndefined();
+    expect(bottle.drinkTo).toBeUndefined();
+  });
+
+  test('round-trips through export → import: mapBottlesForExport → exportBottleToItem → buildBottle', () => {
+    const oid = (s) => ({ toString: () => s });
+    const exportBottle = {
+      _id: oid('b1'), vintage: '2018', wineDefinition: { name: 'W' },
+      drinkFrom: 2030, drinkTo: 2040, occasion: 'For my 50th',
+    };
+    const [exported] = mapBottlesForExport([exportBottle], []);
+    const item = exportBottleToItem(exported);
+    const bottle = build({ ...item, vintage: '2018' });
+    expect(bottle.drinkFrom).toBe(2030);
+    expect(bottle.drinkTo).toBe(2040);
+    expect(bottle.occasion).toBe('For my 50th');
   });
 });
 

--- a/backend/src/services/drinkWindowNotifier.js
+++ b/backend/src/services/drinkWindowNotifier.js
@@ -128,6 +128,15 @@ async function processUser(user, isFirstRun) {
     const maturityStatus = classifyMaturity(bottle, profileMap);
     if (!maturityStatus) continue;
 
+    // A personal-window bottle whose wine request hasn't been approved yet has
+    // NO wineDefinition (it qualified for this query purely via drinkFrom/
+    // drinkTo). Its wdId is undefined, so the dedup key `undefined:vintage:status`
+    // would collapse every such bottle into ONE "Unknown wine" notification with
+    // a dead search link. There's no stable wine identity to notify about yet —
+    // skip it (and don't seed it) until it gains a definition; the marker starts
+    // null, so the correct alert fires cleanly on the first run after approval.
+    if (!bottle.wineDefinition) continue;
+
     const wdId = bottle.wineDefinition?._id?.toString();
     const profile = profileMap.get(`${wdId}:${bottle.vintage}`);
     const prevStatus = bottle.drinkWindowNotifiedStatus;
@@ -276,4 +285,4 @@ function buildNotification(alert) {
   }
 }
 
-module.exports = { runDrinkWindowCheck, shouldSendDigestEmail };
+module.exports = { runDrinkWindowCheck, processUser, shouldSendDigestEmail };

--- a/backend/src/services/drinkWindowNotifier.test.js
+++ b/backend/src/services/drinkWindowNotifier.test.js
@@ -1,4 +1,17 @@
-const { shouldSendDigestEmail } = require('./drinkWindowNotifier');
+// Model / side-effect mocks so processUser can be exercised without MongoDB.
+// These are hoisted above the require below; shouldSendDigestEmail is pure and
+// unaffected (its tests pass emailVerificationEnabled explicitly).
+jest.mock('../models/Cellar', () => ({ distinct: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ find: jest.fn(), updateOne: jest.fn(), bulkWrite: jest.fn() }));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('./notifications', () => ({ createNotification: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('./mailgun', () => ({ sendDrinkWindowDigest: jest.fn().mockResolvedValue(undefined), EMAIL_VERIFICATION_ENABLED: false }));
+
+const { shouldSendDigestEmail, processUser } = require('./drinkWindowNotifier');
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const WineVintageProfile = require('../models/WineVintageProfile');
+const { createNotification } = require('./notifications');
 
 /**
  * Regression coverage for the "silently dead digest" bug: the email opt-in
@@ -40,5 +53,82 @@ describe('shouldSendDigestEmail', () => {
     expect(shouldSendDigestEmail({}, true)).toBe(false);
     expect(shouldSendDigestEmail({ emailVerified: true }, true)).toBe(false);
     expect(shouldSendDigestEmail({ emailVerified: true, preferences: { notifications: {} } }, true)).toBe(false);
+  });
+});
+
+/**
+ * BUG 4 regression: the widened bottle query admits personal-window bottles that
+ * have NO wineDefinition (their wine request isn't approved yet). Their wdId is
+ * undefined, so the dedup key `undefined:vintage:status` merged every such bottle
+ * into ONE bogus "Unknown wine" notification with a dead search link. They must
+ * be skipped (no stable wine identity to notify about) while matched-wine bottles
+ * are unaffected.
+ */
+describe('processUser — definition-less personal-window bottles (BUG 4)', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-15T00:00:00Z'));
+  });
+  afterAll(() => jest.useRealTimers());
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Cellar.distinct.mockResolvedValue(['cellar1']);
+    Bottle.updateOne.mockResolvedValue({});
+    Bottle.bulkWrite.mockResolvedValue({});
+    // No reviewed sommelier profiles — every classification here is personal.
+    WineVintageProfile.find.mockReturnValue({ lean: () => Promise.resolve([]) });
+  });
+
+  const mockBottles = (bottles) => {
+    Bottle.find.mockReturnValue({ populate: () => ({ lean: () => Promise.resolve(bottles) }) });
+  };
+
+  test('two definition-less bottles of the same vintage do NOT merge into an "Unknown wine" alert', async () => {
+    // Both are in-window (2020–2030, current year 2026 → peak) but carry no wine
+    // definition. A real matched-wine bottle sits alongside them.
+    mockBottles([
+      { _id: 'b1', cellar: 'cellar1', vintage: '2019', drinkFrom: 2020, drinkTo: 2030, wineDefinition: null },
+      { _id: 'b2', cellar: 'cellar1', vintage: '2019', drinkFrom: 2020, drinkTo: 2030, wineDefinition: null },
+      { _id: 'b3', cellar: 'cellar1', vintage: '2018', drinkFrom: 2020, drinkTo: 2030, wineDefinition: { _id: 'wd1', name: 'Real Wine' } },
+    ]);
+
+    const count = await processUser({ _id: 'u1' }, false);
+
+    // Only the matched-wine bottle produced a notification.
+    expect(count).toBe(1);
+    expect(createNotification).toHaveBeenCalledTimes(1);
+    const [, , title, message] = createNotification.mock.calls[0];
+    expect(`${title} ${message}`).toContain('Real Wine');
+    // The bug's tell-tale: never an "Unknown wine" line.
+    for (const call of createNotification.mock.calls) {
+      expect(`${call[2]} ${call[3]}`).not.toContain('Unknown wine');
+    }
+    // The definition-less bottles are never even marked (no seed/update for them).
+    const markedIds = Bottle.updateOne.mock.calls.map((c) => c[0]._id);
+    expect(markedIds).not.toContain('b1');
+    expect(markedIds).not.toContain('b2');
+    expect(markedIds).toContain('b3');
+  });
+
+  test('a lone definition-less personal-window bottle yields no notification', async () => {
+    mockBottles([
+      { _id: 'b1', cellar: 'cellar1', vintage: 'NV', drinkFrom: 2020, drinkTo: 2030, wineDefinition: null },
+    ]);
+    const count = await processUser({ _id: 'u1' }, false);
+    expect(count).toBe(0);
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  test('after a window reset (marker null), a matched-wine bottle fires cleanly', async () => {
+    // Mirrors BUG 1's downstream effect: a bottle whose marker was cleared by an
+    // edit re-fires on the next run.
+    mockBottles([
+      { _id: 'b3', cellar: 'cellar1', vintage: '2018', drinkFrom: 2020, drinkTo: 2030,
+        drinkWindowNotifiedStatus: null, wineDefinition: { _id: 'wd1', name: 'Real Wine' } },
+    ]);
+    const count = await processUser({ _id: 'u1' }, false);
+    expect(count).toBe(1);
+    expect(createNotification).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/services/globalStatsService.js
+++ b/backend/src/services/globalStatsService.js
@@ -453,6 +453,16 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
   // be compared against absolute calendar years — including them misclassified
   // every somm-reviewed NV bottle as 'declining'. Bottles without a reviewed
   // profile fall into 'noProfile'.
+  //
+  // KNOWN DIVERGENCE from utils/maturityUtils.js#classifyMaturity: that function
+  // gives a bottle's PERSONAL drink window (Bottle.drinkFrom/drinkTo) precedence
+  // over the sommelier profile, and applies it even to NV / definition-less
+  // bottles. This admin-only aggregation does NOT read the personal window — it
+  // classifies purely from the sommelier profile — so a bottle whose per-user
+  // window overrides its profile lands in a different phase here than on the
+  // owner's Statistics page. Accepted: this is a global registry-health view
+  // (low stakes), and personal windows are per-user data that don't belong in an
+  // instance-wide roll-up. See statsService.js for the personal-window-aware path.
   const maturityRaw = await safeAggregate(Bottle, [
     { $match: { ...bottleMatch, status: 'active', vintage: { $nin: ['NV', null, ''] } } },
     { $lookup: {
@@ -471,7 +481,9 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
     { $unwind: { path: '$profile', preserveNullAndEmptyArrays: true } },
     { $addFields: {
       maturity: {
-        // Mirror utils/maturityUtils.js#classifyMaturity exactly:
+        // Mirror utils/maturityUtils.js#classifyMaturity's PROFILE branch (the
+        // personal drinkFrom/drinkTo window is intentionally not applied here —
+        // see the KNOWN DIVERGENCE note above):
         //   - NV bottles return null there; here they are excluded by the
         //     pipeline's vintage $nin filter instead (their profiles hold
         //     purchase-relative offsets, not calendar years)

--- a/backend/src/services/statsService.js
+++ b/backend/src/services/statsService.js
@@ -1,6 +1,6 @@
 const { getOrCreateDailySnapshot, convertCurrency } = require('../utils/exchangeRates');
 const { toNormalized } = require('../utils/ratingUtils');
-const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
+const { classifyMaturity, classifyPersonalWindow, buildProfileMap } = require('../utils/maturityUtils');
 
 // ── Main export ───────────────────────────────────────────────────────────────
 
@@ -111,26 +111,54 @@ async function computeOverview({ activeBottles, consumedBottles, cellars, target
       byPurchaseYear[py] = (byPurchaseYear[py] || 0) + 1;
     }
 
-    // Maturity classification from sommelier profiles
+    // Maturity classification. classifyMaturity prefers the bottle's PERSONAL
+    // drink window (drinkFrom/drinkTo) over the sommelier profile, so the phase
+    // buckets + health score reflect the user's own intent wherever it's set.
+    const personalStatus = classifyPersonalWindow(b);
+    const wdId = wd?._id?.toString() || (typeof b.wineDefinition === 'string' ? b.wineDefinition : null);
+    const reviewedProfile = (wdId && b.vintage && b.vintage !== 'NV')
+      ? profileMap.get(`${wdId}:${b.vintage}`)
+      : null;
+    // A reviewed profile only "counts" when it carries a usable window boundary —
+    // same guard classifyMaturity uses, so a usable profile always yields a phase
+    // (and is never left in the noProfile bucket).
+    const hasUsableProfile = !!reviewedProfile &&
+      (reviewedProfile.earlyFrom != null || reviewedProfile.peakFrom != null || reviewedProfile.peakUntil != null);
+
     const maturityStatus = classifyMaturity(b, profileMap);
     if (maturityStatus) {
       const key = maturityStatus === 'not-ready' ? 'notReady' : maturityStatus;
       maturity[key]++;
-      maturityCoverage.sommSet++;
       healthScoreSum += HEALTH_SCORES[maturityStatus] ?? 0;
       healthScoreCount++;
     } else {
       maturity.noProfile++;
-      maturityCoverage.none++;
     }
 
-    // Forecast: for bottles with a reviewed profile, count peak years
+    // Coverage note ("N with sommelier profiles") counts ONLY a usable reviewed
+    // sommelier profile (BUG 5). A personal drink window is the user's own
+    // overlay, not a somm profile, so it must not inflate sommSet. A bottle with
+    // neither signal is "without data" (none); a personal-only bottle carries the
+    // user's data but no somm profile, so it counts toward neither — it still
+    // shows in the phase distribution above, just not in this coverage line.
+    if (hasUsableProfile) maturityCoverage.sommSet++;
+    else if (!personalStatus) maturityCoverage.none++;
+
+    // Forecast: count the years each drinkable bottle sits in its window, using
+    // the SAME window that governed its bucket — the personal window when it
+    // governs (so personal-only bottles are included and a personal override on a
+    // profiled wine uses the personal years), else the sommelier profile. This
+    // keeps the forecast reconciled with how the buckets were counted.
     if (maturityStatus) {
-      const wdId = wd?._id?.toString() || b.wineDefinition?.toString();
-      const profile = profileMap.get(`${wdId}:${b.vintage}`);
-      if (profile) {
-        const pFrom = profile.peakFrom || profile.earlyFrom;
-        const pUntil = profile.lateUntil || profile.peakUntil || profile.earlyUntil;
+      let pFrom = null, pUntil = null;
+      if (personalStatus) {
+        pFrom  = Number.isFinite(b.drinkFrom) ? b.drinkFrom : null;
+        pUntil = Number.isFinite(b.drinkTo)   ? b.drinkTo   : null;
+      } else if (reviewedProfile) {
+        pFrom  = reviewedProfile.peakFrom || reviewedProfile.earlyFrom;
+        pUntil = reviewedProfile.lateUntil || reviewedProfile.peakUntil || reviewedProfile.earlyUntil;
+      }
+      if (personalStatus || reviewedProfile) {
         for (const fy of forecastYears) {
           if ((!pFrom || fy >= pFrom) && (!pUntil || fy <= pUntil)) forecastCounts[fy]++;
         }

--- a/backend/src/services/statsService.test.js
+++ b/backend/src/services/statsService.test.js
@@ -1,0 +1,135 @@
+/**
+ * statsService maturity coverage + forecast (BUG 5).
+ *
+ * WHY THIS TEST EXISTS:
+ * classifyMaturity prefers a bottle's PERSONAL drink window (drinkFrom/drinkTo)
+ * over the sommelier profile. Two knock-on bugs followed:
+ *   1. maturityCoverage.sommSet ("N with sommelier profiles") was incremented for
+ *      personal-window bottles that have NO reviewed profile — an overcount.
+ *   2. the 10-year forecast used profile years even when a personal window
+ *      governed the bucket, and excluded personal-only bottles entirely — so the
+ *      forecast disagreed with the phase buckets.
+ *
+ * Chosen semantics (documented in statsService.js):
+ *   - sommSet  = bottles that actually have a reviewed sommelier profile.
+ *   - none     = bottles with NO signal at all (no personal window, no profile).
+ *   - personal-only bottles count toward NEITHER coverage bucket but still land
+ *     in a phase bucket and the forecast, using their personal years.
+ *
+ * Models / rate snapshot are mocked so no MongoDB is needed.
+ */
+
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+  convertCurrency: jest.fn((amt) => amt),
+}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+
+const { computeOverview } = require('./statsService');
+const WineVintageProfile = require('../models/WineVintageProfile');
+
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-06-15T00:00:00Z'));
+});
+afterAll(() => jest.useRealTimers());
+
+beforeEach(() => jest.clearAllMocks());
+
+const runOverview = (activeBottles, profiles = []) => {
+  // buildProfileMap issues one find({...}).lean(); return the given reviewed profiles.
+  WineVintageProfile.find.mockReturnValue({ lean: () => Promise.resolve(profiles) });
+  return computeOverview({
+    activeBottles,
+    consumedBottles: [],
+    cellars: [{ _id: 'c1', name: 'Main' }],
+    targetCurrency: 'USD',
+    targetRatingScale: '100',
+  });
+};
+
+const forecastByYear = (stats) => Object.fromEntries(stats.maturityForecast.map((d) => [d.year, d.count]));
+
+describe('maturityCoverage.sommSet (BUG 5)', () => {
+  test('a personal-window bottle with NO profile is NOT counted as sommSet', async () => {
+    const stats = await runOverview([
+      { cellar: 'c1', vintage: '2018', drinkFrom: 2024, drinkTo: 2028, wineDefinition: { _id: 'wd1' } },
+    ]);
+    expect(stats.maturity.peak).toBe(1);        // classified via the personal window
+    expect(stats.maturityCoverage.sommSet).toBe(0); // but NOT a sommelier profile
+    expect(stats.maturityCoverage.none).toBe(0);    // and not "without data" either
+  });
+
+  test('a bottle with a reviewed profile IS counted as sommSet', async () => {
+    const stats = await runOverview(
+      [{ cellar: 'c1', vintage: '2019', wineDefinition: { _id: 'wd2' } }],
+      [{ wineDefinition: 'wd2', vintage: '2019', status: 'reviewed', peakFrom: 2025, peakUntil: 2030 }],
+    );
+    expect(stats.maturity.peak).toBe(1);
+    expect(stats.maturityCoverage.sommSet).toBe(1);
+    expect(stats.maturityCoverage.none).toBe(0);
+  });
+
+  test('a bottle with neither a personal window nor a profile is "without data" (none)', async () => {
+    const stats = await runOverview([
+      { cellar: 'c1', vintage: '2019', wineDefinition: { _id: 'wd3' } },
+    ]);
+    expect(stats.maturity.noProfile).toBe(1);
+    expect(stats.maturityCoverage.none).toBe(1);
+    expect(stats.maturityCoverage.sommSet).toBe(0);
+  });
+
+  test('a reviewed-but-empty profile (no window boundaries) is NOT sommSet and lands in noProfile', async () => {
+    // The bottle must not be counted "with a sommelier profile" while it shows in
+    // the No Profile segment — that would be an internal contradiction.
+    const stats = await runOverview(
+      [{ cellar: 'c1', vintage: '2019', wineDefinition: { _id: 'wd4' } }],
+      [{ wineDefinition: 'wd4', vintage: '2019', status: 'reviewed', sommNotes: 'reviewed but no window' }],
+    );
+    expect(stats.maturity.noProfile).toBe(1);
+    expect(stats.maturityCoverage.sommSet).toBe(0);
+    expect(stats.maturityCoverage.none).toBe(1);
+  });
+});
+
+describe('maturityForecast personal-window consistency (BUG 5)', () => {
+  test('a personal-only bottle is included in the forecast using its own years', async () => {
+    const stats = await runOverview([
+      { cellar: 'c1', vintage: '2018', drinkFrom: 2024, drinkTo: 2028, wineDefinition: { _id: 'wd1' } },
+    ]);
+    expect(stats.maturity.peak).toBe(1);
+    const byYear = forecastByYear(stats);
+    expect(byYear[2026]).toBe(1); // inside 2024–2028
+    expect(byYear[2028]).toBe(1); // last in-window year
+    expect(byYear[2029]).toBe(0); // past drinkTo
+  });
+
+  test('a personal override on a profiled wine uses the personal years, not the profile years', async () => {
+    const stats = await runOverview(
+      [{ cellar: 'c1', vintage: '2019', drinkFrom: 2031, drinkTo: 2033, wineDefinition: { _id: 'wd2' } }],
+      [{ wineDefinition: 'wd2', vintage: '2019', status: 'reviewed', peakFrom: 2025, peakUntil: 2030 }],
+    );
+    // Personal window governs the bucket (not-ready in 2026) …
+    expect(stats.maturity.notReady).toBe(1);
+    // … the wine still HAS a reviewed profile, so it honestly counts as sommSet …
+    expect(stats.maturityCoverage.sommSet).toBe(1);
+    // … but the forecast uses the personal 2031–2033 window, not the profile 2025–2030.
+    const byYear = forecastByYear(stats);
+    expect(byYear[2026]).toBe(0);
+    expect(byYear[2031]).toBe(1);
+    expect(byYear[2033]).toBe(1);
+    expect(byYear[2034]).toBe(0);
+  });
+
+  test('a profile-only bottle still forecasts from its profile window', async () => {
+    const stats = await runOverview(
+      [{ cellar: 'c1', vintage: '2019', wineDefinition: { _id: 'wd2' } }],
+      [{ wineDefinition: 'wd2', vintage: '2019', status: 'reviewed', peakFrom: 2027, peakUntil: 2029 }],
+    );
+    const byYear = forecastByYear(stats);
+    expect(byYear[2026]).toBe(0);
+    expect(byYear[2027]).toBe(1);
+    expect(byYear[2029]).toBe(1);
+    expect(byYear[2030]).toBe(0);
+  });
+});

--- a/backend/src/utils/maturityUtils.js
+++ b/backend/src/utils/maturityUtils.js
@@ -87,14 +87,39 @@ async function buildProfileMap(activeBottles) {
 
 /**
  * Return a human-readable maturity label for the chat context.
- * Uses the classification status and the profile's year ranges.
+ *
+ * Uses the classification status and year ranges. When the bottle's PERSONAL
+ * drink window governs the status (same precedence as classifyMaturity), the
+ * label quotes the personal drinkFrom/drinkTo years — NOT the sommelier
+ * profile's — so the years match the status source (otherwise a personal
+ * "not-ready" could read "drinking from 2020" while the real personal drinkFrom
+ * is 2035). With no personal window, the profile-based labels are unchanged.
  *
  * @param {string|null} status  – output of classifyMaturity()
  * @param {object|null} profile – the WineVintageProfile document
+ * @param {object|null} bottle  – the bottle (for its personal drinkFrom/drinkTo)
  * @returns {string|null}
  */
-function maturityLabel(status, profile) {
+function maturityLabel(status, profile, bottle = null) {
   if (!status) return null;
+
+  // Personal window wins: build the label from the user's own years so it is
+  // consistent with the personal-window status classifyMaturity returned.
+  if (bottle && classifyPersonalWindow(bottle)) {
+    const from = Number.isFinite(bottle.drinkFrom) ? bottle.drinkFrom : null;
+    const to   = Number.isFinite(bottle.drinkTo)   ? bottle.drinkTo   : null;
+    switch (status) {
+      case 'not-ready':
+        return `Not ready yet — drinking from ${from ?? '?'}`;
+      case 'peak':
+        return to ? `At peak — drink now through ${to}` : 'At peak maturity — drink now';
+      case 'declining':
+        return 'Past peak — declining, drink immediately if at all';
+      default:
+        break; // any other status → fall through to the profile-based labels
+    }
+  }
+
   switch (status) {
     case 'not-ready':
       return `Not ready yet — drinking from ${profile?.earlyFrom || profile?.peakFrom || '?'}`;

--- a/backend/src/utils/maturityUtils.test.js
+++ b/backend/src/utils/maturityUtils.test.js
@@ -397,3 +397,41 @@ describe('maturityLabel', () => {
     expect(label).toBe('Not ready yet — drinking from ?');
   });
 });
+
+// ── BUG 3: label must quote the PERSONAL window years when it governs ─────────
+// System clock is fixed to 2026 above. The profile deliberately disagrees with
+// the personal window so a leak of profile years is visible.
+describe('maturityLabel — personal window precedence', () => {
+  const profileSaysNow = { earlyFrom: 2018, peakFrom: 2020, peakUntil: 2028, lateUntil: 2032 };
+
+  test('not-ready: quotes the personal drinkFrom, not the profile early/peak year', () => {
+    const bottle = { drinkFrom: 2035, drinkTo: 2040 };
+    // status derived from the personal window (currentYear 2026 < 2035)
+    expect(maturityLabel('not-ready', profileSaysNow, bottle)).toBe('Not ready yet — drinking from 2035');
+  });
+
+  test('peak: quotes the personal drinkTo, not the profile peakUntil', () => {
+    const bottle = { drinkFrom: 2024, drinkTo: 2038 };
+    expect(maturityLabel('peak', profileSaysNow, bottle)).toBe('At peak — drink now through 2038');
+  });
+
+  test('peak with only drinkFrom set: open-ended personal peak has no year suffix', () => {
+    const bottle = { drinkFrom: 2024 };
+    expect(maturityLabel('peak', profileSaysNow, bottle)).toBe('At peak maturity — drink now');
+  });
+
+  test('declining: personal window → year-free past-peak label', () => {
+    const bottle = { drinkFrom: 2018, drinkTo: 2022 };
+    expect(maturityLabel('declining', profileSaysNow, bottle)).toBe('Past peak — declining, drink immediately if at all');
+  });
+
+  test('no personal window on the bottle → unchanged profile-based label', () => {
+    const bottle = { vintage: 2020 }; // no drinkFrom/drinkTo
+    expect(maturityLabel('peak', profileSaysNow, bottle)).toBe('At peak — drink now through 2028');
+    expect(maturityLabel('not-ready', { earlyFrom: 2028 }, bottle)).toBe('Not ready yet — drinking from 2028');
+  });
+
+  test('omitting the bottle arg keeps the legacy profile-based behaviour', () => {
+    expect(maturityLabel('peak', profileSaysNow)).toBe('At peak — drink now through 2028');
+  });
+});


### PR DESCRIPTION
Fixes a batch of AUDIT-confirmed logic bugs in the per-bottle drink-window feature. Each fix ships with a regression test pinned to its scenario. Backend-only.

## BUG 1 (HIGH) — editing a personal window never reset the notifier marker
- **Bug:** `PUT /api/bottles/:id` wrote `drinkFrom`/`drinkTo` but never cleared `drinkWindowNotifiedStatus`/`drinkWindowNotifiedAt`. The notifier only rewrites the marker on a notifiable transition, so a stale marker (e.g. `'peak'`) permanently suppressed the alert for the new window (push `drinkFrom` out to 2030 → the 2030 peak alert never fires).
- **Fix:** when a PUT actually changes `drinkFrom` or `drinkTo` (real value diff), reset both marker fields to `null` so the next notifier run re-evaluates cleanly. Create paths (`POST /api/bottles`, `routes/import.js`, `cellarImport`) build fresh bottles with the marker already `null`, so no change needed there.
- **Test:** `bottles.drinkWindow.test.js` — changing `drinkFrom`/`drinkTo` (and clearing to null) resets the marker; an update that doesn't touch the window, and a no-op same-value write, leave it intact.

## BUG 2 (HIGH) — cellar export omitted drinkFrom/drinkTo/occasion → round-trip destroyed them
- **Bug:** `cellarExport.mapBottlesForExport` never emitted the three fields, but the importer already accepts them, so every export → import round-trip silently dropped the user's personal window + occasion.
- **Fix:** emit `drinkFrom`/`drinkTo`/`occasion` in the export (only when present). Import side: carry them through `cellarImport.exportBottleToItem` and set them in `buildBottle`, sanitizing the years exactly like `routes/import.js` (invalid dropped silently, inverted pair dropped whole) so a bad imported year never fails the bottle. Schema stays `cellarion-export@1` — prior additive fields (cellarHistory, reviews, maturity) were added without a bump, so this matches.
- **Test:** `cellarExport.test.js` (emits when present, single-sided, omits when absent) + `cellarImport.test.js` (`exportBottleToItem` carries them; `buildBottle` applies valid, drops inverted/out-of-range; full `mapBottlesForExport → exportBottleToItem → buildBottle` round-trip preserves them).

## BUG 3 (MED) — AI chat quoted profile years for a personal-window status
- **Bug:** `maturityUtils.maturityLabel` was called with the vintage profile even when `classifyMaturity` returned a status from the bottle's PERSONAL window, producing "Not ready yet — drinking from 2020" while the real personal `drinkFrom` was 2035.
- **Fix:** `maturityLabel` now takes the bottle and, when its personal window governs (same precedence as `classifyMaturity`), quotes the personal `drinkFrom`/`drinkTo` years. Profile-based labels are unchanged when there's no personal window. `aiChat.formatWineList` passes the bottle.
- **Test:** `maturityUtils.test.js` — personal 2035–2040 over a 2020 profile → label reflects 2035/2040; peak quotes `drinkTo`; declining is year-free; no personal window (or omitted bottle arg) → unchanged profile label.

## BUG 4 (MED) — notifier admitted definition-less bottles → "Unknown wine" collapse
- **Bug:** the widened `$or` admits personal-window bottles with no `wineDefinition` (pending wine request). `wdId` is `undefined`, so the dedup key `undefined:vintage:status` merged distinct wines into one "Unknown wine" notification with a dead search link.
- **Fix / decision — option (a), skip:** a personal-window bottle without a resolved `wineDefinition` has no stable wine identity to notify about, so it's skipped (not seeded, not alerted) until its request is approved; the marker starts `null`, so the correct alert fires cleanly on the first run after approval. Matched-wine bottles are unaffected. (Preferred over bottle-id keying since the bottle carries no usable display name at this stage.)
- **Test:** `drinkWindowNotifier.test.js` — `processUser` now exported; two definition-less bottles of the same vintage produce zero notifications (no "Unknown wine", never marked) while a matched-wine bottle alongside them still fires exactly one; a lone definition-less bottle yields nothing; a reset (marker `null`) matched-wine bottle fires.

## BUG 5 (LOW) — stats maturity card overcounted sommSet + forecast ignored personal windows
- **Bug:** `statsService` incremented `maturityCoverage.sommSet` ("N with sommelier profiles") for personal-window statuses with no profile, and the 10-year forecast used profile years even when a personal window governed the bucket / excluded personal-only bottles.
- **Fix / decision:** `sommSet` counts only bottles with a **usable reviewed profile** (window boundary present — same guard `classifyMaturity` uses, so a sommSet bottle is never left in the No-Profile segment). `none` = bottles with no signal at all; a personal-only bottle counts toward neither coverage bucket (it's the user's data, not a somm profile) but still lands in a phase bucket. The forecast uses the **same window that governed the bucket** — the personal window when it governs (personal-only bottles now included; a personal override on a profiled wine uses personal years), else the profile — so forecast and buckets reconcile. Documented in-code.
- **Test:** new `statsService.test.js` — personal-only bottle not counted as sommSet; usable profile counted; reviewed-but-empty profile is not sommSet and lands in noProfile; forecast includes personal-only bottles and uses personal years for an override.

## BUG 6 (LOW) — globalStatsService "mirrors classifyMaturity exactly" comment was false
- **Bug:** the admin-only maturity aggregation was never updated for personal-window precedence, so the "exactly" claim was wrong.
- **Fix:** corrected the comment to document the KNOWN DIVERGENCE (the aggregation classifies purely from the sommelier profile and does not read the per-bottle personal window; accepted as a low-stakes instance-wide registry-health view where per-user windows don't belong). Comment-only — no logic change, no test.

## Accepted / out of scope
- **Grouped-card mixed-window badge (audit BW-7):** not addressed. A grouped card aggregates bottles that may have different personal windows, so a single badge is inherently lossy; low impact. Accepted as-is.

## Testing
- `cd backend && npm test` → **65 suites / 1045 tests pass.**
- No frontend drink-status/maturity code touched, so `frontend` tests were not required.

## docker-compose impact
- **None.** Pure application logic + tests; no new services, ports, env vars, images, or dependencies.
