### PR TITLE
fix(security): launch-gate — wine-list PDF DoS, verify-email login-CSRF, audit PII (H1/M-1/M-2)

### DIFF
--- a/backend/src/models/WineList.js
+++ b/backend/src/models/WineList.js
@@ -230,10 +230,40 @@ const wineListSchema = new mongoose.Schema({
 // Indexes — user-only queries are served by the compound index prefix
 wineListSchema.index({ user: 1, cellar: 1 });
 
-// Update timestamp on save
+// Total-entry cap. A real restaurant menu is well under this; the cap exists
+// because the PUBLIC, unauthenticated PDF endpoint renders every entry
+// synchronously and buffers the whole document in the backend heap — without a
+// cap one account could publish a multi-thousand-entry list and DoS the whole
+// service via a few anonymous PDF requests (security audit H1). Enforced HERE
+// (pre-save) so every write path is covered: REST create/update/duplicate AND
+// the MCP add_to_list tool + its undo. Thrown as a ValidationError so the REST
+// routes (→400) and the MCP tool (→invalid_input) both surface it cleanly.
+const MAX_ENTRIES_PER_LIST = 500;
+
+/** Total entries across BOTH containers (autoGroupEntries + every section). */
+function countWineListEntries(doc) {
+  return (doc.autoGroupEntries?.length || 0) +
+    (doc.sections || []).reduce((n, s) => n + (s.entries?.length || 0), 0);
+}
+
+/** ValidationError when over the cap, else null. Exported so it's unit-testable
+ *  without a DB and reusable if a write path wants to pre-check. */
+function entryCapError(doc) {
+  const total = countWineListEntries(doc);
+  if (total > MAX_ENTRIES_PER_LIST) {
+    const err = new Error(`A wine list can have at most ${MAX_ENTRIES_PER_LIST} entries (this one has ${total}).`);
+    err.name = 'ValidationError';
+    return err;
+  }
+  return null;
+}
+
 wineListSchema.pre('save', function(next) {
   this.updatedAt = Date.now();
-  next();
+  next(entryCapError(this)); // null when within the cap
 });
 
 module.exports = mongoose.model('WineList', wineListSchema);
+module.exports.MAX_ENTRIES_PER_LIST = MAX_ENTRIES_PER_LIST;
+module.exports.countWineListEntries = countWineListEntries;
+module.exports.entryCapError = entryCapError;

--- a/backend/src/models/WineList.test.js
+++ b/backend/src/models/WineList.test.js
@@ -1,0 +1,44 @@
+/**
+ * WineList total-entry cap (security audit H1).
+ *
+ * The public, unauthenticated PDF endpoint renders every entry synchronously
+ * and buffers the whole document in the backend heap, so an uncapped list is a
+ * whole-service DoS. The cap is enforced in a pre('save') hook (so EVERY write
+ * path — REST create/update/duplicate + the MCP add_to_list tool — is covered)
+ * via the exported entryCapError helper, tested directly here.
+ */
+
+const WineList = require('./WineList');
+const { MAX_ENTRIES_PER_LIST: MAX, countWineListEntries, entryCapError } = WineList;
+
+const entry = () => ({ wine: '5f'.repeat(12), vintage: '2019', bottleSize: '750ml' });
+
+test('exports a sane cap', () => {
+  expect(typeof MAX).toBe('number');
+  expect(MAX).toBeGreaterThan(0);
+  expect(MAX).toBeLessThanOrEqual(1000);
+});
+
+test('counts the TOTAL across autoGroupEntries + every section', () => {
+  expect(countWineListEntries({ autoGroupEntries: [entry(), entry()] })).toBe(2);
+  expect(countWineListEntries({ sections: [{ entries: [entry()] }, { entries: [entry(), entry()] }] })).toBe(3);
+  expect(countWineListEntries({})).toBe(0);
+});
+
+test('at/under the cap → no error; over the cap → ValidationError', () => {
+  expect(entryCapError({ autoGroupEntries: Array.from({ length: MAX }, entry) })).toBeNull();
+
+  const err = entryCapError({ autoGroupEntries: Array.from({ length: MAX + 1 }, entry) });
+  expect(err).toBeTruthy();
+  expect(err.name).toBe('ValidationError'); // → REST 400 / MCP invalid_input
+  expect(err.message).toMatch(/at most/);
+});
+
+test('the cap is enforced across BOTH containers (a mode-flip can\'t double it)', () => {
+  const err = entryCapError({
+    sections: [{ entries: Array.from({ length: MAX }, entry) }],
+    autoGroupEntries: [entry()],
+  });
+  expect(err).toBeTruthy();
+  expect(err.name).toBe('ValidationError');
+});

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -320,8 +320,21 @@ router.post('/login', authLimiter, async (req, res) => {
 });
 
 // GET /api/auth/verify-email?token=:token - Verify email address
-router.get('/verify-email', async (req, res) => {
-  const { token } = req.query;
+// POST (not GET) and issues NO session (security audit M-1). The email link
+// points at the SPA page /verify-email?token=…, which now POSTs the token here
+// from same-origin JS. This closes two holes in the old session-issuing GET:
+//   - login-CSRF / session-fixation: a cross-site GET to the old endpoint (or
+//     to the SPA page) let an attacker's verification token Set-Cookie the
+//     attacker's refresh cookie into a victim's browser (SameSite=Lax does not
+//     block storing it), silently logging the victim into the attacker's
+//     account. A POST is not triggerable by a plain cross-site navigation, and
+//     issuing no session removes the fixation entirely — the user logs in
+//     normally afterward.
+//   - one-time-token burn by mail-security prefetchers: link scanners issue
+//     GETs, not the SPA's POST, so they no longer consume the token.
+router.post('/verify-email', async (req, res) => {
+  res.setHeader('Cache-Control', 'no-store');
+  const { token } = req.body || {};
 
   if (!token) {
     return res.status(400).json({ error: 'Verification token is required' });
@@ -338,8 +351,7 @@ router.get('/verify-email', async (req, res) => {
     user.emailVerified = true;
     user.emailVerificationTokenHash = null;
     user.emailVerificationExpiresAt = null;
-
-    const accessToken = await issueTokens(user, res);
+    await user.save();
 
     logAudit(req, 'auth.email_verified',
       { type: 'user', id: user._id },
@@ -349,11 +361,8 @@ router.get('/verify-email', async (req, res) => {
     // Resolve any pending cellar shares for this email
     resolvePendingShares(user).catch(() => {});
 
-    res.json({
-      message: 'Email verified successfully.',
-      token: accessToken,
-      user: user.toJSON()
-    });
+    // No session is issued here — the client sends the user to log in.
+    res.json({ verified: true, message: 'Email verified successfully. Please log in.' });
   } catch (error) {
     console.error('Email verification error:', error);
     res.status(500).json({ error: 'Email verification failed' });

--- a/backend/src/routes/auth.refresh.test.js
+++ b/backend/src/routes/auth.refresh.test.js
@@ -632,6 +632,47 @@ describe('POST /api/auth/reset-password', () => {
 });
 
 // ---------------------------------------------------------------------------
+// POST /api/auth/verify-email — must NOT issue a session (security audit M-1)
+// ---------------------------------------------------------------------------
+describe('POST /api/auth/verify-email', () => {
+  const withVerifyToken = (raw) => makeUserDoc({
+    emailVerified: false,
+    emailVerificationTokenHash: sha256(raw),
+    emailVerificationExpiresAt: new Date(NOW + 24 * 60 * 60 * 1000),
+    validateEmailVerificationToken(candidate) {
+      if (!this.emailVerificationTokenHash || !this.emailVerificationExpiresAt) return false;
+      if (Date.now() > this.emailVerificationExpiresAt.getTime()) return false;
+      return sha256(candidate) === this.emailVerificationTokenHash;
+    },
+  });
+
+  test('verifies the email and issues NO session (no token, no refresh cookie)', async () => {
+    const user = withVerifyToken('verify-raw-token');
+    const res = await request({ method: 'POST', path: '/api/auth/verify-email', body: { token: 'verify-raw-token' } });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ verified: true, message: expect.any(String) });
+    // The login-CSRF/session-fixation fix: no access token, no refresh cookie.
+    expect(res.body.token).toBeUndefined();
+    expect(res.setCookies).toEqual([]);
+    expect(user.emailVerified).toBe(true);
+    expect(user.emailVerificationTokenHash).toBeNull();
+    expect(user.save).toHaveBeenCalled();
+  });
+
+  test('rejects an unknown/expired token without issuing a session', async () => {
+    makeUserDoc(); // a user exists, but no verification token matches
+    const res = await request({ method: 'POST', path: '/api/auth/verify-email', body: { token: 'nope' } });
+    expect(res.status).toBe(400);
+    expect(res.setCookies).toEqual([]);
+  });
+
+  test('400 with no token', async () => {
+    const res = await request({ method: 'POST', path: '/api/auth/verify-email', body: {} });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // GET /api/auth/whoami — minimal stable identity for scoped integrations
 // ---------------------------------------------------------------------------
 describe('GET /api/auth/whoami', () => {

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -1677,10 +1677,26 @@ router.get('/:id/audit', async (req, res) => {
       return res.status(403).json({ error: 'Not authorized' });
     }
 
-    const logs = await AuditLog.find({ 'resource.cellarId': req.params.id })
+    // Return a MINIMISED projection (security audit M-2): the raw AuditLog docs
+    // carry actor.ipAddress, userAgent, and the actor's email — a cellar owner
+    // must not harvest collaborators' (incl. former collaborators', and any
+    // admin/somm actor's) IP + email. The app's own token layer already blocks
+    // this path for API tokens (apiTokenAuth TOKEN_EXCLUSIONS, "audit log incl.
+    // collaborator IPs and emails"); apply the same discipline to the web path.
+    // Populate username only, and drop ip/userAgent/email before responding.
+    const raw = await AuditLog.find({ 'resource.cellarId': req.params.id })
       .sort({ timestamp: -1 })
       .limit(100)
-      .populate('actor.userId', 'username email');
+      .populate('actor.userId', 'username')
+      .lean();
+
+    const logs = raw.map((l) => ({
+      _id: l._id,
+      action: l.action,
+      detail: l.detail,
+      timestamp: l.timestamp,
+      actor: { userId: l.actor?.userId ? { username: l.actor.userId.username } : null },
+    }));
 
     res.json({ logs });
   } catch (error) {

--- a/backend/src/routes/wineListPublic.js
+++ b/backend/src/routes/wineListPublic.js
@@ -95,6 +95,16 @@ router.get('/:shareToken/pdf', async (req, res) => {
     if (!wineList) return res.status(404).json({ error: 'Wine list not found or not published' });
     if (!(await cellarIsActive(wineList))) return res.status(404).json({ error: 'Wine list not found or not published' });
 
+    // Defence-in-depth for the synchronous, heap-buffered render (security
+    // audit H1): the write-side pre-save cap stops any NEW list exceeding
+    // MAX_ENTRIES_PER_LIST, but refuse to render a pre-existing over-cap list
+    // here too rather than block the event loop / OOM the worker.
+    const totalEntries = (wineList.autoGroupEntries?.length || 0) +
+      (wineList.sections || []).reduce((n, s) => n + (s.entries?.length || 0), 0);
+    if (totalEntries > (WineList.MAX_ENTRIES_PER_LIST || 500)) {
+      return res.status(413).json({ error: 'This wine list is too large to render as a PDF.' });
+    }
+
     const wineMap = await loadWineMap(wineList);
 
     // QR code on the printed PDF points at the web menu, which is what a

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -277,13 +277,16 @@ export const AuthProvider = ({ children }) => {
 
   const verifyEmail = async (token) => {
     try {
-      const response = await fetch(`/api/auth/verify-email?token=${encodeURIComponent(token)}`, {
-        credentials: 'include'
+      // POST the token (security audit M-1): the endpoint verifies the email
+      // and issues NO session, so the user logs in normally afterward — this
+      // removes the old GET's login-CSRF/session-fixation and prefetch-burn.
+      const response = await fetch('/api/auth/verify-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token })
       });
       const data = await response.json();
       if (!response.ok) throw new Error(data.error || 'Verification failed');
-
-      applySession(data.token, data.user);
       return { success: true };
     } catch (error) {
       return { success: false, error: error.message };

--- a/frontend/src/pages/VerifyEmail.js
+++ b/frontend/src/pages/VerifyEmail.js
@@ -34,7 +34,9 @@ function VerifyEmail() {
     verifyEmail(token).then(result => {
       if (result.success) {
         setStatus('success');
-        setTimeout(() => navigate('/cellars', { replace: true }), 1500);
+        // Verification no longer logs the user in (security audit M-1) — send
+        // them to log in rather than into an authenticated view.
+        setTimeout(() => navigate('/login', { replace: true }), 1500);
       } else {
         setStatus('error');
         setErrorMessage(result.error || t('auth.verificationFailed'));


### PR DESCRIPTION
First remediation batch from SECURITY_AUDIT_2026-07-17 — the three findings that gate the public launch.

## H1 — unauthenticated wine-list PDF render → whole-service DoS
The `WineList` schema capped individual string fields but placed **no count cap** on `entries`/`autoGroupEntries`/`sections`, and `GET /api/wine-lists/public/:shareToken/pdf` (no auth) renders synchronously with `bufferPages:true` on the single event loop + full doc in the 480 MB heap. One free account publishes a ~6,000-entry list → a few anonymous PDF hits block all requests / OOM the worker.
- **Total-entry cap (500)** enforced in a `pre('save')` hook → covers **every** write path (REST create/update/duplicate + MCP `add_to_list` + its undo), thrown as a `ValidationError` (REST 400 / MCP `invalid_input`). The cap logic is an exported helper (`entryCapError`) with a dedicated unit test.
- **Defence-in-depth 413** in the public `/pdf` route for any pre-existing over-cap list.
- *(This is the security consequence of the missing cap already flagged as code-audit perf-L9.)*

## M-1 — verify-email GET issued a session → login-CSRF / session-fixation + token burn
`GET /api/auth/verify-email` verified the email **and minted a full 30-day session**. A cross-site GET (to the SPA verify page) with an attacker's token let the victim's browser store the attacker's refresh cookie (`SameSite=Lax` doesn't block storing on a top-level navigation) → the victim is silently logged **into the attacker's account**; and mail-security prefetchers burned the one-time token.
- Now **POST**, issues **no session** (the user logs in normally afterward), `Cache-Control: no-store`. The SPA POSTs the token and routes to `/login` on success. New regression test asserts no token + no refresh cookie.

## M-2 — cellar audit endpoint leaked collaborators' IP + email + UA to the owner
`GET /api/cellars/:id/audit` returned full `AuditLog` docs — the app's own token layer already blocks this exact path for API tokens (`TOKEN_EXCLUSIONS`, *"audit log incl. collaborator IPs and emails"*); the web path now applies the same discipline: populate `username` only + a minimised projection stripping `actor.ipAddress`/`userAgent`/`email`.

## Tests
Backend **128 suites / 1945** green in node:20-alpine (new WineList cap suite + verify-email cases); frontend **653** green. No compose impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)