### PR TITLE
feat(mcp): Phase 6 — anonymous public MCP (/api/mcp/public)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -158,7 +158,10 @@ const isStripeWebhook = (req) => req.originalUrl.split('?')[0] === '/api/stripe/
 // Revisit again before AI-spending tools ship (enrichment adds cost beyond DB).
 const isMcp = (req) => {
   const p = req.originalUrl.split('?')[0];
-  return p === '/api/mcp' || p === '/api/mcp/';
+  // /api/mcp/public (anonymous, read-only) has its own strict dedicated
+  // limiter in routes/mcp.js — exempt from the write limiter like the
+  // personal endpoint (its calls are budgeted inside mcp/server.js).
+  return p === '/api/mcp' || p === '/api/mcp/' || p === '/api/mcp/public';
 };
 
 // Global API rate limiter — default 200 requests per 15 min per IP (admin-configurable)

--- a/backend/src/mcp/eval/cases.js
+++ b/backend/src/mcp/eval/cases.js
@@ -134,6 +134,18 @@ const CASES = [
     expect: { tool: 'mark_notification_read' },
     args: (a) => a.all === true || a.notification_id !== undefined,
   },
+
+  // ── Phase 6: public registry/guides tools (also on the personal surface) ──
+  {
+    id: 'when-to-drink-vintage',
+    prompt: 'When should a 2016 Barolo Monfortino be drunk? Is it ready now?',
+    expect: { anyOf: ['drink_window_for', 'search_registry'] }, // may resolve the wine id first
+  },
+  {
+    id: 'storage-guide',
+    prompt: 'Do you have a guide on how to store wine properly long-term?',
+    expect: { tool: 'list_guides' },
+  },
 ];
 
 module.exports = { CASES };

