### PR TITLE
fix(security): bound the OAuth AS, mask the anon MCP budget key, guard token types

### DIFF
--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -98,7 +98,18 @@ const defaults = {
   //             almost no users. It still has to stay bounded (each call
   //             persists an OAuthClient row), so this is a raise, not a removal,
   //             and it is now tunable without a deploy.
-  mcp: { enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000, registerMax: 200 },
+  //   oauthMax — per-IP ceiling per 15 min across the REST of the OAuth
+  //             authorization server (/authorize, /approve, /token, /revoke).
+  //             Those four are exempt from the global apiLimiter/writeLimiter
+  //             for the shared-egress reason above — but the exemption left
+  //             them with NO bound at all (security audit 2026-07-25 M-1), and
+  //             nginx carries no limit_req either, so a self-hosted instance
+  //             had nothing. This restores a ceiling that EXISTS without
+  //             reintroducing a tight one: sized so a whole platform's user
+  //             base can refresh hourly from one egress IP and never see it.
+  //             registerMax stays separate — DCR persists a row per call and
+  //             needs the stricter, per-HOUR bound.
+  mcp: { enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000, registerMax: 200, oauthMax: 2000 },
 };
 
 let cache = {
@@ -169,6 +180,7 @@ async function load() {
           userMax:       doc.value.mcp?.userMax       ?? defaults.mcp.userMax,
           ipMax:         doc.value.mcp?.ipMax         ?? defaults.mcp.ipMax,
           registerMax:   doc.value.mcp?.registerMax   ?? defaults.mcp.registerMax,
+          oauthMax:      doc.value.mcp?.oauthMax      ?? defaults.mcp.oauthMax,
         },
       };
     }

--- a/backend/src/mcp/callBudget.js
+++ b/backend/src/mcp/callBudget.js
@@ -45,11 +45,23 @@ function takeCallSlot(key, max) {
   return w.count <= max;
 }
 
