### PR TITLE
feat: 'Unplaced' badge + filter for bottles not yet in a rack

### DIFF
--- a/frontend/src/components/BottleCard.css
+++ b/frontend/src/components/BottleCard.css
@@ -142,6 +142,19 @@
   background: rgba(var(--color-accent-rgb), 0.18);
 }
 
+/* "Unplaced" — added to the cellar but not yet assigned a rack slot. Dashed
+   border (vs the solid rack/maturity chips) reads as "pending placement". */
+.unplaced-badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 500;
+  padding: 1px 8px;
+  border-radius: var(--radius-full);
+  background: #fff3e0;
+  color: #e65100;
+  border: 1px dashed #ffb74d;
+}
+
 /* Cross-cellar view: which cellar this bottle lives in. */
 .cellar-badge {
   display: inline-flex;

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -19,7 +19,7 @@ const MATURITY_LABELS = {
  * Renders a single bottle in either list or card (grid) view.
  * Props: bottle, rackMap, cellarId, viewMode ('list' | 'card')
  */
-function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick, showCellarBadge = false, compact = false }) {
+function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick, showCellarBadge = false, compact = false, rackKnown = false }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -30,6 +30,11 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
   // A collapsed group spans multiple bottles (possibly in different racks), so a
   // single rack badge would be misleading — suppress it until the group expands.
   const rackInfo = isGroup ? null : rackMap?.get(bottle._id);
+  // "Unplaced" = the caller knows this cellar's rack layout (single-cellar view
+  // of a cellar that has racks) and this active bottle isn't in any slot — i.e.
+  // it's been added but not shelved. Suppressed for groups (members may differ)
+  // and whenever placement is unknown (cross-cellar view, or no racks exist).
+  const isUnplaced = rackKnown && !isGroup && !rackInfo && bottle.status === 'active';
   const rackNavPref = user?.preferences?.rackNavigation || 'auto';
   const imgSrc = bottle.defaultImageUrl || bottle.wineDefinition?.image || bottle.pendingImageUrl;
   const credit = bottle.defaultImageUrl ? null : bottle.wineDefinition?.imageCredit;
@@ -112,6 +117,11 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
             {!maturityInfo && bottle.maturityStatus === null && bottle.hasOwnProperty('maturityStatus') && (
               <span className="maturity-badge maturity-badge--none">{t('maturity.noData')}</span>
             )}
