### PR TITLE
fix(audit): MCP undo/robustness — un-claim, unplace guard, cache bust, mode-flip (M1-M4)

### DIFF
--- a/backend/src/mcp/resultCache.js
+++ b/backend/src/mcp/resultCache.js
@@ -28,4 +28,17 @@ async function cachedResult(tool, userId, variant, compute) {
   return result;
 }
 
-module.exports = { cachedResult, TTL_MS };
+/**
+ * Drop every cached entry for one user — called when their cellar mutates
+ * (grand-audit M3), so the next read recomputes instead of serving a stale
+ * 60s window (e.g. a just-consumed bottle still ranked as a "tonight"
+ * candidate). Keys are `${tool}:${userId}:${variant}`.
+ */
+function bustUser(userId) {
+  const needle = `:${userId}:`;
+  for (const k of cache.keys()) {
+    if (k.includes(needle)) cache.delete(k);
+  }
+}
+
+module.exports = { cachedResult, bustUser, TTL_MS };

--- a/backend/src/mcp/revert.js
+++ b/backend/src/mcp/revert.js
@@ -14,6 +14,16 @@ const { resolveBottleAccess } = require('./toolUtil');
 // Actions a caller may reverse given their scopes. Reversing a write-class
 // action needs the write grant (a consume-only token must never gain
 // delete-a-bottle power through undo).
+// Release a claim made before a mutation that then failed, so the ledger row
+// stays un-reversed and the undo can be retried (grand-audit M1: claiming
+// reversed:true and then hitting a VersionError on save() left the row marked
+// undone while nothing was actually restored — the retry then found nothing).
+// The idempotencyKey was nulled at claim time and stays null; that only means
+// the ORIGINAL action can't idempotency-replay, which is fine — it already ran.
+async function unclaim(rowId) {
+  await McpActionLog.updateOne({ _id: rowId }, { $set: { reversed: false } }).catch(() => {});
+}
+
 const CONSUME_REVERSIBLE = ['consume', 'restore'];
 const WRITE_REVERSIBLE = ['add', 'update', 'bulk_add', 'somm_maturity', 'somm_price',
   'cellar_create', 'rack_create', 'place', 'unplace', 'move', 'arrange', 'tasting_note', 'attach_image',
@@ -139,6 +149,7 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
         try {
           await list.save();
         } catch (err) {
+          await unclaim(row._id); // failed → let the undo be retried
           if (err?.name === 'VersionError') return fail('conflict', 'The list changed mid-undo — retry.');
           throw err;
         }
@@ -168,6 +179,7 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
     try {
       await list.save();
     } catch (err) {
+      await unclaim(row._id); // failed → let the undo be retried
       if (err?.name === 'VersionError') return fail('conflict', 'The list changed mid-undo — retry.');
       throw err;
     }
@@ -209,7 +221,13 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
       profile.relative = !!prev.relative;
       profile.setBy = prev.setBy || null;
       profile.setAt = prev.setAt || null;
-      await profile.save();
+      try {
+        await profile.save();
+      } catch (err) {
+        await unclaim(row._id); // failed → let the undo be retried (was unguarded, M1 class)
+        if (err?.name === 'VersionError') return fail('conflict', 'The profile changed mid-undo — retry.');
+        throw err;
+      }
       envelope = { summary: `Undid maturity review — vintage ${row.detail?.vintage} back to ${profile.status}`, data: { undone: 'set_vintage_maturity', profile_id: String(profile._id), status: profile.status } };
     }
     await logAction(ctx, { tool: 'undo_last', action: row.action, viaUndo: true, detail: { undid: String(row._id) }, result: envelope });

--- a/backend/src/mcp/revert.test.js
+++ b/backend/src/mcp/revert.test.js
@@ -7,7 +7,8 @@
  * claim (so a double-revert loses cleanly).
  */
 
