### PR TITLE
fix(registry): canonicalize appellations by stripping the tier suffix

### DIFF
--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -2,7 +2,7 @@ const express = require('express');
 const multer = require('multer');
 const { parse } = require('csv-parse');
 const { requireAuth, requireRole } = require('../../middleware/auth');
-const { generateWineKey, normalizeString, resolveCountryName, isUnknownName } = require('../../utils/normalize');
+const { generateWineKey, normalizeString, normalizeAppellation, resolveCountryName, isUnknownName } = require('../../utils/normalize');
 const WineDefinition = require('../../models/WineDefinition');
 const Country = require('../../models/Country');
 const Region = require('../../models/Region');
@@ -115,7 +115,7 @@ function mapRow(row, format) {
     name: (row.Wine || '').trim() || null,
     country: (row.Country || '').trim() || null,
     region: (row.Region || '').trim() || null,
-    appellation: (row.Appellation || '').trim() || null,
+    appellation: normalizeAppellation((row.Appellation || '').trim()) || null,
     type: mapType(null, null, row.WineType),
     classification: (row.Classification || '').trim() || null,
     status: 'Live',

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -8,7 +8,8 @@ const {
   trigramSimilarity,
   tokenSimilarity,
   normalizeString,
-  normalizeProducerKey
+  normalizeProducerKey,
+  normalizeAppellation
 } = require('../../utils/normalize');
 const { scoreWineMatch } = require('../../services/wineMatching');
 const WineDefinition = require('../../models/WineDefinition');
@@ -148,7 +149,7 @@ router.post('/', async (req, res) => {
       producer: producer.trim(),
       country,
       region: region || null,
-      appellation: appellation?.trim(),
+      appellation: normalizeAppellation(appellation?.trim()),
       grapes: grapes || [],
       type: type || 'red',
       image: image || null,
@@ -664,7 +665,7 @@ router.put('/:id', async (req, res) => {
     if (producer) wine.producer = producer.trim();
     if (country) wine.country = country;
     if (region !== undefined) wine.region = region || null;
-    if (appellation !== undefined) wine.appellation = appellation?.trim();
+    if (appellation !== undefined) wine.appellation = normalizeAppellation(appellation?.trim());
     if (grapes !== undefined) wine.grapes = grapes;
     if (type) wine.type = type;
 

--- a/backend/src/scripts/normalize-appellation-tiers.js
+++ b/backend/src/scripts/normalize-appellation-tiers.js
@@ -1,0 +1,90 @@
+/**
+ * normalize-appellation-tiers.js
+ *
+ * Ticket #2C: the same appellation is stored both with and without its
+ * classification tier ("Barolo" vs "Barolo DOCG"), fragmenting it in any
+ * appellation-grouped view. The write paths now canonicalize on create
+ * (utils/normalize.normalizeAppellation), so this cleans up existing rows.
+ *
+ * For each wine whose appellation carries a strippable tier, it computes the
+ * canonical appellation (place name) and the new normalizedKey (appellation is
+ * part of the dedup key). Because normalizedKey is UNIQUE:
+ *   - no collision → update appellation + normalizedKey, re-index Meili.
+ *   - collision (another wine already has the canonical key: a genuine
+ *     same-producer+name duplicate) → SKIP and report it for manual merge via
+ *     the admin duplicate-clusters UI. This script never merges wines.
+ *
+ * generateWineSlug uses name+producer only, so the public /wines/:slug URL is
+ * unaffected; bottles carry no denormalized appellation.
+ *
+ * Dry-run by default. On --apply: writes a JSON backup of affected rows first.
+ * Run the admin embedding job afterwards (appellation feeds the embed text).
+ *
+ * Usage:
+ *   node src/scripts/normalize-appellation-tiers.js            # dry run
+ *   node src/scripts/normalize-appellation-tiers.js --apply    # execute
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const { normalizeAppellation, generateWineKey } = require('../utils/normalize');
+
+const APPLY = process.argv.includes('--apply');
+const tag = APPLY ? '✔' : '[dry]';
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log(`Connected. Mode: ${APPLY ? 'APPLY' : 'DRY RUN (pass --apply to execute)'}\n`);
+
+  const wines = await WineDefinition
+    .find({ appellation: { $nin: [null, ''] } })
+    .select('name producer appellation normalizedKey')
+    .lean();
+
+  const stats = { scanned: 0, changed: 0, same: 0, collisions: 0 };
+  const backup = [];
+  let shown = 0;
+
+  for (const w of wines) {
+    stats.scanned += 1;
+    const canonical = normalizeAppellation(w.appellation);
+    if (canonical === w.appellation) { stats.same += 1; continue; }
+
+    const newKey = generateWineKey(w.name, w.producer, canonical || '');
+    // A different wine already occupying the canonical key = a real duplicate.
+    const clash = await WineDefinition.findOne({ normalizedKey: newKey, _id: { $ne: w._id } }).select('_id').lean();
+    if (clash) {
+      stats.collisions += 1;
+      console.log(`  ⚠ collision (manual merge): "${w.name}" — ${w.producer} | "${w.appellation}" → "${canonical}" clashes with ${clash._id}`);
+      continue;
+    }
+
+    stats.changed += 1;
+    if (shown < 40) {
+      console.log(`${tag} "${w.name}" — ${w.producer}:  "${w.appellation}"  →  "${canonical}"`);
+      shown += 1;
+    }
+    backup.push({ _id: String(w._id), appellation: w.appellation, normalizedKey: w.normalizedKey });
+
+    if (APPLY) {
+      await WineDefinition.updateOne({ _id: w._id }, { $set: { appellation: canonical || null, normalizedKey: newKey } });
+      try { await require('../services/search').indexWine(w._id); } catch { /* best-effort */ }
+    }
+  }
+
+  if (APPLY && backup.length) {
+    const file = path.join(os.tmpdir(), `appellation-tiers-backup-${Date.now()}.json`);
+    fs.writeFileSync(file, JSON.stringify(backup, null, 2));
+    console.log(`\nBackup of ${backup.length} rows → ${file}`);
+  }
+
+  console.log(`\nSummary: ${stats.scanned} wines with an appellation, ${stats.changed} ${APPLY ? 'canonicalized' : 'would change'}, ${stats.same} already canonical, ${stats.collisions} collisions left for manual merge.`);
+  if (APPLY) console.log('Next: run the admin embedding job (appellation feeds the embed text); the appellation field + grouping update now.');
+  await mongoose.disconnect();
+}
+
+run().catch((err) => { console.error('Appellation cleanup failed:', err); process.exit(1); });

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -18,7 +18,7 @@ const Country = require('../models/Country');
 const Region = require('../models/Region');
 const Grape = require('../models/Grape');
 const searchService = require('./search');
-const { generateWineKey, normalizeString, resolveGrapeName, resolveCountryName, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
+const { generateWineKey, normalizeString, normalizeAppellation, resolveGrapeName, resolveCountryName, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
 const { stripProducerName } = require('../utils/producerPrefix');
 const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
@@ -139,7 +139,10 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   const MAX_FIELD = 200;
   let trimmedName = name.trim().slice(0, MAX_FIELD);
   const trimmedProducer = producer.trim().slice(0, MAX_FIELD);
-  const trimmedAppellation = (typeof appellation === 'string' ? appellation.trim() : '').slice(0, MAX_FIELD);
+  // Canonicalize the appellation (strip a trailing DOCG/DOC/AOC/… tier) so
+  // "Barolo" and "Barolo DOCG" resolve to / create ONE registry appellation
+  // instead of two (ticket #2C). The tier belongs in classification.
+  const trimmedAppellation = normalizeAppellation((typeof appellation === 'string' ? appellation.trim() : '')).slice(0, MAX_FIELD);
 
   // 0. Registry canon: a wine's name never embeds its producer. Cellar-format
   // imports and the occasional non-compliant AI response arrive as

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -54,6 +54,29 @@ const tokenize = (str) => {
   return tokens;
 };
 
+// Classification-tier suffixes some labels/imports append to an appellation and
+// others omit, splitting one appellation into variants ("Barolo" vs "Barolo
+// DOCG"). The tier belongs in the separate classification field, so the
+// canonical appellation is the place name with a trailing tier stripped. Only
+// unambiguous 3–4 char tiers — deliberately NOT 'do'/'ao', which collide with
+// real place-name words.
+const APPELLATION_TIER_RX = /[\s,]+(docg|doca|doc|aoc|aop|ava|igt|igp)\.?$/i;
+
+/**
+ * Canonicalize an appellation by stripping a trailing classification tier
+ * ("Barolo DOCG" → "Barolo", "Napa Valley AVA" → "Napa Valley"). Preserves the
+ * casing/spacing of the place part; never returns empty (falls back to the
+ * trimmed original). Passes null/undefined through unchanged.
+ */
+const normalizeAppellation = (appellation) => {
+  if (appellation == null) return appellation;
+  const original = String(appellation).trim();
+  let s = original;
+  let prev;
+  do { prev = s; s = s.replace(APPELLATION_TIER_RX, '').trim(); } while (s && s !== prev);
+  return s || original;
+};
+
 /**
  * Corporate / legal-form suffixes that vary between a wine label and a registry
  * entry for the SAME producer ("Kumeu River" vs "Kumeu River Wines Limited").
@@ -618,6 +641,7 @@ module.exports = {
   generateWineSlug,
   GRAPE_SYNONYMS,
   normalizeProducerKey,
+  normalizeAppellation,
   resolveGrapeName,
   resolveCountryName,
   isUnknownName,

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -60,21 +60,29 @@ const tokenize = (str) => {
 // canonical appellation is the place name with a trailing tier stripped. Only
 // unambiguous 3–4 char tiers — deliberately NOT 'do'/'ao', which collide with
 // real place-name words.
-const APPELLATION_TIER_RX = /[\s,]+(docg|doca|doc|aoc|aop|ava|igt|igp)\.?$/i;
+const APPELLATION_TIER_TOKENS = new Set(['docg', 'doca', 'doc', 'aoc', 'aop', 'ava', 'igt', 'igp']);
 
 /**
  * Canonicalize an appellation by stripping a trailing classification tier
  * ("Barolo DOCG" → "Barolo", "Napa Valley AVA" → "Napa Valley"). Preserves the
- * casing/spacing of the place part; never returns empty (falls back to the
+ * casing/accents of the place part; never returns empty (falls back to the
  * trimmed original). Passes null/undefined through unchanged.
+ *
+ * Token-based (no trailing-quantifier regex) so it stays strictly linear.
  */
 const normalizeAppellation = (appellation) => {
   if (appellation == null) return appellation;
   const original = String(appellation).trim();
-  let s = original;
-  let prev;
-  do { prev = s; s = s.replace(APPELLATION_TIER_RX, '').trim(); } while (s && s !== prev);
-  return s || original;
+  const parts = original.split(/\s+/);
+  // Drop trailing tier token(s), tolerating a trailing dot/comma on each.
+  while (parts.length > 1) {
+    const last = parts[parts.length - 1].replace(/[.,]+$/, '').toLowerCase();
+    if (!APPELLATION_TIER_TOKENS.has(last)) break;
+    parts.pop();
+  }
+  let result = parts.join(' ').trim();
+  while (result.endsWith(',')) result = result.slice(0, -1).trim();
+  return result || original;
 };
 
 /**

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -62,13 +62,21 @@ const tokenize = (str) => {
 // real place-name words.
 const APPELLATION_TIER_TOKENS = new Set(['docg', 'doca', 'doc', 'aoc', 'aop', 'ava', 'igt', 'igp']);
 
+// Strip trailing characters (any in `chars`) without a `$`-anchored quantifier
+// regex — a plain scan, so it can never be a polynomial-ReDoS shape.
+const trimTrailingChars = (str, chars) => {
+  let end = str.length;
+  while (end > 0 && chars.includes(str[end - 1])) end -= 1;
+  return str.slice(0, end);
+};
+
 /**
  * Canonicalize an appellation by stripping a trailing classification tier
  * ("Barolo DOCG" → "Barolo", "Napa Valley AVA" → "Napa Valley"). Preserves the
  * casing/accents of the place part; never returns empty (falls back to the
  * trimmed original). Passes null/undefined through unchanged.
  *
- * Token-based (no trailing-quantifier regex) so it stays strictly linear.
+ * Token-based + regex-free trailing strip, so it stays strictly linear.
  */
 const normalizeAppellation = (appellation) => {
   if (appellation == null) return appellation;
@@ -76,12 +84,11 @@ const normalizeAppellation = (appellation) => {
   const parts = original.split(/\s+/);
   // Drop trailing tier token(s), tolerating a trailing dot/comma on each.
   while (parts.length > 1) {
-    const last = parts[parts.length - 1].replace(/[.,]+$/, '').toLowerCase();
+    const last = trimTrailingChars(parts[parts.length - 1], '.,').toLowerCase();
     if (!APPELLATION_TIER_TOKENS.has(last)) break;
     parts.pop();
   }
-  let result = parts.join(' ').trim();
-  while (result.endsWith(',')) result = result.slice(0, -1).trim();
+  const result = trimTrailingChars(parts.join(' '), ' ,').trim();
   return result || original;
 };
 

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -3,6 +3,7 @@ const {
   tokenize,
   normalizeProducerKey,
   generateWineKey,
+  normalizeAppellation,
   levenshteinDistance,
   calculateSimilarity,
   generateTrigrams,
@@ -79,6 +80,32 @@ describe('tokenize', () => {
 });
 
 // ─── generateWineKey ─────────────────────────────────────────────────────────
+
+describe('normalizeAppellation (ticket #2C: tier-suffix proliferation)', () => {
+  test('strips the trailing classification tier', () => {
+    expect(normalizeAppellation('Barolo DOCG')).toBe('Barolo');
+    expect(normalizeAppellation('Barolo')).toBe('Barolo');
+    expect(normalizeAppellation('Napa Valley AVA')).toBe('Napa Valley');
+    expect(normalizeAppellation('Chianti Classico DOCG')).toBe('Chianti Classico');
+    expect(normalizeAppellation('Rueda, DO')).toBe('Rueda, DO'); // 'do' deliberately NOT stripped
+  });
+
+  test('the two Barolo variants converge to one canonical form', () => {
+    expect(normalizeAppellation('Barolo DOCG')).toBe(normalizeAppellation('Barolo'));
+  });
+
+  test('does not strip a tier token that is part of the place name', () => {
+    // No trailing tier here — "Classico" is part of the name, left intact.
+    expect(normalizeAppellation('Chianti Classico')).toBe('Chianti Classico');
+  });
+
+  test('passes null/undefined through and never returns empty', () => {
+    expect(normalizeAppellation(null)).toBeNull();
+    expect(normalizeAppellation(undefined)).toBeUndefined();
+    expect(normalizeAppellation('DOCG')).toBe('DOCG'); // all-tier input preserved, not emptied
+    expect(normalizeAppellation('   Barolo   DOCG ')).toBe('Barolo');
+  });
+});
 
 describe('generateWineKey', () => {
   test('produces a consistent colon-delimited key', () => {


### PR DESCRIPTION
Ticket #2C (registry data quality — appellation proliferation). Confirmed on prod: the same Barolo appellation is stored as both `Barolo` (3 wines) and `Barolo DOCG` (7 wines).

## Fix
New `normalizeAppellation()` strips a trailing **DOCG/DOCa/DOC/AOC/AOP/AVA/IGT/IGP** tier — the tier belongs in the `classification` field, so the canonical appellation is the place name (accents/casing preserved). Only unambiguous 3–4 char tiers; deliberately **not** `do`/`ao` (collide with real place-name words).

**Prevention** wired into every write path (the plan flagged the LWIN import as easy to miss):
- `findOrCreateWine` (covers label scan + cellar/CSV import + MCP add/bulk)
- `admin/wines` POST + PUT
- `admin/import.js`

**Cleanup** `scripts/normalize-appellation-tiers.js`, dry-run by default. Appellation is part of the unique `normalizedKey`, so it recomputes the key and **SKIPS + reports the rare collision** (a genuine same-producer+name duplicate) for manual merge — it never merges wines itself. `--apply` writes a backup + re-indexes Meili.

`generateWineSlug` uses name+producer only → `/wines/:slug` URLs unaffected; bottles carry no denormalized appellation.

## Verified
- `normalizeAppellation` unit tests (Barolo variants converge, tier-in-name preserved, null passthrough, no-empty guard).
- import + MCP-write suites green (**207 tests**) on Node 24.
- Dry-run on dev data: **678 canonicalized / 2432 already clean / 0 collisions**; accents preserved ("Château Grillet AOC" → "Château Grillet", "Toscana IGT" → "Toscana").

## Deploy (after merge + release)
1. `docker exec cellarion-backend node src/scripts/normalize-appellation-tiers.js` (dry-run)
2. `… --apply`
3. Run the admin embedding job (appellation feeds the embed text). Appellation field + grouping update immediately.