### PR TITLE
fix(registry): house-prefix dedup + undo rolls back minted wines (AI-filed ticket)

### DIFF
--- a/backend/src/mcp/revert.js
+++ b/backend/src/mcp/revert.js
@@ -257,8 +257,19 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
         else removed.push(String(b._id));
       } catch (err) { failures.push({ bottle_id: String(b._id), error: err.message }); }
     }
-    const envelope = { summary: `Undid bulk add — ${removed.length} bottle(s) removed${failures.length ? `, ${failures.length} FAILED (remove those manually)` : ''}`, data: { undone: 'bulk_add', removed_bottle_ids: removed, ...(failures.length ? { failures } : {}) } };
-    await logAction(ctx, { tool: 'undo_last', action: 'undo_add', viaUndo: true, cellar: row.cellar, detail: { undid: String(row._id), count: resolved.length }, result: envelope });
+    // A batch that MINTED registry wines rolls them back too, when nothing
+    // else references them (the launch-day orphaned-wine + pending-maturity-
+    // profile report). Conservative guards + best-effort in registryGc.
+    const winesRemoved = [];
+    if (!failures.length && Array.isArray(row.detail?.createdWineIds)) {
+      const { gcOrphanMintedWine } = require('../services/registryGc');
+      for (const wid of row.detail.createdWineIds) {
+        const gc = await gcOrphanMintedWine(wid, ctx.req);
+        if (gc.removed) winesRemoved.push(String(wid));
+      }
+    }
+    const envelope = { summary: `Undid bulk add — ${removed.length} bottle(s) removed${winesRemoved.length ? `, ${winesRemoved.length} newly-created registry wine(s) rolled back` : ''}${failures.length ? `, ${failures.length} FAILED (remove those manually)` : ''}`, data: { undone: 'bulk_add', removed_bottle_ids: removed, ...(winesRemoved.length ? { removed_wine_ids: winesRemoved } : {}), ...(failures.length ? { failures } : {}) } };
+    await logAction(ctx, { tool: 'undo_last', action: 'undo_add', viaUndo: true, cellar: row.cellar, detail: { undid: String(row._id), count: resolved.length, ...(winesRemoved.length ? { winesRemoved } : {}) }, result: envelope });
     return ok(envelope.summary, envelope.data);
   }
 
@@ -273,7 +284,14 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
     const { removeBottleCascade } = require('../services/bottleOps');
     const result = await removeBottleCascade(bottle, ctx.req, 'bottle.undo');
     if (result.error) return fail('conflict', `Cannot undo that add: ${result.error.message} Nothing was changed.`);
