### PR TITLE
feat(cellar): opt-in personal-note preview in the bottle list

### DIFF
--- a/frontend/src/components/BottleCard.css
+++ b/frontend/src/components/BottleCard.css
@@ -102,6 +102,16 @@
   flex-wrap: wrap;
 }
 
+.bottle-note-preview {
+  font-size: 0.78rem;
+  font-style: italic;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 0.15rem;
+}
+
 .bottle-producer {
   white-space: nowrap;
   overflow: hidden;

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -19,7 +19,7 @@ const MATURITY_LABELS = {
  * Renders a single bottle in either list or card (grid) view.
  * Props: bottle, rackMap, cellarId, viewMode ('list' | 'card')
  */
-function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick, showCellarBadge = false, compact = false, rackKnown = false }) {
+function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick, showCellarBadge = false, compact = false, rackKnown = false, showNotes = false }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -49,6 +49,20 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
   // onClick overrides navigation — used to expand a collapsed group instead.
   const handleClick = onClick || (() => navigate(`/cellars/${cellarId}/bottles/${bottle._id}`));
   const handleKey = e => e.key === 'Enter' && handleClick();
+
+  // Opt-in personal-note preview (list view only). Occasion ("Gift from Anna")
+  // leads, then the first line of the tasting notes; CSS clamps to one line.
+  // Suppressed for collapsed groups — members may carry different notes, so a
+  // single bottle's text would be misleading (same reasoning as the rack badge).
+  const occasion = (bottle.occasion || '').trim();
+  const firstNoteLine = (bottle.notes || '').split('\n')[0].trim();
+  const notePreview = showNotes && !isGroup && viewMode !== 'card'
+    ? [occasion, firstNoteLine].filter(Boolean).join(' · ')
+    : '';
+  // Desktop hover bonus (the ticket asked for a tooltip): full text on title.
+  const noteTitle = notePreview
+    ? [occasion, (bottle.notes || '').trim()].filter(Boolean).join('\n\n')
+    : undefined;
 
   if (viewMode === 'card') {
     return (
@@ -171,6 +185,9 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
           <span className="bottle-producer">{displayProducer}</span>
           {bottle.vintage && <span className="bottle-vintage">{bottle.vintage}</span>}
         </div>
+        {notePreview && (
+          <div className="bottle-note-preview" title={noteTitle}>{notePreview}</div>
+        )}
         <div className="bottle-badges">
           {cellarBadge && (
             <span className="cellar-badge" style={cellarBadgeColor ? { '--cellar-badge-color': cellarBadgeColor } : undefined}>
@@ -227,7 +244,7 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
 // values derived from the OTHER compared props (the bottle/group item) — if a
 // future caller closes over unrelated state, that handler must be stabilized
 // with useCallback instead.
-const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount', 'showCellarBadge', 'compact', 'rackKnown'];
+const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount', 'showCellarBadge', 'compact', 'rackKnown', 'showNotes'];
 export default memo(BottleCard, (prev, next) =>
   COMPARED_PROPS.every(key => prev[key] === next[key])
 );

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -704,6 +704,7 @@
     "noSearchResults": "No bottles match your search.",
     "toggleFilters": "Filters",
     "compactView": "Compact view",
+    "showNotes": "Show notes",
     "addFirstBottle": "Add Your First Bottle",
     "loadMore": "Load more bottles",
     "myCellarColor": "My Cellar Color",

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -726,6 +726,9 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
   const [density, setDensity] = useState(() => {
     try { return localStorage.getItem('cellarion_bottle_density') || 'comfortable'; } catch { return 'comfortable'; }
   });
+  const [showNotes, setShowNotes] = useState(() => {
+    try { return localStorage.getItem('cellarion_bottle_notes') === '1'; } catch { return false; }
+  });
   const [expandedGroups, setExpandedGroups] = useState(() => new Set());
 
   const setView = (mode) => {
@@ -738,8 +741,17 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
     try { localStorage.setItem('cellarion_bottle_density', mode); } catch {}
   };
 
+  const toggleNotes = () => {
+    setShowNotes(on => {
+      try { localStorage.setItem('cellarion_bottle_notes', on ? '0' : '1'); } catch {}
+      return !on;
+    });
+  };
+
   // Compact only applies to list view — the grid's height is driven by the image.
   const compact = viewMode === 'list' && density === 'compact';
+  // Notes preview likewise: the grid tiles have no room for a text line.
+  const notesOn = viewMode === 'list' && showNotes;
 
   const toggleGroup = (key) => {
     setExpandedGroups(prev => {
@@ -752,6 +764,17 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
   return (
     <>
       <div className="bottles-view-toggle">
+        {viewMode === 'list' && (
+          <button
+            className={`view-toggle-btn notes-toggle-btn ${showNotes ? 'active' : ''}`}
+            onClick={toggleNotes}
+            aria-label={t('cellarDetail.showNotes', 'Show notes')}
+            aria-pressed={showNotes}
+            title={t('cellarDetail.showNotes', 'Show notes')}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          </button>
+        )}
         {viewMode === 'list' && (
           <button
             className={`view-toggle-btn density-toggle-btn ${density === 'compact' ? 'active' : ''}`}
@@ -795,6 +818,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                 showCellarBadge
                 compact={compact}
                 rackKnown={rackKnown}
+                showNotes={notesOn}
               />
             );
           }
@@ -803,7 +827,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
             const rep = item.bottles[0];
             if (item.count === 1) {
               return (
-                <BottleCard key={rep._id} bottle={rep} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} />
+                <BottleCard key={rep._id} bottle={rep} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} showNotes={notesOn} />
               );
             }
             if (!expandedGroups.has(item.key)) {
@@ -818,6 +842,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                   onClick={() => toggleGroup(item.key)}
                   compact={compact}
                   rackKnown={rackKnown}
+                  showNotes={notesOn}
                 />
               );
             }
@@ -831,14 +856,14 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                   </button>
                 </div>
                 {item.bottles.map(b => (
-                  <BottleCard key={b._id} bottle={b} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} />
+                  <BottleCard key={b._id} bottle={b} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} showNotes={notesOn} />
                 ))}
               </Fragment>
             );
           }
           // Defensive fallback: a plain bottle item (responses are always grouped)
           return (
-            <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} />
+            <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} showNotes={notesOn} />
           );
         })}
       </div>


