### PR TITLE
fix(mcp/security): bound public-MCP read amplification + DCR client flood (M-4, M-6)

### DIFF
--- a/backend/src/mcp/callBudget.js
+++ b/backend/src/mcp/callBudget.js
@@ -1,0 +1,64 @@
+// Cross-request MCP tool-call budget (security audit M-4 / prior audit M5).
+//
+// The per-request cap (MAX_CALLS_PER_REQUEST) and the per-IP HTTP limiters
+// count REQUESTS, not tool calls — one request fans out to up to 20 calls
+// (10 anonymous), and authenticated read tools otherwise have no cumulative
+// budget at all, so a caller can drive thousands of full-portfolio / Qdrant
+// reads per window (read amplification onto the 256 MB Qdrant shared with
+// cellar chat). This is a rolling-window counter keyed by CALLER identity —
+// the user id for authenticated connections, the client IP for the anonymous
+// public surface — charged for every tool/resource/prompt call. Reads and
+// writes both count (writes also ride the separate mutationBudget).
+//
+// In-memory like the mutation budget; a generous ceiling that only bites
+// abuse, not legitimate agent turns.
+const WINDOW_MS = 15 * 60 * 1000;
+
+// Authenticated: ~2.2 calls/sec sustained for 15 min — far above any real
+// agent session, far below the ~4,000 the request cap alone allowed.
+const USER_CALL_MAX = 2000;
+// Anonymous per-IP: the public request limiter is 60/15min × up to 10 calls =
+// 600 possible; this tightens the actual work to 200 tool calls/15min/IP.
+const PUBLIC_CALL_MAX = 200;
+
+const windows = new Map(); // key -> { start, count }
+const MAX_KEYS = 10000;
+
+/**
+ * Charge one call against the caller's rolling window. Returns true if the
+ * call is within budget, false when the caller has exhausted it. Never throws.
+ */
+function takeCallSlot(key, max) {
+  if (!max || max <= 0) return true; // 0/undefined = unlimited
+  const now = Date.now();
+  let w = windows.get(key);
+  if (!w || now - w.start >= WINDOW_MS) {
+    if (windows.size >= MAX_KEYS) {
+      // Evict the oldest half (insertion order) rather than clear everyone.
+      let drop = Math.ceil(MAX_KEYS / 2);
+      for (const k of windows.keys()) { if (drop-- <= 0) break; windows.delete(k); }
+    }
+    w = { start: now, count: 0 };
+    windows.set(key, w);
+  }
+  w.count += 1;
+  return w.count <= max;
+}
+
+/** The budget key + cap for a request context (anon → IP, else → user id). */
+function budgetFor(ctx) {
+  if (ctx.anonymous || !ctx.user) {
+    let ip = 'anon';
+    try { ip = require('../utils/clientIp').getClientIp(ctx.req) || 'anon'; } catch { /* no req in unit tests */ }
+    return { key: `ip:${ip}`, max: PUBLIC_CALL_MAX };
+  }
+  return { key: `u:${ctx.user.id}`, max: USER_CALL_MAX };
+}
+
+/** True when the caller is still within their call budget (charges one slot). */
+function withinCallBudget(ctx) {
+  const { key, max } = budgetFor(ctx);
+  return takeCallSlot(key, max);
+}
+
+module.exports = { takeCallSlot, withinCallBudget, budgetFor, WINDOW_MS, USER_CALL_MAX, PUBLIC_CALL_MAX };

