### PR TITLE
feat(registry): producer spelling canonicalization + importer invariants

### DIFF
--- a/backend/src/routes/admin/import.finalize.test.js
+++ b/backend/src/routes/admin/import.finalize.test.js
@@ -1,0 +1,95 @@
+/**
+ * finalizeMintedWines — the post-import invariant repair (strategy 2026-07-29,
+ * R4). The LWIN import's bulkWrite bypasses every mongoose hook, so rows it
+ * inserts are born without canonicalKey (invisible to duplicate prevention),
+ * slug (no public wine page) and createdVia (unreviewable as a class). This
+ * pins: only the given ids are touched, each gains all three invariants, slug
+ * collisions get the -2 suffix, existing values are never overwritten, and a
+ * per-row failure doesn't abort the rest.
+ */
+
+jest.mock('../../services/search', () => ({ fullSync: jest.fn(), indexWine: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../models/WineDefinition', () => ({ findById: jest.fn(), findOne: jest.fn() }));
+jest.mock('../../models/Country', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../../models/Region', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../../models/Appellation', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+
+const WineDefinition = require('../../models/WineDefinition');
+const { finalizeMintedWines } = require('./import');
+const { computeCanonicalKey } = require('../../utils/wineIdentity');
+
+const doc = (over = {}) => ({
+  _id: 'w1',
+  name: 'Albe',
+  producer: 'G.D. Vajra',
+  appellation: 'Barolo',
+  canonicalKey: null,
+  slug: null,
+  createdVia: null,
+  save: jest.fn().mockResolvedValue(undefined),
+  ...over,
+});
+
+const selectChain = (result) => ({ select: jest.fn().mockReturnValue(
+  typeof result?.then === 'function' ? result : Promise.resolve(result)
+) });
+const slugProbe = (result) => ({ select: () => ({ lean: () => Promise.resolve(result) }) });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  WineDefinition.findOne.mockReturnValue(slugProbe(null)); // no slug collision
+});
+
+describe('finalizeMintedWines', () => {
+  test('stamps canonicalKey, slug and createdVia on a bare imported row', async () => {
+    const d = doc();
+    WineDefinition.findById.mockReturnValue(selectChain(d));
+    const n = await finalizeMintedWines(['w1']);
+    expect(n).toBe(1);
+    expect(d.canonicalKey).toBe(computeCanonicalKey('Albe', 'G.D. Vajra', 'Barolo'));
+    expect(d.createdVia).toBe('import');
+    expect(typeof d.slug).toBe('string');
+    expect(d.slug.length).toBeGreaterThan(0);
+    expect(d.save).toHaveBeenCalled();
+  });
+
+  test('slug collision gets the -2 suffix, mirroring the model pre-save hook', async () => {
+    const d = doc();
+    WineDefinition.findById.mockReturnValue(selectChain(d));
+    // First probe: taken; second: free.
+    WineDefinition.findOne
+      .mockReturnValueOnce(slugProbe({ _id: 'other' }))
+      .mockReturnValue(slugProbe(null));
+    await finalizeMintedWines(['w1']);
+    expect(d.slug.endsWith('-2')).toBe(true);
+  });
+
+  test('existing slug and createdVia are never overwritten', async () => {
+    const d = doc({ slug: 'kept-slug', createdVia: 'ui' });
+    WineDefinition.findById.mockReturnValue(selectChain(d));
+    await finalizeMintedWines(['w1']);
+    expect(d.slug).toBe('kept-slug');
+    expect(d.createdVia).toBe('ui');
+    // canonicalKey is always recomputed — idempotent by construction.
+    expect(d.canonicalKey).toBe(computeCanonicalKey('Albe', 'G.D. Vajra', 'Barolo'));
+  });
+
+  test('a per-row failure is non-fatal — the rest still finalize', async () => {
+    const bad = doc({ _id: 'w1', save: jest.fn().mockRejectedValue(new Error('boom')) });
+    const good = doc({ _id: 'w2' });
+    WineDefinition.findById
+      .mockReturnValueOnce(selectChain(bad))
+      .mockReturnValueOnce(selectChain(good));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const n = await finalizeMintedWines(['w1', 'w2']);
+    expect(n).toBe(1);
+    expect(good.save).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  test('a vanished id is skipped without counting', async () => {
+    WineDefinition.findById.mockReturnValue(selectChain(null));
+    expect(await finalizeMintedWines(['gone'])).toBe(0);
+  });
+});

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -2,8 +2,9 @@ const express = require('express');
 const multer = require('multer');
 const { parse } = require('csv-parse');
 const { requireAuth, requireRole } = require('../../middleware/auth');
-const { generateWineKey, normalizeString, normalizeAppellation, resolveCountryName, isRecognizedCountry, isUnknownName } = require('../../utils/normalize');
+const { generateWineKey, generateWineSlug, normalizeString, normalizeAppellation, resolveCountryName, isRecognizedCountry, isUnknownName } = require('../../utils/normalize');
 const { canonicalizeWineName } = require('../../utils/producerPrefix');
+const { computeCanonicalKey } = require('../../utils/wineIdentity');
 const WineDefinition = require('../../models/WineDefinition');
 const Country = require('../../models/Country');
 const Region = require('../../models/Region');
@@ -289,6 +290,7 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
   let format = null;
   let batch = [];
   let rowIndex = 0;
+  const mintedIds = [];
 
   // Reusable flush closure with userId in scope
   const flush = async () => {
@@ -331,6 +333,14 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
     const result = await WineDefinition.bulkWrite(ops, { ordered: false });
     stats.created += result.upsertedCount || 0;
     stats.updated += result.modifiedCount || 0;
+    // bulkWrite bypasses every mongoose hook, so rows minted here would be
+    // born without the identity invariants (canonicalKey, slug, createdVia)
+    // every other write path guarantees — the one hole the 2026-07-29
+    // registry strategy found in the write paths. Collect the ids of the
+    // rows this flush actually INSERTED and finalize them after the import.
+    for (const id of Object.values(result.upsertedIds || {})) {
+      mintedIds.push(id);
+    }
     batch = [];
   };
 
@@ -415,11 +425,18 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
 
     await flush();
 
+    // Give the freshly minted rows the invariants the bulkWrite skipped.
+    // Only rows this import INSERTED — existing rows were $ifNull-protected
+    // and must not be touched (their keys/slugs/provenance are already right,
+    // and stamping createdVia would misattribute pre-import rows).
+    stats.finalized = await finalizeMintedWines(mintedIds);
+
     logAudit(req, 'admin.import.wines', {}, {
       total: stats.total,
       created: stats.created,
       updated: stats.updated,
       skipped: stats.skipped,
+      finalized: stats.finalized,
       errorCount: stats.errors.length,
     });
 
@@ -436,7 +453,59 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
   }
 });
 
+/**
+ * Post-import invariant pass over the rows the bulkWrite INSERTED.
+ *
+ * bulkWrite runs no mongoose hooks, so without this the LWIN import was the
+ * one write path that minted wines with no canonicalKey (invisible to the
+ * duplicate-prevention lookup and the collision report), no slug (no public
+ * wine page) and no createdVia (unreviewable as a class). Slug collision
+ * handling mirrors the model's pre-save hook (-2/-3 suffix, never overwrite).
+ *
+ * Per-doc on purpose: only newly inserted rows are processed (a re-import of
+ * an existing file inserts nothing), and the slug uniqueness probe is a
+ * per-candidate indexed findOne — the same cost findOrCreateWine pays per
+ * mint. Failures are per-row and non-fatal: a finalize error must not fail an
+ * import whose data already landed.
+ *
+ * @returns {Promise<number>} rows finalized
+ */
+async function finalizeMintedWines(ids) {
+  let done = 0;
+  for (const id of ids) {
+    try {
+      const doc = await WineDefinition.findById(id).select('name producer appellation canonicalKey slug createdVia');
+      if (!doc) continue;
+      doc.canonicalKey = computeCanonicalKey(doc.name, doc.producer, doc.appellation);
+      if (!doc.createdVia) doc.createdVia = 'import';
+      if (!doc.slug) {
+        const base = generateWineSlug(doc.name, doc.producer);
+        if (base) {
+          let candidate = base;
+          for (let i = 2; i < 100; i++) {
+            const collision = await WineDefinition.findOne({ slug: candidate }).select('_id').lean();
+            if (!collision) break;
+            candidate = `${base}-${i}`;
+          }
+          doc.slug = candidate;
+        }
+      }
+      // save(): the pre-validate hook recomputes canonicalKey the same way
+      // (idempotent) and the slug hook skips non-new docs, which is why the
+      // slug is assigned by hand above.
+      await doc.save();
+      done += 1;
+    } catch (err) {
+      console.warn(`[import] finalize failed for ${id} (non-fatal):`, err.message);
+    }
+  }
+  return done;
+}
+
 module.exports = router;
 // mapRow is exported for its unit tests (the DISPLAY_NAME fallback rules are
 // load-bearing — audit RC-2); it is pure and DB-free.
 module.exports.mapRow = mapRow;
+// finalizeMintedWines exported for its unit tests — the invariant repair is
+// load-bearing (strategy 2026-07-29 R4).
+module.exports.finalizeMintedWines = finalizeMintedWines;

--- a/backend/src/scripts/unify-producer-spellings.js
+++ b/backend/src/scripts/unify-producer-spellings.js
@@ -1,0 +1,109 @@
+/**
+ * Unify producer DISPLAY spellings across the registry (strategy 2026-07-29,
+ * R1 — the ~85 spelling-splits the 2026-07-26 audit left on the backlog, plus
+ * the Ribeauvillé accent split from support ticket 2026-07-28).
+ *
+ * Groups every wine by normalizeString(producer) — which folds accents, case
+ * and punctuation but deliberately NOT corporate suffixes or stop words, so
+ * "Kumeu River" vs "Kumeu River Wines Limited" (a judgement call) is left for
+ * a human while "Ribeauvillé"/"Ribeauville"/"RIBEAUVILLE" (a typo) is unified.
+ * Groups with more than one raw spelling are rewritten to the majority
+ * spelling (most wines; ties → the spelling whose earliest wine is oldest,
+ * matching services/producerSpelling.js so mint-time and cleanup agree).
+ *
+ * Safe by construction: normalizedKey, canonicalKey and slugs all fold the
+ * spelling away, so this is a display-string-only update — verified per row
+ * before writing (any row where the keys WOULD change is skipped and
+ * reported, because that means the group was not a pure spelling variant).
+ * Plain updateOne, no hooks needed: canonicalKey stays valid (invariant) and
+ * verifiedChecks should NOT be cleared for a fold-equivalent respelling.
+ *
+ * Dry-run by default — prints every group and the chosen target. --apply to
+ * write; after applying it triggers a Meilisearch fullSync (producer is
+ * denormalized into search docs). Embeddings: producer is part of the
+ * embedding text, so run the embedding job in incremental mode afterwards.
+ *
+ *   docker exec cellarion-backend node src/scripts/unify-producer-spellings.js
+ *   docker exec cellarion-backend node src/scripts/unify-producer-spellings.js --apply
+ */
+
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const { normalizeString } = require('../utils/normalize');
+const { computeCanonicalKey } = require('../utils/wineIdentity');
+
+(async () => {
+  const apply = process.argv.includes('--apply');
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+
+  const wines = await WineDefinition.find({})
+    .select('name producer appellation canonicalKey nonWine createdAt')
+    .lean();
+
+  // group key → { spellings: Map<raw, {count, oldest, wines[]}> }
+  const groups = new Map();
+  for (const w of wines) {
+    const key = normalizeString(w.producer || '');
+    if (!key) continue;
+    let g = groups.get(key);
+    if (!g) { g = new Map(); groups.set(key, g); }
+    let s = g.get(w.producer);
+    if (!s) { s = { count: 0, oldest: w.createdAt, wines: [] }; g.set(w.producer, s); }
+    // Quarantined rows get rewritten too (consistency) but no vote (their
+    // data is exactly what we don't want to canonize) — mirror producerSpelling.js.
+    if (!w.nonWine) {
+      s.count += 1;
+      if (w.createdAt < s.oldest) s.oldest = w.createdAt;
+    }
+    s.wines.push(w);
+  }
+
+  const ops = [];
+  let groupsToUnify = 0;
+  let skippedKeyDrift = 0;
+  for (const [key, spellings] of groups) {
+    if (spellings.size < 2) continue;
+    groupsToUnify += 1;
+
+    const ranked = [...spellings.entries()].sort((a, b) =>
+      (b[1].count - a[1].count) || (a[1].oldest - b[1].oldest));
+    const target = ranked[0][0];
+    console.log(`  [${key}] → "${target}"  (${ranked.map(([sp, s]) => `"${sp}"×${s.count}`).join('  ')})`);
+
+    for (const [spelling, s] of spellings) {
+      if (spelling === target) continue;
+      for (const w of s.wines) {
+        // Safety proof, per row: a pure spelling variant leaves canonicalKey
+        // untouched. If it would change, this was NOT a trivial variant —
+        // leave it for a human rather than silently altering identity keys.
+        const before = w.canonicalKey || computeCanonicalKey(w.name, spelling, w.appellation);
+        const after = computeCanonicalKey(w.name, target, w.appellation);
+        if (before !== after) {
+          skippedKeyDrift += 1;
+          console.log(`    SKIP (canonicalKey would change): "${w.name}" — "${spelling}" [${w._id}]`);
+          continue;
+        }
+        ops.push({ updateOne: {
+          filter: { _id: w._id },
+          update: { $set: { producer: target, updatedAt: new Date() } },
+        } });
+      }
+    }
+  }
+
+  console.log(`[unify-producer-spellings] ${apply ? 'APPLY' : 'DRY-RUN'} wines=${wines.length} splitGroups=${groupsToUnify} rowsToRewrite=${ops.length} skippedKeyDrift=${skippedKeyDrift}`);
+
+  if (apply && ops.length > 0) {
+    const res = await WineDefinition.bulkWrite(ops, { ordered: false });
+    console.log(`[unify-producer-spellings] modified=${res.modifiedCount}`);
+    try {
+      await require('../services/search').fullSync();
+      console.log('[unify-producer-spellings] Meilisearch fullSync done');
+    } catch (e) {
+      console.warn('[unify-producer-spellings] Meili sync failed — run fullSync manually:', e.message);
+    }
+    console.log('[unify-producer-spellings] NOTE: run the embedding job (incremental) — producer is in the embedding text.');
+  }
+
+  await mongoose.disconnect();
+})().catch((e) => { console.error('ERR:', e.message); process.exit(1); });

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -24,6 +24,7 @@ const { scoreAllMatches } = require('./wineMatching');
 const { canonicalizeWineName } = require('../utils/producerPrefix');
 const { computeCanonicalKey, canonicalSiblingPrefix } = require('../utils/wineIdentity');
 const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
+const { resolveCanonicalProducerSpelling } = require('./producerSpelling');
 const { escapeRegex } = require('../utils/sanitize');
 
 // Auto-match when combined score >= SIMILARITY_THRESHOLD (near-identical — e.g.
@@ -358,6 +359,13 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
     throw err;
   }
 
