### PR TITLE
feat: drag & drop bottles between rack slots (move + swap)

### DIFF
--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -372,6 +372,61 @@ router.put('/:id/slots/:position', async (req, res) => {
   }
 });
 
+// POST /api/racks/:id/slots/:position/move  — move a bottle to another slot
+// in the same rack (owner or editor). Body: { toPosition }. If the target
+// slot is occupied the two bottles swap. One save() under the rack's
+// optimistic-concurrency guard, so the move/swap is atomic.
+router.post('/:id/slots/:position/move', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const from = parseInt(req.params.position, 10);
+    const to = parseInt(req.body?.toPosition, 10);
+    if (isNaN(from) || isNaN(to)) return res.status(400).json({ error: 'Invalid position' });
+    if (from === to) return res.status(400).json({ error: 'Source and target are the same slot' });
+
+    const rack = await Rack.findOne({ _id: req.params.id, deletedAt: null });
+    if (!rack) return res.status(404).json({ error: 'Rack not found' });
+
+    const cellarDoc = await Cellar.findById(rack.cellar);
+    const role = getCellarRole(cellarDoc, req.user.id);
+    if (!role || role === 'viewer') {
+      return res.status(403).json({ error: 'Not authorized to modify rack slots' });
+    }
+
+    const maxPos = getMaxPosition(rack);
+    if (from < 1 || from > maxPos || to < 1 || to > maxPos) {
+      return res.status(400).json({ error: `Position must be 1–${maxPos}` });
+    }
+    // Only the target needs the disabled check — an occupied source slot
+    // that was later disabled must still be allowed to move its bottle out.
+    if ((rack.disabledPositions || []).includes(to)) {
+      return res.status(400).json({ error: 'This slot is disabled' });
+    }
+
+    const fromSlot = rack.slots.find(s => s.position === from);
+    if (!fromSlot) return res.status(400).json({ error: 'Source slot is empty' });
+    const toSlot = rack.slots.find(s => s.position === to);
+
+    fromSlot.position = to;
+    if (toSlot) toSlot.position = from; // occupied target → swap
+    await rack.save();
+
+    await rack.populate({
+      path: 'slots.bottle',
+      populate: { path: 'wineDefinition', populate: ['country', 'region', 'grapes'] }
+    });
+
+    logAudit(req, 'rack.slot_move', { type: 'rack', id: rack._id }, { from, to, swapped: !!toSlot });
+    res.json({ rack: await withMaturity(rack) });
+  } catch (err) {
+    if (err.name === 'VersionError') {
+      return res.status(409).json({ error: 'This rack was modified by another request. Please refresh and try again.' });
+    }
+    console.error('Move slot error:', err);
+    res.status(500).json({ error: 'Failed to move bottle' });
+  }
+});
+
 // DELETE /api/racks/:id/slots/:position  — clear a slot (owner or editor)
 router.delete('/:id/slots/:position', async (req, res) => {
   try {

--- a/frontend/src/api/racks.js
+++ b/frontend/src/api/racks.js
@@ -16,6 +16,13 @@ export const updateSlot = (apiFetch, rackId, position, data) =>
 export const clearSlot = (apiFetch, rackId, position) =>
   apiFetch(`/api/racks/${rackId}/slots/${position}`, { method: 'DELETE' });
 
+export const moveSlot = (apiFetch, rackId, fromPosition, toPosition) =>
+  apiFetch(`/api/racks/${rackId}/slots/${fromPosition}/move`, {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ toPosition }),
+  });
+
 export const disableSlot = (apiFetch, rackId, position) =>
   apiFetch(`/api/racks/${rackId}/slots/${position}/disable`, { method: 'POST' });
 

--- a/frontend/src/components/racks/RackRenderer.css
+++ b/frontend/src/components/racks/RackRenderer.css
@@ -102,3 +102,14 @@
 .rack-slot-g {
   transition: opacity 0.15s ease;
 }
+
+/* While a bottle is being dragged: no text selection, grabbing cursor */
+.rack-svg--dragging {
+  user-select: none;
+  -webkit-user-select: none;
+  cursor: grabbing;
+}
+
+.rack-svg--dragging .rack-slot-g {
+  cursor: grabbing !important;
+}

--- a/frontend/src/components/racks/RackRenderer.js
+++ b/frontend/src/components/racks/RackRenderer.js
@@ -1,6 +1,7 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { computeLayout, computeModularLayout, SLOT_RADIUS, CELL_SIZE } from '../../utils/rackLayouts';
+import useSlotDrag from '../../hooks/useSlotDrag';
 import './RackRenderer.css';
 
 const WINE_COLORS = {
@@ -75,11 +76,13 @@ export default function RackRenderer({
   activePosition,
   highlightPos,
   onSlotClick,
+  onSlotMove,
   onDelete,
   onNfcLink,
   getSlotStyle,
 }) {
   const { t } = useTranslation();
+  const svgRef = useRef(null);
   const isModular = rack.isModular && rack.modules?.length > 0;
   const layout = useMemo(
     () => isModular
@@ -102,6 +105,48 @@ export default function RackRenderer({
 
   const activePos = activeRackId === rack._id ? activePosition : null;
   const R = SLOT_RADIUS;
+
+  // Actual rendered slot centers (mirrors the render logic below, including
+  // the sub-circle offsets of multi-bottle cells) — the drag hit map.
+  const slotCenters = useMemo(() => {
+    const bpc = layout.bottlesPerCell || 1;
+    const backR = layout.backRadius;
+    if (bpc === 1) {
+      return layout.slots.map(s => ({
+        position: s.position, cx: s.cx, cy: s.cy, r: s.isBack && backR ? backR : R,
+      }));
+    }
+    const cellMap = {};
+    layout.slots.forEach(s => {
+      const key = `${s.cx},${s.cy}`;
+      if (!cellMap[key]) cellMap[key] = { cx: s.cx, cy: s.cy, isBack: !!s.isBack, positions: [] };
+      cellMap[key].positions.push(s.position);
+    });
+    const centers = [];
+    Object.values(cellMap).forEach(cell => {
+      const useR = cell.isBack && backR ? getSubRadius(bpc, backR) : getSubRadius(bpc, R);
+      const useOff = cell.isBack && backR ? getSubOffsets(bpc, backR) : getSubOffsets(bpc, R);
+      cell.positions.forEach((pos, idx) => {
+        const off = useOff[idx] || { dx: 0, dy: 0 };
+        centers.push({ position: pos, cx: cell.cx + off.dx, cy: cell.cy + off.dy, r: useR });
+      });
+    });
+    return centers;
+  }, [layout, R]);
+
+  const { drag, startDrag, shouldSuppressClick } = useSlotDrag({
+    svgRef,
+    slotCenters,
+    isValidTarget: (pos) => !disabledSet.has(pos),
+    onMove: onSlotMove,
+    enabled: !!onSlotMove,
+  });
+
+  // A click that lands right after a drop must not open the slot popup.
+  const handleSlotClick = (pos, slotData) => {
+    if (shouldSuppressClick()) return;
+    onSlotClick(pos, slotData);
+  };
 
   return (
     <div className="rack-container card">
@@ -147,8 +192,9 @@ export default function RackRenderer({
 
       <div className="rack-svg-wrapper">
         <svg
+          ref={svgRef}
           viewBox={`0 0 ${layout.viewBox.width} ${layout.viewBox.height}`}
-          className="rack-svg"
+          className={`rack-svg ${drag ? 'rack-svg--dragging' : ''}`}
           role="group"
           aria-label={`${rack.name} rack`}
         >
@@ -230,8 +276,11 @@ export default function RackRenderer({
                   disabled={disabledSet.has(position)}
                   isActive={activePos === position}
                   isHighlight={highlightPos === position}
-                  onSlotClick={onSlotClick}
+                  onSlotClick={handleSlotClick}
                   getSlotStyle={getSlotStyle}
+                  onDragStart={onSlotMove ? startDrag : undefined}
+                  isDragOrigin={drag?.from === position}
+                  isDragTarget={drag?.over === position}
                 />
               ));
             }
@@ -287,14 +336,39 @@ export default function RackRenderer({
                         disabled={disabledSet.has(pos)}
                         isActive={activePos === pos}
                         isHighlight={highlightPos === pos}
-                        onSlotClick={onSlotClick}
+                        onSlotClick={handleSlotClick}
                         getSlotStyle={getSlotStyle}
+                        onDragStart={onSlotMove ? startDrag : undefined}
+                        isDragOrigin={drag?.from === pos}
+                        isDragTarget={drag?.over === pos}
                       />
                     );
                   })}
                 </g>
               );
             });
+          })()}
+
+          {/* Drag ghost — a floating bottle that follows the pointer */}
+          {drag && (() => {
+            const originSlot = slotMap[drag.from];
+            const wine = originSlot?.bottle?.wineDefinition;
+            const colors = WINE_COLORS[wine?.type || 'red'] || WINE_COLORS.red;
+            const custom = getSlotStyle && originSlot ? getSlotStyle(originSlot) : null;
+            const r = slotCenters.find(s => s.position === drag.from)?.r || R;
+            return (
+              <g pointerEvents="none">
+                <circle cx={drag.x + 1} cy={drag.y + 2} r={r} fill="rgba(0,0,0,0.15)" />
+                <circle
+                  cx={drag.x} cy={drag.y} r={r}
+                  fill={custom?.fill || colors.fill}
+                  stroke={custom?.stroke || colors.stroke}
+                  strokeWidth={1.5}
+                  opacity={0.85}
+                />
+                <circle cx={drag.x} cy={drag.y} r={r * 0.3} fill="rgba(0,0,0,0.4)" />
+              </g>
+            );
           })()}
         </svg>
       </div>
