### PR TITLE
chore(security): supply-chain pinning — SHA-pin CI actions, digest-pin base images, d3-color override (M-5, L-2, L-11)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Keeps the supply-chain pins current (security audit 2026-07-17, M-5 + L-11).
+# Both the SHA-pinned GitHub Actions and the @sha256 digest-pinned base images
+# are frozen on purpose — Dependabot is what turns "frozen" into "frozen but
+# maintained", opening a PR when a new version/digest is published so a pin can
+# never silently rot into an unpatched base. Weekly + grouped to stay low-noise
+# for a solo maintainer; npm is intentionally left out (handled manually).
+version: 2
+updates:
+  # CI workflow actions — Dependabot understands `@<sha> # vX.Y.Z` pins and
+  # bumps both the SHA and the version comment together.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # Container base images: one entry per Dockerfile directory + the root for
+  # docker-compose.yml. All are digest-pinned, so these bump the @sha256.
+  - package-ecosystem: docker
+    directories:
+      - /backend
+      - /frontend
+      - /rembg
+      - /
+    schedule:
+      interval: weekly
+    groups:
+      docker-images:
+        patterns: ["*"]

--- a/.github/workflows/cloudflare-ip-watch.yml
+++ b/.github/workflows/cloudflare-ip-watch.yml
@@ -19,7 +19,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Compare Cloudflare ranges to the committed baseline
         env:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Prepare variables (lowercase owner + normalized tag)
         id: vars
@@ -44,7 +44,7 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -52,7 +52,7 @@ jobs:
 
       # Backend
       - name: Build & push backend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./backend
           push: true
@@ -62,7 +62,7 @@ jobs:
 
       # Frontend
       - name: Build & push frontend
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./frontend
           push: true
@@ -76,7 +76,7 @@ jobs:
 
       # rembg
       - name: Build & push rembg
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./rembg
           push: true

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:20-alpine
+# Digest-pinned (security audit L-11) so a moved tag can't swap the base out
+# from under a build. Dependabot's docker ecosystem bumps this. Tag kept for
+# readability; the @sha256 is what's resolved.
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 # Bake production mode into the image: the refresh-cookie Secure flag and
 # 5xx error redaction key off NODE_ENV, and Express itself runs faster with

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,9 @@
 # minimal cap_add set that step-down needs.
 services:
   mongo:
-    image: mongo:7
+    # Digest-pinned (security audit L-11): mongo:7 is a moving minor tag.
+    # Dependabot's docker ecosystem bumps this; the tag is kept for readability.
+    image: mongo:7@sha256:340c1c56fb10e95cf79ff547f8664b96bc6ead9909bc355238cbf865a9695a6f
     container_name: cellarion-mongo
     restart: unless-stopped
     security_opt:
@@ -247,7 +249,9 @@ services:
   # VITE_UMAMI_URL and VITE_UMAMI_WEBSITE_ID are set at build time, so this
   # service is optional and inert without those vars.
   umami:
-    image: ghcr.io/umami-software/umami:postgresql-latest
+    # Digest-pinned (security audit L-11): `:postgresql-latest` is a fully
+    # moving tag — the worst supply-chain case. Dependabot bumps it.
+    image: ghcr.io/umami-software/umami:postgresql-latest@sha256:8edfe4beaef13f9d1300619fa264ef250a3688df9cc54d24ca830ca31cb475ec
     container_name: cellarion-umami
     restart: unless-stopped
     # Opt-in: only starts with `docker compose --profile analytics up`. It is
@@ -285,7 +289,8 @@ services:
         condition: service_healthy
 
   umami-db:
