### PR TITLE
release: v1.83.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.83.0",
+  "version": "1.83.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.83.0",
+      "version": "1.83.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.83.0",
+  "version": "1.83.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.83.0",
+  "version": "1.83.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.83.0",
+      "version": "1.83.1",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.83.0",
+  "version": "1.83.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Version bump only — all four files (both `package.json` + both `package-lock.json`).

## What ships in v1.83.1

- **#785** — the MCP OAuth endpoints (`/token`, `/authorize`, `/register`, `/revoke`) are now exempt from the global per-IP limiters, and Dynamic Client Registration is raised from a hardcoded 10/hour to an admin-tunable 200/hour (`mcp.registerMax`).

Both halves address the same failure: hosted AI platforms reach us from a small shared egress pool, so per-IP buckets pooled every user of that platform together. With both servers now listed in the official MCP registry, this is the endpoint new connections arrive through.

## Deploy notes

- **Compose impact: none.**
- No migration, no new env var, no reverse-proxy change.
- `mcp.registerMax` becomes editable at SuperAdmin → rate limits after deploy, so the new default can be corrected without another release.