### PR TITLE
chore(deps): Node 24 LTS + Python 3.14 base images, plus a CI test gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,12 @@ updates:
     groups:
       docker-images:
         patterns: ["*"]
+    ignore:
+      # Node majors are chosen by LTS status, not by "newest". Dependabot offers
+      # the Current line the moment it exists (it proposed 26 in #751, three
+      # months before 26 becomes LTS on 2026-10-28), and re-proposes it weekly.
+      # Digest bumps WITHIN the pinned major still come through — this only
+      # suppresses the major hop, which we take deliberately when a line goes
+      # Active LTS. Bump/remove this when moving to the next LTS.
+      - dependency-name: node
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: CI
+
+# Test gate on PRs into main. Until this existed, release-docker.yml was the
+# ONLY workflow that touched the app — and it triggers on `release: published`,
+# i.e. it builds and pushes :latest with no tests run at all. A base-image or
+# dependency change that broke the build or the suite was therefore discovered
+# on the prod VM, after `pull + up -d`. This moves that signal left of the tag.
+#
+# Deliberately does NOT push images: `push: false` proves the three Dockerfiles
+# still build without touching GHCR or needing registry credentials.
+#
+# Public repo → GitHub-hosted Actions minutes are free, so this is cost-free.
+
+on:
+  pull_request:
+    branches: [main]
+  # Lets a branch be checked before opening the PR, and gives a manual re-run.
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# A new push to the same PR cancels the previous run — a solo maintainer does
+# not need three stale runs competing for the queue.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  backend:
+    name: Backend tests (Node 24)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          # Must track backend/Dockerfile's FROM. Testing on a different major
+          # than we ship would defeat the point of the gate.
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install
+        working-directory: backend
+        run: npm ci
+
+      - name: Test
+        working-directory: backend
+        run: npm test
+
+  frontend:
+    name: Frontend tests (Node 24)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      # --legacy-peer-deps mirrors frontend/Dockerfile:8 — React 19 against
+      # deps that still declare a ^18 peer. Dropping it fails the install.
+      - name: Install
+        working-directory: frontend
+        run: npm ci --legacy-peer-deps
+
+      - name: Test
+        working-directory: frontend
+        run: npm test
+
+  images:
+    name: Docker build (${{ matrix.context }})
+    runs-on: ubuntu-latest
+    strategy:
+      # Report every broken context in one run, not just the first.
+      fail-fast: false
+      matrix:
+        context: [backend, frontend, rembg]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Same three contexts release-docker.yml publishes, built the same way but
+      # never pushed. The backend Dockerfile's `RUN node -e "require('sharp')"`
+      # makes a missing musl prebuilt fail HERE rather than on first upload.
+      - name: Build ${{ matrix.context }}
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./${{ matrix.context }}
+          push: false
+          cache-from: type=gha,scope=${{ matrix.context }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.context }}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This is the primary way to use Cellarion. Create an account and start using the 
 - **MongoDB 7** — Database (Mongoose 8)
 - **Express 4** — Backend API
 - **React 19** — Frontend (React Router 6)
-- **Node.js 20** — Runtime
+- **Node.js 24 (LTS)** — Runtime
 - **Meilisearch** — Fuzzy search engine
 - **Qdrant** — Vector database for AI cellar chat
 - **Voyage AI** — Wine embedding generation

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,14 @@
 # Digest-pinned (security audit L-11) so a moved tag can't swap the base out
 # from under a build. Dependabot's docker ecosystem bumps this. Tag kept for
-# readability; the @sha256 is what's resolved.
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
+# readability; the @sha256 is what's resolved — if you edit the tag by hand,
+# re-resolve the digest too, or the digest silently wins and you ship the old
+# major.
+#
+# Stay on an Active/Maintenance LTS line: Node 20 went EOL 2026-04-30, and 24
+# (Krypton) is Active LTS until 2026-10-20, maintenance to 2028-04-30.
+# Dependabot will offer Current releases (26 before 2026-10-28) — those are
+# ignored in .github/dependabot.yml rather than tracked.
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 # Bake production mode into the image: the refresh-cookie Secure flag and
 # 5xx error redaction key off NODE_ENV, and Express itself runs faster with
