### PR TITLE
release: v1.87.2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.86.0",
+  "version": "1.87.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.86.0",
+      "version": "1.87.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.87.1",
+  "version": "1.87.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.86.0",
+  "version": "1.87.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.86.0",
+      "version": "1.87.2",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.87.1",
+  "version": "1.87.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for the audit fast-follow 2 patch — ships the two post-v1.87.1 merges:

- #826 fix(import): upfront warning + friendly guard for files over the 2000-row import cap (audit M2)
- #824 fix(seo): JSON-LD `</script>`-breakout escaping in SEOHead (audit M4)

Both frontend-only; no compose/env impact. This bump also includes the package-lock version fields (audit L21 — stops the recurring one-version-behind lockfile noise in unrelated PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)