### PR TITLE
feat(demo): public ephemeral "try before you sign up" demo accounts

### DIFF
--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -60,6 +60,19 @@ const defaults = {
   // Default 30/hour bounds worst-case to ~7 GB/day per user — generous for
   // real use (a session of adding bottles rarely exceeds 30 uploads).
   imageUploadBurst: { max: 30, windowMs: 60 * 60 * 1000 },
+  // Ephemeral public-demo accounts (POST /api/auth/demo-login). Cloning a
+  // snapshot cellar per visitor is write-heavy, so this is bounded on three
+  // axes: per-IP creation rate, a DURABLE global ceiling on concurrent live
+  // demos (the real backstop — it survives restarts, unlike the in-memory
+  // per-IP limiter), and a short account lifetime the demoSweepJob enforces.
+  // Conservative defaults sized for a 4 GB VM: ~100 live demos × a small
+  // snapshot. All runtime-tunable by SuperAdmin.
+  demo: {
+    createMax:      3,                  // demo creations per IP per window
+    createWindowMs: 60 * 60 * 1000,     // 1 hour
+    globalMax:      100,                // max concurrent live demo accounts
+    ttlMs:          2 * 60 * 60 * 1000, // demo account lifetime (2 hours)
+  },
 };
 
 let cache = {
@@ -74,6 +87,7 @@ let cache = {
   aiImportPerRequestCap: { ...defaults.aiImportPerRequestCap },
   aiGlobalDailyCap: { ...defaults.aiGlobalDailyCap },
   imageUploadBurst: { ...defaults.imageUploadBurst },
+  demo: { ...defaults.demo },
 };
 
 async function load() {
@@ -115,6 +129,12 @@ async function load() {
         imageUploadBurst: {
           max:      doc.value.imageUploadBurst?.max      ?? defaults.imageUploadBurst.max,
           windowMs: doc.value.imageUploadBurst?.windowMs ?? defaults.imageUploadBurst.windowMs,
+        },
+        demo: {
+          createMax:      doc.value.demo?.createMax      ?? defaults.demo.createMax,
+          createWindowMs: doc.value.demo?.createWindowMs ?? defaults.demo.createWindowMs,
+          globalMax:      doc.value.demo?.globalMax      ?? defaults.demo.globalMax,
+          ttlMs:          doc.value.demo?.ttlMs          ?? defaults.demo.ttlMs,
         },
       };
     }

--- a/backend/src/data/demo-snapshot.json
+++ b/backend/src/data/demo-snapshot.json
@@ -1,0 +1,38 @@
+{
+  "schema": "cellarion-export@1",
+  "_placeholder": true,
+  "_note": "PLACEHOLDER demo snapshot. Replace with the scrubbed, registry-validated capture of the curated prod cellar (run scripts/validate-demo-snapshot.js before committing the real one). Wines here mirror backend/src/seed-demo.js so a seeded dev DB clones them; unresolved wines are skipped by the registry-safe demo clone, so an empty demo is harmless.",
+  "cellars": [
+    {
+      "cellarName": "Demo Cellar",
+      "description": "A sample cellar to explore Cellarion — add bottles, build racks, and browse drink windows. This demo resets automatically.",
+      "racks": [],
+      "layout": null,
+      "bottles": [
+        {
+          "wineName": "Château Margaux",
+          "producer": "Château Margaux",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Margaux",
+          "type": "red",
+          "grapes": ["Cabernet Sauvignon", "Merlot"],
+          "vintage": "2015",
+          "currency": "EUR",
+          "bottleSize": "750ml"
+        },
+        {
+          "wineName": "Sauvignon Blanc",
+          "producer": "Cloudy Bay",
+          "country": "New Zealand",
+          "region": "Marlborough",
+          "type": "white",
+          "grapes": ["Sauvignon Blanc"],
+          "vintage": "2022",
+          "currency": "NZD",
+          "bottleSize": "750ml"
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -23,6 +23,20 @@ const requireAuth = async (req, res, next) => {
     // Verify token
     const decoded = jwt.verify(token, process.env.JWT_SECRET, { algorithms: ['HS256'] });
 
+    // Demo access tokens are stateless 15-min JWTs, but the reaper HARD-DELETES
+    // the demo User the moment demoExpiresAt passes — leaving a window where a
+    // still-valid token outlives its account and could create orphan data on any
+    // creation route not covered by requireNonDemo (e.g. POST /api/cellars). For
+    // demo tokens ONLY (real users incur zero extra cost), confirm the account
+    // still exists; a reaped session cleanly 401s → the client logs out.
+    if (decoded.isDemo === true) {
+      const User = require('../models/User');
+      const stillLive = await User.exists({ _id: decoded.id, isDemo: true });
+      if (!stillLive) {
+        return res.status(401).json({ error: 'Demo session ended' });
+      }
+    }
+
     // Support old tokens that carry a single `role` string
     const roles = decoded.roles || (decoded.role ? [decoded.role] : ['user']);
 
@@ -36,6 +50,9 @@ const requireAuth = async (req, res, next) => {
       roles,
       plan: effectivePlan,
       planExpiresAt: decoded.planExpiresAt || null,
+      // Ephemeral public-demo accounts carry this claim so guard rails and the
+      // AI kill-switch can branch with zero DB cost. Absent on all real users.
+      isDemo: decoded.isDemo === true,
     };
 
     next();
@@ -106,6 +123,23 @@ const requireRole = (role) => {
 };
 
 /**
+ * Middleware that blocks ephemeral public-demo accounts (isDemo) from a route.
+ * Used to protect consequential/self-management actions a throwaway demo user
+ * must never reach — changing the password, deleting the account, and minting
+ * personal API tokens (a cel_ token would bypass the JWT and defeat the demo
+ * AI/guard gates). Real users are unaffected.
+ */
+const requireNonDemo = (req, res, next) => {
+  if (!req.user) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  if (req.user.isDemo) {
+    return res.status(403).json({ error: 'This action is not available in the demo. Create a free account to use it.' });
+  }
+  next();
+};
+
+/**
  * Middleware that allows both somm and admin roles.
  * Used to protect sommelier queue routes.
  */
@@ -150,6 +184,7 @@ module.exports = {
   requireAuth,
   optionalAuth,
   requireRole,
+  requireNonDemo,
   requireSommOrAdmin,
   requireModeratorOrAdmin,
   isModerator,

--- a/backend/src/middleware/auth.test.js
+++ b/backend/src/middleware/auth.test.js
@@ -3,7 +3,13 @@ const jwt = require('jsonwebtoken');
 // Use a fixed test secret so we can sign real tokens
 process.env.JWT_SECRET = 'test-secret';
 
-const { requireAuth, optionalAuth, requireRole, requireSommOrAdmin } = require('./auth');
+// requireAuth does a demo-session existence check (User.exists) for isDemo tokens
+// only; mock it so those paths are testable without a DB. Real-user tokens never
+// trigger the lookup, so the mock is inert for the rest of the suite.
+jest.mock('../models/User', () => ({ exists: jest.fn() }));
+const User = require('../models/User');
+
+const { requireAuth, optionalAuth, requireRole, requireNonDemo, requireSommOrAdmin } = require('./auth');
 
 // ─── Helpers ────────────────────────────────────────��────────────────────────
 
@@ -311,5 +317,94 @@ describe('requireSommOrAdmin', () => {
     requireSommOrAdmin(req, res, next);
 
     expect(next).toHaveBeenCalled();
+  });
+});
+
+// ─── requireNonDemo ───────────────────────────────────────────────────────────
+
+describe('requireNonDemo', () => {
+  test('401 when unauthenticated', () => {
+    const req = {};
+    const res = makeRes();
+    const next = jest.fn();
+
+    requireNonDemo(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('403 for a demo account', () => {
+    const req = { user: { id: 'u1', isDemo: true } };
+    const res = makeRes();
+    const next = jest.fn();
+
+    requireNonDemo(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('calls next for a normal (non-demo) user', () => {
+    const req = { user: { id: 'u1', isDemo: false } };
+    const res = makeRes();
+    const next = jest.fn();
+
+    requireNonDemo(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('calls next when isDemo is absent (defensive)', () => {
+    const req = { user: { id: 'u1' } };
+    const res = makeRes();
+    const next = jest.fn();
+
+    requireNonDemo(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+// ─── requireAuth — demo session existence check ───────────────────────────────
+
+describe('requireAuth demo-session existence check', () => {
+  test('demo token passes and attaches isDemo when the account still exists', async () => {
+    User.exists.mockResolvedValue({ _id: 'u1' });
+    const req = makeReq({ headers: { authorization: `Bearer ${signToken({ id: 'u1', roles: ['user'], isDemo: true })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await requireAuth(req, res, next);
+
+    expect(User.exists).toHaveBeenCalledWith({ _id: 'u1', isDemo: true });
+    expect(next).toHaveBeenCalled();
+    expect(req.user.isDemo).toBe(true);
+  });
+
+  test('401 when the demo account has been reaped (zombie token)', async () => {
+    User.exists.mockResolvedValue(null);
+    const req = makeReq({ headers: { authorization: `Bearer ${signToken({ id: 'u1', roles: ['user'], isDemo: true })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('a normal (non-demo) token never triggers the existence lookup', async () => {
+    User.exists.mockClear();
+    const req = makeReq({ headers: { authorization: `Bearer ${signToken({ id: 'u1', roles: ['user'] })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await requireAuth(req, res, next);
+
+    expect(User.exists).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+    expect(req.user.isDemo).toBe(false);
   });
 });

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -306,6 +306,22 @@ const userSchema = new mongoose.Schema({
   lastImageExportAt: {
     type: Date,
     default: null
+  },
+  // ─── Ephemeral public demo accounts ──────────────────────────────────────
+  // A demo account is a throwaway, auto-expiring user created by
+  // POST /api/auth/demo-login so anonymous visitors can try Cellarion with a
+  // fully-populated (cloned) cellar without signing up. `isDemo` gates a set of
+  // server-side guard rails (no password/account changes, no API tokens, no AI
+  // spend) and `demoExpiresAt` drives the demoSweepJob reaper, which fully
+  // erases the user + every cloned document via purgeUserData once the window
+  // passes. Never granted the somm/admin role; never mailed (unroutable address).
+  isDemo: {
+    type: Boolean,
+    default: false
+  },
+  demoExpiresAt: {
+    type: Date,
+    default: null
   }
 });
 
@@ -318,6 +334,11 @@ userSchema.index({ refreshTokenHash: 1 }, { sparse: true });
 // SSO login resolves the account by (provider, provider's user id) on every
 // federated sign-in — index it so that lookup isn't a full collection scan.
 userSchema.index({ 'authProviders.provider': 1, 'authProviders.providerId': 1 });
+// The demoSweepJob reaper queries { isDemo: true, demoExpiresAt: { $lte: now } }
+// every ~15 min, and demo-login counts live demos ({ isDemo: true }) to enforce
+// the global concurrency ceiling. A partial index keyed to demo rows keeps both
+// cheap and stays empty (zero bytes) for the overwhelming majority of real users.
+userSchema.index({ demoExpiresAt: 1 }, { partialFilterExpression: { isDemo: true } });
 
 // Heal legacy notification-pref shapes before save. Old docs stored
 // `drinkWindow: false` (single boolean); the current schema expects
@@ -356,10 +377,24 @@ userSchema.pre('save', function(next) {
   next();
 });
 
+// Non-login sentinel stored as the password for ephemeral demo accounts: it is
+// not a valid bcrypt hash, so comparePassword always returns false — a demo can
+// never password-login (it authenticates by JWT only, on an unroutable address).
+const DEMO_PASSWORD_SENTINEL = '!demo-no-login!';
+
 // Hash password before saving
 userSchema.pre('save', async function(next) {
   // Only hash if password is modified or new
   if (!this.isModified('password')) {
+    return next();
+  }
+
+  // Ephemeral demo accounts skip the expensive bcrypt hash entirely: they never
+  // password-login, and under a burst of demo-logins N parallel cost-12 hashes
+  // on the single Node thread would degrade latency for everyone. Store the
+  // non-login sentinel instead.
+  if (this.isDemo) {
+    this.password = DEMO_PASSWORD_SENTINEL;
     return next();
   }
 
@@ -465,6 +500,10 @@ userSchema.methods.toJSON = function() {
   // review and acknowledge the update. Derived, never stored.
   const pp = obj.gdprConsent?.privacyPolicy;
   obj.requiresPolicyReconsent = !pp?.accepted || (pp?.version || null) !== CURRENT_PRIVACY_POLICY_VERSION;
+  // Surface the demo flag as a clean boolean so the frontend can show the
+  // persistent "demo resets" banner and hide restricted actions. demoExpiresAt
+  // rides along on obj (null for real users) so the banner can show a countdown.
+  obj.isDemo = !!obj.isDemo;
   return obj;
 };
 

--- a/backend/src/routes/admin/settings.js
+++ b/backend/src/routes/admin/settings.js
@@ -34,7 +34,7 @@ router.get('/rate-limits', async (req, res) => {
 // accountLockout.threshold to 9999 effectively turns lockout off).
 router.patch('/rate-limits', async (req, res) => {
   try {
-    const { api, write, auth, accountLockout, chatBurst, chatConcurrentStreams, aiDailyBudget, aiImportPerRequestCap, aiGlobalDailyCap } = req.body;
+    const { api, write, auth, accountLockout, chatBurst, chatConcurrentStreams, aiDailyBudget, aiImportPerRequestCap, aiGlobalDailyCap, demo } = req.body;
 
     const previous = { ...rateLimitsConfig.get() };
 
@@ -90,6 +90,17 @@ router.patch('/rate-limits', async (req, res) => {
       requireIntInRange('aiGlobalDailyCap.max', aiGlobalDailyCap.max, 0, 10_000_000);
     }
 
+    // Ephemeral public-demo accounts. globalMax=0 is the demo kill-switch
+    // (demo-login always 429s), so the lower bound is 0. ttlMs floor of 5 min
+    // keeps the reaper meaningful; createWindowMs floor of 1 min matches the
+    // other burst windows.
+    if (demo !== undefined) {
+      requireIntInRange('demo.createMax',      demo.createMax,      1,       1000);
+      requireIntInRange('demo.createWindowMs', demo.createWindowMs, 60_000,  24 * 60 * 60 * 1000);
+      requireIntInRange('demo.globalMax',      demo.globalMax,      0,       100_000);
+      requireIntInRange('demo.ttlMs',          demo.ttlMs,          5 * 60_000, 24 * 60 * 60 * 1000);
+    }
+
     if (errors.length > 0) {
       return res.status(400).json({ error: errors[0], errors });
     }
@@ -123,6 +134,12 @@ router.patch('/rate-limits', async (req, res) => {
       },
       aiGlobalDailyCap: {
         max: aiGlobalDailyCap?.max ?? previous.aiGlobalDailyCap?.max ?? rateLimitsConfig.defaults.aiGlobalDailyCap.max,
+      },
+      demo: {
+        createMax:      demo?.createMax      ?? previous.demo?.createMax      ?? rateLimitsConfig.defaults.demo.createMax,
+        createWindowMs: demo?.createWindowMs ?? previous.demo?.createWindowMs ?? rateLimitsConfig.defaults.demo.createWindowMs,
+        globalMax:      demo?.globalMax      ?? previous.demo?.globalMax      ?? rateLimitsConfig.defaults.demo.globalMax,
+        ttlMs:          demo?.ttlMs          ?? previous.demo?.ttlMs          ?? rateLimitsConfig.defaults.demo.ttlMs,
       },
     };
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -3,7 +3,7 @@ const crypto = require('crypto');
 const bcrypt = require('bcryptjs');
 const rateLimit = require('express-rate-limit');
 const User = require('../models/User');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { checkIsSuperAdmin } = require('../middleware/superAdmin');
 const { logAudit } = require('../services/audit');
 const eventBus = require('../services/eventBus');
@@ -17,6 +17,7 @@ const { rateLimitKey } = require('../utils/clientIp');
 // (routes/oauth.js) share one implementation.
 const { issueTokens, clearRefreshCookie } = require('../services/authTokens');
 const { resolvePendingShares } = require('../services/pendingShares');
+const { createDemoAccountWithinCeiling } = require('../services/demoAccount');
 
 const router = express.Router();
 
@@ -65,6 +66,23 @@ const resendLimiter = rateLimit({
   legacyHeaders: false,
   handler: (req, res) => {
     res.status(429).json({ error: 'Too many resend attempts, please try again later' });
+  }
+});
+
+// Ephemeral public-demo creation limiter — default 3/hour per IP (admin-tunable
+// max). Cloning a snapshot cellar per visitor is write-heavy, so this per-IP cap
+// is tighter than authLimiter. windowMs is fixed at limiter-build time (like
+// authLimiter); the durable global ceiling in the handler is the real backstop,
+// since this in-memory limiter resets on every backend restart.
+const demoLimiter = rateLimit({
+  windowMs: rateLimitsConfig.defaults.demo.createWindowMs,
+  max: () => rateLimitsConfig.get().demo.createMax,
+  keyGenerator: (req) => rateLimitKey(req),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'demo', limit: rateLimitsConfig.get().demo.createMax });
+    res.status(429).json({ error: 'Too many demo sessions from this network. Please try again later, or create a free account.' });
   }
 });
 
@@ -158,6 +176,41 @@ router.post('/register', authLimiter, async (req, res) => {
     }
     console.error('Registration error:', error);
     res.status(500).json({ error: 'Registration failed' });
+  }
+});
+
+// POST /api/auth/demo-login - Create an ephemeral, auto-expiring demo account
+// (no signup) and clone a populated sample cellar into it so an anonymous
+// visitor can try Cellarion. The account is heavily guarded elsewhere: no AI
+// spend, no password/account changes, no API-token minting (requireNonDemo +
+// isDemo short-circuits), and it is fully erased by the demoSweepJob reaper once
+// demoExpiresAt passes. Volume is bounded by demoLimiter (per-IP) plus a durable
+// global ceiling (demo.globalMax; set to 0 to disable demos entirely).
+router.post('/demo-login', demoLimiter, async (req, res) => {
+  try {
+    // Durable global ceiling — the real backstop against DB-bloat abuse, since
+    // the in-memory per-IP limiter resets on restart. The count-check and the
+    // insert are serialized into one atomic critical section (demoAccount) so a
+    // concurrent burst can't overshoot the ceiling. null = at/over capacity
+    // (demo.globalMax; 0 → always → demo kill-switch).
+    const user = await createDemoAccountWithinCeiling();
+    if (!user) {
+      return res.status(429).json({ error: 'The live demo is at capacity right now. Please try again shortly, or create a free account.' });
+    }
+
+    // Bound the session to the demo TTL: set the refresh-token deadline to the
+    // account's expiry and PRESERVE it through issueTokens (no 30-day default),
+    // with a session cookie (rememberMe:false). A page reload refreshes within
+    // the window; once the account is reaped, /refresh 401s cleanly.
+    user.refreshTokenExpiresAt = user.demoExpiresAt;
+    const accessToken = await issueTokens(user, res, { preserveLifetime: true, rememberMe: false });
+
+    logAudit(req, 'auth.demo_login', { type: 'user', id: user._id }, { expiresAt: user.demoExpiresAt });
+
+    res.status(201).json({ token: accessToken, user: user.toJSON() });
+  } catch (error) {
+    console.error('Demo login error:', error);
+    res.status(500).json({ error: 'Could not start a demo session. Please try again.' });
   }
 });
 
@@ -402,7 +455,7 @@ router.post('/refresh', refreshLimiter, async (req, res) => {
 });
 
 // POST /api/auth/change-password - Change password while authenticated
-router.post('/change-password', requireAuth, authLimiter, async (req, res) => {
+router.post('/change-password', requireAuth, requireNonDemo, authLimiter, async (req, res) => {
   const { currentPassword, newPassword } = req.body;
 
   if (!currentPassword || !newPassword) {

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { requireBottleAccess } = require('../middleware/bottleAccess');
 const Bottle = require('../models/Bottle');
 const Cellar = require('../models/Cellar');
@@ -344,8 +344,13 @@ router.get('/', async (req, res) => {
   }
 });
 
-// POST /api/bottles - Add bottle to cellar (owner or editor)
-router.post('/', async (req, res) => {
+// POST /api/bottles - Add bottle to cellar (owner or editor).
+// requireNonDemo: adding a bottle is intentionally NOT available in the demo.
+// The real add-bottle experience leans on AI (label scan / identify), which is
+// disabled for demo accounts, so rather than offer a lesser AI-free add we keep
+// the demo an explore-and-interact experience on the pre-populated cellar
+// (consume, pour, move, arrange, edit, browse). "Sign up to add your bottles."
+router.post('/', requireNonDemo, async (req, res) => {
   try {
     const {
       cellar,
@@ -509,6 +514,8 @@ router.post('/', async (req, res) => {
     // new wine the user just created), generate one — which also re-embeds the
     // wine so Qdrant carries the taste data. No-op if already enriched / a batch
     // enrichment job is running / AI isn't configured.
+    // (Demo accounts never reach this route — requireNonDemo blocks bottle-add —
+    // so no demo AI/Voyage spend occurs here.)
     enrichWineById(wineDefinition, { budgetUserId: req.user.id }).catch(() => {});
 
     // Fire-and-forget: auto-resolve any restock alerts for this wine
@@ -732,7 +739,10 @@ router.put('/:id', requireBottleAccess('editor'), async (req, res) => {
 
     // If vintage changed, the old (wine, oldVintage) embedding is still in Qdrant
     // but won't match this bottle anymore (user changed the year). Embed the new pair.
-    if (changes.vintage) {
+    // Skipped for demo accounts: a novel year misses the embedding cache and would
+    // fire a paid Voyage call, and a demo's ephemeral edits never need Qdrant
+    // coverage — keeps demo AI/Voyage spend at exactly zero.
+    if (changes.vintage && !req.user.isDemo) {
       embedSinglePair(bottle.wineDefinition._id || bottle.wineDefinition, bottle.vintage).catch(err => console.error('Failed to embed wine-vintage pair after vintage update:', err.message));
     }
 
@@ -875,8 +885,11 @@ router.post('/:id/consume', requireBottleAccess('editor'), async (req, res) => {
       { reason }
     );
 
-    // Fire-and-forget: check if user needs a restock alert (paid plans only)
-    if (reason === 'drank') {
+    // Fire-and-forget: check if user needs a restock alert. Skipped for demo
+    // accounts: on an un-cached (wine, vintage) pair checkRestockGap fires a paid
+    // Voyage embedding call (no budget gate of its own), which would breach the
+    // demo's "zero AI spend" guarantee.
+    if (reason === 'drank' && !req.user.isDemo) {
       checkRestockGap(req.user.id, bottle._id, bottle.cellar).catch(() => {});
     }
 

--- a/backend/src/routes/cellarImport.js
+++ b/backend/src/routes/cellarImport.js
@@ -12,7 +12,7 @@
 const express = require('express');
 const multer = require('multer');
 const yauzl = require('yauzl');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const User = require('../models/User');
 const Cellar = require('../models/Cellar');
 const { logAudit } = require('../services/audit');
@@ -23,7 +23,11 @@ const {
 } = require('../services/cellarImport');
 
 const router = express.Router();
-router.use(requireAuth);
+// requireNonDemo: importing a file into a demo would re-create registry wines
+// verbatim (the known cellar-import registry-pollution vector), drive heavy DB
+// work, and — for the CT path — spend AI. Demo users can't import; "sign up to
+// import your collection".
+router.use(requireAuth, requireNonDemo);
 
 // The ZIP can hold many images; cap generously but bound memory (entries are
 // buffered). A data-only JSON is tiny; the cap mainly guards the image ZIP.

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const Cellar = require('../models/Cellar');
 const Bottle = require('../models/Bottle');
 const Rack = require('../models/Rack');
@@ -1476,7 +1476,10 @@ router.delete('/:id', async (req, res) => {
 });
 
 // POST /api/cellars/:id/members - Add a member (owner only)
-router.post('/:id/members', async (req, res) => {
+// requireNonDemo: inviting a member sends an email to an arbitrary address — an
+// outbound-email/PII spam vector a throwaway demo must not have. A demo user can
+// explore a populated cellar but can't invite others to it.
+router.post('/:id/members', requireNonDemo, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
     const { email, role } = req.body;

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -77,6 +77,12 @@ async function getChatUsage(userId) {
  * or sends an error response and returns null.
  */
 async function validateAndCheckLimit(req, res) {
+  // Ephemeral demo accounts get no AI — block chat before reserving any per-user
+  // quota (ChatUsage) or touching the shared global cap / Anthropic.
+  if (req.user?.isDemo) {
+    res.status(403).json({ error: 'Cellar Chat is not available in the demo. Create a free account to use it.', code: 'demo_ai_disabled' });
+    return null;
+  }
   const cfg = aiConfig.get();
   if (!cfg.chatEnabled) {
     res.status(503).json({ error: 'Cellar Chat is currently disabled.' });

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
-const { requireAuth, optionalAuth, requireModeratorOrAdmin, isModerator } = require('../middleware/auth');
+const { requireAuth, requireNonDemo, optionalAuth, requireModeratorOrAdmin, isModerator } = require('../middleware/auth');
 const Discussion = require('../models/Discussion');
 const { CATEGORIES } = require('../models/Discussion');
 const DiscussionReply = require('../models/DiscussionReply');
@@ -405,7 +405,7 @@ router.get('/:idOrSlug', optionalAuth, async (req, res) => {
 });
 
 // POST /api/discussions - Create a discussion
-router.post('/', requireAuth, async (req, res) => {
+router.post('/', requireAuth, requireNonDemo, async (req, res) => {
   try {
     if (await checkDiscussionBan(req, res)) return;
 
@@ -662,7 +662,7 @@ router.get('/:idOrSlug/replies', optionalAuth, async (req, res) => {
 });
 
 // POST /api/discussions/:idOrSlug/replies - Create a reply
-router.post('/:idOrSlug/replies', requireAuth, async (req, res) => {
+router.post('/:idOrSlug/replies', requireAuth, requireNonDemo, async (req, res) => {
   try {
     if (await checkDiscussionBan(req, res)) return;
 
@@ -991,7 +991,7 @@ router.get('/:discussionId/replies/:replyId/original', requireAuth, requireModer
 //
 // Self-reactions are allowed (Slack/Discord/GitHub all do this — letting an
 // author 🥂 their own answer is a normal interaction).
-router.post('/:discussionId/replies/:replyId/reactions', requireAuth, async (req, res) => {
+router.post('/:discussionId/replies/:replyId/reactions', requireAuth, requireNonDemo, async (req, res) => {
   try {
     if (!isValidId(req.params.replyId)) return res.status(400).json({ error: 'Invalid reply ID' });
     const { kind } = req.body || {};
@@ -1167,7 +1167,7 @@ router.patch('/:idOrSlug/move', requireAuth, requireModeratorOrAdmin, async (req
 // ─── Reporting ──────────────────────────────────────────────────────────────
 
 // POST /api/discussions/:idOrSlug/report - Report a discussion
-router.post('/:idOrSlug/report', requireAuth, async (req, res) => {
+router.post('/:idOrSlug/report', requireAuth, requireNonDemo, async (req, res) => {
   try {
     const discussion = await findDiscussionByIdOrSlug(req.params.idOrSlug);
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
@@ -1196,7 +1196,7 @@ router.post('/:idOrSlug/report', requireAuth, async (req, res) => {
 });
 
 // POST /api/discussions/:discussionId/replies/:replyId/report - Report a reply
-router.post('/:discussionId/replies/:replyId/report', requireAuth, async (req, res) => {
+router.post('/:discussionId/replies/:replyId/report', requireAuth, requireNonDemo, async (req, res) => {
   try {
     if (!isValidId(req.params.replyId)) return res.status(400).json({ error: 'Invalid reply ID' });
 

--- a/backend/src/routes/follows.js
+++ b/backend/src/routes/follows.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const Follow = require('../models/Follow');
 const User = require('../models/User');
 const Notification = require('../models/Notification');
@@ -12,7 +12,9 @@ const router = express.Router();
 router.use(requireAuth);
 
 // POST /api/follows/:userId - Follow a user
-router.post('/:userId', async (req, res) => {
+// requireNonDemo: following notifies a real user, from an account that then
+// vanishes — notification spam. Demo accounts don't create follow relationships.
+router.post('/:userId', requireNonDemo, async (req, res) => {
   try {
     const targetId = req.params.userId;
     if (!isValidId(targetId)) return res.status(400).json({ error: 'Invalid user ID' });

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -3,7 +3,7 @@ const express = require('express');
 const fs = require('fs');
 const mongoose = require('mongoose');
 const rateLimit = require('express-rate-limit');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { upload, ORIGINALS_DIR } = require('../config/upload');
 const BottleImage = require('../models/BottleImage');
 const Bottle = require('../models/Bottle');
@@ -170,7 +170,10 @@ function handleImageUpload(req, res, next) {
 }
 
 // POST /api/images/upload - Upload image for a bottle or wine definition
-router.post('/upload', requireAuth, imageUploadLimiter, handleImageUpload, async (req, res) => {
+// requireNonDemo: image upload writes a 10 MB original to disk and spawns a
+// rembg background-removal job (memory-heavy, shared with real users' label
+// scans). The demo is JSON-only / zero-compute by design, so uploads are off.
+router.post('/upload', requireAuth, requireNonDemo, imageUploadLimiter, handleImageUpload, async (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'No image file provided' });
@@ -416,7 +419,7 @@ router.get('/:id', requireAuth, async (req, res) => {
 });
 
 // POST /api/images/remove-bg-preview - Remove background from a base64 image (no DB storage)
-router.post('/remove-bg-preview', requireAuth, bgRemovalLimiter, async (req, res) => {
+router.post('/remove-bg-preview', requireAuth, requireNonDemo, bgRemovalLimiter, async (req, res) => {
   try {
     const { image } = req.body;
     if (!image || typeof image !== 'string') {
@@ -517,7 +520,7 @@ router.post('/link-to-bottle', requireAuth, async (req, res) => {
 });
 
 // POST /api/images/:id/retry - Retry background removal
-router.post('/:id/retry', requireAuth, async (req, res) => {
+router.post('/:id/retry', requireAuth, requireNonDemo, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
 

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const aiBurstLimiter = require('../middleware/aiBurstLimiter');
 const Bottle = require('../models/Bottle');
 const Cellar = require('../models/Cellar');
@@ -41,7 +41,9 @@ const WineRequest = require('../models/WineRequest');
 const ImportSession = require('../models/ImportSession');
 
 const router = express.Router();
-router.use(requireAuth);
+// requireNonDemo: the CT/CSV importer spends AI on identify and creates registry
+// wines; a throwaway demo must do neither. Demo users can't bulk-import.
+router.use(requireAuth, requireNonDemo);
 
 // Aliases for readability (imported from config/constants.js)
 const EXACT_THRESHOLD = IMPORT_EXACT_THRESHOLD;
@@ -318,7 +320,7 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
           pr.aiSkipped = true;
           return AI_SKIPPED;
         }
-        const debit = await tryDebitAi(req.user.id);
+        const debit = await tryDebitAi(req.user.id, { isDemo: req.user.isDemo });
         if (!debit.ok) {
           aiBudgetExhausted = true;
           pr.aiSkipped = true;

--- a/backend/src/routes/journal.js
+++ b/backend/src/routes/journal.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const JournalEntry = require('../models/JournalEntry');
 const Bottle = require('../models/Bottle');
 const User = require('../models/User');
@@ -229,7 +229,10 @@ router.get('/', async (req, res) => {
 });
 
 // POST /api/journal — create a new entry
-router.post('/', async (req, res) => {
+// requireNonDemo: a public journal entry can tag real users, firing
+// journal_mention notifications to them from an account that then vanishes —
+// notification spam (same class the follows route guards against).
+router.post('/', requireNonDemo, async (req, res) => {
   try {
     const clean = sanitizeEntry(req.body);
 

--- a/backend/src/routes/recommendations.js
+++ b/backend/src/routes/recommendations.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const Recommendation = require('../models/Recommendation');
 const WineDefinition = require('../models/WineDefinition');
 const User = require('../models/User');
@@ -68,7 +68,9 @@ router.get('/sent', async (req, res) => {
 });
 
 // POST /api/recommendations — send a recommendation
-router.post('/', async (req, res) => {
+// requireNonDemo: this sends an email to a third-party recipient — an outbound-
+// email abuse vector a throwaway demo account must not have.
+router.post('/', requireNonDemo, async (req, res) => {
   try {
     const { wineId, recipientId, recipientEmail, note } = req.body;
 

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const Review = require('../models/Review');
 const ReviewVote = require('../models/ReviewVote');
 const WineDefinition = require('../models/WineDefinition');
@@ -37,7 +37,10 @@ function sanitizeTasting(tasting) {
 }
 
 // POST /api/reviews - Create a review
-router.post('/', async (req, res) => {
+// requireNonDemo: public reviews on shared registry wines persist after the demo
+// account is reaped (anonymised, not erased) — a spam vector. Demo users rate
+// their own bottles instead.
+router.post('/', requireNonDemo, async (req, res) => {
   try {
     const { wineDefinition, bottle, vintage, rating, ratingScale, tasting, visibility } = req.body;
 
@@ -416,7 +419,7 @@ router.delete('/:id', async (req, res) => {
 });
 
 // POST /api/reviews/:id/like - Toggle like
-router.post('/:id/like', async (req, res) => {
+router.post('/:id/like', requireNonDemo, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid review ID' });
     const review = await Review.findById(req.params.id);

--- a/backend/src/routes/support.js
+++ b/backend/src/routes/support.js
@@ -1,14 +1,16 @@
 const express = require('express');
 const router = express.Router();
 const SupportTicket = require('../models/SupportTicket');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const { stripHtml } = require('../utils/sanitize');
 
 const VALID_CATEGORIES = ['bug', 'help', 'feature', 'other'];
 
 // POST /api/support — submit a support ticket
-router.post('/', requireAuth, async (req, res) => {
+// requireNonDemo: support tickets land in the admin queue and would waste admin
+// attention on a throwaway account that's gone before anyone replies.
+router.post('/', requireAuth, requireNonDemo, async (req, res) => {
   try {
     const { category, subject, message } = req.body;
 

--- a/backend/src/routes/tokens.js
+++ b/backend/src/routes/tokens.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const ApiToken = require('../models/ApiToken');
 const User = require('../models/User');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const eventBus = require('../services/eventBus');
 const { passwordConfirmLimiter } = require('../middleware/passwordConfirmLimiter');
@@ -24,8 +24,11 @@ const USER_MINTABLE_SCOPES = TOKEN_SCOPES.filter(s => s !== 'climate');
 // (middleware/apiTokenAuth.js), so a token can never create, list, or revoke
 // tokens — management is a logged-in-session (JWT) capability only.
 
-// POST /api/tokens — create a personal API token (plaintext shown ONCE)
-router.post('/', requireAuth, authLimiter, async (req, res) => {
+// POST /api/tokens — create a personal API token (plaintext shown ONCE).
+// requireNonDemo: a cel_ token authenticates via apiTokenAuth (bypassing the JWT),
+// so it carries no isDemo claim — a demo user minting one would defeat the demo
+// AI/guard gates. Token creation is off-limits to demo accounts entirely.
+router.post('/', requireAuth, requireNonDemo, authLimiter, async (req, res) => {
   const { name, scopes, password } = req.body;
 
   if (!name || typeof name !== 'string' || !name.trim() || name.trim().length > 100) {

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -33,7 +33,7 @@ const WineReport = require('../models/WineReport');
 const WishlistItem = require('../models/WishlistItem');
 const PriceTrackingRequest = require('../models/PriceTrackingRequest');
 const PriceTrackingSkip = require('../models/PriceTrackingSkip');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { buildUserExport } = require('../services/userDataRegistry');
 const { buildCellarDataExport, EXPORT_README } = require('../services/cellarExport');
 const { safeUploadPath } = require('../services/imageProcessor');
@@ -564,8 +564,10 @@ router.get('/me/export-summary', requireAuth, async (req, res) => {
   }
 });
 
-// DELETE /api/users/me — schedule account deletion (7-day cooling-off period)
-router.delete('/me', requireAuth, async (req, res) => {
+// DELETE /api/users/me — schedule account deletion (7-day cooling-off period).
+// requireNonDemo: demo accounts are throwaway and auto-expire via the reaper;
+// the cooling-off deletion flow (and its email) makes no sense for them.
+router.delete('/me', requireAuth, requireNonDemo, async (req, res) => {
   const userId = req.user.id;
   try {
     const user = await User.findById(userId);

--- a/backend/src/routes/wineReports.js
+++ b/backend/src/routes/wineReports.js
@@ -3,14 +3,16 @@ const router = express.Router();
 const mongoose = require('mongoose');
 const WineReport = require('../models/WineReport');
 const WineDefinition = require('../models/WineDefinition');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const { stripHtml } = require('../utils/sanitize');
 
 const VALID_REASONS = ['wrong_info', 'duplicate', 'inappropriate', 'wrong_price', 'wrong_tasting_profile', 'other'];
 
 // POST /api/wine-reports — report a wine
-router.post('/', requireAuth, async (req, res) => {
+// requireNonDemo: wine reports enter the admin moderation queue — demo accounts
+// must not spam it (same class as the guarded wine-requests route).
+router.post('/', requireAuth, requireNonDemo, async (req, res) => {
   try {
     const { wineDefinitionId, reason, details, duplicateOfId } = req.body;
 

--- a/backend/src/routes/wineRequests.js
+++ b/backend/src/routes/wineRequests.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const WineRequest = require('../models/WineRequest');
 const WineDefinition = require('../models/WineDefinition');
@@ -27,7 +27,9 @@ function validateUrl(url) {
 }
 
 // POST /api/wine-requests - Submit wine request (new_wine or grape_suggestion)
-router.post('/', async (req, res) => {
+// requireNonDemo: wine requests land in the admin review queue and persist after
+// the demo is reaped — queue-spam vector.
+router.post('/', requireNonDemo, async (req, res) => {
   try {
     const { requestType = 'new_wine', wineName, sourceUrl, image, linkedWineDefinition, suggestedGrapes } = req.body;
 

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const WineDefinition = require('../models/WineDefinition');
 const Discussion = require('../models/Discussion');
 const searchService = require('../services/search');
-const { requireAuth, optionalAuth } = require('../middleware/auth');
+const { requireAuth, requireNonDemo, optionalAuth } = require('../middleware/auth');
 const { scanLabelFull, identifyWineFromQuery } = require('../services/labelScan');
 const { sanitizeImageBuffer, detectImageFormat } = require('../services/imageSanitizer');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
@@ -34,6 +34,14 @@ const MAX_AI_QUERY_LEN = 300;
  * daily window resets.
  */
 function sendAiBudgetExhausted(res, debit) {
+  // Demo accounts get no AI at all — a distinct, non-retryable 403 so the client
+  // shows "sign up to use AI" rather than a "try again at midnight" budget message.
+  if (debit.reason === 'demo_disabled') {
+    return res.status(403).json({
+      error: 'AI features are not available in the demo. Create a free account to use them.',
+      code: 'demo_ai_disabled',
+    });
+  }
   res.set('Retry-After', String(debit.retryAfterSeconds));
   return res.status(429).json({
     error: 'Daily AI budget reached. AI features reset at midnight UTC.',
@@ -211,7 +219,7 @@ router.post('/scan-label', requireAuth, aiBurstLimiter, asyncHandler(async (req,
   // Debit the shared daily AI budget BEFORE any expensive work (rembg + the
   // Claude vision call); refunded below if the scan fails (mirrors chat's
   // debit-before / refund-on-error pattern).
-  const debit = await tryDebitAi(req.user.id);
+  const debit = await tryDebitAi(req.user.id, { isDemo: req.user.isDemo });
   if (!debit.ok) return sendAiBudgetExhausted(res, debit);
 
   // Phase 1: the billable work (rembg + the Claude vision call). Refund the
@@ -336,7 +344,12 @@ router.post('/scan-label', requireAuth, aiBurstLimiter, asyncHandler(async (req,
 //
 // Pass `confirmCreate: true` after the user has reviewed the soft-zone
 // candidates and explicitly chosen to create a new wine anyway.
-router.post('/find-or-create', requireAuth, async (req, res) => {
+// requireNonDemo: find-or-create is a NON-AI registry-write primitive — on a miss
+// it mints a WineDefinition + Country/Region/Grape into the SHARED registry
+// (reachable via the AddBottle/Wishlist "create new wine" flow). purgeUserData
+// only reassigns createdBy on reap, so those rows would persist forever. A demo
+// must never create registry entries; it can only resolve existing ones elsewhere.
+router.post('/find-or-create', requireAuth, requireNonDemo, async (req, res) => {
   const { name, producer, country, region, appellation, type, grapes, labelImage, confirmCreate } = req.body;
 
   if (!name?.trim() || !producer?.trim()) {
@@ -388,7 +401,7 @@ router.post('/identify-text', requireAuth, aiBurstLimiter, asyncHandler(async (r
   if (!query) return res.status(400).json({ error: 'query is required' });
   if (query.length > MAX_AI_QUERY_LEN) return res.status(400).json({ error: `query must be at most ${MAX_AI_QUERY_LEN} characters` });
 
-  const debit = await tryDebitAi(req.user.id);
+  const debit = await tryDebitAi(req.user.id, { isDemo: req.user.isDemo });
   if (!debit.ok) return sendAiBudgetExhausted(res, debit);
 
   try {
@@ -417,7 +430,7 @@ router.post('/ai-info', requireAuth, aiBurstLimiter, asyncHandler(async (req, re
   if (!query) return res.status(400).json({ error: 'query is required' });
   if (query.length > MAX_AI_QUERY_LEN) return res.status(400).json({ error: `query must be at most ${MAX_AI_QUERY_LEN} characters` });
 
-  const debit = await tryDebitAi(req.user.id);
+  const debit = await tryDebitAi(req.user.id, { isDemo: req.user.isDemo });
   if (!debit.ok) return sendAiBudgetExhausted(res, debit);
 
   try {

--- a/backend/src/scripts/validate-demo-snapshot.js
+++ b/backend/src/scripts/validate-demo-snapshot.js
@@ -1,0 +1,87 @@
+/**
+ * validate-demo-snapshot.js
+ *
+ * Registry-safety gate for the public-demo snapshot fixture
+ * (src/data/demo-snapshot.json). The ephemeral-demo clone runs in registry-safe
+ * "demoMode": it resolves each snapshot wine to an EXISTING WineDefinition and
+ * SKIPS any that don't match (it never mints registry rows). So a wine that
+ * doesn't already exist in the registry would silently vanish from the demo.
+ *
+ * Run this against the SAME database the demo will clone into (i.e. prod, or a
+ * prod-registry copy) BEFORE committing a freshly-captured snapshot. It reports
+ * every wine that would NOT resolve to an exact/confident existing match, so you
+ * can add it to the registry or drop it from the snapshot.
+ *
+ * Usage (inside the backend container, against the target DB):
+ *   MONGO_URI=... node src/scripts/validate-demo-snapshot.js
+ *   MONGO_URI=... node src/scripts/validate-demo-snapshot.js path/to/other-snapshot.json
+ *
+ * Exit code 0 = every wine resolves (safe to commit); 1 = one or more misses.
+ */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const mongoose = require('mongoose');
+const { parseCellarExport, exportBottleToItem } = require('../services/cellarImport');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/winecellar';
+const snapshotArg = process.argv[2];
+const SNAPSHOT_PATH = snapshotArg
+  ? path.resolve(process.cwd(), snapshotArg)
+  : path.join(__dirname, '..', 'data', 'demo-snapshot.json');
+
+// A throwaway ObjectId string for findOrCreateWine's createdBy param — matchOnly
+// never creates, so nothing is ever attributed to it.
+const PROBE_USER = new mongoose.Types.ObjectId().toString();
+
+async function main() {
+  const raw = fs.readFileSync(SNAPSHOT_PATH, 'utf8');
+  const { cellars } = parseCellarExport(raw);
+
+  await mongoose.connect(MONGO_URI);
+  console.log(`[validate-demo-snapshot] Checking ${SNAPSHOT_PATH} against ${MONGO_URI}\n`);
+
+  let total = 0;
+  const misses = [];
+
+  for (const cellar of cellars) {
+    for (const b of cellar.bottles || []) {
+      const item = exportBottleToItem(b);
+      const name = (item.wineName || item.producer || '').trim();
+      if (!name) continue;
+      total++;
+      try {
+        const { wine } = await findOrCreateWine(
+          { name, producer: item.producer || name, country: item.country, region: item.region,
+            appellation: item.appellation, type: item.type,
+            grapes: Array.isArray(item.grapes) ? item.grapes : [] },
+          PROBE_USER,
+          { confirmCreate: true, matchOnly: true }
+        );
+        if (!wine) misses.push({ name, producer: item.producer, vintage: item.vintage });
+      } catch (err) {
+        misses.push({ name, producer: item.producer, vintage: item.vintage, error: err.message });
+      }
+    }
+  }
+
+  console.log(`Checked ${total} wine(s). Resolved: ${total - misses.length}. Missed: ${misses.length}.`);
+  if (misses.length > 0) {
+    console.log('\nThese wines would NOT resolve to an existing registry entry and would be SKIPPED in the demo:');
+    for (const m of misses) {
+      console.log(`  - ${m.producer ? m.producer + ' — ' : ''}${m.name} (${m.vintage || 'NV'})${m.error ? ' [' + m.error + ']' : ''}`);
+    }
+    console.log('\nFix: add each to the registry, or remove it from the snapshot, then re-run.');
+  }
+
+  await mongoose.disconnect();
+  process.exit(misses.length === 0 ? 0 : 1);
+}
+
+main().catch(async (err) => {
+  console.error('[validate-demo-snapshot] Failed:', err.message);
+  try { await mongoose.disconnect(); } catch { /* ignore */ }
+  process.exit(1);
+});

--- a/backend/src/services/aiBudget.js
+++ b/backend/src/services/aiBudget.js
@@ -123,7 +123,17 @@ async function getEffectiveDailyMax(userId) {
  * when the Anthropic call fails at the transport level so a failed call
  * doesn't consume budget.
  */
-async function tryDebitAi(userId) {
+async function tryDebitAi(userId, { isDemo = false } = {}) {
+  // Ephemeral public-demo accounts get ZERO Anthropic spend: no per-user budget
+  // and no draw on the shared global cap. This denial covers the AI-gated
+  // registry-write paths that run findOrCreateWine only AFTER a debit (label-scan
+  // / identify-text / import). The NON-AI registry-write path (POST
+  // /api/wines/find-or-create) is not downstream of this debit and is guarded
+  // separately with requireNonDemo. The UI surfaces AI features as "sign up to
+  // use"; a direct API call gets this clean denial (`code:'demo_disabled'`).
+  if (isDemo) {
+    return { ok: false, reason: 'demo_disabled', retryAfterSeconds: secondsUntilMidnightUTC() };
+  }
   const cfg = rateLimitsConfig.get();
   // Effective per-user budget: an active admin-granted override wins over the
   // global default (getEffectiveDailyMax). The global cap is never overridden.

--- a/backend/src/services/aiBudget.test.js
+++ b/backend/src/services/aiBudget.test.js
@@ -71,6 +71,17 @@ describe('tryDebitAi', () => {
     expect(globalCount()).toBe(1);
   });
 
+  test('demo accounts are denied with zero spend (no user or global debit)', async () => {
+    const res = await tryDebitAi(USER, { isDemo: true });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('demo_disabled');
+    expect(res.retryAfterSeconds).toBeGreaterThan(0);
+    // The short-circuit runs BEFORE any AiUsage $inc — nothing is billed.
+    expect(userCount()).toBe(0);
+    expect(globalCount()).toBe(0);
+    expect(AiUsage.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
   test('the increment is the gate: over-budget call is rejected and refunded', async () => {
     setLimits({ budget: 2, globalCap: 20000 });
     expect((await tryDebitAi(USER)).ok).toBe(true);

--- a/backend/src/services/authTokens.js
+++ b/backend/src/services/authTokens.js
@@ -11,7 +11,7 @@ const crypto = require('crypto');
 const generateAccessToken = (user) => {
   const roles = user.roles && user.roles.length > 0 ? user.roles : ['user'];
   return jwt.sign(
-    { id: user._id, roles, plan: user.plan || 'free', planExpiresAt: user.planExpiresAt || null },
+    { id: user._id, roles, plan: user.plan || 'free', planExpiresAt: user.planExpiresAt || null, isDemo: !!user.isDemo },
     process.env.JWT_SECRET,
     { algorithm: 'HS256', expiresIn: process.env.ACCESS_TOKEN_EXPIRES_IN || '15m' }
   );

--- a/backend/src/services/cellarImport.js
+++ b/backend/src/services/cellarImport.js
@@ -367,8 +367,11 @@ async function createRacks(cellarId, userId, cellar, items, result) {
 }
 
 /** Resolve a wine: auto-create via findOrCreateWine, else fall back to a
- *  pending WineRequest (mirrors the existing importer's no-match path). */
-async function resolveWine(item, userId, cache, result) {
+ *  pending WineRequest (mirrors the existing importer's no-match path).
+ *  In demoMode, resolve to an EXISTING registry wine only (matchOnly) and skip
+ *  the bottle on a miss — a throwaway demo clone must never mint a
+ *  WineDefinition, taxonomy, or WineRequest in the shared registry. */
+async function resolveWine(item, userId, cache, result, demoMode = false) {
   const name = (item.wineName || item.producer || '').trim();
   const producer = (item.producer || '').trim();
   if (!name) return { error: 'Wine name or producer is required' };
@@ -379,7 +382,7 @@ async function resolveWine(item, userId, cache, result) {
         appellation: item.appellation, type: item.type,
         grapes: Array.isArray(item.grapes) ? item.grapes : [] },
       userId,
-      { confirmCreate: true } // non-interactive: match >= 0.95 or create
+      { confirmCreate: true, matchOnly: demoMode } // demo: match existing only; else match >= 0.95 or create
     );
     if (wine) {
       if (created) result.winesCreated++;
@@ -389,6 +392,14 @@ async function resolveWine(item, userId, cache, result) {
     // Most commonly: country missing (findOrCreateWine throws 400). Fall through
     // to a WineRequest so the bottle is still imported (pending admin review).
     if (err.status !== 400) console.warn('[cellarImport] findOrCreateWine error:', err.message);
+  }
+
+  // Demo clone: never touch the shared registry on a miss — skip the bottle.
+  // The snapshot fixture is pre-validated so every wine resolves exact; this is
+  // the defense-in-depth backstop if a snapshot ever drifts from the registry.
+  if (demoMode) {
+    result.winesSkipped = (result.winesSkipped || 0) + 1;
+    return { skip: true };
   }
 
   const key = `${name.toLowerCase()}|${producer.toLowerCase()}`;
@@ -691,7 +702,7 @@ async function createLayout(cellarId, layout, result) {
  * `result`; only an unexpected failure rejects. Returns the ids of the active
  * bottles created, for search indexing.
  */
-async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, imagesByIndex, anchor, getFileBuffer, defaultCurrency, result }) {
+async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, imagesByIndex, anchor, getFileBuffer, defaultCurrency, result, demoMode = false }) {
   // Racks (exact geometry, fallback inference), then the 3D room layout.
   await createRacks(cellarId, ownerId, cellar, items, result);
   await createLayout(cellarId, cellar.layout, result);
@@ -723,8 +734,11 @@ async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, i
         continue;
       }
 
-      const wine = await resolveWine(item, userId, requestCache, result);
+      const wine = await resolveWine(item, userId, requestCache, result, demoMode);
       if (wine.error) { result.errors.push({ index: i, reason: wine.error }); continue; }
+      // Demo clone: a wine that didn't resolve to an existing registry entry is
+      // skipped rather than imported against a freshly-minted definition.
+      if (wine.skip) continue;
 
       const bottle = buildBottle({
         cellarId, ownerId, item, canonicalVintage,
@@ -772,15 +786,21 @@ async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, i
       if (bottle.status === 'active') createdActiveIds.push(bottle._id);
 
       await attachImages(bottle, imagesByIndex[i], userId, getFileBuffer, result, wineImageDedup, i);
-      await attachReviews(bottle, item.reviews, userId, wine.wineDefinitionId, result);
-      await attachMaturity(item.maturity, wine.wineDefinitionId, canonicalVintage, result, seenMaturity);
+      // Demo clones deliberately create NOTHING in the shared registry: no
+      // disposable-author public reviews, no WineVintageProfile, no pending-somm
+      // queue entries. The demo bottle still shows its drink window from the
+      // registry wine's existing profile at read time.
+      if (!demoMode) {
+        await attachReviews(bottle, item.reviews, userId, wine.wineDefinitionId, result);
+        await attachMaturity(item.maturity, wine.wineDefinitionId, canonicalVintage, result, seenMaturity);
+      }
 
       // Seed the sommelier maturity queue for resolved wines that didn't carry a
       // reviewed window in the export (attachMaturity only restores existing
       // curated data). Mirrors the hand-add / CSV-import behaviour so imported
       // wines surface for a somm. Idempotent ($setOnInsert never clobbers the
       // reviewed profile above) and deduped per wine+vintage.
-      if (wine.wineDefinitionId) {
+      if (!demoMode && wine.wineDefinitionId) {
         const pk = `${wine.wineDefinitionId}:${canonicalVintage}`;
         if (!seenPendingProfile.has(pk)) {
           seenPendingProfile.add(pk);
@@ -837,7 +857,11 @@ async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, i
  *
  * @param userId   importing user (becomes owner of created cellar/bottles/images)
  * @param cellar   one entry from parseCellarExport().cellars
- * @param opts     { targetName, mode: 'create'|'overwrite', getFileBuffer(archivePath)->Buffer|null, defaultCurrency }
+ * @param opts     { targetName, mode: 'create'|'overwrite', getFileBuffer(archivePath)->Buffer|null, defaultCurrency, demoMode }
+ *                 demoMode=true → registry-safe clone: resolve wines to existing
+ *                 registry entries only (never create WineDefinition/taxonomy/
+ *                 WineRequest), and skip reviews / maturity / pending-somm-profile
+ *                 side effects. Used by the ephemeral public-demo account clone.
  * @returns per-cellar result object
  */
 async function importCellar(userId, cellar, opts) {
@@ -853,6 +877,7 @@ async function importCellar(userId, cellar, opts) {
     imagesDeduped: 0,
     imagesSkipped: 0,
     winesCreated: 0,
+    winesSkipped: 0,
     wineRequests: 0,
     reviewsCreated: 0,
     reviewsSkipped: 0,
@@ -889,6 +914,7 @@ async function importCellar(userId, cellar, opts) {
       cellarId: buildCellar._id, ownerId: buildCellar.user, userId, cellar,
       items, imagesByIndex, anchor, getFileBuffer,
       defaultCurrency: opts.defaultCurrency, result,
+      demoMode: !!opts.demoMode,
     });
     if (liveCellar) {
       swapStarted = true;

--- a/backend/src/services/demoAccount.js
+++ b/backend/src/services/demoAccount.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * Ephemeral public-demo accounts.
+ *
+ * POST /api/auth/demo-login creates a throwaway, auto-expiring User and clones a
+ * frozen, PII-scrubbed snapshot cellar into it so an anonymous visitor can try
+ * Cellarion with a fully-populated cellar — no signup. The account is stamped
+ * `isDemo` + `demoExpiresAt`; the demoSweepJob reaper (services/demoSweepJob.js)
+ * fully erases the user + all cloned data via purgeUserData once the window
+ * passes. Concurrent visitors each get a fresh, isolated userId, so demos never
+ * collide.
+ *
+ * Cost/abuse posture: the clone is registry-safe (never mints registry rows,
+ * see cellarImport demoMode) and JSON-only (no per-visitor image files); demo
+ * users get zero AI (guard rails elsewhere). Volume is bounded by the per-IP
+ * demoLimiter + a durable global ceiling + a short TTL — all in config/rateLimits.
+ */
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const User = require('../models/User');
+const { parseCellarExport, importCellar } = require('./cellarImport');
+const rateLimitsConfig = require('../config/rateLimits');
+const { CURRENT_PRIVACY_POLICY_VERSION } = require('../config/legal');
+
+// The frozen demo cellar cloned into every ephemeral account: a
+// `cellarion-export@1` document (see services/cellarExport.js). Captured once
+// from a curated prod cellar, scrubbed of personal/financial free-text, and
+// validated so every wine resolves to an EXISTING registry entry
+// (scripts/validate-demo-snapshot.js). Loaded + parsed once and cached — it
+// never changes at runtime.
+const SNAPSHOT_PATH = path.join(__dirname, '..', 'data', 'demo-snapshot.json');
+
+// Unroutable, RFC 6761-reserved TLD: a demo account can never be emailed.
+const DEMO_EMAIL_DOMAIN = 'demo.cellarion.invalid';
+
+let cachedSnapshot = null;
+/** Read + parse the snapshot fixture once; cached for the process lifetime. */
+function loadSnapshot() {
+  if (cachedSnapshot) return cachedSnapshot;
+  const raw = fs.readFileSync(SNAPSHOT_PATH, 'utf8');
+  cachedSnapshot = parseCellarExport(raw); // { cellars: [...] }
+  return cachedSnapshot;
+}
+
+/** Count currently-live demo accounts, for the global concurrency ceiling.
+ *  Counts expired-but-not-yet-reaped demos too, since they still occupy the DB. */
+function countLiveDemos() {
+  return User.countDocuments({ isDemo: true });
+}
+
+/**
+ * Create a throwaway ephemeral demo user and clone the frozen snapshot cellar
+ * into it (registry-safe, JSON-only). Returns the saved User WITHOUT issuing
+ * tokens — the caller issues them via authTokens.issueTokens so the demo session
+ * is byte-for-byte identical to a normal login session.
+ */
+async function createDemoAccount() {
+  const ttlMs = rateLimitsConfig.get().demo.ttlMs;
+  const rand = crypto.randomBytes(8).toString('hex'); // 16 hex chars → unique username/email
+  const now = new Date();
+
+  const user = new User({
+    username: `demo-${rand}`,
+    email: `demo-${rand}@${DEMO_EMAIL_DOMAIN}`,
+    // The schema requires a password; a demo logs in via JWT only and the address
+    // is unroutable, so this value is never used for anything. Random + discarded.
+    password: crypto.randomBytes(24).toString('hex'),
+    roles: ['user'],
+    emailVerified: true,
+    isDemo: true,
+    demoExpiresAt: new Date(now.getTime() + ttlMs),
+    // Consent is recorded so downstream consent checks behave; the demo notice in
+    // the connect/landing UI explains the ephemeral nature to the visitor.
+    gdprConsent: {
+      privacyPolicy: { accepted: true, acceptedAt: now, version: CURRENT_PRIVACY_POLICY_VERSION },
+      dataProcessing: { accepted: true, acceptedAt: now },
+    },
+  });
+  await user.save();
+
+  // Clone the snapshot cellars in registry-safe demo mode. A clone hiccup is
+  // non-fatal: a demo with fewer bottles still works, and we never want a snapshot
+  // problem to 500 the "try the demo" click. The account is created either way and
+  // will be reaped normally.
+  try {
+    const { cellars } = loadSnapshot();
+    for (const cellar of cellars) {
+      await importCellar(user._id, cellar, {
+        targetName: cellar.cellarName,
+        mode: 'create',
+        demoMode: true,
+        getFileBuffer: () => null, // JSON-only: bottles show the shared registry wine image
+        defaultCurrency: 'USD',
+      });
+    }
+  } catch (err) {
+    console.error('[demoAccount] snapshot clone failed for', String(user._id), '-', err.message);
+  }
+
+  return user;
+}
+
+// Serialize demo creation so the global-ceiling check and the insert form ONE
+// critical section (single backend container). Without this, concurrent demo-
+// logins all read the same countDocuments before any insert commits and overshoot
+// globalMax (TOCTOU). demo-login is low-volume (per-IP + global caps), so
+// serializing costs nothing in practice while making the ceiling actually hold.
+let _demoChain = Promise.resolve();
+function serializeDemo(fn) {
+  const run = _demoChain.then(fn, fn);
+  _demoChain = run.then(() => {}, () => {}); // never let a rejection break the chain
+  return run;
+}
+
+/**
+ * Atomically enforce the global live-demo ceiling and create a demo account.
+ * Returns the saved User, or null if at/over capacity (demo.globalMax; 0 disables
+ * demos entirely). A fast best-effort pre-check sheds obvious over-capacity load
+ * without queueing behind the serialized reserve section.
+ */
+async function createDemoAccountWithinCeiling() {
+  const globalMax = rateLimitsConfig.get().demo.globalMax;
+  if ((await countLiveDemos()) >= globalMax) return null; // fast path
+  return serializeDemo(async () => {
+    const live = await countLiveDemos(); // authoritative re-check under the lock
+    if (live >= globalMax) return null;
+    return createDemoAccount();
+  });
+}
+
+module.exports = {
+  createDemoAccount,
+  createDemoAccountWithinCeiling,
+  countLiveDemos,
+  loadSnapshot,
+  SNAPSHOT_PATH,
+  DEMO_EMAIL_DOMAIN,
+};

--- a/backend/src/services/demoSweepJob.js
+++ b/backend/src/services/demoSweepJob.js
@@ -1,0 +1,51 @@
+/**
+ * Ephemeral demo sweep — runs every ~15 min via the scheduler.
+ *
+ * Finds demo accounts whose lifetime (demoExpiresAt) has passed and fully erases
+ * them: the user row AND every cloned document (bottles/racks/cellars/layout/
+ * journal/on-disk images/Meilisearch docs) via the SAME registry-driven cascade
+ * used for real account deletion (services/userDataRegistry.purgeUserData), so
+ * demo cleanup can never drift from that source of truth.
+ *
+ * Why a cron sweep rather than a Mongo TTL index: a TTL index would delete only
+ * the User row and orphan all cloned data — the exact DB-bloat outcome we're
+ * avoiding. purgeUserData (application code) is mandatory for the cascade.
+ */
+const User = require('../models/User');
+const { purgeUserData } = require('./userDataRegistry');
+const eventBus = require('./eventBus');
+
+// Cap one sweep pass so an abusive burst of demos can't make a single run do
+// unbounded work; the next tick (~15 min later) picks up any remainder.
+const SWEEP_BATCH = 500;
+
+async function runDemoSweep() {
+  const now = new Date();
+
+  const expired = await User.find({
+    isDemo: true,
+    demoExpiresAt: { $lte: now },
+  }).select('_id email').limit(SWEEP_BATCH).lean();
+
+  if (expired.length === 0) return { deleted: 0 };
+
+  let deleted = 0;
+  for (const user of expired) {
+    try {
+      // Close any live SSE stream first so it doesn't dangle once the row is
+      // gone (mirrors the account-deletion path); /refresh then 401s cleanly.
+      eventBus.dropUser(user._id);
+      await purgeUserData(user._id, user.email);
+      await User.deleteOne({ _id: user._id });
+      deleted++;
+    } catch (err) {
+      // Demo data is not real PII; a per-user failure is logged in aggregate and
+      // retried next tick rather than emitting per-user audit/log churn.
+      console.error(`[demo-sweep] Failed to purge demo user ${user._id}:`, err.message);
+    }
+  }
+
+  return { deleted };
+}
+
+module.exports = { runDemoSweep };

--- a/backend/src/services/demoSweepJob.test.js
+++ b/backend/src/services/demoSweepJob.test.js
@@ -1,0 +1,117 @@
+/**
+ * Guards the ephemeral-demo reaper invariants:
+ *  - only isDemo accounts whose demoExpiresAt is due are selected;
+ *  - the FULL cascade (purgeUserData) runs before the user doc is deleted;
+ *  - a live SSE stream is closed (eventBus.dropUser) before deletion;
+ *  - one user's purge failure never aborts the rest of the batch;
+ *  - the sweep is batch-capped so an abusive burst can't run unbounded.
+ */
+jest.mock('../models/User', () => ({
+  find: jest.fn(),
+  deleteOne: jest.fn(),
+}));
+jest.mock('./userDataRegistry', () => ({
+  purgeUserData: jest.fn(),
+}));
+jest.mock('./eventBus', () => ({
+  dropUser: jest.fn(),
+}));
+
+const User = require('../models/User');
+const { purgeUserData } = require('./userDataRegistry');
+const eventBus = require('./eventBus');
+const { runDemoSweep } = require('./demoSweepJob');
+
+function mockExpiredDemos(users) {
+  User.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue(users),
+      }),
+    }),
+  });
+}
+
+let logSpy, errorSpy;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  purgeUserData.mockResolvedValue();
+  User.deleteOne.mockResolvedValue({ deletedCount: 1 });
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+describe('runDemoSweep', () => {
+  test('selects only isDemo accounts whose demoExpiresAt is due, capped + minimal projection', async () => {
+    mockExpiredDemos([]);
+
+    const before = Date.now();
+    const result = await runDemoSweep();
+    const after = Date.now();
+
+    expect(result).toEqual({ deleted: 0 });
+    expect(User.find).toHaveBeenCalledTimes(1);
+    const [filter] = User.find.mock.calls[0];
+    expect(filter.isDemo).toBe(true);
+    expect(filter.demoExpiresAt.$lte).toBeInstanceOf(Date);
+    expect(filter.demoExpiresAt.$lte.getTime()).toBeGreaterThanOrEqual(before);
+    expect(filter.demoExpiresAt.$lte.getTime()).toBeLessThanOrEqual(after);
+    // Data minimisation + batch cap
+    const chain = User.find.mock.results[0].value;
+    expect(chain.select).toHaveBeenCalledWith('_id email');
+    expect(chain.select.mock.results[0].value.limit).toHaveBeenCalledWith(500);
+  });
+
+  test('does nothing when no demo accounts are expired', async () => {
+    mockExpiredDemos([]);
+
+    await runDemoSweep();
+
+    expect(purgeUserData).not.toHaveBeenCalled();
+    expect(User.deleteOne).not.toHaveBeenCalled();
+    expect(eventBus.dropUser).not.toHaveBeenCalled();
+  });
+
+  test('closes the SSE stream, purges ALL data, then deletes the user doc — in that order', async () => {
+    mockExpiredDemos([{ _id: 'd1', email: 'demo-x@demo.cellarion.invalid' }]);
+
+    const result = await runDemoSweep();
+
+    expect(eventBus.dropUser).toHaveBeenCalledWith('d1');
+    expect(purgeUserData).toHaveBeenCalledWith('d1', 'demo-x@demo.cellarion.invalid');
+    expect(User.deleteOne).toHaveBeenCalledWith({ _id: 'd1' });
+    expect(result).toEqual({ deleted: 1 });
+
+    // Order: dropUser → purge → deleteOne (deleting first would orphan cloned data)
+    const dropOrder = eventBus.dropUser.mock.invocationCallOrder[0];
+    const purgeOrder = purgeUserData.mock.invocationCallOrder[0];
+    const deleteOrder = User.deleteOne.mock.invocationCallOrder[0];
+    expect(dropOrder).toBeLessThan(purgeOrder);
+    expect(purgeOrder).toBeLessThan(deleteOrder);
+  });
+
+  test('one demo purge failure does not abort the batch, and is not counted as deleted', async () => {
+    mockExpiredDemos([
+      { _id: 'd1', email: 'a@demo.cellarion.invalid' },
+      { _id: 'd2', email: 'b@demo.cellarion.invalid' },
+    ]);
+    purgeUserData
+      .mockRejectedValueOnce(new Error('purge exploded'))
+      .mockResolvedValueOnce();
+
+    const result = await runDemoSweep();
+
+    expect(purgeUserData).toHaveBeenCalledTimes(2);
+    // d1 failed before its doc deletion; d2 completed
+    expect(User.deleteOne).toHaveBeenCalledTimes(1);
+    expect(User.deleteOne).toHaveBeenCalledWith({ _id: 'd2' });
+    expect(result).toEqual({ deleted: 1 });
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -115,8 +115,13 @@ async function findOrCreateGrapes(names, userId) {
  * @param {boolean} [opts.skipSiblingMatch=false] - Skip step 1b. Pass when the user has
  *   explicitly rejected the suggested matches (find-or-create route with confirmCreate),
  *   so their "create anyway" isn't silently overridden by an appellation-variant sibling.
+ * @param {boolean} [opts.matchOnly=false] - Never create. Resolve only to an existing
+ *   registry wine (exact/sibling/fuzzy>=threshold); if nothing confident matches, return
+ *   { wine: null, noMatch: true } instead of minting a WineDefinition + taxonomy. Used by
+ *   the registry-safe ephemeral-demo clone so a throwaway account can't pollute the shared
+ *   registry. Combine with confirmCreate:true to also bypass the soft-zone candidate return.
  */
-async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false, skipSiblingMatch = false } = {}) {
+async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false, skipSiblingMatch = false, matchOnly = false } = {}) {
   // Cap stored/compared field lengths at this single create chokepoint (covers
   // the find-or-create route, CSV import, cellar-format import and label-scan).
   // This bounds both the fuzzy-match cost and the persisted document size
@@ -210,6 +215,11 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
       return { wine: null, candidates: softCandidates };
     }
   }
+
+  // Match-only callers (the registry-safe demo clone) never create: if no
+  // confident match was found above, report no-match so the caller can skip the
+  // item instead of minting a WineDefinition + taxonomy per use.
+  if (matchOnly) return { wine: null, noMatch: true };
 
   // 3. Create new wine — resolve taxonomy first
   const countryDoc = await findOrCreateCountry(country, userId);

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -423,6 +423,28 @@ describe('findOrCreateWine — creation', () => {
     expect(searchService.indexWine).toHaveBeenCalledWith('wine-new');
   });
 
+  test('matchOnly: no match anywhere returns { noMatch: true } and creates NOTHING (registry-safe demo clone)', async () => {
+    const result = await findOrCreateWine(INPUT, USER_ID, { confirmCreate: true, matchOnly: true });
+
+    expect(result.wine).toBeNull();
+    expect(result.noMatch).toBe(true);
+    // The load-bearing guarantee: a match-only resolve never mints a
+    // WineDefinition, taxonomy, or search index entry on a miss.
+    expect(WineDefinition).not.toHaveBeenCalled(); // no `new WineDefinition(...)`
+    expect(Country.findOne).not.toHaveBeenCalled();
+    expect(Region.findOne).not.toHaveBeenCalled();
+    expect(Grape.findOne).not.toHaveBeenCalled();
+    expect(searchService.indexWine).not.toHaveBeenCalled();
+  });
+
+  test('matchOnly still resolves an EXACT existing match (created: false), never creating', async () => {
+    WineDefinition.findOne.mockReturnValue(findOneChain(EXISTING_WINE));
+    const result = await findOrCreateWine(INPUT, USER_ID, { matchOnly: true });
+    expect(result.wine).toBe(EXISTING_WINE);
+    expect(result.created).toBe(false);
+    expect(WineDefinition).not.toHaveBeenCalled();
+  });
+
   test('unknown wine type defaults to "red"; valid types are kept', async () => {
     await findOrCreateWine({ ...INPUT, type: 'orange' }, USER_ID);
     expect(WineDefinition.mock.calls[0][0].type).toBe('red');

--- a/backend/src/services/scheduler.js
+++ b/backend/src/services/scheduler.js
@@ -7,6 +7,7 @@ const { runCellarRetentionPurge } = require('./cellarRetentionJob');
 const { runRecommendationEmailScrub } = require('./recommendationRetentionJob');
 const { runSecurityAlertCheck } = require('./securityAlertJob');
 const { runClimateOfflineCheck } = require('./climateOfflineJob');
+const { runDemoSweep } = require('./demoSweepJob');
 
 /**
  * Start all scheduled cron jobs.
@@ -100,7 +101,21 @@ function startScheduler() {
     }
   });
 
-  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, cellar-retention daily 04:00 UTC, recommendation-email-scrub daily 04:30 UTC, security-spike every 15 min, climate-offline every 15 min)');
+  // Ephemeral demo sweep: every 15 minutes, offset (5,20,35,50) so it doesn't
+  // pile onto the two */15 jobs above. Fully erases expired demo accounts + all
+  // cloned data via the purgeUserData cascade. A short cadence keeps dead demo
+  // data (and the global-ceiling headroom) from accumulating between the hourly-
+  // scale TTLs. Cheap: a partial-indexed query over only demo rows.
+  cron.schedule('5,20,35,50 * * * *', async () => {
+    try {
+      const result = await runDemoSweep();
+      if (result?.deleted > 0) console.log('[scheduler] Demo sweep deleted', result.deleted, 'expired demo account(s)');
+    } catch (err) {
+      console.error('[scheduler] Demo sweep failed:', err);
+    }
+  });
+
+  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, cellar-retention daily 04:00 UTC, recommendation-email-scrub daily 04:30 UTC, security-spike every 15 min, climate-offline every 15 min, demo-sweep every 15 min offset)');
 }
 
 module.exports = { startScheduler };

--- a/frontend/src/components/DemoBanner.css
+++ b/frontend/src/components/DemoBanner.css
@@ -1,0 +1,31 @@
+/* Demo banner: reuses the .announcement-banner layout (see AnnouncementBanner.css)
+   but is persistent (no dismiss button) and carries an inline sign-up CTA. */
+
+.demo-banner {
+  gap: 0.75rem;
+}
+
+.demo-banner-cta {
+  flex: 0 0 auto;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.demo-banner-cta:hover {
+  background: currentColor;
+}
+
+/* On hover the pill fills with currentColor; keep the label readable by flipping
+   it to the banner's own background. Works in both light and dark themes since it
+   inherits from the surrounding banner surface. */
+.demo-banner-cta:hover {
+  color: var(--color-bg, #fff);
+}

--- a/frontend/src/components/DemoBanner.js
+++ b/frontend/src/components/DemoBanner.js
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import './AnnouncementBanner.css';
+import './DemoBanner.css';
+
+/**
+ * Persistent, non-dismissible banner shown for the whole ephemeral demo session.
+ * Driven purely by user.isDemo (stamped by the backend on the demo JWT), it warns
+ * the visitor their changes reset and points them at signup — the conversion
+ * surface. Because a demo user is authenticated, "create your own cellar" must
+ * first end the demo session (else the /login route bounces an authed user back
+ * to /cellars); demo→real upgrade is a later enhancement.
+ */
+function DemoBanner() {
+  const { t } = useTranslation();
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+  const [now, setNow] = useState(() => Date.now());
+
+  const isDemo = !!user?.isDemo;
+
+  useEffect(() => {
+    if (!isDemo) return undefined;
+    const id = setInterval(() => setNow(Date.now()), 30 * 1000);
+    return () => clearInterval(id);
+  }, [isDemo]);
+
+  if (!isDemo) return null;
+
+  // Optional "resets in ~N min" hint when the backend supplied an expiry.
+  let remaining = null;
+  if (user.demoExpiresAt) {
+    const ms = new Date(user.demoExpiresAt).getTime() - now;
+    if (Number.isFinite(ms) && ms > 0) remaining = Math.max(1, Math.round(ms / 60000));
+  }
+
+  const signUp = async () => {
+    await logout();
+    navigate('/login');
+  };
+
+  return (
+    <div className="announcement-banner info demo-banner" role="status">
+      <span className="announcement-icon" aria-hidden="true">🍷</span>
+      <span className="announcement-text">
+        {remaining != null
+          ? t('demo.bannerTextTimed', { minutes: remaining })
+          : t('demo.bannerText')}
+      </span>
+      <button type="button" className="demo-banner-cta" onClick={signUp}>
+        {t('demo.bannerCta')}
+      </button>
+    </div>
+  );
+}
+
+export default DemoBanner;

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -7,6 +7,7 @@ import { PLANS } from '../config/plans';
 import NotificationBell from './NotificationBell';
 import InstallPrompt from './InstallPrompt';
 import AnnouncementBanner from './AnnouncementBanner';
+import DemoBanner from './DemoBanner';
 import './Layout.css';
 
 const LOGO_LIGHT_WEBP = '/cellarion-logo-light.webp';
@@ -315,6 +316,9 @@ function Layout({ children }) {
 
       {/* SuperAdmin-managed site announcement (e.g. planned maintenance) */}
       <AnnouncementBanner />
+
+      {/* Persistent notice for ephemeral demo sessions (data resets + sign-up CTA) */}
+      <DemoBanner />
 
       <main id="main-content" className="main-content" tabIndex={-1}>
         {children}

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -247,6 +247,34 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
+  // Start an ephemeral demo session — no signup. The backend creates a throwaway,
+  // auto-expiring account with a populated (cloned) cellar and returns the same
+  // { token, user } shape as login; user.isDemo drives the persistent banner and
+  // hides restricted actions app-wide with no further plumbing.
+  const demoLogin = async () => {
+    try {
+      const response = await fetch('/api/auth/demo-login', {
+        method: 'POST',
+        credentials: 'include'
+      });
+      // Parse defensively: a non-JSON proxy body (502/504 HTML during a deploy)
+      // must not throw a raw SyntaxError that ends up rendered on the public
+      // landing page. `serverIssued` tells the caller whether the backend
+      // actually sent a message (surface it) or this was a transport/proxy
+      // failure (use generic localized copy).
+      let data = null;
+      try { data = await response.json(); } catch { /* non-JSON body */ }
+      if (!response.ok) {
+        return { success: false, error: data?.error, code: data?.code, serverIssued: !!data?.error };
+      }
+      applySession(data.token, data.user);
+      return { success: true };
+    } catch {
+      // Transport failure — fetch rejected; no server-issued message.
+      return { success: false, error: null, serverIssued: false };
+    }
+  };
+
   const verifyEmail = async (token) => {
     try {
       const response = await fetch(`/api/auth/verify-email?token=${encodeURIComponent(token)}`, {
@@ -308,6 +336,7 @@ export const AuthProvider = ({ children }) => {
     loading,
     register,
     login,
+    demoLogin,
     logout,
     verifyEmail,
     updatePreferences,

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2621,6 +2621,17 @@
   "announcement": {
     "dismiss": "Dismiss"
   },
+  "demo": {
+    "tryDemo": "Try the live demo",
+    "starting": "Starting demo…",
+    "startError": "Could not start a demo session. Please try again.",
+    "bannerText": "You're exploring the Cellarion demo — changes are temporary and reset automatically.",
+    "bannerTextTimed": "You're exploring the Cellarion demo — this session resets in about {{minutes}} min.",
+    "bannerCta": "Create your own free cellar",
+    "noAddTitle": "Adding bottles isn't available in the demo",
+    "noAddBody": "The demo lets you explore a ready-made cellar — pour a glass, move bottles, arrange racks and browse your stats. Create a free account to start adding your own bottles.",
+    "backToCellar": "Back to the cellar"
+  },
   "wineLists": {
     "title": "Wine Lists",
     "loadFailed": "Failed to load wine list.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2621,6 +2621,17 @@
   "announcement": {
     "dismiss": "Stäng"
   },
+  "demo": {
+    "tryDemo": "Testa livedemon",
+    "starting": "Startar demo…",
+    "startError": "Det gick inte att starta en demosession. Försök igen.",
+    "bannerText": "Du utforskar Cellarion-demon — ändringar är tillfälliga och återställs automatiskt.",
+    "bannerTextTimed": "Du utforskar Cellarion-demon — den här sessionen återställs om cirka {{minutes}} min.",
+    "bannerCta": "Skapa din egen gratis vinkällare",
+    "noAddTitle": "Att lägga till flaskor är inte tillgängligt i demon",
+    "noAddBody": "I demon kan du utforska en färdig vinkällare — häll ett glas, flytta flaskor, ordna ställ och bläddra i din statistik. Skapa ett gratiskonto för att börja lägga till egna flaskor.",
+    "backToCellar": "Tillbaka till vinkällaren"
+  },
   "wineLists": {
     "title": "Vinlistor",
     "loadFailed": "Kunde inte ladda vinlistan.",

--- a/frontend/src/pages/AddBottle.css
+++ b/frontend/src/pages/AddBottle.css
@@ -1,3 +1,17 @@
+/* Demo accounts can't add bottles — a centered sign-up nudge replaces the form. */
+.add-bottle-demo-block {
+  max-width: 560px;
+  margin: 2rem auto;
+  text-align: center;
+}
+.add-bottle-demo-block h2 {
+  margin-top: 0;
+}
+.add-bottle-demo-block p {
+  margin: 0.75rem 0 1.25rem;
+  color: var(--color-text-muted, #666);
+}
+
 .add-bottle-page {
   max-width: 900px;
   margin: 0 auto;

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -364,6 +364,22 @@ function AddBottle() {
     }
   };
 
+  // Adding bottles is not available in the demo (backend enforces via
+  // requireNonDemo on POST /api/bottles). Show a friendly sign-up nudge instead
+  // of the form if a demo visitor navigates here directly. The persistent
+  // DemoBanner already carries the "create your own cellar" CTA.
+  if (user?.isDemo) {
+    return (
+      <div className="add-bottle-page">
+        <div className="card add-bottle-demo-block">
+          <h2>{t('demo.noAddTitle')}</h2>
+          <p>{t('demo.noAddBody')}</p>
+          <Link to={`/cellars/${cellarId}`} className="btn btn-primary">{t('demo.backToCellar')}</Link>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="add-bottle-page">
       {/* Label-scan camera modal */}

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -279,7 +279,7 @@ function CellarDetail() {
         ) : null}
         actions={!loading && (
           <>
-            {canEdit && (
+            {canEdit && !user?.isDemo && (
               <Link to={`/cellars/${id}/add-bottle`} className="btn btn-primary btn-small cph-desktop-only">
                 + {t('cellarDetail.addBottle')}
               </Link>

--- a/frontend/src/pages/LandingPage.css
+++ b/frontend/src/pages/LandingPage.css
@@ -98,6 +98,24 @@
   border-radius: var(--radius-md);
 }
 
+/* button.btn-landing-ghost needs an explicit pointer + inherited font (native
+   <button> defaults otherwise). */
+button.btn-landing-ghost {
+  cursor: pointer;
+  font-family: inherit;
+}
+
+button.btn-landing-ghost:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.landing-demo-error {
+  margin-top: 12px;
+  color: var(--color-danger, #c0392b);
+  font-size: 0.9rem;
+}
+
 /* ── Hero ── */
 .landing-hero {
   position: relative;

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
@@ -13,9 +13,29 @@ const LOGO_DARK  = '/cellarion-logo-dark.png';
 
 export default function LandingPage() {
   const { t, i18n } = useTranslation();
-  const { user } = useAuth();
+  const { user, demoLogin } = useAuth();
   const { theme } = useTheme();
+  const navigate = useNavigate();
   const [contactEmail, setContactEmail] = useState(null);
+  const [demoStarting, setDemoStarting] = useState(false);
+  const [demoError, setDemoError] = useState(null);
+
+  // Start an ephemeral demo session and drop the visitor straight into a
+  // populated cellar — the frictionless "try before you sign up" entry point.
+  const handleTryDemo = async () => {
+    if (demoStarting) return;
+    setDemoStarting(true);
+    setDemoError(null);
+    const res = await demoLogin();
+    if (res.success) {
+      navigate('/cellars');
+    } else {
+      setDemoStarting(false);
+      // Only surface a backend-issued message (e.g. "at capacity"); transport/
+      // proxy failures fall back to friendly localized copy — never raw error text.
+      setDemoError(res.serverIssued ? res.error : t('demo.startError'));
+    }
+  };
 
   const features = [
     { icon: '🍷', title: t('landing.featureBottleTitle'), desc: t('landing.featureBottleDesc') },
@@ -149,11 +169,22 @@ export default function LandingPage() {
                 {t('landing.goToCellar')}
               </Link>
             ) : (
-              <Link to="/login" className="btn-landing-primary btn-landing-large">
-                {t('landing.getStarted')}
-              </Link>
+              <>
+                <Link to="/login" className="btn-landing-primary btn-landing-large">
+                  {t('landing.getStarted')}
+                </Link>
+                <button
+                  type="button"
+                  className="btn-landing-ghost btn-landing-large"
+                  onClick={handleTryDemo}
+                  disabled={demoStarting}
+                >
+                  {demoStarting ? t('demo.starting') : t('demo.tryDemo')}
+                </button>
+              </>
             )}
           </div>
+          {demoError && <p className="landing-demo-error" role="alert">{demoError}</p>}
         </div>
       </section>
 

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -413,7 +413,8 @@ function Settings() {
         </form>
       </div>
 
-      {/* ── Change password card ── */}
+      {/* ── Change password card (hidden for demo accounts — no credential changes) ── */}
+      {!user?.isDemo && (
       <div className="card settings-card">
         <h2 className="settings-section-title">{t('settings.changePassword.title')}</h2>
         <p className="settings-hint">{t('settings.changePassword.hint')}</p>
@@ -474,12 +475,13 @@ function Settings() {
           </div>
         </form>
       </div>
+      )}
 
-      {/* ── API tokens card ── */}
-      <ApiTokensSection />
+      {/* ── API tokens card (hidden for demo — token creation is blocked) ── */}
+      {!user?.isDemo && <ApiTokensSection />}
 
-      {/* ── Climate devices card ── */}
-      <ClimateDevicesSection />
+      {/* ── Climate devices card (hidden for demo) ── */}
+      {!user?.isDemo && <ClimateDevicesSection />}
 
       {/* ── Your Supporter Tier card ── */}
       <div className="card settings-card settings-plan-card">
@@ -785,7 +787,8 @@ function Settings() {
         </p>
       </div>
 
-      {/* ── Take your cellars with you (portability / anti-lock-in) ── */}
+      {/* ── Portability (hidden for demo — cellar import is blocked, export is moot) ── */}
+      {!user?.isDemo && (
       <div className="card settings-card">
         <h2 className="settings-section-title">{t('settings.portability.title', 'Take your cellars with you')}</h2>
         <p className="settings-hint">
@@ -802,8 +805,10 @@ function Settings() {
           </Trans>
         </p>
       </div>
+      )}
 
-      {/* ── Danger zone ── */}
+      {/* ── Danger zone (hidden for demo — account deletion is blocked) ── */}
+      {!user?.isDemo && (
       <div className="card settings-card settings-danger-card">
         <h2 className="settings-section-title settings-danger-title">{t('settings.danger.title', 'Danger zone')}</h2>
         {isDeletionScheduled ? (
@@ -867,6 +872,7 @@ function Settings() {
           </>
         )}
       </div>
+      )}
 
       {appVersion && (
         <p className="settings-version">


### PR DESCRIPTION
## What & why

A public **"try before you sign up"** demo for cellarion.app. An anonymous visitor clicks **"Try the live demo"** on the landing page and is dropped straight into a fully-populated cellar — no signup. Each visitor gets their **own isolated, throwaway account** that auto-expires (default 2h) and is then **fully erased**. Concurrent visitors never collide.

Ephemeral-per-visitor was chosen over a single shared demo account so people can freely add/consume/move/arrange without stepping on each other.

## How it works

1. `POST /api/auth/demo-login` → creates a throwaway `isDemo` User and **clones a frozen snapshot cellar** into it, issues a short-lived JWT (bounded to the demo TTL), returns `{token, user}`.
2. The clone runs in a new **registry-safe `demoMode`**: wine resolution is `matchOnly`, so a demo clone **mints nothing** in the shared registry (no `WineDefinition`/taxonomy/`WineRequest`/`WineVintageProfile`/public review/pending-somm-profile).
3. A `*/15` **reaper** (`demoSweepJob`) fully erases expired demos via the existing `purgeUserData` cascade (same path as real account deletion).

Almost entirely reuses existing infra (JWT issuance, cellar export/import, `purgeUserData`, the cron scheduler, admin-tunable rate limits). **No docker-compose changes.**

## Safety / security (the core of this PR)

- **AI fully OFF for demo — zero Anthropic/Voyage spend.** `tryDebitAi` short-circuits on `isDemo`; chat 403s; every embedding path (bottle add/edit/consume) is skipped or unreachable.
- **Can't add bottles** — the "real" add flow leans on AI (label scan); rather than a lesser AI-free add, the demo is an explore-and-interact experience (pour, move, arrange, edit, browse). `POST /api/bottles` is `requireNonDemo`.
- **`requireNonDemo` guard** on every consequential/shared-state write: find-or-create-wine, images (upload/rembg), imports, change-password, delete-account, token creation, journal, support, wine-reports, reviews, discussions, follows, recommendations, wine-requests, cellar member-invite.
- **Abuse bounds for the 4 GB VM:** per-IP `demoLimiter` (3/hr) + an **atomic** durable global ceiling (100 concurrent; `globalMax=0` = kill-switch) + short TTL. Demo passwords skip bcrypt (CPU). All `demo.*` knobs are SuperAdmin-tunable.
- **No post-reap orphan data:** `requireAuth` does a demo-only existence check so a still-valid token can't outlive its reaped account.
- **GDPR:** trivially/fully erased by the existing cascade + auto-expiry retention; the snapshot must be PII-scrubbed.

## Verification

- **Backend: 91 tests pass** in `node:20-alpine` (incl. new demo tests: `requireNonDemo`, `matchOnly` registry-safety, `demoSweepJob`, `tryDebitAi` demo denial, demo-session existence check).
- **Frontend: 647 tests pass.**
- **7-agent adversarial review → 11 findings, all confirmed and fixed** in this PR (un-gated find-or-create/images/journal/support/wine-reports, two AI-embed leak paths, the ceiling TOCTOU + bcrypt waste, and the post-reap zombie token).

## ⚠️ Before merge/release

The snapshot fixture (`backend/src/data/demo-snapshot.json`) is a **PLACEHOLDER**. The real one is captured from a curated prod cellar → **PII-scrubbed** → **registry-validated** (`scripts/validate-demo-snapshot.js` asserts every wine resolves to an existing registry entry) → committed. Also: **machine-authored Swedish strings pending review**.