### PR TITLE
feat(registry): per-rule admin verification for wine-name data-quality checks

### DIFF
--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -147,6 +147,37 @@ const wineDefinitionSchema = new mongoose.Schema({
     enum: ['ui', 'import', 'mcp', 'ai', null],
     default: null
   },
+  // Human data-quality review (support ticket 2026-07-26): the registry's
+  // false-positive whitelist AND its skip-on-rescan record. Each entry is a
+  // RULE ID from utils/nameChecks.js that an admin has read this wine and
+  // confirmed it passes — deliberately NOT a bare `verified` boolean: a rule
+  // id nobody has cleared appears in no wine's array, so a NEW rule (or a
+  // REFINED one, whose id is bumped in the same commit) surfaces all ~4.3k
+  // rows by construction, where a bare flag would have silently suppressed
+  // every rule added after it was set.
+  //
+  // Cleared automatically when `name` or `producer` changes (pre-validate hook
+  // below). SCOPE RULE: only a rule whose verdict reads NOTHING but
+  // name + producer may consult this field — a rule reading country/region/
+  // grapes must check the taxonomy collections instead (renaming a Country
+  // writes nothing here, so no hook could ever invalidate it).
+  //
+  // Absent on rows predating the field; .lean() applies no defaults, so reads
+  // treat undefined as "nothing cleared" (also why no backfill is needed).
+  // Never bulk-set from a script — a machine asserting human review is what
+  // would make the record worthless.
+  verifiedChecks: {
+    type: [String],
+    default: undefined
+  },
+  // When the most recent clearance above was recorded. DISPLAY AND FORENSICS
+  // ONLY — never filter a scan on this: suppression is always per rule id, so
+  // a rule added tomorrow can't be pre-cleared by a timestamp set against
+  // yesterday's rule set. null on rows never reviewed.
+  verifiedAt: {
+    type: Date,
+    default: null
+  },
   createdAt: {
     type: Date,
     default: Date.now
@@ -180,13 +211,27 @@ wineDefinitionSchema.pre('save', function(next) {
   next();
 });
 
-// Keep canonicalKey in sync with the identity fields. pre-validate (not
-// pre-save) so plain doc.validate() computes it too. Covers every save-based
-// write path (create, admin PUT rename, strip-producer); scripted updateOne
-// callers must set it themselves (backfill-canonical-key.js does).
+// Keep canonicalKey in sync with the identity fields, and drop the human-review
+// record when the reviewed strings change. pre-validate (not pre-save) so plain
+// doc.validate() computes it too. Covers every save-based write path (create,
+// admin PUT rename, strip-producer); scripted updateOne callers must set
+// canonicalKey themselves (backfill-canonical-key.js does).
+//
+// verifiedChecks/verifiedAt watch ONLY name + producer, and unlike canonicalKey
+// they have NO scripted-caller blind spot: enumerated 2026-07-26, no updateOne/
+// updateMany/bulkWrite/findByIdAndUpdate caller in the codebase mutates either
+// field on an existing row (admin LWIN import wraps both in $ifNull, so it can
+// only fill them on upsert-insert).
 wineDefinitionSchema.pre('validate', function(next) {
   if (!this.canonicalKey || this.isModified('name') || this.isModified('producer') || this.isModified('appellation')) {
     this.canonicalKey = computeCanonicalKey(this.name, this.producer, this.appellation);
+  }
+  // !isNew: on a create both fields count as "modified" and the defaults are
+  // already empty — being explicit keeps a future born-verified admin-create
+  // flow from being silently undone here.
+  if (!this.isNew && (this.isModified('name') || this.isModified('producer'))) {
+    this.verifiedChecks = undefined;
+    this.verifiedAt = null;
   }
   next();
 });

--- a/backend/src/models/WineDefinition.verifiedChecks.test.js
+++ b/backend/src/models/WineDefinition.verifiedChecks.test.js
@@ -1,0 +1,112 @@
+/**
+ * The pre-validate hook clears the human-review record (verifiedChecks /
+ * verifiedAt) when — and ONLY when — `name` or `producer` changes on an
+ * existing doc. The only-when half is the load-bearing part: taxonomy repairs,
+ * image swaps and the USER-REACHABLE communityRating write
+ * (services/reviewAggregation.js fires on every review) must never un-verify a
+ * curated wine. No DB needed: doc.validate() runs the pre-validate middleware.
+ */
+const mongoose = require('mongoose');
+const WineDefinition = require('./WineDefinition');
+
+const oid = () => new mongoose.Types.ObjectId();
+
+const baseDoc = (overrides = {}) => new WineDefinition({
+  name: 'Block 3 Pinot Noir',
+  producer: 'Felton Road',
+  appellation: 'Bannockburn',
+  country: oid(),
+  createdBy: oid(),
+  normalizedKey: 'raw:key:x',
+  ...overrides,
+});
+
+// A doc that has been saved once ($isNew false, no dirty paths) and carries
+// clearances — the state of a prod row an admin reviewed. A fresh constructor
+// marks EVERY path modified, so unmark the two the hook watches to simulate a
+// loaded document; the other paths don't matter (the hook ignores them).
+const reviewedDoc = async () => {
+  const doc = baseDoc({
+    verifiedChecks: ['name-equals-producer.v1', 'dangling-name-tail.v1'],
+    verifiedAt: new Date('2026-07-26T10:00:00Z'),
+  });
+  doc.$isNew = false;
+  doc.unmarkModified('name');
+  doc.unmarkModified('producer');
+  await doc.validate();
+  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+  return doc;
+};
+
+test('a new doc is born unreviewed', async () => {
+  const doc = baseDoc();
+  await doc.validate();
+  expect((doc.verifiedChecks || []).length).toBe(0);
+  expect(doc.verifiedAt).toBeNull();
+});
+
+test('changing name clears both fields', async () => {
+  const doc = await reviewedDoc();
+  doc.name = 'Block 5 Pinot Noir';
+  await doc.validate();
+  expect((doc.verifiedChecks || []).length).toBe(0);
+  expect(doc.verifiedAt).toBeNull();
+});
+
+test('changing producer clears both fields', async () => {
+  const doc = await reviewedDoc();
+  doc.producer = 'Maude Wines';
+  await doc.validate();
+  expect((doc.verifiedChecks || []).length).toBe(0);
+  expect(doc.verifiedAt).toBeNull();
+});
+
+test('THE FALSE-CLEAR GUARD: every other field change leaves the record intact', async () => {
+  // Protects the user-reachable reviewAggregation communityRating write and
+  // the merge keeper's image adoption from silently un-verifying wines.
+  const mutations = [
+    (d) => { d.appellation = 'Central Otago'; },
+    (d) => { d.country = oid(); },
+    (d) => { d.region = oid(); },
+    (d) => { d.grapes = [oid()]; },
+    (d) => { d.type = 'white'; },
+    (d) => { d.image = 'https://example.com/x.png'; },
+    (d) => { d.imageCredit = 'Someone'; },
+    (d) => { d.aiProfile.description = 'Bright cherry.'; },
+    (d) => { d.communityRating.reviewCount = 7; },
+  ];
+  for (const mutate of mutations) {
+    const doc = await reviewedDoc();
+    mutate(doc);
+    await doc.validate();
+    expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+    expect(doc.verifiedAt).toEqual(new Date('2026-07-26T10:00:00Z'));
+  }
+});
+
+test('reassigning an IDENTICAL name does not clear (the admin PUT posts the whole form)', async () => {
+  // routes/admin/wines.js PUT /:id assigns wine.name = name.trim()
+  // unconditionally; Mongoose does not mark a path modified when a primitive
+  // is reassigned to an identical value — the behaviour this design leans on.
+  const doc = await reviewedDoc();
+  doc.name = 'Block 3 Pinot Noir';
+  doc.producer = 'Felton Road';
+  await doc.validate();
+  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+  expect(doc.verifiedAt).toEqual(new Date('2026-07-26T10:00:00Z'));
+});
+
+test('validate with no modification leaves the record intact', async () => {
+  const doc = await reviewedDoc();
+  await doc.validate();
+  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+});
+
+test('regression: canonicalKey still recomputes on an appellation change', async () => {
+  const doc = await reviewedDoc();
+  const before = doc.canonicalKey;
+  doc.appellation = 'Central Otago';
+  await doc.validate();
+  expect(doc.canonicalKey).not.toBe(before);
+  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+});

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -42,6 +42,10 @@ const { isValidId } = require('../../utils/validation');
 const { escapeRegex } = require('../../utils/sanitize');
 const { parsePagination } = require('../../utils/pagination');
 const { stripProducerName, stripProducerKeyPrefix, canonicalizeWineName } = require('../../utils/producerPrefix');
+const {
+  NAME_CHECKS, NAME_CHECK_IDS, DEFAULT_CHECK_IDS, NAME_CHECK_SELECT,
+  resolveCheck, runNameChecks,
+} = require('../../utils/nameChecks');
 const Country = require('../../models/Country');
 const { findOrCreateWine } = require('../../services/findOrCreateWine');
 
@@ -493,6 +497,91 @@ router.delete('/dismiss-duplicates', async (req, res) => {
   }
 });
 
+// POST /api/admin/wines/verify-checks — record that an admin read these wines
+// and confirmed they pass these specific name checks, so the scan stops
+// surfacing them FOR THOSE CHECKS ONLY. A check added later has no clearance
+// on any row and surfaces the whole registry. DELETE undoes it.
+// Body: { wineIds: [id, …], checks: [ruleId, …] }   (1..N ids)
+//
+// `checks` is required with no "all" default — a hidden default-to-everything
+// would be exactly the bare-flag semantics this design rejects; the client
+// always has the row's `checks` array to send. No MCP tool exists for this on
+// purpose: "a human checked this" asserted by an AI defeats the record.
+router.post('/verify-checks', async (req, res) => {
+  try {
+    const ids = [...new Set((Array.isArray(req.body?.wineIds) ? req.body.wineIds : []).filter(isValidId))];
+    if (ids.length < 1) return res.status(400).json({ error: 'wineIds must contain at least 1 valid id' });
+    if (ids.length > 500) return res.status(400).json({ error: 'At most 500 wineIds per call' });
+
+    const raw = Array.isArray(req.body?.checks) ? req.body.checks : null;
+    const specs = (raw || []).map(resolveCheck);
+    if (!raw || raw.length === 0 || specs.some(s => !s)) {
+      return res.status(400).json({ error: 'checks must be a non-empty array of known check ids' });
+    }
+    const checkIds = [...new Set(specs.map(s => s.id))];
+
+    const oids = ids.map(id => new mongoose.Types.ObjectId(id));
+    const wines = await WineDefinition.find({ _id: { $in: oids } })
+      .select(NAME_CHECK_SELECT).lean();
+    if (wines.length === 0) return res.status(404).json({ error: 'No matching wines' });
+
+    // Re-run the rules server-side, exactly as strip-producer recomputes its
+    // check — a stale client row must not be able to clear a rule the admin
+    // never actually saw on screen.
+    const now = new Date();
+    const ops = [];
+    const notFlagged = [];
+    for (const w of wines) {
+      const hit = runNameChecks(w, { checkIds, ignoreCleared: true });
+      if (!hit) { notFlagged.push(String(w._id)); continue; }
+      ops.push({ updateOne: {
+        filter: { _id: w._id },
+        // $addToSet is idempotent, so re-verifying is safe and ordering is
+        // irrelevant (no $pull/$push pairing on the same path).
+        update: { $addToSet: { verifiedChecks: { $each: hit.checks } }, $set: { verifiedAt: now } },
+      } });
+    }
+    // Nothing searchable, embeddable or public changed: deliberately NO
+    // searchService.indexWine, NO embedSinglePair, NO submitUrls.
+    const result = ops.length ? await WineDefinition.bulkWrite(ops, { ordered: false }) : { modifiedCount: 0 };
+
+    logAudit(req, 'admin.wine.verifyChecks', { type: 'wine', id: ids[0] },
+      { wineIds: ids, checks: checkIds, updated: result.modifiedCount || 0, notFlagged: notFlagged.length });
+    res.json({ message: 'Recorded', updated: result.modifiedCount || 0, checks: checkIds, notFlagged });
+  } catch (error) {
+    console.error('Verify checks error:', error);
+    res.status(500).json({ error: 'Failed to record verification' });
+  }
+});
+
+// DELETE /api/admin/wines/verify-checks — undo the above.
+// verifiedAt is deliberately left as-is: it is display/forensics metadata
+// ("last reviewed"), not the suppression key.
+router.delete('/verify-checks', async (req, res) => {
+  try {
+    const ids = [...new Set((Array.isArray(req.body?.wineIds) ? req.body.wineIds : []).filter(isValidId))];
+    if (ids.length < 1) return res.status(400).json({ error: 'wineIds must contain at least 1 valid id' });
+
+    const raw = Array.isArray(req.body?.checks) ? req.body.checks : null;
+    const specs = (raw || []).map(resolveCheck);
+    if (!raw || raw.length === 0 || specs.some(s => !s)) {
+      return res.status(400).json({ error: 'checks must be a non-empty array of known check ids' });
+    }
+    const checkIds = [...new Set(specs.map(s => s.id))];
+
+    const result = await WineDefinition.updateMany(
+      { _id: { $in: ids.map(id => new mongoose.Types.ObjectId(id)) } },
+      { $pull: { verifiedChecks: { $in: checkIds } } }
+    );
+    logAudit(req, 'admin.wine.unverifyChecks', { type: 'wine', id: ids[0] },
+      { wineIds: ids, checks: checkIds, updated: result.modifiedCount || 0 });
+    res.json({ message: 'Verification cleared', updated: result.modifiedCount || 0 });
+  } catch (error) {
+    console.error('Unverify checks error:', error);
+    res.status(500).json({ error: 'Failed to clear verification' });
+  }
+});
+
 router.get('/duplicates', async (req, res) => {
   try {
     const { name, producer, appellation, threshold = 0.75 } = req.query;
@@ -676,35 +765,59 @@ router.get('/canonical-collisions', async (req, res) => {
   }
 });
 
-// GET /api/admin/wines/producer-in-name — wines whose name STARTS or ENDS
-// with their own producer (prefix: producer "Meerlust", name "Meerlust
-// Chardonnay"; suffix: producer "Mastroberardino", name "Fiano di Avellino
-// Mastroberardino" — the launch-day admin report), INCLUDING producer
-// variants where only the comparison-key tokens are embedded (name "Felton
-// Road Block 3 Pinot Noir", producer "Felton Road Wines Ltd" — the shape the
-// old exact-string $expr scan could never see). Mostly AI-import artefacts;
-// the registry convention is a producer-free name.
+// GET /api/admin/wines/producer-in-name — the registry NAME-CHECK scan. The
+// path keeps its historical name (a rename churns working i18n keys and a
+// live client for zero functional gain) but it now runs every defaultActive
+// rule in utils/nameChecks.js:
+//   producer-in-name.v1        — name starts/ends with its own producer,
+//                                including key-token variants ("Felton Road
+//                                Block 3 Pinot Noir" / "Felton Road Wines Ltd")
+//   dangling-name-tail.v1      — name ends in a stranded connective
+//                                ("La Viña de" — support ticket 2026-07-26)
+//   name-equals-producer.v1    — name === producer, non-estate shape
+// plus the non-default estate cohort via ?check=name-equals-producer-estate.v1.
 //
-// The key-token check has no aggregation mirror, so the scan runs in Node —
-// same full-fetch pattern (and cost) as the duplicate-clusters scan above,
-// fine at the registry's ~4k-doc size.
+// Query params:
+//   ?check=<ruleId>      scope to one rule (default = every defaultActive rule)
+//   ?includeVerified=1   AUDIT VIEW — ignore clearances entirely, so a newly
+//                        added or refined rule can be validated against all
+//                        ~4.3k rows before its suppression is trusted
 //
-// Returns: { wines: [{ _id, producer, name, proposedName, bottleCount, createdAt }], total, page, pages }
+// Rows an admin cleared via POST /verify-checks are suppressed PER RULE. The
+// key-token check has no aggregation mirror, so the scan runs in Node — same
+// full-fetch pattern (and cost) as the duplicate-clusters scan above, fine at
+// the registry's ~4k-doc size.
+//
+// Returns: { wines: [{ _id, producer, name, proposedName, checks, verifiedChecks,
+//   verifiedAt, bottleCount, createdAt }], total, page, pages, clearedCount,
+//   scannedCount, checkIds, allCheckIds, checkLabelKeys }
 router.get('/producer-in-name', async (req, res) => {
   try {
     const { limit: parsedLimit, offset: skip, page: parsedPage } =
       parsePagination(req.query, { limit: 50, maxLimit: 200 });
 
+    const only = req.query.check;
+    if (only !== undefined && !resolveCheck(only)) {
+      return res.status(400).json({ error: 'Unknown check id' });
+    }
+    const checkIds = only ? [only] : DEFAULT_CHECK_IDS;
+    const ignoreCleared = req.query.includeVerified === '1' || req.query.includeVerified === 'true';
+
+    // Suppression is evaluated in Node, not as a Mongo clause, because a row
+    // may be cleared for one rule and outstanding for another — and `total`
+    // below is computed from flagged.length, so in-memory pagination stays
+    // honest.
     const all = await WineDefinition.find({})
-      .select('name producer createdAt')
+      .select(`${NAME_CHECK_SELECT} createdAt verifiedAt`)
       .sort({ producer: 1, name: 1 })
       .lean();
 
     const flagged = [];
+    let clearedCount = 0;
     for (const w of all) {
-      const proposedName = stripProducerName(w.name, w.producer)
-        ?? stripProducerKeyPrefix(w.name, w.producer);
-      if (proposedName) flagged.push({ ...w, proposedName });
+      const hit = runNameChecks(w, { checkIds, ignoreCleared });
+      if (hit) flagged.push({ ...w, ...hit });
+      else if (checkIds.some(id => (w.verifiedChecks || []).includes(id))) clearedCount += 1;
     }
 
     const total = flagged.length;
@@ -725,13 +838,21 @@ router.get('/producer-in-name', async (req, res) => {
         _id: w._id,
         producer: w.producer,
         name: w.name,
-        proposedName: w.proposedName,
+        proposedName: w.proposedName,           // null for the non-strippable rules
+        checks: w.checks,                       // rule ids this row trips
+        verifiedChecks: w.verifiedChecks || [], // for the audit view
+        verifiedAt: w.verifiedAt || null,
         bottleCount: bottleCounts.get(String(w._id)) || 0,
         createdAt: w.createdAt,
       })),
       total,
       page: parsedPage,
       pages: Math.ceil(total / parsedLimit),
+      clearedCount,
+      scannedCount: all.length,
+      checkIds,
+      allCheckIds: NAME_CHECK_IDS,
+      checkLabelKeys: NAME_CHECKS.reduce((m, c) => (m[c.id] = c.labelKey, m), {}),
     });
   } catch (error) {
     console.error('Producer-in-name scan error:', error);

--- a/backend/src/routes/admin/wines.verifyChecks.test.js
+++ b/backend/src/routes/admin/wines.verifyChecks.test.js
@@ -1,0 +1,293 @@
+/**
+ * POST/DELETE /api/admin/wines/verify-checks + the per-rule suppression in
+ * GET /producer-in-name.
+ *
+ * What is pinned here and why:
+ *   - server-side re-detect: a stale client row cannot clear a rule the admin
+ *     never saw on screen (mirrors strip-producer's recompute)
+ *   - per-rule granularity: cleared for rule A still surfaces for rule B —
+ *     the design's guarantee against bare-boolean staleness
+ *   - operator-injection rejection BEFORE any query (house rule)
+ *   - audit-log calls (CLAUDE.md GDPR rule 4)
+ *   - no search re-index / no IndexNow: verification is not public content
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../models/WineDefinition', () => {
+  const ctor = jest.fn();
+  ctor.find = jest.fn();
+  ctor.findById = jest.fn();
+  ctor.findOne = jest.fn();
+  ctor.countDocuments = jest.fn();
+  ctor.bulkWrite = jest.fn();
+  ctor.updateMany = jest.fn();
+  return ctor;
+});
+jest.mock('../../models/Bottle', () => ({ aggregate: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../../models/BottleImage', () => ({}));
+jest.mock('../../models/WineVintageProfile', () => ({}));
+jest.mock('../../models/WineVintagePrice', () => ({}));
+jest.mock('../../models/WineReport', () => ({}));
+jest.mock('../../models/Review', () => ({}));
+jest.mock('../../models/Discussion', () => ({}));
+jest.mock('../../models/DiscussionReply', () => ({}));
+jest.mock('../../models/WineEmbedding', () => ({}));
+jest.mock('../../models/WineNotDuplicate', () => ({ find: jest.fn() }));
+jest.mock('../../models/WineList', () => ({}));
+jest.mock('../../models/WishlistItem', () => ({}));
+jest.mock('../../models/PriceTrackingRequest', () => ({}));
+jest.mock('../../models/PriceTrackingSkip', () => ({}));
+jest.mock('../../models/CommunityWinePrice', () => ({}));
+jest.mock('../../models/JournalEntry', () => ({}));
+jest.mock('../../models/Recommendation', () => ({}));
+jest.mock('../../models/RestockAlert', () => ({}));
+jest.mock('../../models/WineRequest', () => ({}));
+jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
+jest.mock('../../services/vectorStore', () => ({}));
+jest.mock('../../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../../services/embeddingJob', () => ({ embedSinglePair: jest.fn() }));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn(), removeWine: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineDefinition = require('../../models/WineDefinition');
+const Bottle = require('../../models/Bottle');
+const searchService = require('../../services/search');
+const { logAudit } = require('../../services/audit');
+const { submitUrls } = require('../../services/indexNow');
+const { NAME_CHECK_SELECT } = require('../../utils/nameChecks');
+const adminWinesRouter = require('./wines');
+
+const ADMIN_ID = '64b000000000000000000001';
+const WINE_A = '64b0000000000000000000b1';
+const WINE_B = '64b0000000000000000000b2';
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/wines', adminWinesRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+// One chain serves both query shapes the routes issue:
+//   scan:   find({}).select(...).sort(...).lean()
+//   verify: find({ _id: { $in } }).select(...).lean()
+const findChain = (rows) => {
+  const select = jest.fn().mockReturnValue({
+    sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(rows) }),
+    lean: jest.fn().mockResolvedValue(rows),
+  });
+  return { select };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  WineDefinition.find.mockReturnValue(findChain([]));
+  WineDefinition.bulkWrite.mockResolvedValue({ modifiedCount: 1 });
+  WineDefinition.updateMany.mockResolvedValue({ modifiedCount: 1 });
+  Bottle.aggregate.mockResolvedValue([]);
+});
+
+const call = (method, path, body) => fetch(`${baseUrl}/api/admin/wines${path}`, {
+  method,
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+  ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+});
+
+// Trips name-equals-producer.v1 (non-estate) and nothing else.
+const OPUS = { _id: WINE_A, name: 'Opus One', producer: 'Opus One' };
+// Trips dangling-name-tail.v1 only (the ticket's launch row).
+const VINA = { _id: WINE_B, name: 'La Viña de', producer: 'Madaras' };
+
+describe('POST /verify-checks', () => {
+  test('records the clearance with $addToSet + verifiedAt, audits, and never re-indexes', async () => {
+    WineDefinition.find.mockReturnValue(findChain([OPUS]));
+
+    const res = await call('POST', '/verify-checks', {
+      wineIds: [WINE_A], checks: ['name-equals-producer.v1'],
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.updated).toBe(1);
+    expect(data.notFlagged).toEqual([]);
+
+    const ops = WineDefinition.bulkWrite.mock.calls[0][0];
+    expect(ops).toHaveLength(1);
+    expect(ops[0].updateOne.update.$addToSet).toEqual({
+      verifiedChecks: { $each: ['name-equals-producer.v1'] },
+    });
+    expect(ops[0].updateOne.update.$set.verifiedAt).toBeInstanceOf(Date);
+
+    expect(logAudit).toHaveBeenCalledWith(
+      expect.anything(), 'admin.wine.verifyChecks',
+      { type: 'wine', id: WINE_A },
+      expect.objectContaining({ checks: ['name-equals-producer.v1'], updated: 1 })
+    );
+    expect(searchService.indexWine).not.toHaveBeenCalled();
+    expect(submitUrls).not.toHaveBeenCalled();
+  });
+
+  test('server-side re-detect: a wine that does not trip the named rule is notFlagged, nothing written', async () => {
+    WineDefinition.find.mockReturnValue(findChain([{ _id: WINE_A, name: 'Chardonnay', producer: 'Meerlust' }]));
+
+    const res = await call('POST', '/verify-checks', {
+      wineIds: [WINE_A], checks: ['name-equals-producer.v1'],
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.updated).toBe(0);
+    expect(data.notFlagged).toEqual([WINE_A]);
+    expect(WineDefinition.bulkWrite).not.toHaveBeenCalled();
+  });
+
+  test('the projection covers every field the rules read (silent-divergence guard)', async () => {
+    const chain = findChain([OPUS]);
+    WineDefinition.find.mockReturnValue(chain);
+
+    await call('POST', '/verify-checks', { wineIds: [WINE_A], checks: ['name-equals-producer.v1'] });
+
+    const selectArg = chain.select.mock.calls[0][0];
+    for (const field of NAME_CHECK_SELECT.split(' ')) {
+      expect(selectArg).toContain(field);
+    }
+  });
+
+  test.each([
+    ['missing checks', { wineIds: [WINE_A] }],
+    ['empty checks', { wineIds: [WINE_A], checks: [] }],
+    ['unknown check id', { wineIds: [WINE_A], checks: ['bogus.v9'] }],
+    ['operator-injection in checks', { wineIds: [WINE_A], checks: [{ $gt: '' }] }],
+    ['operator-injection in wineIds', { wineIds: [{ $gt: '' }], checks: ['name-equals-producer.v1'] }],
+    ['no valid wineIds', { wineIds: [], checks: ['name-equals-producer.v1'] }],
+  ])('%s → 400, nothing queried', async (_label, body) => {
+    const res = await call('POST', '/verify-checks', body);
+    expect(res.status).toBe(400);
+    expect(WineDefinition.find).not.toHaveBeenCalled();
+    expect(WineDefinition.bulkWrite).not.toHaveBeenCalled();
+  });
+
+  test('more than 500 wineIds → 400', async () => {
+    const ids = Array.from({ length: 501 }, (_, i) =>
+      `64b00000000000000000${String(1000 + i).slice(1)}`);
+    const res = await call('POST', '/verify-checks', { wineIds: ids, checks: ['name-equals-producer.v1'] });
+    expect(res.status).toBe(400);
+    expect(WineDefinition.find).not.toHaveBeenCalled();
+  });
+
+  test('unknown wine ids → 404', async () => {
+    WineDefinition.find.mockReturnValue(findChain([]));
+    const res = await call('POST', '/verify-checks', { wineIds: [WINE_A], checks: ['name-equals-producer.v1'] });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /verify-checks', () => {
+  test('pulls the rule ids and audits the undo', async () => {
+    const res = await call('DELETE', '/verify-checks', {
+      wineIds: [WINE_A], checks: ['name-equals-producer.v1'],
+    });
+    expect(res.status).toBe(200);
+
+    const [filter, update] = WineDefinition.updateMany.mock.calls[0];
+    expect(filter._id.$in.map(String)).toEqual([WINE_A]);
+    expect(update).toEqual({ $pull: { verifiedChecks: { $in: ['name-equals-producer.v1'] } } });
+
+    expect(logAudit).toHaveBeenCalledWith(
+      expect.anything(), 'admin.wine.unverifyChecks',
+      { type: 'wine', id: WINE_A },
+      expect.objectContaining({ checks: ['name-equals-producer.v1'] })
+    );
+  });
+
+  test('bad checks → 400, nothing updated', async () => {
+    const res = await call('DELETE', '/verify-checks', { wineIds: [WINE_A], checks: ['nope'] });
+    expect(res.status).toBe(400);
+    expect(WineDefinition.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /producer-in-name — per-rule suppression', () => {
+  const get = (qs = '') => fetch(`${baseUrl}/api/admin/wines/producer-in-name${qs}`, {
+    headers: { Authorization: `Bearer ${adminToken()}` },
+  });
+
+  test('a wine cleared for the rule it trips leaves the queue (total 0, clearedCount 1)', async () => {
+    WineDefinition.find.mockReturnValue(findChain([
+      { ...OPUS, verifiedChecks: ['name-equals-producer.v1'] },
+    ]));
+    const data = await (await get()).json();
+    expect(data.total).toBe(0);
+    expect(data.clearedCount).toBe(1);
+  });
+
+  test('cleared for a DIFFERENT rule → still surfaces (per-rule granularity)', async () => {
+    WineDefinition.find.mockReturnValue(findChain([
+      { ...OPUS, verifiedChecks: ['dangling-name-tail.v1'] },
+    ]));
+    const data = await (await get()).json();
+    expect(data.total).toBe(1);
+    expect(data.wines[0].checks).toEqual(['name-equals-producer.v1']);
+  });
+
+  test('?includeVerified=1 is the audit view — cleared rows return anyway', async () => {
+    WineDefinition.find.mockReturnValue(findChain([
+      { ...OPUS, verifiedChecks: ['name-equals-producer.v1'] },
+    ]));
+    const data = await (await get('?includeVerified=1')).json();
+    expect(data.total).toBe(1);
+    expect(data.wines[0].verifiedChecks).toEqual(['name-equals-producer.v1']);
+  });
+
+  test('the dangling-tail row reports its rule with a null proposedName; strip rows keep theirs', async () => {
+    WineDefinition.find.mockReturnValue(findChain([
+      VINA,
+      { _id: WINE_A, name: 'Meerlust Chardonnay', producer: 'Meerlust' },
+    ]));
+    const data = await (await get()).json();
+    expect(data.total).toBe(2);
+    const vina = data.wines.find(w => w._id === WINE_B);
+    expect(vina.checks).toEqual(['dangling-name-tail.v1']);
+    expect(vina.proposedName).toBeNull();
+    const meerlust = data.wines.find(w => w._id === WINE_A);
+    expect(meerlust.checks).toEqual(['producer-in-name.v1']);
+    expect(meerlust.proposedName).toBe('Chardonnay');
+  });
+
+  test('the estate cohort is reachable via ?check= but absent from the default queue', async () => {
+    const latour = { _id: WINE_A, name: 'Château Latour', producer: 'Château Latour' };
+    WineDefinition.find.mockReturnValue(findChain([latour]));
+
+    let data = await (await get()).json();
+    expect(data.total).toBe(0); // not in the default queue
+
+    WineDefinition.find.mockReturnValue(findChain([latour]));
+    data = await (await get('?check=name-equals-producer-estate.v1')).json();
+    expect(data.total).toBe(1);
+    expect(data.wines[0].checks).toEqual(['name-equals-producer-estate.v1']);
+  });
+
+  test('?check=bogus → 400', async () => {
+    const res = await get('?check=bogus');
+    expect(res.status).toBe(400);
+  });
+
+  test('the envelope names what it covered (checkIds, allCheckIds, labels, scannedCount)', async () => {
+    WineDefinition.find.mockReturnValue(findChain([OPUS]));
+    const data = await (await get()).json();
+    expect(data.checkIds).toEqual([
+      'producer-in-name.v1', 'dangling-name-tail.v1', 'name-equals-producer.v1',
+    ]);
+    expect(data.allCheckIds).toContain('name-equals-producer-estate.v1');
+    expect(data.checkLabelKeys['dangling-name-tail.v1']).toBe('danglingTail');
+    expect(data.scannedCount).toBe(1);
+  });
+});

--- a/backend/src/scripts/scan-name-anomalies.js
+++ b/backend/src/scripts/scan-name-anomalies.js
@@ -1,0 +1,41 @@
+/**
+ * scan-name-anomalies — size the registry name-check queues (support ticket
+ * 2026-07-26). Read-only; changes nothing, has no --apply flag.
+ *
+ * Prints, per rule in utils/nameChecks.js: outstanding / already-cleared /
+ * total-matching, plus up to 40 sample rows. Use it BEFORE trusting a newly
+ * added or refined rule, and to re-tune DANGLING_TAIL_WORDS from evidence
+ * rather than guesswork (widening the set means bumping the rule id).
+ *
+ * Usage:
+ *   docker exec cellarion-backend node src/scripts/scan-name-anomalies.js
+ */
+require('dotenv').config();
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const { NAME_CHECKS, NAME_CHECK_SELECT } = require('../utils/nameChecks');
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log('Connected. Mode: READ-ONLY (this script never writes)\n');
+
+  const all = await WineDefinition.find({}).select(`${NAME_CHECK_SELECT} verifiedAt`).lean();
+  for (const check of NAME_CHECKS) {
+    const matching = all.filter(w => check.detect(w));
+    const cleared = matching.filter(w => (w.verifiedChecks || []).includes(check.id));
+    const outstanding = matching.filter(w => !(w.verifiedChecks || []).includes(check.id));
+    console.log(`${check.id}${check.defaultActive ? '' : '  (not in the default queue)'}`);
+    console.log(`  matching=${matching.length}  cleared=${cleared.length}  outstanding=${outstanding.length}`);
+    for (const w of outstanding.slice(0, 40)) {
+      console.log(`    "${w.name}" — ${w.producer} [${w._id}]`);
+    }
+    if (outstanding.length > 40) console.log(`    … and ${outstanding.length - 40} more`);
+    console.log('');
+  }
+  console.log(`Scanned ${all.length} registry wines.`);
+  console.log('No Meilisearch re-index and NO embedding job are needed — verification is in');
+  console.log('neither the search document nor the embedding text. Do not run the embed job.');
+  await mongoose.disconnect();
+}
+
+run().catch((err) => { console.error('Name-anomaly scan failed:', err); process.exit(1); });

--- a/backend/src/services/embedding.buildText.test.js
+++ b/backend/src/services/embedding.buildText.test.js
@@ -1,0 +1,64 @@
+/**
+ * buildEmbeddingText golden-string test — the property the whole "verification
+ * costs zero re-embeds" claim rests on.
+ *
+ * textHash = sha256(buildEmbeddingText(...)) is the embedding job's skip key:
+ * if a WineDefinition field ever leaks into this text, every registry wine's
+ * hash changes and the next job run re-embeds ~4.3k wines against the Voyage
+ * API for real money. The function is a closed field whitelist today; this
+ * test pins the exact output for a fully-populated wine that ALSO carries the
+ * admin-review fields (verifiedChecks / verifiedAt), so a refactor that
+ * spreads the doc into the text fails here first.
+ */
+const { buildEmbeddingText } = require('./embedding');
+
+const FULL_WINE = {
+  name: 'Block 3 Pinot Noir',
+  producer: 'Felton Road',
+  type: 'red',
+  region: { name: 'Central Otago' },
+  country: { name: 'New Zealand' },
+  grapes: [{ name: 'Pinot Noir' }],
+  appellation: 'Bannockburn',
+  classification: 'Single Vineyard',
+  aiProfile: {
+    body: 'medium',
+    tannin: 'medium',
+    acidity: 'high',
+    sweetness: 'dry',
+    flavors: ['dark cherry', 'thyme'],
+    foodPairings: ['duck breast'],
+  },
+  // Admin-review metadata — must never reach the embedding text.
+  verifiedChecks: ['name-equals-producer.v1'],
+  verifiedAt: new Date('2026-07-26T10:00:00Z'),
+};
+
+const GOLDEN = [
+  'Name: Block 3 Pinot Noir',
+  'Producer: Felton Road',
+  'Type: red',
+  'Vintage: 2019',
+  'Region: Central Otago',
+  'Country: New Zealand',
+  'Grapes: Pinot Noir',
+  'Appellation: Bannockburn',
+  'Classification: Single Vineyard',
+  'Style: medium-bodied, medium tannin, high acidity, dry',
+  'Flavours: dark cherry, thyme',
+  'Pairs with: duck breast',
+].join('\n');
+
+test('output is the exact whitelist — review metadata cannot change textHash', () => {
+  expect(buildEmbeddingText(FULL_WINE, '2019')).toBe(GOLDEN);
+});
+
+test('adding/removing the review fields produces byte-identical text', () => {
+  const { verifiedChecks, verifiedAt, ...withoutReview } = FULL_WINE;
+  expect(buildEmbeddingText(withoutReview, '2019')).toBe(buildEmbeddingText(FULL_WINE, '2019'));
+});
+
+test('the text never mentions the review fields by name', () => {
+  const text = buildEmbeddingText(FULL_WINE, '2019');
+  expect(text).not.toMatch(/verified/i);
+});

--- a/backend/src/services/registryGc.js
+++ b/backend/src/services/registryGc.js
@@ -33,7 +33,7 @@ const { logAudit } = require('./audit');
 async function gcOrphanMintedWine(wineId, req) {
   try {
     if (!mongoose.isValidObjectId(wineId)) return { removed: false, reason: 'invalid id' };
-    const wine = await WineDefinition.findById(wineId).select('name producer');
+    const wine = await WineDefinition.findById(wineId).select('name producer verifiedChecks');
     if (!wine) return { removed: false, reason: 'already gone' };
 
     const bottleCount = await Bottle.countDocuments({ wineDefinition: wineId });
@@ -47,6 +47,12 @@ async function gcOrphanMintedWine(wineId, req) {
       status: { $ne: 'pending' },
     });
     if (reviewedProfiles > 0) return { removed: false, reason: 'a maturity profile was reviewed' };
+
+    // An admin cleared a data-quality check on this row — never let a user's
+    // undo silently delete curated registry data.
+    if ((wine.verifiedChecks || []).length > 0) {
+      return { removed: false, reason: 'an admin verified a data-quality check on it' };
+    }
 
     // Guards passed — clean up everything the mint created, quietest first.
     await WineVintageProfile.deleteMany({ wineDefinition: wineId, status: 'pending' });

--- a/backend/src/services/registryGc.test.js
+++ b/backend/src/services/registryGc.test.js
@@ -66,6 +66,23 @@ describe('gcOrphanMintedWine guards', () => {
     expect((await gcOrphanMintedWine(WINE_ID, REQ)).removed).toBe(false);
     expect(WineDefinition.deleteOne).not.toHaveBeenCalled();
   });
+
+  test('an admin-verified data-quality check keeps it (user undo must not delete curated data)', async () => {
+    WineDefinition.findById.mockReturnValue(selectable({
+      _id: WINE_ID, name: 'Opus One', producer: 'Opus One',
+      verifiedChecks: ['name-equals-producer.v1'],
+    }));
+    const res = await gcOrphanMintedWine(WINE_ID, REQ);
+    expect(res.removed).toBe(false);
+    expect(res.reason).toContain('verified');
+    expect(WineDefinition.deleteOne).not.toHaveBeenCalled();
+  });
+
+  test('the findById projection includes verifiedChecks (or the guard would always pass)', async () => {
+    await gcOrphanMintedWine(WINE_ID, REQ);
+    const selectMock = WineDefinition.findById.mock.results[0].value.select;
+    expect(selectMock.mock.calls[0][0]).toContain('verifiedChecks');
+  });
 });
 
 describe('gcOrphanMintedWine happy path', () => {

--- a/backend/src/utils/__snapshots__/nameChecks.snapshot.test.js.snap
+++ b/backend/src/utils/__snapshots__/nameChecks.snapshot.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`detect() source of dangling-name-tail.v1 is unchanged — bump the id if you edited it 1`] = `
+"w => {
+    const tokens = normalizeString(w.name || '').split(' ').filter(Boolean);
+    if (tokens.length < 2) return null; // a one-word name is not "dangling"
+    return DANGLING_TAIL_WORDS.has(tokens[tokens.length - 1]) ? w.name : null;
+  }"
+`;
+
+exports[`detect() source of name-equals-producer.v1 is unchanged — bump the id if you edited it 1`] = `"w => nameEqualsProducer(w) && !ESTATE_WORDS.has(firstToken(w)) ? w.name : null"`;
+
+exports[`detect() source of name-equals-producer-estate.v1 is unchanged — bump the id if you edited it 1`] = `"w => nameEqualsProducer(w) && ESTATE_WORDS.has(firstToken(w)) ? w.name : null"`;
+
+exports[`detect() source of producer-in-name.v1 is unchanged — bump the id if you edited it 1`] = `"w => stripProducerName(w.name, w.producer) ?? stripProducerKeyPrefix(w.name, w.producer)"`;
+
+exports[`rule ids are pinned (adding/removing/renaming a rule must be deliberate) 1`] = `
+[
+  "producer-in-name.v1",
+  "dangling-name-tail.v1",
+  "name-equals-producer.v1",
+  "name-equals-producer-estate.v1 (non-default)",
+]
+`;

--- a/backend/src/utils/nameChecks.js
+++ b/backend/src/utils/nameChecks.js
@@ -1,0 +1,139 @@
+/**
+ * The registry NAME-CHECK registry: the row-shaped data-quality rules an admin
+ * can clear a wine for (support ticket 2026-07-26). Every rule's verdict reads
+ * NOTHING but `name` and `producer` — that invariant is what lets
+ * WineDefinition's pre-validate hook be a complete invalidation chokepoint for
+ * clearances (see the verifiedChecks field comment there).
+ *
+ * Rule ids are VERSIONED. Refining a rule means bumping its id in the same
+ * commit that edits its detect(), which invalidates that rule's clearances
+ * across the whole registry while leaving every other rule's work intact.
+ * nameChecks.snapshot.test.js pins each detect body's source and FAILS on an
+ * un-snapshotted edit, so the bump cannot be forgotten silently.
+ *
+ * Residual, stated honestly: a change to a shared helper (stripProducerName,
+ * normalizeString) alters a verdict without altering any detect body, so the
+ * snapshot will not fire. That edit is itself a reviewed change to
+ * producerPrefix.js / normalize.js, both of which have their own test suites.
+ */
+const { normalizeString } = require('./normalize');
+// DANGLING_TAIL_WORDS lives in producerPrefix.js (which cannot require this
+// module back) so the suffix-strip guard and the dangling-tail rule share one
+// list — see its definition there for what it includes and why.
+const {
+  stripProducerName, stripProducerKeyPrefix, DANGLING_TAIL_WORDS,
+} = require('./producerPrefix');
+
+// House/estate words that legitimately OPEN a wine name equal to its producer —
+// "Château Latour" the wine IS Château Latour the estate. Pre-normalized
+// (normalizeString strips diacritics + punctuation: 'château' → 'chateau').
+//
+// A SEPARATE list from normalize.js WINE_STOP_WORDS on purpose: that set is
+// tuned for fuzzy MATCHING and is re-tuned whenever the deduper misbehaves (it
+// is also not exported). Sharing it would silently change what this scan flags
+// every time the matcher is touched.
+const ESTATE_WORDS = new Set([
+  'chateau', 'chateaux', 'domaine', 'domaines', 'clos', 'mas', 'maison',
+  'cave', 'caves', 'weingut', 'schloss', 'tenuta', 'tenute', 'castello',
+  'cantina', 'cantine', 'azienda', 'fattoria', 'podere', 'poderi', 'cascina',
+  'bodega', 'bodegas', 'vina', 'quinta', 'herdade', 'casa', 'finca',
+]);
+
+const nameEqualsProducer = (w) =>
+  !!normalizeString(w.name || '') &&
+  normalizeString(w.name || '') === normalizeString(w.producer || '');
+
+const firstToken = (w) => normalizeString(w.name || '').split(' ')[0] || '';
+
+/**
+ * Each rule:
+ *   id            - stable, VERSIONED. Bump on refinement.
+ *   labelKey      - i18n leaf under admin.wines.producerInName.reasons.
+ *                   Decoupled from `id` because i18next treats '.' as nesting.
+ *   defaultActive - included when the scan is called with no ?check.
+ *   detect        - (wine) => proposed replacement name | truthy detail | null.
+ */
+const NAME_CHECKS = [
+  {
+    // The pre-existing scan rule, unchanged, registered here so there is one
+    // implementation and one place a clearance id is declared.
+    id: 'producer-in-name.v1',
+    labelKey: 'producerInName',
+    defaultActive: true,
+    detect: (w) => stripProducerName(w.name, w.producer) ?? stripProducerKeyPrefix(w.name, w.producer),
+  },
+  {
+    // Defect (b) from the ticket. A SAFETY NET for rows already in the
+    // registry; preventing NEW ones is a guard in stripProducerSuffix itself
+    // (its own PR — it changes a function every write surface calls).
+    id: 'dangling-name-tail.v1',
+    labelKey: 'danglingTail',
+    defaultActive: true,
+    detect: (w) => {
+      const tokens = normalizeString(w.name || '').split(' ').filter(Boolean);
+      if (tokens.length < 2) return null; // a one-word name is not "dangling"
+      return DANGLING_TAIL_WORDS.has(tokens[tokens.length - 1]) ? w.name : null;
+    },
+  },
+  {
+    // name === producer, NON-estate shape. Invisible to producer-in-name:
+    // stripProducerPrefix/-Suffix both bail on `n.length <= p.length + 1`, and
+    // stripProducerKeyPrefix on "nothing meaningful would remain".
+    id: 'name-equals-producer.v1',
+    labelKey: 'nameEqualsProducer',
+    defaultActive: true,
+    detect: (w) => (nameEqualsProducer(w) && !ESTATE_WORDS.has(firstToken(w)) ? w.name : null),
+  },
+  {
+    // The ~139-row legitimate cohort (Château Latour, Domaine X). Registered
+    // as a NAMED, QUERYABLE rule but NOT in the default queue — it neither
+    // floods the review list nor becomes an invisible hardcoded exemption.
+    // Open it deliberately with ?check=name-equals-producer-estate.v1.
+    id: 'name-equals-producer-estate.v1',
+    labelKey: 'nameEqualsProducerEstate',
+    defaultActive: false,
+    detect: (w) => (nameEqualsProducer(w) && ESTATE_WORDS.has(firstToken(w)) ? w.name : null),
+  },
+];
+
+const NAME_CHECK_IDS = NAME_CHECKS.map(c => c.id);
+const DEFAULT_CHECK_IDS = NAME_CHECKS.filter(c => c.defaultActive).map(c => c.id);
+const byId = new Map(NAME_CHECKS.map(c => [c.id, c]));
+
+/** Operator-injection-safe lookup for an untrusted body/query value. */
+const resolveCheck = (id) =>
+  (typeof id === 'string' && byId.has(id) ? byId.get(id) : null);
+
+/**
+ * Run a set of rules against one wine. Clearances come from the wine's own
+ * verifiedChecks (undefined on legacy rows — .lean() applies no defaults, so
+ * guard it). Returns { checks: [id], proposedName } or null when clean.
+ */
+function runNameChecks(wine, { checkIds = DEFAULT_CHECK_IDS, ignoreCleared = false } = {}) {
+  const cleared = Array.isArray(wine.verifiedChecks) ? wine.verifiedChecks : [];
+  const hits = [];
+  let proposedName = null;
+  for (const id of checkIds) {
+    // Live lookup (not the load-time Map) so the rule list is the single
+    // source of truth — the staleness contract test appends a rule and proves
+    // clearances recorded before it existed cannot suppress it.
+    const check = NAME_CHECKS.find(c => c.id === id);
+    if (!check) continue;
+    if (!ignoreCleared && cleared.includes(id)) continue;
+    const detail = check.detect(wine);
+    if (!detail) continue;
+    hits.push(id);
+    // Only producer-in-name has an auto-fix; it is first in NAME_CHECKS so its
+    // proposal wins when several rules fire on the same row.
+    if (proposedName === null && id === 'producer-in-name.v1') proposedName = detail;
+  }
+  return hits.length ? { checks: hits, proposedName } : null;
+}
+
+/** Fields runNameChecks reads — every scan's .select() must cover these. */
+const NAME_CHECK_SELECT = 'name producer verifiedChecks';
+
+module.exports = {
+  NAME_CHECKS, NAME_CHECK_IDS, DEFAULT_CHECK_IDS, NAME_CHECK_SELECT,
+  resolveCheck, runNameChecks, DANGLING_TAIL_WORDS, ESTATE_WORDS,
+};

--- a/backend/src/utils/nameChecks.snapshot.test.js
+++ b/backend/src/utils/nameChecks.snapshot.test.js
@@ -1,0 +1,35 @@
+/**
+ * Source snapshot of every name-check rule's detect() body.
+ *
+ * WHY: a wine's verifiedChecks clearance means "an admin confirmed this wine
+ * passes rule <id> AS THAT RULE WAS DEFINED". Editing a detect() without
+ * bumping its versioned id would silently re-scope thousands of recorded
+ * clearances to logic the admin never saw. This suite makes that edit
+ * impossible to land quietly: change a detect body and CI fails HERE, showing
+ * the source diff, until you either
+ *   - bump the rule id in the same commit (".v1" -> ".v2"), invalidating that
+ *     rule's clearances registry-wide — usually the right call, or
+ *   - regenerate the snapshot (npx jest nameChecks.snapshot -u) for a provable
+ *     no-op (comment/whitespace) and say so in the PR.
+ *
+ * NOTE: the snapshotted text is String(detect) AS JEST'S BABEL TRANSFORM
+ * PRINTS IT (mock hoisting regenerates source), not the raw file bytes — which
+ * is why this uses jest snapshots instead of a hand-pinned hash: the transform
+ * output is only stable under jest itself.
+ *
+ * Residual gap, on purpose: edits to shared helpers (stripProducerName,
+ * normalizeString) change verdicts without changing any detect body. Those
+ * files carry their own suites and reviews; see the nameChecks.js header.
+ */
+const { NAME_CHECKS } = require('./nameChecks');
+
+test('rule ids are pinned (adding/removing/renaming a rule must be deliberate)', () => {
+  expect(NAME_CHECKS.map(c => `${c.id}${c.defaultActive ? '' : ' (non-default)'}`))
+    .toMatchSnapshot();
+});
+
+for (const check of NAME_CHECKS) {
+  test(`detect() source of ${check.id} is unchanged — bump the id if you edited it`, () => {
+    expect(String(check.detect)).toMatchSnapshot();
+  });
+}

--- a/backend/src/utils/nameChecks.test.js
+++ b/backend/src/utils/nameChecks.test.js
@@ -1,0 +1,203 @@
+/**
+ * The name-check rules are pure functions over { name, producer,
+ * verifiedChecks } — no DB, no mocks. What matters most here:
+ *   - per-rule clearance granularity (cleared for one rule ≠ cleared for all)
+ *   - the contract that a rule NOT in a wine's verifiedChecks always surfaces,
+ *     even when every OTHER rule is cleared — the design's whole guarantee
+ *     against the bare-boolean staleness trap
+ *   - the estate cohort staying out of the default queue
+ */
+const {
+  NAME_CHECKS,
+  NAME_CHECK_IDS,
+  DEFAULT_CHECK_IDS,
+  NAME_CHECK_SELECT,
+  resolveCheck,
+  runNameChecks,
+} = require('./nameChecks');
+
+const byId = (id) => NAME_CHECKS.find(c => c.id === id);
+
+describe('rule registry shape', () => {
+  test('every rule has an id, a labelKey and a detect function; ids are unique', () => {
+    for (const c of NAME_CHECKS) {
+      expect(typeof c.id).toBe('string');
+      expect(c.id).toMatch(/\.v\d+$/); // versioned — refinement bumps it
+      expect(typeof c.labelKey).toBe('string');
+      expect(typeof c.detect).toBe('function');
+      expect(typeof c.defaultActive).toBe('boolean');
+    }
+    expect(new Set(NAME_CHECK_IDS).size).toBe(NAME_CHECK_IDS.length);
+  });
+
+  test('the estate rule is NOT in the default queue (reachable only via ?check=)', () => {
+    expect(byId('name-equals-producer-estate.v1').defaultActive).toBe(false);
+    expect(DEFAULT_CHECK_IDS).not.toContain('name-equals-producer-estate.v1');
+    expect(NAME_CHECK_IDS).toContain('name-equals-producer-estate.v1');
+  });
+
+  test('NAME_CHECK_SELECT covers every field the rules read', () => {
+    for (const field of ['name', 'producer', 'verifiedChecks']) {
+      expect(NAME_CHECK_SELECT.split(' ')).toContain(field);
+    }
+  });
+});
+
+describe('producer-in-name.v1', () => {
+  const detect = byId('producer-in-name.v1').detect;
+
+  test('flags an exact producer prefix and proposes the stripped name', () => {
+    expect(detect({ name: 'Meerlust Chardonnay', producer: 'Meerlust' })).toBe('Chardonnay');
+  });
+
+  test('flags the key-token variant (producer "… Wines Ltd")', () => {
+    expect(detect({ name: 'Felton Road Block 3 Pinot Noir', producer: 'Felton Road Wines Ltd' }))
+      .toBe('Block 3 Pinot Noir');
+  });
+
+  test('does not flag a producer-free name', () => {
+    expect(detect({ name: 'Chardonnay', producer: 'Meerlust' })).toBeNull();
+  });
+});
+
+describe('dangling-name-tail.v1', () => {
+  const detect = byId('dangling-name-tail.v1').detect;
+
+  test('flags the ticket row and its class', () => {
+    expect(detect({ name: 'La Viña de', producer: 'Madaras' })).toBe('La Viña de');
+    expect(detect({ name: 'Clos de', producer: 'X' })).toBe('Clos de');
+    expect(detect({ name: 'Re di', producer: 'Renieri' })).toBe('Re di');
+  });
+
+  test('does not flag names that merely CONTAIN connectives', () => {
+    // Suffix producer names ending in real words stay untouched
+    expect(detect({ name: 'Les Forts de Latour', producer: 'Château Latour' })).toBeNull();
+    expect(detect({ name: 'Cheval des Andes', producer: 'Cheval des Andes' })).toBeNull();
+    expect(detect({ name: 'Barolo', producer: 'Boroli' })).toBeNull();
+  });
+
+  test('never flags a one-word name (protects Yquem\'s "Y")', () => {
+    expect(detect({ name: 'Y', producer: "Château d'Yquem" })).toBeNull();
+    expect(detect({ name: 'de', producer: 'X' })).toBeNull(); // degenerate, still one word
+  });
+});
+
+describe('name-equals-producer.v1 and its estate twin', () => {
+  const plain = byId('name-equals-producer.v1').detect;
+  const estate = byId('name-equals-producer-estate.v1').detect;
+
+  test('non-estate equality flags on the plain rule only', () => {
+    const w = { name: 'Opus One', producer: 'Opus One' };
+    expect(plain(w)).toBe('Opus One');
+    expect(estate(w)).toBeNull();
+  });
+
+  test('estate equality flags on the estate rule only (Château Latour is legitimate)', () => {
+    const w = { name: 'Château Latour', producer: 'Chateau Latour' }; // accent variant on purpose
+    expect(plain(w)).toBeNull();
+    expect(estate(w)).toBe('Château Latour');
+  });
+
+  test('comparison is normalizeString-based (case/diacritics/punctuation immune)', () => {
+    expect(plain({ name: 'ANNAPURNA', producer: 'Annapurna' })).toBe('ANNAPURNA');
+  });
+
+  test('does not flag when name and producer differ', () => {
+    expect(plain({ name: 'Chardonnay', producer: 'Meerlust' })).toBeNull();
+    expect(estate({ name: 'Chardonnay', producer: 'Meerlust' })).toBeNull();
+  });
+
+  test('empty name never flags', () => {
+    expect(plain({ name: '', producer: '' })).toBeNull();
+    expect(plain({ name: null, producer: null })).toBeNull();
+  });
+});
+
+describe('runNameChecks — per-rule clearance semantics', () => {
+  // Trips producer-in-name (prefix) AND dangling tail ("… de" after strip? no —
+  // build a row tripping exactly two known rules): name "Madaras La Viña de",
+  // producer "Madaras" trips producer-in-name (prefix strip → "La Viña de")
+  // and dangling-name-tail (raw name ends in "de").
+  const doubleHit = { name: 'Madaras La Viña de', producer: 'Madaras' };
+
+  test('reports every tripped rule and the strip proposal', () => {
+    const hit = runNameChecks(doubleHit);
+    expect(hit.checks).toEqual(
+      expect.arrayContaining(['producer-in-name.v1', 'dangling-name-tail.v1'])
+    );
+    expect(hit.proposedName).toBe('La Viña de');
+  });
+
+  test('a rule listed in verifiedChecks is skipped; others still report (per-rule granularity)', () => {
+    const hit = runNameChecks({ ...doubleHit, verifiedChecks: ['producer-in-name.v1'] });
+    expect(hit.checks).toEqual(['dangling-name-tail.v1']);
+    expect(hit.proposedName).toBeNull(); // the proposing rule was cleared
+  });
+
+  test('all tripped rules cleared → null (row leaves the queue)', () => {
+    expect(runNameChecks({
+      ...doubleHit,
+      verifiedChecks: ['producer-in-name.v1', 'dangling-name-tail.v1'],
+    })).toBeNull();
+  });
+
+  test('undefined verifiedChecks (the .lean() legacy-row case) and [] mean nothing cleared', () => {
+    expect(runNameChecks({ ...doubleHit, verifiedChecks: undefined })).not.toBeNull();
+    expect(runNameChecks({ ...doubleHit, verifiedChecks: [] })).not.toBeNull();
+  });
+
+  test('ignoreCleared reports everything (the audit view)', () => {
+    const hit = runNameChecks(
+      { ...doubleHit, verifiedChecks: ['producer-in-name.v1', 'dangling-name-tail.v1'] },
+      { ignoreCleared: true }
+    );
+    expect(hit.checks).toHaveLength(2);
+  });
+
+  test('checkIds scopes the run (the ?check= path)', () => {
+    const hit = runNameChecks(doubleHit, { checkIds: ['dangling-name-tail.v1'] });
+    expect(hit.checks).toEqual(['dangling-name-tail.v1']);
+  });
+
+  test('a clean wine returns null', () => {
+    expect(runNameChecks({ name: 'Chardonnay', producer: 'Meerlust' })).toBeNull();
+  });
+
+  test('THE CONTRACT: clearances for every KNOWN rule cannot suppress a rule added later', () => {
+    // Simulate tomorrow's rule arriving: a wine cleared for EVERY id that
+    // exists today must still surface for the new rule — and its existing
+    // clearances stay honoured for their own rules. This single test is the
+    // design's guarantee against the bare-boolean staleness trap.
+    const futureRule = {
+      id: 'always-fires.v1',
+      labelKey: 'test',
+      defaultActive: true,
+      detect: () => 'hit',
+    };
+    NAME_CHECKS.push(futureRule);
+    try {
+      // Cleared for all of today's ids — exactly like a prod row reviewed
+      // before the new rule shipped.
+      const wine = { ...doubleHit, verifiedChecks: [...NAME_CHECK_IDS] };
+      const hit = runNameChecks(wine, { checkIds: [...NAME_CHECK_IDS, futureRule.id] });
+      expect(hit).not.toBeNull();
+      expect(hit.checks).toEqual(['always-fires.v1']); // new rule fires; cleared rules stay suppressed
+    } finally {
+      NAME_CHECKS.pop();
+    }
+  });
+});
+
+describe('resolveCheck — untrusted-input gate', () => {
+  test('returns the rule for a known id', () => {
+    expect(resolveCheck('producer-in-name.v1').id).toBe('producer-in-name.v1');
+  });
+
+  test('rejects operator-injection shapes and unknowns', () => {
+    expect(resolveCheck({ $gt: '' })).toBeNull();
+    expect(resolveCheck(null)).toBeNull();
+    expect(resolveCheck(42)).toBeNull();
+    expect(resolveCheck('bogus.v9')).toBeNull();
+    expect(resolveCheck(['producer-in-name.v1'])).toBeNull();
+  });
+});

--- a/backend/src/utils/producerPrefix.js
+++ b/backend/src/utils/producerPrefix.js
@@ -1,6 +1,32 @@
 const { normalizeString, normalizeProducerKey, tokenize } = require('./normalize');
 
 /**
+ * Multi-character connectives / prepositions that cannot legitimately END a
+ * wine name. "La Viña de" (producer "Madaras") is the launch symptom of
+ * leaving one stranded: an exact-string suffix strip lopped the producer off
+ * the tail of "La Viña de Madaras" and kept the linking word (support ticket
+ * 2026-07-26; 10 such rows on prod).
+ *
+ * Lives HERE (not in nameChecks.js, which consumes it) so the suffix-strip
+ * guard below can use it without a circular require — nameChecks requires
+ * this module for its rules.
+ *
+ * Deliberately EXCLUDES bare single letters (Château d'Yquem's dry white is
+ * literally named "Y"; 'e'/'y' are Italian/Spanish "and") and bare ARTICLES
+ * (la, le, el, il, the, der, die, das open wine names far more often than
+ * they end them). Widen only from measured evidence —
+ * scripts/scan-name-anomalies.js reports the hit list — and bump the
+ * dangling-name-tail rule id in nameChecks.js when you do.
+ */
+const DANGLING_TAIL_WORDS = new Set([
+  'de', 'del', 'della', 'delle', 'dei', 'degli', 'di', 'du', 'des',
+  'da', 'dal', 'dalla', 'do', 'dos', 'das',
+  'von', 'vom', 'van', 'of', 'and', 'et', 'und', 'och',
+  'zu', 'zum', 'zur', 'au', 'aux', 'sur', 'sous', 'in', 'im', 'am',
+  'con', 'com', 'avec', 'mit', 'med',
+]);
+
+/**
  * Detect and strip a redundant producer prefix from a wine name.
  *
  * AI import lookups often store names like "Meerlust Chardonnay" for producer
@@ -121,6 +147,7 @@ function canonicalizeWineName(name, producer) {
 }
 
 module.exports = {
+  DANGLING_TAIL_WORDS,
   stripProducerPrefix,
   stripProducerSuffix,
   stripProducerName,


### PR DESCRIPTION
## What this is (and is not)

Johan's ask: *"a flag on registry wines so we know which we've checked and don't re-review every one on every scan."*

**Not the moderation gate rejected earlier** — nothing is withheld pending review. This is a **post-hoc suppression record**, the same kind as `dismiss-duplicates`: *"I looked at this row for this rule; stop showing it to me."* It doubles as the false-positive whitelist the name-scan needs (marking Château Latour fine IS the whitelist entry).

## Why not `verified: true`

A bare boolean silently suppresses every rule added after it was set — verify 4k wines today, add a 4th check next month, and the whole registry is skipped for a rule nobody examined. That's the same silent-drift class as the Espalda taxonomy bug (#836).

Instead: **`verifiedChecks: [String]` of versioned rule ids** (`name-equals-producer.v1`). A new rule's id is in nobody's array → all 4,282 rows surface by construction. Refining a rule = bumping its id in the same commit → its clearances (only its own) auto-invalidate. A jest **source snapshot suite** pins each `detect()` body, so editing one without a bump fails CI with the diff.

## The four rules (`utils/nameChecks.js`)

| Rule | Default queue | What it catches |
|---|---|---|
| `producer-in-name.v1` | yes | the existing scan, registered |
| `dangling-name-tail.v1` | yes | "La Viña de" (ticket 2026-07-26; 10 prod rows) |
| `name-equals-producer.v1` | yes | Annapurna/Annapurna shape |
| `name-equals-producer-estate.v1` | **no** | the ~139 legit Château/Domaine rows — named + queryable via `?check=`, never floods the queue, never an invisible hardcoded exemption |

## Key properties (each carries a test)

- **Invalidation**: the existing pre-validate hook clears the record when `name`/`producer` change — and only then. Exhaustive grep (2026-07-26): no `updateOne`/`bulkWrite` caller mutates either field on existing rows (LWIN import wraps both in `$ifNull` → insert-only), so the hook is a complete chokepoint. A user posting a review (communityRating write) can NEVER un-verify a wine.
- **Server-side re-detect** on `POST /verify-checks` — a stale client row can't clear a rule the admin never saw (strip-producer precedent).
- **`GET /producer-in-name`** absorbs the rules: per-rule suppression, `?check=` scoping, `?includeVerified=1` audit view. Pair-shaped scans (duplicate-clusters, canonical-collisions) deliberately untouched — `WineNotDuplicate` already covers them, and per-wine suppression there would hide a verified wine from pairing against a NEW duplicate of itself.
- **`undo_last` GC guard**: a user's undo can no longer delete a wine carrying clearances (also fixes the guard's field never being projected).
- **Merge**: keeper keeps its own clearances; loser's die with its doc. Zero merge-code changes — verified against `reassignWineRefs`.

## Explicitly zero-impact (tested)

- **Embeddings**: `buildEmbeddingText` is a closed whitelist — new golden-string test proves `textHash` is byte-identical. **Do NOT run the embed job after deploy.**
- **Meilisearch**: no document/settings change, no re-index.
- **GDPR**: no user ref stored (`WineNotDuplicate` precedent — actor in AuditLog). No export/deletion-cascade changes.
- **No index, no migration, no backfill** — legacy rows read as unreviewed via the `.lean()`-safe guard. The 139 estate rows are NOT machine-pre-verified (a script asserting human review would make the record worthless).

## Ships inert

No UI reaches the endpoints yet — the admin modal lands in the follow-up PR. After this merges + deploys, run the read-only sizing script once:
`docker exec cellarion-backend node src/scripts/scan-name-anomalies.js`

## Tests

6 new/extended suites, 68 tests + 5 snapshots — incl. the staleness contract (a wine cleared for every current rule still surfaces for a rule appended later) and the false-clear guard (9 non-name field mutations leave the record intact). Neighboring suites (dedup route, producerPrefix, canonicalKey, normalize, findOrCreateWine, embedding transport): 174 tests green.

## Docker-compose impact

**None.** No env vars, services, ports, volumes; `docker-compose.prod.yml` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)