### PR TITLE
release: v1.83.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.82.4",
+  "version": "1.83.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.82.4",
+      "version": "1.83.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.82.4",
+  "version": "1.83.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.82.4",
+  "version": "1.83.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.82.4",
+      "version": "1.83.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.82.4",
+  "version": "1.83.0",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump only — all four files (both `package.json` + both `package-lock.json`).

## What ships in v1.83.0

- **#782** — public `/connect-ai` page with per-client MCP set-up, official MCP registry entries (`app.cellarion/cellarion` + `app.cellarion/wine-registry`), `mcpName` on the npm bridge, and SEO/AEO registration (sitemap, robots, llms.txt, crawler-rendered page).
- **#783** — demo snapshot remapped onto wines that exist in the prod registry.
- **#781** — producer-in-name detection now covers SUFFIX placements, not just prefixes.

Verified on the merged union: frontend **37 files / 690 tests**, backend **139 suites / 2088 tests**, both green.

## Deploy notes

- **Compose impact: none.** `nginx.conf` ships inside the frontend image, so the new `/connect-ai` location rides the normal frontend rebuild. No prod compose or Traefik change.
- `TRUST_PROXY_HOPS=2` and the rack-duplicate script were already handled during the v1.82.0 deploy — nothing outstanding there.
- After deploy: ping IndexNow for `/connect-ai` by hand (static routes have no automatic trigger) — command in `mcp-registry/README.md`.
- ⚠️ Swedish strings in the new page are machine-authored and still pending review.