### PR TITLE
fix(registry): stop identify-text minting a wine for every AI guess

### DIFF
--- a/backend/src/routes/wines.aiBudget.test.js
+++ b/backend/src/routes/wines.aiBudget.test.js
@@ -243,18 +243,21 @@ describe('POST /api/wines/identify-text — daily AI budget', () => {
     expect(identifyWineFromQuery).not.toHaveBeenCalled();
   });
 
+  // Budget claim only — the response SHAPE is pinned in wines.identifyText.test.js.
+  // This used to assert res.body.wine.name against a { created: true } fixture,
+  // which is impossible under matchOnly and would have stayed green against a
+  // route that still minted.
   test('successful identify debits once', async () => {
     identifyWineFromQuery.mockResolvedValue({
       data: { name: 'Fixin', producer: 'Albert Bichot', country: 'France', grapes: [] },
       debugRaw: 'raw',
       debugReason: null,
     });
-    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1', name: 'Fixin', producer: 'Albert Bichot' }, created: true });
+    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1', name: 'Fixin', producer: 'Albert Bichot' } });
 
     const res = await postJson(app, '/api/wines/identify-text', { query: 'Albert Bichot Fixin 2019' });
 
     expect(res.status).toBe(200);
-    expect(res.body.wine.name).toBe('Fixin');
     expect(userDebits()).toBe(1);
   });
 
