### PR TITLE
fix(a11y): dialog semantics for the 7 hand-rolled overlays (grand-audit H6)

### DIFF
--- a/frontend/src/components/DialogBox.js
+++ b/frontend/src/components/DialogBox.js
@@ -1,0 +1,30 @@
+import { useDialogA11y } from '../utils/useDialogA11y';
+
+/**
+ * Thin a11y shell for hand-rolled dialog boxes that keep their own overlay
+ * and styling instead of using the shared <Modal> (custom layouts: slot
+ * popups, room overlays, in-page confirms). Renders the box div with the
+ * standard dialog semantics and the useDialogA11y wiring — focus moves into
+ * the dialog on open, Escape calls onClose.
+ *
+ * Purely additive: pass the box's existing className/onClick/style through,
+ * and name the dialog with `label` (aria-label) or `labelledBy` (the id of
+ * the visible title element). Mount it only while the dialog is open — the
+ * Escape listener and focus move live for exactly that time.
+ */
+export default function DialogBox({ onClose, label, labelledBy, children, ...divProps }) {
+  const boxRef = useDialogA11y(onClose);
+  return (
+    <div
+      ref={boxRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={label}
+      aria-labelledby={labelledBy}
+      tabIndex={-1}
+      {...divProps}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/DialogBox.test.js
+++ b/frontend/src/components/DialogBox.test.js
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import DialogBox from './DialogBox';
+
+/**
+ * DialogBox is the a11y shell the hand-rolled overlays (slot popups, room
+ * consume/blocker, bottle-detail confirms) mount instead of a bare box div
+ * (grand-audit H6). These tests pin the contract: dialog semantics, focus
+ * moving in on open, Escape closing, and NOT stealing focus from an
+ * autoFocus child.
+ */
+describe('DialogBox', () => {
+  test('renders a dialog with aria-modal, the given label, and its children', () => {
+    render(
+      <DialogBox onClose={() => {}} label="Remove Bottle" className="slot-modal">
+        <button>Confirm</button>
+      </DialogBox>
+    );
+    const dialog = screen.getByRole('dialog', { name: 'Remove Bottle' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveClass('slot-modal');
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+  });
+
+  test('supports aria-labelledby via labelledBy', () => {
+    render(
+      <DialogBox onClose={() => {}} labelledBy="dlg-title">
+        <h2 id="dlg-title">Slot 4</h2>
+      </DialogBox>
+    );
+    expect(screen.getByRole('dialog', { name: 'Slot 4' })).toBeInTheDocument();
+  });
+
+  test('moves focus to the first focusable element on open', () => {
+    render(
+      <DialogBox onClose={() => {}} label="Confirm">
+        <button>Cancel</button>
+        <button>OK</button>
+      </DialogBox>
+    );
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+  });
+
+  test('focuses the box itself when nothing inside is focusable', () => {
+    render(
+      <DialogBox onClose={() => {}} label="Info">
+        <p>Just text</p>
+      </DialogBox>
+    );
+    expect(screen.getByRole('dialog')).toHaveFocus();
+  });
+
+  test('does NOT steal focus from an autoFocus child (search-first popups)', () => {
+    render(
+      <DialogBox onClose={() => {}} label="Place bottle">
+        <button aria-label="Close">&times;</button>
+        {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+        <input autoFocus aria-label="Search wines" />
+      </DialogBox>
+    );
+    expect(screen.getByRole('textbox', { name: 'Search wines' })).toHaveFocus();
+  });
+
+  test('Escape calls onClose; other keys do not', () => {
+    const onClose = vi.fn();
+    render(<DialogBox onClose={onClose} label="X">body</DialogBox>);
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('Escape listener is removed on unmount', () => {
+    const onClose = vi.fn();
+    const { unmount } = render(<DialogBox onClose={onClose} label="X">body</DialogBox>);
+    unmount();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('passes className, style and click handlers through to the box div', () => {
+    const onClick = vi.fn();
+    render(
+      <DialogBox onClose={() => {}} label="X" className="room-consume-modal" style={{ maxWidth: 400 }} onClick={onClick}>
+        body
+      </DialogBox>
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveStyle({ maxWidth: '400px' });
+    fireEvent.click(dialog);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -21,6 +21,7 @@ import ConsumedDetails from '../components/bottle/ConsumedDetails';
 import EditForm from '../components/bottle/EditForm';
 import ViewDetails from '../components/bottle/ViewDetails';
 import BottleJourney from '../components/BottleJourney';
+import DialogBox from '../components/DialogBox';
 import JournalPrompt, { journalPromptOptedOut } from '../components/JournalPrompt';
 import './BottleDetail.css';
 
@@ -729,7 +730,12 @@ function BottleDetail() {
 
       {mistakeOpen && (
         <div className="modal-overlay" onClick={() => !mistakeBusy && setMistakeOpen(false)}>
-          <div className="modal-box" onClick={e => e.stopPropagation()}>
+          <DialogBox
+            className="modal-box"
+            onClick={e => e.stopPropagation()}
+            onClose={() => !mistakeBusy && setMistakeOpen(false)}
+            label={t('bottleDetail.mistakeTitle', 'Remove as a mistake?')}
+          >
             <h2>{t('bottleDetail.mistakeTitle', 'Remove as a mistake?')}</h2>
             <p>{t('bottleDetail.mistakeBody', 'This will permanently remove the bottle as if it had never been added. It will not appear in your stats, history, or search. This cannot be undone.')}</p>
             <div className="modal-actions">
@@ -752,7 +758,7 @@ function BottleDetail() {
                   : t('bottleDetail.mistakeConfirm', 'Yes, remove it')}
               </button>
             </div>
-          </div>
+          </DialogBox>
         </div>
       )}
 
@@ -811,7 +817,12 @@ function BottleDetail() {
 
         {openPickerOpen && (
           <div className="modal-overlay" onClick={() => !openingBusy && setOpenPickerOpen(false)}>
-            <div className="modal-box" onClick={e => e.stopPropagation()}>
+            <DialogBox
+              className="modal-box"
+              onClick={e => e.stopPropagation()}
+              onClose={() => !openingBusy && setOpenPickerOpen(false)}
+              label={t('openBottle.pickerTitle', 'Open this bottle')}
+            >
               <h2>{t('openBottle.pickerTitle', 'Open this bottle')}</h2>
               <p>{t('openBottle.pickerText', 'How will you preserve it? This sets the drink-by window — the bottle stays in your cellar until you finish it.')}</p>
               <div className="bd-open-methods">
@@ -839,7 +850,7 @@ function BottleDetail() {
                   {openingBusy ? t('common.saving', 'Saving...') : t('openBottle.confirmBtn', 'Open bottle')}
                 </button>
               </div>
-            </div>
+            </DialogBox>
           </div>
         )}
       </Suspense>

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -24,6 +24,7 @@ import RackAuditModal from '../components/racks/RackAuditModal';
 import { LENSES, getLensStyle, getLensLegend, bottleMatchesSearch } from '../utils/rackLens';
 import CellarNav from '../components/CellarNav';
 import CellarPageHeader from '../components/CellarPageHeader';
+import DialogBox from '../components/DialogBox';
 import './CellarRacks.css';
 
 function CellarRacks() {
@@ -807,8 +808,13 @@ function CellarRacks() {
           }
         }
         return (
-          <div className="slot-modal-overlay" onClick={() => setActivePopup(null)} role="dialog" aria-modal="true">
-            <div className="slot-modal" onClick={e => e.stopPropagation()}>
+          <div className="slot-modal-overlay" onClick={() => setActivePopup(null)}>
+            <DialogBox
+              className="slot-modal"
+              onClick={e => e.stopPropagation()}
+              onClose={() => setActivePopup(null)}
+              labelledBy="slot-popup-heading"
+            >
               {activePopup.slot ? (
                 <FilledSlotContent
                   position={activePopup.position}
@@ -846,7 +852,7 @@ function CellarRacks() {
                   onClose={() => setActivePopup(null)}
                 />
               )}
-            </div>
+            </DialogBox>
           </div>
         );
       })()}
@@ -1206,7 +1212,7 @@ function EmptySlotContent({ position, zone, apiFetch, cellarId, canEdit, onAssig
   return (
     <>
       <div className="slot-popup-header">
-        <span className="slot-popup-title">
+        <span className="slot-popup-title" id="slot-popup-heading">
           {t('racks.slotPlaceBottle', { position })}
           {zone && (
             <span className="slot-zone-chip">
@@ -1341,7 +1347,7 @@ function DisabledSlotContent({ position, canEdit, onEnable, onClose }) {
   return (
     <>
       <div className="slot-popup-header">
-        <span className="slot-popup-title">{t('racks.disabledSlotTitle', { position })}</span>
+        <span className="slot-popup-title" id="slot-popup-heading">{t('racks.disabledSlotTitle', { position })}</span>
         <button className="slot-popup-close" onClick={onClose} aria-label="Close">&times;</button>
       </div>
       <p className="slot-disabled-note">{t('racks.disabledSlotNote')}</p>
@@ -1365,7 +1371,7 @@ function FilledSlotContent({ position, slot, zone, canEdit, onRemoveFromRack, on
   return (
     <>
       <div className="slot-popup-header">
-        <span className="slot-popup-title">
+        <span className="slot-popup-title" id="slot-popup-heading">
           {t('racks.slotTitle', { position })}
           {zone && (
             <span className="slot-zone-chip">
@@ -1445,7 +1451,12 @@ function ConsumeModal({ defaultRatingScale, onSubmit, onCancel, onPartial }) {
 
   return (
     <div className="slot-modal-overlay" onClick={onCancel}>
-      <div className="slot-modal consume-modal-box" onClick={e => e.stopPropagation()}>
+      <DialogBox
+        className="slot-modal consume-modal-box"
+        onClick={e => e.stopPropagation()}
+        onClose={onCancel}
+        label={t('bottleDetail.removeBottleTitle')}
+      >
         <div className="slot-popup-header">
           <span className="slot-popup-title">{t('bottleDetail.removeBottleTitle')}</span>
           <button className="slot-popup-close" onClick={onCancel} aria-label="Close">&times;</button>
@@ -1496,7 +1507,7 @@ function ConsumeModal({ defaultRatingScale, onSubmit, onCancel, onPartial }) {
             </button>
           </div>
         </form>
-      </div>
+      </DialogBox>
     </div>
   );
 }
@@ -1533,8 +1544,14 @@ function NfcLinkModal({ rack, onSave, onCancel }) {
   };
 
   return (
-    <div className="slot-modal-overlay" onClick={onCancel} role="dialog" aria-modal="true">
-      <div className="slot-modal" onClick={e => e.stopPropagation()} style={{ maxWidth: 400 }}>
+    <div className="slot-modal-overlay" onClick={onCancel}>
+      <DialogBox
+        className="slot-modal"
+        onClick={e => e.stopPropagation()}
+        style={{ maxWidth: 400 }}
+        onClose={onCancel}
+        label={t('nfc.linkTitle')}
+      >
         <div className="slot-popup-header">
           <span className="slot-popup-title">{t('nfc.linkTitle')}</span>
           <button className="slot-popup-close" onClick={onCancel} aria-label="Close">&times;</button>
@@ -1595,7 +1612,7 @@ function NfcLinkModal({ rack, onSave, onCancel }) {
             )}
           </div>
         </div>
-      </div>
+      </DialogBox>
     </div>
   );
 }

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -15,6 +15,7 @@ import JournalPrompt, { journalPromptOptedOut } from '../components/JournalPromp
 import { LENSES, getLensStyle, getLensLegend, bottleMatchesSearch } from '../utils/rackLens';
 import CellarNav from '../components/CellarNav';
 import CellarPageHeader from '../components/CellarPageHeader';
+import DialogBox from '../components/DialogBox';
 import './CellarRoom.css';
 
 const DEFAULT_DIMENSIONS = { width: 10, depth: 10, height: 3 };
@@ -1398,7 +1399,12 @@ export default function CellarRoom() {
           {/* Consume modal */}
           {consumeModal && (
             <div className="room-consume-overlay" onClick={() => setConsumeModal(null)}>
-              <div className="room-consume-modal" onClick={e => e.stopPropagation()}>
+              <DialogBox
+                className="room-consume-modal"
+                onClick={e => e.stopPropagation()}
+                onClose={() => setConsumeModal(null)}
+                label={t('bottleDetail.removeBottleTitle', 'Remove Bottle')}
+              >
                 <RoomConsumeForm
                   onSubmit={handleConsumeSubmit}
                   onCancel={() => setConsumeModal(null)}
@@ -1406,7 +1412,7 @@ export default function CellarRoom() {
                   defaultRatingScale={user?.preferences?.ratingScale}
                   t={t}
                 />
-              </div>
+              </DialogBox>
             </div>
           )}
 
@@ -1593,7 +1599,12 @@ export default function CellarRoom() {
       {/* Unsaved changes navigation blocker */}
       {pendingNavPath && (
         <div className="room-consume-overlay" onClick={() => setPendingNavPath(null)}>
-          <div className="room-consume-modal" onClick={e => e.stopPropagation()}>
+          <DialogBox
+            className="room-consume-modal"
+            onClick={e => e.stopPropagation()}
+            onClose={() => setPendingNavPath(null)}
+            label={t('room.unsavedChangesTitle', 'Unsaved Changes')}
+          >
             <h3>{t('room.unsavedChangesTitle', 'Unsaved Changes')}</h3>
             <p>{t('room.unsavedChangesMessage', 'You have unsaved changes to the room layout. Are you sure you want to leave?')}</p>
             <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', marginTop: '1rem' }}>
@@ -1620,7 +1631,7 @@ export default function CellarRoom() {
                 {t('room.leaveWithoutSaving', 'Leave')}
               </button>
             </div>
-          </div>
+          </DialogBox>
         </div>
       )}
     </div>

--- a/frontend/src/utils/useDialogA11y.js
+++ b/frontend/src/utils/useDialogA11y.js
@@ -22,7 +22,10 @@ export function useDialogA11y(onClose) {
 
   useEffect(() => {
     const box = boxRef.current;
-    if (box) {
+    // Move focus in ONLY if it isn't already inside — a child with autoFocus
+    // (e.g. a search input) has focused itself during commit, before this
+    // effect runs, and stealing focus to the first button would undo it.
+    if (box && !box.contains(document.activeElement)) {
       const focusable = box.querySelector(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
       );


### PR DESCRIPTION
## The last open High from the 2026-07-17 grand audit

The `useDialogA11y` remediation covered the four shared modal components, but **seven hand-rolled overlays on core bottle/rack/room flows were missed** (grand-audit H6): no `role="dialog"`/`aria-modal` on the box, Escape did nothing, and focus stayed behind the overlay — screen-reader users got no dialog announcement at all.

| Site | Dialog |
|------|--------|
| BottleDetail | remove-as-mistake confirm · open-bottle preservation picker |
| CellarRoom | consume form · unsaved-changes navigation blocker |
| CellarRacks | slot popup (filled/empty/disabled) · consume form · NFC link modal |

### How

**New `components/DialogBox.js`** — a thin shell that renders the box div with the standard dialog attributes plus the `useDialogA11y` wiring (focus moves in on open, Escape closes). Each site keeps its exact markup, className, and styling — the shell mounts only while the dialog is open, so the Escape listener and focus move live for exactly that time. The two overlays that already carried `role="dialog"` on the **wrong element** (the overlay div, not the box) had it moved.

Labels: the slot popup is labelled by its visible title (`slot-popup-heading` id on all three content variants); the others use their translated titles as `aria-label`. Escape respects the same busy guards as overlay clicks (a removal or bottle-opening in flight can't be dismissed).

**One hook improvement:** `useDialogA11y` no longer steals focus when the dialog already contains it — a child with `autoFocus` (EmptySlotContent's wine search, and the pre-existing SuggestGrapesModal input) focuses itself during commit, and the hook was yanking focus onto the close button.

### Tests
- New `DialogBox.test.js` (8 tests): dialog semantics, labelledBy, focus-in, box-fallback focus, **autoFocus no-steal**, Escape + non-Escape keys, listener cleanup on unmount, prop passthrough.
- Frontend **33 suites / 661 tests green**; production build clean.
- Backend untouched.

### Compose impact
None.

Closes grand-audit H6 — with this, **all 7 grand-audit Highs are remediated** (#736-#743 covered H1-H5/H7).