### PR TITLE
feat(registry): the appellation system — membership list, write-time adoption, review queue

### DIFF
--- a/backend/src/models/Appellation.js
+++ b/backend/src/models/Appellation.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { normalizeString } = require('../utils/normalize');
 
 const appellationSchema = new mongoose.Schema({
   name: {
@@ -23,6 +24,19 @@ const appellationSchema = new mongoose.Schema({
     default: null,
     index: true
   },
+  // Alternative spellings that resolve to this appellation at write time
+  // ("Chateauneuf du Pape" → "Châteauneuf-du-Pape") — same design as
+  // Region/Grape synonyms, so a variant can't quietly become a second string
+  // on wines. normalizedSynonyms is what lookups match against.
+  synonyms: {
+    type: [String],
+    default: undefined
+  },
+  normalizedSynonyms: {
+    type: [String],
+    default: undefined,
+    index: true
+  },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',
@@ -36,5 +50,15 @@ const appellationSchema = new mongoose.Schema({
 
 // No two appellations with the same name in the same country
 appellationSchema.index({ country: 1, normalizedName: 1 }, { unique: true });
+
+// Keep normalizedSynonyms in lockstep with synonyms — same hook as Grape, so
+// every save-based admin edit maintains what the write-time lookup matches.
+appellationSchema.pre('save', function(next) {
+  if (this.isModified('synonyms') || this.isNew) {
+    const normalized = (this.synonyms || []).map(s => normalizeString(s)).filter(Boolean);
+    this.normalizedSynonyms = normalized.length ? normalized : undefined;
+  }
+  next();
+});
 
 module.exports = mongoose.model('Appellation', appellationSchema);

--- a/backend/src/models/Appellation.js
+++ b/backend/src/models/Appellation.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose');
-const { normalizeString } = require('../utils/normalize');
+const { normalizeAppellationKey } = require('../utils/normalize');
 
 const appellationSchema = new mongoose.Schema({
   name: {
@@ -55,7 +55,7 @@ appellationSchema.index({ country: 1, normalizedName: 1 }, { unique: true });
 // every save-based admin edit maintains what the write-time lookup matches.
 appellationSchema.pre('save', function(next) {
   if (this.isModified('synonyms') || this.isNew) {
-    const normalized = (this.synonyms || []).map(s => normalizeString(s)).filter(Boolean);
+    const normalized = (this.synonyms || []).map(s => normalizeAppellationKey(s)).filter(Boolean);
     this.normalizedSynonyms = normalized.length ? normalized : undefined;
   }
   next();

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -580,6 +580,78 @@ for (const [path, { fn, type }] of Object.entries(MERGERS)) {
 
 // ===== APPELLATIONS =====
 
+// GET /api/admin/taxonomy/appellations/unmatched — the appellation review
+// queue (strategy 2026-07-29 R2). Wines store appellations as free text; this
+// lists every distinct normalized string that NO curated Appellation doc (by
+// name or synonym) covers, with the majority display spelling and the
+// majority country/region so the admin can promote it in one click (the
+// existing create endpoint) or fix the wines. Unknown values are reviewed,
+// never rejected — adding a bottle must not be blocked by taxonomy.
+router.get('/appellations/unmatched', async (req, res) => {
+  try {
+    const [existing, rows] = await Promise.all([
+      Appellation.find({}).select('normalizedName normalizedSynonyms').lean(),
+      WineDefinition.aggregate([
+        { $match: { appellation: { $nin: [null, ''] }, nonWine: { $ne: true } } },
+        { $group: { _id: { ap: '$appellation', country: '$country', region: '$region' }, n: { $sum: 1 } } },
+      ]),
+    ]);
+    const matched = new Set();
+    for (const a of existing) {
+      if (a.normalizedName) matched.add(a.normalizedName);
+      for (const s of a.normalizedSynonyms || []) matched.add(s);
+    }
+
+    // normalized → aggregate across raw-spelling/country/region variants
+    const groups = new Map();
+    for (const r of rows) {
+      const key = normalizeString(r._id.ap || '');
+      if (!key || matched.has(key)) continue;
+      let g = groups.get(key);
+      if (!g) { g = { spellings: new Map(), countries: new Map(), regions: new Map(), total: 0 }; groups.set(key, g); }
+      g.total += r.n;
+      g.spellings.set(r._id.ap, (g.spellings.get(r._id.ap) || 0) + r.n);
+      if (r._id.country) g.countries.set(String(r._id.country), (g.countries.get(String(r._id.country)) || 0) + r.n);
+      if (r._id.region) g.regions.set(String(r._id.region), (g.regions.get(String(r._id.region)) || 0) + r.n);
+    }
+
+    const top = (map) => [...map.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || null;
+    const countryIds = new Set(), regionIds = new Set();
+    const items = [...groups.entries()].map(([normalized, g]) => {
+      const countryId = top(g.countries);
+      const regionId = top(g.regions);
+      if (countryId) countryIds.add(countryId);
+      if (regionId) regionIds.add(regionId);
+      return { normalized, name: top(g.spellings), wineCount: g.total, countryId, regionId };
+    }).sort((a, b) => b.wineCount - a.wineCount);
+
+    const [countries, regions] = await Promise.all([
+      Country.find({ _id: { $in: [...countryIds] } }).select('name').lean(),
+      Region.find({ _id: { $in: [...regionIds] } }).select('name country').lean(),
+    ]);
+    const countryName = new Map(countries.map(c => [String(c._id), c.name]));
+    const regionById = new Map(regions.map(r => [String(r._id), r]));
+
+    res.json({
+      total: items.length,
+      items: items.map(i => {
+        const region = i.regionId ? regionById.get(i.regionId) : null;
+        return {
+          ...i,
+          countryName: i.countryId ? countryName.get(i.countryId) || null : null,
+          // A majority region from a DIFFERENT country than the majority
+          // country would violate the Appellation schema — drop it.
+          regionId: region && String(region.country) === i.countryId ? i.regionId : null,
+          regionName: region && String(region.country) === i.countryId ? region.name : null,
+        };
+      }),
+    });
+  } catch (error) {
+    console.error('Unmatched appellations error:', error);
+    res.status(500).json({ error: 'Failed to list unmatched appellations' });
+  }
+});
+
 // GET /api/admin/taxonomy/appellations - List (filter by country and/or region)
 router.get('/appellations', async (req, res) => {
   try {
@@ -623,7 +695,7 @@ router.get('/appellations', async (req, res) => {
 // POST /api/admin/taxonomy/appellations - Create appellation
 router.post('/appellations', async (req, res) => {
   try {
-    const { name, country, region } = req.body;
+    const { name, country, region, synonyms } = req.body;
 
     if (!name || !country) {
       return res.status(400).json({ error: 'Name and country are required' });
@@ -636,6 +708,7 @@ router.post('/appellations', async (req, res) => {
       normalizedName,
       country,
       region: region || null,
+      synonyms: Array.isArray(synonyms) && synonyms.length ? synonyms : undefined,
       createdBy: req.user.id
     });
 
@@ -661,7 +734,7 @@ router.post('/appellations', async (req, res) => {
 router.put('/appellations/:id', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
-    const { name, region } = req.body;
+    const { name, region, synonyms } = req.body;
 
     const appellation = await Appellation.findById(req.params.id);
     if (!appellation) {
@@ -673,6 +746,7 @@ router.put('/appellations/:id', async (req, res) => {
       appellation.normalizedName = normalizeString(name);
     }
     if (region !== undefined) appellation.region = region || null;
+    if (synonyms !== undefined) appellation.synonyms = Array.isArray(synonyms) && synonyms.length ? synonyms : undefined;
 
     await appellation.save();
     await appellation.populate('country', 'name');

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const { requireAuth, requireRole } = require('../../middleware/auth');
-const { normalizeString } = require('../../utils/normalize');
+const { normalizeString, normalizeAppellation, normalizeAppellationKey } = require('../../utils/normalize');
 const Country = require('../../models/Country');
 const Region = require('../../models/Region');
 const Grape = require('../../models/Grape');
@@ -62,7 +62,7 @@ async function wineCountsByAppellation() {
   ]);
   const map = new Map();
   for (const r of rows) {
-    const key = normalizeString(r._id || '');
+    const key = normalizeAppellationKey(normalizeAppellation(r._id || '') || r._id || '');
     if (!key) continue;
     map.set(key, (map.get(key) || 0) + r.n);
   }
@@ -605,12 +605,15 @@ router.get('/appellations/unmatched', async (req, res) => {
     // normalized → aggregate across raw-spelling/country/region variants
     const groups = new Map();
     for (const r of rows) {
-      const key = normalizeString(r._id.ap || '');
+      // Tier-strip before grouping, mirroring the seed script: pre-guard rows
+      // ("… DO", "… DOCG") fold into their clean form instead of listing twice.
+      const cleaned = normalizeAppellation(r._id.ap || '') || r._id.ap || '';
+      const key = normalizeAppellationKey(cleaned);
       if (!key || matched.has(key)) continue;
       let g = groups.get(key);
       if (!g) { g = { spellings: new Map(), countries: new Map(), regions: new Map(), total: 0 }; groups.set(key, g); }
       g.total += r.n;
-      g.spellings.set(r._id.ap, (g.spellings.get(r._id.ap) || 0) + r.n);
+      g.spellings.set(cleaned, (g.spellings.get(cleaned) || 0) + r.n);
       if (r._id.country) g.countries.set(String(r._id.country), (g.countries.get(String(r._id.country)) || 0) + r.n);
       if (r._id.region) g.regions.set(String(r._id.region), (g.regions.get(String(r._id.region)) || 0) + r.n);
     }
@@ -682,7 +685,7 @@ router.get('/appellations', async (req, res) => {
     // usage is every wine whose normalized string matches its normalizedName.
     const rows = appellations.map(a => ({
       ...a,
-      wineCount: wineCounts.get(a.normalizedName || normalizeString(a.name || '')) || 0,
+      wineCount: wineCounts.get(a.normalizedName || normalizeAppellationKey(a.name || '')) || 0,
     }));
 
     res.json({ count: rows.length, appellations: rows });
@@ -701,7 +704,7 @@ router.post('/appellations', async (req, res) => {
       return res.status(400).json({ error: 'Name and country are required' });
     }
 
-    const normalizedName = normalizeString(name);
+    const normalizedName = normalizeAppellationKey(name);
 
     const appellation = new Appellation({
       name: name.trim(),
@@ -743,7 +746,7 @@ router.put('/appellations/:id', async (req, res) => {
 
     if (name) {
       appellation.name = name.trim();
-      appellation.normalizedName = normalizeString(name);
+      appellation.normalizedName = normalizeAppellationKey(name);
     }
     if (region !== undefined) appellation.region = region || null;
     if (synonyms !== undefined) appellation.synonyms = Array.isArray(synonyms) && synonyms.length ? synonyms : undefined;

--- a/backend/src/scripts/seed-appellations-from-wines.js
+++ b/backend/src/scripts/seed-appellations-from-wines.js
@@ -31,7 +31,7 @@ const mongoose = require('mongoose');
 const WineDefinition = require('../models/WineDefinition');
 const Appellation = require('../models/Appellation');
 const User = require('../models/User');
-const { normalizeString } = require('../utils/normalize');
+const { normalizeAppellationKey, normalizeAppellation } = require('../utils/normalize');
 
 (async () => {
   const apply = process.argv.includes('--apply');
@@ -56,15 +56,19 @@ const { normalizeString } = require('../utils/normalize');
   // normalized → { spellings: Map<raw,{count,oldest}>, countries: Map<id,count>, regionsByCountry: Map<id, Map<regionId,count>>, total }
   const groups = new Map();
   for (const w of wines) {
-    const key = normalizeString(w.appellation);
+    // Tier-strip BEFORE grouping: strings stored before the write-path guard
+    // ("Ribera del Duero DO") must fold into their clean form, not become a
+    // tier-suffixed taxonomy doc — found on the first prod-data dry run.
+    const cleaned = normalizeAppellation(w.appellation) || w.appellation;
+    const key = normalizeAppellationKey(cleaned);
     if (!key || matched.has(key)) continue;
     let g = groups.get(key);
     if (!g) { g = { spellings: new Map(), countries: new Map(), regionsByCountry: new Map(), total: 0 }; groups.set(key, g); }
     g.total += 1;
-    const s = g.spellings.get(w.appellation) || { count: 0, oldest: w.createdAt };
+    const s = g.spellings.get(cleaned) || { count: 0, oldest: w.createdAt };
     s.count += 1;
     if (w.createdAt < s.oldest) s.oldest = w.createdAt;
-    g.spellings.set(w.appellation, s);
+    g.spellings.set(cleaned, s);
     const c = String(w.country || '');
     if (c) {
       g.countries.set(c, (g.countries.get(c) || 0) + 1);

--- a/backend/src/scripts/seed-appellations-from-wines.js
+++ b/backend/src/scripts/seed-appellations-from-wines.js
@@ -1,0 +1,125 @@
+/**
+ * Seed the Appellation taxonomy from the appellation strings wines already
+ * carry (registry strategy 2026-07-29, R2).
+ *
+ * The Appellation collection has been vestigial (8 docs) while ~4k wines
+ * carry >1k distinct free-text strings. This script promotes the strings the
+ * registry itself vouches for — each distinct normalized appellation used by
+ * at least --min-wines wines (default 3, the same floor the public taxonomy
+ * pages use) — into curated docs, so the write-time resolver
+ * (services/appellationResolve.js) can start collapsing variants and the
+ * admin unmatched queue shrinks to the long tail worth human eyes.
+ *
+ * Per group: name = the majority display spelling (ties → the spelling whose
+ * earliest wine is oldest — same rule as producer unification), country = the
+ * majority country among the group's wines, region = the majority region
+ * among wines of that country when one covers >= half of them (else null —
+ * an appellation is not forced under a region it only sometimes sits in).
+ *
+ * Groups already matched by an existing doc (name or synonym) are skipped;
+ * so is anything below the floor — the point is to canonize what is clearly
+ * established, not to bless every typo. The long tail stays free text and
+ * surfaces in GET /api/admin/taxonomy/appellations/unmatched.
+ *
+ * Dry-run by default. --apply writes; --min-wines N overrides the floor.
+ *
+ *   docker exec cellarion-backend node src/scripts/seed-appellations-from-wines.js
+ *   docker exec cellarion-backend node src/scripts/seed-appellations-from-wines.js --apply
+ */
+
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const Appellation = require('../models/Appellation');
+const User = require('../models/User');
+const { normalizeString } = require('../utils/normalize');
+
+(async () => {
+  const apply = process.argv.includes('--apply');
+  const minIdx = process.argv.indexOf('--min-wines');
+  const minWines = minIdx > -1 ? Math.max(1, parseInt(process.argv[minIdx + 1], 10) || 3) : 3;
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+
+  const [wines, existing, admin] = await Promise.all([
+    WineDefinition.find({ appellation: { $nin: [null, ''] }, nonWine: { $ne: true } })
+      .select('appellation country region createdAt').lean(),
+    Appellation.find({}).select('normalizedName normalizedSynonyms').lean(),
+    User.findOne({ roles: 'admin' }).select('_id').lean(),
+  ]);
+  if (!admin) { console.error('ERR: no admin user found (createdBy is required)'); process.exit(1); }
+
+  const matched = new Set();
+  for (const a of existing) {
+    if (a.normalizedName) matched.add(a.normalizedName);
+    for (const s of a.normalizedSynonyms || []) matched.add(s);
+  }
+
+  // normalized → { spellings: Map<raw,{count,oldest}>, countries: Map<id,count>, regionsByCountry: Map<id, Map<regionId,count>>, total }
+  const groups = new Map();
+  for (const w of wines) {
+    const key = normalizeString(w.appellation);
+    if (!key || matched.has(key)) continue;
+    let g = groups.get(key);
+    if (!g) { g = { spellings: new Map(), countries: new Map(), regionsByCountry: new Map(), total: 0 }; groups.set(key, g); }
+    g.total += 1;
+    const s = g.spellings.get(w.appellation) || { count: 0, oldest: w.createdAt };
+    s.count += 1;
+    if (w.createdAt < s.oldest) s.oldest = w.createdAt;
+    g.spellings.set(w.appellation, s);
+    const c = String(w.country || '');
+    if (c) {
+      g.countries.set(c, (g.countries.get(c) || 0) + 1);
+      if (w.region) {
+        let rm = g.regionsByCountry.get(c);
+        if (!rm) { rm = new Map(); g.regionsByCountry.set(c, rm); }
+        rm.set(String(w.region), (rm.get(String(w.region)) || 0) + 1);
+      }
+    }
+  }
+
+  const toCreate = [];
+  let belowFloor = 0;
+  for (const [key, g] of groups) {
+    if (g.total < minWines) { belowFloor += 1; continue; }
+    const spelling = [...g.spellings.entries()]
+      .sort((a, b) => (b[1].count - a[1].count) || (a[1].oldest - b[1].oldest))[0][0];
+    const countryEntry = [...g.countries.entries()].sort((a, b) => b[1] - a[1])[0];
+    if (!countryEntry) continue; // country is required on Appellation
+    const [countryId, countryCount] = countryEntry;
+    let regionId = null;
+    const rm = g.regionsByCountry.get(countryId);
+    if (rm) {
+      const top = [...rm.entries()].sort((a, b) => b[1] - a[1])[0];
+      if (top && top[1] * 2 >= countryCount) regionId = top[0];
+    }
+    toCreate.push({ key, name: spelling, countryId, regionId, wines: g.total });
+  }
+  toCreate.sort((a, b) => b.wines - a.wines);
+
+  console.log(`[seed-appellations] ${apply ? 'APPLY' : 'DRY-RUN'} wineRows=${wines.length} distinctUnmatched=${groups.size} toCreate=${toCreate.length} belowFloor(min ${minWines})=${belowFloor} existingDocs=${existing.length}`);
+  for (const c of toCreate) {
+    console.log(`  + "${c.name}" (${c.wines} wines) country=${c.countryId}${c.regionId ? ` region=${c.regionId}` : ''}`);
+  }
+
+  if (apply) {
+    let created = 0, conflicts = 0;
+    for (const c of toCreate) {
+      try {
+        // .save(), not bulkWrite — the model hook maintains normalizedSynonyms
+        // and the {country, normalizedName} unique index turns a race or a
+        // cross-run repeat into a skipped conflict instead of a duplicate.
+        const doc = new Appellation({
+          name: c.name, normalizedName: c.key,
+          country: c.countryId, region: c.regionId, createdBy: admin._id,
+        });
+        await doc.save();
+        created += 1;
+      } catch (err) {
+        if (err.code === 11000) { conflicts += 1; continue; }
+        console.warn(`  WARN "${c.name}": ${err.message}`);
+      }
+    }
+    console.log(`[seed-appellations] created=${created} conflicts=${conflicts}`);
+  }
+
+  await mongoose.disconnect();
+})().catch((e) => { console.error('ERR:', e.message); process.exit(1); });

--- a/backend/src/scripts/unify-producer-spellings.js
+++ b/backend/src/scripts/unify-producer-spellings.js
@@ -47,8 +47,12 @@ const { computeCanonicalKey } = require('../utils/wineIdentity');
     if (!key) continue;
     let g = groups.get(key);
     if (!g) { g = new Map(); groups.set(key, g); }
-    let s = g.get(w.producer);
-    if (!s) { s = { count: 0, oldest: w.createdAt, wines: [] }; g.set(w.producer, s); }
+    // Whitespace-collapsed spelling candidates: "Wrights  Estate" must never
+    // WIN a majority vote on the strength of its own duplication (first
+    // prod-data dry run) — the double-space rows count toward the clean form.
+    const spelling = String(w.producer).trim().replace(/\s+/g, ' ');
+    let s = g.get(spelling);
+    if (!s) { s = { count: 0, oldest: w.createdAt, wines: [] }; g.set(spelling, s); }
     // Quarantined rows get rewritten too (consistency) but no vote (their
     // data is exactly what we don't want to canonize) — mirror producerSpelling.js.
     if (!w.nonWine) {
@@ -71,8 +75,11 @@ const { computeCanonicalKey } = require('../utils/wineIdentity');
     console.log(`  [${key}] → "${target}"  (${ranked.map(([sp, s]) => `"${sp}"×${s.count}`).join('  ')})`);
 
     for (const [spelling, s] of spellings) {
-      if (spelling === target) continue;
       for (const w of s.wines) {
+        // Compare the STORED string, not the collapsed group spelling: a row
+        // stored with a double space groups under the clean form and still
+        // needs the rewrite.
+        if (w.producer === target) continue;
         // Safety proof, per row: a pure spelling variant leaves canonicalKey
         // untouched. If it would change, this was NOT a trivial variant —
         // leave it for a human rather than silently altering identity keys.

--- a/backend/src/services/appellationResolve.js
+++ b/backend/src/services/appellationResolve.js
@@ -1,0 +1,53 @@
+/**
+ * Canonical appellation SPELLING at mint time (registry strategy 2026-07-29,
+ * R2 — the write-time half; the seed script and the unmatched review queue
+ * are the other halves).
+ *
+ * Wines store the appellation as a free string, and `appellation_wrong` was
+ * the single largest category of the 2026-07-26 registry audit (231 rows):
+ * with no membership list, every writer invents its own spelling and every
+ * rule that reasons about appellations has to guess grammatically (the
+ * "Clairette de Die" false positive — "Die" read as a German article instead
+ * of the Drôme town, PR #850).
+ *
+ * This resolver is the Grape treatment, not the Country treatment: when the
+ * typed appellation matches a curated Appellation doc (by normalized name or
+ * synonym), the doc's canonical display spelling is adopted — so variants
+ * collapse into ONE string on wines and the membership list actually governs
+ * what the registry shows. When nothing matches, the free text is kept
+ * verbatim: appellations are genuinely open-ended (new AVAs and DOCs appear,
+ * and oddities like "Vin de France" are legitimate), so an unknown value is
+ * REVIEWED (admin unmatched queue), never rejected — a user adding a bottle
+ * must not be blocked by taxonomy.
+ */
+const Appellation = require('../models/Appellation');
+const { normalizeString } = require('../utils/normalize');
+
+/**
+ * @param {string} rawAppellation  tier-stripped, trimmed appellation string
+ * @returns {Promise<string>} canonical spelling when curated, else the input.
+ *   Never throws — on lookup failure the input is kept; a mint must not fail
+ *   over taxonomy.
+ */
+async function resolveCanonicalAppellation(rawAppellation) {
+  if (!rawAppellation) return rawAppellation;
+  const normalized = normalizeString(rawAppellation);
+  if (!normalized) return rawAppellation;
+  try {
+    // limit(2): one match → adopt. Two docs can share a name across countries
+    // (the unique index is per-country); adopt only when their display
+    // spellings agree — when even the curated docs disagree, the typed
+    // spelling is not obviously wrong and is left alone.
+    const docs = await Appellation.find({
+      $or: [{ normalizedName: normalized }, { normalizedSynonyms: normalized }],
+    }).select('name').limit(2).lean();
+    if (docs.length === 0) return rawAppellation;
+    if (docs.length === 1 || docs[0].name === docs[1].name) return docs[0].name;
+    return rawAppellation;
+  } catch (err) {
+    console.warn('[appellationResolve] lookup failed (non-fatal, keeping input):', err.message);
+    return rawAppellation;
+  }
+}
+
+module.exports = { resolveCanonicalAppellation };

--- a/backend/src/services/appellationResolve.js
+++ b/backend/src/services/appellationResolve.js
@@ -21,7 +21,7 @@
  * must not be blocked by taxonomy.
  */
 const Appellation = require('../models/Appellation');
-const { normalizeString } = require('../utils/normalize');
+const { normalizeAppellationKey } = require('../utils/normalize');
 
 /**
  * @param {string} rawAppellation  tier-stripped, trimmed appellation string
@@ -31,7 +31,7 @@ const { normalizeString } = require('../utils/normalize');
  */
 async function resolveCanonicalAppellation(rawAppellation) {
   if (!rawAppellation) return rawAppellation;
-  const normalized = normalizeString(rawAppellation);
+  const normalized = normalizeAppellationKey(rawAppellation);
   if (!normalized) return rawAppellation;
   try {
     // limit(2): one match → adopt. Two docs can share a name across countries

--- a/backend/src/services/appellationResolve.test.js
+++ b/backend/src/services/appellationResolve.test.js
@@ -31,6 +31,21 @@ describe('resolveCanonicalAppellation', () => {
     ]);
   });
 
+  // The reason normalizeAppellationKey exists: normalizeString DELETES
+  // hyphens, so the hyphenated and spaced forms of one place produced two
+  // different keys — found on the first prod-data test of this resolver.
+  test('hyphenated and spaced forms produce the SAME lookup key', async () => {
+    Appellation.find.mockReturnValue(chain([{ name: 'Châteauneuf-du-Pape' }]));
+    await resolveCanonicalAppellation('Châteauneuf-du-Pape');
+    const hyphenQ = Appellation.find.mock.calls[0][0].$or[0].normalizedName;
+    Appellation.find.mockClear();
+    Appellation.find.mockReturnValue(chain([{ name: 'Châteauneuf-du-Pape' }]));
+    await resolveCanonicalAppellation('Chateauneuf du Pape');
+    const spacedQ = Appellation.find.mock.calls[0][0].$or[0].normalizedName;
+    expect(hyphenQ).toBe(spacedQ);
+    expect(hyphenQ).toBe('chateauneuf du pape');
+  });
+
   test('an un-curated appellation passes through verbatim — reviewed, never rejected', async () => {
     Appellation.find.mockReturnValue(chain([]));
     expect(await resolveCanonicalAppellation('Vin de Garage de Jean')).toBe('Vin de Garage de Jean');

--- a/backend/src/services/appellationResolve.test.js
+++ b/backend/src/services/appellationResolve.test.js
@@ -1,0 +1,61 @@
+/**
+ * Appellation spelling adoption at mint (strategy 2026-07-29, R2).
+ *
+ * Pins: curated spelling wins over the typed variant (by name OR synonym), an
+ * un-curated appellation passes through verbatim (reviewed, never rejected),
+ * a cross-country name clash only adopts when the curated spellings agree,
+ * and a lookup failure never fails the mint.
+ */
+jest.mock('../models/Appellation', () => ({ find: jest.fn() }));
+
+const Appellation = require('../models/Appellation');
+const { resolveCanonicalAppellation } = require('./appellationResolve');
+
+const chain = (docs) => ({
+  select: jest.fn().mockReturnValue({
+    limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(docs) }),
+  }),
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('resolveCanonicalAppellation', () => {
+  test('adopts the curated spelling when the taxonomy knows the appellation', async () => {
+    Appellation.find.mockReturnValue(chain([{ name: 'Châteauneuf-du-Pape' }]));
+    expect(await resolveCanonicalAppellation('Chateauneuf du Pape')).toBe('Châteauneuf-du-Pape');
+    // The lookup matches by normalized name OR synonym — one query, both axes.
+    const q = Appellation.find.mock.calls[0][0];
+    expect(q.$or).toEqual([
+      { normalizedName: 'chateauneuf du pape' },
+      { normalizedSynonyms: 'chateauneuf du pape' },
+    ]);
+  });
+
+  test('an un-curated appellation passes through verbatim — reviewed, never rejected', async () => {
+    Appellation.find.mockReturnValue(chain([]));
+    expect(await resolveCanonicalAppellation('Vin de Garage de Jean')).toBe('Vin de Garage de Jean');
+  });
+
+  test('two curated docs with the SAME display spelling still adopt it', async () => {
+    // Same name in two countries (the unique index is per-country).
+    Appellation.find.mockReturnValue(chain([{ name: 'Moscato' }, { name: 'Moscato' }]));
+    expect(await resolveCanonicalAppellation('moscato')).toBe('Moscato');
+  });
+
+  test('two curated docs that DISAGREE on spelling leave the input alone', async () => {
+    Appellation.find.mockReturnValue(chain([{ name: 'Moscato' }, { name: 'Moscatel' }]));
+    expect(await resolveCanonicalAppellation('moscato')).toBe('moscato');
+  });
+
+  test('empty input short-circuits without querying', async () => {
+    expect(await resolveCanonicalAppellation('')).toBe('');
+    expect(Appellation.find).not.toHaveBeenCalled();
+  });
+
+  test('a lookup failure keeps the input — a mint must not fail over taxonomy', async () => {
+    Appellation.find.mockImplementation(() => { throw new Error('db down'); });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await resolveCanonicalAppellation('Barolo')).toBe('Barolo');
+    warn.mockRestore();
+  });
+});

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -25,6 +25,7 @@ const { canonicalizeWineName } = require('../utils/producerPrefix');
 const { computeCanonicalKey, canonicalSiblingPrefix } = require('../utils/wineIdentity');
 const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
 const { resolveCanonicalProducerSpelling } = require('./producerSpelling');
+const { resolveCanonicalAppellation } = require('./appellationResolve');
 const { escapeRegex } = require('../utils/sanitize');
 
 // Auto-match when combined score >= SIMILARITY_THRESHOLD (near-identical — e.g.
@@ -168,7 +169,13 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // Canonicalize the appellation (strip a trailing DOCG/DOC/AOC/… tier) so
   // "Barolo" and "Barolo DOCG" resolve to / create ONE registry appellation
   // instead of two (ticket #2C). The tier belongs in classification.
-  const trimmedAppellation = normalizeAppellation((typeof appellation === 'string' ? appellation.trim() : '')).slice(0, MAX_FIELD);
+  // Then adopt the curated spelling when the Appellation taxonomy knows this
+  // one (strategy R2) — BEFORE key generation, so a synonym ("Chateauneuf du
+  // Pape") produces the same normalizedKey as the canonical form and the
+  // exact-match stage collapses them instead of minting a sibling.
+  const trimmedAppellation = await resolveCanonicalAppellation(
+    normalizeAppellation((typeof appellation === 'string' ? appellation.trim() : '')).slice(0, MAX_FIELD)
+  );
 
   // 0. Registry canon: the registry is vintage-neutral — a trailing year on
   // the name ("Reserve Cabernet Sauvignon 2023") belongs on the user's

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -164,8 +164,12 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // (full-document validation) and would make legacy rows that predate the cap
   // un-editable.
   const MAX_FIELD = 200;
-  let trimmedName = name.trim().slice(0, MAX_FIELD);
-  const trimmedProducer = producer.trim().slice(0, MAX_FIELD);
+  // Internal whitespace collapses too, not just the ends: a double space is
+  // invisible in every UI and every normalized key, so "Wrights  Estate" and
+  // "Wrights Estate" would otherwise coexist as two display spellings forever
+  // (found by the unify script's first prod-data dry run).
+  let trimmedName = name.trim().replace(/\s+/g, ' ').slice(0, MAX_FIELD);
+  const trimmedProducer = producer.trim().replace(/\s+/g, ' ').slice(0, MAX_FIELD);
   // Canonicalize the appellation (strip a trailing DOCG/DOC/AOC/… tier) so
   // "Barolo" and "Barolo DOCG" resolve to / create ONE registry appellation
   // instead of two (ticket #2C). The tier belongs in classification.

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -43,7 +43,7 @@ jest.mock('../models/Grape', () => {
   ctor.findOne = jest.fn();
   return ctor;
 });
-jest.mock('../models/Appellation', () => ({ exists: jest.fn() }));
+jest.mock('../models/Appellation', () => ({ exists: jest.fn(), find: jest.fn() }));
 jest.mock('./search', () => ({
   getIsAvailable: jest.fn(),
   search: jest.fn(),
@@ -146,6 +146,12 @@ beforeEach(() => {
   WineDefinition.findOne.mockReturnValue(findOneChain(null));
   // Producer-spelling adoption: default = producer is new to the registry
   WineDefinition.aggregate.mockResolvedValue([]);
+  // Appellation adoption: default = not curated → typed spelling kept
+  Appellation.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+    }),
+  });
   searchService.getIsAvailable.mockReturnValue(false);
   primeFind();
   scoreAllMatches.mockReturnValue([]);
@@ -646,6 +652,28 @@ describe('findOrCreateWine — creation', () => {
     const result = await findOrCreateWine(INPUT, USER_ID);
     expect(result.created).toBe(true);
     expect(WineDefinition.mock.calls[0][0].producer).toBe('Paul Avril');
+  });
+
+  // Strategy R2: a curated appellation's spelling is adopted BEFORE key
+  // generation, so a synonym produces the canonical normalizedKey and the
+  // exact-match stage collapses variants instead of minting siblings.
+  test('adopts the curated appellation spelling, and the keys follow it', async () => {
+    Appellation.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([{ name: 'Châteauneuf-du-Pape' }]) }),
+      }),
+    });
+    const result = await findOrCreateWine({ ...INPUT, appellation: 'Chateauneuf du Pape' }, USER_ID);
+    expect(result.created).toBe(true);
+    expect(WineDefinition.mock.calls[0][0].appellation).toBe('Châteauneuf-du-Pape');
+    // Same key as the canonical INPUT — the two spellings are ONE wine now.
+    expect(WineDefinition.mock.calls[0][0].normalizedKey).toBe(INPUT_KEY);
+  });
+
+  test('an un-curated appellation is stored verbatim — reviewed, never rejected', async () => {
+    const result = await findOrCreateWine({ ...INPUT, appellation: 'Völlig Neues Anbaugebiet' }, USER_ID);
+    expect(result.created).toBe(true);
+    expect(WineDefinition.mock.calls[0][0].appellation).toBe('Völlig Neues Anbaugebiet');
   });
 
   test('matchOnly: no match anywhere returns { noMatch: true } and creates NOTHING (registry-safe demo clone)', async () => {

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -91,6 +91,20 @@ const trimTrailingChars = (str, chars) => {
  *
  * Token-based + regex-free trailing strip, so it stays strictly linear.
  */
+/**
+ * The comparison KEY for appellation identity (strategy 2026-07-29 R2).
+ *
+ * normalizeString DELETES hyphens, so "Châteauneuf-du-Pape" folds to
+ * 'chateauneufdupape' while the typed "Chateauneuf du Pape" folds to
+ * 'chateauneuf du pape' — two keys for one place, found on the first
+ * prod-data test of the appellation resolver. Hyphens become spaces FIRST so
+ * both forms share one key. Appellation-specific on purpose: normalizedKey /
+ * canonicalKey semantics must not change (unique index + 4k existing keys),
+ * so this fold applies only where Appellation docs are matched.
+ */
+const normalizeAppellationKey = (appellation) =>
+  normalizeString(String(appellation == null ? '' : appellation).replace(/-/g, ' '));
+
 const normalizeAppellation = (appellation) => {
   if (appellation == null) return appellation;
   const original = String(appellation).trim();
@@ -722,6 +736,7 @@ module.exports = {
   GRAPE_SYNONYMS,
   normalizeProducerKey,
   normalizeAppellation,
+  normalizeAppellationKey,
   stripTrailingVintage,
   resolveGrapeName,
   resolveCountryName,

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -59,6 +59,11 @@ export const adminUndismissDuplicateCluster = (apiFetch, wineIds) =>
 export const adminGetCanonicalCollisions = (apiFetch) =>
   apiFetch('/api/admin/wines/canonical-collisions');
 
+// Distinct wine-appellation strings no curated Appellation doc covers —
+// the review queue that keeps free-text appellations honest.
+export const adminGetUnmatchedAppellations = (apiFetch) =>
+  apiFetch('/api/admin/taxonomy/appellations/unmatched');
+
 /** Merge one taxonomy doc into another. tab ∈ countries|regions|grapes. */
 export const adminMergeTaxonomy = (apiFetch, tab, fromId, toId) =>
   apiFetch(`/api/admin/taxonomy/${tab}/merge`, {

--- a/frontend/src/components/AppellationUnmatchedModal.js
+++ b/frontend/src/components/AppellationUnmatchedModal.js
@@ -1,0 +1,144 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import Modal from './Modal';
+import { adminGetUnmatchedAppellations, adminCreateTaxonomy } from '../api/admin';
+
+/**
+ * The appellation review queue (registry strategy 2026-07-29, R2).
+ *
+ * Wines carry appellations as free text; anything no curated Appellation doc
+ * covers surfaces here with the majority spelling, wine count and suggested
+ * country/region. "Add to taxonomy" promotes the row via the normal create
+ * endpoint — from then on the write-time resolver adopts this spelling and
+ * new variants stop forming. Unknown values are reviewed, never rejected:
+ * adding a bottle is never blocked by taxonomy, which is why this queue
+ * exists at all.
+ *
+ * The name is editable before promoting (the majority spelling of a rare
+ * appellation can itself be the typo); country is required by the schema.
+ * Styling matches its sibling review modals: generic classes + inline layout.
+ *
+ * Props: apiFetch (from useAuth()), countries (admin country list), onClose(),
+ * onPromoted() — refresh the appellations tab.
+ */
+function AppellationUnmatchedModal({ apiFetch, countries, onClose, onPromoted }) {
+  const { t } = useTranslation();
+  const [items, setItems] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [drafts, setDrafts] = useState({});      // normalized → { name, countryId }
+  const [pendingKey, setPendingKey] = useState(null);
+  const [rowErrors, setRowErrors] = useState({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await adminGetUnmatchedAppellations(apiFetch);
+      const data = await res.json();
+      if (res.ok) setItems(data.items || []);
+      else setError(data.error || t('admin.taxonomy.unmatched.loadError'));
+    } catch {
+      setError('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch, t]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const draftFor = (item) => drafts[item.normalized] || { name: item.name, countryId: item.countryId || '' };
+  const setDraft = (item, patch) =>
+    setDrafts(prev => ({ ...prev, [item.normalized]: { ...draftFor(item), ...patch } }));
+
+  const promote = async (item) => {
+    const d = draftFor(item);
+    if (!d.name?.trim() || !d.countryId) return;
+    setPendingKey(item.normalized);
+    setRowErrors(prev => ({ ...prev, [item.normalized]: null }));
+    try {
+      const res = await adminCreateTaxonomy(apiFetch, '/api/admin/taxonomy/appellations', {
+        name: d.name.trim(),
+        country: d.countryId,
+        // The suggested region only holds for the suggested country.
+        region: d.countryId === item.countryId ? item.regionId : null,
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setItems(prev => prev.filter(i => i.normalized !== item.normalized));
+        onPromoted?.();
+      } else {
+        setRowErrors(prev => ({ ...prev, [item.normalized]: data.error || t('admin.taxonomy.unmatched.promoteError') }));
+      }
+    } catch {
+      setRowErrors(prev => ({ ...prev, [item.normalized]: 'Network error' }));
+    } finally {
+      setPendingKey(null);
+    }
+  };
+
+  return (
+    <Modal title={t('admin.taxonomy.unmatched.title')} onClose={onClose} wide>
+      <p style={{ color: 'var(--color-text-muted)', fontSize: '0.85rem', marginTop: 0 }}>
+        {t('admin.taxonomy.unmatched.explainer')}
+      </p>
+
+      {error && <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>}
+
+      {loading || items === null ? (
+        <div className="loading">{t('common.loading')}</div>
+      ) : items.length === 0 ? (
+        <div className="empty-state"><p>{t('admin.taxonomy.unmatched.empty')}</p></div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {items.map(item => {
+            const d = draftFor(item);
+            return (
+              <div key={item.normalized} style={{ border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)', padding: '0.6rem 0.8rem' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                  <input
+                    type="text"
+                    value={d.name}
+                    onChange={(e) => setDraft(item, { name: e.target.value })}
+                    style={{ flex: '1 1 180px', minWidth: 140 }}
+                    aria-label={t('admin.taxonomy.appellationNameLabel')}
+                  />
+                  <select
+                    value={d.countryId}
+                    onChange={(e) => setDraft(item, { countryId: e.target.value })}
+                    style={{ flex: '0 1 170px' }}
+                    aria-label={t('admin.requests.countryLabel')}
+                  >
+                    <option value="">{t('admin.taxonomy.selectCountry')}</option>
+                    {countries.map(c => (
+                      <option key={c._id} value={c._id}>{c.name}</option>
+                    ))}
+                  </select>
+                  <span style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)', whiteSpace: 'nowrap' }}>
+                    {t('admin.taxonomy.wineCount', { count: item.wineCount })}
+                    {item.regionName && d.countryId === item.countryId && ` · ${item.regionName}`}
+                  </span>
+                  <button
+                    type="button"
+                    className="btn btn-primary btn-small"
+                    disabled={pendingKey === item.normalized || !d.name?.trim() || !d.countryId}
+                    onClick={() => promote(item)}
+                  >
+                    {pendingKey === item.normalized ? t('admin.taxonomy.unmatched.promoting') : t('admin.taxonomy.unmatched.promote')}
+                  </button>
+                </div>
+                {rowErrors[item.normalized] && (
+                  <div className="alert alert-error" style={{ marginTop: 6, fontSize: '0.8rem', padding: '0.35rem 0.5rem' }}>
+                    {rowErrors[item.normalized]}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+export default AppellationUnmatchedModal;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1349,7 +1349,19 @@
       "mergeTargetPlaceholder": "Choose the entry to keep…",
       "mergeHint": "Merge the low-count variant into the canonical one — the target is the entry that survives.",
       "mergeConfirm": "Merge",
-      "merging": "Merging…"
+      "merging": "Merging…",
+      "appellationSynonymsPlaceholder": "Chateauneuf du Pape, Châteauneuf du Pape",
+      "unmatched": {
+        "button": "Review unmatched",
+        "buttonTitle": "Appellation strings on wines that no taxonomy entry covers yet",
+        "title": "Unmatched appellations",
+        "explainer": "Wines carry these appellation strings, but no taxonomy entry covers them. Promote the real ones — new wines then adopt the canonical spelling automatically — and fix the wines behind the typos. Rare or new appellations are normal here; adding a bottle is never blocked by taxonomy.",
+        "empty": "Every appellation on every wine is covered by the taxonomy.",
+        "promote": "Add to taxonomy",
+        "promoting": "Adding…",
+        "promoteError": "Failed to add appellation",
+        "loadError": "Failed to load unmatched appellations"
+      }
     },
     "wines": {
       "title": "Admin: Wine Library",

--- a/frontend/src/pages/AdminTaxonomy.js
+++ b/frontend/src/pages/AdminTaxonomy.js
@@ -10,6 +10,7 @@ import GrapePicker from '../components/GrapePicker';
 import ConfirmModal from '../components/ConfirmModal';
 import Modal from '../components/Modal';
 import BottleSizesAdmin from '../components/BottleSizesAdmin';
+import AppellationUnmatchedModal from '../components/AppellationUnmatchedModal';
 import './AdminTaxonomy.css';
 
 function AdminTaxonomy() {
@@ -27,6 +28,7 @@ function AdminTaxonomy() {
   const [allRegions, setAllRegions] = useState([]); // for parent region / appellation dropdowns
   const [confirmDelete, setConfirmDelete] = useState(null); // id of item to delete
   const [mergeItem, setMergeItem] = useState(null);         // item being merged away
+  const [showUnmatched, setShowUnmatched] = useState(false); // appellation review queue
   const [mergeTarget, setMergeTarget] = useState('');       // toId
   const [merging, setMerging] = useState(false);
 
@@ -244,7 +246,8 @@ function AdminTaxonomy() {
       setFormData({
         name: item.name,
         country: countryId,
-        region: item.region?._id || item.region || ''
+        region: item.region?._id || item.region || '',
+        synonyms: (item.synonyms || []).join(', ')
       });
     }
   };
@@ -287,7 +290,8 @@ function AdminTaxonomy() {
       return {
         name: fd.name,
         country: fd.country,
-        region: fd.region || null
+        region: fd.region || null,
+        synonyms: fd.synonyms ? fd.synonyms.split(',').map(s => s.trim()).filter(Boolean) : []
       };
     }
     return fd;
@@ -586,6 +590,15 @@ function AdminTaxonomy() {
         </select>
       </div>
       <div className="form-group">
+        <label>{t('admin.taxonomy.synonymsLabel')}</label>
+        <input
+          type="text"
+          value={formData.synonyms || ''}
+          onChange={(e) => setFormData({ ...formData, synonyms: e.target.value })}
+          placeholder={t('admin.taxonomy.appellationSynonymsPlaceholder')}
+        />
+      </div>
+      <div className="form-group">
         <label>{t('admin.taxonomy.appellationRegionLabel')}</label>
         <select
           value={formData.region || ''}
@@ -651,9 +664,16 @@ function AdminTaxonomy() {
       <div className="page-header">
         <h1>{t('admin.taxonomy.title')}</h1>
         {!isEditing && !isBottleSizes && (
-          <button onClick={() => { setShowForm(!showForm); setFormData({}); }} className="btn btn-primary">
-            {showForm ? t('common.cancel') : addBtnLabel}
-          </button>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {activeTab === 'appellations' && (
+              <button onClick={() => setShowUnmatched(true)} className="btn btn-secondary" title={t('admin.taxonomy.unmatched.buttonTitle')}>
+                {t('admin.taxonomy.unmatched.button')}
+              </button>
+            )}
+            <button onClick={() => { setShowForm(!showForm); setFormData({}); }} className="btn btn-primary">
+              {showForm ? t('common.cancel') : addBtnLabel}
+            </button>
+          </div>
         )}
       </div>
 
@@ -753,6 +773,15 @@ function AdminTaxonomy() {
           warning={t('admin.taxonomy.deleteWarning', 'This action cannot be undone.')}
           onConfirm={() => handleDelete(confirmDelete)}
           onCancel={() => setConfirmDelete(null)}
+        />
+      )}
+
+      {showUnmatched && (
+        <AppellationUnmatchedModal
+          apiFetch={apiFetch}
+          countries={allCountries}
+          onClose={() => setShowUnmatched(false)}
+          onPromoted={fetchItems}
         />
       )}
 


### PR DESCRIPTION
Fourth PR of the registry-quality campaign (`REGISTRY_STRATEGY_2026-07-29.md`, item **R2** — the structural centerpiece).

## The problem

Appellations had *nothing*: a free string on the wine (1,077 distinct strings across ~4k wines), an `Appellation` collection wines never referenced, and no membership list — so `appellation_wrong` was the 2026-07-26 audit's largest category (231 rows), and rules had to parse grammar where they should test membership (the "Clairette de Die" false positive, #850: "Die" read as a German article instead of the Drôme town).

## The design: the Grape treatment, not the Country treatment

Countries are a closed set — unknown is rejected. Appellations are genuinely open-ended (new AVAs and DOCs appear; "Vin de France" and "Wine of Origin Western Cape" look wrong and aren't), so an unknown value is **reviewed, never rejected** — a user adding a bottle is never blocked by taxonomy. Three parts:

**1. Write-time adoption** (`services/appellationResolve.js`): the tier-stripped appellation is looked up by normalized name OR synonym; a curated match adopts the canonical display spelling **before key generation**, so "Chateauneuf du Pape" produces the same `normalizedKey` as "Châteauneuf-du-Pape" and the exact-match stage collapses them instead of minting a sibling. Cross-country name clashes (the per-country unique index allows them) adopt only when the curated spellings agree. Non-fatal by construction. `Appellation` gains `synonyms`/`normalizedSynonyms` with the same lockstep save-hook as `Grape`.

**2. Seeding** (`scripts/seed-appellations-from-wines.js`, dry-run default): promotes every normalized appellation string carried by **≥ 3 wines** (the same floor the public taxonomy pages use) into a curated doc — majority display spelling (ties → oldest, the same rule as producer unification), majority country, region only when one covers at least half the group's wines in that country. The long tail below the floor deliberately stays free text: the point is to canonize the clearly established, not to bless every typo. ⚠️ Before running on prod, cross-check the output against `REGISTRY_AUDIT_2026-07-26.md` §4's leave-alone list.

**3. Review queue** (`GET /api/admin/taxonomy/appellations/unmatched` + the AdminTaxonomy "Review unmatched" modal): every string no doc covers, with majority spelling, wine count, and suggested country/region. One click promotes it through the normal create endpoint — the name is editable first, because the majority spelling of a rare appellation can itself be the typo. A suggested region from a different country than the suggested one is dropped (schema would reject it). The appellation create/edit form gains a synonyms field.

Together with #856's weekly cron this closes the loop: new variants can't form (adoption), the established ones are curated (seed), the tail is visible (queue), and future rules can *test membership instead of parsing grammar* — the "de Die" class of false positive dies here.

## Testing

- New `appellationResolve.test.js` (6) — adoption by name and by synonym, verbatim pass-through, cross-country agree/disagree, empty short-circuit, non-fatal failure
- `findOrCreateWine.test.js` extended — synonym input produces the canonical `normalizedKey` (the collapse that matters), un-curated stored verbatim
- Full sweep: **1004 backend tests / 78 suites**, **801 frontend**, all green

## Prod notes

No compose/env impact. After deploy: run the seed script (dry-run first, review the list, then `--apply`). The write-time resolver is inert until docs exist, so the deploy order is safe either way.