### PR TITLE
fix: canonicalize producer-in-name wines at the findOrCreateWine chokepoint

### DIFF
--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -354,7 +354,10 @@ router.post('/find-or-create', requireAuth, async (req, res) => {
     const result = await findOrCreateWine(
       { name, producer, country, region, appellation, type, grapes: grapes || [] },
       req.user.id,
-      { confirmCreate: !!confirmCreate }
+      // skipSiblingMatch: the user has already reviewed the suggested matches
+      // (that's what confirmCreate means here) — an appellation-variant sibling
+      // must not silently override their explicit "create a new wine anyway".
+      { confirmCreate: !!confirmCreate, skipSiblingMatch: !!confirmCreate }
     );
 
     // Soft-zone: hand the candidates back so the UI can prompt the user

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -2,7 +2,10 @@
  * findOrCreateWine service
  *
  * Resolves a wine definition from AI-extracted label data:
+ *   0. Canonicalize the name — strip a redundant producer prefix
+ *      ("Amisfield Pinot Noir" / "Amisfield" → "Pinot Noir")
  *   1. Exact match by normalizedKey (producer:name:appellation)
+ *   1b. Unique producer+name sibling match (appellation-agnostic)
  *   2. Fuzzy similarity search using Meilisearch + scoring
  *   3. If no match above threshold: create wine + any missing taxonomy records
  *
@@ -17,6 +20,8 @@ const Grape = require('../models/Grape');
 const searchService = require('./search');
 const { generateWineKey, normalizeString, resolveGrapeName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
+const { stripProducerPrefix } = require('../utils/producerPrefix');
+const { escapeRegex } = require('../utils/sanitize');
 
 // Auto-match when combined score >= SIMILARITY_THRESHOLD (near-identical — e.g.
 // token-order or punctuation differences the exact normalizedKey match missed).
@@ -91,22 +96,54 @@ async function findOrCreateGrapes(names, userId) {
  * @param {string} userId     - ObjectId string of the authenticated user (for createdBy)
  * @param {Object} [opts]
  * @param {boolean} [opts.confirmCreate=false] - Skip soft-zone candidate return and create directly
+ * @param {boolean} [opts.skipSiblingMatch=false] - Skip step 1b. Pass when the user has
+ *   explicitly rejected the suggested matches (find-or-create route with confirmCreate),
+ *   so their "create anyway" isn't silently overridden by an appellation-variant sibling.
  */
-async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false } = {}) {
+async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false, skipSiblingMatch = false } = {}) {
   // Cap stored/compared field lengths at this single create chokepoint (covers
-  // the find-or-create route, CSV import, and label-scan). This bounds both the
-  // fuzzy-match cost and the persisted document size WITHOUT a schema maxlength
-  // validator — a validator re-runs on every .save() (full-document validation)
-  // and would make legacy rows that predate the cap un-editable.
+  // the find-or-create route, CSV import, cellar-format import and label-scan).
+  // This bounds both the fuzzy-match cost and the persisted document size
+  // WITHOUT a schema maxlength validator — a validator re-runs on every .save()
+  // (full-document validation) and would make legacy rows that predate the cap
+  // un-editable.
   const MAX_FIELD = 200;
-  const trimmedName = name.trim().slice(0, MAX_FIELD);
+  let trimmedName = name.trim().slice(0, MAX_FIELD);
   const trimmedProducer = producer.trim().slice(0, MAX_FIELD);
   const trimmedAppellation = (typeof appellation === 'string' ? appellation.trim() : '').slice(0, MAX_FIELD);
+
+  // 0. Registry canon: a wine's name never embeds its producer. Cellar-format
+  // imports and the occasional non-compliant AI response arrive as
+  // name "Amisfield Pinot Noir" + producer "Amisfield" — canonicalize BEFORE
+  // any matching so that input resolves to (or creates) the producer-free
+  // entry instead of minting a producer-in-name duplicate the admin tool has
+  // to clean up later. Loop: concatenated sources can double the prefix.
+  for (let rest = stripProducerPrefix(trimmedName, trimmedProducer); rest;
+       rest = stripProducerPrefix(trimmedName, trimmedProducer)) {
+    trimmedName = rest;
+  }
 
   // 1. Exact match by normalizedKey
   const normalizedKey = generateWineKey(trimmedName, trimmedProducer, trimmedAppellation);
   let wine = await WineDefinition.findOne({ normalizedKey }).populate(POPULATE);
   if (wine) return { wine, created: false };
+
+  // 1b. Sibling match: same producer + same canonical name, ANY appellation.
+  // Import files and AI output often carry a different appellation granularity
+  // than the registry ("Cromwell" vs the registry's "Central Otago") — the
+  // full-key match above misses and the fuzzy score lands around 0.90, below
+  // the auto-match threshold, so without this step a non-interactive caller
+  // (confirmCreate) would mint a near-duplicate. A UNIQUE producer+name hit is
+  // overwhelmingly the same wine; with several siblings we fall through to the
+  // fuzzy scorer so the soft zone can disambiguate instead of picking one
+  // arbitrarily. The anchored regex is a prefix scan on the normalizedKey index.
+  if (!skipSiblingMatch) {
+    const siblingPrefix = `${normalizeString(trimmedProducer)}:${normalizeString(trimmedName)}:`;
+    const siblings = await WineDefinition.find({ normalizedKey: new RegExp(`^${escapeRegex(siblingPrefix)}`) })
+      .limit(2)
+      .populate(POPULATE);
+    if (siblings.length === 1) return { wine: siblings[0], created: false };
+  }
 
   // 2. Fuzzy similarity search
   const searchQuery = `${trimmedName} ${trimmedProducer}`.trim();

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -3,7 +3,11 @@
  * previously auto-created ~430 junk registry entries, so the threshold routing
  * IS the feature:
  *
+ *   producer-prefix strip (step 0)     → "Amisfield Pinot Noir"/"Amisfield" is
+ *                                        canonicalized to "Pinot Noir" before ANY matching
  *   exact normalizedKey match          → return existing, never create
+ *   unique producer+name sibling (1b)  → auto-match regardless of appellation
+ *                                        (unless skipSiblingMatch)
  *   fuzzy score >= 0.95                → auto-match existing (>= — exactly 0.95 matches)
  *   0.85 <= score < 0.95 (soft zone)   → { wine: null, candidates } "did you mean?",
  *                                        never a silent create (unless confirmCreate)
@@ -11,9 +15,9 @@
  *
  * The scorer (wineMatching.scoreAllMatches) is mocked so the boundary values
  * can be pinned exactly; wineMatching has its own dedicated suites. The
- * normalize utils (generateWineKey, normalizeString, resolveGrapeName) are the
- * REAL implementations, so key generation and grape-synonym dedup are tested
- * for real.
+ * normalize utils (generateWineKey, normalizeString, resolveGrapeName) and the
+ * producer-prefix stripper are the REAL implementations, so key generation,
+ * grape-synonym dedup and prefix stripping are tested for real.
  */
 jest.mock('../models/WineDefinition', () => {
   const ctor = jest.fn();
@@ -75,18 +79,33 @@ const EXISTING_WINE = { _id: 'wine-existing', name: 'Clos des Papes' };
 
 // findOne(...).populate(...) — populate resolves to the doc or null
 const findOneChain = (doc) => ({ populate: jest.fn().mockResolvedValue(doc) });
-// find($text...).populate(...).limit(20) — the MongoDB text-search fallback
-const textSearchChain = (docs) => ({
-  populate: jest.fn().mockReturnValue({ limit: jest.fn().mockResolvedValue(docs) }),
-});
+
+/**
+ * Query-shape dispatcher for WineDefinition.find — the service issues three
+ * differently-chained find() queries, so a single mockReturnValue can't serve
+ * them all:
+ *   { normalizedKey: RegExp } → .limit(2).populate(...)   (step 1b sibling lookup)
+ *   { _id: { $in: ids } }     → .populate(...)            (Meilisearch id fetch)
+ *   { $text: ... }            → .populate(...).limit(20)  (Mongo text fallback)
+ */
+function primeFind({ siblings = [], meiliDocs = [], textDocs = [] } = {}) {
+  WineDefinition.find.mockImplementation((q) => {
+    if (q && q.normalizedKey) {
+      return { limit: jest.fn().mockReturnValue({ populate: jest.fn().mockResolvedValue(siblings) }) };
+    }
+    if (q && q.$text) {
+      return { populate: jest.fn().mockReturnValue({ limit: jest.fn().mockResolvedValue(textDocs) }) };
+    }
+    return { populate: jest.fn().mockResolvedValue(meiliDocs) };
+  });
+}
 
 /** Prime the Meilisearch path with ranked results the mocked scorer returns. */
 function primeCandidates(ranked) {
   const candidates = ranked.map((r) => r.wine);
   searchService.getIsAvailable.mockReturnValue(true);
   searchService.search.mockResolvedValue({ ids: candidates.map((c) => c._id) });
-  // find({ _id: { $in: ids } }).populate(POPULATE) — awaited directly
-  WineDefinition.find.mockReturnValue({ populate: jest.fn().mockResolvedValue(candidates) });
+  primeFind({ meiliDocs: candidates });
   scoreAllMatches.mockReturnValue(ranked);
 }
 
@@ -111,10 +130,11 @@ beforeEach(() => {
     });
   }
 
-  // Defaults: no exact match, Meilisearch down, text fallback empty → create path
+  // Defaults: no exact match, no siblings, Meilisearch down, text fallback
+  // empty → create path
   WineDefinition.findOne.mockReturnValue(findOneChain(null));
   searchService.getIsAvailable.mockReturnValue(false);
-  WineDefinition.find.mockReturnValue(textSearchChain([]));
+  primeFind();
   scoreAllMatches.mockReturnValue([]);
 
   // Taxonomy defaults: everything already exists
@@ -150,6 +170,106 @@ describe('findOrCreateWine — exact match', () => {
     );
 
     expect(WineDefinition.findOne).toHaveBeenCalledWith({ normalizedKey: INPUT_KEY });
+  });
+});
+
+describe('findOrCreateWine — producer-prefix canonicalization (step 0)', () => {
+  // Registry canon: the name never embeds the producer. Cellar-format imports
+  // and non-compliant AI output arrive as "Producer Wine Name" + "Producer" —
+  // these previously minted producer-in-name duplicates (42 on prod, 2026-07-11).
+  const PREFIXED = { ...INPUT, name: 'Paul Avril Clos des Papes' };
+
+  test('name embedding the producer is stripped before the exact-key lookup', async () => {
+    WineDefinition.findOne.mockReturnValue(findOneChain(EXISTING_WINE));
+
+    const result = await findOrCreateWine(PREFIXED, USER_ID);
+
+    // INPUT_KEY is built from the producer-free name — the prefixed input must
+    // resolve to the very same key.
+    expect(WineDefinition.findOne).toHaveBeenCalledWith({ normalizedKey: INPUT_KEY });
+    expect(result).toEqual({ wine: EXISTING_WINE, created: false });
+  });
+
+  test('created wines store the stripped name, never producer-in-name', async () => {
+    const result = await findOrCreateWine(PREFIXED, USER_ID);
+
+    expect(result.created).toBe(true);
+    expect(WineDefinition.mock.calls[0][0].name).toBe('Clos des Papes');
+    expect(WineDefinition.mock.calls[0][0].normalizedKey).toBe(INPUT_KEY);
+  });
+
+  test('a doubled producer prefix is stripped repeatedly', async () => {
+    await findOrCreateWine({ ...INPUT, name: 'Paul Avril Paul Avril Clos des Papes' }, USER_ID);
+
+    expect(WineDefinition.mock.calls[0][0].name).toBe('Clos des Papes');
+  });
+
+  test('a name identical to the producer is left alone (nothing would remain)', async () => {
+    await findOrCreateWine({ ...INPUT, name: 'Paul Avril' }, USER_ID);
+
+    expect(WineDefinition.mock.calls[0][0].name).toBe('Paul Avril');
+  });
+});
+
+describe('findOrCreateWine — sibling match (step 1b)', () => {
+  // Same producer + same canonical name but a different appellation granularity
+  // ("Cromwell" vs "Central Otago") misses the exact key and fuzzy-scores ~0.90
+  // — below auto-match — so non-interactive callers used to create a duplicate.
+  const SIBLING = {
+    _id: 'wine-sibling',
+    name: 'Clos des Papes',
+    producer: 'Paul Avril',
+    appellation: 'Rhône',
+  };
+
+  test('a unique producer+name hit auto-matches regardless of appellation — no create, no fuzzy', async () => {
+    primeFind({ siblings: [SIBLING] });
+
+    const result = await findOrCreateWine(INPUT, USER_ID);
+
+    expect(result).toEqual({ wine: SIBLING, created: false });
+    expect(scoreAllMatches).not.toHaveBeenCalled();
+    expect(WineDefinition).not.toHaveBeenCalled();
+    expect(searchService.indexWine).not.toHaveBeenCalled();
+  });
+
+  test('sibling match fires under confirmCreate too (non-interactive importers rely on it)', async () => {
+    primeFind({ siblings: [SIBLING] });
+
+    const result = await findOrCreateWine(INPUT, USER_ID, { confirmCreate: true });
+
+    expect(result).toEqual({ wine: SIBLING, created: false });
+  });
+
+  test('the sibling lookup uses an anchored producer:name: prefix regex', async () => {
+    primeFind({ siblings: [SIBLING] });
+
+    await findOrCreateWine(INPUT, USER_ID);
+
+    const call = WineDefinition.find.mock.calls.find((c) => c[0] && c[0].normalizedKey);
+    const regex = call[0].normalizedKey;
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex.source.startsWith('^')).toBe(true);
+    expect('paul avril:clos des papes:any appellation at all').toMatch(regex);
+    expect('other producer:clos des papes:').not.toMatch(regex);
+  });
+
+  test('several siblings fall through to the fuzzy scorer instead of picking one arbitrarily', async () => {
+    primeFind({ siblings: [SIBLING, { _id: 'wine-sibling-2' }] });
+
+    const result = await findOrCreateWine(INPUT, USER_ID);
+
+    // Default fuzzy mocks are empty → the create path proves we fell through.
+    expect(result.created).toBe(true);
+  });
+
+  test('skipSiblingMatch honours an explicit "create anyway" over a lone sibling', async () => {
+    primeFind({ siblings: [SIBLING] });
+
+    const result = await findOrCreateWine(INPUT, USER_ID, { confirmCreate: true, skipSiblingMatch: true });
+
+    expect(result.created).toBe(true);
+    expect(result.wine._id).toBe('wine-new');
   });
 });
 
