### PR TITLE
fix(mcp): per-USER rate limiting for the protocol endpoint (MCP-audit M8)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -171,11 +171,19 @@ const isStripeWebhook = (req) => req.originalUrl.split('?')[0] === '/api/stripe/
 // that writes — the HTTP write limiter can't tell them apart, so limiting it at
 // this layer would throttle the read-mostly handshake while providing no real
 // write protection. Per-tool authorization (registry scope filter) and, for
-// write tools, the write-safety layers govern MCP mutations instead. It stays
-// under the global apiLimiter, so it is never unbounded.
+// write tools, the write-safety layers govern MCP mutations instead.
+//
+// The MCP endpoints are ALSO exempt from the global per-IP apiLimiter
+// (MCP-audit M8): hosted AI connectors (claude.ai, ChatGPT) egress from a
+// small shared IP pool, so a per-IP bucket here made every hosted user share
+// one 15-minute allowance — one chatty agent starved the rest. The personal
+// endpoint carries its own TWO dedicated limiters in routes/mcp.js (a high
+// per-IP pre-auth flood guard + a per-USER fair-share ceiling after auth);
+// /api/mcp/public keeps its own strict per-IP limiter there (60/15min, far
+// below the global cap — anonymous callers have no user to key on).
 //
 // A JSON-RPC body may be a *batch* (array) of calls, so one HTTP request can
-// fan out to many tool invocations — apiLimiter counts requests, not calls.
+// fan out to many tool invocations — HTTP limiters count requests, not calls.
 // That amplification is capped in mcp/server.js at TWO layers: the per-request
 // tool-call budget (MAX_CALLS_PER_REQUEST) and, for MUTATING tools, a per-user
 // budget sharing the SAME admin-tunable number as this writeLimiter — so an
@@ -183,9 +191,6 @@ const isStripeWebhook = (req) => req.originalUrl.split('?')[0] === '/api/stripe/
 // Revisit again before AI-spending tools ship (enrichment adds cost beyond DB).
 const isMcp = (req) => {
   const p = req.originalUrl.split('?')[0];
-  // /api/mcp/public (anonymous, read-only) has its own strict dedicated
-  // limiter in routes/mcp.js — exempt from the write limiter like the
-  // personal endpoint (its calls are budgeted inside mcp/server.js).
   return p === '/api/mcp' || p === '/api/mcp/' || p === '/api/mcp/public';
 };
 
