### PR TITLE
fix(security): self-host hardening — trust-proxy hops, edge headers, optional datastore auth (M-3, L-5, L-13, L-17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,13 @@ MEILI_MASTER_KEY=change-me-to-a-strong-random-string
 
 # Optional overrides (defaults shown)
 # MONGO_URI=mongodb://mongo:27017/winecellar
+#                                      # To harden the internal Mongo (security audit L-5): add MONGO_INITDB_ROOT_USERNAME/
+#                                      # _PASSWORD to the mongo service + `--auth` to its command on a FRESH volume, then set
+#                                      # MONGO_URI=mongodb://user:pass@mongo:27017/winecellar?authSource=admin here. Auth cannot
+#                                      # be enabled in place on an existing dataful volume, so do this at first init.
+# TRUST_PROXY_HOPS=1                   # reverse-proxy hops in front of Express for req.ip resolution (security audit M-3).
+#                                      # Default 1 = the shipped nginx→backend chain. Set 2 behind Cloudflare→Traefik→nginx.
+#                                      # Never set higher than the real hop count — it lets clients forge their rate-limit IP.
 # ACCESS_TOKEN_EXPIRES_IN=15m          # access-token TTL; sessions are refreshed via a rotating 30-day cookie
 # COOKIE_SECURE=true                   # Secure flag on the refresh cookie ('true'/'false'); unset = inferred from NODE_ENV=production.
 #                                      # Set to false ONLY when self-hosting over plain HTTP (no HTTPS), or logins won't persist.
@@ -91,6 +98,8 @@ MEILI_MASTER_KEY=change-me-to-a-strong-random-string
 # Qdrant — optional. Required for AI cellar chat (vector search).
 # In Docker Compose this is set automatically; override only if using an external Qdrant instance.
 # QDRANT_URL=http://qdrant:6333
+# QDRANT_API_KEY=                      # optional (security audit L-5); Qdrant is internal-only so it defaults to no auth.
+#                                      # Set a strong random value to require the key on both the qdrant container and backend.
 
 # Mailgun — optional. If unset, email verification is skipped (users log in immediately after registration).
 # MAILGUN_API_KEY=your-mailgun-api-key

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -76,9 +76,18 @@ const { logAudit } = require('./services/audit');
 
 const app = express();
 
-// Trust two proxy hops: Traefik → frontend nginx → backend.
-// req.ip is used as fallback when CF-Connecting-IP is absent (local dev).
-app.set('trust proxy', 2);
+// How many reverse-proxy hops sit in front of Express, i.e. how many trailing
+// X-Forwarded-For entries Express may trust when resolving req.ip (the per-IP
+// rate-limit + audit key when CF-Connecting-IP is absent). Security audit M-3:
+// this MUST match the actual chain — trusting MORE hops than exist lets a client
+// forge req.ip via a spoofed XFF prefix and get a fresh bucket on every limiter.
+//   - Shipped compose (nginx → backend): 1 hop. This is the default.
+//   - Hosted prod (Cloudflare → Traefik → nginx → backend): set TRUST_PROXY_HOPS=2
+//     so req.ip resolves to the Cloudflare edge IP and getClientIp() can trust
+//     CF-Connecting-IP. Without it, req.ip collapses to Traefik's internal IP and
+//     every per-IP limiter shares one bucket. See utils/clientIp.js.
+const trustProxyHops = Number(process.env.TRUST_PROXY_HOPS ?? 1);
+app.set('trust proxy', Number.isFinite(trustProxyHops) ? trustProxyHops : 1);
 
 // Security headers — explicit config for production SaaS
 app.use(helmet({

--- a/backend/src/services/vectorStore.js
+++ b/backend/src/services/vectorStore.js
@@ -30,9 +30,15 @@ function collectionName(indexVersion) {
 
 async function qdrantRequest(method, path, body) {
   const url = `${qdrantBase()}${path}`;
+  const headers = { 'Content-Type': 'application/json' };
+  // Optional Qdrant API key (security audit L-5). Qdrant is internal-only and
+  // not host-published, so this defaults off; a self-hoster who sets
+  // QDRANT_API_KEY (and QDRANT__SERVICE__API_KEY on the qdrant container) gets
+  // authenticated access, closing same-network container access.
+  if (process.env.QDRANT_API_KEY) headers['api-key'] = process.env.QDRANT_API_KEY;
   const opts = {
     method,
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     signal: AbortSignal.timeout(QDRANT_TIMEOUT_MS)
   };
   if (body !== undefined) opts.body = JSON.stringify(body);

--- a/backend/src/services/vectorStore.test.js
+++ b/backend/src/services/vectorStore.test.js
@@ -51,4 +51,27 @@ describe('qdrant fetches', () => {
     await expect(vectorStore.searchSimilar('v1', [0.1], 5))
       .rejects.toThrow(/Qdrant POST .* timed out/);
   });
+
+  // Security audit L-5: optional Qdrant API-key auth, off by default.
+  describe('QDRANT_API_KEY header', () => {
+    const saved = process.env.QDRANT_API_KEY;
+    afterEach(() => {
+      if (saved === undefined) delete process.env.QDRANT_API_KEY;
+      else process.env.QDRANT_API_KEY = saved;
+    });
+
+    test('no api-key header is sent when QDRANT_API_KEY is unset', async () => {
+      delete process.env.QDRANT_API_KEY;
+      global.fetch.mockResolvedValue({ ok: true, json: async () => ({ result: [] }) });
+      await vectorStore.searchSimilar('v1', [0.1], 5);
+      expect(global.fetch.mock.calls[0][1].headers['api-key']).toBeUndefined();
+    });
+
+    test('the api-key header is sent when QDRANT_API_KEY is set', async () => {
+      process.env.QDRANT_API_KEY = 'secret-key';
+      global.fetch.mockResolvedValue({ ok: true, json: async () => ({ result: [] }) });
+      await vectorStore.searchSimilar('v1', [0.1], 5);
+      expect(global.fetch.mock.calls[0][1].headers['api-key']).toBe('secret-key');
+    });
+  });
 });

--- a/backend/src/utils/clientIp.js
+++ b/backend/src/utils/clientIp.js
@@ -7,10 +7,12 @@ const { isCloudflareIP } = require('./cloudflareIps');
  * Cellarion runs behind Cloudflare → Traefik → nginx → backend. The trust
  * model on this hop chain is:
  *
- *   - `req.ip` is resolved by Express against `trust proxy = 2`. With our
- *     chain, that means req.ip is the Cloudflare edge IP for requests that
- *     actually came through Cloudflare, and the attacker's IP for requests
- *     that hit the Hetzner origin directly (bypassing CF).
+ *   - `req.ip` is resolved by Express against `trust proxy` (TRUST_PROXY_HOPS,
+ *     default 1 for the shipped single-hop compose; set to 2 on the hosted
+ *     CF→Traefik→nginx chain). With the hosted value, req.ip is the Cloudflare
+ *     edge IP for requests that actually came through Cloudflare, and the
+ *     attacker's IP for requests that hit the Hetzner origin directly (bypassing
+ *     CF). Trusting more hops than exist is what M-3 warns against.
  *   - The CF-Connecting-IP header is only set by Cloudflare itself, but the
  *     header can be spoofed by anyone hitting the origin directly. Trusting
  *     it unconditionally — as an earlier version did — turned every rate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,12 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    # Optional API-key auth (security audit L-5). Qdrant is internal-only and not
+    # host-published, so this defaults OFF (empty = no auth, unchanged behaviour).
+    # Set QDRANT_API_KEY in .env to require the key here AND on the backend below;
+    # the readiness endpoints used by the healthcheck stay key-exempt.
+    environment:
+      - QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY:-}
     volumes:
       - qdrant-data:/qdrant/storage
     deploy:
@@ -109,7 +115,11 @@ services:
       # cookie is dropped (Secure is otherwise inferred from NODE_ENV=production).
       # The env block enumerates vars, so it must be forwarded to be settable.
       - COOKIE_SECURE=${COOKIE_SECURE:-}
-      - MONGO_URI=mongodb://mongo:27017/winecellar
+      # Reverse-proxy hop count for req.ip resolution (security audit M-3).
+      # Default 1 matches this shipped single-hop chain (nginx → backend). The
+      # hosted CF→Traefik→nginx deploy sets TRUST_PROXY_HOPS=2 in its .env.
+      - TRUST_PROXY_HOPS=${TRUST_PROXY_HOPS:-}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongo:27017/winecellar}
       - JWT_SECRET=${JWT_SECRET}
       - ACCESS_TOKEN_EXPIRES_IN=${ACCESS_TOKEN_EXPIRES_IN:-15m}
       - PORT=5000
@@ -151,6 +161,9 @@ services:
       - EMBEDDING_DIMENSION=${EMBEDDING_DIMENSION:-}
       - EMBEDDING_TIMEOUT_MS=${EMBEDDING_TIMEOUT_MS:-}
       - QDRANT_URL=http://qdrant:6333
+      # Optional Qdrant API key (security audit L-5) — must match the qdrant
+      # service's QDRANT__SERVICE__API_KEY above. Empty = no auth (default).
+      - QDRANT_API_KEY=${QDRANT_API_KEY:-}
       - SUPER_ADMIN_EMAIL=${SUPER_ADMIN_EMAIL:-}
       - SUPER_ADMIN_IPS=${SUPER_ADMIN_IPS:-}
       - VAPID_PUBLIC_KEY=${VAPID_PUBLIC_KEY:-}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -360,11 +360,16 @@ server {
         try_files         /index.html =404;
     }
 
-    # Long-lived cache for hashed static assets
+    # Long-lived cache for hashed static assets. This location sets its own
+    # add_header (Cache-Control), which stops it inheriting any server-level
+    # headers — so it must re-include the security snippet or these assets ship
+    # with no nosniff/HSTS (security audit L-13). nosniff matters most for the
+    # served .svg/.js so a MIME-confused response can't be sniffed executable.
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         root              /usr/share/nginx/html;
         expires           1y;
         add_header        Cache-Control "public, immutable";
+        include           /etc/nginx/snippets/security-headers.conf;
         try_files         $uri =404;
     }
 }

