### PR TITLE
fix(security): CodeQL tainted-format-string + Dependabot transitive dep bumps

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3174,9 +3174,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4419,9 +4419,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -4803,9 +4803,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.29",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
-      "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5000,9 +5000,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6634,9 +6634,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8435,9 +8435,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/src/services/embeddingJob.js
+++ b/backend/src/services/embeddingJob.js
@@ -381,8 +381,10 @@ async function embedSinglePair(wineDefId, vintage) {
 
     console.log(`[embeddingJob] Real-time embedded: ${wine.name} ${vintage}`);
   } catch (err) {
-    // Non-fatal — the batch job will retry on next run
-    console.warn(`[embeddingJob] Real-time embed failed (${wineDefId}, ${vintage}):`, err.message);
+    // Non-fatal — the batch job will retry on next run. Constant format string:
+    // vintage is user-entered free text (Bottle.vintage), so it must stay out of
+    // console.warn's format-string position (CodeQL js/tainted-format-string).
+    console.warn('[embeddingJob] Real-time embed failed (%s, %s):', String(wineDefId), String(vintage), err.message);
   }
 }
 

--- a/cellarion-mcp/package-lock.json
+++ b/cellarion-mcp/package-lock.json
@@ -451,9 +451,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -588,9 +588,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -639,9 +639,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,7 +67,7 @@
     "yaml": "2.8.3",
     "serialize-javascript": "7.0.5",
     "postcss": "^8.5.18",
-    "fast-uri": "3.1.4",
+    "fast-uri": "^3.1.5",
     "esbuild": "^0.28.1",
     "markdown-it": "^14.2.0",
     "form-data": "^4.0.6",


### PR DESCRIPTION
## Scanner-alert triage (2026-08-05)

Full pass over everything open in GitHub Security: 4 CodeQL alerts + 14 Dependabot alerts. Every item was verified against the actual code before being classified.

### CodeQL — 1 valid (fixed here), 3 false positives (dismissed with justification)

| Alert | Location | Verdict | Why |
|---|---|---|---|
| #204 `js/tainted-format-string` | `embeddingJob.js:385` | **VALID — fixed** | `Bottle.vintage` is free-text (String, maxlen 20). A vintage like `%s` flows user → `bottleOps.addBottle` → `embedSinglePair` → the `console.warn` **format-string position**, where util.format substitutes `err.message` into it. Impact is log-line garbling only, but the fix is a one-liner: constant format string, tainted values passed as `%s` args. Output is byte-identical for normal vintages. |
| #183 `js/sql-injection` | `bottles.js:360` | False positive | `mongoose.isValidObjectId(cellar)` gates the value at line 357 before `findById`; operator objects can never reach the query. CodeQL doesn't model it as a sanitizer. |
| #190 `js/sql-injection` | `journal.js:128` | False positive | Every user value in the query object is sanitized: `req.user.id` via `isValidId`, `occasion` via `OCCASIONS.includes` allowlist, `q` via `escapeRegex` into a RegExp instance (no operator smuggling possible). |
| #178 `js/path-injection` | `imageSanitizer.js:89` | False positive | The flagged tmp path derives from `req.file.path`, but both multer configs feeding it (shared `config/upload.js` and the wineLists logo storage) generate `crypto.randomUUID()` filenames into fixed directories — no user-controlled path component exists. |

Merging this closes #204: Fixes https://github.com/jagduvi1/Cellarion/security/code-scanning/204

### Dependabot — 12 fixed here, 2 deliberately left open

All four packages are **transitive**; parents use caret ranges, so lockfile-only bumps (regenerated in digest-pinned `node:24-alpine`, per the sharp/platform-entry rule) resolve them:

| Package | From → To | Via | Alerts |
|---|---|---|---|
| ip-address | 10.2.0 → 10.4.0 | express-rate-limit 8.x (client-IP parsing; worst case here was rate-limit key confusion, not SSRF) | #137–#140, #143, #144 |
| hono | 4.12.29/.30 → 4.13.0 | @hono/node-server / MCP SDK chain | #141, #142 |
| fast-uri | 3.1.4 → 3.1.5 | ajv | #135, #136 |
| brace-expansion | 2.1.3 → 2.1.4 | minimatch (archiver/export path); nested 1.x/5.x copies are outside the vulnerable range | #133 (#134 was its auto-dismissed dev-scope twin) |

**Left open on purpose:** react-router #127/#128 (frontend). #127 has **no patched version in the v6 line**; the fix is the Router 7 migration, which is parked as deliberate work (audit 2026-07-25 assessed the open-redirect as unreachable in our usage). Not blind-merging that here.

**Also in this PR:** frontend `overrides` exact-pinned `fast-uri: "3.1.4"` — a stale leftover (fast-uri is no longer in the frontend tree at all) sitting one patch below the new advisory's fix. Converted to a caret floor `^3.1.5` so the override can never re-pin a vulnerable version — same class as the postcss override trap fixed in #872.

### Verification

- Backend Jest (targeted: bottleOps, enrichmentJob, imageSanitizer): **77/77 pass**
- Frontend vitest: **860/860 pass** (49 files)
- `npm ci` from the new cellarion-mcp lockfile in node:24-alpine: clean
- Lock diffs are surgical — zero `@img/sharp-*`/libc/rollup entry churn
- Docker smoke test: full `docker compose up --build` — backend healthcheck green, `/api/health` 200 `{"mongo":"connected","version":"1.99.1"}`, no errors in logs

**Prod compose impact: none** — no env vars, ports, or service changes; lockfiles + one log line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)