### PR TITLE
feat(registry): canonical wine identity — lookup-first duplicate prevention

### DIFF
--- a/backend/src/models/WineDefinition.canonicalKey.test.js
+++ b/backend/src/models/WineDefinition.canonicalKey.test.js
@@ -1,0 +1,52 @@
+/**
+ * The pre-validate hook keeps canonicalKey in sync with the identity fields —
+ * every save-based write path (create, admin rename, strip-producer) gets the
+ * fresh key without remembering to compute it. No DB needed: doc.validate()
+ * runs the pre-validate middleware.
+ */
+const mongoose = require('mongoose');
+const WineDefinition = require('./WineDefinition');
+const { computeCanonicalKey } = require('../utils/wineIdentity');
+
+const oid = () => new mongoose.Types.ObjectId();
+
+const baseDoc = (overrides = {}) => new WineDefinition({
+  name: 'Felton Road Block 3 Pinot Noir',
+  producer: 'Felton Road Wines Ltd',
+  appellation: 'Bannockburn',
+  country: oid(),
+  createdBy: oid(),
+  normalizedKey: 'raw:key:x',
+  ...overrides,
+});
+
+test('computes canonicalKey on new docs — variant input collapses to the canonical identity', async () => {
+  const doc = baseDoc();
+  await doc.validate();
+  expect(doc.canonicalKey).toBe('felton road:block 3 pinot noir:bannockburn');
+  expect(doc.canonicalKey).toBe(computeCanonicalKey(doc.name, doc.producer, doc.appellation));
+});
+
+test('recomputes on rename', async () => {
+  const doc = baseDoc({ name: 'Old Name', appellation: null });
+  await doc.validate();
+  expect(doc.canonicalKey).toBe('felton road:old name:');
+
+  doc.name = 'Block 5 Pinot Noir';
+  await doc.validate();
+  expect(doc.canonicalKey).toBe('felton road:block 5 pinot noir:');
+});
+
+test('recomputes on producer and appellation changes', async () => {
+  const doc = baseDoc();
+  await doc.validate();
+
+  doc.appellation = 'Central Otago';
+  await doc.validate();
+  expect(doc.canonicalKey).toBe('felton road:block 3 pinot noir:central otago');
+
+  doc.producer = 'Maude Wines';
+  await doc.validate();
+  // name no longer embeds the (new) producer → only the producer segment moves
+  expect(doc.canonicalKey).toBe(computeCanonicalKey(doc.name, 'Maude Wines', 'Central Otago'));
+});

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const { generateWineSlug } = require('../utils/normalize');
+const { computeCanonicalKey } = require('../utils/wineIdentity');
 
 const wineDefinitionSchema = new mongoose.Schema({
   name: {
@@ -108,6 +109,17 @@ const wineDefinitionSchema = new mongoose.Schema({
     unique: true,
     index: true
   },
+  // Canonical identity for duplicate PREVENTION (utils/wineIdentity.js):
+  // collapses producer variants, producer-in-name embeds and appellation
+  // tiers. Deliberately NON-unique — distinct wineries can share a key
+  // (Domaine vs Bodegas Chandon); collisions feed the admin review queue.
+  // Maintained by the pre-validate hook; null only on rows predating the
+  // field that haven't been saved or backfilled yet.
+  canonicalKey: {
+    type: String,
+    index: true,
+    default: null
+  },
   // Vintage-neutral, human-readable slug used in public URLs (/wines/:slug).
   // Sparse so older docs without a slug don't violate the unique index until
   // the migration runs. Once set, never auto-regenerated on rename — URLs are
@@ -165,6 +177,17 @@ wineDefinitionSchema.index({ type: 1, name: 1 });
 // Update timestamp on save
 wineDefinitionSchema.pre('save', function(next) {
   this.updatedAt = Date.now();
+  next();
+});
+
+// Keep canonicalKey in sync with the identity fields. pre-validate (not
+// pre-save) so plain doc.validate() computes it too. Covers every save-based
+// write path (create, admin PUT rename, strip-producer); scripted updateOne
+// callers must set it themselves (backfill-canonical-key.js does).
+wineDefinitionSchema.pre('validate', function(next) {
+  if (!this.canonicalKey || this.isModified('name') || this.isModified('producer') || this.isModified('appellation')) {
+    this.canonicalKey = computeCanonicalKey(this.name, this.producer, this.appellation);
+  }
   next();
 });
 

--- a/backend/src/routes/admin/wines.dedup.test.js
+++ b/backend/src/routes/admin/wines.dedup.test.js
@@ -52,6 +52,8 @@ const express = require('express');
 const http = require('http');
 const jwt = require('jsonwebtoken');
 const WineDefinition = require('../../models/WineDefinition');
+const WineNotDuplicate = require('../../models/WineNotDuplicate');
+const Bottle = require('../../models/Bottle');
 const Country = require('../../models/Country');
 const { findOrCreateWine } = require('../../services/findOrCreateWine');
 const { generateWineKey } = require('../../utils/normalize');
@@ -161,4 +163,53 @@ test('operator-injection shapes are rejected with 400, nothing queried', async (
 
   expect(Country.findById).not.toHaveBeenCalled();
   expect(WineDefinition).not.toHaveBeenCalled();
+});
+
+test('canonical-collisions groups by canonicalKey, flags likely false positives, sorts by bottles', async () => {
+  const rows = [
+    { _id: 'a', name: 'Garden Spritz', producer: 'Domaine Chandon', appellation: null, type: 'sparkling', country: { _id: 'c-us', name: 'United States' }, canonicalKey: 'chandon:garden spritz:', createdAt: 'd1', createdVia: null },
+    { _id: 'b', name: 'Garden Spritz', producer: 'Bodegas Chandon', appellation: null, type: 'sparkling', country: { _id: 'c-ar', name: 'Argentina' }, canonicalKey: 'chandon:garden spritz:', createdAt: 'd2', createdVia: 'import' },
+    { _id: 'solo', name: 'Solo Wine', producer: 'X', appellation: null, type: 'red', country: { _id: 'c-us', name: 'United States' }, canonicalKey: 'x:solo wine:', createdAt: 'd3', createdVia: null },
+  ];
+  WineDefinition.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      populate: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(rows) }),
+    }),
+  });
+  WineNotDuplicate.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+  });
+  Bottle.aggregate.mockResolvedValue([{ _id: 'b', count: 4 }]);
+
+  const res = await fetch(`${baseUrl}/api/admin/wines/canonical-collisions`, {
+    headers: { Authorization: `Bearer ${adminToken()}` },
+  });
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  expect(data.total).toBe(1); // the solo wine is not a collision
+  expect(data.sets[0].flags).toContain('DIFF-COUNTRY');
+  expect(data.sets[0].wines.map(w => w._id)).toEqual(['b', 'a']); // most-bottled first
+  expect(data.sets[0].wines[0].bottleCount).toBe(4);
+});
+
+test('canonical-collisions hides sets where every pair was dismissed as not-a-duplicate', async () => {
+  const rows = [
+    { _id: 'a', name: 'W', producer: 'P1', appellation: null, type: 'red', country: { _id: 'c1', name: 'France' }, canonicalKey: 'p:w:', createdAt: 'd1', createdVia: null },
+    { _id: 'b', name: 'W', producer: 'P2', appellation: null, type: 'red', country: { _id: 'c1', name: 'France' }, canonicalKey: 'p:w:', createdAt: 'd2', createdVia: null },
+  ];
+  WineDefinition.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      populate: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(rows) }),
+    }),
+  });
+  WineNotDuplicate.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([{ wineA: 'a', wineB: 'b' }]) }),
+  });
+  Bottle.aggregate.mockResolvedValue([]);
+
+  const res = await fetch(`${baseUrl}/api/admin/wines/canonical-collisions`, {
+    headers: { Authorization: `Bearer ${adminToken()}` },
+  });
+  const data = await res.json();
+  expect(data.total).toBe(0);
 });

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -598,6 +598,84 @@ router.get('/duplicates', async (req, res) => {
   }
 });
 
