### PR TITLE
fix(import): anchor Vivino history bottles to the scan date (dateAdded)

### DIFF
--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -8,6 +8,7 @@ import { searchWines } from '../api/wines';
 import { getRacks } from '../api/racks';
 import { parseAndMap, parseJSON, summariseRacks, getDefaultRackConfig, getDefaultAnchor, decodeImportBuffer } from '../utils/importMappers';
 import { buildImportItem as buildImportItemPayload } from '../utils/importPayload';
+import { prepareImportItems } from '../utils/importPrepare';
 import { describePriceWarning } from '../utils/priceValidation';
 import { summariseImportOutcome, buildImportReportCsv } from '../utils/importReport';
 import {
@@ -501,29 +502,10 @@ function ImportBottles() {
     }
   }, [apiFetch, cellarId, t]);
 
-  // Apply the Vivino scan-history mode choice and strip the transient
-  // scanDate before anything is sent to the backend. In history mode every
-  // scan becomes a consumed bottle: consumedAt = scan date and the user's
-  // Vivino rating doubles as the drinking rating (it was given at scan
-  // time). In wishlist mode every row becomes a WishlistItem instead of a
-  // bottle. The transformed items flow into the validate results, which is
-  // what both the session draft and the confirm payload are built from.
-  const prepareItems = () => parsedItems.map(({ scanDate, ...item }) => {
-    if (!vivinoScanHistory) return item;
-    if (vivinoImportMode === 'wishlist') {
-      return { ...item, addToWishlist: true };
-    }
-    if (vivinoImportMode !== 'history') return item;
-    return {
-      ...item,
-      addToHistory: true,
-      consumedReason: 'drank',
-      ...(scanDate ? { consumedAt: scanDate } : {}),
-      ...(item.rating !== undefined
-        ? { consumedRating: item.rating, consumedRatingScale: item.ratingScale }
-        : {}),
-    };
-  });
+  // Vivino scan-history mode transform — extracted to utils/importPrepare.js
+  // (unit-tested there) so mode/date/rating mapping can't silently drop
+  // fields between the review screen and the created bottles.
+  const prepareItems = () => prepareImportItems(parsedItems, { vivinoScanHistory, vivinoImportMode });
 
   const handleValidate = async () => {
     setValidating(true);

--- a/frontend/src/utils/importPrepare.js
+++ b/frontend/src/utils/importPrepare.js
@@ -1,0 +1,38 @@
+/**
+ * Applies the Vivino scan-history destination choice to parsed rows and
+ * strips the transient scanDate before anything is sent to the backend.
+ * In history mode every scan becomes a consumed bottle; in wishlist mode
+ * every row becomes a WishlistItem instead of a bottle. The transformed
+ * items flow into the validate results, which is what both the session
+ * draft and the confirm payload are built from.
+ *
+ * Extracted from ImportBottles (audit 2026-07-24 M3) so the mode transform
+ * sits behind a unit test like its siblings importMappers/importPayload —
+ * a field dropped here silently disappears between review and creation.
+ */
+export function prepareImportItems(parsedItems, { vivinoScanHistory, vivinoImportMode } = {}) {
+  return parsedItems.map(({ scanDate, ...item }) => {
+    if (!vivinoScanHistory) return item;
+    if (vivinoImportMode === 'wishlist') {
+      return { ...item, addToWishlist: true };
+    }
+    if (vivinoImportMode !== 'history') return item;
+    return {
+      ...item,
+      addToHistory: true,
+      consumedReason: 'drank',
+      // The scan date anchors BOTH ends of the journey: the bottle entered
+      // the collection and was drunk at the scan moment. Without dateAdded
+      // the backend stamps addedToCellarAt = import day, producing "Added
+      // Jul 2026 → Drank May 2019" journeys and negative holding-time
+      // stats (audit 2026-07-24 H1). Vivino histories have no purchase
+      // date, so scanDate is the only truthful anchor.
+      ...(scanDate ? { consumedAt: scanDate, dateAdded: scanDate } : {}),
+      // The user's Vivino rating doubles as the drinking rating (it was
+      // given at scan time).
+      ...(item.rating !== undefined
+        ? { consumedRating: item.rating, consumedRatingScale: item.ratingScale }
+        : {}),
+    };
+  });
+}

--- a/frontend/src/utils/importPrepare.test.js
+++ b/frontend/src/utils/importPrepare.test.js
@@ -1,0 +1,60 @@
+import { describe, test, expect } from 'vitest';
+import { prepareImportItems } from './importPrepare';
+
+const row = (over = {}) => ({
+  wineName: 'Barolo', producer: 'P', vintage: '2015',
+  rating: 4, ratingScale: '5', scanDate: '2019-05-12', ...over,
+});
+
+describe('prepareImportItems', () => {
+  test('non-Vivino files pass through untouched except the transient scanDate', () => {
+    const [out] = prepareImportItems([row()], { vivinoScanHistory: false });
+    expect(out).not.toHaveProperty('scanDate');
+    expect(out).not.toHaveProperty('addToHistory');
+    expect(out).not.toHaveProperty('addToWishlist');
+    expect(out.rating).toBe(4);
+  });
+
+  test('wishlist mode: rows become wishlist items, never consumed bottles', () => {
+    const [out] = prepareImportItems([row()], { vivinoScanHistory: true, vivinoImportMode: 'wishlist' });
+    expect(out.addToWishlist).toBe(true);
+    expect(out).not.toHaveProperty('addToHistory');
+    expect(out).not.toHaveProperty('consumedAt');
+    expect(out).not.toHaveProperty('dateAdded');
+  });
+
+  test('cellar mode: plain active bottles, scanDate stripped', () => {
+    const [out] = prepareImportItems([row()], { vivinoScanHistory: true, vivinoImportMode: 'cellar' });
+    expect(out).not.toHaveProperty('scanDate');
+    expect(out).not.toHaveProperty('addToHistory');
+    expect(out).not.toHaveProperty('consumedAt');
+  });
+
+  test('history mode anchors BOTH journey ends to the scan date (dateAdded + consumedAt)', () => {
+    const [out] = prepareImportItems([row()], { vivinoScanHistory: true, vivinoImportMode: 'history' });
+    expect(out).toMatchObject({
+      addToHistory: true,
+      consumedReason: 'drank',
+      consumedAt: '2019-05-12',
+      // Without dateAdded the backend stamps addedToCellarAt = import day →
+      // inverted journeys and negative daysHeld (audit 2026-07-24 H1).
+      dateAdded: '2019-05-12',
+      consumedRating: 4,
+      consumedRatingScale: '5',
+    });
+    expect(out).not.toHaveProperty('scanDate');
+  });
+
+  test('history mode without a scan date emits neither date (backend falls back to now)', () => {
+    const [out] = prepareImportItems([row({ scanDate: undefined })], { vivinoScanHistory: true, vivinoImportMode: 'history' });
+    expect(out.addToHistory).toBe(true);
+    expect(out).not.toHaveProperty('consumedAt');
+    expect(out).not.toHaveProperty('dateAdded');
+  });
+
+  test('history mode without a rating leaves the consumed rating unset', () => {
+    const [out] = prepareImportItems([row({ rating: undefined, ratingScale: undefined })], { vivinoScanHistory: true, vivinoImportMode: 'history' });
+    expect(out).not.toHaveProperty('consumedRating');
+    expect(out).not.toHaveProperty('consumedRatingScale');
+  });
+});


### PR DESCRIPTION
Audit 2026-07-24 **H1** (+ its test twin **M3**), release-gating for v1.87.1.

History mode set `consumedAt = scanDate` but never emitted `dateAdded`. Vivino scan histories have no purchase-date column, so the backend anchored `addedToCellarAt = now` — producing inverted journeys ("Added Jul 2026 → Drank May 2019") and negative `daysHeld` rows in the Statistics holding-time buckets on every history import (the feature's default mode).

- History mode now emits `dateAdded: scanDate` alongside `consumedAt` — the backend (`import.js:914-920`) already honours it.
- The whole mode transform is extracted from `ImportBottles.js` to `utils/importPrepare.js` with a 6-case suite beside it (M3): pass-through, wishlist, cellar, history (both dates + rating doubling), no-scanDate, no-rating.

Tests: new suite green; full frontend suite in the release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)