### PR TITLE
fix: drop dead journal_mention link + add phantom CSS-token build guard

### DIFF
--- a/backend/src/routes/journal.js
+++ b/backend/src/routes/journal.js
@@ -260,7 +260,10 @@ router.post('/', async (req, res) => {
             'journal_mention',
             'Journal Mention',
             `${senderName} mentioned you in a journal entry: "${populated.title || 'Untitled'}"`,
-            `/journal/${populated._id}`,
+            // No link: journal entries are private to their owner (there is no
+            // route or endpoint to view another user's entry), so a per-entry
+            // deep link would 404. Keep the notification informational-only.
+            null,
             undefined,
             req.user.id // actor — lets GDPR erasure remove this on the mentioner's deletion
           );

--- a/backend/src/routes/journal.refs.test.js
+++ b/backend/src/routes/journal.refs.test.js
@@ -346,7 +346,7 @@ describe('POST /api/journal response redaction (old rows / create echo)', () => 
     // Trailing args: category (undefined here) + actor (the mentioner) so GDPR
     // erasure can remove the notification on the mentioner's deletion.
     expect(createNotification).toHaveBeenCalledWith(
-      PRIVATE_USER, 'journal_mention', 'Journal Mention', expect.any(String), expect.any(String), undefined, expect.any(String)
+      PRIVATE_USER, 'journal_mention', 'Journal Mention', expect.any(String), null, undefined, expect.any(String)
     );
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,8 @@
   },
   "scripts": {
     "start": "vite",
+    "lint:tokens": "node scripts/check-css-tokens.mjs",
+    "prebuild": "node scripts/check-css-tokens.mjs",
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/frontend/scripts/check-css-tokens.mjs
+++ b/frontend/scripts/check-css-tokens.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Phantom design-token guard.
+ *
+ * Fails the build if any `var(--x)` references a custom property that is never
+ * defined anywhere in src/ — the class of bug fixed in audit Batch 3 (PR #689),
+ * where a parallel `--bg-secondary`/`--text-*`/`--accent` namespace was used but
+ * never declared, so those styles rendered transparent / broke in dark mode.
+ *
+ * A token counts as "defined" if it appears as:
+ *   - a CSS declaration            `--x: value;`
+ *   - a JS inline-style object key  `'--x': value` / `"--x": value`
+ * so runtime-set tokens (e.g. --cellar-color, --wlm-*) are correctly allowed.
+ *
+ * Runs as `prebuild`, so `npm run build` (and the Docker frontend image build)
+ * fails before shipping a phantom token. Run directly with `npm run lint:tokens`.
+ */
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+const EXTS = new Set(['.css', '.js', '.jsx', '.ts', '.tsx']);
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (EXTS.has(name.slice(name.lastIndexOf('.')))) out.push(p);
+  }
+  return out;
+}
+
+const files = walk(SRC);
+const defined = new Set();
+const used = new Map(); // token -> [{ file, line }]
+
+const RE_CSS_DEF = /(--[a-zA-Z0-9-]+)\s*:/g;        // --x: value
+const RE_JS_DEF = /['"](--[a-zA-Z0-9-]+)['"]\s*:/g; // '--x':  "--x":
+const RE_USE = /var\(\s*(--[a-zA-Z0-9-]+)/g;
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  for (const m of text.matchAll(RE_CSS_DEF)) defined.add(m[1]);
+  for (const m of text.matchAll(RE_JS_DEF)) defined.add(m[1]);
+  const lines = text.split('\n');
+  lines.forEach((line, i) => {
+    for (const m of line.matchAll(RE_USE)) {
+      if (!used.has(m[1])) used.set(m[1], []);
+      used.get(m[1]).push({ file, line: i + 1 });
+    }
+  });
+}
+
+const phantoms = [...used.keys()].filter(t => !defined.has(t)).sort();
+
+if (phantoms.length === 0) {
+  console.log(`✓ CSS token guard: ${used.size} custom properties used, all defined.`);
+  process.exit(0);
+}
+
+console.error(`\n✗ CSS token guard: ${phantoms.length} phantom token(s) used but never defined:\n`);
+for (const t of phantoms) {
+  const first = used.get(t)[0];
+  const rel = first.file.replace(/\\/g, '/').replace(/.*\/src\//, 'src/');
+  console.error(`  var(${t})  — e.g. ${rel}:${first.line}  (${used.get(t).length} use(s))`);
+}
+console.error(`\nUse a real token (--color-*/--radius-*/--shadow-*/--drink-*), or define it.\n`);
+process.exit(1);


### PR DESCRIPTION
## Audit follow-ups

Two remaining items from the GRAND_AUDIT_2026-07-11 follow-up list.

### 1. journal_mention dead link (code LOW-2)
`journal_mention` notifications linked to `/journal/:id`, but:
- there is **no `/journal/:id` frontend route** (only `/journal`, the owner's own list), and
- there is **no backend endpoint** to view another user's entry (`GET /api/journal` returns only the caller's own entries; entries are owner-private).

So the deep link always 404'd, and there's nothing to deep-link *to* without building a public journal-entry viewer (a feature with its own privacy design). Scoped fix: make the mention notification **informational-only** (`link = null`, non-clickable) instead of pointing at a page that can't exist. Test updated to expect the null link. A public journal-entry viewer remains possible future work.

### 2. Phantom CSS-token build guard (design MED-1 hardening)
`frontend/scripts/check-css-tokens.mjs` fails the build if any `var(--x)` references a custom property **never defined** in `src/` — the exact class of bug fixed in Batch 3 (#689), where a `--bg-secondary`/`--text-*`/`--accent` namespace was used but never declared and rendered transparent / broke in dark mode.

- A token is "defined" if declared as CSS `--x:` **or** a JS inline-style key `'--x':` — so runtime-set tokens (`--cellar-*`, `--wlm-*`) correctly pass.
- Wired as **`prebuild`**, so `npm run build` and the **Docker frontend image build** reject phantom tokens (real enforcement — the deploy needs a green build). Also `npm run lint:tokens`.
- Current tree: **117 tokens used, 0 phantom.** Verified it fails (exit 1) on an injected bogus token.

### Verification
- Backend **1358 tests pass**; frontend **642 tests pass**; `npm run build` runs the guard then builds clean.

### Docker impact
Frontend build gains a fast prebuild token check. No compose/env changes.
