### PR TITLE
test(add-bottle): cover the AI search flow end to end

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -12,7 +12,7 @@ Cellarion's interface is community-translated. Thank you for helping!
 
   Weblate shows each English string with context, tracks per-language completeness, and opens pull requests against this repo automatically.
 
-  Weblate can also offer machine/AI suggestions you correct rather than typing from scratch, but they are **not on by default**: an engine has to be added to the project first, under Operations → Settings → Automatic suggestions. The keyless engines (Weblate Translation Memory, Glosbe, MyMemory) need nothing; the AI ones (Anthropic, OpenAI, DeepL, Google) need an API key the project owner supplies. If the Automatic suggestions tab is empty when you translate, that is why — ask, don't assume it is broken.
+  Weblate also offers **automatic suggestions** you correct rather than typing from scratch, and several are already available: Hosted Weblate enables Weblate Translation Memory, LibreTranslate and Apertium APy for every project. They appear in the *Automatic suggestions* panel under the translation box. Coverage varies by language pair, so a blank panel on one string doesn't mean the feature is off. AI engines (Anthropic, OpenAI, DeepL, Google) are *not* enabled — they bill the project owner's own API key per use, and this project is public.
 
 **Please do not open pull requests that edit `translation.json` files directly** (except for `en`, which is developer-maintained). Direct edits conflict with Weblate's two-way sync and will be closed with a friendly pointer here.
 

