### PR TITLE
feat(mcp): Phase 1 — 12 read tools (bottles, cellars, racks, stats, registry, wishlist, journal)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -149,11 +149,11 @@ const isStripeWebhook = (req) => req.originalUrl.split('?')[0] === '/api/stripe/
 // write tools, the write-safety layers govern MCP mutations instead. It stays
 // under the global apiLimiter, so it is never unbounded.
 //
-// NOTE for future write/DB tools: a JSON-RPC body may be a *batch* (array) of
-// calls, so one HTTP request can fan out to many tool invocations — apiLimiter
-// counts requests, not calls. Before the first tool that touches Mongo/AI ships,
-// add a per-tool/per-batch guard (and likely a dedicated MCP limiter). Today the
-// only tool is get_source_info (in-memory, no I/O), so this is a non-issue.
+// A JSON-RPC body may be a *batch* (array) of calls, so one HTTP request can
+// fan out to many tool invocations — apiLimiter counts requests, not calls.
+// That amplification is capped by the per-request tool-call budget in
+// mcp/server.js (MAX_CALLS_PER_REQUEST). Revisit with a dedicated MCP limiter
+// before write/AI tools ship (they add cost beyond DB reads).
 const isMcp = (req) => {
   const p = req.originalUrl.split('?')[0];
   return p === '/api/mcp' || p === '/api/mcp/';

--- a/backend/src/mcp/instructions.js
+++ b/backend/src/mcp/instructions.js
@@ -8,9 +8,14 @@ const INSTRUCTIONS = [
   `You are connected to Cellarion — a self-hosted wine cellar manager, open-source under AGPL-3.0 (https://github.com/jagduvi1/Cellarion). This MCP server (v${pkg.version}) exposes the connected user's OWN cellar.`,
   '',
   'How to work with it:',
-  "- Every tool acts only on the authenticated user's data. Reads are free — prefer them.",
-  '- When a tool returns structured data, reason over it directly: you are the sommelier; the server just supplies the facts.',
-  '- Cite the specific wine, vintage, and rack location in your answers so the user can verify what you did.',
+  "- Every tool acts only on the authenticated user's data. Reads are free — prefer them, and prefer filtered searches over fetching everything.",
+  '- Tool families: cellars (list_cellars, get_cellar) → bottles (search_bottles, get_bottle, list_history) → racks (list_racks, get_rack) → portfolio (cellar_stats) → shared registry (search_registry, get_wine) → personal (list_wishlist, list_journal).',
+  '- Typical flow: list_cellars once to learn ids, then search_bottles / get_bottle for specifics. search_bottles = what the user OWNS; search_registry = ALL wines Cellarion knows.',
+  '- You are the sommelier: reason over the structured data yourself (pairing, what to open, gaps). cellar_stats gives you the maturity + urgency signals for "what should I drink soon".',
+  '- Cite the specific wine, vintage, and rack position in your answers so the user can verify what you did.',
+  '- IDs (cellar_id, bottle_id, rack_id, wine_id) come from list/search tools — never invent one.',
+  '- Errors return { error: { code, message } }: not_found usually means a wrong/foreign id (re-list to recover); invalid_input explains exactly what to fix.',
+  '- This connection is read-only for now: you cannot add, modify or consume bottles yet. If the user asks for a change, do the reasoning, then point them to the web app for the action itself.',
   '- Call get_source_info if the user asks what Cellarion is, which version this instance runs, whether it is open source, or where to find or contribute to the code.',
 ].join('\n');
 

--- a/backend/src/mcp/readTools.test.js
+++ b/backend/src/mcp/readTools.test.js
@@ -1,0 +1,280 @@
+/**
+ * Phase-1 MCP read tools — security invariants.
+ *
+ * WHY THIS TEST EXISTS:
+ * Every MCP tool handler receives (args, ctx) and must scope EVERY query to
+ * ctx.user — there is no route middleware in front of it. These tests pin the
+ * invariants an adversarial caller (or confused AI) would probe: ownership
+ * filters present in queries, foreign resources indistinguishable from missing
+ * (not_found), PII never serialized (member ids, journal user links, registry
+ * internals), and REST privilege parity (registry cap 10, list caps ≤ 50).
+ */
+
+const chain = (result) => {
+  const c = {};
+  for (const m of ['populate', 'sort', 'skip', 'limit', 'select']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(() => Promise.resolve(result));
+  c.distinct = jest.fn(() => Promise.resolve(result));
+  // Thenable: `await Model.findById(id)` (no .lean()) resolves to result too.
+  c.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return c;
+};
+
+jest.mock('../models/Cellar', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/Bottle', () => ({
+  find: jest.fn(), findById: jest.fn(), aggregate: jest.fn(), countDocuments: jest.fn(),
+}));
+jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
+// Lazy-required inside handlers; jest still intercepts by resolved path.
+jest.mock('../services/search', () => ({
+  getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn(),
+}));
+jest.mock('../services/statsService', () => ({
+  computeOverview: jest.fn(async () => ({
+    overview: { totalBottles: 1 }, byType: [], byCountry: [], byGrape: [],
+    topProducers: [], maturity: {}, urgencyLadder: [], pace: {},
+  })),
+  buildEmptyStats: jest.fn(() => ({ overview: {} })),
+}));
+
+const mongoose = require('mongoose');
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const Rack = require('../models/Rack');
+const WishlistItem = require('../models/WishlistItem');
+const JournalEntry = require('../models/JournalEntry');
+const WineDefinition = require('../models/WineDefinition');
+const searchService = require('../services/search');
+const { allTools } = require('./registry');
+const { budgetedHandler, MAX_CALLS_PER_REQUEST } = require('./server');
+require('./tools');
+
+const oid = (c) => c.repeat(24);
+const ME = oid('a');
+const STRANGER = oid('b');
+const CTX = { user: { id: ME }, scopes: ['read'] };
+
+const tool = (name) => allTools().find((t) => t.name === name);
+const parse = (res) => JSON.parse(res.content[0].text);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  searchService.getIsAvailable.mockReturnValue(false);
+});
+
+describe('registration invariants', () => {
+  test('every Phase-1 tool is read-scoped and readOnly-annotated', () => {
+    const expected = [
+      'list_cellars', 'get_cellar', 'search_bottles', 'get_bottle', 'list_history',
+      'list_racks', 'get_rack', 'cellar_stats', 'search_registry', 'get_wine',
+      'list_wishlist', 'list_journal',
+    ];
+    for (const name of expected) {
+      const t = tool(name);
+      expect(t).toBeDefined();
+      expect(t.scope).toBe('read');
+      expect(t.annotations.readOnlyHint).toBe(true);
+    }
+  });
+});
+
+describe('ownership scoping', () => {
+  test('search_bottles without cellar_id scopes to the user\'s OWNED cellars', async () => {
+    Cellar.find.mockReturnValue(chain([oid('c')]));
+    Bottle.countDocuments.mockResolvedValue(0);
+    Bottle.find.mockReturnValue(chain([]));
+
+    await tool('search_bottles').handler({ status: 'active' }, CTX);
+
+    expect(Cellar.find).toHaveBeenCalledWith({ user: ME, deletedAt: null });
+    const filter = Bottle.find.mock.calls[0][0];
+    expect(filter.user).toBe(ME);
+    expect(filter.cellar).toEqual({ $in: [oid('c')] });
+    expect(filter.status).toEqual({ $nin: ['drank', 'gifted', 'sold', 'other'] });
+  });
+
+  test('get_cellar on a foreign cellar → not_found (indistinguishable from missing)', async () => {
+    Cellar.findById.mockReturnValue(chain({ _id: oid('c'), user: STRANGER, members: [], deletedAt: null }));
+    const res = await tool('get_cellar').handler({ cellar_id: oid('c') }, CTX);
+    expect(res.isError).toBe(true);
+    expect(parse(res).error.code).toBe('not_found');
+  });
+
+  test('get_bottle in a foreign cellar → not_found', async () => {
+    Bottle.findById.mockReturnValue(chain({ _id: oid('d'), cellar: oid('c') }));
+    Cellar.findById.mockReturnValue(chain({ _id: oid('c'), user: STRANGER, members: [], deletedAt: null }));
+    const res = await tool('get_bottle').handler({ bottle_id: oid('d') }, CTX);
+    expect(res.isError).toBe(true);
+    expect(parse(res).error.code).toBe('not_found');
+  });
+
+  // REGRESSION (audit HIGH): document refs are ObjectId INSTANCES, not strings.
+  // A string-only isValidId gate made get_bottle/get_rack fail on every real
+  // call while string-mocked tests stayed green. These success paths use real
+  // ObjectIds so that class of bug can never pass the suite again.
+  test('get_bottle succeeds on the owner\'s own bottle with a real ObjectId cellar ref', async () => {
+    const cellarId = new mongoose.Types.ObjectId(oid('c'));
+    Bottle.findById.mockReturnValue(chain({
+      _id: oid('d'), cellar: cellarId, vintage: '2015', status: 'active',
+      wineDefinition: { _id: oid('f'), name: 'Barolo', producer: 'X', grapes: [] },
+      pours: [],
+    }));
+    Cellar.findById.mockReturnValue(chain({ _id: cellarId, user: ME, members: [], deletedAt: null, name: 'Mine' }));
+    Rack.findOne.mockReturnValue(chain(null));
+    const res = await tool('get_bottle').handler({ bottle_id: oid('d') }, CTX);
+    expect(res.isError).toBeUndefined();
+    const body = parse(res);
+    expect(body.data.wine.name).toBe('Barolo');
+    expect(body.data.placement).toBeNull();
+  });
+
+  test('get_rack succeeds for the owner (ObjectId cellar ref) and hides existence from strangers', async () => {
+    const cellarId = new mongoose.Types.ObjectId(oid('c'));
+    const fullRack = {
+      _id: oid('e'), name: 'Rack A', cellar: cellarId, type: 'grid', rows: 3, cols: 4,
+      slots: [{ position: 1, bottle: { _id: oid('d'), vintage: '2015', wineDefinition: { name: 'Barolo', producer: 'X' } } }],
+      disabledPositions: [], zones: [],
+    };
+    // Owner: stub (access probe) then full doc.
+    Rack.findOne
+      .mockReturnValueOnce(chain({ cellar: cellarId }))
+      .mockReturnValueOnce(chain(fullRack));
+    Cellar.findById.mockReturnValue(chain({ _id: cellarId, user: ME, members: [], deletedAt: null }));
+    const okRes = await tool('get_rack').handler({ rack_id: oid('e') }, CTX);
+    expect(okRes.isError).toBeUndefined();
+    expect(parse(okRes).data.slots).toHaveLength(1);
+
+    // Oracle check: foreign-but-existing and missing must be indistinguishable.
+    Rack.findOne.mockReturnValueOnce(chain({ cellar: cellarId }));
+    Cellar.findById.mockReturnValue(chain({ _id: cellarId, user: STRANGER, members: [], deletedAt: null }));
+    const foreign = await tool('get_rack').handler({ rack_id: oid('e') }, CTX);
+    Rack.findOne.mockReturnValueOnce(chain(null));
+    const missing = await tool('get_rack').handler({ rack_id: oid('9') }, CTX);
+    expect(foreign.isError).toBe(true);
+    expect(missing.isError).toBe(true);
+    expect(parse(foreign).error.message).toBe(parse(missing).error.message);
+  });
+
+  test('member (viewer) access to a shared cellar IS allowed', async () => {
+    Cellar.findById.mockReturnValue(chain({
+      _id: oid('c'), user: STRANGER, members: [{ user: ME, role: 'viewer' }], deletedAt: null, name: 'Shared',
+    }));
+    Bottle.countDocuments.mockResolvedValue(3);
+    Rack.countDocuments.mockResolvedValue(1);
+    const res = await tool('get_cellar').handler({ cellar_id: oid('c') }, CTX);
+    expect(res.isError).toBeUndefined();
+    expect(parse(res).data.role).toBe('viewer');
+  });
+
+  test('wishlist and journal queries are keyed to ctx.user', async () => {
+    WishlistItem.countDocuments.mockResolvedValue(0);
+    WishlistItem.find.mockReturnValue(chain([]));
+    await tool('list_wishlist').handler({}, CTX);
+    expect(WishlistItem.find.mock.calls[0][0]).toMatchObject({ user: ME, status: 'wanted' });
+
+    JournalEntry.countDocuments.mockResolvedValue(0);
+    JournalEntry.find.mockReturnValue(chain([]));
+    await tool('list_journal').handler({}, CTX);
+    expect(JournalEntry.find.mock.calls[0][0]).toEqual({ user: ME });
+  });
+});
+
+describe('PII and data minimisation', () => {
+  test('get_cellar never serializes member user ids (only a count)', async () => {
+    Cellar.findById.mockReturnValue(chain({
+      _id: oid('c'), user: ME, members: [{ user: STRANGER, role: 'editor' }], deletedAt: null, name: 'Mine',
+    }));
+    Bottle.countDocuments.mockResolvedValue(0);
+    Rack.countDocuments.mockResolvedValue(0);
+    const res = await tool('get_cellar').handler({ cellar_id: oid('c') }, CTX);
+    const text = res.content[0].text;
+    expect(parse(res).data.member_count).toBe(1);
+    expect(text).not.toContain(STRANGER);
+  });
+
+  test('list_journal returns people as names only — no linked user ids', async () => {
+    JournalEntry.countDocuments.mockResolvedValue(1);
+    JournalEntry.find.mockReturnValue(chain([{
+      _id: oid('e'), date: new Date(), people: [{ name: 'Anna', user: STRANGER }], pairings: [],
+    }]));
+    const res = await tool('list_journal').handler({}, CTX);
+    expect(parse(res).data[0].people).toEqual(['Anna']);
+    expect(res.content[0].text).not.toContain(STRANGER);
+  });
+
+  test('search_registry output excludes registry internals (normalizedKey, createdBy)', async () => {
+    WineDefinition.find.mockReturnValue(chain([{
+      _id: oid('f'), name: 'Barolo', producer: 'X', type: 'red',
+      normalizedKey: 'SECRET-KEY', createdBy: STRANGER, grapes: [],
+    }]));
+    const res = await tool('search_registry').handler({ query: 'barolo' }, CTX);
+    expect(res.content[0].text).not.toContain('SECRET-KEY');
+    expect(res.content[0].text).not.toContain(STRANGER);
+  });
+});
+
+describe('privilege parity & bounds', () => {
+  test('search_registry via engine is capped at 10 (== REST USER_SEARCH_LIMIT)', async () => {
+    searchService.getIsAvailable.mockReturnValue(true);
+    searchService.search.mockResolvedValue({ ids: [] });
+    WineDefinition.find.mockReturnValue(chain([]));
+    await tool('search_registry').handler({ query: 'barolo' }, CTX);
+    expect(searchService.search).toHaveBeenCalledWith('barolo', { limit: 10 });
+  });
+
+  test('search_bottles clamps an oversized limit to 50', async () => {
+    Cellar.find.mockReturnValue(chain([]));
+    Bottle.countDocuments.mockResolvedValue(0);
+    const q = chain([]);
+    Bottle.find.mockReturnValue(q);
+    await tool('search_bottles').handler({ limit: 500 }, CTX);
+    expect(q.limit).toHaveBeenCalledWith(50);
+  });
+
+  test('list_history year filter bounds consumedAt to that calendar year', async () => {
+    Cellar.find.mockReturnValue(chain([{ _id: oid('c'), user: ME, members: [] }]));
+    Bottle.countDocuments.mockResolvedValue(0);
+    Bottle.find.mockReturnValue(chain([]));
+    await tool('list_history').handler({ year: 2025 }, CTX);
+    const filter = Bottle.find.mock.calls[0][0];
+    expect(filter.status).toEqual({ $in: ['drank', 'gifted', 'sold', 'other'] });
+    expect(filter.consumedAt.$gte.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+    expect(filter.consumedAt.$lt.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  test('search_bottles degrades gracefully when the search engine is down (warning, no text match)', async () => {
+    Cellar.find.mockReturnValue(chain([]));
+    Bottle.countDocuments.mockResolvedValue(0);
+    Bottle.find.mockReturnValue(chain([]));
+    const res = await tool('search_bottles').handler({ query: 'barolo' }, CTX);
+    const body = parse(res);
+    expect(body.warnings.join(' ')).toMatch(/search engine unavailable/i);
+  });
+
+  test('search_bottles Meili path re-applies the user filter (both paths share one contract)', async () => {
+    searchService.getIsAvailable.mockReturnValue(true);
+    searchService.searchBottles.mockResolvedValue({ ids: [oid('d')], estimatedTotalHits: 1 });
+    Cellar.find.mockReturnValue(chain([oid('c')]));
+    Bottle.find.mockReturnValue(chain([]));
+    await tool('search_bottles').handler({ query: 'barolo' }, CTX);
+    expect(Bottle.find.mock.calls[0][0]).toMatchObject({ user: ME });
+  });
+
+  test('per-request tool-call budget rejects call #21 with rate_limited (batch amplification cap)', async () => {
+    const t = { name: 'noop', handler: jest.fn(async () => ({ content: [] })) };
+    const state = { calls: 0 };
+    const wrapped = budgetedHandler(t, CTX, state);
+    for (let i = 0; i < MAX_CALLS_PER_REQUEST; i++) {
+      await wrapped({});
+    }
+    const over = await wrapped({});
+    expect(over.isError).toBe(true);
+    expect(JSON.parse(over.content[0].text).error.code).toBe('rate_limited');
+    expect(t.handler).toHaveBeenCalledTimes(MAX_CALLS_PER_REQUEST);
+  });
+});

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -26,6 +26,37 @@ function loadSdk() {
   return sdkPromise;
 }
 
+// A JSON-RPC body may be a BATCH (array) of calls, so one HTTP request can fan
+// out to many tool invocations — and /api/mcp is exempt from the write limiter
+// while apiLimiter counts requests, not calls. This per-request budget caps that
+// amplification: generous for a legitimate agent turn, far below abuse scale.
+const MAX_CALLS_PER_REQUEST = 20;
+
+// Wrap a tool handler with the per-request call budget. `state` is shared by
+// all tools of ONE request's server instance (fresh per request in stateless
+// mode). Exported for unit testing — jest cannot load the ESM SDK, so
+// buildServer itself is covered by the smoke test instead.
+function budgetedHandler(tool, ctx, state) {
+  return (args) => {
+    state.calls += 1;
+    if (state.calls > MAX_CALLS_PER_REQUEST) {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            error: {
+              code: 'rate_limited',
+              message: `Too many tool calls in one request (max ${MAX_CALLS_PER_REQUEST}). Send fewer calls per batch and paginate instead.`,
+            },
+          }),
+        }],
+      };
+    }
+    return tool.handler(args || {}, ctx);
+  };
+}
+
 // Build a per-request MCP server exposing ONLY the tools the caller's token
 // scopes allow. Because a disallowed tool is never registered on this server, it
 // is not merely hidden from tools/list — it is uncallable (a tools/call for it
