### PR TITLE
fix: remediate the 6 verified Highs from the 2026-08-03 full code audit

### DIFF
--- a/backend/src/models/WineVintageProfile.js
+++ b/backend/src/models/WineVintageProfile.js
@@ -39,10 +39,10 @@ const wineVintageProfileSchema = new mongoose.Schema({
   // When true (used for NV / non-vintage wines), the six phase numbers below are
   // year-OFFSETS after each bottle's purchase year — not absolute calendar years
   // — so the drink window recalculates per bottle (NV has no vintage to anchor
-  // to). Offsets are resolved to absolute years client-side only
-  // (frontend/src/utils/maturityUtils.js); the backend classifier
-  // (backend/src/utils/maturityUtils.js) currently skips NV bottles entirely,
-  // so server-side maturity stats/notifications give NV bottles no status.
+  // to). Offsets are resolved against the bottle's purchase year (falling back
+  // to createdAt) by BOTH classifiers — frontend/src/utils/maturityUtils.js and
+  // backend/src/utils/maturityUtils.js (resolveWindowForBottle) — so NV bottles
+  // get a maturity status in stats, exports and the drink-window notifier too.
   relative: { type: Boolean, default: false },
 
   // Phase 1 — Early drinking (absolute year, or year-offset when `relative`)

--- a/backend/src/routes/admin/import.bulkError.test.js
+++ b/backend/src/routes/admin/import.bulkError.test.js
@@ -1,0 +1,130 @@
+/**
+ * applyBulkWriteError — partial-success recovery for the LWIN import flush
+ * (audit 2026-08-03 H1).
+ *
+ * An UNORDERED bulkWrite commits every non-failing op even when the promise
+ * rejects (e.g. two CSV rows normalizing to the same unique normalizedKey —
+ * common in LWIN dumps). The old flush let the rejection bubble into the
+ * per-row catch, which misattributed a whole-batch failure to ONE row: up to
+ * 499 genuinely-created wines vanished from the stats and never reached
+ * finalizeMintedWines (no canonicalKey/slug/createdVia). This pins: failing
+ * ops are charged to their own CSV rows, the partial result is returned for
+ * crediting, and a hard (non-bulk) failure reports the whole batch instead of
+ * discarding the accumulated stats.
+ */
+
+jest.mock('../../services/search', () => ({ fullSync: jest.fn(), indexWine: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../models/WineDefinition', () => ({ findById: jest.fn(), findOne: jest.fn(), bulkWrite: jest.fn() }));
+jest.mock('../../models/Country', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../../models/Region', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../../models/Appellation', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+
+const { applyBulkWriteError } = require('./import');
+
+const freshStats = () => ({
+  total: 10, created: 0, updated: 0, skipped: 0,
+  skippedReasons: { delisted: 0, notWine: 0, missingFields: 0, other: 0 },
+  errors: [],
+});
+
+// Batch rows in op order, each remembering its CSV row number.
+const rows = (...rowIndexes) => rowIndexes.map((rowIndex) => ({ rowIndex }));
+
+const bulkError = ({ writeErrors, result }) =>
+  Object.assign(new Error('E11000 duplicate key'), {
+    name: 'MongoBulkWriteError',
+    writeErrors,
+    result,
+  });
+
+describe('applyBulkWriteError — MongoBulkWriteError (partial success)', () => {
+  test('failing ops are charged to their own CSV rows; the partial result is returned', () => {
+    const stats = freshStats();
+    const err = bulkError({
+      // Op #1 (CSV row 42) collided on normalizedKey; ops #0 and #2 landed.
+      writeErrors: [{ index: 1, errmsg: 'E11000 duplicate key error (normalizedKey)' }],
+      result: { upsertedCount: 2, modifiedCount: 0, upsertedIds: { 0: 'idA', 2: 'idC' } },
+    });
+
+    const result = applyBulkWriteError(err, rows(41, 42, 43), stats);
+
+    expect(result).toBe(err.result); // caller credits created/updated/mintedIds from this
+    expect(stats.total).toBe(9);     // only the ONE failing row is deducted
+    expect(stats.skipped).toBe(1);
+    expect(stats.skippedReasons.other).toBe(1);
+    expect(stats.errors).toEqual([{ row: 42, reason: 'E11000 duplicate key error (normalizedKey)' }]);
+  });
+
+  test('multiple write errors each map to their own row', () => {
+    const stats = freshStats();
+    const err = bulkError({
+      writeErrors: [
+        { index: 0, errmsg: 'dup A' },
+        { index: 2, errmsg: 'dup C' },
+      ],
+      result: { upsertedCount: 1, modifiedCount: 0, upsertedIds: { 1: 'idB' } },
+    });
+
+    applyBulkWriteError(err, rows(7, 8, 9), stats);
+
+    expect(stats.total).toBe(8);
+    expect(stats.skipped).toBe(2);
+    expect(stats.errors).toEqual([
+      { row: 7, reason: 'dup A' },
+      { row: 9, reason: 'dup C' },
+    ]);
+  });
+
+  test('a single (non-array) writeError is normalized', () => {
+    const stats = freshStats();
+    const err = bulkError({
+      writeErrors: { index: 0, errmsg: 'dup' },
+      result: { upsertedCount: 0, modifiedCount: 0, upsertedIds: {} },
+    });
+
+    const result = applyBulkWriteError(err, rows(3), stats);
+    expect(result).toBe(err.result);
+    expect(stats.errors).toEqual([{ row: 3, reason: 'dup' }]);
+  });
+
+  test('the error cap (100) is respected', () => {
+    const stats = freshStats();
+    stats.errors = Array.from({ length: 100 }, (_, i) => ({ row: i, reason: 'x' }));
+    const err = bulkError({
+      writeErrors: [{ index: 0, errmsg: 'dup' }],
+      result: { upsertedCount: 0, modifiedCount: 0, upsertedIds: {} },
+    });
+
+    applyBulkWriteError(err, rows(1), stats);
+    expect(stats.errors).toHaveLength(100); // still counted...
+    expect(stats.skipped).toBe(1);          // ...just not listed
+  });
+});
+
+describe('applyBulkWriteError — hard (non-bulk) failure', () => {
+  test('the whole batch becomes row errors and null is returned (stats survive, no crediting)', () => {
+    const stats = freshStats();
+    const err = new Error('connection reset');
+
+    const result = applyBulkWriteError(err, rows(1, 2, 3), stats);
+
+    expect(result).toBeNull();
+    expect(stats.total).toBe(7);
+    expect(stats.skipped).toBe(3);
+    expect(stats.errors).toEqual([
+      { row: 1, reason: 'Batch write failed: connection reset' },
+      { row: 2, reason: 'Batch write failed: connection reset' },
+      { row: 3, reason: 'Batch write failed: connection reset' },
+    ]);
+  });
+
+  test('a MongoBulkWriteError WITHOUT a result is treated as a hard failure (nothing to credit)', () => {
+    const stats = freshStats();
+    const err = Object.assign(new Error('boom'), { name: 'MongoBulkWriteError' });
+
+    const result = applyBulkWriteError(err, rows(5), stats);
+    expect(result).toBeNull();
+    expect(stats.errors[0].row).toBe(5);
+  });
+});

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -292,11 +292,23 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
   let rowIndex = 0;
   const mintedIds = [];
 
-  // Reusable flush closure with userId in scope
+  // Reusable flush closure with userId in scope. Never throws: an UNORDERED
+  // bulkWrite commits every non-failing op even when the promise rejects
+  // (e.g. two rows normalizing to the same unique normalizedKey — common in
+  // LWIN dumps), so both failure shapes are absorbed here instead of letting
+  // a whole-batch rejection be misattributed to one row by the per-row catch:
+  //   - MongoBulkWriteError → credit the ops that DID land (stats + mintedIds,
+  //     so finalizeMintedWines still repairs them) and report only the
+  //     failing ops as row errors (applyBulkWriteError);
+  //   - hard failure (connection drop) → report the whole batch as row errors,
+  //     so the stats of every earlier batch still reach the response and the
+  //     audit log instead of a bare 500.
   const flush = async () => {
     if (batch.length === 0) return;
+    const rows = batch;
+    batch = [];
 
-    const ops = batch.map(({ mapped, countryId, regionId, normalizedKey }) => {
+    const ops = rows.map(({ mapped, countryId, regionId, normalizedKey }) => {
       const filter = mapped.lwin7
         ? { $or: [{ normalizedKey }, { 'lwin.lwin7': mapped.lwin7 }] }
         : { normalizedKey };
@@ -330,7 +342,13 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
       };
     });
 
-    const result = await WineDefinition.bulkWrite(ops, { ordered: false });
+    let result;
+    try {
+      result = await WineDefinition.bulkWrite(ops, { ordered: false });
+    } catch (err) {
+      result = applyBulkWriteError(err, rows, stats);
+      if (!result) return; // whole batch failed hard — already reported as row errors
+    }
     stats.created += result.upsertedCount || 0;
     stats.updated += result.modifiedCount || 0;
     // bulkWrite bypasses every mongoose hook, so rows minted here would be
@@ -341,7 +359,6 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
     for (const id of Object.values(result.upsertedIds || {})) {
       mintedIds.push(id);
     }
-    batch = [];
   };
 
   try {
@@ -408,7 +425,7 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
         await getOrCreateAppellation(mapped.appellation, countryId, regionId, userId, appellationCache);
         const normalizedKey = generateWineKey(mapped.name, mapped.producer, mapped.appellation || '');
 
-        batch.push({ mapped, countryId, regionId, normalizedKey });
+        batch.push({ mapped, countryId, regionId, normalizedKey, rowIndex });
 
         if (batch.length >= BATCH_SIZE) {
           await flush();
@@ -423,6 +440,9 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
       }
     }
 
+    // Trailing batch. flush() absorbs its own failures (see above), so a
+    // tail-batch failure can no longer discard the accumulated stats or skip
+    // the audit log below.
     await flush();
 
     // Give the freshly minted rows the invariants the bulkWrite skipped.
@@ -452,6 +472,50 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
     res.status(500).json({ error: 'Import failed', details: err.message });
   }
 });
+
+/**
+ * Fold a rejected flush bulkWrite into the running stats.
+ *
+ * An unordered bulkWrite that rejects with MongoBulkWriteError has still
+ * committed every non-failing op; the error carries the partial
+ * BulkWriteResult (`err.result`) plus one WriteError per failing op. Each
+ * failing op is charged to ITS OWN CSV row (mirroring the per-row catch:
+ * total--, skipped++, capped error entry) and the partial result is returned
+ * so the caller credits the surviving ops. Any other error shape (connection
+ * drop mid-batch) has no reliable partial result — every row in the batch is
+ * reported as failed and null is returned.
+ *
+ * @param {Error} err    rejection from WineDefinition.bulkWrite
+ * @param {Array} rows   the batch rows, in op order ({ rowIndex, ... })
+ * @param {object} stats running import stats (mutated)
+ * @returns {object|null} the partial BulkWriteResult to credit, or null
+ */
+function applyBulkWriteError(err, rows, stats) {
+  const failRow = (rowIndex, reason) => {
+    stats.total--;
+    stats.skipped++;
+    stats.skippedReasons.other++;
+    if (stats.errors.length < 100) {
+      stats.errors.push({ row: rowIndex ?? null, reason });
+    }
+  };
+
+  if (err && err.name === 'MongoBulkWriteError' && err.result) {
+    const writeErrors = Array.isArray(err.writeErrors)
+      ? err.writeErrors
+      : err.writeErrors ? [err.writeErrors] : [];
+    for (const we of writeErrors) {
+      failRow(rows[we.index]?.rowIndex, we.errmsg || err.message);
+    }
+    return err.result;
+  }
+
+  console.error('Wine import flush failed (batch dropped):', err?.message);
+  for (const row of rows) {
+    failRow(row.rowIndex, `Batch write failed: ${err?.message}`);
+  }
+  return null;
+}
 
 /**
  * Post-import invariant pass over the rows the bulkWrite INSERTED.
@@ -526,3 +590,7 @@ module.exports.mapRow = mapRow;
 // finalizeMintedWines exported for its unit tests — the invariant repair is
 // load-bearing (strategy 2026-07-29 R4).
 module.exports.finalizeMintedWines = finalizeMintedWines;
+// applyBulkWriteError exported for its unit tests — the partial-success
+// recovery keeps a mid-batch duplicate-key from discarding up to 499
+// created wines' stats and invariants (audit 2026-08-03 H1).
+module.exports.applyBulkWriteError = applyBulkWriteError;

--- a/backend/src/routes/admin/wineRequests.js
+++ b/backend/src/routes/admin/wineRequests.js
@@ -283,18 +283,16 @@ router.put('/:id/reject', async (req, res) => {
       return res.status(400).json({ error: 'Wine request has already been resolved' });
     }
 
-    wineRequest.status = 'rejected';
-    wineRequest.resolvedBy = req.user.id;
-    wineRequest.resolvedAt = new Date();
-    wineRequest.adminNotes = adminNotes.trim();
-
-    await wineRequest.save();
-
     // Detach any bottles that were imported pending this request — the mirror
     // of resolve's backfill above. A rejected request can never become
     // resolvable again, and wineDefinition isn't user-updatable, so a bottle
     // left pointing at it would be permanently stranded; unset the reference
     // and the bottle falls back to the normal editable "no wine" state.
+    // Runs BEFORE the status flip: if the detach fails the request is still
+    // pending, so the admin's retry re-runs it (the $unset is idempotent).
+    // Saved first, a detach failure would leave the request rejected behind
+    // the not-pending guard above — re-stranding the bottles permanently,
+    // the exact condition this detach exists to fix.
     let bottlesDetached = 0;
     if (wineRequest.requestType === 'new_wine') {
       const result = await Bottle.updateMany(
@@ -303,6 +301,13 @@ router.put('/:id/reject', async (req, res) => {
       );
       bottlesDetached = result.modifiedCount || 0;
     }
+
+    wineRequest.status = 'rejected';
+    wineRequest.resolvedBy = req.user.id;
+    wineRequest.resolvedAt = new Date();
+    wineRequest.adminNotes = adminNotes.trim();
+
+    await wineRequest.save();
 
     let notifMsg = `Your request for "${wineRequest.wineName}" was declined. Reason: ${adminNotes.trim()}`;
     if (bottlesDetached > 0) {

--- a/backend/src/routes/admin/wineRequests.js
+++ b/backend/src/routes/admin/wineRequests.js
@@ -290,11 +290,30 @@ router.put('/:id/reject', async (req, res) => {
 
     await wineRequest.save();
 
+    // Detach any bottles that were imported pending this request — the mirror
+    // of resolve's backfill above. A rejected request can never become
+    // resolvable again, and wineDefinition isn't user-updatable, so a bottle
+    // left pointing at it would be permanently stranded; unset the reference
+    // and the bottle falls back to the normal editable "no wine" state.
+    let bottlesDetached = 0;
+    if (wineRequest.requestType === 'new_wine') {
+      const result = await Bottle.updateMany(
+        { pendingWineRequest: wineRequest._id },
+        { $unset: { pendingWineRequest: '' } }
+      );
+      bottlesDetached = result.modifiedCount || 0;
+    }
+
+    let notifMsg = `Your request for "${wineRequest.wineName}" was declined. Reason: ${adminNotes.trim()}`;
+    if (bottlesDetached > 0) {
+      notifMsg += ` Your ${bottlesDetached} bottle${bottlesDetached !== 1 ? 's' : ''} awaiting this wine remain in your cellar without a linked registry wine.`;
+    }
+
     createNotification(
       wineRequest.user,
       'wine_request_rejected',
       'Wine request declined',
-      `Your request for "${wineRequest.wineName}" was declined. Reason: ${adminNotes.trim()}`,
+      notifMsg,
       '/wine-requests'
     );
 
@@ -305,10 +324,11 @@ router.put('/:id/reject', async (req, res) => {
 
     logAudit(req, 'admin.request.reject',
       { type: 'wineRequest', id: wineRequest._id },
-      { wineName: wineRequest.wineName }
+      { wineName: wineRequest.wineName, bottlesDetached }
     );
 
-    res.json({ wineRequest });
+    // bottlesDetached is additive — existing clients read only wineRequest.
+    res.json({ wineRequest, bottlesDetached });
   } catch (error) {
     console.error('Reject wine request error:', error);
     res.status(500).json({ error: 'Failed to reject wine request' });

--- a/backend/src/routes/admin/wineRequests.reject.test.js
+++ b/backend/src/routes/admin/wineRequests.reject.test.js
@@ -133,3 +133,15 @@ test('missing adminNotes is refused before any bottle is touched', async () => {
   expect(res.status).toBe(400);
   expect(Bottle.updateMany).not.toHaveBeenCalled();
 });
+
+test('a detach failure leaves the request PENDING so a retry re-runs the detach', async () => {
+  // Ordering guard: were the status saved first, a detach failure would leave
+  // the request rejected behind the not-pending 400 guard — re-stranding the
+  // bottles permanently, the exact condition the detach exists to fix.
+  Bottle.updateMany.mockRejectedValue(new Error('connection reset'));
+
+  const res = await reject();
+  expect(res.status).toBe(500);
+  expect(requestDoc.save).not.toHaveBeenCalled();
+  expect(requestDoc.status).toBe('pending'); // retryable — the $unset is idempotent
+});

--- a/backend/src/routes/admin/wineRequests.reject.test.js
+++ b/backend/src/routes/admin/wineRequests.reject.test.js
@@ -1,0 +1,135 @@
+/**
+ * PUT /api/admin/wine-requests/:id/reject — bottle detachment (audit
+ * 2026-08-03 H2).
+ *
+ * WHY THIS TEST EXISTS: import paths create bottles with `pendingWineRequest`
+ * instead of `wineDefinition`. Resolve backfills them; reject used to flip
+ * only the request's status, stranding every referencing bottle forever
+ * (wineDefinition isn't user-updatable, so the only escape was delete-and-
+ * re-add). This suite pins: reject unsets pendingWineRequest on the bottles,
+ * reports the count (response + audit log), and keeps the response shape
+ * backward-compatible.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../models/WineRequest', () => ({ findById: jest.fn() }));
+jest.mock('../../models/WineDefinition', () => {
+  const ctor = jest.fn();
+  ctor.findById = jest.fn();
+  ctor.findOne = jest.fn();
+  return ctor;
+});
+jest.mock('../../models/Bottle', () => ({ distinct: jest.fn(), updateMany: jest.fn() }));
+jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
+jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/notifications', () => ({ createNotification: jest.fn() }));
+jest.mock('../../utils/cellarCred', () => ({ incrementCred: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../../utils/vintageProfile', () => ({ ensurePendingVintageProfile: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineRequest = require('../../models/WineRequest');
+const Bottle = require('../../models/Bottle');
+const { logAudit } = require('../../services/audit');
+const { createNotification } = require('../../services/notifications');
+const wineRequestsRouter = require('./wineRequests');
+
+const ADMIN_ID = '64b000000000000000000001';
+const REQUEST_ID = '64b000000000000000000002';
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/wine-requests', wineRequestsRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+let requestDoc;
+beforeEach(() => {
+  jest.clearAllMocks();
+  requestDoc = {
+    _id: REQUEST_ID,
+    status: 'pending',
+    requestType: 'new_wine',
+    wineName: 'Barolo del Comune',
+    user: '64b000000000000000000003',
+    save: jest.fn().mockResolvedValue({}),
+    populate: jest.fn().mockResolvedValue({}),
+  };
+  WineRequest.findById.mockResolvedValue(requestDoc);
+  Bottle.updateMany.mockResolvedValue({ modifiedCount: 0 });
+});
+
+const reject = (body = { adminNotes: 'Not a real wine' }) =>
+  fetch(`${baseUrl}/api/admin/wine-requests/${REQUEST_ID}/reject`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+    body: JSON.stringify(body),
+  });
+
+test('reject detaches every bottle pending this request (mirrors resolve backfill)', async () => {
+  Bottle.updateMany.mockResolvedValue({ modifiedCount: 3 });
+
+  const res = await reject();
+  expect(res.status).toBe(200);
+  const data = await res.json();
+
+  expect(Bottle.updateMany).toHaveBeenCalledWith(
+    { pendingWineRequest: REQUEST_ID },
+    { $unset: { pendingWineRequest: '' } }
+  );
+  expect(data.bottlesDetached).toBe(3);
+  expect(requestDoc.status).toBe('rejected');
+  expect(requestDoc.save).toHaveBeenCalled();
+
+  // Audit log carries the affected-bottle count.
+  const audit = logAudit.mock.calls.find((c) => c[1] === 'admin.request.reject');
+  expect(audit[3]).toMatchObject({ bottlesDetached: 3 });
+
+  // The user is told their bottles remain (editable, just unlinked).
+  const [, , , message] = createNotification.mock.calls[0];
+  expect(message).toContain('Not a real wine');
+  expect(message).toContain('3 bottles');
+});
+
+test('response stays backward-compatible: wineRequest present, count additive, zero when nothing referenced', async () => {
+  const res = await reject();
+  const data = await res.json();
+
+  expect(res.status).toBe(200);
+  expect(data.wineRequest).toBeDefined();
+  expect(data.bottlesDetached).toBe(0);
+  // No bottle count in the notification when nothing was detached.
+  const [, , , message] = createNotification.mock.calls[0];
+  expect(message).not.toContain('bottle');
+});
+
+test('grape suggestions never touch bottles (no pendingWineRequest can reference them)', async () => {
+  requestDoc.requestType = 'grape_suggestion';
+
+  const res = await reject();
+  expect(res.status).toBe(200);
+  expect(Bottle.updateMany).not.toHaveBeenCalled();
+});
+
+test('a non-pending request is refused before any bottle is touched', async () => {
+  requestDoc.status = 'rejected';
+
+  const res = await reject();
+  expect(res.status).toBe(400);
+  expect(Bottle.updateMany).not.toHaveBeenCalled();
+});
+
+test('missing adminNotes is refused before any bottle is touched', async () => {
+  const res = await reject({});
+  expect(res.status).toBe(400);
+  expect(Bottle.updateMany).not.toHaveBeenCalled();
+});

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -257,13 +257,19 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     // registry ALREADY knows, the AI's canonicalized result would dedup to
     // the same registry wine anyway — so a confident registry match skips the
     // AI call with an outcome-identical result (audit M-2 cost defense).
-    const aiEligible = aiProvider.isConfigured()
-      ? preResults.filter(pr => !pr.errorMsg && pr.item.wineName && pr.item.producer)
-      : [];
+    //
+    // The dedup-by-wine-key + Pass 1a cascade run regardless of whether AI is
+    // configured: a no-AI self-hosted install still gets ONE shared registry
+    // lookup per unique wine — previously every row of a keyless install fell
+    // through to a sequential per-row findWineMatches in Pass 3, defeating
+    // the cascade's own "zero AI for known wines" intent. Only the AI fan-out
+    // itself (Pass 1b) is gated on availability.
+    const aiConfigured = aiProvider.isConfigured(); // invariant for the whole request
+    const cascadeEligible = preResults.filter(pr => !pr.errorMsg && pr.item.wineName && pr.item.producer);
 
-    // Build unique wine keys — one AI call per unique wine, not per bottle
+    // Build unique wine keys — one cascade/AI attempt per unique wine, not per bottle
     const aiKeyMap = new Map(); // normalizedKey -> preResult (representative)
-    for (const pr of aiEligible) {
+    for (const pr of cascadeEligible) {
       const key = `${normalizeString(pr.item.wineName)}:${normalizeString(pr.item.producer)}`;
       if (!aiKeyMap.has(key)) aiKeyMap.set(key, pr);
       if (pr.forceAi) aiKeyMap.get(key).forceAi = true; // any row's Look-up button forces the key
@@ -289,7 +295,9 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     // (c) everything else goes to AI exactly as before.
     for (const pr of uniquePrs) {
       if (clientDisconnected) break; // requester gone — stop the cascade, skip AI entirely
-      if (pr.forceAi) continue;
+      // forceAi bypasses the cascade only when there is an AI to reach; with
+      // no key configured the shared cascade is the best available outcome.
+      if (pr.forceAi && aiConfigured) continue;
       const exactWine = await findExactRegistryWine(pr.item);
       if (exactWine) {
         pr.registryWine = { wine: exactWine, score: 1 };
@@ -308,7 +316,7 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     // refunded on transport failure), and a client-disconnect check that
     // stops LAUNCHING new calls once the requester has gone away. All three
     // degrade gracefully to the fuzzy path (aiSkipped: true) — never an error.
-    const needAi = uniquePrs.filter(pr => !pr.registryWine);
+    const needAi = aiConfigured ? uniquePrs.filter(pr => !pr.registryWine) : [];
     const perRequestCap = rateLimitsConfig.get().aiImportPerRequestCap?.max
       ?? rateLimitsConfig.defaults.aiImportPerRequestCap.max;
     const aiRun = needAi.slice(0, perRequestCap);
@@ -356,7 +364,7 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
 
     // Attach the shared cascade/AI result to every eligible preResult with
     // that key (duplicates share the representative's outcome, as before).
-    for (const pr of aiEligible) {
+    for (const pr of cascadeEligible) {
       const key = `${normalizeString(pr.item.wineName)}:${normalizeString(pr.item.producer)}`;
       const rep = aiKeyMap.get(key);
       if (rep.registryWine) { pr.registryWine = rep.registryWine; continue; }
@@ -418,9 +426,8 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
       pr.matches = matches;
     }
 
-    // Pass 4: build final results
+    // Pass 4: build final results (aiConfigured hoisted above — don't re-derive per row)
     const results = [];
-    const aiConfigured = aiProvider.isConfigured(); // invariant — don't re-derive per row
     for (const pr of preResults) {
       if (pr.errorMsg) {
         results.push({ index: pr.index, item: pr.item, status: 'error', error: pr.errorMsg, matches: [] });

--- a/backend/src/routes/import.validate.noAi.test.js
+++ b/backend/src/routes/import.validate.noAi.test.js
@@ -1,0 +1,218 @@
+/**
+ * POST /api/bottles/import/validate — no-AI installs share the registry-first
+ * cascade (audit 2026-08-03 H3).
+ *
+ * WHY THIS TEST EXISTS: `uniquePrs` (the dedup-by-wine-key list driving the
+ * Pass 1a registry cascade) used to be built only when aiProvider
+ * .isConfigured() — an explicitly supported self-hosted mode is running with
+ * NO AI key, and for those installs every row fell through to Pass 3's
+ * sequential per-row findWineMatches with zero dedup: a 2000-row import of a
+ * mixed case cost one lookup PER ROW instead of per unique wine, slow enough
+ * to hit the shipped 120s nginx proxy_read_timeout. This pins: with no AI
+ * key, the cascade still runs once per unique wine key and its outcome is
+ * shared across duplicate rows; only the AI fan-out itself stays gated.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+// The one behavioural switch under test: AI is NOT configured.
+jest.mock('../services/aiProvider', () => ({ isConfigured: () => false }));
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexWine: () => {},
+  bulkIndexBottles: jest.fn(),
+}));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/priceWarnings', () => ({
+  computeUserMediansByCurrency: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/Country', () => ({ findOne: jest.fn() }));
+jest.mock('../models/ImportSession', () => ({}));
+jest.mock('../models/Bottle', () => function Bottle() {});
+jest.mock('../models/WineRequest', () => function WineRequest() {});
+jest.mock('../models/AiUsage', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => {
+  const model = { find: jest.fn() };
+  model.RACK_TYPES = ['grid'];
+  return model;
+});
+
+// Registry mock: exact normalizedKey lookups + the MongoDB fallback candidate
+// searches used by findWineMatches ($text, normalizedKey regex).
+jest.mock('../models/WineDefinition', () => {
+  const state = { exactByKey: new Map(), candidates: [] };
+  const chain = (docs) => {
+    const c = { populate: () => c, sort: () => c, limit: () => c, lean: async () => docs };
+    return c;
+  };
+  const model = {
+    findOne: jest.fn((filter) => ({
+      populate: async () => state.exactByKey.get(filter?.normalizedKey) ?? null,
+    })),
+    find: jest.fn(() => chain(state.candidates)),
+    findById: jest.fn(),
+    __state: state,
+  };
+  return model;
+});
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const WineDefinition = require('../models/WineDefinition');
+const { identifyWineFromText } = require('../services/labelScan');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const importRouter = require('./import');
+
+const USER_ID = '64b000000000000000000001';
+const CELLAR_ID = '64b0000000000000000000bb';
+
+const LA_TACHE = {
+  _id: '64b0000000000000000000c1',
+  name: 'La Tâche',
+  producer: 'Domaine de la Romanée-Conti',
+  appellation: null,
+  type: 'red',
+  image: null,
+  country: { name: 'France' },
+  region: { name: 'Burgundy' },
+  normalizedKey: 'domaine de la romaneeconti:la tache:',
+};
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles/import', importRouter);
+  return app;
+}
+
+function authToken() {
+  return jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+}
+
+function postJson(app, url, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${authToken()}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.write(payload);
+      req.end();
+    });
+  });
+}
+
+const validate = (items) => postJson(buildApp(), '/api/bottles/import/validate', { cellarId: CELLAR_ID, items });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  WineDefinition.__state.exactByKey.clear();
+  WineDefinition.__state.candidates = [];
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, user: USER_ID, deletedAt: null, members: [] });
+});
+
+test('an exact registry wine resolves as "exact" via the cascade — not per-row fuzzy', async () => {
+  WineDefinition.__state.exactByKey.set(LA_TACHE.normalizedKey, LA_TACHE);
+
+  const res = await validate([
+    { wineName: 'La Tâche', producer: 'Domaine de la Romanée-Conti', vintage: '2018' },
+  ]);
+
+  expect(res.status).toBe(200);
+  expect(res.body.results[0].status).toBe('exact');
+  expect(res.body.results[0].matches[0].wineId).toBe(LA_TACHE._id);
+  expect(res.body.results[0].aiSkipped).toBeUndefined(); // full-quality outcome, not degradation
+  expect(identifyWineFromText).not.toHaveBeenCalled();
+  expect(findOrCreateWine).not.toHaveBeenCalled();
+});
+
+test('duplicate rows of one wine share ONE cascade lookup (the H3 per-row explosion)', async () => {
+  const row = { wineName: 'Mystery Cuvée', producer: 'Unknown Estate' };
+  const res = await validate([
+    { ...row, vintage: '2019' },
+    { ...row, vintage: '2020' },
+    { ...row, vintage: '2021' },
+  ]);
+
+  expect(res.status).toBe(200);
+  for (const r of res.body.results) expect(r.status).toBe('no_match');
+
+  // The exact-key probe runs once per UNIQUE wine key (raw + prefix-stripped
+  // variants ≤ 2 findOne calls), not once per row.
+  expect(WineDefinition.findOne.mock.calls.length).toBeLessThanOrEqual(2);
+  // findWineMatches (2 fallback `find` strategies with Meili unavailable) runs
+  // once for the unique key and is REUSED by the other rows: 2 calls, not 6.
+  expect(WineDefinition.find).toHaveBeenCalledTimes(2);
+});
+
+test('exact-scoring fuzzy candidates short-circuit to "exact" shared across rows', async () => {
+  WineDefinition.__state.candidates = [LA_TACHE];
+
+  const row = { wineName: 'La Tâche', producer: 'Domaine de la Romanée-Conti' };
+  const res = await validate([{ ...row, vintage: '2018' }, { ...row, vintage: '2019' }]);
+
+  for (const r of res.body.results) {
+    expect(r.status).toBe('exact');
+    expect(r.matches[0].wineId).toBe(LA_TACHE._id);
+    expect(r.matches[0].score).toBeGreaterThanOrEqual(0.95);
+  }
+  // One shared cascade run: candidates fetched once, not once per row.
+  expect(WineDefinition.find).toHaveBeenCalledTimes(2);
+});
+
+test('forceAi rows fall back to the shared cascade when there is no AI to force', async () => {
+  WineDefinition.__state.exactByKey.set(LA_TACHE.normalizedKey, LA_TACHE);
+
+  const res = await validate([
+    { wineName: 'La Tâche', producer: 'Domaine de la Romanée-Conti', vintage: '2018', forceAi: true },
+  ]);
+
+  expect(res.body.results[0].status).toBe('exact');
+  expect(res.body.results[0].matches[0].wineId).toBe(LA_TACHE._id);
+  expect(identifyWineFromText).not.toHaveBeenCalled();
+});
+
+test('no-AI responses carry no degradation markers (aiSkipped / aiBudgetExhausted / aiDebug)', async () => {
+  const res = await validate([{ wineName: 'Ghost', producer: 'Phantom', vintage: '2020' }]);
+
+  expect(res.status).toBe(200);
+  expect(res.body.results[0].status).toBe('no_match');
+  expect(res.body.results[0].aiSkipped).toBeUndefined();
+  expect(res.body.results[0].aiDebug).toBeUndefined();
+  expect(res.body.summary.aiBudgetExhausted).toBeUndefined();
+});

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -434,7 +434,9 @@ router.post('/:id/arrange/preview', async (req, res) => {
 
     const rack = await Rack.findOne({ _id: req.params.id, deletedAt: null }).populate({
       path: 'slots.bottle',
-      select: 'vintage status drinkFrom drinkTo wineDefinition',
+      // purchaseDate/createdAt anchor relative (NV) profile windows for the
+      // maturity arrangement strategy.
+      select: 'vintage status drinkFrom drinkTo wineDefinition purchaseDate createdAt',
       populate: { path: 'wineDefinition', select: 'name producer type' },
     });
     if (!rack) return res.status(404).json({ error: 'Rack not found' });

--- a/backend/src/services/cellarExport.js
+++ b/backend/src/services/cellarExport.js
@@ -217,7 +217,8 @@ function mapBottlesForExport(bottles, racks, imagesByBottle = new Map(), reviews
     // (the `relative` flag plus phase years, or year-offsets when relative) so the
     // window re-creates identically on import — no resolution to absolute years.
     const wdId = wine?._id?.toString();
-    if (wdId && b.vintage && b.vintage !== 'NV') {
+    // NV included: relative profiles export their raw `relative` flag + offsets.
+    if (wdId && b.vintage) {
       const profile = profilesByWineVintage.get(`${wdId}:${b.vintage}`);
       if (profile) {
         const m = {};

--- a/backend/src/services/drinkWindowNotifier.js
+++ b/backend/src/services/drinkWindowNotifier.js
@@ -13,7 +13,7 @@ const Cellar = require('../models/Cellar');
 const Bottle = require('../models/Bottle');
 const SiteConfig = require('../models/SiteConfig');
 const { CONSUMED_STATUSES } = require('../config/constants');
-const { classifyMaturity, classifyPersonalWindow, buildProfileMap } = require('../utils/maturityUtils');
+const { classifyMaturity, classifyPersonalWindow, buildProfileMap, resolveWindowForBottle } = require('../utils/maturityUtils');
 const { shouldNotifyOpenBottle, openBottleDaysLeft } = require('../utils/openBottleUtils');
 const { createNotification } = require('./notifications');
 const { sendDrinkWindowDigest, EMAIL_VERIFICATION_ENABLED } = require('./mailgun');
@@ -113,11 +113,13 @@ async function processUser(user, isFirstRun) {
     user: user._id,
     cellar: { $in: cellarIds },
     status: { $nin: CONSUMED_STATUSES },
-    // Profile-classified bottles need a wine definition + real vintage; a
-    // bottle with a PERSONAL drink window (drinkFrom/drinkTo) is classified
-    // from that window directly and qualifies regardless (incl. NV).
+    // Profile-classified bottles need a wine definition — including NV
+    // bottles, whose curated `relative` profiles are resolved per bottle by
+    // classifyMaturity (bottles with no reviewed profile classify to null and
+    // are skipped below). A bottle with a PERSONAL drink window
+    // (drinkFrom/drinkTo) qualifies regardless, even without a definition.
     $or: [
-      { wineDefinition: { $ne: null }, vintage: { $ne: 'NV' } },
+      { wineDefinition: { $ne: null } },
       { drinkFrom: { $ne: null } },
       { drinkTo: { $ne: null } }
     ]
@@ -153,11 +155,12 @@ async function processUser(user, isFirstRun) {
 
     // When the bottle's PERSONAL window governs the status (same precedence as
     // classifyMaturity), "ending soon" is measured against its drinkTo year
-    // rather than the profile's peakUntil.
+    // rather than the profile's peakUntil. Profile windows are resolved per
+    // bottle so a relative (NV) peakUntil is a calendar year, not an offset.
     const personalGoverns = classifyPersonalWindow(bottle, currentYear) !== null;
     const windowEnd = personalGoverns
       ? (Number.isFinite(bottle.drinkTo) ? bottle.drinkTo : null)
-      : profile?.peakUntil;
+      : resolveWindowForBottle(profile, bottle)?.peakUntil;
 
     // Determine notification type based on transition
     let notifType = null;

--- a/backend/src/services/drinkWindowNotifier.test.js
+++ b/backend/src/services/drinkWindowNotifier.test.js
@@ -137,3 +137,89 @@ describe('processUser — definition-less personal-window bottles (BUG 4)', () =
     expect(createNotification).toHaveBeenCalledTimes(1);
   });
 });
+
+/**
+ * Audit 2026-08-03 H6 regression: NV bottles with a curated `relative` profile
+ * were excluded from the candidate query (vintage: { $ne: 'NV' }), so the cron
+ * never even evaluated them — the notification path was structurally dead for
+ * the entire NV/Champagne category despite a fully-curated profile.
+ */
+describe('processUser — NV bottles with relative profiles (H6)', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-15T00:00:00Z'));
+  });
+  afterAll(() => jest.useRealTimers());
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Cellar.distinct.mockResolvedValue(['cellar1']);
+    Bottle.updateOne.mockResolvedValue({});
+    Bottle.bulkWrite.mockResolvedValue({});
+  });
+
+  const mockBottles = (bottles) => {
+    Bottle.find.mockReturnValue({ populate: () => ({ lean: () => Promise.resolve(bottles) }) });
+  };
+
+  // Peak 2–5 years after purchase; bought 2024 → peak 2026–2029 → 'peak' now.
+  const relProfile = {
+    wineDefinition: 'wd1', vintage: 'NV', status: 'reviewed', relative: true,
+    earlyFrom: 0, earlyUntil: 1, peakFrom: 2, peakUntil: 5,
+  };
+
+  test('the candidate query no longer excludes NV wine-definition bottles', async () => {
+    mockBottles([]);
+    await processUser({ _id: 'u1' }, false);
+    const query = Bottle.find.mock.calls[0][0];
+    expect(query.$or).toContainEqual({ wineDefinition: { $ne: null } });
+    // The old exclusion shape must be gone.
+    expect(JSON.stringify(query)).not.toContain('NV');
+  });
+
+  test('an NV bottle entering its relative peak window fires a peak notification', async () => {
+    WineVintageProfile.find.mockReturnValue({ lean: () => Promise.resolve([relProfile]) });
+    mockBottles([
+      { _id: 'nv1', cellar: 'cellar1', vintage: 'NV', purchaseDate: '2024-03-01',
+        wineDefinition: { _id: 'wd1', name: 'Grande Cuvée' } },
+    ]);
+
+    const count = await processUser({ _id: 'u1' }, false);
+
+    expect(count).toBe(1);
+    expect(createNotification).toHaveBeenCalledTimes(1);
+    const [, type, , message] = createNotification.mock.calls[0];
+    expect(type).toBe('drink_window_peak');
+    expect(message).toContain('Grande Cuvée');
+  });
+
+  test('an NV bottle with NO anchor (no purchaseDate/createdAt) stays unclassified — no alert, no marker', async () => {
+    WineVintageProfile.find.mockReturnValue({ lean: () => Promise.resolve([relProfile]) });
+    mockBottles([
+      { _id: 'nv1', cellar: 'cellar1', vintage: 'NV',
+        wineDefinition: { _id: 'wd1', name: 'Grande Cuvée' } },
+    ]);
+
+    const count = await processUser({ _id: 'u1' }, false);
+
+    expect(count).toBe(0);
+    expect(createNotification).not.toHaveBeenCalled();
+    expect(Bottle.bulkWrite).not.toHaveBeenCalled();
+  });
+
+  test('first run silently seeds the NV bottle status instead of notifying', async () => {
+    WineVintageProfile.find.mockReturnValue({ lean: () => Promise.resolve([relProfile]) });
+    mockBottles([
+      { _id: 'nv1', cellar: 'cellar1', vintage: 'NV', purchaseDate: '2024-03-01',
+        wineDefinition: { _id: 'wd1', name: 'Grande Cuvée' } },
+    ]);
+
+    const count = await processUser({ _id: 'u1' }, true);
+
+    expect(count).toBe(0);
+    expect(createNotification).not.toHaveBeenCalled();
+    const seedOps = Bottle.bulkWrite.mock.calls[0][0];
+    expect(seedOps[0].updateOne.filter._id).toBe('nv1');
+    expect(seedOps[0].updateOne.update.$set.drinkWindowNotifiedStatus).toBe('peak');
+  });
+});

