### PR TITLE
feat(auth): GET /api/auth/whoami — read-scoped account identity for HA reauth

### DIFF
--- a/backend/src/middleware/apiTokenAuth.js
+++ b/backend/src/middleware/apiTokenAuth.js
@@ -25,7 +25,9 @@ const LAST_USED_THROTTLE_MS = 60 * 60 * 1000; // 1 hour
  *
  * Scopes (docs/ha-push-events.md §3; climate: docs/climate-monitoring.md):
  *   read    — the GETs the Home Assistant integration uses: stats, cellars,
- *             bottles, notifications, and the SSE event stream.
+ *             bottles, notifications, the SSE event stream, and /auth/whoami
+ *             (its own account id, for reauth same-account verification — id
+ *             only, no PII, unlike /auth/me).
  *   consume — POST /api/bottles/:id/consume only.
  *   climate — POST /api/climate/ingest only: the sensor-device credential.
  *             A leaked device token can post readings and nothing else.
@@ -37,6 +39,9 @@ const SCOPE_ALLOWLIST = {
     { method: 'GET', pattern: /^\/api\/bottles(\/|$)/ },
     { method: 'GET', pattern: /^\/api\/notifications(\/|$)/ },
     { method: 'GET', pattern: /^\/api\/events\/stream$/ },
+    // Exact match only — the caller's own account id (id, no PII). Anchored so
+    // it can never widen to /api/auth/me or any other /api/auth/* route.
+    { method: 'GET', pattern: /^\/api\/auth\/whoami$/ },
   ],
   consume: [
     { method: 'POST', pattern: /^\/api\/bottles\/[a-f0-9]{24}\/consume$/ },

--- a/backend/src/middleware/apiTokenAuth.test.js
+++ b/backend/src/middleware/apiTokenAuth.test.js
@@ -66,6 +66,7 @@ describe('isRequestAllowed (default-deny)', () => {
     ['GET', `/api/bottles/${oid}`],
     ['GET', '/api/notifications'],
     ['GET', '/api/events/stream'],
+    ['GET', '/api/auth/whoami'],
   ])('read scope allows %s %s', (method, path) => {
     expect(isRequestAllowed(READ, method, path)).toBe(true);
   });
@@ -80,10 +81,15 @@ describe('isRequestAllowed (default-deny)', () => {
     ['GET', '/api/users/me/export'],
     ['GET', '/api/tokens'],
     ['GET', '/api/admin/users'],
-    ['GET', '/api/auth/me'],
+    ['GET', '/api/auth/me'], // /whoami is allowed but /me (full user + PII) is NOT
     // A prefix that merely CONTAINS an allowed prefix
     ['GET', '/api/statsy'],
     ['GET', '/api/cellars-export'],
+    // whoami is exact-anchored: no other method, sibling, or sub-path leaks
+    ['POST', '/api/auth/whoami'],
+    ['GET', '/api/auth/whoami/extra'],
+    ['GET', '/api/auth/whoamix'],
+    ['GET', '/api/auth/logout'],
     // Writes are never granted by read
     ['POST', '/api/bottles'],
     ['DELETE', `/api/cellars/${oid}`],
@@ -141,6 +147,15 @@ describe('isRequestAllowed (default-deny)', () => {
     // And the other scopes never grant ingest.
     expect(isRequestAllowed(READ, 'POST', '/api/climate/ingest')).toBe(false);
     expect(isRequestAllowed(BOTH, 'POST', '/api/climate/ingest')).toBe(false);
+  });
+
+  test('GET /api/auth/whoami is granted ONLY by read (own account id for HA reauth)', () => {
+    expect(isRequestAllowed(READ, 'GET', '/api/auth/whoami')).toBe(true);
+    expect(isRequestAllowed(BOTH, 'GET', '/api/auth/whoami')).toBe(true); // read+consume
+    expect(isRequestAllowed(CONSUME, 'GET', '/api/auth/whoami')).toBe(false);
+    expect(isRequestAllowed(['climate'], 'GET', '/api/auth/whoami')).toBe(false);
+    // Never the wider /me even for read.
+    expect(isRequestAllowed(READ, 'GET', '/api/auth/me')).toBe(false);
   });
 });
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -589,6 +589,17 @@ router.post('/logout', requireAuth, async (req, res) => {
   }
 });
 
