### PR TITLE
chore(ci): run the test gate on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # The MERGED state of main must be verified too: two PRs green in isolation
+  # can still break combined, and a release is tagged from main's HEAD — which
+  # otherwise never ran CI (bit v1.87.0: #818 then #817 merged sequentially,
+  # so the tagged tree was CI-unverified; audit 2026-07-24 M13).
+  push:
+    branches: [main]
   # Lets a branch be checked before opening the PR, and gives a manual re-run.
   workflow_dispatch: {}
 


### PR DESCRIPTION
Audit 2026-07-24 **M13** (process).

ci.yml triggered on `pull_request` only, and release-docker.yml runs zero tests — so the merged state of main was never CI-verified. This bit v1.87.0 directly: #818 and #817 merged sequentially, meaning the exact tree the release was tagged from never ran suites in CI (mitigated only by local post-merge runs).

One trigger added: `push: branches: [main]`. The existing concurrency group already dedupes rapid sequential merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)