### PR TITLE
fix(i18n): localize Settings, review/support/report modals (audit batch 5)

### DIFF
--- a/frontend/src/components/DeleteCellarModal.js
+++ b/frontend/src/components/DeleteCellarModal.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { deleteCellar } from '../api/cellars';
 import Modal from './Modal';
@@ -34,7 +34,7 @@ export function DeleteCellarModal({ cellar, onDeleted, onClose }) {
   return (
     <Modal title={t('cellarDetail.deleteCellarTitle')} onClose={onClose}>
       <p className="delete-warning">
-        This will delete <strong>{cellar.name}</strong> and all its racks.<br />
+        <Trans i18nKey="cellarDetail.deleteWillDelete" components={{ strong: <strong /> }} values={{ name: cellar.name }} /><br />
         {t('cellarDetail.bottlesPreserved')}
       </p>
       <p className="delete-recovery">
@@ -42,7 +42,7 @@ export function DeleteCellarModal({ cellar, onDeleted, onClose }) {
       </p>
       {error && <div className="alert alert-error">{error}</div>}
       <div className="form-group">
-        <label>Type <strong>{cellar.name}</strong> to confirm</label>
+        <label><Trans i18nKey="cellarDetail.typeToConfirm" components={{ strong: <strong /> }} values={{ name: cellar.name }} /></label>
         <input
           type="text"
           value={typed}

--- a/frontend/src/components/ReportWineModal.js
+++ b/frontend/src/components/ReportWineModal.js
@@ -1,19 +1,14 @@
 import { useState } from 'react';
+import { useTranslation, Trans } from 'react-i18next';
 import Modal from './Modal';
 import { submitWineReport } from '../api/support';
 import { useAuth } from '../contexts/AuthContext';
 import './ReportWineModal.css';
 
-const REASONS = [
-  { value: 'wrong_info', label: 'Wrong information (name, producer, region, etc.)' },
-  { value: 'duplicate', label: 'Duplicate wine entry' },
-  { value: 'wrong_price', label: 'Wrong or inaccurate market price' },
-  { value: 'wrong_tasting_profile', label: 'Incorrect tasting profile (structure, flavours, pairings)' },
-  { value: 'inappropriate', label: 'Inappropriate content' },
-  { value: 'other', label: 'Other' },
-];
+const REASON_VALUES = ['wrong_info', 'duplicate', 'wrong_price', 'wrong_tasting_profile', 'inappropriate', 'other'];
 
 function ReportWineModal({ wine, defaultReason, onClose }) {
+  const { t } = useTranslation();
   const { apiFetch } = useAuth();
   const [form, setForm] = useState({ reason: defaultReason || 'wrong_info', details: '' });
   const [submitting, setSubmitting] = useState(false);
@@ -37,10 +32,10 @@ function ReportWineModal({ wine, defaultReason, onClose }) {
         details: form.details || undefined,
       });
       const data = await res.json();
-      if (!res.ok) return setError(data.error || 'Failed to submit report');
+      if (!res.ok) return setError(data.error || t('reportWine.submitFailed'));
       setSuccess(true);
     } catch {
-      setError('Network error. Please try again.');
+      setError(t('common.networkError'));
     } finally {
       setSubmitting(false);
     }
@@ -48,39 +43,43 @@ function ReportWineModal({ wine, defaultReason, onClose }) {
 
   if (success) {
     return (
-      <Modal title="Report Submitted" onClose={onClose}>
+      <Modal title={t('reportWine.sentTitle')} onClose={onClose}>
         <div className="report-wine-success">
-          <p>Thank you for your report. Our team will review it shortly.</p>
+          <p>{t('reportWine.sentBody')}</p>
         </div>
         <div className="modal-actions">
-          <button className="btn-primary" onClick={onClose}>Close</button>
+          <button className="btn-primary" onClick={onClose}>{t('common.close')}</button>
         </div>
       </Modal>
     );
   }
 
   return (
-    <Modal title="Report Wine" onClose={onClose}>
+    <Modal title={t('reportWine.title')} onClose={onClose}>
       <p className="report-wine-subtitle">
-        Reporting: <strong>{wine.name}{wine.producer ? ` — ${wine.producer}` : ''}</strong>
+        <Trans
+          i18nKey="reportWine.reporting"
+          components={{ strong: <strong /> }}
+          values={{ wine: `${wine.name}${wine.producer ? ` — ${wine.producer}` : ''}` }}
+        />
       </p>
       <form onSubmit={handleSubmit} className="report-wine-form">
         <label>
-          Reason
+          {t('reportWine.reason')}
           <select name="reason" value={form.reason} onChange={handleChange}>
-            {REASONS.map(r => (
-              <option key={r.value} value={r.value}>{r.label}</option>
+            {REASON_VALUES.map(v => (
+              <option key={v} value={v}>{t(`reportWine.reasons.${v}`)}</option>
             ))}
           </select>
         </label>
 
         <label>
-          Details <span className="optional">(optional)</span>
+          {t('reportWine.details')} <span className="optional">{t('reportWine.optional')}</span>
           <textarea
             name="details"
             value={form.details}
             onChange={handleChange}
-            placeholder="Provide any additional information that will help us investigate…"
+            placeholder={t('reportWine.detailsPlaceholder')}
             rows={4}
             maxLength={2000}
           />
@@ -91,10 +90,10 @@ function ReportWineModal({ wine, defaultReason, onClose }) {
 
         <div className="modal-actions">
           <button type="button" className="btn-secondary" onClick={onClose} disabled={submitting}>
-            Cancel
+            {t('common.cancel')}
           </button>
           <button type="submit" className="btn-danger" disabled={submitting}>
-            {submitting ? 'Submitting…' : 'Submit Report'}
+            {submitting ? t('reportWine.submitting') : t('reportWine.submit')}
           </button>
         </div>
       </form>

--- a/frontend/src/components/ReviewForm.js
+++ b/frontend/src/components/ReviewForm.js
@@ -59,17 +59,17 @@ export default function ReviewForm({ wineDefinition, wineName, existingReview, d
         setError(result.error || 'Failed to save review');
       }
     } catch {
-      setError('Failed to save review');
+      setError(t('reviews.saveFailed', 'Failed to save review'));
     } finally {
       setSaving(false);
     }
   };
 
   return (
-    <Modal title={isEdit ? 'Edit Review' : `Review: ${wineName || 'Wine'}`} onClose={onClose}>
+    <Modal title={isEdit ? t('reviews.editTitle', 'Edit Review') : t('reviews.reviewTitle', { wine: wineName || t('common.wine', 'Wine') })} onClose={onClose}>
       <form onSubmit={handleSubmit} className="review-form">
         <div className="form-group">
-          <label>Rating *</label>
+          <label>{t('reviews.ratingLabel', 'Rating *')}</label>
           <RatingInput
             value={rating}
             scale={ratingScale}
@@ -80,14 +80,14 @@ export default function ReviewForm({ wineDefinition, wineName, existingReview, d
         </div>
 
         <div className="form-group">
-          <label htmlFor="review-vintage">Vintage</label>
+          <label htmlFor="review-vintage">{t('reviews.vintage', 'Vintage')}</label>
           <input
             id="review-vintage"
             type="text"
             className="input"
             value={vintage}
             onChange={e => setVintage(e.target.value)}
-            placeholder="e.g. 2019"
+            placeholder={t('reviews.vintagePlaceholder', 'e.g. 2019')}
             maxLength={10}
           />
         </div>
@@ -124,47 +124,47 @@ export default function ReviewForm({ wineDefinition, wineName, existingReview, d
             className="input"
             value={overall}
             onChange={e => setOverall(e.target.value)}
-            placeholder="What did you think of this wine?"
+            placeholder={t('reviews.overallPlaceholder', 'What did you think of this wine?')}
             rows={3}
             maxLength={2000}
           />
         </div>
 
         <details className="review-form__details">
-          <summary>Detailed Tasting Notes</summary>
+          <summary>{t('reviews.tastingNotes', 'Detailed Tasting Notes')}</summary>
           <div className="review-form__tasting-fields">
             <div className="form-group">
-              <label htmlFor="review-aroma">Aroma / Nose</label>
+              <label htmlFor="review-aroma">{t('reviews.aroma', 'Aroma / Nose')}</label>
               <textarea
                 id="review-aroma"
                 className="input"
                 value={aroma}
                 onChange={e => setAroma(e.target.value)}
-                placeholder="What do you smell?"
+                placeholder={t('reviews.aromaPlaceholder', 'What do you smell?')}
                 rows={2}
                 maxLength={1000}
               />
             </div>
             <div className="form-group">
-              <label htmlFor="review-palate">Palate</label>
+              <label htmlFor="review-palate">{t('reviews.palate', 'Palate')}</label>
               <textarea
                 id="review-palate"
                 className="input"
                 value={palate}
                 onChange={e => setPalate(e.target.value)}
-                placeholder="What do you taste?"
+                placeholder={t('reviews.palatePlaceholder', 'What do you taste?')}
                 rows={2}
                 maxLength={1000}
               />
             </div>
             <div className="form-group">
-              <label htmlFor="review-finish">Finish</label>
+              <label htmlFor="review-finish">{t('reviews.finish', 'Finish')}</label>
               <textarea
                 id="review-finish"
                 className="input"
                 value={finish}
                 onChange={e => setFinish(e.target.value)}
-                placeholder="How does it linger?"
+                placeholder={t('reviews.finishPlaceholder', 'How does it linger?')}
                 rows={2}
                 maxLength={1000}
               />
@@ -176,10 +176,10 @@ export default function ReviewForm({ wineDefinition, wineName, existingReview, d
 
         <div className="modal-actions">
           <button type="button" className="btn btn-secondary" onClick={onClose} disabled={saving}>
-            Cancel
+            {t('common.cancel')}
           </button>
           <button type="submit" className="btn btn-primary" disabled={saving || rating == null}>
-            {saving ? 'Saving...' : (isEdit ? 'Update Review' : 'Submit Review')}
+            {saving ? t('common.saving') : (isEdit ? t('reviews.update', 'Update Review') : t('reviews.submit', 'Submit Review'))}
           </button>
         </div>
       </form>

--- a/frontend/src/components/SimilarWinesModal.js
+++ b/frontend/src/components/SimilarWinesModal.js
@@ -1,3 +1,4 @@
+import { useTranslation, Trans } from 'react-i18next';
 import Modal from './Modal';
 import WineImage from './WineImage';
 import './WineModalThumbs.css';
@@ -17,12 +18,15 @@ import './WineModalThumbs.css';
  *   busy         — disables buttons while a follow-up request is in flight
  */
 function SimilarWinesModal({ candidates, queryName, onPick, onCreateNew, onCancel, busy }) {
+  const { t } = useTranslation();
   return (
-    <Modal title="Did you mean one of these?" onClose={onCancel} showClose wide>
+    <Modal title={t('similarWines.title')} onClose={onCancel} showClose wide>
       <p style={{ margin: '0 0 1rem', fontSize: '0.95rem', color: 'var(--color-text-secondary, #666)' }}>
-        We found wines in the registry that look close to{' '}
-        <strong>{queryName || 'what you entered'}</strong>. Picking an existing
-        wine keeps the registry tidy and lets you share data with other users.
+        <Trans
+          i18nKey="similarWines.intro"
+          components={{ strong: <strong /> }}
+          values={{ query: queryName || t('similarWines.whatYouEntered') }}
+        />
       </p>
 
       <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 1.25rem', maxHeight: 380, overflowY: 'auto' }}>
@@ -59,10 +63,10 @@ function SimilarWinesModal({ candidates, queryName, onPick, onCreateNew, onCance
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
               <span
-                title="Similarity score"
+                title={t('similarWines.similarityTitle')}
                 style={{ fontSize: '0.75rem', color: 'var(--color-text-secondary, #888)' }}
               >
-                {Math.round(score * 100)}% match
+                {t('similarWines.matchLabel', { percent: Math.round(score * 100) })}
               </span>
               <button
                 type="button"
@@ -71,7 +75,7 @@ function SimilarWinesModal({ candidates, queryName, onPick, onCreateNew, onCance
                 onClick={() => onPick(wine)}
                 style={{ padding: '0.35rem 0.8rem', fontSize: '0.85rem' }}
               >
-                Use this
+                {t('similarWines.useThis')}
               </button>
             </div>
           </li>
@@ -80,10 +84,10 @@ function SimilarWinesModal({ candidates, queryName, onPick, onCreateNew, onCance
 
       <div className="modal-actions" style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
         <button type="button" className="btn" disabled={busy} onClick={onCancel}>
-          Cancel
+          {t('common.cancel')}
         </button>
         <button type="button" className="btn btn-secondary" disabled={busy} onClick={onCreateNew}>
-          No, create new wine
+          {t('similarWines.createNew')}
         </button>
       </div>
     </Modal>

--- a/frontend/src/components/SupportModal.js
+++ b/frontend/src/components/SupportModal.js
@@ -1,17 +1,14 @@
 import { useState } from 'react';
+import { useTranslation, Trans } from 'react-i18next';
 import Modal from './Modal';
 import { submitSupportTicket } from '../api/support';
 import { useAuth } from '../contexts/AuthContext';
 import './SupportModal.css';
 
-const CATEGORIES = [
-  { value: 'bug', label: 'Bug Report' },
-  { value: 'help', label: 'Help / Question' },
-  { value: 'feature', label: 'Feature Request' },
-  { value: 'other', label: 'Other' },
-];
+const CATEGORY_VALUES = ['bug', 'help', 'feature', 'other'];
 
 function SupportModal({ onClose }) {
+  const { t } = useTranslation();
   const { apiFetch } = useAuth();
   const [form, setForm] = useState({ category: 'bug', subject: '', message: '' });
   const [submitting, setSubmitting] = useState(false);
@@ -25,18 +22,18 @@ function SupportModal({ onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!form.subject.trim()) return setError('Subject is required');
-    if (!form.message.trim()) return setError('Message is required');
+    if (!form.subject.trim()) return setError(t('support.subjectRequired'));
+    if (!form.message.trim()) return setError(t('support.messageRequired'));
 
     setSubmitting(true);
     setError(null);
     try {
       const res = await submitSupportTicket(apiFetch, form);
       const data = await res.json();
-      if (!res.ok) return setError(data.error || 'Failed to submit ticket');
+      if (!res.ok) return setError(data.error || t('support.submitFailed'));
       setSuccess(true);
     } catch {
-      setError('Network error. Please try again.');
+      setError(t('common.networkError'));
     } finally {
       setSubmitting(false);
     }
@@ -44,49 +41,51 @@ function SupportModal({ onClose }) {
 
   if (success) {
     return (
-      <Modal title="Support Request Sent" onClose={onClose}>
+      <Modal title={t('support.sentTitle')} onClose={onClose}>
         <div className="support-modal-success">
-          <p>Your ticket has been submitted. An admin will respond shortly.</p>
-          <p>You can track your tickets under <strong>Support</strong> in the menu.</p>
+          <p>{t('support.sentBody')}</p>
+          <p>
+            <Trans i18nKey="support.sentTrack" components={{ strong: <strong /> }} />
+          </p>
         </div>
         <div className="modal-actions">
-          <button className="btn-primary" onClick={onClose}>Close</button>
+          <button className="btn-primary" onClick={onClose}>{t('common.close')}</button>
         </div>
       </Modal>
     );
   }
 
   return (
-    <Modal title="Contact Support" onClose={onClose}>
+    <Modal title={t('support.contactTitle', 'Contact Support')} onClose={onClose}>
       <form onSubmit={handleSubmit} className="support-modal-form">
         <label>
-          Category
+          {t('support.categoryLabel', 'Category')}
           <select name="category" value={form.category} onChange={handleChange}>
-            {CATEGORIES.map(c => (
-              <option key={c.value} value={c.value}>{c.label}</option>
+            {CATEGORY_VALUES.map(v => (
+              <option key={v} value={v}>{t(`support.category.${v}`)}</option>
             ))}
           </select>
         </label>
 
         <label>
-          Subject
+          {t('support.subject')}
           <input
             type="text"
             name="subject"
             value={form.subject}
             onChange={handleChange}
-            placeholder="Brief summary of your issue"
+            placeholder={t('support.subjectPlaceholder')}
             maxLength={200}
           />
         </label>
 
         <label>
-          Message
+          {t('support.message')}
           <textarea
             name="message"
             value={form.message}
             onChange={handleChange}
-            placeholder="Describe your issue or question in detail..."
+            placeholder={t('support.messagePlaceholder')}
             rows={6}
             maxLength={5000}
           />
@@ -97,10 +96,10 @@ function SupportModal({ onClose }) {
 
         <div className="modal-actions">
           <button type="button" className="btn-secondary" onClick={onClose} disabled={submitting}>
-            Cancel
+            {t('common.cancel')}
           </button>
           <button type="submit" className="btn-primary" disabled={submitting}>
-            {submitting ? 'Sending…' : 'Send Ticket'}
+            {submitting ? t('support.sending') : t('support.sendTicket')}
           </button>
         </div>
       </form>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -45,7 +45,6 @@
     "optional": "optional",
     "or": "or"
   },
-
   "nav": {
     "myCellars": "My Cellars",
     "wineRegistry": "Wine Registry",
@@ -95,7 +94,6 @@
     "switchToDark": "Switch to dark mode",
     "switchToLight": "Switch to light mode"
   },
-
   "auth": {
     "login": "Login",
     "register": "Register",
@@ -145,7 +143,6 @@
     "newLinkSent": "New verification link sent. Check your inbox.",
     "sendFailed": "Failed to send. Please try again."
   },
-
   "settings": {
     "title": "Settings",
     "signedInAs": "Signed in as",
@@ -279,7 +276,56 @@
       "errorRateLimited": "Too many attempts. Please wait a few minutes and try again."
     },
     "defaultRatingScale": "Default Rating Scale",
-    "ratingScaleHint": "Choose which rating scale to use by default when adding ratings. You can always override per bottle."
+    "ratingScaleHint": "Choose which rating scale to use by default when adding ratings. You can always override per bottle.",
+    "profile": {
+      "title": "Profile",
+      "displayName": "Display Name",
+      "displayNameHint": "How your name appears to other users. Leave blank to use your username.",
+      "bio": "Bio",
+      "bioHint": "A short description visible on your public profile.",
+      "bioPlaceholder": "Tell others about your wine journey...",
+      "visibility": "Profile Visibility",
+      "visibilityHint": "Public profiles appear in search results and the Discover feed. Private profiles are hidden from other users.",
+      "public": "Public",
+      "private": "Private"
+    },
+    "push": {
+      "deviceRegistered": "This device is registered",
+      "deviceNotRegistered": "This device is not registered",
+      "removing": "Removing...",
+      "removeDevice": "Remove this device",
+      "registering": "Registering...",
+      "registerDevice": "Register this device",
+      "devicesRegistered_one": "{{count}} device registered for push notifications.",
+      "devicesRegistered_other": "{{count}} devices registered for push notifications.",
+      "sending": "Sending...",
+      "sendTest": "Send test notification",
+      "testSent": "Test sent!"
+    },
+    "data": {
+      "title": "Your Data",
+      "intro": "Download a complete copy of all your personal data stored in Cellarion, including your profile, bottles, cellars, reviews, and activity log.",
+      "exporting": "Exporting...",
+      "exportBtn": "Export my data",
+      "privacyLink": "Read our <a>Privacy Policy</a> to learn how your data is processed and what rights you have."
+    },
+    "portability": {
+      "title": "Take your cellars with you",
+      "intro": "Export one cellar or all of them — bottles, rack placements, 3D room layout, reviews, maturity data and the images you uploaded yourself — in a format you can import into any Cellarion instance. Your data is yours; we never lock it in.",
+      "exportBtn": "Export your cellars →",
+      "importLink": "Moving in from another Cellarion instance? <a>Import a cellar export</a> to recreate your cellars, bottles and images here."
+    },
+    "danger": {
+      "title": "Danger zone",
+      "scheduledFor": "Account deletion is scheduled for <strong>{{date}}</strong>. All your data will be permanently removed after this date.",
+      "cancelling": "Cancelling...",
+      "cancelDeletion": "Cancel deletion",
+      "intro": "Permanently delete your account and all associated data — cellars, bottles, reviews, and settings. After requesting deletion, you have 7 days to change your mind before the deletion is permanent.",
+      "deleteBtn": "Delete my account",
+      "typeToConfirm": "Type <strong>DELETE</strong> to confirm:",
+      "scheduling": "Scheduling...",
+      "scheduleBtn": "Schedule account deletion"
+    }
   },
   "climate": {
     "title": "Climate",
@@ -383,11 +429,9 @@
     "laugh": "Funny",
     "pray": "Thanks"
   },
-
   "plans": {
     "expired": "Expired"
   },
-
   "supporter": {
     "title": "Cellarion is free, and open-source. Here's what keeps it running.",
     "subtitle": "Every feature is free for everyone, forever — no paywalls, nothing locked. But the servers and AI behind the app cost real money. If Cellarion has earned a place in your cellar, you're warmly invited to help split the tab.",
@@ -426,7 +470,6 @@
     "alreadySupporting": "💛 You're supporting Cellarion — thank you! You can change or cancel anytime.",
     "donateNote": "Payments are handled securely by Stripe. Cellarion stays free and open whether you support or not."
   },
-
   "cellars": {
     "title": "My Cellars",
     "newCellar": "New Cellar",
@@ -454,7 +497,6 @@
     "sharedCount_one": "{{count}} shared",
     "sharedCount_other": "{{count}} shared"
   },
-
   "cellarDetail": {
     "backToCellars": "← Back to Cellars",
     "loadingCellar": "Loading cellar...",
@@ -542,9 +584,9 @@
     "removeFilterAria": "Remove {{label}}",
     "groupBottleCount_one": "{{count}} bottle",
     "groupBottleCount_other": "{{count}} bottles",
-    "collapseGroup": "Collapse ▲"
+    "collapseGroup": "Collapse ▲",
+    "deleteWillDelete": "This will delete <strong>{{name}}</strong> and all its racks."
   },
-
   "addBottle": {
     "title": "Add Bottle",
     "backToCellar": "← Back to Cellar",
@@ -650,7 +692,6 @@
     "partialAdded_one": "{{msg}} — {{count}} of {{total}} bottles was added. Retrying will add only the remaining {{remaining}}.",
     "partialAdded_other": "{{msg}} — {{count}} of {{total}} bottles were added. Retrying will add only the remaining {{remaining}}."
   },
-
   "bottleDetail": {
     "backToCellar": "← Back to Cellar",
     "backToChat": "← Back to chat",
@@ -746,7 +787,6 @@
     "pairsWith": "Pairs with",
     "consumeError": "Failed to remove bottle"
   },
-
   "bottles": {
     "title": "All bottles",
     "loading": "Loading…",
@@ -781,7 +821,6 @@
     "status_sold": "Sold",
     "status_other": "Other"
   },
-
   "racks": {
     "title": "Storage Racks",
     "backToCellar": "← Back to Cellar",
@@ -856,10 +895,8 @@
     "viewCompact": "Compact",
     "viewShelf": "Shelf view",
     "view3d": "3D",
-    "toolsMenu": "Rack tools",
     "consumeNotePlaceholder": "How was it?"
   },
-
   "nfc": {
     "linkTitle": "Link NFC Tag",
     "linkDescription": "Write this rack's URL to an NFC sticker. When someone taps the sticker with their phone, it will open directly to this rack.",
@@ -877,7 +914,6 @@
     "networkError": "Network error. Please try again.",
     "goToCellars": "Go to Cellars"
   },
-
   "room": {
     "title": "Room View",
     "subtitle": "3D cellar layout",
@@ -923,7 +959,6 @@
     "loadRacksError": "Failed to load racks for this cellar",
     "loadLayoutError": "Failed to load the room layout"
   },
-
   "wines": {
     "title": "Wine Registry",
     "subtitle": "Browse all available wines in the registry",
@@ -949,7 +984,6 @@
     "appellationLabel": "Appellation:",
     "grapesLabel": "Grapes:"
   },
-
   "wineRequests": {
     "title": "My Wine Requests",
     "newRequest": "New Request",
@@ -970,7 +1004,6 @@
     "imageUrlPlaceholder": "Paste image URL…",
     "imageNotice": "Images are reviewed by an admin before being added to the shared wine registry, where they will be visible to all Cellarion users."
   },
-
   "history": {
     "title": "Bottle History",
     "backTo": "← Back to {{cellarName}}",
@@ -1002,7 +1035,6 @@
     "viewBottleAria": "View {{name}}",
     "noResults": "No bottles match your search."
   },
-
   "cellarScope": {
     "title": "Choose which cellars to show",
     "thisCellar": "This cellar",
@@ -1013,7 +1045,6 @@
     "thisCellarOnly": "This cellar only",
     "current": "Current"
   },
-
   "cellarAudit": {
     "backToCellar": "← Back to Cellar",
     "auditLogTitle": "Audit Log",
@@ -1036,7 +1067,6 @@
     "sharedAs": "{{user}} as {{role}}",
     "roleChanged": "Role changed: {{from}} → {{to}}"
   },
-
   "moveBottle": {
     "action": "Move to another cellar",
     "actionShort": "Move",
@@ -1054,7 +1084,6 @@
     "movedInfo": "This bottle was moved to {{cellar}}.",
     "backToCellar": "Back to cellar"
   },
-
   "admin": {
     "requests": {
       "title": "Admin: Wine Requests",
@@ -1280,7 +1309,6 @@
       "page": "Page {{current}} of {{total}}"
     }
   },
-
   "somm": {
     "maturity": {
       "title": "Maturity Queue",
@@ -1352,7 +1380,6 @@
       "requesterNoteLabel": "Requester note"
     }
   },
-
   "priceTracking": {
     "trigger": "Track market price",
     "triggerRequested": "Tracking requested",
@@ -1367,7 +1394,6 @@
     "cancel": "Cancel request",
     "saving": "Saving…"
   },
-
   "bottleSizeNames": {
     "split": "Split",
     "half": "Half",
@@ -1399,7 +1425,6 @@
     "noneYet": "None yet",
     "valueSeedStarted": "Value tracking has started. Your first data point will appear after the weekly snapshot runs.",
     "valueSeedFirst": "Your first snapshot is recorded. Trend data will appear after next week's snapshot.",
-
     "typeLabels": {
       "red": "Red",
       "white": "White",
@@ -1409,7 +1434,6 @@
       "fortified": "Fortified",
       "unknown": "Pending review"
     },
-
     "ratingBands": {
       "excellent": "Excellent",
       "veryGood": "Very Good",
@@ -1417,7 +1441,6 @@
       "fair": "Fair",
       "poor": "Poor"
     },
-
     "maturityPhases": {
       "declining": "Past Prime",
       "late": "Late Maturity",
@@ -1426,31 +1449,26 @@
       "notReady": "Not Ready Yet",
       "noProfile": "No Profile"
     },
-
     "days": {
       "overdue": "{{count}}d overdue",
       "today": "Today",
       "left": "{{count}}d left",
       "ago": "{{count}}d ago"
     },
-
     "donut": {
       "ariaLabel": "Donut chart: {{count}} total bottles",
       "bottles": "bottles"
     },
-
     "rating": {
       "average": "Average:",
       "acrossBottles_one": "across {{count}} rated bottle",
       "acrossBottles_other": "across {{count}} rated bottles"
     },
-
     "maturity": {
       "withProfiles": "{{count}} with sommelier profiles",
       "withoutData": "{{count}} without data",
       "profilesNeeded": "Sommelier maturity profiles needed to see your score"
     },
-
     "regret": {
       "pastPrime_one": "{{count}} bottle past their prime, still unopened.",
       "pastPrime_other": "{{count}} bottles past their prime, still unopened.",
@@ -1460,22 +1478,18 @@
       "mild": "A few bottles slipping by. Stay on top of your cellar.",
       "great": "Excellent! Your cellar is well managed."
     },
-
     "forecast": {
       "inWindow_one": "{{year}}: {{count}} bottle in window",
       "inWindow_other": "{{year}}: {{count}} bottles in window",
       "now": "now"
     },
-
     "urgency": {
       "noUrgent": "No bottles need urgent attention — your cellar is well timed!"
     },
-
     "holdingTime": {
       "empty": "Mark bottles as consumed to see your patience profile.",
       "note": "Higher ratings at longer holding times suggest aging is rewarding for your cellar."
     },
-
     "joyPerDollar": {
       "empty": "Rate your consumed bottles to see which type gives you the most joy per {{currency}}.",
       "count_one": "{{count}} bottle",
@@ -1483,7 +1497,6 @@
       "avg": "avg {{price}}",
       "note": "Score = enjoyment rating per {{currency}}1,000 spent. Higher = better value."
     },
-
     "regretSignal": {
       "empty": "Rate bottles before and after drinking to track expectation vs reality.",
       "avgDelta": "Avg delta:",
@@ -1492,7 +1505,6 @@
       "surprises": "Surprises",
       "disappointments": "Disappointments"
     },
-
     "pace": {
       "bottlesIn": "bottles in / year",
       "bottlesOut": "bottles out / year",
@@ -1503,7 +1515,6 @@
       "runway_other": "years of wine at current consumption",
       "consumeToSee": "Consume bottles to see your cellar trajectory."
     },
-
     "consumption": {
       "empty": "No consumption history yet — mark bottles as drank, gifted, or sold to see your history.",
       "drank": "Drank",
@@ -1513,18 +1524,15 @@
       "totalConsumed_one": "{{count}} total bottle consumed",
       "totalConsumed_other": "{{count}} total bottles consumed"
     },
-
     "topValue": {
       "empty": "Add prices to your bottles to see your most valuable wines."
     },
-
     "cellarBreakdown": {
       "bottle_one": "{{count}} bottle",
       "bottle_other": "{{count}} bottles",
       "uniqueWine_one": "{{count}} unique wine",
       "uniqueWine_other": "{{count}} unique wines"
     },
-
     "worldMap": {
       "bottle_one": "{{count}} bottle",
       "bottle_other": "{{count}} bottles",
@@ -1533,7 +1541,6 @@
       "unmapped_one": "{{count}} country without ISO code hidden",
       "unmapped_other": "{{count}} countries without ISO code hidden"
     },
-
     "premiumGate": {
       "desc": "Deep insights into your entire wine collection — types, origins, vintages, value, maturity profiles, consumption history, and more. The most comprehensive wine analytics dashboard available.",
       "feat1": "Wine type & origin breakdown",
@@ -1548,12 +1555,10 @@
       "notSure": "Not sure yet?",
       "startTrial": "Start a free 30-day trial"
     },
-
     "upgrade": {
       "unlockWith": "Unlock with {{plan}}",
       "upgradeTo": "Upgrade to {{plan}}"
     },
-
     "sections": {
       "wineTypes": "Wine Types",
       "maturityStatus": "Maturity Status",
@@ -1589,7 +1594,6 @@
       "mostValuableBottles": "Most Valuable Bottles",
       "valueOverTime": "Collection Value Over Time"
     },
-
     "kpi": {
       "activeBottles": "Active Bottles",
       "uniqueWines": "{{count}} unique wines",
@@ -1609,15 +1613,12 @@
       "sold": "Sold",
       "avgConsumedRating": "Avg Consumed Rating"
     },
-
-
     "footnote": {
       "activeOnly": "Active bottles only",
       "pricesConverted": "Prices converted using today's exchange rates to {{currency}}",
       "maturityData": "Maturity data from sommelier profiles",
       "ownedOnly": "Only your owned cellars are included"
     },
-
     "bottle_one": "{{count}} bottle",
     "bottle_other": "{{count}} bottles",
     "vintageBottle_one": "{{vintage}}: {{count}} bottle",
@@ -1625,7 +1626,6 @@
     "purchased_one": "{{year}}: {{count}} bottle purchased",
     "purchased_other": "{{year}}: {{count}} bottles purchased"
   },
-
   "blog": {
     "title": "Blog",
     "subtitle": "News, tips, and updates from the Cellarion team",
@@ -1706,7 +1706,23 @@
     "deleteTitle": "Delete review?",
     "deleteBody": "This will permanently delete your review. This cannot be undone.",
     "deleteError": "Failed to delete the review — please try again.",
-    "deleting": "Deleting…"
+    "deleting": "Deleting…",
+    "saveFailed": "Failed to save review",
+    "editTitle": "Edit Review",
+    "reviewTitle": "Review: {{wine}}",
+    "ratingLabel": "Rating *",
+    "vintage": "Vintage",
+    "vintagePlaceholder": "e.g. 2019",
+    "overallPlaceholder": "What did you think of this wine?",
+    "tastingNotes": "Detailed Tasting Notes",
+    "aroma": "Aroma / Nose",
+    "aromaPlaceholder": "What do you smell?",
+    "palate": "Palate",
+    "palatePlaceholder": "What do you taste?",
+    "finish": "Finish",
+    "finishPlaceholder": "How does it linger?",
+    "update": "Update Review",
+    "submit": "Submit Review"
   },
   "discussions": {
     "community": "Community",
@@ -2212,7 +2228,6 @@
       }
     }
   },
-
   "landing": {
     "heroHeadline": "Your wine cellar,",
     "heroAccent": "beautifully organised.",
@@ -2276,7 +2291,6 @@
       "a6": "Yes — your data is yours. Cellarion includes a one-click data export that gives you everything as JSON, plus CSV import and export for bottles. You can delete your account from Settings with a 7-day cooling-off window. Hosted data lives on European infrastructure under GDPR."
     }
   },
-
   "maturity": {
     "peak": "Peak",
     "early": "Early",
@@ -2285,11 +2299,9 @@
     "notReady": "Not Ready",
     "noData": "No Maturity Data"
   },
-
   "cellarNav": {
     "aria": "Cellar views"
   },
-
   "cellarBook": {
     "title": "Cellar Book",
     "linkBtn": "Cellar Book",
@@ -2312,7 +2324,6 @@
     "colWindow": "Drink window",
     "footer": "Generated by Cellarion"
   },
-
   "openBottle": {
     "openBtn": "Open bottle…",
     "pickerTitle": "Open this bottle",
@@ -2340,7 +2351,6 @@
     "partialOr": "or remove it completely:",
     "partialConfirmBtn": "Open & pour a glass"
   },
-
   "audit": {
     "title": "Audit rack — {{name}}",
     "openBtn": "Audit",
@@ -2363,7 +2373,6 @@
     "clearSlot": "Clear slot",
     "cleared": "Cleared"
   },
-
   "zones": {
     "title": "Rack zones",
     "editBtn": "Rack zones",
@@ -2375,7 +2384,6 @@
     "nameMissing": "Give every zone with slots a name (or remove it).",
     "saveError": "Failed to save zones — please try again."
   },
-
   "arrange": {
     "title": "Organize this rack",
     "openBtn": "Organize…",
@@ -2409,7 +2417,6 @@
     "undoUnavailable": "The rack has changed since — this organization can no longer be undone.",
     "undoError": "A move failed while undoing — the rack may have changed. Close and check the rack."
   },
-
   "rackLens": {
     "dragHint": "Tip: drag a bottle to an empty slot to move it, onto another bottle to swap them.",
     "searchPlaceholder": "Find in racks…",
@@ -2430,7 +2437,6 @@
     "ratingLow": "Low",
     "ratingNone": "Not rated"
   },
-
   "cellarCred": {
     "newcomer": "Newcomer",
     "contributor": "Contributor",
@@ -3424,6 +3430,50 @@
       "pending": "Pending",
       "resolved": "Resolved",
       "dismissed": "Dismissed"
-    }
+    },
+    "contactTitle": "Contact Support",
+    "categoryLabel": "Category",
+    "sentTitle": "Support Request Sent",
+    "sentBody": "Your ticket has been submitted. An admin will respond shortly.",
+    "sentTrack": "You can track your tickets under <strong>Support</strong> in the menu.",
+    "subject": "Subject",
+    "subjectPlaceholder": "Brief summary of your issue",
+    "message": "Message",
+    "messagePlaceholder": "Describe your issue or question in detail...",
+    "sending": "Sending…",
+    "sendTicket": "Send Ticket",
+    "subjectRequired": "Subject is required",
+    "messageRequired": "Message is required",
+    "submitFailed": "Failed to submit ticket"
+  },
+  "similarWines": {
+    "title": "Did you mean one of these?",
+    "intro": "We found wines in the registry that look close to <strong>{{query}}</strong>. Picking an existing wine keeps the registry tidy and lets you share data with other users.",
+    "whatYouEntered": "what you entered",
+    "similarityTitle": "Similarity score",
+    "matchLabel": "{{percent}}% match",
+    "useThis": "Use this",
+    "createNew": "No, create new wine"
+  },
+  "reportWine": {
+    "title": "Report Wine",
+    "sentTitle": "Report Submitted",
+    "sentBody": "Thank you for your report. Our team will review it shortly.",
+    "reporting": "Reporting: <strong>{{wine}}</strong>",
+    "reason": "Reason",
+    "reasons": {
+      "wrong_info": "Wrong information (name, producer, region, etc.)",
+      "duplicate": "Duplicate wine entry",
+      "wrong_price": "Wrong or inaccurate market price",
+      "wrong_tasting_profile": "Incorrect tasting profile (structure, flavours, pairings)",
+      "inappropriate": "Inappropriate content",
+      "other": "Other"
+    },
+    "details": "Details",
+    "optional": "(optional)",
+    "detailsPlaceholder": "Provide any additional information that will help us investigate…",
+    "submitting": "Submitting…",
+    "submit": "Submit Report",
+    "submitFailed": "Failed to submit report"
   }
 }

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -45,7 +45,6 @@
     "optional": "valfritt",
     "or": "eller"
   },
-
   "nav": {
     "myCellars": "Mina källare",
     "wineRegistry": "Vinregister",
@@ -95,7 +94,6 @@
     "switchToDark": "Byt till mörkt läge",
     "switchToLight": "Byt till ljust läge"
   },
-
   "auth": {
     "login": "Logga in",
     "register": "Registrera",
@@ -145,7 +143,6 @@
     "newLinkSent": "En ny verifieringslänk har skickats. Kolla din inkorg.",
     "sendFailed": "Kunde inte skicka. Försök igen."
   },
-
   "settings": {
     "title": "Inställningar",
     "signedInAs": "Inloggad som",
@@ -279,7 +276,56 @@
       "errorRateLimited": "För många försök. Vänta några minuter och försök igen."
     },
     "defaultRatingScale": "Standardbetygsskala",
-    "ratingScaleHint": "Välj vilken betygsskala som används som standard när du sätter betyg. Du kan alltid ändra per flaska."
+    "ratingScaleHint": "Välj vilken betygsskala som används som standard när du sätter betyg. Du kan alltid ändra per flaska.",
+    "profile": {
+      "title": "Profil",
+      "displayName": "Visningsnamn",
+      "displayNameHint": "Hur ditt namn visas för andra användare. Lämna tomt för att använda ditt användarnamn.",
+      "bio": "Biografi",
+      "bioHint": "En kort beskrivning som visas på din offentliga profil.",
+      "bioPlaceholder": "Berätta för andra om din vinresa...",
+      "visibility": "Profilens synlighet",
+      "visibilityHint": "Offentliga profiler visas i sökresultat och i Upptäck-flödet. Privata profiler är dolda för andra användare.",
+      "public": "Offentlig",
+      "private": "Privat"
+    },
+    "push": {
+      "deviceRegistered": "Den här enheten är registrerad",
+      "deviceNotRegistered": "Den här enheten är inte registrerad",
+      "removing": "Tar bort...",
+      "removeDevice": "Ta bort den här enheten",
+      "registering": "Registrerar...",
+      "registerDevice": "Registrera den här enheten",
+      "devicesRegistered_one": "{{count}} enhet registrerad för push-notiser.",
+      "devicesRegistered_other": "{{count}} enheter registrerade för push-notiser.",
+      "sending": "Skickar...",
+      "sendTest": "Skicka testnotis",
+      "testSent": "Test skickat!"
+    },
+    "data": {
+      "title": "Dina uppgifter",
+      "intro": "Ladda ner en fullständig kopia av alla dina personuppgifter som lagras i Cellarion, inklusive din profil, flaskor, vinkällare, recensioner och aktivitetslogg.",
+      "exporting": "Exporterar...",
+      "exportBtn": "Exportera mina uppgifter",
+      "privacyLink": "Läs vår <a>integritetspolicy</a> för att förstå hur dina uppgifter behandlas och vilka rättigheter du har."
+    },
+    "portability": {
+      "title": "Ta med dig dina vinkällare",
+      "intro": "Exportera en vinkällare eller alla — flaskor, hyllplaceringar, 3D-rumslayout, recensioner, mognadsdata och bilderna du själv laddat upp — i ett format du kan importera till valfri Cellarion-instans. Dina uppgifter är dina; vi låser aldrig in dem.",
+      "exportBtn": "Exportera dina vinkällare →",
+      "importLink": "Flyttar du in från en annan Cellarion-instans? <a>Importera en vinkällarexport</a> för att återskapa dina vinkällare, flaskor och bilder här."
+    },
+    "danger": {
+      "title": "Farozon",
+      "scheduledFor": "Kontoradering är schemalagd till <strong>{{date}}</strong>. Alla dina uppgifter tas bort permanent efter detta datum.",
+      "cancelling": "Avbryter...",
+      "cancelDeletion": "Avbryt radering",
+      "intro": "Radera ditt konto och alla tillhörande uppgifter permanent — vinkällare, flaskor, recensioner och inställningar. Efter att du begärt radering har du 7 dagar på dig att ändra dig innan raderingen blir permanent.",
+      "deleteBtn": "Radera mitt konto",
+      "typeToConfirm": "Skriv <strong>DELETE</strong> för att bekräfta:",
+      "scheduling": "Schemalägger...",
+      "scheduleBtn": "Schemalägg kontoradering"
+    }
   },
   "climate": {
     "title": "Klimat",
@@ -383,11 +429,9 @@
     "laugh": "Roligt",
     "pray": "Tack"
   },
-
   "plans": {
     "expired": "Utgånget"
   },
-
   "supporter": {
     "title": "Cellarion är gratis och öppen källkod. Här är vad som håller det igång.",
     "subtitle": "Varje funktion är gratis för alla, för alltid — inga betalväggar, inget låst. Men servrarna och AI:n bakom appen kostar riktiga pengar. Om Cellarion har förtjänat en plats i din källare är du varmt välkommen att hjälpa till att dela på notan.",
@@ -426,7 +470,6 @@
     "alreadySupporting": "💛 Du stödjer Cellarion — tack! Du kan ändra eller avsluta när som helst.",
     "donateNote": "Betalningar hanteras säkert av Stripe. Cellarion förblir gratis och öppet oavsett om du stödjer eller inte."
   },
-
   "cellars": {
     "title": "Mina källare",
     "newCellar": "Ny källare",
@@ -454,7 +497,6 @@
     "sharedCount_one": "{{count}} delad",
     "sharedCount_other": "{{count}} delade"
   },
-
   "cellarDetail": {
     "backToCellars": "← Tillbaka till källare",
     "loadingCellar": "Laddar källare...",
@@ -542,9 +584,9 @@
     "removeFilterAria": "Ta bort {{label}}",
     "groupBottleCount_one": "{{count}} flaska",
     "groupBottleCount_other": "{{count}} flaskor",
-    "collapseGroup": "Fäll ihop ▲"
+    "collapseGroup": "Fäll ihop ▲",
+    "deleteWillDelete": "Detta raderar <strong>{{name}}</strong> och alla dess hyllor."
   },
-
   "addBottle": {
     "title": "Lägg till flaska",
     "backToCellar": "← Tillbaka till källare",
@@ -650,7 +692,6 @@
     "partialAdded_one": "{{msg}} — {{count}} av {{total}} flaskor lades till. Vid nytt försök läggs bara de återstående {{remaining}} till.",
     "partialAdded_other": "{{msg}} — {{count}} av {{total}} flaskor lades till. Vid nytt försök läggs bara de återstående {{remaining}} till."
   },
-
   "bottleDetail": {
     "backToCellar": "← Tillbaka till källare",
     "backToChat": "← Tillbaka till chatten",
@@ -746,7 +787,6 @@
     "pairsWith": "Passar till",
     "consumeError": "Kunde inte ta bort flaskan"
   },
-
   "bottles": {
     "title": "Alla flaskor",
     "loading": "Laddar…",
@@ -781,7 +821,6 @@
     "status_sold": "Sålda",
     "status_other": "Övriga"
   },
-
   "racks": {
     "title": "Förvaringshyllor",
     "backToCellar": "← Tillbaka till källare",
@@ -856,10 +895,8 @@
     "viewCompact": "Kompakt",
     "viewShelf": "Hyllvy",
     "view3d": "3D",
-    "toolsMenu": "Hyllverktyg",
     "consumeNotePlaceholder": "Hur var det?"
   },
-
   "nfc": {
     "linkTitle": "Koppla NFC-tagg",
     "linkDescription": "Skriv hyllans URL till en NFC-klisterlapp. När någon håller telefonen mot lappen öppnas hyllan direkt.",
@@ -877,7 +914,6 @@
     "networkError": "Nätverksfel. Försök igen.",
     "goToCellars": "Gå till vinförråd"
   },
-
   "room": {
     "title": "Rumsvy",
     "subtitle": "3D-källarlayout",
@@ -923,7 +959,6 @@
     "loadRacksError": "Kunde inte ladda hyllorna för denna källare",
     "loadLayoutError": "Kunde inte ladda rumslayouten"
   },
-
   "wines": {
     "title": "Vinregister",
     "subtitle": "Bläddra bland alla tillgängliga viner i registret",
@@ -949,7 +984,6 @@
     "appellationLabel": "Appellation:",
     "grapesLabel": "Druvor:"
   },
-
   "wineRequests": {
     "title": "Mina vinförfrågningar",
     "newRequest": "Ny förfrågan",
@@ -970,7 +1004,6 @@
     "imageUrlPlaceholder": "Klistra in bild-URL…",
     "imageNotice": "Bilder granskas av en administratör innan de läggs till i det delade vinregistret, där de visas för alla Cellarion-användare."
   },
-
   "history": {
     "title": "Flaskhistorik",
     "backTo": "← Tillbaka till {{cellarName}}",
@@ -1002,7 +1035,6 @@
     "viewBottleAria": "Visa {{name}}",
     "noResults": "Inga flaskor matchar din sökning."
   },
-
   "cellarScope": {
     "title": "Välj vilka källare som visas",
     "thisCellar": "Denna källare",
@@ -1013,7 +1045,6 @@
     "thisCellarOnly": "Endast denna källare",
     "current": "Aktuell"
   },
-
   "cellarAudit": {
     "backToCellar": "← Tillbaka till källare",
     "auditLogTitle": "Aktivitetslogg",
@@ -1036,7 +1067,6 @@
     "sharedAs": "{{user}} som {{role}}",
     "roleChanged": "Roll ändrad: {{from}} → {{to}}"
   },
-
   "moveBottle": {
     "action": "Flytta till en annan källare",
     "actionShort": "Flytta",
@@ -1054,7 +1084,6 @@
     "movedInfo": "Den här flaskan flyttades till {{cellar}}.",
     "backToCellar": "Tillbaka till källaren"
   },
-
   "admin": {
     "requests": {
       "title": "Admin: Vinförfrågningar",
@@ -1280,7 +1309,6 @@
       "page": "Sida {{current}} av {{total}}"
     }
   },
-
   "somm": {
     "maturity": {
       "title": "Mognadskö",
@@ -1352,7 +1380,6 @@
       "requesterNoteLabel": "Förfrågans kommentar"
     }
   },
-
   "priceTracking": {
     "trigger": "Bevaka marknadspris",
     "triggerRequested": "Bevakning begärd",
@@ -1367,7 +1394,6 @@
     "cancel": "Avbryt förfrågan",
     "saving": "Sparar…"
   },
-
   "bottleSizeNames": {
     "split": "Split",
     "half": "Halvflaska",
@@ -1399,7 +1425,6 @@
     "noneYet": "Inga ännu",
     "valueSeedStarted": "Värdespårningen har startat. Din första datapunkt visas efter att veckans ögonblicksbild har körts.",
     "valueSeedFirst": "Din första ögonblicksbild är sparad. Trenddata visas efter nästa veckas ögonblicksbild.",
-
     "typeLabels": {
       "red": "Rött",
       "white": "Vitt",
@@ -1409,7 +1434,6 @@
       "fortified": "Starkvin",
       "unknown": "Väntar på granskning"
     },
-
     "ratingBands": {
       "excellent": "Utmärkt",
       "veryGood": "Mycket bra",
@@ -1417,7 +1441,6 @@
       "fair": "Godkänt",
       "poor": "Svagt"
     },
-
     "maturityPhases": {
       "declining": "Förbi bäst-före",
       "late": "Sen mognad",
@@ -1426,31 +1449,26 @@
       "notReady": "Inte redo ännu",
       "noProfile": "Ingen profil"
     },
-
     "days": {
       "overdue": "{{count}}d försenad",
       "today": "Idag",
       "left": "{{count}}d kvar",
       "ago": "{{count}}d sedan"
     },
-
     "donut": {
       "ariaLabel": "Munkdiagram: {{count}} flaskor totalt",
       "bottles": "flaskor"
     },
-
     "rating": {
       "average": "Genomsnitt:",
       "acrossBottles_one": "baserat på {{count}} betygsatt flaska",
       "acrossBottles_other": "baserat på {{count}} betygsatta flaskor"
     },
-
     "maturity": {
       "withProfiles": "{{count}} med sommelierprofiler",
       "withoutData": "{{count}} utan data",
       "profilesNeeded": "Sommelierprofiler för mognad krävs för att se ditt betyg"
     },
-
     "regret": {
       "pastPrime_one": "{{count}} flaska förbi sin bästa tid, fortfarande oöppnad.",
       "pastPrime_other": "{{count}} flaskor förbi sin bästa tid, fortfarande oöppnade.",
@@ -1460,22 +1478,18 @@
       "mild": "Några flaskor börjar passera sin topp. Håll koll på din källare.",
       "great": "Utmärkt! Din källare är välskött."
     },
-
     "forecast": {
       "inWindow_one": "{{year}}: {{count}} flaska i fönstret",
       "inWindow_other": "{{year}}: {{count}} flaskor i fönstret",
       "now": "nu"
     },
-
     "urgency": {
       "noUrgent": "Inga flaskor kräver brådskande uppmärksamhet — din källare är väl tajmad!"
     },
-
     "holdingTime": {
       "empty": "Markera flaskor som konsumerade för att se din tålamodsprofil.",
       "note": "Högre betyg vid längre lagringstid tyder på att lagring lönar sig för din källare."
     },
-
     "joyPerDollar": {
       "empty": "Betygsätt dina konsumerade flaskor för att se vilken typ som ger mest glädje per {{currency}}.",
       "count_one": "{{count}} flaska",
@@ -1483,7 +1497,6 @@
       "avg": "snitt {{price}}",
       "note": "Poäng = nöjesbetyg per {{currency}} 1 000 spenderat. Högre = bättre värde."
     },
-
     "regretSignal": {
       "empty": "Betygsätt flaskor före och efter drickning för att spåra förväntning vs verklighet.",
       "avgDelta": "Snittdelta:",
@@ -1492,7 +1505,6 @@
       "surprises": "Överraskningar",
       "disappointments": "Besvikelser"
     },
-
     "pace": {
       "bottlesIn": "flaskor in / år",
       "bottlesOut": "flaskor ut / år",
@@ -1503,7 +1515,6 @@
       "runway_other": "år av vin vid nuvarande konsumtion",
       "consumeToSee": "Konsumera flaskor för att se din källares bana."
     },
-
     "consumption": {
       "empty": "Ingen konsumtionshistorik ännu — markera flaskor som druckna, bortgivna eller sålda för att se din historik.",
       "drank": "Drucken",
@@ -1513,18 +1524,15 @@
       "totalConsumed_one": "{{count}} flaska konsumerad totalt",
       "totalConsumed_other": "{{count}} flaskor konsumerade totalt"
     },
-
     "topValue": {
       "empty": "Lägg till priser på dina flaskor för att se dina mest värdefulla viner."
     },
-
     "cellarBreakdown": {
       "bottle_one": "{{count}} flaska",
       "bottle_other": "{{count}} flaskor",
       "uniqueWine_one": "{{count}} unikt vin",
       "uniqueWine_other": "{{count}} unika viner"
     },
-
     "worldMap": {
       "bottle_one": "{{count}} flaska",
       "bottle_other": "{{count}} flaskor",
@@ -1533,7 +1541,6 @@
       "unmapped_one": "{{count}} land utan ISO-kod dolt",
       "unmapped_other": "{{count}} länder utan ISO-kod dolda"
     },
-
     "premiumGate": {
       "desc": "Djupgående insikter i hela din vinsamling — typer, ursprung, årgångar, värde, mognadsprofiler, konsumtionshistorik och mer. Den mest omfattande vinanalysen tillgänglig.",
       "feat1": "Vintyp- och ursprungsfördelning",
@@ -1548,12 +1555,10 @@
       "notSure": "Inte säker ännu?",
       "startTrial": "Starta en gratis 30-dagars provperiod"
     },
-
     "upgrade": {
       "unlockWith": "Lås upp med {{plan}}",
       "upgradeTo": "Uppgradera till {{plan}}"
     },
-
     "sections": {
       "wineTypes": "Vintyper",
       "maturityStatus": "Mognadsstatus",
@@ -1589,7 +1594,6 @@
       "mostValuableBottles": "Mest värdefulla flaskor",
       "valueOverTime": "Samlingens värde över tid"
     },
-
     "kpi": {
       "activeBottles": "Aktiva flaskor",
       "uniqueWines": "{{count}} unika viner",
@@ -1609,15 +1613,12 @@
       "sold": "Sålda",
       "avgConsumedRating": "Snittbetyg vid konsumtion"
     },
-
-
     "footnote": {
       "activeOnly": "Endast aktiva flaskor",
       "pricesConverted": "Priser omräknade med dagens växelkurser till {{currency}}",
       "maturityData": "Mognadsdata från sommelierprofiler",
       "ownedOnly": "Endast dina egna källare inkluderas"
     },
-
     "bottle_one": "{{count}} flaska",
     "bottle_other": "{{count}} flaskor",
     "vintageBottle_one": "{{vintage}}: {{count}} flaska",
@@ -1625,7 +1626,6 @@
     "purchased_one": "{{year}}: {{count}} flaska inköpt",
     "purchased_other": "{{year}}: {{count}} flaskor inköpta"
   },
-
   "blog": {
     "title": "Blogg",
     "subtitle": "Nyheter, tips och uppdateringar från Cellarion-teamet",
@@ -1706,7 +1706,23 @@
     "deleteTitle": "Ta bort omdömet?",
     "deleteBody": "Detta tar bort ditt omdöme permanent. Det går inte att ångra.",
     "deleteError": "Det gick inte att ta bort omdömet — försök igen.",
-    "deleting": "Tar bort…"
+    "deleting": "Tar bort…",
+    "saveFailed": "Det gick inte att spara recensionen",
+    "editTitle": "Redigera recension",
+    "reviewTitle": "Recension: {{wine}}",
+    "ratingLabel": "Betyg *",
+    "vintage": "Årgång",
+    "vintagePlaceholder": "t.ex. 2019",
+    "overallPlaceholder": "Vad tyckte du om vinet?",
+    "tastingNotes": "Detaljerade smaknoteringar",
+    "aroma": "Doft / Nos",
+    "aromaPlaceholder": "Vad känner du för dofter?",
+    "palate": "Smak",
+    "palatePlaceholder": "Vad känner du för smaker?",
+    "finish": "Eftersmak",
+    "finishPlaceholder": "Hur dröjer den sig kvar?",
+    "update": "Uppdatera recension",
+    "submit": "Skicka recension"
   },
   "discussions": {
     "community": "Gemenskap",
@@ -2212,7 +2228,6 @@
       }
     }
   },
-
   "landing": {
     "heroHeadline": "Din vinkällare,",
     "heroAccent": "vackert organiserad.",
@@ -2276,7 +2291,6 @@
       "a6": "Ja — din data är din. Cellarion har en en-kliks dataexport som ger dig allt som JSON, plus CSV-import och -export för flaskor. Du kan radera ditt konto från Inställningar med 7 dagars betänketid. Data på den hostade tjänsten lagras på europeisk infrastruktur under GDPR."
     }
   },
-
   "maturity": {
     "peak": "Optimal",
     "early": "Tidig",
@@ -2285,11 +2299,9 @@
     "notReady": "Ej redo",
     "noData": "Ingen mognadsdata"
   },
-
   "cellarNav": {
     "aria": "Källarvyer"
   },
-
   "cellarBook": {
     "title": "Källarbok",
     "linkBtn": "Källarbok",
@@ -2312,7 +2324,6 @@
     "colWindow": "Dryckesfönster",
     "footer": "Skapad med Cellarion"
   },
-
   "openBottle": {
     "openBtn": "Öppna flaska…",
     "pickerTitle": "Öppna den här flaskan",
@@ -2340,7 +2351,6 @@
     "partialOr": "eller ta bort den helt:",
     "partialConfirmBtn": "Öppna & häll upp ett glas"
   },
-
   "audit": {
     "title": "Inventera hylla — {{name}}",
     "openBtn": "Inventera",
@@ -2363,7 +2373,6 @@
     "clearSlot": "Töm plats",
     "cleared": "Tömd"
   },
-
   "zones": {
     "title": "Hyllzoner",
     "editBtn": "Hyllzoner",
@@ -2375,7 +2384,6 @@
     "nameMissing": "Ge varje zon med platser ett namn (eller ta bort den).",
     "saveError": "Kunde inte spara zonerna — försök igen."
   },
-
   "arrange": {
     "title": "Organisera hyllan",
     "openBtn": "Organisera…",
@@ -2409,7 +2417,6 @@
     "undoUnavailable": "Hyllan har ändrats sedan dess — organiseringen kan inte längre ångras.",
     "undoError": "En flytt misslyckades under ångringen — hyllan kan ha ändrats. Stäng och kontrollera hyllan."
   },
-
   "rackLens": {
     "dragHint": "Tips: dra en flaska till en tom plats för att flytta den, eller släpp den på en annan flaska för att byta plats.",
     "searchPlaceholder": "Sök i hyllorna…",
@@ -2430,7 +2437,6 @@
     "ratingLow": "Lågt",
     "ratingNone": "Ej betygsatt"
   },
-
   "cellarCred": {
     "newcomer": "Nykomling",
     "contributor": "Bidragsgivare",
@@ -3424,6 +3430,50 @@
       "pending": "Väntar",
       "resolved": "Åtgärdad",
       "dismissed": "Avvisad"
-    }
+    },
+    "contactTitle": "Kontakta support",
+    "categoryLabel": "Kategori",
+    "sentTitle": "Supportförfrågan skickad",
+    "sentBody": "Ditt ärende har skickats. En administratör svarar inom kort.",
+    "sentTrack": "Du kan följa dina ärenden under <strong>Support</strong> i menyn.",
+    "subject": "Ämne",
+    "subjectPlaceholder": "Kort sammanfattning av ditt ärende",
+    "message": "Meddelande",
+    "messagePlaceholder": "Beskriv ditt problem eller din fråga i detalj...",
+    "sending": "Skickar…",
+    "sendTicket": "Skicka ärende",
+    "subjectRequired": "Ämne krävs",
+    "messageRequired": "Meddelande krävs",
+    "submitFailed": "Det gick inte att skicka ärendet"
+  },
+  "similarWines": {
+    "title": "Menade du någon av dessa?",
+    "intro": "Vi hittade viner i registret som liknar <strong>{{query}}</strong>. Att välja ett befintligt vin håller registret städat och låter dig dela data med andra användare.",
+    "whatYouEntered": "det du angav",
+    "similarityTitle": "Likhetspoäng",
+    "matchLabel": "{{percent}}% träff",
+    "useThis": "Använd detta",
+    "createNew": "Nej, skapa nytt vin"
+  },
+  "reportWine": {
+    "title": "Rapportera vin",
+    "sentTitle": "Rapport skickad",
+    "sentBody": "Tack för din rapport. Vårt team granskar den inom kort.",
+    "reporting": "Rapporterar: <strong>{{wine}}</strong>",
+    "reason": "Anledning",
+    "reasons": {
+      "wrong_info": "Fel information (namn, producent, region m.m.)",
+      "duplicate": "Dubblettvin",
+      "wrong_price": "Fel eller felaktigt marknadspris",
+      "wrong_tasting_profile": "Felaktig smakprofil (struktur, smaker, matchningar)",
+      "inappropriate": "Olämpligt innehåll",
+      "other": "Annat"
+    },
+    "details": "Detaljer",
+    "optional": "(valfritt)",
+    "detailsPlaceholder": "Ange ytterligare information som hjälper oss att undersöka…",
+    "submitting": "Skickar…",
+    "submit": "Skicka rapport",
+    "submitFailed": "Det gick inte att skicka rapporten"
   }
 }

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import useVersion from '../hooks/useVersion';
 import { updateProfile } from '../api/profiles';
@@ -349,16 +349,16 @@ function Settings() {
 
       {/* ── Profile card ── */}
       <div className="card settings-card">
-        <h2 className="settings-section-title">Profile</h2>
+        <h2 className="settings-section-title">{t('settings.profile.title', 'Profile')}</h2>
         <form onSubmit={handleProfileSave}>
           <div className="form-group">
             <label>{t('settings.signedInAs', 'Signed in as')}</label>
             <div className="settings-email-display">{user?.email || '—'}</div>
           </div>
           <div className="form-group">
-            <label htmlFor="display-name-input">Display Name</label>
+            <label htmlFor="display-name-input">{t('settings.profile.displayName', 'Display Name')}</label>
             <p className="settings-hint">
-              How your name appears to other users. Leave blank to use your username.
+              {t('settings.profile.displayNameHint', 'How your name appears to other users. Leave blank to use your username.')}
             </p>
             <input
               id="display-name-input"
@@ -366,30 +366,30 @@ function Settings() {
               className="input"
               value={displayName}
               onChange={e => setDisplayName(e.target.value)}
-              placeholder={user?.username || 'Display name'}
+              placeholder={user?.username || t('settings.profile.displayName', 'Display Name')}
               maxLength={50}
             />
           </div>
           <div className="form-group">
-            <label htmlFor="bio-input">Bio</label>
+            <label htmlFor="bio-input">{t('settings.profile.bio', 'Bio')}</label>
             <p className="settings-hint">
-              A short description visible on your public profile.
+              {t('settings.profile.bioHint', 'A short description visible on your public profile.')}
             </p>
             <textarea
               id="bio-input"
               className="input"
               value={bio}
               onChange={e => setBio(e.target.value)}
-              placeholder="Tell others about your wine journey..."
+              placeholder={t('settings.profile.bioPlaceholder', 'Tell others about your wine journey...')}
               maxLength={500}
               rows={3}
             />
           </div>
 
           <div className="form-group">
-            <label htmlFor="visibility-select">Profile Visibility</label>
+            <label htmlFor="visibility-select">{t('settings.profile.visibility', 'Profile Visibility')}</label>
             <p className="settings-hint">
-              Public profiles appear in search results and the Discover feed. Private profiles are hidden from other users.
+              {t('settings.profile.visibilityHint', 'Public profiles appear in search results and the Discover feed. Private profiles are hidden from other users.')}
             </p>
             <select
               id="visibility-select"
@@ -397,8 +397,8 @@ function Settings() {
               value={profileVisibility}
               onChange={e => setProfileVisibility(e.target.value)}
             >
-              <option value="public">Public</option>
-              <option value="private">Private</option>
+              <option value="public">{t('settings.profile.public', 'Public')}</option>
+              <option value="private">{t('settings.profile.private', 'Private')}</option>
             </select>
           </div>
 
@@ -593,7 +593,7 @@ function Settings() {
           <div className="settings-push-devices">
             <div className="settings-push-device-row">
               <span className={`settings-push-device-status ${deviceStatus.thisDeviceRegistered ? 'settings-push-device-status--active' : ''}`}>
-                {deviceStatus.thisDeviceRegistered ? 'This device is registered' : 'This device is not registered'}
+                {deviceStatus.thisDeviceRegistered ? t('settings.push.deviceRegistered', 'This device is registered') : t('settings.push.deviceNotRegistered', 'This device is not registered')}
               </span>
               {deviceStatus.thisDeviceRegistered ? (
                 <button
@@ -601,7 +601,7 @@ function Settings() {
                   onClick={handleRemoveDevice}
                   disabled={deviceLoading}
                 >
-                  {deviceLoading ? 'Removing...' : 'Remove this device'}
+                  {deviceLoading ? t('settings.push.removing', 'Removing...') : t('settings.push.removeDevice', 'Remove this device')}
                 </button>
               ) : (
                 <button
@@ -609,13 +609,13 @@ function Settings() {
                   onClick={handleRegisterDevice}
                   disabled={deviceLoading}
                 >
-                  {deviceLoading ? 'Registering...' : 'Register this device'}
+                  {deviceLoading ? t('settings.push.registering', 'Registering...') : t('settings.push.registerDevice', 'Register this device')}
                 </button>
               )}
             </div>
             {deviceStatus.totalDevices > 0 && (
               <p className="settings-hint" style={{ marginTop: '0.25rem' }}>
-                {deviceStatus.totalDevices} {deviceStatus.totalDevices === 1 ? 'device' : 'devices'} registered for push notifications.
+                {t('settings.push.devicesRegistered', { count: deviceStatus.totalDevices, defaultValue: '{{count}} devices registered for push notifications.' })}
               </p>
             )}
             {deviceStatus.thisDeviceRegistered && (
@@ -625,11 +625,11 @@ function Settings() {
                   onClick={handleTestPush}
                   disabled={testSending}
                 >
-                  {testSending ? 'Sending...' : 'Send test notification'}
+                  {testSending ? t('settings.push.sending', 'Sending...') : t('settings.push.sendTest', 'Send test notification')}
                 </button>
                 {testResult && (
                   <span className={testResult.success ? 'settings-saved' : 'settings-push-test-error'}>
-                    {testResult.success ? 'Test sent!' : testResult.error}
+                    {testResult.success ? t('settings.push.testSent', 'Test sent!') : testResult.error}
                   </span>
                 )}
               </div>
@@ -766,74 +766,81 @@ function Settings() {
 
       {/* ── Your Data (GDPR) ── */}
       <div className="card settings-card">
-        <h2 className="settings-section-title">Your Data</h2>
+        <h2 className="settings-section-title">{t('settings.data.title', 'Your Data')}</h2>
         <p className="settings-hint">
-          Download a complete copy of all your personal data stored in Cellarion, including
-          your profile, bottles, cellars, reviews, and activity log.
+          {t('settings.data.intro', 'Download a complete copy of all your personal data stored in Cellarion, including your profile, bottles, cellars, reviews, and activity log.')}
         </p>
         <button
           className="btn btn-secondary"
           onClick={handleExportData}
           disabled={exporting}
         >
-          {exporting ? 'Exporting...' : 'Export my data'}
+          {exporting ? t('settings.data.exporting', 'Exporting...') : t('settings.data.exportBtn', 'Export my data')}
         </button>
         {exportError && <div className="alert alert-error" style={{ marginTop: '0.75rem' }}>{exportError}</div>}
         <p className="settings-hint" style={{ marginTop: '1rem' }}>
-          Read our <a href="/privacy">Privacy Policy</a> to learn how your data is processed and what rights you have.
+          <Trans i18nKey="settings.data.privacyLink" components={{ a: <a href="/privacy" /> }}>
+            Read our <a href="/privacy">Privacy Policy</a> to learn how your data is processed and what rights you have.
+          </Trans>
         </p>
       </div>
 
       {/* ── Take your cellars with you (portability / anti-lock-in) ── */}
       <div className="card settings-card">
-        <h2 className="settings-section-title">Take your cellars with you</h2>
+        <h2 className="settings-section-title">{t('settings.portability.title', 'Take your cellars with you')}</h2>
         <p className="settings-hint">
-          Export one cellar or all of them — bottles, rack placements, 3D room layout, reviews,
-          maturity data and the images you uploaded yourself — in a format you can import into any
-          Cellarion instance. Your data is yours; we never lock it in.
+          {t('settings.portability.intro', 'Export one cellar or all of them — bottles, rack placements, 3D room layout, reviews, maturity data and the images you uploaded yourself — in a format you can import into any Cellarion instance. Your data is yours; we never lock it in.')}
         </p>
 
         <div className="settings-actions" style={{ marginTop: '1rem' }}>
-          <Link to="/export-cellar" className="btn btn-secondary">Export your cellars →</Link>
+          <Link to="/export-cellar" className="btn btn-secondary">{t('settings.portability.exportBtn', 'Export your cellars →')}</Link>
         </div>
 
         <p className="settings-hint" style={{ marginTop: '1rem' }}>
-          Moving in from another Cellarion instance? <Link to="/import-cellar">Import a cellar export</Link> to
-          recreate your cellars, bottles and images here.
+          <Trans i18nKey="settings.portability.importLink" components={{ a: <Link to="/import-cellar" /> }}>
+            Moving in from another Cellarion instance? <Link to="/import-cellar">Import a cellar export</Link> to recreate your cellars, bottles and images here.
+          </Trans>
         </p>
       </div>
 
       {/* ── Danger zone ── */}
       <div className="card settings-card settings-danger-card">
-        <h2 className="settings-section-title settings-danger-title">Danger zone</h2>
+        <h2 className="settings-section-title settings-danger-title">{t('settings.danger.title', 'Danger zone')}</h2>
         {isDeletionScheduled ? (
           <div>
             <div className="alert alert-error" style={{ marginBottom: '1rem' }}>
-              Account deletion is scheduled for{' '}
-              <strong>{new Date(user.deletionScheduledFor).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}</strong>.
-              All your data will be permanently removed after this date.
+              <Trans
+                i18nKey="settings.danger.scheduledFor"
+                components={{ strong: <strong /> }}
+                values={{ date: new Date(user.deletionScheduledFor).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' }) }}
+              >
+                Account deletion is scheduled for <strong>{'{{date}}'}</strong>. All your data will be permanently removed after this date.
+              </Trans>
             </div>
             <button
               className="btn btn-secondary"
               onClick={handleCancelDeletion}
               disabled={cancelling}
             >
-              {cancelling ? 'Cancelling...' : 'Cancel deletion'}
+              {cancelling ? t('settings.danger.cancelling', 'Cancelling...') : t('settings.danger.cancelDeletion', 'Cancel deletion')}
             </button>
           </div>
         ) : (
           <>
             <p className="settings-hint">
-              Permanently delete your account and all associated data — cellars, bottles, reviews, and settings.
-              After requesting deletion, you have 7 days to change your mind before the deletion is permanent.
+              {t('settings.danger.intro', 'Permanently delete your account and all associated data — cellars, bottles, reviews, and settings. After requesting deletion, you have 7 days to change your mind before the deletion is permanent.')}
             </p>
             {!showDeleteConfirm ? (
               <button className="btn btn-danger" onClick={() => setShowDeleteConfirm(true)}>
-                Delete my account
+                {t('settings.danger.deleteBtn', 'Delete my account')}
               </button>
             ) : (
               <div className="settings-delete-confirm">
-                <p>Type <strong>DELETE</strong> to confirm:</p>
+                <p>
+                  <Trans i18nKey="settings.danger.typeToConfirm" components={{ strong: <strong /> }}>
+                    Type <strong>DELETE</strong> to confirm:
+                  </Trans>
+                </p>
                 <input
                   type="text"
                   className="input"
@@ -849,10 +856,10 @@ function Settings() {
                     onClick={handleDeleteAccount}
                     disabled={deleteConfirmText !== 'DELETE' || deleting}
                   >
-                    {deleting ? 'Scheduling...' : 'Schedule account deletion'}
+                    {deleting ? t('settings.danger.scheduling', 'Scheduling...') : t('settings.danger.scheduleBtn', 'Schedule account deletion')}
                   </button>
                   <button className="btn btn-secondary" onClick={() => { setShowDeleteConfirm(false); setDeleteConfirmText(''); }}>
-                    Cancel
+                    {t('common.cancel')}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Audit Batch 5 — i18n coverage

Fifth batch from the GRAND_AUDIT_2026-07-11 design/UX track. **Frontend-only** — no backend, compose, or env changes.

Several user-facing surfaces were hardcoded English (or only partly translated) while the app ships both `en` and `sv` locales, so Swedish users saw half-translated screens — including the most sensitive ones.

### What was localized
- **`Settings.js`** (MED-12): Profile card, per-device push strings, the **"Your Data" GDPR export** card, the **"Take your cellars with you"** portability card, and the entire **"Danger zone"** account-deletion flow (type-DELETE confirm, schedule/cancel).
- **`SimilarWinesModal`** (MED-13): was **100% hardcoded** in the core add-bottle / add-wishlist find-or-create flow — now fully localized.
- **`ReviewForm`** (MED-14): finished the partial translation — tasting-note section (Aroma/Palate/Finish + placeholders), overall placeholder, Rating/Vintage labels, Cancel/Submit.
- **`DeleteCellarModal`** (LOW-8): the two hardcoded confirmation strings.
- **`SupportModal`** (LOW-12) & **`ReportWineModal`** (LOW-13): fully localized. SupportModal reuses the existing `support.category.*` option labels rather than duplicating them.

### Keys
- Added **~94 keys to each** of `en` and `sv`. Strings containing inline markup (links, `<strong>`) use `<Trans>` with matching component tags and `{{interpolation}}`.
- **Swedish is machine-authored and pending review** (standing caveat for this project).

### Verification
- `npx vite build` clean; `npm test` → **642 passed**.
- Rendered `/settings` in Docker: English resolves with **no raw-tag/key leaks** (`<a>`/`<strong>`/`[object Object]`/`settings.*` keys all absent; "Danger zone", "Your Data", "Privacy Policy" present).
- Static check: every added `sv` string has the **same interpolation tokens/tags** as its `en` counterpart — **352 leaf strings across the 6 namespaces, 0 mismatches** — so the `<Trans>` structures that render correctly in English render correctly in Swedish.

### Note
`translation.json` blank-line separators were collapsed as a side effect of programmatic key insertion (content unchanged, JSON valid — equivalent to a formatter pass).

### Docker impact
Frontend-only — rebuild the frontend image. No compose/backend/env changes.
