### PR TITLE
feat(mcp): deprecation marker + versioning policy + connect docs

### DIFF
--- a/backend/src/mcp/registry.js
+++ b/backend/src/mcp/registry.js
@@ -14,6 +14,21 @@
 const tools = [];
 
 /**
+ * Deprecation marker (docs/mcp-versioning.md): a deprecated tool/resource/
+ * prompt STAYS registered and callable through its sunset window, but its
+ * description — the text driving model tool-selection — leads with the
+ * deprecation and the migration path, so calling models steer themselves to
+ * the replacement without any client-side support.
+ */
+function applyDeprecation(def) {
+  if (!def.deprecated) return def;
+  if (typeof def.deprecated !== 'string' || !def.deprecated.trim()) {
+    throw new Error(`register(${def.name}): deprecated must be a non-empty migration message (e.g. "use search_bottles instead; removed after v1.90")`);
+  }
+  return { ...def, description: `[DEPRECATED — ${def.deprecated.trim()}] ${def.description || ''}`.trim() };
+}
+
+/**
  * Register an MCP tool. Throws on a duplicate name (a programming error).
  * @param {object} def
  * @param {string}   def.name          unique snake_case tool name
@@ -22,6 +37,7 @@ const tools = [];
  * @param {string}   def.scope         required token scope ('public' | 'read' | …)
  * @param {object}   [def.inputSchema] zod raw shape ({} = no params)
  * @param {object}   [def.annotations] MCP hints (readOnlyHint, destructiveHint, …)
+ * @param {string}   [def.deprecated]  migration message — see docs/mcp-versioning.md
  * @param {Function} def.handler       async (args, ctx) => ({ content: [...] })
  */
 function registerTool(def) {
@@ -37,7 +53,7 @@ function registerTool(def) {
   if (tools.some((t) => t.name === def.name)) {
     throw new Error(`registerTool: duplicate tool name "${def.name}"`);
   }
-  tools.push({ inputSchema: {}, annotations: {}, ...def });
+  tools.push(applyDeprecation({ inputSchema: {}, annotations: {}, ...def }));
 }
 
 /**
@@ -111,7 +127,7 @@ function registerResource(def) {
   if (resources.some((r) => r.name === def.name)) {
     throw new Error(`registerResource: duplicate resource name "${def.name}"`);
   }
-  resources.push({ mimeType: 'application/json', ...def });
+  resources.push(applyDeprecation({ mimeType: 'application/json', ...def }));
 }
 
 /** The subset of registered resources a token with `tokenScopes` may read. */
@@ -157,7 +173,7 @@ function registerPrompt(def) {
   if (prompts.some((p) => p.name === def.name)) {
     throw new Error(`registerPrompt: duplicate prompt name "${def.name}"`);
   }
-  prompts.push({ argsSchema: {}, ...def });
+  prompts.push(applyDeprecation({ argsSchema: {}, ...def }));
 }
 
 /** The subset of registered prompts a token with `tokenScopes` may use. */

--- a/backend/src/mcp/registry.test.js
+++ b/backend/src/mcp/registry.test.js
@@ -48,3 +48,29 @@ describe('get_source_info handler', () => {
     expect(JSON.stringify(info)).not.toMatch(/secret|password|token|api[_-]?key|process\.env/i);
   });
 });
+
+describe('deprecation marker (docs/mcp-versioning.md)', () => {
+  test('a deprecated tool stays registered but its description LEADS with the migration path', () => {
+    registerTool({
+      name: 'zz_test_deprecated', title: 'Old tool', scope: 'read',
+      description: 'Does the old thing.',
+      deprecated: 'use zz_new_tool instead; removed after v1.99',
+      handler: async () => ({}),
+    });
+    const t = allTools().find((x) => x.name === 'zz_test_deprecated');
+    expect(t.description).toBe('[DEPRECATED — use zz_new_tool instead; removed after v1.99] Does the old thing.');
+    expect(t.deprecated).toBeTruthy();
+  });
+
+  test('an empty deprecation message is a programming error (the marker must carry a migration path)', () => {
+    expect(() => registerTool({
+      name: 'zz_test_deprecated_bad', scope: 'read', description: 'x',
+      deprecated: '   ', handler: async () => ({}),
+    })).toThrow(/migration message/i);
+  });
+
+  test('no live tool ships deprecated right now (drift guard — clean the marker after each sunset)', () => {
+    const live = allTools().filter((t) => t.deprecated && !t.name.startsWith('zz_test_'));
+    expect(live).toEqual([]);
+  });
+});