--- a/frontend/security-headers.conf
+++ b/frontend/security-headers.conf
@@ -12,8 +12,14 @@
 # - Referrer-Policy: limits referer leakage to third parties.
 # - Permissions-Policy: denies geolocation/microphone outright; camera is
 #   allowed for self only — the label-scan feature uses getUserMedia.
-# (HSTS is set at Cloudflare, the TLS-terminating layer.)
+# - Strict-Transport-Security: the hosted deploy also gets HSTS from Cloudflare,
+#   but a non-CF self-hoster who terminates TLS here got none (security audit
+#   L-17). Browsers ignore HSTS on plain-HTTP responses (and exempt localhost),
+#   so emitting it unconditionally is safe for http self-hosts and correct for
+#   https ones. No includeSubDomains/preload by default — we can't assume the
+#   self-hoster's subdomain topology; add them per-deploy if it fits.
 add_header X-Frame-Options        "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff"    always;
 add_header Referrer-Policy        "strict-origin-when-cross-origin"              always;
 add_header Permissions-Policy     "geolocation=(), microphone=(), camera=(self)" always;
+add_header Strict-Transport-Security "max-age=31536000"                          always;


### PR DESCRIPTION
Security audit 2026-07-17 — batch 3. Self-host hardening for the public open-source launch. Everything defaults to today's behaviour; each item adds a knob or header a self-hoster needs.

