### PR TITLE
fix(mcp): per-user session cap evicts the stalest session instead of refusing

### DIFF
--- a/backend/src/mcp/sessions.js
+++ b/backend/src/mcp/sessions.js
@@ -67,7 +67,25 @@ function createSession({ userId, tokenId }) {
     }
     return null;
   }
-  if ((perUserCounts.get(userKey) || 0) >= MAX_SESSIONS_PER_USER) return null;
+  // Per-user cap: EVICT the user's least-recently-seen session instead of
+  // refusing. Refusing degraded the NEW connection to stateless — and Claude
+  // Desktop treats a session-less initialize as a broken server: it bailed
+  // out and revoked its fresh grant (launch-day report: connecting a 4th
+  // client silently failed while old claude.ai sessions kept the 3 slots
+  // alive via SSE refreshes). The newest connection is the one the user is
+  // actually at; their stalest one dies, exactly like the event bus treats
+  // its stream cap. Global cap stays a refusal — evicting ANOTHER user's
+  // live session to seat this one would trade a known cost for a stranger's.
+  if ((perUserCounts.get(userKey) || 0) >= MAX_SESSIONS_PER_USER) {
+    let oldest = null;
+    for (const s of sessions.values()) {
+      if (s.userId === userKey && (!oldest || s.lastSeenAt < oldest.lastSeenAt)) oldest = s;
+    }
+    if (oldest) {
+      destroySession(oldest.id, 'evicted_for_new_session');
+    }
+    if ((perUserCounts.get(userKey) || 0) >= MAX_SESSIONS_PER_USER) return null; // defensive: eviction failed
+  }
 
   const session = {
     id: crypto.randomUUID(),

--- a/backend/src/mcp/sessions.test.js
+++ b/backend/src/mcp/sessions.test.js
@@ -45,14 +45,34 @@ describe('identity binding', () => {
 });
 
 describe('caps', () => {
-  test('per-user cap: the 4th session is refused; destroy frees a slot', () => {
+  test('per-user cap EVICTS the least-recently-seen session — the new client always seats', () => {
+    // The launch-day Desktop report: refusing the 4th session degraded the NEW
+    // connection to stateless, which Claude Desktop treats as a broken server.
+    const a = sessions.createSession({ userId: 'u1' });
+    jest.advanceTimersByTime(1000);
+    const b = sessions.createSession({ userId: 'u1' });
+    jest.advanceTimersByTime(1000);
+    const c = sessions.createSession({ userId: 'u1' });
+    jest.advanceTimersByTime(1000);
+    jest.setSystemTime(Date.now());
+    // b becomes most-recently-seen; a stays the stalest.
+    expect(sessions.getSession(b.id, { userId: 'u1', tokenId: null })).toBe(b);
+
+    const d = sessions.createSession({ userId: 'u1' });
+    expect(d).not.toBeNull(); // seated, not refused
+    expect(sessions.getSession(a.id, { userId: 'u1', tokenId: null })).toBeNull(); // stalest evicted
+    expect(sessions.getSession(b.id, { userId: 'u1', tokenId: null })).toBe(b);    // survivors intact
+    expect(sessions.getSession(c.id, { userId: 'u1', tokenId: null })).toBe(c);
+    expect(sessions.createSession({ userId: 'u2' })).not.toBeNull(); // other users unaffected
+  });
+
+  test('destroy frees a slot without waiting for eviction', () => {
     const a = sessions.createSession({ userId: 'u1' });
     sessions.createSession({ userId: 'u1' });
     sessions.createSession({ userId: 'u1' });
-    expect(sessions.createSession({ userId: 'u1' })).toBeNull();
-    expect(sessions.createSession({ userId: 'u2' })).not.toBeNull(); // other users unaffected
     sessions.destroySession(a.id);
-    expect(sessions.createSession({ userId: 'u1' })).not.toBeNull();
+    const d = sessions.createSession({ userId: 'u1' });
+    expect(d).not.toBeNull();
   });
 
   test('global cap refuses new sessions across all users', () => {


### PR DESCRIPTION
Live-debugged with Johan on launch day. Connecting **Claude Desktop** as a user whose 3 stateful-session slots were held by still-alive claude.ai sessions (their SSE pushes keep refreshing the idle TTL) silently fell back to **stateless** mode — and Desktop treats a session-less initialize as a broken server: it bails and **revokes its freshly-minted grant**, showing "not connected" with zero server-side errors. The audit log told the story: six clean register→consent→token cycles in five minutes, each token used exactly once, then revoked.

**Fix:** the per-user cap now **evicts the user's least-recently-seen session** to seat the new one — the newest connection is the one the user is actually sitting at (same semantics as the event bus's stream cap). The **global** cap stays a refusal: evicting a *stranger's* live session to seat this user would trade a known cost for someone else's.

Tests: eviction seats the 4th client, kills exactly the stalest, leaves the survivors and other users intact; explicit destroy still frees slots. **Backend 138 suites / 2072 green.**

Interim relief was the v1.82.3 restart (cleared in-memory sessions); this closes the class.