### PR TITLE
release: v1.87.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.86.0",
+  "version": "1.87.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.86.0",
+  "version": "1.87.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for v1.87.0. Ships everything merged since v1.86.0:

- #809 Vivino scan-history import (ratings, notes, drink windows, history mode) + #812 per-file destination guidance
- #815 MCP: capture_tasting_note occasion form — several bottles, title, people, mood in ONE journal entry
- #814 cellar filters/sort survive opening a bottle page
- #807 #808 #810 #811 #813 community-translation infrastructure + i18n fixes + Swedish update
- #806 deps: sharp 0.35, dompurify 3.4.12

Full suites green on merged main: backend 147/2202 (node:24-alpine, fresh npm ci), frontend 37/707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)