### PR TITLE
fix(registry): stripProducerSuffix must not leave a stranded connective

### DIFF
--- a/backend/src/utils/producerPrefix.js
+++ b/backend/src/utils/producerPrefix.js
@@ -74,7 +74,17 @@ function stripProducerSuffix(name, producer) {
   if (!/[\s\-–—]$/.test(rest)) return null;
 
   const remainder = rest.replace(/[\s\-–—]+$/, '').trim();
-  return remainder.length > 0 ? remainder : null;
+  if (remainder.length === 0) return null;
+  // Never leave a stranded connective at the tail: "La Viña de Madaras" with
+  // producer "Madaras" must NOT strip to "La Viña de" — exactly how prod's 10
+  // dangling-name rows were minted (support ticket 2026-07-26). When the
+  // producer token is grammatically part of the name, the full phrase IS the
+  // name (same family as "Les Forts de Latour"); keeping it beats writing a
+  // broken one. canonicalizeWineName loops this function on every registry
+  // write surface, so the guard closes the class at create time.
+  const lastToken = normalizeString(remainder).split(' ').filter(Boolean).pop();
+  if (lastToken && DANGLING_TAIL_WORDS.has(lastToken)) return null;
+  return remainder;
 }
 
 /**

--- a/backend/src/utils/producerPrefix.test.js
+++ b/backend/src/utils/producerPrefix.test.js
@@ -71,6 +71,32 @@ describe('stripProducerSuffix', () => {
     expect(stripProducerSuffix('Meerlust Chardonnay', 'Meerlust')).toBeNull();
   });
 
+  test('never strips to a stranded connective — the "La Viña de" ticket class (2026-07-26)', () => {
+    // The two real prod rows this guard would have prevented:
+    expect(stripProducerSuffix('La Viña de Madaras', 'Madaras')).toBeNull();
+    expect(stripProducerSuffix('Re di Renieri', 'Renieri')).toBeNull();
+    // Other connectives from the shared list, either script:
+    expect(stripProducerSuffix('Cuvée von Weingut X', 'Weingut X')).toBeNull();
+    expect(stripProducerSuffix('Blanc du Château Y', 'Château Y')).toBeNull();
+  });
+
+  test('the dangling guard only inspects the TAIL — interior connectives still strip', () => {
+    // "di" is inside the remainder, tail is "Avellino" → legit strip.
+    expect(stripProducerSuffix('Fiano di Avellino Mastroberardino', 'Mastroberardino'))
+      .toBe('Fiano di Avellino');
+    // Diacritics/case on the tail token don't dodge the guard (normalizeString).
+    expect(stripProducerSuffix('Cuvée DU Domaine Z', 'Domaine Z')).toBeNull();
+  });
+
+  test('canonicalizeWineName keeps the full phrase when the strip would dangle', () => {
+    const { canonicalizeWineName } = require('./producerPrefix');
+    // The create-time loop must settle on the ORIGINAL name, not the broken one.
+    expect(canonicalizeWineName('La Viña de Madaras', 'Madaras')).toBe('La Viña de Madaras');
+    expect(canonicalizeWineName('Re di Renieri', 'Renieri')).toBe('Re di Renieri');
+    // Untouched happy path: a clean suffix embed still canonicalizes.
+    expect(canonicalizeWineName('Lacrimarosa Mastroberardino', 'Mastroberardino')).toBe('Lacrimarosa');
+  });
+
   test('stripProducerName handles either end, prefix first, and loops clean both-ends input', () => {
     expect(stripProducerName('Meerlust Chardonnay', 'Meerlust')).toBe('Chardonnay');
     expect(stripProducerName('Fiano di Avellino Mastroberardino', 'Mastroberardino')).toBe('Fiano di Avellino');


### PR DESCRIPTION
## The tap behind the ticket

#837 ships the scan that FINDS dangling names (`dangling-name-tail.v1`); this PR stops new ones being minted. "La Viña de Madaras" (producer "Madaras") was stripped to **"La Viña de"** at create time — `stripProducerSuffix` is exact-string with only a something-remains guard, and `canonicalizeWineName` loops it on every registry write surface (findOrCreateWine, admin create, wine-request approval). 10 such rows existed on prod when the ticket was filed.

## The guard

After the strip, if the remainder's last normalized token is in `DANGLING_TAIL_WORDS` (the same list the scan rule uses — one list, one behavior), refuse the strip and keep the full phrase. Rationale: when the producer token is grammatically part of the name, the full phrase **is** the name — the "Les Forts de Latour" family the suffix stripper already respects by staying exact-string. Keeping a producer-embedded name (reviewable) beats writing a broken one (invisible).

Only the **tail** token is inspected — "Fiano di Avellino Mastroberardino" still strips to "Fiano di Avellino". Prefix strips untouched (a leading-edge strip can't create this shape).

## Base branch note

**Based on `feat/registry-name-check-verification` (#837)** — it uses the `DANGLING_TAIL_WORDS` set that lands there. Merge #837 first; this then retargets to `main` (I'll rebase it so the diff is clean).

## Tests

6 suites / 136 tests green in `node:20-alpine`, including the two real prod rows ("La Viña de Madaras", "Re di Renieri"), von/du connectives, diacritics/case immunity, the interior-connective happy path, and `canonicalizeWineName` settling on the original name. The #837 snapshot suite still passes — no `detect()` source changed (a shared-helper behavior change is the documented residual there, called out in `nameChecks.js`).

## Docker-compose impact

**None.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)