@@ -37,6 +68,7 @@ async function buildServer(ctx) {
     { name: 'cellarion', version: pkg.version },
     { instructions: INSTRUCTIONS }
   );
+  const state = { calls: 0 };
   for (const tool of toolsForScopes(ctx.scopes)) {
     server.registerTool(
       tool.name,
@@ -46,7 +78,7 @@ async function buildServer(ctx) {
         inputSchema: tool.inputSchema,
         annotations: tool.annotations,
       },
-      (args) => tool.handler(args || {}, ctx)
+      budgetedHandler(tool, ctx, state)
     );
   }
   return server;
@@ -74,4 +106,4 @@ async function handleMcpRequest(req, res, ctx) {
   await transport.handleRequest(req, res, req.body);
 }
 
-module.exports = { handleMcpRequest, buildServer, loadSdk };
+module.exports = { handleMcpRequest, buildServer, loadSdk, budgetedHandler, MAX_CALLS_PER_REQUEST };

--- a/backend/src/mcp/toolUtil.js
+++ b/backend/src/mcp/toolUtil.js
@@ -1,0 +1,142 @@
+// Shared helpers for MCP tool handlers: uniform response envelope, the error
+// taxonomy from MCP plan §5.4, and the standalone access checks (the service-
+// context equivalents of middleware/cellarAccess + middleware/bottleAccess —
+// same semantics, no req/res).
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const { getCellarRole } = require('../utils/cellarAccess');
+const { isValidId } = require('../utils/validation');
+
+const ROLE_LEVELS = { viewer: 1, editor: 2, owner: 3 };
+
+/** Success envelope (§7): { summary, data, warnings?, page? } as one text part. */
+function ok(summary, data, extra = {}) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ summary, data, ...extra }) }],
+  };
+}
+
+/**
+ * Error envelope. `code` is from the §5.4 taxonomy: invalid_input | not_found |
+ * forbidden_scope | budget_exhausted | conflict | rate_limited. Messages are
+ * written for the calling MODEL to self-correct from, not for humans.
+ */
+function fail(code, message) {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify({ error: { code, message } }) }],
+  };
+}
+
+/**
+ * Load a cellar and the caller's role in it. Returns { cellar, role } or null
+ * when the cellar is missing, soft-deleted, or the caller is not owner/member.
+ * Callers MUST treat null as not_found (never reveal that a foreign cellar
+ * exists — same policy as requireCellarAccess).
+ */
+async function resolveCellarAccess(userId, cellarId, minRole = 'viewer') {
+  // Callers pass both client-supplied strings AND document refs (ObjectId
+  // instances, e.g. bottle.cellar / rack.cellar). isValidId is string-only, so
+  // coerce first: String(ObjectId) is the 24-hex id, while any smuggled
+  // object/array stringifies to something isValidId rejects — still fail-closed.
+  const id = String(cellarId);
+  if (!isValidId(id)) return null;
+  const cellar = await Cellar.findById(id);
+  if (!cellar || cellar.deletedAt) return null;
+  const role = getCellarRole(cellar, userId);
+  if (!role) return null;
+  if ((ROLE_LEVELS[role] || 0) < (ROLE_LEVELS[minRole] || 0)) return null;
+  return { cellar, role };
+}
+
+/**
+ * Load a bottle plus its cellar and the caller's role — the standalone
+ * equivalent of requireBottleAccess(minRole). Returns { bottle, cellar, role }
+ * or null (missing bottle, deleted cellar, or no access — all not_found).
+ */
+async function resolveBottleAccess(userId, bottleId, minRole = 'viewer') {
+  if (!isValidId(bottleId)) return null;
+  const bottle = await Bottle.findById(bottleId);
+  if (!bottle) return null;
+  const access = await resolveCellarAccess(userId, bottle.cellar, minRole);
+  if (!access) return null;
+  return { bottle, ...access };
+}
+
+/** All cellars the user owns or is a member of (lean). Mirrors cellars.js. */
+function accessibleCellars(userId) {
+  return Cellar.find({
+    $or: [{ user: userId }, { 'members.user': userId }],
+    deletedAt: null,
+  }).lean();
+}
+
+/** Compact registry-wine summary. NEVER include normalizedKey/createdBy/productNumber. */
+function wineSummary(wd) {
+  if (!wd) return null;
+  return {
+    wine_id: wd._id,
+    name: wd.name,
+    producer: wd.producer || null,
+    type: wd.type || null,
+    country: wd.country?.name || null,
+    region: wd.region?.name || null,
+    appellation: wd.appellation || null,
+    grapes: Array.isArray(wd.grapes) ? wd.grapes.map((g) => g.name).filter(Boolean) : [],
+  };
+}
+
+/** Compact bottle line item for list responses. */
+function bottleSummary(b) {
+  return {
+    bottle_id: b._id,
+    wine: b.wineDefinition
+      ? { name: b.wineDefinition.name, producer: b.wineDefinition.producer || null, type: b.wineDefinition.type || null }
+      : { name: b.pendingWineRequest?.wineName || 'Unknown wine', pending_registry_review: true },
+    vintage: b.vintage,
+    status: b.status,
+    cellar_id: b.cellar,
+    price: b.price ?? null,
+    currency: b.currency || null,
+    rating: b.rating ?? null,
+    rating_scale: b.rating != null ? b.ratingScale : undefined,
+    drink_from: b.drinkFrom ?? null,
+    drink_to: b.drinkTo ?? null,
+    opened_at: b.openedAt || undefined,
+  };
+}
+
+/**
+ * True when a (lean) subdocument carries any real value. Mongoose materializes
+ * default subdocs (e.g. a never-enriched aiProfile of all-nulls); those should
+ * serialize as null over MCP, not as empty shells the model misreads as data.
+ */
+function hasContent(obj) {
+  if (!obj || typeof obj !== 'object') return false;
+  return Object.values(obj).some((v) => {
+    if (v == null) return false;
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === 'object') return hasContent(v);
+    return true;
+  });
+}
+
+/** Clamp a limit/offset pair from validated zod input. */
+function pageParams(args, defLimit, maxLimit) {
+  const limit = Math.min(Math.max(parseInt(args.limit, 10) || defLimit, 1), maxLimit);
+  const offset = Math.max(parseInt(args.offset, 10) || 0, 0);
+  return { limit, offset };
+}
+
+module.exports = {
+  ok,
+  fail,
+  resolveCellarAccess,
+  resolveBottleAccess,
+  accessibleCellars,
+  wineSummary,
+  bottleSummary,
+  pageParams,
+  hasContent,
+  ROLE_LEVELS,
+};

