### PR TITLE
fix(demo): working demo-login + real anonymized snapshot

### DIFF
--- a/backend/src/data/demo-snapshot.json
+++ b/backend/src/data/demo-snapshot.json
@@ -1,38 +1,8350 @@
 {
   "schema": "cellarion-export@1",
-  "_placeholder": true,
-  "_note": "PLACEHOLDER demo snapshot. Replace with the scrubbed, registry-validated capture of the curated prod cellar (run scripts/validate-demo-snapshot.js before committing the real one). Wines here mirror backend/src/seed-demo.js so a seeded dev DB clones them; unresolved wines are skipped by the registry-safe demo clone, so an empty demo is harmless.",
+  "exportedAt": null,
+  "cellarCount": 4,
+  "bottleCount": 261,
+  "imageCount": 36,
+  "reviewCount": 0,
+  "maturityCount": 82,
   "cellars": [
     {
-      "cellarName": "Demo Cellar",
-      "description": "A sample cellar to explore Cellarion — add bottles, build racks, and browse drink windows. This demo resets automatically.",
+      "cellarName": "Main Cellar",
+      "description": "",
+      "racks": [
+        {
+          "name": "Rack A",
+          "type": "grid",
+          "rows": 7,
+          "cols": 7,
+          "zones": [
+            {
+              "name": "Zone 1",
+              "color": "#2E7D32",
+              "positions": [
+                1,
+                2,
+                8,
+                9,
+                15,
+                16
+              ]
+            },
+            {
+              "name": "Zone 2",
+              "color": "#1565C0",
+              "positions": [
+                3,
+                4,
+                5,
+                10,
+                11,
+                12
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Rack B",
+          "type": "grid",
+          "rows": 8,
+          "cols": 6
+        },
+        {
+          "name": "Rack C",
+          "type": "grid",
+          "rows": 7,
+          "cols": 7
+        },
+        {
+          "name": "Rack D",
+          "type": "grid",
+          "rows": 7,
+          "cols": 7
+        },
+        {
+          "name": "Rack E",
+          "type": "shelf",
+          "rows": 4,
+          "cols": 3,
+          "typeConfig": {
+            "bottlesPerCell": 2,
+            "backCols": 1
+          }
+        }
+      ],
+      "layout": {
+        "roomDimensions": {
+          "width": 2.5,
+          "depth": 2.5,
+          "height": 2.5
+        },
+        "rackPlacements": [
+          {
+            "rackName": "Rack A",
+            "position": {
+              "x": -0.1,
+              "y": 0,
+              "z": 1
+            },
+            "rotation": 180,
+            "wall": "none"
+          },
+          {
+            "rackName": "Rack B",
+            "position": {
+              "x": -1.1,
+              "y": 0,
+              "z": -0.9
+            },
+            "rotation": 90,
+            "wall": "none"
+          },
+          {
+            "rackName": "Rack C",
+            "position": {
+              "x": 0.5,
+              "y": 0,
+              "z": -0.85
+            },
+            "rotation": 270,
+            "wall": "none"
+          },
+          {
+            "rackName": "Rack D",
+            "position": {
+              "x": -1.1,
+              "y": 0,
+              "z": -0.15
+            },
+            "rotation": 90,
+            "wall": "none"
+          }
+        ]
+      },
+      "bottles": [
+        {
+          "wineName": "Barolo Albe",
+          "producer": "G.D. Vajra",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.488Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.488Z"
+            }
+          ],
+          "price": 299,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 29,
+          "rackRow": 5,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Albe",
+          "producer": "G.D. Vajra",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.505Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.505Z"
+            }
+          ],
+          "price": 299,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 30,
+          "rackRow": 5,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Cascina Nuova",
+          "producer": "Elvio Cogno",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.512Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.512Z"
+            }
+          ],
+          "price": 449,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 24,
+          "rackRow": 4,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Cascina Nuova",
+          "producer": "Elvio Cogno",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.520Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.520Z"
+            }
+          ],
+          "price": 449,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 23,
+          "rackRow": 4,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Cascina Nuova",
+          "producer": "Elvio Cogno",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.527Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.527Z"
+            }
+          ],
+          "price": 449,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 22,
+          "rackRow": 4,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Mâcon Milly-Lamartine Clos du Four",
+          "producer": "Famille Cordier",
+          "vintage": "2024",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Mâcon Milly-Lamartine",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.536Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.536Z"
+            }
+          ],
+          "price": 299,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 49,
+          "rackRow": 7,
+          "rackCol": 7,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Brut Rosé Champagne Grand Cru 'Aÿ'",
+          "producer": "H. Goutorbe",
+          "vintage": "NV",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne",
+          "type": "sparkling",
+          "grapes": [
+            "Pinot Noir",
+            "Chardonnay",
+            "Pinot Meunier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.544Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.544Z"
+            }
+          ],
+          "rackName": "Rack D",
+          "rackPosition": 13,
+          "rackRow": 2,
+          "rackCol": 6,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Châteauneuf-du-Pape",
+          "producer": "Château Sixtine Cuvée du Vatican",
+          "vintage": "2023",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Châteauneuf-du-Pape",
+          "type": "red",
+          "grapes": [
+            "Grenache",
+            "Syrah",
+            "Mourvèdre"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.554Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.554Z"
+            }
+          ],
+          "price": 279,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 32,
+          "rackRow": 5,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Châteauneuf-du-Pape",
+          "producer": "Château Sixtine Cuvée du Vatican",
+          "vintage": "2023",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Châteauneuf-du-Pape",
+          "type": "red",
+          "grapes": [
+            "Grenache",
+            "Syrah",
+            "Mourvèdre"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.568Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.568Z"
+            }
+          ],
+          "price": 279,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 31,
+          "rackRow": 5,
+          "rackCol": 3,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Barolo Azelia",
+          "producer": "Azelia",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.583Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.583Z"
+            }
+          ],
+          "price": 439,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 36,
+          "rackRow": 6,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Azelia",
+          "producer": "Azelia",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.591Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.591Z"
+            }
+          ],
+          "price": 439,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 35,
+          "rackRow": 6,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Azelia",
+          "producer": "Azelia",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.597Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.597Z"
+            }
+          ],
+          "price": 439,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 34,
+          "rackRow": 6,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Del Comune Di Serralunga d'Alba",
+          "producer": "Luigi Baudana",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.608Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.608Z"
+            }
+          ],
+          "price": 349,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 28,
+          "rackRow": 5,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Del Comune Di Serralunga d'Alba",
+          "producer": "Luigi Baudana",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.612Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.612Z"
+            }
+          ],
+          "price": 349,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 27,
+          "rackRow": 5,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Del Comune Di Serralunga d'Alba",
+          "producer": "Luigi Baudana",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.616Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.616Z"
+            }
+          ],
+          "price": 349,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 26,
+          "rackRow": 5,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Del Comune Di Serralunga d'Alba",
+          "producer": "Luigi Baudana",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.621Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.621Z"
+            }
+          ],
+          "price": 349,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 25,
+          "rackRow": 5,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Blaufränkisch Ried Ruster Umriss",
+          "producer": "Feiler Artinger",
+          "vintage": "2021",
+          "country": "Austria",
+          "region": "Burgenland",
+          "appellation": "Rust",
+          "type": "red",
+          "grapes": [
+            "Blaufränkisch"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.624Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.624Z"
+            }
+          ],
+          "price": 150,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 41,
+          "rackRow": 6,
+          "rackCol": 6,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Ried Steinhaus Riesling",
+          "producer": "Steininger",
+          "vintage": "NV",
+          "country": "Austria",
+          "region": "Kamptal",
+          "appellation": "Kamptal DAC",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.627Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.627Z"
+            }
+          ],
+          "price": 219,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-03-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Ried Steinhaus Riesling",
+          "producer": "Steininger",
+          "vintage": "NV",
+          "country": "Austria",
+          "region": "Kamptal",
+          "appellation": "Kamptal DAC",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.630Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.630Z"
+            }
+          ],
+          "price": 219,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 1,
+          "rackRow": 1,
+          "rackCol": 1,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Kaapse Vonkel Brut",
+          "producer": "Simonsig",
+          "vintage": "2023",
+          "country": "South Africa",
+          "region": "Stellenbosch",
+          "appellation": "Stellenbosch",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay",
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.634Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.634Z"
+            }
+          ],
+          "price": 179,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-04-02",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Cepas Viejas Reserva Tempranillo",
+          "producer": "Pata Negra",
+          "vintage": "2018",
+          "country": "Spain",
+          "region": "La Mancha",
+          "appellation": "La Mancha DO",
+          "type": "red",
+          "grapes": [
+            "Tempranillo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.637Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.637Z"
+            }
+          ],
+          "rackName": "Rack A",
+          "rackPosition": 1,
+          "rackRow": 1,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Wildflower Syrah",
+          "producer": "Salomon Estate",
+          "vintage": "2019",
+          "country": "Australia",
+          "region": "Barossa Valley",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Syrah"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.641Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.641Z"
+            }
+          ],
+          "price": 330,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 40,
+          "rackRow": 6,
+          "rackCol": 5,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Vieilles Vignes Riesling Alsace Grand Cru Altenberg de Bergheim",
+          "producer": "Gustave Lorentz",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Alsace",
+          "appellation": "Alsace Grand Cru Altenberg de Bergheim",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.645Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.645Z"
+            }
+          ],
+          "price": 375,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 33,
+          "rackRow": 5,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Vieilles Vignes Riesling Alsace Grand Cru Altenberg de Bergheim",
+          "producer": "Gustave Lorentz",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Alsace",
+          "appellation": "Alsace Grand Cru Altenberg de Bergheim",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.649Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.649Z"
+            }
+          ],
+          "price": 375,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 32,
+          "rackRow": 5,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Mofete Etna Rosso",
+          "producer": "Palmento Costanzo",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Sicily",
+          "appellation": "Etna DOC",
+          "type": "red",
+          "grapes": [
+            "Nerello Mascalese"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.653Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.653Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-07-05",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Barolo Albe",
+          "producer": "G.D. Vajra",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.657Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.657Z"
+            }
+          ],
+          "price": 309,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 37,
+          "rackRow": 6,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Albe",
+          "producer": "G.D. Vajra",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.661Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.661Z"
+            }
+          ],
+          "price": 309,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 36,
+          "rackRow": 6,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Produttori del Barbaresco",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.664Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.664Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 20,
+          "rackRow": 4,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Saint-Émilion Grand Cru (Grand Cru Classé)",
+          "producer": "Château Cadet-Bon",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Saint-Émilion Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Merlot",
+            "Cabernet Franc",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.667Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.667Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 48,
+          "rackRow": 7,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Saint-Émilion Grand Cru (Grand Cru Classé)",
+          "producer": "Château Cadet-Bon",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Saint-Émilion Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Merlot",
+            "Cabernet Franc",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.671Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.671Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 47,
+          "rackRow": 7,
+          "rackCol": 5,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Saint-Émilion Grand Cru (Grand Cru Classé)",
+          "producer": "Château Cadet-Bon",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Saint-Émilion Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Merlot",
+            "Cabernet Franc",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.674Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.674Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-04-03",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling Tradition",
+          "producer": "Philipp Kuhn",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.677Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.677Z"
+            }
+          ],
+          "price": 195,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-03-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Caruso Rosso",
+          "producer": "Terrazze dell'Etna",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Sicily",
+          "appellation": "Etna DOC",
+          "type": "red",
+          "grapes": [
+            "Nerello Mascalese"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.681Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.681Z"
+            }
+          ],
+          "price": 179,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 18,
+          "rackRow": 3,
+          "rackCol": 4,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Albariño",
+          "producer": "Zarate",
+          "vintage": "2023",
+          "country": "Spain",
+          "region": "Galicia",
+          "appellation": "Rías Baixas",
+          "type": "white",
+          "grapes": [
+            "Albariño"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.686Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.686Z"
+            }
+          ],
+          "price": 219,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-03-21",
+          "consumedRating": 90,
+          "consumedRatingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Brut",
+          "producer": "Pongrácz",
+          "vintage": "NV",
+          "country": "South Africa",
+          "region": "Western Cape",
+          "appellation": "",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay",
+            "Pinot Noir",
+            "Pinot Meunier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.690Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.690Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-05-22",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Riesling Feinherb",
+          "producer": "Weingüter Wegeler",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.693Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.693Z"
+            }
+          ],
+          "price": 129,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-03-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Le Petit Tracteur de Brunel",
+          "producer": "André Brunel",
+          "vintage": "2025",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Côtes du Rhône",
+          "type": "red",
+          "grapes": [
+            "Grenache",
+            "Syrah"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.698Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.698Z"
+            }
+          ],
+          "price": 129,
+          "currency": "SEK",
+          "rackName": "Rack A",
+          "rackPosition": 24,
+          "rackRow": 4,
+          "rackCol": 3,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Franciscus Grüner Veltliner",
+          "producer": "Salomon Undhof",
+          "vintage": "2024",
+          "country": "Austria",
+          "region": "Niederösterreich",
+          "appellation": "Wachau",
+          "type": "white",
+          "grapes": [
+            "Grüner Veltliner"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.702Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.702Z"
+            }
+          ],
+          "price": 331,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 39,
+          "rackRow": 6,
+          "rackCol": 4,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Berri Barolo",
+          "producer": "Trediberri",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.705Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.705Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 19,
+          "rackRow": 3,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Berri Barolo",
+          "producer": "Trediberri",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.709Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.709Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-03-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Berri Barolo",
+          "producer": "Trediberri",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.713Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.713Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-03-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Pouilly Fumé 'Les Deux Cailloux'",
+          "producer": "Domaine Fournier Père et Fils",
+          "vintage": "2023",
+          "country": "France",
+          "region": "Loire Valley",
+          "appellation": "Pouilly-Fumé",
+          "type": "white",
+          "grapes": [
+            "Sauvignon Blanc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.717Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.717Z"
+            }
+          ],
+          "price": 249,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-03-15",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Serralunga d'Alba",
+          "producer": "Fontanafredda",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "375ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.720Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.720Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 44,
+          "rackRow": 7,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château La Branne",
+          "producer": "Château La Branne",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Médoc",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.724Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.724Z"
+            }
+          ],
+          "price": 189,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 30,
+          "rackRow": 5,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château La Branne",
+          "producer": "Château La Branne",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Médoc",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.728Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.728Z"
+            }
+          ],
+          "price": 189,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 29,
+          "rackRow": 5,
+          "rackCol": 1,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Barolo",
+          "producer": "Paolo Scavino",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.731Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.731Z"
+            }
+          ],
+          "price": 419,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 38,
+          "rackRow": 6,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo",
+          "producer": "Paolo Scavino",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.734Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.734Z"
+            }
+          ],
+          "price": 419,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 39,
+          "rackRow": 6,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo",
+          "producer": "Paolo Scavino",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.738Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.738Z"
+            }
+          ],
+          "price": 419,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 40,
+          "rackRow": 6,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Gevrey-Chambertin",
+          "producer": "Domaine Trapet",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Gevrey-Chambertin",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.741Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.741Z"
+            }
+          ],
+          "price": 859,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 41,
+          "rackRow": 6,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Gevrey-Chambertin",
+          "producer": "Domaine Trapet",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Gevrey-Chambertin",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.745Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.745Z"
+            }
+          ],
+          "price": 859,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 42,
+          "rackRow": 6,
+          "rackCol": 7,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Les Garrigues",
+          "producer": "Terra Costantino",
+          "vintage": "2022",
+          "country": "Italy",
+          "region": "Sicily",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Nero d'Avola"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.749Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.749Z"
+            }
+          ],
+          "rackName": "Rack E",
+          "rackPosition": 7,
+          "openedAt": "2026-07-10T14:36:17.055Z",
+          "preservationMethod": "vacuum",
+          "pours": [
+            {
+              "at": "2026-07-10T14:36:17.075Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-10T14:36:18.802Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-10T14:36:19.464Z",
+              "ml": 125
+            }
+          ],
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grenache Noir",
+          "producer": "Illimis",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Languedoc-Roussillon",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Grenache"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.752Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.752Z"
+            }
+          ],
+          "price": 285,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-05-09",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Kirschgarten GG Riesling",
+          "producer": "Philipp Kuhn",
+          "vintage": "2022",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "Kirschgarten",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.755Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.755Z"
+            }
+          ],
+          "price": 469,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 31,
+          "rackRow": 5,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Kirschgarten GG Riesling",
+          "producer": "Philipp Kuhn",
+          "vintage": "2022",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "Kirschgarten",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.759Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.759Z"
+            }
+          ],
+          "price": 469,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 30,
+          "rackRow": 5,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "5 Puttonyos Aszú (Blue Label)",
+          "producer": "Royal Tokaji",
+          "vintage": "2018",
+          "country": "Hungary",
+          "region": "Tokaj",
+          "appellation": "Tokaji",
+          "type": "dessert",
+          "grapes": [
+            "Furmint",
+            "Hárslevelű",
+            "Sárgamuskotály"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.764Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.764Z"
+            }
+          ],
+          "price": 359,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 39,
+          "rackRow": 7,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "5 Puttonyos Aszú (Blue Label)",
+          "producer": "Royal Tokaji",
+          "vintage": "2018",
+          "country": "Hungary",
+          "region": "Tokaj",
+          "appellation": "Tokaji",
+          "type": "dessert",
+          "grapes": [
+            "Furmint",
+            "Hárslevelű",
+            "Sárgamuskotály"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.768Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.768Z"
+            }
+          ],
+          "price": 359,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 38,
+          "rackRow": 7,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "5 Puttonyos Aszú (Blue Label)",
+          "producer": "Royal Tokaji",
+          "vintage": "2018",
+          "country": "Hungary",
+          "region": "Tokaj",
+          "appellation": "Tokaji",
+          "type": "dessert",
+          "grapes": [
+            "Furmint",
+            "Hárslevelű",
+            "Sárgamuskotály"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.771Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.771Z"
+            }
+          ],
+          "price": 359,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 37,
+          "rackRow": 7,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo",
+          "producer": "Paolo Scavino",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.780Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.780Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 32,
+          "rackRow": 6,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo",
+          "producer": "Paolo Scavino",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.786Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.786Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "rackName": "Rack B",
+          "rackPosition": 31,
+          "rackRow": 6,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Moscato d'Asti",
+          "producer": "G.D. Vajra",
+          "vintage": "2024",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Moscato d'Asti",
+          "type": "sparkling",
+          "grapes": [
+            "Moscato Bianco"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.790Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.790Z"
+            }
+          ],
+          "price": 149,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-04-02",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Moscato d'Asti",
+          "producer": "G.D. Vajra",
+          "vintage": "2024",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Moscato d'Asti",
+          "type": "sparkling",
+          "grapes": [
+            "Moscato Bianco"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.793Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.793Z"
+            }
+          ],
+          "price": 149,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-04-02",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Cuvée Fleuron",
+          "producer": "Pierre Gimonnet & Fils",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.799Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.799Z"
+            }
+          ],
+          "price": 549,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "other",
+          "consumedAt": "2026-03-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Fixin",
+          "producer": "Albert Bichot",
+          "vintage": "2023",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Fixin",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.807Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.807Z"
+            }
+          ],
+          "price": 259,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-03-21",
+          "consumedRating": 88,
+          "consumedRatingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Fixin",
+          "producer": "Albert Bichot",
+          "vintage": "2023",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Fixin",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.810Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.810Z"
+            }
+          ],
+          "price": 259,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 35,
+          "rackRow": 5,
+          "rackCol": 7,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Faustino I Gran Reserva",
+          "producer": "Bodegas Faustino",
+          "vintage": "2016",
+          "country": "Spain",
+          "region": "La Rioja",
+          "appellation": "Rioja DOCa",
+          "type": "red",
+          "grapes": [
+            "Tempranillo",
+            "Graciano",
+            "Carignan"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.815Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.815Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 45,
+          "rackRow": 7,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Faustino I Gran Reserva",
+          "producer": "Bodegas Faustino",
+          "vintage": "2016",
+          "country": "Spain",
+          "region": "La Rioja",
+          "appellation": "Rioja DOCa",
+          "type": "red",
+          "grapes": [
+            "Tempranillo",
+            "Graciano",
+            "Carignan"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.818Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.818Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 44,
+          "rackRow": 7,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Langhe Nebbiolo",
+          "producer": "Lay & Wheeler",
+          "vintage": "2024",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.822Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.822Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-04-02",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Azelia",
+          "producer": "Azelia",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.825Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.825Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Mâcon Milly-Lamartine Clos du Four",
+          "producer": "Famille Cordier",
+          "vintage": "2024",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Mâcon Milly-Lamartine",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.828Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.828Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Mâcon Milly-Lamartine Clos du Four",
+          "producer": "Famille Cordier",
+          "vintage": "2024",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Mâcon Milly-Lamartine",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.831Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.831Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling Tradition",
+          "producer": "Philipp Kuhn",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.835Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.835Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling Tradition",
+          "producer": "Philipp Kuhn",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.838Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.838Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Langhe Nebbiolo",
+          "producer": "Paolo Scavino",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.841Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.841Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Limited Edition",
+          "producer": "Fontanafredda",
+          "vintage": "NV",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.844Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.844Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-01",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Le Petit Tracteur de Brunel",
+          "producer": "André Brunel",
+          "vintage": "2025",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Côtes du Rhône",
+          "type": "red",
+          "grapes": [
+            "Grenache",
+            "Syrah"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.847Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.847Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-01-23",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Crémant de Bourgogne Brut blanc",
+          "producer": "Domaine des Temps Perdus – Cécile Devaux",
+          "vintage": "NV",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Crémant de Bourgogne",
+          "type": "sparkling",
+          "grapes": [],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.850Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.850Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-01-11",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Pouilly-Fuissé 1er Cru",
+          "producer": "Famille Cordier",
+          "vintage": "2023",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Pouilly-Fuissé",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.853Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.853Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-01-01",
+          "consumedRating": 95,
+          "consumedRatingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Pouilly-Fuissé 1er Cru",
+          "producer": "Famille Cordier",
+          "vintage": "2023",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Pouilly-Fuissé",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.858Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.858Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-12-28",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Ried Seeberg Riesling Kamptal DAC Reserve",
+          "producer": "Weingut Steininger",
+          "vintage": "2020",
+          "country": "Austria",
+          "region": "Kamptal",
+          "appellation": "Kamptal DAC",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.862Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.862Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "other",
+          "consumedAt": "2025-12-12",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Moscatel Roxo",
+          "producer": "José Maria da Fonseca",
+          "vintage": "2021",
+          "country": "Portugal",
+          "region": "Setúbal",
+          "appellation": "Moscatel de Setúbal",
+          "type": "dessert",
+          "grapes": [
+            "Muscat"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.867Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.867Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-12-25",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling Tradition",
+          "producer": "Philipp Kuhn",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.871Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.871Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-12-05",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Nebbiolo Langhe",
+          "producer": "Azelia",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe DOC",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.874Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.874Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-11-22",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Le Blanc de Blancs Millésime Champagne Grand Cru",
+          "producer": "Champagne de Saint-Gall",
+          "vintage": "2017",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.877Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.877Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-11-18",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Chablis",
+          "producer": "Jean-Paul & Benoît Droin",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Chablis",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.881Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.881Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-11-08",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco Cottà",
+          "producer": "Albino Rocca",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.885Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.885Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-10-11",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Rosabella Rosato",
+          "producer": "G.D. Vajra",
+          "vintage": "2024",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Vino Rosato",
+          "type": "rosé",
+          "grapes": [
+            "Barbera",
+            "Dolcetto",
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.888Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.888Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-09-06",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Colección",
+          "producer": "Cuvelier Los Andes",
+          "vintage": "2020",
+          "country": "Argentina",
+          "region": "Mendoza",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Malbec"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.891Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.891Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-09-08",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Organic Malbec",
+          "producer": "Alamos",
+          "vintage": "2023",
+          "country": "Argentina",
+          "region": "Salta",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Malbec"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.894Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.894Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-09-01",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Chianti Classico",
+          "producer": "Poggerino",
+          "vintage": "2022",
+          "country": "Italy",
+          "region": "Tuscany",
+          "appellation": "Chianti Classico DOCG",
+          "type": "red",
+          "grapes": [
+            "Sangiovese"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.896Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.896Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-08-24",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Lilla Vingån",
+          "producer": "Arilds Vingård",
+          "vintage": "2023",
+          "country": "Sweden",
+          "region": "Skåne",
+          "appellation": "",
+          "type": "white",
+          "grapes": [],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.899Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.899Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-08-23",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Sauvignon Blanc",
+          "producer": "Tement",
+          "vintage": "2023",
+          "country": "Austria",
+          "region": "Styria",
+          "appellation": "Südsteiermark",
+          "type": "white",
+          "grapes": [
+            "Sauvignon Blanc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.901Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.901Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-08-23",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Albariño",
+          "producer": "Zarate",
+          "vintage": "2023",
+          "country": "Spain",
+          "region": "Galicia",
+          "appellation": "Rías Baixas",
+          "type": "white",
+          "grapes": [
+            "Albariño"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.904Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.904Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-08-15",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Saint-Émilion Grand Cru (Grand Cru Classé)",
+          "producer": "Château Cadet-Bon",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Saint-Émilion Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Merlot",
+            "Cabernet Franc",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.907Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.907Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "other",
+          "consumedAt": "2025-07-26",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Albe",
+          "producer": "G.D. Vajra",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.910Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.910Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-07-06",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Pinot Noir",
+          "producer": "Black Stallion",
+          "vintage": "2020",
+          "country": "United States",
+          "region": "California",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.913Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.913Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-06-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Moscato d'Asti",
+          "producer": "G.D. Vajra",
+          "vintage": "2024",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Moscato d'Asti",
+          "type": "sparkling",
+          "grapes": [
+            "Moscato Bianco"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.919Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.919Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-06-28",
+          "consumedRating": 85,
+          "consumedRatingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grenache Noir",
+          "producer": "Illimis",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Languedoc-Roussillon",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Grenache"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.924Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.924Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-06-03",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Chablis",
+          "producer": "Jean-Paul & Benoît Droin",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Chablis",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.929Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.929Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-05-28",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Lilla Vingån",
+          "producer": "Arilds Vingård",
+          "vintage": "2023",
+          "country": "Sweden",
+          "region": "Skåne",
+          "appellation": "",
+          "type": "white",
+          "grapes": [],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.935Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.935Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-05-24",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Nebbiolo d'Alba Spumante Brut Rosé",
+          "producer": "Sora Vezza",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Nebbiolo d'Alba",
+          "type": "sparkling",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.939Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.939Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-05-01",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barolo Albe",
+          "producer": "G.D. Vajra",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barolo",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.943Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.943Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-04-27",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Caruso Rosso",
+          "producer": "Terrazze dell'Etna",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Sicily",
+          "appellation": "Etna DOC",
+          "type": "red",
+          "grapes": [
+            "Nerello Mascalese"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.947Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.947Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-04-12",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "P.Lex Langhe Nebbiolo",
+          "producer": "Cantina Terre del Barolo",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.950Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.950Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-04-09",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Pinot Noir",
+          "producer": "Ultra Estate",
+          "vintage": "2020",
+          "country": "United States",
+          "region": "California",
+          "appellation": "Sonoma County",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.955Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.955Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-03-28",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Tradition Pinot Noir",
+          "producer": "Philipp Kuhn",
+          "vintage": "2022",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.957Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.957Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-03-28",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Großkarlbacher Burgweg Riesling",
+          "producer": "Philipp Kuhn",
+          "vintage": "2021",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "Großkarlbach",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.962Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.962Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-03-12",
+          "consumedRating": 4.2,
+          "consumedRatingScale": "5",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Mâcon Milly-Lamartine Clos du Four",
+          "producer": "Famille Cordier",
+          "vintage": "2024",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Mâcon Milly-Lamartine",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.965Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.965Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "other",
+          "consumedAt": "2025-03-01",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Châteauneuf-du-Pape",
+          "producer": "E. Guigal",
+          "vintage": "2018",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Châteauneuf-du-Pape",
+          "type": "red",
+          "grapes": [
+            "Grenache",
+            "Syrah",
+            "Mourvèdre"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.970Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.970Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-23",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Cuvée du Vatican Châteauneuf-du-Pape",
+          "producer": "Château Sixtine",
+          "vintage": "2020",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Châteauneuf-du-Pape",
+          "type": "red",
+          "grapes": [
+            "Grenache",
+            "Syrah",
+            "Mourvèdre",
+            "Cinsault",
+            "Counoise",
+            "Muscardin",
+            "Vaccarèse",
+            "Picpoul",
+            "Terret Noir",
+            "Clairette"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.974Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.974Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-07",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "P.Lex Langhe Nebbiolo",
+          "producer": "Cantina Terre del Barolo",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.977Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.977Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-02-07",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Dawn Méthode Traditionnelle",
+          "producer": "Saint Clair Family Estate",
+          "vintage": "2018",
+          "country": "New Zealand",
+          "region": "Marlborough",
+          "appellation": "",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay",
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.981Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.981Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-01-31",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Produttori del Barbaresco",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.985Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.985Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "other",
+          "consumedAt": "2025-01-26",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "P.Lex Langhe Nebbiolo",
+          "producer": "Cantina Terre del Barolo",
+          "vintage": "2021",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T08:56:39.989Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T08:56:39.989Z"
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2025-01-25",
+          "consumedRating": 3,
+          "consumedRatingScale": "5",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grand Cru Mesnil Sur Oger",
+          "producer": "Michel Gonet",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne Grand Cru",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T10:04:01.010Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T10:04:01.010Z"
+            }
+          ],
+          "price": 549,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 13,
+          "rackRow": 2,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grand Cru Mesnil Sur Oger",
+          "producer": "Michel Gonet",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne Grand Cru",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-13",
+          "addedToCellarAt": "2026-03-13T10:04:01.077Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-13T10:04:01.077Z"
+            }
+          ],
+          "price": 549,
+          "currency": "SEK",
+          "rackName": "Rack C",
+          "rackPosition": 14,
+          "rackRow": 2,
+          "rackCol": 7,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Mâcon Milly-Lamartine Clos du Four",
+          "producer": "Famille Cordier",
+          "vintage": "2024",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Mâcon Milly-Lamartine",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-19",
+          "addedToCellarAt": "2026-03-19T10:34:47.564Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-19T10:34:47.564Z"
+            }
+          ],
+          "price": 299,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 48,
+          "rackRow": 7,
+          "rackCol": 6,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Mâcon Milly-Lamartine Clos du Four",
+          "producer": "Famille Cordier",
+          "vintage": "2024",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Mâcon Milly-Lamartine",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-19",
+          "addedToCellarAt": "2026-03-19T10:34:47.691Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-19T10:34:47.691Z"
+            }
+          ],
+          "price": 299,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 47,
+          "rackRow": 7,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Mâcon Milly-Lamartine Clos du Four",
+          "producer": "Famille Cordier",
+          "vintage": "2024",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Mâcon Milly-Lamartine",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-19",
+          "addedToCellarAt": "2026-03-19T10:34:47.819Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-19T10:34:47.819Z"
+            }
+          ],
+          "price": 299,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 46,
+          "rackRow": 7,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Mâcon Milly-Lamartine Clos du Four",
+          "producer": "Famille Cordier",
+          "vintage": "2024",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Mâcon Milly-Lamartine",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-19",
+          "addedToCellarAt": "2026-03-19T10:34:47.920Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-19T10:34:47.920Z"
+            }
+          ],
+          "price": 299,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-05-17",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Dolcetto d'Alba Bricco dell'Oriolo",
+          "producer": "Azelia",
+          "vintage": "2023",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Dolcetto d'Alba DOC",
+          "type": "red",
+          "grapes": [
+            "Dolcetto"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-19",
+          "addedToCellarAt": "2026-03-19T10:36:57.402Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-19T10:36:57.402Z"
+            }
+          ],
+          "price": 219,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 6,
+          "rackRow": 1,
+          "rackCol": 6,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Dolcetto d'Alba Bricco dell'Oriolo",
+          "producer": "Azelia",
+          "vintage": "2023",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Dolcetto d'Alba DOC",
+          "type": "red",
+          "grapes": [
+            "Dolcetto"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-19",
+          "addedToCellarAt": "2026-03-19T10:36:57.531Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-19T10:36:57.531Z"
+            }
+          ],
+          "price": 219,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 4,
+          "rackRow": 1,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Dolcetto d'Alba Bricco dell'Oriolo",
+          "producer": "Azelia",
+          "vintage": "2023",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Dolcetto d'Alba DOC",
+          "type": "red",
+          "grapes": [
+            "Dolcetto"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-19",
+          "addedToCellarAt": "2026-03-19T10:36:57.634Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-19T10:36:57.634Z"
+            }
+          ],
+          "price": 219,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 5,
+          "rackRow": 1,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Mâcon Milly-Lamartine Clos du Four",
+          "producer": "Famille Cordier",
+          "vintage": "2024",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Mâcon Milly-Lamartine",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-24",
+          "addedToCellarAt": "2026-03-24T11:44:46.143Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-24T11:44:46.143Z"
+            }
+          ],
+          "price": 250,
+          "currency": "SEK",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-03-24",
+          "consumedRating": 4,
+          "consumedRatingScale": "5",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Fleuron Blanc de Blancs Brut 1er Cru",
+          "producer": "Pierre Gimonnet & Fils",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne 1er Cru",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-27",
+          "addedToCellarAt": "2026-03-27T15:37:58.621Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-27T15:37:58.621Z"
+            }
+          ],
+          "price": 549,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 12,
+          "rackRow": 2,
+          "rackCol": 5,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Alta Langa Limited Edition Brut",
+          "producer": "Fontanafredda",
+          "vintage": "2022",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Alta Langa DOCG",
+          "type": "sparkling",
+          "grapes": [
+            "Pinot Nero",
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-27",
+          "addedToCellarAt": "2026-03-27T15:40:22.776Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-27T15:40:22.776Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 11,
+          "rackRow": 2,
+          "rackCol": 4,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Ried Steinhaus Riesling",
+          "producer": "Steininger",
+          "vintage": "2023",
+          "country": "Austria",
+          "region": "Kamptal",
+          "appellation": "Kamptal DAC",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-03-27",
+          "addedToCellarAt": "2026-03-27T15:45:50.903Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-03-27T15:45:50.903Z"
+            }
+          ],
+          "price": 219,
+          "currency": "SEK",
+          "rackName": "Rack D",
+          "rackPosition": 2,
+          "rackRow": 1,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "deAetna Etna Rosso",
+          "producer": "Terra Costantino",
+          "vintage": "2022",
+          "country": "Italy",
+          "region": "Sicily",
+          "appellation": "Etna Rosso DOC",
+          "type": "red",
+          "grapes": [
+            "Nerello Mascalese"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-02",
+          "addedToCellarAt": "2026-04-02T13:56:48.109Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-02T13:56:48.109Z"
+            }
+          ],
+          "price": 195,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-02",
+          "rackName": "Rack A",
+          "rackPosition": 18,
+          "rackRow": 3,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "L'appel des Sereines",
+          "producer": "François Villard",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Saint-Michel-sur-Rhône",
+          "type": "red",
+          "grapes": [
+            "Syrah"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-09",
+          "addedToCellarAt": "2026-04-09T08:31:49.084Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-09T08:31:49.084Z"
+            }
+          ],
+          "price": 189,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-09",
+          "rackName": "Rack D",
+          "rackPosition": 22,
+          "rackRow": 4,
+          "rackCol": 1,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "L'appel des Sereines",
+          "producer": "François Villard",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Saint-Michel-sur-Rhône",
+          "type": "red",
+          "grapes": [
+            "Syrah"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-09",
+          "addedToCellarAt": "2026-04-09T08:31:49.233Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-09T08:31:49.233Z"
+            }
+          ],
+          "price": 189,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-09",
+          "rackName": "Rack D",
+          "rackPosition": 25,
+          "rackRow": 4,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "L'appel des Sereines",
+          "producer": "François Villard",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Saint-Michel-sur-Rhône",
+          "type": "red",
+          "grapes": [
+            "Syrah"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-09",
+          "addedToCellarAt": "2026-04-09T08:31:49.396Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-09T08:31:49.396Z"
+            }
+          ],
+          "price": 189,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-09",
+          "rackName": "Rack D",
+          "rackPosition": 24,
+          "rackRow": 4,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "L'appel des Sereines",
+          "producer": "François Villard",
+          "vintage": "2022",
+          "country": "France",
+          "region": "Rhône Valley",
+          "appellation": "Saint-Michel-sur-Rhône",
+          "type": "red",
+          "grapes": [
+            "Syrah"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-09",
+          "addedToCellarAt": "2026-04-09T08:31:49.495Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-09T08:31:49.495Z"
+            }
+          ],
+          "price": 189,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-09",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-05-22",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Chianti Classico Storia di Famiglia",
+          "producer": "Cecchi",
+          "vintage": "2024",
+          "country": "Italy",
+          "region": "Tuscany",
+          "appellation": "Chianti Classico DOCG",
+          "type": "red",
+          "grapes": [
+            "Sangiovese"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-10",
+          "addedToCellarAt": "2026-04-10T10:02:44.408Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-10T10:02:44.408Z"
+            }
+          ],
+          "price": 139,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-10",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-04-11",
+          "consumedRating": 85,
+          "consumedRatingScale": "100",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Langhe Nebbiolo",
+          "producer": "Alberto Ballarin",
+          "vintage": "2024",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe DOC",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-17",
+          "addedToCellarAt": "2026-04-17T15:18:07.685Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-17T15:18:07.685Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-17",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-04-17",
+          "consumedRating": 87,
+          "consumedRatingScale": "100",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Pinot Noir",
+          "producer": "Schwarz Wein GmbH & Co KG",
+          "vintage": "2023",
+          "country": "Austria",
+          "region": "Burgenland",
+          "appellation": "Österreichischer Qualitätswein",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-30",
+          "addedToCellarAt": "2026-04-30T08:33:11.311Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-30T08:33:11.311Z"
+            }
+          ],
+          "price": 169,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-30",
+          "rackName": "Rack A",
+          "rackPosition": 3,
+          "rackRow": 1,
+          "rackCol": 3,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Pinot Noir",
+          "producer": "Schwarz Wein GmbH & Co KG",
+          "vintage": "2023",
+          "country": "Austria",
+          "region": "Burgenland",
+          "appellation": "Österreichischer Qualitätswein",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-30",
+          "addedToCellarAt": "2026-04-30T08:33:11.424Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-30T08:33:11.424Z"
+            }
+          ],
+          "price": 169,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-30",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-04-30",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling Tradition",
+          "producer": "Philipp Kuhn",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-30",
+          "addedToCellarAt": "2026-04-30T10:20:51.859Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-30T10:20:51.859Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-30",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-06-05",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling Tradition",
+          "producer": "Philipp Kuhn",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-30",
+          "addedToCellarAt": "2026-04-30T10:20:51.951Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-30T10:20:51.951Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-30",
+          "rackName": "Rack A",
+          "rackPosition": 23,
+          "rackRow": 4,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling Tradition",
+          "producer": "Philipp Kuhn",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-30",
+          "addedToCellarAt": "2026-04-30T10:20:52.068Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-30T10:20:52.068Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-30",
+          "rackName": "Rack A",
+          "rackPosition": 7,
+          "rackRow": 1,
+          "rackCol": 7,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling Tradition",
+          "producer": "Philipp Kuhn",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-30",
+          "addedToCellarAt": "2026-04-30T10:20:52.161Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-30T10:20:52.161Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-30",
+          "rackName": "Rack A",
+          "rackPosition": 6,
+          "rackRow": 1,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling Tradition",
+          "producer": "Philipp Kuhn",
+          "vintage": "2024",
+          "country": "Germany",
+          "region": "Pfalz",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-04-30",
+          "addedToCellarAt": "2026-04-30T10:20:52.258Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-04-30T10:20:52.258Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-04-30",
+          "rackName": "Rack A",
+          "rackPosition": 5,
+          "rackRow": 1,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Produttori del Barbaresco",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-05-10",
+          "addedToCellarAt": "2026-05-10T13:46:56.276Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-05-10T13:46:56.276Z"
+            }
+          ],
+          "price": 399,
+          "currency": "SEK",
+          "purchaseDate": "2026-05-10",
+          "rackName": "Rack B",
+          "rackPosition": 19,
+          "rackRow": 4,
+          "rackCol": 1,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Rosabella Rosato",
+          "producer": "G.D. Vajra",
+          "vintage": "2025",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Vino Rosato",
+          "type": "rosé",
+          "grapes": [
+            "Barbera",
+            "Dolcetto",
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-05-28",
+          "addedToCellarAt": "2026-05-28T18:07:56.277Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-05-28T18:07:56.277Z"
+            }
+          ],
+          "price": 139,
+          "currency": "SEK",
+          "purchaseDate": "2026-05-28",
+          "rackName": "Rack A",
+          "rackPosition": 10,
+          "rackRow": 2,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Langhe Nebbiolo",
+          "producer": "Trediberri",
+          "vintage": "2025",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe DOC",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-05-29",
+          "addedToCellarAt": "2026-05-29T08:29:23.782Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-05-29T08:29:23.782Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-05-29",
+          "rackName": "Rack D",
+          "rackPosition": 16,
+          "rackRow": 3,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Langhe Nebbiolo",
+          "producer": "Trediberri",
+          "vintage": "2025",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe DOC",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-05-29",
+          "addedToCellarAt": "2026-05-29T08:29:23.983Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-05-29T08:29:23.983Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-05-29",
+          "rackName": "Rack D",
+          "rackPosition": 15,
+          "rackRow": 3,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Langhe Nebbiolo",
+          "producer": "Trediberri",
+          "vintage": "2025",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Langhe DOC",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-05-29",
+          "addedToCellarAt": "2026-05-29T08:29:24.164Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-05-29T08:29:24.164Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-05-29",
+          "rackName": "Rack D",
+          "rackPosition": 17,
+          "rackRow": 3,
+          "rackCol": 3,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Hey Malbec",
+          "producer": "Riccitelli",
+          "vintage": "2024",
+          "country": "Argentina",
+          "region": "Mendoza",
+          "appellation": "Mendoza",
+          "type": "red",
+          "grapes": [
+            "Malbec"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-05-29",
+          "addedToCellarAt": "2026-05-29T18:06:06.016Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-05-29T18:06:06.016Z"
+            }
+          ],
+          "price": 159,
+          "currency": "SEK",
+          "purchaseDate": "2026-05-29",
+          "rackName": "Rack A",
+          "rackPosition": 4,
+          "rackRow": 1,
+          "rackCol": 4,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Break a Leg Chardonnay",
+          "producer": "Lukas von Loggerenberg",
+          "vintage": "2024",
+          "country": "South Africa",
+          "region": "Western Cape",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-05-29",
+          "addedToCellarAt": "2026-05-29T18:10:45.658Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-05-29T18:10:45.658Z"
+            }
+          ],
+          "price": 159,
+          "currency": "SEK",
+          "purchaseDate": "2026-05-29",
+          "rackName": "Rack D",
+          "rackPosition": 38,
+          "rackRow": 6,
+          "rackCol": 3,
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Reserve Pinot Noir",
+          "producer": "Gardo & Morris",
+          "vintage": "2020",
+          "country": "New Zealand",
+          "region": "Central Otago",
+          "appellation": "Central Otago",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-16",
+          "addedToCellarAt": "2026-07-06T18:31:20.246Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-16T09:46:21.495Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:31:37.761Z"
+            },
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-07-06T18:31:20.246Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-16",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Estate Chardonnay",
+          "producer": "Kumeu River",
+          "vintage": "2024",
+          "country": "New Zealand",
+          "region": "Auckland",
+          "appellation": "Kumeu",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-18",
+          "addedToCellarAt": "2026-07-07T14:59:53.223Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-18T11:00:19.489Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:31:06.929Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-07-06T18:31:47.825Z"
+            },
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-07-07T14:59:53.223Z"
+            }
+          ],
+          "price": 289,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-18",
+          "rackName": "Rack E",
+          "rackPosition": 4,
+          "openedAt": "2026-07-10T14:35:54.938Z",
+          "preservationMethod": "inert-gas",
+          "pours": [
+            {
+              "at": "2026-07-10T14:35:54.966Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-10T14:37:28.515Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-10T14:37:30.004Z",
+              "ml": 125
+            }
+          ],
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Estate Chardonnay",
+          "producer": "Kumeu River",
+          "vintage": "2024",
+          "country": "New Zealand",
+          "region": "Auckland",
+          "appellation": "Kumeu",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-18",
+          "addedToCellarAt": "2026-07-06T18:31:34.462Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-18T11:00:19.606Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:30:59.656Z"
+            },
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-07-06T18:31:34.462Z"
+            }
+          ],
+          "price": 289,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-18",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-07-10",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Atemporal",
+          "producer": "Alta Vista",
+          "vintage": "2023",
+          "country": "Argentina",
+          "region": "Mendoza",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Malbec",
+            "Cabernet Sauvignon",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-18",
+          "addedToCellarAt": "2026-06-18T11:01:29.276Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-18T11:01:29.276Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-18",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-06-20",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Atemporal",
+          "producer": "Alta Vista",
+          "vintage": "2023",
+          "country": "Argentina",
+          "region": "Mendoza",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Malbec",
+            "Cabernet Sauvignon",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-18",
+          "addedToCellarAt": "2026-06-18T11:01:29.629Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-18T11:01:29.629Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-18",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-06-20",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Blanc de Blancs",
+          "producer": "Pongrácz",
+          "vintage": "NV",
+          "country": "South Africa",
+          "region": "Western Cape",
+          "appellation": "Méthode Cap Classique",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-23",
+          "addedToCellarAt": "2026-07-06T18:31:59.236Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-23T11:34:05.357Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:30:25.527Z"
+            },
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-07-06T18:31:59.236Z"
+            }
+          ],
+          "price": 172,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-23",
+          "openedAt": "2026-07-10T14:19:50.867Z",
+          "preservationMethod": "coravin",
+          "pours": [
+            {
+              "at": "2026-07-10T14:19:57.222Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-10T14:19:58.250Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-10T14:19:59.248Z",
+              "ml": 125
+            }
+          ],
+          "reviews": [],
+          "images": []
+        }
+      ]
+    },
+    {
+      "cellarName": "Office",
+      "description": "",
       "racks": [],
-      "layout": null,
+      "bottles": [
+        {
+          "wineName": "Blanc de Blancs",
+          "producer": "Pongrácz",
+          "vintage": "NV",
+          "country": "South Africa",
+          "region": "Western Cape",
+          "appellation": "Méthode Cap Classique",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-23",
+          "addedToCellarAt": "2026-06-24T06:30:42.092Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-23T11:34:04.991Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:30:42.092Z"
+            }
+          ],
+          "price": 172,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-23",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Blanc de Blancs",
+          "producer": "Pongrácz",
+          "vintage": "NV",
+          "country": "South Africa",
+          "region": "Western Cape",
+          "appellation": "Méthode Cap Classique",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-23",
+          "addedToCellarAt": "2026-06-24T06:30:34.132Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-23T11:34:05.138Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:30:34.132Z"
+            }
+          ],
+          "price": 172,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-23",
+          "reviews": [],
+          "images": []
+        }
+      ]
+    },
+    {
+      "cellarName": "Summer House",
+      "description": "",
+      "racks": [],
+      "bottles": [
+        {
+          "wineName": "Moscato d'Asti",
+          "producer": "G.D. Vajra",
+          "vintage": "2024",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Moscato d'Asti",
+          "type": "sparkling",
+          "grapes": [
+            "Moscato Bianco"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-05-09",
+          "addedToCellarAt": "2026-06-28T15:41:05.243Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-05-09T15:56:19.014Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-06-28T15:41:05.243Z"
+            }
+          ],
+          "price": 149,
+          "currency": "SEK",
+          "purchaseDate": "2026-05-09",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Rosabella Rosato",
+          "producer": "G.D. Vajra",
+          "vintage": "2025",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Vino Rosato",
+          "type": "rosé",
+          "grapes": [
+            "Barbera",
+            "Dolcetto",
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-05-28",
+          "addedToCellarAt": "2026-06-28T15:40:52.907Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-05-28T18:07:56.076Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-06-28T15:40:52.907Z"
+            }
+          ],
+          "price": 139,
+          "currency": "SEK",
+          "purchaseDate": "2026-05-28",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Blanc de Blancs",
+          "producer": "Pongrácz",
+          "vintage": "NV",
+          "country": "South Africa",
+          "region": "Western Cape",
+          "appellation": "Méthode Cap Classique",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-03",
+          "addedToCellarAt": "2026-06-28T15:43:25.631Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-03T17:51:14.989Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-06-28T15:43:25.631Z"
+            }
+          ],
+          "price": 172,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-03",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Reserve Pinot Noir",
+          "producer": "Gardo & Morris",
+          "vintage": "2020",
+          "country": "New Zealand",
+          "region": "Central Otago",
+          "appellation": "Central Otago",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-16",
+          "addedToCellarAt": "2026-07-08T14:16:44.014Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-16T09:46:21.410Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:31:46.148Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-07-08T14:16:44.014Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-16",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Pinot Noir",
+          "producer": "Rocky Point",
+          "vintage": "2024",
+          "country": "New Zealand",
+          "region": "Central Otago",
+          "appellation": "Central Otago",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-16",
+          "addedToCellarAt": "2026-07-08T14:16:07.765Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-16T09:47:32.104Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:31:30.308Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-07-08T14:16:07.765Z"
+            }
+          ],
+          "price": 329,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-16",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Pinot Noir",
+          "producer": "Dicey",
+          "vintage": "2022",
+          "country": "New Zealand",
+          "region": "Central Otago",
+          "appellation": "Bannockburn",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-16",
+          "addedToCellarAt": "2026-07-08T14:16:01.100Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-16T09:48:22.071Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:30:49.422Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-07-08T14:16:01.100Z"
+            }
+          ],
+          "price": 259,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-16",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Estate Chardonnay",
+          "producer": "Kumeu River",
+          "vintage": "2024",
+          "country": "New Zealand",
+          "region": "Auckland",
+          "appellation": "Kumeu",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-18",
+          "addedToCellarAt": "2026-07-08T14:15:50.833Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-18T11:00:19.212Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:31:22.936Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-07-08T14:15:50.833Z"
+            }
+          ],
+          "price": 289,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-18",
+          "images": [],
+          "reviews": []
+        },
+        {
+          "wineName": "Estate Chardonnay",
+          "producer": "Kumeu River",
+          "vintage": "2024",
+          "country": "New Zealand",
+          "region": "Auckland",
+          "appellation": "Kumeu",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-18",
+          "addedToCellarAt": "2026-07-07T14:45:18.508Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-18T11:00:19.378Z"
+            },
+            {
+              "cellarName": "Office",
+              "enteredAt": "2026-06-24T06:31:15.185Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-07-07T14:45:18.508Z"
+            }
+          ],
+          "price": 289,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-18",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Atemporal",
+          "producer": "Alta Vista",
+          "vintage": "2023",
+          "country": "Argentina",
+          "region": "Mendoza",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Malbec",
+            "Cabernet Sauvignon",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2026-06-18",
+          "addedToCellarAt": "2026-06-24T06:30:15.044Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Main Cellar",
+              "enteredAt": "2026-06-18T11:01:29.423Z"
+            },
+            {
+              "cellarName": "Summer House",
+              "enteredAt": "2026-06-24T06:30:15.044Z"
+            }
+          ],
+          "price": 199,
+          "currency": "SEK",
+          "purchaseDate": "2026-06-18",
+          "reviews": [],
+          "images": []
+        }
+      ]
+    },
+    {
+      "cellarName": "Imported Collection",
+      "description": "",
+      "racks": [
+        {
+          "name": "Basement 1",
+          "type": "grid",
+          "rows": 2,
+          "cols": 3
+        },
+        {
+          "name": "Basement 2",
+          "type": "grid",
+          "rows": 2,
+          "cols": 3
+        },
+        {
+          "name": "Basement 3",
+          "type": "grid",
+          "rows": 2,
+          "cols": 3
+        },
+        {
+          "name": "Cellar Rack",
+          "type": "grid",
+          "rows": 4,
+          "cols": 5
+        },
+        {
+          "name": "Double Deep",
+          "type": "shelf",
+          "rows": 2,
+          "cols": 4,
+          "typeConfig": {
+            "bottlesPerCell": 1,
+            "backCols": 4
+          }
+        },
+        {
+          "name": "Storage Box",
+          "type": "grid",
+          "rows": 4,
+          "cols": 6
+        },
+        {
+          "name": "Wine Fridge",
+          "type": "grid",
+          "rows": 2,
+          "cols": 6
+        }
+      ],
       "bottles": [
         {
           "wineName": "Château Margaux",
           "producer": "Château Margaux",
+          "vintage": "2015",
           "country": "France",
           "region": "Bordeaux",
           "appellation": "Margaux",
           "type": "red",
-          "grapes": ["Cabernet Sauvignon", "Merlot"],
-          "vintage": "2015",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-01-01",
+          "addedToCellarAt": "2018-01-01T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-01-01T00:00:00.000Z"
+            }
+          ],
+          "price": 650,
           "currency": "EUR",
-          "bottleSize": "750ml"
+          "purchaseDate": "2018-01-01",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2025,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 1,
+          "rackRow": 1,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
         },
         {
-          "wineName": "Sauvignon Blanc",
-          "producer": "Cloudy Bay",
-          "country": "New Zealand",
-          "region": "Marlborough",
+          "wineName": "Château Margaux",
+          "producer": "Château Margaux",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Margaux",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-02-02",
+          "addedToCellarAt": "2019-02-02T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-02-02T00:00:00.000Z"
+            }
+          ],
+          "price": 650,
+          "currency": "EUR",
+          "purchaseDate": "2019-02-02",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2025,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 2,
+          "rackRow": 1,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Margaux",
+          "producer": "Château Margaux",
+          "vintage": "2018",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Margaux",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2020-03-03",
+          "addedToCellarAt": "2020-03-03T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-03-03T00:00:00.000Z"
+            }
+          ],
+          "price": 650,
+          "currency": "EUR",
+          "purchaseDate": "2020-03-03",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2025,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 3,
+          "rackRow": 1,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Tâche",
+          "producer": "Domaine de la Romanée-Conti",
+          "vintage": "2017",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "La Tâche Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-04-04",
+          "addedToCellarAt": "2021-04-04T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-04-04T00:00:00.000Z"
+            }
+          ],
+          "price": 3200,
+          "currency": "EUR",
+          "purchaseDate": "2021-04-04",
+          "drinkFrom": 2027,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 4,
+          "rackRow": 1,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Tâche",
+          "producer": "Domaine de la Romanée-Conti",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "La Tâche Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-05-05",
+          "addedToCellarAt": "2022-05-05T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-05-05T00:00:00.000Z"
+            }
+          ],
+          "price": 3200,
+          "currency": "EUR",
+          "purchaseDate": "2022-05-05",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2027,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 5,
+          "rackRow": 1,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Joh Jos Prüm Wehlener Sonnenuhr Spätlese",
+          "producer": "Joh. Jos. Prüm",
+          "vintage": "2019",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Wehlener Sonnenuhr",
           "type": "white",
