### PR TITLE
feat(auth): set-a-password flow for SSO-only accounts (password-confirm gates)

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -494,6 +494,16 @@ router.post('/change-password', requireAuth, requireNonDemo, authLimiter, async 
       return res.status(404).json({ error: 'User not found' });
     }
 
+    // SSO-only account: there is no current password to verify. The UI hides
+    // this form for hasPassword:false and offers the set-password (reset-email)
+    // flow instead — this guard catches direct API calls with an honest answer.
+    if (!user.password) {
+      return res.status(403).json({
+        error: 'This account signs in with Google and has no password yet. Use "Set a password" to create one.',
+        code: 'no_password',
+      });
+    }
+
     const isMatch = await user.comparePassword(currentPassword);
     if (!isMatch) {
       logAudit(req, 'auth.change_password.failed',

--- a/backend/src/routes/climate.js
+++ b/backend/src/routes/climate.js
@@ -318,6 +318,15 @@ router.post('/devices', requireAuth, authLimiter, async (req, res) => {
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
+    // SSO-only account: no password exists to confirm with — point at the
+    // set-password flow instead of reporting "incorrect" (see routes/tokens.js).
+    if (!user.password) {
+      logAudit(req, 'climate.device.create_failed', { type: 'user', id: user._id }, { reason: 'no_password' });
+      return res.status(403).json({
+        error: 'This account signs in with Google and has no password yet. Set one first (Settings → Set a password), then register the device.',
+        code: 'no_password',
+      });
+    }
     const isMatch = await user.comparePassword(password);
     if (!isMatch) {
       logAudit(req, 'climate.device.create_failed', { type: 'user', id: user._id }, { reason: 'incorrect_password' });

--- a/backend/src/routes/climate.test.js
+++ b/backend/src/routes/climate.test.js
@@ -391,7 +391,7 @@ describe('POST /api/climate/devices', () => {
   });
 
   test('wrong password → 403 + audit, nothing created', async () => {
-    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(false) });
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(false) });
     const res = await request('POST', '/api/climate/devices', validBody);
     expect(res.status).toBe(403);
     expect(ApiToken.create).not.toHaveBeenCalled();
@@ -399,8 +399,18 @@ describe('POST /api/climate/devices', () => {
     expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'climate.device.create_failed', expect.anything(), { reason: 'incorrect_password' });
   });
 
+  test('SSO-only account (no password) → 403 with code no_password, nothing created', async () => {
+    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(false) });
+    const res = await request('POST', '/api/climate/devices', validBody);
+    expect(res.status).toBe(403);
+    expect((await res.json()).code).toBe('no_password');
+    expect(ApiToken.create).not.toHaveBeenCalled();
+    expect(ClimateDevice.create).not.toHaveBeenCalled();
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'climate.device.create_failed', expect.anything(), { reason: 'no_password' });
+  });
+
   test('device cap → 400', async () => {
-    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(true) });
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(true) });
     ClimateDevice.countDocuments.mockResolvedValue(5);
     const res = await request('POST', '/api/climate/devices', validBody);
     expect(res.status).toBe(400);
@@ -408,7 +418,7 @@ describe('POST /api/climate/devices', () => {
   });
 
   test('active-token cap → 400 (each device consumes a token slot)', async () => {
-    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(true) });
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(true) });
     ClimateDevice.countDocuments.mockResolvedValue(0);
     ApiToken.countDocuments.mockResolvedValue(10);
     const res = await request('POST', '/api/climate/devices', validBody);
@@ -417,7 +427,7 @@ describe('POST /api/climate/devices', () => {
   });
 
   test('happy path mints a climate-scoped token (shown once) and creates the device', async () => {
-    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(true) });
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(true) });
     ClimateDevice.countDocuments.mockResolvedValue(0);
     ApiToken.countDocuments.mockResolvedValue(0);
     ApiToken.create.mockImplementation(async (doc) => ({ ...doc, _id: 'tok9' }));