@@ -266,7 +386,7 @@ describe('findOrCreateWine — fuzzy threshold routing', () => {
   test('Meilisearch failure falls back to MongoDB text search', async () => {
     searchService.getIsAvailable.mockReturnValue(true);
     searchService.search.mockRejectedValue(new Error('meili down'));
-    WineDefinition.find.mockReturnValue(textSearchChain([EXISTING_WINE]));
+    primeFind({ textDocs: [EXISTING_WINE] });
     scoreAllMatches.mockReturnValue([{ wine: EXISTING_WINE, score: 0.97 }]);
 
     const result = await findOrCreateWine(INPUT, USER_ID);
@@ -306,7 +426,7 @@ describe('findOrCreateWine — creation', () => {
     jest.clearAllMocks();
     WineDefinition.findOne.mockReturnValue(findOneChain(null));
     searchService.getIsAvailable.mockReturnValue(false);
-    WineDefinition.find.mockReturnValue(textSearchChain([]));
+    primeFind();
     Country.findOne.mockResolvedValue({ _id: 'country-1' });
     Region.findOne.mockResolvedValue({ _id: 'region-1' });
     Grape.findOne.mockResolvedValue({ _id: 'grape-1' });


### PR DESCRIPTION
## Problem

On 2026-07-11 a user re-imported a cellar export from his **self-hosted Cellarion instance** via `POST /api/cellar-import`. The file's registry names embedded the producer (`"Amisfield Pinot Noir"` / producer `"Amisfield"`), and the importer passes names **verbatim** into `findOrCreateWine({confirmCreate: true})` — no AI, no producer-strip, soft zone bypassed. Result: **39 producer-in-name registry wines** in one import, several duplicating existing clean entries.

Why the existing defenses missed:
- The exact `normalizedKey` match includes the appellation — the file said `"Cromwell"`, the registry twin says `"Central Otago"`.
- Fuzzy score of `"Amisfield Pinot Noir"` vs `"Pinot Noir"` ≈ 0.70 (name weight drags it below the 0.85 soft zone), and `confirmCreate` would skip the soft zone anyway.
- The hardened AI prompts were never in play on this path (proof: `"Penfolds Bin 407"` — the strip rule's own literal example — was among the created entries).

## Fix (single chokepoint — covers cellar import, CSV import, label scan, text search)

1. **Step 0 — canonicalize**: strip a redundant producer prefix from the incoming name (`utils/producerPrefix`, looped for doubled prefixes) before any matching/creation. The registry never stores producer-in-name.
2. **Step 1b — sibling match**: after an exact-key miss, a **unique** producer+name hit (appellation-agnostic, anchored prefix regex on the indexed `normalizedKey`) is treated as the same wine. Several siblings still fall through to the fuzzy scorer so the soft zone disambiguates instead of picking arbitrarily.
3. **User agency preserved**: the find-or-create route passes the new `skipSiblingMatch` together with `confirmCreate`, so a user who reviewed the "did you mean?" candidates and explicitly chose *create anyway* is not silently overridden.

## Testing

- `findOrCreateWine` suite extended: 9 new tests (strip before key lookup, stripped creation, doubled prefix, name==producer no-op, unique-sibling match incl. under `confirmCreate`, anchored regex shape, multi-sibling fall-through, `skipSiblingMatch`). Test harness reworked to dispatch `WineDefinition.find` mocks by query shape.
- Full backend suite: **82 suites / 1330 tests green**.
- **Docker e2e**: rebuilt backend, exercised `/api/wines/find-or-create` with (A) prefixed name + same appellation, (B) clean name + different appellation, (C) prefixed name + different appellation (the exact prod failure) — all three return the existing registry wine with `created: false`; wine count unchanged.

## Deploy notes

- Backend-only; **no docker-compose changes**, no new env vars, no migration.
- The admin wine-request resolve form still creates verbatim from request data (admin-reviewed) — left as-is deliberately; can add a strip-warning in the UI later if wanted.
- Prod still holds 42 producer-in-name entries created before this fix — being cleaned up separately via the admin strip/merge endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)