### PR TITLE
fix(audit): design/UX — btn base, dark-mode, empty-state, aria, beta (M18-M23)

### DIFF
--- a/frontend/src/components/ReconsentModal.js
+++ b/frontend/src/components/ReconsentModal.js
@@ -50,10 +50,10 @@ export default function ReconsentModal() {
       </p>
       {error && <p className="error-message" role="alert">{error}</p>}
       <div className="modal-actions">
-        <button type="button" className="btn-secondary" onClick={logout} disabled={submitting}>
+        <button type="button" className="btn btn-secondary" onClick={logout} disabled={submitting}>
           {t('reconsent.logout')}
         </button>
-        <button type="button" className="btn-primary" onClick={handleAccept} disabled={submitting}>
+        <button type="button" className="btn btn-primary" onClick={handleAccept} disabled={submitting}>
           {submitting ? t('common.saving') : t('reconsent.acknowledge')}
         </button>
       </div>

--- a/frontend/src/components/ReportWineModal.js
+++ b/frontend/src/components/ReportWineModal.js
@@ -48,7 +48,7 @@ function ReportWineModal({ wine, defaultReason, onClose }) {
           <p>{t('reportWine.sentBody')}</p>
         </div>
         <div className="modal-actions">
-          <button className="btn-primary" onClick={onClose}>{t('common.close')}</button>
+          <button className="btn btn-primary" onClick={onClose}>{t('common.close')}</button>
         </div>
       </Modal>
     );
@@ -89,7 +89,7 @@ function ReportWineModal({ wine, defaultReason, onClose }) {
         {error && <p className="report-wine-error">{error}</p>}
 
         <div className="modal-actions">
-          <button type="button" className="btn-secondary" onClick={onClose} disabled={submitting}>
+          <button type="button" className="btn btn-secondary" onClick={onClose} disabled={submitting}>
             {t('common.cancel')}
           </button>
           <button type="submit" className="btn-danger" disabled={submitting}>

--- a/frontend/src/components/SupportModal.js
+++ b/frontend/src/components/SupportModal.js
@@ -49,7 +49,7 @@ function SupportModal({ onClose }) {
           </p>
         </div>
         <div className="modal-actions">
-          <button className="btn-primary" onClick={onClose}>{t('common.close')}</button>
+          <button className="btn btn-primary" onClick={onClose}>{t('common.close')}</button>
         </div>
       </Modal>
     );
@@ -95,10 +95,10 @@ function SupportModal({ onClose }) {
         {error && <p className="support-modal-error">{error}</p>}
 
         <div className="modal-actions">
-          <button type="button" className="btn-secondary" onClick={onClose} disabled={submitting}>
+          <button type="button" className="btn btn-secondary" onClick={onClose} disabled={submitting}>
             {t('common.cancel')}
           </button>
-          <button type="submit" className="btn-primary" disabled={submitting}>
+          <button type="submit" className="btn btn-primary" disabled={submitting}>
             {submitting ? t('support.sending') : t('support.sendTicket')}
           </button>
         </div>

--- a/frontend/src/pages/AdminAiBudgetRequests.js
+++ b/frontend/src/pages/AdminAiBudgetRequests.js
@@ -135,14 +135,14 @@ function AdminAiBudgetRequests() {
                   />
                 </label>
                 <button
-                  className="btn-primary"
+                  className="btn btn-primary"
                   disabled={submittingId === req._id}
                   onClick={() => handleDecide(req._id, 'approve')}
                 >
                   {submittingId === req._id ? '…' : t('adminAiBudget.approve')}
                 </button>
                 <button
-                  className="btn-secondary"
+                  className="btn btn-secondary"
                   disabled={submittingId === req._id}
                   onClick={() => handleDecide(req._id, 'deny')}
                 >

--- a/frontend/src/pages/AdminSupportTickets.css
+++ b/frontend/src/pages/AdminSupportTickets.css
@@ -151,6 +151,7 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: none;
+  color: var(--color-text); /* else UA-black text on the dark panel (M19) */
   cursor: pointer;
 }
 
@@ -229,6 +230,10 @@
   padding: 10px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
+  /* Themed surface/text — without these the UA-default white box + black text
+     stayed light-on-dark in dark mode (grand-audit M19). */
+  background: var(--color-input-bg, var(--color-surface));
+  color: var(--color-text);
   font-size: 0.9rem;
   font-family: inherit;
   resize: vertical;
@@ -247,6 +252,8 @@
   padding: 6px 10px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
+  background: var(--color-input-bg, var(--color-surface));
+  color: var(--color-text);
   font-size: 0.875rem;
 }
 

--- a/frontend/src/pages/AdminSupportTickets.js
+++ b/frontend/src/pages/AdminSupportTickets.js
@@ -228,7 +228,7 @@ function AdminSupportTickets() {
                     ))}
                   </select>
                   <button
-                    className="btn-primary"
+                    className="btn btn-primary"
                     onClick={handleRespond}
                     disabled={submitting}
                   >
