### PR TITLE
feat: consistent cellar navigation — underline tabs, shared header, responsive Cellar Book

### DIFF
--- a/frontend/src/components/CellarNav.css
+++ b/frontend/src/components/CellarNav.css
@@ -1,17 +1,16 @@
-/* Shared cellar view switcher — visual twin of the CellarDetail segmented
-   tabs so pages that adopt it look native. Horizontally scrollable on
-   phones instead of wrapping. */
+/* Shared cellar view switcher — an underline tab bar (not a segmented pill
+   control). The segmented look was byte-identical to the app's in-page filter
+   toggles (e.g. the rack-lens control), so the nav didn't read as navigation.
+   Underline tabs are the web's canonical "separate destinations" idiom.
+   Horizontally scrollable on phones; hidden in print (Cellar Book). */
 .cellar-nav {
   display: flex;
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 3px;
+  gap: 0.25rem;
   margin: 1rem 0;
-  gap: 3px;
+  border-bottom: 1px solid var(--color-border);
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  scrollbar-width: none; /* the strip itself signals scrollability by cut-off tabs */
+  scrollbar-width: none;
 }
 
 .cellar-nav::-webkit-scrollbar {
@@ -19,44 +18,44 @@
 }
 
 .cellar-nav-tab {
-  flex: 1;
+  flex: 0 0 auto;                 /* natural width, left-aligned (tab-bar look) */
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  padding: 0.6rem 0.75rem;
+  padding: 0.6rem 0.9rem;
   border: none;
-  border-radius: calc(var(--radius-md) - 2px);
   background: transparent;
   color: var(--color-text-muted);
-  font-size: 0.88rem;
+  font-size: 0.9rem;
   font-weight: 500;
   font-family: var(--font-body);
   cursor: pointer;
-  transition: all var(--transition-fast);
   min-height: 44px;
-  position: relative;
-  text-decoration: none;
   white-space: nowrap;
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;            /* sit the 2px indicator on the strip's 1px baseline */
+  transition: color var(--transition-fast), border-color var(--transition-fast);
 }
 
 .cellar-nav-tab:hover {
   color: var(--color-text-secondary);
+  border-bottom-color: var(--color-border);
 }
 
 .cellar-nav-tab.active {
-  background: var(--color-surface);
   color: var(--color-primary);
-  box-shadow: var(--shadow-sm);
+  border-bottom-color: var(--color-primary);
   font-weight: 600;
 }
 
 .cellar-nav-tab:focus-visible {
   outline: 2px solid var(--color-border-focus);
   outline-offset: -2px;
+  border-radius: var(--radius-sm);
 }
 
-/* Never print the navigation (the Cellar Book is a print view) */
 @media print {
   .cellar-nav {
     display: none;

--- a/frontend/src/components/CellarPageHeader.css
+++ b/frontend/src/components/CellarPageHeader.css
@@ -1,0 +1,70 @@
+/* Shared header block above the CellarNav strip. Fixed shape + a
+   height-reserved subtitle line so the nav anchors at the same Y on every
+   cellar page, regardless of whether a subtitle/description is present, the
+   page is still loading, or page-specific action buttons are shown. */
+.cellar-page-header {
+  margin-bottom: 0;              /* the nav's own 1rem top margin is the only gap, everywhere */
+}
+
+.cellar-page-header-main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 0.25rem;
+}
+
+.cellar-page-header-titles {
+  min-width: 0;                  /* allow the title to truncate, don't push actions off-screen */
+}
+
+.cellar-page-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-family: var(--font-heading);
+  color: var(--color-text);
+}
+
+@media (max-width: 768px) {
+  .cellar-page-header h1 {
+    font-size: 1.3rem;
+  }
+}
+
+.cellar-page-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  min-height: 1.2em;             /* RESERVE the line even when empty → no gap, no load-time jump */
+}
+
+.cellar-page-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+/* Self-contained loading skeleton so the component works on pages that don't
+   import CellarDetail.css. */
+.cph-skeleton-h1 {
+  height: 1.5rem;
+  width: 40%;
+  min-width: 8rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-border);
+  animation: cph-skeleton-pulse 1.2s ease-in-out infinite;
+}
+
+@media (max-width: 768px) {
+  .cph-skeleton-h1 { height: 1.3rem; }
+}
+
+@keyframes cph-skeleton-pulse {
+  0%, 100% { opacity: 0.4; }
+  50%      { opacity: 0.8; }
+}
+
+@media print {
+  .cellar-page-header { display: none; }
+}