## ⚠️ PROD DEPLOY GATE — set `TRUST_PROXY_HOPS=2` first
The hosted deploy currently relies on the old hardcoded `trust proxy = 2`. This PR changes the **default to 1** (correct for the shipped single-hop compose). **Before this ships, prod's `.env` must set `TRUST_PROXY_HOPS=2`**, and the hand-maintained `docker-compose.prod.yml` must forward it — otherwise `req.ip` resolves to Traefik's internal IP, `isCloudflareIP(req.ip)` goes false, and every per-IP limiter collapses to one shared bucket (site-wide throttle). CF-Connecting-IP still resolves the real client, but set it to 2 to preserve exact current behaviour.

## M-3 — env-driven trust-proxy hop count
[`app.js`](backend/src/app.js) hardcoded `trust proxy = 2`, which matches CF→Traefik→nginx but **not** the shipped compose (nginx→backend, 1 hop). On the shipped chain, trusting 2 hops lets a client forge `req.ip` via a spoofed `X-Forwarded-For` prefix → a fresh bucket on every per-IP limiter (login/reset/api/write/MCP/OG). Now `Number(process.env.TRUST_PROXY_HOPS ?? 1)`, default 1. Prod remains mitigated by the CF-only origin firewall + mTLS (RUNBOOK_ORIGIN_LOCKDOWN) regardless.

## L-13 / L-17 — edge security headers ([nginx.conf](frontend/nginx.conf), [security-headers.conf](frontend/security-headers.conf))
- The hashed-asset location sets its own `Cache-Control`, which stops nginx header inheritance → assets shipped with **no `nosniff`**. Re-include the security snippet there.
- Add `Strict-Transport-Security: max-age=31536000` (no `includeSubDomains`/`preload` — we can't assume a self-hoster's subdomain topology) to the shared snippet, so a non-Cloudflare self-hoster that terminates TLS at nginx gets HSTS. Browsers ignore HSTS on plain-HTTP responses (and exempt localhost), so it's safe for http self-hosts too.

## L-5 — optional internal-datastore auth ([vectorStore.js](backend/src/services/vectorStore.js), [docker-compose.yml](docker-compose.yml))
Qdrant + Mongo are internal-only and not host-published, so this stays **OFF by default**.
- `vectorStore.js` sends an `api-key` header when `QDRANT_API_KEY` is set; compose wires it to `QDRANT__SERVICE__API_KEY` on the qdrant container (readiness endpoints stay key-exempt, so the healthcheck is unaffected).
- `MONGO_URI` is now `.env`-overridable (was hardcoded in compose), so a fresh deploy can point at a credentialed Mongo. `.env.example` documents the first-init auth steps (auth can't be enabled in place on an existing volume).

## Docker-compose impact
- New forwarded backend vars: `TRUST_PROXY_HOPS`, `QDRANT_API_KEY`. New qdrant service env: `QDRANT__SERVICE__API_KEY`. `MONGO_URI` now honours `.env`. **All default to unchanged behaviour.**
- No new services, no image changes, no schema migration. Validated with `docker compose config`.

## Tests
`vectorStore.test.js` gains api-key on/off coverage. `clientIp` + `vectorStore` suites green in `node:20-alpine` (17 tests).