### PR TITLE
fix(mcp): open-bottle audit hardening — consumed-state guards, atomic pours, undo unclaim

### DIFF
--- a/backend/src/mcp/openBottleTools.test.js
+++ b/backend/src/mcp/openBottleTools.test.js
@@ -25,7 +25,7 @@ jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: je
 jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
 jest.mock('../models/User', () => ({ findById: jest.fn() }));
 jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
-jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
 jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
 jest.mock('../services/search', () => ({
   getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn(),
@@ -82,6 +82,7 @@ beforeEach(() => {
   McpActionLog.findOne.mockReturnValue(chain(null));
   McpActionLog.create.mockResolvedValue({});
   McpActionLog.findOneAndUpdate.mockResolvedValue({ _id: 'claimed' });
+  McpActionLog.updateOne.mockResolvedValue({});
 });
 
 describe('scope gating + annotations', () => {
@@ -111,6 +112,18 @@ describe('open_bottle', () => {
     const res = await tool('open_bottle').handler({ bottle_id: oid('d') }, CTX);
     expect(parse(res).error.code).toBe('not_found');
     expect(bottleOps.openBottle).not.toHaveBeenCalled();
+  });
+
+  test('consumed bottle with preserved open history → conflict, never a false "already open" success', async () => {
+    // consume keeps openedAt/pours as drinking history — the shortcut must not
+    // report a drunk bottle as currently open (2026-07-30 audit).
+    ownBottle({ status: 'drank', consumedReason: 'drank', consumedAt: new Date('2026-07-25'), openedAt: new Date('2026-07-24'), preservationMethod: 'coravin', pours: [{ ml: 125 }] });
+    const res = await tool('open_bottle').handler({ bottle_id: oid('d') }, CTX);
+    const body = parse(res);
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message).toMatch(/already consumed/);
+    expect(bottleOps.openBottle).not.toHaveBeenCalled();
+    expect(McpActionLog.create).not.toHaveBeenCalled();
   });
 
   test('already-open bottle → idempotent ok reporting existing state, NO second ledger row (issue #835)', async () => {
@@ -164,8 +177,8 @@ describe('pour_glass', () => {
       bottle.preservationMethod = preservationMethod;
       return { bottle };
     });
-    bottleOps.pourFromBottle.mockImplementation(async (bottle, { ml }) => {
-      bottle.pours.push({ at: new Date(), ml: ml || 125 });
+    bottleOps.pourFromBottle.mockImplementation(async (bottle, { ml, count }) => {
+      for (let i = 0; i < (count || 1); i += 1) bottle.pours.push({ at: new Date(), ml: ml || 125 });
       return { bottle };
     });
     const res = await tool('pour_glass').handler({ bottle_id: oid('d') }, CTX);
@@ -179,17 +192,46 @@ describe('pour_glass', () => {
     expect(row.detail).toMatchObject({ count: 1, ml: 125, implicitOpen: true, openedAt: doc.openedAt });
   });
 
-  test('open bottle: no implicit open; glasses=3 records three pours at the given ml', async () => {
+  test('open bottle: no implicit open; glasses=3 is ONE all-or-nothing service call (single save)', async () => {
     ownBottle({ openedAt: new Date(), preservationMethod: 'vacuum' });
-    bottleOps.pourFromBottle.mockImplementation(async (bottle, { ml }) => {
-      bottle.pours.push({ at: new Date(), ml });
+    bottleOps.pourFromBottle.mockImplementation(async (bottle, { ml, count }) => {
+      for (let i = 0; i < (count || 1); i += 1) bottle.pours.push({ at: new Date(), ml });
       return { bottle };
     });
     const res = await tool('pour_glass').handler({ bottle_id: oid('d'), glasses: 3, ml: 100 }, CTX);
     expect(bottleOps.openBottle).not.toHaveBeenCalled();
-    expect(bottleOps.pourFromBottle).toHaveBeenCalledTimes(3);
+    expect(bottleOps.pourFromBottle).toHaveBeenCalledTimes(1);
+    expect(bottleOps.pourFromBottle.mock.calls[0][1]).toEqual({ ml: 100, count: 3 });
     expect(parse(res).data.poured_ml).toBe(300);
     expect(McpActionLog.create.mock.calls[0][0].detail).toMatchObject({ count: 3, ml: 100, implicitOpen: false });
+  });
+
+  test('consumed bottle → conflict; the open-state history is never touched', async () => {
+    ownBottle({ status: 'drank', consumedReason: 'drank', openedAt: new Date('2026-07-20'), preservationMethod: 'vacuum', pours: [{ ml: 125 }] });
+    const res = await tool('pour_glass').handler({ bottle_id: oid('d') }, CTX);
+    const body = parse(res);
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message).toMatch(/restore_bottle/);
+    expect(bottleOps.openBottle).not.toHaveBeenCalled();
+    expect(bottleOps.pourFromBottle).not.toHaveBeenCalled();
+  });
+
+  test('pour failure after an implicit open rolls the open back (no orphaned unledgered state)', async () => {
+    const doc = ownBottle();
+    const openedAt = new Date('2026-07-30T18:00:00Z');
+    bottleOps.openBottle.mockImplementation(async (bottle) => {
+      bottle.openedAt = openedAt;
+      bottle.preservationMethod = 'recorked';
+      return { bottle };
+    });
+    bottleOps.pourFromBottle.mockResolvedValue({ error: { status: 400, message: 'Too many pours recorded for this bottle' } });
+    // The rollback re-loads the bottle fresh; hand it the same (still ours,
+    // untouched) open state so the compensation may proceed.
+    bottleOps.closeBottle.mockResolvedValue({ bottle: doc, prevOpenState: {} });
+    const res = await tool('pour_glass').handler({ bottle_id: oid('d'), glasses: 2 }, CTX);
+    expect(parse(res).error.code).toBe('invalid_input');
+    expect(bottleOps.closeBottle).toHaveBeenCalledTimes(1); // the compensation
+    expect(McpActionLog.create).not.toHaveBeenCalled();     // nothing to ledger
   });
 
   test('idempotent replay: a seen key returns the ORIGINAL envelope without pouring again', async () => {
@@ -203,16 +245,26 @@ describe('pour_glass', () => {
     expect(McpActionLog.create).not.toHaveBeenCalled();
   });
 
-  test('service faults on the first pour surface as invalid_input', async () => {
+  test('service faults on an already-open bottle surface as invalid_input (no rollback — the open is not ours)', async () => {
     ownBottle({ openedAt: new Date(), preservationMethod: 'vacuum' });
     bottleOps.pourFromBottle.mockResolvedValue({ error: { status: 400, message: 'Too many pours recorded for this bottle' } });
     const res = await tool('pour_glass').handler({ bottle_id: oid('d') }, CTX);
     expect(parse(res).error.code).toBe('invalid_input');
+    expect(bottleOps.closeBottle).not.toHaveBeenCalled();
     expect(McpActionLog.create).not.toHaveBeenCalled();
   });
 });
 
 describe('close_bottle', () => {
+  test('consumed bottle → conflict; preserved open history is never wiped', async () => {
+    ownBottle({ status: 'drank', consumedReason: 'drank', openedAt: new Date('2026-07-24'), preservationMethod: 'coravin', pours: [{ ml: 125 }] });
+    const res = await tool('close_bottle').handler({ bottle_id: oid('d') }, CTX);
+    const body = parse(res);
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message).toMatch(/consumption record/);
+    expect(bottleOps.closeBottle).not.toHaveBeenCalled();
+  });
+
   test('not-open bottle → conflict pointing at consume_bottle', async () => {
     ownBottle();
     bottleOps.closeBottle.mockResolvedValue({ error: { status: 400, message: 'Bottle is not open', code: 'not_open' } });
@@ -242,6 +294,43 @@ describe('close_bottle', () => {
 
 describe('undo_last on open/pour/close', () => {
   const bottleRef = () => new mongoose.Types.ObjectId(oid('d'));
+
+  test('refuses ALL three undos once the bottle was consumed since (history is part of the consumption record)', async () => {
+    // A web-UI consume writes no MCP ledger row, so the pour row is still the
+    // newest candidate — but the pours it would splice out are preserved
+    // drinking history now (2026-07-30 audit).
+    const openedAt = new Date('2026-07-28T19:00:00Z');
+    const entry = { _id: 'log0', action: 'pour', bottle: bottleRef(), reversed: false, detail: { count: 1, ml: 125, implicitOpen: false } };
+    McpActionLog.findOne.mockReturnValue(chain(entry));
+    const doc = ownBottle({ status: 'drank', consumedReason: 'drank', openedAt, preservationMethod: 'vacuum', pours: [{ at: openedAt, ml: 125 }] });
+    const res = await tool('undo_last').handler({}, CTX);
+    const body = parse(res);
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message).toMatch(/consumed since/);
+    expect(doc.save).not.toHaveBeenCalled();
+    expect(bottleOps.closeBottle).not.toHaveBeenCalled();
+    // Not claimed either — the row stays available (the guard fired before the claim).
+    expect(McpActionLog.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('open-undo: a thrown VersionError from closeBottle unclaims the row so the undo can be retried (M1 class)', async () => {
+    const openedAt = new Date('2026-07-28T19:00:00Z');
+    const entry = { _id: 'log7', action: 'open', bottle: bottleRef(), reversed: false, detail: { preservationMethod: 'vacuum', openedAt } };
+    McpActionLog.findOne.mockReturnValue(chain(entry));
+    ownBottle({ openedAt, preservationMethod: 'vacuum', pours: [] });
+    const versionError = new Error('No matching document found');
+    versionError.name = 'VersionError';
+    bottleOps.closeBottle.mockRejectedValue(versionError);
+    const res = await tool('undo_last').handler({}, CTX);
+    const body = parse(res);
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message).toMatch(/mid-undo/);
+    // Claimed, then released again so a retry finds the row un-reversed.
+    expect(McpActionLog.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'log7', reversed: false }, { $set: { reversed: true, idempotencyKey: null } });
+    expect(McpActionLog.updateOne).toHaveBeenCalledWith({ _id: 'log7' }, { $set: { reversed: false } });
+    expect(McpActionLog.create).not.toHaveBeenCalled(); // no viaUndo row — nothing was undone
+  });
 
   test('undoes an open via the shared closeBottle op', async () => {
     const openedAt = new Date('2026-07-28T19:00:00Z');

--- a/backend/src/mcp/revert.js
+++ b/backend/src/mcp/revert.js
@@ -429,6 +429,14 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
     if (!access) return fail('conflict', 'The bottle from that action is no longer accessible; nothing was changed.');
     const { bottle } = access;
 
+    // Consumed since the action: the open-bottle fields on a consumed record
+    // are preserved DRINKING HISTORY (consume deliberately keeps them) — an
+    // undo must never rewrite or erase them. Same invariant the restore-undo
+    // branch enforces on status (2026-07-30 audit).
+    if (CONSUMED_STATUSES.includes(bottle.status)) {
+      return fail('conflict', 'That cannot be undone: the bottle has been consumed since, and its open-bottle history is part of the consumption record now. Use restore_bottle first if the consume itself was the mistake. Nothing was changed.');
+    }
+
     if (row.action === 'open') {
       const openedAt = row.detail?.openedAt ? new Date(row.detail.openedAt).getTime() : null;
       if (!bottle.openedAt || !openedAt || new Date(bottle.openedAt).getTime() !== openedAt) {
@@ -439,7 +447,14 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
       }
       const claimed = await McpActionLog.findOneAndUpdate({ _id: row._id, reversed: false }, { $set: { reversed: true, idempotencyKey: null } });
       if (!claimed) return fail('conflict', 'That action is already being undone by another request.');
-      const result = await closeBottle(bottle, ctx.req);
+      let result;
+      try {
+        result = await closeBottle(bottle, ctx.req);
+      } catch (err) {
+        await unclaim(row._id); // nothing persisted → let the undo be retried (M1 class)
+        if (err?.name === 'VersionError') return fail('conflict', 'The bottle changed mid-undo — retry.');
+        throw err;
+      }
       if (result.error) {
         await unclaim(row._id); // nothing changed → let the undo be retried
         return fail('conflict', `Cannot undo that open: ${result.error.message}`);

--- a/backend/src/mcp/tools/openBottle.js
+++ b/backend/src/mcp/tools/openBottle.js
@@ -22,10 +22,24 @@ const { openBottle, pourFromBottle, closeBottle } = require('../../services/bott
 const {
   PRESERVATION_FRESHNESS_DAYS, PRESERVATION_METHODS, DEFAULT_POUR_ML, openBottleDeadline,
 } = require('../../utils/openBottleUtils');
+const { CONSUMED_STATUSES } = require('../../config/constants');
 const { logAction, replay } = require('../actionLedger');
 const { ok, fail, objectId, MSG_BOTTLE_NOT_FOUND, resolveBottleAccess } = require('../toolUtil');
 
 const bottleLabel = (b) => `bottle ${b._id} (vintage ${b.vintage})`;
+
+/**
+ * Consumed bottles KEEP openedAt/preservationMethod/pours as drinking history
+ * (Bottle schema), so every handler here must gate on status BEFORE trusting
+ * openedAt — otherwise open_bottle would report a drunk bottle as "open and
+ * drinkable" and close_bottle would erase preserved history (2026-07-30 audit).
+ */
+function consumedConflict(bottle, hint) {
+  const when = bottle.consumedAt ? ` on ${new Date(bottle.consumedAt).toISOString().slice(0, 10)}` : '';
+  return fail('conflict',
+    `This bottle was already consumed (${bottle.consumedReason || bottle.status}${when}) — its open-bottle fields are ` +
+    `preserved drinking history, not current state. ${hint} Use restore_bottle first if the consume was a mistake.`);
+}
 
 /** ml poured so far + remaining estimate from the bottle's size ('750ml' …). */
 function pourTotals(bottle) {
@@ -75,6 +89,12 @@ registerTool({
     const access = await resolveBottleAccess(ctx.user.id, args.bottle_id, 'editor');
     if (!access) return fail('not_found', MSG_BOTTLE_NOT_FOUND);
     const { bottle } = access;
+
+    // BEFORE the already-open shortcut: a consumed bottle may still carry
+    // openedAt as history and must never be reported as currently open.
+    if (CONSUMED_STATUSES.includes(bottle.status)) {
+      return consumedConflict(bottle, 'A consumed bottle cannot be opened.');
+    }
 
     // Idempotent by state (issue #835): a repeat call reports the existing
     // open state instead of erroring — and records nothing new to undo.
@@ -136,6 +156,10 @@ registerTool({
     if (!access) return fail('not_found', MSG_BOTTLE_NOT_FOUND);
     const { bottle } = access;
 
+    if (CONSUMED_STATUSES.includes(bottle.status)) {
+      return consumedConflict(bottle, 'A consumed bottle cannot be poured from.');
+    }
+
     // Implicit open (issue #835): "I just poured a glass of X" should not
     // require a separate open_bottle round-trip.
     let implicitOpen = false;
@@ -145,22 +169,27 @@ registerTool({
       implicitOpen = true;
     }
 
+    // ONE all-or-nothing service call for the whole batch (single save): the
+    // per-glass loop this replaces committed up to 10 separate saves before
+    // the ledger row, so a mid-batch failure left pours (and the implicit
+    // open) persisted but unledgered — invisible to undo_last, and re-poured
+    // by a same-key retry after the claim was released (2026-07-30 audit).
     const glasses = args.glasses || 1;
-    let poured = 0;
-    for (let i = 0; i < glasses; i += 1) {
-      const result = await pourFromBottle(bottle, { ml: args.ml }, ctx.req);
-      if (result.error) {
-        // A partial batch (e.g. the MAX_POURS cap mid-loop) is still recorded
-        // honestly: fail only when NOTHING was poured this call.
-        if (poured === 0) return fail('invalid_input', result.error.message);
-        break;
-      }
-      poured += 1;
+    let result;
+    try {
+      result = await pourFromBottle(bottle, { ml: args.ml, count: glasses }, ctx.req);
+    } catch (err) {
+      if (implicitOpen) await rollbackImplicitOpen(bottle, ctx.req);
+      throw err; // server wrapper releases the idempotency claim — with the rollback, nothing persisted
+    }
+    if (result.error) {
+      if (implicitOpen) await rollbackImplicitOpen(bottle, ctx.req);
+      return fail('invalid_input', result.error.message);
     }
 
     const state = openState(bottle);
     const envelope = {
-      summary: `Recorded ${poured > 1 ? `${poured} glasses` : 'a glass'} from ${bottleLabel(bottle)}` +
+      summary: `Recorded ${glasses > 1 ? `${glasses} glasses` : 'a glass'} from ${bottleLabel(bottle)}` +
         `${implicitOpen ? ' (bottle marked open)' : ''}` +
         `${state.remaining_ml != null ? ` — about ${state.remaining_ml} ml left` : ''}`,
       data: { bottle_id: bottle._id, ...state, undo: 'undo_last reverses this pour' },
@@ -171,7 +200,7 @@ registerTool({
       bottle: bottle._id,
       cellar: bottle.cellar,
       detail: {
-        count: poured, // ACTUAL pours recorded (a capped batch may be partial) — the undo removes exactly these
+        count: glasses, // the batch is all-or-nothing, so recorded = requested
         ml: args.ml || DEFAULT_POUR_ML,
         implicitOpen,
         ...(implicitOpen ? { openedAt: bottle.openedAt } : {}),
@@ -183,6 +212,24 @@ registerTool({
     return ok(envelope.summary, envelope.data);
   },
 });
+
+/**
+ * Best-effort rollback of an implicit open whose pour then failed: without it
+ * the open would stay committed with NO ledger row — invisible to undo_last
+ * and the activity timeline. Re-loads the bottle (after a VersionError our
+ * copy is stale) and clears the open state only while it is provably still
+ * OUR untouched open (same openedAt, no pours). Never throws — if the
+ * rollback loses a race, the leftover open is at least visible in the app.
+ */
+async function rollbackImplicitOpen(bottle, req) {
+  try {
+    const Bottle = require('../../models/Bottle');
+    const fresh = await Bottle.findById(bottle._id);
+    if (!fresh || !fresh.openedAt || (fresh.pours || []).length > 0) return;
+    if (new Date(fresh.openedAt).getTime() !== new Date(bottle.openedAt).getTime()) return;
+    await closeBottle(fresh, req);
+  } catch { /* best-effort */ }
+}
 
 registerTool({
   name: 'close_bottle',
@@ -198,6 +245,12 @@ registerTool({
     const access = await resolveBottleAccess(ctx.user.id, args.bottle_id, 'editor');
     if (!access) return fail('not_found', MSG_BOTTLE_NOT_FOUND);
     const { bottle } = access;
+
+    // A consumed bottle's open-bottle fields ARE the drinking history the
+    // consumption record preserves — close_bottle must never wipe them.
+    if (CONSUMED_STATUSES.includes(bottle.status)) {
+      return consumedConflict(bottle, 'Its open-bottle history stays on the consumption record.');
+    }
 
     const result = await closeBottle(bottle, ctx.req);
     if (result.error) {

--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -184,11 +184,14 @@ async function openBottle(bottle, { preservationMethod, openedAt } = {}, req) {
 }
 
 /**
- * Record a pour from an OPEN bottle (default: one 125 ml glass).
- * Mirrors POST /api/bottles/:id/pour exactly.
+ * Record pours from an OPEN bottle (default: one 125 ml glass). `count`
+ * records a whole batch ALL-OR-NOTHING in one save — validation covers the
+ * full batch up front, so there is never a partially-committed batch (the
+ * MCP pour_glass ledger row can then always say recorded = requested).
+ * Mirrors POST /api/bottles/:id/pour exactly (REST always passes count 1).
  * Returns { error } | { bottle }.
  */
-async function pourFromBottle(bottle, { ml } = {}, req) {
+async function pourFromBottle(bottle, { ml, count } = {}, req) {
   if (CONSUMED_STATUSES.includes(bottle.status)) {
     return { error: { status: 400, message: 'Bottle is already consumed' } };
   }
@@ -199,14 +202,21 @@ async function pourFromBottle(bottle, { ml } = {}, req) {
   if (!Number.isFinite(amount) || amount < 1 || amount > 6000) {
     return { error: { status: 400, message: 'Pour must be between 1 and 6000 ml' } };
   }
-  if (bottle.pours.length >= MAX_POURS) {
+  const glasses = count === undefined || count === null ? 1 : Number(count);
+  if (!Number.isInteger(glasses) || glasses < 1 || glasses > 10) {
+    return { error: { status: 400, message: 'count must be an integer between 1 and 10' } };
+  }
+  if (bottle.pours.length + glasses > MAX_POURS) {
     return { error: { status: 400, message: 'Too many pours recorded for this bottle' } };
   }
-  bottle.pours.push({ at: new Date(), ml: Math.round(amount) });
+  const at = new Date();
+  for (let i = 0; i < glasses; i += 1) {
+    bottle.pours.push({ at, ml: Math.round(amount) });
+  }
   await bottle.save();
   logAudit(req, 'bottle.pour',
     { type: 'bottle', id: bottle._id, cellarId: bottle.cellar },
-    { ml: Math.round(amount) }
+    { ml: Math.round(amount), ...(glasses > 1 ? { count: glasses } : {}) }
   );
   return { bottle };
 }

--- a/backend/src/services/bottleOps.test.js
+++ b/backend/src/services/bottleOps.test.js
@@ -457,6 +457,28 @@ describe('open-bottle ops (openBottle / pourFromBottle / closeBottle)', () => {
       { type: 'bottle', id: 'b1', cellarId: 'c1' }, { ml: 100 });
   });
 
+  test('pourFromBottle count batches ALL-OR-NOTHING: one save, full-batch cap check, audited with count', async () => {
+    const bottle = openDoc();
+    const res = await pourFromBottle(bottle, { ml: 150, count: 3 }, REQ);
+    expect(res.error).toBeUndefined();
+    expect(bottle.pours).toHaveLength(3);
+    expect(bottle.pours.every((p) => p.ml === 150)).toBe(true);
+    expect(bottle.save).toHaveBeenCalledTimes(1); // the whole batch is one commit
+    expect(logAudit).toHaveBeenLastCalledWith(REQ, 'bottle.pour',
+      { type: 'bottle', id: 'b1', cellarId: 'c1' }, { ml: 150, count: 3 });
+
+    // A batch that would cross MAX_POURS is refused up front — nothing partial.
+    const nearFull = openDoc({ pours: Array.from({ length: 98 }, () => ({ ml: 10 })) });
+    const capped = await pourFromBottle(nearFull, { count: 3 }, REQ);
+    expect(capped.error.message).toMatch(/Too many pours/);
+    expect(nearFull.pours).toHaveLength(98);
+    expect(nearFull.save).not.toHaveBeenCalled();
+
+    expect((await pourFromBottle(openDoc(), { count: 0 }, REQ)).error.message).toMatch(/between 1 and 10/);
+    expect((await pourFromBottle(openDoc(), { count: 11 }, REQ)).error.message).toMatch(/between 1 and 10/);
+    expect((await pourFromBottle(openDoc(), { count: 2.5 }, REQ)).error.message).toMatch(/between 1 and 10/);
+  });
+
   test('closeBottle refuses an unopened bottle (with code)', async () => {
     const res = await closeBottle(freshBottle({ openedAt: null }), REQ);
     expect(res.error.code).toBe('not_open');


### PR DESCRIPTION
Remediates all 6 verified findings of the 2026-07-30 scoped audit on PR #864 (5 finder lenses + adversarial verification per finding; 27 raw findings deduped to 6 confirmed: 3 medium / 3 low). Full report: `CODE_AUDIT_2026-07-30_OPENBOTTLE.md` (local, untracked).

**Root cause of most findings:** consumed bottles deliberately keep `openedAt` / `preservationMethod` / `pours` as drinking history, and `resolveBottleAccess` doesn't filter by status — the new tools and undo branches trusted `openedAt` as "currently open".

| Finding (sev) | Fix |
|---|---|
| open_bottle's idempotent shortcut reported an opened-then-**consumed** bottle as open + drinkable (M) | All three handlers guard `CONSUMED_STATUSES` first → `conflict` with reason/date + restore_bottle hint |
| undo of open/pour/close after a web-UI consume rewrote/erased the preserved drinking history (M) | Blanket consumed guard in the revert branch, before any claim — mirrors the restore-undo invariant |
| open-undo claimed the ledger row, then `closeBottle()` unguarded — a thrown VersionError permanently marked it reversed while undoing nothing, and the next undo_last silently reversed the wrong action (M) | try/catch → unclaim + `conflict("retry")`, same as the sibling pour/close branches |
| already-consumed surfaced as `invalid_input` instead of the documented `conflict` (L) | Covered by the guards above |
| pour_glass committed up to 11 saves before its single ledger row — a mid-batch throw left open+pours persisted but invisible to undo_last, and the released idempotency claim made a same-key retry double-pour (L) | `pourFromBottle` gained `count`: whole batch validated up front and committed **all-or-nothing in one save**; pour failure after an implicit open triggers a best-effort rollback (fresh reload, only while provably still ours). REST unchanged (always count 1) |
| the partial-batch path was untestable/untested (L) | Path eliminated by the all-or-nothing design; 8 new tests pin the batch semantics, the three consumed guards, the undo consumed guard, the VersionError unclaim, and the rollback |

Notable refutation for the record: "close wipes consumed history" via **REST** `DELETE /:id/open` is pre-existing (that route never checked status) — MCP now guards it; whether REST should too is a separate decision.

Testing: the four touched suites = 109 tests green (8 new); full `src/mcp` + MCP route suites = 34 suites / 431 tests green in node:20-alpine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)