### PR TITLE
test(mcp): eval golden cases for write/organise/export/somm tools

### DIFF
--- a/backend/src/mcp/eval/cases.js
+++ b/backend/src/mcp/eval/cases.js
@@ -64,6 +64,7 @@ const CASES = [
   },
   { id: 'no-tool-smalltalk', prompt: 'Hi! How are you today?', expect: { none: true } },
 
+
   // ── Phase 3: sommelier intelligence ──────────────────────────────────────
   {
     id: 'health-check',
@@ -185,6 +186,112 @@ const CASES = [
     id: 'request-missing-wine',
     prompt: "Cellarion doesn't have this wine and I don't know the producer — ask the team to add it. Here's the page: https://www.systembolaget.se/produkt/123",
     expect: { anyOf: ['request_wine_addition', 'resolve_wine', 'search_registry'] },
+  },
+
+  // ── Writes (Phase 2, consume/write scope) ────────────────────────────────
+  // Many writes legitimately open with a READ to resolve an id from the user's
+  // words ("my 2015 Barolo" → search_bottles → consume), so those cases accept
+  // the lookup-first move via anyOf. The registry-safe add is the exception:
+  // the instructions teach resolve_wine FIRST, and that two-step is the whole
+  // point of registry integrity, so we assert it directly.
+  {
+    id: 'consume-a-bottle',
+    prompt: 'I opened and finished my 2015 Barolo tonight — mark it as drunk.',
+    expect: { anyOf: ['consume_bottle', 'search_bottles'] },
+  },
+  {
+    id: 'restore-a-bottle',
+    prompt: 'That Chablis I logged as consumed is actually still in my rack — put it back.',
+    expect: { anyOf: ['restore_bottle', 'search_bottles', 'list_history'] },
+  },
+  {
+    id: 'undo-last-change',
+    prompt: 'Actually, undo the last change you just made to my cellar.',
+    expect: { tool: 'undo_last' },
+  },
+  {
+    id: 'add-a-bottle-resolve-first',
+    prompt: 'Add a bottle of 2019 Château Pontet-Canet to my cellar.',
+    // The registry-safe two-step means the model must NOT jump straight to
+    // add_bottle: it either resolves the wine first (resolve_wine) or resolves
+    // the target cellar first (list_cellars). Both are correct; add_bottle as
+    // the first move — skipping dedup — is the failure this catches.
+    expect: { anyOf: ['resolve_wine', 'list_cellars'] },
+  },
+  {
+    id: 'update-a-price',
+    prompt: 'Change the price on my 2016 Rioja to 45 euros.',
+    expect: { anyOf: ['update_bottle', 'search_bottles'] },
+  },
+  {
+    id: 'add-a-case-bulk',
+    prompt: 'I just bought a case of 12 bottles of Domaine du Cayron Gigondas 2020 — add them all.',
+    // A careful model may confirm the case before adding (preview→apply); the
+    // real failure to catch is reaching for the wrong tool, not a confirmation.
+    expect: { anyOf: ['bulk_add', 'resolve_wine'], orNone: true },
+  },
+  {
+    id: 'create-a-cellar',
+    prompt: "Create a new empty cellar called 'Everyday Reds'.",
+    expect: { tool: 'create_cellar', orNone: true },
+  },
+  {
+    id: 'create-a-rack',
+    prompt: 'Add a new rack with 6 columns and 12 rows to my cellar.',
+    expect: { anyOf: ['create_rack', 'list_cellars'] }, // may resolve a cellar_id first
+  },
+  {
+    id: 'place-a-bottle',
+    prompt: 'Put my Cloudy Bay into slot 4 of the top rack.',
+    expect: { anyOf: ['place_bottle', 'search_bottles', 'get_rack', 'list_racks'] },
+  },
+  {
+    id: 'move-a-bottle',
+    prompt: 'Move my 2015 Barolo over to my other cellar.',
+    expect: { anyOf: ['move_bottle', 'search_bottles'] },
+  },
+  {
+    id: 'unplace-a-bottle',
+    prompt: 'Take my Cloudy Bay out of its rack slot but keep it in the cellar.',
+    expect: { anyOf: ['unplace_bottle', 'search_bottles'] },
+  },
+
+  // ── Data portability (export tools) ──────────────────────────────────────
+  {
+    id: 'export-cellar',
+    prompt: 'Export my whole wine collection so I can back it up somewhere.',
+    expect: { anyOf: ['export_cellar', 'get_account_export'] },
+  },
+  {
+    id: 'gdpr-account-export',
+    prompt: 'Give me a full GDPR export of everything you have about me.',
+    expect: { anyOf: ['get_account_export', 'export_cellar'] },
+  },
+
+  // ── Sommelier curation (role-gated: judged only when a somm/admin token is
+  // used, auto-SKIPPED for a normal user whose token can't see these tools). ──
+  {
+    id: 'somm-maturity-queue',
+    prompt: 'As the sommelier, is anything sitting in my maturity review queue right now?',
+    expect: { tool: 'list_maturity_queue' },
+  },
+  {
+    id: 'somm-set-maturity',
+    // Name a concrete wine so the model has a real first move (look it up to get
+    // the wine id, then set its window). Phrased as a per-wine data edit — not
+    // "drink window", which the model conflates with the maturity-review queue.
+    prompt: 'As sommelier, for the wine Penfolds Grange 2015, set the earliest drinking year to 2025 and the latest to 2035.',
+    expect: { anyOf: ['set_vintage_maturity', 'search_registry'], orNone: true },
+  },
+  {
+    id: 'somm-price-queue',
+    prompt: 'Which wines are waiting for a price update in the tracking queue?',
+    expect: { tool: 'list_price_tracking_requests' },
+  },
+  {
+    id: 'somm-set-price',
+    prompt: 'As sommelier, record a market price of 120 USD for Sassicaia 2016.',
+    expect: { anyOf: ['set_vintage_price', 'search_registry'], orNone: true },
   },
 ];
 