@@ -303,14 +377,17 @@ export default function RackRenderer({
 }
 
 /** Single slot circle (bpc=1 standard rendering) */
-function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight, onSlotClick, getSlotStyle }) {
+function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight, onSlotClick, getSlotStyle, onDragStart, isDragOrigin, isDragTarget }) {
   const wine = slot?.bottle?.wineDefinition;
   const wineType = wine?.type || 'red';
   const colors = slot ? (WINE_COLORS[wineType] || WINE_COLORS.red) : null;
   // Lens/search style: overrides fill/stroke for filled slots, dims
   // non-matching slots while a search is active.
   const custom = getSlotStyle ? getSlotStyle(slot || null) : null;
-  const dimStyle = custom?.dim ? { opacity: 0.22 } : null;
+  // Drag origin fades harder than a search dim so the "lifted" bottle reads
+  // as coming from that slot.
+  const dimStyle = isDragOrigin ? { opacity: 0.3 } : custom?.dim ? { opacity: 0.22 } : null;
+  const draggable = !!(slot && onDragStart);
 
   // Disabled (unusable) position: greyed circle with a subtle diagonal cross.
   // Still clickable so editors can re-enable it from the slot popup.
@@ -349,10 +426,11 @@ function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight
       className={`rack-slot-g ${slot ? 'filled' : 'empty'} ${isActive ? 'active' : ''} ${isHighlight ? 'highlighted' : ''}`}
       onClick={() => onSlotClick(position, slot || null)}
       onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onSlotClick(position, slot || null)}