@@ -444,7 +454,7 @@ describe('POST /api/climate/devices', () => {
   });
 
   test('cellar assignment requires owner/editor role', async () => {
-    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(true) });
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(true) });
     ClimateDevice.countDocuments.mockResolvedValue(0);
     ApiToken.countDocuments.mockResolvedValue(0);
     Cellar.findOne.mockResolvedValue({ _id: OID2, user: 'other' });
@@ -456,7 +466,7 @@ describe('POST /api/climate/devices', () => {
   });
 
   test('a failed device insert never leaves an orphaned live token', async () => {
-    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(true) });
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(true) });
     ClimateDevice.countDocuments.mockResolvedValue(0);
     ApiToken.countDocuments.mockResolvedValue(0);
     ApiToken.create.mockImplementation(async (doc) => ({ ...doc, _id: 'tok9' }));

--- a/backend/src/routes/tokens.js
+++ b/backend/src/routes/tokens.js
@@ -49,6 +49,16 @@ router.post('/', requireAuth, requireNonDemo, authLimiter, async (req, res) => {
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
+    // SSO-only accounts have no password at all — comparePassword would return
+    // a truthful-but-misleading "incorrect". Tell them the actual fix (the UI
+    // keys on the code to show the set-password flow instead of the field).
+    if (!user.password) {
+      logAudit(req, 'token.create_failed', { type: 'user', id: user._id }, { reason: 'no_password' });
+      return res.status(403).json({
+        error: 'This account signs in with Google and has no password yet. Set one first (Settings → Set a password), then create the token.',
+        code: 'no_password',
+      });
+    }
     const isMatch = await user.comparePassword(password);
     if (!isMatch) {
       logAudit(req, 'token.create_failed', { type: 'user', id: user._id }, { reason: 'incorrect_password' });

--- a/backend/src/routes/tokens.test.js
+++ b/backend/src/routes/tokens.test.js
@@ -84,8 +84,19 @@ describe('POST /api/tokens', () => {
     expect(res.status).toBe(400);
   });
 
-  test('wrong password → 403 (NOT 401 — apiFetch auto-refreshes and re-submits on 401) and an audit entry, no token created', async () => {
+  test('SSO-only account (no password) → 403 with code no_password, pointing at set-password', async () => {
     User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(false) });
+    const res = await request('POST', '/api/tokens', validBody);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe('no_password');
+    expect(body.error).toMatch(/set one first/i);
+    expect(ApiToken.create).not.toHaveBeenCalled();
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'token.create_failed', expect.anything(), { reason: 'no_password' });
+  });
+
+  test('wrong password → 403 (NOT 401 — apiFetch auto-refreshes and re-submits on 401) and an audit entry, no token created', async () => {
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(false) });
     const res = await request('POST', '/api/tokens', validBody);
     expect(res.status).toBe(403);
     expect(ApiToken.create).not.toHaveBeenCalled();
@@ -93,7 +104,7 @@ describe('POST /api/tokens', () => {
   });
 
   test('active-token cap → 400', async () => {
-    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(true) });
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(true) });
     ApiToken.countDocuments.mockResolvedValue(10);
     const res = await request('POST', '/api/tokens', validBody);
     expect(res.status).toBe(400);
@@ -101,7 +112,7 @@ describe('POST /api/tokens', () => {
   });
 
   test('happy path: returns plaintext once, stores only the hash, audits the id', async () => {
-    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(true) });
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(true) });
     ApiToken.countDocuments.mockResolvedValue(0);
     ApiToken.create.mockImplementation(async (doc) => ({ ...doc, _id: 't1', createdAt: new Date() }));
 
