### PR TITLE
fix(audit): cross-surface drift — single-source lists + audit parity (M5-M9)

### DIFF
--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -80,8 +80,21 @@ const DISCUSSIONS_MAX_PER_PAGE = 50;
 // Maximum character lengths for discussion fields
 const DISCUSSION_MAX_LENGTHS = { title: 200, body: 5000, replyBody: 3000 };
 
+// The token scopes that reach the PERSONAL MCP surface (POST /api/mcp) — the
+// single source for the JWT-session grant, the OAuth grantable set, and the
+// admin usage-view connection filter, so adding a scope can't silently miss
+// one of the three (grand-audit M7). NOT the same as ApiToken.TOKEN_SCOPES,
+// which also includes 'climate' (device-only, never an MCP connection).
+const MCP_PERSONAL_SCOPES = ['read', 'consume', 'write'];
+
+// Support-ticket categories — single source for the model enum, the
+// accountOps validation, and the MCP tool's input schema (grand-audit M9).
+const SUPPORT_CATEGORIES = ['bug', 'help', 'feature', 'other'];
+
 module.exports = {
   CONSUMED_STATUSES,
+  MCP_PERSONAL_SCOPES,
+  SUPPORT_CATEGORIES,
   MS_PER_DAY,
   WINE_POPULATE,
   WINE_POPULATE_LIST,

--- a/backend/src/mcp/tools/account.js
+++ b/backend/src/mcp/tools/account.js
@@ -180,7 +180,7 @@ registerTool({
   scope: 'write',
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
   inputSchema: {
-    category: z.enum(['bug', 'help', 'feature', 'other']),
+    category: z.enum(SUPPORT_CATEGORIES),
     subject: z.string().min(1).max(200),
     message: z.string().min(1).max(5000),
   },

--- a/backend/src/models/SupportTicket.js
+++ b/backend/src/models/SupportTicket.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { SUPPORT_CATEGORIES } = require('../config/constants');
 
 // One follow-up message in a ticket's conversation. `author` disambiguates the
 // side (the user's AI/web reply vs an admin response); `by` records the actual
@@ -19,7 +20,7 @@ const supportTicketSchema = new mongoose.Schema({
   },
   category: {
     type: String,
-    enum: ['bug', 'help', 'feature', 'other'],
+    enum: SUPPORT_CATEGORIES,
     required: true,
     index: true
   },

--- a/backend/src/routes/admin/mcp.js
+++ b/backend/src/routes/admin/mcp.js
@@ -11,7 +11,7 @@ router.use(requireAuth, requireRole('admin'));
 
 // Token scopes that mean "this credential can talk to /api/mcp" — climate-only
 // device tokens are not AI connections and are excluded from the counts.
-const MCP_SCOPES = ['read', 'consume', 'write'];
+const { MCP_PERSONAL_SCOPES: MCP_SCOPES } = require('../../config/constants');
 
 // GET /api/admin/mcp/usage?days=30 — the admin MCP overview: per-day call/error
 // series, top tools, connection counts, recent write volume, kill-switch state.

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -87,7 +87,7 @@ const REVERSIBLE_ACTIONS = new Set(reversibleActionsFor(['consume', 'write']));
 // write-safety stack (registry-safe two-step add, conflict guards, idempotency
 // keys, the McpActionLog undo ledger, per-user mutation budget). Demo sessions
 // are blocked below; cel_ tokens opt into scopes explicitly at mint time.
-const JWT_SCOPES = ['read', 'consume', 'write'];
+const { MCP_PERSONAL_SCOPES: JWT_SCOPES } = require('../config/constants');
 
 // POST /api/mcp — stateless Streamable HTTP MCP endpoint. Auth is the same
 // requireAuth as the REST API. For `cel_` tokens the SCOPE_ALLOWLIST grants this

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -167,7 +167,11 @@ router.post('/', requireCellarAccess('editor'), async (req, res) => {
     const rack = new Rack(rackData);
 
     await rack.save();
-    logAudit(req, 'rack.create', { type: 'rack', id: rack._id });
+    // cellarId so this rack appears in the cellar's audit page (which filters
+    // on resource.cellarId) — web-created racks were invisible there while
+    // MCP-created ones showed, since rackOps.createGridRack already records it
+    // (grand-audit M6). name in detail matches the MCP surface too.
+    logAudit(req, 'rack.create', { type: 'rack', id: rack._id, cellarId: rack.cellar }, { name: rack.name });
     res.status(201).json({ rack });
   } catch (err) {
     if (err.code === 11000) return res.status(409).json({ error: 'A rack with that name already exists in this cellar' });

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -24,7 +24,7 @@ const { updateSiteConfig } = require('../utils/siteConfig');
 const { parsePagination } = require('../utils/pagination');
 const { escapeRegex } = require('../utils/sanitize');
 const { coerceStringQuery } = require('../utils/validation');
-const { SYSTEM_PROMPT_MAX_LENGTH, SCAN_PROMPT_MAX_LENGTH } = require('../config/constants');
+const { SYSTEM_PROMPT_MAX_LENGTH, SCAN_PROMPT_MAX_LENGTH, CONSUMED_STATUSES } = require('../config/constants');
 
 const router = express.Router();
 
@@ -53,8 +53,8 @@ router.get('/overview', async (req, res) => {
     ] = await Promise.all([
       User.countDocuments(),
       Bottle.countDocuments(),
-      Bottle.countDocuments({ status: { $nin: ['drank', 'gifted', 'sold', 'other'] } }),
-      Bottle.countDocuments({ status: { $in: ['drank', 'gifted', 'sold', 'other'] } }),
+      Bottle.countDocuments({ status: { $nin: CONSUMED_STATUSES } }),
+      Bottle.countDocuments({ status: { $in: CONSUMED_STATUSES } }),
       WineDefinition.countDocuments(),
       Cellar.countDocuments({ deletedAt: null }),
       BottleImage.countDocuments(),

--- a/backend/src/services/accountOps.js
+++ b/backend/src/services/accountOps.js
@@ -24,7 +24,7 @@ const ALLOWED_RATING_SCALES = ['5', '20', '100'];
 const ALLOWED_RACK_NAV = ['auto', 'room', 'rack'];
 const ALLOWED_RESTOCK_SCOPE = ['all', 'cellar'];
 const ALLOWED_VISIBILITY = ['public', 'private'];
-const SUPPORT_CATEGORIES = ['bug', 'help', 'feature', 'other'];
+const { SUPPORT_CATEGORIES } = require('../config/constants');
 
 const err = (status, message) => ({ status, message });
 

--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -222,9 +222,12 @@ async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
     const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
     await ensurePendingVintageProfile(wineDoc._id, bottle.vintage);
   } catch (err) { /* profile bookkeeping must never fail the add */ }
+  // Include wineName so the Cellar Audit page shows what was added, matching
+  // the REST POST /bottles audit (grand-audit M5 — AI-added bottles showed a
+  // bare vintage with no wine name). wineDoc is the resolved registry wine.
   logAudit(req, 'bottle.add',
     { type: 'bottle', id: bottle._id, cellarId: cellarDoc._id },
-    { vintage: bottle.vintage });
+    { wineName: wineDoc.name, vintage: bottle.vintage });
   if (hasPrice) {
     require('../utils/exchangeRates').getOrCreateDailySnapshot().catch(() => {});
   }

--- a/backend/src/services/bottleOps.test.js
+++ b/backend/src/services/bottleOps.test.js
@@ -158,7 +158,8 @@ describe('addBottle (real execution)', () => {
     expect(b.user).toBe('owner1');             // owner = cellar owner
     expect(embedSinglePair).toHaveBeenCalledWith('w1', '2019');
     expect(enrichWineById).toHaveBeenCalledWith('w1', { budgetUserId: 'u1' });
-    expect(logAudit).toHaveBeenCalledWith(REQ, 'bottle.add', expect.anything(), { vintage: '2019' });
+    // wineName rides along so the Cellar Audit page shows what was added (M5).
+    expect(logAudit).toHaveBeenCalledWith(REQ, 'bottle.add', expect.anything(), { wineName: 'Barolo', vintage: '2019' });
   });
 
   test('rejects bad vintage / reversed drink window / oversized notes', async () => {

--- a/backend/src/services/mcpOAuth.js
+++ b/backend/src/services/mcpOAuth.js
@@ -16,7 +16,7 @@ const ACCESS_TOKEN_TTL_SEC = 60 * 60; // 1 hour
 // The cel_ scopes an OAuth token may carry. offline_access is a meta-scope that
 // only signals "issue a refresh token" (we always do) — it is advertised for
 // client compatibility (claude.ai appends it) but never stored as a cel_ scope.
-const GRANTABLE_SCOPES = ['read', 'consume', 'write'];
+const { MCP_PERSONAL_SCOPES: GRANTABLE_SCOPES } = require('../config/constants');
 const SUPPORTED_SCOPES = [...GRANTABLE_SCOPES, 'offline_access'];
 
 /** Origin the AS + RS are served from (prod: https://cellarion.app). */

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -672,7 +672,7 @@ async function searchDiscussions(query, { category, limit = 20, offset = 0 } = {
   }
   assertIndexReady('discussions');
 
-  const VALID_CATEGORIES = ['tasting-notes', 'food-pairing', 'recommendations', 'cellar-tips', 'general'];
+  const { CATEGORIES: VALID_CATEGORIES } = require('../models/Discussion');
   const filters = [];
   if (category && VALID_CATEGORIES.includes(String(category))) {
     filters.push(`category = "${category}"`);


### PR DESCRIPTION
Fifth remediation batch from GRAND_AUDIT_2026-07-17 — the "one implementation" rule was quietly broken in several spots.

## M7 — MCP scope list hard-coded in 3 files
`['read','consume','write']` lived in `routes/mcp` (JWT_SCOPES), `services/mcpOAuth` (GRANTABLE_SCOPES), and `routes/admin/mcp` (MCP_SCOPES) — adding a scope would silently miss OAuth grants, JWT sessions, or the usage view. Now one **`MCP_PERSONAL_SCOPES`** in `config/constants`, derived by all three. (Deliberately distinct from `ApiToken.TOKEN_SCOPES`, which also has device-only `climate`.)

## M9 — support-category enum in 3 places (one next to its own import)
`tools/account.js` hard-coded `z.enum(['bug','help','feature','other'])` while already importing `SUPPORT_CATEGORIES` for the description; third copy in the model. Single-sourced in `config/constants`; accountOps, the model `enum`, and the tool `z.enum` all derive from it.

## M5 — AI-added bottles had no wine name in the audit trail
`bottleOps.addBottle` audited `{ vintage }` only; REST `POST /bottles` audits `{ wineName, vintage }` and CellarAudit renders `wineName`. Now the service includes it too — MCP-added bottles read the same as web-added ones.

## M6 — web-created racks invisible in the cellar audit page
The REST rack-create audit logged no `cellarId`, and the cellar audit endpoint filters on `resource.cellarId` — so web-created racks never appeared while MCP-created ones (via `rackOps.createGridRack`) did. Added `cellarId` + `name`.

## L18 / L22
`services/search` now imports `Discussion.CATEGORIES` instead of re-declaring it; `superadmin` imports `CONSUMED_STATUSES` instead of two inline copies.

## Deferred (larger/riskier, own PR)
M8 (preservation-method list in 5 places) and the **full fold** of REST `bottles` POST/PUT onto `addBottle`/`updateBottleFields` — the observable audit-parity symptoms are fixed here; the structural unification is a bigger change.

## Tests
Full backend **124 suites / 1923** green in node:20-alpine. No compose impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)