### PR TITLE
fix(audit): ops + self-host — history indexing, OOM heap cap, env forwarding (H3/H4/H5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,15 @@ MEILI_MASTER_KEY=change-me-to-a-strong-random-string
 # BACKEND_URL=                         # absolute backend URL for server-rendered pages; defaults to FRONTEND_URL
 # MEILI_URL=http://meilisearch:7700
 # MEILI_SEARCH_KEY=                    # optional restricted Meilisearch search key (falls back to the master key)
+# MEILI_FORCE_REINDEX=1                # recovery lever: set to 1 to force a full Meili reindex on next boot, then unset
 # REMBG_URL=http://rembg:5000
+# NODE_OPTIONS=--max-old-space-size=480 # cap V8 heap below the backend container's memory limit (default already set in compose)
+
+# Climate monitoring — optional. All have safe in-code defaults; override to tune.
+# CLIMATE_RETENTION_DAYS=730           # telemetry TTL in days (GDPR storage-limitation lever; applied at write time)
+# CLIMATE_MAX_DEVICES_PER_USER=5
+# CLIMATE_SUGGESTED_INTERVAL_S=300     # suggested sensor reporting interval
+# CLIMATE_MAX_READINGS_PER_DAY=        # per-device daily ingest cap
 
 # Google Sign-In (SSO) — optional. Enables the "Continue with Google" button on
 # the login page. BOTH values must be set to turn it on; leave unset to keep

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -490,8 +490,11 @@ router.post('/', requireNonDemo, async (req, res) => {
     await bottle.save();
     await bottle.populate(WINE_POPULATE);
 
-    // Index in Meilisearch (fire-and-forget) — skip if added directly as consumed
-    if (!addToHistory) searchService.indexBottle(bottle._id);
+    // Index in Meilisearch (fire-and-forget). Consumed ("add to history")
+    // bottles ARE indexed too — the History tab's search/filter path queries
+    // Meili with a consumed status filter, so skipping them made them silently
+    // vanish from filtered History (grand-audit H3). The index carries status.
+    searchService.indexBottle(bottle._id);
 
     // Seed the sommelier maturity queue for this wine+vintage (no-op for
     // "Unknown"; NV is included). Shared by every add/import path.

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -868,11 +868,12 @@ router.post('/confirm', async (req, res) => {
 
           await bottle.save();
           created++;
+          // Index every created bottle (consumed history rows too — H3).
+          createdBottleIds.push(bottle._id);
           if (item.addToHistory) {
             createdHistory++;
           } else {
             createdActive++;
-            createdBottleIds.push(bottle._id);
           }
 
           // Queue rack placement for unmatched bottles too
@@ -961,11 +962,14 @@ router.post('/confirm', async (req, res) => {
 
         await bottle.save();
         created++;
+        // Index EVERY created bottle for Meilisearch, consumed history rows
+        // included — the History tab searches/filters via Meili, so leaving
+        // them out made imported consumed bottles unsearchable (grand-audit H3).
+        createdBottleIds.push(bottle._id);
         if (item.addToHistory) {
           createdHistory++;
         } else {
           createdActive++;
-          createdBottleIds.push(bottle._id);
         }
 
         // Queue rack placement — actual slot assignment runs per-rack after

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,14 @@ services:
       # Belt-and-braces with the Dockerfile ENV (audit L-22): secure refresh
       # cookie + redacted 5xx bodies must not depend on out-of-band config.
       - NODE_ENV=production
+      # Cap V8's heap BELOW the 640M cgroup limit below — without this V8 sizes
+      # its heap from HOST RAM (~2GB on a 4GB box) and the kernel OOM-killer
+      # fires before GC pressure, killing the whole container (grand-audit H4).
+      - NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=480}
+      # Self-hosters on plain HTTP must set COOKIE_SECURE=false or the refresh
+      # cookie is dropped (Secure is otherwise inferred from NODE_ENV=production).
+      # The env block enumerates vars, so it must be forwarded to be settable.
+      - COOKIE_SECURE=${COOKIE_SECURE:-}
       - MONGO_URI=mongodb://mongo:27017/winecellar
       - JWT_SECRET=${JWT_SECRET}
       - ACCESS_TOKEN_EXPIRES_IN=${ACCESS_TOKEN_EXPIRES_IN:-15m}
@@ -110,7 +118,15 @@ services:
       - MEILI_URL=http://meilisearch:7700
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
       - MEILI_SEARCH_KEY=${MEILI_SEARCH_KEY:-}
+      # Recovery lever: set to 1 in .env to force a full Meili reindex on boot.
+      - MEILI_FORCE_REINDEX=${MEILI_FORCE_REINDEX:-}
       - REMBG_URL=http://rembg:5000
+      # Climate monitoring knobs (all optional; unset keeps in-code defaults).
+      # A GDPR storage-limitation lever — must be forwarded to be settable.
+      - CLIMATE_RETENTION_DAYS=${CLIMATE_RETENTION_DAYS:-}
+      - CLIMATE_MAX_DEVICES_PER_USER=${CLIMATE_MAX_DEVICES_PER_USER:-}
+      - CLIMATE_SUGGESTED_INTERVAL_S=${CLIMATE_SUGGESTED_INTERVAL_S:-}
+      - CLIMATE_MAX_READINGS_PER_DAY=${CLIMATE_MAX_READINGS_PER_DAY:-}
       - LOG_LEVEL=${LOG_LEVEL:-}
       - AUDIT_TTL_DAYS=${AUDIT_TTL_DAYS:-}
       - INDEXNOW_KEY=${INDEXNOW_KEY:-}


### PR DESCRIPTION
Second remediation batch from GRAND_AUDIT_2026-07-17 — operational + self-host correctness.

## H3 — bottles added to history were invisible in History search/filter
`if (!addToHistory) indexBottle(...)` skipped Meili indexing for consumed "add to history" bottles (and CellarTracker imports of consumed rows). The History tab searches/filters via Meili with a consumed status filter → those bottles silently vanished, reappearing only when the filter was cleared (the Mongo path). Now every created bottle is indexed (POST route + both import push sites); the index carries `status` and the consume path already re-indexes consumed bottles, so it's consistent.

## H4 — backend could OOM-kill under one GDPR export + normal load
No `NODE_OPTIONS` anywhere, so V8 sized its heap from **host** RAM (~2GB) while the backend cgroup limit is **640M** → the kernel OOM-killer fired before GC pressure, killing the whole container (all in-flight requests). Now `NODE_OPTIONS=--max-old-space-size=480` (env-overridable) — a runaway allocation (e.g. the in-memory account export) fails that one request instead of the container.
- Streaming the account export to avoid even the single-request failure is noted as a follow-up perf item (this cap is the safety net).

## H5 — documented env vars were silent no-ops
The backend env block enumerates vars explicitly, so knobs it never forwarded couldn't be set: **COOKIE_SECURE** (.env.example tells plain-HTTP self-hosters to set it → their logins couldn't persist, the doc fix did nothing), the four **CLIMATE_*** vars (incl. a GDPR retention lever, baked into the TTL at collection creation), and **MEILI_FORCE_REINDEX**. All forwarded + documented.

## Docker-compose impact — YES
Backend env block gains `NODE_OPTIONS`, `COOKIE_SECURE`, `CLIMATE_*` (×4), `MEILI_FORCE_REINDEX`. **Mirror into the hand-maintained `docker-compose.prod.yml` on deploy.** Compose config validated.

## Tests
Backend bottles/import suites 54/54 in node:20-alpine. Full suite on the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)