### PR TITLE
chore(release): v1.94.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.93.0",
+  "version": "1.94.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.93.0",
+      "version": "1.94.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.93.0",
+  "version": "1.94.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.93.0",
+  "version": "1.94.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.93.0",
+      "version": "1.94.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.93.0",
+  "version": "1.94.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — 4 files, 6 lines, same shape as v1.93.0 (`f175f70`).

Ships on `main` since v1.93.0:
- **#867** French + German as complete-but-beta locales (3,512 / 3,422 strings, `MACHINE_DRAFTED` + `UNREVIEWED` gates, TRANSLATING.md)
- **#866** open-bottle audit hardening — consumed-state guards, atomic pour batches, undo unclaim
- **#863** corrected sommelier profiles reach Qdrant immediately + weekly Mon 05:30 UTC embed sweep
- **#865** iOS PWA bottom tab bar respects the home-indicator safe area
- **#864** MCP open_bottle / pour_glass / close_bottle

**Infra impact: none.** #863's sweep is in-app cron (`services/scheduler.js`), not a host crontab — no compose or env change. `CRAWLER_LANGUAGES` stays `['en','sv']` because fr/de ship as beta.