### PR TITLE
feat(mcp): public /connect-ai page + official MCP registry entries

### DIFF
--- a/backend/src/routes/og.connectAi.test.js
+++ b/backend/src/routes/og.connectAi.test.js
@@ -1,0 +1,104 @@
+/**
+ * GET /api/og/connect-ai — the crawler-rendered MCP set-up page.
+ *
+ * This page exists so AI crawlers learn that this instance HAS an MCP server:
+ * nginx routes crawler user-agents here instead of the empty SPA shell. The
+ * value is entirely in the rendered text, so the test pins that the endpoints
+ * actually appear, that the JSON-LD is parseable, and that the script block
+ * cannot be broken out of.
+ */
+
+const express = require('express');
+const http = require('http');
+const ogRouter = require('./og');
+
+let server, baseUrl;
+
+beforeAll((done) => {
+  const app = express();
+  app.use('/api/og', ogRouter);
+  server = http.createServer(app);
+  server.listen(0, () => {
+    baseUrl = `http://127.0.0.1:${server.address().port}`;
+    done();
+  });
+});
+
+afterAll((done) => {
+  server.closeAllConnections();
+  server.close(done);
+});
+
+const get = async () => {
+  const res = await fetch(`${baseUrl}/api/og/connect-ai`);
+  return { status: res.status, type: res.headers.get('content-type'), html: await res.text() };
+};
+
+describe('GET /api/og/connect-ai', () => {
+  test('renders HTML naming BOTH MCP endpoints as literal text', async () => {
+    const { status, type, html } = await get();
+    expect(status).toBe(200);
+    expect(type).toMatch(/text\/html/);
+    // The whole point of the page — a crawler must be able to read these
+    // without executing any JavaScript.
+    expect(html).toContain('/api/mcp');
+    expect(html).toContain('/api/mcp/public');
+    expect(html).toContain('/.well-known/oauth-protected-resource/api/mcp');
+    // The public endpoint has to be identifiable as the no-account one.
+    expect(html).toMatch(/no account/i);
+  });
+
+  // Drift guard. This page duplicates the client list from the SPA's
+  // `connectAi.clients.*` locale block, and the first version of it silently
+  // shipped without Claude Code and Gemini CLI — invisible to exactly the
+  // audience the page exists for. Every client family the SPA lists must be
+  // named here too; add to both when a new one is supported.
+  test('names every client family the SPA page lists', async () => {
+    const { html } = await get();
+    for (const client of [
+      'Claude',
+      'Claude Code',
+      'Claude Desktop',
+      'ChatGPT',
+      'VS Code',
+      'Cursor',
+      'Gemini CLI',
+      'LM Studio',
+      'cellarion-mcp',
+    ]) {
+      expect(html).toContain(client);
+    }
+  });
+
+  test('emits valid, parseable HowTo + BreadcrumbList JSON-LD', async () => {
+    const { html } = await get();
+    const match = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+    expect(match).not.toBeNull();
+
+    // serializeJsonLd escapes < > & as \uXXXX, which JSON.parse resolves back.
+    const parsed = JSON.parse(match[1]);
+    const types = parsed['@graph'].map((n) => n['@type']);
+    expect(types).toContain('HowTo');
+    expect(types).toContain('BreadcrumbList');
+
+    const howTo = parsed['@graph'].find((n) => n['@type'] === 'HowTo');
+    expect(howTo.step.length).toBeGreaterThan(0);
+    // Positions must be 1-based and contiguous or crawlers reorder the steps.
+    expect(howTo.step.map((s) => s.position)).toEqual(howTo.step.map((_, i) => i + 1));
+  });
+
+  test('the JSON-LD block cannot be broken out of', async () => {
+    const { html } = await get();
+    const block = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)[1];
+    // Raw angle brackets inside the block would let a crafted string close the
+    // <script> element early.
+    expect(block).not.toMatch(/[<>]/);
+  });
+
+  test('sets a canonical URL and is cacheable', async () => {
+    const res = await fetch(`${baseUrl}/api/og/connect-ai`);
+    expect(res.headers.get('cache-control')).toMatch(/max-age=3600/);
+    const html = await res.text();
+    expect(html).toMatch(/<link rel="canonical" href="[^"]+\/connect-ai"/);
+  });
+});

--- a/backend/src/routes/og.js
+++ b/backend/src/routes/og.js
@@ -292,6 +292,128 @@ router.get('/help', ogLimiter, (req, res) => {
   }
 });
 
