### PR TITLE
feat(registry): weekly registry health check — alert admins on regressions

### DIFF
--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -44,7 +44,8 @@ const notificationSchema = new mongoose.Schema({
       'ai_budget_denied',
       'climate_alert',
       'climate_recovered',
-      'climate_offline'
+      'climate_offline',
+      'registry_health'
     ],
     required: true
   },

--- a/backend/src/models/RegistryHealthSnapshot.js
+++ b/backend/src/models/RegistryHealthSnapshot.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+/**
+ * One row per weekly registry-health run (services/registryHealthJob.js) —
+ * the baseline the next run compares against, so admins are notified when a
+ * metric REGRESSES rather than being re-alerted about a known backlog every
+ * week (the alert-once-then-re-baseline pattern the prod registry watchdog
+ * proved out).
+ *
+ * Contains only aggregate counts about shared registry data — no user data,
+ * so it has no place in the GDPR export/deletion registry (same category as
+ * the metric fields on McpUsageStat). TTL keeps a year of history for
+ * trend-reading; the job only ever reads the newest row.
+ */
+const registryHealthSnapshotSchema = new mongoose.Schema({
+  metrics: { type: Map, of: Number, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+registryHealthSnapshotSchema.index({ createdAt: -1 });
+registryHealthSnapshotSchema.index({ createdAt: 1 }, { expireAfterSeconds: 365 * 24 * 60 * 60 });
+
+module.exports = mongoose.model('RegistryHealthSnapshot', registryHealthSnapshotSchema);

--- a/backend/src/services/registryHealthJob.js
+++ b/backend/src/services/registryHealthJob.js
@@ -1,0 +1,148 @@
+/**
+ * Weekly registry-health check (registry strategy 2026-07-29, R6).
+ *
+ * Every detection net the registry has — name checks, canonical collisions,
+ * the low-confidence queue, producer spelling splits, invariant drift — was
+ * manual before this: a human had to remember to press a button or run a
+ * container command, and the 2026-07 audits repeatedly found month-old
+ * regressions nobody had looked for. This job runs the cheap read-only counts
+ * on a schedule and notifies every admin when a metric REGRESSES against the
+ * previous run (alert-on-increase + re-baseline — the same pattern as the
+ * prod registry watchdog, so a standing backlog alerts once, not weekly).
+ *
+ * Deliberately counts, not findings: the queues themselves are the workbench
+ * (AdminWines), this is only the doorbell. Every metric here mirrors an
+ * existing admin surface's own query so the numbers agree with what the admin
+ * sees when they click through.
+ */
+const WineDefinition = require('../models/WineDefinition');
+const WineReport = require('../models/WineReport');
+const WineRequest = require('../models/WineRequest');
+const User = require('../models/User');
+const RegistryHealthSnapshot = require('../models/RegistryHealthSnapshot');
+const { runNameChecks, NAME_CHECK_SELECT } = require('../utils/nameChecks');
+const { normalizeString } = require('../utils/normalize');
+const { createNotification } = require('./notifications');
+
+// Mirrors the admin low-confidence queue's default (routes/admin/wines.js).
+const LOW_CONFIDENCE_THRESHOLD = 0.3;
+
+/** Human labels for the notification message — keys match computeMetrics. */
+const METRIC_LABELS = {
+  nameCheckFlags: 'name-check flags',
+  canonicalCollisionSets: 'canonical-key collision sets',
+  lowConfidenceQueue: 'low-confidence profiles',
+  producerSpellingSplits: 'producer spelling splits',
+  missingInvariants: 'rows missing canonicalKey/slug',
+  pendingWineReports: 'open wine reports',
+  pendingWineRequests: 'pending wine requests',
+};
+
+async function computeMetrics() {
+  // One lean pass serves both the name checks and the spelling-split count —
+  // ~4k rows of three short fields, the same order of work as one admin scan.
+  const wines = await WineDefinition.find({ nonWine: { $ne: true } })
+    .select(`${NAME_CHECK_SELECT} canonicalKey slug`)
+    .lean();
+
+  let nameCheckFlags = 0;
+  const spellingsByKey = new Map();
+  let missingInvariants = 0;
+  for (const w of wines) {
+    if (runNameChecks(w)) nameCheckFlags += 1;
+    if (!w.canonicalKey || !w.slug) missingInvariants += 1;
+    const key = normalizeString(w.producer || '');
+    if (key) {
+      let set = spellingsByKey.get(key);
+      if (!set) { set = new Set(); spellingsByKey.set(key, set); }
+      set.add(w.producer);
+    }
+  }
+  let producerSpellingSplits = 0;
+  for (const set of spellingsByKey.values()) {
+    if (set.size > 1) producerSpellingSplits += 1;
+  }
+
+  const [collisionAgg, lowConfidenceQueue, pendingWineReports, pendingWineRequests] = await Promise.all([
+    // Raw collision sets (the admin endpoint additionally hides dismissed
+    // sets; dismissals only shrink the number, so an INCREASE here is always
+    // a real new collision — which is the only thing this job alerts on).
+    WineDefinition.aggregate([
+      { $match: { nonWine: { $ne: true }, canonicalKey: { $ne: null } } },
+      { $group: { _id: '$canonicalKey', n: { $sum: 1 } } },
+      { $match: { n: { $gte: 2 } } },
+      { $count: 'sets' },
+    ]),
+    WineDefinition.countDocuments({
+      nonWine: { $ne: true },
+      'aiProfile.confidence': { $ne: null, $lte: LOW_CONFIDENCE_THRESHOLD },
+      $expr: {
+        $or: [
+          { $eq: ['$profileReviewedAt', null] },
+          { $lt: ['$profileReviewedAt', '$aiProfile.generatedAt'] },
+        ],
+      },
+    }),
+    WineReport.countDocuments({ status: 'pending' }),
+    WineRequest.countDocuments({ status: 'pending' }),
+  ]);
+
+  return {
+    nameCheckFlags,
+    canonicalCollisionSets: collisionAgg[0]?.sets || 0,
+    lowConfidenceQueue,
+    producerSpellingSplits,
+    missingInvariants,
+    pendingWineReports,
+    pendingWineRequests,
+  };
+}
+
+/**
+ * @returns {Promise<{metrics: object, regressions: string[], notified: number, baseline: boolean}>}
+ */
+async function runRegistryHealthCheck() {
+  const metrics = await computeMetrics();
+  const previous = await RegistryHealthSnapshot.findOne().sort({ createdAt: -1 }).lean();
+
+  const regressions = [];
+  if (previous) {
+    const prev = previous.metrics instanceof Map ? Object.fromEntries(previous.metrics) : (previous.metrics || {});
+    for (const [key, label] of Object.entries(METRIC_LABELS)) {
+      const before = prev[key];
+      // A metric added after the baseline was written has no `before` — skip
+      // one cycle rather than alerting on the difference from undefined.
+      if (typeof before !== 'number') continue;
+      if (metrics[key] > before) regressions.push(`${label}: ${before} → ${metrics[key]}`);
+    }
+  }
+
+  // Always write the new baseline — including on a regression, so each alert
+  // fires once and the next run measures from here (alert-once + re-baseline).
+  await RegistryHealthSnapshot.create({ metrics });
+
+  let notified = 0;
+  if (regressions.length > 0) {
+    const admins = await User.find({ roles: 'admin' }).select('_id').lean();
+    const message = `Weekly registry check found regressions since last run — ${regressions.join('; ')}.`;
+    for (const admin of admins) {
+      try {
+        await createNotification(
+          admin._id,
+          'registry_health',
+          'Registry health: something regressed',
+          message,
+          '/admin/wines'
+        );
+        notified += 1;
+      } catch (err) {
+        console.warn('[registryHealth] notify failed (non-fatal):', err.message);
+      }
+    }
+  }
+
+  console.log(`[registryHealth] ${JSON.stringify(metrics)} regressions=${regressions.length} notified=${notified}`);
+  return { metrics, regressions, notified, baseline: !previous };
+}
+
+module.exports = { runRegistryHealthCheck, computeMetrics, METRIC_LABELS };

--- a/backend/src/services/registryHealthJob.test.js
+++ b/backend/src/services/registryHealthJob.test.js
@@ -1,0 +1,133 @@
+/**
+ * Weekly registry-health check (strategy 2026-07-29, R6).
+ *
+ * Pins the alerting contract: first run writes a baseline and stays silent;
+ * an increase notifies every admin ONCE and re-baselines (no weekly re-alert
+ * for a standing backlog); a decrease or steady state is silent; a metric
+ * added after the baseline skips one cycle instead of alerting on undefined;
+ * a notify failure is per-admin non-fatal.
+ */
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), aggregate: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineReport', () => ({ countDocuments: jest.fn() }));
+jest.mock('../models/WineRequest', () => ({ countDocuments: jest.fn() }));
+jest.mock('../models/User', () => ({ find: jest.fn() }));
+jest.mock('../models/RegistryHealthSnapshot', () => ({ findOne: jest.fn(), create: jest.fn() }));
+jest.mock('./notifications', () => ({ createNotification: jest.fn() }));
+
+const WineDefinition = require('../models/WineDefinition');
+const WineReport = require('../models/WineReport');
+const WineRequest = require('../models/WineRequest');
+const User = require('../models/User');
+const RegistryHealthSnapshot = require('../models/RegistryHealthSnapshot');
+const { createNotification } = require('./notifications');
+const { runRegistryHealthCheck, computeMetrics } = require('./registryHealthJob');
+
+const leanChain = (result) => ({
+  select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(result) }),
+  sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(result) }),
+});
+
+const wine = (over = {}) => ({
+  name: 'Albe', producer: 'G.D. Vajra', verifiedChecks: [],
+  canonicalKey: 'k', slug: 's', ...over,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  WineDefinition.find.mockReturnValue(leanChain([]));
+  WineDefinition.aggregate.mockResolvedValue([]);
+  WineDefinition.countDocuments.mockResolvedValue(0);
+  WineReport.countDocuments.mockResolvedValue(0);
+  WineRequest.countDocuments.mockResolvedValue(0);
+  User.find.mockReturnValue(leanChain([{ _id: 'admin1' }]));
+  RegistryHealthSnapshot.findOne.mockReturnValue(leanChain(null));
+  RegistryHealthSnapshot.create.mockResolvedValue({});
+  createNotification.mockResolvedValue({});
+});
+
+afterEach(() => console.log.mockRestore());
+
+describe('computeMetrics', () => {
+  test('counts spelling splits by folded producer, and invariant drift', async () => {
+    WineDefinition.find.mockReturnValue(leanChain([
+      wine({ producer: 'Cave de Ribeauvillé' }),
+      wine({ producer: 'Cave de Ribeauville' }),   // split with the above
+      wine({ producer: 'Guigal' }),
+      wine({ producer: 'Guigal' }),                // same spelling — no split
+      wine({ producer: 'Vajra', canonicalKey: null }), // invariant drift
+    ]));
+    const m = await computeMetrics();
+    expect(m.producerSpellingSplits).toBe(1);
+    expect(m.missingInvariants).toBe(1);
+  });
+
+  test('name-check flags respect per-row verifiedChecks clearances', async () => {
+    // "Barolo — Barolo" trips name-equals-producer.v1 unless cleared.
+    WineDefinition.find.mockReturnValue(leanChain([
+      wine({ name: 'Barolo', producer: 'Barolo' }),
+      wine({ name: 'Barolo', producer: 'Barolo', verifiedChecks: ['name-equals-producer.v1'] }),
+    ]));
+    const m = await computeMetrics();
+    expect(m.nameCheckFlags).toBe(1);
+  });
+});
+
+describe('runRegistryHealthCheck', () => {
+  test('first run writes a baseline and never notifies', async () => {
+    const res = await runRegistryHealthCheck();
+    expect(res.baseline).toBe(true);
+    expect(res.regressions).toEqual([]);
+    expect(RegistryHealthSnapshot.create).toHaveBeenCalled();
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  test('an increase notifies every admin and re-baselines', async () => {
+    RegistryHealthSnapshot.findOne.mockReturnValue(leanChain({
+      metrics: { nameCheckFlags: 0, canonicalCollisionSets: 2, lowConfidenceQueue: 5,
+        producerSpellingSplits: 0, missingInvariants: 0, pendingWineReports: 0, pendingWineRequests: 0 },
+    }));
+    WineDefinition.aggregate.mockResolvedValue([{ sets: 4 }]); // 2 → 4
+    User.find.mockReturnValue(leanChain([{ _id: 'a1' }, { _id: 'a2' }]));
+
+    const res = await runRegistryHealthCheck();
+    expect(res.regressions).toEqual(['canonical-key collision sets: 2 → 4']);
+    expect(res.notified).toBe(2);
+    expect(createNotification).toHaveBeenCalledWith(
+      'a1', 'registry_health', expect.any(String),
+      expect.stringContaining('2 → 4'), '/admin/wines');
+    // Re-baseline happens regardless, so this alert cannot repeat next week.
+    expect(RegistryHealthSnapshot.create).toHaveBeenCalledWith({ metrics: expect.objectContaining({ canonicalCollisionSets: 4 }) });
+  });
+
+  test('steady or improving metrics stay silent', async () => {
+    RegistryHealthSnapshot.findOne.mockReturnValue(leanChain({
+      metrics: { nameCheckFlags: 3, canonicalCollisionSets: 9, lowConfidenceQueue: 90,
+        producerSpellingSplits: 85, missingInvariants: 2, pendingWineReports: 1, pendingWineRequests: 1 },
+    }));
+    const res = await runRegistryHealthCheck(); // everything computes to 0
+    expect(res.regressions).toEqual([]);
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  test('a metric missing from the baseline skips a cycle instead of alerting on undefined', async () => {
+    RegistryHealthSnapshot.findOne.mockReturnValue(leanChain({ metrics: { nameCheckFlags: 0 } }));
+    WineReport.countDocuments.mockResolvedValue(7); // no baseline for this key
+    const res = await runRegistryHealthCheck();
+    expect(res.regressions).toEqual([]);
+  });
+
+  test('a notify failure is per-admin non-fatal', async () => {
+    RegistryHealthSnapshot.findOne.mockReturnValue(leanChain({
+      metrics: { pendingWineReports: 0, nameCheckFlags: 0, canonicalCollisionSets: 0,
+        lowConfidenceQueue: 0, producerSpellingSplits: 0, missingInvariants: 0, pendingWineRequests: 0 },
+    }));
+    WineReport.countDocuments.mockResolvedValue(3);
+    User.find.mockReturnValue(leanChain([{ _id: 'a1' }, { _id: 'a2' }]));
+    createNotification.mockRejectedValueOnce(new Error('push down')).mockResolvedValue({});
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const res = await runRegistryHealthCheck();
+    expect(res.notified).toBe(1);
+    warn.mockRestore();
+  });
+});

--- a/backend/src/services/scheduler.js
+++ b/backend/src/services/scheduler.js
@@ -8,6 +8,7 @@ const { runRecommendationEmailScrub } = require('./recommendationRetentionJob');
 const { runSecurityAlertCheck } = require('./securityAlertJob');
 const { runClimateOfflineCheck } = require('./climateOfflineJob');
 const { runDemoSweep } = require('./demoSweepJob');
+const { runRegistryHealthCheck } = require('./registryHealthJob');
 
 /**
  * Start all scheduled cron jobs.
@@ -115,7 +116,21 @@ function startScheduler() {
     }
   });
 
-  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, cellar-retention daily 04:00 UTC, recommendation-email-scrub daily 04:30 UTC, security-spike every 15 min, climate-offline every 15 min, demo-sweep every 15 min offset)');
+  // Registry health: weekly on Monday at 05:00 UTC (quiet slot — Sunday has
+  // the value/price jobs, 06:00 has drink-window). Read-only counts over the
+  // registry's detection nets; notifies admins only when a metric regresses
+  // against the previous run (strategy 2026-07-29 R6 — every net existed but
+  // nothing ran them on a schedule).
+  cron.schedule('0 5 * * 1', async () => {
+    console.log('[scheduler] Running registry health check…');
+    try {
+      await runRegistryHealthCheck();
+    } catch (err) {
+      console.error('[scheduler] Registry health check failed:', err);
+    }
+  });
+
+  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, cellar-retention daily 04:00 UTC, recommendation-email-scrub daily 04:30 UTC, security-spike every 15 min, climate-offline every 15 min, demo-sweep every 15 min offset, registry-health weekly Mon 05:00 UTC)');
 }
 
 module.exports = { startScheduler };


### PR DESCRIPTION
Second PR of the registry-quality campaign (`REGISTRY_STRATEGY_2026-07-29.md`, item **R6**). Independent of #855 — different files, either can merge first.

## The gap

The registry has eight detection nets, and none of them ran unless a human remembered to press the button. `scheduler.js` runs nine cron jobs — drink windows, retention purges, demo sweeps — and not one touches the registry. The July audits kept finding regressions that had been sitting for weeks because nothing ever looked.

## What this adds

A weekly cron (Monday 05:00 UTC, a quiet slot) that computes cheap read-only counts and notifies every admin **only when a metric regresses** against the previous run:

- name-check flags (respecting `verifiedChecks` clearances)
- canonical-key collision sets
- low-confidence profiles (same query as the admin queue, threshold 0.3)
- producer spelling splits — ties directly into #855's mint guard: this is the number that proves it works (should go to ~0 after the unify script and *stay* there)
- rows missing `canonicalKey`/`slug` — ties into #855's importer fix the same way
- open wine reports + pending wine requests

**Alert-once + re-baseline:** the snapshot rewrites on every run, so a standing backlog alerts once and goes quiet, and only *new* movement rings again — the exact pattern the prod `registry-watch` shell watchdog already proved out, now inside the app where it can't be forgotten on a server rebuild. Notification links to `/admin/wines`.

Design choices worth reviewing:
- **Counts, not findings.** The queues are the workbench; this is only the doorbell. Every metric mirrors the corresponding admin surface's own query so the numbers agree when the admin clicks through.
- Collision count is the *raw* set count (the admin endpoint additionally hides dismissed sets) — dismissals only shrink the number, and the job only alerts on increases, so an alert is always a genuinely new collision.
- A metric added in a future release skips one cycle instead of alerting against `undefined`.
- New `registry_health` notification type; the frontend renders notifications generically, so no UI change. `RegistryHealthSnapshot` holds only aggregate counts about shared registry data — no personal data, nothing for the GDPR registry — 1-year TTL.

## Testing

7 new tests pin the contract: baseline-first-run silence, notify-every-admin + re-baseline on increase, silence on steady/improving, the undefined-baseline skip, per-admin non-fatal notify failures, spelling-split + clearance-aware flag counting. Plus the 10 adjacent model/scheduler suites — 72 tests green.

## Prod notes

No compose/env impact. First run after deploy writes the baseline silently; the first real alert can only happen a week later.