### PR TITLE
feat(mcp): "Connect your AI" settings section — copy-paste MCP configs + token test

### DIFF
--- a/frontend/src/components/AiConnectSection.js
+++ b/frontend/src/components/AiConnectSection.js
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Settings section: "Connect your AI" — copy-paste MCP configs for Claude
+ * Desktop (via the npx cellarion-mcp bridge), Claude Code, and any generic
+ * Streamable-HTTP MCP client.
+ *
+ * The token is pasted by the user (minted in the API-tokens section above,
+ * `read` scope) and lives ONLY in component state — never persisted, never
+ * sent anywhere except the same-origin test call to /api/auth/whoami, the
+ * endpoint built for exactly this "is my token valid?" check.
+ */
+const HOSTED_ORIGIN = 'https://cellarion.app';
+
+function buildSnippets(rawToken) {
+  const token = rawToken.trim() || 'cel_YOUR_TOKEN_HERE';
+  const origin = window.location.origin;
+  const selfHosted = origin !== HOSTED_ORIGIN;
+  const desktop = {
+    mcpServers: {
+      cellarion: {
+        command: 'npx',
+        args: ['-y', 'cellarion-mcp'],
+        env: {
+          CELLARION_TOKEN: token,
+          ...(selfHosted ? { CELLARION_URL: origin } : {}),
+        },
+      },
+    },
+  };
+  return {
+    desktop: JSON.stringify(desktop, null, 2),
+    code: `claude mcp add --transport http cellarion ${origin}/api/mcp --header "Authorization: Bearer ${token}"`,
+    generic: `${origin}/api/mcp\nAuthorization: Bearer ${token}`,
+  };
+}
+
+function Snippet({ label, text }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch { /* clipboard unavailable (http / permissions) — user selects manually */ }
+  };
+  return (
+    <div className="ai-connect-snippet-block">
+      <div className="ai-connect-snippet-head">
+        <h3>{label}</h3>
+        <button type="button" className="btn btn-secondary btn-small" onClick={handleCopy}>
+          {copied ? t('settings.aiConnect.copied', 'Copied!') : t('settings.aiConnect.copy', 'Copy')}
+        </button>
+      </div>
+      <pre className="api-token-plain ai-connect-snippet"><code>{text}</code></pre>
+    </div>
+  );
+}
+
+export default function AiConnectSection() {
+  const { t } = useTranslation();
+  const [token, setToken] = useState('');
+  const [testState, setTestState] = useState(null); // null | 'testing' | 'ok' | 'fail'
+
+  const snippets = buildSnippets(token);
+
+  const handleTest = async () => {
+    setTestState('testing');
+    try {
+      // Deliberately a raw fetch with the PASTED token (not the session JWT):
+      // this verifies the exact credential the AI client will use. /whoami is
+      // the read-scope identity endpoint built for this check.
+      const res = await fetch('/api/auth/whoami', {
+        headers: { Authorization: `Bearer ${token.trim()}` },
+      });
+      // 401/403 = the token itself was rejected; anything else (429 limiter,
+      // 5xx) says nothing about the token — don't blame it.
+      setTestState(res.ok ? 'ok' : res.status === 401 || res.status === 403 ? 'fail' : 'error');
+    } catch {
+      setTestState('error');
+    }
+  };
+
+  return (
+    <div className="card settings-card">
+      <h2 className="settings-section-title">{t('settings.aiConnect.title', 'Connect your AI')}</h2>
+      <p className="settings-hint">
+        {t('settings.aiConnect.hint',
+          'Talk to your cellar from Claude Desktop, Claude Code, or any MCP-capable assistant: ask what to open tonight, where a bottle is stored, or what your collection is worth. Connections are read-only and use a personal token you can revoke at any time.')}
+      </p>
+      <p className="settings-hint">
+        {t('settings.aiConnect.step1',
+          'Step 1 — create an API token with the "read" scope in the API tokens section above, then paste it here to fill in the configs (the token is only kept on this page):')}
+      </p>
+      <div className="form-group ai-connect-token-row">
+        <input
+          className="input"
+          type="password"
+          value={token}
+          onChange={(e) => { setToken(e.target.value); setTestState(null); }}
+          placeholder={t('settings.aiConnect.tokenPlaceholder', 'cel_… (paste your token, optional)')}
+          autoComplete="new-password"
+        />
+        <button
+          type="button"
+          className="btn btn-secondary"
+          onClick={handleTest}
+          disabled={!token.trim() || testState === 'testing'}
+        >
+          {testState === 'testing'
+            ? t('settings.aiConnect.testing', 'Testing…')
+            : t('settings.aiConnect.testBtn', 'Test connection')}
+        </button>
+      </div>
+      {testState === 'ok' && (
+        <p className="settings-saved">{t('settings.aiConnect.testOk', 'Connected — the token works.')}</p>
+      )}
+      {testState === 'fail' && (
+        <div className="alert alert-error">
+          {t('settings.aiConnect.testFail', 'That token was rejected. Check it was copied completely and has the "read" scope, and that it has not been revoked.')}
+        </div>
+      )}
+      {testState === 'error' && (
+        <div className="alert alert-error">
+          {t('settings.aiConnect.testError', 'Could not verify right now (server busy or unreachable) — this says nothing about your token. Try again in a moment.')}
+        </div>
+      )}
+
+      <Snippet
+        label={t('settings.aiConnect.claudeDesktopTitle', 'Claude Desktop (claude_desktop_config.json)')}
+        text={snippets.desktop}
+      />
+      <Snippet
+        label={t('settings.aiConnect.claudeCodeTitle', 'Claude Code (terminal)')}
+        text={snippets.code}
+      />
+      <Snippet
+        label={t('settings.aiConnect.genericTitle', 'Any MCP client (Streamable HTTP)')}
+        text={snippets.generic}
+      />
+
+      <p className="settings-hint ai-connect-footnote">
+        {t('settings.aiConnect.securityNote',
+          'Your AI sees only your own cellar data. Revoking the token in the API tokens section cuts the connection off instantly.')}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/AiConnectSection.test.js
+++ b/frontend/src/components/AiConnectSection.test.js
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AiConnectSection from './AiConnectSection';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Components pass English fallbacks inline — return those so assertions
+    // read like the real UI.
+    t: (key, fallback) => (typeof fallback === 'string' ? fallback : key),
+  }),
+}));
+
+const snippetTexts = (container) =>
+  [...container.querySelectorAll('.ai-connect-snippet')].map((el) => el.textContent);
+
+beforeEach(() => {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete window.navigator.clipboard;
+});
+
+describe('AiConnectSection', () => {
+  test('renders all three configs with a placeholder token and, off-cellarion.app, a CELLARION_URL override', () => {
+    const { container } = render(<AiConnectSection />);
+    expect(screen.getByRole('heading', { name: 'Connect your AI' })).toBeInTheDocument();
+    const texts = snippetTexts(container);
+    expect(texts).toHaveLength(3);
+    for (const t of texts) expect(t).toContain('cel_YOUR_TOKEN_HERE');
+    // jsdom origin is http://localhost:3000 → self-hosted → URL override present
+    expect(texts[0]).toContain('CELLARION_URL');
+    expect(texts[1]).toContain('/api/mcp');
+  });
+
+  test('pasting a token fills it into every snippet (and never leaves the page)', () => {
+    const { container } = render(<AiConnectSection />);
+    fireEvent.change(screen.getByPlaceholderText(/paste your token/i), {
+      target: { value: 'cel_abc123' },
+    });
+    for (const t of snippetTexts(container)) expect(t).toContain('cel_abc123');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('test connection sends the PASTED token to /api/auth/whoami and reports success', async () => {
+    global.fetch.mockResolvedValue({ ok: true });
+    render(<AiConnectSection />);
+    const btn = screen.getByRole('button', { name: 'Test connection' });
+    expect(btn).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText(/paste your token/i), { target: { value: ' cel_abc123 ' } });
+    fireEvent.click(btn);
+    expect(global.fetch).toHaveBeenCalledWith('/api/auth/whoami', {
+      headers: { Authorization: 'Bearer cel_abc123' },
+    });
+    expect(await screen.findByText(/Connected — the token works/)).toBeInTheDocument();
+  });
+
+  test('a rejected token shows the failure alert', async () => {
+    global.fetch.mockResolvedValue({ ok: false, status: 401 });
+    render(<AiConnectSection />);
+    fireEvent.change(screen.getByPlaceholderText(/paste your token/i), { target: { value: 'cel_bad' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Test connection' }));
+    expect(await screen.findByText(/That token was rejected/)).toBeInTheDocument();
+  });
+
+  test('copy button writes the exact snippet to the clipboard and flips its label', async () => {
+    const { container } = render(<AiConnectSection />);
+    const firstSnippet = snippetTexts(container)[0];
+    fireEvent.click(screen.getAllByRole('button', { name: 'Copy' })[0]);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(firstSnippet);
+    expect(await screen.findByText('Copied!')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -238,6 +238,23 @@
       "errorWrongPassword": "Your password is incorrect.",
       "errorRateLimited": "Too many attempts. Please wait a few minutes and try again."
     },
+    "aiConnect": {
+      "title": "Connect your AI",
+      "hint": "Talk to your cellar from Claude Desktop, Claude Code, or any MCP-capable assistant: ask what to open tonight, where a bottle is stored, or what your collection is worth. Connections are read-only and use a personal token you can revoke at any time.",
+      "step1": "Step 1 — create an API token with the \"read\" scope in the API tokens section above, then paste it here to fill in the configs (the token is only kept on this page):",
+      "tokenPlaceholder": "cel_… (paste your token, optional)",
+      "testBtn": "Test connection",
+      "testing": "Testing…",
+      "testOk": "Connected — the token works.",
+      "testFail": "That token was rejected. Check it was copied completely and has the \"read\" scope, and that it has not been revoked.",
+      "claudeDesktopTitle": "Claude Desktop (claude_desktop_config.json)",
+      "claudeCodeTitle": "Claude Code (terminal)",
+      "genericTitle": "Any MCP client (Streamable HTTP)",
+      "copy": "Copy",
+      "copied": "Copied!",
+      "securityNote": "Your AI sees only your own cellar data. Revoking the token in the API tokens section cuts the connection off instantly.",
+      "testError": "Could not verify right now (server busy or unreachable) — this says nothing about your token. Try again in a moment."
+    },
     "climateDevices": {
       "title": "Climate devices",
       "hint": "Sensor devices (like an ESP32 with temperature and humidity probes) that post readings into your cellars. Creating a device mints its own scoped access token — shown once — that can only post readings, nothing else. Firmware template and API details: docs/climate-monitoring.md in the repository.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -238,6 +238,23 @@
       "errorWrongPassword": "Fel lösenord.",
       "errorRateLimited": "För många försök. Vänta några minuter och försök igen."
     },
+    "aiConnect": {
+      "title": "Anslut din AI",
+      "hint": "Prata med din källare från Claude Desktop, Claude Code eller vilken MCP-kompatibel assistent som helst: fråga vad du ska öppna ikväll, var en flaska står eller vad samlingen är värd. Anslutningen är skrivskyddad och använder en personlig token som du kan återkalla när som helst.",
+      "step1": "Steg 1 — skapa en API-token med behörigheten \"read\" i avsnittet API-tokens ovan och klistra in den här så fylls konfigurationerna i (din token stannar på den här sidan):",
+      "tokenPlaceholder": "cel_… (klistra in din token, valfritt)",
+      "testBtn": "Testa anslutningen",
+      "testing": "Testar…",
+      "testOk": "Ansluten — din token fungerar.",
+      "testFail": "Din token avvisades. Kontrollera att hela värdet kopierades, att den har behörigheten \"read\" och att den inte har återkallats.",
+      "claudeDesktopTitle": "Claude Desktop (claude_desktop_config.json)",
+      "claudeCodeTitle": "Claude Code (terminal)",
+      "genericTitle": "Valfri MCP-klient (Streamable HTTP)",
+      "copy": "Kopiera",
+      "copied": "Kopierat!",
+      "securityNote": "Din AI ser bara dina egna källardata. Återkallar du din token i avsnittet API-tokens bryts anslutningen omedelbart.",
+      "testError": "Det gick inte att verifiera just nu (servern är upptagen eller onåbar) — det säger ingenting om din token. Försök igen om en stund."
+    },
     "climateDevices": {
       "title": "Klimatenheter",
       "hint": "Sensorenheter (t.ex. en ESP32 med temperatur- och fuktgivare) som skickar mätvärden till dina källare. När du lägger till en enhet skapas en egen behörighetsstyrd åtkomsttoken — den visas bara en gång — som bara kan skicka mätvärden, inget annat. Firmware-mall och API-detaljer: docs/climate-monitoring.md i kodförrådet.",

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -343,3 +343,38 @@
   margin-bottom: 0.35rem;
   font-weight: normal;
 }
+
+/* ── Connect your AI section ── */
+.ai-connect-token-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.ai-connect-token-row .input {
+  flex: 1;
+}
+.ai-connect-snippet-block {
+  margin-top: 1rem;
+}
+.ai-connect-snippet-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+.ai-connect-snippet-head h3 {
+  font-size: 0.95rem;
+  margin: 0;
+}
+.ai-connect-snippet {
+  display: block;
+  white-space: pre;
+  overflow-x: auto;
+  word-break: normal;
+  user-select: all;
+  margin: 0;
+}
+.ai-connect-footnote {
+  margin-top: 1rem;
+}

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -11,6 +11,7 @@ import { SCALE_META, VALID_SCALES } from '../utils/ratingUtils';
 import { isPushSupported, getPushPermissionState, subscribeToPush, unsubscribeFromPush, getCurrentEndpoint, getDeviceStatus, sendTestPush } from '../utils/pushSubscription';
 import { downloadBlobObject } from '../utils/downloadBlob';
 import ApiTokensSection from '../components/ApiTokensSection';
+import AiConnectSection from '../components/AiConnectSection';
 import ClimateDevicesSection from '../components/ClimateDevicesSection';
 import { journalPromptOptedOut, setJournalPromptOptOut } from '../components/JournalPrompt';
 import './Settings.css';
@@ -479,6 +480,9 @@ function Settings() {
 
       {/* ── API tokens card (hidden for demo — token creation is blocked) ── */}
       {!user?.isDemo && <ApiTokensSection />}
+
+      {/* ── Connect your AI card (needs a token → hidden for demo too) ── */}
+      {!user?.isDemo && <AiConnectSection />}
 
       {/* ── Climate devices card (hidden for demo) ── */}
       {!user?.isDemo && <ClimateDevicesSection />}


### PR DESCRIPTION
## What this is

The user-facing on-ramp for the MCP: a new Settings card (right after **API tokens**, hidden for demo accounts like its siblings) with everything a user needs to connect Claude Desktop / Claude Code / any MCP client:

- **Paste-your-token flow** — the token lives only in component state, is never persisted, and is sent nowhere except the same-origin `GET /api/auth/whoami` **Test connection** check (the endpoint built for exactly this). 401/403 → "token rejected"; 429/5xx → a separate "couldn't verify — says nothing about your token" message.
- **Three live-filling configs** with copy buttons: Claude Desktop (`npx cellarion-mcp` JSON — `CELLARION_URL` auto-added on self-hosted origins), Claude Code (`claude mcp add --transport http …`), and a generic Streamable-HTTP block.
- Security copy: read-only scope, instant revocation.

## ⚠️ sv strings need review
`settings.aiConnect.*` added to **both** locales key-for-key (verified identical sets) — **the Swedish translations are machine-authored** and need Johan's eyes before this ships in a release.

## Verification
- 5 new RTL tests (render + live-fill, pasted-token-only whoami call, rejected-token alert, clipboard copy, stubbed globals restored per test).
- **Full frontend suite: 30 files / 652 tests green.**
- Adversarial audit: **no High/Med** — token cannot leak (state-only, React-escaped snippets, no logging), whoami is Bearer-only (no CSRF surface), en/sv key parity verified programmatically, CSS class names collision-free. Lows fixed in this diff.

## Scope
Frontend-only (component + 2-line Settings integration + CSS + locales). No new endpoints. **docker-compose impact: none.**

Pairs with #709 (`cellarion-mcp` bridge — the Claude Desktop config this page renders) and completes the Phase-1 UX loop: mint token → connect → talk to your cellar.