### PR TITLE
fix(somm): close pending proposals when their wine is merged/deleted; IndexNow parity on approve

### DIFF
--- a/backend/src/routes/admin/wineProposals.js
+++ b/backend/src/routes/admin/wineProposals.js
@@ -32,6 +32,7 @@ const Bottle = require('../../models/Bottle');
 const Country = require('../../models/Country');
 const { requireAuth, requireRole } = require('../../middleware/auth');
 const { logAudit } = require('../../services/audit');
+const { submitUrls } = require('../../services/indexNow');
 const searchService = require('../../services/search');
 const { reembedActiveVintages } = require('../../services/embeddingJob');
 const { findOrCreateRegion } = require('../../services/findOrCreateWine');
@@ -244,7 +245,10 @@ router.post('/:id/approve', async (req, res) => {
         }
 
         // The PUT's follow-through: registry index, the bottles' denormalized
-        // search docs (no scheduled resync exists), and the embedding text.
+        // search docs (no scheduled resync exists), the embedding text — and
+        // the IndexNow ping (an approved identity fix changes the public wine
+        // page exactly like a PUT rename; parity per audit 2026-08-10).
+        submitUrls(`/wines/${wine._id}`);
         searchService.indexWine(wine._id);
         Bottle.distinct('_id', { wineDefinition: wine._id })
           .then((ids) => searchService.bulkIndexBottles(ids))

--- a/backend/src/routes/admin/wineProposals.test.js
+++ b/backend/src/routes/admin/wineProposals.test.js
@@ -25,6 +25,7 @@ jest.mock('../../models/WineVintageProfile', () => ({ deleteMany: jest.fn() }));
 jest.mock('../../models/Bottle', () => ({ distinct: jest.fn() }));
 jest.mock('../../models/Country', () => ({ findOne: jest.fn() }));
 jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/indexNow', () => ({ submitUrls: jest.fn() }));
 jest.mock('../../services/search', () => ({ indexWine: jest.fn(), bulkIndexBottles: jest.fn() }));
 jest.mock('../../services/embeddingJob', () => ({ reembedActiveVintages: jest.fn().mockResolvedValue(undefined) }));
 jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateRegion: jest.fn() }));