+// GET /og/connect-ai — server-rendered MCP set-up page for crawlers.
+//
+// This one matters more than a normal OG page: AI crawlers are exactly the
+// audience that should learn this instance HAS an MCP server, so the endpoints
+// are rendered as literal text rather than hidden behind client-side JS. The
+// copy is deliberately duplicated from the frontend's `connectAi` locale block
+// (short, stable, and the backend has no access to frontend locales) — keep the
+// two in sync when either changes.
+router.get('/connect-ai', ogLimiter, (req, res) => {
+  try {
+    const pageUrl = `${SITE_URL}/connect-ai`;
+    const title = 'Connect your AI to your wine cellar';
+    const metaDescription = 'Cellarion speaks the Model Context Protocol. Connect Claude, ChatGPT, VS Code, Cursor, Gemini CLI or any MCP client to your wine cellar.';
+    const personalEndpoint = `${SITE_URL}/api/mcp`;
+    const publicEndpoint = `${SITE_URL}/api/mcp/public`;
+
+    const steps = [
+      {
+        title: 'Claude (web, desktop and mobile)',
+        text: `Settings, then Connectors, then Add custom connector, and paste ${personalEndpoint}. Sign in with your Cellarion account and choose an access level.`,
+      },
+      {
+        title: 'ChatGPT',
+        text: `Settings, then Connectors, then Advanced, enable Developer mode, choose Create and paste ${personalEndpoint} with authentication set to OAuth.`,
+      },
+      {
+        title: 'Claude Code',
+        text: `Run: claude mcp add --transport http cellarion ${personalEndpoint}`,
+      },
+      {
+        title: 'VS Code, Cursor and Windsurf',
+        text: `Add ${personalEndpoint} as an HTTP MCP server in mcp.json.`,
+      },
+      {
+        title: 'Gemini CLI',
+        text: `Add ${personalEndpoint} as an httpUrl MCP server in ~/.gemini/settings.json.`,
+      },
+      {
+        title: 'Claude Desktop, LM Studio and other stdio clients',
+        text: 'Run the published bridge with: npx -y cellarion-mcp, setting CELLARION_TOKEN to a personal API token from Settings, then API tokens.',
+      },
+      {
+        title: 'No account needed',
+        text: `A public endpoint at ${publicEndpoint} serves the shared wine registry, grape and region profiles, sommelier drink windows and published guides to any AI, with no sign-up and no personal data.`,
+      },
+    ];
+
+    const jsonLd = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'HowTo',
+          name: title,
+          description: metaDescription,
+          url: pageUrl,
+          step: steps.map((s, i) => ({
+            '@type': 'HowToStep',
+            position: i + 1,
+            name: s.title,
+            text: s.text,
+          })),
+        },
+        {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Cellarion', item: SITE_URL },
+            { '@type': 'ListItem', position: 2, name: title, item: pageUrl },
+          ],
+        },
+      ],
+    };
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${esc(title)} — Cellarion</title>
+  <meta name="description" content="${esc(metaDescription)}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="${esc(title)} — Cellarion" />
+  <meta property="og:description" content="${esc(metaDescription)}" />
+  <meta property="og:image" content="${esc(SITE_URL)}/cellarion-logo.jpg" />
+  <meta property="og:url" content="${esc(pageUrl)}" />
+  <meta property="og:site_name" content="Cellarion" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${esc(title)} — Cellarion" />
+  <meta name="twitter:description" content="${esc(metaDescription)}" />
+  <link rel="canonical" href="${esc(pageUrl)}" />
+  <script type="application/ld+json">${serializeJsonLd(jsonLd)}</script>
+</head>
+<body>
+  <nav><a href="${esc(SITE_URL)}">Cellarion</a> / ${esc(title)}</nav>
+  <header>
+    <h1>${esc(title)}</h1>
+    <p>${esc(metaDescription)}</p>
+  </header>
+  <main>
+    <section>
+      <h2>Endpoints</h2>
+      <ul>
+        <li>Personal (your own cellar, requires sign-in): ${esc(personalEndpoint)} — Streamable HTTP, OAuth 2.1 with PKCE, or a personal bearer token.</li>
+        <li>Public (shared wine reference, no account): ${esc(publicEndpoint)} — Streamable HTTP, no authentication, read-only.</li>
+        <li>Discovery: ${esc(SITE_URL)}/.well-known/oauth-protected-resource/api/mcp</li>
+      </ul>
+    </section>
+    ${steps.map(s => `<section><h2>${esc(s.title)}</h2><p>${esc(s.text)}</p></section>`).join('\n    ')}
+  </main>
+  <footer>
+    <p><a href="${esc(SITE_URL)}">Cellarion</a> — track your wine collection, get drink-window alerts, and share cellars with friends. Open source, AGPL-3.0.</p>
+  </footer>
+</body>
+</html>`;
+
+    res.set('Content-Type', 'text/html; charset=utf-8');
+    res.set('Cache-Control', 'public, max-age=3600');
+    res.send(html);
+  } catch (err) {
+    console.error('[og] connect-ai page error:', err.message);
+    res.status(500).send('Error generating page');
+  }
+});
+
 // GET /og/wines/:idOrSlug — Full server-rendered HTML for search engine crawlers.
 // Nginx routes crawler user-agents here; real users get the SPA.
 // Accepts both ObjectId and slug. When given an ObjectId for a wine that has a slug,

--- a/backend/src/routes/sitemap.js
+++ b/backend/src/routes/sitemap.js
@@ -49,6 +49,7 @@ router.get('/', sitemapLimiter, async (req, res) => {
       { loc: '/blog', priority: '0.8', changefreq: 'daily' },
       { loc: '/community/discussions', priority: '0.8', changefreq: 'daily' },
       { loc: '/help', priority: '0.6', changefreq: 'monthly' },
+      { loc: '/connect-ai', priority: '0.7', changefreq: 'monthly' },
       { loc: '/privacy', priority: '0.3', changefreq: 'yearly' },
     ];
 

--- a/cellarion-mcp/package.json
+++ b/cellarion-mcp/package.json
@@ -1,7 +1,8 @@
 {
   "name": "cellarion-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Connect your AI (Claude Desktop, Cursor, …) to your Cellarion wine cellar — a stdio MCP bridge to a Cellarion server.",
+  "mcpName": "app.cellarion/cellarion",
   "type": "module",
   "bin": {
     "cellarion-mcp": "index.js"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -294,6 +294,33 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    # MCP connect page — crawlers get the server-rendered set-up guide with the
+    # literal endpoints + HowTo JSON-LD; real users get the SPA. Exact match, so
+    # /connect-ai/authorize (the OAuth consent screen) is untouched and keeps
+    # falling through to the SPA shell.
+    location = /connect-ai {
+        error_page 418 = @connect_ai_og;
+        if ($is_crawler) {
+            return 418;
+        }
+        root              /usr/share/nginx/html;
+        add_header        Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header        Pragma                                "no-cache"  always;
+        add_header        Expires                               "0"         always;
+        include           /etc/nginx/snippets/security-headers.conf;
+        try_files         /index.html =404;
+    }
+
+    location @connect_ai_og {
+        rewrite ^ /api/og/connect-ai break;
+        proxy_pass         http://backend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
     # Blog index — crawlers get the server-rendered post list + CollectionPage
     # JSON-LD; real users get the SPA. Individual /blog/<slug> posts are handled
     # by the regex location further below.

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -5,6 +5,7 @@
 ## Start here
 - [Home](https://cellarion.app/): what Cellarion is, the full feature list, and FAQ.
 - [Help](https://cellarion.app/help): how to track a wine collection, drink windows, racks, sharing, import/export.
+- [Connect your AI](https://cellarion.app/connect-ai): set-up instructions for Claude, ChatGPT, VS Code, Cursor, Gemini CLI and any other MCP client.
 - [Blog](https://cellarion.app/blog): guides on wine storage, ageing, drink windows, and cellar management.
 - [Community](https://cellarion.app/community): discussions among wine collectors and enthusiasts.
 
@@ -15,8 +16,10 @@
 - [Grapes](https://cellarion.app/grapes/)
 
 ## Connect your AI (MCP)
-- Cellarion has a built-in MCP (Model Context Protocol) server. Connect Claude, ChatGPT, or any MCP-capable assistant to your account to search your cellar, ask what to open tonight, pair wines with dishes, add and consume bottles, and organise racks — with scoped permissions, a reviewable activity trail, and one-click undo. Set it up under Settings → Connect your AI.
+- Cellarion has a built-in MCP (Model Context Protocol) server. Connect Claude, ChatGPT, or any MCP-capable assistant to your account to search your cellar, ask what to open tonight, pair wines with dishes, add and consume bottles, and organise racks — with scoped permissions, a reviewable activity trail, and one-click undo. Set it up under Settings → Connect your AI, or follow the per-client guides at https://cellarion.app/connect-ai.
+- Personal endpoint: https://cellarion.app/api/mcp (Streamable HTTP; OAuth 2.1 with PKCE, or a personal `cel_` bearer token). Discovery: https://cellarion.app/.well-known/oauth-protected-resource/api/mcp
 - AI clients can also use Cellarion anonymously: a public MCP endpoint at https://cellarion.app/api/mcp/public serves the shared wine registry, drink-window knowledge, and guides — no account required, no personal data involved.
+- A stdio bridge is published on npm as `cellarion-mcp` for clients that cannot speak remote HTTP: `npx -y cellarion-mcp`.
 
 ## Key facts
 - Platforms: a web app that runs in any browser, plus an Android app on Google Play (https://play.google.com/store/apps/details?id=app.cellarion.twa). iPhone users can install it to the home screen as a web app.

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -24,6 +24,7 @@ Allow: /regions/
 Allow: /countries/
 Allow: /grapes/
 Allow: /help
+Allow: /connect-ai
 Allow: /privacy
 Allow: /community
 Allow: /api/sitemap.xml
@@ -71,6 +72,7 @@ Allow: /regions/
 Allow: /countries/
 Allow: /grapes/
 Allow: /help
+Allow: /connect-ai
 Allow: /privacy
 Allow: /community
 Allow: /api/sitemap.xml

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -74,6 +74,7 @@ const CountryDetail        = lazy(() => import('./pages/CountryDetail'));
 const GrapeDetail          = lazy(() => import('./pages/GrapeDetail'));
 const WineTypeDetail       = lazy(() => import('./pages/WineTypeDetail'));
 const Help                 = lazy(() => import('./pages/Help'));
+const ConnectAi            = lazy(() => import('./pages/ConnectAi'));
 const WineLists            = lazy(() => import('./pages/WineLists'));
 const WineListEditor       = lazy(() => import('./pages/WineListEditor'));
 const PublicWineList       = lazy(() => import('./pages/PublicWineList'));
@@ -379,6 +380,9 @@ function AppRoutes() {
         <Route path="/blog" element={<Layout><Blog /></Layout>} />
         <Route path="/blog/:slug" element={<Layout><BlogPost /></Layout>} />
         <Route path="/help" element={<Layout><Help /></Layout>} />
+        {/* Public set-up docs for the MCP connector. Distinct from
+            /connect-ai/authorize above, which is the OAuth consent screen. */}
+        <Route path="/connect-ai" element={<Layout><ConnectAi /></Layout>} />
 
         {/* Admin routes */}
         <Route

--- a/frontend/src/components/AiConnectSection.js
+++ b/frontend/src/components/AiConnectSection.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { HOSTED_ORIGIN, isHostedOrigin, claudeOneClickUrl } from '../utils/mcpConnect';
 
 /**
  * Settings section: "Connect your AI" — copy-paste MCP configs for Claude
@@ -11,8 +12,6 @@ import { useTranslation } from 'react-i18next';
  * sent anywhere except the same-origin test call to /api/auth/whoami, the
  * endpoint built for exactly this "is my token valid?" check.
  */
-const HOSTED_ORIGIN = 'https://cellarion.app';
-
 function buildSnippets(rawToken) {
   const token = rawToken.trim() || 'cel_YOUR_TOKEN_HERE';
   const origin = window.location.origin;
@@ -139,6 +138,23 @@ export default function AiConnectSection() {
         </div>
       )}
 
+      {isHostedOrigin(window.location.origin) && (
+        <div className="ai-connect-oneclick">
+          <a
+            className="btn btn-primary btn-small"
+            href={claudeOneClickUrl(window.location.origin)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t('settings.aiConnect.oneClickCta', 'Add to Claude in one click')}
+          </a>
+          <span className="settings-hint">
+            {t('settings.aiConnect.oneClickHint',
+              'Opens Claude with the connector prefilled — no token needed. You sign in and pick an access level there.')}
+          </span>
+        </div>
+      )}
+
       <Snippet
         label={t('settings.aiConnect.claudeDesktopTitle', 'Claude Desktop (claude_desktop_config.json)')}
         text={snippets.desktop}
@@ -155,6 +171,10 @@ export default function AiConnectSection() {
       <p className="settings-hint ai-connect-footnote">
         {t('settings.aiConnect.securityNote',
           'Your AI sees only your own cellar data. Revoking the token in the API tokens section cuts the connection off instantly.')}
+        {' '}
+        <a href="/connect-ai" target="_blank" rel="noopener noreferrer">
+          {t('settings.aiConnect.docsLink', 'Set-up guides for every client')}
+        </a>
       </p>
     </div>
   );

--- a/frontend/src/components/AiConnectSection.test.js
+++ b/frontend/src/components/AiConnectSection.test.js
@@ -47,6 +47,38 @@ describe('AiConnectSection', () => {
     expect(texts[1]).toContain('/api/mcp');
   });
 
+  test('self-hosted installs get NO claude.ai one-click link', () => {
+    // jsdom origin is http://localhost:3000, i.e. self-hosted. A claude.ai deep
+    // link would point at a server claude.ai cannot reach.
+    render(<AiConnectSection />);
+    expect(screen.queryByRole('link', { name: /Add to Claude in one click/ })).toBeNull();
+  });
+
+  test('on cellarion.app, offers a prefilled claude.ai connector link for /api/mcp', () => {
+    const original = window.location;
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://cellarion.app'),
+      writable: true,
+      configurable: true,
+    });
+    try {
+      render(<AiConnectSection />);
+      const link = screen.getByRole('link', { name: /Add to Claude in one click/ });
+      const url = new URL(link.getAttribute('href'));
+      expect(url.origin).toBe('https://claude.ai');
+      expect(url.searchParams.get('modal')).toBe('add-custom-connector');
+      expect(url.searchParams.get('connectorUrl')).toBe('https://cellarion.app/api/mcp');
+      // Opening claude.ai must not hand it a window handle back to us.
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    } finally {
+      Object.defineProperty(window, 'location', {
+        value: original,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
   test('pasting a token fills it into every snippet (and never leaves the page)', () => {
     const { container } = render(<AiConnectSection />);
     fireEvent.change(screen.getByPlaceholderText(/paste your token/i), {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -174,6 +174,71 @@
     "levelConsume": "Read + log drinking — it can also mark bottles opened or drunk (reversible)",
     "levelFull": "Full access — it can also add and edit bottles, racks and cellars"
   },
+  "connectAi": {
+    "title": "Connect your AI to your wine cellar",
+    "subtitle": "Cellarion speaks the Model Context Protocol, so you can run your cellar from Claude, ChatGPT or any MCP client.",
+    "beta": "The AI connector is in beta. Everything an assistant changes is listed in your account and can be undone.",
+    "copy": "Copy",
+    "copied": "Copied",
+    "oneClick": {
+      "title": "One click with Claude",
+      "body": "Opens Claude with the connector details filled in. You still sign in and choose an access level.",
+      "cta": "Add Cellarion to Claude"
+    },
+    "access": {
+      "title": "What the assistant may do",
+      "body": "You pick an access level when you connect, and you can revoke it at any time from your settings.",
+      "readTitle": "Read",
+      "readBody": "Look at your cellars, bottles, racks and notes. Changes nothing.",
+      "consumeTitle": "Read and drink",
+      "consumeBody": "Also mark bottles as consumed. Every consumption can be restored.",
+      "writeTitle": "Full access",
+      "writeBody": "Also add and edit bottles, and organise racks and cellars.",
+      "tokenNote": "Set-ups that use a URL sign you in with OAuth, so there is nothing to paste. Only the stdio bridge needs a personal API token: mint one under Settings → API tokens and put it where those snippets say cel_YOUR_TOKEN_HERE."
+    },
+    "clientsTitle": "Set-up per client",
+    "clients": {
+      "claude": {
+        "title": "Claude (web, desktop and mobile)",
+        "body": "Settings → Connectors → Add custom connector, then paste the URL below. You sign in with your Cellarion account and choose what the assistant may do."
+      },
+      "claudeDesktop": {
+        "title": "Claude Desktop (local bridge)",
+        "body": "Prefer a local connection, or self-hosting? Add this to claude_desktop_config.json. It runs on your machine and talks to your server with a personal API token."
+      },
+      "claudeCode": {
+        "title": "Claude Code",
+        "body": "One command in your terminal."
+      },
+      "chatgpt": {
+        "title": "ChatGPT",
+        "body": "Settings → Connectors → Advanced → enable Developer mode, then Create and paste the URL below with authentication set to OAuth."
+      },
+      "vscode": {
+        "title": "VS Code (GitHub Copilot)",
+        "body": "Add to .vscode/mcp.json in your workspace, or your user mcp.json."
+      },
+      "cursor": {
+        "title": "Cursor and Windsurf",
+        "body": "Add to ~/.cursor/mcp.json (Cursor) or the equivalent Windsurf config."
+      },
+      "gemini": {
+        "title": "Gemini CLI",
+        "body": "Add to ~/.gemini/settings.json."
+      },
+      "stdio": {
+        "title": "LM Studio, Jan, LibreChat, Open WebUI, Goose",
+        "body": "These connect over stdio. Use the same bridge as Claude Desktop — it works with any MCP client that can run a command."
+      }
+    },
+    "publicTitle": "The open wine registry — no account needed",
+    "publicBody": "Cellarion also runs a public endpoint that any AI can use without signing up. It serves the shared wine registry, grape and region profiles, sommelier drink windows and our published guides. It holds no personal data and changes nothing.",
+    "rawTitle": "Raw protocol details",
+    "rawBody": "For anything that speaks MCP directly.",
+    "selfHostNote": "These URLs point at this install. All OAuth discovery URLs are derived from FRONTEND_URL, so set it to the address your users actually reach.",
+    "helpLink": "Browse the help centre",
+    "privacyLink": "How your data is handled"
+  },
   "settings": {
     "title": "Settings",
     "signedInAs": "Signed in as",
@@ -295,6 +360,9 @@
       "copy": "Copy",
       "copied": "Copied!",
       "securityNote": "Your AI sees only your own cellar data. Revoking the token in the API tokens section cuts the connection off instantly.",
+      "oneClickCta": "Add to Claude in one click",
+      "oneClickHint": "Opens Claude with the connector prefilled — no token needed. You sign in and pick an access level there.",
+      "docsLink": "Set-up guides for every client",
       "testError": "Could not verify right now (server busy or unreachable) — this says nothing about your token. Try again in a moment.",
       "beta": "Beta",
       "betaNotice": "This is a beta feature and you use it at your own risk. It works, but it is new and still being tested — expect rough edges, and changes while we refine it. If you are unsure, connect with a read-only token: anything an AI changes can be undone under \"What your AI has changed\", and revoking the token cuts it off instantly."
@@ -2163,6 +2231,7 @@
     "searchPlaceholder": "Search help topics...",
     "noResults": "No matching topics found. Try a different search term.",
     "goTo": "Go to {{name}}",
+    "connectAiLink": "Run your cellar from Claude, ChatGPT or any AI assistant",
     "sections": {
       "cellars": {
         "title": "Cellars",
@@ -2346,6 +2415,7 @@
     "createAccount": "Create a free account",
     "openCellar": "Open My Cellar",
     "footerSourceLink": "Source on GitHub",
+    "footerConnectAi": "Connect your AI",
     "footerCopy": "Cellarion",
     "metaTitle": "Cellarion — Wine Cellar App | Track Your Wine Collection Online",
     "metaDescription": "Track your wine collection with Cellarion. Log every bottle, visualise racks, get drink-window alerts, and share cellars with friends. Free wine cellar app at cellarion.app.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -174,6 +174,71 @@
     "levelConsume": "Läsa + logga drickande — den kan även markera flaskor som öppnade eller druckna (går att ångra)",
     "levelFull": "Full åtkomst — den kan även lägga till och redigera flaskor, hyllor och källare"
   },
+  "connectAi": {
+    "title": "Koppla din AI till din vinkällare",
+    "subtitle": "Cellarion talar Model Context Protocol, så du kan sköta din källare från Claude, ChatGPT eller vilken MCP-klient som helst.",
+    "beta": "AI-kopplingen är i beta. Allt en assistent ändrar listas i ditt konto och går att ångra.",
+    "copy": "Kopiera",
+    "copied": "Kopierat",
+    "oneClick": {
+      "title": "Ett klick med Claude",
+      "body": "Öppnar Claude med kopplingens uppgifter ifyllda. Du loggar fortfarande in och väljer åtkomstnivå.",
+      "cta": "Lägg till Cellarion i Claude"
+    },
+    "access": {
+      "title": "Vad assistenten får göra",
+      "body": "Du väljer åtkomstnivå när du kopplar, och du kan när som helst återkalla den i dina inställningar.",
+      "readTitle": "Läsa",
+      "readBody": "Se dina källare, flaskor, hyllor och anteckningar. Ändrar ingenting.",
+      "consumeTitle": "Läsa och dricka",
+      "consumeBody": "Kan även markera flaskor som druckna. Varje druckning går att återställa.",
+      "writeTitle": "Full åtkomst",
+      "writeBody": "Kan även lägga till och redigera flaskor samt organisera hyllor och källare.",
+      "tokenNote": "Uppsättningar som använder en adress loggar in dig med OAuth, så det finns inget att klistra in. Bara stdio-bryggan behöver en personlig API-token: skapa en under Inställningar → API-tokens och lägg in den där de kodexemplen säger cel_YOUR_TOKEN_HERE."
+    },
+    "clientsTitle": "Inställningar per klient",
+    "clients": {
+      "claude": {
+        "title": "Claude (webb, dator och mobil)",
+        "body": "Inställningar → Kopplingar → Lägg till egen koppling, klistra sedan in adressen nedan. Du loggar in med ditt Cellarion-konto och väljer vad assistenten får göra."
+      },
+      "claudeDesktop": {
+        "title": "Claude Desktop (lokal brygga)",
+        "body": "Föredrar du en lokal koppling, eller kör du själv? Lägg till detta i claude_desktop_config.json. Den körs på din dator och pratar med din server via en personlig API-token."
+      },
+      "claudeCode": {
+        "title": "Claude Code",
+        "body": "Ett kommando i terminalen."
+      },
+      "chatgpt": {
+        "title": "ChatGPT",
+        "body": "Inställningar → Kopplingar → Avancerat → slå på utvecklarläge, välj sedan Skapa och klistra in adressen nedan med autentisering satt till OAuth."
+      },
+      "vscode": {
+        "title": "VS Code (GitHub Copilot)",
+        "body": "Lägg till i .vscode/mcp.json i din arbetsyta, eller i din egen mcp.json."
+      },
+      "cursor": {
+        "title": "Cursor och Windsurf",
+        "body": "Lägg till i ~/.cursor/mcp.json (Cursor) eller motsvarande konfiguration i Windsurf."
+      },
+      "gemini": {
+        "title": "Gemini CLI",
+        "body": "Lägg till i ~/.gemini/settings.json."
+      },
+      "stdio": {
+        "title": "LM Studio, Jan, LibreChat, Open WebUI, Goose",
+        "body": "Dessa kopplar via stdio. Använd samma brygga som för Claude Desktop — den fungerar med alla MCP-klienter som kan köra ett kommando."
+      }
+    },
+    "publicTitle": "Det öppna vinregistret — inget konto behövs",
+    "publicBody": "Cellarion kör också en öppen endpoint som vilken AI som helst kan använda utan att registrera sig. Den ger det delade vinregistret, druv- och regionprofiler, sommelierernas dricktidsfönster och våra publicerade guider. Den innehåller inga personuppgifter och ändrar ingenting.",
+    "rawTitle": "Tekniska protokolluppgifter",
+    "rawBody": "För allt som talar MCP direkt.",
+    "selfHostNote": "Dessa adresser pekar på den här installationen. Alla OAuth-adresser härleds från FRONTEND_URL, så sätt den till adressen dina användare faktiskt når.",
+    "helpLink": "Bläddra i hjälpcentret",
+    "privacyLink": "Så hanteras dina uppgifter"
+  },
   "settings": {
     "title": "Inställningar",
     "signedInAs": "Inloggad som",
@@ -295,6 +360,9 @@
       "copy": "Kopiera",
       "copied": "Kopierat!",
       "securityNote": "Din AI ser bara dina egna källardata. Återkallar du din token i avsnittet API-tokens bryts anslutningen omedelbart.",
+      "oneClickCta": "Lägg till i Claude med ett klick",
+      "oneClickHint": "Öppnar Claude med kopplingen ifylld — ingen token behövs. Du loggar in och väljer åtkomstnivå där.",
+      "docsLink": "Guider för alla klienter",
       "testError": "Det gick inte att verifiera just nu (servern är upptagen eller onåbar) — det säger ingenting om din token. Försök igen om en stund.",
       "beta": "Beta",
       "betaNotice": "Det här är en betafunktion och du använder den på egen risk. Den fungerar, men är ny och testas fortfarande — räkna med ojämnheter och att saker ändras medan vi finslipar. Är du osäker, anslut med en läsbehörig token: allt en AI ändrar kan ångras under \"Vad din AI har ändrat\", och återkallar du token bryts anslutningen omedelbart."
@@ -2163,6 +2231,7 @@
     "searchPlaceholder": "Sök hjälpämnen...",
     "noResults": "Inga matchande ämnen hittades. Prova ett annat sökord.",
     "goTo": "Gå till {{name}}",
+    "connectAiLink": "Sköt din källare från Claude, ChatGPT eller vilken AI-assistent som helst",
     "sections": {
       "cellars": {
         "title": "Källare",
@@ -2346,6 +2415,7 @@
     "createAccount": "Skapa ett gratis konto",
     "openCellar": "Öppna min källare",
     "footerSourceLink": "Källkod på GitHub",
+    "footerConnectAi": "Koppla din AI",
     "footerCopy": "Cellarion",
     "metaTitle": "Cellarion — Vinkällar-app | Spåra din vinsamling online",
     "metaDescription": "Spåra din vinsamling med Cellarion. Logga varje flaska, visualisera ställ, få drickfönster-aviseringar och dela källare med vänner. Gratis vinkällar-app på cellarion.app.",

--- a/frontend/src/locales/translation.test.js
+++ b/frontend/src/locales/translation.test.js
@@ -1,0 +1,91 @@
+/**
+ * Locale integrity.
+ *
+ * Component tests mock react-i18next with `t: (key, fallback) => fallback`, so
+ * they assert the inline English fallbacks and never touch these files at all —
+ * every `connectAi.*` key could be deleted from both locales and the whole UI
+ * suite would still pass. This suite is the thing that actually reads them.
+ *
+ * `sv` mirrors `en` key-for-key by convention: i18n.js sets fallbackLng 'en',
+ * so a missing Swedish key degrades silently to English rather than failing
+ * loudly — which is exactly why it needs a test.
+ */
+
+import en from './en/translation.json';
+import sv from './sv/translation.json';
+
+const flatten = (obj, prefix = '') =>
+  Object.entries(obj).flatMap(([k, v]) => {
+    const key = prefix ? `${prefix}.${k}` : k;
+    return v && typeof v === 'object' && !Array.isArray(v) ? flatten(v, key) : [key];
+  });
+
+const enKeys = flatten(en);
+const svKeys = flatten(sv);
+
+const get = (obj, path) => path.split('.').reduce((o, k) => (o == null ? undefined : o[k]), obj);
+
+describe('translation files', () => {
+  test('en and sv mirror each other key-for-key', () => {
+    const missingInSv = enKeys.filter((k) => !svKeys.includes(k));
+    const missingInEn = svKeys.filter((k) => !enKeys.includes(k));
+    expect({ missingInSv, missingInEn }).toEqual({ missingInSv: [], missingInEn: [] });
+  });
+
+  test('no key resolves to an empty string in either locale', () => {
+    const blank = (locale, keys, obj) =>
+      keys.filter((k) => typeof get(obj, k) === 'string' && get(obj, k).trim() === '').map((k) => `${locale}:${k}`);
+    expect([...blank('en', enKeys, en), ...blank('sv', svKeys, sv)]).toEqual([]);
+  });
+
+  test('every leaf is a string (a stray object or null breaks interpolation)', () => {
+    const nonString = enKeys.filter((k) => typeof get(en, k) !== 'string');
+    expect(nonString).toEqual([]);
+  });
+
+  // The public MCP connect page is the one surface whose copy is load-bearing
+  // for distribution — it is what a stranger reads before trusting us with
+  // their cellar. Pin its shape so a partial merge cannot half-ship it.
+  describe('connectAi (public MCP set-up page)', () => {
+    const CLIENTS = ['claude', 'claudeDesktop', 'claudeCode', 'chatgpt', 'vscode', 'cursor', 'gemini', 'stdio'];
+
+    test.each(['en', 'sv'])('%s has the full connectAi block', (locale) => {
+      const bundle = locale === 'en' ? en : sv;
+      const block = bundle.connectAi;
+      expect(block).toBeDefined();
+
+      for (const k of ['title', 'subtitle', 'beta', 'copy', 'copied', 'clientsTitle', 'publicTitle', 'publicBody', 'rawTitle', 'rawBody', 'selfHostNote', 'helpLink', 'privacyLink']) {
+        expect(typeof block[k]).toBe('string');
+      }
+      for (const k of ['title', 'body', 'cta']) {
+        expect(typeof block.oneClick[k]).toBe('string');
+      }
+      for (const k of ['title', 'body', 'readTitle', 'readBody', 'consumeTitle', 'consumeBody', 'writeTitle', 'writeBody', 'tokenNote']) {
+        expect(typeof block.access[k]).toBe('string');
+      }
+      // Every client card the page maps over must have copy in both locales.
+      expect(Object.keys(block.clients).sort()).toEqual([...CLIENTS].sort());
+      for (const c of CLIENTS) {
+        expect(typeof block.clients[c].title).toBe('string');
+        expect(typeof block.clients[c].body).toBe('string');
+      }
+    });
+
+    test('the token note does not claim URL-based configs need a token', () => {
+      // The URL set-ups (VS Code, Cursor, Gemini CLI) authenticate over OAuth
+      // and have no token field, so telling people to paste one there sends
+      // them looking for a slot that does not exist.
+      expect(en.connectAi.access.tokenNote).toMatch(/OAuth/);
+      expect(en.connectAi.access.tokenNote).toMatch(/stdio/);
+    });
+  });
+
+  test('the pages linking to /connect-ai have their link labels', () => {
+    for (const bundle of [en, sv]) {
+      expect(typeof bundle.landing.footerConnectAi).toBe('string');
+      expect(typeof bundle.help.connectAiLink).toBe('string');
+      expect(typeof bundle.settings.aiConnect.oneClickCta).toBe('string');
+      expect(typeof bundle.settings.aiConnect.docsLink).toBe('string');
+    }
+  });
+});

--- a/frontend/src/pages/ConnectAi.css
+++ b/frontend/src/pages/ConnectAi.css
@@ -1,0 +1,166 @@
+.connect-ai-page {
+  padding: 2rem 1rem 4rem;
+}
+
+.connect-ai-container {
+  max-width: 820px;
+  margin: 0 auto;
+}
+
+.connect-ai-header h1 {
+  font-family: var(--font-heading);
+  color: var(--color-text);
+  margin-bottom: 0.5rem;
+}
+
+.connect-ai-subtitle {
+  color: var(--color-text-secondary);
+  font-size: 1.05rem;
+  margin-bottom: 0.75rem;
+}
+
+.connect-ai-beta {
+  background: var(--color-info-bg);
+  color: var(--color-info);
+  border: 1px solid var(--color-info-border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}
+
+.connect-ai-oneclick {
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 1.5rem;
+  margin-bottom: 2.5rem;
+  text-align: center;
+}
+
+.connect-ai-oneclick h2 {
+  font-family: var(--font-heading);
+  margin-bottom: 0.5rem;
+}
+
+.connect-ai-oneclick p {
+  color: var(--color-text-secondary);
+  margin-bottom: 1.25rem;
+}
+
+.connect-ai-section {
+  margin-bottom: 2.5rem;
+}
+
+.connect-ai-section > h2 {
+  font-family: var(--font-heading);
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-border-light);
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.connect-ai-section > p {
+  color: var(--color-text-secondary);
+  margin-bottom: 1rem;
+}
+
+.connect-ai-scopes {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+}
+
+.connect-ai-scopes li {
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-secondary);
+}
+
+.connect-ai-scopes li:last-child {
+  border-bottom: none;
+}
+
+.connect-ai-scopes strong {
+  color: var(--color-text);
+}
+
+.connect-ai-note {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.connect-ai-client {
+  margin-bottom: 1.75rem;
+}
+
+.connect-ai-client h3 {
+  font-family: var(--font-heading);
+  font-size: 1.05rem;
+  color: var(--color-text);
+  margin-bottom: 0.35rem;
+}
+
+.connect-ai-client p {
+  color: var(--color-text-secondary);
+  font-size: 0.925rem;
+  margin-bottom: 0.65rem;
+}
+
+/* Snippet block: the copy button floats over the top-right of the code box.
+   The <pre> scrolls on its own so a long URL never widens the page. */
+.connect-ai-snippet-block {
+  position: relative;
+}
+
+.connect-ai-copy {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 1;
+}
+
+.connect-ai-snippet {
+  background: var(--color-input-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem 1rem;
+  padding-right: 5.5rem;
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--color-text);
+  white-space: pre;
+  overflow-x: auto;
+  user-select: all;
+}
+
+.connect-ai-footer {
+  border-top: 1px solid var(--color-border-light);
+  padding-top: 1.25rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.connect-ai-footer a {
+  color: var(--color-primary);
+}
+
+@media (max-width: 600px) {
+  .connect-ai-page {
+    padding: 1.25rem 0.75rem 3rem;
+  }
+
+  /* On narrow screens the floating button would sit on top of the code, so
+     put it back in flow above the block. */
+  .connect-ai-copy {
+    position: static;
+    display: block;
+    margin-bottom: 0.5rem;
+  }
+
+  .connect-ai-snippet {
+    padding-right: 1rem;
+  }
+}

--- a/frontend/src/pages/ConnectAi.js
+++ b/frontend/src/pages/ConnectAi.js
@@ -1,0 +1,299 @@
+import { useState, useMemo, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import SEOHead from '../components/SEOHead';
+import SITE_URL from '../config/siteUrl';
+import { HOSTED_ORIGIN, isHostedOrigin, claudeOneClickUrl } from '../utils/mcpConnect';
+import './ConnectAi.css';
+
+const TOKEN_PLACEHOLDER = 'cel_YOUR_TOKEN_HERE';
+
+function Snippet({ text, copyLabel, copiedLabel }) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef(null);
+
+  // Clear on unmount, and reset on every click, so rapid re-clicks can't have
+  // an older timer flip the label back early.
+  useEffect(() => () => clearTimeout(timer.current), []);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable (insecure context / denied) — the text is
+         selectable anyway, so failing silently is the honest behaviour */
+    }
+  };
+
+  return (
+    <div className="connect-ai-snippet-block">
+      <button type="button" className="btn btn-secondary btn-small connect-ai-copy" onClick={copy}>
+        {copied ? copiedLabel : copyLabel}
+      </button>
+      <pre className="connect-ai-snippet"><code>{text}</code></pre>
+    </div>
+  );
+}
+
+function ConnectAi() {
+  const { t } = useTranslation();
+  const origin = typeof window !== 'undefined' ? window.location.origin : HOSTED_ORIGIN;
+  const selfHosted = !isHostedOrigin(origin);
+  const mcpUrl = `${origin}/api/mcp`;
+  const publicUrl = `${origin}/api/mcp/public`;
+
+  const copyLabel = t('connectAi.copy', 'Copy');
+  const copiedLabel = t('connectAi.copied', 'Copied');
+
+  // Every client's config, derived from the running origin so a self-hosted
+  // install shows its own URLs. Snippets themselves are code and stay
+  // untranslated; only the surrounding prose goes through i18n.
+  const clients = useMemo(() => {
+    const stdio = JSON.stringify(
+      {
+        mcpServers: {
+          cellarion: {
+            command: 'npx',
+            args: ['-y', 'cellarion-mcp'],
+            env: {
+              CELLARION_TOKEN: TOKEN_PLACEHOLDER,
+              ...(selfHosted ? { CELLARION_URL: origin } : {}),
+            },
+          },
+        },
+      },
+      null,
+      2,
+    );
+
+    return [
+      {
+        id: 'claude',
+        title: t('connectAi.clients.claude.title', 'Claude (web, desktop and mobile)'),
+        body: t(
+          'connectAi.clients.claude.body',
+          'Settings → Connectors → Add custom connector, then paste the URL below. You sign in with your Cellarion account and choose what the assistant may do.',
+        ),
+        snippet: mcpUrl,
+      },
+      {
+        id: 'claudeDesktop',
+        title: t('connectAi.clients.claudeDesktop.title', 'Claude Desktop (local bridge)'),
+        body: t(
+          'connectAi.clients.claudeDesktop.body',
+          'Prefer a local connection, or self-hosting? Add this to claude_desktop_config.json. It runs on your machine and talks to your server with a personal API token.',
+        ),
+        snippet: stdio,
+      },
+      {
+        id: 'claudeCode',
+        title: t('connectAi.clients.claudeCode.title', 'Claude Code'),
+        body: t('connectAi.clients.claudeCode.body', 'One command in your terminal.'),
+        snippet: `claude mcp add --transport http cellarion ${mcpUrl}`,
+      },
+      {
+        id: 'chatgpt',
+        title: t('connectAi.clients.chatgpt.title', 'ChatGPT'),
+        body: t(
+          'connectAi.clients.chatgpt.body',
+          'Settings → Connectors → Advanced → enable Developer mode, then Create and paste the URL below with authentication set to OAuth.',
+        ),
+        snippet: mcpUrl,
+      },
+      {
+        id: 'vscode',
+        title: t('connectAi.clients.vscode.title', 'VS Code (GitHub Copilot)'),
+        body: t('connectAi.clients.vscode.body', 'Add to .vscode/mcp.json in your workspace, or your user mcp.json.'),
+        snippet: JSON.stringify({ servers: { cellarion: { type: 'http', url: mcpUrl } } }, null, 2),
+      },
+      {
+        id: 'cursor',
+        title: t('connectAi.clients.cursor.title', 'Cursor and Windsurf'),
+        body: t('connectAi.clients.cursor.body', 'Add to ~/.cursor/mcp.json (Cursor) or the equivalent Windsurf config.'),
+        snippet: JSON.stringify({ mcpServers: { cellarion: { url: mcpUrl } } }, null, 2),
+      },
+      {
+        id: 'gemini',
+        title: t('connectAi.clients.gemini.title', 'Gemini CLI'),
+        body: t('connectAi.clients.gemini.body', 'Add to ~/.gemini/settings.json.'),
+        snippet: JSON.stringify({ mcpServers: { cellarion: { httpUrl: mcpUrl } } }, null, 2),
+      },
+      {
+        id: 'stdio',
+        title: t('connectAi.clients.stdio.title', 'LM Studio, Jan, LibreChat, Open WebUI, Goose'),
+        body: t(
+          'connectAi.clients.stdio.body',
+          'These connect over stdio. Use the same bridge as Claude Desktop — it works with any MCP client that can run a command.',
+        ),
+        snippet: stdio,
+      },
+    ];
+  }, [t, mcpUrl, origin, selfHosted]);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'TechArticle',
+        headline: t('connectAi.title', 'Connect your AI to your wine cellar'),
+        description: t(
+          'connectAi.subtitle',
+          'Cellarion speaks the Model Context Protocol, so you can run your cellar from Claude, ChatGPT or any MCP client.',
+        ),
+        url: `${SITE_URL}/connect-ai`,
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Cellarion', item: SITE_URL },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: t('connectAi.title', 'Connect your AI to your wine cellar'),
+            item: `${SITE_URL}/connect-ai`,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <div className="connect-ai-page">
+      <SEOHead
+        title={`${t('connectAi.title', 'Connect your AI to your wine cellar')} — Cellarion`}
+        description={t(
+          'connectAi.subtitle',
+          'Cellarion speaks the Model Context Protocol, so you can run your cellar from Claude, ChatGPT or any MCP client.',
+        )}
+        path="/connect-ai"
+        jsonLd={jsonLd}
+      />
+
+      <div className="connect-ai-container">
+        <header className="connect-ai-header">
+          <h1>{t('connectAi.title', 'Connect your AI to your wine cellar')}</h1>
+          <p className="connect-ai-subtitle">
+            {t(
+              'connectAi.subtitle',
+              'Cellarion speaks the Model Context Protocol, so you can run your cellar from Claude, ChatGPT or any MCP client.',
+            )}
+          </p>
+          <p className="connect-ai-beta">
+            {t(
+              'connectAi.beta',
+              'The AI connector is in beta. Everything an assistant changes is listed in your account and can be undone.',
+            )}
+          </p>
+        </header>
+
+        {!selfHosted && (
+          <section className="connect-ai-oneclick">
+            <h2>{t('connectAi.oneClick.title', 'One click with Claude')}</h2>
+            <p>
+              {t(
+                'connectAi.oneClick.body',
+                'Opens Claude with the connector details filled in. You still sign in and choose an access level.',
+              )}
+            </p>
+            <a className="btn btn-primary" href={claudeOneClickUrl(origin)} target="_blank" rel="noopener noreferrer">
+              {t('connectAi.oneClick.cta', 'Add Cellarion to Claude')}
+            </a>
+          </section>
+        )}
+
+        <section className="connect-ai-section">
+          <h2>{t('connectAi.access.title', 'What the assistant may do')}</h2>
+          <p>
+            {t(
+              'connectAi.access.body',
+              'You pick an access level when you connect, and you can revoke it at any time from your settings.',
+            )}
+          </p>
+          <ul className="connect-ai-scopes">
+            <li>
+              <strong>{t('connectAi.access.readTitle', 'Read')}</strong>
+              {' — '}
+              {t('connectAi.access.readBody', 'Look at your cellars, bottles, racks and notes. Changes nothing.')}
+            </li>
+            <li>
+              <strong>{t('connectAi.access.consumeTitle', 'Read and drink')}</strong>
+              {' — '}
+              {t('connectAi.access.consumeBody', 'Also mark bottles as consumed. Every consumption can be restored.')}
+            </li>
+            <li>
+              <strong>{t('connectAi.access.writeTitle', 'Full access')}</strong>
+              {' — '}
+              {t('connectAi.access.writeBody', 'Also add and edit bottles, and organise racks and cellars.')}
+            </li>
+          </ul>
+          <p className="connect-ai-note">
+            {t(
+              'connectAi.access.tokenNote',
+              'Set-ups that use a URL sign you in with OAuth, so there is nothing to paste. Only the stdio bridge needs a personal API token: mint one under Settings → API tokens and put it where those snippets say cel_YOUR_TOKEN_HERE.',
+            )}
+          </p>
+        </section>
+
+        <section className="connect-ai-section">
+          <h2>{t('connectAi.clientsTitle', 'Set-up per client')}</h2>
+          {clients.map((c) => (
+            <div className="connect-ai-client" key={c.id}>
+              <h3>{c.title}</h3>
+              <p>{c.body}</p>
+              <Snippet text={c.snippet} copyLabel={copyLabel} copiedLabel={copiedLabel} />
+            </div>
+          ))}
+        </section>
+
+        <section className="connect-ai-section">
+          <h2>{t('connectAi.publicTitle', 'The open wine registry — no account needed')}</h2>
+          <p>
+            {t(
+              'connectAi.publicBody',
+              'Cellarion also runs a public endpoint that any AI can use without signing up. It serves the shared wine registry, grape and region profiles, sommelier drink windows and our published guides. It holds no personal data and changes nothing.',
+            )}
+          </p>
+          <Snippet text={publicUrl} copyLabel={copyLabel} copiedLabel={copiedLabel} />
+        </section>
+
+        <section className="connect-ai-section">
+          <h2>{t('connectAi.rawTitle', 'Raw protocol details')}</h2>
+          <p>{t('connectAi.rawBody', 'For anything that speaks MCP directly.')}</p>
+          <Snippet
+            text={[
+              `Personal endpoint   ${mcpUrl}`,
+              `Public endpoint     ${publicUrl}`,
+              'Transport           Streamable HTTP',
+              'Auth                OAuth 2.1 (PKCE S256), or Bearer cel_ token',
+              `Discovery           ${origin}/.well-known/oauth-protected-resource/api/mcp`,
+              'Scopes              read · consume · write · offline_access',
+            ].join('\n')}
+            copyLabel={copyLabel}
+            copiedLabel={copiedLabel}
+          />
+          {selfHosted && (
+            <p className="connect-ai-note">
+              {t(
+                'connectAi.selfHostNote',
+                'These URLs point at this install. All OAuth discovery URLs are derived from FRONTEND_URL, so set it to the address your users actually reach.',
+              )}
+            </p>
+          )}
+        </section>
+
+        <footer className="connect-ai-footer">
+          <p>
+            <Link to="/help">{t('connectAi.helpLink', 'Browse the help centre')}</Link>
+            {' · '}
+            <Link to="/privacy">{t('connectAi.privacyLink', 'How your data is handled')}</Link>
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+export default ConnectAi;

--- a/frontend/src/pages/ConnectAi.test.js
+++ b/frontend/src/pages/ConnectAi.test.js
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+import ConnectAi from './ConnectAi';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // The page passes English fallbacks inline — return those so assertions
+    // read like the real UI.
+    t: (key, fallback) => (typeof fallback === 'string' ? fallback : key),
+  }),
+}));
+
+const HOSTED = 'https://cellarion.app';
+
+// jsdom's window.location is not writable, so swap in a URL object — it exposes
+// `.origin`, which is the only part of location this page reads.
+const setOrigin = (origin) => {
+  Object.defineProperty(window, 'location', {
+    value: new URL(origin),
+    writable: true,
+    configurable: true,
+  });
+};
+
+const renderPage = () =>
+  render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <ConnectAi />
+      </MemoryRouter>
+    </HelmetProvider>,
+  );
+
+const snippets = (container) =>
+  [...container.querySelectorAll('.connect-ai-snippet')].map((el) => el.textContent);
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    value: originalLocation,
+    writable: true,
+    configurable: true,
+  });
+  delete window.navigator.clipboard;
+  vi.restoreAllMocks();
+});
+
+describe('ConnectAi', () => {
+  test('renders the page and is honest that the connector is in beta', () => {
+    setOrigin(HOSTED);
+    renderPage();
+    expect(
+      screen.getByRole('heading', { name: /Connect your AI to your wine cellar/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/in beta/i)).toBeInTheDocument();
+    expect(screen.getByText(/can be undone/i)).toBeInTheDocument();
+  });
+
+  test('on the hosted origin, shows a prefilled claude.ai connector link pointing at /api/mcp', () => {
+    setOrigin(HOSTED);
+    renderPage();
+    const link = screen.getByRole('link', { name: /Add Cellarion to Claude/ });
+    const url = new URL(link.getAttribute('href'));
+    expect(url.origin).toBe('https://claude.ai');
+    expect(url.pathname).toBe('/customize/connectors');
+    expect(url.searchParams.get('modal')).toBe('add-custom-connector');
+    expect(url.searchParams.get('connectorName')).toBe('Cellarion');
+    // The connector URL must be the personal endpoint, not the public one.
+    expect(url.searchParams.get('connectorUrl')).toBe('https://cellarion.app/api/mcp');
+  });
+
+  test('self-hosted installs get their own URLs and NO claude.ai one-click link', () => {
+    setOrigin('https://wine.example.org');
+    const { container } = renderPage();
+
+    // A claude.ai deep link would point at a server claude.ai cannot reach.
+    expect(screen.queryByRole('link', { name: /Add Cellarion to Claude/ })).toBeNull();
+
+    const texts = snippets(container).join('\n');
+    expect(texts).toContain('https://wine.example.org/api/mcp');
+    expect(texts).not.toContain('https://cellarion.app');
+    // The stdio bridge needs CELLARION_URL only when self-hosted.
+    expect(texts).toContain('"CELLARION_URL": "https://wine.example.org"');
+    expect(screen.getByText(/derived from FRONTEND_URL/i)).toBeInTheDocument();
+  });
+
+  test('hosted snippets omit CELLARION_URL and use the placeholder token', () => {
+    setOrigin(HOSTED);
+    const { container } = renderPage();
+    const texts = snippets(container).join('\n');
+    expect(texts).toContain('cel_YOUR_TOKEN_HERE');
+    expect(texts).not.toContain('CELLARION_URL');
+  });
+
+  test('documents both endpoints, and the public one as the no-account option', () => {
+    setOrigin(HOSTED);
+    const { container } = renderPage();
+    const texts = snippets(container).join('\n');
+    expect(texts).toContain('https://cellarion.app/api/mcp/public');
+    expect(screen.getByRole('heading', { name: /no account needed/i })).toBeInTheDocument();
+    expect(screen.getByText(/holds no personal data/i)).toBeInTheDocument();
+  });
+
+  test('copy button writes the snippet to the clipboard and confirms', async () => {
+    setOrigin(HOSTED);
+    const { container } = renderPage();
+    const firstBlock = container.querySelector('.connect-ai-snippet-block');
+    const button = firstBlock.querySelector('.connect-ai-copy');
+    const text = firstBlock.querySelector('.connect-ai-snippet').textContent;
+
+    fireEvent.click(button);
+
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(text);
+    await waitFor(() => expect(button).toHaveTextContent('Copied'));
+  });
+});

--- a/frontend/src/pages/Help.css
+++ b/frontend/src/pages/Help.css
@@ -146,6 +146,18 @@
 
 /* ─── No results ─── */
 
+.help-connect-ai {
+  margin-top: 2rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--color-border-light);
+  text-align: center;
+}
+
+.help-connect-ai a {
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
 .help-no-results {
   text-align: center;
   padding: 2rem;

--- a/frontend/src/pages/Help.js
+++ b/frontend/src/pages/Help.js
@@ -154,6 +154,10 @@ function Help() {
             );
           })}
         </div>
+
+        <p className="help-connect-ai">
+          <a href="/connect-ai">{t('help.connectAiLink')} &rarr;</a>
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -280,6 +280,7 @@ export default function LandingPage() {
             <img src={theme === 'dark' ? LOGO_DARK : LOGO_LIGHT} alt="" className="landing-footer-logo-img" /> Cellarion
           </span>
           <div className="landing-footer-links">
+            <Link to="/connect-ai">{t('landing.footerConnectAi')}</Link>
             <Link to="/privacy">Privacy</Link>
             {contactEmail && (
               <a href={`mailto:${contactEmail}`}>{contactEmail}</a>

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -391,6 +391,22 @@
   user-select: all;
   margin: 0;
 }
+.ai-connect-oneclick {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  background: var(--color-info-bg);
+  border: 1px solid var(--color-info-border);
+  border-radius: var(--radius-md);
+}
+.ai-connect-oneclick .settings-hint {
+  margin: 0;
+  flex: 1;
+  min-width: 14rem;
+}
 .ai-connect-footnote {
   margin-top: 1rem;
 }

--- a/frontend/src/utils/mcpConnect.js
+++ b/frontend/src/utils/mcpConnect.js
@@ -1,0 +1,30 @@
+/**
+ * Shared contract for pointing an AI client at this Cellarion install.
+ *
+ * Both the Settings card (AiConnectSection) and the public /connect-ai docs
+ * page build claude.ai deep links, so the URL shape lives here — if Anthropic
+ * renames a query parameter there must be exactly one place to fix it.
+ */
+
+/** The hosted app. Any other origin is a self-hosted install. */
+export const HOSTED_ORIGIN = 'https://cellarion.app';
+
+export const isHostedOrigin = (origin) => origin === HOSTED_ORIGIN;
+
+/**
+ * claude.ai "add custom connector" deep link, prefilled with this install's MCP
+ * endpoint. `connectorUrl` is percent-encoded exactly once, which is what the
+ * documented format expects — URLSearchParams does that for us.
+ *
+ * Hosted-only by design: claude.ai reaches the connector URL from its own
+ * servers, so handing it a self-hosted origin (frequently a LAN or localhost
+ * address) would produce a connector that can never connect.
+ */
+export function claudeOneClickUrl(origin) {
+  const params = new URLSearchParams({
+    modal: 'add-custom-connector',
+    connectorName: 'Cellarion',
+    connectorUrl: `${origin}/api/mcp`,
+  });
+  return `https://claude.ai/customize/connectors?${params.toString()}`;
+}