--- a/frontend/src/components/CellarPageHeader.js
+++ b/frontend/src/components/CellarPageHeader.js
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom';
+import './CellarPageHeader.css';
+
+/**
+ * Standard header block that sits ABOVE <CellarNav> on every cellar subpage.
+ * A fixed shape (back-link row → title + always-reserved subtitle line, with an
+ * optional right-side action slot) means the nav strip always anchors at the
+ * same vertical position, so it no longer "jumps" as the user moves between
+ * Bottles / Racks / Room / History / Cellar Book.
+ *
+ *   backTo, backLabel   — the shared back-link
+ *   title               — cellar name / page title (string or node)
+ *   subtitle            — one optional line; its space is ALWAYS reserved
+ *   loading             — swap the h1 for a skeleton
+ *   userColor           — left accent border on the h1
+ *   titleBadge          — optional inline node after the h1 (e.g. shared-by / Beta)
+ *   actions             — right-aligned action slot (buttons / menus)
+ */
+function CellarPageHeader({ backTo, backLabel, title, subtitle, loading, userColor, titleBadge, actions }) {
+  return (
+    <div className="cellar-page-header">
+      <Link to={backTo} className="back-link">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+        {backLabel}
+      </Link>
+      <div className="cellar-page-header-main">
+        <div className="cellar-page-header-titles">
+          {loading ? (
+            <div className="cph-skeleton-h1" />
+          ) : (
+            <h1 className={userColor ? 'cellar-accent-border' : ''} style={userColor ? { '--cellar-color': userColor } : undefined}>
+              {title}{titleBadge}
+            </h1>
+          )}
+          <p className="cellar-page-subtitle">{loading ? '' : subtitle}</p>
+        </div>
+        {actions && <div className="cellar-page-header-actions">{actions}</div>}
+      </div>
+    </div>
+  );
+}
+
+export default CellarPageHeader;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -880,6 +880,7 @@
 
   "room": {
     "title": "Room View",
+    "subtitle": "3D cellar layout",
     "backToRacks": "Racks",
     "editMode": "Edit",
     "viewMode": "View",
@@ -2294,6 +2295,7 @@
     "linkBtn": "Cellar Book",
     "linkDesc": "Printable rack maps & lists",
     "printBtn": "Print / Save as PDF",
+    "tableAria": "Bottle list (scroll sideways to see all columns)",
     "backToRacks": "Back to racks",
     "backToCellar": "Back to cellar",
     "summary": "{{total}} bottles — {{placed}} in racks, {{unplaced}} unplaced",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -880,6 +880,7 @@
 
   "room": {
     "title": "Rumsvy",
+    "subtitle": "3D-källarlayout",
     "backToRacks": "Hyllor",
     "editMode": "Redigera",
     "viewMode": "Visa",
@@ -2294,6 +2295,7 @@
     "linkBtn": "Källarbok",
     "linkDesc": "Utskrivbara ställkartor & listor",
     "printBtn": "Skriv ut / Spara som PDF",
+    "tableAria": "Flasklista (skrolla i sidled för att se alla kolumner)",
     "backToRacks": "Tillbaka till hyllorna",
     "backToCellar": "Tillbaka till källaren",
     "summary": "{{total}} flaskor — {{placed}} i hyllor, {{unplaced}} oplacerade",

--- a/frontend/src/pages/CellarBook.css
+++ b/frontend/src/pages/CellarBook.css
@@ -14,12 +14,10 @@
   padding-top: 3rem;
 }
 
-.cb-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+/* The screen header lives in the shared CellarPageHeader above the nav; the
+   .cb-header block is the PRINT document heading only. */
+.cb-header {
+  display: none;
 }
 
 .cb-header h1 {
@@ -122,6 +120,25 @@
   white-space: nowrap;
 }
 
+/* On screen the 6 nowrap columns exceed a phone's width; scroll the table
+   inside its own container so the page body never scrolls sideways. */
+.cb-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* On phones, drop the three lowest-value columns — Type is already conveyed by
+   the colored rack-map slot, and Rating/Drink-window are supplementary. Pos +
+   Wine + Vintage are enough to locate and identify a bottle. (The full table
+   is restored for print below.) */
+@media screen and (max-width: 640px) {
+  .cb-col-type,
+  .cb-col-rating,
+  .cb-col-window {
+    display: none;
+  }
+}
+
 .cb-wine-name {
   font-weight: 600;
 }
@@ -167,8 +184,20 @@
     color: #000;
   }
 
