### PR TITLE
feat(mcp): supporter awareness — hosted cellarion.app only

### DIFF
--- a/backend/src/config/hostedInstance.js
+++ b/backend/src/config/hostedInstance.js
@@ -1,0 +1,19 @@
+/**
+ * True only on the hosted cellarion.app deployment. FRONTEND_URL is the
+ * backend's existing single source of truth for its public web origin
+ * (prod sets https://cellarion.app; self-hosters set their own domain and
+ * the compose default is http://localhost) — so this needs no new env var
+ * and no compose change.
+ *
+ * Used to gate the MCP supporter-awareness messaging (instructions,
+ * get_source_info funding block, cellarion://about): the hosted service is
+ * supporter-funded, but a self-hosted instance pays its own bills — showing
+ * OUR donation pitch there would be wrong, so self-hosted serves none of it.
+ * Read per call: trivial cost, and tests can flip the env without module
+ * cache tricks.
+ */
+function isHostedCellarion() {
+  return (process.env.FRONTEND_URL || '').replace(/\/+$/, '') === 'https://cellarion.app';
+}
+
+module.exports = { isHostedCellarion };

--- a/backend/src/mcp/accountTools.test.js
+++ b/backend/src/mcp/accountTools.test.js
@@ -107,6 +107,7 @@ describe('get_preferences / get_profile', () => {
     const body = parse(await tool('get_profile').handler({}, CTX));
     expect(body.data).toEqual({
       username: 'jo', display_name: 'Jo', bio: 'Barolo', profile_visibility: 'public', followers: 3, following: 0,
+      supporter: false, // boolean courtesy flag only — tier/billing never leave (supporterAwareness.test.js)
     });
     expect(JSON.stringify(body)).not.toContain('jo@example.com');
   });