--- a/mcp-registry/README.md
+++ b/mcp-registry/README.md
@@ -1,0 +1,141 @@
+# MCP Registry entries
+
+Cellarion publishes **two** servers to the official MCP registry
+(`registry.modelcontextprotocol.io`), because they are two different products:
+
+| Entry | Name | Endpoint | Who it is for |
+|---|---|---|---|
+| [`cellarion/`](cellarion/server.json) | `app.cellarion/cellarion` | `POST /api/mcp` | Account holders. OAuth 2.1, ~57 tools, read/consume/write scopes. |
+| [`wine-registry/`](wine-registry/server.json) | `app.cellarion/wine-registry` | `POST /api/mcp/public` | Anyone. No auth, 7 read-only tools over the shared wine registry and guides. |
+
+They are deliberately **not** two `remotes` on one entry: a client that picked a
+remote at random would land on 7 tools instead of 57 and conclude the server was
+broken.
+
+The registry is not consumed directly by most host apps — its value is that the
+directories and aggregators poll it, so publishing here beats submitting to each
+one by hand.
+
+---
+
+## Prerequisites (one-time)
+
+### 1. Namespace ownership — DNS, not HTTP
+
+The `app.cellarion/*` namespace is claimed by proving control of
+`cellarion.app`. **Use DNS verification.** HTTP verification would fetch
+`https://cellarion.app/.well-known/mcp-registry-auth`, which today returns the
+SPA HTML shell with a `200` (verified 2026-07-18) — a status-only check would
+"succeed" while content parsing fails, which produces confusing errors. DNS also
+grants subdomain namespaces; HTTP does not.
+
+Generate the keypair (keep the private key safe — it is the long-lived
+credential for the whole namespace, so store it in the password manager, not the
+repo):
+
+```bash
+openssl genpkey -algorithm Ed25519 -out mcp-registry-key.pem
+PUBLIC_KEY="$(openssl pkey -in mcp-registry-key.pem -pubout -outform DER | tail -c 32 | base64)"
+echo "cellarion.app. IN TXT \"v=MCPv1; k=ed25519; p=${PUBLIC_KEY}\""
+```
+
+Add that TXT record at the **apex** (`cellarion.app`), *not* under a selector —
+`_mcp-auth` / `_mcp-registry` are common enough mistakes that the registry keeps
+a list of them purely to emit a better error message.
+
+The apex currently holds two TXT records (an SPF record and a
+`google-site-verification`); adding a third is safe and does not disturb them.
+
+### 2. `mcp-publisher`
+
+```powershell
+$arch = if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq "Arm64") { "arm64" } else { "amd64" }
+Invoke-WebRequest -Uri "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_windows_$arch.tar.gz" -OutFile "mcp-publisher.tar.gz"
+tar xf mcp-publisher.tar.gz mcp-publisher.exe
+```
+
+---
+
+## Publishing
+
+Log in once per session. The seed is the last 32 bytes of the DER private key —
+extracting it that way is exact, unlike scraping `openssl pkey -text` output,
+which depends on the key happening to print across three lines and fails
+silently (a truncated key, then an opaque login error) if that ever changes:
+
+```bash
+PRIVATE_KEY="$(openssl pkey -in mcp-registry-key.pem -outform DER | tail -c 32 | xxd -p -c 64)"
+[ ${#PRIVATE_KEY} -eq 64 ] || { echo "seed is ${#PRIVATE_KEY} hex chars, expected 64 — aborting"; exit 1; }
+mcp-publisher login dns --domain cellarion.app --private-key "${PRIVATE_KEY}"
+```
+
+Then publish from **inside each entry's directory** (`mcp-publisher` reads
+`server.json` from the working directory):
+
+```bash
+cd mcp-registry/wine-registry && mcp-publisher validate && mcp-publisher publish
+cd ../cellarion        && mcp-publisher validate && mcp-publisher publish
+```
+
+Verify:
+
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=app.cellarion"
+```
+
+### Order matters for the `cellarion` entry
+
+`cellarion/server.json` declares an npm package, and the registry's **only**
+proof of npm ownership is that `package.json` carries an `mcpName` field
+matching `server.json`'s `name`. So:
+
+1. Publish `cellarion-mcp@0.1.1` to npm **first** (it now has
+   `"mcpName": "app.cellarion/cellarion"`). This must be run in an
+   **interactive terminal** — the npm account's 2FA is a passkey, so a non-TTY
+   `npm publish` fails with `EOTP`.
+2. Then publish `cellarion/server.json`.
+
+Publishing it before the npm release fails with
+`NPM package 'cellarion-mcp' is missing required 'mcpName' field`.
+
+`wine-registry/server.json` has no package block and no such dependency — it can
+be published immediately.
+
+---
+
+## Maintenance
+
+- **Versions are immutable.** A published version cannot be edited; publish a new
+  one. A listing can be withdrawn with `mcp-publisher status --status deleted`,
+  but metadata is never permanently erased — so pick the name deliberately.
+- **`version` tracks the app version.** Bump both `server.json` files on releases
+  that change the tool surface, and re-publish.
+- Both files validate against the pinned `2025-12-11` schema. Re-validate after
+  any edit: `mcp-publisher validate`.
+- `description` is capped at **100 characters** by the schema. The npm
+  `description` field is longer and separate — do not copy one into the other.
+
+## Before you publish
+
+A registry listing is a discovery multiplier aimed straight at the rate limiters.
+See `MCP_DISTRIBUTION_PLAN_2026-07-18.md` §4.2, §4.3 and §7 — in particular
+`TRUST_PROXY_HOPS=2` must be set in the prod environment first, or every per-IP
+bucket collapses into a single shared one.
+
+## After deploying the /connect-ai page
+
+IndexNow submission is wired to *content* routes only (blog posts, wines,
+discussions) — static routes have no trigger, so the new page is not pushed to
+Bing/Yandex automatically. Fire it once by hand after the deploy, the same way
+blog posts are pinged:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" "https://api.indexnow.org/indexnow?url=https://cellarion.app/connect-ai&key=<INDEXNOW_KEY>"
+```
+
+Then confirm the crawler render is live (it should return the endpoints as
+literal text, not the SPA shell):
+
+```bash
+curl -s -A "ClaudeBot/1.0" https://cellarion.app/connect-ai | grep -c "api/mcp"
+```

