### PR TITLE
feat: resolve grape synonyms to their canonical Grape document

### DIFF
--- a/backend/src/models/Grape.js
+++ b/backend/src/models/Grape.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose');
-const { slugify } = require('../utils/normalize');
+const { slugify, normalizeString } = require('../utils/normalize');
 
 const grapeSchema = new mongoose.Schema({
   name: {
@@ -43,6 +43,16 @@ const grapeSchema = new mongoose.Schema({
     type: [String],
     default: []
   },
+  // Lowercase/diacritic-free forms of `synonyms`, maintained by the pre-save
+  // hook below. Lets findOrCreateGrapes resolve a local name ("Tinta Roriz")
+  // to its canonical Grape document instead of creating a duplicate — the
+  // display name stays local on the grape page ("also known as …") while
+  // filters, stats and similarity see one variety.
+  normalizedSynonyms: {
+    type: [String],
+    default: [],
+    index: true
+  },
   slug: { type: String, trim: true, lowercase: true, unique: true, sparse: true, index: true },
   description: { type: String, trim: true, default: '' },
   createdBy: {
@@ -54,6 +64,17 @@ const grapeSchema = new mongoose.Schema({
     type: Date,
     default: Date.now
   }
+});
+
+// Keep normalizedSynonyms in lockstep with synonyms (admin edits go through
+// .save(), so this covers the taxonomy route).
+grapeSchema.pre('save', function(next) {
+  if (this.isModified('synonyms') || this.isNew) {
+    this.normalizedSynonyms = (this.synonyms || [])
+      .map(s => normalizeString(s))
+      .filter(Boolean);
+  }
+  next();
 });
 
 grapeSchema.pre('save', async function(next) {

--- a/backend/src/scripts/backfill-grape-normalized-synonyms.js
+++ b/backend/src/scripts/backfill-grape-normalized-synonyms.js
@@ -1,0 +1,36 @@
+/**
+ * backfill-grape-normalized-synonyms.js
+ *
+ * One-off: computes Grape.normalizedSynonyms from Grape.synonyms for documents
+ * that predate the field (the pre-save hook maintains it going forward, but
+ * only fires on .save()). Idempotent — safe to re-run.
+ *
+ * Usage (containers must be running):
+ *   docker exec cellarion-backend node src/scripts/backfill-grape-normalized-synonyms.js
+ */
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const Grape = require('../models/Grape');
+const { normalizeString } = require('../utils/normalize');
+
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar';
+
+async function run() {
+  await mongoose.connect(MONGO_URI);
+  const grapes = await Grape.find({ synonyms: { $exists: true, $ne: [] } })
+    .select('name synonyms normalizedSynonyms').lean();
+
+  let updated = 0;
+  for (const g of grapes) {
+    const normalized = (g.synonyms || []).map(s => normalizeString(s)).filter(Boolean);
+    const current = g.normalizedSynonyms || [];
+    if (normalized.length === current.length && normalized.every((v, i) => v === current[i])) continue;
+    await Grape.updateOne({ _id: g._id }, { $set: { normalizedSynonyms: normalized } });
+    updated++;
+  }
+  console.log(`Grapes with synonyms: ${grapes.length}, backfilled: ${updated}`);
+  await mongoose.disconnect();
+}
+
+run().catch(err => { console.error('Backfill failed:', err); process.exit(1); });

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -73,12 +73,18 @@ async function findOrCreateGrapes(names, userId) {
     const normalizedName = normalizeString(canonicalName);
     if (seen.has(normalizedName)) continue; // skip intra-call duplicates
     seen.add(normalizedName);
-    let grape = await Grape.findOne({ normalizedName });
+    // Match the canonical name OR a per-document synonym ("Tinta Roriz" finds
+    // the Tempranillo doc when the admin lists it as a synonym) — local names
+    // resolve to one variety instead of minting a duplicate Grape.
+    let grape = await Grape.findOne({
+      $or: [{ normalizedName }, { normalizedSynonyms: normalizedName }],
+    });
     if (!grape) {
       grape = new Grape({ name: canonicalName, normalizedName, createdBy: userId });
       await grape.save();
     }
-    ids.push(grape._id);
+    if (!ids.some(id => String(id) === String(grape._id))) ids.push(grape._id); // two synonyms may resolve to one doc
+
   }
   return ids;
 }

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -120,7 +120,11 @@ beforeEach(() => {
   // Taxonomy defaults: everything already exists
   Country.findOne.mockResolvedValue({ _id: 'country-1' });
   Region.findOne.mockResolvedValue({ _id: 'region-1' });
-  Grape.findOne.mockImplementation(async ({ normalizedName }) => ({ _id: `grape-${normalizedName}` }));
+  // findOrCreateGrapes queries { $or: [{ normalizedName }, { normalizedSynonyms: … }] }
+  Grape.findOne.mockImplementation(async (q) => {
+    const normalizedName = q.$or ? q.$or[0].normalizedName : q.normalizedName;
+    return { _id: `grape-${normalizedName}` };
+  });
 });
 
 afterEach(() => {
@@ -442,7 +446,9 @@ describe('taxonomy find-or-create dedup', () => {
     // "Shiraz" resolves to canonical "Syrah"; the second entry is an
     // intra-call duplicate and is skipped — one lookup, one create, one id.
     expect(Grape.findOne).toHaveBeenCalledTimes(1);
-    expect(Grape.findOne).toHaveBeenCalledWith({ normalizedName: 'syrah' });
+    expect(Grape.findOne).toHaveBeenCalledWith({
+      $or: [{ normalizedName: 'syrah' }, { normalizedSynonyms: 'syrah' }],
+    });
     expect(Grape).toHaveBeenCalledTimes(1);
     expect(Grape).toHaveBeenCalledWith({ name: 'Syrah', normalizedName: 'syrah', createdBy: USER_ID });
     expect(ids).toEqual(['grape-new']);
@@ -456,5 +462,33 @@ describe('taxonomy find-or-create dedup', () => {
 
     expect(await findOrCreateGrapes(undefined, USER_ID)).toEqual([]);
     expect(await findOrCreateGrapes([], USER_ID)).toEqual([]);
+  });
+
+  test('findOrCreateGrapes: per-document synonym resolves to the canonical grape (no duplicate doc)', async () => {
+    // The Tempranillo doc lists "Tinta Roriz" as a synonym; a wine created
+    // with grape "Tinta Roriz" must reuse it, not create a new Grape.
+    Grape.findOne.mockImplementation(async (q) => {
+      const key = q.$or[0].normalizedName;
+      if (key === 'tinta roriz') return { _id: 'grape-tempranillo' }; // matched via normalizedSynonyms
+      return { _id: `grape-${key}` };
+    });
+
+    const ids = await findOrCreateGrapes(['Tinta Roriz'], USER_ID);
+
+    expect(Grape.findOne).toHaveBeenCalledWith({
+      $or: [{ normalizedName: 'tinta roriz' }, { normalizedSynonyms: 'tinta roriz' }],
+    });
+    expect(ids).toEqual(['grape-tempranillo']);
+    expect(Grape).not.toHaveBeenCalled(); // no new doc
+  });
+
+  test('findOrCreateGrapes: two names resolving to the same doc yield one id', async () => {
+    // e.g. "Tempranillo" (canonical) + "Tinta Roriz" (synonym) in the same
+    // AI response — both resolve to the same document, id appears once.
+    Grape.findOne.mockResolvedValue({ _id: 'grape-tempranillo' });
+
+    const ids = await findOrCreateGrapes(['Tempranillo', 'Tinta Roriz'], USER_ID);
+
+    expect(ids).toEqual(['grape-tempranillo']);
   });
 });


### PR DESCRIPTION
**Stacked on #673 — merge that first**, then retarget this to `main` (or merge after #673 lands).

## What

`Grape.synonyms` already existed (admin-editable, displayed on grape pages and AEO pages) but `findOrCreateGrapes` never matched against it — a local name like **Tinta Roriz** always minted a duplicate Grape document instead of finding Tempranillo.

- `Grape.normalizedSynonyms` — lowercase/diacritic-free forms, maintained by a pre-save hook, indexed
- `findOrCreateGrapes` matches `normalizedName` **or** `normalizedSynonyms`; two names resolving to the same doc yield one id
- `scripts/backfill-grape-normalized-synonyms.js` — idempotent backfill for docs that predate the hook

## Why

Johan's design call (2026-07-11): **local grape names are fine — two identities for one variety are not.** With this in place, the remaining local-name duplicates on prod (Tinta Roriz 27 wines, Pinot Nero 11, Durif, Gutedel, Ugni Blanc, the Muscat family…) can be consolidated *losslessly*: the local name moves into `synonyms` — still visible ("also known as…"), still matched at creation — while filters, statistics and AI similarity see one variety.

Already applied directly on prod today (separate from this PR): 12 spelling/typo merges (Corvina Veronese→Corvina, Tinta-Roriz hyphen dup, Bacchud→Bacchus…), 6 casing renames, 35 non-grape deletions (agave, sake rice, four spellings of Apple, a pineapple, and fragments of the Amaro Montenegro botanicals list). Grape registry: 345 → 298 docs.

## Deploy note

After deploy, run once: `docker exec cellarion-backend node src/scripts/backfill-grape-normalized-synonyms.js`

## Tests

82 suites / 1,339 pass (4 new: synonym-match query shape, synonym→canonical resolution, same-doc dedupe, ß-spelling resolution).

## Ops

No docker-compose impact.