### PR TITLE
fix: canonicalize country names + reject Unknown/junk taxonomy values in AI importer and CSV import

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -41,6 +41,7 @@ Important rules:
 - Labels often print a founder's or family name as part of the producer's crest/logo lockup (e.g. "DESIDERIUS" in small text above "PONGRÁCZ"). Such words belong to the producer identity, NOT the wine name. The name is the line that distinguishes this bottle within the producer's range (here "Blanc de Blancs") — include a person's name only when it genuinely names the cuvée itself (e.g. Pongrácz's separate prestige bottling "Desiderius").
 - Production-method terms are NOT part of the name — put "Méthode Cap Classique" / "Cap Classique", "Méthode Traditionnelle", "Metodo Classico" / "Traditional Method" in the appellation field instead (name "Blanc de Blancs" + appellation "Méthode Cap Classique", NOT name "Blanc de Blancs Méthode Cap Classique"). Legally-defined aging classifications that belong to the displayed name (Reserva, Gran Reserva, Riserva, Spätlese, Grosses Gewächs) and dosage words that are part of a cuvée name (e.g. "Brut Premier") stay in the name.
 - Do not hallucinate appellation names, producer names, or grape varieties. Only use names you are confident are real and match what is visible on the label or your knowledge of that specific producer/appellation.
+- Country must be the canonical English country name: "United States" (never "USA" or "America"), "Germany" (never "Deutschland" or a local-language name like "Tyskland"), "Italy" (never "Italia"/"Italie"), "England" for English wines. Never return a country name in the label's language.
 - If a field is genuinely unknown and cannot be reliably inferred, set it to null rather than guessing.
 - Only return {"error":"cannot read label"} if the image contains no wine label at all.`;
 
@@ -61,6 +62,7 @@ Rules:
 - Production-method terms are NOT part of the name — move "Méthode Cap Classique" / "Cap Classique", "Méthode Traditionnelle", "Metodo Classico" / "Traditional Method" to the appellation field (name "Blanc de Blancs" + appellation "Méthode Cap Classique"). Aging classifications that belong to the displayed name (Reserva, Gran Reserva, Riserva, Spätlese, Grosses Gewächs) and dosage words that are part of a cuvée name (e.g. "Brut Premier") stay in the name
 - Fill in country, region, appellation, type, and grapes from your wine knowledge
 - Country is REQUIRED — always provide a country name; it is never acceptable to return null for country
+- Country must be the canonical English country name: "United States" (never "USA" or "America"), "Germany" (never "Deutschland"/"Tyskland"), "Italy" (never "Italia"/"Italie"), "England" for English wines — never a local-language or abbreviated name, even if the import data uses one
 - For any other field you are unsure about, use null — do NOT omit the field
 - Grapes: provide an empty array [] if unknown, never null for grapes
 - confidence: 1.0 = well-known wine you are certain about, 0.7 = confident from producer knowledge, 0.5 = reasonably sure
@@ -83,6 +85,7 @@ Rules:
 - Production-method terms are NOT part of the name — move "Méthode Cap Classique" / "Cap Classique", "Méthode Traditionnelle", "Metodo Classico" / "Traditional Method" to the appellation field (name "Blanc de Blancs" + appellation "Méthode Cap Classique"). Aging classifications (Reserva, Gran Reserva, Riserva, Spätlese, Grosses Gewächs) and dosage words that are part of a cuvée name (e.g. "Brut Premier") stay in the name
 - Fill in country, region, appellation, type, and grapes from your wine knowledge
 - Country is REQUIRED — always provide a country name; it is never acceptable to return null for country
+- Country must be the canonical English country name: "United States" (never "USA" or "America"), "Germany" (never "Deutschland"/"Tyskland"), "Italy" (never "Italia"/"Italie"), "England" for English wines — never a local-language or abbreviated name, even if the query uses one
 - For any other unknown field use null; use [] for unknown grapes, never null
 - confidence: 1.0 = certain, 0.7 = confident, 0.5 = reasonably sure
 - IMPORTANT: if you recognise the producer or wine name, return a result even if some fields are null — partial information is always better than returning unknown

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -2,7 +2,7 @@ const express = require('express');
 const multer = require('multer');
 const { parse } = require('csv-parse');
 const { requireAuth, requireRole } = require('../../middleware/auth');
-const { generateWineKey, normalizeString } = require('../../utils/normalize');
+const { generateWineKey, normalizeString, resolveCountryName } = require('../../utils/normalize');
 const WineDefinition = require('../../models/WineDefinition');
 const Country = require('../../models/Country');
 const Region = require('../../models/Region');
@@ -133,10 +133,13 @@ async function getOrCreateCountry(name, userId, cache) {
   const key = name.toLowerCase().trim();
   if (cache.has(key)) return cache.get(key);
 
-  const normalized = normalizeString(name);
+  // Alias → canonical ("USA" → "United States", "Tyskland" → "Germany") so a
+  // CSV in another language can't mint a duplicate Country document.
+  const canonicalName = resolveCountryName(name);
+  const normalized = normalizeString(canonicalName);
   const doc = await Country.findOneAndUpdate(
     { normalizedName: normalized },
-    { $setOnInsert: { name: name.trim(), normalizedName: normalized, createdBy: userId } },
+    { $setOnInsert: { name: canonicalName.trim(), normalizedName: normalized, createdBy: userId } },
     { upsert: true, new: true }
   );
   cache.set(key, doc._id);

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -2,7 +2,7 @@ const express = require('express');
 const multer = require('multer');
 const { parse } = require('csv-parse');
 const { requireAuth, requireRole } = require('../../middleware/auth');
-const { generateWineKey, normalizeString, resolveCountryName } = require('../../utils/normalize');
+const { generateWineKey, normalizeString, resolveCountryName, isUnknownName } = require('../../utils/normalize');
 const WineDefinition = require('../../models/WineDefinition');
 const Country = require('../../models/Country');
 const Region = require('../../models/Region');
@@ -130,6 +130,9 @@ function mapRow(row, format) {
  * Results are cached in `cache` (Map) to avoid repeated DB round-trips.
  */
 async function getOrCreateCountry(name, userId, cache) {
+  // "Unknown"/placeholder values must not become a Country document; the row
+  // fails WineDefinition validation (country required) and is counted as an error.
+  if (isUnknownName(name)) return null;
   const key = name.toLowerCase().trim();
   if (cache.has(key)) return cache.get(key);
 
@@ -151,7 +154,7 @@ async function getOrCreateCountry(name, userId, cache) {
  * Returns null when name is falsy.
  */
 async function getOrCreateRegion(name, countryId, userId, cache) {
-  if (!name) return null;
+  if (!name || isUnknownName(name) || !countryId) return null;
   const key = `${countryId}:${name.toLowerCase().trim()}`;
   if (cache.has(key)) return cache.get(key);
 
@@ -179,7 +182,7 @@ async function getOrCreateRegion(name, countryId, userId, cache) {
  * Returns null when name is falsy.
  */
 async function getOrCreateAppellation(name, countryId, regionId, userId, cache) {
-  if (!name) return null;
+  if (!name || isUnknownName(name) || !countryId) return null;
   const key = `${countryId}:${name.toLowerCase().trim()}`;
   if (cache.has(key)) return cache.get(key);
 

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -15,7 +15,7 @@ const Country = require('../models/Country');
 const Region = require('../models/Region');
 const Grape = require('../models/Grape');
 const searchService = require('./search');
-const { generateWineKey, normalizeString, resolveGrapeName, resolveCountryName } = require('../utils/normalize');
+const { generateWineKey, normalizeString, resolveGrapeName, resolveCountryName, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
 
 // Auto-match when combined score >= SIMILARITY_THRESHOLD (near-identical — e.g.
@@ -33,7 +33,9 @@ const POPULATE = ['country', 'region', 'grapes'];
 // ── Taxonomy helpers ─────────────────────────────────────────────────────────
 
 async function findOrCreateCountry(name, userId) {
-  if (!name || !name.trim()) return null;
+  // "Unknown"/placeholder → null, never a Country doc named "Unknown". The
+  // caller treats a null country as a 400 — honest, since country is required.
+  if (isUnknownName(name)) return null;
   // Resolve alias → canonical name before lookup (e.g. "USA" → "United States",
   // "Tyskland" → "Germany") so localized/abbreviated AI output can't mint a
   // duplicate Country — mirrors the resolveGrapeName pattern below.
@@ -47,7 +49,8 @@ async function findOrCreateCountry(name, userId) {
 }
 
 async function findOrCreateRegion(name, countryId, userId) {
-  if (!name || !name.trim() || !countryId) return null;
+  // "Unknown"/placeholder → null region (the schema's representation of unknown)
+  if (isUnknownName(name) || !countryId) return null;
   const normalizedName = normalizeString(name);
   let region = await Region.findOne({ country: countryId, normalizedName });
   if (region) return region;
@@ -61,7 +64,10 @@ async function findOrCreateGrapes(names, userId) {
   const ids = [];
   const seen = new Set(); // deduplicate within the same call (e.g. AI returns "Shiraz" + "Syrah")
   for (const name of names) {
-    if (!name || !name.trim()) continue;
+    // Placeholders and descriptions-instead-of-varietals ("unknown", "blend -
+    // specific varieties unknown") are dropped — a blend is represented by its
+    // actual varieties or an empty array, never a junk Grape document.
+    if (isJunkGrapeName(name)) continue;
     // Resolve synonym → canonical name before lookup (e.g. "Shiraz" → "Syrah")
     const canonicalName = resolveGrapeName(name);
     const normalizedName = normalizeString(canonicalName);

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -15,7 +15,7 @@ const Country = require('../models/Country');
 const Region = require('../models/Region');
 const Grape = require('../models/Grape');
 const searchService = require('./search');
-const { generateWineKey, normalizeString, resolveGrapeName } = require('../utils/normalize');
+const { generateWineKey, normalizeString, resolveGrapeName, resolveCountryName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
 
 // Auto-match when combined score >= SIMILARITY_THRESHOLD (near-identical — e.g.
@@ -34,10 +34,14 @@ const POPULATE = ['country', 'region', 'grapes'];
 
 async function findOrCreateCountry(name, userId) {
   if (!name || !name.trim()) return null;
-  const normalizedName = normalizeString(name);
+  // Resolve alias → canonical name before lookup (e.g. "USA" → "United States",
+  // "Tyskland" → "Germany") so localized/abbreviated AI output can't mint a
+  // duplicate Country — mirrors the resolveGrapeName pattern below.
+  const canonicalName = resolveCountryName(name);
+  const normalizedName = normalizeString(canonicalName);
   let country = await Country.findOne({ normalizedName });
   if (country) return country;
-  country = new Country({ name: name.trim(), normalizedName, createdBy: userId });
+  country = new Country({ name: canonicalName.trim(), normalizedName, createdBy: userId });
   await country.save();
   return country;
 }

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -282,6 +282,27 @@ const GRAPE_SYNONYMS = {
 
   // Muscadet (the wine name used as grape name by mistake)
   'muscadet':             'Melon de Bourgogne',
+
+  // Spelling variants / typos / short forms that existed as duplicate Grape
+  // docs on prod (merged 2026-07-11) — mapped so they can't come back.
+  'agiorghitiko':         'Agiorgitiko',
+  'inzolia':              'Insolia',
+  'corvina veronese':     'Corvina',
+  'cesanese di affile':   "Cesanese d'Affile",
+  'sylvaner':             'Silvaner',
+  'tinta barocca':        'Tinta Barroca',
+  'tintaroriz':           'Tinta Roriz',   // "Tinta-Roriz" — hyphens are deleted by normalizeString
+  'verdehlo':             'Verdelho',
+  'bacchud':              'Bacchus',
+  'vidal':                'Vidal Blanc',
+  'foch':                 'Maréchal Foch',
+  'portugieser':          'Blauer Portugieser',
+
+  // ß is stripped (not expanded to ss) by normalizeString, so the existing
+  // 'weissburgunder' key never matched the actual label spelling Weißburgunder
+  // — a duplicate Grape doc proved it on prod.
+  'weiburgunder':         'Pinot Blanc',
+  'weisser burgunder':    'Pinot Blanc',
 };
 
 /**

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -254,6 +254,7 @@ const GRAPE_SYNONYMS = {
   'brunello':             'Sangiovese',
   'prugnolo gentile':     'Sangiovese',
   'morellino':            'Sangiovese',
+  'sangiovese grosso':    'Sangiovese', // Montalcino's local name — 15 Brunelli on prod carried it as a separate grape
 
   // Zinfandel / Primitivo — same DNA, often listed interchangeably
   'primitivo':            'Zinfandel',
@@ -490,6 +491,34 @@ const resolveCountryName = (name) => {
 };
 
 /**
+ * Placeholder values the AI (or an import file) uses when it doesn't actually
+ * know the value — despite the prompts demanding null. The registry's
+ * representation for unknown is country/region = null and grapes = [] — never
+ * a taxonomy document literally named "Unknown" (prod accumulated an Unknown
+ * country, five Unknown regions and an "unknown" grape this way).
+ * Keys are checked after normalizeString(), so "Okänd" → "okand", "N/A" → "na",
+ * "?" / "-" → "" (caught by the empty check).
+ */
+const UNKNOWN_NAME_RX = /^(unknown|unbekannt|okand|ukjent|inconnu|inconnue|sconosciuto|desconocido|na|none|null|nil|various|misc|miscellaneous|not specified|unspecified|not available|tbd|to be determined)$/;
+
+const isUnknownName = (name) => {
+  if (!name || !name.trim()) return true;
+  const key = normalizeString(name);
+  return key === '' || UNKNOWN_NAME_RX.test(key);
+};
+
+/**
+ * Grape names additionally reject descriptions-instead-of-varietals: the AI
+ * sometimes returns hedges like "blend - specific varieties unknown",
+ * "unknown - likely Riesling, Gewurztraminer, Pinot Gris, or Muscat" or
+ * "blend of 40 botanicals including orange peel" (all real prod examples).
+ * A blend's correct representation is the list of its varieties, or [].
+ */
+const JUNK_GRAPE_RX = /\bblends?\b|\bbotanicals?\b|\blikely\b|\bunknown\b|\bvarieties\b|\bunspecified\b/i;
+
+const isJunkGrapeName = (name) => isUnknownName(name) || JUNK_GRAPE_RX.test(name);
+
+/**
  * Convert any string to a URL-safe slug (lowercase, hyphenated, ASCII-only).
  * Builds on normalizeString (which already strips diacritics and punctuation).
  */
@@ -527,6 +556,8 @@ module.exports = {
   generateWineSlug,
   resolveGrapeName,
   resolveCountryName,
+  isUnknownName,
+  isJunkGrapeName,
   levenshteinDistance,
   calculateSimilarity,
   generateTrigrams,

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -298,6 +298,198 @@ const resolveGrapeName = (name) => {
 };
 
 /**
+ * Map of alternate country names → canonical English name.
+ * Keys are the output of normalizeString() applied to the alternate name.
+ * Values are the canonical Country.name used by the seeded taxonomy.
+ *
+ * Same idea as GRAPE_SYNONYMS: the AI importer and label scan receive labels
+ * in the user's language ("Tyskland", "Italie") or informal abbreviations
+ * ("USA"), and findOrCreateCountry would otherwise mint a duplicate Country
+ * document for each spelling — this happened on prod (USA / United States Of
+ * America / Tyskland / Italie / New Zeeland were all created as countries).
+ * Covers Swedish, German, French, Spanish, Italian and Dutch names for the
+ * wine countries plus common English variants; anything unmapped passes
+ * through unchanged and still dedupes by normalizedName.
+ */
+const COUNTRY_ALIASES = {
+  // United States
+  'usa':                      'United States',
+  'us':                       'United States',
+  'united states of america': 'United States',
+  'america':                  'United States',
+  'estados unidos':           'United States',
+  'etatsunis':                'United States', // États-Unis (hyphen deleted by normalizeString)
+  'vereinigte staaten':       'United States',
+
+  // England — canonical wine country (English PDO sparkling/still wines;
+  // wine-world convention over ISO). Welsh wines are rare enough that a
+  // separate "Wales" country may still be created deliberately.
+  'united kingdom':           'England',
+  'uk':                       'England',
+  'great britain':            'England',
+  'storbritannien':           'England',
+  'grobritannien':            'England', // Großbritannien (ß is stripped by normalizeString)
+
+  // Germany
+  'tyskland':                 'Germany',   // sv/da/no
+  'deutschland':              'Germany',
+  'allemagne':                'Germany',
+  'alemania':                 'Germany',
+  'germania':                 'Germany',
+  'duitsland':                'Germany',
+
+  // Italy
+  'italie':                   'Italy',     // fr
+  'italia':                   'Italy',
+  'italien':                  'Italy',     // sv + de
+
+  // France
+  'frankrike':                'France',    // sv
+  'frankreich':               'France',
+  'francia':                  'France',
+  'frankrijk':                'France',
+
+  // Spain
+  'spanien':                  'Spain',     // sv + de
+  'espagne':                  'Spain',
+  'espana':                   'Spain',
+  'espanha':                  'Spain',
+  'spagna':                   'Spain',
+  'spanje':                   'Spain',
+
+  // Portugal — same spelling in most languages; no aliases needed
+
+  // New Zealand
+  'new zeeland':              'New Zealand', // common typo (created a prod country)
+  'nya zeeland':              'New Zealand', // sv
+  'neuseeland':               'New Zealand',
+  'nouvellezelande':          'New Zealand', // Nouvelle-Zélande (hyphen deleted)
+  'nueva zelanda':            'New Zealand',
+  'nuova zelanda':            'New Zealand',
+
+  // Austria
+  'osterrike':                'Austria',   // sv (Österrike)
+  'osterreich':               'Austria',   // de (Österreich)
+  'autriche':                 'Austria',
+
+  // South Africa
+  'sydafrika':                'South Africa', // sv
+  'sudafrika':                'South Africa', // de (Südafrika)
+  'afrique du sud':           'South Africa',
+  'sudafrica':                'South Africa',
+
+  // Australia
+  'australien':               'Australia', // sv + de
+  'australie':                'Australia',
+
+  // Greece
+  'grekland':                 'Greece',    // sv
+  'griechenland':             'Greece',
+  'grece':                    'Greece',
+  'grecia':                   'Greece',
+
+  // Hungary
+  'ungern':                   'Hungary',   // sv
+  'ungarn':                   'Hungary',
+  'hongrie':                  'Hungary',
+  'ungheria':                 'Hungary',
+
+  // Switzerland
+  'schweiz':                  'Switzerland', // sv + de
+  'suisse':                   'Switzerland',
+  'svizzera':                 'Switzerland',
+
+  // Croatia
+  'kroatien':                 'Croatia',   // sv + de
+  'croatie':                  'Croatia',
+  'croazia':                  'Croatia',
+  'hrvatska':                 'Croatia',
+
+  // Czech Republic
+  'czechia':                  'Czech Republic',
+  'tjeckien':                 'Czech Republic', // sv
+  'tschechien':               'Czech Republic',
+
+  // Netherlands
+  'holland':                  'Netherlands',
+  'nederlanderna':            'Netherlands', // sv
+  'niederlande':              'Netherlands',
+  'paysbas':                  'Netherlands', // Pays-Bas (hyphen deleted)
+
+  // Georgia
+  'georgien':                 'Georgia',   // sv + de
+  'georgie':                  'Georgia',
+
+  // Lebanon
+  'libanon':                  'Lebanon',   // sv + de
+  'liban':                    'Lebanon',
+
+  // Turkey
+  'turkiye':                  'Turkey',
+  'turkiet':                  'Turkey',    // sv
+  'turkei':                   'Turkey',    // de (Türkei)
+  'turquie':                  'Turkey',
+
+  // Belgium
+  'belgien':                  'Belgium',   // sv + de
+  'belgique':                 'Belgium',
+  'belgie':                   'Belgium',
+
+  // Scandinavia
+  'sverige':                  'Sweden',
+  'schweden':                 'Sweden',
+  'suede':                    'Sweden',
+  'norge':                    'Norway',
+  'norwegen':                 'Norway',
+  'norvege':                  'Norway',
+  'danmark':                  'Denmark',
+  'danemark':                 'Denmark',
+
+  // Canada / Mexico / Brazil / Japan / Morocco
+  'kanada':                   'Canada',    // sv + de
+  'mexiko':                   'Mexico',    // sv + de
+  'mexique':                  'Mexico',
+  'brasilien':                'Brazil',    // sv + de
+  'bresil':                   'Brazil',
+  'brasil':                   'Brazil',
+  'japon':                    'Japan',
+  'marocko':                  'Morocco',   // sv
+  'marokko':                  'Morocco',   // de
+  'maroc':                    'Morocco',
+
+  // Eastern Europe
+  'slovenien':                'Slovenia',  // sv
+  'slowenien':                'Slovenia',  // de
+  'rumanien':                 'Romania',   // sv/de (Rumänien)
+  'roumanie':                 'Romania',
+  'bulgarien':                'Bulgaria',  // sv + de
+  'bulgarie':                 'Bulgaria',
+  'moldavien':                'Moldova',   // sv
+  'moldawien':                'Moldova',   // de
+  'russia':                   'Russian Federation',
+  'ryssland':                 'Russian Federation', // sv
+
+  // South America
+  'argentine':                'Argentina', // fr
+  'argentinien':              'Argentina', // de
+  'chili':                    'Chile',     // fr + nl
+};
+
+/**
+ * Resolve a country name to its canonical English form.
+ * If the name (after normalization) matches a known alias, the canonical
+ * name is returned. Otherwise the original trimmed name is returned unchanged.
+ *
+ * @param {string} name  Raw country name from label scan, AI lookup or import
+ * @returns {string}     Canonical country name for storage
+ */
+const resolveCountryName = (name) => {
+  if (!name || !name.trim()) return name;
+  const key = normalizeString(name);
+  return COUNTRY_ALIASES[key] || name.trim();
+};
+
+/**
  * Convert any string to a URL-safe slug (lowercase, hyphenated, ASCII-only).
  * Builds on normalizeString (which already strips diacritics and punctuation).
  */
@@ -334,6 +526,7 @@ module.exports = {
   generateWineKey,
   generateWineSlug,
   resolveGrapeName,
+  resolveCountryName,
   levenshteinDistance,
   calculateSimilarity,
   generateTrigrams,

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -9,6 +9,9 @@ const {
   tokenSimilarity,
   combinedSimilarity,
   resolveCountryName,
+  isUnknownName,
+  isJunkGrapeName,
+  resolveGrapeName,
 } = require('./normalize');
 
 // ─── normalizeString ──────────────────────────────────────────────────────────
@@ -331,5 +334,63 @@ describe('resolveCountryName', () => {
   test('passes unknown countries through trimmed', () => {
     expect(resolveCountryName('  Uzbekistan  ')).toBe('Uzbekistan');
     expect(resolveCountryName('Atlantis')).toBe('Atlantis');
+  });
+});
+
+// ─── isUnknownName / isJunkGrapeName ─────────────────────────────────────────
+
+describe('isUnknownName', () => {
+  test('true for empty/falsy input', () => {
+    expect(isUnknownName(null)).toBe(true);
+    expect(isUnknownName('')).toBe(true);
+    expect(isUnknownName('   ')).toBe(true);
+  });
+
+  test('true for placeholder values in several languages (the prod junk)', () => {
+    // Each of these existed as a taxonomy document on prod
+    expect(isUnknownName('Unknown')).toBe(true);
+    expect(isUnknownName('unknown')).toBe(true);
+    expect(isUnknownName('Okänd')).toBe(true);     // sv
+    expect(isUnknownName('Unbekannt')).toBe(true); // de
+    expect(isUnknownName('Inconnu')).toBe(true);   // fr
+    expect(isUnknownName('N/A')).toBe(true);
+    expect(isUnknownName('n.a.')).toBe(true);
+    expect(isUnknownName('none')).toBe(true);
+    expect(isUnknownName('Not specified')).toBe(true);
+    expect(isUnknownName('?')).toBe(true);   // normalizes to empty
+    expect(isUnknownName('-')).toBe(true);   // normalizes to empty
+  });
+
+  test('false for real names', () => {
+    expect(isUnknownName('Mendoza')).toBe(false);
+    expect(isUnknownName('Napa Valley')).toBe(false);
+    expect(isUnknownName('Germany')).toBe(false);
+    // 'Nahe' must not be confused with placeholder 'na'
+    expect(isUnknownName('Nahe')).toBe(false);
+  });
+});
+
+describe('isJunkGrapeName', () => {
+  test('rejects placeholders and hedge descriptions (real prod examples)', () => {
+    expect(isJunkGrapeName('unknown')).toBe(true);
+    expect(isJunkGrapeName('Red Blend')).toBe(true);
+    expect(isJunkGrapeName('blend - specific varieties unknown')).toBe(true);
+    expect(isJunkGrapeName('unknown white blend')).toBe(true);
+    expect(isJunkGrapeName('blend of 40 botanicals including orange peel')).toBe(true);
+    expect(isJunkGrapeName('unknown - likely Riesling, Gewurztraminer, Pinot Gris, or Muscat')).toBe(true);
+  });
+
+  test('accepts real varietals, including compound names', () => {
+    expect(isJunkGrapeName('Syrah')).toBe(false);
+    expect(isJunkGrapeName('Cabernet Sauvignon')).toBe(false);
+    expect(isJunkGrapeName('Refosco dal Peduncolo Rosso')).toBe(false);
+    expect(isJunkGrapeName('Moscato Bianco')).toBe(false);
+    expect(isJunkGrapeName('Colombard')).toBe(false);
+  });
+});
+
+describe('resolveGrapeName — Sangiovese Grosso', () => {
+  test('maps the Montalcino local name to Sangiovese', () => {
+    expect(resolveGrapeName('Sangiovese Grosso')).toBe('Sangiovese');
   });
 });

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -8,6 +8,7 @@ const {
   trigramSimilarity,
   tokenSimilarity,
   combinedSimilarity,
+  resolveCountryName,
 } = require('./normalize');
 
 // ─── normalizeString ──────────────────────────────────────────────────────────
@@ -274,5 +275,61 @@ describe('combinedSimilarity', () => {
     const combined = combinedSimilarity('burgundy', 'burgundie');
     expect(combined).toBeGreaterThanOrEqual(Math.min(lev, tri, tok));
     expect(combined).toBeLessThanOrEqual(Math.max(lev, tri, tok));
+  });
+});
+
+// ─── resolveCountryName ──────────────────────────────────────────────────────
+
+describe('resolveCountryName', () => {
+  test('returns falsy input unchanged', () => {
+    expect(resolveCountryName(null)).toBe(null);
+    expect(resolveCountryName('')).toBe('');
+    expect(resolveCountryName('   ')).toBe('   ');
+  });
+
+  test('maps English abbreviations to canonical names', () => {
+    expect(resolveCountryName('USA')).toBe('United States');
+    expect(resolveCountryName('U.S.A.')).toBe('United States'); // punctuation stripped
+    expect(resolveCountryName('US')).toBe('United States');
+    expect(resolveCountryName('United States of America')).toBe('United States');
+    expect(resolveCountryName('America')).toBe('United States');
+  });
+
+  test('maps local-language names to canonical English (the prod duplicates)', () => {
+    // Each of these existed as a duplicate Country document on prod
+    expect(resolveCountryName('Tyskland')).toBe('Germany');   // Swedish
+    expect(resolveCountryName('Italie')).toBe('Italy');       // French
+    expect(resolveCountryName('New Zeeland')).toBe('New Zealand'); // typo
+  });
+
+  test('maps United Kingdom to England (canonical wine country)', () => {
+    expect(resolveCountryName('United Kingdom')).toBe('England');
+    expect(resolveCountryName('UK')).toBe('England');
+    expect(resolveCountryName('Great Britain')).toBe('England');
+  });
+
+  test('handles diacritics and hyphens through normalizeString', () => {
+    expect(resolveCountryName('Österrike')).toBe('Austria');        // Swedish, Ö → o
+    expect(resolveCountryName('Nouvelle-Zélande')).toBe('New Zealand'); // hyphen deleted
+    expect(resolveCountryName('États-Unis')).toBe('United States');
+    expect(resolveCountryName('Großbritannien')).toBe('England');   // ß stripped
+    expect(resolveCountryName('Südafrika')).toBe('South Africa');
+  });
+
+  test('is case-insensitive', () => {
+    expect(resolveCountryName('tyskland')).toBe('Germany');
+    expect(resolveCountryName('FRANKRIKE')).toBe('France');
+  });
+
+  test('returns canonical names unchanged', () => {
+    expect(resolveCountryName('France')).toBe('France');
+    expect(resolveCountryName('United States')).toBe('United States');
+    expect(resolveCountryName('England')).toBe('England');
+    expect(resolveCountryName('South Africa')).toBe('South Africa');
+  });
+
+  test('passes unknown countries through trimmed', () => {
+    expect(resolveCountryName('  Uzbekistan  ')).toBe('Uzbekistan');
+    expect(resolveCountryName('Atlantis')).toBe('Atlantis');
   });
 });

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -394,3 +394,24 @@ describe('resolveGrapeName — Sangiovese Grosso', () => {
     expect(resolveGrapeName('Sangiovese Grosso')).toBe('Sangiovese');
   });
 });
+
+describe('resolveGrapeName — spelling variants merged 2026-07-11', () => {
+  test('maps spelling variants and typos to canonical names', () => {
+    expect(resolveGrapeName('Agiorghitiko')).toBe('Agiorgitiko');
+    expect(resolveGrapeName('Inzolia')).toBe('Insolia');
+    expect(resolveGrapeName('Corvina Veronese')).toBe('Corvina');
+    expect(resolveGrapeName('Sylvaner')).toBe('Silvaner');
+    expect(resolveGrapeName('Tinta Barocca')).toBe('Tinta Barroca');
+    expect(resolveGrapeName('Tinta-Roriz')).toBe('Tinta Roriz'); // hyphen deleted by normalizeString
+    expect(resolveGrapeName('Verdehlo')).toBe('Verdelho');
+    expect(resolveGrapeName('Vidal')).toBe('Vidal Blanc');
+    expect(resolveGrapeName('Portugieser')).toBe('Blauer Portugieser');
+  });
+
+  test('ß-spelled Weißburgunder finally resolves to Pinot Blanc', () => {
+    // normalizeString strips ß entirely ('weiburgunder'), so the old
+    // 'weissburgunder' key never matched the real label spelling
+    expect(resolveGrapeName('Weißburgunder')).toBe('Pinot Blanc');
+    expect(resolveGrapeName('Weisser Burgunder')).toBe('Pinot Blanc');
+  });
+});


### PR DESCRIPTION
## Problem

The registry accumulated **duplicate Country documents** because the AI importer passes through whatever the model returns:

| Duplicate created | Wines | Canonical |
|---|---|---|
| USA | 140 | United States |
| United States Of America | 2 | United States |
| Tyskland (Swedish) | 1 | Germany |
| Italie (French) | 1 | Italy |
| New Zeeland (typo) | 1 | New Zealand |

Each also duplicated its region tree (California, Napa Valley, Sonoma County… existed under both `USA` and `United States`). Root cause: `findOrCreateCountry()` dedupes only by normalized spelling — grapes already solve this with `resolveGrapeName()` (Shiraz → Syrah), countries never got the equivalent.

## Fix

- **`resolveCountryName()` + `COUNTRY_ALIASES`** in `utils/normalize.js` — alias map covering English abbreviations (USA, US, U.S.A., America) and Swedish/German/French/Spanish/Italian/Dutch country names → canonical seeded `Country.name`
- **England is canonical** for wine (English PDO convention; per Johan's decision) — United Kingdom / UK / Great Britain alias to it
- Wired into **both** creation paths: `findOrCreateWine.findOrCreateCountry` (AI label scan / lookup / text search) and `admin/import.getOrCreateCountry` (CSV import)
- **Prompt hardening**: label-scan, import-lookup and text-search default prompts now require canonical English country names (prod uses default prompts, so this takes effect on deploy)
- Alias keys account for `normalizeString` quirks: hyphens deleted (Nouvelle-Zélande → nouvellezelande), ß stripped (Großbritannien → grobritannien)

## Prod data (already fixed, separately)

The existing duplicates were merged directly on prod 2026-07-11 with pre-merge backups (`~/backups-adhoc/`): regions repointed/merged (16 dup US region docs removed), wines repointed (472 US wines consolidated), England given `code: GB` (lights up the Statistics world map), Meilisearch fully resynced. All verification checks passed (0 orphans, 0 dups remaining).

## Tests

- `npm test`: **82 suites, 1,329 tests pass**
- New `resolveCountryName` suite: abbreviations, local-language names, UK→England, diacritics/hyphen/ß edge cases, unknown passthrough

## Ops

No docker-compose impact — ships in the normal backend image; no env vars, no migration (prod data already merged).