### PR TITLE
fix(bottles): pending photo on every bottle of the wine, and a findable details panel

### DIFF
--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -336,15 +336,38 @@ async function attachBottleImageUrls(bottles, userId) {
   if (!bottles.length) return bottles;
   const bottleIds = bottles.map(b => b._id);
 
+  // Matched by bottle OR by wine, mirroring the single-bottle route. A photo
+  // taken while adding five bottles of the same wine is linked to exactly one
+  // of them, so matching on bottle alone left the other four blank in every
+  // list — while the bottle page, which already matches on wineDefinition,
+  // showed the photo on all five. Same bottle, two answers depending on which
+  // page you opened.
+  const wineIdOf = (b) => b.wineDefinition && (b.wineDefinition._id || b.wineDefinition);
+  const wineIds = [...new Set(bottles.map(wineIdOf).filter(Boolean).map(String))];
+
   const pendingImages = await BottleImage.find({
-    bottle: { $in: bottleIds },
+    $or: [
+      { bottle: { $in: bottleIds } },
+      ...(wineIds.length ? [{ wineDefinition: { $in: wineIds } }] : []),
+    ],
     uploadedBy: userId,
     status: { $in: ['uploaded', 'processing', 'processed'] },
   }).sort({ createdAt: -1 }).lean();
+
+  // Two maps, consulted bottle-first: a photo pinned to this exact bottle must
+  // always beat one that merely matches the wine, or choosing a per-bottle
+  // photo would appear to do nothing.
   const pendingByBottle = {};
+  const pendingByWine = {};
   for (const img of pendingImages) {
-    const key = img.bottle.toString();
-    if (!pendingByBottle[key]) pendingByBottle[key] = img.processedUrl || img.originalUrl;
+    const url = img.processedUrl || img.originalUrl;
+    if (!url) continue;
+    if (img.bottle && !pendingByBottle[img.bottle.toString()]) {
+      pendingByBottle[img.bottle.toString()] = url;
+    }
+    if (img.wineDefinition && !pendingByWine[img.wineDefinition.toString()]) {
+      pendingByWine[img.wineDefinition.toString()] = url;
+    }
   }
 
   const defaultImageIds = bottles.filter(b => b.defaultImage).map(b => b.defaultImage);
@@ -356,11 +379,17 @@ async function attachBottleImageUrls(bottles, userId) {
     defaultImageMap[img._id.toString()] = img.processedUrl || img.originalUrl;
   }
 
-  return bottles.map(b => ({
-    ...b,
-    pendingImageUrl: pendingByBottle[b._id.toString()] || null,
-    defaultImageUrl: b.defaultImage ? (defaultImageMap[b.defaultImage.toString()] || null) : null,
-  }));
+  return bottles.map(b => {
+    const wineId = wineIdOf(b);
+    return {
+      ...b,
+      pendingImageUrl:
+        pendingByBottle[b._id.toString()]
+        || (wineId ? pendingByWine[wineId.toString()] : null)
+        || null,
+      defaultImageUrl: b.defaultImage ? (defaultImageMap[b.defaultImage.toString()] || null) : null,
+    };
+  });
 }
 
 // Facets + facetMeta across the cellar set, for the shared filter modal.
