### PR TITLE
fix(mcp): release update_bottle no-change idempotency claim + unclaim tasting undo on mid-undo throws

### DIFF
--- a/backend/src/mcp/revert.js
+++ b/backend/src/mcp/revert.js
@@ -96,7 +96,14 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
       const claimed = await McpActionLog.findOneAndUpdate({ _id: row._id, reversed: false }, { $set: { reversed: true, idempotencyKey: null } });
       if (!claimed) return fail('conflict', 'That action is already being undone by another request.');
 
-      const del = await deleteEntry(ctx.user.id, row.detail?.journalId, ctx.req, { auditMeta: { via: 'undo' } });
+      let del;
+      try {
+        del = await deleteEntry(ctx.user.id, row.detail?.journalId, ctx.req, { auditMeta: { via: 'undo' } });
+      } catch (err) {
+        await unclaim(row._id); // nothing restored yet → let the undo be retried
+        if (err?.name === 'VersionError') return fail('conflict', 'The journal entry changed mid-undo — retry.');
+        throw err;
+      }
       let restored = 0; let skipped = 0; let failed = 0;
       for (const { r, bottle } of restorable) {
         // Same changed-since guard as the single-bottle path: only restore
@@ -110,10 +117,14 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
           const result = await updateBottleFields(bottle, { rating: r.rating, ratingScale: r.ratingScale || undefined }, ctx.req);
           if (result.error) failed += 1; else restored += 1;
         } else {
-          bottle.consumedRating = r.consumedRating ?? undefined;
-          bottle.consumedRatingScale = r.consumedRatingScale || undefined;
-          await bottle.save();
-          restored += 1;
+          try {
+            bottle.consumedRating = r.consumedRating ?? undefined;
+            bottle.consumedRatingScale = r.consumedRatingScale || undefined;
+            await bottle.save();
+            restored += 1;
+          } catch {
+            failed += 1; // a throw counts like a returned error → honest ratings_failed report
+          }
         }
       }
       const parts = [];
@@ -133,7 +144,14 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
     const claimed = await McpActionLog.findOneAndUpdate({ _id: row._id, reversed: false }, { $set: { reversed: true, idempotencyKey: null } });
     if (!claimed) return fail('conflict', 'That action is already being undone by another request.');
 
-    const del = await deleteEntry(ctx.user.id, row.detail?.journalId, ctx.req, { auditMeta: { via: 'undo' } });
+    let del;
+    try {
+      del = await deleteEntry(ctx.user.id, row.detail?.journalId, ctx.req, { auditMeta: { via: 'undo' } });
+    } catch (err) {
+      await unclaim(row._id); // nothing restored yet → let the undo be retried
+      if (err?.name === 'VersionError') return fail('conflict', 'The journal entry changed mid-undo — retry.');
+      throw err;
+    }
     let ratingRestored = false;
     let ratingSkipped = false;
     if (row.prev && row.prev.field) {
@@ -152,10 +170,12 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
         const result = await updateBottleFields(bottle, { rating: row.prev.rating, ratingScale: row.prev.ratingScale || undefined }, ctx.req);
         ratingRestored = !result.error;
       } else {
-        bottle.consumedRating = row.prev.consumedRating ?? undefined;
-        bottle.consumedRatingScale = row.prev.consumedRatingScale || undefined;
-        await bottle.save();
-        ratingRestored = true;
+        try {
+          bottle.consumedRating = row.prev.consumedRating ?? undefined;
+          bottle.consumedRatingScale = row.prev.consumedRatingScale || undefined;
+          await bottle.save();
+          ratingRestored = true;
+        } catch { /* stays false → reported as "rating could NOT be restored" */ }
       }
     }
     const ratingNote = !row.prev?.field ? ''

