### PR TITLE
chore(release): v1.98.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.97.0",
+  "version": "1.98.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.97.0",
+      "version": "1.98.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.97.0",
+  "version": "1.98.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.97.0",
+  "version": "1.98.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.97.0",
+      "version": "1.98.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.97.0",
+  "version": "1.98.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — both `package.json` files and both lockfiles, 1.97.0 → 1.98.0.

## What v1.98.0 ships

**#888 — the blog actually reaches people now.** Two halves:

- **Unread-post count on the Blog nav link.** localStorage-backed, no backend change, no new personal data on the server. First-time readers are seeded one millisecond behind the newest post, so exactly one badge is waiting.
- **The tag filter no longer buries the posts.** 86 tags rendered above the grid meant roughly two screens of filter before the first post on a phone. Now collapsed to the 8 most-used behind an "All 86 tags" toggle, and `GET /api/blog/tags` sorts by post count rather than alphabetically.

## Post-deploy expectations

- **Every existing reader sees a badge of `1` on their first page load**, pointing at the call-for-translators post. Nobody has a stored timestamp yet, so everyone takes the first-run path exactly once. This is intended — it's what puts that post in front of the user base.
- **`/api/blog/tags` ordering changes** from alphabetical to most-used-first. Blog.js is the only consumer; the response shape is unchanged.
- Worth a live check after deploy: `curl -s https://cellarion.app/api/blog/tags` should lead with the high-frequency tags, not `3d`/`ai`/`analytics`.

Maintenance banner ≥15 min before the restart, as usual.