@@ -1227,39 +1256,13 @@ router.get('/:id', async (req, res) => {
       bottles = bottles.slice(skip, skip + limit);
     }
 
-    // Attach the uploader's own pending image to each bottle (visible before admin approval)
-    const bottleIds = bottles.map(b => b._id);
-    const pendingImages = await BottleImage.find({
-      bottle: { $in: bottleIds },
-      uploadedBy: req.user.id,
-      status: { $in: ['uploaded', 'processing', 'processed'] }
-    }).sort({ createdAt: -1 }).lean();
-
-    // Keep only the most recent pending image per bottle
-    const pendingByBottle = {};
-    for (const img of pendingImages) {
-      const key = img.bottle.toString();
-      if (!pendingByBottle[key]) {
-        pendingByBottle[key] = img.processedUrl || img.originalUrl;
-      }
-    }
-
-    // Resolve user-chosen default images for bottles that have one set
-    const defaultImageIds = bottles
-      .filter(b => b.defaultImage)
-      .map(b => b.defaultImage);
-    const defaultImages = defaultImageIds.length > 0
-      ? await BottleImage.find({ _id: { $in: defaultImageIds } }).lean()
-      : [];
-    const defaultImageMap = {};
-    for (const img of defaultImages) {
-      defaultImageMap[img._id.toString()] = img.processedUrl || img.originalUrl;
-    }
-
-    const bottleItems = bottles.map(b => ({
+    // Image resolution is attachBottleImageUrls' job — this route used to carry
+    // its own copy of the same logic, which is exactly how the two drifted apart
+    // (the copy matched pending photos on bottle only, the helper's sibling route
+    // on bottle or wine). One implementation, one behaviour.
+    const withImages = await attachBottleImageUrls(bottles, req.user.id);
+    const bottleItems = withImages.map(b => ({
       ...b,
-      pendingImageUrl: pendingByBottle[b._id.toString()] || null,
-      defaultImageUrl: b.defaultImage ? (defaultImageMap[b.defaultImage.toString()] || null) : null,
       ...(maturityStatusMap ? { maturityStatus: maturityStatusMap.get(b._id.toString()) || null } : {})
     }));
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -826,8 +826,8 @@
     "scanSaving": "Saving…",
     "scanNameProducerCountryRequired": "Wine name, producer, and country are required.",
     "scanFailedToSaveWine": "Failed to save wine. Please try again.",
-    "showDetails": "More details",
-    "hideDetails": "Hide details",
+    "showDetails": "Add notes, occasion, purchase info",
+    "hideDetails": "Hide notes, occasion, purchase info",
     "cantFindAiTitle": "Can't find your wine?",
     "cantFindAiHint": "Look it up",
     "aiFoundWine": "Already in the registry",
@@ -853,7 +853,9 @@
     "aiMatchHint": "This wine is already in our registry — using it won't create a duplicate.",
     "aiAddAndUse": "Looks right — add it",
     "aiConfidence": "{{percent}}% confident",
-    "aiSimilarTitle": "Already in the registry — did you mean one of these?"
+    "aiSimilarTitle": "Already in the registry — did you mean one of these?",
+    "detailsApplyToAll_one": "This applies to the bottle you are adding.",
+    "detailsApplyToAll_other": "These details apply to all {{count}} bottles."
   },
   "bottleDetail": {
     "backToCellar": "← Back to Cellar",

--- a/frontend/src/pages/AddBottle.css
+++ b/frontend/src/pages/AddBottle.css
@@ -880,6 +880,18 @@
   margin-top: 0.75rem;
 }
 
+/* Answers "will this go on all of them?" before it is asked. Accent-tinted
+   rather than a plain hint, because it needs to be read, not skimmed past. */
+.details-applies-all {
+  margin: 0 0 0.875rem;
+  padding: 0.5rem 0.75rem;
+  border-left: 3px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+  background: var(--color-accent-light);
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
 /* form-label: block label outside a form-group wrapper */
 .form-label {
   display: block;

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
@@ -64,6 +64,19 @@ function AddBottle() {
   });
   const [uploadedImages, setUploadedImages] = useState([]);
   const [showDetails, setShowDetails] = useState(false);
+
+  // Whether the user has worked the toggle themselves. Auto-expanding is a
+  // suggestion, not a policy — once someone closes the panel deliberately,
+  // re-opening it under them is worse than leaving the fields hidden.
+  const detailsTouchedRef = useRef(false);
+
+  // Adding several bottles at once is precisely when missing these fields hurts:
+  // the alternative is opening every bottle afterwards and typing the same note
+  // again. A support ticket arrived describing exactly that, from someone who
+  // never found the panel — so for a multi-bottle add we open it for them.
+  useEffect(() => {
+    if (numBottles > 1 && !detailsTouchedRef.current) setShowDetails(true);
+  }, [numBottles]);
   const [saving, setSaving] = useState(false);
   // Bottles already created by earlier attempts of the current submission —
   // when POST k of N fails, a retry only creates the remaining N−k instead of
@@ -940,7 +953,7 @@ function AddBottle() {
             <button
               type="button"
               className={`details-toggle ${showDetails ? 'details-toggle--open' : ''}`}
-              onClick={() => setShowDetails(v => !v)}
+              onClick={() => { detailsTouchedRef.current = true; setShowDetails(v => !v); }}
             >
               <span>{showDetails ? t('addBottle.hideDetails') : t('addBottle.showDetails')}</span>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="details-toggle-chevron">
@@ -951,6 +964,15 @@ function AddBottle() {
             {/* ── Collapsible: purchase info, notes, drink window ── */}
             {showDetails && (
               <div className="details-panel">
+                {/* Both the reporter of the support ticket and the maintainer
+                    independently assumed a note would land on only one of the
+                    bottles. It goes on all of them — but nothing said so, and a
+                    field people believe won't work is a field they don't use. */}
+                {numBottles > 1 && (
+                  <p className="details-applies-all">
+                    {t('addBottle.detailsApplyToAll', { count: numBottles })}
+                  </p>
+                )}
                 <div className="grid-2">
                   <div className="form-group">
                     <label>{t('addBottle.purchaseDate')}</label>


### PR DESCRIPTION
Both halves of support ticket `6a6b91e1` — adding several bottles at once.

## The photo

A photo uploaded while adding five bottles is linked to exactly one of them, and the two views disagreed about what that means:

| View | Pending-image lookup | Result |
|---|---|---|
| Bottle detail | `$or: [{bottle}, {wineDefinition}]` | photo on all five |
| Cellar list | `bottle: {$in: …}` | photo on one |

Same bottle, two answers depending on which page you opened.

**Fixed at the query rather than by duplicating image records.** Matching on the wine as well makes all five show it — no extra `BottleImage` rows, no extra disk on the 4 GB box, no interaction with the 20-image cap, and it repairs bottles that *already exist* instead of only new ones. A photo pinned to a specific bottle still beats one that merely matches the wine, so choosing a per-bottle image still does something.

The route carried **its own copy** of `attachBottleImageUrls`' logic, which is how the two drifted apart. That copy is gone; both callers now share one implementation.

Worth knowing why this only bites before approval: once an admin assigns a photo to the `WineDefinition`, `BottleCard` picks it up via `bottle.wineDefinition?.image` and it shows on every bottle of that wine for everyone. The bug was only ever in the window between upload and approval.

## The fields

`notes` and `occasion` already applied to every bottle — the submit builds one payload and POSTs it N times. But they sit behind a toggle labelled only "More details", defaulting closed. The reporter never found them and edited bottles one at a time instead.

- The toggle now names what's behind it: **"Add notes, occasion, purchase info"**.
- Adding more than one bottle **opens the panel**, since that's exactly when not finding the fields costs the most. Closing it yourself sticks — auto-expand is a suggestion, not a policy.
- Above one bottle, the panel states **"These details apply to all N bottles."**

That last line is the one that matters. Both the reporter *and* the maintainer independently assumed a note would land on only one bottle. A field people believe won't work is a field they don't use.

## Not in this PR

Batch comment and occasion on **import** — genuinely missing, and real work. Raised with the reporter as still to build.

## Tests

Backend routes 42 suites / 498 tests, frontend 48 / 847, production build clean.

Two new `en` plurals (`addBottle.detailsApplyToAll`) plus reworded values for `showDetails`/`hideDetails` — reworded rather than renamed, so Weblate flags the existing translations for review instead of discarding them.