### PR TITLE
fix(audit): GDPR + data integrity — likesCount, recipientEmail, climate, zombie racks (M10-M13)

### DIFF
--- a/backend/src/routes/admin/cellars.js
+++ b/backend/src/routes/admin/cellars.js
@@ -55,13 +55,21 @@ router.post('/:id/restore', async (req, res) => {
       return res.status(404).json({ error: 'Deleted cellar not found' });
     }
 
+    // Capture the cellar's deletion timestamp BEFORE clearing it — the
+    // cascade stamped exactly this value on the racks that were live at
+    // delete time, so we can restore ONLY those and leave racks the user had
+    // individually deleted earlier (a different, earlier deletedAt) removed
+    // (grand-audit M13). Restoring every deletedAt!=null rack resurrected them
+    // as zombies.
+    const cellarDeletedAt = cellar.deletedAt;
     const restoredName = `RESTORED - ${cellar.name}`;
     cellar.name = restoredName;
     cellar.deletedAt = null;
     await cellar.save();
 
-    // Restore all racks that were cascade-deleted with this cellar
-    await Rack.updateMany({ cellar: cellar._id, deletedAt: { $ne: null } }, { $set: { deletedAt: null } });
+    // Restore only the racks cascade-deleted WITH this cellar (matching its
+    // exact deletedAt).
+    await Rack.updateMany({ cellar: cellar._id, deletedAt: cellarDeletedAt }, { $set: { deletedAt: null } });
 
     logAudit(req, 'cellar.restore', { cellarId: cellar._id }, { name: restoredName, owner: cellar.user });
 

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -1446,8 +1446,16 @@ router.delete('/:id', async (req, res) => {
     cellar.deletedAt = now;
     await cellar.save();
 
-    // Cascade soft-delete to all racks in this cellar
-    await Rack.updateMany({ cellar: cellar._id }, { deletedAt: now });
+    // Cascade soft-delete to the LIVE racks only ({ deletedAt: null }). Racks
+    // the user already soft-deleted individually keep their own (earlier)
+    // deletedAt — restamping "now" would reset their 30-day purge clock, and a
+    // later restore would flip them back as zombie racks the user had removed
+    // (grand-audit M13). Restore below re-activates only racks stamped with
+    // this exact timestamp, so the two sets never mix.
+    // Also free NFC tags: the rfidTag unique index has no deletedAt filter, so
+    // a soft-deleted rack would keep its tag claimed (blocking re-link on
+    // another rack) until the retention purge (grand-audit L14).
+    await Rack.updateMany({ cellar: cellar._id, deletedAt: null }, { $set: { deletedAt: now }, $unset: { rfidTag: '' } });
 
     // Wine lists and the 3D room layout are intentionally NOT removed here:
     // this is a reversible soft-delete (restorable for 30 days), so curated

--- a/backend/src/services/cellarPurge.js
+++ b/backend/src/services/cellarPurge.js
@@ -24,6 +24,7 @@ const CellarValueSnapshot = require('../models/CellarValueSnapshot');
 const ImportSession = require('../models/ImportSession');
 const PendingShare = require('../models/PendingShare');
 const WineList = require('../models/WineList');
+const ClimateDevice = require('../models/ClimateDevice');
 const Cellar = require('../models/Cellar');
 const { deleteLogoFilesFor } = require('./wineListLogos');
 const { unlinkImageFiles } = require('./imageProcessor');
@@ -62,6 +63,11 @@ async function purgeCellarPermanently(cellarId) {
     ImportSession.deleteMany({ cellar: cellarId }),
     PendingShare.deleteMany({ cellar: cellarId }),
     WineList.deleteMany({ cellar: cellarId }),
+    // Detach any climate device that was assigned to this cellar — the device
+    // itself belongs to the user, not the cellar, so it survives; leaving the
+    // ref would point it at a nonexistent cellar (grand-audit M12). Same as the
+    // member-remove/downgrade detach paths in routes/cellars.js.
+    ClimateDevice.updateMany({ cellar: cellarId }, { $set: { cellar: null } }),
   ]);
 
   await searchService.removeBottles(bottleIds);

--- a/backend/src/services/cellarPurge.test.js
+++ b/backend/src/services/cellarPurge.test.js
@@ -20,6 +20,7 @@ jest.mock('../models/CellarValueSnapshot', () => ({ deleteMany: jest.fn() }));
 jest.mock('../models/ImportSession', () => ({ deleteMany: jest.fn() }));
 jest.mock('../models/PendingShare', () => ({ deleteMany: jest.fn() }));
 jest.mock('../models/WineList', () => ({ deleteMany: jest.fn() }));
+jest.mock('../models/ClimateDevice', () => ({ updateMany: jest.fn() }));
 jest.mock('../models/Cellar', () => ({ deleteOne: jest.fn() }));
 jest.mock('./wineListLogos', () => ({ deleteLogoFilesFor: jest.fn() }));
 jest.mock('./imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
@@ -33,6 +34,7 @@ const CellarValueSnapshot = require('../models/CellarValueSnapshot');
 const ImportSession = require('../models/ImportSession');
 const PendingShare = require('../models/PendingShare');
 const WineList = require('../models/WineList');
+const ClimateDevice = require('../models/ClimateDevice');
 const Cellar = require('../models/Cellar');
 const { deleteLogoFilesFor } = require('./wineListLogos');
 const { unlinkImageFiles } = require('./imageProcessor');
@@ -84,6 +86,8 @@ describe('purgeCellarPermanently', () => {
     expect(ImportSession.deleteMany).toHaveBeenCalledWith(cellarFilter);
     expect(PendingShare.deleteMany).toHaveBeenCalledWith(cellarFilter);
     expect(WineList.deleteMany).toHaveBeenCalledWith(cellarFilter);
+    // Climate devices belong to the user, not the cellar → detached, not deleted (M12).
+    expect(ClimateDevice.updateMany).toHaveBeenCalledWith(cellarFilter, { $set: { cellar: null } });
     expect(Cellar.deleteOne).toHaveBeenCalledWith({ _id: CELLAR_ID });
   });
 

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -355,7 +355,23 @@ const REGISTRY = [
   },
   {
     model: ReviewVote, category: 'personal-data', userFields: ['user'],
-    purge: (ctx) => ReviewVote.deleteMany({ user: ctx.userId }),
+    // Review.likesCount is $inc-maintained by the like/unlike route, so a bare
+    // deleteMany would leave phantom likes on public reviews forever
+    // (grand-audit M11). Reconcile the counter down per affected review BEFORE
+    // deleting — same discipline as the Follow entry below. Clamped at 0 so a
+    // pre-existing drift can't drive it negative.
+    purge: async (ctx) => {
+      const votes = await ReviewVote.find({ user: ctx.userId }).select('review').lean();
+      const perReview = {};
+      for (const v of votes) perReview[v.review] = (perReview[v.review] || 0) + 1;
+      const ops = Object.entries(perReview).map(([id, n]) => ({
+        updateOne: { filter: { _id: id, likesCount: { $gte: n } }, update: { $inc: { likesCount: -n } } },
+      }));
+      if (ops.length) await Review.bulkWrite(ops);
+      // Any counter that would have gone negative (drift): clamp to 0.
+      await Review.updateMany({ _id: { $in: Object.keys(perReview) }, likesCount: { $lt: 0 } }, [{ $set: { likesCount: 0 } }]);
+      await ReviewVote.deleteMany({ user: ctx.userId });
+    },
     // BUG FIX: schema has no `vote` field (only user/review/createdAt); the old
     // export emitted vote:undefined. Export the real fields.
     exportFragment: async (ctx) => ({
@@ -410,7 +426,7 @@ const REGISTRY = [
     },
   },
   {
-    model: Recommendation, category: 'personal-data', userFields: ['sender', 'recipient'],
+    model: Recommendation, category: 'personal-data', userFields: ['sender', 'recipient', 'recipientEmail'],
     // Anonymise the departing user's side instead of deleting, so the OTHER
     // party keeps the recommendation: a recipient keeps a from-[deleted] rec,
     // and a sender keeps a to-[deleted] entry in their sent list.
@@ -419,6 +435,11 @@ const REGISTRY = [
       // supplied) while anonymising the sender side.
       Recommendation.updateMany({ sender: ctx.userId }, { $set: { sender: ctx.deletedUserId }, $unset: { recipientEmail: '' } }),
       Recommendation.updateMany({ recipient: ctx.userId }, { $set: { recipient: ctx.deletedUserId } }),
+      // ALSO scrub the departing user's OWN address where it sits as the
+      // recipientEmail on OTHER users' sent recs — a recommendation sent to
+      // this email before they ever signed up leaves recipient:null, so the
+      // two updates above never touch it (grand-audit M10). Match by email.
+      ...(ctx.userEmail ? [Recommendation.updateMany({ recipientEmail: ctx.userEmail }, { $unset: { recipientEmail: '' } })] : []),
     ],
     exportFragment: async (ctx) => {
       const [sent, received] = await Promise.all([

--- a/backend/src/services/userDataRegistry.test.js
+++ b/backend/src/services/userDataRegistry.test.js
@@ -148,3 +148,34 @@ describe('DiscussionReply purge — quote.authorName erasure (L-17)', () => {
     ]);
   });
 });
+
+describe('ReviewVote purge — reconciles Review.likesCount (grand-audit M11)', () => {
+  const ReviewVote = require('../models/ReviewVote');
+  const Review = require('../models/Review');
+  const entry = REGISTRY.find(e => e.model.modelName === 'ReviewVote');
+  const ctx = { userId: 'u1', deletedUserId: 'del1' };
+
+  test('decrements likesCount per liked review BEFORE deleting the votes', async () => {
+    const findSpy = jest.spyOn(ReviewVote, 'find').mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve([{ review: 'rev1' }, { review: 'rev1' }, { review: 'rev2' }]) }),
+    });
+    const bulkSpy = jest.spyOn(Review, 'bulkWrite').mockResolvedValue({});
+    const clampSpy = jest.spyOn(Review, 'updateMany').mockResolvedValue({});
+    const delSpy = jest.spyOn(ReviewVote, 'deleteMany').mockResolvedValue({});
+
+    await entry.purge(ctx);
+
+    // rev1 had two of the user's likes → -2; rev2 → -1. Guarded by likesCount>=n.
+    const ops = bulkSpy.mock.calls[0][0];
+    expect(ops).toContainEqual({ updateOne: { filter: { _id: 'rev1', likesCount: { $gte: 2 } }, update: { $inc: { likesCount: -2 } } } });
+    expect(ops).toContainEqual({ updateOne: { filter: { _id: 'rev2', likesCount: { $gte: 1 } }, update: { $inc: { likesCount: -1 } } } });
+    expect(delSpy).toHaveBeenCalledWith({ user: 'u1' });
+
+    findSpy.mockRestore(); bulkSpy.mockRestore(); clampSpy.mockRestore(); delSpy.mockRestore();
+  });
+
+  test('registers recipientEmail on the Recommendation entry (M10)', () => {
+    const rec = REGISTRY.find(e => e.model.modelName === 'Recommendation');
+    expect(rec.userFields).toContain('recipientEmail');
+  });
+});


### PR DESCRIPTION
Fourth remediation batch from GRAND_AUDIT_2026-07-17 — GDPR completeness and data-integrity cascades.

## M11 — erasure permanently inflated Review.likesCount
Deleting the departing user's ReviewVote rows was a bare `deleteMany`, but `likesCount` is ``-maintained by the like/unlike route → phantom likes on public reviews forever, and the like-toggle's `>0` clamp then masks the drift. Now reconciles down per review (`bulkWrite`, guarded `likesCount >= n`, negative-clamp) **before** the delete — the same discipline the adjacent Follow entry uses.

## M10 — recipientEmail survived the email owner's erasure
A recommendation sent to an address **before that person signed up** keeps `recipient: null`, so the sender/recipient-scoped purge never touched it → their email lingered in other users' rows up to the 90-day retention. Added an email-scoped `` (and registered `recipientEmail` as a userField so the completeness test tracks it).

## M12 — permanent cellar purge left ClimateDevice dangling
The cascade cleaned 8 collections but not climate devices; the device belongs to the **user**, not the cellar, so it survived pointing at a nonexistent cellar (readings into a dead assignment, broken joins). Detach `cellar → null` in the cascade, matching the member-remove/downgrade paths.

## M13 — restore resurrected individually-deleted racks as zombies
Cellar soft-delete stamped `deletedAt` on **all** racks (resetting the purge clock of racks the user had deleted earlier), and restore flipped **every** `deletedAt != null` rack back. Now soft-delete stamps only **live** racks, and restore reactivates only racks matching the cellar's **exact** `deletedAt`.

## L14 — NFC tag stuck on a soft-deleted cellar's racks
The soft-delete cascade now also unsets `rfidTag` (the unique index has no `deletedAt` filter), matching what individual rack-delete already does — so the tag can be re-linked elsewhere immediately instead of waiting for the retention purge.

## Tests
Full backend **124 suites / 1925** green in node:20-alpine — new ReviewVote-reconcile + Recommendation-userField tests, cellarPurge climate-detach assertion. No compose impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)