### PR TITLE
fix(mcp): correctness — glass-price parity, self-host links, reply cap, no preview double-charge (M4/M5/M6/M7)

### DIFF
--- a/backend/src/mcp/accountTools.test.js
+++ b/backend/src/mcp/accountTools.test.js
@@ -49,6 +49,7 @@ jest.mock('../services/accountOps', () => ({
   ALLOWED_RESTOCK_SCOPE: ['all', 'cellar'],
   ALLOWED_VISIBILITY: ['public', 'private'],
   SUPPORT_CATEGORIES: ['bug', 'help', 'feature', 'other'],
+  TICKET_REPLY_CAP: 30,
 }));
 
 const User = require('../models/User');
@@ -220,6 +221,19 @@ describe('list_my_tickets (the read side of create_support_ticket)', () => {
     expect(body.data[1].can_reply).toBe(true);
     expect(body.summary).toContain('2 support ticket(s)');
     expect(body.page.total).toBe(2);
+  });
+
+  test('can_reply is false once the reply cap is reached, even on an OPEN ticket (M6)', async () => {
+    // reply_to_ticket refuses at TICKET_REPLY_CAP (admin replies count too), so
+    // an open thread already at the cap must report can_reply:false.
+    const replies = Array.from({ length: 30 }, (_, i) => ({ author: i % 2 ? 'admin' : 'user', message: `r${i}`, createdAt: new Date() }));
+    SupportTicket.countDocuments.mockResolvedValue(1);
+    SupportTicket.find.mockReturnValue(ticketChain([
+      { _id: 't3', category: 'bug', subject: 'Long thread', message: 'start', status: 'open', replies, createdAt: new Date() },
+    ]));
+    const body = parse(await tool('list_my_tickets').handler({}, CTX));
+    expect(body.data[0].status).toBe('open');
+    expect(body.data[0].can_reply).toBe(false); // at cap
   });
 
   test('the conversation thread ships author+message+date, never the by refs', async () => {

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -119,7 +119,10 @@ function budgetedHandler(tool, ctx, state) {
           content: [{ type: 'text', text: JSON.stringify({ error: { code: 'forbidden_scope', message: 'Mutations need an authenticated connection.' } }) }],
         };
       }
-      if (!takeMutationSlot(String(ctx.user.id), 1, ipKeyFor(ctx))) {
+      // Self-budgeted tools (bulk_add, auto_arrange) charge the write budget
+      // themselves — per ITEM on apply, nothing on preview — so the generic
+      // one-slot-per-call charge here would double-count (MCP-audit M7).
+      if (!tool.selfBudgeted && !takeMutationSlot(String(ctx.user.id), 1, ipKeyFor(ctx))) {
         recordUsage(ctx, 'tool', tool.name, true);
         return rateLimited('Too many cellar changes in a short time — wait a few minutes before mutating again. Reads still work.');
       }

--- a/backend/src/mcp/tools/account.js
+++ b/backend/src/mcp/tools/account.js
@@ -20,6 +20,7 @@ const {
   updatePreferences, updateProfile, createSupportTicket, replyToTicket, createWineRequest,
   ALLOWED_CURRENCIES, ALLOWED_LANGUAGES, ALLOWED_RATING_SCALES,
   ALLOWED_RACK_NAV, ALLOWED_RESTOCK_SCOPE, ALLOWED_VISIBILITY, SUPPORT_CATEGORIES,
+  TICKET_REPLY_CAP,
 } = require('../../services/accountOps');
 
 /** Compact, PII-safe view of the caller's preferences. */
@@ -241,7 +242,10 @@ registerTool({
       admin_response: t.adminResponse || null,
       responded_at: t.respondedAt || null,
       replies: (t.replies || []).map((r) => ({ author: r.author, message: r.message, created_at: r.createdAt })),
-      can_reply: t.status !== 'closed',
+      // Mirror BOTH bounds reply_to_ticket enforces (MCP-audit M6): not closed
+      // AND under the reply cap (which counts admin replies too), so the model
+      // isn't told it can reply and then refused.
+      can_reply: t.status !== 'closed' && (t.replies || []).length < TICKET_REPLY_CAP,
       created_at: t.createdAt,
     }));
     const answered = data.filter((t) => t.admin_response).length;

--- a/backend/src/mcp/tools/arrange.js
+++ b/backend/src/mcp/tools/arrange.js
@@ -74,6 +74,10 @@ registerTool({
     'restores the previous layout. Disabled slots stay empty; zone assignments are IGNORED (bottles may land in other ' +
     'zones) — warn the user if their rack uses zones; zone-aware arranging is web-app-only.',
   scope: 'write',
+  // Charges the write budget ITSELF — one slot per bottle moved on apply,
+  // nothing on preview — so the generic per-call charge in server.js must skip
+  // it or a 12-bottle arrange would cost 14 (MCP-audit M7).
+  selfBudgeted: true,
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
   inputSchema: {
     mode: z.enum(['preview', 'apply']).default('preview'),

--- a/backend/src/mcp/tools/bulk.js
+++ b/backend/src/mcp/tools/bulk.js
@@ -98,6 +98,10 @@ registerTool({
     "mode:'apply' and the preview_id. The whole batch is one undo_last unit. Prefer resolve_wine-verified wine_ids in " +
     'items; new_wine items follow the same registry rules as add_bottle.',
   scope: 'write',
+  // Charges the write budget ITSELF — one slot per item on apply, nothing on
+  // preview — so the generic per-call charge in server.js must skip it or a
+  // 12-bottle case would cost 14 (MCP-audit M7).
+  selfBudgeted: true,
   annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
   inputSchema: {
     mode: z.enum(['preview', 'apply']).default('preview'),

--- a/backend/src/mcp/tools/publicContent.js
+++ b/backend/src/mcp/tools/publicContent.js
@@ -7,6 +7,7 @@ const { z } = require('zod');
 const { registerTool } = require('../registry');
 const { isValidId } = require('../../utils/validation');
 const { ok, fail } = require('../toolUtil');
+const { siteBaseUrl } = require('../../utils/siteUrl');
 
 registerTool({
   name: 'drink_window_for',
@@ -111,7 +112,7 @@ registerTool({
       excerpt: p.excerpt || null,
       tags: p.tags || [],
       published_at: p.publishedAt,
-      public_url: `https://cellarion.app/blog/${p.slug}`,
+      public_url: `${siteBaseUrl()}/blog/${p.slug}`,
     })), { page: { limit, offset, total } });
   },
 });
@@ -139,7 +140,7 @@ registerTool({
       excerpt: post.excerpt || null,
       tags: post.tags || [],
       published_at: post.publishedAt,
-      public_url: `https://cellarion.app/blog/${post.slug}`,
+      public_url: `${siteBaseUrl()}/blog/${post.slug}`,
       content: truncated ? post.content.slice(0, GUIDE_MAX_CHARS) : post.content,
     }, truncated ? { warnings: [`Content truncated at ${GUIDE_MAX_CHARS} characters — the full article is at the public_url.`] } : {});
   },

--- a/backend/src/mcp/tools/wineLists.js
+++ b/backend/src/mcp/tools/wineLists.js
@@ -20,16 +20,9 @@ const { registerTool } = require('../registry');
 const { logAudit } = require('../../services/audit');
 const { ok, fail, objectId, pageParams, wineSummary } = require('../toolUtil');
 const { logAction, replay } = require('../actionLedger');
-
-// Suggested glass price per the layout rule documented on the model:
-// listPrice / glassesPerBottle × (1 + glassMarkup/100), rounded to the
-// nearest glassRounding step. Null when there is no bottle price to derive from.
-function suggestGlassPrice(layout, listPrice) {
-  if (listPrice == null) return null;
-  const per = (listPrice / (layout?.glassesPerBottle || 6)) * (1 + (layout?.glassMarkup || 0) / 100);
-  const step = parseInt(layout?.glassRounding || '1', 10) || 1;
-  return Math.round(per / step) * step;
-}
+// Single source for the glass-price rule (MCP-audit M4) — identical to the web
+// editor's, and now floored at one step so a cheap wine no longer suggests 0.
+const { suggestGlassPrice } = require('../../utils/glassPrice');
 
 // The active entry container for writes; [{ section, entries }] for reads.
 function activeContainers(list) {
@@ -221,7 +214,7 @@ registerTool({
 
     const glassGiven = args.glass_price != null;
     const glassPrice = args.by_glass
-      ? (glassGiven ? args.glass_price : suggestGlassPrice(list.layout, args.list_price))
+      ? (glassGiven ? args.glass_price : suggestGlassPrice(args.list_price, list.layout))
       : undefined;
     container.push({
       wine: wine._id,
@@ -331,7 +324,7 @@ registerTool({
     // Turning by-glass on (or clearing the manual price) with no explicit
     // price → derive the suggestion from the current bottle price.
     if (entry.byGlass && entry.glassPrice == null) {
-      const suggested = suggestGlassPrice(list.layout, entry.listPrice);
+      const suggested = suggestGlassPrice(entry.listPrice, list.layout);
       if (suggested != null) { entry.glassPrice = suggested; entry.glassPriceManual = false; }
     }
 

--- a/backend/src/mcp/tools/wines.js
+++ b/backend/src/mcp/tools/wines.js
@@ -8,6 +8,7 @@ const WineDefinition = require('../../models/WineDefinition');
 const { registerTool } = require('../registry');
 const { isValidId } = require('../../utils/validation');
 const { ok, fail, wineSummary, hasContent } = require('../toolUtil');
+const { siteBaseUrl } = require('../../utils/siteUrl');
 
 const REGISTRY_LIMIT = 10; // == USER_SEARCH_LIMIT in routes/wines.js
 
@@ -83,7 +84,7 @@ registerTool({
       lwin7: w.lwin?.lwin7 || null,
       community_rating: w.communityRating?.reviewCount ? w.communityRating : null,
       tasting_profile: hasContent(w.aiProfile) ? w.aiProfile : null,
-      public_url: w.slug ? `https://cellarion.app/wines/${w.slug}` : null,
+      public_url: w.slug ? `${siteBaseUrl()}/wines/${w.slug}` : null,
     });
   },
 });

--- a/backend/src/utils/glassPrice.js
+++ b/backend/src/utils/glassPrice.js
@@ -1,0 +1,20 @@
+// Suggested by-the-glass price from a wine list's glass-pricing rule.
+//
+// SINGLE SOURCE on the backend (MCP-audit M4). The web editor applies the same
+// rule in frontend/src/pages/WineListEditor.js (suggestGlassPrice); the two are
+// separate npm packages so the formula can't be physically shared, but it MUST
+// stay identical or the same "add by the glass" action produces a different
+// menu depending on surface. The rule: listPrice / glassesPerBottle × (1 +
+// markup%), rounded to the nearest `glassRounding` step, and FLOORED at one step
+// so a glass is never free (a cheap wine used to suggest 0 on the backend and 1
+// on the web). Returns null when there is no list price to derive from.
+function suggestGlassPrice(listPrice, layout = {}) {
+  if (listPrice == null) return null;
+  const glasses = layout.glassesPerBottle || 6;
+  const markup = layout.glassMarkup || 0;
+  const step = parseInt(layout.glassRounding || '1', 10) || 1;
+  const raw = (listPrice / glasses) * (1 + markup / 100);
+  return Math.max(step, Math.round(raw / step) * step);
+}
+
+module.exports = { suggestGlassPrice };

--- a/backend/src/utils/siteUrl.js
+++ b/backend/src/utils/siteUrl.js
@@ -1,0 +1,12 @@
+// Single source for the public site base URL (MCP-audit M5). Every user-facing
+// link must derive from FRONTEND_URL so a self-hosted instance emits its OWN
+// origin, never a hardcoded https://cellarion.app (whose /wines and /blog paths
+// don't exist on someone else's deployment). Same fallback as routes/og.js,
+// routes/sitemap.js, services/indexNow.js and mcp/tools/export.js — kept here so
+// there is one place to change it. Trailing slashes are trimmed so
+// `${siteBaseUrl()}/wines/x` never produces a double slash.
+function siteBaseUrl() {
+  return (process.env.FRONTEND_URL || 'https://cellarion.app').replace(/\/+$/, '');
+}
+
+module.exports = { siteBaseUrl };

--- a/frontend/src/pages/WineListEditor.js
+++ b/frontend/src/pages/WineListEditor.js
@@ -24,7 +24,12 @@ const AUTOSAVE_DELAY = 1500;
 const keyOf = (e) =>
   `${e.wine?._id || e.wine}|${e.vintage || 'NV'}|${e.bottleSize || '750ml'}`;
 
-/** Suggested glass price from the list's glass pricing rule. */
+/**
+ * Suggested glass price from the list's glass pricing rule.
+ * MUST stay identical to the backend's canonical copy in
+ * backend/src/utils/glassPrice.js (MCP-audit M4) — separate npm packages, one
+ * rule. If you change the formula, change it in BOTH places.
+ */
 const suggestGlassPrice = (listPrice, layout = {}) => {
   if (listPrice == null) return null;
   const glasses = layout.glassesPerBottle || 6;


### PR DESCRIPTION
MCP non-security audit — correctness batch 2. Full backend suite green (1972) in node:20-alpine.

## M4 — glass-price suggestion duplicated & drifted (0 vs 1)
The by-the-glass rule lived in both the MCP backend and the web editor, and had drifted: the backend didn't floor at one rounding step, so a cheap wine suggested **0** by-glass on the AI surface and **1** on the web. Extracted to [`utils/glassPrice.js`](backend/src/utils/glassPrice.js) (single backend source, floored to match), and cross-referenced the frontend copy so they can't silently diverge again.

## M5 — hardcoded `cellarion.app` links break self-host
`get_wine` / `list_guides` / `read_guide` hardcoded `https://cellarion.app` in the `public_url` handed to the model, so a self-hoster got dead links. New [`utils/siteUrl.js`](backend/src/utils/siteUrl.js) derives the base from `FRONTEND_URL` (same fallback as `og.js`/`sitemap.js`/`export.js`). Supporter URLs stay hardcoded — hosted-only by design.

## M6 — `can_reply` ignored the reply cap
`list_my_tickets` set `can_reply` on status alone, but `reply_to_ticket` also refuses at the 30-reply cap (admin replies count). The model was told it could reply, then refused. Now mirrors both bounds via `TICKET_REPLY_CAP` from accountOps.

## M7 — `bulk_add` / `auto_arrange` double-charged the write budget
Both are `readOnlyHint:false`, so the generic wrapper charged one slot per call — on top of the per-**item** charge they do themselves on apply, and even on the no-op preview (a 12-bottle case cost 14, and at the cap you couldn't even preview). Marked both `selfBudgeted:true`; the wrapper skips its auto-charge for them.

## Docker-compose impact
None.