+      onPointerDown={draggable ? (e) => onDragStart(e, position) : undefined}
       role="button"
       tabIndex={0}
       aria-label={slot ? `${wine?.name || '?'} (${slot.bottle?.vintage || ''})` : `Empty slot ${position}`}
-      style={{ cursor: 'pointer', ...dimStyle }}
+      style={{ cursor: draggable ? 'grab' : 'pointer', ...dimStyle }}
     >
       <circle cx={cx + 1} cy={cy + 1} r={R} fill="rgba(0,0,0,0.08)" pointerEvents="none" />
       <circle
@@ -372,6 +450,9 @@ function SlotCircle({ position, cx, cy, R, slot, disabled, isActive, isHighlight
       )}
       {isHighlight && (
         <circle cx={cx} cy={cy} r={R + 4} fill="none" stroke={ACTIVE_STROKE} strokeWidth={2} className="highlight-ring" />
+      )}
+      {isDragTarget && (
+        <circle cx={cx} cy={cy} r={R + 3} fill="none" stroke={ACTIVE_STROKE} strokeWidth={2.5} strokeDasharray="5 3" />
       )}
     </g>
   );

--- a/frontend/src/components/racks/ShelfView.css
+++ b/frontend/src/components/racks/ShelfView.css
@@ -103,3 +103,14 @@
 .shelf-view-bottle {
   transition: opacity 0.15s ease;
 }
