### PR TITLE
chore(deps): bump nanoid + js-yaml (clears both HIGH Dependabot alerts)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5823,9 +5823,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6464,9 +6464,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Lockfile-only bumps, regenerated in node:20-alpine: **nanoid 3.3.16→3.3.18** (GHSA-2v37-7h3g-55p8) and **js-yaml 3.15.0→3.15.1** (GHSA-5p4m-2wfm-xmqj). Both alerts were triaged unreachable (nanoid transitive via postcss, no size-0 generator path; js-yaml dev-scope coverage tooling, not in the prod image) — hygiene, not an incident. Both patches sit inside the dependents' existing semver ranges, so no overrides were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)