### PR TITLE
fix(cellar): keep filters/sort when returning from a bottle page

### DIFF
--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -25,6 +25,23 @@ const DeleteCellarModal = lazy(() => import('../components/DeleteCellarModal').t
 
 const BOTTLES_PER_PAGE = 30;
 
+// Persist the per-cellar filter/sort selection for the tab session so that
+// opening a bottle and hitting browser-back doesn't wipe it (the bottle page is
+// a separate route, so CellarDetail unmounts and remounts on the way back).
+// Deep-link URL params still take priority; this is only the fallback.
+const FILTERS_STORAGE_PREFIX = 'cellarFilters:';
+const buildDefaultFilters = () => ({
+  search: '', type: [], country: [], region: [], appellation: [],
+  grapes: [], vintage: [], minRating: '', maturity: '', unplaced: '', sort: '-createdAt'
+});
+const readSavedFilters = (cellarId) => {
+  try {
+    const raw = sessionStorage.getItem(FILTERS_STORAGE_PREFIX + cellarId);
+    if (raw) return { ...buildDefaultFilters(), ...JSON.parse(raw) };
+  } catch { /* private mode / bad JSON — fall back to defaults */ }
+  return null;
+};
+
 function CellarDetail() {
   const { t } = useTranslation();
   const { id } = useParams();
@@ -55,19 +72,27 @@ function CellarDetail() {
   // over as local state.
   const [activeTab, setActiveTab] = useState(() => searchParams.get('tab') === 'overview' ? 'overview' : 'bottles');
   const [showFilterModal, setShowFilterModal] = useState(false);
-  const [filters, setFilters] = useState(() => ({
-    search: searchParams.get('search') || '',
-    type: searchParams.get('type')?.split(',').filter(Boolean) || [],
-    country: searchParams.get('country')?.split(',').filter(Boolean) || [],
-    region: searchParams.get('region')?.split(',').filter(Boolean) || [],
-    appellation: searchParams.get('appellation')?.split(',').filter(Boolean) || [],
-    grapes: searchParams.get('grapes')?.split(',').filter(Boolean) || [],
-    vintage: searchParams.get('vintage')?.split(',').filter(Boolean) || [],
-    minRating: searchParams.get('minRating') || '',
-    maturity: searchParams.get('maturity') || '',
-    unplaced: searchParams.get('unplaced') || '',
-    sort: searchParams.get('sort') || '-createdAt'
-  }));
+  const [filters, setFilters] = useState(() => {
+    // A deep link with any filter param wins (shared/bookmarked URL). Otherwise
+    // restore the last-used selection for this cellar so browser-back keeps it.
+    const hasUrlFilters = ['search', 'type', 'country', 'region', 'appellation',
+      'grapes', 'vintage', 'minRating', 'maturity', 'unplaced', 'sort']
+      .some(k => searchParams.has(k));
+    if (!hasUrlFilters) return readSavedFilters(id) || buildDefaultFilters();
+    return {
+      search: searchParams.get('search') || '',
+      type: searchParams.get('type')?.split(',').filter(Boolean) || [],
+      country: searchParams.get('country')?.split(',').filter(Boolean) || [],
+      region: searchParams.get('region')?.split(',').filter(Boolean) || [],
+      appellation: searchParams.get('appellation')?.split(',').filter(Boolean) || [],
+      grapes: searchParams.get('grapes')?.split(',').filter(Boolean) || [],
+      vintage: searchParams.get('vintage')?.split(',').filter(Boolean) || [],
+      minRating: searchParams.get('minRating') || '',
+      maturity: searchParams.get('maturity') || '',
+      unplaced: searchParams.get('unplaced') || '',
+      sort: searchParams.get('sort') || '-createdAt'
+    };
+  });
   const [facets, setFacets] = useState(null);
   const [baseFacets, setBaseFacets] = useState(null);
   const [facetMeta, setFacetMeta] = useState(null);
@@ -121,6 +146,14 @@ function CellarDetail() {
       setSearchParams({}, { replace: true });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Remember the filter/sort selection per cellar so it survives leaving the
+  // page (e.g. opening a bottle and coming back). Restored by the initializer.
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(FILTERS_STORAGE_PREFIX + id, JSON.stringify(filters));
+    } catch { /* quota / private mode — persistence is best-effort */ }
+  }, [id, filters]);
 
   // Serialize array filters for dependency comparison
   const filterKey = [


### PR DESCRIPTION
## Problem

Reported via support (rekerukuru):

> - apply filter on cellar to order wine differently
> - open a wine description
> - back to my cellar
> - filter has been reset

## Root cause

`CellarDetail` seeds its filter/sort state from URL params on mount, then deliberately clears those params to keep the URL clean — but it never persists the selection anywhere. The bottle detail page is a **separate route** (`/cellars/:id/bottles/:bottleId`), so opening a bottle unmounts `CellarDetail`; navigating back remounts it fresh with an empty URL, and filters fall back to defaults.

## Fix

Persist the per-cellar filter/sort selection in `sessionStorage` (a convention already used in `AuthContext`, `CellarChat`, `InstallPrompt`) and restore it from the initializer when no deep-link filter params are present.

- Deep-link URL params still take priority (shared/bookmarked links are unchanged).
- Clean-URL behaviour is unchanged — nothing is added to shareable URLs.
- `sessionStorage` writes are wrapped in try/catch for private mode / quota.
- Scoped per cellar id; `clearAll` persists the cleared state as expected.

Kept narrow to the reported symptom (filters + sort). Active tab and the cross-cellar scope picker have their own deliberate reset behaviour and are left as-is.

## Testing

- `cd frontend && npm test` → 707 passed.
- Manual: apply a sort/filter, open a bottle, hit back → selection preserved.

## Docker / compose impact

None — frontend-only change, no new env vars or services.