### PR TITLE
chore(release): v1.75.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.74.0",
+  "version": "1.75.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.74.0",
+  "version": "1.75.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for the v1.75.0 release: CellarTracker import mission + Home Assistant integration backend (SSE push, scoped API tokens, consume support) + audit remediations.