-          "grapes": ["Sauvignon Blanc"],
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-06-06",
+          "addedToCellarAt": "2023-06-06T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-06-06T00:00:00.000Z"
+            }
+          ],
+          "price": 45,
+          "currency": "EUR",
+          "purchaseDate": "2023-06-06",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 92,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 6,
+          "rackRow": 1,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Wehlener Sonnenuhr Riesling Auslese",
+          "producer": "Joh. Jos. Prüm",
+          "vintage": "2020",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Wehlener Sonnenuhr",
+          "type": "dessert",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-07-07",
+          "addedToCellarAt": "2024-07-07T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-07-07T00:00:00.000Z"
+            }
+          ],
+          "price": 45,
+          "currency": "EUR",
+          "purchaseDate": "2024-07-07",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 92,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 7,
+          "rackRow": 2,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Wehlener Sonnenuhr Riesling Auslese",
+          "producer": "Joh. Jos. Prüm",
+          "vintage": "2021",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Wehlener Sonnenuhr",
+          "type": "dessert",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-08-08",
+          "addedToCellarAt": "2018-08-08T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-08-08T00:00:00.000Z"
+            }
+          ],
+          "price": 45,
+          "currency": "EUR",
+          "purchaseDate": "2018-08-08",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 92,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 8,
+          "rackRow": 2,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grande Cuvée Brut",
+          "producer": "Krug",
+          "vintage": "NV",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne AOC",
+          "type": "sparkling",
+          "grapes": [
+            "Pinot Noir",
+            "Chardonnay",
+            "Pinot Meunier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-09-09",
+          "addedToCellarAt": "2019-09-09T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-09-09T00:00:00.000Z"
+            }
+          ],
+          "price": 220,
+          "currency": "EUR",
+          "purchaseDate": "2019-09-09",
+          "rating": 95,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 9,
+          "rackRow": 2,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château d'Yquem",
+          "producer": "Château d'Yquem",
+          "vintage": "2015",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Sauternes",
+          "type": "dessert",
+          "grapes": [
+            "Sémillon",
+            "Sauvignon Blanc"
+          ],
+          "bottleSize": "375ml",
+          "dateAdded": "2020-10-10",
+          "addedToCellarAt": "2020-10-10T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-10-10T00:00:00.000Z"
+            }
+          ],
+          "price": 210,
+          "currency": "EUR",
+          "purchaseDate": "2020-10-10",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2025,
+          "drinkTo": 2070,
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 10,
+          "rackRow": 2,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Pétrus",
+          "producer": "Pétrus",
+          "vintage": "2010",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Pomerol",
+          "type": "red",
+          "grapes": [
+            "Merlot",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-11-11",
+          "addedToCellarAt": "2021-11-11T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-11-11T00:00:00.000Z"
+            }
+          ],
+          "price": 4100,
+          "currency": "EUR",
+          "purchaseDate": "2021-11-11",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2022,
+          "drinkTo": 2050,
+          "rackName": "Wine Fridge",
+          "rackPosition": 11,
+          "rackRow": 2,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Mouline",
+          "producer": "E. Guigal",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Rhône",
+          "appellation": "Côte-Rôtie",
+          "type": "red",
+          "grapes": [
+            "Syrah",
+            "Viognier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-12-12",
+          "addedToCellarAt": "2022-12-12T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-12-12T00:00:00.000Z"
+            }
+          ],
+          "price": 380,
+          "currency": "EUR",
+          "purchaseDate": "2022-12-12",
+          "purchaseLocation": "Millesima",
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Wine Fridge",
+          "rackPosition": 12,
+          "rackRow": 2,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Mouline",
+          "producer": "E. Guigal",
+          "vintage": "2017",
+          "country": "France",
+          "region": "Rhône",
+          "appellation": "Côte-Rôtie",
+          "type": "red",
+          "grapes": [
+            "Syrah",
+            "Viognier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-01-13",
+          "addedToCellarAt": "2023-01-13T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-01-13T00:00:00.000Z"
+            }
+          ],
+          "price": 380,
+          "currency": "EUR",
+          "purchaseDate": "2023-01-13",
+          "purchaseLocation": "K&L Wines",
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 1,
+          "rackRow": 1,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Gaja",
+          "vintage": "2016",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-02-14",
+          "addedToCellarAt": "2024-02-14T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-02-14T00:00:00.000Z"
+            }
+          ],
+          "price": 240,
+          "currency": "EUR",
+          "purchaseDate": "2024-02-14",
+          "drinkFrom": 2026,
+          "drinkTo": 2048,
+          "rating": 94,
+          "ratingScale": "100",
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-07-11",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Gaja",
+          "vintage": "2018",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-03-15",
+          "addedToCellarAt": "2018-03-15T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-03-15T00:00:00.000Z"
+            }
+          ],
+          "price": 240,
+          "currency": "EUR",
+          "purchaseDate": "2018-03-15",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2026,
+          "drinkTo": 2048,
+          "rating": 94,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 3,
+          "rackRow": 1,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Gaja",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-04-16",
+          "addedToCellarAt": "2019-04-16T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-04-16T00:00:00.000Z"
+            }
+          ],
+          "price": 240,
+          "currency": "EUR",
+          "purchaseDate": "2019-04-16",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2026,
+          "drinkTo": 2048,
+          "rating": 94,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 4,
+          "rackRow": 1,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Único",
+          "producer": "Vega Sicilia",
+          "vintage": "2011",
+          "country": "Spain",
+          "region": "Castilla y León",
+          "appellation": "Ribera del Duero",
+          "type": "red",
+          "grapes": [
+            "Tempranillo",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2020-05-17",
+          "addedToCellarAt": "2020-05-17T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-05-17T00:00:00.000Z"
+            }
+          ],
+          "price": 420,
+          "currency": "EUR",
+          "purchaseDate": "2020-05-17",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 5,
+          "rackRow": 1,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Único",
+          "producer": "Vega Sicilia",
+          "vintage": "2012",
+          "country": "Spain",
+          "region": "Castilla y León",
+          "appellation": "Ribera del Duero",
+          "type": "red",
+          "grapes": [
+            "Tempranillo",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-06-18",
+          "addedToCellarAt": "2021-06-18T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-06-18T00:00:00.000Z"
+            }
+          ],
+          "price": 420,
+          "currency": "EUR",
+          "purchaseDate": "2021-06-18",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 6,
+          "rackRow": 2,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grange",
+          "producer": "Penfolds",
+          "vintage": "2017",
+          "country": "Australia",
+          "region": "South Australia",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Syrah",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-07-19",
+          "addedToCellarAt": "2022-07-19T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-07-19T00:00:00.000Z"
+            }
+          ],
+          "price": 720,
+          "currency": "AUD",
+          "purchaseDate": "2022-07-19",
+          "drinkFrom": 2027,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 7,
+          "rackRow": 2,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Monte Bello",
+          "producer": "Ridge",
+          "vintage": "2018",
+          "country": "USA",
+          "region": "Santa Cruz Mountains",
+          "appellation": "Santa Cruz Mountains",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Petit Verdot",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-08-20",
+          "addedToCellarAt": "2023-08-20T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-08-20T00:00:00.000Z"
+            }
+          ],
+          "price": 260,
+          "currency": "USD",
+          "purchaseDate": "2023-08-20",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 8,
+          "rackRow": 2,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Monte Bello",
+          "producer": "Ridge",
+          "vintage": "2019",
+          "country": "USA",
+          "region": "Santa Cruz Mountains",
+          "appellation": "Santa Cruz Mountains",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Petit Verdot",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-09-21",
+          "addedToCellarAt": "2024-09-21T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-09-21T00:00:00.000Z"
+            }
+          ],
+          "price": 260,
+          "currency": "USD",
+          "purchaseDate": "2024-09-21",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 9,
+          "rackRow": 2,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Mouton Rothschild",
+          "producer": "Château Mouton Rothschild",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Pauillac",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "1500ml",
+          "dateAdded": "2018-10-22",
+          "addedToCellarAt": "2018-10-22T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-10-22T00:00:00.000Z"
+            }
+          ],
+          "price": 1450,
+          "currency": "EUR",
+          "purchaseDate": "2018-10-22",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2026,
+          "drinkTo": 2060,
+          "rating": 99,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 10,
+          "rackRow": 2,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Vintage Porto",
+          "producer": "Taylor Fladgate",
+          "vintage": "2017",
+          "country": "Portugal",
+          "region": "Douro Valley",
+          "appellation": "Porto",
+          "type": "fortified",
+          "grapes": [
+            "Touriga Nacional",
+            "Touriga Franca",
+            "Tinta Roriz",
+            "Tinta Barroca",
+            "Tinto Cão"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-11-23",
+          "addedToCellarAt": "2019-11-23T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-11-23T00:00:00.000Z"
+            }
+          ],
+          "price": 95,
+          "currency": "EUR",
+          "purchaseDate": "2019-11-23",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2035,
+          "drinkTo": 2080,
+          "rating": 95,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 11,
+          "rackRow": 3,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Scharzhofberger Riesling Kabinett",
+          "producer": "Egon Müller",
+          "vintage": "2020",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Scharzhofberg",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2020-12-24",
+          "addedToCellarAt": "2020-12-24T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-12-24T00:00:00.000Z"
+            }
+          ],
+          "price": 320,
+          "currency": "EUR",
+          "purchaseDate": "2020-12-24",
+          "rackName": "Cellar Rack",
+          "rackPosition": 12,
+          "rackRow": 3,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Scharzhofberger Riesling Kabinett",
+          "producer": "Egon Müller",
           "vintage": "2022",
