### PR TITLE
fix(perf): frontend correctness & backend performance (audit batch 6)

### DIFF
--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -569,14 +569,22 @@ router.get('/:id/statistics', async (req, res) => {
       return res.status(404).json({ error: 'Cellar not found' });
     }
 
-    // Only count active bottles in statistics. Lean + the list projection:
-    // this handler only reads scalar fields (wine _id, country.name, type),
-    // so hydrating full documents with the multi-KB aiProfile made this the
-    // heaviest per-request allocation in the file on large cellars.
+    // Only count active bottles in statistics. This handler reads only scalar
+    // bottle fields plus wineDefinition.type and wineDefinition.country.name, so
+    // populate just those — the full WINE_POPULATE_LIST also joins region + the
+    // grapes array (never read here), pure waste on large cellars. Capped at 10k
+    // to match the sibling list/history routes.
     const bottles = await Bottle.find({
       cellar: req.params.id,
       status: { $nin: CONSUMED_STATUSES }
-    }).populate(WINE_POPULATE_LIST).lean();
+    })
+      .populate({
+        path: 'wineDefinition',
+        select: 'type country',
+        populate: { path: 'country', select: 'name' },
+      })
+      .limit(10000)
+      .lean();
 
     // Batch-load historical rate snapshots for all priceSetAt dates (one DB query)
     const targetCurrency = req.query.currency || null;

--- a/backend/src/services/drinkWindowNotifier.js
+++ b/backend/src/services/drinkWindowNotifier.js
@@ -132,6 +132,7 @@ async function processUser(user, isFirstRun) {
   const currentYear = new Date().getFullYear();
   const alerts = []; // { bottleId, name, vintage, status, notifType }
   const seedOps = []; // first-run status seeds, flushed as one bulkWrite
+  const transitionOps = []; // per-transition status updates, flushed as one bulkWrite
 
   for (const bottle of bottles) {
     const maturityStatus = classifyMaturity(bottle, profileMap);
@@ -211,14 +212,20 @@ async function processUser(user, isFirstRun) {
       status: notifType,
     });
 
-    await Bottle.updateOne(
-      { _id: bottle._id },
-      { $set: { drinkWindowNotifiedStatus: effectiveStatus, drinkWindowNotifiedAt: new Date() } }
-    );
+    transitionOps.push({
+      updateOne: {
+        filter: { _id: bottle._id },
+        update: { $set: { drinkWindowNotifiedStatus: effectiveStatus, drinkWindowNotifiedAt: new Date() } },
+      },
+    });
   }
 
   if (seedOps.length > 0) {
     await Bottle.bulkWrite(seedOps, { ordered: false });
+  }
+
+  if (transitionOps.length > 0) {
+    await Bottle.bulkWrite(transitionOps, { ordered: false });
   }
 
   if (alerts.length === 0) return 0;

--- a/backend/src/services/drinkWindowNotifier.test.js
+++ b/backend/src/services/drinkWindowNotifier.test.js
@@ -105,7 +105,12 @@ describe('processUser — definition-less personal-window bottles (BUG 4)', () =
       expect(`${call[2]} ${call[3]}`).not.toContain('Unknown wine');
     }
     // The definition-less bottles are never even marked (no seed/update for them).
-    const markedIds = Bottle.updateOne.mock.calls.map((c) => c[0]._id);
+    // Transition marks go through Bottle.bulkWrite (transitionOps); older direct
+    // updateOne calls are collected too so the assertion is path-agnostic.
+    const markedIds = [
+      ...Bottle.updateOne.mock.calls.map((c) => c[0]._id),
+      ...Bottle.bulkWrite.mock.calls.flatMap((c) => c[0].map((op) => op.updateOne.filter._id)),
+    ];
     expect(markedIds).not.toContain('b1');
     expect(markedIds).not.toContain('b2');
     expect(markedIds).toContain('b3');