@@ -236,7 +236,7 @@ function AdminSupportTickets() {
                   </button>
                   {selected.status !== 'closed' && (
                     <button
-                      className="btn-secondary"
+                      className="btn btn-secondary"
                       onClick={() => handleStatusOnly(selected._id, 'closed')}
                     >
                       Close ticket

--- a/frontend/src/pages/AdminWineReports.js
+++ b/frontend/src/pages/AdminWineReports.js
@@ -208,14 +208,14 @@ function AdminWineReports() {
                   />
                   <div className="awr-action-buttons">
                     <button
-                      className="btn-primary"
+                      className="btn btn-primary"
                       onClick={() => handleAction('resolve')}
                       disabled={submitting}
                     >
                       {submitting ? '…' : 'Mark Resolved'}
                     </button>
                     <button
-                      className="btn-secondary"
+                      className="btn btn-secondary"
                       onClick={() => handleAction('dismiss')}
                       disabled={submitting}
                     >

--- a/frontend/src/pages/CellarRoom.css
+++ b/frontend/src/pages/CellarRoom.css
@@ -44,6 +44,7 @@
   border-radius: 4px;
   background: var(--color-primary, #6366f1);
   color: #fff;
+  margin-left: 0.5rem; /* was an inline style on the title-badge span (M22) */
 }
 
 .room-mode-badge {

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -1033,7 +1033,7 @@ export default function CellarRoom() {
           title={`${cellar?.name || '...'} — ${t('room.title', 'Room View')}`}
           loading={loading}
           subtitle={t('room.subtitle', '3D cellar layout')}
-          titleBadge={<span className="room-beta-badge" style={{ marginLeft: '0.5rem' }}>Beta</span>}
+          titleBadge={<span className="room-beta-badge">{t('cellarDetail.beta', 'Beta')}</span>}
           actions={canEdit && (
             <>
               <button className="btn btn-secondary btn-small" onClick={() => setShowSettings(s => !s)}>
@@ -1061,7 +1061,7 @@ export default function CellarRoom() {
               {t('room.backToRacks', 'Racks')}
             </Link>
             <h1>{cellar?.name || '...'} — {t('room.title', 'Room View')}</h1>
-            <span className="room-beta-badge">Beta</span>
+            <span className="room-beta-badge">{t('cellarDetail.beta', 'Beta')}</span>
             <span className="room-mode-badge edit">{t('room.editMode', 'Edit')}</span>
           </div>
 

--- a/frontend/src/pages/SupportPage.js
+++ b/frontend/src/pages/SupportPage.js
@@ -35,6 +35,9 @@ function SupportPage() {
       const reportData = await reportRes.json();
       if (ticketRes.ok) setTickets(ticketData.tickets || []);
       if (reportRes.ok) setWineReports(reportData.reports || []);
+      // A non-ok response set no data AND no error, so a 500 looked like the
+      // normal "you have no tickets" empty state (grand-audit M20).
+      if (!ticketRes.ok && !reportRes.ok) setError(t('support.failedLoad'));
     } catch {
       setError(t('support.failedLoad'));
     } finally {
@@ -73,7 +76,7 @@ function SupportPage() {
     <div className="support-page">
       <div className="support-header">
         <h1>{t('support.title')}</h1>
-        <button className="btn-primary" onClick={() => setShowModal(true)}>
+        <button className="btn btn-primary" onClick={() => setShowModal(true)}>
           {t('support.newTicket')}
         </button>
       </div>
@@ -108,6 +111,7 @@ function SupportPage() {
                   onClick={() => toggleExpand(ticket._id)}
                   role="button"
                   tabIndex={0}
+                  aria-expanded={expanded === ticket._id}
                   onKeyDown={e => e.key === 'Enter' && toggleExpand(ticket._id)}
                 >
                   <div className="support-card-meta">
@@ -160,13 +164,14 @@ function SupportPage() {
                           value={replyText}
                           onChange={e => setReplyText(e.target.value)}
                           placeholder={t('support.replyPlaceholder')}
+                          aria-label={t('support.replyPlaceholder')}
                           maxLength={5000}
                           rows={3}
                           disabled={replySending}
                         />
                         {replyError && <p className="support-error">{replyError}</p>}
                         <button
-                          className="btn-primary"
+                          className="btn btn-primary"
                           onClick={() => sendReply(ticket._id)}
                           disabled={replySending || !replyText.trim()}
                         >
@@ -196,6 +201,7 @@ function SupportPage() {
                   onClick={() => toggleExpand(report._id)}
                   role="button"
                   tabIndex={0}
+                  aria-expanded={expanded === report._id}
                   onKeyDown={e => e.key === 'Enter' && toggleExpand(report._id)}
                 >
                   <div className="support-card-meta">


### PR DESCRIPTION
Sixth remediation batch from GRAND_AUDIT_2026-07-17 — the standing Design/UX track (the safe, mechanical subset; the dialog-a11y High follows separately).

## M18 — buttons missing the `.btn` base class
~15 buttons used only `btn-primary`/`btn-secondary`, but all padding/radius/min-height live on `.btn` — so they rendered with UA-default chrome in brand colours. Added `btn ` at every site (SupportPage, AdminSupportTickets, AdminWineReports, AdminAiBudgetRequests, SupportModal, ReportWineModal, ReconsentModal).

## M19 — AdminSupportTickets controls broke in dark mode
The reply textarea, status select, and pagination buttons set no bg/color → white UA controls / UA-black text on the dark panel. Themed with `--color-input-bg`/`--color-text`.

## M20 — SupportPage false "no tickets" on API failure
A non-ok fetch set neither data nor error, so a 500 looked like the empty state. Now surfaces the load error.

## M23 — a11y
The two expandable support-card headers gained `aria-expanded`; the reply textarea gained an `aria-label` (placeholder ≠ label).

## M22 — hardcoded "Beta" in CellarRoom
Now `t('cellarDetail.beta')` like every sibling badge; the inline `marginLeft` moved into `.room-beta-badge`.

## Deferred — H6
The 7 hand-rolled dialogs missing `useDialogA11y` (BottleDetail/CellarRoom/CellarRacks) are riskier surgery in large core files and get their own reviewable batch.

## Tests
Frontend **31 files / 650** green. No compose impact. (sv strings unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)