### PR TITLE
fix(design): resolve phantom CSS design tokens across the frontend (audit batch 3)

### DIFF
--- a/frontend/src/components/BottleCard.css
+++ b/frontend/src/components/BottleCard.css
@@ -150,9 +150,9 @@
   font-weight: 500;
   padding: 1px 8px;
   border-radius: var(--radius-full);
-  background: #fff3e0;
-  color: #e65100;
-  border: 1px dashed #ffb74d;
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  border: 1px dashed var(--color-warning-border);
 }
 
 /* Cross-cellar view: which cellar this bottle lives in. */
@@ -199,34 +199,37 @@
   font-weight: 500;
 }
 
+/* Mapped to the theme-aware --drink-* tokens (defined for both light + dark in
+   index.css) so these adapt in dark mode instead of showing bright light pastels
+   on a dark card. */
 .maturity-badge--peak {
-  background: #e8f5e9;
-  color: #2e7d32;
-  border: 1px solid #a5d6a7;
+  background: var(--drink-inwindow-bg);
+  color: var(--drink-inwindow-text);
+  border: 1px solid var(--drink-inwindow-border);
 }
 
 .maturity-badge--early {
-  background: #e3f2fd;
-  color: #1565c0;
-  border: 1px solid #90caf9;
+  background: var(--drink-notready-bg);
+  color: var(--drink-notready-text);
+  border: 1px solid var(--drink-notready-border);
 }
 
 .maturity-badge--late {
-  background: #fff3e0;
-  color: #e65100;
-  border: 1px solid #ffcc80;
+  background: var(--drink-soon-bg);
+  color: var(--drink-soon-text);
+  border: 1px solid var(--drink-soon-border);
 }
 
 .maturity-badge--declining {
-  background: #fce4ec;
-  color: #c62828;
-  border: 1px solid #ef9a9a;
+  background: var(--drink-overdue-bg);
+  color: var(--drink-overdue-text);
+  border: 1px solid var(--drink-overdue-border);
 }
 
 .maturity-badge--not-ready {
-  background: #f3e5f5;
-  color: #6a1b9a;
-  border: 1px solid #ce93d8;
+  background: var(--drink-notready-bg);
+  color: var(--drink-notready-text);
+  border: 1px solid var(--drink-notready-border);
 }
 
 .maturity-badge--none {
@@ -428,20 +431,21 @@
   font-weight: 600;
 }
 
+/* Theme-aware semantic tokens (adapt in dark mode). */
 .open-bottle-badge--ok {
-  background: #ede7f6;
-  color: #4527a0;
-  border: 1px solid #b39ddb;
+  background: var(--color-info-bg);
+  color: var(--color-info);
+  border: 1px solid var(--color-info-border);
 }
 
 .open-bottle-badge--soon {
-  background: #fff3e0;
-  color: #e65100;
-  border: 1px solid #ffcc80;
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning-border);
 }
 
 .open-bottle-badge--past {
-  background: #fce4ec;
-  color: #c62828;
-  border: 1px solid #ef9a9a;
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger-border);
 }

--- a/frontend/src/components/CategoryBadge.css
+++ b/frontend/src/components/CategoryBadge.css
@@ -56,3 +56,12 @@ button.category-badge:hover {
   background: var(--color-surface-hover);
   color: var(--color-text-muted);
 }
