### PR TITLE
feat: rack lenses (color by drink window/age/rating) + in-rack search

### DIFF
--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -10,10 +10,33 @@ const { getCellarRole } = require('../utils/cellarAccess');
 const { getMaxPosition } = require('../utils/rackGeometry');
 const { isValidId } = require('../utils/validation');
 const { logAudit } = require('../services/audit');
+const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
 
 const router = express.Router();
 
 const MAX_MODULES = 50;
+
+/**
+ * Serialize rack doc(s) with a maturityStatus attached to every populated
+ * slot bottle (same classification the cellar list attaches per bottle), so
+ * the rack views can color slots by drink window. Accepts a single rack or
+ * an array; returns plain objects ready for res.json.
+ */
+async function withMaturity(rackOrRacks) {
+  const rackDocs = Array.isArray(rackOrRacks) ? rackOrRacks : [rackOrRacks];
+  const bottles = rackDocs.flatMap(r => (r.slots || []).map(s => s.bottle).filter(Boolean));
+  const profileMap = await buildProfileMap(bottles);
+  const out = rackDocs.map(r => {
+    const obj = typeof r.toObject === 'function' ? r.toObject() : r;
+    for (const s of obj.slots || []) {
+      if (s.bottle && s.bottle._id) {
+        s.bottle.maturityStatus = classifyMaturity(s.bottle, profileMap) || null;
+      }
+    }
+    return obj;
+  });
+  return Array.isArray(rackOrRacks) ? out : out[0];
+}
 
 /**
  * Validate typeConfig.doubleHeightRows: grid racks (non-modular) only,
@@ -85,7 +108,7 @@ router.get('/', requireCellarAccess('viewer'), async (req, res) => {
         populate: { path: 'wineDefinition', populate: ['country', 'region', 'grapes'] }
       });
 
-    res.json({ racks });
+    res.json({ racks: await withMaturity(racks) });
   } catch (err) {
     console.error('Get racks error:', err);
     res.status(500).json({ error: 'Failed to get racks' });
@@ -226,7 +249,7 @@ router.put('/:id', async (req, res) => {
     });
 
     logAudit(req, 'rack.update', { type: 'rack', id: rack._id });
-    res.json({ rack });
+    res.json({ rack: await withMaturity(rack) });
   } catch (err) {
     if (err.code === 11000) {
       // Two unique indexes can throw here — report the right conflict.
@@ -339,7 +362,7 @@ router.put('/:id/slots/:position', async (req, res) => {
     });
 
     logAudit(req, 'rack.slot_assign', { type: 'rack', id: rack._id });
-    res.json({ rack });
+    res.json({ rack: await withMaturity(rack) });
   } catch (err) {
     if (err.name === 'VersionError') {
       return res.status(409).json({ error: 'This rack was modified by another request. Please refresh and try again.' });
@@ -374,7 +397,7 @@ router.delete('/:id/slots/:position', async (req, res) => {
     });
 
     logAudit(req, 'rack.slot_clear', { type: 'rack', id: rack._id });
-    res.json({ rack });
+    res.json({ rack: await withMaturity(rack) });
   } catch (err) {
     console.error('Clear slot error:', err);
     res.status(500).json({ error: 'Failed to clear slot' });
@@ -418,7 +441,7 @@ router.post('/:id/slots/:position/disable', async (req, res) => {
     });
 
     logAudit(req, 'rack.slot_disable', { type: 'rack', id: rack._id });
-    res.json({ rack });
+    res.json({ rack: await withMaturity(rack) });
   } catch (err) {
     if (err.name === 'VersionError') {
       return res.status(409).json({ error: 'This rack was modified by another request. Please refresh and try again.' });
@@ -455,7 +478,7 @@ router.delete('/:id/slots/:position/disable', async (req, res) => {
     });
 
     logAudit(req, 'rack.slot_enable', { type: 'rack', id: rack._id });
-    res.json({ rack });
+    res.json({ rack: await withMaturity(rack) });
   } catch (err) {
     if (err.name === 'VersionError') {
       return res.status(409).json({ error: 'This rack was modified by another request. Please refresh and try again.' });

--- a/frontend/src/components/racks/RackRenderer.css
+++ b/frontend/src/components/racks/RackRenderer.css
@@ -97,3 +97,8 @@
   font-weight: 500;
   border: 1px solid rgba(180, 150, 100, 0.3);
 }
+
+/* Lens/search dimming animates smoothly as the user types */
+.rack-slot-g {
+  transition: opacity 0.15s ease;
+}

--- a/frontend/src/components/racks/RackRenderer.js
+++ b/frontend/src/components/racks/RackRenderer.js
@@ -77,6 +77,7 @@ export default function RackRenderer({
   onSlotClick,
   onDelete,
   onNfcLink,
+  getSlotStyle,
 }) {
   const { t } = useTranslation();
   const isModular = rack.isModular && rack.modules?.length > 0;
@@ -230,6 +231,7 @@ export default function RackRenderer({
                   isActive={activePos === position}
                   isHighlight={highlightPos === position}
                   onSlotClick={onSlotClick}
+                  getSlotStyle={getSlotStyle}
                 />
               ));
             }
@@ -286,6 +288,7 @@ export default function RackRenderer({
                         isActive={activePos === pos}
                         isHighlight={highlightPos === pos}
                         onSlotClick={onSlotClick}
+                        getSlotStyle={getSlotStyle}
                       />
                     );
                   })}
@@ -300,10 +303,14 @@ export default function RackRenderer({
 }
 
 /** Single slot circle (bpc=1 standard rendering) */
-function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight, onSlotClick }) {
+function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight, onSlotClick, getSlotStyle }) {
   const wine = slot?.bottle?.wineDefinition;
   const wineType = wine?.type || 'red';
   const colors = slot ? (WINE_COLORS[wineType] || WINE_COLORS.red) : null;
+  // Lens/search style: overrides fill/stroke for filled slots, dims
+  // non-matching slots while a search is active.
+  const custom = getSlotStyle ? getSlotStyle(slot || null) : null;
+  const dimStyle = custom?.dim ? { opacity: 0.22 } : null;
 
   // Disabled (unusable) position: greyed circle with a subtle diagonal cross.
   // Still clickable so editors can re-enable it from the slot popup.
@@ -317,7 +324,7 @@ function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight
         role="button"
         tabIndex={0}
         aria-label={`Disabled slot ${position}`}
-        style={{ cursor: 'default' }}
+        style={{ cursor: 'default', ...dimStyle }}
       >
         <circle
           cx={cx} cy={cy} r={R}
@@ -334,6 +341,9 @@ function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight
     );
   }
 
