### PR TITLE
release: v1.82.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.82.0",
+  "version": "1.82.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.82.0",
+      "version": "1.82.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.82.0",
+  "version": "1.82.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.82.0",
+  "version": "1.82.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.82.0",
+      "version": "1.82.1",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.82.0",
+  "version": "1.82.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Patch release: the set-a-password flow for Google-SSO accounts (#763) — closes the gap where SSO users could not pass the password-confirmation gates (API tokens, climate devices, change password). Deploying 10:20 CEST (banner live).