--- a/backend/src/mcp/tools/bottles.js
+++ b/backend/src/mcp/tools/bottles.js
@@ -1,0 +1,222 @@
+// Bottle read tools: search/list, one-bottle detail, and the drinking log.
+//
+// Scoping mirrors the REST API exactly:
+//  - without cellar_id → the user's OWN bottles across cellars they OWN
+//    (same as GET /api/bottles: { user, cellar: { $in: ownedCellarIds } });
+//  - with cellar_id    → all bottles of that cellar after a member/owner
+//    access check (same as the per-cellar routes).
+//
+// services/search (Meilisearch) is required LAZILY inside the handler — the
+// meilisearch package is ESM-only and a top-level require would drag it into
+// every jest suite that loads the tool registry (the #702 failure mode).
+const { z } = require('zod');
+const Bottle = require('../../models/Bottle');
+const Cellar = require('../../models/Cellar');
+const Rack = require('../../models/Rack');
+const { WINE_POPULATE, WINE_POPULATE_LIST, CONSUMED_STATUSES } = require('../../config/constants');
+const { registerTool } = require('../registry');
+const {
+  ok, fail, resolveCellarAccess, resolveBottleAccess, accessibleCellars,
+  wineSummary, bottleSummary, pageParams, hasContent,
+} = require('../toolUtil');
+
+const objectId = z.string().regex(/^[a-f0-9]{24}$/i, 'must be a 24-hex id');
+
+function statusToMongo(status) {
+  if (status === 'all') return {};
+  if (status === 'consumed') return { status: { $in: CONSUMED_STATUSES } };
+  return { status: { $nin: CONSUMED_STATUSES } }; // active (default)
+}
+
+registerTool({
+  name: 'search_bottles',
+  title: 'Search / list bottles',
+  description:
+    'Searches the user\'s bottles. Filters: free-text query (wine name, producer, region, grape, notes), cellar_id, ' +
+    'status (active | consumed | all), vintage, wine type. Paginated and bounded; every item includes its rating, ' +
+    'so filter by rating yourself from the results. Call for any "what do I have…", "find my…", "do I own…" question. ' +
+    'Prefer filters over fetching everything.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  // No min_rating filter on purpose: stored ratings are on per-bottle scales
+  // (5/20/100) and the search index holds the RAW value, so a server-side
+  // threshold compares across scales incorrectly (REST normalizes in memory).
+  // Ratings ship in every result; the calling model filters better than a
+  // wrong index query would. A normalized filter can come with Phase 3.
+  inputSchema: {
+    query: z.string().max(200).optional().describe('Free-text search (name, producer, region, grape…)'),
+    cellar_id: objectId.optional().describe('Restrict to one cellar (any cellar you own or are a member of)'),
+    status: z.enum(['active', 'consumed', 'all']).default('active'),
+    vintage: z.string().max(10).optional().describe('e.g. "2015" or "NV"'),
+    type: z.enum(['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified']).optional(),
+    limit: z.number().int().min(1).max(50).default(20),
+    offset: z.number().int().min(0).default(0),
+  },
+  handler: async (args, ctx) => {
+    const { limit, offset } = pageParams(args, 20, 50);
+    const warnings = [];
+
+    // Resolve the cellar scope first (access model in the header comment).
+    let cellarIds;
+    if (args.cellar_id) {
+      const access = await resolveCellarAccess(ctx.user.id, args.cellar_id);
+      if (!access) return fail('not_found', 'No such cellar, or you have no access to it. Use list_cellars for valid ids.');
+      cellarIds = [access.cellar._id];
+    } else {
+      cellarIds = await Cellar.find({ user: ctx.user.id, deletedAt: null }).distinct('_id');
+    }
+
+    // Meilisearch path — handles text + all filters with correct pagination.
+    const searchService = require('../../services/search');
+    if (args.query && searchService.getIsAvailable()) {
+      try {
+        const res = await searchService.searchBottles(args.query, {
+          cellarIds: cellarIds.map(String),
+          statusFilter: args.status || 'active',
+          type: args.type,
+          vintage: args.vintage,
+          limit,
+          offset,
+        });
+        // Same ownership contract as the Mongo path below: without cellar_id
+        // this lists the user's OWN bottles, so re-apply the user filter here —
+        // the search index can't express it, and owned cellars may contain
+        // bottles added by shared-cellar editors.
+        const docs = await Bottle.find({
+          _id: { $in: res.ids },
+          ...(args.cellar_id ? {} : { user: ctx.user.id }),
+        }).populate(WINE_POPULATE_LIST).lean();
+        const byId = new Map(docs.map((d) => [String(d._id), d]));
+        const items = res.ids.map((id) => byId.get(String(id))).filter(Boolean).map(bottleSummary);
+        return ok(`${items.length} of ${res.estimatedTotalHits} matching bottle(s)`, items, {
+          page: { limit, offset, total: res.estimatedTotalHits },
+        });
+      } catch (err) {
+        warnings.push('Text search engine unavailable — fell back to basic filters without free-text matching.');
+      }
+    } else if (args.query) {
+      warnings.push('Text search engine unavailable — fell back to basic filters without free-text matching.');
+    }
+
+    // Mongo fallback: cellar/status/vintage are DB-filterable; type and
+    // min_rating live on the populated wine / vary by rating scale, so they
+    // are dropped here with an explicit warning rather than half-applied.
+    const filter = {
+      cellar: { $in: cellarIds },
+      ...(args.cellar_id ? {} : { user: ctx.user.id }),
+      ...statusToMongo(args.status),
+      ...(args.vintage ? { vintage: args.vintage } : {}),
+    };
+    if (args.type) warnings.push('type filter requires the search engine — ignored in this response.');
+    const [total, docs] = await Promise.all([
+      Bottle.countDocuments(filter),
+      Bottle.find(filter).populate(WINE_POPULATE_LIST)
+        .sort({ createdAt: -1 }).skip(offset).limit(limit).lean(),
+    ]);
+    return ok(`${docs.length} of ${total} bottle(s)`, docs.map(bottleSummary), {
+      page: { limit, offset, total },
+      ...(warnings.length ? { warnings } : {}),
+    });
+  },
+});
+
+registerTool({
+  name: 'get_bottle',
+  title: 'Get one bottle',
+  description:
+    'Full detail for one bottle: wine (incl. tasting profile when enriched), vintage, price, ratings, personal drink ' +
+    'window, notes, purchase info, open-bottle state, rack placement, cellar, and consumption info if consumed. ' +
+    'Call when the user asks about a specific bottle you already have a bottle_id for.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: { bottle_id: objectId.describe('Bottle id from search_bottles / list_history') },
+  handler: async (args, ctx) => {
+    const access = await resolveBottleAccess(ctx.user.id, args.bottle_id);
+    if (!access) return fail('not_found', 'No such bottle, or you have no access to it. Find ids via search_bottles.');
+    const { cellar, role } = access;
+    const b = await Bottle.findById(access.bottle._id).populate(WINE_POPULATE).lean();
+    const rack = await Rack.findOne({ 'slots.bottle': b._id, deletedAt: null })
+      .select('name slots.position slots.bottle').lean();
+    const slot = rack ? rack.slots.find((s) => String(s.bottle) === String(b._id)) : null;
+    const wd = b.wineDefinition;
+    return ok(`${wd ? wd.name : 'Bottle'} ${b.vintage}`, {
+      bottle_id: b._id,
+      wine: wd ? {
+        ...wineSummary(wd),
+        classification: wd.classification || null,
+        // Skeleton subdocs (0 reviews / never-enriched all-null profile) are
+        // materialized by Mongoose defaults — return null, not empty shells.
+        community_rating: wd.communityRating?.reviewCount ? wd.communityRating : null,
+        tasting_profile: hasContent(wd.aiProfile) ? wd.aiProfile : null,
+      } : { pending_registry_review: true, name: b.pendingWineRequest?.wineName || null },
+      vintage: b.vintage,
+      status: b.status,
+      bottle_size: b.bottleSize,
+      price: b.price ?? null,
+      currency: b.currency || null,
+      rating: b.rating ?? null,
+      rating_scale: b.rating != null ? b.ratingScale : null,
+      drink_from: b.drinkFrom ?? null,
+      drink_to: b.drinkTo ?? null,
+      notes: b.notes || null,
+      occasion: b.occasion || null,
+      purchase: { date: b.purchaseDate || null, location: b.purchaseLocation || null },
+      open_bottle: b.openedAt
+        ? { opened_at: b.openedAt, preservation: b.preservationMethod || null, pours: (b.pours || []).length }
+        : null,
+      consumed: CONSUMED_STATUSES.includes(b.status)
+        ? { at: b.consumedAt, reason: b.consumedReason || b.status, note: b.consumedNote || null, rating: b.consumedRating ?? null }
+        : null,
+      placement: slot ? { rack_id: rack._id, rack_name: rack.name, position: slot.position } : null,
+      cellar: { cellar_id: cellar._id, name: cellar.name, your_role: role },
+      added_at: b.addedToCellarAt || b.createdAt,
+    });
+  },
+});
+
+registerTool({
+  name: 'list_history',
+  title: 'Drinking history (Cellar Book)',
+  description:
+    'The user\'s consumption log: consumed / gifted / sold bottles, newest first, with dates, reasons, ratings and notes. ' +
+    'Call for "what did I drink…", tasting recaps, or to find a bottle_id to restore. Optional cellar and year filters.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    cellar_id: objectId.optional(),
+    year: z.number().int().min(1900).max(2100).optional().describe('Calendar year the bottle was consumed'),
+    limit: z.number().int().min(1).max(50).default(20),
+    offset: z.number().int().min(0).default(0),
+  },
+  handler: async (args, ctx) => {
+    const { limit, offset } = pageParams(args, 20, 50);
+    let cellarIds;
+    if (args.cellar_id) {
+      const access = await resolveCellarAccess(ctx.user.id, args.cellar_id);
+      if (!access) return fail('not_found', 'No such cellar, or you have no access to it.');
+      cellarIds = [access.cellar._id];
+    } else {
+      cellarIds = (await accessibleCellars(ctx.user.id)).map((c) => c._id);
+    }
+    const filter = { cellar: { $in: cellarIds }, status: { $in: CONSUMED_STATUSES } };
+    if (args.year) {
+      // UTC year boundaries — deterministic across environments. Prod runs the
+      // container in UTC, so this matches the web app's (server-local) year
+      // filter there; only non-UTC self-hosts see a boundary-hour difference.
+      filter.consumedAt = { $gte: new Date(Date.UTC(args.year, 0, 1)), $lt: new Date(Date.UTC(args.year + 1, 0, 1)) };
+    }
+    const [total, docs] = await Promise.all([
+      Bottle.countDocuments(filter),
+      Bottle.find(filter).populate(WINE_POPULATE_LIST)
+        .sort({ consumedAt: -1 }).skip(offset).limit(limit).lean(),
+    ]);
+    const items = docs.map((b) => ({
+      ...bottleSummary(b),
+      consumed_at: b.consumedAt,
+      consumed_reason: b.consumedReason || b.status,
+      consumed_rating: b.consumedRating ?? null,
+      consumed_note: b.consumedNote || null,
+    }));
+    return ok(`${items.length} of ${total} consumed bottle(s)`, items, { page: { limit, offset, total } });
+  },
+});

