### PR TITLE
fix(audit): backend correctness & data-integrity

### DIFF
--- a/backend/src/routes/admin/audit.js
+++ b/backend/src/routes/admin/audit.js
@@ -39,8 +39,16 @@ router.get('/', async (req, res) => {
 
     if (from || to) {
       filter.timestamp = {};
-      if (from) filter.timestamp.$gte = new Date(from);
-      if (to)   filter.timestamp.$lte = new Date(to);
+      if (from) {
+        const d = new Date(from);
+        if (Number.isNaN(d.getTime())) return res.status(400).json({ error: 'Invalid "from" date' });
+        filter.timestamp.$gte = d;
+      }
+      if (to) {
+        const d = new Date(to);
+        if (Number.isNaN(d.getTime())) return res.status(400).json({ error: 'Invalid "to" date' });
+        filter.timestamp.$lte = d;
+      }
     }
 
     const [logs, total] = await Promise.all([

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -337,15 +337,19 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
         continue;
       }
 
-      // Skip rows that are missing required fields
-      if (!mapped.producer || !mapped.name || !mapped.country) {
+      // Skip rows that are missing required fields. Country must also be a real
+      // value, not a placeholder like "Unknown"/"N/A" — getOrCreateCountry maps
+      // those to null, and because the flush uses bulkWrite (which bypasses the
+      // `country: required` validator) a placeholder would otherwise be inserted
+      // as a country=null WineDefinition and mis-counted as `created`.
+      if (!mapped.producer || !mapped.name || !mapped.country || isUnknownName(mapped.country)) {
         stats.skipped++;
         stats.skippedReasons.missingFields++;
         if (stats.errors.length < 100) {
           const missing = [
             !mapped.producer && 'producer',
             !mapped.name     && 'name',
-            !mapped.country  && 'country',
+            (!mapped.country || isUnknownName(mapped.country)) && 'country',
           ].filter(Boolean).join(', ');
           stats.errors.push({ row: rowIndex, reason: `Missing: ${missing}` });
         }

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -1084,7 +1084,15 @@ router.get('/:id', async (req, res) => {
 
       let query = Bottle.find(filter).populate(WINE_POPULATE_LIST);
       if (canSortInDb_) query = query.sort({ [sortField]: sortDir });
-      if (canPaginateInDb) query = query.skip(skip).limit(limit);
+      if (canPaginateInDb) {
+        query = query.skip(skip).limit(limit);
+      } else {
+        // Safety cap: an in-memory sort/group path must never hydrate an
+        // unbounded populated set (a large cellar sorted by name/maturity would
+        // otherwise load every active bottle into memory). Mirror the 10k cap
+        // the sibling fallbacks use (bottles.js, cellars history, multi-cellar).
+        query = query.limit(10000);
+      }
       bottles = await query.lean();
 
       if (canPaginateInDb) {

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -166,6 +166,7 @@ router.post('/', requireCellarAccess('editor'), async (req, res) => {
     res.status(201).json({ rack });
   } catch (err) {
     if (err.code === 11000) return res.status(409).json({ error: 'A rack with that name already exists in this cellar' });
+    if (err.name === 'ValidationError') return res.status(400).json({ error: err.message });
     console.error('Create rack error:', err);
     res.status(500).json({ error: 'Failed to create rack' });
   }
@@ -306,6 +307,7 @@ router.put('/:id', async (req, res) => {
     if (err.name === 'VersionError') {
       return res.status(409).json({ error: 'This rack was modified by another request. Please refresh and try again.' });
     }
+    if (err.name === 'ValidationError') return res.status(400).json({ error: err.message });
     console.error('Update rack error:', err);
     res.status(500).json({ error: 'Failed to update rack' });
   }

--- a/backend/src/services/cellarExport.js
+++ b/backend/src/services/cellarExport.js
@@ -87,6 +87,10 @@ function mapBottlesForExport(bottles, racks, imagesByBottle = new Map(), reviews
       region: wine.region?.name || '',
       appellation: wine.appellation || '',
       type: wine.type || '',
+      // Grape varieties (names only) so the importer can reconstruct them via
+      // findOrCreateGrapes on a cross-instance migration — otherwise every
+      // auto-created wine lands with an empty grape list.
+      grapes: Array.isArray(wine.grapes) ? wine.grapes.map((g) => g.name).filter(Boolean) : [],
       bottleSize: b.bottleSize || '750ml',
       dateAdded: b.createdAt ? b.createdAt.toISOString().slice(0, 10) : undefined,
     };
@@ -282,8 +286,9 @@ async function buildCellarDataExport(userId, scope) {
         populate: [
           { path: 'country', select: 'name' },
           { path: 'region', select: 'name' },
+          { path: 'grapes', select: 'name' },
         ],
-        select: 'name producer type appellation country region',
+        select: 'name producer type appellation country region grapes',
       })
       .limit(EXPORT_MAX)
       .lean(),

--- a/backend/src/services/cellarExport.test.js
+++ b/backend/src/services/cellarExport.test.js
@@ -82,6 +82,24 @@ describe('mapBottlesForExport', () => {
     expect(item.drinkTo).toBe(2035);
   });
 
+  test('emits grape variety names so they round-trip on a cross-instance migration', () => {
+    // Without this, an auto-created wine on the destination lands with grapes:[]
+    // — the other taxonomy fields (country/region/appellation) always survived,
+    // making the grapes omission an asymmetric data-loss bug.
+    const bottles = [{
+      _id: oid('b1'), vintage: '2018',
+      wineDefinition: { name: 'W', grapes: [{ name: 'Syrah' }, { name: 'Grenache' }] },
+    }];
+    const [item] = mapBottlesForExport(bottles, []);
+    expect(item.grapes).toEqual(['Syrah', 'Grenache']);
+  });
+
+  test('emits an empty grapes array when the wine has none', () => {
+    const bottles = [{ _id: oid('b1'), vintage: 'NV', wineDefinition: { name: 'W' } }];
+    const [item] = mapBottlesForExport(bottles, []);
+    expect(item.grapes).toEqual([]);
+  });
+
   test('omits drink-window / occasion keys when the bottle has none', () => {
     const bottles = [{ _id: oid('b1'), vintage: 'NV', wineDefinition: { name: 'W' } }];
     const [item] = mapBottlesForExport(bottles, []);

--- a/backend/src/services/cellarImport.js
+++ b/backend/src/services/cellarImport.js
@@ -163,6 +163,9 @@ function exportBottleToItem(b) {
     region: b.region || '',
     appellation: b.appellation || '',
     type: b.type || '',
+    // Grape variety names — reconstructed on the destination via findOrCreateWine
+    // → findOrCreateGrapes when the wine has to be auto-created.
+    grapes: Array.isArray(b.grapes) ? b.grapes : undefined,
     vintage: b.vintage || 'NV',
     price: b.price,
     currency: b.currency,
@@ -373,7 +376,8 @@ async function resolveWine(item, userId, cache, result) {
   try {
     const { wine, created } = await findOrCreateWine(
       { name, producer: producer || name, country: item.country, region: item.region,
-        appellation: item.appellation, type: item.type, grapes: [] },
+        appellation: item.appellation, type: item.type,
+        grapes: Array.isArray(item.grapes) ? item.grapes : [] },
       userId,
       { confirmCreate: true } // non-interactive: match >= 0.95 or create
     );
@@ -728,7 +732,12 @@ async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, i
         pendingWineRequestId: wine.wineRequestId,
         defaultCurrency,
       });
-      if (!item.addToHistory && rating !== undefined) {
+      // The user's live (pre-consumption) rating — restore it for BOTH active
+      // and history bottles. A consumed bottle can legitimately carry both a
+      // cellar rating (`rating`) and a drinking rating (`consumedRating`); the
+      // regret-signal analytics key on having both, so dropping `rating` on
+      // history bottles silently lost that data on a round-trip.
+      if (rating !== undefined) {
         bottle.rating = rating;
         bottle.ratingScale = ratingScale;
       }

--- a/backend/src/services/embeddingJob.js
+++ b/backend/src/services/embeddingJob.js
@@ -229,20 +229,28 @@ async function runJob(cfg) {
         job.lastError = err.message;
         console.error(`[embeddingJob] Error embedding (${wineDefId}, ${vintage}):`, err.message);
 
-        // Mark as error in DB so admins can see which ones failed
+        // Mark as error in DB so admins can see which ones failed. Preserve any
+        // EXISTING qdrantPointId — overwriting it with a fresh UUID (as before)
+        // orphaned the previously-embedded point in Qdrant, because the next
+        // successful re-embed would then delete the bogus new UUID (a no-op)
+        // instead of the real prior point. Only mint a UUID for a brand-new row.
         try {
           await WineEmbedding.findOneAndUpdate(
             { wineDefinition: wineDefId, vintage, model, indexVersion: vectorIndex },
             {
-              wineDefinition: wineDefId,
-              vintage,
-              model,
-              indexVersion: vectorIndex,
-              qdrantPointId: randomUUID(),
-              textHash: '',
-              embeddedAt: new Date(),
-              status: 'error',
-              errorMessage: err.message
+              $set: {
+                textHash: '',
+                embeddedAt: new Date(),
+                status: 'error',
+                errorMessage: err.message,
+              },
+              $setOnInsert: {
+                wineDefinition: wineDefId,
+                vintage,
+                model,
+                indexVersion: vectorIndex,
+                qdrantPointId: randomUUID(),
+              },
             },
             { upsert: true }
           );

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -362,7 +362,33 @@ const REGISTRY = [
   // ── Social ──────────────────────────────────────────────────────────────
   {
     model: Follow, category: 'personal-data', userFields: ['follower', 'following'],
-    purge: (ctx) => Follow.deleteMany({ $or: [{ follower: ctx.userId }, { following: ctx.userId }] }),
+    purge: async (ctx) => {
+      // Reconcile the denormalized counters on the counterparties BEFORE removing
+      // the edges — otherwise deleting a user leaves everyone they were connected
+      // to with a permanently inflated followersCount / followingCount (the live
+      // follow/unfollow paths keep these in sync, but the hard-delete skipped it).
+      const edges = await Follow.find({ $or: [{ follower: ctx.userId }, { following: ctx.userId }] })
+        .select('follower following').lean();
+      const decFollowers = {}; // people this user followed → their followersCount drops
+      const decFollowing = {}; // people who followed this user → their followingCount drops
+      for (const e of edges) {
+        if (String(e.follower) === String(ctx.userId)) decFollowers[e.following] = (decFollowers[e.following] || 0) + 1;
+        if (String(e.following) === String(ctx.userId)) decFollowing[e.follower] = (decFollowing[e.follower] || 0) + 1;
+      }
+      const ops = [
+        ...Object.entries(decFollowers).map(([id, n]) => ({
+          updateOne: { filter: { _id: id }, update: { $inc: { followersCount: -n } } },
+        })),
+        ...Object.entries(decFollowing).map(([id, n]) => ({
+          updateOne: { filter: { _id: id }, update: { $inc: { followingCount: -n } } },
+        })),
+      ];
+      if (ops.length) await User.bulkWrite(ops);
+      // Clamp any counter that may have drifted negative.
+      await User.updateMany({ followersCount: { $lt: 0 } }, [{ $set: { followersCount: 0 } }]);
+      await User.updateMany({ followingCount: { $lt: 0 } }, [{ $set: { followingCount: 0 } }]);
+      return Follow.deleteMany({ $or: [{ follower: ctx.userId }, { following: ctx.userId }] });
+    },
     exportFragment: async (ctx) => {
       const follows = await Follow.find({ $or: [{ follower: ctx.userId }, { following: ctx.userId }] }).limit(EXPORT_MAX)
         .populate('follower', 'username').populate('following', 'username').lean();


### PR DESCRIPTION
**Batch 1 of the 2026-07-11 grand-audit fixes.** Backend only, no compose/migration.

Addresses the Code-track findings that are genuine defects:

| Finding | Fix |
|---|---|
| **MED-1** cellars.js unbounded fallback | Cap the in-memory sort/group path at 10k bottles (mirrors sibling routes) — prevents OOM on a large cellar sorted by name/maturity |
| **MED-2** CSV import null-country | Reject rows whose country is an `Unknown`/`N/A` placeholder up front — bulkWrite was inserting `country:null` wines counted as *created* |
| **MED-3** export→import drops grapes | Carry grape names through export (populate + emit) and import (`exportBottleToItem` + `resolveWine` → `findOrCreateGrapes`) — auto-created wines no longer land with `grapes:[]` |
| **LOW-5** consumed-rating dropped | Restore a history bottle's pre-consumption `rating` on import (regret-signal data) |
| **LOW-1** rack 500→400 | Rack POST/PUT return 400 on schema ValidationError |
| **LOW-6** Qdrant orphan | embeddingJob error path preserves the existing `qdrantPointId` (`$setOnInsert`) instead of minting a new UUID |
| **LOW-3** follow-count drift | Decrement counterparties' `followersCount/followingCount` on user hard-delete |
| **LOW-4** audit date filter | 400 on an unparseable `from`/`to` instead of silently empty |

**Deferred:** LOW-2 (journal_mention dead link) — needs a coordinated FE/BE change + product decision on whether mentioned users may view others' journal entries.

**Tests:** 83 suites / 1358 pass, incl. new grapes round-trip assertions. Read-only audit fixes — no behavior change beyond the findings.