### PR TITLE
feat(mcp): eval harness — real-model tool-selection eval + in-repo full-stack e2e

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "jest"
+    "test": "jest",
+    "mcp:e2e": "node src/mcp/e2e.js",
+    "mcp:eval": "node src/mcp/eval/run.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.55.0",

--- a/backend/src/mcp/e2e.js
+++ b/backend/src/mcp/e2e.js
@@ -1,0 +1,137 @@
+/* Full-stack MCP e2e — drives the RUNNING backend (real Mongo/Meili/Qdrant)
+ * with the real SDK client. The Docker smoke for the MCP surface:
+ *
+ *   docker-compose up -d           # then, if the DB is fresh:
+ *   docker exec cellarion-backend node src/seed-demo.js
+ *   npm run mcp:e2e                # from backend/ (or CELLARION_URL=… node src/mcp/e2e.js)
+ *
+ * Checks auth negatives (401/405/demo-403/foreign-probe), the initialize
+ * handshake, every read tool against seeded data, and both resource kinds.
+ * NOT part of jest (needs a live stack). First ran as the pre-merge Docker
+ * verification of PRs #705/#707 — kept in-repo so every future MCP change can
+ * re-run it in minutes (plan §9; the release checklist should include it).
+ */
+const BASE = process.env.CELLARION_URL || 'http://127.0.0.1:5000';
+// Guard: this script logs in with documented DEV credentials and creates a
+// demo session — refuse to point it at anything non-local by accident.
+if (!/^https?:\/\/(127\.0\.0\.1|localhost)([:/]|$)/.test(BASE) && process.env.CELLARION_ALLOW_REMOTE !== '1') {
+  console.error('Refusing non-local CELLARION_URL without CELLARION_ALLOW_REMOTE=1:', BASE);
+  process.exit(2);
+}
+const MCP = `${BASE}/api/mcp`;
+
+const fail = (m) => { console.error('FAIL:', m); process.exit(1); };
+const okLog = (m) => console.log('  ✓', m);
+
+async function main() {
+  let r = await fetch(`${BASE}/api/auth/login`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      username: process.env.CELLARION_USER || 'user@cellarion.app',
+      password: process.env.CELLARION_PASS || 'User1234!demo',
+    }),
+  });
+  if (!r.ok) fail(`login ${r.status} — is the stack up and seeded? (docker exec cellarion-backend node src/seed-demo.js)`);
+  const { token } = await r.json();
+  okLog('login');
+
+  r = await fetch(MCP, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+  if (r.status !== 401) fail(`unauthenticated POST expected 401, got ${r.status}`);
+  okLog('no-auth POST → 401');
+  r = await fetch(MCP, { method: 'GET', headers: { Authorization: `Bearer ${token}` } });
+  if (r.status !== 405) fail(`GET expected 405, got ${r.status}`);
+  okLog('JWT GET → 405');
+
+  // Ephemeral demo sessions must never reach the MCP (requireNonDemo).
+  r = await fetch(`${BASE}/api/auth/demo-login`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+  if (r.ok) {
+    const demo = await r.json();
+    const dr = await fetch(MCP, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream', Authorization: `Bearer ${demo.token}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'x', version: '0' } } }),
+    });
+    if (dr.status !== 403) fail(`demo POST expected 403, got ${dr.status}`);
+    okLog('demo JWT → 403 (requireNonDemo)');
+  } else {
+    console.log(`  – demo-login unavailable (${r.status}) — demo-block check skipped`);
+  }
+
+  const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+  const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
+  const client = new Client({ name: 'cellarion-e2e', version: '0.0.0' });
+  await client.connect(new StreamableHTTPClientTransport(new URL(MCP), {
+    requestInit: { headers: { Authorization: `Bearer ${token}` } },
+  }));
+  okLog('initialize handshake');
+
+  const { tools } = await client.listTools();
+  if (tools.length < 14) fail(`expected >=14 tools, got ${tools.length}`);
+  okLog(`tools/list → ${tools.length} tools`);
+
+  const parse = (res, { allowError = false } = {}) => {
+    const body = JSON.parse(res.content.find((c) => c.type === 'text').text);
+    if (body.error && !allowError) fail('tool returned an error envelope: ' + JSON.stringify(body.error));
+    return body;
+  };
+
+  const cellars = parse(await client.callTool({ name: 'list_cellars', arguments: {} }));
+  if (!Array.isArray(cellars.data) || !cellars.data.length) fail('no cellars — seed the stack first');
+  okLog(`list_cellars → ${cellars.summary}`);
+  const cellarId = String(cellars.data[0].cellar_id);
+
+  const bottles = parse(await client.callTool({ name: 'search_bottles', arguments: { cellar_id: cellarId, limit: 5 } }));
+  okLog(`search_bottles(cellar) → ${bottles.summary}`);
+  const text = parse(await client.callTool({ name: 'search_bottles', arguments: { query: 'cloudy', limit: 5 } }));
+  okLog(`search_bottles(query) → ${text.summary}${text.warnings ? ' [fallback]' : ' (Meili)'}`);
+
+  if (bottles.data.length) {
+    const bottleId = String(bottles.data[0].bottle_id);
+    const detail = parse(await client.callTool({ name: 'get_bottle', arguments: { bottle_id: bottleId } }));
+    if (detail.error) fail('get_bottle errored on own bottle: ' + JSON.stringify(detail.error));
+    okLog(`get_bottle → ${detail.summary}`);
+    const sim = parse(await client.callTool({ name: 'find_similar_wines', arguments: { bottle_id: bottleId } }));
+    okLog(`find_similar_wines → ${sim.summary}`);
+  }
+
+  const racks = parse(await client.callTool({ name: 'list_racks', arguments: { cellar_id: cellarId } }));
+  okLog(`list_racks → ${racks.summary}`);
+  if (racks.data.length) {
+    const rack = parse(await client.callTool({ name: 'get_rack', arguments: { rack_id: String(racks.data[0].rack_id) } }));
+    okLog(`get_rack → ${rack.summary}`);
+  }
+
+  const stats = parse(await client.callTool({ name: 'cellar_stats', arguments: {} }));
+  if (!stats.data.overview) fail('cellar_stats missing overview');
+  okLog(`cellar_stats → ${stats.summary}`);
+
+  okLog(`list_history → ${parse(await client.callTool({ name: 'list_history', arguments: { limit: 3 } })).summary}`);
+  okLog(`list_wishlist → ${parse(await client.callTool({ name: 'list_wishlist', arguments: {} })).summary}`);
+  okLog(`list_journal → ${parse(await client.callTool({ name: 'list_journal', arguments: {} })).summary}`);
+
+  const reg = parse(await client.callTool({ name: 'search_registry', arguments: { query: 'cabernet' } }));
+  okLog(`search_registry → ${reg.summary}`);
+  if (reg.data.length) {
+    okLog(`get_wine → ${parse(await client.callTool({ name: 'get_wine', arguments: { wine_id: String(reg.data[0].wine_id) } })).summary}`);
+  }
+
+  const { resources } = await client.listResources();
+  if (!resources.some((x) => x.uri === 'cellar://snapshot')) fail('snapshot resource missing');
+  const snap = JSON.parse((await client.readResource({ uri: 'cellar://snapshot' })).contents[0].text);
+  if (!Array.isArray(snap.data)) fail('snapshot envelope wrong');
+  okLog(`snapshot → ${snap.summary}`);
+  const about = await client.readResource({ uri: 'cellarion://about' });
+  if (!about.contents[0].text.includes('AGPL-3.0')) fail('about wrong');
+  okLog('about → AGPL-3.0');
+  const dossier = JSON.parse((await client.readResource({ uri: `cellar://bottle/${'f'.repeat(24)}` })).contents[0].text);
+  if (!dossier.error || dossier.error.code !== 'not_found') fail('foreign dossier probe not not_found');
+  okLog('foreign bottle dossier → not_found');
+
+  const foreign = parse(await client.callTool({ name: 'get_bottle', arguments: { bottle_id: 'f'.repeat(24) } }), { allowError: true });
+  if (!foreign.error || foreign.error.code !== 'not_found') fail('foreign bottle probe not not_found');
+  okLog('foreign bottle id → not_found');
+
+  await client.close();
+  console.log('\nALL MCP E2E CHECKS PASSED against ' + BASE);
+}
+main().catch((e) => { console.error('FAIL:', e); process.exit(1); });