-  .cb-toolbar {
-    display: none;
+  /* Print: the shared screen header + nav are hidden; show the print document
+     heading and the FULL table (every column, no scroll wrapper). */
+  .cb-header {
+    display: block;
+  }
+
+  .cb-table-wrap {
+    overflow-x: visible;
+  }
+
+  .cb-col-type,
+  .cb-col-rating,
+  .cb-col-window {
+    display: table-cell;
   }
 
   /* Each rack starts on a fresh page — the first follows the header. */

--- a/frontend/src/pages/CellarBook.js
+++ b/frontend/src/pages/CellarBook.js
@@ -8,6 +8,7 @@ import { buildCellarBook, formatDrinkWindow } from '../utils/cellarBook';
 import { formatRating } from '../utils/ratingUtils';
 import PrintRackMap from '../components/racks/PrintRackMap';
 import CellarNav from '../components/CellarNav';
+import CellarPageHeader from '../components/CellarPageHeader';
 import './CellarBook.css';
 
 // The cellar bottles endpoint caps page size at 200 — loop until we have
@@ -101,21 +102,25 @@ function CellarBook() {
 
   return (
     <div className="cellar-book">
-      {/* Screen-only toolbar */}
-      <div className="cb-toolbar">
-        <Link to={`/cellars/${id}`} className="back-link">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
-          {t('cellarBook.backToCellar', 'Back to cellar')}
-        </Link>
-        <button className="btn btn-primary" onClick={() => window.print()}>
-          {t('cellarBook.printBtn', 'Print / Save as PDF')}
-        </button>
-      </div>
+      {/* Screen header — shared shape so the nav anchors like every other page.
+          Print button folded into the action slot. Hidden in print. */}
+      <CellarPageHeader
+        backTo={`/cellars/${id}`}
+        backLabel={t('cellarBook.backToCellar', 'Back to cellar')}
+        title={cellar?.name}
+        subtitle={t('cellarBook.title', 'Cellar Book')}
+        actions={
+          <button className="btn btn-primary btn-small" onClick={() => window.print()}>
+            {t('cellarBook.printBtn', 'Print / Save as PDF')}
+          </button>
+        }
+      />
 
       {/* Shared view switcher (screen only — CellarNav hides itself in print) */}
       <CellarNav cellarId={id} active="book" />
 
-      {/* Book header */}
+      {/* Print-only document heading (hidden on screen; the screen header above
+          carries the title). */}
       <header className="cb-header">
         <h1>{cellar?.name}</h1>
         <p className="cb-subtitle">{t('cellarBook.title', 'Cellar Book')}</p>
@@ -171,6 +176,7 @@ function CellarBook() {
 
 function BottleTable({ entries, t }) {
   return (
+    <div className="cb-table-wrap" role="group" tabIndex={0} aria-label={t('cellarBook.tableAria', 'Bottle list (scroll sideways to see all columns)')}>
     <table className="cb-table">
       <thead>
         <tr>
@@ -210,6 +216,7 @@ function BottleTable({ entries, t }) {
         })}
       </tbody>
     </table>
+    </div>
   );
 }
 

--- a/frontend/src/pages/CellarDetail.css
+++ b/frontend/src/pages/CellarDetail.css
@@ -3,19 +3,10 @@
   margin: 0 auto;
 }
 
-/* ── Header ── */
-.cellar-header {
-  margin-bottom: 0.25rem;
-}
+/* ── Header (now provided by the shared CellarPageHeader component) ── */
 
-.cellar-header h1 {
-  margin: 0.25rem 0 0;
-  font-size: 1.5rem;
-  color: var(--color-text);
-  font-family: var(--font-heading);
-}
-
-/* Skeleton placeholder while cellar data loads */
+/* Skeleton placeholder while cellar data loads (still used by other views
+   that import this stylesheet). */
 .skeleton-h1 {
   height: 1.5rem;
   width: 40%;
@@ -30,28 +21,12 @@
   50%      { opacity: 0.8; }
 }
 
-.cellar-header-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.cellar-header-desktop-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.cellar-description {
-  color: var(--color-text-secondary);
-  margin: 0.25rem 0 0;
-  font-size: 0.9rem;
-}
-
-.shared-by-label {
-  margin-top: 0.35rem;
-  font-size: 0.85rem;
-  color: var(--color-text-secondary);
+/* "+ Add bottle" is desktop-only in the header action slot; the mobile FAB
+   covers phones. */
+@media (max-width: 768px) {
+  .cph-desktop-only {
+    display: none;
+  }
 }
 
 .shared-role-tag {
@@ -994,10 +969,6 @@
 
 /* ── Mobile ── */
 @media (max-width: 768px) {
-  .cellar-header-desktop-actions .btn-primary {
-    display: none;
-  }
-
   .fab {
     display: flex;
   }
@@ -1041,14 +1012,6 @@
 }
 
 @media (max-width: 480px) {
-  .cellar-header h1 {
-    font-size: 1.3rem;
-  }
-
-  .cellar-tabs {
-    margin: 0.75rem 0;
-  }
-
   .statistics-grid {
     grid-template-columns: repeat(2, 1fr);
   }

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -10,6 +10,7 @@ import BottleFilterModal from '../components/BottleFilterModal';
 import CellarScopePicker from '../components/CellarScopePicker';
 import ClimateCard from '../components/ClimateCard';
 import CellarNav from '../components/CellarNav';
+import CellarPageHeader from '../components/CellarPageHeader';
 import './CellarDetail.css';
 
 // Stable empty rack map for the cross-cellar view (rack placement is per-cellar,
@@ -244,11 +245,6 @@ function CellarDetail() {
   // cellar is loaded, transient fetch failures render as an inline banner.
   if (error && !cellar) return <div className="alert alert-error">{error}</div>;
 
-  const h1Style = cellar?.userColor
-    ? { '--cellar-color': cellar.userColor }
-    : {};
-  const h1Class = cellar?.userColor ? 'cellar-accent-border' : '';
-
   return (
     <div className="cellar-detail-page">
       {error && (
@@ -264,133 +260,119 @@ function CellarDetail() {
           </button>
         </div>
       )}
-      {/* ── Header — shell renders immediately, details fill in after load ── */}
-      <div className="cellar-header">
-        <div className="cellar-header-top">
-          <Link to="/cellars?all=1" className="back-link">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
-            {t('cellarDetail.backToCellars')}
-          </Link>
-          {/* Desktop-only add bottle button */}
-          {!loading && (
-            <div className="cellar-header-desktop-actions">
-              {canEdit && (
-                <Link to={`/cellars/${id}/add-bottle`} className="btn btn-primary btn-small">
-                  + {t('cellarDetail.addBottle')}
-                </Link>
-              )}
-              <div className="more-menu-wrap">
-                <button
-                  className="btn btn-secondary btn-small btn-more"
-                  onClick={() => setMoreOpen(o => !o)}
-                  aria-label={t('cellarDetail.moreActions')}
-                  aria-haspopup="menu"
-                  aria-expanded={moreOpen}
-                >
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg>
-                </button>
-                {moreOpen && (
-                  <>
-                    <div className="more-menu-backdrop" onClick={() => setMoreOpen(false)} aria-hidden="true" />
-                    {/* Views (Racks/History/…) moved to the CellarNav strip —
-                        this menu now holds actions only: Manage / Data / Danger. */}
-                    <div className="more-menu-dropdown" role="menu">
-                      {cellar.userRole === 'owner' && (
-                        <button
-                          className="more-menu-item"
-                          onClick={() => { setShowEditModal(true); setMoreOpen(false); }}
-                        >
-                          <span aria-hidden="true">✏️</span> {t('cellarDetail.editCellar')}
-                        </button>
-                      )}
+      {/* ── Header — shared shape so the nav anchors at the same Y everywhere ── */}
+      <CellarPageHeader
+        backTo="/cellars?all=1"
+        backLabel={t('cellarDetail.backToCellars')}
+        title={cellar?.name}
+        loading={loading}
+        userColor={cellar?.userColor}
+        subtitle={cellar?.description}
+        titleBadge={!loading && cellar?.userRole && cellar.userRole !== 'owner' ? (
+          <span className={`shared-role-tag shared-role-tag--${cellar.userRole}`} style={{ marginLeft: '0.5rem' }}>
+            {t('cellarDetail.sharedBy')} {cellar.user?.username}
+          </span>
+        ) : null}
+        actions={!loading && (
+          <>
+            {canEdit && (
+              <Link to={`/cellars/${id}/add-bottle`} className="btn btn-primary btn-small cph-desktop-only">
+                + {t('cellarDetail.addBottle')}
+              </Link>
+            )}
+            <div className="more-menu-wrap">
+              <button
+                className="btn btn-secondary btn-small btn-more"
+                onClick={() => setMoreOpen(o => !o)}
+                aria-label={t('cellarDetail.moreActions')}
+                aria-haspopup="menu"
+                aria-expanded={moreOpen}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+              </button>
+              {moreOpen && (
+                <>
+                  <div className="more-menu-backdrop" onClick={() => setMoreOpen(false)} aria-hidden="true" />
+                  {/* Views (Racks/History/…) live in the CellarNav strip —
+                      this menu holds actions only: Manage / Data / Danger. */}
+                  <div className="more-menu-dropdown" role="menu">
+                    {cellar.userRole === 'owner' && (
                       <button
                         className="more-menu-item"
-                        onClick={() => setShowColorPicker(true) || setMoreOpen(false)}
+                        onClick={() => { setShowEditModal(true); setMoreOpen(false); }}
                       >
-                        <span aria-hidden="true">🎨</span> {t('cellarDetail.setColor')}
+                        <span aria-hidden="true">✏️</span> {t('cellarDetail.editCellar')}
                       </button>
-                      {cellar.userRole === 'owner' && (
+                    )}
+                    <button
+                      className="more-menu-item"
+                      onClick={() => setShowColorPicker(true) || setMoreOpen(false)}
+                    >
+                      <span aria-hidden="true">🎨</span> {t('cellarDetail.setColor')}
+                    </button>
+                    {cellar.userRole === 'owner' && (
+                      <button
+                        className="more-menu-item"
+                        onClick={() => { setShowShareModal(true); setMoreOpen(false); }}
+                      >
+                        <span aria-hidden="true">🔗</span> {t('cellarDetail.share')}
+                      </button>
+                    )}
+                    {cellar.userRole === 'owner' && (
+                      <Link
+                        to={`/cellars/${id}/wine-lists`}
+                        className="more-menu-item"
+                        onClick={() => setMoreOpen(false)}
+                      >
+                        <span aria-hidden="true">📋</span> {t('cellarDetail.wineLists')}
+                      </Link>
+                    )}
+                    {(canEdit || cellar.userRole === 'owner') && <div className="more-menu-divider" />}
+                    {canEdit && (
+                      <Link
+                        to={`/cellars/${id}/import`}
+                        className="more-menu-item"
+                        onClick={() => setMoreOpen(false)}
+                      >
+                        <span aria-hidden="true">📥</span> {t('cellarDetail.importBottles')}
+                      </Link>
+                    )}
+                    {cellar.userRole === 'owner' && (
+                      <Link
+                        to={`/export-cellar?cellar=${id}`}
+                        className="more-menu-item"
+                        onClick={() => setMoreOpen(false)}
+                      >
+                        <span aria-hidden="true">📤</span> {t('cellarDetail.export')}
+                      </Link>
+                    )}
+                    {cellar.userRole === 'owner' && (
+                      <Link
+                        to={`/cellars/${id}/audit`}
+                        className="more-menu-item"
+                        onClick={() => setMoreOpen(false)}
+                      >
+                        <span aria-hidden="true">🧾</span> {t('cellarDetail.auditLog')}
+                      </Link>
+                    )}
+                    {cellar.userRole === 'owner' && (
+                      <>
+                        <div className="more-menu-divider" />
                         <button
-                          className="more-menu-item"
-                          onClick={() => { setShowShareModal(true); setMoreOpen(false); }}
+                          className="more-menu-item more-menu-item--danger"
+                          onClick={() => { setShowDeleteModal(true); setMoreOpen(false); }}
                         >
-                          <span aria-hidden="true">🔗</span> {t('cellarDetail.share')}
+                          <span aria-hidden="true">🗑️</span> {t('cellarDetail.deleteCellar')}
                         </button>
-                      )}
-                      {cellar.userRole === 'owner' && (
-                        <Link
-                          to={`/cellars/${id}/wine-lists`}
-                          className="more-menu-item"
-                          onClick={() => setMoreOpen(false)}
-                        >
-                          <span aria-hidden="true">📋</span> {t('cellarDetail.wineLists')}
-                        </Link>
-                      )}
-                      {(canEdit || cellar.userRole === 'owner') && <div className="more-menu-divider" />}
-                      {canEdit && (
-                        <Link
-                          to={`/cellars/${id}/import`}
-                          className="more-menu-item"
-                          onClick={() => setMoreOpen(false)}
-                        >
-                          <span aria-hidden="true">📥</span> {t('cellarDetail.importBottles')}
-                        </Link>
-                      )}
-                      {cellar.userRole === 'owner' && (
-                        <Link
-                          to={`/export-cellar?cellar=${id}`}
-                          className="more-menu-item"
-                          onClick={() => setMoreOpen(false)}
-                        >
-                          <span aria-hidden="true">📤</span> {t('cellarDetail.export')}
-                        </Link>
-                      )}
-                      {cellar.userRole === 'owner' && (
-                        <Link
-                          to={`/cellars/${id}/audit`}
-                          className="more-menu-item"
-                          onClick={() => setMoreOpen(false)}
-                        >
-                          <span aria-hidden="true">🧾</span> {t('cellarDetail.auditLog')}
-                        </Link>
-                      )}
-                      {cellar.userRole === 'owner' && (
-                        <>
-                          <div className="more-menu-divider" />
-                          <button
-                            className="more-menu-item more-menu-item--danger"
-                            onClick={() => { setShowDeleteModal(true); setMoreOpen(false); }}
-                          >
-                            <span aria-hidden="true">🗑️</span> {t('cellarDetail.deleteCellar')}
-                          </button>
-                        </>
-                      )}
-                    </div>
-                  </>
-                )}
-              </div>
+                      </>
+                    )}
+                  </div>
+                </>
+              )}
             </div>
-          )}
-        </div>
-
-        {loading ? (
-          <div className="skeleton-h1" />
-        ) : (
-          <>
-            <h1 className={h1Class} style={h1Style}>{cellar.name}</h1>
-            {cellar.description && <p className="cellar-description">{cellar.description}</p>}
-            {cellar.userRole && cellar.userRole !== 'owner' && (
-              <p className="shared-by-label">
-                {t('cellarDetail.sharedBy')} <strong>{cellar.user?.username}</strong>
-                {' · '}
-                <span className={`shared-role-tag shared-role-tag--${cellar.userRole}`}>
-                  {cellar.userRole === 'editor' ? t('cellarDetail.editAccess') : t('cellarDetail.viewAccess')}
-                </span>
-              </p>
-            )}
           </>
         )}
-      </div>
+      />
 
       {/* ── View switcher: in-page Bottles/Overview toggles + links to every
              other cellar view (shared CellarNav strip used on all subpages) ── */}

--- a/frontend/src/pages/CellarHistory.css
+++ b/frontend/src/pages/CellarHistory.css
@@ -3,30 +3,7 @@
   margin: 0 auto;
 }
 
-.history-header {
-  margin-bottom: 0.25rem;
-}
-
-.history-header h1 {
-  margin: 0.25rem 0 0;
-  font-size: 1.5rem;
-  color: var(--color-text);
-  font-family: var(--font-heading);
-}
-
-.history-header .skeleton-h1 {
-  height: 1.5rem;
-  width: 30%;
-  margin: 0.25rem 0 0;
-  background: var(--color-border);
-  border-radius: var(--radius-sm);
-  animation: skeleton-pulse 1.2s ease-in-out infinite;
-}
-
-@keyframes skeleton-pulse {
-  0%, 100% { opacity: 0.4; }
-  50%      { opacity: 0.8; }
-}
+/* Header now provided by the shared CellarPageHeader component. */
 
 /* ── Summary pills ── */
 .history-summary-row {

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -9,6 +9,7 @@ import { addToWishlist } from '../api/wishlist';
 import { listCellars, getCellarHistory, getMultiCellarHistory } from '../api/cellars';
 import CellarScopePicker from '../components/CellarScopePicker';
 import CellarNav from '../components/CellarNav';
+import CellarPageHeader from '../components/CellarPageHeader';
 import './CellarDetail.css';
 import './CellarHistory.css';
 
@@ -183,26 +184,14 @@ function CellarHistory() {
           </button>
         </div>
       )}
-      <div className="history-header">
-        <Link to={`/cellars/${id}`} className="back-link">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-          {t('history.backTo', { cellarName: cellar?.name || '…' })}
-        </Link>
-        {loading ? (
-          <div className="skeleton-h1" />
-        ) : (
-          <>
-            <h1 className={cellar?.userColor ? 'cellar-accent-border' : ''} style={cellar?.userColor ? { '--cellar-color': cellar.userColor } : undefined}>
-              {t('history.title')}
-            </h1>
-            <p className="page-subtitle">
-              {total === 0 && !activeChips.length
-                ? t('history.noHistory')
-                : t('history.bottleCount', { count: total })}
-            </p>
-          </>
-        )}
-      </div>
+      <CellarPageHeader
+        backTo={`/cellars/${id}`}
+        backLabel={t('history.backTo', { cellarName: cellar?.name || '…' })}
+        title={t('history.title')}
+        loading={loading}
+        userColor={cellar?.userColor}
+        subtitle={total === 0 && !activeChips.length ? t('history.noHistory') : t('history.bottleCount', { count: total })}
+      />
 
       <CellarNav cellarId={id} active="history" />
 

--- a/frontend/src/pages/CellarRacks.css
+++ b/frontend/src/pages/CellarRacks.css
@@ -3,33 +3,7 @@
   margin: 0 auto;
 }
 
-.cellarracks-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 1.5rem;
-  gap: 1rem;
-}
-
-.cellarracks-header h1 {
-  margin: 0;
-  font-family: var(--font-heading);
-  color: var(--color-text);
-}
-
-.cellarracks-header .skeleton-h1 {
-  height: 1.5rem;
-  width: 40%;
-  margin: 0.25rem 0 0;
-  background: var(--color-border);
-  border-radius: var(--radius-sm);
-  animation: skeleton-pulse 1.2s ease-in-out infinite;
-}
-
-@keyframes skeleton-pulse {
-  0%, 100% { opacity: 0.4; }
-  50%      { opacity: 0.8; }
-}
+/* Header now provided by the shared CellarPageHeader component. */
 
 /* ---- New rack form ---- */
 .new-rack-form {

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -23,6 +23,7 @@ import ZoneEditorModal from '../components/racks/ZoneEditorModal';
 import RackAuditModal from '../components/racks/RackAuditModal';
 import { LENSES, getLensStyle, getLensLegend, bottleMatchesSearch } from '../utils/rackLens';
 import CellarNav from '../components/CellarNav';
+import CellarPageHeader from '../components/CellarPageHeader';
 import './CellarRacks.css';
 
 function CellarRacks() {
@@ -529,34 +530,21 @@ function CellarRacks() {
 
   return (
     <div className="cellar-racks-page">
-      <div className="cellarracks-header">
-        <div>
-          <Link to={`/cellars/${id}`} className="back-link">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
-            {t('racks.backToCellar')}
-          </Link>
-          {loading ? (
-            <div className="skeleton-h1" />
-          ) : (
-            <>
-              <h1 style={cellar?.userColor ? { borderLeft: `4px solid ${cellar.userColor}`, paddingLeft: '0.75rem' } : {}}>
-                {cellar?.name}
-              </h1>
-              <p className="cellar-description">{t('racks.title')}</p>
-            </>
-          )}
-        </div>
-        {!loading && canEdit && (
-          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-            <button className="btn btn-primary" onClick={() => setShowNewRack(v => !v)}>
-              {showNewRack ? t('common.cancel') : `+ ${t('racks.newRack')}`}
-            </button>
-          </div>
+      <CellarPageHeader
+        backTo={`/cellars/${id}`}
+        backLabel={t('racks.backToCellar')}
+        title={cellar?.name}
+        loading={loading}
+        userColor={cellar?.userColor}
+        subtitle={t('racks.title')}
+        actions={!loading && canEdit && (
+          <button className="btn btn-primary btn-small" onClick={() => setShowNewRack(v => !v)}>
+            {showNewRack ? t('common.cancel') : `+ ${t('racks.newRack')}`}
+          </button>
         )}
-      </div>
+      />
 
-      {/* Room View / Cellar Book moved from ad-hoc header links into the
-          shared view switcher used on every cellar page */}
+      {/* Room View / Cellar Book live in the shared view switcher on every page */}
       <CellarNav cellarId={id} active="racks" />
 
       {loading ? (

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -14,6 +14,7 @@ import WineImage from '../components/WineImage';
 import JournalPrompt, { journalPromptOptedOut } from '../components/JournalPrompt';
 import { LENSES, getLensStyle, getLensLegend, bottleMatchesSearch } from '../utils/rackLens';
 import CellarNav from '../components/CellarNav';
+import CellarPageHeader from '../components/CellarPageHeader';
 import './CellarRoom.css';
 
 const DEFAULT_DIMENSIONS = { width: 10, depth: 10, height: 3 };
@@ -1022,19 +1023,48 @@ export default function CellarRoom() {
 
   return (
     <div className="cellar-room-page">
-      <div className="cellar-room-header">
-        <div className="cellar-room-header-left">
-          <Link to={`/cellars/${id}/racks`} className="back-link">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
-            {t('room.backToRacks', 'Racks')}
-          </Link>
-          <h1>{cellar?.name || '...'} — {t('room.title', 'Room View')}</h1>
-          <span className="room-beta-badge">Beta</span>
-          {isEditMode && <span className="room-mode-badge edit">{t('room.editMode', 'Edit')}</span>}
-          {!isEditMode && <span className="room-mode-badge view">{t('room.viewMode', 'View')}</span>}
-        </div>
+      {/* View mode uses the shared header so the nav anchors like every other
+          cellar page. Edit mode keeps its own full-bleed working toolbar (and
+          the nav is hidden while arranging racks). */}
+      {!isEditMode ? (
+        <CellarPageHeader
+          backTo={`/cellars/${id}/racks`}
+          backLabel={t('room.backToRacks', 'Racks')}
+          title={`${cellar?.name || '...'} — ${t('room.title', 'Room View')}`}
+          loading={loading}
+          subtitle={t('room.subtitle', '3D cellar layout')}
+          titleBadge={<span className="room-beta-badge" style={{ marginLeft: '0.5rem' }}>Beta</span>}
+          actions={canEdit && (
+            <>
+              <button className="btn btn-secondary btn-small" onClick={() => setShowSettings(s => !s)}>
+                {t('room.roomSettings', 'Settings')}
+              </button>
+              <button
+                className="btn btn-primary btn-small"
+                onClick={() => {
+                  setIsEditMode(m => {
+                    if (!m) { setSelectedBottle(null); setEmptySlotTarget(null); }
+                    return !m;
+                  });
+                }}
+              >
+                {t('room.editMode', 'Edit')}
+              </button>
+            </>
+          )}
+        />
+      ) : (
+        <div className="cellar-room-header">
+          <div className="cellar-room-header-left">
+            <Link to={`/cellars/${id}/racks`} className="back-link">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+              {t('room.backToRacks', 'Racks')}
+            </Link>
+            <h1>{cellar?.name || '...'} — {t('room.title', 'Room View')}</h1>
+            <span className="room-beta-badge">Beta</span>
+            <span className="room-mode-badge edit">{t('room.editMode', 'Edit')}</span>
+          </div>
 
-        {canEdit && (
           <div className="cellar-room-header-actions">
             <button
               className="btn btn-secondary btn-small"
@@ -1043,7 +1073,7 @@ export default function CellarRoom() {
               {t('room.roomSettings', 'Settings')}
             </button>
             <button
-              className={`btn btn-small ${isEditMode ? 'btn-secondary' : 'btn-primary'}`}
+              className="btn btn-small btn-secondary"
               onClick={() => {
                 setIsEditMode(m => {
                   if (!m) { setSelectedBottle(null); setEmptySlotTarget(null); }
@@ -1051,42 +1081,38 @@ export default function CellarRoom() {
                 });
               }}
             >
-              {isEditMode ? t('room.viewMode', 'View') : t('room.editMode', 'Edit')}
+              {t('room.viewMode', 'View')}
             </button>
-            {isEditMode && (
-              <>
-                <button
-                  className={`btn btn-small ${showAddRackPicker ? 'btn-primary' : 'btn-secondary'}`}
-                  onClick={() => setShowAddRackPicker(p => !p)}
-                  disabled={unplacedRacks.length === 0}
-                >
-                  {t('room.addRack', 'Add Rack')} {unplacedRacks.length > 0 && `(${unplacedRacks.length})`}
-                </button>
-                <button
-                  className="btn btn-secondary btn-small"
-                  onClick={doUndo}
-                  disabled={undoStackRef.current.length === 0}
-                  title={t('room.undo', 'Undo (Ctrl+Z)')}
-                >
-                  {t('room.undo', 'Undo')}
-                </button>
-                <button
-                  className="btn btn-secondary btn-small"
-                  onClick={doRedo}
-                  disabled={redoStackRef.current.length === 0}
-                  title={t('room.redo', 'Redo (Ctrl+Y)')}
-                >
-                  {t('room.redo', 'Redo')}
-                </button>
-                {saveError && <span style={{ color: 'var(--color-danger)', fontSize: '0.75rem' }}>{saveError}</span>}
-                <button className="btn btn-primary btn-small" onClick={handleSave} disabled={saving}>
-                  {saving ? t('common.saving', 'Saving...') : t('room.saveLayout', 'Save')}
-                </button>
-              </>
-            )}
+            <button
+              className={`btn btn-small ${showAddRackPicker ? 'btn-primary' : 'btn-secondary'}`}
+              onClick={() => setShowAddRackPicker(p => !p)}
+              disabled={unplacedRacks.length === 0}
+            >
+              {t('room.addRack', 'Add Rack')} {unplacedRacks.length > 0 && `(${unplacedRacks.length})`}
+            </button>
+            <button
+              className="btn btn-secondary btn-small"
+              onClick={doUndo}
+              disabled={undoStackRef.current.length === 0}
+              title={t('room.undo', 'Undo (Ctrl+Z)')}
+            >
+              {t('room.undo', 'Undo')}
+            </button>
+            <button
+              className="btn btn-secondary btn-small"
+              onClick={doRedo}
+              disabled={redoStackRef.current.length === 0}
+              title={t('room.redo', 'Redo (Ctrl+Y)')}
+            >
+              {t('room.redo', 'Redo')}
+            </button>
+            {saveError && <span style={{ color: 'var(--color-danger)', fontSize: '0.75rem' }}>{saveError}</span>}
+            <button className="btn btn-primary btn-small" onClick={handleSave} disabled={saving}>
+              {saving ? t('common.saving', 'Saving...') : t('room.saveLayout', 'Save')}
+            </button>
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Shared cellar view switcher — hidden in edit mode to keep the 3D
           workbench uncluttered while arranging racks */}


### PR DESCRIPTION
Fixes three UX issues Johan reported (the nav "jumps" between pages, doesn't read as a menu, and the Cellar Book is wider than a phone screen). Backed by a design audit + best-practices research.

## 1. Underline tab bar
The CellarNav strip was a segmented pill control — **byte-identical CSS to the app's in-page filter toggles** (the rack-lens control sits right below it), so it didn't read as navigation. Now an underline tab bar: the canonical "separate destinations" idiom, distinct from filters, using only existing theme tokens (light + dark).

## 2. Shared CellarPageHeader → nav anchors consistently
The nav sat at a different Y on every page (measured **218 / 235 / 222px**) because four bespoke headers had different margins, h1 sizes and conditional subtitles. New `CellarPageHeader` component (back-link + title + **height-reserved** subtitle + action slot) sits above the nav on all pages → nav now anchors at a **constant 248px desktop / 218px mobile** across Bottles, Racks, Room, History. Page-specific controls (+New Rack, Room Settings/Edit, Print) moved into the header action slot. Room **edit** mode keeps its bespoke working toolbar (nav hidden there by design).

## 3. Cellar Book responsive
It overflowed the viewport (431px > 390px) because the 6-column table had no mobile constraint, widening the page and stretching the nav off-screen. Now the table scrolls inside its own `overflow-x` container and drops the 3 lowest-value columns (Type/Rating/Drink-window) below 640px — Pos/Wine/Vintage stay. **Full 6-column table + document heading restored for print** (verified via print-media emulation). Header also reordered above the nav (was inverted).

## Verification
Driven live in Docker with Playwright: desktop + mobile (390px) screenshots on all 5 pages, print-media emulation confirming the full PDF table, nav-position measurements before/after. Vite build + 640 frontend tests green. Removed dead header CSS.

## Ops
Frontend-only — no backend, no docker-compose, no migration.