### PR TITLE
fix(registry): "de Die" is a town, not a German article

### DIFF
--- a/backend/src/utils/producerPrefix.js
+++ b/backend/src/utils/producerPrefix.js
@@ -42,8 +42,14 @@ const DANGLING_TAIL_WORDS = new Set([
  */
 const TAIL_ARTICLES = new Set([
   'la', 'le', 'les', 'el', 'los', 'las', 'il', 'lo', 'gli', 'the',
-  'der', 'die', 'das', 'den', 'dem',
+  'der', 'das', 'den', 'dem',
 ]);
+// 'die' is deliberately NOT in that set. As a tail token after a connective it
+// is essentially never the German article — German takes the dative there
+// ("von der", "an der"), never "von die" — while "de Die" is the French town
+// in the Drôme that names a real appellation. Measured against prod
+// 2026-07-28: including it flagged exactly one row, Jaillance "Tradition
+// Clairette de Die", and that row is correct.
 
 /**
  * Does this candidate name end in a grammatically stranded connective?

--- a/backend/src/utils/producerPrefix.test.js
+++ b/backend/src/utils/producerPrefix.test.js
@@ -105,6 +105,10 @@ describe('stripProducerSuffix', () => {
     // which is why the article list can't simply join DANGLING_TAIL_WORDS.
     expect(stripProducerSuffix('Château La Tour Blanche', 'Blanche')).toBe('Château La Tour');
 
+    // "de Die" is the Drôme town, not the German article — the one row the
+    // first cut of this rule wrongly flagged on prod.
+    expect(hasDanglingTail('Tradition Clairette de Die')).toBe(false);
+
     // The scan in nameChecks.js shares this exact test, so the safety net can
     // no longer disagree with the create-time guard it backs up.
     expect(hasDanglingTail('Clos de la')).toBe(true);


### PR DESCRIPTION
Pre-ship check on #849 before cutting the release. I measured the new connective+article dangling-tail rule against the live registry, and it newly flagged exactly one row — which turned out to be a false positive:

```
Jaillance | Tradition Clairette de Die
```

**Clairette de Die** is a real appellation; *Die* is the town in the Drôme, not the German article `die`.

Dropped `die` from `TAIL_ARTICLES`. As a tail token following a connective it is essentially never the German article — German takes the dative there (`von der`, `an der`), never `von die` — so this costs no real coverage. The other German forms (`der`, `das`, `den`, `dem`) stay, and `de la` / `von der` / `di lo` still flag as intended.

## Verified blast radius on prod (2026-07-28)

| | count |
|---|---|
| Rows newly flagged by the rule, after this fix | **0** |
| Rows re-entering the queue from the `v2 → v3` clearance bump | **2** |
| Rows holding any name-check clearance at all | 139 |

So the rule change lands quietly, which is what you want from a guard fix shipping to a live registry.

## Testing

54 backend tests across `producerPrefix` and `nameChecks`, including a new case pinning `Tradition Clairette de Die` as clean.

No rule-id bump needed — `dangling-name-tail.v3` has never been deployed, so there are no v3 clearances to invalidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)