### PR TITLE
test(mcp): drift guards for unique indexes + budget wiring (H2, M11)

### DIFF
--- a/backend/src/mcp/mutationBudget.test.js
+++ b/backend/src/mcp/mutationBudget.test.js
@@ -83,3 +83,23 @@ test('ipKeyFor returns null without a request, a stable key with one', () => {
   expect(ipKeyFor({})).toBeNull();
   expect(ipKeyFor({ req: { ip: '203.0.113.7', headers: {} } })).toBe('203.0.113.7');
 });
+
+// MCP-audit M11 / security-audit L-18: the cap eviction replaced a wholesale
+// .clear() (which wiped EVERY in-flight window when a burst of distinct keys hit
+// the cap). This was claimed-but-untested. Fresh module for a clean map so the
+// insertion order — and thus which keys land in the evicted oldest half — is
+// deterministic.
+test('at WINDOWS_MAX it evicts the OLDEST half, not everyone', () => {
+  jest.isolateModules(() => {
+    const { takeMutationSlot } = require('./mutationBudget'); // max = 5 (mocked)
+    // Older keys fill the first half; then a recent caller spends its full cap.
+    for (let i = 0; i < 2600; i++) takeMutationSlot(`old-${i}`, 1);
+    expect(takeMutationSlot('recent', 5)).toBe(true);
+    expect(takeMutationSlot('recent', 1)).toBe(false); // exhausted
+    // Overflow past WINDOWS_MAX (5000) → evicts the oldest 2500 (old-0..old-2499).
+    for (let i = 0; i < 2500; i++) takeMutationSlot(`fill-${i}`, 1);
+    // `recent` was inserted after the evicted range, so its exhausted window
+    // SURVIVED the burst. A `.clear()` would have reset it → this would be true.
+    expect(takeMutationSlot('recent', 1)).toBe(false);
+  });
+});

--- a/backend/src/mcp/resultCache.test.js
+++ b/backend/src/mcp/resultCache.test.js
@@ -35,4 +35,44 @@ test('a different variant is a different cache entry', async () => {
   await cachedResult('tool', 'uC', 'v2', compute);
   expect(compute).toHaveBeenCalledTimes(2);
 });
