### PR TITLE
feat(mcp): wine_id + vintage filter on list_maturity_queue

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -115,6 +115,27 @@ describe('list_maturity_queue', () => {
     expect(body.data[0].phases).toHaveProperty('peakFrom', null);
   });
 
+  // Curator feedback on v1.101.0: reaching one wine's reviewed rows meant
+  // paginating ~5,600 profiles at 50/page. A wine-scoped call is one call —
+  // and defaults to status 'all', because "what is curated for THIS wine"
+  // wants reviewed rows, not the pending default.
+  test('wine_id scopes the queue and defaults to all statuses; vintage narrows further (nv → NV)', async () => {
+    WineVintageProfile.countDocuments.mockResolvedValue(0);
+    WineVintageProfile.find.mockReturnValue(chain([]));
+    await tool('list_maturity_queue').handler({ wine_id: oid('f') }, SOMM_CTX);
+    expect(WineVintageProfile.find.mock.calls[0][0]).toEqual({ wineDefinition: oid('f') });
+
+    await tool('list_maturity_queue').handler({ wine_id: oid('f'), status: 'pending' }, SOMM_CTX);
+    expect(WineVintageProfile.find.mock.calls[1][0]).toEqual({ status: 'pending', wineDefinition: oid('f') });
+
+    await tool('list_maturity_queue').handler({ wine_id: oid('f'), vintage: 'nv ' }, SOMM_CTX);
+    expect(WineVintageProfile.find.mock.calls[2][0]).toEqual({ wineDefinition: oid('f'), vintage: 'NV' });
+
+    // Unscoped calls keep the pending-queue default — the killer workflow is untouched.
+    await tool('list_maturity_queue').handler({}, SOMM_CTX);
+    expect(WineVintageProfile.find.mock.calls[3][0]).toEqual({ status: 'pending' });
+  });
+
   // #787: the note was fetched but dropped in the row mapping — write-only data.
   test('reviewed rows carry the curator note; absent note reads as null', async () => {
     WineVintageProfile.countDocuments.mockResolvedValueOnce(2).mockResolvedValueOnce(0);

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -79,13 +79,18 @@ registerTool({
   title: 'Sommelier: list the maturity queue',
   description:
     'Lists wine+vintage pairs awaiting drink-window review (every added bottle seeds one). Pending first, newest ' +
-    'first. Call when the somm asks "anything in my maturity queue?" or before a review session. Use the returned ' +
-    'profile_id with set_vintage_maturity.',
+    'first. Call when the somm asks "anything in my maturity queue?" or before a review session. Pass wine_id ' +
+    '(and optionally vintage) to fetch ONE wine\'s rows — including curator notes, which the public drink_window_for ' +
+    'deliberately omits; a wine-scoped call defaults to status "all" so reviewed rows show without paginating the ' +
+    'whole queue. Use the returned profile_id with set_vintage_maturity (which also accepts wine_id + vintage directly).',
   scope: 'read',
   requireRole: SOMM_ROLES,
   annotations: { readOnlyHint: true, openWorldHint: false },
   inputSchema: {
-    status: z.enum(['pending', 'reviewed', 'all']).default('pending'),
+    status: z.enum(['pending', 'reviewed', 'all']).optional()
+      .describe('Default: "pending" — or "all" when wine_id is given (a wine lookup wants every row)'),
+    wine_id: objectId.optional().describe('Scope to one registry wine (from search_registry/get_wine/drink_window_for)'),
+    vintage: z.string().min(1).max(10).optional().describe('With wine_id: one vintage, e.g. "2019" or "NV"'),
     limit: z.number().int().min(1).max(50).default(20),
     offset: z.number().int().min(0).default(0),
   },
@@ -93,8 +98,19 @@ registerTool({
     const denied = requireSomm(ctx);
     if (denied) return denied;
     const { limit, offset } = pageParams(args, 20, 50);
-    const status = args.status || 'pending';
+    // A wine-scoped call defaults to 'all': the curator asking "what is
+    // curated for THIS wine" wants reviewed rows, and 5,600+ reviewed
+    // profiles made reaching one by pagination ~113 calls (curator feedback
+    // on v1.101.0). Unscoped calls keep the pending-queue default.
+    const status = args.status || (args.wine_id ? 'all' : 'pending');
     const filter = status === 'all' ? {} : { status };
+    if (args.wine_id) {
+      filter.wineDefinition = args.wine_id;
+      if (args.vintage) {
+        // Same canonical vintage form set_vintage_maturity uses.
+        filter.vintage = /^nv$/i.test(args.vintage.trim()) ? 'NV' : args.vintage.trim();
+      }
+    }
     const [total, pending, profiles] = await Promise.all([
       WineVintageProfile.countDocuments(filter),
       WineVintageProfile.countDocuments({ status: 'pending' }),


### PR DESCRIPTION
## Curator feedback, first maturity session on v1.101.0

Reaching one wine's reviewed rows meant paginating ~5,600 profiles at 50/page (~113 calls). This adds the one genuinely missing piece from the curator's four-item gap list:

- `list_maturity_queue` takes optional **`wine_id`** (+ optional **`vintage`**, canonicalized `nv`→`NV` like `set_vintage_maturity`).
- A wine-scoped call **defaults to status `all`** — asking about one wine means wanting its reviewed rows; unscoped calls keep the pending default, so the killer workflow ("anything in my queue?") is untouched.
- This is also the somm's only filtered read of curated rows **with notes** — `drink_window_for` is public scope and deliberately omits `sommNotes`.

## The other three items on the list

Already shipped in v1.101.0 — the curator session was reading a **stale claude.ai tool cache** (known behavior; remedy = new conversation): #907 added wine_id+vintage addressing to `set_vintage_maturity` and rewrote exactly the description the list calls factually wrong; #909 added type/grapes to `set_wine_profile` (the ticket the list references). profile_id-in-`drink_window_for` is unnecessary under the new addressing and would widen a public tool for no remaining consumer.

## Tests

New case pinning: wine-scoped filter shape, status-default flip to `all`, explicit status honored, vintage canonicalization, unscoped default unchanged. `sommTools` + `registry` suites green (43 tests, node:20-alpine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)