### PR TITLE
feat(registry): producer key folds St/Ste/Saint/Sainte and strips trailing founding years

### DIFF
--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -187,15 +187,55 @@ const PRODUCER_CORP_SUFFIXES = new Set([
   'pty', 'co', 'company', 'corp', 'corporation', 'ab', 'oy', 'as', 'kg', 'kft',
 ]);
 
+// Cross-gender and abbreviated Saint forms of one estate name must share a
+// bucket token: "Caronne Sainte Gemme" / "Caronne Ste Gemme" were 3 spellings
+// holding 5 registry records for one Haut-Médoc estate (support ticket
+// d49fea22), invisible to normalization because 'ste' and 'sainte' are simply
+// different tokens. The key is comparison-only and non-unique, so a rare false
+// fold (a 'Ste' abbreviating Société) lands in the human-reviewed canonical-
+// collisions queue — never an auto-merge.
+const PRODUCER_SAINT_TOKENS = new Set(['st', 'ste', 'saint', 'sainte']);
+
+// Fold one already-normalized token into producer-key token space. Exported for
+// stripProducerKeyPrefix, which walks a wine name's display words against the
+// key-token run and must fold each word exactly like the key itself was folded
+// — otherwise a name-side "St"/"Ste" could never match the key's 'saint'.
+const foldProducerToken = (token) => (PRODUCER_SAINT_TOKENS.has(token) ? 'saint' : token);
+
+// A TRAILING year on a producer string is a founding date, never part of the
+// legal producer name — "Grand Pappy's 1846" and "Grand Pappy's" are the same
+// house (support ticket d49dfd38). 1000–2049: founding dates reach centuries
+// further back than TRAILING_VINTAGE_RX's vintage window.
+const PRODUCER_FOUNDING_YEAR_RX = /^(?:1[0-9]{3}|20[0-4][0-9])$/;
+
+// "Est." / "Anno" / "Since" only mean "founded" with a year attached, so a
+// marker is dropped only right after the year it introduced was stripped
+// ("Grand Pappy's Est. 1846" → "Grand Pappy's"); a bare mid-name 'est'
+// (French for east — "Domaine de l'Est") is untouched.
+const PRODUCER_FOUNDING_MARKERS = new Set(['est', 'estd', 'estab', 'anno', 'since']);
+
 /**
  * Normalize a producer to a comparison/bucketing key: drop wine stop words AND
  * corporate suffixes, so "Kumeu River Wines Limited" and "Kumeu River" collapse
- * to the same key ("kumeu river"). Comparison-only — never overwrites the
- * stored display producer. Returns '' for an all-stopword/empty producer.
+ * to the same key ("kumeu river"); fold Saint-token variants to one bucket
+ * token ("St Hallett" ≡ "Saint Hallett") and strip trailing founding year(s).
+ * Comparison-only — never overwrites the stored display producer. Returns ''
+ * for an all-stopword/empty producer (every caller has a raw-string fallback
+ * or skips the empty bucket — see wineIdentity.producerSegment).
  */
 const normalizeProducerKey = (producer) => {
-  return tokenize(producer)
+  // The founding-year strip inspects the PRE-stop-word token sequence: after
+  // tokenize() drops 'winery', the brand year in "1848 Winery" would LOOK
+  // trailing. Position is judged on the raw string, where a LEADING year is a
+  // brand name and only a genuinely trailing one is a founding date.
+  const raw = normalizeString(producer).split(' ').filter(Boolean);
+  while (raw.length > 0 && PRODUCER_FOUNDING_YEAR_RX.test(raw[raw.length - 1])) {
+    raw.pop();
+    if (raw.length > 0 && PRODUCER_FOUNDING_MARKERS.has(raw[raw.length - 1])) raw.pop();
+  }
+  return tokenize(raw.join(' '))
     .filter((t) => !PRODUCER_CORP_SUFFIXES.has(t))
+    .map(foldProducerToken)
     .join(' ')
     .trim();
 };
@@ -765,6 +805,7 @@ module.exports = {
   generateWineSlug,
   GRAPE_SYNONYMS,
   normalizeProducerKey,
+  foldProducerToken,
   normalizeAppellation,
   normalizeAppellationKey,
   stripTrailingVintage,

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -636,3 +636,43 @@ describe('normalizeProducerKey (ticket #2B: dup-cluster bucketing)', () => {
     expect(normalizeProducerKey('Wines Ltd')).toBe('');
   });
 });
