### PR TITLE
refactor(mcp): single-source scope list + non-activity actions (L1, M1/F4)

### DIFF
--- a/backend/src/models/McpActionLog.js
+++ b/backend/src/models/McpActionLog.js
@@ -62,3 +62,10 @@ mcpActionLogSchema.index({ user: 1, createdAt: -1 });
 mcpActionLogSchema.index({ createdAt: 1 }, { expireAfterSeconds: 90 * 24 * 60 * 60 });
 
 module.exports = mongoose.model('McpActionLog', mcpActionLogSchema);
+
+// Actions that are NOT real AI activity: the two preview stubs (shown, maybe
+// declined — changed nothing) and the transient `pending` idempotency claim
+// stub (actionLedger.js). SINGLE SOURCE (MCP-audit M1/F4) so the activity
+// timeline, the admin write count, AND the GDPR export all exclude the same
+// set and can't drift — a stub must never surface as "what your AI did".
+module.exports.NON_ACTIVITY_ACTIONS = ['bulk_preview', 'arrange_preview', 'pending'];

--- a/backend/src/routes/admin/mcp.js
+++ b/backend/src/routes/admin/mcp.js
@@ -55,10 +55,12 @@ router.get('/usage', async (req, res) => {
           activeLast7d: { $sum: { $cond: [{ $gte: ['$lastUsedAt', weekAgo] }, 1, 0] } },
         } },
       ]),
-      // Real (non-preview) writes AIs performed in the last 7 days.
+      // Real writes AIs performed in the last 7 days — excludes preview stubs
+      // AND pending idempotency-claim stubs (MCP-audit M1/F4), same canonical
+      // set the activity timeline uses.
       McpActionLog.countDocuments({
         createdAt: { $gte: weekAgo },
-        action: { $nin: ['bulk_preview', 'arrange_preview'] },
+        action: { $nin: McpActionLog.NON_ACTIVITY_ACTIONS },
       }),
     ]);
 

--- a/backend/src/routes/admin/mcp.test.js
+++ b/backend/src/routes/admin/mcp.test.js
@@ -9,7 +9,7 @@
 process.env.JWT_SECRET = 'test-secret';
 
 jest.mock('../../models/McpUsageStat', () => ({ aggregate: jest.fn() }));
-jest.mock('../../models/McpActionLog', () => ({ countDocuments: jest.fn() }));
+jest.mock('../../models/McpActionLog', () => ({ countDocuments: jest.fn(), NON_ACTIVITY_ACTIONS: ['bulk_preview', 'arrange_preview', 'pending'] }));
 jest.mock('../../models/ApiToken', () => ({ aggregate: jest.fn() }));
 jest.mock('../../models/User', () => ({ findById: jest.fn() }));
 

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -12,6 +12,9 @@ const { revertLedgerRow, reversibleActionsFor } = require('../mcp/revert');
 const { findLiveLink, redeemExportLink } = require('../services/exportLinks');
 const { issuer } = require('../services/mcpOAuth');
 const rateLimitsConfig = require('../config/rateLimits');
+// The canonical personal-session scope set — single source (MCP-audit L1), used
+// for both the reversible-action set and the browser-revert ctx below.
+const { MCP_PERSONAL_SCOPES } = require('../config/constants');
 
 // Admin kill switches (config/rateLimits.js `mcp` group, runtime-tunable from
 // the Admin → MCP page). They gate AI protocol access ONLY — the browser-facing
