### PR TITLE
fix(seo): escape JSON-LD script content in SEOHead (</script> breakout)

### DIFF
--- a/frontend/src/components/SEOHead.js
+++ b/frontend/src/components/SEOHead.js
@@ -3,6 +3,20 @@ import SITE_URL from '../config/siteUrl';
 
 const DEFAULT_IMAGE = `${SITE_URL}/cellarion-logo.jpg`;
 
+// Serialize JSON-LD for embedding inside <script type="application/ld+json">.
+// JSON.stringify does NOT escape `<`/`>`/`&`, and react-helmet-async applies
+// script children via innerHTML — a user-influenced field containing
+// `</script>` (e.g. a registry wine name on WineDetail) could otherwise break
+// out of the script element. Same escaping as the crawler-side twin
+// (backend/src/routes/og.js serializeJsonLd): the JSON stays valid and parses
+// to identical data, while breakout becomes impossible.
+export function serializeJsonLd(obj) {
+  return JSON.stringify(obj)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}
+
 // Single source of truth for public-page SEO meta. Each public page passes its variable
 // bits and gets a complete Helmet block (canonical, OG, Twitter, hreflang, JSON-LD) with
 // no opportunity to forget a tag.
@@ -54,7 +68,7 @@ export default function SEOHead({
         <meta property="article:modified_time" content={articleMeta.modifiedTime} />
       )}
       {jsonLd && (
-        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+        <script type="application/ld+json">{serializeJsonLd(jsonLd)}</script>
       )}
     </Helmet>
   );

--- a/frontend/src/components/SEOHead.test.js
+++ b/frontend/src/components/SEOHead.test.js
@@ -1,0 +1,20 @@
+import { serializeJsonLd } from './SEOHead';
+
+describe('serializeJsonLd', () => {
+  test('neutralizes </script> breakout characters while parsing back to identical data', () => {
+    const jsonLd = {
+      name: 'x</script><img src=https://evil.tld/b>',
+      description: 'Cabernet & friends <3',
+    };
+    const out = serializeJsonLd(jsonLd);
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    expect(out).not.toContain('&');
+    expect(JSON.parse(out)).toEqual(jsonLd);
+  });
+
+  test('plain JSON-LD round-trips unchanged', () => {
+    const jsonLd = { '@context': 'https://schema.org', '@type': 'Product', name: 'Barolo' };
+    expect(JSON.parse(serializeJsonLd(jsonLd))).toEqual(jsonLd);
+  });
+});


### PR DESCRIPTION
CODE_AUDIT_2026-07-24 M4 (live on prod, pre-existing).

`SEOHead` embedded JSON-LD via `JSON.stringify`, which does not escape `<`/`>`/`&` — and react-helmet-async applies script children via `innerHTML`. A user-influenced field reaching `jsonLd` (registry wine names on WineDetail are user-mintable via the AI flows; #770 taxonomy descriptions) containing `</script>` could break out of the script element: the CSP blocks inline handlers, but `img-src https:` still allows a beacon, and structured data corrupts. The backend's crawler-side twin (`og.js serializeJsonLd`) has escaped exactly this since its introduction — with a comment naming the breakout — the SPA side never got it.

Fix: same `<`/`>`/`&` escaping as og.js, exported as `serializeJsonLd` with a unit test (breakout characters gone, JSON parses back to identical data).

Companion audit PRs: #820 (merged), #821, #822, #823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)