### PR TITLE
feat(taxonomy): render grape/country/region descriptions as markdown

### DIFF
--- a/frontend/src/components/MarkdownText.js
+++ b/frontend/src/components/MarkdownText.js
@@ -1,0 +1,14 @@
+import ReactMarkdown from 'react-markdown';
+import rehypeSanitize from 'rehype-sanitize';
+
+// Renders a trusted-but-sanitised markdown string. Same rehype-sanitize guard
+// used for the AI tasting profile on WineDetail. Wrap in a div so callers can
+// style the block elements (headings, lists, paragraphs) via a className.
+export default function MarkdownText({ children, className }) {
+  if (!children) return null;
+  return (
+    <div className={className}>
+      <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{children}</ReactMarkdown>
+    </div>
+  );
+}

--- a/frontend/src/pages/CountryDetail.js
+++ b/frontend/src/pages/CountryDetail.js
@@ -3,9 +3,11 @@ import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import SEOHead from '../components/SEOHead';
 import Layout from '../components/Layout';
+import MarkdownText from '../components/MarkdownText';
 import { useAuth } from '../contexts/AuthContext';
 import SITE_URL from '../config/siteUrl';
 import { API_URL } from '../api/apiConstants';
+import stripMarkdown from '../utils/stripMarkdown';
 import './TaxonomyDetail.css';
 
 export default function CountryDetail() {
@@ -41,7 +43,7 @@ export default function CountryDetail() {
   const pages = Math.ceil(total / limit);
 
   const description = country.description || `Explore wines from ${country.name} tracked by Cellarion collectors worldwide.`;
-  const metaDescription = description.replace(/\n/g, ' ').slice(0, 157);
+  const metaDescription = stripMarkdown(description).slice(0, 157);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -78,7 +80,7 @@ export default function CountryDetail() {
       </div>
 
       {country.description && (
-        <p className="taxonomy-description">{country.description}</p>
+        <MarkdownText className="taxonomy-description taxonomy-markdown">{country.description}</MarkdownText>
       )}
 
       {regions?.length > 0 && (

--- a/frontend/src/pages/GrapeDetail.js
+++ b/frontend/src/pages/GrapeDetail.js
@@ -3,9 +3,11 @@ import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import SEOHead from '../components/SEOHead';
 import Layout from '../components/Layout';
+import MarkdownText from '../components/MarkdownText';
 import { useAuth } from '../contexts/AuthContext';
 import SITE_URL from '../config/siteUrl';
 import { API_URL } from '../api/apiConstants';
+import stripMarkdown from '../utils/stripMarkdown';
 import './TaxonomyDetail.css';
 
 export default function GrapeDetail() {
@@ -41,7 +43,7 @@ export default function GrapeDetail() {
   const pages = Math.ceil(total / limit);
 
   const description = grape.description || `Discover wines made from ${grape.name}${grape.origin ? ` originating in ${grape.origin}` : ''}.`;
-  const metaDescription = description.replace(/\n/g, ' ').slice(0, 157);
+  const metaDescription = stripMarkdown(description).slice(0, 157);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -80,7 +82,7 @@ export default function GrapeDetail() {
       </div>
 
       {grape.description && (
-        <p className="taxonomy-description">{grape.description}</p>
+        <MarkdownText className="taxonomy-description taxonomy-markdown">{grape.description}</MarkdownText>
       )}
 
       {grape.characteristics?.length > 0 && (

--- a/frontend/src/pages/RegionDetail.js
+++ b/frontend/src/pages/RegionDetail.js
@@ -3,9 +3,11 @@ import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import SEOHead from '../components/SEOHead';
 import Layout from '../components/Layout';
+import MarkdownText from '../components/MarkdownText';
 import { useAuth } from '../contexts/AuthContext';
 import SITE_URL from '../config/siteUrl';
 import { API_URL } from '../api/apiConstants';
+import stripMarkdown from '../utils/stripMarkdown';
 import './TaxonomyDetail.css';
 
 export default function RegionDetail() {
@@ -41,7 +43,7 @@ export default function RegionDetail() {
   const pages = Math.ceil(total / limit);
 
   const description = region.description || `Explore wines from ${region.name}${region.country?.name ? `, ${region.country.name}` : ''} tracked by Cellarion collectors.`;
-  const metaDescription = description.replace(/\n/g, ' ').slice(0, 157);
+  const metaDescription = stripMarkdown(description).slice(0, 157);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -84,7 +86,7 @@ export default function RegionDetail() {
       </div>
 
       {region.description && (
-        <p className="taxonomy-description">{region.description}</p>
+        <MarkdownText className="taxonomy-description taxonomy-markdown">{region.description}</MarkdownText>
       )}
 
       {region.typicalGrapes?.length > 0 && (

--- a/frontend/src/pages/TaxonomyDetail.css
+++ b/frontend/src/pages/TaxonomyDetail.css
@@ -33,6 +33,34 @@
   max-width: 760px;
 }
 
+/* Rendered-markdown description (grape/country/region). The block wrapper
+   keeps the outer margin; child elements carry their own rhythm. Our
+   templates use bold section lead-ins, so `strong` is the visual anchor. */
+.taxonomy-markdown > :first-child { margin-top: 0; }
+.taxonomy-markdown > :last-child { margin-bottom: 0; }
+.taxonomy-markdown p { margin: 0 0 12px; }
+.taxonomy-markdown h2,
+.taxonomy-markdown h3,
+.taxonomy-markdown h4 {
+  font-family: var(--font-heading);
+  font-size: 1.02rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 20px 0 8px;
+  letter-spacing: -0.01em;
+}
+.taxonomy-markdown ul,
+.taxonomy-markdown ol { margin: 0 0 12px; padding-left: 1.25em; }
+.taxonomy-markdown li { margin-bottom: 4px; }
+.taxonomy-markdown strong { color: var(--color-text); font-weight: 600; }
+.taxonomy-markdown a { color: var(--color-primary); text-decoration: underline; }
+.taxonomy-markdown blockquote {
+  margin: 0 0 12px;
+  padding-left: 14px;
+  border-left: 3px solid var(--color-border-light);
+  color: var(--color-text-secondary);
+}
+
 .taxonomy-meta-pills {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/utils/stripMarkdown.js
+++ b/frontend/src/utils/stripMarkdown.js
@@ -1,0 +1,20 @@
+// Flatten a markdown string to plain text for places that must stay
+// unformatted: <meta description>, JSON-LD, OpenGraph. Not a full parser —
+// just strips the syntax our taxonomy descriptions actually use (headings,
+// bold/italic, links, inline code, list bullets, blockquotes) and collapses
+// whitespace. Rendering to the page uses react-markdown; this is for metadata.
+export default function stripMarkdown(md) {
+  if (!md) return '';
+  return String(md)
+    .replace(/`([^`]+)`/g, '$1')            // inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')    // images
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → link text
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')      // ATX headings
+    .replace(/^\s{0,3}>\s?/gm, '')           // blockquotes
+    .replace(/^\s*[-*+]\s+/gm, '')           // unordered list bullets
+    .replace(/^\s*\d+\.\s+/gm, '')           // ordered list markers
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')      // bold
+    .replace(/(\*|_)(.*?)\1/g, '$2')         // italic
+    .replace(/\s+/g, ' ')                     // collapse whitespace/newlines
+    .trim();
+}

--- a/frontend/src/utils/stripMarkdown.test.js
+++ b/frontend/src/utils/stripMarkdown.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import stripMarkdown from './stripMarkdown';
+
+describe('stripMarkdown', () => {
+  it('returns empty string for falsy input', () => {
+    expect(stripMarkdown('')).toBe('');
+    expect(stripMarkdown(null)).toBe('');
+    expect(stripMarkdown(undefined)).toBe('');
+  });
+
+  it('strips bold and italic markers, keeping the text', () => {
+    expect(stripMarkdown('**Nebbiolo** is a *red* grape')).toBe('Nebbiolo is a red grape');
+    expect(stripMarkdown('__bold__ and _italic_')).toBe('bold and italic');
+  });
+
+  it('strips heading markers and collapses newlines to spaces', () => {
+    expect(stripMarkdown('## In the glass\nPale garnet.')).toBe('In the glass Pale garnet.');
+  });
+
+  it('reduces links to their text', () => {
+    expect(stripMarkdown('see [the guide](/blog/x) now')).toBe('see the guide now');
+  });
+
+  it('strips list bullets, inline code and blockquotes', () => {
+    expect(stripMarkdown('- one\n- two')).toBe('one two');
+    expect(stripMarkdown('use `npx cellarion-mcp`')).toBe('use npx cellarion-mcp');
+    expect(stripMarkdown('> a quote')).toBe('a quote');
+  });
+
+  it('flattens a realistic taxonomy description for a meta tag', () => {
+    const md = '**Syrah** is a red grape from the Northern Rhône.\n\n**In the glass** — black pepper and dark fruit.';
+    expect(stripMarkdown(md)).toBe(
+      'Syrah is a red grape from the Northern Rhône. In the glass — black pepper and dark fruit.'
+    );
+  });
+});


### PR DESCRIPTION
Part of the taxonomy-content upgrade. The three public taxonomy pages rendered `description` as a plain `<p>`; the field now holds richer **markdown** (bold section lead-ins, occasional lists), so it needs a markdown renderer.

## What
- **`MarkdownText`** — a small shared wrapper around `react-markdown` + `rehype-sanitize`, the exact sanitised path already used for the AI tasting profile on WineDetail.
- **GrapeDetail / CountryDetail / RegionDetail** render `description` through it, inside a styled `.taxonomy-markdown` block.
- **`stripMarkdown`** util flattens the markdown to plain text for the `<meta name=description>` tag and JSON-LD (which must not contain `##`/`**`). Previously the raw string was sliced straight in.
- **CSS** for the rendered block (headings, lists, bold lead-ins, blockquotes) in TaxonomyDetail.css.

## Tests / build
- 6 unit tests for `stripMarkdown`.
- `npm run build` passes (28s, exit 0).

## docker-compose / prod impact
None — frontend-only, no new deps (react-markdown/rehype-sanitize already shipped). Ships in the next frontend image build.

Companion PRs: MCP taxonomy lookup tools (separate) + the content seed that fills these descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)