### PR TITLE
fix(somm): report grape-name substitutions instead of silently canonicalising

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -392,6 +392,23 @@ describe('set_wine_profile', () => {
     expect(McpActionLog.create.mock.calls[0][0].prev).toMatchObject({ type: 'fortified', grapes: [] });
   });
 
+  // Ticket 2026-08-11: "Tinta Roriz" was silently stored as Tempranillo. The
+  // canonicalisation itself is the design (one variety doc keeps search and
+  // stats coherent) — but the response must SAY it happened, at every reading
+  // depth: summary, record payload, and note.
+  test('a synonym-stored grape is REPORTED as a substitution, never silent', async () => {
+    const w = wine({ type: 'fortified', grapes: [] });
+    Grape.findOne.mockReturnValue(chain({ _id: oid('9'), name: 'Tempranillo' }));
+    const body = parse(await tool('set_wine_profile').handler(
+      { wine_id: oid('f'), grapes: ['Tinta Roriz'] }, SOMM_CTX));
+    expect(body.error).toBeUndefined();
+    expect(w.grapes).toEqual([oid('9')]);
+    expect(body.summary).toMatch(/"Tinta Roriz" as Tempranillo/);
+    expect(body.data.record.grapes).toEqual(['Tempranillo']);
+    expect(body.data.record.grape_substitutions).toEqual(['Tinta Roriz → Tempranillo']);
+    expect(body.data.note).toMatch(/canonical variety doc/);
+  });
+
   test('an unknown grape variety refuses the whole write — match-only, nothing minted', async () => {
     const w = wine({ type: 'white', grapes: [] });
     Grape.findOne.mockReturnValue(chain(null));

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -400,6 +400,7 @@ registerTool({
     // Names → taxonomy ids, match-only: an unknown variety fails loudly here
     // rather than minting junk taxonomy every owner then sees.
     let grapeNames = null;
+    let grapeSubs = [];
     if (Array.isArray(check.clean.grapes) && check.clean.grapes.length > 0) {
       const resolved = await resolveGrapeIdsStrict(check.clean.grapes);
       if (!resolved.ok) {
@@ -409,6 +410,7 @@ registerTool({
       }
       check.clean.grapes = resolved.ids;
       grapeNames = resolved.names;
+      grapeSubs = resolved.substitutions || [];
     } else if (Array.isArray(check.clean.grapes)) {
       grapeNames = [];
     }
@@ -446,8 +448,15 @@ registerTool({
     const outcome = !profileTouched
       ? 'record fields corrected'
       : curatorNow ? 'now curator-verified' : 'cleared — still eligible for AI enrichment';
+    // The write path must SAY when it stores something other than what the
+    // curator sent (ticket 2026-08-11: "Tinta Roriz" silently became
+    // Tempranillo) — surfaced in the summary, the record, AND the note so no
+    // reading depth misses it.
+    const subsLine = grapeSubs.length
+      ? ` — stored under canonical variety name${grapeSubs.length > 1 ? 's' : ''}: ${grapeSubs.map((s) => `"${s.from}" as ${s.to}`).join(', ')}`
+      : '';
     const envelope = {
-      summary: `${wine.producer} — ${wine.name} updated (${outcome})`,
+      summary: `${wine.producer} — ${wine.name} updated (${outcome})${subsLine}`,
       data: {
         wine_id: wine._id,
         updated_fields: Object.keys(check.clean),
@@ -464,12 +473,16 @@ registerTool({
         record: {
           type: wine.type || null,
           ...(grapeNames !== null ? { grapes: grapeNames } : {}),
+          ...(grapeSubs.length ? { grape_substitutions: grapeSubs.map((s) => `${s.from} → ${s.to}`) } : {}),
         },
-        note: profileTouched
+        note: (profileTouched
           ? (curatorNow
             ? 'The AI enrichment job will no longer overwrite this wine.'
             : 'Cleared without verifying — the AI enrichment job may regenerate this profile.')
-          : 'Type/grape corrections do not claim the tasting profile was verified.',
+          : 'Type/grape corrections do not claim the tasting profile was verified.')
+          + (grapeSubs.length
+            ? ' Grape names are stored under their canonical variety doc (same variety, canonical display) — see grape_substitutions.'
+            : ''),
         undo: 'undo_last restores the previous profile and its provenance',
       },
     };

--- a/backend/src/routes/somm/wineProfile.js
+++ b/backend/src/routes/somm/wineProfile.js
@@ -65,12 +65,14 @@ router.put('/:wineId', requireSommOrAdmin, async (req, res) => {
     const check = validateProfilePatch(req.body);
     if (!check.ok) return res.status(400).json({ error: check.error });
 
+    let grapeSubstitutions = [];
     if (Array.isArray(check.clean.grapes) && check.clean.grapes.length > 0) {
       const resolved = await resolveGrapeIdsStrict(check.clean.grapes);
       if (!resolved.ok) {
         return res.status(400).json({ error: `Not in the grape taxonomy: ${resolved.unmatched.join(', ')}` });
       }
       check.clean.grapes = resolved.ids;
+      grapeSubstitutions = resolved.substitutions || [];
     }
 
     const wine = await WineDefinition.findById(req.params.wineId);
@@ -101,6 +103,9 @@ router.put('/:wineId', requireSommOrAdmin, async (req, res) => {
       // Additive: present so the panel can reflect record corrections too.
       type: wine.type,
       grapes: wine.grapes,
+      // The write path says when it stored a different name than was sent
+      // (synonym/static-map canonicalisation — ticket 2026-08-11).
+      grapeSubstitutions,
     });
   } catch (error) {
     console.error('Update wine profile error:', error);

--- a/backend/src/services/wineProfileOps.js
+++ b/backend/src/services/wineProfileOps.js
@@ -182,8 +182,13 @@ function validateProfilePatch(patch) {
  * genuinely new variety is an admin taxonomy add first.
  *
  * @param {string[]} names  cleaned names from validateProfilePatch
- * @returns {Promise<{ok:true, ids:any[], names:string[]}|{ok:false, unmatched:string[]}>}
+ * @returns {Promise<{ok:true, ids:any[], names:string[], substitutions:{from:string,to:string}[]}|{ok:false, unmatched:string[]}>}
  *          `names` echoes the CANONICAL display names, for response payloads.
+ *          `substitutions` lists every input stored under a DIFFERENT name
+ *          (synonym or static-map hop, e.g. "Tinta Roriz" → Tempranillo) —
+ *          the write path must SAY when it overrides what the curator typed
+ *          (somm ticket 2026-08-11), so callers surface these in responses.
+ *          Case/diacritic-only differences are not substitutions.
  */
 async function resolveGrapeIdsStrict(names) {
   // Lazy requires, matching the module's load-lean convention: the pure
@@ -193,6 +198,7 @@ async function resolveGrapeIdsStrict(names) {
   const ids = [];
   const canonical = [];
   const unmatched = [];
+  const substitutions = [];
   const seen = new Set();
   for (const raw of names) {
     const resolved = resolveGrapeName(raw);
@@ -210,11 +216,14 @@ async function resolveGrapeIdsStrict(names) {
     if (grape) {
       ids.push(grape._id);
       canonical.push(grape.name);
+      if (normalizeString(raw) !== normalizeString(grape.name)) {
+        substitutions.push({ from: String(raw).trim(), to: grape.name });
+      }
     } else {
       unmatched.push(raw);
     }
   }
-  return unmatched.length ? { ok: false, unmatched } : { ok: true, ids, names: canonical };
+  return unmatched.length ? { ok: false, unmatched } : { ok: true, ids, names: canonical, substitutions };
 }
 
 /** The fields an undo needs to put back, captured before mutation. */

--- a/backend/src/services/wineProfileOps.test.js
+++ b/backend/src/services/wineProfileOps.test.js
@@ -119,12 +119,24 @@ describe('resolveGrapeIdsStrict (match-only)', () => {
   const found = (doc) => ({ select: () => ({ lean: () => Promise.resolve(doc) }) });
   beforeEach(() => jest.clearAllMocks());
 
-  test('resolves a synonym to its canonical taxonomy doc and echoes the display name', async () => {
+  test('resolves a synonym to its canonical doc — and REPORTS the substitution', async () => {
     Grape.findOne.mockReturnValue(found({ _id: 'g-syrah', name: 'Syrah' }));
     const r = await resolveGrapeIdsStrict(['Shiraz']);
-    expect(r).toEqual({ ok: true, ids: ['g-syrah'], names: ['Syrah'] });
+    // Ticket 2026-08-11: "Tinta Roriz" silently became Tempranillo — the
+    // resolver must flag every stored-name override so callers can surface it.
+    expect(r).toEqual({
+      ok: true, ids: ['g-syrah'], names: ['Syrah'],
+      substitutions: [{ from: 'Shiraz', to: 'Syrah' }],
+    });
     // The lookup must consult synonyms, same as findOrCreateGrapes.
     expect(Grape.findOne.mock.calls[0][0].$or).toBeDefined();
+  });
+
+  test('case/diacritic-only differences are NOT substitutions', async () => {
+    Grape.findOne.mockReturnValue(found({ _id: 'g-syrah', name: 'Syrah' }));
+    const r = await resolveGrapeIdsStrict(['syrah']);
+    expect(r.substitutions).toEqual([]);
+    expect(r.names).toEqual(['Syrah']);
   });
 
   test('an unknown variety refuses the whole write — never mints taxonomy', async () => {


### PR DESCRIPTION
## The stopgap from this morning's somm ticket (MED)

`set_wine_profile` with `grapes: ["Tinta Roriz"]` on a Douro Port stored the Tempranillo doc — right variety, canonical display name — and nothing in the response said the curator's input had been rewritten. The curator's minimum ask: **the write path should say when it overrides what the curator sent.**

This PR is exactly that stopgap. The canonicalisation itself stays (one variety doc per grape keeps `find_similar_wines`, stats and pairing on one vocabulary — and the curator agrees: Pinot Nero→Pinot Noir is the right call). What changes:

- `resolveGrapeIdsStrict` now returns `substitutions: [{from, to}]` for every stored-name override (synonym hop or static-map hop; case/diacritic-only differences are not substitutions)
- MCP `set_wine_profile` surfaces them at every reading depth: the **summary** line, `record.grape_substitutions`, and the **note**
- REST `PUT /somm/profile/:wineId` returns `grapeSubstitutions` (additive)

**Not in this PR:** the ticket's option 3 (canonical storage + regional display — Tinta Roriz shown on Portuguese records) — that's the real fix for the presentation half and needs a schema decision (proposed: regional display names on the Grape doc resolved by wine country).

Tests: wineProfileOps + sommTools + somm route suites green (89 tests), including the new Tinta Roriz envelope test pinning summary/record/note all carry the substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)