### PR TITLE
fix(ai): store enriched tasting descriptions as plain text

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -253,7 +253,7 @@ Rules:
 - body/tannin/acidity/sweetness: use one of the listed values, or null if not applicable (e.g. tannin for a white wine should usually be "low" or null).
 - flavors: concrete aromas/flavours (e.g. "dark cherry", "tobacco", "citrus zest"). Avoid vague words like "nice" or "complex".
 - foodPairings: real dishes/categories (e.g. "grilled lamb", "hard cheese", "roast chicken").
-- description: 2-3 sentences, warm but not pretentious. Light Markdown allowed (bold a key flavour at most). No headings, lists, or tables.
+- description: 2-3 sentences, warm but not pretentious. PLAIN TEXT ONLY — no Markdown of any kind: no **bold**, no *italics*, no headings, lists, links, or tables. The field is shown verbatim in places that do not render Markdown.
 - confidence: 1.0 = you know this exact wine well, 0.7 = confident from producer + style, 0.5 = grape/region knowledge only, 0.3 = rough inference.
 - Never invent awards, scores, or specific vintages' weather. If the wine is completely unrecognisable and its grapes/region are unknown, return {"error":"unknown"}.`;
 

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -96,7 +96,7 @@ const wineDefinitionSchema = new mongoose.Schema({
     sweetness:    { type: String, default: null, trim: true },  // dry | off-dry | sweet
     flavors:      { type: [String], default: [] },              // e.g. ['dark cherry', 'tar']
     foodPairings: { type: [String], default: [] },              // e.g. ['braised beef']
-    description:  { type: String, default: null, trim: true },  // short markdown prose for display
+    description:  { type: String, default: null, trim: true },  // short PLAIN-TEXT prose; markdown stripped at write (enrichmentJob)
     confidence:   { type: Number, default: null },             // 0..1 — how sure the AI is
     model:        { type: String, default: null, trim: true }, // model that produced it
     generatedAt:  { type: Date,   default: null },             // when it was generated

--- a/backend/src/scripts/strip-markdown-ai-descriptions.js
+++ b/backend/src/scripts/strip-markdown-ai-descriptions.js
@@ -1,0 +1,75 @@
+/**
+ * strip-markdown-ai-descriptions.js
+ *
+ * One-off cleanup for issue #788: AI enrichment used to be told "light Markdown
+ * allowed" for WineDefinition.aiProfile.description, so already-enriched rows
+ * carry literal ** ... ** (and the odd link/bullet). The field is served raw by
+ * the MCP tools get_wine / get_bottle, where it renders verbatim.
+ *
+ * The prompt now forbids markdown and enrichmentJob strips it at the write
+ * point, so this only has to clean up history. Re-running is idempotent:
+ * stripMarkdown is a no-op on text that is already plain.
+ *
+ * Scope: aiProfile.description ONLY. Deliberately does NOT touch the taxonomy
+ * (Grape/Region/Country) descriptions — those are intentionally markdown and
+ * are rendered as such on the public pages (see seed-taxonomy-descriptions).
+ *
+ * Rows whose stripped text is identical are skipped without a write, so this is
+ * safe to run against prod and cheap when there is nothing to do.
+ *
+ * Usage:
+ *   node src/scripts/strip-markdown-ai-descriptions.js           # dry run
+ *   node src/scripts/strip-markdown-ai-descriptions.js --apply   # execute
+ */
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const { stripMarkdown } = require('../utils/stripMarkdown');
+
+const APPLY = process.argv.includes('--apply');
+const tag = APPLY ? '✔' : '[dry]';
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log(`Connected. Mode: ${APPLY ? 'APPLY' : 'DRY RUN (pass --apply to execute)'}\n`);
+
+  const cursor = WineDefinition
+    .find({ 'aiProfile.description': { $nin: [null, ''] } })
+    .select('name producer aiProfile.description')
+    .lean()
+    .cursor();
+
+  const stats = { scanned: 0, changed: 0, clean: 0, emptied: 0 };
+
+  for await (const wine of cursor) {
+    stats.scanned += 1;
+    const before = wine.aiProfile.description;
+    const after = stripMarkdown(before);
+
+    if (after === before) { stats.clean += 1; continue; }
+
+    // A description that strips to nothing was pure syntax — null it rather
+    // than storing '', so the "needs enrichment" filter picks it up again.
+    if (!after) stats.emptied += 1;
+    stats.changed += 1;
+
+    const label = [wine.name, wine.producer].filter(Boolean).join(' — ');
+    console.log(`${tag} ${label} (${wine._id})`);
+    console.log(`    - ${before}`);
+    console.log(`    + ${after || '(empty → null)'}`);
+
+    if (APPLY) {
+      await WineDefinition.updateOne(
+        { _id: wine._id },
+        { $set: { 'aiProfile.description': after || null } }
+      );
+    }
+  }
+
+  console.log(`\nSummary: ${stats.scanned} scanned, ${stats.changed} ${APPLY ? 'updated' : 'would change'}, ${stats.clean} already plain, ${stats.emptied} stripped to empty.`);
+  console.log('Note: embeddings are unaffected — services/embedding.js builds its text from the structured descriptors, not this prose.');
+  await mongoose.disconnect();
+}
+
+run().catch((err) => { console.error('Cleanup failed:', err); process.exit(1); });

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -22,6 +22,7 @@
 
 const mongoose = require('mongoose');
 const aiConfig = require('../config/aiConfig');
+const { stripMarkdown } = require('../utils/stripMarkdown');
 const { tryDebitAi, isRefundableFailure } = require('./aiBudget');
 const { suggestProfile } = require('./labelScan');
 const aiProvider = require('./aiProvider');
@@ -208,7 +209,11 @@ async function enrichWine(wine, model) {
           sweetness:    data.sweetness ?? null,
           flavors:      Array.isArray(data.flavors) ? data.flavors.slice(0, 10) : [],
           foodPairings: Array.isArray(data.foodPairings) ? data.foodPairings.slice(0, 8) : [],
-          description:  typeof data.description === 'string' ? data.description.trim() : null,
+          // Strip markdown, don't just trim: the model reaches for emphasis even
+          // when told not to, and the raw string is served un-rendered by the MCP
+          // tools. Load-bearing half of the fix — the prompt is only advisory,
+          // and a self-hoster can override it via SiteConfig.
+          description:  typeof data.description === 'string' ? (stripMarkdown(data.description) || null) : null,
           confidence:   typeof data.confidence === 'number' ? data.confidence : null,
           model:        model || aiConfig.get().enrichmentModel,
           generatedAt:  new Date(),

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -1,0 +1,97 @@
+/**
+ * Enrichment persistence — the markdown boundary (#788).
+ *
+ * aiProfile.description is served RAW by the MCP tools (get_wine, get_bottle),
+ * so emphasis the model emits leaks as literal ** to any consumer that doesn't
+ * render markdown. The prompt now forbids it, but the prompt is advisory and a
+ * self-hoster can override it via SiteConfig — so the strip at the write point
+ * is the load-bearing half and is what these tests pin.
+ *
+ * Driven through enrichWineById (the exported single-wine path); enrichWine
+ * itself is module-private and both entry points share it.
+ */
+
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ distinct: jest.fn().mockResolvedValue([]) }));
+jest.mock('./labelScan', () => ({ suggestProfile: jest.fn() }));
+jest.mock('./aiProvider', () => ({ isConfigured: jest.fn(() => true) }));
+jest.mock('./embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('./aiBudget', () => ({ tryDebitAi: jest.fn(), isRefundableFailure: jest.fn(() => false) }));
+jest.mock('../config/aiConfig', () => ({ get: jest.fn(() => ({ enrichmentModel: 'claude-sonnet-5' })) }));
+
+const WineDefinition = require('../models/WineDefinition');
+const { suggestProfile } = require('./labelScan');
+const { enrichWineById } = require('./enrichmentJob');
+
+const WINE_ID = 'a'.repeat(24);
+
+const chain = (doc) => {
+  const c = {};
+  for (const m of ['populate', 'select']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(() => Promise.resolve(doc));
+  return c;
+};
+
+// The profile the model returns; description varies per test.
+const profile = (description) => ({
+  data: {
+    body: 'medium', tannin: 'low', acidity: 'medium', sweetness: 'dry',
+    flavors: ['cherry'], foodPairings: ['roast chicken'],
+    description, confidence: 0.7,
+  },
+  debugReason: null,
+});
+
+// The aiProfile actually handed to the DB.
+const persisted = () => WineDefinition.updateOne.mock.calls[0][1].$set.aiProfile;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  WineDefinition.findById.mockReturnValue(chain({
+    _id: WINE_ID, name: 'Pinot Noir', producer: 'Matua', type: 'red',
+    country: { name: 'New Zealand' }, region: { name: 'Marlborough' }, grapes: [{ name: 'Pinot Noir' }],
+  }));
+  WineDefinition.updateOne.mockResolvedValue({});
+});
+
+describe('aiProfile.description is persisted as plain text', () => {
+  // Verbatim from the issue: Matua Pinot Noir, enriched by claude-sonnet-5.
+  test('strips the bold emphasis the model emits despite the prompt', async () => {
+    suggestProfile.mockResolvedValue(profile(
+      'An everyday **cherry**-driven pinot rather than a serious cellaring wine.'
+    ));
+    await enrichWineById(WINE_ID);
+    expect(persisted().description)
+      .toBe('An everyday cherry-driven pinot rather than a serious cellaring wine.');
+    expect(persisted().description).not.toMatch(/\*/);
+  });
+
+  test('leaves already-plain prose byte-identical', async () => {
+    const plain = 'Bright red fruit and soft tannins. Drink over the next three years.';
+    suggestProfile.mockResolvedValue(profile(plain));
+    await enrichWineById(WINE_ID);
+    expect(persisted().description).toBe(plain);
+  });
+
+  test('a description that is pure markup persists as null, not an empty string', async () => {
+    // '' would look enriched to the incremental filter and never be retried.
+    suggestProfile.mockResolvedValue(profile('****'));
+    await enrichWineById(WINE_ID);
+    expect(persisted().description).toBeNull();
+  });
+
+  test('a non-string description still persists as null', async () => {
+    suggestProfile.mockResolvedValue(profile(undefined));
+    await enrichWineById(WINE_ID);
+    expect(persisted().description).toBeNull();
+  });
+
+  test('the structured descriptors are untouched by the strip', async () => {
+    suggestProfile.mockResolvedValue(profile('Juicy and **bright**.'));
+    await enrichWineById(WINE_ID);
+    expect(persisted()).toMatchObject({
+      body: 'medium', tannin: 'low', acidity: 'medium', sweetness: 'dry',
+      flavors: ['cherry'], foodPairings: ['roast chicken'], confidence: 0.7,
+    });
+  });
+});

