### PR TITLE
fix(mcp): attach-by-URL actually works + one photo covers all bottles of a wine

### DIFF
--- a/backend/src/mcp/imageTools.test.js
+++ b/backend/src/mcp/imageTools.test.js
@@ -52,8 +52,8 @@ const CTX = { user: { id: ME }, scopes: ['write'], req: { user: { id: ME }, head
 const tool = (name) => allTools().find((t) => t.name === name);
 const parse = (res) => JSON.parse(res.content[0].text);
 
-const ownBottle = () => {
-  const b = { _id: new mongoose.Types.ObjectId(oid('d')), cellar: new mongoose.Types.ObjectId(oid('c')), vintage: '2015', status: 'active' };
+const ownBottle = (over = {}) => {
+  const b = { _id: new mongoose.Types.ObjectId(oid('d')), cellar: new mongoose.Types.ObjectId(oid('c')), vintage: '2015', status: 'active', ...over };
   Bottle.findById.mockReturnValue(chain(b));
   Cellar.findById.mockReturnValue(chain({ _id: b.cellar, user: ME, members: [], deletedAt: null }));
   return b;
@@ -76,20 +76,33 @@ describe('registration', () => {
 });
 
 describe('attach_bottle_image', () => {
-  test('image_url path: SSRF-guarded fetch → shared pipeline → ledger row', async () => {
-    ownBottle();
+  test('image_url path: SSRF-guarded fetch → shared pipeline WITH the wine linkage → ledger row', async () => {
+    ownBottle({ wineDefinition: new mongoose.Types.ObjectId(oid('f')) });
     safeFetchImage.mockResolvedValue({ buffer: Buffer.from('imgbytes'), contentType: 'image/jpeg' });
     const res = await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_url: 'https://cdn.example.com/label.jpg' }, CTX);
     const body = parse(res);
     expect(body.error).toBeUndefined();
     expect(safeFetchImage).toHaveBeenCalledWith('https://cdn.example.com/label.jpg');
-    // The bytes go to the SAME pipeline the web upload uses.
+    // The bytes go to the SAME pipeline the web upload uses — INCLUDING the
+    // wine link, so one photo shows on every bottle of the wine (the launch-day
+    // "attached 5 times for 5 identical bottles" report).
     expect(ingestBottleImage).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: ME, buffer: expect.any(Buffer) }), CTX.req);
+      expect.objectContaining({ userId: ME, buffer: expect.any(Buffer), wineDefinitionId: oid('f') }), CTX.req);
     expect(body.data.source).toBe('url');
+    expect(body.data.shows_on_all_bottles_of_wine).toBe(true);
     const row = McpActionLog.create.mock.calls[0][0];
     expect(row.action).toBe('attach_image');
     expect(row.detail.imageId).toBeDefined();
+  });
+
+  test('a bottle with no registry wine yet attaches bottle-only (no wine linkage)', async () => {
+    ownBottle(); // pending-wine-request bottles have no wineDefinition
+    safeFetchImage.mockResolvedValue({ buffer: Buffer.from('imgbytes'), contentType: 'image/jpeg' });
+    const res = await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_url: 'https://cdn.example.com/label.jpg' }, CTX);
+    expect(parse(res).error).toBeUndefined();
+    expect(ingestBottleImage).toHaveBeenCalledWith(
+      expect.objectContaining({ wineDefinitionId: null }), CTX.req);
+    expect(parse(res).data.shows_on_all_bottles_of_wine).toBe(false);
   });
 
   test('image_base64 path: strips a data: prefix and decodes', async () => {

--- a/backend/src/mcp/tools/images.js
+++ b/backend/src/mcp/tools/images.js
@@ -27,7 +27,8 @@ registerTool({
     'Adds a label or bottle photo to one of the user\'s bottles, from an image URL (https) or base64 image data ' +
     '(JPEG/PNG/WebP). Use image_url for a product image you found on the web (e.g. a retailer\'s wine page); use ' +
     'image_base64 for a photo the user shared directly. The image is background-removed automatically after upload. ' +
-    'Confirm with the user which bottle before attaching. Reversible via undo_last.',
+    'Attach ONCE per wine: the photo shows on ALL the user\'s bottles of that wine, so never repeat the same photo ' +
+    'for duplicate bottles. Confirm with the user which bottle before attaching. Reversible via undo_last.',
   scope: 'write',
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
   inputSchema: {
@@ -70,8 +71,16 @@ registerTool({
     }
 
     // Shared pipeline: validate + strip metadata + persist + background-remove.
+    // wineDefinitionId makes the photo WINE-linked exactly like the web upload
+    // (routes/images.js): it then shows on all the user's bottles of this wine
+    // and enters the registry-image review pipeline. Without it the photo was
+    // stranded on the single bottle — the "attached 5 times for 5 identical
+    // bottles" launch-day report.
     const credit = args.credit ? String(args.credit).slice(0, 200) : null;
-    const result = await ingestBottleImage({ buffer, userId: ctx.user.id, bottle, credit }, ctx.req);
+    const wineDefinitionId = bottle.wineDefinition
+      ? String(bottle.wineDefinition._id || bottle.wineDefinition)
+      : null;
+    const result = await ingestBottleImage({ buffer, userId: ctx.user.id, bottle, wineDefinitionId, credit }, ctx.req);
     if (result.error) {
       // 4xx = the caller's image is bad (invalid_input); 5xx = a transient
       // infra fault → `unavailable` (MCP-audit M3: not the agent's cadence).
@@ -81,12 +90,13 @@ registerTool({
     logAudit(ctx.req, 'image.attach', { type: 'bottle', id: bottle._id, cellarId: bottle.cellar }, { via: 'mcp', imageId: String(image._id) });
 
     const envelope = {
-      summary: `Attached a photo to vintage ${bottle.vintage} (background removal in progress)`,
+      summary: `Attached a photo to vintage ${bottle.vintage}${wineDefinitionId ? ' — it shows on all bottles of this wine' : ''} (background removal in progress)`,
       data: {
         image_id: image._id,
         bottle_id: bottle._id,
         status: image.status,
         source: args.image_url ? 'url' : 'upload',
+        shows_on_all_bottles_of_wine: !!wineDefinitionId,
         undo: 'undo_last removes the photo',
       },
     };

--- a/backend/src/utils/safeImageFetch.js
+++ b/backend/src/utils/safeImageFetch.js
@@ -120,6 +120,25 @@ async function resolvePublicAddress(hostname) {
   return records[0];
 }
 
+/**
+ * The DNS pin as a lookup implementation. Node's socket layer calls lookup in
+ * TWO conventions: the classic single-address form, and — when Happy Eyeballs
+ * (autoSelectFamily, default-on since Node 20) probes — with `opts.all: true`,
+ * expecting an ARRAY of { address, family } entries. Answering the all:true
+ * call in the classic form makes Node read `undefined` as the address list and
+ * reject the connection with ERR_INVALID_IP_ADDRESS ("Invalid IP address:
+ * undefined") — which silently broke EVERY attach-by-URL in production. Handle
+ * both conventions; the pin holds either way (only the pre-validated address
+ * is ever returned, whatever DNS would say now).
+ */
+function pinnedLookup(pinned) {
+  return (host, opts, cb) => {
+    if (typeof opts === 'function') { cb = opts; opts = {}; }
+    if (opts && opts.all) return cb(null, [{ address: pinned.address, family: pinned.family }]);
+    return cb(null, pinned.address, pinned.family);
+  };
+}
+
 function fetchOnce(urlObj, pinned) {
   return new Promise((resolve, reject) => {
     // WALL-CLOCK deadline for the whole request (connect + headers + body).
@@ -146,7 +165,10 @@ function fetchOnce(urlObj, pinned) {
         headers: { 'User-Agent': 'Cellarion-ImageFetch/1.0 (+https://cellarion.app)' },
         timeout: TIMEOUT_MS,
         // The pin: whatever DNS says NOW, connect to the address validated above.
-        lookup: (host, opts, cb) => cb(null, pinned.address, pinned.family),
+        lookup: pinnedLookup(pinned),
+        // One pinned address — there is nothing for Happy Eyeballs to race, and
+        // disabling it keeps the classic lookup convention the primary path.
+        autoSelectFamily: false,
       },
       (res) => {
         const status = res.statusCode || 0;
@@ -158,8 +180,14 @@ function fetchOnce(urlObj, pinned) {
           res.resume();
           return failed(new Error(`image URL answered HTTP ${status}`));
         }
+        // Content-Type is a fast-fail HINT only — the byte-level truth is
+        // enforced downstream by sanitizeImageBuffer (decode + format sniff,
+        // fail closed). Generic application/octet-stream is how some product
+        // CDNs (e.g. Systembolaget's) serve images, so it flows through to the
+        // byte check; declared NON-image types (text/html, application/json …)
+        // still fail fast without downloading the body.
         const ct = String(res.headers['content-type'] || '').toLowerCase();
-        if (ct && !ct.startsWith('image/')) {
+        if (ct && !ct.startsWith('image/') && !ct.startsWith('application/octet-stream')) {
           res.destroy();
           return failed(new Error(`URL is not an image (content-type ${ct.split(';')[0]})`));
         }
@@ -217,4 +245,4 @@ async function safeFetchImage(rawUrl) {
   throw new Error(`image URL redirected more than ${MAX_REDIRECTS} times`);
 }
 
-module.exports = { safeFetchImage, isPrivateAddress, MAX_BYTES };
+module.exports = { safeFetchImage, isPrivateAddress, pinnedLookup, MAX_BYTES };

--- a/backend/src/utils/safeImageFetch.test.js
+++ b/backend/src/utils/safeImageFetch.test.js
@@ -9,7 +9,7 @@
  * (dns pinning, redirect re-validation) is exercised by the live e2e.
  */
 
-const { isPrivateAddress, safeFetchImage } = require('./safeImageFetch');
+const { isPrivateAddress, safeFetchImage, pinnedLookup } = require('./safeImageFetch');
 
 describe('isPrivateAddress', () => {
   test.each([
@@ -62,5 +62,47 @@ describe('safeFetchImage input validation (pre-network)', () => {
     await expect(safeFetchImage('https://169.254.169.254/latest/meta-data/')).rejects.toThrow(/private or reserved/);
     await expect(safeFetchImage('https://127.0.0.1/x.jpg')).rejects.toThrow(/private or reserved/);
     await expect(safeFetchImage('https://[::1]/x.jpg')).rejects.toThrow(/private or reserved/);
+  });
+});
+
+// The DNS pin must speak BOTH lookup callback conventions. Node 20's Happy
+// Eyeballs (autoSelectFamily, default-on) calls lookup with { all: true } and
+// expects an ARRAY — answering in the classic (addr, family) form made Node
+// throw ERR_INVALID_IP_ADDRESS ("Invalid IP address: undefined") and broke
+// every attach-by-URL in production on launch day. These pin both shapes.
+describe('pinnedLookup (Happy Eyeballs convention)', () => {
+  const pinned = { address: '93.184.216.34', family: 4 };
+
+  test('classic convention: (err, address, family)', (done) => {
+    pinnedLookup(pinned)('example.com', {}, (err, address, family) => {
+      expect(err).toBeNull();
+      expect(address).toBe('93.184.216.34');
+      expect(family).toBe(4);
+      done();
+    });
+  });
+
+  test('all:true convention (autoSelectFamily): (err, [{ address, family }])', (done) => {
+    pinnedLookup(pinned)('example.com', { all: true }, (err, entries) => {
+      expect(err).toBeNull();
+      expect(entries).toEqual([{ address: '93.184.216.34', family: 4 }]);
+      done();
+    });
+  });
+
+  test('opts-omitted form: (host, cb)', (done) => {
+    pinnedLookup(pinned)('example.com', (err, address, family) => {
+      expect(err).toBeNull();
+      expect(address).toBe('93.184.216.34');
+      expect(family).toBe(4);
+      done();
+    });
+  });
+
+  test('the pin ignores whatever host it is asked for', (done) => {
+    pinnedLookup(pinned)('evil-rebind.example', { all: true }, (err, entries) => {
+      expect(entries[0].address).toBe('93.184.216.34');
+      done();
+    });
   });
 });


### PR DESCRIPTION
Two findings from Johan's first real MCP session on prod (adding 5× Barolo Bartolo Mascarello from a Systembolaget link):

## 1. Every `image_url` attach failed — "Invalid IP address: undefined"
The SSRF guard pins DNS by answering Node's `lookup` in the classic `(err, address, family)` form. **Node 20's Happy Eyeballs** (`autoSelectFamily`, default-on) calls lookup with `{ all: true }` and expects an **array** — so Node read `undefined` as the address list and killed every socket. Not host-specific: attach-by-URL never worked in production.

Fix: `pinnedLookup()` speaks both conventions (the pin holds either way — only the pre-validated address is ever returned, defeating rebinds in both shapes), plus `autoSelectFamily: false` on the request (one pinned address — nothing to race).

**Reproduced before / verified after in the local container** — the exact Barolo image from the report now downloads (48 kB through DNS-pin → TLS → CDN).

## 2. One label, five identical bottles, five attaches
The MCP tool never passed `wineDefinitionId` into the shared ingest — the web upload route does — so the photo was stranded on the single bottle instead of showing on **all the user's bottles of that wine** (and entering the registry-image review pipeline). Now wine-linked exactly like a web upload; the tool description + response envelope say "attach ONCE per wine" so agents stop looping.

## Also
Systembolaget's CDN serves images as `application/octet-stream`; the guard's Content-Type check now lets that generic type through to the **byte-level sanitizer** (the real, fail-closed enforcement — sharp decode + format sniff + metadata strip), while declared non-image types (text/html…) still fail fast without downloading.

## Tests
- New `pinnedLookup` convention suite: classic / `all:true` / opts-omitted / pin-ignores-host.
- imageTools: wine-linkage asserted on the ingest call + envelope flag; wineless (pending-wine-request) bottle case.
- Backend **136 suites / 2049 tests green** in node:20-alpine.

No compose impact. Ready for a v1.82.2 patch deploy — the blog post advertises exactly this capability.