### PR TITLE
feat(mcp): label the AI connector as Beta, used at your own risk

### DIFF
--- a/frontend/src/components/AiConnectSection.js
+++ b/frontend/src/components/AiConnectSection.js
@@ -85,7 +85,18 @@ export default function AiConnectSection() {
 
   return (
     <div className="card settings-card">
-      <h2 className="settings-section-title">{t('settings.aiConnect.title', 'Connect your AI')}</h2>
+      <h2 className="settings-section-title">
+        {t('settings.aiConnect.title', 'Connect your AI')}
+        <span className="settings-beta-badge">{t('settings.aiConnect.beta', 'Beta')}</span>
+      </h2>
+      {/* Shipped to production deliberately early so it gets real use — say so
+          plainly rather than letting people discover the rough edges the hard
+          way. The reassurance is real (read-only default, reversible, instant
+          revoke), so the warning doesn't need to be alarming to be honest. */}
+      <div className="alert alert-info">
+        {t('settings.aiConnect.betaNotice',
+          'This is a beta feature and you use it at your own risk. It works, but it is new and still being tested — expect rough edges, and changes while we refine it. If you are unsure, connect with a read-only token: anything an AI changes can be undone under "What your AI has changed", and revoking the token cuts it off instantly.')}
+      </div>
       <p className="settings-hint">
         {t('settings.aiConnect.hint',
           'Talk to your cellar from Claude Desktop, Claude Code, or any MCP-capable assistant: ask what to open tonight, where a bottle is stored, or what your collection is worth. Connections are read-only and use a personal token you can revoke at any time.')}

--- a/frontend/src/components/AiConnectSection.test.js
+++ b/frontend/src/components/AiConnectSection.test.js
@@ -26,9 +26,19 @@ afterEach(() => {
 });
 
 describe('AiConnectSection', () => {
+  test('is labelled Beta and says plainly that it is used at your own risk', () => {
+    render(<AiConnectSection />);
+    // The badge rides in the heading, so the accessible name carries it too.
+    expect(screen.getByRole('heading', { name: /Connect your AI\s+Beta/ })).toBeInTheDocument();
+    expect(screen.getByText(/beta feature and you use it at your own risk/i)).toBeInTheDocument();
+    // The reassurances that make the warning honest rather than just scary.
+    expect(screen.getByText(/read-only token/i)).toBeInTheDocument();
+    expect(screen.getByText(/revoking the token cuts it off instantly/i)).toBeInTheDocument();
+  });
+
   test('renders all three configs with a placeholder token and, off-cellarion.app, a CELLARION_URL override', () => {
     const { container } = render(<AiConnectSection />);
-    expect(screen.getByRole('heading', { name: 'Connect your AI' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Connect your AI/ })).toBeInTheDocument();
     const texts = snippetTexts(container);
     expect(texts).toHaveLength(3);
     for (const t of texts) expect(t).toContain('cel_YOUR_TOKEN_HERE');

--- a/frontend/src/components/McpActivitySection.js
+++ b/frontend/src/components/McpActivitySection.js
@@ -72,7 +72,10 @@ function McpActivitySection() {
 
   return (
     <div className="card settings-card">
-      <h2 className="settings-section-title">{t('settings.aiActivity.title')}</h2>
+      <h2 className="settings-section-title">
+        {t('settings.aiActivity.title')}
+        <span className="settings-beta-badge">{t('settings.aiConnect.beta', 'Beta')}</span>
+      </h2>
       <p className="settings-hint">
         {windowDays != null
           ? t('settings.aiActivity.hint', { days: windowDays })

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -255,7 +255,9 @@
       "copy": "Copy",
       "copied": "Copied!",
       "securityNote": "Your AI sees only your own cellar data. Revoking the token in the API tokens section cuts the connection off instantly.",
-      "testError": "Could not verify right now (server busy or unreachable) — this says nothing about your token. Try again in a moment."
+      "testError": "Could not verify right now (server busy or unreachable) — this says nothing about your token. Try again in a moment.",
+      "beta": "Beta",
+      "betaNotice": "This is a beta feature and you use it at your own risk. It works, but it is new and still being tested — expect rough edges, and changes while we refine it. If you are unsure, connect with a read-only token: anything an AI changes can be undone under \"What your AI has changed\", and revoking the token cuts it off instantly."
     },
     "climateDevices": {
       "title": "Climate devices",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -255,7 +255,9 @@
       "copy": "Kopiera",
       "copied": "Kopierat!",
       "securityNote": "Din AI ser bara dina egna källardata. Återkallar du din token i avsnittet API-tokens bryts anslutningen omedelbart.",
-      "testError": "Det gick inte att verifiera just nu (servern är upptagen eller onåbar) — det säger ingenting om din token. Försök igen om en stund."
+      "testError": "Det gick inte att verifiera just nu (servern är upptagen eller onåbar) — det säger ingenting om din token. Försök igen om en stund.",
+      "beta": "Beta",
+      "betaNotice": "Det här är en betafunktion och du använder den på egen risk. Den fungerar, men är ny och testas fortfarande — räkna med ojämnheter och att saker ändras medan vi finslipar. Är du osäker, anslut med en läsbehörig token: allt en AI ändrar kan ångras under \"Vad din AI har ändrat\", och återkallar du token bryts anslutningen omedelbart."
     },
     "climateDevices": {
       "title": "Klimatenheter",

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -26,6 +26,22 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+/* "Beta" tag next to a settings section title — same shape as the Room View /
+   Discussions beta badges, so a beta feature reads the same wherever it is. */
+.settings-beta-badge {
+  display: inline-block;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
+  background: var(--color-primary, #6366f1);
+  color: #fff;
+}
+
 .settings-hint {
   font-size: 0.82rem;
   color: var(--color-text-muted);


### PR DESCRIPTION
So we can **ship the MCP / "Connect your AI" surface to production early and test it live**, with users told plainly what they're opting into instead of discovering the rough edges themselves.

## Which label
Matches the **existing convention** rather than inventing one: the app already ships uppercase **"Beta"** badges on new features (Room View, Discussions, the cellar Overview tab) with a `beta` i18n key. So that answers *"alpha or beta or something"* — **Beta** is what this app calls a new feature. New shared `.settings-beta-badge`, shaped like `.room-beta-badge`.

## Which surfaces
| Surface | Gets |
|---|---|
| Settings → **Connect your AI** | Beta badge + the at-your-own-risk notice (this is the opt-in decision point) |
| Settings → **What your AI has changed** | Beta badge (same feature; self-hides until an AI has acted) |
| **OAuth consent screen** | Same framing — lands on #719, where that page lives |

## The copy
A bare badge isn't enough when you're letting an external AI into your cellar, so the connect card carries an `alert-info`:

> This is a beta feature and you use it at your own risk. It works, but it is new and still being tested — expect rough edges, and changes while we refine it. If you are unsure, connect with a read-only token: anything an AI changes can be undone under "What your AI has changed", and revoking the token cuts it off instantly.

Deliberately honest rather than alarming — the reassurances are real (read-only default, full reversibility, instant revoke), so the warning doesn't have to be scary to be truthful.

## Testing
en/sv both added, key parity checked (⚠️ **sv machine-authored, pending review**). New test pins the badge + the risk copy + the reassurances. **Frontend 30 files / 653 green**; production build clean.

Compose impact: none (frontend copy/CSS only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)