### PR TITLE
refactor(bottles,racks): ONE shared write path for REST and MCP (MCP-audit H1)

### DIFF
--- a/backend/src/mcp/tools/write.js
+++ b/backend/src/mcp/tools/write.js
@@ -20,7 +20,7 @@ const { registerTool } = require('../registry');
 // services/search → the ESM-only meilisearch package, which jest cannot parse
 // — a top-level require here would break every suite that loads the tool
 // registry (the #702 failure mode).
-const { addBottle, updateBottleFields, UPDATABLE_FIELDS } = require('../../services/bottleOps');
+const { addBottle, updateBottleFields } = require('../../services/bottleOps');
 const { logAudit } = require('../../services/audit');
 const { isValidId } = require('../../utils/validation');
 const {
@@ -198,11 +198,17 @@ registerTool({
   },
 });
 
+// The AI-useful subset of the shared service's UPDATABLE_FIELDS — the web
+// edit form covers the rest (vintage, bottle size, purchase metadata). Named
+// here, next to the inputSchema it must mirror, so description and schema
+// can't drift apart.
+const MCP_UPDATE_PARAMS = ['price', 'currency', 'notes', 'occasion', 'rating', 'rating_scale', 'drink_from', 'drink_to'];
+
 registerTool({
   name: 'update_bottle',
   title: 'Update a bottle (price, notes, rating, drink window, occasion)',
   description:
-    `Partially updates one bottle. Updatable: ${UPDATABLE_FIELDS.join(', ')} (snake_case params). Only send the ` +
+    `Partially updates one bottle. Updatable: ${MCP_UPDATE_PARAMS.join(', ')}. Only send the ` +
     'fields to change; confirm the change with the user first. Reversible via undo_last.',
   scope: 'write',
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },

--- a/backend/src/mcp/wineListTools.test.js
+++ b/backend/src/mcp/wineListTools.test.js
@@ -14,7 +14,7 @@ jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
 // revert.js and tools/write.js top-require bottleOps (which pulls the search/
 // meili chain) — mock the full surface they read at load, same as
-// sommTools.test.js (write.js joins UPDATABLE_FIELDS into its description).
+// sommTools.test.js.
 jest.mock('../services/bottleOps', () => ({
   consumeBottle: jest.fn(), restoreBottle: jest.fn(), removeFromRacks: jest.fn(),
   RESTORE_WINDOW_MS: 2 * 24 * 60 * 60 * 1000,

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -13,27 +13,23 @@ const BottleImage = require('../models/BottleImage');
 const WineRequest = require('../models/WineRequest');
 const { getCellarRole } = require('../utils/cellarAccess');
 const { logAudit } = require('../services/audit');
-const { getOrCreateDailySnapshot, getSnapshotForDate } = require('../utils/exchangeRates');
+const { getSnapshotForDate } = require('../utils/exchangeRates');
 const { resolveRating } = require('../utils/ratingUtils');
-const { embedSinglePair } = require('../services/embeddingJob');
-const { enrichWineById } = require('../services/enrichmentJob');
 const { CONSUMED_STATUSES, WINE_POPULATE, WINE_POPULATE_LIST } = require('../config/constants');
-const { resolveRestockAlerts } = require('../services/restockChecker');
 const { unlinkImageFiles } = require('../services/imageProcessor');
 const { gatherPriceWarnings } = require('../services/priceWarnings');
 const { getCurrentRelease } = require('../services/communityPrice');
-const { stripHtml, isSafeUrl, escapeRegex } = require('../utils/sanitize');
-const { parseAndValidateVintage, parseDrinkYear } = require('../utils/validation');
-const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
+const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { toNormalized } = require('../utils/ratingUtils');
 const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
-const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
 const { parsePagination } = require('../utils/pagination');
 const mongoose = require('mongoose');
 const searchService = require('../services/search');
-// consume/restore logic + rack-slot freeing live in the shared service so the
-// REST routes and the MCP tools can never drift (plan §7).
-const { consumeBottle, restoreBottle, removeFromRacks, removeBottleCascade } = require('../services/bottleOps');
+// add/update/consume/restore/remove logic + rack-slot freeing live in the
+// shared service so the REST routes and the MCP tools can never drift (§7).
+const {
+  addBottle, updateBottleFields, consumeBottle, restoreBottle, removeFromRacks, removeBottleCascade,
+} = require('../services/bottleOps');
 const { moveBottleToCellar } = require('../services/rackOps');
 
 const router = express.Router();
@@ -347,76 +343,16 @@ router.get('/', async (req, res) => {
 // (consume, pour, move, arrange, edit, browse). "Sign up to add your bottles."
 router.post('/', requireNonDemo, async (req, res) => {
   try {
-    const {
-      cellar,
-      wineDefinition,
-      vintage,
-      price,
-      currency,
-      bottleSize,
-      purchaseDate,
-      purchaseLocation,
-      purchaseUrl,
-      location,
-      notes,
-      occasion,
-      rating,
-      ratingScale,
-      drinkFrom,
-      drinkTo,
-      // Migration helpers — let users backdate bottles or add directly to history
-      dateAdded,
-      addToHistory,
-      consumedAt,
-      consumedReason,
-      consumedNote,
-      consumedRating,
-      consumedRatingScale
-    } = req.body;
+    const { cellar, wineDefinition, price, currency } = req.body;
 
     if (!cellar || !wineDefinition) {
       return res.status(400).json({ error: 'Cellar and wine definition are required' });
     }
 
-    const vintageCheck = parseAndValidateVintage(vintage);
-    if (!vintageCheck.ok) return res.status(400).json({ error: vintageCheck.error });
-    const canonicalVintage = vintageCheck.value;
-
-    if (purchaseUrl) {
-      if (purchaseUrl.length > 2048) return res.status(400).json({ error: 'purchaseUrl is too long (max 2048 characters)' });
-      if (!isSafeUrl(purchaseUrl)) return res.status(400).json({ error: 'purchaseUrl must be a valid http or https URL' });
-    }
-    if (notes && notes.length > 5000) return res.status(400).json({ error: 'Notes are too long (max 5000 characters)' });
-    if (occasion && occasion.length > 500) return res.status(400).json({ error: 'Occasion is too long (max 500 characters)' });
-    if (location && location.length > 500) return res.status(400).json({ error: 'Location is too long (max 500 characters)' });
-    if (purchaseLocation && purchaseLocation.length > 500) return res.status(400).json({ error: 'Purchase location is too long (max 500 characters)' });
-
-    const { rating: resolvedRating, ratingScale: resolvedRatingScale, error: ratingError } = resolveRating(rating, ratingScale);
-    if (ratingError) return res.status(400).json({ error: ratingError });
-
-    // Personal per-bottle drink window — explicitly provided invalid values
-    // are a 400 (unlike the import pipeline, which drops them silently).
-    const drinkFromCheck = parseDrinkYear(drinkFrom, 'drinkFrom');
-    if (!drinkFromCheck.ok) return res.status(400).json({ error: drinkFromCheck.error });
-    const drinkToCheck = parseDrinkYear(drinkTo, 'drinkTo');
-    if (!drinkToCheck.ok) return res.status(400).json({ error: drinkToCheck.error });
-    if (drinkFromCheck.value !== undefined && drinkToCheck.value !== undefined && drinkFromCheck.value > drinkToCheck.value) {
-      return res.status(400).json({ error: 'drinkFrom cannot be after drinkTo' });
-    }
-
-    // Validate add-to-history fields
-    if (addToHistory) {
-      if (consumedReason && !CONSUMED_STATUSES.includes(consumedReason)) {
-        return res.status(400).json({ error: 'Invalid consumed reason' });
-      }
-    }
-    const { rating: resolvedConsumedRating, ratingScale: resolvedConsumedScale, error: consumeRatingError } =
-      addToHistory ? resolveRating(consumedRating, consumedRatingScale) : { rating: undefined, ratingScale: undefined, error: null };
-    if (consumeRatingError) return res.status(400).json({ error: consumeRatingError });
-
-    // Verify user has editor/owner access to this cellar. Soft-deleted cellars
-    // are rejected too — a bottle added there would be invisible everywhere
-    // (all cellar lists filter deletedAt) and effectively lost.
+    // Access + existence checks stay on the route — the shared service takes
+    // ACCESS-CHECKED docs (same contract as the MCP tools). Soft-deleted
+    // cellars are rejected too: a bottle added there would be invisible
+    // everywhere (all cellar lists filter deletedAt) and effectively lost.
     if (!mongoose.isValidObjectId(cellar)) {
       return res.status(400).json({ error: 'Invalid cellar ID' });
     }
@@ -428,8 +364,6 @@ router.post('/', requireNonDemo, async (req, res) => {
     if (!role || role === 'viewer') {
       return res.status(403).json({ error: 'Not authorized to add bottles to this cellar' });
     }
-
-    // Verify wine definition exists
     if (!mongoose.isValidObjectId(wineDefinition)) {
       return res.status(400).json({ error: 'Invalid wine definition ID' });
     }
@@ -438,90 +372,18 @@ router.post('/', requireNonDemo, async (req, res) => {
       return res.status(404).json({ error: 'Wine definition not found' });
     }
 
-    // Ensure today's rate snapshot exists so historical conversion works later.
-    // Non-fatal: price still saves if the API call fails.
-    const priceSetAt = (price !== undefined && price !== null && price !== '')
-      ? new Date()
-      : undefined;
-    if (priceSetAt) await getOrCreateDailySnapshot();
-
-    // Bottle always belongs to the cellar owner (clean ownership model)
-    const bottle = new Bottle({
-      cellar,
-      user: cellarDoc.user,
-      wineDefinition,
-      vintage: canonicalVintage,
-      price,
-      currency: currency || 'USD',
-      priceSetAt,
-      bottleSize: normalizeBottleSize(bottleSize) || DEFAULT_SIZE,
-      purchaseDate: purchaseDate || new Date(),
-      purchaseLocation: stripHtml(purchaseLocation),
-      purchaseUrl,
-      location: stripHtml(location),
-      notes: stripHtml(notes),
-      occasion: stripHtml(occasion),
-      rating: resolvedRating,
-      ratingScale: resolvedRatingScale,
-      drinkFrom: drinkFromCheck.value,
-      drinkTo: drinkToCheck.value
-    });
-
-    // Allow backdating the "added" date for cellar migration
-    if (dateAdded) bottle.createdAt = new Date(dateAdded);
-
-    // Seed the cellar journey: the bottle enters this cellar at its added date.
-    bottle.addedToCellarAt = bottle.createdAt;
-    bottle.cellarHistory = [{ cellar: cellarDoc._id, cellarName: cellarDoc.name, enteredAt: bottle.createdAt }];
-
-    // Allow creating bottles directly as consumed (add to history)
-    if (addToHistory) {
-      const reason = consumedReason || 'drank';
-      bottle.status = reason;
-      bottle.consumedReason = reason;
-      bottle.consumedAt = consumedAt ? new Date(consumedAt) : new Date();
-      if (consumedNote) bottle.consumedNote = stripHtml(consumedNote);
-      if (resolvedConsumedRating !== undefined) {
-        bottle.consumedRating = resolvedConsumedRating;
-        bottle.consumedRatingScale = resolvedConsumedScale;
-      }
-    }
-
-    await bottle.save();
+    // ONE shared implementation with the MCP add_bottle tool (plan §7):
+    // validation, defaults, priceSetAt + FX snapshot, journey seed, migration
+    // helpers (dateAdded / addToHistory), indexing, vintage-profile seed,
+    // audit and the gated AI side effects all live in bottleOps.addBottle.
+    const result = await addBottle(cellarDoc, wineDoc, req.body, req);
+    if (result.error) return res.status(result.error.status).json({ error: result.error.message });
+    const { bottle } = result;
     await bottle.populate(WINE_POPULATE);
 
-    // Index in Meilisearch (fire-and-forget). Consumed ("add to history")
-    // bottles ARE indexed too — the History tab's search/filter path queries
-    // Meili with a consumed status filter, so skipping them made them silently
-    // vanish from filtered History (grand-audit H3). The index carries status.
-    searchService.indexBottle(bottle._id);
-
-    // Seed the sommelier maturity queue for this wine+vintage (no-op for
-    // "Unknown"; NV is included). Shared by every add/import path.
-    await ensurePendingVintageProfile(wineDoc._id, canonicalVintage);
-
-    logAudit(req, addToHistory ? 'bottle.addToHistory' : 'bottle.add',
-      { type: 'bottle', id: bottle._id, cellarId: cellarDoc._id },
-      { wineName: bottle.wineDefinition?.name, vintage: bottle.vintage }
-    );
-
-    // Fire-and-forget: embed this (wine, vintage) pair for AI chat
-    embedSinglePair(wineDefinition, bottle.vintage).catch(err => console.error('Failed to embed wine-vintage pair after bottle creation:', err.message));
-
-    // Fire-and-forget: if this wine has no AI tasting profile yet (e.g. a brand-
-    // new wine the user just created), generate one — which also re-embeds the
-    // wine so Qdrant carries the taste data. No-op if already enriched / a batch
-    // enrichment job is running / AI isn't configured.
-    // (Demo accounts never reach this route — requireNonDemo blocks bottle-add —
-    // so no demo AI/Voyage spend occurs here.)
-    enrichWineById(wineDefinition, { budgetUserId: req.user.id }).catch(() => {});
-
-    // Fire-and-forget: auto-resolve any restock alerts for this wine
-    resolveRestockAlerts(req.user.id, wineDefinition, bottle._id).catch(() => {});
-
-    // Non-blocking sanity warnings on the entered price. Surfaced in the
-    // response so the form can highlight a likely mistake (100×, cents-as-
-    // units, etc.) without rejecting the save. See utils/priceValidation.
+    // Non-blocking sanity warnings on the entered price — a REST-only response
+    // affordance (the add form highlights a likely mistake — 100×, cents-as-
+    // units, etc. — without rejecting the save). See utils/priceValidation.
     let priceWarnings = [];
     if (typeof price === 'number' && price > 0) {
       try {
@@ -530,7 +392,7 @@ router.post('/', requireNonDemo, async (req, res) => {
           currency: currency || 'USD',
           userId: cellarDoc.user,
           wineDefinitionId: wineDefinition,
-          vintage: canonicalVintage,
+          vintage: bottle.vintage,
         });
       } catch (err) {
         console.warn('Price-warning gather failed (non-fatal):', err.message);
@@ -539,9 +401,6 @@ router.post('/', requireNonDemo, async (req, res) => {
 
     res.status(201).json({ bottle, priceWarnings });
   } catch (error) {
-    if (error.name === 'ValidationError') {
-      return res.status(400).json({ error: error.message });
-    }
     console.error('Create bottle error:', error);
     res.status(500).json({ error: 'Failed to create bottle' });
   }
@@ -612,146 +471,17 @@ router.put('/:id', requireBottleAccess('editor'), async (req, res) => {
   try {
     const { bottle } = req;
 
-    if (req.body.purchaseUrl) {
-      if (req.body.purchaseUrl.length > 2048) return res.status(400).json({ error: 'purchaseUrl is too long (max 2048 characters)' });
-      if (!isSafeUrl(req.body.purchaseUrl)) return res.status(400).json({ error: 'purchaseUrl must be a valid http or https URL' });
-    }
-    if (req.body.notes && req.body.notes.length > 5000) return res.status(400).json({ error: 'Notes are too long (max 5000 characters)' });
-    if (req.body.occasion && req.body.occasion.length > 500) return res.status(400).json({ error: 'Occasion is too long (max 500 characters)' });
-    if (req.body.location && req.body.location.length > 500) return res.status(400).json({ error: 'Location is too long (max 500 characters)' });
-    if (req.body.purchaseLocation && req.body.purchaseLocation.length > 500) return res.status(400).json({ error: 'Purchase location is too long (max 500 characters)' });
+    // ONE shared implementation with the MCP update_bottle tool (plan §7):
+    // validation, vintage/size coercion, change detection, priceSetAt
+    // anchoring, notifier-marker reset, re-index, vintage re-embed and the
+    // { field: { from, to } } audit all live in bottleOps.updateBottleFields.
+    // VersionError → 409 and ValidationError → 400 come back as { error }.
+    const result = await updateBottleFields(bottle, req.body, req);
+    if (result.error) return res.status(result.error.status).json({ error: result.error.message });
 
-    // Coerce vintage to its canonical form (or reject) before the generic
-    // field-diff loop assigns it onto the bottle.
-    if ('vintage' in req.body) {
-      const vintageCheck = parseAndValidateVintage(req.body.vintage);
-      if (!vintageCheck.ok) return res.status(400).json({ error: vintageCheck.error });
-      req.body.vintage = vintageCheck.value;
-    }
-
-    // Canonicalize bottle size on the way in (e.g. '1.5L (Magnum)' → '1500ml').
-    if (req.body.bottleSize !== undefined) {
-      req.body.bottleSize = normalizeBottleSize(req.body.bottleSize) || DEFAULT_SIZE;
-    }
-
-    // Validate the personal drink-window years before the generic field-diff
-    // loop assigns them. Explicitly provided invalid values → 400; null/''
-    // clears the field. The from<=to check uses effective values so a partial
-    // update can't invert a window against the bottle's stored other half.
-    for (const field of ['drinkFrom', 'drinkTo']) {
-      if (field in req.body) {
-        const check = parseDrinkYear(req.body[field], field);
-        if (!check.ok) return res.status(400).json({ error: check.error });
-        req.body[field] = check.value ?? null;
-      }
-    }
-    const effDrinkFrom = 'drinkFrom' in req.body ? req.body.drinkFrom : bottle.drinkFrom;
-    const effDrinkTo = 'drinkTo' in req.body ? req.body.drinkTo : bottle.drinkTo;
-    if (effDrinkFrom != null && effDrinkTo != null && effDrinkFrom > effDrinkTo) {
-      return res.status(400).json({ error: 'drinkFrom cannot be after drinkTo' });
-    }
-
-    // Update allowed fields — diff old vs new for the audit log
-    const updateFields = [
-      'vintage', 'price', 'currency', 'bottleSize',
-      'purchaseDate', 'purchaseLocation', 'purchaseUrl',
-      'location', 'notes', 'occasion', 'rating', 'ratingScale',
-      'drinkFrom', 'drinkTo'
-    ];
-
-    // Normalize a value to a comparable string (handles Date objects vs ISO strings)
-    const norm = v => {
-      if (v === null || v === undefined || v === '') return '';
-      if (v instanceof Date) return v.toISOString().slice(0, 10);
-      if (typeof v === 'string' && /^\d{4}-\d{2}-\d{2}/.test(v)) {
-        try { return new Date(v).toISOString().slice(0, 10); } catch { return v; }
-      }
-      return String(v);
-    };
-
-    // A scale change without a rating value would leave the stored rating
-    // meaningless on the new scale (e.g. a 4/5 persisted as 4 on the 100
-    // scale, later clamped to 0 by toNormalized) — require both together.
-    if ('ratingScale' in req.body && !('rating' in req.body) && bottle.rating != null) {
-      return res.status(400).json({ error: 'Send rating together with ratingScale when changing the rating scale' });
-    }
-
-    const htmlFields = new Set(['purchaseLocation', 'location', 'notes', 'occasion']);
-    const changes = {};
-    updateFields.forEach(field => {
-      if (req.body[field] !== undefined) {
-        const oldVal = bottle[field];
-        const rawVal = req.body[field];
-        const newVal = htmlFields.has(field) ? stripHtml(rawVal) : rawVal;
-        if (norm(oldVal) !== norm(newVal)) {
-          changes[field] = { from: oldVal ?? null, to: newVal !== '' ? newVal : null };
-        }
-        bottle[field] = newVal;
-      }
-    });
-
-    // Validate and coerce rating if it was updated
-    if ('rating' in req.body) {
-      const { rating: r, ratingScale: rs, error: ratingError } = resolveRating(req.body.rating, bottle.ratingScale);
-      if (ratingError) return res.status(400).json({ error: ratingError });
-      bottle.rating = r;
-      bottle.ratingScale = rs;
-    }
-
-    // Re-anchor the price date whenever price or currency is being updated,
-    // and ensure today's rate snapshot exists for future lookups.
-    if ('price' in req.body || 'currency' in req.body) {
-      if (bottle.price !== null && bottle.price !== undefined) {
-        bottle.priceSetAt = new Date();
-        await getOrCreateDailySnapshot();
-      } else {
-        bottle.priceSetAt = undefined;
-      }
-    }
-
-    // A changed personal drink window invalidates the drink-window notifier's
-    // "already notified" marker: the notifier only rewrites the marker on a
-    // notifiable transition, so a stale status (e.g. 'peak' from the old window)
-    // would permanently suppress the alert for the NEW window (e.g. drinkFrom
-    // pushed out to 2030 → not-ready now, but 'peak' marker blocks the 2030
-    // peak alert forever). Clear it so the next notifier run re-evaluates from a
-    // clean slate. Only when a window bound actually changed (changes[field] is
-    // set only on a real value diff).
-    if (changes.drinkFrom || changes.drinkTo) {
-      bottle.drinkWindowNotifiedStatus = null;
-      bottle.drinkWindowNotifiedAt = null;
-    }
-
-    await bottle.save();
     await bottle.populate(WINE_POPULATE);
-
-    // Re-index in Meilisearch (fire-and-forget)
-    searchService.indexBottle(bottle._id);
-
-    if (Object.keys(changes).length > 0) {
-      logAudit(req, 'bottle.update',
-        { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
-        { changes }
-      );
-    }
-
-    // If vintage changed, the old (wine, oldVintage) embedding is still in Qdrant
-    // but won't match this bottle anymore (user changed the year). Embed the new pair.
-    // Skipped for demo accounts: a novel year misses the embedding cache and would
-    // fire a paid Voyage call, and a demo's ephemeral edits never need Qdrant
-    // coverage — keeps demo AI/Voyage spend at exactly zero.
-    if (changes.vintage && !req.user.isDemo) {
-      embedSinglePair(bottle.wineDefinition._id || bottle.wineDefinition, bottle.vintage).catch(err => console.error('Failed to embed wine-vintage pair after vintage update:', err.message));
-    }
-
     res.json({ bottle });
   } catch (error) {
-    if (error.name === 'VersionError') {
-      return res.status(409).json({ error: 'This bottle was modified by another request. Please refresh and try again.' });
-    }
-    if (error.name === 'ValidationError') {
-      return res.status(400).json({ error: error.message });
-    }
     console.error('Update bottle error:', error);
     res.status(500).json({ error: 'Failed to update bottle' });
   }

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -7,9 +7,9 @@ const Cellar = require('../models/Cellar');
 const Bottle = require('../models/Bottle');
 const CellarLayout = require('../models/CellarLayout');
 const { getCellarRole } = require('../utils/cellarAccess');
-const { getMaxPosition } = require('../utils/rackGeometry');
+const { getMaxPosition, validateDoubleHeightRows } = require('../utils/rackGeometry');
 const {
-  placeBottleInRack, clearRackSlot,
+  createGridRack, placeBottleInRack, clearRackSlot,
   buildAnnotatedEntries, validateArrangementTarget, applyArrangement,
 } = require('../services/rackOps');
 const { ARRANGE_STRATEGIES, buildArrangePlan } = require('../utils/rackArrange');
@@ -43,38 +43,9 @@ async function withMaturity(rackOrRacks) {
   return Array.isArray(rackOrRacks) ? out : out[0];
 }
 
-/**
- * Validate typeConfig.doubleHeightRows: grid racks (non-modular) only,
- * entries must be integers in [1, rows].
- *
- * POSITION NUMBERING CONTRACT (double-height rows): the base grid keeps
- * positions 1..rows*cols row-major EXACTLY as a plain grid — existing
- * bottles never move. Top-layer positions are APPENDED after rows*cols:
- * iterate valid double-height rows in ascending row order, each contributing
- * cols-1 positions left-to-right. Example 4x6 grid with doubleHeightRows
- * [2]: base 1..24 unchanged, top layer of row 2 = positions 25..29.
- * (The capacity math lives in utils/rackGeometry.js; the resize guard below
- * therefore also catches removing a double row while top-layer bottles are
- * still placed.)
- *
- * @returns {string|null} error message, or null when valid
- */
-function validateDoubleHeightRows(typeConfig, effectiveType, effectiveRows, effectiveModular) {
-  const dhr = typeConfig?.doubleHeightRows;
-  if (dhr === undefined || dhr === null) return null;
-  if (effectiveModular || (effectiveType || 'grid') !== 'grid') {
-    return 'Double-height rows are only supported on grid racks';
-  }
-  if (!Array.isArray(dhr)) {
-    return 'doubleHeightRows must be an array of row numbers';
-  }
-  for (const r of dhr) {
-    if (!Number.isInteger(r) || r < 1 || r > effectiveRows) {
-      return `doubleHeightRows entries must be whole row numbers between 1 and ${effectiveRows}`;
-    }
-  }
-  return null;
-}
+// typeConfig.doubleHeightRows request validation lives in utils/rackGeometry
+// (validateDoubleHeightRows) — shared with services/rackOps.createGridRack so
+// the create path and the update route below can't drift.
 
 // GET /api/racks/nfc/:id  — resolve a rack ID to its cellar (for NFC tag redirect)
 // Requires auth so only logged-in users can follow NFC links.
@@ -124,9 +95,10 @@ router.get('/', requireCellarAccess('viewer'), async (req, res) => {
 router.post('/', requireCellarAccess('editor'), async (req, res) => {
   try {
     const { name, rows, cols, type, typeConfig, isModular, modules } = req.body;
-    if (!name) return res.status(400).json({ error: 'cellar and name are required' });
+    if (!name) return res.status(400).json({ error: 'Rack name is required' });
 
-    // Validate modular rack modules
+    // Modular racks are a REST-only route path (no MCP twin to drift against;
+    // the read tools treat them specially).
     if (isModular && modules) {
       if (!Array.isArray(modules) || modules.length === 0) {
         return res.status(400).json({ error: 'Modular racks must have at least one module' });
@@ -139,40 +111,27 @@ router.post('/', requireCellarAccess('editor'), async (req, res) => {
           return res.status(400).json({ error: `Invalid module type: ${m.type}` });
         }
       }
-    } else if (type && !RACK_TYPES.includes(type)) {
-      return res.status(400).json({ error: `Invalid rack type. Must be one of: ${RACK_TYPES.join(', ')}` });
+      // Racks are owned by the cellar owner
+      const rack = new Rack({
+        cellar: req.cellar._id,
+        user: req.cellar.user,
+        name,
+        isModular: true,
+        modules,
+      });
+      await rack.save();
+      // cellarId so this rack appears in the cellar's audit page (which
+      // filters on resource.cellarId) — grand-audit M6.
+      logAudit(req, 'rack.create', { type: 'rack', id: rack._id, cellarId: rack.cellar }, { name: rack.name });
+      return res.status(201).json({ rack });
     }
 
-    // Racks are owned by the cellar owner
-    const rackData = {
-      cellar: req.cellar._id,
-      user: req.cellar.user,
-      name,
-    };
-
-    if (isModular && modules) {
-      rackData.isModular = true;
-      rackData.modules = modules;
-    } else {
-      rackData.type = type || 'grid';
-      rackData.rows = rows || 4;
-      rackData.cols = cols || 8;
-      if (typeConfig) {
-        const dhrError = validateDoubleHeightRows(typeConfig, rackData.type, rackData.rows, false);
-        if (dhrError) return res.status(400).json({ error: dhrError });
-        rackData.typeConfig = typeConfig;
-      }
-    }
-
-    const rack = new Rack(rackData);
-
-    await rack.save();
-    // cellarId so this rack appears in the cellar's audit page (which filters
-    // on resource.cellarId) — web-created racks were invisible there while
-    // MCP-created ones showed, since rackOps.createGridRack already records it
-    // (grand-audit M6). name in detail matches the MCP surface too.
-    logAudit(req, 'rack.create', { type: 'rack', id: rack._id, cellarId: rack.cellar }, { name: rack.name });
-    res.status(201).json({ rack });
+    // Grid family: ONE shared implementation with the MCP create_rack tool
+    // (plan §7) — type/typeConfig validation, ownership, duplicate-name 409
+    // and the rack.create audit all live in rackOps.createGridRack.
+    const result = await createGridRack(req.cellar, { name, type, rows, cols, typeConfig }, req);
+    if (result.error) return res.status(result.error.status).json({ error: result.error.message });
+    res.status(201).json({ rack: result.rack });
   } catch (err) {
     if (err.code === 11000) return res.status(409).json({ error: 'A rack with that name already exists in this cellar' });
     if (err.name === 'ValidationError') return res.status(400).json({ error: err.message });

--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -136,19 +136,23 @@ async function restoreBottle(bottle, req) {
 
 /**
  * Create a bottle in an ACCESS-CHECKED cellar for an EXISTING registry wine —
- * the shared core of REST POST /api/bottles and the MCP add_bottle tool.
- * Mirrors the route's field handling exactly (validation helpers, caps,
- * priceSetAt anchoring, owner = cellar owner) and fires the same post-save
- * side effects, so the two surfaces cannot drift. The enrichment/embedding
- * calls inherit their internal kill-switch + per-user budget gates.
+ * the ONE implementation behind REST POST /api/bottles and the MCP add_bottle
+ * tool (the route delegates here; H1 of the 2026-07-17 MCP audit). Covers the
+ * full REST field surface including the migration helpers (dateAdded backdate,
+ * addToHistory + consumed-* fields) and fires the same post-save side effects.
+ * The enrichment/embedding calls inherit their internal kill-switch + per-user
+ * budget gates.
  *
  * Returns { error: { status, message } } | { bottle }.
  */
 async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
   const {
     vintage, price, currency, bottleSize,
-    purchaseDate, purchaseLocation, purchaseUrl,
+    purchaseDate, purchaseLocation, purchaseUrl, location,
     notes, occasion, rating, ratingScale, drinkFrom, drinkTo,
+    // Migration helpers — backdate the bottle, or add it directly to history.
+    dateAdded, addToHistory,
+    consumedAt, consumedReason, consumedNote, consumedRating, consumedRatingScale,
   } = fields;
 
   const parsedVintage = parseAndValidateVintage(vintage);
@@ -169,32 +173,58 @@ async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
   if (notes && (typeof notes !== 'string' || notes.length > 5000)) {
     return { error: { status: 400, message: 'Notes are too long (max 5000 characters)' } };
   }
-  const capped = [['occasion', occasion], ['purchaseLocation', purchaseLocation]];
-  for (const pair of capped) {
-    if (pair[1] && (typeof pair[1] !== 'string' || pair[1].length > 500)) {
-      return { error: { status: 400, message: pair[0] + ' is too long (max 500 characters)' } };
+  const capped = [
+    ['Occasion', occasion], ['Purchase location', purchaseLocation], ['Location', location],
+  ];
+  for (const [label, value] of capped) {
+    if (value && (typeof value !== 'string' || value.length > 500)) {
+      return { error: { status: 400, message: `${label} is too long (max 500 characters)` } };
     }
   }
-  if (purchaseUrl && (typeof purchaseUrl !== 'string' || purchaseUrl.length > 2048 || !isSafeUrl(purchaseUrl))) {
-    return { error: { status: 400, message: 'purchaseUrl is not a valid http(s) URL' } };
+  if (purchaseUrl) {
+    if (typeof purchaseUrl !== 'string' || purchaseUrl.length > 2048) {
+      return { error: { status: 400, message: 'purchaseUrl is too long (max 2048 characters)' } };
+    }
+    if (!isSafeUrl(purchaseUrl)) {
+      return { error: { status: 400, message: 'purchaseUrl must be a valid http or https URL' } };
+    }
   }
 
+  // Add-to-history: reason must be a consumed status; its rating resolves on
+  // its own scale, independent of the pre-drink rating above.
+  if (addToHistory && consumedReason && !CONSUMED_STATUSES.includes(consumedReason)) {
+    return { error: { status: 400, message: 'Invalid consumed reason' } };
+  }
+  const { rating: resolvedConsumedRating, ratingScale: resolvedConsumedScale, error: consumedRatingError } =
+    addToHistory
+      ? resolveRatingUtil(consumedRating, consumedRatingScale)
+      : { rating: undefined, ratingScale: undefined, error: null };
+  if (consumedRatingError) return { error: { status: 400, message: consumedRatingError } };
+
   const hasPrice = price !== undefined && price !== null && price !== '';
+  // Ensure today's FX snapshot exists BEFORE responding, so an immediate read
+  // of the new bottle can time-anchor its price. Non-fatal: the helper returns
+  // null (never throws) when the rates API is down.
+  if (hasPrice) await require('../utils/exchangeRates').getOrCreateDailySnapshot();
+
   const doc = {
     user: cellarDoc.user, // bottle owner = cellar owner, same as the REST route
     cellar: cellarDoc._id,
     wineDefinition: wineDoc._id,
     vintage: parsedVintage.value,
+    // Kept even without a price — the add form lets users pick their currency
+    // before (or without) entering a price; the schema default fills 'USD'.
+    currency: currency || 'USD',
     bottleSize: normalizeBottleSize(bottleSize) || DEFAULT_SIZE,
     purchaseDate: purchaseDate || new Date(), // REST defaults this too
   };
   if (hasPrice) {
     doc.price = price;
-    doc.currency = currency || 'USD';
     doc.priceSetAt = new Date();
   }
   if (purchaseLocation) doc.purchaseLocation = stripHtml(purchaseLocation);
   if (purchaseUrl) doc.purchaseUrl = purchaseUrl;
+  if (location) doc.location = stripHtml(location);
   if (notes) doc.notes = stripHtml(notes);
   if (occasion) doc.occasion = stripHtml(occasion);
   if (resolvedRating !== undefined) {
@@ -205,10 +235,23 @@ async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
   if (to.value !== undefined) doc.drinkTo = to.value;
 
   const bottle = new Bottle(doc);
-  // Seed the cellar journey exactly like the REST route: the bottle enters
-  // this cellar at its added date.
+  // Backdate BEFORE seeding the journey, which anchors on the added date.
+  if (dateAdded) bottle.createdAt = new Date(dateAdded);
+  // Seed the cellar journey: the bottle enters this cellar at its added date.
   bottle.addedToCellarAt = bottle.createdAt;
   bottle.cellarHistory = [{ cellar: cellarDoc._id, cellarName: cellarDoc.name, enteredAt: bottle.createdAt }];
+  // Migration helper: create the bottle directly as consumed history.
+  if (addToHistory) {
+    const reason = consumedReason || 'drank';
+    bottle.status = reason;
+    bottle.consumedReason = reason;
+    bottle.consumedAt = consumedAt ? new Date(consumedAt) : new Date();
+    if (consumedNote) bottle.consumedNote = stripHtml(consumedNote);
+    if (resolvedConsumedRating !== undefined) {
+      bottle.consumedRating = resolvedConsumedRating;
+      bottle.consumedRatingScale = resolvedConsumedScale;
+    }
+  }
   try {
     await bottle.save();
   } catch (err) {
@@ -216,7 +259,9 @@ async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
     throw err;
   }
 
-  // Same post-save side effects as the REST route, same order.
+  // Post-save side effects, one order for both surfaces. Consumed
+  // (add-to-history) bottles ARE indexed too — the History tab's search path
+  // filters on status at query time (grand-audit H3).
   require('./search').indexBottle(bottle._id);
   try {
     const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
@@ -225,12 +270,9 @@ async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
   // Include wineName so the Cellar Audit page shows what was added, matching
   // the REST POST /bottles audit (grand-audit M5 — AI-added bottles showed a
   // bare vintage with no wine name). wineDoc is the resolved registry wine.
-  logAudit(req, 'bottle.add',
+  logAudit(req, addToHistory ? 'bottle.addToHistory' : 'bottle.add',
     { type: 'bottle', id: bottle._id, cellarId: cellarDoc._id },
     { wineName: wineDoc.name, vintage: bottle.vintage });
-  if (hasPrice) {
-    require('../utils/exchangeRates').getOrCreateDailySnapshot().catch(() => {});
-  }
   // Fire-and-forget AI enrichment — both calls carry their own kill-switch /
   // per-user budget gates (embeddingJob: chatEnabled; enrichmentJob: tryDebitAi).
   const { embedSinglePair } = require('./embeddingJob');
@@ -243,18 +285,41 @@ async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
   return { bottle };
 }
 
-// Fields update_bottle may touch — the AI-useful subset of the REST PUT route.
-const UPDATABLE_FIELDS = ['price', 'currency', 'notes', 'occasion', 'rating', 'ratingScale', 'drinkFrom', 'drinkTo'];
+// Every field a bottle update may touch — ONE list for the REST PUT route and
+// the MCP update_bottle tool (whose schema exposes the AI-useful subset).
+const UPDATABLE_FIELDS = [
+  'vintage', 'price', 'currency', 'bottleSize',
+  'purchaseDate', 'purchaseLocation', 'purchaseUrl',
+  'location', 'notes', 'occasion', 'rating', 'ratingScale',
+  'drinkFrom', 'drinkTo',
+];
+
+// Normalize a value for change detection: Date objects and ISO-ish strings
+// compare by calendar day, and null/undefined/'' collapse to one "empty"
+// value — so the web form re-sending an unchanged field (it always sends the
+// FULL form) never records a phantom change.
+function normForCompare(v) {
+  if (v === null || v === undefined || v === '') return '';
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (typeof v === 'string' && /^\d{4}-\d{2}-\d{2}/.test(v)) {
+    try { return new Date(v).toISOString().slice(0, 10); } catch { return v; }
+  }
+  return String(v);
+}
 
 /**
- * Diff-based partial update of an access-checked bottle (MCP update_bottle).
- * Mirrors the REST PUT route's handling for the fields it covers: rating
- * resolution against the bottle's own scale, drink-window ordering +
- * notifier-marker reset, priceSetAt re-anchoring, HTML stripping, re-index,
- * bottle.update audit. Returns { error } | { bottle, changes, prev }.
+ * Diff-based partial update of an access-checked bottle — the ONE
+ * implementation behind REST PUT /api/bottles/:id and the MCP update_bottle
+ * tool (the route delegates here; H1 of the 2026-07-17 MCP audit). Handles
+ * the full REST field surface: vintage coercion (+ re-embed on change),
+ * bottle-size canonicalization, rating resolution against the bottle's own
+ * scale, drink-window ordering + notifier-marker reset, priceSetAt
+ * re-anchoring, HTML stripping, re-index, and the { field: { from, to } }
+ * audit shape CellarAudit renders.
+ * Returns { error } | { bottle, changes, prev }.
  */
 async function updateBottleFields(bottle, fields, req) {
-  fields = fields || {};
+  fields = { ...(fields || {}) }; // shallow copy — REST passes req.body
   const changes = {};
   const prev = {};
 
@@ -262,9 +327,32 @@ async function updateBottleFields(bottle, fields, req) {
       (typeof fields.notes !== 'string' || fields.notes.length > 5000)) {
     return { error: { status: 400, message: 'Notes are too long (max 5000 characters)' } };
   }
-  if (fields.occasion !== undefined && fields.occasion &&
-      (typeof fields.occasion !== 'string' || fields.occasion.length > 500)) {
-    return { error: { status: 400, message: 'occasion is too long (max 500 characters)' } };
+  const capped = [
+    ['Occasion', fields.occasion], ['Purchase location', fields.purchaseLocation], ['Location', fields.location],
+  ];
+  for (const [label, value] of capped) {
+    if (value && (typeof value !== 'string' || value.length > 500)) {
+      return { error: { status: 400, message: `${label} is too long (max 500 characters)` } };
+    }
+  }
+  if (fields.purchaseUrl) {
+    if (typeof fields.purchaseUrl !== 'string' || fields.purchaseUrl.length > 2048) {
+      return { error: { status: 400, message: 'purchaseUrl is too long (max 2048 characters)' } };
+    }
+    if (!isSafeUrl(fields.purchaseUrl)) {
+      return { error: { status: 400, message: 'purchaseUrl must be a valid http or https URL' } };
+    }
+  }
+
+  // Vintage: coerce to canonical form ('NV' / 'Unknown' / 'YYYY') or reject.
+  if (fields.vintage !== undefined) {
+    const p = parseAndValidateVintage(fields.vintage);
+    if (!p.ok) return { error: { status: 400, message: p.error } };
+    fields.vintage = p.value;
+  }
+  // Bottle size: canonicalize on the way in (e.g. '1.5L (Magnum)' → '1500ml').
+  if (fields.bottleSize !== undefined) {
+    fields.bottleSize = normalizeBottleSize(fields.bottleSize) || DEFAULT_SIZE;
   }
 
   // Drink window: validate the EFFECTIVE pair (new values overlaying current).
@@ -288,34 +376,40 @@ async function updateBottleFields(bottle, fields, req) {
     return { error: { status: 400, message: 'drinkFrom cannot be after drinkTo' } };
   }
 
-  if (fields.rating === null) {
+  if (fields.rating === null || fields.rating === '') {
     // Explicit clear — needed so undoing a rating-SET can restore "unrated"
-    // (resolveRating treats null as "no input" and would silently skip it,
+    // (resolveRating treats null/'' as "no input" and would silently skip it,
     // leaving the old rating stranded on a possibly-changed scale).
     // ratingScale may ride along (e.g. restoring the pre-update scale).
+    fields.rating = null;
   } else if (fields.rating !== undefined) {
     const scale = fields.ratingScale || bottle.ratingScale;
     const resolved = resolveRatingUtil(fields.rating, scale);
     if (resolved.error) return { error: { status: 400, message: resolved.error } };
     fields.rating = resolved.rating;
     fields.ratingScale = resolved.ratingScale;
-  } else if (fields.ratingScale !== undefined) {
-    return { error: { status: 400, message: 'ratingScale can only be changed together with rating' } };
+  } else if (fields.ratingScale !== undefined && bottle.rating != null) {
+    // A scale change without a rating value would leave the stored rating
+    // meaningless on the new scale (e.g. a 4/5 persisted as 4 on the 100
+    // scale, later clamped by toNormalized) — require both together. On an
+    // UNRATED bottle a scale-only change is harmless and allowed (the web
+    // form always sends the scale).
+    return { error: { status: 400, message: 'Send rating together with ratingScale when changing the rating scale' } };
   }
 
   const apply = (key, value) => {
-    const current = bottle[key] == null ? null : bottle[key];
-    const next = value == null ? null : value;
-    if (String(current) === String(next)) return;
+    if (normForCompare(bottle[key]) === normForCompare(value)) return;
     prev[key] = bottle[key] === undefined ? null : bottle[key];
     bottle[key] = value;
-    changes[key] = value == null ? null : value;
+    changes[key] = value === '' || value == null ? null : value;
   };
 
   for (const key of UPDATABLE_FIELDS) {
     if (fields[key] === undefined) continue;
     let value = fields[key];
-    if (key === 'notes' || key === 'occasion') value = value ? stripHtml(value) : value;
+    if (key === 'notes' || key === 'occasion' || key === 'purchaseLocation' || key === 'location') {
+      value = value ? stripHtml(value) : value;
+    }
     if (key === 'drinkFrom') value = fromYear;
     if (key === 'drinkTo') value = toYear;
     apply(key, value);
@@ -325,15 +419,18 @@ async function updateBottleFields(bottle, fields, req) {
     return { bottle, changes, prev };
   }
 
-  // Same semantics as the REST route: a price/currency touch re-anchors the
-  // price date (or clears it when the price itself is cleared); a drink-window
-  // change resets the notifier markers.
+  // A price/currency CHANGE re-anchors the price date (or clears it when the
+  // price itself is gone). Deliberately change-based, not presence-based: the
+  // web form re-sends every field on save, and a presence-based re-anchor
+  // moved the FX anchor date on every unrelated edit. The snapshot is awaited
+  // so an immediate read can time-anchor (non-fatal — returns null, never
+  // throws, when the rates API is down).
   if ('price' in changes || 'currency' in changes) {
-    if ('price' in changes && changes.price === null) {
-      bottle.priceSetAt = undefined;
-    } else {
+    if (bottle.price !== null && bottle.price !== undefined && bottle.price !== '') {
       bottle.priceSetAt = new Date();
-      require('../utils/exchangeRates').getOrCreateDailySnapshot().catch(() => {});
+      await require('../utils/exchangeRates').getOrCreateDailySnapshot();
+    } else {
+      bottle.priceSetAt = undefined;
     }
   }
   if ('drinkFrom' in changes || 'drinkTo' in changes) {
@@ -345,10 +442,20 @@ async function updateBottleFields(bottle, fields, req) {
     await bottle.save();
   } catch (err) {
     if (err?.name === 'ValidationError') return { error: { status: 400, message: err.message } };
-    if (err?.name === 'VersionError') return { error: { status: 409, message: 'The bottle was modified concurrently — retry.' } };
+    if (err?.name === 'VersionError') return { error: { status: 409, message: 'This bottle was modified by another request. Please refresh and try again.' } };
     throw err;
   }
   require('./search').indexBottle(bottle._id);
+  // Vintage changed: the old (wine, oldVintage) embedding is still in Qdrant
+  // but no longer matches this bottle — embed the new pair. Skipped for demo
+  // accounts (a novel year misses the cache and would fire a paid Voyage call).
+  if ('vintage' in changes && !req?.user?.isDemo) {
+    const wineId = bottle.wineDefinition && (bottle.wineDefinition._id || bottle.wineDefinition);
+    if (wineId) {
+      const { embedSinglePair } = require('./embeddingJob');
+      embedSinglePair(wineId, bottle.vintage).catch(() => {});
+    }
+  }
   // Audit in the SAME { field: { from, to } } shape the REST PUT /bottles/:id
   // route emits, so CellarAudit renders both surfaces identically (a bare
   // { field: newValue } here made the page crash when a value was cleared —

--- a/backend/src/services/bottleOps.test.js
+++ b/backend/src/services/bottleOps.test.js
@@ -134,6 +134,7 @@ const BottleModel = require('../models/Bottle');
 const BottleImage = require('../models/BottleImage');
 const { embedSinglePair } = require('./embeddingJob');
 const { enrichWineById } = require('./enrichmentJob');
+const { getOrCreateDailySnapshot } = require('../utils/exchangeRates');
 const { addBottle, updateBottleFields, removeBottleCascade } = require('./bottleOps');
 
 const CELLAR = { _id: 'c1', user: 'owner1', name: 'Main Cellar' };
@@ -172,6 +173,65 @@ describe('addBottle (real execution)', () => {
     const res = await addBottle(CELLAR, WINE, {}, REQ);
     expect(res.bottle.vintage).toBe('NV');
     expect(res.bottle.priceSetAt).toBeUndefined();
+  });
+
+  // ── REST-parity surface (POST /api/bottles delegates here — MCP-audit H1) ──
+
+  test('currency is kept even WITHOUT a price (the audit-proven drift), snapshot only when priced', async () => {
+    const res = await addBottle(CELLAR, WINE, { currency: 'EUR' }, REQ);
+    expect(res.bottle.currency).toBe('EUR');
+    expect(res.bottle.price).toBeUndefined();
+    expect(res.bottle.priceSetAt).toBeUndefined();
+    expect(getOrCreateDailySnapshot).not.toHaveBeenCalled();
+
+    await addBottle(CELLAR, WINE, { price: 25, currency: 'EUR' }, REQ);
+    expect(getOrCreateDailySnapshot).toHaveBeenCalledTimes(1); // awaited pre-save, REST parity
+  });
+
+  test('location is stored HTML-stripped and capped with the REST message', async () => {
+    const res = await addBottle(CELLAR, WINE, { location: 'Shelf <i>2</i>' }, REQ);
+    expect(res.bottle.location).toBe('Shelf 2');
+    const err = (await addBottle(CELLAR, WINE, { location: 'x'.repeat(501) }, REQ)).error;
+    expect(err.status).toBe(400);
+    expect(err.message).toBe('Location is too long (max 500 characters)');
+  });
+
+  test('purchaseUrl: too-long and non-http(s) each get their REST message', async () => {
+    const long = (await addBottle(CELLAR, WINE, { purchaseUrl: 'https://x.com/' + 'a'.repeat(2050) }, REQ)).error;
+    expect(long.message).toBe('purchaseUrl is too long (max 2048 characters)');
+    const unsafe = (await addBottle(CELLAR, WINE, { purchaseUrl: 'javascript:alert(1)' }, REQ)).error;
+    expect(unsafe.message).toBe('purchaseUrl must be a valid http or https URL');
+  });
+
+  test('dateAdded backdates createdAt AND the journey seed', async () => {
+    const res = await addBottle(CELLAR, WINE, { dateAdded: '2024-03-01' }, REQ);
+    expect(res.bottle.createdAt).toEqual(new Date('2024-03-01'));
+    expect(res.bottle.addedToCellarAt).toEqual(new Date('2024-03-01'));
+    expect(res.bottle.cellarHistory[0].enteredAt).toEqual(new Date('2024-03-01'));
+  });
+
+  test('addToHistory creates the bottle directly as consumed, with its own audit action', async () => {
+    const res = await addBottle(CELLAR, WINE, {
+      addToHistory: true, consumedReason: 'gifted', consumedAt: '2025-12-31',
+      consumedNote: 'to Anna <b>x</b>', consumedRating: 4, consumedRatingScale: '5',
+    }, REQ);
+    const b = res.bottle;
+    expect(b.status).toBe('gifted');
+    expect(b.consumedReason).toBe('gifted');
+    expect(b.consumedAt).toEqual(new Date('2025-12-31'));
+    expect(b.consumedNote).toBe('to Anna x');
+    expect(b.consumedRating).toBe(4);
+    expect(b.consumedRatingScale).toBe('5');
+    expect(logAudit).toHaveBeenCalledWith(REQ, 'bottle.addToHistory', expect.anything(),
+      { wineName: 'Barolo', vintage: 'NV' });
+  });
+
+  test('addToHistory defaults the reason to drank; rejects an invalid reason / rating', async () => {
+    const res = await addBottle(CELLAR, WINE, { addToHistory: true }, REQ);
+    expect(res.bottle.status).toBe('drank');
+    expect(res.bottle.consumedAt).toBeInstanceOf(Date);
+    expect((await addBottle(CELLAR, WINE, { addToHistory: true, consumedReason: 'evaporated' }, REQ)).error.status).toBe(400);
+    expect((await addBottle(CELLAR, WINE, { addToHistory: true, consumedRating: 9 }, REQ)).error.status).toBe(400);
   });
 });
 
@@ -230,6 +290,97 @@ describe('updateBottleFields (real execution)', () => {
     const res = await updateBottleFields(b, { price: 25 }, REQ);
     expect(res.changes).toEqual({});
     expect(b.save).not.toHaveBeenCalled();
+  });
+
+  // ── REST-parity surface (PUT /api/bottles/:id delegates here — MCP-audit H1) ──
+
+  test('vintage is canonicalized, audited, and re-embeds the new (wine, vintage) pair', async () => {
+    const b = liveBottle({ wineDefinition: 'w9' });
+    const res = await updateBottleFields(b, { vintage: 2021 }, REQ);
+    expect(res.error).toBeUndefined();
+    expect(b.vintage).toBe('2021');
+    expect(res.changes.vintage).toBe('2021');
+    expect(embedSinglePair).toHaveBeenCalledWith('w9', '2021');
+    expect((await updateBottleFields(liveBottle(), { vintage: '20x9' }, REQ)).error.status).toBe(400);
+  });
+
+  test('vintage re-embed is skipped for demo users (zero AI spend guarantee)', async () => {
+    const b = liveBottle({ wineDefinition: 'w9' });
+    await updateBottleFields(b, { vintage: 2022 }, { user: { id: 'd1', isDemo: true }, headers: {} });
+    expect(b.vintage).toBe('2022');
+    expect(embedSinglePair).not.toHaveBeenCalled();
+  });
+
+  test('bottleSize is canonicalized on the way in', async () => {
+    const b = liveBottle({ bottleSize: '750ml' });
+    const res = await updateBottleFields(b, { bottleSize: '1.5L (Magnum)' }, REQ);
+    expect(b.bottleSize).toBe('1500ml');
+    expect(res.changes.bottleSize).toBe('1500ml');
+  });
+
+  test('re-sending an unchanged purchaseDate (ISO string vs stored Date) records NO phantom change', async () => {
+    const b = liveBottle({ purchaseDate: new Date('2026-05-01T00:00:00Z') });
+    const res = await updateBottleFields(b, { purchaseDate: '2026-05-01' }, REQ);
+    expect(res.changes).toEqual({});
+    expect(b.save).not.toHaveBeenCalled();
+  });
+
+  test('a full-form re-send with no real edits does NOT move priceSetAt (the FX-anchor drift fix)', async () => {
+    const anchor = new Date('2026-01-01');
+    const b = liveBottle({
+      priceSetAt: anchor, bottleSize: '750ml', notes: 'x',
+      purchaseDate: new Date('2026-05-01T00:00:00Z'),
+    });
+    // Exactly what the web edit form sends on save: every field, changed or not.
+    const res = await updateBottleFields(b, {
+      vintage: '2019', price: 25, currency: 'USD', bottleSize: '750ml',
+      purchaseDate: '2026-05-01', purchaseLocation: '', purchaseUrl: '',
+      notes: 'x', occasion: '', rating: null, ratingScale: '5',
+      drinkFrom: null, drinkTo: null,
+    }, REQ);
+    expect(res.changes).toEqual({});
+    expect(b.priceSetAt).toBe(anchor);
+    expect(getOrCreateDailySnapshot).not.toHaveBeenCalled();
+    expect(b.save).not.toHaveBeenCalled();
+  });
+
+  test('ratingScale alone: 400 on a RATED bottle, allowed on an unrated one (web-form parity)', async () => {
+    const rated = liveBottle({ rating: 4, ratingScale: '5' });
+    const err = (await updateBottleFields(rated, { ratingScale: '100' }, REQ)).error;
+    expect(err.status).toBe(400);
+    expect(err.message).toBe('Send rating together with ratingScale when changing the rating scale');
+
+    const unrated = liveBottle();
+    const res = await updateBottleFields(unrated, { ratingScale: '100' }, REQ);
+    expect(res.error).toBeUndefined();
+    expect(res.changes.ratingScale).toBe('100');
+  });
+
+  test("rating '' clears exactly like rating null", async () => {
+    const b = liveBottle({ rating: 4 });
+    const res = await updateBottleFields(b, { rating: '' }, REQ);
+    expect(b.rating).toBeNull();
+    expect(res.changes.rating).toBeNull();
+    expect(res.prev.rating).toBe(4);
+  });
+
+  test('VersionError on save → 409 with the REST retry message (PUT delegates the mapping here)', async () => {
+    const b = liveBottle();
+    b.save.mockRejectedValue({ name: 'VersionError' });
+    const res = await updateBottleFields(b, { price: 30 }, REQ);
+    expect(res.error.status).toBe(409);
+    expect(res.error.message).toBe('This bottle was modified by another request. Please refresh and try again.');
+  });
+
+  test('purchaseUrl and location validate with the REST messages; location is HTML-stripped', async () => {
+    expect((await updateBottleFields(liveBottle(), { purchaseUrl: 'javascript:alert(1)' }, REQ)).error.message)
+      .toBe('purchaseUrl must be a valid http or https URL');
+    expect((await updateBottleFields(liveBottle(), { location: 'x'.repeat(501) }, REQ)).error.message)
+      .toBe('Location is too long (max 500 characters)');
+    const b = liveBottle();
+    const res = await updateBottleFields(b, { location: 'Rack <b>3</b>' }, REQ);
+    expect(b.location).toBe('Rack 3');
+    expect(res.changes.location).toBe('Rack 3');
   });
 });
 

--- a/backend/src/services/rackOps.js
+++ b/backend/src/services/rackOps.js
@@ -13,7 +13,7 @@ const Cellar = require('../models/Cellar');
 const Rack = require('../models/Rack');
 const Bottle = require('../models/Bottle');
 const { logAudit } = require('./audit');
-const { getMaxPosition } = require('../utils/rackGeometry');
+const { getMaxPosition, validateDoubleHeightRows } = require('../utils/rackGeometry');
 const { removeFromRacks } = require('./bottleOps');
 
 const { RACK_TYPES } = Rack;
@@ -38,11 +38,14 @@ async function createCellar({ name, description }, req) {
 }
 
 /**
- * Create a GRID-family rack in an access-checked cellar (v1: no modular racks
- * — that path has its own validation and the read tools treat it specially).
- * Mirrors the grid branch of POST /api/racks.
+ * Create a GRID-family rack in an access-checked cellar — the ONE
+ * implementation behind the grid branch of REST POST /api/racks and the MCP
+ * create_rack tool (the route delegates here; H1 of the 2026-07-17 MCP
+ * audit). Modular racks stay a REST-only route path (their validation has no
+ * MCP twin to drift against). typeConfig (double-height rows etc.) is
+ * accepted and validated; MCP simply doesn't pass it in v1.
  */
-async function createGridRack(cellarDoc, { name, type = 'grid', rows = 4, cols = 8 }, req) {
+async function createGridRack(cellarDoc, { name, type = 'grid', rows = 4, cols = 8, typeConfig }, req) {
   if (!name || !String(name).trim()) return { error: { status: 400, message: 'Rack name is required' } };
   if (type && !RACK_TYPES.includes(type)) {
     return { error: { status: 400, message: `Invalid rack type. Must be one of: ${RACK_TYPES.join(', ')}` } };
@@ -55,6 +58,11 @@ async function createGridRack(cellarDoc, { name, type = 'grid', rows = 4, cols =
     rows: rows || 4,
     cols: cols || 8,
   });
+  if (typeConfig) {
+    const dhrError = validateDoubleHeightRows(typeConfig, rack.type, rack.rows, false);
+    if (dhrError) return { error: { status: 400, message: dhrError } };
+    rack.typeConfig = typeConfig;
+  }
   try {
     await rack.save();
   } catch (err) {

--- a/backend/src/services/rackOps.test.js
+++ b/backend/src/services/rackOps.test.js
@@ -17,7 +17,12 @@ jest.mock('../models/Rack', () => {
 });
 jest.mock('../models/Bottle', () => ({ findOne: jest.fn(), findById: jest.fn() }));
 jest.mock('./audit', () => ({ logAudit: jest.fn() }));
-jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 32) }));
+jest.mock('../utils/rackGeometry', () => ({
+  getMaxPosition: jest.fn(() => 32),
+  // Real validator — createGridRack's typeConfig gate is part of the pinned
+  // contract (shared with the REST rack-update route).
+  validateDoubleHeightRows: jest.requireActual('../utils/rackGeometry').validateDoubleHeightRows,
+}));
 jest.mock('./bottleOps', () => ({ removeFromRacks: jest.fn().mockResolvedValue(undefined) }));
 jest.mock('./search', () => ({ indexBottle: jest.fn() }));
 
@@ -56,6 +61,28 @@ describe('createGridRack', () => {
     expect(res.rack.type).toBe('grid');
     expect(logAudit).toHaveBeenCalledWith(REQ, 'rack.create', expect.anything(), { name: 'A' });
     expect((await createGridRack(cellar, { name: 'B', type: 'modular' }, REQ)).error.status).toBe(400);
+  });
+
+  // typeConfig arrived with the REST POST /racks delegation (MCP-audit H1) —
+  // the grid branch of the route now runs through here, double-height rows
+  // included.
+  test('valid typeConfig.doubleHeightRows is stored; invalid rows / non-grid type are 400', async () => {
+    const res = await createGridRack(cellar, { name: 'DH', rows: 4, cols: 6, typeConfig: { doubleHeightRows: [2] } }, REQ);
+    expect(res.error).toBeUndefined();
+    expect(res.rack.typeConfig).toEqual({ doubleHeightRows: [2] });
+
+    const bad = await createGridRack(cellar, { name: 'DH2', rows: 4, cols: 6, typeConfig: { doubleHeightRows: [99] } }, REQ);
+    expect(bad.error.status).toBe(400);
+    expect(bad.error.message).toMatch(/between 1 and 4/);
+
+    const nonGrid = await createGridRack(cellar, { name: 'DH3', type: 'hex', typeConfig: { doubleHeightRows: [1] } }, REQ);
+    expect(nonGrid.error.status).toBe(400);
+    expect(nonGrid.error.message).toMatch(/only supported on grid racks/);
+  });
+
+  test('trims the rack name', async () => {
+    const res = await createGridRack(cellar, { name: '  Wall rack  ' }, REQ);
+    expect(res.rack.name).toBe('Wall rack');
   });
 });
 

--- a/backend/src/utils/rackGeometry.js
+++ b/backend/src/utils/rackGeometry.js
@@ -34,6 +34,39 @@ function validDoubleHeightRows(rows, cols, doubleHeightRows) {
 }
 
 /**
+ * Validate REQUEST-supplied typeConfig.doubleHeightRows before it is stored:
+ * grid racks (non-modular) only, entries must be integers in [1, rows]. The
+ * runtime counterpart above (validDoubleHeightRows) is defensive filtering of
+ * STORED data; this one rejects bad input with a message. Shared by the
+ * create path (services/rackOps.createGridRack — REST POST /api/racks and MCP
+ * both land there) and the REST rack-update route.
+ *
+ * See the POSITION NUMBERING CONTRACT in totalSlots below: the base grid
+ * keeps positions 1..rows*cols row-major exactly as a plain grid, and
+ * top-layer positions are appended after rows*cols — so this guard also
+ * catches removing a double row while top-layer bottles are still placed
+ * (via the routes' resize check on getMaxPosition).
+ *
+ * @returns {string|null} error message, or null when valid
+ */
+function validateDoubleHeightRows(typeConfig, effectiveType, effectiveRows, effectiveModular) {
+  const dhr = typeConfig?.doubleHeightRows;
+  if (dhr === undefined || dhr === null) return null;
+  if (effectiveModular || (effectiveType || 'grid') !== 'grid') {
+    return 'Double-height rows are only supported on grid racks';
+  }
+  if (!Array.isArray(dhr)) {
+    return 'doubleHeightRows must be an array of row numbers';
+  }
+  for (const r of dhr) {
+    if (!Number.isInteger(r) || r < 1 || r > effectiveRows) {
+      return `doubleHeightRows entries must be whole row numbers between 1 and ${effectiveRows}`;
+    }
+  }
+  return null;
+}
+
+/**
  * Total number of valid slot positions for a given rack configuration.
  */
 function totalSlots(type, rows, cols, typeConfig) {
@@ -127,4 +160,4 @@ function getMaxPosition(rack) {
   return totalSlots(rack.type || 'grid', rack.rows, rack.cols, rack.typeConfig);
 }
 
-module.exports = { totalSlots, modularTotalSlots, getMaxPosition, validDoubleHeightRows };
+module.exports = { totalSlots, modularTotalSlots, getMaxPosition, validDoubleHeightRows, validateDoubleHeightRows };

--- a/backend/src/utils/rackGeometry.test.js
+++ b/backend/src/utils/rackGeometry.test.js
@@ -1,6 +1,26 @@
-const { totalSlots, modularTotalSlots, getMaxPosition, validDoubleHeightRows } = require('./rackGeometry');
+const { totalSlots, modularTotalSlots, getMaxPosition, validDoubleHeightRows, validateDoubleHeightRows } = require('./rackGeometry');
 
 describe('rackGeometry', () => {
+  // Request-side validator (moved here from routes/racks.js so the create
+  // service and the update route share ONE implementation — MCP-audit H1).
+  describe('validateDoubleHeightRows (request validation)', () => {
+    it('accepts absent/null config and valid in-range rows', () => {
+      expect(validateDoubleHeightRows(undefined, 'grid', 4, false)).toBeNull();
+      expect(validateDoubleHeightRows({}, 'grid', 4, false)).toBeNull();
+      expect(validateDoubleHeightRows({ doubleHeightRows: null }, 'grid', 4, false)).toBeNull();
+      expect(validateDoubleHeightRows({ doubleHeightRows: [1, 4] }, 'grid', 4, false)).toBeNull();
+      // effectiveType undefined defaults to grid
+      expect(validateDoubleHeightRows({ doubleHeightRows: [2] }, undefined, 4, false)).toBeNull();
+    });
+    it('rejects non-grid, modular, non-array, and out-of-range entries', () => {
+      expect(validateDoubleHeightRows({ doubleHeightRows: [1] }, 'hex', 4, false)).toMatch(/only supported on grid/);
+      expect(validateDoubleHeightRows({ doubleHeightRows: [1] }, 'grid', 4, true)).toMatch(/only supported on grid/);
+      expect(validateDoubleHeightRows({ doubleHeightRows: 2 }, 'grid', 4, false)).toMatch(/must be an array/);
+      expect(validateDoubleHeightRows({ doubleHeightRows: [0] }, 'grid', 4, false)).toMatch(/between 1 and 4/);
+      expect(validateDoubleHeightRows({ doubleHeightRows: [5] }, 'grid', 4, false)).toMatch(/between 1 and 4/);
+      expect(validateDoubleHeightRows({ doubleHeightRows: [1.5] }, 'grid', 4, false)).toMatch(/between 1 and 4/);
+    });
+  });
   describe('totalSlots — grid', () => {
     it('returns rows × cols', () => {
       expect(totalSlots('grid', 4, 8)).toBe(32);


### PR DESCRIPTION
## The last big drift-eliminator from the 2026-07-17 MCP audit (H1)

`POST /api/bottles`, `PUT /api/bottles/:id` and the grid branch of `POST /api/racks` claimed (in doc-comments) to share one implementation with the MCP tools — but all three routes carried their own copies, and they had **already drifted**: currency was dropped when no price was given on the MCP path, grand-audit M5 had to be fixed in two places, and change detection differed enough that the web form's full-form saves re-anchored `priceSetAt` on every unrelated edit.

The routes now **delegate** to the shared services. There is exactly one implementation of each write path left in the codebase.

### Service extensions (to cover the full REST surface)

**`bottleOps.addBottle`** — now the whole of REST `POST /bottles`:
- `location`, `dateAdded` backdating, `addToHistory` + `consumed*` fields (with the `bottle.addToHistory` audit action)
- currency kept even **without** a price (the audit-proven drift — REST honored it, the service dropped it)
- FX snapshot awaited pre-save (REST parity), REST validation messages
- kept the service's guarded `ensurePendingVintageProfile` (the old route could 500 *after* the bottle saved)

**`bottleOps.updateBottleFields`** — now the whole of REST `PUT /bottles/:id`:
- full 14-field `UPDATABLE_FIELDS`: vintage coercion + re-embed on change (demo-skipped), bottleSize canonicalization, `purchaseDate`/`purchaseLocation`/`purchaseUrl`/`location`
- REST's `norm()` comparator (dates compare by calendar day, `''` ≡ `null`) — no phantom changes from full-form re-sends
- REST's laxer ratingScale guard (scale-only allowed on unrated bottles — the web form always sends the scale), `rating: ''` clears like `null`, REST's VersionError message

**`rackOps.createGridRack`** — now the grid branch of REST `POST /racks`:
- `typeConfig` accepted + validated via `validateDoubleHeightRows`, **moved to `utils/rackGeometry`** and shared with the REST rack-update route
- modular rack creation stays a REST-only route path (no MCP twin to drift against)

### One deliberate behavior fix

`priceSetAt` now re-anchors on a price/currency **change**, not on field **presence**. The web edit form re-sends every field on save, so the old presence-based route silently moved the FX anchor date (and thus the historical-rate conversion) to *today* on every notes-only edit. Change-based is what the service already did and what the field means.

### Drift guards

- MCP `update_bottle`'s description now derives from its **own** schema params, so the shared list growing can't make the tool advertise params it doesn't accept.
- +19 service tests pin the newly shared surface: migration fields, currency-without-price, the norm comparator (ISO-vs-Date no-op), re-anchor-on-change (full-form re-send leaves `priceSetAt` alone), the scale guard both ways, VersionError→409 mapping, `typeConfig` validation.

### Tests
- Backend **133 suites / 2014 tests green** in node:20-alpine (was 1995 — +19)
- Frontend **653 green** (zero frontend changes)

### Compose impact
None — no env, ports, services, or Dockerfile changes.

Closes the H1 deferral from CODE_AUDIT_2026-07-17_MCP.md.