### PR TITLE
feat(registry): infer grapes from the wine name when none supplied

### DIFF
--- a/backend/src/scripts/backfill-wine-grapes-from-name.js
+++ b/backend/src/scripts/backfill-wine-grapes-from-name.js
@@ -1,0 +1,105 @@
+/**
+ * backfill-wine-grapes-from-name.js
+ *
+ * Ticket #2A: registry wines whose grape is explicit in the name
+ * ("Felton Road Block 3 Pinot Noir", "Bannockburn Chardonnay") but whose
+ * grapes[] is empty — so they silently drop out of the Statistics "by grape"
+ * breakdown and the /api/wines?grapes= filter. This tags them using the same
+ * name-inference the create path now runs (services/grapeInference.js), which
+ * only ever assigns grapes ALREADY in the taxonomy and never mints one.
+ *
+ * Safe by construction (see grapeInference.js): longest-first span consumption
+ * (so "Cabernet Sauvignon" is never also tagged Sauvignon Blanc), word-boundary
+ * matching, a minimum synonym length, and a tiny mono-varietal-appellation
+ * fallback (Barolo→Nebbiolo, Chablis→Chardonnay — NOT Rioja/Sancerre/Chianti).
+ * Wines where nothing matches are left untouched.
+ *
+ * Dry-run by default. On --apply it writes a JSON backup of every affected row
+ * (old grapes) first, then updates + re-indexes Meilisearch per wine (so the
+ * grapes= filter reflects the change). NOTE: embeddings are NOT refreshed here
+ * — grapes feed the embed text, so run the admin embedding job afterwards to
+ * update semantic search (the DB-backed Statistics + Mongo grapes= filter are
+ * correct immediately).
+ *
+ * Usage:
+ *   node src/scripts/backfill-wine-grapes-from-name.js            # dry run
+ *   node src/scripts/backfill-wine-grapes-from-name.js --apply    # execute
+ *   node src/scripts/backfill-wine-grapes-from-name.js --limit=50 # cap (testing)
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const Grape = require('../models/Grape');
+const { buildSurfaceForms, inferGrapeIds } = require('../services/grapeInference');
+const { stripProducerName } = require('../utils/producerPrefix');
+
+const APPLY = process.argv.includes('--apply');
+const limitArg = process.argv.find((a) => a.startsWith('--limit='));
+const LIMIT = limitArg ? parseInt(limitArg.split('=')[1], 10) : 0;
+const tag = APPLY ? '✔' : '[dry]';
+
+// Strip the producer off the name the way findOrCreateWine's step-0 does, so a
+// stray producer-in-name row still infers cleanly.
+function producerFreeName(name, producer) {
+  let n = String(name || '').trim();
+  for (let rest = stripProducerName(n, producer); rest; rest = stripProducerName(n, producer)) n = rest;
+  return n;
+}
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log(`Connected. Mode: ${APPLY ? 'APPLY' : 'DRY RUN (pass --apply to execute)'}\n`);
+
+  const grapeDocs = await Grape.find({}).select('name normalizedName normalizedSynonyms').lean();
+  const forms = buildSurfaceForms(grapeDocs);
+  const grapeName = new Map(grapeDocs.map((g) => [String(g._id), g.name]));
+  console.log(`Loaded ${grapeDocs.length} grapes → ${forms.length} surface forms.\n`);
+
+  const q = WineDefinition
+    .find({ $or: [{ grapes: { $exists: false } }, { grapes: { $size: 0 } }] })
+    .select('name producer appellation grapes')
+    .lean();
+  if (LIMIT) q.limit(LIMIT);
+  const wines = await q;
+
+  const stats = { scanned: 0, inferred: 0, noMatch: 0 };
+  const backup = [];
+  let shown = 0;
+
+  for (const w of wines) {
+    stats.scanned += 1;
+    const cleanName = producerFreeName(w.name, w.producer);
+    const ids = inferGrapeIds(cleanName, w.appellation || '', forms);
+    if (ids.length === 0) { stats.noMatch += 1; continue; }
+    stats.inferred += 1;
+
+    const names = ids.map((id) => grapeName.get(String(id)) || String(id));
+    if (shown < 40) {
+      console.log(`${tag} ${w.name}${w.producer ? ' — ' + w.producer : ''}  →  ${names.join(', ')}`);
+      shown += 1;
+    }
+    backup.push({ _id: String(w._id), name: w.name, oldGrapes: (w.grapes || []).map(String) });
+
+    if (APPLY) {
+      await WineDefinition.updateOne({ _id: w._id }, { $set: { grapes: ids } });
+      // Re-index so the Meili grapes= filter + denormalized bottle rows update.
+      try { await require('../services/search').indexWine(w._id); } catch { /* best-effort */ }
+    }
+  }
+
+  if (APPLY && backup.length) {
+    const file = path.join(os.tmpdir(), `grape-backfill-backup-${Date.now()}.json`);
+    fs.writeFileSync(file, JSON.stringify(backup, null, 2));
+    console.log(`\nBackup of ${backup.length} rows (old grapes) → ${file}`);
+  }
+
+  console.log(`\nSummary: ${stats.scanned} empty-grape wines scanned, ${stats.inferred} ${APPLY ? 'tagged' : 'would tag'}, ${stats.noMatch} left untouched (no varietal in name).`);
+  if (APPLY) console.log('Next: run the admin embedding job to refresh semantic search (grapes feed the embed text). Statistics + /api/wines grapes= reflect the change now.');
+  await mongoose.disconnect();
+}
+
+run().catch((err) => { console.error('Backfill failed:', err); process.exit(1); });

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -21,6 +21,7 @@ const searchService = require('./search');
 const { generateWineKey, normalizeString, resolveGrapeName, resolveCountryName, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
 const { stripProducerName } = require('../utils/producerPrefix');
+const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
 const { escapeRegex } = require('../utils/sanitize');
 
 // Auto-match when combined score >= SIMILARITY_THRESHOLD (near-identical — e.g.
@@ -239,7 +240,17 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   }
 
   const regionDoc = await findOrCreateRegion(region, countryDoc._id, userId);
