### PR TITLE
fix(deps): resolve the postcss path-traversal advisory in both trees (GHSA-r28c-9q8g-f849)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6519,9 +6519,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7208,9 +7208,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7227,7 +7227,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4691,9 +4691,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4830,9 +4830,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4850,7 +4850,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,7 @@
   "overrides": {
     "yaml": "2.8.3",
     "serialize-javascript": "7.0.5",
-    "postcss": "8.5.12",
+    "postcss": "^8.5.18",
     "fast-uri": "3.1.4",
     "esbuild": "^0.28.1",
     "markdown-it": "^14.2.0",


### PR DESCRIPTION
**L-4 from the 2026-07-30 security audit** (`SECURITY_AUDIT_2026-07-30.md`): postcss ≤ 8.5.17 discloses arbitrary `.map` files via `sourceMappingURL` auto-loading ([GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849)). Both trees now resolve **postcss 8.5.25**. Diff is 15 lines per lockfile: postcss + its `nanoid` dependency, nothing else.

## The root cause worth knowing about

The frontend never picked up the patch on its own because `package.json` **`overrides` exact-pinned `postcss: "8.5.12"`** — a previous advisory's fix. An exact override wins over every dependency's range, so `npm update` and Dependabot lockfile bumps have been silently no-oping ever since: the pin that once fixed an advisory became the thing holding the tree below the next one.

The override is now a **caret floor**: `"postcss": "^8.5.18"` (the first patched release). It still guarantees the minimum, but future patches flow through routine updates instead of needing this same hand-edit again. The `vite` HIGH was purely "depends on vulnerable postcss" and clears with it. The other overrides are untouched.

Backend needed no manifest change — postcss rides sanitize-html's `^8` range; a targeted `npm update postcss` moved it.

## Regen procedure note

Lockfiles were regenerated inside **`node:24-alpine`** — the digest-pinned image both Dockerfiles build `FROM`. First attempt used `node:20-alpine` (per the older runbook) and its npm 10 stripped the `libc` metadata fields that npm ≥ 11 writes, turning a 2-entry bump into 62 lines of churn; redone on node 24 the diff is surgical. All 24 `@img/sharp-*` and the rollup-musl platform entries are intact.

## Verification (all inside node:24-alpine)

- **Backend:** `npm ci --omit=dev` clean + `require('sharp')` loads — the silent-runtime-breakage mode that host-regenerated locks caused in v1.67.1
- **Frontend:** `npm ci --legacy-peer-deps` clean, `vite build` green, **vitest 814/814**
- **npm audit after:** frontend **0 high** (only the react-router moderates remain — known-unreachable #127/#128); backend postcss/vite gone (the jest/archiver devDep chain remains, verified unreachable in the audit)

## Not in this PR

`brace-expansion` (the third Dependabot high) is deliberately excluded: its advisory range is `<=5.0.7` with **no patched release in the 1.x/2.x lines** that minimatch/glob require, so fixing it means the archiver@8 semver-major chain — a separate decision, and the path is verified unreachable (`cellarExport` never calls `.glob()`; jest is a devDependency outside the runtime image).

The two postcss Dependabot alerts should auto-resolve on merge.

## Compose impact

None — no new env vars, services, ports or migrations. Docker images pick up the new lockfile on the next build.