### PR DESCRIPTION
Implements the feature requested in support ticket "Commentary displayed on wine list" (rekerukuru, 2026-07-29): surface a bottle's personal notes in the cellar bottle list.

## What it does
- New **Show notes** toggle (speech-bubble icon) in the bottle-list view toggle row, next to the density toggle. **Off by default**, persisted per device in localStorage (`cellarion_bottle_notes`) — exactly the pattern the list/card and comfortable/compact toggles already use. Users who never press it see no change.
- When on, list-view rows show a one-line, ellipsis-clamped preview under the producer/vintage line: `occasion` ("Gift from Anna") first, then the first line of the tasting `notes`, joined with ` · `.
- The preview row carries the full text (occasion + complete notes) as a `title` tooltip — the ticket's hover-tooltip ask, as a free desktop bonus on top of the inline preview that mobile needs.
- Suppressed for collapsed groups (members may carry different notes — same reasoning as the existing rack-badge suppression) and in card view (no room in the grid tiles; v1 is list-only by design).

## Notes
- Frontend-only: the list endpoints already return `notes`/`occasion` on every bottle.
- `showNotes` added to BottleCard's memo `COMPARED_PROPS` so toggling actually re-renders the cards.
- One new en-only i18n key (`cellarDetail.showNotes`) per the i18n workflow; other locales via Weblate.

## Testing
- `npm test`: 45 files / 814 tests green.
- `npm run build` (Vite production) green.