### PR TITLE
feat: compact (dense) list view for bottles

### DIFF
--- a/frontend/src/components/BottleCard.css
+++ b/frontend/src/components/BottleCard.css
@@ -120,6 +120,12 @@
   margin-top: 0.3rem;
 }
 
+/* A bottle with no badges still renders the container; without this the
+   empty flex box's margin-top reserves ~5px of dead vertical space per row. */
+.bottle-badges:empty {
+  display: none;
+}
+
 /* ── Rack badge ── */
 .rack-badge {
   display: inline-block;
@@ -229,6 +235,36 @@
   color: var(--color-text-muted);
   flex-shrink: 0;
   line-height: 1;
+}
+
+/* ── Compact (dense) list rows ──
+   Opt-in via the density toggle. The 64px thumbnail is the height floor for a
+   comfortable row, so compact both trims the padding AND shrinks the image —
+   dropping rows from ~88px to ~60px to fit far more bottles on screen. */
+.bottle-card--compact {
+  padding: 0.35rem 0.75rem;
+  gap: 0.6rem;
+  min-height: 0;
+}
+
+.bottle-card--compact .bottle-wine-image,
+.bottle-card--compact .bottle-wine-placeholder {
+  width: 36px;
+  height: 52px;
+}
+
+.bottle-card--compact .bottle-name {
+  font-size: 0.9rem;
+  margin-bottom: 0.1rem;
+}
+
+.bottle-card--compact .bottle-meta {
+  font-size: 0.78rem;
+}
+
+.bottle-card--compact .bottle-badges {
+  margin-top: 0.15rem;
+  gap: 0.25rem;
 }
 
 /* ── Card grid-mode ── */

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -19,7 +19,7 @@ const MATURITY_LABELS = {
  * Renders a single bottle in either list or card (grid) view.
  * Props: bottle, rackMap, cellarId, viewMode ('list' | 'card')
  */
-function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick, showCellarBadge = false }) {
+function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick, showCellarBadge = false, compact = false }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -130,7 +130,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
   // list view (default)
   return (
     <div
-      className={`bottle-card${isGroup ? ' bottle-card--stacked' : ''}`}
+      className={`bottle-card${isGroup ? ' bottle-card--stacked' : ''}${compact ? ' bottle-card--compact' : ''}`}
       onClick={handleClick}
       role="button"
       tabIndex={0}
@@ -212,7 +212,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
 // values derived from the OTHER compared props (the bottle/group item) — if a
 // future caller closes over unrelated state, that handler must be stabilized
 // with useCallback instead.
-const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount', 'showCellarBadge'];
+const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount', 'showCellarBadge', 'compact'];
 export default memo(BottleCard, (prev, next) =>
   COMPARED_PROPS.every(key => prev[key] === next[key])
 );

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -510,6 +510,7 @@
     "noBottles": "No bottles in this cellar yet.",
     "noSearchResults": "No bottles match your search.",
     "toggleFilters": "Filters",
+    "compactView": "Compact view",
     "addFirstBottle": "Add Your First Bottle",
     "loadMore": "Load more bottles",
     "myCellarColor": "My Cellar Color",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -510,6 +510,7 @@
     "noBottles": "Inga flaskor i denna källare ännu.",
     "noSearchResults": "Inga flaskor matchar din sökning.",
     "toggleFilters": "Filter",
+    "compactView": "Kompakt vy",
     "addFirstBottle": "Lägg till din första flaska",
     "loadMore": "Ladda fler flaskor",
     "myCellarColor": "Min källarfärg",

--- a/frontend/src/pages/CellarDetail.css
+++ b/frontend/src/pages/CellarDetail.css
@@ -632,6 +632,12 @@
   background: var(--color-primary-light);
 }
 
