### PR TITLE
fix: show journal prompt when consuming from rack views

### DIFF
--- a/frontend/src/components/JournalPrompt.js
+++ b/frontend/src/components/JournalPrompt.js
@@ -1,0 +1,77 @@
+import { lazy, Suspense, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const JournalEntryForm = lazy(() => import('./JournalEntryForm'));
+
+const OPTOUT_KEY = 'cellarion_journal_prompt_optout';
+
+// localStorage can throw in private-browsing / blocked-storage contexts —
+// treat that as "no opt-out saved" so the prompt still works.
+export function journalPromptOptedOut() {
+  try { return localStorage.getItem(OPTOUT_KEY) === '1'; } catch { return false; }
+}
+
+export function setJournalPromptOptOut(optOut) {
+  try {
+    if (optOut) localStorage.setItem(OPTOUT_KEY, '1');
+    else localStorage.removeItem(OPTOUT_KEY);
+  } catch { /* ignore */ }
+}
+
+/**
+ * Post-consume "Add to your journal?" prompt, shared by every consume flow
+ * (bottle detail, flat rack view, 3D room view). Shows the prompt first; if
+ * the user accepts, swaps to the full JournalEntryForm prefilled with the
+ * consumed bottle. Calls onDone() when the flow is over, however it ended.
+ *
+ * The "Don't ask again" checkbox persists the opt-out per device; it can be
+ * re-enabled from Settings → Display Preferences.
+ */
+export default function JournalPrompt({ bottle, onDone }) {
+  const { t } = useTranslation();
+  const [formOpen, setFormOpen] = useState(false);
+  const [dontAsk, setDontAsk] = useState(false);
+
+  const finish = () => {
+    if (dontAsk) setJournalPromptOptOut(true);
+    onDone();
+  };
+
+  const accept = () => {
+    if (dontAsk) setJournalPromptOptOut(true);
+    setFormOpen(true);
+  };
+
+  if (formOpen) {
+    return (
+      <Suspense fallback={null}>
+        <JournalEntryForm prefilledBottle={bottle} onClose={onDone} onSaved={onDone} />
+      </Suspense>
+    );
+  }
+
+  return (
+    <div className="modal-overlay" onClick={finish}>
+      <div className="modal-box" onClick={e => e.stopPropagation()}>
+        <h2>{t('journal.promptTitle', 'Add to your journal?')}</h2>
+        <p>{t('journal.promptText', 'Would you like to capture this moment in your wine journal?')}</p>
+        <div className="modal-actions" style={{ flexDirection: 'column', gap: '0.5rem' }}>
+          <button className="btn btn-primary" onClick={accept}>
+            {t('journal.yesAddEntry', 'Yes, add journal entry')}
+          </button>
+          <button className="btn btn-secondary" onClick={finish}>
+            {t('journal.notNow', 'Not now')}
+          </button>
+        </div>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.75rem', fontSize: '0.85rem', opacity: 0.75, cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={dontAsk}
+            onChange={e => setDontAsk(e.target.checked)}
+          />
+          {t('journal.dontAskAgain', "Don't ask again")}
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -168,6 +168,8 @@
     "restockScopeHint": "When checking if you have similar wines after consuming a bottle, should we check all your cellars or only the one the bottle came from?",
     "restockScopeAll": "All cellars (default)",
     "restockScopeCellar": "Same cellar only",
+    "journalPrompt": "Ask to add a journal entry after drinking a bottle",
+    "journalPromptHint": "When you mark a bottle as drunk, Cellarion offers to capture the moment in your wine journal. Applies immediately and is stored on this device, so choosing \"Don't ask again\" in the prompt can be undone here.",
     "plan": {
       "title": "Your Plan",
       "expires": "Valid until:",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -168,6 +168,8 @@
     "restockScopeHint": "När vi kontrollerar om du har liknande viner efter att du konsumerat en flaska, ska vi kolla alla dina källare eller bara den som flaskan kom från?",
     "restockScopeAll": "Alla källare (standard)",
     "restockScopeCellar": "Samma källare",
+    "journalPrompt": "Fråga om att lägga till en journalanteckning efter att du druckit en flaska",
+    "journalPromptHint": "När du markerar en flaska som drucken erbjuder Cellarion att fånga ögonblicket i din vinjournal. Gäller direkt och sparas på den här enheten, så valet \"Fråga inte igen\" i rutan kan ångras här.",
     "plan": {
       "title": "Ditt abonnemang",
       "expires": "Giltigt till:",

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -19,6 +19,7 @@ import ConsumedDetails from '../components/bottle/ConsumedDetails';
 import EditForm from '../components/bottle/EditForm';
 import ViewDetails from '../components/bottle/ViewDetails';
 import BottleJourney from '../components/BottleJourney';
+import JournalPrompt, { journalPromptOptedOut } from '../components/JournalPrompt';
 import './BottleDetail.css';
 
 // Lazy-load heavy components only needed on user interaction
@@ -28,7 +29,6 @@ const ReviewForm = lazy(() => import('../components/ReviewForm'));
 const ConsumeModal = lazy(() => import('../components/ConsumeModal').then(m => ({ default: m.ConsumeModal })));
 const SuggestGrapesModal = lazy(() => import('../components/SuggestGrapesModal').then(m => ({ default: m.SuggestGrapesModal })));
 const RecommendWineModal = lazy(() => import('../components/RecommendWineModal'));
-const JournalEntryForm = lazy(() => import('../components/JournalEntryForm'));
 
 function BottleDetail() {
   const { t } = useTranslation();
@@ -57,8 +57,7 @@ function BottleDetail() {
   const [reportWineOpen, setReportWineOpen] = useState(false);
   const [reportDefaultReason, setReportDefaultReason] = useState(null);
   const [recommendOpen, setRecommendOpen] = useState(false);
-  const [journalPrompt, setJournalPrompt] = useState(false);
-  const [journalFormOpen, setJournalFormOpen] = useState(false);
+  const [journalPromptOpen, setJournalPromptOpen] = useState(false);
   const [reviewFormOpen, setReviewFormOpen] = useState(false);
   const [wineReviews, setWineReviews] = useState([]);
   const [communityRating, setCommunityRating] = useState(null);
@@ -249,10 +248,9 @@ function BottleDetail() {
       const data = await res.json();
       if (res.ok) {
         // Prompt for journal entry if user hasn't opted out
-        const optedOut = localStorage.getItem('cellarion_journal_prompt_optout') === '1';
-        if (!optedOut && reason === 'drank') {
+        if (!journalPromptOptedOut() && reason === 'drank') {
           setConsumeOpen(false);
-          setJournalPrompt(true);
+          setJournalPromptOpen(true);
         } else {
           navigate(`/cellars/${cellarId}`);
         }
@@ -671,39 +669,10 @@ function BottleDetail() {
           />
         )}
 
-        {journalPrompt && (
-          <div className="modal-overlay" onClick={() => { setJournalPrompt(false); navigate(`/cellars/${cellarId}`); }}>
-            <div className="modal-box" onClick={e => e.stopPropagation()}>
-              <h2>{t('journal.promptTitle', 'Add to your journal?')}</h2>
-              <p>{t('journal.promptText', 'Would you like to capture this moment in your wine journal?')}</p>
-              <div className="modal-actions" style={{ flexDirection: 'column', gap: '0.5rem' }}>
-                <button className="btn btn-primary" onClick={() => { setJournalPrompt(false); setJournalFormOpen(true); }}>
-                  {t('journal.yesAddEntry', 'Yes, add journal entry')}
-                </button>
-                <button className="btn btn-secondary" onClick={() => { setJournalPrompt(false); navigate(`/cellars/${cellarId}`); }}>
-                  {t('journal.notNow', 'Not now')}
-                </button>
-                <button
-                  className="btn btn-secondary"
-                  style={{ fontSize: '0.8rem', opacity: 0.6 }}
-                  onClick={() => {
-                    localStorage.setItem('cellarion_journal_prompt_optout', '1');
-                    setJournalPrompt(false);
-                    navigate(`/cellars/${cellarId}`);
-                  }}
-                >
-                  {t('journal.dontAskAgain', "Don't ask again")}
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {journalFormOpen && (
-          <JournalEntryForm
-            prefilledBottle={bottle}
-            onClose={() => { setJournalFormOpen(false); navigate(`/cellars/${cellarId}`); }}
-            onSaved={() => { setJournalFormOpen(false); navigate(`/cellars/${cellarId}`); }}
+        {journalPromptOpen && (
+          <JournalPrompt
+            bottle={bottle}
+            onDone={() => { setJournalPromptOpen(false); navigate(`/cellars/${cellarId}`); }}
           />
         )}
       </Suspense>

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -15,6 +15,7 @@ import RackTypeSelector, { TYPE_DIMENSIONS } from '../components/racks/RackTypeS
 import RatingInput from '../components/RatingInput';
 import WineImage from '../components/WineImage';
 import ConfirmModal from '../components/ConfirmModal';
+import JournalPrompt, { journalPromptOptedOut } from '../components/JournalPrompt';
 import './CellarRacks.css';
 
 function CellarRacks() {
@@ -65,8 +66,11 @@ function CellarRacks() {
   // active popup: { rackId, position, slot: slotData|null } — rendered as fixed modal
   const [activePopup, setActivePopup] = useState(null);
 
-  // consume modal: { bottleId } or null
+  // consume modal: { bottleId, bottle } or null
   const [consumeModal, setConsumeModal] = useState(null);
+
+  // consumed bottle awaiting the "add to journal?" prompt, or null
+  const [journalBottle, setJournalBottle] = useState(null);
 
   // NFC modal: { rackId } or null
   const [nfcModal, setNfcModal] = useState(null);
@@ -253,7 +257,7 @@ function CellarRacks() {
 
   // --- soft-remove bottle via the shared consume endpoint ---
   const handleConsumeSubmit = async (reason, note, rating, consumedRatingScale) => {
-    const { bottleId } = consumeModal;
+    const { bottleId, bottle } = consumeModal;
     try {
       const res = await consumeBottle(apiFetch, bottleId, { reason, note, rating, consumedRatingScale });
       const data = await res.json();
@@ -267,6 +271,9 @@ function CellarRacks() {
           })
         })));
         setConsumeModal(null);
+        if (reason === 'drank' && !journalPromptOptedOut()) {
+          setJournalBottle(bottle);
+        }
       } else {
         alert(data.error || 'Failed to remove bottle');
       }
@@ -468,7 +475,7 @@ function CellarRacks() {
                   canEdit={canEdit}
                   onRemoveFromRack={() => handleRemoveFromRack(activePopup.rackId, activePopup.position)}
                   onConsume={() => {
-                    setConsumeModal({ bottleId: activePopup.slot.bottle._id });
+                    setConsumeModal({ bottleId: activePopup.slot.bottle._id, bottle: activePopup.slot.bottle });
                     setActivePopup(null);
                   }}
                   onClose={() => setActivePopup(null)}
@@ -503,6 +510,11 @@ function CellarRacks() {
           onSubmit={handleConsumeSubmit}
           onCancel={() => setConsumeModal(null)}
         />
+      )}
+
+      {/* Post-consume "add to journal?" prompt */}
+      {journalBottle && (
+        <JournalPrompt bottle={journalBottle} onDone={() => setJournalBottle(null)} />
       )}
 
       {/* NFC link modal */}

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -10,6 +10,7 @@ import { getCellarLayout, saveCellarLayout } from '../api/cellarLayout';
 import RoomScene from '../components/room/RoomScene';
 import { getRackHeight, clampToRoom } from '../utils/roomConstants';
 import WineImage from '../components/WineImage';
+import JournalPrompt, { journalPromptOptedOut } from '../components/JournalPrompt';
 import './CellarRoom.css';
 
 const DEFAULT_DIMENSIONS = { width: 10, depth: 10, height: 3 };
@@ -55,7 +56,8 @@ export default function CellarRoom() {
   const [slotResults, setSlotResults] = useState([]);
   const [slotLoading, setSlotLoading] = useState(false);
   const slotTimerRef = useRef(null);
-  const [consumeModal, setConsumeModal] = useState(null); // { bottleId }
+  const [consumeModal, setConsumeModal] = useState(null); // { bottleId, bottle }
+  const [journalBottle, setJournalBottle] = useState(null); // consumed bottle awaiting journal prompt
 
   // Undo / redo history for layout changes (edit mode)
   const undoStackRef = useRef([]);
@@ -903,6 +905,9 @@ export default function CellarRoom() {
         })));
         setConsumeModal(null);
         setSelectedBottle(null);
+        if (reason === 'drank' && !journalPromptOptedOut()) {
+          setJournalBottle(consumeModal.bottle);
+        }
       } else {
         alert(data.error || 'Failed to remove bottle');
       }
@@ -1177,7 +1182,7 @@ export default function CellarRoom() {
                     <button
                       className="btn btn-consume btn-small"
                       onClick={() => {
-                        setConsumeModal({ bottleId: bottle._id });
+                        setConsumeModal({ bottleId: bottle._id, bottle });
                       }}
                     >
                       {t('racks.remove', 'Remove')}
@@ -1250,6 +1255,11 @@ export default function CellarRoom() {
                 />
               </div>
             </div>
+          )}
+
+          {/* Post-consume "add to journal?" prompt */}
+          {journalBottle && (
+            <JournalPrompt bottle={journalBottle} onDone={() => setJournalBottle(null)} />
           )}
 
           {/* Multi-select detail panel */}

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -11,6 +11,7 @@ import { SCALE_META, VALID_SCALES } from '../utils/ratingUtils';
 import { isPushSupported, getPushPermissionState, subscribeToPush, unsubscribeFromPush, getCurrentEndpoint, getDeviceStatus, sendTestPush } from '../utils/pushSubscription';
 import { downloadBlobObject } from '../utils/downloadBlob';
 import ApiTokensSection from '../components/ApiTokensSection';
+import { journalPromptOptedOut, setJournalPromptOptOut } from '../components/JournalPrompt';
 import './Settings.css';
 
 function Settings() {
@@ -23,6 +24,8 @@ function Settings() {
   const [ratingScale, setRatingScale] = useState(user?.preferences?.ratingScale || '5');
   const [rackNavigation, setRackNavigation] = useState(user?.preferences?.rackNavigation || 'auto');
   const [restockScope, setRestockScope] = useState(user?.preferences?.restockScope || 'all');
+  // Device-local (localStorage) — applies immediately, no save button needed.
+  const [journalPromptEnabled, setJournalPromptEnabled] = useState(() => !journalPromptOptedOut());
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState(null);
@@ -727,6 +730,23 @@ function Settings() {
               <option value="all">{t('settings.restockScopeAll', 'All cellars (default)')}</option>
               <option value="cellar">{t('settings.restockScopeCellar', 'Same cellar only')}</option>
             </select>
+          </div>
+
+          <div className="form-group">
+            <label className="settings-toggle-row">
+              <input
+                type="checkbox"
+                checked={journalPromptEnabled}
+                onChange={e => {
+                  setJournalPromptEnabled(e.target.checked);
+                  setJournalPromptOptOut(!e.target.checked);
+                }}
+              />
+              <span>{t('settings.journalPrompt', 'Ask to add a journal entry after drinking a bottle')}</span>
+            </label>
+            <p className="settings-hint">
+              {t('settings.journalPromptHint', 'When you mark a bottle as drunk, Cellarion offers to capture the moment in your wine journal. Applies immediately and is stored on this device, so choosing "Don\'t ask again" in the prompt can be undone here.')}
+            </p>
           </div>
 
           {error && <div className="alert alert-error">{error}</div>}


### PR DESCRIPTION
## Problem

The "Add to your journal?" prompt after drinking a bottle only existed in `BottleDetail` (the flow reached from the cellar list). Consuming a bottle from the **flat rack view** (`CellarRacks`) or the **3D room view** (`CellarRoom`) used the same consume endpoint but never asked — the journal moment was silently lost.

## Changes

- **New shared `JournalPrompt` component** (`frontend/src/components/JournalPrompt.js`) — encapsulates the prompt modal, the lazy-loaded `JournalEntryForm` (prefilled with the consumed bottle), and the per-device opt-out helpers (`localStorage`, same `cellarion_journal_prompt_optout` key as before).
- **Wired into all three consume flows**: `BottleDetail` (refactored to use the shared component, behavior unchanged), `CellarRacks`, and `CellarRoom`. Prompt appears only for reason `drank`, as before.
- **"Don'''t ask again" is now a checkbox** in the prompt instead of the old easy-to-miss tertiary button.
- **New Settings toggle** (Settings → Display Preferences): "Ask to add a journal entry after drinking a bottle" — applies immediately, lets users undo a "Don'''t ask again" choice. Stored per device.
- EN + SV translation keys added (`settings.journalPrompt`, `settings.journalPromptHint`). ⚠️ Swedish strings are machine-authored — please review.

## Docker / compose impact

None — frontend-only change, no new dependencies, no env vars, no compose changes.

## Testing

- `cd frontend && npm test` — 552/552 pass
- Vite production build compiles
- Docker smoke test: full stack up, frontend 200, backend health OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)