### PR TITLE
feat: restore a mistakenly-consumed bottle from history

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -1069,6 +1069,51 @@ router.post('/:id/move', requireBottleAccess('owner'), async (req, res) => {
   }
 });
 
+// POST /api/bottles/:id/restore - Put a consumed bottle back to active.
+// The inverse of /consume: for when a bottle was marked drank/gifted/sold by
+// mistake. Clears every consumed-* field so it re-enters the cellar cleanly.
+// The bottle is NOT auto-returned to its old rack slot (the slot was freed on
+// consume and may now be occupied) — it comes back unplaced, and the user
+// re-racks it.
+router.post('/:id/restore', requireBottleAccess('editor'), async (req, res) => {
+  try {
+    const { bottle } = req;
+
+    if (bottle.status === 'active') {
+      return res.status(400).json({ error: 'Bottle is already active' });
+    }
+    if (!CONSUMED_STATUSES.includes(bottle.status)) {
+      return res.status(400).json({ error: 'Only a consumed bottle can be restored' });
+    }
+
+    const previousStatus = bottle.status;
+    bottle.status = 'active';
+    bottle.consumedAt = undefined;
+    bottle.consumedReason = undefined;
+    bottle.consumedNote = undefined;
+    bottle.consumedRating = undefined;
+    bottle.consumedRatingScale = undefined;
+    await bottle.save();
+
+    // Re-index so the bottle leaves history-only search results and rejoins the
+    // active cellar index.
+    searchService.indexBottle(bottle._id);
+
+    logAudit(req, 'bottle.restore',
+      { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
+      { from: previousStatus }
+    );
+
+    res.json({ bottle });
+  } catch (error) {
+    if (error.name === 'ValidationError') {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error('Restore bottle error:', error);
+    res.status(500).json({ error: 'Failed to restore bottle' });
+  }
+});
+
 // POST /api/bottles/:id/undo - Reverse an incorrectly-added bottle.
 // The bottle disappears from cellar, racks, search, and stats as if it had
 // never been added. Internal audit log keeps the original `bottle.add` row

--- a/backend/src/routes/bottles.restore.test.js
+++ b/backend/src/routes/bottles.restore.test.js
@@ -1,0 +1,177 @@
+/**
+ * POST /api/bottles/:id/restore — put a consumed bottle back to active.
+ *
+ * WHY THIS TEST EXISTS:
+ * The inverse of /consume, for a drink/gift/sale logged by mistake. It must:
+ *   - flip a consumed bottle back to 'active' and clear EVERY consumed-* field
+ *   - reject an already-active bottle (400) so it can't wipe live data
+ *   - be an editor-only action (requireBottleAccess('editor'))
+ *
+ * Real router + real requireAuth/requireBottleAccess (HS256 test tokens);
+ * models and side-effect services are mocked so no MongoDB is needed.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexBottle: jest.fn(),
+  removeBottle: jest.fn(),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/restockChecker', () => ({
+  checkRestockGap: jest.fn().mockResolvedValue(null),
+  resolveRestockAlerts: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../services/priceWarnings', () => ({ gatherPriceWarnings: jest.fn().mockResolvedValue([]) }));
+jest.mock('../services/communityPrice', () => ({ getCurrentRelease: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+  getSnapshotForDate: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => ({ updateMany: jest.fn() }));
+jest.mock('../models/Country', () => ({}));
+jest.mock('../models/Region', () => ({}));
+jest.mock('../models/Grape', () => ({}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('../models/PriceTrackingRequest', () => ({}));
+jest.mock('../models/BottleImage', () => ({}));
+jest.mock('../models/WineRequest', () => ({}));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const searchService = require('../services/search');
+const bottlesRouter = require('./bottles');
+
+const USER_ID = '64b000000000000000000001';
+const OTHER_ID = '64b000000000000000000002';
+const CELLAR_ID = '64b0000000000000000000bb';
+const BOTTLE_ID = '64b0000000000000000000dd';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles', bottlesRouter);
+  return app;
+}
+
+function request(method, url, userId = USER_ID) {
+  const app = buildApp();
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+            authorization: `Bearer ${jwt.sign({ id: userId, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' })}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end();
+    });
+  });
+}
+
+const restore = (userId) => request('POST', `/api/bottles/${BOTTLE_ID}/restore`, userId);
+
+function makeBottle(overrides = {}) {
+  return {
+    _id: BOTTLE_ID,
+    cellar: CELLAR_ID,
+    user: USER_ID,
+    vintage: '2018',
+    status: 'drank',
+    consumedAt: new Date('2026-07-11T11:07:00Z'),
+    consumedReason: 'drank',
+    consumedNote: 'oops',
+    consumedRating: 4,
+    consumedRatingScale: '5',
+    save: jest.fn().mockImplementation(function () { return Promise.resolve(this); }),
+    populate: jest.fn().mockImplementation(function () { return Promise.resolve(this); }),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, name: 'Main', user: USER_ID, members: [], deletedAt: null });
+});
+
+describe('POST /api/bottles/:id/restore', () => {
+  test('restores a drank bottle to active and clears every consumed field', async () => {
+    const bottle = makeBottle();
+    Bottle.findById.mockResolvedValue(bottle);
+
+    const { status, body } = await restore();
+
+    expect(status).toBe(200);
+    expect(bottle.status).toBe('active');
+    expect(bottle.consumedAt).toBeUndefined();
+    expect(bottle.consumedReason).toBeUndefined();
+    expect(bottle.consumedNote).toBeUndefined();
+    expect(bottle.consumedRating).toBeUndefined();
+    expect(bottle.consumedRatingScale).toBeUndefined();
+    expect(bottle.save).toHaveBeenCalledTimes(1);
+    expect(searchService.indexBottle).toHaveBeenCalledWith(bottle._id);
+    expect(body.bottle.status).toBe('active');
+  });
+
+  test.each(['gifted', 'sold', 'other'])('restores a %s bottle too', async (reason) => {
+    const bottle = makeBottle({ status: reason, consumedReason: reason });
+    Bottle.findById.mockResolvedValue(bottle);
+
+    const { status } = await restore();
+
+    expect(status).toBe(200);
+    expect(bottle.status).toBe('active');
+  });
+
+  test('rejects an already-active bottle (400) without saving', async () => {
+    const bottle = makeBottle({ status: 'active', consumedAt: undefined, consumedReason: undefined });
+    Bottle.findById.mockResolvedValue(bottle);
+
+    const { status, body } = await restore();
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/already active/i);
+    expect(bottle.save).not.toHaveBeenCalled();
+  });
+
+  test('is editor-only: a non-member gets 403/404, bottle untouched', async () => {
+    const bottle = makeBottle();
+    Bottle.findById.mockResolvedValue(bottle);
+
+    const { status } = await restore(OTHER_ID);
+
+    expect([403, 404]).toContain(status);
+    expect(bottle.save).not.toHaveBeenCalled();
+    expect(bottle.status).toBe('drank');
+  });
+});

--- a/frontend/src/api/bottles.js
+++ b/frontend/src/api/bottles.js
@@ -57,6 +57,13 @@ export const undoBottle = (apiFetch, id) =>
     method: 'POST',
   });
 
+// Put a consumed bottle back to active (inverse of consumeBottle) — for a
+// drink/gift/sale logged by mistake. Comes back unplaced.
+export const restoreBottle = (apiFetch, id) =>
+  apiFetch(`/api/bottles/${id}/restore`, {
+    method: 'POST',
+  });
+
 export const moveBottle = (apiFetch, id, toCellarId) =>
   apiFetch(`/api/bottles/${id}/move`, {
     method: 'POST',

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -993,6 +993,10 @@
     "addingToWishlist": "Adding…",
     "onWishlist": "On wishlist",
     "wishlistError": "Try again",
+    "restore": "Move back to cellar",
+    "restoring": "Moving back…",
+    "restoreHint": "Logged by mistake? Put this bottle back in your cellar as active (it returns unplaced).",
+    "restoreError": "Could not move it back — try again",
     "viewBottleAria": "View {{name}}",
     "noResults": "No bottles match your search."
   },

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -993,6 +993,10 @@
     "addingToWishlist": "Lägger till…",
     "onWishlist": "På önskelistan",
     "wishlistError": "Försök igen",
+    "restore": "Flytta tillbaka till källaren",
+    "restoring": "Flyttar tillbaka…",
+    "restoreHint": "Registrerad av misstag? Lägg tillbaka flaskan i källaren som aktiv (den återkommer utan hyllplats).",
+    "restoreError": "Kunde inte flytta tillbaka – försök igen",
     "viewBottleAria": "Visa {{name}}",
     "noResults": "Inga flaskor matchar din sökning."
   },

--- a/frontend/src/pages/CellarHistory.css
+++ b/frontend/src/pages/CellarHistory.css
@@ -419,6 +419,54 @@
   font-style: italic;
 }
 
+/* Restore ("move back to cellar") action — sits below the consumption details.
+   position: relative keeps it above the card's stretched-link overlay so the
+   click lands on the button, not the navigation anchor. */
+.history-bottle-actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 0.6rem;
+}
+
+.history-restore-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: var(--color-surface-2, rgba(127, 127, 127, 0.08));
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.history-restore-btn:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft, rgba(125, 42, 60, 0.08));
+}
+
+.history-restore-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.history-restore-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.history-restore-error {
+  font-size: 0.78rem;
+  color: var(--color-danger, #b3392f);
+}
+
 @media (max-width: 600px) {
   .history-summary-row {
     gap: 0.5rem;

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -6,6 +6,7 @@ import RatingDisplay from '../components/RatingDisplay';
 import WineImage from '../components/WineImage';
 import BottleFilterModal from '../components/BottleFilterModal';
 import { addToWishlist } from '../api/wishlist';
+import { restoreBottle } from '../api/bottles';
 import { listCellars, getCellarHistory, getMultiCellarHistory } from '../api/cellars';
 import CellarScopePicker from '../components/CellarScopePicker';
 import './CellarDetail.css';
@@ -123,6 +124,24 @@ function CellarHistory() {
     } finally {
       if (seq === fetchSeq.current) setLoading(false);
     }
+  };
+
+  // Restoring a consumed bottle is an editor/owner action (the backend
+  // re-checks per bottle). In the cross-cellar view we don't have a per-row
+  // role, so gate on the page cellar's role.
+  const canEdit = ['owner', 'editor'].includes(cellar?.userRole);
+
+  // Drop a restored bottle from the history list in place (it's back in the
+  // active cellar now) without a full refetch.
+  const handleRestored = (bottleId) => {
+    setGrouped(prev => {
+      const next = {};
+      for (const [key, items] of Object.entries(prev)) {
+        next[key] = items.filter(b => b._id !== bottleId);
+      }
+      return next;
+    });
+    setTotal(prev => Math.max(0, prev - 1));
   };
 
   // Only replace the whole page when nothing has loaded yet; after a successful
@@ -311,7 +330,7 @@ function CellarHistory() {
               </div>
               <div className="history-bottles">
                 {items.map(bottle => (
-                  <HistoryBottleCard key={bottle._id} bottle={bottle} cellarId={id} showCellarBadge={isMulti} />
+                  <HistoryBottleCard key={bottle._id} bottle={bottle} cellarId={id} showCellarBadge={isMulti} canRestore={canEdit} onRestored={handleRestored} />
                 ))}
               </div>
             </section>
@@ -329,10 +348,28 @@ function CellarHistory() {
   );
 }
 
-function HistoryBottleCard({ bottle, cellarId, showCellarBadge = false }) {
+function HistoryBottleCard({ bottle, cellarId, showCellarBadge = false, canRestore = false, onRestored }) {
   const { t } = useTranslation();
   const { apiFetch, user } = useAuth();
   const wine = bottle.wineDefinition;
+  const [restoreState, setRestoreState] = useState('idle'); // idle | saving | error
+
+  const handleRestore = async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (restoreState === 'saving') return;
+    setRestoreState('saving');
+    try {
+      const res = await restoreBottle(apiFetch, bottle._id);
+      if (res.ok) {
+        onRestored?.(bottle._id);
+      } else {
+        setRestoreState('error');
+      }
+    } catch {
+      setRestoreState('error');
+    }
+  };
   // In the cross-cellar view each row belongs to its own cellar; fall back to
   // the page's cellar id for the single-cellar view.
   const linkCellarId = bottle.cellar || cellarId;
@@ -436,6 +473,26 @@ function HistoryBottleCard({ bottle, cellarId, showCellarBadge = false }) {
           <p className="history-note">"{bottle.consumedNote}"</p>
         )}
       </div>
+
+      {canRestore && (
+        <div className="history-bottle-actions">
+          <button
+            type="button"
+            className="history-restore-btn"
+            onClick={handleRestore}
+            disabled={restoreState === 'saving'}
+            title={t('history.restoreHint')}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><polyline points="3 3 3 8 8 8"/>
+            </svg>
+            <span>{restoreState === 'saving' ? t('history.restoring') : t('history.restore')}</span>
+          </button>
+          {restoreState === 'error' && (
+            <span className="history-restore-error">{t('history.restoreError')}</span>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Johan drank a bottle by mistake (well — *logged* it by mistake 🍷) and there was no way back: `/undo` only deletes mistake-added **active** bottles and explicitly refuses consumed ones.

## Backend
- **POST `/api/bottles/:id/restore`** — inverse of `/consume`: flips the bottle back to `active`, clears every consumed-* field (date, reason, note, rating, scale), re-indexes search, audit-logs `bottle.restore` with the previous status
- Editor-only (`requireBottleAccess('editor')`); 400 on an already-active bottle
- The bottle is **not** auto-returned to its old rack slot (freed on consume, may be occupied) — it comes back **unplaced** and shows the v1.76.0 Unplaced badge

## Frontend
- History page: every bottle card gets a **"Move back to cellar"** button (owners/editors only), with saving/error states; the card leaves the list in place on success
- en + sv strings

## Tests
- 6 new route tests (restore per consumed reason, field clearing, already-active 400, editor-only access)
- Backend suite + frontend suite green; Vite build ✓

## Ops
No docker-compose impact.