--- a/backend/src/mcp/instructions.js
+++ b/backend/src/mcp/instructions.js
@@ -9,7 +9,8 @@ const INSTRUCTIONS = [
   '',
   'How to work with it:',
   "- Every tool acts only on the authenticated user's data. Reads are free — prefer them, and prefer filtered searches over fetching everything.",
-  '- Tool families: cellars (list_cellars, get_cellar) → bottles (search_bottles, get_bottle, list_history) → racks (list_racks, get_rack) → portfolio (cellar_stats) → shared registry (search_registry, get_wine, find_similar_wines, semantic_search_wines) → personal (list_wishlist, list_journal) → sommelier intelligence (cellar_health_check, what_should_i_open_tonight, pair_with_dish, find_gaps, value_report, case_journey) → consuming (consume_bottle, restore_bottle, undo_last — consume scope) → adding/editing (resolve_wine, add_bottle, update_bottle, bulk_add, capture_tasting_note — write scope) → sommelier curation (list_maturity_queue, set_vintage_maturity, list_price_tracking_requests, set_vintage_price — only for sommelier/admin accounts) → organising (create_cellar, create_rack, place_bottle, unplace_bottle, move_bottle, auto_arrange — write scope).',
+  '- Tool families: cellars (list_cellars, get_cellar) → bottles (search_bottles, get_bottle, list_history) → racks (list_racks, get_rack) → portfolio (cellar_stats) → shared registry (search_registry, get_wine, find_similar_wines, semantic_search_wines, drink_window_for) → guides (list_guides, read_guide) → personal (list_wishlist, list_journal) → sommelier intelligence (cellar_health_check, what_should_i_open_tonight, pair_with_dish, find_gaps, value_report, case_journey) → consuming (consume_bottle, restore_bottle, undo_last — consume scope) → adding/editing (resolve_wine, add_bottle, update_bottle, bulk_add, capture_tasting_note — write scope) → sommelier curation (list_maturity_queue, set_vintage_maturity, list_price_tracking_requests, set_vintage_price — only for sommelier/admin accounts) → organising (create_cellar, create_rack, place_bottle, unplace_bottle, move_bottle, auto_arrange — write scope).',
+  '- drink_window_for = sommelier-curated aging windows for a registry wine+vintage; list_guides / read_guide = Cellarion\'s published how-to articles (public content — quote and link freely).',
   '- Resources you can attach as ambient context: cellar://snapshot (collection overview), cellar://stats (portfolio doc), cellar://bottle/{id} (one bottle\'s dossier), cellarion://alerts (unread alerts), cellarion://about.',
   '- Prompts (workflow templates the user can invoke): sommelier_pairing, plan_tonight, cellar_health_check, plan_rack_layout, year_in_wine.',
   '- Proactive mode: on a stateful session you can resources/subscribe to cellar://snapshot, cellar://stats and cellarion://alerts — the server pushes notifications/resources/updated when the cellar changes or a new alert lands (drink-window transitions, restock, climate excursions); re-read the resource and, when relevant, list_notifications / climate_status for detail, then mark_notification_read after relaying.',
@@ -25,4 +26,21 @@ const INSTRUCTIONS = [
   '- Call get_source_info if the user asks what Cellarion is, which version this instance runs, whether it is open source, or where to find or contribute to the code.',
 ].join('\n');
 
-module.exports = { INSTRUCTIONS };
+// Instructions for the ANONYMOUS surface (/api/mcp/public, plan Phase 6).
+// Different framing: no user, no cellar — the shared registry + guides only,
+// with an honest pointer to the personal surface. Every tool here costs
+// Cellarion zero AI spend by design.
+const PUBLIC_INSTRUCTIONS = [
+  `You are connected to Cellarion's PUBLIC wine data — the shared registry and guides of an open-source (AGPL-3.0) wine cellar manager (https://github.com/jagduvi1/Cellarion, hosted free at https://cellarion.app). This is the anonymous surface of the MCP server (v${pkg.version}): no account, no personal data.`,
+  '',
+  'What you can do here:',
+  '- search_registry / get_wine — look up any wine Cellarion knows: producer, region, grapes, classification, community rating, tasting profile.',
+  '- drink_window_for — sommelier-curated aging windows per vintage ("when should I drink 2015 X?"), with where the vintage stands right now.',
+  '- find_similar_wines — "more like this" by taste/style vectors from a wine_id (bottle_id needs an account).',
+  '- list_guides / read_guide — Cellarion\'s published cellar-management guides and articles; quote, summarise and link the public_url freely.',
+  '- get_source_info / the cellarion://about resource — what Cellarion is.',
+  '- Wines carry a public_url — link it so people can see the full page.',
+  '- This surface is rate-limited and read-only. To manage an actual cellar (bottles, racks, drink-window alerts, a full sommelier toolset), the user creates a free account at https://cellarion.app and connects their AI under Settings → Connect your AI — or self-hosts.',
+].join('\n');
+
+module.exports = { INSTRUCTIONS, PUBLIC_INSTRUCTIONS };

--- a/backend/src/mcp/publicTools.test.js
+++ b/backend/src/mcp/publicTools.test.js
@@ -1,0 +1,180 @@
+/**
+ * MCP Phase-6 public surface — anonymous-safety invariants.
+ *
+ * Pins THE property the public endpoint stands on: an anonymous ctx
+ * (scopes [], user null) structurally exposes ONLY 'public'-scoped tools —
+ * personal tools are unregistered, not hidden. Plus the new public tools'
+ * contracts: reviewed-only drink windows (OG-page field boundary, no
+ * sommNotes), published-only guides, the anonymous bottle_id guard on
+ * find_similar_wines, and zero AI spend (no aiBudget/embedding touched).
+ */
+
+const chain = (result) => {
+  const c = {};
+  for (const m of ['populate', 'sort', 'skip', 'limit', 'select']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(() => Promise.resolve(result));
+  c.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return c;
+};
+
+jest.mock('../models/Cellar', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/Bottle', () => ({
+  find: jest.fn(), findById: jest.fn(), aggregate: jest.fn(), countDocuments: jest.fn(), distinct: jest.fn(),
+}));
+jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('../models/BlogPost', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/Notification', () => ({ find: jest.fn(), countDocuments: jest.fn(), updateOne: jest.fn(), updateMany: jest.fn() }));
+jest.mock('../models/ClimateDevice', () => ({ find: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../services/search', () => ({ getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn() }));
+jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), buildEmptyStats: jest.fn() }));
+jest.mock('../services/vectorStore', () => ({ getPoints: jest.fn(), searchSimilar: jest.fn() }));
+jest.mock('../config/aiConfig', () => ({ get: jest.fn(() => ({ vectorIndex: 'v1' })) }));
+jest.mock('../services/bottleOps', () => ({
+  consumeBottle: jest.fn(), restoreBottle: jest.fn(), addBottle: jest.fn(), updateBottleFields: jest.fn(),
+  removeBottleCascade: jest.fn(), RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,
+  UPDATABLE_FIELDS: ['price', 'currency', 'notes', 'occasion', 'rating', 'ratingScale', 'drinkFrom', 'drinkTo'],
+}));
+
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const WineVintageProfile = require('../models/WineVintageProfile');
+const BlogPost = require('../models/BlogPost');
+const { allTools, toolsForScopes, resourcesForScopes, promptsForScopes } = require('./registry');
+require('./tools');
+require('./resources'); // resource registration is a side-effect too
+require('./prompts');
+
+const oid = (c) => c.repeat(24);
+const ANON = { user: null, scopes: [], anonymous: true };
+const tool = (name) => allTools().find((t) => t.name === name);
+const parse = (res) => JSON.parse(res.content[0].text);
+const THIS_YEAR = new Date().getFullYear();
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('the anonymous surface is structural', () => {
+  test('scopes [] exposes EXACTLY the public tool set — nothing personal', () => {
+    const names = toolsForScopes([], []).map((t) => t.name).sort();
+    expect(names).toEqual([
+      'drink_window_for', 'find_similar_wines', 'get_source_info', 'get_wine',
+      'list_guides', 'read_guide', 'search_registry',
+    ]);
+  });
+
+  test('every public tool is read-only (the anonymous surface can never mutate)', () => {
+    for (const t of toolsForScopes([], [])) {
+      expect(t.annotations.readOnlyHint).toBe(true);
+    }
+  });
+
+  test('anonymous resources = about only; prompts = none', () => {
+    expect(resourcesForScopes([]).map((r) => r.uri)).toEqual(['cellarion://about']);
+    expect(promptsForScopes([])).toEqual([]);
+  });
+});
+
+describe('find_similar_wines anonymous guard', () => {
+  test('bottle_id without a user → invalid_input pointing at wine_id, before any DB work', async () => {
+    const res = await tool('find_similar_wines').handler({ bottle_id: oid('d') }, ANON);
+    const body = parse(res);
+    expect(body.error.code).toBe('invalid_input');
+    expect(body.error.message).toMatch(/wine_id/);
+    const Bottle = require('../models/Bottle');
+    expect(Bottle.findById).not.toHaveBeenCalled();
+  });
+});
+
+describe('drink_window_for', () => {
+  const WINE = { _id: new mongoose.Types.ObjectId(oid('f')), name: 'Barolo X', producer: 'P', type: 'red' };
+
+  test('reviewed-only, OG field boundary (no sommNotes), status_now mapping', async () => {
+    WineDefinition.findById.mockReturnValue(chain(WINE));
+    WineVintageProfile.find.mockReturnValue(chain([
+      { vintage: '2015', relative: false, earlyFrom: 2018, earlyUntil: 2021, peakFrom: THIS_YEAR - 2, peakUntil: THIS_YEAR + 3, lateFrom: THIS_YEAR + 4, lateUntil: THIS_YEAR + 8 },
+    ]));
+    const res = await tool('drink_window_for').handler({ wine_id: oid('f') }, ANON);
+    const body = parse(res);
+    expect(WineVintageProfile.find).toHaveBeenCalledWith({ wineDefinition: WINE._id, status: 'reviewed' });
+    const v = body.data.vintages[0];
+    expect(v.status_now).toBe('peak');
+    expect(v.unit).toBe('calendar_year');
+    expect(v.windows.peak).toEqual({ from: THIS_YEAR - 2, until: THIS_YEAR + 3 });
+    expect(JSON.stringify(body)).not.toMatch(/sommNotes/);
+  });
+
+  test('relative (NV) profiles report offsets with no now-status', async () => {
+    WineDefinition.findById.mockReturnValue(chain(WINE));
+    WineVintageProfile.find.mockReturnValue(chain([
+      { vintage: 'NV', relative: true, peakFrom: 0, peakUntil: 3 },
+    ]));
+    const res = await tool('drink_window_for').handler({ wine_id: oid('f') }, ANON);
+    const v = parse(res).data.vintages[0];
+    expect(v.unit).toBe('years_after_purchase');
+    expect(v.status_now).toBeNull();
+  });
+
+  test('no curated profile → honest empty with estimate warning; bad/missing wine handled', async () => {
+    WineDefinition.findById.mockReturnValue(chain(WINE));
+    WineVintageProfile.find.mockReturnValue(chain([]));
+    let res = await tool('drink_window_for').handler({ wine_id: oid('f'), vintage: '1999' }, ANON);
+    let body = parse(res);
+    expect(body.data).toEqual([]);
+    expect(body.warnings.join(' ')).toMatch(/estimate/i);
+
+    res = await tool('drink_window_for').handler({ wine_id: 'junk' }, ANON);
+    expect(parse(res).error.code).toBe('invalid_input');
+
+    WineDefinition.findById.mockReturnValue(chain(null));
+    res = await tool('drink_window_for').handler({ wine_id: oid('9') }, ANON);
+    expect(parse(res).error.code).toBe('not_found');
+  });
+});
+
+describe('guides', () => {
+  test('list_guides: published-only filter, tag pass-through, public_url shape', async () => {
+    BlogPost.countDocuments.mockResolvedValue(1);
+    BlogPost.find.mockReturnValue(chain([
+      { slug: 'drink-windows-101', title: 'Drink Windows 101', excerpt: 'x', tags: ['aging'], publishedAt: new Date() },
+    ]));
+    const res = await tool('list_guides').handler({ tag: 'Aging' }, ANON);
+    const body = parse(res);
+    expect(BlogPost.find).toHaveBeenCalledWith({ status: 'published', tags: 'aging' });
+    expect(body.data[0].public_url).toBe('https://cellarion.app/blog/drink-windows-101');
+  });
+
+  test('read_guide: published-only, slug lowercased, truncation warning on huge content', async () => {
+    BlogPost.findOne.mockReturnValue(chain({
+      slug: 's', title: 'T', excerpt: null, tags: [], publishedAt: new Date(), content: 'x'.repeat(30001),
+    }));
+    let res = await tool('read_guide').handler({ slug: '  MY-Guide ' }, ANON);
+    let body = parse(res);
+    expect(BlogPost.findOne).toHaveBeenCalledWith({ slug: 'my-guide', status: 'published' });
+    expect(body.data.content).toHaveLength(30000);
+    expect(body.warnings.join(' ')).toMatch(/truncated/i);
+
+    BlogPost.findOne.mockReturnValue(chain(null));
+    res = await tool('read_guide').handler({ slug: 'draft-post' }, ANON);
+    expect(parse(res).error.code).toBe('not_found');
+  });
+});
+
+describe('zero-AI guarantee', () => {
+  test('no public tool touches the AI budget or the embedding service', async () => {
+    // aiBudget/embedding are NOT mocked in this file: a public tool reaching
+    // them would load the real modules and try real work. Assert statically:
+    // the public tool modules never import them.
+    const fs = require('fs');
+    const path = require('path');
+    for (const file of ['tools/wines.js', 'tools/similar.js', 'tools/publicContent.js', 'tools/meta.js']) {
+      const src = fs.readFileSync(path.join(__dirname, file), 'utf8');
+      expect(src).not.toMatch(/aiBudget|services\/embedding/);
+    }
+  });
+});