-  const grapeIds = await findOrCreateGrapes(grapes, userId);
+  let grapeIds = await findOrCreateGrapes(grapes, userId);
+
+  // Ticket #2A: when no grapes were supplied, infer them from the name
+  // ("… Pinot Noir" → Pinot Noir) so the wine still counts in the Statistics
+  // by-grape breakdown and the grapes= filter. trimmedName already has the
+  // producer stripped (step 0). Only tags grapes already in the taxonomy —
+  // never mints one — and stays silent when nothing matches.
+  if (grapeIds.length === 0) {
+    const grapeDocs = await Grape.find({}).select('name normalizedName normalizedSynonyms').lean();
+    grapeIds = inferGrapeIds(trimmedName, trimmedAppellation, buildSurfaceForms(grapeDocs));
+  }
 
   const validTypes = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
   const wineType = validTypes.includes(type) ? type : 'red';

--- a/backend/src/services/grapeInference.js
+++ b/backend/src/services/grapeInference.js
@@ -1,0 +1,121 @@
+// Infer a wine's grape varieties from its NAME when none were supplied.
+//
+// Ticket #2A: many registry wines carry the grape explicitly in the name
+// ("Felton Road Block 3 Pinot Noir", "Bannockburn Chardonnay") yet have an
+// empty grapes[] array, so they silently drop out of the Statistics "by grape"
+// breakdown and the /api/wines?grapes= filter. Grapes are only ever set from
+// the caller-supplied arg in findOrCreateWine — there is no name inference.
+//
+// This matches grape SURFACE FORMS (canonical names + admin synonyms + the
+// global GRAPE_SYNONYMS map) against the normalized name, and only ever tags
+// grapes that ALREADY EXIST in the taxonomy — it never mints a new Grape doc.
+//
+// Safety (the two traps a naive scan falls into):
+//   1. Longest-first with span consumption: "Cabernet Sauvignon" is matched as
+//      itself and its span is blanked out, so the bare "sauvignon" → Sauvignon
+//      Blanc synonym can never also fire on the same wine. Same for
+//      Pinot Noir/Gris/Blanc, Cabernet Franc/Sauvignon.
+//   2. Word-boundary matching + a minimum surface-form length, so short
+//      synonyms ("cot" → Malbec) can't match a substring of an unrelated word.
+//
+// The appellation fallback is deliberately tiny: only LEGALLY mono-varietal
+// appellations, keyed on the place name with the tier suffix (DOCG/DOC/…)
+// stripped. NOT Rioja (white = Viura, reds blend), Sancerre (rouge = Pinot
+// Noir), Chianti (a blend) — those would mis-tag.
+
+const { normalizeString, GRAPE_SYNONYMS } = require('../utils/normalize');
+
+// Surface forms shorter than this are skipped for name matching — avoids the
+// 3–4 char synonyms ("cot", "cote") that collide with substrings of real words.
+const MIN_FORM_LEN = 5;
+
+// Never tag more than this many grapes from one name — a guard against a
+// pathological name that happens to contain many varietal words.
+const MAX_INFERRED = 4;
+
+// Place name (tier suffix stripped) → the single variety that appellation is
+// by law. Conservative: only appellations that are mono-varietal in the colour
+// their wines are made. Keyed on normalizeString(placeName).
+const APPELLATION_GRAPE = {
+  barolo: 'Nebbiolo',
+  barbaresco: 'Nebbiolo',
+  chablis: 'Chardonnay',
+};
+
+const TIER_SUFFIX_RX = /\b(docg|doca|doc|aoc|aop|ava|igt|igp|do|ao)\b/g;
+
+function escapeRx(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build the longest-first list of grape surface forms from the grape corpus.
+ * @param {Array<{_id:any,name:string,normalizedName?:string,normalizedSynonyms?:string[]}>} grapeDocs
+ * @returns {Array<{form:string, grapeId:any, canonical:string}>}
+ */
+function buildSurfaceForms(grapeDocs) {
+  const forms = [];
+  const byNormName = new Map();
+  const push = (grape, raw) => {
+    const form = normalizeString(raw);
+    if (form.length < MIN_FORM_LEN) return;
+    forms.push({ form, grapeId: grape._id, canonical: grape.name });
+  };
+  for (const g of grapeDocs || []) {
+    const nn = g.normalizedName || normalizeString(g.name);
+    if (nn) byNormName.set(nn, g);
+    push(g, g.name);
+    for (const s of (g.normalizedSynonyms || [])) push(g, s);
+  }
+  // Global synonym map — attach each synonym to its canonical grape's doc, so
+  // "Shiraz" → Syrah / "Primitivo" → Zinfandel are matchable even when a doc
+  // carries no admin synonyms.
+  for (const [syn, canonical] of Object.entries(GRAPE_SYNONYMS)) {
+    const g = byNormName.get(normalizeString(canonical));
+    if (g) push(g, syn);
+  }
+  // Longest first so multi-word forms win and consume their span before any
+  // shorter form (single tokens) can match inside them.
+  forms.sort((a, b) => b.form.length - a.form.length);
+  return forms;
+}
+
+/**
+ * Infer grape _ids from a wine name (with an optional appellation fallback).
+ * @param {string} name         wine name (ideally producer already stripped)
+ * @param {string} appellation  optional appellation string
+ * @param {Array} surfaceForms  from buildSurfaceForms()
+ * @returns {Array} grape _ids (may be empty)
+ */
+function inferGrapeIds(name, appellation, surfaceForms) {
+  let work = ` ${normalizeString(name)} `;
+  const ids = [];
+  const seen = new Set();
+  for (const { form, grapeId } of surfaceForms) {
+    if (ids.length >= MAX_INFERRED) break;
+    const boundary = new RegExp(`\\b${escapeRx(form)}\\b`);
+    if (!boundary.test(work)) continue;
+    const key = String(grapeId);
+    if (!seen.has(key)) {
+      seen.add(key);
+      ids.push(grapeId);
+    }
+    // Blank every occurrence of this span so shorter overlapping forms (e.g.
+    // "sauvignon" inside a just-matched "cabernet sauvignon") cannot re-match.
+    work = work.replace(new RegExp(`\\b${escapeRx(form)}\\b`, 'g'), ' '.repeat(form.length));
+  }
+
+  // Appellation fallback — only when the name yielded nothing, and only for the
+  // hand-picked mono-varietal appellations.
+  if (ids.length === 0 && appellation) {
+    const place = normalizeString(appellation).replace(TIER_SUFFIX_RX, '').replace(/\s+/g, ' ').trim();
+    const canonical = APPELLATION_GRAPE[place];
+    if (canonical) {
+      const match = surfaceForms.find((f) => normalizeString(f.canonical) === normalizeString(canonical));
+      if (match) ids.push(match.grapeId);
+    }
+  }
+  return ids;
+}
+
+module.exports = { buildSurfaceForms, inferGrapeIds, MIN_FORM_LEN, MAX_INFERRED, APPELLATION_GRAPE };

--- a/backend/src/services/grapeInference.test.js
+++ b/backend/src/services/grapeInference.test.js
@@ -1,0 +1,83 @@
+const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
+const { normalizeString } = require('../utils/normalize');
+
+// Synthetic grape corpus covering every trap: substring pairs (Cabernet
+// Sauvignon vs Sauvignon Blanc, Pinot Noir/Gris/Blanc), a global-synonym grape
+// (Syrah←shiraz, Zinfandel←primitivo), and a mono-varietal-appellation grape
+// (Nebbiolo). Grape ids are the canonical name for readable assertions.
+const CORPUS = [
+  'Pinot Noir', 'Pinot Gris', 'Pinot Blanc', 'Chardonnay', 'Riesling',
+  'Cabernet Sauvignon', 'Cabernet Franc', 'Sauvignon Blanc', 'Merlot',
+  'Syrah', 'Zinfandel', 'Nebbiolo', 'Malbec', 'Sangiovese',
+].map((name) => ({ _id: name, name, normalizedName: normalizeString(name), normalizedSynonyms: [] }));
+
+const FORMS = buildSurfaceForms(CORPUS);
+const infer = (name, appellation) => inferGrapeIds(name, appellation || '', FORMS).map(String);
+
+describe('grape inference — the substring traps (must not double- or mis-tag)', () => {
+  test('"Cabernet Sauvignon" tags ONLY Cabernet Sauvignon, never Sauvignon Blanc', () => {
+    // The bare "sauvignon" → Sauvignon Blanc global synonym must not also fire.
+    expect(infer('Château Whatever Cabernet Sauvignon')).toEqual(['Cabernet Sauvignon']);
+  });
+
+  test('a real blend tags both varieties', () => {
+    expect(infer('Cabernet Sauvignon Merlot').sort()).toEqual(['Cabernet Sauvignon', 'Merlot']);
+  });
+
+  test('Pinot Noir / Gris / Blanc are never confused for one another', () => {
+    expect(infer('Felton Road Block 3 Pinot Noir')).toEqual(['Pinot Noir']);
+    expect(infer('Alsace Pinot Gris')).toEqual(['Pinot Gris']);
+    expect(infer('Pinot Blanc')).toEqual(['Pinot Blanc']);
+  });
+
+  test('Cabernet Franc is not tagged as Cabernet Sauvignon', () => {
+    expect(infer('Loire Cabernet Franc')).toEqual(['Cabernet Franc']);
+  });
+});
+
+describe('grape inference — the Felton Road cases from the ticket', () => {
+  test.each([
+    ['Felton Road Bannockburn Chardonnay', ['Chardonnay']],
+    ['Felton Road Block 1 Riesling', ['Riesling']],
+    ['Felton Road Block 5 Pinot Noir', ['Pinot Noir']],
+    ['Felton Road Cornish Point Pinot Noir', ['Pinot Noir']],
+  ])('%s → %j', (name, expected) => {
+    expect(infer(name)).toEqual(expected);
+  });
+});
+
+describe('grape inference — global synonyms resolve to canonical', () => {
+  test('Shiraz → Syrah', () => expect(infer('Barossa Shiraz')).toEqual(['Syrah']));
+  test('Primitivo → Zinfandel', () => expect(infer('Primitivo di Manduria')).toEqual(['Zinfandel']));
+});
+
+describe('grape inference — mono-varietal appellation fallback', () => {
+  test('name has no grape, appellation "Barolo" → Nebbiolo', () => {
+    expect(infer('Riserva', 'Barolo')).toEqual(['Nebbiolo']);
+  });
+  test('tier suffix is stripped: "Barolo DOCG" → Nebbiolo', () => {
+    expect(infer('Riserva', 'Barolo DOCG')).toEqual(['Nebbiolo']);
+  });
+  test('name inference wins over the appellation fallback', () => {
+    // A (contrived) Barolo-appellation wine whose name names a different grape
+    // still trusts the name, not the appellation.
+    expect(infer('Chardonnay', 'Barolo')).toEqual(['Chardonnay']);
+  });
+  test('non-mono-varietal appellations do NOT infer (Rioja is a blend / white Viura)', () => {
+    expect(infer('Reserva', 'Rioja')).toEqual([]);
+    expect(infer('Rouge', 'Sancerre')).toEqual([]);
+  });
+});
+
+describe('grape inference — no false positives', () => {
+  test('a short synonym ("cot" → Malbec) never matches a substring', () => {
+    // "cot" is below MIN_FORM_LEN, so "Apricot" must not tag Malbec.
+    expect(infer('Apricot Dessert Wine')).toEqual([]);
+  });
+  test('a name with no known varietal returns nothing', () => {
+    expect(infer('House Red Blend', 'Vin de France')).toEqual([]);
+  });
+  test('Malbec is still tagged when it is the actual word', () => {
+    expect(infer('Cahors Malbec')).toEqual(['Malbec']);
+  });
+});

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -590,6 +590,7 @@ module.exports = {
   tokenize,
   generateWineKey,
   generateWineSlug,
+  GRAPE_SYNONYMS,
   resolveGrapeName,
   resolveCountryName,
   isUnknownName,


### PR DESCRIPTION
Ticket #2A (registry data quality — empty grape tags). The reporter's "highest impact" item, **confirmed on prod**: 9/10 Felton Road wines have `grapes: []` despite grape-explicit names, so they drop out of the Statistics "by grape" breakdown and the `/api/wines?grapes=` filter.

## Root cause
Grapes are set **only** from the caller-supplied arg in `findOrCreateWine` (:242); all match branches return early without backfilling, and no name inference exists. Untouched by the taxonomy (#765-769) or producer (#674/#781) work.

## Fix
New `services/grapeInference.js` matches grape **surface forms** (canonical names + admin synonyms + the global `GRAPE_SYNONYMS` map) against the normalized name, and **only tags grapes already in the taxonomy — never mints one.**

Two mis-tag traps handled and **pinned by 17 unit tests**:
1. **Longest-first with span consumption** → "Cabernet Sauvignon" is tagged as itself; the bare `sauvignon → Sauvignon Blanc` synonym can never also fire. Same for Pinot Noir/Gris/Blanc, Cabernet Franc/Sauvignon.
2. **Word-boundary matching + minimum surface-form length** → short synonyms (`cot → Malbec`) can't match a substring ("Apricot" ≠ Malbec).

Appellation fallback is deliberately tiny — only legally mono-varietal appellations (Barolo/Barbaresco→Nebbiolo, Chablis→Chardonnay), tier suffix stripped. **NOT** Rioja / Sancerre / Chianti.

- **Prevention:** `findOrCreateWine` infers when supplied grapes resolve empty — single chokepoint covers label scan + CSV/cellar import + MCP `add_bottle`/`bulk_add`.
- **Cleanup:** `scripts/backfill-wine-grapes-from-name.js`, dry-run by default; `--apply` writes a JSON backup + re-indexes Meili per wine.

## Verified
- 17 grapeInference unit tests (every trap + the exact Felton Road cases).
- Full backend suite **143 suites / 2126 tests** green on Node 24.
- Dry-run on dev data: **40 tagged / 181 conservatively left untouched**; live traps held — "St Hugo **Cabernet Sauvignon**" → Cabernet Sauvignon (not Sauvignon Blanc), "Howell Cabernet Franc" → Cabernet Franc, "…Shiraz" → Syrah.

## Deploy (after merge + release)
1. `docker exec cellarion-backend node src/scripts/backfill-wine-grapes-from-name.js` (dry-run, review)
2. `… --apply`
3. Run the admin embedding job to refresh semantic search (grapes feed the embed text). Statistics + Mongo `grapes=` filter reflect the change immediately; only Meili filter + Qdrant need the refresh.