+
+/* While a bottle is being dragged: no text selection, grabbing cursor */
+.shelf-view-svg--dragging {
+  user-select: none;
+  -webkit-user-select: none;
+  cursor: grabbing;
+}
+
+.shelf-view-svg--dragging .shelf-view-bottle {
+  cursor: grabbing !important;
+}

--- a/frontend/src/components/racks/ShelfView.js
+++ b/frontend/src/components/racks/ShelfView.js
@@ -1,4 +1,5 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
+import useSlotDrag from '../../hooks/useSlotDrag';
 import './ShelfView.css';
 
 const WINE_COLORS = {
@@ -23,8 +24,9 @@ const SHELF_LABEL_W = 64;
  * Designed for Oeno-style cabinets but works for any rack with type === 'shelf'.
  * Falls back to a friendly message for other rack types.
  */
-export default function ShelfView({ rack, activePosition, highlightPos, onSlotClick, getSlotStyle }) {
+export default function ShelfView({ rack, activePosition, highlightPos, onSlotClick, getSlotStyle, onSlotMove }) {
   const [layerMode, setLayerMode] = useState('front');
+  const svgRef = useRef(null);
   // All hooks must run before the non-shelf early return below, or a rack
   // type change on a mounted instance breaks the Rules of Hooks.
   const slotMap = useMemo(() => {
@@ -38,18 +40,11 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
     [rack?.disabledPositions]
   );
 
-  if (rack?.type !== 'shelf') {
-    return (
-      <div className="shelf-view-empty">
-        Shelf view is only available for Open Shelf racks. Switch back to the compact view to see this rack.
-      </div>
-    );
-  }
-
-  const cols = rack.cols || 0;
-  const backCols = rack.typeConfig?.backCols || 0;
-  const bpc = rack.typeConfig?.bottlesPerCell || 1;
-  const rows = rack.rows || 0;
+  const isShelf = rack?.type === 'shelf';
+  const cols = rack?.cols || 0;
+  const backCols = rack?.typeConfig?.backCols || 0;
+  const bpc = rack?.typeConfig?.bottlesPerCell || 1;
+  const rows = rack?.rows || 0;
   const slotsPerShelf = (cols + backCols) * bpc;
   const hasBack = backCols > 0;
 
@@ -64,6 +59,48 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
   const shelfRowWidth = SHELF_LABEL_W + layerCols * layerBpc * (BOTTLE_RX * 2 + BOTTLE_GAP) + BOTTLE_GAP;
   const shelfRowHeight = BOTTLE_RY * 2 + SHELF_PAD_Y * 2;
   const totalHeight = rows * shelfRowHeight;
+
+  // Absolute svg coords of every visible oval on the active layer — the
+  // drag hit map (mirrors the geometry in the render loop below).
+  const slotCenters = useMemo(() => {
+    const centers = [];
+    const count = (layerMode === 'front' ? cols : backCols) * bpc;
+    const offset = layerMode === 'front' ? 0 : cols * bpc;
+    for (let displayIdx = 0; displayIdx < rows; displayIdx++) {
+      const shelfBase = displayIdx * slotsPerShelf;
+      for (let c = 1; c <= count; c++) {
+        centers.push({
+          position: shelfBase + offset + c,
+          cx: SHELF_LABEL_W + BOTTLE_GAP + BOTTLE_RX + (c - 1) * (BOTTLE_RX * 2 + BOTTLE_GAP),
+          cy: displayIdx * shelfRowHeight + shelfRowHeight / 2,
+          r: BOTTLE_RY,
+        });
+      }
+    }
+    return centers;
+  }, [rows, cols, backCols, bpc, slotsPerShelf, layerMode, shelfRowHeight]);
+
+  const { drag, startDrag, shouldSuppressClick } = useSlotDrag({
+    svgRef,
+    slotCenters,
+    isValidTarget: (pos) => !disabledSet.has(pos),
+    onMove: onSlotMove,
+    enabled: !!onSlotMove && isShelf,
+  });
+
+  // A click that lands right after a drop must not open the slot popup.
+  const handleSlotClick = (pos, slotData) => {
+    if (shouldSuppressClick()) return;
+    if (onSlotClick) onSlotClick(pos, slotData);
+  };
+
+  if (!isShelf) {
+    return (
+      <div className="shelf-view-empty">
+        Shelf view is only available for Open Shelf racks. Switch back to the compact view to see this rack.
+      </div>
+    );
+  }
 
   const shelves = [];
   for (let displayIdx = 0; displayIdx < rows; displayIdx++) {
@@ -111,7 +148,8 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
         <div className="shelf-view-empty">This shelf has no {layerMode} cells.</div>
       ) : (
         <svg
-          className="shelf-view-svg"
+          ref={svgRef}
+          className={`shelf-view-svg ${drag ? 'shelf-view-svg--dragging' : ''}`}
           viewBox={`0 0 ${shelfRowWidth} ${totalHeight}`}
           width="100%"
         >
@@ -150,20 +188,44 @@ export default function ShelfView({ rack, activePosition, highlightPos, onSlotCl
                     disabled={disabledSet.has(s.position)}
                     isActive={activePosition === s.position}
                     isHighlight={highlightPos === s.position}
-                    onClick={() => onSlotClick && onSlotClick(s.position, s.slot || null)}
+                    onClick={() => handleSlotClick(s.position, s.slot || null)}
                     getSlotStyle={getSlotStyle}
+                    onDragStart={onSlotMove ? startDrag : undefined}
+                    isDragOrigin={drag?.from === s.position}
+                    isDragTarget={drag?.over === s.position}
                   />
                 );
               })}
             </g>
           ))}
