### PR TITLE
chore(ui): narrow the Beta label to the AI connector only

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -642,7 +642,6 @@
     "tabOverview": "Overview",
     "viewRackLayout": "View rack layout",
     "consumedBottles": "Consumed bottles",
-    "beta": "Beta",
     "sortBottlesAria": "Sort bottles",
     "removeFilterAria": "Remove {{label}}",
     "groupBottleCount_one": "{{count}} bottle",
@@ -1789,7 +1788,6 @@
   },
   "discussions": {
     "community": "Community",
-    "beta": "Beta",
     "reviews": "Reviews",
     "discussions": "Discussions",
     "all": "All",
@@ -3042,9 +3040,9 @@
   "importBottles": {
     "title": "Import Bottles",
     "backToCellar": "Back to Cellar",
-    "betaNotice": "This feature is in beta. If anything doesn't import the way you expect, email <1>{{email}}</1> and attach a small example of the file you're trying to import — we'll take a look and either fix it or tell you how to get it through.",
-    "betaEmailSubject": "Import issue",
-    "betaEmailBody": "Hi, I ran into an issue importing bottles into Cellarion. A sample of the file I tried to import is attached.",
+    "supportNotice": "If anything doesn't import the way you expect, email <1>{{email}}</1> and attach a small example of the file you're trying to import — we'll take a look and either fix it or tell you how to get it through.",
+    "supportEmailSubject": "Import issue",
+    "supportEmailBody": "Hi, I ran into an issue importing bottles into Cellarion. A sample of the file I tried to import is attached.",
     "steps": {
       "upload": "Upload",
       "review": "Review",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -642,7 +642,6 @@
     "tabOverview": "Översikt",
     "viewRackLayout": "Visa hyllayout",
     "consumedBottles": "Konsumerade flaskor",
-    "beta": "Beta",
     "sortBottlesAria": "Sortera flaskor",
     "removeFilterAria": "Ta bort {{label}}",
     "groupBottleCount_one": "{{count}} flaska",
@@ -1789,7 +1788,6 @@
   },
   "discussions": {
     "community": "Gemenskap",
-    "beta": "Beta",
     "reviews": "Omdömen",
     "discussions": "Diskussioner",
     "all": "Alla",
@@ -3042,9 +3040,9 @@
   "importBottles": {
     "title": "Importera flaskor",
     "backToCellar": "Tillbaka till källaren",
-    "betaNotice": "Den här funktionen är i beta. Om något inte importeras som du förväntar dig, mejla <1>{{email}}</1> och bifoga ett litet exempel på filen du försöker importera — vi tittar på det och antingen fixar det eller berättar hur du får igenom den.",
-    "betaEmailSubject": "Importproblem",
-    "betaEmailBody": "Hej, jag stötte på ett problem när jag importerade flaskor till Cellarion. Ett exempel på filen jag försökte importera är bifogat.",
+    "supportNotice": "Om något inte importeras som du förväntar dig, mejla <1>{{email}}</1> och bifoga ett litet exempel på filen du försöker importera — vi tittar på det och antingen fixar det eller berättar hur du får igenom den.",
+    "supportEmailSubject": "Importproblem",
+    "supportEmailBody": "Hej, jag stötte på ett problem när jag importerade flaskor till Cellarion. Ett exempel på filen jag försökte importera är bifogat.",
     "steps": {
       "upload": "Ladda upp",
       "review": "Granska",

--- a/frontend/src/pages/CellarDetail.css
+++ b/frontend/src/pages/CellarDetail.css
@@ -180,19 +180,6 @@
   color: var(--color-text-muted);
 }
 
-.overview-beta-badge {
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.1rem 0.4rem;
-  border-radius: 4px;
-  background: var(--color-primary, #6366f1);
-  color: #fff;
-  vertical-align: middle;
-  margin-left: 0.3rem;
-}
-
 /* ── FAB (Floating Action Button) — mobile only ── */
 .fab {
   display: none;

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -436,7 +436,7 @@ function CellarDetail() {
             <Link to={`/cellars/${id}/room`} className="overview-link-card">
               <span className="overview-link-icon" aria-hidden="true">🏠</span>
               <div>
-                <strong>{t('cellarDetail.roomView', 'Room View')} <span className="overview-beta-badge">{t('cellarDetail.beta')}</span></strong>
+                <strong>{t('cellarDetail.roomView', 'Room View')}</strong>
                 <span>{t('cellarDetail.roomViewDesc', '3D cellar layout')}</span>
               </div>
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>

--- a/frontend/src/pages/CellarRoom.css
+++ b/frontend/src/pages/CellarRoom.css
@@ -35,18 +35,6 @@
   gap: 0.5rem;
 }
 
-.room-beta-badge {
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.15rem 0.45rem;
-  border-radius: 4px;
-  background: var(--color-primary, #6366f1);
-  color: #fff;
-  margin-left: 0.5rem; /* was an inline style on the title-badge span (M22) */
-}
-
 .room-mode-badge {
   font-size: 0.75rem;
   padding: 0.15rem 0.6rem;

--- a/frontend/src/pages/CellarRoom.js
+++ b/frontend/src/pages/CellarRoom.js
@@ -1034,7 +1034,6 @@ export default function CellarRoom() {
           title={`${cellar?.name || '...'} — ${t('room.title', 'Room View')}`}
           loading={loading}
           subtitle={t('room.subtitle', '3D cellar layout')}
-          titleBadge={<span className="room-beta-badge">{t('cellarDetail.beta', 'Beta')}</span>}
           actions={canEdit && (
             <>
               <button className="btn btn-secondary btn-small" onClick={() => setShowSettings(s => !s)}>
@@ -1062,7 +1061,6 @@ export default function CellarRoom() {
               {t('room.backToRacks', 'Racks')}
             </Link>
             <h1>{cellar?.name || '...'} — {t('room.title', 'Room View')}</h1>
-            <span className="room-beta-badge">{t('cellarDetail.beta', 'Beta')}</span>
             <span className="room-mode-badge edit">{t('room.editMode', 'Edit')}</span>
           </div>
 

--- a/frontend/src/pages/CommunityDiscussions.js
+++ b/frontend/src/pages/CommunityDiscussions.js
@@ -12,11 +12,7 @@ function CommunityDiscussions() {
   return (
     <div className="review-feed-page">
       <div className="review-feed__header">
-        <h1>
-          {t('discussions.community')}
-          {' '}
-          <span className="discussions__beta-badge">{t('discussions.beta')}</span>
-        </h1>
+        <h1>{t('discussions.community')}</h1>
         {/* Reviews tab is hidden for anonymous visitors — that feed is auth-only
             and would just bounce them back here via /community redirect. */}
         {user && (

--- a/frontend/src/pages/Discussions.css
+++ b/frontend/src/pages/Discussions.css
@@ -19,17 +19,6 @@
   letter-spacing: -0.01em;
 }
 
-.discussions__beta-badge {
-  font-size: 0.6rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 0.1rem 0.4rem;
-  border-radius: 3px;
-  background: var(--color-surface-hover);
-  color: var(--color-text-muted);
-}
-
 /* ── Search bar ── */
 .discussions__search {
   display: flex;

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -117,9 +117,9 @@
   margin: 0.25rem 0 0;
 }
 
-/* ── Beta Notice ─────────────────────────────────────────────────────────── */
+/* ── Import support notice ─────────────────────────────────────────────────────────── */
 
-.import-beta-notice {
+.import-support-notice {
   background: rgba(var(--color-primary-rgb), 0.1);
   border: 1px solid rgba(var(--color-primary-rgb), 0.3);
   border-radius: 6px;
@@ -129,12 +129,12 @@
   margin-bottom: 1.5rem;
 }
 
-.import-beta-notice a {
+.import-support-notice a {
   color: var(--color-primary);
   text-decoration: none;
 }
 
-.import-beta-notice a:hover {
+.import-support-notice a:hover {
   text-decoration: underline;
 }
 

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -2084,11 +2084,11 @@ function ImportBottles() {
       </div>
 
       {contactEmail && (
-        <div className="import-beta-notice">
+        <div className="import-support-notice">
           <Trans
-            i18nKey="importBottles.betaNotice"
+            i18nKey="importBottles.supportNotice"
             values={{ email: contactEmail }}
-            components={{ 1: <a href={`mailto:${contactEmail}?subject=${encodeURIComponent(t('importBottles.betaEmailSubject'))}&body=${encodeURIComponent(t('importBottles.betaEmailBody'))}`}>{contactEmail}</a> }}
+            components={{ 1: <a href={`mailto:${contactEmail}?subject=${encodeURIComponent(t('importBottles.supportEmailSubject'))}&body=${encodeURIComponent(t('importBottles.supportEmailBody'))}`}>{contactEmail}</a> }}
           />
         </div>
       )}

--- a/frontend/src/pages/SuperAdmin/TabSettings.js
+++ b/frontend/src/pages/SuperAdmin/TabSettings.js
@@ -453,7 +453,7 @@ function ContactEmailPanel({ apiFetch }) {
       </div>
       <div className="sa-panel-body">
         <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 12 }}>
-          Shown in beta notices and support prompts across the app.
+          Shown in support prompts across the app (e.g. the import page's "email us" notice).
         </div>
         <div className="sa-kv">
           <div className="sa-kv-row">


### PR DESCRIPTION
With the AI connector launching as the headline beta, the mature features drop their beta framing so the label keeps its meaning.

- **3D Room View** — badges removed (cellar overview card + both room headers).
- **Community Discussions** — badge removed.
- **Bottle import** — no longer *beta*, but the support prompt stays: "if anything doesn't import the way you expect, email us with a small sample file." Keys renamed `betaNotice`/`betaEmail*` → `supportNotice`/`supportEmail*` (en+sv) and the CSS class to `import-support-notice`, so no key named *beta* carries non-beta copy.
- Orphaned i18n keys (`cellarDetail.beta`, `discussions.beta`) and the three now-unused badge CSS classes removed in the same pass; SuperAdmin contact-email hint updated.

**The AI connector keeps its full beta framing** — Settings section, OAuth consent screen, and activity timeline, in both languages, pinned by tests.

Frontend **33 suites / 661 tests green**; Vite build clean. Backend untouched. No compose impact.