--- a/docs/weblate-operations.md
+++ b/docs/weblate-operations.md
@@ -55,7 +55,7 @@ The project menu is `Languages · Components · Diagnostics · Overview · Searc
 | I want to… | Path |
 |---|---|
 | Invite a contributor, grant Review | **Operations → Users** |
-| Turn on AI/machine suggestions | **Operations → Settings → Automatic suggestions** |
+| Add an automatic-suggestion engine | **Operations → Automatic suggestions** (a page of its own, *not* a Settings tab) |
 | Fix JSON indentation on write | **Operations → Settings → Files → File format parameters** |
 | Pull the repo after a release | **Operations → Update** (usually automatic via webhook) |
 | See who contributed, with counts | **Insights → Credits** (pick a date range) |
@@ -72,10 +72,13 @@ Reviews are **on**, which is what makes the Approved column exist.
 - Because project access is **Public**, any signed-in user can already **edit** any unapproved string. Contributors need no permission from you to fix something wrong.
 - **Approving requires the `Review` role.** Ordinary translators cannot approve, and they can no longer edit a string *once it is approved* — approval effectively locks it to reviewers.
 - Grant it at **Operations → Users**: add an existing user by username (they confirm by invitation) or invite by e-mail (they register, then get access). Pick the **Review** team, not Administration — Administration also hands over settings, VCS and access control.
-- **Scope teams per language.** Teams can be limited by language as well as project, and that limit applies to reviewing/saving/suggesting. Make `Reviewers (sv)`, `Reviewers (fr)`, `Reviewers (de)` rather than one global team, so a French volunteer can't approve Swedish.
+- **Scope the grant to one language**, so a French volunteer can't approve Swedish. Two ways, both fine:
+  - Set a **Language limit** on the user directly in the *Add a user* form — the built-in project-wide `Review` team plus a limit is the fewest moving parts.
+  - Or make `Reviewers (sv)` / `(fr)` / `(de)` teams under the **Teams** tab and add people to those. More typing, but the Teams table then shows at a glance who can approve what, which is worth having once there is more than one reviewer.
+- ⚠️ **Whichever you choose, check the language you picked matches the locale directory.** See §7 — `Swedish (sv_SV)` is a plausible-looking wrong answer that grants nothing at all.
 - Trust is earned in-band: let people translate, read their work under **Insights → Credits**/**History**, then promote the good ones. Don't wait for pre-trusted strangers.
 
-⚠️ **Until at least one Review team exists, nobody — including possibly you — can move the Approved %.** Verify by opening an unreviewed string and looking for the Approve control; if it's missing, add yourself too.
+A `Review` team covering **all languages** already exists — Weblate creates it when the review workflow is on, so there is nothing to build before you can approve. If you are in **Administration**, you have review rights through that alone. Confirm rather than assume: open an unreviewed string and look for the Approve control. If it isn't there, add yourself to a Review team.
 
 ---
 
@@ -113,14 +116,16 @@ Each of these has already happened once.
 - **Set JSON indentation to 2** under Settings → Files → File format parameters. The default of 4 produced a 379 KB whole-file first diff. (The old "Customize JSON output" add-on was removed in Weblate 5.13.)
 - **Stale keys**: when `en` drops a key, translations keep it and CI fails on the orphan. Fix with the **Cleanup translation files** add-on, or one-off via **Cleanup unused** under Repository maintenance. It only removes keys absent from the base file — it does not inject empty strings, and it does no code analysis, so dynamic keys are safe.
 - **Do not poll `hosted.weblate.org`** with scripts or monitors. Their fail2ban banned the office IP for a day around a GitHub OAuth login. Use a browser; use mobile data if it looks unreachable. Anthropic's fetcher is blocked by their bot protection too, so an AI assistant cannot verify project pages for you.
-- **Machine suggestions are off until you add an engine** (Operations → Settings → Automatic suggestions). Keyless: Weblate Translation Memory, Glosbe, MyMemory. AI engines (Anthropic, OpenAI, DeepL, Google) need your own API key — use a separate key with a spend cap, because the project is public and every translator's click bills it.
+- **Automatic suggestions are *already on*, and the page is not where you'd look.** It's **Operations → Automatic suggestions** — its own page, a sibling of Settings, not a tab inside it. (Settings has exactly five tabs: Basic, Access, Workflow, Commit messages, Components.) Hosted Weblate installs three engines **site wide** for every project: Weblate Translation Memory, LibreTranslate, and Apertium APy. The keyless ones worth adding on top are **MyMemory** (the best single addition for our languages) and **Glosbe**. **Anthropic sits third in the Available list — don't.** It, and OpenAI/DeepL/Google/Azure/Amazon, bill your own API key on every translator's click, and this project is public. If you ever want one, use a separate key with a hard spend cap.
+- **Weblate Translation Memory is nearly empty until you tick "Use shared translation memory"** (Settings → **Workflow** tab). Without it the engine can only offer strings this project has already translated — near-useless on a young locale. Ticking it opens the cross-project pool, at the price of contributing ours back to it.
+- **Scope a review team to the language the repo actually uses.** Weblate's language list contains near-miss entries: picking `Swedish (sv_SV)` for a `Reviewers (sv)` team looks right and silently grants nothing, because our locale directory — and therefore the project's language object — is plain `sv`. (`sv_SV` isn't even Sweden; that's `SE`.) The failure is invisible: members simply never see an Approve control, with nothing to explain why. Check the code on the team against the directory name under `frontend/src/locales/`.
 - **Do not use Operations → Automatic translation** (the bulk one). It writes machine output in as real translations, which is how you end up with a "100 % translated" language nobody has read.
 
 ---
 
 ## 8. Billing and hosting
 
-- Plan and trial state: the **billing** page (linked from the project). Libre is free for libre projects but requires **human approval**, and the trial has a hard expiry date — watch it, and chase via the **Contact** link if approval lags more than a week.
+- **Libre was approved on 2026-08-03**, so the plan is settled and the trial clock is gone. Kept for whoever does this next: Libre is free for libre projects but requires **human approval**, the trial has a hard expiry date, and the **Contact** link is how you chase it if approval lags more than a week. Ours was granted partly on the strength of crediting Weblate in the README and on the site — that's a guideline, not a courtesy.
 - Approval criteria are a checklist on that page: one project, a public URL, components under a libre licence. When they're all ticked, there is nothing left for you to do but wait.
 - The **glossary** component (`local:` repository) permanently shows "outbound delivery is manual" and "updates are pulled manually" warnings. They are inapplicable — it has no VCS — and will never clear. Ignore them.
 
@@ -136,13 +141,13 @@ Brand names that must never be translated: Cellarion, CellarTracker, Vivino, and
 
 ## 10. A first-week checklist
 
-- [ ] Chase Libre approval if the trial is close to expiring.
+- [x] ~~Chase Libre approval if the trial is close to expiring.~~ Approved 2026-08-03.
 - [ ] Confirm you personally can approve a string; if not, add yourself to a Review team.
-- [ ] Create `Reviewers (sv)` / `(fr)` / `(de)` teams, empty for now.
+- [ ] Create `Reviewers (sv)` / `(fr)` / `(de)` teams, empty for now — checking each one's language against the locale directory name (§7).
 - [ ] Skim **Insights → Credits** for the last month — those are your reviewer candidates.
 - [ ] Work the Swedish `Unreviewed` queue yourself; you're the native speaker and it needs nobody else.
 - [ ] Triage the pending **Suggestions** (accept, reject, or comment).
-- [ ] Decide on machine suggestions (§7) before inviting reviewers, so they have the tool from day one.
+- [ ] Tick **Use shared translation memory** (Settings → Workflow), then install **MyMemory** and **Glosbe** (§7) — the three site-wide engines are already on, so this is topping up rather than starting from nothing.
 - [ ] Set JSON indentation to 2 if it isn't already.
 
 ---

--- a/frontend/src/pages/AddBottle.aiSearch.test.js
+++ b/frontend/src/pages/AddBottle.aiSearch.test.js
@@ -1,0 +1,182 @@
+/**
+ * AddBottle's wine-selection step — the AI search path.
+ *
+ * This surface had no test at all, and every way it can break is SILENT: a
+ * plain-string country rendered as a blank, an unsaved suggestion carried into
+ * step 2 where `selectedWine._id` is undefined and only 400s at final submit,
+ * or the AI call quietly returning to fire on every search again. A manual
+ * click-through passes all three.
+ *
+ * The behaviour being locked (PR #884): searching is registry-only and writes
+ * nothing; AI is opt-in; an unsaved suggestion is only ever turned into a wine
+ * through find-or-create, on an explicit press.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+vi.mock('../api/wines', () => ({
+  searchWines: vi.fn(),
+  findOrCreateWine: vi.fn(),
+  identifyWineByText: vi.fn(),
+}));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ apiFetch: vi.fn(), user: { preferences: { currency: 'USD' } } }),
+}));
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: 'cellar1' }),
+  useNavigate: () => vi.fn(),
+  Link: ({ children }) => <a href="/">{children}</a>,
+}));
+// The camera hook owns getUserMedia; keep it inert.
+vi.mock('../hooks/useLabelScanner', () => ({
+  default: () => ({
+    labelCam: { open: false }, labelScanning: false, labelFacing: 'environment',
+    setLabelFacing: vi.fn(), labelVideoRef: { current: null }, labelCanvasRef: { current: null },
+    startCamera: vi.fn(), stopCamera: vi.fn(), capturePhoto: vi.fn(),
+  }),
+}));
+vi.mock('../components/ImageUpload', () => ({ default: () => <div /> }));
+vi.mock('../components/RatingInput', () => ({ default: () => <div /> }));
+
+// Key-only so assertions target keys, never copy — several of these strings
+// carry inline English fallbacks that would otherwise shadow the key.
+vi.mock('react-i18next', () => {
+  const t = (key) => key;
+  // SimilarWinesModal — the soft-zone "did you mean?" prompt — renders <Trans>.
+  const Trans = ({ i18nKey }) => <span>{i18nKey}</span>;
+  return { useTranslation: () => ({ t }), Trans };
+});
+
+const { searchWines, findOrCreateWine, identifyWineByText } = await import('../api/wines');
+const AddBottle = (await import('./AddBottle')).default;
+
+const jsonRes = (body, ok = true, status = 200) => ({ ok, status, json: async () => body });
+
+// An AI suggestion is UNSAVED: plain strings, no _id, no populated refs.
+const SUGGESTION = {
+  name: 'Les Romains', producer: 'Domaine Vacheron', country: 'France',
+  region: 'Loire Valley', appellation: 'Sancerre', type: 'white',
+  grapes: ['Sauvignon Blanc'], confidence: 0.7,
+};
+const REGISTRY_WINE = {
+  _id: 'w1', name: 'Les Romains', producer: 'Domaine Vacheron', type: 'white',
+  country: { name: 'France' }, region: { name: 'Loire Valley' }, grapes: [{ name: 'Sauvignon Blanc' }],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  searchWines.mockResolvedValue(jsonRes({ wines: [] }));
+  findOrCreateWine.mockResolvedValue(jsonRes({ wine: REGISTRY_WINE, created: true }, true, 201));
+});
+
+/** Open the text-search pane and run a search for `q`. */
+async function search(q = 'vacheron les romains') {
+  render(<AddBottle />);
+  fireEvent.click(screen.getByText('addBottle.searchManuallyInstead'));
+  fireEvent.change(screen.getByPlaceholderText('addBottle.searchPlaceholder'), { target: { value: q } });
+  await act(async () => { fireEvent.click(screen.getByText('addBottle.searchBtn')); });
+}
+
+const askAi = async () => {
+  await act(async () => { fireEvent.click(screen.getByText('addBottle.cantFindAiTitle')); });
+};
+
+describe('AddBottle — searching is registry-only', () => {
+  test('pressing Search never calls the AI (the regression that polluted the registry)', async () => {
+    await search();
+
+    expect(searchWines).toHaveBeenCalledTimes(1);
+    expect(identifyWineByText).not.toHaveBeenCalled();
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+
+  test('registry results stay visible — they are no longer hidden behind an AI card', async () => {
+    searchWines.mockResolvedValue(jsonRes({ wines: [REGISTRY_WINE] }));
+    identifyWineByText.mockResolvedValue(jsonRes({
+      identified: SUGGESTION, match: null, candidates: [], reason: null,
+    }));
+
+    await search();
+    await askAi();
+
+    // both the suggestion card and the real registry row are on screen
+    expect(screen.getByText('addBottle.aiIdentifiedTitle')).toBeInTheDocument();
+    expect(screen.getAllByText('Les Romains').length).toBeGreaterThan(1);
+  });
+});
+
+describe('AddBottle — an unsaved AI suggestion', () => {
+  beforeEach(() => {
+    identifyWineByText.mockResolvedValue(jsonRes({
+      identified: SUGGESTION, match: null, candidates: [], reason: null,
+    }));
+  });
+
+  test('renders plain-string country/region/grapes instead of silently blanking them', async () => {
+    await search();
+    await askAi();
+
+    // Reading .name off these strings would render nothing at all — the exact
+    // fields the user is being asked to authorise a registry write for.
+    expect(screen.getByText('France')).toBeInTheDocument();
+    expect(screen.getByText('• Loire Valley')).toBeInTheDocument();
+    expect(screen.getByText('• Sancerre')).toBeInTheDocument();
+    expect(screen.getByText('Sauvignon Blanc')).toBeInTheDocument();
+  });
+
+  test('says it is not in the registry yet, and offers "add it" rather than "use this"', async () => {
+    await search();
+    await askAi();
+
+    expect(screen.getByText('addBottle.aiIdentifiedHint')).toBeInTheDocument();
+    expect(screen.getByText('addBottle.aiAddAndUse')).toBeInTheDocument();
+    expect(screen.queryByText('addBottle.aiUseThisWine')).not.toBeInTheDocument();
+  });
+
+  test('accepting routes through find-or-create with source:ai — never straight to step 2', async () => {
+    await search();
+    await askAi();
+    await act(async () => { fireEvent.click(screen.getByText('addBottle.aiAddAndUse')); });
+
+    expect(findOrCreateWine).toHaveBeenCalledTimes(1);
+    const body = findOrCreateWine.mock.calls[0][1];
+    expect(body).toMatchObject({
+      name: 'Les Romains', producer: 'Domaine Vacheron', country: 'France',
+      appellation: 'Sancerre', type: 'white', source: 'ai',
+    });
+    expect(body.grapes).toEqual(['Sauvignon Blanc']);
+    // and only THEN does the saved wine carry the flow forward
+    await waitFor(() => expect(screen.getByText('addBottle.addBottleBtn')).toBeInTheDocument());
+  });
+
+  test('a soft-zone response opens the "did you mean" modal instead of creating', async () => {
+    findOrCreateWine.mockResolvedValue(jsonRes({
+      candidates: [{ wine: { ...REGISTRY_WINE, _id: 'w9' }, score: 0.9 }],
+    }));
+
+    await search();
+    await askAi();
+    await act(async () => { fireEvent.click(screen.getByText('addBottle.aiAddAndUse')); });
+
+    expect(screen.queryByText('addBottle.addBottleBtn')).not.toBeInTheDocument();
+  });
+});
+
+describe('AddBottle — an AI result already in the registry', () => {
+  test('is selected directly, writing nothing', async () => {
+    identifyWineByText.mockResolvedValue(jsonRes({
+      identified: SUGGESTION, match: { wine: REGISTRY_WINE }, candidates: [], reason: null,
+    }));
+
+    await search();
+    await askAi();
+
+    expect(screen.getByText('addBottle.aiFoundWine')).toBeInTheDocument();
+    expect(screen.getByText('addBottle.aiMatchHint')).toBeInTheDocument();
+
+    await act(async () => { fireEvent.click(screen.getByText('addBottle.aiUseThisWine')); });
+
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByText('addBottle.addBottleBtn')).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
Follow-up to #884, test-only — no runtime change.

`AddBottle` had **no test coverage**, and every failure mode of the #884 rewrite is *silent*: a plain-string `country` rendered as a blank instead of throwing, an unsaved suggestion carried into step 2 where `selectedWine._id` is `undefined` and only 400s at final submit after the user filled the whole form, or the automatic AI call quietly returning and polluting the registry again. A manual click-through passes all three.

Seven cases lock the contract:

| Case | Locks |
|---|---|
| Search never calls the AI | the regression that caused 52% orphan rows |
| Registry results stay visible | the hiding that let a guess beat the correct row |
| Plain-string country/region/appellation/grapes render | the silent-blanking class |
| "Looks right — add it" + not-in-registry hint | the card tells the truth about what will happen |
| Accept → `find-or-create` with `source:'ai'` | nothing is written before an explicit press; step 2 only after save |
| Soft zone → "did you mean" modal | near-duplicates get caught before creation |
| A registry match is selected directly | no write when the wine already exists |

Verified against the merged v1.97.0 tree: 834 frontend tests, 2533 backend tests, clean build, and a live Docker smoke test of the same flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)