### PR TITLE
release: v1.86.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.85.0",
+  "version": "1.86.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.85.0",
+  "version": "1.86.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for v1.86.0.

- #802 fix(registry): recognize producer variants in dedup matching
- #803 fix(registry): close the dedup-bypass write paths + stamp provenance
- #804 feat(registry): canonical wine identity — lookup-first duplicate prevention
- #801 fix(images): move the admin-only credit gate into the shared image pipeline

Post-deploy step: run `src/scripts/backfill-canonical-key.js` (dry-run → --apply) on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)