### PR TITLE
feat(supporter): GitHub Sponsors — repo button + one-time gift link on Support Us page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: jagduvi1

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -628,7 +628,9 @@
     "reassure": "Cancel anytime · same app either way 💛",
     "reassureYear": "Billed once a year · fewer card fees, so more of it reaches Cellarion · cancel anytime 💛",
     "alreadySupporting": "💛 You're supporting Cellarion — thank you! You can change or cancel anytime.",
-    "donateNote": "Payments are handled securely by Stripe. Cellarion stays free and open whether you support or not."
+    "donateNote": "Payments are handled securely by Stripe. Cellarion stays free and open whether you support or not.",
+    "oneTimeLead": "Prefer a one-time gift, any amount you like?",
+    "oneTimeCta": "Sponsor once on GitHub"
   },
   "cellars": {
     "title": "My Cellars",

--- a/frontend/src/pages/Plans.css
+++ b/frontend/src/pages/Plans.css
@@ -308,6 +308,25 @@
   color: var(--color-text-muted);
 }
 
+/* One-time GitHub Sponsors alternative under the subscription buttons */
+.donate-onetime {
+  margin: 0.9rem 0 0;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+}
+
+.donate-onetime-link {
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.donate-onetime-link:hover {
+  text-decoration: underline;
+}
+
 /* ── Support page: header open-source chips ── */
 .support-emoji {
   font-style: normal;

--- a/frontend/src/pages/Supporter.js
+++ b/frontend/src/pages/Supporter.js
@@ -6,6 +6,7 @@ import { createCheckout, createPortal } from '../api/stripe';
 import './Plans.css';
 
 const GITHUB_URL = 'https://github.com/jagduvi1/Cellarion';
+const SPONSORS_URL = 'https://github.com/sponsors/jagduvi1';
 
 /**
  * Shared support call-to-action — rendered both at the top (compact, the first
@@ -77,6 +78,17 @@ function DonateActions({
         </p>
       )}
       {actionError && <p className="plans-trial-error">{actionError}</p>}
+      <p className="donate-onetime">
+        {t('supporter.oneTimeLead')}{' '}
+        <a
+          className="donate-onetime-link"
+          href={SPONSORS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span aria-hidden="true">♥</span> {t('supporter.oneTimeCta')} →
+        </a>
+      </p>
     </>
   );
 }


### PR DESCRIPTION
## What

Adds GitHub Sponsors in two places:

1. **Repo** — `.github/FUNDING.yml` with `github: jagduvi1`, which makes the **Sponsor** button appear at the top of the GitHub repo page (the Sponsors profile at https://github.com/sponsors/jagduvi1 is already approved and public).
2. **Support Us page** — a small "Prefer a one-time gift, any amount you like? ♥ Sponsor once on GitHub →" line under the Stripe subscription buttons, in both CTA instances (top compact + bottom donate card), shown to users without an active subscription. It complements the monthly/yearly Stripe plans with a single-payment option.

## Why this is compliant

- **GitHub Sponsors rules**: one-time sponsorships with custom amounts are an official Sponsors feature; linking to your own sponsors page from your project is exactly its intended use.
- **CSP**: plain outbound `<a>` link — no script, no iframe, no CSP change needed.
- **GDPR**: no new data processing on Cellarion's side; nothing loads from GitHub until the user deliberately clicks an external link. No consent, export, or deletion-cascade impact.
- **i18n workflow**: en locale only; other locales fall back to English until Weblate catches up.

## Testing

- `cd frontend && npm test` — 51 files, 890 tests passed
- `npm run build` — clean production build (pre-existing chunk-size warning only)
- No backend changes; no compose/prod-env impact.

## Note for after merge

One-time custom amounts must be enabled in the Sponsors dashboard (the API currently shows **no published tiers**). Check https://github.com/sponsors/jagduvi1/dashboard/tiers and make sure at least "custom amount" one-time sponsorship is enabled, otherwise visitors will have nothing to select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)