### PR TITLE
fix(taxonomy): enforce appellation region belongs to its country on every write surface

### DIFF
--- a/backend/src/mcp/adminRegistryTools.test.js
+++ b/backend/src/mcp/adminRegistryTools.test.js
@@ -147,6 +147,7 @@ describe('official image + credit', () => {
 jest.mock('../services/taxonomyReview', () => ({
   listPendingRegions: jest.fn(),
   listUnmatchedAppellations: jest.fn(),
+  appellationRefsError: jest.fn(), // resolves undefined → guard passes
 }));
 jest.mock('../models/Region', () => ({ findById: jest.fn() }));
 jest.mock('../models/Appellation', () => {
@@ -154,7 +155,7 @@ jest.mock('../models/Appellation', () => {
   return M;
 });
 
-const { listPendingRegions, listUnmatchedAppellations } = require('../services/taxonomyReview');
+const { listPendingRegions, listUnmatchedAppellations, appellationRefsError } = require('../services/taxonomyReview');
 const Region = require('../models/Region');
 const Appellation = require('../models/Appellation');
 
@@ -213,5 +214,15 @@ describe('taxonomy review tools', () => {
     const body = parse(await tool('promote_appellation').handler(
       { name: 'Alsace', country_id: oid('c') }, ADMIN_CTX));
     expect(body.error.code).toBe('conflict');
+  });
+
+  test('promote_appellation runs the shared ref guard — "must belong to the same country" is now enforced, not documented (audit 2026-07-30)', async () => {
+    appellationRefsError.mockResolvedValueOnce('Region "Rioja" belongs to a different country than the appellation');
+    const body = parse(await tool('promote_appellation').handler(
+      { name: 'Somontano', country_id: oid('c'), region_id: oid('d') }, ADMIN_CTX));
+    expect(body.error.code).toBe('invalid_input');
+    expect(body.error.message).toMatch(/different country/);
+    expect(appellationRefsError).toHaveBeenCalledWith(oid('c'), oid('d'));
+    expect(Appellation).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/mcp/tools/adminRegistry.js
+++ b/backend/src/mcp/tools/adminRegistry.js
@@ -256,6 +256,12 @@ registerTool({
   handler: async (args, ctx) => {
     if (!isValidId(args.country_id)) return fail('invalid_input', 'country_id must be a 24-hex Mongo id.');
     if (args.region_id && !isValidId(args.region_id)) return fail('invalid_input', 'region_id must be a 24-hex Mongo id.');
+    // The schema's "must belong to the same country" was documentation, not
+    // validation (code audit 2026-07-30) — enforce it via the shared guard so
+    // this surface and the REST twin cannot drift.
+    const { appellationRefsError } = require('../../services/taxonomyReview');
+    const refsError = await appellationRefsError(args.country_id, args.region_id);
+    if (refsError) return fail('invalid_input', refsError);
     const Appellation = require('../../models/Appellation');
     const { normalizeAppellationKey } = require('../../utils/normalize');
     const appellation = new Appellation({

--- a/backend/src/routes/admin/taxonomy.appellationRefs.test.js
+++ b/backend/src/routes/admin/taxonomy.appellationRefs.test.js
@@ -1,0 +1,131 @@
+/**
+ * POST/PUT /api/admin/taxonomy/appellations — ref-guard wiring (code audit
+ * 2026-07-30: "appellation region not checked against country").
+ *
+ * The invariant itself is pinned in services/taxonomyReview.refs.test.js;
+ * what THIS file pins is that the routes actually call the shared guard and
+ * honour its answer — create validates the body's country/region pair, and
+ * update re-validates a NEW region against the doc's existing country (update
+ * was the easiest drift path: a correctly created doc could be re-pointed at
+ * any region). Clearing the region stays guard-free.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../services/search', () => ({
+  getIsAvailable: jest.fn(() => false),
+  indexWine: jest.fn(),
+  removeWine: jest.fn(),
+  bulkIndexWines: jest.fn(),
+  bulkIndexBottles: jest.fn(),
+  fullSync: jest.fn(),
+  fullSyncBottles: jest.fn(),
+  waitForTasks: jest.fn(),
+}));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/taxonomyReview', () => ({
+  listPendingRegions: jest.fn(),
+  listUnmatchedAppellations: jest.fn(),
+  appellationRefsError: jest.fn(),
+}));
+jest.mock('../../models/Appellation', () => {
+  const M = jest.fn(function (doc) {
+    Object.assign(this, doc);
+    this._id = 'ap-1';
+    this.save = jest.fn().mockResolvedValue(undefined);
+    this.populate = jest.fn().mockResolvedValue(undefined);
+  });
+  M.findById = jest.fn();
+  M.find = jest.fn();
+  return M;
+});
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const { appellationRefsError } = require('../../services/taxonomyReview');
+const Appellation = require('../../models/Appellation');
+const router = require('./taxonomy');
+
+const ADMIN_ID = '64b000000000000000000001';
+const COUNTRY_ID = '64b0000000000000000000c1';
+const REGION_ID = '64b0000000000000000000e1';
+const AP_ID = '64b0000000000000000000a1';
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/taxonomy', router);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const call = (method, path, body) => fetch(`${baseUrl}/api/admin/taxonomy${path}`, {
+  method,
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+  body: JSON.stringify(body),
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('POST /appellations', () => {
+  test('rejects with the guard\'s message and never constructs the doc', async () => {
+    appellationRefsError.mockResolvedValue('Region "Rioja" belongs to a different country than the appellation');
+    const res = await call('POST', '/appellations', { name: 'Somontano', country: COUNTRY_ID, region: REGION_ID });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/different country/);
+    expect(appellationRefsError).toHaveBeenCalledWith(COUNTRY_ID, REGION_ID);
+    expect(Appellation).not.toHaveBeenCalled();
+  });
+
+  test('creates when the guard passes', async () => {
+    appellationRefsError.mockResolvedValue(null);
+    const res = await call('POST', '/appellations', { name: 'Somontano', country: COUNTRY_ID, region: REGION_ID });
+    expect(res.status).toBe(201);
+    expect(Appellation.mock.calls[0][0]).toMatchObject({ country: COUNTRY_ID, region: REGION_ID });
+  });
+});
+
+describe('PUT /appellations/:id', () => {
+  const doc = () => ({
+    _id: AP_ID, name: 'Somontano', country: COUNTRY_ID, region: null,
+    save: jest.fn().mockResolvedValue(undefined),
+    populate: jest.fn().mockResolvedValue(undefined),
+  });
+
+  test('setting a region validates it against the DOC\'s country and honours a rejection', async () => {
+    const ap = doc();
+    Appellation.findById.mockResolvedValue(ap);
+    appellationRefsError.mockResolvedValue('Region "Rioja" belongs to a different country than the appellation');
+    const res = await call('PUT', `/appellations/${AP_ID}`, { region: REGION_ID });
+    expect(res.status).toBe(400);
+    // The existing country, not anything from the request body.
+    expect(appellationRefsError).toHaveBeenCalledWith(COUNTRY_ID, REGION_ID);
+    expect(ap.save).not.toHaveBeenCalled();
+    expect(ap.region).toBeNull();
+  });
+
+  test('setting a valid region passes and saves', async () => {
+    const ap = doc();
+    Appellation.findById.mockResolvedValue(ap);
+    appellationRefsError.mockResolvedValue(null);
+    const res = await call('PUT', `/appellations/${AP_ID}`, { region: REGION_ID });
+    expect(res.status).toBe(200);
+    expect(ap.region).toBe(REGION_ID);
+    expect(ap.save).toHaveBeenCalled();
+  });
+
+  test('clearing the region (null) needs no guard — always allowed', async () => {
+    const ap = doc();
+    ap.region = REGION_ID;
+    Appellation.findById.mockResolvedValue(ap);
+    const res = await call('PUT', `/appellations/${AP_ID}`, { region: null });
+    expect(res.status).toBe(200);
+    expect(appellationRefsError).not.toHaveBeenCalled();
+    expect(ap.region).toBeNull();
+    expect(ap.save).toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -12,7 +12,7 @@ const { logAudit } = require('../../services/audit');
 const { isValidId } = require('../../utils/validation');
 const { distinctSizes, normalizeAll, remap } = require('../../services/bottleSizeMaintenance');
 const { mergeGrapes, mergeRegions, mergeCountries } = require('../../services/taxonomyMerge');
-const { listUnmatchedAppellations } = require('../../services/taxonomyReview');
+const { listUnmatchedAppellations, appellationRefsError } = require('../../services/taxonomyReview');
 const { BOTTLE_SIZES } = require('../../config/bottleSizes');
 
 const router = express.Router();
@@ -731,6 +731,12 @@ router.post('/appellations', async (req, res) => {
     if (!country) {
       return res.status(400).json({ error: 'Country is required' });
     }
+    // Both refs verified: the ids must exist and the region must belong to the
+    // country (code audit 2026-07-30) — the schema declares the refs but
+    // enforces neither, so a cross-country region would sit silently wrong in
+    // curated taxonomy until the appellation-hierarchy work inherited it.
+    const refsError = await appellationRefsError(country, region);
+    if (refsError) return res.status(400).json({ error: refsError });
 
     let cleanSynonyms;
     if (synonyms !== undefined && synonyms !== null) {
@@ -787,7 +793,16 @@ router.put('/appellations/:id', async (req, res) => {
       appellation.name = name.trim();
       appellation.normalizedName = normalizeAppellationKey(name);
     }
-    if (region !== undefined) appellation.region = region || null;
+    if (region !== undefined) {
+      // Clearing (null/'') is always fine; SETTING a region re-validates it
+      // against the appellation's country — update was the easiest drift path,
+      // since a correctly created doc could be re-pointed at any region.
+      if (region) {
+        const refsError = await appellationRefsError(appellation.country, region);
+        if (refsError) return res.status(400).json({ error: refsError });
+      }
+      appellation.region = region || null;
+    }
     if (synonyms !== undefined) {
       // null clears the list, matching how the rest of the admin surface
       // distinguishes "leave alone" (absent) from "clear" (explicit null).

--- a/backend/src/scripts/check-appellation-region-country.js
+++ b/backend/src/scripts/check-appellation-region-country.js
@@ -1,0 +1,69 @@
+/**
+ * READ-ONLY sweep of the curated Appellation collection for ref integrity
+ * (code audit 2026-07-30: "appellation region not checked against country").
+ *
+ * The write surfaces now enforce, via appellationRefsError, that an
+ * appellation's region belongs to its country and that both refs exist — but
+ * ~880 docs were created before the guard (seed script, joint-review
+ * promotions, admin UI). The seed script grouped regions per country so those
+ * are structurally safe; this verifies the whole collection rather than
+ * assuming it.
+ *
+ * Reports, never writes:
+ *   - region docs pointing at a DIFFERENT country than the appellation's
+ *   - dangling country refs (id no longer exists)
+ *   - dangling region refs (id no longer exists)
+ *
+ * Any hit is fixed by hand in Admin → Taxonomy (re-point or clear the region)
+ * — with wine counts this small, a write mode would be more risk than typing.
+ *
+ *   docker exec cellarion-backend node src/scripts/check-appellation-region-country.js
+ */
+
+const mongoose = require('mongoose');
+const Appellation = require('../models/Appellation');
+const Country = require('../models/Country');
+const Region = require('../models/Region');
+
+(async () => {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+
+  const docs = await Appellation.find({}).select('name country region').lean();
+  const countryIds = [...new Set(docs.map(d => String(d.country)).filter(Boolean))];
+  const regionIds = [...new Set(docs.map(d => d.region && String(d.region)).filter(Boolean))];
+
+  const [countries, regions] = await Promise.all([
+    Country.find({ _id: { $in: countryIds } }).select('name').lean(),
+    Region.find({ _id: { $in: regionIds } }).select('name country').lean(),
+  ]);
+  const countryById = new Map(countries.map(c => [String(c._id), c]));
+  const regionById = new Map(regions.map(r => [String(r._id), r]));
+
+  let mismatches = 0, danglingCountry = 0, danglingRegion = 0;
+  for (const d of docs) {
+    const country = countryById.get(String(d.country));
+    if (!country) {
+      danglingCountry += 1;
+      console.log(`DANGLING COUNTRY  "${d.name}" (${d._id}) → country ${d.country} does not exist`);
+    }
+    if (!d.region) continue;
+    const region = regionById.get(String(d.region));
+    if (!region) {
+      danglingRegion += 1;
+      console.log(`DANGLING REGION   "${d.name}" (${d._id}) → region ${d.region} does not exist`);
+    } else if (String(region.country) !== String(d.country)) {
+      mismatches += 1;
+      const regionCountry = countryById.get(String(region.country));
+      console.log(
+        `COUNTRY MISMATCH  "${d.name}" (${d._id}) is in ${country?.name || d.country} ` +
+        `but its region "${region.name}" belongs to ${regionCountry?.name || region.country}`
+      );
+    }
+  }
+
+  console.log(`\nChecked ${docs.length} appellations (${regionIds.length} distinct regions referenced).`);
+  console.log(`Mismatched regions: ${mismatches} · dangling country refs: ${danglingCountry} · dangling region refs: ${danglingRegion}`);
+  if (mismatches + danglingCountry + danglingRegion === 0) console.log('All clean — the invariant already holds for existing data.');
+
+  await mongoose.disconnect();
+})().catch((err) => { console.error(err); process.exit(1); });

--- a/backend/src/services/taxonomyReview.js
+++ b/backend/src/services/taxonomyReview.js
@@ -32,14 +32,20 @@ const { isValidId } = require('../utils/validation');
  * @returns {Promise<string|null>} a human-readable error, or null when valid.
  */
 async function appellationRefsError(countryId, regionId) {
-  if (!countryId || !isValidId(String(countryId))) return 'A valid country id is required';
-  const countryExists = await Country.exists({ _id: countryId });
+  // Queries use the STRING that passed isValidId, never the raw input — the
+  // caller may hand us an ObjectId (the PUT path) or request-body junk, and
+  // querying the validated derivative is what keeps operator objects out of
+  // the filter (CodeQL js/sql-injection).
+  const countryKey = String(countryId ?? '');
+  if (!isValidId(countryKey)) return 'A valid country id is required';
+  const countryExists = await Country.exists({ _id: countryKey });
   if (!countryExists) return 'No country with that id';
   if (!regionId) return null;
-  if (!isValidId(String(regionId))) return 'Invalid region id';
-  const region = await Region.findById(regionId).select('name country').lean();
+  const regionKey = String(regionId);
+  if (!isValidId(regionKey)) return 'Invalid region id';
+  const region = await Region.findById(regionKey).select('name country').lean();
   if (!region) return 'No region with that id';
-  if (String(region.country) !== String(countryId)) {
+  if (String(region.country) !== countryKey) {
     return `Region "${region.name}" belongs to a different country than the appellation`;
   }
   return null;

--- a/backend/src/services/taxonomyReview.js
+++ b/backend/src/services/taxonomyReview.js
@@ -15,6 +15,35 @@ const Region = require('../models/Region');
 const Country = require('../models/Country');
 const Appellation = require('../models/Appellation');
 const { normalizeAppellation, normalizeAppellationKey } = require('../utils/normalize');
+const { isValidId } = require('../utils/validation');
+
+/**
+ * Ref validation for an Appellation write (code audit 2026-07-30: "appellation
+ * region not checked against country"). The schema declares country and region
+ * refs but Mongoose verifies neither that the ids exist nor that the region
+ * belongs to the country — listUnmatchedAppellations() below even drops
+ * cross-country suggestions on the assumption the schema enforces this, which
+ * it never did. Every write surface (REST create/update, MCP
+ * promote_appellation) shares this one check so the invariant holds no matter
+ * what the caller sends and the surfaces cannot drift.
+ *
+ * @param {*} countryId  required — the appellation's country
+ * @param {*} regionId   optional — validated only when set
+ * @returns {Promise<string|null>} a human-readable error, or null when valid.
+ */
+async function appellationRefsError(countryId, regionId) {
+  if (!countryId || !isValidId(String(countryId))) return 'A valid country id is required';
+  const countryExists = await Country.exists({ _id: countryId });
+  if (!countryExists) return 'No country with that id';
+  if (!regionId) return null;
+  if (!isValidId(String(regionId))) return 'Invalid region id';
+  const region = await Region.findById(regionId).select('name country').lean();
+  if (!region) return 'No region with that id';
+  if (String(region.country) !== String(countryId)) {
+    return `Region "${region.name}" belongs to a different country than the appellation`;
+  }
+  return null;
+}
 
 /**
  * Regions minted by user writes and not yet reviewed, newest first, each with
@@ -100,11 +129,12 @@ async function listUnmatchedAppellations() {
       ...i,
       countryName: i.countryId ? countryName.get(i.countryId) || null : null,
       // A majority region from a DIFFERENT country than the majority country
-      // would violate the Appellation schema — drop it.
+      // would be rejected by appellationRefsError at promotion time — drop it
+      // from the suggestion instead of suggesting an invalid promotion.
       regionId: regionOk ? i.regionId : null,
       regionName: regionOk ? region.name : null,
     };
   });
 }
 
-module.exports = { listPendingRegions, listUnmatchedAppellations };
+module.exports = { listPendingRegions, listUnmatchedAppellations, appellationRefsError };

--- a/backend/src/services/taxonomyReview.refs.test.js
+++ b/backend/src/services/taxonomyReview.refs.test.js
@@ -1,0 +1,89 @@
+/**
+ * appellationRefsError — the shared ref guard for every Appellation write
+ * surface (code audit 2026-07-30: "appellation region not checked against
+ * country").
+ *
+ * WHY THIS TEST EXISTS: the Appellation schema declares country and region
+ * refs but enforces neither existence nor that the region belongs to the
+ * country. Three surfaces (REST create, REST update, MCP promote_appellation)
+ * accepted any valid ObjectId — the MCP schema even *documented* "must belong
+ * to the same country" without checking it. The guard is the invariant; this
+ * pins its behaviour for every input class.
+ */
+
+jest.mock('../models/WineDefinition', () => ({ aggregate: jest.fn() }));
+jest.mock('../models/Region', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/Country', () => ({ find: jest.fn(), exists: jest.fn() }));
+jest.mock('../models/Appellation', () => ({ find: jest.fn() }));
+
+const mongoose = require('mongoose');
+const Country = require('../models/Country');
+const Region = require('../models/Region');
+const { appellationRefsError } = require('./taxonomyReview');
+
+const oid = (c) => c.repeat(24);
+// Region.findById(id).select('name country').lean()
+const regionChain = (doc) => ({ select: jest.fn(() => ({ lean: jest.fn(() => Promise.resolve(doc)) })) });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('country ref', () => {
+  test('missing or malformed country id fails before any query', async () => {
+    for (const bad of [undefined, null, '', 'not-an-id', { $ne: null }, 42]) {
+      expect(await appellationRefsError(bad, undefined)).toMatch(/valid country id/i);
+    }
+    expect(Country.exists).not.toHaveBeenCalled();
+  });
+
+  test('a well-formed id that matches no country is rejected — no dangling refs', async () => {
+    Country.exists.mockResolvedValue(null);
+    expect(await appellationRefsError(oid('c'), undefined)).toMatch(/No country/i);
+  });
+
+  test('an ObjectId (not just a string) is accepted — the PUT path passes doc.country', async () => {
+    Country.exists.mockResolvedValue({ _id: oid('c') });
+    expect(await appellationRefsError(new mongoose.Types.ObjectId(oid('c')), undefined)).toBeNull();
+  });
+});
+
+describe('region ref', () => {
+  beforeEach(() => Country.exists.mockResolvedValue({ _id: oid('c') }));
+
+  test('no region is always fine — region is optional on the schema', async () => {
+    for (const empty of [undefined, null, '']) {
+      expect(await appellationRefsError(oid('c'), empty)).toBeNull();
+    }
+    expect(Region.findById).not.toHaveBeenCalled();
+  });
+
+  test('malformed region id fails before any query', async () => {
+    expect(await appellationRefsError(oid('c'), 'nope')).toMatch(/Invalid region id/);
+    expect(Region.findById).not.toHaveBeenCalled();
+  });
+
+  test('a well-formed id that matches no region is rejected', async () => {
+    Region.findById.mockReturnValue(regionChain(null));
+    expect(await appellationRefsError(oid('c'), oid('d'))).toMatch(/No region/i);
+  });
+
+  test('THE AUDIT FINDING: a region from another country is rejected, by name', async () => {
+    Region.findById.mockReturnValue(regionChain({ _id: oid('d'), name: 'Rioja', country: oid('e') }));
+    const error = await appellationRefsError(oid('c'), oid('d'));
+    expect(error).toMatch(/"Rioja"/);
+    expect(error).toMatch(/different country/i);
+  });
+
+  test('a region of the same country passes', async () => {
+    Region.findById.mockReturnValue(regionChain({ _id: oid('d'), name: 'Pfalz', country: oid('c') }));
+    expect(await appellationRefsError(oid('c'), oid('d'))).toBeNull();
+  });
+
+  test('ObjectId-vs-string country comparison is normalized, not ===', async () => {
+    // The PUT path compares the doc's ObjectId country against a lean region's
+    // ObjectId country; the POST path compares two strings. Both must pass.
+    Region.findById.mockReturnValue(regionChain({
+      _id: oid('d'), name: 'Pfalz', country: new mongoose.Types.ObjectId(oid('c')),
+    }));
+    expect(await appellationRefsError(new mongoose.Types.ObjectId(oid('c')), oid('d'))).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Audit finding: **appellation region not checked against country**. The `Appellation` schema declares `country` and `region` refs but validates neither existence nor ownership, so all three write surfaces accepted a region from a different country:

- **REST POST** `/api/admin/taxonomy/appellations` — stored `region` straight from the body
- **REST PUT** — the easiest drift path: could re-point a correctly created doc at any region
- **MCP `promote_appellation`** — the schema *documented* "must belong to the same country" but the handler never checked it

`listUnmatchedAppellations()` even drops cross-country suggestions on the assumption the schema enforces this — it never did.

## How

- New shared guard `appellationRefsError(countryId, regionId)` in `services/taxonomyReview.js` (the existing shared REST+MCP taxonomy service): ids must be valid **and exist**, and `region.country` must equal the appellation's country. One implementation, so the surfaces cannot drift.
- POST validates the body pair; PUT validates a **newly set** region against the doc's existing country (clearing the region stays guard-free); `promote_appellation` runs the same guard → `invalid_input`.
- Read-only sweep script `check-appellation-region-country.js` for existing docs (cross-country regions + dangling country/region refs).

## Blast radius

None to user data: the write-time resolver only adopts the appellation *name string* onto wines — it never copies country/region. This protects curated taxonomy ahead of the appellation-hierarchy work, which would inherit these links as load-bearing.

## Verification

- 5 affected Jest suites in `node:20-alpine`: **48/48 green** (new guard unit suite, new REST wiring suite, extended MCP suite, plus the two existing taxonomy suites)
- Sweep run against **prod** (read-only, 2026-07-30): 875 appellations, 208 distinct regions referenced — **0 mismatches, 0 dangling refs**. The guard protects an invariant that already holds.

## Compose / prod impact

None — no env vars, no compose changes, no migration. The sweep script is optional and read-only.