### PR TITLE
chore(release): v1.99.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.98.0",
+  "version": "1.99.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.98.0",
+      "version": "1.99.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.98.0",
+  "version": "1.99.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.98.0",
+  "version": "1.99.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.98.0",
+      "version": "1.99.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.98.0",
+  "version": "1.99.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — both `package.json` files and both lockfiles, 1.98.0 → 1.99.0.

## What v1.99.0 ships

**#890 — adding several bottles at once behaves the way you'd expect.** From support ticket `6a6b91e1`:

- **A pending photo now shows on every bottle of that wine, not just one.** The bottle page and the cellar list disagreed: the former matched pending images by bottle *or* wine, the latter by bottle alone. Fixed at the query, so no duplicated image records and no extra disk — and it repairs bottles that already exist, not only new ones.
- **The notes/occasion panel is findable.** The toggle names its contents, it auto-opens when you're adding more than one bottle, and it states that the details apply to all of them.

## Post-deploy expectations

- Bottles added in a batch with a photo will **start showing that photo across the batch** — including ones added before this release, since the fix is in the read path rather than the write path.
- No migration, no schema change, no compose or env impact.

Maintenance banner ≥15 min before the restart, as usual.