### PR TITLE
fix(registry): recognize producer variants in dedup matching

### DIFF
--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -41,7 +41,7 @@ const { submitUrls } = require('../../services/indexNow');
 const { isValidId } = require('../../utils/validation');
 const { escapeRegex } = require('../../utils/sanitize');
 const { parsePagination } = require('../../utils/pagination');
-const { stripProducerName } = require('../../utils/producerPrefix');
+const { stripProducerName, stripProducerKeyPrefix } = require('../../utils/producerPrefix');
 
 const router = express.Router();
 
@@ -555,13 +555,15 @@ router.get('/duplicates', async (req, res) => {
 // GET /api/admin/wines/producer-in-name — wines whose name STARTS or ENDS
 // with their own producer (prefix: producer "Meerlust", name "Meerlust
 // Chardonnay"; suffix: producer "Mastroberardino", name "Fiano di Avellino
-// Mastroberardino" — the launch-day admin report). Mostly AI-import
-// artefacts; the registry convention is a producer-free name.
+// Mastroberardino" — the launch-day admin report), INCLUDING producer
+// variants where only the comparison-key tokens are embedded (name "Felton
+// Road Block 3 Pinot Noir", producer "Felton Road Wines Ltd" — the shape the
+// old exact-string $expr scan could never see). Mostly AI-import artefacts;
+// the registry convention is a producer-free name.
 //
-// A field-to-field comparison needs $expr; there's no index for it, so this
-// is a collection scan — fine at the registry's ~3k-doc size. The char right
-// AFTER a prefix / BEFORE a suffix must be a separator so producer "Chateau"
-// doesn't flag "Chateauneuf-du-Pape" (mirrors utils/producerPrefix.js).
+// The key-token check has no aggregation mirror, so the scan runs in Node —
+// same full-fetch pattern (and cost) as the duplicate-clusters scan above,
+// fine at the registry's ~4k-doc size.
 //
 // Returns: { wines: [{ _id, producer, name, proposedName, bottleCount, createdAt }], total, page, pages }
 router.get('/producer-in-name', async (req, res) => {
@@ -569,57 +571,37 @@ router.get('/producer-in-name', async (req, res) => {
     const { limit: parsedLimit, offset: skip, page: parsedPage } =
       parsePagination(req.query, { limit: 50, maxLimit: 200 });
 
-    const producerLen = { $strLenCP: { $ifNull: ['$producer', ''] } };
-    const nameLen = { $strLenCP: '$name' };
-    const lowerProducer = { $toLower: { $ifNull: ['$producer', ''] } };
-    const SEPARATORS = [' ', '\t', '-', '–', '—'];
-    const common = [
-      { $gt: [producerLen, 0] },
-      { $gt: [nameLen, { $add: [producerLen, 1] }] },
-    ];
-    const prefixExpr = {
-      $and: [
-        ...common,
-        { $eq: [{ $indexOfCP: [{ $toLower: '$name' }, lowerProducer] }, 0] },
-        { $in: [{ $substrCP: ['$name', producerLen, 1] }, SEPARATORS] },
-      ],
-    };
-    const suffixStart = { $subtract: [nameLen, producerLen] };
-    const suffixExpr = {
-      $and: [
-        ...common,
-        { $eq: [{ $toLower: { $substrCP: ['$name', suffixStart, producerLen] } }, lowerProducer] },
-        { $in: [{ $substrCP: ['$name', { $subtract: [suffixStart, 1] }, 1] }, SEPARATORS] },
-      ],
-    };
-    const filter = { $expr: { $or: [prefixExpr, suffixExpr] } };
+    const all = await WineDefinition.find({})
+      .select('name producer createdAt')
+      .sort({ producer: 1, name: 1 })
+      .lean();
 
-    const [wines, total] = await Promise.all([
-      WineDefinition.find(filter)
-        .select('name producer createdAt')
-        .sort({ producer: 1, name: 1 })
-        .skip(skip)
-        .limit(parsedLimit)
-        .lean(),
-      WineDefinition.countDocuments(filter),
-    ]);
+    const flagged = [];
+    for (const w of all) {
+      const proposedName = stripProducerName(w.name, w.producer)
+        ?? stripProducerKeyPrefix(w.name, w.producer);
+      if (proposedName) flagged.push({ ...w, proposedName });
+    }
+
+    const total = flagged.length;
+    const pageRows = flagged.slice(skip, skip + parsedLimit);
 
     // Bottle counts for the page's rows in one aggregate
     const bottleCounts = new Map();
-    if (wines.length > 0) {
+    if (pageRows.length > 0) {
       const counts = await Bottle.aggregate([
-        { $match: { wineDefinition: { $in: wines.map(w => w._id) } } },
+        { $match: { wineDefinition: { $in: pageRows.map(w => w._id) } } },
         { $group: { _id: '$wineDefinition', count: { $sum: 1 } } },
       ]);
       for (const c of counts) bottleCounts.set(String(c._id), c.count);
     }
 
     res.json({
-      wines: wines.map(w => ({
+      wines: pageRows.map(w => ({
         _id: w._id,
         producer: w.producer,
         name: w.name,
-        proposedName: stripProducerName(w.name, w.producer),
+        proposedName: w.proposedName,
         bottleCount: bottleCounts.get(String(w._id)) || 0,
         createdAt: w.createdAt,
       })),
@@ -843,21 +825,25 @@ router.post('/:id/strip-producer', async (req, res) => {
       return res.status(404).json({ error: 'Wine not found' });
     }
 
-    const stripped = stripProducerName(wine.name, wine.producer);
+    const stripped = stripProducerName(wine.name, wine.producer)
+      ?? stripProducerKeyPrefix(wine.name, wine.producer);
     if (!stripped) {
       return res.status(400).json({
         error: 'Wine name does not start or end with its producer, or nothing would remain after stripping'
       });
     }
 
-    // If the same producer already has a wine with the stripped name, renaming
-    // would create the very duplicate the registry avoids — the admin should
-    // resolve that pair via the duplicates tool instead.
-    const conflict = await WineDefinition.findOne({
+    // If the same producer — under ANY spelling that shares the comparison key
+    // ("Felton Road" vs "Felton Road Wines Ltd") — already has a wine with the
+    // stripped name, renaming would just surface the very duplicate the
+    // registry avoids: the admin should MERGE that pair via the duplicates
+    // tool instead (the merge keeps bottles; a rename would collide).
+    const producerKey = normalizeProducerKey(wine.producer);
+    const nameTwins = await WineDefinition.find({
       _id: { $ne: wine._id },
-      producer: new RegExp(`^${escapeRegex(wine.producer)}$`, 'i'),
       name: new RegExp(`^${escapeRegex(stripped)}$`, 'i'),
-    }).select('name producer');
+    }).select('name producer').limit(10).lean();
+    const conflict = nameTwins.find(t => producerKey && normalizeProducerKey(t.producer) === producerKey);
     if (conflict) {
       return res.status(409).json({
         error: `"${conflict.name}" by ${conflict.producer} already exists — merge these via the duplicates tool instead.`,

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -20,7 +20,7 @@ const Grape = require('../models/Grape');
 const searchService = require('./search');
 const { generateWineKey, normalizeString, normalizeAppellation, resolveGrapeName, resolveCountryName, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
-const { stripProducerName } = require('../utils/producerPrefix');
+const { stripProducerName, stripProducerKeyPrefix } = require('../utils/producerPrefix');
 const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
 const { escapeRegex } = require('../utils/sanitize');
 
@@ -150,12 +150,34 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // "Fiano di Avellino Mastroberardino" (the launch-day admin report) —
   // canonicalize BEFORE any matching so that input resolves to (or creates)
   // the producer-free entry instead of minting a producer-in-name duplicate
-  // the admin tool has to clean up later. Loop: concatenated sources can
-  // repeat the producer on either end.
-  for (let rest = stripProducerName(trimmedName, trimmedProducer); rest;
-       rest = stripProducerName(trimmedName, trimmedProducer)) {
+  // the admin tool has to clean up later. The key-prefix twin also catches
+  // producer VARIANTS — name "Felton Road Block 3 Pinot Noir" with producer
+  // "Felton Road Wines Ltd" — which the exact-string strip can't see (the
+  // shape behind most July-2026 prod duplicates). Loop: concatenated sources
+  // can repeat the producer on either end.
+  for (let rest = stripProducerName(trimmedName, trimmedProducer)
+         ?? stripProducerKeyPrefix(trimmedName, trimmedProducer);
+       rest;
+       rest = stripProducerName(trimmedName, trimmedProducer)
+         ?? stripProducerKeyPrefix(trimmedName, trimmedProducer)) {
     trimmedName = rest;
   }
+
+  // Different-country guard for every non-exact auto-link below: an identical
+  // canonical producer+name can still be two wineries (Domaine Chandon, Napa
+  // vs Bodegas Chandon, Mendoza — the "Garden Spritz" false positive). When
+  // BOTH sides state a country and they disagree, never link silently — fall
+  // through so the soft zone (or creation) decides.
+  const queryCountryKey = (typeof country === 'string' && country.trim() && !isUnknownName(country))
+    ? normalizeString(resolveCountryName(country))
+    : '';
+  const conflictsCountry = (candidate) => {
+    if (!queryCountryKey) return false;
+    const candidateCountry = candidate && candidate.country && candidate.country.name
+      ? normalizeString(candidate.country.name)
+      : '';
+    return Boolean(candidateCountry && candidateCountry !== queryCountryKey);
+  };
 
   // 1. Exact match by normalizedKey
   const normalizedKey = generateWineKey(trimmedName, trimmedProducer, trimmedAppellation);
@@ -176,7 +198,9 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
     const siblings = await WineDefinition.find({ normalizedKey: new RegExp(`^${escapeRegex(siblingPrefix)}`) })
       .limit(2)
       .populate(POPULATE);
-    if (siblings.length === 1) return { wine: siblings[0], created: false };
+    if (siblings.length === 1 && !conflictsCountry(siblings[0])) {
+      return { wine: siblings[0], created: false };
+    }
   }
 
   // 2. Fuzzy similarity search
@@ -212,9 +236,12 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
       { redistribute: false }
     );
 
-    // Auto-match: top score is confident enough
-    if (ranked[0].score >= SIMILARITY_THRESHOLD) {
-      return { wine: ranked[0].wine, created: false };
+    // Auto-match: best confident hit that doesn't conflict on country. A
+    // conflicting >=0.95 candidate falls through to the soft zone below, so
+    // the caller/user still sees it — it just never links silently.
+    const autoHit = ranked.find(r => r.score >= SIMILARITY_THRESHOLD && !conflictsCountry(r.wine));
+    if (autoHit) {
+      return { wine: autoHit.wine, created: false };
     }
 
     // Soft zone: top score is suggestive but not confident. Surface up to N

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -215,6 +215,110 @@ describe('findOrCreateWine — producer-prefix canonicalization (step 0)', () =>
   });
 });
 
+describe('findOrCreateWine — producer-VARIANT key-prefix canonicalization (step 0, dup analysis 2026-07-22)', () => {
+  // The exact-string strip is blind when the producer field is a variant:
+  // name "Felton Road Block 3 Pinot Noir" + producer "Felton Road Wines Ltd"
+  // never matched, minted a duplicate, and scored just 0.62 against the real
+  // record — the shape behind most July-2026 prod duplicates. The key-token
+  // prefix strip closes it.
+  test('variant producer key prefix is stripped before the exact-key lookup', async () => {
+    WineDefinition.findOne.mockReturnValue(findOneChain(EXISTING_WINE));
+
+    const result = await findOrCreateWine(
+      { ...INPUT, name: 'Felton Road Block 3 Pinot Noir', producer: 'Felton Road Wines Ltd', appellation: 'Bannockburn' },
+      USER_ID
+    );
+
+    expect(WineDefinition.findOne).toHaveBeenCalledWith({
+      normalizedKey: generateWineKey('Block 3 Pinot Noir', 'Felton Road Wines Ltd', 'Bannockburn'),
+    });
+    expect(result).toEqual({ wine: EXISTING_WINE, created: false });
+  });
+
+  test('created wines store the key-stripped name', async () => {
+    const result = await findOrCreateWine(
+      { ...INPUT, name: 'Maude Kids Block Pinot Noir', producer: 'Maude Wines' },
+      USER_ID
+    );
+
+    expect(result.created).toBe(true);
+    expect(WineDefinition.mock.calls[0][0].name).toBe('Kids Block Pinot Noir');
+  });
+
+  test('a name ENDING with the producer key is left alone — "Les Forts de Latour" is a real wine name', async () => {
+    await findOrCreateWine(
+      { ...INPUT, name: 'Les Forts de Latour', producer: 'Château Latour', appellation: 'Pauillac' },
+      USER_ID
+    );
+
+    expect(WineDefinition.mock.calls[0][0].name).toBe('Les Forts de Latour');
+  });
+});
+
+describe('findOrCreateWine — different-country guard', () => {
+  // Identical canonical producer+name can still be two wineries (Domaine
+  // Chandon, Napa vs Bodegas Chandon, Mendoza — the Garden Spritz false
+  // positive). A stated-and-conflicting country must block every silent link.
+  const QUERY = {
+    name: 'Garden Spritz',
+    producer: 'Chandon',
+    country: 'United States',
+    region: '',
+    appellation: 'Napa Valley',
+    type: 'sparkling',
+    grapes: ['Chardonnay'],
+  };
+
+  test('a single sibling with a conflicting country is NOT auto-linked (falls through to create)', async () => {
+    const sibling = { _id: 'wine-ar', name: 'Garden Spritz', country: { name: 'Argentina' } };
+    primeFind({ siblings: [sibling] });
+
+    const result = await findOrCreateWine(QUERY, USER_ID);
+
+    expect(result.created).toBe(true);
+    expect(result.wine).not.toBe(sibling);
+  });
+
+  test('a single sibling with the SAME country still auto-links — aliases resolve ("USA" = "United States")', async () => {
+    const sibling = { _id: 'wine-us', name: 'Garden Spritz', country: { name: 'United States' } };
+    primeFind({ siblings: [sibling] });
+
+    const result = await findOrCreateWine({ ...QUERY, country: 'USA' }, USER_ID);
+
+    expect(result).toEqual({ wine: sibling, created: false });
+  });
+
+  test('a >=0.95 fuzzy hit with a conflicting country falls to the soft zone instead of auto-linking', async () => {
+    const candidate = { _id: 'wine-ar', name: 'Garden Spritz', country: { name: 'Argentina' } };
+    primeCandidates([{ wine: candidate, score: 0.96 }]);
+
+    const result = await findOrCreateWine(QUERY, USER_ID);
+
+    expect(result.wine).toBeNull();
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0].wine).toBe(candidate);
+  });
+
+  test('auto-match skips a conflicting-country candidate but takes the next confident one', async () => {
+    const wrongCountry = { _id: 'wine-ar', name: 'Garden Spritz', country: { name: 'Argentina' } };
+    const rightCountry = { _id: 'wine-us', name: 'Garden Spritz', country: { name: 'United States' } };
+    primeCandidates([{ wine: wrongCountry, score: 0.97 }, { wine: rightCountry, score: 0.96 }]);
+
+    const result = await findOrCreateWine(QUERY, USER_ID);
+
+    expect(result).toEqual({ wine: rightCountry, created: false });
+  });
+
+  test('with confirmCreate, a conflicting-country near-match creates the new wine', async () => {
+    const candidate = { _id: 'wine-ar', name: 'Garden Spritz', country: { name: 'Argentina' } };
+    primeCandidates([{ wine: candidate, score: 0.96 }]);
+
+    const result = await findOrCreateWine(QUERY, USER_ID, { confirmCreate: true });
+
+    expect(result.created).toBe(true);
+  });
+});
+
 describe('findOrCreateWine — sibling match (step 1b)', () => {
   // Same producer + same canonical name but a different appellation granularity
   // ("Cromwell" vs "Central Otago") misses the exact key and fuzzy-scores ~0.90

--- a/backend/src/services/wineMatching.js
+++ b/backend/src/services/wineMatching.js
@@ -7,9 +7,24 @@
  * Composite score = name × 0.45 + producer × 0.45 + appellation × 0.10
  */
 
-const { combinedSimilarity, normalizeString } = require('../utils/normalize');
+const { combinedSimilarity, normalizeString, normalizeProducerKey } = require('../utils/normalize');
 
 const WEIGHTS = { name: 0.45, producer: 0.45, appellation: 0.10 };
+
+/**
+ * Producer-axis similarity, compared on producer KEYS ("Kumeu River Wines
+ * Limited" → "kumeu river") instead of raw strings. Corporate suffixes and
+ * house prefixes used to drag the SAME winery to ~0.5 similarity, which put a
+ * producer-variant duplicate at ~0.77 composite — under the soft zone, so it
+ * was silently created (registry duplicate analysis 2026-07-22). On equal keys
+ * the axis now scores 1. Falls back to the raw comparison whenever either side
+ * has no key left (an all-stopword producer like "Domaine").
+ */
+function producerSimilarity(a, b) {
+  const keyA = normalizeProducerKey(a || '');
+  const keyB = normalizeProducerKey(b || '');
+  return keyA && keyB ? combinedSimilarity(keyA, keyB) : combinedSimilarity(a, b);
+}
 
 /**
  * Score a single wine candidate against a query.
@@ -23,7 +38,7 @@ const WEIGHTS = { name: 0.45, producer: 0.45, appellation: 0.10 };
  */
 function scoreWineMatch(candidate, query, { redistribute = true } = {}) {
   const nameScore     = combinedSimilarity(candidate.name, query.name);
-  const producerScore = combinedSimilarity(candidate.producer, query.producer);
+  const producerScore = producerSimilarity(candidate.producer, query.producer);
 
   let score = nameScore * WEIGHTS.name + producerScore * WEIGHTS.producer;
 

--- a/backend/src/services/wineMatching.test.js
+++ b/backend/src/services/wineMatching.test.js
@@ -90,6 +90,41 @@ describe('scoreWineMatch', () => {
   });
 });
 
+// ─── producer variants — comparison-key axis (dup analysis 2026-07-22) ──────
+
+describe('scoreWineMatch — producer variants', () => {
+  test('corporate-suffix variant of the same producer scores as an exact producer match', () => {
+    // Raw-string comparison used to score this ~0.77 — below the soft zone, so
+    // the duplicate was created silently. Key comparison makes it auto-match.
+    const candidate = { name: "Mate's Vineyard Chardonnay", producer: 'Kumeu River', appellation: 'Kumeu' };
+    const query = { name: "Mate's Vineyard Chardonnay", producer: 'Kumeu River Wines Limited', appellation: 'Kumeu' };
+    expect(scoreWineMatch(candidate, query)).toBeGreaterThanOrEqual(0.95);
+  });
+
+  test('house-prefix variant (Weingut …) scores as the same producer', () => {
+    const candidate = { name: 'Grüner Veltliner', producer: 'Steininger', appellation: 'Kamptal' };
+    const query = { name: 'Grüner Veltliner', producer: 'Weingut Steininger', appellation: 'Kamptal' };
+    expect(scoreWineMatch(candidate, query)).toBeGreaterThanOrEqual(0.95);
+  });
+
+  test('shared producer key but different appellation lands in the ASK zone, not auto-match', () => {
+    // The Garden Spritz shape: two REAL wineries share the key "chandon".
+    // The differing appellation must keep this under 0.95 so callers ask
+    // instead of silently linking two distinct wineries.
+    const candidate = { name: 'Garden Spritz', producer: 'Domaine Chandon', appellation: 'Napa Valley' };
+    const query = { name: 'Garden Spritz', producer: 'Bodegas Chandon', appellation: 'Mendoza' };
+    const score = scoreWineMatch(candidate, query);
+    expect(score).toBeLessThan(0.95);
+    expect(score).toBeGreaterThanOrEqual(0.85);
+  });
+
+  test('genuinely different producers still score far apart', () => {
+    const candidate = { name: 'Pinot Noir', producer: 'Felton Road', appellation: 'Bannockburn' };
+    const query = { name: 'Pinot Noir', producer: 'Cloudy Bay', appellation: 'Bannockburn' };
+    expect(scoreWineMatch(candidate, query)).toBeLessThan(0.85);
+  });
+});
+
 // ─── findBestMatch ───────────────────────────────────────────────────────────
 
 describe('findBestMatch', () => {

--- a/backend/src/utils/producerPrefix.js
+++ b/backend/src/utils/producerPrefix.js
@@ -1,3 +1,5 @@
+const { normalizeString, normalizeProducerKey, tokenize } = require('./normalize');
+
 /**
  * Detect and strip a redundant producer prefix from a wine name.
  *
@@ -59,4 +61,45 @@ function stripProducerName(name, producer) {
   return stripProducerPrefix(name, producer) ?? stripProducerSuffix(name, producer);
 }
 
-module.exports = { stripProducerPrefix, stripProducerSuffix, stripProducerName };
+/**
+ * Variant-tolerant twin of stripProducerPrefix: strips the producer's
+ * COMPARISON-KEY tokens off the FRONT of a name, so the exact-string blind
+ * spot — name "Felton Road Block 3 Pinot Noir" with producer "Felton Road
+ * Wines Ltd" — still canonicalizes (registry duplicate analysis 2026-07-22:
+ * every observed variant embed was a prefix).
+ *
+ * Rules, in order:
+ *   - Leading words that normalize away entirely (house/stop words: "Fattoria",
+ *     "La", "Weingut") may precede the key run — they belong to the producer
+ *     reference even though the comparison key drops them.
+ *   - The FULL key-token run must then match word-for-word (normalized), so a
+ *     partial producer overlap never strips.
+ *   - Something meaningful must remain.
+ *   - Suffixes are deliberately NOT handled here: legitimate wine names END
+ *     with the producer key ("Les Forts de Latour" — Château Latour), so
+ *     suffix stripping stays exact-string only (stripProducerSuffix).
+ *
+ * Operates on whitespace-split display words and compares their normalized
+ * forms, so the remainder keeps its original casing and punctuation.
+ *
+ * @returns {string|null} the cleaned name, or null when no safe strip applies.
+ */
+function stripProducerKeyPrefix(name, producer) {
+  const n = typeof name === 'string' ? name.trim() : '';
+  if (!n) return null;
+  const keyTokens = normalizeProducerKey(producer || '').split(' ').filter(Boolean);
+  if (keyTokens.length === 0) return null;
+
+  const words = n.split(/\s+/);
+  let start = 0;
+  while (start < words.length && tokenize(words[start]).length === 0) start += 1;
+  if (start + keyTokens.length >= words.length) return null; // nothing meaningful would remain
+  for (let i = 0; i < keyTokens.length; i++) {
+    if (normalizeString(words[start + i]) !== keyTokens[i]) return null;
+  }
+
+  const remainder = words.slice(start + keyTokens.length).join(' ').replace(/^[\s\-–—]+/, '').trim();
+  return remainder.length > 0 ? remainder : null;
+}
+
+module.exports = { stripProducerPrefix, stripProducerSuffix, stripProducerName, stripProducerKeyPrefix };

--- a/backend/src/utils/producerPrefix.test.js
+++ b/backend/src/utils/producerPrefix.test.js
@@ -82,3 +82,59 @@ describe('stripProducerSuffix', () => {
     expect(stripProducerName('Chardonnay', 'Meerlust')).toBeNull();
   });
 });
+
+// ── Key-token twin: producer VARIANTS (registry duplicate analysis 2026-07-22) ─
+describe('stripProducerKeyPrefix', () => {
+  const { stripProducerKeyPrefix } = require('./producerPrefix');
+
+  test('strips the key run when the producer string is a variant — the July prod duplicates', () => {
+    expect(stripProducerKeyPrefix('Felton Road Block 3 Pinot Noir', 'Felton Road Wines Ltd'))
+      .toBe('Block 3 Pinot Noir');
+    expect(stripProducerKeyPrefix('Maude Kids Block Pinot Noir', 'Maude Wines'))
+      .toBe('Kids Block Pinot Noir');
+    expect(stripProducerKeyPrefix('St Hugo Cabernet Sauvignon', 'St Hugo Wines'))
+      .toBe('Cabernet Sauvignon');
+    expect(stripProducerKeyPrefix('Cloudy Bay Sauvignon Blanc', 'Cloudy Bay Vineyards'))
+      .toBe('Sauvignon Blanc');
+  });
+
+  test('skips leading house/stop words that the comparison key drops', () => {
+    // key("La Vialla") = "vialla"; "Fattoria" and "La" belong to the producer reference
+    expect(stripProducerKeyPrefix('Fattoria La Vialla Chianti', 'La Vialla')).toBe('Chianti');
+    // key("La Rioja Alta, S.A.") = "rioja alta"
+    expect(stripProducerKeyPrefix('La Rioja Alta Gran Reserva 904', 'La Rioja Alta, S.A.'))
+      .toBe('Gran Reserva 904');
+  });
+
+  test('preserves original casing and punctuation of the remainder', () => {
+    expect(stripProducerKeyPrefix("Miner Family The Iliad", 'Miner Family Winery'))
+      .toBe('The Iliad');
+  });
+
+  test('never strips a SUFFIX — legitimate names end with the producer key', () => {
+    // "Les Forts de Latour" IS the second wine's name; key("Château Latour") = "latour"
+    expect(stripProducerKeyPrefix('Les Forts de Latour', 'Château Latour')).toBeNull();
+  });
+
+  test('requires the FULL key run — partial producer overlap never strips', () => {
+    expect(stripProducerKeyPrefix('Felton Something Pinot Noir', 'Felton Road Wines Ltd')).toBeNull();
+    expect(stripProducerKeyPrefix('Block 3 Pinot Noir', 'Felton Road Wines Ltd')).toBeNull();
+  });
+
+  test('never strips to nothing', () => {
+    expect(stripProducerKeyPrefix('Felton Road', 'Felton Road Wines Ltd')).toBeNull();
+    expect(stripProducerKeyPrefix('Fattoria La Vialla', 'La Vialla')).toBeNull();
+  });
+
+  test('word-boundary safe — a producer key inside a longer word never strips', () => {
+    // normalize("Felton-Road") = "feltonroad" ≠ token "felton"
+    expect(stripProducerKeyPrefix('Felton-Road Block 3', 'Felton Road Wines Ltd')).toBeNull();
+  });
+
+  test('returns null for empty inputs or an all-stopword producer', () => {
+    expect(stripProducerKeyPrefix('', 'Felton Road Wines Ltd')).toBeNull();
+    expect(stripProducerKeyPrefix('Chardonnay Reserve', 'Domaine')).toBeNull();
+    expect(stripProducerKeyPrefix(null, 'Felton Road')).toBeNull();
+    expect(stripProducerKeyPrefix('Felton Road Riesling', undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

`REGISTRY_DUPLICATE_ANALYSIS_2026-07-22.md`: 25 duplicate sets (~246 bottles) on prod, 20 members minted in July — the leak is active. Root cause: every matching layer compares RAW producer strings, so a corporate-suffix variant of the same winery ("Felton Road Wines Ltd" vs "Felton Road") craters the 0.45-weighted producer axis and the identical wine scores 0.62–0.77 — under the 0.85 soft zone — and is created silently.

## What

- **Producer axis on comparison keys** — `scoreWineMatch` compares `normalizeProducerKey()` output; same-winery variants score 1.0 → auto-match at ≥0.95. Raw fallback for all-stopword producers.
- **Step-0 variant strip** — new `stripProducerKeyPrefix`: strips the producer KEY-token run (plus leading house/stop words) off the FRONT of a name. Prefix-only by design — legitimate names END with the producer key ("Les Forts de Latour").
- **Different-country guard** — identical canonical producer+name can be two wineries (Domaine Chandon Napa vs Bodegas Chandon Mendoza). A stated, conflicting country demotes sibling/fuzzy auto-links to the soft zone; nothing links silently.
- **Admin tooling sees variants** — producer-in-name scan (now a Node scan; the key check has no `$expr` mirror) + strip endpoint propose variant strips; strip conflict check compares producer keys and routes to the merge tool.

## UX invariant

No new prompts for clean inputs: variant inputs that used to silently duplicate now silently **match** (fewer prompts, richer records). The only added ask is the genuinely-ambiguous different-country shape.

## Tests

Backend in node:24-alpine: **143 suites / 2154 tests green.** New pins: 0.77-Kumeu and 0.62-Felton must auto-match; Garden Spritz shape must ask, never link; suffix immunity; strip edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)