@@ -77,7 +80,7 @@ function mcpChallenge(req, res, next) {
 // The action types a browser session can reverse (full personal authority =
 // consume + write). Excludes bulk_preview (changed nothing) and undo_add / other
 // viaUndo records — so a "preview then declined" row never shows a Revert button.
-const REVERSIBLE_ACTIONS = new Set(reversibleActionsFor(['consume', 'write']));
+const REVERSIBLE_ACTIONS = new Set(reversibleActionsFor(MCP_PERSONAL_SCOPES));
 
 // Scopes a caller has when talking to the MCP endpoint. For a personal API token
 // (`cel_…`) these are the token's OWN scopes — so a read-only token sees and can
@@ -87,7 +90,7 @@ const REVERSIBLE_ACTIONS = new Set(reversibleActionsFor(['consume', 'write']));
 // write-safety stack (registry-safe two-step add, conflict guards, idempotency
 // keys, the McpActionLog undo ledger, per-user mutation budget). Demo sessions
 // are blocked below; cel_ tokens opt into scopes explicitly at mint time.
-const { MCP_PERSONAL_SCOPES: JWT_SCOPES } = require('../config/constants');
+const JWT_SCOPES = MCP_PERSONAL_SCOPES;
 
 // POST /api/mcp — stateless Streamable HTTP MCP endpoint. Auth is the same
 // requireAuth as the REST API. For `cel_` tokens the SCOPE_ALLOWLIST grants this
@@ -274,7 +277,7 @@ router.get('/activity', requireAuth, requireNonDemo, async (req, res, next) => {
     // separate `bulk_add` / `arrange` rows. 'pending' rows are idempotency
     // claim stubs (actionLedger.js) whose mutation hasn't completed — equally
     // not activity.
-    const filter = { user: req.user.id, action: { $nin: ['bulk_preview', 'arrange_preview', 'pending'] } };
+    const filter = { user: req.user.id, action: { $nin: McpActionLog.NON_ACTIVITY_ACTIONS } };
     const [rows, total] = await Promise.all([
       McpActionLog.find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
       McpActionLog.countDocuments(filter),
@@ -314,7 +317,7 @@ router.post('/activity/:id/revert', requireAuth, requireNonDemo, async (req, res
     // A logged-in session acts as the user with their full personal authority,
     // so every action class is reversible; the engine still re-checks per-bottle
     // access and somm role before touching anything.
-    const ctx = { user: req.user, scopes: ['read', 'consume', 'write'], req };
+    const ctx = { user: req.user, scopes: [...MCP_PERSONAL_SCOPES], req };
     const result = await revertLedgerRow(row, ctx, {
       ok: (summary, data) => ({ ok: true, summary, data }),
       fail: (code, message) => ({ ok: false, code, message }),

--- a/backend/src/routes/mcp.test.js
+++ b/backend/src/routes/mcp.test.js
@@ -29,6 +29,7 @@ jest.mock('../models/McpActionLog', () => ({
   find: jest.fn(),
   findOne: jest.fn(),
   countDocuments: jest.fn(),
+  NON_ACTIVITY_ACTIONS: ['bulk_preview', 'arrange_preview', 'pending'],
 }));
 
 const express = require('express');

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -584,9 +584,11 @@ const REGISTRY = [
     // Export what the connected AI changed (right of access) INCLUDING prev —
     // after a restore, the user's consumed note/rating snapshot may exist only
     // here for up to the TTL. Never the idempotency keys or stored result
-    // payloads (operational plumbing).
+    // payloads (operational plumbing). Excludes preview + pending claim stubs
+    // (MCP-audit M1/F4) — data-minimisation: those changed nothing and are the
+    // same rows hidden from the timeline.
     exportFragment: async (ctx) => ({
-      mcpActions: markTrunc(ctx, 'mcpActions', await McpActionLog.find({ user: ctx.userId })
+      mcpActions: markTrunc(ctx, 'mcpActions', await McpActionLog.find({ user: ctx.userId, action: { $nin: McpActionLog.NON_ACTIVITY_ACTIONS } })
         .select('tool action bottle cellar detail prev reversed createdAt').limit(EXPORT_MAX).lean())
         .map(a => ({ tool: a.tool, action: a.action, bottle: a.bottle, cellar: a.cellar, detail: a.detail, prev: a.prev || null, reversed: a.reversed, createdAt: a.createdAt })),
     }),


### PR DESCRIPTION
MCP non-security audit — maintainability / no-drift batch. Full backend suite green (1971) in node:20-alpine.

## L1 — scope list hardcoded at two sites
`routes/mcp.js` hardcoded `['read','consume','write']` twice (the reversible-action set + the browser-revert ctx) while already importing the canonical `MCP_PERSONAL_SCOPES`. Both now derive from it, so a scope change can't leave one behind.

## M1/F4 — `pending` claim stubs leaked into export + admin count
The transient `pending` idempotency stubs (and `bulk_preview`/`arrange_preview` rows) were hidden from the activity timeline but still landed in:
- the **GDPR export** (`userDataRegistry` had *no* action filter → stubs exported as "what your AI changed"), and
- the **admin `writesLast7d`** count (missing `pending`).

Added one canonical `McpActionLog.NON_ACTIVITY_ACTIONS` list, now used by the timeline, the admin count, **and** the export — so the three can't drift and a transient stub never surfaces as real activity.

## Docker-compose impact
None.