### PR TITLE
chore(release): v1.92.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.92.0",
+  "version": "1.92.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.92.0",
+      "version": "1.92.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.92.0",
+  "version": "1.92.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.92.0",
+  "version": "1.92.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.92.0",
+      "version": "1.92.1",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.92.0",
+  "version": "1.92.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — six fields across `backend/package.json`, `frontend/package.json` and both lockfiles (root + `packages[""]`). No other changes.

## What ships in v1.92.1

All from the 2026-07-27 code audit. Every one is a fix; no new features.

| PR | Fix |
|---|---|
| #848 | The v1.92.0 low-confidence review queue was **unreachable** — its modal was imported, stated and button-wired but never rendered. Plus four defects inside it: offset-drained pagination (was skipping rows mid-review), a stale-response race, a silently swallowed undo failure, and hardcoded English strings. |
| #849 | Dangling-tail guard extended to connective+article tails (`Clos de la`) and unified with its safety-net scan so they can't drift; quarantine filter added to the three dedup pools and two public routes #844 claimed to cover; `strip-name-vintages.js` fixed to match the real `'NV'` sentinel, recompute `canonicalKey`, flush its backup incrementally, and await reindexing. |
| #850 | `de Die` is a Drôme town, not a German article — caught by measuring the new rule against the live registry before shipping. |
| #851 | `an` was missing from the connective list even though the docstring claimed `an der` was covered; plus a comment and test pinning *why* only the suffix strip is guarded. |

## Verified against prod before shipping

- Rows the new rule newly flags: **0**
- Rows re-entering the name-check queue from the `v2 → v3` clearance bump: **2**
- Stale `dangling-name-tail.v2` values stored on prod rows: ignored safely — `runNameChecks` iterates current ids and never looks up by the stored value.
- `strip-name-vintages.js` already ran on 2026-07-26 and dated **0** bottles (confirmed: 0 at `vintage: null`, 535 at `'NV'`). No data was lost, because all 34 affected bottles already carried correct vintages. The bug was latent, not historic.

## Deploy

No compose change, no env change, no migration. Backend first, frontend last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)