### PR TITLE
chore(release): v1.94.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.94.0",
+  "version": "1.94.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.94.0",
+      "version": "1.94.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.94.0",
+  "version": "1.94.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.94.0",
+  "version": "1.94.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.94.0",
+      "version": "1.94.1",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.94.0",
+  "version": "1.94.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for the v1.94.1 patch release.

Ships (merged on main since v1.94.0):
- #870 — fix(security): consumed-bottle guards on the REST open-bottle routes; appellation input validation (2026-07-30 security audit M-1 + L-1 + L-2)
- #872 — fix(deps): postcss 8.5.25 in both trees (GHSA-r28c-9q8g-f849, audit L-4); frontend overrides exact-pin → caret floor

Standard 6-line bump (both package.json + both lockfile roots).