--- a/backend/src/mcp/callBudget.test.js
+++ b/backend/src/mcp/callBudget.test.js
@@ -1,0 +1,54 @@
+/**
+ * MCP cross-request call budget (security audit M-4).
+ *
+ * Bounds read amplification: the per-request cap and per-IP HTTP limiter count
+ * requests, not tool calls, so without this a caller could drive thousands of
+ * reads per window. These tests pin the rolling-window counter, the per-caller
+ * keying (user vs anon IP), and the window rollover.
+ */
+
+jest.mock('../utils/clientIp', () => ({ getClientIp: (req) => req?.ip || 'anon' }));
+
+const { takeCallSlot, withinCallBudget, budgetFor, WINDOW_MS, USER_CALL_MAX, PUBLIC_CALL_MAX } = require('./callBudget');
+
+let now = 1_000_000;
+beforeEach(() => jest.spyOn(Date, 'now').mockImplementation(() => now));
+afterEach(() => jest.restoreAllMocks());
+
+const key = (n) => `k-${n}-${now}`; // unique per test to dodge the module-level map
+
+test('allows calls up to the cap, then refuses; 0/undefined = unlimited', () => {
+  const k = key(1);
+  for (let i = 0; i < 5; i++) expect(takeCallSlot(k, 5)).toBe(true);
+  expect(takeCallSlot(k, 5)).toBe(false);
+  // Unlimited sentinel
+  for (let i = 0; i < 100; i++) expect(takeCallSlot(key(2), 0)).toBe(true);
+});
+
+test('the window rolls over after WINDOW_MS', () => {
+  const k = key(3);
+  for (let i = 0; i < 5; i++) takeCallSlot(k, 5);
+  expect(takeCallSlot(k, 5)).toBe(false);
+  now += WINDOW_MS + 1;
+  expect(takeCallSlot(k, 5)).toBe(true);
+});
+
+test('budgetFor keys an authenticated caller by user id with the user cap', () => {
+  const { key: k, max } = budgetFor({ user: { id: 'u1' } });
+  expect(k).toBe('u:u1');
+  expect(max).toBe(USER_CALL_MAX);
+});
+
+test('budgetFor keys the anonymous surface by client IP with the tighter public cap', () => {
+  const { key: k, max } = budgetFor({ anonymous: true, req: { ip: '203.0.113.9' } });
+  expect(k).toBe('ip:203.0.113.9');
+  expect(max).toBe(PUBLIC_CALL_MAX);
+  // Falls back to 'anon' when no req/ip is available (unit-test contexts).
+  expect(budgetFor({ anonymous: true }).key).toBe('ip:anon');
+});
+
+test('withinCallBudget charges one slot for the caller', () => {
+  const ctx = { user: { id: `budget-user-${now}` } };
+  // Far below USER_CALL_MAX, so always true — just proves it charges without throwing.
+  for (let i = 0; i < 10; i++) expect(withinCallBudget(ctx)).toBe(true);
+});

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -48,6 +48,12 @@ const rateLimited = (message) => ({
 // would. Batch tools (bulk_add) charge one slot PER ITEM through the same
 // module, so a case of 12 costs 12 — see mcp/mutationBudget.js.
 const { takeMutationSlot, WRITE_WINDOW_MS } = require('./mutationBudget');
+// Cross-request tool-call budget per caller (user id / anon IP) — caps read
+// amplification the per-request cap and per-IP HTTP limiter can't (M-4).
+const { withinCallBudget } = require('./callBudget');
+
+const callBudgetExceeded = () =>
+  rateLimited('Too many Cellarion tool calls in a short time — pause a moment and continue. This protects the shared service.');
 
 // Aggregate usage counters behind the admin view (GET /api/admin/mcp/usage).
 // record() is fire-and-forget and no-ops without a live Mongo connection, so
@@ -96,6 +102,11 @@ function budgetedHandler(tool, ctx, state) {
     if (state.calls > maxCalls) {
       recordUsage(ctx, 'tool', tool.name, true);
       return rateLimited(`Too many tool calls in one request (max ${maxCalls}). Send fewer calls per batch and paginate instead.`);
+    }
+    // Cross-request caller budget — bounds read amplification (M-4).
+    if (!withinCallBudget(ctx)) {
+      recordUsage(ctx, 'tool', tool.name, true);
+      return callBudgetExceeded();
     }
     if (tool.annotations?.readOnlyHint === false) {
       // Fail-closed for the anonymous surface (audit P6-L2): if a mutating
@@ -248,6 +259,10 @@ function budgetedPromptHandler(prompt, ctx, state) {
       recordUsage(ctx, 'prompt', prompt.name, true);
       throw new Error(`rate_limited: too many calls in one request (max ${maxCalls})`);
     }
+    if (!withinCallBudget(ctx)) {
+      recordUsage(ctx, 'prompt', prompt.name, true);
+      throw new Error('rate_limited: too many Cellarion tool calls in a short time');
+    }
     return withUsage(ctx, 'prompt', prompt.name, () => prompt.handler(args || {}, ctx));
   };
 }
@@ -264,6 +279,10 @@ function budgetedResourceHandler(rsrc, ctx, state) {
     if (state.calls > maxCalls) {
       recordUsage(ctx, 'resource', rsrc.name, true);
       throw new Error(`rate_limited: too many calls in one request (max ${maxCalls})`);
+    }
+    if (!withinCallBudget(ctx)) {
+      recordUsage(ctx, 'resource', rsrc.name, true);
+      throw new Error('rate_limited: too many Cellarion tool calls in a short time');
     }
     const params = rsrc.uriTemplate ? (varsOrExtra || {}) : {};
     return withUsage(ctx, 'resource', rsrc.name, () => rsrc.handler(uri, params, ctx));

--- a/backend/src/models/OAuthClient.js
+++ b/backend/src/models/OAuthClient.js
@@ -41,7 +41,15 @@ const oauthClientSchema = new mongoose.Schema({
   softwareVersion: { type: String, default: null },
   createdAt: { type: Date, default: Date.now },
   lastUsedAt: { type: Date, default: null },
+  // Reap NEVER-USED clients only (security audit M-6): set to now+30d at
+  // registration and UNSET the first time the client completes a token
+  // exchange, so an actively-connected client persists forever and is never
+  // orphaned while a live token references it. TTL-at-date (expireAfterSeconds
+  // 0); a document with expiresAt null/absent is never expired.
+  expiresAt: { type: Date, default: null },
 });
+
+oauthClientSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 /** Random public client id. Prefixed for readability in logs/DB. */
 oauthClientSchema.statics.generateClientId = function () {

--- a/backend/src/routes/mcpOAuth.js
+++ b/backend/src/routes/mcpOAuth.js
@@ -1,11 +1,27 @@
 const express = require('express');
 const crypto = require('crypto');
+const rateLimit = require('express-rate-limit');
 const router = express.Router();
 const ApiToken = require('../models/ApiToken');
 const OAuthClient = require('../models/OAuthClient');
 const OAuthAuthCode = require('../models/OAuthAuthCode');
 const { requireAuth, requireNonDemo } = require('../middleware/auth');
+const { rateLimitKey } = require('../utils/clientIp');
 const { logAudit } = require('../services/audit');
+
+// Dedicated strict limiter for unauthenticated Dynamic Client Registration
+// (security audit M-6): /register persists an OAuthClient row per call and
+// otherwise rode only the 200/15min global write limiter — an IP-rotating
+// attacker could accumulate ~19k inert client rows/day. Real MCP clients
+// register once. 10/hour/IP is generous for that and shuts the flood.
+const registerLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  keyGenerator: (req) => rateLimitKey(req),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'invalid_request', error_description: 'Too many client registrations from this address; try again later.' },
+});
 const eventBus = require('../services/eventBus');
 const {
   issuer, resourceUrl, verifyPkce, grantedScopes, redirectUriRegistered,
@@ -58,7 +74,7 @@ function isValidRedirectUri(uri) {
 }
 
 // ── POST /register — Dynamic Client Registration (RFC 7591) ──────────────────
-router.post('/register', async (req, res) => {
+router.post('/register', registerLimiter, async (req, res) => {
   try {
     const body = req.body || {};
     const redirectUris = body.redirect_uris;
@@ -96,6 +112,9 @@ router.post('/register', async (req, res) => {
       responseTypes: ['code'],
       softwareId: typeof body.software_id === 'string' ? body.software_id.slice(0, 200) : null,
       softwareVersion: typeof body.software_version === 'string' ? body.software_version.slice(0, 50) : null,
+      // Auto-reap if it never completes a token exchange (M-6). Cleared on
+      // first use below, so a real connector persists.
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
     });
 
     logAudit(req, 'oauth.client_registered', { type: 'oauthClient', id: client._id }, { clientName: client.clientName });
@@ -283,7 +302,8 @@ router.post('/token', async (req, res) => {
         resource: codeDoc.resource || resourceUrl(),
         ...cred.fields,
       });
-      OAuthClient.updateOne({ _id: client._id }, { $set: { lastUsedAt: new Date() } }).catch(() => {});
+      // Mark used → make the client permanent (drop the never-used TTL, M-6).
+      OAuthClient.updateOne({ _id: client._id }, { $set: { lastUsedAt: new Date() }, $unset: { expiresAt: '' } }).catch(() => {});
       logAudit(req, 'oauth.token_issued', { type: 'apiToken', id: token._id }, { clientId: client.clientId, scopes: codeDoc.scopes });
       res.setHeader('Cache-Control', 'no-store');
       return res.json(tokenResponse(cred.raw.access, cred.raw.refresh, codeDoc.scopes));

--- a/backend/src/routes/mcpOAuth.test.js
+++ b/backend/src/routes/mcpOAuth.test.js
@@ -105,6 +105,15 @@ describe('POST /register (DCR)', () => {
     const r = await jsonPost('/register', { redirect_uris: [] });
     expect(r.status).toBe(400);
   });
+
+  test('a new client is registered with a never-used TTL (expiresAt in the future)', async () => {
+    OAuthClient.create.mockResolvedValue({ _id: 'c1', clientId: 'mcpc_x', clientName: null, createdAt: new Date(), grantTypes: [], responseTypes: [] });
+    await jsonPost('/register', { redirect_uris: [REDIRECT] });
+    const created = OAuthClient.create.mock.calls[0][0];
+    expect(created.expiresAt).toBeInstanceOf(Date);
+    // ~30 days out — armed, so an abandoned registration is auto-reaped.
+    expect(created.expiresAt.getTime()).toBeGreaterThan(Date.now() + 20 * 24 * 60 * 60 * 1000);
+  });
 });
 
 describe('GET /authorize', () => {
@@ -250,6 +259,10 @@ describe('POST /token — authorization_code', () => {
     expect(created).toMatchObject({ user: USER, origin: 'oauth', oauthClientId: CLIENT.clientId, scopes: ['read', 'write'] });
     expect(created.tokenHash).toBeTruthy();
     expect(created.expiresAt).toBeInstanceOf(Date);
+    // First successful exchange makes the client permanent: clear the never-used TTL (M-6).
+    const upd = OAuthClient.updateOne.mock.calls[0];
+    expect(upd[0]).toEqual({ _id: CLIENT._id });
+    expect(upd[1].$unset).toEqual({ expiresAt: '' });
   });
 
   test('the connection cap is enforced', async () => {


### PR DESCRIPTION
Security audit 2026-07-17 — batch 2 of the remediation. Public-MCP DoS surface. No functional change for legitimate clients; two abuse ceilings + one orphan-reaper.

## M-4 — cross-request tool-call budget (read amplification)
The per-request cap (`MAX_CALLS_PER_REQUEST`) and the per-IP HTTP limiter both count **requests**, not tool calls. One request fans out to up to 20 calls (10 anon), and authenticated read tools had **no cumulative budget at all** — so a caller could drive thousands of full-portfolio / Qdrant reads per window, onto the 256 MB Qdrant instance shared with cellar chat.

- New [`backend/src/mcp/callBudget.js`](backend/src/mcp/callBudget.js): rolling-window counter keyed by **caller identity** — user id when authenticated, client IP for the anonymous public surface. Charged on every tool / resource / prompt call.
- Ceilings: **2000/15 min** authenticated (~2.2 calls/s sustained — far above any real agent turn), **200/15 min/IP** anonymous.
- Wired into all three budgeted handlers in [`server.js`](backend/src/mcp/server.js); over-budget returns the same `rateLimited` shape the per-request cap already used.
- In-memory (like the existing mutation budget), bounded map with oldest-half eviction at 10k keys.

## M-6 — DCR flood + orphan reaping
`POST /oauth/register` persists an `OAuthClient` row per call and rode only the 200/15 min global write limiter — an IP-rotating attacker could accumulate ~19k inert client rows/day.

- Dedicated **10/hour/IP** `registerLimiter` on `/register` ([`mcpOAuth.js`](backend/src/routes/mcpOAuth.js)). Real connectors register once.
- Never-used TTL on [`OAuthClient`](backend/src/models/OAuthClient.js): `expiresAt` set to now+30d at registration, **UNSET on the first successful token exchange**. An actively-connected client persists forever (a live token always references it); an abandoned registration is auto-reaped by a TTL index. TTL-at-date, so `expiresAt: null` never expires.

## Docker-compose impact
**None.** In-memory counter, no new services, no new env, no schema migration (the TTL index builds on next boot; existing rows have `expiresAt` absent → never expire, correct).

## Tests
- New `callBudget.test.js` — window counting, user-vs-IP keying, window rollover, unlimited sentinel.
- `mcpOAuth.test.js` — added *register arms the TTL* + *exchange clears the TTL* assertions.
- Full MCP dir + OAuth route/service suites green: **328 passed** in `node:20-alpine`.