@@ -196,7 +201,7 @@ const apiLimiter = rateLimit({
   keyGenerator: (req) => rateLimitKey(req),
   standardHeaders: true,
   legacyHeaders: false,
-  skip: isStripeWebhook,
+  skip: (req) => isStripeWebhook(req) || isMcp(req),
   handler: (req, res) => {
     logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'api', limit: rateLimitsConfig.get().api.max });
     res.status(429).json({ error: 'Too many requests, please try again later' });

--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -80,7 +80,16 @@ const defaults = {
   // routes under /api/mcp (activity timeline, revert, export-link download)
   // stay up either way — the switch cuts AI protocol access, not the human's
   // review tools. Checked per request from this in-memory cache: zero DB cost.
-  mcp: { enabled: 1, publicEnabled: 1 },
+  //
+  // Protocol-endpoint rate limits (MCP-audit M8): hosted AI connectors
+  // (claude.ai, ChatGPT) egress from a SMALL shared IP pool, so the global
+  // per-IP apiLimiter made every hosted user share one 15-minute bucket. The
+  // personal endpoint instead runs its own two-layer limit (routes/mcp.js):
+  //   userMax — fair-share ceiling per 15 min, keyed by the AUTHENTICATED
+  //             user id (one chatty agent can only starve itself);
+  //   ipMax   — pre-auth per-IP flood/credential-probe guard, sized for many
+  //             users behind one shared egress IP (fairness is userMax's job).
+  mcp: { enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000 },
 };
 
 let cache = {
@@ -148,6 +157,8 @@ async function load() {
         mcp: {
           enabled:       doc.value.mcp?.enabled       ?? defaults.mcp.enabled,
           publicEnabled: doc.value.mcp?.publicEnabled ?? defaults.mcp.publicEnabled,
+          userMax:       doc.value.mcp?.userMax       ?? defaults.mcp.userMax,
+          ipMax:         doc.value.mcp?.ipMax         ?? defaults.mcp.ipMax,
         },
       };
     }

--- a/backend/src/routes/admin/settings.js
+++ b/backend/src/routes/admin/settings.js
@@ -103,9 +103,16 @@ router.patch('/rate-limits', async (req, res) => {
 
     // MCP kill switches (0 = off, 1 = on). enabled=0 shuts the whole AI
     // surface; publicEnabled=0 shuts only the anonymous endpoint.
+    // userMax/ipMax are the protocol-endpoint limits (MCP-audit M8): per-USER
+    // fair share and the pre-auth per-IP flood guard. Floors keep a typo from
+    // effectively bricking the surface (userMax 10 ≈ one short exchange);
+    // ipMax must stay well above userMax or one shared egress IP throttles
+    // before any user reaches their own allowance.
     if (mcp !== undefined) {
       requireIntInRange('mcp.enabled',       mcp.enabled,       0, 1);
       requireIntInRange('mcp.publicEnabled', mcp.publicEnabled, 0, 1);
+      requireIntInRange('mcp.userMax',       mcp.userMax,       10, 100_000);
+      requireIntInRange('mcp.ipMax',         mcp.ipMax,         100, 1_000_000);
     }
 
     if (errors.length > 0) {
@@ -151,6 +158,8 @@ router.patch('/rate-limits', async (req, res) => {
       mcp: {
         enabled:       mcp?.enabled       ?? previous.mcp?.enabled       ?? rateLimitsConfig.defaults.mcp.enabled,
         publicEnabled: mcp?.publicEnabled ?? previous.mcp?.publicEnabled ?? rateLimitsConfig.defaults.mcp.publicEnabled,
+        userMax:       mcp?.userMax       ?? previous.mcp?.userMax       ?? rateLimitsConfig.defaults.mcp.userMax,
+        ipMax:         mcp?.ipMax         ?? previous.mcp?.ipMax         ?? rateLimitsConfig.defaults.mcp.ipMax,
       },
     };
 

--- a/backend/src/routes/mcp.js
+++ b/backend/src/routes/mcp.js
@@ -12,6 +12,7 @@ const { revertLedgerRow, reversibleActionsFor } = require('../mcp/revert');
 const { findLiveLink, redeemExportLink } = require('../services/exportLinks');
 const { issuer } = require('../services/mcpOAuth');
 const rateLimitsConfig = require('../config/rateLimits');
+const { logAudit } = require('../services/audit');
 // The canonical personal-session scope set — single source (MCP-audit L1), used
 // for both the reversible-action set and the browser-revert ctx below.
 const { MCP_PERSONAL_SCOPES } = require('../config/constants');
@@ -34,6 +35,54 @@ function requirePublicMcpEnabled(req, res, next) {
   }
   next();
 }
+
+// ── Dedicated protocol-endpoint limiters (MCP-audit M8) ─────────────────────
+// Hosted AI connectors (claude.ai, ChatGPT) egress from a SMALL shared IP
+// pool, so the global per-IP apiLimiter made every hosted user share one
+// 15-minute bucket — one chatty agent could starve everyone else's connector.
+// The personal protocol endpoint is therefore EXEMPT from apiLimiter (app.js
+// isMcp skip) and runs two layers of its own instead:
+//
+//   1. mcpIpLimiter (BEFORE auth): a deliberately HIGH per-IP ceiling that
+//      only bounds raw floods and credential probing. Unauthenticated junk is
+//      a cheap 401, and real fairness is the next layer's job — so this is
+//      sized for many legitimate users behind one shared egress IP.
+//   2. mcpUserLimiter (AFTER requireAuth): the fair-share ceiling, keyed by
+//      the VERIFIED user id — not the token (three tokens must not buy a 3×
+//      budget) and not the IP (shared egress must not pool strangers).
+//
+// Both read live admin-tunable numbers (config/rateLimits `mcp` group — the
+// same runtime machinery as the kill switches; the AdminMcp usage payload
+// already round-trips the whole group). Tool-call fan-out inside one request
+// stays bounded by callBudget + mutationBudget in mcp/server.js, and the
+// anonymous /public endpoint keeps its own strict per-IP limiter below.
+const mcpLimits = () => rateLimitsConfig.get().mcp || rateLimitsConfig.defaults.mcp;
+const mcpIpLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: () => mcpLimits().ipMax ?? rateLimitsConfig.defaults.mcp.ipMax,
+  keyGenerator: (req) => rateLimitKey(req),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'mcp_ip', limit: mcpLimits().ipMax ?? rateLimitsConfig.defaults.mcp.ipMax });
+    res.status(429).json({ error: 'Too many MCP requests from this network — try again in a few minutes.' });
+  },
+});
+const mcpUserLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: () => mcpLimits().userMax ?? rateLimitsConfig.defaults.mcp.userMax,
+  // requireAuth has run — req.user.id is verified identity. The IP fallback is
+  // defense-in-depth only (unreachable in the mounted order).
+  keyGenerator: (req) => (req.user?.id ? `u:${req.user.id}` : rateLimitKey(req)),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, { limiter: 'mcp_user', limit: mcpLimits().userMax ?? rateLimitsConfig.defaults.mcp.userMax });
+    res.status(429).json({
+      error: 'This account has made too many MCP requests in a short time — wait a few minutes before retrying. Batch related tool calls into one request where possible.',
+    });
+  },
+});
 
 // JSON-RPC initialize marker (single message or batch). Local check — the
 // SDK's isInitializeRequest helper lives in the ESM package.
