### PR TITLE
fix(mcp): route thrown rating-write failures through the tasting-note compensation path

### DIFF
--- a/backend/src/mcp/arrangeTasting.test.js
+++ b/backend/src/mcp/arrangeTasting.test.js
@@ -392,6 +392,20 @@ describe('capture_tasting_note', () => {
     expect(tool('capture_tasting_note').selfBudgeted).toBe(true);
     expect(takeMutationSlot).toHaveBeenCalledWith(ME, 1, null);
   });
+
+  test('a THROWN consumed-rating save (VersionError) still compensates: entry deleted, conflict, no ledger row (audit M1)', async () => {
+    const b = ownBottle({ status: 'drank', consumedRating: null, consumedRatingScale: null });
+    b.save.mockRejectedValue(Object.assign(new Error('version conflict'), { name: 'VersionError' }));
+    JournalEntry.create.mockResolvedValue({ _id: new mongoose.Types.ObjectId(oid('9')) });
+    JournalEntry.findOneAndDelete.mockResolvedValue({ _id: oid('9') });
+
+    const res = await tool('capture_tasting_note').handler({ bottle_id: oid('d'), note: 'x', rating: 5 }, CTX);
+    const body = parse(res);
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message).toContain('Nothing was saved');
+    expect(JournalEntry.findOneAndDelete).toHaveBeenCalledWith({ _id: expect.anything(), user: ME });
+    expect(McpActionLog.create).not.toHaveBeenCalled();
+  });
 });
 
 describe('capture_tasting_note — occasion form (bottles[])', () => {
@@ -519,6 +533,27 @@ describe('capture_tasting_note — occasion form (bottles[])', () => {
     expect(body.error.message).toContain(oid('b'));
     // b1's previous rating restored, entry compensated away, no ledger row.
     expect(bottleOps.updateBottleFields).toHaveBeenNthCalledWith(3, b1, { rating: 3, ratingScale: '5' }, CTX.req);
+    expect(JournalEntry.findOneAndDelete).toHaveBeenCalledWith({ _id: expect.anything(), user: ME });
+    expect(McpActionLog.create).not.toHaveBeenCalled();
+  });
+
+  test('a THROW mid-batch (consumed save rejects) rolls back applied ratings and deletes the entry (audit M1)', async () => {
+    const { b1, b2 } = wireTwo();
+    b2.save.mockRejectedValue(Object.assign(new Error('version conflict'), { name: 'VersionError' }));
+    JournalEntry.create.mockResolvedValue({ _id: new mongoose.Types.ObjectId(oid('9')) });
+    JournalEntry.findOneAndDelete.mockResolvedValue({ _id: oid('9') });
+    bottleOps.updateBottleFields
+      .mockResolvedValueOnce({ changes: { rating: 4 }, prev: { rating: 3 } }) // b1 apply ok
+      .mockResolvedValueOnce({ changes: {}, prev: {} });                       // b1 rollback
+
+    const res = await tool('capture_tasting_note').handler({
+      bottles: [{ bottle_id: oid('d'), rating: 4 }, { bottle_id: oid('b'), rating: 5 }], note: 'x',
+    }, CTX);
+    const body = parse(res);
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message).toContain(oid('b'));
+    expect(body.error.message).toContain('Nothing was saved');
+    expect(bottleOps.updateBottleFields).toHaveBeenNthCalledWith(2, b1, { rating: 3, ratingScale: '5' }, CTX.req);
     expect(JournalEntry.findOneAndDelete).toHaveBeenCalledWith({ _id: expect.anything(), user: ME });
     expect(McpActionLog.create).not.toHaveBeenCalled();
   });

--- a/backend/src/mcp/tools/tasting.js
+++ b/backend/src/mcp/tools/tasting.js
@@ -204,17 +204,29 @@ registerTool({
 
     // 2. The ratings (pre-validated above). All-or-nothing: a failure rolls
     //    back the already-applied ones and removes the just-created entry.
+    //    THROWN failures (VersionError from a concurrent edit on the direct
+    //    consumed-rating save, document deleted mid-flight) compensate exactly
+    //    like returned ones — an escaping throw would strand the entry and the
+    //    earlier ratings with no ledger row for undo, and the released
+    //    idempotency claim would let a same-key retry double-write (audit
+    //    2026-07-24 M1). Thrown = concurrency-shaped → `conflict`; returned =
+    //    validation-shaped → `invalid_input`, as before.
     const applied = [];
     for (const r of resolved) {
       if (!r.change) continue;
-      const result = await applyRatingChange(r.bottle, r.change, ctx.req);
+      let result;
+      try {
+        result = await applyRatingChange(r.bottle, r.change, ctx.req);
+      } catch (err) {
+        result = { error: { thrown: true, message: err?.message || 'unexpected write failure.' } };
+      }
       if (result.error) {
         let rollbackFailed = 0;
         for (const a of applied.reverse()) {
           if (!(await rollbackRatingChange(a.bottle, a.change, ctx.req))) rollbackFailed += 1;
         }
         await deleteEntry(ctx.user.id, entry._id, ctx.req, { auditMeta: { via: 'mcp', compensation: true } });
-        return fail('invalid_input',
+        return fail(result.error.thrown ? 'conflict' : 'invalid_input',
           `Could not set the rating${multi ? ` on bottle ${r.item.bottle_id}` : ''}: ${result.error.message} Nothing was saved.`
           + (rollbackFailed ? ` (${rollbackFailed} earlier rating(s) could not be rolled back — re-check them.)` : ''));
       }


### PR DESCRIPTION
Audit 2026-07-24 **M1**, release-gating for v1.87.1.

The all-or-nothing compensation in `capture_tasting_note` only fired on a *returned* `{error}`. The consumed-rating branch does a direct `bottle.save()`, which can **throw** (Bottle has `optimisticConcurrency` → VersionError on a concurrent edit; DocumentNotFound on a concurrent delete). An escaping throw skipped the rollback, the entry deletion AND `logAction`: orphaned journal entry, earlier bottles keep their new ratings, no ledger row for `undo_last`, and — because the server wrapper releases the idempotency claim on error — a same-key retry wrote a second entry.

Fix: the apply loop catches throws and routes them through the existing compensation path (rollback applied ratings → delete entry → fail). Thrown, concurrency-shaped failures return `conflict`; returned validation failures keep `invalid_input` as before. After compensation a same-key retry re-executing is now *correct* — nothing was saved.

Tests: 2 new cases (single form consumed-save VersionError; occasion form mid-batch throw with rollback of the applied rating) — suite 30/30 green.

Complementary to (not overlapping) the in-flight `fix/mcp-audit-atomicity` branch, which covers M11 + the undo-path unclaim Lows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)