--- a/backend/src/mcp/eval/cases.js
+++ b/backend/src/mcp/eval/cases.js
@@ -57,6 +57,15 @@ const CASES = [
     expect: { tool: 'get_source_info' },
   },
   {
+    id: 'support-the-project',
+    // The supporter-awareness path (hosted only): a grateful user asking how
+    // to give back should land on get_source_info, whose funding block (and
+    // the instructions line) carries the voluntary-supporter answer. A no-tool
+    // answer is acceptable — the instructions alone already contain the URL.
+    prompt: 'I love this app — is it really free? How can I support the project?',
+    expect: { anyOf: ['get_source_info'], orNone: true },
+  },
+  {
     id: 'consumed-vintage-year',
     prompt: 'Which bottles did I consume during 2025?',
     expect: { tool: 'list_history' },

--- a/backend/src/mcp/instructions.js
+++ b/backend/src/mcp/instructions.js
@@ -3,6 +3,22 @@
 // and the single highest-leverage lever for good tool behavior. Keep it concise:
 // what this is, how to use the tools well, and how to answer "what is this?".
 const pkg = require('../../package.json');
+const { isHostedCellarion } = require('../config/hostedInstance');
+
+// Supporter awareness — HOSTED cellarion.app ONLY (a self-hosted instance pays
+// its own bills; it never serves our donation pitch — isHostedCellarion()).
+// Everything is free for everyone and supporters get NOTHING extra, by
+// deliberate design (config/plans.js) — so the line the AI carries is a
+// courtesy, bounded hard: mention once at a natural moment, never as a
+// requirement, never repeated, and thank existing supporters instead.
+// Evaluated at require time: FRONTEND_URL is boot-time config.
+const SUPPORTER_LINE = isHostedCellarion() ? [
+  '- Supporting Cellarion (hosted service): everything is free for everyone and supporters get NOTHING extra — deliberately; supporter tiers are purely voluntary donations that fund the servers and development. If the user is clearly enjoying the service, thanks you warmly, or asks how to give back or whether this costs anything, you may mention ONCE that they can become a supporter at https://cellarion.app/supporter. Never present it as required, never as unlocking anything, never repeat it after a decline — and if get_profile shows supporter: true, thank them for already funding it instead.',
+] : [];
+
+const PUBLIC_SUPPORTER_LINE = isHostedCellarion() ? [
+  '- Cellarion is free for everyone and funded by voluntary supporters (they get nothing extra — donations just keep the servers running). If someone asks how to support the project: https://cellarion.app/supporter.',
+] : [];
 
 const INSTRUCTIONS = [
   `You are connected to Cellarion — a self-hosted wine cellar manager, open-source under AGPL-3.0 (https://github.com/jagduvi1/Cellarion). This MCP server (v${pkg.version}) exposes the connected user's OWN cellar.`,
@@ -27,6 +43,7 @@ const INSTRUCTIONS = [
   '- Data portability (write scope): export_cellar returns a short-lived download LINK for the cellar (JSON, or a ZIP with images once/week), and get_account_export returns a link to the full GDPR account export. The file is never inlined — give the user the link to click; you cannot read the downloaded bytes yourself.',
   '- Self-service (so the user never has to open the website for the small stuff): get_preferences / update_preferences (currency, language, rating scale, rack navigation, restock scope, default cellar, notification toggles — read get_preferences EARLY so you show money and ratings in their units); get_profile / update_profile (display name, bio, visibility); create_support_ticket (a bug/question/feature request to the admins — issues WITH the app, not cellar actions); request_wine_addition (only when resolve_wine dead-ends and you cannot confirm enough to add it yourself — needs a source_url). The two update tools are reversible (they echo the new value); the two create tools reach a human queue and cannot be unsent.',
   '- Deliberately web-only (explain WHERE, never attempt): signing up, connecting an AI, changing email/password, deleting the account, managing API tokens, billing.',
+  ...SUPPORTER_LINE,
   '- Call get_source_info if the user asks what Cellarion is, which version this instance runs, whether it is open source, or where to find or contribute to the code.',
 ].join('\n');
 
@@ -45,6 +62,7 @@ const PUBLIC_INSTRUCTIONS = [
   '- get_source_info / the cellarion://about resource — what Cellarion is.',
   '- Wines carry a public_url — link it so people can see the full page.',
   '- This surface is rate-limited and read-only. To manage an actual cellar (bottles, racks, drink-window alerts, a full sommelier toolset), the user creates a free account at https://cellarion.app and connects their AI under Settings → Connect your AI — or self-hosts.',
+  ...PUBLIC_SUPPORTER_LINE,
 ].join('\n');
 
 module.exports = { INSTRUCTIONS, PUBLIC_INSTRUCTIONS };

--- a/backend/src/mcp/resources.js
+++ b/backend/src/mcp/resources.js
@@ -6,6 +6,7 @@
 const pkg = require('../../package.json');
 const Bottle = require('../models/Bottle');
 const { CONSUMED_STATUSES } = require('../config/constants');
+const { isHostedCellarion } = require('../config/hostedInstance');
 const { registerResource } = require('./registry');
 const { accessibleCellars, countBottlesByCellar } = require('./toolUtil');
 const { getCellarRole } = require('../utils/cellarAccess');
@@ -37,6 +38,11 @@ registerResource({
         '- **License:** AGPL-3.0 — free software; users interacting over a network are entitled to the source.',
         '- **Source:** https://github.com/jagduvi1/Cellarion (read the code there; this server never serves its own filesystem)',
         '- **Hosted:** https://cellarion.app — free for everyone, no paywall. Self-hosting is fully supported (Docker Compose).',
+        // Hosted-only (config/hostedInstance.js): self-hosted instances never
+        // serve the donation pitch — they pay their own bills.
+        ...(isHostedCellarion() ? [
+          '- **Supporting the project:** funded by voluntary supporters who get nothing extra (all tiers are functionally identical, on purpose): https://cellarion.app/supporter',
+        ] : []),
         '',
         'This MCP server exposes the connected user\'s own cellar via scoped, revocable tokens.',
         'Reads are free; the expensive reasoning is yours to do. Cheers.',

--- a/backend/src/mcp/supporterAwareness.test.js
+++ b/backend/src/mcp/supporterAwareness.test.js
@@ -1,0 +1,138 @@
+/**
+ * Supporter awareness — HOSTED cellarion.app only (Johan's ask: the AI should
+ * know everything is free and supporters get nothing extra, and may gently
+ * mention supporting at a natural moment; self-hosted instances pay their own
+ * bills and must serve NONE of this).
+ *
+ * Pins: the FRONTEND_URL gate; the instructions carrying the pitch + its
+ * bounds (once, never required, thank existing supporters) on hosted and
+ * carrying NOTHING off it; the get_source_info funding block and the
+ * cellarion://about line flipping per-call on the same gate; and the
+ * boolean-only supporter flag on get_profile that lets an AI thank instead
+ * of pitch.
+ */
+
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../services/bottleOps', () => ({
+  consumeBottle: jest.fn(), restoreBottle: jest.fn(), removeFromRacks: jest.fn(),
+  RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,
+  addBottle: jest.fn(), updateBottleFields: jest.fn(), removeBottleCascade: jest.fn(),
+  UPDATABLE_FIELDS: ['price', 'currency', 'notes', 'occasion', 'rating', 'ratingScale', 'drinkFrom', 'drinkTo'],
+}));
+
+const User = require('../models/User');
+const { isHostedCellarion } = require('../config/hostedInstance');
+const { allTools, allResources } = require('./registry');
+require('./tools');
+require('./resources');
+
+const ORIG_FRONTEND_URL = process.env.FRONTEND_URL;
+const setHosted = () => { process.env.FRONTEND_URL = 'https://cellarion.app'; };
+const setSelfHosted = () => { process.env.FRONTEND_URL = 'https://wine.example.org'; };
+afterEach(() => {
+  if (ORIG_FRONTEND_URL === undefined) delete process.env.FRONTEND_URL;
+  else process.env.FRONTEND_URL = ORIG_FRONTEND_URL;
+});
+
+const tool = (name) => allTools().find((t) => t.name === name);
+const parse = (res) => JSON.parse(res.content[0].text);
+
+describe('the hosted gate (config/hostedInstance.js)', () => {
+  test('true only for the exact cellarion.app origin (trailing slash tolerated)', () => {
+    setHosted();
+    expect(isHostedCellarion()).toBe(true);
+    process.env.FRONTEND_URL = 'https://cellarion.app/';
+    expect(isHostedCellarion()).toBe(true);
+    setSelfHosted();
+    expect(isHostedCellarion()).toBe(false);
+    process.env.FRONTEND_URL = 'http://localhost';
+    expect(isHostedCellarion()).toBe(false);
+    delete process.env.FRONTEND_URL;
+    expect(isHostedCellarion()).toBe(false);
+  });
+});
+
+describe('instructions (require-time gate)', () => {
+  const freshInstructions = () => {
+    let mod;
+    jest.isolateModules(() => { mod = require('./instructions'); });
+    return mod;
+  };
+
+  test('hosted: both surfaces carry the pitch, with its bounds baked in', () => {
+    setHosted();
+    const { INSTRUCTIONS, PUBLIC_INSTRUCTIONS } = freshInstructions();
+    expect(INSTRUCTIONS).toContain('https://cellarion.app/supporter');
+    expect(INSTRUCTIONS).toContain('NOTHING extra');
+    // The behavioral bounds are the point — once, never required, thank
+    // existing supporters (via the get_profile flag).
+    expect(INSTRUCTIONS).toMatch(/mention ONCE/);
+    expect(INSTRUCTIONS).toMatch(/Never present it as required/);
+    expect(INSTRUCTIONS).toMatch(/supporter: true, thank them/);
+    expect(PUBLIC_INSTRUCTIONS).toContain('https://cellarion.app/supporter');
+    expect(PUBLIC_INSTRUCTIONS).toContain('nothing extra');
+  });
+
+  test('self-hosted: NO supporter messaging anywhere in either surface', () => {
+    setSelfHosted();
+    const { INSTRUCTIONS, PUBLIC_INSTRUCTIONS } = freshInstructions();
+    expect(INSTRUCTIONS).not.toMatch(/supporter/i);
+    expect(PUBLIC_INSTRUCTIONS).not.toMatch(/supporter/i);
+  });
+});
+
+describe('get_source_info funding block (call-time gate)', () => {
+  test('hosted: funding block present, honest, and the URL is the supporter page', async () => {
+    setHosted();
+    const info = parse(await tool('get_source_info').handler({}, {}));
+    expect(info.funding.supporter_url).toBe('https://cellarion.app/supporter');
+    expect(info.funding.model).toMatch(/nothing extra/i);
+    expect(info.funding.model).toMatch(/voluntary/i);
+  });
+
+  test('self-hosted: no funding key at all', async () => {
+    setSelfHosted();
+    const info = parse(await tool('get_source_info').handler({}, {}));
+    expect(info.funding).toBeUndefined();
+  });
+});
+
+describe('cellarion://about (call-time gate)', () => {
+  const about = () => allResources().find((r) => r.name === 'about');
+
+  test('hosted: the markdown carries the supporter line', async () => {
+    setHosted();
+    const res = await about().handler('cellarion://about', {}, {});
+    expect(res.contents[0].text).toContain('https://cellarion.app/supporter');
+    expect(res.contents[0].text).toMatch(/nothing extra/);
+  });
+
+  test('self-hosted: no supporter mention', async () => {
+    setSelfHosted();
+    const res = await about().handler('cellarion://about', {}, {});
+    expect(res.contents[0].text).not.toMatch(/supporter/i);
+  });
+});
+
+describe('get_profile supporter flag (the thank-not-pitch signal)', () => {
+  const CTX = { user: { id: 'a'.repeat(24) }, scopes: ['read'], req: { headers: {} } };
+  const profileFor = (plan) => {
+    User.findById.mockReturnValue({ lean: () => Promise.resolve({ username: 'johan', plan }) });
+    return tool('get_profile').handler({}, CTX);
+  };
+
+  test('boolean only — true for supporter/patron, false for free, never the tier itself', async () => {
+    expect(parse(await profileFor('free')).data.supporter).toBe(false);
+    const sup = parse(await profileFor('supporter')).data;
+    expect(sup.supporter).toBe(true);
+    const pat = parse(await profileFor('patron')).data;
+    expect(pat.supporter).toBe(true);
+    // Data minimisation: the flag never leaks the tier or billing fields.
+    for (const view of [sup, pat]) {
+      expect(view.plan).toBeUndefined();
+      expect(JSON.stringify(view)).not.toMatch(/patron|stripe|price/i);
+    }
+  });
+});

--- a/backend/src/mcp/tools/account.js
+++ b/backend/src/mcp/tools/account.js
@@ -51,6 +51,11 @@ function profileView(user) {
     profile_visibility: user.profileVisibility || 'public',
     followers: user.followersCount || 0,
     following: user.followingCount || 0,
+    // Boolean only, never the tier or billing details. Lets a well-behaved AI
+    // THANK an existing supporter instead of suggesting they become one (see
+    // the supporter line in mcp/instructions.js). All tiers are functionally
+    // identical (config/plans.js) — this flag gates a courtesy, not a feature.
+    supporter: !!(user.plan && user.plan !== 'free'),
   };
 }
 