-    envelope = { summary: `Undid add — ${bottleLabel(bottle)} removed from the cellar`, data: { undone: 'add_bottle', bottle_id: bottle._id } };
+    // If THIS add minted the registry wine (detail.wine_created), roll the
+    // wine + its seeded maturity profile back too when nothing else uses it.
+    let wineRolledBack = false;
+    if (row.detail?.wine_created && row.detail?.wine) {
+      const { gcOrphanMintedWine } = require('../services/registryGc');
+      wineRolledBack = (await gcOrphanMintedWine(row.detail.wine, ctx.req)).removed;
+    }
+    envelope = { summary: `Undid add — ${bottleLabel(bottle)} removed from the cellar${wineRolledBack ? ' (its newly-created registry wine was rolled back too)' : ''}`, data: { undone: 'add_bottle', bottle_id: bottle._id, ...(wineRolledBack ? { removed_wine_id: String(row.detail.wine) } : {}) } };
     reverseEntry = { action: 'undo_add', prev: null };
   } else if (row.action === 'update') {
     const { updateBottleFields } = require('../services/bottleOps');

--- a/backend/src/mcp/revert.test.js
+++ b/backend/src/mcp/revert.test.js
@@ -23,6 +23,7 @@ jest.mock('./structuralUndo', () => ({ undoStructural: jest.fn() }));
 jest.mock('../models/WineVintageProfile', () => ({ findById: jest.fn() }));
 jest.mock('../models/WineVintagePrice', () => ({ deleteOne: jest.fn() }));
 jest.mock('../services/journalOps', () => ({ deleteEntry: jest.fn() }));
+jest.mock('../services/registryGc', () => ({ gcOrphanMintedWine: jest.fn().mockResolvedValue({ removed: false }) }));
 jest.mock('../models/BottleImage', () => ({ findOne: jest.fn(), deleteOne: jest.fn() }));
 jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
 
@@ -331,5 +332,54 @@ describe('winelist undo (grand-audit M1 — un-claim on failure)', () => {
     expect(res).toMatchObject({ ok: false, code: 'conflict' });
     // The claim (reversed:true) must be released so a retry finds the row.
     expect(McpActionLog.updateOne).toHaveBeenCalledWith({ _id: oid('f') }, { $set: { reversed: false } });
+  });
+});
+
+// Undo GC of minted registry wines (the launch-day orphan report): a batch or
+// single add that CREATED the wine rolls it back too — via registryGc's
+// conservative guards, never here.
+describe('undo rolls back wines the undone action minted', () => {
+  const { gcOrphanMintedWine } = require('../services/registryGc');
+
+  test('bulk_add undo calls the GC for each recorded createdWineId', async () => {
+    const b = { _id: 'b1', status: 'active', save: jest.fn() };
+    resolveBottleAccess.mockResolvedValue({ bottle: b });
+    bottleOps.removeBottleCascade.mockResolvedValue({ removed: true });
+    gcOrphanMintedWine.mockResolvedValue({ removed: true });
+    const row = { _id: 'r1', action: 'bulk_add', cellar: 'c1', detail: { bottles: ['b1'], createdWineIds: ['w1', 'w2'] } };
+    const res = await revertLedgerRow(row, ctx(), H);
+    expect(res.ok).toBe(true);
+    expect(gcOrphanMintedWine).toHaveBeenCalledTimes(2);
+    expect(gcOrphanMintedWine).toHaveBeenCalledWith('w1', expect.anything());
+    expect(res.data.removed_wine_ids).toEqual(['w1', 'w2']);
+    expect(res.summary).toMatch(/registry wine\(s\) rolled back/);
+  });
+
+  test('bulk_add undo without createdWineIds (older rows) never calls the GC', async () => {
+    const b = { _id: 'b1', status: 'active', save: jest.fn() };
+    resolveBottleAccess.mockResolvedValue({ bottle: b });
+    bottleOps.removeBottleCascade.mockResolvedValue({ removed: true });
+    const row = { _id: 'r1', action: 'bulk_add', cellar: 'c1', detail: { bottles: ['b1'] } };
+    const res = await revertLedgerRow(row, ctx(), H);
+    expect(res.ok).toBe(true);
+    expect(gcOrphanMintedWine).not.toHaveBeenCalled();
+  });
+
+  test('single add undo GCs only when the ledger says wine_created', async () => {
+    const b = { _id: 'b1', status: 'active', vintage: '2019', save: jest.fn() };
+    resolveBottleAccess.mockResolvedValue({ bottle: b });
+    bottleOps.removeBottleCascade.mockResolvedValue({ removed: true });
+    McpActionLog.findOne.mockReturnValue({ sort: () => Promise.resolve(null) });
+
+    gcOrphanMintedWine.mockResolvedValue({ removed: true });
+    let res = await revertLedgerRow({ _id: 'r2', action: 'add', bottle: 'b1', detail: { wine: 'w9', wine_created: true } }, ctx(), H);
+    expect(res.ok).toBe(true);
+    expect(gcOrphanMintedWine).toHaveBeenCalledWith('w9', expect.anything());
+    expect(res.data.removed_wine_id).toBe('w9');
+
+    gcOrphanMintedWine.mockClear();
+    res = await revertLedgerRow({ _id: 'r3', action: 'add', bottle: 'b1', detail: { wine: 'w9', wine_created: false } }, ctx(), H);
+    expect(res.ok).toBe(true);
+    expect(gcOrphanMintedWine).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/mcp/tools/bulk.js
+++ b/backend/src/mcp/tools/bulk.js
@@ -247,7 +247,9 @@ registerTool({
       tool: 'bulk_add',
       action: 'bulk_add',
       cellar: access.cellar._id,
-      detail: { bottles: added, count: added.length, wines_created: winesCreated.length, failures: failures.length, previewId: String(preview._id) },
+      // createdWineIds: the ids (not just the count) so undo can garbage-collect
+      // a wine THIS batch minted when nothing else references it (registryGc).
+      detail: { bottles: added, count: added.length, wines_created: winesCreated.length, createdWineIds: winesCreated, failures: failures.length, previewId: String(preview._id) },
       result: envelope,
     });
     return ok(envelope.summary, envelope.data);

--- a/backend/src/services/registryGc.js
+++ b/backend/src/services/registryGc.js
@@ -1,0 +1,99 @@
+/**
+ * Garbage-collect a registry wine that an UNDONE action minted — the fix for
+ * the launch-day report: undoing a bulk_add removed the bottles but left the
+ * freshly-created WineDefinition and its auto-seeded pending maturity profile
+ * orphaned in the somm queue.
+ *
+ * DELIBERATELY CONSERVATIVE. The registry is shared, so the wine is deleted
+ * only when every guard agrees nothing else has grown around it:
+ *   - zero bottles reference it (ANY user, ANY status — active or history);
+ *   - no image has been approved as the wine's official photo
+ *     (assignedToWine — an admin curated it; keep);
+ *   - every maturity profile is still the auto-seeded 'pending' stub
+ *     (a somm reviewed one → keep everything).
+ * If any guard fails the wine simply stays — the undo of the bottles is
+ * already complete and correct.
+ *
+ * Cleanup on success: pending profiles, the wine's un-approved images (rows +
+ * files), embedding rows + their Qdrant points (best-effort), the Meilisearch
+ * document, the WineDefinition itself, and a wine.undo_create audit entry.
+ *
+ * Callers pass wine ids their OWN ledger row recorded as created (add_bottle
+ * detail.wine_created / bulk_add detail.createdWineIds) — never arbitrary ids.
+ *
+ * Returns { removed: boolean, reason?: string }. Never throws.
+ */
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const WineVintageProfile = require('../models/WineVintageProfile');
+const Bottle = require('../models/Bottle');
+const BottleImage = require('../models/BottleImage');
+const { logAudit } = require('./audit');
+
+async function gcOrphanMintedWine(wineId, req) {
+  try {
+    if (!mongoose.isValidObjectId(wineId)) return { removed: false, reason: 'invalid id' };
+    const wine = await WineDefinition.findById(wineId).select('name producer');
+    if (!wine) return { removed: false, reason: 'already gone' };
+
+    const bottleCount = await Bottle.countDocuments({ wineDefinition: wineId });
+    if (bottleCount > 0) return { removed: false, reason: `${bottleCount} bottle(s) still reference it` };
+
+    const officialImage = await BottleImage.countDocuments({ wineDefinition: wineId, assignedToWine: true });
+    if (officialImage > 0) return { removed: false, reason: 'has an approved wine image' };
+
+    const reviewedProfiles = await WineVintageProfile.countDocuments({
+      wineDefinition: wineId,
+      status: { $ne: 'pending' },
+    });
+    if (reviewedProfiles > 0) return { removed: false, reason: 'a maturity profile was reviewed' };
+
+    // Guards passed — clean up everything the mint created, quietest first.
+    await WineVintageProfile.deleteMany({ wineDefinition: wineId, status: 'pending' });
+
+    // Un-approved images (rows + files). unlinkImageFiles is best-effort.
+    const images = await BottleImage.find({ wineDefinition: wineId });
+    if (images.length) {
+      const { unlinkImageFiles } = require('./imageProcessor');
+      for (const img of images) {
+        try { await unlinkImageFiles(img); } catch { /* file may already be gone */ }
+      }
+      await BottleImage.deleteMany({ wineDefinition: wineId });
+    }
+
+    // Embeddings: rows + Qdrant points, best-effort (the vector store may be
+    // down; a stale point is harmless — searches dedupe against Mongo).
+    try {
+      const WineEmbedding = require('../models/WineEmbedding');
+      const rows = await WineEmbedding.find({ wineDefinition: wineId }).select('qdrantPointId indexVersion').lean();
+      if (rows.length) {
+        const vectorStore = require('./vectorStore');
+        const byIndex = new Map();
+        for (const r of rows) {
+          if (!r.qdrantPointId) continue;
+          if (!byIndex.has(r.indexVersion)) byIndex.set(r.indexVersion, []);
+          byIndex.get(r.indexVersion).push(r.qdrantPointId);
+        }
+        for (const [indexVersion, ids] of byIndex) {
+          await vectorStore.deletePoints(indexVersion, ids).catch(() => {});
+        }
+        await WineEmbedding.deleteMany({ wineDefinition: wineId });
+      }
+    } catch { /* embedding cleanup is best-effort */ }
+
+    require('./search').removeWine(wineId);
+    await WineDefinition.deleteOne({ _id: wineId });
+
+    logAudit(req, 'wine.undo_create',
+      { type: 'wine', id: wineId },
+      { name: wine.name, producer: wine.producer, via: 'undo' });
+
+    return { removed: true };
+  } catch (err) {
+    // The bottles' undo already succeeded — a GC failure must never fail it.
+    console.warn('[registryGc] gcOrphanMintedWine failed (non-fatal):', err.message);
+    return { removed: false, reason: 'gc error' };
+  }
+}
+
+module.exports = { gcOrphanMintedWine };

--- a/backend/src/services/registryGc.test.js
+++ b/backend/src/services/registryGc.test.js
@@ -1,0 +1,106 @@
+/**
+ * Undo GC of a minted registry wine (the launch-day orphan report): every
+ * guard must hold the wine in place, and the happy path must clean up the
+ * profile stubs, images, embeddings, search doc and the wine itself.
+ */
+
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn(), deleteOne: jest.fn().mockResolvedValue({}) }));
+jest.mock('../models/WineVintageProfile', () => ({ countDocuments: jest.fn(), deleteMany: jest.fn().mockResolvedValue({}) }));
+jest.mock('../models/Bottle', () => ({ countDocuments: jest.fn() }));
+jest.mock('../models/BottleImage', () => ({ countDocuments: jest.fn(), find: jest.fn(), deleteMany: jest.fn().mockResolvedValue({}) }));
+jest.mock('../models/WineEmbedding', () => ({ find: jest.fn(), deleteMany: jest.fn().mockResolvedValue({}) }));
+jest.mock('./vectorStore', () => ({ deletePoints: jest.fn().mockResolvedValue({}) }));
+jest.mock('./search', () => ({ removeWine: jest.fn() }));
+jest.mock('./imageProcessor', () => ({ unlinkImageFiles: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('./audit', () => ({ logAudit: jest.fn() }));
+
+const WineDefinition = require('../models/WineDefinition');
+const WineVintageProfile = require('../models/WineVintageProfile');
+const Bottle = require('../models/Bottle');
+const BottleImage = require('../models/BottleImage');
+const WineEmbedding = require('../models/WineEmbedding');
+const vectorStore = require('./vectorStore');
+const searchService = require('./search');
+const { logAudit } = require('./audit');
+const { gcOrphanMintedWine } = require('./registryGc');
+
+const WINE_ID = 'a'.repeat(24);
+const REQ = { user: { id: 'u1' }, headers: {} };
+
+const selectable = (doc) => ({ select: jest.fn().mockReturnValue(doc) });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  WineDefinition.findById.mockReturnValue(selectable({ _id: WINE_ID, name: 'Barolo', producer: 'Cantina Bartolo Mascarello' }));
+  Bottle.countDocuments.mockResolvedValue(0);
+  BottleImage.countDocuments.mockResolvedValue(0);
+  BottleImage.find.mockResolvedValue([]);
+  WineVintageProfile.countDocuments.mockResolvedValue(0);
+  WineEmbedding.find.mockReturnValue({ select: () => ({ lean: () => Promise.resolve([]) }) });
+});
+
+describe('gcOrphanMintedWine guards', () => {
+  test('invalid id / already-gone wine → not removed, nothing touched', async () => {
+    expect((await gcOrphanMintedWine('nope', REQ)).removed).toBe(false);
+    WineDefinition.findById.mockReturnValue(selectable(null));
+    expect((await gcOrphanMintedWine(WINE_ID, REQ)).removed).toBe(false);
+    expect(WineDefinition.deleteOne).not.toHaveBeenCalled();
+  });
+
+  test('ANY bottle referencing the wine (any user, any status) keeps it', async () => {
+    Bottle.countDocuments.mockResolvedValue(1);
+    const res = await gcOrphanMintedWine(WINE_ID, REQ);
+    expect(res.removed).toBe(false);
+    expect(WineDefinition.deleteOne).not.toHaveBeenCalled();
+    expect(WineVintageProfile.deleteMany).not.toHaveBeenCalled();
+  });
+
+  test('an admin-approved official wine image keeps it', async () => {
+    BottleImage.countDocuments.mockResolvedValue(1);
+    expect((await gcOrphanMintedWine(WINE_ID, REQ)).removed).toBe(false);
+    expect(WineDefinition.deleteOne).not.toHaveBeenCalled();
+  });
+
+  test('a somm-reviewed maturity profile keeps it', async () => {
+    WineVintageProfile.countDocuments.mockResolvedValue(1);
+    expect((await gcOrphanMintedWine(WINE_ID, REQ)).removed).toBe(false);
+    expect(WineDefinition.deleteOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('gcOrphanMintedWine happy path', () => {
+  test('removes pending profiles, embeddings + Qdrant points, search doc, wine — and audits', async () => {
+    WineEmbedding.find.mockReturnValue({ select: () => ({ lean: () => Promise.resolve([
+      { qdrantPointId: 'p1', indexVersion: 'v1' },
+      { qdrantPointId: 'p2', indexVersion: 'v1' },
+    ]) }) });
+
+    const res = await gcOrphanMintedWine(WINE_ID, REQ);
+    expect(res.removed).toBe(true);
+    expect(WineVintageProfile.deleteMany).toHaveBeenCalledWith({ wineDefinition: WINE_ID, status: 'pending' });
+    expect(vectorStore.deletePoints).toHaveBeenCalledWith('v1', ['p1', 'p2']);
+    expect(WineEmbedding.deleteMany).toHaveBeenCalledWith({ wineDefinition: WINE_ID });
+    expect(searchService.removeWine).toHaveBeenCalledWith(WINE_ID);
+    expect(WineDefinition.deleteOne).toHaveBeenCalledWith({ _id: WINE_ID });
+    expect(logAudit).toHaveBeenCalledWith(REQ, 'wine.undo_create',
+      { type: 'wine', id: WINE_ID },
+      { name: 'Barolo', producer: 'Cantina Bartolo Mascarello', via: 'undo' });
+  });
+
+  test('a Qdrant outage does not stop the Mongo cleanup (best-effort vectors)', async () => {
+    WineEmbedding.find.mockReturnValue({ select: () => ({ lean: () => Promise.resolve([
+      { qdrantPointId: 'p1', indexVersion: 'v1' },
+    ]) }) });
+    vectorStore.deletePoints.mockRejectedValue(new Error('qdrant down'));
+    const res = await gcOrphanMintedWine(WINE_ID, REQ);
+    expect(res.removed).toBe(true);
+    expect(WineDefinition.deleteOne).toHaveBeenCalled();
+  });
+
+  test('never throws — an unexpected model error reports removed:false', async () => {
+    Bottle.countDocuments.mockRejectedValue(new Error('mongo hiccup'));
+    const res = await gcOrphanMintedWine(WINE_ID, REQ);
+    expect(res.removed).toBe(false);
+    expect(WineDefinition.deleteOne).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -8,6 +8,14 @@ const WINE_STOP_WORDS = new Set([
   'wine', 'wines', 'winery', 'vineyard', 'vineyards', 'estate', 'estates',
   'cellars', 'cellar', 'reserve', 'selection', 'cuvee', 'cuvée',
   'château', 'chateau', 'domaine', 'domain', 'bodega', 'casa',
+  // House prefixes that labels include and databases omit (or vice versa) —
+  // "Cantina Bartolo Mascarello" IS "Bartolo Mascarello". Stripping them on
+  // the token axis lifts such pairs into the resolver's soft zone ("did you
+  // mean?") instead of silently minting a duplicate registry wine (the
+  // launch-day Barolo report). Comparison-only: display names keep prefixes.
+  'cantina', 'cantine', 'azienda', 'agricola', 'tenuta', 'tenute',
+  'cascina', 'fattoria', 'podere', 'poderi', 'vinicola',
+  'weingut', 'bodegas', 'maison', 'vinos', 'vina', 'viña',
   'the', 'le', 'la', 'de', 'di', 'del', 'della', 'des', 'du',
   'and', 'et', 'y', 'e', 'und'
 ]);

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -437,3 +437,29 @@ describe('resolveGrapeName — spelling variants merged 2026-07-11', () => {
     expect(resolveGrapeName('Weisser Burgunder')).toBe('Pinot Blanc');
   });
 });
+
+describe('producer house prefixes (the launch-day Barolo duplicate)', () => {
+  const { tokenSimilarity, combinedSimilarity } = require('./normalize');
+
+  test('"Cantina Bartolo Mascarello" tokens equal "Bartolo Mascarello"', () => {
+    expect(tokenSimilarity('Cantina Bartolo Mascarello', 'Bartolo Mascarello')).toBe(1);
+    expect(tokenSimilarity('Azienda Agricola Montevertine', 'Montevertine')).toBe(1);
+    expect(tokenSimilarity('Tenuta San Guido', 'San Guido')).toBe(1);
+    expect(tokenSimilarity('Weingut Keller', 'Keller')).toBe(1);
+  });
+
+  test('combined producer similarity clears the resolver soft zone', () => {
+    // With name (0.45) and appellation (0.10) identical, the wine-level score
+    // is 0.55 + 0.45 × producerSim — producerSim ≥ 0.75 puts the pair at
+    // ≥ 0.8875, safely above SOFT_ZONE_MIN (0.85), so the resolver surfaces
+    // "did you mean?" instead of silently minting a duplicate. Before the
+    // stop-word fix this pair scored ~0.65 and fell through to no_match.
+    expect(combinedSimilarity('Cantina Bartolo Mascarello', 'Bartolo Mascarello')).toBeGreaterThanOrEqual(0.75);
+  });
+
+  test('distinct producers do NOT collapse to auto-match territory', () => {
+    // Sharing a stripped prefix must not make different houses near-identical:
+    // candidates at worst (soft zone asks the user), never a silent merge.
+    expect(combinedSimilarity('Cantina Rossi', 'Cantina Bianchi')).toBeLessThan(0.6);
+  });
+});


### PR DESCRIPTION
Fixes both issues from the **first AI-filed support ticket** (created through the MCP `create_support_ticket` tool during the launch-day Barolo session — the connector reporting its own bugs).

## 1. Producer house prefixes defeated the resolver
"Cantina Bartolo Mascarello" vs the registry's "Bartolo Mascarello" scored **~0.844 — a hair under the 0.85 soft zone** — so `resolve_wine` answered `no_match` and a duplicate wine was minted. The Italian/wine-world house prefixes (Cantina, Cantine, Azienda, Agricola, Tenuta, Tenute, Cascina, Fattoria, Podere, Poderi, Vinicola, Weingut, Bodegas, Maison, Viña) now join `WINE_STOP_WORDS`:

- **comparison-only** — display names keep their prefixes;
- **token-axis-only** (30% weight) — lifts the ticket's pair to ~0.89, into the *"did you mean?"* soft zone;
- **never auto-merges** — the 0.95 auto-match still requires a near-identical producer, and the regression suite pins that distinct houses sharing a prefix ("Cantina Rossi" vs "Cantina Bianchi") stay far below it.

## 2. Undo left the minted wine + maturity profile orphaned
Undoing an `add`/`bulk_add` that created a registry wine removed the bottles but stranded the wine and its auto-seeded `pending` profile in the somm queue. New `services/registryGc.gcOrphanMintedWine`, deliberately conservative:

| Guard | Effect |
|---|---|
| any bottle references the wine (any user, any status) | keep |
| an approved official wine image exists | keep |
| any maturity profile is no longer `pending` | keep |

On a clean pass it removes: pending profiles, un-approved images (+files), embedding rows + Qdrant points (best-effort), the Meilisearch doc, and the wine — audited as `wine.undo_create`. It never throws (the bottle undo already succeeded and stays valid).

`bulk_add` now records `createdWineIds` (ids, not just a count) in its ledger detail; both undo branches GC **only wines their own ledger row minted**. Older rows without ids simply don't GC.

## Tests
registryGc guard/happy-path/outage/never-throws suite · revert wiring (per-id GC, old-row no-op, `wine_created` gate) · normalize prefix regressions. **Backend 137 suites / 2062 green.**

The orphaned profile from the ticket (wine 6a5b58784ed0c648df714acf) was already hand-removed on prod; this prevents the class.