### PR TITLE
feat(i18n): public call for translators, and make ?lng= previews work when signed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,21 @@ Uses Jest. Covers auth middleware, cellar access control, wine normalisation/sim
 
 ### Translations
 
-Want Cellarion in your language? Translations are contributed through Weblate — no coding required. See [TRANSLATING.md](TRANSLATING.md) to get started. (Please don't PR edits to `translation.json` files directly; they conflict with Weblate's sync.)
+[![Translation status](https://hosted.weblate.org/widget/cellarion/frontend/svg-badge.svg)](https://hosted.weblate.org/engage/cellarion/)
+
+Cellarion's interface is community-translated with **[Weblate](https://hosted.weblate.org/engage/cellarion/)** — a web editor, no Git and no coding required. English is maintained by the developers alongside the code; every other language comes from volunteers.
+
+**What's useful differs by language:**
+
+| Language | What it needs |
+|---|---|
+| **French, German** | **Reviewers, not translators.** Both were machine-drafted in bulk, so every field is already filled — the work is reading what's there and correcting it. The queue you want is `state:translated NOT state:approved`, not the untranslated one. |
+| **Swedish** | A native reader. Effectively complete, barely reviewed. |
+| **Estonian, or a language not listed** | Translators, from the top. Request the language in Weblate and start — it shows up in the app from roughly 10 % onwards, and `?lng=<code>` previews it before that. |
+
+Guidelines, the wine-terminology glossary, and how a language graduates out of beta: **[TRANSLATING.md](TRANSLATING.md)**.
+
+(Please don't open pull requests that edit `translation.json` files directly — `en` excepted. They conflict with Weblate's two-way sync.)
 
 ---
 

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -1,7 +1,7 @@
 import React, { createContext, useState, useContext, useEffect, useRef, useCallback } from 'react';
 import { findLanguage } from '../config/locales';
 import { createApiFetch } from '../utils/apiFetch';
-import i18n from '../i18n';
+import i18n, { hasLanguagePreview } from '../i18n';
 
 const AuthContext = createContext();
 
@@ -53,6 +53,15 @@ export const AuthProvider = ({ children }) => {
     // a choice the user made. A code whose locale no longer exists (translation
     // withdrawn, or set from another install) is ignored rather than applied,
     // so the session falls back to English instead of a stale half-language.
+    //
+    // A `?lng=` preview outranks the stored preference: it is a choice made
+    // just now, against one made months ago. Without this guard the detector
+    // picks the preview at boot and this line reverts it a beat later, so the
+    // page flashes the language and settles back — and since every screen worth
+    // previewing (racks, bottle lists, a cellar) sits behind this login, the
+    // preview TRANSLATING.md promises "on any page" would work only while
+    // signed out, which is precisely backwards for a translator.
+    if (hasLanguagePreview()) return;
     const preferred = userData?.preferences?.language;
     if (preferred && findLanguage(preferred)) {
       i18n.changeLanguage(preferred);

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -51,6 +51,24 @@ export const resolveLocaleCode = (lng, codes = Object.keys(LOADERS).map((p) => p
 export const shippedNavigatorLanguage = (preferred = [], codes = SHIPPED_CODES) =>
   preferred.map((tag) => resolveLocaleCode(tag, codes)).find(Boolean);
 
+// The querystring key i18next detects below. Exported because one other place
+// has to recognise a preview — AuthContext, which must not overwrite it with
+// the stored account preference — and a second hard-coded 'lng' there would be
+// free to drift out of step with this one.
+export const LANGUAGE_QUERY_PARAM = 'lng';
+
+/**
+ * Whether this page load carries an explicit `?lng=` preview.
+ *
+ * Deliberately reads the live URL rather than a router value: the preview is a
+ * property of how the document was opened, and it has to be answerable during
+ * session restore, before any router exists.
+ */
+export const hasLanguagePreview = (search) =>
+  new URLSearchParams(
+    search ?? (typeof window === 'undefined' ? '' : window.location.search)
+  ).has(LANGUAGE_QUERY_PARAM);
+
 const detector = new LanguageDetector();
 
 detector.addDetector({
@@ -84,7 +102,7 @@ i18n
       order: ['querystring', 'localStorage', 'shippedNavigator'],
       caches: ['localStorage'],
       lookupLocalStorage: 'i18nextLng',
-      lookupQuerystring: 'lng',
+      lookupQuerystring: LANGUAGE_QUERY_PARAM,
     },
     interpolation: {
       escapeValue: false,

--- a/frontend/src/i18n.test.js
+++ b/frontend/src/i18n.test.js
@@ -20,7 +20,8 @@ vi.mock('virtual:locale-coverage', () => ({
   SHIPPED_CODES: ['en', 'sv'],
 }));
 
-const { default: i18n, shippedNavigatorLanguage, resolveLocaleCode } = await import('./i18n');
+const { default: i18n, shippedNavigatorLanguage, resolveLocaleCode, hasLanguagePreview } =
+  await import('./i18n');
 
 describe('resolving a language tag to a locale directory', () => {
   // Weblate names the directory after the language code, which for a regional
@@ -129,5 +130,36 @@ describe('explicit choices', () => {
     expect(document.documentElement.lang).toBe('fr');
     await i18n.changeLanguage('sv');
     expect(document.documentElement.lang).toBe('sv');
+  });
+});
+
+/**
+ * `?lng=` is the preview a translator works from, and AuthContext consults this
+ * to decide whether to leave it alone. The regression it guards against is
+ * silent: a signed-in translator opens ?lng=fr, sees French for one frame, and
+ * concludes the feature is broken — which is exactly the report that prompted
+ * these tests.
+ */
+describe('detecting a ?lng= preview', () => {
+  test('recognises the preview parameter, wherever it sits in the query', () => {
+    expect(hasLanguagePreview('?lng=fr')).toBe(true);
+    expect(hasLanguagePreview('?sort=name&lng=et')).toBe(true);
+  });
+
+  test('an empty value still counts — `?lng=` is an explicit act', () => {
+    // i18next resolves the empty value to nothing and moves down its detection
+    // order; what matters here is that a stored preference does not overwrite
+    // whatever it settled on.
+    expect(hasLanguagePreview('?lng=')).toBe(true);
+  });
+
+  test('is false for ordinary URLs, so saved preferences still apply', () => {
+    expect(hasLanguagePreview('')).toBe(false);
+    expect(hasLanguagePreview('?sort=name')).toBe(false);
+  });
+
+  test('does not match a parameter that merely contains lng', () => {
+    expect(hasLanguagePreview('?lngx=fr')).toBe(false);
+    expect(hasLanguagePreview('?mylng=fr')).toBe(false);
   });
 });

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2560,6 +2560,7 @@
     "openCellar": "Open My Cellar",
     "footerSourceLink": "Source on GitHub",
     "footerConnectAi": "Connect your AI",
+    "footerTranslate": "Translate Cellarion",
     "footerCopy": "Cellarion",
     "metaTitle": "Cellarion — Wine Cellar App | Track Your Wine Collection Online",
     "metaDescription": "Track your wine collection with Cellarion. Log every bottle, visualise racks, get drink-window alerts, and share cellars with friends. Free wine cellar app at cellarion.app.",

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -295,6 +295,16 @@ export default function LandingPage() {
             >
               {t('landing.footerSourceLink')}
             </a>
+            {/* The in-app translation link lives in Settings → Language, behind
+                login. Anonymous visitors — which is every translator who hasn't
+                signed up — had no path to Weblate before this one. */}
+            <a
+              href="https://hosted.weblate.org/engage/cellarion/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('landing.footerTranslate')}
+            </a>
           </div>
           <span className="landing-footer-copy">
             © {new Date().getFullYear()} {t('landing.footerCopy')}


### PR DESCRIPTION
Weblate's Libre plan was approved today, so the translation project is open for good. Two things stood between that and actually recruiting people.

## 1. There was no public way in

The only in-app Weblate link was `WEBLATE_URL` in [`LanguagePicker.js`](frontend/src/components/LanguagePicker.js) — Settings → Language, **behind login**. Anonymous visitors, which is every translator who hasn't signed up, had no path to Weblate at all.

- **Landing footer** → external link to the Weblate *engage* page (the recruiting landing page, not the bare project page). One new `en` string, `landing.footerTranslate`.
- **README** → live translation-status badge, plus a per-language table of what each language actually needs.

**Why the table matters more than the badge:** French and German are `MACHINE_DRAFTED`, so every field is already filled. A volunteer recruited as a "translator" opens French, finds no blanks, concludes there's nothing to do, and leaves. Those languages need **reviewers** working `state:translated NOT state:approved`. [`TRANSLATING.md`](TRANSLATING.md) already says this; the README and the public CTA now do too.

## 2. The `?lng=` preview didn't work where it's needed

Found while testing the claim this PR's README repeats. `?lng=` is first in the detection order in [`i18n.js`](frontend/src/i18n.js), so the page does boot in the requested language — then `applySession()` in [`AuthContext.js`](frontend/src/contexts/AuthContext.js) applied the stored account preference a beat later and reverted it. The language flashes and settles back.

Signed out it worked. Signed in it never did — and **every screen worth previewing (racks, bottle lists, a cellar page) is behind that login**, so the preview promised "on any page" was unavailable precisely where a translator needs it.

`applySession` now returns early when the load carries `?lng=`. The guard is exported from `i18n.js` next to `lookupQuerystring` so the parameter name has one definition instead of two that can drift. It covers every caller, so signing in from `/login?lng=fr` keeps the preview rather than dropping it at the door.

## Notes

- `en` only — no other locale touched, per the locale workflow.
- Frontend suite: 45 files / 818 tests green (+4 covering the preview guard).
- No compose or env impact.