### PR TITLE
chore(release): v1.95.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.94.1",
+  "version": "1.95.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.94.1",
+      "version": "1.95.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.94.1",
+  "version": "1.95.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.94.1",
+  "version": "1.95.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.94.1",
+      "version": "1.95.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.94.1",
+  "version": "1.95.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for v1.95.0.

Ships:
- #871 appellation region↔country guard on every write surface (security audit L-3)
- #874 brace-expansion DoS backports (Dependabot #131, CVE-2026-14257)
- #875 opt-in personal-note preview in the bottle list (support ticket)
- #869 Weblate maintainer runbook (docs)
- #830 docker/login-action bump