### PR TITLE
release: v1.82.2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.82.1",
+  "version": "1.82.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.82.1",
+      "version": "1.82.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.82.1",
+  "version": "1.82.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.82.1",
+  "version": "1.82.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.82.1",
+      "version": "1.82.2",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.82.1",
+  "version": "1.82.2",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Patch release: attach-by-URL fixed (Happy Eyeballs DNS-pin bug — every image_url failed on prod) + one photo now covers all bottles of a wine (#773), plus the taxonomy merge tooling, cleanup backstops and enrichment descriptions (#765–#772, data already applied on prod). Deploying 12:20 CEST (banner live).