### PR TITLE
fix(audit): docs + dead-code truthfulness (L20, L25-L28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,15 @@ This is the primary way to use Cellarion. Create an account and start using the 
 
 ### Run the app
 
+The app is routed through Traefik, so create the external `web` Docker network **before** the first `up` (compose declares it external — the first command fails otherwise):
+
 ```bash
 git clone https://github.com/jagduvi1/Cellarion.git
 cd Cellarion
 cp .env.example .env
 # Edit .env and set JWT_SECRET and MEILI_MASTER_KEY to strong random strings
+docker network create web        # once; skip if it already exists
 docker-compose up --build
-```
-
-The app is routed through Traefik. Make sure the `web` Docker network exists before starting:
-
-```bash
-docker network create web
 ```
 
 Then bring up the stack:

--- a/README.md
+++ b/README.md
@@ -73,12 +73,6 @@ docker network create web        # once; skip if it already exists
 docker-compose up --build
 ```
 
-Then bring up the stack:
-
-```bash
-docker-compose up --build
-```
-
 | URL | Description |
 |-----|-------------|
 | http://localhost | Frontend (React SPA) — served via Traefik |

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -101,6 +101,8 @@ const EXCLUDED = {
   ClimateReading: 'no user reference (telemetry keyed by meta.device; purged + exported via the ClimateDevice entry)',
   OAuthClient: 'no user reference (a DCR-registered connector, not personal data — it is registered pre-login and shared across whoever connects it; the per-user tokens it mints live on ApiToken)',
   McpUsageStat: 'no user reference (aggregate per-day MCP usage counters, 180-day TTL)',
+  BackupStatus: 'no user reference (singleton backup health/status doc, not personal data)',
+  CommunityWinePrice: 'no user reference (k-anonymised aggregate community prices; never an individual\'s purchase)',
 };
 
 const REGISTRY = [

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -65,6 +65,19 @@ server {
         proxy_read_timeout 120s;
     }
 
+    # MCP OAuth 2.1 discovery — the spec mandates these at the ORIGIN ROOT (not
+    # under /api), so without this block they fall through to the SPA shell and
+    # every one-click AI-connector flow fails on a self-hosted instance
+    # (grand-audit L28; the hosted deploy already has this — docs/mcp-oauth.md).
+    location ~ "^/\.well-known/oauth-(authorization-server|protected-resource)" {
+        proxy_pass         http://backend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     # Rewrite sitemap.xml to /api/ path so it flows through the existing proxy
     location = /sitemap.xml {
         rewrite ^ /api/sitemap.xml break;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2351,7 +2351,7 @@
       "q5": "How do I import wines from Vivino or CellarTracker?",
       "a5": "Cellarion supports CSV import. Export your collection from Vivino, CellarTracker, or any spreadsheet, then upload the CSV in Cellarion's import tool. The shared wine registry deduplicates entries automatically so your data stays clean and consistent across the whole catalogue.",
       "q6": "Can I export my data and leave any time?",
-      "a6": "Yes — your data is yours. Cellarion includes a one-click data export that gives you everything as JSON, plus CSV import and export for bottles. You can delete your account from Settings with a 7-day cooling-off window. Hosted data lives on European infrastructure under GDPR."
+      "a6": "Yes — your data is yours. Cellarion includes a one-click data export that gives you everything as JSON (or a ZIP with your images), plus CSV import for bottles. You can delete your account from Settings with a 7-day cooling-off window. Hosted data lives on European infrastructure under GDPR."
     }
   },
   "maturity": {
@@ -2462,7 +2462,6 @@
     "colWine": "Wine",
     "colFrom": "From",
     "applyBtn": "Apply ({{count}} moves)",
-    "applying": "Moving… {{done}}/{{total}}",
     "applyingNow": "Applying…",
     "undoingNow": "Undoing…",
     "previewLoading": "Computing the plan…",
@@ -2479,7 +2478,6 @@
     "backToLast": "← Back to last organization",
     "newPlanBtn": "New organization…",
     "undoBtn": "Undo ({{count}} moves)",
-    "undoing": "Undoing… {{done}}/{{total}}",
     "undoneText": "Undone — the bottles are back where they were before the organization. Remember to restore the physical rack too if you had already moved them.",
     "undoUnavailable": "The rack has changed since — this organization can no longer be undone.",
     "undoError": "A move failed while undoing — the rack may have changed. Close and check the rack."

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2351,7 +2351,7 @@
       "q5": "Hur importerar jag viner från Vivino eller CellarTracker?",
       "a5": "Cellarion stöder CSV-import. Exportera din samling från Vivino, CellarTracker eller något kalkylark, ladda sedan upp CSV-filen i Cellarions importverktyg. Det delade vinregistret deduplicerar poster automatiskt så att din data förblir ren och konsekvent i hela katalogen.",
       "q6": "Kan jag exportera min data och lämna när jag vill?",
-      "a6": "Ja — din data är din. Cellarion har en en-kliks dataexport som ger dig allt som JSON, plus CSV-import och -export för flaskor. Du kan radera ditt konto från Inställningar med 7 dagars betänketid. Data på den hostade tjänsten lagras på europeisk infrastruktur under GDPR."
+      "a6": "Ja — din data är din. Cellarion har en en-kliks dataexport som ger dig allt som JSON (eller en ZIP med dina bilder), plus CSV-import för flaskor. Du kan radera ditt konto från Inställningar med 7 dagars betänketid. Data på den hostade tjänsten lagras på europeisk infrastruktur under GDPR."
     }
   },
   "maturity": {
@@ -2462,7 +2462,6 @@
     "colWine": "Vin",
     "colFrom": "Från",
     "applyBtn": "Utför ({{count}} flyttar)",
-    "applying": "Flyttar… {{done}}/{{total}}",
     "applyingNow": "Utför…",
     "undoingNow": "Ångrar…",
     "previewLoading": "Beräknar planen…",
@@ -2479,7 +2478,6 @@
     "backToLast": "← Tillbaka till senaste organiseringen",
     "newPlanBtn": "Ny organisering…",
     "undoBtn": "Ångra ({{count}} flyttar)",
-    "undoing": "Ångrar… {{done}}/{{total}}",
     "undoneText": "Ångrat — flaskorna är tillbaka där de stod före organiseringen. Kom ihåg att återställa den fysiska hyllan också om du redan hade flyttat dem.",
     "undoUnavailable": "Hyllan har ändrats sedan dess — organiseringen kan inte längre ångras.",
     "undoError": "En flytt misslyckades under ångringen — hyllan kan ha ändrats. Stäng och kontrollera hyllan."


### PR DESCRIPTION
Eighth remediation batch from GRAND_AUDIT_2026-07-17 — the cheap truthfulness/dead-code Lows.

## L27 — landing FAQ falsely claimed CSV export
The FAQ still said "CSV import **and export**" (en+sv) while the app exports JSON/ZIP only (CSV is import-only) — and the crawler-rendered copy was already corrected, so the SPA contradicted the server-rendered FAQ of the same page. Now: "JSON (or a ZIP with images), plus CSV import for bottles."

## L26 — README first command failed on a fresh machine
Quick Start ran `docker-compose up` **before** `docker network create web`, but compose declares `web` external → the first documented command errored. Reordered (create the network first).

## L28 — self-hosted MCP OAuth broken by default
`frontend/nginx.conf` proxied only `/api/`, so the spec-mandated root `/.well-known/oauth-*` discovery paths fell through to the SPA shell → every self-hosted one-click AI-connector flow failed. Added the discovery proxy block (the hosted deploy already has it per docs/mcp-oauth.md).

## L20 — orphaned i18n keys
Removed `arrange.applying` / `arrange.undoing` from both locales (the consumer uses `applyingNow` / `undoingNow`).

## L25 — GDPR registry completeness
`BackupStatus` + `CommunityWinePrice` now listed in EXCLUDED with reasons (both genuinely non-personal — no user ref) so the "every model is a conscious decision" contract holds.

*(CLAUDE.md's stale counts — 47→57 models, 823→~1930 tests — refreshed locally too; it's gitignored, so not in this diff.)*

## Tests
Frontend **650** green; registry completeness test green in node:20-alpine. No compose impact (nginx.conf ships with the frontend image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)