### PR TITLE
fix(somm): corrected profiles reach Qdrant immediately + weekly embed sweep

### DIFF
--- a/backend/src/mcp/revert.js
+++ b/backend/src/mcp/revert.js
@@ -289,6 +289,9 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
       throw err;
     }
     require('../services/search').indexWine(wine._id).catch(() => {});
+    // The undo changes the embedding text back — Qdrant must follow, same as
+    // on the original correction.
+    require('../services/embeddingJob').reembedActiveVintages(wine._id).catch(() => {});
 
     const envelope = {
       summary: `Undid tasting-profile edit — ${wine.producer} — ${wine.name} back to ${wine.aiProfile?.source || 'ai'}-sourced`,

--- a/backend/src/mcp/revert.test.js
+++ b/backend/src/mcp/revert.test.js
@@ -8,6 +8,7 @@
  */
 
 jest.mock('../models/McpActionLog', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ reembedActiveVintages: jest.fn().mockResolvedValue(undefined) }));
 jest.mock('../models/WineList', () => ({ findOne: jest.fn() }));
 jest.mock('../config/constants', () => ({ CONSUMED_STATUSES: ['drank', 'gifted', 'sold', 'other'] }));
 jest.mock('../services/bottleOps', () => ({

--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -38,6 +38,7 @@ jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), build
 jest.mock('../services/vectorStore', () => ({ getPoints: jest.fn(), searchSimilar: jest.fn() }));
 jest.mock('../config/aiConfig', () => ({ get: jest.fn(() => ({ vectorIndex: 'v1' })) }));
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ reembedActiveVintages: jest.fn().mockResolvedValue(undefined) }));
 jest.mock('../services/notifications', () => ({ createNotification: jest.fn().mockResolvedValue(undefined) }));
 jest.mock('../utils/exchangeRates', () => ({ getOrCreateDailySnapshot: jest.fn().mockResolvedValue({}) }));
 jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -341,6 +341,9 @@ registerTool({
       throw err;
     }
     require('../../services/search').indexWine(wine._id).catch(() => {});
+    // Same follow-through as the REST route: the corrected profile must reach
+    // Qdrant now, not at the next manual batch run (none is scheduled).
+    require('../../services/embeddingJob').reembedActiveVintages(wine._id).catch(() => {});
 
     // Same audit action string as the REST route — REST and MCP curation must
     // audit identically (see this file's header).

--- a/backend/src/routes/somm/wineProfile.js
+++ b/backend/src/routes/somm/wineProfile.js
@@ -59,11 +59,13 @@ router.put('/:wineId', requireSommOrAdmin, async (req, res) => {
     applyProfilePatch(wine, check.clean, req.user.id);
     await wine.save();
 
-    // The structured descriptors feed buildEmbeddingText, so the embedding is
-    // now stale. It is textHash-keyed, so the next incremental embedding run
-    // picks this up by itself — no explicit invalidation needed. Meili does
-    // need a nudge, since it carries the profile fields for filtering.
+    // The structured descriptors feed buildEmbeddingText, so both indexes are
+    // now stale. Meili is nudged directly; Qdrant is re-embedded inline —
+    // relying on "the next incremental run" was wrong because NO run is
+    // scheduled, so a correction stayed invisible to semantic search until a
+    // manual job (mirrors enrichmentJob's own post-write re-embed).
     searchService.indexWine(wine._id).catch(() => {});
+    require('../../services/embeddingJob').reembedActiveVintages(wine._id).catch(() => {});
 
     logAudit(req, 'somm.wineProfile.update', { type: 'wine', id: wine._id }, {
       wine: `${wine.producer} — ${wine.name}`,

--- a/backend/src/services/embeddingJob.js
+++ b/backend/src/services/embeddingJob.js
@@ -386,4 +386,24 @@ async function embedSinglePair(wineDefId, vintage) {
   }
 }
 
-module.exports = { start, requestStop, getStatus, embedSinglePair };
+/**
+ * Re-embed every ACTIVE vintage of one wine — the follow-through for any
+ * write that changes what buildEmbeddingText produces (curator profile
+ * corrections; enrichment already inlines the same loop). Without it the
+ * Qdrant vector keeps matching on the OLD profile until someone manually
+ * runs the batch job — for the Sandeman case that motivated #853, the wrong
+ * character would live on in semantic search after the curator fixed it.
+ * Best-effort by design: embedding lag must never fail a curation write.
+ */
+async function reembedActiveVintages(wineDefId) {
+  try {
+    const vintages = await Bottle.distinct('vintage', { wineDefinition: wineDefId, status: 'active' });
+    for (const v of vintages) {
+      await embedSinglePair(wineDefId, v).catch(() => {});
+    }
+  } catch (err) {
+    console.warn(`[embeddingJob] re-embed after correction failed (${wineDefId}):`, err.message);
+  }
+}
+
+module.exports = { start, requestStop, getStatus, embedSinglePair, reembedActiveVintages };

--- a/backend/src/services/scheduler.js
+++ b/backend/src/services/scheduler.js
@@ -9,6 +9,7 @@ const { runSecurityAlertCheck } = require('./securityAlertJob');
 const { runClimateOfflineCheck } = require('./climateOfflineJob');
 const { runDemoSweep } = require('./demoSweepJob');
 const { runRegistryHealthCheck } = require('./registryHealthJob');
+const embeddingJob = require('./embeddingJob');
 
 /**
  * Start all scheduled cron jobs.
@@ -130,7 +131,25 @@ function startScheduler() {
     }
   });
 
-  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, cellar-retention daily 04:00 UTC, recommendation-email-scrub daily 04:30 UTC, security-spike every 15 min, climate-offline every 15 min, demo-sweep every 15 min offset, registry-health weekly Mon 05:00 UTC)');
+  // Incremental embedding catch-all: weekly on Monday at 05:30 UTC (after the
+  // registry health check). Curation writes re-embed inline, but this sweeps
+  // up anything that slipped (a failed inline call, a script-driven change) —
+  // textHash-keyed, so an up-to-date registry makes this a near-no-op.
+  // "Already running" is fine, not an error: someone started a manual run.
+  cron.schedule('30 5 * * 1', async () => {
+    console.log('[scheduler] Running weekly incremental embedding sweep…');
+    try {
+      await embeddingJob.start({ mode: 'incremental' });
+    } catch (err) {
+      if (/already running/i.test(err.message)) {
+        console.log('[scheduler] Embedding job already running — sweep skipped');
+      } else {
+        console.error('[scheduler] Weekly embedding sweep failed:', err.message);
+      }
+    }
+  });
+
+  console.log('[scheduler] Cron jobs registered (drink-window daily 06:00 UTC, value-snapshot weekly Sun 01:00 UTC, community-price weekly Sun 02:00 UTC, user-deletion daily 03:00 UTC, cellar-retention daily 04:00 UTC, recommendation-email-scrub daily 04:30 UTC, security-spike every 15 min, climate-offline every 15 min, demo-sweep every 15 min offset, registry-health weekly Mon 05:00 UTC, embed-sweep weekly Mon 05:30 UTC)');
 }
 
 module.exports = { startScheduler };


### PR DESCRIPTION
Follow-up to #853/#860, from Johan's question "if we correct a profile, does the embedding update?" — the honest answer was **no, and nothing scheduled would ever fix it**.

## The gap

A profile correction nudged Meilisearch inline but deliberately left Qdrant to "the next incremental embedding run" — which doesn't exist as a scheduled thing; the embed job only runs when an admin starts it manually. So `semantic_search_wines`, `find_similar_wines` and cellar-chat retrieval kept matching on the **old, wrong profile** indefinitely after a curator fixed it — for the exact Sandeman case that motivated the correction feature.

## The fix

**Inline re-embed on every correction path.** New `embeddingJob.reembedActiveVintages(wineId)` — the same loop `enrichmentJob` already inlines after its own writes (distinct active vintages → `embedSinglePair`, textHash-keyed so unchanged pairs are cheap no-ops, best-effort so embedding lag can never fail a curation write). Called from the REST route, the MCP tool, **and the undo** — restoring the old profile changes the embedding text back, so Qdrant must follow there too.

**Weekly incremental sweep** (Mon 05:30 UTC, right after the registry health check) as the catch-all for anything that slips past the inline calls — a failed Voyage call, a script-driven profile change. On an up-to-date registry the sweep is a near-no-op thanks to textHash keying. "Already running" is logged as fine, not an error — it means someone started a manual run.

## Testing

- `sommTools.test.js` asserts the re-embed fires on `set_wine_profile` apply; `revert.test.js` mocks it for the undo path
- 943 tests / 72 suites across `src/mcp`, `src/services`, `src/routes/somm` green

No compose/env impact. Small enough to ride along with whatever the next release is — no urgency to deploy alone (corrections made since v1.93.0 went live will be swept by the first Monday run, or sooner by any manual incremental run).