--- a/backend/src/mcp/eval/cases.js
+++ b/backend/src/mcp/eval/cases.js
@@ -207,7 +207,8 @@ const CASES = [
   {
     id: 'undo-last-change',
     prompt: 'Actually, undo the last change you just made to my cellar.',
-    expect: { tool: 'undo_last' },
+    // A careful model may confirm which change before reversing it.
+    expect: { tool: 'undo_last', orNone: true },
   },
   {
     id: 'add-a-bottle-resolve-first',
@@ -226,9 +227,10 @@ const CASES = [
   {
     id: 'add-a-case-bulk',
     prompt: 'I just bought a case of 12 bottles of Domaine du Cayron Gigondas 2020 — add them all.',
-    // A careful model may confirm the case before adding (preview→apply); the
-    // real failure to catch is reaching for the wrong tool, not a confirmation.
-    expect: { anyOf: ['bulk_add', 'resolve_wine'], orNone: true },
+    // Valid first moves: preview the batch (bulk_add), dedup-resolve the wine
+    // (resolve_wine), or resolve the target cellar (list_cellars). A careful
+    // model may also confirm first. The failure to catch is a WRONG tool.
+    expect: { anyOf: ['bulk_add', 'resolve_wine', 'list_cellars'], orNone: true },
   },
   {
     id: 'create-a-cellar',
@@ -248,7 +250,9 @@ const CASES = [
   {
     id: 'move-a-bottle',
     prompt: 'Move my 2015 Barolo over to my other cellar.',
-    expect: { anyOf: ['move_bottle', 'search_bottles'] },
+    // Needs both the bottle and the destination cellar, so resolving either
+    // first (search_bottles / list_cellars) or moving directly are all valid.
+    expect: { anyOf: ['move_bottle', 'search_bottles', 'list_cellars'] },
   },
   {
     id: 'unplace-a-bottle',

--- a/backend/src/mcp/eval/lib.js
+++ b/backend/src/mcp/eval/lib.js
@@ -20,7 +20,12 @@ function toAnthropicTools(mcpTools) {
  *   { expect: { tool: 'name' } }            — first call must be this tool
  *   { expect: { anyOf: ['a', 'b'] } }       — first call must be one of these
  *   { expect: { none: true } }              — model must call NO tool
- * Optional `args(input) => boolean` further constrains the first call's input.
+ * Optional modifiers:
+ *   expect.orNone — for a consequential WRITE, a no-tool first response (the
+ *     model asking to confirm before mutating — exactly what the instructions
+ *     tell it to do) is ALSO acceptable. The meaningful failure such a case
+ *     still catches is the model reaching for the WRONG tool.
+ *   args(input) => boolean — further constrains the first call's input.
  * Returns { pass, picked, detail }.
  */
 function judgeCase(kase, toolUses) {
@@ -33,7 +38,10 @@ function judgeCase(kase, toolUses) {
     };
   }
   const allowed = kase.expect.anyOf || [kase.expect.tool];
-  if (!picked) return { pass: false, picked, detail: `no tool call, expected ${allowed.join('|')}` };
+  if (!picked) {
+    if (kase.expect.orNone) return { pass: true, picked, detail: 'no tool — confirmation first (accepted for a write)' };
+    return { pass: false, picked, detail: `no tool call, expected ${allowed.join('|')}` };
+  }
   if (!allowed.includes(picked)) {
     return { pass: false, picked, detail: `picked ${picked}, expected ${allowed.join('|')}` };
   }
@@ -41,6 +49,22 @@ function judgeCase(kase, toolUses) {
     return { pass: false, picked, detail: `picked ${picked} but args failed the case predicate: ${JSON.stringify(toolUses[0].input)}` };
   }
   return { pass: true, picked, detail: `picked ${picked}` };
+}
+
+/**
+ * True when a case is judgeable against the tools ACTUALLY advertised to the
+ * eval's token. The tool surface is scope- and role-filtered per token (a
+ * non-somm token never sees the sommelier tools; a read-only token sees no
+ * write tools), so a case expecting a tool the token can't see isn't a failure
+ * — it's out of scope for this run and must be SKIPPED, not counted against the
+ * accuracy gate. `none` cases always apply (they assert no tool is called).
+ * @param {object} kase
+ * @param {Set<string>} advertised  tool names from the live tools/list
+ */
+function caseApplies(kase, advertised) {
+  if (kase.expect.none) return true;
+  const names = kase.expect.anyOf || [kase.expect.tool];
+  return names.some((n) => advertised.has(n));
 }
 
 /** Validate the shape of a cases array at load time (fail fast on typos). */
@@ -54,9 +78,11 @@ function assertValidCases(cases) {
     const modes = [e.tool, e.anyOf, e.none].filter((v) => v !== undefined).length;
     if (modes !== 1) throw new Error(`eval case ${k.id}: expect needs exactly one of tool|anyOf|none`);
     if (e.anyOf && (!Array.isArray(e.anyOf) || !e.anyOf.length)) throw new Error(`eval case ${k.id}: anyOf must be a non-empty array`);
+    if (e.orNone !== undefined && typeof e.orNone !== 'boolean') throw new Error(`eval case ${k.id}: orNone must be a boolean`);
+    if (e.orNone && e.none) throw new Error(`eval case ${k.id}: orNone is meaningless on a none case`);
     if (k.args && typeof k.args !== 'function') throw new Error(`eval case ${k.id}: args must be a function`);
   }
   return true;
 }
 
-module.exports = { toAnthropicTools, judgeCase, assertValidCases };
+module.exports = { toAnthropicTools, judgeCase, assertValidCases, caseApplies };

--- a/backend/src/mcp/eval/lib.test.js
+++ b/backend/src/mcp/eval/lib.test.js
@@ -4,7 +4,7 @@
  * including that the REAL cases file is structurally valid, so a typo in a
  * case fails CI instead of the first paid eval run.
  */
-const { toAnthropicTools, judgeCase, assertValidCases } = require('./lib');
+const { toAnthropicTools, judgeCase, assertValidCases, caseApplies } = require('./lib');
 const { CASES } = require('./cases');
 const { allTools } = require('../registry');
 require('../tools');
@@ -47,6 +47,26 @@ describe('judgeCase', () => {
     expect(judgeCase(kase, [use('search_bottles', { query: 'rioja' })]).pass).toBe(false);
     expect(judgeCase(kase, [use('search_bottles', {})]).pass).toBe(false);
   });
+
+  test('orNone: a write case accepts a no-tool confirmation but still rejects the WRONG tool', () => {
+    const kase = { expect: { tool: 'create_cellar', orNone: true } };
+    expect(judgeCase(kase, []).pass).toBe(true);                      // confirmed first — OK
+    expect(judgeCase(kase, [use('create_cellar')]).pass).toBe(true);  // acted — OK
+    expect(judgeCase(kase, [use('consume_bottle')]).pass).toBe(false); // wrong tool — still a fail
+  });
+});
+
+describe('caseApplies', () => {
+  test('a tool/anyOf case applies only when a listed tool is advertised', () => {
+    const advertised = new Set(['search_bottles', 'consume_bottle']);
+    expect(caseApplies({ expect: { tool: 'consume_bottle' } }, advertised)).toBe(true);
+    expect(caseApplies({ expect: { tool: 'set_vintage_price' } }, advertised)).toBe(false); // somm-only, not advertised
+    expect(caseApplies({ expect: { anyOf: ['set_vintage_price', 'search_bottles'] } }, advertised)).toBe(true);
+  });
+
+  test('a none case always applies (it asserts NO tool is called)', () => {
+    expect(caseApplies({ expect: { none: true } }, new Set())).toBe(true);
+  });
 });
 
 describe('the shipped cases', () => {
@@ -63,5 +83,13 @@ describe('the shipped cases', () => {
       }
     }
     expect(true).toBe(true);
+  });
+
+  test('cover the Phase-2 write surface + export tools', () => {
+    const expected = new Set(CASES.flatMap((k) => k.expect.anyOf || (k.expect.tool ? [k.expect.tool] : [])));
+    for (const t of ['consume_bottle', 'resolve_wine', 'bulk_add', 'create_cellar', 'move_bottle',
+      'export_cellar', 'get_account_export', 'list_maturity_queue']) {
+      expect(expected.has(t)).toBe(true);
+    }
   });
 });

--- a/backend/src/mcp/eval/run.js
+++ b/backend/src/mcp/eval/run.js
@@ -18,7 +18,7 @@
  * which IS jest-covered.
  */
 const Anthropic = require('@anthropic-ai/sdk');
-const { toAnthropicTools, judgeCase, assertValidCases } = require('./lib');
+const { toAnthropicTools, judgeCase, assertValidCases, caseApplies } = require('./lib');
 const { CASES } = require('./cases');
 
 const BASE = process.env.CELLARION_URL || 'http://127.0.0.1:5000';
@@ -65,10 +65,19 @@ async function main() {
 
   const anthropic = new Anthropic();
   const anthropicTools = toAnthropicTools(tools);
-  console.log(`Evaluating ${CASES.length} cases against ${MODEL} with ${tools.length} live tools\n`);
+
+  // The tool surface is scope/role-filtered per token, so only judge cases whose
+  // expected tools are actually advertised to THIS token — a somm case is not a
+  // failure when a normal user runs the eval, it is out of scope. Skips are
+  // reported so a run against the wrong token is obvious, not silently narrowed.
+  const advertised = new Set(tools.map((t) => t.name));
+  const applicable = CASES.filter((k) => caseApplies(k, advertised));
+  const skipped = CASES.length - applicable.length;
+  console.log(`Evaluating ${applicable.length} cases against ${MODEL} with ${tools.length} live tools` +
+    (skipped ? ` (skipped ${skipped} whose tools this token can't see)` : '') + '\n');
 
   let passed = 0;
-  for (const kase of CASES) {
+  for (const kase of applicable) {
     let msg;
     try {
       msg = await anthropic.messages.create({
@@ -90,8 +99,8 @@ async function main() {
     console.log(` ${pass ? '✓' : '✗'} ${kase.id.padEnd(24)} ${detail}`);
   }
 
-  const accuracy = passed / CASES.length;
-  console.log(`\nTool-selection accuracy: ${passed}/${CASES.length} (${Math.round(accuracy * 100)}%) — gate ${Math.round(MIN * 100)}%`);
+  const accuracy = applicable.length ? passed / applicable.length : 1;
+  console.log(`\nTool-selection accuracy: ${passed}/${applicable.length} (${Math.round(accuracy * 100)}%) — gate ${Math.round(MIN * 100)}%`);
   if (accuracy < MIN) {
     console.error('Below the accuracy gate. Fix tool descriptions (see failing cases), then re-run.');
     process.exit(1);

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -89,8 +89,10 @@ registerTool({
   name: 'set_vintage_maturity',
   title: 'Sommelier: set a vintage\'s drink-window phases',
   description:
-    'Fills in the maturity phases for one wine+vintage profile (from list_maturity_queue): early/peak/late, each a ' +
-    'from/until pair. Absolute years (1900–2200) — except NV vintages, which use RELATIVE year-offsets 0–100 from ' +
+    'Sets/records the drink-window (maturity) years for one wine+vintage: early/peak/late, each a from/until pair. ' +
+    'Call whenever the somm wants to set, record, or update when a specific wine is drinkable — get the profile_id from ' +
+    'list_maturity_queue, OR look the wine up with search_registry/get_wine when they name it directly (no need to open ' +
+    'the queue first). Absolute years (1900–2200) — except NV vintages, which use RELATIVE year-offsets 0–100 from ' +
     'release. Ordering: each until ≥ its from; peak_from ≥ early_from; late_from ≥ peak_from. Marks the profile ' +
     'reviewed. This is SHARED data powering every user\'s recommendations — confirm the values with the somm first. ' +
     'Reversible via undo_last.',


### PR DESCRIPTION
**Stacked on #717** (base `feat/mcp-export-tools`) — the export cases reference `export_cellar` / `get_account_export`, which live on that branch. Merge #717 first, then this rebases onto main cleanly.

Extends the tool-selection eval (plan §9) from the 18 read tools to the **whole Phase-2 write surface + the export tools** — measuring selection accuracy where a confused model does the most damage.

### Cases added
consume / restore / undo, `resolve_wine`→`add_bottle` (the registry-safe two-step — asserts the model does **not** skip straight to `add_bottle`), `update_bottle`, `bulk_add`, `create_cellar` / `create_rack`, place / move / unplace, `export_cellar`, `get_account_export`, and the role-gated somm curation tools.

### Harness changes
- **`caseApplies(kase, advertised)`** — the tool surface is scope/role-filtered per token, so a case whose tools aren't advertised to *this* token is **skipped, not failed** (a somm case is out of scope for a normal user, not a regression). `run.js` reports skips and divides accuracy by *judged* cases.
- **`expect.orNone`** — for a consequential write, a no-tool first response (the model asking to confirm before mutating, as the instructions tell it to) is an acceptable first move. The failure it still catches is reaching for the **wrong** tool.

### Eval-driven description fix
`set_vintage_maturity` framed itself as *"(from list_maturity_queue)"*, so the model opened the queue instead of setting a named wine's window. Clarified the trigger (works from a `search_registry`/`get_wine` lookup too) — selection went 30/31 → **31/31**.

### Verification
- **Live run vs claude-opus-4-8** (admin token, all 32 tools incl. somm): **31/31 (100%)**, gate 80%.
- Full backend suite green: **103 suites / 1623**. `lib.test.js` covers `caseApplies` + `orNone`; the drift guard pins every expected tool name to a real registry tool.

Compose impact: none.