### PR TITLE
fix(security): consumed-bottle guards on the REST open-bottle routes; validate appellation input

### DIFF
--- a/backend/src/routes/admin/taxonomy.appellationInput.test.js
+++ b/backend/src/routes/admin/taxonomy.appellationInput.test.js
@@ -1,0 +1,121 @@
+/**
+ * Appellation input validation on the REST admin surface.
+ *
+ * WHY THIS TEST EXISTS (security audit 2026-07-30, L-1 + L-2):
+ *   L-1 — POST/PUT /api/admin/taxonomy/appellations accepted `synonyms` with
+ *         no element-type check, no length cap and no array-size cap, while
+ *         the MCP twin (promote_appellation) enforced `max(10)` × `max(200)`.
+ *         normalizedSynonyms is an INDEXED multikey field, so an unbounded
+ *         array grew the index; a non-string element failed the Mongoose cast
+ *         into a 500.
+ *   L-2 — `name` was checked for truthiness, then .trim()'d. A JSON body value
+ *         like {"$ne":null} is truthy, so .trim() threw a TypeError that the
+ *         route's catch turned into a 500 with a stack trace.
+ *
+ * The parity with promote_appellation's zod schema is the actual contract, so
+ * it is asserted here rather than described in a comment.
+ */
+// services/search.js eagerly requires the ESM-only `meilisearch` package,
+// which Jest can't parse — mock it (same pattern as userDataRegistry.test.js).
+// The validators under test are pure; nothing here is exercised.
+jest.mock('../../services/search', () => ({
+  getIsAvailable: jest.fn(() => false),
+  indexWine: jest.fn(),
+  removeWine: jest.fn(),
+  bulkIndexWines: jest.fn(),
+  bulkIndexBottles: jest.fn(),
+  fullSync: jest.fn(),
+  fullSyncBottles: jest.fn(),
+  waitForTasks: jest.fn(),
+}));
+
+const { appellationNameError, validateAppellationSynonyms } = require('./taxonomy');
+
+describe('appellationNameError (L-2: typeof, not truthiness)', () => {
+  test('accepts a normal name', () => {
+    expect(appellationNameError('Châteauneuf-du-Pape')).toBeNull();
+  });
+
+  test('THE L-2 GUARD: a truthy non-string is rejected, never .trim()ed', () => {
+    // Each of these is truthy, so the old `if (!name)` let it through to
+    // .trim() → TypeError → 500. All must now be a plain validation error.
+    for (const value of [{ $ne: null }, ['Rioja'], 42, true, { toString: () => 'x' }]) {
+      expect(appellationNameError(value)).toMatch(/required/i);
+    }
+  });
+
+  test('rejects missing / empty / whitespace-only names', () => {
+    for (const value of [undefined, null, '', '   ', '\t\n']) {
+      expect(appellationNameError(value)).toMatch(/required/i);
+    }
+  });
+
+  test('caps at 200 chars — the mint chokepoint\'s wine-field cap', () => {
+    expect(appellationNameError('a'.repeat(200))).toBeNull();
+    expect(appellationNameError('a'.repeat(201))).toMatch(/200 characters or fewer/);
+    // Measured after trimming, so trailing space doesn't spend the budget.
+    expect(appellationNameError(`${'a'.repeat(200)}   `)).toBeNull();
+  });
+});
+
+describe('validateAppellationSynonyms (L-1: parity with the MCP schema)', () => {
+  test('accepts a normal list and returns it trimmed', () => {
+    expect(validateAppellationSynonyms(['  Chateauneuf du Pape ', 'CNDP']))
+      .toEqual({ value: ['Chateauneuf du Pape', 'CNDP'] });
+  });
+
+  test('collapses internal whitespace, like every other registry-bound string', () => {
+    expect(validateAppellationSynonyms(['Chateauneuf   du  Pape']))
+      .toEqual({ value: ['Chateauneuf du Pape'] });
+  });
+
+  test('de-duplicates case-insensitively — an admin pasting a list gets one entry', () => {
+    expect(validateAppellationSynonyms(['Rioja', 'RIOJA', 'rioja']))
+      .toEqual({ value: ['Rioja'] });
+  });
+
+  test('THE L-1 GUARD: a non-string element is rejected, not cast', () => {
+    for (const bad of [{ $ne: null }, 42, null, undefined, ['nested'], true]) {
+      expect(validateAppellationSynonyms(['Rioja', bad]).error).toMatch(/array of strings/);
+    }
+  });
+
+  test('THE L-1 GUARD: at most 10 synonyms, each at most 200 chars', () => {
+    expect(validateAppellationSynonyms(Array.from({ length: 10 }, (_, i) => `s${i}`)).error).toBeUndefined();
+    expect(validateAppellationSynonyms(Array.from({ length: 11 }, (_, i) => `s${i}`)).error).toMatch(/At most 10/);
+    expect(validateAppellationSynonyms(['a'.repeat(200)]).error).toBeUndefined();
+    expect(validateAppellationSynonyms(['a'.repeat(201)]).error).toMatch(/200 characters or fewer/);
+  });
+
+  test('rejects a non-array outright', () => {
+    for (const bad of ['Rioja', { 0: 'Rioja' }, 42, true]) {
+      expect(validateAppellationSynonyms(bad).error).toMatch(/array of strings/);
+    }
+  });
+
+  test('an empty or blank-only list yields undefined, not [] — matching the schema default', () => {
+    // `default: undefined` on the field is what keeps an empty array out of the
+    // normalizedSynonyms index; returning [] here would defeat it.
+    expect(validateAppellationSynonyms([])).toEqual({ value: undefined });
+    expect(validateAppellationSynonyms(['', '   '])).toEqual({ value: undefined });
+  });
+
+  test('PARITY: the caps match the MCP promote_appellation zod schema exactly', () => {
+    // z.array(z.string().max(200)).max(10) — if either side moves, this fails
+    // and whoever moved it has to move the other.
+    const { z } = require('zod');
+    const mcpSchema = z.array(z.string().max(200)).max(10);
+    const elevenNames = Array.from({ length: 11 }, (_, i) => `s${i}`);
+    const tooLong = ['a'.repeat(201)];
+
+    expect(mcpSchema.safeParse(elevenNames).success).toBe(false);
+    expect(validateAppellationSynonyms(elevenNames).error).toBeTruthy();
+
+    expect(mcpSchema.safeParse(tooLong).success).toBe(false);
+    expect(validateAppellationSynonyms(tooLong).error).toBeTruthy();
+
+    const ok = Array.from({ length: 10 }, () => 'a'.repeat(200));
+    expect(mcpSchema.safeParse(ok).success).toBe(true);
+    expect(validateAppellationSynonyms(ok).error).toBeUndefined();
+  });
+});

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -608,6 +608,62 @@ for (const [path, { fn, type }] of Object.entries(MERGERS)) {
 
 // ===== APPELLATIONS =====
 
+// Input validation for the two write routes below, mirroring the MCP
+// promote_appellation schema byte-for-byte (name ≤200; synonyms at most 10
+// strings of ≤200 chars) so the two curation surfaces cannot drift. REST
+// previously validated neither the synonym element type nor the array length,
+// and normalizedSynonyms is an INDEXED multikey field, so an unbounded array
+// grew the index — while a non-string element failed the Mongoose cast into a
+// 500 (security audit 2026-07-30 L-1).
+const APPELLATION_NAME_MAX = 200;
+const APPELLATION_SYNONYMS_MAX = 10;
+
+/**
+ * typeof, not truthiness (security audit 2026-07-30 L-2): a JSON body value
+ * like {"$ne":null} is truthy, and the .trim() below would throw a TypeError
+ * that the route's catch turns into a 500. Nothing is exploitable — it throws
+ * before any Mongo query — but the answer should be a 400.
+ *
+ * @returns {string|null} the error message, or null when the name is valid.
+ */
+function appellationNameError(name) {
+  if (typeof name !== 'string' || !name.trim()) return 'Appellation name is required';
+  // The mint chokepoint caps wine fields at 200; a longer curated name would be
+  // adopted onto wines past that cap (audit 2026-07-29 A1).
+  if (name.trim().length > APPELLATION_NAME_MAX) {
+    return `Appellation name must be ${APPELLATION_NAME_MAX} characters or fewer`;
+  }
+  return null;
+}
+
+/**
+ * @returns {{error: string}|{value: string[]|undefined}} trimmed, de-duplicated
+ *   synonyms — `undefined` rather than [] when nothing survives, matching the
+ *   schema's `default: undefined` so an empty list leaves no array behind for
+ *   the normalizedSynonyms lookup to scan.
+ */
+function validateAppellationSynonyms(synonyms) {
+  if (!Array.isArray(synonyms)) return { error: 'synonyms must be an array of strings' };
+  if (synonyms.length > APPELLATION_SYNONYMS_MAX) {
+    return { error: `At most ${APPELLATION_SYNONYMS_MAX} synonyms per appellation` };
+  }
+  const out = [];
+  const seen = new Set();
+  for (const raw of synonyms) {
+    if (typeof raw !== 'string') return { error: 'synonyms must be an array of strings' };
+    const value = raw.trim().replace(/\s+/g, ' ');
+    if (!value) continue;
+    if (value.length > APPELLATION_NAME_MAX) {
+      return { error: `Each synonym must be ${APPELLATION_NAME_MAX} characters or fewer` };
+    }
+    const key = value.toLowerCase();
+    if (seen.has(key)) continue; // an admin pasting a list shouldn't create dupes
+    seen.add(key);
+    out.push(value);
+  }
+  return { value: out.length ? out : undefined };
+}
+
 // GET /api/admin/taxonomy/appellations/unmatched — the appellation review
 // queue (strategy 2026-07-29 R2). Wines store appellations as free text; this
 // lists every distinct normalized string that NO curated Appellation doc (by
@@ -670,14 +726,17 @@ router.post('/appellations', async (req, res) => {
   try {
     const { name, country, region, synonyms } = req.body;
 
-    if (!name || !country) {
-      return res.status(400).json({ error: 'Name and country are required' });
+    const nameError = appellationNameError(name);
+    if (nameError) return res.status(400).json({ error: nameError });
+    if (!country) {
+      return res.status(400).json({ error: 'Country is required' });
     }
-    // The mint chokepoint caps wine fields at 200; a longer curated name would
-    // be adopted onto wines past that cap (audit 2026-07-29 A1). MCP already
-    // enforces this; the REST surface must match.
-    if (name.trim().length > 200) {
-      return res.status(400).json({ error: 'Appellation name must be 200 characters or fewer' });
+
+    let cleanSynonyms;
+    if (synonyms !== undefined && synonyms !== null) {
+      const checked = validateAppellationSynonyms(synonyms);
+      if (checked.error) return res.status(400).json({ error: checked.error });
+      cleanSynonyms = checked.value;
     }
 
     const normalizedName = normalizeAppellationKey(name);
@@ -687,7 +746,7 @@ router.post('/appellations', async (req, res) => {
       normalizedName,
       country,
       region: region || null,
-      synonyms: Array.isArray(synonyms) && synonyms.length ? synonyms : undefined,
+      synonyms: cleanSynonyms,
       createdBy: req.user.id
     });
 
@@ -720,15 +779,26 @@ router.put('/appellations/:id', async (req, res) => {
       return res.status(404).json({ error: 'Appellation not found' });
     }
 
-    if (name) {
-      if (name.trim().length > 200) {
-        return res.status(400).json({ error: 'Appellation name must be 200 characters or fewer' });
-      }
+    // An absent name leaves it alone (partial update); a PRESENT one is
+    // validated, so a non-string can no longer reach .trim().
+    if (name !== undefined && name !== null) {
+      const nameError = appellationNameError(name);
+      if (nameError) return res.status(400).json({ error: nameError });
       appellation.name = name.trim();
       appellation.normalizedName = normalizeAppellationKey(name);
     }
     if (region !== undefined) appellation.region = region || null;
-    if (synonyms !== undefined) appellation.synonyms = Array.isArray(synonyms) && synonyms.length ? synonyms : undefined;
+    if (synonyms !== undefined) {
+      // null clears the list, matching how the rest of the admin surface
+      // distinguishes "leave alone" (absent) from "clear" (explicit null).
+      if (synonyms === null) {
+        appellation.synonyms = undefined;
+      } else {
+        const checked = validateAppellationSynonyms(synonyms);
+        if (checked.error) return res.status(400).json({ error: checked.error });
+        appellation.synonyms = checked.value;
+      }
+    }
 
     await appellation.save();
     await appellation.populate('country', 'name');
@@ -809,3 +879,8 @@ router.post('/bottle-sizes/normalize-all', async (req, res) => {
 });
 
 module.exports = router;
+// The appellation input validators are exported for their unit tests (same
+// pattern as admin/import.js mapRow): they are pure and DB-free, and they are
+// the half of the REST/MCP parity contract that lives on this side.
+module.exports.appellationNameError = appellationNameError;
+module.exports.validateAppellationSynonyms = validateAppellationSynonyms;

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -633,6 +633,15 @@ router.post('/:id/pour', requireBottleAccess('editor'), async (req, res) => {
 router.delete('/:id/pour', requireBottleAccess('editor'), async (req, res) => {
   try {
     const { bottle } = req;
+    // Same invariant closeBottle enforces: on a consumed bottle the pours are
+    // preserved drinking history on the consumption record, not a live tally
+    // (security audit 2026-07-30 M-1). This handler is inline rather than a
+    // bottleOps call, so it needs its own copy of the guard.
+    if (CONSUMED_STATUSES.includes(bottle.status)) {
+      return res.status(409).json({
+        error: 'This bottle was already consumed — its recorded pours are preserved drinking history. Restore the bottle first if the consume was a mistake.',
+      });
+    }
     if (!bottle.pours || bottle.pours.length === 0) {
       return res.status(400).json({ error: 'No pours to undo' });
     }

--- a/backend/src/routes/bottles.openBottle.consumed.test.js
+++ b/backend/src/routes/bottles.openBottle.consumed.test.js
@@ -1,0 +1,219 @@
+/**
+ * DELETE /api/bottles/:id/open and DELETE /api/bottles/:id/pour must refuse a
+ * CONSUMED bottle.
+ *
+ * WHY THIS TEST EXISTS (security audit 2026-07-30, M-1):
+ * A consumed bottle deliberately KEEPS openedAt / preservationMethod / pours —
+ * they are drinking history on the consumption record, not current state. PR
+ * #866 added that guard to the three MCP tools one at a time and left the REST
+ * twins with none, so any cellar EDITOR could silently destroy the owner's
+ * consumption record: no error, no MCP ledger row, nothing to undo.
+ *
+ * The `/open` guard lives in services/bottleOps.closeBottle so both surfaces
+ * inherit one implementation; `/pour` is an inline handler and carries its own.
+ * Both halves are asserted here, together with the active-bottle happy paths
+ * that prove the guard is not over-broad.
+ *
+ * Real router + real requireAuth/requireBottleAccess (HS256 test tokens);
+ * models and side-effect services are mocked so no MongoDB is needed.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexBottle: jest.fn(),
+  removeBottle: jest.fn(),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/restockChecker', () => ({
+  checkRestockGap: jest.fn().mockResolvedValue(null),
+  resolveRestockAlerts: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../services/priceWarnings', () => ({ gatherPriceWarnings: jest.fn().mockResolvedValue([]) }));
+jest.mock('../services/communityPrice', () => ({ getCurrentRelease: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+  getSnapshotForDate: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => ({ updateMany: jest.fn() }));
+jest.mock('../models/Country', () => ({}));
+jest.mock('../models/Region', () => ({}));
+jest.mock('../models/Grape', () => ({}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('../models/PriceTrackingRequest', () => ({}));
+jest.mock('../models/BottleImage', () => ({}));
+jest.mock('../models/WineRequest', () => ({}));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const { logAudit } = require('../services/audit');
+const bottlesRouter = require('./bottles');
+
+const OWNER_ID = '64b000000000000000000001';
+const EDITOR_ID = '64b000000000000000000003';
+const CELLAR_ID = '64b0000000000000000000bb';
+const BOTTLE_ID = '64b0000000000000000000dd';
+
+const OPENED_AT = new Date('2026-07-28T19:00:00Z');
+const POURS = [{ at: OPENED_AT, ml: 125 }, { at: OPENED_AT, ml: 150 }];
+
+function request(method, url, userId = OWNER_ID) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles', bottlesRouter);
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+            authorization: `Bearer ${jwt.sign({ id: userId, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' })}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end();
+    });
+  });
+}
+
+const closeOpen = (userId) => request('DELETE', `/api/bottles/${BOTTLE_ID}/open`, userId);
+const undoPour  = (userId) => request('DELETE', `/api/bottles/${BOTTLE_ID}/pour`, userId);
+
+/** A bottle carrying open-bottle state — consumed or not, the fields are there. */
+function makeBottle(overrides = {}) {
+  return {
+    _id: BOTTLE_ID,
+    cellar: CELLAR_ID,
+    user: OWNER_ID,
+    vintage: '2018',
+    status: 'active',
+    openedAt: OPENED_AT,
+    preservationMethod: 'vacuum',
+    pours: POURS.map((p) => ({ ...p })),
+    openBottleNotifiedAt: null,
+    save: jest.fn().mockImplementation(function () { return Promise.resolve(this); }),
+    populate: jest.fn().mockImplementation(function () { return Promise.resolve(this); }),
+    ...overrides,
+  };
+}
+
+/** Every field the guard exists to protect, unchanged. */
+function expectHistoryIntact(bottle) {
+  expect(bottle.openedAt).toEqual(OPENED_AT);
+  expect(bottle.preservationMethod).toBe('vacuum');
+  expect(bottle.pours).toEqual(POURS);
+  expect(bottle.save).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // The editor is a MEMBER, not the owner — the role that made this exploitable:
+  // an editor could destroy the owner's consumption record.
+  Cellar.findById.mockResolvedValue({
+    _id: CELLAR_ID, name: 'Main', user: OWNER_ID, deletedAt: null,
+    members: [{ user: EDITOR_ID, role: 'editor', addedAt: new Date() }],
+  });
+});
+
+describe('DELETE /api/bottles/:id/open on a consumed bottle', () => {
+  test.each(['drank', 'gifted', 'sold', 'other'])(
+    'refuses a %s bottle with 409 and destroys nothing', async (status) => {
+      const bottle = makeBottle({ status, consumedAt: new Date(), consumedReason: status });
+      Bottle.findById.mockResolvedValue(bottle);
+
+      const res = await closeOpen();
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toMatch(/already consumed/i);
+      expectHistoryIntact(bottle);
+      expect(logAudit).not.toHaveBeenCalled();
+    }
+  );
+
+  test('an EDITOR (not the owner) is refused too — the record belongs to the consume', async () => {
+    const bottle = makeBottle({ status: 'drank', consumedAt: new Date(), consumedReason: 'drank' });
+    Bottle.findById.mockResolvedValue(bottle);
+
+    const res = await closeOpen(EDITOR_ID);
+
+    expect(res.status).toBe(409);
+    expectHistoryIntact(bottle);
+  });
+
+  test('still closes an ACTIVE open bottle — the guard is not over-broad', async () => {
+    const bottle = makeBottle();
+    Bottle.findById.mockResolvedValue(bottle);
+
+    const res = await closeOpen();
+
+    expect(res.status).toBe(200);
+    expect(bottle.openedAt).toBeNull();
+    expect(bottle.pours).toEqual([]);
+    expect(bottle.save).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DELETE /api/bottles/:id/pour on a consumed bottle', () => {
+  test.each(['drank', 'gifted', 'sold', 'other'])(
+    'refuses a %s bottle with 409 and pops nothing', async (status) => {
+      const bottle = makeBottle({ status, consumedAt: new Date(), consumedReason: status });
+      Bottle.findById.mockResolvedValue(bottle);
+
+      const res = await undoPour();
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toMatch(/already consumed/i);
+      expectHistoryIntact(bottle);
+      expect(logAudit).not.toHaveBeenCalled();
+    }
+  );
+
+  test('consumed is checked BEFORE "no pours to undo" — the message names the real reason', async () => {
+    const bottle = makeBottle({ status: 'drank', pours: [], consumedAt: new Date() });
+    Bottle.findById.mockResolvedValue(bottle);
+
+    const res = await undoPour();
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already consumed/i);
+  });
+
+  test('still undoes the last pour on an ACTIVE bottle — the guard is not over-broad', async () => {
+    const bottle = makeBottle();
+    Bottle.findById.mockResolvedValue(bottle);
+
+    const res = await undoPour();
+
+    expect(res.status).toBe(200);
+    expect(bottle.pours).toEqual([POURS[0]]);
+    expect(bottle.save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -229,6 +229,21 @@ async function pourFromBottle(bottle, { ml, count } = {}, req) {
  * Returns { error } | { bottle, prevOpenState }.
  */
 async function closeBottle(bottle, req) {
+  // A consumed bottle KEEPS openedAt/preservationMethod/pours as drinking
+  // history on its consumption record (Bottle schema) — those fields are no
+  // longer current state, so clearing them destroys the record rather than
+  // undoing a mistake. openBottle/pourFromBottle already gate on this; the
+  // guard belongs here rather than in the callers so REST and MCP inherit one
+  // implementation (security audit 2026-07-30 M-1: #866 fixed the MCP tools
+  // one at a time, which left DELETE /api/bottles/:id/open with no guard at
+  // all). To reverse the consume itself, restore the bottle first.
+  if (CONSUMED_STATUSES.includes(bottle.status)) {
+    return { error: {
+      status: 409,
+      code: 'consumed',
+      message: 'This bottle was already consumed — its open-bottle fields are preserved drinking history, not current state. Restore the bottle first if the consume was a mistake.',
+    } };
+  }
   if (!bottle.openedAt) {
     return { error: { status: 400, message: 'Bottle is not open', code: 'not_open' } };
   }

--- a/backend/src/services/bottleOps.test.js
+++ b/backend/src/services/bottleOps.test.js
@@ -484,6 +484,35 @@ describe('open-bottle ops (openBottle / pourFromBottle / closeBottle)', () => {
     expect(res.error.code).toBe('not_open');
   });
 
+  // Security audit 2026-07-30 M-1. A consumed bottle KEEPS its open-bottle
+  // fields as drinking history on the consumption record, so closing it
+  // destroys data instead of undoing a mistake. The guard lives in the service
+  // (not the callers) precisely so REST DELETE /api/bottles/:id/open inherits
+  // it — that route was the hole #866's per-tool guards left open.
+  test('closeBottle refuses a CONSUMED bottle and mutates NOTHING (the drinking history is the record)', async () => {
+    const openedAt = new Date('2026-07-28T19:00:00Z');
+    for (const status of ['drank', 'gifted', 'sold', 'other']) {
+      const bottle = openDoc({ status, openedAt, pours: [{ at: openedAt, ml: 125 }] });
+      const res = await closeBottle(bottle, REQ);
+      expect(res.error.status).toBe(409);
+      expect(res.error.code).toBe('consumed');
+      expect(res.error.message).toMatch(/already consumed/);
+      // The whole point: the history survives the refused call untouched.
+      expect(bottle.openedAt).toEqual(openedAt);
+      expect(bottle.preservationMethod).toBe('vacuum');
+      expect(bottle.pours).toEqual([{ at: openedAt, ml: 125 }]);
+      expect(bottle.save).not.toHaveBeenCalled();
+      expect(logAudit).not.toHaveBeenCalledWith(REQ, 'bottle.open_undo', expect.anything());
+    }
+  });
+
+  test('closeBottle checks consumed BEFORE not_open — a consumed, never-opened bottle still says consumed', async () => {
+    // Order matters for the message the user sees: "not open" would send them
+    // looking for an open state that was never the problem.
+    const res = await closeBottle(freshBottle({ status: 'drank', openedAt: null }), REQ);
+    expect(res.error.code).toBe('consumed');
+  });
+
   test('closeBottle clears the open state and returns the prev snapshot the MCP undo restores', async () => {
     const openedAt = new Date('2026-07-28T19:00:00Z');
     const notified = new Date('2026-07-29T08:00:00Z');


### PR DESCRIPTION
Fixes the Medium and the two cheap Lows from the **2026-07-30 security audit** (`SECURITY_AUDIT_2026-07-30.md`, diff v1.87.2 → v1.94.0: 0 Crit / 0 High / 1 Med / 5 Low).

---

## M-1 — the REST open-bottle routes never got #866's consumed guards

A consumed bottle deliberately **keeps** `openedAt` / `preservationMethod` / `pours`: they are drinking history on the consumption record, not current state. #866 added that guard to the three MCP tools one at a time, which left both REST twins with none:

| Route | Before |
|---|---|
| `DELETE /api/bottles/:id/open` | → `closeBottle()`, whose only precondition was `!bottle.openedAt`. On a consumed bottle it nulled `openedAt`, cleared `preservationMethod` and **discarded the whole `pours` array**. |
| `DELETE /api/bottles/:id/pour` | inline handler, no status check — popped a pour off the same preserved history. |

`requireBottleAccess('editor')` loads the bottle with no status filter, so any cellar **editor** (not just the owner) could destroy the owner's consumption record. No error, and REST writes no MCP ledger row, so there was nothing to undo.

**The fix puts the guard in `bottleOps.closeBottle` rather than in its callers**, so REST and MCP inherit one implementation — fixing it per-caller is precisely what produced this gap. `/pour` is an inline handler and carries its own copy. Both answer **409**, and both check consumed *before* `not_open` / "no pours to undo" so the message names the real reason rather than sending the user looking for an open state that was never the problem.

**No user flow changes:** `BottleDetail` already gates `OpenBottlePanel` on `!isConsumed`, so nothing in the UI could reach these paths legitimately.

One behavioural note worth stating: `rollbackImplicitOpen` (MCP `pour_glass`) also calls `closeBottle`, so if a bottle is consumed in the race window between an implicit open and a failed pour, the rollback is now refused and the open state stays. That is the right trade — never rewrite consumption history — and the function is already documented as best-effort ("if the rollback loses a race, the leftover open is at least visible in the app").

## L-1 — appellation `synonyms` were unvalidated on REST while the MCP twin capped them

`POST`/`PUT /api/admin/taxonomy/appellations` accepted `synonyms` with no element-type check, no per-element length cap and no array-size cap, while `promote_appellation` enforced `z.array(z.string().max(200)).max(10)`. `normalizedSynonyms` is an **indexed multikey field**, so an unbounded array grew the index; a non-string element failed the Mongoose cast into a 500.

Both routes now share a helper that mirrors the zod schema, trims, collapses internal whitespace and de-duplicates case-insensitively (the same shape as `wineProfileOps.normalizeList`). It returns `undefined` rather than `[]` for an empty list, matching the field's `default: undefined` so no empty array is left for the lookup to scan. **A test asserts the REST caps and the MCP zod schema agree** — if either moves, whoever moved it has to move the other.

## L-2 — `name.trim()` before the type check

`name` was checked for truthiness and then `.trim()`ed, so a truthy non-string (`{"$ne":null}`) threw a `TypeError` the catch turned into a 500 with a stack trace. Nothing was exploitable — it throws before any Mongo query — but an admin route should answer 400. `typeof` now, the same fix the auth routes got on 2026-07-25. `PUT` gained the same treatment plus explicit-`null`-clears-the-list, matching how the rest of the admin surface separates "leave alone" from "clear".

---

## Testing

- New: `bottles.openBottle.consumed.test.js` — both routes × all four consumed statuses, asserting the history is **byte-identical after the refused call** and `save()` was never reached; the editor-not-owner case; guard ordering; and active-bottle happy paths proving the guard is not over-broad.
- New: `taxonomy.appellationInput.test.js` — 12 cases including the MCP-parity assertion.
- Extended: `bottleOps.test.js` — `closeBottle` refuses all four consumed statuses and mutates nothing.
- **Regression:** every suite touching `bottleOps` / `openBottle` / `revert` / taxonomy — **38 suites, 507 tests, all green**.

## Compose impact

None. No new env vars, services, ports or migrations — pure application logic.

## Not in this PR

L-3 (appellation `region` not checked against `country` on either surface), L-4 (postcss/vite lockfile bumps — own PR, needs alpine regen) and L-5 (no concurrency guard on `/admin/search/reindex`) are left open; see the audit report.