@@ -124,7 +135,7 @@ describe('POST /api/tokens', () => {
   });
 
   test('duplicate scopes are de-duplicated', async () => {
-    User.findById.mockResolvedValue({ _id: 'u1', comparePassword: jest.fn().mockResolvedValue(true) });
+    User.findById.mockResolvedValue({ _id: 'u1', password: 'bcrypt-hash', comparePassword: jest.fn().mockResolvedValue(true) });
     ApiToken.countDocuments.mockResolvedValue(0);
     ApiToken.create.mockImplementation(async (doc) => ({ ...doc, _id: 't1', createdAt: new Date() }));
 

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -12,3 +12,15 @@ export const changePassword = (apiFetch, { currentPassword, newPassword }) =>
     headers: JSON_HEADERS,
     body: JSON.stringify({ currentPassword, newPassword })
   });
+
+// POST /api/auth/forgot-password — body: { email }. Deliberately plain fetch
+// (the endpoint is unauthenticated): the login page uses it for forgotten
+// passwords, and Settings reuses it so an SSO-only account can SET its first
+// password through the same email-verified reset flow (SetPasswordNotice).
+// The response is always the same generic 200 to prevent email enumeration.
+export const requestPasswordReset = (email) =>
+  fetch('/api/auth/forgot-password', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ email })
+  });

--- a/frontend/src/components/ApiTokensSection.js
+++ b/frontend/src/components/ApiTokensSection.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import Modal from './Modal';
+import SetPasswordNotice from './SetPasswordNotice';
 import { listApiTokens, createApiToken, revokeApiToken } from '../api/tokens';
 
 // Personal API tokens (Settings card). Scoped machine credentials for
@@ -16,7 +17,7 @@ const ALL_SCOPES = ['read', 'consume', 'write'];
 
 function ApiTokensSection() {
   const { t } = useTranslation();
-  const { apiFetch } = useAuth();
+  const { apiFetch, user } = useAuth();
 
   const [tokens, setTokens] = useState([]);
   const [listError, setListError] = useState(null);
@@ -207,19 +208,25 @@ function ApiTokensSection() {
                   </label>
                 ))}
               </div>
-              <div className="form-group">
-                <label htmlFor="api-token-password">{t('settings.apiTokens.passwordLabel')}</label>
-                <input
-                  id="api-token-password"
-                  type="password"
-                  className="input"
-                  autoComplete="current-password"
-                  value={password}
-                  onChange={e => setPassword(e.target.value)}
-                  required
-                />
-                <p className="settings-hint">{t('settings.apiTokens.passwordHint')}</p>
-              </div>
+              {user?.hasPassword === false ? (
+                // SSO-only account: nothing to confirm with — offer the email
+                // set-password flow instead of a field they can't fill.
+                <SetPasswordNotice />
+              ) : (
+                <div className="form-group">
+                  <label htmlFor="api-token-password">{t('settings.apiTokens.passwordLabel')}</label>
+                  <input
+                    id="api-token-password"
+                    type="password"
+                    className="input"
+                    autoComplete="current-password"
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    required
+                  />
+                  <p className="settings-hint">{t('settings.apiTokens.passwordHint')}</p>
+                </div>
+              )}
 
               {createError && <div className="alert alert-error">{createError}</div>}
 
