### PR TITLE
fix: pass data: URLs through getWineImageUrl unchanged

### DIFF
--- a/frontend/src/utils/wineImageUrl.js
+++ b/frontend/src/utils/wineImageUrl.js
@@ -4,14 +4,16 @@ import { API_URL } from '../api/apiConstants';
  * Resolves a wine image field value into a full URL.
  * Returns null when there is no image.
  *
- * Handles three formats stored in the DB:
+ * Handles four formats stored in the DB:
  *  - Full external URL  ("http…")  → returned as-is
+ *  - Inline data URL    ("data:…") → returned as-is
  *  - Internal API path  ("/api/…") → prefixed with API_URL
  *  - Plain filename     ("abc.png")→ prefixed with API_URL + /api/uploads/
  */
 export function getWineImageUrl(image) {
   if (!image) return null;
   if (image.startsWith('http')) return image;
+  if (image.startsWith('data:')) return image;
   if (image.startsWith('/api/')) return `${API_URL}${image}`;
   return `${API_URL}/api/uploads/${image}`;
 }

--- a/frontend/src/utils/wineImageUrl.test.js
+++ b/frontend/src/utils/wineImageUrl.test.js
@@ -1,0 +1,28 @@
+import { getWineImageUrl } from './wineImageUrl';
+import { API_URL } from '../api/apiConstants';
+
+describe('getWineImageUrl', () => {
+  test('returns null for missing image', () => {
+    expect(getWineImageUrl(null)).toBeNull();
+    expect(getWineImageUrl(undefined)).toBeNull();
+    expect(getWineImageUrl('')).toBeNull();
+  });
+
+  test('passes full external URLs through unchanged', () => {
+    expect(getWineImageUrl('https://example.com/a.png')).toBe('https://example.com/a.png');
+    expect(getWineImageUrl('http://example.com/a.png')).toBe('http://example.com/a.png');
+  });
+
+  test('passes data URLs through unchanged', () => {
+    const dataUrl = 'data:image/png;base64,iVBORw0KGgo=';
+    expect(getWineImageUrl(dataUrl)).toBe(dataUrl);
+  });
+
+  test('prefixes internal API paths with API_URL', () => {
+    expect(getWineImageUrl('/api/uploads/processed/a.png')).toBe(`${API_URL}/api/uploads/processed/a.png`);
+  });
+
+  test('treats plain filenames as uploads', () => {
+    expect(getWineImageUrl('abc.png')).toBe(`${API_URL}/api/uploads/abc.png`);
+  });
+});


### PR DESCRIPTION
## What

`getWineImageUrl` handles `http…`, `/api/…`, and plain-filename image values, but a `data:image/…;base64` value fell through to the plain-filename branch and got mangled into `/api/uploads/data:image…` — a broken URL. Two wines in the registry currently store inline data URLs, and their images render broken in **WineImage**, **WineDetail**, and **AdminWines**.

## Fix

One line: return `data:` URLs as-is (they are self-contained, same as external `http` URLs). Adds `wineImageUrl.test.js` covering all four formats plus the null case.

## Testing

- `cd frontend && npm test` — suite green (new file: 5 tests)

## Docker-compose impact

None — pure frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)