### PR TITLE
fix(registry): close the write paths behind the audit's 8 root causes

### DIFF
--- a/backend/src/models/WineDefinition.verifiedChecks.test.js
+++ b/backend/src/models/WineDefinition.verifiedChecks.test.js
@@ -27,14 +27,14 @@ const baseDoc = (overrides = {}) => new WineDefinition({
 // loaded document; the other paths don't matter (the hook ignores them).
 const reviewedDoc = async () => {
   const doc = baseDoc({
-    verifiedChecks: ['name-equals-producer.v1', 'dangling-name-tail.v1'],
+    verifiedChecks: ['name-equals-producer.v1', 'dangling-name-tail.v2'],
     verifiedAt: new Date('2026-07-26T10:00:00Z'),
   });
   doc.$isNew = false;
   doc.unmarkModified('name');
   doc.unmarkModified('producer');
   await doc.validate();
-  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v2']);
   return doc;
 };
 
@@ -79,7 +79,7 @@ test('THE FALSE-CLEAR GUARD: every other field change leaves the record intact',
     const doc = await reviewedDoc();
     mutate(doc);
     await doc.validate();
-    expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+    expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v2']);
     expect(doc.verifiedAt).toEqual(new Date('2026-07-26T10:00:00Z'));
   }
 });
