### PR TITLE
chore(import): Vivino destination choice is per-file — copy for mixed lists

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3215,7 +3215,7 @@
     },
     "vivinoHistory": {
       "title": "This looks like your Vivino scan history",
-      "body": "This file lists every wine you've scanned or reviewed on Vivino — not the bottles currently in your cellar. Your ratings, reviews, personal notes and drinking windows come along either way. Choose what these wines should become:",
+      "body": "This file lists every wine you've scanned or reviewed on Vivino — not the bottles currently in your cellar. Your ratings, reviews, personal notes and drinking windows come along either way. Choose what these wines should become — the choice applies to every row in this file. If your list mixes wines you still own, wines you've drunk and wines you just want, import the file once per destination and skip the other rows during review, or split the CSV first.",
       "historyTitle": "Drinking history",
       "recommended": "Recommended",
       "historyDesc": "Each wine is added as a consumed bottle, dated to when you scanned it. It appears in your history and statistics, not among your in-stock bottles.",

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -3215,7 +3215,7 @@
     },
     "vivinoHistory": {
       "title": "Det här ser ut som din Vivino-skanningshistorik",
-      "body": "Den här filen listar varje vin du har skannat eller recenserat på Vivino — inte flaskorna som just nu finns i din källare. Dina betyg, recensioner, personliga anteckningar och drickfönster följer med oavsett. Välj vad vinerna ska bli:",
+      "body": "Den här filen listar varje vin du har skannat eller recenserat på Vivino — inte flaskorna som just nu finns i din källare. Dina betyg, recensioner, personliga anteckningar och drickfönster följer med oavsett. Välj vad vinerna ska bli — valet gäller alla rader i filen. Om din lista blandar viner du fortfarande äger, viner du har druckit och viner du bara önskar dig, importera filen en gång per destination och hoppa över övriga rader vid granskningen, eller dela upp CSV-filen först.",
       "historyTitle": "Dryckeshistorik",
       "recommended": "Rekommenderas",
       "historyDesc": "Varje vin läggs till som en konsumerad flaska, daterad till när du skannade det. Det visas i din historik och statistik, inte bland dina flaskor i lager.",


### PR DESCRIPTION
Follow-up to #809. The scan-history destination (history / wishlist / cellar) is one global choice per import run. The panel copy now states that explicitly and tells users whose list mixes categories to import once per destination (skipping the other rows at review) or split the CSV first. en + sv.

Per-row destination overrides were considered and deliberately not built (decision: keep the global choice).

Frontend tests 37 files / 706 green (locale-parity included).