--- a/backend/src/mcp/revert.test.js
+++ b/backend/src/mcp/revert.test.js
@@ -158,6 +158,50 @@ describe('revertLedgerRow dispatch', () => {
     expect(McpActionLog.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
+  test('tasting_note: deleteEntry THROW after the claim unclaims the row so the undo can be retried', async () => {
+    const { deleteEntry } = require('../services/journalOps');
+    deleteEntry.mockRejectedValue(Object.assign(new Error('v'), { name: 'VersionError' }));
+    resolveBottleAccess.mockResolvedValue({ bottle: { _id: 'b5', save: jest.fn() } });
+    const row = {
+      _id: 'r5', action: 'tasting_note', bottle: 'b5',
+      detail: { journalId: 'j5' }, prev: { field: 'rating', rating: 4, ratingScale: '5' },
+    };
+    const res = await revertLedgerRow(row, ctx(), H);
+    expect(res).toMatchObject({ ok: false, code: 'conflict' });
+    expect(McpActionLog.updateOne).toHaveBeenCalledWith({ _id: 'r5' }, { $set: { reversed: false } });
+    expect(logAction).not.toHaveBeenCalled();
+  });
+
+  test('tasting_note (occasion): deleteEntry THROW unclaims; a consumed-restore throw counts as failed, not thrown', async () => {
+    const { deleteEntry } = require('../services/journalOps');
+    const mkRow = () => ({
+      _id: 'r6', action: 'tasting_note', cellar: 'c1',
+      detail: { journalId: 'j6', count: 2, bottles: [{ bottle: 'ba', rating_changed: true }, { bottle: 'bb', rating_changed: true }] },
+      prev: {
+        ratings: [
+          { bottle: 'ba', field: 'consumedRating', set: { value: 90, scale: '100' }, consumedRating: null, consumedRatingScale: null },
+          { bottle: 'bb', field: 'consumedRating', set: { value: 80, scale: '100' }, consumedRating: null, consumedRatingScale: null },
+        ],
+      },
+    });
+    const ba = { _id: 'ba', consumedRating: 90, consumedRatingScale: '100', save: jest.fn().mockResolvedValue({}) };
+    const bb = { _id: 'bb', consumedRating: 80, consumedRatingScale: '100', save: jest.fn().mockRejectedValue(Object.assign(new Error('v'), { name: 'VersionError' })) };
+    resolveBottleAccess.mockImplementation((_u, id) => Promise.resolve({ bottle: id === 'ba' ? ba : bb }));
+
+    // 1) deleteEntry throws → conflict + unclaim, nothing restored yet.
+    deleteEntry.mockRejectedValueOnce(Object.assign(new Error('v'), { name: 'VersionError' }));
+    let res = await revertLedgerRow(mkRow(), ctx(), H);
+    expect(res).toMatchObject({ ok: false, code: 'conflict' });
+    expect(McpActionLog.updateOne).toHaveBeenCalledWith({ _id: 'r6' }, { $set: { reversed: false } });
+    expect(ba.save).not.toHaveBeenCalled();
+
+    // 2) deleteEntry ok, bb's restore save throws → honest partial report.
+    deleteEntry.mockResolvedValue({ deleted: true });
+    res = await revertLedgerRow(mkRow(), ctx(), H);
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({ ratings_restored: 1, ratings_failed: 1 });
+  });
+
   test('attach_image: deletes the caller\'s own un-assigned image + its files, claims atomically', async () => {
     const BottleImage = require('../models/BottleImage');
     const { unlinkImageFiles } = require('../services/imageProcessor');

--- a/backend/src/mcp/tools/write.js
+++ b/backend/src/mcp/tools/write.js
@@ -27,7 +27,7 @@ const {
   ok, fail, objectId, MSG_CELLAR_NOT_FOUND, MSG_BOTTLE_NOT_FOUND,
   resolveCellarAccess, resolveBottleAccess, wineSummary,
 } = require('../toolUtil');
-const { logAction, replay } = require('../actionLedger');
+const { logAction, replay, releaseClaim } = require('../actionLedger');
 
 const NEW_WINE_SHAPE = {
   name: z.string().trim().min(1).max(200).describe('Wine name WITHOUT the producer in it (e.g. "Sauvignon Blanc", not "Cloudy Bay Sauvignon Blanc")'),
@@ -245,6 +245,11 @@ registerTool({
     if (result.error) return fail('invalid_input', result.error.message);
 
     if (Object.keys(result.changes).length === 0) {
+      // No mutation → logAction never runs, so the claim replay() took above
+      // would stay pending and turn every same-key retry into a bogus `busy`
+      // for CLAIM_STALE_MS (audit 2026-07-24 M11). Release it: a retry simply
+      // re-runs and no-ops again.
+      await releaseClaim(ctx, args.idempotency_key, 'update_bottle');
       return ok('No changes — every value already matched', { bottle_id: bottle._id, changes: {} });
     }
     const envelope = {

--- a/backend/src/mcp/writeTools.test.js
+++ b/backend/src/mcp/writeTools.test.js
@@ -26,7 +26,7 @@ jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: je
 jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
 jest.mock('../models/User', () => ({ findById: jest.fn() }));
 jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
-jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), deleteOne: jest.fn(() => Promise.resolve({})) }));
 jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
 jest.mock('../services/search', () => ({
   getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn(),
@@ -205,6 +205,17 @@ describe('update_bottle', () => {
     body = parse(await tool('update_bottle').handler({ bottle_id: oid('d'), price: 30 }, CTX));
     expect(body.data.changes).toEqual({});
     expect(McpActionLog.create).not.toHaveBeenCalled();
+  });
+
+  test('no-change WITH an idempotency_key releases the claim so a same-key retry re-runs instead of busy (audit M11)', async () => {
+    ownBottle();
+    bottleOps.updateBottleFields.mockResolvedValue({ bottle: { _id: oid('d') }, changes: {}, prev: {} });
+    const body = parse(await tool('update_bottle').handler({ bottle_id: oid('d'), price: 30, idempotency_key: 'k7' }, CTX));
+    expect(body.data.changes).toEqual({});
+    expect(McpActionLog.create).not.toHaveBeenCalled();
+    // The pending claim stub must not be stranded — it would turn every
+    // same-key retry into `busy` until CLAIM_STALE_MS.
+    expect(McpActionLog.deleteOne).toHaveBeenCalledWith({ user: ME, tool: 'update_bottle', idempotencyKey: 'k7', pending: true });
   });
 
   test('foreign bottle → not_found, service untouched', async () => {


### PR DESCRIPTION
Two defects from CODE_AUDIT_2026-07-24 (both in the tagged-but-undeployed v1.87.0 → pre-deploy catches), plus their tests:

## M11 — update_bottle no-change path strands its idempotency claim
`replay()` claim-first inserts a pending stub before the handler runs, and `logAction` completes it — but the "No changes — every value already matched" early return skips `logAction`, and the server wrapper only releases claims on **errors**. Result: an agent that re-asserts an already-matching value with an `idempotency_key` (LLM agents do this constantly) strands a pending stub; every same-key retry gets a bogus `busy` for up to CLAIM_STALE_MS (2 min), and the stale-steal re-strands it. Fix: `releaseClaim` before the no-change `ok` — a retry simply re-runs and no-ops again.

## Undo-throw guards in revert.js tasting branches (audit Lows, M1-class)
The occasion + single-bottle `tasting_note` undo branches ran `deleteEntry` and the consumed-rating restore `save()` unguarded **after** claiming `reversed: true`. A VersionError (Bottle has optimisticConcurrency) or transient DB error mid-undo left the row permanently "already being undone" with nothing restored — the winelist/somm branches already had the unclaim-on-failure pattern; these two were the remaining gaps:
- `deleteEntry` throw → `unclaim` + `conflict` (retryable), matching the winelist pattern
- consumed-restore throw → counted in the honest `ratings_failed` / "could NOT be restored" report instead of escaping raw

## Tests
- `writeTools.test.js`: no-change WITH a key → claim stub deleted (retry re-runs instead of busy)
- `revert.test.js`: deleteEntry throw unclaims (single + occasion); occasion restore-throw reports `ratings_failed: 1` with the other rating still restored

Suites: `arrangeTasting` + `revert` + `writeTools` green in node:24-alpine (67 tests).

Companion PRs from the same audit: #821 (tasting-note throw compensation), #822 (CI push-to-main gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)