### PR TITLE
feat(import): Vivino scan-history support — ratings, notes, drink windows, history mode

### DIFF
--- a/backend/src/routes/import.confirm.test.js
+++ b/backend/src/routes/import.confirm.test.js
@@ -79,6 +79,11 @@ jest.mock('../models/WineRequest', () => {
   return WineRequest;
 });
 
+jest.mock('../models/WishlistItem', () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+}));
+
 const express = require('express');
 const http = require('http');
 const jwt = require('jsonwebtoken');
@@ -86,6 +91,7 @@ const Cellar = require('../models/Cellar');
 const WineDefinition = require('../models/WineDefinition');
 const Bottle = require('../models/Bottle');
 const WineRequest = require('../models/WineRequest');
+const WishlistItem = require('../models/WishlistItem');
 const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
 const importRouter = require('./import');
 
@@ -143,6 +149,8 @@ beforeEach(() => {
   Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, name: 'Main', user: USER_ID, members: [], deletedAt: null });
   wineDoc = { _id: WINE_ID, name: 'Test Wine', producer: 'Test Prod', grapes: ['g-existing'] };
   WineDefinition.findById.mockResolvedValue(wineDoc);
+  WishlistItem.findOne.mockResolvedValue(null);
+  WishlistItem.create.mockImplementation(async (data) => ({ _id: 'wish-1', ...data }));
 });
 
 // ── Regression: items without the new fields ────────────────────────────────
@@ -152,11 +160,13 @@ describe('additive regression (items without grapes/drink windows)', () => {
     const { status, body } = await confirm([{ wineDefinition: WINE_ID, vintage: '2018', notes: 'plain row' }]);
 
     expect(status).toBe(200);
-    // Response shape unchanged
+    // Response shape unchanged (wishlistCreated is additive — 0 when no
+    // items carry addToWishlist)
     expect(body).toEqual({
       created: 1,
       createdActive: 1,
       createdHistory: 0,
+      wishlistCreated: 0,
       skipped: [],
       errors: [],
       total: 1,
@@ -299,5 +309,93 @@ describe('item.drinkFrom / item.drinkTo', () => {
     expect(body.created).toBe(1);
     expect(Bottle.__instances[0].drinkFrom).toBeUndefined();
     expect(Bottle.__instances[0].drinkTo).toBeUndefined();
+  });
+});
+
+// ── Wishlist destination (item.addToWishlist) ────────────────────────────────
+
+describe('item.addToWishlist', () => {
+  test('creates a WishlistItem for the importing user instead of a Bottle', async () => {
+    const { status, body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', notes: 'sounded great', addToWishlist: true },
+    ]);
+
+    expect(status).toBe(200);
+    expect(body.wishlistCreated).toBe(1);
+    expect(body.created).toBe(0);
+    expect(body.errors).toEqual([]);
+    expect(Bottle.__instances).toHaveLength(0);
+    expect(WishlistItem.create).toHaveBeenCalledWith({
+      user: USER_ID,
+      wineDefinition: WINE_ID,
+      vintage: '2018',
+      notes: 'sounded great',
+      priority: 'medium',
+    });
+  });
+
+  test('skips rows already on the wishlist (same wine + vintage, wanted)', async () => {
+    WishlistItem.findOne.mockResolvedValue({ _id: 'existing-wish' });
+    const { body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', addToWishlist: true },
+    ]);
+
+    expect(body.wishlistCreated).toBe(0);
+    expect(body.skipped).toEqual([{ index: 0, reason: 'Already on your wishlist' }]);
+    expect(WishlistItem.create).not.toHaveBeenCalled();
+    expect(WishlistItem.findOne).toHaveBeenCalledWith({
+      user: USER_ID,
+      wineDefinition: WINE_ID,
+      status: 'wanted',
+      vintage: '2018',
+    });
+  });
+
+  test('dedups repeated wine+vintage rows within one batch (scan histories repeat wines)', async () => {
+    const { body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', addToWishlist: true },
+      { wineDefinition: WINE_ID, vintage: '2018', addToWishlist: true },
+      { wineDefinition: WINE_ID, vintage: '2019', addToWishlist: true },
+    ]);
+
+    expect(body.wishlistCreated).toBe(2);
+    expect(body.skipped).toEqual([{ index: 1, reason: 'Duplicate wishlist row in this import' }]);
+    expect(WishlistItem.create).toHaveBeenCalledTimes(2);
+  });
+
+  test('request-wine rows cannot be wishlisted — per-row error, no WineRequest created', async () => {
+    const { body } = await confirm([
+      { requestWine: true, wineName: 'Mystery', producer: 'Someone', vintage: '2019', addToWishlist: true },
+      { wineDefinition: WINE_ID, vintage: '2018', addToWishlist: true },
+    ]);
+
+    expect(body.wishlistCreated).toBe(1);
+    expect(body.errors).toEqual([
+      { index: 0, reason: 'Only wines matched to the registry can be added to the wishlist' },
+    ]);
+    expect(WineRequest.__instances).toHaveLength(0);
+  });
+
+  test('mixed batch: wishlist rows and bottle rows are both honoured', async () => {
+    const { body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '2018', addToWishlist: true },
+      { wineDefinition: WINE_ID, vintage: '2018' },
+    ]);
+
+    expect(body.wishlistCreated).toBe(1);
+    expect(body.created).toBe(1);
+    expect(body.createdActive).toBe(1);
+    expect(Bottle.__instances).toHaveLength(1);
+  });
+
+  test('NV vintage rows use the canonical NV identity for dedup', async () => {
+    const { body } = await confirm([
+      { wineDefinition: WINE_ID, vintage: '', addToWishlist: true },
+      { wineDefinition: WINE_ID, vintage: 'NV', addToWishlist: true },
+    ]);
+
+    // '' and 'NV' both canonicalise to 'NV' → second row is an in-batch dupe
+    expect(body.wishlistCreated).toBe(1);
+    expect(body.skipped).toEqual([{ index: 1, reason: 'Duplicate wishlist row in this import' }]);
   });
 });

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -39,6 +39,7 @@ const { validatePriceSanity } = require('../utils/priceValidation');
 const { computeUserMediansByCurrency } = require('../services/priceWarnings');
 const { runConcurrent } = require('../utils/concurrency');
 const WineRequest = require('../models/WineRequest');
+const WishlistItem = require('../models/WishlistItem');
 const ImportSession = require('../models/ImportSession');
 
 const router = express.Router();
@@ -563,7 +564,11 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
  *                     user's own per-bottle drink window (Bottle.drinkFrom/
  *                     drinkTo — never the shared registry). Invalid values
  *                     are silently dropped, never failing the row.