+
+/* Dark mode: the translucent backgrounds adapt, but the solid dark text becomes
+   dark-on-dark (low contrast). Lighten each label's hue for dark surfaces while
+   keeping the intentionally-desaturated identity. The app toggles theme via
+   [data-theme], so match that (no prefers-color-scheme). */
+[data-theme="dark"] .category-badge--tasting-notes   { color: #C89AD0; }
+[data-theme="dark"] .category-badge--food-pairing    { color: #D9A84E; }
+[data-theme="dark"] .category-badge--recommendations { color: #8FB0D6; }
+[data-theme="dark"] .category-badge--cellar-tips     { color: #7FB08A; }

--- a/frontend/src/components/CellarCredBadge.css
+++ b/frontend/src/components/CellarCredBadge.css
@@ -20,29 +20,30 @@
   padding: 2px 8px;
 }
 
-/* Tier colours */
+/* Tier colours — mapped to the theme-aware semantic token families so the chips
+   adapt in dark mode instead of showing light pastels on a dark surface. */
 .cred-badge--contributor {
-  background: #e8f5e9;
-  color: #2e7d32;
-  border: 1px solid #a5d6a7;
+  background: var(--color-success-bg);
+  color: var(--color-success);
+  border: 1px solid var(--color-success-border);
 }
 
 .cred-badge--enthusiast {
-  background: #e3f2fd;
-  color: #1565c0;
-  border: 1px solid #90caf9;
+  background: var(--color-info-bg);
+  color: var(--color-info);
+  border: 1px solid var(--color-info-border);
 }
 
 .cred-badge--connoisseur {
-  background: #fff8e1;
-  color: #f57f17;
-  border: 1px solid #ffe082;
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning-border);
 }
 
 .cred-badge--ambassador {
-  background: #fce4ec;
-  color: #ad1457;
-  border: 1px solid #f48fb1;
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger-border);
 }
 
 /* Icon sizing */

--- a/frontend/src/components/ClimateCard.css
+++ b/frontend/src/components/ClimateCard.css
@@ -155,7 +155,7 @@
 .climate-tooltip {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
   padding: 0.6rem 0.75rem;
   font-size: 0.78rem;
   color: var(--color-text);

--- a/frontend/src/components/CommunityCTA.css
+++ b/frontend/src/components/CommunityCTA.css
@@ -17,7 +17,7 @@
 .community-cta__message {
   margin: 0;
   font-size: 0.95rem;
-  color: var(--text-color, inherit);
+  color: var(--color-text, inherit);
 }
 
 .community-cta__actions {

--- a/frontend/src/components/Drawer.css
+++ b/frontend/src/components/Drawer.css
@@ -13,7 +13,7 @@
   width: min(560px, 100vw);
   max-width: 100vw;
   height: 100%;
-  background: var(--bg, #fff);
+  background: var(--color-bg, #fff);
   box-shadow: -8px 0 28px rgba(0, 0, 0, 0.18);
   display: flex;
   flex-direction: column;
@@ -24,7 +24,7 @@
 .drawer-footer {
   flex: 0 0 auto;
   padding: 1rem 1.25rem;
-  background: var(--bg, #fff);
+  background: var(--color-bg, #fff);
 }
 
 .drawer-header {
@@ -32,7 +32,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  border-bottom: 1px solid var(--border, #e5e5e5);
+  border-bottom: 1px solid var(--color-border, #e5e5e5);
   position: sticky;
   top: 0;
 }
@@ -46,12 +46,12 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-secondary, #888);
+  color: var(--color-text-secondary, #888);
   padding: 4px;
   border-radius: 4px;
   display: inline-flex;
 }
-.drawer-close:hover { background: var(--bg-secondary, #f0f0f0); color: var(--text-primary, #222); }
+.drawer-close:hover { background: var(--color-surface, #f0f0f0); color: var(--color-text, #222); }
 
 .drawer-body {
   flex: 1 1 auto;
@@ -60,7 +60,7 @@
 }
 
 .drawer-footer {
-  border-top: 1px solid var(--border, #e5e5e5);
+  border-top: 1px solid var(--color-border, #e5e5e5);
   display: flex;
   justify-content: flex-end;
   gap: 0.6rem;

--- a/frontend/src/components/JournalEntryForm.css
+++ b/frontend/src/components/JournalEntryForm.css
@@ -90,7 +90,7 @@
 }
 
 .journal-form__friend-suggestions button:hover {
-  background: var(--color-hover, rgba(0,0,0,.05));
+  background: var(--color-surface-hover, rgba(0,0,0,.05));
 }
 
 .journal-form__friend-username {
@@ -104,7 +104,7 @@
   flex-direction: column;
   gap: 0.4rem;
   padding: 0.75rem;
-  background: var(--color-surface-alt, #fafafa);
+  background: var(--color-surface-raised, #fafafa);
   border-radius: var(--radius-md, 8px);
   border: 1px solid var(--color-border);
   margin-bottom: 0.5rem;
@@ -184,7 +184,7 @@
 
 .journal-form__vis-btn.active {
   background: var(--color-primary);
-  color: var(--color-on-primary, #fff);
+  color: var(--color-text-inverse, #fff);
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/Layout.css
+++ b/frontend/src/components/Layout.css
@@ -498,3 +498,15 @@
 .install-prompt-dismiss:hover {
   color: #fff;
 }
+
+/* Print: hide the app chrome (top navbar, mobile bottom bar, announcement
+   banner) so print flows like the Cellar Book produce a clean document with no
+   navigation bands. */
+@media print {
+  .navbar,
+  .bottom-nav,
+  .announcement-banner,
+  .install-prompt {
+    display: none !important;
+  }
+}

--- a/frontend/src/components/RecommendWineModal.css
+++ b/frontend/src/components/RecommendWineModal.css
@@ -24,7 +24,7 @@
 
 .recommend-mode-btn.active {
   background: var(--color-primary);
-  color: var(--color-on-primary, #fff);
+  color: var(--color-text-inverse, #fff);
 }
 
 .recommend-friend-list {
@@ -53,7 +53,7 @@
 }
 
 .recommend-friend-item:hover {
-  background: var(--color-hover, rgba(0,0,0,.05));
+  background: var(--color-surface-hover, rgba(0,0,0,.05));
 }
 
 .recommend-friend-username {
@@ -64,7 +64,7 @@
 .recommend-selected {
   margin-top: 0.5rem;
   padding: 0.5rem 0.75rem;
-  background: var(--color-surface-alt, #f5f5f5);
+  background: var(--color-surface-raised, #f5f5f5);
   border-radius: var(--radius-md, 8px);
   font-size: 0.9rem;
   display: flex;

--- a/frontend/src/components/ShareButton.css
+++ b/frontend/src/components/ShareButton.css
@@ -30,7 +30,7 @@
 }
 
 .share-icon-btn:hover {
-  background: var(--color-hover, #f0f0f0);
+  background: var(--color-surface-hover, #f0f0f0);
   color: var(--color-primary);
   box-shadow: 0 2px 8px rgba(0,0,0,.15);
 }
@@ -76,7 +76,7 @@
 }
 
 .share-dropdown__item:hover {
-  background: var(--color-hover, rgba(0,0,0,.05));
+  background: var(--color-surface-hover, rgba(0,0,0,.05));
 }
 
 .share-dropdown__item:hover svg {

--- a/frontend/src/components/ShareCellarModal.css
+++ b/frontend/src/components/ShareCellarModal.css
@@ -1,14 +1,6 @@
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--color-overlay);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: 1rem;
-}
-
+/* .modal-overlay comes from the shared styles/common.css — redefining it here
+   as a global (and dropping the backdrop blur) made the app-wide backdrop
+   bundle-order dependent. */
 .share-modal {
   background: var(--color-surface);
   border: 1px solid var(--color-border);

--- a/frontend/src/components/SimilarWinesModal.js
+++ b/frontend/src/components/SimilarWinesModal.js
@@ -19,7 +19,7 @@ import './WineModalThumbs.css';
 function SimilarWinesModal({ candidates, queryName, onPick, onCreateNew, onCancel, busy }) {
   return (
     <Modal title="Did you mean one of these?" onClose={onCancel} showClose wide>
-      <p style={{ margin: '0 0 1rem', fontSize: '0.95rem', color: 'var(--text-secondary, #666)' }}>
+      <p style={{ margin: '0 0 1rem', fontSize: '0.95rem', color: 'var(--color-text-secondary, #666)' }}>
         We found wines in the registry that look close to{' '}
         <strong>{queryName || 'what you entered'}</strong>. Picking an existing
         wine keeps the registry tidy and lets you share data with other users.
@@ -34,7 +34,7 @@ function SimilarWinesModal({ candidates, queryName, onPick, onCreateNew, onCance
               alignItems: 'center',
               gap: 12,
               padding: '0.6rem 0.4rem',
-              borderBottom: '1px solid var(--border, #e5e5e5)',
+              borderBottom: '1px solid var(--color-border, #e5e5e5)',
             }}
           >
             <div style={{ width: 48, height: 64, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -48,19 +48,19 @@ function SimilarWinesModal({ candidates, queryName, onPick, onCreateNew, onCance
             </div>
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontWeight: 600 }}>{wine.name}</div>
-              <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+              <div style={{ fontSize: '0.85rem', color: 'var(--color-text-secondary, #666)' }}>
                 {wine.producer}
                 {wine.country?.name ? ` · ${wine.country.name}` : ''}
                 {wine.region?.name ? ` · ${wine.region.name}` : ''}
               </div>
               {wine.appellation && (
-                <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)' }}>{wine.appellation}</div>
+                <div style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary, #888)' }}>{wine.appellation}</div>
               )}
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
               <span
                 title="Similarity score"
-                style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}
+                style={{ fontSize: '0.75rem', color: 'var(--color-text-secondary, #888)' }}
               >
                 {Math.round(score * 100)}% match
               </span>

--- a/frontend/src/components/WineClusterCompareModal.js
+++ b/frontend/src/components/WineClusterCompareModal.js
@@ -121,19 +121,19 @@ function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
   if (!wines) {
     return (
       <Modal title="Compare & merge" onClose={onClose} showClose wide>
-        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>Loading…</div>
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--color-text-secondary, #888)' }}>Loading…</div>
       </Modal>
     );
   }
 
-  const C = { border: '1px solid var(--border, #e5e5e5)', pad: '7px 10px' };
-  const accent = 'var(--accent, #4a7c4a)';
-  const warnBg = 'var(--bg-warning-faint, #fdf6e3)';
+  const C = { border: '1px solid var(--color-border, #e5e5e5)', pad: '7px 10px' };
+  const accent = 'var(--color-accent, #4a7c4a)';
+  const warnBg = 'var(--color-warning-bg, #fdf6e3)';
 
   return (
     <Modal title={`Compare & merge — ${wines.length} wines`} onClose={onClose} showClose
            boxStyle={{ maxWidth: 'min(96vw, 1100px)', width: 'min(96vw, 1100px)' }}>
-      <p style={{ margin: '0 0 0.75rem', fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+      <p style={{ margin: '0 0 0.75rem', fontSize: '0.85rem', color: 'var(--color-text-secondary, #666)' }}>
         Pick the keeper, then click the best value for each field to compose the surviving wine.
         <strong> Conflicting values are highlighted</strong>; fields everyone agrees on are dimmed.
       </p>
@@ -149,11 +149,11 @@ function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
                 const id = wid(w);
                 const isKeeper = id === keeperId;
                 return (
-                  <th key={id} style={{ ...thStyle, background: isKeeper ? 'var(--bg-success-faint, #f0f7f0)' : undefined, borderBottom: isKeeper ? `2px solid ${accent}` : thStyle.borderBottom }}>
+                  <th key={id} style={{ ...thStyle, background: isKeeper ? 'var(--color-success-bg, #f0f7f0)' : undefined, borderBottom: isKeeper ? `2px solid ${accent}` : thStyle.borderBottom }}>
                     <label style={{ display: 'flex', flexDirection: 'column', gap: 3, alignItems: 'center', cursor: 'pointer' }}>
                       <input type="radio" name="keeper" checked={isKeeper} disabled={merging} onChange={() => { setKeeperId(id); setConfirming(false); }} />
                       <span style={{ fontWeight: isKeeper ? 700 : 500, color: isKeeper ? accent : 'inherit' }}>{isKeeper ? 'KEEP' : 'keep'}</span>
-                      <span style={{ fontSize: '0.7rem', fontWeight: 400, color: 'var(--text-secondary, #888)' }}>{w.bottleCount || 0} btl</span>
+                      <span style={{ fontSize: '0.7rem', fontWeight: 400, color: 'var(--color-text-secondary, #888)' }}>{w.bottleCount || 0} btl</span>
                     </label>
                   </th>
                 );
@@ -169,7 +169,7 @@ function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
               const pickedVal = f.show(byId[pickedId] || keeper);
               return (
                 <tr key={f.key} style={{ opacity: allSame ? 0.55 : 1 }}>
-                  <td style={{ ...tdStyle, fontWeight: 600, color: 'var(--text-secondary, #555)' }}>{f.label}{!allSame && <span title="values differ" style={{ color: 'var(--warning, #b8860b)' }}> ⚠</span>}</td>
+                  <td style={{ ...tdStyle, fontWeight: 600, color: 'var(--color-text-secondary, #555)' }}>{f.label}{!allSame && <span title="values differ" style={{ color: 'var(--color-warning, #b8860b)' }}> ⚠</span>}</td>
                   {wines.map((w, i) => {
                     const id = wid(w);
                     const isPicked = id === pickedId;
@@ -184,7 +184,7 @@ function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
                           style={{
                             width: '100%', height: '100%', textAlign: 'left', cursor: 'pointer',
                             padding: C.pad, border: 'none', font: 'inherit',
-                            background: isPicked ? 'var(--bg-success-faint, #eef6ee)' : (differs ? warnBg : 'transparent'),
+                            background: isPicked ? 'var(--color-success-bg, #eef6ee)' : (differs ? warnBg : 'transparent'),
                             boxShadow: isPicked ? `inset 3px 0 0 ${accent}` : 'none',
                             color: 'inherit',
                           }}
@@ -201,7 +201,7 @@ function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
 
             {/* Image row */}
             <tr>
-              <td style={{ ...tdStyle, fontWeight: 600, color: 'var(--text-secondary, #555)' }}>Photo</td>
+              <td style={{ ...tdStyle, fontWeight: 600, color: 'var(--color-text-secondary, #555)' }}>Photo</td>
               {wines.map(w => {
                 const id = wid(w);
                 const isPicked = picks.image === id;
@@ -224,7 +224,7 @@ function WineClusterCompareModal({ cluster, apiFetch, onClose, onMerged }) {
       </div>
 
       {/* After-merge preview + actions */}
-      <div style={{ marginTop: 14, padding: '10px 12px', background: 'var(--bg-secondary, #fafafa)', borderRadius: 6, fontSize: '0.85rem' }}>
+      <div style={{ marginTop: 14, padding: '10px 12px', background: 'var(--color-surface, #fafafa)', borderRadius: 6, fontSize: '0.85rem' }}>
         <strong>After merge:</strong>{' '}
         “{f0(byId[picks.name], 'name', keeper)}” — {f0(byId[picks.producer], 'producer', keeper)}
         {f0(byId[picks.appellation], 'appellation', keeper) ? `, ${f0(byId[picks.appellation], 'appellation', keeper)}` : ''}
@@ -263,7 +263,7 @@ function f0(wine, key, keeper) {
   return (w[key] || '').toString();
 }
 
-const thStyle = { border: '1px solid var(--border, #e5e5e5)', padding: '7px 10px', textAlign: 'center', background: 'var(--bg-secondary, #f7f7f7)', position: 'sticky', top: 0, verticalAlign: 'bottom' };
-const tdStyle = { border: '1px solid var(--border, #e5e5e5)', padding: '7px 10px', verticalAlign: 'middle' };
+const thStyle = { border: '1px solid var(--color-border, #e5e5e5)', padding: '7px 10px', textAlign: 'center', background: 'var(--color-surface, #f7f7f7)', position: 'sticky', top: 0, verticalAlign: 'bottom' };
+const tdStyle = { border: '1px solid var(--color-border, #e5e5e5)', padding: '7px 10px', verticalAlign: 'middle' };
 
 export default WineClusterCompareModal;

--- a/frontend/src/components/WineDuplicatesModal.js
+++ b/frontend/src/components/WineDuplicatesModal.js
@@ -117,7 +117,7 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
           {scanning ? 'Scanning…' : 'Re-scan'}
         </button>
         {meta && !scanning && (
-          <span style={{ fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+          <span style={{ fontSize: '0.85rem', color: 'var(--color-text-secondary, #666)' }}>
             Scanned {meta.scannedCount} wines across {meta.producerGroupCount} producers · {meta.totalClusters} cluster{meta.totalClusters === 1 ? '' : 's'} found
           </span>
         )}
@@ -129,7 +129,7 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
         <div style={{
           display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8,
           padding: '0.5rem 0.75rem', marginBottom: 12, borderRadius: 6,
-          background: 'var(--bg-secondary, #f4f4f4)', border: '1px solid var(--border, #e5e5e5)',
+          background: 'var(--color-surface, #f4f4f4)', border: '1px solid var(--color-border, #e5e5e5)',
           fontSize: '0.85rem',
         }}>
           <span>
@@ -147,13 +147,13 @@ function WineDuplicatesModal({ apiFetch, onClose, onMerged }) {
       )}
 
       {scanning && !clusters && (
-        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--color-text-secondary, #888)' }}>
           Scanning registry… this can take a few seconds.
         </div>
       )}
 
       {!scanning && clusters?.length === 0 && (
-        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--color-text-secondary, #888)' }}>
           No duplicate clusters at this threshold.
         </div>
       )}
@@ -222,15 +222,15 @@ function ClusterCard({ cluster, apiFetch, onMerged, onOpenCompare, onDismiss }) 
 
   return (
     <div style={{
-      border: '1px solid var(--border, #e5e5e5)',
+      border: '1px solid var(--color-border, #e5e5e5)',
       borderRadius: 6,
       padding: 12,
-      background: 'var(--bg-secondary, #fafafa)',
+      background: 'var(--color-surface, #fafafa)',
     }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8, gap: 8 }}>
         <strong>{cluster.wines[0]?.producer}</strong>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)' }}>
+          <span style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary, #888)' }}>
             {Math.round(cluster.score * 100)}% match
           </span>
           <button
@@ -268,8 +268,8 @@ function ClusterCard({ cluster, apiFetch, onMerged, onOpenCompare, onDismiss }) 
                 alignItems: 'center',
                 gap: 10,
                 padding: '0.5rem',
-                borderTop: '1px solid var(--border, #eee)',
-                background: isTarget ? 'var(--bg-success-faint, #f0f7f0)' : 'transparent',
+                borderTop: '1px solid var(--color-border, #eee)',
+                background: isTarget ? 'var(--color-success-bg, #f0f7f0)' : 'transparent',
               }}
             >
               <input
@@ -285,14 +285,14 @@ function ClusterCard({ cluster, apiFetch, onMerged, onOpenCompare, onDismiss }) 
               </div>
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div style={{ fontWeight: 600 }}>{wine.name}</div>
-                <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #666)' }}>
+                <div style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary, #666)' }}>
                   {wine.appellation || '—'}
                   {wine.country?.name ? ` · ${wine.country.name}` : ''}
                   {' · '}{wine.bottleCount || 0} bottle{(wine.bottleCount || 0) === 1 ? '' : 's'}
                 </div>
               </div>
               {isTarget ? (
-                <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent, #4a7c4a)' }}>
+                <span style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--color-accent, #4a7c4a)' }}>
                   KEEP
                 </span>
               ) : (

--- a/frontend/src/components/WineModalThumbs.css
+++ b/frontend/src/components/WineModalThumbs.css
@@ -22,7 +22,7 @@
   width: 80px;
   height: 110px;
   border-radius: 4px;
-  background: var(--color-bg-elev, #eee);
+  background: var(--color-surface-raised, #eee);
   opacity: 0.4;
 }
 .compare-wine-placeholder.red       { background: #722f37; }

--- a/frontend/src/components/WinePicker.css
+++ b/frontend/src/components/WinePicker.css
@@ -69,7 +69,7 @@
 }
 
 .wine-picker__option:hover {
-  background: var(--color-hover, rgba(0,0,0,.04));
+  background: var(--color-surface-hover, rgba(0,0,0,.04));
 }
 
 .wine-picker__option-icon {

--- a/frontend/src/components/WineProducerInNameModal.js
+++ b/frontend/src/components/WineProducerInNameModal.js
@@ -134,20 +134,20 @@ function WineProducerInNameModal({ apiFetch, onClose, onChanged }) {
     textAlign: 'left',
     padding: '0.4rem 0.5rem',
     fontSize: '0.8rem',
-    color: 'var(--text-secondary, #666)',
-    borderBottom: '1px solid var(--border, #e5e5e5)',
+    color: 'var(--color-text-secondary, #666)',
+    borderBottom: '1px solid var(--color-border, #e5e5e5)',
     whiteSpace: 'nowrap',
   };
   const tdStyle = {
     padding: '0.45rem 0.5rem',
-    borderBottom: '1px solid var(--border, #eee)',
+    borderBottom: '1px solid var(--color-border, #eee)',
     verticalAlign: 'top',
   };
 
   return (
     <Modal title={t('admin.wines.producerInName.title')} onClose={onClose} showClose wide>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
-        <span style={{ fontSize: '0.85rem', color: 'var(--text-secondary, #666)' }}>
+        <span style={{ fontSize: '0.85rem', color: 'var(--color-text-secondary, #666)' }}>
           {t('admin.wines.producerInName.intro')}
         </span>
         {wines !== null && !loading && (
@@ -157,8 +157,8 @@ function WineProducerInNameModal({ apiFetch, onClose, onChanged }) {
               fontWeight: 600,
               padding: '0.15rem 0.6rem',
               borderRadius: 999,
-              background: 'var(--bg-secondary, #f4f4f4)',
-              border: '1px solid var(--border, #e5e5e5)',
+              background: 'var(--color-surface, #f4f4f4)',
+              border: '1px solid var(--color-border, #e5e5e5)',
               flexShrink: 0,
             }}
           >
@@ -175,13 +175,13 @@ function WineProducerInNameModal({ apiFetch, onClose, onChanged }) {
       )}
 
       {loading && !wines && (
-        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--color-text-secondary, #888)' }}>
           {t('common.loading')}
         </div>
       )}
 
       {!loading && wines?.length === 0 && (
-        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-secondary, #888)' }}>
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--color-text-secondary, #888)' }}>
           {t('admin.wines.producerInName.empty')}
         </div>
       )}

--- a/frontend/src/components/WineReferenceCard.css
+++ b/frontend/src/components/WineReferenceCard.css
@@ -3,7 +3,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.45rem 0.65rem;
-  background: var(--color-bg-secondary, #f9fafb);
+  background: var(--color-surface, #f9fafb);
   border: 1px solid var(--color-border);
   border-radius: 8px;
   font-size: 0.84rem;

--- a/frontend/src/components/WineSearchPicker.css
+++ b/frontend/src/components/WineSearchPicker.css
@@ -51,7 +51,7 @@
 }
 
 .wine-search-picker__option:hover {
-  background: var(--color-bg-secondary, #f5f5f5);
+  background: var(--color-surface, #f5f5f5);
 }
 
 .wine-search-picker__option-dot {
@@ -133,7 +133,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.45rem 0.65rem;
-  background: var(--color-bg-secondary, #f5f5f5);
+  background: var(--color-surface, #f5f5f5);
   border: 1px solid var(--color-border);
   border-radius: 8px;
   font-size: 0.88rem;

--- a/frontend/src/components/racks/RackTypeSelector.css
+++ b/frontend/src/components/racks/RackTypeSelector.css
@@ -22,22 +22,22 @@
   align-items: center;
   gap: 0.35rem;
   padding: 0.5rem;
-  border: 2px solid var(--border-color, #333);
+  border: 2px solid var(--color-border, #333);
   border-radius: 8px;
-  background: var(--bg-secondary, #1a1a1a);
+  background: var(--color-surface, #1a1a1a);
   cursor: pointer;
   transition: border-color 0.2s, background 0.2s;
 }
 
 .rack-type-option:hover {
-  border-color: var(--text-secondary, #888);
-  background: var(--bg-tertiary, #2a2a2a);
+  border-color: var(--color-text-secondary, #888);
+  background: var(--color-surface-raised, #2a2a2a);
 }
 
 .rack-type-option.selected {
-  border-color: var(--primary, #8b5cf6);
-  background: var(--bg-tertiary, #2a2a2a);
-  box-shadow: 0 0 0 1px var(--primary, #8b5cf6);
+  border-color: var(--color-primary, #8b5cf6);
+  background: var(--color-surface-raised, #2a2a2a);
+  box-shadow: 0 0 0 1px var(--color-primary, #8b5cf6);
 }
 
 .rack-type-preview-svg {
@@ -48,12 +48,12 @@
 
 .rack-type-name {
   font-size: 0.75rem;
-  color: var(--text-secondary, #aaa);
+  color: var(--color-text-secondary, #aaa);
   text-transform: capitalize;
   white-space: nowrap;
 }
 
 .rack-type-option.selected .rack-type-name {
-  color: var(--text-primary, #fff);
+  color: var(--color-text, #fff);
   font-weight: 600;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -57,9 +57,11 @@
   --color-danger: #C94040;
   --color-danger-bg: #FDF0F0;
   --color-danger-border: #F0C8C8;
+  --color-danger-rgb: 201, 64, 64;
   --color-warning: #B8860B;
   --color-warning-bg: #FFF8E6;
   --color-warning-border: #F0E0A0;
+  --color-warning-rgb: 184, 134, 11;
   --color-info: #2E6B9E;
   --color-info-bg: #EBF3FA;
   --color-info-border: #C0D8EE;
@@ -173,9 +175,11 @@
   --color-danger: #E07060;
   --color-danger-bg: #2d1414;
   --color-danger-border: #5a2020;
+  --color-danger-rgb: 224, 112, 96;
   --color-warning: #e0a060;
   --color-warning-bg: #2d1e10;
   --color-warning-border: #5a3a10;
+  --color-warning-rgb: 224, 160, 96;
   --color-info: #7aade0;
   --color-info-bg: #14202d;
   --color-info-border: #1e3a5a;

--- a/frontend/src/pages/AdminBlog.css
+++ b/frontend/src/pages/AdminBlog.css
@@ -25,9 +25,9 @@
 .admin-blog-filters select {
   padding: 0.4rem 0.75rem;
   border-radius: 6px;
-  border: 1px solid var(--border);
-  background: var(--bg-card);
-  color: var(--text-primary);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
   font-size: 0.9rem;
 }
 
@@ -44,13 +44,13 @@
 .admin-blog-table td {
   padding: 0.75rem 0.5rem;
   text-align: left;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--color-border);
   font-size: 0.9rem;
 }
 
 .admin-blog-table th {
   font-weight: 600;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.03em;
@@ -68,7 +68,7 @@
 .admin-blog-slug {
   display: block;
   font-size: 0.78rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   opacity: 0.7;
 }
 
@@ -81,8 +81,8 @@
 }
 
 .admin-blog-status--draft {
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
 }
 
 .admin-blog-status--published {

--- a/frontend/src/pages/AdminBlogEditor.css
+++ b/frontend/src/pages/AdminBlogEditor.css
@@ -38,17 +38,17 @@
   padding: 0.75rem;
   font-family: 'Playfair Display', serif;
   font-size: 1.6rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
-  background: var(--bg-card);
-  color: var(--text-primary);
+  background: var(--color-surface);
+  color: var(--color-text);
   margin-bottom: 1rem;
   box-sizing: border-box;
 }
 
 .blog-editor-title-input:focus {
   outline: none;
-  border-color: var(--accent);
+  border-color: var(--color-accent);
 }
 
 /* ── Toolbar ── */
@@ -57,10 +57,10 @@
   flex-wrap: wrap;
   gap: 2px;
   padding: 0.5rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border);
   border-bottom: none;
   border-radius: 8px 8px 0 0;
-  background: var(--bg-secondary);
+  background: var(--color-surface);
 }
 
 .blog-editor-toolbar button {
@@ -72,18 +72,18 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-primary);
+  color: var(--color-text);
   cursor: pointer;
   font-size: 0.85rem;
   transition: background 0.15s;
 }
 
 .blog-editor-toolbar button:hover {
-  background: var(--bg-card);
+  background: var(--color-surface);
 }
 
 .blog-editor-toolbar button.active {
-  background: var(--accent);
+  background: var(--color-accent);
   color: #fff;
 }
 
@@ -94,17 +94,17 @@
 
 .toolbar-divider {
   width: 1px;
-  background: var(--border);
+  background: var(--color-border);
   margin: 4px 4px;
   align-self: stretch;
 }
 
 /* ── Editor content area (TipTap) ── */
 .blog-editor-content {
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border);
   border-top: none;
   border-radius: 0 0 8px 8px;
-  background: var(--bg-card);
+  background: var(--color-surface);
   min-height: 400px;
 }
 
@@ -115,8 +115,8 @@
   font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
   font-size: 0.88rem;
   line-height: 1.5;
-  color: var(--text-primary);
-  background: var(--bg-card);
+  color: var(--color-text);
+  background: var(--color-surface);
   border: none;
   outline: none;
   resize: vertical;
@@ -130,14 +130,14 @@
   min-height: 400px;
   font-size: 1rem;
   line-height: 1.7;
-  color: var(--text-primary);
+  color: var(--color-text);
   outline: none;
 }
 
 .blog-editor-content .tiptap p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   float: left;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   opacity: 0.5;
   pointer-events: none;
   height: 0;
@@ -156,10 +156,10 @@
 }
 
 .blog-editor-content .tiptap blockquote {
-  border-left: 3px solid var(--accent);
+  border-left: 3px solid var(--color-accent);
   padding-left: 1rem;
   margin: 1rem 0;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-style: italic;
 }
 
@@ -175,7 +175,7 @@
 }
 
 .blog-editor-content .tiptap a {
-  color: var(--accent);
+  color: var(--color-accent);
   text-decoration: underline;
 }
 
@@ -186,7 +186,7 @@
 
 .blog-editor-content .tiptap hr {
   border: none;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--color-border);
   margin: 1.5rem 0;
 }
 
@@ -202,17 +202,17 @@
   font-weight: 500;
   font-size: 0.85rem;
   margin-bottom: 0.35rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .blog-editor-field input,
 .blog-editor-field textarea {
   width: 100%;
   padding: 0.5rem 0.6rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: var(--bg-card);
-  color: var(--text-primary);
+  background: var(--color-surface);
+  color: var(--color-text);
   font-size: 0.9rem;
   box-sizing: border-box;
 }
@@ -224,7 +224,7 @@
 .blog-editor-field input:focus,
 .blog-editor-field textarea:focus {
   outline: none;
-  border-color: var(--accent);
+  border-color: var(--color-accent);
 }
 
 .blog-editor-cover-preview {
@@ -236,7 +236,7 @@
 }
 
 .blog-editor-seo {
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.75rem;
 }
@@ -245,7 +245,7 @@
   cursor: pointer;
   font-weight: 500;
   font-size: 0.9rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .blog-editor-seo .blog-editor-field {
@@ -256,7 +256,7 @@
   display: block;
   text-align: right;
   font-size: 0.75rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-top: 0.2rem;
 }
 

--- a/frontend/src/pages/AdminRequests.css
+++ b/frontend/src/pages/AdminRequests.css
@@ -302,5 +302,5 @@
 .admin-notes-hint {
   font-weight: normal;
   font-size: 0.85em;
-  color: var(--text-secondary, #888);
+  color: var(--color-text-secondary, #888);
 }

--- a/frontend/src/pages/AdminStats.css
+++ b/frontend/src/pages/AdminStats.css
@@ -24,7 +24,7 @@
   align-items: center;
   gap: 1rem;
   font-size: 0.85rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   flex-wrap: wrap;
 }
 
@@ -46,7 +46,7 @@
 }
 
 .admin-stats-toggle-info {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   opacity: 0.7;
   font-size: 0.8rem;
 }
@@ -58,23 +58,23 @@
 }
 
 .admin-stats-note {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
   margin: 0 0 2rem;
   padding: 0.75rem 1rem;
-  background: var(--bg-secondary);
+  background: var(--color-surface);
   border-radius: 6px;
-  border-left: 3px solid var(--accent);
+  border-left: 3px solid var(--color-accent);
 }
 
 .admin-stats-section-note {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-size: 0.85rem;
   margin: -0.5rem 0 1rem;
 }
 
 .admin-stats-empty {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-style: italic;
 }
 
@@ -91,7 +91,7 @@
   font-family: 'Playfair Display', serif;
   font-size: 1.4rem;
   margin: 0 0 1rem;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--color-border);
   padding-bottom: 0.5rem;
 }
 
@@ -104,8 +104,8 @@
 }
 
 .admin-stats-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 1rem 1.1rem;
 }
@@ -123,12 +123,12 @@
   font-size: 1.8rem;
   font-weight: 600;
   line-height: 1.1;
-  color: var(--text-primary);
+  color: var(--color-text);
 }
 
 .admin-stats-card-label {
   font-size: 0.85rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-top: 0.25rem;
   text-transform: uppercase;
   letter-spacing: 0.02em;
@@ -136,7 +136,7 @@
 
 .admin-stats-card-sub {
   font-size: 0.8rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   opacity: 0.75;
   margin-top: 0.4rem;
 }
@@ -149,8 +149,8 @@
 }
 
 .admin-stats-panel {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 1rem 1.1rem;
 }
@@ -164,7 +164,7 @@
 .admin-stats-panel .admin-stats-sub {
   display: block;
   font-size: 0.8rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin: 0 0 0.5rem;
 }
 
@@ -180,14 +180,14 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   padding: 0.4rem 0.4rem;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .admin-stats-table td {
   padding: 0.4rem 0.4rem;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--color-border);
   vertical-align: top;
 }
 
@@ -197,7 +197,7 @@
 
 .admin-stats-rank {
   width: 2rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-variant-numeric: tabular-nums;
 }
 
@@ -208,7 +208,7 @@
 .admin-stats-name .admin-stats-sub {
   display: block;
   font-size: 0.75rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-weight: 400;
   margin-top: 0.1rem;
 }
@@ -216,13 +216,13 @@
 .admin-stats-count {
   text-align: right;
   font-variant-numeric: tabular-nums;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .admin-stats-pct {
   text-align: right;
   font-variant-numeric: tabular-nums;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   width: 3.5rem;
   font-size: 0.85rem;
 }
@@ -253,7 +253,7 @@
 
 .admin-stats-bar {
   width: 100%;
-  background: var(--accent);
+  background: var(--color-accent);
   border-radius: 3px 3px 0 0;
   min-height: 4px;
   position: relative;
@@ -271,7 +271,7 @@
   left: 50%;
   transform: translateX(-50%);
   font-size: 0.65rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   white-space: nowrap;
   pointer-events: none;
   font-variant-numeric: tabular-nums;
@@ -279,7 +279,7 @@
 
 .admin-stats-bar-label {
   font-size: 0.7rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-variant-numeric: tabular-nums;
   text-align: center;
 }
@@ -295,12 +295,12 @@
 }
 
 .admin-stats-hbar-label {
-  color: var(--text-primary);
+  color: var(--color-text);
 }
 
 .admin-stats-hbar-track {
   height: 16px;
-  background: var(--bg-secondary);
+  background: var(--color-surface);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -313,7 +313,7 @@
 
 .admin-stats-hbar-count {
   text-align: right;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-variant-numeric: tabular-nums;
 }
 

--- a/frontend/src/pages/AdminStats.js
+++ b/frontend/src/pages/AdminStats.js
@@ -159,7 +159,7 @@ function AdminStats() {
     notReady:   '#9e9e9e',
     late:       '#bf8a2e',
     declining:  '#dc3545',
-    noProfile:  'var(--border)',
+    noProfile:  'var(--color-border)',
   };
 
   return (
@@ -376,7 +376,7 @@ function AdminStats() {
             <div className="admin-stats-panel">
               <h3>{t('adminStats.ratingDistribution')}</h3>
               {ratings.distribution.filter(r => r.count > 0).map((r, i) => (
-                <HorizontalBar key={`${r.band}-${i}`} label={r.band} count={r.count} total={ratings.ratedCount} color="var(--accent)" />
+                <HorizontalBar key={`${r.band}-${i}`} label={r.band} count={r.count} total={ratings.ratedCount} color="var(--color-accent)" />
               ))}
             </div>
           )}

--- a/frontend/src/pages/AdminWines.css
+++ b/frontend/src/pages/AdminWines.css
@@ -324,7 +324,7 @@
   padding: 0;
   font: inherit;
   font-weight: 600;
-  color: var(--accent, #4a7c4a);
+  color: var(--color-accent, #4a7c4a);
   cursor: pointer;
   text-align: left;
 }
@@ -341,9 +341,9 @@
   flex-wrap: wrap;
   margin-top: 1rem;
 }
-.pagination-range { font-size: 0.85rem; color: var(--text-secondary, #777); }
+.pagination-range { font-size: 0.85rem; color: var(--color-text-secondary, #777); }
 .pagination-controls { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
-.pagination-page { font-size: 0.85rem; color: var(--text-secondary, #777); padding: 0 0.25rem; }
+.pagination-page { font-size: 0.85rem; color: var(--color-text-secondary, #777); padding: 0 0.25rem; }
 .page-size select { padding: 2px 4px; }
 
 .toast-stack {
@@ -364,6 +364,6 @@
   animation: toast-in 0.18s ease;
   max-width: 340px;
 }
-.toast--success { background: var(--accent, #4a7c4a); }
+.toast--success { background: var(--color-accent, #4a7c4a); }
 .toast--error { background: var(--danger, #c0392b); }
 @keyframes toast-in { from { transform: translateY(8px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }

--- a/frontend/src/pages/Blog.css
+++ b/frontend/src/pages/Blog.css
@@ -17,7 +17,7 @@
 }
 
 .blog-subtitle {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-size: 1.1rem;
 }
 
@@ -32,9 +32,9 @@
 .blog-tag {
   padding: 0.35rem 0.9rem;
   border-radius: 20px;
-  border: 1px solid var(--border);
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
   font-size: 0.85rem;
   cursor: pointer;
   transition: all 0.2s;
@@ -42,9 +42,9 @@
 
 .blog-tag:hover,
 .blog-tag.active {
-  background: var(--accent);
+  background: var(--color-accent);
   color: #fff;
-  border-color: var(--accent);
+  border-color: var(--color-accent);
 }
 
 .blog-grid {
@@ -56,8 +56,8 @@
 .blog-card {
   border-radius: 12px;
   overflow: hidden;
-  border: 1px solid var(--border);
-  background: var(--bg-card);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
   transition: box-shadow 0.2s, transform 0.2s;
 }
 
@@ -76,7 +76,7 @@
   width: 100%;
   aspect-ratio: 16 / 9;
   overflow: hidden;
-  background: var(--bg-secondary);
+  background: var(--color-surface);
 }
 
 .blog-card-image img {
@@ -94,7 +94,7 @@
   align-items: center;
   gap: 0.75rem;
   font-size: 0.8rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-bottom: 0.5rem;
 }
 
@@ -111,7 +111,7 @@
 }
 
 .blog-card-excerpt {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
   line-height: 1.5;
   margin: 0 0 0.75rem;
@@ -131,8 +131,8 @@
   font-size: 0.75rem;
   padding: 0.2rem 0.6rem;
   border-radius: 12px;
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
   text-decoration: none;
 }
 
@@ -147,7 +147,7 @@
 }
 
 .blog-pagination-info {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
 }
 
@@ -157,7 +157,7 @@
 .blog-error {
   text-align: center;
   padding: 3rem 1rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .blog-error .btn {
@@ -176,12 +176,12 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.85rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-bottom: 1.5rem;
 }
 
 .blog-breadcrumb a {
-  color: var(--accent);
+  color: var(--color-accent);
   text-decoration: none;
 }
 
@@ -221,7 +221,7 @@
   align-items: center;
   gap: 0.75rem;
   font-size: 0.9rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-bottom: 0.75rem;
 }
 
@@ -240,7 +240,7 @@
 .blog-article-content {
   font-size: 1.05rem;
   line-height: 1.75;
-  color: var(--text-primary);
+  color: var(--color-text);
 }
 
 .blog-article-content h2 {
@@ -273,10 +273,10 @@
 }
 
 .blog-article-content blockquote {
-  border-left: 3px solid var(--accent);
+  border-left: 3px solid var(--color-accent);
   margin: 1.25rem 0;
   padding: 0.5rem 1.25rem;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   font-style: italic;
 }
 
@@ -291,19 +291,19 @@
 }
 
 .blog-article-content a {
-  color: var(--accent);
+  color: var(--color-accent);
   text-decoration: underline;
 }
 
 .blog-article-content hr {
   border: none;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--color-border);
   margin: 2rem 0;
 }
 
 .blog-article-content aside.post-attribution {
-  background: var(--bg-secondary);
-  border-left: 3px solid var(--accent);
+  background: var(--color-surface);
+  border-left: 3px solid var(--color-accent);
   padding: 0.9rem 1.25rem;
   margin: 0 0 1.5rem;
   border-radius: 6px;
@@ -324,29 +324,29 @@
 .blog-article-content th,
 .blog-article-content td {
   padding: 0.6rem 0.8rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border);
   text-align: left;
   vertical-align: top;
 }
 
 .blog-article-content thead th {
-  background: var(--bg-secondary);
+  background: var(--color-surface);
   font-weight: 600;
 }
 
 .blog-article-content tbody tr:nth-child(even) {
-  background: var(--bg-secondary);
+  background: var(--color-surface);
 }
 
 .blog-article-content table td[colspan] {
-  background: var(--bg-card);
+  background: var(--color-surface);
   font-size: 1rem;
 }
 
 .blog-post-footer {
   margin-top: 3rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--color-border);
 }
 
 /* ── Responsive ── */

--- a/frontend/src/pages/BottleDetail.css
+++ b/frontend/src/pages/BottleDetail.css
@@ -811,35 +811,9 @@
   margin-bottom: 0.35rem;
 }
 
-/* ── Consume modal ── */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.65);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: 1rem;
-}
-
-.modal-box {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 1.5rem;
-  width: 100%;
-  max-width: 420px;
-  max-height: 90vh;
-  overflow-y: auto;
-  box-shadow: var(--shadow-lg);
-}
-
-.modal-box h2 {
-  margin: 0 0 0.25rem 0;
-  color: var(--color-text);
-}
-
+/* ── Consume modal ── (overlay/box come from the shared styles/common.css
+   .modal-overlay / .modal-box — redefining them here as globals made the
+   backdrop's blur/opacity depend on CSS bundle order) */
 .modal-wine-name {
   color: var(--color-text-muted);
   font-size: 0.9rem;

--- a/frontend/src/pages/Bottles.css
+++ b/frontend/src/pages/Bottles.css
@@ -19,7 +19,7 @@
 
 .bottles-subtitle {
   margin: 0.25rem 0 0;
-  color: var(--text-muted, #9A9484);
+  color: var(--color-text-muted, #9A9484);
   font-size: 0.95rem;
 }
 
@@ -63,7 +63,7 @@
 .bottles-chip-clear {
   background: none;
   border: none;
-  color: var(--text-muted, #9A9484);
+  color: var(--color-text-muted, #9A9484);
   cursor: pointer;
   padding: 0.3rem 0.5rem;
   font-size: 0.85rem;
@@ -77,7 +77,7 @@
 .bottles-empty {
   padding: 3rem 1rem;
   text-align: center;
-  color: var(--text-muted, #9A9484);
+  color: var(--color-text-muted, #9A9484);
   background: rgba(255, 255, 255, 0.02);
   border: 1px dashed rgba(255, 255, 255, 0.08);
   border-radius: 8px;
@@ -118,6 +118,6 @@
 }
 
 .bottles-page-indicator {
-  color: var(--text-muted, #9A9484);
+  color: var(--color-text-muted, #9A9484);
   font-size: 0.9rem;
 }

--- a/frontend/src/pages/CellarChat.css
+++ b/frontend/src/pages/CellarChat.css
@@ -118,7 +118,7 @@
 }
 
 .cellar-chat__scope-option:hover {
-  background: var(--color-hover);
+  background: var(--color-surface-hover);
 }
 
 .cellar-chat__scope-option input[type="checkbox"] {

--- a/frontend/src/pages/CellarRacks.css
+++ b/frontend/src/pages/CellarRacks.css
@@ -75,7 +75,8 @@
 
 .rack-tab-count {
   font-size: 0.72rem;
-  background: rgba(255, 255, 255, 0.08);
+  /* Theme-aware tint — white-at-8% was invisible on the white tab surface. */
+  background: rgba(var(--color-primary-rgb), 0.08);
   border-radius: 10px;
   padding: 1px 6px;
   font-weight: 400;

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -1553,7 +1553,7 @@ function NfcLinkModal({ rack, onSave, onCancel }) {
                 </p>
               )}
               {status === 'error' && (
-                <p style={{ color: 'var(--color-error)', fontSize: '0.85rem', margin: '0.5rem 0 0' }}>
+                <p style={{ color: 'var(--color-danger)', fontSize: '0.85rem', margin: '0.5rem 0 0' }}>
                   {errorMsg}
                 </p>
               )}

--- a/frontend/src/pages/ExportCellar.js
+++ b/frontend/src/pages/ExportCellar.js
@@ -148,7 +148,7 @@ function ExportCellar() {
 
         {/* Total export summary (hidden when there is nothing to export yet) */}
         {!noCellars && (
-          <div className="card" style={{ marginTop: '1rem', padding: '1rem', background: 'var(--surface-2, #f7f7f8)' }}>
+          <div className="card" style={{ marginTop: '1rem', padding: '1rem', background: 'var(--color-surface-raised, #f7f7f8)' }}>
             <div style={{ fontWeight: 600, marginBottom: '0.5rem' }}>{t('exportCellar.containsTitle')}</div>
             {loadingSummary ? (
               <div className="settings-hint">{t('exportCellar.calculating')}</div>

--- a/frontend/src/pages/Help.css
+++ b/frontend/src/pages/Help.css
@@ -31,7 +31,7 @@
   border: 1px solid var(--color-border, #e0d6d0);
   border-radius: 8px;
   font-size: 0.9rem;
-  background: var(--color-card-bg, #fff);
+  background: var(--color-surface, #fff);
   color: var(--color-text);
   outline: none;
   transition: border-color 0.15s;
@@ -42,7 +42,7 @@
 }
 
 .help-search::placeholder {
-  color: var(--color-text-tertiary, #999);
+  color: var(--color-text-muted, #999);
 }
 
 /* ─── Sections ─── */
@@ -54,8 +54,8 @@
 }
 
 .help-section {
-  background: var(--color-card-bg, #fff);
-  border-radius: var(--radius, 8px);
+  background: var(--color-surface, #fff);
+  border-radius: var(--radius-md, 8px);
   border: 1px solid var(--color-border, #e0d6d0);
   overflow: hidden;
   transition: box-shadow 0.15s;
@@ -81,7 +81,7 @@
 }
 
 .help-section-header:hover {
-  background: var(--color-bg-secondary, #f5f0ec);
+  background: var(--color-surface, #f5f0ec);
 }
 
 .help-section-header-text h2 {
@@ -100,7 +100,7 @@
 .help-section-chevron {
   flex-shrink: 0;
   transition: transform 0.2s;
-  color: var(--color-text-tertiary, #999);
+  color: var(--color-text-muted, #999);
 }
 
 .help-section--open .help-section-chevron {

--- a/frontend/src/pages/ImportCellar.js
+++ b/frontend/src/pages/ImportCellar.js
@@ -193,7 +193,7 @@ function ImportCellar() {
               )}
 
               {rows.map(r => (
-                <div key={r.sourceName} className="form-group" style={{ borderTop: '1px solid var(--border, #ddd)', paddingTop: '0.75rem' }}>
+                <div key={r.sourceName} className="form-group" style={{ borderTop: '1px solid var(--color-border, #ddd)', paddingTop: '0.75rem' }}>
                   <label htmlFor={`name-${r.sourceName}`}>{t('importCellar.importAsLabel', { name: r.sourceName })}</label>
                   <input
                     id={`name-${r.sourceName}`}

--- a/frontend/src/pages/Journal.css
+++ b/frontend/src/pages/Journal.css
@@ -98,7 +98,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--color-surface-alt, #f8f6f3);
+  background: var(--color-surface-raised, #f8f6f3);
   border-radius: 12px;
 }
 
@@ -202,7 +202,7 @@
   display: flex;
   align-items: stretch;
   gap: 0;
-  background: var(--color-surface-alt, #fafaf8);
+  background: var(--color-surface-raised, #fafaf8);
   border-radius: var(--radius-md, 8px);
   overflow: hidden;
   border: 1px solid var(--color-border);
@@ -241,7 +241,7 @@
   color: var(--color-text-secondary);
   font-style: italic;
   border-top: 1px dashed var(--color-border);
-  background: var(--color-surface-alt, #fafaf8);
+  background: var(--color-surface-raised, #fafaf8);
 }
 
 /* Notes */

--- a/frontend/src/pages/PrivacyPolicy.css
+++ b/frontend/src/pages/PrivacyPolicy.css
@@ -7,8 +7,8 @@
 .privacy-container {
   max-width: 720px;
   margin: 0 auto;
-  background: var(--color-card-bg, #fff);
-  border-radius: var(--radius, 8px);
+  background: var(--color-surface, #fff);
+  border-radius: var(--radius-md, 8px);
   padding: 2.5rem;
   box-shadow: var(--shadow-sm);
 }
@@ -69,7 +69,7 @@
 
 .privacy-table th {
   font-weight: 600;
-  background: var(--color-bg-secondary, #f5f5f5);
+  background: var(--color-surface, #f5f5f5);
 }
 
 .privacy-table tr:last-child td {

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -129,8 +129,8 @@
 .settings-push-devices {
   margin-top: 0.5rem;
   padding: 0.75rem;
-  background: var(--color-bg-muted, rgba(0,0,0,0.03));
-  border-radius: var(--radius);
+  background: var(--color-surface-hover, rgba(0,0,0,0.03));
+  border-radius: var(--radius-md);
 }
 
 .settings-push-device-row {
@@ -205,7 +205,7 @@
   color: #fff;
   border: none;
   padding: 0.5rem 1.25rem;
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 0.875rem;
   font-weight: 500;
@@ -300,7 +300,7 @@
   justify-content: space-between;
   gap: 0.75rem;
   padding: 0.6rem 0;
-  border-bottom: 1px solid var(--border-color, #e0e0e0);
+  border-bottom: 1px solid var(--color-border, #e0e0e0);
 }
 
 .api-token-row:last-child {
@@ -316,15 +316,15 @@
 
 .api-token-meta {
   font-size: 0.85rem;
-  color: var(--text-secondary, #777);
+  color: var(--color-text-secondary, #777);
 }
 
 .api-token-plain {
   display: block;
   padding: 0.75rem;
   margin: 0.75rem 0;
-  background: var(--bg-secondary, #f5f5f5);
-  border: 1px solid var(--border-color, #e0e0e0);
+  background: var(--color-surface, #f5f5f5);
+  border: 1px solid var(--color-border, #e0e0e0);
   border-radius: 6px;
   font-family: monospace;
   font-size: 0.85rem;

--- a/frontend/src/pages/Statistics.css
+++ b/frontend/src/pages/Statistics.css
@@ -450,7 +450,7 @@
 
 .rating-fill {
   height: 100%;
-  background: linear-gradient(to right, var(--color-accent-dark, #B4882A), var(--color-accent));
+  background: linear-gradient(to right, var(--color-accent-hover, #B4882A), var(--color-accent));
   border-radius: 4px;
   transition: width 0.5s cubic-bezier(0.25, 1, 0.5, 1);
 }
@@ -2081,7 +2081,7 @@
 .value-chart-tooltip {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
   padding: 0.6rem 0.75rem;
   font-size: 0.78rem;
   color: var(--color-text);

--- a/frontend/src/pages/SuperAdmin/TabBackups.js
+++ b/frontend/src/pages/SuperAdmin/TabBackups.js
@@ -59,7 +59,7 @@ export default function TabBackups() {
         </tbody>
       </table>
 
-      <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary, #888)', marginTop: 12 }}>
+      <p style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary, #888)', marginTop: 12 }}>
         Reported by the backup job — the app reads this status only and never accesses the backup repository.
       </p>
       <button className="sa-btn" onClick={reload} style={{ marginTop: 8 }}>Refresh</button>

--- a/frontend/src/pages/TaxonomyDetail.css
+++ b/frontend/src/pages/TaxonomyDetail.css
@@ -100,7 +100,7 @@
 
 .taxonomy-wine-meta {
   font-size: 0.78rem;
-  color: var(--color-text-tertiary, var(--color-text-secondary));
+  color: var(--color-text-muted, var(--color-text-secondary));
   margin-top: 4px;
 }
 

--- a/frontend/src/pages/WineDetail.css
+++ b/frontend/src/pages/WineDetail.css
@@ -102,7 +102,7 @@
   display: flex;
   justify-content: center;
   padding: 2rem 1.5rem 1rem;
-  background: var(--color-surface-alt, #fafafa);
+  background: var(--color-surface-raised, #fafafa);
 }
 
 .wd-image {

--- a/frontend/src/pages/WineListEditor.css
+++ b/frontend/src/pages/WineListEditor.css
@@ -271,7 +271,7 @@
 .wle-glass-calc {
   margin-top: 0.75rem;
   padding: 0.75rem;
-  background: var(--color-bg-secondary, #f8f8f8);
+  background: var(--color-surface, #f8f8f8);
   border-radius: var(--radius-sm);
 }
 
@@ -536,7 +536,7 @@
   border-radius: 10px;
   font-size: 0.7rem;
   font-weight: 600;
-  background: var(--color-bg-secondary, #f0f0f0);
+  background: var(--color-surface, #f0f0f0);
   color: var(--color-text-secondary, #666);
 }
 


### PR DESCRIPTION
## Audit Batch 3 — Design system CSS

Third batch from the GRAND_AUDIT_2026-07-11 design/UX track. **Frontend CSS/JS only** — no backend, compose, or env changes.

### The core problem
Dozens of components referenced CSS custom properties that were **never defined** in the theme (`index.css`). Two failure modes:
- **With inline fallback** (`var(--token, #fff)`) → rendered a hardcoded *light-mode* value that broke in **dark mode**.
- **No fallback** (`var(--token)`) → rendered transparent/wrong — e.g. the Blog active tag pill, and various invisible pills.

I diffed every *used* token against every *defined* token to find the complete phantom set, then mapped each to its correct theme-aware token.

### Phantom-token fixes (used → real)
| Phantom | Real |
|---|---|
| `--accent` | `--color-accent` |
| `--bg` | `--color-bg` |
| `--bg-card`, `--color-bg-secondary`, `--color-card-bg` | `--color-surface` |
| `--color-bg-elev`, `--surface-2`, `--color-surface-alt` | `--color-surface-raised` |
| `--color-hover`, `--color-bg-muted` | `--color-surface-hover` |
| `--color-error` | `--color-danger` |
| `--warning` | `--color-warning` |
| `--color-accent-dark` | `--color-accent-hover` |
| `--color-on-primary` | `--color-text-inverse` |
| `--color-text-tertiary`, `--text-muted` | `--color-text-muted` |
| `--text-color` | `--color-text` |
| `--bg-success-faint` / `--bg-warning-faint` | `--color-success-bg` / `--color-warning-bg` |
| `--radius` | `--radius-md` |

Added the genuinely-missing `--color-danger-rgb` / `--color-warning-rgb` tokens (both themes) so the Wishlist `rgba()` tints are theme-aware. Legit inline-set tokens (`--cellar-*`, `--wlm-*`) were left alone.

### Also in this batch
- **Dark-mode badge remaps** — BottleCard maturity/open-bottle/unplaced badges, CellarCredBadge tiers, CategoryBadge label hues → semantic token families so they adapt on dark surfaces.
- **Removed duplicate global** `.modal-overlay` / `.modal-box` declarations (BottleDetail.css, ShareCellarModal.css) that were shadowing the shared Modal styles.
- **Fixed the invisible rack-tab-count pill** (hardcoded white `rgba` → primary tint).
- **Print stylesheet** hides app chrome (`.navbar`, `.bottom-nav`, `.announcement-banner`, `.install-prompt`) so Cellar Book prints are clean.

### Verification
- `npx vite build` clean; `npm test` → **640 passed**.
- Visual check in Docker (light + dark): Blog tag pills now render correctly (active pill shows the accent fill `rgb(212,163,115)`; dark mode uses dark surfaces instead of light fallbacks).

### Docker impact
Frontend-only — rebuild the frontend image (`docker compose build frontend`). No compose/backend/env changes.
