### PR TITLE
fix: the `/remove-bg` endpoint accepts file uploads ... in app.py

### DIFF
--- a/rembg/app.py
+++ b/rembg/app.py
@@ -4,6 +4,14 @@ from flask import Flask, request, send_file, jsonify
 from rembg import remove
 from PIL import Image
 
+MAX_FILE_SIZE = 20 * 1024 * 1024  # 20 MB
+
+_ALLOWED_MAGIC = (b'\x89PNG', b'\xff\xd8\xff', b'GIF8', b'BM')
+
+def _is_allowed_image(data):
+    return (any(data.startswith(m) for m in _ALLOWED_MAGIC) or
+            (len(data) >= 12 and data[:4] == b'RIFF' and data[8:12] == b'WEBP'))
+
 # Defense-in-depth against decompression-bomb images: cap decoded pixels so a
 # small compressed payload can't expand to hundreds of millions of pixels and
 # exhaust memory / tie up this single-worker service. ~8000x8000 matches the
@@ -25,7 +33,11 @@ def remove_bg():
         return jsonify({"error": "No image file provided"}), 400
 
     input_file = request.files['image']
-    input_bytes = input_file.read()
+    input_bytes = input_file.read(MAX_FILE_SIZE + 1)
+    if len(input_bytes) > MAX_FILE_SIZE:
+        return jsonify({"error": "File too large"}), 413
+    if not _is_allowed_image(input_bytes):
+        return jsonify({"error": "Unsupported file type"}), 415
 
     try:
         # Check if the image already has a transparent background.


### PR DESCRIPTION
## Summary
Fix high severity security issue in `rembg/app.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `rembg/app.py:24` |
| **Assessment** | Likely exploitable |

**Description**: The `/remove-bg` endpoint accepts file uploads without validating file type or size before processing. While a global pixel limit exists, it can be bypassed by crafting images that stay under the limit but consume excessive memory during intermediate processing. No file type validation (magic bytes) is performed, allowing attackers to upload non-image files that PIL attempts to parse, potentially triggering crashes or resource exhaustion.

## Evidence

**Exploitation scenario**: Attacker uploads specially crafted image files (e.g., PNG with malicious chunks or non-image files with .png extension) to the `/remove-bg` endpoint.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This main application appears to be publicly accessible. This is embedded firmware - exploitation requires physical access or a compromised network peer on the same bus/LAN segment.

## Changes
- `rembg/app.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
