### PR TITLE
fix(enrichment): coerce sentinel-string descriptors to real null; harden generator prompts

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -41,6 +41,7 @@ Important rules:
 - Labels often print a founder's or family name as part of the producer's crest/logo lockup (e.g. "DESIDERIUS" in small text above "PONGRÁCZ"). Such words belong to the producer identity, NOT the wine name. The name is the line that distinguishes this bottle within the producer's range (here "Blanc de Blancs") — include a person's name only when it genuinely names the cuvée itself (e.g. Pongrácz's separate prestige bottling "Desiderius").
 - Production-method terms are NOT part of the name — put "Méthode Cap Classique" / "Cap Classique", "Méthode Traditionnelle", "Metodo Classico" / "Traditional Method" in the appellation field instead (name "Blanc de Blancs" + appellation "Méthode Cap Classique", NOT name "Blanc de Blancs Méthode Cap Classique"). Legally-defined aging classifications that belong to the displayed name (Reserva, Gran Reserva, Riserva, Spätlese, Grosses Gewächs) and dosage words that are part of a cuvée name (e.g. "Brut Premier") stay in the name.
 - Do not hallucinate appellation names, producer names, or grape varieties. Only use names you are confident are real and match what is visible on the label or your knowledge of that specific producer/appellation.
+- Grapes: only varieties this specific wine actually contains. Single-variety appellations may be inferred (Barolo → Nebbiolo); for multi-variety appellations (Champagne, southern-Rhône blends, Bordeaux) list only what you know about THIS cuvée — never the appellation's full permitted set by default. Fewer correct grapes beat a complete-looking list.
 - Country must be the canonical English country name: "United States" (never "USA" or "America"), "Germany" (never "Deutschland" or a local-language name like "Tyskland"), "Italy" (never "Italia"/"Italie"), "England" for English wines. Never return a country name in the label's language.
 - If a field is genuinely unknown and cannot be reliably inferred, set it to null rather than guessing.
 - Only return {"error":"cannot read label"} if the image contains no wine label at all.`;
@@ -64,7 +65,7 @@ Rules:
 - Country is REQUIRED — always provide a country name; it is never acceptable to return null for country
 - Country must be the canonical English country name: "United States" (never "USA" or "America"), "Germany" (never "Deutschland"/"Tyskland"), "Italy" (never "Italia"/"Italie"), "England" for English wines — never a local-language or abbreviated name, even if the import data uses one
 - For any other field you are unsure about, use null — do NOT omit the field
-- Grapes: provide an empty array [] if unknown, never null for grapes
+- Grapes: provide an empty array [] if unknown, never null for grapes. List only varieties you know THIS cuvée contains — single-variety appellations may be inferred (Barolo → Nebbiolo), but for multi-variety appellations (Champagne, southern-Rhône blends, Bordeaux) never default to the appellation's full permitted set; fewer correct grapes beat a complete-looking list
 - confidence: 1.0 = well-known wine you are certain about, 0.7 = confident from producer knowledge, 0.5 = reasonably sure
 - IMPORTANT: if you recognise the producer or the wine name, return a result even if some fields are null — partial information is always better than returning unknown
 - Never invent a wine that does not exist in reality
@@ -87,6 +88,7 @@ Rules:
 - Country is REQUIRED — always provide a country name; it is never acceptable to return null for country
 - Country must be the canonical English country name: "United States" (never "USA" or "America"), "Germany" (never "Deutschland"/"Tyskland"), "Italy" (never "Italia"/"Italie"), "England" for English wines — never a local-language or abbreviated name, even if the query uses one
 - For any other unknown field use null; use [] for unknown grapes, never null
+- Grapes: only varieties you know THIS cuvée contains — single-variety appellations may be inferred (Barolo → Nebbiolo), but never default a multi-variety appellation (Champagne, southern-Rhône blends, Bordeaux) to its full permitted set; fewer correct grapes beat a complete-looking list
 - confidence: 1.0 = certain, 0.7 = confident, 0.5 = reasonably sure
 - IMPORTANT: if you recognise the producer or wine name, return a result even if some fields are null — partial information is always better than returning unknown
 - Never invent a wine that does not exist in reality
@@ -247,16 +249,17 @@ Grapes: {{grapes}}
 Base the profile on what you genuinely know about this wine, producer, appellation, and grapes. Be factual and conservative — describe the wine's typical character, not marketing hyperbole. If you don't recognise the specific wine, infer a sensible profile from its grapes, region, and type, and lower your confidence accordingly.
 
 Return ONLY a raw JSON object (no markdown, no code fences, no extra text):
-{"body":"light|medium|full|null","tannin":"low|medium|high|null","acidity":"low|medium|high|null","sweetness":"dry|off-dry|sweet|null","flavors":["3-6 short flavour/aroma descriptors"],"foodPairings":["2-4 classic food pairings"],"description":"2-3 sentence plain-language tasting note for the owner","confidence":0.0,"producerSuspect":false,"producerNote":null}
+{"body":"light|medium|full","tannin":"low|medium|high","acidity":"low|medium|high","sweetness":"dry|off-dry|sweet","flavors":["3-6 short flavour/aroma descriptors"],"foodPairings":["2-4 classic food pairings"],"description":"2-3 sentence plain-language tasting note for the owner","confidence":0.0,"producerSuspect":false,"producerNote":null}
 
 Rules:
-- body/tannin/acidity/sweetness: use one of the listed values, or null if not applicable (e.g. tannin for a white wine should usually be "low" or null).
+- body/tannin/acidity/sweetness: exactly one of the listed values, or the JSON value null when the axis does not apply (e.g. tannin for a white wine is usually "low" or null). null is the unquoted JSON literal — NEVER the quoted string "null".
 - flavors: concrete aromas/flavours (e.g. "dark cherry", "tobacco", "citrus zest"). Avoid vague words like "nice" or "complex".
 - foodPairings: real dishes/categories (e.g. "grilled lamb", "hard cheese", "roast chicken").
-- description: 2-3 sentences, warm but not pretentious. PLAIN TEXT ONLY — no Markdown of any kind: no **bold**, no *italics*, no headings, lists, links, or tables. The field is shown verbatim in places that do not render Markdown.
+- description: 2-3 sentences, warm but not pretentious, about the wine ONLY. Never mention vintages or their absence, your confidence, missing information, or how this profile was derived — no sentences like "without a confirmed vintage..." or "this profile reflects...". State the style directly. PLAIN TEXT ONLY — no Markdown of any kind: no **bold**, no *italics*, no headings, lists, links, or tables. The field is shown verbatim in places that do not render Markdown.
+- Describe THIS wine, not its category: never assert a trait (aging need, quality level, everyday-vs-serious) merely because it is typical for the appellation, region or country.
 - confidence: 1.0 = you know this exact wine well, 0.7 = confident from producer + style, 0.5 = grape/region knowledge only, 0.3 = rough inference.
-- producerSuspect: true when the Producer value above does not look like an actual winery — a cuvée range or brand line that belongs to another house (e.g. "Arcane" is Xavier Vignon's range, "Montes Alpha" is Viña Montes's line), a place name, a retailer/importer/bottler, or a label term. Judge only from what you genuinely know; an unfamiliar small producer is NOT suspect.
-- producerNote: when producerSuspect is true and you are confident of the real producer, name it in one short plain-text sentence (e.g. "Arcane is a range of Xavier Vignon"). Otherwise null — never guess a specific house you are unsure of.
+- producerSuspect: true when the Producer value above does not look like an actual winery — a cuvée range or brand line that belongs to another house (e.g. "Arcane" is Xavier Vignon's range, "Montes Alpha" is Viña Montes's line), a place name, a retailer/importer/bottler, or a label term — and ALSO when you cannot place the producer at all, so this profile is really an appellation-level estimate. A small producer you genuinely half-know is not suspect. If your description would call the producer undocumented or unverifiable, producerSuspect MUST be true — the flag and the prose must agree.
+- producerNote: when producerSuspect is true, one short plain-text sentence saying why — the real producer if you are confident of it (e.g. "Arcane is a range of Xavier Vignon"), or that the producer is unknown to you. Never guess a specific house you are unsure of. Otherwise null.
 - Never invent awards, scores, or specific vintages' weather. If the wine is completely unrecognisable and its grapes/region are unknown, return {"error":"unknown"}.`;
 
 // Models that are known to work reliably for text chat.

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -28,8 +28,42 @@ const { suggestProfile } = require('./labelScan');
 const aiProvider = require('./aiProvider');
 const { embedSinglePair } = require('./embeddingJob');
 const { isValidId } = require('../utils/validation');
+const { PROFILE_ENUMS } = require('./wineProfileOps');
 const WineDefinition = require('../models/WineDefinition');
 const Bottle = require('../models/Bottle');
+
+// The model occasionally emits a placeholder STRING where the prompt asks for
+// JSON null — support ticket 2026-07-30: 161 prod profiles carried the literal
+// string "null" in tannin, which passes every truthiness check downstream and
+// leaks the token into the embedding text. The prompt now spells out "never
+// the quoted string", but a prompt is advisory; this is the guarantee. A value
+// outside the field's enum is equally meaningless to the UI pickers and the
+// embedding text, so both collapse to null.
+const SENTINEL_VALUE_RX = /^(null|none|n\/?a|undefined|unknown|nil|-+|)$/i;
+
+function cleanDescriptor(field, raw) {
+  if (typeof raw !== 'string') return null;
+  const v = raw.trim().toLowerCase();
+  if (SENTINEL_VALUE_RX.test(v)) return null;
+  return PROFILE_ENUMS[field].includes(v) ? v : null;
+}
+
+function cleanStringList(raw, cap) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((x) => typeof x === 'string')
+    .map((x) => x.trim())
+    .filter((x) => !SENTINEL_VALUE_RX.test(x))
+    .slice(0, cap);
+}
+
+// Prose fields get the same sentinel guard after their existing cleanup — a
+// description or producerNote of "null"/"N/A" is an absent value, not prose.
+function cleanProse(raw) {
+  if (typeof raw !== 'string') return null;
+  const v = stripMarkdown(raw);
+  return v && !SENTINEL_VALUE_RX.test(v.trim()) ? v : null;
+}
 
 // ── In-memory job state ────────────────────────────────────────────────────
 