@@ -13,6 +20,13 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 RUN npm ci --omit=dev
+
+# Fail the BUILD, not prod, if sharp's musl prebuilt didn't land. `npm ci`
+# exiting 0 does not prove this: the binary is chosen by detect-libc at
+# require() time from the @img/sharp-linuxmusl-* optional deps, so a lockfile
+# regenerated off-alpine (which drops them) breaks only when the first image
+# upload hits imageProcessor. A Node major bump is exactly when that can slip.
+RUN node -e "require('sharp')"
 
 COPY . .
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -43,6 +43,9 @@
         "jest": "^30.2.0",
         "nodemon": "^3.0.2",
         "pino-pretty": "^13.1.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,6 +3,9 @@
   "version": "1.83.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # ── Stage 1: build React app ──────────────────────────────────────────────────
 # Digest-pinned (security audit L-11); Dependabot's docker ecosystem bumps it.
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS builder
 
 WORKDIR /app
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,9 @@
         "jsdom": "^25.0.1",
         "vite": "^7.3.5",
         "vitest": "^4.1.7"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "version": "1.83.1",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "dependencies": {
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",

--- a/rembg/Dockerfile
+++ b/rembg/Dockerfile
@@ -1,5 +1,5 @@
 # Digest-pinned (security audit L-11); Dependabot's docker ecosystem bumps it.
-FROM python:3.11-slim@sha256:db3ff2e1800a8581e2c48a27c3995339d47bdf046da21c7627accd3d51053a93
+FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /app
 


### PR DESCRIPTION
Supersedes #751. Closes #751 once merged.

## Why not Node 26 (what #751 proposed)

Dependabot picked the newest tag, not the right one. Verified against `nodejs/Release` `schedule.json`:

| Line | Status on 2026-07-19 | Ends |
|---|---|---|
| **20** (current pin) | **EOL since 2026-04-30** | — |
| 22 | Maintenance LTS | 2027-04-30 |
| **24** (this PR) | **Active LTS** | maintenance 2026-10-20 → EOL 2028-04-30 |
| 26 (#751) | **Current** — LTS only from 2026-10-28 | 2029-04-30 |

Node's own guidance is that production runs Active or Maintenance LTS. #751 would put prod on a Current line for ~101 days.

But **doing nothing was the worst option**: `node:20-alpine` has been EOL for ~80 days (last release v20.20.2, 2026-03-24), so the bump itself is right and overdue — only the target was wrong.

The **Python half of #751 is taken exactly as proposed** — see verification below.

## Also in this PR

| Change | Why |
|---|---|
| `RUN node -e "require('sharp')"` in `backend/Dockerfile` | `npm ci` exiting 0 does **not** prove sharp works — the musl binary is selected by `detect-libc` at `require()` time from `@img/sharp-linuxmusl-*`. A lockfile regenerated off-alpine drops those and fails only on the first image upload. Now it fails the build. Verified it exits non-zero when sharp is absent. |
| `engines: >=24` on both `package.json` | Neither had one. Lockfiles regenerated **inside node:24-alpine** (per project rule) — 3 lines each, all 14 musl entries intact, `npm ci` + `require('sharp')` re-verified after. |
| dependabot `ignore` for node **majors** | It offered 26 three months before 26 is LTS and would re-offer every week. Digest bumps *within* the pinned major still come through. |
| `README.md:43` | Said "Node.js 20 — Runtime"; the only place a self-hoster learns the runtime. |

## CI test gate (`.github/workflows/ci.yml`)

Until now `release-docker.yml` was the only workflow touching the app, and it fires on `release: published` — it **builds and pushes `:latest` with no tests run at all**. A broken base image was discoverable only on the prod VM after `pull + up -d`.

The new workflow, on every PR into `main`: backend Jest + frontend Vitest on Node 24, plus all three Dockerfiles built with `push: false`. Public repo, so minutes are free. All four action SHAs verified to resolve to their claimed tags.

Note it pins `node-version: '24'` to match the Dockerfiles — testing on a different major than we ship would defeat the point.

## Verification (all run locally)

**Node 24** — backend **142 suites / 2109 tests green**; frontend **37 files / 690 tests green**; all three images build; `sharp 0.34.5` + `libvips 8.17.3` loads and does real resize/rotate/composite work; frontend serves HTTP 200 with its bundle.

**Python 3.14 (rembg)** — builds clean, **100% prebuilt cp314 wheels, zero source builds** (onnxruntime 1.27.0, numpy 2.4.6, pillow 12.3.0); build-time `new_session('u2net')` prefetch completes; a real POST to `/remove-bg` returns a cropped transparent PNG (34.5% transparent, subject retained).

**Cross-service seam** — the full compose stack up on Node 24 + Py 3.14: backend → rembg over global `fetch()` → back into sharp, 10/10 checks green. This is the seam #751 changed on both sides at once.

For completeness I also ran the whole battery on Node 26 and it passes too — the objection to 26 is lifecycle, not compatibility.

## Deploy notes

- All three application containers get recreated; **no `docker-compose.prod.yml` edit needed** (image names unchanged) — which also means prod compose gives no signal the runtime moved. Worth noting in the Release body.
- `python:3.11-slim → 3.14-slim` is also **Debian bookworm → trixie**. `rembg/Dockerfile:7-9` installs `libglib2.0-0` by literal name (renamed `libglib2.0-0t64` in trixie) — verified apt still resolves it; the image contains `libglib2.0-0t64 2.84.4-3~deb13u3`.
- Rollback is unchanged: every release also pushes an immutable `:X.Y.Z`, so pin the previous tag in prod compose and `up -d`.