### PR TITLE
release: v1.82.3

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.82.2",
+  "version": "1.82.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.82.2",
+      "version": "1.82.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.82.2",
+  "version": "1.82.3",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.82.2",
+  "version": "1.82.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.82.2",
+      "version": "1.82.3",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.82.2",
+  "version": "1.82.3",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Patch release: registry dedup handles producer house prefixes + undo rolls back minted wines (#775, both from the AI-filed ticket), and admin registry-wine creation with official image + credit on web and MCP (#776). Deploying 14:25 CEST (banner live).