### PR TITLE
fix(deps): take the brace-expansion DoS backports (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3174,9 +3174,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8435,9 +8435,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Closes Dependabot alert #131 (CVE-2026-14257, high): DoS via unbounded brace expansion causing an OOM crash.

When the 2026-07-30 security audit assessed this alert, no patch existed for the 1.x/2.x lines and the only route looked like an archiver@8 major bump, so it was parked as unreachable. Upstream has since backported the fix: **2.1.3** (Jul 28) and **1.1.17** (Jul 29) — the 2.1.3 commit is literally `fix: backport GHSA-mh99-v99m-4gvg`. Both are inside the lockfile's existing `^2.0.2` / `^1.1.7` ranges, so this is a lockfile-only targeted bump, no manifest or major-version changes.

## Changes
- `backend/package-lock.json`: brace-expansion 2.1.2 → 2.1.3 (runtime, via archiver → glob/readdir-glob → minimatch) and 1.1.16 → 1.1.17 (dev, via jest → test-exclude → minimatch). nodemon's copy was already on the patched 5.0.8.

## Process
- Bump run as `npm update brace-expansion` inside **node:24-alpine** (mount-copy pattern) — diff is surgical, no platform-metadata churn.
- Verified in node:24-alpine: `npm ci --omit=dev` clean, `require('sharp')` loads, installed brace-expansion is 2.1.3.

## Notes
- The vulnerable path was and remains unreachable in practice (`cellarExport.js` only uses `archive.append()`/`.file()`, never the glob API), so no release urgency — this rides the next one.
- GitHub's advisory metadata still lists only 5.0.8 as patched (`<= 5.0.7` vulnerable), so Dependabot may not auto-close #131 after merge; if it lingers, dismiss it manually citing the 2.1.3 backport commit.