--- a/backend/src/mcp/eval/cases.js
+++ b/backend/src/mcp/eval/cases.js
@@ -1,0 +1,60 @@
+// Golden tool-selection cases (plan §9): natural phrasings a real user would
+// type into their assistant, with the tool a well-instructed model SHOULD
+// reach for first. `anyOf` marks cases where more than one first move is
+// legitimately correct (e.g. resolving a cellar id before a per-cellar tool).
+// Keep prompts realistic — the eval measures our NAMES + DESCRIPTIONS, not the
+// model. When a case fails consistently, fix the tool description, not the case.
+
+const CASES = [
+  { id: 'cellars-overview', prompt: 'What cellars do I have?', expect: { tool: 'list_cellars' } },
+  {
+    id: 'own-a-wine',
+    prompt: 'Do I have any Barolo left?',
+    expect: { tool: 'search_bottles' },
+    args: (a) => /barolo/i.test(a.query || ''),
+  },
+  {
+    id: 'where-is-bottle',
+    prompt: 'Where in my cellar is the Cloudy Bay stored?',
+    expect: { anyOf: ['search_bottles', 'get_rack'] },
+  },
+  { id: 'drank-recently', prompt: 'What did I drink last month?', expect: { tool: 'list_history' } },
+  { id: 'portfolio-value', prompt: 'What is my wine collection worth right now?', expect: { tool: 'cellar_stats' } },
+  {
+    id: 'drink-soon-urgency',
+    prompt: 'Which of my wines should I drink soon, before they go past their peak?',
+    expect: { anyOf: ['cellar_stats', 'search_bottles'] },
+  },
+  {
+    id: 'rack-layout',
+    prompt: 'Show me how my racks are laid out.',
+    expect: { anyOf: ['list_racks', 'list_cellars'] }, // may need a cellar_id first — both are correct first moves
+  },
+  {
+    id: 'registry-lookup',
+    prompt: 'Does Cellarion know the wine Château Margaux?',
+    expect: { tool: 'search_registry' },
+    args: (a) => /margaux/i.test(a.query || ''),
+  },
+  {
+    id: 'more-like-this',
+    prompt: 'I love my Felsina Chianti — find me wines similar in style to it.',
+    expect: { anyOf: ['find_similar_wines', 'search_bottles'] }, // may resolve the bottle id first
+  },
+  { id: 'wishlist', prompt: "What's on my wine wishlist?", expect: { tool: 'list_wishlist' } },
+  { id: 'journal', prompt: 'Read me my latest tasting journal entries.', expect: { tool: 'list_journal' } },
+  {
+    id: 'what-is-cellarion',
+    prompt: 'What exactly is Cellarion, and is it open source?',
+    expect: { tool: 'get_source_info' },
+  },
+  {
+    id: 'consumed-vintage-year',
+    prompt: 'Which bottles did I consume during 2025?',
+    expect: { tool: 'list_history' },
+    args: (a) => Number(a.year) === 2025 || a.year === undefined, // year arg preferred, plain call acceptable
+  },
+  { id: 'no-tool-smalltalk', prompt: 'Hi! How are you today?', expect: { none: true } },
+];
+
+module.exports = { CASES };

