### PR TITLE
fix(registry): add 'an' to the connective list; pin why only the suffix strip is guarded

### DIFF
--- a/backend/src/utils/producerPrefix.js
+++ b/backend/src/utils/producerPrefix.js
@@ -26,7 +26,7 @@ const DANGLING_TAIL_WORDS = new Set([
   'de', 'del', 'della', 'delle', 'dei', 'degli', 'di', 'du', 'des',
   'da', 'dal', 'dalla', 'do', 'dos', 'das',
   'von', 'vom', 'van', 'of', 'and', 'et', 'und', 'och',
-  'zu', 'zum', 'zur', 'au', 'aux', 'sur', 'sous', 'in', 'im', 'am',
+  'zu', 'zum', 'zur', 'au', 'aux', 'sur', 'sous', 'in', 'im', 'am', 'an',
   'con', 'com', 'avec', 'mit', 'med',
   'by', 'sans', 'a',
 ]);
@@ -99,6 +99,13 @@ function stripProducerPrefix(name, producer) {
   if (!/^[\s\-–—]/.test(rest)) return null;
 
   const remainder = rest.replace(/^[\s\-–—]+/, '').trim();
+  // Deliberately NO dangling-tail guard here, unlike the suffix twin below.
+  // A prefix strip returns everything AFTER the producer, so the remainder's
+  // last token is always the input's last token — this function cannot create
+  // a stranded tail, it can only pass one through that the input already had.
+  // Guarding it anyway would suppress the producer-in-name signal on exactly
+  // the rows that need both flags: "Madaras La Viña de" must trip
+  // producer-in-name AND dangling-name-tail, not just the latter.
   return remainder.length > 0 ? remainder : null;
 }
 
@@ -180,6 +187,9 @@ function stripProducerKeyPrefix(name, producer) {
   }
 
   const remainder = words.slice(start + keyTokens.length).join(' ').replace(/^[\s\-–—]+/, '').trim();
+  // No dangling-tail guard, for the same reason as stripProducerPrefix above:
+  // this also takes words off the FRONT, so it cannot strand a tail that the
+  // input did not already have.
   return remainder.length > 0 ? remainder : null;
 }
 

--- a/backend/src/utils/producerPrefix.test.js
+++ b/backend/src/utils/producerPrefix.test.js
@@ -109,6 +109,38 @@ describe('stripProducerSuffix', () => {
     // first cut of this rule wrongly flagged on prod.
     expect(hasDanglingTail('Tradition Clairette de Die')).toBe(false);
 
+    // 'an der' is the other common German locative. The docstring named it
+    // from the start but 'an' was missing from the word list, so the two-token
+    // test never fired on it.
+    expect(hasDanglingTail('Weingut an der')).toBe(true);
+    expect(stripProducerSuffix('Weingut an der Ruwer', 'Ruwer')).toBeNull();
+  });
+
+  test('ONLY the suffix strip is guarded — a prefix strip cannot strand a tail', () => {
+    const { stripProducerPrefix: pre, stripProducerKeyPrefix: keyPre, canonicalizeWineName } =
+      require('./producerPrefix');
+
+    // A prefix strip returns everything AFTER the producer, so the remainder's
+    // last token is the input's last token: it can only pass through a tail the
+    // input already had, never create one. Guarding it would be worse than
+    // useless — it would suppress the producer-in-name signal on exactly the
+    // rows that should carry both flags (see the runNameChecks double-hit test
+    // in nameChecks.test.js, which pins that contract).
+    expect(pre('Madaras La Viña de', 'Madaras')).toBe('La Viña de');
+    // normalizeProducerKey collapses the corporate suffix, so the key is just
+    // "madaras" and only that token comes off — the dangling tail rides along
+    // either way, which is the point being pinned here.
+    expect(keyPre('Madaras Wines La Viña de', 'Madaras Wines')).toBe('Wines La Viña de');
+
+    // The suffix strip is the one that turns a good name into a broken one,
+    // and it is guarded.
+    expect(stripProducerSuffix('La Viña de Madaras', 'Madaras')).toBeNull();
+
+    // Ordinary strips are untouched.
+    expect(canonicalizeWineName('Meerlust Chardonnay', 'Meerlust')).toBe('Chardonnay');
+    expect(canonicalizeWineName('Felton Road Block 3 Pinot Noir', 'Felton Road Wines Ltd'))
+      .toBe('Block 3 Pinot Noir');
+
     // The scan in nameChecks.js shares this exact test, so the safety net can
     // no longer disagree with the create-time guard it backs up.
     expect(hasDanglingTail('Clos de la')).toBe(true);


### PR DESCRIPTION
Two findings from the pre-ship audit of #849. One was real. The other looked real, and investigating it produced a better result than fixing it would have.

## Real: `an der` was never actually caught

`TAIL_ARTICLES`' own docstring named the German locative `an der` alongside `von der` as a shape the two-token check exists to catch — but `an` was never in `DANGLING_TAIL_WORDS`, so the check never fired on it:

```
stripProducerSuffix('Weingut an der Ruwer', 'Ruwer')  ->  'Weingut an der'
```

The comment was writing cheques the code didn't honour. `an` is now in the list (`am`, `im`, `in` were already there), and both the create-time guard and the `dangling-name-tail.v3` scan pick it up.

## Not real: the missing guard on the prefix strips

The audit also reported that `stripProducerPrefix` and `stripProducerKeyPrefix` lack the same guard, and it's an easy thing to believe — symmetry is usually right. I added it, and it broke this existing test:

> `runNameChecks — reports every tripped rule` — expected `['producer-in-name.v1', 'dangling-name-tail.v3']`, received `['dangling-name-tail.v3']`

The test was right and the "fix" was a regression. **A prefix strip returns everything after the producer, so the remainder's last token is always the input's last token.** It cannot create a stranded tail; it can only pass through one the input already had. Only the *suffix* strip turns a good name into a broken one:

| | input | output |
|---|---|---|
| suffix strip (guarded) | `La Viña de Madaras` — fine | `La Viña de` — **broken, created here** |
| prefix strip (not guarded) | `Madaras La Viña de` — already broken | `La Viña de` — same tail, passed through |

And guarding it isn't merely useless, it's harmful: it suppressed the `producer-in-name` flag on precisely the rows that should carry **both** flags, since that rule's `detect()` doubles as its auto-fix proposal. A row with the producer embedded *and* a dangling tail needs a human to see both problems.

Both functions now carry a comment explaining the asymmetry, and a test pins it so the next reader doesn't "fix" it again.

## Testing

270 tests across 10 suites, all passing — `producerPrefix`, `nameChecks`, the snapshot suite, `findOrCreateWine`, `normalize`, `WineDefinition.verifiedChecks`, and the four `admin/wines` suites.

No rule-id bump: `dangling-name-tail.v3` hasn't shipped yet, so there are no v3 clearances to invalidate.

## Deferred from the same audit

Not included here, all pre-existing rather than regressions from #849:
- `findOrCreateWine`'s dedup lookups don't exclude quarantined rows. Partly **intentional** — #844 explicitly says exact `normalizedKey` resolution should still match so re-adding a quarantined bottle attaches rather than minting a twin. Whether the *fuzzy* branches should also match is a genuine design question, not a bug to patch under release pressure.
- `POST /:id/strip-producer`'s collision check, and the `community-prices` / `discussions` public routes, don't filter `nonWine` either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)