--- a/backend/src/utils/maturityUtils.js
+++ b/backend/src/utils/maturityUtils.js
@@ -78,9 +78,18 @@ async function buildProfileMap(activeBottles) {
   const map = new Map();
   if (profileQueries.length === 0) return map;
 
-  const profiles = await WineVintageProfile.find({ $or: profileQueries, status: 'reviewed' }).lean();
+  // One index-friendly $in over wineDefinition instead of an N-branch $or (which
+  // can reach thousands of clauses on a large maturity-sorted cellar), then drop
+  // rows whose (wineDefinition, vintage) pair wasn't requested. Same
+  // {wineDefinition, vintage} unique index, one query.
+  const wineIds = [...new Set(profileQueries.map(q => q.wineDefinition))];
+  const profiles = await WineVintageProfile.find({
+    wineDefinition: { $in: wineIds },
+    status: 'reviewed',
+  }).lean();
   for (const p of profiles) {
-    map.set(`${p.wineDefinition.toString()}:${p.vintage}`, p);
+    const key = `${p.wineDefinition.toString()}:${p.vintage}`;
+    if (seenPairs.has(key)) map.set(key, p);
   }
   return map;
 }

--- a/frontend/src/components/RatingDisplay.js
+++ b/frontend/src/components/RatingDisplay.js
@@ -26,9 +26,10 @@ export default function RatingDisplay({ value, scale, preferredScale }) {
   const precision = meta.step < 1 ? 1 : 0;
   const originalFormatted = `${numVal.toFixed(precision)}${meta.suffix}`;
 
-  // Star fill % for the original scale '5' star bar, or the converted star value
-  const starNorm = scales.normalized;
-  const starFill = Math.max(0, Math.min(100, starNorm));
+  // Star fill % for the '5'-scale star bar. The bar only renders when
+  // resolvedScale === '5' (below), so numVal is the 0–5 star value — fill to the
+  // star proportion (matching RatingInput), NOT the non-linear normalized score.
+  const starFill = Math.max(0, Math.min(100, (numVal / 5) * 100));
 
   // Determine if we need to show a preferred-scale conversion
   const prefScale = SCALE_META[preferredScale] ? preferredScale : null;

--- a/frontend/src/components/charts/WorldMapChart.js
+++ b/frontend/src/components/charts/WorldMapChart.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
 import worldData from 'world-atlas/countries-110m.json';
@@ -13,18 +13,63 @@ function getCountryFill(count, maxCount) {
   return `rgb(${r},${g},${b})`;
 }
 
+// Memoized map paths: re-renders only when byCode/maxCount change, NOT when the
+// parent's hover state updates — so moving the pointer between countries no
+// longer reconciles all ~177 <Geography> elements (hover highlight is CSS-driven
+// via style.hover; onHover only feeds the parent's info bar).
+const MapPaths = memo(function MapPaths({ byCode, maxCount, onHover }) {
+  return (
+    <ComposableMap
+      width={800}
+      height={400}
+      projection="geoEqualEarth"
+      projectionConfig={{ scale: 155 }}
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <Geographies geography={worldData}>
+        {({ geographies }) =>
+          geographies.map(geo => {
+            const alpha2  = NUM_TO_A2[String(geo.id)];
+            const data    = alpha2 ? byCode[alpha2] : null;
+            const fill    = getCountryFill(data?.count, maxCount);
+            const hasData = !!data;
+
+            return (
+              <Geography
+                key={geo.rsmKey}
+                geography={geo}
+                fill={fill}
+                stroke="#0a1512"
+                strokeWidth={0.35}
+                onMouseEnter={() => hasData && onHover(data)}
+                onMouseLeave={() => onHover(null)}
+                style={{
+                  default: { outline: 'none', transition: 'fill 0.1s' },
+                  hover:   { fill: hasData ? '#9bbfa8' : '#1e2e28', outline: 'none', cursor: 'default' },
+                  pressed: { outline: 'none' },
+                }}
+              />
+            );
+          })
+        }
+      </Geographies>
+    </ComposableMap>
+  );
+});
+
 function WorldMapChart({ byCountry }) {
   const { t } = useTranslation();
   const [hovered, setHovered] = useState(null);
 
-  const byCode = {};
-  for (const c of byCountry) {
-    if (c.code) byCode[c.code] = c;
-  }
-
-  const maxCount = byCountry.length > 0 ? Math.max(...byCountry.map(c => c.count)) : 1;
-  const mappedCount  = byCountry.filter(c => c.code).length;
-  const unmappedCount = byCountry.length - mappedCount;
+  const { byCode, maxCount, unmappedCount } = useMemo(() => {
+    const codes = {};
+    for (const c of byCountry) {
+      if (c.code) codes[c.code] = c;
+    }
+    const max = byCountry.length > 0 ? Math.max(...byCountry.map(c => c.count)) : 1;
+    const mapped = byCountry.filter(c => c.code).length;
+    return { byCode: codes, maxCount: max, unmappedCount: byCountry.length - mapped };
+  }, [byCountry]);
 
   return (
     <div className="worldmap-wrap">
@@ -41,41 +86,7 @@ function WorldMapChart({ byCountry }) {
         )}
       </div>
 
-      <ComposableMap
-        width={800}
-        height={400}
-        projection="geoEqualEarth"
-        projectionConfig={{ scale: 155 }}
-        style={{ width: '100%', height: 'auto', display: 'block' }}
-      >
-        <Geographies geography={worldData}>
-          {({ geographies }) =>
-            geographies.map(geo => {
-              const alpha2  = NUM_TO_A2[String(geo.id)];
-              const data    = alpha2 ? byCode[alpha2] : null;
-              const fill    = getCountryFill(data?.count, maxCount);
-              const hasData = !!data;
-
-              return (
-                <Geography
-                  key={geo.rsmKey}
-                  geography={geo}
-                  fill={fill}
-                  stroke="#0a1512"
-                  strokeWidth={0.35}
-                  onMouseEnter={() => hasData && setHovered(data)}
-                  onMouseLeave={() => setHovered(null)}
-                  style={{
-                    default: { outline: 'none', transition: 'fill 0.1s' },
-                    hover:   { fill: hasData ? '#9bbfa8' : '#1e2e28', outline: 'none', cursor: 'default' },
-                    pressed: { outline: 'none' },
-                  }}
-                />
-              );
-            })
-          }
-        </Geographies>
-      </ComposableMap>
+      <MapPaths byCode={byCode} maxCount={maxCount} onHover={setHovered} />
 
       <div className="worldmap-legend">
         <div className="worldmap-legend-scale">

--- a/frontend/src/contexts/NotificationContext.js
+++ b/frontend/src/contexts/NotificationContext.js
@@ -96,13 +96,21 @@ export function NotificationProvider({ children }) {
     // can't see net-zero changes (one read on another device while a new
     // notification arrives keeps the count equal), so waking is the moment
     // we resynchronize the actual list — same self-heal the old code had.
-    const handleWake = () => { if (!document.hidden) fetchNotifications(); };
+    // Returning to a tab fires BOTH visibilitychange and focus, so debounce to
+    // coalesce that burst into a single fetch.
+    let wakeTimer = null;
+    const handleWake = () => {
+      if (document.hidden) return;
+      clearTimeout(wakeTimer);
+      wakeTimer = setTimeout(() => fetchNotifications(), 250);
+    };
     window.addEventListener('focus', handleWake);
     document.addEventListener('visibilitychange', handleWake);
 
     return () => {
       clearInterval(intervalRef.current);
       intervalRef.current = null;
+      clearTimeout(wakeTimer);
       window.removeEventListener('focus', handleWake);
       document.removeEventListener('visibilitychange', handleWake);
     };

--- a/frontend/src/pages/CellarHistory.js
+++ b/frontend/src/pages/CellarHistory.js
@@ -23,7 +23,7 @@ const REASON_CONFIG = {
 function CellarHistory() {
   const { t } = useTranslation();
   const { id } = useParams();
-  const { apiFetch, user } = useAuth();
+  const { apiFetch } = useAuth();
   const [cellar, setCellar] = useState(null);
   const [grouped, setGrouped] = useState({});
   const [loading, setLoading] = useState(true);

--- a/frontend/src/pages/DiscussionDetail.js
+++ b/frontend/src/pages/DiscussionDetail.js
@@ -78,10 +78,15 @@ function DiscussionDetail() {
   const isOwner = user && discussion?.author?._id === user.id;
   const isMod = user && (user.roles?.includes('moderator') || user.roles?.includes('admin'));
 
-  const fetchDiscussion = useCallback(async () => {
+  // Latest-wins guard so an out-of-order response for a previous thread can't
+  // overwrite the current thread's header/replies (mirrors CellarDetail/History).
+  const fetchSeq = useRef(0);
+
+  const fetchDiscussion = useCallback(async (seq) => {
     try {
       const res = await getDiscussion(apiFetch, idOrSlug);
       const data = await res.json();
+      if (seq !== fetchSeq.current) return; // superseded by a newer thread load
       if (res.ok) {
         setDiscussion(data.discussion);
         setError(null);
@@ -95,11 +100,12 @@ function DiscussionDetail() {
         setError(data.error || t('discussions.failedLoadDiscussion'));
       }
     } catch {
+      if (seq !== fetchSeq.current) return;
       setError(t('discussions.failedLoadDiscussion'));
     }
   }, [apiFetch, idOrSlug, t]);
 
-  const fetchReplies = useCallback(async (p, replace = false) => {
+  const fetchReplies = useCallback(async (p, replace = false, seq = fetchSeq.current) => {
     try {
       if (replace) setLoading(true);
       else setLoadingMore(true);
@@ -107,6 +113,7 @@ function DiscussionDetail() {
       const res = await getDiscussionReplies(apiFetch, id, `page=${p}&limit=30`);
       const data = await res.json();
 
+      if (seq !== fetchSeq.current) return; // superseded by a newer thread load
       if (res.ok) {
         setReplies(prev => replace ? data.replies : [...prev, ...data.replies]);
         setPage(p);
@@ -115,14 +122,17 @@ function DiscussionDetail() {
     } catch {
       // silent
     } finally {
-      setLoading(false);
-      setLoadingMore(false);
+      if (seq === fetchSeq.current) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
     }
   }, [apiFetch, id]);
 
   useEffect(() => {
-    fetchDiscussion();
-    fetchReplies(1, true);
+    const seq = ++fetchSeq.current;
+    fetchDiscussion(seq);
+    fetchReplies(1, true, seq);
   }, [fetchDiscussion, fetchReplies]);
 
   const handleSubmitReply = async (e) => {

--- a/frontend/src/pages/Statistics.js
+++ b/frontend/src/pages/Statistics.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -22,9 +22,13 @@ import PurchaseHistoryChart from '../components/charts/PurchaseHistoryChart';
 import TopValueList from '../components/charts/TopValueList';
 import CellarBreakdownViz from '../components/charts/CellarBreakdownViz';
 import BottleSizeChart from '../components/charts/BottleSizeChart';
-import WorldMapChart from '../components/charts/WorldMapChart';
 import ValueOverTimeChart from '../components/ValueOverTimeChart';
 import './Statistics.css';
+
+// Lazy-loaded: pulls in react-simple-maps + a 108 KB world-atlas topojson, and
+// the map sits at the bottom of the page (desktop-only), so keep it out of the
+// Statistics route chunk — matches the ShelfView3D / modal code-splitting pattern.
+const WorldMapChart = lazy(() => import('../components/charts/WorldMapChart'));
 
 // ── KPI Card ──────────────────────────────────────────────────────────────────
 function KPICard({ icon, label, value, sub, accentColor }) {
@@ -359,7 +363,9 @@ function Statistics() {
             {t('statistics.sections.collectionOrigins')}
             <span className="stats-card-title-note">{t('statistics.sections.lighterMoreBottles')}</span>
           </h2>
-          <WorldMapChart byCountry={byCountry} />
+          <Suspense fallback={null}>
+            <WorldMapChart byCountry={byCountry} />
+          </Suspense>
         </div>
 
         {/* Top Origins */}

--- a/frontend/src/pages/UserProfile.js
+++ b/frontend/src/pages/UserProfile.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -31,36 +31,45 @@ function UserProfile() {
 
   const isOwnProfile = currentUser?.id === userId;
 
+  // Latest-wins guard: the followers/following modal navigates to /users/:userId
+  // in place (route stays mounted), so switching profiles fires a new fetch while
+  // the old one may still be pending. Drop responses whose captured seq is stale.
+  const fetchSeq = useRef(0);
+
   useEffect(() => {
     // Reset stale state when navigating between profiles client-side,
     // otherwise a previously-errored view stays stuck.
+    const seq = ++fetchSeq.current;
     setLoading(true);
     setError(null);
-    fetchProfile();
-    fetchReviews(1, true);
+    fetchProfile(seq);
+    fetchReviews(1, true, seq);
   }, [userId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const fetchProfile = async () => {
+  const fetchProfile = async (seq) => {
     try {
       const res = await getPublicProfile(apiFetch, userId);
       const data = await res.json();
+      if (seq !== fetchSeq.current) return; // a newer profile load superseded this one
       if (res.ok) {
         setProfile(data.user);
       } else {
         setError(data.error || t('userProfile.failedLoad'));
       }
     } catch {
+      if (seq !== fetchSeq.current) return;
       setError(t('userProfile.failedLoad'));
     } finally {
-      setLoading(false);
+      if (seq === fetchSeq.current) setLoading(false);
     }
   };
 
-  const fetchReviews = async (p, replace = false) => {
+  const fetchReviews = async (p, replace = false, seq = fetchSeq.current) => {
     try {
       if (!replace) setLoadingMore(true);
       const res = await getUserReviews(apiFetch, userId, `page=${p}&limit=20`);
       const data = await res.json();
+      if (seq !== fetchSeq.current) return; // superseded by a newer profile load
       if (res.ok) {
         setReviews(prev => replace ? data.reviews : [...prev, ...data.reviews]);
         setReviewPage(p);
@@ -69,7 +78,7 @@ function UserProfile() {
     } catch {
       // silently fail for reviews
     } finally {
-      setLoadingMore(false);
+      if (seq === fetchSeq.current) setLoadingMore(false);
     }
   };
 

--- a/frontend/src/utils/currency.js
+++ b/frontend/src/utils/currency.js
@@ -1,16 +1,25 @@
 // Module-level frontend cache — avoids repeated API calls within the same session
 let ratesCache = null;
-let ratesFetchedAt = 0;
-const FRONTEND_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+let ratesFetchedAt = 0;   // time of the last SUCCESSFUL fetch
+let lastAttemptAt = 0;    // time of the last attempt (success or failure)
+const FRONTEND_CACHE_TTL = 60 * 60 * 1000; // 1 hour on success
+const FAILURE_BACKOFF = 5 * 60 * 1000;     // negative-cache window after a failure
 /**
  * Fetch USD-based exchange rates from open.er-api.com (CORS-enabled, free, no key).
  * Returns a rates object like { USD: 1, EUR: 0.92, SEK: 10.5, ... }
  * Returns null on error — callers should degrade gracefully.
  */
 export async function fetchRates() {
-  if (ratesCache && Date.now() - ratesFetchedAt < FRONTEND_CACHE_TTL) {
+  const now = Date.now();
+  if (ratesCache && now - ratesFetchedAt < FRONTEND_CACHE_TTL) {
     return ratesCache;
   }
+  // Negative caching: after a failed/stale attempt, wait out the backoff before
+  // hitting the (likely still-down) FX API again instead of retrying every call.
+  if (now - lastAttemptAt < FAILURE_BACKOFF) {
+    return ratesCache;
+  }
+  lastAttemptAt = now;
   try {
     const res = await fetch('https://open.er-api.com/v6/latest/USD');
     if (!res.ok) return ratesCache;

--- a/frontend/src/utils/downloadBlob.js
+++ b/frontend/src/utils/downloadBlob.js
@@ -8,6 +8,11 @@ export function downloadBlobObject(blob, filename) {
   const a = document.createElement('a');
   a.href = url;
   a.download = filename;
+  // Attach to the DOM before clicking (some browsers, notably Firefox, ignore
+  // click() on a detached anchor) and defer the revoke so the browser has
+  // finished reading the blob for large GDPR/cellar exports.
+  document.body.appendChild(a);
   a.click();
-  URL.revokeObjectURL(url);
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }


### PR DESCRIPTION
## Audit Batch 6 — Frontend correctness & backend performance

Sixth and final batch from the GRAND_AUDIT_2026-07-11. All **low-severity**. Mixed frontend + backend.

### Frontend correctness
- **UserProfile / DiscussionDetail** (LOW-7/8): added a latest-wins `fetchSeq` guard so an out-of-order response can't render a different user/thread than the URL points to — the same guard the other list/detail pages already use.
- **RatingDisplay** (LOW-9): the 5-star bar filled to the non-linear *normalized quality score* (a 3.0★ wine filled 50% = looked like 2.5★) instead of the star proportion. Now fills `(value/5)*100`, matching `RatingInput` and the number printed right beside it.
- **downloadBlob** (LOW-10): append the anchor to the DOM before `click()` and defer the `revokeObjectURL` by 1s, so large GDPR/cellar exports aren't truncated/aborted (and Firefox's detached-anchor quirk is avoided).
- **currency.fetchRates** (LOW-12): record the attempt time on failure + a 5-minute negative-cache window, so a down FX API isn't re-hit on every navigation.

### Frontend performance
- **WorldMapChart** (LOW-4): memoize `byCode`/`maxCount` and extract the ~177 `<Geography>` paths into a `React.memo` child, so hovering (which only updates the info bar) no longer re-renders the whole map.
- **Statistics** (LOW-5): `lazy()` + `Suspense` the WorldMapChart so `react-simple-maps` + the **108 KB world-atlas topojson** leave the route chunk — now its own ~206 KB async chunk (verified in the build).
- **NotificationContext** (LOW-6): debounce the `focus` + `visibilitychange` wake pair so returning to a tab fetches notifications **once**, not twice.

### Backend performance
- **cellars.js `/statistics`** (LOW-1): narrow the populate to `wineDefinition` `type` + `country.name` (drop the never-read `region` + `grapes` joins) and cap at 10k to match the sibling list/history routes.
- **maturityUtils.buildProfileMap** (LOW-2): replace the N-branch `$or` of exact `(wine, vintage)` pairs (thousands of clauses on a big maturity-sorted cellar) with one `wineDefinition: {$in}` query + in-memory pair filter — same index, one query.
- **drinkWindowNotifier** (LOW-3): batch the per-transition status updates into one `bulkWrite` (mirrors the first-run seed path) instead of N awaited `updateOne`.

### Also
- Removed a dead `user` binding in CellarHistory's outer component (INFO-1).

### Verification
- Frontend: `npx vite build` clean, **642 tests pass**; WorldMapChart confirmed split into its own async chunk.
- Backend: **1358 tests pass** (updated one `drinkWindowNotifier` assertion to read the new `bulkWrite` path).
- Docker: Statistics page lazy-loads the world map (**177 SVG paths render**) via the narrowed stats query; no page/JS errors.

### Not included
- LOW-2 (`journal_mention` dead-link) is deferred — needs a coordinated FE/BE change plus a product decision. ConsumeModal's try/finally (LOW-11) already shipped in Batch 4.

### Docker impact
Rebuild **frontend + backend** images. No compose or env changes.
