### PR TITLE
release: v1.87.1

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Fast-follow patch for v1.87.0 — the release-gating findings from the 2026-07-24 code audit:

- #820 **H1+M3**: Vivino history imports anchor `dateAdded` to the scan date (no more inverted journeys / negative holding-time stats) + the mode transform extracted to `utils/importPrepare.js` with tests
- #821 **M1**: `capture_tasting_note` routes *thrown* rating-write failures through the all-or-nothing compensation path
- #823 **M11 + undo-throw Lows**: `update_bottle` no-change path completes its idempotency claim; tasting-undo unclaims on mid-undo throws
- #822 **M13**: CI now runs on pushes to main, so the tree a release is tagged from is always verified (live for this very release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)