+            {isUnplaced && (
+              <span className="unplaced-badge" title={t('bottleCard.unplacedTooltip', 'Added but not placed in a rack')}>
+                {t('bottleCard.unplaced', 'Unplaced')}
+              </span>
+            )}
             {rackInfo && (
               <Link
                 to={buildRackUrl(cellarId, { rackId: rackInfo.rackId, bottleId: bottle._id, inRoom: rackInfo.inRoom, preference: rackNavPref })}
@@ -184,6 +194,11 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
           {!maturityInfo && bottle.maturityStatus === null && bottle.hasOwnProperty('maturityStatus') && (
             <span className="maturity-badge maturity-badge--none">{t('maturity.noData')}</span>
           )}
+          {isUnplaced && (
+            <span className="unplaced-badge" title={t('bottleCard.unplacedTooltip', 'Added but not placed in a rack')}>
+              {t('bottleCard.unplaced', 'Unplaced')}
+            </span>
+          )}
           {rackInfo && (
             <Link
               to={buildRackUrl(cellarId, { rackId: rackInfo.rackId, bottleId: bottle._id, inRoom: rackInfo.inRoom, preference: rackNavPref })}
@@ -212,7 +227,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
 // values derived from the OTHER compared props (the bottle/group item) — if a
 // future caller closes over unrelated state, that handler must be stabilized
 // with useCallback instead.
-const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount', 'showCellarBadge', 'compact'];
+const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount', 'showCellarBadge', 'compact', 'rackKnown'];
 export default memo(BottleCard, (prev, next) =>
   COMPARED_PROPS.every(key => prev[key] === next[key])
 );

--- a/frontend/src/components/BottleFilterModal.js
+++ b/frontend/src/components/BottleFilterModal.js
@@ -66,7 +66,10 @@ function FilterSection({ label, icon, children, defaultExpanded = true }) {
 // showRatingMaturity: pages whose backend endpoint doesn't support the
 // rating/maturity filters (e.g. consumed history) hide those controls —
 // rendering them would silently do nothing.
-function BottleFilterModal({ filters, onApply, onClose, facets, baseFacets, facetMeta, bottlesTotal, showRatingMaturity = true }) {
+// showUnplaced: only the single-cellar active list supports the unplaced
+// filter (placement is per-cellar; consumed bottles hold no rack slot), and
+// only when the cellar actually has racks.
+function BottleFilterModal({ filters, onApply, onClose, facets, baseFacets, facetMeta, bottlesTotal, showRatingMaturity = true, showUnplaced = false }) {
   const { t } = useTranslation();
 
   // baseFacets = all options in the cellar (unfiltered) — used to LIST available pills
@@ -85,13 +88,14 @@ function BottleFilterModal({ filters, onApply, onClose, facets, baseFacets, face
     onApply({
       ...filters,
       type: [], country: [], region: [], appellation: [], grapes: [], vintage: [],
-      minRating: '', maturity: ''
+      minRating: '', maturity: '', unplaced: ''
     });
   };
 
   const activeCount = (filters.type?.length || 0) + (filters.country?.length || 0) +
     (filters.region?.length || 0) + (filters.appellation?.length || 0) + (filters.grapes?.length || 0) +
-    (filters.vintage?.length || 0) + (filters.minRating ? 1 : 0) + (filters.maturity ? 1 : 0);
+    (filters.vintage?.length || 0) + (filters.minRating ? 1 : 0) + (filters.maturity ? 1 : 0) +
+    (filters.unplaced ? 1 : 0);
 
   // For a given facet key, decide which counts to use:
   // - If THIS category has active selections, use baseFacets (so you can still add more)
@@ -263,6 +267,19 @@ function BottleFilterModal({ filters, onApply, onClose, facets, baseFacets, face
             </FilterSection>
           );
         })()}
+
+        {/* Placement — single toggle, no facet count (Meilisearch doesn't know
+            rack placement; the filter is applied server-side after search, so
+            cascading counts in the other sections won't reflect it). */}
+        {showUnplaced && (
+          <FilterSection label={t('cellarDetail.placementLabel', 'Placement')} icon="📍">
+            <FilterPill
+              label={t('cellarDetail.unplacedOnly', 'Unplaced only')}
+              selected={!!filters.unplaced}
+              onClick={() => onApply({ ...filters, unplaced: filters.unplaced ? '' : '1' })}
+            />
+          </FilterSection>
+        )}
 
         {/* Rating + Maturity — side by side */}
         {showRatingMaturity && (

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -490,6 +490,8 @@
     "countryLabel": "Country",
     "regionLabel": "Region",
     "appellationLabel": "Appellation",
+    "placementLabel": "Placement",
+    "unplacedOnly": "Unplaced only",
     "grapeLabel": "Grapes",
     "vintageLabel": "Vintage",
     "showMore": "+{{count}} more",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3234,7 +3234,9 @@
     "openBadge": "{{glasses}} gl · {{days}}d",
     "groupTooltip": "{{count}} identical bottles — click to expand",
     "yourWindow": "your window",
-    "yourWindowTooltip": "Based on your own drink window for this bottle"
+    "yourWindowTooltip": "Based on your own drink window for this bottle",
+    "unplaced": "Unplaced",
+    "unplacedTooltip": "Added but not placed in a rack"
   },
   "followButton": {
     "follow": "Follow",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -490,6 +490,8 @@
     "countryLabel": "Länder",
     "regionLabel": "Regioner",
     "appellationLabel": "Appellation",
+    "placementLabel": "Placering",
+    "unplacedOnly": "Endast oplacerade",
     "grapeLabel": "Druvor",
     "vintageLabel": "Årgångar",
     "showMore": "+{{count}} till",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -3234,7 +3234,9 @@
     "openBadge": "{{glasses}} glas · {{days}} d",
     "groupTooltip": "{{count}} identiska flaskor — klicka för att visa alla",
     "yourWindow": "ditt fönster",
-    "yourWindowTooltip": "Baserat på ditt eget dryckesfönster för den här flaskan"
+    "yourWindowTooltip": "Baserat på ditt eget dryckesfönster för den här flaskan",
+    "unplaced": "Oplacerad",
+    "unplacedTooltip": "Tillagd men inte placerad i en ställning"
   },
   "followButton": {
     "follow": "Följ",

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -59,6 +59,7 @@ function CellarDetail() {
     vintage: searchParams.get('vintage')?.split(',').filter(Boolean) || [],
     minRating: searchParams.get('minRating') || '',
     maturity: searchParams.get('maturity') || '',
+    unplaced: searchParams.get('unplaced') || '',
     sort: searchParams.get('sort') || '-createdAt'
   }));
   const [facets, setFacets] = useState(null);
@@ -71,6 +72,7 @@ function CellarDetail() {
   const [allCellars, setAllCellars] = useState([]);
   const [scopeIds, setScopeIds] = useState([id]);
   const scopeKey = scopeIds.join(',');
+  const multiScope = !(scopeIds.length === 1 && scopeIds[0] === id);
   // Shape of the bottles CURRENTLY in state (grouped vs flat). Tracked separately
   // from the live scope selection so a scope change never renders the just-loaded
   // (old-shape) list through the wrong BottlesList branch before the refetch lands.
@@ -91,6 +93,13 @@ function CellarDetail() {
   // Reset scope to just this cellar when navigating to another cellar.
   useEffect(() => { setScopeIds([id]); }, [id]);
 
+  // The unplaced filter is single-cellar only (placement is per-cellar; the
+  // cross-cellar endpoint doesn't resolve rack slots) — drop it when the scope
+  // widens rather than leaving a chip that silently does nothing.
+  useEffect(() => {
+    if (multiScope) setFilters(prev => (prev.unplaced ? { ...prev, unplaced: '' } : prev));
+  }, [multiScope]);
+
   // Debounce the search input — only send the API call after the user stops typing
   const [debouncedSearch, setDebouncedSearch] = useState(filters.search);
   const searchTimer = useRef(null);
@@ -102,7 +111,7 @@ function CellarDetail() {
 
   // Clear URL search params after they've been read into filter state
   useEffect(() => {
-    if (searchParams.has('search') || searchParams.has('vintage') || searchParams.has('minRating') || searchParams.has('sort') || searchParams.has('type') || searchParams.has('country') || searchParams.has('region') || searchParams.has('grapes')) {
+    if (searchParams.has('search') || searchParams.has('vintage') || searchParams.has('minRating') || searchParams.has('sort') || searchParams.has('type') || searchParams.has('country') || searchParams.has('region') || searchParams.has('grapes') || searchParams.has('unplaced')) {
       setSearchParams({}, { replace: true });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -112,7 +121,7 @@ function CellarDetail() {
     debouncedSearch,
     filters.type.join(','), filters.country.join(','), filters.region.join(','),
     filters.appellation.join(','), filters.grapes.join(','), filters.vintage.join(','),
-    filters.minRating, filters.maturity, filters.sort
+    filters.minRating, filters.maturity, filters.unplaced, filters.sort
   ].join('|');
 
   // Refetch on cellar id, filters, or scope change. `id` is included so an
@@ -139,6 +148,9 @@ function CellarDetail() {
         const val = filters[key];
         if (key === 'search') {
           if (debouncedSearch) params.append('search', debouncedSearch);
+        } else if (key === 'unplaced') {
+          // Mapped to the backend's excludePlaced param below — single-cellar
+          // only (the cross-cellar endpoint doesn't resolve rack slots).
         } else if (Array.isArray(val)) {
           if (val.length > 0) params.append(key, val.join(','));
         } else if (val) {
@@ -154,6 +166,7 @@ function CellarDetail() {
         res = await getMultiCellarBottles(apiFetch, params.toString());
       } else {
         params.set('group', '1');
+        if (filters.unplaced) params.set('excludePlaced', '1');
         res = await getCellar(apiFetch, id, params);
       }
       const data = await res.json();
@@ -503,6 +516,7 @@ function CellarDetail() {
             (filters.vintage || []).forEach(v => activeChips.push({ key: 'vintage', value: v, label: v }));
             if (filters.minRating) activeChips.push({ key: 'minRating', value: filters.minRating, label: `${filters.minRating}+ rating` });
             if (filters.maturity) activeChips.push({ key: 'maturity', value: filters.maturity, label: filters.maturity });
+            if (filters.unplaced) activeChips.push({ key: 'unplaced', value: '1', label: t('cellarDetail.unplacedOnly', 'Unplaced only') });
 
             const removeChip = (chip) => {
               setFilters(prev => {
@@ -517,7 +531,7 @@ function CellarDetail() {
             const clearAll = () => setFilters(prev => ({
               ...prev,
               type: [], country: [], region: [], appellation: [], grapes: [], vintage: [],
-              minRating: '', maturity: ''
+              minRating: '', maturity: '', unplaced: ''
             }));
 
             return (
@@ -600,6 +614,7 @@ function CellarDetail() {
                       baseFacets={baseFacets}
                       facetMeta={facetMeta}
                       bottlesTotal={bottlesTotal}
+                      showUnplaced={!multiScope && hasRacks === true}
                     />
                   </Suspense>
                 )}
@@ -610,7 +625,7 @@ function CellarDetail() {
           {loading ? (
             <div className="loading">{t('cellarDetail.loadingCellar')}</div>
           ) : bottles.length === 0 && !bottlesLoading ? (
-            (filters.search || filters.vintage?.length || filters.minRating || filters.maturity || filters.type?.length || filters.country?.length || filters.region?.length || filters.appellation?.length || filters.grapes?.length) ? (
+            (filters.search || filters.vintage?.length || filters.minRating || filters.maturity || filters.unplaced || filters.type?.length || filters.country?.length || filters.region?.length || filters.appellation?.length || filters.grapes?.length) ? (
               <div className="empty-state">
                 <p>{t('cellarDetail.noSearchResults')}</p>
               </div>

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -35,6 +35,10 @@ function CellarDetail() {
   const [bottlesTotal, setBottlesTotal] = useState(0);
   const [statistics, setStatistics] = useState(null);
   const [rackMap, setRackMap] = useState(new Map());
+  // null = rack layout not yet loaded. Gates the "Unplaced" badge: only badge
+  // once we know the cellar has racks (true) — never while loading, and never
+  // for cellars with no racks at all (false), where placement isn't a concept.
+  const [hasRacks, setHasRacks] = useState(null);
   const [loading, setLoading] = useState(true);
   const [bottlesLoading, setBottlesLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -195,6 +199,7 @@ function CellarDetail() {
   };
 
   const fetchRacks = async () => {
+    setHasRacks(null);
     try {
       const [racksRes, layoutRes] = await Promise.all([
         getRacks(apiFetch, id),
@@ -214,6 +219,7 @@ function CellarDetail() {
           });
         });
         setRackMap(map);
+        setHasRacks((racksData.racks || []).length > 0);
       }
     } catch {}
   };
@@ -627,6 +633,7 @@ function CellarDetail() {
               loadingMore={bottlesLoading}
               onLoadMore={loadMore}
               multi={dataIsMulti}
+              rackKnown={!dataIsMulti && hasRacks === true}
             />
           )}
         </div>
@@ -685,7 +692,7 @@ function CellarDetail() {
 // `multi` = cross-cellar view: `bottles` is a flat list (no grouping), each item
 // carries its own `cellar` id + `cellarName` so it links to and is badged with
 // the right cellar.
-function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore, multi = false }) {
+function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore, multi = false, rackKnown = false }) {
   const { t } = useTranslation();
   const [viewMode, setViewMode] = useState(() => {
     try { return localStorage.getItem('cellarion_bottle_view') || 'list'; } catch { return 'list'; }
@@ -761,6 +768,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                 viewMode={viewMode}
                 showCellarBadge
                 compact={compact}
+                rackKnown={rackKnown}
               />
             );
           }
@@ -769,7 +777,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
             const rep = item.bottles[0];
             if (item.count === 1) {
               return (
-                <BottleCard key={rep._id} bottle={rep} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} />
+                <BottleCard key={rep._id} bottle={rep} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} />
               );
             }
             if (!expandedGroups.has(item.key)) {
@@ -783,6 +791,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                   groupCount={item.count}
                   onClick={() => toggleGroup(item.key)}
                   compact={compact}
+                  rackKnown={rackKnown}
                 />
               );
             }
@@ -796,14 +805,14 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                   </button>
                 </div>
                 {item.bottles.map(b => (
-                  <BottleCard key={b._id} bottle={b} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} />
+                  <BottleCard key={b._id} bottle={b} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} />
                 ))}
               </Fragment>
             );
           }
           // Defensive fallback: a plain bottle item (responses are always grouped)
           return (
-            <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} />
+            <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} />
           );
         })}
       </div>


### PR DESCRIPTION
Part 3 of 3 from Kiet's email feedback. **Stacked on `feat/appellation-filter` (PR #671) — merge last.**

## What
Make bottles that have been added but never shelved into a rack **visible and findable** — Kiet's "12 assorted sitting on the floor, not checked into the cellar yet." Two pieces:

1. **"Unplaced" badge** — an amber dashed chip on any active bottle that isn't in a rack slot.
2. **"Unplaced only" filter** — a Placement section in the filter modal, so you can list exactly the bottles still waiting to be shelved.

## Details
**Badge** (`BottleCard`): shows when the caller knows the cellar's rack layout and the active bottle isn't in any slot. Reuses the `rackMap` the list already builds — **no new request**. Gated to avoid noise/flicker: only after racks have loaded, and only for cellars that actually have racks (placement isn't a concept otherwise). Suppressed in the cross-cellar view and for collapsed groups (members may differ).

**Filter** (frontend-only): maps to the backend's **existing** `?excludePlaced=` param, which is already applied on all three query paths of the single-cellar route (grouped hot path, Meilisearch path, Mongo fallback) — so search and other filters compose with it, groups and totals stay correct. Facet counts don't reflect the placement filter (Meilisearch doesn't know rack slots) — same behavior as the maturity filter. Single-cellar only, like the badge: the control hides in cross-cellar scope and for rack-less cellars, and the filter auto-clears when the scope widens rather than leaving a chip that silently does nothing.

en/sv strings added for both.

## Why not a true "no cellar" bucket
Every `Bottle` requires a `cellar` in the model; a top-level inbox would be an invasive change (access control, stats, indexes all assume a cellar). "In a cellar but not in a rack" is the existing, aligned concept — the rack view already lists these.

## Testing
- `frontend` vitest: **640 passed**. Production build: clean. Zero backend changes.
- UI-gated logic; recommend a quick visual check (a cellar with racks + one unplaced bottle: badge shows, filter narrows to it, both disappear in cross-cellar scope).

## docker-compose impact
**None.** Frontend-only.