+
+          {/* Drag ghost — a floating oval that follows the pointer */}
+          {drag && (() => {
+            const originSlot = slotMap[drag.from];
+            const wineType = originSlot?.bottle?.wineDefinition?.type || 'red';
+            const colors = WINE_COLORS[wineType] || WINE_COLORS.red;
+            const custom = getSlotStyle && originSlot ? getSlotStyle(originSlot) : null;
+            return (
+              <g pointerEvents="none">
+                <ellipse cx={drag.x + 0.5} cy={drag.y + 1.5} rx={BOTTLE_RX} ry={BOTTLE_RY} fill="rgba(0,0,0,0.12)" />
+                <ellipse
+                  cx={drag.x} cy={drag.y}
+                  rx={BOTTLE_RX} ry={BOTTLE_RY}
+                  fill={custom?.fill || colors.fill}
+                  stroke={custom?.stroke || colors.stroke}
+                  strokeWidth={1.5}
+                  opacity={0.85}
+                />
+              </g>
+            );
+          })()}
         </svg>
       )}
     </div>
   );
 }
 
-function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, onClick, getSlotStyle }) {
+function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, onClick, getSlotStyle, onDragStart, isDragOrigin, isDragTarget }) {
   const bottle = slot?.bottle;
   const wine = bottle?.wineDefinition;
   const wineType = wine?.type || 'red';
@@ -172,7 +234,10 @@ function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, o
   // Lens/search style: overrides fill/stroke/text for filled ovals, dims
   // non-matching slots while a search is active.
   const custom = getSlotStyle ? getSlotStyle(slot || null) : null;
-  const dimStyle = custom?.dim ? { opacity: 0.22 } : null;
+  // Drag origin fades harder than a search dim so the "lifted" bottle reads
+  // as coming from that slot.
+  const dimStyle = isDragOrigin ? { opacity: 0.3 } : custom?.dim ? { opacity: 0.22 } : null;
+  const draggable = !!(filled && onDragStart);
 
   // Disabled (unusable) position: greyed oval with a subtle diagonal cross.
   // Still clickable so editors can re-enable it from the slot popup.
@@ -214,11 +279,12 @@ function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, o
     <g
       onClick={onClick}
       onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onClick?.()}
+      onPointerDown={draggable ? (e) => onDragStart(e, position) : undefined}
       role="button"
       tabIndex={0}
       className={`shelf-view-bottle ${filled ? 'filled' : 'empty'} ${isActive ? 'active' : ''} ${isHighlight ? 'highlight' : ''}`}
       aria-label={filled ? `${wine?.name || 'Wine'} ${bottle?.vintage || ''}` : `Empty slot ${position}`}
-      style={dimStyle || undefined}
+      style={{ ...(draggable ? { cursor: 'grab' } : null), ...dimStyle }}
     >
       <ellipse
         cx={cx + 0.5}
