### PR TITLE
fix(a11y): dialog semantics, keyboard operability & error feedback (audit batch 4)

### DIFF
--- a/frontend/src/components/ConsumeModal.js
+++ b/frontend/src/components/ConsumeModal.js
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import RatingInput from './RatingInput';
+import { useDialogA11y } from '../utils/useDialogA11y';
 
 export function ConsumeModal({ wineName, defaultRatingScale, onConfirm, onCancel }) {
   const { t } = useTranslation();
@@ -9,18 +10,23 @@ export function ConsumeModal({ wineName, defaultRatingScale, onConfirm, onCancel
   const [rating,       setRating]      = useState('');
   const [ratingScale,  setRatingScale] = useState(defaultRatingScale || '5');
   const [saving,       setSaving]      = useState(false);
+  const titleId = useId();
+  const boxRef = useDialogA11y(onCancel);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSaving(true);
-    await onConfirm(reason, note || undefined, rating || undefined, ratingScale);
-    setSaving(false);
+    try {
+      await onConfirm(reason, note || undefined, rating || undefined, ratingScale);
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
     <div className="modal-overlay" onClick={onCancel}>
-      <div className="modal-box" onClick={e => e.stopPropagation()}>
-        <h2>{t('bottleDetail.removeBottleTitle')}</h2>
+      <div className="modal-box" onClick={e => e.stopPropagation()} ref={boxRef} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1}>
+        <h2 id={titleId}>{t('bottleDetail.removeBottleTitle')}</h2>
         {wineName && <p className="modal-wine-name">{wineName}</p>}
         <form onSubmit={handleSubmit}>
           <div className="form-group">

--- a/frontend/src/components/JournalPrompt.js
+++ b/frontend/src/components/JournalPrompt.js
@@ -1,5 +1,6 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDialogA11y } from '../utils/useDialogA11y';
 
 const JournalEntryForm = lazy(() => import('./JournalEntryForm'));
 
@@ -31,11 +32,14 @@ export default function JournalPrompt({ bottle, onDone }) {
   const { t } = useTranslation();
   const [formOpen, setFormOpen] = useState(false);
   const [dontAsk, setDontAsk] = useState(false);
+  const titleId = useId();
 
   const finish = () => {
     if (dontAsk) setJournalPromptOptOut(true);
     onDone();
   };
+
+  const boxRef = useDialogA11y(finish);
 
   const accept = () => {
     if (dontAsk) setJournalPromptOptOut(true);
@@ -52,8 +56,8 @@ export default function JournalPrompt({ bottle, onDone }) {
 
   return (
     <div className="modal-overlay" onClick={finish}>
-      <div className="modal-box" onClick={e => e.stopPropagation()}>
-        <h2>{t('journal.promptTitle', 'Add to your journal?')}</h2>
+      <div className="modal-box" onClick={e => e.stopPropagation()} ref={boxRef} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1}>
+        <h2 id={titleId}>{t('journal.promptTitle', 'Add to your journal?')}</h2>
         <p>{t('journal.promptText', 'Would you like to capture this moment in your wine journal?')}</p>
         <div className="modal-actions" style={{ flexDirection: 'column', gap: '0.5rem' }}>
           <button className="btn btn-primary" onClick={accept}>

--- a/frontend/src/components/Modal.js
+++ b/frontend/src/components/Modal.js
@@ -21,6 +21,15 @@ function Modal({ title, onClose, children, wide, showClose, boxStyle, trapFocus 
   const titleId = useId();
   const boxRef = useRef(null);
 
+  // Escape closes the dialog, independent of the optional focus trap — mirrors
+  // Drawer.js so every shared-Modal dialog is keyboard-dismissible.
+  useEffect(() => {
+    if (!onClose) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') onClose(e); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
   useEffect(() => {
     if (!trapFocus) return;
     const box = boxRef.current;

--- a/frontend/src/components/Modal.test.js
+++ b/frontend/src/components/Modal.test.js
@@ -31,4 +31,18 @@ describe('Modal', () => {
     fireEvent.click(screen.getByText('body'));
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  test('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    render(<Modal onClose={onClose}>body</Modal>);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('exposes dialog semantics', () => {
+    render(<Modal title="Edit Wine" onClose={() => {}}>body</Modal>);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+  });
 });

--- a/frontend/src/components/ShareCellarModal.js
+++ b/frontend/src/components/ShareCellarModal.js
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { useDialogA11y } from '../utils/useDialogA11y';
 import './ShareCellarModal.css';
 
 function ShareCellarModal({ cellarId, cellarName, onClose }) {
@@ -10,6 +11,8 @@ function ShareCellarModal({ cellarId, cellarName, onClose }) {
   const [adding, setAdding] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
+  const titleId = useId();
+  const boxRef = useDialogA11y(onClose);
 
   useEffect(() => {
     fetchMembers();
@@ -90,9 +93,9 @@ function ShareCellarModal({ cellarId, cellarName, onClose }) {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="share-modal" onClick={e => e.stopPropagation()}>
+      <div className="share-modal" onClick={e => e.stopPropagation()} ref={boxRef} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1}>
         <div className="share-modal-header">
-          <h2>Share "{cellarName}"</h2>
+          <h2 id={titleId}>Share "{cellarName}"</h2>
           <button className="modal-close-btn" onClick={onClose} aria-label="Close">{'\u2715'}</button>
         </div>
 

--- a/frontend/src/components/SuggestGrapesModal.js
+++ b/frontend/src/components/SuggestGrapesModal.js
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
+import { useDialogA11y } from '../utils/useDialogA11y';
 
 export function SuggestGrapesModal({ wine, onClose }) {
   const { t } = useTranslation();
@@ -9,6 +10,8 @@ export function SuggestGrapesModal({ wine, onClose }) {
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState(null);
+  const titleId = useId();
+  const boxRef = useDialogA11y(onClose);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -38,10 +41,10 @@ export function SuggestGrapesModal({ wine, onClose }) {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-box" onClick={e => e.stopPropagation()}>
+      <div className="modal-box" onClick={e => e.stopPropagation()} ref={boxRef} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1}>
         {submitted ? (
           <>
-            <h2>{t('bottleDetail.suggestGrapesThankYou', 'Thanks for contributing!')}</h2>
+            <h2 id={titleId}>{t('bottleDetail.suggestGrapesThankYou', 'Thanks for contributing!')}</h2>
             <p className="modal-wine-name">{wine?.name}</p>
             <p style={{ fontSize: '0.9rem', color: 'var(--color-text-muted)', marginBottom: '1.25rem' }}>
               {t('bottleDetail.suggestGrapesConfirm', 'Your suggestion has been submitted for review. Our team will add the verified varieties to the wine registry.')}
@@ -52,7 +55,7 @@ export function SuggestGrapesModal({ wine, onClose }) {
           </>
         ) : (
           <>
-            <h2>{t('bottleDetail.suggestGrapesTitle', 'Suggest Grape Varieties')}</h2>
+            <h2 id={titleId}>{t('bottleDetail.suggestGrapesTitle', 'Suggest Grape Varieties')}</h2>
             <p className="modal-wine-name">{wine?.name}</p>
             <form onSubmit={handleSubmit}>
               <div className="form-group">

--- a/frontend/src/components/WineSearchPicker.css
+++ b/frontend/src/components/WineSearchPicker.css
@@ -50,8 +50,9 @@
   transition: background 0.1s;
 }
 
-.wine-search-picker__option:hover {
-  background: var(--color-surface, #f5f5f5);
+.wine-search-picker__option:hover,
+.wine-search-picker__option.is-active {
+  background: var(--color-surface-hover, #eee);
 }
 
 .wine-search-picker__option-dot {

--- a/frontend/src/components/WineSearchPicker.js
+++ b/frontend/src/components/WineSearchPicker.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useId, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { searchWines } from '../api/wines';
@@ -19,8 +19,10 @@ export default function WineSearchPicker({ selected, onSelect, placeholder }) {
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
   const [noResults, setNoResults] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const wrapperRef = useRef(null);
   const debounceRef = useRef(null);
+  const listboxId = useId();
 
   // Debounced search
   useEffect(() => {
@@ -39,6 +41,7 @@ export default function WineSearchPicker({ selected, onSelect, placeholder }) {
         const wines = data.wines || [];
         setResults(wines);
         setNoResults(wines.length === 0);
+        setActiveIndex(-1);
         setOpen(true);
       } catch {
         setResults([]);
@@ -75,6 +78,29 @@ export default function WineSearchPicker({ selected, onSelect, placeholder }) {
     setQuery('');
   };
 
+  // Keyboard operability for the results list (ARIA combobox pattern): arrow
+  // keys move a virtual highlight via aria-activedescendant, Enter selects,
+  // Escape closes. The input keeps DOM focus throughout.
+  const handleKeyDown = (e) => {
+    if (e.key === 'ArrowDown') {
+      if (results.length === 0) return;
+      e.preventDefault();
+      setOpen(true);
+      setActiveIndex((i) => (i + 1) % results.length);
+    } else if (e.key === 'ArrowUp') {
+      if (results.length === 0) return;
+      e.preventDefault();
+      setActiveIndex((i) => (i <= 0 ? results.length - 1 : i - 1));
+    } else if (e.key === 'Enter') {
+      if (open && activeIndex >= 0 && results[activeIndex]) {
+        e.preventDefault();
+        handleSelect(results[activeIndex]);
+      }
+    } else if (e.key === 'Escape') {
+      if (open) { e.preventDefault(); setOpen(false); }
+    }
+  };
+
   if (selected) {
     return (
       <div className="wine-search-picker__selected">
@@ -96,13 +122,27 @@ export default function WineSearchPicker({ selected, onSelect, placeholder }) {
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         onFocus={() => results.length > 0 && setOpen(true)}
+        onKeyDown={handleKeyDown}
         placeholder={placeholder || t('wineSearchPicker.placeholder')}
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={open && activeIndex >= 0 ? `${listboxId}-opt-${activeIndex}` : undefined}
       />
       {loading && <span className="wine-search-picker__spinner" />}
       {open && (results.length > 0 || noResults) && (
-        <ul className="wine-search-picker__dropdown">
-          {results.map((wine) => (
-            <li key={wine._id} className="wine-search-picker__option" onClick={() => handleSelect(wine)}>
+        <ul className="wine-search-picker__dropdown" id={listboxId} role="listbox">
+          {results.map((wine, idx) => (
+            <li
+              key={wine._id}
+              id={`${listboxId}-opt-${idx}`}
+              role="option"
+              aria-selected={idx === activeIndex}
+              className={`wine-search-picker__option${idx === activeIndex ? ' is-active' : ''}`}
+              onClick={() => handleSelect(wine)}
+              onMouseEnter={() => setActiveIndex(idx)}
+            >
               <span className={`wine-search-picker__option-dot ${wine.type || ''}`} />
               <div className="wine-search-picker__option-text">
                 <span className="wine-search-picker__option-name">{wine.name}</span>
@@ -118,7 +158,7 @@ export default function WineSearchPicker({ selected, onSelect, placeholder }) {
             </li>
           ))}
           {noResults && (
-            <li className="wine-search-picker__no-results">{t('wineSearchPicker.noResults')}</li>
+            <li className="wine-search-picker__no-results" role="presentation">{t('wineSearchPicker.noResults')}</li>
           )}
         </ul>
       )}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2711,6 +2711,7 @@
     "tabShare": "Share",
     "previewEmpty": "Select wines to see the preview.",
     "statsEmpty": "Save your wine list first to see dashboard stats.",
+    "tableScrollAria": "Stats table (scroll sideways to see all columns)",
     "noWinesMatch": "No wines match your search.",
     "noActiveBottles": "No active bottles in this cellar.",
     "noWinesInSection": "No wines in this section yet. Select wines below.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2711,6 +2711,7 @@
     "tabShare": "Dela",
     "previewEmpty": "Välj viner för att se förhandsgranskningen.",
     "statsEmpty": "Spara din vinlista först för att se statistik.",
+    "tableScrollAria": "Statistiktabell (skrolla i sidled för att se alla kolumner)",
     "noWinesMatch": "Inga viner matchar din sökning.",
     "noActiveBottles": "Inga aktiva flaskor i den här källaren.",
     "noWinesInSection": "Inga viner i den här sektionen ännu. Välj viner nedan.",

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -328,12 +328,19 @@ function CellarRacks() {
 
   // --- remove bottle from slot (keep bottle in cellar) ---
   const handleRemoveFromRack = async (rackId, position) => {
-    const res = await clearSlot(apiFetch, rackId, position);
-    const data = await res.json();
-    if (res.ok) {
-      setRacks(racks.map(r => r._id === rackId ? data.rack : r));
+    try {
+      const res = await clearSlot(apiFetch, rackId, position);
+      const data = await res.json();
+      if (res.ok) {
+        setRacks(racks.map(r => r._id === rackId ? data.rack : r));
+      } else {
+        alert(data.error || 'Failed to remove from rack');
+      }
+    } catch {
+      alert('Network error — please try again.');
+    } finally {
+      setActivePopup(null);
     }
-    setActivePopup(null);
   };
 
   // --- disable / re-enable a slot position ---

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation, Trans } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -9,6 +9,10 @@ const LOGO_WEBP = '/cellarion-logo-light.webp';
 const LOGO_PNG  = '/cellarion-logo-light.png';
 
 function Login() {
+  const usernameId = useId();
+  const emailId = useId();
+  const passwordId = useId();
+  const forgotEmailId = useId();
   const [mode, setMode] = useState('login');
   const [formData, setFormData] = useState({ username: '', email: '', password: '' });
   const [error, setError] = useState(null);
@@ -154,8 +158,9 @@ function Login() {
                 {t('auth.forgotIntro')}
               </p>
               <div className="form-group">
-                <label>{t('auth.emailLabel')}</label>
+                <label htmlFor={forgotEmailId}>{t('auth.emailLabel')}</label>
                 <input
+                  id={forgotEmailId}
                   type="email"
                   value={forgotEmail}
                   onChange={(e) => setForgotEmail(e.target.value)}
@@ -274,8 +279,9 @@ function Login() {
 
         <form onSubmit={handleSubmit}>
           <div className="form-group">
-            <label>{mode === 'login' ? t('auth.usernameOrEmail') : t('auth.usernameLabel')}</label>
+            <label htmlFor={usernameId}>{mode === 'login' ? t('auth.usernameOrEmail') : t('auth.usernameLabel')}</label>
             <input
+              id={usernameId}
               type="text"
               value={formData.username}
               onChange={(e) => setFormData({ ...formData, username: e.target.value })}
@@ -285,8 +291,9 @@ function Login() {
           </div>
           {mode === 'register' && (
             <div className="form-group">
-              <label>{t('auth.emailLabel')}</label>
+              <label htmlFor={emailId}>{t('auth.emailLabel')}</label>
               <input
+                id={emailId}
                 type="email"
                 value={formData.email}
                 onChange={(e) => setFormData({ ...formData, email: e.target.value })}
@@ -295,8 +302,9 @@ function Login() {
             </div>
           )}
           <div className="form-group">
-            <label>{t('auth.passwordLabel')}</label>
+            <label htmlFor={passwordId}>{t('auth.passwordLabel')}</label>
             <input
+              id={passwordId}
               type="password"
               value={formData.password}
               onChange={(e) => setFormData({ ...formData, password: e.target.value })}

--- a/frontend/src/pages/WineListEditor.css
+++ b/frontend/src/pages/WineListEditor.css
@@ -446,6 +446,14 @@
 }
 
 /* Stats table */
+/* Scroll wrapper so the 7 columns stay reachable on narrow viewports — the
+   page body sets overflow-x:hidden, so without this the rightmost columns
+   (Glass, Margin) would be clipped with no way to scroll to them. */
+.wle-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .wle-stats-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/pages/WineListEditor.js
+++ b/frontend/src/pages/WineListEditor.js
@@ -1048,6 +1048,7 @@ function WineListEditor() {
                 </div>
               </div>
 
+              <div className="wle-table-wrap" role="group" tabIndex={0} aria-label={t('wineLists.tableScrollAria', 'Stats table (scroll sideways to see all columns)')}>
               <table className="wle-stats-table">
                 <thead>
                   <tr>
@@ -1081,6 +1082,7 @@ function WineListEditor() {
                   ))}
                 </tbody>
               </table>
+              </div>
             </>
           )}
           {!statsLoading && !stats && (

--- a/frontend/src/pages/Wishlist.js
+++ b/frontend/src/pages/Wishlist.js
@@ -104,7 +104,7 @@ function Wishlist() {
     const newStatus = item.status === 'wanted' ? 'bought' : 'wanted';
     try {
       const res = await updateWishlistItem(apiFetch, item._id, { status: newStatus });
-      if (!res.ok) return;
+      if (!res.ok) { setError(t('wishlist.failedUpdateStatus')); return; }
       // Remove from current list if filter doesn't match
       if (statusFilter !== 'all' && newStatus !== statusFilter) {
         setItems(prev => prev.filter(i => i._id !== item._id));
@@ -127,7 +127,7 @@ function Wishlist() {
   const handleDelete = async (id) => {
     try {
       const res = await removeWishlistItem(apiFetch, id);
-      if (!res.ok) return;
+      if (!res.ok) { setError(t('wishlist.failedRemove')); return; }
       setItems(prev => prev.filter(i => i._id !== id));
       setTotal(prev => prev - 1);
       setDeleteConfirm(null);

--- a/frontend/src/utils/useDialogA11y.js
+++ b/frontend/src/utils/useDialogA11y.js
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * A11y wiring for hand-rolled modal dialogs that build their own
+ * `.modal-overlay` + box instead of using the shared <Modal> component.
+ *
+ * Attach the returned ref to the dialog box element and spread the usual
+ * dialog attributes (role="dialog" aria-modal="true" aria-labelledby tabIndex={-1}).
+ * This hook then:
+ *   - moves focus into the dialog on open (first focusable, else the box), and
+ *   - closes the dialog on Escape (mirrors the shared Modal / Drawer).
+ *
+ * Purely additive — it does not change layout or markup.
+ */
+export function useDialogA11y(onClose) {
+  const boxRef = useRef(null);
+  // Keep the latest onClose in a ref so callers can pass an inline/recreated
+  // handler without re-running the mount effect (which would re-steal focus and
+  // re-bind the listener on every render).
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    const box = boxRef.current;
+    if (box) {
+      const focusable = box.querySelector(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      (focusable || box).focus();
+    }
+    const onKey = (e) => {
+      if (e.key === 'Escape' && onCloseRef.current) onCloseRef.current(e);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, []);
+
+  return boxRef;
+}


### PR DESCRIPTION
## Audit Batch 4 — Design a11y & UX

Fourth batch from the GRAND_AUDIT_2026-07-11 design/UX track. **Frontend-only** — no backend, compose, or env changes.

### Dialog accessibility
- **Shared `Modal`** (MED-8): now closes on **Escape** — previously only overlay-click or the (often-omitted) close button. Mirrors the existing `Drawer` pattern.
- **Hand-rolled modals** (MED-9) — `ConsumeModal`, `SuggestGrapesModal`, `ShareCellarModal`, `JournalPrompt`: added `role="dialog"`, `aria-modal`, `aria-labelledby`, focus-into-dialog-on-open, and Escape-to-close via a new shared `useDialogA11y` hook. Purely additive — no markup/layout change (kept their custom boxes).

### Keyboard operability
- **`WineSearchPicker`** (MED-10): results were click-only `<li>`. Now a proper ARIA **combobox + listbox** — arrow keys move a highlight (`aria-activedescendant`, input keeps focus), **Enter** selects, **Escape** closes, mouse hover syncs the highlight.

### Responsive / forms / feedback
- **`WineListEditor`** 7-column stats table (MED-6): wrapped in an `overflow-x:auto` scroll container (`role=group`, `tabIndex`, aria-label). `body { overflow-x:hidden }` previously clipped Glass/Margin on phones with no way to scroll.
- **Login/registration form labels** (MED-7): username, email, password and forgot-password email now associate `<label htmlFor>` ↔ `<input id>` (the app's front door; other forms remain for a later systemic pass).
- **Error feedback**:
  - **CellarRacks "Remove from rack"** (MED-11): surfaced server/network failures + close popup in `finally` (was silent — could leave the bottle in the slot or hang the popup open).
  - **Wishlist** bought-toggle & delete (LOW-11): show an error on a non-ok response instead of silently no-op'ing.
- **ConsumeModal** `handleSubmit` (LOW-11 correctness): wrapped in `try/finally` so the submit button can't wedge on "Saving…" if `onConfirm` rejects.

### New shared code
- `frontend/src/utils/useDialogA11y.js` — Escape + focus-on-open wiring for hand-rolled dialogs (ref-based so an inline `onClose` doesn't re-run the effect).

### i18n
- Added `wineLists.tableScrollAria` (en + sv) for the new scroll wrapper's aria-label.

### Verification
- `npx vite build` clean; `npm test` → **642 passed** (added 2 Modal tests: Escape + dialog semantics).

### Docker impact
Frontend-only — rebuild the frontend image. No compose/backend/env changes.