@@ -227,7 +234,7 @@ function ApiTokensSection() {
                 <button type="button" className="btn btn-secondary" onClick={closeCreate} disabled={creating}>
                   {t('common.cancel')}
                 </button>
-                <button type="submit" className="btn btn-primary" disabled={creating}>
+                <button type="submit" className="btn btn-primary" disabled={creating || user?.hasPassword === false}>
                   {creating ? t('settings.apiTokens.creatingBtn') : t('settings.apiTokens.createConfirmBtn')}
                 </button>
               </div>

--- a/frontend/src/components/ClimateDevicesSection.js
+++ b/frontend/src/components/ClimateDevicesSection.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import Modal from './Modal';
+import SetPasswordNotice from './SetPasswordNotice';
 import { listClimateDevices, createClimateDevice, updateClimateDevice, deleteClimateDevice } from '../api/climate';
 import { listCellars } from '../api/cellars';
 
@@ -12,7 +13,7 @@ import { listCellars } from '../api/cellars';
 // be labeled / calibration-adjusted here.
 function ClimateDevicesSection() {
   const { t } = useTranslation();
-  const { apiFetch } = useAuth();
+  const { apiFetch, user } = useAuth();
 
   const [devices, setDevices] = useState([]);
   const [maxDevices, setMaxDevices] = useState(5);
@@ -260,19 +261,25 @@ function ClimateDevicesSection() {
                 <label htmlFor="climate-device-cellar">{t('settings.climateDevices.cellarLabel')}</label>
                 {cellarSelect(cellarId, setCellarId, 'climate-device-cellar')}
               </div>
-              <div className="form-group">
-                <label htmlFor="climate-device-password">{t('settings.climateDevices.passwordLabel')}</label>
-                <input
-                  id="climate-device-password"
-                  type="password"
-                  className="input"
-                  autoComplete="current-password"
-                  value={password}
-                  onChange={e => setPassword(e.target.value)}
-                  required
-                />
-                <p className="settings-hint">{t('settings.climateDevices.passwordHint')}</p>
-              </div>
+              {user?.hasPassword === false ? (
+                // SSO-only account: nothing to confirm with — offer the email
+                // set-password flow instead of a field they can't fill.
+                <SetPasswordNotice />
+              ) : (
+                <div className="form-group">
+                  <label htmlFor="climate-device-password">{t('settings.climateDevices.passwordLabel')}</label>
+                  <input
+                    id="climate-device-password"
+                    type="password"
+                    className="input"
+                    autoComplete="current-password"
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    required
+                  />
+                  <p className="settings-hint">{t('settings.climateDevices.passwordHint')}</p>
+                </div>
+              )}
 
               {createError && <div className="alert alert-error">{createError}</div>}
 
@@ -280,7 +287,7 @@ function ClimateDevicesSection() {
                 <button type="button" className="btn btn-secondary" onClick={closeCreate} disabled={creating}>
                   {t('common.cancel')}
                 </button>
-                <button type="submit" className="btn btn-primary" disabled={creating}>
+                <button type="submit" className="btn btn-primary" disabled={creating || user?.hasPassword === false}>
                   {creating ? t('settings.climateDevices.creatingBtn') : t('settings.climateDevices.createConfirmBtn')}
                 </button>
               </div>

--- a/frontend/src/components/SetPasswordNotice.js
+++ b/frontend/src/components/SetPasswordNotice.js
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import { requestPasswordReset } from '../api/auth';
+
+/**
+ * Shown wherever a password-confirmed action meets an SSO-only account
+ * (user.hasPassword === false): explains why there is no password and offers
+ * to email a set-password link — the SAME battle-tested reset flow the login
+ * page uses, so control of the INBOX (not just this browser session) is what
+ * mints the first password. A hijacked session must not be able to grant
+ * itself a password silently.
+ *
+ * Pass `text` to override the default "this action asks for a password"
+ * explanation (e.g. the Settings card supplies its own hint).
+ */
+export default function SetPasswordNotice({ text }) {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const [status, setStatus] = useState('idle'); // idle | sending | sent | error
+
+  const send = async () => {
+    setStatus('sending');
+    try {
+      const res = await requestPasswordReset(user.email);
+      setStatus(res.ok ? 'sent' : 'error');
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  return (
+    <div className="set-password-notice">
+      <p className="settings-hint">
+        {text || t('settings.setPassword.notice',
+          'You sign in with Google, so this account has no password yet — and this action asks for one as extra confirmation.')}
+      </p>
+      {status === 'sent' ? (
+        <p className="settings-saved">
+          {t('settings.setPassword.sent',
+            "Link sent — check your inbox. After you set a password you'll be signed out everywhere once; sign back in with Google or your new password.")}
+        </p>
+      ) : (
+        <button
+          type="button"
+          className="btn btn-secondary"
+          onClick={send}
+          disabled={status === 'sending'}
+        >
+          {status === 'sending'
+            ? t('settings.setPassword.sending', 'Sending…')
+            : t('settings.setPassword.cta', 'Email me a set-password link')}
+        </button>
+      )}
+      {status === 'error' && (
+        <div className="alert alert-error">
+          {t('settings.setPassword.error', 'Could not send the email — please try again.')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SetPasswordNotice.test.js
+++ b/frontend/src/components/SetPasswordNotice.test.js
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import SetPasswordNotice from './SetPasswordNotice';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, fallback) => (typeof fallback === 'string' ? fallback : key),
+  }),
+}));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'somm@cellarion.app', hasPassword: false } }),
+}));
+
+beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+afterEach(() => vi.unstubAllGlobals());
+
+describe('SetPasswordNotice', () => {
+  test('explains the missing password and offers the email link', () => {
+    render(<SetPasswordNotice />);
+    expect(screen.getByText(/no password yet/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /set-password link/i })).toBeInTheDocument();
+  });
+
+  test('custom text overrides the default explanation', () => {
+    render(<SetPasswordNotice text="Custom explanation" />);
+    expect(screen.getByText('Custom explanation')).toBeInTheDocument();
+    expect(screen.queryByText(/asks for one as extra confirmation/i)).not.toBeInTheDocument();
+  });
+
+  test('emails the reset link for the signed-in account and shows the sent state', async () => {
+    fetch.mockResolvedValue({ ok: true });
+    render(<SetPasswordNotice />);
+    fireEvent.click(screen.getByRole('button', { name: /set-password link/i }));
+    await waitFor(() => expect(screen.getByText(/check your inbox/i)).toBeInTheDocument());
+    // Uses the SAME forgot-password flow as the login page — inbox control,
+    // not this session, is what mints the first password.
+    expect(fetch).toHaveBeenCalledWith('/api/auth/forgot-password', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ email: 'somm@cellarion.app' }),
+    }));
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('shows an error state when the request fails, button stays for retry', async () => {
+    fetch.mockRejectedValue(new Error('network'));
+    render(<SetPasswordNotice />);
+    fireEvent.click(screen.getByRole('button', { name: /set-password link/i }));
+    await waitFor(() => expect(screen.getByText(/could not send/i)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /set-password link/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -214,6 +214,15 @@
       "pushNotConfigured": "Push notifications are not configured on this server.",
       "pushHint": "Push delivers notifications to your device even when Cellarion is closed."
     },
+    "setPassword": {
+      "title": "Set a password",
+      "hint": "You sign in with Google. Setting a password also lets you log in with email + password, and unlocks actions that ask for a password as extra confirmation (API tokens, climate devices).",
+      "notice": "You sign in with Google, so this account has no password yet — and this action asks for one as extra confirmation.",
+      "cta": "Email me a set-password link",
+      "sending": "Sending…",
+      "sent": "Link sent — check your inbox. After you set a password you'll be signed out everywhere once; sign back in with Google or your new password.",
+      "error": "Could not send the email — please try again."
+    },
     "changePassword": {
       "title": "Change password",
       "hint": "Choose a strong password: at least 12 characters with an uppercase letter, a lowercase letter, a number, and a special character. Changing your password signs you out on all other devices.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -214,6 +214,15 @@
       "pushNotConfigured": "Push-aviseringar är inte konfigurerade på denna server.",
       "pushHint": "Push levererar aviseringar till din enhet även när Cellarion är stängt."
     },
+    "setPassword": {
+      "title": "Skapa ett lösenord",
+      "hint": "Du loggar in med Google. Med ett lösenord kan du även logga in med e-post + lösenord, och använda funktioner som ber om lösenordet som extra bekräftelse (API-nycklar, klimatenheter).",
+      "notice": "Du loggar in med Google, så kontot har inget lösenord ännu — och den här åtgärden ber om ett som extra bekräftelse.",
+      "cta": "Mejla mig en länk för att skapa lösenord",
+      "sending": "Skickar…",
+      "sent": "Länk skickad — kolla din inkorg. När du har skapat ett lösenord loggas du ut överallt en gång; logga in igen med Google eller ditt nya lösenord.",
+      "error": "Kunde inte skicka mejlet — försök igen."
+    },
     "changePassword": {
       "title": "Byt lösenord",
       "hint": "Välj ett starkt lösenord: minst 12 tecken med en versal, en gemen, en siffra och ett specialtecken. När du byter lösenord loggas du ut på alla andra enheter.",

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -12,6 +12,7 @@ import { isPushSupported, getPushPermissionState, subscribeToPush, unsubscribeFr
 import { downloadBlobObject } from '../utils/downloadBlob';
 import ApiTokensSection from '../components/ApiTokensSection';
 import AiConnectSection from '../components/AiConnectSection';
+import SetPasswordNotice from '../components/SetPasswordNotice';
 import McpActivitySection from '../components/McpActivitySection';
 import ClimateDevicesSection from '../components/ClimateDevicesSection';
 import { journalPromptOptedOut, setJournalPromptOptOut } from '../components/JournalPrompt';
@@ -415,8 +416,18 @@ function Settings() {
         </form>
       </div>
 
+      {/* ── Set-password card: SSO-only accounts (no password) get the email
+             set-password flow instead of a change form they can't fill ── */}
+      {!user?.isDemo && user?.hasPassword === false && (
+      <div className="card settings-card">
+        <h2 className="settings-section-title">{t('settings.setPassword.title', 'Set a password')}</h2>
+        <SetPasswordNotice text={t('settings.setPassword.hint',
+          'You sign in with Google. Setting a password also lets you log in with email + password, and unlocks actions that ask for a password as extra confirmation (API tokens, climate devices).')} />
+      </div>
+      )}
+
       {/* ── Change password card (hidden for demo accounts — no credential changes) ── */}
-      {!user?.isDemo && (
+      {!user?.isDemo && user?.hasPassword !== false && (
       <div className="card settings-card">
         <h2 className="settings-section-title">{t('settings.changePassword.title')}</h2>
         <p className="settings-hint">{t('settings.changePassword.hint')}</p>


### PR DESCRIPTION
## The gap
Google-SSO accounts have **no password**, but three surfaces demand a fresh password confirmation: **API-token minting**, **climate-device creation**, and **change-password**. An SSO-only user faced a field they could never fill and a misleading "Password is incorrect."

## The design (as discussed)
The first password is minted through the **existing forgot-password reset flow** (email link) — not a session-based form. A hijacked browser session must not be able to grant itself a password; control of the **inbox** is the proof, exactly the trust password reset has always encoded. Two things made this small: `comparePassword` already returns a clean `false` for password-less accounts, and `reset-password` already works for them.

### Backend
- The three gates now answer a password-less account with **403 `{ code: 'no_password' }`** and an honest message pointing at Settings → Set a password (audit reason `no_password`). `User.toJSON` already exposed `hasPassword`/`linkedProviders` — the SSO PR anticipated this; the UI just never consumed it.

### Frontend
- New **`SetPasswordNotice`** — explains the situation and emails the set-password link (`requestPasswordReset`, the same enumeration-safe endpoint the login page uses), with sending/sent/error states. Sent-state copy warns about the one-time sign-out-everywhere that reset performs.
- **ApiTokensSection** + **ClimateDevicesSection**: for `hasPassword:false` the password field is replaced by the notice, submit disabled.
- **Settings**: the change-password card becomes a **"Set a password"** card for password-less accounts.
- i18n `settings.setPassword` in en + sv (sv machine-authored — flag for the review pass).

### Tests
- `no_password` 403 cases for both token gates (existing user mocks gained the `password` field the guard checks — they'd have tripped it).
- 4-test RTL suite for `SetPasswordNotice`: default/custom text, the sent flow asserting the `forgot-password` POST carries the signed-in account's email, error + retry.
- Backend **134 suites / 2020 green** (node:20-alpine) · frontend **34 suites / 665 green** · build clean.

## Compose impact
None. Not released — rides the next release; prod v1.82.0 unaffected (SSO users there can use the OAuth connector path meanwhile, and "forgot password" from the login page as the interim workaround).