--- a/backend/src/mcp/tools/cellars.js
+++ b/backend/src/mcp/tools/cellars.js
@@ -1,0 +1,71 @@
+// Cellar read tools. PII rule: member EMAILS are never returned over MCP —
+// the REST /members and /audit sub-routes are TOKEN_EXCLUSIONS for the same
+// reason; here we return only counts and the caller's own role.
+const { z } = require('zod');
+const Bottle = require('../../models/Bottle');
+const Rack = require('../../models/Rack');
+const { CONSUMED_STATUSES } = require('../../config/constants');
+const { registerTool } = require('../registry');
+const { getCellarRole } = require('../../utils/cellarAccess');
+const { ok, fail, resolveCellarAccess, accessibleCellars } = require('../toolUtil');
+
+registerTool({
+  name: 'list_cellars',
+  title: 'List my cellars',
+  description:
+    'Lists every cellar the user owns or is a member of, with their role and the number of active bottles in each. ' +
+    'Call this first when you need a cellar_id for other tools, or when the user asks what cellars they have.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {},
+  handler: async (_args, ctx) => {
+    const cellars = await accessibleCellars(ctx.user.id);
+    const ids = cellars.map((c) => c._id);
+    const counts = await Bottle.aggregate([
+      { $match: { cellar: { $in: ids }, status: { $nin: CONSUMED_STATUSES } } },
+      { $group: { _id: '$cellar', n: { $sum: 1 } } },
+    ]);
+    const countByCellar = new Map(counts.map((c) => [String(c._id), c.n]));
+    const data = cellars.map((c) => ({
+      cellar_id: c._id,
+      name: c.name,
+      description: c.description || null,
+      role: getCellarRole(c, ctx.user.id),
+      active_bottles: countByCellar.get(String(c._id)) || 0,
+      shared: (c.members || []).length > 0,
+    }));
+    return ok(`${data.length} cellar(s)`, data);
+  },
+});
+
+registerTool({
+  name: 'get_cellar',
+  title: 'Get one cellar',
+  description:
+    'Returns one cellar\'s summary: name, your role, active-bottle count, consumed count, rack count, member count. ' +
+    'Call when the user refers to a specific cellar and you already know its cellar_id (from list_cellars).',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: { cellar_id: z.string().describe('Cellar id from list_cellars') },
+  handler: async (args, ctx) => {
+    const access = await resolveCellarAccess(ctx.user.id, args.cellar_id);
+    if (!access) return fail('not_found', 'No such cellar, or you have no access to it. Use list_cellars for valid ids.');
+    const { cellar, role } = access;
+    const [active, consumed, racks] = await Promise.all([
+      Bottle.countDocuments({ cellar: cellar._id, status: { $nin: CONSUMED_STATUSES } }),
+      Bottle.countDocuments({ cellar: cellar._id, status: { $in: CONSUMED_STATUSES } }),
+      Rack.countDocuments({ cellar: cellar._id, deletedAt: null }),
+    ]);
+    return ok(`Cellar "${cellar.name}"`, {
+      cellar_id: cellar._id,
+      name: cellar.name,
+      description: cellar.description || null,
+      role,
+      active_bottles: active,
+      consumed_bottles: consumed,
+      racks,
+      member_count: (cellar.members || []).length,
+      created_at: cellar.createdAt,
+    });
+  },
+});