@@ -270,6 +336,16 @@ function BottleOval({ cx, cy, slot, position, disabled, isActive, isHighlight, o
         >
           {position}
         </text>
+      )}
+      {isDragTarget && (
+        <ellipse
+          cx={cx} cy={cy}
+          rx={BOTTLE_RX + 3} ry={BOTTLE_RY + 3}
+          fill="none"
+          stroke="#7A1E2D"
+          strokeWidth={2.5}
+          strokeDasharray="5 3"
+        />
       )}
     </g>
   );

--- a/frontend/src/hooks/useSlotDrag.js
+++ b/frontend/src/hooks/useSlotDrag.js
@@ -1,0 +1,115 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+/**
+ * Find the slot whose center is nearest to (x, y) within its own hit radius
+ * (scaled by `factor` to be a little forgiving). Returns the slot's position
+ * or null. Pure — exported for tests.
+ */
+export function findNearestSlot(slotCenters, x, y, { exclude = null, factor = 1.2 } = {}) {
+  let best = null;
+  let bestD = Infinity;
+  for (const s of slotCenters) {
+    if (s.position === exclude) continue;
+    const dx = s.cx - x;
+    const dy = s.cy - y;
+    const d = dx * dx + dy * dy;
+    const hit = s.r * factor;
+    if (d <= hit * hit && d < bestD) {
+      bestD = d;
+      best = s.position;
+    }
+  }
+  return best;
+}
+
+/**
+ * Pointer-based drag & drop between the slots of an SVG rack renderer.
+ *
+ * Mouse/pen only — on touch the tap→popup flow already covers moving a
+ * bottle, and capturing touch drags would fight page scrolling.
+ *
+ * A drag only begins once the pointer travels past a small threshold, so
+ * plain clicks still open the slot popup; after a drop the next click on
+ * the rack is suppressed (shouldSuppressClick) so the popup doesn't open
+ * on top of the just-finished drag.
+ *
+ * @param {object}   opts
+ * @param {object}   opts.svgRef        ref to the <svg> element (viewBox coords)
+ * @param {Array}    opts.slotCenters   [{ position, cx, cy, r }] in viewBox coords
+ * @param {Function} opts.isValidTarget (position) => boolean
+ * @param {Function} opts.onMove        (fromPosition, toPosition) => void
+ * @param {boolean}  opts.enabled
+ * @returns {{ drag: null | { from, x, y, over }, startDrag, shouldSuppressClick }}
+ */
+export default function useSlotDrag({ svgRef, slotCenters, isValidTarget, onMove, enabled }) {
+  const [drag, setDrag] = useState(null);
+  const pendingRef = useRef(null); // pointer down on a slot, threshold not yet passed
+  const dragRef = useRef(null);
+  const suppressUntilRef = useRef(0);
+
+  const toSvgPoint = useCallback((clientX, clientY) => {
+    const svg = svgRef.current;
+    const ctm = svg?.getScreenCTM();
+    if (!ctm) return null;
+    const pt = new DOMPoint(clientX, clientY).matrixTransform(ctm.inverse());
+    return { x: pt.x, y: pt.y };
+  }, [svgRef]);
+
+  const findTarget = useCallback((x, y, from) => {
+    const pos = findNearestSlot(slotCenters, x, y, { exclude: from });
+    return pos != null && isValidTarget(pos) ? pos : null;
+  }, [slotCenters, isValidTarget]);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    const onPointerMove = (e) => {
+      const pending = pendingRef.current;
+      if (pending && !dragRef.current) {
+        const dx = e.clientX - pending.clientX;
+        const dy = e.clientY - pending.clientY;
+        if (dx * dx + dy * dy < 36) return; // < 6px — still a click
+        dragRef.current = { from: pending.from };
+      }
+      if (!dragRef.current) return;
+      const p = toSvgPoint(e.clientX, e.clientY);
+      if (!p) return;
+      setDrag({
+        from: dragRef.current.from,
+        x: p.x,
+        y: p.y,
+        over: findTarget(p.x, p.y, dragRef.current.from),
+      });
+    };
+
+    const onPointerUp = (e) => {
+      const active = dragRef.current;
+      pendingRef.current = null;
+      dragRef.current = null;
+      if (!active) return;
+      suppressUntilRef.current = Date.now() + 400;
+      setDrag(null);
+      const p = toSvgPoint(e.clientX, e.clientY);
+      const target = p ? findTarget(p.x, p.y, active.from) : null;
+      if (target != null) onMove(active.from, target);
+    };
+
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [enabled, toSvgPoint, findTarget, onMove]);
+
+  const startDrag = useCallback((e, position) => {
+    if (!enabled || e.pointerType === 'touch' || e.button !== 0) return;
+    pendingRef.current = { from: position, clientX: e.clientX, clientY: e.clientY };
+  }, [enabled]);
+
+  const shouldSuppressClick = useCallback(() => Date.now() < suppressUntilRef.current, []);
+
+  return { drag, startDrag, shouldSuppressClick };
+}

