### PR TITLE
feat: SSE push events at /api/events/stream (HA §1)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -62,6 +62,7 @@ const ogRoute = require('./routes/og');
 const taxonomyRoute = require('./routes/taxonomy');
 const stripeRoute = require('./routes/stripe');
 const tokensRoute = require('./routes/tokens');
+const eventsRoute = require('./routes/events');
 const rateLimitsConfig = require('./config/rateLimits');
 const aiConfig = require('./config/aiConfig');
 const announcementConfig = require('./config/announcement');
@@ -224,6 +225,7 @@ app.use('/api/help', helpRoute);
 app.use('/api/wine-lists', wineListsRoute);
 app.use('/api/stripe', stripeRoute);
 app.use('/api/tokens', tokensRoute);
+app.use('/api/events', eventsRoute);
 
 // 404 handler
 app.use((req, res) => {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -7,6 +7,7 @@ const User = require('../models/User');
 const { requireAuth } = require('../middleware/auth');
 const { checkIsSuperAdmin } = require('../middleware/superAdmin');
 const { logAudit } = require('../services/audit');
+const eventBus = require('../services/eventBus');
 const { CURRENT_PRIVACY_POLICY_VERSION } = require('../config/legal');
 const rateLimitsConfig = require('../config/rateLimits');
 const { sendVerificationEmail, sendPasswordResetEmail, sendAccountLockoutAlert, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
@@ -542,6 +543,9 @@ router.post('/change-password', requireAuth, authLimiter, async (req, res) => {
 
     user.password = newPassword;
     user.refreshTokenHash = null; // Invalidate all existing sessions
+    // Also force-close any open SSE event streams — same trust boundary as
+    // refresh sessions (docs/ha-push-events.md §1).
+    eventBus.dropUser(user._id);
 
     const accessToken = await issueTokens(user, res);
 
@@ -572,6 +576,10 @@ router.post('/logout', requireAuth, async (req, res) => {
       user.refreshTokenHash = null;
       await user.save();
     }
+    // Logout invalidates the account's (single) refresh session, so it is a
+    // logout-everywhere — close open SSE event streams too. An integration
+    // holding valid credentials simply reconnects.
+    eventBus.dropUser(req.user.id);
     clearRefreshCookie(res);
     res.json({ message: 'Logged out' });
   } catch (error) {
@@ -659,6 +667,7 @@ router.post('/reset-password', authLimiter, async (req, res) => {
     user.passwordResetTokenHash = null;
     user.passwordResetExpiresAt = null;
     user.refreshTokenHash = null; // Invalidate all existing sessions
+    eventBus.dropUser(user._id); // and force-close open SSE event streams
     // Successful password reset is the user's explicit recovery signal —
     // clear any brute-force lockout state too. Otherwise a locked user
     // would still be locked after resetting their password.

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -447,6 +447,8 @@ router.post('/', async (req, res) => {
 
     await cellar.save();
 
+    logAudit(req, 'cellar.create', { type: 'cellar', id: cellar._id, cellarId: cellar._id }, { name: cellar.name });
+
     const obj = cellar.toObject();
     obj.userRole = 'owner';
     obj.userColor = getUserColor(cellar, req.user.id);
@@ -1347,6 +1349,9 @@ router.put('/:id', async (req, res) => {
     if (description !== undefined) cellar.description = description?.trim() || '';
 
     await cellar.save();
+
+    logAudit(req, 'cellar.update', { type: 'cellar', id: cellar._id, cellarId: cellar._id }, { name: cellar.name });
+
     const obj = cellar.toObject();
     obj.userRole = 'owner';
     obj.userColor = getUserColor(cellar, req.user.id);

--- a/backend/src/routes/events.js
+++ b/backend/src/routes/events.js
@@ -1,0 +1,76 @@
+const express = require('express');
+const router = express.Router();
+const { requireAuth } = require('../middleware/auth');
+const eventBus = require('../services/eventBus');
+const User = require('../models/User');
+const ApiToken = require('../models/ApiToken');
+
+// Stream lifetime and liveness (docs/ha-push-events.md §1):
+// - heartbeat comment every 25 s — clients treat >90 s of silence as dead, and
+//   nginx's proxy_read_timeout 120s would otherwise kill idle streams
+// - hard cap 24 h per stream; the client reconnects
+// - hourly revalidation: one cheap indexed read per stream per hour to catch
+//   revocations the dropUser/dropToken hooks might have missed (deleted user,
+//   revoked token). No bcrypt anywhere on this path.
+const HEARTBEAT_MS = 25 * 1000;
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const REVALIDATE_MS = 60 * 60 * 1000;
+
+// GET /api/events/stream — Server-Sent Events push channel.
+//
+// Auth: the same requireAuth as the REST API — either a JWT access token or a
+// `read`-scoped personal API token (the scope allowlist includes this route).
+// The credential is validated AT CONNECT; the stream is deliberately NOT
+// terminated when a 15-min JWT expires (that would force a bcrypt re-login
+// every 15 min per household — worse than the polling this replaces). The
+// stream carries no data, only "something changed" nudges; real reads still
+// require a live credential. Force-close hooks (password change/reset, logout,
+// account deletion, token revocation) plus the hourly revalidation bound the
+// exposure.
+router.get('/stream', requireAuth, (req, res) => {
+  const tokenId = req.apiToken?.id || null;
+  const registered = eventBus.register(req.user.id, res, tokenId);
+  if (!registered.ok) {
+    return res.status(429).json({ error: 'Too many event streams' });
+  }
+
+  res.set({
+    'Content-Type': 'text/event-stream',
+    // no-transform keeps the global compression() middleware away — it would
+    // buffer the stream and frames would never flush
+    'Cache-Control': 'no-cache, no-transform',
+    // nginx: do not buffer this response (per-route; no nginx.conf change)
+    'X-Accel-Buffering': 'no',
+  });
+  res.flushHeaders();
+  res.write('retry: 5000\n\nevent: ready\ndata: {}\n\n');
+
+  const heartbeat = setInterval(() => {
+    if (res.destroyed || res.writableEnded) return;
+    try { res.write(': hb\n\n'); } catch { /* close handler cleans up */ }
+  }, HEARTBEAT_MS);
+
+  const maxAge = setTimeout(() => {
+    try { res.end(); } catch { /* already gone */ }
+  }, MAX_AGE_MS);
+
+  const revalidate = setInterval(async () => {
+    try {
+      const user = await User.findById(req.user.id).select('deletionScheduledFor').lean();
+      if (!user || user.deletionScheduledFor) return res.end();
+      if (tokenId) {
+        const token = await ApiToken.findOne({ _id: tokenId, revokedAt: null }).select('_id').lean();
+        if (!token) return res.end();
+      }
+    } catch { /* transient DB error — keep the stream, retry next hour */ }
+  }, REVALIDATE_MS);
+
+  req.on('close', () => {
+    clearInterval(heartbeat);
+    clearInterval(revalidate);
+    clearTimeout(maxAge);
+    eventBus.unregister(req.user.id, res);
+  });
+});
+
+module.exports = router;

--- a/backend/src/routes/events.test.js
+++ b/backend/src/routes/events.test.js
@@ -1,0 +1,130 @@
+/**
+ * GET /api/events/stream (docs/ha-push-events.md §1).
+ *
+ * WHY THIS TEST EXISTS:
+ * The SSE endpoint is the app's first long-lived response. It must (a) demand
+ * auth, (b) speak the exact wire contract the Home Assistant client parses
+ * (headers, retry hint, ready frame), (c) enforce the per-user stream cap with
+ * 429, (d) deliver emitted events, and (e) unregister on disconnect so caps
+ * don't leak.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/ApiToken', () => ({
+  findOne: jest.fn(),
+  hashToken: () => 'x',
+  TOKEN_PREFIX: 'cel_',
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const eventBus = require('../services/eventBus');
+const eventsRouter = require('./events');
+
+let server, port;
+beforeAll((done) => {
+  const app = express();
+  app.use('/api/events', eventsRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { port = server.address().port; done(); });
+});
+afterAll((done) => {
+  server.closeAllConnections();
+  server.close(done);
+});
+
+const token = (id = 'u1') =>
+  jwt.sign({ id, roles: ['user'] }, process.env.JWT_SECRET, { algorithm: 'HS256' });
+
+// Open a raw streaming GET; resolve with status/headers and a handle that can
+// await body chunks and destroy the socket.
+const openStream = (headers = {}) => new Promise((resolve, reject) => {
+  const req = http.get(
+    { host: '127.0.0.1', port, path: '/api/events/stream', headers },
+    (res) => {
+      const chunks = [];
+      const waiters = [];
+      res.on('data', (c) => {
+        chunks.push(c.toString());
+        waiters.splice(0).forEach(w => w());
+      });
+      resolve({
+        status: res.statusCode,
+        headers: res.headers,
+        body: () => chunks.join(''),
+        nextChunk: () => new Promise(resolveWait => {
+          const safety = setTimeout(resolveWait, 4000); // never hang the suite
+          waiters.push(() => { clearTimeout(safety); resolveWait(); });
+        }),
+        destroy: () => req.destroy(),
+      });
+    }
+  );
+  req.on('error', reject);
+});
+
+afterEach(() => {
+  // Any stream a test left open would leak into the next one
+  eventBus.dropUser('u1');
+  eventBus.dropUser('u2');
+});
+
+describe('GET /api/events/stream', () => {
+  test('rejects without auth (401), stream not registered', async () => {
+    const s = await openStream();
+    expect(s.status).toBe(401);
+    expect(eventBus.streamCounts().total).toBe(0);
+  });
+
+  test('opens with the SSE contract: headers, retry hint, ready frame', async () => {
+    const s = await openStream({ Authorization: `Bearer ${token()}` });
+    expect(s.status).toBe(200);
+    expect(s.headers['content-type']).toMatch(/^text\/event-stream/);
+    expect(s.headers['cache-control']).toContain('no-transform');
+    expect(s.headers['x-accel-buffering']).toBe('no');
+
+    if (!s.body().includes('event: ready')) await s.nextChunk();
+    expect(s.body()).toContain('retry: 5000');
+    expect(s.body()).toContain('event: ready\ndata: {}');
+    expect(eventBus.streamCounts().total).toBe(1);
+    s.destroy();
+  });
+
+  test('delivers emitted events to the connected user only', async () => {
+    const s = await openStream({ Authorization: `Bearer ${token('u1')}` });
+    if (!s.body().includes('event: ready')) await s.nextChunk();
+
+    eventBus.emit('u2', 'stats_changed', { reason: 'not-yours' });
+    eventBus.emit('u1', 'stats_changed', { reason: 'bottle.add' });
+    // debounce window (2s) + delivery
+    await s.nextChunk();
+    expect(s.body()).toContain('event: stats_changed\ndata: {"reason":"bottle.add"}');
+    expect(s.body()).not.toContain('not-yours');
+    s.destroy();
+  }, 10000);
+
+  test('over the per-user cap → 429', async () => {
+    // Fill the user's cap with dummy registrations (cheaper than 5 sockets)
+    const dummies = Array.from({ length: eventBus.MAX_STREAMS_PER_USER }, () => ({
+      destroyed: false, writableEnded: false, write() {}, end() { this.writableEnded = true; },
+    }));
+    dummies.forEach(d => eventBus.register('u1', d));
+
+    const s = await openStream({ Authorization: `Bearer ${token('u1')}` });
+    expect(s.status).toBe(429);
+  });
+
+  test('disconnect unregisters the stream (caps do not leak)', async () => {
+    const s = await openStream({ Authorization: `Bearer ${token()}` });
+    if (!s.body().includes('event: ready')) await s.nextChunk();
+    expect(eventBus.streamCounts().total).toBe(1);
+
+    s.destroy();
+    await new Promise(r => setTimeout(r, 100)); // let the close event fire
+    expect(eventBus.streamCounts().total).toBe(0);
+  });
+});

--- a/backend/src/routes/tokens.js
+++ b/backend/src/routes/tokens.js
@@ -5,6 +5,7 @@ const ApiToken = require('../models/ApiToken');
 const User = require('../models/User');
 const { requireAuth } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
+const eventBus = require('../services/eventBus');
 const rateLimitsConfig = require('../config/rateLimits');
 const { rateLimitKey } = require('../utils/clientIp');
 
@@ -117,9 +118,9 @@ router.delete('/:id', requireAuth, async (req, res) => {
 
     logAudit(req, 'token.revoked', { type: 'apiToken', id: token._id }, { name: token.name });
 
-    // §1 SSE interaction: when the event-stream endpoint ships, revoking a
-    // token must also close any open streams it authenticated (eventBus
-    // dropUser-style hook goes here).
+    // Revocation must also close any open SSE event streams this token
+    // authenticated (docs/ha-push-events.md §3).
+    eventBus.dropToken(token._id);
 
     res.json({ message: 'Token revoked' });
   } catch (error) {

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -38,6 +38,7 @@ const { buildUserExport } = require('../services/userDataRegistry');
 const { buildCellarDataExport, EXPORT_README } = require('../services/cellarExport');
 const { safeUploadPath } = require('../services/imageProcessor');
 const { logAudit } = require('../services/audit');
+const eventBus = require('../services/eventBus');
 const { CURRENT_PRIVACY_POLICY_VERSION } = require('../config/legal');
 const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { isValidId, coerceStringQuery } = require('../utils/validation');
@@ -600,6 +601,7 @@ router.delete('/me', requireAuth, async (req, res) => {
     // deletion) — matching change-password / password-reset, which also clear it.
     user.refreshTokenHash = null;
     user.refreshTokenExpiresAt = null;
+    eventBus.dropUser(user._id); // and force-close open SSE event streams
     await user.save();
 
     // Clean up pending cellar invites sent by this user

--- a/backend/src/services/audit.events.test.js
+++ b/backend/src/services/audit.events.test.js
@@ -1,0 +1,46 @@
+/**
+ * Audit → SSE nudge hook (docs/ha-push-events.md §1).
+ *
+ * WHY THIS TEST EXISTS:
+ * logAudit doubles as the stats_changed emitter — every bottle./cellar. action
+ * with a user actor must nudge that user's event streams, and NOTHING else may
+ * (auth events, admin taxonomy work, system jobs). If the prefix filter drifts,
+ * either Home Assistant stops updating (missed prefix) or every login pushes a
+ * pointless refresh (over-broad prefix).
+ */
+
+jest.mock('../models/AuditLog', () => ({ create: jest.fn().mockResolvedValue({}) }));
+jest.mock('./eventBus', () => ({ emit: jest.fn() }));
+
+const eventBus = require('./eventBus');
+const { logAudit } = require('./audit');
+
+beforeEach(() => jest.clearAllMocks());
+
+const reqFor = (userId) => ({ user: { id: userId, roles: ['user'] }, headers: {} });
+
+describe('logAudit → eventBus.emit', () => {
+  test.each([
+    'bottle.add', 'bottle.update', 'bottle.consume', 'bottle.delete',
+    'bottle.move.out', 'bottle.undo', 'bottle.import',
+    'cellar.create', 'cellar.update', 'cellar.delete', 'cellar.import',
+    'cellar.share.add',
+  ])('%s emits stats_changed to the acting user', (action) => {
+    logAudit(reqFor('u1'), action, { type: 'bottle' }, {});
+    expect(eventBus.emit).toHaveBeenCalledWith('u1', 'stats_changed', { reason: action });
+  });
+
+  test.each([
+    'auth.login.success', 'auth.change_password', 'user.profile.update',
+    'wishlist.add', 'token.created', 'admin.wine.update', 'chat.query',
+    'system.rate_limit_exceeded',
+  ])('%s does NOT emit', (action) => {
+    logAudit(reqFor('u1'), action, {}, {});
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  test('system-actor events (req = null) never emit, even for matching actions', () => {
+    logAudit(null, 'cellar.retention_purge', {}, {});
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/audit.js
+++ b/backend/src/services/audit.js
@@ -1,6 +1,15 @@
 const pino = require('pino');
 const AuditLog = require('../models/AuditLog');
 const { getClientIp } = require('../utils/clientIp');
+const eventBus = require('./eventBus');
+
+// SSE nudges (docs/ha-push-events.md §1): audit is the one funnel every
+// significant mutation already flows through on its success path, so it doubles
+// as the stats_changed emitter — a new bottle/cellar route gets push support by
+// following the existing "audit your mutations" rule, with no second hook to
+// forget. Only actions in these categories are user-visible wine-data changes;
+// the emit targets the acting user (each account watches its own stream).
+const STATS_CHANGED_PREFIXES = ['bottle.', 'cellar.'];
 
 // Structured logger — outputs newline-delimited JSON to stdout.
 // In Docker this is captured by the container runtime.
@@ -57,6 +66,13 @@ function logAudit(req, action, resource = {}, detail = {}) {
   AuditLog.create(entry).catch(err =>
     logger.error({ err }, 'Failed to persist audit log entry')
   );
+
+  // SSE push nudge — debounced in the bus, no-op when the user has no open
+  // stream. System-actor events (req = null, e.g. retention jobs) are skipped:
+  // there is no acting user to notify.
+  if (entry.actor.userId && STATS_CHANGED_PREFIXES.some(p => action.startsWith(p))) {
+    eventBus.emit(entry.actor.userId, 'stats_changed', { reason: action });
+  }
 }
 
 module.exports = { logAudit, logger };

--- a/backend/src/services/eventBus.js
+++ b/backend/src/services/eventBus.js
@@ -1,0 +1,155 @@
+/**
+ * In-memory SSE event bus (docs/ha-push-events.md §1).
+ *
+ * Holds the open /api/events/stream responses per user and fans out
+ * "something changed" nudges. Events carry NO cellar data — clients react to
+ * any event by refreshing via the normal REST API — so the bus can stay dumb:
+ * per-user debounce, last event wins.
+ *
+ * Single-process by design (the backend runs as one Node process). If the
+ * deployment ever goes multi-instance this becomes a thin facade over Redis
+ * pub/sub; the route and emitters stay the same.
+ *
+ * Hardening beyond the spec sketch:
+ * - writes are guarded (a half-dead socket must never throw into an emitter)
+ * - debounce timers are cleaned up when they fire or when the user drops
+ * - a GLOBAL stream cap protects the whole process, not just one user
+ * - dropToken() closes only the streams a revoked API token authenticated
+ */
+
+const MAX_STREAMS_PER_USER = 5;
+const MAX_STREAMS_GLOBAL = 500;
+const DEBOUNCE_MS = 2000;
+
+// userId -> Set<{ res, tokenId }>
+const streams = new Map();
+// userId -> pending debounce timer
+const timers = new Map();
+let totalStreams = 0;
+
+function safeWrite(res, frame) {
+  if (res.destroyed || res.writableEnded) return;
+  try { res.write(frame); } catch { /* socket died mid-write — close handler cleans up */ }
+}
+
+function safeEnd(res) {
+  if (res.destroyed || res.writableEnded) return;
+  try { res.end(); } catch { /* already gone */ }
+}
+
+/**
+ * Queue an event for all of a user's open streams, debounced per user so a
+ * 50-bottle import produces one nudge, not 50. Within the window the LAST
+ * event wins — clients refresh everything on any event, so coalescing loses
+ * nothing.
+ */
+function emit(userId, event, data = {}) {
+  const key = String(userId);
+  const set = streams.get(key);
+  if (!set || set.size === 0) return;
+
+  clearTimeout(timers.get(key));
+  const timer = setTimeout(() => {
+    timers.delete(key);
+    const current = streams.get(key);
+    if (!current) return;
+    const frame = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    for (const entry of current) safeWrite(entry.res, frame);
+  }, DEBOUNCE_MS);
+  // Never hold the process open just for a pending nudge (also keeps Jest quiet)
+  timer.unref?.();
+  timers.set(key, timer);
+}
+
+/**
+ * Register an open SSE response. tokenId is set when the stream was
+ * authenticated by a personal API token, so dropToken() can find it.
+ * Returns { ok: true } or { ok: false, reason: 'user_cap' | 'global_cap' }.
+ */
+function register(userId, res, tokenId = null) {
+  if (totalStreams >= MAX_STREAMS_GLOBAL) return { ok: false, reason: 'global_cap' };
+  const key = String(userId);
+  let set = streams.get(key);
+  if (!set) {
+    set = new Set();
+    streams.set(key, set);
+  }
+  if (set.size >= MAX_STREAMS_PER_USER) return { ok: false, reason: 'user_cap' };
+  set.add({ res, tokenId: tokenId ? String(tokenId) : null });
+  totalStreams++;
+  return { ok: true };
+}
+
+/** Remove a response (client disconnected or stream aged out). */
+function unregister(userId, res) {
+  const key = String(userId);
+  const set = streams.get(key);
+  if (!set) return;
+  for (const entry of set) {
+    if (entry.res === res) {
+      set.delete(entry);
+      totalStreams--;
+      break;
+    }
+  }
+  if (set.size === 0) {
+    streams.delete(key);
+    clearTimeout(timers.get(key));
+    timers.delete(key);
+  }
+}
+
+/**
+ * Force-close ALL of a user's streams. Call wherever refresh sessions are
+ * invalidated: password change, password reset, logout, account deletion.
+ * (ended sockets fire 'close', whose handler unregisters them — but do the
+ * bookkeeping here too so caps free up immediately, not a tick later.)
+ */
+function dropUser(userId) {
+  const key = String(userId);
+  const set = streams.get(key);
+  if (!set) return;
+  for (const entry of set) {
+    safeEnd(entry.res);
+    totalStreams--;
+  }
+  streams.delete(key);
+  clearTimeout(timers.get(key));
+  timers.delete(key);
+}
+
+/** Force-close the streams a specific (revoked) API token authenticated. */
+function dropToken(tokenId) {
+  const id = String(tokenId);
+  for (const [key, set] of streams) {
+    for (const entry of set) {
+      if (entry.tokenId === id) {
+        safeEnd(entry.res);
+        set.delete(entry);
+        totalStreams--;
+      }
+    }
+    if (set.size === 0) {
+      streams.delete(key);
+      clearTimeout(timers.get(key));
+      timers.delete(key);
+    }
+  }
+}
+
+/** Counts for logging/tests. */
+function streamCounts() {
+  return { total: totalStreams, users: streams.size };
+}
+
+module.exports = {
+  emit,
+  register,
+  unregister,
+  dropUser,
+  dropToken,
+  streamCounts,
+  MAX_STREAMS_PER_USER,
+  MAX_STREAMS_GLOBAL,
+  DEBOUNCE_MS,
+};

--- a/backend/src/services/eventBus.test.js
+++ b/backend/src/services/eventBus.test.js
@@ -1,0 +1,160 @@
+/**
+ * SSE event bus (docs/ha-push-events.md §1).
+ *
+ * WHY THIS TEST EXISTS:
+ * The bus holds live sockets in module state, so its failure modes are
+ * process-wide: an uncaught throw from a half-dead socket would surface inside
+ * whatever mutation handler emitted the event; a leaked timer or missed
+ * unregister slowly exhausts the caps. These tests pin the debounce/coalesce
+ * contract, both caps, cleanup, the write-safety guards, and the two
+ * force-close paths (dropUser for credential events, dropToken for revoked
+ * API tokens).
+ */
+
+const mockRes = () => ({
+  written: [],
+  destroyed: false,
+  writableEnded: false,
+  write(frame) { this.written.push(frame); },
+  end() { this.writableEnded = true; },
+});
+
+let eventBus;
+beforeEach(() => {
+  jest.resetModules(); // fresh module state per test — the bus is a singleton
+  jest.useFakeTimers();
+  eventBus = require('./eventBus');
+});
+afterEach(() => jest.useRealTimers());
+
+describe('emit (debounce + coalesce)', () => {
+  test('a burst of emits within the window produces ONE frame — the last event', () => {
+    const res = mockRes();
+    eventBus.register('u1', res);
+
+    for (let i = 0; i < 50; i++) eventBus.emit('u1', 'stats_changed', { reason: 'bottle.import' });
+    eventBus.emit('u1', 'stats_changed', { reason: 'cellar.import' });
+    expect(res.written).toHaveLength(0); // nothing before the window closes
+
+    jest.advanceTimersByTime(eventBus.DEBOUNCE_MS);
+    expect(res.written).toHaveLength(1);
+    expect(res.written[0]).toBe('event: stats_changed\ndata: {"reason":"cellar.import"}\n\n');
+  });
+
+  test('emits after the window produce a new frame', () => {
+    const res = mockRes();
+    eventBus.register('u1', res);
+    eventBus.emit('u1', 'stats_changed', {});
+    jest.advanceTimersByTime(eventBus.DEBOUNCE_MS);
+    eventBus.emit('u1', 'notification', { id: 'n1' });
+    jest.advanceTimersByTime(eventBus.DEBOUNCE_MS);
+    expect(res.written).toHaveLength(2);
+  });
+
+  test('emit is a no-op for users without streams (no timer leak)', () => {
+    eventBus.emit('nobody', 'stats_changed', {});
+    jest.advanceTimersByTime(eventBus.DEBOUNCE_MS * 2);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('all of a user\'s streams get the frame; other users get nothing', () => {
+    const a1 = mockRes(); const a2 = mockRes(); const b = mockRes();
+    eventBus.register('a', a1);
+    eventBus.register('a', a2);
+    eventBus.register('b', b);
+    eventBus.emit('a', 'stats_changed', {});
+    jest.advanceTimersByTime(eventBus.DEBOUNCE_MS);
+    expect(a1.written).toHaveLength(1);
+    expect(a2.written).toHaveLength(1);
+    expect(b.written).toHaveLength(0);
+  });
+
+  test('a dead socket never throws into the emitter', () => {
+    const ok = mockRes();
+    const ended = mockRes();
+    ended.writableEnded = true;
+    const throwing = mockRes();
+    throwing.write = () => { throw new Error('EPIPE'); };
+    eventBus.register('u1', ok);
+    eventBus.register('u1', ended);
+    eventBus.register('u1', throwing);
+
+    eventBus.emit('u1', 'stats_changed', {});
+    expect(() => jest.advanceTimersByTime(eventBus.DEBOUNCE_MS)).not.toThrow();
+    expect(ok.written).toHaveLength(1);
+    expect(ended.written).toHaveLength(0);
+  });
+});
+
+describe('caps', () => {
+  test('per-user cap rejects the 6th stream', () => {
+    for (let i = 0; i < eventBus.MAX_STREAMS_PER_USER; i++) {
+      expect(eventBus.register('u1', mockRes()).ok).toBe(true);
+    }
+    expect(eventBus.register('u1', mockRes())).toEqual({ ok: false, reason: 'user_cap' });
+    // another user is unaffected
+    expect(eventBus.register('u2', mockRes()).ok).toBe(true);
+  });
+
+  test('global cap rejects new streams across all users', () => {
+    const perUser = eventBus.MAX_STREAMS_PER_USER;
+    const users = Math.ceil(eventBus.MAX_STREAMS_GLOBAL / perUser);
+    let registered = 0;
+    for (let u = 0; u < users && registered < eventBus.MAX_STREAMS_GLOBAL; u++) {
+      for (let i = 0; i < perUser && registered < eventBus.MAX_STREAMS_GLOBAL; i++) {
+        expect(eventBus.register(`user${u}`, mockRes()).ok).toBe(true);
+        registered++;
+      }
+    }
+    expect(eventBus.register('one-more', mockRes())).toEqual({ ok: false, reason: 'global_cap' });
+    expect(eventBus.streamCounts().total).toBe(eventBus.MAX_STREAMS_GLOBAL);
+  });
+
+  test('unregister frees capacity and cleans up per-user state', () => {
+    const rs = Array.from({ length: eventBus.MAX_STREAMS_PER_USER }, () => mockRes());
+    rs.forEach(r => eventBus.register('u1', r));
+    eventBus.unregister('u1', rs[0]);
+    expect(eventBus.register('u1', mockRes()).ok).toBe(true);
+
+    // dropping the last stream clears the user entry AND any pending timer
+    const solo = mockRes();
+    eventBus.register('u9', solo);
+    eventBus.emit('u9', 'stats_changed', {});
+    eventBus.unregister('u9', solo);
+    expect(eventBus.streamCounts().users).toBe(1); // only u1 left
+    jest.advanceTimersByTime(eventBus.DEBOUNCE_MS);
+    expect(solo.written).toHaveLength(0);
+  });
+});
+
+describe('force-close', () => {
+  test('dropUser ends every stream and later emits are no-ops', () => {
+    const r1 = mockRes(); const r2 = mockRes();
+    eventBus.register('u1', r1);
+    eventBus.register('u1', r2, 'tok1');
+    eventBus.emit('u1', 'stats_changed', {}); // pending — must be cancelled too
+
+    eventBus.dropUser('u1');
+    expect(r1.writableEnded).toBe(true);
+    expect(r2.writableEnded).toBe(true);
+    expect(eventBus.streamCounts()).toEqual({ total: 0, users: 0 });
+
+    jest.advanceTimersByTime(eventBus.DEBOUNCE_MS);
+    expect(r1.written).toHaveLength(0);
+  });
+
+  test('dropToken ends only the revoked token\'s streams', () => {
+    const jwtStream = mockRes();
+    const tokStream = mockRes();
+    const otherTok = mockRes();
+    eventBus.register('u1', jwtStream);            // JWT-authenticated
+    eventBus.register('u1', tokStream, 'tok1');    // the revoked token
+    eventBus.register('u2', otherTok, 'tok2');     // a different token
+
+    eventBus.dropToken('tok1');
+    expect(tokStream.writableEnded).toBe(true);
+    expect(jwtStream.writableEnded).toBe(false);
+    expect(otherTok.writableEnded).toBe(false);
+    expect(eventBus.streamCounts().total).toBe(2);
+  });
+});

--- a/backend/src/services/notifications.js
+++ b/backend/src/services/notifications.js
@@ -2,6 +2,7 @@ const Notification = require('../models/Notification');
 const PushSubscription = require('../models/PushSubscription');
 const User = require('../models/User');
 const { runConcurrent } = require('../utils/concurrency');
+const eventBus = require('./eventBus');
 
 // Max simultaneous web-push HTTPS calls per batch — a popular thread can have
 // hundreds of watchers; an uncapped burst stampedes the event loop and the
@@ -85,10 +86,16 @@ async function createNotifications(items) {
   if (!items || items.length === 0) return;
 
   try {
-    await Notification.insertMany(
+    const created = await Notification.insertMany(
       items.map(i => ({ user: i.userId, type: i.type, title: i.title, message: i.message, link: i.link || null })),
       { ordered: false }
     );
+    // SSE push nudge (docs/ha-push-events.md §1) — debounced per user in the
+    // bus, no-op for users without an open stream. Payload is informational
+    // only; clients refresh via REST on any event.
+    for (const doc of created) {
+      eventBus.emit(doc.user, 'notification', { id: doc._id.toString(), type: doc.type });
+    }
   } catch (err) {
     console.error('[notifications] Failed to create notifications:', err.message);
   }


### PR DESCRIPTION
## What

`GET /api/events/stream` — Server-Sent Events push channel per §1 of `docs/ha-push-events.md`, so the Home Assistant integration can drop from 30-min polling (a ~250 ms bcrypt re-login per poll) to a 6-h safety net with instant updates.

**Stacked on #652** (`feat/api-tokens`) so the stream accepts `read`-scoped API tokens and token revocation drops that token''s open streams. Merge #652 first, then retarget/merge this.

## Wire contract (verified against the spec + our infra)

- `retry: 5000` + `event: ready` on connect; `: hb` comment heartbeat every 25 s (nginx `proxy_read_timeout` is 120 s)
- `Cache-Control: no-cache, no-transform` keeps the global `compression()` middleware from buffering; `X-Accel-Buffering: no` disables nginx buffering per-route — **no nginx.conf change**
- 24 h max stream age (client reconnects); per-user cap 5 + **global cap 500** (429 over cap)
- Events are content-free nudges (`stats_changed` / `notification`) — the client refreshes via REST; no cellar data crosses this channel

## Emitters

`logAudit` doubles as the `stats_changed` emitter for `bottle.*` / `cellar.*` actions with a user actor — every significant mutation already flows through audit on its success path, so **new routes get push support by following the existing "audit your mutations" rule** instead of a second hook that can be forgotten. Added the missing `cellar.create` / `cellar.update` audit calls (an audit-coverage gap in their own right). `notification` events emit from `createNotifications`, covering the drink-window notifier and community fan-outs. Per-user 2 s debounce: a 50-bottle import emits one nudge.

## Safety (per the pre-build assessment)

- **Force-close hooks** at every refresh-session invalidation site: change-password, password-reset, logout, account-deletion request → `dropUser`; API-token revocation → `dropToken` (only that token''s streams)
- **Hourly per-stream revalidation** (indexed reads, no bcrypt): deleted user / pending deletion / revoked token ends the stream even if a hook were ever missed
- JWT expiry deliberately does NOT kill the stream (would force a bcrypt login per household per 15 min — worse than the polling this replaces); the caps + hooks + revalidation bound the exposure, and the channel carries no data
- Guarded writes — a half-dead socket can never throw into a mutation handler; debounce timers cleaned on fire/unregister/drop
- In-memory bus is single-process by design (matches deployment); Redis pub/sub swap-in point documented in `eventBus.js`

## Docker smoke test (full stack, through nginx)

- `event: ready` arrived **immediately** → compression/nginx buffering defeated ✔
- `POST /api/cellars` → `event: stats_changed data: {"reason":"cellar.create"}` within ~2 s ✔
- Stream opens with a `read`-scoped `cel_` token ✔; revoked token → 401 on next request ✔

## Docker-compose / prod impact

None. No new services, ports, env vars, or nginx changes. One idle socket per connected household (~10–30 KB RAM). Prod note: Traefik fronts nginx — defaults don''t buffer/time out active streams, but confirm no custom `respondingTimeouts` before relying on 24 h connections.

## Tests

36 new (eventBus debounce/coalesce/caps/cleanup/dead-socket/drop hooks; route wire-contract over real HTTP incl. 429 + disconnect cleanup; audit-hook prefix filter). Backend suite **1253/1253** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)