### PR TITLE
fix(admin): bucket producer variants together in duplicate-clusters scan

### DIFF
--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -7,7 +7,8 @@ const {
   combinedSimilarity,
   trigramSimilarity,
   tokenSimilarity,
-  normalizeString
+  normalizeString,
+  normalizeProducerKey
 } = require('../../utils/normalize');
 const { scoreWineMatch } = require('../../services/wineMatching');
 const WineDefinition = require('../../models/WineDefinition');
@@ -263,10 +264,15 @@ router.get('/duplicate-clusters', async (req, res) => {
       .populate('region', 'name')
       .lean();
 
-    // Group by normalised producer
+    // Group by normalised producer KEY: wine stop words + corporate suffixes
+    // stripped, so "Kumeu River Wines Limited" and "Kumeu River" land in the
+    // same bucket and the pairwise scorer + merge UI can surface them (ticket
+    // #2B). Bucketing only ever MERGES buckets (fewer distinct keys), never
+    // splits, so existing clusters can't regress; every surfaced cluster is
+    // admin-reviewed before any merge, so over-grouping is safe.
     const byProducer = new Map();
     for (const wine of wines) {
-      const key = normalizeString(wine.producer || '');
+      const key = normalizeProducerKey(wine.producer || '');
       if (!key) continue;
       let group = byProducer.get(key);
       if (!group) { group = []; byProducer.set(key, group); }

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -55,6 +55,32 @@ const tokenize = (str) => {
 };
 
 /**
+ * Corporate / legal-form suffixes that vary between a wine label and a registry
+ * entry for the SAME producer ("Kumeu River" vs "Kumeu River Wines Limited").
+ * Distinct from WINE_STOP_WORDS (which also governs wine-NAME matching) — these
+ * are producer-specific and stripped only when building a producer COMPARISON
+ * key, never from a display string.
+ */
+const PRODUCER_CORP_SUFFIXES = new Set([
+  'ltd', 'limited', 'inc', 'incorporated', 'llc', 'llp', 'plc',
+  'gmbh', 'ag', 'sa', 'sas', 'sarl', 'srl', 'spa', 'sl', 'bv', 'nv',
+  'pty', 'co', 'company', 'corp', 'corporation', 'ab', 'oy', 'as', 'kg', 'kft',
+]);
+
+/**
+ * Normalize a producer to a comparison/bucketing key: drop wine stop words AND
+ * corporate suffixes, so "Kumeu River Wines Limited" and "Kumeu River" collapse
+ * to the same key ("kumeu river"). Comparison-only — never overwrites the
+ * stored display producer. Returns '' for an all-stopword/empty producer.
+ */
+const normalizeProducerKey = (producer) => {
+  return tokenize(producer)
+    .filter((t) => !PRODUCER_CORP_SUFFIXES.has(t))
+    .join(' ')
+    .trim();
+};
+
+/**
  * Generate a normalized key for wine deduplication
  * Combines producer + wine name + appellation
  */
@@ -591,6 +617,7 @@ module.exports = {
   generateWineKey,
   generateWineSlug,
   GRAPE_SYNONYMS,
+  normalizeProducerKey,
   resolveGrapeName,
   resolveCountryName,
   isUnknownName,

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -1,6 +1,7 @@
 const {
   normalizeString,
   tokenize,
+  normalizeProducerKey,
   generateWineKey,
   levenshteinDistance,
   calculateSimilarity,
@@ -461,5 +462,27 @@ describe('producer house prefixes (the launch-day Barolo duplicate)', () => {
     // Sharing a stripped prefix must not make different houses near-identical:
     // candidates at worst (soft zone asks the user), never a silent merge.
     expect(combinedSimilarity('Cantina Rossi', 'Cantina Bianchi')).toBeLessThan(0.6);
+  });
+});
+
+describe('normalizeProducerKey (ticket #2B: dup-cluster bucketing)', () => {
+  test('a corporate suffix + a wine stop word collapse to the same key', () => {
+    // The exact repro: two registry strings for one producer must bucket together.
+    expect(normalizeProducerKey('Kumeu River Wines Limited')).toBe('kumeu river');
+    expect(normalizeProducerKey('Kumeu River')).toBe('kumeu river');
+  });
+
+  test('common legal forms are stripped', () => {
+    expect(normalizeProducerKey('Foo Bar Ltd')).toBe(normalizeProducerKey('Foo Bar'));
+    expect(normalizeProducerKey('Weingut Müller GmbH')).toBe(normalizeProducerKey('Müller'));
+  });
+
+  test('genuinely different producers keep different keys', () => {
+    expect(normalizeProducerKey('Kumeu River')).not.toBe(normalizeProducerKey('Cloudy Bay'));
+  });
+
+  test('empty / all-stopword producer yields an empty key (bucket skipped)', () => {
+    expect(normalizeProducerKey('')).toBe('');
+    expect(normalizeProducerKey('Wines Ltd')).toBe('');
   });
 });


### PR DESCRIPTION
Ticket #2B (registry data quality — producer variants), the **safe half**.

## Problem
Confirmed on prod: the same producer is stored under two strings — "Kumeu River Wines Limited" (wine `69f07565`) and "Kumeu River" (`6a33cf99`). The admin **duplicate-clusters** scan groups wines by raw `normalizeString(producer)`, so the variants land in different buckets, are never pairwise-scored, and never surface for merging. The code self-documented the gap: *"a future producer-dedup pass is the right fix"* (`admin/wines.js:247-249`).

## Fix
New `normalizeProducerKey()` strips wine stop-words **and** corporate/legal suffixes (Ltd/Limited/Inc/LLC/GmbH/SA/Srl/Pty/Co…), so both variants collapse to `"kumeu river"` and bucket together — the existing pairwise scorer + merge UI then surface them.

- **Comparison/bucketing only** — the stored display producer is never touched.
- **Bucketing can only merge buckets (fewer distinct keys), never split**, so existing clusters can't regress.
- Every surfaced cluster is **admin-reviewed before any merge**, so over-grouping is safe.

## Deliberately NOT here
A **bulk producer-field rewrite** — genuinely risky ("Smith Estate" ≠ "Smith Wines" ≠ "Smith Ltd"), so it stays an admin decision, exactly as flagged in `SUPPORT_TICKETS_ASSESSMENT_2026-07-21.md`. This PR just makes the existing variants **discoverable** through the tool you already have.

## Tests
`normalizeProducerKey` unit-tested: the exact Kumeu River repro, legal-form stripping (GmbH/Ltd), distinct-producers-stay-distinct, and the empty-key guard. normalize suite green (72 tests) on Node 24.

## Post-merge (optional, your call)
Open `/admin` → duplicate clusters and merge any real producer variants it now surfaces, via the existing merge endpoint (which re-embeds the keeper).