--- a/docs/mcp-connect.md
+++ b/docs/mcp-connect.md
@@ -1,0 +1,100 @@
+# Connecting an AI to Cellarion (MCP)
+
+Cellarion ships a built-in [MCP](https://modelcontextprotocol.io) server:
+any MCP-capable assistant (Claude, ChatGPT, Cursor, …) can search the
+cellar, advise what to open, add/consume bottles, and organise racks — with
+scoped permissions, an in-app activity trail, and one-click undo. This doc
+is the operator/developer view; the in-app path for users is **Settings →
+Connect your AI**.
+
+## The three ways in
+
+| Path | Endpoint | Auth | For |
+|---|---|---|---|
+| One-click connector | `POST /api/mcp` | OAuth 2.1 (see [mcp-oauth.md](mcp-oauth.md)) | claude.ai / ChatGPT custom connectors |
+| Personal token | `POST /api/mcp` | `Authorization: Bearer cel_…` | stdio bridges, scripts, self-rolled agents |
+| Anonymous public | `POST /api/mcp/public` | none | registry lookups, drink windows, guides — no account, no PII, strict rate limit |
+
+Transport is stateless Streamable HTTP; a client that `initialize`s may be
+granted a stateful session (`Mcp-Session-Id`) with a GET/SSE stream for
+`resources/subscribe` pushes. `GET /api/mcp` without a session → 405.
+
+## Scopes
+
+Minted per token in Settings (OAuth consent grants map to the same scopes):
+
+- `read` — everything read-only: search/list/get, stats, exports discovery,
+  sommelier intelligence.
+- `consume` — consume/open/pour/restore + `undo_last`.
+- `write` — add/edit bottles, racks/cellars, bulk + arrange, wine lists,
+  tasting notes, preferences/profile, account export links.
+- `climate` — sensor ingest only (device tokens; not an AI scope).
+
+Scope enforcement is **structural**: a tool outside the token's scopes is
+never registered on that request's server — invisible in `tools/list`,
+unknown on `tools/call`. Sommelier curation tools additionally require the
+`somm`/`admin` role (re-read per request for `cel_` tokens).
+
+## Claude Desktop / Cursor (stdio bridge)
+
+The [`cellarion-mcp`](../cellarion-mcp/) npm package proxies stdio ⇄
+Streamable HTTP. `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cellarion": {
+      "command": "npx",
+      "args": ["-y", "cellarion-mcp"],
+      "env": {
+        "CELLARION_TOKEN": "cel_your_token_here",
+        "CELLARION_URL": "https://cellarion.your-domain.example"
+      }
+    }
+  }
+}
+```
+
+`CELLARION_URL` defaults to `https://cellarion.app`. `--token` / `--url`
+flags work too.
+
+## Smoke test (curl)
+
+```bash
+curl -s https://your-host/api/mcp \
+  -H "Authorization: Bearer $CEL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
+```
+
+Expect `serverInfo.name: "cellarion"` and the instructions block. The same
+call unauthenticated must return **401 + `WWW-Authenticate: Bearer
+resource_metadata=…`** (that header is how OAuth clients discover the
+authorization server — RFC 9728).
+
+## Operational levers
+
+- **Kill switches** (Admin → AI Connector, or `PATCH
+  /api/admin/settings/rate-limits` `{ mcp: { enabled, publicEnabled } }`):
+  `enabled=0` → the whole AI surface answers 503; `publicEnabled=0` → only
+  the anonymous endpoint sheds. The in-app activity timeline, revert, and
+  export-link downloads stay up either way.
+- **Usage view**: `GET /api/admin/mcp/usage` + the Admin → AI Connector
+  page — per-day calls/errors, top tools, OAuth-vs-bearer connection
+  counts.
+- **Per-user revocation**: deleting a token in Settings cuts its access on
+  the next request; OAuth grants revoke the same way (they are ApiToken
+  rows underneath).
+- **Budgets**: per-request call cap (20; 10 anonymous), per-user mutation
+  budget (shared with the REST write limiter), the AI daily budget for the
+  few tools that spend AI (semantic search embeds), and the public
+  endpoint's dedicated per-IP limiter.
+
+## Self-hosting notes
+
+- No compose changes: the MCP server runs in-process in the backend.
+- OAuth discovery needs the `.well-known` nginx pass-through — see the
+  **PROD deployment steps** in [mcp-oauth.md](mcp-oauth.md).
+- The contract stability rules (what may change when, how tools retire)
+  live in [mcp-versioning.md](mcp-versioning.md).

--- a/docs/mcp-versioning.md
+++ b/docs/mcp-versioning.md
@@ -1,0 +1,74 @@
+# MCP tool versioning & deprecation policy
+
+The MCP surface is a **contract**: external agents get wired against tool
+names, input schemas, and response shapes, and unlike our own frontend they
+don't redeploy when we do. This document is the policy that keeps that
+contract trustworthy. It covers tools, resources, and prompts alike —
+"tool" below means all three.
+
+## Versioning model
+
+- **The server version is the app version.** `initialize` announces
+  `cellarion vX.Y.Z` (from `backend/package.json`); there is no separate
+  MCP version to track. `get_source_info` returns the same version.
+- **Within a major line, changes are additive-only.** Allowed at any time:
+  - a new tool / resource / prompt;
+  - a new **optional** input field (with a default that preserves old behavior);
+  - a new field in the response `data`;
+  - description/title copy improvements (they steer models, not parsers).
+- **Never** without the deprecation process below:
+  - removing or renaming a tool or an input/response field;
+  - changing a field's type or meaning;
+  - narrowing accepted input (tightening a max, removing an enum value);
+  - **raising the required scope** of an existing tool (a token minted
+    yesterday must keep working); *lowering* scope is a security decision,
+    not a compat one — treat it as a new tool.
+- **The error taxonomy is API**: `invalid_input | not_found |
+  forbidden_scope | budget_exhausted | conflict | rate_limited` (see
+  `mcp/toolUtil.js`). New codes may be added; existing codes never change
+  meaning. Agents key retry behavior off these.
+- The response envelope — `{ summary, data, warnings?, page? }` on success,
+  `{ error: { code, message } }` on failure, JSON in one text part — is
+  frozen shape-wise the same way.
+
+## Breaking changes: the parallel-tool rule
+
+When a tool genuinely needs an incompatible contract, ship it as a **new
+tool** (`search_bottles_v2`, or better: a new honest name) and deprecate the
+old one. Two tools coexist through the sunset window. Never break the old
+name in place.
+
+## Deprecation process
+
+1. **Mark it** — pass `deprecated: 'use <replacement> instead; removed
+   after v<X.Y>'` to `registerTool` / `registerResource` / `registerPrompt`
+   (`mcp/registry.js`). The registry prefixes the description with
+   `[DEPRECATED — …]`, which is the text driving model tool-selection — so
+   calling models steer to the replacement **without any client-side
+   support**. The tool keeps working unchanged.
+2. **Sunset window** — the marker stays for **at least 2 minor releases or
+   90 days, whichever is longer**. The message must name the replacement
+   and the removal release.
+3. **Announce** — the release notes of the marking release and of the
+   removal release both list it (What's New + GitHub release body).
+4. **Remove** — delete the tool in the announced release, remove its
+   `instructions.js` mention (the drift guard in `resources.test.js` forces
+   this), and drop the marker. The `registry.test.js` drift guard
+   (`no live tool ships deprecated right now`) fails the build until the
+   sunset actually completes — a marker can't silently live forever.
+
+## Emergency lever
+
+The admin **kill switches** (Admin → AI Connector; `rateLimits.mcp` config)
+shut the whole surface or just the anonymous endpoint with an honest 503 —
+that's for incidents, never for retiring a tool.
+
+## What guards the contract in CI
+
+- `resources.test.js` — every tool/resource/prompt name must be mentioned
+  in the server `instructions` (models can't select what they can't see).
+- `registry.test.js` — deprecation marker format + the no-forgotten-markers
+  drift guard.
+- `mcp/eval/` golden cases — pin that real models still pick the right tool
+  for the canonical intents; a rename or description regression shows up as
+  a selection failure before any user sees it.


### PR DESCRIPTION
## What

The remaining Phase-7 polish items: "tool versioning/deprecation policy, full docs".

### Deprecation support (code)
- `registerTool` / `registerResource` / `registerPrompt` accept `deprecated: '<migration message>'`. The entry **stays registered and callable** through its sunset window, but its description — the text that drives model tool-selection — leads with `[DEPRECATED — …]`, so calling models steer to the replacement with **zero client-side support needed**.
- Guards in `registry.test.js`: marker format is enforced (must carry a migration path), and a **drift guard fails the build if any live tool ships deprecated** — a marker can't silently outlive its announced sunset.

### Policy + docs
- **`docs/mcp-versioning.md`** — the contract policy: server version = app version; additive-only changes within a major; the frozen error taxonomy + response envelope; scope changes are never silent; the parallel-tool rule for breaking changes; the ≥2-minor/90-day sunset process; kill switches are for incidents, never retirement; and which CI guards enforce each piece.
- **`docs/mcp-connect.md`** — operator/developer connect guide: the three auth paths (OAuth connector / `cel_` token / anonymous public), the scope model, Claude Desktop `cellarion-mcp` config, a curl smoke test incl. the RFC 9728 401 challenge, the admin kill switches + usage view, and self-hosting notes (cross-links mcp-oauth.md's prod nginx steps).

## Tests
Registry + both drift-guard suites green (34 tests) in node:20-alpine. Docs-only otherwise.

## Docker-compose impact
**None.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)