### PR TITLE
perf(mcp): debounce the per-user cache bust (M10)

### DIFF
--- a/backend/src/services/audit.js
+++ b/backend/src/services/audit.js
@@ -15,7 +15,24 @@ const STATS_CHANGED_PREFIXES = ['bottle.', 'cellar.'];
 // M3). Lazy-required so these MCP modules stay off audit's load path (they pull
 // the tool registry, whose search dep is ESM-only and unparseable by jest —
 // the #702 failure mode). Never throws: a cache miss must not fail a mutation.
+//
+// Debounced per user (MCP-audit M10): a bulk_add of 24 bottles fires 24 bottle.
+// audits within milliseconds, each doing two full Map scans (up to ~4000 string
+// compares) for the SAME user — the first bust already cleared everything, the
+// rest are pure waste. Collapse repeats within a short window; the cache already
+// tolerates a 60s stale window, so a sub-window skip can never serve stale data
+// that a synchronous batch would have re-populated (reads don't run mid-batch).
+const lastBustAt = new Map(); // userId -> ms
+const BUST_DEBOUNCE_MS = 250;
 function bustMcpCaches(userId) {
+  if (!userId) return;
+  const key = String(userId);
+  const now = Date.now();
+  const prev = lastBustAt.get(key);
+  if (prev && now - prev < BUST_DEBOUNCE_MS) return; // already busted this instant
+  // Bounded: drop the oldest half rather than grow unbounded.
+  if (lastBustAt.size >= 5000) { let drop = 2500; for (const k of lastBustAt.keys()) { if (drop-- <= 0) break; lastBustAt.delete(k); } }
+  lastBustAt.set(key, now);
   try {
     require('../mcp/tools/stats').bustStats(userId);
     require('../mcp/resultCache').bustUser(userId);


### PR DESCRIPTION
MCP non-security audit — the clean performance win. Full backend suite green (1995) in node:20-alpine.

## M10 — `bulk_add` cache-bust storm
A 24-bottle `bulk_add` fired 24 `bottle.*` audit events within milliseconds, each running `bustMcpCaches` → two full Map scans (up to ~4000 string compares) for the **same** user — ~96k comparisons per batch, all but the first redundant. Debounced per user within a 250 ms window: the cache still busts once per burst, and since it already tolerates a 60 s stale window (and reads don't run mid-batch), a sub-window skip can never serve stale data. Bounded map, oldest-half eviction.

## Docker-compose impact
None.

## Note on the other performance findings
The audit's other perf items are **real refactors, not clean wins**, so they're deferred for their own careful change (see the audit doc): **H4** (portfolio load-all) needs a status-aware pre-aggregation — `case_journey` genuinely needs consumed bottles, and `cellar_stats` needs the country/region/grape populate, so neither can just be trimmed; it only bites very large cellars today. **M8** (per-user MCP rate-limit keying) is a hosted-availability design change (a dedicated post-auth limiter). **M12** (buildServer per-request) needs a scope-keyed server/descriptor cache that respects the session role-freeze.