--- a/backend/src/utils/stripMarkdown.js
+++ b/backend/src/utils/stripMarkdown.js
@@ -1,0 +1,29 @@
+// Flatten a markdown string to plain text. Backend counterpart of
+// frontend/src/utils/stripMarkdown.js — kept deliberately in sync, same rules.
+//
+// Why the backend needs it: LLM enrichment output is persisted once and then
+// read by consumers that do NOT render markdown (the MCP tools get_wine /
+// get_bottle emit the raw subdoc as JSON), so emphasis that renders fine on
+// WineDetail leaks as literal ** elsewhere. Stripping at the write point keeps
+// every consumer honest without each having to know about markdown.
+//
+// Not a full parser — it strips the syntax our prose actually uses (headings,
+// bold/italic, links, inline code, list bullets, blockquotes) and collapses
+// whitespace.
+function stripMarkdown(md) {
+  if (!md) return '';
+  return String(md)
+    .replace(/`([^`]+)`/g, '$1')             // inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')    // images
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → link text
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')      // ATX headings
+    .replace(/^\s{0,3}>\s?/gm, '')           // blockquotes
+    .replace(/^\s*[-*+]\s+/gm, '')           // unordered list bullets
+    .replace(/^\s*\d+\.\s+/gm, '')           // ordered list markers
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')      // bold
+    .replace(/(\*|_)(.*?)\1/g, '$2')         // italic
+    .replace(/\s+/g, ' ')                    // collapse whitespace/newlines
+    .trim();
+}
+
+module.exports = { stripMarkdown };

--- a/backend/src/utils/stripMarkdown.test.js
+++ b/backend/src/utils/stripMarkdown.test.js
@@ -1,0 +1,37 @@
+const { stripMarkdown } = require('./stripMarkdown');
+
+describe('stripMarkdown', () => {
+  test('falsy input returns an empty string', () => {
+    expect(stripMarkdown(null)).toBe('');
+    expect(stripMarkdown(undefined)).toBe('');
+    expect(stripMarkdown('')).toBe('');
+  });
+
+  // The exact leak from #788 (Matua Pinot Noir, enriched by claude-sonnet-5).
+  test('unwraps the bold emphasis the enrichment model emits', () => {
+    expect(stripMarkdown('an everyday **cherry**-driven pinot rather than a serious cellaring wine.'))
+      .toBe('an everyday cherry-driven pinot rather than a serious cellaring wine.');
+  });
+
+  test('handles the rest of the inline syntax prose can pick up', () => {
+    expect(stripMarkdown('*Bright* and __lively__, with `zest`.')).toBe('Bright and lively, with zest.');
+    expect(stripMarkdown('See [the appellation](https://example.com/x) notes.')).toBe('See the appellation notes.');
+    expect(stripMarkdown('![label](https://example.com/a.png)Crisp.')).toBe('Crisp.');
+  });
+
+  test('flattens block syntax and collapses the resulting whitespace', () => {
+    expect(stripMarkdown('## Tasting\n\n> Elegant.\n\n- cherry\n- plum\n\n1. decant')).
+      toBe('Tasting Elegant. cherry plum decant');
+  });
+
+  test('is a no-op on already-plain prose, so re-running the cleanup is idempotent', () => {
+    const plain = 'A juicy, medium-bodied red with soft tannins. Drink now.';
+    expect(stripMarkdown(plain)).toBe(plain);
+    expect(stripMarkdown(stripMarkdown(plain))).toBe(plain);
+  });
+
+  test('stripping twice equals stripping once for marked-up prose too', () => {
+    const once = stripMarkdown('**Bold** and *bright*.');
+    expect(stripMarkdown(once)).toBe(once);
+  });
+});


### PR DESCRIPTION
Closes #788.

## The bug

Two halves, both in the enrichment path:

1. `aiConfig.js:256` — the prompt *explicitly invited* markdown: `- description: 2-3 sentences ... Light Markdown allowed (bold a key flavour at most).` (The "no markdown, no code fences" on line 249 governs the JSON envelope, not the `description` value.)
2. `enrichmentJob.js:211` — persisted it with a bare `.trim()`.

`aiProfile.description` is served **raw** by MCP `get_wine` and `get_bottle`, so `**cherry**` reaches every consumer that doesn't render markdown. Exactly the Matua Pinot Noir case in the issue.

## The fix

Three parts, because the prompt alone can't hold this — `aiConfig.js:353` lets an admin override `enrichmentPrompt` from `SiteConfig`, so a prompt-only fix silently does nothing on such an instance. **The write-point strip is the load-bearing half.**

| | |
|---|---|
| `utils/stripMarkdown.js` | New backend util — a port of `frontend/src/utils/stripMarkdown.js`, already used for taxonomy meta descriptions. The backend had no markdown stripper (`utils/sanitize.js` is HTML-only). |
| `services/enrichmentJob.js` | Strips at the single write point both entry paths funnel through (`runJob` and `enrichWineById`). |
| `config/aiConfig.js` | Prompt now forbids markdown outright. |
| `models/WineDefinition.js` | The `// short markdown prose for display` comment was actively misleading — corrected. |
| `scripts/strip-markdown-ai-descriptions.js` | One-off cleanup, dry-run by default, `--apply` to execute. |