--- a/backend/src/mcp/publicTools.test.js
+++ b/backend/src/mcp/publicTools.test.js
@@ -36,6 +36,17 @@ jest.mock('../services/search', () => ({ getIsAvailable: jest.fn(() => false), s
 jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), buildEmptyStats: jest.fn() }));
 jest.mock('../services/vectorStore', () => ({ getPoints: jest.fn(), searchSimilar: jest.fn() }));
 jest.mock('../config/aiConfig', () => ({ get: jest.fn(() => ({ vectorIndex: 'v1' })) }));
+// The zero-AI invariant pinned at the RUNTIME boundary (audit P6-L1): if any
+// public tool ever reaches the embedding layer, these throw and the happy-path
+// tests below fail — regardless of which module the call is laundered through.
+jest.mock('../services/embedding', () => ({
+  embed: jest.fn(() => { throw new Error('embedding must never run on the public surface'); }),
+  embedSingle: jest.fn(() => { throw new Error('embedding must never run on the public surface'); }),
+}));
+jest.mock('../services/aiBudget', () => ({
+  tryDebitAi: jest.fn(() => { throw new Error('AI budget must never be touched on the public surface'); }),
+  tryDebitGlobalAi: jest.fn(() => { throw new Error('AI budget must never be touched on the public surface'); }),
+}));
 jest.mock('../services/bottleOps', () => ({
   consumeBottle: jest.fn(), restoreBottle: jest.fn(), addBottle: jest.fn(), updateBottleFields: jest.fn(),
   removeBottleCascade: jest.fn(), RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,
@@ -166,15 +177,62 @@ describe('guides', () => {
 });
 
 describe('zero-AI guarantee', () => {
-  test('no public tool touches the AI budget or the embedding service', async () => {
-    // aiBudget/embedding are NOT mocked in this file: a public tool reaching
-    // them would load the real modules and try real work. Assert statically:
-    // the public tool modules never import them.
+  test('find_similar_wines full happy path completes without EVER reaching embedding/aiBudget (runtime pin)', async () => {
+    // The throwing embedding/aiBudget mocks above are the assertion: if the
+    // similarity flow (or anything it calls, e.g. vectorStore) laundered an
+    // embed call, this run would throw instead of returning results.
+    const WineEmbedding = require('../models/WineEmbedding');
+    const vectorStore = require('../services/vectorStore');
+    WineEmbedding.findOne.mockReturnValue(chain({ qdrantPointId: 'uuid-1' }));
+    vectorStore.getPoints.mockResolvedValue([{ id: 'uuid-1', vector: [0.1, 0.2] }]);
+    const other = new mongoose.Types.ObjectId();
+    vectorStore.searchSimilar.mockResolvedValue([
+      { score: 0.9, payload: { wineDefinitionId: String(other), vintage: '2019' } },
+    ]);
+    WineDefinition.find.mockReturnValue(chain([{ _id: other, name: 'Similar', producer: 'P', grapes: [] }]));
+
+    const res = await tool('find_similar_wines').handler({ wine_id: oid('f') }, ANON);
+    const body = parse(res);
+    expect(body.error).toBeUndefined();
+    expect(body.data[0].name).toBe('Similar');
+    const { embedSingle } = require('../services/embedding');
+    const { tryDebitAi } = require('../services/aiBudget');
+    expect(embedSingle).not.toHaveBeenCalled();
+    expect(tryDebitAi).not.toHaveBeenCalled();
+  });
+
+  test('static belt-and-braces: public tool modules never import aiBudget/embedding directly', async () => {
     const fs = require('fs');
     const path = require('path');
     for (const file of ['tools/wines.js', 'tools/similar.js', 'tools/publicContent.js', 'tools/meta.js']) {
       const src = fs.readFileSync(path.join(__dirname, file), 'utf8');
       expect(src).not.toMatch(/aiBudget|services\/embedding/);
     }
+  });
+});
+
+describe('anonymous mutation fail-closed (audit P6-L2) + tighter anon batch budget (P6-L3)', () => {
+  const { budgetedHandler } = require('./server');
+
+  test('a hypothetically mis-scoped mutating tool refuses cleanly on the anonymous ctx', async () => {
+    const evil = { annotations: { readOnlyHint: false }, handler: jest.fn() };
+    const res = await budgetedHandler(evil, { user: null, anonymous: true }, { calls: 0 })({});
+    const body = JSON.parse(res.content[0].text);
+    expect(res.isError).toBe(true);
+    expect(body.error.code).toBe('forbidden_scope');
+    expect(evil.handler).not.toHaveBeenCalled(); // never runs, never derefs ctx.user
+  });
+
+  test('anonymous per-request call budget honours state.max (10) instead of the full 20', async () => {
+    const t = { annotations: { readOnlyHint: true }, handler: jest.fn(async () => ({ content: [{ type: 'text', text: '{}' }] })) };
+    const state = { calls: 0, max: 10 };
+    const wrapped = budgetedHandler(t, { user: null, anonymous: true }, state);
+    for (let i = 0; i < 10; i++) {
+      const r = await wrapped({});
+      expect(r.isError).toBeUndefined();
+    }
+    const over = await wrapped({});
+    expect(over.isError).toBe(true);
+    expect(JSON.parse(over.content[0].text).error.code).toBe('rate_limited');
   });
 });

--- a/backend/src/mcp/readTools.test.js
+++ b/backend/src/mcp/readTools.test.js
@@ -68,16 +68,24 @@ beforeEach(() => {
 });
 
 describe('registration invariants', () => {
-  test('every Phase-1 tool is read-scoped and readOnly-annotated', () => {
+  test('every personal-data Phase-1 tool is read-scoped and readOnly-annotated', () => {
     const expected = [
       'list_cellars', 'get_cellar', 'search_bottles', 'get_bottle', 'list_history',
-      'list_racks', 'get_rack', 'cellar_stats', 'search_registry', 'get_wine',
+      'list_racks', 'get_rack', 'cellar_stats',
       'list_wishlist', 'list_journal',
     ];
     for (const name of expected) {
       const t = tool(name);
       expect(t).toBeDefined();
       expect(t.scope).toBe('read');
+      expect(t.annotations.readOnlyHint).toBe(true);
+    }
+  });
+
+  test('registry tools are PUBLIC-scoped (shared public-site data — Phase 6 anonymous surface)', () => {
+    for (const name of ['search_registry', 'get_wine']) {
+      const t = tool(name);
+      expect(t.scope).toBe('public');
       expect(t.annotations.readOnlyHint).toBe(true);
     }
   });

--- a/backend/src/mcp/resources.test.js
+++ b/backend/src/mcp/resources.test.js
@@ -158,9 +158,9 @@ describe('find_similar_wines', () => {
     expect(res.content[0].text).not.toContain('INTERNAL'); // registry internals never serialize
   });
 
-  test('is read-scoped + readOnly, and limit is clamped to 10', async () => {
+  test('is PUBLIC-scoped ($0 stored-vector lookup — Phase 6 anonymous surface) + readOnly, and limit is clamped to 10', async () => {
     const t = tool('find_similar_wines');
-    expect(t.scope).toBe('read');
+    expect(t.scope).toBe('public');
     expect(t.annotations.readOnlyHint).toBe(true);
     WineEmbedding.findOne.mockReturnValue(chain({ qdrantPointId: 'uuid-1' }));
     vectorStore.getPoints.mockResolvedValue([{ id: 'uuid-1', vector: [0.1] }]);
@@ -250,6 +250,13 @@ describe('previously-uncovered handlers', () => {
     }
     for (const p of allPrompts()) {
       expect(INSTRUCTIONS).toContain(p.name);
+    }
+  });
+
+  test('public-instructions drift guard: every anonymous-surface tool is mentioned there too', () => {
+    const { PUBLIC_INSTRUCTIONS } = require('./instructions');
+    for (const t of allTools().filter((x) => x.scope === 'public')) {
+      expect(PUBLIC_INSTRUCTIONS).toContain(t.name);
     }
   });
 });

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -57,11 +57,23 @@ const { takeMutationSlot, WRITE_WINDOW_MS } = require('./mutationBudget');
 function budgetedHandler(tool, ctx, state) {
   return (args) => {
     state.calls += 1;
-    if (state.calls > MAX_CALLS_PER_REQUEST) {
-      return rateLimited(`Too many tool calls in one request (max ${MAX_CALLS_PER_REQUEST}). Send fewer calls per batch and paginate instead.`);
+    const maxCalls = state.max || MAX_CALLS_PER_REQUEST;
+    if (state.calls > maxCalls) {
+      return rateLimited(`Too many tool calls in one request (max ${maxCalls}). Send fewer calls per batch and paginate instead.`);
     }
-    if (tool.annotations?.readOnlyHint === false && !takeMutationSlot(String(ctx.user.id))) {
-      return rateLimited('Too many cellar changes in a short time — wait a few minutes before mutating again. Reads still work.');
+    if (tool.annotations?.readOnlyHint === false) {
+      // Fail-closed for the anonymous surface (audit P6-L2): if a mutating
+      // tool is ever mis-scoped 'public', refuse cleanly instead of running a
+      // userless mutation (and crashing on ctx.user.id below).
+      if (ctx.anonymous || !ctx.user) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: JSON.stringify({ error: { code: 'forbidden_scope', message: 'Mutations need an authenticated connection.' } }) }],
+        };
+      }
+      if (!takeMutationSlot(String(ctx.user.id))) {
+        return rateLimited('Too many cellar changes in a short time — wait a few minutes before mutating again. Reads still work.');
+      }
     }
     return tool.handler(args || {}, ctx);
   };
@@ -89,6 +101,10 @@ async function buildServer(ctx, opts = {}) {
     }
   );
   const state = opts.callState || { calls: 0 };
+  // The anonymous surface gets a tighter per-request batch budget (audit
+  // P6-L3): 20 read_guide calls at the 30k cap would be ~600KB from one
+  // unauthenticated 10KB request. Authenticated callers keep the full cap.
+  if (ctx.anonymous) state.max = 10;
   for (const tool of toolsForScopes(ctx.scopes, ctx.user?.roles || [])) {
     server.registerTool(
       tool.name,
@@ -188,8 +204,9 @@ function eventBusRef() {
 function budgetedPromptHandler(prompt, ctx, state) {
   return (args) => {
     state.calls += 1;
-    if (state.calls > MAX_CALLS_PER_REQUEST) {
-      throw new Error(`rate_limited: too many calls in one request (max ${MAX_CALLS_PER_REQUEST})`);
+    const maxCalls = state.max || MAX_CALLS_PER_REQUEST;
+    if (state.calls > maxCalls) {
+      throw new Error(`rate_limited: too many calls in one request (max ${maxCalls})`);
     }
     return prompt.handler(args || {}, ctx);
   };
@@ -202,8 +219,9 @@ function budgetedPromptHandler(prompt, ctx, state) {
 function budgetedResourceHandler(rsrc, ctx, state) {
   return (uri, varsOrExtra) => {
     state.calls += 1;
-    if (state.calls > MAX_CALLS_PER_REQUEST) {
-      throw new Error(`rate_limited: too many calls in one request (max ${MAX_CALLS_PER_REQUEST})`);
+    const maxCalls = state.max || MAX_CALLS_PER_REQUEST;
+    if (state.calls > maxCalls) {
+      throw new Error(`rate_limited: too many calls in one request (max ${maxCalls})`);
     }
     const params = rsrc.uriTemplate ? (varsOrExtra || {}) : {};
     return rsrc.handler(uri, params, ctx);

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -1,5 +1,5 @@
 const { toolsForScopes, resourcesForScopes, promptsForScopes } = require('./registry');
-const { INSTRUCTIONS } = require('./instructions');
+const { INSTRUCTIONS, PUBLIC_INSTRUCTIONS } = require('./instructions');
 const pkg = require('../../package.json');
 require('./tools');     // register all tools (side-effect)
 require('./resources'); // register all resources (side-effect)
@@ -80,9 +80,11 @@ function budgetedHandler(tool, ctx, state) {
 async function buildServer(ctx, opts = {}) {
   const { McpServer, ResourceTemplate } = await loadSdk();
   const server = new McpServer(
-    { name: 'cellarion', version: pkg.version },
+    // The anonymous surface announces itself distinctly — different name and
+    // instructions, so a client connected to both never confuses the two.
+    { name: ctx.anonymous ? 'cellarion-public' : 'cellarion', version: pkg.version },
     {
-      instructions: INSTRUCTIONS,
+      instructions: ctx.anonymous ? PUBLIC_INSTRUCTIONS : INSTRUCTIONS,
       ...(opts.session ? { capabilities: { resources: { subscribe: true, listChanged: false } } } : {}),
     }
   );

--- a/backend/src/mcp/smoke.js
+++ b/backend/src/mcp/smoke.js
@@ -124,8 +124,29 @@ async function main() {
   if (sessionCounts().total !== 0) throw new Error(`session not torn down on DELETE (${sessionCounts().total} left)`);
   console.log('[smoke] session terminated (DELETE) + store empty');
 
+  // Anonymous public surface (Phase 6): scopes [] + user null exposes exactly
+  // the public tool set, the about resource, no prompts, and the distinct
+  // server identity/instructions.
+  app.post('/api/mcp/public', (req, res, next) =>
+    handleMcpRequest(req, res, { user: null, scopes: [], anonymous: true, req }).catch(next));
+  const anon = new Client({ name: 'mcp-smoke-anon', version: '0.0.0' });
+  await anon.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/api/mcp/public`)));
+  const sv = anon.getServerVersion();
+  if (sv.name !== 'cellarion-public') throw new Error(`anon server should announce cellarion-public, got ${sv.name}`);
+  const anonTools = (await anon.listTools()).tools.map((t) => t.name).sort();
+  const EXPECT_ANON = ['drink_window_for', 'find_similar_wines', 'get_source_info', 'get_wine', 'list_guides', 'read_guide', 'search_registry'];
+  if (JSON.stringify(anonTools) !== JSON.stringify(EXPECT_ANON)) {
+    throw new Error(`anon tool surface wrong: ${anonTools.join(', ')}`);
+  }
+  const anonResources = (await anon.listResources()).resources.map((r) => r.uri);
+  if (anonResources.length !== 1 || anonResources[0] !== 'cellarion://about') {
+    throw new Error(`anon resources wrong: ${anonResources.join(', ')}`);
+  }
+  console.log('[smoke] anonymous surface: exactly the public tools + about, identity cellarion-public');
+  await anon.close();
+
   httpServer.close();
-  console.log('[smoke] OK — tools + resources + prompts + sessions/subscriptions round-trip clean on /api/mcp.');
+  console.log('[smoke] OK — tools + resources + prompts + sessions/subscriptions + anonymous surface clean.');
 }
 
 main().catch((e) => { console.error('[smoke] FAILED:', e); process.exit(1); });

--- a/backend/src/mcp/tools/index.js
+++ b/backend/src/mcp/tools/index.js
@@ -26,5 +26,6 @@ require('./semantic');
 require('./tasting');
 require('./arrange');
 require('./notify');
+require('./publicContent');
 
 module.exports = {};

--- a/backend/src/mcp/tools/publicContent.js
+++ b/backend/src/mcp/tools/publicContent.js
@@ -1,0 +1,148 @@
+// Public/growth tools (plan Phase 6 §3.9): the anonymous-safe surface beyond
+// the registry lookups — curated drink windows for a named wine, and the blog
+// guides (cornerstone AEO content). Everything here is data the PUBLIC website
+// already serves (wine pages / OG crawler pages / the blog), never user data,
+// and never an AI call ($0 rule for the anonymous endpoint is absolute).
+const { z } = require('zod');
+const { registerTool } = require('../registry');
+const { isValidId } = require('../../utils/validation');
+const { ok, fail } = require('../toolUtil');
+
+registerTool({
+  name: 'drink_window_for',
+  title: 'Drink window for a wine',
+  description:
+    'Sommelier-curated drink windows for a registry wine: per vintage, when it is young, at peak, and in late ' +
+    'maturity, with where the vintage stands right now. Call for "when should I drink <wine> <vintage>", aging ' +
+    'questions, or buy-now-drink-later advice. Only sommelier-REVIEWED vintages are returned — an empty result ' +
+    'means no curated window exists yet (reason from grape/region/structure yourself, and say it is an estimate).',
+  scope: 'public',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    wine_id: z.string().describe('Registry wine id (from search_registry)'),
+    vintage: z.string().max(10).optional().describe('One vintage year; omit for all curated vintages of the wine'),
+  },
+  handler: async (args) => {
+    // Lazy model requires keep the registry load path lean (file convention).
+    const WineDefinition = require('../../models/WineDefinition');
+    const WineVintageProfile = require('../../models/WineVintageProfile');
+
+    if (!isValidId(String(args.wine_id || ''))) {
+      return fail('invalid_input', 'wine_id must be a 24-hex id from search_registry.');
+    }
+    const wine = await WineDefinition.findById(args.wine_id).select('name producer type').lean();
+    if (!wine) return fail('not_found', 'No such registry wine. Use search_registry for valid ids.');
+
+    const filter = { wineDefinition: wine._id, status: 'reviewed' };
+    if (args.vintage) filter.vintage = String(args.vintage).trim();
+    // Same field boundary as the public OG pages: window years only — never
+    // sommNotes or curator identity.
+    const profiles = await WineVintageProfile.find(filter)
+      .select('vintage relative earlyFrom earlyUntil peakFrom peakUntil lateFrom lateUntil')
+      .sort({ vintage: -1 }).limit(30).lean();
+
+    const currentYear = new Date().getFullYear();
+    const data = profiles.map((p) => {
+      // `relative` profiles (NV wines) hold year-OFFSETS from purchase, not
+      // calendar years — without a bottle there is no anchor, so report the
+      // offsets as such and no now-status.
+      const windows = {
+        early: { from: p.earlyFrom ?? null, until: p.earlyUntil ?? null },
+        peak: { from: p.peakFrom ?? null, until: p.peakUntil ?? null },
+        late: { from: p.lateFrom ?? null, until: p.lateUntil ?? null },
+      };
+      let now = null;
+      if (!p.relative) {
+        if (p.peakFrom && currentYear < p.peakFrom) now = (p.earlyFrom && currentYear >= p.earlyFrom) ? 'early' : 'not_ready';
+        else if (p.peakUntil && currentYear <= p.peakUntil) now = 'peak';
+        else if (p.lateUntil && currentYear <= p.lateUntil) now = 'late';
+        else if (p.peakUntil || p.lateUntil) now = 'past';
+        else if (p.peakFrom && currentYear >= p.peakFrom) now = 'peak';
+      }
+      return {
+        vintage: p.vintage,
+        unit: p.relative ? 'years_after_purchase' : 'calendar_year',
+        windows,
+        status_now: now,
+      };
+    });
+    if (data.length === 0) {
+      return ok(`No curated drink window for ${wine.name}${args.vintage ? ` ${args.vintage}` : ''}`, [], {
+        warnings: ['No sommelier-reviewed window exists for this wine/vintage yet — any guidance you give is your own estimate; say so.'],
+      });
+    }
+    return ok(
+      `${data.length} curated vintage window(s) for ${wine.name}${wine.producer ? ` (${wine.producer})` : ''}`,
+      { wine_id: wine._id, name: wine.name, producer: wine.producer || null, type: wine.type || null, vintages: data }
+    );
+  },
+});
+
+const GUIDE_LIST_LIMIT = 20;
+
+registerTool({
+  name: 'list_guides',
+  title: 'List wine guides & articles',
+  description:
+    'Cellarion\'s published guides and blog articles (cellar management, drink windows, storage, buying) — title, ' +
+    'slug, excerpt and tags. Call when the user wants a how-to or background reading; follow with read_guide for ' +
+    'the full text.',
+  scope: 'public',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: {
+    tag: z.string().max(40).optional().describe('Filter by tag'),
+    limit: z.number().int().min(1).max(GUIDE_LIST_LIMIT).default(10),
+    offset: z.number().int().min(0).default(0),
+  },
+  handler: async (args) => {
+    const BlogPost = require('../../models/BlogPost');
+    const limit = Math.min(Math.max(parseInt(args.limit, 10) || 10, 1), GUIDE_LIST_LIMIT);
+    const offset = Math.max(parseInt(args.offset, 10) || 0, 0);
+    const filter = { status: 'published' };
+    if (args.tag && String(args.tag).trim()) filter.tags = String(args.tag).trim().toLowerCase();
+    const [total, posts] = await Promise.all([
+      BlogPost.countDocuments(filter),
+      BlogPost.find(filter).sort({ publishedAt: -1 }).skip(offset).limit(limit)
+        .select('title slug excerpt tags publishedAt').lean(),
+    ]);
+    return ok(`${posts.length} of ${total} published guide(s)`, posts.map((p) => ({
+      slug: p.slug,
+      title: p.title,
+      excerpt: p.excerpt || null,
+      tags: p.tags || [],
+      published_at: p.publishedAt,
+      public_url: `https://cellarion.app/blog/${p.slug}`,
+    })), { page: { limit, offset, total } });
+  },
+});
+
+const GUIDE_MAX_CHARS = 30000;
+
+registerTool({
+  name: 'read_guide',
+  title: 'Read a guide / article',
+  description:
+    'The full text of one published Cellarion guide or blog article, by slug (from list_guides). Public website ' +
+    'content — quote or summarise freely, and link the public_url when pointing the user to it.',
+  scope: 'public',
+  annotations: { readOnlyHint: true, openWorldHint: false },
+  inputSchema: { slug: z.string().min(1).max(200).describe('Article slug from list_guides') },
+  handler: async (args) => {
+    const BlogPost = require('../../models/BlogPost');
+    const post = await BlogPost.findOne({ slug: String(args.slug).trim().toLowerCase(), status: 'published' })
+      .select('title slug excerpt tags publishedAt content').lean();
+    if (!post) return fail('not_found', 'No published article with that slug. Use list_guides for valid slugs.');
+    const truncated = post.content.length > GUIDE_MAX_CHARS;
+    return ok(`"${post.title}"`, {
+      slug: post.slug,
+      title: post.title,
+      excerpt: post.excerpt || null,
+      tags: post.tags || [],
+      published_at: post.publishedAt,
+      public_url: `https://cellarion.app/blog/${post.slug}`,
+      content: truncated ? post.content.slice(0, GUIDE_MAX_CHARS) : post.content,
+    }, truncated ? { warnings: [`Content truncated at ${GUIDE_MAX_CHARS} characters — the full article is at the public_url.`] } : {});
+  },
+});
+
+module.exports = {};

--- a/backend/src/mcp/tools/similar.js
+++ b/backend/src/mcp/tools/similar.js
@@ -22,7 +22,11 @@ registerTool({
     'from the shared registry, using vector similarity over wine embeddings. Call for "more like this", "what else is ' +
     'like my favourite Barolo", or to seed purchase ideas from a wine the user loves. Only wines that have been ' +
     'embedded are searchable — an empty result does not mean nothing similar exists.',
-  scope: 'read',
+  // 'public' (plan §3.17): the reference wine is already embedded, so this is
+  // a stored-vector Qdrant lookup — $0 per call and safe on the anonymous
+  // /api/mcp/public surface. The bottle_id input is guarded below (anonymous
+  // callers have no bottles).
+  scope: 'public',
   annotations: { readOnlyHint: true, openWorldHint: false },
   inputSchema: {
     wine_id: z.string().optional().describe('Registry wine id (from search_registry or a bottle\'s wine)'),
@@ -38,6 +42,11 @@ registerTool({
     let wineId = null;
     let preferVintage = null;
     if (args.bottle_id) {
+      // Anonymous callers (public MCP) have no bottles — refuse before any
+      // deref instead of leaking a confusing not_found.
+      if (!ctx.user) {
+        return fail('invalid_input', 'bottle_id needs an authenticated connection — on the public endpoint use wine_id (from search_registry).');
+      }
       const access = await resolveBottleAccess(ctx.user.id, args.bottle_id);
       if (!access) return fail('not_found', 'No such bottle, or you have no access to it. Find ids via search_bottles.');
       wineId = access.bottle.wineDefinition ? String(access.bottle.wineDefinition) : null;

--- a/backend/src/mcp/tools/wines.js
+++ b/backend/src/mcp/tools/wines.js
@@ -21,7 +21,10 @@ registerTool({
     'Searches Cellarion\'s shared wine database (vintage-neutral wines, community data) by name, producer, region or ' +
     'grape. Returns up to 10 matches. Call to identify a wine the user mentions, before recommending, or to check ' +
     'whether a wine exists in the registry. This searches ALL known wines — use search_bottles for what the user owns.',
-  scope: 'read',
+  // 'public': registry data is public-site content (every wine has a public
+  // URL) — served to ANY authenticated token and to the anonymous
+  // /api/mcp/public surface (Phase 6).
+  scope: 'public',
   annotations: { readOnlyHint: true, openWorldHint: false },
   inputSchema: {
     query: z.string().min(2).max(200).describe('Wine name, producer, appellation or grape'),
@@ -64,7 +67,9 @@ registerTool({
     'Full registry record for one wine: producer, region, appellation, classification, grapes, community rating, and ' +
     'the AI tasting profile when the wine has been enriched. Vintage-neutral (bottles carry the vintage). ' +
     'Call after search_registry when the user wants depth on a specific wine.',
-  scope: 'read',
+  // 'public' — same rationale as search_registry: this is the public wine
+  // page's data over MCP.
+  scope: 'public',
   annotations: { readOnlyHint: true, openWorldHint: false },
   inputSchema: { wine_id: z.string().describe('Registry wine id from search_registry or a bottle\'s wine') },
   handler: async (args) => {

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -1,6 +1,8 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const router = express.Router();
 const { requireAuth, requireNonDemo } = require('../middleware/auth');
+const { rateLimitKey } = require('../utils/clientIp');
 const { handleMcpRequest, initStatefulSession } = require('../mcp/server');
 const { getSession } = require('../mcp/sessions');
 const mongoose = require('mongoose');
@@ -115,6 +117,43 @@ router.delete('/', requireAuth, requireNonDemo, async (req, res, next) => {
   } catch (err) {
     next(err);
   }
+});
+
+// ── Anonymous public MCP (plan Phase 6, §2.1) ───────────────────────────────
+// POST /api/mcp/public — NO auth: the shared wine registry + guides as an MCP
+// any AI can call (growth/AEO). The anonymous ctx carries scopes [] and
+// user null, so the registry's structural filter exposes ONLY 'public'-scoped
+// tools/resources (registry lookups, drink windows, guides, about) — personal
+// tools are not hidden, they are UNREGISTERED. Zero Cellarion AI spend by
+// design: every public tool is a DB/Meili/Qdrant read of public-site content.
+// Stateless only (no sessions, no SSE — nothing to subscribe to without a
+// user), behind a strict dedicated per-IP limiter on top of the global
+// apiLimiter. requireNonDemo is irrelevant here (no auth at all).
+const publicMcpLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60, // strict by design (plan decision #4); each request ≤20 tool calls
+  keyGenerator: (req) => rateLimitKey(req),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => res.status(429).json({
+    error: 'Public MCP rate limit reached — try again later, or connect a free Cellarion account for the full personal surface.',
+  }),
+});
+
+router.post('/public', publicMcpLimiter, async (req, res, next) => {
+  try {
+    await handleMcpRequest(req, res, { user: null, scopes: [], anonymous: true, req });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// The public surface is stateless: no session streams to open or terminate.
+router.get('/public', (req, res) => {
+  res.status(405).json({ error: 'The public MCP endpoint is POST-only (stateless).' });
+});
+router.delete('/public', (req, res) => {
+  res.status(405).json({ error: 'The public MCP endpoint is stateless — no session to terminate.' });
 });
 
 // ── Recent AI activity timeline (Phase 2d) ──────────────────────────────────

--- a/backend/src/routes/mcp.test.js
+++ b/backend/src/routes/mcp.test.js
@@ -303,3 +303,38 @@ describe('stateful session dispatch (plan §4)', () => {
     expect(res.status).toBe(405);
   });
 });
+
+describe('anonymous public MCP (Phase 6)', () => {
+  test('POST /api/mcp/public needs NO auth and gets the anonymous ctx (scopes [], user null)', async () => {
+    handleMcpRequest.mockImplementationOnce(async (req, r) => r.status(200).json({ anon: true }));
+    const res = await fetch(`${baseUrl}/api/mcp/public`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }, // deliberately no Authorization
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    });
+    expect(res.status).toBe(200);
+    const ctx = handleMcpRequest.mock.calls[0][2];
+    expect(ctx.user).toBeNull();
+    expect(ctx.scopes).toEqual([]);
+    expect(ctx.anonymous).toBe(true);
+    expect(initStatefulSession).not.toHaveBeenCalled(); // public = stateless, never sessions
+  });
+
+  test('a bearer header on the public endpoint is simply ignored (still anonymous)', async () => {
+    handleMcpRequest.mockImplementationOnce(async (req, r) => r.status(200).json({}));
+    await fetch(`${baseUrl}/api/mcp/public`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token()}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(handleMcpRequest.mock.calls[0][2].user).toBeNull();
+  });
+
+  test('GET and DELETE /api/mcp/public → 405 (stateless surface, no sessions)', async () => {
+    let res = await fetch(`${baseUrl}/api/mcp/public`, { method: 'GET' });
+    expect(res.status).toBe(405);
+    res = await fetch(`${baseUrl}/api/mcp/public`, { method: 'DELETE' });
+    expect(res.status).toBe(405);
+    expect(getSession).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What this is

MCP Phase 6 (plan §2.1 / §3.9, decision #4): the **growth/AEO surface** — any AI can query Cellarion's shared wine data with no account, and gets an honest pointer to the personal surface for everything else. This makes Cellarion an anonymous wine-data MCP any assistant can call.

**⚠️ STACKED: #721 → #722 → #723 → this.** Merge in order (capture pre-merge tip SHAs; rebase --onto per the documented procedure).

## The endpoint

- `POST /api/mcp/public` — **no auth**, stateless only (GET/DELETE → 405, sessions are never minted here). The anonymous ctx carries `scopes: []` + `user: null`, so the registry's structural filter registers **only** `public`-scoped tools — personal tools are *unregistered* (uncallable, `-32602`), not hidden. Distinct identity (`cellarion-public`) + its own initialize instructions with the sign-up/self-host pointer.
- Strict dedicated per-IP limiter (60/15 min, on the audited spoof-resistant `rateLimitKey` — Cloudflare-aware, IPv6 /64-masked) on top of the global apiLimiter; per-request batch budget **10** for anonymous callers (20 stays for authenticated).

## The public tool surface (7 tools + `cellarion://about`)

- `search_registry` / `get_wine` / `find_similar_wines` — **rescoped `read` → `public`**: registry data is public-site content (every wine has a `public_url`; field set identical to the existing unauthenticated `GET /api/wines/:idOrSlug/public`), and similar-wines is a stored-vector Qdrant lookup — $0/call (§3.17). `find_similar_wines` gains an anonymous `bottle_id` guard (invalid_input → use wine_id). Side effect on the personal endpoint: consume/write-only tokens can now also use registry lookups (needed for the resolve→add flow anyway; audit rated it Info/desirable).
- **NEW `drink_window_for`** — sommelier-curated windows per vintage with where the vintage stands now. **Reviewed profiles only, OG-page field boundary** (window years only — never `sommNotes`/curator); relative (NV) profiles reported as purchase-offsets with no now-status.
- **NEW `list_guides` / `read_guide`** — published blog posts (query-level `status:'published'`, author never populated, 30k-char content cap with `public_url` for the rest). The AEO play: assistants can quote and link the cornerstone articles.
- `get_source_info` + `cellarion://about` (already public-scoped).

## Zero-AI guarantee (the §5.2 absolute)

The anonymous surface can never spend Cellarion AI money: every tool is a DB/Meili/Qdrant read. Pinned **at the runtime boundary** — the test suite mocks `services/embedding` + `services/aiBudget` as *throwing* and drives the similarity flow end-to-end (catches an embed call laundered through any module), plus a static import scan, plus a fail-closed guard: a hypothetically mis-scoped mutating tool refuses (`forbidden_scope`) on an anonymous ctx before any deref.

## Adversarial audit: **GO — 0 High / 0 Med / 3 Low / 2 Info** (all Lows fixed in this PR)

- L1 zero-AI pin strengthened to runtime (above). L2 anonymous-mutation fail-closed guard (above). L3 anonymous batch budget 10 (above).
- Info: the read→public rescope widening to consume/write tokens (accepted, desirable); `get_wine`'s aiProfile/communityRating exposure verified **identical** to the existing public web route (aggregates only, no PII).
- Audit-verified clean: anon ctx never derefs `user` on any public path; no NoSQL-injectable position; guides/windows filtered at the query; the dedicated limiter trips before the global one (no AuditLog spam from floods); bearer/`Mcp-Session-Id` headers on `/public` are simply ignored.

## Verification

- Backend suite: **112 suites / 1724 tests green** (node:20-alpine), incl. the new `publicTools.test.js` (structural anon surface = exactly 7 tools/1 resource/0 prompts, runtime zero-AI pin, fail-closed + budget guards) and updated scope pins.
- **SDK smoke**: anonymous leg asserts the exact tool set, `cellarion://about`, and the `cellarion-public` identity over the wire.
- **Live Docker e2e ALL OK**: real anonymous round-trip — registry search (10 hits), `get_wine` (Barolo Albe), `drink_window_for` (3 curated vintage windows), `list_guides` (20 published), the bottle_id guard, structural unknown-tool refusal for `list_cellars`, GET → 405. Full Phase 1–4 e2e re-run green alongside.
- **Real-model eval: 29/29 (100%)** on claude-opus-4-8 with the two new cases (drink-window intent, storage-guide intent) across the full 41-tool authenticated surface.

## Merge coordination / release notes

- **Prod nginx**: no change needed (`/api/*` already proxies; the new path is under `/api`).
- Docs/marketing (llms.txt, Connect-your-AI page section for the public endpoint) = launch-content work, deliberately not in this PR.
- Compose impact: **none** (in-process, no new service/env/dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)