### PR TITLE
chore(release): v1.92.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.91.0",
+  "version": "1.92.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.91.0",
+      "version": "1.92.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.91.0",
+  "version": "1.92.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.91.0",
+  "version": "1.92.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.91.0",
+      "version": "1.92.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.91.0",
+  "version": "1.92.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only.

## Contents of v1.92.0

**#846 — low-confidence review queue**: the enrichment model's doubt becomes a first-class admin signal. `producerSuspect`/`producerNote` from the enrichment prompt, `GET /api/admin/wines/low-confidence` (default threshold 0.3 — 88 rows on prod), self-invalidating `profileReviewedAt` clearance, and the "Low confidence" admin modal.

## Post-deploy

- Add `low_confidence_outstanding` to the prod watchdog probe + re-baseline.
- If prod has a SiteConfig-overridden enrichment prompt, add the two new JSON fields via SuperAdmin (the default prompt carries them).
- No re-embed, no Meili changes, no migration. Compose impact: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)