### PR TITLE
release: v1.85.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.84.0",
+  "version": "1.85.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.84.0",
+      "version": "1.85.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.84.0",
+  "version": "1.85.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.84.0",
+  "version": "1.85.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.84.0",
+      "version": "1.85.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.84.0",
+  "version": "1.85.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v1.85.0** — support-ticket fixes for semantic search + registry data quality.

## What's in this release (4 PRs since v1.84.0)
- **#796** — `semantic_search_wines` tells callers to query in English (ticket #1: non-English queries matched poorly against the English taste-profile corpus).
- **#797** — infer grapes from the wine name when none supplied + backfill script (ticket #2A: wines like "…Pinot Noir" had empty `grapes[]` and dropped out of Statistics/filters). 17 unit tests pin the mis-tag traps.
- **#798** — bucket producer variants together in the admin duplicate-clusters scan (ticket #2B: "Kumeu River" vs "Kumeu River Wines Limited" now surface in the merge UI).
- **#799** — canonicalize appellations by stripping the tier suffix + backfill script (ticket #2C: "Barolo" vs "Barolo DOCG").

## Verification
Full backend suite **143 suites / 2134 tests** green on Node 24 (the merged main). Each PR passed the full CI gate incl. CodeQL.

## Post-deploy data steps (run on prod after the flip)
Both dry-run-first, then an embedding-job refresh:
1. `backfill-wine-grapes-from-name.js` (dry-run → `--apply`)
2. `normalize-appellation-tiers.js` (dry-run → `--apply`)
3. Admin embedding job (grapes + appellation feed the embed text; Statistics + Mongo filters update immediately).

No schema changes. No env changes.