--- a/backend/src/mcp/eval/lib.js
+++ b/backend/src/mcp/eval/lib.js
@@ -1,0 +1,62 @@
+// Pure helpers for the MCP tool-selection eval (plan §9). Kept free of SDK /
+// network / API dependencies so they are unit-testable in jest.
+
+/**
+ * Map MCP tools/list entries to Anthropic Messages-API tool definitions.
+ * tools/list already carries JSON Schema (the server converts zod shapes),
+ * so this is a rename, not a conversion.
+ */
+function toAnthropicTools(mcpTools) {
+  return mcpTools.map((t) => ({
+    name: t.name,
+    description: t.description || '',
+    input_schema: t.inputSchema || { type: 'object', properties: {} },
+  }));
+}
+
+/**
+ * Judge one eval case against the tool_use blocks of the model's FIRST
+ * response. Case shapes:
+ *   { expect: { tool: 'name' } }            — first call must be this tool
+ *   { expect: { anyOf: ['a', 'b'] } }       — first call must be one of these
+ *   { expect: { none: true } }              — model must call NO tool
+ * Optional `args(input) => boolean` further constrains the first call's input.
+ * Returns { pass, picked, detail }.
+ */
+function judgeCase(kase, toolUses) {
+  const picked = toolUses.length ? toolUses[0].name : null;
+  if (kase.expect.none) {
+    return {
+      pass: toolUses.length === 0,
+      picked,
+      detail: toolUses.length === 0 ? 'no tool (correct)' : `called ${picked}, expected none`,
+    };
+  }
+  const allowed = kase.expect.anyOf || [kase.expect.tool];
+  if (!picked) return { pass: false, picked, detail: `no tool call, expected ${allowed.join('|')}` };
+  if (!allowed.includes(picked)) {
+    return { pass: false, picked, detail: `picked ${picked}, expected ${allowed.join('|')}` };
+  }
+  if (kase.args && !kase.args(toolUses[0].input || {})) {
+    return { pass: false, picked, detail: `picked ${picked} but args failed the case predicate: ${JSON.stringify(toolUses[0].input)}` };
+  }
+  return { pass: true, picked, detail: `picked ${picked}` };
+}
+
+/** Validate the shape of a cases array at load time (fail fast on typos). */
+function assertValidCases(cases) {
+  const ids = new Set();
+  for (const k of cases) {
+    if (!k.id || ids.has(k.id)) throw new Error(`eval case: missing/duplicate id "${k.id}"`);
+    ids.add(k.id);
+    if (typeof k.prompt !== 'string' || !k.prompt.trim()) throw new Error(`eval case ${k.id}: prompt required`);
+    const e = k.expect || {};
+    const modes = [e.tool, e.anyOf, e.none].filter((v) => v !== undefined).length;
+    if (modes !== 1) throw new Error(`eval case ${k.id}: expect needs exactly one of tool|anyOf|none`);
+    if (e.anyOf && (!Array.isArray(e.anyOf) || !e.anyOf.length)) throw new Error(`eval case ${k.id}: anyOf must be a non-empty array`);
+    if (k.args && typeof k.args !== 'function') throw new Error(`eval case ${k.id}: args must be a function`);
+  }
+  return true;
+}
+
+module.exports = { toAnthropicTools, judgeCase, assertValidCases };