+  const fillColor = slot ? (custom?.fill || colors.fill) : EMPTY_FILL;
+  const strokeColor = slot ? (custom?.stroke || colors.stroke) : EMPTY_STROKE;
+
   return (
     <g
       className={`rack-slot-g ${slot ? 'filled' : 'empty'} ${isActive ? 'active' : ''} ${isHighlight ? 'highlighted' : ''}`}
@@ -342,13 +352,13 @@ function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight
       role="button"
       tabIndex={0}
       aria-label={slot ? `${wine?.name || '?'} (${slot.bottle?.vintage || ''})` : `Empty slot ${position}`}
-      style={{ cursor: 'pointer' }}
+      style={{ cursor: 'pointer', ...dimStyle }}
     >
       <circle cx={cx + 1} cy={cy + 1} r={R} fill="rgba(0,0,0,0.08)" pointerEvents="none" />
       <circle
         cx={cx} cy={cy} r={R}
-        fill={slot ? colors.fill : EMPTY_FILL}
-        stroke={isActive || isHighlight ? ACTIVE_STROKE : (slot ? colors.stroke : EMPTY_STROKE)}
+        fill={fillColor}
+        stroke={isActive || isHighlight ? ACTIVE_STROKE : strokeColor}
         strokeWidth={isActive || isHighlight ? 3 : 1.5}
       />
       <circle cx={cx} cy={cy} r={R * 0.82} fill="none"

--- a/frontend/src/components/racks/ShelfView.css
+++ b/frontend/src/components/racks/ShelfView.css
@@ -98,3 +98,8 @@
   font-size: 0.85rem;
   font-style: italic;
 }
+
+/* Lens/search dimming animates smoothly as the user types */
+.shelf-view-bottle {
+  transition: opacity 0.15s ease;
+}

--- a/frontend/src/components/racks/ShelfView.js
+++ b/frontend/src/components/racks/ShelfView.js
@@ -23,7 +23,7 @@ const SHELF_LABEL_W = 64;
  * Designed for Oeno-style cabinets but works for any rack with type === 'shelf'.
  * Falls back to a friendly message for other rack types.
  */
-export default function ShelfView({ rack, activePosition, highlightPos, onSlotClick }) {
+export default function ShelfView({ rack, activePosition, highlightPos, onSlotClick, getSlotStyle }) {
   const [layerMode, setLayerMode] = useState('front');
   // All hooks must run before the non-shelf early return below, or a rack
   // type change on a mounted instance breaks the Rules of Hooks.
@@ -151,6 +151,7 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
                     isActive={activePosition === s.position}
                     isHighlight={highlightPos === s.position}
                     onClick={() => onSlotClick && onSlotClick(s.position, s.slot || null)}
+                    getSlotStyle={getSlotStyle}
                   />
                 );
               })}
@@ -162,12 +163,16 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
   );
 }
 
-function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, onClick }) {
+function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, onClick, getSlotStyle }) {
   const bottle = slot?.bottle;
   const wine = bottle?.wineDefinition;
   const wineType = wine?.type || 'red';
   const colors = bottle ? (WINE_COLORS[wineType] || WINE_COLORS.red) : null;
   const filled = !!bottle;
+  // Lens/search style: overrides fill/stroke/text for filled ovals, dims
+  // non-matching slots while a search is active.
+  const custom = getSlotStyle ? getSlotStyle(slot || null) : null;
+  const dimStyle = custom?.dim ? { opacity: 0.22 } : null;
 
   // Disabled (unusable) position: greyed oval with a subtle diagonal cross.
   // Still clickable so editors can re-enable it from the slot popup.
@@ -182,7 +187,7 @@ function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, o
         tabIndex={0}
         className="shelf-view-bottle disabled"
         aria-label={`Disabled slot ${position}`}
-        style={{ cursor: 'default' }}
+        style={{ cursor: 'default', ...dimStyle }}
       >
         <ellipse
           cx={cx}
@@ -201,6 +206,10 @@ function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, o
     );
   }
 
