### PR TITLE
fix(import): upfront warning + friendly guard for files over the 2000-row import cap

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3176,12 +3176,15 @@
       "validationNetwork": "Network error during validation",
       "importFailed": "Import failed",
       "importNetwork": "Network error during import",
+      "tooManyRows": "Cannot import {{count}} rows in one run — the cap is {{max}}. Skip rows during review, or split the file and import the rest in a second run.",
       "ctErrorPage": "This file is a CellarTracker error page, not an export — log in to CellarTracker and re-export.",
       "ctAvailability": "This is CellarTracker's Availability table — drinking-window statistics, not a cellar export. Export the List or Inventory table instead.",
       "ctAllPending_one": "The only bottle in this file is a pending (undelivered) purchase — Cellarion doesn't track bottles you haven't received yet.",
       "ctAllPending_other": "All {{count}} bottles in this file are pending (undelivered) purchases — Cellarion doesn't track bottles you haven't received yet."
     },
     "warnings": {
+      "tooManyRowsTitle": "{{count}} rows — more than one import run can take.",
+      "tooManyRows": "Imports are capped at {{max}} rows per run. Split the file and import the parts one at a time (the destination choice applies per file), or skip rows during review — anything above the cap is refused at the final step.",
       "ctTruncatedTitle": "Only 25 rows found — this export may be cut off.",
       "ctTruncated": "This looks like a single-page export (exactly 25 rows). In CellarTracker, choose 'All wines' instead of 'Only wines on this page' before exporting, or your import may be missing most of your cellar.",
       "ctPendingSkipped_one": "{{count}} pending (undelivered) bottle was not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery.",

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -35,6 +35,12 @@ import './ImportBottles.css';
 
 const STEPS = ['upload', 'review', 'importing', 'done'];
 
+// Mirrors backend config/constants MAX_IMPORT_SIZE: /confirm hard-rejects
+// bigger batches in one request, while /validate runs in 25-row slices and
+// happily validates any size — so without an upfront warning a larger file
+// only fails at the very last click, after all the review work.
+const MAX_IMPORT_ROWS = 2000;
+
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 
 const FORMAT_LABEL_KEYS = {
@@ -842,6 +848,16 @@ function ImportBottles() {
     setUnresolvedRows(unresolvedAtReview);
     const items = importableRows.map(buildImportItem);
 
+    // Mirror of the backend cap: /confirm refuses more than MAX_IMPORT_ROWS
+    // in one request — fail here with guidance instead of a bare 400 after
+    // the whole review.
+    if (items.length > MAX_IMPORT_ROWS) {
+      setError(t('importBottles.errors.tooManyRows', { count: items.length, max: MAX_IMPORT_ROWS }));
+      setStep('review');
+      setImporting(false);
+      return;
+    }
+
     try {
       const res = await confirmImport(apiFetch, { cellarId, items, positionAnchor, rackConfigs, defaultCurrency: importCurrency });
       const data = await res.json();
@@ -874,8 +890,14 @@ function ImportBottles() {
   // The CT truncation warning gets elevated styling + a bold headline: a
   // 25-row page export silently missing 90% of a cellar is the single worst
   // "looked like it worked" outcome an import can have.
-  const renderImportWarnings = () => importWarnings.length > 0 && (
+  const renderImportWarnings = () => (importWarnings.length > 0 || parsedItems.length > MAX_IMPORT_ROWS) && (
     <div className="import-parse-warnings">
+      {parsedItems.length > MAX_IMPORT_ROWS && (
+        <div className="import-parse-warning-banner import-parse-warning-strong" role="alert">
+          <strong>{t('importBottles.warnings.tooManyRowsTitle', { count: parsedItems.length })}</strong>{' '}
+          {t('importBottles.warnings.tooManyRows', { max: MAX_IMPORT_ROWS })}
+        </div>
+      )}
       {importWarnings.map((w, i) => (
         <div
           key={i}


### PR DESCRIPTION
CODE_AUDIT_2026-07-24 M2 (in v1.87.0 — Vivino scan histories are the first import source where >2000 rows is a normal file).

`/validate` runs in 25-row batches, so a 2,400-row file validates fully (spending AI budget and the user's review time) — then `/confirm` posts everything at once and hard-rejects with a bare `Maximum 2000 items per import` 400 at the very last click. No client-side check existed.

Fix, mirroring the backend cap (`MAX_IMPORT_SIZE`):
- **Upload-step warning banner** (strong/alert style, same shell as the ct-truncated banner) as soon as a parsed file exceeds 2,000 rows, with the #812-consistent guidance: split the file (the destination choice applies per file) or skip rows during review. Derived from `parsedItems`, so it also survives session restore.
- **`handleImport` guard**: if the post-skip submit count still exceeds the cap, fail immediately with a friendly, specific error and return to review — never posting the doomed request.

EN-only strings via `t()` per the i18n workflow rules. Frontend suite green: 38 files / 713 tests.

Companion audit PRs: #820–#824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)