+// GET /api/admin/wines/canonical-collisions — the standing duplicate queue
+// (dup analysis 2026-07-22, phases 1-2). Groups wines by canonicalKey; every
+// group of ≥2 is either a real duplicate (→ merge tool) or a legitimate
+// same-name collision (→ dismiss via the not-a-duplicate flow, which hides it
+// here too). DIFF-COUNTRY / DIFF-TYPE flags mark likely false positives
+// (Domaine Chandon Napa vs Bodegas Chandon Mendoza). Healthy steady state:
+// zero sets — new canonical duplicates can't be minted (findOrCreateWine
+// resolves them), so anything appearing here entered via a raced write or a
+// pre-backfill row and deserves a look.
+router.get('/canonical-collisions', async (req, res) => {
+  try {
+    const wines = await WineDefinition.find({ canonicalKey: { $ne: null } })
+      .select('name producer appellation type country canonicalKey createdAt createdVia')
+      .populate('country', 'name')
+      .lean();
+
+    const groups = new Map();
+    for (const w of wines) {
+      let group = groups.get(w.canonicalKey);
+      if (!group) { group = []; groups.set(w.canonicalKey, group); }
+      group.push(w);
+    }
+    const collisions = [...groups.entries()].filter(([, arr]) => arr.length >= 2);
+
+    // Sets where the admin has dismissed EVERY pair stop resurfacing.
+    const notDup = await WineNotDuplicate.find({}).select('wineA wineB').lean();
+    const dismissed = new Set(notDup.map(d => `${d.wineA}|${d.wineB}`));
+    const pairKey = (a, b) => (String(a) < String(b) ? `${a}|${b}` : `${b}|${a}`);
+    const active = collisions.filter(([, arr]) => {
+      for (let i = 0; i < arr.length; i++) {
+        for (let j = i + 1; j < arr.length; j++) {
+          if (!dismissed.has(pairKey(arr[i]._id, arr[j]._id))) return true;
+        }
+      }
+      return false;
+    });
+
+    const ids = active.flatMap(([, arr]) => arr.map(w => w._id));
+    const bottleCounts = new Map();
+    if (ids.length > 0) {
+      const counts = await Bottle.aggregate([
+        { $match: { wineDefinition: { $in: ids } } },
+        { $group: { _id: '$wineDefinition', count: { $sum: 1 } } },
+      ]);
+      for (const c of counts) bottleCounts.set(String(c._id), c.count);
+    }
+
+    const totalBottles = (arr) => arr.reduce((s, w) => s + (bottleCounts.get(String(w._id)) || 0), 0);
+    const sets = active
+      .map(([key, arr]) => ({
+        canonicalKey: key,
+        flags: [
+          new Set(arr.map(w => String(w.country?._id || ''))).size > 1 ? 'DIFF-COUNTRY' : null,
+          new Set(arr.map(w => w.type)).size > 1 ? 'DIFF-TYPE' : null,
+        ].filter(Boolean),
+        wines: arr
+          .map(w => ({
+            _id: w._id,
+            name: w.name,
+            producer: w.producer,
+            appellation: w.appellation || null,
+            type: w.type,
+            country: w.country?.name || null,
+            createdAt: w.createdAt,
+            createdVia: w.createdVia || null,
+            bottleCount: bottleCounts.get(String(w._id)) || 0,
+          }))
+          .sort((a, b) => b.bottleCount - a.bottleCount),
+      }))
+      .sort((a, b) => totalBottles(groups.get(b.canonicalKey)) - totalBottles(groups.get(a.canonicalKey)));
+
+    res.json({ sets, total: sets.length, scannedCount: wines.length });
+  } catch (error) {
+    console.error('Canonical collisions error:', error);
+    res.status(500).json({ error: 'Failed to list canonical collisions' });
+  }
+});
+
 // GET /api/admin/wines/producer-in-name — wines whose name STARTS or ENDS
 // with their own producer (prefix: producer "Meerlust", name "Meerlust
 // Chardonnay"; suffix: producer "Mastroberardino", name "Fiano di Avellino