@@ -101,7 +150,7 @@ const JWT_SCOPES = MCP_PERSONAL_SCOPES;
 // are shared/throwaway (they also can't mint `cel_` tokens, so this closes the
 // only other way in). A `cel_` token never carries isDemo, so requireNonDemo is a
 // no-op for it and blocks only demo JWT sessions.
-router.post('/', requireMcpEnabled, mcpChallenge, requireAuth, requireNonDemo, async (req, res, next) => {
+router.post('/', requireMcpEnabled, mcpIpLimiter, mcpChallenge, requireAuth, requireNonDemo, mcpUserLimiter, async (req, res, next) => {
   try {
     const scopes = req.apiToken ? req.apiToken.scopes : JWT_SCOPES;
     // ctx.req rides along for the mutating tools: logAudit reads actor/ip/UA
@@ -143,7 +192,7 @@ router.post('/', requireMcpEnabled, mcpChallenge, requireAuth, requireNonDemo, a
 // stream to open — 405 keeps the old stateless contract for those callers.
 // mcpChallenge: an OAuth client probing with a stale token must get the RFC
 // 9728 WWW-Authenticate pointer here too, not only on POST.
-router.get('/', requireMcpEnabled, mcpChallenge, requireAuth, requireNonDemo, async (req, res, next) => {
+router.get('/', requireMcpEnabled, mcpIpLimiter, mcpChallenge, requireAuth, requireNonDemo, mcpUserLimiter, async (req, res, next) => {
   try {
     const session = sessionFor(req);
     if (session && session.transport) return await session.transport.handleRequest(req, res);
@@ -156,7 +205,7 @@ router.get('/', requireMcpEnabled, mcpChallenge, requireAuth, requireNonDemo, as
 
 // DELETE terminates the session (MCP spec). The SDK transport fires
 // onsessionclosed → the store tears down server, transport and bus listener.
-router.delete('/', requireMcpEnabled, requireAuth, requireNonDemo, async (req, res, next) => {
+router.delete('/', requireMcpEnabled, mcpIpLimiter, requireAuth, requireNonDemo, mcpUserLimiter, async (req, res, next) => {
   try {
     const session = sessionFor(req);
     if (session && session.transport) return await session.transport.handleRequest(req, res);

--- a/backend/src/routes/mcp.killswitch.test.js
+++ b/backend/src/routes/mcp.killswitch.test.js
@@ -59,7 +59,7 @@ const post = (path, auth) => fetch(`${baseUrl}${path}`, {
 });
 
 test('defaults leave every MCP surface open', async () => {
-  expect(rateLimitsConfig.defaults.mcp).toEqual({ enabled: 1, publicEnabled: 1 });
+  expect(rateLimitsConfig.defaults.mcp).toEqual({ enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000 });
   const res = await post('/api/mcp/public');
   expect(res.status).toBe(200);
   expect((await res.json()).handled).toBe(true);

--- a/backend/src/routes/mcp.rateLimit.test.js
+++ b/backend/src/routes/mcp.rateLimit.test.js
@@ -1,0 +1,122 @@
+/**
+ * Dedicated MCP protocol-endpoint rate limits (MCP-audit M8).
+ *
+ * Hosted AI connectors (claude.ai, ChatGPT) egress from a small shared IP
+ * pool, so the old setup — /api/mcp under the global per-IP apiLimiter — made
+ * every hosted user share one 15-minute bucket. These tests pin the fix:
+ *   - the per-USER limiter is keyed by verified identity, so one user's burst
+ *     429s only that user, across DIFFERENT source IPs (shared egress must
+ *     not pool strangers, and IP-hopping must not reset the budget);
+ *   - the pre-auth per-IP limiter bounds unauthenticated flood/probing;
+ *   - the kill switch outranks both (503 without consuming any bucket);
+ *   - a stored config missing the new fields falls back to defaults instead
+ *     of crashing or going unlimited.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../mcp/server', () => ({
+  handleMcpRequest: jest.fn(async (req, res) => res.json({ handled: true })),
+  initStatefulSession: jest.fn(async () => false),
+}));
+jest.mock('../mcp/sessions', () => ({ getSession: jest.fn(() => null) }));
+jest.mock('../mcp/revert', () => ({
+  revertLedgerRow: jest.fn(),
+  reversibleActionsFor: jest.fn(() => ['consume', 'restore']),
+}));
+jest.mock('../services/bottleOps', () => ({ RESTORE_WINDOW_MS: 7 * 24 * 60 * 60 * 1000 }));
+jest.mock('../services/exportLinks', () => ({ findLiveLink: jest.fn(), redeemExportLink: jest.fn() }));
+jest.mock('../services/mcpOAuth', () => ({ issuer: () => 'http://localhost' }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/User', () => ({ exists: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const rateLimitsConfig = require('../config/rateLimits');
+const { logAudit } = require('../services/audit');
+const mcpRouter = require('./mcp');
+
+const token = (id) => jwt.sign({ id, roles: ['user'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  // Honour X-Forwarded-For so each test controls the source IP the limiter
+  // keys on — that's how "same user, different IPs" is driven below.
+  app.set('trust proxy', 1);
+  app.use(express.json());
+  app.use('/api/mcp', mcpRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+beforeEach(() => jest.clearAllMocks());
+
+// Flip the in-memory config the way admin settings PATCH does, restore after.
+const withMcpConfig = (mcp, fn) => async () => {
+  const previous = rateLimitsConfig.get();
+  rateLimitsConfig.set({ ...previous, mcp });
+  try { await fn(); } finally { rateLimitsConfig.set(previous); }
+};
+
+const post = (ip, auth) => fetch(`${baseUrl}/api/mcp`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Forwarded-For': ip,
+    ...(auth ? { Authorization: `Bearer ${auth}` } : {}),
+  },
+  body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
+});
+
+test('per-user limit: one user 429s across DIFFERENT IPs; another user on a SHARED IP is untouched',
+  withMcpConfig({ enabled: 1, publicEnabled: 1, userMax: 2, ipMax: 5000 }, async () => {
+    const chatty = token('64b0000000000000000000aa');
+    // Two allowed requests from two different egress IPs — one identity, one bucket.
+    expect((await post('20.0.0.1', chatty)).status).toBe(200);
+    expect((await post('20.0.0.2', chatty)).status).toBe(200);
+    // Third request 429s even from a THIRD ip — rotating IPs must not reset it.
+    const blocked = await post('20.0.0.3', chatty);
+    expect(blocked.status).toBe(429);
+    expect((await blocked.json()).error).toMatch(/this account/i);
+    expect(blocked.headers.get('retry-after')).toBeTruthy();
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'system.rate_limit_exceeded', {},
+      { limiter: 'mcp_user', limit: 2 });
+    // A DIFFERENT user calling from an IP the first user already used (the
+    // shared-egress scenario) still has their full own allowance.
+    const other = token('64b0000000000000000000bb');
+    expect((await post('20.0.0.1', other)).status).toBe(200);
+  }));
+
+test('pre-auth per-IP guard: unauthenticated probing from one IP is bounded (401s count, then 429)',
+  withMcpConfig({ enabled: 1, publicEnabled: 1, userMax: 100000, ipMax: 3 }, async () => {
+    expect((await post('30.0.0.9')).status).toBe(401);
+    expect((await post('30.0.0.9')).status).toBe(401);
+    expect((await post('30.0.0.9')).status).toBe(401);
+    const blocked = await post('30.0.0.9');
+    expect(blocked.status).toBe(429);
+    expect((await blocked.json()).error).toMatch(/this network/i);
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'system.rate_limit_exceeded', {},
+      { limiter: 'mcp_ip', limit: 3 });
+    // Another IP is unaffected.
+    expect((await post('30.0.0.10')).status).toBe(401);
+  }));
+
+test('kill switch outranks the limiters: 503 without consuming any bucket',
+  withMcpConfig({ enabled: 0, publicEnabled: 1, userMax: 100000, ipMax: 1 }, async () => {
+    // ipMax=1: if the limiter ran before the switch, the second request would
+    // be a 429 — both must be the switch's 503.
+    expect((await post('40.0.0.1', token('64b0000000000000000000cc'))).status).toBe(503);
+    expect((await post('40.0.0.1', token('64b0000000000000000000cc'))).status).toBe(503);
+  }));
+
+test('a stored config missing the new fields falls back to defaults (not unlimited, no crash)',
+  withMcpConfig({ enabled: 1, publicEnabled: 1 }, async () => {
+    const res = await post('50.0.0.1', token('64b0000000000000000000dd'));
+    expect(res.status).toBe(200);
+    // draft-7 standardHeaders expose the effective limit — must be the DEFAULT
+    // userMax, proving the ?? fallback engaged rather than 0/undefined.
+    expect(res.headers.get('ratelimit-limit')).toBe(String(rateLimitsConfig.defaults.mcp.userMax));
+  }));

--- a/docs/mcp-connect.md
+++ b/docs/mcp-connect.md
@@ -86,10 +86,18 @@ authorization server — RFC 9728).
 - **Per-user revocation**: deleting a token in Settings cuts its access on
   the next request; OAuth grants revoke the same way (they are ApiToken
   rows underneath).
+- **Protocol rate limits** (SuperAdmin → Settings → "AI connector (MCP)
+  limits"; `{ mcp: { userMax, ipMax } }` in the same PATCH): the personal
+  endpoint is limited **per user** (default 300 req / 15 min — one bucket
+  across all of a user's tokens and source IPs), not per IP — hosted
+  connectors (claude.ai, ChatGPT) egress from a small shared IP pool, so a
+  per-IP bucket would let one chatty agent starve every other hosted user.
+  A high per-IP pre-auth guard (default 5000 / 15 min) bounds
+  unauthenticated flooding and credential probing.
 - **Budgets**: per-request call cap (20; 10 anonymous), per-user mutation
   budget (shared with the REST write limiter), the AI daily budget for the
   few tools that spend AI (semantic search embeds), and the public
-  endpoint's dedicated per-IP limiter.
+  endpoint's dedicated per-IP limiter (60 / 15 min).
 
 ## Self-hosting notes
 

--- a/frontend/src/pages/SuperAdmin/TabSettings.js
+++ b/frontend/src/pages/SuperAdmin/TabSettings.js
@@ -136,6 +136,70 @@ function PerIpLimitsPanel({ apiFetch, config, defaults, error }) {
   );
 }
 
+// The AI connector's own two-layer protocol limit (backend routes/mcp.js):
+// hosted connectors (claude.ai, ChatGPT) call from a small shared IP pool, so
+// /api/mcp is exempt from the per-IP limits above and throttled per USER
+// instead, with a high per-IP guard against unauthenticated flooding. The
+// on/off kill switches live on the Admin → AI Connector page; only the two
+// numbers are edited here. PATCHes only { mcp: { userMax, ipMax } } — the
+// backend's field-level merge leaves the switches untouched.
+function McpLimitsPanel({ apiFetch, config, defaults, error }) {
+  const [form,   setForm]   = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [msg,    setMsg]    = useState(null);
+
+  useEffect(() => {
+    if (config) {
+      setForm({
+        userMax: String(config.mcp?.userMax ?? defaults?.mcp?.userMax ?? ''),
+        ipMax:   String(config.mcp?.ipMax   ?? defaults?.mcp?.ipMax   ?? ''),
+      });
+    }
+  }, [config, defaults]);
+
+  const save = async () => {
+    setSaving(true); setMsg(null);
+    try {
+      const res = await adminSaveRateLimits(apiFetch, {
+        mcp: { userMax: Number(form.userMax), ipMax: Number(form.ipMax) },
+      });
+      if (!res.ok) { const d = await res.json(); setMsg({ ok: false, text: d.error || 'Save failed' }); }
+      else setMsg({ ok: true, text: 'Saved — takes effect immediately' });
+    } catch { setMsg({ ok: false, text: 'Network error' }); }
+    finally { setSaving(false); }
+  };
+
+  if (error)  return null; // the Per-IP panel already shows the shared load error
+  if (!form)  return <div className="sa-loading">Loading MCP limits...</div>;
+
+  return (
+    <PanelShell
+      title="AI connector (MCP) limits"
+      intro="The MCP endpoint is limited per USER, not per IP — hosted AI connectors share a small egress IP pool, so a per-IP bucket would let one chatty agent starve everyone. Keep the per-IP flood guard well above the per-user number. On/off switches are on Admin → AI Connector."
+      saving={saving} onSave={save} msg={msg}
+    >
+      <NumberField
+        label="Per-user requests"
+        unit="req / 15 min"
+        hint="fair share per account, across all their tokens and IPs"
+        value={form.userMax}
+        defaultValue={defaults?.mcp?.userMax}
+        onChange={v => setForm(f => ({ ...f, userMax: v }))}
+        min={10} max={100000}
+      />
+      <NumberField
+        label="Per-IP flood guard"
+        unit="req / 15 min"
+        hint="pre-auth ceiling per source IP; bounds probing, not fairness"
+        value={form.ipMax}
+        defaultValue={defaults?.mcp?.ipMax}
+        onChange={v => setForm(f => ({ ...f, ipMax: v }))}
+        min={100} max={1000000}
+      />
+    </PanelShell>
+  );
+}
+
 function AccountLockoutPanel({ apiFetch, config, defaults, error }) {
   const [form,   setForm]   = useState(null);
   const [saving, setSaving] = useState(false);
@@ -417,6 +481,7 @@ export default function TabSettings() {
     <>
       <ContactEmailPanel apiFetch={apiFetch} />
       <PerIpLimitsPanel apiFetch={apiFetch} {...rateLimits} />
+      <McpLimitsPanel apiFetch={apiFetch} {...rateLimits} />
       <AccountLockoutPanel apiFetch={apiFetch} {...rateLimits} />
       <ChatLimitsPanel apiFetch={apiFetch} {...rateLimits} />
       <AiBudgetPanel apiFetch={apiFetch} {...rateLimits} />


### PR DESCRIPTION
## The hosted-launch availability trap (MCP-audit M8)

Hosted AI connectors (claude.ai, ChatGPT) call server-side from a **small shared egress IP pool** (`docs/mcp-oauth.md` names Anthropic's `160.79.104.0/21`). With `/api/mcp` under the global per-IP `apiLimiter` (200–500 req/15 min), **every hosted user shared one bucket** — one chatty agent could 429 everyone else's connector. The internal per-user budgets (`callBudget`/`mutationBudget`) couldn't help: the throttle sat at the HTTP/IP layer above them.

## The fix: two dedicated layers, keyed correctly

The protocol endpoint (`POST/GET/DELETE /api/mcp`) is now **exempt from the global per-IP limiters** and runs:

| Layer | Where | Key | Default | Purpose |
|---|---|---|---|---|
| `mcpIpLimiter` | **before** auth | IP | 5000/15 min | flood + credential-probe guard, sized for many users behind one egress IP |
| `mcpUserLimiter` | **after** auth | verified user id | 300/15 min | the fair share — one bucket per account across **all tokens and all IPs** |

- Kill switch outranks both — a 503 consumes no bucket.
- `/api/mcp/public` keeps its strict dedicated 60/15 min per-IP limiter (anonymous callers have no user to key on).
- Browser routes (`/activity`, revert, export links) stay under the global `apiLimiter` — that's real per-user-IP traffic.
- 429s carry `RateLimit-*`/`Retry-After`, distinct account-vs-network messages, and `system.rate_limit_exceeded` audit rows (`mcp_user`/`mcp_ip`).

## Live-tunable

`config/rateLimits` `mcp` group gains `userMax`/`ipMax` (with `??`-fallback to defaults, so a stored config from before this change can never mean *unlimited*). The admin settings PATCH validates + merges them field-by-field (the AdminMcp kill-switch toggles can't clobber them), and **SuperAdmin → Settings gets an "AI connector (MCP) limits" panel**. Takes effect immediately, like the other rate limits.

## Tests

New `mcp.rateLimit.test.js` drives the **real router** with trust-proxy'd `X-Forwarded-For` IPs:
- one user hits 429 across **three different IPs** while a second user calling from the **same shared IP** keeps their full allowance — the exact M8 scenario;
- unauthenticated probing is bounded per IP pre-auth (401s count, then 429);
- the kill switch answers 503 without consuming any bucket (proven with `ipMax=1`);
- a stored config missing the new fields falls back to defaults (`RateLimit-Limit` header asserted).

Killswitch defaults-shape guard updated (that's the drift-guard firing as designed).

**Backend 134 suites / 2018 tests green** in node:20-alpine · **frontend 661 + Vite build green**.

## Compose impact
None — no env, ports, or service changes. Config lives in the existing SiteConfig `rateLimits` doc.

## Flagged, deliberately not changed
OAuth **Dynamic Client Registration** stays at its hardcoded 10/hr/IP (#745 anti-flood decision). If claude.ai performs DCR per user-connection from shared egress, a launch-day onboarding wave could pinch there — watch for `/register` 429s at launch; the mitigation (raise the cap or make it config-driven) is a small follow-up, but loosening a security control deserves its own decision.

Closes MCP-audit **M8** (the last hosted-availability deferral).