### PR TITLE
fix(mcp): OAuth audience covers the full session lifecycle — GET/DELETE /api/mcp

### DIFF
--- a/backend/src/middleware/apiTokenAuth.js
+++ b/backend/src/middleware/apiTokenAuth.js
@@ -99,13 +99,16 @@ function isApiTokenCredential(credential) {
 }
 
 /**
- * The one request an OAuth-issued token may make: the MCP endpoint it was
- * minted for. Exact-anchored, same shape as the allowlist patterns.
- * Exported for direct unit testing.
+ * The one surface an OAuth-issued token may reach: the MCP endpoint it was
+ * minted for. Exact-anchored, same shape as the allowlist patterns. All three
+ * verbs of the MCP session lifecycle count as the audience (POST = requests,
+ * GET = the session's standalone SSE stream, DELETE = session termination) —
+ * confining to POST alone would let an OAuth connector initialize a session it
+ * could then never stream from or terminate. Exported for direct unit testing.
  */
 function isMcpEndpoint(method, path) {
   const p = path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
-  return method === 'POST' && /^\/api\/mcp$/.test(p);
+  return (method === 'POST' || method === 'GET' || method === 'DELETE') && /^\/api\/mcp$/.test(p);
 }
 
 /** Default-deny scope check. Exported for direct unit testing. */

--- a/backend/src/middleware/apiTokenAuth.test.js
+++ b/backend/src/middleware/apiTokenAuth.test.js
@@ -136,6 +136,31 @@ describe('isRequestAllowed (default-deny)', () => {
     expect(isRequestAllowed(undefined, 'GET', '/api/stats')).toBe(false);
   });
 
+  test('MCP session verbs: GET/DELETE on the exact path are allowed per scope', () => {
+    for (const scopes of [READ, CONSUME, ['write']]) {
+      expect(isRequestAllowed(scopes, 'GET', '/api/mcp')).toBe(true);
+      expect(isRequestAllowed(scopes, 'DELETE', '/api/mcp')).toBe(true);
+    }
+    // …but never a sibling or sub-path (activity stays JWT-only).
+    expect(isRequestAllowed(READ, 'GET', '/api/mcp/activity')).toBe(false);
+    expect(isRequestAllowed(READ, 'DELETE', '/api/mcp/public')).toBe(false);
+  });
+
+  test('isMcpEndpoint (OAuth audience): all three session verbs on the exact path, nothing else', () => {
+    const { isMcpEndpoint } = require('./apiTokenAuth');
+    // The MCP session lifecycle: POST requests, GET SSE stream, DELETE terminate.
+    // Confining OAuth tokens to POST alone would let a connector initialize a
+    // session it could never stream from or terminate (#719 + #723 coordination).
+    for (const method of ['POST', 'GET', 'DELETE']) {
+      expect(isMcpEndpoint(method, '/api/mcp')).toBe(true);
+      expect(isMcpEndpoint(method, '/api/mcp/')).toBe(true); // trailing slash normalized
+    }
+    expect(isMcpEndpoint('PUT', '/api/mcp')).toBe(false);
+    expect(isMcpEndpoint('GET', '/api/mcp/activity')).toBe(false);
+    expect(isMcpEndpoint('POST', '/api/mcp/public')).toBe(false);
+    expect(isMcpEndpoint('GET', '/api/stats')).toBe(false);
+  });
+
   test('climate scope allows exactly POST /api/climate/ingest — the device credential', () => {
     const CLIMATE = ['climate'];
     expect(isRequestAllowed(CLIMATE, 'POST', '/api/climate/ingest')).toBe(true);


### PR DESCRIPTION
The **#719 + #723 merge-coordination fix**, flagged in both PRs' notes — required now that both are on main.

#719 confined `origin:'oauth'` tokens to `POST /api/mcp` (RFC 8707 audience enforcement). #723 made `/api/mcp` stateful: sessions stream server→client pushes over **GET** and terminate over **DELETE** on the same path. With POST-only confinement, an OAuth-connected AI could initialize a session it could then never stream from or terminate.

**Change:** `isMcpEndpoint` accepts `POST|GET|DELETE` on the exact-anchored path — still nothing else (no `/api/mcp/activity` which stays JWT-only, no `/api/mcp/public`, no REST routes). The per-scope allowlist already carried the GET/DELETE entries from #723, so this only widens the audience check to match. New unit tests pin all three verbs + the sibling/sub-path denials.

Verified: apiTokenAuth + routes/mcp suites green in node:20-alpine (81 tests); full suite run in progress on the merged main. Compose impact: none.