### PR TITLE
feat(bottles): add more bottles directly from an existing bottle

### DIFF
--- a/frontend/src/api/bottles.js
+++ b/frontend/src/api/bottles.js
@@ -18,6 +18,15 @@ export const listBottles = (apiFetch, params = {}) => {
 export const getBottle = (apiFetch, id) =>
   apiFetch(`/api/bottles/${id}`);
 
+// Create ONE bottle (POST /api/bottles). There is no batch endpoint — a
+// multi-bottle add is N sequential calls of this (see AddMoreBottlesModal).
+export const createBottle = (apiFetch, data) =>
+  apiFetch('/api/bottles', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(data),
+  });
+
 export const updateBottle = (apiFetch, id, data) =>
   apiFetch(`/api/bottles/${id}`, {
     method: 'PUT',

--- a/frontend/src/components/AddMoreBottlesModal.js
+++ b/frontend/src/components/AddMoreBottlesModal.js
@@ -1,0 +1,174 @@
+import { useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import { createBottle } from '../api/bottles';
+import Modal from './Modal';
+
+// Cap per batch — this flow tops up a bottle you already registered (a case or
+// two), it is not the bulk importer. Matches the sequential-POST budget the
+// Add Bottle page tolerates.
+const MAX_MORE = 24;
+
+/**
+ * Add more bottles of a wine directly from a bottle you already registered —
+ * the answer to the support question "I added a bottle with Qty 1, how do I
+ * make it 6?" without re-searching the wine in Add Bottle (support reply
+ * promised 2026-08-10).
+ *
+ * Creating N bottles is N sequential POSTs, exactly like the Add Bottle page's
+ * own multi-bottle loop, including its partial-failure contract: on a
+ * mid-batch error the created/total count is reported (reusing
+ * addBottle.partialAdded) and a retry creates only the remainder — the bottles
+ * already created are real, there is no rollback. New bottles arrive unplaced;
+ * rack placement stays a separate step.
+ *
+ * Props: bottle (the populated bottle being viewed — must have a
+ * wineDefinition), onClose(), onAdded(count) — fired only when the whole
+ * batch succeeded.
+ */
+function AddMoreBottlesModal({ bottle, onClose, onAdded }) {
+  const { t } = useTranslation();
+  const { apiFetch } = useAuth();
+  const countId = useId();
+  const [count, setCount] = useState(1);
+  const [copyDetails, setCopyDetails] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  // Bottles already created by earlier attempts of THIS batch — a retry after
+  // a partial failure resumes here instead of duplicating the whole batch
+  // (same contract as AddBottle's createdBottlesRef).
+  const [createdSoFar, setCreatedSoFar] = useState(0);
+
+  // Instant clamp, like AddBottle's Number-of-bottles field, plus the cap.
+  const clampCount = (raw) => Math.min(MAX_MORE, Math.max(1, parseInt(raw, 10) || 1));
+
+  // Once part of the batch exists, its parameters are frozen — a retry must
+  // finish the SAME batch. Changing count or the copy toggle between attempts
+  // would silently mix differently-shaped bottles into one batch.
+  const locked = saving || createdSoFar > 0;
+
+  // What a copy is made of — only fields POST /api/bottles accepts (see
+  // backend bottleOps.addBottle):
+  // - wine / cellar / vintage / bottleSize always travel: "more of this
+  //   bottle" means the same wine, same vintage, same format, same cellar.
+  // - The details checkbox carries provenance: price, currency, purchase
+  //   info, notes, occasion.
+  // - Never copied: rating and the personal drink window (judgements about
+  //   that specific bottle, not the purchase), rack position (new bottles
+  //   arrive unplaced) and the migration helpers (dateAdded / addToHistory).
+  const buildPayload = () => {
+    const payload = {
+      cellar: bottle.cellar?._id || bottle.cellar,
+      wineDefinition: bottle.wineDefinition?._id || bottle.wineDefinition,
+      vintage: bottle.vintage,
+      bottleSize: bottle.bottleSize || undefined,
+    };
+    if (copyDetails) {
+      if (bottle.price != null) payload.price = bottle.price;
+      if (bottle.currency) payload.currency = bottle.currency;
+      if (bottle.purchaseDate) payload.purchaseDate = bottle.purchaseDate;
+      if (bottle.purchaseLocation) payload.purchaseLocation = bottle.purchaseLocation;
+      if (bottle.purchaseUrl) payload.purchaseUrl = bottle.purchaseUrl;
+      if (bottle.notes) payload.notes = bottle.notes;
+      if (bottle.occasion) payload.occasion = bottle.occasion;
+    }
+    return payload;
+  };
+
+  const handleSubmit = async () => {
+    // In-flight guard (belt to the disabled buttons): a second submit during
+    // the N sequential POSTs would duplicate bottles.
+    if (saving) return;
+    setSaving(true);
+    setError(null);
+    // AddBottle's partial-failure message, verbatim: report created/total and
+    // promise that a retry adds only the remaining bottles.
+    const partialError = (msg, done) => done > 0
+      ? t('addBottle.partialAdded', { msg, count: done, total: count, remaining: count - done })
+      : msg;
+    // Local counter, not the render closure: submit is single-flight (the
+    // button is disabled while saving), so createdSoFar is fresh here, and
+    // `done` advances it exactly — no snapshot drift across the awaits.
+    let done = createdSoFar;
+    try {
+      const payload = buildPayload();
+      for (let i = done; i < count; i++) {
+        const res = await createBottle(apiFetch, payload);
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          setError(partialError(data.error || t('addBottle.addFailed'), done));
+          return;
+        }
+        done += 1;
+        setCreatedSoFar(done);
+      }
+      onAdded(count);
+    } catch {
+      setError(partialError(t('common.networkError'), done));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Interlock: while the batch runs nothing may close the modal — overlay
+  // click, Escape and the ✕ all route through this guard.
+  const guardedClose = () => { if (!saving) onClose(); };
+
+  const wine = bottle.wineDefinition;
+  const hintStyle = { color: 'var(--color-text-muted)', fontSize: '0.85rem' };
+
+  return (
+    <Modal title={t('bottleDetail.addMore.title', 'Add more bottles')} onClose={guardedClose} showClose trapFocus>
+      <p style={{ marginTop: 0 }}>
+        <strong>{wine?.name}{bottle.vintage ? ` · ${bottle.vintage}` : ''}</strong>
+      </p>
+
+      <div className="form-group">
+        <label htmlFor={countId}>{t('bottleDetail.addMore.countLabel', 'How many more bottles?')}</label>
+        <input
+          id={countId}
+          type="number"
+          min="1"
+          max={MAX_MORE}
+          value={count}
+          onChange={(e) => setCount(clampCount(e.target.value))}
+          onFocus={(e) => e.target.select()}
+          disabled={locked}
+          required
+        />
+      </div>
+
+      <div className="form-group">
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <input
+            type="checkbox"
+            checked={copyDetails}
+            onChange={(e) => setCopyDetails(e.target.checked)}
+            disabled={locked}
+          />
+          <span>{t('bottleDetail.addMore.copyLabel', "Copy this bottle's details")}</span>
+        </label>
+        <p style={{ ...hintStyle, marginBottom: 0 }}>
+          {t('bottleDetail.addMore.copyHint', 'Price, purchase info, notes and occasion are copied from this bottle. Unticked, the new bottles start blank.')}
+        </p>
+      </div>
+
+      <p style={hintStyle}>
+        {t('bottleDetail.addMore.unplacedNote', 'The new bottles are added unplaced — placing them in a rack is a separate step, from the cellar page.')}
+      </p>
+
+      {error && <div className="alert alert-error" role="alert">{error}</div>}
+
+      <div className="modal-actions">
+        <button type="button" className="btn btn-secondary" onClick={onClose} disabled={saving}>
+          {t('common.cancel', 'Cancel')}
+        </button>
+        <button type="button" className="btn btn-success" onClick={handleSubmit} disabled={saving}>
+          {saving ? t('common.saving', 'Saving…') : t('bottleDetail.addMore.submit', { count })}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+export default AddMoreBottlesModal;

--- a/frontend/src/components/AddMoreBottlesModal.test.js
+++ b/frontend/src/components/AddMoreBottlesModal.test.js
@@ -1,0 +1,178 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('../api/bottles', () => ({
+  createBottle: vi.fn(),
+}));
+
+// `t` must keep a stable identity across renders, as react-i18next's real one
+// does (see WineLowConfidenceModal.test.js). Three-arg aware: the component
+// uses both t(key, defaultValue) and t(key, vars) — vars, wherever they sit,
+// are appended so plural/interpolation calls stay observable.
+vi.mock('react-i18next', () => {
+  const t = (key, a, b) => {
+    const vars = b && typeof b === 'object' ? b : (a && typeof a === 'object' ? a : undefined);
+    return vars ? `${key}:${JSON.stringify(vars)}` : key;
+  };
+  return { useTranslation: () => ({ t }) };
+});
+
+// Hoisted so the AuthContext mock factory may reference it safely.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: () => {} }));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ apiFetch }),
+}));
+
+const { createBottle } = await import('../api/bottles');
+const AddMoreBottlesModal = (await import('./AddMoreBottlesModal')).default;
+
+// A populated bottle as GET /api/bottles/:id returns it — including fields
+// that must NOT be copied (rating, drinkFrom/To), so the exact-payload
+// assertions below prove they stay behind.
+const BOTTLE = {
+  _id: 'b1',
+  cellar: 'c1',
+  wineDefinition: { _id: 'w1', name: 'Barolo Monfortino' },
+  vintage: '2016',
+  bottleSize: '750ml',
+  price: 120,
+  currency: 'EUR',
+  purchaseDate: '2026-05-01T00:00:00.000Z',
+  purchaseLocation: 'Systembolaget',
+  purchaseUrl: 'https://example.com/monfortino',
+  notes: 'Case of six from the release',
+  occasion: 'Anniversary case',
+  rating: 5,
+  ratingScale: '5',
+  drinkFrom: 2030,
+  drinkTo: 2045,
+};
+
+const COPIED_PAYLOAD = {
+  cellar: 'c1',
+  wineDefinition: 'w1',
+  vintage: '2016',
+  bottleSize: '750ml',
+  price: 120,
+  currency: 'EUR',
+  purchaseDate: '2026-05-01T00:00:00.000Z',
+  purchaseLocation: 'Systembolaget',
+  purchaseUrl: 'https://example.com/monfortino',
+  notes: 'Case of six from the release',
+  occasion: 'Anniversary case',
+};
+
+const ok = () => ({ ok: true, json: async () => ({ bottle: { _id: 'new' } }) });
+const fail = (error) => ({ ok: false, json: async () => ({ error }) });
+
+const countInput = () => screen.getByLabelText('bottleDetail.addMore.countLabel');
+const submitBtn = (n) => screen.getByText(`bottleDetail.addMore.submit:{"count":${n}}`);
+
+const renderModal = (props = {}) =>
+  render(
+    <AddMoreBottlesModal bottle={BOTTLE} onClose={() => {}} onAdded={() => {}} {...props} />
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('renders the count input (default 1), a ticked copy checkbox and the unplaced note', () => {
+  renderModal();
+  expect(countInput()).toHaveValue(1);
+  expect(screen.getByRole('checkbox')).toBeChecked();
+  expect(screen.getByText('bottleDetail.addMore.unplacedNote')).toBeInTheDocument();
+  expect(screen.getByText('Barolo Monfortino · 2016')).toBeInTheDocument();
+});
+
+test('the count input clamps to 1–24', () => {
+  renderModal();
+  fireEvent.change(countInput(), { target: { value: '99' } });
+  expect(countInput()).toHaveValue(24);
+  fireEvent.change(countInput(), { target: { value: '0' } });
+  expect(countInput()).toHaveValue(1);
+  fireEvent.change(countInput(), { target: { value: '' } });
+  expect(countInput()).toHaveValue(1);
+});
+
+test('submit fires one create per bottle with the copied payload and reports the count', async () => {
+  createBottle.mockResolvedValue(ok());
+  const onAdded = vi.fn();
+  renderModal({ onAdded });
+
+  fireEvent.change(countInput(), { target: { value: '3' } });
+  fireEvent.click(submitBtn(3));
+
+  await waitFor(() => expect(onAdded).toHaveBeenCalledWith(3));
+  expect(createBottle).toHaveBeenCalledTimes(3);
+  // Exact match — proves rating / drink window / dateAdded never travel.
+  expect(createBottle).toHaveBeenLastCalledWith(apiFetch, COPIED_PAYLOAD);
+});
+
+test('unticking "copy details" sends only wine, cellar, vintage and size', async () => {
+  createBottle.mockResolvedValue(ok());
+  const onAdded = vi.fn();
+  renderModal({ onAdded });
+
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.click(submitBtn(1));
+
+  await waitFor(() => expect(onAdded).toHaveBeenCalledWith(1));
+  expect(createBottle).toHaveBeenCalledWith(apiFetch, {
+    cellar: 'c1',
+    wineDefinition: 'w1',
+    vintage: '2016',
+    bottleSize: '750ml',
+  });
+});
+
+test('a mid-batch failure reports created/total, locks the batch shape, and a retry adds only the remainder', async () => {
+  createBottle
+    .mockResolvedValueOnce(ok())
+    .mockResolvedValueOnce(ok())
+    .mockResolvedValueOnce(fail('boom'));
+  const onAdded = vi.fn();
+  renderModal({ onAdded });
+
+  fireEvent.change(countInput(), { target: { value: '4' } });
+  fireEvent.click(submitBtn(4));
+
+  // AddBottle's partial-failure message, with the created/total/remaining split.
+  expect(
+    await screen.findByText('addBottle.partialAdded:{"msg":"boom","count":2,"total":4,"remaining":2}')
+  ).toBeInTheDocument();
+  expect(onAdded).not.toHaveBeenCalled();
+  expect(createBottle).toHaveBeenCalledTimes(3);
+  // Batch parameters freeze once part of the batch exists — a retry must
+  // finish the SAME batch, not a differently-shaped one.
+  expect(countInput()).toBeDisabled();
+  expect(screen.getByRole('checkbox')).toBeDisabled();
+
+  createBottle.mockResolvedValue(ok());
+  fireEvent.click(submitBtn(4));
+
+  await waitFor(() => expect(onAdded).toHaveBeenCalledWith(4));
+  // 3 calls before + only the 2 missing bottles on retry, never 4 again.
+  expect(createBottle).toHaveBeenCalledTimes(5);
+});
+
+test('everything is disabled and the modal cannot be closed while the batch runs', async () => {
+  let release;
+  createBottle.mockImplementation(() => new Promise((resolve) => { release = resolve; }));
+  const onAdded = vi.fn();
+  const onClose = vi.fn();
+  const { container } = renderModal({ onAdded, onClose });
+
+  fireEvent.click(submitBtn(1));
+
+  expect(screen.getByText('common.saving')).toBeDisabled();
+  expect(screen.getByText('common.cancel')).toBeDisabled();
+  expect(countInput()).toBeDisabled();
+  expect(screen.getByRole('checkbox')).toBeDisabled();
+  // Overlay click and Escape route through the same guarded close.
+  fireEvent.click(container.querySelector('.modal-overlay'));
+  fireEvent.keyDown(document, { key: 'Escape' });
+  expect(onClose).not.toHaveBeenCalled();
+
+  release(ok());
+  await waitFor(() => expect(onAdded).toHaveBeenCalledWith(1));
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -966,7 +966,19 @@
     "structure": "Structure",
     "flavours": "Flavours",
     "pairsWith": "Pairs with",
-    "consumeError": "Failed to remove bottle"
+    "consumeError": "Failed to remove bottle",
+    "addMore": {
+      "action": "Add more bottles",
+      "title": "Add more bottles",
+      "countLabel": "How many more bottles?",
+      "copyLabel": "Copy this bottle's details",
+      "copyHint": "Price, purchase info, notes and occasion are copied from this bottle. Unticked, the new bottles start blank.",
+      "unplacedNote": "The new bottles are added unplaced — placing them in a rack is a separate step, from the cellar page.",
+      "submit_one": "Add {{count}} bottle",
+      "submit_other": "Add {{count}} bottles",
+      "success_one": "{{count}} more bottle added to this cellar. It's unplaced — place it from the cellar page whenever you like.",
+      "success_other": "{{count}} more bottles added to this cellar. They're unplaced — place them from the cellar page whenever you like."
+    }
   },
   "bottles": {
     "title": "All bottles",

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -33,6 +33,7 @@ const ReviewForm = lazy(() => import('../components/ReviewForm'));
 const ConsumeModal = lazy(() => import('../components/ConsumeModal').then(m => ({ default: m.ConsumeModal })));
 const SuggestGrapesModal = lazy(() => import('../components/SuggestGrapesModal').then(m => ({ default: m.SuggestGrapesModal })));
 const RecommendWineModal = lazy(() => import('../components/RecommendWineModal'));
+const AddMoreBottlesModal = lazy(() => import('../components/AddMoreBottlesModal'));
 
 function BottleDetail() {
   const { t } = useTranslation();
@@ -61,6 +62,8 @@ function BottleDetail() {
   const [mistakeOpen, setMistakeOpen] = useState(false);
   const [mistakeBusy, setMistakeBusy] = useState(false);
   const [suggestGrapesOpen, setSuggestGrapesOpen] = useState(false);
+  const [addMoreOpen, setAddMoreOpen] = useState(false);
+  const [addMoreMsg, setAddMoreMsg] = useState(null); // success banner after "Add more bottles"
   const [reportWineOpen, setReportWineOpen] = useState(false);
   const [reportDefaultReason, setReportDefaultReason] = useState(null);
   const [recommendOpen, setRecommendOpen] = useState(false);
@@ -320,9 +323,20 @@ function BottleDetail() {
     (Date.now() - new Date(bottle.consumedAt).getTime()) <= RESTORE_WINDOW_MS;
 
   // Shared overflow-menu contents — same list used by the desktop header ⋮ and
-  // the mobile bar ⋮, so the rare actions live in exactly one place.
+  // the mobile bar ⋮, so these actions live in exactly one place and can never
+  // drift between the page's two action surfaces.
   const overflowItems = (
     <>
+      {/* "Add more bottles" — the support answer to "I added Qty 1, how do I
+          make it 6?" without re-searching in Add Bottle (promised 2026-08-10).
+          Needs a real registry wine to clone (pending-request bottles have
+          none) and a non-demo account (POST /api/bottles is requireNonDemo,
+          same gate that hides the Add Bottle form in the demo). */}
+      {canEdit && wine && !user?.isDemo && (
+        <button className="bd-overflow-item" role="menuitem" onClick={() => { setAddMoreOpen(true); setBdMoreOpen(false); }}>
+          <span aria-hidden="true">➕</span> {t('bottleDetail.addMore.action', 'Add more bottles')}
+        </button>
+      )}
       {canMove && (
         <button className="bd-overflow-item" role="menuitem" onClick={() => { setMoveOpen(true); setBdMoreOpen(false); }}>
           <span aria-hidden="true">📦</span> {t('moveBottle.action')}
@@ -339,6 +353,14 @@ function BottleDetail() {
   const handleMoved = () => {
     setMoveOpen(false);
     navigate(`/cellars/${cellarId}`); // stay with the source cellar — back to its list
+  };
+
+  const handleAddedMore = (n) => {
+    setAddMoreOpen(false);
+    setAddMoreMsg(t('bottleDetail.addMore.success', { count: n }));
+    // Same refresh path every other mutation on this page uses (edit, open):
+    // re-pull the bottle + its cellar/rack context after the cellar changed.
+    fetchBottle();
   };
 
   const handleRestore = async () => {
@@ -375,6 +397,22 @@ function BottleDetail() {
           </button>
         </div>
       )}
+      {/* Confirmation after "Add more bottles" — same dismissible-banner shape
+          as the error banner above, since the modal is gone by the time the
+          batch result matters. */}
+      {addMoreMsg && (
+        <div className="alert alert-success" role="status">
+          {addMoreMsg}
+          <button
+            type="button"
+            className="btn btn-small btn-secondary"
+            style={{ marginLeft: '0.75rem' }}
+            onClick={() => setAddMoreMsg(null)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
       {/* ── Clean header ── */}
       <div className="bd-page-header">
         <div className="bd-header-top">
@@ -401,8 +439,9 @@ function BottleDetail() {
                   </button>
                 </>
               )}
-              {/* Rare actions (Move, Added by mistake) live in the overflow —
-                  frequent actions stay visible, so the bar fits on phones too */}
+              {/* Less-frequent actions (Add more, Move, Added by mistake) live
+                  in the overflow — frequent actions stay visible, so the bar
+                  fits on phones too */}
               {(canMove || canEdit) && (
                 <div className="bd-overflow-wrap">
                   <button
@@ -708,8 +747,9 @@ function BottleDetail() {
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M8 2h8l4 10H4L8 2z"/><path d="M12 12v6"/><path d="M8 22h8"/></svg>
             {t('bottleDetail.removeBottleShort')}
           </button>
-          {/* Rare actions (Move, Added by mistake) — keeps the bar to three
-              visible buttons so nothing gets cut off on narrow screens */}
+          {/* Less-frequent actions (Add more, Move, Added by mistake) — keeps
+              the bar to three visible buttons so nothing gets cut off on
+              narrow screens */}
           {(canMove || canEdit) && (
             <div className="bd-overflow-wrap bd-overflow-wrap--mobile">
               <button className="bd-mobile-action-btn bd-mobile-action-more" onClick={() => setBdMoreOpen(o => !o)} aria-label={t('cellarDetail.moreActions')} aria-haspopup="menu" aria-expanded={bdMoreOpen}>
@@ -791,6 +831,14 @@ function BottleDetail() {
           <SuggestGrapesModal
             wine={wine}
             onClose={() => setSuggestGrapesOpen(false)}
+          />
+        )}
+
+        {addMoreOpen && bottle && (
+          <AddMoreBottlesModal
+            bottle={bottle}
+            onClose={() => setAddMoreOpen(false)}
+            onAdded={handleAddedMore}
           />
         )}
 


### PR DESCRIPTION
## The feature promised in mjo's support reply (2026-08-10)

"I added a bottle with Qty 1 — how do I make it 6?" Until now the only answer was to re-search the wine on Add Bottle and set Number of bottles again. This PR puts an **"Add more bottles"** action directly on the bottle page: pick how many (1–24), optionally copy the bottle's details, done. Frontend-only — creating N bottles is N sequential `POST /api/bottles`, exactly the loop the Add Bottle page already runs, so no new backend surface.

### What a copy is made of

- **Always:** cellar, wine, vintage, bottle size — "more of this bottle" means the same wine, same vintage, same format, same cellar (size is identity: a magnum owner must not silently get 750 ml copies).
- **"Copy this bottle's details" (default ON):** price, currency, purchase date/location/URL, notes, occasion — the provenance of the purchase.
- **Never:** rating and the personal drink window (judgements about that specific bottle), rack position (new bottles arrive unplaced — the modal says so), and the migration-only helpers. An exact-equality test assertion proves these never travel.

### Where it lives

Prepended to the shared `overflowItems` list, which **both** action surfaces render — the desktop header ⋮ and the ≤768 px `.bd-mobile-actions` ⋮ — so one insertion covers both with zero drift. A visible fourth button was ruled out: the mobile bar's in-code comment caps it at three visible buttons so nothing gets cut off on narrow screens. Gated on `canEdit && wine && !user?.isDemo` (pending-request bottles have no registry wine to clone; `POST /api/bottles` is requireNonDemo).

### Partial failure — AddBottle's contract, verbatim

A mid-batch error reports created/total with the existing `addBottle.partialAdded` message and a retry creates **only the remainder**; no invented rollback. One improvement over AddBottle: the count and the copy toggle freeze once part of the batch exists, so a retry can't mix differently-shaped bottles into one batch. While the batch runs, inputs, both buttons, overlay-click and Escape are all inert. Success → dismissible banner with pluralized count + the page's canonical `fetchBottle()` refresh.

### Tests

6 new vitest/RTL tests against the real shared Modal (render defaults, 1–24 clamp, exact copied payload ×N, unticked minimal payload, partial-failure → freeze → resume-from-created retry, full interlock incl. overlay/Escape). Full frontend suite on the branch: **52 files, 896 tests, green**. Locale keys en-only with complete `_one`/`_other` plural families.

### Notes for review

- Copies inherit the source bottle's purchase date — intentional ("same purchase"), flag if you'd rather default to today.
- Vintage-less source bottles are safe: the create path coerces absent vintage to `NV` server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
