### PR TITLE
chore(release): v1.78.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for v1.78.0: unified cellar navigation strip, tidied bottle actions (overflow menu), restore-to-detail-view with a 2-day window, and removal of dead tour markers (#681).