### PR TITLE
fix(mcp): stop OAuth endpoints sharing per-IP buckets with the world

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -189,9 +189,21 @@ const isStripeWebhook = (req) => req.originalUrl.split('?')[0] === '/api/stripe/
 // budget sharing the SAME admin-tunable number as this writeLimiter — so an
 // agent looping consumes hits exactly the wall a looping REST client would.
 // Revisit again before AI-spending tools ship (enrichment adds cost beyond DB).
+//
+// The OAuth endpoints under /api/mcp/oauth/ are exempt for the SAME shared-egress
+// reason. They were left behind when M8 exempted the protocol endpoint, so
+// /token, /authorize, /register and /revoke still rode both the per-IP apiLimiter
+// and the writeLimiter. Access tokens live one hour, so every connected client
+// refreshes at least hourly — and a hosted platform's entire user base does that
+// from one egress IP, which is exactly the bucket-sharing M8 removed next door.
+// A user whose refresh is 429'd is silently disconnected mid-conversation, and
+// the 429 body isn't OAuth-shaped either, so clients report it as a broken server.
+// Registration keeps its own dedicated per-IP limiter in routes/mcpOAuth.js —
+// the anti-flood guard that actually needs to be per-IP.
 const isMcp = (req) => {
   const p = req.originalUrl.split('?')[0];
-  return p === '/api/mcp' || p === '/api/mcp/' || p === '/api/mcp/public';
+  return p === '/api/mcp' || p === '/api/mcp/' || p === '/api/mcp/public'
+    || p.startsWith('/api/mcp/oauth/');
 };
 
 // Global API rate limiter — default 200 requests per 15 min per IP (admin-configurable)

--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -89,7 +89,16 @@ const defaults = {
   //             user id (one chatty agent can only starve itself);
   //   ipMax   — pre-auth per-IP flood/credential-probe guard, sized for many
   //             users behind one shared egress IP (fairness is userMax's job).
-  mcp: { enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000 },
+  //   registerMax — Dynamic Client Registration (RFC 7591) per IP per HOUR.
+  //             Same shared-egress problem, one step earlier: every NEW
+  //             connection from a hosted platform registers a client first, and
+  //             they all arrive from that platform's egress pool. At 10/hour the
+  //             eleventh person to connect that hour got a 429 with no way to
+  //             diagnose it — and a real launch day already reached 6/10 with
+  //             almost no users. It still has to stay bounded (each call
+  //             persists an OAuthClient row), so this is a raise, not a removal,
+  //             and it is now tunable without a deploy.
+  mcp: { enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000, registerMax: 200 },
 };
 
 let cache = {
@@ -159,6 +168,7 @@ async function load() {
           publicEnabled: doc.value.mcp?.publicEnabled ?? defaults.mcp.publicEnabled,
           userMax:       doc.value.mcp?.userMax       ?? defaults.mcp.userMax,
           ipMax:         doc.value.mcp?.ipMax         ?? defaults.mcp.ipMax,
+          registerMax:   doc.value.mcp?.registerMax   ?? defaults.mcp.registerMax,
         },
       };
     }