-jest.mock('../models/McpActionLog', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../models/WineList', () => ({ findOne: jest.fn() }));
 jest.mock('../config/constants', () => ({ CONSUMED_STATUSES: ['drank', 'gifted', 'sold', 'other'] }));
 jest.mock('../services/bottleOps', () => ({
   RESTORE_WINDOW_MS: 5 * 86400000,
@@ -42,6 +43,7 @@ const ctx = (over = {}) => ({ user: { id: 'u1', roles: ['user'] }, scopes: ['rea
 beforeEach(() => {
   jest.clearAllMocks();
   McpActionLog.findOneAndUpdate.mockResolvedValue({ _id: 'claimed' }); // claim succeeds by default
+  McpActionLog.updateOne.mockResolvedValue({}); // unclaim (M1) — resolves so .catch() is safe
 });
 
 describe('reversibleActionsFor (scope gate)', () => {
@@ -294,5 +296,40 @@ describe('revertLedgerRow dispatch', () => {
     const res = await revertLedgerRow({ _id: 'r', action: 'consume', bottle: 'b1' }, ctx(), H);
     expect(res).toMatchObject({ ok: false, code: 'conflict' });
     expect(bottleOps.restoreBottle).not.toHaveBeenCalled();
+  });
+});
+
+describe('winelist undo (grand-audit M1 — un-claim on failure)', () => {
+  const WineList = require('../models/WineList');
+  const oid = (c) => c.repeat(24);
+  const LIST = oid('1');
+  const WINE = oid('e');
+  const addRow = () => ({ _id: oid('f'), action: 'winelist_add', cellar: oid('c'),
+    detail: { listId: LIST, listName: 'Menu', wineId: WINE, vintage: '2019', bottleSize: '750ml' } });
+
+  const listWith = (entry, saveImpl) => ({
+    _id: LIST, sections: [], autoGroupEntries: entry ? [entry] : [],
+    save: saveImpl || jest.fn().mockResolvedValue(undefined),
+  });
+  const entry = () => ({ wine: WINE, vintage: '2019', bottleSize: '750ml', listPrice: 100 });
+
+  test('winelist_add undo pulls the active-container entry and claims the row', async () => {
+    const list = listWith(entry());
+    WineList.findOne.mockResolvedValue(list);
+    const res = await revertLedgerRow(addRow(), ctx(), H);
+    expect(res.ok).toBe(true);
+    expect(res.data.entry_removed).toBe(true);
+    expect(list.autoGroupEntries).toHaveLength(0);
+    expect(McpActionLog.findOneAndUpdate).toHaveBeenCalled();
+  });
+
+  test('a VersionError on save UN-CLAIMS the row so the undo can be retried', async () => {
+    const err = new Error('conflict'); err.name = 'VersionError';
+    const list = listWith(entry(), jest.fn().mockRejectedValue(err));
+    WineList.findOne.mockResolvedValue(list);
+    const res = await revertLedgerRow(addRow(), ctx(), H);
+    expect(res).toMatchObject({ ok: false, code: 'conflict' });
+    // The claim (reversed:true) must be released so a retry finds the row.
+    expect(McpActionLog.updateOne).toHaveBeenCalledWith({ _id: oid('f') }, { $set: { reversed: false } });
   });
 });

--- a/backend/src/mcp/structuralUndo.js
+++ b/backend/src/mcp/structuralUndo.js
@@ -93,8 +93,27 @@ async function undoStructural(last, ctx, { ok, fail, logAction }) {
     if (!access) return fail('conflict', 'You no longer have access to that rack; nothing was changed.');
     const bottleId = last.detail?.bottleId || last.bottle;
     if (!bottleId) return fail('conflict', 'That slot was already empty; nothing to undo.');
-    const maxPos = getMaxPosition(rack);
     const pos = last.detail?.position;
+    // Verify EVERYTHING before claiming (the move branch's discipline), so a
+    // reversal that would fail doesn't burn the ledger row:
+    //  - the bottle must still be active (grand-audit M2: without this, a
+    //    bottle consumed via the web since the unplace would be re-slotted,
+    //    breaking "consume frees the slot" — dead bottle in fill counts/3D);
+    //  - it must still live in this rack's cellar;
+    //  - the position must still exist (rack resized smaller since — the
+    //    previously-computed-but-unused maxPos check);
+    //  - the slot must be free.
+    const bottle = await Bottle.findById(bottleId);
+    if (!bottle) return fail('conflict', 'That bottle no longer exists; nothing was changed.');
+    if (bottle.status !== 'active') {
+      return fail('conflict', 'That bottle has been consumed since; nothing was changed.');
+    }
+    if (String(bottle.cellar) !== String(rack.cellar)) {
+      return fail('conflict', 'That bottle is no longer in this rack\'s cellar; nothing was changed.');
+    }
+    if (pos > getMaxPosition(rack)) {
+      return fail('conflict', 'That rack was resized and the slot no longer exists; nothing was changed.');
+    }
     const occupied = rack.slots.find((s) => s.position === pos && String(s.bottle) !== String(bottleId));
     if (occupied) return fail('conflict', `Position ${pos} is occupied again; cannot restore. Nothing was changed.`);
     if (!(await claim(last))) return fail('conflict', 'That action is already being undone.');

--- a/backend/src/mcp/structuralUndo.test.js
+++ b/backend/src/mcp/structuralUndo.test.js
@@ -1,0 +1,73 @@
+/**
+ * structuralUndo — the unplace-undo status guard (grand-audit M2).
+ *
+ * Pins that undoing an unplace refuses when the bottle has been CONSUMED (or
+ * left the cellar, or the rack shrank) since — and, critically, that it does
+ * so BEFORE claiming the ledger row, so a doomed reversal doesn't burn the row
+ * (the M1 class). placeBottleInRack is mocked, so a re-slot attempt on a
+ * consumed bottle would show up as a call — it must not happen.
+ */
+
+jest.mock('../models/Cellar', () => ({ findOne: jest.fn() }));
+jest.mock('../models/Rack', () => ({ findOne: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
+jest.mock('../services/rackOps', () => ({
+  placeBottleInRack: jest.fn(), clearRackSlot: jest.fn(), moveBottleToCellar: jest.fn(),
+}));
+jest.mock('./toolUtil', () => ({ resolveBottleAccess: jest.fn(), resolveCellarAccess: jest.fn() }));
+
+const Rack = require('../models/Rack');
+const Bottle = require('../models/Bottle');
+const McpActionLog = require('../models/McpActionLog');
+const { placeBottleInRack } = require('../services/rackOps');
+const { resolveCellarAccess } = require('./toolUtil');
+const { undoStructural } = require('./structuralUndo');
+
+const oid = (c) => c.repeat(24);
+const RACK = oid('a');
+const CELLAR = oid('c');
+const BOTTLE = oid('b');
+const helpers = {
+  ok: (summary, data) => ({ ok: true, summary, data }),
+  fail: (code, message) => ({ ok: false, code, message }),
+  logAction: jest.fn(),
+};
+const CTX = { user: { id: oid('9') }, req: { headers: {} } };
+const unplaceRow = () => ({ _id: oid('f'), action: 'unplace', cellar: CELLAR, bottle: BOTTLE,
+  detail: { rackId: RACK, position: 3, bottleId: BOTTLE } });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Rack.findOne.mockResolvedValue({ _id: RACK, cellar: CELLAR, slots: [] });
+  resolveCellarAccess.mockResolvedValue({ cellar: { _id: CELLAR } });
+  McpActionLog.findOneAndUpdate.mockResolvedValue({ _id: oid('f') });
+});
+
+test('refuses to re-slot a CONSUMED bottle, and does NOT claim the row', async () => {
+  Bottle.findById.mockResolvedValue({ _id: BOTTLE, status: 'drank', cellar: CELLAR });
+  const res = await undoStructural(unplaceRow(), CTX, helpers);
+  expect(res.ok).toBe(false);
+  expect(res.message).toMatch(/consumed/i);
+  expect(placeBottleInRack).not.toHaveBeenCalled();
+  expect(McpActionLog.findOneAndUpdate).not.toHaveBeenCalled(); // not burned
+});
+
+test('refuses when the bottle left the rack\'s cellar', async () => {
+  Bottle.findById.mockResolvedValue({ _id: BOTTLE, status: 'active', cellar: oid('e') });
+  const res = await undoStructural(unplaceRow(), CTX, helpers);
+  expect(res.ok).toBe(false);
+  expect(placeBottleInRack).not.toHaveBeenCalled();
+  expect(McpActionLog.findOneAndUpdate).not.toHaveBeenCalled();
+});
+
+test('an active in-cellar bottle IS re-slotted (claims, then places)', async () => {
+  Bottle.findById.mockResolvedValue({ _id: BOTTLE, status: 'active', cellar: CELLAR });
+  placeBottleInRack.mockResolvedValue({ ok: true });
+  const res = await undoStructural(unplaceRow(), CTX, helpers);
+  expect(res.ok).toBe(true);
+  expect(McpActionLog.findOneAndUpdate).toHaveBeenCalled();
+  expect(placeBottleInRack).toHaveBeenCalledWith(expect.any(Object), 3, BOTTLE, expect.any(Object));
+});

--- a/backend/src/mcp/tools/stats.js
+++ b/backend/src/mcp/tools/stats.js
@@ -100,9 +100,27 @@ async function buildStats(userId, currencyOverride) {
     },
     extra: { warnings: ['Distributions truncated to top entries; full breakdowns are in the web app\'s Statistics page.'] },
   };
-  if (statsCache.size >= STATS_CACHE_MAX) statsCache.clear();
+  if (statsCache.size >= STATS_CACHE_MAX) {
+    // Evict the oldest half (insertion order) rather than a wholesale clear —
+    // one user's churn shouldn't cold-start everyone (grand-audit L29).
+    let drop = Math.ceil(STATS_CACHE_MAX / 2);
+    for (const k of statsCache.keys()) { if (drop-- <= 0) break; statsCache.delete(k); }
+  }
   statsCache.set(cacheKey, { at: Date.now(), result });
   return result;
 }
 
-module.exports = { buildStats };
+/**
+ * Drop this user's cached stats so the next read (tool or cellar://stats
+ * resource) recomputes — called on any cellar mutation (grand-audit M3), so
+ * the stats_changed push doesn't tell a subscriber to re-read stale numbers.
+ * Keys are `${userId}:${currency}:${scale}`.
+ */
+function bustStats(userId) {
+  const prefix = `${userId}:`;
+  for (const k of statsCache.keys()) {
+    if (k.startsWith(prefix)) statsCache.delete(k);
+  }
+}
+
+module.exports = { buildStats, bustStats };

--- a/backend/src/mcp/tools/wineLists.js
+++ b/backend/src/mcp/tools/wineLists.js
@@ -39,8 +39,6 @@ function activeContainers(list) {
   return [{ section: null, entries: list.autoGroupEntries }];
 }
 
-const entryKey = (e) => `${String(e.wine?._id || e.wine)}|${e.vintage || 'NV'}|${e.bottleSize || '750ml'}`;
-
 function countEntries(list) {
   return list.structureMode === 'custom'
     ? (list.sections || []).reduce((n, s) => n + (s.entries?.length || 0), 0)
@@ -58,20 +56,23 @@ const entryOut = (e) => ({
   glass_price: e.byGlass ? (e.glassPrice ?? null) : undefined,
 });
 
-// Find every entry for a wine across BOTH containers (see module comment).
+// Find every entry for a wine in the ACTIVE container only — the same set
+// get_wine_list renders (grand-audit M4). Scanning both containers made a
+// wine present in both (a list mode-flipped from auto to custom) look like a
+// duplicate with identical disambiguators (permanently un-editable), and let
+// update_list_pricing edit an entry hidden from the rendered menu. The
+// inactive container's stale entries are ignored, matching what the user sees.
 // Returns [{ entry, section }].
 function findEntries(list, wineId, { vintage, bottleSize } = {}) {
   const hits = [];
-  const scan = (entries, section) => {
+  for (const { section, entries } of activeContainers(list)) {
     for (const e of entries || []) {
       if (String(e.wine?._id || e.wine) !== String(wineId)) continue;
       if (vintage !== undefined && (e.vintage || 'NV') !== vintage) continue;
       if (bottleSize !== undefined && (e.bottleSize || '750ml') !== bottleSize) continue;
       hits.push({ entry: e, section });
     }
-  };
-  for (const s of list.sections || []) scan(s.entries, s.title);
-  scan(list.autoGroupEntries, null);
+  }
   return hits;
 }
 
@@ -181,8 +182,12 @@ registerTool({
     if (!list) return fail('not_found', 'No such wine list. Use list_wine_lists for valid ids.');
     if (!wine) return fail('not_found', 'No such registry wine. Find the wine_id via search_registry or a bottle\'s wine.');
 
-    const vintage = args.vintage || 'NV';
-    const bottleSize = args.bottle_size || '750ml';
+    // Trim to match the schema (trim: true) BEFORE we save and record the
+    // ledger detail — otherwise the saved entry is "2019" while the undo
+    // detail keeps "2019 ", and winelist_add undo's strict compare misses the
+    // entry (grand-audit L7/L11), and the dupe check leaks near-duplicates.
+    const vintage = (args.vintage || 'NV').trim() || 'NV';
+    const bottleSize = (args.bottle_size || '750ml').trim() || '750ml';
     const dupes = findEntries(list, wine._id, { vintage, bottleSize });
     if (dupes.length) {
       return fail('conflict', `${wine.name} ${vintage} (${bottleSize}) is already on "${list.name}"${dupes[0].section ? ` in section "${dupes[0].section}"` : ''} — use update_list_pricing to change its prices.`);
@@ -300,8 +305,8 @@ registerTool({
     if (!list) return fail('not_found', 'No such wine list. Use list_wine_lists for valid ids.');
 
     const hits = findEntries(list, args.wine_id, {
-      ...(args.vintage !== undefined ? { vintage: args.vintage } : {}),
-      ...(args.bottle_size !== undefined ? { bottleSize: args.bottle_size } : {}),
+      ...(args.vintage !== undefined ? { vintage: args.vintage.trim() } : {}),
+      ...(args.bottle_size !== undefined ? { bottleSize: args.bottle_size.trim() } : {}),
     });
     if (!hits.length) return fail('not_found', 'That wine is not on this list. See get_wine_list; add it with add_to_list.');
     if (hits.length > 1) {

--- a/backend/src/services/audit.js
+++ b/backend/src/services/audit.js
@@ -11,6 +11,17 @@ const eventBus = require('./eventBus');
 // the emit targets the acting user (each account watches its own stream).
 const STATS_CHANGED_PREFIXES = ['bottle.', 'cellar.'];
 
+// Invalidate a user's MCP read caches on any wine-data mutation (grand-audit
+// M3). Lazy-required so these MCP modules stay off audit's load path (they pull
+// the tool registry, whose search dep is ESM-only and unparseable by jest —
+// the #702 failure mode). Never throws: a cache miss must not fail a mutation.
+function bustMcpCaches(userId) {
+  try {
+    require('../mcp/tools/stats').bustStats(userId);
+    require('../mcp/resultCache').bustUser(userId);
+  } catch { /* cache is best-effort */ }
+}
+
 // Structured logger — outputs newline-delimited JSON to stdout.
 // In Docker this is captured by the container runtime.
 // Use pino-pretty in development: node server.js | pino-pretty
@@ -71,6 +82,12 @@ function logAudit(req, action, resource = {}, detail = {}) {
   // stream. System-actor events (req = null, e.g. retention jobs) are skipped:
   // there is no acting user to notify.
   if (entry.actor.userId && STATS_CHANGED_PREFIXES.some(p => action.startsWith(p))) {
+    // Bust the MCP read caches for the affected user BEFORE the push, so a
+    // client that re-reads cellar://stats (or calls cellar_stats / the
+    // insight tools) on the nudge recomputes instead of serving the stale 60s
+    // window (grand-audit M3). Lazy-require keeps the MCP modules off audit's
+    // load path. Same owner-resolution as the push below.
+    bustMcpCaches(entry.actor.userId);
     eventBus.emit(entry.actor.userId, 'stats_changed', { reason: action });
 
     // Shared cellars: /api/stats aggregates the OWNER's bottles, so when a
@@ -82,6 +99,7 @@ function logAudit(req, action, resource = {}, detail = {}) {
     const ownerFromReq = req?.cellar?.user;
     if (ownerFromReq) {
       if (String(ownerFromReq) !== String(entry.actor.userId)) {
+        bustMcpCaches(ownerFromReq);
         eventBus.emit(ownerFromReq, 'stats_changed', { reason: action });
       }
     } else if (resource.cellarId && eventBus.streamCounts().total > 0) {
@@ -94,6 +112,7 @@ function logAudit(req, action, resource = {}, detail = {}) {
         Cellar.findById(cellarId).select('user').lean()
           .then(cellar => {
             if (cellar && String(cellar.user) !== String(entry.actor.userId)) {
+              bustMcpCaches(cellar.user);
               eventBus.emit(cellar.user, 'stats_changed', { reason: action });
             }
           })


### PR DESCRIPTION
Third remediation batch from GRAND_AUDIT_2026-07-17 — the undo/revert edge-cases and staleness in the new MCP code.

## M1 — undo burned its ledger row on a failed save
`winelist_add`, `winelist_price`, and `somm_maturity` undo claimed the row (`reversed:true`) **before** `save()`, then on a VersionError returned "retry" — but the row was already marked reversed, so the retry found nothing and the pricing/entry was never restored. Added `unclaim()`; the failure paths release the claim so a retry works. `somm_maturity`'s save was entirely unguarded (500 + burnt row) — now guarded. `revert.test` gains the winelist coverage it never had.

## M2 — undoing an unplace could re-slot a CONSUMED bottle
The unplace-undo branch never loaded the bottle, so if it had been consumed via the web since the unplace, the reversal put a drunk bottle back in the slot (breaking "consume frees the slot" — dead bottle in fill counts / arrange / 3D). Now loads the bottle and refuses **non-active / cellar-changed / rack-shrunk** (the previously computed-but-unused `maxPos`) **before** claiming, mirroring the `move` branch. New `structuralUndo.test`.

## M3 — stats push served stale cache
The 60s stats/result caches had no invalidation, so `stats_changed` told a subscriber to re-read `cellar://stats` and got pre-mutation numbers (a just-consumed bottle still a "tonight" candidate). `audit.js` now busts the affected user's stats + result caches right where it emits `stats_changed` (shared-cellar owner branches too). Both caches export `bustStats`/`bustUser`; `statsCache`'s clear-at-cap became evict-oldest-half (L29).

## M4 — wine-list mode-flip dead-ends
`findEntries` scanned **both** containers while `get_wine_list` shows only the active one → a wine in both (auto→custom flipped list) dead-ended `update_list_pricing` with identical disambiguators, and one only in the inactive container was hidden yet un-addable. Now matches the **active container only**. Also trims `vintage`/`bottle_size` so saved values match the undo ledger detail (L7/L11), and drops the dead `entryKey` helper.

## Tests
Full backend suite **125 suites / 1928** green in node:20-alpine (2 new suites). No compose impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)