### PR TITLE
chore(release): v1.100.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.99.1",
+  "version": "1.100.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.99.1",
+      "version": "1.100.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.99.1",
+  "version": "1.100.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.99.1",
+  "version": "1.100.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.99.1",
+      "version": "1.100.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.99.1",
+  "version": "1.100.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for the v1.100.0 release.

Contents (7 PRs merged today):
- #896 — remediate the 6 verified Highs from the 2026-08-03 full code audit
- #897 — reserved ("spoken for") bottles
- #898 — climate history aggregates in MCP climate_status
- #901 — decline price-tracking requests with a reason
- #899 — import /validate is registry-read-only; wines mint on /confirm (security 2026-08-03 H-1)
- #900 — CodeQL tainted-format-string fix + 12 Dependabot transitive dep bumps
- #895 — brace-expansion override ^2.1.4 (GHSA-rgw5-rvv9-x895)

🤖 Generated with [Claude Code](https://claude.com/claude-code)