One deliberate detail: a description that strips to **nothing** persists as `null`, not `''`. An empty string looks enriched to the incremental filter (`enrichmentJob.js:116-118`) and the wine would never be retried.

## Not changed

- **`WineDetail` / `BottleDetail` keep their `ReactMarkdown` render.** It is a no-op on clean text and still renders rows not yet cleaned up. (Side note: both inline it rather than using the shared `MarkdownText` component from #770/#771 — functionally identical, worth a tidy-up someday, out of scope here.)
- **Embeddings are unaffected** — `embedding.js:238-249` builds its text from the structured descriptors, not this prose, so nothing needs re-embedding.
- **Taxonomy descriptions are untouched** — those are *intentionally* markdown and rendered as such.

## Tests

- `utils/stripMarkdown.test.js` — 6 tests incl. the verbatim `**cherry**` case and idempotency.
- `services/enrichmentJob.test.js` — **new file; this service had no test coverage at all.** Pins the strip at the persist boundary, the plain-text no-op, the `null`-not-`''` rule, and that structured descriptors survive untouched.

Full backend suite: **142 suites / 2107 tests passed**.

## Deploy note

The code fix only governs *new* enrichment. Existing rows stay dirty until the cleanup script runs against prod:

```bash
docker exec cellarion-backend node src/scripts/strip-markdown-ai-descriptions.js          # dry run first
docker exec cellarion-backend node src/scripts/strip-markdown-ai-descriptions.js --apply
```

Idempotent and safe to re-run. I have not run it — that is yours to trigger post-deploy.