### PR TITLE
fix(mcp): make somm_notes readable back through the somm tools

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -109,6 +109,25 @@ describe('list_maturity_queue', () => {
     expect(body.data[0].profile_id).toBe(oid('1'));
     expect(body.data[0].phases).toHaveProperty('peakFrom', null);
   });
+
+  // #787: the note was fetched but dropped in the row mapping — write-only data.
+  test('reviewed rows carry the curator note; absent note reads as null', async () => {
+    WineVintageProfile.countDocuments.mockResolvedValueOnce(2).mockResolvedValueOnce(0);
+    WineVintageProfile.find.mockReturnValue(chain([
+      {
+        _id: oid('1'), vintage: '2023', status: 'reviewed', relative: false,
+        sommNotes: 'Drink young — fruit fades fast.',
+        wineDefinition: { _id: oid('f'), name: 'Pinot Noir', producer: 'Matua', grapes: [] },
+      },
+      {
+        _id: oid('2'), vintage: '2019', status: 'reviewed', relative: false,
+        wineDefinition: { _id: oid('f'), name: 'Barolo', producer: 'P', grapes: [] },
+      },
+    ]));
+    const body = parse(await tool('list_maturity_queue').handler({ status: 'reviewed' }, SOMM_CTX));
+    expect(body.data[0].somm_notes).toBe('Drink young — fruit fades fast.');
+    expect(body.data[1].somm_notes).toBeNull();
+  });
 });
 
 describe('set_vintage_maturity', () => {
@@ -144,6 +163,25 @@ describe('set_vintage_maturity', () => {
     expect(parse(res).error).toBeUndefined();
     expect(p2.relative).toBe(true);
     expect(p2.status).toBe('reviewed');
+  });
+
+  // #787: the write landed but the response echoed phases only, so a curator
+  // had no way to confirm the note saved.
+  test('echoes the note it just saved, and the pre-existing note when none is sent', async () => {
+    const p = profile();
+    let body = parse(await tool('set_vintage_maturity').handler(
+      { profile_id: oid('1'), peak_from: 2026, somm_notes: 'Hold two more years.' }, SOMM_CTX));
+    expect(body.error).toBeUndefined();
+    expect(p.sommNotes).toBe('Hold two more years.');
+    expect(body.data.somm_notes).toBe('Hold two more years.');
+
+    profile({ sommNotes: 'Existing note.' });
+    body = parse(await tool('set_vintage_maturity').handler({ profile_id: oid('1'), peak_from: 2026 }, SOMM_CTX));
+    expect(body.data.somm_notes).toBe('Existing note.');
+
+    profile();
+    body = parse(await tool('set_vintage_maturity').handler({ profile_id: oid('1'), peak_from: 2026 }, SOMM_CTX));
+    expect(body.data.somm_notes).toBeNull();
   });
 
   test('prev snapshot captures phases + review state for undo; audit uses the REST action string', async () => {

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -78,6 +78,9 @@ registerTool({
       status: p.status,
       relative_nv: !!p.relative,
       phases: PHASE_FIELDS.reduce((acc, f) => ((acc[f] = p[f] ?? null), acc), {}),
+      // Somm-gated tool, so the curator's own note comes back with the row.
+      // Kept out of drink_window_for, which is public — see publicContent.js.
+      somm_notes: p.sommNotes || null,
     }));
     return ok(`${pending} pending in the maturity queue (showing ${data.length} of ${total} ${status})`, data, {
       page: { limit, offset, total },
@@ -176,6 +179,7 @@ registerTool({
         vintage: profile.vintage,
         relative_nv: isNv,
         phases: next,
+        somm_notes: profile.sommNotes || null,
         undo: 'undo_last restores the previous values and review state',
       },
     };


### PR DESCRIPTION
Closes #787.

## The bug

`sommNotes` was write-only over MCP:

- `set_vintage_maturity` persisted it (`somm.js:161`) but its response envelope echoed phases only.
- `list_maturity_queue` loaded the whole doc via `.lean()` and then **dropped** the field in the row mapping.

So a curator could write a note and had no way to read it back or even confirm it landed.

## The fix

Two mapping changes in `backend/src/mcp/tools/somm.js`. Both tools are already `requireRole: SOMM_ROLES` and both already had the data in memory — no new query, no new read path.

## What I deliberately did *not* change

The issue also asks for `somm_notes` in `drink_window_for`. I left that alone:

- it is `scope: 'public'` and anonymous-reachable
- the exclusion is documented in `publicContent.js:39-43` as a deliberate field boundary
- `routes/og.js:495-498` mirrors the same `.select(...)`
- `publicTools.test.js:120` pins it with `expect(JSON.stringify(body)).not.toMatch(/sommNotes/)`

Adding it there would quietly widen a public data boundary rather than fix an oversight. Curators who want the note over HTTP already get it from `GET /api/somm/maturity/lookup`, which returns the full profile doc. Happy to revisit as an auth-gated field if you want it in the public tool.

## Tests

Two regression tests added to `sommTools.test.js` covering the note round-trip, the pre-existing-note case, and the absent-note-reads-null case.

`sommTools` + `publicTools` + `revert`: **54 passed**. The public-boundary negative assertion still passes.