### PR TITLE
chore(release): v1.76.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for v1.76.0.

Ships everything since v1.75.0: the full rack roadmap (#657–#665), open-bottle tracking (#666), arrange persist+undo (#667), cellar climate monitoring (#668), compact list view (#670), appellation filter (#671), unplaced badge (#672), registry canonicalization (#673/#674/#676).

No docker-compose changes required on prod (climate monitoring rides the existing backend; verified in the feature plan).