### PR TITLE
feat(mcp): Model Context Protocol foundation — scoped /api/mcp endpoint

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.81.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "archiver": "^7.0.1",
         "bcryptjs": "^2.4.3",
         "compression": "^1.8.1",
@@ -35,7 +36,8 @@
         "sharp": "^0.34.5",
         "stripe": "^22.0.1",
         "web-push": "^3.6.7",
-        "yauzl": "^3.4.0"
+        "yauzl": "^3.4.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "jest": "^30.2.0",
@@ -629,6 +631,18 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@img/colour": {
@@ -1531,6 +1545,385 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
@@ -2179,6 +2572,39 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -3732,6 +4158,27 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3884,6 +4331,22 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4253,6 +4716,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/hono": {
+      "version": "4.12.29",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
+      "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4441,6 +4913,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4530,6 +5011,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -5272,6 +5759,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -5328,6 +5824,18 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6212,7 +6720,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6573,6 +7080,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -7025,6 +7541,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -7059,6 +7584,55 @@
       "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "license": "MIT"
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -8325,7 +8899,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -8470,6 +9043,24 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.55.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "archiver": "^7.0.1",
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",
@@ -36,7 +37,8 @@
     "sharp": "^0.34.5",
     "stripe": "^22.0.1",
     "web-push": "^3.6.7",
-    "yauzl": "^3.4.0"
+    "yauzl": "^3.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "jest": "^30.2.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -65,6 +65,7 @@ const stripeRoute = require('./routes/stripe');
 const tokensRoute = require('./routes/tokens');
 const eventsRoute = require('./routes/events');
 const climateRoute = require('./routes/climate');
+const mcpRoute = require('./routes/mcp');
 const rateLimitsConfig = require('./config/rateLimits');
 const aiConfig = require('./config/aiConfig');
 const announcementConfig = require('./config/announcement');