+  // Adopt the registry's majority spelling for this producer (accent, case
+  // and punctuation variants — "Cave de Ribeauville" → "Cave de Ribeauvillé").
+  // Display-only: every derived key (normalizedKey, canonicalKey, slug) folds
+  // both spellings identically, which is precisely why nothing upstream of
+  // this point needs recomputing and why no key-based net ever caught these.
+  const producerToStore = await resolveCanonicalProducerSpelling(trimmedProducer, producerNorm);
+
   // Resolve taxonomy
   const countryDoc = await findOrCreateCountry(country, userId);
   if (!countryDoc) {
@@ -384,7 +392,7 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
 
   const newWine = new WineDefinition({
     name: trimmedName,
-    producer: trimmedProducer,
+    producer: producerToStore,
     country: countryDoc._id,
     region: regionDoc?._id || null,
     appellation: trimmedAppellation || null,

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -23,6 +23,7 @@ jest.mock('../models/WineDefinition', () => {
   const ctor = jest.fn();
   ctor.findOne = jest.fn();
   ctor.find = jest.fn();
+  ctor.aggregate = jest.fn();
   return ctor;
 });
 jest.mock('../models/Country', () => {
@@ -143,6 +144,8 @@ beforeEach(() => {
   // Defaults: no exact match, no siblings, Meilisearch down, text fallback
   // empty → create path
   WineDefinition.findOne.mockReturnValue(findOneChain(null));
+  // Producer-spelling adoption: default = producer is new to the registry
+  WineDefinition.aggregate.mockResolvedValue([]);
   searchService.getIsAvailable.mockReturnValue(false);
   primeFind();
   scoreAllMatches.mockReturnValue([]);
@@ -620,6 +623,29 @@ describe('findOrCreateWine — creation', () => {
     expect(result.wine.save).toHaveBeenCalled();
     expect(result.wine.populate).toHaveBeenCalledWith(POPULATE);
     expect(searchService.indexWine).toHaveBeenCalledWith('wine-new');
+  });
+
+  // Strategy 2026-07-29 R1: an accent/case variant of an EXISTING producer
+  // must adopt the registry's majority spelling — the display split is the one
+  // axis no key-based net can catch, because every key folds it away.
+  test('adopts the registry majority producer spelling on create; the typed variant is not stored', async () => {
+    WineDefinition.aggregate.mockResolvedValue([
+      { _id: 'Cave de Ribeauvillé', count: 12, oldest: new Date('2026-01-01') },
+    ]);
+    const result = await findOrCreateWine(
+      { ...INPUT, producer: 'Paul Avril' }, USER_ID);
+    expect(result.created).toBe(true);
+    expect(WineDefinition.mock.calls[0][0].producer).toBe('Cave de Ribeauvillé');
+    // The keys were computed BEFORE adoption and must be spelling-invariant —
+    // normalizedKey still reflects the fold, which both spellings share.
+    expect(WineDefinition.mock.calls[0][0].normalizedKey).toBe(INPUT_KEY);
+  });
+
+  test('a producer new to the registry keeps the typed spelling', async () => {
+    WineDefinition.aggregate.mockResolvedValue([]);
+    const result = await findOrCreateWine(INPUT, USER_ID);
+    expect(result.created).toBe(true);
+    expect(WineDefinition.mock.calls[0][0].producer).toBe('Paul Avril');
   });
 
   test('matchOnly: no match anywhere returns { noMatch: true } and creates NOTHING (registry-safe demo clone)', async () => {

--- a/backend/src/services/producerSpelling.js
+++ b/backend/src/services/producerSpelling.js
@@ -1,0 +1,57 @@
+/**
+ * Canonical producer SPELLING at mint time (registry strategy 2026-07-29, R1).
+ *
+ * The producer is a free string, and every dedup mechanism in the registry —
+ * normalizedKey, canonicalKey, duplicate clusters, sibling matching — is
+ * derived from it. The keys themselves are spelling-proof (normalizeString
+ * folds accents/case/punctuation), which is exactly why display splits slip
+ * through every net: "Cave de Ribeauvillé" (12 wines) and a hand-typed "Cave
+ * de Ribeauville" (1 wine) never collide on any KEY, so nothing ever flagged
+ * them, and the registry showed two producers where the world has one
+ * (support ticket 2026-07-28, finding 2).
+ *
+ * The fix is at the source: when a NEW wine is about to be minted, look up
+ * every existing wine of the same normalized producer (anchored prefix scan on
+ * the indexed normalizedKey — 'producer:name:appellation', and ':' can never
+ * appear inside the producer segment because normalizeString strips
+ * punctuation) and adopt the majority raw spelling. The user who types the
+ * accent-less variant gets the registry's canonical one; no new split is ever
+ * created. Display-only by construction: every derived key normalizes both
+ * spellings identically, so adopting changes NOTHING but the string users see.
+ *
+ * Majority = most wines, ties broken by the spelling whose earliest wine is
+ * oldest (stability: the registry's original spelling wins a 1-vs-1).
+ *
+ * Mint-time only, like the producer-is-a-place gate: existing rows are
+ * unified once by scripts/unify-producer-spellings.js and stay consistent
+ * from then on because this function prevents new divergence.
+ */
+const WineDefinition = require('../models/WineDefinition');
+const { escapeRegex } = require('../utils/sanitize');
+
+/**
+ * @param {string} rawProducer   trimmed display producer the caller wants to store
+ * @param {string} producerNorm  normalizeString(rawProducer) — caller already has it
+ * @returns {Promise<string>} the spelling to store (majority, or the input when
+ *   this producer is new to the registry). Never throws — on lookup failure the
+ *   input spelling is kept; a mint must not fail over a display nicety.
+ */
+async function resolveCanonicalProducerSpelling(rawProducer, producerNorm) {
+  if (!producerNorm) return rawProducer;
+  try {
+    const rows = await WineDefinition.aggregate([
+      // Quarantined rows keep their spelling but don't get a vote — a nonWine
+      // row's producer is exactly the kind of data we don't want to copy.
+      { $match: { normalizedKey: new RegExp(`^${escapeRegex(producerNorm)}:`), nonWine: { $ne: true } } },
+      { $group: { _id: '$producer', count: { $sum: 1 }, oldest: { $min: '$createdAt' } } },
+      { $sort: { count: -1, oldest: 1 } },
+      { $limit: 1 },
+    ]);
+    return rows[0]?._id || rawProducer;
+  } catch (err) {
+    console.warn('[producerSpelling] lookup failed (non-fatal, keeping input):', err.message);
+    return rawProducer;
+  }
+}
+
+module.exports = { resolveCanonicalProducerSpelling };

--- a/backend/src/services/producerSpelling.test.js
+++ b/backend/src/services/producerSpelling.test.js
@@ -1,0 +1,69 @@
+/**
+ * Producer spelling canonicalization at mint (strategy 2026-07-29, R1).
+ *
+ * Pins the invariants: majority spelling wins, ties go to the registry's
+ * oldest spelling, a brand-new producer keeps the typed spelling, quarantined
+ * rows don't vote, and a lookup failure NEVER fails the mint.
+ */
+jest.mock('../models/WineDefinition', () => ({ aggregate: jest.fn() }));
+
+const WineDefinition = require('../models/WineDefinition');
+const { resolveCanonicalProducerSpelling } = require('./producerSpelling');
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('resolveCanonicalProducerSpelling', () => {
+  test('adopts the majority spelling over the typed variant', async () => {
+    // The aggregate is $sort/$limit'd server-side; the mock returns the winner.
+    WineDefinition.aggregate.mockResolvedValue([
+      { _id: 'Cave de Ribeauvillé', count: 12, oldest: new Date('2026-01-01') },
+    ]);
+    const got = await resolveCanonicalProducerSpelling('Cave de Ribeauville', 'cave de ribeauville');
+    expect(got).toBe('Cave de Ribeauvillé');
+  });
+
+  test('a producer new to the registry keeps the typed spelling', async () => {
+    WineDefinition.aggregate.mockResolvedValue([]);
+    const got = await resolveCanonicalProducerSpelling('Château Neuf', 'chateau neuf');
+    expect(got).toBe('Château Neuf');
+  });
+
+  test('the query is an anchored prefix on normalizedKey and excludes quarantined rows', async () => {
+    WineDefinition.aggregate.mockResolvedValue([]);
+    await resolveCanonicalProducerSpelling('Léoville Barton', 'leoville barton');
+    const [pipeline] = WineDefinition.aggregate.mock.calls[0];
+    const match = pipeline[0].$match;
+    expect(match.normalizedKey).toBeInstanceOf(RegExp);
+    expect(match.normalizedKey.source.startsWith('^')).toBe(true);
+    // The ':' terminator keeps "domaine x" from matching "domaine xy".
+    expect(match.normalizedKey.source.endsWith(':')).toBe(true);
+    expect('leoville barton:pauillac wine:x').toMatch(match.normalizedKey);
+    expect('leoville bartonx:wine:x').not.toMatch(match.normalizedKey);
+    expect(match.nonWine).toEqual({ $ne: true });
+    // Majority-then-oldest is the SAME rule scripts/unify-producer-spellings.js
+    // applies — mint-time and cleanup must agree or they'd fight.
+    expect(pipeline.find(s => s.$sort)).toEqual({ $sort: { count: -1, oldest: 1 } });
+  });
+
+  test('an empty normalized producer short-circuits without querying', async () => {
+    const got = await resolveCanonicalProducerSpelling('??', '');
+    expect(got).toBe('??');
+    expect(WineDefinition.aggregate).not.toHaveBeenCalled();
+  });
+
+  test('a lookup failure keeps the typed spelling — a mint must not fail over a display nicety', async () => {
+    WineDefinition.aggregate.mockRejectedValue(new Error('db down'));
+    const got = await resolveCanonicalProducerSpelling('Guigal', 'guigal');
+    expect(got).toBe('Guigal');
+  });
+
+  test('regex special characters in the producer are escaped, not interpreted', async () => {
+    WineDefinition.aggregate.mockResolvedValue([]);
+    await resolveCanonicalProducerSpelling('R. López (Heredia)', 'r lopez heredia');
+    const [pipeline] = WineDefinition.aggregate.mock.calls[0];
+    // normalizeString strips punctuation, but the escape must hold even for a
+    // caller that passes a rawer norm — the guard is in this function, not its
+    // callers.
+    expect(() => new RegExp(pipeline[0].$match.normalizedKey)).not.toThrow();
+  });
+});


### PR DESCRIPTION
First PR of the registry-quality campaign (`REGISTRY_STRATEGY_2026-07-29.md`, items **R1 + R4** — the write path, since everything downstream benefits from cleaner mints).

## R1 — producer spelling canonicalization at mint

**The problem class:** the producer is a free string, and every dedup net (normalizedKey, canonicalKey, duplicate clusters, sibling matching) is *derived* from it with accent/case/punctuation folding. That folding is exactly why display splits are invisible: "Cave de Ribeauvillé" (12 wines) and a hand-typed "Cave de Ribeauville" (1 wine) share every key, so no scan ever flags them — the registry just shows two producers (support ticket 2026-07-28, finding 2, and the ~85 spelling-splits on the audit backlog).

**The fix, at the source:** when `findOrCreateWine` reaches the create path, one indexed aggregate (anchored prefix on `normalizedKey`) finds every existing wine of that normalized producer and adopts the **majority raw spelling** — ties go to the registry's oldest spelling. The user who types the accent-less variant gets the canonical one; no new split can form.

Two properties worth reviewing:
- **Display-only by construction.** Both spellings fold to identical keys, so nothing computed earlier in the flow needs recomputing — the adoption happens after all matching, right before the document is built.
- **Non-fatal by construction.** A lookup failure keeps the typed spelling. A mint must never fail over a display nicety.

Quarantined (`nonWine`) rows don't get a vote — their producer strings are exactly the data we don't want to canonize.

**`scripts/unify-producer-spellings.js`** (dry-run default, `--apply`) unifies the existing splits with the *same* majority rule, so mint-time and cleanup can't disagree. Safety proof per row: it recomputes `canonicalKey` before/after and **skips + reports** any row where the key would change — that means the group wasn't a pure spelling variant and a human should look. Groups by `normalizeString` (accents/case/punct) deliberately NOT `normalizeProducerKey`, so corp-suffix variants ("Kumeu River Wines Limited") are left for human judgement. After apply it triggers a Meili fullSync and reminds about the incremental embedding run (producer is in the embedding text).

## R4 — LWIN importer invariants

The admin CSV import's `bulkWrite` bypasses every mongoose hook, so rows it inserted were born without `canonicalKey` (invisible to the duplicate-prevention lookup and the collision report), `slug` (no public wine page) and `createdVia` (unreviewable as a class) — the one write path outside the registry invariants. The flush now collects `upsertedIds` and `finalizeMintedWines()` stamps all three after the import: canonicalKey via the shared `computeCanonicalKey`, slug with the model hook's exact `-2/-3` collision behaviour, `createdVia:'import'` only when null. Only rows the import actually **inserted** are touched — `$ifNull`-protected existing rows keep their provenance. Per-row and non-fatal; the audit entry and response stats now report `finalized`.

## Testing

- New `producerSpelling.test.js` (6) — majority adoption, new-producer keep, anchored+escaped regex shape, quarantine exclusion, tie rule pinned as identical to the script's, non-fatal failure
- New `import.finalize.test.js` (5) — all three invariants stamped, slug `-2` collision, never-overwrite, per-row failure isolation
- `findOrCreateWine.test.js` extended (adoption on create + keys stay spelling-invariant)
- Full sweep: **1008 tests / 78 suites** across `src/services`, `src/routes`, MCP write tools — all green

## Prod notes

- No compose/env impact. After deploy, run the unify script once (dry-run first) and then the embedding job incrementally.
- Next PRs in the campaign: hygiene cron (R6), taxonomy-merge + collisions UI (R5), the appellation system (R2), region queue + report corrections (R3/R7).