### PR TITLE
fix(test): stop meilisearch ESM from breaking the auth.refresh jest suite

### DIFF
--- a/backend/src/routes/auth.refresh.test.js
+++ b/backend/src/routes/auth.refresh.test.js
@@ -60,6 +60,34 @@ jest.mock('../services/notifications', () => ({ createNotification: jest.fn() })
 jest.mock('../models/PendingShare', () => ({ find: jest.fn(), deleteMany: jest.fn() }));
 jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
 
+// auth.js now transitively requires the search service (auth.js →
+// services/demoAccount → services/cellarImport → services/search), and
+// services/search does `require('meilisearch')` at module load. meilisearch@0.58
+// is ESM-only (its only `.` export is an ESM dist/index.js); Node 20.19+ loads it
+// at runtime via require(esm), but jest's CJS module runtime can't parse it — so
+// merely requiring auth.js would fail this whole suite at load. A factory mock
+// short-circuits the chain (jest never loads the real search.js, hence never
+// meilisearch), matching how the route suites (bottles.restore, cellarImport,
+// import.confirm, …) already stub search. This suite never exercises search.
+jest.mock('../services/search', () => ({
+  initialize: jest.fn(),
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  searchBottles: async () => ({ ids: [] }),
+  searchDiscussions: async () => ({ ids: [] }),
+  indexWine: jest.fn(),
+  removeWine: jest.fn(),
+  indexBottle: jest.fn(),
+  removeBottle: jest.fn(),
+  removeBottles: jest.fn(),
+  bulkIndexBottles: jest.fn(),
+  indexDiscussion: jest.fn(),
+  removeDiscussion: jest.fn(),
+  fullSync: jest.fn(),
+  fullSyncBottles: jest.fn(),
+  fullSyncDiscussions: jest.fn(),
+}));
+
 // Give every request a UNIQUE rate-limit key so the real express-rate-limit
 // limiters are mounted (their wiring is exercised) but never trip mid-suite.
 jest.mock('../utils/clientIp', () => {


### PR DESCRIPTION
## The break

On `main`, `backend/src/routes/auth.refresh.test.js` **fails to run** — not a failing assertion, a parse error at load:

```
/app/node_modules/meilisearch/dist/index.js:1153
export { ... };
^^^^^^
SyntaxError: Unexpected token 'export'
  at Object.require (src/services/search.js:3:38)
  at Object.require (src/services/cellarImport.js:41:23)
  at Object.require (src/services/demoAccount.js:25:45)
  at Object.require (src/routes/auth.js:20:44)
  at Object.require (src/routes/auth.refresh.test.js:80:20)
```

## Root cause

The public-demo merge (#700) wired the **auth router** into the search stack: `auth.js → services/demoAccount → services/cellarImport → services/search`, and `services/search` does `require('meilisearch')` at module load. `meilisearch@0.58` is **ESM-only** (its only `.` export is an ESM `dist/index.js`, `"type": "module"`). Node 20.19+ loads that fine at runtime via `require(esm)` — which is why the app itself works — but **jest's CommonJS module runtime can't parse `export`**, so the whole suite dies at load. `auth.refresh.test.js` is the only suite that requires the *real* auth router; every other suite that reaches the search stack already stubs it.

## Fix

Follows the existing repo convention — a **factory mock** of `../services/search` (same pattern as `bottles.restore`, `cellarImport.limits`, `import.confirm`, and ~6 others) — so jest never loads the real `search.js`, hence never `meilisearch`. This suite doesn't exercise search, so the stub is load-only. **Test-only change**, no production code touched.

## Verification (node:20-alpine)

- `auth.refresh.test.js`: **23/23 pass** (was: suite failed to run).
- **Full backend suite: green, `jest` exit 0** (jest exits non-zero on any failure).

## Compose impact

None — test-only.