### PR TITLE
feat(blog): unread-post badge in the nav, and a blog page you can actually see the posts on

### DIFF
--- a/backend/src/routes/blog.js
+++ b/backend/src/routes/blog.js
@@ -48,11 +48,22 @@ router.get('/', async (req, res) => {
   }
 });
 
-// GET /api/blog/tags — List all tags from published posts
+// GET /api/blog/tags — Tags from published posts, most-used first
+//
+// Ordered by how many posts carry the tag rather than alphabetically. The blog
+// page shows only the first handful before a "show all" toggle, and with 86
+// tags the alphabetical head ("3d", "ai", "analytics") is close to the least
+// useful slice available. Ties break alphabetically so the order is stable.
+// Response shape is unchanged — an array of tag strings.
 router.get('/tags', async (req, res) => {
   try {
-    const tags = await BlogPost.distinct('tags', { status: 'published' });
-    res.json({ tags: tags.sort() });
+    const rows = await BlogPost.aggregate([
+      { $match: { status: 'published' } },
+      { $unwind: '$tags' },
+      { $group: { _id: '$tags', count: { $sum: 1 } } },
+      { $sort: { count: -1, _id: 1 } },
+    ]);
+    res.json({ tags: rows.map((row) => row._id) });
   } catch (err) {
     res.status(500).json({ error: 'Failed to fetch tags' });
   }

--- a/frontend/src/components/Layout.css
+++ b/frontend/src/components/Layout.css
@@ -154,6 +154,15 @@
   color: #065f46;
 }
 
+/* Unread blog posts. Deliberately the brand colour rather than the danger red
+   the notification bell uses — an unread announcement is an invitation, not an
+   alert, and borrowing the alert colour would train people to ignore both. */
+.badge--unread {
+  background: var(--color-primary);
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+}
+
 .badge--plan { font-weight: 600; }
 .badge--plan-free      { background: var(--badge-plan-free-bg); color: var(--badge-plan-free-text); }
 .badge--plan-supporter { background: var(--badge-plan-basic-bg); color: var(--badge-plan-basic-text); }

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
 import { PLANS } from '../config/plans';
 import NotificationBell from './NotificationBell';
+import useUnreadBlog from '../hooks/useUnreadBlog';
 import InstallPrompt from './InstallPrompt';
 import AnnouncementBanner from './AnnouncementBanner';
 import DemoBanner from './DemoBanner';
@@ -22,6 +23,7 @@ function Layout({ children }) {
   const navigate = useNavigate();
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const unreadBlog = useUnreadBlog();
 
   const handleLogout = () => {
     logout();
@@ -36,6 +38,21 @@ function Layout({ children }) {
 
   const planLabel = user ? (PLANS[user.plan]?.label || user.plan || 'Free') : null;
   const roles = user?.roles || [];
+
+  // Built once and rendered into both the desktop nav and the mobile menu. The
+  // blog link exists twice, and a badge added to only one of them is the usual
+  // way this half-ships — sharing the node makes them impossible to drift apart.
+  const blogBadge = unreadBlog > 0 ? (
+    <span
+      className="badge badge--unread"
+      aria-label={t('nav.blogUnread', { count: unreadBlog })}
+    >
+      {/* Same 9+ cap as the notification bell, so two counters in the same bar
+          don't disagree about how they round. The aria-label keeps the exact
+          number for screen readers. */}
+      {unreadBlog > 9 ? '9+' : unreadBlog}
+    </span>
+  ) : null;
 
   return (
     <div className="layout">
@@ -126,6 +143,7 @@ function Layout({ children }) {
                   className={`nav-link ${isActive('/blog') ? 'active' : ''}`}
                 >
                   {t('nav.blog')}
+                  {blogBadge}
                 </Link>
                 <Link
                   to="/supporter"
@@ -254,7 +272,7 @@ function Layout({ children }) {
               <Link to="/restock" className={`mobile-menu-link ${isActive('/restock') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.restock')}</Link>
               <Link to="/wine-requests" className={`mobile-menu-link ${isActive('/wine-requests') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.myRequests')}</Link>
               <Link to="/cellar-chat" className={`mobile-menu-link ${isActive('/cellar-chat') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.cellarChat')}</Link>
-              <Link to="/blog" className={`mobile-menu-link ${isActive('/blog') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.blog')}</Link>
+              <Link to="/blog" className={`mobile-menu-link ${isActive('/blog') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.blog')}{blogBadge}</Link>
               <Link to="/supporter" className={`mobile-menu-link ${isActive('/supporter') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.supporter')}</Link>
               <Link to="/support" className={`mobile-menu-link ${isActive('/support') ? 'active' : ''}`} onClick={closeMenu}>{t('nav.support')}</Link>
             </div>

--- a/frontend/src/hooks/useUnreadBlog.js
+++ b/frontend/src/hooks/useUnreadBlog.js
@@ -1,0 +1,111 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { getBlogPosts } from '../api/blog';
+
+export const STORAGE_KEY = 'blogLastSeenAt';
+
+// One page of posts is enough to count against. The badge exists to say "there
+// is something new", not to be an inbox — and since the first run seeds the
+// timestamp (see below), a reader can only accumulate unread posts at the rate
+// we publish them. A count that hits the cap is reported as the cap.
+export const SCAN_LIMIT = 20;
+
+/**
+ * How many of `posts` were published after `lastSeenAt`.
+ *
+ * Pure and exported because the counting rule is the whole feature: an
+ * unparseable date must not silently become "unread", and a missing timestamp
+ * must mean zero rather than everything. Far easier to pin here than through a
+ * rendered nav bar.
+ */
+export function countUnread(posts, lastSeenAt) {
+  if (!Array.isArray(posts) || !lastSeenAt) return 0;
+  const seen = Date.parse(lastSeenAt);
+  if (Number.isNaN(seen)) return 0;
+  return posts.filter((post) => {
+    const at = Date.parse(post?.publishedAt);
+    return !Number.isNaN(at) && at > seen;
+  }).length;
+}
+
+// Storage can throw outright — Safari private mode, or a browser configured to
+// block it. The badge is decorative, so every access degrades to "no badge"
+// rather than taking the navigation bar down with it.
+const readLastSeen = () => {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const writeLastSeen = (iso) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, iso);
+  } catch {
+    /* storage unavailable — the badge simply won't persist */
+  }
+};
+
+// The blog page and the nav are in different subtrees, so clearing the badge on
+// visit needs a channel between them. A module-level subscriber set is enough:
+// this is one boolean's worth of state, and a context provider around the whole
+// app would be more wiring than the feature is worth.
+const subscribers = new Set();
+
+/** Called when the reader opens /blog — everything published so far is now seen. */
+export function markBlogSeen() {
+  const now = new Date().toISOString();
+  writeLastSeen(now);
+  subscribers.forEach((notify) => notify());
+}
+
+/** Unread post count for the nav badge. Always 0 when signed out. */
+export default function useUnreadBlog() {
+  const { apiFetch, user } = useAuth();
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!user) {
+      setCount(0);
+      return undefined;
+    }
+
+    const stored = readLastSeen();
+    if (!stored) {
+      // First run: treat the back catalogue as already read. A badge counting
+      // every post ever published is noise on someone's first login, not news —
+      // the promise is "new since you last looked", and there is no last look yet.
+      writeLastSeen(new Date().toISOString());
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await getBlogPosts(apiFetch, { limit: SCAN_LIMIT });
+        // apiFetch resolves on non-2xx too, and an error body has no posts array.
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setCount(countUnread(data?.posts, stored));
+      } catch {
+        /* offline or malformed — leave the badge off */
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiFetch, user]);
+
+  useEffect(() => {
+    const clear = () => setCount(0);
+    subscribers.add(clear);
+    return () => {
+      subscribers.delete(clear);
+    };
+  }, []);
+
+  return count;
+}

--- a/frontend/src/hooks/useUnreadBlog.js
+++ b/frontend/src/hooks/useUnreadBlog.js
@@ -28,6 +28,28 @@ export function countUnread(posts, lastSeenAt) {
   }).length;
 }
 
+/**
+ * The last-seen timestamp a first-time reader starts from: one millisecond
+ * before the newest post, so exactly the latest post shows as unread.
+ *
+ * Both obvious alternatives are worse. Seeding to *now* makes the badge
+ * invisible until the next time we publish, which means shipping a feature
+ * nobody sees work. Seeding to the beginning of time counts the entire back
+ * catalogue, and a nav badge reading "12" on a first login is noise people
+ * learn to dismiss. One is an invitation; the others are nothing or spam.
+ *
+ * Pure, and it derives the newest date rather than trusting the response order.
+ */
+export function firstRunLastSeen(posts, now = Date.now()) {
+  const newest = (Array.isArray(posts) ? posts : [])
+    .map((post) => Date.parse(post?.publishedAt))
+    .filter((at) => !Number.isNaN(at))
+    .reduce((max, at) => (at > max ? at : max), -Infinity);
+
+  // No posts at all (or none with a usable date): nothing to invite anyone to.
+  return new Date(newest === -Infinity ? now : newest - 1).toISOString();
+}
+
 // Storage can throw outright — Safari private mode, or a browser configured to
 // block it. The badge is decorative, so every access degrades to "no badge"
 // rather than taking the navigation bar down with it.
@@ -71,15 +93,6 @@ export default function useUnreadBlog() {
       return undefined;
     }
 
-    const stored = readLastSeen();
-    if (!stored) {
-      // First run: treat the back catalogue as already read. A badge counting
-      // every post ever published is noise on someone's first login, not news —
-      // the promise is "new since you last looked", and there is no last look yet.
-      writeLastSeen(new Date().toISOString());
-      return undefined;
-    }
-
     let cancelled = false;
 
     (async () => {
@@ -88,7 +101,18 @@ export default function useUnreadBlog() {
         // apiFetch resolves on non-2xx too, and an error body has no posts array.
         if (!res.ok) return;
         const data = await res.json();
-        if (!cancelled) setCount(countUnread(data?.posts, stored));
+        const posts = data?.posts;
+
+        // The seed needs the posts, so it happens here rather than before the
+        // fetch: a first-time reader is started just behind the newest post so
+        // that exactly one badge is waiting for them.
+        let stored = readLastSeen();
+        if (!stored) {
+          stored = firstRunLastSeen(posts);
+          writeLastSeen(stored);
+        }
+
+        if (!cancelled) setCount(countUnread(posts, stored));
       } catch {
         /* offline or malformed — leave the badge off */
       }

--- a/frontend/src/hooks/useUnreadBlog.test.js
+++ b/frontend/src/hooks/useUnreadBlog.test.js
@@ -7,7 +7,7 @@
  * counting rule is pinned directly.
  */
 import { describe, it, expect } from 'vitest';
-import { countUnread } from './useUnreadBlog';
+import { countUnread, firstRunLastSeen } from './useUnreadBlog';
 
 const post = (publishedAt) => ({ slug: `p-${publishedAt}`, publishedAt });
 
@@ -35,8 +35,8 @@ describe('countUnread', () => {
   });
 
   it('returns 0 without a last-seen timestamp rather than counting everything', () => {
-    // First run seeds the timestamp instead of counting the back catalogue —
-    // a badge reading "12" on someone's first login is noise, not news.
+    // The hook always seeds before counting (see firstRunLastSeen), so this is
+    // the defensive floor: absent a stamp, count nothing rather than everything.
     expect(countUnread([post('2026-08-03T09:00:00.000Z')], null)).toBe(0);
     expect(countUnread([post('2026-08-03T09:00:00.000Z')], undefined)).toBe(0);
     expect(countUnread([post('2026-08-03T09:00:00.000Z')], '')).toBe(0);
@@ -64,5 +64,49 @@ describe('countUnread', () => {
     expect(countUnread(undefined, SEEN)).toBe(0);
     expect(countUnread({ error: 'nope' }, SEEN)).toBe(0);
     expect(countUnread([], SEEN)).toBe(0);
+  });
+});
+
+describe('firstRunLastSeen', () => {
+  const NEWEST = '2026-08-03T09:00:00.000Z';
+  const posts = [post(NEWEST), post('2026-07-20T09:00:00.000Z'), post('2026-06-01T09:00:00.000Z')];
+
+  it('leaves exactly the newest post unread', () => {
+    // The whole point: a first-time reader gets one badge inviting them to the
+    // latest post — not zero (feature invisible) and not the back catalogue.
+    expect(countUnread(posts, firstRunLastSeen(posts))).toBe(1);
+  });
+
+  it('lands one millisecond before the newest post', () => {
+    expect(firstRunLastSeen(posts)).toBe('2026-08-03T08:59:59.999Z');
+  });
+
+  it('finds the newest post regardless of response order', () => {
+    // Derived rather than trusting posts[0]: the endpoint sorts descending
+    // today, but a future tag filter or pagination change must not silently
+    // turn the badge into "every post is unread".
+    const shuffled = [posts[2], posts[0], posts[1]];
+    expect(firstRunLastSeen(shuffled)).toBe(firstRunLastSeen(posts));
+    expect(countUnread(shuffled, firstRunLastSeen(shuffled))).toBe(1);
+  });
+
+  it('ignores posts with unusable dates when picking the newest', () => {
+    const messy = [{ slug: 'no-date' }, { slug: 'bad', publishedAt: 'soon' }, post(NEWEST)];
+    expect(firstRunLastSeen(messy)).toBe('2026-08-03T08:59:59.999Z');
+  });
+
+  it('falls back to now when there is nothing to invite anyone to', () => {
+    const now = Date.parse('2026-08-03T12:00:00.000Z');
+    expect(firstRunLastSeen([], now)).toBe('2026-08-03T12:00:00.000Z');
+    expect(firstRunLastSeen(undefined, now)).toBe('2026-08-03T12:00:00.000Z');
+    expect(firstRunLastSeen([{ slug: 'no-date' }], now)).toBe('2026-08-03T12:00:00.000Z');
+  });
+
+  it('shows one badge, not two, when a second post lands before the first visit', () => {
+    // Seeded once and stored, so the count grows normally from there — the
+    // seeding rule must not re-run and re-hide older unread posts.
+    const seeded = firstRunLastSeen(posts);
+    const later = [post('2026-08-04T09:00:00.000Z'), ...posts];
+    expect(countUnread(later, seeded)).toBe(2);
   });
 });

--- a/frontend/src/hooks/useUnreadBlog.test.js
+++ b/frontend/src/hooks/useUnreadBlog.test.js
@@ -1,0 +1,68 @@
+/**
+ * Unread-blog counting.
+ *
+ * The failure mode this guards is quiet, not loud: a badge that counts wrong
+ * either nags forever about posts already read, or stays silent when something
+ * new is up. Neither throws, and neither is visible in a screenshot — so the
+ * counting rule is pinned directly.
+ */
+import { describe, it, expect } from 'vitest';
+import { countUnread } from './useUnreadBlog';
+
+const post = (publishedAt) => ({ slug: `p-${publishedAt}`, publishedAt });
+
+const SEEN = '2026-08-01T12:00:00.000Z';
+
+describe('countUnread', () => {
+  it('counts only posts published strictly after the last visit', () => {
+    const posts = [
+      post('2026-08-03T09:00:00.000Z'), // after
+      post('2026-08-02T09:00:00.000Z'), // after
+      post('2026-07-30T09:00:00.000Z'), // before
+    ];
+    expect(countUnread(posts, SEEN)).toBe(2);
+  });
+
+  it('treats a post published at exactly the last-seen moment as read', () => {
+    // markBlogSeen() stamps "now" as the reader opens the list, so a post whose
+    // timestamp ties with it was on the page they just looked at. Counting it
+    // would leave a badge that reappears the instant it is cleared.
+    expect(countUnread([post(SEEN)], SEEN)).toBe(0);
+  });
+
+  it('returns 0 when nothing is newer', () => {
+    expect(countUnread([post('2026-07-01T00:00:00.000Z')], SEEN)).toBe(0);
+  });
+
+  it('returns 0 without a last-seen timestamp rather than counting everything', () => {
+    // First run seeds the timestamp instead of counting the back catalogue —
+    // a badge reading "12" on someone's first login is noise, not news.
+    expect(countUnread([post('2026-08-03T09:00:00.000Z')], null)).toBe(0);
+    expect(countUnread([post('2026-08-03T09:00:00.000Z')], undefined)).toBe(0);
+    expect(countUnread([post('2026-08-03T09:00:00.000Z')], '')).toBe(0);
+  });
+
+  it('ignores an unparseable last-seen value instead of counting everything', () => {
+    // Storage is user-writable and survives across versions; a corrupt value
+    // must not turn into "every post is unread".
+    expect(countUnread([post('2026-08-03T09:00:00.000Z')], 'not-a-date')).toBe(0);
+  });
+
+  it('skips posts with a missing or unparseable publish date', () => {
+    const posts = [
+      post('2026-08-03T09:00:00.000Z'),
+      { slug: 'draft-ish' }, // no publishedAt
+      { slug: 'broken', publishedAt: 'sometime' },
+      null,
+    ];
+    expect(countUnread(posts, SEEN)).toBe(1);
+  });
+
+  it('returns 0 for a non-array payload', () => {
+    // apiFetch resolves on non-2xx, so an error body ({error: '…'}) can reach
+    // this with no posts array at all.
+    expect(countUnread(undefined, SEEN)).toBe(0);
+    expect(countUnread({ error: 'nope' }, SEEN)).toBe(0);
+    expect(countUnread([], SEEN)).toBe(0);
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1923,6 +1923,8 @@
     "title": "Blog",
     "subtitle": "News, tips, and updates from the Cellarion team",
     "allPosts": "All Posts",
+    "showAllTags": "All {{total}} tags",
+    "showFewerTags": "Fewer tags",
     "loading": "Loading...",
     "noPosts": "No blog posts yet.",
     "postNotFound": "Post not found.",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -68,6 +68,8 @@
     "plans": "Plans",
     "supporter": "Support Us",
     "blog": "Blog",
+    "blogUnread_one": "{{count}} unread post",
+    "blogUnread_other": "{{count}} unread posts",
     "blogAdmin": "Blog",
     "adminStats": "Global Stats",
     "adminMcp": "AI Connector",

--- a/frontend/src/pages/Blog.css
+++ b/frontend/src/pages/Blog.css
@@ -47,6 +47,19 @@
   border-color: var(--color-accent);
 }
 
+/* The expander is a control, not a filter — dashed and unfilled so it reads as
+   "there is more behind this" rather than as one more tag you could select. */
+.blog-tag--toggle {
+  border-style: dashed;
+  font-weight: 600;
+}
+
+.blog-tag--toggle:hover {
+  background: var(--color-surface);
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
 .blog-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));

--- a/frontend/src/pages/Blog.js
+++ b/frontend/src/pages/Blog.js
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { getBlogPosts, getBlogTags } from '../api/blog';
 import { useAuth } from '../contexts/AuthContext';
+import { markBlogSeen } from '../hooks/useUnreadBlog';
 import SEOHead from '../components/SEOHead';
 import SITE_URL from '../config/siteUrl';
 import './Blog.css';
@@ -53,6 +54,11 @@ function Blog() {
 
   useEffect(() => { fetchPosts(); }, [fetchPosts]);
   useEffect(() => { fetchTags(); }, [fetchTags]);
+
+  // Opening the index counts as reading the list — that is what the nav badge
+  // claims to track. Fires once on mount rather than per page/tag change, so
+  // paging through the archive doesn't keep rewriting the timestamp.
+  useEffect(() => { markBlogSeen(); }, []);
 
   const setPage = (p) => {
     const params = new URLSearchParams(searchParams);

--- a/frontend/src/pages/Blog.js
+++ b/frontend/src/pages/Blog.js
@@ -8,6 +8,12 @@ import SEOHead from '../components/SEOHead';
 import SITE_URL from '../config/siteUrl';
 import './Blog.css';
 
+// The blog carries 86 tags. Rendering them all put every post below the fold on
+// a phone — you scrolled past the entire filter to reach the thing you came
+// for. Collapsed to the most-used handful (the endpoint sorts by post count),
+// with the rest one tap away.
+const COLLAPSED_TAG_COUNT = 8;
+
 function Blog() {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
@@ -17,6 +23,7 @@ function Blog() {
   const [total, setTotal] = useState(0);
   const [pages, setPages] = useState(1);
   const [loading, setLoading] = useState(true);
+  const [showAllTags, setShowAllTags] = useState(false);
 
   const page = Math.max(1, parseInt(searchParams.get('page'), 10) || 1);
   const activeTag = searchParams.get('tag') || '';
@@ -72,6 +79,16 @@ function Blog() {
     setSearchParams(params);
   };
 
+  // The active tag is always kept visible, even when it falls outside the
+  // collapsed set: a filter you can see the effect of but not the control for
+  // reads as a broken page, and you'd have no way to switch it off.
+  const visibleTags = showAllTags
+    ? tags
+    : [...new Set([
+        ...tags.slice(0, COLLAPSED_TAG_COUNT),
+        ...(activeTag ? [activeTag] : []),
+      ])];
+
   const formatDate = (dateStr) => {
     if (!dateStr) return '';
     return new Date(dateStr).toLocaleDateString(undefined, {
@@ -121,7 +138,7 @@ function Blog() {
           >
             {t('blog.allPosts')}
           </button>
-          {tags.map(tag => (
+          {visibleTags.map(tag => (
             <button
               key={tag}
               className={`blog-tag ${activeTag === tag ? 'active' : ''}`}
@@ -130,6 +147,20 @@ function Blog() {
               {tag}
             </button>
           ))}
+          {tags.length > COLLAPSED_TAG_COUNT && (
+            <button
+              className="blog-tag blog-tag--toggle"
+              onClick={() => setShowAllTags(v => !v)}
+              aria-expanded={showAllTags}
+            >
+              {showAllTags
+                ? t('blog.showFewerTags')
+                : /* `total`, not `count`: passing `count` makes i18next look for
+                     plural forms this label has no use for — the toggle only
+                     appears above the collapse threshold, so "1" never renders. */
+                  t('blog.showAllTags', { total: tags.length })}
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Two related problems with how the blog reaches people: nothing signalled that a new post existed, and when you did open the page you couldn't see any posts.

## 1. Unread count on the Blog nav link

A `blogLastSeenAt` timestamp in localStorage, counted against `GET /api/blog` — which already sorts by `publishedAt` and strips `content`, so no new endpoint. Opening `/blog` clears it.

**localStorage, not a field on `User`.** The account route syncs across devices but drags in the whole GDPR checklist from CLAUDE.md — export entry, deletion cascade, arguably audit logging — for one "have you seen this" flag. The server learns nothing here. The cost is that it's per-device; fine for a blog, not a trade I'd make for notifications.

**First-time readers are seeded one millisecond behind the newest post**, so exactly one badge is waiting: an invitation to the latest article. Seeding to *now* would keep the badge invisible until the next time we publish — shipping a feature nobody sees work. Seeding from the beginning of time counts all 20+ posts, which reads as noise on a first login.

Since nobody has a stored timestamp yet, **every reader takes this path on the first load after deploy**, which puts the call-for-translators post in front of the whole user base once.

Other decisions: the badge node is built once and rendered into **both** the desktop nav and the mobile menu (the blog link exists twice — adding it to one is the usual way this half-ships); it uses the brand colour rather than the notification bell's danger red, because a new post is an invitation not an alert; it shares the bell's `9+` cap so two counters in the same bar don't round differently; and every localStorage access degrades to "no badge" rather than throwing, since Safari private mode can refuse outright.

## 2. The tag filter buried the posts

The blog has **86 tags** and rendered all of them above the grid — about two screens of filter before the first post on a phone.

- Collapsed to the **8 most-used**, rest behind an "All 86 tags" toggle. The active tag stays visible even when it falls outside that set, or you'd have a filtered page with no way to clear the filter.
- **`GET /api/blog/tags` now sorts by post count**, not alphabetically. Collapsing to an alphabetical head would surface "3d", "ai", "analytics" — close to the least useful eight available. Ties break alphabetically so the order is stable; response shape unchanged, and Blog.js is the only consumer.

## Tests

`countUnread` and `firstRunLastSeen` are pure and pinned directly, because this fails quietly rather than loudly — a wrong count either nags forever or stays silent, and neither throws. Covered: a post tying exactly with the last-seen stamp counts as **read** (otherwise the badge reappears the instant it's cleared); the seed leaves exactly one post unread; the newest date is derived rather than trusting `posts[0]`, so a future pagination or filter change can't turn the badge into "everything is unread"; corrupt stored values, missing publish dates, and non-array bodies all return 0.

Frontend suite green: 48 files / 847 tests. Production build clean.

**Not covered by tests:** the `/api/blog/tags` aggregation. This repo has no backend route-test pattern (no `mongodb-memory-server`, backend tests are unit-level), so adding one would mean introducing that infrastructure. CI plus a live check after deploy is the gate.

## Not fixed here

The tag list has genuine duplicates — `cellar management` / `cellar-management`, `drink-window` / `drink-windows`, `feature` / `features`, `wine-ageing` / `wine-aging`. Sorting by count now buries them, but they want merging. That's content, not code.

Three new `en` strings (`nav.blogUnread` as a real plural, `blog.showAllTags`, `blog.showFewerTags`). No other locale touched.