@@ -92,14 +92,14 @@ test('reassigning an IDENTICAL name does not clear (the admin PUT posts the whol
   doc.name = 'Block 3 Pinot Noir';
   doc.producer = 'Felton Road';
   await doc.validate();
-  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v2']);
   expect(doc.verifiedAt).toEqual(new Date('2026-07-26T10:00:00Z'));
 });
 
 test('validate with no modification leaves the record intact', async () => {
   const doc = await reviewedDoc();
   await doc.validate();
-  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v2']);
 });
 
 test('regression: canonicalKey still recomputes on an appellation change', async () => {
@@ -108,5 +108,5 @@ test('regression: canonicalKey still recomputes on an appellation change', async
   doc.appellation = 'Central Otago';
   await doc.validate();
   expect(doc.canonicalKey).not.toBe(before);
-  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v1']);
+  expect(doc.verifiedChecks).toEqual(['name-equals-producer.v1', 'dangling-name-tail.v2']);
 });

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -2,7 +2,8 @@ const express = require('express');
 const multer = require('multer');
 const { parse } = require('csv-parse');
 const { requireAuth, requireRole } = require('../../middleware/auth');
-const { generateWineKey, normalizeString, normalizeAppellation, resolveCountryName, isUnknownName } = require('../../utils/normalize');
+const { generateWineKey, normalizeString, normalizeAppellation, resolveCountryName, isRecognizedCountry, isUnknownName } = require('../../utils/normalize');
+const { canonicalizeWineName } = require('../../utils/producerPrefix');
 const WineDefinition = require('../../models/WineDefinition');
 const Country = require('../../models/Country');
 const Region = require('../../models/Region');
@@ -80,16 +81,26 @@ function mapRow(row, format) {
     // Fallback: when PRODUCER_NAME or WINE is NA, parse DISPLAY_NAME.
     // LWIN DISPLAY_NAME format: "ProducerTitle ProducerName, SubRegion, WineName"
     // e.g. "G.D. Vajra, Barolo, Albe" → producer="G.D. Vajra", name="Albe"
+    //
+    // parts[0] is only trusted as the producer with THREE OR MORE parts —
+    // matching the documented format. A two-part display is as often
+    // "SubRegion, WineName" as "Producer, WineName", and trusting it wrote
+    // "Bordeaux" / "California" / "Tuscany" into the producer field ~45 times
+    // across four import waves (registry audit 2026-07-26, RC-2; the same
+    // split also truncated "…Côtes de Bordeaux" names mid-appellation). A row
+    // left without a producer fails the required-fields check downstream and
+    // lands in the import error report — visible beats corrupted.
     if (!producer || !name) {
       const display = lwinVal(row.DISPLAY_NAME);
       if (display) {
         const parts = display.split(',').map(p => p.trim()).filter(Boolean);
-        if (parts.length >= 2) {
+        if (parts.length >= 3) {
           if (!producer) producer = parts[0];
           if (!name)     name     = parts[parts.length - 1];
+        } else if (parts.length === 2) {
+          if (!name) name = parts[1];
         } else if (parts.length === 1) {
-          if (!producer) producer = parts[0];
-          if (!name)     name     = parts[0];
+          if (!name) name = parts[0];
         }
       }
     }
@@ -100,7 +111,9 @@ function mapRow(row, format) {
       name,
       country: lwinVal(row.COUNTRY),
       region: lwinVal(row.REGION),
-      appellation: lwinVal(row.SUB_REGION),
+      // Same tier-strip as the simple format below and findOrCreateWine —
+      // LWIN SUB_REGION carries "… DOCG"/"DO …" forms too (audit RC-4).
+      appellation: normalizeAppellation(lwinVal(row.SUB_REGION)),
       type: mapType(row.COLOUR, row.SUB_TYPE, null),
       classification: lwinVal(row.CLASSIFICATION),
       status: (row.STATUS || '').trim() || 'Live',
@@ -140,6 +153,21 @@ async function getOrCreateCountry(name, userId, cache) {
   // CSV in another language can't mint a duplicate Country document.
   const canonicalName = resolveCountryName(name);
   const normalized = normalizeString(canonicalName);
+  // Mint gate, same as findOrCreateCountry (#836): a CSV cell that is not a
+  // recognized real-world country must not become a Country document. THROWS
+  // rather than returning null — the flush uses bulkWrite, which bypasses the
+  // `country: required` validator, so a null here would insert a countryless
+  // wine instead of skipping the row. The throw is caught per-row and lands
+  // in the import error report. An EXISTING doc (matched below by upsert
+  // filter) still resolves — matching is not minting.
+  if (!isRecognizedCountry(canonicalName)) {
+    const existing = await Country.findOne({ normalizedName: normalized }).select('_id').lean();
+    if (!existing) {
+      throw new Error(`Unrecognized country "${String(name).trim().slice(0, 80)}"`);
+    }
+    cache.set(key, existing._id);
+    return existing._id;
+  }
   const doc = await Country.findOneAndUpdate(
     { normalizedName: normalized },
     { $setOnInsert: { name: canonicalName.trim(), normalizedName: normalized, createdBy: userId } },
@@ -359,6 +387,12 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
       stats.total++;
 
       try {
+        // Step-0 name canon, same as findOrCreateWine: this path bulkWrites
+        // directly, so without it a producer-embedded name ("Vajra Albe" /
+        // producer "Vajra") mints the producer-in-name shape the admin tool
+        // then has to clean up (registry audit 2026-07-26).
+        mapped.name = canonicalizeWineName(mapped.name, mapped.producer);
+
         const countryId = await getOrCreateCountry(mapped.country, userId, countryCache);
         const regionId = await getOrCreateRegion(mapped.region, countryId, userId, regionCache);
         await getOrCreateAppellation(mapped.appellation, countryId, regionId, userId, appellationCache);
@@ -403,3 +437,6 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
 });
 
 module.exports = router;
+// mapRow is exported for its unit tests (the DISPLAY_NAME fallback rules are
+// load-bearing — audit RC-2); it is pure and DB-free.
+module.exports.mapRow = mapRow;

--- a/backend/src/routes/admin/import.mapRow.test.js
+++ b/backend/src/routes/admin/import.mapRow.test.js
@@ -1,0 +1,73 @@
+/**
+ * mapRow — the LWIN CSV row mapper, and specifically its DISPLAY_NAME
+ * fallback. The old fallback trusted a 2-part split ("Bordeaux, Château
+ * Margaux") and wrote the REGION into the producer field ~45 times across
+ * four prod import waves (registry audit 2026-07-26, RC-2); it also truncated
+ * "…Côtes de Bordeaux" names mid-appellation. These tests pin the repaired
+ * rules: 3+ parts = trust producer+name, 2 parts = name only, 1 part = name
+ * only — a missing producer is skipped-and-reported downstream, never minted.
+ */
+
+jest.mock('../../services/search', () => ({ fullSync: jest.fn(), indexWine: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+
+const { mapRow } = require('./import');
+
+const lwinRow = (over = {}) => ({
+  LWIN: '1234567',
+  STATUS: 'Live',
+  DISPLAY_NAME: 'NA',
+  PRODUCER_TITLE: 'NA',
+  PRODUCER_NAME: 'NA',
+  WINE: 'NA',
+  COUNTRY: 'France',
+  REGION: 'Bordeaux',
+  SUB_REGION: 'NA',
+  COLOUR: 'Red',
+  TYPE: 'Wine',
+  SUB_TYPE: 'Still',
+  CLASSIFICATION: 'NA',
+  ...over,
+});
+
+describe('mapRow (lwin) — explicit PRODUCER_NAME/WINE columns win', () => {
+  test('uses the explicit columns when present', () => {
+    const m = mapRow(lwinRow({ PRODUCER_NAME: 'G.D. Vajra', WINE: 'Albe' }), 'lwin');
+    expect(m.producer).toBe('G.D. Vajra');
+    expect(m.name).toBe('Albe');
+  });
+});
+
+describe('mapRow (lwin) — DISPLAY_NAME fallback', () => {
+  test('3+ parts follow the documented format: producer, subregion, name', () => {
+    const m = mapRow(lwinRow({ DISPLAY_NAME: 'G.D. Vajra, Barolo, Albe' }), 'lwin');
+    expect(m.producer).toBe('G.D. Vajra');
+    expect(m.name).toBe('Albe');
+  });
+
+  test('2 parts NEVER fill the producer — "Bordeaux, Château Margaux" was the RC-2 corruption', () => {
+    const m = mapRow(lwinRow({ DISPLAY_NAME: 'Bordeaux, Château Margaux' }), 'lwin');
+    expect(m.producer).toBeNull();          // skipped-and-reported downstream
+    expect(m.name).toBe('Château Margaux'); // the name half is safe
+  });
+
+  test('1 part fills the name only, never the producer', () => {
+    const m = mapRow(lwinRow({ DISPLAY_NAME: 'Château Margaux' }), 'lwin');
+    expect(m.producer).toBeNull();
+    expect(m.name).toBe('Château Margaux');
+  });
+
+  test('an explicit producer survives alongside a 2-part display (only the missing field falls back)', () => {
+    const m = mapRow(lwinRow({ PRODUCER_NAME: 'Château Margaux', DISPLAY_NAME: 'Bordeaux, Pavillon Rouge' }), 'lwin');
+    expect(m.producer).toBe('Château Margaux');
+    expect(m.name).toBe('Pavillon Rouge');
+  });
+});
+
+describe('mapRow (lwin) — appellation tier strip', () => {
+  test('SUB_REGION is canonicalized like every other write path (audit RC-4)', () => {
+    expect(mapRow(lwinRow({ SUB_REGION: 'Barolo DOCG' }), 'lwin').appellation).toBe('Barolo');
+    expect(mapRow(lwinRow({ SUB_REGION: 'DO Alicante' }), 'lwin').appellation).toBe('Alicante');
+    expect(mapRow(lwinRow({ SUB_REGION: 'NA' }), 'lwin').appellation).toBeNull();
+  });
+});

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -772,7 +772,7 @@ router.get('/canonical-collisions', async (req, res) => {
 //   producer-in-name.v1        — name starts/ends with its own producer,
 //                                including key-token variants ("Felton Road
 //                                Block 3 Pinot Noir" / "Felton Road Wines Ltd")
-//   dangling-name-tail.v1      — name ends in a stranded connective
+//   dangling-name-tail.v2      — name ends in a stranded connective
 //                                ("La Viña de" — support ticket 2026-07-26)
 //   name-equals-producer.v1    — name === producer, non-estate shape
 // plus the non-default estate cohort via ?check=name-equals-producer-estate.v1.

--- a/backend/src/routes/admin/wines.verifyChecks.test.js
+++ b/backend/src/routes/admin/wines.verifyChecks.test.js
@@ -105,7 +105,7 @@ const call = (method, path, body) => fetch(`${baseUrl}/api/admin/wines${path}`, 
 
 // Trips name-equals-producer.v1 (non-estate) and nothing else.
 const OPUS = { _id: WINE_A, name: 'Opus One', producer: 'Opus One' };
-// Trips dangling-name-tail.v1 only (the ticket's launch row).
+// Trips dangling-name-tail.v2 only (the ticket's launch row).
 const VINA = { _id: WINE_B, name: 'La Viña de', producer: 'Madaras' };
 
 describe('POST /verify-checks', () => {
@@ -231,7 +231,7 @@ describe('GET /producer-in-name — per-rule suppression', () => {
 
   test('cleared for a DIFFERENT rule → still surfaces (per-rule granularity)', async () => {
     WineDefinition.find.mockReturnValue(findChain([
-      { ...OPUS, verifiedChecks: ['dangling-name-tail.v1'] },
+      { ...OPUS, verifiedChecks: ['dangling-name-tail.v2'] },
     ]));
     const data = await (await get()).json();
     expect(data.total).toBe(1);
@@ -255,7 +255,7 @@ describe('GET /producer-in-name — per-rule suppression', () => {
     const data = await (await get()).json();
     expect(data.total).toBe(2);
     const vina = data.wines.find(w => w._id === WINE_B);
-    expect(vina.checks).toEqual(['dangling-name-tail.v1']);
+    expect(vina.checks).toEqual(['dangling-name-tail.v2']);
     expect(vina.proposedName).toBeNull();
     const meerlust = data.wines.find(w => w._id === WINE_A);
     expect(meerlust.checks).toEqual(['producer-in-name.v1']);
@@ -284,10 +284,10 @@ describe('GET /producer-in-name — per-rule suppression', () => {
     WineDefinition.find.mockReturnValue(findChain([OPUS]));
     const data = await (await get()).json();
     expect(data.checkIds).toEqual([
-      'producer-in-name.v1', 'dangling-name-tail.v1', 'name-equals-producer.v1',
+      'producer-in-name.v1', 'dangling-name-tail.v2', 'name-equals-producer.v1',
     ]);
     expect(data.allCheckIds).toContain('name-equals-producer-estate.v1');
-    expect(data.checkLabelKeys['dangling-name-tail.v1']).toBe('danglingTail');
+    expect(data.checkLabelKeys['dangling-name-tail.v2']).toBe('danglingTail');
     expect(data.scannedCount).toBe(1);
   });
 });

--- a/backend/src/scripts/strip-name-vintages.js
+++ b/backend/src/scripts/strip-name-vintages.js
@@ -1,0 +1,112 @@
+/**
+ * strip-name-vintages.js
+ *
+ * Registry audit 2026-07-26 (B2): 19 wines carry a trailing vintage year in
+ * their NAME ("Reserve Cabernet Sauvignon 2023") even though the registry is
+ * vintage-neutral by construction — the year belongs on Bottle.vintage. The
+ * write paths now strip it on create (utils/normalize.stripTrailingVintage,
+ * wired into findOrCreateWine step 0); this cleans up existing rows.
+ *
+ * For each wine whose name ends in a plausible vintage (1950–2049, TRAILING
+ * only — leading years are brand names like "1924 Double Black"):
+ *   - compute the stripped name and the new normalizedKey (name is part of
+ *     the dedup key). Because normalizedKey is UNIQUE:
+ *       no collision → update name + normalizedKey, re-index Meili (wine AND
+ *       its bottles — bottle documents denormalize wineName);
+ *       collision → SKIP and report for manual merge (the year was the only
+ *       thing distinguishing two rows = a genuine duplicate).
+ *   - write the stripped year to Bottle.vintage for the wine's bottles, but
+ *     ONLY where bottle.vintage is null — an owner's explicit vintage is
+ *     never overwritten, even when it disagrees with the name.
+ *
+ * The wine's slug is deliberately untouched (URL stability — same rule as
+ * every rename path). Embedding: the name feeds the embed text, so touched
+ * wines re-embed on the next incremental job run; start one after --apply.
+ *
+ * Dry-run by default. On --apply: writes a JSON backup of affected rows first.
+ *
+ * Usage:
+ *   node src/scripts/strip-name-vintages.js            # dry run
+ *   node src/scripts/strip-name-vintages.js --apply    # execute
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const Bottle = require('../models/Bottle');
+const searchService = require('../services/search');
+const { stripTrailingVintage, generateWineKey } = require('../utils/normalize');
+
+const APPLY = process.argv.includes('--apply');
+const tag = APPLY ? '✔' : '[dry]';
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log(`Connected. Mode: ${APPLY ? 'APPLY' : 'DRY RUN (pass --apply to execute)'}\n`);
+
+  const wines = await WineDefinition
+    .find({ name: { $regex: /(?:19[5-9]\d|20[0-4]\d)\)?$/ } })
+    .select('name producer appellation normalizedKey')
+    .lean();
+
+  const stats = { candidates: 0, changed: 0, collisions: 0, bottlesDated: 0 };
+  const backup = [];
+
+  for (const w of wines) {
+    const stripped = stripTrailingVintage(w.name);
+    if (stripped === w.name) continue; // name IS just a year, or no real match
+    stats.candidates += 1;
+
+    // The year that was removed — what the owners' undated bottles receive.
+    const yearMatch = w.name.match(/(19[5-9]\d|20[0-4]\d)/g);
+    const year = yearMatch ? parseInt(yearMatch[yearMatch.length - 1], 10) : null;
+
+    const newKey = generateWineKey(stripped, w.producer, w.appellation || '');
+    const clash = await WineDefinition.findOne({ normalizedKey: newKey, _id: { $ne: w._id } }).select('_id name').lean();
+    if (clash) {
+      stats.collisions += 1;
+      console.log(`  SKIP (collision) "${w.name}" — ${w.producer} [${w._id}] → would collide with [${clash._id}] "${clash.name}"; merge via the admin duplicates tool instead`);
+      continue;
+    }
+
+    const undated = await Bottle.countDocuments({ wineDefinition: w._id, vintage: null });
+    console.log(`  ${tag} "${w.name}" → "${stripped}"  (year ${year} → ${undated} undated bottle(s))  [${w._id}]`);
+
+    if (APPLY) {
+      backup.push(w);
+      await WineDefinition.updateOne(
+        { _id: w._id },
+        { $set: { name: stripped, normalizedKey: newKey, updatedAt: new Date() } }
+      );
+      if (year && undated > 0) {
+        const r = await Bottle.updateMany(
+          { wineDefinition: w._id, vintage: null },
+          { $set: { vintage: year } }
+        );
+        stats.bottlesDated += r.modifiedCount || 0;
+      }
+      searchService.indexWine(w._id);
+      const bottleIds = await Bottle.distinct('_id', { wineDefinition: w._id });
+      if (bottleIds.length) {
+        searchService.bulkIndexBottles(bottleIds).catch(() => {});
+      }
+    }
+    stats.changed += 1;
+  }
+
+  if (APPLY && backup.length) {
+    const file = path.join(os.tmpdir(), `strip-name-vintages-backup-${Date.now()}.json`);
+    fs.writeFileSync(file, JSON.stringify(backup, null, 1));
+    console.log(`\nBackup of ${backup.length} pre-change rows: ${file}`);
+    console.log('(container /tmp is ephemeral — docker cp it off before recreating the container)');
+  }
+
+  console.log(`\nCandidates: ${stats.candidates}  changed: ${stats.changed}  collisions(skipped): ${stats.collisions}  bottles dated: ${stats.bottlesDated}`);
+  if (APPLY) console.log('Next: start the admin embedding job (incremental) — the name feeds the embed text.');
+  await mongoose.disconnect();
+}
+
+run().catch((err) => { console.error('strip-name-vintages failed:', err); process.exit(1); });

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -17,8 +17,9 @@ const WineDefinition = require('../models/WineDefinition');
 const Country = require('../models/Country');
 const Region = require('../models/Region');
 const Grape = require('../models/Grape');
+const Appellation = require('../models/Appellation');
 const searchService = require('./search');
-const { generateWineKey, normalizeString, normalizeAppellation, resolveGrapeName, resolveCountryName, isRecognizedCountry, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
+const { generateWineKey, normalizeString, normalizeAppellation, stripTrailingVintage, resolveGrapeName, resolveCountryName, isRecognizedCountry, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
 const { canonicalizeWineName } = require('../utils/producerPrefix');
 const { computeCanonicalKey, canonicalSiblingPrefix } = require('../utils/wineIdentity');
@@ -80,6 +81,16 @@ async function findOrCreateRegion(name, countryId, userId) {
     $or: [{ normalizedName }, { normalizedSynonyms: normalizedName }],
   });
   if (region) return region;
+  // Mint gates (registry audit 2026-07-26 RC-8). A comma means the caller
+  // packed a hierarchy into one string ("Bordeaux, Haut-Médoc", "Niagara
+  // Peninsula, Ontario") — never a region name; and a region that IS a
+  // recognized country name belongs in the country field, not here (prod grew
+  // region "Scotland" under country "England"). A null region is the honest
+  // state — the schema allows it, and an admin can add real taxonomy
+  // deliberately. (Cost: a US wine can't auto-mint a "Georgia" region — the
+  // one state that collides with a country name; an existing doc still
+  // matches above.)
+  if (String(name).includes(',') || isRecognizedCountry(name)) return null;
   region = new Region({ name: name.trim(), normalizedName, country: countryId, createdBy: userId });
   await region.save();
   return region;
@@ -158,7 +169,15 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // instead of two (ticket #2C). The tier belongs in classification.
   const trimmedAppellation = normalizeAppellation((typeof appellation === 'string' ? appellation.trim() : '')).slice(0, MAX_FIELD);
 
-  // 0. Registry canon: a wine's name never embeds its producer. Cellar-format
+  // 0. Registry canon: the registry is vintage-neutral — a trailing year on
+  // the name ("Reserve Cabernet Sauvignon 2023") belongs on the user's
+  // Bottle.vintage, never on the shared wine (audit 2026-07-26: 19 such rows;
+  // no write path stripped it). BEFORE the producer strip, so "Pinot Noir
+  // Amisfield 2019" sheds the year first and the suffix strip still sees the
+  // producer at the tail.
+  trimmedName = stripTrailingVintage(trimmedName);
+
+  // Registry canon: a wine's name never embeds its producer. Cellar-format
   // imports and the occasional non-compliant AI response arrive as
   // name "Amisfield Pinot Noir" + producer "Amisfield" — or as a SUFFIX,
   // "Fiano di Avellino Mastroberardino" (the launch-day admin report) —
@@ -312,7 +331,34 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // item instead of minting a WineDefinition + taxonomy per use.
   if (matchOnly) return { wine: null, noMatch: true };
 
-  // 3. Create new wine — resolve taxonomy first
+  // 3. Create new wine — producer sanity gate first (registry audit
+  // 2026-07-26, RC-2): a producer that IS a place is never right — the LWIN
+  // import's comma-split wrote "Bordeaux" / "California" / "Tuscany" into the
+  // producer field ~45 times, and every add matching such a string would
+  // compound it. Exact normalized full-string match only, so "Marchesi di
+  // Barolo" and "La Rioja Alta" pass while bare "Barolo" / "La Rioja" do not.
+  // Mint-time only (like the country gate): existing rows keep resolving
+  // above until the data cleanup re-points them.
+  const producerNorm = normalizeString(trimmedProducer);
+  if (producerNorm.length < 2) {
+    const err = new Error(`"${trimmedProducer}" is not a usable producer name`);
+    err.status = 400;
+    throw err;
+  }
+  const [placeCountry, placeRegion, placeAppellation] = await Promise.all([
+    Country.exists({ normalizedName: producerNorm }),
+    Region.exists({ $or: [{ normalizedName: producerNorm }, { normalizedSynonyms: producerNorm }] }),
+    Appellation.exists({ normalizedName: producerNorm }),
+  ]);
+  if (placeCountry || placeRegion || placeAppellation) {
+    const err = new Error(
+      `"${trimmedProducer}" is a wine region, not a producer — put the actual winery in the producer field`
+    );
+    err.status = 400;
+    throw err;
+  }
+
+  // Resolve taxonomy
   const countryDoc = await findOrCreateCountry(country, userId);
   if (!countryDoc) {
     const err = new Error('Country is required to create a wine');

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -28,11 +28,13 @@ jest.mock('../models/WineDefinition', () => {
 jest.mock('../models/Country', () => {
   const ctor = jest.fn();
   ctor.findOne = jest.fn();
+  ctor.exists = jest.fn();
   return ctor;
 });
 jest.mock('../models/Region', () => {
   const ctor = jest.fn();
   ctor.findOne = jest.fn();
+  ctor.exists = jest.fn();
   return ctor;
 });
 jest.mock('../models/Grape', () => {
@@ -40,6 +42,7 @@ jest.mock('../models/Grape', () => {
   ctor.findOne = jest.fn();
   return ctor;
 });
+jest.mock('../models/Appellation', () => ({ exists: jest.fn() }));
 jest.mock('./search', () => ({
   getIsAvailable: jest.fn(),
   search: jest.fn(),
@@ -51,6 +54,7 @@ const WineDefinition = require('../models/WineDefinition');
 const Country = require('../models/Country');
 const Region = require('../models/Region');
 const Grape = require('../models/Grape');
+const Appellation = require('../models/Appellation');
 const searchService = require('./search');
 const { scoreAllMatches } = require('./wineMatching');
 const { generateWineKey } = require('../utils/normalize');
@@ -146,6 +150,10 @@ beforeEach(() => {
   // Taxonomy defaults: everything already exists
   Country.findOne.mockResolvedValue({ _id: 'country-1' });
   Region.findOne.mockResolvedValue({ _id: 'region-1' });
+  // Producer-place gate defaults: the producer is NOT a known place
+  Country.exists.mockResolvedValue(null);
+  Region.exists.mockResolvedValue(null);
+  Appellation.exists.mockResolvedValue(null);
   // findOrCreateGrapes queries { $or: [{ normalizedName }, { normalizedSynonyms: … }] }
   Grape.findOne.mockImplementation(async (q) => {
     const normalizedName = q.$or ? q.$or[0].normalizedName : q.normalizedName;
@@ -682,6 +690,66 @@ describe('findOrCreateWine — creation', () => {
     expect(WineDefinition).not.toHaveBeenCalled();
   });
 
+  test('producer-place gate: a producer that IS a known place is rejected 400 at mint (audit RC-2)', async () => {
+    Region.exists.mockResolvedValue({ _id: 'region-bordeaux' });
+
+    await expect(findOrCreateWine({ ...INPUT, producer: 'Bordeaux' }, USER_ID)).rejects.toMatchObject({
+      message: expect.stringContaining('wine region, not a producer'),
+      status: 400,
+    });
+    expect(WineDefinition).not.toHaveBeenCalled();
+    // The gate consults all three taxonomies with the normalized producer.
+    expect(Region.exists).toHaveBeenCalledWith({
+      $or: [{ normalizedName: 'bordeaux' }, { normalizedSynonyms: 'bordeaux' }],
+    });
+    expect(Appellation.exists).toHaveBeenCalledWith({ normalizedName: 'bordeaux' });
+  });
+
+  test('producer-place gate: exact full-string match only — "Marchesi di Barolo" passes', async () => {
+    // The taxonomy holds "barolo"; the gate must query the FULL normalized
+    // producer, which no taxonomy row equals — mocks return null (default).
+    await findOrCreateWine({ ...INPUT, producer: 'Marchesi di Barolo' }, USER_ID);
+
+    expect(Appellation.exists).toHaveBeenCalledWith({ normalizedName: 'marchesi di barolo' });
+    expect(WineDefinition).toHaveBeenCalled(); // created normally
+  });
+
+  test('producer-place gate runs at MINT only — the exact-match path never queries it', async () => {
+    WineDefinition.findOne.mockReturnValue(findOneChain(EXISTING_WINE));
+
+    await findOrCreateWine({ ...INPUT, producer: 'Bordeaux' }, USER_ID);
+
+    expect(Country.exists).not.toHaveBeenCalled();
+    expect(Region.exists).not.toHaveBeenCalled();
+    expect(Appellation.exists).not.toHaveBeenCalled();
+  });
+
+  test('a single-character producer is rejected at mint ("G" — audit RC-5)', async () => {
+    await expect(findOrCreateWine({ ...INPUT, producer: 'G' }, USER_ID)).rejects.toMatchObject({
+      message: expect.stringContaining('not a usable producer name'),
+      status: 400,
+    });
+    expect(WineDefinition).not.toHaveBeenCalled();
+  });
+
+  test('step 0 strips a trailing vintage year before matching (registry is vintage-neutral)', async () => {
+    WineDefinition.findOne.mockReturnValue(findOneChain(EXISTING_WINE));
+
+    await findOrCreateWine({ ...INPUT, name: 'Clos des Papes 2019' }, USER_ID);
+
+    // The year never reaches the dedup key — same key as the year-free name.
+    expect(WineDefinition.findOne).toHaveBeenCalledWith({ normalizedKey: INPUT_KEY });
+  });
+
+  test('a leading-year brand name survives step 0 ("1924 Double Black")', async () => {
+    WineDefinition.findOne.mockReturnValue(findOneChain(null));
+
+    await findOrCreateWine({ ...INPUT, name: '1924 Double Black' }, USER_ID);
+
+    const doc = WineDefinition.mock.calls[0][0];
+    expect(doc.name).toBe('1924 Double Black');
+  });
+
   test('duplicate-key race (11000): returns the concurrently created wine as created: false', async () => {
     WineDefinition.mockImplementation(function (doc) {
       Object.assign(this, doc);
@@ -803,6 +871,28 @@ describe('taxonomy find-or-create dedup', () => {
     });
     expect(result).toBe(existing);
     expect(Region).not.toHaveBeenCalled();
+  });
+
+  test('findOrCreateRegion: a comma-packed hierarchy is never minted — null region instead (audit RC-8)', async () => {
+    Region.findOne.mockResolvedValue(null);
+
+    expect(await findOrCreateRegion('Bordeaux, Haut-Médoc', 'country-1', USER_ID)).toBeNull();
+    expect(await findOrCreateRegion('Niagara Peninsula, Ontario', 'country-1', USER_ID)).toBeNull();
+    expect(Region).not.toHaveBeenCalled(); // no `new Region(...)`
+  });
+
+  test('findOrCreateRegion: a region named like a COUNTRY is never minted ("Scotland" under England)', async () => {
+    Region.findOne.mockResolvedValue(null);
+
+    expect(await findOrCreateRegion('Scotland', 'country-england', USER_ID)).toBeNull();
+    expect(Region).not.toHaveBeenCalled();
+  });
+
+  test('findOrCreateRegion: an EXISTING doc still matches even when named like a country (matching ≠ minting)', async () => {
+    const existing = { _id: 'region-georgia-usa', name: 'Georgia' };
+    Region.findOne.mockResolvedValue(existing);
+
+    expect(await findOrCreateRegion('Georgia', 'country-usa', USER_ID)).toBe(existing);
   });
 
   test('findOrCreateRegion: creates when missing; returns null without a countryId', async () => {

--- a/backend/src/utils/__snapshots__/nameChecks.snapshot.test.js.snap
+++ b/backend/src/utils/__snapshots__/nameChecks.snapshot.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`detect() source of dangling-name-tail.v1 is unchanged — bump the id if you edited it 1`] = `
+exports[`detect() source of dangling-name-tail.v2 is unchanged — bump the id if you edited it 1`] = `
 "w => {
     const tokens = normalizeString(w.name || '').split(' ').filter(Boolean);
     if (tokens.length < 2) return null; // a one-word name is not "dangling"
@@ -17,7 +17,7 @@ exports[`detect() source of producer-in-name.v1 is unchanged — bump the id if 
 exports[`rule ids are pinned (adding/removing/renaming a rule must be deliberate) 1`] = `
 [
   "producer-in-name.v1",
-  "dangling-name-tail.v1",
+  "dangling-name-tail.v2",
   "name-equals-producer.v1",
   "name-equals-producer-estate.v1 (non-default)",
 ]

--- a/backend/src/utils/nameChecks.js
+++ b/backend/src/utils/nameChecks.js
@@ -64,9 +64,11 @@ const NAME_CHECKS = [
   },
   {
     // Defect (b) from the ticket. A SAFETY NET for rows already in the
-    // registry; preventing NEW ones is a guard in stripProducerSuffix itself
-    // (its own PR — it changes a function every write surface calls).
-    id: 'dangling-name-tail.v1',
+    // registry; preventing NEW ones is a guard in stripProducerSuffix itself.
+    // v2: DANGLING_TAIL_WORDS gained by/sans/a (registry audit 2026-07-26) —
+    // the id bump invalidates v1 clearances so every row is re-examined
+    // against the wider list (none existed at bump time).
+    id: 'dangling-name-tail.v2',
     labelKey: 'danglingTail',
     defaultActive: true,
     detect: (w) => {

--- a/backend/src/utils/nameChecks.test.js
+++ b/backend/src/utils/nameChecks.test.js
@@ -60,8 +60,8 @@ describe('producer-in-name.v1', () => {
   });
 });
 
-describe('dangling-name-tail.v1', () => {
-  const detect = byId('dangling-name-tail.v1').detect;
+describe('dangling-name-tail.v2', () => {
+  const detect = byId('dangling-name-tail.v2').detect;
 
   test('flags the ticket row and its class', () => {
     expect(detect({ name: 'La Viña de', producer: 'Madaras' })).toBe('La Viña de');
@@ -79,6 +79,15 @@ describe('dangling-name-tail.v1', () => {
   test('never flags a one-word name (protects Yquem\'s "Y")', () => {
     expect(detect({ name: 'Y', producer: "Château d'Yquem" })).toBeNull();
     expect(detect({ name: 'de', producer: 'X' })).toBeNull(); // degenerate, still one word
+  });
+
+  test('v2 additions flag the audit rows the v1 list missed', () => {
+    expect(detect({ name: 'The Barry Bros by', producer: 'Jim Barry' })).toBe('The Barry Bros by');
+    expect(detect({ name: 'Vin Sans', producer: 'X' })).toBe('Vin Sans');
+    expect(detect({ name: 'Barolo Dedicato a', producer: 'Renieri' })).toBe('Barolo Dedicato a');
+    // …while mid-name occurrences of the same words stay clean.
+    expect(detect({ name: 'Sans Soufre Rouge', producer: 'X' })).toBeNull();
+    expect(detect({ name: 'Wine by the Sea', producer: 'X' })).toBeNull();
   });
 });
 
@@ -123,21 +132,21 @@ describe('runNameChecks — per-rule clearance semantics', () => {
   test('reports every tripped rule and the strip proposal', () => {
     const hit = runNameChecks(doubleHit);
     expect(hit.checks).toEqual(
-      expect.arrayContaining(['producer-in-name.v1', 'dangling-name-tail.v1'])
+      expect.arrayContaining(['producer-in-name.v1', 'dangling-name-tail.v2'])
     );
     expect(hit.proposedName).toBe('La Viña de');
   });
 
   test('a rule listed in verifiedChecks is skipped; others still report (per-rule granularity)', () => {
     const hit = runNameChecks({ ...doubleHit, verifiedChecks: ['producer-in-name.v1'] });
-    expect(hit.checks).toEqual(['dangling-name-tail.v1']);
+    expect(hit.checks).toEqual(['dangling-name-tail.v2']);
     expect(hit.proposedName).toBeNull(); // the proposing rule was cleared
   });
 
   test('all tripped rules cleared → null (row leaves the queue)', () => {
     expect(runNameChecks({
       ...doubleHit,
-      verifiedChecks: ['producer-in-name.v1', 'dangling-name-tail.v1'],
+      verifiedChecks: ['producer-in-name.v1', 'dangling-name-tail.v2'],
     })).toBeNull();
   });
 
@@ -148,15 +157,15 @@ describe('runNameChecks — per-rule clearance semantics', () => {
 
   test('ignoreCleared reports everything (the audit view)', () => {
     const hit = runNameChecks(
-      { ...doubleHit, verifiedChecks: ['producer-in-name.v1', 'dangling-name-tail.v1'] },
+      { ...doubleHit, verifiedChecks: ['producer-in-name.v1', 'dangling-name-tail.v2'] },
       { ignoreCleared: true }
     );
     expect(hit.checks).toHaveLength(2);
   });
 
   test('checkIds scopes the run (the ?check= path)', () => {
-    const hit = runNameChecks(doubleHit, { checkIds: ['dangling-name-tail.v1'] });
-    expect(hit.checks).toEqual(['dangling-name-tail.v1']);
+    const hit = runNameChecks(doubleHit, { checkIds: ['dangling-name-tail.v2'] });
+    expect(hit.checks).toEqual(['dangling-name-tail.v2']);
   });
 
   test('a clean wine returns null', () => {

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -60,9 +60,20 @@ const tokenize = (str) => {
 // others omit, splitting one appellation into variants ("Barolo" vs "Barolo
 // DOCG"). The tier belongs in the separate classification field, so the
 // canonical appellation is the place name with a trailing tier stripped. Only
-// unambiguous 3–4 char tiers — deliberately NOT 'do'/'ao', which collide with
-// real place-name words.
-const APPELLATION_TIER_TOKENS = new Set(['docg', 'doca', 'doc', 'aoc', 'aop', 'ava', 'igt', 'igp']);
+// unambiguous 2–4 char tiers — deliberately NOT 'do'/'ao' as TRAILING tokens,
+// which collide with real place-name words ('do' is safe as a LEADING token,
+// below). dop/doq/vqa/wo added per the 2026-07-26 registry audit (RC-4:
+// "Ontario VQA", "Swartland WO", "Priorat DOQ", ~20 "… DOP" rows survived the
+// old set). 'dac' stays out — "Kamptal DAC" is the official appellation form.
+const APPELLATION_TIER_TOKENS = new Set(['docg', 'doca', 'doc', 'aoc', 'aop', 'ava', 'igt', 'igp', 'dop', 'doq', 'vqa', 'wo']);
+
+// Tier tokens that may open an appellation ("DO Alicante", "DOCa Rioja",
+// "D.O. Valle Central", "IGT Toscana") — the majority of the tier pollution
+// the audit found was PREFIX-form, which the trailing loop can never see.
+// Narrower than the trailing set on purpose: "VQA Ontario" and "Wine of
+// Origin Western Cape" are the official forms of real appellations (audit
+// leave-alone list), so 'vqa'/'wo' are trailing-only.
+const APPELLATION_LEADING_TIER_TOKENS = new Set(['do', 'doca', 'docg', 'doc', 'aoc', 'aop', 'ava', 'igt', 'igp', 'dop', 'doq']);
 
 // Strip trailing characters (any in `chars`) without a `$`-anchored quantifier
 // regex — a plain scan, so it can never be a polynomial-ReDoS shape.
@@ -84,6 +95,12 @@ const normalizeAppellation = (appellation) => {
   if (appellation == null) return appellation;
   const original = String(appellation).trim();
   const parts = original.split(/\s+/);
+  // Drop leading tier token(s) — dots tolerated so "D.O." matches 'do'.
+  while (parts.length > 1) {
+    const first = parts[0].replace(/[.,]/g, '').toLowerCase();
+    if (!APPELLATION_LEADING_TIER_TOKENS.has(first)) break;
+    parts.shift();
+  }
   // Drop trailing tier token(s), tolerating a trailing dot/comma on each.
   while (parts.length > 1) {
     const last = trimTrailingChars(parts[parts.length - 1], '.,').toLowerCase();
@@ -92,6 +109,33 @@ const normalizeAppellation = (appellation) => {
   }
   const result = trimTrailingChars(parts.join(' '), ' ,').trim();
   return result || original;
+};
+
+// A vintage year TRAILING a wine name — imports and label scans routinely
+// append it ("Reserve Cabernet Sauvignon 2023"), but the registry is
+// vintage-neutral by construction: the year lives on Bottle.vintage.
+// TRAILING only, on purpose: leading years are brand names ("1924 Double
+// Black", "19 Crimes"), and a mid-name year is part of a cuvée. The window is
+// 1950–2049 so historic marks like "1865" (Viña San Pedro's brand) survive
+// even at the tail. Optional parens absorb "(2019)".
+const TRAILING_VINTAGE_RX = /[\s\-–—(]+(?:19[5-9]\d|20[0-4]\d)\)?$/;
+
+/**
+ * Strip trailing vintage-year token(s) from a wine name ("Rioja Reserva 2019"
+ * → "Rioja Reserva"). Loops for the double-stamp case ("X 2019 2019"); never
+ * returns empty — a name that IS just a year is left alone (junk, but honest
+ * junk beats an empty required field). Non-strings pass through unchanged.
+ */
+const stripTrailingVintage = (name) => {
+  if (typeof name !== 'string') return name;
+  let n = name.trim();
+  for (let next = n.replace(TRAILING_VINTAGE_RX, '').trim();
+       next !== n;
+       next = n.replace(TRAILING_VINTAGE_RX, '').trim()) {
+    if (!next) break;
+    n = next;
+  }
+  return n;
 };
 
 /**
@@ -678,6 +722,7 @@ module.exports = {
   GRAPE_SYNONYMS,
   normalizeProducerKey,
   normalizeAppellation,
+  stripTrailingVintage,
   resolveGrapeName,
   resolveCountryName,
   isRecognizedCountry,

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -15,6 +15,7 @@ const {
   isUnknownName,
   isJunkGrapeName,
   resolveGrapeName,
+  stripTrailingVintage,
 } = require('./normalize');
 
 // ─── normalizeString ──────────────────────────────────────────────────────────
@@ -105,6 +106,65 @@ describe('normalizeAppellation (ticket #2C: tier-suffix proliferation)', () => {
     expect(normalizeAppellation(undefined)).toBeUndefined();
     expect(normalizeAppellation('DOCG')).toBe('DOCG'); // all-tier input preserved, not emptied
     expect(normalizeAppellation('   Barolo   DOCG ')).toBe('Barolo');
+  });
+
+  test('strips LEADING tier tokens — the prefix form the audit found surviving (RC-4)', () => {
+    expect(normalizeAppellation('DO Alicante')).toBe('Alicante');
+    expect(normalizeAppellation('DOCa Rioja')).toBe('Rioja');
+    expect(normalizeAppellation('IGT Toscana')).toBe('Toscana');
+    expect(normalizeAppellation('IGP Pays d\'Hérault')).toBe('Pays d\'Hérault');
+    expect(normalizeAppellation('D.O. Valle Central')).toBe('Valle Central'); // dots tolerated
+    expect(normalizeAppellation('DO')).toBe('DO'); // never emptied
+  });
+
+  test('audit additions to the trailing set: DOP / DOQ / VQA / WO', () => {
+    expect(normalizeAppellation('Sicilia DOP')).toBe('Sicilia');
+    expect(normalizeAppellation('Priorat DOQ')).toBe('Priorat');
+    expect(normalizeAppellation('Ontario VQA')).toBe('Ontario');
+    expect(normalizeAppellation('Swartland WO')).toBe('Swartland');
+  });
+
+  test('the audit leave-alone list survives untouched', () => {
+    // Official appellation forms — stripping them would corrupt real names.
+    expect(normalizeAppellation('VQA Ontario')).toBe('VQA Ontario');      // leading VQA is the official form
+    expect(normalizeAppellation('Wine of Origin Western Cape')).toBe('Wine of Origin Western Cape');
+    expect(normalizeAppellation('Kamptal DAC')).toBe('Kamptal DAC');      // DAC deliberately not a tier token
+    expect(normalizeAppellation('Vin de France')).toBe('Vin de France');
+    expect(normalizeAppellation('Muscat de Beaumes-de-Venise')).toBe('Muscat de Beaumes-de-Venise');
+  });
+});
+
+describe('stripTrailingVintage (registry is vintage-neutral — audit B2)', () => {
+  test('strips a trailing year token, with or without separator dashes/parens', () => {
+    expect(stripTrailingVintage('Reserve Cabernet Sauvignon 2023')).toBe('Reserve Cabernet Sauvignon');
+    expect(stripTrailingVintage('Rioja Reserva - 2019')).toBe('Rioja Reserva');
+    expect(stripTrailingVintage('Amarone (2016)')).toBe('Amarone');
+    expect(stripTrailingVintage('Barolo 1996')).toBe('Barolo');
+  });
+
+  test('loops the double-stamp case', () => {
+    expect(stripTrailingVintage('Bourgogne Rouge 2019 2019')).toBe('Bourgogne Rouge');
+  });
+
+  test('LEADING years are brand names and survive', () => {
+    expect(stripTrailingVintage('1924 Double Black')).toBe('1924 Double Black');
+    expect(stripTrailingVintage('19 Crimes')).toBe('19 Crimes');
+  });
+
+  test('years outside the 1950–2049 vintage window survive anywhere', () => {
+    expect(stripTrailingVintage('Cuvée 1865')).toBe('Cuvée 1865');   // Viña San Pedro's brand
+    expect(stripTrailingVintage('Reserva 1899')).toBe('Reserva 1899');
+    expect(stripTrailingVintage('Anno 2077')).toBe('Anno 2077');
+  });
+
+  test('never empties the name and passes non-strings through', () => {
+    expect(stripTrailingVintage('2019')).toBe('2019'); // name IS a year — honest junk beats empty
+    expect(stripTrailingVintage(null)).toBeNull();
+    expect(stripTrailingVintage(undefined)).toBeUndefined();
+  });
+
+  test('a mid-name year is part of the cuvée and survives', () => {
+    expect(stripTrailingVintage('Cuvée 2000 Réserve')).toBe('Cuvée 2000 Réserve');
   });
 });
 

--- a/backend/src/utils/producerPrefix.js
+++ b/backend/src/utils/producerPrefix.js
@@ -14,9 +14,13 @@ const { normalizeString, normalizeProducerKey, tokenize } = require('./normalize
  * Deliberately EXCLUDES bare single letters (Château d'Yquem's dry white is
  * literally named "Y"; 'e'/'y' are Italian/Spanish "and") and bare ARTICLES
  * (la, le, el, il, the, der, die, das open wine names far more often than
- * they end them). Widen only from measured evidence —
- * scripts/scan-name-anomalies.js reports the hit list — and bump the
- * dangling-name-tail rule id in nameChecks.js when you do.
+ * they end them). The one single-letter exception is 'a' — as a standalone
+ * TAIL token it is the Romance preposition ("Barolo Dedicato a Renina"
+ * truncated to "…Dedicato a"), never a name ending. Widen only from measured
+ * evidence — scripts/scan-name-anomalies.js reports the hit list — and bump
+ * the dangling-name-tail rule id in nameChecks.js when you do (v1→v2:
+ * +by/+sans/+a, registry audit 2026-07-26 — "The Barry Bros by" and
+ * "Vin Sans" were still mintable).
  */
 const DANGLING_TAIL_WORDS = new Set([
   'de', 'del', 'della', 'delle', 'dei', 'degli', 'di', 'du', 'des',
@@ -24,6 +28,7 @@ const DANGLING_TAIL_WORDS = new Set([
   'von', 'vom', 'van', 'of', 'and', 'et', 'und', 'och',
   'zu', 'zum', 'zur', 'au', 'aux', 'sur', 'sous', 'in', 'im', 'am',
   'con', 'com', 'avec', 'mit', 'med',
+  'by', 'sans', 'a',
 ]);
 
 /**

--- a/backend/src/utils/producerPrefix.test.js
+++ b/backend/src/utils/producerPrefix.test.js
@@ -80,6 +80,17 @@ describe('stripProducerSuffix', () => {
     expect(stripProducerSuffix('Blanc du Château Y', 'Château Y')).toBeNull();
   });
 
+  test('v2 additions: by / sans / bare a cannot be left stranded either (registry audit 2026-07-26)', () => {
+    // "The Barry Bros by Jim Barry" → stripping the producer would leave "The
+    // Barry Bros by" (a real prod row minted before the words were listed).
+    expect(stripProducerSuffix('The Barry Bros by Jim Barry', 'Jim Barry')).toBeNull();
+    expect(stripProducerSuffix('Vin Sans Soufre Ajouté', 'Soufre Ajouté')).toBeNull();
+    expect(stripProducerSuffix('Barolo Dedicato a Renina', 'Renina')).toBeNull();
+    // 'a' guards the TAIL only — a name merely containing 'a' still strips.
+    expect(stripProducerSuffix('Vigna a Sole Mastroberardino', 'Mastroberardino'))
+      .toBe('Vigna a Sole');
+  });
+
   test('the dangling guard only inspects the TAIL — interior connectives still strip', () => {
     // "di" is inside the remainder, tail is "Avellino" → legit strip.
     expect(stripProducerSuffix('Fiano di Avellino Mastroberardino', 'Mastroberardino'))


### PR DESCRIPTION
## Context

The full-registry audit ([REGISTRY_AUDIT_2026-07-26.md](https://github.com/jagduvi1/Cellarion/blob/main/REGISTRY_AUDIT_2026-07-26.md) — 4,287 wines read, 778 confirmed defects, 7.4% of raw claims rejected as false positives) traced nearly everything to a handful of write-path gaps. This PR closes the mechanically-closable ones so the defect classes stop growing while the data cleanup proceeds.

## The guards

| Audit cause | Guard | Where |
|---|---|---|
| RC-2: producer = "Bordeaux"/"California"/"Tuscany" (~45 rows) | Producer whose normalized **full string** is a known Country/Region/Appellation → 400 at mint. "Marchesi di Barolo" passes; bare "Barolo" doesn't. Single-char producers ("G") rejected too. Mint-time only — existing rows keep resolving | `findOrCreateWine` create branch |
| RC-2's origin | LWIN `DISPLAY_NAME` fallback only trusts `parts[0]` as producer with **≥3** comma parts (a 2-part "Bordeaux, Château Margaux" fills the *name* only; missing producer → skipped-and-reported). `getOrCreateCountry` now **throws** on unrecognized countries — returning null would `bulkWrite` a countryless wine, since bulkWrite bypasses validators. `SUB_REGION` tier-stripped; names canonicalized before key generation | `routes/admin/import.js` |
| RC-4: tier-polluted appellations (~130 rows) | Trailing set +`dop/doq/vqa/wo`; **new leading-token pass** ("DO Alicante", "DOCa Rioja", "D.O. Valle Central"). Leading set deliberately excludes `vqa`/`wo` — "VQA Ontario" and "Wine of Origin Western Cape" are official forms per the audit's leave-alone list; `dac` excluded entirely ("Kamptal DAC") | `normalizeAppellation` |
| RC-6d: vintage in name (19 rows) | **Trailing** 1950–2049 year stripped at step 0. Leading years are brands — "1924 Double Black" and "19 Crimes" survive, as does mid-name "Cuvée 2000" and historic "1865" | `findOrCreateWine` step 0 |
| RC-8: junk regions | Comma-packed hierarchies ("Bordeaux, Haut-Médoc") and regions named like a **country** ("Scotland" under England) → null region instead of minting; existing docs still match (US "Georgia" keeps working) | `findOrCreateRegion` |
| Residue of #840 | `DANGLING_TAIL_WORDS` +`by`/+`sans`/+`a` — "The Barry Bros by", "Vin Sans", "Barolo Dedicato a" were still mintable → rule id bumped `dangling-name-tail.v1` → **`.v2`** (zero v1 clearances existed on prod, so nothing is invalidated) | `producerPrefix.js` + `nameChecks.js` |

Plus **`scripts/strip-name-vintages.js`** (audit B2): dry-run-by-default cleanup for the 19 existing vintage-in-name rows — strips the name, writes the year to `Bottle.vintage` **only where null** (an owner's explicit vintage is never overwritten), skips normalizedKey collisions (reported for manual merge), re-indexes wine + bottles, JSON backup on `--apply`.

## Deliberately NOT in this PR (audit says review-only, not automation)

Producer-variant merges (different estates share keys — Trapet ≠ Trapet Alsace), the 07-24 twin merges (naive merges would delete images/appellations), appellation-echo name strips, the non-wine policy call (44 rows with owners), and the type-enum question.

## Tests

248 tests across 8 suites in `node:20-alpine`, including: the false-positive protections from the audit's leave-alone list as explicit fixtures, the exact-match-only property of the place gate, gate-runs-at-mint-only, and the new `import.mapRow` suite pinning the DISPLAY_NAME fallback rules. Rule snapshot regenerated for the v2 id.

## Docker-compose impact

**None.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)