### PR TITLE
chore(release): v1.90.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.89.0",
+      "version": "1.90.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.89.0",
+      "version": "1.90.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.89.0",
+  "version": "1.90.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — all 4 fields.

## Contents of v1.90.0

**#842 — registry write-path guards**, closing the mechanically-closable root causes from the full-registry audit (REGISTRY_AUDIT_2026-07-26.md):

- producer-place gate + single-char producer rejection at mint
- trailing-vintage strip at step 0 (registry is vintage-neutral)
- region mint gates (comma hierarchies, country-named regions)
- appellation tier strip: leading pass + dop/doq/vqa/wo
- LWIN import: safe DISPLAY_NAME fallback, throwing country gate, name canon
- dangling-word list +by/+sans/+a → `dangling-name-tail.v2`
- new `strip-name-vintages.js` cleanup script (dry-run default)

## Post-deploy plan (this release unblocks it)

1. `normalize-appellation-tiers.js` dry-run → review → `--apply` (~130 rows)
2. `strip-name-vintages.js` dry-run → review → `--apply` (19 rows)
3. Incremental embed job for the touched rows (their embed text genuinely changes — this is NOT the needless-re-embed case)

## Docker-compose impact

**None.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)