### PR TITLE
feat(admin): taxonomy merge UI + canonical-collisions review + usage counts

### DIFF
--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -23,6 +23,51 @@ router.use(requireAuth, requireRole('admin'));
 // drop it after any successful admin mutation so renames/deletions show up
 // immediately instead of after the TTL.
 const { clearTaxonomyListCache } = require('../taxonomy');
+
+// ── Usage counts for the admin lists ─────────────────────────────────────────
+// The taxonomy UI gained merge/delete power (strategy 2026-07-29 R5), and both
+// verbs need the same context to be used safely: how many wines actually
+// reference this doc. Delete already refuses non-zero usage server-side; the
+// count makes that visible BEFORE the click, and for merges it tells the admin
+// which of two spellings is the real one (merge the 1-wine typo into the
+// 300-wine canonical, never the reverse).
+
+/** Map<idString, wineCount> for a ref field ('country' | 'region'). */
+async function wineCountsByRef(field) {
+  const rows = await WineDefinition.aggregate([
+    { $match: { [field]: { $ne: null } } },
+    { $group: { _id: `$${field}`, n: { $sum: 1 } } },
+  ]);
+  return new Map(rows.map(r => [String(r._id), r.n]));
+}
+
+/** Map<grapeIdString, wineCount> (grapes is an array field). */
+async function wineCountsByGrape() {
+  const rows = await WineDefinition.aggregate([
+    { $unwind: '$grapes' },
+    { $group: { _id: '$grapes', n: { $sum: 1 } } },
+  ]);
+  return new Map(rows.map(r => [String(r._id), r.n]));
+}
+
+/**
+ * Map<normalizedAppellation, wineCount>. Wines store the appellation as free
+ * text (not a ref — see routes/admin/import.js), so the join is by normalized
+ * string: the same normalization both writers apply.
+ */
+async function wineCountsByAppellation() {
+  const rows = await WineDefinition.aggregate([
+    { $match: { appellation: { $nin: [null, ''] } } },
+    { $group: { _id: '$appellation', n: { $sum: 1 } } },
+  ]);
+  const map = new Map();
+  for (const r of rows) {
+    const key = normalizeString(r._id || '');
+    if (!key) continue;
+    map.set(key, (map.get(key) || 0) + r.n);
+  }
+  return map;
+}
 router.use((req, res, next) => {
   if (req.method !== 'GET') {
     res.on('finish', () => {
@@ -37,8 +82,18 @@ router.use((req, res, next) => {
 // GET /api/admin/taxonomy/countries - List all countries
 router.get('/countries', async (req, res) => {
   try {
-    const countries = await Country.find().sort({ name: 1 });
-    res.json({ count: countries.length, countries });
+    const [countries, wineCounts, regionAgg] = await Promise.all([
+      Country.find().sort({ name: 1 }).lean(),
+      wineCountsByRef('country'),
+      Region.aggregate([{ $group: { _id: '$country', n: { $sum: 1 } } }]),
+    ]);
+    const regionCounts = new Map(regionAgg.map(r => [String(r._id), r.n]));
+    const rows = countries.map(c => ({
+      ...c,
+      wineCount: wineCounts.get(String(c._id)) || 0,
+      regionCount: regionCounts.get(String(c._id)) || 0,
+    }));
+    res.json({ count: rows.length, countries: rows });
   } catch (error) {
     console.error('Get countries error:', error);
     res.status(500).json({ error: 'Failed to get countries' });
@@ -168,14 +223,19 @@ router.get('/regions', async (req, res) => {
       filter.country = country;
     }
 
-    const regions = await Region.find(filter)
-      .populate('country', 'name')
-      .populate('parentRegion', 'name')
-      .populate('typicalGrapes', 'name')
-      .populate('permittedGrapes', 'name')
-      .sort({ name: 1 });
+    const [regions, wineCounts] = await Promise.all([
+      Region.find(filter)
+        .populate('country', 'name')
+        .populate('parentRegion', 'name')
+        .populate('typicalGrapes', 'name')
+        .populate('permittedGrapes', 'name')
+        .sort({ name: 1 })
+        .lean(),
+      wineCountsByRef('region'),
+    ]);
+    const rows = regions.map(r => ({ ...r, wineCount: wineCounts.get(String(r._id)) || 0 }));
 
-    res.json({ count: regions.length, regions });
+    res.json({ count: rows.length, regions: rows });
   } catch (error) {
     console.error('Get regions error:', error);
     res.status(500).json({ error: 'Failed to get regions' });
@@ -350,8 +410,12 @@ router.delete('/regions/:id', async (req, res) => {
 // GET /api/admin/taxonomy/grapes - List all grapes
 router.get('/grapes', async (req, res) => {
   try {
-    const grapes = await Grape.find().sort({ name: 1 });
-    res.json({ count: grapes.length, grapes });
+    const [grapes, wineCounts] = await Promise.all([
+      Grape.find().sort({ name: 1 }).lean(),
+      wineCountsByGrape(),
+    ]);
+    const rows = grapes.map(g => ({ ...g, wineCount: wineCounts.get(String(g._id)) || 0 }));
+    res.json({ count: rows.length, grapes: rows });
   } catch (error) {
     console.error('Get grapes error:', error);
     res.status(500).json({ error: 'Failed to get grapes' });
@@ -534,12 +598,22 @@ router.get('/appellations', async (req, res) => {
       filter.region = region;
     }
 
-    const appellations = await Appellation.find(filter)
-      .populate('country', 'name')
-      .populate('region', 'name')
-      .sort({ name: 1 });
+    const [appellations, wineCounts] = await Promise.all([
+      Appellation.find(filter)
+        .populate('country', 'name')
+        .populate('region', 'name')
+        .sort({ name: 1 })
+        .lean(),
+      wineCountsByAppellation(),
+    ]);
+    // Free-text join: wines carry the appellation as a string, so a doc's
+    // usage is every wine whose normalized string matches its normalizedName.
+    const rows = appellations.map(a => ({
+      ...a,
+      wineCount: wineCounts.get(a.normalizedName || normalizeString(a.name || '')) || 0,
+    }));
 
-    res.json({ count: appellations.length, appellations });
+    res.json({ count: rows.length, appellations: rows });
   } catch (error) {
     console.error('Get appellations error:', error);
     res.status(500).json({ error: 'Failed to get appellations' });

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -53,6 +53,20 @@ export const adminUndismissDuplicateCluster = (apiFetch, wineIds) =>
     body: JSON.stringify({ wineIds }),
   });
 
+// Wines sharing one canonical identity key (spelling/embed/tier variants
+// collapsed). Distinct wineries CAN legitimately collide — that is why this
+// is a review list, not an auto-merge.
+export const adminGetCanonicalCollisions = (apiFetch) =>
+  apiFetch('/api/admin/wines/canonical-collisions');
+
+/** Merge one taxonomy doc into another. tab ∈ countries|regions|grapes. */
+export const adminMergeTaxonomy = (apiFetch, tab, fromId, toId) =>
+  apiFetch(`/api/admin/taxonomy/${tab}/merge`, {
+    method: 'POST',
+    headers: J,
+    body: JSON.stringify({ fromId, toId }),
+  });
+
 // The registry name-check scan (historical path name — it now runs every
 // default rule in backend utils/nameChecks.js, not just producer-in-name).
 export const adminGetProducerInNameWines = (apiFetch, params) =>

--- a/frontend/src/components/WineCanonicalCollisionsModal.js
+++ b/frontend/src/components/WineCanonicalCollisionsModal.js
@@ -1,0 +1,156 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import Modal from './Modal';
+import { adminGetCanonicalCollisions, adminDismissDuplicateCluster } from '../api/admin';
+
+/**
+ * Admin review list for wines sharing one canonical identity key — the
+ * strongest duplicate signal the registry computes (producer-spelling,
+ * producer-in-name and appellation-tier variance all collapsed), detected
+ * since the 2026-07-22 dup analysis but never surfaced in any UI until now
+ * (strategy 2026-07-29, R5).
+ *
+ * Deliberately a REVIEW list, not an auto-merge: distinct wineries can
+ * legitimately share a key (Domaine Chandon, Napa vs Bodegas Chandon,
+ * Mendoza — the endpoint flags those DIFF-COUNTRY). "Not duplicates" records
+ * every pair in the set so the whole set stops resurfacing here and in the
+ * duplicate scanner; actual merging goes through the existing golden-record
+ * merge in the duplicates scanner, where the keeper is chosen field by field.
+ *
+ * Styling follows its siblings (WineLowConfidenceModal): generic classes +
+ * inline layout, no bespoke stylesheet.
+ *
+ * Props: apiFetch (from useAuth()), onClose().
+ */
+function WineCanonicalCollisionsModal({ apiFetch, onClose }) {
+  const { t } = useTranslation();
+  const [sets, setSets] = useState(null);
+  const [scanned, setScanned] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [pendingKey, setPendingKey] = useState(null); // canonicalKey being dismissed
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await adminGetCanonicalCollisions(apiFetch);
+      const data = await res.json();
+      if (res.ok) {
+        setSets(data.sets || []);
+        setScanned(data.scannedCount || 0);
+      } else {
+        setError(data.error || t('admin.wines.canonicalCollisions.loadError'));
+      }
+    } catch {
+      setError('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch, t]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const dismissSet = async (set) => {
+    setPendingKey(set.canonicalKey);
+    setError(null);
+    try {
+      const res = await adminDismissDuplicateCluster(apiFetch, set.wines.map(w => w._id));
+      const data = await res.json();
+      if (res.ok) setSets(prev => prev.filter(s => s.canonicalKey !== set.canonicalKey));
+      else setError(data.error || t('admin.wines.canonicalCollisions.dismissError'));
+    } catch {
+      setError('Network error');
+    } finally {
+      setPendingKey(null);
+    }
+  };
+
+  const flagStyle = {
+    fontSize: '0.7rem', fontWeight: 600, padding: '0.1rem 0.45rem',
+    borderRadius: 'var(--radius-sm)', background: 'var(--color-warning-bg)',
+    border: '1px solid var(--color-warning-border)',
+  };
+
+  return (
+    <Modal title={t('admin.wines.canonicalCollisions.title')} onClose={onClose} wide>
+      <p style={{ color: 'var(--color-text-muted)', fontSize: '0.85rem', marginTop: 0 }}>
+        {t('admin.wines.canonicalCollisions.explainer')}
+      </p>
+
+      {error && <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>}
+
+      {loading || sets === null ? (
+        <div className="loading">{t('common.loading')}</div>
+      ) : sets.length === 0 ? (
+        <div className="empty-state">
+          <p>{t('admin.wines.canonicalCollisions.empty', { scanned })}</p>
+        </div>
+      ) : (
+        <>
+          <p style={{ fontSize: '0.85rem' }}>
+            {t('admin.wines.canonicalCollisions.count', { count: sets.length, scanned })}
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {sets.map(set => (
+              <div
+                key={set.canonicalKey}
+                style={{ border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', padding: '0.65rem 0.85rem' }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 6 }}>
+                  <code
+                    title={set.canonicalKey}
+                    style={{ fontSize: '0.72rem', color: 'var(--color-text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '45%' }}
+                  >
+                    {set.canonicalKey}
+                  </code>
+                  {set.flags.map(f => (
+                    <span key={f} style={flagStyle}>
+                      {f === 'DIFF-COUNTRY'
+                        ? t('admin.wines.canonicalCollisions.flagDiffCountry')
+                        : t('admin.wines.canonicalCollisions.flagDiffType')}
+                    </span>
+                  ))}
+                  <button
+                    type="button"
+                    className="btn btn-secondary btn-small"
+                    style={{ marginLeft: 'auto' }}
+                    disabled={pendingKey === set.canonicalKey}
+                    onClick={() => dismissSet(set)}
+                    title={t('admin.wines.canonicalCollisions.dismissTitle')}
+                  >
+                    {pendingKey === set.canonicalKey
+                      ? t('admin.wines.canonicalCollisions.dismissing')
+                      : t('admin.wines.canonicalCollisions.dismiss')}
+                  </button>
+                </div>
+                {set.wines.map(w => (
+                  <div
+                    key={w._id}
+                    style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', padding: '0.25rem 0', borderTop: '1px solid var(--color-border)' }}
+                  >
+                    <span>
+                      <strong>{w.producer}</strong> — {w.name}
+                      {w.appellation && <em style={{ color: 'var(--color-text-muted)' }}> · {w.appellation}</em>}
+                    </span>
+                    <span style={{ display: 'flex', gap: 10, fontSize: '0.8rem', color: 'var(--color-text-muted)' }}>
+                      {w.country && <span>{w.country}</span>}
+                      <span>{w.type}</span>
+                      {w.createdVia && <span>{w.createdVia}</span>}
+                      <span>{t('admin.wines.canonicalCollisions.bottleCount', { count: w.bottleCount })}</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+          <p style={{ color: 'var(--color-text-muted)', fontSize: '0.8rem', marginBottom: 0 }}>
+            {t('admin.wines.canonicalCollisions.mergeHint')}
+          </p>
+        </>
+      )}
+    </Modal>
+  );
+}
+
+export default WineCanonicalCollisionsModal;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1337,7 +1337,19 @@
       "appellationRegionLabel": "Region (optional)",
       "appellationRegionNone": "No specific region",
       "confirmDeleteItem": "Are you sure you want to delete this item?",
-      "deleteWarning": "This action cannot be undone."
+      "deleteWarning": "This action cannot be undone.",
+      "wineCount_one": "{{count, number}} wine",
+      "wineCount_other": "{{count, number}} wines",
+      "wineCountTitle": "How many registry wines reference this entry",
+      "mergeBtn": "Merge…",
+      "mergeTitle": "Merge this entry into another — every wine is re-pointed and the old name becomes a synonym",
+      "mergeModalTitle": "Merge \"{{name}}\" into…",
+      "mergeExplainer": "\"{{name}}\" ({{wineCount}} wines) will be absorbed: every wine that references it is re-pointed to the target, its name becomes a synonym on the target so imports and label scans cannot re-create it, and the entry itself is deleted.",
+      "mergeTargetLabel": "Merge into",
+      "mergeTargetPlaceholder": "Choose the entry to keep…",
+      "mergeHint": "Merge the low-count variant into the canonical one — the target is the entry that survives.",
+      "mergeConfirm": "Merge",
+      "merging": "Merging…"
     },
     "wines": {
       "title": "Admin: Wine Library",
@@ -1425,7 +1437,26 @@
         "unreviewBtn": "Unreview",
         "empty": "No wines below this confidence threshold. The registry is in good shape."
       },
-      "defaultImageHint": "Click the star to set the default image for this wine."
+      "defaultImageHint": "Click the star to set the default image for this wine.",
+      "canonicalCollisions": {
+        "button": "Canonical collisions",
+        "buttonTitle": "Wines sharing one canonical identity key — the strongest duplicate signal",
+        "title": "Canonical-key collisions",
+        "explainer": "These wines collapse to the same identity once producer spelling, producer-in-name embeds and appellation tiers are folded away. Most sets are duplicates; some are legitimately distinct wineries (those are flagged). Merging happens in the duplicates scanner — this list is for judging.",
+        "count_one": "{{count}} collision set (scanned {{scanned}} wines)",
+        "count_other": "{{count}} collision sets (scanned {{scanned}} wines)",
+        "empty": "No collisions — all {{scanned}} scanned wines have a unique canonical identity.",
+        "flagDiffCountry": "Different countries",
+        "flagDiffType": "Different types",
+        "dismiss": "Not duplicates",
+        "dismissing": "Saving…",
+        "dismissTitle": "Record every pair in this set as distinct wines, so it stops resurfacing here and in the duplicates scanner",
+        "bottleCount_one": "{{count}} bottle",
+        "bottleCount_other": "{{count}} bottles",
+        "loadError": "Failed to load collisions",
+        "dismissError": "Failed to record the dismissal",
+        "mergeHint": "To merge a set: open \"Find duplicates\" and use the golden-record merge — it lets you pick the surviving value per field."
+      }
     },
     "images": {
       "title": "Admin: Image Review",

--- a/frontend/src/pages/AdminTaxonomy.css
+++ b/frontend/src/pages/AdminTaxonomy.css
@@ -138,3 +138,29 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Usage counts + merge (registry strategy 2026-07-29 R5) ── */
+.taxonomy-usage {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.15rem 0.5rem;
+  white-space: nowrap;
+}
+
+.taxonomy-usage--zero {
+  color: var(--color-danger);
+}
+
+.taxonomy-merge-explainer {
+  margin-top: 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.taxonomy-merge-hint {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}

--- a/frontend/src/pages/AdminTaxonomy.js
+++ b/frontend/src/pages/AdminTaxonomy.js
@@ -4,9 +4,11 @@ import { useAuth } from '../contexts/AuthContext';
 import {
   adminGetTaxonomy, adminGetCountries, adminGetGrapes, adminGetRegions,
   adminCreateTaxonomy, adminUpdateTaxonomy, adminDeleteTaxonomy,
+  adminMergeTaxonomy,
 } from '../api/admin';
 import GrapePicker from '../components/GrapePicker';
 import ConfirmModal from '../components/ConfirmModal';
+import Modal from '../components/Modal';
 import BottleSizesAdmin from '../components/BottleSizesAdmin';
 import './AdminTaxonomy.css';
 
@@ -24,6 +26,14 @@ function AdminTaxonomy() {
   const [allGrapes, setAllGrapes] = useState([]);
   const [allRegions, setAllRegions] = useState([]); // for parent region / appellation dropdowns
   const [confirmDelete, setConfirmDelete] = useState(null); // id of item to delete
+  const [mergeItem, setMergeItem] = useState(null);         // item being merged away
+  const [mergeTarget, setMergeTarget] = useState('');       // toId
+  const [merging, setMerging] = useState(false);
+
+  // Merge backends exist for exactly these three (services/taxonomyMerge.js);
+  // appellations have no merge service — wines reference them by string, so a
+  // rename IS the merge there.
+  const MERGEABLE_TABS = ['countries', 'regions', 'grapes'];
 
   const endpoints = {
     countries: '/api/admin/taxonomy/countries',
@@ -160,6 +170,37 @@ function AdminTaxonomy() {
       setConfirmDelete(null);
     }
   };
+
+  const handleMerge = async () => {
+    if (!mergeItem || !mergeTarget) return;
+    setMerging(true);
+    setError(null);
+    try {
+      const res = await adminMergeTaxonomy(apiFetch, activeTab, mergeItem._id, mergeTarget);
+      const data = await res.json();
+      if (res.ok) {
+        setMergeItem(null);
+        setMergeTarget('');
+        fetchItems();
+      } else {
+        setError(data.error || 'Failed to merge');
+      }
+    } catch (err) {
+      setError('Network error');
+    } finally {
+      setMerging(false);
+    }
+  };
+
+  // Merge candidates: same taxon, never itself; regions only within the same
+  // country (the backend enforces this — mirroring it here keeps the dropdown
+  // from offering choices that would 400).
+  const mergeCandidates = mergeItem
+    ? items.filter(i =>
+        i._id !== mergeItem._id &&
+        (activeTab !== 'regions' ||
+          String(i.country?._id || i.country) === String(mergeItem.country?._id || mergeItem.country)))
+    : [];
 
   const handleEditClick = (item) => {
     setShowForm(false);
@@ -669,12 +710,29 @@ function AdminTaxonomy() {
               <div key={item._id} className={`taxonomy-item ${editItem?._id === item._id ? 'editing' : ''}`}>
                 <div className="taxonomy-item-content">{renderItem(item)}</div>
                 <div className="taxonomy-item-actions">
+                  {typeof item.wineCount === 'number' && (
+                    <span
+                      className={`taxonomy-usage ${item.wineCount === 0 ? 'taxonomy-usage--zero' : ''}`}
+                      title={t('admin.taxonomy.wineCountTitle')}
+                    >
+                      {t('admin.taxonomy.wineCount', { count: item.wineCount })}
+                    </span>
+                  )}
                   <button
                     onClick={() => handleEditClick(item)}
                     className="btn btn-secondary btn-small"
                   >
                     {t('common.edit')}
                   </button>
+                  {MERGEABLE_TABS.includes(activeTab) && (
+                    <button
+                      onClick={() => { setMergeItem(item); setMergeTarget(''); }}
+                      className="btn btn-secondary btn-small"
+                      title={t('admin.taxonomy.mergeTitle')}
+                    >
+                      {t('admin.taxonomy.mergeBtn')}
+                    </button>
+                  )}
                   <button
                     onClick={() => setConfirmDelete(item._id)}
                     className="btn btn-danger btn-small"
@@ -696,6 +754,49 @@ function AdminTaxonomy() {
           onConfirm={() => handleDelete(confirmDelete)}
           onCancel={() => setConfirmDelete(null)}
         />
+      )}
+
+      {mergeItem && (
+        <Modal
+          title={t('admin.taxonomy.mergeModalTitle', { name: mergeItem.name })}
+          onClose={() => { setMergeItem(null); setMergeTarget(''); }}
+        >
+          <p className="taxonomy-merge-explainer">
+            {t('admin.taxonomy.mergeExplainer', {
+              name: mergeItem.name,
+              wineCount: mergeItem.wineCount ?? 0,
+            })}
+          </p>
+          <div className="form-group">
+            <label htmlFor="taxonomy-merge-target">{t('admin.taxonomy.mergeTargetLabel')}</label>
+            <select
+              id="taxonomy-merge-target"
+              value={mergeTarget}
+              onChange={(e) => setMergeTarget(e.target.value)}
+            >
+              <option value="">{t('admin.taxonomy.mergeTargetPlaceholder')}</option>
+              {mergeCandidates.map(c => (
+                <option key={c._id} value={c._id}>
+                  {c.name}{typeof c.wineCount === 'number' ? ` (${t('admin.taxonomy.wineCount', { count: c.wineCount })})` : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+          <p className="taxonomy-merge-hint">{t('admin.taxonomy.mergeHint')}</p>
+          <div className="modal-actions">
+            <button type="button" className="btn btn-secondary" onClick={() => { setMergeItem(null); setMergeTarget(''); }}>
+              {t('common.cancel')}
+            </button>
+            <button
+              type="button"
+              className="btn btn-danger"
+              disabled={!mergeTarget || merging}
+              onClick={handleMerge}
+            >
+              {merging ? t('admin.taxonomy.merging') : t('admin.taxonomy.mergeConfirm')}
+            </button>
+          </div>
+        </Modal>
       )}
     </div>
   );

--- a/frontend/src/pages/AdminWines.js
+++ b/frontend/src/pages/AdminWines.js
@@ -12,6 +12,7 @@ import Drawer from '../components/Drawer';
 import WineDuplicatesModal from '../components/WineDuplicatesModal';
 import WineProducerInNameModal from '../components/WineProducerInNameModal';
 import WineLowConfidenceModal from '../components/WineLowConfidenceModal';
+import WineCanonicalCollisionsModal from '../components/WineCanonicalCollisionsModal';
 import { WINE_TYPES } from '../config/wineTypes';
 import GrapePicker from '../components/GrapePicker';
 import ImageUpload from '../components/ImageUpload';
@@ -81,6 +82,7 @@ function AdminWines() {
   // Producer-in-name cleanup tool
   const [showProducerInName, setShowProducerInName] = useState(false);
   const [showLowConfidence, setShowLowConfidence] = useState(false);
+  const [showCollisions, setShowCollisions] = useState(false);
 
   // Taxonomy
   const [countries, setCountries] = useState([]);
@@ -380,6 +382,9 @@ function AdminWines() {
           </button>
           <button className="btn btn-secondary" onClick={() => setShowLowConfidence(true)} title={t('admin.wines.lowConfidence.buttonTitle')}>
             {t('admin.wines.lowConfidence.button')}
+          </button>
+          <button className="btn btn-secondary" onClick={() => setShowCollisions(true)} title={t('admin.wines.canonicalCollisions.buttonTitle')}>
+            {t('admin.wines.canonicalCollisions.button')}
           </button>
           <button className="btn btn-primary" onClick={openCreate}>
             {t('admin.wines.newWine')}
@@ -880,6 +885,13 @@ function AdminWines() {
           apiFetch={apiFetch}
           onClose={() => setShowLowConfidence(false)}
           onChanged={fetchWines}
+        />
+      )}
+
+      {showCollisions && (
+        <WineCanonicalCollisionsModal
+          apiFetch={apiFetch}
+          onClose={() => setShowCollisions(false)}
         />
       )}
 


### PR DESCRIPTION
Third PR of the registry-quality campaign (`REGISTRY_STRATEGY_2026-07-29.md`, item **R5**). Independent of #855/#856 — no shared files, any merge order.

## The gap

The two strongest cleanup tools in the codebase were finished, tested, and unreachable:

- **Taxonomy merge** (`services/taxonomyMerge.js`) — rewrites every wine/region/appellation reference, absorbs the old name as a synonym so label scans can't re-mint the duplicate, guards same-country region merges. Zero UI; every merge to date has been a container command.
- **Canonical collisions** (`GET /api/admin/wines/canonical-collisions`) — the registry's strongest duplicate signal (producer spelling, producer-in-name embeds and appellation tiers all folded), live since the 2026-07-22 dup analysis. Zero frontend consumers.

## What this adds

**AdminTaxonomy** — a "Merge…" action on countries/regions/grapes rows opening a target picker; regions are constrained to the same country client-side, mirroring the backend guard so the dropdown can't offer a choice that would 400. Appellations deliberately have no merge — wines reference them by string, so a rename *is* the merge there.

**AdminWines** — a "Canonical collisions" button + review modal: collision sets with DIFF-COUNTRY / DIFF-TYPE flags, per-wine bottle counts and `createdVia` provenance, and a per-set "Not duplicates" that records every pair via the existing dismiss endpoint (the set then stops resurfacing here *and* in the duplicates scanner). Deliberately a review list, not an auto-merge — Domaine Chandon (Napa) vs Bodegas Chandon (Mendoza) legitimately share a key; actual merging stays in the golden-record flow where the keeper is chosen field by field. Styling matches its sibling modals (generic classes + inline layout, no new stylesheet).

**Usage counts** — the four admin taxonomy GETs now return per-doc `wineCount` (countries also `regionCount`). Appellation counts join by normalized string since wines store the appellation as free text. This is the context both verbs need: merge the 1-wine typo into the 300-wine canonical, never the reverse, and see the zero before trusting a delete. Zero-usage entries render the count in the danger colour.

## Testing

- 445 backend tests across all `src/routes/` + the taxonomyMerge suite, green (the counts ride on existing GET shapes — additive fields only)
- 801 frontend tests green; en-only strings, plural keys in the repo's `_one/_other` form, `count`-named i18n variables avoided where no plural is intended (i18next treats `count` as a plural trigger)

## Prod notes

No compose/env impact, no migration. The counts add three cheap aggregations to admin-only list endpoints.