@@ -147,6 +148,9 @@ describe('POST /:id/approve', () => {
     expect(wine.normalizedKey).toBe(generateWineKey('Barolo', 'E. Pira e Figli', 'Barolo'));
     expect(wine.save).toHaveBeenCalled();
     expect(searchService.indexWine).toHaveBeenCalledWith(W1);
+    // IndexNow parity with the PUT: an approved identity fix changes the
+    // public wine page and must ping crawlers the same way (audit 2026-08-10).
+    expect(require('../../services/indexNow').submitUrls).toHaveBeenCalledWith(`/wines/${W1}`);
     // The receipt lands on the row.
     const noteSet = WineCorrectionProposal.updateOne.mock.calls.at(-1);
     expect(noteSet[1].$set.appliedNote).toMatch(/Applied/);

--- a/backend/src/routes/admin/wines.dedup.test.js
+++ b/backend/src/routes/admin/wines.dedup.test.js
@@ -39,6 +39,7 @@ jest.mock('../../models/JournalEntry', () => ({}));
 jest.mock('../../models/Recommendation', () => ({}));
 jest.mock('../../models/RestockAlert', () => ({}));
 jest.mock('../../models/WineRequest', () => ({}));
+jest.mock('../../models/WineCorrectionProposal', () => ({ updateMany: jest.fn().mockResolvedValue({}) }));
 jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
 jest.mock('../../services/vectorStore', () => ({}));
 jest.mock('../../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -24,6 +24,7 @@ const Discussion = require('../../models/Discussion');
 const DiscussionReply = require('../../models/DiscussionReply');
 const WineEmbedding = require('../../models/WineEmbedding');
 const WineNotDuplicate = require('../../models/WineNotDuplicate');
+const WineCorrectionProposal = require('../../models/WineCorrectionProposal');
 const WineList = require('../../models/WineList');
 const WishlistItem = require('../../models/WishlistItem');
 const PriceTrackingRequest = require('../../models/PriceTrackingRequest');
@@ -1223,6 +1224,12 @@ router.delete('/:id', async (req, res) => {
       WineReport.updateMany({ duplicateOf: id }, { $unset: { duplicateOf: '' } }),
       WineRequest.updateMany({ linkedWineDefinition: id }, { $unset: { linkedWineDefinition: '' } }),
       WineNotDuplicate.deleteMany({ $or: [{ wineA: id }, { wineB: id }] }),
+      // Pending correction proposals on (or targeting) a deleted wine would
+      // dangle in the review queue forever — same closure as performWineMerge.
+      WineCorrectionProposal.updateMany(
+        { status: 'pending', $or: [{ wineDefinition: id }, { mergeTargetId: id }] },
+        { $set: { status: 'rejected', decidedAt: new Date(), rejectReason: 'Closed automatically: the wine was deleted before review.' } }
+      ),
       // Qdrant points + WineEmbedding bookkeeping rows (same helper as merge).
       purgeSourceVectors(id),
     ]);
@@ -1430,6 +1437,24 @@ async function performWineMerge(sourceId, targetId, req) {
   searchService.removeWine(String(sourceId));
   // Target was mutated if we adopted the image; re-index so search sees it
   if (imageAction === 'adopted_from_source') searchService.indexWine(targetId);
+
+  // Close the source's PENDING correction proposals — a pending row whose
+  // subject wine is gone would dangle forever: the review list renders a null
+  // wine, approve 404s and reverts its claim back to pending, and the
+  // AdminWines badge stays inflated (audit 2026-08-10 MED). Auto-reject with
+  // the reason rather than re-point: the merge usually RESOLVES the complaint,
+  // and silently re-targeting what an admin later approves would be spookier
+  // than asking the somm to re-file against the keeper. decidedBy stays null —
+  // this is lifecycle closure, not a reviewer's judgement.
+  const keeperLabel = [target.producer, target.name].filter(Boolean).join(' — ');
+  await WineCorrectionProposal.updateMany(
+    { status: 'pending', $or: [{ wineDefinition: sourceId }, { mergeTargetId: sourceId }] },
+    { $set: {
+      status: 'rejected',
+      decidedAt: new Date(),
+      rejectReason: `Closed automatically: the wine was merged into "${keeperLabel}". Re-file against that wine if the issue still applies.`.slice(0, 500),
+    } }
+  );
 
   // Re-embed the keeper's vintages (it just absorbed the source's bottles and
   // possibly its profile) so semantic search reflects the merged wine.


### PR DESCRIPTION
Remediation for the v1.102.0 pre-release audit (2 agents over the #914+#915 diff: 0 HIGH / 1 MED / 3 LOW / 1 INFO).

- **MED fixed**: pending `WineCorrectionProposal` rows dangled forever when their subject wine was merged away or deleted (null wine in the review list, approve 404→claim-revert loop, inflated badge). `performWineMerge` and the wine DELETE cascade now auto-**reject** pendings on (or targeting) the removed wine with an explanatory reason — rejection rather than re-pointing, since the merge usually resolves the complaint and silent re-targeting of what an admin approves would be worse.
- **LOW fixed**: approve now pings IndexNow after a field correction — parity with the admin PUT it mirrors.
- **Deferred with notes**: merge image-consolidation retry edge (pre-existing), non_wine TOCTOU (one stray self-healing queue row), the family-wide offset-drain page-N nit, optional client-side URL-scheme guard (backend double-validates; INFO).

Suites green: proposals, dedup, fragmentation, nonWine, lowConfidence, verifyChecks, sommTools, registry — 106 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)