### PR TITLE
fix(mcp): idempotency correctness — per-tool keys, distinct busy code, undo unclaim (H3/M1/M2)

### DIFF
--- a/backend/src/mcp/actionLedger.js
+++ b/backend/src/mcp/actionLedger.js
@@ -9,6 +9,12 @@
 // (replay) or an in-progress conflict, and never reaches the mutation. The old
 // shape (findOne → mutate → create, duplicate-key swallowed) let both twins
 // mutate and only deduplicated the ledger row afterwards.
+//
+// Idempotency keys are scoped PER TOOL (MCP-audit M2): the stub records the
+// claiming tool, and a key seen on a DIFFERENT tool is refused (invalid_input)
+// rather than replaying the first tool's result — so an agent that recycles one
+// key across `update_bottle` then `add_bottle` can't be told the add "succeeded"
+// with the update's envelope.
 const McpActionLog = require('../models/McpActionLog');
 
 // A pending claim older than this is considered crashed (the process died
@@ -19,11 +25,21 @@ const CLAIM_STALE_MS = 2 * 60 * 1000;
 
 // `idempotencyBusy` tells the server's release-on-error wrapper that this
 // error DOESN'T mean "my claim failed" — a concurrent twin owns the key and
-// its live pending claim must not be deleted out from under it.
+// its live pending claim must not be deleted out from under it. The `busy`
+// code (distinct from `conflict`, MCP-audit M1) tells the CLIENT this is
+// transient: retry the SAME idempotency_key shortly, don't rotate it (rotating
+// would bypass the claim and double-execute).
 const inProgress = () => ({
   isError: true,
   idempotencyBusy: true,
-  content: [{ type: 'text', text: JSON.stringify({ error: { code: 'conflict', message: 'An identical request (same idempotency_key) is already in progress — wait a moment; if it succeeded, retrying returns its result.' } }) }],
+  content: [{ type: 'text', text: JSON.stringify({ error: { code: 'busy', message: 'An identical request (same idempotency_key) is already in progress — retry the SAME idempotency_key in a moment; if it succeeded, the retry returns its result. Do not generate a new key.' } }) }],
+});
+
+// A key already used by a DIFFERENT tool. Not retryable with this key — the
+// client must use a fresh key for the new operation (MCP-audit M2).
+const crossToolConflict = (otherTool) => ({
+  isError: true,
+  content: [{ type: 'text', text: JSON.stringify({ error: { code: 'invalid_input', message: `That idempotency_key was already used for a different tool (${otherTool}). Use a fresh idempotency_key per distinct operation.` } }) }],
 });
 
 const replayEnvelope = (row) =>
@@ -33,13 +49,14 @@ const replayEnvelope = (row) =>
  * Persist the action ledger row. Never throws (the action itself succeeded).
  * With an idempotencyKey this COMPLETES the pending claim replay() took
  * (overwrites the stub in place — same _id, unique index untouched); without