--- a/backend/src/scripts/backfill-canonical-key.js
+++ b/backend/src/scripts/backfill-canonical-key.js
@@ -1,0 +1,51 @@
+/**
+ * Backfill canonicalKey for every WineDefinition (dup analysis 2026-07-22,
+ * phase 1). Safe to re-run: rows whose stored key already matches are skipped,
+ * and the pre-validate hook keeps keys current for all save-based writes after
+ * this one-time pass.
+ *
+ * Dry-run by default — prints what would change plus every collision set the
+ * canonical grouping reveals (the admin merge queue). Pass --apply to write.
+ *
+ *   docker exec cellarion-backend node src/scripts/backfill-canonical-key.js
+ *   docker exec cellarion-backend node src/scripts/backfill-canonical-key.js --apply
+ */
+
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const { computeCanonicalKey } = require('../utils/wineIdentity');
+
+(async () => {
+  const apply = process.argv.includes('--apply');
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+
+  const wines = await WineDefinition.find({})
+    .select('name producer appellation canonicalKey')
+    .lean();
+
+  const groups = new Map();
+  const ops = [];
+  let unchanged = 0;
+  for (const w of wines) {
+    const key = computeCanonicalKey(w.name, w.producer, w.appellation);
+    let group = groups.get(key);
+    if (!group) { group = []; groups.set(key, group); }
+    group.push(w);
+    if (w.canonicalKey === key) { unchanged += 1; continue; }
+    ops.push({ updateOne: { filter: { _id: w._id }, update: { $set: { canonicalKey: key } } } });
+  }
+
+  const collisions = [...groups.values()].filter(arr => arr.length >= 2);
+  console.log(`[backfill-canonical-key] ${apply ? 'APPLY' : 'DRY-RUN'} wines=${wines.length} toSet=${ops.length} unchanged=${unchanged} collisionSets=${collisions.length}`);
+  for (const set of collisions.slice(0, 50)) {
+    console.log(`  collision: ${set.map(w => `"${w.name}" — ${w.producer} [${w._id}]`).join('  |  ')}`);
+  }
+  if (collisions.length > 50) console.log(`  … and ${collisions.length - 50} more sets`);
+
+  if (apply && ops.length > 0) {
+    const res = await WineDefinition.bulkWrite(ops, { ordered: false });
+    console.log(`[backfill-canonical-key] modified=${res.modifiedCount}`);
+  }
+
+  await mongoose.disconnect();
+})().catch((e) => { console.error('ERR:', e.message); process.exit(1); });