-          "currency": "NZD",
-          "bottleSize": "750ml"
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Scharzhofberg",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-01-25",
+          "addedToCellarAt": "2021-01-25T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-01-25T00:00:00.000Z"
+            }
+          ],
+          "price": 320,
+          "currency": "EUR",
+          "purchaseDate": "2021-01-25",
+          "purchaseLocation": "Auction",
+          "rackName": "Cellar Rack",
+          "rackPosition": 13,
+          "rackRow": 3,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Puligny-Montrachet Les Combettes",
+          "producer": "Domaine Leflaive",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Puligny-Montrachet 1er Cru",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-02-26",
+          "addedToCellarAt": "2022-02-26T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-02-26T00:00:00.000Z"
+            }
+          ],
+          "price": 285,
+          "currency": "EUR",
+          "purchaseDate": "2022-02-26",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2023,
+          "drinkTo": 2035,
+          "rating": 93,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 14,
+          "rackRow": 3,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Puligny-Montrachet Les Combettes",
+          "producer": "Domaine Leflaive",
+          "vintage": "2020",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Puligny-Montrachet 1er Cru",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-03-27",
+          "addedToCellarAt": "2023-03-27T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-03-27T00:00:00.000Z"
+            }
+          ],
+          "price": 285,
+          "currency": "EUR",
+          "purchaseDate": "2023-03-27",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2023,
+          "drinkTo": 2035,
+          "rating": 93,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 15,
+          "rackRow": 3,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Sassicaia",
+          "producer": "Tenuta San Guido",
+          "vintage": "2018",
+          "country": "Italy",
+          "region": "Tuscany",
+          "appellation": "Bolgheri Sassicaia DOC",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-04-01",
+          "addedToCellarAt": "2024-04-01T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-04-01T00:00:00.000Z"
+            }
+          ],
+          "price": 310,
+          "currency": "EUR",
+          "purchaseDate": "2024-04-01",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 16,
+          "rackRow": 4,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Sassicaia",
+          "producer": "Tenuta San Guido",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Tuscany",
+          "appellation": "Bolgheri Sassicaia DOC",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-05-02",
+          "addedToCellarAt": "2018-05-02T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-05-02T00:00:00.000Z"
+            }
+          ],
+          "price": 310,
+          "currency": "EUR",
+          "purchaseDate": "2018-05-02",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 17,
+          "rackRow": 4,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Sassicaia",
+          "producer": "Tenuta San Guido",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Tuscany",
+          "appellation": "Bolgheri Sassicaia DOC",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-06-03",
+          "addedToCellarAt": "2019-06-03T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-06-03T00:00:00.000Z"
+            }
+          ],
+          "price": 310,
+          "currency": "EUR",
+          "purchaseDate": "2019-06-03",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 18,
+          "rackRow": 4,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Le Mesnil Blanc de Blancs",
+          "producer": "Champagne Salon",
+          "vintage": "2012",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne AOC",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "1500ml",
+          "dateAdded": "2020-07-04",
+          "addedToCellarAt": "2020-07-04T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-07-04T00:00:00.000Z"
+            }
+          ],
+          "price": 1900,
+          "currency": "EUR",
+          "purchaseDate": "2020-07-04",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2024,
+          "drinkTo": 2042,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 19,
+          "rackRow": 4,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Climens",
+          "producer": "Château Climens",
+          "vintage": "2014",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Barsac",
+          "type": "dessert",
+          "grapes": [
+            "Sémillon"
+          ],
+          "bottleSize": "375ml",
+          "dateAdded": "2021-08-05",
+          "addedToCellarAt": "2021-08-05T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-08-05T00:00:00.000Z"
+            }
+          ],
+          "price": 60,
+          "currency": "EUR",
+          "purchaseDate": "2021-08-05",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2022,
+          "drinkTo": 2050,
+          "rating": 93,
+          "ratingScale": "100",
+          "rackName": "Cellar Rack",
+          "rackPosition": 20,
+          "rackRow": 4,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Almaviva",
+          "producer": "Almaviva",
+          "vintage": "2019",
+          "country": "Chile",
+          "region": "Maipo Valley",
+          "appellation": "Puente Alto",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Carmenère",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-09-06",
+          "addedToCellarAt": "2022-09-06T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-09-06T00:00:00.000Z"
+            }
+          ],
+          "price": 145,
+          "currency": "USD",
+          "purchaseDate": "2022-09-06",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2025,
+          "drinkTo": 2045,
+          "rating": 94,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Almaviva",
+          "producer": "Almaviva",
+          "vintage": "2021",
+          "country": "Chile",
+          "region": "Maipo Valley",
+          "appellation": "Puente Alto",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Carmenère",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-10-07",
+          "addedToCellarAt": "2023-10-07T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-10-07T00:00:00.000Z"
+            }
+          ],
+          "price": 145,
+          "currency": "USD",
+          "purchaseDate": "2023-10-07",
+          "drinkFrom": 2025,
+          "drinkTo": 2045,
+          "rating": 94,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling trocken",
+          "producer": "Weingut Keller",
+          "vintage": "2022",
+          "country": "Germany",
+          "region": "Rheinhessen",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-11-08",
+          "addedToCellarAt": "2024-11-08T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-11-08T00:00:00.000Z"
+            }
+          ],
+          "price": 28,
+          "currency": "EUR",
+          "purchaseDate": "2024-11-08",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2023,
+          "drinkTo": 2032,
+          "rating": 90,
+          "ratingScale": "100",
+          "openedAt": "2026-07-11T18:34:33.066Z",
+          "preservationMethod": "inert-gas",
+          "pours": [
+            {
+              "at": "2026-07-11T18:34:34.964Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-11T18:34:36.746Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-11T18:34:46.588Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-11T18:34:47.129Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-11T18:34:47.489Z",
+              "ml": 125
+            },
+            {
+              "at": "2026-07-11T18:34:47.905Z",
+              "ml": 125
+            }
+          ],
+          "addToHistory": true,
+          "consumedReason": "drank",
+          "consumedAt": "2026-07-11",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Margaux",
+          "producer": "Château Margaux",
+          "vintage": "2015",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Margaux",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-12-09",
+          "addedToCellarAt": "2018-12-09T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-12-09T00:00:00.000Z"
+            }
+          ],
+          "price": 650,
+          "currency": "EUR",
+          "purchaseDate": "2018-12-09",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2025,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Margaux",
+          "producer": "Château Margaux",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Margaux",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-01-10",
+          "addedToCellarAt": "2019-01-10T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-01-10T00:00:00.000Z"
+            }
+          ],
+          "price": 650,
+          "currency": "EUR",
+          "purchaseDate": "2019-01-10",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2025,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Margaux",
+          "producer": "Château Margaux",
+          "vintage": "2018",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Margaux",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2020-02-11",
+          "addedToCellarAt": "2020-02-11T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-02-11T00:00:00.000Z"
+            }
+          ],
+          "price": 650,
+          "currency": "EUR",
+          "purchaseDate": "2020-02-11",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2025,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 7,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Tâche",
+          "producer": "Domaine de la Romanée-Conti",
+          "vintage": "2017",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "La Tâche Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-03-12",
+          "addedToCellarAt": "2021-03-12T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-03-12T00:00:00.000Z"
+            }
+          ],
+          "price": 3200,
+          "currency": "EUR",
+          "purchaseDate": "2021-03-12",
+          "drinkFrom": 2027,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Tâche",
+          "producer": "Domaine de la Romanée-Conti",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "La Tâche Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-04-13",
+          "addedToCellarAt": "2022-04-13T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-04-13T00:00:00.000Z"
+            }
+          ],
+          "price": 3200,
+          "currency": "EUR",
+          "purchaseDate": "2022-04-13",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2027,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 8,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Wehlener Sonnenuhr Riesling Auslese",
+          "producer": "Joh. Jos. Prüm",
+          "vintage": "2019",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Wehlener Sonnenuhr",
+          "type": "dessert",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-05-14",
+          "addedToCellarAt": "2023-05-14T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-05-14T00:00:00.000Z"
+            }
+          ],
+          "price": 45,
+          "currency": "EUR",
+          "purchaseDate": "2023-05-14",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 92,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 9,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Wehlener Sonnenuhr Riesling Auslese",
+          "producer": "Joh. Jos. Prüm",
+          "vintage": "2020",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Wehlener Sonnenuhr",
+          "type": "dessert",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-06-15",
+          "addedToCellarAt": "2024-06-15T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-06-15T00:00:00.000Z"
+            }
+          ],
+          "price": 45,
+          "currency": "EUR",
+          "purchaseDate": "2024-06-15",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 92,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 13,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Wehlener Sonnenuhr Riesling Auslese",
+          "producer": "Joh. Jos. Prüm",
+          "vintage": "2021",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Wehlener Sonnenuhr",
+          "type": "dessert",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-07-16",
+          "addedToCellarAt": "2018-07-16T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-07-16T00:00:00.000Z"
+            }
+          ],
+          "price": 45,
+          "currency": "EUR",
+          "purchaseDate": "2018-07-16",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 92,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 10,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grande Cuvée Brut",
+          "producer": "Krug",
+          "vintage": "NV",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne AOC",
+          "type": "sparkling",
+          "grapes": [
+            "Pinot Noir",
+            "Chardonnay",
+            "Pinot Meunier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-08-17",
+          "addedToCellarAt": "2019-08-17T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-08-17T00:00:00.000Z"
+            }
+          ],
+          "price": 220,
+          "currency": "EUR",
+          "purchaseDate": "2019-08-17",
+          "rating": 95,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 14,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château d'Yquem",
+          "producer": "Château d'Yquem",
+          "vintage": "2015",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Sauternes",
+          "type": "dessert",
+          "grapes": [
+            "Sémillon",
+            "Sauvignon Blanc"
+          ],
+          "bottleSize": "375ml",
+          "dateAdded": "2020-09-18",
+          "addedToCellarAt": "2020-09-18T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-09-18T00:00:00.000Z"
+            }
+          ],
+          "price": 210,
+          "currency": "EUR",
+          "purchaseDate": "2020-09-18",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2025,
+          "drinkTo": 2070,
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 11,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Pétrus",
+          "producer": "Pétrus",
+          "vintage": "2010",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Pomerol",
+          "type": "red",
+          "grapes": [
+            "Merlot",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-10-19",
+          "addedToCellarAt": "2021-10-19T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-10-19T00:00:00.000Z"
+            }
+          ],
+          "price": 4100,
+          "currency": "EUR",
+          "purchaseDate": "2021-10-19",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2022,
+          "drinkTo": 2050,
+          "rackName": "Double Deep",
+          "rackPosition": 15,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Mouline",
+          "producer": "E. Guigal",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Rhône",
+          "appellation": "Côte-Rôtie",
+          "type": "red",
+          "grapes": [
+            "Syrah",
+            "Viognier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-11-20",
+          "addedToCellarAt": "2022-11-20T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-11-20T00:00:00.000Z"
+            }
+          ],
+          "price": 380,
+          "currency": "EUR",
+          "purchaseDate": "2022-11-20",
+          "purchaseLocation": "Millesima",
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 12,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Mouline",
+          "producer": "E. Guigal",
+          "vintage": "2017",
+          "country": "France",
+          "region": "Rhône",
+          "appellation": "Côte-Rôtie",
+          "type": "red",
+          "grapes": [
+            "Syrah",
+            "Viognier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-12-21",
+          "addedToCellarAt": "2023-12-21T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-12-21T00:00:00.000Z"
+            }
+          ],
+          "price": 380,
+          "currency": "EUR",
+          "purchaseDate": "2023-12-21",
+          "purchaseLocation": "K&L Wines",
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Double Deep",
+          "rackPosition": 16,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Gaja",
+          "vintage": "2016",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-01-22",
+          "addedToCellarAt": "2024-01-22T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-01-22T00:00:00.000Z"
+            }
+          ],
+          "price": 240,
+          "currency": "EUR",
+          "purchaseDate": "2024-01-22",
+          "drinkFrom": 2026,
+          "drinkTo": 2048,
+          "rating": 94,
+          "ratingScale": "100",
+          "rackName": "Basement 1",
+          "rackPosition": 1,
+          "rackRow": 1,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Gaja",
+          "vintage": "2018",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-02-23",
+          "addedToCellarAt": "2018-02-23T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-02-23T00:00:00.000Z"
+            }
+          ],
+          "price": 240,
+          "currency": "EUR",
+          "purchaseDate": "2018-02-23",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2026,
+          "drinkTo": 2048,
+          "rating": 94,
+          "ratingScale": "100",
+          "rackName": "Basement 1",
+          "rackPosition": 2,
+          "rackRow": 1,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Gaja",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-03-24",
+          "addedToCellarAt": "2019-03-24T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-03-24T00:00:00.000Z"
+            }
+          ],
+          "price": 240,
+          "currency": "EUR",
+          "purchaseDate": "2019-03-24",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2026,
+          "drinkTo": 2048,
+          "rating": 94,
+          "ratingScale": "100",
+          "rackName": "Basement 1",
+          "rackPosition": 3,
+          "rackRow": 1,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Único",
+          "producer": "Vega Sicilia",
+          "vintage": "2011",
+          "country": "Spain",
+          "region": "Castilla y León",
+          "appellation": "Ribera del Duero",
+          "type": "red",
+          "grapes": [
+            "Tempranillo",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2020-04-25",
+          "addedToCellarAt": "2020-04-25T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-04-25T00:00:00.000Z"
+            }
+          ],
+          "price": 420,
+          "currency": "EUR",
+          "purchaseDate": "2020-04-25",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Basement 1",
+          "rackPosition": 4,
+          "rackRow": 2,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Único",
+          "producer": "Vega Sicilia",
+          "vintage": "2012",
+          "country": "Spain",
+          "region": "Castilla y León",
+          "appellation": "Ribera del Duero",
+          "type": "red",
+          "grapes": [
+            "Tempranillo",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-05-26",
+          "addedToCellarAt": "2021-05-26T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-05-26T00:00:00.000Z"
+            }
+          ],
+          "price": 420,
+          "currency": "EUR",
+          "purchaseDate": "2021-05-26",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Basement 1",
+          "rackPosition": 5,
+          "rackRow": 2,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grange",
+          "producer": "Penfolds",
+          "vintage": "2017",
+          "country": "Australia",
+          "region": "South Australia",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Syrah",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-06-27",
+          "addedToCellarAt": "2022-06-27T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-06-27T00:00:00.000Z"
+            }
+          ],
+          "price": 720,
+          "currency": "AUD",
+          "purchaseDate": "2022-06-27",
+          "drinkFrom": 2027,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Basement 1",
+          "rackPosition": 6,
+          "rackRow": 2,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Monte Bello",
+          "producer": "Ridge",
+          "vintage": "2018",
+          "country": "USA",
+          "region": "Santa Cruz Mountains",
+          "appellation": "Santa Cruz Mountains",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Petit Verdot",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-07-01",
+          "addedToCellarAt": "2023-07-01T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-07-01T00:00:00.000Z"
+            }
+          ],
+          "price": 260,
+          "currency": "USD",
+          "purchaseDate": "2023-07-01",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Basement 2",
+          "rackPosition": 1,
+          "rackRow": 1,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Monte Bello",
+          "producer": "Ridge",
+          "vintage": "2019",
+          "country": "USA",
+          "region": "Santa Cruz Mountains",
+          "appellation": "Santa Cruz Mountains",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Petit Verdot",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-08-02",
+          "addedToCellarAt": "2024-08-02T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-08-02T00:00:00.000Z"
+            }
+          ],
+          "price": 260,
+          "currency": "USD",
+          "purchaseDate": "2024-08-02",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Basement 2",
+          "rackPosition": 2,
+          "rackRow": 1,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Mouton Rothschild",
+          "producer": "Château Mouton Rothschild",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Pauillac",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "1500ml",
+          "dateAdded": "2018-09-03",
+          "addedToCellarAt": "2018-09-03T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-09-03T00:00:00.000Z"
+            }
+          ],
+          "price": 1450,
+          "currency": "EUR",
+          "purchaseDate": "2018-09-03",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2026,
+          "drinkTo": 2060,
+          "rating": 99,
+          "ratingScale": "100",
+          "rackName": "Basement 2",
+          "rackPosition": 3,
+          "rackRow": 1,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Vintage Porto",
+          "producer": "Taylor Fladgate",
+          "vintage": "2017",
+          "country": "Portugal",
+          "region": "Douro Valley",
+          "appellation": "Porto",
+          "type": "fortified",
+          "grapes": [
+            "Touriga Nacional",
+            "Touriga Franca",
+            "Tinta Roriz",
+            "Tinta Barroca",
+            "Tinto Cão"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-10-04",
+          "addedToCellarAt": "2019-10-04T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-10-04T00:00:00.000Z"
+            }
+          ],
+          "price": 95,
+          "currency": "EUR",
+          "purchaseDate": "2019-10-04",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2035,
+          "drinkTo": 2080,
+          "rating": 95,
+          "ratingScale": "100",
+          "rackName": "Basement 2",
+          "rackPosition": 4,
+          "rackRow": 2,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Scharzhofberger Riesling Kabinett",
+          "producer": "Egon Müller",
+          "vintage": "2020",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Scharzhofberg",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2020-11-05",
+          "addedToCellarAt": "2020-11-05T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-11-05T00:00:00.000Z"
+            }
+          ],
+          "price": 320,
+          "currency": "EUR",
+          "purchaseDate": "2020-11-05",
+          "rackName": "Basement 2",
+          "rackPosition": 5,
+          "rackRow": 2,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Scharzhofberger Riesling Kabinett",
+          "producer": "Egon Müller",
+          "vintage": "2022",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Scharzhofberg",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-12-06",
+          "addedToCellarAt": "2021-12-06T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-12-06T00:00:00.000Z"
+            }
+          ],
+          "price": 320,
+          "currency": "EUR",
+          "purchaseDate": "2021-12-06",
+          "purchaseLocation": "Auction",
+          "rackName": "Basement 2",
+          "rackPosition": 6,
+          "rackRow": 2,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Puligny-Montrachet Les Combettes",
+          "producer": "Domaine Leflaive",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Puligny-Montrachet 1er Cru",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-01-07",
+          "addedToCellarAt": "2022-01-07T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-01-07T00:00:00.000Z"
+            }
+          ],
+          "price": 285,
+          "currency": "EUR",
+          "purchaseDate": "2022-01-07",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2023,
+          "drinkTo": 2035,
+          "rating": 93,
+          "ratingScale": "100",
+          "rackName": "Basement 3",
+          "rackPosition": 1,
+          "rackRow": 1,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Puligny-Montrachet Les Combettes",
+          "producer": "Domaine Leflaive",
+          "vintage": "2020",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Puligny-Montrachet 1er Cru",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-02-08",
+          "addedToCellarAt": "2023-02-08T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-02-08T00:00:00.000Z"
+            }
+          ],
+          "price": 285,
+          "currency": "EUR",
+          "purchaseDate": "2023-02-08",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2023,
+          "drinkTo": 2035,
+          "rating": 93,
+          "ratingScale": "100",
+          "rackName": "Basement 3",
+          "rackPosition": 2,
+          "rackRow": 1,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Sassicaia",
+          "producer": "Tenuta San Guido",
+          "vintage": "2018",
+          "country": "Italy",
+          "region": "Tuscany",
+          "appellation": "Bolgheri Sassicaia DOC",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-03-09",
+          "addedToCellarAt": "2024-03-09T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-03-09T00:00:00.000Z"
+            }
+          ],
+          "price": 310,
+          "currency": "EUR",
+          "purchaseDate": "2024-03-09",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Basement 3",
+          "rackPosition": 3,
+          "rackRow": 1,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Sassicaia",
+          "producer": "Tenuta San Guido",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Tuscany",
+          "appellation": "Bolgheri Sassicaia DOC",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-04-10",
+          "addedToCellarAt": "2018-04-10T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-04-10T00:00:00.000Z"
+            }
+          ],
+          "price": 310,
+          "currency": "EUR",
+          "purchaseDate": "2018-04-10",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Basement 3",
+          "rackPosition": 4,
+          "rackRow": 2,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Sassicaia",
+          "producer": "Tenuta San Guido",
+          "vintage": "2020",
+          "country": "Italy",
+          "region": "Tuscany",
+          "appellation": "Bolgheri Sassicaia DOC",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-05-11",
+          "addedToCellarAt": "2019-05-11T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-05-11T00:00:00.000Z"
+            }
+          ],
+          "price": 310,
+          "currency": "EUR",
+          "purchaseDate": "2019-05-11",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Basement 3",
+          "rackPosition": 5,
+          "rackRow": 2,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Le Mesnil Blanc de Blancs",
+          "producer": "Champagne Salon",
+          "vintage": "2012",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne AOC",
+          "type": "sparkling",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "1500ml",
+          "dateAdded": "2020-06-12",
+          "addedToCellarAt": "2020-06-12T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-06-12T00:00:00.000Z"
+            }
+          ],
+          "price": 1900,
+          "currency": "EUR",
+          "purchaseDate": "2020-06-12",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2024,
+          "drinkTo": 2042,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Basement 3",
+          "rackPosition": 6,
+          "rackRow": 2,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Climens",
+          "producer": "Château Climens",
+          "vintage": "2014",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Barsac",
+          "type": "dessert",
+          "grapes": [
+            "Sémillon"
+          ],
+          "bottleSize": "375ml",
+          "dateAdded": "2021-07-13",
+          "addedToCellarAt": "2021-07-13T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-07-13T00:00:00.000Z"
+            }
+          ],
+          "price": 60,
+          "currency": "EUR",
+          "purchaseDate": "2021-07-13",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2022,
+          "drinkTo": 2050,
+          "rating": 93,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 1,
+          "rackRow": 1,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Almaviva",
+          "producer": "Almaviva",
+          "vintage": "2019",
+          "country": "Chile",
+          "region": "Maipo Valley",
+          "appellation": "Puente Alto",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Carmenère",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-08-14",
+          "addedToCellarAt": "2022-08-14T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-08-14T00:00:00.000Z"
+            }
+          ],
+          "price": 145,
+          "currency": "USD",
+          "purchaseDate": "2022-08-14",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2025,
+          "drinkTo": 2045,
+          "rating": 94,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 2,
+          "rackRow": 1,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Almaviva",
+          "producer": "Almaviva",
+          "vintage": "2021",
+          "country": "Chile",
+          "region": "Maipo Valley",
+          "appellation": "Puente Alto",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Carmenère",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-09-15",
+          "addedToCellarAt": "2023-09-15T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-09-15T00:00:00.000Z"
+            }
+          ],
+          "price": 145,
+          "currency": "USD",
+          "purchaseDate": "2023-09-15",
+          "drinkFrom": 2025,
+          "drinkTo": 2045,
+          "rating": 94,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 3,
+          "rackRow": 1,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Riesling trocken",
+          "producer": "Weingut Keller",
+          "vintage": "2022",
+          "country": "Germany",
+          "region": "Rheinhessen",
+          "appellation": "",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-10-16",
+          "addedToCellarAt": "2024-10-16T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-10-16T00:00:00.000Z"
+            }
+          ],
+          "price": 28,
+          "currency": "EUR",
+          "purchaseDate": "2024-10-16",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2023,
+          "drinkTo": 2032,
+          "rating": 90,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 4,
+          "rackRow": 1,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Margaux",
+          "producer": "Château Margaux",
+          "vintage": "2015",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Margaux",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-11-17",
+          "addedToCellarAt": "2018-11-17T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-11-17T00:00:00.000Z"
+            }
+          ],
+          "price": 650,
+          "currency": "EUR",
+          "purchaseDate": "2018-11-17",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2025,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 5,
+          "rackRow": 1,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Margaux",
+          "producer": "Château Margaux",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Margaux",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-12-18",
+          "addedToCellarAt": "2019-12-18T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-12-18T00:00:00.000Z"
+            }
+          ],
+          "price": 650,
+          "currency": "EUR",
+          "purchaseDate": "2019-12-18",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2025,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 6,
+          "rackRow": 1,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Margaux",
+          "producer": "Château Margaux",
+          "vintage": "2018",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Margaux",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2020-01-19",
+          "addedToCellarAt": "2020-01-19T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-01-19T00:00:00.000Z"
+            }
+          ],
+          "price": 650,
+          "currency": "EUR",
+          "purchaseDate": "2020-01-19",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2025,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 7,
+          "rackRow": 2,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Tâche",
+          "producer": "Domaine de la Romanée-Conti",
+          "vintage": "2017",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "La Tâche Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-02-20",
+          "addedToCellarAt": "2021-02-20T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-02-20T00:00:00.000Z"
+            }
+          ],
+          "price": 3200,
+          "currency": "EUR",
+          "purchaseDate": "2021-02-20",
+          "drinkFrom": 2027,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 8,
+          "rackRow": 2,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Tâche",
+          "producer": "Domaine de la Romanée-Conti",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "La Tâche Grand Cru",
+          "type": "red",
+          "grapes": [
+            "Pinot Noir"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-03-21",
+          "addedToCellarAt": "2022-03-21T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-03-21T00:00:00.000Z"
+            }
+          ],
+          "price": 3200,
+          "currency": "EUR",
+          "purchaseDate": "2022-03-21",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2027,
+          "drinkTo": 2050,
+          "rating": 97,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 9,
+          "rackRow": 2,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Wehlener Sonnenuhr Riesling Auslese",
+          "producer": "Joh. Jos. Prüm",
+          "vintage": "2019",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Wehlener Sonnenuhr",
+          "type": "dessert",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-04-22",
+          "addedToCellarAt": "2023-04-22T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-04-22T00:00:00.000Z"
+            }
+          ],
+          "price": 45,
+          "currency": "EUR",
+          "purchaseDate": "2023-04-22",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 92,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 10,
+          "rackRow": 2,
+          "rackCol": 4,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Wehlener Sonnenuhr Riesling Auslese",
+          "producer": "Joh. Jos. Prüm",
+          "vintage": "2020",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Wehlener Sonnenuhr",
+          "type": "dessert",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-05-23",
+          "addedToCellarAt": "2024-05-23T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-05-23T00:00:00.000Z"
+            }
+          ],
+          "price": 45,
+          "currency": "EUR",
+          "purchaseDate": "2024-05-23",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 92,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 11,
+          "rackRow": 2,
+          "rackCol": 5,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Wehlener Sonnenuhr Riesling Auslese",
+          "producer": "Joh. Jos. Prüm",
+          "vintage": "2021",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Wehlener Sonnenuhr",
+          "type": "dessert",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-06-24",
+          "addedToCellarAt": "2018-06-24T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-06-24T00:00:00.000Z"
+            }
+          ],
+          "price": 45,
+          "currency": "EUR",
+          "purchaseDate": "2018-06-24",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 92,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 12,
+          "rackRow": 2,
+          "rackCol": 6,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grande Cuvée Brut",
+          "producer": "Krug",
+          "vintage": "NV",
+          "country": "France",
+          "region": "Champagne",
+          "appellation": "Champagne AOC",
+          "type": "sparkling",
+          "grapes": [
+            "Pinot Noir",
+            "Chardonnay",
+            "Pinot Meunier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-07-25",
+          "addedToCellarAt": "2019-07-25T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-07-25T00:00:00.000Z"
+            }
+          ],
+          "price": 220,
+          "currency": "EUR",
+          "purchaseDate": "2019-07-25",
+          "rating": 95,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 13,
+          "rackRow": 3,
+          "rackCol": 1,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château d'Yquem",
+          "producer": "Château d'Yquem",
+          "vintage": "2015",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Sauternes",
+          "type": "dessert",
+          "grapes": [
+            "Sémillon",
+            "Sauvignon Blanc"
+          ],
+          "bottleSize": "375ml",
+          "dateAdded": "2020-08-26",
+          "addedToCellarAt": "2020-08-26T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-08-26T00:00:00.000Z"
+            }
+          ],
+          "price": 210,
+          "currency": "EUR",
+          "purchaseDate": "2020-08-26",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2025,
+          "drinkTo": 2070,
+          "rating": 96,
+          "ratingScale": "100",
+          "rackName": "Storage Box",
+          "rackPosition": 14,
+          "rackRow": 3,
+          "rackCol": 2,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Pétrus",
+          "producer": "Pétrus",
+          "vintage": "2010",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Pomerol",
+          "type": "red",
+          "grapes": [
+            "Merlot",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-09-27",
+          "addedToCellarAt": "2021-09-27T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-09-27T00:00:00.000Z"
+            }
+          ],
+          "price": 4100,
+          "currency": "EUR",
+          "purchaseDate": "2021-09-27",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2022,
+          "drinkTo": 2050,
+          "rackName": "Storage Box",
+          "rackPosition": 15,
+          "rackRow": 3,
+          "rackCol": 3,
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Mouline",
+          "producer": "E. Guigal",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Rhône",
+          "appellation": "Côte-Rôtie",
+          "type": "red",
+          "grapes": [
+            "Syrah",
+            "Viognier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-10-01",
+          "addedToCellarAt": "2022-10-01T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-10-01T00:00:00.000Z"
+            }
+          ],
+          "price": 380,
+          "currency": "EUR",
+          "purchaseDate": "2022-10-01",
+          "purchaseLocation": "Millesima",
+          "rating": 96,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "La Mouline",
+          "producer": "E. Guigal",
+          "vintage": "2017",
+          "country": "France",
+          "region": "Rhône",
+          "appellation": "Côte-Rôtie",
+          "type": "red",
+          "grapes": [
+            "Syrah",
+            "Viognier"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-11-02",
+          "addedToCellarAt": "2023-11-02T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-11-02T00:00:00.000Z"
+            }
+          ],
+          "price": 380,
+          "currency": "EUR",
+          "purchaseDate": "2023-11-02",
+          "purchaseLocation": "K&L Wines",
+          "rating": 96,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Gaja",
+          "vintage": "2016",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-12-03",
+          "addedToCellarAt": "2024-12-03T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-12-03T00:00:00.000Z"
+            }
+          ],
+          "price": 240,
+          "currency": "EUR",
+          "purchaseDate": "2024-12-03",
+          "drinkFrom": 2026,
+          "drinkTo": 2048,
+          "rating": 94,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Gaja",
+          "vintage": "2018",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2018-01-04",
+          "addedToCellarAt": "2018-01-04T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-01-04T00:00:00.000Z"
+            }
+          ],
+          "price": 240,
+          "currency": "EUR",
+          "purchaseDate": "2018-01-04",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2026,
+          "drinkTo": 2048,
+          "rating": 94,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Barbaresco",
+          "producer": "Gaja",
+          "vintage": "2019",
+          "country": "Italy",
+          "region": "Piedmont",
+          "appellation": "Barbaresco DOCG",
+          "type": "red",
+          "grapes": [
+            "Nebbiolo"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-02-05",
+          "addedToCellarAt": "2019-02-05T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-02-05T00:00:00.000Z"
+            }
+          ],
+          "price": 240,
+          "currency": "EUR",
+          "purchaseDate": "2019-02-05",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2026,
+          "drinkTo": 2048,
+          "rating": 94,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Único",
+          "producer": "Vega Sicilia",
+          "vintage": "2011",
+          "country": "Spain",
+          "region": "Castilla y León",
+          "appellation": "Ribera del Duero",
+          "type": "red",
+          "grapes": [
+            "Tempranillo",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2020-03-06",
+          "addedToCellarAt": "2020-03-06T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-03-06T00:00:00.000Z"
+            }
+          ],
+          "price": 420,
+          "currency": "EUR",
+          "purchaseDate": "2020-03-06",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 97,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Único",
+          "producer": "Vega Sicilia",
+          "vintage": "2012",
+          "country": "Spain",
+          "region": "Castilla y León",
+          "appellation": "Ribera del Duero",
+          "type": "red",
+          "grapes": [
+            "Tempranillo",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-04-07",
+          "addedToCellarAt": "2021-04-07T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-04-07T00:00:00.000Z"
+            }
+          ],
+          "price": 420,
+          "currency": "EUR",
+          "purchaseDate": "2021-04-07",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2024,
+          "drinkTo": 2045,
+          "rating": 97,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Grange",
+          "producer": "Penfolds",
+          "vintage": "2017",
+          "country": "Australia",
+          "region": "South Australia",
+          "appellation": "",
+          "type": "red",
+          "grapes": [
+            "Syrah",
+            "Cabernet Sauvignon"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-05-08",
+          "addedToCellarAt": "2022-05-08T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-05-08T00:00:00.000Z"
+            }
+          ],
+          "price": 720,
+          "currency": "AUD",
+          "purchaseDate": "2022-05-08",
+          "drinkFrom": 2027,
+          "drinkTo": 2055,
+          "rating": 98,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Monte Bello",
+          "producer": "Ridge",
+          "vintage": "2018",
+          "country": "USA",
+          "region": "Santa Cruz Mountains",
+          "appellation": "Santa Cruz Mountains",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Petit Verdot",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-06-09",
+          "addedToCellarAt": "2023-06-09T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-06-09T00:00:00.000Z"
+            }
+          ],
+          "price": 260,
+          "currency": "USD",
+          "purchaseDate": "2023-06-09",
+          "purchaseLocation": "Auction",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 96,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Monte Bello",
+          "producer": "Ridge",
+          "vintage": "2019",
+          "country": "USA",
+          "region": "Santa Cruz Mountains",
+          "appellation": "Santa Cruz Mountains",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Petit Verdot",
+            "Cabernet Franc"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2024-07-10",
+          "addedToCellarAt": "2024-07-10T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2024-07-10T00:00:00.000Z"
+            }
+          ],
+          "price": 260,
+          "currency": "USD",
+          "purchaseDate": "2024-07-10",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2026,
+          "drinkTo": 2050,
+          "rating": 96,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Château Mouton Rothschild",
+          "producer": "Château Mouton Rothschild",
+          "vintage": "2016",
+          "country": "France",
+          "region": "Bordeaux",
+          "appellation": "Pauillac",
+          "type": "red",
+          "grapes": [
+            "Cabernet Sauvignon",
+            "Merlot",
+            "Cabernet Franc",
+            "Petit Verdot"
+          ],
+          "bottleSize": "1500ml",
+          "dateAdded": "2018-08-11",
+          "addedToCellarAt": "2018-08-11T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2018-08-11T00:00:00.000Z"
+            }
+          ],
+          "price": 1450,
+          "currency": "EUR",
+          "purchaseDate": "2018-08-11",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2026,
+          "drinkTo": 2060,
+          "rating": 99,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Vintage Porto",
+          "producer": "Taylor Fladgate",
+          "vintage": "2017",
+          "country": "Portugal",
+          "region": "Douro Valley",
+          "appellation": "Porto",
+          "type": "fortified",
+          "grapes": [
+            "Touriga Nacional",
+            "Touriga Franca",
+            "Tinta Roriz",
+            "Tinta Barroca",
+            "Tinto Cão"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2019-09-12",
+          "addedToCellarAt": "2019-09-12T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2019-09-12T00:00:00.000Z"
+            }
+          ],
+          "price": 95,
+          "currency": "EUR",
+          "purchaseDate": "2019-09-12",
+          "purchaseLocation": "K&L Wines",
+          "drinkFrom": 2035,
+          "drinkTo": 2080,
+          "rating": 95,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Scharzhofberger Riesling Kabinett",
+          "producer": "Egon Müller",
+          "vintage": "2020",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Scharzhofberg",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2020-10-13",
+          "addedToCellarAt": "2020-10-13T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2020-10-13T00:00:00.000Z"
+            }
+          ],
+          "price": 320,
+          "currency": "EUR",
+          "purchaseDate": "2020-10-13",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Scharzhofberger Riesling Kabinett",
+          "producer": "Egon Müller",
+          "vintage": "2022",
+          "country": "Germany",
+          "region": "Mosel",
+          "appellation": "Scharzhofberg",
+          "type": "white",
+          "grapes": [
+            "Riesling"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2021-11-14",
+          "addedToCellarAt": "2021-11-14T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2021-11-14T00:00:00.000Z"
+            }
+          ],
+          "price": 320,
+          "currency": "EUR",
+          "purchaseDate": "2021-11-14",
+          "purchaseLocation": "Auction",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Puligny-Montrachet Les Combettes",
+          "producer": "Domaine Leflaive",
+          "vintage": "2019",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Puligny-Montrachet 1er Cru",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2022-12-15",
+          "addedToCellarAt": "2022-12-15T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2022-12-15T00:00:00.000Z"
+            }
+          ],
+          "price": 285,
+          "currency": "EUR",
+          "purchaseDate": "2022-12-15",
+          "purchaseLocation": "Systembolaget",
+          "drinkFrom": 2023,
+          "drinkTo": 2035,
+          "rating": 93,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
+        },
+        {
+          "wineName": "Puligny-Montrachet Les Combettes",
+          "producer": "Domaine Leflaive",
+          "vintage": "2020",
+          "country": "France",
+          "region": "Burgundy",
+          "appellation": "Puligny-Montrachet 1er Cru",
+          "type": "white",
+          "grapes": [
+            "Chardonnay"
+          ],
+          "bottleSize": "750ml",
+          "dateAdded": "2023-01-16",
+          "addedToCellarAt": "2023-01-16T00:00:00.000Z",
+          "cellarHistory": [
+            {
+              "cellarName": "Imported Collection",
+              "enteredAt": "2023-01-16T00:00:00.000Z"
+            }
+          ],
+          "price": 285,
+          "currency": "EUR",
+          "purchaseDate": "2023-01-16",
+          "purchaseLocation": "Millesima",
+          "drinkFrom": 2023,
+          "drinkTo": 2035,
+          "rating": 93,
+          "ratingScale": "100",
+          "reviews": [],
+          "images": []
         }
       ]
     }
