### PR TITLE
feat(registry): low-confidence review queue — route the model's doubt to the admin

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -247,7 +247,7 @@ Grapes: {{grapes}}
 Base the profile on what you genuinely know about this wine, producer, appellation, and grapes. Be factual and conservative — describe the wine's typical character, not marketing hyperbole. If you don't recognise the specific wine, infer a sensible profile from its grapes, region, and type, and lower your confidence accordingly.
 
 Return ONLY a raw JSON object (no markdown, no code fences, no extra text):
-{"body":"light|medium|full|null","tannin":"low|medium|high|null","acidity":"low|medium|high|null","sweetness":"dry|off-dry|sweet|null","flavors":["3-6 short flavour/aroma descriptors"],"foodPairings":["2-4 classic food pairings"],"description":"2-3 sentence plain-language tasting note for the owner","confidence":0.0}
+{"body":"light|medium|full|null","tannin":"low|medium|high|null","acidity":"low|medium|high|null","sweetness":"dry|off-dry|sweet|null","flavors":["3-6 short flavour/aroma descriptors"],"foodPairings":["2-4 classic food pairings"],"description":"2-3 sentence plain-language tasting note for the owner","confidence":0.0,"producerSuspect":false,"producerNote":null}
 
 Rules:
 - body/tannin/acidity/sweetness: use one of the listed values, or null if not applicable (e.g. tannin for a white wine should usually be "low" or null).
@@ -255,6 +255,8 @@ Rules:
 - foodPairings: real dishes/categories (e.g. "grilled lamb", "hard cheese", "roast chicken").
 - description: 2-3 sentences, warm but not pretentious. PLAIN TEXT ONLY — no Markdown of any kind: no **bold**, no *italics*, no headings, lists, links, or tables. The field is shown verbatim in places that do not render Markdown.
 - confidence: 1.0 = you know this exact wine well, 0.7 = confident from producer + style, 0.5 = grape/region knowledge only, 0.3 = rough inference.
