### PR TITLE
fix: HA integration audit remediation (2 Med + 4 Low)

### DIFF
--- a/backend/src/middleware/apiTokenAuth.js
+++ b/backend/src/middleware/apiTokenAuth.js
@@ -41,6 +41,24 @@ const SCOPE_ALLOWLIST = {
   ],
 };
 
+/**
+ * Endpoints under the allowed prefixes that tokens must NOT reach, checked
+ * before the scope rules. The read prefixes cover the wine-data GETs the HA
+ * integration uses, but three sub-paths under them carry a different class of
+ * data than "the caller's wine data":
+ *   - /api/cellars/:id/audit    — audit log incl. collaborator IPs and emails
+ *   - /api/cellars/:id/members  — collaborator emails
+ *   - /api/bottles/import/*     — the import subsystem (a separate router
+ *                                 mounted under the /api/bottles prefix)
+ * When adding a new sub-route under /api/cellars or /api/bottles, ask whether
+ * it returns anything beyond the caller's own wine data — if so, add it here.
+ */
+const TOKEN_EXCLUSIONS = [
+  /^\/api\/cellars\/[^/]+\/audit(\/|$)/,
+  /^\/api\/cellars\/[^/]+\/members(\/|$)/,
+  /^\/api\/bottles\/import(\/|$)/,
+];
+
 /** True when the bearer credential is a personal API token, not a JWT. */
 function isApiTokenCredential(credential) {
   return typeof credential === 'string' && credential.startsWith(TOKEN_PREFIX);
@@ -51,6 +69,7 @@ function isRequestAllowed(scopes, method, path) {
   // Normalize: Express treats HEAD as GET, and a trailing slash as the same route.
   const m = method === 'HEAD' ? 'GET' : method;
   const p = path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+  if (TOKEN_EXCLUSIONS.some(rule => rule.test(p))) return false;
   for (const scope of scopes || []) {
     for (const rule of SCOPE_ALLOWLIST[scope] || []) {
       if (rule.method === m && rule.pattern.test(p)) return true;
@@ -114,5 +133,6 @@ module.exports = {
   authenticateApiToken,
   isRequestAllowed,
   SCOPE_ALLOWLIST,
+  TOKEN_EXCLUSIONS,
   LAST_USED_THROTTLE_MS,
 };

--- a/backend/src/middleware/apiTokenAuth.test.js
+++ b/backend/src/middleware/apiTokenAuth.test.js
@@ -102,6 +102,20 @@ describe('isRequestAllowed (default-deny)', () => {
     expect(isRequestAllowed(CONSUME, 'DELETE', `/api/bottles/${oid}`)).toBe(false);
   });
 
+  test.each([
+    // PII-bearing / non-wine-data endpoints under the allowed prefixes must be
+    // excluded even for a read token (audit log carries collaborator IPs and
+    // emails; members carries emails; import is a separate subsystem).
+    ['GET', `/api/cellars/${oid}/audit`],
+    ['GET', `/api/cellars/${oid}/audit/`],
+    ['GET', `/api/cellars/${oid}/members`],
+    ['GET', '/api/bottles/import/sessions'],
+    ['GET', `/api/bottles/import/sessions/${oid}`],
+  ])('read scope denies excluded sub-path %s %s', (method, path) => {
+    expect(isRequestAllowed(READ, method, path)).toBe(false);
+    expect(isRequestAllowed(BOTH, method, path)).toBe(false);
+  });
+
   test('scopes combine, unknown scopes grant nothing', () => {
     expect(isRequestAllowed(BOTH, 'GET', '/api/stats/overview')).toBe(true);
     expect(isRequestAllowed(BOTH, 'POST', `/api/bottles/${oid}/consume`)).toBe(true);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -500,6 +500,7 @@ router.post('/refresh', refreshLimiter, async (req, res) => {
     if (user.refreshTokenExpiresAt && Date.now() > user.refreshTokenExpiresAt.getTime()) {
       user.refreshTokenHash = null;
       user.refreshTokenExpiresAt = null;
+      eventBus.dropUser(user._id); // session hard-cap is a credential event — close open SSE streams too
       await user.save();
       clearRefreshCookie(res);
       return res.status(401).json({ error: 'Session expired, please log in again' });

--- a/backend/src/routes/events.js
+++ b/backend/src/routes/events.js
@@ -65,12 +65,22 @@ router.get('/stream', requireAuth, (req, res) => {
     } catch { /* transient DB error — keep the stream, retry next hour */ }
   }, REVALIDATE_MS);
 
-  req.on('close', () => {
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
     clearInterval(heartbeat);
     clearInterval(revalidate);
     clearTimeout(maxAge);
     eventBus.unregister(req.user.id, res);
-  });
+  };
+  req.on('close', cleanup);
+  // If the socket died while requireAuth awaited its DB lookups (the API-token
+  // path awaits twice), 'close' fired BEFORE the listener above was attached
+  // and will never re-fire — reap immediately or the registration + timers
+  // leak until restart, and five such aborts fill the user's stream cap with
+  // zombies (permanent 429 for the household).
+  if (req.destroyed || res.destroyed || res.writableEnded) cleanup();
 });
 
 module.exports = router;

--- a/backend/src/routes/events.test.js
+++ b/backend/src/routes/events.test.js
@@ -118,6 +118,31 @@ describe('GET /api/events/stream', () => {
     expect(s.status).toBe(429);
   });
 
+  test('a socket that died DURING auth is reaped immediately (close already fired)', async () => {
+    // Simulate the API-token auth path: requireAuth awaits DB lookups, the
+    // client aborts meanwhile, so req 'close' fires before the handler attaches
+    // its listener. Invoke the handler directly with an already-destroyed pair —
+    // the registration must not survive, or five flaky connects would fill the
+    // user's cap with zombies (permanent 429).
+    const handler = eventsRouter.stack
+      .find(l => l.route?.path === '/stream').route.stack.at(-1).handle;
+
+    const req = {
+      user: { id: 'u1' },
+      destroyed: true,           // socket already gone
+      on: () => {},              // 'close' will never fire again
+    };
+    const res = {
+      destroyed: true,
+      writableEnded: false,
+      set() {}, flushHeaders() {}, write() {}, end() { this.writableEnded = true; },
+      status() { return this; }, json() { return this; },
+    };
+
+    handler(req, res);
+    expect(eventBus.streamCounts().total).toBe(0);
+  });
+
   test('disconnect unregisters the stream (caps do not leak)', async () => {
     const s = await openStream({ Authorization: `Bearer ${token()}` });
     if (!s.body().includes('event: ready')) await s.nextChunk();

--- a/backend/src/routes/tokens.js
+++ b/backend/src/routes/tokens.js
@@ -54,7 +54,12 @@ router.post('/', requireAuth, authLimiter, async (req, res) => {
     const isMatch = await user.comparePassword(password);
     if (!isMatch) {
       logAudit(req, 'token.create_failed', { type: 'user', id: user._id }, { reason: 'incorrect_password' });
-      return res.status(401).json({ error: 'Password is incorrect' });
+      // 403, NOT 401: the session is fine, the password confirmation failed.
+      // The frontend's apiFetch treats any 401 as "access token expired" and
+      // silently refreshes + re-submits — which would double every bcrypt
+      // compare and, if the refresh raced another tab, log the user out for
+      // a typo.
+      return res.status(403).json({ error: 'Password is incorrect' });
     }
 
     const activeCount = await ApiToken.countDocuments({ user: req.user.id, revokedAt: null });

--- a/backend/src/routes/tokens.test.js
+++ b/backend/src/routes/tokens.test.js
@@ -84,10 +84,10 @@ describe('POST /api/tokens', () => {
     expect(res.status).toBe(400);
   });
 
-  test('wrong password → 401 and an audit entry, no token created', async () => {
+  test('wrong password → 403 (NOT 401 — apiFetch auto-refreshes and re-submits on 401) and an audit entry, no token created', async () => {
     User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(false) });
     const res = await request('POST', '/api/tokens', validBody);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(403);
     expect(ApiToken.create).not.toHaveBeenCalled();
     expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'token.create_failed', expect.anything(), { reason: 'incorrect_password' });
   });

--- a/backend/src/services/audit.events.test.js
+++ b/backend/src/services/audit.events.test.js
@@ -10,9 +10,11 @@
  */
 
 jest.mock('../models/AuditLog', () => ({ create: jest.fn().mockResolvedValue({}) }));
-jest.mock('./eventBus', () => ({ emit: jest.fn() }));
+jest.mock('./eventBus', () => ({ emit: jest.fn(), streamCounts: jest.fn(() => ({ total: 0, users: 0 })) }));
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
 
 const eventBus = require('./eventBus');
+const Cellar = require('../models/Cellar');
 const { logAudit } = require('./audit');
 
 beforeEach(() => jest.clearAllMocks());
@@ -42,5 +44,33 @@ describe('logAudit → eventBus.emit', () => {
   test('system-actor events (req = null) never emit, even for matching actions', () => {
     logAudit(null, 'cellar.retention_purge', {}, {});
     expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+});
+
+describe('shared-cellar owner nudge', () => {
+  test('a member mutation also nudges the cellar OWNER (req.cellar fast path)', () => {
+    const req = { ...reqFor('member1'), cellar: { user: 'owner1' } };
+    logAudit(req, 'bottle.consume', { type: 'bottle', cellarId: 'c1' }, {});
+    expect(eventBus.emit).toHaveBeenCalledWith('member1', 'stats_changed', { reason: 'bottle.consume' });
+    expect(eventBus.emit).toHaveBeenCalledWith('owner1', 'stats_changed', { reason: 'bottle.consume' });
+  });
+
+  test('the owner acting in their own cellar is nudged exactly once', () => {
+    const req = { ...reqFor('owner1'), cellar: { user: 'owner1' } };
+    logAudit(req, 'bottle.add', { type: 'bottle', cellarId: 'c1' }, {});
+    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+  });
+
+  test('without req.cellar the owner is resolved from cellarId — but only when streams exist', async () => {
+    // No streams anywhere → no lookup at all
+    logAudit(reqFor('member1'), 'cellar.restore', { type: 'cellar', cellarId: 'c1' }, {});
+    expect(Cellar.findById).not.toHaveBeenCalled();
+
+    // Streams exist → owner resolved and nudged
+    eventBus.streamCounts.mockReturnValue({ total: 1, users: 1 });
+    Cellar.findById.mockReturnValue({ select: () => ({ lean: () => Promise.resolve({ user: 'owner1' }) }) });
+    logAudit(reqFor('admin1'), 'cellar.restore', { type: 'cellar', cellarId: 'c1' }, {});
+    await new Promise(r => setImmediate(r)); // let the fire-and-forget lookup settle
+    expect(eventBus.emit).toHaveBeenCalledWith('owner1', 'stats_changed', { reason: 'cellar.restore' });
   });
 });

--- a/backend/src/services/audit.events.test.js
+++ b/backend/src/services/audit.events.test.js
@@ -62,15 +62,23 @@ describe('shared-cellar owner nudge', () => {
   });
 
   test('without req.cellar the owner is resolved from cellarId — but only when streams exist', async () => {
+    const cellarId = 'a'.repeat(24);
     // No streams anywhere → no lookup at all
-    logAudit(reqFor('member1'), 'cellar.restore', { type: 'cellar', cellarId: 'c1' }, {});
+    logAudit(reqFor('member1'), 'cellar.restore', { type: 'cellar', cellarId }, {});
     expect(Cellar.findById).not.toHaveBeenCalled();
 
     // Streams exist → owner resolved and nudged
     eventBus.streamCounts.mockReturnValue({ total: 1, users: 1 });
     Cellar.findById.mockReturnValue({ select: () => ({ lean: () => Promise.resolve({ user: 'owner1' }) }) });
-    logAudit(reqFor('admin1'), 'cellar.restore', { type: 'cellar', cellarId: 'c1' }, {});
+    logAudit(reqFor('admin1'), 'cellar.restore', { type: 'cellar', cellarId }, {});
     await new Promise(r => setImmediate(r)); // let the fire-and-forget lookup settle
     expect(eventBus.emit).toHaveBeenCalledWith('owner1', 'stats_changed', { reason: 'cellar.restore' });
+  });
+
+  test('a cellarId that is not a plain 24-hex id never reaches the query', () => {
+    eventBus.streamCounts.mockReturnValue({ total: 1, users: 1 });
+    logAudit(reqFor('u1'), 'cellar.restore', { type: 'cellar', cellarId: { $ne: null } }, {});
+    logAudit(reqFor('u1'), 'cellar.restore', { type: 'cellar', cellarId: 'not-an-objectid' }, {});
+    expect(Cellar.findById).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/audit.js
+++ b/backend/src/services/audit.js
@@ -72,6 +72,28 @@ function logAudit(req, action, resource = {}, detail = {}) {
   // there is no acting user to notify.
   if (entry.actor.userId && STATS_CHANGED_PREFIXES.some(p => action.startsWith(p))) {
     eventBus.emit(entry.actor.userId, 'stats_changed', { reason: action });
+
+    // Shared cellars: /api/stats aggregates the OWNER's bottles, so when a
+    // member (or an admin) mutates a bottle, it is the owner's stats that
+    // changed — nudge them too. Prefer the cellar requireBottleAccess already
+    // loaded onto the request; otherwise resolve the owner from the audited
+    // cellarId, but only when anyone is connected at all (skips the extra read
+    // on instances with no push clients).
+    const ownerFromReq = req?.cellar?.user;
+    if (ownerFromReq) {
+      if (String(ownerFromReq) !== String(entry.actor.userId)) {
+        eventBus.emit(ownerFromReq, 'stats_changed', { reason: action });
+      }
+    } else if (resource.cellarId && eventBus.streamCounts().total > 0) {
+      const Cellar = require('../models/Cellar');
+      Cellar.findById(resource.cellarId).select('user').lean()
+        .then(cellar => {
+          if (cellar && String(cellar.user) !== String(entry.actor.userId)) {
+            eventBus.emit(cellar.user, 'stats_changed', { reason: action });
+          }
+        })
+        .catch(() => {});
+    }
   }
 }
 

--- a/backend/src/services/audit.js
+++ b/backend/src/services/audit.js
@@ -85,14 +85,20 @@ function logAudit(req, action, resource = {}, detail = {}) {
         eventBus.emit(ownerFromReq, 'stats_changed', { reason: action });
       }
     } else if (resource.cellarId && eventBus.streamCounts().total > 0) {
-      const Cellar = require('../models/Cellar');
-      Cellar.findById(resource.cellarId).select('user').lean()
-        .then(cellar => {
-          if (cellar && String(cellar.user) !== String(entry.actor.userId)) {
-            eventBus.emit(cellar.user, 'stats_changed', { reason: action });
-          }
-        })
-        .catch(() => {});
+      // Cast-guard before querying: every caller passes a document ObjectId
+      // today, but logAudit is a generic funnel — accept only a plain 24-hex
+      // id so no query-operator object can ever reach the lookup.
+      const cellarId = String(resource.cellarId);
+      if (/^[a-f0-9]{24}$/i.test(cellarId)) {
+        const Cellar = require('../models/Cellar');
+        Cellar.findById(cellarId).select('user').lean()
+          .then(cellar => {
+            if (cellar && String(cellar.user) !== String(entry.actor.userId)) {
+              eventBus.emit(cellar.user, 'stats_changed', { reason: action });
+            }
+          })
+          .catch(() => {});
+      }
     }
   }
 }

--- a/backend/src/services/eventBus.js
+++ b/backend/src/services/eventBus.js
@@ -66,8 +66,18 @@ function emit(userId, event, data = {}) {
  * authenticated by a personal API token, so dropToken() can find it.
  * Returns { ok: true } or { ok: false, reason: 'user_cap' | 'global_cap' }.
  */
+let lastGlobalCapWarn = 0;
+
 function register(userId, res, tokenId = null) {
-  if (totalStreams >= MAX_STREAMS_GLOBAL) return { ok: false, reason: 'global_cap' };
+  if (totalStreams >= MAX_STREAMS_GLOBAL) {
+    // The cap silently degrades every OTHER user to polling — make sure the
+    // operator can see it happening (throttled so reconnect storms don't spam).
+    if (Date.now() - lastGlobalCapWarn > 60_000) {
+      lastGlobalCapWarn = Date.now();
+      console.warn(`[eventBus] global stream cap (${MAX_STREAMS_GLOBAL}) reached — new SSE connections are being rejected`);
+    }
+    return { ok: false, reason: 'global_cap' };
+  }
   const key = String(userId);
   let set = streams.get(key);
   if (!set) {

--- a/backend/src/services/notifications.js
+++ b/backend/src/services/notifications.js
@@ -85,19 +85,23 @@ async function sendToSubscription(sub, payload) {
 async function createNotifications(items) {
   if (!items || items.length === 0) return;
 
+  let created = [];
   try {
-    const created = await Notification.insertMany(
+    created = await Notification.insertMany(
       items.map(i => ({ user: i.userId, type: i.type, title: i.title, message: i.message, link: i.link || null })),
       { ordered: false }
     );
-    // SSE push nudge (docs/ha-push-events.md §1) — debounced per user in the
-    // bus, no-op for users without an open stream. Payload is informational
-    // only; clients refresh via REST on any event.
-    for (const doc of created) {
-      eventBus.emit(doc.user, 'notification', { id: doc._id.toString(), type: doc.type });
-    }
   } catch (err) {
+    // ordered:false rejects AFTER inserting the valid rows — those users must
+    // still get their SSE nudge (the bulk-write error carries the inserted docs).
+    created = err?.insertedDocs || [];
     console.error('[notifications] Failed to create notifications:', err.message);
+  }
+  // SSE push nudge (docs/ha-push-events.md §1) — debounced per user in the
+  // bus, no-op for users without an open stream. Payload is informational
+  // only; clients refresh via REST on any event.
+  for (const doc of created) {
+    eventBus.emit(doc.user, 'notification', { id: doc._id.toString(), type: doc.type });
   }
 
   // Web push — fire and forget

--- a/backend/src/services/notifications.sse.test.js
+++ b/backend/src/services/notifications.sse.test.js
@@ -1,0 +1,62 @@
+/**
+ * createNotifications → SSE nudge (docs/ha-push-events.md §1).
+ *
+ * WHY THIS TEST EXISTS:
+ * insertMany runs with { ordered: false }, which REJECTS after inserting the
+ * valid rows when one row is bad. The SSE nudge must be emitted for every row
+ * that actually landed (via the bulk-write error's insertedDocs) — otherwise
+ * one malformed notification silently degrades every other recipient's push
+ * to the 6-hour polling fallback.
+ */
+
+jest.mock('../models/Notification', () => ({ insertMany: jest.fn() }));
+jest.mock('../models/PushSubscription', () => ({ find: jest.fn() }));
+jest.mock('../models/User', () => ({ find: jest.fn() }));
+jest.mock('./eventBus', () => ({ emit: jest.fn() }));
+
+const Notification = require('../models/Notification');
+const eventBus = require('./eventBus');
+const { createNotifications } = require('./notifications');
+
+beforeEach(() => jest.clearAllMocks());
+
+const doc = (id, user, type) => ({ _id: { toString: () => id }, user, type });
+
+describe('createNotifications SSE nudges', () => {
+  test('every inserted notification emits one nudge to its recipient', async () => {
+    Notification.insertMany.mockResolvedValue([
+      doc('n1', 'u1', 'drink_window'),
+      doc('n2', 'u2', 'community_reply'),
+    ]);
+
+    await createNotifications([
+      { userId: 'u1', type: 'drink_window', title: 't', message: 'm' },
+      { userId: 'u2', type: 'community_reply', title: 't', message: 'm' },
+    ]);
+
+    expect(eventBus.emit).toHaveBeenCalledWith('u1', 'notification', { id: 'n1', type: 'drink_window' });
+    expect(eventBus.emit).toHaveBeenCalledWith('u2', 'notification', { id: 'n2', type: 'community_reply' });
+  });
+
+  test('partial insertMany failure still nudges the rows that DID insert', async () => {
+    const err = new Error('E11000 partial failure');
+    err.insertedDocs = [doc('n1', 'u1', 'drink_window')];
+    Notification.insertMany.mockRejectedValue(err);
+
+    await createNotifications([
+      { userId: 'u1', type: 'drink_window', title: 't', message: 'm' },
+      { userId: 'u2', type: 'bad-row', title: 't', message: 'm' },
+    ]);
+
+    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+    expect(eventBus.emit).toHaveBeenCalledWith('u1', 'notification', { id: 'n1', type: 'drink_window' });
+  });
+
+  test('total failure (no insertedDocs on the error) emits nothing and does not throw', async () => {
+    Notification.insertMany.mockRejectedValue(new Error('connection lost'));
+    await expect(createNotifications([
+      { userId: 'u1', type: 'drink_window', title: 't', message: 'm' },
+    ])).resolves.toBeUndefined();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/tokens.js
+++ b/frontend/src/api/tokens.js
@@ -8,7 +8,8 @@ export const listApiTokens = (apiFetch) => apiFetch('/api/tokens');
 
 // POST /api/tokens — body: { name, scopes, password }. Returns { token, ... }
 // where `token` is the plaintext shown exactly ONCE.
-// Errors: 400 (validation / token cap), 401 (wrong password), 429 (auth limit).
+// Errors: 400 (validation / token cap), 403 (wrong password — NOT 401, which
+// apiFetch would treat as session expiry and retry), 429 (auth limit).
 export const createApiToken = (apiFetch, { name, scopes, password }) =>
   apiFetch('/api/tokens', {
     method: 'POST',

--- a/frontend/src/components/ApiTokensSection.js
+++ b/frontend/src/components/ApiTokensSection.js
@@ -67,7 +67,9 @@ function ApiTokensSection() {
     setCreateError(null);
     try {
       const res = await createApiToken(apiFetch, { name: name.trim(), scopes, password });
-      if (res.status === 401) {
+      // 403 = wrong password confirmation (401 is reserved for session expiry,
+      // which apiFetch handles transparently)
+      if (res.status === 403) {
         setCreateError(t('settings.apiTokens.errorWrongPassword'));
       } else if (res.status === 429) {
         setCreateError(t('settings.apiTokens.errorRateLimited'));


### PR DESCRIPTION
Post-merge security + bug audit of the HA backend work (#651 / #652 / #654), run as two independent fresh-eyes review passes (security lens + correctness lens) over the merged diff, findings adversarially verified against source and key claims reproduced empirically. Full report: `SECURITY_AUDIT_2026-07-10_HA.md`.

**Result: 0 Critical / 0 High / 2 Medium / 6 Low / 3 Info.** No allowlist escape, no cross-user data leak, no privilege escalation. All Mediums + 4 Lows fixed here; 2 Lows + Infos accepted with rationale in the report.

## Fixed

| Sev | Finding | Fix |
|-----|---------|-----|
| **Med** (bug) | SSE registration + timers leak when the client aborts *during* the API-token auth DB lookups (`close` fires before the listener attaches) → 5 flaky connects fill the per-user cap → permanent **429** for the household. Reproduced with a live Node HTTP test. | Idempotent `cleanup()`, invoked immediately when the socket is already destroyed. |
| **Med** (sec) | `read` scope prefix-matched `GET /api/cellars/:id/audit` (collaborator **IPs + emails**), `/members` (emails), and `/api/bottles/import/*` (separate router under the prefix) — beyond the documented "your wine data" contract. | `TOKEN_EXCLUSIONS` checked before the scope rules. |
| Low (sec) | Absolute session-deadline expiry in `/refresh` invalidated the session but left SSE streams alive up to 24 h. | `dropUser` on that branch. |
| Low (bug) | `insertMany({ordered:false})` rejects *after* inserting valid rows → those recipients got no SSE nudge. | Emit from `err.insertedDocs`. |
| Low (bug) | Shared-cellar **owner** never got `stats_changed` when a member/admin mutated (their stats, their stale dashboard). | Also nudge `req.cellar.user` (free) or guarded owner lookup by `cellarId`. |
| Low (bug) | Wrong password on token-create returned 401 → `apiFetch` transparently refreshed + **re-submitted the wrong password**, and could log the user out on a refresh race. | Return **403** (401 stays reserved for genuine session expiry). |

Plus a throttled operator warning when the global stream cap starts rejecting.

## Accepted (rationale in report)
Stolen-JWT 24 h metadata channel (deliberate trade-off; data-free nudges; API tokens don''t have it), global-cap DoS at self-hosted scale (now observable), token-cap create race (self-inflicted), separate authLimiter budget + no-expiry tokens (match existing posture / product follow-up).

## Verification
14 new regression tests. **Backend 1267/1267, frontend 552/552.** Docker smoke through nginx: excluded paths → 403, wrong password → 403, `/api/stats` with a read token → 200.

## Docker-compose / prod impact
None — no new services, ports, env vars, or nginx changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)