- * Response: { created, skipped, errors[] }
+ *   addToWishlist   — the row becomes a WishlistItem for the importing user
+ *                     instead of a Bottle (requires a matched registry wine;
+ *                     request-wine rows are reported as per-row errors).
+ *                     Duplicates — in-batch or already-wanted — are skipped.
+ * Response: { created, skipped, errors[], wishlistCreated, ... }
  */
 router.post('/confirm', async (req, res) => {
   try {
@@ -727,6 +732,14 @@ router.post('/confirm', async (req, res) => {
     // Oeno-export rows with a Consumed On date.
     let createdActive = 0;
     let createdHistory = 0;
+    // Rows flagged addToWishlist (e.g. a Vivino scan-history import sent to
+    // the wishlist) become WishlistItems for the IMPORTING user — wishlists
+    // are personal, unlike bottles which belong to the cellar owner.
+    let wishlistCreated = 0;
+    // In-batch wishlist dedup: scan-history files routinely list the same
+    // wine several times. Keyed wineDefinition|vintage, same identity the
+    // existing-wishlist duplicate check uses.
+    const wishlistSeen = new Set();
     const skipped = [];
     const errors = [];
     const createdBottleIds = []; // Track IDs for Meilisearch bulk sync
@@ -757,6 +770,58 @@ router.post('/confirm', async (req, res) => {
 
       try {
         let wineDoc = null;
+
+        // Wishlist destination (e.g. a Vivino scan-history import sent to
+        // the wishlist): the row becomes a WishlistItem instead of a Bottle.
+        // WishlistItem requires a registry wine, so request-wine rows can't
+        // be wishlisted — reported per-row, never failing the batch.
+        if (item.addToWishlist) {
+          if (item.requestWine || !item.wineDefinition) {
+            errors.push({ index: i, reason: 'Only wines matched to the registry can be added to the wishlist' });
+            continue;
+          }
+          if (!mongoose.Types.ObjectId.isValid(item.wineDefinition)) {
+            errors.push({ index: i, reason: 'Invalid wine definition ID' });
+            continue;
+          }
+          const wishWine = await WineDefinition.findById(item.wineDefinition);
+          if (!wishWine) {
+            errors.push({ index: i, reason: 'Wine definition not found' });
+            continue;
+          }
+
+          // Dedup within this batch, then against the existing wishlist —
+          // same identity POST /api/wishlist uses (user + wine + vintage,
+          // 'wanted' only, blank vintage matching null/absent/'').
+          const wishKey = `${item.wineDefinition}|${canonicalVintage || ''}`;
+          if (wishlistSeen.has(wishKey)) {
+            skipped.push({ index: i, reason: 'Duplicate wishlist row in this import' });
+            continue;
+          }
+          const dupFilter = { user: req.user.id, wineDefinition: item.wineDefinition, status: 'wanted' };
+          if (canonicalVintage) {
+            dupFilter.vintage = canonicalVintage;
+          } else {
+            dupFilter.$or = [{ vintage: null }, { vintage: { $exists: false } }, { vintage: '' }];
+          }
+          const existingWish = await WishlistItem.findOne(dupFilter);
+          if (existingWish) {
+            wishlistSeen.add(wishKey);
+            skipped.push({ index: i, reason: 'Already on your wishlist' });
+            continue;
+          }
+
+          await WishlistItem.create({
+            user: req.user.id,
+            wineDefinition: item.wineDefinition,
+            vintage: canonicalVintage || undefined,
+            notes: (stripHtml(item.notes) || '').slice(0, 2000) || undefined,
+            priority: 'medium'
+          });
+          wishlistSeen.add(wishKey);
+          wishlistCreated++;
+          continue;
+        }
 
         // Optional personal drink window (drinkFrom/drinkTo years, e.g.
         // CellarTracker BeginConsume/EndConsume) — stored on the bottle
@@ -1070,6 +1135,7 @@ router.post('/confirm', async (req, res) => {
       created,
       createdActive,
       createdHistory,
+      wishlistCreated,
       skipped: skipped.length,
       errors: errors.length,
       total: items.length,
@@ -1083,6 +1149,7 @@ router.post('/confirm', async (req, res) => {
       created,
       createdActive,
       createdHistory,
+      wishlistCreated,
       skipped,
       errors,
       total: items.length,

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2438,7 +2438,7 @@
       "q4": "Is Cellarion really free?",
       "a4": "Yes. All core features at cellarion.app are free — track unlimited bottles, organise cellars, get drink-window alerts, share with friends, and export your data anytime. There are no credit-card prompts, no premium tiers gating basic functionality, and we don't sell ads or your data.",
       "q5": "How do I import wines from Vivino or CellarTracker?",
-      "a5": "Cellarion supports CSV import. Export your collection from Vivino, CellarTracker, or any spreadsheet, then upload the CSV in Cellarion's import tool. The shared wine registry deduplicates entries automatically so your data stays clean and consistent across the whole catalogue.",
+      "a5": "Cellarion supports CSV import. Export your collection from Vivino, CellarTracker, or any spreadsheet, then upload the CSV in Cellarion's import tool. Note that Vivino's \"full wine list\" download is your scan history, not your cellar — Cellarion detects this and offers to import it as drinking history (with your ratings, reviews and notes) instead of as bottles in stock. The shared wine registry deduplicates entries automatically so your data stays clean and consistent across the whole catalogue.",
       "q6": "Can I export my data and leave any time?",
       "a6": "Yes — your data is yours. Cellarion includes a one-click data export that gives you everything as JSON (or a ZIP with your images), plus CSV import for bottles. You can delete your account from Settings with a 7-day cooling-off window. Hosted data lives on European infrastructure under GDPR."
     }
@@ -3185,7 +3185,9 @@
       "ctTruncatedTitle": "Only 25 rows found — this export may be cut off.",
       "ctTruncated": "This looks like a single-page export (exactly 25 rows). In CellarTracker, choose 'All wines' instead of 'Only wines on this page' before exporting, or your import may be missing most of your cellar.",
       "ctPendingSkipped_one": "{{count}} pending (undelivered) bottle was not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery.",
-      "ctPendingSkipped_other": "{{count}} pending (undelivered) bottles were not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery."
+      "ctPendingSkipped_other": "{{count}} pending (undelivered) bottles were not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery.",
+      "noIdentitySkipped_one": "{{count}} row was skipped because it has no wine name or producer (usually a failed label scan).",
+      "noIdentitySkipped_other": "{{count}} rows were skipped because they have no wine name or producer (usually failed label scans)."
     },
     "ctTables": {
       "list": "List table",
@@ -3211,6 +3213,15 @@
       "notCarriedWishlist": "Wishlists",
       "notCarriedWhy": "CellarTracker's export files simply don't include these, so no importer can carry them over."
     },
+    "vivinoHistory": {
+      "title": "This looks like your Vivino scan history",
+      "body": "This file lists every wine you've scanned or reviewed on Vivino — not the bottles currently in your cellar. Your ratings, reviews, personal notes and drinking windows come along either way. Choose what these wines should become:",
+      "historyTitle": "Drinking history",
+      "recommended": "Recommended",
+      "historyDesc": "Each wine is added as a consumed bottle, dated to when you scanned it. It appears in your history and statistics, not among your in-stock bottles.",
+      "cellarTitle": "Bottles in my cellar",
+      "cellarDesc": "Each wine is added as a bottle you currently own. Only pick this if the list really matches what's in your cellar."
+    },
     "upload": {
       "resumeReviewTitle": "Your matched results are still here",
       "resumeReviewMeta": "Return to review to keep every match, skip and manual selection. Re-matching below starts the review over.",
@@ -3226,7 +3237,7 @@
       "oenoTitle": "Oeno by Vintec",
       "genericTitle": "Generic CSV",
       "cellarionDesc": "Download from any cellar via ⋯ → Export (JSON). Bottles from all cellars in the file are imported into the cellar you pick here — to recreate whole cellars with racks and layout, use Import Cellar in Settings instead.",
-      "vivinoDesc": "Export your collection from Vivino app settings",
+      "vivinoDesc": "Cellar exports import as bottles; the \"full wine list\" download (your scan history) can import as drinking history",
       "cellartrackerDesc": "Export from CellarTracker via My Cellar → Download",
       "oenoDesc": "Real Oeno-by-Vintec export — two-section CSV with cabinet definitions + bottles. Cabinets, shelves, and bottle history all import automatically.",
       "genericDesc": "Any CSV with Wine, Producer, Vintage columns",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3421,6 +3421,8 @@
       "activeBottles": "Active bottles",
       "consumedHistory": "Consumed (history)",
       "wishlistAdded": "Added to wishlist",
+      "allWishlistedNote_one": "Your wine was added to your wishlist.",
+      "allWishlistedNote_other": "All {{count}} wines were added to your wishlist.",
       "skipped": "Skipped",
       "errors": "Errors",
       "racksCreated_one": "Rack created",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3219,6 +3219,8 @@
       "historyTitle": "Drinking history",
       "recommended": "Recommended",
       "historyDesc": "Each wine is added as a consumed bottle, dated to when you scanned it. It appears in your history and statistics, not among your in-stock bottles.",
+      "wishlistTitle": "My wishlist",
+      "wishlistDesc": "Each wine is added to your wishlist (duplicates are skipped). Only wines matched to the registry can be wishlisted.",
       "cellarTitle": "Bottles in my cellar",
       "cellarDesc": "Each wine is added as a bottle you currently own. Only pick this if the list really matches what's in your cellar."
     },
@@ -3418,6 +3420,7 @@
       "title": "Import Complete",
       "activeBottles": "Active bottles",
       "consumedHistory": "Consumed (history)",
+      "wishlistAdded": "Added to wishlist",
       "skipped": "Skipped",
       "errors": "Errors",
       "racksCreated_one": "Rack created",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -2438,7 +2438,7 @@
       "q4": "Är Cellarion verkligen gratis?",
       "a4": "Ja. Alla grundfunktioner på cellarion.app är gratis — spåra obegränsat antal flaskor, organisera källare, få drickfönster-aviseringar, dela med vänner och exportera din data när som helst. Det finns inga kreditkortsuppmaningar, inga premiumnivåer som låser grundfunktioner, och vi säljer inte annonser eller din data.",
       "q5": "Hur importerar jag viner från Vivino eller CellarTracker?",
-      "a5": "Cellarion stöder CSV-import. Exportera din samling från Vivino, CellarTracker eller något kalkylark, ladda sedan upp CSV-filen i Cellarions importverktyg. Det delade vinregistret deduplicerar poster automatiskt så att din data förblir ren och konsekvent i hela katalogen.",
+      "a5": "Cellarion stöder CSV-import. Exportera din samling från Vivino, CellarTracker eller något kalkylark, ladda sedan upp CSV-filen i Cellarions importverktyg. Observera att Vivinos nedladdning \"full wine list\" är din skanningshistorik, inte din källare — Cellarion upptäcker detta och erbjuder att importera den som dryckeshistorik (med dina betyg, recensioner och anteckningar) i stället för som flaskor i lager. Det delade vinregistret deduplicerar poster automatiskt så att din data förblir ren och konsekvent i hela katalogen.",
       "q6": "Kan jag exportera min data och lämna när jag vill?",
       "a6": "Ja — din data är din. Cellarion har en en-kliks dataexport som ger dig allt som JSON (eller en ZIP med dina bilder), plus CSV-import för flaskor. Du kan radera ditt konto från Inställningar med 7 dagars betänketid. Data på den hostade tjänsten lagras på europeisk infrastruktur under GDPR."
     }
@@ -3185,7 +3185,9 @@
       "ctTruncatedTitle": "Bara 25 rader hittades — exporten kan vara avklippt.",
       "ctTruncated": "Det här ser ut som en export av en enda sida (exakt 25 rader). Välj 'All wines' istället för 'Only wines on this page' i CellarTracker innan du exporterar, annars kan större delen av din källare saknas i importen.",
       "ctPendingSkipped_one": "{{count}} väntande (olevererad) flaska importerades inte: {{wines}}. Cellarion hanterar inte flaskor du ännu inte har fått — importera igen efter leverans.",
-      "ctPendingSkipped_other": "{{count}} väntande (olevererade) flaskor importerades inte: {{wines}}. Cellarion hanterar inte flaskor du ännu inte har fått — importera igen efter leverans."
+      "ctPendingSkipped_other": "{{count}} väntande (olevererade) flaskor importerades inte: {{wines}}. Cellarion hanterar inte flaskor du ännu inte har fått — importera igen efter leverans.",
+      "noIdentitySkipped_one": "{{count}} rad hoppades över eftersom den saknar vinnamn och producent (oftast en misslyckad etikettskanning).",
+      "noIdentitySkipped_other": "{{count}} rader hoppades över eftersom de saknar vinnamn och producent (oftast misslyckade etikettskanningar)."
     },
     "ctTables": {
       "list": "List-tabellen",
@@ -3211,6 +3213,15 @@
       "notCarriedWishlist": "Önskelistor",
       "notCarriedWhy": "CellarTrackers exportfiler innehåller helt enkelt inte det här, så ingen import kan ta med det."
     },
+    "vivinoHistory": {
+      "title": "Det här ser ut som din Vivino-skanningshistorik",
+      "body": "Den här filen listar varje vin du har skannat eller recenserat på Vivino — inte flaskorna som just nu finns i din källare. Dina betyg, recensioner, personliga anteckningar och drickfönster följer med oavsett. Välj vad vinerna ska bli:",
+      "historyTitle": "Dryckeshistorik",
+      "recommended": "Rekommenderas",
+      "historyDesc": "Varje vin läggs till som en konsumerad flaska, daterad till när du skannade det. Det visas i din historik och statistik, inte bland dina flaskor i lager.",
+      "cellarTitle": "Flaskor i min källare",
+      "cellarDesc": "Varje vin läggs till som en flaska du äger just nu. Välj bara detta om listan verkligen motsvarar vad som finns i din källare."
+    },
     "upload": {
       "resumeReviewTitle": "Dina matchade resultat finns kvar",
       "resumeReviewMeta": "Gå tillbaka till granskningen för att behålla varje matchning, överhoppning och manuellt val. Att matcha om nedan börjar om granskningen.",
@@ -3226,7 +3237,7 @@
       "oenoTitle": "Oeno by Vintec",
       "genericTitle": "Generisk CSV",
       "cellarionDesc": "Ladda ner från valfri källare via ⋯ → Exportera (JSON). Flaskor från alla källare i filen importeras till källaren du väljer här — för att återskapa hela källare med hyllor och layout, använd Importera källare i Inställningar istället.",
-      "vivinoDesc": "Exportera din samling från Vivino-appens inställningar",
+      "vivinoDesc": "Källarexporter importeras som flaskor; nedladdningen \"full wine list\" (din skanningshistorik) kan importeras som dryckeshistorik",
       "cellartrackerDesc": "Exportera från CellarTracker via My Cellar → Download",
       "oenoDesc": "Äkta Oeno by Vintec-export — CSV i två sektioner med skåpdefinitioner + flaskor. Skåp, hyllplan och flaskhistorik importeras automatiskt.",
       "genericDesc": "Valfri CSV med kolumnerna Wine, Producer och Vintage",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -3219,6 +3219,8 @@
       "historyTitle": "Dryckeshistorik",
       "recommended": "Rekommenderas",
       "historyDesc": "Varje vin läggs till som en konsumerad flaska, daterad till när du skannade det. Det visas i din historik och statistik, inte bland dina flaskor i lager.",
+      "wishlistTitle": "Min önskelista",
+      "wishlistDesc": "Varje vin läggs till i din önskelista (dubbletter hoppas över). Endast viner som matchats mot registret kan läggas till.",
       "cellarTitle": "Flaskor i min källare",
       "cellarDesc": "Varje vin läggs till som en flaska du äger just nu. Välj bara detta om listan verkligen motsvarar vad som finns i din källare."
     },
@@ -3418,6 +3420,7 @@
       "title": "Importen är klar",
       "activeBottles": "Aktiva flaskor",
       "consumedHistory": "Konsumerade (historik)",
+      "wishlistAdded": "Tillagda i önskelistan",
       "skipped": "Överhoppade",
       "errors": "Fel",
       "racksCreated_one": "Hylla skapad",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -3421,6 +3421,8 @@
       "activeBottles": "Aktiva flaskor",
       "consumedHistory": "Konsumerade (historik)",
       "wishlistAdded": "Tillagda i önskelistan",
+      "allWishlistedNote_one": "Ditt vin lades till i din önskelista.",
+      "allWishlistedNote_other": "Alla {{count}} viner lades till i din önskelista.",
       "skipped": "Överhoppade",
       "errors": "Fel",
       "racksCreated_one": "Hylla skapad",

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1551,6 +1551,59 @@
   color: var(--color-text-muted);
 }
 
+/* ── Vivino scan-history destination choice (upload step) ────────────────── */
+
+.vivino-history-body {
+  margin: 0 0 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+.vivino-history-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.vivino-history-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.vivino-history-option.selected {
+  border-color: var(--color-primary);
+  background: var(--color-surface-hover);
+}
+
+.vivino-history-option input {
+  margin-top: 0.2rem;
+  flex-shrink: 0;
+}
+
+.vivino-history-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.vivino-history-option-desc {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.vivino-history-recommended {
+  margin-left: 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-success);
+}
+
 /* ── Honest reporting: done-step partial-success state ───────────────────── */
 
 .done-icon-warn {

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -504,10 +504,15 @@ function ImportBottles() {
   // scanDate before anything is sent to the backend. In history mode every
   // scan becomes a consumed bottle: consumedAt = scan date and the user's
   // Vivino rating doubles as the drinking rating (it was given at scan
-  // time). The transformed items flow into the validate results, which is
+  // time). In wishlist mode every row becomes a WishlistItem instead of a
+  // bottle. The transformed items flow into the validate results, which is
   // what both the session draft and the confirm payload are built from.
   const prepareItems = () => parsedItems.map(({ scanDate, ...item }) => {
-    if (!vivinoScanHistory || vivinoImportMode !== 'history') return item;
+    if (!vivinoScanHistory) return item;
+    if (vivinoImportMode === 'wishlist') {
+      return { ...item, addToWishlist: true };
+    }
+    if (vivinoImportMode !== 'history') return item;
     return {
       ...item,
       addToHistory: true,
@@ -1014,6 +1019,19 @@ function ImportBottles() {
               <span className="vivino-history-recommended">{t('importBottles.vivinoHistory.recommended')}</span>
             </strong>
             <span className="vivino-history-option-desc">{t('importBottles.vivinoHistory.historyDesc')}</span>
+          </span>
+        </label>
+        <label className={`vivino-history-option ${vivinoImportMode === 'wishlist' ? 'selected' : ''}`}>
+          <input
+            type="radio"
+            name="vivino-import-mode"
+            value="wishlist"
+            checked={vivinoImportMode === 'wishlist'}
+            onChange={() => setVivinoImportMode('wishlist')}
+          />
+          <span className="vivino-history-option-text">
+            <strong>{t('importBottles.vivinoHistory.wishlistTitle')}</strong>
+            <span className="vivino-history-option-desc">{t('importBottles.vivinoHistory.wishlistDesc')}</span>
           </span>
         </label>
         <label className={`vivino-history-option ${vivinoImportMode === 'cellar' ? 'selected' : ''}`}>
@@ -1988,6 +2006,12 @@ function ImportBottles() {
             <div className="done-stat">
               <span className="done-number">{importResult.createdHistory}</span>
               <span>{t('importBottles.done.consumedHistory')}</span>
+            </div>
+          )}
+          {importResult.wishlistCreated > 0 && (
+            <div className="done-stat">
+              <span className="done-number">{importResult.wishlistCreated}</span>
+              <span>{t('importBottles.done.wishlistAdded')}</span>
             </div>
           )}
           {skippedCount > 0 && (

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -166,8 +166,9 @@ function ImportBottles() {
   // CellarTracker "what transfers" disclosure panel (upload step)
   const [ctDisclosureDismissed, setCtDisclosureDismissed] = useState(false);
   // Vivino "full wine list" (scan history) detection + the user's choice of
-  // what its rows become: 'history' (consumed bottles, default) or 'cellar'
-  // (active bottles). See isVivinoScanHistory in importMappers.
+  // what its rows become: 'history' (consumed bottles, default), 'wishlist'
+  // (WishlistItems) or 'cellar' (active bottles). See isVivinoScanHistory
+  // in importMappers.
   const [vivinoScanHistory, setVivinoScanHistory] = useState(false);
   const [vivinoImportMode, setVivinoImportMode] = useState('history');
 
@@ -998,6 +999,12 @@ function ImportBottles() {
   // column with no quantity/purchase data). Importing those as active
   // bottles silently inflates the cellar with wines drunk years ago, so the
   // destination is an explicit choice, defaulting to drinking history.
+  const VIVINO_MODE_OPTIONS = [
+    { mode: 'history', titleKey: 'importBottles.vivinoHistory.historyTitle', descKey: 'importBottles.vivinoHistory.historyDesc', recommended: true },
+    { mode: 'wishlist', titleKey: 'importBottles.vivinoHistory.wishlistTitle', descKey: 'importBottles.vivinoHistory.wishlistDesc' },
+    { mode: 'cellar', titleKey: 'importBottles.vivinoHistory.cellarTitle', descKey: 'importBottles.vivinoHistory.cellarDesc' },
+  ];
+
   const renderVivinoHistoryChoice = () => detectedFormat === 'vivino' && vivinoScanHistory && (
     <div className="ct-disclosure-panel vivino-history-panel">
       <div className="ct-disclosure-head">
@@ -1005,48 +1012,24 @@ function ImportBottles() {
       </div>
       <p className="vivino-history-body">{t('importBottles.vivinoHistory.body')}</p>
       <div className="vivino-history-options" role="radiogroup" aria-label={t('importBottles.vivinoHistory.title')}>
-        <label className={`vivino-history-option ${vivinoImportMode === 'history' ? 'selected' : ''}`}>
-          <input
-            type="radio"
-            name="vivino-import-mode"
-            value="history"
-            checked={vivinoImportMode === 'history'}
-            onChange={() => setVivinoImportMode('history')}
-          />
-          <span className="vivino-history-option-text">
-            <strong>
-              {t('importBottles.vivinoHistory.historyTitle')}
-              <span className="vivino-history-recommended">{t('importBottles.vivinoHistory.recommended')}</span>
-            </strong>
-            <span className="vivino-history-option-desc">{t('importBottles.vivinoHistory.historyDesc')}</span>
-          </span>
-        </label>
-        <label className={`vivino-history-option ${vivinoImportMode === 'wishlist' ? 'selected' : ''}`}>
-          <input
-            type="radio"
-            name="vivino-import-mode"
-            value="wishlist"
-            checked={vivinoImportMode === 'wishlist'}
-            onChange={() => setVivinoImportMode('wishlist')}
-          />
-          <span className="vivino-history-option-text">
-            <strong>{t('importBottles.vivinoHistory.wishlistTitle')}</strong>
-            <span className="vivino-history-option-desc">{t('importBottles.vivinoHistory.wishlistDesc')}</span>
-          </span>
-        </label>
-        <label className={`vivino-history-option ${vivinoImportMode === 'cellar' ? 'selected' : ''}`}>
-          <input
-            type="radio"
-            name="vivino-import-mode"
-            value="cellar"
-            checked={vivinoImportMode === 'cellar'}
-            onChange={() => setVivinoImportMode('cellar')}
-          />
-          <span className="vivino-history-option-text">
-            <strong>{t('importBottles.vivinoHistory.cellarTitle')}</strong>
-            <span className="vivino-history-option-desc">{t('importBottles.vivinoHistory.cellarDesc')}</span>
-          </span>
-        </label>
+        {VIVINO_MODE_OPTIONS.map(({ mode, titleKey, descKey, recommended }) => (
+          <label key={mode} className={`vivino-history-option ${vivinoImportMode === mode ? 'selected' : ''}`}>
+            <input
+              type="radio"
+              name="vivino-import-mode"
+              value={mode}
+              checked={vivinoImportMode === mode}
+              onChange={() => setVivinoImportMode(mode)}
+            />
+            <span className="vivino-history-option-text">
+              <strong>
+                {t(titleKey)}
+                {recommended && <span className="vivino-history-recommended">{t('importBottles.vivinoHistory.recommended')}</span>}
+              </strong>
+              <span className="vivino-history-option-desc">{t(descKey)}</span>
+            </span>
+          </label>
+        ))}
       </div>
     </div>
   );
@@ -1952,7 +1935,7 @@ function ImportBottles() {
   };
 
   const renderDoneStep = () => {
-    const { created, totalRows, skippedCount, errorCount, unplacedCount, unresolvedCount, missedCount, fullSuccess } =
+    const { created, wishlistCreated, succeeded, totalRows, skippedCount, errorCount, unplacedCount, unresolvedCount, missedCount, fullSuccess } =
       summariseImportOutcome(importResult, userSkippedRows.length, unresolvedRows.length);
 
     // Everything that didn't become a bottle, with per-row reasons: rows the
@@ -1980,13 +1963,19 @@ function ImportBottles() {
         <>
           <div className="done-icon">&#10003;</div>
           <h2>{t('importBottles.done.title')}</h2>
-          <p className="done-subtitle">{t('importBottles.done.allImportedNote', { count: created })}</p>
+          <p className="done-subtitle">
+            {/* Wishlist-only imports create no bottles — "made it into your
+                cellar" would be wrong, so they get their own success note. */}
+            {wishlistCreated > 0 && created === 0
+              ? t('importBottles.done.allWishlistedNote', { count: wishlistCreated })
+              : t('importBottles.done.allImportedNote', { count: succeeded })}
+          </p>
         </>
       ) : (
         <>
           <div className="done-icon done-icon-warn">!</div>
           <h2>{t('importBottles.done.partialTitle', {
-            created: created.toLocaleString(),
+            created: succeeded.toLocaleString(),
             total: totalRows.toLocaleString()
           })}</h2>
           <p className="done-subtitle done-partial-note">

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -165,6 +165,11 @@ function ImportBottles() {
   const [aiSearchingRow, setAiSearchingRow] = useState(null); // index of fuzzy row doing forced AI search
   // CellarTracker "what transfers" disclosure panel (upload step)
   const [ctDisclosureDismissed, setCtDisclosureDismissed] = useState(false);
+  // Vivino "full wine list" (scan history) detection + the user's choice of
+  // what its rows become: 'history' (consumed bottles, default) or 'cellar'
+  // (active bottles). See isVivinoScanHistory in importMappers.
+  const [vivinoScanHistory, setVivinoScanHistory] = useState(false);
+  const [vivinoImportMode, setVivinoImportMode] = useState('history');
 
   // AI daily budget (rows with aiSkipped fell back to fuzzy matching).
   // Status from GET /api/ai-budget/status: { dailyMax, usedToday, override, pendingRequest }
@@ -410,6 +415,8 @@ function ImportBottles() {
         setImportWarnings(parsed.warnings || []);
         setCtTextFallback(parsed.ctRackAutoMap?.textFallback || []);
         setCtDisclosureDismissed(false); // new file → show the CT disclosure again
+        setVivinoScanHistory(!!parsed.vivinoScanHistory);
+        setVivinoImportMode('history'); // new file → back to the recommended default
         setFileName(file.name);
 
         // Build per-rack summary + seed editable config with format-aware
@@ -493,11 +500,31 @@ function ImportBottles() {
     }
   }, [apiFetch, cellarId, t]);
 
+  // Apply the Vivino scan-history mode choice and strip the transient
+  // scanDate before anything is sent to the backend. In history mode every
+  // scan becomes a consumed bottle: consumedAt = scan date and the user's
+  // Vivino rating doubles as the drinking rating (it was given at scan
+  // time). The transformed items flow into the validate results, which is
+  // what both the session draft and the confirm payload are built from.
+  const prepareItems = () => parsedItems.map(({ scanDate, ...item }) => {
+    if (!vivinoScanHistory || vivinoImportMode !== 'history') return item;
+    return {
+      ...item,
+      addToHistory: true,
+      consumedReason: 'drank',
+      ...(scanDate ? { consumedAt: scanDate } : {}),
+      ...(item.rating !== undefined
+        ? { consumedRating: item.rating, consumedRatingScale: item.ratingScale }
+        : {}),
+    };
+  });
+
   const handleValidate = async () => {
     setValidating(true);
     setError(null);
 
-    const total = parsedItems.length;
+    const preparedItems = prepareItems();
+    const total = preparedItems.length;
     setValidationProgress({ done: 0, total });
 
     const allResults = [];
@@ -506,7 +533,7 @@ function ImportBottles() {
     try {
       for (let offset = 0; offset < total; offset += VALIDATE_BATCH_SIZE) {
         // Re-index each batch so indices match their position in parsedItems
-        const batch = parsedItems.slice(offset, offset + VALIDATE_BATCH_SIZE);
+        const batch = preparedItems.slice(offset, offset + VALIDATE_BATCH_SIZE);
 
         const data = await validateBatch(batch);
 
@@ -877,6 +904,7 @@ function ImportBottles() {
             count: w.count,
             wines: (w.wines || []).join(', ')
           })}
+          {w.code === 'no-identity-skipped' && t('importBottles.warnings.noIdentitySkipped', { count: w.count })}
         </div>
       ))}
     </div>
@@ -958,6 +986,51 @@ function ImportBottles() {
       </div>
     </div>
 
+  );
+
+  // Vivino "full wine list" exports are scan HISTORY — every label the user
+  // ever scanned — not a cellar inventory (fingerprint: a "Scan date"
+  // column with no quantity/purchase data). Importing those as active
+  // bottles silently inflates the cellar with wines drunk years ago, so the
+  // destination is an explicit choice, defaulting to drinking history.
+  const renderVivinoHistoryChoice = () => detectedFormat === 'vivino' && vivinoScanHistory && (
+    <div className="ct-disclosure-panel vivino-history-panel">
+      <div className="ct-disclosure-head">
+        <strong>{t('importBottles.vivinoHistory.title')}</strong>
+      </div>
+      <p className="vivino-history-body">{t('importBottles.vivinoHistory.body')}</p>
+      <div className="vivino-history-options" role="radiogroup" aria-label={t('importBottles.vivinoHistory.title')}>
+        <label className={`vivino-history-option ${vivinoImportMode === 'history' ? 'selected' : ''}`}>
+          <input
+            type="radio"
+            name="vivino-import-mode"
+            value="history"
+            checked={vivinoImportMode === 'history'}
+            onChange={() => setVivinoImportMode('history')}
+          />
+          <span className="vivino-history-option-text">
+            <strong>
+              {t('importBottles.vivinoHistory.historyTitle')}
+              <span className="vivino-history-recommended">{t('importBottles.vivinoHistory.recommended')}</span>
+            </strong>
+            <span className="vivino-history-option-desc">{t('importBottles.vivinoHistory.historyDesc')}</span>
+          </span>
+        </label>
+        <label className={`vivino-history-option ${vivinoImportMode === 'cellar' ? 'selected' : ''}`}>
+          <input
+            type="radio"
+            name="vivino-import-mode"
+            value="cellar"
+            checked={vivinoImportMode === 'cellar'}
+            onChange={() => setVivinoImportMode('cellar')}
+          />
+          <span className="vivino-history-option-text">
+            <strong>{t('importBottles.vivinoHistory.cellarTitle')}</strong>
+            <span className="vivino-history-option-desc">{t('importBottles.vivinoHistory.cellarDesc')}</span>
+          </span>
+        </label>
+      </div>
+    </div>
   );
 
   const renderUploadStep = () => (
@@ -1077,6 +1150,7 @@ function ImportBottles() {
 
       {parsedItems.length > 0 && renderImportWarnings()}
       {parsedItems.length > 0 && renderCtDisclosure()}
+      {parsedItems.length > 0 && renderVivinoHistoryChoice()}
 
       {parsedItems.length > 0 && parsedItems.some(i => i.price) && (
         <CurrencyPicker

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -36,6 +36,9 @@
  *   grapes        - [string] grape varieties (from Varietal/MasterVarietal)
  *   drinkFrom     - integer drink-window start year, or null
  *   drinkTo       - integer drink-window end year, or null
+ * Vivino imports also emit drinkFrom/drinkTo (from "Drinking Window") plus a
+ * transient `scanDate` that the import UI turns into consumedAt for
+ * scan-history files (see isVivinoScanHistory) and strips otherwise.
  * …and, when a CT Location's bin codes follow a consistent pattern, the rack
  * fields above are auto-derived per bottle (see applyCtRackAutoMap +
  * binCodeParser.js). The freeform `location` string is always kept as well.
@@ -450,6 +453,23 @@ function mapRackFields(get) {
 }
 
 // ── Vivino Mapper ───────────────────────────────────────────────────────────
+//
+// Vivino has TWO CSV exports with different meanings:
+//
+//   A. Cellar export — the user's current inventory. Carries Quantity /
+//      Purchase date / Price columns. Rows are bottles they own.
+//   B. "Full wine list" (app settings → download your data) — the user's
+//      SCAN HISTORY: one row per wine ever scanned or reviewed, with a
+//      "Scan date" column and no quantity or purchase data. Rows are mostly
+//      wines the user drank, not bottles in the cellar.
+//
+// Both share the same column vocabulary, so one mapper handles them; the
+// history file is fingerprinted by isVivinoScanHistory() below and the
+// import UI lets the user choose whether its rows become drinking history
+// (default) or active bottles.
+//
+// Vivino's "Average rating" is the community score and is never imported —
+// same policy as CellarTracker's `CT` column. Only "Your rating" is.
 
 function mapWineType(typeStr) {
   if (!typeStr) return 'red';
@@ -463,16 +483,55 @@ function mapWineType(typeStr) {
   return 'red';
 }
 
+/**
+ * Vivino "Drinking Window" is two space-separated years ("2026 2034").
+ * Tolerates a dash separator ("2026 - 2034"). Returns { drinkFrom, drinkTo }
+ * as integers, or nulls when the value doesn't contain a usable pair —
+ * matching the CT mappers' null convention for "no window".
+ */
+export function parseVivinoDrinkWindow(value) {
+  const years = (value || '').match(/\b(19|20)\d{2}\b/g);
+  if (!years || years.length < 2) return { drinkFrom: null, drinkTo: null };
+  const from = parseInt(years[0], 10);
+  const to = parseInt(years[years.length - 1], 10);
+  if (from > to) return { drinkFrom: null, drinkTo: null };
+  return { drinkFrom: from, drinkTo: to };
+}
+
+/**
+ * Fingerprint Vivino's "full wine list" (scan history) export: it has a
+ * "Scan date" column and none of the inventory columns (Quantity / Purchase
+ * date) a cellar export carries. parseAndMap surfaces this as
+ * `vivinoScanHistory: true` so the import UI can offer the history-vs-cellar
+ * destination choice instead of silently inflating the cellar with every
+ * wine the user ever scanned.
+ */
+export function isVivinoScanHistory(headers) {
+  const h = new Set(headers.map((s) => s.toLowerCase().trim()));
+  return h.has('scan date') && !h.has('quantity') && !h.has('purchase date');
+}
+
 function mapVivinoRow(row) {
   // Vivino CSV columns vary but common ones:
   // "Wine name", "Winery", "Vintage", "Country", "Region", "Appellation",
   // "Wine type", "Price", "Currency", "Rating", "Note", "Quantity",
   // "Purchase date", "Store name", "Bottle size"
+  // The "full wine list" export adds: "Average rating" (community — never
+  // imported), "Scan date", "Your rating", "Your review", "Personal Note",
+  // "Drinking Window", "Link to wine", "Label image".
   const get = makeGetter(row);
 
-  const rating = parseLocaleNumber(get(['Rating', 'My Rating', 'rating']));
+  const rating = parseLocaleNumber(get(['Your rating', 'Rating', 'My Rating', 'rating']));
   const price = parseLocaleNumber(get(['Price', 'price', 'Purchase Price']));
   const qty = parseInt(get(['Quantity', 'quantity', 'Qty', 'Count']), 10);
+  const { drinkFrom, drinkTo } = parseVivinoDrinkWindow(get(['Drinking Window', 'Drinking window']));
+
+  // "Your review" is the published review text, "Personal Note" the private
+  // note — both are the user's own words, so carry both (joined) into notes.
+  const notes = [
+    get(['Your review', 'Note', 'Notes', 'note', 'notes', 'Tasting Note', 'Review']),
+    get(['Personal Note', 'Personal note']),
+  ].filter(Boolean).join('\n');
 
   return {
     wineName: get(['Wine name', 'Wine Name', 'wine name', 'Wine', 'wine']),
@@ -488,9 +547,15 @@ function mapVivinoRow(row) {
     quantity: isNaN(qty) || qty < 1 ? 1 : qty,
     purchaseDate: get(['Purchase date', 'Purchase Date', 'purchase date', 'Date']),
     purchaseLocation: get(['Store name', 'Store', 'store', 'Purchase Location']),
-    notes: get(['Note', 'Notes', 'note', 'notes', 'Tasting Note', 'Review']),
+    notes,
     rating: isNaN(rating) ? undefined : rating,
     ratingScale: inferRatingScale(rating),
+    drinkFrom,
+    drinkTo,
+    // Scan-history exports: when the user picks "drinking history" in the
+    // import UI, this becomes consumedAt. Stripped before items are sent to
+    // the backend either way (see ImportBottles' mode transform).
+    scanDate: tryParseDate(get(['Scan date', 'Scan Date'])),
     location: get(['Location', 'location', 'Bin', 'bin']),
     ...mapRackFields(get),
   };
@@ -1461,11 +1526,16 @@ export function applyCtRackAutoMap(items) {
  *             ctTable?: string, warnings?: object[] }}
  *   `ctTable` identifies which CellarTracker table was fingerprinted
  *   ('list'|'inventory'|'bottles'|'consumed'|'purchase'|'pending').
+ *   `vivinoScanHistory` is true when a Vivino file matches the scan-history
+ *   fingerprint (see isVivinoScanHistory) \u2014 the UI then offers importing the
+ *   rows as drinking history instead of active bottles.
  *   `warnings` are non-blocking notices:
  *     { code: 'ct-truncated' }                       \u2014 exactly 25 data rows
  *       (CellarTracker's "Only wines on this page" default page size)
  *     { code: 'ct-pending-skipped', count, wines }   \u2014 undelivered bottles
  *       skipped (Cellarion has no on-order state)
+ *     { code: 'no-identity-skipped', count }         \u2014 rows with neither a
+ *       wine name nor a producer skipped (e.g. failed Vivino scans)
  * @throws Error with code 'ct-error-page' for HTML error pages, or
  *   'ct-availability' for CT's Availability statistics table.
  */
@@ -1525,6 +1595,7 @@ export function parseAndMap(text, forceFormat) {
   // Map rows and expand quantity > 1 into individual items
   const items = [];
   const ctPendingSkipped = { count: 0, wines: [] };
+  let noIdentitySkipped = 0;
   for (const row of rows) {
     const mapped = mapper(row);
 
@@ -1543,8 +1614,10 @@ export function parseAndMap(text, forceFormat) {
     if (mapped.consumedAt)   mapped.consumedAt   = tryParseDate(mapped.consumedAt);
     if (mapped.dateAdded)    mapped.dateAdded    = tryParseDate(mapped.dateAdded);
 
-    // Skip rows with no wine name and no producer
-    if (!mapped.wineName && !mapped.producer) continue;
+    // Skip rows with no wine name and no producer \u2014 counted so the upload
+    // step can say so instead of the rows just vanishing (Vivino scan
+    // history routinely contains label-image-only rows for failed scans).
+    if (!mapped.wineName && !mapped.producer) { noIdentitySkipped++; continue; }
 
     // `?? 1` not `|| 1`: CT List rows can legitimately carry quantity 0
     // (fully pending wines) and must expand to zero items. All other
@@ -1581,12 +1654,16 @@ export function parseAndMap(text, forceFormat) {
       wines: ctPendingSkipped.wines,
     });
   }
+  if (noIdentitySkipped > 0) {
+    warnings.push({ code: 'no-identity-skipped', count: noIdentitySkipped });
+  }
 
   return {
     items,
     format,
     headers,
     ...(ctTable ? { ctTable } : {}),
+    ...(format === 'vivino' && isVivinoScanHistory(headers) ? { vivinoScanHistory: true } : {}),
     ...(ctRackAutoMap ? { ctRackAutoMap } : {}),
     ...(warnings.length > 0 ? { warnings } : {}),
   };

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -8,6 +8,8 @@ import {
   parseOenoExport,
   detectOenoExportBoundary,
   parseLocaleNumber,
+  parseVivinoDrinkWindow,
+  isVivinoScanHistory,
 } from './importMappers';
 
 // ---------------------------------------------------------------------------
@@ -478,6 +480,85 @@ describe('parseAndMap', () => {
     expect(result.items[0].vintage).toBe('2018');
   });
 
+  // Vivino's "full wine list" download (scan history) — the real header row
+  // from the app-settings export.
+  const VIVINO_HISTORY_HEADER =
+    'Winery,Wine name,Vintage,Region,Country,Regional wine style,Average rating,' +
+    'Scan date,Scan/Review Location,Your rating,Your review,Personal Note,' +
+    'Wine type,Drinking Window,Link to wine,Label image';
+
+  describe('Vivino scan-history export', () => {
+    it('flags the scan-history format and maps the user columns', () => {
+      const csv = VIVINO_HISTORY_HEADER + '\n' +
+        'Château Test,Cuvée Test,2020,Graves,France,Bordeaux Red,3.7,' +
+        '2026-05-06 11:36:35,,4.0,Lovely nose,cadeau zouzou,' +
+        'Red Wine,2026 2034,https://www.vivino.com/wines/1,https://images.vivino.com/labels/x.jpg';
+      const result = parseAndMap(csv);
+      expect(result.format).toBe('vivino');
+      expect(result.vivinoScanHistory).toBe(true);
+      const item = result.items[0];
+      expect(item.wineName).toBe('Cuvée Test');
+      expect(item.producer).toBe('Château Test');
+      // "Your rating" — never the "Average rating" community score
+      expect(item.rating).toBe(4.0);
+      expect(item.ratingScale).toBe('5');
+      // "Your review" + "Personal Note" both land in notes
+      expect(item.notes).toBe('Lovely nose\ncadeau zouzou');
+      expect(item.drinkFrom).toBe(2026);
+      expect(item.drinkTo).toBe(2034);
+      expect(item.scanDate).toBe('2026-05-06');
+    });
+
+    it('never imports the Average rating community score', () => {
+      const csv = VIVINO_HISTORY_HEADER + '\n' +
+        'Château Test,Cuvée Test,2020,Graves,France,Bordeaux Red,3.7,' +
+        '2026-05-06 11:36:35,,,,,Red Wine,,,';
+      const item = parseAndMap(csv).items[0];
+      expect(item.rating).toBeUndefined();
+    });
+
+    it('counts identity-less rows (failed scans) in a warning', () => {
+      const csv = VIVINO_HISTORY_HEADER + '\n' +
+        ',,,,,,,2026-04-09 16:44:14,,,,,,,,https://images.vivino.com/labels/x.jpg\n' +
+        'Château Test,Cuvée Test,2020,Graves,France,Bordeaux Red,3.7,,,,,,Red Wine,,,';
+      const result = parseAndMap(csv);
+      expect(result.items).toHaveLength(1);
+      expect(result.warnings).toContainEqual({ code: 'no-identity-skipped', count: 1 });
+    });
+
+    it('does NOT flag a Vivino cellar export (has Quantity) as scan history', () => {
+      const csv = 'Wine name,Winery,Vintage,Quantity,Purchase date\nMargaux,Chateau Margaux,2015,2,2024-01-05';
+      const result = parseAndMap(csv);
+      expect(result.format).toBe('vivino');
+      expect(result.vivinoScanHistory).toBeUndefined();
+    });
+  });
+
+  describe('parseVivinoDrinkWindow', () => {
+    it('parses the "YYYY YYYY" pair', () => {
+      expect(parseVivinoDrinkWindow('2026 2034')).toEqual({ drinkFrom: 2026, drinkTo: 2034 });
+    });
+    it('tolerates a dash separator', () => {
+      expect(parseVivinoDrinkWindow('2026 - 2034')).toEqual({ drinkFrom: 2026, drinkTo: 2034 });
+    });
+    it('returns nulls for blank, single-year, or inverted values', () => {
+      expect(parseVivinoDrinkWindow('')).toEqual({ drinkFrom: null, drinkTo: null });
+      expect(parseVivinoDrinkWindow('2026')).toEqual({ drinkFrom: null, drinkTo: null });
+      expect(parseVivinoDrinkWindow('2034 2026')).toEqual({ drinkFrom: null, drinkTo: null });
+    });
+  });
+
+  describe('isVivinoScanHistory', () => {
+    it('matches the full-wine-list header set', () => {
+      expect(isVivinoScanHistory(VIVINO_HISTORY_HEADER.split(','))).toBe(true);
+    });
+    it('rejects headers with inventory columns', () => {
+      expect(isVivinoScanHistory(['Wine name', 'Winery', 'Scan date', 'Quantity'])).toBe(false);
+      expect(isVivinoScanHistory(['Wine name', 'Winery', 'Scan date', 'Purchase date'])).toBe(false);
+      expect(isVivinoScanHistory(['Wine name', 'Winery', 'Vintage'])).toBe(false);
+    });
+  });
+
   it('maps generic CSV correctly', () => {
     const csv = 'Wine,Producer,Vintage,Country\nSassicaia,Tenuta San Guido,2017,Italy';
     const result = parseAndMap(csv);
@@ -539,11 +620,12 @@ describe('parseAndMap', () => {
     expect(result.items[0].producer).toBe('Chateau Margaux');
   });
 
-  it('skips rows with no wine name and no producer', () => {
+  it('skips rows with no wine name and no producer, with a warning', () => {
     const csv = 'Wine,Producer,Vintage\n,,2015\nMargaux,CM,2016';
     const result = parseAndMap(csv);
     expect(result.items).toHaveLength(1);
     expect(result.items[0].wineName).toBe('Margaux');
+    expect(result.warnings).toEqual([{ code: 'no-identity-skipped', count: 1 }]);
   });
 
   it('handles BOM-prefixed CSV', () => {

--- a/frontend/src/utils/importPayload.js
+++ b/frontend/src/utils/importPayload.js
@@ -47,5 +47,8 @@ export function buildImportItem(r, selection) {
     consumedRating: r.item.consumedRating,
     consumedRatingScale: r.item.consumedRatingScale,
     consumedNote: r.item.consumedNote,
+    // Wishlist destination (e.g. Vivino scan-history sent to the wishlist):
+    // the backend creates a WishlistItem instead of a Bottle.
+    addToWishlist: r.item.addToWishlist,
   };
 }

--- a/frontend/src/utils/importPayload.test.js
+++ b/frontend/src/utils/importPayload.test.js
@@ -59,6 +59,14 @@ describe('buildImportItem', () => {
     expect(out.wineDefinition).toBeUndefined();
   });
 
+  test('forwards addToWishlist (Vivino scan-history wishlist mode)', () => {
+    const out = buildImportItem(
+      { item: { wineName: 'X', producer: 'Y', vintage: '2018', addToWishlist: true } },
+      'w1'
+    );
+    expect(out.addToWishlist).toBe(true);
+  });
+
   test('forwards internalSlot for cellarion round-trips', () => {
     const out = buildImportItem(
       { item: { wineName: 'X', producer: 'Y', rackName: 'Hex', rackPosition: 11, internalSlot: true } },

--- a/frontend/src/utils/importReport.js
+++ b/frontend/src/utils/importReport.js
@@ -35,6 +35,11 @@
  */
 export function summariseImportOutcome(importResult, userSkippedCount = 0, unresolvedCount = 0) {
   const created = importResult?.created ?? 0;
+  // Rows that became WishlistItems instead of bottles (addToWishlist). They
+  // never increment `created`, so success math must count them separately —
+  // otherwise a perfect wishlist-only import reads as "0 of N imported".
+  const wishlistCreated = importResult?.wishlistCreated ?? 0;
+  const succeeded = created + wishlistCreated;
   const backendSkipped = importResult?.skipped?.length ?? 0;
   const errorCount = importResult?.errors?.length ?? 0;
   const unplacedCount = importResult?.unplaced?.length ?? 0;
@@ -43,13 +48,15 @@ export function summariseImportOutcome(importResult, userSkippedCount = 0, unres
   const missedCount = skippedCount + errorCount + unresolvedCount;
   return {
     created,
+    wishlistCreated,
+    succeeded,
     totalRows,
     skippedCount,
     errorCount,
     unplacedCount,
     unresolvedCount,
     missedCount,
-    fullSuccess: Boolean(importResult) && missedCount === 0 && unplacedCount === 0 && created === totalRows,
+    fullSuccess: Boolean(importResult) && missedCount === 0 && unplacedCount === 0 && succeeded === totalRows,
   };
 }
 
@@ -121,7 +128,7 @@ export function buildOutcomeRows({ importResult, submittedRows = [], userSkipped
  * @returns {string} CSV text (no BOM; the caller prepends one for Excel)
  */
 export function buildImportReportCsv({ importResult, submittedRows = [], userSkippedRows = [], unresolvedRows = [], userSkippedReason, unresolvedReason } = {}) {
-  const { created, totalRows, skippedCount, errorCount, unplacedCount, unresolvedCount } =
+  const { succeeded, totalRows, skippedCount, errorCount, unplacedCount, unresolvedCount } =
     summariseImportOutcome(importResult, userSkippedRows.length, unresolvedRows.length);
 
   // The summary line is intentionally left unquoted (it's for humans; the
@@ -134,7 +141,7 @@ export function buildImportReportCsv({ importResult, submittedRows = [], userSki
     ...(unresolvedCount > 0 ? [`${unresolvedCount} not imported`] : []),
     `${unplacedCount} imported but unplaced`,
   ];
-  const summary = `# Import report: ${created} of ${totalRows} rows imported (${parts.join(', ')})`;
+  const summary = `# Import report: ${succeeded} of ${totalRows} rows imported (${parts.join(', ')})`;
   const header = 'index,wineName,producer,vintage,outcome,reason';
   const lines = buildOutcomeRows({ importResult, submittedRows, userSkippedRows, unresolvedRows, userSkippedReason, unresolvedReason })
     .map(r => [r.index, r.wineName, r.producer, r.vintage, r.outcome, r.reason].map(csvEscape).join(','));

--- a/frontend/src/utils/importReport.test.js
+++ b/frontend/src/utils/importReport.test.js
@@ -56,6 +56,36 @@ describe('summariseImportOutcome', () => {
     expect(out.created).toBe(0);
     expect(out.totalRows).toBe(0);
   });
+
+  it('counts wishlist rows as successes — a perfect wishlist-only import is a full success', () => {
+    const out = summariseImportOutcome(
+      { created: 0, wishlistCreated: 3, total: 3, skipped: [], errors: [], unplaced: [] },
+      0
+    );
+    expect(out.fullSuccess).toBe(true);
+    expect(out.succeeded).toBe(3);
+    expect(out.wishlistCreated).toBe(3);
+    expect(out.created).toBe(0);
+  });
+
+  it('mixed bottle + wishlist rows both count toward success', () => {
+    const out = summariseImportOutcome(
+      { created: 2, wishlistCreated: 1, total: 3, skipped: [], errors: [], unplaced: [] },
+      0
+    );
+    expect(out.fullSuccess).toBe(true);
+    expect(out.succeeded).toBe(3);
+  });
+
+  it('wishlist import with a skipped duplicate is not a full success', () => {
+    const out = summariseImportOutcome(
+      { created: 0, wishlistCreated: 2, total: 3, skipped: [{ index: 1, reason: 'Already on your wishlist' }], errors: [], unplaced: [] },
+      0
+    );
+    expect(out.fullSuccess).toBe(false);
+    expect(out.succeeded).toBe(2);
+    expect(out.skippedCount).toBe(1);
+  });
 });
 
 describe('csvEscape', () => {


### PR DESCRIPTION
## Problem

A user (support contact via Reddit) imported Vivino's **"full wine list"** download and ended up with 482 phantom in-stock bottles — that file is **scan history** (every wine ever scanned, with a `Scan date` column and no quantity/purchase data), not a cellar export. On top of that, the Vivino mapper silently dropped most of the personal data in the file:

| Column | Rows in his file | Before | After |
|---|---|---|---|
| `Your rating` | 144 | dropped | → rating + drinking rating |
| `Personal Note` / `Your review` | 265 | dropped | → notes |
| `Drinking Window` | 308 | dropped | → drinkFrom/drinkTo |
| `Scan date` | 420 | dropped | → consumedAt (history mode) |

He also asked how to import his **wishlist** — there was no path for that at all.

## Changes

### Mapper + detection (frontend)
- `mapVivinoRow`: map `Your rating` (never `Average rating` — community score, same policy as CT's `CT` column), join `Your review` + `Personal Note` into notes, parse `Drinking Window` ("2026 2034") into `drinkFrom`/`drinkTo`, carry the scan date transiently.
- **Scan-history fingerprint**: `isVivinoScanHistory()` — `Scan date` present, no `Quantity`/`Purchase date` → `parseAndMap` returns `vivinoScanHistory: true`.
- **Skipped-rows warning**: rows with no wine name/producer (failed label scans) now produce a visible `no-identity-skipped` warning instead of vanishing.

### Destination choice (frontend)
Flagged files get a 3-way radio panel on the upload step (same visual family as the CT disclosure):
1. **Drinking history** (default) — each scan becomes a consumed bottle dated to the scan; the Vivino rating doubles as the drinking rating. The done screen's existing `createdHistory` counter — previously unreachable for Vivino — now lights up.
2. **My wishlist** — each row becomes a `WishlistItem`.
3. **Bottles in my cellar** — old behaviour, for people whose list really is their cellar.

### Wishlist destination (backend — `POST /api/bottles/import/confirm`)
- New additive per-item field `addToWishlist`: creates a `WishlistItem` for the **importing user** (wishlists are personal — unlike bottles, which belong to the cellar owner).
- Requires a matched registry wine; request-wine rows get a per-row error, never failing the batch.
- Dedup both **in-batch** (scan histories repeat wines; canonical-vintage identity so `''` and `'NV'` collide) and against **already-wanted** items — same filter as `POST /api/wishlist`.
- `wishlistCreated` added to the response + `bottle.import` audit details; done screen shows an "Added to wishlist" stat.
- GDPR: `WishlistItem` already covered by account export, deletion cascade and the data registry.

### Copy (en + sv)
FAQ answer + upload format card now explain the two Vivino exports.

## Verified

- Backend: **147 suites, 2193/2193** green (node:24-alpine; 6 new confirm-route tests)
- Frontend: **37 files, 703/703** green (15 new tests) + production build
- End-to-end against the reporter's actual 494-row CSV: 489 items all `addToHistory`, 415 `consumedAt`, 144 drinking ratings, 265 notes, 308 drink windows, 5 skipped-rows warned, no transient-field leak into the payload

## Not in scope (follow-up)

- Label-image URL fetching (Vivino CDN ToS)