### PR TITLE
fix(security): hardening lows — SSRF classifier, IP-scoped limiters, PII-safe error log, timing parity (L-1/4/8/10/18)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -72,7 +72,7 @@ const wellKnownOAuthRoute = require('./routes/wellKnownOAuth');
 const rateLimitsConfig = require('./config/rateLimits');
 const aiConfig = require('./config/aiConfig');
 const announcementConfig = require('./config/announcement');
-const { logAudit } = require('./services/audit');
+const { logAudit, logger } = require('./services/audit');
 
 const app = express();
 
@@ -291,7 +291,12 @@ app.use((req, res) => {
 // Centralized error handler — catches errors passed via next(err)
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res, next) => {
-  console.error(err);
+  // Log through pino with field discipline (security audit L-4): a raw
+  // console.error(err) dumped the full error + stack — potentially carrying
+  // request PII — onto the un-TTL'd stdout stream that audit.js is careful to
+  // keep PII out of. Log only the method/path/status + pino's err serializer
+  // (type/message/stack), never req.body/headers.
+  logger.error({ err, method: req.method, path: req.path, status: err.status || err.statusCode || 500 }, 'Unhandled request error');
   // If the response has already started (e.g. an SSE/stream route threw mid-
   // flight), we can't set a status/body — hand off to Express's default handler
   // which closes the connection.

--- a/backend/src/mcp/arrangeTasting.test.js
+++ b/backend/src/mcp/arrangeTasting.test.js
@@ -32,7 +32,7 @@ jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn
 jest.mock('../services/search', () => ({ getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn() }));
 jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), buildEmptyStats: jest.fn() }));
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
-jest.mock('./mutationBudget', () => ({ takeMutationSlot: jest.fn(() => true), WRITE_WINDOW_MS: 900000 }));
+jest.mock('./mutationBudget', () => ({ takeMutationSlot: jest.fn(() => true), ipKeyFor: jest.fn(() => null), WRITE_WINDOW_MS: 900000 }));
 jest.mock('../services/bottleOps', () => ({
   consumeBottle: jest.fn(), restoreBottle: jest.fn(), addBottle: jest.fn(), updateBottleFields: jest.fn(),
   removeBottleCascade: jest.fn(), RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,

--- a/backend/src/mcp/bulkTools.test.js
+++ b/backend/src/mcp/bulkTools.test.js
@@ -35,7 +35,7 @@ jest.mock('../services/bottleOps', () => ({
   addBottle: jest.fn(), updateBottleFields: jest.fn(), removeBottleCascade: jest.fn(),
   UPDATABLE_FIELDS: ['price', 'currency', 'notes', 'occasion', 'rating', 'ratingScale', 'drinkFrom', 'drinkTo'],
 }));
-jest.mock('./mutationBudget', () => ({ takeMutationSlot: jest.fn(() => true), WRITE_WINDOW_MS: 15 * 60 * 1000 }));
+jest.mock('./mutationBudget', () => ({ takeMutationSlot: jest.fn(() => true), ipKeyFor: jest.fn(() => null), WRITE_WINDOW_MS: 15 * 60 * 1000 }));
 
 const mongoose = require('mongoose');
 const Cellar = require('../models/Cellar');
@@ -121,7 +121,7 @@ describe('apply', () => {
     const body = parse(res);
     expect(body.data.added_bottle_ids).toHaveLength(2);
     expect(body.data.wines_created).toBe(1);
-    expect(takeMutationSlot).toHaveBeenCalledWith(ME, 2); // whole batch upfront
+    expect(takeMutationSlot).toHaveBeenCalledWith(ME, 2, null); // whole batch upfront, with the per-IP key
     // Unconfirmed will_create → soft-zone stays live (confirmCreate false)
     expect(findOrCreateWine.mock.calls[0][2]).toMatchObject({ confirmCreate: false, skipSiblingMatch: false, createdVia: 'mcp' });
     const ledger = McpActionLog.create.mock.calls.at(-1)[0];

--- a/backend/src/mcp/mutationBudget.js
+++ b/backend/src/mcp/mutationBudget.js
@@ -1,31 +1,80 @@
-// Per-user mutation budget for MCP tools — write-limiter parity at the tool
-// layer (see the isMcp comment in app.js). Lives in its own module so BOTH
-// mcp/server.js (which charges one slot per mutating tool call) and batch
-// tools like bulk_add (which charge one slot PER ITEM upfront) can use it
-// without a circular require.
+// Mutation budget for MCP tools — write-limiter parity at the tool layer (see
+// the isMcp comment in app.js). Lives in its own module so BOTH mcp/server.js
+// (which charges one slot per mutating tool call) and batch tools like bulk_add
+// (which charge one slot PER ITEM upfront) can use it without a circular require.
 //
-// In-memory like express-rate-limit; the whole map is cleared at the cap.
+// In-memory like express-rate-limit. Two dimensions (security audit L-18):
+//   - per USER  — the write throughput of one account.
+//   - per IP    — bounds the ~60×accounts amplification a per-user-only budget
+//                 allowed (many accounts behind one NAT). Generous multiple of
+//                 the per-user cap so a few colocated real users aren't throttled.
+// All-or-nothing across BOTH dimensions and across a batch: a batch never
+// half-charges before being refused, and a call that would breach either
+// dimension takes nothing.
 const WRITE_WINDOW_MS = 15 * 60 * 1000;
-const mutationWindows = new Map(); // userId -> { start, count }
-const MUTATION_WINDOWS_MAX = 5000;
+const userWindows = new Map(); // userId -> { start, count }
+const ipWindows = new Map();   // ipKey  -> { start, count }
+const WINDOWS_MAX = 5000;
+// A single NAT/office may host several Cellarion users, each with their own AI
+// connection; the per-IP write ceiling is a multiple of the per-user cap.
+const IP_WRITE_MULTIPLIER = 4;
+
+// Evict the oldest half (insertion order) instead of clearing everyone (the old
+// `.clear()` wiped every in-flight window when a burst of distinct keys hit the
+// cap, resetting all limiters — security audit L-18).
+function evictOldestHalf(map) {
+  let drop = Math.ceil(WINDOWS_MAX / 2);
+  for (const k of map.keys()) { if (drop-- <= 0) break; map.delete(k); }
+}
+
+// True if `n` more slots fit in key's current window without charging.
+function hasRoom(map, key, n, max, now) {
+  const w = map.get(key);
+  if (!w || now - w.start >= WRITE_WINDOW_MS) return true; // fresh/expired window
+  return w.count + n <= max;
+}
+
+// Charge `n` slots against key's window, rolling it over if fresh/expired.
+function charge(map, key, n, now) {
+  let w = map.get(key);
+  if (!w || now - w.start >= WRITE_WINDOW_MS) {
+    if (map.size >= WINDOWS_MAX) evictOldestHalf(map);
+    w = { start: now, count: 0 };
+    map.set(key, w);
+  }
+  w.count += n;
+}
 
 /**
- * Try to take `n` mutation slots for a user in the current 15-minute window.
- * All-or-nothing: returns false (and takes NOTHING) when fewer than n remain,
- * so a batch never half-charges before being refused.
+ * Try to take `n` mutation slots for a user (and optionally their IP) in the
+ * current 15-minute window. All-or-nothing: returns false (and takes NOTHING)
+ * when fewer than n remain in EITHER dimension. `ipKey` is optional — omit it
+ * (or pass null) for the per-user-only behaviour.
  */
-function takeMutationSlot(userId, n = 1) {
+function takeMutationSlot(userId, n = 1, ipKey = null) {
   const max = require('../config/rateLimits').get().write.max;
   const now = Date.now();
-  let w = mutationWindows.get(userId);
-  if (!w || now - w.start >= WRITE_WINDOW_MS) {
-    if (mutationWindows.size >= MUTATION_WINDOWS_MAX) mutationWindows.clear();
-    w = { start: now, count: 0 };
-    mutationWindows.set(userId, w);
-  }
-  if (w.count + n > max) return false;
-  w.count += n;
+  if (n > max) return false; // a single batch larger than the whole window
+  // Peek both dimensions first; commit only if both fit (single-threaded Node,
+  // so peek-then-charge is atomic).
+  if (!hasRoom(userWindows, userId, n, max, now)) return false;
+  if (ipKey && !hasRoom(ipWindows, ipKey, n, max * IP_WRITE_MULTIPLIER, now)) return false;
+  charge(userWindows, userId, n, now);
+  if (ipKey) charge(ipWindows, ipKey, n, now);
   return true;
 }
 
-module.exports = { takeMutationSlot, WRITE_WINDOW_MS };
+/**
+ * Derive the per-IP budget key from an MCP request context, or null when no
+ * request is attached (unit-test contexts) — in which case takeMutationSlot
+ * falls back to the per-user-only budget. Lazy-requires clientIp to keep this
+ * module off audit/MCP load paths.
+ */
+function ipKeyFor(ctx) {
+  try {
+    const { rateLimitKey } = require('../utils/clientIp');
+    return (ctx && ctx.req) ? rateLimitKey(ctx.req) : null;
+  } catch { return null; }
+}
+
+module.exports = { takeMutationSlot, ipKeyFor, WRITE_WINDOW_MS, IP_WRITE_MULTIPLIER };

--- a/backend/src/mcp/mutationBudget.test.js
+++ b/backend/src/mcp/mutationBudget.test.js
@@ -10,7 +10,7 @@
 jest.mock('../config/rateLimits', () => ({ get: jest.fn(() => ({ write: { max: 5 } })) }));
 
 const rateLimits = require('../config/rateLimits');
-const { takeMutationSlot, WRITE_WINDOW_MS } = require('./mutationBudget');
+const { takeMutationSlot, ipKeyFor, WRITE_WINDOW_MS, IP_WRITE_MULTIPLIER } = require('./mutationBudget');
 
 let now = 1_000_000;
 beforeEach(() => {
@@ -51,4 +51,35 @@ test('reads the LIVE write.max on each call (admin can tune it down)', () => {
   rateLimits.get.mockReturnValue({ write: { max: 2 } }); // admin lowered it
   expect(takeMutationSlot(u, 3)).toBe(false); // 3 > new cap 2
   expect(takeMutationSlot(u, 2)).toBe(true);
+});
+
+// Security audit L-18: a per-IP write budget bounds the amplification of many
+// distinct accounts sharing one NAT. Per-user cap 5, per-IP cap 5×4 = 20.
+test('a shared IP is capped across distinct users at max × IP_WRITE_MULTIPLIER', () => {
+  const ip = `ip-${now}`;
+  const perIpCap = 5 * IP_WRITE_MULTIPLIER; // 20
+  // Each distinct user can spend its full 5, but the IP tops out at 20.
+  let spent = 0;
+  for (let i = 0; spent < perIpCap; i++) {
+    expect(takeMutationSlot(`shared-${i}-${now}`, 5, ip)).toBe(true);
+    spent += 5;
+  }
+  // A brand-new user still has per-user room, but the IP budget is exhausted.
+  expect(takeMutationSlot(`shared-final-${now}`, 1, ip)).toBe(false);
+});
+
+test('all-or-nothing across BOTH dimensions — an IP-blocked call takes nothing per-user', () => {
+  const ip = `ip2-${now}`;
+  // Fill the IP window to its cap (20) via other users.
+  for (let i = 0; i < 4; i++) expect(takeMutationSlot(`filler-${i}-${now}`, 5, ip)).toBe(true);
+  const u = `victim-${now}`;
+  expect(takeMutationSlot(u, 5, ip)).toBe(false); // fits per-user but IP is full
+  // Because the refused call took nothing per-user, a call WITHOUT the ip key
+  // (fresh window) still has the full per-user budget available.
+  expect(takeMutationSlot(u, 5)).toBe(true);
+});
+
+test('ipKeyFor returns null without a request, a stable key with one', () => {
+  expect(ipKeyFor({})).toBeNull();
+  expect(ipKeyFor({ req: { ip: '203.0.113.7', headers: {} } })).toBe('203.0.113.7');
 });

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -47,7 +47,7 @@ const rateLimited = (message) => ({
 // truth. An agent looping consumes hits exactly the wall a looping REST client
 // would. Batch tools (bulk_add) charge one slot PER ITEM through the same
 // module, so a case of 12 costs 12 — see mcp/mutationBudget.js.
-const { takeMutationSlot, WRITE_WINDOW_MS } = require('./mutationBudget');
+const { takeMutationSlot, ipKeyFor, WRITE_WINDOW_MS } = require('./mutationBudget');
 
 // Aggregate usage counters behind the admin view (GET /api/admin/mcp/usage).
 // record() is fire-and-forget and no-ops without a live Mongo connection, so
@@ -108,7 +108,7 @@ function budgetedHandler(tool, ctx, state) {
           content: [{ type: 'text', text: JSON.stringify({ error: { code: 'forbidden_scope', message: 'Mutations need an authenticated connection.' } }) }],
         };
       }
-      if (!takeMutationSlot(String(ctx.user.id))) {
+      if (!takeMutationSlot(String(ctx.user.id), 1, ipKeyFor(ctx))) {
         recordUsage(ctx, 'tool', tool.name, true);
         return rateLimited('Too many cellar changes in a short time — wait a few minutes before mutating again. Reads still work.');
       }

--- a/backend/src/mcp/tools/arrange.js
+++ b/backend/src/mcp/tools/arrange.js
@@ -26,7 +26,7 @@ const { buildAnnotatedEntries, applyArrangement } = require('../../services/rack
 const { isValidId } = require('../../utils/validation');
 const { ok, fail, objectId, resolveCellarAccess } = require('../toolUtil');
 const { logAction } = require('../actionLedger');
-const { takeMutationSlot } = require('../mutationBudget');
+const { takeMutationSlot, ipKeyFor } = require('../mutationBudget');
 
 const PREVIEW_FRESH_MS = 15 * 60 * 1000;
 const NOT_FOUND = 'No such rack, or you have no access to it. Use list_racks for valid ids.';
@@ -168,7 +168,7 @@ registerTool({
     // window refills in minutes and never double-applies, which is the side
     // to fail on.
     const moved = moveList?.length || target.length;
-    if (!takeMutationSlot(String(ctx.user.id), moved)) {
+    if (!takeMutationSlot(String(ctx.user.id), moved, ipKeyFor(ctx))) {
       return fail('rate_limited', `Not enough write budget left to move ${moved} bottle(s) this window — wait a few minutes.`);
     }
 

--- a/backend/src/mcp/tools/bulk.js
+++ b/backend/src/mcp/tools/bulk.js
@@ -25,7 +25,7 @@ const WineDefinition = require('../../models/WineDefinition');
 const { NEW_WINE_SHAPE } = require('./write');
 const { ok, fail, objectId, MSG_CELLAR_NOT_FOUND, resolveCellarAccess, wineSummary } = require('../toolUtil');
 const { logAction } = require('../actionLedger');
-const { takeMutationSlot } = require('../mutationBudget');
+const { takeMutationSlot, ipKeyFor } = require('../mutationBudget');
 
 const MAX_ITEMS = 24; // two cases — keeps one batch well inside the write budget
 const PREVIEW_FRESH_MS = 15 * 60 * 1000;
@@ -169,7 +169,7 @@ registerTool({
     if (!access) return fail('not_found', MSG_CELLAR_NOT_FOUND);
 
     // Whole batch charged upfront — all-or-nothing against the write budget.
-    if (!takeMutationSlot(String(ctx.user.id), items.length)) {
+    if (!takeMutationSlot(String(ctx.user.id), items.length, ipKeyFor(ctx))) {
       return fail('rate_limited', `Not enough write budget left for ${items.length} adds this window — wait a few minutes, or split the batch.`);
     }
     // ATOMIC claim — plain doc.save() gives no concurrency guard here (no

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -32,6 +32,22 @@ if (bcrypt.getRounds(DUMMY_HASH) !== User.BCRYPT_COST) {
   throw new Error(`DUMMY_HASH cost ${bcrypt.getRounds(DUMMY_HASH)} != BCRYPT_COST ${User.BCRYPT_COST} — regenerate DUMMY_HASH in routes/auth.js`);
 }
 
+// Enumeration-timing parity for /forgot-password + /resend-verification
+// (security audit L-8). The "account found" branch pays a token-generation +
+// user.save() write that the early-return branch skips, making a real account
+// measurably slower — a timing oracle the equalized login flow already closed.
+// A no-op write against a fresh random _id matches nothing (writes no data) but
+// pays the same index-lookup + Mongo round-trip. Best-effort: never fail the
+// request over it.
+async function equalizeLookupTiming() {
+  try {
+    await User.updateOne(
+      { _id: crypto.randomBytes(12).toString('hex') },
+      { $set: { updatedAt: new Date() } }
+    );
+  } catch { /* timing parity only — swallow */ }
+}
+
 // Rate limiter for auth endpoints — default 10 per 15 min (admin-configurable)
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -377,6 +393,7 @@ router.post('/resend-verification', resendLimiter, async (req, res) => {
     const user = await User.findOne({ email: email.toLowerCase() });
 
     if (!user || user.emailVerified || !EMAIL_VERIFICATION_ENABLED) {
+      await equalizeLookupTiming(); // L-8: match the found-branch write cost
       return res.status(200).json(genericResponse);
     }
 
@@ -570,6 +587,7 @@ router.post('/forgot-password', forgotLimiter, async (req, res) => {
     const user = await User.findOne({ email: email.toLowerCase() });
 
     if (!user) {
+      await equalizeLookupTiming(); // L-8: match the found-branch write cost
       return res.status(200).json(genericResponse);
     }
 

--- a/backend/src/routes/og.js
+++ b/backend/src/routes/og.js
@@ -13,6 +13,7 @@ const { fromNormalized } = require('../utils/ratingUtils');
 const { isValidId } = require('../utils/validation');
 const { sanitizeForumHtml, sanitizeBlogHtml, extractFaqFromHtml, extractHowToFromHtml } = require('../utils/sanitizeHtml');
 const { stripHtml } = require('../utils/sanitize');
+const { rateLimitKey } = require('../utils/clientIp');
 
 const WINE_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
 const MIN_WINES = 3;
@@ -38,6 +39,11 @@ const router = express.Router();
 const ogLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 60,
+  // Key on the masked client IP (security audit L-10): the default keyGenerator
+  // uses the raw req.ip, so an IPv6 client could rotate the low 64 bits of its
+  // /64 for an unbounded number of (uncached, DB-hitting) OG renders. rateLimitKey
+  // collapses IPv6 to its /64 and honours the CF-Connecting-IP trust model.
+  keyGenerator: (req) => rateLimitKey(req),
   standardHeaders: true,
   legacyHeaders: false
 });

--- a/backend/src/services/accountOps.js
+++ b/backend/src/services/accountOps.js
@@ -8,10 +8,12 @@
 // response envelope. None of these functions write an audit log — the caller
 // owns audit attribution (it has the req), exactly as the extracted bottleOps /
 // rackOps services do.
+const net = require('net');
 const mongoose = require('mongoose');
 const User = require('../models/User');
 const Cellar = require('../models/Cellar');
 const SupportTicket = require('../models/SupportTicket');
+const { isPrivateAddress } = require('../utils/safeImageFetch');
 const WineRequest = require('../models/WineRequest');
 const { stripHtml } = require('../utils/sanitize');
 const { SUPPORTED_CURRENCIES } = require('../config/currencies');
@@ -247,13 +249,21 @@ function validateSourceUrl(url) {
   let parsed;
   try { parsed = new URL(url); } catch { return 'Please provide a valid URL'; }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return 'URL must use http or https protocol';
-  const h = parsed.hostname.toLowerCase();
-  const private_ = [
-    /^localhost$/, /^127\.\d+\.\d+\.\d+$/, /^10\.\d+\.\d+\.\d+$/,
-    /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/, /^192\.168\.\d+\.\d+$/,
-    /^169\.254\.\d+\.\d+$/, /^0\.0\.0\.0$/, /^\[?::1?\]?$/,
-  ];
-  if (private_.some((p) => p.test(h))) return 'URLs pointing to private/internal addresses are not allowed';
+  // Strip the brackets URL keeps on an IPv6 .hostname so net.isIP can classify it.
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  // localhost is a name, not an IP literal — reject it (and its subdomains) by name.
+  if (host === 'localhost' || host.endsWith('.localhost')) {
+    return 'URLs pointing to private/internal addresses are not allowed';
+  }
+  // For IP-literal hosts, reuse the structural private/reserved classifier the
+  // image-fetch SSRF guard uses (security audit L-1). WHATWG `new URL` already
+  // canonicalizes decimal/hex/octal IPv4 to dotted-quad; isPrivateAddress adds
+  // the IPv6 / ULA / link-local / v4-mapped forms the old lexical denylist
+  // missed. DNS names are intentionally left as-is: this value is stored and
+  // rendered as a link, never fetched by the server, so no DNS resolution here.
+  if (net.isIP(host) && isPrivateAddress(host)) {
+    return 'URLs pointing to private/internal addresses are not allowed';
+  }
   return null;
 }
 

--- a/backend/src/services/accountOps.test.js
+++ b/backend/src/services/accountOps.test.js
@@ -164,6 +164,22 @@ describe('validateSourceUrl', () => {
     expect(validateSourceUrl('http://192.168.1.1/x')).toMatch(/private\/internal/);
     expect(validateSourceUrl('not a url')).toMatch(/valid URL/);
   });
+
+  // Security audit L-1: the structural classifier closes forms the old lexical
+  // regex missed. WHATWG `new URL` canonicalizes decimal/hex/octal IPv4, and
+  // isPrivateAddress catches IPv6 loopback/ULA/link-local + v4-mapped.
+  test('rejects private targets in canonicalized-IPv4 and IPv6 forms', () => {
+    expect(validateSourceUrl('http://2130706433/')).toMatch(/private\/internal/);   // decimal 127.0.0.1
+    expect(validateSourceUrl('http://0x7f000001/')).toMatch(/private\/internal/);   // hex 127.0.0.1
+    expect(validateSourceUrl('http://[::1]/')).toMatch(/private\/internal/);        // IPv6 loopback
+    expect(validateSourceUrl('http://[fc00::1]/')).toMatch(/private\/internal/);    // IPv6 ULA
+    expect(validateSourceUrl('http://[fe80::1]/')).toMatch(/private\/internal/);    // IPv6 link-local
+    expect(validateSourceUrl('http://[::ffff:169.254.169.254]/')).toMatch(/private\/internal/); // v4-mapped metadata
+    expect(validateSourceUrl('http://100.64.0.1/')).toMatch(/private\/internal/);   // CGNAT
+    expect(validateSourceUrl('http://sub.localhost/')).toMatch(/private\/internal/); // localhost subdomain
+    // A genuine public host still passes.
+    expect(validateSourceUrl('https://www.vivino.com/wine/1')).toBeNull();
+  });
 });
 
 describe('createWineRequest', () => {


### PR DESCRIPTION
Security audit 2026-07-17 — batch 5. Five LOW findings with clean, low-risk fixes. Full backend suite green (1942) in node:20-alpine.

## L-1 — SSRF classifier for `validateSourceUrl` ([accountOps.js](backend/src/services/accountOps.js))
Replaced the bypassable lexical private-IP regex with the structural `isPrivateAddress` classifier the image-fetch SSRF guard already uses. Closes the IPv6 loopback/ULA/link-local + v4-mapped + decimal/hex/octal-IPv4 forms the regex missed. Remains defense-in-depth — the server never fetches `sourceUrl` (stored + rendered as a link), so DNS names are intentionally not resolved here.

## L-4 — PII-safe error logging ([app.js](backend/src/app.js))
The global error handler did `console.error(err)`, dumping the full error + stack (potentially request PII) onto the stdout stream `audit.js` is careful to keep PII out of. Now logs through the pino `logger` with field discipline: `method`/`path`/`status` + pino's `err` serializer, never `req.body`/headers.

## L-8 — enumeration-timing parity ([auth.js](backend/src/routes/auth.js))
`/forgot-password` + `/resend-verification` were faster on the account-not-found branch (they skip the token-gen + `user.save()` the found branch pays). Added `equalizeLookupTiming()` — a no-op write against a random `_id` matches nothing but pays the same Mongo round-trip — mirroring the already-equalized login flow.

## L-10 — IPv6-maskless OG limiter ([og.js](backend/src/routes/og.js))
`ogLimiter` had no `keyGenerator` → default raw `req.ip`, no IPv6 /64 masking, so an IPv6 client could rotate its low 64 bits for unbounded uncached (DB-hitting) OG renders. Now `keyGenerator: rateLimitKey`.

## L-18 — MCP write budget: per-IP + evict-oldest ([mutationBudget.js](backend/src/mcp/mutationBudget.js))
1. A burst of distinct keys at the 5,000 cap called `.clear()`, wiping **every** in-flight window (resetting all limiters). Now evicts the oldest half.
2. The budget was per-**user** only, so ~60×accounts behind one NAT amplified write throughput. Added a per-**IP** window (cap = per-user × 4 — generous for colocated real users) charged all-or-nothing alongside the per-user one, threaded via a new `ipKeyFor(ctx)` helper through `server.js` + the arrange/bulk tools.

## Deferred (documented, not silently dropped)
- **L-3** — external wine-label images legitimately load from arbitrary HTTPS hosts, so tightening `img-src` off `https:` breaks a core feature; clickjacking is already covered by the existing `X-Frame-Options: SAMEORIGIN`.
- **L-6** — web refresh-token reuse-detection needs a rotation-grace window, else concurrent multi-tab refreshes (browsers share one cookie) false-positive and spuriously log users out — a larger, riskier auth change than a LOW warrants. MCP OAuth has it because those clients serialize refreshes.
- **L-7** — ≤15 min access-token exposure with refresh already cut on credential events; a `tokenNonce` per-request check defeats the stateless JWT.
- **L-9** — atomic lockout `$inc`: marginal gain (a few extra parallel guesses) vs. regression risk on security-critical lockout logic; per-IP + per-account bounds still hold.

## Docker-compose impact
None.