+
+describe('normalizeProducerKey — Saint fold + founding-year strip (tickets d49fea22 / d49dfd38)', () => {
+  test('St / Ste / Saint / Sainte share one bucket token — the Caronne 3-spelling split', () => {
+    const key = normalizeProducerKey('Château Caronne Sainte Gemme');
+    expect(key).toBe('caronne saint gemme');
+    expect(normalizeProducerKey('Château Caronne Ste Gemme')).toBe(key);
+    expect(normalizeProducerKey('Chateau Caronne Saint Gemme')).toBe(key);
+  });
+
+  test('folds at any token position, not just leading', () => {
+    expect(normalizeProducerKey('St Hallett')).toBe('saint hallett');
+    expect(normalizeProducerKey('Mount St John')).toBe('mount saint john');
+    expect(normalizeProducerKey('Chateau Ste Michelle')).toBe(normalizeProducerKey('Chateau Sainte Michelle'));
+  });
+
+  test('a trailing founding year is a date, not producer identity', () => {
+    expect(normalizeProducerKey("Grand Pappy's 1846")).toBe(normalizeProducerKey("Grand Pappy's"));
+    expect(normalizeProducerKey("Grand Pappy's Est. 1846")).toBe('grand pappys');
+    expect(normalizeProducerKey('Bodega Norton Anno 1895')).toBe('norton');
+  });
+
+  test('a LEADING year is a brand name and survives — even when the tail is a stop word', () => {
+    // tokenize() drops 'winery', which would leave the brand year LOOKING
+    // trailing — this pins that position is judged on the raw string.
+    expect(normalizeProducerKey('1848 Winery')).toBe('1848');
+  });
+
+  test('a producer that IS only a year keys empty — callers fall back to the raw string', () => {
+    // wineIdentity.producerSegment and wineMatching.producerSimilarity both
+    // fall back to normalizeString on an empty key, so bare-year producers
+    // stay distinct from each other instead of sharing one canonical bucket.
+    expect(normalizeProducerKey('1846')).toBe('');
+    expect(normalizeProducerKey('Est. 1846')).toBe('');
+  });
+
+  test('corp-suffix stripping still works alongside both folds', () => {
+    expect(normalizeProducerKey('St Hallett Wines Ltd')).toBe('saint hallett');
+    expect(normalizeProducerKey('Kumeu River Wines Limited')).toBe('kumeu river');
+  });
+});

