### PR TITLE
chore(release): v1.91.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.90.0",
+  "version": "1.91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.90.0",
+      "version": "1.91.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.90.0",
+  "version": "1.91.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.90.0",
+  "version": "1.91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.90.0",
+      "version": "1.91.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.90.0",
+  "version": "1.91.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only.

## Contents of v1.91.0

**#844 — non-wine quarantine**: `WineDefinition.nonWine` flag; flagged rows excluded from registry search (Meili + Mongo fallback), type facets, public taxonomy/OG/sitemap listings and the admin duplicate-scan pools. Owners' bottles and direct wine pages keep working. Admin toggle endpoint (audited, reversible). Ships `flag-non-wine-rows.js` carrying the audit's 44 confirmed non-wine ids.

## Post-deploy

Run the flag script (dry-run → --apply). No re-embed, no Meili settings change, no migration. Compose impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)