### PR TITLE
chore(release): v1.80.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.79.1",
+  "version": "1.80.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.79.1",
+  "version": "1.80.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## v1.80.0 — Audit remediation release

Bumps frontend + backend to **1.80.0**. Ships the full GRAND_AUDIT_2026-07-11 remediation (PRs #687–#693), already merged to main:

- **#687** backend correctness & data-integrity
- **#688** security & GDPR (chat AI global cap, erasure PII scrub, CSP hardening)
- **#689** design-system CSS (phantom tokens, dark-mode badges, modal dedup)
- **#690** a11y & UX (Modal Escape, dialog semantics, keyboard nav, error feedback)
- **#691** i18n coverage (Settings GDPR/danger + 5 modals, en/sv)
- **#692** frontend correctness & backend performance
- **#693** journal_mention dead-link fix + phantom-token build guard

Full suites green (backend 1358, frontend 642). Frontend build now runs a phantom-token guard as a prebuild step.

Version-bump only — no functional change in this PR.
