### PR TITLE
chore(release): v1.88.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.87.2",
+  "version": "1.88.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.87.2",
+      "version": "1.88.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.87.2",
+  "version": "1.88.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.87.2",
+  "version": "1.88.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.87.2",
+      "version": "1.88.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.87.2",
+  "version": "1.88.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — backend + frontend `package.json` and the corresponding `package-lock.json` version fields.

Ships [#833](https://github.com/jagduvi1/Cellarion/pull/833): community languages are offered as soon as they have something to show, labelled with how far along they are, with completeness counted over user-facing strings only.