### PR TITLE
feat(registry): non-wine quarantine — keep the rows, hide them from wine surfaces

### DIFF
--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -147,6 +147,18 @@ const wineDefinitionSchema = new mongoose.Schema({
     enum: ['ui', 'import', 'mcp', 'ai', null],
     default: null
   },
+  // Non-wine quarantine (registry audit 2026-07-26; policy decided by Johan:
+  // KEEP, HIDE). Spirits/cider/sake rows imported by users stay in the
+  // registry — their owners' bottles keep working, direct wine pages render —
+  // but flagged rows are excluded from the Meilisearch index (registry
+  // search + type facets), public taxonomy/OG/sitemap listings, and the
+  // admin duplicate-scan pools. Exact-key resolution still matches them, so
+  // re-adding the same bottle attaches instead of minting a twin. Toggled via
+  // POST /api/admin/wines/:id/non-wine (admin only, audited).
+  nonWine: {
+    type: Boolean,
+    default: false
+  },
   // Human data-quality review (support ticket 2026-07-26): the registry's
   // false-positive whitelist AND its skip-on-rescan record. Each entry is a
   // RULE ID from utils/nameChecks.js that an admin has read this wine and

--- a/backend/src/models/WineDefinition.verifiedChecks.test.js
+++ b/backend/src/models/WineDefinition.verifiedChecks.test.js
@@ -45,6 +45,12 @@ test('a new doc is born unreviewed', async () => {
   expect(doc.verifiedAt).toBeNull();
 });
 
+test('a new doc is a wine by default (nonWine false — quarantine is opt-in)', async () => {
+  const doc = baseDoc();
+  await doc.validate();
+  expect(doc.nonWine).toBe(false);
+});
+
 test('changing name clears both fields', async () => {
   const doc = await reviewedDoc();
   doc.name = 'Block 5 Pinot Noir';

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -582,6 +582,34 @@ router.delete('/verify-checks', async (req, res) => {
   }
 });
 
+// POST /api/admin/wines/:id/non-wine — quarantine (or restore) a row that is
+// not a wine (spirits/cider/sake; registry audit 2026-07-26, policy: keep,
+// hide). Body: { value: boolean }. The row and its owners' bottles keep
+// working; flagged rows leave the search index (indexWine self-heals), the
+// public taxonomy/OG/sitemap listings and the admin duplicate-scan pools.
+router.post('/:id/non-wine', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    if (typeof req.body?.value !== 'boolean') {
+      return res.status(400).json({ error: 'value must be a boolean' });
+    }
+    const wine = await WineDefinition.findById(req.params.id);
+    if (!wine) return res.status(404).json({ error: 'Wine not found' });
+
+    wine.nonWine = req.body.value;
+    await wine.save();
+    // Self-healing index sync: indexWine removes flagged rows, re-adds restored ones.
+    searchService.indexWine(wine._id);
+
+    logAudit(req, 'admin.wine.nonWine', { type: 'wine', id: wine._id },
+      { value: req.body.value, name: wine.name, producer: wine.producer });
+    res.json({ message: req.body.value ? 'Quarantined as non-wine' : 'Restored as wine', nonWine: wine.nonWine });
+  } catch (error) {
+    console.error('Non-wine toggle error:', error);
+    res.status(500).json({ error: 'Failed to update non-wine flag' });
+  }
+});
+
 router.get('/duplicates', async (req, res) => {
   try {
     const { name, producer, appellation, threshold = 0.75 } = req.query;
@@ -807,7 +835,7 @@ router.get('/producer-in-name', async (req, res) => {
     // may be cleared for one rule and outstanding for another — and `total`
     // below is computed from flagged.length, so in-memory pagination stays
     // honest.
-    const all = await WineDefinition.find({})
+    const all = await WineDefinition.find({ nonWine: { $ne: true } })
       .select(`${NAME_CHECK_SELECT} createdAt verifiedAt`)
       .sort({ producer: 1, name: 1 })
       .lean();

--- a/backend/src/routes/admin/wines.nonWine.test.js
+++ b/backend/src/routes/admin/wines.nonWine.test.js
@@ -1,0 +1,143 @@
+/**
+ * POST /api/admin/wines/:id/non-wine — the quarantine toggle (registry audit
+ * 2026-07-26, policy: keep non-wine rows, hide them). Pins: the flag round-trips
+ * through save + a self-healing indexWine call, the mutation is audited, bad
+ * input never touches the DB — and the name-check scan pool excludes flagged
+ * rows at the QUERY level (a whisky must not pair against wines in any scan).
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../models/WineDefinition', () => {
+  const ctor = jest.fn();
+  ctor.find = jest.fn();
+  ctor.findById = jest.fn();
+  ctor.findOne = jest.fn();
+  ctor.countDocuments = jest.fn();
+  ctor.bulkWrite = jest.fn();
+  ctor.updateMany = jest.fn();
+  return ctor;
+});
+jest.mock('../../models/Bottle', () => ({ aggregate: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../../models/BottleImage', () => ({}));
+jest.mock('../../models/WineVintageProfile', () => ({}));
+jest.mock('../../models/WineVintagePrice', () => ({}));
+jest.mock('../../models/WineReport', () => ({}));
+jest.mock('../../models/Review', () => ({}));
+jest.mock('../../models/Discussion', () => ({}));
+jest.mock('../../models/DiscussionReply', () => ({}));
+jest.mock('../../models/WineEmbedding', () => ({}));
+jest.mock('../../models/WineNotDuplicate', () => ({ find: jest.fn() }));
+jest.mock('../../models/WineList', () => ({}));
+jest.mock('../../models/WishlistItem', () => ({}));
+jest.mock('../../models/PriceTrackingRequest', () => ({}));
+jest.mock('../../models/PriceTrackingSkip', () => ({}));
+jest.mock('../../models/CommunityWinePrice', () => ({}));
+jest.mock('../../models/JournalEntry', () => ({}));
+jest.mock('../../models/Recommendation', () => ({}));
+jest.mock('../../models/RestockAlert', () => ({}));
+jest.mock('../../models/WineRequest', () => ({}));
+jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
+jest.mock('../../services/vectorStore', () => ({}));
+jest.mock('../../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../../services/embeddingJob', () => ({ embedSinglePair: jest.fn() }));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn(), removeWine: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineDefinition = require('../../models/WineDefinition');
+const Bottle = require('../../models/Bottle');
+const searchService = require('../../services/search');
+const { logAudit } = require('../../services/audit');
+const adminWinesRouter = require('./wines');
+
+const ADMIN_ID = '64b000000000000000000001';
+const WINE_ID = '64b0000000000000000000c1';
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/wines', adminWinesRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Bottle.aggregate.mockResolvedValue([]);
+});
+
+const toggle = (id, body) => fetch(`${baseUrl}/api/admin/wines/${id}/non-wine`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+  body: JSON.stringify(body),
+});
+
+const wineDoc = () => {
+  const doc = { _id: WINE_ID, name: 'Blue Label', producer: 'Johnnie Walker', nonWine: false };
+  doc.save = jest.fn().mockResolvedValue(doc);
+  return doc;
+};
+
+test('quarantines a row: sets the flag, saves, self-heals the index, audits', async () => {
+  const doc = wineDoc();
+  WineDefinition.findById.mockResolvedValue(doc);
+
+  const res = await toggle(WINE_ID, { value: true });
+  expect(res.status).toBe(200);
+  expect((await res.json()).nonWine).toBe(true);
+  expect(doc.nonWine).toBe(true);
+  expect(doc.save).toHaveBeenCalled();
+  expect(searchService.indexWine).toHaveBeenCalledWith(WINE_ID);
+  expect(logAudit).toHaveBeenCalledWith(
+    expect.anything(), 'admin.wine.nonWine',
+    { type: 'wine', id: WINE_ID },
+    expect.objectContaining({ value: true, name: 'Blue Label' })
+  );
+});
+
+test('restores a row with value: false', async () => {
+  const doc = { ...wineDoc(), nonWine: true };
+  doc.save = jest.fn().mockResolvedValue(doc);
+  WineDefinition.findById.mockResolvedValue(doc);
+
+  const res = await toggle(WINE_ID, { value: false });
+  expect(res.status).toBe(200);
+  expect(doc.nonWine).toBe(false);
+});
+
+test.each([
+  ['missing value', {}],
+  ['string value', { value: 'true' }],
+  ['number value', { value: 1 }],
+])('%s → 400, nothing queried', async (_label, body) => {
+  const res = await toggle(WINE_ID, body);
+  expect(res.status).toBe(400);
+  expect(WineDefinition.findById).not.toHaveBeenCalled();
+});
+
+test('invalid id → 400; unknown id → 404', async () => {
+  expect((await toggle('nope', { value: true })).status).toBe(400);
+  WineDefinition.findById.mockResolvedValue(null);
+  expect((await toggle(WINE_ID, { value: true })).status).toBe(404);
+});
+
+test('the name-check scan pool excludes quarantined rows at the query level', async () => {
+  const select = jest.fn().mockReturnValue({
+    sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+  });
+  WineDefinition.find.mockReturnValue({ select });
+
+  await fetch(`${baseUrl}/api/admin/wines/producer-in-name`, {
+    headers: { Authorization: `Bearer ${adminToken()}` },
+  });
+
+  expect(WineDefinition.find).toHaveBeenCalledWith({ nonWine: { $ne: true } });
+});

--- a/backend/src/routes/og.js
+++ b/backend/src/routes/og.js
@@ -987,7 +987,7 @@ router.get('/regions/:slug', ogLimiter, async (req, res) => {
       .lean();
     if (!region) return res.status(404).send('Not found');
 
-    const wines = await WineDefinition.find({ region: region._id })
+    const wines = await WineDefinition.find({ region: region._id, nonWine: { $ne: true } })
       .select('name producer slug _id')
       .sort({ name: 1 })
       .limit(20)
@@ -1048,7 +1048,7 @@ router.get('/countries/:slug', ogLimiter, async (req, res) => {
       .lean();
     if (!country) return res.status(404).send('Not found');
 
-    const wines = await WineDefinition.find({ country: country._id })
+    const wines = await WineDefinition.find({ country: country._id, nonWine: { $ne: true } })
       .select('name producer slug _id')
       .sort({ name: 1 })
       .limit(20)
@@ -1098,7 +1098,7 @@ router.get('/grapes/:slug', ogLimiter, async (req, res) => {
       .lean();
     if (!grape) return res.status(404).send('Not found');
 
-    const wines = await WineDefinition.find({ grapes: grape._id })
+    const wines = await WineDefinition.find({ grapes: grape._id, nonWine: { $ne: true } })
       .select('name producer slug _id')
       .sort({ name: 1 })
       .limit(20)
@@ -1161,7 +1161,7 @@ router.get('/wine-types/:type', ogLimiter, async (req, res) => {
     const type = String(req.params.type).toLowerCase();
     if (!WINE_TYPES.includes(type)) return res.status(404).send('Not found');
 
-    const wines = await WineDefinition.find({ type })
+    const wines = await WineDefinition.find({ type, nonWine: { $ne: true } })
       .select('name producer slug _id')
       .sort({ name: 1 })
       .limit(20)

--- a/backend/src/routes/sitemap.js
+++ b/backend/src/routes/sitemap.js
@@ -77,7 +77,7 @@ router.get('/', sitemapLimiter, async (req, res) => {
     // Wine pages — public wine detail pages. Prefer slug URLs when available
     // (human-readable, AI-citable); fall back to ObjectId for any wine that
     // hasn't been migrated yet so the sitemap stays complete.
-    const wines = await WineDefinition.find()
+    const wines = await WineDefinition.find({ nonWine: { $ne: true } })
       .sort({ updatedAt: -1 })
       .select('_id slug updatedAt')
       .limit(5000)

--- a/backend/src/routes/taxonomy.js
+++ b/backend/src/routes/taxonomy.js
@@ -44,6 +44,7 @@ function getCachedList(key) {
 async function countWinesBy(field, { unwind = false } = {}) {
   const pipeline = unwind
     ? [
+        { $match: { nonWine: { $ne: true } } },
         // $setUnion dedups the array first: the old countDocuments({grapes: id})
         // counted a wine once however many times the grape appeared in its
         // array; a bare $unwind would count every occurrence.
@@ -52,7 +53,7 @@ async function countWinesBy(field, { unwind = false } = {}) {
         { $group: { _id: '$values', count: { $sum: 1 } } },
       ]
     : [
-        { $match: { [field]: { $ne: null } } },
+        { $match: { [field]: { $ne: null }, nonWine: { $ne: true } } },
         { $group: { _id: `$${field}`, count: { $sum: 1 } } },
       ];
   const rows = await WineDefinition.aggregate(pipeline);
@@ -114,7 +115,7 @@ router.get('/countries/:slug', async (req, res) => {
     const { limit, offset } = parsePagination(req.query, { limit: 24, maxLimit: 100 });
 
     const [wines, total, regions] = await Promise.all([
-      WineDefinition.find({ country: country._id })
+      WineDefinition.find({ country: country._id, nonWine: { $ne: true } })
         .select(WINE_PROJECTION)
         .populate('region', 'name slug')
         .populate('country', 'name slug')
@@ -122,7 +123,7 @@ router.get('/countries/:slug', async (req, res) => {
         .skip(offset)
         .limit(limit)
         .lean(),
-      WineDefinition.countDocuments({ country: country._id }),
+      WineDefinition.countDocuments({ country: country._id, nonWine: { $ne: true } }),
       Region.find({ country: country._id, slug: { $exists: true } })
         .select('name slug description')
         .sort({ name: 1 })
@@ -185,7 +186,7 @@ router.get('/regions/:slug', async (req, res) => {
     const { limit, offset } = parsePagination(req.query, { limit: 24, maxLimit: 100 });
 
     const [wines, total] = await Promise.all([
-      WineDefinition.find({ region: region._id })
+      WineDefinition.find({ region: region._id, nonWine: { $ne: true } })
         .select(WINE_PROJECTION)
         .populate('region', 'name slug')
         .populate('country', 'name slug')
@@ -194,7 +195,7 @@ router.get('/regions/:slug', async (req, res) => {
         .skip(offset)
         .limit(limit)
         .lean(),
-      WineDefinition.countDocuments({ region: region._id })
+      WineDefinition.countDocuments({ region: region._id, nonWine: { $ne: true } })
     ]);
 
     if (total < MIN_WINES) return res.status(404).json({ error: 'Region not found' });
@@ -250,7 +251,7 @@ router.get('/grapes/:slug', async (req, res) => {
     const { limit, offset } = parsePagination(req.query, { limit: 24, maxLimit: 100 });
 
     const [wines, total] = await Promise.all([
-      WineDefinition.find({ grapes: grape._id })
+      WineDefinition.find({ grapes: grape._id, nonWine: { $ne: true } })
         .select(WINE_PROJECTION)
         .populate('region', 'name slug')
         .populate('country', 'name slug')
@@ -258,7 +259,7 @@ router.get('/grapes/:slug', async (req, res) => {
         .skip(offset)
         .limit(limit)
         .lean(),
-      WineDefinition.countDocuments({ grapes: grape._id })
+      WineDefinition.countDocuments({ grapes: grape._id, nonWine: { $ne: true } })
     ]);
 
     if (total < MIN_WINES) return res.status(404).json({ error: 'Grape not found' });
@@ -282,7 +283,7 @@ router.get('/wine-types/:type', async (req, res) => {
     const { limit, offset } = parsePagination(req.query, { limit: 24, maxLimit: 100 });
 
     const [wines, total] = await Promise.all([
-      WineDefinition.find({ type })
+      WineDefinition.find({ type, nonWine: { $ne: true } })
         .select(WINE_PROJECTION)
         .populate('region', 'name slug')
         .populate('country', 'name slug')
@@ -290,7 +291,7 @@ router.get('/wine-types/:type', async (req, res) => {
         .skip(offset)
         .limit(limit)
         .lean(),
-      WineDefinition.countDocuments({ type })
+      WineDefinition.countDocuments({ type, nonWine: { $ne: true } })
     ]);
 
     res.set('Cache-Control', 'public, max-age=3600');

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -55,6 +55,9 @@ const USER_SEARCH_LIMIT = 10;
 
 // MongoDB fallback search (used when Meilisearch is unavailable)
 async function mongoSearch(filter, sort, limit, offset, search) {
+  // Quarantined non-wine rows never surface in registry search — the Meili
+  // branch excludes them at index time; this is the fallback's mirror.
+  filter.nonWine = { $ne: true };
   let sortOptions = {};
   const sortField = sort.startsWith('-') ? sort.substring(1) : sort;
   const sortDir = sort.startsWith('-') ? -1 : 1;

--- a/backend/src/scripts/flag-non-wine-rows.js
+++ b/backend/src/scripts/flag-non-wine-rows.js
@@ -1,0 +1,82 @@
+/**
+ * flag-non-wine-rows.js
+ *
+ * Registry audit 2026-07-26 (B8): 44 rows in the wine registry are not wine —
+ * one 2026-07-07 session imported an entire spirits bar (Jack Daniel's,
+ * Johnnie Walker, tequilas, grappas…), plus an April cider/alcohol-free
+ * cluster and three sakes. All are owned by users, so nothing may be deleted.
+ * Policy (Johan, 2026-07-26): KEEP the rows and their bottles, HIDE them from
+ * registry search, type facets, public taxonomy/OG/sitemap listings and the
+ * admin duplicate-scan pools — i.e. set WineDefinition.nonWine.
+ *
+ * The id list below is the audit's confirmed non_wine finding set, verbatim.
+ * Each row is looked up and printed before flagging; ids that no longer exist
+ * are reported and skipped. Already-flagged rows are counted as no-ops, so
+ * the script is idempotent and safe to re-run.
+ *
+ * On --apply, each flagged row is also removed from the Meilisearch index
+ * (their documents predate the exclusion). No backup file is written — the
+ * flag is a boolean the admin non-wine endpoint can reverse per row, and the
+ * full id list IS this file.
+ *
+ * Dry-run by default.
+ *
+ * Usage:
+ *   node src/scripts/flag-non-wine-rows.js            # dry run
+ *   node src/scripts/flag-non-wine-rows.js --apply    # execute
+ */
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const searchService = require('../services/search');
+
+const APPLY = process.argv.includes('--apply');
+const tag = APPLY ? '✔' : '[dry]';
+
+// Registry audit 2026-07-26, category non_wine — 44 confirmed rows.
+const NON_WINE_IDS = [
+  '69f07610cfe7ecdc31f06cb0', '6a0ffb98a1cf43519eccaf47', '69f07e8bcfe7ecdc31f07c7f',
+  '6a4d631c00378da992426589', '6a4d648f00378da9924270ad', '69db5dabbcd6b4d68a78d41d',
+  '6a4d69bc00378da992427aaa', '6a4d635d00378da992426636', '6a4d5d0500378da992425fd6',
+  '6a14a270039226deb9b0a7ad', '6a4d633e00378da9924265e2', '6a4d630300378da992426531',
+  '6a4d639b00378da99242673c', '6a4d667e00378da99242755b', '69d290b53dcca3f60841d57d',
+  '6a4d644c00378da992426f84', '69db65fbbcd6b4d68a78e015', '69db5edabcd6b4d68a78d687',
+  '69db6670bcd6b4d68a78e167', '6a4d5c5d00378da992425ecc', '6a4d5bc800378da992425dcf',
+  '6a4d637200378da99242668a', '6a4d5c7d00378da992425f25', '6a4d646000378da992426fd9',
+  '6a4d638800378da9924266e0', '69db5ec7bcd6b4d68a78d63d', '6a1dacfe341b290385b0cebc',
+  '6a4d643200378da992426f33', '6a4d63e900378da992426b37', '69f07cfbcfe7ecdc31f07858',
+  '6a4d5dd500378da9924260fc', '6a4d63c000378da992426ac4', '6a4d64ee00378da9924271f0',
+  '6a4d63ff00378da992426b93', '6a4d641700378da992426edb', '6a4d63ac00378da992426789',
+  '69f075d9cfe7ecdc31f06be4', '6a4d5df700378da992426159', '6a4d64a100378da992427110',
+  '69db5eb1bcd6b4d68a78d5e8', '69db65a2bcd6b4d68a78df2a', '6a4d5c4200378da992425e74',
+  '6a4d5e6d00378da99242624f', '69f075f1cfe7ecdc31f06c35',
+];
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log(`Connected. Mode: ${APPLY ? 'APPLY' : 'DRY RUN (pass --apply to execute)'}\n`);
+
+  const stats = { flagged: 0, already: 0, missing: 0 };
+  for (const id of NON_WINE_IDS) {
+    const w = await WineDefinition.findById(id).select('name producer nonWine').lean();
+    if (!w) { stats.missing += 1; console.log(`  MISSING ${id}`); continue; }
+    if (w.nonWine === true) { stats.already += 1; continue; }
+    console.log(`  ${tag} "${w.name}" — ${w.producer} [${id}]`);
+    if (APPLY) {
+      await WineDefinition.updateOne({ _id: id }, { $set: { nonWine: true, updatedAt: new Date() } });
+      searchService.removeWine(id);
+    }
+    stats.flagged += 1;
+  }
+
+  console.log(`\nFlagged: ${stats.flagged}  already flagged: ${stats.already}  missing: ${stats.missing}  of ${NON_WINE_IDS.length}`);
+  if (APPLY) {
+    console.log('Rows removed from Meilisearch; owners keep their bottles and wine pages.');
+    console.log('No re-embed needed: nonWine is not in the embedding text (embeddings for');
+    console.log('these rows are harmless leftovers; semantic search dedupes against Mongo).');
+  }
+  await mongoose.disconnect();
+}
+
+run().catch((err) => { console.error('flag-non-wine-rows failed:', err); process.exit(1); });

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -216,7 +216,9 @@ async function fullSync() {
 
   try {
     await syncViaCursor(
-      WineDefinition.find()
+      // Quarantined non-wine rows (spirits/cider/sake kept for their owners —
+      // registry audit 2026-07-26, policy: keep, hide) never enter the index.
+      WineDefinition.find({ nonWine: { $ne: true } })
         .populate('country', 'name')
         .populate('region', 'name')
         .populate('grapes', 'name')
@@ -241,6 +243,13 @@ async function indexWine(wineId) {
       .lean();
 
     if (!wine) return;
+
+    // A wine flagged non-wine after having been indexed must LEAVE the index —
+    // indexWine is called on every save, so the flag toggle self-heals here.
+    if (wine.nonWine === true) {
+      await index.deleteDocument(String(wine._id));
+      return;
+    }
 
     await index.addDocuments([buildDocument(wine)], { primaryKey: 'id' });
   } catch (err) {


### PR DESCRIPTION
## What

The audit found **44 non-wine rows** (the July 7 spirits-bar import, ciders, 3 sakes) — all owned by users, so deletion was never on the table. Johan's policy call: **keep, hide**. This implements it:

- `WineDefinition.nonWine` flag (default false)
- **Meilisearch**: excluded from `fullSync`; `indexWine` self-heals (flag → doc deleted from index on next save; restore → re-added). Search + type facets covered by absence
- **Mongo fallback search** mirrors the exclusion
- **Public listings**: taxonomy discovery pages + facet counts, OG crawler pages, sitemap — all exclude flagged rows. Direct wine pages and owners' bottles keep working: *hiding, not breaking*
- **Admin dup-scan pools** exclude them; exact-key resolution still matches (re-adding the same whisky attaches instead of minting a twin)
- **`POST /api/admin/wines/:id/non-wine`** — admin toggle, audited, reversible per row
- **`scripts/flag-non-wine-rows.js`** — dry-run default, idempotent, carries the audit's 44 ids verbatim, de-indexes on apply

## Post-merge

Deploy, then: `docker exec cellarion-backend node src/scripts/flag-non-wine-rows.js` (dry-run → `--apply`). No re-embed, no Meili settings change, no migration.

## Docker-compose impact

**None.**

## Tests

48 across 5 suites, incl. the toggle round-trip, audit call, 400-before-DB input gates, and a query-level assertion that the scan pool filters on the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)