### PR TITLE
fix(audit): crash-stoppers — AdminMcp load + bottle-update audit shape (H1/H2)

### DIFF
--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -346,9 +346,18 @@ async function updateBottleFields(bottle, fields, req) {
     throw err;
   }
   require('./search').indexBottle(bottle._id);
+  // Audit in the SAME { field: { from, to } } shape the REST PUT /bottles/:id
+  // route emits, so CellarAudit renders both surfaces identically (a bare
+  // { field: newValue } here made the page crash when a value was cleared —
+  // grand-audit H2). `prev` holds the old value, `changes` the new (null on
+  // clear); both carry exactly the keys that changed.
+  const auditChanges = {};
+  for (const key of Object.keys(changes)) {
+    auditChanges[key] = { from: prev[key] ?? null, to: changes[key] };
+  }
   logAudit(req, 'bottle.update',
     { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
-    { changes });
+    { changes: auditChanges });
 
   return { bottle, changes, prev };
 }

--- a/backend/src/services/bottleOps.test.js
+++ b/backend/src/services/bottleOps.test.js
@@ -194,6 +194,16 @@ describe('updateBottleFields (real execution)', () => {
     expect(b.drinkWindowNotifiedStatus).toBeNull();
   });
 
+  test('audit log uses the { field: { from, to } } shape CellarAudit renders (grand-audit H2)', async () => {
+    const b = liveBottle({ rating: 92, ratingScale: '100' });
+    await updateBottleFields(b, { rating: null, ratingScale: '5' }, REQ);
+    const call = logAudit.mock.calls.find((c) => c[1] === 'bottle.update');
+    // A CLEAR must log { from: <old>, to: null } — the bare { rating: null }
+    // shape is what crashed the audit page.
+    expect(call[3].changes.rating).toEqual({ from: 92, to: null });
+    expect(call[3].changes.ratingScale).toEqual({ from: '100', to: '5' });
+  });
+
   test('rating null CLEARS the rating (undo-of-rating-set path) with the ride-along scale', async () => {
     const b = liveBottle({ rating: 92, ratingScale: '100' });
     const res = await updateBottleFields(b, { rating: null, ratingScale: '5' }, REQ);

--- a/frontend/src/pages/AdminMcp.js
+++ b/frontend/src/pages/AdminMcp.js
@@ -45,7 +45,13 @@ function AdminMcp() {
     setLoading(true);
     setError(null);
     try {
-      setData(await adminGetMcpUsage(apiFetch, days));
+      // apiFetch resolves to a raw Response — parse it (and check ok) rather
+      // than storing the Response as `data` (which would make data.daily
+      // undefined and crash byDay on render).
+      const res = await adminGetMcpUsage(apiFetch, days);
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || 'Failed to load');
+      setData(body);
     } catch (err) {
       setError(err.message || 'Failed to load');
     } finally {
@@ -61,7 +67,11 @@ function AdminMcp() {
     setSaving(true);
     setError(null);
     try {
-      await adminSetMcpSwitches(apiFetch, next);
+      // Only reflect the flip if the server actually accepted it — otherwise
+      // the UI would show "disabled" while the AI surface stays live.
+      const res = await adminSetMcpSwitches(apiFetch, next);
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error || 'Failed to save');
       setData((d) => ({ ...d, mcpConfig: next }));
     } catch (err) {
       setError(err.message || 'Failed to save');

--- a/frontend/src/pages/AdminMcp.test.js
+++ b/frontend/src/pages/AdminMcp.test.js
@@ -1,0 +1,62 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import AdminMcp from './AdminMcp';
+
+// The bug this suite exists for (grand-audit H1): the page stored the raw
+// Response as `data`, so `byDay(data.daily)` iterated undefined and crashed the
+// whole app on every load. These tests drive the real parse path.
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key, opts) => (opts && opts.count !== undefined ? `${key}:${opts.count}` : key) }),
+}));
+
+const apiFetch = vi.fn();
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ apiFetch }) }));
+
+const getUsage = vi.fn();
+const setSwitches = vi.fn();
+vi.mock('../api/admin', () => ({
+  adminGetMcpUsage: (...a) => getUsage(...a),
+  adminSetMcpSwitches: (...a) => setSwitches(...a),
+}));
+
+const jsonRes = (body, ok = true) => ({ ok, json: () => Promise.resolve(body) });
+
+const USAGE = {
+  days: 30,
+  daily: [{ day: '2026-07-15T00:00:00.000Z', surface: 'personal', calls: 41, errors: 2 }],
+  topTools: [{ name: 'search_bottles', surface: 'personal', calls: 20, errors: 1 }],
+  connections: { bearer: { total: 3, activeLast7d: 2 }, oauth: { total: 5, activeLast7d: 4 } },
+  writesLast7d: 12,
+  mcpConfig: { enabled: 1, publicEnabled: 1 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUsage.mockResolvedValue(jsonRes(USAGE));
+  setSwitches.mockResolvedValue(jsonRes({}));
+});
+
+test('parses the usage payload and renders it without crashing', async () => {
+  render(<AdminMcp />);
+  // The daily row must appear — proving byDay() ran over parsed data, not a Response.
+  await waitFor(() => expect(screen.getByText('2026-07-15')).toBeInTheDocument());
+  expect(screen.getByText('search_bottles')).toBeInTheDocument();
+});
+
+test('surfaces a server error instead of blanking', async () => {
+  getUsage.mockResolvedValue(jsonRes({ error: 'Failed to load MCP usage' }, false));
+  render(<AdminMcp />);
+  await waitFor(() => expect(screen.getByText('Failed to load MCP usage')).toBeInTheDocument());
+});
+
+test('a rejected kill-switch PATCH does not flip the UI (reports the error)', async () => {
+  setSwitches.mockResolvedValue(jsonRes({ error: 'nope' }, false));
+  const { container } = render(<AdminMcp />);
+  await waitFor(() => expect(screen.getByText('2026-07-15')).toBeInTheDocument());
+  const master = container.querySelector('input[type="checkbox"]');
+  expect(master.checked).toBe(true);
+  fireEvent.click(master);
+  await waitFor(() => expect(screen.getByText('nope')).toBeInTheDocument());
+  // Still on (server rejected) — no false "disabled" state.
+  expect(master.checked).toBe(true);
+});

