### PR TITLE
feat(mcp): Phase 2a — consume/restore/undo tools + the write-safety stack

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -151,9 +151,11 @@ const isStripeWebhook = (req) => req.originalUrl.split('?')[0] === '/api/stripe/
 //
 // A JSON-RPC body may be a *batch* (array) of calls, so one HTTP request can
 // fan out to many tool invocations — apiLimiter counts requests, not calls.
-// That amplification is capped by the per-request tool-call budget in
-// mcp/server.js (MAX_CALLS_PER_REQUEST). Revisit with a dedicated MCP limiter
-// before write/AI tools ship (they add cost beyond DB reads).
+// That amplification is capped in mcp/server.js at TWO layers: the per-request
+// tool-call budget (MAX_CALLS_PER_REQUEST) and, for MUTATING tools, a per-user
+// budget sharing the SAME admin-tunable number as this writeLimiter — so an
+// agent looping consumes hits exactly the wall a looping REST client would.
+// Revisit again before AI-spending tools ship (enrichment adds cost beyond DB).
 const isMcp = (req) => {
   const p = req.originalUrl.split('?')[0];
   return p === '/api/mcp' || p === '/api/mcp/';

--- a/backend/src/mcp/consumeTools.test.js
+++ b/backend/src/mcp/consumeTools.test.js
@@ -1,0 +1,255 @@
+/**
+ * MCP consume tools — write-safety invariants.
+ *
+ * Pins the layers that make the first mutating tools safe: scope gating
+ * (read-only tokens never see them), access re-verification before any
+ * mutation, the already-consumed conflict guard, idempotency replay (the
+ * original result comes back, the op does NOT run again), the undo ledger,
+ * and token attribution (id only, never the credential).
+ */
+
+const chain = (result) => {
+  const c = {};
+  for (const m of ['populate', 'sort', 'skip', 'limit', 'select']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(() => Promise.resolve(result));
+  c.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return c;
+};
+
+jest.mock('../models/Cellar', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/Bottle', () => ({
+  find: jest.fn(), findById: jest.fn(), aggregate: jest.fn(), countDocuments: jest.fn(),
+}));
+jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn() }));
+jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
+jest.mock('../services/search', () => ({
+  getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn(),
+}));
+jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), buildEmptyStats: jest.fn() }));
+jest.mock('../services/vectorStore', () => ({ getPoints: jest.fn(), searchSimilar: jest.fn() }));
+jest.mock('../config/aiConfig', () => ({ get: jest.fn(() => ({ vectorIndex: 'v1' })) }));
+jest.mock('../services/bottleOps', () => ({
+  consumeBottle: jest.fn(),
+  restoreBottle: jest.fn(),
+  removeFromRacks: jest.fn(),
+  RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,
+}));
+
+const mongoose = require('mongoose');
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const McpActionLog = require('../models/McpActionLog');
+const bottleOps = require('../services/bottleOps');
+const { allTools, toolsForScopes } = require('./registry');
+require('./tools');
+
+const oid = (c) => c.repeat(24);
+const ME = oid('a');
+const STRANGER = oid('b');
+const REQ = { user: { id: ME, roles: ['user'] }, headers: {}, apiToken: { id: 't1', scopes: ['consume'] } };
+const CTX = { user: { id: ME }, scopes: ['consume'], req: REQ };
+
+const tool = (name) => allTools().find((t) => t.name === name);
+const parse = (res) => JSON.parse(res.content[0].text);
+
+const ownBottle = (over = {}) => {
+  Bottle.findById.mockReturnValue(chain({
+    _id: oid('d'), cellar: oid('c'), status: 'active', vintage: '2015', ...over,
+  }));
+  Cellar.findById.mockReturnValue(chain({ _id: oid('c'), user: ME, members: [], deletedAt: null }));
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  McpActionLog.findOne.mockReturnValue(chain(null));
+  McpActionLog.create.mockResolvedValue({});
+});
+
+describe('scope gating', () => {
+  test('consume tools exist, carry the consume scope + honest annotations', () => {
+    for (const name of ['consume_bottle', 'restore_bottle', 'undo_last']) {
+      expect(tool(name).scope).toBe('consume');
+      expect(tool(name).annotations.readOnlyHint).toBe(false);
+    }
+    expect(tool('consume_bottle').annotations.destructiveHint).toBe(true);
+    expect(tool('consume_bottle').annotations.idempotentHint).toBe(false);
+    expect(tool('restore_bottle').annotations.idempotentHint).toBe(true);
+  });
+
+  test('a read-only token NEVER sees the consume tools; a consume token sees them but not read tools', () => {
+    const readNames = toolsForScopes(['read']).map((t) => t.name);
+    expect(readNames).not.toContain('consume_bottle');
+    expect(readNames).not.toContain('undo_last');
+    const consumeNames = toolsForScopes(['consume']).map((t) => t.name);
+    expect(consumeNames).toEqual(expect.arrayContaining(['consume_bottle', 'restore_bottle', 'undo_last', 'get_source_info']));
+    expect(consumeNames).not.toContain('search_bottles');
+  });
+});
+
+describe('consume_bottle', () => {
+  test('foreign bottle → not_found, and the mutation service is never touched', async () => {
+    Bottle.findById.mockReturnValue(chain({ _id: oid('d'), cellar: oid('c') }));
+    Cellar.findById.mockReturnValue(chain({ _id: oid('c'), user: STRANGER, members: [], deletedAt: null }));
+    const res = await tool('consume_bottle').handler({ bottle_id: oid('d') }, CTX);
+    expect(parse(res).error.code).toBe('not_found');
+    expect(bottleOps.consumeBottle).not.toHaveBeenCalled();
+  });
+
+  test('already-consumed bottle → conflict (a looping agent cannot double-log)', async () => {
+    ownBottle({ status: 'drank', consumedReason: 'drank', consumedAt: new Date('2026-07-01') });
+    const res = await tool('consume_bottle').handler({ bottle_id: oid('d') }, CTX);
+    expect(parse(res).error.code).toBe('conflict');
+    expect(bottleOps.consumeBottle).not.toHaveBeenCalled();
+  });
+
+  test('success: shared service called with ctx.req; ledger row carries token id + reason, never the token value', async () => {
+    ownBottle();
+    bottleOps.consumeBottle.mockImplementation(async (bottle, opts) => {
+      bottle.status = opts.reason; bottle.consumedAt = new Date();
+      return { bottle };
+    });
+    const res = await tool('consume_bottle').handler(
+      { bottle_id: oid('d'), reason: 'gifted', idempotency_key: 'k1' }, CTX);
+    const body = parse(res);
+    expect(body.data.status).toBe('gifted');
+    expect(body.data.undo).toMatch(/restore_bottle/);
+    expect(bottleOps.consumeBottle.mock.calls[0][2]).toBe(REQ);
+    const row = McpActionLog.create.mock.calls[0][0];
+    expect(row).toMatchObject({
+      user: ME, tokenId: 't1', tool: 'consume_bottle', action: 'consume', idempotencyKey: 'k1',
+    });
+    expect(JSON.stringify(row)).not.toMatch(/cel_/);
+  });
+
+  test('idempotent replay: a seen key returns the ORIGINAL envelope without re-consuming', async () => {
+    McpActionLog.findOne.mockReturnValue(chain({ result: { summary: 'Consumed once', data: { bottle_id: oid('d') } } }));
+    const res = await tool('consume_bottle').handler({ bottle_id: oid('d'), idempotency_key: 'k1' }, CTX);
+    expect(parse(res).summary).toBe('Consumed once');
+    expect(bottleOps.consumeBottle).not.toHaveBeenCalled();
+    expect(McpActionLog.create).not.toHaveBeenCalled();
+  });
+
+  test('service validation faults surface as invalid_input', async () => {
+    ownBottle();
+    bottleOps.consumeBottle.mockResolvedValue({ error: { status: 400, message: 'Invalid reason' } });
+    const res = await tool('consume_bottle').handler({ bottle_id: oid('d'), reason: 'drank' }, CTX);
+    expect(parse(res).error).toEqual({ code: 'invalid_input', message: 'Invalid reason' });
+  });
+});
+
+describe('restore_bottle', () => {
+  test('snapshots the consumed fields into prev BEFORE the restore clears them', async () => {
+    ownBottle({ status: 'drank', consumedReason: 'drank', consumedNote: 'great', consumedRating: 4, consumedRatingScale: '5', consumedAt: new Date() });
+    bottleOps.restoreBottle.mockImplementation(async (bottle) => {
+      bottle.status = 'active'; bottle.consumedReason = undefined;
+      return { bottle, from: 'drank' };
+    });
+    await tool('restore_bottle').handler({ bottle_id: oid('d') }, CTX);
+    const row = McpActionLog.create.mock.calls[0][0];
+    expect(row.action).toBe('restore');
+    expect(row.prev).toEqual({ reason: 'drank', note: 'great', rating: 4, ratingScale: '5' });
+  });
+
+  test('expired window surfaces as conflict', async () => {
+    ownBottle({ status: 'drank' });
+    bottleOps.restoreBottle.mockResolvedValue({ error: { status: 400, message: 'too old', code: 'restore_window_expired' } });
+    const res = await tool('restore_bottle').handler({ bottle_id: oid('d') }, CTX);
+    expect(parse(res).error.code).toBe('conflict');
+  });
+});
+
+describe('undo_last', () => {
+  // REGRESSION (audit HIGH, second occurrence of the class): McpActionLog.bottle
+  // is an ObjectId INSTANCE on a hydrated doc — a string-typed mock here masked
+  // resolveBottleAccess rejecting every real undo. Always mock the ref as a
+  // real ObjectId.
+  const bottleRef = () => new mongoose.Types.ObjectId(oid('d'));
+
+  test('nothing to undo → not_found', async () => {
+    McpActionLog.findOne.mockReturnValue(chain(null));
+    const res = await tool('undo_last').handler({}, CTX);
+    expect(parse(res).error.code).toBe('not_found');
+  });
+
+  test('query is per-user, un-reversed, and recency-bounded to the restore window', async () => {
+    McpActionLog.findOne.mockReturnValue(chain(null));
+    await tool('undo_last').handler({}, CTX);
+    const q = McpActionLog.findOne.mock.calls[0][0];
+    expect(q.user).toBe(ME);
+    expect(q.reversed).toBe(false);
+    expect(q.createdAt.$gte).toBeInstanceOf(Date);
+    expect(Date.now() - q.createdAt.$gte.getTime()).toBeLessThanOrEqual(2 * 24 * 3600 * 1000 + 5000);
+  });
+
+  test('undoes a consume by restoring (ObjectId ref!), snapshots prev for the reverse row, marks reversed', async () => {
+    const entry = { _id: 'log1', action: 'consume', bottle: bottleRef(), reversed: false, save: jest.fn() };
+    McpActionLog.findOne.mockReturnValue(chain(entry));
+    ownBottle({ status: 'drank', consumedReason: 'gifted', consumedNote: 'oops', consumedRating: 4, consumedRatingScale: '5' });
+    bottleOps.restoreBottle.mockImplementation(async (bottle) => { bottle.status = 'active'; return { bottle, from: 'gifted' }; });
+    const res = await tool('undo_last').handler({}, CTX);
+    expect(parse(res).data.undone).toBe('consume_bottle');
+    expect(entry.reversed).toBe(true);
+    expect(entry.save).toHaveBeenCalled();
+    // The undo's own ledger row must carry the pre-restore snapshot, so a
+    // second undo re-consumes with the ORIGINAL values, not defaults.
+    const row = McpActionLog.create.mock.calls[0][0];
+    expect(row.action).toBe('restore');
+    expect(row.prev).toEqual({ reason: 'gifted', note: 'oops', rating: 4, ratingScale: '5' });
+  });
+
+  test('undoes a restore by re-consuming with the ORIGINAL prev fields', async () => {
+    const entry = {
+      _id: 'log2', action: 'restore', bottle: bottleRef(), reversed: false, save: jest.fn(),
+      prev: { reason: 'gifted', note: 'to Anna', rating: 4, ratingScale: '5' },
+    };
+    McpActionLog.findOne.mockReturnValue(chain(entry));
+    ownBottle({ status: 'active' });
+    bottleOps.consumeBottle.mockImplementation(async (bottle, opts) => { bottle.status = opts.reason; return { bottle }; });
+    const res = await tool('undo_last').handler({}, CTX);
+    expect(parse(res).data.undone).toBe('restore_bottle');
+    expect(bottleOps.consumeBottle.mock.calls[0][1]).toEqual({ reason: 'gifted', note: 'to Anna', rating: 4, ratingScale: '5' });
+    expect(entry.reversed).toBe(true);
+  });
+
+  test('refuses to undo a restore when the bottle was consumed again since (state moved on)', async () => {
+    const entry = { _id: 'log3', action: 'restore', bottle: bottleRef(), reversed: false, save: jest.fn(), prev: {} };
+    McpActionLog.findOne.mockReturnValue(chain(entry));
+    ownBottle({ status: 'drank' }); // re-consumed via the UI since the restore
+    const res = await tool('undo_last').handler({}, CTX);
+    expect(parse(res).error.code).toBe('conflict');
+    expect(bottleOps.consumeBottle).not.toHaveBeenCalled();
+    expect(entry.reversed).toBe(false); // nothing changed → row stays undoable-looking but untouched
+  });
+});
+
+describe('mutation rate budget (write-limiter parity at the tool layer)', () => {
+  const { budgetedHandler, takeMutationSlot } = require('./server');
+  const mkTool = (readOnly) => ({
+    name: 'x', annotations: { readOnlyHint: readOnly }, handler: async () => ({ content: [] }),
+  });
+
+  test('mutating tools share the admin-tunable write cap per user; reads are exempt', async () => {
+    const max = require('../config/rateLimits').get().write.max;
+    const userId = 'u-budget-test';
+    for (let i = 0; i < max; i++) expect(takeMutationSlot(userId)).toBe(true);
+    expect(takeMutationSlot(userId)).toBe(false); // window exhausted
+
+    const ctx = { user: { id: userId }, scopes: ['consume'] };
+    const blocked = await budgetedHandler(mkTool(false), ctx, { calls: 0 })({});
+    expect(blocked.isError).toBe(true);
+    expect(JSON.parse(blocked.content[0].text).error.code).toBe('rate_limited');
+
+    // Read-only tools never touch the mutation budget.
+    const readRes = await budgetedHandler(mkTool(true), ctx, { calls: 0 })({});
+    expect(readRes.isError).toBeUndefined();
+
+    // Other users are unaffected (per-user windows).
+    expect(takeMutationSlot('someone-else')).toBe(true);
+  });
+});