+  const fillColor = filled ? (custom?.fill || colors.fill) : 'transparent';
+  const strokeColor = filled ? (custom?.stroke || colors.stroke) : '#B09060';
+  const textColor = custom?.text || colors?.text;
+
   return (
     <g
       onClick={onClick}
@@ -209,6 +218,7 @@ function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, o
       tabIndex={0}
       className={`shelf-view-bottle ${filled ? 'filled' : 'empty'} ${isActive ? 'active' : ''} ${isHighlight ? 'highlight' : ''}`}
       aria-label={filled ? `${wine?.name || 'Wine'} ${bottle?.vintage || ''}` : `Empty slot ${position}`}
+      style={dimStyle || undefined}
     >
       <ellipse
         cx={cx + 0.5}
@@ -223,8 +233,8 @@ function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, o
         cy={cy}
         rx={BOTTLE_RX}
         ry={BOTTLE_RY}
-        fill={filled ? colors.fill : 'transparent'}
-        stroke={filled ? colors.stroke : '#B09060'}
+        fill={fillColor}
+        stroke={strokeColor}
         strokeWidth={isActive || isHighlight ? 2.5 : 1.5}
         strokeDasharray={filled ? null : '3 2'}
       />
@@ -245,7 +255,7 @@ function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, o
           textAnchor="middle"
           dominantBaseline="central"
           className="shelf-view-vintage"
-          fill={colors.text}
+          fill={textColor}
         >
           {bottle.vintage}
         </text>

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -117,11 +117,18 @@ function useResetCursorOnUnmount() {
   useEffect(() => () => { document.body.style.cursor = ''; }, []);
 }
 
-function Bottle({ position, wineType, slot, onBottleClick, highlighted, scale = 1, flipNeck = false }) {
-  const glassColor = GLASS_COLORS[wineType] || GLASS_COLORS.red;
-  const wineColor = WINE_COLORS[wineType] || WINE_COLORS.red;
-  const foilColor = FOIL_COLORS[wineType] || FOIL_COLORS.red;
-  const emissive = EMISSIVE_COLORS[wineType] || EMISSIVE_COLORS.red;
+function Bottle({ position, wineType, slot, onBottleClick, highlighted, scale = 1, flipNeck = false, lensStyle }) {
+  // Lens/search style: a lens color re-tints the whole bottle (glass + wine
+  // + glow) so the room reads as a heatmap; dim greys a non-matching bottle
+  // out while a search is active. Highlight (gold) still wins below.
+  const dim = !!lensStyle?.dim;
+  const lensColor = dim ? null : lensStyle?.color || null;
+  const glassColor = dim ? '#4A453E' : (lensColor || GLASS_COLORS[wineType] || GLASS_COLORS.red);
+  const wineColor = dim ? '#4A453E' : (lensColor || WINE_COLORS[wineType] || WINE_COLORS.red);
+  const foilColor = dim ? '#3A362F' : (FOIL_COLORS[wineType] || FOIL_COLORS.red);
+  const emissive = dim ? '#000000' : (lensColor || EMISSIVE_COLORS[wineType] || EMISSIVE_COLORS.red);
+  const emissiveIntensity = highlighted ? 1.2 : dim ? 0 : lensColor ? 0.25 : 0.3;
+  const labelColor = dim ? '#6A645C' : '#F0E8D8';
   const bottleGeo = useMemo(() => getBottleGeometry(), []);
   useResetCursorOnUnmount();
 
@@ -154,7 +161,7 @@ function Bottle({ position, wineType, slot, onBottleClick, highlighted, scale = 
         <meshPhysicalMaterial
           color={highlighted ? '#FFE060' : glassColor}
           emissive={highlighted ? '#FFD700' : emissive}
-          emissiveIntensity={highlighted ? 1.2 : 0.3}
+          emissiveIntensity={emissiveIntensity}
           roughness={0.15}
           metalness={0.05}
           transmission={highlighted ? 0 : 0.12}
@@ -183,7 +190,7 @@ function Bottle({ position, wineType, slot, onBottleClick, highlighted, scale = 
       {/* Label band */}
       <mesh position={[0, 0.12, 0]}>
         <cylinderGeometry args={[BOTTLE_RADIUS + 0.001, BOTTLE_RADIUS + 0.001, 0.06, 8]} />
-        <meshStandardMaterial color="#F0E8D8" roughness={0.85} metalness={0} />
+        <meshStandardMaterial color={labelColor} roughness={0.85} metalness={0} />
       </mesh>
     </group>
   );
@@ -504,6 +511,7 @@ function PullOutShelfRow({
   onBottleClick,
   onEmptySlotClick,
   highlightBottleId,
+  getBottleStyle,
 }) {
   useResetCursorOnUnmount();
   const groupRef = useRef();
@@ -562,6 +570,7 @@ function PullOutShelfRow({
               onBottleClick={onBottleClick}
               highlighted={highlightBottleId && (slot.bottle?._id || slot.bottle) === highlightBottleId}
               flipNeck={!!flipNeck}
+              lensStyle={getBottleStyle ? getBottleStyle(slot) : null}
             />
           );
         }
@@ -626,6 +635,7 @@ export default function RackMesh({
   onEmptySlotClick,
   onSnapPosition,
   highlightBottleId,
+  getBottleStyle,
   enableShelfPullOut = false,
 }) {
   // Which shelf row is currently pulled out (or null). Telescopic-drawer
@@ -1023,6 +1033,7 @@ export default function RackMesh({
               onBottleClick={onBottleClick}
               onEmptySlotClick={onEmptySlotClick}
               highlightBottleId={highlightBottleId}
+              getBottleStyle={getBottleStyle}
             />
           );
         })
@@ -1050,6 +1061,7 @@ export default function RackMesh({
               onBottleClick={onBottleClick}
               highlighted={highlightBottleId && (slot.bottle?._id || slot.bottle) === highlightBottleId}
               flipNeck={!!flipNeck}
+              lensStyle={getBottleStyle ? getBottleStyle(slot) : null}
             />
           ) : (
             <EmptySlot

--- a/frontend/src/components/room/RoomScene.js
+++ b/frontend/src/components/room/RoomScene.js
@@ -67,6 +67,7 @@ export default function RoomScene({
   onEmptySlotClick,
   focusTarget,
   highlightBottleId,
+  getBottleStyle,
 }) {
   const { width: rw, depth: rd, height: rh } = roomDimensions;
   const halfW = rw / 2;
@@ -450,6 +451,7 @@ export default function RoomScene({
             onBottleClick={onBottleClick ? (slot) => onBottleClick(rack._id, slot) : undefined}
             onEmptySlotClick={onEmptySlotClick ? (slotPos) => onEmptySlotClick(rack._id, slotPos) : undefined}
             highlightBottleId={highlightBottleId}
+            getBottleStyle={getBottleStyle}
           />
         );
       })}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2197,6 +2197,26 @@
     "noData": "No Maturity Data"
   },
 
+  "rackLens": {
+    "searchPlaceholder": "Find in racks…",
+    "colorBy": "Color by",
+    "lensType": "Wine type",
+    "lensMaturity": "Drink window",
+    "lensAge": "Bottle age",
+    "lensRating": "My rating",
+    "age0to2": "≤ 2 yrs",
+    "age3to5": "3–5 yrs",
+    "age6to10": "6–10 yrs",
+    "age11to20": "11–20 yrs",
+    "age20plus": "> 20 yrs",
+    "ageNV": "NV / unknown",
+    "ratingExcellent": "Excellent",
+    "ratingGood": "Good",
+    "ratingAverage": "Average",
+    "ratingLow": "Low",
+    "ratingNone": "Not rated"
+  },
+
   "cellarCred": {
     "newcomer": "Newcomer",
     "contributor": "Contributor",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2197,6 +2197,26 @@
     "noData": "Ingen mognadsdata"
   },
 
+  "rackLens": {
+    "searchPlaceholder": "Sök i hyllorna…",
+    "colorBy": "Färglägg efter",
+    "lensType": "Vintyp",
+    "lensMaturity": "Dryckesfönster",
+    "lensAge": "Flaskålder",
+    "lensRating": "Mitt betyg",
+    "age0to2": "≤ 2 år",
+    "age3to5": "3–5 år",
+    "age6to10": "6–10 år",
+    "age11to20": "11–20 år",
+    "age20plus": "> 20 år",
+    "ageNV": "NV / okänd",
+    "ratingExcellent": "Utmärkt",
+    "ratingGood": "Bra",
+    "ratingAverage": "Medel",
+    "ratingLow": "Lågt",
+    "ratingNone": "Ej betygsatt"
+  },
+
   "cellarCred": {
     "newcomer": "Nykomling",
     "contributor": "Bidragsgivare",

--- a/frontend/src/pages/CellarRacks.css
+++ b/frontend/src/pages/CellarRacks.css
@@ -528,47 +528,134 @@
 .rack-lens-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
-  margin: 0.75rem 0 0.4rem;
+  margin: 0.9rem 0 0.5rem;
+}
+
+.rack-lens-search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1 1 200px;
+  max-width: 300px;
+}
+
+.rack-lens-search-icon {
+  position: absolute;
+  left: 12px;
+  color: var(--color-text-muted);
+  pointer-events: none;
 }
 
 .rack-lens-search {
-  flex: 1 1 220px;
-  max-width: 320px;
+  width: 100%;
+  padding: 0.42rem 2rem 0.42rem 2.15rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.rack-lens-label {
-  display: inline-flex;
+.rack-lens-search::placeholder {
+  color: var(--color-text-muted);
+}
+
+.rack-lens-search:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.15);
+}
+
+/* We render our own clear button */
+.rack-lens-search::-webkit-search-cancel-button {
+  display: none;
+}
+
+.rack-lens-search-clear {
+  position: absolute;
+  right: 7px;
+  width: 20px;
+  height: 20px;
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.rack-lens-search-clear:hover {
+  color: var(--color-text);
+}
+
+/* Segmented lens control — same pill language as .rack-view-mode-toggle */
+.rack-lens-segment {
+  display: inline-flex;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.2rem;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.rack-lens-segment::-webkit-scrollbar {
+  display: none;
+}
+
+.rack-lens-segment-btn {
+  border: none;
+  background: transparent;
+  padding: 0.32rem 0.8rem;
+  font-size: 0.82rem;
+  border-radius: 999px;
+  cursor: pointer;
   color: var(--color-text-muted);
   white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
 }
 
-.rack-lens-select {
-  width: auto;
+.rack-lens-segment-btn:hover {
+  color: var(--color-text);
+}
+
+.rack-lens-segment-btn.active {
+  background: var(--color-primary);
+  color: white;
 }
 
 .rack-lens-legend {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem 0.9rem;
-  margin-bottom: 0.75rem;
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
+  gap: 0.3rem;
+  margin-bottom: 0.85rem;
 }
 
 .rack-lens-chip {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.14rem 0.6rem 0.14rem 0.45rem;
 }
 
 .rack-lens-dot {
-  width: 10px;
-  height: 10px;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
   border: 1px solid rgba(0, 0, 0, 0.25);
   flex-shrink: 0;

--- a/frontend/src/pages/CellarRacks.css
+++ b/frontend/src/pages/CellarRacks.css
@@ -523,3 +523,68 @@
 .new-rack-preview-canvas .rack-meta {
   display: none;
 }
+
+/* ---- Lens + search toolbar ---- */
+.rack-lens-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin: 0.75rem 0 0.4rem;
+}
+
+.rack-lens-search {
+  flex: 1 1 220px;
+  max-width: 320px;
+}
+
+.rack-lens-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.rack-lens-select {
+  width: auto;
+}
+
+.rack-lens-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.9rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.rack-lens-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.rack-lens-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  flex-shrink: 0;
+}
+
+/* Per-tab search match count */
+.rack-tab-matches {
+  font-size: 0.72rem;
+  border-radius: 10px;
+  padding: 1px 6px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--color-text-muted);
+}
+
+.rack-tab-matches.has-matches {
+  background: rgba(var(--color-primary-rgb), 0.25);
+  color: var(--color-primary);
+}

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -16,6 +16,7 @@ import RatingInput from '../components/RatingInput';
 import WineImage from '../components/WineImage';
 import ConfirmModal from '../components/ConfirmModal';
 import JournalPrompt, { journalPromptOptedOut } from '../components/JournalPrompt';
+import { LENSES, getLensStyle, getLensLegend, bottleMatchesSearch } from '../utils/rackLens';
 import './CellarRacks.css';
 
 function CellarRacks() {
@@ -62,6 +63,53 @@ function CellarRacks() {
       // localStorage unavailable (e.g. private mode) — view mode just won't persist
     }
   };
+
+  // Lens: which dimension colors the slots (type = classic wine-type colors).
+  // Persisted like the view mode so the choice survives navigation.
+  const [lens, setLensState] = useState(() => {
+    try {
+      const stored = window.localStorage.getItem('cellarion.rackLens');
+      return LENSES.includes(stored) ? stored : 'type';
+    } catch {
+      return 'type';
+    }
+  });
+  const setLens = (l) => {
+    setLensState(l);
+    try {
+      window.localStorage.setItem('cellarion.rackLens', l);
+    } catch {
+      // not persisted — fine
+    }
+  };
+
+  // Free-text search across rack slots — non-matching slots are dimmed.
+  const [rackSearch, setRackSearch] = useState('');
+  const searchActive = rackSearch.trim().length > 0;
+
+  // Per-slot style callback for the renderers; null = default rendering.
+  // Empty/disabled slots and non-matching bottles dim while searching so
+  // matches pop; the lens picks the fill for filled slots.
+  const getSlotStyle = useMemo(() => {
+    if (lens === 'type' && !searchActive) return null;
+    return (slot) => {
+      const bottle = slot?.bottle;
+      const style = bottle ? getLensStyle(lens, bottle) : null;
+      const dim = searchActive && (!bottle || !bottleMatchesSearch(bottle, rackSearch));
+      return { ...(style || {}), dim };
+    };
+  }, [lens, searchActive, rackSearch]);
+
+  // While searching, show a match count on every rack tab so cross-rack
+  // hits are visible from the current rack.
+  const matchCounts = useMemo(() => {
+    if (!searchActive) return null;
+    const counts = {};
+    for (const r of racks) {
+      counts[r._id] = r.slots.filter(s => s.bottle && bottleMatchesSearch(s.bottle, rackSearch)).length;
+    }
+    return counts;
+  }, [racks, searchActive, rackSearch]);
 
   // active popup: { rackId, position, slot: slotData|null } — rendered as fixed modal
   const [activePopup, setActivePopup] = useState(null);
@@ -374,9 +422,51 @@ function CellarRacks() {
                     : getTotalSlots(r.type || 'grid', r.rows, r.cols, r.typeConfig))
                     - (r.disabledPositions?.length || 0)}
                 </span>
+                {matchCounts && (
+                  <span className={`rack-tab-matches ${matchCounts[r._id] > 0 ? 'has-matches' : ''}`}>
+                    {matchCounts[r._id]}
+                  </span>
+                )}
               </button>
             ))}
           </div>
+
+          {/* Lens + search toolbar (the 3D shelf view doesn't support lenses yet) */}
+          {!(rack.type === 'shelf' && !rack.isModular && viewMode === '3d') && (
+            <>
+              <div className="rack-lens-toolbar">
+                <input
+                  type="search"
+                  className="input rack-lens-search"
+                  placeholder={t('rackLens.searchPlaceholder', 'Find in racks…')}
+                  aria-label={t('rackLens.searchPlaceholder', 'Find in racks…')}
+                  value={rackSearch}
+                  onChange={e => setRackSearch(e.target.value)}
+                />
+                <label className="rack-lens-label">
+                  {t('rackLens.colorBy', 'Color by')}
+                  <select
+                    className="input rack-lens-select"
+                    value={lens}
+                    onChange={e => setLens(e.target.value)}
+                  >
+                    <option value="type">{t('rackLens.lensType', 'Wine type')}</option>
+                    <option value="maturity">{t('rackLens.lensMaturity', 'Drink window')}</option>
+                    <option value="age">{t('rackLens.lensAge', 'Bottle age')}</option>
+                    <option value="rating">{t('rackLens.lensRating', 'My rating')}</option>
+                  </select>
+                </label>
+              </div>
+              <div className="rack-lens-legend" aria-hidden="true">
+                {getLensLegend(lens).map(e => (
+                  <span key={e.tKey} className="rack-lens-chip">
+                    <span className="rack-lens-dot" style={{ background: e.fill }} />
+                    {t(e.tKey)}
+                  </span>
+                ))}
+              </div>
+            </>
+          )}
           {rack.type === 'shelf' && !rack.isModular && (
             <div className="rack-view-mode-toggle" role="tablist">
               <button
@@ -423,6 +513,7 @@ function CellarRacks() {
                 activePosition: activePopup?.rackId === rack._id ? activePopup.position : null,
                 highlightPos: highlightPos?.rackId === rack._id ? highlightPos.position : null,
                 onSlotClick: handleClick,
+                getSlotStyle,
               };
               if (viewMode === '3d') {
                 return (
@@ -440,6 +531,7 @@ function CellarRacks() {
               activeRackId={activePopup?.rackId}
               activePosition={activePopup?.position}
               highlightPos={highlightPos?.rackId === rack._id ? highlightPos.position : null}
+              getSlotStyle={getSlotStyle}
               onSlotClick={(pos, slotData) => {
                 // Viewers can only inspect filled or disabled slots, not interact with empty ones
                 const isDisabled = (rack.disabledPositions || []).includes(pos);

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -435,27 +435,41 @@ function CellarRacks() {
           {!(rack.type === 'shelf' && !rack.isModular && viewMode === '3d') && (
             <>
               <div className="rack-lens-toolbar">
-                <input
-                  type="search"
-                  className="input rack-lens-search"
-                  placeholder={t('rackLens.searchPlaceholder', 'Find in racks…')}
-                  aria-label={t('rackLens.searchPlaceholder', 'Find in racks…')}
-                  value={rackSearch}
-                  onChange={e => setRackSearch(e.target.value)}
-                />
-                <label className="rack-lens-label">
-                  {t('rackLens.colorBy', 'Color by')}
-                  <select
-                    className="input rack-lens-select"
-                    value={lens}
-                    onChange={e => setLens(e.target.value)}
-                  >
-                    <option value="type">{t('rackLens.lensType', 'Wine type')}</option>
-                    <option value="maturity">{t('rackLens.lensMaturity', 'Drink window')}</option>
-                    <option value="age">{t('rackLens.lensAge', 'Bottle age')}</option>
-                    <option value="rating">{t('rackLens.lensRating', 'My rating')}</option>
-                  </select>
-                </label>
+                <div className="rack-lens-search-wrap">
+                  <svg className="rack-lens-search-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                  <input
+                    type="search"
+                    className="rack-lens-search"
+                    placeholder={t('rackLens.searchPlaceholder', 'Find in racks…')}
+                    aria-label={t('rackLens.searchPlaceholder', 'Find in racks…')}
+                    value={rackSearch}
+                    onChange={e => setRackSearch(e.target.value)}
+                  />
+                  {searchActive && (
+                    <button
+                      type="button"
+                      className="rack-lens-search-clear"
+                      onClick={() => setRackSearch('')}
+                      aria-label={t('common.clear', 'Clear')}
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+                <div className="rack-lens-segment" role="tablist" aria-label={t('rackLens.colorBy', 'Color by')}>
+                  <button role="tab" aria-selected={lens === 'type'} className={`rack-lens-segment-btn ${lens === 'type' ? 'active' : ''}`} onClick={() => setLens('type')}>
+                    {t('rackLens.lensType', 'Wine type')}
+                  </button>
+                  <button role="tab" aria-selected={lens === 'maturity'} className={`rack-lens-segment-btn ${lens === 'maturity' ? 'active' : ''}`} onClick={() => setLens('maturity')}>
+                    {t('rackLens.lensMaturity', 'Drink window')}
+                  </button>
+                  <button role="tab" aria-selected={lens === 'age'} className={`rack-lens-segment-btn ${lens === 'age' ? 'active' : ''}`} onClick={() => setLens('age')}>
+                    {t('rackLens.lensAge', 'Bottle age')}
+                  </button>
+                  <button role="tab" aria-selected={lens === 'rating'} className={`rack-lens-segment-btn ${lens === 'rating' ? 'active' : ''}`} onClick={() => setLens('rating')}>
+                    {t('rackLens.lensRating', 'My rating')}
+                  </button>
+                </div>
               </div>
               <div className="rack-lens-legend" aria-hidden="true">
                 {getLensLegend(lens).map(e => (

--- a/frontend/src/pages/CellarRoom.css
+++ b/frontend/src/pages/CellarRoom.css
@@ -567,3 +567,159 @@
     left: 0.5rem;
   }
 }
+
+/* ── Lens + search overlay (view mode) ─────────────────── */
+.room-lens-bar {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 12;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  max-width: calc(100% - 20px);
+  pointer-events: none;
+}
+
+.room-lens-bar > * {
+  pointer-events: auto;
+}
+
+.room-lens-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.room-lens-search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.room-lens-search-icon {
+  position: absolute;
+  left: 10px;
+  color: rgba(255, 255, 255, 0.55);
+  pointer-events: none;
+}
+
+.room-lens-search {
+  width: 190px;
+  padding: 0.35rem 1.8rem 0.35rem 1.85rem;
+  font-size: 0.8rem;
+  color: #fff;
+  background: rgba(20, 16, 12, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.room-lens-search::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.room-lens-search:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.room-lens-search::-webkit-search-cancel-button {
+  display: none;
+}
+
+.room-lens-clear {
+  position: absolute;
+  right: 6px;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.room-lens-segment {
+  display: inline-flex;
+  background: rgba(20, 16, 12, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  padding: 2px;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  max-width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.room-lens-segment::-webkit-scrollbar {
+  display: none;
+}
+
+.room-lens-segment-btn {
+  border: none;
+  background: transparent;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.78rem;
+  border-radius: 999px;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.6);
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+
+.room-lens-segment-btn:hover {
+  color: #fff;
+}
+
+.room-lens-segment-btn.active {
+  background: var(--color-primary, #6366f1);
+  color: #fff;
+}
+
+.room-lens-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 4px;
+}
+
+.room-lens-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.68rem;
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(20, 16, 12, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  padding: 2px 8px 2px 5px;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.room-lens-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.3);
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .room-lens-search {
+    width: 150px;
+  }
+}

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -11,6 +11,7 @@ import RoomScene from '../components/room/RoomScene';
 import { getRackHeight, clampToRoom } from '../utils/roomConstants';
 import WineImage from '../components/WineImage';
 import JournalPrompt, { journalPromptOptedOut } from '../components/JournalPrompt';
+import { LENSES, getLensStyle, getLensLegend, bottleMatchesSearch } from '../utils/rackLens';
 import './CellarRoom.css';
 
 const DEFAULT_DIMENSIONS = { width: 10, depth: 10, height: 3 };
@@ -58,6 +59,43 @@ export default function CellarRoom() {
   const slotTimerRef = useRef(null);
   const [consumeModal, setConsumeModal] = useState(null); // { bottleId, bottle }
   const [journalBottle, setJournalBottle] = useState(null); // consumed bottle awaiting journal prompt
+
+  // Lens + search — shares the persisted lens choice with the flat rack view.
+  const [lens, setLensState] = useState(() => {
+    try {
+      const stored = window.localStorage.getItem('cellarion.rackLens');
+      return LENSES.includes(stored) ? stored : 'type';
+    } catch {
+      return 'type';
+    }
+  });
+  const setLens = (l) => {
+    setLensState(l);
+    try {
+      window.localStorage.setItem('cellarion.rackLens', l);
+    } catch { /* not persisted — fine */ }
+  };
+  // The input updates instantly; the applied term is debounced so hundreds
+  // of bottle materials aren't re-tinted on every keystroke.
+  const [roomSearchInput, setRoomSearchInput] = useState('');
+  const [roomSearch, setRoomSearch] = useState('');
+  useEffect(() => {
+    const id = setTimeout(() => setRoomSearch(roomSearchInput), 250);
+    return () => clearTimeout(id);
+  }, [roomSearchInput]);
+  const searchActive = roomSearch.trim().length > 0;
+
+  // Per-bottle 3D style: { color, dim } or null for the natural look.
+  const getBottleStyle = useMemo(() => {
+    if (lens === 'type' && !searchActive) return null;
+    return (slot) => {
+      const bottle = slot?.bottle;
+      if (!bottle) return null;
+      const style = getLensStyle(lens, bottle);
+      const dim = searchActive && !bottleMatchesSearch(bottle, roomSearch);
+      return { color: style?.fill || null, dim };
+    };
+  }, [lens, searchActive, roomSearch]);
 
   // Undo / redo history for layout changes (edit mode)
   const undoStackRef = useRef([]);
@@ -1031,6 +1069,60 @@ export default function CellarRoom() {
             </div>
           )}
 
+          {/* Lens + search overlay (view mode only — edit mode has its own toolbar) */}
+          {!isEditMode && placements.length > 0 && (
+            <div className="room-lens-bar">
+              <div className="room-lens-controls">
+                <div className="room-lens-search-wrap">
+                  <svg className="room-lens-search-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                  <input
+                    type="search"
+                    className="room-lens-search"
+                    placeholder={t('rackLens.searchPlaceholder', 'Find in racks…')}
+                    aria-label={t('rackLens.searchPlaceholder', 'Find in racks…')}
+                    value={roomSearchInput}
+                    onChange={e => setRoomSearchInput(e.target.value)}
+                  />
+                  {roomSearchInput && (
+                    <button
+                      type="button"
+                      className="room-lens-clear"
+                      onClick={() => setRoomSearchInput('')}
+                      aria-label={t('common.clear', 'Clear')}
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+                <div className="room-lens-segment" role="tablist" aria-label={t('rackLens.colorBy', 'Color by')}>
+                  <button role="tab" aria-selected={lens === 'type'} className={`room-lens-segment-btn ${lens === 'type' ? 'active' : ''}`} onClick={() => setLens('type')}>
+                    {t('rackLens.lensType', 'Wine type')}
+                  </button>
+                  <button role="tab" aria-selected={lens === 'maturity'} className={`room-lens-segment-btn ${lens === 'maturity' ? 'active' : ''}`} onClick={() => setLens('maturity')}>
+                    {t('rackLens.lensMaturity', 'Drink window')}
+                  </button>
+                  <button role="tab" aria-selected={lens === 'age'} className={`room-lens-segment-btn ${lens === 'age' ? 'active' : ''}`} onClick={() => setLens('age')}>
+                    {t('rackLens.lensAge', 'Bottle age')}
+                  </button>
+                  <button role="tab" aria-selected={lens === 'rating'} className={`room-lens-segment-btn ${lens === 'rating' ? 'active' : ''}`} onClick={() => setLens('rating')}>
+                    {t('rackLens.lensRating', 'My rating')}
+                  </button>
+                </div>
+              </div>
+              {/* Legend only for non-type lenses: the natural bottle look needs no key */}
+              {lens !== 'type' && (
+                <div className="room-lens-legend" aria-hidden="true">
+                  {getLensLegend(lens).map(e => (
+                    <span key={e.tKey} className="room-lens-chip">
+                      <span className="room-lens-dot" style={{ background: e.fill }} />
+                      {t(e.tKey)}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
           <Canvas
             shadows
             camera={{
@@ -1049,6 +1141,7 @@ export default function CellarRoom() {
                 isEditMode={isEditMode}
                 selectedRackIds={selectedRackIds}
                 groupColorMap={groupColorMap}
+                getBottleStyle={getBottleStyle}
                 onRackClick={(rackId, shiftKey) => {
                   // Handle click-to-stack / click-to-link modes
                   if (interactionMode === 'stack' && selectedRackId && rackId !== selectedRackId) {

--- a/frontend/src/utils/rackLens.js
+++ b/frontend/src/utils/rackLens.js
@@ -1,0 +1,131 @@
+/**
+ * Rack "lens" engine — recolors rack slots by a chosen dimension (drink-window
+ * maturity, bottle age, rating) and matches bottles against a free-text
+ * search so the renderers can dim non-matching slots.
+ *
+ * The default lens is 'type' (wine type): for it getLensStyle returns null
+ * and the renderers fall back to their built-in wine-type colors, so the
+ * default view is pixel-identical to the pre-lens behavior.
+ *
+ * All fills are chosen to read against the wood rack background (#DCC8A4).
+ * Maturity hues match the .maturity-badge--* colors in BottleCard.css so the
+ * rack speaks the same color language as the bottle list.
+ */
+import { toNormalized } from './ratingUtils';
+
+export const LENSES = ['type', 'maturity', 'age', 'rating'];
+
+const NEUTRAL = { fill: '#A89880', stroke: '#8A7A64', text: '#fff' };
+
+// ── Maturity (drink window) ──────────────────────────────────────────
+const MATURITY_STYLES = {
+  'not-ready': { fill: '#6A1B9A', stroke: '#4A148C', text: '#fff' },
+  early:       { fill: '#1565C0', stroke: '#0D47A1', text: '#fff' },
+  peak:        { fill: '#2E7D32', stroke: '#1B5E20', text: '#fff' },
+  late:        { fill: '#E65100', stroke: '#BF360C', text: '#fff' },
+  declining:   { fill: '#C62828', stroke: '#8E0000', text: '#fff' },
+  none:        NEUTRAL,
+};
+
+// ── Age (years since vintage) — single-hue ramp, young → old ─────────
+const AGE_BUCKETS = [
+  { max: 2,        key: 'age0to2',   fill: '#90CAF9', stroke: '#5B9BD5', text: '#0D2F4C' },
+  { max: 5,        key: 'age3to5',   fill: '#42A5F5', stroke: '#1E88E5', text: '#fff' },
+  { max: 10,       key: 'age6to10',  fill: '#1E88E5', stroke: '#1565C0', text: '#fff' },
+  { max: 20,       key: 'age11to20', fill: '#1565C0', stroke: '#0D47A1', text: '#fff' },
+  { max: Infinity, key: 'age20plus', fill: '#0D2F6C', stroke: '#081F4A', text: '#fff' },
+];
+
+// ── Rating (normalized 0–100) — diverging ramp, low → high ───────────
+const RATING_BUCKETS = [
+  { min: 85, key: 'ratingExcellent', fill: '#2E7D32', stroke: '#1B5E20', text: '#fff' },
+  { min: 70, key: 'ratingGood',      fill: '#7CB342', stroke: '#558B2F', text: '#233300' },
+  { min: 50, key: 'ratingAverage',   fill: '#F9A825', stroke: '#C17900', text: '#3A2A00' },
+  { min: 0,  key: 'ratingLow',       fill: '#C62828', stroke: '#8E0000', text: '#fff' },
+];
+
+function ageStyle(vintage, currentYear = new Date().getFullYear()) {
+  const year = Number(vintage);
+  if (!Number.isInteger(year) || year < 1800 || year > currentYear + 1) return NEUTRAL;
+  const age = Math.max(0, currentYear - year);
+  return AGE_BUCKETS.find(b => age <= b.max) || NEUTRAL;
+}
+
+function ratingStyle(rating, ratingScale) {
+  const norm = toNormalized(rating, ratingScale || '5');
+  if (norm == null) return NEUTRAL;
+  return RATING_BUCKETS.find(b => norm >= b.min) || NEUTRAL;
+}
+
+/**
+ * Style for a filled slot under the given lens: { fill, stroke, text } or
+ * null for the default 'type' lens (renderer uses its built-in colors).
+ */
+export function getLensStyle(lens, bottle, currentYear) {
+  if (!bottle) return null;
+  switch (lens) {
+    case 'maturity': return MATURITY_STYLES[bottle.maturityStatus] || MATURITY_STYLES.none;
+    case 'age':      return ageStyle(bottle.vintage, currentYear);
+    case 'rating':   return ratingStyle(bottle.rating, bottle.ratingScale);
+    default:         return null;
+  }
+}
+
+// Wine-type legend colors mirror RackRenderer's compact-view palette.
+const TYPE_LEGEND = [
+  { key: 'red',       fill: '#8A1028' },
+  { key: 'white',     fill: '#C8B850' },
+  { key: 'rosé',      fill: '#D06888' },
+  { key: 'sparkling', fill: '#88A848' },
+  { key: 'dessert',   fill: '#A06020' },
+  { key: 'fortified', fill: '#7A3010' },
+];
+
+/**
+ * Legend entries for a lens: [{ tKey, fill }]. tKey is resolved against the
+ * translation bundle by the caller ('statistics.typeLabels.*', 'maturity.*',
+ * 'rackLens.*').
+ */
+export function getLensLegend(lens) {
+  switch (lens) {
+    case 'type':
+      return TYPE_LEGEND.map(e => ({ tKey: `statistics.typeLabels.${e.key}`, fill: e.fill }));
+    case 'maturity':
+      return [
+        { tKey: 'maturity.notReady',  fill: MATURITY_STYLES['not-ready'].fill },
+        { tKey: 'maturity.early',     fill: MATURITY_STYLES.early.fill },
+        { tKey: 'maturity.peak',      fill: MATURITY_STYLES.peak.fill },
+        { tKey: 'maturity.late',      fill: MATURITY_STYLES.late.fill },
+        { tKey: 'maturity.declining', fill: MATURITY_STYLES.declining.fill },
+        { tKey: 'maturity.noData',    fill: NEUTRAL.fill },
+      ];
+    case 'age':
+      return AGE_BUCKETS.map(b => ({ tKey: `rackLens.${b.key}`, fill: b.fill }))
+        .concat([{ tKey: 'rackLens.ageNV', fill: NEUTRAL.fill }]);
+    case 'rating':
+      return RATING_BUCKETS.map(b => ({ tKey: `rackLens.${b.key}`, fill: b.fill }))
+        .concat([{ tKey: 'rackLens.ratingNone', fill: NEUTRAL.fill }]);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Free-text match against a rack slot bottle: wine name, producer,
+ * appellation, country, region, grapes and vintage. Empty term matches all.
+ */
+export function bottleMatchesSearch(bottle, term) {
+  const q = (term || '').trim().toLowerCase();
+  if (!q) return true;
+  const wd = bottle?.wineDefinition || {};
+  const haystack = [
+    wd.name,
+    wd.producer,
+    wd.appellation,
+    wd.country?.name,
+    wd.region?.name,
+    ...(Array.isArray(wd.grapes) ? wd.grapes.map(g => g?.name) : []),
+    bottle?.vintage,
+  ];
+  return haystack.some(v => v != null && String(v).toLowerCase().includes(q));
+}

--- a/frontend/src/utils/rackLens.test.js
+++ b/frontend/src/utils/rackLens.test.js
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { getLensStyle, getLensLegend, bottleMatchesSearch, LENSES } from './rackLens';
+
+const CURRENT_YEAR = new Date().getFullYear();
+
+// ─── getLensStyle — type (default) lens ──────────────────────────────────────
+
+describe('getLensStyle — type lens', () => {
+  it('returns null so renderers use their built-in wine-type colors', () => {
+    expect(getLensStyle('type', { maturityStatus: 'peak' })).toBeNull();
+  });
+
+  it('returns null for missing bottle regardless of lens', () => {
+    for (const lens of LENSES) {
+      expect(getLensStyle(lens, null)).toBeNull();
+      expect(getLensStyle(lens, undefined)).toBeNull();
+    }
+  });
+});
+
+// ─── getLensStyle — maturity lens ────────────────────────────────────────────
+
+describe('getLensStyle — maturity lens', () => {
+  it.each(['not-ready', 'early', 'peak', 'late', 'declining'])(
+    'returns a distinct style for %s',
+    (status) => {
+      const style = getLensStyle('maturity', { maturityStatus: status });
+      expect(style.fill).toMatch(/^#/);
+      expect(style.stroke).toMatch(/^#/);
+    }
+  );
+
+  it('gives every maturity status a unique fill', () => {
+    const fills = ['not-ready', 'early', 'peak', 'late', 'declining', null]
+      .map(s => getLensStyle('maturity', { maturityStatus: s }).fill);
+    expect(new Set(fills).size).toBe(fills.length);
+  });
+
+  it('falls back to the neutral style for null/unknown status', () => {
+    const neutral = getLensStyle('maturity', { maturityStatus: null });
+    expect(getLensStyle('maturity', { maturityStatus: 'bogus' })).toEqual(neutral);
+    expect(getLensStyle('maturity', {})).toEqual(neutral);
+  });
+});
+
+// ─── getLensStyle — age lens ─────────────────────────────────────────────────
+
+describe('getLensStyle — age lens', () => {
+  const style = (vintage) => getLensStyle('age', { vintage }, CURRENT_YEAR);
+
+  it('buckets by years since vintage', () => {
+    const young = style(String(CURRENT_YEAR - 1));
+    const mid = style(String(CURRENT_YEAR - 8));
+    const old = style(String(CURRENT_YEAR - 30));
+    expect(young.fill).not.toBe(mid.fill);
+    expect(mid.fill).not.toBe(old.fill);
+  });
+
+  it('handles bucket boundaries (2/3 and 20/21 years)', () => {
+    expect(style(String(CURRENT_YEAR - 2)).fill).not.toBe(style(String(CURRENT_YEAR - 3)).fill);
+    expect(style(String(CURRENT_YEAR - 20)).fill).not.toBe(style(String(CURRENT_YEAR - 21)).fill);
+  });
+
+  it('returns the neutral style for NV and unparseable vintages', () => {
+    const neutral = style('NV');
+    expect(style(undefined)).toEqual(neutral);
+    expect(style('n/a')).toEqual(neutral);
+    expect(style('1750')).toEqual(neutral); // before plausible range
+  });
+
+  it('treats next-year (pre-release) vintages as youngest, not neutral', () => {
+    expect(style(String(CURRENT_YEAR + 1))).toEqual(style(String(CURRENT_YEAR)));
+  });
+});
+
+// ─── getLensStyle — rating lens ──────────────────────────────────────────────
+
+describe('getLensStyle — rating lens', () => {
+  it('maps a top rating and a bottom rating to different styles', () => {
+    const top = getLensStyle('rating', { rating: 5, ratingScale: '5' });
+    const bottom = getLensStyle('rating', { rating: 1, ratingScale: '5' });
+    expect(top.fill).not.toBe(bottom.fill);
+  });
+
+  it('normalizes across scales — 100-point and 5-star tops land in the same bucket', () => {
+    const hundred = getLensStyle('rating', { rating: 98, ratingScale: '100' });
+    const fiveStar = getLensStyle('rating', { rating: 5, ratingScale: '5' });
+    expect(hundred.fill).toBe(fiveStar.fill);
+  });
+
+  it('defaults missing scale to 5-star', () => {
+    expect(getLensStyle('rating', { rating: 5 }))
+      .toEqual(getLensStyle('rating', { rating: 5, ratingScale: '5' }));
+  });
+
+  it('returns the neutral style for unrated bottles', () => {
+    const neutral = getLensStyle('rating', {});
+    expect(getLensStyle('rating', { rating: null })).toEqual(neutral);
+    expect(getLensStyle('maturity', { maturityStatus: null })).toEqual(neutral); // shared neutral
+  });
+});
+
+// ─── getLensLegend ───────────────────────────────────────────────────────────
+
+describe('getLensLegend', () => {
+  it('returns entries with tKey + fill for every lens', () => {
+    for (const lens of LENSES) {
+      const legend = getLensLegend(lens);
+      expect(legend.length).toBeGreaterThan(0);
+      for (const e of legend) {
+        expect(typeof e.tKey).toBe('string');
+        expect(e.fill).toMatch(/^#/);
+      }
+    }
+  });
+
+  it('maturity legend covers all five statuses plus no-data', () => {
+    expect(getLensLegend('maturity')).toHaveLength(6);
+  });
+
+  it('rating legend runs best-first', () => {
+    const keys = getLensLegend('rating').map(e => e.tKey);
+    expect(keys[0]).toBe('rackLens.ratingExcellent');
+    expect(keys[keys.length - 1]).toBe('rackLens.ratingNone');
+  });
+
+  it('unknown lens yields an empty legend', () => {
+    expect(getLensLegend('bogus')).toEqual([]);
+  });
+});
+
+// ─── bottleMatchesSearch ─────────────────────────────────────────────────────
+
+describe('bottleMatchesSearch', () => {
+  const bottle = {
+    vintage: '2015',
+    wineDefinition: {
+      name: 'Château Margaux',
+      producer: 'Château Margaux',
+      appellation: 'Margaux AOC',
+      country: { name: 'France' },
+      region: { name: 'Bordeaux' },
+      grapes: [{ name: 'Cabernet Sauvignon' }, { name: 'Merlot' }],
+    },
+  };
+
+  it('matches on name, producer, appellation, country, region, grape and vintage', () => {
+    expect(bottleMatchesSearch(bottle, 'margaux')).toBe(true);
+    expect(bottleMatchesSearch(bottle, 'france')).toBe(true);
+    expect(bottleMatchesSearch(bottle, 'bordeaux')).toBe(true);
+    expect(bottleMatchesSearch(bottle, 'merlot')).toBe(true);
+    expect(bottleMatchesSearch(bottle, '2015')).toBe(true);
+  });
+
+  it('is case-insensitive and trims the term', () => {
+    expect(bottleMatchesSearch(bottle, '  MARGAUX  ')).toBe(true);
+  });
+
+  it('rejects non-matching terms', () => {
+    expect(bottleMatchesSearch(bottle, 'barolo')).toBe(false);
+    expect(bottleMatchesSearch(bottle, '1999')).toBe(false);
+  });
+
+  it('empty or whitespace-only term matches everything', () => {
+    expect(bottleMatchesSearch(bottle, '')).toBe(true);
+    expect(bottleMatchesSearch(bottle, '   ')).toBe(true);
+    expect(bottleMatchesSearch(bottle, null)).toBe(true);
+  });
+
+  it('survives bottles with missing wineDefinition or fields', () => {
+    expect(bottleMatchesSearch({}, 'margaux')).toBe(false);
+    expect(bottleMatchesSearch({ vintage: '2015' }, '2015')).toBe(true);
+    expect(bottleMatchesSearch(null, 'margaux')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The rack views showed *where* bottles are, but not *what matters*. This adds **lenses + search** to the flat rack page **and the 3D room**.

### Lenses ("Color by")
Segmented pill control recolors slots/bottles by:
- **Wine type** — default; identical to the old rendering
- **Drink window** — not ready / early / **peak** / late / declining / no data, same hues as the bottle-list maturity badges
- **Bottle age** — 5 age buckets on a single-hue ramp, NV/unknown neutral
- **My rating** — normalized across rating scales (5★/10/20/100) into 4 quality buckets + not rated

Color legend below the control; lens choice persists per device and is **shared between the flat view and the 3D room**.

### In-rack search
Pill search field (icon + clear button) dims non-matching slots (matches wine name, producer, appellation, country, region, grapes, vintage). Every rack **tab shows a live match count**, so cross-rack hits are visible. In the **3D room**, non-matching bottles grey out and matches stay lit — the room reads as a heatmap under a lens (bottles re-tint glass + wine + glow). Room search is debounced 250 ms so hundreds of bottle materials aren't re-tinted per keystroke; the overlay bar shows in view mode only.

The 3D **shelf** view (racks page, shelf racks) is the one mode still without lenses — the toolbar hides itself there.

## Backend

Racks responses (`GET /api/racks` + all 5 rack/slot mutation endpoints) now attach `maturityStatus` per slot bottle via a shared `withMaturity()` serializer — same `classifyMaturity`/`buildProfileMap` logic the cellar list already uses. One extra indexed `WineVintageProfile` query per rack response.

## Docker / compose impact

None — no new dependencies, env vars, or compose changes.

## Testing

- New `rackLens` unit suite: 26 tests (bucket boundaries, scale normalization, neutral fallbacks, search matching)
- Full suites green: frontend 578/578, backend 1268/1268
- Vite production build compiles
- Docker e2e: rack created via API, bottle assigned → `maturityStatus` present in PUT + GET responses (null without profile, `peak` after setting a 2024–2028 personal window); smoke rack cleaned up
- Manual: toolbar polish + 3D room verified in local Docker

⚠️ Swedish strings (rackLens section) are machine-authored — please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)