### PR TITLE
chore(release): v1.99.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.99.0",
+  "version": "1.99.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.99.0",
+      "version": "1.99.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.99.0",
+  "version": "1.99.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.99.0",
+  "version": "1.99.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.99.0",
+      "version": "1.99.1",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.99.0",
+  "version": "1.99.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — both `package.json` files and both lockfiles, 1.99.0 → 1.99.1.

v1.99.0 was tagged and built but never deployed, so this ships both it and the security remediation in one window.

## What v1.99.1 ships

**#890 — adding several bottles at once behaves as expected.** A pending photo now shows on every bottle of that wine (the cellar list and the bottle page disagreed), and the notes/occasion panel is findable.

**#893 — security audit remediation**, 2 MEDIUM + 4 LOW from the `v1.94.0..v1.99.0` review, revised after an adversarial pass found three of the first fixes ineffective:

- **Low-confidence queue now matches `null`.** Unusable model output sanitises to null, and the queue's `$ne: null` was excluding exactly those rows. Same change in the registry watchdog.
- **Prompt substitution no longer honours `$` patterns.** A wine named `$'` expanded to the whole remaining template — a working injection and a ~30× token bill.
- **Taxonomy name bounds now cover renames**, not just creates.
- `wine.create` audit entry on the sole user-facing registry-write path; enrichment output length-bounded to the curator's limits; `/find-or-create` no longer hangs on a non-string name; blog tag filter no longer renders the raw `?tag=` value.

## Post-deploy expectations

- **The low-confidence queue and the watchdog count will both rise by 2** — the null-confidence rows that were invisible. Expected, not a regression.
- Batch-added bottles start showing their photo across the batch, including ones added before this release (the fix is in the read path).
- No migration, no schema change, no compose or env impact.

Maintenance banner ≥15 min before the restart, as usual.