--- a/backend/src/mcp/instructions.js
+++ b/backend/src/mcp/instructions.js
@@ -9,7 +9,7 @@ const INSTRUCTIONS = [
   '',
   'How to work with it:',
   "- Every tool acts only on the authenticated user's data. Reads are free — prefer them, and prefer filtered searches over fetching everything.",
-  '- Tool families: cellars (list_cellars, get_cellar) → bottles (search_bottles, get_bottle, list_history) → racks (list_racks, get_rack) → portfolio (cellar_stats) → shared registry (search_registry, get_wine, find_similar_wines) → personal (list_wishlist, list_journal).',
+  '- Tool families: cellars (list_cellars, get_cellar) → bottles (search_bottles, get_bottle, list_history) → racks (list_racks, get_rack) → portfolio (cellar_stats) → shared registry (search_registry, get_wine, find_similar_wines) → personal (list_wishlist, list_journal) → consuming (consume_bottle, restore_bottle, undo_last — only when the connection has the consume scope).',
   '- Resources you can attach as ambient context: cellar://snapshot (collection overview), cellar://stats (portfolio doc), cellar://bottle/{id} (one bottle\'s dossier), cellarion://about.',
   '- find_similar_wines = "more like this" by taste/style vectors — ideal for purchase ideas seeded from a wine the user loves.',
   '- Typical flow: list_cellars once to learn ids, then search_bottles / get_bottle for specifics. search_bottles = what the user OWNS; search_registry = ALL wines Cellarion knows.',
@@ -17,7 +17,8 @@ const INSTRUCTIONS = [
   '- Cite the specific wine, vintage, and rack position in your answers so the user can verify what you did.',
   '- IDs (cellar_id, bottle_id, rack_id, wine_id) come from list/search tools — never invent one.',
   '- Errors return { error: { code, message } }: not_found usually means a wrong/foreign id (re-list to recover); invalid_input explains exactly what to fix.',
-  '- This connection is read-only for now: you cannot add, modify or consume bottles yet. If the user asks for a change, do the reasoning, then point them to the web app for the action itself.',
+  '- Consuming changes the cellar: ALWAYS confirm with the user first, naming the exact wine, vintage and reason ("mark the 2015 Barolo as drank?"). Every consume is reversible for 2 days (restore_bottle / undo_last) — say so when you log one. Pass an idempotency_key if you retry.',
+  '- You cannot yet ADD or edit bottles, racks or cellars over this connection. For those, do the reasoning, then point the user to the web app.',
   '- Call get_source_info if the user asks what Cellarion is, which version this instance runs, whether it is open source, or where to find or contribute to the code.',
 ].join('\n');
 

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -34,26 +34,48 @@ function loadSdk() {
 // amplification: generous for a legitimate agent turn, far below abuse scale.
 const MAX_CALLS_PER_REQUEST = 20;
 
-// Wrap a tool handler with the per-request call budget. `state` is shared by
-// all tools of ONE request's server instance (fresh per request in stateless
-// mode). Exported for unit testing — jest cannot load the ESM SDK, so
-// buildServer itself is covered by the smoke test instead.
+const rateLimited = (message) => ({
+  isError: true,
+  content: [{ type: 'text', text: JSON.stringify({ error: { code: 'rate_limited', message } }) }],
+});
+
+// MUTATING tools additionally ride the same per-user budget as REST writes
+// (the admin-tunable write limiter number, per 15 minutes). /api/mcp is exempt
+// from the HTTP writeLimiter because one POST can't be classified — so the
+// classification happens HERE, per tool call, where readOnlyHint tells us the
+// truth. An agent looping consumes hits exactly the wall a looping REST client
+// would. In-memory like express-rate-limit; cleared wholesale at the cap.
+const WRITE_WINDOW_MS = 15 * 60 * 1000;
+const mutationWindows = new Map(); // userId -> { start, count }
+const MUTATION_WINDOWS_MAX = 5000;
+
+function takeMutationSlot(userId) {
+  const max = require('../config/rateLimits').get().write.max;
+  const now = Date.now();
+  let w = mutationWindows.get(userId);
+  if (!w || now - w.start >= WRITE_WINDOW_MS) {
+    if (mutationWindows.size >= MUTATION_WINDOWS_MAX) mutationWindows.clear();
+    w = { start: now, count: 0 };
+    mutationWindows.set(userId, w);
+  }
+  if (w.count >= max) return false;
+  w.count += 1;
+  return true;
+}
+
+// Wrap a tool handler with the per-request call budget (+ the per-user
+// mutation budget for non-read-only tools). `state` is shared by all tools of
+// ONE request's server instance (fresh per request in stateless mode).
+// Exported for unit testing — jest cannot load the ESM SDK, so buildServer
+// itself is covered by the smoke test instead.
 function budgetedHandler(tool, ctx, state) {
   return (args) => {
     state.calls += 1;
     if (state.calls > MAX_CALLS_PER_REQUEST) {
-      return {
-        isError: true,
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            error: {
-              code: 'rate_limited',
-              message: `Too many tool calls in one request (max ${MAX_CALLS_PER_REQUEST}). Send fewer calls per batch and paginate instead.`,
-            },
-          }),
-        }],
-      };
+      return rateLimited(`Too many tool calls in one request (max ${MAX_CALLS_PER_REQUEST}). Send fewer calls per batch and paginate instead.`);
+    }
+    if (tool.annotations?.readOnlyHint === false && !takeMutationSlot(String(ctx.user.id))) {
+      return rateLimited('Too many cellar changes in a short time — wait a few minutes before mutating again. Reads still work.');
     }
     return tool.handler(args || {}, ctx);
   };