--- a/backend/src/mcp/tools/index.js
+++ b/backend/src/mcp/tools/index.js
@@ -1,6 +1,17 @@
 // Single place that loads every tool module (each registers its tools as a
 // side-effect at require time). server.js requires this once so the registry is
 // fully populated before the first request. Add new tool files here.
+//
+// Tool modules may require Mongoose models freely, but must NEVER top-require
+// services/search or anything else that pulls the ESM-only meilisearch package
+// — lazy-require those inside handlers (jest cannot parse the ESM dist; the
+// same chain broke auth.refresh.test.js, fixed in PR #702).
 require('./meta');
+require('./cellars');
+require('./bottles');
+require('./racks');
+require('./stats');
+require('./wines');
+require('./personal');
 
 module.exports = {};

--- a/backend/src/mcp/tools/personal.js
+++ b/backend/src/mcp/tools/personal.js
@@ -1,0 +1,101 @@
+// Wishlist + tasting-journal reads. PII rule for journal entries: tagged
+// people are returned as the display NAMES the user typed — never linked user
+// ids/accounts (mirrors redactPeople's intent in routes/journal.js).
+const { z } = require('zod');
+const WishlistItem = require('../../models/WishlistItem');
+const JournalEntry = require('../../models/JournalEntry');
+const { registerTool } = require('../registry');
+const { ok, pageParams } = require('../toolUtil');
+
+registerTool({
+  name: 'list_wishlist',
+  title: 'List the wine wishlist',
+  description:
+    'The user\'s wishlist: wines they want to buy, with priority and status (wanted | bought). ' +
+    'Call for "what am I looking for", purchase planning, or before suggesting wines they already wishlisted.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    status: z.enum(['wanted', 'bought', 'all']).default('wanted'),
+    limit: z.number().int().min(1).max(50).default(30),
+    offset: z.number().int().min(0).default(0),
+  },
+  handler: async (args, ctx) => {
+    const { limit, offset } = pageParams(args, 30, 50);
+    // Explicit default: zod fills it on the SDK path, but the handler must be
+    // safe when called directly (tests, future internal reuse).
+    const status = args.status || 'wanted';
+    const filter = { user: ctx.user.id };
+    if (status !== 'all') filter.status = status;
+    const [total, items] = await Promise.all([
+      WishlistItem.countDocuments(filter),
+      WishlistItem.find(filter)
+        .populate({ path: 'wineDefinition', select: 'name producer type', populate: ['country', 'region'] })
+        .sort({ createdAt: -1 }).skip(offset).limit(limit).lean(),
+    ]);
+    const data = items.map((it) => ({
+      wishlist_id: it._id,
+      wine: it.wineDefinition
+        ? {
+            wine_id: it.wineDefinition._id,
+            name: it.wineDefinition.name,
+            producer: it.wineDefinition.producer || null,
+            type: it.wineDefinition.type || null,
+            country: it.wineDefinition.country?.name || null,
+            region: it.wineDefinition.region?.name || null,
+          }
+        : null,
+      vintage: it.vintage || null,
+      priority: it.priority,
+      status: it.status,
+      notes: it.notes || null,
+      added_at: it.createdAt,
+    }));
+    return ok(`${data.length} of ${total} wishlist item(s)`, data, { page: { limit, offset, total } });
+  },
+});
+
+registerTool({
+  name: 'list_journal',
+  title: 'List tasting-journal entries',
+  description:
+    'The user\'s tasting journal: dated entries with occasion, mood, dishes and the wines poured. Newest first. ' +
+    'Call for "when did I last taste…", dinner recaps, or context before recommending a repeat pairing.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    limit: z.number().int().min(1).max(50).default(20),
+    offset: z.number().int().min(0).default(0),
+  },
+  handler: async (args, ctx) => {
+    const { limit, offset } = pageParams(args, 20, 50);
+    const filter = { user: ctx.user.id };
+    const [total, entries] = await Promise.all([
+      JournalEntry.countDocuments(filter),
+      JournalEntry.find(filter)
+        .sort({ date: -1 }).skip(offset).limit(limit)
+        .populate({ path: 'pairings.bottle', select: 'vintage wineDefinition', populate: { path: 'wineDefinition', select: 'name producer' } })
+        .populate({ path: 'pairings.wine', select: 'name producer' })
+        .lean(),
+    ]);
+    const data = entries.map((e) => ({
+      journal_id: e._id,
+      date: e.date,
+      title: e.title || null,
+      occasion: e.occasion || null,
+      mood: e.mood ?? null,
+      notes: e.notes || null,
+      people: (e.people || []).map((p) => p.name).filter(Boolean),
+      pairings: (e.pairings || []).map((p) => ({
+        dish: p.dish || null,
+        wine:
+          p.bottle?.wineDefinition?.name ||
+          p.wine?.name ||
+          p.wineName || null,
+        vintage: p.bottle?.vintage || null,
+        notes: p.notes || null,
+      })),
+    }));
+    return ok(`${data.length} of ${total} journal entr(ies)`, data, { page: { limit, offset, total } });
+  },
+});

