### PR TITLE
fix: rack lens toolbar mess on mobile (⋮ menu rendered off-screen)

### DIFF
--- a/frontend/src/pages/CellarRacks.css
+++ b/frontend/src/pages/CellarRacks.css
@@ -714,6 +714,28 @@
   background: var(--color-primary-light);
 }
 
+/* Mobile: keep the lens toolbar tidy. Search + the ⋮ tools button share the
+   top row (tools pinned to the RIGHT so its dropdown opens on-screen), and the
+   lens segment drops to its own full-width scrollable row below. Without this
+   the ⋮ wrapped to its own row at the far left and its right-anchored menu
+   rendered off the left screen edge, overlapping the legend. */
+@media (max-width: 700px) {
+  .rack-lens-search-wrap {
+    max-width: none;
+    flex: 1 1 auto;
+    order: 1;
+  }
+
+  .rack-tools {
+    order: 2;
+  }
+
+  .rack-lens-segment {
+    order: 3;
+    flex-basis: 100%;
+  }
+}
+
 /* ---- Auto-arrange modal ---- */
 .rack-arrange-btn {
   white-space: nowrap;


### PR DESCRIPTION
On phones the rack lens toolbar wrapped into three rows with the ⋮ rack-tools button orphaned at the far left. Opening its menu (anchored `right: 0; min-width: 160px`) rendered it **112px off the left screen edge** — the stray white box in Johan's screenshot, overlapping the color legend ("Red" → "ed", "Dessert" clipped).

**Fix (CSS-only):** on ≤700px, search + ⋮ share the top row (⋮ pinned right so its dropdown opens on-screen), and the lens segment drops to its own full-width scrollable row. Fixes the off-screen menu, the legend overlap, and the orphaned button in one rule.

**Verified live** in Docker at 390px with Playwright: the tools menu now opens fully on-screen (measured x=214, was x=-112); toolbar is a clean 2-row layout. 640 frontend tests green.

Follow-up to the v1.79.0 nav work. Frontend-only — no backend, no compose.