### PR TITLE
chore(i18n): community translation setup — TRANSLATING.md + hardened locale tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,9 +609,13 @@ Uses Jest. Covers auth middleware, cellar access control, wine normalisation/sim
 
 1. Fork the repo and create a feature branch off `main`
 2. Make your changes
-3. Run the tests (`cd frontend && npm test -- --watchAll=false` and `cd backend && npm test`)
+3. Run the tests (`cd frontend && npm test` and `cd backend && npm test`)
 4. Smoke-test in Docker: `docker-compose up --build`
 5. Submit a pull request with a clear description of your changes
+
+### Translations
+
+Want Cellarion in your language? Translations are contributed through Weblate — no coding required. See [TRANSLATING.md](TRANSLATING.md) to get started. (Please don't PR edits to `translation.json` files directly; they conflict with Weblate's sync.)
 
 ---
 

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -1,0 +1,44 @@
+# Translating Cellarion
+
+Cellarion's interface is community-translated. Thank you for helping!
+
+## How it works
+
+- UI strings live in `frontend/src/locales/<language>/translation.json` (one file per language, [i18next](https://www.i18next.com/) format).
+- **English (`en`) is the source language** — it is maintained by the developers alongside the code. Every other language is a translation of it.
+- Translations are contributed through **Weblate**, a web-based translation tool — no programming or Git knowledge needed:
+
+  👉 **https://hosted.weblate.org/projects/cellarion/**
+
+  Weblate shows each English string with context, suggests machine translations you can correct, tracks per-language completeness, and opens pull requests against this repo automatically.
+
+**Please do not open pull requests that edit `translation.json` files directly** (except for `en`, which is developer-maintained). Direct edits conflict with Weblate's two-way sync and will be closed with a friendly pointer here.
+
+## Translation guidelines
+
+1. **Keep placeholders exactly as they are.** Anything in double curly braces is replaced with a value at runtime and must survive translation untouched:
+   - `"{{count}} bottles in {{cellar}}"` → `"{{count}} flaskor i {{cellar}}"` ✔
+   - Renaming or dropping a placeholder shows the raw `{{...}}` text to users.
+   - Some placeholders carry a format, e.g. `{{count, number}}` — keep the `, number` part too.
+
+2. **Plural forms.** Keys ending in `_one` / `_other` are plural variants selected by `count`. Translate each form for your language's grammar — the `_one` form may drop the number entirely if that reads better (e.g. `"one bottle"`). Languages with more plural categories (e.g. Polish, Arabic) get additional forms (`_few`, `_many`, …) in Weblate automatically.
+
+3. **Wine terminology.** Check the project glossary in Weblate before inventing a translation for domain terms (drink window, maturity, appellation, rack, vintage…). Consistency matters more than any single "best" word.
+
+4. **Tone.** Informal but precise — address the user directly (Swedish: du-form). Cellarion is a hobbyist's tool, not enterprise software.
+
+5. **Don't translate:** product names (Cellarion, CellarTracker, Vivino), technical identifiers, or the demo email addresses.
+
+## How a new language gets shipped
+
+1. Request the language in Weblate (or open a GitHub discussion) and start translating.
+2. When the language reaches **~90 % translated**, we enable it in the app (`frontend/src/i18n.js` — it is added to `supportedLngs` and the lazy-loading table) in the next release.
+3. Untranslated strings fall back to English, so a shipped language degrades gracefully while you finish it.
+
+## Notes for developers
+
+- **Never delete "unused-looking" keys.** Many keys are referenced dynamically — e.g. `t(`support.status.${ticket.status}`)` resolves keys that no grep for the literal key will find. The locale test suite, not string search, is the authority.
+- New user-facing strings go into `en/translation.json` in the same PR as the code. Don't machine-translate them into the other languages — leave that to Weblate, where translators see them as new work.
+- Don't build sentences by concatenating strings or placing numbers next to `t()` calls — put the whole sentence in one key and interpolate (`{{count}}`, `{{name}}`). Word order differs across languages.
+- Renaming a key discards its existing translations in every language. Reword the English value only when the *meaning* changes (Weblate then flags translations for review); avoid renaming keys casually.
+- `frontend/src/locales/translation.test.js` enforces structural integrity (key parity across languages, placeholder consistency, no empty strings) and runs in CI on every PR.

--- a/frontend/src/locales/translation.test.js
+++ b/frontend/src/locales/translation.test.js
@@ -14,6 +14,14 @@
 import en from './en/translation.json';
 import sv from './sv/translation.json';
 
+// Picks up every locale automatically so community languages added via
+// Weblate are covered without touching this file.
+const bundles = Object.fromEntries(
+  Object.entries(import.meta.glob('./*/translation.json', { eager: true }))
+    .map(([path, mod]) => [path.split('/')[1], mod.default])
+);
+const otherLocales = Object.entries(bundles).filter(([code]) => code !== 'en');
+
 const flatten = (obj, prefix = '') =>
   Object.entries(obj).flatMap(([k, v]) => {
     const key = prefix ? `${prefix}.${k}` : k;
@@ -21,26 +29,63 @@ const flatten = (obj, prefix = '') =>
   });
 
 const enKeys = flatten(en);
-const svKeys = flatten(sv);
 
 const get = (obj, path) => path.split('.').reduce((o, k) => (o == null ? undefined : o[k]), obj);
 
+// CLDR plural categories differ per language (Swedish has one/other, Polish
+// adds few/many, …), so parity is compared on plural-suffix-stripped keys.
+const PLURAL_SUFFIX = /_(zero|one|two|few|many|other)$/;
+const normalize = (keys) => [...new Set(keys.map((k) => k.replace(PLURAL_SUFFIX, '')))];
+
+// "{{count, number}}" → "count" — the format part is per-string, the
+// variable name must survive translation exactly.
+const placeholders = (str) =>
+  [...str.matchAll(/\{\{\s*([^,}\s]+)\s*(?:,[^}]*)?\}\}/g)].map((m) => m[1]);
+
 describe('translation files', () => {
-  test('en and sv mirror each other key-for-key', () => {
-    const missingInSv = enKeys.filter((k) => !svKeys.includes(k));
-    const missingInEn = svKeys.filter((k) => !enKeys.includes(k));
-    expect({ missingInSv, missingInEn }).toEqual({ missingInSv: [], missingInEn: [] });
+  test.each(otherLocales)('%s mirrors en key-for-key (ignoring plural suffixes)', (code, bundle) => {
+    const keys = normalize(flatten(bundle));
+    const base = normalize(enKeys);
+    const missing = base.filter((k) => !keys.includes(k));
+    const orphaned = keys.filter((k) => !base.includes(k));
+    expect({ missing, orphaned }).toEqual({ missing: [], orphaned: [] });
   });
 
-  test('no key resolves to an empty string in either locale', () => {
-    const blank = (locale, keys, obj) =>
-      keys.filter((k) => typeof get(obj, k) === 'string' && get(obj, k).trim() === '').map((k) => `${locale}:${k}`);
-    expect([...blank('en', enKeys, en), ...blank('sv', svKeys, sv)]).toEqual([]);
+  test.each(Object.entries(bundles))('%s has no key resolving to an empty string', (code, bundle) => {
+    const blank = flatten(bundle).filter((k) => {
+      const v = get(bundle, k);
+      return typeof v === 'string' && v.trim() === '';
+    });
+    expect(blank).toEqual([]);
   });
 
-  test('every leaf is a string (a stray object or null breaks interpolation)', () => {
-    const nonString = enKeys.filter((k) => typeof get(en, k) !== 'string');
+  test.each(Object.entries(bundles))('%s: every leaf is a string (a stray object or null breaks interpolation)', (code, bundle) => {
+    const nonString = flatten(bundle).filter((k) => typeof get(bundle, k) !== 'string');
     expect(nonString).toEqual([]);
+  });
+
+  // A translated string may only use placeholders that exist in its English
+  // source — a renamed or invented placeholder renders as literal "{{...}}".
+  // Subset (not equality) because plural _one forms may legitimately drop
+  // {{count}} ("one bottle").
+  test.each(otherLocales)('%s uses no placeholder that en does not have', (code, bundle) => {
+    const enAllowed = new Map();
+    for (const k of enKeys) {
+      const norm = k.replace(PLURAL_SUFFIX, '');
+      const set = enAllowed.get(norm) || new Set();
+      placeholders(get(en, k)).forEach((p) => set.add(p));
+      enAllowed.set(norm, set);
+    }
+    const bad = flatten(bundle).flatMap((k) => {
+      const v = get(bundle, k);
+      if (typeof v !== 'string') return [];
+      const allowed = enAllowed.get(k.replace(PLURAL_SUFFIX, ''));
+      if (!allowed) return [];
+      return placeholders(v)
+        .filter((p) => !allowed.has(p))
+        .map((p) => `${k}: {{${p}}}`);
+    });
+    expect(bad).toEqual([]);
   });
 
   // The public MCP connect page is the one surface whose copy is load-bearing


### PR DESCRIPTION
Repo-side prep for community translations via Weblate (follow-up to #807).

- **TRANSLATING.md** — contributor guide: the Weblate flow, placeholder + plural rules, glossary/tone notes, when a new language ships (~90% + enabled in i18n.js), and developer rules (never delete dynamically-referenced keys; no direct locale-file PRs).
- **Hardened locale tests** — locales auto-discovered via `import.meta.glob` (future Weblate languages covered without editing the test); key parity now compares plural-suffix-stripped keys (Polish/Arabic have more CLDR plural categories than English); new placeholder-consistency check (a translation using a placeholder its English source lacks renders literal `{{...}}` to users — the classic community-translation bug).
- **README** — Translations section pointing at TRANSLATING.md; drops the stale CRA `--watchAll` flag from the contributing steps (it errors under Vitest).

Tests: 37 files / 693 green (locale suite grew 6 → 10).

The Weblate project itself (hosted.weblate.org libre plan) is set up separately — the TRANSLATING.md URL assumes project slug `cellarion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)