### PR TITLE
chore(release): v1.79.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump for v1.79.0: consistent cellar navigation — underline tab bar, shared page header (nav no longer jumps), responsive Cellar Book on mobile (#683).