### PR TITLE
release: v1.84.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.83.1",
+  "version": "1.84.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.83.1",
+      "version": "1.84.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.83.1",
+  "version": "1.84.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.83.1",
+  "version": "1.84.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.83.1",
+      "version": "1.84.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.83.1",
+  "version": "1.84.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v1.84.0** — rolls up everything merged since v1.83.1.

## What's in this release (7 PRs)

**Runtime / infra**
- **#791** — base images moved to **Node 24 LTS** (off EOL Node 20) + **Python 3.14** for rembg, plus a new **CI test gate** (`.github/workflows/ci.yml`) that runs both suites + all three Docker builds on every PR.
- **#792** — nginx-unprivileged base image digest refresh (frontend runtime).
- **#794** — body-parser 1.20.5 → 1.20.6 (fixes GHSA-v422-hmwv-36x6, DoS).
- **#750 / #793** — GitHub Actions bumps (checkout v7.0.1, buildx/login/build-push majors). CI-only, no prod impact.

**Fixes**
- **#790** — AI tasting-profile descriptions stored as plain text (markdown stripped at enrichment); closes #788.
- **#789** — `somm_notes` readable back through the somm MCP tools; closes #787.

## Verification (local, on the shipping runtime)
- Full stack rebuilt on Node 24.18 / Python 3.14.6 — all containers healthy.
- Backend **142 suites / 2109 tests** green on node:24-alpine; frontend **37 files / 690 tests** green.
- Frontend SPA serves 200; live backend→rembg background-removal seam works.
- CI gate green on all constituent PRs.

## Security posture
Net **positive**: moves off EOL Node 20 (10 unpatched CVEs) and patches body-parser. Pre-existing CodeQL findings (3 false-positive, 1 low ReDoS) and low-reachability transitive Dependabot alerts are unchanged from current prod and tracked for a separate cleanup PR — none are regressions from this release.

## Deploy notes (for the prod rollout after this merges + release is cut)
- **Before `up`** (hand-maintained docker-compose.prod.yml): `TRUST_PROXY_HOPS=2` and the #737 env mirror (`NODE_OPTIONS` / `COOKIE_SECURE` / `CLIMATE`).
- **After deploy**: run `strip-markdown-ai-descriptions.js --apply` (cleans existing AI descriptions; #790 only fixes new ones).
- Every user hits ReconsentModal once (privacy v2026-07) — expected.
- Base-image switch flows through on image pull (prod compose references image names) — no compose edit needed for that part. Rollback: pin `:1.83.1` and `up -d`.