@@ -139,4 +161,5 @@ async function handleMcpRequest(req, res, ctx) {
 module.exports = {
   handleMcpRequest,
   budgetedHandler, budgetedResourceHandler, MAX_CALLS_PER_REQUEST,
+  takeMutationSlot, WRITE_WINDOW_MS,
 };

--- a/backend/src/mcp/toolUtil.js
+++ b/backend/src/mcp/toolUtil.js
@@ -65,8 +65,13 @@ async function resolveCellarAccess(userId, cellarId, minRole = 'viewer') {
  * or null (missing bottle, deleted cellar, or no access — all not_found).
  */
 async function resolveBottleAccess(userId, bottleId, minRole = 'viewer') {
-  if (!isValidId(bottleId)) return null;
-  const bottle = await Bottle.findById(bottleId);
+  // Same coercion as resolveCellarAccess above: callers pass client strings
+  // AND document refs (ObjectId instances, e.g. McpActionLog.bottle in
+  // undo_last). String() of an ObjectId is its 24-hex id; a smuggled object
+  // stringifies to something isValidId rejects — still fail-closed.
+  const id = String(bottleId);
+  if (!isValidId(id)) return null;
+  const bottle = await Bottle.findById(id);
   if (!bottle) return null;
   const access = await resolveCellarAccess(userId, bottle.cellar, minRole);
   if (!access) return null;

--- a/backend/src/mcp/tools/consume.js
+++ b/backend/src/mcp/tools/consume.js
@@ -1,0 +1,246 @@
+// The first MUTATING MCP tools (plan §5.7 write-safety ships WITH them):
+// consume_bottle / restore_bottle / undo_last, scope `consume` — the same
+// scope the Home Assistant integration already uses for its consume button.
+//
+// Write-safety layers active here:
+//  - L1 structural: only `consume`-scoped callers ever see these tools; the
+//    worst outcome is a reversible soft status change (no deletes exist).
+//  - L2 client confirmation: destructiveHint + concrete summaries let clients
+//    prompt "consume the 2015 Barolo?" before executing.
+//  - L3 server checks: editor-level access re-verified per call, an already-
+//    consumed bottle is a conflict (a looping agent can't double-log), and an
+//    optional idempotency_key replays the ORIGINAL result instead of re-acting.
+//  - L4 reversibility + ledger: every action lands in McpActionLog (undo_last,
+//    the future activity timeline) and in the normal audit log (which also
+//    emits the stats_changed SSE nudge the HA integration listens to).
+//
+// bottleOps is the SAME implementation the REST routes run — validation, rack
+// freeing, re-indexing, audit and restock checks cannot drift between surfaces.
+const { z } = require('zod');
+const Bottle = require('../../models/Bottle');
+const McpActionLog = require('../../models/McpActionLog');
+const { CONSUMED_STATUSES } = require('../../config/constants');
+const { registerTool } = require('../registry');
+const { consumeBottle, restoreBottle, RESTORE_WINDOW_MS } = require('../../services/bottleOps');
+const { ok, fail, objectId, MSG_BOTTLE_NOT_FOUND, resolveBottleAccess } = require('../toolUtil');
+
+const RESTORE_WINDOW_DAYS = Math.round(RESTORE_WINDOW_MS / 86400000);
+
+function bottleLabel(bottle) {
+  return `bottle ${bottle._id} (vintage ${bottle.vintage})`;
+}
+
+/** Persist the action ledger row. Never throws (the action itself succeeded). */
+async function logAction(ctx, entry) {
+  try {
+    return await McpActionLog.create({
+      user: ctx.user.id,
+      tokenId: ctx.req?.apiToken?.id || null,
+      ...entry,
+    });
+  } catch (err) {
+    // Duplicate idempotencyKey race: the concurrent twin already recorded it.
+    if (err?.code !== 11000) console.error('[mcp] action log failed:', err.message);
+    return null;
+  }
+}
+
+/**
+ * Idempotent replay: return the stored envelope for a seen key, else null.
+ * Reversed actions don't replay — if the action was undone since, a retry
+ * should go through the normal path (and re-assert) rather than reporting a
+ * stale success for a state that no longer holds.
+ */
+async function replay(ctx, idempotencyKey) {
+  if (!idempotencyKey) return null;
+  const seen = await McpActionLog.findOne({ user: ctx.user.id, idempotencyKey, reversed: false }).lean();
+  return seen?.result ? { content: [{ type: 'text', text: JSON.stringify(seen.result) }] } : null;
+}
+
+registerTool({
+  name: 'consume_bottle',
+  title: 'Consume a bottle (drank / gifted / sold)',
+  description:
+    'Marks one bottle as consumed: drank (default), gifted, sold or other, with an optional note and rating. ' +
+    'Frees its rack slot. ALWAYS confirm with the user first, naming the exact wine and vintage — this changes their ' +
+    `cellar. Reversible for ${RESTORE_WINDOW_DAYS} days via restore_bottle / undo_last. ` +
+    'Pass an idempotency_key when retrying so the action can never run twice.',
+  scope: 'consume',
+  annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
+  inputSchema: {
+    bottle_id: objectId.describe('Bottle id from search_bottles'),
+    reason: z.enum(CONSUMED_STATUSES).default('drank'),
+    note: z.string().max(1000).optional().describe('Tasting note / occasion'),
+    rating: z.number().min(0).max(100).optional(),
+    rating_scale: z.enum(['5', '20', '100']).optional().describe('Scale the rating is on (required with rating)'),
+    idempotency_key: z.string().max(100).optional().describe('Unique key: a retry with the same key returns the original result'),
+  },
+  handler: async (args, ctx) => {
+    const replayed = await replay(ctx, args.idempotency_key);
+    if (replayed) return replayed;
+
+    const access = await resolveBottleAccess(ctx.user.id, args.bottle_id, 'editor');
+    if (!access) return fail('not_found', MSG_BOTTLE_NOT_FOUND);
+    const { bottle } = access;
+
+    // Guard a retrying/confused agent: consuming twice would silently
+    // overwrite the original consumption record.
+    if (CONSUMED_STATUSES.includes(bottle.status)) {
+      return fail('conflict',
+        `This bottle was already consumed (${bottle.consumedReason || bottle.status}${bottle.consumedAt ? ` on ${bottle.consumedAt.toISOString().slice(0, 10)}` : ''}). ` +
+        'Use restore_bottle first if that was a mistake, or check you have the right bottle_id.');
+    }
+
+    const result = await consumeBottle(bottle, {
+      reason: args.reason || 'drank',
+      note: args.note,
+      rating: args.rating,
+      ratingScale: args.rating_scale,
+    }, ctx.req);
+    if (result.error) return fail('invalid_input', result.error.message);
+
+    const data = {
+      bottle_id: bottle._id,
+      status: bottle.status,
+      consumed_at: bottle.consumedAt,
+      undo: `restore_bottle with this bottle_id (or undo_last) within ${RESTORE_WINDOW_DAYS} days`,
+    };
+    const envelope = { summary: `Consumed ${bottleLabel(bottle)}: ${bottle.status}`, data };
+    await logAction(ctx, {
+      tool: 'consume_bottle',
+      action: 'consume',
+      bottle: bottle._id,
+      cellar: bottle.cellar,
+      detail: { reason: bottle.status },
+      idempotencyKey: args.idempotency_key || null,
+      result: envelope,
+    });
+    return ok(envelope.summary, envelope.data);
+  },
+});
+
+registerTool({
+  name: 'restore_bottle',
+  title: 'Restore a consumed bottle',
+  description:
+    'Puts a recently-consumed bottle back into the cellar (undo an accidental consume). Only works within ' +
+    `${RESTORE_WINDOW_DAYS} days of consumption; the bottle returns UNPLACED (its old rack slot may be taken). ` +
+    'Find candidates via list_history.',
+  scope: 'consume',
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  inputSchema: { bottle_id: objectId.describe('Bottle id from list_history') },
+  handler: async (args, ctx) => {
+    const access = await resolveBottleAccess(ctx.user.id, args.bottle_id, 'editor');
+    if (!access) return fail('not_found', MSG_BOTTLE_NOT_FOUND);
+    const { bottle } = access;
+
+    // Snapshot BEFORE the restore clears the fields — undoing a restore means
+    // re-consuming with exactly these values.
+    const prev = {
+      reason: bottle.consumedReason || bottle.status,
+      note: bottle.consumedNote,
+      rating: bottle.consumedRating,
+      ratingScale: bottle.consumedRatingScale,
+    };
+    const result = await restoreBottle(bottle, ctx.req);
+    if (result.error) {
+      return fail(result.error.code === 'restore_window_expired' ? 'conflict' : 'invalid_input', result.error.message);
+    }
+
+    const envelope = {
+      summary: `Restored ${bottleLabel(bottle)} to the cellar (was ${result.from})`,
+      data: { bottle_id: bottle._id, status: 'active', was: result.from, placement: null },
+    };
+    await logAction(ctx, {
+      tool: 'restore_bottle',
+      action: 'restore',
+      bottle: bottle._id,
+      cellar: bottle.cellar,
+      detail: { from: result.from },
+      prev,
+      result: envelope,
+    });
+    return ok(envelope.summary, envelope.data);
+  },
+});
+
+registerTool({
+  name: 'undo_last',
+  title: 'Undo the last MCP cellar change on this account',
+  description:
+    'Reverses the account\'s most recent un-reversed MCP action (any MCP connection, not UI changes): an accidental ' +
+    'consume_bottle becomes a restore; an accidental restore_bottle re-consumes with the original reason/note/rating. ' +
+    `Only actions from the last ${RESTORE_WINDOW_DAYS} days are undoable, and only if the bottle hasn't been changed ` +
+    'since. Call when the user says "undo that" about a change YOU just made. Tell the user exactly what was undone.',
+  scope: 'consume',
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  inputSchema: {},
+  handler: async (_args, ctx) => {
+    // Recency bound mirrors the restore window: an action too old to reverse
+    // cleanly is also too old to be "the thing the user just did".
+    const last = await McpActionLog.findOne({
+      user: ctx.user.id,
+      reversed: false,
+      action: { $in: ['consume', 'restore'] },
+      createdAt: { $gte: new Date(Date.now() - RESTORE_WINDOW_MS) },
+    }).sort({ createdAt: -1 });
+    if (!last) return fail('not_found', 'No recent MCP action to undo — nothing has been changed through MCP in the last few days.');
+
+    const access = await resolveBottleAccess(ctx.user.id, last.bottle, 'editor');
+    if (!access) return fail('conflict', 'The bottle from the last action is no longer accessible; nothing was changed.');
+    const { bottle } = access;
+
+    let envelope;
+    let reverseEntry;
+    if (last.action === 'consume') {
+      // Snapshot BEFORE restoring, so undoing THIS undo can re-consume with
+      // the original values instead of defaults.
+      const prevSnapshot = {
+        reason: bottle.consumedReason || bottle.status,
+        note: bottle.consumedNote,
+        rating: bottle.consumedRating,
+        ratingScale: bottle.consumedRatingScale,
+      };
+      const result = await restoreBottle(bottle, ctx.req);
+      if (result.error) return fail('conflict', `Cannot undo that consume: ${result.error.message}`);
+      envelope = {
+        summary: `Undid consume — ${bottleLabel(bottle)} is back in the cellar (unplaced)`,
+        data: { undone: 'consume_bottle', bottle_id: bottle._id, status: 'active' },
+      };
+      reverseEntry = { action: 'restore', prev: prevSnapshot };
+    } else {
+      // The bottle's state may have moved on since that restore (e.g. the user
+      // re-consumed it in the web app — UI actions never enter this ledger).
+      // Re-consuming would silently overwrite the newer record: refuse.
+      if (CONSUMED_STATUSES.includes(bottle.status)) {
+        return fail('conflict',
+          'That restore cannot be undone: the bottle has been consumed again since (possibly in the web app). Nothing was changed.');
+      }
+      const prev = last.prev || {};
+      const result = await consumeBottle(bottle, {
+        reason: prev.reason || 'drank',
+        note: prev.note,
+        rating: prev.rating,
+        ratingScale: prev.ratingScale,
+      }, ctx.req);
+      if (result.error) return fail('conflict', `Cannot undo that restore: ${result.error.message}`);
+      envelope = {
+        summary: `Undid restore — ${bottleLabel(bottle)} is consumed again (${bottle.status})`,
+        data: { undone: 'restore_bottle', bottle_id: bottle._id, status: bottle.status },
+      };
+      reverseEntry = { action: 'consume', prev: null };
+    }
+
+    last.reversed = true;
+    await last.save();
+    await logAction(ctx, {
+      tool: 'undo_last',
+      ...reverseEntry,
+      bottle: bottle._id,
+      cellar: bottle.cellar,
+      detail: { undid: String(last._id) },
+      result: envelope,
+    });
+    return ok(envelope.summary, envelope.data);
+  },
+});

--- a/backend/src/mcp/tools/index.js
+++ b/backend/src/mcp/tools/index.js
@@ -13,6 +13,7 @@ require('./racks');
 require('./stats');
 require('./wines');
 require('./personal');
+require('./consume');
 require('./similar');
 
 module.exports = {};

--- a/backend/src/middleware/apiTokenAuth.js
+++ b/backend/src/middleware/apiTokenAuth.js
@@ -48,11 +48,13 @@ const SCOPE_ALLOWLIST = {
     // the caller may actually invoke is enforced *inside* by the MCP registry's
     // scope filter (a read token only ever sees read/public tools), so reaching
     // this path is safe. Anchored exact — cannot widen to any other /api/mcp/*.
-    // When consume/write MCP tools ship, add this entry under those scopes too.
     { method: 'POST', pattern: /^\/api\/mcp$/ },
   ],
   consume: [
     { method: 'POST', pattern: /^\/api\/bottles\/[a-f0-9]{24}\/consume$/ },
+    // MCP endpoint — a consume-scoped token may reach it; the registry's scope
+    // filter decides which tools it sees (consume + public, not read/write).
+    { method: 'POST', pattern: /^\/api\/mcp$/ },
   ],
   climate: [
     { method: 'POST', pattern: /^\/api\/climate\/ingest$/ },

--- a/backend/src/middleware/apiTokenAuth.test.js
+++ b/backend/src/middleware/apiTokenAuth.test.js
@@ -154,15 +154,17 @@ describe('isRequestAllowed (default-deny)', () => {
     expect(isRequestAllowed(BOTH, 'POST', '/api/climate/ingest')).toBe(false);
   });
 
-  test('POST /api/mcp is granted by read — per-tool authz lives inside the MCP registry', () => {
+  test('POST /api/mcp is granted by read AND consume — per-tool authz lives inside the MCP registry', () => {
     expect(isRequestAllowed(READ, 'POST', '/api/mcp')).toBe(true);
     expect(isRequestAllowed(BOTH, 'POST', '/api/mcp')).toBe(true); // read+consume
-    // Neither consume nor climate reaches the MCP endpoint until write/consume
-    // tools ship and their scopes are added to the allowlist alongside them.
-    expect(isRequestAllowed(CONSUME, 'POST', '/api/mcp')).toBe(false);
+    // consume tokens reach the endpoint since the consume tools shipped; the
+    // registry scope filter decides which tools they actually see.
+    expect(isRequestAllowed(CONSUME, 'POST', '/api/mcp')).toBe(true);
+    // climate (device credential) still reaches NOTHING but ingest.
     expect(isRequestAllowed(['climate'], 'POST', '/api/mcp')).toBe(false);
     // POST-only + exact-anchored — GET (the 405 fallback) and sub-paths denied.
     expect(isRequestAllowed(READ, 'GET', '/api/mcp')).toBe(false);
+    expect(isRequestAllowed(CONSUME, 'GET', '/api/mcp')).toBe(false);
     expect(isRequestAllowed(READ, 'POST', '/api/mcp/tools')).toBe(false);
   });
 

--- a/backend/src/models/McpActionLog.js
+++ b/backend/src/models/McpActionLog.js
@@ -1,0 +1,51 @@
+const mongoose = require('mongoose');
+
+/**
+ * McpActionLog — the write-safety ledger for MCP mutations (plan §5.3/§5.7 L4).
+ *
+ * One row per mutating MCP tool call. Powers three things:
+ *  1. Idempotency: a retrying/looping agent that resends the same
+ *     idempotency_key gets the ORIGINAL result back instead of acting twice.
+ *  2. undo_last: the newest un-reversed action is what "undo" undoes; `prev`
+ *     snapshots whatever the reverse operation needs (e.g. the consumed-*
+ *     fields so undoing a restore can re-consume identically).
+ *  3. The "recent AI activity" timeline (frontend, Phase 2d) — what did my
+ *     connected AI change, with one-click revert.
+ *
+ * Retention: 90 days (TTL below) — matches AuditLog's default; undo itself is
+ * bounded much tighter by the bottle restore window. GDPR: registered in
+ * services/userDataRegistry.js (export + purge on account deletion).
+ */
+const mcpActionLogSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  // The cel_ token that performed the action; null when a logged-in session
+  // (JWT) called the MCP directly. Never store the token itself.
+  tokenId: { type: mongoose.Schema.Types.ObjectId, ref: 'ApiToken', default: null },
+  tool: { type: String, required: true },
+  action: { type: String, enum: ['consume', 'restore'], required: true },
+  bottle: { type: mongoose.Schema.Types.ObjectId, ref: 'Bottle' },
+  cellar: { type: mongoose.Schema.Types.ObjectId, ref: 'Cellar' },
+  // Small, non-PII operational detail (reason, ml, …) for the timeline.
+  detail: { type: mongoose.Schema.Types.Mixed, default: {} },
+  // Snapshot needed to REVERSE this action (e.g. consumed-* fields).
+  prev: { type: mongoose.Schema.Types.Mixed, default: null },
+  // Client-supplied replay guard; unique per user when present.
+  idempotencyKey: { type: String, default: null },
+  // The ok()-envelope body originally returned — replayed verbatim on an
+  // idempotent retry so the caller can't tell the difference.
+  result: { type: mongoose.Schema.Types.Mixed, default: null },
+  // Set once undo_last (or a manual revert) has reversed this action.
+  reversed: { type: Boolean, default: false },
+  createdAt: { type: Date, default: Date.now },
+});
+
+mcpActionLogSchema.index(
+  { user: 1, idempotencyKey: 1 },
+  { unique: true, partialFilterExpression: { idempotencyKey: { $type: 'string' } } }
+);
+mcpActionLogSchema.index({ user: 1, createdAt: -1 });
+// TTL — single index on createdAt, no competing plain index (IndexOptionsConflict
+// silently disables TTL otherwise; see models/AuditLog.js).
+mcpActionLogSchema.index({ createdAt: 1 }, { expireAfterSeconds: 90 * 24 * 60 * 60 });
+
+module.exports = mongoose.model('McpActionLog', mcpActionLogSchema);

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -3,7 +3,6 @@ const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { requireBottleAccess } = require('../middleware/bottleAccess');
 const Bottle = require('../models/Bottle');
 const Cellar = require('../models/Cellar');
-const Rack = require('../models/Rack');
 const WineDefinition = require('../models/WineDefinition');
 const Country = require('../models/Country');
 const Region = require('../models/Region');
@@ -19,7 +18,7 @@ const { resolveRating } = require('../utils/ratingUtils');
 const { embedSinglePair } = require('../services/embeddingJob');
 const { enrichWineById } = require('../services/enrichmentJob');
 const { CONSUMED_STATUSES, WINE_POPULATE, WINE_POPULATE_LIST } = require('../config/constants');
-const { checkRestockGap, resolveRestockAlerts } = require('../services/restockChecker');
+const { resolveRestockAlerts } = require('../services/restockChecker');
 const { unlinkImageFiles } = require('../services/imageProcessor');
 const { gatherPriceWarnings } = require('../services/priceWarnings');
 const { getCurrentRelease } = require('../services/communityPrice');
@@ -32,16 +31,11 @@ const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
 const { parsePagination } = require('../utils/pagination');
 const mongoose = require('mongoose');
 const searchService = require('../services/search');
+// consume/restore logic + rack-slot freeing live in the shared service so the
+// REST routes and the MCP tools can never drift (plan §7).
+const { consumeBottle, restoreBottle, removeFromRacks } = require('../services/bottleOps');
 
 const router = express.Router();
-
-// Remove a bottle from every rack slot that references it
-async function removeFromRacks(bottleId) {
-  await Rack.updateMany(
-    { 'slots.bottle': bottleId },
-    { $pull: { slots: { bottle: bottleId } } }
-  );
-}
 
 // All routes require authentication
 router.use(requireAuth);
@@ -847,53 +841,10 @@ router.put('/:id/default-image', requireBottleAccess('editor'), async (req, res)
 // POST /api/bottles/:id/consume - Soft-remove bottle (owner or editor)
 router.post('/:id/consume', requireBottleAccess('editor'), async (req, res) => {
   try {
-    const { bottle } = req;
     const { reason = 'drank', note, rating, consumedRatingScale } = req.body;
-
-    if (!CONSUMED_STATUSES.includes(reason)) {
-      return res.status(400).json({ error: 'Invalid reason' });
-    }
-
-    if (note && (typeof note !== 'string' || note.length > 1000)) {
-      return res.status(400).json({ error: 'Note is too long (max 1000 characters)' });
-    }
-
-    const { rating: resolvedConsumedRating, ratingScale: resolvedConsumedScale, error: consumeRatingError } = resolveRating(rating, consumedRatingScale);
-    if (consumeRatingError) return res.status(400).json({ error: consumeRatingError });
-
-    bottle.status = reason;
-    bottle.consumedAt = new Date();
-    bottle.consumedReason = reason;
-    if (note) bottle.consumedNote = stripHtml(note);
-    if (resolvedConsumedRating !== undefined) {
-      bottle.consumedRating = resolvedConsumedRating;
-      bottle.consumedRatingScale = resolvedConsumedScale;
-    }
-
-    await bottle.save();
-
-    // Remove from any rack slot so the slot is freed up — after the save, so a
-    // failed save doesn't leave an active bottle already pulled from its rack
-    await removeFromRacks(bottle._id);
-
-    // Re-index so search reflects the consumed status (consumed bottles stay
-    // in the index for history search; they're filtered at query time)
-    searchService.indexBottle(bottle._id);
-
-    logAudit(req, 'bottle.consume',
-      { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
-      { reason }
-    );
-
-    // Fire-and-forget: check if user needs a restock alert. Skipped for demo
-    // accounts: on an un-cached (wine, vintage) pair checkRestockGap fires a paid
-    // Voyage embedding call (no budget gate of its own), which would breach the
-    // demo's "zero AI spend" guarantee.
-    if (reason === 'drank' && !req.user.isDemo) {
-      checkRestockGap(req.user.id, bottle._id, bottle.cellar).catch(() => {});
-    }
-
-    res.json({ bottle });
+    const result = await consumeBottle(req.bottle, { reason, note, rating, ratingScale: consumedRatingScale }, req);
+    if (result.error) return res.status(result.error.status).json({ error: result.error.message });
+    res.json({ bottle: result.bottle });
   } catch (error) {
     if (error.name === 'ValidationError') {
       return res.status(400).json({ error: error.message });
@@ -1082,11 +1033,10 @@ router.post('/:id/move', requireBottleAccess('owner'), async (req, res) => {
   }
 });
 
-// A consumed bottle can be moved back to the cellar only within this window of
-// being removed — restore is an "undo an accidental log", not a way to
-// resurrect a bottle drunk long ago. Enforced server-side (the UI also hides
-// the button past the window, but the check is here so it's real).
-const RESTORE_WINDOW_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+// A consumed bottle can be moved back to the cellar only within a 2-day
+// window of being removed — restore is an "undo an accidental log", not a way
+// to resurrect a bottle drunk long ago. The window (RESTORE_WINDOW_MS) is
+// enforced inside services/bottleOps.restoreBottle, shared with the MCP tool.
 
 // POST /api/bottles/:id/restore - Put a recently-consumed bottle back to active.
 // The inverse of /consume: for when a bottle was marked drank/gifted/sold by
@@ -1096,40 +1046,12 @@ const RESTORE_WINDOW_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
 // re-racks it. Only allowed within RESTORE_WINDOW_MS of removal.
 router.post('/:id/restore', requireBottleAccess('editor'), async (req, res) => {
   try {
-    const { bottle } = req;
-
-    if (bottle.status === 'active') {
-      return res.status(400).json({ error: 'Bottle is already active' });
+    const result = await restoreBottle(req.bottle, req);
+    if (result.error) {
+      const { status, message, code } = result.error;
+      return res.status(status).json({ error: message, ...(code ? { code } : {}) });
     }
-    if (!CONSUMED_STATUSES.includes(bottle.status)) {
-      return res.status(400).json({ error: 'Only a consumed bottle can be restored' });
-    }
-    if (bottle.consumedAt && (Date.now() - new Date(bottle.consumedAt).getTime()) > RESTORE_WINDOW_MS) {
-      return res.status(400).json({
-        error: 'This bottle was removed too long ago to move back. Add it again as a new bottle instead.',
-        code: 'restore_window_expired',
-      });
-    }
-
-    const previousStatus = bottle.status;
-    bottle.status = 'active';
-    bottle.consumedAt = undefined;
-    bottle.consumedReason = undefined;
-    bottle.consumedNote = undefined;
-    bottle.consumedRating = undefined;
-    bottle.consumedRatingScale = undefined;
-    await bottle.save();
-
-    // Re-index so the bottle leaves history-only search results and rejoins the
-    // active cellar index.
-    searchService.indexBottle(bottle._id);
-
-    logAudit(req, 'bottle.restore',
-      { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
-      { from: previousStatus }
-    );
-
-    res.json({ bottle });
+    res.json({ bottle: result.bottle });
   } catch (error) {
     if (error.name === 'ValidationError') {
       return res.status(400).json({ error: error.message });

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -5,12 +5,12 @@ const { handleMcpRequest } = require('../mcp/server');
 
 // Scopes a caller has when talking to the MCP endpoint. For a personal API token
 // (`cel_…`) these are the token's OWN scopes — so a read-only token sees and can
-// call only read tools. A JWT session is the user themselves, but we DELIBERATELY
-// cap it at `read`: the only tools today are read/public, and pre-granting
-// `consume`/`write` here would silently hand every logged-in session write power
-// the instant the first mutating tool ships. When consume/write tools land, that
-// PR extends this set as a conscious decision alongside the write-safety layers.
-const JWT_SCOPES = ['read'];
+// call only read tools. A JWT session is the user themselves; it gets `consume`
+// (a logged-in user can consume/restore in the UI already, and the consume
+// tools ship with the full write-safety stack: conflict guard, idempotency
+// keys, the McpActionLog undo ledger). `write` is deliberately NOT granted —
+// that extension happens with Phase 2b's add/edit tools, consciously.
+const JWT_SCOPES = ['read', 'consume'];
 
 // POST /api/mcp — stateless Streamable HTTP MCP endpoint. Auth is the same
 // requireAuth as the REST API. For `cel_` tokens the SCOPE_ALLOWLIST grants this
@@ -24,7 +24,11 @@ const JWT_SCOPES = ['read'];
 router.post('/', requireAuth, requireNonDemo, async (req, res, next) => {
   try {
     const scopes = req.apiToken ? req.apiToken.scopes : JWT_SCOPES;
-    await handleMcpRequest(req, res, { user: req.user, scopes });
+    // ctx.req rides along for the mutating tools: logAudit reads actor/ip/UA
+    // from it (which also emits the stats_changed SSE nudge), and req.apiToken
+    // lets the action ledger attribute the acting token (id only, never the
+    // token value).
+    await handleMcpRequest(req, res, { user: req.user, scopes, req });
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -1,0 +1,126 @@
+// Shared bottle mutations — ONE implementation for the REST routes and the MCP
+// tools (plan §7), so validation, rack-slot freeing, re-indexing, audit and
+// SSE nudges can never drift between the two surfaces.
+//
+// Contract: each op takes a LOADED, ACCESS-CHECKED bottle document (the caller
+// owns authorization — requireBottleAccess on REST, resolveBottleAccess on
+// MCP) plus a req-like object for audit attribution ({ user, headers, ip … };
+// the real req on both surfaces). Returns { error: { status, message, code? } }
+// for client faults, or the mutated { bottle } on success.
+//
+// services/search and services/restockChecker are required LAZILY inside the
+// functions: search top-requires the ESM-only meilisearch package, which jest
+// cannot parse — a top-level require here would break every suite that loads
+// the MCP tool registry (the #702 failure mode).
+const { CONSUMED_STATUSES } = require('../config/constants');
+const { resolveRating } = require('../utils/ratingUtils');
+const { stripHtml } = require('../utils/sanitize');
+const { logAudit } = require('./audit');
+const Rack = require('../models/Rack');
+
+// Restores are "undo an accidental log", not resurrection of a bottle drunk
+// long ago (see the /restore route docs). Shared so REST and MCP agree.
+const RESTORE_WINDOW_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+
+/** Free any rack slot holding this bottle (consume/delete paths). */
+async function removeFromRacks(bottleId) {
+  await Rack.updateMany(
+    { 'slots.bottle': bottleId },
+    { $pull: { slots: { bottle: bottleId } } }
+  );
+}
+
+/**
+ * Mark a bottle consumed (drank/gifted/sold/other), free its rack slot,
+ * re-index, audit (which also emits the stats_changed SSE nudge), and fire the
+ * restock-gap check. Mirrors POST /api/bottles/:id/consume exactly.
+ */
+async function consumeBottle(bottle, { reason = 'drank', note, rating, ratingScale } = {}, req) {
+  if (!CONSUMED_STATUSES.includes(reason)) {
+    return { error: { status: 400, message: 'Invalid reason' } };
+  }
+  if (note && (typeof note !== 'string' || note.length > 1000)) {
+    return { error: { status: 400, message: 'Note is too long (max 1000 characters)' } };
+  }
+  const { rating: resolvedRating, ratingScale: resolvedScale, error: ratingError } =
+    resolveRating(rating, ratingScale);
+  if (ratingError) return { error: { status: 400, message: ratingError } };
+
+  bottle.status = reason;
+  bottle.consumedAt = new Date();
+  bottle.consumedReason = reason;
+  if (note) bottle.consumedNote = stripHtml(note);
+  if (resolvedRating !== undefined) {
+    bottle.consumedRating = resolvedRating;
+    bottle.consumedRatingScale = resolvedScale;
+  }
+
+  await bottle.save();
+
+  // Free the rack slot AFTER the save, so a failed save doesn't leave an
+  // active bottle already pulled from its rack.
+  await removeFromRacks(bottle._id);
+
+  // Consumed bottles stay in the index for history search (filtered at query
+  // time) — re-index so status is current. Fire-and-forget.
+  require('./search').indexBottle(bottle._id);
+
+  logAudit(req, 'bottle.consume',
+    { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
+    { reason }
+  );
+
+  // Fire-and-forget restock-gap check. Skipped for demo accounts: on an
+  // un-cached (wine, vintage) pair this fires a paid Voyage embedding call,
+  // which would breach the demo's "zero AI spend" guarantee.
+  if (reason === 'drank' && !req?.user?.isDemo) {
+    const { checkRestockGap } = require('./restockChecker');
+    checkRestockGap(req.user.id, bottle._id, bottle.cellar).catch(() => {});
+  }
+
+  return { bottle };
+}
+
+/**
+ * Put a recently-consumed bottle back to active — the inverse of consume.
+ * Clears every consumed-* field; the bottle deliberately comes back UNPLACED
+ * (its old slot was freed and may be occupied). Only within RESTORE_WINDOW_MS.
+ * Mirrors POST /api/bottles/:id/restore exactly.
+ */
+async function restoreBottle(bottle, req) {
+  if (bottle.status === 'active') {
+    return { error: { status: 400, message: 'Bottle is already active' } };
+  }
+  if (!CONSUMED_STATUSES.includes(bottle.status)) {
+    return { error: { status: 400, message: 'Only a consumed bottle can be restored' } };
+  }
+  if (bottle.consumedAt && (Date.now() - new Date(bottle.consumedAt).getTime()) > RESTORE_WINDOW_MS) {
+    return {
+      error: {
+        status: 400,
+        message: 'This bottle was removed too long ago to move back. Add it again as a new bottle instead.',
+        code: 'restore_window_expired',
+      },
+    };
+  }
+
+  const previousStatus = bottle.status;
+  bottle.status = 'active';
+  bottle.consumedAt = undefined;
+  bottle.consumedReason = undefined;
+  bottle.consumedNote = undefined;
+  bottle.consumedRating = undefined;
+  bottle.consumedRatingScale = undefined;
+  await bottle.save();
+
+  require('./search').indexBottle(bottle._id);
+
+  logAudit(req, 'bottle.restore',
+    { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
+    { from: previousStatus }
+  );
+
+  return { bottle, from: previousStatus };
+}
+
+module.exports = { consumeBottle, restoreBottle, removeFromRacks, RESTORE_WINDOW_MS };

--- a/backend/src/services/bottleOps.test.js
+++ b/backend/src/services/bottleOps.test.js
@@ -1,0 +1,101 @@
+/**
+ * Shared consume/restore service — the ONE implementation behind both the REST
+ * routes and the MCP tools. These tests pin the contract both surfaces rely
+ * on: validation faults, exact field mutations, the save→rack-free ordering,
+ * audit actions (which drive the SSE nudge), and the restore window.
+ */
+
+jest.mock('../models/Rack', () => ({ updateMany: jest.fn().mockResolvedValue({}) }));
+jest.mock('./search', () => ({ indexBottle: jest.fn() }));
+jest.mock('./audit', () => ({ logAudit: jest.fn() }));
+jest.mock('./restockChecker', () => ({ checkRestockGap: jest.fn().mockResolvedValue(undefined) }));
+
+const Rack = require('../models/Rack');
+const searchService = require('./search');
+const { logAudit } = require('./audit');
+const { checkRestockGap } = require('./restockChecker');
+const { consumeBottle, restoreBottle, RESTORE_WINDOW_MS } = require('./bottleOps');
+
+const REQ = { user: { id: 'u1', roles: ['user'] }, headers: {} };
+const freshBottle = (over = {}) => ({
+  _id: 'b1', cellar: 'c1', status: 'active', vintage: '2015',
+  save: jest.fn().mockResolvedValue(undefined),
+  ...over,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('consumeBottle', () => {
+  test('rejects a bad reason, an oversized note, and an unresolvable rating', async () => {
+    expect((await consumeBottle(freshBottle(), { reason: 'evaporated' }, REQ)).error.status).toBe(400);
+    expect((await consumeBottle(freshBottle(), { note: 'x'.repeat(1001) }, REQ)).error.status).toBe(400);
+    // Rating out of range for its scale (missing scale defaults to '5', same as REST).
+    expect((await consumeBottle(freshBottle(), { rating: 9 }, REQ)).error.status).toBe(400);
+  });
+
+  test('sets the consumed fields, saves, THEN frees the rack slot, reindexes, audits', async () => {
+    const bottle = freshBottle();
+    const callOrder = [];
+    bottle.save.mockImplementation(async () => callOrder.push('save'));
+    Rack.updateMany.mockImplementation(async () => callOrder.push('rack'));
+
+    const res = await consumeBottle(bottle, { reason: 'gifted', note: 'to Anna <b>x</b>', rating: 4, ratingScale: '5' }, REQ);
+
+    expect(res.error).toBeUndefined();
+    expect(bottle.status).toBe('gifted');
+    expect(bottle.consumedReason).toBe('gifted');
+    expect(bottle.consumedAt).toBeInstanceOf(Date);
+    expect(bottle.consumedNote).toBe('to Anna x'); // stripHtml applied
+    expect(bottle.consumedRating).toBe(4);
+    expect(bottle.consumedRatingScale).toBe('5');
+    expect(callOrder).toEqual(['save', 'rack']); // failed save must not orphan a slot
+    expect(Rack.updateMany).toHaveBeenCalledWith(
+      { 'slots.bottle': 'b1' }, { $pull: { slots: { bottle: 'b1' } } }
+    );
+    expect(searchService.indexBottle).toHaveBeenCalledWith('b1');
+    expect(logAudit).toHaveBeenCalledWith(REQ, 'bottle.consume',
+      { type: 'bottle', id: 'b1', cellarId: 'c1' }, { reason: 'gifted' });
+  });
+
+  test('restock check fires only for "drank" and never for demo users', async () => {
+    await consumeBottle(freshBottle(), { reason: 'gifted' }, REQ);
+    expect(checkRestockGap).not.toHaveBeenCalled();
+
+    await consumeBottle(freshBottle(), { reason: 'drank' }, REQ);
+    expect(checkRestockGap).toHaveBeenCalledWith('u1', 'b1', 'c1');
+
+    checkRestockGap.mockClear();
+    await consumeBottle(freshBottle(), { reason: 'drank' }, { user: { id: 'd1', isDemo: true }, headers: {} });
+    expect(checkRestockGap).not.toHaveBeenCalled();
+  });
+});
+
+describe('restoreBottle', () => {
+  const consumed = (over = {}) => freshBottle({
+    status: 'drank', consumedAt: new Date(), consumedReason: 'drank',
+    consumedNote: 'n', consumedRating: 4, consumedRatingScale: '5', ...over,
+  });
+
+  test('guards: active bottle, non-consumed status, expired window (with code)', async () => {
+    expect((await restoreBottle(freshBottle(), REQ)).error.message).toMatch(/already active/);
+    expect((await restoreBottle(freshBottle({ status: 'weird' }), REQ)).error.message).toMatch(/Only a consumed/);
+    const old = consumed({ consumedAt: new Date(Date.now() - RESTORE_WINDOW_MS - 1000) });
+    const res = await restoreBottle(old, REQ);
+    expect(res.error.code).toBe('restore_window_expired');
+  });
+
+  test('clears every consumed-* field, reindexes, audits with the previous status', async () => {
+    const bottle = consumed({ status: 'gifted', consumedReason: 'gifted' });
+    const res = await restoreBottle(bottle, REQ);
+    expect(res.error).toBeUndefined();
+    expect(res.from).toBe('gifted');
+    expect(bottle.status).toBe('active');
+    for (const f of ['consumedAt', 'consumedReason', 'consumedNote', 'consumedRating', 'consumedRatingScale']) {
+      expect(bottle[f]).toBeUndefined();
+    }
+    expect(bottle.save).toHaveBeenCalled();
+    expect(searchService.indexBottle).toHaveBeenCalledWith('b1');
+    expect(logAudit).toHaveBeenCalledWith(REQ, 'bottle.restore',
+      { type: 'bottle', id: 'b1', cellarId: 'c1' }, { from: 'gifted' });
+  });
+});

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -27,6 +27,7 @@
 const User = require('../models/User');
 const AiBudgetRequest = require('../models/AiBudgetRequest');
 const ApiToken = require('../models/ApiToken');
+const McpActionLog = require('../models/McpActionLog');
 const AiUsage = require('../models/AiUsage');
 const Bottle = require('../models/Bottle');
 const ClimateDevice = require('../models/ClimateDevice');
@@ -511,6 +512,22 @@ const REGISTRY = [
       apiTokens: markTrunc(ctx, 'apiTokens', await ApiToken.find({ user: ctx.userId })
         .select('name scopes lastUsedAt createdAt revokedAt').limit(EXPORT_MAX).lean())
         .map(t => ({ name: t.name, scopes: t.scopes, lastUsedAt: t.lastUsedAt, createdAt: t.createdAt, revokedAt: t.revokedAt })),
+    }),
+  },
+
+  // ── MCP action ledger ───────────────────────────────────────────────────
+  {
+    model: McpActionLog, category: 'personal-data', userFields: ['user'],
+    // Hard-delete on erasure — operational undo/idempotency bookkeeping.
+    purge: (ctx) => McpActionLog.deleteMany({ user: ctx.userId }),
+    // Export what the connected AI changed (right of access) INCLUDING prev —
+    // after a restore, the user's consumed note/rating snapshot may exist only
+    // here for up to the TTL. Never the idempotency keys or stored result
+    // payloads (operational plumbing).
+    exportFragment: async (ctx) => ({
+      mcpActions: markTrunc(ctx, 'mcpActions', await McpActionLog.find({ user: ctx.userId })
+        .select('tool action bottle cellar detail prev reversed createdAt').limit(EXPORT_MAX).lean())
+        .map(a => ({ tool: a.tool, action: a.action, bottle: a.bottle, cellar: a.cellar, detail: a.detail, prev: a.prev || null, reversed: a.reversed, createdAt: a.createdAt })),
     }),
   },
 


### PR DESCRIPTION
## What this is

**The first mutating MCP tools** — `consume_bottle`, `restore_bottle`, `undo_last` on the existing `consume` scope (the one the HA button already uses) — shipped **together with** the plan-§5.7 write-safety machinery, per the "writes don't go live until this is in place" rule.

## One implementation, two surfaces (plan §7)

Consume/restore logic is extracted to `services/bottleOps.js`; the REST handlers are now thin delegates. Validation, rack-slot freeing (save→free ordering), re-indexing, audit (+ the `stats_changed` SSE nudge HA listens to) and the restock check are **byte-identical** between web app and MCP. REST behavior unchanged (verified against the old handlers, same messages/codes).

## The write-safety stack

| Layer | Implementation |
|---|---|
| Structural | consume tools invisible + uncallable without the scope; **no deletes exist** — worst case is a reversible soft status |
| Client confirmation | `destructiveHint` + concrete "wine, vintage" summaries; instructions mandate confirming before consuming |
| Server guards | editor access re-verified per call; already-consumed → `conflict` (looping agents can't double-log); `idempotency_key` replays the **original** envelope instead of re-acting; optimistic concurrency backstops races |
| Ledger | new `McpActionLog`: token **id** attribution (never the token), prev-state snapshots, 90-day TTL, partial-unique keys; **GDPR-registered** (export incl. `prev`, purge on deletion — the completeness regression test enforces it) |
| Undo | `undo_last` reverses the newest un-reversed action within the restore window; undo-of-undo re-consumes with the **original** values; refuses when the bottle changed since (UI actions never enter the ledger — newer records are never overwritten) |
| Rate parity | mutating tools share the **same admin-tunable per-user budget as the REST write limiter** — closes the "dedicated MCP limiter before write tools" gate from the foundation audit |

JWT sessions gain `consume` (UI parity; demo stays blocked); consume-scoped `cel_` tokens can now reach `POST /api/mcp`.

## Audit (2 agents, before push — all findings fixed)

- **High:** `undo_last` was dead on arrival — ledger ObjectId ref vs string-only `isValidId` (same class as the read-tools bug; a string-typed mock masked it **again**). Fix: coercion inside `resolveBottleAccess` itself + ledger mocks now use real ObjectIds so the class can't hide.
- **Med ×3:** undo-of-undo data loss (prev now snapshotted), re-consume state guard + recency bound, the unhonored mutation-limiter gate (now closed).
- Lows: replay skips reversed actions, GDPR export includes `prev`, honest per-account wording, unused import.

## Verification

- **107 targeted tests** (service contract incl. ordering + demo restock skip; tool scope/idempotency/undo/conflict/budget; allowlist) — **full suite 93 suites / 1495 green** in `node:20-alpine`.
- **Live-stack round-trip on real data:** consume → idempotent replay (identical envelope) → conflict guard → `undo_last` → bottle active again.

## Notes

- Eval golden cases for the consume tools will be added to the harness once #708 merges (the cases file lives there).
- No new dependencies; lockfile untouched. **docker-compose impact: none.**
- Next: Phase 2b — `write` scope, `resolve_wine` → `add_bottle` with registry safety + provenance tagging.