### PR TITLE
feat: expose bottle id in stats urgency ladder (HA consume support)

### DIFF
--- a/backend/src/services/statsService.js
+++ b/backend/src/services/statsService.js
@@ -167,6 +167,11 @@ async function computeOverview({ activeBottles, consumedBottles, cellars, target
 
     if (maturityStatus === 'declining' || maturityStatus === 'late') {
       urgencyArr.push({
+        // Bottle id lets API consumers (e.g. the Home Assistant card) act on the
+        // item — consume via POST /api/bottles/:id/consume. Optional-chained so a
+        // missing _id omits the field instead of crashing (clients treat absence
+        // as "no actions available").
+        id:            b._id?.toString(),
         name:          wd?.name      || 'Unknown',
         producer:      wd?.producer  || '',
         vintage:       b.vintage     || 'NV',

--- a/backend/src/services/statsService.test.js
+++ b/backend/src/services/statsService.test.js
@@ -92,6 +92,26 @@ describe('maturityCoverage.sommSet (BUG 5)', () => {
   });
 });
 
+describe('urgencyLadder bottle id (HA consume support)', () => {
+  test('urgency items carry the bottle id so API consumers can act on them', async () => {
+    const stats = await runOverview([
+      // drinkTo in the past → 'declining' → lands on the urgency ladder
+      { _id: 'b1', cellar: 'c1', vintage: '2015', drinkFrom: 2016, drinkTo: 2020, wineDefinition: { _id: 'wd1', name: 'Old Red' } },
+    ]);
+    expect(stats.urgencyLadder).toHaveLength(1);
+    expect(stats.urgencyLadder[0].id).toBe('b1');
+    expect(stats.urgencyLadder[0].name).toBe('Old Red');
+  });
+
+  test('a bottle without _id omits the id field instead of crashing', async () => {
+    const stats = await runOverview([
+      { cellar: 'c1', vintage: '2015', drinkFrom: 2016, drinkTo: 2020, wineDefinition: { _id: 'wd1' } },
+    ]);
+    expect(stats.urgencyLadder).toHaveLength(1);
+    expect(stats.urgencyLadder[0].id).toBeUndefined();
+  });
+});
+
 describe('maturityForecast personal-window consistency (BUG 5)', () => {
   test('a personal-only bottle is included in the forecast using its own years', async () => {
     const stats = await runOverview([


### PR DESCRIPTION
## What

Adds `id` (bottle ObjectId) to each item in the stats `urgencyLadder`, per §2 of `docs/ha-push-events.md`.

## Why

The Home Assistant integration (ha-cellarion v1.2.0+) renders a one-tap consume button on its urgency card, calling the **existing** `POST /api/bottles/:id/consume` — it just needs to know which bottle. The HA card checks for the field, so:

- old server + new client → button simply does not render
- new server + old client → extra field ignored

Fully backward/forward compatible.

## Safety

- Stats are per-user authenticated; bottle ObjectIds are already exposed on every bottle endpoint — no new information disclosure.
- Optional-chained (`b._id?.toString()`) so a missing `_id` omits the field instead of crashing.

## Docker-compose / prod impact

None. No new services, ports, env vars, or nginx changes.

## Tests

Two new cases in `statsService.test.js` (id present; id omitted when `_id` missing). Suite: 9/9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)