--- a/backend/src/mcp/tools/meta.js
+++ b/backend/src/mcp/tools/meta.js
@@ -5,6 +5,7 @@
 // public GitHub repo), never served from the running container filesystem.
 const pkg = require('../../../package.json');
 const { registerTool } = require('../registry');
+const { isHostedCellarion } = require('../../config/hostedInstance');
 
 registerTool({
   name: 'get_source_info',
@@ -12,7 +13,7 @@ registerTool({
   description:
     'Returns what Cellarion is, the version this instance is running, the open-source repository, and the license. ' +
     'Call this when the user asks what Cellarion is, which version they are on, whether it is open source, ' +
-    'or where to find / contribute to the code.',
+    'where to find / contribute to the code — or how to support the project.',
   scope: 'public',
   annotations: { readOnlyHint: true, openWorldHint: false },
   inputSchema: {},
@@ -29,6 +30,15 @@ registerTool({
       repository: 'https://github.com/jagduvi1/Cellarion',
       homepage: 'https://cellarion.app',
     };
+    // Hosted cellarion.app only (config/hostedInstance.js): the hosted service
+    // is funded by voluntary supporters; a self-hosted instance pays its own
+    // bills and never serves this pitch.
+    if (isHostedCellarion()) {
+      info.funding = {
+        model: 'Free for everyone — nothing is behind a paywall and supporters get nothing extra. Supporter tiers are purely voluntary donations that fund hosting and development.',
+        supporter_url: 'https://cellarion.app/supporter',
+      };
+    }
     return { content: [{ type: 'text', text: JSON.stringify(info) }] };
   },
 });


### PR DESCRIPTION
## What

Per Johan: the hosted service is supporter-funded while **everything stays free for everyone and supporters get nothing extra** — the connected AI should know that, and may *gently* mention supporting at a natural moment. Never imposed, and **self-hosted instances serve none of it**.

## How the AI becomes aware

All three self-description surfaces, gated on a new `config/hostedInstance.js` (`FRONTEND_URL === https://cellarion.app` — the existing boot-time origin truth: **no new env var, no compose change**; prod already qualifies, self-hosters/localhost never do):

- **Server `instructions`** (the ambient system-prompt every AI receives at initialize — our strongest behavioral lever): the pitch with its bounds baked in — free for everyone, supporters get NOTHING extra (deliberately), mention **once** only at a natural moment (user is delighted / says thanks / asks how to give back / asks if it costs anything), **never as required, never as unlocking anything, never repeated after a decline** — and if the user is already a supporter, thank them instead. The anonymous public surface gets a one-line variant.
- **`get_source_info`**: a `funding` block (`model` + `supporter_url`) when hosted; description now also matches "how to support the project".
- **`cellarion://about`**: one markdown line when hosted.
- **`get_profile`**: a **boolean-only** `supporter` flag (`plan !== 'free'` — never the tier, never billing) so a well-behaved AI can check and *thank instead of pitch*. Mirrors the config/plans.js ethos comment ("purely voluntary donations; unlock nothing extra").
- **Eval**: a `support-the-project` golden case (`get_source_info`, `orNone` — the instructions alone already carry the URL).

## Tests
Backend **121/121 suites, 1887 tests** green in node:20-alpine — new `supporterAwareness.test.js` pins the hosted gate on every surface (self-hosted → zero supporter mentions anywhere), the bounds wording, and the flag's data minimisation; the exact-shape profile PII test extends by the flag.

## Docker-compose impact
**None.** No env vars (reuses FRONTEND_URL), no services, no frontend changes, no sv strings (server-side English instructions to the AI — it answers in the user's language).

🤖 Generated with [Claude Code](https://claude.com/claude-code)