### PR TITLE
fix(taxonomy): add missed Refosco merge and Pinot Meunier enrichment

### DIFF
--- a/backend/src/scripts/cleanup-taxonomy-2026-07.js
+++ b/backend/src/scripts/cleanup-taxonomy-2026-07.js
@@ -52,6 +52,7 @@ const GRAPE_MERGES = [
   { from: 'Moscatel', to: 'Muscat of Alexandria', synonyms: false },  // Canary "Moscatel"
   { from: 'Bonarda', to: 'Croatina', synonyms: false },               // Colli Piacentini Bonarda
   { from: 'Picpoul', to: 'Picpoul Noir', synonyms: false },           // both wines are red CdP
+  { from: 'Refosco', to: 'Refosco dal Peduncolo Rosso', synonyms: false }, // Miani grows RdPR
 
   // Same variety, different name — old name becomes a synonym
   { from: 'Pinot Nero', to: 'Pinot Noir' },

--- a/backend/src/scripts/enrich-taxonomy-2026-07.js
+++ b/backend/src/scripts/enrich-taxonomy-2026-07.js
@@ -58,6 +58,7 @@ const G = {
   'Picardan': { color: 'White', origin: 'France (Châteauneuf-du-Pape)' },
   'Grenache Gris': { color: 'White', origin: 'Spain / France (Roussillon)' },
   'Grolleau': { color: 'Red', origin: 'France (Loire Valley)' },
+  'Pinot Meunier': { color: 'Red', origin: 'France (Champagne)', desc: 'Champagne\'s quietly essential third grape — a Pinot Noir mutation that buds late and ripens early, bringing supple orchard fruit and roundness to the blend; increasingly bottled on its own by growers.', chars: ['orchard fruit', 'supple', 'round'], aging: 'Very good in Champagne blends' },
   'Gamay': { color: 'Red', origin: 'France (Beaujolais)', desc: 'The grape of Beaujolais, where granite crus like Morgon and Moulin-à-Vent turn its bright cherry fruit and crunchy acidity into wines of real depth.', chars: ['cherry', 'crunchy acidity', 'light-medium body'], aging: 'Cru Beaujolais ages 10+ years' },
   'Trousseau': { color: 'Red', origin: 'France (Jura)' },
   'Poulsard': { color: 'Red', origin: 'France (Jura)' },


### PR DESCRIPTION
Post-apply verification on prod caught two omissions from #766/#767: the audit's Refosco→Refosco dal Peduncolo Rosso merge never made it into the script's merge map, and Pinot Meunier (130 wines — a top-10 grape) was missing from the enrichment data. Both scripts are idempotent, so re-running them applies exactly these two changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)