### PR TITLE
feat(mcp): sommelier tools — maturity & price queues + curation, role-gated

### DIFF
--- a/backend/src/mcp/consumeTools.test.js
+++ b/backend/src/mcp/consumeTools.test.js
@@ -270,7 +270,7 @@ describe('undo_last walk-backward + scope gating (e2e-caught regression)', () =>
     McpActionLog.findOne.mockReturnValue(chain(null));
     await tool('undo_last').handler({}, { ...CTX, scopes: ['consume', 'write'] });
     q = McpActionLog.findOne.mock.calls[0][0];
-    expect(q.action.$in).toEqual(['consume', 'restore', 'add', 'update', 'bulk_add']);
+    expect(q.action.$in).toEqual(['consume', 'restore', 'add', 'update', 'bulk_add', 'somm_maturity', 'somm_price']);
   });
 
   test('the reverse row is marked viaUndo and the undone row frees its idempotency key', async () => {

--- a/backend/src/mcp/instructions.js
+++ b/backend/src/mcp/instructions.js
@@ -9,7 +9,7 @@ const INSTRUCTIONS = [
   '',
   'How to work with it:',
   "- Every tool acts only on the authenticated user's data. Reads are free — prefer them, and prefer filtered searches over fetching everything.",
-  '- Tool families: cellars (list_cellars, get_cellar) → bottles (search_bottles, get_bottle, list_history) → racks (list_racks, get_rack) → portfolio (cellar_stats) → shared registry (search_registry, get_wine, find_similar_wines) → personal (list_wishlist, list_journal) → consuming (consume_bottle, restore_bottle, undo_last — consume scope) → adding/editing (resolve_wine, add_bottle, update_bottle, bulk_add — write scope).',
+  '- Tool families: cellars (list_cellars, get_cellar) → bottles (search_bottles, get_bottle, list_history) → racks (list_racks, get_rack) → portfolio (cellar_stats) → shared registry (search_registry, get_wine, find_similar_wines) → personal (list_wishlist, list_journal) → consuming (consume_bottle, restore_bottle, undo_last — consume scope) → adding/editing (resolve_wine, add_bottle, update_bottle, bulk_add — write scope) → sommelier curation (list_maturity_queue, set_vintage_maturity, list_price_tracking_requests, set_vintage_price — only for sommelier/admin accounts).',
   '- Resources you can attach as ambient context: cellar://snapshot (collection overview), cellar://stats (portfolio doc), cellar://bottle/{id} (one bottle\'s dossier), cellarion://about.',
   '- find_similar_wines = "more like this" by taste/style vectors — ideal for purchase ideas seeded from a wine the user loves.',
   '- Typical flow: list_cellars once to learn ids, then search_bottles / get_bottle for specifics. search_bottles = what the user OWNS; search_registry = ALL wines Cellarion knows.',

--- a/backend/src/mcp/registry.js
+++ b/backend/src/mcp/registry.js
@@ -47,9 +47,21 @@ function scopeSatisfies(tokenScopes, required) {
   return Array.isArray(tokenScopes) && tokenScopes.includes(required);
 }
 
-/** The subset of registered tools a token with `tokenScopes` may see and call. */
-function toolsForScopes(tokenScopes) {
-  return tools.filter((t) => scopeSatisfies(tokenScopes, t.scope));
+/**
+ * The subset of registered tools a caller may see and call. Filtered by token
+ * scope AND, when a tool declares `requireRole: ['somm', 'admin']`, by the
+ * caller's roles — role-gated tools are structurally INVISIBLE to callers
+ * without the role, not merely rejected. Roles come from the auth layer:
+ * fresh from the User document on every `cel_` token request (revoking the
+ * somm role cuts the tools off immediately); from the JWT claims for browser
+ * sessions (bounded by the 15-minute access-token lifetime, same as REST).
+ */
+function toolsForScopes(tokenScopes, roles = []) {
+  return tools.filter((t) => {
+    if (!scopeSatisfies(tokenScopes, t.scope)) return false;
+    if (t.requireRole && !t.requireRole.some((r) => roles.includes(r))) return false;
+    return true;
+  });
 }
 
 /** All registered tools (for tests / introspection). */

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -78,7 +78,7 @@ async function buildServer(ctx) {
     { instructions: INSTRUCTIONS }
   );
   const state = { calls: 0 };
-  for (const tool of toolsForScopes(ctx.scopes)) {
+  for (const tool of toolsForScopes(ctx.scopes, ctx.user?.roles || [])) {
     server.registerTool(
       tool.name,
       {

--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -1,0 +1,231 @@
+/**
+ * Somm MCP tools — role-gating + shared-data safety invariants.
+ *
+ * Pins: structural invisibility without the somm/admin role (registry level)
+ * AND the in-handler re-check; the NV-relative vs absolute-year validation
+ * mirror; phase ordering; prev snapshots for undo; append-only price entries
+ * with currency validation; ledger attribution.
+ */
+
+const chain = (result) => {
+  const c = {};
+  for (const m of ['populate', 'sort', 'skip', 'limit', 'select']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(() => Promise.resolve(result));
+  c.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return c;
+};
+
+jest.mock('../models/Cellar', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ find: jest.fn(), findById: jest.fn(), aggregate: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn(), findById: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineVintagePrice', () => {
+  const M = jest.fn(function (doc) { Object.assign(this, doc); this._id = 'price-1'; this.save = jest.fn().mockResolvedValue(undefined); });
+  M.aggregate = jest.fn().mockResolvedValue([]);
+  M.deleteOne = jest.fn();
+  return M;
+});
+jest.mock('../models/PriceTrackingRequest', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
+jest.mock('../services/search', () => ({ getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn() }));
+jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), buildEmptyStats: jest.fn() }));
+jest.mock('../services/vectorStore', () => ({ getPoints: jest.fn(), searchSimilar: jest.fn() }));
+jest.mock('../config/aiConfig', () => ({ get: jest.fn(() => ({ vectorIndex: 'v1' })) }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/notifications', () => ({ createNotification: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../utils/exchangeRates', () => ({ getOrCreateDailySnapshot: jest.fn().mockResolvedValue({}) }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../services/bottleOps', () => ({
+  consumeBottle: jest.fn(), restoreBottle: jest.fn(), removeFromRacks: jest.fn(),
+  RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,
+  addBottle: jest.fn(), updateBottleFields: jest.fn(), removeBottleCascade: jest.fn(),
+  UPDATABLE_FIELDS: ['price', 'currency', 'notes', 'occasion', 'rating', 'ratingScale', 'drinkFrom', 'drinkTo'],
+}));
+jest.mock('./mutationBudget', () => ({ takeMutationSlot: jest.fn(() => true), WRITE_WINDOW_MS: 15 * 60 * 1000 }));
+
+const WineVintageProfile = require('../models/WineVintageProfile');
+const WineVintagePrice = require('../models/WineVintagePrice');
+const WineDefinition = require('../models/WineDefinition');
+const McpActionLog = require('../models/McpActionLog');
+const { logAudit } = require('../services/audit');
+const { allTools, toolsForScopes } = require('./registry');
+require('./tools');
+
+const oid = (c) => c.repeat(24);
+const ME = oid('a');
+const SOMM_CTX = { user: { id: ME, roles: ['somm'] }, scopes: ['read', 'write'], req: { user: { id: ME, roles: ['somm'] }, headers: {}, apiToken: { id: 't1' } } };
+const USER_CTX = { user: { id: ME, roles: ['user'] }, scopes: ['read', 'write'], req: { user: { id: ME, roles: ['user'] }, headers: {} } };
+
+const tool = (name) => allTools().find((t) => t.name === name);
+const parse = (res) => JSON.parse(res.content[0].text);
+const SOMM_TOOLS = ['list_maturity_queue', 'set_vintage_maturity', 'list_price_tracking_requests', 'set_vintage_price'];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  McpActionLog.create.mockResolvedValue({});
+});
+
+describe('role gating (structural + in-handler)', () => {
+  test('somm tools are INVISIBLE without the role, visible with somm or admin', () => {
+    const plain = toolsForScopes(['read', 'write'], ['user']).map((t) => t.name);
+    for (const n of SOMM_TOOLS) expect(plain).not.toContain(n);
+    const somm = toolsForScopes(['read', 'write'], ['somm']).map((t) => t.name);
+    const admin = toolsForScopes(['read', 'write'], ['admin']).map((t) => t.name);
+    for (const n of SOMM_TOOLS) {
+      expect(somm).toContain(n);
+      expect(admin).toContain(n);
+    }
+    // scope still applies on top of role: read-only somm token sees listers only
+    const readSomm = toolsForScopes(['read'], ['somm']).map((t) => t.name);
+    expect(readSomm).toContain('list_maturity_queue');
+    expect(readSomm).not.toContain('set_vintage_maturity');
+  });
+
+  test('defense-in-depth: handlers refuse a role-less ctx even if reached', async () => {
+    for (const n of SOMM_TOOLS) {
+      const res = await tool(n).handler({ profile_id: oid('1'), wine_id: oid('2'), vintage: 'NV', price: 1 }, USER_CTX);
+      expect(parse(res).error.code).toBe('forbidden_scope');
+    }
+  });
+});
+
+describe('list_maturity_queue', () => {
+  test('defaults to pending, reports the pending count, pages at ≤50', async () => {
+    WineVintageProfile.countDocuments.mockResolvedValueOnce(7).mockResolvedValueOnce(7);
+    WineVintageProfile.find.mockReturnValue(chain([{
+      _id: oid('1'), vintage: '2019', status: 'pending', relative: false,
+      wineDefinition: { _id: oid('f'), name: 'Barolo', producer: 'P', grapes: [] },
+    }]));
+    const res = await tool('list_maturity_queue').handler({}, SOMM_CTX);
+    const body = parse(res);
+    expect(body.summary).toMatch(/7 pending/);
+    expect(WineVintageProfile.find.mock.calls[0][0]).toEqual({ status: 'pending' });
+    expect(body.data[0].profile_id).toBe(oid('1'));
+    expect(body.data[0].phases).toHaveProperty('peakFrom', null);
+  });
+});
+
+describe('set_vintage_maturity', () => {
+  const profile = (over = {}) => {
+    const p = {
+      _id: oid('1'), vintage: '2019', status: 'pending', relative: false,
+      wineDefinition: { _id: oid('f'), name: 'Barolo' },
+      save: jest.fn().mockResolvedValue(undefined),
+      ...over,
+    };
+    WineVintageProfile.findById.mockReturnValue(chain(p));
+    return p;
+  };
+
+  test('year vintages validate 1900–2200; ordering enforced', async () => {
+    profile();
+    let res = await tool('set_vintage_maturity').handler({ profile_id: oid('1'), peak_from: 1500 }, SOMM_CTX);
+    expect(parse(res).error.message).toMatch(/1900–2200/);
+    profile();
+    res = await tool('set_vintage_maturity').handler({ profile_id: oid('1'), peak_from: 2030, peak_until: 2025 }, SOMM_CTX);
+    expect(parse(res).error.message).toMatch(/cannot be before/);
+    profile();
+    res = await tool('set_vintage_maturity').handler({ profile_id: oid('1'), early_from: 2030, peak_from: 2025 }, SOMM_CTX);
+    expect(parse(res).error.message).toMatch(/peak_from cannot be before early_from/);
+  });
+
+  test('NV vintages use relative offsets 0–100 and set relative=true', async () => {
+    const p = profile({ vintage: 'NV' });
+    let res = await tool('set_vintage_maturity').handler({ profile_id: oid('1'), peak_from: 1990 }, SOMM_CTX);
+    expect(parse(res).error.message).toMatch(/relative offsets 0–100/);
+    const p2 = profile({ vintage: 'NV' });
+    res = await tool('set_vintage_maturity').handler({ profile_id: oid('1'), peak_from: 1, peak_until: 5 }, SOMM_CTX);
+    expect(parse(res).error).toBeUndefined();
+    expect(p2.relative).toBe(true);
+    expect(p2.status).toBe('reviewed');
+  });
+
+  test('prev snapshot captures phases + review state for undo; audit uses the REST action string', async () => {
+    const p = profile({ peakFrom: 2020, peakUntil: 2030, status: 'reviewed', setBy: oid('b'), setAt: new Date('2026-01-01') });
+    await tool('set_vintage_maturity').handler({ profile_id: oid('1'), peak_from: 2026, peak_until: 2040 }, SOMM_CTX);
+    const row = McpActionLog.create.mock.calls[0][0];
+    expect(row.action).toBe('somm_maturity');
+    expect(row.prev).toMatchObject({ peakFrom: 2020, peakUntil: 2030, status: 'reviewed', setBy: oid('b') });
+    expect(logAudit).toHaveBeenCalledWith(SOMM_CTX.req, 'somm.maturity.review',
+      expect.anything(), expect.objectContaining({ via: 'mcp' }));
+    expect(p.setBy).toBe(ME);
+  });
+});
+
+describe('set_vintage_price', () => {
+  test('rejects unsupported currency; creates an append-only snapshot with setBy; ledger keeps entryId', async () => {
+    let res = await tool('set_vintage_price').handler({ wine_id: oid('f'), vintage: '2019', price: 100, currency: 'XXX' }, SOMM_CTX);
+    expect(parse(res).error.message).toMatch(/Unsupported currency/);
+
+    WineDefinition.findById.mockReturnValue(chain({ _id: oid('f'), name: 'Barolo' }));
+    const PriceTrackingRequest = require('../models/PriceTrackingRequest');
+    PriceTrackingRequest.findOne.mockReturnValue(chain(null));
+    res = await tool('set_vintage_price').handler({ wine_id: oid('f'), vintage: '2019', price: 100, currency: 'sek' }, SOMM_CTX);
+    const body = parse(res);
+    expect(body.error).toBeUndefined();
+    expect(body.data.currency).toBe('SEK');
+    const created = WineVintagePrice.mock.calls[0][0];
+    expect(created).toMatchObject({ vintage: '2019', price: 100, currency: 'SEK', setBy: ME });
+    const row = McpActionLog.create.mock.calls[0][0];
+    expect(row.action).toBe('somm_price');
+    expect(row.detail.entryId).toBe('price-1');
+    expect(logAudit).toHaveBeenCalledWith(SOMM_CTX.req, 'somm.price.add', expect.anything(), expect.objectContaining({ via: 'mcp' }));
+    // Requesters (none here) would be notified with the somm-prices link.
+    const { createNotification } = require('../services/notifications');
+    expect(createNotification).not.toHaveBeenCalled(); // no requesters on this pair
+  });
+});
+
+describe('undo of somm actions', () => {
+  test('undo somm_price deletes exactly the snapshot this user created; role re-checked', async () => {
+    const row = {
+      _id: 'sp', action: 'somm_price', reversed: false,
+      detail: { entryId: 'price-1', vintage: '2019' },
+    };
+    McpActionLog.findOne.mockReturnValue(chain(row));
+    // Role-less caller refused before any claim:
+    let res = await tool('undo_last').handler({}, { ...USER_CTX, scopes: ['consume', 'write'] });
+    expect(parse(res).error.code).toBe('forbidden_scope');
+    expect(McpActionLog.findOneAndUpdate).not.toHaveBeenCalled();
+
+    McpActionLog.findOneAndUpdate.mockResolvedValue(row);
+    WineVintagePrice.deleteOne.mockResolvedValue({ deletedCount: 1 });
+    res = await tool('undo_last').handler({}, { ...SOMM_CTX, scopes: ['consume', 'write'] });
+    expect(parse(res).data.undone).toBe('set_vintage_price');
+    expect(WineVintagePrice.deleteOne).toHaveBeenCalledWith({ _id: 'price-1', setBy: ME });
+  });
+
+  test('the somm undo record is viaUndo:true (excluded from candidacy → no undo-of-undo corruption)', async () => {
+    const row = { _id: 'sp', action: 'somm_price', reversed: false, detail: { entryId: 'price-1', vintage: '2019' } };
+    McpActionLog.findOne.mockReturnValue(chain(row));
+    McpActionLog.findOneAndUpdate.mockResolvedValue(row);
+    WineVintagePrice.deleteOne.mockResolvedValue({ deletedCount: 1 });
+    await tool('undo_last').handler({}, { ...SOMM_CTX, scopes: ['consume', 'write'] });
+    expect(McpActionLog.create.mock.calls.at(-1)[0]).toMatchObject({ action: 'somm_price', viaUndo: true });
+  });
+
+  test('undo somm_maturity re-applies the FULL prev snapshot (phases, notes, status, reviewer)', async () => {
+    const row = {
+      _id: 'sm', action: 'somm_maturity', reversed: false,
+      detail: { profileId: oid('1'), vintage: '2019' },
+      prev: { earlyFrom: null, earlyUntil: null, peakFrom: 2020, peakUntil: 2030, lateFrom: null, lateUntil: null, sommNotes: null, status: 'pending', relative: false, setBy: null, setAt: null },
+    };
+    McpActionLog.findOne.mockReturnValue(chain(row));
+    McpActionLog.findOneAndUpdate.mockResolvedValue(row);
+    const p = { _id: oid('1'), peakFrom: 2026, peakUntil: 2040, status: 'reviewed', save: jest.fn().mockResolvedValue(undefined) };
+    WineVintageProfile.findById.mockReturnValue(chain(p));
+    const res = await tool('undo_last').handler({}, { ...SOMM_CTX, scopes: ['consume', 'write'] });
+    expect(parse(res).data.undone).toBe('set_vintage_maturity');
+    expect(p.peakFrom).toBe(2020);
+    expect(p.peakUntil).toBe(2030);
+    expect(p.status).toBe('pending');
+    expect(p.setBy).toBeNull();
+    expect(p.save).toHaveBeenCalled();
+  });
+});

--- a/backend/src/mcp/tools/consume.js
+++ b/backend/src/mcp/tools/consume.js
@@ -163,12 +163,71 @@ registerTool({
       // must never gain delete-a-bottle power through undo.
       action: {
         $in: (ctx.scopes || []).includes('write')
-          ? ['consume', 'restore', 'add', 'update', 'bulk_add']
+          ? ['consume', 'restore', 'add', 'update', 'bulk_add', 'somm_maturity', 'somm_price']
           : ['consume', 'restore'],
       },
       createdAt: { $gte: new Date(Date.now() - RESTORE_WINDOW_MS) },
     }).sort({ createdAt: -1 });
     if (!last) return fail('not_found', 'No recent MCP action to undo — nothing has been changed through MCP in the last few days.');
+
+    // Somm curation rows reference registry data, not a bottle — handled first.
+    // The role is re-checked: a somm demoted since the action cannot keep
+    // rewriting shared data through undo.
+    if (last.action === 'somm_maturity' || last.action === 'somm_price') {
+      const roles = ctx.user?.roles || [];
+      if (!roles.includes('somm') && !roles.includes('admin')) {
+        return fail('forbidden_scope', 'Undoing sommelier curation needs the sommelier (or admin) role.');
+      }
+      // Load the maturity target BEFORE claiming the row, so a deleted
+      // profile leaves the ledger row un-consumed (retryable) instead of
+      // burning it on a no-op.
+      let profile = null;
+      if (last.action === 'somm_maturity') {
+        const WineVintageProfile = require('../../models/WineVintageProfile');
+        profile = await WineVintageProfile.findById(last.detail?.profileId);
+        if (!profile) return fail('conflict', 'That maturity profile no longer exists; nothing was changed.');
+      }
+      const claimed = await McpActionLog.findOneAndUpdate(
+        { _id: last._id, reversed: false },
+        { $set: { reversed: true, idempotencyKey: null } }
+      );
+      if (!claimed) return fail('conflict', 'That action is already being undone by another request.');
+
+      let sommEnvelope;
+      if (last.action === 'somm_price') {
+        const WineVintagePrice = require('../../models/WineVintagePrice');
+        const del = await WineVintagePrice.deleteOne({ _id: last.detail?.entryId, setBy: ctx.user.id });
+        sommEnvelope = {
+          summary: del.deletedCount
+            ? `Undid price entry — snapshot for vintage ${last.detail?.vintage} removed`
+            : 'Price snapshot was already gone; ledger marked undone.',
+          data: { undone: 'set_vintage_price', removed: !!del.deletedCount },
+        };
+      } else {
+        const prev = last.prev || {};
+        for (const f of ['earlyFrom', 'earlyUntil', 'peakFrom', 'peakUntil', 'lateFrom', 'lateUntil']) {
+          profile[f] = prev[f] === null || prev[f] === undefined ? undefined : prev[f];
+        }
+        profile.sommNotes = prev.sommNotes === null ? undefined : prev.sommNotes;
+        profile.status = prev.status || 'pending';
+        profile.relative = !!prev.relative;
+        profile.setBy = prev.setBy || null;
+        profile.setAt = prev.setAt || null;
+        await profile.save();
+        sommEnvelope = {
+          summary: `Undid maturity review — vintage ${last.detail?.vintage} back to ${profile.status}`,
+          data: { undone: 'set_vintage_maturity', profile_id: String(profile._id), status: profile.status },
+        };
+      }
+      await logAction(ctx, {
+        tool: 'undo_last',
+        action: last.action,
+        viaUndo: true,
+        detail: { undid: String(last._id) },
+        result: sommEnvelope,
+      });
+      return ok(sommEnvelope.summary, sommEnvelope.data);
+    }
 
     // Bulk rows reference MANY bottles (detail.bottles), no single last.bottle
     // — handled before the single-bottle access resolution below.

--- a/backend/src/mcp/tools/index.js
+++ b/backend/src/mcp/tools/index.js
@@ -16,6 +16,7 @@ require('./personal');
 require('./consume');
 require('./write');
 require('./bulk');
+require('./somm');
 require('./similar');
 
 module.exports = {};

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1,0 +1,320 @@
+// Sommelier MCP tools (plan Phase-2 somm note, per Johan): queue listing +
+// data entry for the SHARED recommendation data a somm curates. The killer
+// workflow: "anything in my maturity queue?" → set the windows → next.
+//
+// Role gating is STRUCTURAL: every tool here declares requireRole, so the
+// registry never even advertises them to non-somm callers (mcp/registry.js).
+// A defense-in-depth role re-check runs inside each handler anyway — the two
+// layers can only drift safely.
+//
+// Audit action strings are IDENTICAL to the REST somm routes (somm.maturity.
+// review, somm.price.add) so REST and MCP curation audit identically.
+const { z } = require('zod');
+const WineVintageProfile = require('../../models/WineVintageProfile');
+const WineVintagePrice = require('../../models/WineVintagePrice');
+const PriceTrackingRequest = require('../../models/PriceTrackingRequest');
+const WineDefinition = require('../../models/WineDefinition');
+const { registerTool } = require('../registry');
+const { logAudit } = require('../../services/audit');
+const { SUPPORTED_CURRENCIES } = require('../../config/currencies');
+const { isValidId } = require('../../utils/validation');
+const { ok, fail, objectId, pageParams } = require('../toolUtil');
+const { logAction } = require('../actionLedger');
+
+const SOMM_ROLES = ['somm', 'admin'];
+const PHASE_FIELDS = ['earlyFrom', 'earlyUntil', 'peakFrom', 'peakUntil', 'lateFrom', 'lateUntil'];
+const PRICE_STALE_MS = 90 * 24 * 60 * 60 * 1000; // mirror routes/somm/prices.js
+
+function requireSomm(ctx) {
+  const roles = ctx.user?.roles || [];
+  return SOMM_ROLES.some((r) => roles.includes(r))
+    ? null
+    : fail('forbidden_scope', 'This tool needs the sommelier (or admin) role.');
+}
+
+const wineLite = (wd) => (wd ? {
+  wine_id: wd._id,
+  name: wd.name,
+  producer: wd.producer || null,
+  type: wd.type || null,
+  country: wd.country?.name || null,
+  region: wd.region?.name || null,
+} : null);
+
+registerTool({
+  name: 'list_maturity_queue',
+  title: 'Sommelier: list the maturity queue',
+  description:
+    'Lists wine+vintage pairs awaiting drink-window review (every added bottle seeds one). Pending first, newest ' +
+    'first. Call when the somm asks "anything in my maturity queue?" or before a review session. Use the returned ' +
+    'profile_id with set_vintage_maturity.',
+  scope: 'read',
+  requireRole: SOMM_ROLES,
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    status: z.enum(['pending', 'reviewed', 'all']).default('pending'),
+    limit: z.number().int().min(1).max(50).default(20),
+    offset: z.number().int().min(0).default(0),
+  },
+  handler: async (args, ctx) => {
+    const denied = requireSomm(ctx);
+    if (denied) return denied;
+    const { limit, offset } = pageParams(args, 20, 50);
+    const status = args.status || 'pending';
+    const filter = status === 'all' ? {} : { status };
+    const [total, pending, profiles] = await Promise.all([
+      WineVintageProfile.countDocuments(filter),
+      WineVintageProfile.countDocuments({ status: 'pending' }),
+      WineVintageProfile.find(filter)
+        .sort({ status: 1, createdAt: -1 })
+        .skip(offset).limit(limit)
+        .populate({ path: 'wineDefinition', select: 'name producer type', populate: ['country', 'region'] })
+        .lean(),
+    ]);
+    const data = profiles.map((p) => ({
+      profile_id: p._id,
+      wine: wineLite(p.wineDefinition),
+      vintage: p.vintage,
+      status: p.status,
+      relative_nv: !!p.relative,
+      phases: PHASE_FIELDS.reduce((acc, f) => ((acc[f] = p[f] ?? null), acc), {}),
+    }));
+    return ok(`${pending} pending in the maturity queue (showing ${data.length} of ${total} ${status})`, data, {
+      page: { limit, offset, total },
+    });
+  },
+});
+
+registerTool({
+  name: 'set_vintage_maturity',
+  title: 'Sommelier: set a vintage\'s drink-window phases',
+  description:
+    'Fills in the maturity phases for one wine+vintage profile (from list_maturity_queue): early/peak/late, each a ' +
+    'from/until pair. Absolute years (1900–2200) — except NV vintages, which use RELATIVE year-offsets 0–100 from ' +
+    'release. Ordering: each until ≥ its from; peak_from ≥ early_from; late_from ≥ peak_from. Marks the profile ' +
+    'reviewed. This is SHARED data powering every user\'s recommendations — confirm the values with the somm first. ' +
+    'Reversible via undo_last.',
+  scope: 'write',
+  requireRole: SOMM_ROLES,
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  inputSchema: {
+    profile_id: objectId.describe('From list_maturity_queue'),
+    early_from: z.number().int().nullable().optional(),
+    early_until: z.number().int().nullable().optional(),
+    peak_from: z.number().int().nullable().optional(),
+    peak_until: z.number().int().nullable().optional(),
+    late_from: z.number().int().nullable().optional(),
+    late_until: z.number().int().nullable().optional(),
+    somm_notes: z.string().max(2000).optional(),
+  },
+  handler: async (args, ctx) => {
+    const denied = requireSomm(ctx);
+    if (denied) return denied;
+    const profile = await WineVintageProfile.findById(args.profile_id).populate('wineDefinition', 'name producer');
+    if (!profile) return fail('not_found', 'No such maturity profile. Use list_maturity_queue for valid ids.');
+
+    // Mirror REST validation exactly: NV → relative offsets [0,100], else
+    // absolute years [1900,2200] (routes/somm/maturity.js).
+    const isNv = profile.vintage === 'NV';
+    const [min, max] = isNv ? [0, 100] : [1900, 2200];
+    const incoming = {
+      earlyFrom: args.early_from, earlyUntil: args.early_until,
+      peakFrom: args.peak_from, peakUntil: args.peak_until,
+      lateFrom: args.late_from, lateUntil: args.late_until,
+    };
+    const next = {};
+    for (const f of PHASE_FIELDS) {
+      const v = incoming[f];
+      if (v === undefined) { next[f] = profile[f] ?? null; continue; }
+      if (v === null) { next[f] = null; continue; }
+      if (v < min || v > max) {
+        return fail('invalid_input', `${f}: ${v} out of range (${isNv ? 'NV uses relative offsets 0–100' : 'years 1900–2200'})`);
+      }
+      next[f] = v;
+    }
+    const pairs = [['earlyFrom', 'earlyUntil'], ['peakFrom', 'peakUntil'], ['lateFrom', 'lateUntil']];
+    for (const [from, until] of pairs) {
+      if (next[from] != null && next[until] != null && next[until] < next[from]) {
+        return fail('invalid_input', `${until} cannot be before ${from}`);
+      }
+    }
+    if (next.earlyFrom != null && next.peakFrom != null && next.peakFrom < next.earlyFrom) {
+      return fail('invalid_input', 'peak_from cannot be before early_from');
+    }
+    if (next.peakFrom != null && next.lateFrom != null && next.lateFrom < next.peakFrom) {
+      return fail('invalid_input', 'late_from cannot be before peak_from');
+    }
+
+    // Snapshot for undo: phases + notes + review state, restored verbatim.
+    const prev = {
+      ...PHASE_FIELDS.reduce((acc, f) => ((acc[f] = profile[f] ?? null), acc), {}),
+      sommNotes: profile.sommNotes ?? null,
+      status: profile.status,
+      relative: profile.relative,
+      setBy: profile.setBy ? String(profile.setBy) : null,
+      setAt: profile.setAt || null,
+    };
+
+    for (const f of PHASE_FIELDS) profile[f] = next[f] === null ? undefined : next[f];
+    if (args.somm_notes !== undefined) profile.sommNotes = args.somm_notes;
+    profile.relative = isNv;
+    profile.status = 'reviewed';
+    profile.setBy = ctx.user.id;
+    profile.setAt = new Date();
+    await profile.save();
+
+    logAudit(ctx.req, 'somm.maturity.review',
+      { type: 'wine', id: profile.wineDefinition?._id || profile.wineDefinition },
+      { vintage: profile.vintage, relative: isNv, via: 'mcp' });
+
+    const envelope = {
+      summary: `Maturity set for ${profile.wineDefinition?.name || 'wine'} ${profile.vintage} (reviewed)`,
+      data: {
+        profile_id: profile._id,
+        vintage: profile.vintage,
+        relative_nv: isNv,
+        phases: next,
+        undo: 'undo_last restores the previous values and review state',
+      },
+    };
+    await logAction(ctx, {
+      tool: 'set_vintage_maturity',
+      action: 'somm_maturity',
+      detail: { profileId: String(profile._id), vintage: profile.vintage },
+      prev,
+      result: envelope,
+    });
+    return ok(envelope.summary, envelope.data);
+  },
+});
+
+registerTool({
+  name: 'list_price_tracking_requests',
+  title: 'Sommelier: list the price-request queue',
+  description:
+    'Lists wine+vintage pairs users have asked to have price-tracked, where no price exists yet or the latest is ' +
+    'older than 3 months. Most-requested first. Call when the somm asks "any price requests waiting?"; fulfil with ' +
+    'set_vintage_price.',
+  scope: 'read',
+  requireRole: SOMM_ROLES,
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    limit: z.number().int().min(1).max(50).default(20),
+  },
+  handler: async (args, ctx) => {
+    const denied = requireSomm(ctx);
+    if (denied) return denied;
+    const limit = Math.min(Math.max(parseInt(args.limit, 10) || 20, 1), 50);
+    const requests = await PriceTrackingRequest.find({})
+      .populate({ path: 'wineDefinition', select: 'name producer type', populate: ['country', 'region'] })
+      .lean();
+    const alive = requests.filter((r) => r.wineDefinition);
+
+    // Actionable = no price yet, or latest snapshot stale (>90d) — mirrors
+    // routes/somm/prices.js GET /queue.
+    const latestByPair = new Map();
+    if (alive.length) {
+      const rows = await WineVintagePrice.aggregate([
+        { $match: { wineDefinition: { $in: alive.map((r) => r.wineDefinition._id) } } },
+        { $sort: { setAt: 1 } },
+        { $group: { _id: { w: '$wineDefinition', v: '$vintage' }, price: { $last: '$price' }, currency: { $last: '$currency' }, setAt: { $last: '$setAt' } } },
+      ]);
+      for (const row of rows) latestByPair.set(`${row._id.w}:${row._id.v}`, row);
+    }
+    const now = Date.now();
+    const actionable = alive
+      .map((r) => ({ r, latest: latestByPair.get(`${r.wineDefinition._id}:${r.vintage}`) || null }))
+      .filter(({ latest }) => !latest || now - new Date(latest.setAt).getTime() > PRICE_STALE_MS)
+      .sort((a, b) => (b.r.requesters?.length || 0) - (a.r.requesters?.length || 0)
+        || new Date(a.r.firstRequestedAt || 0) - new Date(b.r.firstRequestedAt || 0));
+
+    const data = actionable.slice(0, limit).map(({ r, latest }) => ({
+      request_id: r._id,
+      wine: wineLite(r.wineDefinition),
+      vintage: r.vintage,
+      requester_count: r.requesters?.length || 0,
+      first_requested_at: r.firstRequestedAt || null,
+      latest_price: latest ? { price: latest.price, currency: latest.currency, set_at: latest.setAt } : null,
+    }));
+    return ok(`${actionable.length} actionable price request(s)${actionable.length > limit ? ` (showing ${limit})` : ''}`, data);
+  },
+});
+
+registerTool({
+  name: 'set_vintage_price',
+  title: 'Sommelier: add a price valuation for a vintage',
+  description:
+    'Records a new price snapshot for one wine+vintage (price history accumulates — this never overwrites). ' +
+    'Requesters are notified, and the pair leaves the price queue until the snapshot goes stale. This is SHARED ' +
+    'valuation data — confirm price, currency and source with the somm first. Reversible via undo_last (removes the ' +
+    'snapshot).',
+  scope: 'write',
+  requireRole: SOMM_ROLES,
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  inputSchema: {
+    wine_id: objectId,
+    vintage: z.string().min(1).max(10),
+    price: z.number().min(0),
+    currency: z.string().regex(/^[A-Za-z]{3}$/).optional().describe('Default USD'),
+    source: z.string().max(100).optional().describe('e.g. auction, retail, Systembolaget'),
+    somm_notes: z.string().max(2000).optional(),
+  },
+  handler: async (args, ctx) => {
+    const denied = requireSomm(ctx);
+    if (denied) return denied;
+    const currency = String(args.currency || 'USD').toUpperCase();
+    if (!SUPPORTED_CURRENCIES.includes(currency)) {
+      return fail('invalid_input', `Unsupported currency ${currency}. Supported: ${SUPPORTED_CURRENCIES.join(', ')}`);
+    }
+    if (!isValidId(args.wine_id)) return fail('invalid_input', 'wine_id must be a 24-hex id.');
+    const wine = await WineDefinition.findById(args.wine_id).select('name producer');
+    if (!wine) return fail('not_found', 'No registry wine with that id.');
+
+    const entry = new WineVintagePrice({
+      wineDefinition: wine._id,
+      vintage: String(args.vintage).trim(),
+      price: args.price,
+      currency,
+      source: args.source?.trim() || undefined,
+      sommNotes: args.somm_notes?.trim() || undefined,
+      setBy: ctx.user.id,
+    });
+    await entry.save();
+
+    require('../../utils/exchangeRates').getOrCreateDailySnapshot().catch(() => {});
+    // Notify requesters exactly like REST (best-effort).
+    PriceTrackingRequest.findOne({ wineDefinition: wine._id, vintage: entry.vintage }).lean()
+      .then((reqDoc) => {
+        if (!reqDoc?.requesters?.length) return;
+        const { createNotification } = require('../../services/notifications');
+        for (const { user } of reqDoc.requesters) {
+          createNotification(user, 'price_tracked', 'Price added',
+            `${wine.name} ${entry.vintage}: ${entry.price} ${entry.currency}`,
+            '/somm/prices', 'community').catch(() => {}); // link parity with REST
+        }
+      }).catch(() => {});
+
+    logAudit(ctx.req, 'somm.price.add',
+      { type: 'wine', id: wine._id },
+      { vintage: entry.vintage, price: entry.price, currency: entry.currency, via: 'mcp' });
+
+    const envelope = {
+      summary: `Price recorded: ${wine.name} ${entry.vintage} = ${entry.price} ${entry.currency}`,
+      data: {
+        price_entry_id: entry._id,
+        wine_id: wine._id,
+        vintage: entry.vintage,
+        price: entry.price,
+        currency: entry.currency,
+        undo: 'undo_last removes this snapshot',
+      },
+    };
+    await logAction(ctx, {
+      tool: 'set_vintage_price',
+      action: 'somm_price',
+      detail: { entryId: String(entry._id), wineId: String(wine._id), vintage: entry.vintage },
+      result: envelope,
+    });
+    return ok(envelope.summary, envelope.data);
+  },
+});

--- a/backend/src/models/McpActionLog.js
+++ b/backend/src/models/McpActionLog.js
@@ -22,7 +22,7 @@ const mcpActionLogSchema = new mongoose.Schema({
   // (JWT) called the MCP directly. Never store the token itself.
   tokenId: { type: mongoose.Schema.Types.ObjectId, ref: 'ApiToken', default: null },
   tool: { type: String, required: true },
-  action: { type: String, enum: ['consume', 'restore', 'add', 'update', 'undo_add', 'bulk_preview', 'bulk_add'], required: true },
+  action: { type: String, enum: ['consume', 'restore', 'add', 'update', 'undo_add', 'bulk_preview', 'bulk_add', 'somm_maturity', 'somm_price'], required: true },
   bottle: { type: mongoose.Schema.Types.ObjectId, ref: 'Bottle' },
   cellar: { type: mongoose.Schema.Types.ObjectId, ref: 'Cellar' },
   // Small, non-PII operational detail (reason, ml, …) for the timeline.


### PR DESCRIPTION
> **Stack: #711 → #712 → #713 → this.** Merge in order; I rebase each layer after its parent.

## What this is (Johan's ask)

Sommeliers/admins can drive the curation queues from their AI — and crucially the **queue listing** that turns it into a workflow: *"anything in my maturity queue?"* → *"65 pending"* → set the windows → next.

| Tool | | |
|---|---|---|
| `list_maturity_queue` | read | pending-first, **pending count up front** |
| `set_vintage_maturity` | write | 6 phase fields; NV→relative 0–100, else years 1900–2200; ordering enforced; marks reviewed |
| `list_price_tracking_requests` | read | actionable queue (no price / >3mo stale), most-requested first |
| `set_vintage_price` | write | append-only valuation snapshot; notifies requesters |

## Role gating — structural, not just a reject

The tool registry gained per-tool **`requireRole`**: these tools are **invisible in `tools/list`** to non-somm callers (`toolsForScopes(scopes, roles)`; server passes `ctx.user.roles`). Roles are **fresh-from-User on every `cel_` request** (revoke somm → tools vanish immediately); JWT sessions are bounded by the 15-min access token, *identical staleness to the REST `requireSommOrAdmin` path*. A defense-in-depth in-handler re-check backs it up — including on `undo_last`, so a demoted somm can't keep rewriting shared data.

## Parity + safety

Validation, side effects (FX snapshot, requester notifications), and **audit action strings** (`somm.maturity.review`, `somm.price.add`) mirror the REST somm routes exactly — REST and MCP curate identically. `undo_last` handles both: maturity restores the full prev snapshot (phases + notes + status + reviewer), price deletes the exact snapshot this user created. Writers ride the per-user mutation budget; listers are free.

## Audit + verification

- Read-only adversarial audit: **no High/Med.** Two Low parity nits fixed (notification click-through link; maturity-undo loads the profile before claiming the ledger row). Added undo-of-undo (`viaUndo`) coverage.
- **Live on real data:** non-somm user can't see the tools; admin gets *"65 pending in the maturity queue"*; `set_vintage_maturity` → undo restores pending; `set_vintage_price` (SEK) → undo removes it.
- **Full suite: 96 suites / 1535 tests green** in `node:20-alpine`.

No new dependencies. **docker-compose impact: none.** (The write-scope mint UI + these tools' Swedish-facing copy land with the 2d connect-page work.)