### PR TITLE
chore(release): v1.97.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.96.0",
+      "version": "1.97.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.96.0",
+      "version": "1.97.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — both `package.json` files and both lockfiles, 1.96.0 → 1.97.0.

## What v1.97.0 ships

| PR | Change |
|---|---|
| **#884** | `identify-text` no longer mints a registry wine for every AI guess (read-only now), plus a live budget-refund bug fix |
| **#883** | Public call for translators — landing-page CTA + README badge — and `?lng=` previews now survive the saved account language |
| **#882** | Enrichment: sentinel-string descriptors coerced to real `null`, generator prompts hardened |
| **#877** | Estonian translation added (community contribution, 1.1 %) |
| **#879 / #878** | `docker/login-action` 4.5.1 → 4.6.0, `nginx-unprivileged` digest bump |

## Post-deploy follow-ups

- **#884** — `createdVia:'ai'` **changes meaning** from this release on, and 3 reworded i18n keys leave the Swedish/French/German translations stale until Weblate syncs.
- **#882** — re-check the sentinel tannin count; the 08-03 enrichment batch ran under the old prompt.
- **#883** — `?lng=fr` should now hold on authenticated pages (a cellar page is the case that was reported broken), and the landing footer gains a public "Translate Cellarion" link.

Maintenance banner ≥15 min before the restart, as usual.