-/** The budget key + cap for a request context (anon → IP, else → user id). */
+/**
+ * The budget key + cap for a request context (anon → IP, else → user id).
+ *
+ * The anonymous key uses rateLimitKey, NOT getClientIp: a client is routinely
+ * assigned a whole IPv6 /64, so keying on the full /128 let one rotate the low
+ * 64 bits for a fresh budget per request. This was the last per-IP key in the
+ * codebase still on the unmasked address after the L-10 sweep (security audit
+ * 2026-07-25 L-1) — and it mattered here because the HTTP limiter in front
+ * (publicMcpLimiter) IS /64-masked, so the two disagreed on what "one client"
+ * means and the effective anonymous ceiling was ~3x the intended one.
+ * (middleware/superAdmin.js keeps getClientIp on purpose — an IP allowlist
+ * needs the exact address.)
+ */
 function budgetFor(ctx) {
   if (ctx.anonymous || !ctx.user) {
     let ip = 'anon';
-    try { ip = require('../utils/clientIp').getClientIp(ctx.req) || 'anon'; } catch { /* no req in unit tests */ }
+    try { ip = require('../utils/clientIp').rateLimitKey(ctx.req) || 'anon'; } catch { /* no req in unit tests */ }
     return { key: `ip:${ip}`, max: PUBLIC_CALL_MAX };
   }
   return { key: `u:${ctx.user.id}`, max: USER_CALL_MAX };

--- a/backend/src/mcp/callBudget.test.js
+++ b/backend/src/mcp/callBudget.test.js
@@ -7,7 +7,17 @@
  * keying (user vs anon IP), and the window rollover.
  */
 
-jest.mock('../utils/clientIp', () => ({ getClientIp: (req) => req?.ip || 'anon' }));
+// Stub only the IP SOURCE (there is no real socket here); the key derivation
+// itself is the genuine implementation, so the /64 assertion below exercises
+// real masking rather than a re-implementation of it.
+jest.mock('../utils/clientIp', () => {
+  const actual = jest.requireActual('../utils/clientIp');
+  return {
+    getClientIp: (req) => req?.ip || 'anon',
+    rateLimitKey: (req) => actual.maskIpForRateLimit(req?.ip || 'anon'),
+    maskIpForRateLimit: actual.maskIpForRateLimit,
+  };
+});
 
 const { takeCallSlot, withinCallBudget, budgetFor, WINDOW_MS, USER_CALL_MAX, PUBLIC_CALL_MAX } = require('./callBudget');
 
@@ -45,6 +55,38 @@ test('budgetFor keys the anonymous surface by client IP with the tighter public 
   expect(max).toBe(PUBLIC_CALL_MAX);
   // Falls back to 'anon' when no req/ip is available (unit-test contexts).
   expect(budgetFor({ anonymous: true }).key).toBe('ip:anon');
+});
+
+// Security audit 2026-07-25 L-1. This budget used getClientIp (the full /128),
+// while the HTTP limiter in front of the same endpoint used rateLimitKey (the
+// /64) — so the two disagreed on what "one client" is, and an IPv6 caller
+// rotating the low 64 bits of its own prefix collected a fresh 200-call budget
+// per address. A single /64 must be a single budget.
+test('an IPv6 caller cannot rotate its /64 suffix for a fresh anonymous budget', () => {
+  const inSamePrefix = [
+    '2001:db8:abcd:1234::1',
+    '2001:db8:abcd:1234::dead:beef',
+    '2001:db8:abcd:1234:aaaa:bbbb:cccc:dddd',
+  ].map((ip) => budgetFor({ anonymous: true, req: { ip } }).key);
+
+  expect(new Set(inSamePrefix).size).toBe(1);
+  expect(inSamePrefix[0]).toBe('ip:2001:db8:abcd:1234::/64');
+
+  // A genuinely different /64 is still its own bucket — the masking must not
+  // collapse unrelated clients together.
+  const otherPrefix = budgetFor({ anonymous: true, req: { ip: '2001:db8:abcd:9999::1' } }).key;
+  expect(otherPrefix).not.toBe(inSamePrefix[0]);
+
+  // IPv4 keeps full precision (one address is one client there).
+  expect(budgetFor({ anonymous: true, req: { ip: '198.51.100.7' } }).key).toBe('ip:198.51.100.7');
+});
+
+test('the shared /64 budget is actually enforced, not just keyed', () => {
+  const spend = (ip) => withinCallBudget({ anonymous: true, req: { ip } });
+  // Burn the public cap from one address inside the prefix…
+  for (let i = 0; i < PUBLIC_CALL_MAX; i++) expect(spend('2001:db8:1:1::1')).toBe(true);
+  // …and a "fresh" address in the SAME /64 is already exhausted.
+  expect(spend('2001:db8:1:1::2')).toBe(false);
 });
 
 test('withinCallBudget charges one slot for the caller', () => {

--- a/backend/src/routes/admin/settings.js
+++ b/backend/src/routes/admin/settings.js
@@ -111,12 +111,18 @@ router.patch('/rate-limits', async (req, res) => {
     // registerMax bounds OAuth Dynamic Client Registration per IP per hour. The
     // floor is 10 (the old hardcoded value) rather than 0 — dropping it lower
     // would block new connections outright rather than merely slow abuse.
+    // oauthMax bounds the rest of the OAuth AS per IP per 15 min. Its floor is
+    // deliberately high (100): every connected client refreshes its access
+    // token at least hourly and a hosted platform does that for its whole user
+    // base from one egress IP, so a low value here disconnects real people
+    // mid-conversation — the exact failure the exemption existed to prevent.
     if (mcp !== undefined) {
       requireIntInRange('mcp.enabled',       mcp.enabled,       0, 1);
       requireIntInRange('mcp.publicEnabled', mcp.publicEnabled, 0, 1);
       requireIntInRange('mcp.userMax',       mcp.userMax,       10, 100_000);
       requireIntInRange('mcp.ipMax',         mcp.ipMax,         100, 1_000_000);
       requireIntInRange('mcp.registerMax',   mcp.registerMax,   10, 100_000);
+      requireIntInRange('mcp.oauthMax',      mcp.oauthMax,      100, 1_000_000);
     }
 
     if (errors.length > 0) {
@@ -165,6 +171,7 @@ router.patch('/rate-limits', async (req, res) => {
         userMax:       mcp?.userMax       ?? previous.mcp?.userMax       ?? rateLimitsConfig.defaults.mcp.userMax,
         ipMax:         mcp?.ipMax         ?? previous.mcp?.ipMax         ?? rateLimitsConfig.defaults.mcp.ipMax,
         registerMax:   mcp?.registerMax   ?? previous.mcp?.registerMax   ?? rateLimitsConfig.defaults.mcp.registerMax,
+        oauthMax:      mcp?.oauthMax      ?? previous.mcp?.oauthMax      ?? rateLimitsConfig.defaults.mcp.oauthMax,
       },
     };
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -352,7 +352,13 @@ router.post('/verify-email', async (req, res) => {
   res.setHeader('Cache-Control', 'no-store');
   const { token } = req.body || {};
 
-  if (!token) {
+  // typeof, not truthiness (security audit 2026-07-25 L-2): a JSON body value
+  // like {"token":{"$ne":null}} is truthy, and crypto's update() then throws a
+  // TypeError that the catch below turns into a 500 with a full stack trace.
+  // Nothing is exploitable — it throws BEFORE the Mongo query, so no operator
+  // ever reaches the database — but an unauthenticated endpoint should answer
+  // 400 for a malformed token instead of logging noise on request.
+  if (typeof token !== 'string' || !token) {
     return res.status(400).json({ error: 'Verification token is required' });
   }
 
@@ -635,7 +641,9 @@ router.post('/forgot-password', forgotLimiter, async (req, res) => {
 router.post('/reset-password', authLimiter, async (req, res) => {
   const { token, password } = req.body;
 
-  if (!token || !password) {
+  // typeof on the token for the same reason as /verify-email (L-2). `password`
+  // needs no guard here — Mongoose casts/validates it and answers 400.
+  if (typeof token !== 'string' || !token || !password) {
     return res.status(400).json({ error: 'Token and new password are required' });
   }
 

--- a/backend/src/routes/auth.refresh.test.js
+++ b/backend/src/routes/auth.refresh.test.js
@@ -629,6 +629,31 @@ describe('POST /api/auth/reset-password', () => {
     expect(after.status).toBe(401);
     expect(after.body).toEqual({ error: 'Invalid or expired refresh token' });
   });
+
+  // Same L-2 guard as /verify-email — this endpoint hashes the token first too.
+  test.each([
+    ['an operator object', { $ne: null }],
+    ['an array',           ['a']],
+    ['a number',           12345],
+  ])('400, never 500, when the token is %s', async (_label, token) => {
+    seedWithResetToken();
+    const res = await request({
+      path: '/api/auth/reset-password',
+      body: { token, password: NEW_PASSWORD },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('a non-string token never reaches the User lookup', async () => {
+    seedWithResetToken();
+    User.findOne.mockClear();
+    const res = await request({
+      path: '/api/auth/reset-password',
+      body: { token: { $ne: null }, password: NEW_PASSWORD },
+    });
+    expect(res.status).toBe(400);
+    expect(User.findOne).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -669,6 +694,31 @@ describe('POST /api/auth/verify-email', () => {
   test('400 with no token', async () => {
     const res = await request({ method: 'POST', path: '/api/auth/verify-email', body: {} });
     expect(res.status).toBe(400);
+  });
+
+  // Security audit 2026-07-25 L-2. A JSON object is truthy, so the old
+  // truthiness check let it reach crypto's update(), which throws a TypeError
+  // the catch turned into a 500 + a full stack trace on an UNAUTHENTICATED
+  // endpoint. Nothing was exploitable (it throws before the Mongo query, so no
+  // operator ever reached the database) — but the answer must be 400.
+  test.each([
+    ['an operator object', { $ne: null }],
+    ['an array',           ['a']],
+    ['a number',           12345],
+    ['a boolean',          true],
+  ])('400, never 500, when the token is %s', async (_label, token) => {
+    const res = await request({ method: 'POST', path: '/api/auth/verify-email', body: { token } });
+    expect(res.status).toBe(400);
+    expect(res.setCookies).toEqual([]);
+  });
+
+  test('a non-string token never reaches the User lookup', async () => {
+    User.findOne.mockClear();
+    const res = await request({
+      method: 'POST', path: '/api/auth/verify-email', body: { token: { $ne: null } },
+    });
+    expect(res.status).toBe(400);
+    expect(User.findOne).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/src/routes/mcp.killswitch.test.js
+++ b/backend/src/routes/mcp.killswitch.test.js
@@ -58,10 +58,18 @@ const post = (path, auth) => fetch(`${baseUrl}${path}`, {
   body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
 });
 
+// Exact-shape on purpose: a new knob in this group must be a deliberate edit
+// here, not something that slips in unnoticed. Every LIMIT must also be a real
+// number — an undefined max makes express-rate-limit treat its endpoint as
+// unlimited, which is how the OAuth AS ended up unbounded (audit M-1).
 test('defaults leave every MCP surface open', async () => {
   expect(rateLimitsConfig.defaults.mcp).toEqual({
-    enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000, registerMax: 200,
+    enabled: 1, publicEnabled: 1, userMax: 300, ipMax: 5000, registerMax: 200, oauthMax: 2000,
   });
+  for (const knob of ['userMax', 'ipMax', 'registerMax', 'oauthMax']) {
+    expect(typeof rateLimitsConfig.defaults.mcp[knob]).toBe('number');
+    expect(rateLimitsConfig.defaults.mcp[knob]).toBeGreaterThan(0);
+  }
   const res = await post('/api/mcp/public');
   expect(res.status).toBe(200);
   expect((await res.json()).handled).toBe(true);

--- a/backend/src/routes/mcpOAuth.js
+++ b/backend/src/routes/mcpOAuth.js
@@ -31,6 +31,44 @@ const registerLimiter = rateLimit({
   legacyHeaders: false,
   message: { error: 'invalid_request', error_description: 'Too many client registrations from this address; try again later.' },
 });
+
+// Ceiling for the REST of the authorization server (security audit 2026-07-25
+// M-1). /authorize, /approve, /token and /revoke are exempt from the global
+// apiLimiter + writeLimiter (app.js `isMcp`) because a hosted platform's whole
+// user base refreshes hourly from one egress IP — but that exemption left them
+// with NO bound whatsoever, and frontend/nginx.conf carries no limit_req, so a
+// self-hosted instance had nothing at all in front of four unauthenticated
+// DB-touching endpoints.
+//
+// This is a ceiling that EXISTS, not a tight one: the number is sized for
+// shared egress and admin-tunable (SuperAdmin → rate limits, mcp.oauthMax) so a
+// bad default is correctable without a deploy — the same lesson registerMax
+// learned on launch day. One shared bucket across the four endpoints keeps the
+// accounting simple; per-endpoint precision would buy nothing here because the
+// point is bounding aggregate load, not shaping it.
+//
+// Note this is NOT a credential-guessing control: auth codes and refresh tokens
+// are 256-bit random, so brute force was never the exposure. What it bounds is
+// unauthenticated DB load and unbounded OAuthAuthCode row creation.
+const oauthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: () => rateLimitsConfig.get().mcp?.oauthMax ?? rateLimitsConfig.defaults.mcp.oauthMax,
+  keyGenerator: (req) => rateLimitKey(req),
+  standardHeaders: true,
+  legacyHeaders: false,
+  // RFC 6749 §5.2-shaped body: an OAuth client that gets a bare {error:"..."}
+  // string reports "broken server" rather than surfacing the real reason.
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, {
+      limiter: 'mcp_oauth',
+      limit: rateLimitsConfig.get().mcp?.oauthMax ?? rateLimitsConfig.defaults.mcp.oauthMax,
+    });
+    res.status(429).json({
+      error: 'temporarily_unavailable',
+      error_description: 'Too many OAuth requests from this address; try again in a few minutes.',
+    });
+  },
+});
 const eventBus = require('../services/eventBus');
 const {
   issuer, resourceUrl, verifyPkce, grantedScopes, redirectUriRegistered,
@@ -146,7 +184,7 @@ router.post('/register', registerLimiter, async (req, res) => {
 });
 
 // ── GET /authorize — validate, then hand off to the frontend consent page ────
-router.get('/authorize', async (req, res) => {
+router.get('/authorize', oauthLimiter, async (req, res) => {
   try {
     const { client_id, redirect_uri, response_type, code_challenge, code_challenge_method, scope, state, resource } = req.query;
 
@@ -193,7 +231,7 @@ router.get('/authorize', async (req, res) => {
 // logged-in user, never a cel_ token or a demo account. Re-validates the whole
 // request against the DB — the browser round-trip through the consent page is
 // UX, not trust.
-router.post('/approve', requireAuth, requireNonDemo, async (req, res) => {
+router.post('/approve', oauthLimiter, requireAuth, requireNonDemo, async (req, res) => {
   try {
     const { client_id, redirect_uri, code_challenge, code_challenge_method, scope, state, resource, approved } = req.body || {};
 
@@ -295,7 +333,7 @@ async function authenticateClient(req) {
 }
 
 // ── POST /token — code exchange + refresh rotation ───────────────────────────
-router.post('/token', async (req, res) => {
+router.post('/token', oauthLimiter, async (req, res) => {
   try {
     const client = await authenticateClient(req);
     if (!client) return oauthError(res, 401, 'invalid_client', 'client authentication failed');
@@ -303,7 +341,15 @@ router.post('/token', async (req, res) => {
 
     if (grantType === 'authorization_code') {
       const { code, code_verifier, redirect_uri, resource } = req.body;
-      if (!code || !code_verifier) return oauthError(res, 400, 'invalid_request', 'code and code_verifier are required');
+      // typeof, not truthiness (L-2). The urlencoded parser below only ever
+      // yields strings, but app.js mounts express.json() on the /api/mcp
+      // PREFIX — which matches /api/mcp/oauth/* — so a caller sending
+      // Content-Type: application/json can put an object here. hashCode()
+      // would then throw a TypeError and the catch would answer 500 instead of
+      // the RFC-shaped invalid_request. (verifyPkce already guards its own.)
+      if (typeof code !== 'string' || !code || !code_verifier) {
+        return oauthError(res, 400, 'invalid_request', 'code and code_verifier are required');
+      }
 
       // Single-use: atomically claim the code (consumedAt null → now). A replay
       // or a lost-response retry finds it already consumed and is rejected.
@@ -343,7 +389,9 @@ router.post('/token', async (req, res) => {
 
     if (grantType === 'refresh_token') {
       const { refresh_token } = req.body;
-      if (!refresh_token) return oauthError(res, 400, 'invalid_request', 'refresh_token is required');
+      if (typeof refresh_token !== 'string' || !refresh_token) {
+        return oauthError(res, 400, 'invalid_request', 'refresh_token is required');
+      }
       const presented = ApiToken.hashToken(refresh_token);
       // Look up the connection by the CURRENT refresh hash.
       const token = await ApiToken.findOne({ refreshTokenHash: presented, origin: 'oauth', revokedAt: null });
@@ -397,12 +445,15 @@ router.post('/token', async (req, res) => {
 });
 
 // ── POST /revoke — RFC 7009 ──────────────────────────────────────────────────
-router.post('/revoke', async (req, res) => {
+router.post('/revoke', oauthLimiter, async (req, res) => {
   try {
     const client = await authenticateClient(req);
     if (!client) return oauthError(res, 401, 'invalid_client', 'client authentication failed');
     const { token } = req.body;
-    if (token) {
+    // typeof for the same JSON-content-type reason as /token (L-2). RFC 7009
+    // §2.2 says an unknown/invalid token is still a 200, so a malformed one
+    // simply falls through to the success response — never a 500.
+    if (typeof token === 'string' && token) {
       // Match either an access token (tokenHash) or a refresh token
       // (refreshTokenHash), but only this client's own OAuth connections.
       const hash = ApiToken.hashToken(token);

--- a/backend/src/routes/mcpOAuth.limits.test.js
+++ b/backend/src/routes/mcpOAuth.limits.test.js
@@ -111,6 +111,72 @@ describe('global limiter exemption for /api/mcp/oauth/*', () => {
   });
 });
 
+// Security audit 2026-07-25 M-1. Exempting /api/mcp/oauth/* from the global
+// limiters (above) was right, but it left the four remaining AS endpoints with
+// NO ceiling at all — and nginx carries no limit_req, so a self-hosted instance
+// had nothing in front of them. The exemption must coexist with a dedicated,
+// generous, admin-tunable bound.
+describe('the OAuth AS has its own ceiling (M-1)', () => {
+  test('oauthMax has a default, is in the mcp group, and is sized for shared egress', () => {
+    expect(rateLimitsConfig.defaults.mcp).toHaveProperty('oauthMax');
+    expect(rateLimitsConfig.get().mcp).toHaveProperty('oauthMax');
+    // Must stay far above the per-user protocol allowance: a whole platform's
+    // user base refreshes hourly through one egress IP.
+    expect(rateLimitsConfig.defaults.mcp.oauthMax)
+      .toBeGreaterThan(rateLimitsConfig.defaults.mcp.userMax);
+  });
+
+  test('the limiter reads the CURRENT value, so a change takes effect without a deploy', () => {
+    const previous = rateLimitsConfig.get();
+    try {
+      rateLimitsConfig.set({ ...previous, mcp: { ...previous.mcp, oauthMax: 123 } });
+      expect(rateLimitsConfig.get().mcp.oauthMax).toBe(123);
+    } finally {
+      rateLimitsConfig.set(previous);
+    }
+  });
+
+  test('a stored config predating oauthMax falls back to the default, never undefined', () => {
+    const previous = rateLimitsConfig.get();
+    try {
+      const { oauthMax, ...withoutOauthMax } = previous.mcp;
+      rateLimitsConfig.set({ ...previous, mcp: withoutOauthMax });
+      // The route resolves `get().mcp?.oauthMax ?? defaults.mcp.oauthMax` —
+      // an undefined max would make express-rate-limit treat it as unlimited,
+      // which is exactly the bug being fixed.
+      const live = rateLimitsConfig.get().mcp?.oauthMax ?? rateLimitsConfig.defaults.mcp.oauthMax;
+      expect(live).toBeGreaterThan(0);
+    } finally {
+      rateLimitsConfig.set(previous);
+    }
+  });
+
+  // Asserted against the SOURCE rather than by requiring the router: pulling
+  // routes/mcpOAuth.js in drags the model + service graph behind it (~1 min in
+  // CI) to prove a one-line wiring fact, and express-rate-limit's middleware is
+  // anonymous on the layer stack so runtime introspection can't identify it
+  // reliably anyway. Every AS route must name a limiter in its own declaration
+  // — that is exactly what regressed, and what a future edit could silently
+  // drop.
+  test('every OAuth AS route declares a limiter', () => {
+    const src = require('fs').readFileSync(require('path').join(__dirname, 'mcpOAuth.js'), 'utf8');
+
+    const expected = {
+      '/register':  'registerLimiter',
+      '/authorize': 'oauthLimiter',
+      '/approve':   'oauthLimiter',
+      '/token':     'oauthLimiter',
+      '/revoke':    'oauthLimiter',
+    };
+
+    for (const [route, limiter] of Object.entries(expected)) {
+      const decl = new RegExp(`router\\.(get|post)\\('${route}',([^)]*?)(async|\\()`, 's').exec(src);
+      expect(decl && decl[2]).toBeTruthy();
+      expect(decl[2]).toContain(limiter);
+    }
+  });
+});
+
 describe('DCR limit is admin-tunable', () => {
   test('registerMax has a default and is exposed in the mcp config group', () => {
     expect(rateLimitsConfig.defaults.mcp.registerMax).toBeGreaterThan(10);

--- a/backend/src/routes/mcpOAuth.test.js
+++ b/backend/src/routes/mcpOAuth.test.js
@@ -409,3 +409,48 @@ describe('POST /revoke', () => {
     expect(r.status).toBe(200);
   });
 });
+
+// Security audit 2026-07-25 L-2. These endpoints declare a urlencoded parser
+// (which only ever yields strings), but app.js mounts express.json() on the
+// /api/mcp PREFIX — and that matches /api/mcp/oauth/* — so a caller sending
+// Content-Type: application/json can put an object where a token string
+// belongs. Hashing it threw a TypeError that surfaced as a 500 with a stack
+// trace instead of the RFC-shaped error. Not exploitable (the throw happens
+// before any query, so no operator reaches Mongo) — but a 500 on an
+// unauthenticated endpoint is both a bad contract and log noise.
+describe('non-string credentials are rejected, never 500 (L-2)', () => {
+  const NON_STRINGS = [
+    ['an operator object', { $ne: null }],
+    ['an array',           ['x']],
+    ['a number',           1234],
+  ];
+
+  test.each(NON_STRINGS)('/token authorization_code: %s code → 400 invalid_request', async (_l, code) => {
+    OAuthClient.findOne.mockResolvedValue(CLIENT);
+    const r = await jsonPost('/token', {
+      grant_type: 'authorization_code', client_id: CLIENT.clientId, code, code_verifier: VERIFIER,
+    });
+    expect(r.status).toBe(400);
+    expect((await r.json()).error).toBe('invalid_request');
+    // Never reached the code lookup.
+    expect(OAuthAuthCode.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test.each(NON_STRINGS)('/token refresh_token: %s refresh_token → 400 invalid_request', async (_l, refresh_token) => {
+    OAuthClient.findOne.mockResolvedValue(CLIENT);
+    const r = await jsonPost('/token', {
+      grant_type: 'refresh_token', client_id: CLIENT.clientId, refresh_token,
+    });
+    expect(r.status).toBe(400);
+    expect((await r.json()).error).toBe('invalid_request');
+    expect(ApiToken.findOne).not.toHaveBeenCalled();
+  });
+
+  test.each(NON_STRINGS)('/revoke: %s token → 200 (RFC 7009) and no lookup', async (_l, token) => {
+    OAuthClient.findOne.mockResolvedValue(CLIENT);
+    const r = await jsonPost('/revoke', { client_id: CLIENT.clientId, token });
+    // RFC 7009 §2.2: an invalid token is still a success — just never a 500.
+    expect(r.status).toBe(200);
+    expect(ApiToken.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/SuperAdmin/TabSettings.js
+++ b/frontend/src/pages/SuperAdmin/TabSettings.js
@@ -140,9 +140,10 @@ function PerIpLimitsPanel({ apiFetch, config, defaults, error }) {
 // hosted connectors (claude.ai, ChatGPT) call from a small shared IP pool, so
 // /api/mcp is exempt from the per-IP limits above and throttled per USER
 // instead, with a high per-IP guard against unauthenticated flooding. The
-// on/off kill switches live on the Admin → AI Connector page; only the three
-// numbers are edited here. PATCHes only { mcp: { userMax, ipMax, registerMax } }
-// — the backend's field-level merge leaves the switches untouched.
+// on/off kill switches live on the Admin → AI Connector page; only the four
+// numbers are edited here. PATCHes only
+// { mcp: { userMax, ipMax, registerMax, oauthMax } } — the backend's
+// field-level merge leaves the switches untouched.
 function McpLimitsPanel({ apiFetch, config, defaults, error }) {
   const [form,   setForm]   = useState(null);
   const [saving, setSaving] = useState(false);
@@ -154,6 +155,7 @@ function McpLimitsPanel({ apiFetch, config, defaults, error }) {
         userMax:     String(config.mcp?.userMax     ?? defaults?.mcp?.userMax     ?? ''),
         ipMax:       String(config.mcp?.ipMax       ?? defaults?.mcp?.ipMax       ?? ''),
         registerMax: String(config.mcp?.registerMax ?? defaults?.mcp?.registerMax ?? ''),
+        oauthMax:    String(config.mcp?.oauthMax    ?? defaults?.mcp?.oauthMax    ?? ''),
       });
     }
   }, [config, defaults]);
@@ -166,6 +168,7 @@ function McpLimitsPanel({ apiFetch, config, defaults, error }) {
           userMax: Number(form.userMax),
           ipMax: Number(form.ipMax),
           registerMax: Number(form.registerMax),
+          oauthMax: Number(form.oauthMax),
         },
       });
       if (!res.ok) { const d = await res.json(); setMsg({ ok: false, text: d.error || 'Save failed' }); }
@@ -209,6 +212,15 @@ function McpLimitsPanel({ apiFetch, config, defaults, error }) {
         defaultValue={defaults?.mcp?.registerMax}
         onChange={v => setForm(f => ({ ...f, registerMax: v }))}
         min={10} max={100000}
+      />
+      <NumberField
+        label="OAuth sign-in flow"
+        unit="req / 15 min / IP"
+        hint="authorize, approve, token and revoke combined. Every connected client refreshes its token at least hourly and a whole platform does that from one egress IP — keep this high; too low disconnects people mid-conversation"
+        value={form.oauthMax}
+        defaultValue={defaults?.mcp?.oauthMax}
+        onChange={v => setForm(f => ({ ...f, oauthMax: v }))}
+        min={100} max={1000000}
       />
     </PanelShell>
   );


### PR DESCRIPTION
Remediates the 2026-07-25 full security audit (`SECURITY_AUDIT_2026-07-25.md`): the one **Medium** and two of the **Lows**. No behavior change for legitimate callers.

## M-1 — the OAuth authorization server had no rate limiter at all

Exempting `/api/mcp/oauth/*` from the global `apiLimiter` + `writeLimiter` was right: a hosted platform's whole user base refreshes its access token hourly through one egress IP, and a 429 there silently disconnects people mid-conversation.

But the exemption went further than the problem. It left `/authorize`, `/approve`, `/token` and `/revoke` with **no ceiling whatsoever** — and `frontend/nginx.conf` carries no `limit_req` either, so a self-hosted instance had nothing in front of four unauthenticated, DB-touching endpoints.

Adds one shared `oauthLimiter` across those four:
- keyed on the masked client IP (`rateLimitKey`)
- reads an admin-tunable `mcp.oauthMax`, default **2000 / 15 min / IP**
- same runtime machinery `registerMax` already uses, so a bad default is correctable from SuperAdmin → rate limits without a deploy — the lesson `registerMax` learned on launch day when a hardcoded 10/hour throttled real users at 6 connections
- 429 body is RFC 6749 §5.2-shaped, so a client reports the real reason instead of "broken server"

**This is not a credential-guessing control.** Auth codes and refresh tokens are 256-bit random, so brute force was never the exposure. What it bounds is unauthenticated DB load and unbounded `OAuthAuthCode` row creation.

## L-1 — the anonymous MCP call budget keyed on the full IPv6 /128

`mcp/callBudget.js` was the last per-IP key still on `getClientIp` after the L-10 sweep converted everything else to `rateLimitKey`. It mattered because the HTTP limiter in front of the *same* endpoint is /64-masked — the two disagreed on what "one client" is, so a caller rotating the low 64 bits of its own prefix collected a fresh 200-call budget per address and the effective anonymous ceiling was ~3× the intended one.

`middleware/superAdmin.js` keeps `getClientIp` deliberately: an IP allowlist needs the exact address.

## L-2 — non-string credentials returned 500 instead of 400

Five endpoints read a token from the body, checked it for *truthiness*, and fed it straight to a sha256 `update()`. A JSON object is truthy, so `update()` threw a `TypeError` the catch turned into a **500 with a full stack trace**.

Nothing was exploitable — the throw happens *before* the Mongo query, so no operator ever reached the database. But a 500 on an unauthenticated endpoint is a bad contract and a cheap log-flooding vector.

The audit found two (`verify-email`, `reset-password`). **Implementing the fix surfaced three more** on the OAuth AS (`/token`'s `code` and `refresh_token`, `/revoke`'s `token`). Those look protected by the urlencoded parser, which only ever yields strings — but `app.js` mounts `express.json()` on the `/api/mcp` **prefix**, and that matches `/api/mcp/oauth/*`, so a caller sending `Content-Type: application/json` reaches them. Verified against the running container rather than reasoned about.

## Notes on the tests

The route-wiring assertion is deliberately **static** (reads the source) rather than requiring the router: pulling `routes/mcpOAuth.js` in drags the model + service graph behind it (~1 min in CI) to prove a one-line fact, and express-rate-limit's middleware is anonymous on the layer stack so runtime introspection can't identify it reliably.

It earned its keep immediately — it caught that I'd left `/revoke` unwired.

`mcp.killswitch.test.js`'s exact-shape assertion on the `mcp` defaults is kept (a new knob should be a deliberate edit) and extended to assert every limit is a real number: an `undefined` max makes express-rate-limit treat its endpoint as unlimited, which is precisely how the AS ended up unbounded.

## Verification

- Backend **2233/2233**, frontend **717/717**
- Full Docker stack rebuilt; live probes against the container:
  - `RateLimit-Limit: 2000` present on `/token` and `/authorize`, `200` on `/register` (its own per-hour limiter, untouched)
  - object-`code` → `400 invalid_request` (was 500); object-`token` on `/revoke` → `200` per RFC 7009 (was 500); object-token on `/verify-email` → `400` (was 500)
  - no `TypeError` stacks in the backend log
  - `/api/health` ok, OAuth discovery still `200`, frontend `200`

## Compose / prod impact

**None.** No new environment variable, no restart-ordering change. The limit reads from the existing admin-tunable `mcp` group, so the number is correctable at runtime after deploy.

## Not in this PR

Remaining audit items, deliberately deferred: **L-3** (registryGc check-then-delete race — belongs with the next registry-integrity pass), **L-4** (frontend `postcss`, build-time only, needs an alpine lockfile regen), **L-5**/**L-6** (standing deferrals).