--- a/backend/src/utils/producerPrefix.js
+++ b/backend/src/utils/producerPrefix.js
@@ -1,4 +1,4 @@
-const { normalizeString, normalizeProducerKey, tokenize } = require('./normalize');
+const { normalizeString, normalizeProducerKey, foldProducerToken, tokenize } = require('./normalize');
 
 /**
  * Multi-character connectives / prepositions that cannot legitimately END a
@@ -160,8 +160,9 @@ function stripProducerName(name, producer) {
  *   - Leading words that normalize away entirely (house/stop words: "Fattoria",
  *     "La", "Weingut") may precede the key run — they belong to the producer
  *     reference even though the comparison key drops them.
- *   - The FULL key-token run must then match word-for-word (normalized), so a
- *     partial producer overlap never strips.
+ *   - The FULL key-token run must then match word-for-word (normalized, each
+ *     word folded into key-token space so a name-side "St"/"Ste" matches the
+ *     key's 'saint'), so a partial producer overlap never strips.
  *   - Something meaningful must remain.
  *   - Suffixes are deliberately NOT handled here: legitimate wine names END
  *     with the producer key ("Les Forts de Latour" — Château Latour), so
@@ -183,7 +184,9 @@ function stripProducerKeyPrefix(name, producer) {
   while (start < words.length && tokenize(words[start]).length === 0) start += 1;
   if (start + keyTokens.length >= words.length) return null; // nothing meaningful would remain
   for (let i = 0; i < keyTokens.length; i++) {
-    if (normalizeString(words[start + i]) !== keyTokens[i]) return null;
+    // Same per-token fold the key went through — without it the Saint fold
+    // would break every same-spelling embed ("St Hugo …" vs key 'saint hugo').
+    if (foldProducerToken(normalizeString(words[start + i])) !== keyTokens[i]) return null;
   }
 
   const remainder = words.slice(start + keyTokens.length).join(' ').replace(/^[\s\-–—]+/, '').trim();

--- a/backend/src/utils/wineIdentity.test.js
+++ b/backend/src/utils/wineIdentity.test.js
@@ -24,6 +24,23 @@ describe('computeCanonicalKey', () => {
     expect(computeCanonicalKey('', '')).toBe('::');
     expect(computeCanonicalKey('X', 'Y', null)).toBe('y:x:');
   });
+
+  test('Saint-spelling producer variants share one canonical identity — the Caronne split (ticket d49fea22)', () => {
+    const canonical = computeCanonicalKey('Grand Vin', 'Château Caronne Sainte Gemme', 'Haut-Médoc');
+    expect(computeCanonicalKey('Grand Vin', 'Château Caronne Ste Gemme', 'Haut-Médoc')).toBe(canonical);
+    expect(computeCanonicalKey('Grand Vin', 'Chateau Caronne Saint Gemme', 'Haut-Médoc')).toBe(canonical);
+    // The HYPHENATED spelling does NOT fold: normalizeString deletes hyphens,
+    // gluing 'saintegemme' into one token the Saint fold never sees. Pinned as
+    // a known limit — a producer-key hyphen fold would regress
+    // stripProducerKeyPrefix on hyphenated producers, so that axis stays with
+    // the human merge queue.
+    expect(computeCanonicalKey('Grand Vin', 'Château Caronne Sainte-Gemme', 'Haut-Médoc')).not.toBe(canonical);
+  });
+
+  test('an only-a-founding-year producer falls back to the raw string, never one shared empty bucket', () => {
+    expect(computeCanonicalKey('Red', '1846', '')).toBe('1846:red:');
+    expect(computeCanonicalKey('Red', '1846', '')).not.toBe(computeCanonicalKey('Red', '1921', ''));
+  });
 });
 
 describe('canonicalSiblingPrefix', () => {


### PR DESCRIPTION
## What (Tier 2, item 1 of the registry/add-experience push)

Two upgrades to `normalizeProducerKey` — the producer **comparison** key behind canonical matching, sibling lookup, fuzzy producer scoring and the admin duplicate clusters — so more adds resolve to existing registry records instead of minting duplicates. Display strings are never touched; the unique `normalizedKey` is untouched.

1. **Saint fold**: `st`/`ste`/`saint`/`sainte` bucket as one token, any position. The Caronne case (3 spellings, 5 records, ticket d49fea22) now shares one producer key; "St Hallett"≡"Saint Hallett", "Chateau Ste Michelle"≡"Chateau Sainte Michelle". False folds (a `Ste` abbreviating Société) can only land in the human-reviewed canonical-collisions queue — the key is non-unique by design, nothing auto-merges.
2. **Trailing founding-year strip**: trailing year tokens 1000–2049 (plus a dangling `Est./Estd/Estab/Anno/Since` marker) come off the key — "Grand Pappy's 1846" ≡ "Grand Pappy's" (ticket d49dfd38). Trailing-ness is judged on the pre-stop-word sequence, so "**1848 Winery**" keeps its brand year (`tokenize` drops "Winery", which would otherwise make the year *look* trailing). A producer that is only a year keys empty and every caller already falls back to the raw string.

**Ripple handled:** `stripProducerKeyPrefix` folds each name-side word into key-token space before comparing — otherwise every same-spelling St-embed ("St Hugo Cabernet Sauvignon" + producer "St Hugo Wines") would have stopped stripping. nameChecks verdicts may shift through that shared helper; that is the documented, accepted residual of its snapshot policy (no detect body changed, no rule id bumped).

## Effect at add time

- Identical-spelling St-variant adds now hit the canonical/sibling match directly (no duplicate minted).
- Adds where the *name* carries the variant (estate-named Bordeaux wines) rise on the producer-similarity axis from silent-mint territory (~0.76) into the soft zone (~0.88) — the user gets the "did you mean?" prompt instead of a twin record.
- The admin duplicates tool now buckets all St-spellings of a producer into one review group.

## Known limit (pinned in tests)

The **hyphenated** axis does not fold: `normalizeString` deletes hyphens, so "Sainte-Gemme" is one token (`saintegemme`) the fold never sees. A producer-key hyphen fold would regress `stripProducerKeyPrefix` on hyphenated producers — separate deliberate decision if we want it. Until then that variant stays a manual merge (the fragmentation queue PR surfaces it by exact-producer grouping).

## Tests

+6 `normalizeProducerKey` cases, +2 `computeCanonicalKey` cases (Caronne trio collision; only-a-year fallback). Full run: `normalize`, `producerPrefix`, `nameChecks`, `nameChecks.snapshot` (passes untouched), `wineIdentity`, `wineMatching`, `findOrCreateWine` — 265 tests, 5 snapshots, all green in node:20-alpine.

## Deploy (required step)

`canonicalKey` is stored per row. After deploy:

```
docker exec cellarion-backend node src/scripts/backfill-canonical-key.js          # dry-run, eyeball collisions
docker exec cellarion-backend node src/scripts/backfill-canonical-key.js --apply
```

The script needs no change (recomputes stored-vs-computed for every row, safe to re-run). The collision sets it prints after this change are exactly the new merge candidates — work them through the admin merge queue, never auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