--- a/frontend/src/pages/CellarAudit.js
+++ b/frontend/src/pages/CellarAudit.js
@@ -72,7 +72,14 @@ function formatDetail(action, detail, t) {
     const entries = Object.entries(detail.changes);
     if (entries.length === 0) return null;
     return entries
-      .map(([field, { from, to }]) => `${field}: ${fmtVal(from)} → ${fmtVal(to)}`)
+      .map(([field, change]) => {
+        // Normal shape is { from, to }; guard against a bare value (a legacy
+        // row, or any writer that logs { field: newValue }) so a single odd
+        // entry can't crash the whole audit page.
+        const from = change && typeof change === 'object' ? change.from : undefined;
+        const to = change && typeof change === 'object' ? change.to : change;
+        return `${field}: ${fmtVal(from)} → ${fmtVal(to)}`;
+      })
       .join(' · ');
   }
   return null;


### PR DESCRIPTION
First remediation batch from GRAND_AUDIT_2026-07-17 — the two verified crash bugs, both in code merged the same day as the audit.

## H1 — Admin → AI Connector page crashed on every load
`AdminMcp.js` stored the raw `Response` as `data` (the API helper returns a Response, no `.json()`), so `byDay(data.daily)` iterated `undefined` → TypeError → the app-wide ErrorBoundary blanked the whole app, 100% of loads.
- Parse + `res.ok` check (the AdminStats.js pattern).
- **M16 (same page):** the kill-switch `toggle()` now checks `res.ok` before applying the optimistic state — it was showing "disabled" even when the PATCH was rejected, i.e. telling an admin the AI surface was off while it stayed live.
- **New `AdminMcp.test.js`** — parse path, server-error path, and reject-doesn't-flip. The page had zero tests, which is exactly why H1 shipped.

## H2 — Cellar Audit page crashed when an AI cleared a field
`updateBottleFields` (the shared MCP service) logged `bottle.update` audit as `{ field: newValue|null }`, but REST `PUT /bottles/:id` logs `{ field: { from, to } }` and `CellarAudit.js` destructures `{ from, to }`. So an MCP `update_bottle` clearing a field (`{ rating: null }`) threw `Cannot destructure property 'from' of null` and killed the whole audit view.
- The service now emits the `{ from, to }` shape from its existing `prev`/`changes` tracking (internal price/drink-window logic and the MCP-response `.changes` are untouched).
- `CellarAudit` also defensively null-guards any non-`{from,to}` row so one odd entry can never crash the page again.
- Backend test pins the audit shape on a clear.

Deeper cross-surface unification (REST PUT should call the service — grand-audit M5) is deferred to the cross-surface-drift batch.

## Tests
Frontend AdminMcp 3/3 (new). Backend bottleOps/write/revert 49/49 in node:20-alpine. Full suites run on the batch branches.

## Docker-compose impact
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)