@@ -214,26 +248,24 @@ async function enrichWine(wine, model) {
     {
       $set: {
         aiProfile: {
-          body:         data.body ?? null,
-          tannin:       data.tannin ?? null,
-          acidity:      data.acidity ?? null,
-          sweetness:    data.sweetness ?? null,
-          flavors:      Array.isArray(data.flavors) ? data.flavors.slice(0, 10) : [],
-          foodPairings: Array.isArray(data.foodPairings) ? data.foodPairings.slice(0, 8) : [],
+          body:         cleanDescriptor('body', data.body),
+          tannin:       cleanDescriptor('tannin', data.tannin),
+          acidity:      cleanDescriptor('acidity', data.acidity),
+          sweetness:    cleanDescriptor('sweetness', data.sweetness),
+          flavors:      cleanStringList(data.flavors, 10),
+          foodPairings: cleanStringList(data.foodPairings, 8),
           // Strip markdown, don't just trim: the model reaches for emphasis even
           // when told not to, and the raw string is served un-rendered by the MCP
           // tools. Load-bearing half of the fix — the prompt is only advisory,
           // and a self-hoster can override it via SiteConfig.
-          description:  typeof data.description === 'string' ? (stripMarkdown(data.description) || null) : null,
+          description:  cleanProse(data.description),
           confidence:   typeof data.confidence === 'number' ? data.confidence : null,
           // The model's own doubt about the producer FIELD (registry audit
           // follow-up: "Arcane" — a range sold as a producer — sailed past
           // every string gate AND 49 audit agents; only this model hedged).
           // Strict true-check: absent on old/custom prompts → false.
           producerSuspect: data.producerSuspect === true,
-          producerNote: typeof data.producerNote === 'string'
-            ? (stripMarkdown(data.producerNote).slice(0, 300) || null)
-            : null,
+          producerNote: cleanProse(data.producerNote)?.slice(0, 300) ?? null,
           model:        model || aiConfig.get().enrichmentModel,
           generatedAt:  new Date(),
         },
@@ -324,4 +356,8 @@ async function enrichWineById(wineDefId, { budgetUserId } = {}) {
   }
 }
 
-module.exports = { start, requestStop, getStatus, enrichWineById };
+module.exports = {
+  start, requestStop, getStatus, enrichWineById,
+  // exported for unit tests
+  cleanDescriptor, cleanStringList, cleanProse,
+};

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -95,3 +95,70 @@ describe('aiProfile.description is persisted as plain text', () => {
     });
   });
 });
