### PR TITLE
Add color inheritance to history section header

### DIFF
--- a/frontend/src/pages/CellarHistory.css
+++ b/frontend/src/pages/CellarHistory.css
@@ -184,6 +184,7 @@
 .history-section-header h2 {
   margin: 0;
   font-size: 1.1rem;
+  color: inherit;
 }
 
 .history-section-icon { font-size: 1.2rem; }


### PR DESCRIPTION
When accessing history, the heading isn't legible because it is using the default colour, and on a dark background does not contrast well. Inheriting the colour would fix this

Before: 
<img width="1482" height="846" alt="image" src="https://github.com/user-attachments/assets/d255e57d-5e0a-4fda-abc5-104a5e78e800" />


After:

<img width="1482" height="846" alt="image" src="https://github.com/user-attachments/assets/755e2636-92fb-47ad-9f4f-1dcef7d080ee" />

### Testing

1. To test, add a bottle to your history, preferably one in each category (Drank, Gifted, Sold, and Other) and navigate between tabs.
2. Ensure the section title matches the section colour.