-  ]
+  ],
+  "_demo": true,
+  "_note": "Anonymized snapshot of the maintainer's own cellar, used for the public \"try the demo\" account. Personal free-text (notes, consumed notes, purchase URLs, per-bottle location), personal reviews and uploaded images are removed; personal names/places in cellar/rack/zone names are neutralized. Kept: wines, vintages, prices, ratings, drink windows, rack geometry and the 3D room layout."
 }

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -377,11 +377,6 @@ userSchema.pre('save', function(next) {
   next();
 });
 
-// Non-login sentinel stored as the password for ephemeral demo accounts: it is
-// not a valid bcrypt hash, so comparePassword always returns false — a demo can
-// never password-login (it authenticates by JWT only, on an unroutable address).
-const DEMO_PASSWORD_SENTINEL = '!demo-no-login!';
-
 // Hash password before saving
 userSchema.pre('save', async function(next) {
   // Only hash if password is modified or new
@@ -390,11 +385,14 @@ userSchema.pre('save', async function(next) {
   }
 
   // Ephemeral demo accounts skip the expensive bcrypt hash entirely: they never
-  // password-login, and under a burst of demo-logins N parallel cost-12 hashes
-  // on the single Node thread would degrade latency for everyone. Store the
-  // non-login sentinel instead.
+  // password-login (JWT only, on an unroutable address), and under a burst of
+  // demo-logins N parallel cost-12 hashes on the single Node thread would degrade
+  // latency for everyone. The demo's random password is complexity-valid (so it
+  // passes the schema validator, which re-runs on the later issueTokens save) but
+  // is left UNHASHED — it is never used, and comparePassword returns false against
+  // a non-bcrypt value, so it can never authenticate. (Do NOT substitute a fixed
+  // sentinel here: full-document validation on the next save would reject it.)
   if (this.isDemo) {
-    this.password = DEMO_PASSWORD_SENTINEL;
     return next();
   }
 

--- a/backend/src/services/demoAccount.js
+++ b/backend/src/services/demoAccount.js
@@ -66,9 +66,12 @@ async function createDemoAccount() {
   const user = new User({
     username: `demo-${rand}`,
     email: `demo-${rand}@${DEMO_EMAIL_DOMAIN}`,
-    // The schema requires a password; a demo logs in via JWT only and the address
-    // is unroutable, so this value is never used for anything. Random + discarded.
-    password: crypto.randomBytes(24).toString('hex'),
+    // The schema password-complexity validator runs on every save (full-document
+    // validation), so this must stay complexity-valid: the fixed "Aa1!" prefix
+    // supplies the required upper/lower/digit/special classes, the random hex the
+    // length + uniqueness. The pre-save hook leaves it UNHASHED for demo accounts
+    // (they log in via JWT only, unroutable address), and it can never authenticate.
+    password: 'Aa1!' + crypto.randomBytes(24).toString('hex'),
     roles: ['user'],
     emailVerified: true,
     isDemo: true,

--- a/backend/src/services/demoAccount.test.js
+++ b/backend/src/services/demoAccount.test.js
@@ -1,0 +1,40 @@
+/**
+ * Guards the ephemeral demo User shape. The password-complexity validator runs at
+ * pre-validate — BEFORE the pre-save hook swaps in the demo sentinel — so the
+ * password createDemoAccount constructs must itself be complexity-valid. An
+ * all-hex random string is NOT (no uppercase, no special char) and 500s
+ * demo-login; this regression guards the "Aa1!" + hex shape.
+ *
+ * Uses the REAL User model (no mock) so validators actually run.
+ */
+const crypto = require('crypto');
+const User = require('../models/User');
+
+describe('ephemeral demo User shape', () => {
+  test('the demo password shape (Aa1! + hex) passes schema validation', () => {
+    const rand = crypto.randomBytes(8).toString('hex');
+    const user = new User({
+      username: `demo-${rand}`,
+      email: `demo-${rand}@demo.cellarion.invalid`,
+      password: 'Aa1!' + crypto.randomBytes(24).toString('hex'),
+      roles: ['user'],
+      emailVerified: true,
+      isDemo: true,
+      demoExpiresAt: new Date(),
+    });
+    expect(user.validateSync()).toBeUndefined();
+  });
+
+  test('a plain-hex password FAILS validation (documents the fixed bug)', () => {
+    const user = new User({
+      username: 'demo-x',
+      email: 'demo-x@demo.cellarion.invalid',
+      password: crypto.randomBytes(24).toString('hex'), // no uppercase / special char
+      roles: ['user'],
+      isDemo: true,
+    });
+    const err = user.validateSync();
+    expect(err).toBeDefined();
+    expect(err.errors.password).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #700 (merged). Running the demo end-to-end in local Docker surfaced that **demo-login 500s on main** — two password bugs the mocked unit tests couldn't catch — and swaps the placeholder snapshot for the real anonymized cellar.

## Fixes

1. **Password validator vs pre-save ordering:** the complexity validator runs at pre-validate, *before* the pre-save hook — the all-hex random demo password failed it. → `"Aa1!" + hex`.
2. **Sentinel failed on re-save:** `issueTokens` re-saves the user and full-document validation re-runs, rejecting the `!demo-no-login!` sentinel. → keep the random complexity-valid password **unhashed** (never used; `comparePassword` is false against a non-bcrypt value; the bcrypt skip for demo bursts is retained).
3. Regression test with the **real User model** so validators actually run.

## Real demo snapshot (replaces placeholder)

Anonymized capture of the maintainer's own cellar: **4 cellars / 261 bottles / 12 racks / 3D room layout**.
- Stripped: personal notes, consumed notes, purchase URLs/locations, occasions, personal reviews, uploaded images, maturity blocks (demo reads drink windows from the registry).
- Neutralized to English: cellar names (Main Cellar, Office, Summer House, Imported Collection), rack/zone names — including per-bottle `rackName` + `cellarHistory` so the importer can't re-infer an old-named rack.
- **Registry-safe: 261/261 wines resolve to existing registry entries under `matchOnly`** (validated with `scripts/validate-demo-snapshot.js`).

## Verified in local Docker

demo-login 201 → 4 cellars, 186 active bottles, racks + placements + 3D cloned; chat / add-bottle / find-or-create / change-password / image-upload all 403; consume 200; per-IP demo limiter enforced; admin `demo.*` rate-limit PATCH works live.

⚠️ Until this merges, the demo feature on main is non-functional (demo-login 500s).