+
+/**
+ * Sentinel-string coercion (support tickets 2026-07-30 / 2026-08-03).
+ *
+ * The model sometimes emits the four-character STRING "null" inside a
+ * string-typed descriptor instead of the JSON literal — 161 prod profiles
+ * carried tannin: "null", which passes every truthiness check and leaks the
+ * token into the embedding text. The prompt now forbids it, but the write
+ * point is the guarantee: sentinel strings and out-of-enum values collapse
+ * to a real null.
+ */
+describe('descriptor sanitization at the write point', () => {
+  test('the string "null" persists as a real null (the Fino/Dives case)', async () => {
+    const p = profile('A pale, bone-dry fino style.');
+    p.data.tannin = 'null';
+    suggestProfile.mockResolvedValue(p);
+    await enrichWineById(WINE_ID);
+    expect(persisted().tannin).toBeNull();
+  });
+
+  test.each([['None'], ['N/A'], ['n/a'], ['undefined'], ['unknown'], [''], ['-']])(
+    'sentinel %p collapses to null', async (val) => {
+      const p = profile('Fine.');
+      p.data.sweetness = val;
+      suggestProfile.mockResolvedValue(p);
+      await enrichWineById(WINE_ID);
+      expect(persisted().sweetness).toBeNull();
+    });
+
+  test('an out-of-enum value collapses to null rather than persisting', async () => {
+    const p = profile('Fine.');
+    p.data.body = 'muscular';
+    suggestProfile.mockResolvedValue(p);
+    await enrichWineById(WINE_ID);
+    expect(persisted().body).toBeNull();
+  });
+
+  test('valid values case-fold onto the enum', async () => {
+    const p = profile('Fine.');
+    p.data.tannin = 'High';
+    p.data.sweetness = ' Off-Dry ';
+    suggestProfile.mockResolvedValue(p);
+    await enrichWineById(WINE_ID);
+    expect(persisted().tannin).toBe('high');
+    expect(persisted().sweetness).toBe('off-dry');
+  });
+
+  test('sentinel entries are dropped from flavors/foodPairings, real ones kept', async () => {
+    const p = profile('Fine.');
+    p.data.flavors = ['cherry', 'null', 'N/A', '  ', 'tar'];
+    p.data.foodPairings = ['None', 'roast chicken'];
+    suggestProfile.mockResolvedValue(p);
+    await enrichWineById(WINE_ID);
+    expect(persisted().flavors).toEqual(['cherry', 'tar']);
+    expect(persisted().foodPairings).toEqual(['roast chicken']);
+  });
+
+  test('a producerNote of "null" persists as a real null', async () => {
+    const p = profile('Fine.');
+    p.data.producerSuspect = true;
+    p.data.producerNote = 'null';
+    suggestProfile.mockResolvedValue(p);
+    await enrichWineById(WINE_ID);
+    expect(persisted().producerNote).toBeNull();
+    expect(persisted().producerSuspect).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Fixes the generator-quality defects flagged by the maturity-queue curation sessions (support tickets 2026-07-30 → 2026-08-03).

**Write point — the guarantee ([`enrichmentJob.js`](../blob/fix/enrichment-sentinel-null-and-prompt/backend/src/services/enrichmentJob.js)):**
- Structured descriptors (`body`/`tannin`/`acidity`/`sweetness`) are enum-validated (reusing `wineProfileOps.PROFILE_ENUMS`) and case-folded; sentinel strings (`"null"`, `None`, `N/A`, `undefined`, `unknown`, `-`, empty) and out-of-enum values collapse to a **real null**.
- `flavors`/`foodPairings` drop sentinel entries; `description`/`producerNote` get the same guard after the markdown strip.

**Prompt — the advisory half ([`aiConfig.js`](../blob/fix/enrichment-sentinel-null-and-prompt/backend/src/config/aiConfig.js)):**
- Template no longer prints `null` inside the quoted option string (`"tannin":"low|medium|high|null"` was the root cause of 161 prod rows storing the literal string `"null"`).
- `description` must never narrate vintage absence / confidence / provenance (the Château Margaux "without a confirmed vintage…" case).
- "Describe THIS wine, not its category" (the Cahors / Luxembourg tone cases).
- `producerSuspect` now also covers producers the model cannot place at all, and **must agree with the prose** (the Arein / Chamaux wiring gap — the model wrote "not a widely documented producer" while the flag read `false`).
- Label-scan / import-lookup / text-search prompts: never default a multi-variety appellation to its full grape set (the invented third Champagne grape on Cazé-Thibaut Crayère and Cuvée Émeraude).

## Prod state

The data side is already done directly on prod (2026-08-03): 161 `tannin: "null"` rows backfilled to real null, embeddings re-run. This PR closes the reopen path. Prod SiteConfig has **no prompt overrides**, so the new defaults take effect on deploy with no config surgery.

## Tests

- 6 new cases in `enrichmentJob.test.js` covering sentinel coercion, enum validation, case-fold, list filtering, and the producerNote guard (through `enrichWineById`, same as the existing markdown-strip suite).
- Suites run in node:20-alpine: `enrichmentJob` + `wineProfileOps` + `bottleOps` (75 ✓), `wines.scanLabel` + `import.validate.aiBudget` + `sommTools` (39 ✓).

## Compose impact

None — backend code only, no env/compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)