+/* Density toggle sits just left of the list/card control (list view only),
+   separated by a small gutter so it doesn't read as part of that segmented pair. */
+.density-toggle-btn {
+  margin-right: 0.4rem;
+}
+
 /* ── Expanded bottle-group header (full-width across the grid/list) ── */
 .bottle-group-bar {
   grid-column: 1 / -1;

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -688,12 +688,23 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
   const [viewMode, setViewMode] = useState(() => {
     try { return localStorage.getItem('cellarion_bottle_view') || 'list'; } catch { return 'list'; }
   });
+  const [density, setDensity] = useState(() => {
+    try { return localStorage.getItem('cellarion_bottle_density') || 'comfortable'; } catch { return 'comfortable'; }
+  });
   const [expandedGroups, setExpandedGroups] = useState(() => new Set());
 
   const setView = (mode) => {
     setViewMode(mode);
     try { localStorage.setItem('cellarion_bottle_view', mode); } catch {}
   };
+
+  const setDens = (mode) => {
+    setDensity(mode);
+    try { localStorage.setItem('cellarion_bottle_density', mode); } catch {}
+  };
+
+  // Compact only applies to list view — the grid's height is driven by the image.
+  const compact = viewMode === 'list' && density === 'compact';
 
   const toggleGroup = (key) => {
     setExpandedGroups(prev => {
@@ -706,6 +717,17 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
   return (
     <>
       <div className="bottles-view-toggle">
+        {viewMode === 'list' && (
+          <button
+            className={`view-toggle-btn density-toggle-btn ${density === 'compact' ? 'active' : ''}`}
+            onClick={() => setDens(density === 'compact' ? 'comfortable' : 'compact')}
+            aria-label={t('cellarDetail.compactView', 'Compact view')}
+            aria-pressed={density === 'compact'}
+            title={t('cellarDetail.compactView', 'Compact view')}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="3" y1="14" x2="21" y2="14"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+          </button>
+        )}
         <button
           className={`view-toggle-btn ${viewMode === 'list' ? 'active' : ''}`}
           onClick={() => setView('list')}
@@ -736,6 +758,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                 cellarId={item.cellar || cellarId}
                 viewMode={viewMode}
                 showCellarBadge
+                compact={compact}
               />
             );
           }
@@ -744,7 +767,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
             const rep = item.bottles[0];
             if (item.count === 1) {
               return (
-                <BottleCard key={rep._id} bottle={rep} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} />
+                <BottleCard key={rep._id} bottle={rep} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} />
               );
             }
             if (!expandedGroups.has(item.key)) {
@@ -757,6 +780,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                   viewMode={viewMode}
                   groupCount={item.count}
                   onClick={() => toggleGroup(item.key)}
+                  compact={compact}
                 />
               );
             }
@@ -770,14 +794,14 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                   </button>
                 </div>
                 {item.bottles.map(b => (
-                  <BottleCard key={b._id} bottle={b} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} />
+                  <BottleCard key={b._id} bottle={b} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} />
                 ))}
               </Fragment>
             );
           }
           // Defensive fallback: a plain bottle item (responses are always grouped)
           return (
-            <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} />
+            <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} />
           );
         })}
       </div>


### PR DESCRIPTION
Part 1 of 3 from Kiet's email feedback. **Stacked PR — base `main`, merge first.**

## What
An opt-in **compact (dense) list view** for the cellar bottle list, so users with large collections fit far more bottles on screen.

Kiet (700-ish bottles incoming) noted the list rows have too much vertical padding. He's right — but the 64px thumbnail is the real height floor, so compact mode trims the row padding **and** shrinks the thumbnail (44×64 → 36×52), dropping list rows from **~88px to ~60px**.

## Details
- New `compact` prop on `BottleCard` + `.bottle-card--compact` CSS overrides (list view only — grid height is image-driven).
- A density toggle button appears next to the existing list/card toggle (list view only); the choice persists in `localStorage` alongside the view choice.
- Bonus fix: `.bottle-badges:empty { display: none }` — a bottle with no badges was still reserving ~5px per row via the empty flex box's `margin-top`.

## Testing
- `frontend` vitest: **640 passed**.
- Production build: clean.
- Not Docker-smoke-tested here (pure CSS + a localStorage toggle; recommend a quick visual check).

## docker-compose impact
**None.** Frontend-only; no service, port, or env change.
