### PR TITLE
fix(pwa): bottom tab bar respects the iOS home-indicator safe area

### DIFF
--- a/frontend/src/components/JumpToReplyButton.css
+++ b/frontend/src/components/JumpToReplyButton.css
@@ -43,12 +43,13 @@
   .jump-to-reply-btn:hover { transform: none; }
 }
 
-/* Mobile: clear the bottom-nav (~64px tall) so the FAB doesn't overlap
-   the tab strip when the user is signed in. */
+/* Mobile: clear the bottom-nav so the FAB doesn't overlap the tab strip
+   when the user is signed in. The nav's total height is
+   --bottom-nav-height + the iOS home-indicator inset (issue #861). */
 @media (max-width: 768px) {
   .jump-to-reply-btn {
     right: 1rem;
-    bottom: calc(64px + 1rem);
+    bottom: calc(var(--bottom-nav-height, 64px) + 1rem + env(safe-area-inset-bottom, 0px));
     padding: 0.65rem 1rem;
     font-size: 0.9rem;
   }

--- a/frontend/src/components/Layout.css
+++ b/frontend/src/components/Layout.css
@@ -401,11 +401,20 @@
     bottom: 0;
     left: 0;
     right: 0;
-    height: var(--bottom-nav-height);
+    /* The bar is border-box (global reset), so the safe-area padding must be
+       ADDED to the height — with height: var(--bottom-nav-height) alone the
+       ~34px home-indicator inset of an installed iOS PWA was carved OUT of the
+       64px, squeezing the items into ~29px: icons overflowed through the
+       border-top (the "stray line") and labels sat on the home indicator
+       (issue #861). In a Safari tab the inset is 0 and nothing changes. The
+       content box stays exactly --bottom-nav-height, and the total matches
+       every calc(var(--bottom-nav-height) + env(safe-area-inset-bottom))
+       offset elsewhere. */
+    height: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
     background: var(--color-nav);
     border-top: 1px solid var(--color-nav-border);
     z-index: 200;
-    padding-bottom: env(safe-area-inset-bottom);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
     box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.06);
   }
 


### PR DESCRIPTION
Fixes #861.

## Root cause

[Layout.css](frontend/src/components/Layout.css) gave `.bottom-nav` **both** `height: var(--bottom-nav-height)` (64px) **and** `padding-bottom: env(safe-area-inset-bottom)` — under the app's global `* { box-sizing: border-box }` reset, the safe-area padding is carved **out of** the fixed 64px instead of extending it.

- In a regular Safari tab, `env(safe-area-inset-bottom)` is 0 (Safari's own toolbar occupies the bottom), so nothing looked wrong.
- In an installed PWA (standalone mode) on a Face-ID iPhone the inset is ~34px, so the five items were squeezed into a 64 − 34 − 1 = **29px** content box. The ~50px of icon+label overflowed that box in both directions: **through the bar's `border-top`** (the reported "stray horizontal line above the tab bar", with the next list card's edge visible in the gap) **and down into the home-indicator zone** (the reported misalignment). Matches the reporter's screenshot exactly, incl. Edge-on-iOS (same WebKit engine).

## Fix

The bar's height now **adds** the inset:

```css
height: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
padding-bottom: env(safe-area-inset-bottom, 0px);
```

so the flex content box stays exactly 64px, the bar background/border extend under the home indicator, and the total height now agrees with every existing `calc(var(--bottom-nav-height) + env(safe-area-inset-bottom))` offset in the codebase (main-content padding, the Cellars/CellarDetail/BottleDetail/WineRequests FABs, mobile-menu padding). Also fixed the one sibling that had the gap hardcoded without the inset: the `JumpToReplyButton` FAB (`calc(64px + 1rem)` → shared var + inset).

Safari tab / desktop / Android (inset 0) are pixel-identical to before — `env()` resolves to 0 and the calc degrades to today's values.

## Verification (no physical iPhone available)

Built a pixel-exact harness of the bar's geometry (same reset, same rules, `env()` substituted with the standalone inset of 34px) and measured it in a headless browser at the iPhone's logical viewport:

| | bar total | item content box | label bottom → screen edge |
|---|---|---|---|
| **before (shipped)** | 64px | **29px** (squeezed) | **28px — inside the 34px indicator zone** |
| **after (fix)** | 98px | 63px | 45px — clear of the indicator |

The before-render reproduces the issue screenshot (labels on the indicator, line floating above the icons); the after-render shows the bar sitting flush above the indicator. Layout math (border-box + padding + flex) is engine-independent, so this pins the geometry; @bocste, a quick on-device check of the deployed fix would still be appreciated since we could not test on real hardware.

Also ran: full frontend suite (801 tests pass), production build, and a Docker smoke confirming the compiled rule ships in the served CSS bundle.

No backend, compose, or i18n changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)