### PR TITLE
chore(release): v1.81.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.80.0",
+  "version": "1.81.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.80.0",
+  "version": "1.81.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## v1.81.0

Bumps frontend + backend to **1.81.0**. Contents since 1.80.0 (all merged to main):

- **#696** `feat(auth)`: `GET /api/auth/whoami` — a `read`-scoped account-identity endpoint (returns only `{ id }`, no PII) so the Home Assistant integration can verify same-account on re-auth. Least-privilege; `/me` stays denied for tokens.
- **#695** `fix(cellar-nav)`: show **Overview** on every cellar page (was only on the landing).
- **#669** `fix`: pass `data:` URLs through `getWineImageUrl` unchanged.

Suites green: backend 1366, frontend 647. Version-bump only.
