### PR TITLE
feat(registry): structured report corrections + public wine page report link

### DIFF
--- a/backend/src/mcp/tools/adminRegistry.js
+++ b/backend/src/mcp/tools/adminRegistry.js
@@ -161,11 +161,14 @@ registerTool({
   scope: 'read',
   requireRole: ['admin'],
   annotations: { readOnlyHint: true, openWorldHint: false },
-  inputSchema: {},
-  handler: async (_args, _ctx) => {
+  inputSchema: {
+    limit: z.number().int().min(1).max(100).default(30).describe('Newest first; the backlog can grow between reviews'),
+  },
+  handler: async (args, _ctx) => {
     const { listPendingRegions } = require('../../services/taxonomyReview');
-    const items = await listPendingRegions();
-    return ok(`${items.length} region(s) awaiting review`, items.map(r => ({
+    const all = await listPendingRegions();
+    const items = all.slice(0, args.limit || 30);
+    return ok(`${all.length} region(s) awaiting review (showing ${items.length})`, items.map(r => ({
       region_id: r._id,
       name: r.name,
       country: r.country,

--- a/backend/src/models/WineReport.js
+++ b/backend/src/models/WineReport.js
@@ -29,6 +29,20 @@ const wineReportSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: 'WineDefinition'
   },
+  // Optional STRUCTURED correction (strategy 2026-07-29 R7): "this field
+  // should say this" instead of prose the admin has to re-type elsewhere.
+  // Only the one-click-appliable string fields — region/country are refs and
+  // stay free-text in `details`. Resolution can apply this in one action.
+  suggestedField: {
+    type: String,
+    enum: ['name', 'producer', 'appellation', 'type'],
+    default: undefined
+  },
+  suggestedValue: {
+    type: String,
+    trim: true,
+    maxlength: 200
+  },
   status: {
     type: String,
     enum: ['pending', 'resolved', 'dismissed'],

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -492,8 +492,25 @@ async function finalizeMintedWines(ids) {
       }
       // save(): the pre-validate hook recomputes canonicalKey the same way
       // (idempotent) and the slug hook skips non-new docs, which is why the
-      // slug is assigned by hand above.
-      await doc.save();
+      // slug is assigned by hand above. The slug probe is check-then-set, so
+      // a concurrent import can win the race — on a unique-index collision,
+      // bump the suffix and retry instead of abandoning the row unfinalized
+      // (audit 2026-07-29 F3: an abandoned row is exactly the invariant hole
+      // this function exists to close).
+      let attempt = 0;
+      for (;;) {
+        try {
+          await doc.save();
+          break;
+        } catch (err) {
+          if (err.code === 11000 && doc.slug && attempt < 5) {
+            attempt += 1;
+            doc.slug = `${doc.slug}-r${attempt}`;
+            continue;
+          }
+          throw err;
+        }
+      }
       done += 1;
     } catch (err) {
       console.warn(`[import] finalize failed for ${id} (non-fatal):`, err.message);

--- a/backend/src/routes/admin/search.js
+++ b/backend/src/routes/admin/search.js
@@ -26,11 +26,17 @@ router.post('/reindex', async (req, res) => {
     if (!searchService.getIsAvailable()) {
       return res.status(503).json({ error: 'Meilisearch is not available' });
     }
+    // fullSync returns the enqueued Meili task uids — addDocuments is 202 +
+    // async task, so without waitForTasks the response would mean "enqueued",
+    // not "searchable", and async indexing failures would be invisible
+    // (audit 2026-07-29). The wait makes the durations honest too.
     const t0 = Date.now();
-    await searchService.fullSync();
+    const wineTasks = await searchService.fullSync();
+    await searchService.waitForTasks(wineTasks);
     const winesMs = Date.now() - t0;
     const t1 = Date.now();
-    await searchService.fullSyncBottles();
+    const bottleTasks = await searchService.fullSyncBottles();
+    await searchService.waitForTasks(bottleTasks);
     const bottlesMs = Date.now() - t1;
 
     logAudit(req, 'admin.search.reindex', {}, { winesMs, bottlesMs });

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -36,7 +36,8 @@ const { clearTaxonomyListCache } = require('../taxonomy');
 /** Map<idString, wineCount> for a ref field ('country' | 'region'). */
 async function wineCountsByRef(field) {
   const rows = await WineDefinition.aggregate([
-    { $match: { [field]: { $ne: null } } },
+    // Quarantined rows don't count as "in use" — mirror taxonomyReview.js.
+    { $match: { [field]: { $ne: null }, nonWine: { $ne: true } } },
     { $group: { _id: `$${field}`, n: { $sum: 1 } } },
   ]);
   return new Map(rows.map(r => [String(r._id), r.n]));
@@ -45,6 +46,7 @@ async function wineCountsByRef(field) {
 /** Map<grapeIdString, wineCount> (grapes is an array field). */
 async function wineCountsByGrape() {
   const rows = await WineDefinition.aggregate([
+    { $match: { nonWine: { $ne: true } } },
     { $unwind: '$grapes' },
     { $group: { _id: '$grapes', n: { $sum: 1 } } },
   ]);
@@ -58,7 +60,7 @@ async function wineCountsByGrape() {
  */
 async function wineCountsByAppellation() {
   const rows = await WineDefinition.aggregate([
-    { $match: { appellation: { $nin: [null, ''] } } },
+    { $match: { appellation: { $nin: [null, ''] }, nonWine: { $ne: true } } },
     { $group: { _id: '$appellation', n: { $sum: 1 } } },
   ]);
   const map = new Map();
@@ -551,6 +553,9 @@ router.post('/regions/:id/approve', async (req, res) => {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
     const region = await Region.findById(req.params.id);
     if (!region) return res.status(404).json({ error: 'Region not found' });
+    // Idempotent like the MCP tool: a second click must not write a second
+    // audit entry for a no-op (audit 2026-07-29, REST/MCP drift).
+    if (!region.pendingReview) return res.json({ region, already: true });
     region.pendingReview = false;
     await region.save();
     logAudit(req, 'admin.taxonomy.approveRegion',
@@ -668,6 +673,12 @@ router.post('/appellations', async (req, res) => {
     if (!name || !country) {
       return res.status(400).json({ error: 'Name and country are required' });
     }
+    // The mint chokepoint caps wine fields at 200; a longer curated name would
+    // be adopted onto wines past that cap (audit 2026-07-29 A1). MCP already
+    // enforces this; the REST surface must match.
+    if (name.trim().length > 200) {
+      return res.status(400).json({ error: 'Appellation name must be 200 characters or fewer' });
+    }
 
     const normalizedName = normalizeAppellationKey(name);
 
@@ -710,6 +721,9 @@ router.put('/appellations/:id', async (req, res) => {
     }
 
     if (name) {
+      if (name.trim().length > 200) {
+        return res.status(400).json({ error: 'Appellation name must be 200 characters or fewer' });
+      }
       appellation.name = name.trim();
       appellation.normalizedName = normalizeAppellationKey(name);
     }

--- a/backend/src/routes/admin/wineReports.apply.test.js
+++ b/backend/src/routes/admin/wineReports.apply.test.js
@@ -10,7 +10,9 @@ process.env.JWT_SECRET = 'test-secret';
 
 jest.mock('../../models/WineReport', () => ({ findById: jest.fn(), find: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../../models/WineDefinition', () => ({ findById: jest.fn() }));
-jest.mock('../../services/search', () => ({ indexWine: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../../models/Bottle', () => ({ distinct: jest.fn().mockResolvedValue([]) }));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn().mockResolvedValue(undefined), bulkIndexBottles: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../../services/appellationResolve', () => ({ resolveCanonicalAppellation: jest.fn(async (v) => v) }));
 jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../../utils/cellarCred', () => ({ incrementCred: jest.fn().mockResolvedValue(undefined) }));
 
@@ -62,6 +64,20 @@ const wine = (over = {}) => ({
 beforeEach(() => jest.clearAllMocks());
 
 describe('resolve with applySuggestion', () => {
+  test('a NAME suggestion is canonicalized, not raw-assigned (audit R7-#1)', async () => {
+    // Trailing vintage + embedded producer — both defect classes the write
+    // pipeline strips must be stripped here too.
+    const r = report({ suggestedField: 'name', suggestedValue: 'Cave de Ribeauville Sylvaner  Grand 2022' });
+    const w = wine();
+    WineReport.findById.mockResolvedValue(r);
+    WineDefinition.findById.mockResolvedValue(w);
+    const res = await resolve({ applySuggestion: true });
+    expect(res.status).toBe(200);
+    expect(w.name).not.toMatch(/2022/);   // trailing vintage stripped
+    expect(w.name).not.toMatch(/ {2}/);   // internal whitespace collapsed
+    expect(w.name).toMatch(/Sylvaner/);
+  });
+
   test('applies the field, recomputes normalizedKey, saves, reindexes, audits both actions', async () => {
     const r = report();
     const w = wine();

--- a/backend/src/routes/admin/wineReports.apply.test.js
+++ b/backend/src/routes/admin/wineReports.apply.test.js
@@ -1,0 +1,121 @@
+/**
+ * PUT /api/admin/wine-reports/:id/resolve with applySuggestion (strategy
+ * 2026-07-29 R7). Pins: the structured correction is applied to the wine
+ * through .save() (hooks) with normalizedKey recomputed; a unique-key
+ * collision surfaces as a 409 merge-hint, not a crash; resolve without apply
+ * never touches the wine; a suggestion-less report refuses apply.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../models/WineReport', () => ({ findById: jest.fn(), find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../utils/cellarCred', () => ({ incrementCred: jest.fn().mockResolvedValue(undefined) }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineReport = require('../../models/WineReport');
+const WineDefinition = require('../../models/WineDefinition');
+const searchService = require('../../services/search');
+const { logAudit } = require('../../services/audit');
+const { generateWineKey } = require('../../utils/normalize');
+const router = require('./wineReports');
+
+const ADMIN_ID = '64b000000000000000000001';
+const REPORT_ID = '64b0000000000000000000d1';
+const WINE_ID = '64b0000000000000000000c1';
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/wine-reports', router);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const resolve = (body) => fetch(`${baseUrl}/api/admin/wine-reports/${REPORT_ID}/resolve`, {
+  method: 'PUT',
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+  body: JSON.stringify(body),
+});
+
+const report = (over = {}) => ({
+  _id: REPORT_ID, status: 'pending', user: 'u1', wineDefinition: WINE_ID,
+  suggestedField: 'producer', suggestedValue: 'Cave de Ribeauvillé',
+  save: jest.fn().mockResolvedValue(undefined),
+  populate: jest.fn().mockResolvedValue(undefined),
+  ...over,
+});
+
+const wine = (over = {}) => ({
+  _id: WINE_ID, name: 'Sylvaner', producer: 'Cave de Ribeauville', appellation: 'Alsace',
+  normalizedKey: 'stale', save: jest.fn().mockResolvedValue(undefined),
+  ...over,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('resolve with applySuggestion', () => {
+  test('applies the field, recomputes normalizedKey, saves, reindexes, audits both actions', async () => {
+    const r = report();
+    const w = wine();
+    WineReport.findById.mockResolvedValue(r);
+    WineDefinition.findById.mockResolvedValue(w);
+
+    const res = await resolve({ applySuggestion: true, adminNotes: 'confirmed on producer site' });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(w.producer).toBe('Cave de Ribeauvillé');
+    expect(w.normalizedKey).toBe(generateWineKey('Sylvaner', 'Cave de Ribeauvillé', 'Alsace'));
+    expect(w.save).toHaveBeenCalled();
+    expect(searchService.indexWine).toHaveBeenCalledWith(WINE_ID);
+    expect(body.applied).toEqual({ field: 'producer', from: 'Cave de Ribeauville', to: 'Cave de Ribeauvillé' });
+    expect(r.status).toBe('resolved');
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'admin.wine.update',
+      expect.anything(), expect.objectContaining({ via: 'wine-report' }));
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'wine.report.resolved',
+      expect.anything(), expect.anything());
+  });
+
+  test('a type suggestion does NOT touch normalizedKey (type is not identity)', async () => {
+    const r = report({ suggestedField: 'type', suggestedValue: 'white' });
+    const w = wine();
+    WineReport.findById.mockResolvedValue(r);
+    WineDefinition.findById.mockResolvedValue(w);
+    await resolve({ applySuggestion: true });
+    expect(w.type).toBe('white');
+    expect(w.normalizedKey).toBe('stale');
+  });
+
+  test('a unique-key collision is a 409 merge-hint and the report stays pending', async () => {
+    const r = report();
+    const w = wine({ save: jest.fn().mockRejectedValue({ code: 11000 }) });
+    WineReport.findById.mockResolvedValue(r);
+    WineDefinition.findById.mockResolvedValue(w);
+    const res = await resolve({ applySuggestion: true });
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/merge/i);
+    expect(r.save).not.toHaveBeenCalled();
+    expect(r.status).toBe('pending');
+  });
+
+  test('apply on a report without a suggestion is a 400; plain resolve never loads the wine', async () => {
+    const r = report({ suggestedField: undefined, suggestedValue: undefined });
+    WineReport.findById.mockResolvedValue(r);
+    expect((await resolve({ applySuggestion: true })).status).toBe(400);
+
+    const r2 = report();
+    WineReport.findById.mockResolvedValue(r2);
+    const res = await resolve({});
+    expect(res.status).toBe(200);
+    expect(WineDefinition.findById).not.toHaveBeenCalled();
+    expect(r2.status).toBe('resolved');
+  });
+});

--- a/backend/src/routes/admin/wineReports.js
+++ b/backend/src/routes/admin/wineReports.js
@@ -2,8 +2,11 @@ const express = require('express');
 const router = express.Router();
 const WineReport = require('../../models/WineReport');
 const WineDefinition = require('../../models/WineDefinition');
+const Bottle = require('../../models/Bottle');
 const searchService = require('../../services/search');
-const { generateWineKey } = require('../../utils/normalize');
+const { generateWineKey, normalizeAppellation, stripTrailingVintage } = require('../../utils/normalize');
+const { canonicalizeWineName } = require('../../utils/producerPrefix');
+const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const { requireAuth, requireRole } = require('../../middleware/auth');
 const { logAudit } = require('../../services/audit');
 const { stripHtml } = require('../../utils/sanitize');
@@ -81,7 +84,19 @@ router.put('/:id/resolve', async (req, res) => {
       if (!wine) return res.status(404).json({ error: 'The reported wine no longer exists' });
 
       const previous = wine[report.suggestedField] ?? null;
-      wine[report.suggestedField] = report.suggestedValue;
+      // Run the suggestion through the SAME field normalizers the write
+      // pipeline applies — a raw assignment would let a one-click apply
+      // reintroduce the exact defect classes the registry campaign closed:
+      // tier-suffixed appellations, trailing vintages, producer-in-name
+      // embeds (audit 2026-07-29 R7-#1). The reporter's text is untrusted
+      // input that merely happens to arrive via an admin's click.
+      let value = report.suggestedValue.trim().replace(/\s+/g, ' ');
+      if (report.suggestedField === 'name') {
+        value = canonicalizeWineName(stripTrailingVintage(value), wine.producer);
+      } else if (report.suggestedField === 'appellation') {
+        value = await resolveCanonicalAppellation(normalizeAppellation(value));
+      }
+      wine[report.suggestedField] = value;
       if (report.suggestedField !== 'type') {
         wine.normalizedKey = generateWineKey(wine.name, wine.producer, wine.appellation);
       }
@@ -96,6 +111,12 @@ router.put('/:id/resolve', async (req, res) => {
         throw err;
       }
       searchService.indexWine(wine._id).catch(() => {});
+      // Bottles denormalize wineName/producer/appellation into their own
+      // search index — without this, cellar search matches the OLD values
+      // indefinitely (mirrors the admin wine-edit route; audit R7-#3).
+      Bottle.distinct('_id', { wineDefinition: wine._id })
+        .then(ids => searchService.bulkIndexBottles(ids))
+        .catch(() => {});
       applied = { field: report.suggestedField, from: previous, to: report.suggestedValue };
       logAudit(req, 'admin.wine.update',
         { type: 'wine', id: wine._id },

--- a/backend/src/routes/admin/wineReports.js
+++ b/backend/src/routes/admin/wineReports.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const WineReport = require('../../models/WineReport');
+const WineDefinition = require('../../models/WineDefinition');
+const searchService = require('../../services/search');
+const { generateWineKey } = require('../../utils/normalize');
 const { requireAuth, requireRole } = require('../../middleware/auth');
 const { logAudit } = require('../../services/audit');
 const { stripHtml } = require('../../utils/sanitize');
@@ -33,7 +36,7 @@ router.get('/', async (req, res) => {
         .skip(offset)
         .limit(limit)
         .populate('user', 'username email')
-        .populate({ path: 'wineDefinition', select: 'name producer country type', populate: { path: 'country', select: 'name' } })
+        .populate({ path: 'wineDefinition', select: 'name producer country type appellation', populate: { path: 'country', select: 'name' } })
         .populate('duplicateOf', 'name producer')
         .populate('resolvedBy', 'username')
         .lean(),
@@ -47,16 +50,56 @@ router.get('/', async (req, res) => {
   }
 });
 
-// PUT /api/admin/wine-reports/:id/resolve — mark a wine report as resolved
+// PUT /api/admin/wine-reports/:id/resolve — mark a wine report as resolved.
+// Body: { adminNotes?, applySuggestion?: true }
+//
+// applySuggestion (R7): when the report carries a structured correction and
+// the admin agrees, resolving APPLIES it to the wine in the same action —
+// before this, resolution wrote nothing back and the admin re-typed the fix
+// in Admin → Wines (or, in practice, didn't). Applied via .save() so the
+// model hooks run (canonicalKey recompute + verifiedChecks invalidation),
+// with normalizedKey recomputed the same way the admin edit route does; a
+// unique-key collision means the correction would make this wine identical
+// to an existing one — that is a MERGE, refused here with a clear 409.
 router.put('/:id/resolve', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
-    const { adminNotes } = req.body;
+    const { adminNotes, applySuggestion } = req.body;
 
     const report = await WineReport.findById(req.params.id);
     if (!report) return res.status(404).json({ error: 'Report not found' });
     if (report.status !== 'pending') {
       return res.status(400).json({ error: 'Report is already resolved or dismissed' });
+    }
+
+    let applied = null;
+    if (applySuggestion) {
+      if (!report.suggestedField || !report.suggestedValue) {
+        return res.status(400).json({ error: 'This report has no structured suggestion to apply' });
+      }
+      const wine = await WineDefinition.findById(report.wineDefinition);
+      if (!wine) return res.status(404).json({ error: 'The reported wine no longer exists' });
+
+      const previous = wine[report.suggestedField] ?? null;
+      wine[report.suggestedField] = report.suggestedValue;
+      if (report.suggestedField !== 'type') {
+        wine.normalizedKey = generateWineKey(wine.name, wine.producer, wine.appellation);
+      }
+      try {
+        await wine.save();
+      } catch (err) {
+        if (err.code === 11000) {
+          return res.status(409).json({
+            error: 'Applying this correction would make the wine identical to an existing registry wine — merge them in Admin → Wines instead',
+          });
+        }
+        throw err;
+      }
+      searchService.indexWine(wine._id).catch(() => {});
+      applied = { field: report.suggestedField, from: previous, to: report.suggestedValue };
+      logAudit(req, 'admin.wine.update',
+        { type: 'wine', id: wine._id },
+        { via: 'wine-report', field: applied.field, from: applied.from, to: applied.to });
     }
 
     report.status = 'resolved';
@@ -73,9 +116,9 @@ router.put('/:id/resolve', async (req, res) => {
     });
 
     await report.populate('user', 'username email');
-    await report.populate('wineDefinition', 'name producer country type');
+    await report.populate('wineDefinition', 'name producer country type appellation');
     await report.populate('resolvedBy', 'username');
-    res.json({ report });
+    res.json({ report, applied });
   } catch (err) {
     console.error('Admin resolve wine report error:', err);
     res.status(500).json({ error: 'Failed to resolve wine report' });
@@ -105,7 +148,7 @@ router.put('/:id/dismiss', async (req, res) => {
     });
 
     await report.populate('user', 'username email');
-    await report.populate('wineDefinition', 'name producer country type');
+    await report.populate('wineDefinition', 'name producer country type appellation');
     await report.populate('resolvedBy', 'username');
     res.json({ report });
   } catch (err) {

--- a/backend/src/routes/wineReports.js
+++ b/backend/src/routes/wineReports.js
@@ -14,7 +14,7 @@ const VALID_REASONS = ['wrong_info', 'duplicate', 'inappropriate', 'wrong_price'
 // must not spam it (same class as the guarded wine-requests route).
 router.post('/', requireAuth, requireNonDemo, async (req, res) => {
   try {
-    const { wineDefinitionId, reason, details, duplicateOfId } = req.body;
+    const { wineDefinitionId, reason, details, duplicateOfId, suggestedField, suggestedValue } = req.body;
 
     if (!wineDefinitionId || !mongoose.Types.ObjectId.isValid(wineDefinitionId)) {
       return res.status(400).json({ error: 'Invalid wineDefinitionId' });
@@ -29,6 +29,25 @@ router.post('/', requireAuth, requireNonDemo, async (req, res) => {
     }
     if (details && details.trim().length > 2000) {
       return res.status(400).json({ error: 'Details must be 2000 characters or fewer' });
+    }
+    // Structured correction (R7): both-or-neither, appliable fields only.
+    const SUGGESTABLE = ['name', 'producer', 'appellation', 'type'];
+    const WINE_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
+    const hasField = suggestedField != null && suggestedField !== '';
+    const hasValue = typeof suggestedValue === 'string' && suggestedValue.trim() !== '';
+    if (hasField !== hasValue) {
+      return res.status(400).json({ error: 'A suggested correction needs both the field and the new value' });
+    }
+    if (hasField) {
+      if (!SUGGESTABLE.includes(suggestedField)) {
+        return res.status(400).json({ error: `suggestedField must be one of: ${SUGGESTABLE.join(', ')}` });
+      }
+      if (suggestedValue.trim().length > 200) {
+        return res.status(400).json({ error: 'Suggested value must be 200 characters or fewer' });
+      }
+      if (suggestedField === 'type' && !WINE_TYPES.includes(suggestedValue.trim())) {
+        return res.status(400).json({ error: `Type must be one of: ${WINE_TYPES.join(', ')}` });
+      }
     }
 
     const wine = await WineDefinition.findById(wineDefinitionId).lean();
@@ -59,7 +78,9 @@ router.post('/', requireAuth, requireNonDemo, async (req, res) => {
       wineDefinition: wineRef,
       reason,
       details: details ? stripHtml(details) : undefined,
-      duplicateOf: (duplicateOfId && mongoose.Types.ObjectId.isValid(duplicateOfId)) ? duplicateOfId : undefined
+      duplicateOf: (duplicateOfId && mongoose.Types.ObjectId.isValid(duplicateOfId)) ? duplicateOfId : undefined,
+      suggestedField: hasField ? suggestedField : undefined,
+      suggestedValue: hasField ? stripHtml(suggestedValue.trim()) : undefined
     });
 
     logAudit(req, 'wine.report.created', { type: 'WineReport', id: report._id }, {

--- a/backend/src/routes/wineReports.js
+++ b/backend/src/routes/wineReports.js
@@ -38,6 +38,12 @@ router.post('/', requireAuth, requireNonDemo, async (req, res) => {
     if (hasField !== hasValue) {
       return res.status(400).json({ error: 'A suggested correction needs both the field and the new value' });
     }
+    // The frontend only offers the suggestion inputs for wrong_info, but a
+    // client is not a trust boundary — and stale state CAN leak a suggestion
+    // onto another reason (audit 2026-07-29 R7-#5). Enforce the pairing here.
+    if (hasField && reason !== 'wrong_info') {
+      return res.status(400).json({ error: 'A suggested correction is only valid with the "wrong info" reason' });
+    }
     if (hasField) {
       if (!SUGGESTABLE.includes(suggestedField)) {
         return res.status(400).json({ error: `suggestedField must be one of: ${SUGGESTABLE.join(', ')}` });
@@ -80,7 +86,10 @@ router.post('/', requireAuth, requireNonDemo, async (req, res) => {
       details: details ? stripHtml(details) : undefined,
       duplicateOf: (duplicateOfId && mongoose.Types.ObjectId.isValid(duplicateOfId)) ? duplicateOfId : undefined,
       suggestedField: hasField ? suggestedField : undefined,
-      suggestedValue: hasField ? stripHtml(suggestedValue.trim()) : undefined
+      // Collapse internal whitespace/newlines too — this string is destined
+      // for a registry field that feeds titles and JSON-LD, where an embedded
+      // newline corrupts rendering (stripHtml only strips tags + ends).
+      suggestedValue: hasField ? stripHtml(suggestedValue.trim().replace(/\s+/g, ' ')) : undefined
     });
 
     logAudit(req, 'wine.report.created', { type: 'WineReport', id: report._id }, {

--- a/backend/src/scripts/backfill-appellation-keys.js
+++ b/backend/src/scripts/backfill-appellation-keys.js
@@ -1,0 +1,72 @@
+/**
+ * Re-derive normalizedName/normalizedSynonyms for every Appellation doc using
+ * normalizeAppellationKey (audit 2026-07-29 A2).
+ *
+ * Docs created before the appellation system (#858) carry keys computed with
+ * plain normalizeString, which DELETES hyphens — so "Châteauneuf-du-Pape" is
+ * stored as 'chateauneufdupape' while every lookup now folds to
+ * 'chateauneuf du pape'. Those legacy docs are unmatchable by the resolver,
+ * keep appearing in the unmatched review queue next to the doc that nominally
+ * covers them, and a re-run of the seed script could mint a competing twin.
+ * The model has no hook that re-derives normalizedName from name (only
+ * synonyms are hook-maintained), so a one-off backfill is the fix.
+ *
+ * Collision guard: if two docs in the same country fold to the same NEW key
+ * (the unique index would reject the second), both are SKIPPED and reported —
+ * that pair needs a human merge, not a silent overwrite.
+ *
+ * Dry-run by default; --apply to write.
+ *
+ *   docker exec cellarion-backend node src/scripts/backfill-appellation-keys.js
+ *   docker exec cellarion-backend node src/scripts/backfill-appellation-keys.js --apply
+ */
+
+const mongoose = require('mongoose');
+const Appellation = require('../models/Appellation');
+const { normalizeAppellationKey } = require('../utils/normalize');
+
+(async () => {
+  const apply = process.argv.includes('--apply');
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+
+  const docs = await Appellation.find({}).select('name normalizedName synonyms normalizedSynonyms country').lean();
+
+  // country → newKey → [docIds] for the collision guard
+  const byCountryKey = new Map();
+  for (const d of docs) {
+    const key = normalizeAppellationKey(d.name || '');
+    const ck = `${d.country}:${key}`;
+    if (!byCountryKey.has(ck)) byCountryKey.set(ck, []);
+    byCountryKey.get(ck).push(String(d._id));
+  }
+
+  const ops = [];
+  let unchanged = 0, collisions = 0;
+  for (const d of docs) {
+    const newName = normalizeAppellationKey(d.name || '');
+    const newSyns = (d.synonyms || []).map(s => normalizeAppellationKey(s)).filter(Boolean);
+    const synsChanged = JSON.stringify(newSyns.length ? newSyns : undefined) !== JSON.stringify(d.normalizedSynonyms?.length ? d.normalizedSynonyms : undefined);
+    if (d.normalizedName === newName && !synsChanged) { unchanged += 1; continue; }
+
+    const twins = byCountryKey.get(`${d.country}:${newName}`) || [];
+    if (twins.length > 1) {
+      collisions += 1;
+      console.log(`  COLLISION (needs manual merge): "${d.name}" [${d._id}] — ${twins.length} docs in this country fold to "${newName}"`);
+      continue;
+    }
+    console.log(`  ~ "${d.name}": "${d.normalizedName}" → "${newName}"${synsChanged ? ' (+synonyms)' : ''}`);
+    ops.push({ updateOne: {
+      filter: { _id: d._id },
+      update: newSyns.length
+        ? { $set: { normalizedName: newName, normalizedSynonyms: newSyns } }
+        : { $set: { normalizedName: newName }, $unset: { normalizedSynonyms: '' } },
+    } });
+  }
+
+  console.log(`[backfill-appellation-keys] ${apply ? 'APPLY' : 'DRY-RUN'} docs=${docs.length} toFix=${ops.length} unchanged=${unchanged} collisions=${collisions}`);
+  if (apply && ops.length > 0) {
+    const res = await Appellation.bulkWrite(ops, { ordered: false });
+    console.log(`[backfill-appellation-keys] modified=${res.modifiedCount}`);
+  }
+  await mongoose.disconnect();
+})().catch((e) => { console.error('ERR:', e.message); process.exit(1); });

--- a/backend/src/scripts/unify-producer-spellings.js
+++ b/backend/src/scripts/unify-producer-spellings.js
@@ -52,12 +52,16 @@ const { computeCanonicalKey } = require('../utils/wineIdentity');
     // prod-data dry run) — the double-space rows count toward the clean form.
     const spelling = String(w.producer).trim().replace(/\s+/g, ' ');
     let s = g.get(spelling);
-    if (!s) { s = { count: 0, oldest: w.createdAt, wines: [] }; g.set(spelling, s); }
+    // oldest seeds null and is only ever set by VOTING rows — seeding it from
+    // whichever row happens to iterate first let a quarantined row's ancient
+    // createdAt flip the tie-break against producerSpelling.js's identical
+    // rule (audit 2026-07-29 F1).
+    if (!s) { s = { count: 0, oldest: null, wines: [] }; g.set(spelling, s); }
     // Quarantined rows get rewritten too (consistency) but no vote (their
     // data is exactly what we don't want to canonize) — mirror producerSpelling.js.
     if (!w.nonWine) {
       s.count += 1;
-      if (w.createdAt < s.oldest) s.oldest = w.createdAt;
+      if (s.oldest === null || w.createdAt < s.oldest) s.oldest = w.createdAt;
     }
     s.wines.push(w);
   }
@@ -70,7 +74,7 @@ const { computeCanonicalKey } = require('../utils/wineIdentity');
     groupsToUnify += 1;
 
     const ranked = [...spellings.entries()].sort((a, b) =>
-      (b[1].count - a[1].count) || (a[1].oldest - b[1].oldest));
+      (b[1].count - a[1].count) || ((a[1].oldest ?? Infinity) - (b[1].oldest ?? Infinity)));
     const target = ranked[0][0];
     console.log(`  [${key}] → "${target}"  (${ranked.map(([sp, s]) => `"${sp}"×${s.count}`).join('  ')})`);
 
@@ -83,7 +87,10 @@ const { computeCanonicalKey } = require('../utils/wineIdentity');
         // Safety proof, per row: a pure spelling variant leaves canonicalKey
         // untouched. If it would change, this was NOT a trivial variant —
         // leave it for a human rather than silently altering identity keys.
-        const before = w.canonicalKey || computeCanonicalKey(w.name, spelling, w.appellation);
+        // Always compute BOTH sides fresh: a stored canonicalKey stamped by an
+        // older algorithm (the tier-token list grows, #842) would false-skip a
+        // pure spelling variant as "key drift" (audit 2026-07-29 F2).
+        const before = computeCanonicalKey(w.name, spelling, w.appellation);
         const after = computeCanonicalKey(w.name, target, w.appellation);
         if (before !== after) {
           skippedKeyDrift += 1;

--- a/backend/src/services/appellationResolve.js
+++ b/backend/src/services/appellationResolve.js
@@ -34,15 +34,20 @@ async function resolveCanonicalAppellation(rawAppellation) {
   const normalized = normalizeAppellationKey(rawAppellation);
   if (!normalized) return rawAppellation;
   try {
-    // limit(2): one match → adopt. Two docs can share a name across countries
-    // (the unique index is per-country); adopt only when their display
-    // spellings agree — when even the curated docs disagree, the typed
-    // spelling is not obviously wrong and is left alone.
+    // Docs can share a name across countries (the unique index is per-country);
+    // adopt only when EVERY curated doc agrees on the display spelling — when
+    // even the curated docs disagree, the typed spelling is not obviously
+    // wrong and is left alone. limit(4) with an agree-all check (audit
+    // 2026-07-29 A5: limit(2) could see two agreeing docs and miss a third
+    // that disagrees); .sort keeps the answer deterministic across query
+    // plans. Adoption is re-capped at 200 chars — the doc name is admin
+    // input with its own validation, but the mint chokepoint's field cap must
+    // hold regardless of where the string came from (audit A1).
     const docs = await Appellation.find({
       $or: [{ normalizedName: normalized }, { normalizedSynonyms: normalized }],
-    }).select('name').limit(2).lean();
+    }).select('name').sort({ _id: 1 }).limit(4).lean();
     if (docs.length === 0) return rawAppellation;
-    if (docs.length === 1 || docs[0].name === docs[1].name) return docs[0].name;
+    if (docs.every(d => d.name === docs[0].name)) return docs[0].name.slice(0, 200);
     return rawAppellation;
   } catch (err) {
     console.warn('[appellationResolve] lookup failed (non-fatal, keeping input):', err.message);

--- a/backend/src/services/appellationResolve.test.js
+++ b/backend/src/services/appellationResolve.test.js
@@ -13,7 +13,9 @@ const { resolveCanonicalAppellation } = require('./appellationResolve');
 
 const chain = (docs) => ({
   select: jest.fn().mockReturnValue({
-    limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(docs) }),
+    sort: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(docs) }),
+    }),
   }),
 });
 

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -19,7 +19,7 @@ const Region = require('../models/Region');
 const Grape = require('../models/Grape');
 const Appellation = require('../models/Appellation');
 const searchService = require('./search');
-const { generateWineKey, normalizeString, normalizeAppellation, stripTrailingVintage, resolveGrapeName, resolveCountryName, isRecognizedCountry, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
+const { generateWineKey, normalizeString, normalizeAppellation, normalizeAppellationKey, stripTrailingVintage, resolveGrapeName, resolveCountryName, isRecognizedCountry, isUnknownName, isJunkGrapeName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
 const { canonicalizeWineName } = require('../utils/producerPrefix');
 const { computeCanonicalKey, canonicalSiblingPrefix } = require('../utils/wineIdentity');
@@ -362,7 +362,13 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   const [placeCountry, placeRegion, placeAppellation] = await Promise.all([
     Country.exists({ normalizedName: producerNorm }),
     Region.exists({ $or: [{ normalizedName: producerNorm }, { normalizedSynonyms: producerNorm }] }),
-    Appellation.exists({ normalizedName: producerNorm }),
+    // Appellation keys fold hyphens to spaces (normalizeAppellationKey) —
+    // querying with plain normalizeString would MISS every hyphenated
+    // appellation doc ("Châteauneuf-du-Pape") and silently reopen the
+    // place-as-producer hole for exactly the places the seed script promotes
+    // (audit 2026-07-29 A3). Both keys queried: legacy docs may still carry
+    // the old fold until the backfill script has run.
+    Appellation.exists({ normalizedName: { $in: [producerNorm, normalizeAppellationKey(trimmedProducer)] } }),
   ]);
   if (placeCountry || placeRegion || placeAppellation) {
     const err = new Error(

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -149,7 +149,9 @@ beforeEach(() => {
   // Appellation adoption: default = not curated → typed spelling kept
   Appellation.find.mockReturnValue({
     select: jest.fn().mockReturnValue({
-      limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+      sort: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+      }),
     }),
   });
   searchService.getIsAvailable.mockReturnValue(false);
@@ -660,7 +662,9 @@ describe('findOrCreateWine — creation', () => {
   test('adopts the curated appellation spelling, and the keys follow it', async () => {
     Appellation.find.mockReturnValue({
       select: jest.fn().mockReturnValue({
-        limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([{ name: 'Châteauneuf-du-Pape' }]) }),
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([{ name: 'Châteauneuf-du-Pape' }]) }),
+        }),
       }),
     });
     const result = await findOrCreateWine({ ...INPUT, appellation: 'Chateauneuf du Pape' }, USER_ID);
@@ -756,7 +760,9 @@ describe('findOrCreateWine — creation', () => {
     expect(Region.exists).toHaveBeenCalledWith({
       $or: [{ normalizedName: 'bordeaux' }, { normalizedSynonyms: 'bordeaux' }],
     });
-    expect(Appellation.exists).toHaveBeenCalledWith({ normalizedName: 'bordeaux' });
+    // Both folds queried: legacy docs may carry the old (hyphen-deleting)
+    // key until the backfill runs; new docs carry the appellation key.
+    expect(Appellation.exists).toHaveBeenCalledWith({ normalizedName: { $in: ['bordeaux', 'bordeaux'] } });
   });
 
   test('producer-place gate: exact full-string match only — "Marchesi di Barolo" passes', async () => {
@@ -764,7 +770,7 @@ describe('findOrCreateWine — creation', () => {
     // producer, which no taxonomy row equals — mocks return null (default).
     await findOrCreateWine({ ...INPUT, producer: 'Marchesi di Barolo' }, USER_ID);
 
-    expect(Appellation.exists).toHaveBeenCalledWith({ normalizedName: 'marchesi di barolo' });
+    expect(Appellation.exists).toHaveBeenCalledWith({ normalizedName: { $in: ['marchesi di barolo', 'marchesi di barolo'] } });
     expect(WineDefinition).toHaveBeenCalled(); // created normally
   });
 

--- a/backend/src/services/registryHealthJob.js
+++ b/backend/src/services/registryHealthJob.js
@@ -107,7 +107,9 @@ async function runRegistryHealthCheck() {
 
   const regressions = [];
   if (previous) {
-    const prev = previous.metrics instanceof Map ? Object.fromEntries(previous.metrics) : (previous.metrics || {});
+    // .lean() always yields the Map field as a plain object (Mongoose only
+    // hydrates SchemaMap on document init, never on lean queries).
+    const prev = previous.metrics || {};
     for (const [key, label] of Object.entries(METRIC_LABELS)) {
       const before = prev[key];
       // A metric added after the baseline was written has no `before` — skip

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -195,27 +195,35 @@ const SYNC_CHUNK_SIZE = 2000;
 async function syncViaCursor(query, buildDoc, idx, label) {
   let batch = [];
   let total = 0;
+  // addDocuments only ENQUEUES a Meili task (202); collect the task uids so a
+  // caller that needs done-means-done (the admin force-reindex) can wait on
+  // them. Boot-time and fire-and-forget callers just ignore the return value —
+  // their behavior is unchanged (audit 2026-07-29, reindex "awaited" claim).
+  const taskUids = [];
   const cursor = query.cursor();
   for await (const doc of cursor) {
     batch.push(buildDoc(doc));
     if (batch.length >= SYNC_CHUNK_SIZE) {
-      await idx.addDocuments(batch, { primaryKey: 'id' });
+      const task = await idx.addDocuments(batch, { primaryKey: 'id' });
+      if (task?.taskUid != null) taskUids.push(task.taskUid);
       total += batch.length;
       batch = [];
     }
   }
   if (batch.length > 0) {
-    await idx.addDocuments(batch, { primaryKey: 'id' });
+    const task = await idx.addDocuments(batch, { primaryKey: 'id' });
+    if (task?.taskUid != null) taskUids.push(task.taskUid);
     total += batch.length;
   }
   console.log(`Meilisearch: synced ${total} ${label}`);
+  return taskUids;
 }
 
 async function fullSync() {
   if (!isAvailable) return;
 
   try {
-    await syncViaCursor(
+    return await syncViaCursor(
       // Quarantined non-wine rows (spirits/cider/sake kept for their owners —
       // registry audit 2026-07-26, policy: keep, hide) never enter the index.
       WineDefinition.find({ nonWine: { $ne: true } })
@@ -344,7 +352,7 @@ async function fullSyncBottles() {
 
   try {
     // Sync ALL bottles (active + consumed) so history search works too
-    await syncViaCursor(
+    return await syncViaCursor(
       Bottle.find().populate(WINE_POPULATE).lean(),
       buildBottleDocument,
       bottlesIndex,
@@ -703,10 +711,21 @@ function getIsAvailable() {
   return isAvailable;
 }
 
+/**
+ * Wait for enqueued Meili tasks to actually complete — done-means-done for
+ * callers like the admin force-reindex, where responding before indexing
+ * finishes recreates the stale-index window the button exists to close.
+ */
+async function waitForTasks(taskUids, { timeOutMs = 120000 } = {}) {
+  if (!isAvailable || !Array.isArray(taskUids) || taskUids.length === 0) return;
+  await client.waitForTasks(taskUids, { timeOutMs, intervalMs: 250 });
+}
+
 module.exports = {
   initialize,
   fullSync,
   fullSyncBottles,
+  waitForTasks,
   fullSyncDiscussions,
   indexWine,
   removeWine,

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -511,8 +511,10 @@ const REGISTRY = [
       WineReport.updateMany({ resolvedBy: ctx.userId }, { $unset: { resolvedBy: '' } }),
     ],
     exportFragment: async (ctx) => ({
-      reports: { wines: markTrunc(ctx, 'wineReports', await WineReport.find({ user: ctx.userId }).select('wineDefinition reason status createdAt').limit(EXPORT_MAX).lean())
-        .map(r => ({ reason: r.reason, status: r.status, createdAt: r.createdAt })) },
+      // details/suggestedField/suggestedValue are text the USER typed —
+      // portability requires they come back out (audit 2026-07-29 M1).
+      reports: { wines: markTrunc(ctx, 'wineReports', await WineReport.find({ user: ctx.userId }).select('wineDefinition reason status createdAt details suggestedField suggestedValue').limit(EXPORT_MAX).lean())
+        .map(r => ({ reason: r.reason, status: r.status, createdAt: r.createdAt, details: r.details, suggestedField: r.suggestedField, suggestedValue: r.suggestedValue })) },
     }),
   },
   {

--- a/frontend/src/components/ReportWineModal.js
+++ b/frontend/src/components/ReportWineModal.js
@@ -6,11 +6,15 @@ import { useAuth } from '../contexts/AuthContext';
 import './ReportWineModal.css';
 
 const REASON_VALUES = ['wrong_info', 'duplicate', 'wrong_price', 'wrong_tasting_profile', 'inappropriate', 'other'];
+// The one-click-appliable fields (mirrors the backend allowlist). Region and
+// country are references — describe those in the details text instead.
+const SUGGESTABLE_FIELDS = ['name', 'producer', 'appellation', 'type'];
+const WINE_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
 
 function ReportWineModal({ wine, defaultReason, onClose }) {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
-  const [form, setForm] = useState({ reason: defaultReason || 'wrong_info', details: '' });
+  const [form, setForm] = useState({ reason: defaultReason || 'wrong_info', details: '', suggestedField: '', suggestedValue: '' });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
@@ -30,6 +34,9 @@ function ReportWineModal({ wine, defaultReason, onClose }) {
         wineDefinitionId: wine._id,
         reason: form.reason,
         details: form.details || undefined,
+        ...(form.suggestedField && form.suggestedValue.trim()
+          ? { suggestedField: form.suggestedField, suggestedValue: form.suggestedValue.trim() }
+          : {}),
       });
       const data = await res.json();
       if (!res.ok) return setError(data.error || t('reportWine.submitFailed'));
@@ -72,6 +79,40 @@ function ReportWineModal({ wine, defaultReason, onClose }) {
             ))}
           </select>
         </label>
+
+        {form.reason === 'wrong_info' && (
+          <div className="report-wine-suggestion">
+            <label>
+              {t('reportWine.suggestField')} <span className="optional">{t('reportWine.optional')}</span>
+              <select name="suggestedField" value={form.suggestedField} onChange={handleChange}>
+                <option value="">{t('reportWine.suggestFieldNone')}</option>
+                {SUGGESTABLE_FIELDS.map(f => (
+                  <option key={f} value={f}>{t(`reportWine.fields.${f}`)}</option>
+                ))}
+              </select>
+            </label>
+            {form.suggestedField && (
+              <label>
+                {t('reportWine.suggestValue')}
+                {form.suggestedField === 'type' ? (
+                  <select name="suggestedValue" value={form.suggestedValue} onChange={handleChange}>
+                    <option value="">—</option>
+                    {WINE_TYPES.map(v => <option key={v} value={v}>{v}</option>)}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    name="suggestedValue"
+                    value={form.suggestedValue}
+                    onChange={handleChange}
+                    maxLength={200}
+                    placeholder={String(wine[form.suggestedField] || '')}
+                  />
+                )}
+              </label>
+            )}
+          </div>
+        )}
 
         <label>
           {t('reportWine.details')} <span className="optional">{t('reportWine.optional')}</span>

--- a/frontend/src/components/ReportWineModal.js
+++ b/frontend/src/components/ReportWineModal.js
@@ -20,7 +20,15 @@ function ReportWineModal({ wine, defaultReason, onClose }) {
   const [success, setSuccess] = useState(false);
 
   const handleChange = (e) => {
-    setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+    const { name, value } = e.target;
+    setForm(f => ({
+      ...f,
+      [name]: value,
+      // Suggestion inputs only exist for wrong_info — switching the reason
+      // hides them, and hidden stale state must not ride along in the submit
+      // (audit 2026-07-29 R7-#5). The backend enforces this too.
+      ...(name === 'reason' && value !== 'wrong_info' ? { suggestedField: '', suggestedValue: '' } : {}),
+    }));
     setError(null);
   };
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2229,7 +2229,8 @@
     "tastingProfile": "Tasting profile",
     "structure": "Structure",
     "flavours": "Flavours",
-    "pairsWith": "Pairs with"
+    "pairsWith": "Pairs with",
+    "reportIssue": "Report an issue"
   },
   "taxonomy": {
     "loading": "Loading…",
@@ -3829,6 +3830,15 @@
     "detailsPlaceholder": "Provide any additional information that will help us investigate…",
     "submitting": "Submitting…",
     "submit": "Submit Report",
-    "submitFailed": "Failed to submit report"
+    "submitFailed": "Failed to submit report",
+    "suggestField": "Suggest a correction",
+    "suggestFieldNone": "No specific field — described below",
+    "suggestValue": "Correct value",
+    "fields": {
+      "name": "Wine name",
+      "producer": "Producer",
+      "appellation": "Appellation",
+      "type": "Wine type"
+    }
   }
 }

--- a/frontend/src/pages/AdminWineReports.js
+++ b/frontend/src/pages/AdminWineReports.js
@@ -59,13 +59,13 @@ function AdminWineReports() {
     setSuccess(null);
   };
 
-  const handleAction = async (action) => {
+  const handleAction = async (action, opts = {}) => {
     setSubmitting(true);
     setError(null);
     setSuccess(null);
     try {
       const fn = action === 'resolve' ? adminResolveWineReport : adminDismissWineReport;
-      const res = await fn(apiFetch, selected._id, { adminNotes });
+      const res = await fn(apiFetch, selected._id, { adminNotes, ...(opts.apply ? { applySuggestion: true } : {}) });
       const data = await res.json();
       if (!res.ok) return setError(data.error || `Failed to ${action} report`);
       setSuccess(`Report ${action === 'resolve' ? 'resolved' : 'dismissed'}.`);
@@ -196,6 +196,15 @@ function AdminWineReports() {
                 </div>
               )}
 
+              {selected.suggestedField && (
+                <div className="awr-duplicate-ref">
+                  <h4>Suggested correction</h4>
+                  <p>
+                    <strong>{selected.suggestedField}</strong>: {String(selected.wineDefinition?.[selected.suggestedField] ?? '—')} → <strong>{selected.suggestedValue}</strong>
+                  </p>
+                </div>
+              )}
+
               {selected.status === 'pending' && (
                 <div className="awr-actions">
                   <h4>Admin notes <span className="optional">(optional)</span></h4>
@@ -207,8 +216,18 @@ function AdminWineReports() {
                     maxLength={2000}
                   />
                   <div className="awr-action-buttons">
+                    {selected.suggestedField && (
+                      <button
+                        className="btn btn-primary"
+                        onClick={() => handleAction('resolve', { apply: true })}
+                        disabled={submitting}
+                        title="Apply the suggested correction to the wine, then resolve"
+                      >
+                        {submitting ? '…' : 'Apply & Resolve'}
+                      </button>
+                    )}
                     <button
-                      className="btn btn-primary"
+                      className={selected.suggestedField ? 'btn btn-secondary' : 'btn btn-primary'}
                       onClick={() => handleAction('resolve')}
                       disabled={submitting}
                     >

--- a/frontend/src/pages/WineDetail.js
+++ b/frontend/src/pages/WineDetail.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, lazy, Suspense } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
@@ -14,6 +14,10 @@ import { getWineImageUrl } from '../utils/wineImageUrl';
 import { API_URL } from '../api/apiConstants';
 import './WineDetail.css';
 
+// Lazy like BottleDetail: the report modal is a rare interaction and must not
+// weigh on the public wine page bundle.
+const ReportWineModal = lazy(() => import('../components/ReportWineModal'));
+
 // Same regex used by the backend's isValidId — 24 hex chars = ObjectId, anything
 // else is treated as a slug.
 const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
@@ -23,6 +27,7 @@ export default function WineDetail() {
   const { idOrSlug } = useParams();
   const { user } = useAuth();
   const [wine, setWine] = useState(null);
+  const [showReport, setShowReport] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -265,7 +270,18 @@ export default function WineDetail() {
           <Link to="/cellars" className="btn btn-secondary">
             {t('wineDetail.backToCellars')}
           </Link>
+          {/* R7: the report link used to exist only on the bottle page — but
+              wrong shared data is most visible to NON-owners, right here. */}
+          <button type="button" className="btn btn-secondary" onClick={() => setShowReport(true)}>
+            {t('wineDetail.reportIssue')}
+          </button>
         </div>
+      )}
+
+      {showReport && (
+        <Suspense fallback={null}>
+          <ReportWineModal wine={wine} onClose={() => setShowReport(false)} />
+        </Suspense>
       )}
 
       <WineDiscussionsPanel wine={wine} />


### PR DESCRIPTION
**The final PR of the registry campaign** (`REGISTRY_STRATEGY_2026-07-29.md`, item **R7**). With this, all seven roadmap items are built.

## The two gaps

The report flow worked end to end (modal → admin queue → Cellar Cred reward) but had the two flaws the strategy called out:

1. **Resolution wrote nothing back.** The admin read "the producer is misspelled", clicked Resolve, then re-typed the fix in Admin → Wines — or, realistically, didn't.
2. **The link only existed on the bottle page**, where only *owners* are. Wrong shared data is most visible to non-owners browsing the public wine page.

## What this adds

**Structured corrections.** When the reason is "wrong info", the reporter can optionally pick a field (name / producer / appellation / type — the one-click-appliable string fields; region/country are refs and stay free-text in details) and type the correct value, with the current value shown as the placeholder. Validated both-or-neither server-side; type is validated against the wine-type enum at submission so a junk suggestion can't even enter the queue.

**Apply & Resolve.** The admin queue shows the suggestion as `field: current → proposed`, and a report that carries one gets an **Apply & Resolve** button. Applying goes through `.save()` so the model hooks run (canonicalKey recompute + `verifiedChecks` invalidation — a renamed wine must re-earn its clearances), with `normalizedKey` recomputed exactly as the admin edit route does it. The subtle case is pinned by a test: if applying the correction would make the wine **identical to an existing registry wine**, that's a *merge*, not an edit — refused with a 409 that points at the golden-record merge, and the report stays pending. Both the wine change and the resolution are audited (`admin.wine.update` with `via: 'wine-report'` + `from`/`to`); the reporter still earns Cellar Cred.

**The public wine page report link** — lazy-loaded modal, same pattern as the bottle page, shown to logged-in users next to the wishlist action.

GDPR: `WineReport` already deletes with the reporter's account (`userDataRegistry.js:508`); the new fields ride in the same document — nothing new to register.

## Testing

- New `wineReports.apply.test.js` (4 route-level tests over a live express server, matching the house harness): apply-with-hooks + reindex + dual audit, type-doesn't-touch-identity, the 409 merge-hint with the report left pending, and refuse-apply-without-suggestion / plain-resolve-never-loads-the-wine
- 513 backend tests across all route/model suites; 801 frontend; en-only strings

## Campaign complete

R1 producer canonicalization (#855) · R2 appellation system (#858) · R3 region queue (#859) · R4 importer invariants (#855) · R5 admin tooling UIs (#857) · R6 weekly health cron (#856) · R7 this PR — plus MCP curation parity, the force-reindex button, and the scan-bench matching fixes. Deploy-day runbook lives in the strategy doc: seed script → unify script (dry-run first) → incremental embed → reindex after any restore.