--- a/frontend/src/hooks/useSlotDrag.test.js
+++ b/frontend/src/hooks/useSlotDrag.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { findNearestSlot } from './useSlotDrag';
+
+const centers = [
+  { position: 1, cx: 40, cy: 40, r: 20 },
+  { position: 2, cx: 88, cy: 40, r: 20 },
+  { position: 3, cx: 136, cy: 40, r: 20 },
+];
+
+describe('findNearestSlot', () => {
+  it('returns the slot whose center is hit exactly', () => {
+    expect(findNearestSlot(centers, 40, 40)).toBe(1);
+    expect(findNearestSlot(centers, 88, 40)).toBe(2);
+  });
+
+  it('hits within the scaled radius (default 1.2×r)', () => {
+    expect(findNearestSlot(centers, 40 + 23, 40)).toBe(1); // 23 < 24
+    expect(findNearestSlot(centers, 40, 40 + 25)).toBeNull(); // 25 > 24
+  });
+
+  it('picks the nearest when hit zones overlap between two slots', () => {
+    // x=62 is 22 from slot 1 and 26 from slot 2 — both within 24? 26 is not.
+    // Use x=64: 24 from both — tie broken by first-nearest (strictly closer wins).
+    expect(findNearestSlot(centers, 62, 40)).toBe(1);
+    expect(findNearestSlot(centers, 66, 40)).toBe(2);
+  });
+
+  it('excludes the dragged slot itself', () => {
+    expect(findNearestSlot(centers, 40, 40, { exclude: 1 })).toBeNull();
+    // A point in slot 2's hit zone but nearer to excluded slot 1 resolves to 2
+    expect(findNearestSlot(centers, 66, 40, { exclude: 1 })).toBe(2);
+  });
+
+  it('respects per-slot radii', () => {
+    const mixed = [
+      { position: 1, cx: 40, cy: 40, r: 20 },
+      { position: 2, cx: 80, cy: 40, r: 10 }, // small back-row slot
+    ];
+    expect(findNearestSlot(mixed, 80, 40 + 13)).toBeNull(); // 13 > 12
+    expect(findNearestSlot(mixed, 80, 40 + 11)).toBe(2);    // 11 < 12
+  });
+
+  it('returns null for empty center lists', () => {
+    expect(findNearestSlot([], 40, 40)).toBeNull();
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2219,6 +2219,7 @@
   },
 
   "rackLens": {
+    "dragHint": "Tip: drag a bottle to an empty slot to move it, onto another bottle to swap them.",
     "searchPlaceholder": "Find in racks…",
     "colorBy": "Color by",
     "lensType": "Wine type",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2219,6 +2219,7 @@
   },
 
   "rackLens": {
+    "dragHint": "Tips: dra en flaska till en tom plats för att flytta den, eller släpp den på en annan flaska för att byta plats.",
     "searchPlaceholder": "Sök i hyllorna…",
     "colorBy": "Färglägg efter",
     "lensType": "Vintyp",

--- a/frontend/src/pages/CellarRacks.css
+++ b/frontend/src/pages/CellarRacks.css
@@ -675,3 +675,16 @@
   background: rgba(var(--color-primary-rgb), 0.25);
   color: var(--color-primary);
 }
+
+/* Drag & drop hint — pointless on touch devices (drag is mouse/pen only) */
+.rack-drag-hint {
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+  margin: -0.35rem 0 0.75rem;
+}
+
+@media (hover: none) {
+  .rack-drag-hint {
+    display: none;
+  }
+}

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -3,7 +3,7 @@ import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { getCellar } from '../api/cellars';
-import { getRacks, deleteRack, updateSlot, clearSlot, createRack, updateRack, disableSlot, enableSlot } from '../api/racks';
+import { getRacks, deleteRack, updateSlot, clearSlot, moveSlot, createRack, updateRack, disableSlot, enableSlot } from '../api/racks';
 import { consumeBottle } from '../api/bottles';
 import { getTotalSlots, getModularTotalSlots } from '../utils/rackLayouts';
 import RackRenderer from '../components/racks/RackRenderer';
@@ -331,6 +331,21 @@ function CellarRacks() {
     }
   };
 
+  // --- drag & drop: move a bottle to another slot / swap two bottles ---
+  const handleSlotMove = async (rackId, fromPosition, toPosition) => {
+    try {
+      const res = await moveSlot(apiFetch, rackId, fromPosition, toPosition);
+      const data = await res.json();
+      if (res.ok) {
+        setRacks(prev => prev.map(r => r._id === rackId ? data.rack : r));
+      } else {
+        alert(data.error || 'Failed to move bottle');
+      }
+    } catch {
+      alert('Network error — please try again.');
+    }
+  };
+
   // --- NFC: save or clear rfidTag on rack ---
   const handleNfcSave = async (rackId, rfidTag) => {
     try {
@@ -482,6 +497,11 @@ function CellarRacks() {
                   </span>
                 ))}
               </div>
+              {canEdit && (
+                <p className="rack-drag-hint">
+                  {t('rackLens.dragHint', 'Tip: drag a bottle to an empty slot to move it, onto another bottle to swap them.')}
+                </p>
+              )}
             </>
           )}
           {rack.type === 'shelf' && !rack.isModular && (
@@ -531,6 +551,7 @@ function CellarRacks() {
                 highlightPos: highlightPos?.rackId === rack._id ? highlightPos.position : null,
                 onSlotClick: handleClick,
                 getSlotStyle,
+                onSlotMove: canEdit ? (from, to) => handleSlotMove(rack._id, from, to) : undefined,
               };
               if (viewMode === '3d') {
                 return (
@@ -549,6 +570,7 @@ function CellarRacks() {
               activePosition={activePopup?.position}
               highlightPos={highlightPos?.rackId === rack._id ? highlightPos.position : null}
               getSlotStyle={getSlotStyle}
+              onSlotMove={canEdit ? (from, to) => handleSlotMove(rack._id, from, to) : undefined}
               onSlotClick={(pos, slotData) => {
                 // Viewers can only inspect filled or disabled slots, not interact with empty ones
                 const isDisabled = (rack.disabledPositions || []).includes(pos);


### PR DESCRIPTION
## What

**Step 4 of the rack roadmap** — reorganizing a rack no longer takes four clicks per bottle:

- **Drag a bottle to an empty slot** → it moves there.
- **Drop it on another bottle** → the two **swap**.
- Works in the **compact** rack view and the **shelf** view (within the visible layer). Ghost bottle follows the pointer (lens-colored when a lens is active), a dashed ring marks the drop target, and the origin slot fades while "lifted".
- Plain clicks still open the slot popup: a drag only starts after a 6 px movement threshold, and the click that lands right after a drop is suppressed.
- **Mouse/pen only** — on touch, capturing drags would fight page scrolling, and the tap → popup → assign flow already covers moves there. Editors see a one-line hint (hidden on touch devices).

## Backend

New `POST /api/racks/:id/slots/:position/move` with body `{ toPosition }`:
- Move **or swap in one `save()`** under the rack''s optimistic-concurrency guard — atomic, no clear+assign race, 409 on concurrent modification like the other slot endpoints.
- Validates position range and disabled **target** (a bottle on a since-disabled slot may still move out), 400 on empty source; audit-logs `rack.slot_move` with `{ from, to, swapped }`.
- Response goes through the same `withMaturity()` serializer, so lens data survives the update.

## Docker / compose impact

None — no new dependencies, env vars, or compose changes.

## Testing

- `findNearestSlot` hit-testing unit tests (radius scaling, per-slot radii, exclusion, overlap resolution)
- Full suites green: frontend 596/596, backend 1268/1268; Vite build compiles
- Docker e2e: move to empty slot ✓, swap two occupied slots ✓, empty source → 400 ✓, out-of-range → 400 ✓ (smoke rack cleaned up)
- Manual drag/swap verified in local Docker

⚠️ Swedish string (`rackLens.dragHint`) is machine-authored — please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)