+// GET /api/auth/whoami — minimal stable identity for scoped integrations
+// (e.g. the Home Assistant integration verifying, on re-auth, that a new
+// credential belongs to the SAME account). Returns ONLY the account id — never
+// email/plan or any other PII — so a `read`-scoped API token can confirm which
+// account it belongs to without the wider exposure that /me carries. The id is
+// the stable, non-secret Mongo ObjectId (already sent to the frontend via
+// user.toJSON()). req.user.id is set on both auth paths (JWT and API token).
+router.get('/whoami', requireAuth, (req, res) => {
+  res.json({ id: req.user.id });
+});
+
 // GET /api/auth/me - Get current user (protected)
 router.get('/me', requireAuth, async (req, res) => {
   try {

--- a/backend/src/routes/auth.refresh.test.js
+++ b/backend/src/routes/auth.refresh.test.js
@@ -602,3 +602,20 @@ describe('POST /api/auth/reset-password', () => {
     expect(after.body).toEqual({ error: 'Invalid or expired refresh token' });
   });
 });
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/whoami — minimal stable identity for scoped integrations
+// ---------------------------------------------------------------------------
+describe('GET /api/auth/whoami', () => {
+  test('returns ONLY the account id for an authenticated session', async () => {
+    const res = await request({ method: 'GET', path: '/api/auth/whoami', bearer: tokenFor('user-abc') });
+    expect(res.status).toBe(200);
+    // No email/plan/roles — id and nothing else (HA reads data.id).
+    expect(res.body).toEqual({ id: 'user-abc' });
+  });
+
+  test('401 without a credential', async () => {
+    const res = await request({ method: 'GET', path: '/api/auth/whoami' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/docs/ha-push-events.md
+++ b/docs/ha-push-events.md
@@ -259,7 +259,7 @@ auth; JWT sessions implicitly have all scopes. Initial scopes:
 
 | Scope | Grants |
 |-------|--------|
-| `read` | all GETs the HA integration uses (stats, cellars, notifications, events stream) |
+| `read` | all GETs the HA integration uses (stats, cellars, notifications, events stream) + `GET /api/auth/whoami` (own account id, no PII — for reauth same-account verification) |
 | `consume` | `POST /api/bottles/:id/consume` only |
 
 **Management endpoints + settings UI**


### PR DESCRIPTION
## `GET /api/auth/whoami` — read-scoped account identity (for HA reauth)

**Requested by** the Home Assistant integration: on re-auth it verifies the new credential belongs to the **same account**, so it needs a stable account id it can read with a `read`-scoped token. Today the default-deny allowlist grants `read` only the wine-data GETs — none return the caller's id, and `/api/auth/me` is (correctly) not on the list — so a `cel_` token gets `403`.

### Approach — least-privilege (the HA team's recommended Option B)
Not the 1-line "allow `/me` for `read`", which would expose the owner's **email/plan** to a read token — against the `read = the caller's wine data only` posture the `TOKEN_EXCLUSIONS` comment is careful about.

- **New `GET /api/auth/whoami`** (`requireAuth`) returns **only** `{ id: req.user.id }` — no email/plan/roles/PII. `req.user.id` is set on both auth paths (JWT and API token), so no DB lookup.
- **`SCOPE_ALLOWLIST.read`** gains an **exact-anchored** entry `/^\/api\/auth\/whoami$/` — it can't widen to `/api/auth/me` or any other `/api/auth/*` route. `/me` stays denied for tokens.

The id is the stable, non-secret Mongo ObjectId already sent to the frontend via `user.toJSON()`. HA reads `data.id`.

### Tests
- `apiTokenAuth.test.js`: whoami allowed for `read` only (denied for `consume`/`climate`); `/me` + sibling/sub-paths (`/whoami/extra`, `/whoamix`, `POST /whoami`, `/logout`) + other methods stay denied.
- `auth.refresh.test.js`: route returns `{ id }` and 401 without auth.
- **Backend suite: 1366 pass.**
- **Verified live in Docker:** a `read` token gets `200 {id}` on `/whoami` and `403` on `/me`; the id matches the JWT's.

Docs `ha-push-events.md §3` updated.

### For the HA team
Endpoint is **`GET /api/auth/whoami`** → `{ "id": "<accountId>" }`. Point the integration at it in your next release (`data.id`). Until then it degrades gracefully.

### Docker impact
Backend-only (new route + allowlist entry) — rebuild the backend image. No compose/env changes.
