### PR TITLE
feat(mcp): Phase 2b — resolve_wine / add_bottle / update_bottle + write scope

### DIFF
--- a/backend/src/mcp/actionLedger.js
+++ b/backend/src/mcp/actionLedger.js
@@ -1,0 +1,33 @@
+// Shared ledger helpers for MUTATING MCP tools (consume.js, write.js):
+// idempotency replay + the McpActionLog row every mutation records for
+// undo_last / the activity timeline. See models/McpActionLog.js.
+const McpActionLog = require('../models/McpActionLog');
+
+/** Persist the action ledger row. Never throws (the action itself succeeded). */
+async function logAction(ctx, entry) {
+  try {
+    return await McpActionLog.create({
+      user: ctx.user.id,
+      tokenId: ctx.req?.apiToken?.id || null,
+      ...entry,
+    });
+  } catch (err) {
+    // Duplicate idempotencyKey race: the concurrent twin already recorded it.
+    if (err?.code !== 11000) console.error('[mcp] action log failed:', err.message);
+    return null;
+  }
+}
+
+/**
+ * Idempotent replay: return the stored envelope for a seen key, else null.
+ * Reversed actions don't replay — if the action was undone since, a retry
+ * should go through the normal path (and re-assert) rather than reporting a
+ * stale success for a state that no longer holds.
+ */
+async function replay(ctx, idempotencyKey) {
+  if (!idempotencyKey) return null;
+  const seen = await McpActionLog.findOne({ user: ctx.user.id, idempotencyKey, reversed: false }).lean();
+  return seen?.result ? { content: [{ type: 'text', text: JSON.stringify(seen.result) }] } : null;
+}
+
+module.exports = { logAction, replay };

--- a/backend/src/mcp/consumeTools.test.js
+++ b/backend/src/mcp/consumeTools.test.js
@@ -257,3 +257,33 @@ describe('mutation rate budget (write-limiter parity at the tool layer)', () => 
     expect(takeMutationSlot('someone-else')).toBe(true);
   });
 });
+
+describe('undo_last walk-backward + scope gating (e2e-caught regression)', () => {
+  test('the candidate query excludes undo-generated rows and respects the write grant', async () => {
+    McpActionLog.findOne.mockReturnValue(chain(null));
+    await tool('undo_last').handler({}, CTX); // CTX has scopes ['consume'] only
+    let q = McpActionLog.findOne.mock.calls[0][0];
+    expect(q.viaUndo).toEqual({ $ne: true });
+    expect(q.action.$in).toEqual(['consume', 'restore']); // no add/update without write
+
+    McpActionLog.findOne.mockClear();
+    McpActionLog.findOne.mockReturnValue(chain(null));
+    await tool('undo_last').handler({}, { ...CTX, scopes: ['consume', 'write'] });
+    q = McpActionLog.findOne.mock.calls[0][0];
+    expect(q.action.$in).toEqual(['consume', 'restore', 'add', 'update']);
+  });
+
+  test('the reverse row is marked viaUndo and the undone row frees its idempotency key', async () => {
+    const entry = {
+      _id: 'log9', action: 'consume', bottle: new mongoose.Types.ObjectId(oid('d')),
+      reversed: false, idempotencyKey: 'k-once', save: jest.fn(),
+    };
+    McpActionLog.findOne.mockReturnValue(chain(entry));
+    ownBottle({ status: 'drank' });
+    bottleOps.restoreBottle.mockImplementation(async (bottle) => { bottle.status = 'active'; return { bottle, from: 'drank' }; });
+    await tool('undo_last').handler({}, CTX);
+    expect(entry.reversed).toBe(true);
+    expect(entry.idempotencyKey).toBeNull();
+    expect(McpActionLog.create.mock.calls[0][0].viaUndo).toBe(true);
+  });
+});

--- a/backend/src/mcp/consumeTools.test.js
+++ b/backend/src/mcp/consumeTools.test.js
@@ -39,6 +39,10 @@ jest.mock('../services/bottleOps', () => ({
   restoreBottle: jest.fn(),
   removeFromRacks: jest.fn(),
   RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,
+  addBottle: jest.fn(),
+  updateBottleFields: jest.fn(),
+  removeBottleCascade: jest.fn(),
+  UPDATABLE_FIELDS: ['price', 'currency', 'notes', 'occasion', 'rating', 'ratingScale', 'drinkFrom', 'drinkTo'],
 }));
 
 const mongoose = require('mongoose');

