### PR TITLE
feat(oauth): choose read / consume / write at the consent screen

### DIFF
--- a/backend/src/routes/mcpOAuth.js
+++ b/backend/src/routes/mcpOAuth.js
@@ -214,7 +214,30 @@ router.post('/approve', requireAuth, requireNonDemo, async (req, res) => {
       return res.status(400).json({ error: 'invalid resource' });
     }
 
-    const scopes = grantedScopes(scope);
+    // The user's scope CHOICE: the consent page may NARROW the client's
+    // requested scopes ("connect read-only" is a promise the launch post
+    // makes, and the consent moment is where it belongs). Rules: the choice
+    // must be a subset of what the client requested (offered = requested ∩
+    // grantable), and 'read' is the floor — every flow starts with lookups,
+    // so a read-less grant would just be a broken connector. `scopes` absent
+    // (older consent pages, direct API callers) → the full intersection,
+    // exactly the previous behavior.
+    const offered = grantedScopes(scope);
+    let scopes = offered;
+    if (req.body.scopes !== undefined) {
+      const chosen = req.body.scopes;
+      if (!Array.isArray(chosen) || chosen.length === 0 || chosen.some((s) => typeof s !== 'string')) {
+        return res.status(400).json({ error: 'scopes must be a non-empty array of scope strings' });
+      }
+      const invalid = chosen.filter((s) => !offered.includes(s));
+      if (invalid.length) {
+        return res.status(400).json({ error: `scopes not requested by the client: ${invalid.join(', ')}` });
+      }
+      if (!chosen.includes('read')) {
+        return res.status(400).json({ error: 'the read scope is required' });
+      }
+      scopes = offered.filter((s) => chosen.includes(s)); // canonical order, deduped
+    }
     const rawCode = OAuthAuthCode.generateCode();
     await OAuthAuthCode.create({
       codeHash: OAuthAuthCode.hashCode(rawCode),

--- a/backend/src/routes/mcpOAuth.test.js
+++ b/backend/src/routes/mcpOAuth.test.js
@@ -203,6 +203,51 @@ describe('POST /approve (consent, JWT-only)', () => {
     expect(r.status).toBe(400);
     expect(OAuthAuthCode.create).not.toHaveBeenCalled();
   });
+
+  // ── The user's scope choice (consent-page picker) ─────────────────────────
+  const approveWith = (extra) => jsonPost('/approve', {
+    client_id: CLIENT.clientId, redirect_uri: REDIRECT, code_challenge: CHALLENGE,
+    code_challenge_method: 'S256', scope: 'read consume write', resource: RESOURCE, approved: true, ...extra,
+  }, { Authorization: `Bearer ${jwtFor()}` });
+
+  test('the user may NARROW the grant: chosen ["read"] mints a read-only code', async () => {
+    OAuthClient.findOne.mockResolvedValue(CLIENT);
+    OAuthAuthCode.create.mockResolvedValue({});
+    const r = await approveWith({ scopes: ['read'] });
+    expect(r.status).toBe(200);
+    expect(OAuthAuthCode.create.mock.calls[0][0].scopes).toEqual(['read']);
+  });
+
+  test('the choice cannot EXCEED the client request: write when only read was requested → 400', async () => {
+    OAuthClient.findOne.mockResolvedValue(CLIENT);
+    const r = await approveWith({ scope: 'read', scopes: ['read', 'write'] });
+    expect(r.status).toBe(400);
+    expect((await r.json()).error).toMatch(/not requested/);
+    expect(OAuthAuthCode.create).not.toHaveBeenCalled();
+  });
+
+  test('read is the floor: a choice without it → 400', async () => {
+    OAuthClient.findOne.mockResolvedValue(CLIENT);
+    const r = await approveWith({ scopes: ['consume', 'write'] });
+    expect(r.status).toBe(400);
+    expect((await r.json()).error).toMatch(/read scope is required/);
+    expect(OAuthAuthCode.create).not.toHaveBeenCalled();
+  });
+
+  test.each([[[]], ['not-an-array'], [[42]]])('malformed scopes (%j) → 400', async (scopes) => {
+    OAuthClient.findOne.mockResolvedValue(CLIENT);
+    const r = await approveWith({ scopes });
+    expect(r.status).toBe(400);
+    expect(OAuthAuthCode.create).not.toHaveBeenCalled();
+  });
+
+  test('absent scopes keeps the previous behavior: the full requested∩grantable set', async () => {
+    OAuthClient.findOne.mockResolvedValue(CLIENT);
+    OAuthAuthCode.create.mockResolvedValue({});
+    const r = await approveWith({});
+    expect(r.status).toBe(200);
+    expect(OAuthAuthCode.create.mock.calls[0][0].scopes).toEqual(['read', 'consume', 'write']);
+  });
 });
 
 describe('POST /token — authorization_code', () => {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -167,7 +167,12 @@
     "invalidRequest": "This authorization link is invalid or incomplete. Start the connection again from your AI assistant.",
     "demoBlocked": "Connecting an AI assistant is not available in the demo. Create a free account to use it.",
     "beta": "Beta",
-    "betaNotice": "Connecting an AI is a beta feature and you use it at your own risk — it is new and still being tested. Everything it changes is reversible, and you can revoke access at any time in Settings."
+    "betaNotice": "Connecting an AI is a beta feature and you use it at your own risk — it is new and still being tested. Everything it changes is reversible, and you can revoke access at any time in Settings.",
+    "wantsChoose": "wants to connect to your Cellarion cellar. Choose how much it may do:",
+    "accessLevel": "Access level",
+    "levelRead": "Read only — it can look, never change anything",
+    "levelConsume": "Read + log drinking — it can also mark bottles opened or drunk (reversible)",
+    "levelFull": "Full access — it can also add and edit bottles, racks and cellars"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -167,7 +167,12 @@
     "invalidRequest": "Den här auktoriseringslänken är ogiltig eller ofullständig. Starta anslutningen igen från din AI-assistent.",
     "demoBlocked": "Att ansluta en AI-assistent är inte tillgängligt i demot. Skapa ett gratiskonto för att använda det.",
     "beta": "Beta",
-    "betaNotice": "Att ansluta en AI är en betafunktion och du använder den på egen risk — den är ny och testas fortfarande. Allt den ändrar går att ångra, och du kan återkalla åtkomsten när som helst i Inställningar."
+    "betaNotice": "Att ansluta en AI är en betafunktion och du använder den på egen risk — den är ny och testas fortfarande. Allt den ändrar går att ångra, och du kan återkalla åtkomsten när som helst i Inställningar.",
+    "wantsChoose": "vill ansluta till din Cellarion-källare. Välj hur mycket den får göra:",
+    "accessLevel": "Åtkomstnivå",
+    "levelRead": "Endast läsa — den kan titta men aldrig ändra något",
+    "levelConsume": "Läsa + logga drickande — den kan även markera flaskor som öppnade eller druckna (går att ångra)",
+    "levelFull": "Full åtkomst — den kan även lägga till och redigera flaskor, hyllor och källare"
   },
   "settings": {
     "title": "Inställningar",

--- a/frontend/src/pages/ConnectAiAuthorize.css
+++ b/frontend/src/pages/ConnectAiAuthorize.css
@@ -55,3 +55,37 @@
 .oauth-consent-actions .btn {
   min-width: 7rem;
 }
+
+/* Access-level picker: one radio per prefix of the offered scope set. */
+.oauth-consent-levels {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+}
+.oauth-consent-level {
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  cursor: pointer;
+}
+.oauth-consent-level.selected {
+  border-color: var(--color-primary);
+  background: rgba(var(--color-primary-rgb), 0.06);
+}
+.oauth-consent-level input {
+  margin-top: 0.2rem;
+  flex-shrink: 0;
+}
+.oauth-consent-level-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.oauth-consent-level-text small {
+  color: var(--color-text-secondary);
+  line-height: 1.35;
+}

--- a/frontend/src/pages/ConnectAiAuthorize.js
+++ b/frontend/src/pages/ConnectAiAuthorize.js
@@ -25,6 +25,16 @@ const SCOPE_INFO = {
 };
 const GRANTABLE = ['read', 'consume', 'write'];
 
+// Access levels the user can choose at consent. Each level is a PREFIX of the
+// canonically-ordered offered scopes, so narrowing is the only possible
+// direction — the server re-validates (subset of the client's request, read
+// mandatory) either way. Labelled by the level's topmost capability.
+const LEVEL_LABELS = {
+  read: { key: 'levelRead', fallback: 'Read only — it can look, never change anything' },
+  consume: { key: 'levelConsume', fallback: 'Read + log drinking — it can also mark bottles opened or drunk (reversible)' },
+  write: { key: 'levelFull', fallback: 'Full access — it can also add and edit bottles, racks and cellars' },
+};
+
 function ConnectAiAuthorize() {
   const { t } = useTranslation();
   const { user, loading, apiFetch, login } = useAuth();
@@ -45,6 +55,10 @@ function ConnectAiAuthorize() {
   const [creds, setCreds] = useState({ username: '', password: '' });
   const [loginError, setLoginError] = useState(null);
   const [loggingIn, setLoggingIn] = useState(false);
+  // How much of the offered scope set the user grants — an index into
+  // `levelOptions` below; null = the full offered set (the default, and
+  // today's behavior for everyone who just clicks Approve).
+  const [chosenLevel, setChosenLevel] = useState(null);
 
   // The request is unusable without these three — show a hard error rather than
   // POSTing something the backend will reject.
@@ -55,6 +69,11 @@ function ConnectAiAuthorize() {
   const requested = scope.split(/\s+/).filter(Boolean);
   const displayScopes = GRANTABLE.filter((s) => requested.includes(s));
   if (displayScopes.length === 0) displayScopes.push('read');
+
+  // One selectable level per prefix of the offered set ("Read only" …
+  // "Full access"). A single-scope request renders as one pre-picked option.
+  const levelOptions = displayScopes.map((_, i) => displayScopes.slice(0, i + 1));
+  const grantScopes = chosenLevel === null ? displayScopes : levelOptions[chosenLevel];
 
   let redirectHost = '';
   try { redirectHost = new URL(redirectUri).host; } catch { /* shown-nothing */ }
@@ -72,6 +91,9 @@ function ConnectAiAuthorize() {
         state,
         resource,
         approved,
+        // The user's choice — a prefix of the offered set; the server
+        // re-validates (subset of the client's request, read mandatory).
+        ...(approved ? { scopes: grantScopes } : {}),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || !data.redirect) {
@@ -176,13 +198,31 @@ function ConnectAiAuthorize() {
       </div>
       <p className="oauth-consent-lead">
         <strong>{who}</strong>{' '}
-        {t('oauthConsent.wants', 'wants to connect to your Cellarion cellar and will be able to:')}
+        {t('oauthConsent.wantsChoose', 'wants to connect to your Cellarion cellar. Choose how much it may do:')}
       </p>
-      <ul className="oauth-consent-scopes">
-        {displayScopes.map((s) => (
-          <li key={s}>{t(`oauthConsent.${SCOPE_INFO[s].key}`, SCOPE_INFO[s].fallback)}</li>
-        ))}
-      </ul>
+      <div className="oauth-consent-levels" role="radiogroup" aria-label={t('oauthConsent.accessLevel', 'Access level')}>
+        {levelOptions.map((scopes, i) => {
+          const top = scopes[scopes.length - 1];
+          const selected = grantScopes.length === scopes.length;
+          return (
+            <label key={top} className={`oauth-consent-level ${selected ? 'selected' : ''}`}>
+              <input
+                type="radio"
+                name="access-level"
+                checked={selected}
+                onChange={() => setChosenLevel(i)}
+                disabled={submitting}
+              />
+              <span className="oauth-consent-level-text">
+                <strong>{t(`oauthConsent.${LEVEL_LABELS[top].key}`, LEVEL_LABELS[top].fallback)}</strong>
+                <small>
+                  {scopes.map((s) => t(`oauthConsent.${SCOPE_INFO[s].key}`, SCOPE_INFO[s].fallback)).join(' · ')}
+                </small>
+              </span>
+            </label>
+          );
+        })}
+      </div>
       <p className="oauth-consent-muted">
         {t('oauthConsent.revokeNote', 'You can revoke this access anytime in Settings. You stay in control — the assistant confirms every change before it happens.')}
       </p>

--- a/frontend/src/pages/ConnectAiAuthorize.test.js
+++ b/frontend/src/pages/ConnectAiAuthorize.test.js
@@ -65,9 +65,10 @@ test('logged in → shows the client name, requested scopes, and the return host
   render(<ConnectAiAuthorize />);
   expect(screen.getByRole('heading', { name: /Connect your AI assistant/ })).toBeInTheDocument();
   expect(screen.getByText('Claude')).toBeInTheDocument();
-  // read + write requested → both shown; consume NOT requested → hidden.
-  expect(screen.getByText(/View your cellars/i)).toBeInTheDocument();
-  expect(screen.getByText(/Add and edit bottles/i)).toBeInTheDocument();
+  // read + write requested → both described (across the level options);
+  // consume NOT requested → neither its description nor its level appears.
+  expect(screen.getAllByText(/View your cellars/i).length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/add and edit bottles/i).length).toBeGreaterThan(0);
   expect(screen.queryByText(/Mark bottles as opened/i)).not.toBeInTheDocument();
   expect(screen.getByText('claude.ai')).toBeInTheDocument(); // return host, transparency
 });
@@ -106,4 +107,41 @@ test('a backend failure shows an error and does not navigate', async () => {
 
   await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument());
   expect(window.location.href).toBe('');
+});
+
+// ── The scope picker (read/consume/write choice at consent) ─────────────────
+test('defaults to full offered access and posts the full scope set', async () => {
+  approveMock.mockResolvedValue({ ok: true, json: async () => ({ redirect: 'https://claude.ai/cb' }) });
+  render(<ConnectAiAuthorize />);
+  // scope 'read write' → two levels, full pre-selected.
+  const radios = screen.getAllByRole('radio');
+  expect(radios).toHaveLength(2);
+  expect(radios[1]).toBeChecked();
+  fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+  await waitFor(() => expect(approveMock).toHaveBeenCalled());
+  expect(approveMock.mock.calls[0][1].scopes).toEqual(['read', 'write']);
+});
+
+test('choosing "Read only" narrows the grant to just read', async () => {
+  approveMock.mockResolvedValue({ ok: true, json: async () => ({ redirect: 'https://claude.ai/cb' }) });
+  render(<ConnectAiAuthorize />);
+  fireEvent.click(screen.getByLabelText(/Read only/i));
+  fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+  await waitFor(() => expect(approveMock).toHaveBeenCalled());
+  expect(approveMock.mock.calls[0][1].scopes).toEqual(['read']);
+});
+
+test('a full read+consume+write request renders three levels', () => {
+  searchParams = new URLSearchParams({ ...VALID, scope: 'read consume write' });
+  render(<ConnectAiAuthorize />);
+  expect(screen.getAllByRole('radio')).toHaveLength(3);
+  expect(screen.getByLabelText(/Full access/i)).toBeChecked();
+});
+
+test('denying does not send a scopes field at all', async () => {
+  approveMock.mockResolvedValue({ ok: true, json: async () => ({ redirect: 'https://claude.ai/cb?error=access_denied' }) });
+  render(<ConnectAiAuthorize />);
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  await waitFor(() => expect(approveMock).toHaveBeenCalled());
+  expect(approveMock.mock.calls[0][1]).not.toHaveProperty('scopes');
 });


### PR DESCRIPTION
The launch post promises *"connect read-only if you'd rather the AI could look but not touch"* — but the OAuth flow (the path claude.ai and Claude Desktop users actually take) granted the full scope set with no choice. Read-only existed only via hand-minted tokens + the npx bridge — exactly the path casual users won't take.

## What changed
- **Consent screen** ([ConnectAiAuthorize](frontend/src/pages/ConnectAiAuthorize.js)): one selectable access level per prefix of the offered scope set — *Read only* / *Read + log drinking* / *Full access* — with **full pre-selected**, so click-through behavior is unchanged. Each option lists exactly what it includes.
- **`POST /approve`**: accepts the chosen `scopes`; re-validates server-side — subset of the client's request (requested ∩ grantable), `read` mandatory (a read-less grant is a broken connector), absent field → previous behavior (older consent pages, direct callers).
- **Downstream needs nothing**: the tool registry filters structurally by token scopes, so a read-only OAuth grant never even sees the write tools — same machinery as read-only PATs. Upgrading later = disconnect + reconnect and pick more.

## Tests
`/approve`: narrowing honored on the minted code · exceed-the-request / missing-read / malformed → 400 · absent → unchanged. Consent page RTL: default posts the full set, "Read only" posts `['read']`, level count follows the request, deny sends no scopes field. **Backend 138 suites / 2079 green · frontend 675 + build green.** sv strings machine-authored (review pass pending).

No compose impact. Rides v1.82.4 together with #778 (session-cap eviction).