--- a/backend/src/mcp/tools/racks.js
+++ b/backend/src/mcp/tools/racks.js
@@ -1,0 +1,100 @@
+// Rack read tools. list_racks is deliberately slot-free (occupancy summary
+// only); get_rack returns the full slot map for one rack — keeps responses
+// bounded instead of dumping every slot of every rack.
+const { z } = require('zod');
+const Rack = require('../../models/Rack');
+const { registerTool } = require('../registry');
+const { getMaxPosition } = require('../../utils/rackGeometry');
+const { ok, fail, resolveCellarAccess } = require('../toolUtil');
+
+const objectId = z.string().regex(/^[a-f0-9]{24}$/i, 'must be a 24-hex id');
+
+registerTool({
+  name: 'list_racks',
+  title: 'List racks in a cellar',
+  description:
+    'Lists the racks of one cellar with type, dimensions, capacity, fill level and zone names — no per-slot detail. ' +
+    'Call to get a rack overview or find a rack_id; use get_rack for the slot-by-slot map.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: { cellar_id: objectId },
+  handler: async (args, ctx) => {
+    const access = await resolveCellarAccess(ctx.user.id, args.cellar_id);
+    if (!access) return fail('not_found', 'No such cellar, or you have no access to it. Use list_cellars for valid ids.');
+    const racks = await Rack.find({ cellar: access.cellar._id, deletedAt: null }).lean();
+    const data = racks.map((r) => {
+      const capacity = Math.max(getMaxPosition(r) - (r.disabledPositions || []).length, 0);
+      return {
+        rack_id: r._id,
+        name: r.name,
+        type: r.isModular ? 'modular' : r.type,
+        // Modular racks keep geometry in modules[]; the schema-default rows/cols
+        // are meaningless there and would mislead placement reasoning.
+        rows: r.isModular ? null : r.rows ?? null,
+        cols: r.isModular ? null : r.cols ?? null,
+        modules: r.isModular ? (r.modules || []).length : undefined,
+        capacity,
+        filled: (r.slots || []).length,
+        free: Math.max(capacity - (r.slots || []).length, 0),
+        zones: (r.zones || []).map((zn) => ({ name: zn.name, positions: (zn.positions || []).length })),
+      };
+    });
+    return ok(`${data.length} rack(s) in "${access.cellar.name}"`, data);
+  },
+});
+
+registerTool({
+  name: 'get_rack',
+  title: 'Get one rack (slot map)',
+  description:
+    'Full slot map of one rack: every occupied position with its bottle (wine, producer, vintage), plus zones and ' +
+    'disabled positions. Call when the user asks where something is, what is in a rack, or before reasoning about placement.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: { rack_id: objectId.describe('Rack id from list_racks') },
+  handler: async (args, ctx) => {
+    // Access check BEFORE the slot populate: no DB work on foreign racks, and
+    // one identical not_found for missing and foreign alike — a caller probing
+    // rack ids cannot distinguish "exists but not yours" from "doesn't exist".
+    const NOT_FOUND = 'No such rack, or you have no access to it. Use list_racks for valid ids.';
+    const stub = await Rack.findOne({ _id: args.rack_id, deletedAt: null }).select('cellar').lean();
+    if (!stub) return fail('not_found', NOT_FOUND);
+    const access = await resolveCellarAccess(ctx.user.id, stub.cellar);
+    if (!access) return fail('not_found', NOT_FOUND);
+    const rack = await Rack.findOne({ _id: args.rack_id, deletedAt: null })
+      .populate({
+        path: 'slots.bottle',
+        select: 'vintage status wineDefinition',
+        populate: { path: 'wineDefinition', select: 'name producer type' },
+      })
+      .lean();
+    if (!rack) return fail('not_found', NOT_FOUND);
+    const slots = (rack.slots || [])
+      .filter((s) => s.bottle)
+      .map((s) => ({
+        position: s.position,
+        bottle_id: s.bottle._id,
+        wine: s.bottle.wineDefinition
+          ? { name: s.bottle.wineDefinition.name, producer: s.bottle.wineDefinition.producer || null, type: s.bottle.wineDefinition.type || null }
+          : null,
+        vintage: s.bottle.vintage,
+      }))
+      .sort((a, b) => a.position - b.position);
+    const capacity = Math.max(getMaxPosition(rack) - (rack.disabledPositions || []).length, 0);
+    return ok(`Rack "${rack.name}": ${slots.length}/${capacity} filled`, {
+      rack_id: rack._id,
+      name: rack.name,
+      cellar_id: rack.cellar,
+      type: rack.isModular ? 'modular' : rack.type,
+      rows: rack.isModular ? null : rack.rows ?? null,
+      cols: rack.isModular ? null : rack.cols ?? null,
+      modules: rack.isModular
+        ? (rack.modules || []).map((m) => ({ type: m.type, rows: m.rows, cols: m.cols }))
+        : undefined,
+      capacity,
+      disabled_positions: rack.disabledPositions || [],
+      zones: (rack.zones || []).map((zn) => ({ name: zn.name, color: zn.color || null, positions: zn.positions || [] })),
+      slots,
+    });
+  },
+});