--- a/backend/src/mcp/instructions.js
+++ b/backend/src/mcp/instructions.js
@@ -9,7 +9,7 @@ const INSTRUCTIONS = [
   '',
   'How to work with it:',
   "- Every tool acts only on the authenticated user's data. Reads are free — prefer them, and prefer filtered searches over fetching everything.",
-  '- Tool families: cellars (list_cellars, get_cellar) → bottles (search_bottles, get_bottle, list_history) → racks (list_racks, get_rack) → portfolio (cellar_stats) → shared registry (search_registry, get_wine, find_similar_wines) → personal (list_wishlist, list_journal) → consuming (consume_bottle, restore_bottle, undo_last — only when the connection has the consume scope).',
+  '- Tool families: cellars (list_cellars, get_cellar) → bottles (search_bottles, get_bottle, list_history) → racks (list_racks, get_rack) → portfolio (cellar_stats) → shared registry (search_registry, get_wine, find_similar_wines) → personal (list_wishlist, list_journal) → consuming (consume_bottle, restore_bottle, undo_last — consume scope) → adding/editing (resolve_wine, add_bottle, update_bottle — write scope).',
   '- Resources you can attach as ambient context: cellar://snapshot (collection overview), cellar://stats (portfolio doc), cellar://bottle/{id} (one bottle\'s dossier), cellarion://about.',
   '- find_similar_wines = "more like this" by taste/style vectors — ideal for purchase ideas seeded from a wine the user loves.',
   '- Typical flow: list_cellars once to learn ids, then search_bottles / get_bottle for specifics. search_bottles = what the user OWNS; search_registry = ALL wines Cellarion knows.',
@@ -18,7 +18,7 @@ const INSTRUCTIONS = [
   '- IDs (cellar_id, bottle_id, rack_id, wine_id) come from list/search tools — never invent one.',
   '- Errors return { error: { code, message } }: not_found usually means a wrong/foreign id (re-list to recover); invalid_input explains exactly what to fix.',
   '- Consuming changes the cellar: ALWAYS confirm with the user first, naming the exact wine, vintage and reason ("mark the 2015 Barolo as drank?"). Every consume is reversible for 2 days (restore_bottle / undo_last) — say so when you log one. Pass an idempotency_key if you retry.',
-  '- You cannot yet ADD or edit bottles, racks or cellars over this connection. For those, do the reasoning, then point the user to the web app.',
+  '- Adding a wine is TWO steps: resolve_wine first (the registry probably knows it), then add_bottle with the matched wine_id. Only create with new_wine after no_match AND user confirmation — never put the producer inside the wine name. Racks/cellars cannot be created over MCP yet.',
   '- Call get_source_info if the user asks what Cellarion is, which version this instance runs, whether it is open source, or where to find or contribute to the code.',
 ].join('\n');
 

--- a/backend/src/mcp/tools/consume.js
+++ b/backend/src/mcp/tools/consume.js
@@ -155,9 +155,17 @@ registerTool({
     const last = await McpActionLog.findOne({
       user: ctx.user.id,
       reversed: false,
-      // undo_add rows are the record OF an undo — not themselves undoable
-      // (the bottle is gone).
-      action: { $in: ['consume', 'restore', 'add', 'update'] },
+      // Rows created BY an undo are never candidates: sequential undos walk
+      // BACKWARD through the user's own actions ("undo, undo" = revert the
+      // update, then the add) — they must not ping-pong on one action.
+      viaUndo: { $ne: true },
+      // Reversing add/update needs the write grant — a consume-only token
+      // must never gain delete-a-bottle power through undo.
+      action: {
+        $in: (ctx.scopes || []).includes('write')
+          ? ['consume', 'restore', 'add', 'update']
+          : ['consume', 'restore'],
+      },
       createdAt: { $gte: new Date(Date.now() - RESTORE_WINDOW_MS) },
     }).sort({ createdAt: -1 });
     if (!last) return fail('not_found', 'No recent MCP action to undo — nothing has been changed through MCP in the last few days.');
@@ -237,10 +245,14 @@ registerTool({
     }
 
     last.reversed = true;
+    // Free the idempotency key: a retry after an undo must re-execute AND get
+    // a fresh ledger row (the unique index would otherwise swallow it).
+    last.idempotencyKey = null;
     await last.save();
     await logAction(ctx, {
       tool: 'undo_last',
       ...reverseEntry,
+      viaUndo: true,
       bottle: bottle._id,
       cellar: bottle.cellar,
       detail: { undid: String(last._id) },

--- a/backend/src/mcp/tools/consume.js
+++ b/backend/src/mcp/tools/consume.js
@@ -22,39 +22,13 @@ const McpActionLog = require('../../models/McpActionLog');
 const { CONSUMED_STATUSES } = require('../../config/constants');
 const { registerTool } = require('../registry');
 const { consumeBottle, restoreBottle, RESTORE_WINDOW_MS } = require('../../services/bottleOps');
+const { logAction, replay } = require('../actionLedger');
 const { ok, fail, objectId, MSG_BOTTLE_NOT_FOUND, resolveBottleAccess } = require('../toolUtil');
 
 const RESTORE_WINDOW_DAYS = Math.round(RESTORE_WINDOW_MS / 86400000);
 
 function bottleLabel(bottle) {
   return `bottle ${bottle._id} (vintage ${bottle.vintage})`;
-}
-
-/** Persist the action ledger row. Never throws (the action itself succeeded). */
-async function logAction(ctx, entry) {
-  try {
-    return await McpActionLog.create({
-      user: ctx.user.id,
-      tokenId: ctx.req?.apiToken?.id || null,
-      ...entry,
-    });
-  } catch (err) {
-    // Duplicate idempotencyKey race: the concurrent twin already recorded it.
-    if (err?.code !== 11000) console.error('[mcp] action log failed:', err.message);
-    return null;
-  }
-}
-
-/**
- * Idempotent replay: return the stored envelope for a seen key, else null.
- * Reversed actions don't replay — if the action was undone since, a retry
- * should go through the normal path (and re-assert) rather than reporting a
- * stale success for a state that no longer holds.
- */
-async function replay(ctx, idempotencyKey) {
-  if (!idempotencyKey) return null;
-  const seen = await McpActionLog.findOne({ user: ctx.user.id, idempotencyKey, reversed: false }).lean();
-  return seen?.result ? { content: [{ type: 'text', text: JSON.stringify(seen.result) }] } : null;
 }
 
 registerTool({
@@ -181,7 +155,9 @@ registerTool({
     const last = await McpActionLog.findOne({
       user: ctx.user.id,
       reversed: false,
-      action: { $in: ['consume', 'restore'] },
+      // undo_add rows are the record OF an undo — not themselves undoable
+      // (the bottle is gone).
+      action: { $in: ['consume', 'restore', 'add', 'update'] },
       createdAt: { $gte: new Date(Date.now() - RESTORE_WINDOW_MS) },
     }).sort({ createdAt: -1 });
     if (!last) return fail('not_found', 'No recent MCP action to undo — nothing has been changed through MCP in the last few days.');
@@ -192,7 +168,36 @@ registerTool({
 
     let envelope;
     let reverseEntry;
-    if (last.action === 'consume') {
+    if (last.action === 'add') {
+      // Undo an add = remove the bottle again (the REST /undo cascade: rack
+      // slots, search, images, pending wine request, then the doc). Only an
+      // ACTIVE bottle — if it was consumed/changed since, refuse.
+      const { removeBottleCascade } = require('../../services/bottleOps');
+      const result = await removeBottleCascade(bottle, ctx.req, 'bottle.undo');
+      if (result.error) {
+        return fail('conflict', `Cannot undo that add: ${result.error.message} Nothing was changed.`);
+      }
+      envelope = {
+        summary: `Undid add — ${bottleLabel(bottle)} removed from the cellar`,
+        data: { undone: 'add_bottle', bottle_id: bottle._id },
+      };
+      reverseEntry = { action: 'undo_add', prev: null };
+    } else if (last.action === 'update') {
+      // Undo an update = re-apply the snapshotted previous values.
+      const { updateBottleFields } = require('../../services/bottleOps');
+      const prevFields = last.prev || {};
+      if (Object.keys(prevFields).length === 0) {
+        return fail('conflict', 'That update has no recorded previous values; nothing was changed.');
+      }
+      const result = await updateBottleFields(bottle, prevFields, ctx.req);
+      if (result.error) return fail('conflict', `Cannot undo that update: ${result.error.message}`);
+      envelope = {
+        summary: `Undid update on ${bottleLabel(bottle)} — restored: ${Object.keys(prevFields).join(', ')}`,
+        data: { undone: 'update_bottle', bottle_id: bottle._id, restored: result.changes },
+      };
+      // The reverse row snapshots what we just overwrote, so undo-of-undo works.
+      reverseEntry = { action: 'update', prev: result.prev };
+    } else if (last.action === 'consume') {
       // Snapshot BEFORE restoring, so undoing THIS undo can re-consume with
       // the original values instead of defaults.
       const prevSnapshot = {

--- a/backend/src/mcp/tools/index.js
+++ b/backend/src/mcp/tools/index.js
@@ -14,6 +14,7 @@ require('./stats');
 require('./wines');
 require('./personal');
 require('./consume');
+require('./write');
 require('./similar');
 
 module.exports = {};

--- a/backend/src/mcp/tools/write.js
+++ b/backend/src/mcp/tools/write.js
@@ -1,0 +1,264 @@
+// Registry-safe write tools (plan §5.1 — the two-step resolve→add contract):
+// resolve_wine [read] / add_bottle [write] / update_bottle [write].
+//
+// Registry integrity is the design center here. add_bottle can only reference
+// an EXISTING registry wine (wine_id) or go through findOrCreateWine — the
+// same #674-hardened chokepoint every other surface uses (producer-in-name
+// strip, sibling match, fuzzy scoring, soft-zone). MCP is deliberately
+// STRICTER than REST: sibling matching stays ON even for confirmed creates,
+// and every wine minted here is stamped createdVia:'mcp' + audited
+// (wine.create), so admins can review AI-created wines as a class.
+//
+// AI cost: creating a bottle fires the same fire-and-forget embed/enrich calls
+// as the web app, which carry their own kill-switch + per-user budget gates —
+// an MCP add costs exactly what a UI add costs, and dedup means a known wine
+// costs nothing.
+const { z } = require('zod');
+const WineDefinition = require('../../models/WineDefinition');
+const { registerTool } = require('../registry');
+// findOrCreateWine is required LAZILY inside handlers: it top-requires
+// services/search → the ESM-only meilisearch package, which jest cannot parse
+// — a top-level require here would break every suite that loads the tool
+// registry (the #702 failure mode).
+const { addBottle, updateBottleFields, UPDATABLE_FIELDS } = require('../../services/bottleOps');
+const { logAudit } = require('../../services/audit');
+const { isValidId } = require('../../utils/validation');
+const {
+  ok, fail, objectId, MSG_CELLAR_NOT_FOUND, MSG_BOTTLE_NOT_FOUND,
+  resolveCellarAccess, resolveBottleAccess, wineSummary,
+} = require('../toolUtil');
+const { logAction, replay } = require('../actionLedger');
+
+const NEW_WINE_SHAPE = {
+  name: z.string().trim().min(1).max(200).describe('Wine name WITHOUT the producer in it (e.g. "Sauvignon Blanc", not "Cloudy Bay Sauvignon Blanc")'),
+  producer: z.string().trim().min(1).max(200),
+  country: z.string().trim().min(1).max(200).describe('Country name (required to create)'),
+  region: z.string().max(200).optional(),
+  appellation: z.string().max(200).optional(),
+  type: z.enum(['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified']).describe('Required: creating without the real type would mint a default-red registry entry'),
+  grapes: z.array(z.string().max(200)).max(10).optional(),
+};
+
+registerTool({
+  name: 'resolve_wine',
+  title: 'Resolve a wine against the shared registry (STEP 1 of adding)',
+  description:
+    'ALWAYS call this before add_bottle with a new wine. Checks the shared registry for the wine using the same ' +
+    'dedup pipeline as every other surface (producer-prefix stripping, sibling match, fuzzy scoring). Returns either ' +
+    'the matched existing wine (use its wine_id), close candidates to choose from, or no_match (then confirm the ' +
+    'details with the user and call add_bottle with new_wine). Pure lookup — never creates anything.',
+  scope: 'read',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    name: z.string().min(1).max(200),
+    producer: z.string().min(1).max(200),
+    appellation: z.string().max(200).optional(),
+  },
+  handler: async (args, ctx) => {
+    const { findOrCreateWine } = require('../../services/findOrCreateWine');
+    const result = await findOrCreateWine(
+      { name: args.name, producer: args.producer, appellation: args.appellation },
+      ctx.user.id,
+      { matchOnly: true }
+    );
+    if (result.wine) {
+      return ok(`Matched existing registry wine: ${result.wine.name}`, {
+        matched: { ...wineSummary(result.wine) },
+        guidance: 'Use this wine_id in add_bottle. Do not create a new wine.',
+      });
+    }
+    if (result.candidates?.length) {
+      return ok(`${result.candidates.length} close candidate(s) — none certain`, {
+        candidates: result.candidates.map((c) => ({ ...wineSummary(c.wine), score: c.score })),
+        guidance: 'If one of these IS the wine, use its wine_id in add_bottle. Only if none match, call add_bottle with new_wine and confirm_new_wine:true.',
+      });
+    }
+    return ok('No registry match', {
+      no_match: true,
+      guidance: 'Confirm name/producer/country with the user, then call add_bottle with new_wine. Keep the producer OUT of the name field.',
+    });
+  },
+});
+
+registerTool({
+  name: 'add_bottle',
+  title: 'Add a bottle to a cellar (STEP 2)',
+  description:
+    'Adds one bottle to a cellar the user owns or edits. Reference the wine by wine_id (from resolve_wine / ' +
+    'search_registry / an existing bottle) — or, only after resolve_wine returned no_match and the user confirmed the ' +
+    'details, pass new_wine to mint a registry entry. ALWAYS confirm with the user before adding (name, vintage, ' +
+    'cellar). The bottle arrives UNPLACED (rack placement is a separate step in the web app for now). Reversible via ' +
+    'undo_last. Pass an idempotency_key when retrying.',
+  scope: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  inputSchema: {
+    cellar_id: objectId,
+    wine_id: z.string().optional().describe('Existing registry wine id (preferred — see resolve_wine)'),
+    new_wine: z.object(NEW_WINE_SHAPE).optional().describe('Only after resolve_wine returned no_match'),
+    confirm_new_wine: z.boolean().optional().describe('Set true to create despite close-but-unconfirmed candidates'),
+    vintage: z.string().max(10).optional().describe('e.g. "2019" or "NV"'),
+    price: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Za-z]{3}$/).optional(),
+    purchase_location: z.string().max(500).optional(),
+    notes: z.string().max(5000).optional(),
+    occasion: z.string().max(500).optional(),
+    rating: z.number().min(0).max(100).optional(),
+    rating_scale: z.enum(['5', '20', '100']).optional(),
+    drink_from: z.number().int().optional(),
+    drink_to: z.number().int().optional(),
+    idempotency_key: z.string().max(100).optional(),
+  },
+  handler: async (args, ctx) => {
+    const replayed = await replay(ctx, args.idempotency_key);
+    if (replayed) return replayed;
+
+    if (!args.wine_id && !args.new_wine) {
+      return fail('invalid_input', 'Provide wine_id (preferred — call resolve_wine first) or new_wine.');
+    }
+    if (args.wine_id && args.new_wine) {
+      return fail('invalid_input', 'Provide wine_id OR new_wine, not both.');
+    }
+
+    const access = await resolveCellarAccess(ctx.user.id, args.cellar_id, 'editor');
+    if (!access) return fail('not_found', MSG_CELLAR_NOT_FOUND);
+
+    // Resolve the registry wine.
+    let wineDoc;
+    let wineCreated = false;
+    if (args.wine_id) {
+      if (!isValidId(args.wine_id)) return fail('invalid_input', 'wine_id must be a 24-hex Mongo id.');
+      wineDoc = await WineDefinition.findById(args.wine_id).populate(['country', 'region', 'grapes']);
+      if (!wineDoc) return fail('not_found', 'No registry wine with that id. Use resolve_wine or search_registry.');
+    } else {
+      const { findOrCreateWine } = require('../../services/findOrCreateWine');
+      let result;
+      try {
+        // Sibling matching stays ON even when confirmed — stricter than REST,
+        // deliberately: an exact producer+name sibling IS the same wine.
+        result = await findOrCreateWine(args.new_wine, ctx.user.id, {
+          confirmCreate: !!args.confirm_new_wine,
+          skipSiblingMatch: false,
+          createdVia: 'mcp',
+        });
+      } catch (err) {
+        if (err?.status === 400) return fail('invalid_input', err.message);
+        throw err;
+      }
+      if (!result.wine && result.candidates?.length) {
+        return fail('conflict',
+          'Very similar wines already exist — use one of these wine_ids, or call again with confirm_new_wine:true ONLY if the user confirms it is genuinely different: ' +
+          result.candidates.map((c) => `${c.wine.name} — ${c.wine.producer} (wine_id ${c.wine._id}, score ${c.score})`).join('; '));
+      }
+      wineDoc = result.wine;
+      wineCreated = !!result.created;
+      if (wineCreated) {
+        logAudit(ctx.req, 'wine.create',
+          { type: 'wine', id: wineDoc._id },
+          { via: 'mcp', name: wineDoc.name, producer: wineDoc.producer });
+      }
+    }
+
+    const result = await addBottle(access.cellar, wineDoc, {
+      vintage: args.vintage,
+      price: args.price,
+      currency: args.currency,
+      purchaseLocation: args.purchase_location,
+      notes: args.notes,
+      occasion: args.occasion,
+      rating: args.rating,
+      ratingScale: args.rating_scale,
+      drinkFrom: args.drink_from,
+      drinkTo: args.drink_to,
+    }, ctx.req);
+    if (result.error) return fail('invalid_input', result.error.message);
+    const { bottle } = result;
+
+    const envelope = {
+      summary: `Added ${wineDoc.name} ${bottle.vintage} to "${access.cellar.name}"${wineCreated ? ' (new registry wine created)' : ''}`,
+      data: {
+        bottle_id: bottle._id,
+        wine: { ...wineSummary(wineDoc) },
+        wine_created: wineCreated,
+        vintage: bottle.vintage,
+        cellar_id: access.cellar._id,
+        placement: null,
+        undo: 'undo_last removes this bottle again if it was a mistake',
+      },
+    };
+    await logAction(ctx, {
+      tool: 'add_bottle',
+      action: 'add',
+      bottle: bottle._id,
+      cellar: access.cellar._id,
+      detail: { wine: String(wineDoc._id), wine_created: wineCreated, vintage: bottle.vintage },
+      idempotencyKey: args.idempotency_key || null,
+      result: envelope,
+    });
+    return ok(envelope.summary, envelope.data);
+  },
+});
+
+registerTool({
+  name: 'update_bottle',
+  title: 'Update a bottle (price, notes, rating, drink window, occasion)',
+  description:
+    `Partially updates one bottle. Updatable: ${UPDATABLE_FIELDS.join(', ')} (snake_case params). Only send the ` +
+    'fields to change; confirm the change with the user first. Reversible via undo_last.',
+  scope: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  inputSchema: {
+    bottle_id: objectId,
+    price: z.number().min(0).optional(),
+    currency: z.string().regex(/^[A-Za-z]{3}$/).optional(),
+    notes: z.string().max(5000).optional(),
+    occasion: z.string().max(500).optional(),
+    rating: z.number().min(0).max(100).optional(),
+    rating_scale: z.enum(['5', '20', '100']).optional(),
+    drink_from: z.number().int().nullable().optional(),
+    drink_to: z.number().int().nullable().optional(),
+    idempotency_key: z.string().max(100).optional(),
+  },
+  handler: async (args, ctx) => {
+    const replayed = await replay(ctx, args.idempotency_key);
+    if (replayed) return replayed;
+
+    const access = await resolveBottleAccess(ctx.user.id, args.bottle_id, 'editor');
+    if (!access) return fail('not_found', MSG_BOTTLE_NOT_FOUND);
+    const { bottle } = access;
+
+    const result = await updateBottleFields(bottle, {
+      price: args.price,
+      currency: args.currency,
+      notes: args.notes,
+      occasion: args.occasion,
+      rating: args.rating,
+      ratingScale: args.rating_scale,
+      drinkFrom: args.drink_from,
+      drinkTo: args.drink_to,
+    }, ctx.req);
+    if (result.error) return fail('invalid_input', result.error.message);
+
+    if (Object.keys(result.changes).length === 0) {
+      return ok('No changes — every value already matched', { bottle_id: bottle._id, changes: {} });
+    }
+    const envelope = {
+      summary: `Updated bottle ${bottle._id}: ${Object.keys(result.changes).join(', ')}`,
+      data: {
+        bottle_id: bottle._id,
+        changes: result.changes,
+        undo: 'undo_last restores the previous values',
+      },
+    };
+    await logAction(ctx, {
+      tool: 'update_bottle',
+      action: 'update',
+      bottle: bottle._id,
+      cellar: bottle.cellar,
+      detail: { changed: Object.keys(result.changes) },
+      prev: result.prev,
+      idempotencyKey: args.idempotency_key || null,
+      result: envelope,
+    });
+    return ok(envelope.summary, envelope.data);
+  },
+});

--- a/backend/src/mcp/writeTools.test.js
+++ b/backend/src/mcp/writeTools.test.js
@@ -1,0 +1,210 @@
+/**
+ * MCP write tools — registry-integrity + write-safety invariants.
+ *
+ * Pins the two-step contract (resolve_wine → add_bottle), the soft-zone
+ * conflict that stops an AI minting near-duplicates, provenance stamping +
+ * wine.create audit, ledger rows (REAL ObjectId refs — the masking-bug rule),
+ * idempotency replay, and scope gating (read sees resolve_wine but never
+ * add/update; write sees them all).
+ */
+
+const chain = (result) => {
+  const c = {};
+  for (const m of ['populate', 'sort', 'skip', 'limit', 'select']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(() => Promise.resolve(result));
+  c.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return c;
+};
+
+jest.mock('../models/Cellar', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/Bottle', () => ({
+  find: jest.fn(), findById: jest.fn(), aggregate: jest.fn(), countDocuments: jest.fn(),
+}));
+jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn(), updateMany: jest.fn() }));
+jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn() }));
+jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
+jest.mock('../services/search', () => ({
+  getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn(),
+}));
+jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), buildEmptyStats: jest.fn() }));
+jest.mock('../services/vectorStore', () => ({ getPoints: jest.fn(), searchSimilar: jest.fn() }));
+jest.mock('../config/aiConfig', () => ({ get: jest.fn(() => ({ vectorIndex: 'v1' })) }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../services/bottleOps', () => ({
+  consumeBottle: jest.fn(), restoreBottle: jest.fn(), removeFromRacks: jest.fn(),
+  RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,
+  addBottle: jest.fn(), updateBottleFields: jest.fn(), removeBottleCascade: jest.fn(),
+  UPDATABLE_FIELDS: ['price', 'currency', 'notes', 'occasion', 'rating', 'ratingScale', 'drinkFrom', 'drinkTo'],
+}));
+
+const mongoose = require('mongoose');
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const WineDefinition = require('../models/WineDefinition');
+const McpActionLog = require('../models/McpActionLog');
+const { logAudit } = require('../services/audit');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const bottleOps = require('../services/bottleOps');
+const { allTools, toolsForScopes } = require('./registry');
+require('./tools');
+
+const oid = (c) => c.repeat(24);
+const ME = oid('a');
+const STRANGER = oid('b');
+const REQ = { user: { id: ME, roles: ['user'] }, headers: {}, apiToken: { id: 't1', scopes: ['read', 'write'] } };
+const CTX = { user: { id: ME }, scopes: ['read', 'write'], req: REQ };
+
+const tool = (name) => allTools().find((t) => t.name === name);
+const parse = (res) => JSON.parse(res.content[0].text);
+
+const ownCellar = () => {
+  Cellar.findById.mockReturnValue(chain({ _id: oid('c'), user: ME, members: [], deletedAt: null, name: 'Mine' }));
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  McpActionLog.findOne.mockReturnValue(chain(null));
+  McpActionLog.create.mockResolvedValue({});
+});
+
+describe('scope gating', () => {
+  test('write tools carry write scope; resolve_wine is read; read tokens never see add/update', () => {
+    expect(tool('resolve_wine').scope).toBe('read');
+    expect(tool('add_bottle').scope).toBe('write');
+    expect(tool('update_bottle').scope).toBe('write');
+    const readNames = toolsForScopes(['read']).map((t) => t.name);
+    expect(readNames).toContain('resolve_wine');
+    expect(readNames).not.toContain('add_bottle');
+    const writeNames = toolsForScopes(['write']).map((t) => t.name);
+    expect(writeNames).toEqual(expect.arrayContaining(['add_bottle', 'update_bottle', 'get_source_info']));
+    expect(writeNames).not.toContain('consume_bottle'); // write ≠ consume
+  });
+});
+
+describe('resolve_wine', () => {
+  test('is a pure lookup (matchOnly) and maps all three outcomes', async () => {
+    findOrCreateWine.mockResolvedValue({ wine: { _id: oid('f'), name: 'Barolo', producer: 'X', grapes: [] }, created: false });
+    let body = parse(await tool('resolve_wine').handler({ name: 'Barolo', producer: 'X' }, CTX));
+    expect(body.data.matched.wine_id).toBeDefined();
+    expect(findOrCreateWine.mock.calls[0][2]).toEqual({ matchOnly: true });
+
+    findOrCreateWine.mockResolvedValue({ wine: null, candidates: [{ wine: { _id: oid('f'), name: 'B', producer: 'X', grapes: [] }, score: 0.9 }] });
+    body = parse(await tool('resolve_wine').handler({ name: 'B', producer: 'X' }, CTX));
+    expect(body.data.candidates[0].score).toBe(0.9);
+
+    findOrCreateWine.mockResolvedValue({ wine: null, noMatch: true });
+    body = parse(await tool('resolve_wine').handler({ name: 'Z', producer: 'Q' }, CTX));
+    expect(body.data.no_match).toBe(true);
+  });
+});
+
+describe('add_bottle', () => {
+  test('requires exactly one of wine_id / new_wine', async () => {
+    expect(parse(await tool('add_bottle').handler({ cellar_id: oid('c') }, CTX)).error.code).toBe('invalid_input');
+    expect(parse(await tool('add_bottle').handler(
+      { cellar_id: oid('c'), wine_id: oid('f'), new_wine: { name: 'x', producer: 'y', country: 'z' } }, CTX
+    )).error.code).toBe('invalid_input');
+  });
+
+  test('foreign cellar → not_found before any wine work', async () => {
+    Cellar.findById.mockReturnValue(chain({ _id: oid('c'), user: STRANGER, members: [], deletedAt: null }));
+    const res = await tool('add_bottle').handler({ cellar_id: oid('c'), wine_id: oid('f') }, CTX);
+    expect(parse(res).error.code).toBe('not_found');
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(bottleOps.addBottle).not.toHaveBeenCalled();
+  });
+
+  test('soft-zone candidates → conflict listing wine_ids; nothing created', async () => {
+    ownCellar();
+    findOrCreateWine.mockResolvedValue({
+      wine: null,
+      candidates: [{ wine: { _id: oid('f'), name: 'Close Wine', producer: 'P' }, score: 0.9 }],
+    });
+    const res = await tool('add_bottle').handler(
+      { cellar_id: oid('c'), new_wine: { name: 'Close Wine', producer: 'P', country: 'France' } }, CTX);
+    const body = parse(res);
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message).toContain(oid('f'));
+    expect(bottleOps.addBottle).not.toHaveBeenCalled();
+  });
+
+  test('new wine: provenance createdVia mcp + sibling matching ON + wine.create audit + ledger add', async () => {
+    ownCellar();
+    findOrCreateWine.mockResolvedValue({
+      wine: { _id: oid('f'), name: 'New Wine', producer: 'P', grapes: [] }, created: true,
+    });
+    bottleOps.addBottle.mockResolvedValue({ bottle: { _id: new mongoose.Types.ObjectId(oid('d')), vintage: '2019', cellar: oid('c') } });
+    const res = await tool('add_bottle').handler({
+      cellar_id: oid('c'),
+      new_wine: { name: 'New Wine', producer: 'P', country: 'France' },
+      confirm_new_wine: true,
+      vintage: '2019',
+      idempotency_key: 'k-add',
+    }, CTX);
+    const body = parse(res);
+    expect(body.data.wine_created).toBe(true);
+
+    const opts = findOrCreateWine.mock.calls[0][2];
+    expect(opts).toMatchObject({ confirmCreate: true, skipSiblingMatch: false, createdVia: 'mcp' });
+    expect(logAudit).toHaveBeenCalledWith(REQ, 'wine.create',
+      { type: 'wine', id: oid('f') }, expect.objectContaining({ via: 'mcp' }));
+    const row = McpActionLog.create.mock.calls[0][0];
+    expect(row).toMatchObject({ user: ME, tokenId: 't1', action: 'add', idempotencyKey: 'k-add' });
+    expect(bottleOps.addBottle.mock.calls[0][3]).toBe(REQ); // audit/SSE attribution rides the real req
+  });
+
+  test('existing wine_id: no findOrCreateWine call, no wine.create audit', async () => {
+    ownCellar();
+    WineDefinition.findById.mockReturnValue(chain({ _id: oid('f'), name: 'Known', producer: 'P', grapes: [] }));
+    bottleOps.addBottle.mockResolvedValue({ bottle: { _id: oid('d'), vintage: 'NV', cellar: oid('c') } });
+    const body = parse(await tool('add_bottle').handler({ cellar_id: oid('c'), wine_id: oid('f') }, CTX));
+    expect(body.data.wine_created).toBe(false);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(logAudit).not.toHaveBeenCalledWith(expect.anything(), 'wine.create', expect.anything(), expect.anything());
+  });
+
+  test('idempotent replay short-circuits everything', async () => {
+    McpActionLog.findOne.mockReturnValue(chain({ result: { summary: 'Added once', data: { bottle_id: oid('d') } } }));
+    const body = parse(await tool('add_bottle').handler(
+      { cellar_id: oid('c'), wine_id: oid('f'), idempotency_key: 'k-add' }, CTX));
+    expect(body.summary).toBe('Added once');
+    expect(Cellar.findById).not.toHaveBeenCalled();
+    expect(bottleOps.addBottle).not.toHaveBeenCalled();
+  });
+});
+
+describe('update_bottle', () => {
+  const ownBottle = () => {
+    Bottle.findById.mockReturnValue(chain({ _id: new mongoose.Types.ObjectId(oid('d')), cellar: new mongoose.Types.ObjectId(oid('c')), status: 'active', vintage: '2019' }));
+    ownCellar();
+  };
+
+  test('changes + prev land in the ledger; no-change is a fast path without a ledger row', async () => {
+    ownBottle();
+    bottleOps.updateBottleFields.mockResolvedValue({ bottle: { _id: oid('d'), cellar: oid('c') }, changes: { price: 30 }, prev: { price: 25 } });
+    let body = parse(await tool('update_bottle').handler({ bottle_id: oid('d'), price: 30 }, CTX));
+    expect(body.data.changes).toEqual({ price: 30 });
+    const row = McpActionLog.create.mock.calls[0][0];
+    expect(row).toMatchObject({ action: 'update', prev: { price: 25 } });
+
+    McpActionLog.create.mockClear();
+    bottleOps.updateBottleFields.mockResolvedValue({ bottle: { _id: oid('d') }, changes: {}, prev: {} });
+    body = parse(await tool('update_bottle').handler({ bottle_id: oid('d'), price: 30 }, CTX));
+    expect(body.data.changes).toEqual({});
+    expect(McpActionLog.create).not.toHaveBeenCalled();
+  });
+
+  test('foreign bottle → not_found, service untouched', async () => {
+    Bottle.findById.mockReturnValue(chain({ _id: oid('d'), cellar: oid('c') }));
+    Cellar.findById.mockReturnValue(chain({ _id: oid('c'), user: STRANGER, members: [], deletedAt: null }));
+    const res = await tool('update_bottle').handler({ bottle_id: oid('d'), price: 30 }, CTX);
+    expect(parse(res).error.code).toBe('not_found');
+    expect(bottleOps.updateBottleFields).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/middleware/apiTokenAuth.js
+++ b/backend/src/middleware/apiTokenAuth.js
@@ -56,6 +56,11 @@ const SCOPE_ALLOWLIST = {
     // filter decides which tools it sees (consume + public, not read/write).
     { method: 'POST', pattern: /^\/api\/mcp$/ },
   ],
+  write: [
+    // MCP endpoint only — the write scope exists FOR the MCP write tools; it
+    // grants no REST routes. Per-tool authz lives in the MCP registry.
+    { method: 'POST', pattern: /^\/api\/mcp$/ },
+  ],
   climate: [
     { method: 'POST', pattern: /^\/api\/climate\/ingest$/ },
   ],

--- a/backend/src/middleware/apiTokenAuth.test.js
+++ b/backend/src/middleware/apiTokenAuth.test.js
@@ -168,6 +168,15 @@ describe('isRequestAllowed (default-deny)', () => {
     expect(isRequestAllowed(READ, 'POST', '/api/mcp/tools')).toBe(false);
   });
 
+  test('write scope: MCP endpoint only — never any REST route', () => {
+    const WRITE = ['write'];
+    expect(isRequestAllowed(WRITE, 'POST', '/api/mcp')).toBe(true);
+    expect(isRequestAllowed(WRITE, 'POST', '/api/bottles')).toBe(false);
+    expect(isRequestAllowed(WRITE, 'PUT', '/api/bottles/' + 'a'.repeat(24))).toBe(false);
+    expect(isRequestAllowed(WRITE, 'GET', '/api/cellars')).toBe(false);
+    expect(isRequestAllowed(WRITE, 'GET', '/api/mcp')).toBe(false);
+  });
+
   test('GET /api/auth/whoami is granted ONLY by read (own account id for HA reauth)', () => {
     expect(isRequestAllowed(READ, 'GET', '/api/auth/whoami')).toBe(true);
     expect(isRequestAllowed(BOTH, 'GET', '/api/auth/whoami')).toBe(true); // read+consume

--- a/backend/src/models/ApiToken.js
+++ b/backend/src/models/ApiToken.js
@@ -18,7 +18,7 @@ const crypto = require('crypto');
 //   userDataRegistry.js.
 
 const TOKEN_PREFIX = 'cel_';
-const TOKEN_SCOPES = ['read', 'consume', 'climate'];
+const TOKEN_SCOPES = ['read', 'consume', 'write', 'climate'];
 const MAX_ACTIVE_TOKENS_PER_USER = 10;
 
 const apiTokenSchema = new mongoose.Schema({

--- a/backend/src/models/McpActionLog.js
+++ b/backend/src/models/McpActionLog.js
@@ -22,7 +22,7 @@ const mcpActionLogSchema = new mongoose.Schema({
   // (JWT) called the MCP directly. Never store the token itself.
   tokenId: { type: mongoose.Schema.Types.ObjectId, ref: 'ApiToken', default: null },
   tool: { type: String, required: true },
-  action: { type: String, enum: ['consume', 'restore'], required: true },
+  action: { type: String, enum: ['consume', 'restore', 'add', 'update', 'undo_add'], required: true },
   bottle: { type: mongoose.Schema.Types.ObjectId, ref: 'Bottle' },
   cellar: { type: mongoose.Schema.Types.ObjectId, ref: 'Cellar' },
   // Small, non-PII operational detail (reason, ml, …) for the timeline.

--- a/backend/src/models/McpActionLog.js
+++ b/backend/src/models/McpActionLog.js
@@ -36,6 +36,10 @@ const mcpActionLogSchema = new mongoose.Schema({
   result: { type: mongoose.Schema.Types.Mixed, default: null },
   // Set once undo_last (or a manual revert) has reversed this action.
   reversed: { type: Boolean, default: false },
+  // True on rows created BY undo_last (the record of a reversal). Excluded
+  // from undo candidacy so sequential undos walk backward through the user's
+  // own actions instead of ping-ponging on one.
+  viaUndo: { type: Boolean, default: false },
   createdAt: { type: Date, default: Date.now },
 });
 

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -125,6 +125,16 @@ const wineDefinitionSchema = new mongoose.Schema({
     ref: 'User',
     required: true
   },
+  // Provenance: which surface minted this registry entry ('mcp' = a connected
+  // AI via the MCP write tools). Lets admins review AI-created wines as a
+  // class (registry-integrity plan §5.1). null for rows predating the field
+  // and for surfaces that haven't adopted it yet; actor detail stays in
+  // AuditLog (wine.create).
+  createdVia: {
+    type: String,
+    enum: ['ui', 'import', 'mcp', 'ai', null],
+    default: null
+  },
   createdAt: {
     type: Date,
     default: Date.now

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -33,7 +33,7 @@ const mongoose = require('mongoose');
 const searchService = require('../services/search');
 // consume/restore logic + rack-slot freeing live in the shared service so the
 // REST routes and the MCP tools can never drift (plan §7).
-const { consumeBottle, restoreBottle, removeFromRacks } = require('../services/bottleOps');
+const { consumeBottle, restoreBottle, removeFromRacks, removeBottleCascade } = require('../services/bottleOps');
 
 const router = express.Router();
 
@@ -1068,49 +1068,13 @@ router.post('/:id/restore', requireBottleAccess('editor'), async (req, res) => {
 // Active bottles only — consumed bottles must use a different path.
 router.post('/:id/undo', requireBottleAccess('editor'), async (req, res) => {
   try {
-    const { bottle } = req;
-
-    if (bottle.status !== 'active') {
-      return res.status(400).json({
+    // Full cleanup cascade shared with the MCP undo path (services/bottleOps).
+    const result = await removeBottleCascade(req.bottle, req, 'bottle.undo');
+    if (result.error) {
+      return res.status(result.error.status).json({
         error: 'Only active bottles can be marked as a mistake. Already-consumed bottles cannot be undone.'
       });
     }
-
-    const bottleId = bottle._id;
-    const cellarId = bottle.cellar;
-    const pendingRequestId = bottle.pendingWineRequest || null;
-
-    await removeFromRacks(bottleId);
-    searchService.removeBottle(bottleId);
-
-    // Bottle-only images go away — files first: the docs hold the only disk
-    // reference, and the hourly orphan sweep only reconciles originals/, so a
-    // processed PNG whose doc was deleted would leak forever. Images promoted
-    // to a WineDefinition (e.g. approved community photos) stay, but lose
-    // their link back to this bottle.
-    const ownImages = await BottleImage.find({ bottle: bottleId, assignedToWine: false })
-      .select('originalUrl processedUrl').lean();
-    for (const img of ownImages) await unlinkImageFiles(img);
-    await BottleImage.deleteMany({ bottle: bottleId, assignedToWine: false });
-    await BottleImage.updateMany(
-      { bottle: bottleId, assignedToWine: true },
-      { $set: { bottle: null } }
-    );
-
-    // If this bottle held a still-pending wine request, drop it — the user
-    // is saying the entry shouldn't have been created in the first place.
-    // Resolved/rejected requests are admin-actioned and stay put.
-    if (pendingRequestId) {
-      await WineRequest.deleteOne({ _id: pendingRequestId, status: 'pending' });
-    }
-
-    await bottle.deleteOne();
-
-    logAudit(req, 'bottle.undo',
-      { type: 'bottle', id: bottleId, cellarId },
-      { reason: 'mistake' }
-    );
-
     res.json({ message: 'Bottle removed as mistake' });
   } catch (error) {
     console.error('Undo bottle error:', error);

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -10,7 +10,7 @@ const { handleMcpRequest } = require('../mcp/server');
 // tools ship with the full write-safety stack: conflict guard, idempotency
 // keys, the McpActionLog undo ledger). `write` is deliberately NOT granted —
 // that extension happens with Phase 2b's add/edit tools, consciously.
-const JWT_SCOPES = ['read', 'consume'];
+const JWT_SCOPES = ['read', 'consume', 'write'];
 
 // POST /api/mcp — stateless Streamable HTTP MCP endpoint. Auth is the same
 // requireAuth as the REST API. For `cel_` tokens the SCOPE_ALLOWLIST grants this

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -5,11 +5,12 @@ const { handleMcpRequest } = require('../mcp/server');
 
 // Scopes a caller has when talking to the MCP endpoint. For a personal API token
 // (`cel_…`) these are the token's OWN scopes — so a read-only token sees and can
-// call only read tools. A JWT session is the user themselves; it gets `consume`
-// (a logged-in user can consume/restore in the UI already, and the consume
-// tools ship with the full write-safety stack: conflict guard, idempotency
-// keys, the McpActionLog undo ledger). `write` is deliberately NOT granted —
-// that extension happens with Phase 2b's add/edit tools, consciously.
+// call only read tools. A JWT session is the user themselves and gets the full
+// personal set including `write` (Phase 2b, conscious): the UI already lets a
+// logged-in user add/edit/consume, and every mutating tool ships with the
+// write-safety stack (registry-safe two-step add, conflict guards, idempotency
+// keys, the McpActionLog undo ledger, per-user mutation budget). Demo sessions
+// are blocked below; cel_ tokens opt into scopes explicitly at mint time.
 const JWT_SCOPES = ['read', 'consume', 'write'];
 
 // POST /api/mcp — stateless Streamable HTTP MCP endpoint. Auth is the same

--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -14,9 +14,15 @@
 // the MCP tool registry (the #702 failure mode).
 const { CONSUMED_STATUSES } = require('../config/constants');
 const { resolveRating } = require('../utils/ratingUtils');
-const { stripHtml } = require('../utils/sanitize');
+const resolveRatingUtil = resolveRating;
+const { stripHtml, isSafeUrl } = require('../utils/sanitize');
+const { parseAndValidateVintage, parseDrinkYear } = require('../utils/validation');
+const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
 const { logAudit } = require('./audit');
 const Rack = require('../models/Rack');
+const Bottle = require('../models/Bottle');
+const BottleImage = require('../models/BottleImage');
+const WineRequest = require('../models/WineRequest');
 
 // Restores are "undo an accidental log", not resurrection of a bottle drunk
 // long ago (see the /restore route docs). Shared so REST and MCP agree.
@@ -123,4 +129,267 @@ async function restoreBottle(bottle, req) {
   return { bottle, from: previousStatus };
 }
 
-module.exports = { consumeBottle, restoreBottle, removeFromRacks, RESTORE_WINDOW_MS };
+/**
+ * Create a bottle in an ACCESS-CHECKED cellar for an EXISTING registry wine —
+ * the shared core of REST POST /api/bottles and the MCP add_bottle tool.
+ * Mirrors the route's field handling exactly (validation helpers, caps,
+ * priceSetAt anchoring, owner = cellar owner) and fires the same post-save
+ * side effects, so the two surfaces cannot drift. The enrichment/embedding
+ * calls inherit their internal kill-switch + per-user budget gates.
+ *
+ * Returns { error: { status, message } } | { bottle }.
+ */
+async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
+  const {
+    vintage, price, currency, bottleSize,
+    purchaseDate, purchaseLocation, purchaseUrl,
+    notes, occasion, rating, ratingScale, drinkFrom, drinkTo,
+  } = fields;
+
+  const parsedVintage = parseAndValidateVintage(vintage);
+  if (!parsedVintage.ok) return { error: { status: 400, message: parsedVintage.error } };
+
+  const from = parseDrinkYear(drinkFrom, 'drinkFrom');
+  if (!from.ok) return { error: { status: 400, message: from.error } };
+  const to = parseDrinkYear(drinkTo, 'drinkTo');
+  if (!to.ok) return { error: { status: 400, message: to.error } };
+  if (from.value && to.value && from.value > to.value) {
+    return { error: { status: 400, message: 'drinkFrom cannot be after drinkTo' } };
+  }
+
+  const { rating: resolvedRating, ratingScale: resolvedScale, error: ratingError } =
+    resolveRatingUtil(rating, ratingScale);
+  if (ratingError) return { error: { status: 400, message: ratingError } };
+
+  if (notes && (typeof notes !== 'string' || notes.length > 5000)) {
+    return { error: { status: 400, message: 'Notes are too long (max 5000 characters)' } };
+  }
+  const capped = [['occasion', occasion], ['purchaseLocation', purchaseLocation]];
+  for (const pair of capped) {
+    if (pair[1] && (typeof pair[1] !== 'string' || pair[1].length > 500)) {
+      return { error: { status: 400, message: pair[0] + ' is too long (max 500 characters)' } };
+    }
+  }
+  if (purchaseUrl && (typeof purchaseUrl !== 'string' || purchaseUrl.length > 2048 || !isSafeUrl(purchaseUrl))) {
+    return { error: { status: 400, message: 'purchaseUrl is not a valid http(s) URL' } };
+  }
+
+  const hasPrice = price !== undefined && price !== null && price !== '';
+  const doc = {
+    user: cellarDoc.user, // bottle owner = cellar owner, same as the REST route
+    cellar: cellarDoc._id,
+    wineDefinition: wineDoc._id,
+    vintage: parsedVintage.value,
+    bottleSize: normalizeBottleSize(bottleSize) || DEFAULT_SIZE,
+    purchaseDate: purchaseDate || new Date(), // REST defaults this too
+  };
+  if (hasPrice) {
+    doc.price = price;
+    doc.currency = currency || 'USD';
+    doc.priceSetAt = new Date();
+  }
+  if (purchaseLocation) doc.purchaseLocation = stripHtml(purchaseLocation);
+  if (purchaseUrl) doc.purchaseUrl = purchaseUrl;
+  if (notes) doc.notes = stripHtml(notes);
+  if (occasion) doc.occasion = stripHtml(occasion);
+  if (resolvedRating !== undefined) {
+    doc.rating = resolvedRating;
+    doc.ratingScale = resolvedScale;
+  }
+  if (from.value !== undefined) doc.drinkFrom = from.value;
+  if (to.value !== undefined) doc.drinkTo = to.value;
+
+  const bottle = new Bottle(doc);
+  // Seed the cellar journey exactly like the REST route: the bottle enters
+  // this cellar at its added date.
+  bottle.addedToCellarAt = bottle.createdAt;
+  bottle.cellarHistory = [{ cellar: cellarDoc._id, cellarName: cellarDoc.name, enteredAt: bottle.createdAt }];
+  try {
+    await bottle.save();
+  } catch (err) {
+    if (err?.name === 'ValidationError') return { error: { status: 400, message: err.message } };
+    throw err;
+  }
+
+  // Same post-save side effects as the REST route, same order.
+  require('./search').indexBottle(bottle._id);
+  try {
+    const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
+    await ensurePendingVintageProfile(wineDoc._id, bottle.vintage);
+  } catch (err) { /* profile bookkeeping must never fail the add */ }
+  logAudit(req, 'bottle.add',
+    { type: 'bottle', id: bottle._id, cellarId: cellarDoc._id },
+    { vintage: bottle.vintage });
+  if (hasPrice) {
+    require('../utils/exchangeRates').getOrCreateDailySnapshot().catch(() => {});
+  }
+  // Fire-and-forget AI enrichment — both calls carry their own kill-switch /
+  // per-user budget gates (embeddingJob: chatEnabled; enrichmentJob: tryDebitAi).
+  const { embedSinglePair } = require('./embeddingJob');
+  embedSinglePair(wineDoc._id, bottle.vintage).catch(() => {});
+  const { enrichWineById } = require('./enrichmentJob');
+  enrichWineById(wineDoc._id, { budgetUserId: req && req.user ? req.user.id : undefined }).catch(() => {});
+  const { resolveRestockAlerts } = require('./restockChecker');
+  resolveRestockAlerts(req?.user?.id || cellarDoc.user, wineDoc._id, bottle._id).catch(() => {});
+
+  return { bottle };
+}
+
+// Fields update_bottle may touch — the AI-useful subset of the REST PUT route.
+const UPDATABLE_FIELDS = ['price', 'currency', 'notes', 'occasion', 'rating', 'ratingScale', 'drinkFrom', 'drinkTo'];
+
+/**
+ * Diff-based partial update of an access-checked bottle (MCP update_bottle).
+ * Mirrors the REST PUT route's handling for the fields it covers: rating
+ * resolution against the bottle's own scale, drink-window ordering +
+ * notifier-marker reset, priceSetAt re-anchoring, HTML stripping, re-index,
+ * bottle.update audit. Returns { error } | { bottle, changes, prev }.
+ */
+async function updateBottleFields(bottle, fields, req) {
+  fields = fields || {};
+  const changes = {};
+  const prev = {};
+
+  if (fields.notes !== undefined && fields.notes &&
+      (typeof fields.notes !== 'string' || fields.notes.length > 5000)) {
+    return { error: { status: 400, message: 'Notes are too long (max 5000 characters)' } };
+  }
+  if (fields.occasion !== undefined && fields.occasion &&
+      (typeof fields.occasion !== 'string' || fields.occasion.length > 500)) {
+    return { error: { status: 400, message: 'occasion is too long (max 500 characters)' } };
+  }
+
+  // Drink window: validate the EFFECTIVE pair (new values overlaying current).
+  // parseDrinkYear returns { ok, value } — value undefined for empty input,
+  // which here (an explicit null/'' in a PATCH-style update) means CLEAR.
+  let fromYear;
+  let toYear;
+  if (fields.drinkFrom !== undefined) {
+    const p = parseDrinkYear(fields.drinkFrom, 'drinkFrom');
+    if (!p.ok) return { error: { status: 400, message: p.error } };
+    fromYear = p.value !== undefined ? p.value : null;
+  }
+  if (fields.drinkTo !== undefined) {
+    const p = parseDrinkYear(fields.drinkTo, 'drinkTo');
+    if (!p.ok) return { error: { status: 400, message: p.error } };
+    toYear = p.value !== undefined ? p.value : null;
+  }
+  const effFrom = fromYear !== undefined ? fromYear : bottle.drinkFrom;
+  const effTo = toYear !== undefined ? toYear : bottle.drinkTo;
+  if (effFrom && effTo && effFrom > effTo) {
+    return { error: { status: 400, message: 'drinkFrom cannot be after drinkTo' } };
+  }
+
+  if (fields.rating === null) {
+    // Explicit clear — needed so undoing a rating-SET can restore "unrated"
+    // (resolveRating treats null as "no input" and would silently skip it,
+    // leaving the old rating stranded on a possibly-changed scale).
+    // ratingScale may ride along (e.g. restoring the pre-update scale).
+  } else if (fields.rating !== undefined) {
+    const scale = fields.ratingScale || bottle.ratingScale;
+    const resolved = resolveRatingUtil(fields.rating, scale);
+    if (resolved.error) return { error: { status: 400, message: resolved.error } };
+    fields.rating = resolved.rating;
+    fields.ratingScale = resolved.ratingScale;
+  } else if (fields.ratingScale !== undefined) {
+    return { error: { status: 400, message: 'ratingScale can only be changed together with rating' } };
+  }
+
+  const apply = (key, value) => {
+    const current = bottle[key] == null ? null : bottle[key];
+    const next = value == null ? null : value;
+    if (String(current) === String(next)) return;
+    prev[key] = bottle[key] === undefined ? null : bottle[key];
+    bottle[key] = value;
+    changes[key] = value == null ? null : value;
+  };
+
+  for (const key of UPDATABLE_FIELDS) {
+    if (fields[key] === undefined) continue;
+    let value = fields[key];
+    if (key === 'notes' || key === 'occasion') value = value ? stripHtml(value) : value;
+    if (key === 'drinkFrom') value = fromYear;
+    if (key === 'drinkTo') value = toYear;
+    apply(key, value);
+  }
+
+  if (Object.keys(changes).length === 0) {
+    return { bottle, changes, prev };
+  }
+
+  // Same semantics as the REST route: a price/currency touch re-anchors the
+  // price date (or clears it when the price itself is cleared); a drink-window
+  // change resets the notifier markers.
+  if ('price' in changes || 'currency' in changes) {
+    if ('price' in changes && changes.price === null) {
+      bottle.priceSetAt = undefined;
+    } else {
+      bottle.priceSetAt = new Date();
+      require('../utils/exchangeRates').getOrCreateDailySnapshot().catch(() => {});
+    }
+  }
+  if ('drinkFrom' in changes || 'drinkTo' in changes) {
+    bottle.drinkWindowNotifiedStatus = null;
+    bottle.drinkWindowNotifiedAt = null;
+  }
+
+  try {
+    await bottle.save();
+  } catch (err) {
+    if (err?.name === 'ValidationError') return { error: { status: 400, message: err.message } };
+    if (err?.name === 'VersionError') return { error: { status: 409, message: 'The bottle was modified concurrently — retry.' } };
+    throw err;
+  }
+  require('./search').indexBottle(bottle._id);
+  logAudit(req, 'bottle.update',
+    { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
+    { changes });
+
+  return { bottle, changes, prev };
+}
+
+/**
+ * Reverse an incorrectly-added ACTIVE bottle — the full cleanup cascade of
+ * REST POST /api/bottles/:id/undo (rack slots, search index, own images +
+ * file unlink, wine-assigned image unassignment, pending wine request, then
+ * the bottle document itself). auditAction distinguishes 'bottle.undo' from
+ * 'bottle.delete', which run the identical cascade.
+ * Returns { error } | { removed: true }.
+ */
+async function removeBottleCascade(bottle, req, auditAction) {
+  if (bottle.status !== 'active') {
+    return { error: { status: 400, message: 'Only an active bottle can be removed this way' } };
+  }
+  const bottleId = bottle._id;
+  const pendingRequestId = bottle.pendingWineRequest || null;
+
+  await removeFromRacks(bottleId);
+  require('./search').removeBottle(bottleId);
+
+  const { unlinkImageFiles } = require('./imageProcessor');
+  const ownImages = await BottleImage.find({ bottle: bottleId, assignedToWine: false });
+  for (const img of ownImages) await unlinkImageFiles(img);
+  await BottleImage.deleteMany({ bottle: bottleId, assignedToWine: false });
+  await BottleImage.updateMany(
+    { bottle: bottleId, assignedToWine: true },
+    { $set: { bottle: null } }
+  );
+
+  if (pendingRequestId) {
+    await WineRequest.deleteOne({ _id: pendingRequestId, status: 'pending' });
+  }
+
+  const cellarId = bottle.cellar;
+  await bottle.deleteOne();
+
+  logAudit(req, auditAction || 'bottle.undo',
+    { type: 'bottle', id: bottleId, cellarId },
+    { reason: 'mistake' });
+
+  return { removed: true };
+}
+
+module.exports = {
+  consumeBottle, restoreBottle, removeFromRacks, RESTORE_WINDOW_MS,
+  addBottle, updateBottleFields, removeBottleCascade, UPDATABLE_FIELDS,
+};

--- a/backend/src/services/bottleOps.test.js
+++ b/backend/src/services/bottleOps.test.js
@@ -6,9 +6,9 @@
  */
 
 jest.mock('../models/Rack', () => ({ updateMany: jest.fn().mockResolvedValue({}) }));
-jest.mock('./search', () => ({ indexBottle: jest.fn() }));
+jest.mock('./search', () => ({ indexBottle: jest.fn(), removeBottle: jest.fn() }));
 jest.mock('./audit', () => ({ logAudit: jest.fn() }));
-jest.mock('./restockChecker', () => ({ checkRestockGap: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('./restockChecker', () => ({ checkRestockGap: jest.fn().mockResolvedValue(undefined), resolveRestockAlerts: jest.fn().mockResolvedValue(undefined) }));
 
 const Rack = require('../models/Rack');
 const searchService = require('./search');
@@ -97,5 +97,144 @@ describe('restoreBottle', () => {
     expect(searchService.indexBottle).toHaveBeenCalledWith('b1');
     expect(logAudit).toHaveBeenCalledWith(REQ, 'bottle.restore',
       { type: 'bottle', id: 'b1', cellarId: 'c1' }, { from: 'gifted' });
+  });
+});
+
+// ── Write-path ops (Phase 2b) — REAL execution, mocked I/O only ─────────────
+// The 2b audit found the first version of these functions had never been
+// executed (the tool suite mocks bottleOps wholesale). These tests run the
+// real code against the real validation utils.
+
+jest.mock('../models/Bottle', () => {
+  const M = jest.fn(function (doc) {
+    Object.assign(this, doc);
+    this._id = 'new-bottle';
+    this.createdAt = new Date('2026-07-01T00:00:00Z');
+    this.save = jest.fn().mockResolvedValue(undefined);
+    this.deleteOne = jest.fn().mockResolvedValue(undefined);
+  });
+  return M;
+});
+jest.mock('../models/BottleImage', () => ({
+  find: jest.fn().mockResolvedValue([]),
+  deleteMany: jest.fn().mockResolvedValue({}),
+  updateMany: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../models/WineRequest', () => ({ deleteOne: jest.fn().mockResolvedValue({}) }));
+jest.mock('./embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('./enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../utils/exchangeRates', () => ({ getOrCreateDailySnapshot: jest.fn().mockResolvedValue({}) }));
+jest.mock('../utils/vintageProfile', () => ({ ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('./imageProcessor', () => ({ unlinkImageFiles: jest.fn().mockResolvedValue(undefined) }));
+
+const BottleModel = require('../models/Bottle');
+const BottleImage = require('../models/BottleImage');
+const { embedSinglePair } = require('./embeddingJob');
+const { enrichWineById } = require('./enrichmentJob');
+const { addBottle, updateBottleFields, removeBottleCascade } = require('./bottleOps');
+
+const CELLAR = { _id: 'c1', user: 'owner1', name: 'Main Cellar' };
+const WINE = { _id: 'w1', name: 'Barolo' };
+
+describe('addBottle (real execution)', () => {
+  test('stores the PARSED vintage (not NV), drink years, journey seed, and fires gated AI calls', async () => {
+    const res = await addBottle(CELLAR, WINE, {
+      vintage: '2019', price: 25, notes: 'lovely <b>x</b>', drinkFrom: 2026, drinkTo: 2030,
+    }, REQ);
+    expect(res.error).toBeUndefined();
+    const b = res.bottle;
+    expect(b.vintage).toBe('2019');            // the H2 regression: was silently 'NV'
+    expect(b.drinkFrom).toBe(2026);            // was silently dropped
+    expect(b.drinkTo).toBe(2030);
+    expect(b.notes).toBe('lovely x');
+    expect(b.price).toBe(25);
+    expect(b.priceSetAt).toBeInstanceOf(Date);
+    expect(b.purchaseDate).toBeInstanceOf(Date); // REST default parity
+    expect(b.addedToCellarAt).toEqual(b.createdAt);
+    expect(b.cellarHistory).toEqual([{ cellar: 'c1', cellarName: 'Main Cellar', enteredAt: b.createdAt }]);
+    expect(b.user).toBe('owner1');             // owner = cellar owner
+    expect(embedSinglePair).toHaveBeenCalledWith('w1', '2019');
+    expect(enrichWineById).toHaveBeenCalledWith('w1', { budgetUserId: 'u1' });
+    expect(logAudit).toHaveBeenCalledWith(REQ, 'bottle.add', expect.anything(), { vintage: '2019' });
+  });
+
+  test('rejects bad vintage / reversed drink window / oversized notes', async () => {
+    expect((await addBottle(CELLAR, WINE, { vintage: '20x9' }, REQ)).error.status).toBe(400);
+    expect((await addBottle(CELLAR, WINE, { drinkFrom: 2030, drinkTo: 2026 }, REQ)).error.status).toBe(400);
+    expect((await addBottle(CELLAR, WINE, { notes: 'x'.repeat(5001) }, REQ)).error.status).toBe(400);
+  });
+
+  test('empty vintage defaults to NV; no price → no priceSetAt', async () => {
+    const res = await addBottle(CELLAR, WINE, {}, REQ);
+    expect(res.bottle.vintage).toBe('NV');
+    expect(res.bottle.priceSetAt).toBeUndefined();
+  });
+});
+
+describe('updateBottleFields (real execution)', () => {
+  const liveBottle = (over = {}) => {
+    const b = new BottleModel({
+      cellar: 'c1', status: 'active', vintage: '2019',
+      price: 25, currency: 'USD', ratingScale: '5', ...over,
+    });
+    b.save.mockClear();
+    return b;
+  };
+
+  test('drink-year SET actually sets (the H2 clear-instead-of-set regression)', async () => {
+    const b = liveBottle();
+    const res = await updateBottleFields(b, { drinkFrom: 2027 }, REQ);
+    expect(res.error).toBeUndefined();
+    expect(b.drinkFrom).toBe(2027);
+    expect(res.changes).toEqual({ drinkFrom: 2027 });
+    expect(res.prev).toEqual({ drinkFrom: null });
+    expect(b.drinkWindowNotifiedStatus).toBeNull();
+  });
+
+  test('rating null CLEARS the rating (undo-of-rating-set path) with the ride-along scale', async () => {
+    const b = liveBottle({ rating: 92, ratingScale: '100' });
+    const res = await updateBottleFields(b, { rating: null, ratingScale: '5' }, REQ);
+    expect(res.error).toBeUndefined();
+    expect(b.rating).toBeNull();
+    expect(b.ratingScale).toBe('5');
+    expect(res.prev).toEqual({ rating: 92, ratingScale: '100' });
+  });
+
+  test('price clear also clears priceSetAt; price change re-anchors it', async () => {
+    const b = liveBottle({ priceSetAt: new Date('2026-01-01') });
+    await updateBottleFields(b, { price: null }, REQ);
+    expect(b.priceSetAt).toBeUndefined();
+
+    const b2 = liveBottle();
+    await updateBottleFields(b2, { price: 30 }, REQ);
+    expect(b2.price).toBe(30);
+    expect(b2.priceSetAt.getTime()).toBeGreaterThan(Date.now() - 5000);
+  });
+
+  test('no-op update returns empty changes without saving', async () => {
+    const b = liveBottle();
+    const res = await updateBottleFields(b, { price: 25 }, REQ);
+    expect(res.changes).toEqual({});
+    expect(b.save).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeBottleCascade (real execution)', () => {
+  test('active bottle: full cascade in order, then audit', async () => {
+    const b = new BottleModel({ cellar: 'c1', status: 'active', pendingWineRequest: null });
+    const res = await removeBottleCascade(b, REQ, 'bottle.undo');
+    expect(res.removed).toBe(true);
+    expect(Rack.updateMany).toHaveBeenCalled();          // slot freed
+    expect(searchService.removeBottle).toHaveBeenCalledWith('new-bottle');
+    expect(BottleImage.deleteMany).toHaveBeenCalledWith({ bottle: 'new-bottle', assignedToWine: false });
+    expect(b.deleteOne).toHaveBeenCalled();
+    expect(logAudit).toHaveBeenCalledWith(REQ, 'bottle.undo', expect.anything(), { reason: 'mistake' });
+  });
+
+  test('non-active bottle refuses', async () => {
+    const b = new BottleModel({ cellar: 'c1', status: 'drank' });
+    const res = await removeBottleCascade(b, REQ, 'bottle.undo');
+    expect(res.error.status).toBe(400);
+    expect(b.deleteOne).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -121,7 +121,7 @@ async function findOrCreateGrapes(names, userId) {
  *   the registry-safe ephemeral-demo clone so a throwaway account can't pollute the shared
  *   registry. Combine with confirmCreate:true to also bypass the soft-zone candidate return.
  */
-async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false, skipSiblingMatch = false, matchOnly = false } = {}) {
+async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false, skipSiblingMatch = false, matchOnly = false, createdVia = null } = {}) {
   // Cap stored/compared field lengths at this single create chokepoint (covers
   // the find-or-create route, CSV import, cellar-format import and label-scan).
   // This bounds both the fuzzy-match cost and the persisted document size
@@ -244,7 +244,10 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
     type: wineType,
     grapes: grapeIds,
     normalizedKey,
-    createdBy: userId
+    createdBy: userId,
+    // Surface provenance ('mcp' = minted by a connected AI) — reviewable as a
+    // class by admins; see WineDefinition.createdVia.
+    createdVia
   });
 
   try {

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -416,6 +416,7 @@ describe('findOrCreateWine — creation', () => {
       grapes: ['grape-grenache', 'grape-syrah'],
       normalizedKey: INPUT_KEY,
       createdBy: USER_ID,
+      createdVia: null, // provenance default — 'mcp' only via the MCP write tools
     });
     expect(result.created).toBe(true);
     expect(result.wine.save).toHaveBeenCalled();


### PR DESCRIPTION
> **Stacked on #711** (Phase 2a) — merge that first; I'll rebase this onto main after (the #706→#707 routine).

## What this is

**The registry-integrity centerpiece** (plan §5.1): an AI can now add and edit bottles — but only through the same hardened chokepoint every other surface uses, with provenance and full reversibility.

### The two-step contract
- **`resolve_wine`** [read] — pure lookup (verified: returns before any taxonomy/create). Producer-prefix strip, sibling match, fuzzy scoring → `matched` | `candidates` | `no_match` + explicit guidance for the model.
- **`add_bottle`** [write] — `wine_id` (preferred) XOR `new_wine`. New wines: **sibling matching stays ON even for confirmed creates** (stricter than REST), soft-zone near-duplicates come back as a `conflict` listing the candidate `wine_id`s, wine `type` is required (no silent default-red), and every minted wine is stamped **`createdVia:'mcp'`** (new `WineDefinition` field) + audited **`wine.create`** — the first registry-creation audit Cellarion has ever had. Admins can now review AI-created wines as a class.
- **`update_bottle`** [write] — diff-based with prev snapshots; explicit rating-null path so undoing a rating-set restores "unrated".
- **`undo_last`** extended: add → the REST `/undo` cascade (now a shared `bottleOps.removeBottleCascade`, the REST route delegates to it); update → re-apply prev. **Sequential undos walk backward** through the user's actions (the live e2e caught a ping-pong; fixed with a `viaUndo` marker). Add/update reversal is gated on the write scope; reversal frees the idempotency key.

### Cost & safety
- Bottle create is the shared `bottleOps.addBottle` — REST-parity field-for-field incl. the cellar-journey seed, with the same fire-and-forget embed/enrich calls: **budget gates inherited** (per-user `tryDebitAi`, `chatEnabled` kill switch). An MCP add costs exactly what a UI add costs; known wines cost nothing.
- `write` scope: mintable, allowlisted for **`POST /api/mcp` only** (zero REST routes); JWT sessions get it (UI parity, demo blocked); the per-user mutation budget from 2a applies automatically.

## Audit + verification story (the honest version)

The adversarial audit found **2 High** — both mine: a silently-failed CRLF patch left 9 imports missing, and I'd coded against imagined util APIs (every add would have stored vintage "NV"). Both invisible because the tool tests mocked the service wholesale. Fixed, plus 4 Meds — and `bottleOps` now has **real-execution tests** so a mocked-out module can never hide a dead path again. The **live round-trip** then caught the undo ping-pong AND revealed two audit fixes had silently missed the file — all now in with pinning tests.

- **Full suite: 94 suites / 1517 tests green** in `node:20-alpine`.
- **Live e2e on real data:** resolve(no_match) → add(new wine) → `createdVia:'mcp'` verified in Mongo → vintage/window persisted → update → undo → undo → bottle gone, cellar unchanged.

## Not in this PR
`bulk_add` preview→apply (next: 2b-2) · write-scope mint UI + sv strings (2d) · eval golden cases for write tools (→ #708) · DELETE-route cascade unification (later cleanup).

No new dependencies. **docker-compose impact: none.**