### PR TITLE
chore(release): v1.89.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.88.0",
+  "version": "1.89.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.88.0",
+      "version": "1.89.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.88.0",
+  "version": "1.89.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.88.0",
+  "version": "1.89.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.88.0",
+      "version": "1.89.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.88.0",
+  "version": "1.89.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — all 4 fields (backend/frontend package.json + the `version` field in both lockfiles; no dependency-tree changes).

## Contents of v1.89.0

Registry data-quality work, all four PRs from the 2026-07-26 support ticket:

- **#836** — `findOrCreateCountry` mint gate. A garbled label scan created the country "Espalda" (a misread "España") on prod; any user's add could pollute the shared taxonomy. Now only recognized real-world countries can be minted; existing docs still resolve.
- **#837** — per-rule admin verification (`verifiedChecks` on WineDefinition). Versioned rule ids rather than a bare boolean, so a rule added later can't be silently pre-cleared by an earlier review. Ships with the 4-rule `nameChecks.js`, verify/unverify endpoints, hook-based invalidation, an `undo_last` GC guard, and a read-only sizing script.
- **#838** — the admin **Name checks** modal: per-row "Looks fine" with undo, a Why column, a rule picker (reaches the ~139 legitimate estate rows), and an include-already-verified audit view.
- **#840** — `stripProducerSuffix` no longer strips to a stranded connective, so no new "La Viña de" rows get minted.

## Deploy notes

- **Do NOT run the embedding job** — the new fields provably cannot enter the embedding text (golden-string test locks it); a re-embed of 4,282 wines would be pure Voyage spend for zero change.
- No Meilisearch re-index, no `filterableAttributes` change.
- No index build, no migration, no backfill — legacy rows read as unreviewed.
- **docker-compose impact: none** (no env vars, services, ports, volumes) — `docker-compose.prod.yml` needs no edit.
- Nothing user-facing changes; the only externally visible difference is a clearer 400 when an add supplies an unrecognized country.

Post-deploy, two read-only scans (no `--apply` flag) size the review queues and confirm the Espalda blast radius before any data fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)