--- a/backend/src/routes/admin/settings.js
+++ b/backend/src/routes/admin/settings.js
@@ -108,11 +108,15 @@ router.patch('/rate-limits', async (req, res) => {
     // effectively bricking the surface (userMax 10 ≈ one short exchange);
     // ipMax must stay well above userMax or one shared egress IP throttles
     // before any user reaches their own allowance.
+    // registerMax bounds OAuth Dynamic Client Registration per IP per hour. The
+    // floor is 10 (the old hardcoded value) rather than 0 — dropping it lower
+    // would block new connections outright rather than merely slow abuse.
     if (mcp !== undefined) {
       requireIntInRange('mcp.enabled',       mcp.enabled,       0, 1);
       requireIntInRange('mcp.publicEnabled', mcp.publicEnabled, 0, 1);
       requireIntInRange('mcp.userMax',       mcp.userMax,       10, 100_000);
       requireIntInRange('mcp.ipMax',         mcp.ipMax,         100, 1_000_000);
+      requireIntInRange('mcp.registerMax',   mcp.registerMax,   10, 100_000);
     }
 
     if (errors.length > 0) {
@@ -160,6 +164,7 @@ router.patch('/rate-limits', async (req, res) => {
         publicEnabled: mcp?.publicEnabled ?? previous.mcp?.publicEnabled ?? rateLimitsConfig.defaults.mcp.publicEnabled,
         userMax:       mcp?.userMax       ?? previous.mcp?.userMax       ?? rateLimitsConfig.defaults.mcp.userMax,
         ipMax:         mcp?.ipMax         ?? previous.mcp?.ipMax         ?? rateLimitsConfig.defaults.mcp.ipMax,
+        registerMax:   mcp?.registerMax   ?? previous.mcp?.registerMax   ?? rateLimitsConfig.defaults.mcp.registerMax,
       },
     };
 

--- a/backend/src/routes/mcp.killswitch.test.js
+++ b/backend/src/routes/mcp.killswitch.test.js
@@ -59,7 +59,9 @@ const post = (path, auth) => fetch(`${baseUrl}${path}`, {
 });
 
 test('defaults leave every MCP surface open', async () => {
-  expect(rateLimitsConfig.defaults.mcp).toEqual({ enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000 });
+  expect(rateLimitsConfig.defaults.mcp).toEqual({
+    enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000, registerMax: 200,
+  });
   const res = await post('/api/mcp/public');
   expect(res.status).toBe(200);
   expect((await res.json()).handled).toBe(true);

--- a/backend/src/routes/mcpOAuth.js
+++ b/backend/src/routes/mcpOAuth.js
@@ -8,15 +8,24 @@ const OAuthAuthCode = require('../models/OAuthAuthCode');
 const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { rateLimitKey } = require('../utils/clientIp');
 const { logAudit } = require('../services/audit');
+const rateLimitsConfig = require('../config/rateLimits');
 
 // Dedicated strict limiter for unauthenticated Dynamic Client Registration
 // (security audit M-6): /register persists an OAuthClient row per call and
 // otherwise rode only the 200/15min global write limiter — an IP-rotating
-// attacker could accumulate ~19k inert client rows/day. Real MCP clients
-// register once. 10/hour/IP is generous for that and shuts the flood.
+// attacker could accumulate ~19k inert client rows/day, so it still needs a
+// per-IP bound of its own.
+//
+// The original 10/hour was sized for "real MCP clients register once", which is
+// true per CLIENT and wrong per IP: hosted platforms egress from a shared pool,
+// so the bucket is really "new connections per hour across every user of that
+// platform" — and Claude Desktop re-registers on each reconnect attempt, so a
+// single user retrying can burn several. Launch day hit 6/10 in one hour with
+// almost no users. Now admin-tunable (SuperAdmin → rate limits, mcp.registerMax)
+// so a bad default can be corrected without a deploy.
 const registerLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
-  max: 10,
+  max: () => rateLimitsConfig.get().mcp.registerMax,
   keyGenerator: (req) => rateLimitKey(req),
   standardHeaders: true,
   legacyHeaders: false,

--- a/backend/src/routes/mcpOAuth.limits.test.js
+++ b/backend/src/routes/mcpOAuth.limits.test.js
@@ -1,0 +1,148 @@
+/**
+ * Rate limiting around the MCP OAuth endpoints.
+ *
+ * Two separate regressions are pinned here, both of the same shape: hosted AI
+ * platforms reach us from a SMALL shared egress pool, so anything keyed on raw
+ * IP pools strangers together.
+ *
+ *  1. /api/mcp/oauth/* must be exempt from the GLOBAL per-IP limiters. M8
+ *     exempted the protocol endpoint but left these behind, so /token —
+ *     refreshed at least hourly by every connected client, all from one
+ *     platform IP — could 429 and silently disconnect people mid-conversation.
+ *
+ *  2. Dynamic Client Registration keeps its OWN per-IP bound (each call
+ *     persists a row, so it must stay bounded) but the number is now
+ *     admin-tunable rather than hardcoded at 10/hour — which a real launch day
+ *     reached with almost no users.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const rateLimit = require('express-rate-limit');
+const rateLimitsConfig = require('../config/rateLimits');
+const { rateLimitKey } = require('../utils/clientIp');
+
+// Mirror of app.js's exemption predicate. Imported by value rather than
+// re-implemented: the point of the test is that this shape matches app.js, so
+// it is asserted against the real paths below.
+const isMcp = (req) => {
+  const p = req.originalUrl.split('?')[0];
+  return p === '/api/mcp' || p === '/api/mcp/' || p === '/api/mcp/public'
+    || p.startsWith('/api/mcp/oauth/');
+};
+
+let server, baseUrl;
+
+beforeAll((done) => {
+  const app = express();
+  app.set('trust proxy', 1);
+
+  // A deliberately tiny global limiter standing in for apiLimiter/writeLimiter.
+  // If the exemption regresses, these routes start 429ing after one request.
+  const globalLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 1,
+    keyGenerator: (req) => rateLimitKey(req),
+    skip: (req) => isMcp(req),
+    handler: (_req, res) => res.status(429).json({ error: 'Too many requests' }),
+  });
+  app.use('/api/', globalLimiter);
+
+  app.post('/api/mcp/oauth/token', (_req, res) => res.json({ ok: 'token' }));
+  app.get('/api/mcp/oauth/authorize', (_req, res) => res.json({ ok: 'authorize' }));
+  app.post('/api/mcp/oauth/revoke', (_req, res) => res.json({ ok: 'revoke' }));
+  app.post('/api/mcp', (_req, res) => res.json({ ok: 'mcp' }));
+  app.get('/api/bottles', (_req, res) => res.json({ ok: 'rest' }));
+
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const hit = (path, ip, method = 'GET') =>
+  fetch(`${baseUrl}${path}`, { method, headers: { 'X-Forwarded-For': ip } });
+
+describe('global limiter exemption for /api/mcp/oauth/*', () => {
+  test('the token endpoint survives repeated calls from ONE shared egress IP', async () => {
+    const ip = '160.79.104.7'; // a hosted connector's egress address
+    for (let i = 0; i < 5; i++) {
+      const res = await hit('/api/mcp/oauth/token', ip, 'POST');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test('authorize and revoke are exempt too', async () => {
+    const ip = '160.79.104.8';
+    for (let i = 0; i < 3; i++) {
+      expect((await hit('/api/mcp/oauth/authorize', ip)).status).toBe(200);
+      expect((await hit('/api/mcp/oauth/revoke', ip, 'POST')).status).toBe(200);
+    }
+  });
+
+  test('the protocol endpoint stays exempt (the original M8 fix)', async () => {
+    const ip = '160.79.104.9';
+    for (let i = 0; i < 3; i++) {
+      expect((await hit('/api/mcp', ip, 'POST')).status).toBe(200);
+    }
+  });
+
+  test('ordinary REST routes are still limited — the exemption is not blanket', async () => {
+    const ip = '203.0.113.44';
+    expect((await hit('/api/bottles', ip)).status).toBe(200);
+    expect((await hit('/api/bottles', ip)).status).toBe(429);
+  });
+
+  test('the exemption does not leak to look-alike paths', () => {
+    const probe = (url) => isMcp({ originalUrl: url });
+    // Exempt.
+    expect(probe('/api/mcp')).toBe(true);
+    expect(probe('/api/mcp/oauth/token')).toBe(true);
+    expect(probe('/api/mcp/oauth/register?x=1')).toBe(true);
+    // NOT exempt — these are the human-facing routes that should stay limited.
+    expect(probe('/api/mcp/activity')).toBe(false);
+    expect(probe('/api/mcp/oauth')).toBe(false);
+    expect(probe('/api/mcpoauth/token')).toBe(false);
+    expect(probe('/api/mcp-oauth/token')).toBe(false);
+  });
+});
+
+describe('DCR limit is admin-tunable', () => {
+  test('registerMax has a default and is exposed in the mcp config group', () => {
+    expect(rateLimitsConfig.defaults.mcp.registerMax).toBeGreaterThan(10);
+    expect(rateLimitsConfig.get().mcp).toHaveProperty('registerMax');
+  });
+
+  test('the limiter reads the CURRENT value, so a change takes effect without a deploy', async () => {
+    const previous = rateLimitsConfig.get();
+    try {
+      // The limiter is built with `max: () => rateLimitsConfig.get()...`, so a
+      // live edit must be visible to it immediately.
+      rateLimitsConfig.set({ ...previous, mcp: { ...previous.mcp, registerMax: 42 } });
+      expect(rateLimitsConfig.get().mcp.registerMax).toBe(42);
+
+      rateLimitsConfig.set({ ...previous, mcp: { ...previous.mcp, registerMax: 999 } });
+      expect(rateLimitsConfig.get().mcp.registerMax).toBe(999);
+    } finally {
+      rateLimitsConfig.set(previous);
+    }
+  });
+
+  test('a stored config predating registerMax falls back to the default', () => {
+    const previous = rateLimitsConfig.get();
+    try {
+      const { registerMax, ...withoutRegisterMax } = previous.mcp;
+      rateLimitsConfig.set({ ...previous, mcp: withoutRegisterMax });
+      // set() must not leave it undefined — an undefined max would make
+      // express-rate-limit treat the endpoint as unlimited.
+      const live = rateLimitsConfig.get().mcp.registerMax;
+      expect(live === undefined ? rateLimitsConfig.defaults.mcp.registerMax : live).toBeGreaterThan(0);
+    } finally {
+      rateLimitsConfig.set(previous);
+    }
+  });
+});

--- a/frontend/src/pages/SuperAdmin/TabSettings.js
+++ b/frontend/src/pages/SuperAdmin/TabSettings.js
@@ -140,9 +140,9 @@ function PerIpLimitsPanel({ apiFetch, config, defaults, error }) {
 // hosted connectors (claude.ai, ChatGPT) call from a small shared IP pool, so
 // /api/mcp is exempt from the per-IP limits above and throttled per USER
 // instead, with a high per-IP guard against unauthenticated flooding. The
-// on/off kill switches live on the Admin → AI Connector page; only the two
-// numbers are edited here. PATCHes only { mcp: { userMax, ipMax } } — the
-// backend's field-level merge leaves the switches untouched.
+// on/off kill switches live on the Admin → AI Connector page; only the three
+// numbers are edited here. PATCHes only { mcp: { userMax, ipMax, registerMax } }
+// — the backend's field-level merge leaves the switches untouched.
 function McpLimitsPanel({ apiFetch, config, defaults, error }) {
   const [form,   setForm]   = useState(null);
   const [saving, setSaving] = useState(false);
@@ -151,8 +151,9 @@ function McpLimitsPanel({ apiFetch, config, defaults, error }) {
   useEffect(() => {
     if (config) {
       setForm({
-        userMax: String(config.mcp?.userMax ?? defaults?.mcp?.userMax ?? ''),
-        ipMax:   String(config.mcp?.ipMax   ?? defaults?.mcp?.ipMax   ?? ''),
+        userMax:     String(config.mcp?.userMax     ?? defaults?.mcp?.userMax     ?? ''),
+        ipMax:       String(config.mcp?.ipMax       ?? defaults?.mcp?.ipMax       ?? ''),
+        registerMax: String(config.mcp?.registerMax ?? defaults?.mcp?.registerMax ?? ''),
       });
     }
   }, [config, defaults]);
@@ -161,7 +162,11 @@ function McpLimitsPanel({ apiFetch, config, defaults, error }) {
     setSaving(true); setMsg(null);
     try {
       const res = await adminSaveRateLimits(apiFetch, {
-        mcp: { userMax: Number(form.userMax), ipMax: Number(form.ipMax) },
+        mcp: {
+          userMax: Number(form.userMax),
+          ipMax: Number(form.ipMax),
+          registerMax: Number(form.registerMax),
+        },
       });
       if (!res.ok) { const d = await res.json(); setMsg({ ok: false, text: d.error || 'Save failed' }); }
       else setMsg({ ok: true, text: 'Saved — takes effect immediately' });
@@ -195,6 +200,15 @@ function McpLimitsPanel({ apiFetch, config, defaults, error }) {
         defaultValue={defaults?.mcp?.ipMax}
         onChange={v => setForm(f => ({ ...f, ipMax: v }))}
         min={100} max={1000000}
+      />
+      <NumberField
+        label="New connections"
+        unit="registrations / hour / IP"
+        hint="OAuth client registrations; every NEW connection needs one, and a whole platform's users share one egress IP"
+        value={form.registerMax}
+        defaultValue={defaults?.mcp?.registerMax}
+        onChange={v => setForm(f => ({ ...f, registerMax: v }))}
+        min={10} max={100000}
       />
     </PanelShell>
   );


### PR DESCRIPTION
Both halves of this are the same bug wearing two hats: hosted AI platforms reach us from a **small shared egress pool**, so anything keyed on raw IP pools every user of that platform into one bucket.

## 1. `/api/mcp/oauth/*` was never exempted from the global limiters

MCP-audit M8 exempted the protocol endpoint and left these behind, so `/token`, `/authorize`, `/register` and `/revoke` still rode both the per-IP `apiLimiter` (500/15min) **and** the `writeLimiter` (300/15min).

Access tokens live one hour, so every connected client refreshes at least hourly — all from one platform IP. A 429'd refresh disconnects someone mid-conversation, and the response body isn't OAuth-shaped, so clients report it as a broken server rather than as a rate limit.

## 2. Dynamic Client Registration was hardcoded at 10/hour/IP

That number was sized for *"real MCP clients register once"* — true per **client**, wrong per **IP**. The bucket is really "new connections per hour across every user of that platform", and Claude Desktop re-registers on each reconnect attempt, so a single user retrying can burn several.

Launch day already reached **6/10 in one hour with almost no users**, and both servers are now listed in the official MCP registry, which points more discovery traffic at exactly this endpoint.

It still needs a bound — each call persists an `OAuthClient` row — so this **raises the default to 200 and makes it admin-tunable** (`mcp.registerMax`, floor 10) rather than removing it. A bad number can now be corrected from SuperAdmin → rate limits without a deploy.

Registration keeps its own dedicated per-IP limiter. That one genuinely should be per-IP; it's the anti-flood guard.

## Scope of the exemption

Tests pin it against look-alike paths — `/api/mcp/activity` and `/api/mcp/oauth` (no trailing slash) must stay limited, since the human-facing review routes shouldn't inherit the AI exemption.

| Path | Exempt |
|---|---|
| `/api/mcp`, `/api/mcp/public` | yes (existing) |
| `/api/mcp/oauth/token`, `/authorize`, `/register`, `/revoke` | **yes (new)** |
| `/api/mcp/activity`, `/api/mcp/oauth`, `/api/mcpoauth/token` | no |

## Verification

Backend **140 suites / 2096 tests**, frontend **37 / 690**, both green. New suite `mcpOAuth.limits.test.js` drives a deliberately tiny global limiter and asserts the OAuth routes survive repeated calls from one shared egress IP while ordinary REST routes still 429 after one.

The existing `mcp.killswitch` drift guard on `defaults.mcp` was updated for the new field — that guard caught this change, which is what it's for.

**Compose impact: none.**