### PR TITLE
fix: Open bottle action missing from the mobile bottom bar

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2306,6 +2306,7 @@
     "pickerTitle": "Open this bottle",
     "pickerText": "How will you preserve it? This sets the drink-by window — the bottle stays in your cellar until you finish it.",
     "confirmBtn": "Open bottle",
+    "openBtnShort": "Open",
     "freshness": "about {{days}} days",
     "method": {
       "coravin": "Coravin (argon needle)",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2306,6 +2306,7 @@
     "pickerTitle": "Öppna den här flaskan",
     "pickerText": "Hur bevarar du den? Det styr dryckesfönstret — flaskan ligger kvar i din källare tills du avslutar den.",
     "confirmBtn": "Öppna flaska",
+    "openBtnShort": "Öppna",
     "freshness": "cirka {{days}} dagar",
     "method": {
       "coravin": "Coravin (argonnål)",

--- a/frontend/src/pages/BottleDetail.css
+++ b/frontend/src/pages/BottleDetail.css
@@ -90,6 +90,16 @@
   background: var(--color-primary-light);
 }
 
+.bd-mobile-action-open {
+  background: var(--color-surface-raised);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.bd-mobile-action-open:hover {
+  background: var(--color-primary-light);
+}
+
 .bd-mobile-action-consume {
   background: #6a3d8a;
   color: white;

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -624,6 +624,15 @@ function BottleDetail() {
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
             {t('bottleDetail.editDetailsShort')}
           </button>
+          {/* Same visibility rule as the desktop header button — the mobile
+              bar was missed when open-bottle tracking shipped (canEdit already
+              excludes consumed bottles). */}
+          {!bottle?.openedAt && (
+            <button className="bd-mobile-action-btn bd-mobile-action-open" onClick={() => setOpenPickerOpen(true)}>
+              <span aria-hidden="true">🍷</span>
+              {t('openBottle.openBtnShort', 'Open')}
+            </button>
+          )}
           <button className="bd-mobile-action-btn bd-mobile-action-consume" onClick={() => setConsumeOpen(true)}>
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M8 2h8l4 10H4L8 2z"/><path d="M12 12v6"/><path d="M8 22h8"/></svg>
             {t('bottleDetail.removeBottleShort')}


### PR DESCRIPTION
On phones (≤768px) the bottle page swaps the desktop header actions for a sticky bottom bar — and #666 only added the **Open bottle** button to the desktop row, making open-bottle tracking unreachable on mobile (found by Johan on his phone minutes after the v1.76.0 deploy 📱).

- Adds 🍷 **Open** to the mobile bar, same visibility rule as desktop (`!bottle.openedAt`; `canEdit` already excludes consumed bottles)
- Neutral button styling matching Edit/Move
- en + sv short labels (`openBottle.openBtnShort`)

Screenshots in Johan's report: desktop shows Edit / Open bottle… / Remove / Move; mobile showed only Edit / Remove / Move.

Vite build ✓, 548 frontend tests pass. Hotfix candidate for v1.76.1.