--- a/backend/src/services/insightsService.js
+++ b/backend/src/services/insightsService.js
@@ -15,7 +15,7 @@ const Cellar = require('../models/Cellar');
 const Bottle = require('../models/Bottle');
 const WishlistItem = require('../models/WishlistItem');
 const { CONSUMED_STATUSES, WINE_POPULATE_LIST } = require('../config/constants');
-const { classifyMaturity, buildProfileMap, maturityLabel } = require('../utils/maturityUtils');
+const { classifyMaturity, buildProfileMap, maturityLabel, resolveWindowForBottle } = require('../utils/maturityUtils');
 const { toNormalized } = require('../utils/ratingUtils');
 
 const WINE_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
@@ -444,8 +444,11 @@ async function buildCaseJourneys(userId, { focusWineId = null, focusVintage = nu
     const status = rep ? classifyMaturity(rep, profileMap) : null;
     const wdId = rep?.wineDefinition?._id ? String(rep.wineDefinition._id) : null;
     const vintageProfile = rep && wdId ? profileMap.get(`${wdId}:${rep.vintage}`) : null;
+    // Resolved per bottle: a relative (NV) lateUntil/peakUntil is an offset,
+    // and read raw it would make every NV lot look 'too_slow'.
+    const resolvedWindow = vintageProfile ? resolveWindowForBottle(vintageProfile, rep) : null;
     const windowCloses = rep
-      ? (Number.isFinite(rep.drinkTo) ? rep.drinkTo : vintageProfile?.lateUntil || vintageProfile?.peakUntil || null)
+      ? (Number.isFinite(rep.drinkTo) ? rep.drinkTo : resolvedWindow?.lateUntil || resolvedWindow?.peakUntil || null)
       : null;
 
     let pace = null;

--- a/backend/src/services/statsService.js
+++ b/backend/src/services/statsService.js
@@ -1,6 +1,6 @@
 const { getOrCreateDailySnapshot, convertCurrency } = require('../utils/exchangeRates');
 const { toNormalized } = require('../utils/ratingUtils');
-const { classifyMaturity, classifyPersonalWindow, buildProfileMap } = require('../utils/maturityUtils');
+const { classifyMaturity, classifyPersonalWindow, buildProfileMap, resolveWindowForBottle } = require('../utils/maturityUtils');
 
 // ── Main export ───────────────────────────────────────────────────────────────
 
@@ -116,14 +116,17 @@ async function computeOverview({ activeBottles, consumedBottles, cellars, target
     // buckets + health score reflect the user's own intent wherever it's set.
     const personalStatus = classifyPersonalWindow(b);
     const wdId = wd?._id?.toString() || (typeof b.wineDefinition === 'string' ? b.wineDefinition : null);
-    const reviewedProfile = (wdId && b.vintage && b.vintage !== 'NV')
+    const reviewedProfile = (wdId && b.vintage)
       ? profileMap.get(`${wdId}:${b.vintage}`)
       : null;
+    // Windows resolved per bottle so relative (NV) offsets become calendar
+    // years; null when a relative window has no anchor — same as classifyMaturity.
+    const resolvedWindow = reviewedProfile ? resolveWindowForBottle(reviewedProfile, b) : null;
     // A reviewed profile only "counts" when it carries a usable window boundary —
     // same guard classifyMaturity uses, so a usable profile always yields a phase
     // (and is never left in the noProfile bucket).
-    const hasUsableProfile = !!reviewedProfile &&
-      (reviewedProfile.earlyFrom != null || reviewedProfile.peakFrom != null || reviewedProfile.peakUntil != null);
+    const hasUsableProfile = !!resolvedWindow &&
+      (resolvedWindow.earlyFrom != null || resolvedWindow.peakFrom != null || resolvedWindow.peakUntil != null);
 
     const maturityStatus = classifyMaturity(b, profileMap);
     if (maturityStatus) {
@@ -154,11 +157,11 @@ async function computeOverview({ activeBottles, consumedBottles, cellars, target
       if (personalStatus) {
         pFrom  = Number.isFinite(b.drinkFrom) ? b.drinkFrom : null;
         pUntil = Number.isFinite(b.drinkTo)   ? b.drinkTo   : null;
-      } else if (reviewedProfile) {
-        pFrom  = reviewedProfile.peakFrom || reviewedProfile.earlyFrom;
-        pUntil = reviewedProfile.lateUntil || reviewedProfile.peakUntil || reviewedProfile.earlyUntil;
+      } else if (resolvedWindow) {
+        pFrom  = resolvedWindow.peakFrom || resolvedWindow.earlyFrom;
+        pUntil = resolvedWindow.lateUntil || resolvedWindow.peakUntil || resolvedWindow.earlyUntil;
       }
-      if (personalStatus || reviewedProfile) {
+      if (personalStatus || resolvedWindow) {
         for (const fy of forecastYears) {
           if ((!pFrom || fy >= pFrom) && (!pUntil || fy <= pUntil)) forecastCounts[fy]++;
         }

--- a/backend/src/utils/maturityUtils.js
+++ b/backend/src/utils/maturityUtils.js
@@ -15,7 +15,12 @@ const WINDOW_FIELDS = ['earlyFrom', 'earlyUntil', 'peakFrom', 'peakUntil', 'late
 function bottleAnchorYear(bottle) {
   const d = bottle?.purchaseDate || bottle?.createdAt;
   if (!d) return null;
-  const y = new Date(d).getFullYear();
+  // UTC year, not local: date-only purchase dates ("2026-12-31") parse as UTC
+  // midnight, so a local-time read shifts Dec-31/Jan-1 purchases into the
+  // wrong year in non-UTC timezones (a Dec 31 purchase read in a UTC+13
+  // browser becomes next year while the UTC server keeps this year). The UTC
+  // year is always the calendar year the user picked, in every timezone.
+  const y = new Date(d).getUTCFullYear();
   return Number.isFinite(y) ? y : null;
 }
 

--- a/backend/src/utils/maturityUtils.js
+++ b/backend/src/utils/maturityUtils.js
@@ -4,6 +4,54 @@
 
 const WineVintageProfile = require('../models/WineVintageProfile');
 
+const WINDOW_FIELDS = ['earlyFrom', 'earlyUntil', 'peakFrom', 'peakUntil', 'lateFrom', 'lateUntil'];
+
+/**
+ * The year a relative (NV) window is measured from for a given bottle: its
+ * purchase year, falling back to when it was added to the cellar. Mirrors
+ * frontend/src/utils/maturityUtils.js bottleAnchorYear — the two must not
+ * drift or the bottle page and the backend stats/notifier disagree.
+ */
+function bottleAnchorYear(bottle) {
+  const d = bottle?.purchaseDate || bottle?.createdAt;
+  if (!d) return null;
+  const y = new Date(d).getFullYear();
+  return Number.isFinite(y) ? y : null;
+}
+
+/**
+ * Resolve a profile's drink window to absolute calendar years.
+ *
+ * For `relative` profiles (NV / non-vintage wines) the stored numbers are
+ * year-offsets after the bottle's anchor year, so we add the anchor; otherwise
+ * the numbers are already absolute years and the anchor is ignored. Mirrors
+ * the frontend resolveWindow.
+ */
+function resolveWindow(profile, anchorYear) {
+  const rel = !!(profile?.relative) && Number.isFinite(anchorYear);
+  const out = {};
+  for (const f of WINDOW_FIELDS) {
+    const v = profile?.[f];
+    out[f] = (v === null || v === undefined) ? v : (rel ? v + anchorYear : v);
+  }
+  return out;
+}
+
+/**
+ * Resolve a profile's window against a specific bottle: absolute years pass
+ * through; relative (NV) offsets are anchored on the bottle's purchase year.
+ * Returns null when a relative window has no anchor to resolve against (e.g.
+ * a caller that selected the bottle without purchaseDate/createdAt) — raw
+ * offsets must never be read as calendar years.
+ */
+function resolveWindowForBottle(profile, bottle) {
+  if (!profile) return null;
+  if (!profile.relative) return resolveWindow(profile, null);
+  const anchorYear = bottleAnchorYear(bottle);
+  if (anchorYear === null) return null;
+  return resolveWindow(profile, anchorYear);
+}
+
 /**
  * Classify a bottle against its OWN drinkFrom/drinkTo window (optional integer
  * years the user set on the bottle). Returns 'not-ready' | 'peak' | 'declining'
@@ -33,12 +81,18 @@ function classifyMaturity(bottle, profileMap) {
 
   const wdId    = bottle.wineDefinition?._id?.toString() || bottle.wineDefinition?.toString();
   const vintage = bottle.vintage;
-  if (!wdId || !vintage || vintage === 'NV') return null;
+  if (!wdId || !vintage) return null;
 
   const profile = profileMap.get(`${wdId}:${vintage}`);
   if (!profile || profile.status !== 'reviewed') return null;
 
-  const { earlyFrom, earlyUntil, peakFrom, peakUntil, lateFrom, lateUntil } = profile;
+  // NV bottles carry `relative` profiles whose numbers are offsets after the
+  // purchase year — resolved here, same as the frontend, so NV maturity is no
+  // longer invisible server-side. Null when the offsets can't be anchored.
+  const window = resolveWindowForBottle(profile, bottle);
+  if (!window) return null;
+
+  const { earlyFrom, earlyUntil, peakFrom, peakUntil, lateFrom, lateUntil } = window;
 
   // Need at least one window boundary to classify
   if (!earlyFrom && !peakFrom && !peakUntil) return null;
@@ -67,7 +121,9 @@ async function buildProfileMap(activeBottles) {
   for (const b of activeBottles) {
     const wdId = b.wineDefinition?._id?.toString();
     const v    = b.vintage;
-    if (wdId && v && v !== 'NV') {
+    // 'NV' is a valid key — sommeliers curate `relative` profiles for
+    // non-vintage wines, resolved per bottle by classifyMaturity.
+    if (wdId && v) {
       const key = `${wdId}:${v}`;
       if (!seenPairs.has(key)) {
         seenPairs.add(key);
@@ -129,20 +185,25 @@ function maturityLabel(status, profile, bottle = null) {
     }
   }
 
+  // Quote resolved calendar years, never raw relative (NV) offsets. A
+  // relative profile with no anchor yields no years ('?' / generic labels) —
+  // the same bottles classifyMaturity leaves unclassified anyway.
+  const w = (profile?.relative ? resolveWindowForBottle(profile, bottle) : profile) || {};
+
   switch (status) {
     case 'not-ready':
-      return `Not ready yet — drinking from ${profile?.earlyFrom || profile?.peakFrom || '?'}`;
+      return `Not ready yet — drinking from ${w.earlyFrom || w.peakFrom || '?'}`;
     case 'early':
-      return profile?.peakFrom
-        ? `Early drinking — peak from ${profile.peakFrom}`
+      return w.peakFrom
+        ? `Early drinking — peak from ${w.peakFrom}`
         : 'Early drinking window';
     case 'peak':
-      return profile?.peakUntil
-        ? `At peak — drink now through ${profile.peakUntil}`
+      return w.peakUntil
+        ? `At peak — drink now through ${w.peakUntil}`
         : 'At peak maturity — drink now';
     case 'late':
-      return profile?.lateUntil
-        ? `Late maturity — drink soon, until ${profile.lateUntil}`
+      return w.lateUntil
+        ? `Late maturity — drink soon, until ${w.lateUntil}`
         : 'Late maturity — drink soon';
     case 'declining':
       return 'Past peak — declining, drink immediately if at all';
@@ -151,4 +212,7 @@ function maturityLabel(status, profile, bottle = null) {
   }
 }
 
-module.exports = { classifyMaturity, classifyPersonalWindow, buildProfileMap, maturityLabel };
+module.exports = {
+  classifyMaturity, classifyPersonalWindow, buildProfileMap, maturityLabel,
+  bottleAnchorYear, resolveWindow, resolveWindowForBottle,
+};

--- a/backend/src/utils/maturityUtils.test.js
+++ b/backend/src/utils/maturityUtils.test.js
@@ -1,6 +1,10 @@
-jest.mock('../models/WineVintageProfile', () => ({}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
 
-const { classifyMaturity, classifyPersonalWindow, maturityLabel } = require('./maturityUtils');
+const WineVintageProfile = require('../models/WineVintageProfile');
+const {
+  classifyMaturity, classifyPersonalWindow, maturityLabel,
+  buildProfileMap, bottleAnchorYear, resolveWindow,
+} = require('./maturityUtils');
 
 // Fix the system clock to 2026 for all tests
 beforeAll(() => {
@@ -43,10 +47,12 @@ describe('classifyMaturity', () => {
     return map;
   }
 
-  test('returns null for NV vintage', () => {
+  test('NV vintage with a reviewed absolute-year profile classifies (matches the frontend)', () => {
+    // Non-relative NV profile: numbers are absolute years, no anchor needed.
+    // The old backend returned null for every NV bottle (audit 2026-08-03 H6).
     const bottle = makeBottle('NV');
     const map = makeMap('NV', { status: 'reviewed', earlyFrom: 2020 });
-    expect(classifyMaturity(bottle, map)).toBeNull();
+    expect(classifyMaturity(bottle, map)).toBe('early');
   });
 
   test('returns null for missing vintage', () => {
@@ -316,6 +322,111 @@ describe('classifyMaturity — personal window precedence', () => {
   });
 });
 
+// ─── Relative (NV) profiles — audit 2026-08-03 H6 ────────────────────────────
+// Offsets are anchored on the bottle's purchase year (falling back to
+// createdAt), mirroring frontend resolveWindow/bottleAnchorYear. Clock: 2026.
+
+describe('classifyMaturity — relative (NV) profiles', () => {
+  const wdId = 'abc123';
+  const nvBottle = (over = {}) => ({ wineDefinition: { _id: wdId }, vintage: 'NV', ...over });
+
+  // Early 0–1y, peak 2–5y, late 6–8y after purchase.
+  function relMap(overrides = {}) {
+    const map = new Map();
+    map.set(`${wdId}:NV`, {
+      status: 'reviewed', relative: true,
+      earlyFrom: 0, earlyUntil: 1, peakFrom: 2, peakUntil: 5, lateFrom: 6, lateUntil: 8,
+      ...overrides,
+    });
+    return map;
+  }
+
+  test('offsets anchor on the purchase year: bought 2024 → peak in 2026', () => {
+    // Peak = 2024+2 … 2024+5 = 2026–2029.
+    expect(classifyMaturity(nvBottle({ purchaseDate: '2024-03-01' }), relMap())).toBe('peak');
+  });
+
+  test('bought this year → early', () => {
+    expect(classifyMaturity(nvBottle({ purchaseDate: '2026-01-10' }), relMap())).toBe('early');
+  });
+
+  test('bought long ago → declining', () => {
+    // Late until 2015+8 = 2023 < 2026.
+    expect(classifyMaturity(nvBottle({ purchaseDate: '2015-06-01' }), relMap())).toBe('declining');
+  });
+
+  test('falls back to createdAt when purchaseDate is missing', () => {
+    expect(classifyMaturity(nvBottle({ createdAt: '2024-08-20' }), relMap())).toBe('peak');
+  });
+
+  test('no anchor at all → null (offsets must never be read as calendar years)', () => {
+    expect(classifyMaturity(nvBottle(), relMap())).toBeNull();
+  });
+
+  test('a zero offset resolves to the anchor year itself', () => {
+    // earlyFrom 0 → drinkable from 2026; peak from 2028 → early now.
+    const map = relMap({ earlyFrom: 0, earlyUntil: 1, peakFrom: 2, peakUntil: 5 });
+    expect(classifyMaturity(nvBottle({ purchaseDate: '2026-02-02' }), map)).toBe('early');
+  });
+
+  test('personal drink window still wins over a relative profile', () => {
+    const bottle = nvBottle({ purchaseDate: '2024-03-01', drinkFrom: 2030 });
+    expect(classifyMaturity(bottle, relMap())).toBe('not-ready');
+  });
+
+  test('unreviewed relative profile → null', () => {
+    const map = relMap({ status: 'pending' });
+    expect(classifyMaturity(nvBottle({ purchaseDate: '2024-03-01' }), map)).toBeNull();
+  });
+});
+
+describe('bottleAnchorYear / resolveWindow', () => {
+  test('anchor prefers purchaseDate over createdAt', () => {
+    expect(bottleAnchorYear({ purchaseDate: '2019-05-01', createdAt: '2023-01-01' })).toBe(2019);
+    expect(bottleAnchorYear({ createdAt: '2023-01-01' })).toBe(2023);
+    expect(bottleAnchorYear({})).toBeNull();
+    expect(bottleAnchorYear(null)).toBeNull();
+  });
+
+  test('resolveWindow adds the anchor to every offset of a relative profile', () => {
+    const w = resolveWindow({ relative: true, earlyFrom: 0, peakFrom: 2, peakUntil: 5 }, 2020);
+    expect(w).toMatchObject({ earlyFrom: 2020, peakFrom: 2022, peakUntil: 2025 });
+    expect(w.lateFrom).toBeUndefined();
+  });
+
+  test('resolveWindow passes absolute profiles through untouched, anchor ignored', () => {
+    const w = resolveWindow({ earlyFrom: 2024, peakUntil: 2030 }, 2020);
+    expect(w).toMatchObject({ earlyFrom: 2024, peakUntil: 2030 });
+  });
+});
+
+describe('buildProfileMap — NV pairs included', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('NV bottles are queried and their profiles land in the map', async () => {
+    const profiles = [
+      { wineDefinition: 'wd1', vintage: 'NV', status: 'reviewed', relative: true, peakFrom: 2, peakUntil: 5 },
+      { wineDefinition: 'wd1', vintage: '2019', status: 'reviewed', peakFrom: 2024, peakUntil: 2030 },
+    ];
+    WineVintageProfile.find.mockReturnValue({ lean: () => Promise.resolve(profiles) });
+
+    const map = await buildProfileMap([
+      { wineDefinition: { _id: 'wd1' }, vintage: 'NV' },
+      { wineDefinition: { _id: 'wd1' }, vintage: '2019' },
+    ]);
+
+    expect(map.get('wd1:NV')).toMatchObject({ relative: true });
+    expect(map.get('wd1:2019')).toMatchObject({ peakFrom: 2024 });
+  });
+
+  test('an NV-only bottle set still issues the profile query (previously skipped entirely)', async () => {
+    WineVintageProfile.find.mockReturnValue({ lean: () => Promise.resolve([]) });
+    const map = await buildProfileMap([{ wineDefinition: { _id: 'wd1' }, vintage: 'NV' }]);
+    expect(WineVintageProfile.find).toHaveBeenCalledTimes(1);
+    expect(map.size).toBe(0);
+  });
+});
+
 // ─── maturityLabel ───────────────────────────────────────────────────────────
 
 describe('maturityLabel', () => {
@@ -433,5 +544,24 @@ describe('maturityLabel — personal window precedence', () => {
 
   test('omitting the bottle arg keeps the legacy profile-based behaviour', () => {
     expect(maturityLabel('peak', profileSaysNow)).toBe('At peak — drink now through 2028');
+  });
+});
+
+describe('maturityLabel — relative (NV) profiles quote resolved years', () => {
+  const relProfile = { status: 'reviewed', relative: true, earlyFrom: 0, peakFrom: 2, peakUntil: 5, lateUntil: 8 };
+
+  test('peak label quotes anchor + offset, not the raw offset', () => {
+    const bottle = { vintage: 'NV', purchaseDate: '2024-03-01' };
+    expect(maturityLabel('peak', relProfile, bottle)).toBe('At peak — drink now through 2029');
+  });
+
+  test('late label resolves lateUntil the same way', () => {
+    const bottle = { vintage: 'NV', purchaseDate: '2020-03-01' };
+    expect(maturityLabel('late', relProfile, bottle)).toBe('Late maturity — drink soon, until 2028');
+  });
+
+  test('no anchor → generic year-free labels, never a bare offset', () => {
+    expect(maturityLabel('peak', relProfile, { vintage: 'NV' })).toBe('At peak maturity — drink now');
+    expect(maturityLabel('not-ready', relProfile, { vintage: 'NV' })).toBe('Not ready yet — drinking from ?');
   });
 });

--- a/backend/src/utils/maturityUtils.test.js
+++ b/backend/src/utils/maturityUtils.test.js
@@ -388,6 +388,18 @@ describe('bottleAnchorYear / resolveWindow', () => {
     expect(bottleAnchorYear(null)).toBeNull();
   });
 
+  test('year-boundary dates anchor to the calendar year the user picked (UTC read)', () => {
+    // Date-only strings parse as UTC midnight; the year must be read in UTC
+    // too, or Dec-31/Jan-1 purchases shift a year in non-UTC timezones (e.g.
+    // a UTC+13 Auckland browser vs the UTC server) and the frontend/backend
+    // mirrors disagree on the whole window.
+    expect(bottleAnchorYear({ purchaseDate: '2025-12-31' })).toBe(2025);
+    expect(bottleAnchorYear({ purchaseDate: '2026-01-01' })).toBe(2026);
+    // Full ISO timestamps (Mongo createdAt serialization) read the same way.
+    expect(bottleAnchorYear({ createdAt: '2025-12-31T23:59:59.000Z' })).toBe(2025);
+    expect(bottleAnchorYear({ purchaseDate: 'not a date' })).toBeNull();
+  });
+
   test('resolveWindow adds the anchor to every offset of a relative profile', () => {
     const w = resolveWindow({ relative: true, earlyFrom: 0, peakFrom: 2, peakUntil: 5 }, 2020);
     expect(w).toMatchObject({ earlyFrom: 2020, peakFrom: 2022, peakUntil: 2025 });

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1257,6 +1257,8 @@
       "title": "Admin: Wine Requests",
       "selectRequest": "Select a request to review",
       "noRequests": "No requests found",
+      "totalCount_one": "{{count}} request",
+      "totalCount_other": "{{count}} requests",
       "requestedBy": "Requested by:",
       "date": "Date:",
       "createNewWine": "Create New Wine",
@@ -3510,7 +3512,10 @@
       "matching": "Matching wines… {{done}} / {{total}}",
       "largeCollectionHint": "Identifying unknown wines — this may take a moment for large collections",
       "matchButton_one": "Match {{count}} bottle against wine library",
-      "matchButton_other": "Match {{count}} bottles against wine library"
+      "matchButton_other": "Match {{count}} bottles against wine library",
+      "resumeMatchButton": "Resume matching — {{remaining}} of {{total}} bottles left",
+      "resumeMatchHint": "The first {{done}} bottles were already matched and will be kept — resuming won't re-run them or re-spend the AI budget.",
+      "partialKept": "The bottles matched before the error have been kept. Resume matching to continue from where it stopped."
     },
     "review": {
       "matched": "Matched",

--- a/frontend/src/pages/AdminRequests.css
+++ b/frontend/src/pages/AdminRequests.css
@@ -42,9 +42,29 @@
   font-weight: 600;
 }
 
+.requests-total {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+}
+
 .requests-list {
   display: grid;
   gap: 0.75rem;
+}
+
+.requests-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.requests-pagination-page {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
 }
 
 .request-item {

--- a/frontend/src/pages/AdminRequests.js
+++ b/frontend/src/pages/AdminRequests.js
@@ -16,6 +16,10 @@ function AdminRequests() {
   const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState('pending');
+  // Pagination — the backend caps this list at 50 per request, so without
+  // page/limit params anything beyond the oldest 50 was unreachable forever.
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
   const [selected, setSelected] = useState(null);
   const [resolveData, setResolveData] = useState({
     mode: 'create', // 'create' or 'link'
@@ -53,7 +57,7 @@ function AdminRequests() {
 
   useEffect(() => {
     fetchRequests();
-  }, [statusFilter, apiFetch]);
+  }, [statusFilter, page, apiFetch]);
 
   useEffect(() => {
     fetchCountries();
@@ -80,13 +84,23 @@ function AdminRequests() {
     return () => clearTimeout(timer);
   }, [linkSearch, resolveData.mode, apiFetch]);
 
+  const REQUESTS_PER_PAGE = 50;
+
   const fetchRequests = async () => {
     setLoading(true);
     try {
-      const params = statusFilter ? `?status=${statusFilter}` : '';
-      const res = await adminGetWineRequests(apiFetch, params);
+      const params = new URLSearchParams({ page, limit: REQUESTS_PER_PAGE });
+      if (statusFilter) params.set('status', statusFilter);
+      const res = await adminGetWineRequests(apiFetch, `?${params}`);
       const data = await res.json();
-      if (res.ok) setRequests(data.requests);
+      if (res.ok) {
+        setRequests(data.requests || []);
+        setTotal(data.total || 0);
+        // Resolving/rejecting can shrink the filtered set — if the current
+        // page fell off the end, snap back to the new last page (refetches).
+        const pages = Math.max(1, Math.ceil((data.total || 0) / REQUESTS_PER_PAGE));
+        if (page > pages) setPage(pages);
+      }
     } catch (err) {
       console.error('Failed to fetch requests:', err);
     } finally {
@@ -309,6 +323,8 @@ function AdminRequests() {
     }
   };
 
+  const totalPages = Math.max(1, Math.ceil(total / REQUESTS_PER_PAGE));
+
   return (
     <div className="admin-requests-page">
       <div className="page-header">
@@ -323,12 +339,18 @@ function AdminRequests() {
               <button
                 key={s || 'all'}
                 className={`filter-btn ${statusFilter === s ? 'active' : ''}`}
-                onClick={() => setStatusFilter(s)}
+                onClick={() => { setStatusFilter(s); setPage(1); }}
               >
                 {s || t('admin.requests.statusAll')}
               </button>
             ))}
           </div>
+
+          {!loading && (
+            <div className="requests-total">
+              {t('admin.requests.totalCount', { count: total })}
+            </div>
+          )}
 
           {loading ? (
             <div className="loading">{t('common.loading')}</div>
@@ -355,6 +377,28 @@ function AdminRequests() {
                   </div>
                 </div>
               ))}
+            </div>
+          )}
+
+          {!loading && totalPages > 1 && (
+            <div className="requests-pagination">
+              <button
+                className="btn btn-secondary btn-small"
+                disabled={page <= 1}
+                onClick={() => setPage(p => p - 1)}
+              >
+                {t('common.previous')}
+              </button>
+              <span className="requests-pagination-page">
+                {t('admin.audit.page', { current: page, total: totalPages })}
+              </span>
+              <button
+                className="btn btn-secondary btn-small"
+                disabled={page >= totalPages}
+                onClick={() => setPage(p => p + 1)}
+              >
+                {t('common.next')}
+              </button>
             </div>
           )}
         </div>

--- a/frontend/src/pages/AdminRequests.test.js
+++ b/frontend/src/pages/AdminRequests.test.js
@@ -1,0 +1,128 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import AdminRequests from './AdminRequests';
+
+// Audit 2026-08-03 H5: the admin wine-request queue sent no page/limit params
+// and dropped the server's `total`, so anything beyond the oldest 50 requests
+// per status was permanently unreachable through the UI. These tests pin the
+// pagination contract: page/limit are sent, the total is shown, the filter
+// resets to page 1, and a page that fell off the end snaps back.
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, opts) => (opts && opts.count !== undefined ? `${key}:${opts.count}` : key),
+  }),
+}));
+
+const apiFetch = vi.fn();
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ apiFetch }) }));
+
+const getWineRequests = vi.fn();
+vi.mock('../api/admin', () => ({
+  adminGetWineRequests: (...a) => getWineRequests(...a),
+  adminResolveWineRequest: vi.fn(),
+  adminRejectWineRequest: vi.fn(),
+  adminGetCountries: () => Promise.resolve({ ok: true, json: () => Promise.resolve({ countries: [] }) }),
+  adminGetGrapes: () => Promise.resolve({ ok: true, json: () => Promise.resolve({ grapes: [] }) }),
+  adminGetRegions: vi.fn(),
+  adminGetAppellations: vi.fn(),
+}));
+
+vi.mock('../api/wines', () => ({
+  searchWines: vi.fn(),
+  getAiWineInfo: vi.fn(),
+}));
+
+const jsonRes = (body, ok = true) => ({ ok, json: () => Promise.resolve(body) });
+
+const makeRequests = (n, offset = 0) =>
+  Array.from({ length: n }, (_, i) => ({
+    _id: `req-${offset + i}`,
+    wineName: `Wine ${offset + i}`,
+    status: 'pending',
+    user: { username: 'user1' },
+    createdAt: '2026-08-01T00:00:00.000Z',
+  }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('requests page 1 with the backend limit and shows the true total', async () => {
+  getWineRequests.mockResolvedValue(jsonRes({ count: 50, total: 137, requests: makeRequests(50) }));
+  render(<AdminRequests />);
+
+  await waitFor(() => expect(screen.getByText('Wine 0')).toBeInTheDocument());
+  expect(getWineRequests).toHaveBeenCalledWith(apiFetch, '?page=1&limit=50&status=pending');
+  // Total count is on screen (previously dropped entirely).
+  expect(screen.getByText('admin.requests.totalCount:137')).toBeInTheDocument();
+});
+
+test('Next fetches page 2; rows beyond the first 50 become reachable', async () => {
+  getWineRequests.mockImplementation((_af, params) =>
+    Promise.resolve(
+      params.includes('page=2')
+        ? jsonRes({ count: 50, total: 137, requests: makeRequests(50, 50) })
+        : jsonRes({ count: 50, total: 137, requests: makeRequests(50) })
+    )
+  );
+  render(<AdminRequests />);
+  await waitFor(() => expect(screen.getByText('Wine 0')).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole('button', { name: 'common.next' }));
+
+  await waitFor(() => expect(screen.getByText('Wine 50')).toBeInTheDocument());
+  expect(getWineRequests).toHaveBeenLastCalledWith(apiFetch, '?page=2&limit=50&status=pending');
+  // Previous is now enabled, Next still enabled (3 pages of 137).
+  expect(screen.getByRole('button', { name: 'common.previous' })).not.toBeDisabled();
+});
+
+test('hides the pager when everything fits on one page', async () => {
+  getWineRequests.mockResolvedValue(jsonRes({ count: 3, total: 3, requests: makeRequests(3) }));
+  render(<AdminRequests />);
+  await waitFor(() => expect(screen.getByText('Wine 0')).toBeInTheDocument());
+  expect(screen.queryByRole('button', { name: 'common.next' })).toBeNull();
+});
+
+test('changing the status filter resets to page 1', async () => {
+  getWineRequests.mockResolvedValue(jsonRes({ count: 50, total: 120, requests: makeRequests(50) }));
+  render(<AdminRequests />);
+  await waitFor(() => expect(screen.getByText('Wine 0')).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole('button', { name: 'common.next' }));
+  await waitFor(() =>
+    expect(getWineRequests).toHaveBeenLastCalledWith(apiFetch, '?page=2&limit=50&status=pending')
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'resolved' }));
+  await waitFor(() =>
+    expect(getWineRequests).toHaveBeenLastCalledWith(apiFetch, '?page=1&limit=50&status=resolved')
+  );
+});
+
+test('snaps back to the last page when the current page falls off the end', async () => {
+  // Page 1 shows 120 pending. By the time the admin clicks Next the queue has
+  // been cleared down to 30 — the page-2 fetch comes back empty with the new
+  // total, and the component must snap back to (and refetch) page 1 instead of
+  // stranding the admin on an empty page.
+  getWineRequests.mockImplementation((_af, params) =>
+    Promise.resolve(
+      params.includes('page=2')
+        ? jsonRes({ count: 0, total: 30, requests: [] })
+        : jsonRes({ count: 30, total: 30, requests: makeRequests(30) })
+    )
+  );
+  getWineRequests.mockResolvedValueOnce(jsonRes({ count: 50, total: 120, requests: makeRequests(50) }));
+
+  render(<AdminRequests />);
+  await waitFor(() => expect(screen.getByText('Wine 0')).toBeInTheDocument());
+  expect(screen.getByText('admin.requests.totalCount:120')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: 'common.next' }));
+
+  // Page 2 overshot (totalPages is now 1) → automatic refetch of page 1.
+  await waitFor(() =>
+    expect(getWineRequests).toHaveBeenLastCalledWith(apiFetch, '?page=1&limit=50&status=pending')
+  );
+  await waitFor(() => expect(screen.getByText('admin.requests.totalCount:30')).toBeInTheDocument());
+  expect(screen.getByText('Wine 0')).toBeInTheDocument();
+});

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -15,6 +15,9 @@ import {
   rowsNeedingAiRetry,
   reconcileRetrySelections,
   mergeRetryResults,
+  mergeValidateSummaries,
+  autoSelectionsFor,
+  canResumeValidation,
   restoreSessionMeta,
   nextAiBudgetRequestState,
   isAiBudgetRequestPending
@@ -149,6 +152,13 @@ function ImportBottles() {
   const [summary, setSummary] = useState(null);
   const [validating, setValidating] = useState(false);
   const [validationProgress, setValidationProgress] = useState({ done: 0, total: 0 });
+  // Marker for a partially-completed validate run (mid-loop failure): which
+  // upload it belongs to, how many rows are already committed, and the running
+  // server-summary merge. Lets a retry resume at the first unvalidated batch
+  // instead of re-running — and re-spending the shared daily AI budget on —
+  // batches that already succeeded. Cleared when a run completes so a
+  // deliberate re-Match stays a full fresh validation.
+  const [validationResume, setValidationResume] = useState(null);
   const [selections, setSelections] = useState({}); // index -> wineId or 'skip'
   const [searchModal, setSearchModal] = useState(null); // { index } or null
   const [searchQuery, setSearchQuery] = useState('');
@@ -519,13 +529,25 @@ function ImportBottles() {
 
     const preparedItems = prepareItems();
     const total = preparedItems.length;
-    setValidationProgress({ done: 0, total });
 
-    const allResults = [];
-    let combinedSummary = null;
+    // Resume a previous partially-failed run over the SAME upload + Vivino
+    // mode: keep every batch it already committed (whose AI budget is spent
+    // and non-refundable) and start at the first unvalidated batch.
+    const resuming = canResumeValidation(validationResume, parsedItems, vivinoScanHistory, vivinoImportMode);
+    const startOffset = resuming ? validationResume.doneUpTo : 0;
+    // Current `results` state (not a snapshot) so per-row rewrites made in a
+    // between-failure trip to the review screen survive the resume.
+    let workingResults = resuming ? results : [];
+    let combinedSummary = resuming ? validationResume.summary : null;
+    // Auto-selections accumulate batch-by-batch. A resume seeds from the live
+    // selections map so choices the user already made are preserved (rows in
+    // the remaining batches are new, so no user choice can be overwritten).
+    let workingSelections = resuming ? { ...selections } : {};
+
+    setValidationProgress({ done: startOffset, total });
 
     try {
-      for (let offset = 0; offset < total; offset += VALIDATE_BATCH_SIZE) {
+      for (let offset = startOffset; offset < total; offset += VALIDATE_BATCH_SIZE) {
         // Re-index each batch so indices match their position in parsedItems
         const batch = preparedItems.slice(offset, offset + VALIDATE_BATCH_SIZE);
 
@@ -533,34 +555,37 @@ function ImportBottles() {
 
         // Shift batch-local indices back to global indices
         const shifted = data.results.map(r => ({ ...r, index: r.index + offset }));
-        allResults.push(...shifted);
+        workingResults = [...workingResults, ...shifted];
+        combinedSummary = mergeValidateSummaries(combinedSummary, data.summary);
+        // Auto-select exact, fuzzy, and AI-identified matches in this batch
+        workingSelections = { ...workingSelections, ...autoSelectionsFor(shifted) };
 
-        // Merge summaries
-        if (!combinedSummary) {
-          combinedSummary = { ...data.summary };
-        } else {
-          for (const key of Object.keys(data.summary)) {
-            combinedSummary[key] = (combinedSummary[key] || 0) + (data.summary[key] || 0);
-          }
-        }
-
+        // Commit each batch into state AS IT COMPLETES (mirroring
+        // handleRetryAiLookups) so a mid-loop failure keeps everything
+        // already validated — the catch below then shows the error alongside
+        // the partial results instead of discarding batches 1..n-1.
+        setResults(workingResults);
+        setSummary(combinedSummary);
+        setSelections(workingSelections);
+        setValidationResume({
+          parsedItems,
+          vivinoScanHistory,
+          vivinoImportMode,
+          doneUpTo: offset + batch.length,
+          summary: combinedSummary,
+        });
         setValidationProgress({ done: Math.min(offset + VALIDATE_BATCH_SIZE, total), total });
       }
 
-      setResults(allResults);
-      setSummary(combinedSummary);
-
-      // Auto-select exact, fuzzy, and AI-identified matches
-      const autoSelections = {};
-      allResults.forEach((r) => {
-        if ((r.status === 'exact' || r.status === 'fuzzy' || r.status === 'ai_match') && r.matches.length > 0) {
-          autoSelections[r.index] = r.matches[0].wineId;
-        }
-      });
-      setSelections(autoSelections);
+      // Completed — drop the resume marker so a future deliberate "Match"
+      // click re-runs the full validation, exactly as before.
+      setValidationResume(null);
       setStep('review');
     } catch (err) {
-      setError(err.message || t('importBottles.errors.validationNetwork'));
+      const msg = err.message || t('importBottles.errors.validationNetwork');
+      // Partial progress is committed — say so next to the error instead of
+      // letting the user assume everything was lost.
+      setError(workingResults.length > 0 ? `${msg} ${t('importBottles.validate.partialKept')}` : msg);
     } finally {
       setValidating(false);
     }
@@ -1469,6 +1494,21 @@ function ImportBottles() {
               </div>
               <p className="progress-hint">{t('importBottles.validate.largeCollectionHint')}</p>
             </div>
+          ) : canResumeValidation(validationResume, parsedItems, vivinoScanHistory, vivinoImportMode) ? (
+            <>
+              <button
+                className="btn btn-primary btn-validate"
+                onClick={handleValidate}
+              >
+                {t('importBottles.validate.resumeMatchButton', {
+                  remaining: parsedItems.length - validationResume.doneUpTo,
+                  total: parsedItems.length
+                })}
+              </button>
+              <p className="progress-hint">
+                {t('importBottles.validate.resumeMatchHint', { done: validationResume.doneUpTo })}
+              </p>
+            </>
           ) : (
             <button
               className="btn btn-primary btn-validate"

--- a/frontend/src/utils/importReview.js
+++ b/frontend/src/utils/importReview.js
@@ -75,6 +75,70 @@ export function mergeRetryResults(results, batchUpdates) {
 }
 
 /**
+ * Merge one validate batch's server-computed summary into the running
+ * combined summary, returning a NEW object (the previous one may already be
+ * committed to React state). Numeric counters add up; the boolean-ish
+ * aiBudgetExhausted flag survives as a truthy number the same way the old
+ * in-place merge handled it.
+ *
+ * @param {object|null} base   running combined summary (null on first batch)
+ * @param {object} add         this batch's summary from the server
+ * @returns {object} the next combined summary
+ */
+export function mergeValidateSummaries(base, add) {
+  if (!base) return { ...(add || {}) };
+  const next = { ...base };
+  for (const key of Object.keys(add || {})) {
+    next[key] = (next[key] || 0) + (add[key] || 0);
+  }
+  return next;
+}
+
+/**
+ * The auto-selections for a set of freshly validated rows: exact, fuzzy and
+ * AI-identified matches pre-select their top match. Pure per-row rule, so it
+ * can be applied batch-by-batch and the union over all batches equals one
+ * pass over the full results array.
+ *
+ * @param {Array} rows  validation-result rows (global indices)
+ * @returns {object} { [index]: wineId }
+ */
+export function autoSelectionsFor(rows) {
+  const sel = {};
+  for (const r of rows || []) {
+    if (
+      (r.status === 'exact' || r.status === 'fuzzy' || r.status === 'ai_match') &&
+      Array.isArray(r.matches) && r.matches.length > 0
+    ) {
+      sel[r.index] = r.matches[0].wineId;
+    }
+  }
+  return sel;
+}
+
+/**
+ * Whether a stored partial-validate marker still applies to the current
+ * upload. Identity-compares the parsed-items array (a new file parse creates
+ * a new array) and the Vivino mode flags (prepareImportItems is pure, so the
+ * same inputs reproduce the exact prepared rows the partial run validated).
+ *
+ * @param {object|null} marker  { parsedItems, vivinoScanHistory, vivinoImportMode, doneUpTo }
+ * @param {Array} parsedItems
+ * @param {boolean} vivinoScanHistory
+ * @param {string} vivinoImportMode
+ * @returns {boolean}
+ */
+export function canResumeValidation(marker, parsedItems, vivinoScanHistory, vivinoImportMode) {
+  return Boolean(
+    marker &&
+    marker.doneUpTo > 0 &&
+    marker.parsedItems === parsedItems &&
+    marker.vivinoScanHistory === vivinoScanHistory &&
+    marker.vivinoImportMode === vivinoImportMode
+  );
+}
+
+/**
  * The cosmetic + warning metadata to restore when resuming a saved session.
  * Kept pure (and defensive about missing/malformed fields) so the resume path
  * re-renders the ct-truncated banner and the encoding/table/fallback notes.

--- a/frontend/src/utils/importReview.test.js
+++ b/frontend/src/utils/importReview.test.js
@@ -2,6 +2,9 @@ import {
   rowsNeedingAiRetry,
   reconcileRetrySelections,
   mergeRetryResults,
+  mergeValidateSummaries,
+  autoSelectionsFor,
+  canResumeValidation,
   restoreSessionMeta,
   nextAiBudgetRequestState,
   isAiBudgetRequestPending,
@@ -121,6 +124,90 @@ describe('mergeRetryResults', () => {
     const afterB2 = mergeRetryResults(afterB1, new Map([[2, { index: 2, status: 'ai_match' }]]));
     expect(afterB2[0].status).toBe('ai_match');
     expect(afterB2[2].status).toBe('ai_match');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AUDIT 2026-08-03 H4 — handleValidate must commit per batch so a mid-loop
+// failure keeps completed (AI-budget-spending) batches, and a resume must
+// reproduce exactly the state a single full pass would have produced.
+// ---------------------------------------------------------------------------
+describe('mergeValidateSummaries', () => {
+  it('starts from the first batch summary as a copy, not the same object', () => {
+    const first = { total: 25, exact: 10, fuzzy: 5 };
+    const merged = mergeValidateSummaries(null, first);
+    expect(merged).toEqual(first);
+    expect(merged).not.toBe(first);
+  });
+
+  it('adds numeric counters across batches without mutating the base', () => {
+    const base = { total: 25, exact: 10, noMatch: 2 };
+    const merged = mergeValidateSummaries(base, { total: 25, exact: 3, fuzzy: 7 });
+    expect(merged).toEqual({ total: 50, exact: 13, noMatch: 2, fuzzy: 7 });
+    expect(base).toEqual({ total: 25, exact: 10, noMatch: 2 }); // untouched — it may be committed React state
+  });
+
+  it('keeps aiBudgetExhausted truthy once any batch reports it (legacy numeric-add semantics)', () => {
+    const merged = mergeValidateSummaries(
+      mergeValidateSummaries(null, { total: 25, aiBudgetExhausted: false }),
+      { total: 25, aiBudgetExhausted: true }
+    );
+    expect(Boolean(merged.aiBudgetExhausted)).toBe(true);
+  });
+
+  it('tolerates a missing batch summary', () => {
+    expect(mergeValidateSummaries({ total: 25 }, undefined)).toEqual({ total: 25 });
+    expect(mergeValidateSummaries(null, undefined)).toEqual({});
+  });
+});
+
+describe('autoSelectionsFor', () => {
+  const rows = [
+    { index: 0, status: 'exact', matches: [{ wineId: 'a' }] },
+    { index: 1, status: 'fuzzy', matches: [{ wineId: 'b' }, { wineId: 'c' }] },
+    { index: 2, status: 'ai_match', matches: [{ wineId: 'd' }] },
+    { index: 3, status: 'no_match', matches: [] },
+    { index: 4, status: 'error' },
+    { index: 5, status: 'exact', matches: [] }, // defensive: matched status but empty matches
+  ];
+
+  it('pre-selects the top match for exact/fuzzy/ai_match rows only', () => {
+    expect(autoSelectionsFor(rows)).toEqual({ 0: 'a', 1: 'b', 2: 'd' });
+  });
+
+  it('applied per batch, unions to the same map as one pass over all rows', () => {
+    const batch1 = rows.slice(0, 3);
+    const batch2 = rows.slice(3);
+    const perBatch = { ...autoSelectionsFor(batch1), ...autoSelectionsFor(batch2) };
+    expect(perBatch).toEqual(autoSelectionsFor(rows));
+  });
+
+  it('handles empty/missing input', () => {
+    expect(autoSelectionsFor([])).toEqual({});
+    expect(autoSelectionsFor(undefined)).toEqual({});
+  });
+});
+
+describe('canResumeValidation', () => {
+  const parsedItems = [{ wineName: 'A' }];
+  const marker = { parsedItems, vivinoScanHistory: false, vivinoImportMode: 'history', doneUpTo: 25 };
+
+  it('resumes when the marker matches the same upload and mode', () => {
+    expect(canResumeValidation(marker, parsedItems, false, 'history')).toBe(true);
+  });
+
+  it('does not resume with no marker or no committed progress', () => {
+    expect(canResumeValidation(null, parsedItems, false, 'history')).toBe(false);
+    expect(canResumeValidation({ ...marker, doneUpTo: 0 }, parsedItems, false, 'history')).toBe(false);
+  });
+
+  it('does not resume across a re-parsed file (new parsedItems identity)', () => {
+    expect(canResumeValidation(marker, [{ wineName: 'A' }], false, 'history')).toBe(false);
+  });
+
+  it('does not resume when a Vivino mode flag changed (prepared rows would differ)', () => {
+    expect(canResumeValidation(marker, parsedItems, true, 'history')).toBe(false);
+    expect(canResumeValidation(marker, parsedItems, false, 'wishlist')).toBe(false);
   });
 });
 

--- a/frontend/src/utils/maturityUtils.js
+++ b/frontend/src/utils/maturityUtils.js
@@ -31,7 +31,14 @@ export function resolveWindow(profile, anchorYear) {
 export function bottleAnchorYear(bottle) {
   const d = bottle?.purchaseDate || bottle?.createdAt;
   if (!d) return null;
-  const y = new Date(d).getFullYear();
+  // UTC year, not local: date-only purchase dates ("2026-12-31") parse as UTC
+  // midnight, so a local-time read shifts Dec-31/Jan-1 purchases into the
+  // wrong year in non-UTC timezones (a Dec 31 purchase read in a UTC+13
+  // browser becomes next year while the UTC server keeps this year). The UTC
+  // year is always the calendar year the user picked, in every timezone —
+  // and keeps this and the backend mirror (backend/src/utils/maturityUtils.js)
+  // in exact agreement.
+  const y = new Date(d).getUTCFullYear();
   return Number.isFinite(y) ? y : null;
 }
 

--- a/frontend/src/utils/maturityUtils.test.js
+++ b/frontend/src/utils/maturityUtils.test.js
@@ -1,4 +1,26 @@
-import { getMaturityPhases, isPhaseActive } from './maturityUtils';
+import { getMaturityPhases, isPhaseActive, bottleAnchorYear } from './maturityUtils';
+
+// ---------------------------------------------------------------------------
+// bottleAnchorYear — must read the year in UTC, mirroring the backend
+// (backend/src/utils/maturityUtils.js). Date-only purchase dates parse as UTC
+// midnight, so a local-time read shifts Dec-31/Jan-1 purchases into the wrong
+// year in non-UTC browsers (e.g. UTC+13 Auckland) and the two mirrors disagree.
+// ---------------------------------------------------------------------------
+describe('bottleAnchorYear', () => {
+  it('prefers purchaseDate over createdAt, null when neither', () => {
+    expect(bottleAnchorYear({ purchaseDate: '2019-05-01', createdAt: '2023-01-01' })).toBe(2019);
+    expect(bottleAnchorYear({ createdAt: '2023-01-01' })).toBe(2023);
+    expect(bottleAnchorYear({})).toBeNull();
+    expect(bottleAnchorYear(null)).toBeNull();
+  });
+
+  it('year-boundary dates anchor to the calendar year the user picked, in any timezone', () => {
+    expect(bottleAnchorYear({ purchaseDate: '2025-12-31' })).toBe(2025);
+    expect(bottleAnchorYear({ purchaseDate: '2026-01-01' })).toBe(2026);
+    expect(bottleAnchorYear({ createdAt: '2025-12-31T23:59:59.000Z' })).toBe(2025);
+    expect(bottleAnchorYear({ purchaseDate: 'not a date' })).toBeNull();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // getMaturityPhases


### PR DESCRIPTION
## Summary

Remediates all 6 High-severity findings from the full-tree code audit (CODE_AUDIT_2026-08-03_FULL.md, 632 files / 117k lines, every High adversarially verified before fixing).

| # | Finding | Fix |
|---|---------|-----|
| H1 | LWIN import: mid-batch `bulkWrite` failure silently lost up to 499 wines' stats + finalize invariants | `flush()` recovers partial success from `MongoBulkWriteError` — surviving ops keep stats/`mintedIds` and still reach `finalizeMintedWines`; per-op errors attributed to their own CSV rows; trailing flush can no longer 500 away accumulated stats |
| H2 | Rejecting a wine request permanently orphaned bottles holding `pendingWineRequest` | Reject now detaches those bottles (mirrors resolve), reports `bottlesDetached` in audit log + response, mentions it in the user notification |
| H3 | No-AI installs ran the fuzzy-match cascade once per row (up to 2000 sequential lookups) | Registry-first dedup cascade (Pass 1a) now runs regardless of AI availability; only the AI fan-out stays gated — one lookup per unique wine |
| H4 | `handleValidate` discarded all completed (AI-budget-spending) batches on one failure | Per-batch state commits + resume marker: retry continues from the first unvalidated batch, preserving spend and user selections |
| H5 | Admin wine-request queue hard-capped at the oldest 50 (no pagination) | Page/limit/total wired to the backend's existing pagination, pager UI per existing admin convention, snap-back when the queue shrinks |
| H6 | Curated relative (NV) drink windows were invisible to every backend consumer incl. the notification cron | Backend `classifyMaturity`/`buildProfileMap` now resolve `relative:true` profiles anchored on purchase year (ported from the frontend); notifier query widened; stats/insights/export/rack heuristics all see NV windows |

## Tests
- Backend: 14 suites / 216 tests around all touched code green in node:20-alpine (incl. new suites `import.bulkError`, `wineRequests.reject`, `import.validate.noAi`, +16 maturityUtils cases, +4 notifier cases). Full suite gate = CI.
- Frontend: full suite 876/876 green (incl. new `AdminRequests.test.js` and 11 new `importReview` helper tests).
- One deliberate expectation change: `classifyMaturity` no longer returns null for NV — the old test asserted the bug (commented in-code citing the audit).

## Notes
- Mediums/Lows from the audit are NOT in this PR — tracked in the report for follow-up batches.
- i18n: new keys en-only per i18n workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)