--- a/backend/src/mcp/eval/lib.test.js
+++ b/backend/src/mcp/eval/lib.test.js
@@ -1,0 +1,67 @@
+/**
+ * Eval-harness logic (pure part). The runner itself needs a live stack + API
+ * key (opt-in, run.js); everything judgeable without either is pinned here —
+ * including that the REAL cases file is structurally valid, so a typo in a
+ * case fails CI instead of the first paid eval run.
+ */
+const { toAnthropicTools, judgeCase, assertValidCases } = require('./lib');
+const { CASES } = require('./cases');
+const { allTools } = require('../registry');
+require('../tools');
+
+describe('toAnthropicTools', () => {
+  test('maps name/description/inputSchema and defaults a missing schema', () => {
+    const out = toAnthropicTools([
+      { name: 'a', description: 'd', inputSchema: { type: 'object', properties: { x: {} } } },
+      { name: 'b' },
+    ]);
+    expect(out[0]).toEqual({ name: 'a', description: 'd', input_schema: { type: 'object', properties: { x: {} } } });
+    expect(out[1].input_schema).toEqual({ type: 'object', properties: {} });
+  });
+});
+
+describe('judgeCase', () => {
+  const use = (name, input = {}) => ({ name, input });
+
+  test('tool: exact first call passes, wrong tool / no call fails', () => {
+    const kase = { expect: { tool: 'search_bottles' } };
+    expect(judgeCase(kase, [use('search_bottles')]).pass).toBe(true);
+    expect(judgeCase(kase, [use('list_cellars')]).pass).toBe(false);
+    expect(judgeCase(kase, []).pass).toBe(false);
+  });
+
+  test('anyOf accepts any listed first move; judges only the FIRST call', () => {
+    const kase = { expect: { anyOf: ['list_racks', 'list_cellars'] } };
+    expect(judgeCase(kase, [use('list_cellars'), use('get_rack')]).pass).toBe(true);
+    expect(judgeCase(kase, [use('get_rack'), use('list_racks')]).pass).toBe(false);
+  });
+
+  test('none passes only with zero tool calls', () => {
+    expect(judgeCase({ expect: { none: true } }, []).pass).toBe(true);
+    expect(judgeCase({ expect: { none: true } }, [use('list_cellars')]).pass).toBe(false);
+  });
+
+  test('args predicate constrains the first call input', () => {
+    const kase = { expect: { tool: 'search_bottles' }, args: (a) => /barolo/i.test(a.query || '') };
+    expect(judgeCase(kase, [use('search_bottles', { query: 'Barolo 2015' })]).pass).toBe(true);
+    expect(judgeCase(kase, [use('search_bottles', { query: 'rioja' })]).pass).toBe(false);
+    expect(judgeCase(kase, [use('search_bottles', {})]).pass).toBe(false);
+  });
+});
+
+describe('the shipped cases', () => {
+  test('are structurally valid', () => {
+    expect(assertValidCases(CASES)).toBe(true);
+    expect(CASES.length).toBeGreaterThanOrEqual(12);
+  });
+
+  test('every expected tool name actually exists in the registry (no drift)', () => {
+    const names = new Set(allTools().map((t) => t.name));
+    for (const kase of CASES) {
+      for (const name of kase.expect.anyOf || (kase.expect.tool ? [kase.expect.tool] : [])) {
+        if (!names.has(name)) throw new Error(`case ${kase.id} expects unknown tool "${name}"`);
+      }
+    }
+    expect(true).toBe(true);
+  });
+});

