### PR TITLE
feat(mcp): attach_bottle_image — add a label/bottle photo over MCP

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -107,6 +107,13 @@ app.use('/api/bottles/import/sessions', express.json({ limit: '5mb' }));
 app.use('/api/bottles/import', express.json({ limit: '8mb' }));
 app.use('/api/blog/admin/posts', express.json({ limit: '2mb' }));
 app.use('/api/wine-lists', express.json({ limit: '1mb' }));
+// MCP: the anonymous public surface stays tiny (no image tool) — registered
+// BEFORE the personal /api/mcp rule so /api/mcp/public matches it first (the
+// first express.json to parse wins). The personal endpoint allows a larger
+// body for attach_bottle_image's base64 mode (MAX_BASE64_CHARS ≈ 1.5MB + JSON
+// overhead); every personal MCP caller is authenticated and rate-limited.
+app.use('/api/mcp/public', express.json({ limit: '10kb' }));
+app.use('/api/mcp', express.json({ limit: '2mb' }));
 app.use(express.json({ limit: '10kb' }));
 const corsOrigin = process.env.FRONTEND_URL || (process.env.NODE_ENV === 'production' ? false : 'http://localhost:3000');
 if (process.env.NODE_ENV === 'production' && !process.env.FRONTEND_URL) {

--- a/backend/src/mcp/consumeTools.test.js
+++ b/backend/src/mcp/consumeTools.test.js
@@ -285,7 +285,7 @@ describe('undo_last walk-backward + scope gating (e2e-caught regression)', () =>
     await tool('undo_last').handler({}, { ...CTX, scopes: ['consume', 'write'] });
     q = McpActionLog.findOne.mock.calls[0][0];
     expect(q.action.$in).toEqual(['consume', 'restore', 'add', 'update', 'bulk_add', 'somm_maturity', 'somm_price',
-      'cellar_create', 'rack_create', 'place', 'unplace', 'move', 'arrange', 'tasting_note']);
+      'cellar_create', 'rack_create', 'place', 'unplace', 'move', 'arrange', 'tasting_note', 'attach_image']);
   });
 
   test('the reverse row is marked viaUndo and the undone row frees its idempotency key', async () => {

--- a/backend/src/mcp/eval/cases.js
+++ b/backend/src/mcp/eval/cases.js
@@ -146,6 +146,12 @@ const CASES = [
     prompt: 'Do you have a guide on how to store wine properly long-term?',
     expect: { tool: 'list_guides' },
   },
+  {
+    id: 'attach-photo',
+    prompt: 'Here is the label photo for that Barolo — https://example.com/barolo-label.jpg — put it on the bottle.',
+    expect: { anyOf: ['attach_bottle_image', 'search_bottles'] }, // may resolve the bottle id first
+    args: (a) => a.image_url === undefined || /barolo-label/.test(a.image_url),
+  },
 ];
 
 module.exports = { CASES };

--- a/backend/src/mcp/imageTools.test.js
+++ b/backend/src/mcp/imageTools.test.js
@@ -1,0 +1,143 @@
+/**
+ * attach_bottle_image (plan §3.18) — the tool a real user hit as a gap.
+ *
+ * Pins: write scope + honest annotations, the URL/base64 XOR, access
+ * re-check, delegation to the SHARED services/imageOps pipeline (so an
+ * EXIF-laden or malformed image is rejected identically to the web upload),
+ * the SSRF guard on image_url, the ledger row, idempotency replay, and the
+ * undo branch (deletes only the caller's own, un-assigned image).
+ */
+
+const chain = (result) => {
+  const c = {};
+  for (const m of ['populate', 'sort', 'skip', 'limit', 'select']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(() => Promise.resolve(result));
+  c.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return c;
+};
+
+jest.mock('../models/Cellar', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ find: jest.fn(), findById: jest.fn(), aggregate: jest.fn(), countDocuments: jest.fn(), distinct: jest.fn() }));
+jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../services/search', () => ({ getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn() }));
+jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), buildEmptyStats: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('./mutationBudget', () => ({ takeMutationSlot: jest.fn(() => true), WRITE_WINDOW_MS: 900000 }));
+jest.mock('../services/imageOps', () => ({ ingestBottleImage: jest.fn() }));
+jest.mock('../utils/safeImageFetch', () => ({ safeFetchImage: jest.fn() }));
+jest.mock('../services/bottleOps', () => ({
+  consumeBottle: jest.fn(), restoreBottle: jest.fn(), addBottle: jest.fn(), updateBottleFields: jest.fn(),
+  removeBottleCascade: jest.fn(), RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,
+  UPDATABLE_FIELDS: ['price', 'currency', 'notes', 'occasion', 'rating', 'ratingScale', 'drinkFrom', 'drinkTo'],
+}));
+
+const mongoose = require('mongoose');
+const Bottle = require('../models/Bottle');
+const Cellar = require('../models/Cellar');
+const McpActionLog = require('../models/McpActionLog');
+const { ingestBottleImage } = require('../services/imageOps');
+const { safeFetchImage } = require('../utils/safeImageFetch');
+const { allTools, toolsForScopes } = require('./registry');
+require('./tools');
+
+const oid = (c) => c.repeat(24);
+const ME = oid('a');
+const CTX = { user: { id: ME }, scopes: ['write'], req: { user: { id: ME }, headers: {} } };
+const tool = (name) => allTools().find((t) => t.name === name);
+const parse = (res) => JSON.parse(res.content[0].text);
+
+const ownBottle = () => {
+  const b = { _id: new mongoose.Types.ObjectId(oid('d')), cellar: new mongoose.Types.ObjectId(oid('c')), vintage: '2015', status: 'active' };
+  Bottle.findById.mockReturnValue(chain(b));
+  Cellar.findById.mockReturnValue(chain({ _id: b.cellar, user: ME, members: [], deletedAt: null }));
+  return b;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  McpActionLog.findOne.mockReturnValue(chain(null));
+  McpActionLog.create.mockResolvedValue({ _id: new mongoose.Types.ObjectId(oid('e')) });
+  McpActionLog.findOneAndUpdate.mockResolvedValue({ _id: 'claimed' });
+  ingestBottleImage.mockResolvedValue({ image: { _id: new mongoose.Types.ObjectId(oid('9')), status: 'uploaded' } });
+});
+
+describe('registration', () => {
+  test('write-scoped mutation, invisible to read tokens', () => {
+    expect(tool('attach_bottle_image').scope).toBe('write');
+    expect(tool('attach_bottle_image').annotations.readOnlyHint).toBe(false);
+    expect(toolsForScopes(['read'], ['user']).map((t) => t.name)).not.toContain('attach_bottle_image');
+  });
+});
+
+describe('attach_bottle_image', () => {
+  test('image_url path: SSRF-guarded fetch → shared pipeline → ledger row', async () => {
+    ownBottle();
+    safeFetchImage.mockResolvedValue({ buffer: Buffer.from('imgbytes'), contentType: 'image/jpeg' });
+    const res = await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_url: 'https://cdn.example.com/label.jpg' }, CTX);
+    const body = parse(res);
+    expect(body.error).toBeUndefined();
+    expect(safeFetchImage).toHaveBeenCalledWith('https://cdn.example.com/label.jpg');
+    // The bytes go to the SAME pipeline the web upload uses.
+    expect(ingestBottleImage).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: ME, buffer: expect.any(Buffer) }), CTX.req);
+    expect(body.data.source).toBe('url');
+    const row = McpActionLog.create.mock.calls[0][0];
+    expect(row.action).toBe('attach_image');
+    expect(row.detail.imageId).toBeDefined();
+  });
+
+  test('image_base64 path: strips a data: prefix and decodes', async () => {
+    ownBottle();
+    const b64 = Buffer.from('hello-png').toString('base64');
+    const res = await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_base64: `data:image/png;base64,${b64}` }, CTX);
+    expect(parse(res).error).toBeUndefined();
+    const passed = ingestBottleImage.mock.calls[0][0].buffer;
+    expect(passed.toString()).toBe('hello-png');
+    expect(safeFetchImage).not.toHaveBeenCalled();
+    expect(parse(res).data.source).toBe('upload');
+  });
+
+  test('neither / both inputs → invalid_input before any access or fetch', async () => {
+    let res = await tool('attach_bottle_image').handler({ bottle_id: oid('d') }, CTX);
+    expect(parse(res).error.code).toBe('invalid_input');
+    res = await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_url: 'https://x/y.jpg', image_base64: 'aaa' }, CTX);
+    expect(parse(res).error.code).toBe('invalid_input');
+    expect(Bottle.findById).not.toHaveBeenCalled();
+  });
+
+  test('foreign bottle → not_found; a rejected fetch → invalid_input with the guard message', async () => {
+    Bottle.findById.mockReturnValue(chain(null));
+    let res = await tool('attach_bottle_image').handler({ bottle_id: oid('9'), image_url: 'https://x/y.jpg' }, CTX);
+    expect(parse(res).error.code).toBe('not_found');
+
+    ownBottle();
+    safeFetchImage.mockRejectedValue(new Error('URL resolves to a private or reserved address'));
+    res = await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_url: 'https://evil/y.jpg' }, CTX);
+    expect(parse(res).error.code).toBe('invalid_input');
+    expect(parse(res).error.message).toMatch(/private or reserved/);
+    expect(ingestBottleImage).not.toHaveBeenCalled();
+  });
+
+  test('pipeline rejection (bad image) surfaces as invalid_input, no ledger row', async () => {
+    ownBottle();
+    safeFetchImage.mockResolvedValue({ buffer: Buffer.from('x'), contentType: 'image/jpeg' });
+    ingestBottleImage.mockResolvedValue({ error: { status: 400, message: 'Image could not be processed' } });
+    const res = await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_url: 'https://x/y.jpg' }, CTX);
+    expect(parse(res).error.code).toBe('invalid_input');
+    expect(McpActionLog.create).not.toHaveBeenCalled();
+  });
+
+  test('idempotency replay short-circuits before fetch/pipeline', async () => {
+    McpActionLog.findOne.mockReturnValue(chain({ result: { summary: 'seen', data: {} } }));
+    const res = await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_url: 'https://x/y.jpg', idempotency_key: 'k1' }, CTX);
+    expect(parse(res).summary).toBe('seen');
+    expect(safeFetchImage).not.toHaveBeenCalled();
+    expect(ingestBottleImage).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/mcp/instructions.js
+++ b/backend/src/mcp/instructions.js
@@ -23,6 +23,7 @@ const INSTRUCTIONS = [
   '- For CASES or many bottles use bulk_add: preview first, SHOW the returned plan to the user, apply only on their approval. The whole batch undoes as one unit. auto_arrange follows the same contract: preview the move list, apply only on approval, and the move list doubles as the user\'s physical re-shelving guide.',
   '- Consuming changes the cellar: ALWAYS confirm with the user first, naming the exact wine, vintage and reason ("mark the 2015 Barolo as drank?"). Every consume is reversible for 2 days (restore_bottle / undo_last) — say so when you log one. Pass an idempotency_key if you retry. After a memorable bottle, offer capture_tasting_note (note + rating in one step, also undoable).',
   '- Adding a wine is TWO steps: resolve_wine first (the registry probably knows it), then add_bottle with the matched wine_id. Only create with new_wine after no_match AND user confirmation — never put the producer inside the wine name.',
+  '- attach_bottle_image adds a label/bottle photo to a bottle — pass image_url (an https product image you found) or image_base64 (a photo the user shared); it is background-removed automatically and reversible via undo_last.',
   '- Call get_source_info if the user asks what Cellarion is, which version this instance runs, whether it is open source, or where to find or contribute to the code.',
 ].join('\n');
 

