### PR TITLE
fix(audit): security & GDPR

### DIFF
--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -7,6 +7,17 @@ const notificationSchema = new mongoose.Schema({
     required: true,
     index: true
   },
+  // The user who triggered this notification (follower, replier, mentioner, …),
+  // when there is one. The title/message denormalize their display name, so this
+  // ref lets GDPR erasure remove notifications delivered to OTHERS that name a
+  // departing user. Null for system notifications (drink-window, admin, etc.).
+  actor: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    default: null,
+    index: true,
+    sparse: true
+  },
   type: {
     type: String,
     enum: [

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -15,6 +15,7 @@ const rateLimit = require('express-rate-limit');
 const { requireAuth } = require('../middleware/auth');
 const asyncHandler = require('../utils/asyncHandler');
 const aiChat = require('../services/aiChat');
+const { tryDebitGlobalAi } = require('../services/aiBudget');
 const aiConfig = require('../config/aiConfig');
 const ChatUsage = require('../models/ChatUsage');
 const User = require('../models/User');
@@ -199,6 +200,19 @@ router.post('/', requireAuth, chatBurstLimiter, asyncHandler(async (req, res) =>
 
   const { message, useQueryExpansion, history, previousWines, cellarIds, date, usedBefore, limit, period } = validated;
 
+  // Count this chat request toward the site-wide daily AI cap (the SuperAdmin
+  // kill-switch) — chat has its own per-user quota (ChatUsage) but previously
+  // escaped the global brake entirely. If the site cap is hit, don't consume the
+  // user's chat quota that validateAndCheckLimit already reserved.
+  const globalDebit = await tryDebitGlobalAi();
+  if (!globalDebit.ok) {
+    await ChatUsage.findOneAndUpdate({ userId: req.user.id, date }, { $inc: { count: -1 } });
+    return res.status(429).json({
+      error: 'AI is temporarily at capacity. Please try again later.',
+      retryAfterSeconds: globalDebit.retryAfterSeconds,
+    });
+  }
+
   try {
     const result = await aiChat.chat(req.user.id, message, {
       useQueryExpansion,
@@ -221,6 +235,7 @@ router.post('/', requireAuth, chatBurstLimiter, asyncHandler(async (req, res) =>
       { userId: req.user.id, date },
       { $inc: { count: -1 } }
     );
+    await globalDebit.refund(); // the AI call didn't complete — release the global unit
     const status = err.status || 500;
     if (status === 503) return res.status(503).json({ error: err.message });
     console.error('[chat] Error:', err);

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -478,7 +478,8 @@ router.post('/', requireAuth, async (req, res) => {
         `${authorName} mentioned you`,
         `In a new discussion: "${cleanTitle}"`,
         link,
-        'communityMention'
+        'communityMention',
+        req.user.id // actor — lets GDPR erasure remove this on the author's deletion
       );
     }
 
@@ -865,8 +866,10 @@ router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
     }
 
     // Fire-and-forget, same as the old per-recipient calls — delivery must
-    // never block or fail the reply create.
-    createNotifications(notificationItems).catch(err =>
+    // never block or fail the reply create. Every item here is triggered by the
+    // replier, so tag them with actor so GDPR erasure can remove notifications
+    // that name this user from other users' feeds on their deletion.
+    createNotifications(notificationItems.map(i => ({ ...i, actor: req.user.id }))).catch(err =>
       console.error('[discussions] reply notification batch failed:', err.message)
     );
 

--- a/backend/src/routes/follows.js
+++ b/backend/src/routes/follows.js
@@ -40,7 +40,8 @@ router.post('/:userId', async (req, res) => {
       type: 'new_follower',
       title: 'New Follower',
       message: `${followerName} started following you`,
-      link: `/users/${req.user.id}`
+      link: `/users/${req.user.id}`,
+      actor: req.user.id, // so GDPR erasure can remove this on the follower's deletion
     }).save().catch(() => {});
 
     logAudit(req, 'user.follow', { type: 'user', id: targetId });

--- a/backend/src/routes/journal.js
+++ b/backend/src/routes/journal.js
@@ -260,7 +260,9 @@ router.post('/', async (req, res) => {
             'journal_mention',
             'Journal Mention',
             `${senderName} mentioned you in a journal entry: "${populated.title || 'Untitled'}"`,
-            `/journal/${populated._id}`
+            `/journal/${populated._id}`,
+            undefined,
+            req.user.id // actor — lets GDPR erasure remove this on the mentioner's deletion
           );
         }
       }

--- a/backend/src/routes/journal.refs.test.js
+++ b/backend/src/routes/journal.refs.test.js
@@ -342,9 +342,11 @@ describe('POST /api/journal response redaction (old rows / create echo)', () => 
     expect(status).toBe(201);
     expect(body.entry.people[0].user).toEqual({ _id: PRIVATE_USER });
     expect(JSON.stringify(body)).not.toContain('secretanna');
-    // the mention notification still reaches the tagged user (by id, no name leak)
+    // the mention notification still reaches the tagged user (by id, no name leak).
+    // Trailing args: category (undefined here) + actor (the mentioner) so GDPR
+    // erasure can remove the notification on the mentioner's deletion.
     expect(createNotification).toHaveBeenCalledWith(
-      PRIVATE_USER, 'journal_mention', 'Journal Mention', expect.any(String), expect.any(String)
+      PRIVATE_USER, 'journal_mention', 'Journal Mention', expect.any(String), expect.any(String), undefined, expect.any(String)
     );
   });
 });

--- a/backend/src/routes/recommendations.js
+++ b/backend/src/routes/recommendations.js
@@ -163,7 +163,9 @@ router.post('/', async (req, res) => {
         'wine_recommendation',
         'Wine Recommendation',
         `${senderName} recommends "${wineName}"${trimmedNote ? `: "${trimmedNote}"` : ''}`,
-        `/recommendations`
+        `/recommendations`,
+        undefined,
+        req.user.id // actor — lets GDPR erasure remove this on the sender's deletion
       );
     }
 

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -21,6 +21,11 @@ const REMBG_URL = process.env.REMBG_URL || 'http://rembg:5000';
 
 const router = express.Router();
 
+// Cap the free-text AI query length before it becomes Claude prompt input, so a
+// caller can't maximize per-call input-token cost with a ~10KB body. Mirrors the
+// chat message cap (chat.js).
+const MAX_AI_QUERY_LEN = 300;
+
 /**
  * 429 for the Anthropic-backed endpoints when the shared per-user daily AI
  * budget (or the site-wide daily cap) is exhausted. These endpoints have no
@@ -381,6 +386,7 @@ router.post('/find-or-create', requireAuth, async (req, res) => {
 router.post('/identify-text', requireAuth, aiBurstLimiter, asyncHandler(async (req, res) => {
   const query = typeof req.body.query === 'string' ? req.body.query.trim() : '';
   if (!query) return res.status(400).json({ error: 'query is required' });
+  if (query.length > MAX_AI_QUERY_LEN) return res.status(400).json({ error: `query must be at most ${MAX_AI_QUERY_LEN} characters` });
 
   const debit = await tryDebitAi(req.user.id);
   if (!debit.ok) return sendAiBudgetExhausted(res, debit);
@@ -409,6 +415,7 @@ router.post('/identify-text', requireAuth, aiBurstLimiter, asyncHandler(async (r
 router.post('/ai-info', requireAuth, aiBurstLimiter, asyncHandler(async (req, res) => {
   const query = typeof req.body.query === 'string' ? req.body.query.trim() : '';
   if (!query) return res.status(400).json({ error: 'query is required' });
+  if (query.length > MAX_AI_QUERY_LEN) return res.status(400).json({ error: `query must be at most ${MAX_AI_QUERY_LEN} characters` });
 
   const debit = await tryDebitAi(req.user.id);
   if (!debit.ok) return sendAiBudgetExhausted(res, debit);

--- a/backend/src/services/aiBudget.js
+++ b/backend/src/services/aiBudget.js
@@ -194,4 +194,33 @@ function isRefundableScanError(err) {
   return err?.status !== 422;
 }
 
-module.exports = { tryDebitAi, isRefundableFailure, isRefundableScanError, getEffectiveDailyMax, todayUTC, secondsUntilMidnightUTC };
+/**
+ * Debit ONLY the site-wide daily cap (not the per-user AI budget). Cellar chat
+ * has its own per-user quota (ChatUsage / chatDailyLimit), so it must not also
+ * consume the shared per-user AI budget — but it DOES need to count toward the
+ * SuperAdmin kill-switch (aiGlobalDailyCap) so that the site-wide brake actually
+ * bounds chat spend during an abuse event. Returns the same {ok, refund} shape
+ * as tryDebitAi so callers refund on a failed/aborted call.
+ */
+async function tryDebitGlobalAi() {
+  const cfg = rateLimitsConfig.get();
+  const globalCap = cfg.aiGlobalDailyCap?.max ?? rateLimitsConfig.defaults.aiGlobalDailyCap.max;
+  if (globalCap <= 0) return { ok: true, refund: async () => {} }; // cap disabled
+
+  const date = todayUTC();
+  const global = await incUsage(null, date, 1);
+  if (global.count > globalCap) {
+    await incUsage(null, date, -1);
+    return { ok: false, reason: 'global_cap', retryAfterSeconds: secondsUntilMidnightUTC() };
+  }
+
+  let refunded = false;
+  const refund = async () => {
+    if (refunded) return;
+    refunded = true;
+    try { await incUsage(null, date, -1); } catch (err) { console.warn('[aiBudget] global refund failed:', err.message); }
+  };
+  return { ok: true, refund };
+}
+
+module.exports = { tryDebitAi, tryDebitGlobalAi, isRefundableFailure, isRefundableScanError, getEffectiveDailyMax, todayUTC, secondsUntilMidnightUTC };

--- a/backend/src/services/notifications.js
+++ b/backend/src/services/notifications.js
@@ -48,8 +48,8 @@ const PUSH_PREF_PATH = {
  *   callers (recommendations, restock checker, etc.) that don't yet have
  *   per-category prefs.
  */
-async function createNotification(userId, type, title, message, link = null, category) {
-  return createNotifications([{ userId, type, title, message, link, category }]);
+async function createNotification(userId, type, title, message, link = null, category, actor = null) {
+  return createNotifications([{ userId, type, title, message, link, category, actor }]);
 }
 
 // Push-preference gate: category-specific when the caller named one,
@@ -88,7 +88,7 @@ async function createNotifications(items) {
   let created = [];
   try {
     created = await Notification.insertMany(
-      items.map(i => ({ user: i.userId, type: i.type, title: i.title, message: i.message, link: i.link || null })),
+      items.map(i => ({ user: i.userId, type: i.type, title: i.title, message: i.message, link: i.link || null, actor: i.actor || null })),
       { ordered: false }
     );
   } catch (err) {

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -453,8 +453,14 @@ const REGISTRY = [
     }),
   },
   {
-    model: Notification, category: 'personal-data', userFields: ['user'],
-    purge: (ctx) => Notification.deleteMany({ user: ctx.userId }),
+    model: Notification, category: 'personal-data', userFields: ['user', 'actor'],
+    // Delete both the departing user's OWN notifications AND notifications
+    // delivered to OTHERS that this user triggered (follow/reply/mention/
+    // recommendation) — those denormalize the departing user's display name into
+    // the title/message, so leaving them would let a deleted user's name persist
+    // in third parties' feeds until the 90-day TTL. `actor` (set at creation)
+    // makes them matchable.
+    purge: (ctx) => Notification.deleteMany({ $or: [{ user: ctx.userId }, { actor: ctx.userId }] }),
     exportFragment: async (ctx) => ({
       notifications: markTrunc(ctx, 'notifications', await Notification.find({ user: ctx.userId }).limit(EXPORT_MAX).lean())
         .map(n => ({ ...n, _id: undefined })),
@@ -739,13 +745,24 @@ const REGISTRY = [
     // the invitee's address as { sharedWith } / { invitedEmail } (L-15). $unset
     // only touches docs that actually have those keys, so it's safe across the
     // heterogeneous detail shapes.
-    purge: (ctx) => AuditLog.updateMany(
-      { 'actor.userId': ctx.userId },
-      {
-        $set: { 'actor.userId': null, 'actor.ipAddress': null },
-        $unset: { 'detail.email': '', 'detail.username': '', 'detail.sharedWith': '', 'detail.invitedEmail': '' },
-      }
-    ),
+    purge: (ctx) => [
+      // (a) The departing user as the ACTOR of their own events.
+      AuditLog.updateMany(
+        { 'actor.userId': ctx.userId },
+        {
+          $set: { 'actor.userId': null, 'actor.ipAddress': null },
+          $unset: { 'detail.email': '', 'detail.username': '', 'detail.sharedWith': '', 'detail.invitedEmail': '' },
+        }
+      ),
+      // (b) The departing user as the SUBJECT of ANOTHER actor's event — a
+      // cellar-share event stores the invitee's email in the INVITER's row
+      // (detail.sharedWith / detail.invitedEmail). The actor-scoped scrub above
+      // never touches those, so match on the departing user's email instead.
+      ...(ctx.userEmail ? [AuditLog.updateMany(
+        { $or: [{ 'detail.sharedWith': ctx.userEmail }, { 'detail.invitedEmail': ctx.userEmail }] },
+        { $unset: { 'detail.sharedWith': '', 'detail.invitedEmail': '' } }
+      )] : []),
+    ],
     exportFragment: async (ctx) => ({
       activityLog: markTrunc(ctx, 'activityLog', await AuditLog.find({ 'actor.userId': ctx.userId }).sort({ timestamp: -1 }).limit(AUDIT_MAX).lean(), AUDIT_MAX)
         .map(a => ({ action: a.action, timestamp: a.timestamp, detail: a.detail })),

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,7 +36,7 @@
       https://analytics.cellarion.app so the self-hosted tracker can load and POST.
       If you self-host Umami at a different subdomain, update both lists.
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://analytics.cellarion.app; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' blob: data: https:; connect-src 'self' https://open.er-api.com https://analytics.cellarion.app; frame-src https://www.youtube.com https://www.youtube-nocookie.com;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' https://analytics.cellarion.app; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' blob: data: https:; connect-src 'self' https://open.er-api.com https://analytics.cellarion.app; frame-src https://www.youtube.com https://www.youtube-nocookie.com;" />
 
     <!--
       Search engine webmaster verification.


### PR DESCRIPTION
**Batch 2 of the 2026-07-11 grand-audit fixes.** Backend + one CSP line. No compose/migration (the new Notification.actor field is additive and back-fills to null).

| Finding | Fix |
|---|---|
| **sec MED-1** chat escapes the AI kill-switch | Cellar chat now debits the site-wide `aiGlobalDailyCap` via a new `tryDebitGlobalAi` (keeps its own per-user ChatUsage quota; refunds on a failed call). Closes the only unbounded Anthropic-spend vector across many accounts. |
| **gdpr MED-1** email survives erasure | Erasure also scrubs the departing user's email where it's the *subject* of another actor's audit event (cellar-share `sharedWith`/`invitedEmail`), matched on `ctx.userEmail`. |
| **gdpr LOW-1/3** name survives in others' notifications | `Notification.actor` ref set at creation (follow/reply/mention/recommendation); erasure deletes notifications this user triggered in *others'* feeds, not just their own. |
| **sec LOW-1** unbounded AI query | Cap `/identify-text` and `/ai-info` query at 300 chars. |
| **sec LOW-3** CSP gaps | Add `base-uri 'self'` + `object-src 'none'`. |

**Tests:** 83 suites / 1358 pass (journal.refs updated for the new actor arg). Read-only-audit-driven; no behavior change beyond the findings.