### PR TITLE
fix(admin): mount the low-confidence review modal — the button was a no-op

### DIFF
--- a/frontend/src/components/WineLowConfidenceModal.js
+++ b/frontend/src/components/WineLowConfidenceModal.js
@@ -40,6 +40,9 @@ function WineLowConfidenceModal({ apiFetch, onClose, onChanged }) {
   const [pendingUndo, setPendingUndo] = useState(null); // { wine }
   const [successMsg, setSuccessMsg] = useState(null);
   const successTimer = useRef(null);
+  const fetchGen = useRef(0);
+  // Net rows this session has removed from the outstanding set (see fetchPage).
+  const resolvedDelta = useRef(0);
 
   const showSuccess = (msg) => {
     clearTimeout(successTimer.current);
@@ -49,15 +52,27 @@ function WineLowConfidenceModal({ apiFetch, onClose, onChanged }) {
   useEffect(() => () => clearTimeout(successTimer.current), []);
 
   const fetchPage = useCallback(async (p) => {
+    const gen = ++fetchGen.current;
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams({ page: p, limit: PAGE_SIZE, threshold });
+      // Address by explicit offset, not page. In the default view a row leaves
+      // the outstanding set the moment it is marked reviewed, so the set shrinks
+      // underneath us: a fixed page*limit offset would step straight over the
+      // rows that shifted up and silently skip them. Subtracting the number of
+      // rows we have resolved keeps the offset pointing at the first row this
+      // session has not seen. (With includeReviewed the set never shrinks.)
+      const drained = includeReviewed ? 0 : resolvedDelta.current;
+      const offset = Math.max(0, (p - 1) * PAGE_SIZE - drained);
+      const params = new URLSearchParams({ offset, limit: PAGE_SIZE, threshold });
       if (includeReviewed) params.set('includeReviewed', '1');
       const res = await adminGetLowConfidenceWines(apiFetch, params);
       const data = await res.json().catch(() => ({}));
+      // A newer fetch (page/threshold/filter change) started while this one was
+      // in flight — its result is the current truth, so drop ours.
+      if (gen !== fetchGen.current) return;
       if (!res.ok) {
-        setError(data.error || `Failed to load (${res.status})`);
+        setError(data.error || t('common.loadFailed', { status: res.status }));
         return;
       }
       setWines(data.wines || []);
@@ -66,13 +81,17 @@ function WineLowConfidenceModal({ apiFetch, onClose, onChanged }) {
       setReviewedCount(data.reviewedCount || 0);
       setRowErrors({});
     } catch {
-      setError('Network error');
+      if (gen === fetchGen.current) setError(t('common.networkError'));
     } finally {
-      setLoading(false);
+      if (gen === fetchGen.current) setLoading(false);
     }
-  }, [apiFetch, threshold, includeReviewed]);
+  }, [apiFetch, threshold, includeReviewed, t]);
 
   useEffect(() => { fetchPage(page); }, [fetchPage, page]);
+
+  // Changing the threshold or the reviewed filter swaps the underlying set, so
+  // the drain counter from the previous set no longer describes this one.
+  useEffect(() => { resolvedDelta.current = 0; }, [threshold, includeReviewed]);
 
   const removeRow = (wineId) => {
     const remaining = (wines || []).filter(w => w._id !== wineId);
@@ -91,7 +110,7 @@ function WineLowConfidenceModal({ apiFetch, onClose, onChanged }) {
     setRowErrors(prev => ({ ...prev, [wineId]: message }));
 
   const handleReviewed = async (wine) => {
-    if (pending) return;
+    if (pending || loading) return;
     setPending(wine._id);
     setRowError(wine._id, null);
     try {
@@ -100,10 +119,10 @@ function WineLowConfidenceModal({ apiFetch, onClose, onChanged }) {
       if (res.ok) {
         showSuccess(t('admin.wines.lowConfidence.reviewed', { name: wine.name }));
         setPendingUndo({ wine });
-        if (includeReviewed) fetchPage(page);
-        else removeRow(wine._id);
+        if (includeReviewed) { fetchPage(page); onChanged?.(); }
+        else { resolvedDelta.current += 1; removeRow(wine._id); }
       } else {
-        setRowError(wine._id, data.error || `Failed (${res.status})`);
+        setRowError(wine._id, data.error || t('common.actionFailed', { status: res.status }));
       }
     } catch {
       setRowError(wine._id, t('common.networkError'));
@@ -119,17 +138,24 @@ function WineLowConfidenceModal({ apiFetch, onClose, onChanged }) {
     try {
       const res = await adminUnmarkProfileReviewed(apiFetch, wine._id);
       if (res.ok) {
+        // The row rejoins the outstanding set, so give back the drain credit.
+        if (!includeReviewed) resolvedDelta.current = Math.max(0, resolvedDelta.current - 1);
         setPendingUndo(null);
         fetchPage(page);
         onChanged?.();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setRowError(wine._id, data.error || t('common.actionFailed', { status: res.status }));
       }
-    } catch { /* banner stays; retry possible */ } finally {
+    } catch {
+      setRowError(wine._id, t('common.networkError'));
+    } finally {
       setPending(null);
     }
   };
 
   const handleUnreview = async (wine) => {
-    if (pending) return;
+    if (pending || loading) return;
     setPending(wine._id);
     setRowError(wine._id, null);
     try {
@@ -137,7 +163,7 @@ function WineLowConfidenceModal({ apiFetch, onClose, onChanged }) {
       if (res.ok) { fetchPage(page); onChanged?.(); }
       else {
         const data = await res.json().catch(() => ({}));
-        setRowError(wine._id, data.error || `Failed (${res.status})`);
+        setRowError(wine._id, data.error || t('common.actionFailed', { status: res.status }));
       }
     } catch {
       setRowError(wine._id, t('common.networkError'));
@@ -301,12 +327,12 @@ function WineLowConfidenceModal({ apiFetch, onClose, onChanged }) {
                   <td style={{ ...tdStyle, whiteSpace: 'nowrap', textAlign: 'right' }}>
                     {isReviewed(wine) ? (
                       <button type="button" className="btn btn-secondary btn-small"
-                        disabled={!!pending} onClick={() => handleUnreview(wine)}>
+                        disabled={loading || !!pending} onClick={() => handleUnreview(wine)}>
                         {t('admin.wines.lowConfidence.unreviewBtn')}
                       </button>
                     ) : (
                       <button type="button" className="btn btn-secondary btn-small"
-                        disabled={!!pending}
+                        disabled={loading || !!pending}
                         onClick={() => handleReviewed(wine)}
                         title={t('admin.wines.lowConfidence.reviewTitle')}>
                         {pending === wine._id ? t('common.saving') : t('admin.wines.lowConfidence.reviewBtn')}

--- a/frontend/src/components/WineLowConfidenceModal.test.js
+++ b/frontend/src/components/WineLowConfidenceModal.test.js
@@ -6,9 +6,13 @@ vi.mock('../api/admin', () => ({
   adminUnmarkProfileReviewed: vi.fn(),
 }));
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key) => key }),
-}));
+// `t` must keep a stable identity across renders, as react-i18next's real one
+// does — components list it in useCallback deps, so a fresh function per render
+// would spin those callbacks (and any effect keyed on them) forever.
+vi.mock('react-i18next', () => {
+  const t = (key, vars) => (vars ? `${key}:${JSON.stringify(vars)}` : key);
+  return { useTranslation: () => ({ t }) };
+});
 
 const {
   adminGetLowConfidenceWines,
@@ -84,8 +88,33 @@ test('the threshold picker refetches with the chosen value', async () => {
   await waitFor(() => {
     const params = adminGetLowConfidenceWines.mock.calls.at(-1)[1];
     expect(params.get('threshold')).toBe('0.4');
-    expect(params.get('page')).toBe('1');
+    expect(params.get('offset')).toBe('0');
   });
+});
+
+test('paging after a review offsets by rows drained, not by a fixed page size', async () => {
+  // A full page, so "Next" is reachable and the drain is observable.
+  const page1 = Array.from({ length: 50 }, (_, i) => ({ ...ARCANE, _id: `w${i}` }));
+  adminGetLowConfidenceWines.mockResolvedValue(
+    ok({ wines: page1, total: 120, page: 1, pages: 3, threshold: 0.3, reviewedCount: 0 })
+  );
+  adminMarkProfileReviewed.mockResolvedValue(ok({ profileReviewedAt: 'now' }));
+  renderModal();
+
+  await screen.findAllByText('admin.wines.lowConfidence.reviewBtn');
+  expect(adminGetLowConfidenceWines.mock.calls.at(-1)[1].get('offset')).toBe('0');
+
+  // Resolve two rows: they leave the outstanding set, shifting everything up by 2.
+  fireEvent.click(screen.getAllByText('admin.wines.lowConfidence.reviewBtn')[0]);
+  await waitFor(() => expect(adminMarkProfileReviewed).toHaveBeenCalledTimes(1));
+  fireEvent.click(screen.getAllByText('admin.wines.lowConfidence.reviewBtn')[0]);
+  await waitFor(() => expect(adminMarkProfileReviewed).toHaveBeenCalledTimes(2));
+
+  fireEvent.click(screen.getByText('common.next'));
+
+  // Naive offset would be 50 and skip the two rows that shifted into 48 and 49.
+  await waitFor(() =>
+    expect(adminGetLowConfidenceWines.mock.calls.at(-1)[1].get('offset')).toBe('48'));
 });
 
 test('the audit checkbox requests includeReviewed=1 and reviewed rows swap to Unreview', async () => {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -44,7 +44,9 @@
     "reason": "Reason",
     "error": "An error occurred",
     "optional": "optional",
-    "or": "or"
+    "or": "or",
+    "loadFailed": "Failed to load ({{status}})",
+    "actionFailed": "Failed ({{status}})"
   },
   "nav": {
     "myCellars": "My Cellars",

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -875,6 +875,14 @@ function AdminWines() {
         />
       )}
 
+      {showLowConfidence && (
+        <WineLowConfidenceModal
+          apiFetch={apiFetch}
+          onClose={() => setShowLowConfidence(false)}
+          onChanged={fetchWines}
+        />
+      )}
+
       {/* Action-feedback toasts */}
       {toasts.length > 0 && (
         <div className="toast-stack" role="status" aria-live="polite">


### PR DESCRIPTION
The v1.92.0 low-confidence review queue shipped **unreachable**. `AdminWines.js` imported `WineLowConfidenceModal`, declared `showLowConfidence` state, and wired a button to set it — but never rendered the component. Clicking did nothing. The introducing commit (`0414ac1`) added exactly five lines to that file: import, state, button, no render block.

The modal's own Vitest suite renders it directly, which is why a green suite hid the integration gap. There is no ESLint in the project, so the unused import wasn't caught automatically either — worth considering, since `no-unused-vars` would have flagged this at author time.

Found by the 2026-07-27 code audit (H1), along with four defects in the modal itself, all fixed here.

## Changes

**Mount the modal** next to its two siblings in `AdminWines.js`.

**Paginate by drained offset.** A row leaves the `outstanding` set the moment it's marked reviewed, so the set shrinks underneath the client. A fixed `page * limit` offset stepped straight over the rows that shifted up and silently skipped them — at the current ~85-row queue with a 50-row page, that hits on ordinary page-1-then-page-2 review. Now the client sends an explicit `offset` reduced by the number of rows it has resolved this session. `parsePagination` already accepts `offset` (priority: `page` > `offset` > `skip`), so no backend change was needed.

**Ignore stale fetch responses.** Row actions were disabled only by `!!pending` while pagination used `loading || !!pending`, so clicking Next and then immediately marking a still-visible row was possible. The success handler filtered the *old* closured list; if it landed after the in-flight page fetch, it overwrote the new page. Added a fetch-generation guard and blocked row actions while loading.

**Surface a failed undo.** `handleUndo` had an `if (res.ok)` and no `else` at all — a failed DELETE left the banner inviting a retry while the wine stayed reviewed server-side, with no error shown.

**Two smaller ones:** refresh the parent list when marking reviewed from the audit (`includeReviewed`) view, and route the remaining hardcoded English error strings through `t()` (two new `common.*` keys, en only).

## Testing

`cd frontend && npm test` — 6 passed in this suite, including a new regression test asserting that paging after two reviews requests offset 48, not 50.

The test mock now returns a **stable** `t`, matching react-i18next's real behaviour. The previous mock created a fresh function per render, which spins any `useCallback` listing `t` in its deps — a trap for the next person to touch these tests, since the codebase does list `t` in deps elsewhere.

## Not included

The other audit highs (quarantine filter missing from three dedup pools, the two-token dangling-tail gap, the `strip-name-vintages` `'NV'` filter) are registry-guard issues and follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)