--- a/backend/src/mcp/tools/stats.js
+++ b/backend/src/mcp/tools/stats.js
@@ -1,0 +1,94 @@
+// Portfolio stats tool. Reuses services/statsService.computeOverview — the
+// exact computation behind GET /api/stats/overview — then prunes the result to
+// a token-efficient subset (the full stats object is built for a dashboard;
+// an AI needs the headline numbers plus the maturity/urgency signals).
+const { z } = require('zod');
+const User = require('../../models/User');
+const Cellar = require('../../models/Cellar');
+const Bottle = require('../../models/Bottle');
+const { CONSUMED_STATUSES, WINE_POPULATE_LIST } = require('../../config/constants');
+const { registerTool } = require('../registry');
+const { ok } = require('../toolUtil');
+
+const topN = (v, n) => (Array.isArray(v) ? v.slice(0, n) : v);
+
+// Computing stats loads the user's entire bottle set — the REST route shields
+// that with a 2-min cache. MCP callers are automated and can repeat identical
+// calls, so a short TTL cache here removes the recompute amplification (a 60s
+// stale window is irrelevant for portfolio numbers). No invalidation signature:
+// reads-only Phase 1 can't change the data through MCP anyway.
+const statsCache = new Map(); // `${userId}:${currency}:${scale}` -> { at, result }
+const STATS_TTL_MS = 60 * 1000;
+const STATS_CACHE_MAX = 2000;
+
+registerTool({
+  name: 'cellar_stats',
+  title: 'Cellar statistics & drink-window radar',
+  description:
+    'Portfolio overview across all cellars the user owns: bottle counts, total value, distribution by type / top ' +
+    'countries / top grapes / top producers, maturity breakdown (too-young · ready · peak · past), the drink-window ' +
+    'urgency ladder (what to drink soonest), and drinking pace. Call for "what is my cellar worth", "how is my ' +
+    'collection distributed", "what should I drink soon", or any portfolio-level question.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    currency: z.string().length(3).optional().describe('ISO 4217 override; defaults to the user\'s preference'),
+  },
+  handler: async (args, ctx) => {
+    // statsService pulls exchange-rate utils — keep it off the module-load
+    // path of the tool registry (same lazy pattern as services/search).
+    const { computeOverview, buildEmptyStats } = require('../../services/statsService');
+
+    const dbUser = await User.findById(ctx.user.id).select('preferences').lean();
+    const targetCurrency = (args.currency || dbUser?.preferences?.currency || 'USD').toUpperCase();
+    const targetRatingScale = dbUser?.preferences?.ratingScale || '5';
+
+    const cacheKey = `${ctx.user.id}:${targetCurrency}:${targetRatingScale}`;
+    const cached = statsCache.get(cacheKey);
+    if (cached && Date.now() - cached.at < STATS_TTL_MS) return cached.result;
+
+    const cellars = await Cellar.find({ user: ctx.user.id, deletedAt: null }).lean();
+    if (cellars.length === 0) {
+      // Same data shape as the populated case so the model never sees two envelopes.
+      const empty = buildEmptyStats(targetCurrency);
+      return ok('No cellars yet', {
+        currency: targetCurrency,
+        rating_scale: targetRatingScale,
+        overview: empty.overview,
+        by_type: [],
+        top_countries: [],
+        top_grapes: [],
+        top_producers: [],
+        maturity: empty.maturity || {},
+        urgency_ladder: [],
+        pace: empty.pace || {},
+      });
+    }
+    const scope = { user: ctx.user.id, cellar: { $in: cellars.map((c) => c._id) } };
+    const [activeBottles, consumedBottles] = await Promise.all([
+      Bottle.find({ ...scope, status: { $nin: CONSUMED_STATUSES } }).populate(WINE_POPULATE_LIST).lean(),
+      Bottle.find({ ...scope, status: { $in: CONSUMED_STATUSES } }).populate(WINE_POPULATE_LIST).lean(),
+    ]);
+    const stats = await computeOverview({ activeBottles, consumedBottles, cellars, targetCurrency, targetRatingScale });
+
+    const result = ok(
+      `${activeBottles.length} active bottle(s) across ${cellars.length} cellar(s)`,
+      {
+        currency: targetCurrency,
+        rating_scale: targetRatingScale,
+        overview: stats.overview,
+        by_type: stats.byType,
+        top_countries: topN(stats.byCountry, 10),
+        top_grapes: topN(stats.byGrape, 10),
+        top_producers: topN(stats.topProducers, 5),
+        maturity: stats.maturity,
+        urgency_ladder: stats.urgencyLadder,
+        pace: stats.pace,
+      },
+      { warnings: ['Distributions truncated to top entries; full breakdowns are in the web app\'s Statistics page.'] }
+    );
+    if (statsCache.size >= STATS_CACHE_MAX) statsCache.clear();
+    statsCache.set(cacheKey, { at: Date.now(), result });
+    return result;
+  },
+});