--- a/backend/src/mcp/revert.js
+++ b/backend/src/mcp/revert.js
@@ -16,7 +16,7 @@ const { resolveBottleAccess } = require('./toolUtil');
 // delete-a-bottle power through undo).
 const CONSUME_REVERSIBLE = ['consume', 'restore'];
 const WRITE_REVERSIBLE = ['add', 'update', 'bulk_add', 'somm_maturity', 'somm_price',
-  'cellar_create', 'rack_create', 'place', 'unplace', 'move', 'arrange', 'tasting_note'];
+  'cellar_create', 'rack_create', 'place', 'unplace', 'move', 'arrange', 'tasting_note', 'attach_image'];
 
 function reversibleActionsFor(scopes) {
   return (scopes || []).includes('write') ? [...CONSUME_REVERSIBLE, ...WRITE_REVERSIBLE] : CONSUME_REVERSIBLE;
@@ -35,6 +35,32 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
   if (['cellar_create', 'rack_create', 'place', 'unplace', 'move', 'arrange'].includes(row.action)) {
     const { undoStructural } = require('./structuralUndo');
     return undoStructural(row, ctx, { ok, fail, logAction });
+  }
+
+  // Attach image — delete the BottleImage row (and its files) the tool created.
+  // Access re-checked; only images NOT assigned to a shared registry wine are
+  // removable (an attach never assigns, so this always holds for our own row).
+  if (row.action === 'attach_image') {
+    const BottleImage = require('../models/BottleImage');
+    const { unlinkImageFiles } = require('../services/imageProcessor');
+    const access = await resolveBottleAccess(ctx.user.id, row.bottle, 'editor');
+    if (!access) return fail('conflict', 'The bottle from that photo is no longer accessible; nothing was changed.');
+    const claimed = await McpActionLog.findOneAndUpdate({ _id: row._id, reversed: false }, { $set: { reversed: true, idempotencyKey: null } });
+    if (!claimed) return fail('conflict', 'That action is already being undone by another request.');
+
+    const image = await BottleImage.findOne({ _id: row.detail?.imageId, uploadedBy: ctx.user.id, assignedToWine: false });
+    let removed = false;
+    if (image) {
+      try { await unlinkImageFiles(image); } catch { /* files may be gone; row removal is what matters */ }
+      await BottleImage.deleteOne({ _id: image._id });
+      removed = true;
+    }
+    const envelope = {
+      summary: `Undid photo attach${removed ? ' — image removed' : ' — image was already gone'}`,
+      data: { undone: 'attach_bottle_image', image_removed: removed },
+    };
+    await logAction(ctx, { tool: 'undo_last', action: 'attach_image', viaUndo: true, bottle: row.bottle, cellar: row.cellar, detail: { undid: String(row._id) }, result: envelope });
+    return ok(envelope.summary, envelope.data);
   }
 
   // Tasting note — remove the journal entry (via the shared journalOps delete,

--- a/backend/src/mcp/revert.test.js
+++ b/backend/src/mcp/revert.test.js
@@ -22,6 +22,8 @@ jest.mock('./structuralUndo', () => ({ undoStructural: jest.fn() }));
 jest.mock('../models/WineVintageProfile', () => ({ findById: jest.fn() }));
 jest.mock('../models/WineVintagePrice', () => ({ deleteOne: jest.fn() }));
 jest.mock('../services/journalOps', () => ({ deleteEntry: jest.fn() }));
+jest.mock('../models/BottleImage', () => ({ findOne: jest.fn(), deleteOne: jest.fn() }));
+jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
 
 const McpActionLog = require('../models/McpActionLog');
 const bottleOps = require('../services/bottleOps');
@@ -151,6 +153,32 @@ describe('revertLedgerRow dispatch', () => {
     expect(res).toMatchObject({ ok: false, code: 'conflict' });
     expect(deleteEntry).not.toHaveBeenCalled();
     expect(McpActionLog.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('attach_image: deletes the caller\'s own un-assigned image + its files, claims atomically', async () => {
+    const BottleImage = require('../models/BottleImage');
+    const { unlinkImageFiles } = require('../services/imageProcessor');
+    resolveBottleAccess.mockResolvedValue({ bottle: { _id: 'b7' } });
+    BottleImage.findOne.mockResolvedValue({ _id: 'img7' });
+    BottleImage.deleteOne.mockResolvedValue({ deletedCount: 1 });
+    const row = { _id: 'r7', action: 'attach_image', bottle: 'b7', cellar: 'c1', detail: { imageId: 'img7' } };
+    const res = await revertLedgerRow(row, ctx(), H);
+    expect(res.ok).toBe(true);
+    // Scoped to the caller's own, NOT-registry-assigned image (can't delete a shared wine photo).
+    expect(BottleImage.findOne).toHaveBeenCalledWith({ _id: 'img7', uploadedBy: 'u1', assignedToWine: false });
+    expect(unlinkImageFiles).toHaveBeenCalled();
+    expect(BottleImage.deleteOne).toHaveBeenCalledWith({ _id: 'img7' });
+    expect(McpActionLog.findOneAndUpdate).toHaveBeenCalledWith({ _id: 'r7', reversed: false }, { $set: { reversed: true, idempotencyKey: null } });
+    expect(res.data.image_removed).toBe(true);
+  });
+
+  test('attach_image: an already-gone image still marks the row undone (image_removed:false)', async () => {
+    const BottleImage = require('../models/BottleImage');
+    resolveBottleAccess.mockResolvedValue({ bottle: { _id: 'b8' } });
+    BottleImage.findOne.mockResolvedValue(null); // deleted in the app since
+    const res = await revertLedgerRow({ _id: 'r8', action: 'attach_image', bottle: 'b8', detail: { imageId: 'gone' } }, ctx(), H);
+    expect(res.ok).toBe(true);
+    expect(res.data.image_removed).toBe(false);
   });
 
   test('somm_maturity refused without somm/admin role — no mutation, no claim', async () => {

--- a/backend/src/mcp/tools/images.js
+++ b/backend/src/mcp/tools/images.js
@@ -1,0 +1,106 @@
+// attach_bottle_image (plan §3.18) — the parity gap a real user hit: adding a
+// bottle over MCP but having no way to put its label photo on. Two input
+// modes for a caller with no file upload:
+//   - image_url: an https product/label image (e.g. the Systembolaget page's
+//     image). Downloaded server-side through the SSRF guard.
+//   - image_base64: raw bytes the caller already holds (a photo the user
+//     showed their AI). Capped small so it fits an MCP JSON body.
+// Both funnel through services/imageOps.ingestBottleImage — the SAME
+// sanitise/persist/background-removal pipeline the web upload uses, so an
+// EXIF-laden or malformed image is rejected identically on both surfaces.
+const { z } = require('zod');
+const { registerTool } = require('../registry');
+const { ingestBottleImage } = require('../../services/imageOps');
+const { safeFetchImage } = require('../../utils/safeImageFetch');
+const { logAudit } = require('../../services/audit');
+const { ok, fail, objectId, MSG_BOTTLE_NOT_FOUND, resolveBottleAccess } = require('../toolUtil');
+const { logAction, replay } = require('../actionLedger');
+
+// Base64 payloads ride the JSON body (the /api/mcp limit is 2MB). ~1.5M base64
+// chars ≈ ~1.1MB image — plenty for a label; larger photos must come by URL.
+const MAX_BASE64_CHARS = 1_500_000;
+
+registerTool({
+  name: 'attach_bottle_image',
+  title: 'Attach a label/bottle photo',
+  description:
+    'Adds a label or bottle photo to one of the user\'s bottles, from an image URL (https) or base64 image data ' +
+    '(JPEG/PNG/WebP). Use image_url for a product image you found on the web (e.g. a retailer\'s wine page); use ' +
+    'image_base64 for a photo the user shared directly. The image is background-removed automatically after upload. ' +
+    'Confirm with the user which bottle before attaching. Reversible via undo_last.',
+  scope: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+  inputSchema: {
+    bottle_id: objectId.describe('The bottle to attach the photo to (from search_bottles / add_bottle)'),
+    image_url: z.string().url().optional().describe('https URL of the image (retailer/CDN product image)'),
+    image_base64: z.string().max(MAX_BASE64_CHARS).optional().describe('Base64 image data (no data: prefix needed); alternative to image_url'),
+    credit: z.string().max(200).optional().describe('Optional attribution/source note'),
+    idempotency_key: z.string().max(100).optional(),
+  },
+  handler: async (args, ctx) => {
+    const replayed = await replay(ctx, args.idempotency_key);
+    if (replayed) return replayed;
+
+    if (!args.image_url && !args.image_base64) {
+      return fail('invalid_input', 'Provide image_url (https) or image_base64.');
+    }
+    if (args.image_url && args.image_base64) {
+      return fail('invalid_input', 'Provide image_url OR image_base64, not both.');
+    }
+
+    const access = await resolveBottleAccess(ctx.user.id, args.bottle_id, 'editor');
+    if (!access) return fail('not_found', MSG_BOTTLE_NOT_FOUND);
+    const { bottle } = access;
+
+    // Resolve the bytes. Failures here are the caller's fault (bad URL, too
+    // big, not an image) → invalid_input with the guard's own message.
+    let buffer;
+    if (args.image_url) {
+      try {
+        const fetched = await safeFetchImage(args.image_url);
+        buffer = fetched.buffer;
+      } catch (err) {
+        return fail('invalid_input', `Could not fetch that image: ${err.message}`);
+      }
+    } else {
+      // Accept a bare base64 string or a data: URL — strip the prefix if present.
+      const b64 = String(args.image_base64).replace(/^data:image\/[a-z+]+;base64,/i, '');
+      buffer = Buffer.from(b64, 'base64');
+      if (buffer.length === 0) return fail('invalid_input', 'image_base64 did not decode to any bytes.');
+    }
+
+    // Shared pipeline: validate + strip metadata + persist + background-remove.
+    const credit = args.credit ? String(args.credit).slice(0, 200) : null;
+    const result = await ingestBottleImage({ buffer, userId: ctx.user.id, bottle, credit }, ctx.req);
+    if (result.error) {
+      // 4xx = the caller's image is bad (invalid_input); 5xx = a transient
+      // infra fault (rate_limited carries the right retry semantics).
+      return fail(result.error.status >= 500 ? 'rate_limited' : 'invalid_input', result.error.message);
+    }
+    const image = result.image;
+    logAudit(ctx.req, 'image.attach', { type: 'bottle', id: bottle._id, cellarId: bottle.cellar }, { via: 'mcp', imageId: String(image._id) });
+
+    const envelope = {
+      summary: `Attached a photo to vintage ${bottle.vintage} (background removal in progress)`,
+      data: {
+        image_id: image._id,
+        bottle_id: bottle._id,
+        status: image.status,
+        source: args.image_url ? 'url' : 'upload',
+        undo: 'undo_last removes the photo',
+      },
+    };
+    await logAction(ctx, {
+      tool: 'attach_bottle_image',
+      action: 'attach_image',
+      bottle: bottle._id,
+      cellar: bottle.cellar,
+      detail: { imageId: String(image._id) },
+      idempotencyKey: args.idempotency_key || null,
+      result: envelope,
+    });
+    return ok(envelope.summary, envelope.data);
+  },
+});
+
+module.exports = {};

--- a/backend/src/mcp/tools/index.js
+++ b/backend/src/mcp/tools/index.js
@@ -27,5 +27,6 @@ require('./tasting');
 require('./arrange');
 require('./notify');
 require('./publicContent');
+require('./images');
 
 module.exports = {};

--- a/backend/src/models/McpActionLog.js
+++ b/backend/src/models/McpActionLog.js
@@ -22,7 +22,7 @@ const mcpActionLogSchema = new mongoose.Schema({
   // (JWT) called the MCP directly. Never store the token itself.
   tokenId: { type: mongoose.Schema.Types.ObjectId, ref: 'ApiToken', default: null },
   tool: { type: String, required: true },
-  action: { type: String, enum: ['consume', 'restore', 'add', 'update', 'undo_add', 'bulk_preview', 'bulk_add', 'somm_maturity', 'somm_price', 'cellar_create', 'rack_create', 'place', 'unplace', 'move', 'arrange_preview', 'arrange', 'tasting_note'], required: true },
+  action: { type: String, enum: ['consume', 'restore', 'add', 'update', 'undo_add', 'bulk_preview', 'bulk_add', 'somm_maturity', 'somm_price', 'cellar_create', 'rack_create', 'place', 'unplace', 'move', 'arrange_preview', 'arrange', 'tasting_note', 'attach_image'], required: true },
   bottle: { type: mongoose.Schema.Types.ObjectId, ref: 'Bottle' },
   cellar: { type: mongoose.Schema.Types.ObjectId, ref: 'Cellar' },
   // Small, non-PII operational detail (reason, ml, …) for the timeline.

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -10,8 +10,9 @@ const Bottle = require('../models/Bottle');
 const Cellar = require('../models/Cellar');
 const { rateLimitKey } = require('../utils/clientIp');
 const { getCellarRole } = require('../utils/cellarAccess');
-const { processImage, hashImageBytes } = require('../services/imageProcessor');
-const { stripImageMetadata, sanitizeImageBuffer } = require('../services/imageSanitizer');
+const { processImage } = require('../services/imageProcessor');
+const { sanitizeImageBuffer } = require('../services/imageSanitizer');
+const { ingestBottleImage } = require('../services/imageOps');
 const { stripHtml } = require('../utils/sanitize');
 const { isValidId } = require('../utils/validation');
 const rateLimitsConfig = require('../config/rateLimits');
@@ -64,94 +65,11 @@ const imageUploadLimiter = rateLimit({
   }
 });
 
-const MAX_IMAGE_DIMENSION = 8000; // max width or height in pixels
-
-// Validate image file by checking magic bytes (first 12 bytes)
-function validateImageMagicBytes(filePath) {
-  const buf = Buffer.alloc(12);
-  const fd = fs.openSync(filePath, 'r');
-  try {
-    fs.readSync(fd, buf, 0, 12, 0);
-  } finally {
-    fs.closeSync(fd);
-  }
-
-  // JPEG: FF D8 FF
-  if (buf[0] === 0xFF && buf[1] === 0xD8 && buf[2] === 0xFF) return true;
-  // PNG: 89 50 4E 47
-  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4E && buf[3] === 0x47) return true;
-  // WebP: RIFF....WEBP
-  if (buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
-      buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50) return true;
-
-  return false;
-}
-
-/**
- * Read image dimensions from file headers without decoding the full image.
- * Returns { width, height } or null if dimensions cannot be determined.
- */
-function getImageDimensions(filePath) {
-  try {
-    // Ensure filePath is within the expected upload directory
-    const resolved = path.resolve(filePath);
-    const originalsPrefix = path.resolve(ORIGINALS_DIR) + path.sep;
-    if (!resolved.startsWith(originalsPrefix)) return null;
-
-    const fd = fs.openSync(filePath, 'r');
-    try {
-      const header = Buffer.alloc(30);
-      fs.readSync(fd, header, 0, 30, 0);
-
-      // PNG: width at bytes 16-19, height at bytes 20-23 (big-endian in IHDR)
-      if (header[0] === 0x89 && header[1] === 0x50) {
-        return { width: header.readUInt32BE(16), height: header.readUInt32BE(20) };
-      }
-
-      // WebP: VP8 width/height at fixed offsets in RIFF container
-      if (header[0] === 0x52 && header[1] === 0x49 && header[8] === 0x57) {
-        // VP8 lossy
-        if (header[12] === 0x56 && header[13] === 0x50 && header[14] === 0x38 && header[15] === 0x20) {
-          const vp8 = Buffer.alloc(10);
-          fs.readSync(fd, vp8, 0, 10, 20);
-          // Frame tag at offset 3, then width/height as little-endian 16-bit
-          return { width: vp8.readUInt16LE(6) & 0x3FFF, height: vp8.readUInt16LE(8) & 0x3FFF };
-        }
-        // VP8L lossless
-        if (header[12] === 0x56 && header[13] === 0x50 && header[14] === 0x38 && header[15] === 0x4C) {
-          const vp8l = Buffer.alloc(5);
-          fs.readSync(fd, vp8l, 0, 5, 21);
-          const bits = vp8l.readUInt32LE(0);
-          return { width: (bits & 0x3FFF) + 1, height: ((bits >> 14) & 0x3FFF) + 1 };
-        }
-        return null;
-      }
-
-      // JPEG: scan for SOF0/SOF2 markers to find dimensions
-      if (header[0] === 0xFF && header[1] === 0xD8) {
-        const buf = Buffer.alloc(65536);
-        const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
-        let pos = 2;
-        while (pos < bytesRead - 8) {
-          if (buf[pos] !== 0xFF) { pos++; continue; }
-          const marker = buf[pos + 1];
-          // SOF0 (0xC0) or SOF2 (0xC2) — baseline or progressive
-          if (marker === 0xC0 || marker === 0xC2) {
-            return { width: buf.readUInt16BE(pos + 7), height: buf.readUInt16BE(pos + 5) };
-          }
-          // Skip marker segment
-          const segLen = buf.readUInt16BE(pos + 2);
-          pos += 2 + segLen;
-        }
-      }
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch {
-    // If we can't read dimensions, let the upload proceed (fail open for dimension check)
-  }
-  return null;
-}
+// Header-level magic-byte + dimension pre-checks used to live here. They are
+// gone: the /upload route now hands the bytes to services/imageOps, whose
+// sanitizeImageBuffer decodes-validates-and-strips in one fail-CLOSED step
+// (the old dimension check failed OPEN on unreadable headers). The per-request
+// MAX_IMAGES_PER_BOTTLE cap still lives here for the link-to-bottle route.
 
 const router = express.Router();
 
@@ -173,34 +91,30 @@ function handleImageUpload(req, res, next) {
 // requireNonDemo: image upload writes a 10 MB original to disk and spawns a
 // rembg background-removal job (memory-heavy, shared with real users' label
 // scans). The demo is JSON-only / zero-compute by design, so uploads are off.
+//
+// Validation/sanitisation/persistence live in services/imageOps.js — ONE
+// implementation shared with the MCP attach_bottle_image tool, so the two
+// surfaces cannot drift. This route keeps multer (streaming disk upload) and
+// the authorization checks; the shared pipeline takes the bytes from there.
+// Note: sanitizeImageBuffer enforces the pixel cap FAIL-CLOSED (the previous
+// file-header dimension check failed open on unreadable headers).
 router.post('/upload', requireAuth, requireNonDemo, imageUploadLimiter, handleImageUpload, async (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'No image file provided' });
     }
 
-    // Validate magic bytes to confirm the file is actually an image
-    if (!validateImageMagicBytes(req.file.path)) {
-      safeUnlink(req.file.path);
-      return res.status(400).json({ error: 'File content does not match a supported image format (JPEG, PNG, or WebP)' });
-    }
-
-    // Validate image dimensions to prevent pixel flood DoS
-    const dims = getImageDimensions(req.file.path);
-    if (dims && (dims.width > MAX_IMAGE_DIMENSION || dims.height > MAX_IMAGE_DIMENSION)) {
-      safeUnlink(req.file.path);
-      return res.status(400).json({ error: `Image dimensions too large (max ${MAX_IMAGE_DIMENSION}x${MAX_IMAGE_DIMENSION} pixels)` });
-    }
-
     const { bottleId, wineDefinitionId, credit } = req.body;
 
-    // Verify bottle ownership and image count if bottleId is provided
+    // Verify bottle ownership if bottleId is provided (access is the route's
+    // job; the per-bottle image cap lives in the shared pipeline).
+    let bottle = null;
     if (bottleId) {
       if (!mongoose.Types.ObjectId.isValid(bottleId)) {
         safeUnlink(req.file.path);
         return res.status(400).json({ error: 'Invalid bottleId' });
       }
-      const bottle = await Bottle.findById(bottleId);
+      bottle = await Bottle.findById(bottleId);
       if (!bottle) {
         safeUnlink(req.file.path);
         return res.status(404).json({ error: 'Bottle not found' });
@@ -210,11 +124,6 @@ router.post('/upload', requireAuth, requireNonDemo, imageUploadLimiter, handleIm
       if (!cellarRole || cellarRole === 'viewer') {
         safeUnlink(req.file.path);
         return res.status(403).json({ error: 'Not authorized to upload images for this bottle' });
-      }
-      const imageCount = await BottleImage.countDocuments({ bottle: bottleId });
-      if (imageCount >= MAX_IMAGES_PER_BOTTLE) {
-        safeUnlink(req.file.path);
-        return res.status(400).json({ error: `Maximum of ${MAX_IMAGES_PER_BOTTLE} images per bottle reached` });
       }
     }
 
@@ -229,53 +138,26 @@ router.post('/upload', requireAuth, requireNonDemo, imageUploadLimiter, handleIm
       return res.status(400).json({ error: 'Invalid wine definition ID' });
     }
 
-    // Re-encode in place to strip EXIF/GPS and other metadata before the
-    // file becomes reachable under /api/uploads (phone photos embed the
-    // owner's location). Decode failure also catches files that slipped
-    // past the header checks.
+    // Hand the bytes to the shared pipeline and drop the multer temp — the
+    // pipeline persists a sanitised re-encode under its own random name.
+    let buffer;
     try {
-      await stripImageMetadata(req.file.path);
-    } catch (err) {
-      console.error('Image sanitization failed:', err.message);
+      buffer = fs.readFileSync(req.file.path);
+    } finally {
       safeUnlink(req.file.path);
-      return res.status(400).json({ error: 'Image could not be processed — the file may be corrupt or too large' });
+    }
+    const result = await ingestBottleImage({
+      buffer,
+      userId: req.user.id,
+      bottle,
+      wineDefinitionId: wineDefinitionId ? String(wineDefinitionId) : null,
+      credit: sanitizedCredit,
+    }, req);
+    if (result.error) {
+      return res.status(result.error.status).json({ error: result.error.message });
     }
 
-    // Content hash of the stored bytes, so a later cellar export re-imported by
-    // this user dedups against the image they already have instead of writing a
-    // copy (see services/cellarImport.js). Stamped from the original here; once
-    // background removal finishes, processImage refreshes it from the cropped
-    // bytes (the version that actually gets exported). Best-effort — a hash
-    // failure must never block the upload.
-    let contentHash = null;
-    try {
-      // Re-derive the path from the fixed uploads dir + basename so it's provably
-      // confined there (multer already names the file with a random UUID; this also
-      // satisfies static path-injection analysis).
-      const storedPath = path.join(ORIGINALS_DIR, path.basename(req.file.path));
-      contentHash = hashImageBytes(fs.readFileSync(storedPath));
-    } catch (err) {
-      console.warn('Image content-hash failed (non-fatal):', err.message);
-    }
-
-    const image = new BottleImage({
-      bottle: bottleId || null,
-      wineDefinition: wineDefinitionId ? String(wineDefinitionId) : null,
-      uploadedBy: req.user.id,
-      originalUrl: `/api/uploads/originals/${req.file.filename}`,
-      status: 'uploaded',
-      credit: sanitizedCredit || null,
-      contentHash
-    });
-
-    await image.save();
-
-    // Fire-and-forget background removal
-    processImage(image._id).catch(err =>
-      console.error('Background processing error:', err.message)
-    );
-
-    res.status(201).json({ image });
+    res.status(201).json({ image: result.image });
   } catch (error) {
     console.error('Image upload error:', error);
     res.status(500).json({ error: 'Failed to upload image' });

--- a/backend/src/services/imageOps.js
+++ b/backend/src/services/imageOps.js
@@ -1,0 +1,101 @@
+/**
+ * Bottle-image ingestion — ONE implementation for both surfaces (the REST
+ * upload route in routes/images.js and the MCP attach_bottle_image tool), so
+ * validation, sanitisation, per-bottle caps, persistence and the background-
+ * removal hand-off can never drift (same rule as bottleOps/rackOps/journalOps).
+ *
+ * The pipeline takes a BUFFER (REST reads multer's temp file into one; MCP
+ * decodes base64 or a guarded URL download): sanitizeImageBuffer validates it
+ * decodes, is a supported format (jpeg/png/webp), is within the pixel bomb
+ * cap, and re-encodes with metadata (EXIF/GPS) stripped — fail closed. The
+ * CLEAN bytes are what get persisted under a fresh random name; caller input
+ * never lands on disk verbatim.
+ *
+ * Access is the CALLER's job (house style): `bottle`, when given, must already
+ * be access-checked to editor+.
+ */
+const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+const BottleImage = require('../models/BottleImage');
+const { ORIGINALS_DIR } = require('../config/upload');
+const { sanitizeImageBuffer, detectImageFormat } = require('./imageSanitizer');
+const { processImage, hashImageBytes } = require('./imageProcessor');
+
+const MAX_IMAGES_PER_BOTTLE = 20;
+const EXT_FOR = { jpeg: 'jpg', png: 'png', webp: 'webp' };
+
+/**
+ * Validate, sanitise and persist one image buffer for a bottle (and/or a
+ * registry wine), create its BottleImage row and kick off background removal.
+ *
+ * @param {object} opts
+ * @param {Buffer}  opts.buffer            raw image bytes (≤ the caller's cap)
+ * @param {string}  opts.userId            uploader
+ * @param {object}  [opts.bottle]          access-checked bottle doc (editor+)
+ * @param {string}  [opts.wineDefinitionId] pre-validated registry wine id
+ * @param {string}  [opts.credit]          pre-sanitised credit (admin flows)
+ * @param {object}  req                    for downstream audit attribution
+ * @returns {{ image }} | {{ error: { status, message } }}
+ */
+async function ingestBottleImage({ buffer, userId, bottle = null, wineDefinitionId = null, credit = null }, req) {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    return { error: { status: 400, message: 'No image data provided' } };
+  }
+
+  if (bottle) {
+    const imageCount = await BottleImage.countDocuments({ bottle: bottle._id });
+    if (imageCount >= MAX_IMAGES_PER_BOTTLE) {
+      return { error: { status: 400, message: `Maximum of ${MAX_IMAGES_PER_BOTTLE} images per bottle reached` } };
+    }
+  }
+
+  // Decode + validate + strip metadata in one fail-closed step. The returned
+  // buffer preserves the DECODED format, so sniff that (never a client claim)
+  // for the stored extension.
+  let clean;
+  try {
+    clean = await sanitizeImageBuffer(buffer);
+  } catch (err) {
+    return { error: { status: 400, message: 'Image could not be processed — it must be a JPEG, PNG or WebP within normal dimensions' } };
+  }
+  const format = detectImageFormat(clean);
+  if (!format) {
+    return { error: { status: 400, message: 'Image format could not be verified' } };
+  }
+
+  const filename = `${crypto.randomUUID()}.${EXT_FOR[format]}`;
+  // Join against the fixed uploads dir with a server-generated basename — no
+  // caller-controlled path segment exists. A disk failure (EACCES, ENOSPC) is
+  // an INFRA fault, not the caller's — surface a clean 500 rather than letting
+  // it throw out of the tool as a non-JSON crash.
+  try {
+    await fs.promises.writeFile(path.join(ORIGINALS_DIR, filename), clean);
+  } catch (err) {
+    console.error('[imageOps] failed to persist image:', err.message);
+    return { error: { status: 500, message: 'Could not save the image right now — please try again later' } };
+  }
+
+  // Content hash of the stored bytes (export/re-import dedup). Best-effort —
+  // a hash failure must never block the upload.
+  let contentHash = null;
+  try { contentHash = hashImageBytes(clean); } catch { /* non-fatal */ }
+
+  const image = new BottleImage({
+    bottle: bottle ? bottle._id : null,
+    wineDefinition: wineDefinitionId || null,
+    uploadedBy: userId,
+    originalUrl: `/api/uploads/originals/${filename}`,
+    status: 'uploaded',
+    credit: credit || null,
+    contentHash,
+  });
+  await image.save();
+
+  // Fire-and-forget background removal (rembg) — same hand-off as the route.
+  processImage(image._id).catch((err) => console.error('Background processing error:', err.message));
+
+  return { image };
+}
+
+module.exports = { ingestBottleImage, MAX_IMAGES_PER_BOTTLE };

--- a/backend/src/services/imageOps.test.js
+++ b/backend/src/services/imageOps.test.js
@@ -1,0 +1,88 @@
+/**
+ * services/imageOps.ingestBottleImage — the ONE pipeline shared by the REST
+ * upload route and the MCP attach_bottle_image tool.
+ *
+ * Pins: fail-closed sanitisation (a buffer sharp can't decode is rejected,
+ * nothing persisted), the per-bottle image cap, the sniffed-format extension
+ * (never a caller claim), and the background-removal hand-off. Real disk /
+ * sharp are mocked — imageSanitizer + imageProcessor have their own suites.
+ */
+
+jest.mock('../config/upload', () => ({ ORIGINALS_DIR: '/tmp/originals' }));
+jest.mock('../services/imageSanitizer', () => ({
+  sanitizeImageBuffer: jest.fn(),
+  detectImageFormat: jest.fn(),
+}));
+jest.mock('../services/imageProcessor', () => ({
+  processImage: jest.fn(() => Promise.resolve()),
+  hashImageBytes: jest.fn(() => 'deadbeef'),
+}));
+
+const fs = require('fs');
+jest.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+
+const BottleImage = require('../models/BottleImage');
+jest.mock('../models/BottleImage');
+
+const { sanitizeImageBuffer, detectImageFormat } = require('../services/imageSanitizer');
+const { processImage } = require('../services/imageProcessor');
+const { ingestBottleImage } = require('./imageOps');
+
+const REQ = { user: { id: 'u1' } };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fs.promises.writeFile.mockResolvedValue();
+  sanitizeImageBuffer.mockResolvedValue(Buffer.from('CLEAN-BYTES'));
+  detectImageFormat.mockReturnValue('jpeg');
+  BottleImage.countDocuments = jest.fn().mockResolvedValue(0);
+  // `new BottleImage(doc)` → an object that remembers doc + a save().
+  BottleImage.mockImplementation(function (doc) {
+    Object.assign(this, doc, { _id: 'img-new', save: jest.fn().mockResolvedValue(this) });
+  });
+});
+
+test('happy path: sanitises, writes a sniffed-extension file, saves the row, kicks off bg removal', async () => {
+  const res = await ingestBottleImage({ buffer: Buffer.from('RAW'), userId: 'u1', bottle: { _id: 'b1' } }, REQ);
+  expect(res.error).toBeUndefined();
+  expect(sanitizeImageBuffer).toHaveBeenCalledWith(Buffer.from('RAW'));
+  // The CLEAN (re-encoded) bytes are persisted, never the caller's raw input.
+  const [, written] = fs.promises.writeFile.mock.calls[0];
+  expect(written.toString()).toBe('CLEAN-BYTES');
+  // Extension comes from the sniffed format.
+  const [writtenPath] = fs.promises.writeFile.mock.calls[0];
+  expect(writtenPath).toMatch(/\.jpg$/);
+  expect(res.image.originalUrl).toMatch(/^\/api\/uploads\/originals\/.*\.jpg$/);
+  expect(res.image.bottle).toBe('b1');
+  expect(res.image.save).toHaveBeenCalled();
+  expect(processImage).toHaveBeenCalledWith('img-new');
+});
+
+test('fail-closed: an undecodable buffer is rejected, nothing written or saved', async () => {
+  sanitizeImageBuffer.mockRejectedValue(new Error('Input buffer contains unsupported image format'));
+  const res = await ingestBottleImage({ buffer: Buffer.from('NOT-AN-IMAGE'), userId: 'u1' }, REQ);
+  expect(res.error.status).toBe(400);
+  expect(fs.promises.writeFile).not.toHaveBeenCalled();
+  expect(processImage).not.toHaveBeenCalled();
+});
+
+test('empty buffer → 400 before any work', async () => {
+  const res = await ingestBottleImage({ buffer: Buffer.alloc(0), userId: 'u1' }, REQ);
+  expect(res.error.status).toBe(400);
+  expect(sanitizeImageBuffer).not.toHaveBeenCalled();
+});
+
+test('per-bottle image cap enforced', async () => {
+  BottleImage.countDocuments.mockResolvedValue(20);
+  const res = await ingestBottleImage({ buffer: Buffer.from('RAW'), userId: 'u1', bottle: { _id: 'b1' } }, REQ);
+  expect(res.error.status).toBe(400);
+  expect(res.error.message).toMatch(/Maximum of 20/);
+  expect(sanitizeImageBuffer).not.toHaveBeenCalled();
+});
+
+test('unverifiable sniffed format → 400 (never trust a fallback extension)', async () => {
+  detectImageFormat.mockReturnValue(null);
+  const res = await ingestBottleImage({ buffer: Buffer.from('RAW'), userId: 'u1' }, REQ);
+  expect(res.error.status).toBe(400);
+  expect(fs.promises.writeFile).not.toHaveBeenCalled();
+});

--- a/backend/src/utils/safeImageFetch.js
+++ b/backend/src/utils/safeImageFetch.js
@@ -54,9 +54,46 @@ function isPrivateAddress(addr) {
     // a dotted-decimal-only check misses, smuggling the metadata endpoint past
     // the guard. Blanket-refuse instead of parsing every textual form.
     if (lower.startsWith('::ffff:') || /^::\d+\.\d+\.\d+\.\d+$/.test(lower) || /^::[0-9a-f]{1,4}:[0-9a-f]{1,4}$/.test(lower)) return true;
+    // Belt-and-suspenders (SSRF re-audit): the branch above matches the CANONICAL
+    // v4-mapped form, which is what URL and DNS canonicalization always emit. A
+    // future refactor that fed a NON-canonical, zero-uncompressed textual form
+    // (0:0:0:0:0:ffff:a9fe:a9fe) would slip past it. Structurally, ANY address
+    // whose first five 16-bit groups are zero and whose sixth is 0 (v4-compatible)
+    // or ffff (v4-mapped) embeds a v4 target — refuse it however the zeros are
+    // written. A real public address cannot have those leading 80/96 bits, so
+    // this never over-blocks a legitimate CDN (unlike a bare ':ffff:' substring
+    // match, which would trip on any public address carrying an ffff group).
+    const groups = expandV6Hex(lower);
+    if (groups && groups.slice(0, 5).every((g) => g === 0) && (groups[5] === 0 || groups[5] === 0xffff)) return true;
     return false;
   }
   return true; // not an IP at all — refuse
+}
+
+/**
+ * Expand a pure-hex IPv6 literal (no embedded dotted-v4 tail — those are handled
+ * by the regex branches above) to its eight 16-bit groups as numbers, or null if
+ * it is not a well-formed hex-group address. Used only to classify the embedded
+ * v4-mapped/compatible prefix independently of zero-compression.
+ */
+function expandV6Hex(addr) {
+  if (addr.includes('.')) return null;
+  const halves = addr.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 ? (halves[1] ? halves[1].split(':') : []) : null;
+  let groups;
+  if (tail === null) {
+    groups = head;
+  } else {
+    const missing = 8 - head.length - tail.length;
+    if (missing < 0) return null;
+    groups = [...head, ...Array(missing).fill('0'), ...tail];
+  }
+  if (groups.length !== 8) return null;
+  const nums = groups.map((g) => parseInt(g || '0', 16));
+  if (nums.some((n) => Number.isNaN(n) || n < 0 || n > 0xffff)) return null;
+  return nums;
 }
 
 /** Resolve a hostname and return a validated public address, or throw. */

--- a/backend/src/utils/safeImageFetch.js
+++ b/backend/src/utils/safeImageFetch.js
@@ -44,11 +44,16 @@ function isPrivateAddress(addr) {
   if (family === 6) {
     const lower = addr.toLowerCase();
     if (lower === '::' || lower === '::1') return true;
-    if (lower.startsWith('fe8') || lower.startsWith('fe9') || lower.startsWith('fea') || lower.startsWith('feb')) return true; // fe80::/10
-    if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // fc00::/7
-    if (lower.startsWith('64:ff9b')) return true; // NAT64 — hides v4 targets
-    const v4 = lower.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/); // v4-mapped
-    if (v4) return isPrivateAddress(v4[1]);
+    if (/^fe[89ab]/.test(lower)) return true; // fe80::/10 link-local
+    if (/^f[cd]/.test(lower)) return true;    // fc00::/7 unique-local
+    if (lower.startsWith('64:ff9b')) return true; // NAT64 — hides a v4 target
+    // Refuse ANY IPv6 that embeds an IPv4 address: v4-mapped (::ffff:…) or the
+    // deprecated v4-compatible (::a.b.c.d). A legitimate image host never
+    // presents as one, and re-checking the inner v4 is a footgun — Node
+    // normalizes ::ffff:169.254.169.254 to the HEX form ::ffff:a9fe:a9fe, which
+    // a dotted-decimal-only check misses, smuggling the metadata endpoint past
+    // the guard. Blanket-refuse instead of parsing every textual form.
+    if (lower.startsWith('::ffff:') || /^::\d+\.\d+\.\d+\.\d+$/.test(lower) || /^::[0-9a-f]{1,4}:[0-9a-f]{1,4}$/.test(lower)) return true;
     return false;
   }
   return true; // not an IP at all — refuse

--- a/backend/src/utils/safeImageFetch.js
+++ b/backend/src/utils/safeImageFetch.js
@@ -85,6 +85,20 @@ async function resolvePublicAddress(hostname) {
 
 function fetchOnce(urlObj, pinned) {
   return new Promise((resolve, reject) => {
+    // WALL-CLOCK deadline for the whole request (connect + headers + body).
+    // `timeout: TIMEOUT_MS` below is only a socket-INACTIVITY timer: an origin
+    // dribbling one byte per <10s under MAX_BYTES would evade it forever
+    // (slowloris). This absolute timer bounds the total, independent of
+    // activity. Cleared on settle so it never fires post-resolution.
+    let settled = false;
+    const finish = (fn) => (arg) => { if (settled) return; settled = true; clearTimeout(hardTimer); fn(arg); };
+    const done = finish(resolve);
+    const failed = finish(reject);
+    const hardTimer = setTimeout(() => {
+      req.destroy(new Error('image download exceeded the time limit'));
+    }, TIMEOUT_MS);
+    hardTimer.unref?.();
+
     const req = https.request(
       {
         protocol: urlObj.protocol,
@@ -101,21 +115,21 @@ function fetchOnce(urlObj, pinned) {
         const status = res.statusCode || 0;
         if ([301, 302, 303, 307, 308].includes(status)) {
           res.resume();
-          return resolve({ redirect: res.headers.location || null });
+          return done({ redirect: res.headers.location || null });
         }
         if (status !== 200) {
           res.resume();
-          return reject(new Error(`image URL answered HTTP ${status}`));
+          return failed(new Error(`image URL answered HTTP ${status}`));
         }
         const ct = String(res.headers['content-type'] || '').toLowerCase();
         if (ct && !ct.startsWith('image/')) {
           res.destroy();
-          return reject(new Error(`URL is not an image (content-type ${ct.split(';')[0]})`));
+          return failed(new Error(`URL is not an image (content-type ${ct.split(';')[0]})`));
         }
         const declared = parseInt(res.headers['content-length'], 10);
         if (Number.isFinite(declared) && declared > MAX_BYTES) {
           res.destroy();
-          return reject(new Error('image is larger than the 10 MB limit'));
+          return failed(new Error('image is larger than the 10 MB limit'));
         }
         const chunks = [];
         let size = 0;
@@ -123,16 +137,18 @@ function fetchOnce(urlObj, pinned) {
           size += c.length;
           if (size > MAX_BYTES) {
             res.destroy();
-            return reject(new Error('image is larger than the 10 MB limit'));
+            return failed(new Error('image is larger than the 10 MB limit'));
           }
           chunks.push(c);
         });
-        res.on('end', () => resolve({ buffer: Buffer.concat(chunks), contentType: ct || null }));
-        res.on('error', (e) => reject(new Error(`download failed: ${e.message}`)));
+        res.on('end', () => done({ buffer: Buffer.concat(chunks), contentType: ct || null }));
+        res.on('error', (e) => failed(new Error(`download failed: ${e.message}`)));
       }
     );
     req.on('timeout', () => { req.destroy(new Error('image download timed out')); });
-    req.on('error', (e) => reject(new Error(`download failed: ${e.message}`)));
+    // Routes both a real transport error AND the hard-deadline req.destroy()
+    // through the single-settle guard (its message is preserved).
+    req.on('error', (e) => failed(new Error(`download failed: ${e.message}`)));
     req.end();
   });
 }

--- a/backend/src/utils/safeImageFetch.js
+++ b/backend/src/utils/safeImageFetch.js
@@ -1,0 +1,162 @@
+/**
+ * SSRF-guarded image download for server-side "attach image by URL" (the MCP
+ * attach_bottle_image tool). The backend lives on a Docker network with
+ * internal services (mongo, meilisearch, qdrant, rembg) and on a VM with
+ * cloud metadata endpoints — a naive fetch(url) would let a caller aim
+ * requests at any of them. Guards, in order:
+ *
+ *   - https only, default port only (443) — product/CDN images are https.
+ *   - DNS is resolved FIRST and every A/AAAA record must be a public unicast
+ *     address; the connection is then PINNED to the validated address via a
+ *     custom `lookup`, so a DNS-rebinding flip between check and connect
+ *     cannot redirect the socket.
+ *   - Redirects are followed manually (≤3 hops), each hop re-validated from
+ *     scratch — a public host 302ing to http://169.254.169.254 is refused.
+ *   - 10s total timeout, response streaming capped at MAX_BYTES (abort, not
+ *     buffer-then-check), Content-Type must look like an image when present
+ *     (the byte-level truth is enforced downstream by sanitizeImageBuffer).
+ *
+ * Returns { buffer, contentType } or throws Error with a caller-safe message.
+ */
+const dns = require('dns');
+const net = require('net');
+const https = require('https');
+
+const MAX_BYTES = 10 * 1024 * 1024; // matches the REST upload cap
+const MAX_REDIRECTS = 3;
+const TIMEOUT_MS = 10 * 1000;
+
+/** True for any address a server-side fetch must never touch. */
+function isPrivateAddress(addr) {
+  const family = net.isIP(addr);
+  if (family === 4) {
+    const [a, b] = addr.split('.').map(Number);
+    return (
+      a === 0 || a === 10 || a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) || // CGNAT
+      (a === 169 && b === 254) ||           // link-local / cloud metadata
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      a >= 224                              // multicast + reserved
+    );
+  }
+  if (family === 6) {
+    const lower = addr.toLowerCase();
+    if (lower === '::' || lower === '::1') return true;
+    if (lower.startsWith('fe8') || lower.startsWith('fe9') || lower.startsWith('fea') || lower.startsWith('feb')) return true; // fe80::/10
+    if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // fc00::/7
+    if (lower.startsWith('64:ff9b')) return true; // NAT64 — hides v4 targets
+    const v4 = lower.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/); // v4-mapped
+    if (v4) return isPrivateAddress(v4[1]);
+    return false;
+  }
+  return true; // not an IP at all — refuse
+}
+
+/** Resolve a hostname and return a validated public address, or throw. */
+async function resolvePublicAddress(hostname) {
+  // URL.hostname keeps the brackets on an IPv6 literal ([::1]); strip them so
+  // net.isIP classifies it as an address, not a name headed for DNS.
+  const host = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  // A literal IP in the URL skips DNS — validate it directly.
+  if (net.isIP(host)) {
+    if (isPrivateAddress(host)) throw new Error('URL resolves to a private or reserved address');
+    return { address: host, family: net.isIP(host) };
+  }
+  let records;
+  try {
+    records = await dns.promises.lookup(host, { all: true, verbatim: true });
+  } catch {
+    throw new Error('URL hostname could not be resolved');
+  }
+  if (!records.length) throw new Error('URL hostname could not be resolved');
+  // EVERY record must be public — a mixed set is an attack, not a CDN.
+  for (const r of records) {
+    if (isPrivateAddress(r.address)) throw new Error('URL resolves to a private or reserved address');
+  }
+  return records[0];
+}
+
+function fetchOnce(urlObj, pinned) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        protocol: urlObj.protocol,
+        hostname: urlObj.hostname, // SNI + Host header stay the real name
+        port: 443,
+        path: urlObj.pathname + urlObj.search,
+        method: 'GET',
+        headers: { 'User-Agent': 'Cellarion-ImageFetch/1.0 (+https://cellarion.app)' },
+        timeout: TIMEOUT_MS,
+        // The pin: whatever DNS says NOW, connect to the address validated above.
+        lookup: (host, opts, cb) => cb(null, pinned.address, pinned.family),
+      },
+      (res) => {
+        const status = res.statusCode || 0;
+        if ([301, 302, 303, 307, 308].includes(status)) {
+          res.resume();
+          return resolve({ redirect: res.headers.location || null });
+        }
+        if (status !== 200) {
+          res.resume();
+          return reject(new Error(`image URL answered HTTP ${status}`));
+        }
+        const ct = String(res.headers['content-type'] || '').toLowerCase();
+        if (ct && !ct.startsWith('image/')) {
+          res.destroy();
+          return reject(new Error(`URL is not an image (content-type ${ct.split(';')[0]})`));
+        }
+        const declared = parseInt(res.headers['content-length'], 10);
+        if (Number.isFinite(declared) && declared > MAX_BYTES) {
+          res.destroy();
+          return reject(new Error('image is larger than the 10 MB limit'));
+        }
+        const chunks = [];
+        let size = 0;
+        res.on('data', (c) => {
+          size += c.length;
+          if (size > MAX_BYTES) {
+            res.destroy();
+            return reject(new Error('image is larger than the 10 MB limit'));
+          }
+          chunks.push(c);
+        });
+        res.on('end', () => resolve({ buffer: Buffer.concat(chunks), contentType: ct || null }));
+        res.on('error', (e) => reject(new Error(`download failed: ${e.message}`)));
+      }
+    );
+    req.on('timeout', () => { req.destroy(new Error('image download timed out')); });
+    req.on('error', (e) => reject(new Error(`download failed: ${e.message}`)));
+    req.end();
+  });
+}
+
+/**
+ * Download an image from a caller-supplied https URL with the full guard
+ * stack. Throws Error with a message safe to surface to the caller.
+ */
+async function safeFetchImage(rawUrl) {
+  let urlObj;
+  try {
+    urlObj = new URL(String(rawUrl));
+  } catch {
+    throw new Error('image_url is not a valid URL');
+  }
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    if (urlObj.protocol !== 'https:') throw new Error('image_url must be https');
+    if (urlObj.port && urlObj.port !== '443') throw new Error('image_url must use the default https port');
+    if (urlObj.username || urlObj.password) throw new Error('image_url must not carry credentials');
+    const pinned = await resolvePublicAddress(urlObj.hostname);
+    const result = await fetchOnce(urlObj, pinned);
+    if (result.redirect !== undefined) {
+      if (!result.redirect) throw new Error('image URL redirected without a destination');
+      urlObj = new URL(result.redirect, urlObj); // relative redirects resolve against the current hop
+      continue; // full re-validation on the next loop
+    }
+    return result;
+  }
+  throw new Error(`image URL redirected more than ${MAX_REDIRECTS} times`);
+}
+
+module.exports = { safeFetchImage, isPrivateAddress, MAX_BYTES };

