### PR TITLE
fix(release): remediate 2026-08-10 pre-release audit findings (0H/3M/4L)

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -234,6 +234,24 @@ describe('set_vintage_maturity', () => {
     expect(body.error.code).toBe('invalid_input');
   });
 
+  // Audit 2026-08-10: profiles predating the relative-flag derivation hold
+  // absolute years under vintage 'NV'; a partial write flips relative=true on
+  // save, silently reinterpreting retained years as offsets. Must refuse.
+  test('a partial write on an NV profile carrying absolute years is refused, a full rewrite lands', async () => {
+    profile({ vintage: 'NV', relative: false, peakFrom: 2024, peakUntil: 2029 });
+    let body = parse(await tool('set_vintage_maturity').handler(
+      { profile_id: oid('1'), somm_notes: 'legacy row' }, SOMM_CTX));
+    expect(body.error.code).toBe('conflict');
+    expect(body.error.message).toMatch(/retained from the stored profile/);
+
+    const p = profile({ vintage: 'NV', relative: false, peakFrom: 2024, peakUntil: 2029 });
+    body = parse(await tool('set_vintage_maturity').handler(
+      { profile_id: oid('1'), early_from: 0, early_until: 1, peak_from: 2, peak_until: 4, late_from: null, late_until: null }, SOMM_CTX));
+    expect(body.error).toBeUndefined();
+    expect(p.relative).toBe(true);
+    expect(p.save).toHaveBeenCalled();
+  });
+
   test('prev snapshot captures phases + review state for undo; audit uses the REST action string', async () => {
     const p = profile({ peakFrom: 2020, peakUntil: 2030, status: 'reviewed', setBy: oid('b'), setAt: new Date('2026-01-01') });
     await tool('set_vintage_maturity').handler({ profile_id: oid('1'), peak_from: 2026, peak_until: 2040 }, SOMM_CTX);

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -199,6 +199,21 @@ registerTool({
       }
       next[f] = v;
     }
+    // RETAINED values must satisfy the target range too. Profiles that predate
+    // the relative-flag derivation (the #908 backfill's re-curation list) hold
+    // absolute years under vintage 'NV' — the save below flips relative=true,
+    // which would silently reinterpret a carried-forward 2024 as "2024 years
+    // after purchase" (audit 2026-08-10). Refuse the partial write and demand
+    // a full rewrite instead of laundering the corruption.
+    for (const f of PHASE_FIELDS) {
+      if (incoming[f] !== undefined) continue;
+      const v = next[f];
+      if (v != null && (v < min || v > max)) {
+        return fail('conflict',
+          `${f}=${v} retained from the stored profile is outside the ${isNv ? 'NV offset range 0–100' : 'year range 1900–2200'} — ` +
+          'this profile still carries values in the other unit. Rewrite all six phases in this call (pass null to clear a phase).');
+      }
+    }
     const pairs = [['earlyFrom', 'earlyUntil'], ['peakFrom', 'peakUntil'], ['lateFrom', 'lateUntil']];
     for (const [from, until] of pairs) {
       if (next[from] != null && next[until] != null && next[until] < next[from]) {

--- a/backend/src/routes/og.js
+++ b/backend/src/routes/og.js
@@ -508,11 +508,17 @@ router.get('/wines/:idOrSlug', ogLimiter, async (req, res) => {
 
     // Pull the most authoritative vintage profile so we can include real drink-window
     // dates in the prose and FAQ. Prefer reviewed profiles, then most recent vintage.
+    // Relative (NV) profiles are excluded outright: they store year-OFFSETS from each
+    // bottle's purchase, and this page has no bottle to anchor them to — quoting them
+    // would print "peak maturity from 2 to 5" as if those were dates. The byte-wise
+    // vintage sort makes it worse ('NV' > every year string), so without the filter a
+    // reviewed NV profile would WIN the pick whenever one exists (audit 2026-08-10).
     let profile = null;
     try {
       profile = await WineVintageProfile.findOne({
         wineDefinition: wine._id,
-        status: 'reviewed'
+        status: 'reviewed',
+        relative: { $ne: true }
       }).sort({ vintage: -1 }).select('vintage peakFrom peakUntil earlyFrom earlyUntil lateFrom lateUntil').lean();
     } catch (e) {
       // Profile is optional — failure here shouldn't break the page render.

--- a/backend/src/scripts/backfill-maturity-profiles.js
+++ b/backend/src/scripts/backfill-maturity-profiles.js
@@ -91,6 +91,9 @@ async function run() {
       wineDefinition: m.wineDefinition,
       vintage: m.vintage,
       status: 'pending',
+      // Derived, same as ensurePendingVintageProfile — seeding it false shipped
+      // NV rows into the queue self-contradictory (ticket d49d2b36).
+      relative: m.vintage === 'NV',
     }));
     // ordered:false so a single duplicate-key error (race with a live add/import)
     // doesn't abort the whole batch.

--- a/backend/src/scripts/backfill-nv-profiles.js
+++ b/backend/src/scripts/backfill-nv-profiles.js
@@ -82,7 +82,10 @@ async function run() {
     const docs = missing.map(wineDefinition => ({
       wineDefinition,
       vintage: 'NV',
-      status: 'pending'
+      status: 'pending',
+      // Derived, same as ensurePendingVintageProfile — seeding it false shipped
+      // NV rows into the queue self-contradictory (ticket d49d2b36).
+      relative: true
     }));
     // ordered:false so a single duplicate-key error (race with the route)
     // doesn't abort the whole batch

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -269,7 +269,13 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // the soft zone can disambiguate instead of picking one arbitrarily.
   // Canonical prefix first (variant-tolerant); the raw normalizedKey prefix is
   // kept as a fallback for rows that predate canonicalKey on instances that
-  // haven't run the backfill — they converge organically as docs save.
+  // haven't run the backfill. Convergence is NOT organic beyond that: the
+  // pre-validate hook rekeys a row only when name/producer/appellation change,
+  // so after any change to key DERIVATION (e.g. the 2026-08-10 Saint fold /
+  // year strip) stored keys stay stale until backfill-canonical-key.js --apply
+  // is rerun — until then new-style lookups can only MISS old rows, never
+  // mis-match them (folded query keys are a strict subset of fold-class
+  // spellings; audit 2026-08-10).
   if (!skipSiblingMatch) {
     const canonicalSiblings = await WineDefinition.find({
       canonicalKey: new RegExp(`^${escapeRegex(canonicalSiblingPrefix(trimmedName, trimmedProducer))}`),

--- a/backend/src/services/registryFragmentation.js
+++ b/backend/src/services/registryFragmentation.js
@@ -186,8 +186,16 @@ async function sameProducerAppellationGroups({ limit = 50, offset = 0 } = {}) {
 
   // Disjoint-first (the strong candidates), then size desc; producer, then
   // the unique group key, keep pagination deterministic between requests.
+  // Within disjoint, groups where ≥2 members actually CARRY vintage evidence
+  // outrank vacuously-disjoint ones (no bottles, no profiles — common for
+  // seeded/import rows, which would otherwise flood page 1 with groups whose
+  // "no shared vintage" badge rests on no data at all; audit 2026-08-10).
+  const tier = (g) => {
+    if (!g.disjoint) return 0;
+    return g.wines.filter((w) => w.vintages.length > 0).length >= 2 ? 2 : 1;
+  };
   groups.sort((a, b) =>
-    (b.disjoint - a.disjoint) ||
+    (tier(b) - tier(a)) ||
     (b.wines.length - a.wines.length) ||
     String(a.producer).localeCompare(String(b.producer)) ||
     a.key.localeCompare(b.key));

--- a/backend/src/services/registryFragmentation.test.js
+++ b/backend/src/services/registryFragmentation.test.js
@@ -98,6 +98,29 @@ describe('sameProducerAppellationGroups', () => {
     expect(g.wines.find(w => w._id === 'w1').vintages).toEqual(['2015']); // Unknown dropped
   });
 
+  // Audit 2026-08-10: a group with NO vintage evidence anywhere is vacuously
+  // disjoint — seeded/import rows without bottles would flood page 1 wearing a
+  // "no shared vintage" badge that rests on no data. Evidenced groups first.
+  test('vacuously-disjoint zero-evidence groups rank below genuinely evidenced disjoint ones', async () => {
+    WineDefinition.find.mockReturnValue(leanChain([
+      // Zero-evidence pair (no bottles, no profiles) — vacuously disjoint.
+      { _id: 's1', name: 'A', producer: 'Seeded House', appellation: 'Rueda' },
+      { _id: 's2', name: 'B', producer: 'Seeded House', appellation: 'Rueda' },
+      // Evidenced disjoint pair — the genuinely strong candidate.
+      caronne({ _id: 'w1', name: 'Haut-Médoc' }),
+      caronne({ _id: 'w2', name: 'Cru Bourgeois Haut-Médoc' }),
+    ]));
+    Bottle.aggregate.mockResolvedValue([
+      { _id: 'w1', count: 1, vintages: ['2016'] },
+      { _id: 'w2', count: 1, vintages: ['2017'] },
+    ]);
+
+    const res = await sameProducerAppellationGroups({});
+    expect(res.total).toBe(2);
+    expect(res.groups.map(g => g.producer)).toEqual(['Château Caronne Sainte-Gemme', 'Seeded House']);
+    expect(res.groups.map(g => g.disjoint)).toEqual([true, true]); // both flagged; ordering carries the evidence
+  });
+
   test('empty appellation keys and all-stopword producer keys never group', async () => {
     WineDefinition.find.mockReturnValue(leanChain([
       { _id: 'w1', name: 'A', producer: 'Guigal', appellation: '' },

--- a/backend/src/services/wineProfileOps.js
+++ b/backend/src/services/wineProfileOps.js
@@ -197,7 +197,12 @@ async function resolveGrapeIdsStrict(names) {
   for (const raw of names) {
     const resolved = resolveGrapeName(raw);
     const normalizedName = normalizeString(resolved);
-    if (!normalizedName || seen.has(normalizedName)) continue;
+    // A name that normalizes to nothing (non-Latin scripts — normalizeString
+    // strips non-ASCII word chars — or a bare percentage) is UNRESOLVABLE, not
+    // ignorable: silently dropping it turned a set into a partial write, and an
+    // all-such list into an accidental CLEAR of wine.grapes (audit 2026-08-10).
+    if (!normalizedName) { unmatched.push(raw); continue; }
+    if (seen.has(normalizedName)) continue;
     seen.add(normalizedName);
     const grape = await Grape.findOne({
       $or: [{ normalizedName }, { normalizedSynonyms: normalizedName }],

--- a/backend/src/services/wineProfileOps.test.js
+++ b/backend/src/services/wineProfileOps.test.js
@@ -139,6 +139,17 @@ describe('resolveGrapeIdsStrict (match-only)', () => {
     const r = await resolveGrapeIdsStrict(['Syrah', 'Shiraz']);
     expect(r.ids).toEqual(['g-syrah']);
   });
+
+  // Audit 2026-08-10: names that normalize to '' (non-Latin scripts, bare
+  // percentages) were silently DROPPED — a set became a partial write, and an
+  // all-such list became an accidental clear of wine.grapes.
+  test('a name that normalizes to nothing is refused, never silently dropped', async () => {
+    Grape.findOne.mockReturnValue(found({ _id: 'g-syrah', name: 'Syrah' }));
+    const r = await resolveGrapeIdsStrict(['Ркацители', 'Syrah']);
+    expect(r.ok).toBe(false);
+    expect(r.unmatched).toEqual(['Ркацители']);
+    expect((await resolveGrapeIdsStrict(['Ркацители'])).ok).toBe(false);
+  });
 });
 
 describe('applyProfilePatch', () => {

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -233,6 +233,20 @@ const normalizeProducerKey = (producer) => {
     raw.pop();
     if (raw.length > 0 && PRODUCER_FOUNDING_MARKERS.has(raw[raw.length - 1])) raw.pop();
   }
+  // A stop/corp word can also TRAIL the founding year ("Grand Pappy's 1846
+  // Winery", "… 1846 Ltd") and hide it from the literal-tail loop above —
+  // which would split keys the pre-fold code unified ("X 1846" vs "X 1846
+  // Winery"; audit 2026-08-10). Walk back over droppable tail tokens and
+  // strip a year found behind them — but only when it is NOT the opening
+  // token: a leading year is a brand name ("1848 Winery") whatever follows.
+  const droppableTail = (t) => PRODUCER_CORP_SUFFIXES.has(t) || tokenize(t).length === 0;
+  let end = raw.length - 1;
+  while (end > 0 && droppableTail(raw[end])) end -= 1;
+  while (end > 0 && PRODUCER_FOUNDING_YEAR_RX.test(raw[end])) {
+    raw.splice(end, 1);
+    end -= 1;
+    if (end > 0 && PRODUCER_FOUNDING_MARKERS.has(raw[end])) { raw.splice(end, 1); end -= 1; }
+  }
   return tokenize(raw.join(' '))
     .filter((t) => !PRODUCER_CORP_SUFFIXES.has(t))
     .map(foldProducerToken)

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -663,6 +663,16 @@ describe('normalizeProducerKey — Saint fold + founding-year strip (tickets d49
     expect(normalizeProducerKey('1848 Winery')).toBe('1848');
   });
 
+  test('a stop/corp word after the founding year does not hide it (audit 2026-08-10)', () => {
+    // Pre-fix, "X 1846" and "X 1846 Winery" split into different keys — a
+    // regression against the pre-fold bucketing, which unified them.
+    expect(normalizeProducerKey("Grand Pappy's 1846 Winery")).toBe('grand pappys');
+    expect(normalizeProducerKey('Bodega Norton 1895 Ltd')).toBe('norton');
+    expect(normalizeProducerKey("Grand Pappy's Est. 1846 Winery")).toBe('grand pappys');
+    // The leading-brand-year rule still wins over the walk-back.
+    expect(normalizeProducerKey('1848 Winery')).toBe('1848');
+  });
+
   test('a producer that IS only a year keys empty — callers fall back to the raw string', () => {
     // wineIdentity.producerSegment and wineMatching.producerSimilarity both
     // fall back to normalizeString on an empty key, so bare-year producers

--- a/frontend/src/components/WineFragmentationModal.js
+++ b/frontend/src/components/WineFragmentationModal.js
@@ -75,7 +75,10 @@ function WineFragmentationModal({ apiFetch, onClose }) {
   useEffect(() => { fetchPage(page); }, [fetchPage, page]);
 
   const switchMode = (m) => {
-    if (m === mode) return;
+    // Blocked while a dismiss is in flight (belt to the button-disable braces
+    // below): its resolve would setItems a groups-shaped list under the pairs
+    // renderer → TypeError → app ErrorBoundary (audit 2026-08-10).
+    if (m === mode || pendingKey) return;
     dismissedDelta.current = 0;
     setMode(m);
     setItems(null);
@@ -90,11 +93,15 @@ function WineFragmentationModal({ apiFetch, onClose }) {
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
         dismissedDelta.current += 1;
-        const remaining = (items || []).filter(g => g.key !== group.key);
-        const newTotal = Math.max(0, total - 1);
-        setItems(remaining);
-        setTotal(newTotal);
-        if (remaining.length === 0 && newTotal > 0) {
+        // Functional updaters, sibling pattern (WineCanonicalCollisionsModal):
+        // never derive the new list from the render closure — a snapshot write
+        // after an await resurrects concurrently-removed rows. The drain check
+        // may use the closure because every interleaving path (second dismiss,
+        // mode switch, page change) is disabled while this one is pending.
+        setItems(prev => (prev || []).filter(g => g.key !== group.key));
+        setTotal(prev => Math.max(0, prev - 1));
+        const remaining = (items || []).filter(g => g.key !== group.key).length;
+        if (remaining === 0 && total - 1 > 0) {
           if (page > 1) setPage(p => p - 1);
           else fetchPage(1);
         }
@@ -141,6 +148,7 @@ function WineFragmentationModal({ apiFetch, onClose }) {
         <button
           type="button"
           className={`btn ${mode === 'groups' ? 'btn-primary' : 'btn-secondary'} btn-small`}
+          disabled={!!pendingKey}
           onClick={() => switchMode('groups')}
         >
           {t('admin.wines.fragmentation.modeGroups')}
@@ -148,6 +156,7 @@ function WineFragmentationModal({ apiFetch, onClose }) {
         <button
           type="button"
           className={`btn ${mode === 'pairs' ? 'btn-primary' : 'btn-secondary'} btn-small`}
+          disabled={!!pendingKey}
           onClick={() => switchMode('pairs')}
         >
           {t('admin.wines.fragmentation.modePairs')}
@@ -195,7 +204,7 @@ function WineFragmentationModal({ apiFetch, onClose }) {
                   type="button"
                   className="btn btn-secondary btn-small"
                   style={{ marginLeft: 'auto' }}
-                  disabled={pendingKey === group.key}
+                  disabled={!!pendingKey}
                   onClick={() => dismissGroup(group)}
                   title={t('admin.wines.fragmentation.dismissTitle')}
                 >


### PR DESCRIPTION
Remediation batch for the five-auditor diff-scoped audit of `v1.100.0..main` (the #904 + #907–#911 release candidate). **0 HIGH / 3 MED / 4 LOW found; every fix-now item lands here.** Full finding-by-finding detail is in the commit message; summary:

- **MED** `set_vintage_maturity`: partial writes on NV profiles carrying legacy absolute years are now refused (retained values validated against the target range) instead of silently flipping them into "2024 years after purchase" — protects exactly the 79-row re-curation pass.
- **MED** `resolveGrapeIdsStrict`: names normalizing to '' (non-Latin scripts) now refuse the write instead of silently dropping — a set can no longer become an accidental clear.
- **MED** fragmentation modal: functional state updaters + full interlock (mode/dismiss disabled during a pending POST) — kills the stale-closure resurrect and the mode-switch crash-to-ErrorBoundary path.
- **MED** (pre-existing, newly aggravated) `og.js`: relative NV profiles excluded from the public wine page's window pick — no more offsets quoted as calendar years, and the byte-wise 'NV'-first sort no longer matters.
- **LOW** producer keys: founding-year strip now sees years hidden behind trailing stop/corp words ("X 1846 Winery" ≡ "X 1846" ≡ "X"); leading brand years still survive. Stale "converge organically" comment replaced with the real backfill contract.
- **LOW** legacy backfill scripts now seed `relative` correctly (post-restore runs re-opened the d49d2b36 seam).
- **LOW** fragmentation sort: evidenced-disjoint groups rank above vacuously-disjoint zero-evidence ones (seeded rows would have flooded page 1).

**Deferred with rationale** (backlogged, not fixed): undo changed-since guard for `somm_wine_profile` (LOW, interleaving-dependent, self-healing); per-pair dismissal store for producer pairs (needs a new model; rejected pairs resurface per scan until merged).

Tests: 373 backend across the 15 affected suites + full frontend 890 — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)