### PR TITLE
chore(release): v1.93.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.92.1",
+  "version": "1.93.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.92.1",
+      "version": "1.93.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.92.1",
+  "version": "1.93.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.92.1",
+  "version": "1.93.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.92.1",
+      "version": "1.93.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.92.1",
+  "version": "1.93.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for v1.93.0 — the somm maturity-queue features (#853/#854) and the full registry-quality campaign R1-R7 (#855-#860, pre-release audited).