### PR TITLE
test(audit): fix revert mock drift + real-logic budget/cache suites (H7, M24)

### DIFF
--- a/backend/src/mcp/mutationBudget.test.js
+++ b/backend/src/mcp/mutationBudget.test.js
@@ -1,0 +1,54 @@
+/**
+ * mutationBudget — real-execution coverage (grand-audit M24).
+ *
+ * Every consumer suite pins takeMutationSlot to () => true, so the actual
+ * budget logic (all-or-nothing batch charging, the 15-min window rollover, the
+ * live rateLimits.write.max read, the clear-at-cap) had never run. An
+ * off-by-one here means either unlimited AI writes or all writes blocked.
+ */
+
+jest.mock('../config/rateLimits', () => ({ get: jest.fn(() => ({ write: { max: 5 } })) }));
+
+const rateLimits = require('../config/rateLimits');
+const { takeMutationSlot, WRITE_WINDOW_MS } = require('./mutationBudget');
+
+let now = 1_000_000;
+beforeEach(() => {
+  jest.spyOn(Date, 'now').mockImplementation(() => now);
+  rateLimits.get.mockReturnValue({ write: { max: 5 } });
+});
+afterEach(() => jest.restoreAllMocks());
+
+const uid = (n) => `u${n}-${now}`; // unique per test to dodge the module-level map
+
+test('charges single slots up to the cap, then refuses', () => {
+  const u = uid(1);
+  for (let i = 0; i < 5; i++) expect(takeMutationSlot(u)).toBe(true);
+  expect(takeMutationSlot(u)).toBe(false); // 6th over max=5
+});
+
+test('batch charge is ALL-OR-NOTHING — a refused batch takes nothing', () => {
+  const u = uid(2);
+  expect(takeMutationSlot(u, 3)).toBe(true);   // 3/5 used
+  expect(takeMutationSlot(u, 3)).toBe(false);  // would be 6 > 5 → refused
+  // The refused batch must NOT have consumed anything: 2 slots still remain.
+  expect(takeMutationSlot(u, 2)).toBe(true);
+  expect(takeMutationSlot(u, 1)).toBe(false);
+});
+
+test('the window rolls over after WRITE_WINDOW_MS, resetting the count', () => {
+  const u = uid(3);
+  for (let i = 0; i < 5; i++) expect(takeMutationSlot(u)).toBe(true);
+  expect(takeMutationSlot(u)).toBe(false);
+  now += WRITE_WINDOW_MS + 1; // next window
+  expect(takeMutationSlot(u)).toBe(true); // fresh budget
+});
+
+test('reads the LIVE write.max on each call (admin can tune it down)', () => {
+  const u = uid(4);
+  expect(takeMutationSlot(u, 5)).toBe(true);
+  now += WRITE_WINDOW_MS + 1;
+  rateLimits.get.mockReturnValue({ write: { max: 2 } }); // admin lowered it
+  expect(takeMutationSlot(u, 3)).toBe(false); // 3 > new cap 2
+  expect(takeMutationSlot(u, 2)).toBe(true);
+});