-// (bustUser per-user invalidation is covered on the cache-bust batch that adds it.)
+
+// bustUser + eviction (MCP-audit M11 — both were untested; the commit that
+// added them claimed coverage that didn't exist). Fresh module per test so the
+// shared module-level cache from the tests above doesn't skew the boundaries.
+describe('bustUser + eviction', () => {
+  let cachedResult, bustUser;
+  beforeEach(() => {
+    jest.resetModules();
+    ({ cachedResult, bustUser } = require('./resultCache'));
+  });
+
+  test('bustUser drops ONLY the target user\'s entries (a just-mutated cellar recomputes)', async () => {
+    const compute = jest.fn().mockResolvedValue({});
+    await cachedResult('t', 'uX', 'v', compute);
+    await cachedResult('t', 'uY', 'v', compute);
+    bustUser('uX');
+    await cachedResult('t', 'uX', 'v', compute); // busted → recompute
+    await cachedResult('t', 'uY', 'v', compute); // untouched → still cached
+    expect(compute).toHaveBeenCalledTimes(3); // uX×2, uY×1
+  });
+
+  test('the :userId: needle is exact — a substring userId is not busted', async () => {
+    const compute = jest.fn().mockResolvedValue({});
+    await cachedResult('t', 'u1', 'v', compute);
+    await cachedResult('t', 'u12', 'v', compute); // key t:u12:v does NOT contain :u1:
+    bustUser('u1');
+    await cachedResult('t', 'u12', 'v', compute); // survives
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  test('at CACHE_MAX it evicts the oldest half, not everyone (no cold-start)', async () => {
+    const CACHE_MAX = 2000;
+    const compute = jest.fn().mockResolvedValue({});
+    for (let i = 0; i < CACHE_MAX; i++) await cachedResult('t', `u${i}`, 'v', compute);
+    expect(compute).toHaveBeenCalledTimes(CACHE_MAX);
+    await cachedResult('t', 'uNEW', 'v', compute); // size hits cap → evict u0..u999
+    await cachedResult('t', 'u0', 'v', compute);   // oldest → evicted → recompute
+    await cachedResult('t', 'u1999', 'v', compute); // recent → survived → cached
+    expect(compute).toHaveBeenCalledTimes(CACHE_MAX + 2); // uNEW + u0 recompute only
+  });
+});

--- a/backend/src/mcp/server.test.js
+++ b/backend/src/mcp/server.test.js
@@ -1,0 +1,119 @@
+/**
+ * budgetedHandler — the per-tool-call gate (MCP-audit H2, M7).
+ *
+ * This wrapper decides: per-request cap, cross-request call budget, mutating
+ * fail-closed for anonymous, the per-user/IP mutation budget, and the
+ * idempotency claim RELEASE-on-error. None of that was driven end-to-end by any
+ * test — the keyed tool suites call handlers directly, bypassing the wrapper,
+ * so a regression in the release-on-error decision (or the selfBudgeted skip)
+ * would ship green. These tests exercise the real wrapper with a stub tool.
+ */
+
+// The three registration side-effect requires pull the whole tool graph; stub
+// them so this suite stays about the wrapper, not the tools.
+jest.mock('./tools', () => {});
+jest.mock('./resources', () => {});
+jest.mock('./prompts', () => {});
+jest.mock('./callBudget', () => ({ withinCallBudget: jest.fn(() => true) }));
+jest.mock('./mutationBudget', () => ({ takeMutationSlot: jest.fn(() => true), ipKeyFor: jest.fn(() => null), WRITE_WINDOW_MS: 900000 }));
+jest.mock('./actionLedger', () => ({ releaseClaim: jest.fn() }));
+jest.mock('../models/McpUsageStat', () => ({ record: jest.fn() }));
+
+const { withinCallBudget } = require('./callBudget');
+const { takeMutationSlot } = require('./mutationBudget');
+const { releaseClaim } = require('./actionLedger');
+const { budgetedHandler, MAX_CALLS_PER_REQUEST } = require('./server');
+
+const USER = { id: 'u1' };
+const ctxFor = (over = {}) => ({ user: USER, req: { headers: {} }, ...over });
+const readTool = (handler) => ({ name: 'search_bottles', annotations: { readOnlyHint: true }, handler });
+const writeTool = (handler, extra = {}) => ({ name: 'add_bottle', annotations: { readOnlyHint: false }, handler, ...extra });
+const parse = (env) => JSON.parse(env.content[0].text);
+const freshState = () => ({ calls: 0 });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  withinCallBudget.mockReturnValue(true);
+  takeMutationSlot.mockReturnValue(true);
+});
+
+describe('budget gates', () => {
+  test('per-request cap: the (max+1)th call is refused, handler not run', async () => {
+    const handler = jest.fn(async () => ({ content: [] }));
+    const state = { calls: MAX_CALLS_PER_REQUEST }; // next call is over
+    const env = await budgetedHandler(readTool(handler), ctxFor(), state)({});
+    expect(parse(env).error.code).toBe('rate_limited');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('cross-request call budget exhausted → refused before the handler', async () => {
+    withinCallBudget.mockReturnValue(false);
+    const handler = jest.fn(async () => ({ content: [] }));
+    const env = await budgetedHandler(readTool(handler), ctxFor(), freshState())({});
+    expect(parse(env).error.code).toBe('rate_limited');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('a mutating tool on the anonymous surface is refused (forbidden_scope)', async () => {
+    const handler = jest.fn(async () => ({ content: [] }));
+    const env = await budgetedHandler(writeTool(handler), ctxFor({ anonymous: true, user: null }), freshState())({});
+    expect(parse(env).error.code).toBe('forbidden_scope');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('a mutating tool charges the mutation budget and is refused when exhausted', async () => {
+    takeMutationSlot.mockReturnValue(false);
+    const handler = jest.fn(async () => ({ content: [] }));
+    const env = await budgetedHandler(writeTool(handler), ctxFor(), freshState())({});
+    expect(takeMutationSlot).toHaveBeenCalledWith('u1', 1, null);
+    expect(parse(env).error.code).toBe('rate_limited');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('a selfBudgeted tool does NOT ride the generic mutation charge (M7)', async () => {
+    const handler = jest.fn(async () => ({ content: [{ type: 'text', text: '{}' }] }));
+    await budgetedHandler(writeTool(handler, { selfBudgeted: true }), ctxFor(), freshState())({});
+    expect(takeMutationSlot).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalled();
+  });
+});
+
+describe('idempotency claim release-on-error (H2)', () => {
+  const key = 'k1';
+
+  test('a tool that returns an ordinary error RELEASES the claim', async () => {
+    const handler = jest.fn(async () => ({ isError: true, content: [{ type: 'text', text: '{}' }] }));
+    await budgetedHandler(writeTool(handler), ctxFor(), freshState())({ idempotency_key: key });
+    expect(releaseClaim).toHaveBeenCalledWith(ctxForMatch(), key, 'add_bottle');
+  });
+
+  test('a tool that returns the idempotency BUSY error does NOT release (a live twin owns it)', async () => {
+    const handler = jest.fn(async () => ({ isError: true, idempotencyBusy: true, content: [{ type: 'text', text: '{}' }] }));
+    await budgetedHandler(writeTool(handler), ctxFor(), freshState())({ idempotency_key: key });
+    expect(releaseClaim).not.toHaveBeenCalled();
+  });
+
+  test('a tool that THROWS releases the claim and rethrows', async () => {
+    const boom = new Error('boom');
+    const handler = jest.fn(async () => { throw boom; });
+    await expect(budgetedHandler(writeTool(handler), ctxFor(), freshState())({ idempotency_key: key })).rejects.toThrow('boom');
+    expect(releaseClaim).toHaveBeenCalledWith(ctxForMatch(), key, 'add_bottle');
+  });
+
+  test('a SUCCESS never releases (logAction completed the claim)', async () => {
+    const handler = jest.fn(async () => ({ content: [{ type: 'text', text: '{}' }] }));
+    await budgetedHandler(writeTool(handler), ctxFor(), freshState())({ idempotency_key: key });
+    expect(releaseClaim).not.toHaveBeenCalled();
+  });
+
+  test('no idempotency_key → never touches releaseClaim even on error', async () => {
+    const handler = jest.fn(async () => ({ isError: true, content: [{ type: 'text', text: '{}' }] }));
+    await budgetedHandler(writeTool(handler), ctxFor(), freshState())({});
+    expect(releaseClaim).not.toHaveBeenCalled();
+  });
+});
+
+// ctx is spread with extra fields; assert on the object shape we passed.
+function ctxForMatch() {
+  return expect.objectContaining({ user: USER });
+}

--- a/backend/src/models/McpActionLog.test.js
+++ b/backend/src/models/McpActionLog.test.js
@@ -1,0 +1,45 @@
+/**
+ * McpActionLog index + constants guards (MCP-audit H2).
+ *
+ * The whole claim-first idempotency guarantee (prior-audit M2) rests on the
+ * unique {user, idempotencyKey} index: it's what makes "exactly one twin wins
+ * the claim" true. Every actionLedger unit test SIMULATES the E11000 by
+ * mocking the model, so nothing else in the suite would catch someone dropping
+ * `unique: true` — which would silently let concurrent same-key calls both
+ * execute in production. This asserts the index declaration directly (no DB),
+ * mirroring models/AiBudgetRequest.test.js.
+ */
+const McpActionLog = require('./McpActionLog');
+
+describe('McpActionLog indexes', () => {
+  const indexes = McpActionLog.schema.indexes();
+
+  test('unique partial index on {user, idempotencyKey} (the idempotency lynchpin)', () => {
+    const idem = indexes.find(([fields]) => fields.user === 1 && fields.idempotencyKey === 1);
+    expect(idem).toBeDefined();
+    expect(idem[1].unique).toBe(true);
+    // Partial on string keys only — keyless rows (no idempotency_key) must not
+    // collide on a null key.
+    expect(idem[1].partialFilterExpression).toEqual({ idempotencyKey: { $type: 'string' } });
+  });
+
+  test('90-day TTL on createdAt, single index (no competing plain index → IndexOptionsConflict)', () => {
+    const ttl = indexes.find(([fields, opts]) => fields.createdAt === 1 && opts.expireAfterSeconds != null);
+    expect(ttl).toBeDefined();
+    expect(ttl[1].expireAfterSeconds).toBe(90 * 24 * 60 * 60);
+    // The ONLY index whose key is exactly {createdAt:1} is the TTL one.
+    const createdAtOnly = indexes.filter(([fields]) => Object.keys(fields).length === 1 && fields.createdAt);
+    expect(createdAtOnly).toHaveLength(1);
+  });
+});
+
+describe('McpActionLog.NON_ACTIVITY_ACTIONS', () => {
+  test('excludes preview + pending stubs (single source for timeline/admin/export)', () => {
+    expect(McpActionLog.NON_ACTIVITY_ACTIONS).toEqual(['bulk_preview', 'arrange_preview', 'pending']);
+  });
+
+  test('every non-activity action is a real enum value (so the $nin actually matches rows)', () => {
+    const enumVals = McpActionLog.schema.path('action').enumValues;
+    for (const a of McpActionLog.NON_ACTIVITY_ACTIONS) expect(enumVals).toContain(a);
+  });
+});

--- a/backend/src/models/Rack.test.js
+++ b/backend/src/models/Rack.test.js
@@ -1,0 +1,31 @@
+/**
+ * Rack index guard (MCP-audit H2 / prior-audit M4).
+ *
+ * "One slot per bottle across ALL racks" is enforced ONLY by the unique
+ * multikey index on slots.bottle — per-document optimistic concurrency can't
+ * see two racks each admitting the same bottle at once. rackOps.test.js
+ * SIMULATES the E11000 by mocking rack.save, so nothing else would catch
+ * someone dropping `unique: true` (which would silently let a bottle live in
+ * two racks). This asserts the declaration directly (no DB).
+ */
+const Rack = require('./Rack');
+
+describe('Rack indexes', () => {
+  const indexes = Rack.schema.indexes();
+
+  test('unique multikey partial index on slots.bottle (one slot per bottle, cross-rack)', () => {
+    const slotBottle = indexes.find(([fields]) => fields['slots.bottle'] === 1);
+    expect(slotBottle).toBeDefined();
+    expect(slotBottle[1].unique).toBe(true);
+    // Partial on existence — an empty slots array indexes as a null key, and two
+    // slot-less racks must not collide.
+    expect(slotBottle[1].partialFilterExpression).toEqual({ 'slots.bottle': { $exists: true } });
+  });
+
+  test('cellar+name uniqueness is scoped to non-deleted racks', () => {
+    const cellarName = indexes.find(([fields]) => fields.cellar === 1 && fields.name === 1);
+    expect(cellarName).toBeDefined();
+    expect(cellarName[1].unique).toBe(true);
+    expect(cellarName[1].partialFilterExpression).toEqual({ deletedAt: null });
+  });
+});


### PR DESCRIPTION
MCP non-security audit — the anti-drift **test safety net**. All new/added tests, **no production change**. Full backend suite green (1994, +20) in node:20-alpine.

The audit's central worry: the mechanisms that *enforce* the concurrency and budget contracts are invisible to CI, so a regression ships green. This closes those seams.

## H2 — unique-index enforcement was mock-simulated
The whole idempotency (M2) and one-slot-per-bottle (M4) guarantee rests on two unique indexes, but every unit test injects the `E11000` itself (mocked model / mocked `save`), so dropping `unique:true` would silently ship duplicates while CI is green. New [`models/McpActionLog.test.js`](backend/src/models/McpActionLog.test.js) + [`models/Rack.test.js`](backend/src/models/Rack.test.js) assert the index declarations directly via `schema.indexes()` (the `AiBudgetRequest.test.js` pattern) — remove `unique` and they fail loudly.

## H2 — the release-on-error wiring + `selfBudgeted` skip were untested
`budgetedHandler` decides *when* to release an idempotency claim (the `!idempotencyBusy` guard that stops a losing twin from deleting the winner's claim — re-opening M2) and *whether* to charge a `selfBudgeted` tool (M7). No test drove the wrapper. New [`mcp/server.test.js`](backend/src/mcp/server.test.js) exercises the real wrapper: per-request cap, call budget, anon fail-closed, mutation charge/skip, and all four release cases.

## M11 — `bustUser` + eviction were claimed-covered but weren't
`resultCache.bustUser` was entirely untested (the suite literally punted with a comment), and the evict-oldest-half branches in `resultCache` + `mutationBudget` were asserted-in-commit-message but not in code — a revert to `.clear()` (the original L-18 DoS) stayed green. Added exact-needle `bustUser` tests + eviction tests for both maps.

## Docker-compose impact
None.