### PR TITLE
fix(audit): remediate the 2026-08-10 diff-audit LOWs

### DIFF
--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -571,6 +571,7 @@ router.delete('/verify-checks', async (req, res) => {
   try {
     const ids = [...new Set((Array.isArray(req.body?.wineIds) ? req.body.wineIds : []).filter(isValidId))];
     if (ids.length < 1) return res.status(400).json({ error: 'wineIds must contain at least 1 valid id' });
+    if (ids.length > 500) return res.status(400).json({ error: 'At most 500 wineIds per call' });
 
     const raw = Array.isArray(req.body?.checks) ? req.body.checks : null;
     const specs = (raw || []).map(resolveCheck);
@@ -1154,9 +1155,10 @@ router.post('/cross-checks-clear', async (req, res) => {
     const now = new Date();
     const ops = [];
     const notFlagged = [];
-    for (const id of ids) {
-      const tripped = hitsById.get(id);
-      if (tripped === undefined) continue; // wine not found — reported via updated count
+    // Iterate the FOUND docs (map keys are canonical String(_id)), not the
+    // client array — a case-variant id that the $in query matched must not
+    // silently fall out of the clearance (same shape as /verify-checks).
+    for (const [id, tripped] of hitsById) {
       if (tripped.length === 0) { notFlagged.push(id); continue; }
       ops.push({ updateOne: {
         filter: { _id: new mongoose.Types.ObjectId(id) },
@@ -1184,6 +1186,7 @@ router.delete('/cross-checks-clear', async (req, res) => {
   try {
     const ids = [...new Set((Array.isArray(req.body?.wineIds) ? req.body.wineIds : []).filter(isValidId))];
     if (ids.length < 1) return res.status(400).json({ error: 'wineIds must contain at least 1 valid id' });
+    if (ids.length > 500) return res.status(400).json({ error: 'At most 500 wineIds per call' });
 
     const raw = Array.isArray(req.body?.checks) ? req.body.checks : null;
     const specs = (raw || []).map(resolveCrossFieldCheck);

--- a/backend/src/services/crossFieldScan.js
+++ b/backend/src/services/crossFieldScan.js
@@ -46,8 +46,10 @@ async function loadContext() {
 /** The string-only row shape the rules (and the queue UI) consume. */
 const flattenWine = (w, regionNamesById, countryNamesById) => ({
   _id: w._id,
-  name: w.name,
-  producer: w.producer,
+  // String-coerce: one raw-driver-written non-string row must not throw and
+  // take the whole scan (and the weekly metrics run) down with it.
+  name: w.name == null ? '' : String(w.name),
+  producer: w.producer == null ? '' : String(w.producer),
   appellation: w.appellation || null,
   region: w.region ? (regionNamesById.get(String(w.region)) || null) : null,
   country: w.country ? (countryNamesById.get(String(w.country)) || null) : null,

--- a/backend/src/utils/__snapshots__/crossFieldChecks.snapshot.test.js.snap
+++ b/backend/src/utils/__snapshots__/crossFieldChecks.snapshot.test.js.snap
@@ -31,9 +31,9 @@ exports[`detect() source of producer-is-grape.v1 is unchanged — bump the id if
 
 exports[`detect() source of producer-is-region.v1 is unchanged — bump the id if you edited it 1`] = `"(w, refs) => lookupEntity(refs.regions, w.producer)"`;
 
-exports[`detect() source of producer-is-style-term.v1 is unchanged — bump the id if you edited it 1`] = `
+exports[`detect() source of producer-is-style-term.v2 is unchanged — bump the id if you edited it 1`] = `
 "w => {
-    const tokens = normalizeString(w.producer || '').split(' ').filter(Boolean);
+    const tokens = normalizeString((w.producer || '').replace(/ß/g, 'ss')).split(' ').filter(Boolean);
     if (tokens.length === 0) return null;
     const matched = [];
     for (const t of tokens) {
@@ -74,7 +74,7 @@ exports[`rule ids are pinned (adding/removing/renaming a rule must be deliberate
   "producer-is-region.v1",
   "producer-is-country.v1",
   "producer-is-grape.v1",
-  "producer-is-style-term.v1",
+  "producer-is-style-term.v2",
   "producer-placeholder.v1",
   "producer-parenthetical.v1",
   "name-in-producer.v1",

--- a/backend/src/utils/crossFieldChecks.js
+++ b/backend/src/utils/crossFieldChecks.js
@@ -96,17 +96,19 @@ function buildCrossFieldRefs({ appellations = [], regions = [], countries = [], 
 }
 
 // Style vocabulary for producer-is-style-term, pre-normalized (normalizeString
-// folds "Roșu" → 'rosu', "off-dry" → 'offdry', "süß" → 'sus'). Two tiers:
-// STYLE words are EVIDENCE a string is a style descriptor; FILLER words
-// merely don't count against it. A multi-token producer flags only when EVERY
-// token is style-or-filler AND at least one is style — "Roșu Demidulce"
-// flags, "Château Doux Rivage" must not (rivage is a real word).
+// folds "Roșu" → 'rosu' and "off-dry" → 'offdry'; ß is NOT decomposable and
+// would be stripped outright, so the detect pre-folds ß→ss before normalizing
+// — "süß" → 'suss', "Weiß" → 'weiss'). Two tiers: STYLE words are EVIDENCE a
+// string is a style descriptor; FILLER words merely don't count against it. A
+// multi-token producer flags only when EVERY token is style-or-filler AND at
+// least one is style — "Roșu Demidulce" flags, "Château Doux Rivage" must not
+// (rivage is a real word).
 const STYLE_WORDS = new Set([
   // sweetness / dryness scales across label languages
   'demidulce', 'demisec', 'dulce', 'seco', 'semiseco', 'semidulce',
   'abboccato', 'amabile', 'halbtrocken', 'feinherb', 'trocken', 'lieblich',
   'offdry', 'semisweet', 'moelleux', 'doux', 'brut', 'sec', 'dry', 'sweet',
-  'sus', 'suss', 'edes',
+  'suss', 'edes',
   // colour-as-style — the other half of the "Roșu Demidulce" prod row
   'rosu', 'alb', 'negru', 'rosso', 'bianco', 'rosato', 'tinto', 'blanco',
   'rouge', 'blanc', 'rose', 'rot', 'weiss', 'red', 'white',
@@ -205,13 +207,14 @@ const CROSS_FIELD_CHECKS = [
   {
     // "Roșu Demidulce" (= semi-sweet red) as producer. Every token must be a
     // style/filler word, with at least one style word — see the vocabulary
-    // comment above for why "Château Doux Rivage" never flags.
-    id: 'producer-is-style-term.v1',
+    // comment above for why "Château Doux Rivage" never flags. v2: pre-fold
+    // ß→ss so "Süß"/"Weiß" reach the vocabulary (normalizeString deletes ß).
+    id: 'producer-is-style-term.v2',
     labelKey: 'producerIsStyleTerm',
     field: 'producer',
     defaultActive: true,
     detect: (w) => {
-      const tokens = normalizeString(w.producer || '').split(' ').filter(Boolean);
+      const tokens = normalizeString((w.producer || '').replace(/ß/g, 'ss')).split(' ').filter(Boolean);
       if (tokens.length === 0) return null;
       const matched = [];
       for (const t of tokens) {

--- a/backend/src/utils/crossFieldChecks.test.js
+++ b/backend/src/utils/crossFieldChecks.test.js
@@ -143,8 +143,8 @@ describe('producer-is-grape.v1', () => {
   });
 });
 
-describe('producer-is-style-term.v1', () => {
-  const detect = byId('producer-is-style-term.v1').detect;
+describe('producer-is-style-term.v2', () => {
+  const detect = byId('producer-is-style-term.v2').detect;
 
   test('flags the evidence row "Roșu Demidulce" (every token is style vocabulary)', () => {
     expect(detect({ producer: 'Roșu Demidulce' })).toBe('rosu demidulce');
@@ -154,6 +154,12 @@ describe('producer-is-style-term.v1', () => {
     expect(detect({ producer: 'Brut' })).toBe('brut');
     expect(detect({ producer: 'Halbtrocken' })).toBe('halbtrocken');
     expect(detect({ producer: 'Vin Demisec' })).toBe('demisec'); // 'vin' is filler, not evidence
+  });
+
+  test('v2: ß spellings reach the vocabulary (normalizeString alone deletes ß)', () => {
+    expect(detect({ producer: 'Süß' })).toBe('suss');
+    expect(detect({ producer: 'Weiß' })).toBe('weiss');
+    expect(detect({ producer: 'Süß Rot' })).toBe('suss rot');
   });
 
   test('one real word disarms it: "Château Doux Rivage" must not flag', () => {
@@ -333,7 +339,7 @@ describe('mental dry-run against the 2026-08-10 evidence rows', () => {
     [{ producer: 'Monbazillac', name: 'Sec' }, 'producer-is-appellation.v1'],
     [{ producer: 'Dragasani', name: 'Feteasca' }, 'producer-is-region.v1'],
     [{ producer: 'Domaine unknown', name: 'Rouge' }, 'producer-placeholder.v1'],
-    [{ producer: 'Roșu Demidulce', name: 'X' }, 'producer-is-style-term.v1'],
+    [{ producer: 'Roșu Demidulce', name: 'X' }, 'producer-is-style-term.v2'],
     [{ producer: 'The Freaky Wines', name: 'Wines' }, 'name-in-producer.v1'],
     [{ producer: "Trader Joe's (Bersano Estate)", name: 'Barolo' }, 'producer-parenthetical.v1'],
     [{ producer: 'X', name: 'Y', appellation: 'Cabernet Sauvignon' }, 'appellation-is-grape.v1'],

--- a/frontend/src/components/AddMoreBottlesModal.js
+++ b/frontend/src/components/AddMoreBottlesModal.js
@@ -49,10 +49,12 @@ function AddMoreBottlesModal({ bottle, onClose, onAdded }) {
 
   // What a copy is made of — only fields POST /api/bottles accepts (see
   // backend bottleOps.addBottle):
-  // - wine / cellar / vintage / bottleSize always travel: "more of this
-  //   bottle" means the same wine, same vintage, same format, same cellar.
-  // - The details checkbox carries provenance: price, currency, purchase
-  //   info, notes, occasion.
+  // - wine / cellar / vintage / bottleSize / currency always travel: "more of
+  //   this bottle" means the same wine, same vintage, same format, same
+  //   cellar — and the same currency even when details are unticked, because
+  //   the backend otherwise defaults a blank copy to USD (bottleOps).
+  // - The details checkbox carries provenance: price, purchase info, notes,
+  //   occasion.
   // - Never copied: rating and the personal drink window (judgements about
   //   that specific bottle, not the purchase), rack position (new bottles
   //   arrive unplaced) and the migration helpers (dateAdded / addToHistory).
@@ -63,9 +65,9 @@ function AddMoreBottlesModal({ bottle, onClose, onAdded }) {
       vintage: bottle.vintage,
       bottleSize: bottle.bottleSize || undefined,
     };
+    if (bottle.currency) payload.currency = bottle.currency;
     if (copyDetails) {
       if (bottle.price != null) payload.price = bottle.price;
-      if (bottle.currency) payload.currency = bottle.currency;
       if (bottle.purchaseDate) payload.purchaseDate = bottle.purchaseDate;
       if (bottle.purchaseLocation) payload.purchaseLocation = bottle.purchaseLocation;
       if (bottle.purchaseUrl) payload.purchaseUrl = bottle.purchaseUrl;

--- a/frontend/src/components/AddMoreBottlesModal.test.js
+++ b/frontend/src/components/AddMoreBottlesModal.test.js
@@ -108,7 +108,7 @@ test('submit fires one create per bottle with the copied payload and reports the
   expect(createBottle).toHaveBeenLastCalledWith(apiFetch, COPIED_PAYLOAD);
 });
 
-test('unticking "copy details" sends only wine, cellar, vintage and size', async () => {
+test('unticking "copy details" sends only wine, cellar, vintage, size and currency', async () => {
   createBottle.mockResolvedValue(ok());
   const onAdded = vi.fn();
   renderModal({ onAdded });
@@ -117,11 +117,14 @@ test('unticking "copy details" sends only wine, cellar, vintage and size', async
   fireEvent.click(submitBtn(1));
 
   await waitFor(() => expect(onAdded).toHaveBeenCalledWith(1));
+  // Currency still travels — a blank copy must not fall back to the backend's
+  // USD default for a non-USD user.
   expect(createBottle).toHaveBeenCalledWith(apiFetch, {
     cellar: 'c1',
     wineDefinition: 'w1',
     vintage: '2016',
     bottleSize: '750ml',
+    currency: 'EUR',
   });
 });
 

--- a/frontend/src/components/WineCrossFieldChecksModal.js
+++ b/frontend/src/components/WineCrossFieldChecksModal.js
@@ -146,6 +146,11 @@ function WineCrossFieldChecksModal({ apiFetch, onClose }) {
       if (res.ok) {
         setPendingUndo(null);
         fetchPage(page);
+      } else {
+        // Row may already be gone from the list, so surface at modal level —
+        // the banner stays so the admin can retry.
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || `Failed to undo (${res.status})`);
       }
     } catch { /* the banner stays; the admin can retry */ } finally {
       setPending(null);


### PR DESCRIPTION
## Remediation of the 2026-08-10 post-merge diff audit (v1.102.0..main)

Three audit agents (backend #920 / frontend #921 / security) all returned **SHIP with zero critical/high/medium findings**. Six LOWs surfaced; this PR fixes five and defers one.

### Fixed
- **Currency on blank copies** (`AddMoreBottlesModal`): currency now always copies from the source bottle — with "Copy this bottle's details" unticked, new bottles for an EUR user were stored as USD (the backend default) and priced against USD community data. One line + test updated.
- **Silent undo failure** (`WineCrossFieldChecksModal`): a non-OK response to the clearance-undo now surfaces a modal-level error (the row may already be gone from the list, so row-level would be invisible). The banner stays for retry.
- **Case-variant ObjectId no-op** (`POST /cross-checks-clear`): ops are now built from the found docs (canonical ids) instead of the raw client array — an uppercase-hex id that the `$in` query matched could previously fall out of the map lookup and silently clear nothing. Mirrors `/verify-checks`.
- **Scan hardening** (`crossFieldScan.flattenWine`): name/producer String-coerced so a raw-driver-written non-string row cannot throw through the admin route *and* reject the weekly health-job metrics run.
- **`producer-is-style-term` → `.v2`**: `normalizeString` deletes `ß` (not decomposable), so `"Süß"`/`"Weiß"` — the exact class the rule targets — could never match; the vocabulary comment claimed otherwise and carried a dead unreachable entry. The detect now pre-folds `ß→ss`, per the module's own discipline the id is bumped, and **now is the uniquely cheap moment**: the feature is unreleased, so zero prod clearances exist for the bump to invalidate. Snapshot rolled v1→v2.
- **500-id cap on both DELETE clearance endpoints** (security INFO-1): the POST twins had it; the DELETEs now match.

### Deferred (with rationale)
- Stranded-empty-page after totals shrink across a page boundary (frontend LOW-1) — byte-identical inherited behavior from the sibling name-checks modal; fix belongs in one pass across all sibling modals.

### Tests
- Backend in node:20-alpine: crossField rules + snapshot (1 removed / 1 written / 1 updated) + scan + route + health job + verify-checks route — **119 tests green**.
- Frontend: full suite **52 files / 896 tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