--- a/mcp-registry/cellarion/server.json
+++ b/mcp-registry/cellarion/server.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "app.cellarion/cellarion",
+  "title": "Cellarion",
+  "description": "Wine cellar manager: bottles, racks, drink windows, pairings and a shared wine registry.",
+  "version": "1.82.4",
+  "websiteUrl": "https://cellarion.app",
+  "repository": {
+    "url": "https://github.com/jagduvi1/Cellarion",
+    "source": "github",
+    "id": "1166341984",
+    "subfolder": "cellarion-mcp"
+  },
+  "icons": [
+    {
+      "src": "https://cellarion.app/logo512.png",
+      "mimeType": "image/png",
+      "sizes": ["512x512"]
+    },
+    {
+      "src": "https://cellarion.app/logo192.png",
+      "mimeType": "image/png",
+      "sizes": ["192x192"]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://cellarion.app/api/mcp"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "cellarion-mcp",
+      "version": "0.1.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "CELLARION_TOKEN",
+          "description": "Personal API token from Settings -> API tokens (starts with cel_).",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "CELLARION_URL",
+          "description": "Base URL of your Cellarion server. Leave unset for the hosted app.",
+          "isRequired": false,
+          "default": "https://cellarion.app",
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/mcp-registry/wine-registry/server.json
+++ b/mcp-registry/wine-registry/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "app.cellarion/wine-registry",
+  "title": "Cellarion Wine Registry",
+  "description": "Public wine registry and guides: search wines, grapes, regions, appellations. No account.",
+  "version": "1.82.4",
+  "websiteUrl": "https://cellarion.app",
+  "repository": {
+    "url": "https://github.com/jagduvi1/Cellarion",
+    "source": "github",
+    "id": "1166341984"
+  },
+  "icons": [
+    {
+      "src": "https://cellarion.app/logo512.png",
+      "mimeType": "image/png",
+      "sizes": ["512x512"]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://cellarion.app/api/mcp/public"
+    }
+  ]
+}


### PR DESCRIPTION
Distribution groundwork for the MCP server. **Nothing here changes the protocol surface** — it makes the two endpoints we already serve findable. Prod conformance was verified live first: the OAuth discovery chain resolves at every hop and the public endpoint negotiates `2025-06-18` and serves its 7 tools.

## Two entries, not one

The endpoints are two different products, so they are listed separately:

| Entry | Endpoint | Audience |
|---|---|---|
| `app.cellarion/cellarion` | `/api/mcp` | Account holders — OAuth 2.1, ~57 tools |
| `app.cellarion/wine-registry` | `/api/mcp/public` | Anyone — no auth, 7 read-only tools |

Merging them into one entry would let a client pick the public remote at random and land on 7 tools instead of 57, which reads as a broken server.

## What is in here

- **`mcp-registry/`** — both `server.json` files (validated against the pinned `2025-12-11` schema with ajv) plus a publish runbook. Uses **DNS** domain verification, because `/.well-known/mcp-registry-auth` currently returns the SPA HTML shell with a `200` — a status-only check would "succeed" while content parsing fails. DNS also grants subdomain namespaces.
- **`cellarion-mcp`** — adds `mcpName` (the registry's only proof of npm ownership) and bumps to `0.1.1`.
- **Public `/connect-ai` page** — per-client set-up for Claude, Claude Code, ChatGPT, VS Code, Cursor/Windsurf, Gemini CLI and stdio clients, plus the scope model and the anonymous endpoint. Every snippet derives from `window.location.origin`, so self-hosters get their own URLs.
- **Prefilled claude.ai connector link** in Settings — hosted-origin only, since claude.ai fetches the connector URL from its own servers and a LAN origin would produce a connector that can never connect. Shared with the docs page via `utils/mcpConnect.js`.
- **SEO/AEO** — sitemap, robots (both crawler groups), llms.txt, and a crawler-rendered `/api/og/connect-ai` that prints the endpoints as literal text. AI crawlers are precisely the audience that needs to learn this instance has an MCP server.
- **Inbound links** from the landing footer and help centre, without which the page would be an orphan reachable only by crawlers.

## Verification

- Frontend **37 files / 690 tests**, backend **139 suites / 2088 tests** — both green.
- `nginx -t` passes on the full config.
- Docker smoke test: crawlers get the server-rendered page with every endpoint, real users get the SPA, and `/connect-ai/authorize` (OAuth consent) still resolves — the new `location` is an exact match and cannot shadow it.
- New **locale integrity suite**: en/sv parity was previously untested, because component tests mock i18next and never read the locale files.

## Compose / infra impact

**None.** `nginx.conf` ships inside the frontend image, so the new `location` rides a normal frontend rebuild. No prod compose change, no Traefik change.

## Follow-ups (not in this PR)

- ⚠️ **Swedish strings are machine-authored** and need review before release.
- Publishing to the registry needs three manual steps only the owner can do: apex DNS TXT record, `npm publish` of `0.1.1` (passkey 2FA needs a TTY), then `mcp-publisher publish`. Order matters — the npm release must land first. Runbook in `mcp-registry/README.md`.
- **Before the listings drive traffic:** `/api/mcp/oauth/*` is not exempt from the global limiters (`app.js:194`) and DCR is capped at 10/hour/IP (`mcpOAuth.js:19`, already observed at 6/10 during launch). Those plus `TRUST_PROXY_HOPS=2` should land first.
- IndexNow has no trigger for static routes — ping `/connect-ai` by hand after deploy (command in the runbook).