--- a/backend/src/mcp/resultCache.test.js
+++ b/backend/src/mcp/resultCache.test.js
@@ -1,0 +1,38 @@
+/**
+ * resultCache — real-execution coverage (grand-audit M24).
+ *
+ * Tool suites only asserted "no recompute on repeat" and dodged the shared
+ * module-level cache via unique user ids, so TTL expiry, the evict-oldest-half
+ * branch, and per-user busting never ran.
+ */
+
+const { cachedResult, TTL_MS } = require('./resultCache');
+
+let now = 5_000_000;
+beforeEach(() => jest.spyOn(Date, 'now').mockImplementation(() => now));
+afterEach(() => jest.restoreAllMocks());
+
+test('serves the cached value on a repeat within the TTL (no recompute)', async () => {
+  const compute = jest.fn().mockResolvedValue({ n: 1 });
+  const a = await cachedResult('tool', 'uA', 'v', compute);
+  const b = await cachedResult('tool', 'uA', 'v', compute);
+  expect(a).toBe(b);
+  expect(compute).toHaveBeenCalledTimes(1);
+});
+
+test('recomputes once the TTL has elapsed', async () => {
+  const compute = jest.fn().mockResolvedValueOnce({ n: 1 }).mockResolvedValueOnce({ n: 2 });
+  await cachedResult('tool', 'uB', 'v', compute);
+  now += TTL_MS + 1;
+  const second = await cachedResult('tool', 'uB', 'v', compute);
+  expect(second).toEqual({ n: 2 });
+  expect(compute).toHaveBeenCalledTimes(2);
+});
+
+test('a different variant is a different cache entry', async () => {
+  const compute = jest.fn().mockResolvedValue({});
+  await cachedResult('tool', 'uC', 'v1', compute);
+  await cachedResult('tool', 'uC', 'v2', compute);
+  expect(compute).toHaveBeenCalledTimes(2);
+});
+// (bustUser per-user invalidation is covered on the cache-bust batch that adds it.)

--- a/backend/src/routes/mcp.test.js
+++ b/backend/src/routes/mcp.test.js
@@ -16,11 +16,14 @@ const WINDOW = 5 * DAY;
 jest.mock('../mcp/server', () => ({ handleMcpRequest: jest.fn(), initStatefulSession: jest.fn() }));
 jest.mock('../mcp/sessions', () => ({ getSession: jest.fn() }));
 jest.mock('../services/bottleOps', () => ({ RESTORE_WINDOW_MS: 5 * 86400000 }));
+// Use the REAL reversibleActionsFor / action lists (only revertLedgerRow is
+// mocked) so the route's revertible-action set — built from this at load — can
+// never drift from revert.js. A hand-copied 12-action list here silently
+// dropped the 5 newest write actions, making their timeline-revert tests
+// structurally impossible (grand-audit H7).
 jest.mock('../mcp/revert', () => ({
+  ...jest.requireActual('../mcp/revert'),
   revertLedgerRow: jest.fn(),
-  // The route builds its revertible-action set from this at load time.
-  reversibleActionsFor: () => ['consume', 'restore', 'add', 'update', 'bulk_add',
-    'somm_maturity', 'somm_price', 'cellar_create', 'rack_create', 'place', 'unplace', 'move'],
 }));
 jest.mock('../models/McpActionLog', () => ({
   find: jest.fn(),


### PR DESCRIPTION
Seventh remediation batch from GRAND_AUDIT_2026-07-17 — test integrity.

## H7 — drifted mock hid revert regressions for the 5 newest write actions
`routes/mcp.test.js` hand-copied `reversibleActionsFor` as a **12-action** list; the real module returns **17**. The route builds its revertible-action set (which the timeline Revert button keys on) from this at load, so a route-side regression dropping `arrange`/`tasting_note`/`attach_image`/`winelist_add`/`winelist_price` stayed green — the exact "fake confidence" pattern the 2026-07-10 audit flagged. Now `jest.requireActual('../mcp/revert')` drives the real list; only `revertLedgerRow` is mocked, so it can never drift again.

## M24 — real-logic coverage for two zero-coverage modules
- **`mutationBudget`**: every consumer suite pinned `takeMutationSlot` to `() => true`, so the actual logic never ran. New suite covers single-slot-to-cap, **all-or-nothing** batch charging (a refused batch takes nothing), the 15-min window rollover, and the live `write.max` read.
- **`resultCache`**: tool suites only asserted "no recompute on repeat" and dodged the shared cache via unique ids, so TTL expiry / variant keying never ran. New suite covers cache-hit, TTL-expiry recompute, and variant separation.

(The broader M24 test-debt — cron jobs, route-level GDPR tests, frontend UI suites — remains as tracked follow-up; this batch closes the two the report called out as "zero real coverage on a risky path".)

## Tests
Full backend **126 suites / 1930** green in node:20-alpine. No compose impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)