--- a/backend/src/mcp/tools/wines.js
+++ b/backend/src/mcp/tools/wines.js
@@ -1,0 +1,84 @@
+// Shared wine-registry read tools. Privilege parity with REST: GET /api/wines
+// caps non-admin searches at 10 results (USER_SEARCH_LIMIT) — the MCP tool
+// enforces the same cap, so a token never out-privileges the web UI.
+//
+// services/search is required lazily (ESM meilisearch — see tools/bottles.js).
+const { z } = require('zod');
+const WineDefinition = require('../../models/WineDefinition');
+const { registerTool } = require('../registry');
+const { isValidId } = require('../../utils/validation');
+const { ok, fail, wineSummary, hasContent } = require('../toolUtil');
+
+const REGISTRY_LIMIT = 10; // == USER_SEARCH_LIMIT in routes/wines.js
+
+// Fields safe to expose: never normalizedKey / createdBy / productNumber*.
+const SAFE_SELECT = 'name producer slug country region appellation classification grapes type communityRating aiProfile lwin';
+
+registerTool({
+  name: 'search_registry',
+  title: 'Search the shared wine registry',
+  description:
+    'Searches Cellarion\'s shared wine database (vintage-neutral wines, community data) by name, producer, region or ' +
+    'grape. Returns up to 10 matches. Call to identify a wine the user mentions, before recommending, or to check ' +
+    'whether a wine exists in the registry. This searches ALL known wines — use search_bottles for what the user owns.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    query: z.string().min(2).max(200).describe('Wine name, producer, appellation or grape'),
+  },
+  handler: async (args) => {
+    const searchService = require('../../services/search');
+    let wines = [];
+    let viaEngine = false;
+    if (searchService.getIsAvailable()) {
+      try {
+        const res = await searchService.search(args.query, { limit: REGISTRY_LIMIT });
+        const docs = await WineDefinition.find({ _id: { $in: res.ids } })
+          .select(SAFE_SELECT).populate(['country', 'region', 'grapes']).lean();
+        const byId = new Map(docs.map((d) => [String(d._id), d]));
+        wines = res.ids.map((id) => byId.get(String(id))).filter(Boolean);
+        viaEngine = true;
+      } catch { /* fall through to Mongo text search */ }
+    }
+    if (!viaEngine) {
+      wines = await WineDefinition.find(
+        { $text: { $search: args.query } },
+        { score: { $meta: 'textScore' } }
+      )
+        .select(SAFE_SELECT).sort({ score: { $meta: 'textScore' } })
+        .limit(REGISTRY_LIMIT).populate(['country', 'region', 'grapes']).lean();
+    }
+    const data = wines.map((w) => ({
+      ...wineSummary(w),
+      classification: w.classification || null,
+      community_rating: w.communityRating?.reviewCount ? w.communityRating : null,
+    }));
+    return ok(`${data.length} registry match(es) (max ${REGISTRY_LIMIT})`, data);
+  },
+});
+
+registerTool({
+  name: 'get_wine',
+  title: 'Get one registry wine',
+  description:
+    'Full registry record for one wine: producer, region, appellation, classification, grapes, community rating, and ' +
+    'the AI tasting profile when the wine has been enriched. Vintage-neutral (bottles carry the vintage). ' +
+    'Call after search_registry when the user wants depth on a specific wine.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: { wine_id: z.string().describe('Registry wine id from search_registry or a bottle\'s wine') },
+  handler: async (args) => {
+    if (!isValidId(args.wine_id)) return fail('invalid_input', 'wine_id must be a 24-hex Mongo id.');
+    const w = await WineDefinition.findById(args.wine_id)
+      .select(SAFE_SELECT).populate(['country', 'region', 'grapes']).lean();
+    if (!w) return fail('not_found', 'No registry wine with that id. Find wines via search_registry.');
+    return ok(`${w.name}${w.producer ? ` — ${w.producer}` : ''}`, {
+      ...wineSummary(w),
+      classification: w.classification || null,
+      lwin7: w.lwin?.lwin7 || null,
+      community_rating: w.communityRating?.reviewCount ? w.communityRating : null,
+      tasting_profile: hasContent(w.aiProfile) ? w.aiProfile : null,
+      public_url: w.slug ? `https://cellarion.app/wines/${w.slug}` : null,
+    });
+  },
+});


### PR DESCRIPTION
## What this is

**MCP plan Phase 1: the read-only surface.** On top of the #701 foundation, an AI connected with a read-scoped `cel_` token (or a logged-in session) can now browse the entire cellar:

| Tool | What it answers |
|---|---|
| `list_cellars` / `get_cellar` | "what cellars do I have?" (roles, counts — never member emails/ids) |
| `search_bottles` | "what do I have?" — text + cellar/status/vintage/type filters, Meili-backed with honest Mongo fallback |
| `get_bottle` | one bottle in full: wine + tasting profile, drink window, rack placement, open-bottle state |
| `list_history` | the Cellar Book: what was drunk/gifted when, ratings, restore-target discovery |
| `list_racks` / `get_rack` | occupancy summaries / full slot map with zones |
| `cellar_stats` | portfolio value + distributions + **maturity & urgency radar** + drinking pace |
| `search_registry` / `get_wine` | the shared wine registry (capped at 10 = REST parity) |
| `list_wishlist` / `list_journal` | wishlist; tasting journal (people as names only) |

Server `instructions` teach the AI the tool families, the id-discipline ("never invent an id"), and that this connection is read-only.

## Security model (each handler self-enforces — no per-tool route middleware)

- Every query keyed to `ctx.user`; cellar/bottle access via service-context twins of the REST middlewares; **foreign = missing** (single `not_found`, no existence oracle).
- REST privilege parity throughout; PII rules mirrored from `TOKEN_EXCLUSIONS` (no member emails/ids, no audit data, registry internals never serialized).
- Everything bounded: limits ≤ 50, compact envelopes, stats pruned to top-N + 60s TTL cache, **per-request tool-call budget (20)** in `mcp/server.js` closing the JSON-RPC batch fan-out deferral from the #701 audit.
- Meilisearch stays lazy-required inside handlers (ESM — the #702 jest lesson, now documented in `tools/index.js`).

## Adversarial audit (2 independent reviewers, before push — all findings fixed)

| Finding | Sev | Fix |
|---|---|---|
| `get_bottle`/`get_rack` **broken on every real call**: ObjectId refs failed the string-only `isValidId` gate; tests were green off string mocks | **High** | `String()` coercion at the gate (still fail-closed for smuggled objects) + **regression tests using real mongoose ObjectIds** |
| JSON-RPC batch fan-out amplification (uncached `cellar_stats` worst case) | Med | per-request call budget (20) + 60s stats cache + stale `app.js` comment rewritten |
| `min_rating` compared raw mixed-scale ratings in the search index | Med | param removed — ratings ship in every result; the calling model filters (normalized filter comes with Phase 3) |
| Search scoping diverged between Meili/Mongo paths | Med | user filter re-applied on the Meili path — one contract |
| `get_rack` existence oracle + populate-before-access; modular racks reported schema-default rows/cols; empty-stats shape drift; skeleton `community_rating`/`aiProfile` shells | Low | all fixed |

## Verification

- **71 MCP/auth tests** (incl. new ObjectId regressions, oracle-equality, budget-cap) + **full backend suite 87 suites / 1420 tests green** in `node:20-alpine`; `require('sharp')` verified.
- SDK-client smoke: `initialize → tools/list → tools/call` advertises all 13 tools.
- **No new dependencies; lockfile untouched.**

## Docker / compose impact: **none**

In-process route on the existing backend; no new service, port, env var, or volume.

## Not in this PR (next per the plan)

Resources (`cellar://snapshot`), `find_similar_wines` (Qdrant), export tools, eval harness, stdio package — Phase 1 continues; writes (registry-safe `resolve_wine`→`add_bottle` + provenance tagging) are Phase 2.