--- a/backend/src/mcp/eval/run.js
+++ b/backend/src/mcp/eval/run.js
@@ -1,0 +1,102 @@
+/* MCP tool-selection eval (plan §9) — measures whether a REAL model, given our
+ * live tool list + server instructions, reaches for the right tool on natural
+ * user phrasings. This is the feedback loop for tool names/descriptions: when
+ * a case fails consistently, fix the description, not the case.
+ *
+ * Opt-in (costs real API tokens):
+ *   ANTHROPIC_API_KEY=sk-...  node src/mcp/eval/run.js
+ * Environment:
+ *   CELLARION_URL    target backend (default http://127.0.0.1:5000 — the local
+ *                    Docker stack; run `docker exec cellarion-backend node
+ *                    src/seed-demo.js` first if the DB is empty)
+ *   CELLARION_TOKEN  cel_ token or JWT; else CELLARION_USER/CELLARION_PASS
+ *                    (defaults: the seeded demo user)
+ *   EVAL_MODEL       default claude-opus-4-8
+ *   EVAL_MIN         accuracy gate 0..1 (default 0.8); exit 1 below it
+ *
+ * NOT part of jest (needs network + API key). The pure logic lives in lib.js,
+ * which IS jest-covered.
+ */
+const Anthropic = require('@anthropic-ai/sdk');
+const { toAnthropicTools, judgeCase, assertValidCases } = require('./lib');
+const { CASES } = require('./cases');
+
+const BASE = process.env.CELLARION_URL || 'http://127.0.0.1:5000';
+if (!/^https?:\/\/(127\.0\.0\.1|localhost)([:/]|$)/.test(BASE) && process.env.CELLARION_ALLOW_REMOTE !== '1') {
+  console.error('Refusing non-local CELLARION_URL without CELLARION_ALLOW_REMOTE=1:', BASE);
+  process.exit(2);
+}
+const MODEL = process.env.EVAL_MODEL || 'claude-opus-4-8';
+const MIN = Number(process.env.EVAL_MIN || 0.8);
+
+async function bearer() {
+  if (process.env.CELLARION_TOKEN) return process.env.CELLARION_TOKEN;
+  const r = await fetch(`${BASE}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      username: process.env.CELLARION_USER || 'user@cellarion.app',
+      password: process.env.CELLARION_PASS || 'User1234!demo',
+    }),
+  });
+  if (!r.ok) throw new Error(`login failed (${r.status}) — set CELLARION_TOKEN or CELLARION_USER/PASS`);
+  return (await r.json()).token;
+}
+
+async function main() {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('ANTHROPIC_API_KEY not set — the eval calls a real model and is strictly opt-in.');
+    process.exit(2);
+  }
+  assertValidCases(CASES);
+  const token = await bearer();
+
+  const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+  const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
+  const client = new Client({ name: 'cellarion-eval', version: '0.0.0' });
+  await client.connect(new StreamableHTTPClientTransport(new URL(`${BASE}/api/mcp`), {
+    requestInit: { headers: { Authorization: `Bearer ${token}` } },
+  }));
+  const { tools } = await client.listTools();
+  // The server instructions are ambient context in every real client session —
+  // the eval must include them or it measures a setup no user actually has.
+  const system = client.getInstructions?.() || '';
+  await client.close();
+
+  const anthropic = new Anthropic();
+  const anthropicTools = toAnthropicTools(tools);
+  console.log(`Evaluating ${CASES.length} cases against ${MODEL} with ${tools.length} live tools\n`);
+
+  let passed = 0;
+  for (const kase of CASES) {
+    let msg;
+    try {
+      msg = await anthropic.messages.create({
+      model: MODEL,
+      max_tokens: 600,
+      system,
+      tools: anthropicTools,
+      messages: [{ role: 'user', content: kase.prompt }],
+    });
+    } catch (err) {
+      // The SDK already retried transient errors; a hard failure costs this
+      // case only — earlier paid results are kept and the gate stays honest.
+      console.log(` ✗ ${kase.id.padEnd(24)} API error: ${err.status || err.message}`);
+      continue;
+    }
+    const toolUses = msg.content.filter((c) => c.type === 'tool_use');
+    const { pass, detail } = judgeCase(kase, toolUses);
+    passed += pass ? 1 : 0;
+    console.log(` ${pass ? '✓' : '✗'} ${kase.id.padEnd(24)} ${detail}`);
+  }
+
+  const accuracy = passed / CASES.length;
+  console.log(`\nTool-selection accuracy: ${passed}/${CASES.length} (${Math.round(accuracy * 100)}%) — gate ${Math.round(MIN * 100)}%`);
+  if (accuracy < MIN) {
+    console.error('Below the accuracy gate. Fix tool descriptions (see failing cases), then re-run.');
+    process.exit(1);
+  }
+  console.log('PASS');
+}
+
+main().catch((e) => { console.error('EVAL FAILED:', e); process.exit(1); });


### PR DESCRIPTION
## What this is

Plan §9 — the feedback loop that makes "the AI can handle it" **measured instead of assumed**. Two layers:

### `npm run mcp:e2e` — full-stack walkthrough (no LLM, free)
Drives a live Docker stack with the real SDK client: auth negatives (401/405/demo-403/foreign-probes), initialize, **every read tool** on seeded data, both resource kinds. Strict envelope parsing — a tool regressing to an error envelope fails the run. (This is the script that pre-merge-verified #705/#707, now in-repo; belongs in the release checklist.)

### `npm run mcp:eval` — real-model tool-selection eval (opt-in, costs tokens)
Pulls the **live** tools/list + server instructions from `/api/mcp`, then asks a real model 14 natural user phrasings and judges the first tool call (`anyOf` for legitimately-plural first moves, `none` for small talk, arg predicates where arguments matter). Accuracy gate `EVAL_MIN` (default 80%). Exits without `ANTHROPIC_API_KEY`.

**First live run: 14/14 (100%) on `claude-opus-4-8`** against the seeded stack — including correctly calling *no* tool on small talk and resolving `list_cellars` first when a cellar id was needed.

## Safety rails (from the diff audit — no High findings)
- Both scripts **refuse non-localhost** `CELLARION_URL` without `CELLARION_ALLOW_REMOTE=1` (they use documented dev credentials; e2e creates a demo session).
- A hard API failure costs only that case; earlier paid results are kept; the gate stays honest.
- No credential is ever logged; the paid path is strictly opt-in.

## Verification
- Judge/mapping logic is pure (`eval/lib.js`) and jest-covered, incl. structural validation of shipped cases and a **registry drift-guard** (a case expecting a nonexistent tool fails CI, not the first paid run). 46 MCP tests green in `node:20-alpine`.
- e2e ran green against the live stack (22 checks) with this exact branch build.

No new dependencies (`@anthropic-ai/sdk` already a backend dep). **docker-compose impact: none.**