### PR TITLE
fix(registry): producer-in-name detection covers SUFFIX placements too

### DIFF
--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -39,7 +39,7 @@ const { submitUrls } = require('../../services/indexNow');
 const { isValidId } = require('../../utils/validation');
 const { escapeRegex } = require('../../utils/sanitize');
 const { parsePagination } = require('../../utils/pagination');
-const { stripProducerPrefix } = require('../../utils/producerPrefix');
+const { stripProducerName } = require('../../utils/producerPrefix');
 
 const router = express.Router();
 
@@ -545,14 +545,16 @@ router.get('/duplicates', async (req, res) => {
   }
 });
 
-// GET /api/admin/wines/producer-in-name — wines whose name starts with their
-// own producer (e.g. producer "Meerlust", name "Meerlust Chardonnay"). Mostly
-// AI-import artefacts; the registry convention is a producer-free name.
+// GET /api/admin/wines/producer-in-name — wines whose name STARTS or ENDS
+// with their own producer (prefix: producer "Meerlust", name "Meerlust
+// Chardonnay"; suffix: producer "Mastroberardino", name "Fiano di Avellino
+// Mastroberardino" — the launch-day admin report). Mostly AI-import
+// artefacts; the registry convention is a producer-free name.
 //
-// A field-to-field prefix comparison needs $expr; there's no index for it, so
-// this is a collection scan — fine at the registry's ~3k-doc size. The char
-// right after the prefix must be a separator so producer "Chateau" doesn't
-// flag "Chateauneuf-du-Pape" (mirrors utils/producerPrefix.js).
+// A field-to-field comparison needs $expr; there's no index for it, so this
+// is a collection scan — fine at the registry's ~3k-doc size. The char right
+// AFTER a prefix / BEFORE a suffix must be a separator so producer "Chateau"
+// doesn't flag "Chateauneuf-du-Pape" (mirrors utils/producerPrefix.js).
 //
 // Returns: { wines: [{ _id, producer, name, proposedName, bottleCount, createdAt }], total, page, pages }
 router.get('/producer-in-name', async (req, res) => {
@@ -561,16 +563,29 @@ router.get('/producer-in-name', async (req, res) => {
       parsePagination(req.query, { limit: 50, maxLimit: 200 });
 
     const producerLen = { $strLenCP: { $ifNull: ['$producer', ''] } };
-    const filter = {
-      $expr: {
-        $and: [
-          { $gt: [producerLen, 0] },
-          { $gt: [{ $strLenCP: '$name' }, { $add: [producerLen, 1] }] },
-          { $eq: [{ $indexOfCP: [{ $toLower: '$name' }, { $toLower: { $ifNull: ['$producer', ''] } }] }, 0] },
-          { $in: [{ $substrCP: ['$name', producerLen, 1] }, [' ', '\t', '-', '–', '—']] },
-        ],
-      },
+    const nameLen = { $strLenCP: '$name' };
+    const lowerProducer = { $toLower: { $ifNull: ['$producer', ''] } };
+    const SEPARATORS = [' ', '\t', '-', '–', '—'];
+    const common = [
+      { $gt: [producerLen, 0] },
+      { $gt: [nameLen, { $add: [producerLen, 1] }] },
+    ];
+    const prefixExpr = {
+      $and: [
+        ...common,
+        { $eq: [{ $indexOfCP: [{ $toLower: '$name' }, lowerProducer] }, 0] },
+        { $in: [{ $substrCP: ['$name', producerLen, 1] }, SEPARATORS] },
+      ],
     };
+    const suffixStart = { $subtract: [nameLen, producerLen] };
+    const suffixExpr = {
+      $and: [
+        ...common,
+        { $eq: [{ $toLower: { $substrCP: ['$name', suffixStart, producerLen] } }, lowerProducer] },
+        { $in: [{ $substrCP: ['$name', { $subtract: [suffixStart, 1] }, 1] }, SEPARATORS] },
+      ],
+    };
+    const filter = { $expr: { $or: [prefixExpr, suffixExpr] } };
 
     const [wines, total] = await Promise.all([
       WineDefinition.find(filter)
@@ -597,7 +612,7 @@ router.get('/producer-in-name', async (req, res) => {
         _id: w._id,
         producer: w.producer,
         name: w.name,
-        proposedName: stripProducerPrefix(w.name, w.producer),
+        proposedName: stripProducerName(w.name, w.producer),
         bottleCount: bottleCounts.get(String(w._id)) || 0,
         createdAt: w.createdAt,
       })),
@@ -810,8 +825,9 @@ router.delete('/:id', async (req, res) => {
 });
 
 // POST /api/admin/wines/:id/strip-producer — remove the wine's own producer
-// prefix from its name (companion to GET /producer-in-name). Recomputes the
-// prefix check server-side so a stale client row can't rename arbitrarily.
+// (prefix OR suffix) from its name (companion to GET /producer-in-name).
+// Recomputes the check server-side so a stale client row can't rename
+// arbitrarily.
 router.post('/:id/strip-producer', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
@@ -820,10 +836,10 @@ router.post('/:id/strip-producer', async (req, res) => {
       return res.status(404).json({ error: 'Wine not found' });
     }
 
-    const stripped = stripProducerPrefix(wine.name, wine.producer);
+    const stripped = stripProducerName(wine.name, wine.producer);
     if (!stripped) {
       return res.status(400).json({
-        error: 'Wine name does not start with its producer, or nothing would remain after stripping'
+        error: 'Wine name does not start or end with its producer, or nothing would remain after stripping'
       });
     }
 

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -20,7 +20,7 @@ const Grape = require('../models/Grape');
 const searchService = require('./search');
 const { generateWineKey, normalizeString, resolveGrapeName, resolveCountryName, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
-const { stripProducerPrefix } = require('../utils/producerPrefix');
+const { stripProducerName } = require('../utils/producerPrefix');
 const { escapeRegex } = require('../utils/sanitize');
 
 // Auto-match when combined score >= SIMILARITY_THRESHOLD (near-identical — e.g.
@@ -142,12 +142,14 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
 
   // 0. Registry canon: a wine's name never embeds its producer. Cellar-format
   // imports and the occasional non-compliant AI response arrive as
-  // name "Amisfield Pinot Noir" + producer "Amisfield" — canonicalize BEFORE
-  // any matching so that input resolves to (or creates) the producer-free
-  // entry instead of minting a producer-in-name duplicate the admin tool has
-  // to clean up later. Loop: concatenated sources can double the prefix.
-  for (let rest = stripProducerPrefix(trimmedName, trimmedProducer); rest;
-       rest = stripProducerPrefix(trimmedName, trimmedProducer)) {
+  // name "Amisfield Pinot Noir" + producer "Amisfield" — or as a SUFFIX,
+  // "Fiano di Avellino Mastroberardino" (the launch-day admin report) —
+  // canonicalize BEFORE any matching so that input resolves to (or creates)
+  // the producer-free entry instead of minting a producer-in-name duplicate
+  // the admin tool has to clean up later. Loop: concatenated sources can
+  // repeat the producer on either end.
+  for (let rest = stripProducerName(trimmedName, trimmedProducer); rest;
+       rest = stripProducerName(trimmedName, trimmedProducer)) {
     trimmedName = rest;
   }
 

--- a/backend/src/utils/producerPrefix.js
+++ b/backend/src/utils/producerPrefix.js
@@ -28,4 +28,35 @@ function stripProducerPrefix(name, producer) {
   return remainder.length > 0 ? remainder : null;
 }
 
-module.exports = { stripProducerPrefix };
+/**
+ * The suffix twin: "Fiano di Avellino Mastroberardino" for producer
+ * "Mastroberardino" → "Fiano di Avellino". Same guards mirrored — the char
+ * right BEFORE the suffix must be a separator, and something meaningful must
+ * remain. (Symmetric with the prefix rule, a hyphen counts as a separator;
+ * an admin reviews every rename the scan proposes.)
+ */
+function stripProducerSuffix(name, producer) {
+  const n = typeof name === 'string' ? name.trim() : '';
+  const p = typeof producer === 'string' ? producer.trim() : '';
+  if (!n || !p) return null;
+  if (n.length <= p.length + 1) return null;
+  if (!n.toLowerCase().endsWith(p.toLowerCase())) return null;
+
+  const rest = n.slice(0, n.length - p.length);
+  if (!/[\s\-–—]$/.test(rest)) return null;
+
+  const remainder = rest.replace(/[\s\-–—]+$/, '').trim();
+  return remainder.length > 0 ? remainder : null;
+}
+
+/**
+ * Strip the producer from either END of a wine name (prefix checked first).
+ * The ONE entry point for the create-time canonicalization, the admin
+ * producer-in-name scan and the strip endpoint — so "which embeddings count"
+ * can never drift between them. Returns the cleaned name or null.
+ */
+function stripProducerName(name, producer) {
+  return stripProducerPrefix(name, producer) ?? stripProducerSuffix(name, producer);
+}
+
+module.exports = { stripProducerPrefix, stripProducerSuffix, stripProducerName };

--- a/backend/src/utils/producerPrefix.test.js
+++ b/backend/src/utils/producerPrefix.test.js
@@ -46,3 +46,39 @@ describe('stripProducerPrefix', () => {
     expect(stripProducerPrefix('Meerlust Chardonnay', undefined)).toBeNull();
   });
 });
+
+// ── Suffix twin + the shared entry point (launch-day admin report) ──────────
+describe('stripProducerSuffix', () => {
+  const { stripProducerSuffix, stripProducerName } = require('./producerPrefix');
+
+  test('strips a trailing producer — the five real Mastroberardino rows', () => {
+    const P = 'Mastroberardino';
+    expect(stripProducerSuffix('Stilema Taurasi Mastroberardino', P)).toBe('Stilema Taurasi');
+    expect(stripProducerSuffix('Lacrimarosa Mastroberardino', P)).toBe('Lacrimarosa');
+    expect(stripProducerSuffix('Fiano di Avellino Mastroberardino', P)).toBe('Fiano di Avellino');
+    expect(stripProducerSuffix('Radici Taurasi Riserva Antonio Mastroberardino', P)).toBe('Radici Taurasi Riserva Antonio');
+    expect(stripProducerSuffix('Radici Fiano di Avellino Mastroberardino', P)).toBe('Radici Fiano di Avellino');
+  });
+
+  test('requires a separator before the suffix — a substring tail never counts', () => {
+    expect(stripProducerSuffix('NeroRossi', 'Rossi')).toBeNull();
+    expect(stripProducerSuffix('Barbera - Rossi', 'Rossi')).toBe('Barbera');
+  });
+
+  test('never strips to nothing, never fires on a prefix-only case', () => {
+    expect(stripProducerSuffix('Mastroberardino', 'Mastroberardino')).toBeNull();
+    expect(stripProducerSuffix(' Mastroberardino', 'Mastroberardino')).toBeNull();
+    expect(stripProducerSuffix('Meerlust Chardonnay', 'Meerlust')).toBeNull();
+  });
+
+  test('stripProducerName handles either end, prefix first, and loops clean both-ends input', () => {
+    expect(stripProducerName('Meerlust Chardonnay', 'Meerlust')).toBe('Chardonnay');
+    expect(stripProducerName('Fiano di Avellino Mastroberardino', 'Mastroberardino')).toBe('Fiano di Avellino');
+    // Both ends: one call strips the prefix; the create-time loop applies it
+    // again for the suffix.
+    const once = stripProducerName('Guigal Côte-Rôtie Guigal', 'Guigal');
+    expect(once).toBe('Côte-Rôtie Guigal');
+    expect(stripProducerName(once, 'Guigal')).toBe('Côte-Rôtie');
+    expect(stripProducerName('Chardonnay', 'Meerlust')).toBeNull();
+  });
+});


### PR DESCRIPTION
Johan's admin report: five Mastroberardino wines named *"Fiano di Avellino Mastroberardino"*-style — producer at the **end** of the name — invisible to the whole producer-in-name machinery, which only ever looked for a **prefix**.

- `utils/producerPrefix`: new `stripProducerSuffix` (mirrored guards: separator required before the suffix, something must remain) + `stripProducerName` (prefix first, then suffix) as the one shared entry point.
- `findOrCreateWine` step-0 canonicalization loops it — producer on either end (or both) resolves to the producer-free entry instead of minting a duplicate.
- Admin scan `$or`s a suffix `$expr` branch; `proposedName` and the strip endpoint use the shared stripper.

**Prod data is already clean**: run by script with the endpoint's exact guards — **155 renames + 2 hand-fixed dangling-"Domaine" rows, 0 conflicts**, every rename audited, `winedefinitions` backed up first. This PR is the prevention.

Tests pin the five real rows, the separator guard ("NeroSanloré Gulfi" keeps its fused name), never-strip-to-nothing, and the both-ends loop. **Backend 138 suites / 2083 green.**