-    image: postgres:16-alpine
+    # Digest-pinned (security audit L-11). Dependabot bumps it.
+    image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
     container_name: cellarion-umami-db
     restart: unless-stopped
     profiles: ["analytics"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
 # ── Stage 1: build React app ──────────────────────────────────────────────────
-FROM node:20-alpine AS builder
+# Digest-pinned (security audit L-11); Dependabot's docker ecosystem bumps it.
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 
 WORKDIR /app
 
@@ -30,7 +31,7 @@ RUN npm run build
 # (uid 101), so an nginx compromise never holds root in the container (audit
 # L-25). Non-root cannot bind <1024, so the server listens on 8080 — compose
 # and Traefik map onto that port.
-FROM nginxinc/nginx-unprivileged:alpine
+FROM nginxinc/nginx-unprivileged:alpine@sha256:a718212f9cf21e241f14067333000a3f0930292f5354fe0db269e9a2a2596b9e
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.73.0",
+  "version": "1.81.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.73.0",
+      "version": "1.81.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
@@ -2885,10 +2885,13 @@
       }
     },
     "node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
-      "license": "BSD-3-Clause"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-dispatch": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "esbuild": "^0.28.1",
     "markdown-it": "^14.2.0",
     "form-data": "^4.0.6",
-    "@babel/core": "^7.29.6"
+    "@babel/core": "^7.29.6",
+    "d3-color": "^3.1.0"
   }
 }

--- a/rembg/Dockerfile
+++ b/rembg/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-slim
+# Digest-pinned (security audit L-11); Dependabot's docker ecosystem bumps it.
+FROM python:3.11-slim@sha256:db3ff2e1800a8581e2c48a27c3995339d47bdf046da21c7627accd3d51053a93
 
 WORKDIR /app
 


### PR DESCRIPTION
Security audit 2026-07-17 — batch 4. Supply-chain hardening. **No behaviour change** — every pin resolves to the exact bits already in use; this freezes them against silent moves and adds Dependabot to keep the freeze maintained.

## M-5 — CI actions pinned to commit SHAs
[`release-docker.yml`](.github/workflows/release-docker.yml) holds `packages: write` and pushes `ghcr.io/…:latest` that prod auto-pulls, so a hijacked or force-moved action tag was a supply-chain-to-prod path. Every `uses:` in both workflows is now `@<full-sha> # vX.Y.Z`:

| Action | Version | SHA |
|---|---|---|
| actions/checkout | v5.0.1 | `93cb6ef…` |
| docker/setup-buildx-action | v3.12.0 | `8d2750c…` |
| docker/login-action | v3.7.0 | `c94ce9f…` |
| docker/build-push-action | v6.19.2 | `10e90e3…` |

## L-11 — base images digest-pinned
`@sha256` on every base image (tag kept inline for readability): `node:20-alpine` (backend + frontend build), `nginxinc/nginx-unprivileged:alpine` (frontend serve), `python:3.11-slim` (rembg), and the compose images `mongo:7`, `postgres:16-alpine`, and `ghcr.io/umami-software/umami:postgresql-latest` (a fully-moving tag — the worst case). Meili/Qdrant were already version-pinned.

## L-2 — d3-color ReDoS (the Dependabot "1 moderate", GHSA-36jr-mh4h-2g58)
Added `"d3-color": "^3.1.0"` to frontend `overrides`. Lockfile regenerated **in node:20-alpine** (never the Windows host — preserves cross-platform optional binaries). `d3-color` 2.0.0 → 3.1.0, no v2 left in the tree, and the Statistics choropleth (react-simple-maps) still builds — verified with a full Vite build in alpine.

## Sustainability — new [`dependabot.yml`](.github/dependabot.yml)
Adds the `github-actions` + `docker` ecosystems (weekly, grouped, low-noise). This is what turns "frozen" into "frozen but maintained" — both the SHA pins and the `@sha256` digests get auto-bump PRs instead of rotting into an unpatched base. npm is intentionally left out (handled manually).

## Docker-compose / prod impact
Images now carry `@sha256` digests (identical bits to the tags today). Prod's hand-maintained `docker-compose.prod.yml` pins its own images and is unaffected; the images it builds on the next release are byte-identical. No new services, no schema change. Validated with `docker compose config`.