@@ -140,6 +141,24 @@ if (indexNowKey) {
 // sitemap/OG/public-wine-list routes that are mounted before the limiters.
 const isStripeWebhook = (req) => req.originalUrl.split('?')[0] === '/api/stripe/webhook';
 
+// The MCP endpoint is a single JSON-RPC envelope (POST-only, stateless Streamable
+// HTTP). One POST may be a harmless `initialize`/`tools/list` or a `tools/call`
+// that writes — the HTTP write limiter can't tell them apart, so limiting it at
+// this layer would throttle the read-mostly handshake while providing no real
+// write protection. Per-tool authorization (registry scope filter) and, for
+// write tools, the write-safety layers govern MCP mutations instead. It stays
+// under the global apiLimiter, so it is never unbounded.
+//
+// NOTE for future write/DB tools: a JSON-RPC body may be a *batch* (array) of
+// calls, so one HTTP request can fan out to many tool invocations — apiLimiter
+// counts requests, not calls. Before the first tool that touches Mongo/AI ships,
+// add a per-tool/per-batch guard (and likely a dedicated MCP limiter). Today the
+// only tool is get_source_info (in-memory, no I/O), so this is a non-issue.
+const isMcp = (req) => {
+  const p = req.originalUrl.split('?')[0];
+  return p === '/api/mcp' || p === '/api/mcp/';
+};
+
 // Global API rate limiter — default 200 requests per 15 min per IP (admin-configurable)
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -162,7 +181,7 @@ const writeLimiter = rateLimit({
   keyGenerator: (req) => rateLimitKey(req),
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req) => isStripeWebhook(req) || req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS',
+  skip: (req) => isStripeWebhook(req) || isMcp(req) || req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS',
   handler: (req, res) => {
     logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'write', limit: rateLimitsConfig.get().write.max });
     res.status(429).json({ error: 'Too many write requests, please try again later' });
@@ -233,6 +252,10 @@ app.use('/api/stripe', stripeRoute);
 app.use('/api/tokens', tokensRoute);
 app.use('/api/events', eventsRoute);
 app.use('/api/climate', climateRoute);
+// Model Context Protocol endpoint — lets an external AI (Claude Desktop, etc.)
+// read the connected user's own cellar over a scoped `cel_` token or a JWT.
+// Stateless Streamable HTTP; per-tool authorization lives in the MCP registry.
+app.use('/api/mcp', mcpRoute);
 
 // 404 handler
 app.use((req, res) => {

--- a/backend/src/mcp/instructions.js
+++ b/backend/src/mcp/instructions.js
@@ -1,0 +1,17 @@
+// Server `instructions`, sent to the client at MCP `initialize`. This becomes
+// ambient context for every session — effectively a system prompt for the MCP,
+// and the single highest-leverage lever for good tool behavior. Keep it concise:
+// what this is, how to use the tools well, and how to answer "what is this?".
+const pkg = require('../../package.json');
+
+const INSTRUCTIONS = [
+  `You are connected to Cellarion — a self-hosted wine cellar manager, open-source under AGPL-3.0 (https://github.com/jagduvi1/Cellarion). This MCP server (v${pkg.version}) exposes the connected user's OWN cellar.`,
+  '',
+  'How to work with it:',
+  "- Every tool acts only on the authenticated user's data. Reads are free — prefer them.",
+  '- When a tool returns structured data, reason over it directly: you are the sommelier; the server just supplies the facts.',
+  '- Cite the specific wine, vintage, and rack location in your answers so the user can verify what you did.',
+  '- Call get_source_info if the user asks what Cellarion is, which version this instance runs, whether it is open source, or where to find or contribute to the code.',
+].join('\n');
+
+module.exports = { INSTRUCTIONS };

--- a/backend/src/mcp/registry.js
+++ b/backend/src/mcp/registry.js
@@ -1,0 +1,60 @@
+// Declarative MCP tool registry.
+//
+// Each tool is a plain object: { name, title, description, scope, inputSchema,
+// annotations, handler }. One registry drives (a) the tools advertised to a
+// client — filtered to the token's scopes, so a `read`-only token never even
+// sees write tools — and (b) which handler runs. Adding a tool is declarative;
+// no route wiring, no per-endpoint scope check to forget.
+//
+// `scope` is the token scope a tool requires: 'public' (any authenticated
+// token), or one of the SCOPE_ALLOWLIST scopes ('read' | 'consume' | 'write' |
+// …). This mirrors the default-deny philosophy of middleware/apiTokenAuth.js —
+// the tool surface a caller sees is exactly the powers they granted.
+
+const tools = [];
+
+/**
+ * Register an MCP tool. Throws on a duplicate name (a programming error).
+ * @param {object} def
+ * @param {string}   def.name          unique snake_case tool name
+ * @param {string}   def.title         short human-readable title
+ * @param {string}   def.description   when + what — drives model tool-selection
+ * @param {string}   def.scope         required token scope ('public' | 'read' | …)
+ * @param {object}   [def.inputSchema] zod raw shape ({} = no params)
+ * @param {object}   [def.annotations] MCP hints (readOnlyHint, destructiveHint, …)
+ * @param {Function} def.handler       async (args, ctx) => ({ content: [...] })
+ */
+function registerTool(def) {
+  if (!def || typeof def.name !== 'string' || typeof def.handler !== 'function') {
+    throw new Error('registerTool: name and handler are required');
+  }
+  if (typeof def.scope !== 'string') {
+    throw new Error(`registerTool(${def.name}): scope is required`);
+  }
+  if (tools.some((t) => t.name === def.name)) {
+    throw new Error(`registerTool: duplicate tool name "${def.name}"`);
+  }
+  tools.push({ inputSchema: {}, annotations: {}, ...def });
+}
+
+/**
+ * True when a token carrying `tokenScopes` may reach a tool requiring `required`.
+ * 'public' tools are reachable by any authenticated token; every other tool
+ * requires the token to carry that exact scope.
+ */
+function scopeSatisfies(tokenScopes, required) {
+  if (required === 'public') return true;
+  return Array.isArray(tokenScopes) && tokenScopes.includes(required);
+}
+
+/** The subset of registered tools a token with `tokenScopes` may see and call. */
+function toolsForScopes(tokenScopes) {
+  return tools.filter((t) => scopeSatisfies(tokenScopes, t.scope));
+}
+
+/** All registered tools (for tests / introspection). */
+function allTools() {
+  return tools.slice();
+}
+
+module.exports = { registerTool, toolsForScopes, scopeSatisfies, allTools };

--- a/backend/src/mcp/registry.test.js
+++ b/backend/src/mcp/registry.test.js
@@ -1,0 +1,50 @@
+const { registerTool, toolsForScopes, scopeSatisfies, allTools } = require('./registry');
+require('./tools'); // register the real tools (get_source_info, …)
+
+describe('MCP registry — scope gating (the security-relevant logic)', () => {
+  test('public tools are reachable by any authenticated token', () => {
+    expect(scopeSatisfies([], 'public')).toBe(true);
+    expect(scopeSatisfies(undefined, 'public')).toBe(true);
+    expect(scopeSatisfies(['read'], 'public')).toBe(true);
+  });
+
+  test('non-public tools require the token to carry that exact scope', () => {
+    expect(scopeSatisfies(['read'], 'read')).toBe(true);
+    expect(scopeSatisfies(['read'], 'write')).toBe(false);
+    expect(scopeSatisfies([], 'read')).toBe(false);
+    expect(scopeSatisfies(undefined, 'read')).toBe(false);
+  });
+
+  test('get_source_info (public) is visible even to a zero-scope token', () => {
+    expect(toolsForScopes([]).map((t) => t.name)).toContain('get_source_info');
+    expect(toolsForScopes(['read']).map((t) => t.name)).toContain('get_source_info');
+  });
+
+  test('a write-scoped tool is invisible to a read-only token, visible to write', () => {
+    registerTool({ name: 'unit_test_write_tool', title: 't', description: 'd', scope: 'write', handler: async () => ({ content: [] }) });
+    expect(toolsForScopes(['read']).map((t) => t.name)).not.toContain('unit_test_write_tool');
+    expect(toolsForScopes(['write']).map((t) => t.name)).toContain('unit_test_write_tool');
+  });
+
+  test('registerTool rejects missing fields and duplicate names', () => {
+    expect(() => registerTool({ name: 'no_handler', scope: 'read' })).toThrow();
+    expect(() => registerTool({ name: 'no_scope', handler: async () => ({}) })).toThrow(/scope/i);
+    expect(() => registerTool({ name: 'get_source_info', scope: 'public', handler: async () => ({}) })).toThrow(/duplicate/i);
+  });
+});
+
+describe('get_source_info handler', () => {
+  test('is public + read-only and returns repo/license/version with no secrets', async () => {
+    const tool = allTools().find((t) => t.name === 'get_source_info');
+    expect(tool.scope).toBe('public');
+    expect(tool.annotations.readOnlyHint).toBe(true);
+
+    const res = await tool.handler({}, { user: { id: 'u1' }, scopes: ['read'] });
+    const info = JSON.parse(res.content[0].text);
+    expect(info.repository).toContain('github.com/jagduvi1/Cellarion');
+    expect(info.license).toBe('AGPL-3.0');
+    expect(typeof info.version).toBe('string');
+    // Data minimisation: the tool must never surface secrets/config.
+    expect(JSON.stringify(info)).not.toMatch(/secret|password|token|api[_-]?key|process\.env/i);
+  });
+});

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -1,0 +1,77 @@
+const { toolsForScopes } = require('./registry');
+const { INSTRUCTIONS } = require('./instructions');
+const pkg = require('../../package.json');
+require('./tools'); // register all tools (side-effect)
+
+// The MCP SDK is ESM-only (`type: module`), so this CommonJS module loads it via
+// dynamic import() and caches the classes. Loaded lazily (first request) so the
+// backend boot doesn't pay for it and tests can require this module freely.
+let sdkPromise;
+function loadSdk() {
+  if (!sdkPromise) {
+    sdkPromise = Promise.all([
+      import('@modelcontextprotocol/sdk/server/mcp.js'),
+      import('@modelcontextprotocol/sdk/server/streamableHttp.js'),
+    ]).then(([mcp, http]) => ({
+      McpServer: mcp.McpServer,
+      StreamableHTTPServerTransport: http.StreamableHTTPServerTransport,
+    })).catch((err) => {
+      // Never cache a rejected import. A transient first-load failure (e.g.
+      // EMFILE under load) would otherwise poison every future /api/mcp request
+      // until a process restart; clearing the cache lets the next request retry.
+      sdkPromise = undefined;
+      throw err;
+    });
+  }
+  return sdkPromise;
+}
+
+// Build a per-request MCP server exposing ONLY the tools the caller's token
+// scopes allow. Because a disallowed tool is never registered on this server, it
+// is not merely hidden from tools/list — it is uncallable (a tools/call for it
+// gets "unknown tool"). So scope enforcement is structural, not a filter a
+// client could talk around. ctx = { user, scopes }.
+async function buildServer(ctx) {
+  const { McpServer } = await loadSdk();
+  const server = new McpServer(
+    { name: 'cellarion', version: pkg.version },
+    { instructions: INSTRUCTIONS }
+  );
+  for (const tool of toolsForScopes(ctx.scopes)) {
+    server.registerTool(
+      tool.name,
+      {
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        annotations: tool.annotations,
+      },
+      (args) => tool.handler(args || {}, ctx)
+    );
+  }
+  return server;
+}
+
+// Serve one stateless Streamable HTTP request. A fresh server + transport per
+// request (no held session) is the cheapest mode and suits read-mostly use;
+// both are torn down when the response closes so nothing leaks between requests.
+async function handleMcpRequest(req, res, ctx) {
+  const { StreamableHTTPServerTransport } = await loadSdk();
+  const server = await buildServer(ctx);
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  res.on('close', () => {
+    // transport.close() and server.close() are async — a synchronous try/catch
+    // cannot swallow a rejected promise, and Node 20's default policy turns an
+    // unhandled rejection on this per-request hot path into a process crash.
+    // `.then(fn).catch()` captures both a synchronous throw and a rejection.
+    // server.close() also closes the transport, so closing both is intentionally
+    // idempotent (the second close is a harmless no-op) — defensive in case a
+    // future SDK version stops cascading.
+    Promise.resolve().then(() => transport.close()).catch(() => {});
+    Promise.resolve().then(() => server.close()).catch(() => {});
+  });
+  await server.connect(transport);
+  await transport.handleRequest(req, res, req.body);
+}
+
+module.exports = { handleMcpRequest, buildServer, loadSdk };

--- a/backend/src/mcp/smoke.js
+++ b/backend/src/mcp/smoke.js
@@ -1,0 +1,44 @@
+/* Manual MCP smoke test — drives the REAL server module with the MCP SDK's own
+ * client over Streamable HTTP. Run:  node src/mcp/smoke.js
+ *
+ * NOT part of the jest suite: the SDK is ESM-only and jest's CJS transform can't
+ * load it via import(), so end-to-end transport coverage lives here (and, later,
+ * in the eval harness — MCP plan §9). Auth/DB are bypassed with an injected ctx
+ * so this exercises the MCP layer (registry, scope filtering, transport) in
+ * isolation, exactly as the /api/mcp route wires it. */
+const express = require('express');
+const { handleMcpRequest } = require('./server');
+
+async function main() {
+  const ctx = { user: { id: 'smoke-user' }, scopes: ['read'] };
+
+  const app = express();
+  app.use(express.json());
+  app.post('/api/mcp', (req, res, next) => handleMcpRequest(req, res, ctx).catch(next));
+  app.get('/api/mcp', (req, res) => res.status(405).end());
+
+  const httpServer = await new Promise((r) => { const s = app.listen(0, '127.0.0.1', () => r(s)); });
+  const port = httpServer.address().port;
+
+  const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+  const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
+
+  const client = new Client({ name: 'mcp-smoke', version: '0.0.0' });
+  await client.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/api/mcp`)));
+  console.log('[smoke] initialize handshake: OK');
+
+  const { tools } = await client.listTools();
+  console.log('[smoke] tools/list ->', tools.map((t) => t.name));
+  if (!tools.some((t) => t.name === 'get_source_info')) throw new Error('get_source_info not advertised');
+
+  const res = await client.callTool({ name: 'get_source_info', arguments: {} });
+  const info = JSON.parse(res.content.find((c) => c.type === 'text').text);
+  console.log('[smoke] get_source_info ->', info.name, info.version, info.license);
+  if (info.license !== 'AGPL-3.0') throw new Error('unexpected get_source_info payload');
+
+  await client.close();
+  httpServer.close();
+  console.log('[smoke] OK — /api/mcp serves the full initialize -> tools/list -> tools/call round-trip.');
+}
+
+main().catch((e) => { console.error('[smoke] FAILED:', e); process.exit(1); });

--- a/backend/src/mcp/tools/index.js
+++ b/backend/src/mcp/tools/index.js
@@ -1,0 +1,6 @@
+// Single place that loads every tool module (each registers its tools as a
+// side-effect at require time). server.js requires this once so the registry is
+// fully populated before the first request. Add new tool files here.
+require('./meta');
+
+module.exports = {};

--- a/backend/src/mcp/tools/meta.js
+++ b/backend/src/mcp/tools/meta.js
@@ -1,0 +1,32 @@
+// Self-description tools (§3.16 of the MCP plan). Because Cellarion is
+// open-source, the MCP is radically transparent: any connected AI can learn what
+// it is, which version it's talking to, and where the source lives — so it can
+// use the tools well and even help improve the app. Source is pointed at (the
+// public GitHub repo), never served from the running container filesystem.
+const pkg = require('../../../package.json');
+const { registerTool } = require('../registry');
+
+registerTool({
+  name: 'get_source_info',
+  title: 'About this Cellarion instance',
+  description:
+    'Returns what Cellarion is, the version this instance is running, the open-source repository, and the license. ' +
+    'Call this when the user asks what Cellarion is, which version they are on, whether it is open source, ' +
+    'or where to find / contribute to the code.',
+  scope: 'public',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {},
+  handler: async () => {
+    const info = {
+      name: 'Cellarion',
+      description:
+        'Self-hosted wine cellar management (MERN). Track bottles, organise them into cellars and racks, ' +
+        'search a shared wine registry, and get drink-window recommendations.',
+      version: pkg.version,
+      license: 'AGPL-3.0',
+      repository: 'https://github.com/jagduvi1/Cellarion',
+      homepage: 'https://cellarion.app',
+    };
+    return { content: [{ type: 'text', text: JSON.stringify(info, null, 2) }] };
+  },
+});

--- a/backend/src/middleware/apiTokenAuth.js
+++ b/backend/src/middleware/apiTokenAuth.js
@@ -27,7 +27,9 @@ const LAST_USED_THROTTLE_MS = 60 * 60 * 1000; // 1 hour
  *   read    — the GETs the Home Assistant integration uses: stats, cellars,
  *             bottles, notifications, the SSE event stream, and /auth/whoami
  *             (its own account id, for reauth same-account verification — id
- *             only, no PII, unlike /auth/me).
+ *             only, no PII, unlike /auth/me). Also POST /api/mcp: the Model
+ *             Context Protocol endpoint, whose per-tool authorization is
+ *             enforced inside the MCP registry (a read token sees read tools).
  *   consume — POST /api/bottles/:id/consume only.
  *   climate — POST /api/climate/ingest only: the sensor-device credential.
  *             A leaked device token can post readings and nothing else.
@@ -42,6 +44,12 @@ const SCOPE_ALLOWLIST = {
     // Exact match only — the caller's own account id (id, no PII). Anchored so
     // it can never widen to /api/auth/me or any other /api/auth/* route.
     { method: 'GET', pattern: /^\/api\/auth\/whoami$/ },
+    // MCP endpoint (Model Context Protocol). A single POST envelope; which tools
+    // the caller may actually invoke is enforced *inside* by the MCP registry's
+    // scope filter (a read token only ever sees read/public tools), so reaching
+    // this path is safe. Anchored exact — cannot widen to any other /api/mcp/*.
+    // When consume/write MCP tools ship, add this entry under those scopes too.
+    { method: 'POST', pattern: /^\/api\/mcp$/ },
   ],
   consume: [
     { method: 'POST', pattern: /^\/api\/bottles\/[a-f0-9]{24}\/consume$/ },

--- a/backend/src/middleware/apiTokenAuth.test.js
+++ b/backend/src/middleware/apiTokenAuth.test.js
@@ -67,6 +67,7 @@ describe('isRequestAllowed (default-deny)', () => {
     ['GET', '/api/notifications'],
     ['GET', '/api/events/stream'],
     ['GET', '/api/auth/whoami'],
+    ['POST', '/api/mcp'],
   ])('read scope allows %s %s', (method, path) => {
     expect(isRequestAllowed(READ, method, path)).toBe(true);
   });
@@ -90,6 +91,10 @@ describe('isRequestAllowed (default-deny)', () => {
     ['GET', '/api/auth/whoami/extra'],
     ['GET', '/api/auth/whoamix'],
     ['GET', '/api/auth/logout'],
+    // MCP is POST-only and exact-anchored: no GET, no sibling, no sub-path leaks
+    ['GET', '/api/mcp'],
+    ['POST', '/api/mcp/extra'],
+    ['POST', '/api/mcpx'],
     // Writes are never granted by read
     ['POST', '/api/bottles'],
     ['DELETE', `/api/cellars/${oid}`],
@@ -147,6 +152,18 @@ describe('isRequestAllowed (default-deny)', () => {
     // And the other scopes never grant ingest.
     expect(isRequestAllowed(READ, 'POST', '/api/climate/ingest')).toBe(false);
     expect(isRequestAllowed(BOTH, 'POST', '/api/climate/ingest')).toBe(false);
+  });
+
+  test('POST /api/mcp is granted by read — per-tool authz lives inside the MCP registry', () => {
+    expect(isRequestAllowed(READ, 'POST', '/api/mcp')).toBe(true);
+    expect(isRequestAllowed(BOTH, 'POST', '/api/mcp')).toBe(true); // read+consume
+    // Neither consume nor climate reaches the MCP endpoint until write/consume
+    // tools ship and their scopes are added to the allowlist alongside them.
+    expect(isRequestAllowed(CONSUME, 'POST', '/api/mcp')).toBe(false);
+    expect(isRequestAllowed(['climate'], 'POST', '/api/mcp')).toBe(false);
+    // POST-only + exact-anchored — GET (the 405 fallback) and sub-paths denied.
+    expect(isRequestAllowed(READ, 'GET', '/api/mcp')).toBe(false);
+    expect(isRequestAllowed(READ, 'POST', '/api/mcp/tools')).toBe(false);
   });
 
   test('GET /api/auth/whoami is granted ONLY by read (own account id for HA reauth)', () => {

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const router = express.Router();
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
+const { handleMcpRequest } = require('../mcp/server');
+
+// Scopes a caller has when talking to the MCP endpoint. For a personal API token
+// (`cel_…`) these are the token's OWN scopes — so a read-only token sees and can
+// call only read tools. A JWT session is the user themselves, but we DELIBERATELY
+// cap it at `read`: the only tools today are read/public, and pre-granting
+// `consume`/`write` here would silently hand every logged-in session write power
+// the instant the first mutating tool ships. When consume/write tools land, that
+// PR extends this set as a conscious decision alongside the write-safety layers.
+const JWT_SCOPES = ['read'];
+
+// POST /api/mcp — stateless Streamable HTTP MCP endpoint. Auth is the same
+// requireAuth as the REST API. For `cel_` tokens the SCOPE_ALLOWLIST grants this
+// exact path to `read` tokens (middleware/apiTokenAuth.js); a token lacking that
+// scope (e.g. a climate device token) is rejected by requireAuth before it ever
+// reaches this handler. requireNonDemo keeps ephemeral demo sessions out — MCP is
+// a personal-cellar surface reached with your own credentials, and demo accounts
+// are shared/throwaway (they also can't mint `cel_` tokens, so this closes the
+// only other way in). A `cel_` token never carries isDemo, so requireNonDemo is a
+// no-op for it and blocks only demo JWT sessions.
+router.post('/', requireAuth, requireNonDemo, async (req, res, next) => {
+  try {
+    const scopes = req.apiToken ? req.apiToken.scopes : JWT_SCOPES;
+    await handleMcpRequest(req, res, { user: req.user, scopes });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Stateless Streamable HTTP is POST-only; GET is for server→client SSE streams,
+// which stateless mode does not open. 405 lets clients fall back cleanly.
+router.get('/', requireAuth, requireNonDemo, (req, res) => {
+  res.status(405).json({ error: 'MCP endpoint is POST-only (stateless Streamable HTTP)' });
+});
+
+module.exports = router;


### PR DESCRIPTION
## What this is

The **foundation** (walking skeleton) for Cellarion's MCP server, so an external AI (Claude Desktop, ChatGPT MCP, etc.) can talk to a user's **own** cellar over our existing scoped-credential model. This is Phase 0/1 of the MCP master plan — deliberately small, correct, and safe to build on. **Not for release yet** — it ships one harmless read-only tool and the plumbing everything else hangs off.

## Docker / compose impact: **none**

In-process on the existing backend. No new service, no new published port, no new env var, no new volume. `docker-compose.yml` **and** the hand-maintained `docker-compose.prod.yml` need zero changes.

## What lands

- **`POST /api/mcp`** — stateless Streamable HTTP (the SDK's own transport). `GET` → 405.
- **Declarative tool registry** (`backend/src/mcp/registry.js`) — each tool carries a required `scope`. The per-request server registers **only** the tools the caller's scopes allow, so a disallowed tool isn't merely hidden from `tools/list` — it's uncallable. Scope enforcement is *structural*, not a filter a client could talk around.
- **One tool: `get_source_info`** (public, read-only) — tells the connected AI what Cellarion is, the running version, the **AGPL-3.0** licence, and the public repo. Server `instructions` prime the model the same way. (Radically transparent, because we're open-source.)
- **Auth** reuses `requireAuth`. For `cel_` tokens the default-deny allowlist grants this exact path to the **`read`** scope only. JWT sessions are capped at `read` (not consume/write), and `requireNonDemo` keeps ephemeral demo sessions out.

## Reuse, not reinvention

Uses the official `@modelcontextprotocol/sdk` (server **and** client). It's ESM-only; loaded from this CommonJS backend via a cached dynamic `import()`. `zod` comes along for future tool input schemas (this phase uses empty schemas).

## Adversarial audit (ran before this PR)

Two independent reviewers (security + correctness) went over the whole diff. **No presently-exploitable High/Med security findings.** Fixed before pushing:

| Fix | Sev | What |
|-----|-----|------|
| async-safe cleanup | Med | `transport.close()`/`server.close()` are async — a sync `try/catch` can't swallow a rejected promise (Node 20 → possible crash). Now `.then(fn).catch()`. |
| no cached rejected import | Low | A transient first-load `import()` failure no longer poisons `/api/mcp` until restart. |
| `isMcp` trailing slash | Low | `/api/mcp/` now also exempt from the write limiter (was limiter-only; auth already normalised it). |
| conservative JWT scope + demo gate | Low→latent | JWT capped at `read`; `requireNonDemo` added, so the endpoint can't silently arm write for every session when a write tool ships. |

**Deferred (documented in code, land with the first write/DB tool):** per-tool/per-batch rate guard (JSON-RPC batching can fan out under the write-limiter exemption), and a larger per-path body limit than the global 10 kb.

## Tests

- `registry.test.js` — scope-gating + `get_source_info` handler (asserts no secrets leak).
- `apiTokenAuth.test.js` — `/api/mcp` allowlist cases (read-only, POST-only, exact-anchored, denied for consume/climate).
- `smoke.js` — drives a **real SDK client** through `initialize → tools/list → tools/call` end-to-end.
- **Full backend suite: 1380 pass.** Lockfile regenerated in `node:20-alpine`; `npm ci` + `require('sharp')` verified.

## ⚠️ Pre-existing, unrelated (not fixed here)

On current `main`, `src/routes/auth.refresh.test.js` fails to parse because `meilisearch@0.58` ships pure ESM and the demo merge wired `auth.js → demoAccount → cellarImport → search → require('meilisearch')`. It reproduces on clean `main` (before this branch). Flagging for a separate `fix/` PR — out of scope here.