--- a/backend/src/seed-demo.js
+++ b/backend/src/seed-demo.js
@@ -254,6 +254,7 @@ async function seed() {
       BottleModel.distinct('_id'),
     ]);
     for (const id of wineIds) await searchService.indexWine(id);
+    require('./models/WineRequest'); // WINE_POPULATE refs it; standalone runs must register it
     await searchService.bulkIndexBottles(bottleIds);
     console.log(`\nIndexed ${wineIds.length} wines + ${bottleIds.length} bottles into Meilisearch.`);
   }

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -21,6 +21,7 @@ const searchService = require('./search');
 const { generateWineKey, normalizeString, normalizeAppellation, resolveGrapeName, resolveCountryName, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
 const { canonicalizeWineName } = require('../utils/producerPrefix');
+const { computeCanonicalKey, canonicalSiblingPrefix } = require('../utils/wineIdentity');
 const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
 const { escapeRegex } = require('../utils/sanitize');
 
@@ -177,22 +178,52 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   let wine = await WineDefinition.findOne({ normalizedKey }).populate(POPULATE);
   if (wine) return { wine, created: false };
 
+  // 1a. Canonical-identity match: collapses producer spelling variants,
+  // producer-in-name embeds and appellation tiers, so ANY spelling of an
+  // already-registered wine lands here before fuzzy scoring ever runs — a
+  // canonical duplicate cannot be minted because this lookup finds the
+  // original first (dup analysis 2026-07-22, phase 1). ≥2 hits mean the
+  // registry ALREADY holds a duplicate cluster for this identity — never pick
+  // one arbitrarily; fall through so the soft zone / admin queue handles it.
+  // Deliberately not gated on skipSiblingMatch: like the exact key above, an
+  // identity-level hit is the same wine (the different-country guard covers
+  // the distinct-winery collisions).
+  const canonicalKey = computeCanonicalKey(trimmedName, trimmedProducer, trimmedAppellation);
+  const canonicalHits = await WineDefinition.find({ canonicalKey })
+    .limit(2)
+    .populate(POPULATE);
+  if (canonicalHits.length === 1 && !conflictsCountry(canonicalHits[0])) {
+    return { wine: canonicalHits[0], created: false };
+  }
+
   // 1b. Sibling match: same producer + same canonical name, ANY appellation.
   // Import files and AI output often carry a different appellation granularity
   // than the registry ("Cromwell" vs the registry's "Central Otago") — the
   // full-key match above misses and the fuzzy score lands around 0.90, below
   // the auto-match threshold, so without this step a non-interactive caller
-  // (confirmCreate) would mint a near-duplicate. A UNIQUE producer+name hit is
-  // overwhelmingly the same wine; with several siblings we fall through to the
-  // fuzzy scorer so the soft zone can disambiguate instead of picking one
-  // arbitrarily. The anchored regex is a prefix scan on the normalizedKey index.
+  // (confirmCreate) would mint a near-duplicate. A UNIQUE hit is overwhelmingly
+  // the same wine; with several siblings we fall through to the fuzzy scorer so
+  // the soft zone can disambiguate instead of picking one arbitrarily.
+  // Canonical prefix first (variant-tolerant); the raw normalizedKey prefix is
+  // kept as a fallback for rows that predate canonicalKey on instances that
+  // haven't run the backfill — they converge organically as docs save.
   if (!skipSiblingMatch) {
-    const siblingPrefix = `${normalizeString(trimmedProducer)}:${normalizeString(trimmedName)}:`;
-    const siblings = await WineDefinition.find({ normalizedKey: new RegExp(`^${escapeRegex(siblingPrefix)}`) })
+    const canonicalSiblings = await WineDefinition.find({
+      canonicalKey: new RegExp(`^${escapeRegex(canonicalSiblingPrefix(trimmedName, trimmedProducer))}`),
+    })
       .limit(2)
       .populate(POPULATE);
-    if (siblings.length === 1 && !conflictsCountry(siblings[0])) {
-      return { wine: siblings[0], created: false };
+    if (canonicalSiblings.length === 1 && !conflictsCountry(canonicalSiblings[0])) {
+      return { wine: canonicalSiblings[0], created: false };
+    }
+    if (canonicalSiblings.length === 0) {
+      const siblingPrefix = `${normalizeString(trimmedProducer)}:${normalizeString(trimmedName)}:`;
+      const siblings = await WineDefinition.find({ normalizedKey: new RegExp(`^${escapeRegex(siblingPrefix)}`) })
+        .limit(2)
+        .populate(POPULATE);
+      if (siblings.length === 1 && !conflictsCountry(siblings[0])) {
+        return { wine: siblings[0], created: false };
+      }
     }
   }
 

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -81,15 +81,21 @@ const EXISTING_WINE = { _id: 'wine-existing', name: 'Clos des Papes' };
 const findOneChain = (doc) => ({ populate: jest.fn().mockResolvedValue(doc) });
 
 /**
- * Query-shape dispatcher for WineDefinition.find — the service issues three
+ * Query-shape dispatcher for WineDefinition.find — the service issues five
  * differently-chained find() queries, so a single mockReturnValue can't serve
  * them all:
- *   { normalizedKey: RegExp } → .limit(2).populate(...)   (step 1b sibling lookup)
- *   { _id: { $in: ids } }     → .populate(...)            (Meilisearch id fetch)
- *   { $text: ... }            → .populate(...).limit(20)  (Mongo text fallback)
+ *   { canonicalKey: string } → .limit(2).populate(...)   (step 1a canonical identity)
+ *   { canonicalKey: RegExp } → .limit(2).populate(...)   (step 1b canonical sibling)
+ *   { normalizedKey: RegExp } → .limit(2).populate(...)  (step 1b raw-sibling fallback)
+ *   { _id: { $in: ids } }     → .populate(...)           (Meilisearch id fetch)
+ *   { $text: ... }            → .populate(...).limit(20) (Mongo text fallback)
  */
-function primeFind({ siblings = [], meiliDocs = [], textDocs = [] } = {}) {
+function primeFind({ canonicalHits = [], canonicalSiblings = [], siblings = [], meiliDocs = [], textDocs = [] } = {}) {
   WineDefinition.find.mockImplementation((q) => {
+    if (q && q.canonicalKey) {
+      const docs = q.canonicalKey instanceof RegExp ? canonicalSiblings : canonicalHits;
+      return { limit: jest.fn().mockReturnValue({ populate: jest.fn().mockResolvedValue(docs) }) };
+    }
     if (q && q.normalizedKey) {
       return { limit: jest.fn().mockReturnValue({ populate: jest.fn().mockResolvedValue(siblings) }) };
     }
@@ -346,6 +352,56 @@ describe('findOrCreateWine — nearMiss reporting on confirmed create', () => {
 
     expect(result.created).toBe(true);
     expect(result.nearMiss).toBeUndefined();
+  });
+});
+
+describe('findOrCreateWine — canonical-identity match (step 1a)', () => {
+  // The lookup-first design from the 2026-07-22 dup analysis: any spelling of
+  // an already-registered wine resolves to it BEFORE fuzzy scoring, so a
+  // canonical duplicate cannot be minted.
+  const CANONICAL_HIT = { _id: 'wine-canon', name: 'Block 3 Pinot Noir', producer: 'Felton Road' };
+
+  test('a single canonical hit returns the existing wine — variant input, no fuzzy, no create', async () => {
+    primeFind({ canonicalHits: [CANONICAL_HIT] });
+
+    const result = await findOrCreateWine(
+      { ...INPUT, name: 'Felton Road Block 3 Pinot Noir', producer: 'Felton Road Wines Ltd', appellation: 'Bannockburn' },
+      USER_ID
+    );
+
+    expect(result).toEqual({ wine: CANONICAL_HIT, created: false });
+    expect(scoreAllMatches).not.toHaveBeenCalled();
+    expect(WineDefinition).not.toHaveBeenCalled();
+  });
+
+  test('two canonical hits (a pre-existing duplicate cluster) fall through — never picks one arbitrarily', async () => {
+    primeFind({ canonicalHits: [{ _id: 'dup-a' }, { _id: 'dup-b' }] });
+
+    const result = await findOrCreateWine(INPUT, USER_ID);
+
+    expect(result.created).toBe(true); // empty fuzzy → creates; the cluster stays for the admin queue
+  });
+
+  test('a canonical hit with a conflicting country is not linked', async () => {
+    primeFind({ canonicalHits: [{ _id: 'wine-ar', name: 'Garden Spritz', country: { name: 'Argentina' } }] });
+
+    const result = await findOrCreateWine(
+      { name: 'Garden Spritz', producer: 'Chandon', country: 'United States', region: '', appellation: '', type: 'sparkling', grapes: ['Chardonnay'] },
+      USER_ID
+    );
+
+    expect(result.created).toBe(true);
+  });
+
+  test('canonical SIBLING (same identity, other appellation) matches when unique', async () => {
+    primeFind({ canonicalSiblings: [CANONICAL_HIT] });
+
+    const result = await findOrCreateWine(
+      { ...INPUT, name: 'Felton Road Block 3 Pinot Noir', producer: 'Felton Road Wines Ltd', appellation: 'Central Otago' },
+      USER_ID
+    );
+
+    expect(result).toEqual({ wine: CANONICAL_HIT, created: false });
   });
 });
 

--- a/backend/src/utils/wineIdentity.js
+++ b/backend/src/utils/wineIdentity.js
@@ -1,0 +1,52 @@
+/**
+ * Canonical wine identity — the durable duplicate-prevention key
+ * (REGISTRY_DUPLICATE_ANALYSIS_2026-07-22, phase 1).
+ *
+ *   canonicalKey = normalizeProducerKey(producer)
+ *                + ':' + normalizeString(canonicalizeWineName(name, producer))
+ *                + ':' + normalizeString(normalizeAppellation(appellation))
+ *
+ * Unlike normalizedKey (raw strings, UNIQUE — deliberately untouched), the
+ * canonical key collapses the three variance axes that mint duplicates:
+ * producer spelling variants ("Felton Road Wines Ltd" ≡ "Felton Road"),
+ * producer-in-name embeds ("Felton Road Block 3 Pinot Noir" ≡ "Block 3 Pinot
+ * Noir"), and appellation tier suffixes ("Barolo DOCG" ≡ "Barolo").
+ *
+ * It is deliberately NON-unique: findOrCreateWine uses it as the first lookup
+ * (a canonical duplicate can't be minted, because the lookup finds the
+ * original), and the admin collision report drives cleanup of pre-existing
+ * duplicates. Distinct wineries can legitimately collide (Domaine Chandon,
+ * Napa vs Bodegas Chandon, Mendoza both key "chandon:garden spritz:…") —
+ * which is exactly why collisions are a human-reviewed queue, not a unique
+ * constraint, and why the matcher pairs canonical hits with the
+ * different-country guard.
+ */
+
+const { normalizeString, normalizeProducerKey, normalizeAppellation } = require('./normalize');
+const { canonicalizeWineName } = require('./producerPrefix');
+
+// An all-stopword producer ("Domaine", "Cantina") has an EMPTY comparison key
+// — falling back to the raw normalized string keeps such producers distinct
+// from each other instead of sharing one canonical bucket. Mirrors the raw
+// fallback in wineMatching.producerSimilarity.
+const producerSegment = (producer) =>
+  normalizeProducerKey(producer || '') || normalizeString(producer || '');
+
+function computeCanonicalKey(name, producer, appellation = '') {
+  const nameKey = normalizeString(canonicalizeWineName(name || '', producer || ''));
+  const appellationKey = normalizeString(
+    normalizeAppellation(typeof appellation === 'string' ? appellation : '') || ''
+  );
+  return `${producerSegment(producer)}:${nameKey}:${appellationKey}`;
+}
+
+/**
+ * Prefix for canonical sibling lookups: same canonical producer + name, ANY
+ * appellation. Anchored-regex scans on the canonicalKey index.
+ */
+function canonicalSiblingPrefix(name, producer) {
+  const nameKey = normalizeString(canonicalizeWineName(name || '', producer || ''));
+  return `${producerSegment(producer)}:${nameKey}:`;
+}
+
+module.exports = { computeCanonicalKey, canonicalSiblingPrefix };

--- a/backend/src/utils/wineIdentity.test.js
+++ b/backend/src/utils/wineIdentity.test.js
@@ -1,0 +1,36 @@
+const { computeCanonicalKey, canonicalSiblingPrefix } = require('./wineIdentity');
+
+describe('computeCanonicalKey', () => {
+  test('collapses all three variance axes to one key — the July-2026 duplicate shape', () => {
+    const canonical = computeCanonicalKey('Block 3 Pinot Noir', 'Felton Road', 'Bannockburn');
+    expect(canonical).toBe('felton road:block 3 pinot noir:bannockburn');
+    // producer variant + producer-in-name embed → SAME key
+    expect(computeCanonicalKey('Felton Road Block 3 Pinot Noir', 'Felton Road Wines Ltd', 'Bannockburn'))
+      .toBe(canonical);
+  });
+
+  test('appellation tier suffixes collapse', () => {
+    expect(computeCanonicalKey('Barolo', 'Rossi', 'Barolo DOCG'))
+      .toBe(computeCanonicalKey('Barolo', 'Rossi', 'Barolo'));
+  });
+
+  test('different appellations stay distinct — the Garden Spritz two-winery shape', () => {
+    expect(computeCanonicalKey('Garden Spritz', 'Domaine Chandon', 'Napa Valley'))
+      .not.toBe(computeCanonicalKey('Garden Spritz', 'Bodegas Chandon', 'Mendoza'));
+  });
+
+  test('missing appellation → empty third segment; empty inputs stay well-formed', () => {
+    expect(computeCanonicalKey('X', 'Y')).toBe('y:x:');
+    expect(computeCanonicalKey('', '')).toBe('::');
+    expect(computeCanonicalKey('X', 'Y', null)).toBe('y:x:');
+  });
+});
+
+describe('canonicalSiblingPrefix', () => {
+  test('prefixes the full key of the same identity under ANY appellation', () => {
+    const prefix = canonicalSiblingPrefix('Felton Road Block 3 Pinot Noir', 'Felton Road Wines Ltd');
+    expect(prefix).toBe('felton road:block 3 pinot noir:');
+    expect(computeCanonicalKey('Block 3 Pinot Noir', 'Felton Road', 'Central Otago').startsWith(prefix)).toBe(true);
+    expect(computeCanonicalKey('Block 3 Pinot Noir', 'Felton Road').startsWith(prefix)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Phase 1 of `REGISTRY_DUPLICATE_ANALYSIS_2026-07-22.md`. PRs #802/#803 made the matcher variant-aware and closed the bypass endpoints; this PR adds the durable identity layer so a canonical duplicate **cannot be minted** — and gives admins a standing queue for the ones that already exist.

## What

- **`WineDefinition.canonicalKey`** (indexed, deliberately **non-unique** — `normalizedKey` stays the unique raw key, so there is **no risky index migration**): `producerKey : producer-stripped name : tier-stripped appellation`. Maintained by a pre-validate hook (create/rename/strip all stay fresh). All-stopword producers fall back to the raw normalized string so "Domaine" ≠ "Cantina".
- **`findOrCreateWine` step 1a**: exact canonicalKey lookup before fuzzy — any spelling of a registered wine resolves to it. ≥2 hits = a pre-existing duplicate cluster → falls through (never picks one arbitrarily). The different-country guard covers legitimate collisions (Chandon shape).
- **Canonical sibling match** (same identity, any appellation), with the raw-prefix fallback kept so **un-backfilled self-hosted instances degrade gracefully** and converge as docs save.
- **`GET /api/admin/wines/canonical-collisions`**: the duplicate review queue — sets of ≥2 per key, DIFF-COUNTRY/DIFF-TYPE false-positive flags, bottle counts + provenance, `WineNotDuplicate`-dismissed sets hidden. Healthy steady state: **zero sets**.
- **`scripts/backfill-canonical-key.js`**: dry-run-default backfill + collision report. To run on prod at next deploy.
- Drive-by: seeder registered `WineRequest` before bulk bottle indexing (pre-existing warning).

## Verified in Docker (full stack)

- Backfill dry-run → apply → re-run: `wines=3407 toSet=3405` → idempotent `toSet=0`; hook had already keyed the 2 seeder-created rows.
- `find-or-create` with `"Felton Road Block 2 Chardonnay" / "Felton Road Wines Ltd"` → returned the **existing** `"Block 2 Chardonnay" / Felton Road` (created:false).
- Admin create of the same variant → **409** with the canonical candidate at score 1.
- Collision queue lists the local duplicate sets sorted by bottle impact.

## Tests

Backend **2182** green (147 suites): key axioms (variant collapse, Garden-Spritz distinctness), model hook (create/rename/producer-change), step-1a semantics (single hit, cluster fall-through, country guard, canonical sibling), collision endpoint (grouping, flags, dismissed-set hiding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)