### PR TITLE
fix(cellar-nav): show Overview on every cellar page

### DIFF
--- a/frontend/src/components/CellarNav.js
+++ b/frontend/src/components/CellarNav.js
@@ -8,16 +8,20 @@ import './CellarNav.css';
  * without going back through the cellar landing first. Grew out of the menu
  * cleanup: destinations live here, actions live in the ⋮ menu.
  *
- * `active`   — 'bottles' | 'racks' | 'room' | 'history' | 'book'
+ * `active`   — 'bottles' | 'overview' | 'racks' | 'room' | 'history' | 'book'
  * `children` — optional custom leading tabs; when present the built-in
- *              "Bottles" link is omitted (CellarDetail injects its in-page
- *              Bottles/Overview toggle instead).
+ *              Bottles + Overview links are omitted (CellarDetail injects its
+ *              in-page Bottles/Overview toggle instead). On every other cellar
+ *              page they render as links so Overview is reachable everywhere.
  */
 function CellarNav({ cellarId, active, children }) {
   const { t } = useTranslation();
 
   const views = [
-    ...(children ? [] : [{ key: 'bottles', to: `/cellars/${cellarId}`, label: t('cellarDetail.tabBottles') }]),
+    ...(children ? [] : [
+      { key: 'bottles', to: `/cellars/${cellarId}`, label: t('cellarDetail.tabBottles') },
+      { key: 'overview', to: `/cellars/${cellarId}?tab=overview`, label: t('cellarDetail.tabOverview') },
+    ]),
     { key: 'racks', to: `/cellars/${cellarId}/racks`, label: t('cellarDetail.racks') },
     { key: 'room', to: `/cellars/${cellarId}/room`, label: t('cellarDetail.roomView', 'Room View') },
     { key: 'history', to: `/cellars/${cellarId}/history`, label: t('cellarDetail.history') },

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -49,7 +49,11 @@ function CellarDetail() {
   const [showColorPicker, setShowColorPicker] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState('bottles');
+  // Initial tab honours a ?tab=overview deep link (the Overview tab in the
+  // shared CellarNav on the other cellar pages links here); after mount the
+  // param is cleared like the filter params below, and the in-page toggle takes
+  // over as local state.
+  const [activeTab, setActiveTab] = useState(() => searchParams.get('tab') === 'overview' ? 'overview' : 'bottles');
   const [showFilterModal, setShowFilterModal] = useState(false);
   const [filters, setFilters] = useState(() => ({
     search: searchParams.get('search') || '',
@@ -111,9 +115,9 @@ function CellarDetail() {
     return () => clearTimeout(searchTimer.current);
   }, [filters.search]);
 
-  // Clear URL search params after they've been read into filter state
+  // Clear URL search params after they've been read into filter/tab state
   useEffect(() => {
-    if (searchParams.has('search') || searchParams.has('vintage') || searchParams.has('minRating') || searchParams.has('sort') || searchParams.has('type') || searchParams.has('country') || searchParams.has('region') || searchParams.has('grapes') || searchParams.has('unplaced')) {
+    if (searchParams.has('search') || searchParams.has('vintage') || searchParams.has('minRating') || searchParams.has('sort') || searchParams.has('type') || searchParams.has('country') || searchParams.has('region') || searchParams.has('grapes') || searchParams.has('unplaced') || searchParams.has('tab')) {
       setSearchParams({}, { replace: true });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Show Overview on every cellar page

**Reported:** the "Overview" tab only appeared on the main cellar page, not on Racks / Room View / History / Cellar Book.

**Cause:** `CellarNav` (the shared view switcher) renders Bottles·Racks·Room·History·Book. CellarDetail injects an in-page **Bottles/Overview toggle** as `children`, so Overview lived only on the landing page as local state — the subpages showed no Overview.

**Fix** — make Overview a reachable destination on every cellar page:
- **CellarNav:** when a page doesn't inject its own leading tabs (the subpages), render an **Overview** link next to Bottles → `/cellars/:id?tab=overview`. Every cellar page now shows the identical strip: `Bottles · Overview · Racks · Room View · History · Cellar Book`.
- **CellarDetail:** initialise `activeTab` from `?tab=overview` so a link from another page lands on the Overview view, and clear the `tab` param on mount like the existing filter params (URL stays clean; the landing's in-page toggle keeps working as local state, so no full reload when toggling there).

**Verified in Docker:** Overview now present on Racks/Room/History/Book; clicking it from a subpage lands on the Overview hub and the URL cleans up to `/cellars/:id`. Build (phantom-token guard + vite) clean; **642 frontend tests pass**.

**Docker impact:** frontend-only — rebuild the frontend image. No compose/backend/env changes.
