### PR TITLE
chore(release): v1.103.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.102.0",
+      "version": "1.103.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.102.0",
+      "version": "1.103.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for v1.103.0.

Contents since v1.102.0: #918 NV-offset doc fix (MCP) · #919 nanoid+js-yaml Dependabot highs · #920 cross-field domain checks (misplaced-entity review queue) · #921 add more bottles from an existing bottle (mjo's promised feature) · #922 diff-audit LOW remediation · #923 enrichment Type-authoritative prompt rule.

Audited 2026-08-10: 3 agents (backend/frontend/security), SHIP with zero C/H/M; LOWs remediated in #922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)