@@ -262,7 +265,7 @@ describe('POST /api/wines/identify-text — daily AI budget', () => {
     identifyWineFromQuery.mockResolvedValueOnce({ data: null, debugRaw: 'x', debugReason: 'exception: boom' });
     let res = await postJson(app, '/api/wines/identify-text', { query: 'whatever' });
     expect(res.status).toBe(200);
-    expect(res.body.wine).toBeNull();
+    expect(res.body.identified).toBeNull();
     expect(userDebits()).toBe(0); // refunded
 
     identifyWineFromQuery.mockResolvedValueOnce({ data: null, debugRaw: 'x', debugReason: 'ai_unknown: no idea' });

--- a/backend/src/routes/wines.findOrCreate.test.js
+++ b/backend/src/routes/wines.findOrCreate.test.js
@@ -1,0 +1,189 @@
+/**
+ * POST /api/wines/find-or-create — the registry-write chokepoint.
+ *
+ * Since identify-text became read-only, this is the ONLY user-facing path that
+ * mints a WineDefinition, and it now receives machine-generated payloads (the
+ * AI suggestion the user accepted, forwarded verbatim by AddBottle /
+ * AddToWishlist). It had no route-level coverage at all; these tests pin the
+ * guards and the provenance stamp.
+ *
+ * Real router; the service layer is mocked (no MongoDB).
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexWine: jest.fn(),
+}));
+jest.mock('../services/labelScan', () => ({
+  scanLabelFull: jest.fn(),
+  identifyWineFromQuery: jest.fn(),
+}));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../models/User', () => ({
+  findById: jest.fn(() => ({ select: () => ({ lean: async () => null }) })),
+  exists: jest.fn(async () => ({ _id: 'demo1' })),
+}));
+
+const http = require('http');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const { submitUrls } = require('../services/indexNow');
+const winesRouter = require('./wines');
+
+const USER_ID = 'u1';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ limit: '10mb' }));
+  app.use('/api/wines', winesRouter);
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, req, res, next) => {
+    res.status(err.status || 500).json({ error: err.message || 'Internal server error' });
+  });
+  return app;
+}
+
+function token({ id = USER_ID, isDemo = false } = {}) {
+  return jwt.sign({ id, roles: ['user'], ...(isDemo ? { isDemo: true } : {}) },
+    'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+}
+
+function postJson(app, url, body, jwtToken = token()) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${jwtToken}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end(payload);
+    });
+  });
+}
+
+const VALID = { name: 'Bin 407', producer: 'Penfolds', country: 'Australia' };
+const post = (body, jwtToken) => postJson(app, '/api/wines/find-or-create', body, jwtToken);
+
+let app;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  app = buildApp();
+  findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1', name: 'Bin 407', slug: 'bin-407' }, created: false });
+});
+
+describe('POST /api/wines/find-or-create — guards', () => {
+  test('a demo JWT is rejected with 403 before the service is reached', async () => {
+    const res = await post(VALID, token({ id: 'demo1', isDemo: true }));
+
+    expect(res.status).toBe(403);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+
+  test('missing country is a 400 — an AI suggestion with a null country cannot be accepted', async () => {
+    const res = await post({ name: 'Bin 407', producer: 'Penfolds' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/country/i);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+
+  test('missing name or producer is a 400', async () => {
+    expect((await post({ producer: 'Penfolds', country: 'Australia' })).status).toBe(400);
+    expect((await post({ name: 'Bin 407', country: 'Australia' })).status).toBe(400);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+
+  test('an over-long name or region is a 400 (region cap is new — findOrCreateRegion mints what arrives)', async () => {
+    const long = 'x'.repeat(201);
+
+    expect((await post({ ...VALID, name: long })).status).toBe(400);
+    const regionRes = await post({ ...VALID, region: long });
+    expect(regionRes.status).toBe(400);
+    expect(regionRes.body.error).toMatch(/region/);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+
+  test('a grapes array over 20 entries, or a non-array, is a 400', async () => {
+    const many = [...Array(21).keys()].map(i => `Grape ${i}`);
+    expect((await post({ ...VALID, grapes: many })).status).toBe(400);
+    expect((await post({ ...VALID, grapes: 'Shiraz' })).status).toBe(400);
+    expect((await post({ ...VALID, grapes: ['x'.repeat(201)] })).status).toBe(400);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+
+    // the boundary still passes through
+    expect((await post({ ...VALID, grapes: [...Array(20).keys()].map(String) })).status).toBe(200);
+  });
+});
+
+describe('POST /api/wines/find-or-create — behaviour', () => {
+  test('a soft-zone result hands candidates back as 200 and creates nothing', async () => {
+    findOrCreateWine.mockResolvedValue({ candidates: [{ wine: { _id: 'w9' }, score: 0.88 }] });
+
+    const res = await post(VALID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.candidates[0].score).toBe(0.88);
+    expect(submitUrls).not.toHaveBeenCalled();
+  });
+
+  test('a create returns 201 and pings IndexNow', async () => {
+    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1', slug: 'bin-407' }, created: true });
+
+    const res = await post(VALID);
+
+    expect(res.status).toBe(201);
+    expect(submitUrls).toHaveBeenCalledWith('/wines/bin-407');
+  });
+
+  test('confirmCreate also passes skipSiblingMatch — an explicit "create anyway" is not overridden by a sibling', async () => {
+    await post({ ...VALID, confirmCreate: true });
+
+    expect(findOrCreateWine.mock.calls[0][2]).toEqual({
+      confirmCreate: true, skipSiblingMatch: true, createdVia: 'ui',
+    });
+  });
+
+  test("source:'ai' stamps createdVia 'ai'; anything else falls back to 'ui'", async () => {
+    // Provenance keeps the accepted-AI-suggestion cohort measurable after
+    // identify-text stopped being the (unconfirmed) writer of createdVia:'ai'.
+    await post({ ...VALID, source: 'ai' });
+    expect(findOrCreateWine.mock.calls[0][2].createdVia).toBe('ai');
+
+    jest.clearAllMocks();
+    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1' }, created: false });
+
+    await post({ ...VALID, source: 'totally-made-up' });
+    expect(findOrCreateWine.mock.calls[0][2].createdVia).toBe('ui');
+
+    jest.clearAllMocks();
+    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1' }, created: false });
+
+    await post(VALID);
+    expect(findOrCreateWine.mock.calls[0][2].createdVia).toBe('ui');
+  });
+});

--- a/backend/src/routes/wines.identifyText.test.js
+++ b/backend/src/routes/wines.identifyText.test.js
@@ -1,0 +1,290 @@
+/**
+ * POST /api/wines/identify-text is READ-ONLY.
+ *
+ * It used to call findOrCreateWine unconditionally, minting a WineDefinition
+ * for every AI guess before the user confirmed anything — 52% of the rows it
+ * produced on prod never received a bottle. These tests pin the two properties
+ * that keep it honest: it probes with `{ matchOnly: true }` and nothing else,
+ * and its response carries no saved wine.
+ *
+ * The budget half matters just as much. The old handler wrapped everything in
+ * one try/catch that refunded on ANY throw, so a soft-zone probe (which crashed
+ * on `wine.toObject` when wine was null) both 500'd and reversed a completed,
+ * billable call — including its draw on the site-wide kill switch. The
+ * phase-1/phase-2 split is asserted here shape by shape.
+ *
+ * Real router + real aiBudget service; AiUsage and the Anthropic layer are
+ * mocked (no MongoDB).
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+}));
+jest.mock('../services/labelScan', () => ({
+  scanLabelFull: jest.fn(),
+  identifyWineFromQuery: jest.fn(),
+}));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+
+jest.mock('../models/AiUsage', () => {
+  const store = new Map();
+  return {
+    findOneAndUpdate: jest.fn(async (filter, update) => {
+      const k = `${filter.userId}|${filter.date}`;
+      if (!store.has(k)) store.set(k, { userId: filter.userId, date: filter.date, count: 0 });
+      const doc = store.get(k);
+      if (update.$inc && typeof update.$inc.count === 'number') doc.count += update.$inc.count;
+      return { ...doc };
+    }),
+    __store: store,
+  };
+});
+
+// `exists` is required, not optional: requireAuth calls User.exists({ _id, isDemo: true })
+// for a demo token, and without it the TypeError is swallowed into a 401 "Invalid
+// token" — which would let the demo test below pass while proving nothing.
+jest.mock('../models/User', () => ({
+  findById: jest.fn(() => ({ select: () => ({ lean: async () => null }) })),
+  exists: jest.fn(async () => ({ _id: 'demo1' })),
+}));
+
+const http = require('http');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const AiUsage = require('../models/AiUsage');
+const rateLimitsConfig = require('../config/rateLimits');
+const { todayUTC } = require('../services/aiBudget');
+const { identifyWineFromQuery } = require('../services/labelScan');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const winesRouter = require('./wines');
+
+const USER_ID = 'u1';
+const DEMO_ID = 'demo1';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ limit: '10mb' }));
+  app.use('/api/wines', winesRouter);
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, req, res, next) => {
+    res.status(err.status || 500).json({ error: err.message || 'Internal server error' });
+  });
+  return app;
+}
+
+function token({ id = USER_ID, isDemo = false } = {}) {
+  return jwt.sign({ id, roles: ['user'], ...(isDemo ? { isDemo: true } : {}) },
+    'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+}
+
+function postJson(app, url, body, jwtToken = token()) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${jwtToken}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end(payload);
+    });
+  });
+}
+
+const userDebits = (id = USER_ID) => AiUsage.__store.get(`${id}|${todayUTC()}`)?.count ?? 0;
+
+const IDENTIFIED = {
+  name: 'Bin 407',
+  producer: 'Penfolds',
+  country: 'Australia',
+  region: 'South Australia',
+  appellation: null,
+  type: 'red',
+  grapes: ['Cabernet Sauvignon'],
+  confidence: 0.7,
+};
+
+function aiReturns(data) {
+  identifyWineFromQuery.mockResolvedValue({ data, debugRaw: 'raw', debugReason: null });
+}
+
+let app;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  AiUsage.__store.clear();
+  rateLimitsConfig.set(JSON.parse(JSON.stringify(rateLimitsConfig.defaults)));
+  app = buildApp();
+  // Safe default AFTER the clear: an un-stubbed test exercises no-match on
+  // purpose instead of crashing on undefined inside the route.
+  findOrCreateWine.mockResolvedValue({ wine: null, noMatch: true });
+  aiReturns({ ...IDENTIFIED });
+});
+
+afterAll(() => {
+  rateLimitsConfig.set(JSON.parse(JSON.stringify(rateLimitsConfig.defaults)));
+});
+
+describe('POST /api/wines/identify-text — never creates', () => {
+  test('probes with exactly { matchOnly: true } and never passes createdVia', async () => {
+    await postJson(app, '/api/wines/identify-text', { query: 'penfolds bin 407' });
+
+    expect(findOrCreateWine).toHaveBeenCalledTimes(1);
+    // toEqual, NOT objectContaining: objectContaining would also pass
+    // { matchOnly: true, confirmCreate: true }, which silently collapses the
+    // soft zone (the candidate return sits above the matchOnly gate) and
+    // reproduces the duplication this route was changed to stop.
+    expect(findOrCreateWine.mock.calls[0][2]).toEqual({ matchOnly: true });
+    expect(findOrCreateWine.mock.calls[0][2]).not.toHaveProperty('createdVia');
+  });
+
+  test('a confident match returns the registry wine and no top-level wine/created', async () => {
+    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1', name: 'Bin 407', producer: 'Penfolds' } });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'penfolds bin 407' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.match.wine._id).toBe('w1');
+    expect(res.body.candidates).toEqual([]);
+    expect(res.body.reason).toBeNull();
+    expect(res.body.identified.name).toBe('Bin 407');
+    expect(res.body).not.toHaveProperty('wine');
+    expect(res.body).not.toHaveProperty('created');
+  });
+
+  test('a soft-zone probe returns 200 with candidates — never a 500 — and stays debited', async () => {
+    // Against the pre-fix route this failed with 500 and userDebits() === 0:
+    // the handler destructured `wine` from this shape and called wine.toObject.
+    findOrCreateWine.mockResolvedValue({
+      wine: null,
+      candidates: [{ wine: { _id: 'w9', name: 'Bin 407' }, score: 0.9 }],
+    });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'penfolds bin 407' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.candidates[0].score).toBe(0.9);
+    expect(res.body.match).toBeNull();
+    expect(userDebits()).toBe(1);
+  });
+
+  test('a noMatch probe reports identified-but-not-in-registry', async () => {
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'penfolds bin 407' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.identified.producer).toBe('Penfolds');
+    expect(res.body.match).toBeNull();
+    expect(res.body.candidates).toEqual([]);
+    expect(res.body.reason).toBeNull();
+  });
+});
+
+describe('POST /api/wines/identify-text — budget accounting', () => {
+  test('a DB failure in the probe returns 500 and STAYS debited', async () => {
+    // The completed Anthropic call was paid for. The old blanket catch refunded
+    // here, reversing both the per-user row and the global kill switch.
+    findOrCreateWine.mockRejectedValue(new Error('Mongo down'));
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'penfolds bin 407' });
+
+    expect(res.status).toBe(500);
+    expect(userDebits()).toBe(1);
+  });
+
+  test('a transport failure before the probe still refunds and never probes', async () => {
+    identifyWineFromQuery.mockResolvedValue({ data: null, debugRaw: 'x', debugReason: 'exception: boom' });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'whatever' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.identified).toBeNull();
+    expect(res.body.reason).toBe('exception: boom');
+    expect(userDebits()).toBe(0);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+
+  test('an ai_unknown completion stays debited and never probes', async () => {
+    identifyWineFromQuery.mockResolvedValue({ data: null, debugRaw: 'x', debugReason: 'ai_unknown: no idea' });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'whatever' });
+
+    expect(res.status).toBe(200);
+    expect(userDebits()).toBe(1);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/wines/identify-text — model output is normalized before the probe', () => {
+  test('a non-string name is reported as unidentified, stays debited, and never probes', async () => {
+    // findOrCreateWine .trim()s name/producer before consulting any option, so
+    // this would throw inside the probe without the route-level normalize.
+    aiReturns({ name: 42, producer: 'Penfolds', country: 'Australia', grapes: [] });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'x' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.identified).toBeNull();
+    expect(res.body.reason).toBe('invalid_identity_fields');
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(userDebits()).toBe(1);
+  });
+
+  test('over-long fields are capped, junk types dropped and grapes bounded', async () => {
+    aiReturns({
+      name: 'N'.repeat(500),
+      producer: '  Penfolds   Estate  ',
+      country: 'Australia',
+      region: '',
+      appellation: null,
+      type: 'orange',
+      grapes: [...Array(40).keys()].map(i => `Grape ${i}`).concat([null, 7, '']),
+      confidence: 4.2,
+    });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'x' });
+
+    const id = res.body.identified;
+    expect(id.name).toHaveLength(200);
+    expect(id.producer).toBe('Penfolds Estate'); // whitespace collapsed
+    expect(id.region).toBeNull();                // empty string → null
+    expect(id.type).toBeNull();                  // not a registry wine type
+    expect(id.grapes).toHaveLength(20);          // capped, non-strings dropped
+    expect(id.confidence).toBe(1);               // clamped into [0,1]
+    // and the probe receives the cleaned payload, not the raw model output
+    expect(findOrCreateWine.mock.calls[0][0].producer).toBe('Penfolds Estate');
+  });
+});
+
+describe('POST /api/wines/identify-text — demo accounts', () => {
+  test('a demo JWT gets 403 demo_ai_disabled before Claude and before any probe', async () => {
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'penfolds bin 407' },
+      token({ id: DEMO_ID, isDemo: true }));
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('demo_ai_disabled');
+    expect(identifyWineFromQuery).not.toHaveBeenCalled();
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(userDebits(DEMO_ID)).toBe(0);
+  });
+});

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -26,6 +26,59 @@ const router = express.Router();
 // chat message cap (chat.js).
 const MAX_AI_QUERY_LEN = 300;
 
+// Field caps for anything that reaches the registry-write path. Mirrors the
+// value findOrCreateWine enforces at its own create chokepoint.
+const MAX_WINE_FIELD = 200;
+const MAX_GRAPES = 20;
+const WINE_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
+
+const cleanField = (v) => {
+  if (typeof v !== 'string') return null;
+  const s = v.trim().replace(/\s+/g, ' ').slice(0, MAX_WINE_FIELD);
+  return s || null;
+};
+
+/**
+ * Normalize + allowlist the model's identification before it leaves the route.
+ *
+ * identify-text returns this to the client UNSAVED (the user confirms before
+ * anything is written), so it is the last place the shape is guaranteed. Two
+ * jobs: keep the payload inside the same caps findOrCreateWine would apply, and
+ * make the match-only probe throw-free — findOrCreateWine calls .trim() on
+ * name/producer before consulting any option, and labelScan's identity check
+ * only tests truthiness, so a model that returns `"name": 42` would otherwise
+ * 500 inside the probe.
+ *
+ * @returns {object|null} null when name or producer is unusable — the caller
+ *   reports that as "not identified" rather than probing with junk.
+ */
+function normalizeIdentifiedWine(data) {
+  if (!data || typeof data !== 'object') return null;
+
+  const name = cleanField(data.name);
+  const producer = cleanField(data.producer);
+  if (!name || !producer) return null;
+
+  const grapes = Array.isArray(data.grapes)
+    ? data.grapes.map(cleanField).filter(Boolean).slice(0, MAX_GRAPES)
+    : [];
+
+  const confidence = typeof data.confidence === 'number' && Number.isFinite(data.confidence)
+    ? Math.min(1, Math.max(0, data.confidence))
+    : null;
+
+  return {
+    name,
+    producer,
+    country: cleanField(data.country),
+    region: cleanField(data.region),
+    appellation: cleanField(data.appellation),
+    type: WINE_TYPES.includes(data.type) ? data.type : null,
+    grapes,
+    confidence,
+  };
+}
+
 /**
  * 429 for the Anthropic-backed endpoints when the shared per-user daily AI
  * budget (or the site-wide daily cap) is exhausted. These endpoints have no
@@ -349,13 +402,21 @@ router.post('/scan-label', requireAuth, aiBurstLimiter, asyncHandler(async (req,
 //
 // Pass `confirmCreate: true` after the user has reviewed the soft-zone
 // candidates and explicitly chosen to create a new wine anyway.
+//
+// `source: 'ai'` marks "the user accepted an AI suggestion" and stamps
+// createdVia:'ai'. Note the semantic shift: before identify-text became
+// read-only, createdVia:'ai' meant "auto-minted with nobody's confirmation"
+// (the ~162 pre-existing prod rows). From this release it means the opposite —
+// a human looked at the suggestion and said yes. The createdAt deploy boundary
+// separates the two cohorts, which is why this reuses the value rather than
+// adding an enum member.
 // requireNonDemo: find-or-create is a NON-AI registry-write primitive — on a miss
 // it mints a WineDefinition + Country/Region/Grape into the SHARED registry
 // (reachable via the AddBottle/Wishlist "create new wine" flow). purgeUserData
 // only reassigns createdBy on reap, so those rows would persist forever. A demo
 // must never create registry entries; it can only resolve existing ones elsewhere.
 router.post('/find-or-create', requireAuth, requireNonDemo, async (req, res) => {
-  const { name, producer, country, region, appellation, type, grapes, labelImage, confirmCreate } = req.body;
+  const { name, producer, country, region, appellation, type, grapes, labelImage, confirmCreate, source } = req.body;
 
   if (!name?.trim() || !producer?.trim()) {
     return res.status(400).json({ error: 'name and producer are required' });
@@ -366,10 +427,20 @@ router.post('/find-or-create', requireAuth, requireNonDemo, async (req, res) => 
   // Cap the free-text fields that feed the O(m·n) fuzzy-match scorer. Without
   // this, a multi-MB name/producer (the body limit here is 5mb) would drive a
   // huge Levenshtein computation against every candidate — an authenticated DoS.
-  const MAX_WINE_FIELD = 200;
-  for (const [field, value] of Object.entries({ name, producer, appellation })) {
+  // region is capped too: findOrCreateRegion mints whatever arrives, and since
+  // identify-text stopped creating, this is the sole user-facing write path and
+  // now receives machine-generated payloads.
+  for (const [field, value] of Object.entries({ name, producer, appellation, region })) {
     if (typeof value === 'string' && value.length > MAX_WINE_FIELD) {
       return res.status(400).json({ error: `${field} must be ${MAX_WINE_FIELD} characters or fewer` });
+    }
+  }
+  if (grapes !== undefined) {
+    if (!Array.isArray(grapes) || grapes.length > MAX_GRAPES) {
+      return res.status(400).json({ error: `grapes must be an array of at most ${MAX_GRAPES} entries` });
+    }
+    if (grapes.some(g => typeof g === 'string' && g.length > MAX_WINE_FIELD)) {
+      return res.status(400).json({ error: `each grape must be ${MAX_WINE_FIELD} characters or fewer` });
     }
   }
 
@@ -380,7 +451,9 @@ router.post('/find-or-create', requireAuth, requireNonDemo, async (req, res) => 
       // skipSiblingMatch: the user has already reviewed the suggested matches
       // (that's what confirmCreate means here) — an appellation-variant sibling
       // must not silently override their explicit "create a new wine anyway".
-      { confirmCreate: !!confirmCreate, skipSiblingMatch: !!confirmCreate, createdVia: 'ui' }
+      // Strict allowlist on source so an arbitrary body value can't invent a
+      // provenance the enum would reject.
+      { confirmCreate: !!confirmCreate, skipSiblingMatch: !!confirmCreate, createdVia: source === 'ai' ? 'ai' : 'ui' }
     );
 
     // Soft-zone: hand the candidates back so the UI can prompt the user
@@ -398,31 +471,94 @@ router.post('/find-or-create', requireAuth, requireNonDemo, async (req, res) => 
   }
 });
 
-// POST /api/wines/identify-text — identify a wine from a free-text query using AI,
-// then find or create it in the registry. Used by the AddBottle manual search fallback.
+// POST /api/wines/identify-text — identify a wine from a free-text query using
+// AI and report what the registry already holds. READ-ONLY: this route creates
+// nothing.
+//
+// It used to call findOrCreateWine unconditionally, minting a WineDefinition
+// (plus Country/Region/Grape taxonomy) for every AI guess — before the user
+// confirmed and before any bottle existed. Measured on prod 2026-08-03: 85 of
+// 162 createdVia:'ai' rows had zero bottles (52%) against 3% for 'ui', and the
+// same producer arrived spelled three ways from one user retyping a query.
+// Creation now happens only when the user accepts, via POST /find-or-create.
+//
+// Response — 200, one shape with four states:
+//   { identified: {name, producer, country, region, appellation, type,
+//                  grapes: string[], confidence} | null,   // UNSAVED strings
+//     match:      { wine: <populated WineDefinition> } | null,
+//     candidates: [{ wine, score }],
+//     reason:     string | null }
+//
+// Invariants:
+//   1. identified === null  ⟺ the model produced nothing usable; reason is set.
+//   2. match !== null       ⟹ candidates is [] and reason is null.
+//   3. candidates.length>0  ⟹ match is null.
+//   4. identified && !match && !candidates.length ⟹ identified but NOT in the
+//      registry — the state this route exists to report.
+// There is deliberately no top-level `wine`/`created`: the rename makes any
+// consumer that assumed a saved document fail loudly rather than silently
+// dereference undefined.
+//
+// `match` carries no confidence: findOrCreateWine resolves via exact key,
+// canonicalKey, sibling prefix or score ≥ 0.95 without reporting which, so any
+// number here would be fabricated. It stays an object so one can be added later.
+//
+// Stays a POST though it is semantically a read — app.js's writeLimiter skips
+// GET/HEAD/OPTIONS, and this path must keep its rate limit.
+//
 // asyncHandler: tryDebitAi runs before the try; a Mongo error there must 500, not hang (audit HIGH).
 router.post('/identify-text', requireAuth, aiBurstLimiter, asyncHandler(async (req, res) => {
   const query = typeof req.body.query === 'string' ? req.body.query.trim() : '';
   if (!query) return res.status(400).json({ error: 'query is required' });
   if (query.length > MAX_AI_QUERY_LEN) return res.status(400).json({ error: `query must be at most ${MAX_AI_QUERY_LEN} characters` });
 
+  // Demo accounts are stopped here, inside tryDebitAi — no requireNonDemo
+  // needed, and adding one would swap this coded 403 for an uncoded one.
   const debit = await tryDebitAi(req.user.id, { isDemo: req.user.isDemo });
   if (!debit.ok) return sendAiBudgetExhausted(res, debit);
 
+  // Phase 1: the billable call. Only a pre-completion / transport failure refunds.
+  let result;
   try {
-    const result = await identifyWineFromQuery(query);
-    if (!result.data) {
-      // Transport-level failures never produced a billable completion
-      if (isRefundableFailure(result.debugReason)) await debit.refund();
-      return res.json({ wine: null, reason: result.debugReason });
-    }
-
-    const { wine, created } = await findOrCreateWine(result.data, req.user.id, { createdVia: 'ai' });
-    return res.json({ wine: wine.toObject ? wine.toObject() : wine, created });
+    result = await identifyWineFromQuery(query);
   } catch (err) {
     await debit.refund();
     console.error('Identify text error:', err);
     return res.status(500).json({ error: err.message || 'Failed to identify wine' });
+  }
+
+  if (!result.data) {
+    if (isRefundableFailure(result.debugReason)) await debit.refund();
+    return res.json({ identified: null, match: null, candidates: [], reason: result.debugReason });
+  }
+
+  const identified = normalizeIdentifiedWine(result.data);
+  if (!identified) {
+    // A completed, billed call that returned an unusable identity — no refund.
+    return res.json({ identified: null, match: null, candidates: [], reason: 'invalid_identity_fields' });
+  }
+
+  // Phase 2: registry probe. The billable call has completed and been paid for —
+  // a failure here (e.g. a DB error) returns 500 WITHOUT a refund, since the AI
+  // work really happened. The old blanket catch-and-refund reversed both the
+  // per-user debit and the site-wide kill-switch on any throw, and the soft-zone
+  // shape below reached it on every near-match.
+  try {
+    // matchOnly and NOTHING else. confirmCreate would gate off the soft-zone
+    // return that sits above the matchOnly gate, collapsing every 0.85–0.95
+    // near-match into noMatch — which is exactly the duplication this fixes.
+    const probe = await findOrCreateWine(identified, req.user.id, { matchOnly: true });
+
+    if (probe.wine) {
+      return res.json({ identified, match: { wine: probe.wine }, candidates: [], reason: null });
+    }
+    if (probe.candidates?.length) {
+      return res.json({ identified, match: null, candidates: probe.candidates, reason: null });
+    }
+    return res.json({ identified, match: null, candidates: [], reason: null });
+  } catch (err) {
+    console.error('Identify text probe error:', err);
+    return res.status(500).json({ error: 'Failed to identify wine' });
   }
 }));
 

--- a/backend/src/services/aiBudget.js
+++ b/backend/src/services/aiBudget.js
@@ -125,12 +125,16 @@ async function getEffectiveDailyMax(userId) {
  */
 async function tryDebitAi(userId, { isDemo = false } = {}) {
   // Ephemeral public-demo accounts get ZERO Anthropic spend: no per-user budget
-  // and no draw on the shared global cap. This denial covers the AI-gated
-  // registry-write paths that run findOrCreateWine only AFTER a debit (label-scan
-  // / identify-text / import). The NON-AI registry-write path (POST
-  // /api/wines/find-or-create) is not downstream of this debit and is guarded
-  // separately with requireNonDemo. The UI surfaces AI features as "sign up to
-  // use"; a direct API call gets this clean denial (`code:'demo_disabled'`).
+  // and no draw on the shared global cap. The justification is SPEND, not
+  // registry writes — throwaway accounts (no email, 3 per IP per hour, 2h TTL)
+  // must never buy paid inference: ~40 demo sessions at the aiBurst rate would
+  // drain the whole global daily cap. Do not weaken this on the grounds that a
+  // given AI route no longer writes to the registry (identify-text became
+  // read-only in 2026-08); the spend argument is independent of that, and this
+  // check is also what keeps demo accounts out of identify-text entirely.
+  // Registry writes are guarded separately, by requireNonDemo on POST
+  // /api/wines/find-or-create. The UI surfaces AI features as "sign up to use";
+  // a direct API call gets this clean denial (`code:'demo_disabled'`).
   if (isDemo) {
     return { ok: false, reason: 'demo_disabled', retryAfterSeconds: secondsUntilMidnightUTC() };
   }

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -154,9 +154,16 @@ async function findOrCreateGrapes(names, userId) {
  *   so their "create anyway" isn't silently overridden by an appellation-variant sibling.
  * @param {boolean} [opts.matchOnly=false] - Never create. Resolve only to an existing
  *   registry wine (exact/sibling/fuzzy>=threshold); if nothing confident matches, return
- *   { wine: null, noMatch: true } instead of minting a WineDefinition + taxonomy. Used by
- *   the registry-safe ephemeral-demo clone so a throwaway account can't pollute the shared
- *   registry. Combine with confirmCreate:true to also bypass the soft-zone candidate return.
+ *   { wine: null, noMatch: true } instead of minting a WineDefinition + taxonomy. Two
+ *   consumers: the registry-safe ephemeral-demo clone (so a throwaway account can't pollute
+ *   the shared registry), and POST /api/wines/identify-text, which reports what the registry
+ *   already holds and leaves creation to an explicit user confirmation.
+ *   ⚠️ Do NOT combine with confirmCreate outside the demo clone. The soft-zone candidate
+ *   return sits ABOVE the matchOnly gate, so confirmCreate collapses every 0.85–0.95
+ *   near-match into noMatch — for identify-text that would hide exactly the existing wines
+ *   the user should have picked, which is the duplication the read-only change exists to stop.
+ *   ⚠️ Not throw-free: the .trim() on name/producer runs before any option is consulted, so
+ *   callers passing model output must normalize types first (identify-text does).
  */
 async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false, skipSiblingMatch = false, matchOnly = false, createdVia = null } = {}) {
   // Cap stored/compared field lengths at this single create chokepoint (covers

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -702,6 +702,53 @@ describe('findOrCreateWine — creation', () => {
     expect(WineDefinition).not.toHaveBeenCalled();
   });
 
+  // The shape identify-text hits MOST often: an AI-phrased producer rarely lands
+  // on an exact normalizedKey but usually scores in the 0.85-0.95 band. It is
+  // what lets the UI offer "did you mean this existing wine?" instead of
+  // minting a near-duplicate.
+  test('matchOnly still returns soft-zone candidates — the matchOnly gate sits BELOW the candidate return', async () => {
+    primeCandidates([{ wine: EXISTING_WINE, score: 0.9 }]);
+
+    const result = await findOrCreateWine(INPUT, USER_ID, { matchOnly: true });
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0].wine).toBe(EXISTING_WINE);
+    expect(result.noMatch).toBeUndefined();
+    expect(WineDefinition).not.toHaveBeenCalled();
+  });
+
+  test('matchOnly + confirmCreate collapses the soft zone into noMatch — never combine them outside the demo clone', async () => {
+    primeCandidates([{ wine: EXISTING_WINE, score: 0.9 }]);
+
+    const result = await findOrCreateWine(INPUT, USER_ID, { matchOnly: true, confirmCreate: true });
+
+    // confirmCreate gates off the candidate return, and matchOnly then refuses
+    // to create — so a real near-match is reported as "nothing found". Correct
+    // for the demo clone (which wants a hard miss), catastrophic for
+    // identify-text, which is why that route passes matchOnly and nothing else.
+    expect(result.candidates).toBeUndefined();
+    expect(result.noMatch).toBe(true);
+    expect(WineDefinition).not.toHaveBeenCalled();
+  });
+
+  test('matchOnly does not shield junk that would be rejected at create time — it reports noMatch instead of throwing', async () => {
+    // The producer-is-a-place gate, the 2-char producer gate and the
+    // unrecognized-country 400 all sit BELOW the matchOnly return, so they move
+    // from identify time to accept time. identify-text therefore answers "not
+    // in the registry" and find-or-create is where the rejection surfaces.
+    const result = await findOrCreateWine({ ...INPUT, producer: 'Bordeaux' }, USER_ID, { matchOnly: true });
+
+    expect(result.noMatch).toBe(true);
+    expect(WineDefinition).not.toHaveBeenCalled();
+  });
+
+  test('a non-string name throws even under matchOnly — the trim runs before any option is consulted', async () => {
+    // Documents why POST /identify-text normalizes the model payload at the
+    // route instead of relying on this service to be defensive.
+    await expect(findOrCreateWine({ ...INPUT, name: 42 }, USER_ID, { matchOnly: true }))
+      .rejects.toThrow();
+  });
+
   test('unknown wine type defaults to "red"; valid types are kept', async () => {
     await findOrCreateWine({ ...INPUT, type: 'orange' }, USER_ID);
     expect(WineDefinition.mock.calls[0][0].type).toBe('red');

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -451,9 +451,15 @@ const resolveGrapeName = (name) => {
   // returns "70% Monastrell" / "Monastrell 70%" verbatim from a back label,
   // which minted grape documents named "70% Monastrell" on prod. Strip the
   // percentage and resolve what remains ("70%" alone → '' → caller drops it).
+  // Whitespace runs are BOUNDED, not `\s*` (CodeQL js/polynomial-redos, alert
+  // #199 open since 2026-07-18). With `\s*` the trailing pattern is retried at
+  // every index of a long run of spaces, each attempt rescanning the run — a
+  // quadratic walk on an attacker-supplied grape name, and grape names arrive
+  // from label scan, import files and the AI. A real percentage carries at most
+  // one space on either side, so {0,3} changes no legitimate input.
   const stripped = name.trim()
-    .replace(/^\d{1,3}\s*%\s*/, '')
-    .replace(/\s*\d{1,3}\s*%$/, '');
+    .replace(/^\d{1,3}\s{0,3}%\s{0,3}/, '')
+    .replace(/\s{0,3}\d{1,3}\s{0,3}%$/, '');
   const key = normalizeString(stripped);
   return GRAPE_SYNONYMS[key] || stripped;
 };

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -548,6 +548,18 @@ describe('resolveGrapeName — blend-percentage artifacts (taxonomy audit 2026-0
   test('does not touch percentages inside a name', () => {
     expect(resolveGrapeName('Syrah')).toBe('Syrah');
   });
+
+  // CodeQL js/polynomial-redos #199. Grape names arrive from label scan, import
+  // files and AI output, so the input is not trusted. With unbounded `\s*` the
+  // trailing-percentage pattern rescanned the whole run of spaces from every
+  // start index; 50k spaces took seconds. Bounded {0,3} makes it linear.
+  test('a long run of whitespace cannot make the percentage strip quadratic', () => {
+    const hostile = `${' '.repeat(50000)}x`;
+    const start = process.hrtime.bigint();
+    expect(resolveGrapeName(hostile)).toBe('x'); // .trim() leaves just the x
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    expect(ms).toBeLessThan(250);
+  });
 });
 
 describe('resolveGrapeName — Sangiovese Grosso', () => {

--- a/frontend/src/api/wines.js
+++ b/frontend/src/api/wines.js
@@ -19,8 +19,16 @@ export const scanLabel = (apiFetch, image, mediaType = 'image/jpeg') =>
   });
 
 /**
- * Find an existing wine or create a new one from confirmed label data.
- * Returns: { wine: WineDefinition, created: boolean }
+ * Find an existing wine or create a new one from CONFIRMED data. The only
+ * user-facing registry-write path — call it when the user has explicitly
+ * accepted a wine, never speculatively.
+ *
+ * Pass `source: 'ai'` when the data came from an AI suggestion the user
+ * accepted, so the row's provenance stays measurable.
+ *
+ * Returns: { wine, created: true } | { wine, created: false }
+ *        | { candidates: [{ wine, score }] }  — soft zone: ask "did you mean…?"
+ *          and resubmit with confirmCreate: true to create anyway.
  */
 export const findOrCreateWine = (apiFetch, wineData) =>
   apiFetch('/api/wines/find-or-create', {
@@ -30,9 +38,26 @@ export const findOrCreateWine = (apiFetch, wineData) =>
   });
 
 /**
- * Identify a wine from a free-text search query using AI, then find or create
- * it in the registry.
- * Returns: { wine: WineDefinition | null, created?: boolean, reason?: string }
+ * Identify a wine from a free-text search query using AI and report what the
+ * registry already holds. READ-ONLY — this never creates anything. Accepting a
+ * suggestion is a separate, explicit call to findOrCreateWine below.
+ *
+ * Returns: {
+ *   identified: { name, producer, country, region, appellation, type,
+ *                 grapes: string[], confidence } | null,
+ *   match:      { wine: WineDefinition } | null,
+ *   candidates: [{ wine: WineDefinition, score }],
+ *   reason:     string | null
+ * }
+ *
+ * `identified` is UNSAVED: country/region/grapes are plain name strings, not DB
+ * IDs, and there is no _id — the same shape getAiWineInfo returns. Only
+ * `match.wine` and `candidates[].wine` are persisted documents safe to use as a
+ * selected wine. Four states:
+ *   identified === null                          → the model found nothing (see reason)
+ *   match !== null                               → already in the registry
+ *   candidates.length > 0                        → near-matches to choose from
+ *   identified && !match && !candidates.length   → identified but NOT in the registry
  */
 export const identifyWineByText = (apiFetch, query) =>
   apiFetch('/api/wines/identify-text', {

--- a/frontend/src/components/WinePicker.css
+++ b/frontend/src/components/WinePicker.css
@@ -111,3 +111,18 @@
   color: var(--color-text-secondary);
   text-align: center;
 }
+
+/* Smart Search feedback. The lookup is read-only: aiNote reports "identified
+   but not in the wine register", aiError a failed/unavailable lookup — which
+   previously produced no feedback at all. */
+.wine-picker__ai-note {
+  margin: 0.35rem 0 0;
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+}
+
+.wine-picker__ai-error {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: var(--color-danger, #c0392b);
+}

--- a/frontend/src/components/WinePicker.js
+++ b/frontend/src/components/WinePicker.js
@@ -8,6 +8,15 @@ import './WinePicker.css';
  * Wine search picker for journal pairings.
  * Flow: type to search → your bottles + wine register → AI identify fallback
  *
+ * READ-ONLY by design — this component must never create a registry wine, and
+ * must not import findOrCreateWine. A journal pairing does not need a registry
+ * id: journalOps keeps `wine` only when it is a valid id and stores `wineName`
+ * unconditionally. The trigger here is free-text dinner notes with no
+ * confirmation step, often for a wine the user doesn't own, fired before the
+ * entry is even saved — so a minted row would frequently outlive a cancelled
+ * form. Smart Search therefore resolves to an existing wine when there is one
+ * and otherwise just fills the name.
+ *
  * Props:
  *  - value:      { bottle, wine, wineName } — current selection
  *  - onChange:   (update) => void — called with { bottle, wine, wineName }
@@ -21,6 +30,8 @@ export default function WinePicker({ value, onChange, placeholder }) {
   const [showResults, setShowResults] = useState(false);
   const [searching, setSearching] = useState(false);
   const [aiSearching, setAiSearching] = useState(false);
+  const [aiError, setAiError] = useState(null);
+  const [aiNote, setAiNote] = useState(null);
   const [selected, setSelected] = useState(!!(value?.bottle || value?.wine));
   const debounceRef = useRef(null);
   const wrapRef = useRef(null);
@@ -78,25 +89,51 @@ export default function WinePicker({ value, onChange, placeholder }) {
   const handleAiSearch = async () => {
     if (!query.trim()) return;
     setAiSearching(true);
+    setAiError(null);
+    setAiNote(null);
     try {
       const res = await identifyWineByText(apiFetch, query.trim());
-      if (res.ok) {
-        const data = await res.json();
-        if (data.wine) {
-          setQuery(data.wine.name);
-          setSelected(true);
-          setShowResults(false);
-          onChange({ bottle: null, wine: data.wine._id, wineName: data.wine.name });
-        }
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        // Previously an `if (res.ok)` with no else: a 429 or 403 flipped the
+        // button back with no feedback at all.
+        setAiError(t('journal.aiFailed', 'Wine lookup is unavailable right now.'));
+        return;
       }
-    } catch { /* ignore */ }
-    setAiSearching(false);
+      if (data.match?.wine) {
+        selectWine(data.match.wine);
+        return;
+      }
+      if (data.candidates?.length) {
+        // Offer the existing registry rows as options instead of guessing.
+        setResults(prev => ({ ...prev, wines: data.candidates.map(c => c.wine).filter(Boolean) }));
+        setShowResults(true);
+        return;
+      }
+      if (data.identified) {
+        // Recognised but not in the registry: keep the name, create nothing.
+        const label = [data.identified.producer, data.identified.name].filter(Boolean).join(' ');
+        setQuery(label);
+        setSelected(true);
+        setShowResults(false);
+        onChange({ bottle: null, wine: null, wineName: label });
+        setAiNote(t('journal.aiNotInRegistry', "Not in the wine register — we'll save the name with your entry."));
+        return;
+      }
+      setAiError(t('journal.aiNoResult', "Couldn't identify that wine. You can type the name yourself."));
+    } catch {
+      setAiError(t('journal.aiFailed', 'Wine lookup is unavailable right now.'));
+    } finally {
+      setAiSearching(false);
+    }
   };
 
   const handleClear = () => {
     setQuery('');
     setSelected(false);
     setResults({ bottles: [], wines: [] });
+    setAiError(null);
+    setAiNote(null);
     onChange({ bottle: null, wine: null, wineName: '' });
   };
 
@@ -110,7 +147,7 @@ export default function WinePicker({ value, onChange, placeholder }) {
           type="text"
           className="input wine-picker__input"
           value={query}
-          onChange={(e) => { setQuery(e.target.value); setSelected(false); onChange({ bottle: null, wine: null, wineName: e.target.value }); }}
+          onChange={(e) => { setQuery(e.target.value); setSelected(false); setAiError(null); setAiNote(null); onChange({ bottle: null, wine: null, wineName: e.target.value }); }}
           onFocus={() => { if (hasResults && !selected) setShowResults(true); }}
           placeholder={placeholder || t('journal.winePlaceholder', 'Search wine...')}
           maxLength={200}
@@ -119,6 +156,10 @@ export default function WinePicker({ value, onChange, placeholder }) {
           <button type="button" className="wine-picker__clear" onClick={handleClear}>×</button>
         )}
       </div>
+
+      {/* Smart Search found the wine but the registry doesn't have it — the
+          name is kept with the entry and nothing is written. */}
+      {aiNote && <p className="wine-picker__ai-note">{aiNote}</p>}
 
       {showResults && (
         <div className="wine-picker__dropdown">
@@ -160,8 +201,9 @@ export default function WinePicker({ value, onChange, placeholder }) {
             <div className="wine-picker__no-results">
               <p>{t('journal.noWineResults', 'No wines found')}</p>
               <button type="button" className="btn btn-small btn-primary" onClick={handleAiSearch} disabled={aiSearching}>
-                {aiSearching ? t('journal.aiSearching', 'Searching with AI...') : t('journal.aiSearch', 'Search with AI')}
+                {aiSearching ? t('journal.aiSearching', 'Searching...') : t('journal.aiSearch', 'Smart Search')}
               </button>
+              {aiError && <p className="wine-picker__ai-error">{aiError}</p>}
             </div>
           )}
 

--- a/frontend/src/components/WinePicker.test.js
+++ b/frontend/src/components/WinePicker.test.js
@@ -1,0 +1,131 @@
+/**
+ * WinePicker's "Smart Search" must never write to the shared registry.
+ *
+ * It used to call identify-text, which minted a WineDefinition for whatever the
+ * model guessed — from free-text dinner notes, with no confirmation step, for a
+ * wine the user often doesn't own, fired before the journal entry was even
+ * saved. identify-text is now read-only, and these tests pin the three shapes
+ * it can return plus the failure path, which previously produced no feedback at
+ * all (`if (res.ok)` with no else, and `catch { }`).
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+vi.mock('../api/wines', () => ({ identifyWineByText: vi.fn() }));
+
+// The debounced registry search must resolve to an EMPTY result set: that is
+// what renders the no-results block carrying the Smart Search button.
+const apiFetch = vi.fn(async () => ({ ok: true, json: async () => ({ bottles: [], wines: [] }) }));
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ apiFetch: (...a) => apiFetch(...a) }) }));
+
+// Stable `t` identity across renders (components list it in useCallback deps).
+// `(k, f) => f || k` so both bare and fallback-bearing calls render something.
+vi.mock('react-i18next', () => {
+  const t = (key, fallback) => (typeof fallback === 'string' ? fallback : key);
+  return { useTranslation: () => ({ t }) };
+});
+
+const { identifyWineByText } = await import('../api/wines');
+const WinePicker = (await import('./WinePicker')).default;
+
+const jsonRes = (body, ok = true) => ({ ok, json: async () => body });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiFetch.mockResolvedValue({ ok: true, json: async () => ({ bottles: [], wines: [] }) });
+});
+
+async function setup() {
+  const onChange = vi.fn();
+  render(<WinePicker value={{ bottle: null, wine: null, wineName: '' }} onChange={onChange} />);
+  // Type enough to trip the >=2 char search, then let the 300ms debounce fire
+  // so the empty-result dropdown (and its Smart Search button) renders.
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'chateau xyz' } });
+  await act(() => new Promise(r => setTimeout(r, 350)));
+  return { onChange };
+}
+
+const clickSmartSearch = async () => {
+  const btn = await screen.findByRole('button', { name: /smart search/i });
+  fireEvent.click(btn);
+};
+
+describe('WinePicker Smart Search — read-only', () => {
+  test('an identified-but-unmatched wine fills the name and passes wine: null', async () => {
+    identifyWineByText.mockResolvedValue(jsonRes({
+      identified: { name: 'Cuvée X', producer: 'Chateau XYZ', country: 'France' },
+      match: null,
+      candidates: [],
+      reason: null,
+    }));
+
+    const { onChange } = await setup();
+    await clickSmartSearch();
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ wine: null, wineName: 'Chateau XYZ Cuvée X' })
+      );
+    });
+    // and it says so, rather than implying the wine was added
+    expect(screen.getByText(/not in the wine register/i)).toBeInTheDocument();
+  });
+
+  test('a matched registry wine still passes its _id', async () => {
+    identifyWineByText.mockResolvedValue(jsonRes({
+      identified: { name: 'Cuvée X', producer: 'Chateau XYZ' },
+      match: { wine: { _id: 'w42', name: 'Cuvée X', producer: 'Chateau XYZ' } },
+      candidates: [],
+      reason: null,
+    }));
+
+    const { onChange } = await setup();
+    await clickSmartSearch();
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ wine: 'w42', wineName: 'Cuvée X' })
+      );
+    });
+  });
+
+  test('candidates render as register options and picking one passes that _id', async () => {
+    identifyWineByText.mockResolvedValue(jsonRes({
+      identified: { name: 'Cuvée X', producer: 'Chateau XYZ' },
+      match: null,
+      candidates: [{ wine: { _id: 'w7', name: 'Cuvee X', producer: 'Ch. XYZ' }, score: 0.9 }],
+      reason: null,
+    }));
+
+    const { onChange } = await setup();
+    await clickSmartSearch();
+
+    const option = await screen.findByText('Cuvee X');
+    fireEvent.click(option.closest('button'));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ wine: 'w7', wineName: 'Cuvee X' })
+    );
+  });
+
+  test('a failed lookup shows an error instead of silently doing nothing', async () => {
+    identifyWineByText.mockResolvedValue(jsonRes({ error: 'nope' }, false));
+
+    const { onChange } = await setup();
+    await clickSmartSearch();
+
+    expect(await screen.findByText(/unavailable right now/i)).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalledWith(expect.objectContaining({ wine: expect.any(String) }));
+  });
+
+  test('a model that identifies nothing is reported, not swallowed', async () => {
+    identifyWineByText.mockResolvedValue(jsonRes({
+      identified: null, match: null, candidates: [], reason: 'ai_unknown: no idea',
+    }));
+
+    await setup();
+    await clickSmartSearch();
+
+    expect(await screen.findByText(/couldn't identify that wine/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -828,7 +828,7 @@
     "hideDetails": "Hide details",
     "cantFindAiTitle": "Can't find your wine?",
     "cantFindAiHint": "Look it up",
-    "aiFoundWine": "Match found",
+    "aiFoundWine": "Already in the registry",
     "aiUseThisWine": "Use this wine",
     "requestWineInstead": "Request a wine",
     "aiCouldNotIdentify": "Could not identify this wine. You can submit a request instead.",
@@ -840,12 +840,18 @@
     "useCameraInstead": "Use camera instead",
     "searchManuallyInstead": "No camera? Search manually instead →",
     "searchBtn": "Search",
-    "searchHint": "Be as specific as possible — include the wine name and producer. We'll check our library first; if no match is found, we'll identify and add the wine.",
+    "searchHint": "Be as specific as possible — include the wine name and producer. We'll search our library first; if nothing matches, you can ask AI to identify it.",
     "identifyFailed": "Identification failed",
     "identifyNetworkError": "Network error during identification.",
     "addFailed": "Failed to add bottle",
     "partialAdded_one": "{{msg}} — {{count}} of {{total}} bottles was added. Retrying will add only the remaining {{remaining}}.",
-    "partialAdded_other": "{{msg}} — {{count}} of {{total}} bottles were added. Retrying will add only the remaining {{remaining}}."
+    "partialAdded_other": "{{msg}} — {{count}} of {{total}} bottles were added. Retrying will add only the remaining {{remaining}}.",
+    "aiIdentifiedTitle": "We think this is your wine",
+    "aiIdentifiedHint": "This wine isn't in our registry yet. Check the details — we'll add it to the shared registry when you continue.",
+    "aiMatchHint": "This wine is already in our registry — using it won't create a duplicate.",
+    "aiAddAndUse": "Looks right — add it",
+    "aiConfidence": "{{percent}}% confident",
+    "aiSimilarTitle": "Already in the registry — did you mean one of these?"
   },
   "bottleDetail": {
     "backToCellar": "← Back to Cellar",
@@ -2338,7 +2344,10 @@
     "dontAskAgain": "Don't ask again",
     "loadMore": "Load more",
     "dish": "Dish",
-    "wine": "Wine"
+    "wine": "Wine",
+    "aiNotInRegistry": "Not in the wine register — we'll save the name with your entry.",
+    "aiNoResult": "Couldn't identify that wine. You can type the name yourself.",
+    "aiFailed": "Wine lookup is unavailable right now."
   },
   "restock": {
     "title": "Smart Restock",
@@ -3169,7 +3178,7 @@
     "searchPlaceholder": "e.g. Chateau Margaux 2015",
     "searchBtn": "Search",
     "searching": "Searching...",
-    "aiFound": "AI found this wine",
+    "aiFound": "Already in the registry",
     "useThisWine": "Use this wine",
     "select": "Select",
     "cantFind": "Can't find your wine?",
@@ -3192,7 +3201,13 @@
     "networkError": "Network error",
     "networkErrorIdentify": "Network error during identification.",
     "failedAdd": "Failed to add to wishlist",
-    "addedSuccess": "{{name}} added to your wishlist!"
+    "addedSuccess": "{{name}} added to your wishlist!",
+    "aiIdentified": "We think this is your wine",
+    "aiIdentifiedHint": "This wine isn't in our registry yet. Check the details — we'll add it to the shared registry when you continue.",
+    "aiMatchHint": "This wine is already in our registry — using it won't create a duplicate.",
+    "aiAddIt": "Looks right — add it",
+    "aiSimilarTitle": "Already in the registry — did you mean one of these?",
+    "demoAiBlocked": "AI wine lookup isn't available in the demo. Create a free account to use it."
   },
   "notificationBell": {
     "title": "Notifications",

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -28,7 +28,14 @@ function AddBottle() {
   const [showTextSearch, setShowTextSearch] = useState(false);
   const [aiSearching, setAiSearching] = useState(false);
   const [aiSearchError, setAiSearchError] = useState(null);
-  const [aiResult, setAiResult] = useState(null); // AI-found wine awaiting user confirmation
+  // identify-text is read-only: it reports what the AI recognised and what the
+  // registry already holds, and creates nothing. `aiIdentified` is UNSAVED data
+  // (plain strings, no _id); only `aiMatch` and `aiCandidates[].wine` are real
+  // registry documents. Accepting an unsaved suggestion goes through
+  // find-or-create, which is where a wine is actually created.
+  const [aiIdentified, setAiIdentified] = useState(null);
+  const [aiMatch, setAiMatch] = useState(null);
+  const [aiCandidates, setAiCandidates] = useState([]);
   const [selectedWine, setSelectedWine] = useState(null);
   const [numBottles, setNumBottles] = useState(1);
   const [bottleData, setBottleData] = useState({
@@ -100,6 +107,12 @@ function AddBottle() {
   // Apply a resolved wine (from find-or-create OR from a soft-zone pick) and
   // advance to the bottle-details step. Centralised so all entry paths share
   // the same teardown.
+  const clearAi = useCallback(() => {
+    setAiIdentified(null);
+    setAiMatch(null);
+    setAiCandidates([]);
+  }, []);
+
   const applyResolvedWine = useCallback((wine, carriedVintage) => {
     createdBottlesRef.current = [];
     imagesLinkedRef.current = false;
@@ -111,8 +124,9 @@ function AddBottle() {
     setPendingWineData(null);
     setSoftCandidates(null);
     setSoftPending(null);
+    clearAi();
     setStep(2);
-  }, []);
+  }, [clearAi]);
 
   // Submit a find-or-create request, handling the three response shapes:
   // resolved wine, soft-zone candidates, or error.
@@ -128,7 +142,9 @@ function AddBottle() {
       }
       if (data.candidates && data.candidates.length > 0) {
         setSoftCandidates(data.candidates);
-        setSoftPending({ wineData, carriedVintage });
+        // queryLabel: quote what the USER typed in the modal, not the AI's
+        // cleaned-up name, so the comparison reads the way they think of it.
+        setSoftPending({ wineData, carriedVintage, queryLabel: search.trim() || wineData.name });
         return;
       }
       applyResolvedWine(data.wine, carriedVintage);
@@ -137,7 +153,7 @@ function AddBottle() {
     } finally {
       setFindingWine(false);
     }
-  }, [apiFetch, t, applyResolvedWine]);
+  }, [apiFetch, t, applyResolvedWine, search]);
 
   // Confirm scan result — find/create the wine, save label image, go to bottle details
   const handleConfirmScan = useCallback(async () => {
@@ -206,36 +222,30 @@ function AddBottle() {
     setShowManualForm(false);
     setPendingWineData(null);
     setError(null);
-  }, []);
+    clearAi();
+  }, [clearAi]);
 
-  // Explicit search (Enter key or button — deliberately not fired per
-  // keystroke, since each search also triggers a paid AI identification).
-  // Runs both fuzzy search and AI identification in parallel so the AI can
-  // correctly distinguish similar wines (e.g. single vineyard vs generic).
+  // Explicit search (Enter key or button). Registry search ONLY — no AI.
+  //
+  // This used to fire identifyWineByText in parallel on every search, which
+  // both spent AI budget per keystroke-batch and (before identify-text became
+  // read-only) minted a registry wine for every guess, whether or not the user
+  // took it. AI is now something the user asks for via the "Can't find your
+  // wine?" row below, which also means the fast library results paint
+  // immediately instead of waiting behind a slower AI call.
   const handleSearch = useCallback(() => {
     if (!search.trim()) { setWines([]); return; }
     const query = search.trim();
     setLoading(true);
     setAiSearchError(null);
-    setAiSearching(true);
-    setAiResult(null);
+    clearAi();
 
-    // Fuzzy search (fast)
     searchWines(apiFetch, `search=${encodeURIComponent(query)}&limit=10`)
       .then(res => res.json())
       .then(data => { if (data.wines) setWines(data.wines); })
       .catch(err => console.error('Search failed:', err))
       .finally(() => setLoading(false));
-
-    // AI identification in parallel (slower but more accurate)
-    identifyWineByText(apiFetch, query)
-      .then(res => res.json())
-      .then(data => {
-        if (data.wine) setAiResult(data.wine);
-      })
-      .catch(() => { /* AI failure is non-fatal — fuzzy results still available */ })
-      .finally(() => setAiSearching(false));
-  }, [search, apiFetch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [search, apiFetch, clearAi]);
 
   const handleSearchKeyDown = (e) => {
     if (e.key === 'Enter') handleSearch();
@@ -245,13 +255,17 @@ function AddBottle() {
     if (!search.trim()) return;
     setAiSearching(true);
     setAiSearchError(null);
-    setAiResult(null);
+    clearAi();
     try {
       const res = await identifyWineByText(apiFetch, search.trim());
       const data = await res.json();
       if (!res.ok) { setAiSearchError(data.error || t('addBottle.identifyFailed')); return; }
-      if (!data.wine) { setAiSearchError(t('addBottle.aiCouldNotIdentify')); return; }
-      setAiResult(data.wine);
+      // Branch on `identified`, never on a wine: "the model recognised it but
+      // the registry doesn't have it" is a SUCCESS, and is the common case.
+      if (!data.identified) { setAiSearchError(t('addBottle.aiCouldNotIdentify')); return; }
+      setAiIdentified(data.identified);
+      setAiMatch(data.match?.wine || null);
+      setAiCandidates(data.candidates || []);
     } catch {
       setAiSearchError(t('addBottle.identifyNetworkError'));
     } finally {
@@ -259,8 +273,44 @@ function AddBottle() {
     }
   };
 
+  // Seed the (existing) manual edit form from the AI suggestion — used both by
+  // "Not the right wine" and as the escape hatch when the model gave no country,
+  // which find-or-create would reject.
+  const editAiSuggestion = () => {
+    if (!aiIdentified) return;
+    setPendingWineData({
+      name: aiIdentified.name || '',
+      producer: aiIdentified.producer || '',
+      country: aiIdentified.country || '',
+      region: aiIdentified.region || '',
+      appellation: aiIdentified.appellation || '',
+      type: aiIdentified.type || 'red',
+      grapes: (aiIdentified.grapes || []).join(', '),
+      source: 'ai',
+    });
+    setShowManualForm(true);
+  };
+
   const handleAcceptAiResult = () => {
-    if (aiResult) handleSelectWine(aiResult);
+    // Already in the registry — a pure selection, nothing is written.
+    if (aiMatch) { handleSelectWine(aiMatch); return; }
+    if (!aiIdentified) return;
+    // No country means find-or-create would 400; send the user to the edit form
+    // to supply it rather than surfacing a server error.
+    if (!aiIdentified.country) { editAiSuggestion(); return; }
+    // Forward EVERY field, appellation included: it feeds normalizedKey, so
+    // dropping it would both mint an appellation-less row and make the
+    // accept-time match score differently from the identify-time probe.
+    submitFindOrCreate({
+      name: aiIdentified.name,
+      producer: aiIdentified.producer,
+      country: aiIdentified.country,
+      region: aiIdentified.region || '',
+      appellation: aiIdentified.appellation || '',
+      type: aiIdentified.type || 'red',
+      grapes: aiIdentified.grapes || [],
+      source: 'ai',
+    });
   };
 
   const handleSelectWine = (wine) => {
@@ -269,6 +319,27 @@ function AddBottle() {
     setSelectedWine(wine);
     setStep(2);
   };
+
+  // One row renderer for both the registry-search list and the AI near-match
+  // list, so the two can never drift. Takes a SAVED wine only.
+  const renderWineRow = (wine) => (
+    <div key={wine._id} className="wine-row" onClick={() => handleSelectWine(wine)} role="button" tabIndex={0} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelectWine(wine); } }}>
+      <WineImage image={wine.image} alt={wine.name} className="wine-row-image" wrapClass="wine-row-img-wrap" credit={wine.imageCredit} creditClass="wine-row-credit" wineType={wine.type} placeholder="wine-row-placeholder" />
+      <div className="wine-info">
+        <h3>{wine.name}</h3>
+        <p className="producer">{wine.producer}</p>
+        <div className="wine-meta">
+          <span>{wine.country?.name}</span>
+          {wine.region && <span>• {wine.region.name}</span>}
+          <span className={`wine-type-pill ${wine.type}`}>{wine.type}</span>
+        </div>
+        {wine.grapes?.length > 0 && (
+          <p className="wine-grapes">{wine.grapes.map(g => g.name).join(', ')}</p>
+        )}
+      </div>
+      <button className="btn btn-primary btn-small">{t('addBottle.selectBtn')}</button>
+    </div>
+  );
 
   // Link the uploaded images to the first created bottle. Called on full
   // success and after a partial failure, so bottles that were created keep
@@ -498,7 +569,10 @@ function AddBottle() {
           )}
 
           {/* ── Scan result: manual edit form (user said "not the right wine") ── */}
-          {scanResult && showManualForm && pendingWineData && (
+          {/* Manual edit form. No longer gated on scanResult: the AI-suggestion
+              card reuses it for "Not the right wine" and for supplying a
+              country the model didn't give. */}
+          {showManualForm && pendingWineData && (
             <div className="scan-result-panel">
               {labelImage && (
                 <div className="scan-manual-image-wrap">
@@ -557,7 +631,7 @@ function AddBottle() {
           )}
 
           {/* ── Camera-first prompt ──────────────────────────────────────── */}
-          {!scanResult && !showTextSearch && !labelCam.open && (
+          {!scanResult && !showTextSearch && !showManualForm && !labelCam.open && (
             <div className="wine-select-default">
               <div className="camera-prompt-card">
                 <svg className="camera-prompt-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -579,7 +653,7 @@ function AddBottle() {
           )}
 
           {/* ── Manual text search ───────────────────────────────────────── */}
-          {!scanResult && showTextSearch && (
+          {!scanResult && showTextSearch && !showManualForm && (
             <>
               <div className="wine-select-manual-header">
                 <h2>{t('addBottle.searchForWine')}</h2>
@@ -588,7 +662,7 @@ function AddBottle() {
                 </button>
               </div>
               <p className="wine-search-hint">
-                {t('addBottle.searchHint', 'Be as specific as possible — include the wine name and producer. We\'ll check our library first; if no match is found, we\'ll identify and add the wine.')}
+                {t('addBottle.searchHint', 'Be as specific as possible — include the wine name and producer. We\'ll search our library first; if nothing matches, you can ask AI to identify it.')}
               </p>
               <div className="search-section">
                 <div className="search-input-wrapper">
@@ -596,7 +670,7 @@ function AddBottle() {
                     type="text"
                     placeholder={t('addBottle.searchPlaceholder')}
                     value={search}
-                    onChange={(e) => { setSearch(e.target.value); setWines([]); setAiSearchError(null); setAiResult(null); }}
+                    onChange={(e) => { setSearch(e.target.value); setWines([]); setAiSearchError(null); setError(null); clearAi(); }}
                     onKeyDown={handleSearchKeyDown}
                     className="search-input-large"
                     autoFocus
@@ -609,71 +683,94 @@ function AddBottle() {
 
               {loading && <p>{t('addBottle.searching')}</p>}
 
-              {/* ── AI result preview card ── */}
-              {aiResult && !aiSearching && (
-                <div className="ai-result-card">
-                  <div className="ai-result-badge">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 1.95-1.4 3.58-3.25 3.93L12 22"/><path d="M8 6a4 4 0 0 1 8 0"/><path d="M17 12H7"/></svg>
-                    {t('addBottle.aiFoundWine')}
-                  </div>
-                  <div className="ai-result-wine">
-                    {aiResult.image ? (
-                      <div className="wine-row-img-wrap">
-                        <img src={aiResult.image} alt={aiResult.name} className="wine-row-image" onError={(e) => { e.target.style.display = 'none'; }} />
-                      </div>
-                    ) : (
-                      <div className={`wine-row-placeholder ${aiResult.type}`}></div>
-                    )}
-                    <div className="wine-info">
-                      <h3>{aiResult.name}</h3>
-                      <p className="producer">{aiResult.producer}</p>
-                      <div className="wine-meta">
-                        <span>{aiResult.country?.name}</span>
-                        {aiResult.region && <span>• {aiResult.region.name}</span>}
-                        <span className={`wine-type-pill ${aiResult.type}`}>{aiResult.type}</span>
-                      </div>
-                      {aiResult.grapes?.length > 0 && (
-                        <p className="wine-grapes">{aiResult.grapes.map(g => g.name).join(', ')}</p>
-                      )}
+              {/* ── AI result card. Shape-aware: `card` is EITHER a saved
+                   registry wine (populated country/region/grape refs) OR the
+                   AI's unsaved suggestion (plain strings). Reading .name off a
+                   string would render blanks, so normalise both here. ── */}
+              {(aiMatch || aiIdentified) && !aiSearching && (() => {
+                const card = aiMatch || aiIdentified;
+                const isRegistryWine = Boolean(aiMatch);
+                const countryName = typeof card.country === 'string' ? card.country : card.country?.name;
+                const regionName = typeof card.region === 'string' ? card.region : card.region?.name;
+                const grapeNames = (card.grapes || [])
+                  .map(g => (typeof g === 'string' ? g : g?.name))
+                  .filter(Boolean);
+                return (
+                  <div className="ai-result-card">
+                    <div className="ai-result-badge">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 1.95-1.4 3.58-3.25 3.93L12 22"/><path d="M8 6a4 4 0 0 1 8 0"/><path d="M17 12H7"/></svg>
+                      {isRegistryWine ? t('addBottle.aiFoundWine') : t('addBottle.aiIdentifiedTitle')}
                     </div>
-                  </div>
-                  <div className="ai-result-actions">
-                    <button type="button" className="btn btn-success" onClick={handleAcceptAiResult}>
-                      {t('addBottle.aiUseThisWine')}
-                    </button>
-                    <Link to="/wine-requests" className="btn btn-ghost">
-                      {t('addBottle.requestWineInstead')}
-                    </Link>
-                  </div>
-                </div>
-              )}
-
-              {/* ── Search results list ── */}
-              {!aiResult && !aiSearching && wines.length > 0 && (
-                <div className="wines-list">
-                  {wines.map(wine => (
-                    <div key={wine._id} className="wine-row" onClick={() => handleSelectWine(wine)} role="button" tabIndex={0} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelectWine(wine); } }}>
-                      <WineImage image={wine.image} alt={wine.name} className="wine-row-image" wrapClass="wine-row-img-wrap" credit={wine.imageCredit} creditClass="wine-row-credit" wineType={wine.type} placeholder="wine-row-placeholder" />
+                    <p className="wine-search-hint">
+                      {isRegistryWine ? t('addBottle.aiMatchHint') : t('addBottle.aiIdentifiedHint')}
+                    </p>
+                    <div className="ai-result-wine">
+                      <WineImage image={card.image} alt={card.name} className="wine-row-image" wrapClass="wine-row-img-wrap" credit={card.imageCredit} creditClass="wine-row-credit" wineType={card.type} placeholder="wine-row-placeholder" />
                       <div className="wine-info">
-                        <h3>{wine.name}</h3>
-                        <p className="producer">{wine.producer}</p>
+                        <h3>{card.name}</h3>
+                        <p className="producer">{card.producer}</p>
                         <div className="wine-meta">
-                          <span>{wine.country?.name}</span>
-                          {wine.region && <span>• {wine.region.name}</span>}
-                          <span className={`wine-type-pill ${wine.type}`}>{wine.type}</span>
+                          {countryName && <span>{countryName}</span>}
+                          {regionName && <span>• {regionName}</span>}
+                          {card.appellation && <span>• {card.appellation}</span>}
+                          <span className={`wine-type-pill ${card.type || 'red'}`}>{card.type || 'red'}</span>
                         </div>
-                        {wine.grapes?.length > 0 && (
-                          <p className="wine-grapes">{wine.grapes.map(g => g.name).join(', ')}</p>
+                        {grapeNames.length > 0 && (
+                          <p className="wine-grapes">{grapeNames.join(', ')}</p>
+                        )}
+                        {!isRegistryWine && card.confidence != null && (
+                          <span className="scan-confidence">{t('addBottle.aiConfidence', { percent: Math.round(card.confidence * 100) })}</span>
                         )}
                       </div>
-                      <button className="btn btn-primary btn-small">{t('addBottle.selectBtn')}</button>
                     </div>
-                  ))}
+                    <div className="ai-result-actions">
+                      {/* Busy state is load-bearing: this is now an async
+                          registry write, and a double-tap could otherwise
+                          create two rows. */}
+                      <button
+                        type="button"
+                        className={`btn ${aiCandidates.length > 0 ? 'btn-secondary' : 'btn-success'}`}
+                        onClick={handleAcceptAiResult}
+                        disabled={findingWine}
+                      >
+                        {findingWine
+                          ? t('addBottle.scanSaving')
+                          : (isRegistryWine ? t('addBottle.aiUseThisWine') : t('addBottle.aiAddAndUse'))}
+                      </button>
+                      <button type="button" className="btn btn-ghost" onClick={isRegistryWine ? clearAi : editAiSuggestion} disabled={findingWine}>
+                        {t('addBottle.scanNotRight')}
+                      </button>
+                      <Link to="/wine-requests" className="btn btn-ghost">
+                        {t('addBottle.requestWineInstead')}
+                      </Link>
+                    </div>
+                  </div>
+                );
+              })()}
+
+              {/* ── Near-matches already in the registry. Picking one is a pure
+                   read — this is what stops a near-duplicate being minted. ── */}
+              {aiCandidates.length > 0 && !aiSearching && (
+                <div className="wines-list">
+                  <h3 className="wine-select-subheading">{t('addBottle.aiSimilarTitle')}</h3>
+                  {aiCandidates.map(c => renderWineRow(c.wine))}
                 </div>
               )}
 
-              {/* ── "Can't find your wine?" row — appears after search when no AI result is shown ── */}
-              {!loading && search.trim() && !aiResult && !aiSearching && (
+              {/* ── Search results list. Never hidden by the AI card any more:
+                   hiding it is how the AI's guess used to beat the correct
+                   registry row. Rows already shown above are filtered out. ── */}
+              {!aiSearching && wines.length > 0 && (
+                <div className="wines-list">
+                  {wines
+                    .filter(w => String(w._id) !== String(aiMatch?._id)
+                      && !aiCandidates.some(c => String(c.wine?._id) === String(w._id)))
+                    .map(wine => renderWineRow(wine))}
+                </div>
+              )}
+
+              {/* ── "Can't find your wine?" row — the AI entry point ── */}
+              {!loading && search.trim() && !aiIdentified && !aiMatch && !aiSearching && (
                 <div className="ai-search-row" onClick={!aiSearching ? handleAiIdentify : undefined} role="button" tabIndex={0} onKeyDown={e => { if ((e.key === 'Enter' || e.key === ' ') && !aiSearching) { e.preventDefault(); handleAiIdentify(); } }}>
                   <div className="ai-search-row-icon">
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -1032,7 +1129,7 @@ function AddBottle() {
       {softCandidates && (
         <SimilarWinesModal
           candidates={softCandidates}
-          queryName={softPending?.wineData?.name}
+          queryName={softPending?.queryLabel || softPending?.wineData?.name}
           busy={findingWine}
           onPick={(wine) => applyResolvedWine(wine, softPending?.carriedVintage)}
           onCreateNew={() => softPending && submitFindOrCreate(

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -28,7 +28,12 @@ function AddToWishlist() {
   const [loading, setLoading] = useState(false);
   const [aiSearching, setAiSearching] = useState(false);
   const [aiSearchError, setAiSearchError] = useState(null);
-  const [aiResult, setAiResult] = useState(null);
+  // identify-text is read-only — see api/wines.js. `aiIdentified` is UNSAVED
+  // (plain strings, no _id); this page posts wineDefinitionId on save, so an
+  // unsaved suggestion MUST go through find-or-create before it can be used.
+  const [aiIdentified, setAiIdentified] = useState(null);
+  const [aiMatch, setAiMatch] = useState(null);
+  const [aiCandidates, setAiCandidates] = useState([]);
 
   // ── Scan result state ──
   const [scanResult, setScanResult] = useState(null);
@@ -41,6 +46,12 @@ function AddToWishlist() {
   const [softCandidates, setSoftCandidates] = useState(null);
   const [softPending, setSoftPending] = useState(null);
 
+  const clearAi = useCallback(() => {
+    setAiIdentified(null);
+    setAiMatch(null);
+    setAiCandidates([]);
+  }, []);
+
   const applyResolvedWine = useCallback((wine) => {
     setSelectedWine(wine);
     setScanResult(null);
@@ -49,7 +60,8 @@ function AddToWishlist() {
     setPendingWineData(null);
     setSoftCandidates(null);
     setSoftPending(null);
-  }, []);
+    clearAi();
+  }, [clearAi]);
 
   const submitFindOrCreate = useCallback(async (wineData, { confirmCreate = false } = {}) => {
     setError(null);
@@ -183,29 +195,25 @@ function AddToWishlist() {
     setShowManualForm(false);
     setPendingWineData(null);
     setError(null);
-  }, []);
+    clearAi();
+  }, [clearAi]);
 
-  // ── Text search ──
+  // ── Text search. Registry search ONLY — the parallel AI call that used to
+  // run here spent budget on every search and (before identify-text became
+  // read-only) minted a registry wine per guess. AI is opt-in below. ──
   const handleSearch = useCallback(() => {
     if (!search.trim()) { setWines([]); return; }
     const query = search.trim();
     setLoading(true);
     setAiSearchError(null);
-    setAiSearching(true);
-    setAiResult(null);
+    clearAi();
 
     searchWines(apiFetch, `search=${encodeURIComponent(query)}&limit=10`)
       .then(res => res.json())
       .then(data => { if (data.wines) setWines(data.wines); })
       .catch(() => {})
       .finally(() => setLoading(false));
-
-    identifyWineByText(apiFetch, query)
-      .then(res => res.json())
-      .then(data => { if (data.wine) setAiResult(data.wine); })
-      .catch(() => {})
-      .finally(() => setAiSearching(false));
-  }, [search, apiFetch]);
+  }, [search, apiFetch, clearAi]);
 
   const handleSearchKeyDown = (e) => {
     if (e.key === 'Enter') handleSearch();
@@ -215,13 +223,24 @@ function AddToWishlist() {
     if (!search.trim()) return;
     setAiSearching(true);
     setAiSearchError(null);
-    setAiResult(null);
+    clearAi();
     try {
       const res = await identifyWineByText(apiFetch, search.trim());
       const data = await res.json();
-      if (!res.ok) { setAiSearchError(data.error || t('addToWishlist.identificationFailed')); return; }
-      if (!data.wine) { setAiSearchError(t('addToWishlist.couldNotIdentify')); return; }
-      setAiResult(data.wine);
+      if (!res.ok) {
+        // The AI 403 is a hardcoded English server string; translate the one
+        // case we can recognise rather than showing it verbatim in every locale.
+        setAiSearchError(data.code === 'demo_ai_disabled'
+          ? t('addToWishlist.demoAiBlocked')
+          : (data.error || t('addToWishlist.identificationFailed')));
+        return;
+      }
+      // Branch on `identified` — "recognised but not in the registry" is a
+      // success, and is the common case.
+      if (!data.identified) { setAiSearchError(t('addToWishlist.couldNotIdentify')); return; }
+      setAiIdentified(data.identified);
+      setAiMatch(data.match?.wine || null);
+      setAiCandidates(data.candidates || []);
     } catch {
       setAiSearchError(t('addToWishlist.networkErrorIdentify'));
     } finally {
@@ -229,9 +248,63 @@ function AddToWishlist() {
     }
   };
 
+  const editAiSuggestion = () => {
+    if (!aiIdentified) return;
+    setPendingWineData({
+      name: aiIdentified.name || '',
+      producer: aiIdentified.producer || '',
+      country: aiIdentified.country || '',
+      region: aiIdentified.region || '',
+      appellation: aiIdentified.appellation || '',
+      type: aiIdentified.type || 'red',
+      grapes: (aiIdentified.grapes || []).join(', '),
+      source: 'ai',
+    });
+    setShowManualForm(true);
+  };
+
+  // A wishlist item is saved with wineDefinitionId, so an unsaved suggestion
+  // must be resolved through find-or-create before it can be selected.
+  const handleAcceptAiResult = () => {
+    if (aiMatch) { handleSelectWine(aiMatch); return; }
+    if (!aiIdentified) return;
+    if (!aiIdentified.country) { editAiSuggestion(); return; }
+    submitFindOrCreate({
+      name: aiIdentified.name,
+      producer: aiIdentified.producer,
+      country: aiIdentified.country,
+      region: aiIdentified.region || '',
+      appellation: aiIdentified.appellation || '',
+      type: aiIdentified.type || 'red',
+      grapes: aiIdentified.grapes || [],
+      source: 'ai',
+    });
+  };
+
   const handleSelectWine = (wine) => {
     setSelectedWine(wine);
   };
+
+  // One row renderer for both the registry-search list and the AI near-match
+  // list. Takes a SAVED wine only.
+  const renderWineRow = (wine) => (
+    <div key={wine._id} className="wine-row" onClick={() => handleSelectWine(wine)} role="button" tabIndex={0} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelectWine(wine); } }}>
+      <WineImage image={wine.image} alt={wine.name} className="wine-row-image" wrapClass="wine-row-img-wrap" wineType={wine.type} placeholder="wine-row-placeholder" />
+      <div className="wine-info">
+        <h3>{wine.name}</h3>
+        <p className="producer">{wine.producer}</p>
+        <div className="wine-meta">
+          <span>{wine.country?.name}</span>
+          {wine.region && <span>• {wine.region.name}</span>}
+          <span className={`wine-type-pill ${wine.type}`}>{wine.type}</span>
+        </div>
+        {wine.grapes?.length > 0 && (
+          <p className="wine-grapes">{wine.grapes.map(g => g.name).join(', ')}</p>
+        )}
+      </div>
+      <button className="btn btn-primary btn-small">{t('addToWishlist.select')}</button>
+    </div>
+  );
 
   // ── Save to wishlist ──
   const handleSave = async (e) => {
@@ -364,7 +437,9 @@ function AddToWishlist() {
           )}
 
           {/* Scan result: manual edit form */}
-          {scanResult && showManualForm && pendingWineData && (
+          {/* Not gated on scanResult: the AI card reuses this form for
+              "Not the right wine" and for a missing country. */}
+          {showManualForm && pendingWineData && (
             <div className="scan-result-panel">
               {labelImage && (
                 <div className="scan-manual-image-wrap">
@@ -423,7 +498,7 @@ function AddToWishlist() {
           )}
 
           {/* Camera-first prompt */}
-          {!scanResult && !showTextSearch && !labelCam.open && (
+          {!scanResult && !showTextSearch && !showManualForm && !labelCam.open && (
             <div className="wine-select-default">
               <div className="camera-prompt-card">
                 <svg className="camera-prompt-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -445,7 +520,7 @@ function AddToWishlist() {
           )}
 
           {/* Manual text search */}
-          {!scanResult && showTextSearch && (
+          {!scanResult && showTextSearch && !showManualForm && (
             <>
               <div className="wine-select-manual-header">
                 <h2>{t('addToWishlist.searchForWine')}</h2>
@@ -462,7 +537,7 @@ function AddToWishlist() {
                     type="text"
                     placeholder={t('addToWishlist.searchPlaceholder')}
                     value={search}
-                    onChange={(e) => { setSearch(e.target.value); setWines([]); setAiSearchError(null); setAiResult(null); }}
+                    onChange={(e) => { setSearch(e.target.value); setWines([]); setAiSearchError(null); setError(null); clearAi(); }}
                     onKeyDown={handleSearchKeyDown}
                     className="search-input-large"
                     autoFocus
@@ -475,68 +550,84 @@ function AddToWishlist() {
 
               {loading && <p>{t('addToWishlist.searching')}</p>}
 
-              {/* AI result */}
-              {aiResult && !aiSearching && (
-                <div className="ai-result-card">
-                  <div className="ai-result-badge">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 1.95-1.4 3.58-3.25 3.93L12 22"/><path d="M8 6a4 4 0 0 1 8 0"/><path d="M17 12H7"/></svg>
-                    {t('addToWishlist.aiFound')}
-                  </div>
-                  <div className="ai-result-wine">
-                    {aiResult.image ? (
-                      <div className="wine-row-img-wrap">
-                        <img src={aiResult.image} alt={aiResult.name} className="wine-row-image" onError={(e) => { e.target.style.display = 'none'; }} />
+              {/* AI result card — shape-aware: `card` is either a saved
+                  registry wine (populated refs) or the AI's unsaved suggestion
+                  (plain strings). */}
+              {(aiMatch || aiIdentified) && !aiSearching && (() => {
+                const card = aiMatch || aiIdentified;
+                const isRegistryWine = Boolean(aiMatch);
+                const countryName = typeof card.country === 'string' ? card.country : card.country?.name;
+                const regionName = typeof card.region === 'string' ? card.region : card.region?.name;
+                const grapeNames = (card.grapes || [])
+                  .map(g => (typeof g === 'string' ? g : g?.name))
+                  .filter(Boolean);
+                return (
+                  <div className="ai-result-card">
+                    <div className="ai-result-badge">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2a4 4 0 0 1 4 4c0 1.95-1.4 3.58-3.25 3.93L12 22"/><path d="M8 6a4 4 0 0 1 8 0"/><path d="M17 12H7"/></svg>
+                      {isRegistryWine ? t('addToWishlist.aiFound') : t('addToWishlist.aiIdentified')}
+                    </div>
+                    <p className="wine-search-hint">
+                      {isRegistryWine ? t('addToWishlist.aiMatchHint') : t('addToWishlist.aiIdentifiedHint')}
+                    </p>
+                    <div className="ai-result-wine">
+                      <WineImage image={card.image} alt={card.name} className="wine-row-image" wrapClass="wine-row-img-wrap" wineType={card.type} placeholder="wine-row-placeholder" />
+                      <div className="wine-info">
+                        <h3>{card.name}</h3>
+                        <p className="producer">{card.producer}</p>
+                        <div className="wine-meta">
+                          {countryName && <span>{countryName}</span>}
+                          {regionName && <span>• {regionName}</span>}
+                          {card.appellation && <span>• {card.appellation}</span>}
+                          <span className={`wine-type-pill ${card.type || 'red'}`}>{card.type || 'red'}</span>
+                        </div>
+                        {grapeNames.length > 0 && (
+                          <p className="wine-grapes">{grapeNames.join(', ')}</p>
+                        )}
+                        {!isRegistryWine && card.confidence != null && (
+                          <span className="scan-confidence">{t('addToWishlist.confidence', { percent: Math.round(card.confidence * 100) })}</span>
+                        )}
                       </div>
-                    ) : (
-                      <div className={`wine-row-placeholder ${aiResult.type}`}></div>
-                    )}
-                    <div className="wine-info">
-                      <h3>{aiResult.name}</h3>
-                      <p className="producer">{aiResult.producer}</p>
-                      <div className="wine-meta">
-                        <span>{aiResult.country?.name}</span>
-                        {aiResult.region && <span>• {aiResult.region.name}</span>}
-                        <span className={`wine-type-pill ${aiResult.type}`}>{aiResult.type}</span>
-                      </div>
-                      {aiResult.grapes?.length > 0 && (
-                        <p className="wine-grapes">{aiResult.grapes.map(g => g.name).join(', ')}</p>
-                      )}
+                    </div>
+                    <div className="ai-result-actions">
+                      <button
+                        type="button"
+                        className={`btn ${aiCandidates.length > 0 ? 'btn-secondary' : 'btn-success'}`}
+                        onClick={handleAcceptAiResult}
+                        disabled={findingWine}
+                      >
+                        {findingWine
+                          ? t('addToWishlist.saving')
+                          : (isRegistryWine ? t('addToWishlist.useThisWine') : t('addToWishlist.aiAddIt'))}
+                      </button>
+                      <button type="button" className="btn btn-ghost" onClick={isRegistryWine ? clearAi : editAiSuggestion} disabled={findingWine}>
+                        {t('addToWishlist.notRightWine')}
+                      </button>
                     </div>
                   </div>
-                  <div className="ai-result-actions">
-                    <button type="button" className="btn btn-success" onClick={() => handleSelectWine(aiResult)}>
-                      {t('addToWishlist.useThisWine')}
-                    </button>
-                  </div>
+                );
+              })()}
+
+              {/* Near-matches already in the registry — picking one writes nothing */}
+              {aiCandidates.length > 0 && !aiSearching && (
+                <div className="wines-list">
+                  <h3 className="wine-select-subheading">{t('addToWishlist.aiSimilarTitle')}</h3>
+                  {aiCandidates.map(c => renderWineRow(c.wine))}
                 </div>
               )}
 
-              {/* Search results list */}
-              {!aiResult && !aiSearching && wines.length > 0 && (
+              {/* Search results list — no longer hidden behind the AI card */}
+              {!aiSearching && wines.length > 0 && (
                 <div className="wines-list">
-                  {wines.map(wine => (
-                    <div key={wine._id} className="wine-row" onClick={() => handleSelectWine(wine)} role="button" tabIndex={0} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSelectWine(wine); } }}>
-                      <WineImage image={wine.image} alt={wine.name} className="wine-row-image" wrapClass="wine-row-img-wrap" wineType={wine.type} placeholder="wine-row-placeholder" />
-                      <div className="wine-info">
-                        <h3>{wine.name}</h3>
-                        <p className="producer">{wine.producer}</p>
-                        <div className="wine-meta">
-                          <span>{wine.country?.name}</span>
-                          {wine.region && <span>• {wine.region.name}</span>}
-                          <span className={`wine-type-pill ${wine.type}`}>{wine.type}</span>
-                        </div>
-                        {wine.grapes?.length > 0 && (
-                          <p className="wine-grapes">{wine.grapes.map(g => g.name).join(', ')}</p>
-                        )}
-                      </div>
-                      <button className="btn btn-primary btn-small">{t('addToWishlist.select')}</button>
-                    </div>
-                  ))}
+                  {wines
+                    .filter(w => String(w._id) !== String(aiMatch?._id)
+                      && !aiCandidates.some(c => String(c.wine?._id) === String(w._id)))
+                    .map(wine => renderWineRow(wine))}
                 </div>
               )}
 
               {/* Can't find wine? */}
-              {!loading && search.trim() && !aiResult && !aiSearching && (
+              {!loading && search.trim() && !aiIdentified && !aiMatch && !aiSearching && (
                 <div className="ai-search-row" onClick={!aiSearching ? handleAiIdentify : undefined} role="button" tabIndex={0} onKeyDown={e => { if ((e.key === 'Enter' || e.key === ' ') && !aiSearching) { e.preventDefault(); handleAiIdentify(); } }}>
                   <div className="ai-search-row-icon">
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">


### PR DESCRIPTION
## The bug

`POST /api/wines/identify-text` called `findOrCreateWine` **unconditionally**, writing a WineDefinition (plus Country/Region/Grape taxonomy) into the **shared registry** for whatever the model guessed — before the user confirmed anything and before any bottle existed. Both AddBottle and AddToWishlist also fired it **automatically alongside every ordinary search**, so simply searching polluted the registry and spent AI budget.

Measured on prod 2026-08-03: **85 of 162 `createdVia:'ai'` rows have zero bottles (52%)**, against 11/319 (3%) for `'ui'`. One user hunting for the Ballarin "Giuli" on 30 July left behind `[Colonnara] "Ballarin"`, `[Giuli] "Ballarin"`, `[Ballarin] "Ballarin"`, `[La Stoppa] "Giulia"` and `[Château La Verrerie] "Guili Guili"` — none with a bottle. This is the upstream source of most producer-split / wrong-producer tickets from the maturity-queue curation sessions.

## Backend

**identify-text is now read-only.** It probes with the existing `{ matchOnly: true }` and returns one shape with four states:

```
{ identified: {name, producer, country, region, appellation, type, grapes[], confidence} | null,
  match:      { wine } | null,
  candidates: [{ wine, score }],
  reason:     string | null }
```

There is deliberately **no top-level `wine`/`created`** — the rename makes any consumer that assumed a saved document fail loudly rather than dereference `undefined`.

- **Model output is normalized at the route** (field caps, wine-type allowlist, ≤20 grapes, confidence clamped). `findOrCreateWine` trims name/producer before consulting any option, so a `"name": 42` response used to 500 inside the probe.
- **The budget handling is split into phases.** The old single try/catch refunded on *any* throw — and a soft-zone probe crashed on `wine.toObject` when `wine` was null, so **every near-match AI identify both 500'd and reversed a completed billable call**, including its draw on the site-wide kill switch. Transport failure before the call still refunds; a probe failure does not.
- `find-or-create` accepts `source: 'ai'` so accepted suggestions stay measurable, and gains the missing **region** and **grapes** caps now that it is the only user-facing registry-write path.
- **`requireNonDemo` deliberately not added** to identify-text: `tryDebitAi` already denies demo accounts before Claude with a *coded* 403 (`demo_ai_disabled`), and the middleware would swap it for an uncoded one. A test pins this so nobody "hardens" it later.

## Frontend

- The automatic AI call is **gone from both search handlers**. AI is opt-in via the existing "Can't find your wine?" row — so library results now paint immediately instead of waiting behind a slower AI call.
- The AI card is **shape-aware** (saved wine = populated refs; suggestion = plain strings — reading `.name` off a string rendered silent blanks) and says whether the wine is already in the registry or will be added on confirm.
- **Accepting an unsaved suggestion routes through `find-or-create`**, which brings the soft-zone *"did you mean one of these?"* prompt to a path that never had it. This is the part that actually stops duplicates.
- Registry results are **no longer hidden behind the AI card** (that hiding is how a guess beat the correct row), with near-matches de-duplicated.
- The accept button has a **busy state** — it is now an async write, and a double-tap could otherwise mint two rows.
- **WinePicker** (journal pairings) loses its registry write entirely: a pairing needs no registry id, and it fired from free-text dinner notes with no confirmation step, often before the entry was saved. It now resolves to an existing wine or just keeps the name, and reports failures instead of silently doing nothing.

## For Weblate reviewers

i18n is **EN-only**. Three keys were **reworded in place** (keys kept, so sv/fr/de retain translations but now carry stale semantics):

| Key | Was |
|---|---|
| `addBottle.aiFoundWine` | "Match found" |
| `addBottle.searchHint` | "…we'll identify and add the wine." |
| `addToWishlist.aiFound` | "AI found this wine" |

## Tests

New `wines.identifyText.test.js` (12) and `wines.findOrCreate.test.js` (9 — that route had **no** coverage), 5 new `findOrCreateWine` `matchOnly` cases including the soft-zone shape identify-text hits most often, and `WinePicker.test.js` (5).

`wines.aiBudget.test.js`'s "successful identify" asserted a `{ created: true }` fixture that is **impossible** under `matchOnly` — a green that would have survived a completely unfixed route; it is now reduced to its budget claim.

Green: 555 backend tests across 38 wine/mcp/auth suites, 113 more across import/bottles/cellarImport, 823 frontend tests, plus a clean `npm run build`.

## After deploy — expected, not regressions

- identify-text 500s drop to ~0 (the soft-zone crash is fixed).
- Daily AI debits tick **up** slightly (those calls are no longer wrongly refunded) while total AI calls drop sharply (no more per-search identification).
- `SimilarWinesModal` shown-rate goes up — that is the anti-duplicate prompt doing its job.
- `createdVia:'ai'` **changes meaning**: before this release it meant "auto-minted, nobody confirmed" (~162 rows); after, "a human accepted an AI suggestion". The `createdAt` deploy boundary separates the cohorts.

## Follow-ups (not in scope)

- `import.js` discards soft-zone candidates.
- Converge `scan-label` onto `matchOnly`.
- Stop sending the discarded `labelImage` to find-or-create, *then* lower the 5 MB body carve-out in `app.js`.

**Compose impact: none.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)