+- producerSuspect: true when the Producer value above does not look like an actual winery — a cuvée range or brand line that belongs to another house (e.g. "Arcane" is Xavier Vignon's range, "Montes Alpha" is Viña Montes's line), a place name, a retailer/importer/bottler, or a label term. Judge only from what you genuinely know; an unfamiliar small producer is NOT suspect.
+- producerNote: when producerSuspect is true and you are confident of the real producer, name it in one short plain-text sentence (e.g. "Arcane is a range of Xavier Vignon"). Otherwise null — never guess a specific house you are unsure of.
 - Never invent awards, scores, or specific vintages' weather. If the wine is completely unrecognisable and its grapes/region are unknown, return {"error":"unknown"}.`;
 
 // Models that are known to work reliably for text chat.

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -99,8 +99,30 @@ const wineDefinitionSchema = new mongoose.Schema({
     foodPairings: { type: [String], default: [] },              // e.g. ['braised beef']
     description:  { type: String, default: null, trim: true },  // short PLAIN-TEXT prose; markdown stripped at write (enrichmentJob)
     confidence:   { type: Number, default: null },             // 0..1 — how sure the AI is
+    // The model's doubt about the producer FIELD itself — set true when it
+    // recognises the "producer" as a range/brand of another house, a place,
+    // a retailer or a label term ("Arcane" = Xavier Vignon's range — the row
+    // every string gate and 49 audit agents missed). producerNote carries the
+    // suggested real producer when the model is sure of it. Feeds the admin
+    // low-confidence review queue; never shown to end users.
+    producerSuspect: { type: Boolean, default: false },
+    producerNote:    { type: String,  default: null, trim: true },
     model:        { type: String, default: null, trim: true }, // model that produced it
     generatedAt:  { type: Date,   default: null },             // when it was generated
+  },
+  // When an admin last reviewed this wine in the low-confidence queue and
+  // judged its data correct. The clearance is SELF-INVALIDATING by comparison,
+  // not by hook: the queue shows rows where profileReviewedAt is null OR older
+  // than aiProfile.generatedAt — so a re-enriched wine (new profile, new
+  // doubt) re-surfaces automatically, and nothing needs to watch field edits
+  // (editing the wine re-enriches → new generatedAt → re-surfaces if still
+  // low-confidence). Deliberately NOT part of verifiedChecks: that record is
+  // scoped to name+producer string rules its pre-validate hook can fully
+  // invalidate; this one's verdict lives in aiProfile, which the hook must
+  // not watch (see the verifiedChecks scope rule above).
+  profileReviewedAt: {
+    type: Date,
+    default: null
   },
   // Normalized key for deduplication
   normalizedKey: {

--- a/backend/src/models/WineDefinition.verifiedChecks.test.js
+++ b/backend/src/models/WineDefinition.verifiedChecks.test.js
@@ -51,6 +51,14 @@ test('a new doc is a wine by default (nonWine false — quarantine is opt-in)', 
   expect(doc.nonWine).toBe(false);
 });
 
+test('a new doc starts unreviewed for the low-confidence queue, with no producer doubt', async () => {
+  const doc = baseDoc();
+  await doc.validate();
+  expect(doc.profileReviewedAt).toBeNull();
+  expect(doc.aiProfile.producerSuspect).toBe(false);
+  expect(doc.aiProfile.producerNote).toBeNull();
+});
+
 test('changing name clears both fields', async () => {
   const doc = await reviewedDoc();
   doc.name = 'Block 5 Pinot Noir';

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -610,6 +610,123 @@ router.post('/:id/non-wine', async (req, res) => {
   }
 });
 
+// POST /api/admin/wines/:id/profile-reviewed — record that an admin read this
+// low-confidence wine and judged its data correct as of the CURRENT profile.
+// DELETE undoes it. Self-invalidating by timestamp comparison (see GET above),
+// so there is nothing to clear on later edits.
+router.post('/:id/profile-reviewed', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const wine = await WineDefinition.findById(req.params.id).select('name producer');
+    if (!wine) return res.status(404).json({ error: 'Wine not found' });
+    const now = new Date();
+    await WineDefinition.updateOne({ _id: wine._id }, { $set: { profileReviewedAt: now } });
+    logAudit(req, 'admin.wine.profileReviewed', { type: 'wine', id: wine._id },
+      { name: wine.name, producer: wine.producer });
+    res.json({ message: 'Marked reviewed', profileReviewedAt: now });
+  } catch (error) {
+    console.error('Profile-reviewed error:', error);
+    res.status(500).json({ error: 'Failed to mark reviewed' });
+  }
+});
+
+router.delete('/:id/profile-reviewed', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const result = await WineDefinition.updateOne(
+      { _id: req.params.id }, { $set: { profileReviewedAt: null } });
+    if (!result.matchedCount) return res.status(404).json({ error: 'Wine not found' });
+    logAudit(req, 'admin.wine.profileUnreviewed', { type: 'wine', id: req.params.id }, {});
+    res.json({ message: 'Review cleared' });
+  } catch (error) {
+    console.error('Profile-unreviewed error:', error);
+    res.status(500).json({ error: 'Failed to clear review' });
+  }
+});
+
+// GET /api/admin/wines/low-confidence — the "model in doubt" review queue.
+// Surfaces wines whose enrichment confidence is at or below ?threshold
+// (default 0.3 — the band that caught the Arcane range-as-producer row),
+// EXCLUDING rows an admin already reviewed SINCE their profile was last
+// generated: profileReviewedAt >= aiProfile.generatedAt suppresses; a
+// re-enrichment bumps generatedAt past the review and the row re-surfaces
+// by comparison alone. ?includeReviewed=1 is the audit view. Sorted most
+// doubtful first. producerSuspect/producerNote ride along so the model's
+// specific worry is visible per row.
+router.get('/low-confidence', async (req, res) => {
+  try {
+    const { limit: parsedLimit, offset: skip, page: parsedPage } =
+      parsePagination(req.query, { limit: 50, maxLimit: 200 });
+    const rawT = Number(req.query.threshold);
+    const threshold = Number.isFinite(rawT) ? Math.min(Math.max(rawT, 0), 1) : 0.3;
+    const includeReviewed = req.query.includeReviewed === '1' || req.query.includeReviewed === 'true';
+
+    const base = {
+      nonWine: { $ne: true },
+      'aiProfile.confidence': { $ne: null, $lte: threshold },
+    };
+    const outstanding = {
+      ...base,
+      $expr: {
+        $or: [
+          { $eq: ['$profileReviewedAt', null] },
+          { $lt: ['$profileReviewedAt', '$aiProfile.generatedAt'] },
+        ],
+      },
+    };
+
+    const filter = includeReviewed ? base : outstanding;
+    const [rows, total, reviewedCount] = await Promise.all([
+      WineDefinition.find(filter)
+        .select('name producer appellation nonWine profileReviewedAt aiProfile.confidence aiProfile.description aiProfile.producerSuspect aiProfile.producerNote aiProfile.generatedAt')
+        .populate('region', 'name')
+        .populate('country', 'name')
+        .sort({ 'aiProfile.confidence': 1, producer: 1 })
+        .skip(skip)
+        .limit(parsedLimit)
+        .lean(),
+      WineDefinition.countDocuments(filter),
+      WineDefinition.countDocuments(base).then(async (all) =>
+        all - await WineDefinition.countDocuments(outstanding)),
+    ]);
+
+    const bottleCounts = new Map();
+    if (rows.length > 0) {
+      const counts = await Bottle.aggregate([
+        { $match: { wineDefinition: { $in: rows.map(w => w._id) } } },
+        { $group: { _id: '$wineDefinition', count: { $sum: 1 } } },
+      ]);
+      for (const c of counts) bottleCounts.set(String(c._id), c.count);
+    }
+
+    res.json({
+      wines: rows.map(w => ({
+        _id: w._id,
+        name: w.name,
+        producer: w.producer,
+        appellation: w.appellation || null,
+        region: w.region?.name || null,
+        country: w.country?.name || null,
+        confidence: w.aiProfile?.confidence ?? null,
+        description: w.aiProfile?.description || null,
+        producerSuspect: w.aiProfile?.producerSuspect === true,
+        producerNote: w.aiProfile?.producerNote || null,
+        generatedAt: w.aiProfile?.generatedAt || null,
+        profileReviewedAt: w.profileReviewedAt || null,
+        bottleCount: bottleCounts.get(String(w._id)) || 0,
+      })),
+      total,
+      page: parsedPage,
+      pages: Math.ceil(total / parsedLimit),
+      threshold,
+      reviewedCount,
+    });
+  } catch (error) {
+    console.error('Low-confidence list error:', error);
+    res.status(500).json({ error: 'Failed to list low-confidence wines' });
+  }
+});
+
 router.get('/duplicates', async (req, res) => {
   try {
     const { name, producer, appellation, threshold = 0.75 } = req.query;

--- a/backend/src/routes/admin/wines.lowConfidence.test.js
+++ b/backend/src/routes/admin/wines.lowConfidence.test.js
@@ -1,0 +1,192 @@
+/**
+ * GET /api/admin/wines/low-confidence + the profile-reviewed toggle — the
+ * "model in doubt" queue. Pins: the outstanding filter's self-invalidating
+ * comparison (reviewedAt vs generatedAt — NOT a boolean), threshold clamping
+ * against junk input, and the audited mark/unmark round-trip.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../models/WineDefinition', () => {
+  const ctor = jest.fn();
+  ctor.find = jest.fn();
+  ctor.findById = jest.fn();
+  ctor.findOne = jest.fn();
+  ctor.countDocuments = jest.fn();
+  ctor.bulkWrite = jest.fn();
+  ctor.updateMany = jest.fn();
+  ctor.updateOne = jest.fn();
+  return ctor;
+});
+jest.mock('../../models/Bottle', () => ({ aggregate: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../../models/BottleImage', () => ({}));
+jest.mock('../../models/WineVintageProfile', () => ({}));
+jest.mock('../../models/WineVintagePrice', () => ({}));
+jest.mock('../../models/WineReport', () => ({}));
+jest.mock('../../models/Review', () => ({}));
+jest.mock('../../models/Discussion', () => ({}));
+jest.mock('../../models/DiscussionReply', () => ({}));
+jest.mock('../../models/WineEmbedding', () => ({}));
+jest.mock('../../models/WineNotDuplicate', () => ({ find: jest.fn() }));
+jest.mock('../../models/WineList', () => ({}));
+jest.mock('../../models/WishlistItem', () => ({}));
+jest.mock('../../models/PriceTrackingRequest', () => ({}));
+jest.mock('../../models/PriceTrackingSkip', () => ({}));
+jest.mock('../../models/CommunityWinePrice', () => ({}));
+jest.mock('../../models/JournalEntry', () => ({}));
+jest.mock('../../models/Recommendation', () => ({}));
+jest.mock('../../models/RestockAlert', () => ({}));
+jest.mock('../../models/WineRequest', () => ({}));
+jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
+jest.mock('../../services/vectorStore', () => ({}));
+jest.mock('../../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../../services/embeddingJob', () => ({ embedSinglePair: jest.fn() }));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn(), removeWine: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineDefinition = require('../../models/WineDefinition');
+const Bottle = require('../../models/Bottle');
+const { logAudit } = require('../../services/audit');
+const adminWinesRouter = require('./wines');
+
+const ADMIN_ID = '64b000000000000000000001';
+const WINE_ID = '64b0000000000000000000d1';
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/wines', adminWinesRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const listChain = (rows) => {
+  const chain = {};
+  chain.select = jest.fn().mockReturnValue(chain);
+  chain.populate = jest.fn().mockReturnValue(chain);
+  chain.sort = jest.fn().mockReturnValue(chain);
+  chain.skip = jest.fn().mockReturnValue(chain);
+  chain.limit = jest.fn().mockReturnValue(chain);
+  chain.lean = jest.fn().mockResolvedValue(rows);
+  return chain;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  WineDefinition.find.mockReturnValue(listChain([]));
+  WineDefinition.countDocuments.mockResolvedValue(0);
+  WineDefinition.updateOne.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
+  Bottle.aggregate.mockResolvedValue([]);
+});
+
+const get = (qs = '') => fetch(`${baseUrl}/api/admin/wines/low-confidence${qs}`, {
+  headers: { Authorization: `Bearer ${adminToken()}` },
+});
+
+describe('GET /low-confidence', () => {
+  test('default threshold 0.3, outstanding filter compares reviewedAt against generatedAt', async () => {
+    const res = await get();
+    expect(res.status).toBe(200);
+    expect((await res.json()).threshold).toBe(0.3);
+
+    const filter = WineDefinition.find.mock.calls[0][0];
+    expect(filter.nonWine).toEqual({ $ne: true });
+    expect(filter['aiProfile.confidence']).toEqual({ $ne: null, $lte: 0.3 });
+    // The self-invalidation contract: suppression is a COMPARISON, so a
+    // re-enriched profile (new generatedAt) re-surfaces the row with no hook.
+    expect(filter.$expr).toEqual({
+      $or: [
+        { $eq: ['$profileReviewedAt', null] },
+        { $lt: ['$profileReviewedAt', '$aiProfile.generatedAt'] },
+      ],
+    });
+  });
+
+  test('threshold is clamped and junk falls back to the default', async () => {
+    expect((await (await get('?threshold=0.4')).json()).threshold).toBe(0.4);
+    expect((await (await get('?threshold=7')).json()).threshold).toBe(1);
+    expect((await (await get('?threshold=-2')).json()).threshold).toBe(0);
+    expect((await (await get('?threshold=abc')).json()).threshold).toBe(0.3);
+    expect((await (await get('?threshold[$gt]=')).json()).threshold).toBe(0.3);
+  });
+
+  test('?includeReviewed=1 drops the comparison clause (audit view)', async () => {
+    await get('?includeReviewed=1');
+    const filter = WineDefinition.find.mock.calls[0][0];
+    expect(filter.$expr).toBeUndefined();
+    expect(filter['aiProfile.confidence']).toEqual({ $ne: null, $lte: 0.3 });
+  });
+
+  test('rows carry the model doubt fields and bottle counts', async () => {
+    WineDefinition.find.mockReturnValue(listChain([{
+      _id: WINE_ID, name: 'Le Valet d’Épée', producer: 'Arcane',
+      aiProfile: { confidence: 0.2, description: 'hedge', producerSuspect: true, producerNote: 'Arcane is a range of Xavier Vignon', generatedAt: new Date('2026-07-26T08:57:24Z') },
+      profileReviewedAt: null,
+    }]));
+    Bottle.aggregate.mockResolvedValue([{ _id: WINE_ID, count: 8 }]);
+
+    const data = await (await get()).json();
+    expect(data.wines[0]).toMatchObject({
+      producer: 'Arcane', confidence: 0.2, producerSuspect: true,
+      producerNote: 'Arcane is a range of Xavier Vignon', bottleCount: 8,
+    });
+  });
+});
+
+describe('profile-reviewed toggle', () => {
+  test('POST records the review with the current time and audits', async () => {
+    WineDefinition.findById.mockReturnValue({
+      select: jest.fn().mockResolvedValue({ _id: WINE_ID, name: 'Le Valet d’Épée', producer: 'Arcane' }),
+    });
+
+    const res = await fetch(`${baseUrl}/api/admin/wines/${WINE_ID}/profile-reviewed`, {
+      method: 'POST', headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+    expect(res.status).toBe(200);
+
+    const [q, update] = WineDefinition.updateOne.mock.calls[0];
+    expect(String(q._id)).toBe(WINE_ID);
+    expect(update.$set.profileReviewedAt).toBeInstanceOf(Date);
+    expect(logAudit).toHaveBeenCalledWith(
+      expect.anything(), 'admin.wine.profileReviewed',
+      { type: 'wine', id: WINE_ID },
+      expect.objectContaining({ producer: 'Arcane' })
+    );
+  });
+
+  test('DELETE nulls the review and audits the undo', async () => {
+    const res = await fetch(`${baseUrl}/api/admin/wines/${WINE_ID}/profile-reviewed`, {
+      method: 'DELETE', headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+    expect(res.status).toBe(200);
+    expect(WineDefinition.updateOne).toHaveBeenCalledWith(
+      { _id: WINE_ID }, { $set: { profileReviewedAt: null } });
+    expect(logAudit).toHaveBeenCalledWith(
+      expect.anything(), 'admin.wine.profileUnreviewed',
+      { type: 'wine', id: WINE_ID }, {});
+  });
+
+  test('invalid id → 400; unknown id → 404 on both verbs', async () => {
+    expect((await fetch(`${baseUrl}/api/admin/wines/nope/profile-reviewed`, {
+      method: 'POST', headers: { Authorization: `Bearer ${adminToken()}` },
+    })).status).toBe(400);
+
+    WineDefinition.findById.mockReturnValue({ select: jest.fn().mockResolvedValue(null) });
+    expect((await fetch(`${baseUrl}/api/admin/wines/${WINE_ID}/profile-reviewed`, {
+      method: 'POST', headers: { Authorization: `Bearer ${adminToken()}` },
+    })).status).toBe(404);
+
+    WineDefinition.updateOne.mockResolvedValue({ matchedCount: 0 });
+    expect((await fetch(`${baseUrl}/api/admin/wines/${WINE_ID}/profile-reviewed`, {
+      method: 'DELETE', headers: { Authorization: `Bearer ${adminToken()}` },
+    })).status).toBe(404);
+  });
+});

--- a/backend/src/services/embedding.buildText.test.js
+++ b/backend/src/services/embedding.buildText.test.js
@@ -28,6 +28,9 @@ const FULL_WINE = {
     sweetness: 'dry',
     flavors: ['dark cherry', 'thyme'],
     foodPairings: ['duck breast'],
+    // Review metadata inside aiProfile — must never reach the embed text.
+    producerSuspect: true,
+    producerNote: 'Suspect note that must not be embedded',
   },
   // Admin-review metadata — must never reach the embedding text.
   verifiedChecks: ['name-equals-producer.v1'],

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -215,6 +215,14 @@ async function enrichWine(wine, model) {
           // and a self-hoster can override it via SiteConfig.
           description:  typeof data.description === 'string' ? (stripMarkdown(data.description) || null) : null,
           confidence:   typeof data.confidence === 'number' ? data.confidence : null,
+          // The model's own doubt about the producer FIELD (registry audit
+          // follow-up: "Arcane" — a range sold as a producer — sailed past
+          // every string gate AND 49 audit agents; only this model hedged).
+          // Strict true-check: absent on old/custom prompts → false.
+          producerSuspect: data.producerSuspect === true,
+          producerNote: typeof data.producerNote === 'string'
+            ? (stripMarkdown(data.producerNote).slice(0, 300) || null)
+            : null,
           model:        model || aiConfig.get().enrichmentModel,
           generatedAt:  new Date(),
         },

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -65,6 +65,17 @@ export const adminStripProducerFromName = (apiFetch, id) =>
 // Record that an admin read these wines and confirmed they pass these SPECIFIC
 // name checks, so the scan stops surfacing them for those checks only.
 // adminUnverify… reverses it (the undo).
+// The "model in doubt" queue: wines whose enrichment confidence is at or
+// below the threshold and not yet reviewed since their profile was generated.
+export const adminGetLowConfidenceWines = (apiFetch, params) =>
+  apiFetch(`/api/admin/wines/low-confidence?${params}`);
+
+export const adminMarkProfileReviewed = (apiFetch, id) =>
+  apiFetch(`/api/admin/wines/${id}/profile-reviewed`, { method: 'POST' });
+
+export const adminUnmarkProfileReviewed = (apiFetch, id) =>
+  apiFetch(`/api/admin/wines/${id}/profile-reviewed`, { method: 'DELETE' });
+
 export const adminVerifyWineChecks = (apiFetch, wineIds, checks) =>
   apiFetch('/api/admin/wines/verify-checks', {
     method: 'POST', headers: J, body: JSON.stringify({ wineIds, checks }),

--- a/frontend/src/components/WineLowConfidenceModal.js
+++ b/frontend/src/components/WineLowConfidenceModal.js
@@ -1,0 +1,340 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import Modal from './Modal';
+import {
+  adminGetLowConfidenceWines,
+  adminMarkProfileReviewed,
+  adminUnmarkProfileReviewed,
+} from '../api/admin';
+
+const PAGE_SIZE = 50;
+
+/**
+ * Admin "model in doubt" review queue. Surfaces registry wines whose AI
+ * enrichment confidence is at or below the threshold — the signal that caught
+ * the Arcane range-as-producer row after every string rule and the full audit
+ * missed it. Rows the enrichment model explicitly distrusts the PRODUCER of
+ * carry a pill with its note ("Arcane is a range of Xavier Vignon").
+ *
+ * "Mark reviewed" records profileReviewedAt; the clearance self-invalidates
+ * when the wine is re-enriched (new generatedAt), so an edited wine whose
+ * fresh profile is still doubtful re-surfaces by itself. Sibling of
+ * WineProducerInNameModal.
+ *
+ * Props: apiFetch (from useAuth()), onClose(), onChanged().
+ */
+function WineLowConfidenceModal({ apiFetch, onClose, onChanged }) {
+  const { t } = useTranslation();
+
+  const [wines, setWines] = useState(null);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pages, setPages] = useState(1);
+  const [reviewedCount, setReviewedCount] = useState(0);
+  const [threshold, setThreshold] = useState(0.3);
+  const [includeReviewed, setIncludeReviewed] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [rowErrors, setRowErrors] = useState({});
+  const [pending, setPending] = useState(null);
+  const [pendingUndo, setPendingUndo] = useState(null); // { wine }
+  const [successMsg, setSuccessMsg] = useState(null);
+  const successTimer = useRef(null);
+
+  const showSuccess = (msg) => {
+    clearTimeout(successTimer.current);
+    setSuccessMsg(msg);
+    successTimer.current = setTimeout(() => setSuccessMsg(null), 3500);
+  };
+  useEffect(() => () => clearTimeout(successTimer.current), []);
+
+  const fetchPage = useCallback(async (p) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ page: p, limit: PAGE_SIZE, threshold });
+      if (includeReviewed) params.set('includeReviewed', '1');
+      const res = await adminGetLowConfidenceWines(apiFetch, params);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || `Failed to load (${res.status})`);
+        return;
+      }
+      setWines(data.wines || []);
+      setTotal(data.total || 0);
+      setPages(data.pages || 1);
+      setReviewedCount(data.reviewedCount || 0);
+      setRowErrors({});
+    } catch {
+      setError('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch, threshold, includeReviewed]);
+
+  useEffect(() => { fetchPage(page); }, [fetchPage, page]);
+
+  const removeRow = (wineId) => {
+    const remaining = (wines || []).filter(w => w._id !== wineId);
+    const newTotal = Math.max(0, total - 1);
+    setWines(remaining);
+    setTotal(newTotal);
+    setRowErrors(prev => { const { [wineId]: _drop, ...rest } = prev; return rest; });
+    if (remaining.length === 0 && newTotal > 0) {
+      if (page > 1) setPage(p => p - 1);
+      else fetchPage(1);
+    }
+    onChanged?.();
+  };
+
+  const setRowError = (wineId, message) =>
+    setRowErrors(prev => ({ ...prev, [wineId]: message }));
+
+  const handleReviewed = async (wine) => {
+    if (pending) return;
+    setPending(wine._id);
+    setRowError(wine._id, null);
+    try {
+      const res = await adminMarkProfileReviewed(apiFetch, wine._id);
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        showSuccess(t('admin.wines.lowConfidence.reviewed', { name: wine.name }));
+        setPendingUndo({ wine });
+        if (includeReviewed) fetchPage(page);
+        else removeRow(wine._id);
+      } else {
+        setRowError(wine._id, data.error || `Failed (${res.status})`);
+      }
+    } catch {
+      setRowError(wine._id, t('common.networkError'));
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const handleUndo = async () => {
+    const wine = pendingUndo?.wine;
+    if (!wine || pending) return;
+    setPending(wine._id);
+    try {
+      const res = await adminUnmarkProfileReviewed(apiFetch, wine._id);
+      if (res.ok) {
+        setPendingUndo(null);
+        fetchPage(page);
+        onChanged?.();
+      }
+    } catch { /* banner stays; retry possible */ } finally {
+      setPending(null);
+    }
+  };
+
+  const handleUnreview = async (wine) => {
+    if (pending) return;
+    setPending(wine._id);
+    setRowError(wine._id, null);
+    try {
+      const res = await adminUnmarkProfileReviewed(apiFetch, wine._id);
+      if (res.ok) { fetchPage(page); onChanged?.(); }
+      else {
+        const data = await res.json().catch(() => ({}));
+        setRowError(wine._id, data.error || `Failed (${res.status})`);
+      }
+    } catch {
+      setRowError(wine._id, t('common.networkError'));
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const thStyle = {
+    textAlign: 'left',
+    padding: '0.4rem 0.5rem',
+    fontSize: '0.8rem',
+    color: 'var(--color-text-secondary, #666)',
+    borderBottom: '1px solid var(--color-border, #e5e5e5)',
+    whiteSpace: 'nowrap',
+  };
+  const tdStyle = {
+    padding: '0.45rem 0.5rem',
+    borderBottom: '1px solid var(--color-border, #eee)',
+    verticalAlign: 'top',
+  };
+  const pillStyle = {
+    display: 'inline-block',
+    fontSize: '0.75rem',
+    padding: '0.1rem 0.5rem',
+    borderRadius: 999,
+    background: 'var(--color-surface, #f4f4f4)',
+    border: '1px solid var(--color-border, #e5e5e5)',
+    whiteSpace: 'nowrap',
+  };
+
+  const isReviewed = (w) =>
+    w.profileReviewedAt && w.generatedAt &&
+    new Date(w.profileReviewedAt) >= new Date(w.generatedAt);
+
+  return (
+    <Modal title={t('admin.wines.lowConfidence.title')} onClose={onClose} showClose wide>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: '0.85rem', color: 'var(--color-text-secondary, #666)' }}>
+          {t('admin.wines.lowConfidence.intro')}
+        </span>
+        {wines !== null && !loading && (
+          <span style={{
+            fontSize: '0.8rem', fontWeight: 600, padding: '0.15rem 0.6rem', borderRadius: 999,
+            background: 'var(--color-surface, #f4f4f4)', border: '1px solid var(--color-border, #e5e5e5)', flexShrink: 0,
+          }}>
+            {t('admin.wines.lowConfidence.found', { count: total })}
+            {reviewedCount > 0 && <> · {t('admin.wines.lowConfidence.reviewedNote', { count: reviewedCount })}</>}
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 12, flexWrap: 'wrap', fontSize: '0.85rem' }}>
+        <label>
+          {t('admin.wines.lowConfidence.thresholdLabel')}:{' '}
+          <select
+            value={String(threshold)}
+            onChange={e => { setThreshold(Number(e.target.value)); setPage(1); }}
+            disabled={loading || !!pending}
+          >
+            <option value="0.2">≤ 0.2</option>
+            <option value="0.3">≤ 0.3</option>
+            <option value="0.4">≤ 0.4</option>
+          </select>
+        </label>
+        <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          <input
+            type="checkbox"
+            checked={includeReviewed}
+            onChange={e => { setIncludeReviewed(e.target.checked); setPage(1); }}
+            disabled={loading || !!pending}
+          />
+          {t('admin.wines.lowConfidence.includeReviewed')}
+        </label>
+      </div>
+
+      {error && <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>}
+      {successMsg && (
+        <div className="alert alert-success" role="status" style={{ marginBottom: 12 }}>{successMsg}</div>
+      )}
+
+      {pendingUndo && (
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8,
+          padding: '0.5rem 0.75rem', marginBottom: 12, borderRadius: 6,
+          background: 'var(--color-surface, #f4f4f4)', border: '1px solid var(--color-border, #e5e5e5)',
+          fontSize: '0.85rem',
+        }}>
+          <span>{t('admin.wines.lowConfidence.reviewed', { name: pendingUndo.wine.name })}</span>
+          <button type="button" className="btn btn-secondary" onClick={handleUndo} disabled={!!pending}
+            style={{ padding: '0.25rem 0.65rem', fontSize: '0.8rem', flexShrink: 0 }}>
+            {t('common.undo')}
+          </button>
+        </div>
+      )}
+
+      {loading && !wines && (
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--color-text-secondary, #888)' }}>
+          {t('common.loading')}
+        </div>
+      )}
+
+      {!loading && wines?.length === 0 && (
+        <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--color-text-secondary, #888)' }}>
+          {t('admin.wines.lowConfidence.empty')}
+        </div>
+      )}
+
+      {wines?.length > 0 && (
+        <div style={{ maxHeight: 480, overflowY: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+            <thead>
+              <tr>
+                <th style={thStyle}>{t('admin.wines.lowConfidence.confidenceCol')}</th>
+                <th style={thStyle}>{t('admin.wines.producerInName.producerCol')}</th>
+                <th style={thStyle}>{t('common.name')}</th>
+                <th style={thStyle}>{t('admin.wines.lowConfidence.doubtCol')}</th>
+                <th style={{ ...thStyle, textAlign: 'right' }}>{t('admin.wines.producerInName.bottlesCol')}</th>
+                <th style={thStyle}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {wines.map(wine => (
+                <tr key={wine._id} style={{ opacity: pending && pending !== wine._id ? 0.6 : 1 }}>
+                  <td style={tdStyle}>
+                    <span style={{ ...pillStyle, fontWeight: 700 }}>{wine.confidence?.toFixed(1) ?? '—'}</span>
+                  </td>
+                  <td style={tdStyle}>{wine.producer}</td>
+                  <td style={tdStyle}>
+                    {wine.name}
+                    <div style={{ fontSize: '0.75rem', color: 'var(--color-text-secondary, #888)' }}>
+                      {[wine.appellation, wine.region, wine.country].filter(Boolean).join(' · ')}
+                    </div>
+                    {rowErrors[wine._id] && (
+                      <div className="alert alert-error" style={{ marginTop: 6, fontSize: '0.8rem', padding: '0.35rem 0.5rem' }}>
+                        {rowErrors[wine._id]}
+                      </div>
+                    )}
+                  </td>
+                  <td style={{ ...tdStyle, maxWidth: 320 }}>
+                    {wine.producerSuspect && (
+                      <span style={{ ...pillStyle, fontWeight: 600, marginBottom: 4 }}>
+                        {t('admin.wines.lowConfidence.producerSuspect')}
+                      </span>
+                    )}
+                    {wine.producerNote && (
+                      <div style={{ fontSize: '0.8rem' }}>{wine.producerNote}</div>
+                    )}
+                    {!wine.producerSuspect && !wine.producerNote && wine.description && (
+                      <div style={{ fontSize: '0.78rem', color: 'var(--color-text-secondary, #888)' }}>
+                        {wine.description.slice(0, 140)}{wine.description.length > 140 ? '…' : ''}
+                      </div>
+                    )}
+                    {isReviewed(wine) && (
+                      <span style={{ ...pillStyle, fontWeight: 600 }}>
+                        {t('admin.wines.lowConfidence.reviewedBadge')}
+                      </span>
+                    )}
+                  </td>
+                  <td style={{ ...tdStyle, textAlign: 'right' }}>{wine.bottleCount}</td>
+                  <td style={{ ...tdStyle, whiteSpace: 'nowrap', textAlign: 'right' }}>
+                    {isReviewed(wine) ? (
+                      <button type="button" className="btn btn-secondary btn-small"
+                        disabled={!!pending} onClick={() => handleUnreview(wine)}>
+                        {t('admin.wines.lowConfidence.unreviewBtn')}
+                      </button>
+                    ) : (
+                      <button type="button" className="btn btn-secondary btn-small"
+                        disabled={!!pending}
+                        onClick={() => handleReviewed(wine)}
+                        title={t('admin.wines.lowConfidence.reviewTitle')}>
+                        {pending === wine._id ? t('common.saving') : t('admin.wines.lowConfidence.reviewBtn')}
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {wines !== null && pages > 1 && (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8, marginTop: 12 }}>
+          <button type="button" className="btn btn-secondary btn-small"
+            disabled={page <= 1 || loading || !!pending} onClick={() => setPage(p => p - 1)}>
+            {t('common.previous')}
+          </button>
+          <span style={{ fontSize: '0.85rem' }}>{t('admin.audit.page', { current: page, total: pages })}</span>
+          <button type="button" className="btn btn-secondary btn-small"
+            disabled={page >= pages || loading || !!pending} onClick={() => setPage(p => p + 1)}>
+            {t('common.next')}
+          </button>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+export default WineLowConfidenceModal;

--- a/frontend/src/components/WineLowConfidenceModal.test.js
+++ b/frontend/src/components/WineLowConfidenceModal.test.js
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('../api/admin', () => ({
+  adminGetLowConfidenceWines: vi.fn(),
+  adminMarkProfileReviewed: vi.fn(),
+  adminUnmarkProfileReviewed: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+const {
+  adminGetLowConfidenceWines,
+  adminMarkProfileReviewed,
+  adminUnmarkProfileReviewed,
+} = await import('../api/admin');
+const WineLowConfidenceModal = (await import('./WineLowConfidenceModal')).default;
+
+const ARCANE = {
+  _id: 'w1',
+  name: 'Le Valet d’Épée',
+  producer: 'Arcane',
+  appellation: null,
+  region: null,
+  country: 'France',
+  confidence: 0.2,
+  description: 'a hedge',
+  producerSuspect: true,
+  producerNote: 'Arcane is a range of Xavier Vignon',
+  generatedAt: '2026-07-26T08:57:24Z',
+  profileReviewedAt: null,
+  bottleCount: 8,
+};
+
+const PAYLOAD = { wines: [ARCANE], total: 1, page: 1, pages: 1, threshold: 0.3, reviewedCount: 0 };
+const ok = (body) => ({ ok: true, json: async () => body });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  adminGetLowConfidenceWines.mockResolvedValue(ok(PAYLOAD));
+});
+
+const renderModal = () =>
+  render(<WineLowConfidenceModal apiFetch={vi.fn()} onClose={() => {}} onChanged={() => {}} />);
+
+test('shows the model\'s producer doubt as a pill with its note', async () => {
+  renderModal();
+  expect(await screen.findByText('admin.wines.lowConfidence.producerSuspect')).toBeInTheDocument();
+  expect(screen.getByText('Arcane is a range of Xavier Vignon')).toBeInTheDocument();
+});
+
+test('"Mark reviewed" calls the API, drops the row, and offers Undo', async () => {
+  adminMarkProfileReviewed.mockResolvedValue(ok({ profileReviewedAt: 'now' }));
+  renderModal();
+
+  fireEvent.click(await screen.findByText('admin.wines.lowConfidence.reviewBtn'));
+
+  await waitFor(() =>
+    expect(adminMarkProfileReviewed).toHaveBeenCalledWith(expect.any(Function), 'w1'));
+  expect(await screen.findByText('admin.wines.lowConfidence.empty')).toBeInTheDocument();
+  expect(screen.getByText('common.undo')).toBeInTheDocument();
+});
+
+test('Undo reverses the review and refetches', async () => {
+  adminMarkProfileReviewed.mockResolvedValue(ok({}));
+  adminUnmarkProfileReviewed.mockResolvedValue(ok({}));
+  renderModal();
+
+  fireEvent.click(await screen.findByText('admin.wines.lowConfidence.reviewBtn'));
+  fireEvent.click(await screen.findByText('common.undo'));
+
+  await waitFor(() =>
+    expect(adminUnmarkProfileReviewed).toHaveBeenCalledWith(expect.any(Function), 'w1'));
+  await waitFor(() => expect(adminGetLowConfidenceWines).toHaveBeenCalledTimes(2));
+});
+
+test('the threshold picker refetches with the chosen value', async () => {
+  renderModal();
+  await screen.findByText('admin.wines.lowConfidence.reviewBtn');
+
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: '0.4' } });
+
+  await waitFor(() => {
+    const params = adminGetLowConfidenceWines.mock.calls.at(-1)[1];
+    expect(params.get('threshold')).toBe('0.4');
+    expect(params.get('page')).toBe('1');
+  });
+});
+
+test('the audit checkbox requests includeReviewed=1 and reviewed rows swap to Unreview', async () => {
+  renderModal();
+  await screen.findByText('admin.wines.lowConfidence.reviewBtn');
+
+  adminGetLowConfidenceWines.mockResolvedValue(ok({
+    ...PAYLOAD,
+    wines: [{ ...ARCANE, profileReviewedAt: '2026-07-27T00:00:00Z' }],
+    reviewedCount: 1,
+  }));
+  fireEvent.click(screen.getByRole('checkbox'));
+
+  await waitFor(() => {
+    const params = adminGetLowConfidenceWines.mock.calls.at(-1)[1];
+    expect(params.get('includeReviewed')).toBe('1');
+  });
+  expect(await screen.findByText('admin.wines.lowConfidence.unreviewBtn')).toBeInTheDocument();
+  expect(screen.getByText('admin.wines.lowConfidence.reviewedBadge')).toBeInTheDocument();
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1403,6 +1403,26 @@
         "empty": "No wines are flagged by the selected checks.",
         "networkError": "Network error"
       },
+      "lowConfidence": {
+        "button": "Low confidence",
+        "buttonTitle": "Wines the AI couldn't say anything meaningful about — often a sign the producer or other data is wrong",
+        "title": "Low-confidence wines",
+        "intro": "The enrichment model doubted these. Fix the data, or mark the row as reviewed — a re-enriched wine that is still doubtful comes back by itself.",
+        "found_one": "{{count}} wine in doubt",
+        "found_other": "{{count}} wines in doubt",
+        "reviewedNote": "{{count}} reviewed",
+        "thresholdLabel": "Confidence",
+        "includeReviewed": "Include reviewed",
+        "confidenceCol": "Conf.",
+        "doubtCol": "The model's doubt",
+        "producerSuspect": "Producer suspect",
+        "reviewBtn": "Mark reviewed",
+        "reviewTitle": "Record that you've checked this wine's data — it stays hidden until its profile is regenerated",
+        "reviewed": "Marked \"{{name}}\" as reviewed.",
+        "reviewedBadge": "Reviewed",
+        "unreviewBtn": "Unreview",
+        "empty": "No wines below this confidence threshold. The registry is in good shape."
+      },
       "defaultImageHint": "Click the star to set the default image for this wine."
     },
     "images": {

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -11,6 +11,7 @@ import Modal from '../components/Modal';
 import Drawer from '../components/Drawer';
 import WineDuplicatesModal from '../components/WineDuplicatesModal';
 import WineProducerInNameModal from '../components/WineProducerInNameModal';
+import WineLowConfidenceModal from '../components/WineLowConfidenceModal';
 import { WINE_TYPES } from '../config/wineTypes';
 import GrapePicker from '../components/GrapePicker';
 import ImageUpload from '../components/ImageUpload';
@@ -79,6 +80,7 @@ function AdminWines() {
 
   // Producer-in-name cleanup tool
   const [showProducerInName, setShowProducerInName] = useState(false);
+  const [showLowConfidence, setShowLowConfidence] = useState(false);
 
   // Taxonomy
   const [countries, setCountries] = useState([]);
@@ -375,6 +377,9 @@ function AdminWines() {
           </button>
           <button className="btn btn-secondary" onClick={() => setShowProducerInName(true)} title={t('admin.wines.producerInName.buttonTitle')}>
             {t('admin.wines.producerInName.button')}
+          </button>
+          <button className="btn btn-secondary" onClick={() => setShowLowConfidence(true)} title={t('admin.wines.lowConfidence.buttonTitle')}>
+            {t('admin.wines.lowConfidence.button')}
           </button>
           <button className="btn btn-primary" onClick={openCreate}>
             {t('admin.wines.newWine')}


### PR DESCRIPTION
## The Arcane lesson

A range name sold as a producer ("Arcane" = Xavier Vignon's tarot line) passed every string gate **and** all 49 audit agents. The only component in the system that flinched was the enrichment model — confidence 0.2 — and nothing consumed the signal. This PR consumes it.

- **Enrichment now answers the question directly**: `producerSuspect` + `producerNote` ("Arcane is a range of Xavier Vignon") in the prompt + parse, defaulting safely when absent. ⚠️ If prod has a SiteConfig-overridden enrichment prompt, it needs the new fields added via SuperAdmin (default prompt carries them).
- **`GET /api/admin/wines/low-confidence`** — wines at ≤ threshold (default 0.3; **88 rows on prod today**), most doubtful first, with doubt fields + bottle counts.
- **Self-invalidating review clearance**: `profileReviewedAt` hides a row only while it is newer than `aiProfile.generatedAt` — re-enrichment re-surfaces a still-doubtful wine by pure comparison, no hooks. Deliberately separate from `verifiedChecks` (whose scope rule forbids consulting aiProfile).
- **Admin UI**: "Low confidence" button → modal (threshold picker, suspect pills + notes, mark-reviewed with undo, audit view). en-only strings.
- Embed text provably unchanged (golden test extended) — **no re-embed on deploy**. Route registered above `/:id` (ordering matters and is tested by the suite exercising both).

## Post-merge

Deploy (compose impact: **none**), then add `low_confidence_outstanding` to the prod watchdog probe so queue growth alerts on Mondays. The 88 existing rows populate the queue immediately; `producerSuspect` pills appear as wines (re-)enrich.

## Tests

46 backend across 5 suites (incl. the self-invalidation filter contract and threshold clamping) + 800 frontend (new 5-test modal suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)