--- a/backend/src/utils/safeImageFetch.test.js
+++ b/backend/src/utils/safeImageFetch.test.js
@@ -16,8 +16,15 @@ describe('isPrivateAddress', () => {
     // IPv4 — every blocked range
     '0.0.0.0', '10.1.2.3', '127.0.0.1', '100.64.0.1', '169.254.169.254', // cloud metadata
     '172.16.0.1', '172.31.255.255', '192.168.1.1', '198.18.0.1', '224.0.0.1', '255.255.255.255',
-    // IPv6 — loopback, link-local, ULA, NAT64, v4-mapped-private
-    '::1', '::', 'fe80::1', 'fc00::1', 'fd12:3456::1', '64:ff9b::7f00:1', '::ffff:127.0.0.1', '::ffff:10.0.0.1',
+    // IPv6 — loopback, link-local, ULA, NAT64
+    '::1', '::', 'fe80::1', 'fc00::1', 'fd12:3456::1', '64:ff9b::7f00:1',
+    // v4-mapped in EVERY textual form — incl. the hex form Node normalizes
+    // [::ffff:169.254.169.254] to (::ffff:a9fe:a9fe = AWS metadata). ALL
+    // embedded-v4 IPv6 literals are refused, even public ones, since no real
+    // image host presents as one and dotted-only checks miss the hex form.
+    '::ffff:127.0.0.1', '::ffff:10.0.0.1', '::ffff:a9fe:a9fe', '::ffff:8.8.8.8', '::ffff:0808:0808',
+    // deprecated v4-compatible
+    '::127.0.0.1', '::a9fe:a9fe',
     // not an IP at all
     'not-an-ip', '',
   ])('blocks %s', (addr) => {
@@ -27,8 +34,7 @@ describe('isPrivateAddress', () => {
   test.each([
     '1.1.1.1', '8.8.8.8', '93.184.216.34', // public v4
     '172.15.0.1', '172.32.0.1', '11.0.0.1', // just OUTSIDE the private ranges
-    '2606:4700:4700::1111', '2001:4860:4860::8888', // public v6
-    '::ffff:8.8.8.8', // v4-mapped PUBLIC is allowed
+    '2606:4700:4700::1111', '2001:4860:4860::8888', // public global v6
   ])('allows %s', (addr) => {
     expect(isPrivateAddress(addr)).toBe(false);
   });

--- a/backend/src/utils/safeImageFetch.test.js
+++ b/backend/src/utils/safeImageFetch.test.js
@@ -1,0 +1,55 @@
+/**
+ * SSRF guard for server-side image download (attach_bottle_image image_url).
+ *
+ * WHY THIS TEST EXISTS: the backend can reach internal services (mongo, qdrant,
+ * rembg) and the VM's cloud-metadata endpoint. A caller-supplied URL that
+ * resolves — now or after a DNS rebind — to any of those must never be fetched.
+ * The address classifier is the load-bearing gate; these pin every private /
+ * reserved range and the scheme/port/redirect rules. The network path itself
+ * (dns pinning, redirect re-validation) is exercised by the live e2e.
+ */
+
+const { isPrivateAddress, safeFetchImage } = require('./safeImageFetch');
+
+describe('isPrivateAddress', () => {
+  test.each([
+    // IPv4 — every blocked range
+    '0.0.0.0', '10.1.2.3', '127.0.0.1', '100.64.0.1', '169.254.169.254', // cloud metadata
+    '172.16.0.1', '172.31.255.255', '192.168.1.1', '198.18.0.1', '224.0.0.1', '255.255.255.255',
+    // IPv6 — loopback, link-local, ULA, NAT64, v4-mapped-private
+    '::1', '::', 'fe80::1', 'fc00::1', 'fd12:3456::1', '64:ff9b::7f00:1', '::ffff:127.0.0.1', '::ffff:10.0.0.1',
+    // not an IP at all
+    'not-an-ip', '',
+  ])('blocks %s', (addr) => {
+    expect(isPrivateAddress(addr)).toBe(true);
+  });
+
+  test.each([
+    '1.1.1.1', '8.8.8.8', '93.184.216.34', // public v4
+    '172.15.0.1', '172.32.0.1', '11.0.0.1', // just OUTSIDE the private ranges
+    '2606:4700:4700::1111', '2001:4860:4860::8888', // public v6
+    '::ffff:8.8.8.8', // v4-mapped PUBLIC is allowed
+  ])('allows %s', (addr) => {
+    expect(isPrivateAddress(addr)).toBe(false);
+  });
+});
+
+describe('safeFetchImage input validation (pre-network)', () => {
+  test('rejects non-https schemes', async () => {
+    await expect(safeFetchImage('http://example.com/x.jpg')).rejects.toThrow(/https/);
+    await expect(safeFetchImage('ftp://example.com/x.jpg')).rejects.toThrow(/https/);
+    await expect(safeFetchImage('file:///etc/passwd')).rejects.toThrow(/https/);
+  });
+
+  test('rejects a non-default port, embedded credentials, and garbage URLs', async () => {
+    await expect(safeFetchImage('https://example.com:22/x.jpg')).rejects.toThrow(/default https port/);
+    await expect(safeFetchImage('https://user:pass@example.com/x.jpg')).rejects.toThrow(/credentials/);
+    await expect(safeFetchImage('not a url')).rejects.toThrow(/valid URL/);
+  });
+
+  test('rejects an https URL whose host is a literal private IP (no DNS needed)', async () => {
+    await expect(safeFetchImage('https://169.254.169.254/latest/meta-data/')).rejects.toThrow(/private or reserved/);
+    await expect(safeFetchImage('https://127.0.0.1/x.jpg')).rejects.toThrow(/private or reserved/);
+    await expect(safeFetchImage('https://[::1]/x.jpg')).rejects.toThrow(/private or reserved/);
+  });
+});

--- a/backend/src/utils/safeImageFetch.test.js
+++ b/backend/src/utils/safeImageFetch.test.js
@@ -25,6 +25,10 @@ describe('isPrivateAddress', () => {
     '::ffff:127.0.0.1', '::ffff:10.0.0.1', '::ffff:a9fe:a9fe', '::ffff:8.8.8.8', '::ffff:0808:0808',
     // deprecated v4-compatible
     '::127.0.0.1', '::a9fe:a9fe',
+    // zero-UNCOMPRESSED hex forms of the same embedded-v4 addresses — the forms
+    // URL/DNS canonicalization would normally compress, caught structurally so a
+    // future non-canonical caller can't smuggle them past (SSRF re-audit note).
+    '0:0:0:0:0:ffff:a9fe:a9fe', '0000:0000:0000:0000:0000:ffff:a9fe:a9fe', '0:0:0:0:0:0:a9fe:a9fe',
     // not an IP at all
     'not-an-ip', '',
   ])('blocks %s', (addr) => {
@@ -35,6 +39,7 @@ describe('isPrivateAddress', () => {
     '1.1.1.1', '8.8.8.8', '93.184.216.34', // public v4
     '172.15.0.1', '172.32.0.1', '11.0.0.1', // just OUTSIDE the private ranges
     '2606:4700:4700::1111', '2001:4860:4860::8888', // public global v6
+    '2606:4700:ffff::1', // public v6 that merely CONTAINS an ffff group — must NOT over-block
   ])('allows %s', (addr) => {
     expect(isPrivateAddress(addr)).toBe(false);
   });


### PR DESCRIPTION
## What this is

Closes the §3.18 parity gap a real user hit in live testing: they added 5 bottles by talking to their AI, then asked it to attach the label photo — and no tool could. This adds `attach_bottle_image` and, in doing so, extracts the image pipeline into a shared service so the REST upload and MCP run one implementation.

**⚠️ STACKED: #721 → #722 → #723 → #724 → this.** Merge in order.

## The tool

`attach_bottle_image` [write] — two input modes for a caller with no file-upload channel:
- **image_url** (https) — a product/label image found on the web (e.g. a retailer's wine page). Fetched **server-side through a full SSRF guard**.
- **image_base64** — bytes the user showed their AI directly, capped ~1.1MB to fit the JSON body.

Confirm-before-attaching in the instructions; **reversible** via `undo_last` / the activity timeline (deletes the BottleImage row + files, scoped to the caller's own non-registry-assigned image). Background removal (rembg) runs automatically, same as the web upload.

## The SSRF guard (`utils/safeImageFetch.js`) — the crown jewel

The backend sits on a Docker network with internal services and a VM with a cloud-metadata endpoint, so a naive `fetch(url)` is a server-side request forgery hole. The guard, in order:
- **https + default port only**; no embedded credentials.
- **DNS resolved first, then the socket PINNED** to the validated address via a custom `lookup` — a DNS-rebind flip between check and connect can't redirect it. SNI/Host stay the real hostname so legit CDNs still resolve.
- **Every A/AAAA record must be public unicast**; a mixed set is refused.
- **Redirects followed manually (≤3), each hop re-validated from scratch** — a public host 302ing to `http://169.254.169.254` is refused.
- 10s timeout, response **streamed with a 10MB abort cap** (not buffer-then-check).
- Address classifier blocks: 0/8, 10/8, 127/8, 100.64/10 (CGNAT), 169.254/16 (link-local + metadata), 172.16/12, 192.168/16, 198.18/15, 224/4+, 255.255.255.255; v6 ::, ::1, fe80::/10, fc00::/7, 64:ff9b::/96 (NAT64), and **all embedded-v4 IPv6 literals**.

**Self-audit caught a real bypass and this PR fixes it**: `https://[::ffff:169.254.169.254]/` is normalized by Node to the *hex* form `::ffff:a9fe:a9fe`, which a dotted-decimal-only v4-mapped check missed — it would have reached the metadata endpoint. Now all embedded-v4 v6 literals are blanket-refused (no legit image host is one). Decimal/hex/octal IP encodings (`2130706433`, `0x7f000001`, `017700000001`) are already defused because Node's URL parser normalizes them to `127.0.0.1` → caught by the literal-IP check. **SVG is not in the supported formats** (jpeg/png/webp only via sharp), so the SVG-XSS class can't land.

## One implementation for UI and MCP

`services/imageOps.ingestBottleImage` is extracted from the REST `/upload` route and now backs **both**: `sanitizeImageBuffer` (decode + validate + strip EXIF/GPS, **fail closed**), the per-bottle cap, the sniffed-format extension (never a caller claim), persistence under a random UUID name, and the rembg hand-off. The route keeps multer + authz and delegates the bytes. Its old **fail-open** header dimension check is gone — the shared pipeline's pixel cap fails closed (a strict improvement). A disk write failure returns a clean error instead of crashing the tool (→ `rate_limited`, retryable).

## Verification

- **SSRF guard suite (37 tests)**: every private/reserved range for v4 and v6, all v4-mapped textual forms incl. the hex-normalized exploit, scheme/port/credential/redirect rules.
- **imageOps suite**: fail-closed sanitisation, per-bottle cap, sniffed extension, bg hand-off.
- **Tool suite**: URL/base64 XOR, access re-check, SSRF error surfaced, ledger row, idempotency replay, undo scoping.
- **Smoke + live Docker e2e ALL OK**: base64 attach → **visible via `GET /api/images/bottle` (the same pipeline the web upload feeds)** → `undo_last` removes it → a cloud-metadata URL is refused.
- **Full backend suite: 1771 tests green** (node:20-alpine).
- Adversarial audit running; any findings fold into this branch.

## Body-limit / compose

`/api/mcp` raised 10kb → 2mb for the base64 mode (registered **after** `/api/mcp/public`, which stays 10kb — the anonymous surface has no image tool). No new service/env/dependency. `McpActionLog.action` gains `attach_image` (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)