- * one it creates a plain row as before.
+ * one it creates a plain row as before. The completion filter includes `tool`
+ * so it can only ever land on THIS tool's own claim stub.
  */
 async function logAction(ctx, entry) {
   try {
     if (entry.idempotencyKey) {
       return await McpActionLog.findOneAndUpdate(
-        { user: ctx.user.id, idempotencyKey: entry.idempotencyKey, pending: true },
+        { user: ctx.user.id, tool: entry.tool, idempotencyKey: entry.idempotencyKey, pending: true },
         {
           $set: {
             tokenId: ctx.req?.apiToken?.id || null,
@@ -63,21 +80,22 @@ async function logAction(ctx, entry) {
 }
 
 /**
- * Atomic idempotency claim. Returns null when this call now OWNS the key and
- * must proceed to mutate (then logAction completes the claim, or the server
- * releases it on error). Returns a ready-to-return envelope otherwise:
- * the original result for a completed key, or an in-progress conflict while
- * a concurrent twin is still mid-flight.
+ * Atomic idempotency claim for `toolName`. Returns null when this call now OWNS
+ * the key and must proceed to mutate (then logAction completes the claim, or the
+ * server releases it on error). Otherwise returns a ready-to-return envelope:
+ * the original result for a completed same-tool key (`replay`), an in-progress
+ * `busy` conflict while a same-tool twin is mid-flight, or an `invalid_input`
+ * when the key belongs to a DIFFERENT tool.
  *
  * Reversed rows don't block: every revert path nulls idempotencyKey on the
  * row it reverses, freeing the key so a retry re-executes (and re-records).
  */
-async function replay(ctx, idempotencyKey) {
+async function replay(ctx, idempotencyKey, toolName) {
   if (!idempotencyKey) return null;
   const stub = {
     user: ctx.user.id,
     tokenId: ctx.req?.apiToken?.id || null,
-    tool: 'pending',
+    tool: toolName || 'pending',
     action: 'pending',
     idempotencyKey,
     pending: true,
@@ -103,14 +121,22 @@ async function replay(ctx, idempotencyKey) {
     if (!existing) return inProgress(); // deleted in the same instant — treat as busy, retry works
   }
 
-  if (!existing.pending) return replayEnvelope(existing); // completed → replay
-  // Pending: a twin is mid-flight — unless it crashed long enough ago that the
-  // claim is stale, in which case take it over atomically (one taker wins).
+  // Cross-tool reuse guard (M2): the key belongs to another tool — refuse
+  // BEFORE any replay/steal so we never return the wrong tool's result and
+  // never steal a different tool's live claim. Legacy stubs (tool:'pending')
+  // predate per-tool scoping and fall through to the stale-steal path.
+  if (toolName && existing.tool && existing.tool !== 'pending' && existing.tool !== toolName) {
+    return crossToolConflict(existing.tool);
+  }
+
+  if (!existing.pending) return replayEnvelope(existing); // completed (same tool) → replay
+  // Pending: a same-tool twin is mid-flight — unless it crashed long enough ago
+  // that the claim is stale, in which case take it over atomically (one wins).
   const claimedAt = existing.createdAt ? new Date(existing.createdAt).getTime() : 0;
   if (Date.now() - claimedAt > CLAIM_STALE_MS) {
     const stolen = await McpActionLog.findOneAndUpdate(
       { _id: existing._id, pending: true, createdAt: existing.createdAt },
-      { $set: { createdAt: new Date(), tokenId: ctx.req?.apiToken?.id || null } }
+      { $set: { createdAt: new Date(), tool: toolName || existing.tool, tokenId: ctx.req?.apiToken?.id || null } }
     );
     if (stolen) return null; // we own the (re-)claim
   }
@@ -120,13 +146,14 @@ async function replay(ctx, idempotencyKey) {
 /**
  * Drop an UNCOMPLETED claim so the key is immediately reusable — called by the
  * server wrapper when a tool call that carried an idempotency_key returns an
- * error (the mutation did not commit; logAction was never reached). A completed
- * row has pending:false and is never touched. Never throws.
+ * error (the mutation did not commit; logAction was never reached). Scoped by
+ * tool so it can only ever delete THIS tool's own stub. A completed row has
+ * pending:false and is never touched. Never throws.
  */
-async function releaseClaim(ctx, idempotencyKey) {
+async function releaseClaim(ctx, idempotencyKey, toolName) {
   if (!idempotencyKey || !ctx?.user?.id) return;
   try {
-    await McpActionLog.deleteOne({ user: ctx.user.id, idempotencyKey, pending: true });
+    await McpActionLog.deleteOne({ user: ctx.user.id, tool: toolName, idempotencyKey, pending: true });
   } catch { /* best-effort; a leftover stub goes stale-reclaimable, then TTL */ }
 }
 

--- a/backend/src/mcp/actionLedger.test.js
+++ b/backend/src/mcp/actionLedger.test.js
@@ -1,12 +1,13 @@
 /**
- * actionLedger — the idempotency CLAIM contract (prior-audit M2).
+ * actionLedger — the idempotency CLAIM contract (prior-audit M2, MCP-audit M1/M2).
  *
  * The old shape (findOne → mutate → create, duplicate-key swallowed) let two
  * concurrent same-key requests BOTH mutate; only the ledger row was deduped,
  * after the fact. These tests pin the claim-first semantics: replay() reserves
- * the key atomically before any mutation, a losing twin gets the stored result
- * or an in-progress conflict (never a green light), a failed call's claim is
- * releasable, and logAction completes the claim in place.
+ * the key atomically before any mutation, a losing same-tool twin gets the
+ * stored result or a `busy` conflict (never a green light), a key reused on a
+ * DIFFERENT tool is refused, a failed call's claim is releasable, and logAction
+ * completes the claim in place.
  */
 
 jest.mock('../models/McpActionLog', () => ({
@@ -21,82 +22,96 @@ const { logAction, replay, releaseClaim, CLAIM_STALE_MS } = require('./actionLed
 
 const CTX = { user: { id: 'u1' }, req: { apiToken: { id: 't1' } } };
 const KEY = 'idem-abc';
+const TOOL = 'add_bottle';
 const parse = (env) => JSON.parse(env.content[0].text);
 
 beforeEach(() => jest.clearAllMocks());
 
 describe('replay — atomic claim', () => {
   test('no key → null, no DB access', async () => {
-    expect(await replay(CTX, undefined)).toBeNull();
+    expect(await replay(CTX, undefined, TOOL)).toBeNull();
     expect(McpActionLog.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
-  test('fresh key: upsert inserts the pending stub and the caller proceeds (null)', async () => {
+  test('fresh key: upsert inserts the pending stub (recording the tool) and the caller proceeds (null)', async () => {
     McpActionLog.findOneAndUpdate.mockResolvedValue({ lastErrorObject: { updatedExisting: false }, value: null });
-    expect(await replay(CTX, KEY)).toBeNull();
+    expect(await replay(CTX, KEY, TOOL)).toBeNull();
     const [query, update, opts] = McpActionLog.findOneAndUpdate.mock.calls[0];
     expect(query).toEqual({ user: 'u1', idempotencyKey: KEY });
-    expect(update.$setOnInsert).toMatchObject({ action: 'pending', pending: true, idempotencyKey: KEY });
+    expect(update.$setOnInsert).toMatchObject({ tool: TOOL, action: 'pending', pending: true, idempotencyKey: KEY });
     expect(opts).toMatchObject({ upsert: true, new: false });
   });
 
-  test('completed key → the stored result is replayed verbatim', async () => {
+  test('completed same-tool key → the stored result is replayed verbatim', async () => {
     McpActionLog.findOneAndUpdate.mockResolvedValue({
       lastErrorObject: { updatedExisting: true },
-      value: { pending: false, result: { summary: 'done', data: { x: 1 } } },
+      value: { tool: TOOL, pending: false, result: { summary: 'done', data: { x: 1 } } },
     });
-    const env = await replay(CTX, KEY);
+    const env = await replay(CTX, KEY, TOOL);
     expect(env.isError).toBeUndefined();
     expect(parse(env)).toEqual({ summary: 'done', data: { x: 1 } });
   });
 
-  test('live pending twin → in-progress conflict marked idempotencyBusy (never a green light)', async () => {
+  test('key reused on a DIFFERENT tool → invalid_input, never the other tool\'s result (M2)', async () => {
     McpActionLog.findOneAndUpdate.mockResolvedValue({
       lastErrorObject: { updatedExisting: true },
-      value: { _id: 'row1', pending: true, createdAt: new Date() },
+      value: { tool: 'update_bottle', pending: false, result: { summary: 'updated B1' } },
     });
-    const env = await replay(CTX, KEY);
+    const env = await replay(CTX, KEY, 'add_bottle');
     expect(env.isError).toBe(true);
-    expect(env.idempotencyBusy).toBe(true);
-    expect(parse(env).error.code).toBe('conflict');
-    // Exactly one findOneAndUpdate: no steal attempt on a FRESH claim.
+    expect(env.idempotencyBusy).toBeUndefined(); // NOT a busy/steal case
+    expect(parse(env).error.code).toBe('invalid_input');
+    expect(parse(env).error.message).toMatch(/update_bottle/);
+    // Guarded BEFORE any steal attempt.
     expect(McpActionLog.findOneAndUpdate).toHaveBeenCalledTimes(1);
   });
 
-  test('stale pending claim (crashed twin) is taken over atomically', async () => {
+  test('live same-tool twin → busy conflict marked idempotencyBusy (never a green light)', async () => {
+    McpActionLog.findOneAndUpdate.mockResolvedValue({
+      lastErrorObject: { updatedExisting: true },
+      value: { _id: 'row1', tool: TOOL, pending: true, createdAt: new Date() },
+    });
+    const env = await replay(CTX, KEY, TOOL);
+    expect(env.isError).toBe(true);
+    expect(env.idempotencyBusy).toBe(true);
+    expect(parse(env).error.code).toBe('busy'); // distinct from conflict (M1)
+    expect(McpActionLog.findOneAndUpdate).toHaveBeenCalledTimes(1); // no steal on a fresh claim
+  });
+
+  test('stale same-tool claim (crashed twin) is taken over atomically', async () => {
     const staleDate = new Date(Date.now() - CLAIM_STALE_MS - 1000);
     McpActionLog.findOneAndUpdate
-      .mockResolvedValueOnce({ lastErrorObject: { updatedExisting: true }, value: { _id: 'row1', pending: true, createdAt: staleDate } })
+      .mockResolvedValueOnce({ lastErrorObject: { updatedExisting: true }, value: { _id: 'row1', tool: TOOL, pending: true, createdAt: staleDate } })
       .mockResolvedValueOnce({ _id: 'row1' }); // the steal wins
-    expect(await replay(CTX, KEY)).toBeNull(); // we own the re-claim → proceed
+    expect(await replay(CTX, KEY, TOOL)).toBeNull(); // we own the re-claim → proceed
     const stealQuery = McpActionLog.findOneAndUpdate.mock.calls[1][0];
     expect(stealQuery).toMatchObject({ _id: 'row1', pending: true, createdAt: staleDate });
   });
 
-  test('losing the steal race → in-progress, not a green light', async () => {
+  test('losing the steal race → busy, not a green light', async () => {
     const staleDate = new Date(Date.now() - CLAIM_STALE_MS - 1000);
     McpActionLog.findOneAndUpdate
-      .mockResolvedValueOnce({ lastErrorObject: { updatedExisting: true }, value: { _id: 'row1', pending: true, createdAt: staleDate } })
+      .mockResolvedValueOnce({ lastErrorObject: { updatedExisting: true }, value: { _id: 'row1', tool: TOOL, pending: true, createdAt: staleDate } })
       .mockResolvedValueOnce(null); // another taker got there first
-    const env = await replay(CTX, KEY);
+    const env = await replay(CTX, KEY, TOOL);
     expect(env.isError).toBe(true);
     expect(env.idempotencyBusy).toBe(true);
   });
 
   test('E11000 on the racing upsert falls back to the existing row (loser replays)', async () => {
     McpActionLog.findOneAndUpdate.mockRejectedValue(Object.assign(new Error('dup'), { code: 11000 }));
-    McpActionLog.findOne.mockReturnValue({ lean: () => Promise.resolve({ pending: false, result: { summary: 'orig' } }) });
-    const env = await replay(CTX, KEY);
+    McpActionLog.findOne.mockReturnValue({ lean: () => Promise.resolve({ tool: TOOL, pending: false, result: { summary: 'orig' } }) });
+    const env = await replay(CTX, KEY, TOOL);
     expect(parse(env).summary).toBe('orig');
   });
 });
 
 describe('logAction', () => {
-  test('with a key: completes the pending claim in place (same row, pending→false)', async () => {
+  test('with a key: completes the pending claim in place, scoped by tool', async () => {
     McpActionLog.findOneAndUpdate.mockResolvedValue({ _id: 'row1' });
-    await logAction(CTX, { tool: 'add_bottle', action: 'add', idempotencyKey: KEY, result: { summary: 's' } });
+    await logAction(CTX, { tool: TOOL, action: 'add', idempotencyKey: KEY, result: { summary: 's' } });
     const [query, update] = McpActionLog.findOneAndUpdate.mock.calls[0];
-    expect(query).toEqual({ user: 'u1', idempotencyKey: KEY, pending: true });
+    expect(query).toEqual({ user: 'u1', tool: TOOL, idempotencyKey: KEY, pending: true });
     expect(update.$set).toMatchObject({ action: 'add', pending: false });
     expect(McpActionLog.create).not.toHaveBeenCalled();
   });
@@ -110,22 +125,22 @@ describe('logAction', () => {
 
   test('never throws (the mutation already succeeded)', async () => {
     McpActionLog.findOneAndUpdate.mockRejectedValue(new Error('db down'));
-    await expect(logAction(CTX, { action: 'add', idempotencyKey: KEY })).resolves.toBeNull();
+    await expect(logAction(CTX, { tool: TOOL, action: 'add', idempotencyKey: KEY })).resolves.toBeNull();
   });
 });
 
 describe('releaseClaim', () => {
-  test('deletes ONLY the pending stub for this user+key', async () => {
+  test('deletes ONLY the pending stub for this user+tool+key', async () => {
     McpActionLog.deleteOne.mockResolvedValue({});
-    await releaseClaim(CTX, KEY);
-    expect(McpActionLog.deleteOne).toHaveBeenCalledWith({ user: 'u1', idempotencyKey: KEY, pending: true });
+    await releaseClaim(CTX, KEY, TOOL);
+    expect(McpActionLog.deleteOne).toHaveBeenCalledWith({ user: 'u1', tool: TOOL, idempotencyKey: KEY, pending: true });
   });
 
   test('no key / no user / DB error → silent no-op', async () => {
-    await releaseClaim(CTX, undefined);
-    await releaseClaim({}, KEY);
+    await releaseClaim(CTX, undefined, TOOL);
+    await releaseClaim({}, KEY, TOOL);
     expect(McpActionLog.deleteOne).not.toHaveBeenCalled();
     McpActionLog.deleteOne.mockRejectedValue(new Error('down'));
-    await expect(releaseClaim(CTX, KEY)).resolves.toBeUndefined();
+    await expect(releaseClaim(CTX, KEY, TOOL)).resolves.toBeUndefined();
   });
 });

--- a/backend/src/mcp/consumeTools.test.js
+++ b/backend/src/mcp/consumeTools.test.js
@@ -139,7 +139,7 @@ describe('consume_bottle', () => {
     // Keyed ledger writes COMPLETE the pending claim in place (claim-first
     // idempotency, prior-audit M2): the last findOneAndUpdate is logAction's.
     const [query, update] = McpActionLog.findOneAndUpdate.mock.calls.at(-1);
-    expect(query).toEqual({ user: ME, idempotencyKey: 'k1', pending: true });
+    expect(query).toEqual({ user: ME, tool: 'consume_bottle', idempotencyKey: 'k1', pending: true });
     expect(update.$set).toMatchObject({
       tokenId: 't1', tool: 'consume_bottle', action: 'consume', idempotencyKey: 'k1', pending: false,
     });

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -136,8 +136,8 @@ function budgetedHandler(tool, ctx, state) {
       return run.then(
         // idempotencyBusy = the error IS the idempotency conflict — a live
         // twin owns the claim; deleting it here would unlock a double-exec.
-        async (out) => { if (out && out.isError && !out.idempotencyBusy) await releaseClaim(ctx, key); return out; },
-        async (err) => { await releaseClaim(ctx, key); throw err; }
+        async (out) => { if (out && out.isError && !out.idempotencyBusy) await releaseClaim(ctx, key, tool.name); return out; },
+        async (err) => { await releaseClaim(ctx, key, tool.name); throw err; }
       );
     }
     return run;

--- a/backend/src/mcp/structuralUndo.js
+++ b/backend/src/mcp/structuralUndo.js
@@ -23,6 +23,19 @@ async function claim(last) {
   );
 }
 
+/**
+ * Release a claim so a failed structural undo stays retryable (MCP-audit H3).
+ * Every branch here claims BEFORE the mutating rackOps call, and that call can
+ * still fail after the pre-claim checks pass — a concurrent placement (the
+ * unique slots.bottle index → E11000), a VersionError, or a slot disabled since
+ * (applyArrangement re-validates geometry). Without this the row would stay
+ * reversed:true and the action becomes permanently un-undoable. Mirrors
+ * revert.js's unclaim.
+ */
+async function unclaim(rowId) {
+  await McpActionLog.updateOne({ _id: rowId }, { $set: { reversed: false } }).catch(() => {});
+}
+
 async function undoStructural(last, ctx, { ok, fail, logAction }) {
   const record = async (envelope, extra = {}) => {
     await logAction(ctx, {
@@ -44,7 +57,12 @@ async function undoStructural(last, ctx, { ok, fail, logAction }) {
     }
     if (!(await claim(last))) return fail('conflict', 'That action is already being undone.');
     cellar.deletedAt = new Date();
-    await cellar.save();
+    try {
+      await cellar.save();
+    } catch (err) {
+      await unclaim(last._id); // VersionError (concurrent edit) → keep the undo retryable (H3)
+      return fail('conflict', 'That cellar was modified at the same moment; nothing was changed — try the undo again.');
+    }
     logAudit(ctx.req, 'cellar.delete', { type: 'cellar', id: cellar._id, cellarId: cellar._id }, { via: 'undo' });
     return record({ summary: `Undid create — cellar "${cellar.name}" deleted`, data: { undone: 'create_cellar', cellar_id: String(cellar._id) } });
   }
@@ -60,7 +78,12 @@ async function undoStructural(last, ctx, { ok, fail, logAction }) {
     }
     if (!(await claim(last))) return fail('conflict', 'That action is already being undone.');
     rack.deletedAt = new Date();
-    await rack.save();
+    try {
+      await rack.save();
+    } catch (err) {
+      await unclaim(last._id); // VersionError (concurrent edit) → keep the undo retryable (H3)
+      return fail('conflict', 'That rack was modified at the same moment; nothing was changed — try the undo again.');
+    }
     logAudit(ctx.req, 'rack.delete', { type: 'rack', id: rack._id, cellarId: rack.cellar }, { via: 'undo' });
     return record({ summary: `Undid create — rack "${rack.name}" deleted`, data: { undone: 'create_rack', rack_id: String(rack._id) } });
   }
@@ -81,7 +104,7 @@ async function undoStructural(last, ctx, { ok, fail, logAction }) {
     }
     if (!(await claim(last))) return fail('conflict', 'That action is already being undone.');
     const result = await clearRackSlot(rack, last.detail.position, ctx.req);
-    if (result.error) return fail('conflict', `Cannot undo that placement: ${result.error.message}`);
+    if (result.error) { await unclaim(last._id); return fail('conflict', `Cannot undo that placement: ${result.error.message}`); }
     return record({ summary: `Undid placement — position ${last.detail.position} cleared`, data: { undone: 'place_bottle', cleared: true } });
   }
 
@@ -118,7 +141,7 @@ async function undoStructural(last, ctx, { ok, fail, logAction }) {
     if (occupied) return fail('conflict', `Position ${pos} is occupied again; cannot restore. Nothing was changed.`);
     if (!(await claim(last))) return fail('conflict', 'That action is already being undone.');
     const result = await placeBottleInRack(rack, pos, bottleId, ctx.req);
-    if (result.error) return fail('conflict', `Cannot undo that removal: ${result.error.message}`);
+    if (result.error) { await unclaim(last._id); return fail('conflict', `Cannot undo that removal: ${result.error.message}`); }
     return record({ summary: `Undid removal — bottle back in position ${pos}`, data: { undone: 'unplace_bottle', position: pos } });
   }
 
@@ -149,7 +172,7 @@ async function undoStructural(last, ctx, { ok, fail, logAction }) {
     // Same shared one-save apply the arrangement itself used (rackOps).
     const { applyArrangement } = require('../services/rackOps');
     const applied = await applyArrangement(rack, before, ctx.req, { via: 'undo', restored: before.length });
-    if (applied.error) return fail('conflict', `${applied.error.message} Nothing was restored.`);
+    if (applied.error) { await unclaim(last._id); return fail('conflict', `${applied.error.message} Nothing was restored.`); }
     return record({
       summary: `Undid arrangement — rack "${rack.name}" restored to its previous layout`,
       data: { undone: 'auto_arrange', rack_id: String(rack._id), bottles: before.length },
@@ -175,7 +198,7 @@ async function undoStructural(last, ctx, { ok, fail, logAction }) {
     if (!(await claim(last))) return fail('conflict', 'That action is already being undone.');
     const bottle = await Bottle.findById(access.bottle._id);
     const result = await moveBottleToCellar(bottle, access.cellar, origin, ctx.req);
-    if (result.error) return fail('conflict', `Cannot undo that move: ${result.error.message}`);
+    if (result.error) { await unclaim(last._id); return fail('conflict', `Cannot undo that move: ${result.error.message}`); }
     return record({ summary: `Undid move — bottle back in "${origin.name}" (unplaced)`, data: { undone: 'move_bottle', cellar_id: String(origin._id) } });
   }
 

--- a/backend/src/mcp/structuralUndo.test.js
+++ b/backend/src/mcp/structuralUndo.test.js
@@ -11,7 +11,7 @@
 jest.mock('../models/Cellar', () => ({ findOne: jest.fn() }));
 jest.mock('../models/Rack', () => ({ findOne: jest.fn() }));
 jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
-jest.mock('../models/McpActionLog', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
 jest.mock('../services/rackOps', () => ({
@@ -44,6 +44,7 @@ beforeEach(() => {
   Rack.findOne.mockResolvedValue({ _id: RACK, cellar: CELLAR, slots: [] });
   resolveCellarAccess.mockResolvedValue({ cellar: { _id: CELLAR } });
   McpActionLog.findOneAndUpdate.mockResolvedValue({ _id: oid('f') });
+  McpActionLog.updateOne.mockResolvedValue({});
 });
 
 test('refuses to re-slot a CONSUMED bottle, and does NOT claim the row', async () => {
@@ -70,4 +71,19 @@ test('an active in-cellar bottle IS re-slotted (claims, then places)', async () 
   expect(res.ok).toBe(true);
   expect(McpActionLog.findOneAndUpdate).toHaveBeenCalled();
   expect(placeBottleInRack).toHaveBeenCalledWith(expect.any(Object), 3, BOTTLE, expect.any(Object));
+});
+
+// MCP-audit H3: the pre-claim checks pass, the row is claimed, THEN the
+// placement fails (e.g. the bottle was concurrently placed into another rack →
+// the new unique slots.bottle index returns E11000 → placeBottleInRack maps it
+// to {error}). Without unclaim the row would stay reversed:true and the action
+// would be permanently un-undoable. The row must be released so a retry works.
+test('a post-claim placement failure UNCLAIMS the row (stays retryable)', async () => {
+  Bottle.findById.mockResolvedValue({ _id: BOTTLE, status: 'active', cellar: CELLAR });
+  placeBottleInRack.mockResolvedValue({ error: { status: 409, code: 'conflict', message: 'This bottle was just placed in another rack — refresh and retry.' } });
+  const res = await undoStructural(unplaceRow(), CTX, helpers);
+  expect(res.ok).toBe(false);
+  expect(res.message).toMatch(/Cannot undo that removal|another rack/i);
+  expect(McpActionLog.findOneAndUpdate).toHaveBeenCalled(); // claimed
+  expect(McpActionLog.updateOne).toHaveBeenCalledWith({ _id: oid('f') }, { $set: { reversed: false } }); // unclaimed
 });

--- a/backend/src/mcp/toolUtil.js
+++ b/backend/src/mcp/toolUtil.js
@@ -28,8 +28,10 @@ function ok(summary, data, extra = {}) {
 
 /**
  * Error envelope. `code` is from the §5.4 taxonomy: invalid_input | not_found |
- * forbidden_scope | budget_exhausted | conflict | rate_limited. Messages are
- * written for the calling MODEL to self-correct from, not for humans.
+ * forbidden_scope | budget_exhausted | conflict | rate_limited | busy. Messages
+ * are written for the calling MODEL to self-correct from, not for humans.
+ * `busy` (MCP-audit M1) = an identical idempotency_key request is mid-flight;
+ * retry the SAME key shortly (distinct from `conflict`, which is not retryable).
  */
 function fail(code, message) {
   return {

--- a/backend/src/mcp/tools/consume.js
+++ b/backend/src/mcp/tools/consume.js
@@ -49,7 +49,7 @@ registerTool({
     idempotency_key: z.string().max(100).optional().describe('Unique key: a retry with the same key returns the original result'),
   },
   handler: async (args, ctx) => {
-    const replayed = await replay(ctx, args.idempotency_key);
+    const replayed = await replay(ctx, args.idempotency_key, 'consume_bottle');
     if (replayed) return replayed;
 
     const access = await resolveBottleAccess(ctx.user.id, args.bottle_id, 'editor');

--- a/backend/src/mcp/tools/images.js
+++ b/backend/src/mcp/tools/images.js
@@ -38,7 +38,7 @@ registerTool({
     idempotency_key: z.string().max(100).optional(),
   },
   handler: async (args, ctx) => {
-    const replayed = await replay(ctx, args.idempotency_key);
+    const replayed = await replay(ctx, args.idempotency_key, 'attach_bottle_image');
     if (replayed) return replayed;
 
     if (!args.image_url && !args.image_base64) {

--- a/backend/src/mcp/tools/rack.js
+++ b/backend/src/mcp/tools/rack.js
@@ -41,7 +41,7 @@ registerTool({
     idempotency_key: z.string().max(100).optional(),
   },
   handler: async (args, ctx) => {
-    const replayed = await replay(ctx, args.idempotency_key);
+    const replayed = await replay(ctx, args.idempotency_key, 'create_cellar');
     if (replayed) return replayed;
     const result = await createCellar({ name: args.name, description: args.description }, ctx.req);
     if (result.error) {
@@ -75,7 +75,7 @@ registerTool({
     idempotency_key: z.string().max(100).optional(),
   },
   handler: async (args, ctx) => {
-    const replayed = await replay(ctx, args.idempotency_key);
+    const replayed = await replay(ctx, args.idempotency_key, 'create_rack');
     if (replayed) return replayed;
     const access = await resolveCellarAccess(ctx.user.id, args.cellar_id, 'editor');
     if (!access) return fail('not_found', MSG_CELLAR_NOT_FOUND);

--- a/backend/src/mcp/tools/tasting.js
+++ b/backend/src/mcp/tools/tasting.js
@@ -41,7 +41,7 @@ registerTool({
     idempotency_key: z.string().max(100).optional(),
   },
   handler: async (args, ctx) => {
-    const replayed = await replay(ctx, args.idempotency_key);
+    const replayed = await replay(ctx, args.idempotency_key, 'capture_tasting_note');
     if (replayed) return replayed;
 
     const access = await resolveBottleAccess(ctx.user.id, args.bottle_id, 'editor');

--- a/backend/src/mcp/tools/wineLists.js
+++ b/backend/src/mcp/tools/wineLists.js
@@ -172,7 +172,7 @@ registerTool({
     idempotency_key: z.string().max(100).optional(),
   },
   handler: async (args, ctx) => {
-    const replayed = await replay(ctx, args.idempotency_key);
+    const replayed = await replay(ctx, args.idempotency_key, 'add_to_list');
     if (replayed) return replayed;
 
     const [list, wine] = await Promise.all([
@@ -298,7 +298,7 @@ registerTool({
     if (args.list_price === undefined && args.by_glass === undefined && args.glass_price === undefined) {
       return fail('invalid_input', 'Nothing to change — pass list_price, by_glass and/or glass_price.');
     }
-    const replayed = await replay(ctx, args.idempotency_key);
+    const replayed = await replay(ctx, args.idempotency_key, 'update_list_pricing');
     if (replayed) return replayed;
 
     const list = await WineList.findOne({ _id: args.list_id, user: ctx.user.id });

--- a/backend/src/mcp/tools/write.js
+++ b/backend/src/mcp/tools/write.js
@@ -109,7 +109,7 @@ registerTool({
     idempotency_key: z.string().max(100).optional(),
   },
   handler: async (args, ctx) => {
-    const replayed = await replay(ctx, args.idempotency_key);
+    const replayed = await replay(ctx, args.idempotency_key, 'add_bottle');
     if (replayed) return replayed;
 
     if (!args.wine_id && !args.new_wine) {
@@ -219,7 +219,7 @@ registerTool({
     idempotency_key: z.string().max(100).optional(),
   },
   handler: async (args, ctx) => {
-    const replayed = await replay(ctx, args.idempotency_key);
+    const replayed = await replay(ctx, args.idempotency_key, 'update_bottle');
     if (replayed) return replayed;
 
     const access = await resolveBottleAccess(ctx.user.id, args.bottle_id, 'editor');

--- a/backend/src/mcp/wineListTools.test.js
+++ b/backend/src/mcp/wineListTools.test.js
@@ -144,7 +144,7 @@ describe('add_to_list', () => {
     expect(list.save).toHaveBeenCalled();
     // Keyed ledger writes complete the pending claim (claim-first, M2).
     const [lQuery, lUpdate] = McpActionLog.findOneAndUpdate.mock.calls.at(-1);
-    expect(lQuery).toEqual({ user: ME, idempotencyKey: 'k1', pending: true });
+    expect(lQuery).toEqual({ user: ME, tool: 'add_to_list', idempotencyKey: 'k1', pending: true });
     expect(lUpdate.$set).toMatchObject({
       tokenId: 't1', tool: 'add_to_list', action: 'winelist_add', idempotencyKey: 'k1', pending: false,
       detail: expect.objectContaining({ listId: LIST, wineId: WINE, vintage: '2019' }),

--- a/backend/src/mcp/writeTools.test.js
+++ b/backend/src/mcp/writeTools.test.js
@@ -156,7 +156,7 @@ describe('add_bottle', () => {
       { type: 'wine', id: oid('f') }, expect.objectContaining({ via: 'mcp' }));
     // Keyed ledger writes complete the pending claim (claim-first, M2).
     const [lQuery, lUpdate] = McpActionLog.findOneAndUpdate.mock.calls.at(-1);
-    expect(lQuery).toEqual({ user: ME, idempotencyKey: 'k-add', pending: true });
+    expect(lQuery).toEqual({ user: ME, tool: 'add_bottle', idempotencyKey: 'k-add', pending: true });
     expect(lUpdate.$set).toMatchObject({ tokenId: 't1', action: 'add', idempotencyKey: 'k-add', pending: false });
     expect(bottleOps.addBottle.mock.calls[0][3]).toBe(REQ); // audit/SSE attribution rides the real req
   });


### PR DESCRIPTION
MCP non-security audit — correctness batch 1 of the "fix it, no drifting" work. Three related idempotency/undo bugs, full backend suite green (1973) in node:20-alpine.

## M2 — idempotency replay matched across DIFFERENT tools
The claim/replay/release filters were keyed on `{user, idempotencyKey}` with no tool. An agent reusing one key across `update_bottle` then `add_bottle` got the **update's** stored result back for the add — a silent success-looking no-op with the wrong `bottle_id`. Now `replay()`/`releaseClaim()` take the tool name; the claim stub records it, `logAction` completes only its own tool's stub, and a key seen on a different tool is refused (`invalid_input`). Threaded through all 9 keyed tool call sites + the server release-on-error wrapper. *No index change* — the `{user, idempotencyKey}` unique index stays; tool-scoping is enforced in `replay()`, so nothing to migrate on deploy.

## M1 — `conflict` overloaded, letting a client defeat the claim
The in-progress case returned `code:'conflict'`, indistinguishable from permanent conflicts. A client that learned "conflict = don't retry" could retry with a **fresh** key, bypassing the claim → double-execute. It now returns a distinct **`busy`** code whose message tells the client to retry the **same** key (added to the taxonomy in `toolUtil.js`).

## H3 — `structuralUndo.js` burned the ledger row on post-claim failure
It claimed the row before the mutating rackOps call but, unlike `revert.js`, never released it on failure — so any post-claim error (the new unique-`slots.bottle` E11000 branch, a `VersionError`, or a slot disabled since) permanently burned the undo (row stuck `reversed:true`; rack data intact). Added `unclaim()` mirroring `revert.js`, called on every post-claim failure across place/unplace/arrange/move + the two bare-`save()` create branches (now try/caught).

## Docker-compose impact
None. No schema/index change.

## Tests
`actionLedger.test.js` gains the cross-tool + `busy`-code cases; a new `structuralUndo` unclaim-on-failure test closes the previously-untested post-claim path; keyed tool suites updated to the tool-scoped completion filter.