### PR TITLE
feat(taxonomy): regional display names for grapes — canonical storage, label-true display

### DIFF
--- a/backend/src/mcp/readTools.test.js
+++ b/backend/src/mcp/readTools.test.js
@@ -230,6 +230,35 @@ describe('PII and data minimisation', () => {
   });
 });
 
+describe('regional grape display names (somm ticket: Tinta Roriz on a Douro Port)', () => {
+  test('get_wine serializes the regionally correct grape label for the wine\'s own place', async () => {
+    const PORTUGAL = oid('1');
+    const DOURO = oid('2');
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: oid('f'), name: 'Vintage Port', producer: 'Quinta do Exemplo', type: 'fortified',
+      country: { _id: PORTUGAL, name: 'Portugal' },
+      region: { _id: DOURO, name: 'Douro' },
+      grapes: [
+        // Stored canonical (one Grape doc for filters/stats); displayed local.
+        { _id: oid('3'), name: 'Tempranillo', regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }] },
+        { _id: oid('4'), name: 'Touriga Nacional' },
+      ],
+    }));
+    const res = await tool('get_wine').handler({ wine_id: oid('f') }, CTX);
+    expect(parse(res).data.grapes).toEqual(['Tinta Roriz', 'Touriga Nacional']);
+  });
+
+  test('get_wine keeps the canonical name when no entry applies to the wine\'s country', async () => {
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: oid('f'), name: 'Ribera Tinto', producer: 'X', type: 'red',
+      country: { _id: oid('9'), name: 'Spain' },
+      grapes: [{ _id: oid('3'), name: 'Tempranillo', regionalNames: [{ country: oid('1'), region: oid('2'), name: 'Tinta Roriz' }] }],
+    }));
+    const res = await tool('get_wine').handler({ wine_id: oid('f') }, CTX);
+    expect(parse(res).data.grapes).toEqual(['Tempranillo']);
+  });
+});
+
 describe('privilege parity & bounds', () => {
   test('search_registry via engine is capped at 10 (== REST USER_SEARCH_LIMIT)', async () => {
     searchService.getIsAvailable.mockReturnValue(true);

--- a/backend/src/mcp/toolUtil.js
+++ b/backend/src/mcp/toolUtil.js
@@ -103,7 +103,11 @@ function wineSummary(wd) {
     country: wd.country?.name || null,
     region: wd.region?.name || null,
     appellation: wd.appellation || null,
-    grapes: Array.isArray(wd.grapes) ? wd.grapes.map((g) => g.name).filter(Boolean) : [],
+    // Callers that ran the wine through utils/grapeDisplay.decorateGrapes
+    // (get_wine, resolve_wine) surface the regionally correct label here
+    // ("Tinta Roriz" on a Douro Port); undecorated callers keep the canonical
+    // name — same array-of-strings shape either way.
+    grapes: Array.isArray(wd.grapes) ? wd.grapes.map((g) => g.displayName || g.name).filter(Boolean) : [],
   };
 }
 

--- a/backend/src/mcp/tools/wines.js
+++ b/backend/src/mcp/tools/wines.js
@@ -9,6 +9,7 @@ const { registerTool } = require('../registry');
 const { isValidId } = require('../../utils/validation');
 const { ok, fail, wineSummary, hasContent } = require('../toolUtil');
 const { siteBaseUrl } = require('../../utils/siteUrl');
+const { decorateGrapes } = require('../../utils/grapeDisplay');
 
 const REGISTRY_LIMIT = 10; // == USER_SEARCH_LIMIT in routes/wines.js
 
@@ -75,9 +76,13 @@ registerTool({
   inputSchema: { wine_id: z.string().describe('Registry wine id from search_registry or a bottle\'s wine') },
   handler: async (args) => {
     if (!isValidId(args.wine_id)) return fail('invalid_input', 'wine_id must be a 24-hex Mongo id.');
-    const w = await WineDefinition.findById(args.wine_id)
+    const raw = await WineDefinition.findById(args.wine_id)
       .select(SAFE_SELECT).populate(['country', 'region', 'grapes']).lean();
-    if (!w) return fail('not_found', 'No registry wine with that id. Find wines via search_registry.');
+    if (!raw) return fail('not_found', 'No registry wine with that id. Find wines via search_registry.');
+    // Grapes surface as the regionally correct label for THIS wine's place
+    // ("Tinta Roriz" on a Douro Port) — storage stays canonical, and the
+    // grapes field keeps its array-of-strings shape.
+    const w = decorateGrapes(raw);
     return ok(`${w.name}${w.producer ? ` — ${w.producer}` : ''}`, {
       ...wineSummary(w),
       classification: w.classification || null,

--- a/backend/src/mcp/tools/write.js
+++ b/backend/src/mcp/tools/write.js
@@ -23,6 +23,7 @@ const { registerTool } = require('../registry');
 const { addBottle, updateBottleFields } = require('../../services/bottleOps');
 const { logAudit } = require('../../services/audit');
 const { isValidId } = require('../../utils/validation');
+const { decorateGrapes } = require('../../utils/grapeDisplay');
 const {
   ok, fail, objectId, MSG_CELLAR_NOT_FOUND, MSG_BOTTLE_NOT_FOUND,
   resolveCellarAccess, resolveBottleAccess, wineSummary,
@@ -61,15 +62,18 @@ registerTool({
       ctx.user.id,
       { matchOnly: true }
     );
+    // decorateGrapes: matched/candidate wines show the regionally correct
+    // grape label for their own place ("Tinta Roriz" on a Douro Port) — the
+    // registry keeps referencing the canonical Grape doc.
     if (result.wine) {
       return ok(`Matched existing registry wine: ${result.wine.name}`, {
-        matched: { ...wineSummary(result.wine) },
+        matched: { ...wineSummary(decorateGrapes(result.wine)) },
         guidance: 'Use this wine_id in add_bottle. Do not create a new wine.',
       });
     }
     if (result.candidates?.length) {
       return ok(`${result.candidates.length} close candidate(s) — none certain`, {
-        candidates: result.candidates.map((c) => ({ ...wineSummary(c.wine), score: c.score })),
+        candidates: result.candidates.map((c) => ({ ...wineSummary(decorateGrapes(c.wine)), score: c.score })),
         guidance: 'If one of these IS the wine, use its wine_id in add_bottle. Only if none match, call add_bottle with new_wine and confirm_new_wine:true.',
       });
     }

--- a/backend/src/models/Grape.js
+++ b/backend/src/models/Grape.js
@@ -1,6 +1,28 @@
 const mongoose = require('mongoose');
 const { slugify, normalizeString } = require('../utils/normalize');
 
+// One regionally correct display name for one place — see `regionalNames`
+// below. No per-entry _id: entries are replaced wholesale by the admin editor
+// and referenced by (country, region) pair, never individually.
+const regionalNameSchema = new mongoose.Schema({
+  country: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Country',
+    required: [true, 'A regional name needs a country']
+  },
+  region: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Region',
+    default: null
+  },
+  name: {
+    type: String,
+    required: [true, 'A regional name needs a name'],
+    trim: true,
+    maxlength: 60
+  }
+}, { _id: false });
+
 const grapeSchema = new mongoose.Schema({
   name: {
     type: String,
@@ -52,6 +74,18 @@ const grapeSchema = new mongoose.Schema({
     type: [String],
     default: [],
     index: true
+  },
+  // Regionally correct display names for this variety: a Douro wine shows
+  // "Tinta Roriz", an Alentejo one "Aragonez" — both stored as this ONE
+  // canonical doc, so search facets, stats and pairing keep a single
+  // vocabulary. `region` unset means the name applies country-wide; an entry
+  // with a region wins over a country-only entry (utils/grapeDisplay.js).
+  // Deliberately NO normalized copies of these names: they are display-only
+  // and never matched against user input — resolving a typed "Tinta Roriz" to
+  // this doc stays the job of synonyms/normalizedSynonyms above.
+  regionalNames: {
+    type: [regionalNameSchema],
+    default: []
   },
   slug: { type: String, trim: true, lowercase: true, unique: true, sparse: true, index: true },
   description: { type: String, trim: true, default: '' },

--- a/backend/src/models/Grape.regionalNames.test.js
+++ b/backend/src/models/Grape.regionalNames.test.js
@@ -1,0 +1,69 @@
+/**
+ * Grape.regionalNames — schema-level validation for the regional display
+ * names path (somm ticket: "Tinta Roriz stored as Tempranillo on a Douro
+ * Port").
+ *
+ * WHY THIS TEST EXISTS:
+ * The admin route validates payload shape, but the schema is the last line —
+ * scripts and future write paths hit it directly. Pins: country is required
+ * per entry, name is required and capped at 60 (trimmed first), region is
+ * optional, the array defaults to [], and — deliberately — there is NO
+ * normalized copy of these names (display-only; matching stays the job of
+ * synonyms/normalizedSynonyms). No DB needed: doc.validate() runs the
+ * validators without touching pre-save hooks.
+ */
+const mongoose = require('mongoose');
+const Grape = require('./Grape');
+
+const oid = () => new mongoose.Types.ObjectId();
+
+const baseDoc = (overrides = {}) => new Grape({
+  name: 'Tempranillo',
+  normalizedName: 'tempranillo',
+  createdBy: oid(),
+  ...overrides,
+});
+
+test('regionalNames defaults to [] — existing grapes are unaffected', async () => {
+  const doc = baseDoc();
+  await doc.validate();
+  expect(doc.regionalNames.length).toBe(0);
+});
+
+test('accepts country-only and country+region entries; name is trimmed', async () => {
+  const country = oid();
+  const doc = baseDoc({
+    regionalNames: [
+      { country, region: oid(), name: '  Tinta Roriz  ' },
+      { country, name: 'Aragonez' },
+    ],
+  });
+  await doc.validate();
+  expect(doc.regionalNames[0].name).toBe('Tinta Roriz');
+  expect(doc.regionalNames[1].region).toBeNull();
+});
+
+test('country is required on every entry', async () => {
+  const doc = baseDoc({ regionalNames: [{ name: 'Tinta Roriz' }] });
+  await expect(doc.validate()).rejects.toThrow(/regionalNames.0.country/);
+});
+
+test('name is required and capped at 60 chars', async () => {
+  await expect(baseDoc({ regionalNames: [{ country: oid() }] }).validate())
+    .rejects.toThrow(/regionalNames.0.name/);
+  // Whitespace-only trims to empty → required fails.
+  await expect(baseDoc({ regionalNames: [{ country: oid(), name: '   ' }] }).validate())
+    .rejects.toThrow(/regionalNames.0.name/);
+  await expect(baseDoc({ regionalNames: [{ country: oid(), name: 'a'.repeat(61) }] }).validate())
+    .rejects.toThrow(/regionalNames.0.name/);
+  await baseDoc({ regionalNames: [{ country: oid(), name: 'a'.repeat(60) }] }).validate();
+});
+
+test('display-only contract: the schema has no normalized copy of regional names', () => {
+  // Matching a typed "Tinta Roriz" to this doc is synonyms' job — if someone
+  // adds a normalizedRegionalNames-style field, the display/matching split
+  // this feature rests on has been broken. See the schema comment.
+  const paths = Object.keys(Grape.schema.paths);
+  expect(paths.some((p) => /normalized.*regional/i.test(p))).toBe(false);
+  expect(paths).toContain('normalizedSynonyms'); // matching stays here
+});

--- a/backend/src/routes/admin/taxonomy.grapeRegionalNames.test.js
+++ b/backend/src/routes/admin/taxonomy.grapeRegionalNames.test.js
@@ -1,0 +1,194 @@
+/**
+ * Grape regionalNames on the REST admin surface (somm ticket: "Tinta Roriz
+ * stored as Tempranillo on a Douro Port").
+ *
+ * WHY THIS TEST EXISTS:
+ * regionalNames are ref-bearing display data — Mongoose validates neither
+ * that the ids exist nor that a region belongs to its entry's country, and a
+ * duplicate (country, region) pair would make display resolution
+ * order-dependent. The validator carries those invariants; the PUT wiring
+ * test pins that the route honours a rejection (400, nothing saved) and that
+ * an accepted change resyncs the WINES search index (regional names feed its
+ * grapeNames) without the bottles resync a rename needs.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../services/search', () => ({
+  getIsAvailable: jest.fn(() => false),
+  indexWine: jest.fn(),
+  removeWine: jest.fn(),
+  bulkIndexWines: jest.fn(),
+  bulkIndexBottles: jest.fn(),
+  fullSync: jest.fn(),
+  fullSyncBottles: jest.fn(),
+  waitForTasks: jest.fn(),
+}));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../models/Country', () => ({ exists: jest.fn() }));
+jest.mock('../../models/Region', () => ({ findById: jest.fn() }));
+jest.mock('../../models/Grape', () => ({ findById: jest.fn(), find: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Country = require('../../models/Country');
+const Region = require('../../models/Region');
+const Grape = require('../../models/Grape');
+const searchService = require('../../services/search');
+const router = require('./taxonomy');
+const { validateGrapeRegionalNames } = router;
+
+const ADMIN_ID = '64b000000000000000000001';
+const GRAPE_ID = '64b00000000000000000009e';
+const PORTUGAL = 'a'.repeat(24);
+const DOURO = 'b'.repeat(24);
+const ALENTEJO = 'c'.repeat(24);
+
+const regionDoc = (id, country, name) => ({ _id: id, name, country });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Country.exists.mockResolvedValue({ _id: PORTUGAL });
+  Region.findById.mockImplementation((id) => ({
+    select: () => ({
+      lean: async () => (String(id) === DOURO ? regionDoc(DOURO, PORTUGAL, 'Douro') : null),
+    }),
+  }));
+});
+
+describe('validateGrapeRegionalNames', () => {
+  test('accepts a valid set (region entry + country-only entry) and returns it cleaned', async () => {
+    const res = await validateGrapeRegionalNames([
+      { country: PORTUGAL, region: DOURO, name: '  Tinta Roriz ' },
+      { country: PORTUGAL, name: 'Aragonez' },
+    ]);
+    expect(res.error).toBeUndefined();
+    expect(res.value).toEqual([
+      { country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' },
+      { country: PORTUGAL, region: null, name: 'Aragonez' },
+    ]);
+  });
+
+  test('rejects a region that belongs to a different country', async () => {
+    Region.findById.mockImplementation(() => ({
+      select: () => ({ lean: async () => regionDoc(DOURO, 'f'.repeat(24), 'Douro') }),
+    }));
+    const res = await validateGrapeRegionalNames([{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }]);
+    expect(res.error).toMatch(/different country/);
+  });
+
+  test('rejects duplicate (country, region) pairs — including two country-level entries', async () => {
+    const dupRegion = await validateGrapeRegionalNames([
+      { country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' },
+      { country: PORTUGAL, region: DOURO, name: 'Aragonez' },
+    ]);
+    expect(dupRegion.error).toMatch(/Duplicate/);
+    const dupCountry = await validateGrapeRegionalNames([
+      { country: PORTUGAL, name: 'Tinta Roriz' },
+      { country: PORTUGAL, name: 'Aragonez' },
+    ]);
+    expect(dupCountry.error).toMatch(/Duplicate/);
+    // Same country, DIFFERENT regions is legitimate — Douro + Alentejo.
+    Region.findById.mockImplementation((id) => ({
+      select: () => ({
+        lean: async () => regionDoc(String(id), PORTUGAL, String(id) === DOURO ? 'Douro' : 'Alentejo'),
+      }),
+    }));
+    const ok = await validateGrapeRegionalNames([
+      { country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' },
+      { country: PORTUGAL, region: ALENTEJO, name: 'Aragonez' },
+    ]);
+    expect(ok.error).toBeUndefined();
+  });
+
+  test('rejects missing/unknown refs and never queries with raw body junk', async () => {
+    expect((await validateGrapeRegionalNames([{ name: 'X' }])).error).toMatch(/valid country id/);
+    expect((await validateGrapeRegionalNames([{ country: { $ne: null }, name: 'X' }])).error).toMatch(/valid country id/);
+    expect(Country.exists).not.toHaveBeenCalled(); // operator object never reached a query
+    Country.exists.mockResolvedValue(null);
+    expect((await validateGrapeRegionalNames([{ country: PORTUGAL, name: 'X' }])).error).toMatch(/No country/);
+    Country.exists.mockResolvedValue({ _id: PORTUGAL });
+    expect((await validateGrapeRegionalNames([{ country: PORTUGAL, region: ALENTEJO, name: 'X' }])).error)
+      .toMatch(/No region/); // the beforeEach Region mock only knows DOURO
+  });
+
+  test('bounds: name 1–60 after trim, at most 20 entries, array-of-objects only', async () => {
+    expect((await validateGrapeRegionalNames('Tinta Roriz')).error).toMatch(/array/);
+    expect((await validateGrapeRegionalNames([null])).error).toMatch(/array of \{ country/);
+    expect((await validateGrapeRegionalNames([{ country: PORTUGAL, name: '   ' }])).error).toMatch(/non-empty name/);
+    expect((await validateGrapeRegionalNames([{ country: PORTUGAL, name: 'a'.repeat(61) }])).error).toMatch(/60 characters/);
+    expect((await validateGrapeRegionalNames([{ country: PORTUGAL, name: 'a'.repeat(60) }])).error).toBeUndefined();
+    const tooMany = Array.from({ length: 21 }, (_, i) => ({ country: PORTUGAL, name: `n${i}` }));
+    expect((await validateGrapeRegionalNames(tooMany)).error).toMatch(/At most 20/);
+  });
+
+  test('an empty array is valid — it clears the grape\'s regional names', async () => {
+    expect(await validateGrapeRegionalNames([])).toEqual({ value: [] });
+  });
+});
+
+// ── PUT wiring ───────────────────────────────────────────────────────────────
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/taxonomy', router);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+const put = (path, body) => fetch(`${baseUrl}/api/admin/taxonomy${path}`, {
+  method: 'PUT',
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+  body: JSON.stringify(body),
+});
+
+describe('PUT /grapes/:id regionalNames wiring', () => {
+  const grapeDoc = () => ({
+    _id: GRAPE_ID,
+    name: 'Tempranillo',
+    regionalNames: [],
+    save: jest.fn().mockResolvedValue(undefined),
+  });
+
+  test('a rejected payload → 400 with the validator\'s message, nothing saved', async () => {
+    const grape = grapeDoc();
+    Grape.findById.mockResolvedValue(grape);
+    const res = await put(`/grapes/${GRAPE_ID}`, {
+      regionalNames: [
+        { country: PORTUGAL, name: 'Tinta Roriz' },
+        { country: PORTUGAL, name: 'Aragonez' },
+      ],
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/Duplicate/);
+    expect(grape.save).not.toHaveBeenCalled();
+    expect(grape.regionalNames).toEqual([]);
+  });
+
+  test('a valid set saves, and resyncs the WINES index only (no rename → no bottles resync)', async () => {
+    const grape = grapeDoc();
+    Grape.findById.mockResolvedValue(grape);
+    const res = await put(`/grapes/${GRAPE_ID}`, {
+      regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+    });
+    expect(res.status).toBe(200);
+    expect(grape.regionalNames).toEqual([{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }]);
+    expect(grape.save).toHaveBeenCalled();
+    expect(searchService.fullSync).toHaveBeenCalled();
+    expect(searchService.fullSyncBottles).not.toHaveBeenCalled();
+  });
+
+  test('an update that does not touch regionalNames triggers no resync at all', async () => {
+    const grape = grapeDoc();
+    Grape.findById.mockResolvedValue(grape);
+    const res = await put(`/grapes/${GRAPE_ID}`, { origin: 'Rioja, Spain' });
+    expect(res.status).toBe(200);
+    expect(searchService.fullSync).not.toHaveBeenCalled();
+    expect(searchService.fullSyncBottles).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -415,6 +415,67 @@ router.delete('/regions/:id', async (req, res) => {
 
 // ===== GRAPES =====
 
+// ── Regional display names validation ────────────────────────────────────────
+// Grape.regionalNames = [{ country, region?, name }] — regionally correct
+// display labels ("Tinta Roriz" for Tempranillo on Douro wines; see
+// models/Grape.js). Bounded and ref-checked here because Mongoose validates
+// neither that the ids exist nor that the region belongs to the country.
+const REGIONAL_NAMES_MAX = 20;
+const REGIONAL_NAME_MAX_LENGTH = 60; // == the schema's maxlength
+
+/**
+ * Validate a regionalNames payload. Returns { error } (human-readable, safe
+ * for a 400 body) or { value } — the cleaned array: trimmed names, ids as
+ * strings, region null when absent.
+ *
+ * Same discipline as taxonomyReview.appellationRefsError: every id is
+ * isValidId-checked and the validated STRING is what reaches the query, so
+ * operator objects from the request body never enter a filter.
+ */
+async function validateGrapeRegionalNames(input) {
+  if (!Array.isArray(input)) {
+    return { error: 'regionalNames must be an array of { country, region?, name } entries' };
+  }
+  if (input.length > REGIONAL_NAMES_MAX) {
+    return { error: `At most ${REGIONAL_NAMES_MAX} regional names per grape` };
+  }
+  const value = [];
+  const seenPairs = new Set();
+  for (const entry of input) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return { error: 'regionalNames must be an array of { country, region?, name } entries' };
+    }
+    const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+    if (!name) return { error: 'Each regional name needs a non-empty name' };
+    if (name.length > REGIONAL_NAME_MAX_LENGTH) {
+      return { error: `Regional names must be ${REGIONAL_NAME_MAX_LENGTH} characters or fewer` };
+    }
+    const countryKey = String(entry.country ?? '');
+    if (!isValidId(countryKey)) return { error: 'Each regional name needs a valid country id' };
+    const countryExists = await Country.exists({ _id: countryKey });
+    if (!countryExists) return { error: 'No country with that id' };
+    let regionKey = null;
+    if (entry.region) {
+      regionKey = String(entry.region);
+      if (!isValidId(regionKey)) return { error: 'Invalid region id in regional names' };
+      const region = await Region.findById(regionKey).select('name country').lean();
+      if (!region) return { error: 'No region with that id' };
+      if (String(region.country) !== countryKey) {
+        return { error: `Region "${region.name}" belongs to a different country than the regional name's country` };
+      }
+    }
+    // One display name per place — a duplicate (country, region) pair would
+    // make resolution order-dependent.
+    const pairKey = `${countryKey}:${regionKey || ''}`;
+    if (seenPairs.has(pairKey)) {
+      return { error: 'Duplicate (country, region) pair in regional names — each place carries one display name' };
+    }
+    seenPairs.add(pairKey);
+    value.push({ country: countryKey, region: regionKey, name });
+  }
+  return { value };
+}
+
 // GET /api/admin/taxonomy/grapes - List all grapes
 router.get('/grapes', async (req, res) => {
   try {
@@ -433,10 +494,20 @@ router.get('/grapes', async (req, res) => {
 // POST /api/admin/taxonomy/grapes - Add grape
 router.post('/grapes', async (req, res) => {
   try {
-    const { name, synonyms, color, origin, characteristics, agingPotential, prestige, description } = req.body;
+    const { name, synonyms, color, origin, characteristics, agingPotential, prestige, description, regionalNames } = req.body;
 
     if (!name) {
       return res.status(400).json({ error: 'Grape name is required' });
+    }
+
+    // The create and update forms share the grape editor, so both routes
+    // accept regionalNames — a field the UI offers but the API drops would be
+    // silent data loss.
+    let regionalNamesValue = [];
+    if (regionalNames !== undefined) {
+      const check = await validateGrapeRegionalNames(regionalNames);
+      if (check.error) return res.status(400).json({ error: check.error });
+      regionalNamesValue = check.value;
     }
 
     const normalizedName = normalizeString(name);
@@ -451,6 +522,7 @@ router.post('/grapes', async (req, res) => {
       agingPotential: agingPotential || null,
       prestige: prestige || null,
       description: description || '',
+      regionalNames: regionalNamesValue,
       createdBy: req.user.id
     });
 
@@ -473,11 +545,20 @@ router.post('/grapes', async (req, res) => {
 router.put('/grapes/:id', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
-    const { name, synonyms, color, origin, characteristics, agingPotential, prestige, description } = req.body;
+    const { name, synonyms, color, origin, characteristics, agingPotential, prestige, description, regionalNames } = req.body;
 
     const grape = await Grape.findById(req.params.id);
     if (!grape) {
       return res.status(404).json({ error: 'Grape not found' });
+    }
+
+    // Validate before mutating anything, so a rejected payload leaves the
+    // loaded doc untouched.
+    let regionalNamesValue;
+    if (regionalNames !== undefined) {
+      const check = await validateGrapeRegionalNames(regionalNames);
+      if (check.error) return res.status(400).json({ error: check.error });
+      regionalNamesValue = check.value;
     }
 
     if (name) {
@@ -491,17 +572,24 @@ router.put('/grapes/:id', async (req, res) => {
     if (agingPotential !== undefined) grape.agingPotential = agingPotential;
     if (prestige !== undefined) grape.prestige = prestige;
     if (description !== undefined) grape.description = description;
+    if (regionalNamesValue !== undefined) grape.regionalNames = regionalNamesValue;
 
     await grape.save();
     logAudit(req, 'admin.taxonomy.update',
       { type: 'grape', id: grape._id },
-      { name: grape.name }
+      {
+        name: grape.name,
+        ...(regionalNames !== undefined ? { regionalNames: grape.regionalNames.length } : {})
+      }
     );
 
     // Resync search indexes if name changed (denormalized data). Bottle
     // documents denormalize taxonomy names too — fullSync() alone rebuilds
     // only the wines index, leaving cellar search matching the old name.
+    // regionalNames feed only the WINES index's grapeNames (regional display
+    // recall), so that change resyncs wines alone.
     if (name) { searchService.fullSync(); searchService.fullSyncBottles(); }
+    else if (regionalNames !== undefined) { searchService.fullSync(); }
 
     res.json({ grape });
   } catch (error) {
@@ -904,3 +992,6 @@ module.exports = router;
 // the half of the REST/MCP parity contract that lives on this side.
 module.exports.appellationNameError = appellationNameError;
 module.exports.validateAppellationSynonyms = validateAppellationSynonyms;
+// Exported for its unit tests (taxonomy.grapeRegionalNames.test.js) — the DB
+// lookups inside are mocked there.
+module.exports.validateGrapeRegionalNames = validateGrapeRegionalNames;

--- a/backend/src/routes/bottles.grapeDisplay.test.js
+++ b/backend/src/routes/bottles.grapeDisplay.test.js
@@ -1,0 +1,155 @@
+/**
+ * GET /api/bottles/:id — regional grape display decoration on the bottle page
+ * (somm ticket: "Tinta Roriz stored as Tempranillo on a Douro Port").
+ *
+ * WHY THIS TEST EXISTS:
+ * The bottle detail response serializes the populated wineDefinition; each
+ * grape must gain `displayName` resolved against the WINE's own
+ * country/region while `name` stays the canonical variety — the contract the
+ * bottle page's grape pills (`g.displayName || g.name`) rest on. Storage is
+ * untouched: the bottle still references the canonical Grape doc.
+ *
+ * Real router + real requireAuth/requireBottleAccess (HS256 test tokens);
+ * models and side-effect services are mocked so no MongoDB is needed.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexBottle: jest.fn(),
+  removeBottle: jest.fn(),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/restockChecker', () => ({
+  checkRestockGap: jest.fn().mockResolvedValue(null),
+  resolveRestockAlerts: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../services/priceWarnings', () => ({ gatherPriceWarnings: jest.fn().mockResolvedValue([]) }));
+jest.mock('../services/communityPrice', () => ({ getCurrentRelease: jest.fn().mockResolvedValue(null) }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+  getSnapshotForDate: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => ({ updateMany: jest.fn() }));
+jest.mock('../models/Country', () => ({}));
+jest.mock('../models/Region', () => ({}));
+jest.mock('../models/Grape', () => ({}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('../models/PriceTrackingRequest', () => ({}));
+jest.mock('../models/BottleImage', () => ({ findOne: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/WineRequest', () => ({}));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const BottleImage = require('../models/BottleImage');
+const bottlesRouter = require('./bottles');
+
+const USER_ID = '64b000000000000000000001';
+const CELLAR_ID = '64b0000000000000000000bb';
+const WINE_ID = '64b0000000000000000000cc';
+const BOTTLE_ID = '64b0000000000000000000dd';
+const PORTUGAL = 'a'.repeat(24);
+const DOURO = 'b'.repeat(24);
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles', bottlesRouter);
+  return app;
+}
+
+function get(url) {
+  const app = buildApp();
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'GET',
+          headers: {
+            authorization: `Bearer ${jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' })}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end();
+    });
+  });
+}
+
+let storedBottle;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, name: 'Main', user: USER_ID, members: [], deletedAt: null });
+  // No pending/default images in this suite.
+  BottleImage.findOne.mockReturnValue({ sort: () => ({ lean: async () => null }) });
+  BottleImage.findById.mockReturnValue({ lean: async () => null });
+
+  const wineDefinition = {
+    _id: WINE_ID,
+    name: 'Vintage Port',
+    producer: 'Quinta do Exemplo',
+    type: 'fortified',
+    country: { _id: PORTUGAL, name: 'Portugal' },
+    region: { _id: DOURO, name: 'Douro' },
+    grapes: [
+      { _id: 'c'.repeat(24), name: 'Tempranillo', regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }] },
+      { _id: 'd'.repeat(24), name: 'Touriga Nacional' },
+    ],
+  };
+  storedBottle = {
+    _id: BOTTLE_ID,
+    cellar: CELLAR_ID,
+    vintage: '2017',
+    wineDefinition,
+    populate: jest.fn().mockImplementation(function () { return Promise.resolve(this); }),
+    toObject() {
+      return { _id: this._id, cellar: this.cellar, vintage: this.vintage, wineDefinition: this.wineDefinition };
+    },
+  };
+  Bottle.findById.mockResolvedValue(storedBottle);
+});
+
+describe('GET /api/bottles/:id', () => {
+  test('wineDefinition grapes carry displayName for the wine\'s place; name stays canonical', async () => {
+    const { status, body } = await get(`/api/bottles/${BOTTLE_ID}`);
+    expect(status).toBe(200);
+    const grapes = body.bottle.wineDefinition.grapes;
+    expect(grapes[0].displayName).toBe('Tinta Roriz');
+    expect(grapes[0].name).toBe('Tempranillo');
+    expect(grapes[1].displayName).toBe('Touriga Nacional');
+  });
+
+  test('the stored bottle object is not mutated by decoration (canonical stays canonical in memory)', async () => {
+    await get(`/api/bottles/${BOTTLE_ID}`);
+    // The doc the rest of the app sees (indexing, audit) keeps canonical-only
+    // grapes — decoration happens on the serialized copy.
+    expect(storedBottle.wineDefinition.grapes[0].displayName).toBeUndefined();
+  });
+});

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -24,6 +24,10 @@ const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { toNormalized } = require('../utils/ratingUtils');
 const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
 const { parsePagination } = require('../utils/pagination');
+// Read-surface decoration: populated grapes gain `displayName` — the
+// regionally correct label for the bottle's wine (Tinta Roriz on a Douro
+// Port) — while `name` stays canonical for storage/filters/stats.
+const { decorateGrapes } = require('../utils/grapeDisplay');
 const mongoose = require('mongoose');
 const searchService = require('../services/search');
 // add/update/consume/restore/remove logic + rack-slot freeing live in the
@@ -319,6 +323,9 @@ router.get('/', async (req, res) => {
 
     const items = bottles.map(b => ({
       ...b,
+      // Regional grape display names resolved per wine (additive `displayName`
+      // on each populated grape; canonical `name` untouched).
+      ...(b.wineDefinition ? { wineDefinition: decorateGrapes(b.wineDefinition) } : {}),
       ...(maturityMap ? { maturityStatus: maturityMap.get(b._id.toString()) || null } : {}),
     }));
 
@@ -417,6 +424,11 @@ router.get('/:id', requireBottleAccess('viewer'), async (req, res) => {
     // Join the historical rate snapshot for the date this price was entered.
     // Exposed as priceCurrencyRates so the frontend needs no changes.
     const bottleObj = bottle.toObject();
+    // Regional grape display names resolved against the wine's own
+    // country/region (additive `displayName`; canonical `name` untouched).
+    if (bottleObj.wineDefinition) {
+      bottleObj.wineDefinition = decorateGrapes(bottleObj.wineDefinition);
+    }
     if (bottle.priceSetAt) {
       const date = bottle.priceSetAt.toISOString().slice(0, 10);
       const snapshot = await getSnapshotForDate(date);

--- a/backend/src/routes/wines.grapeDisplay.test.js
+++ b/backend/src/routes/wines.grapeDisplay.test.js
@@ -1,0 +1,155 @@
+/**
+ * GET /api/wines/:id + GET /api/wines — regional grape display decoration
+ * (somm ticket: "Tinta Roriz stored as Tempranillo on a Douro Port").
+ *
+ * WHY THIS TEST EXISTS:
+ * Wines keep referencing ONE canonical Grape doc; the read surfaces resolve
+ * the regionally correct label per wine (utils/grapeDisplay). These tests pin
+ * that the wine routes actually apply the decoration: every populated grape
+ * gains `displayName` (region entry wins, canonical fallback) and `name`
+ * stays the canonical variety — the contract the frontend's
+ * `g.displayName || g.name` rendering rests on.
+ *
+ * Real router + real requireAuth (HS256 test token); models and side-effect
+ * services are mocked so no MongoDB is needed.
+ */
+process.env.JWT_SECRET = 'test-secret';
+
+// services/search eagerly requires the ESM-only `meilisearch` package, which
+// Jest can't transform — stub it (matches the repo's unit-test style).
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+}));
+jest.mock('../services/labelScan', () => ({
+  scanLabelFull: jest.fn(),
+  identifyWineFromQuery: jest.fn(),
+}));
+jest.mock('../services/imageSanitizer', () => ({
+  sanitizeImageBuffer: jest.fn(),
+  detectImageFormat: jest.fn(),
+}));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../services/wineMatching', () => ({ findBestMatch: jest.fn() }));
+jest.mock('../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../services/communityPrice', () => ({ getReleaseCurve: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/aiBudget', () => ({
+  tryDebitAi: jest.fn().mockResolvedValue({ ok: true, refund: jest.fn() }),
+  isRefundableFailure: jest.fn().mockReturnValue(false),
+  isRefundableScanError: jest.fn().mockReturnValue(false),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../models/Discussion', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({
+  find: jest.fn(),
+  findById: jest.fn(),
+  findOne: jest.fn(),
+  countDocuments: jest.fn(),
+}));
+
+const http = require('http');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const WineDefinition = require('../models/WineDefinition');
+const winesRouter = require('./wines');
+
+const USER_ID = '64b000000000000000000001';
+const WINE_ID = '64b0000000000000000000cc';
+const PORTUGAL = 'a'.repeat(24);
+const DOURO = 'b'.repeat(24);
+
+// Thenable query stub: supports the .populate()/.select()/.sort()/.limit()/
+// .skip() chains the routes use, resolving to `result` when awaited.
+const chain = (result) => {
+  const c = {};
+  for (const m of ['populate', 'sort', 'skip', 'limit', 'select']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(() => Promise.resolve(result));
+  c.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return c;
+};
+
+const wineDoc = () => ({
+  _id: WINE_ID,
+  name: 'Vintage Port',
+  producer: 'Quinta do Exemplo',
+  type: 'fortified',
+  country: { _id: PORTUGAL, name: 'Portugal' },
+  region: { _id: DOURO, name: 'Douro' },
+  grapes: [
+    { _id: 'c'.repeat(24), name: 'Tempranillo', regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }] },
+    { _id: 'd'.repeat(24), name: 'Touriga Nacional' },
+  ],
+});
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/wines', winesRouter);
+  return app;
+}
+
+function get(url) {
+  const app = buildApp();
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'GET',
+          headers: {
+            authorization: `Bearer ${jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' })}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end();
+    });
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /api/wines/:id', () => {
+  test('grapes carry displayName resolved against the wine\'s own country/region; name stays canonical', async () => {
+    WineDefinition.findById.mockReturnValue(chain(wineDoc()));
+    const { status, body } = await get(`/api/wines/${WINE_ID}`);
+    expect(status).toBe(200);
+    expect(body.wine.grapes[0].displayName).toBe('Tinta Roriz');
+    expect(body.wine.grapes[0].name).toBe('Tempranillo');
+    // Unmapped grape falls back to canonical — the frontend renders
+    // displayName || name, so it must never be missing-and-misleading.
+    expect(body.wine.grapes[1].displayName).toBe('Touriga Nacional');
+  });
+});
+
+describe('GET /api/wines (list)', () => {
+  test('the Mongo list path decorates every wine\'s grapes', async () => {
+    WineDefinition.find.mockReturnValue(chain([wineDoc()]));
+    WineDefinition.countDocuments.mockResolvedValue(1);
+    const { status, body } = await get('/api/wines?search=port');
+    expect(status).toBe(200);
+    expect(body.wines).toHaveLength(1);
+    expect(body.wines[0].grapes[0].displayName).toBe('Tinta Roriz');
+    expect(body.wines[0].grapes[0].name).toBe('Tempranillo');
+  });
+});
+
+describe('GET /api/wines/:idOrSlug/public', () => {
+  test('the public wine page gets the same decoration (no auth required)', async () => {
+    WineDefinition.findOne.mockReturnValue(chain(wineDoc()));
+    const { status, body } = await get(`/api/wines/${WINE_ID}/public`);
+    expect(status).toBe(200);
+    expect(body.wine.grapes[0].displayName).toBe('Tinta Roriz');
+  });
+});

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -11,6 +11,10 @@ const { generateWineKey } = require('../utils/normalize');
 const { findBestMatch } = require('../services/wineMatching');
 const { parsePagination } = require('../utils/pagination');
 const { isValidId } = require('../utils/validation');
+// Read-surface decoration: each populated grape gains `displayName` — the
+// regionally correct label for THIS wine (Tinta Roriz on a Douro Port) —
+// while `name` stays canonical. Storage/filters/stats are untouched.
+const { decorateGrapes } = require('../utils/grapeDisplay');
 const { submitUrls } = require('../services/indexNow');
 const { getReleaseCurve } = require('../services/communityPrice');
 const aiBurstLimiter = require('../middleware/aiBurstLimiter');
@@ -214,7 +218,7 @@ router.get('/', requireAuth, async (req, res) => {
           total: estimatedTotalHits,
           offset: parsedOffset,
           limit: parsedLimit,
-          wines
+          wines: wines.map(decorateGrapes)
         });
       } catch (err) {
         console.warn('Meilisearch query failed, falling back to MongoDB:', err.message);
@@ -229,7 +233,7 @@ router.get('/', requireAuth, async (req, res) => {
       total,
       offset: parsedOffset,
       limit: parsedLimit,
-      wines
+      wines: wines.map(decorateGrapes)
     });
   } catch (error) {
     console.error('Get wines error:', error);
@@ -635,7 +639,7 @@ router.get('/:idOrSlug/public', async (req, res) => {
       return res.status(404).json({ error: 'Wine not found' });
     }
 
-    res.json({ wine });
+    res.json({ wine: decorateGrapes(wine) });
   } catch (error) {
     console.error('Get public wine error:', error);
     res.status(500).json({ error: 'Failed to get wine' });
@@ -686,7 +690,7 @@ router.get('/:id', requireAuth, async (req, res) => {
       return res.status(404).json({ error: 'Wine not found' });
     }
 
-    res.json({ wine });
+    res.json({ wine: decorateGrapes(wine) });
   } catch (error) {
     console.error('Get wine error:', error);
     res.status(500).json({ error: 'Failed to get wine' });

--- a/backend/src/services/embedding.buildText.test.js
+++ b/backend/src/services/embedding.buildText.test.js
@@ -65,3 +65,46 @@ test('the text never mentions the review fields by name', () => {
   const text = buildEmbeddingText(FULL_WINE, '2019');
   expect(text).not.toMatch(/verified/i);
 });
+
+// ── Regional grape display names ─────────────────────────────────────────────
+// A grape can carry regionalNames ({ country, region?, name }); when one
+// applies to the wine's OWN country/region, the Grapes line shows both forms:
+// "Tempranillo (Tinta Roriz)" — additive recall for the label-true name.
+// The property these tests pin: a wine the mapping does NOT apply to produces
+// BYTE-IDENTICAL text to a mapping-free grape, so adding a regional name to
+// the taxonomy never churns textHashes (→ no registry-wide re-embed wave).
+// The golden test above is the other half of that pin: FULL_WINE has no
+// regionalNames anywhere and its exact output did not move.
+
+const PORTUGAL_ID = 'a'.repeat(24);
+const DOURO_ID = 'b'.repeat(24);
+const SPAIN_ID = 'c'.repeat(24);
+
+const TEMPRANILLO_MAPPED = {
+  name: 'Tempranillo',
+  regionalNames: [{ country: PORTUGAL_ID, region: DOURO_ID, name: 'Tinta Roriz' }],
+};
+
+const portBase = {
+  name: 'Vintage Port',
+  producer: 'Quinta do Exemplo',
+  type: 'fortified',
+  region: { _id: DOURO_ID, name: 'Douro' },
+};
+
+test('an applicable regional name joins the canonical on the Grapes line', () => {
+  const wine = { ...portBase, country: { _id: PORTUGAL_ID, name: 'Portugal' }, grapes: [TEMPRANILLO_MAPPED] };
+  const text = buildEmbeddingText(wine, '2017');
+  expect(text).toContain('Grapes: Tempranillo (Tinta Roriz)');
+});
+
+test('NO-CHURN PIN: a wine the mapping does not apply to is byte-identical to a mapping-free grape', () => {
+  // Same grape doc (mapping present) but the wine sits in another country —
+  // the entry cannot apply, so the text must equal the no-regionalNames text.
+  const elsewhere = { ...portBase, country: { _id: SPAIN_ID, name: 'Spain' } };
+  const withMapping = buildEmbeddingText({ ...elsewhere, grapes: [TEMPRANILLO_MAPPED] }, '2017');
+  const withoutMapping = buildEmbeddingText({ ...elsewhere, grapes: [{ name: 'Tempranillo' }] }, '2017');
+  expect(withMapping).toBe(withoutMapping);
+  expect(withMapping).toContain('Grapes: Tempranillo');
+  expect(withMapping).not.toContain('Tinta Roriz');
+});

--- a/backend/src/services/embedding.js
+++ b/backend/src/services/embedding.js
@@ -98,6 +98,7 @@ function activeEmbeddingModel(requestedModel) {
 }
 
 const { fetchWithRetry } = require('../utils/fetchRetry');
+const { resolveGrapeDisplayName } = require('../utils/grapeDisplay');
 
 function retryOpts({ maxRetries, timeoutMs, label }) {
   return {
@@ -225,7 +226,20 @@ function buildEmbeddingText(wine, vintage) {
   ];
   if (wine.region?.name)   lines.push(`Region: ${wine.region.name}`);
   if (wine.country?.name)  lines.push(`Country: ${wine.country.name}`);
-  const grapeNames = (wine.grapes || []).filter(g => g.name).map(g => g.name).join(', ');
+  // Grapes: canonical name, plus the regionally correct label in parentheses
+  // when a Grape.regionalNames entry applies to THIS wine's country/region —
+  // "Tempranillo (Tinta Roriz)" on a Douro wine — so semantic search recalls
+  // the label-true name without forking the vocabulary. A wine with no
+  // applicable mapping produces BYTE-IDENTICAL text to before: textHash is
+  // the embedding job's skip key, so any accidental change here re-embeds the
+  // whole registry (pinned in embedding.buildText.test.js).
+  const grapeNames = (wine.grapes || [])
+    .filter(g => g && g.name)
+    .map(g => {
+      const display = resolveGrapeDisplayName(g, { countryId: wine.country, regionId: wine.region });
+      return display && display !== g.name ? `${g.name} (${display})` : g.name;
+    })
+    .join(', ');
   if (grapeNames)          lines.push(`Grapes: ${grapeNames}`);
   if (wine.appellation)    lines.push(`Appellation: ${wine.appellation}`);
   if (wine.classification) lines.push(`Classification: ${wine.classification}`);

--- a/backend/src/services/embeddingJob.js
+++ b/backend/src/services/embeddingJob.js
@@ -175,7 +175,8 @@ async function runJob(cfg) {
         const wine = await WineDefinition.findById(wineDefId)
           .populate('country', 'name')
           .populate('region', 'name')
-          .populate('grapes', 'name')
+          // regionalNames feed buildEmbeddingText's regional grape labels.
+          .populate('grapes', 'name regionalNames')
           .lean();
 
         if (!wine) {
@@ -321,7 +322,8 @@ async function embedSinglePair(wineDefId, vintage) {
     const wine = await WineDefinition.findById(wineDefId)
       .populate('country', 'name')
       .populate('region', 'name')
-      .populate('grapes', 'name')
+      // regionalNames feed buildEmbeddingText's regional grape labels.
+      .populate('grapes', 'name regionalNames')
       .lean();
 
     if (!wine) return;

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -6,6 +6,7 @@ const Bottle = require('../models/Bottle');
 const Discussion = require('../models/Discussion');
 const { WINE_POPULATE, CONSUMED_STATUSES } = require('../config/constants');
 const { stripHtml } = require('../utils/sanitize');
+const { resolveGrapeDisplayName } = require('../utils/grapeDisplay');
 
 const INDEX_NAME = 'wines';
 const BOTTLES_INDEX_NAME = 'bottles';
@@ -169,6 +170,22 @@ async function syncIfNeeded(idx, syncFn, label, attempt = 0) {
   }
 }
 
+// Canonical grape names, plus any regionally correct display name that
+// applies to THIS wine ("Tinta Roriz" alongside "Tempranillo" on a Douro
+// row) — additive recall so the label-true spelling matches too, while
+// grapeIds filters stay on the single canonical vocabulary. Wines with no
+// applicable mapping index exactly what they indexed before.
+function wineGrapeSearchNames(wine) {
+  const names = [];
+  for (const g of wine.grapes || []) {
+    if (!g || !g.name) continue;
+    names.push(g.name);
+    const display = resolveGrapeDisplayName(g, { countryId: wine.country, regionId: wine.region });
+    if (display && display !== g.name) names.push(display);
+  }
+  return names.join(', ');
+}
+
 function buildDocument(wine) {
   return {
     id: wine._id.toString(),
@@ -181,7 +198,7 @@ function buildDocument(wine) {
     regionId: wine.region?._id?.toString() || wine.region?.toString() || '',
     regionName: wine.region?.name || '',
     grapeIds: (wine.grapes || []).map(g => (g._id || g).toString()),
-    grapeNames: (wine.grapes || []).filter(g => g.name).map(g => g.name).join(', '),
+    grapeNames: wineGrapeSearchNames(wine),
     image: wine.image || '',
     createdAt: wine.createdAt ? Math.floor(new Date(wine.createdAt).getTime() / 1000) : 0
   };
@@ -229,7 +246,8 @@ async function fullSync() {
       WineDefinition.find({ nonWine: { $ne: true } })
         .populate('country', 'name')
         .populate('region', 'name')
-        .populate('grapes', 'name')
+        // regionalNames feed wineGrapeSearchNames (regional display recall).
+        .populate('grapes', 'name regionalNames')
         .lean(),
       buildDocument,
       index,
@@ -247,7 +265,8 @@ async function indexWine(wineId) {
     const wine = await WineDefinition.findById(wineId)
       .populate('country', 'name')
       .populate('region', 'name')
-      .populate('grapes', 'name')
+      // regionalNames feed wineGrapeSearchNames (regional display recall).
+      .populate('grapes', 'name regionalNames')
       .lean();
 
     if (!wine) return;

--- a/backend/src/utils/grapeDisplay.js
+++ b/backend/src/utils/grapeDisplay.js
@@ -1,0 +1,106 @@
+/**
+ * Regional display names for grapes (somm ticket: "Tinta Roriz stored as
+ * Tempranillo on a Douro Port").
+ *
+ * Wines reference ONE canonical Grape doc — storage, dedup, search facets,
+ * stats and pairing all keep a single vocabulary. What varies by place is the
+ * LABEL: the same variety is "Tinta Roriz" on a Douro Port and "Aragonez" on
+ * an Alentejo red. Grape.regionalNames carries those aliases; this util
+ * resolves the right one for a wine's own country/region at serialize time.
+ * Display-only: nothing here writes, and matching typed input to a grape
+ * stays the job of Grape.synonyms/normalizedSynonyms.
+ */
+
+/**
+ * String id of an ObjectId, hex string, or populated doc ({ _id }); null when
+ * absent. Ids are compared as strings so lean docs, populated refs and raw
+ * ObjectIds interoperate. An object we cannot identify (e.g. a projected doc
+ * missing _id) yields null — never "[object Object]", which two different
+ * docs would "share" and falsely match on.
+ */
+function idOf(value) {
+  if (value == null) return null;
+  if (typeof value === 'object') {
+    if (typeof value.toHexString === 'function') return value.toHexString(); // ObjectId
+    if (value._id != null) return String(value._id); // populated doc
+    return null;
+  }
+  const s = String(value);
+  return s || null;
+}
+
+/**
+ * Resolve the display name for one grape in one wine's context.
+ *
+ * Most-specific-wins:
+ *   1. an entry whose region matches the wine's region (and whose country
+ *      matches the wine's country);
+ *   2. else an entry with NO region whose country matches;
+ *   3. else the canonical `grape.name`.
+ *
+ * Null-safe on every field: a grape without regionalNames, or a wine without
+ * a country, resolves to the canonical name. Entries with a blank name are
+ * skipped rather than blanking the display.
+ *
+ * @param {object} grape                – Grape doc/lean object ({ name, regionalNames? })
+ * @param {object} [ctx]
+ * @param {*}      [ctx.countryId]      – wine's country (id, hex string, or populated doc)
+ * @param {*}      [ctx.regionId]       – wine's region (id, hex string, or populated doc)
+ * @returns {string|null} the display name, or null when grape is missing
+ */
+function resolveGrapeDisplayName(grape, { countryId, regionId } = {}) {
+  if (!grape) return null;
+  const canonical = grape.name || null;
+  const entries = Array.isArray(grape.regionalNames) ? grape.regionalNames : [];
+  if (entries.length === 0) return canonical;
+
+  const wineCountry = idOf(countryId);
+  const wineRegion = idOf(regionId);
+  // Every entry carries a country, so a wine without one can never match.
+  if (!wineCountry) return canonical;
+
+  let countryLevelMatch = null;
+  for (const entry of entries) {
+    if (!entry || typeof entry.name !== 'string' || !entry.name.trim()) continue;
+    if (idOf(entry.country) !== wineCountry) continue;
+    const entryRegion = idOf(entry.region);
+    if (entryRegion) {
+      // Region-level entry: most specific — first hit wins outright.
+      if (wineRegion && entryRegion === wineRegion) return entry.name;
+    } else if (!countryLevelMatch) {
+      countryLevelMatch = entry.name;
+    }
+  }
+  return countryLevelMatch || canonical;
+}
+
+/**
+ * Decorate a wine's populated grapes with `displayName`, resolved against the
+ * wine's own country/region. Returns a plain-object copy (Mongoose docs go
+ * through toObject(), lean objects are shallow-copied) — the input is never
+ * mutated and `name` always stays the canonical variety, so callers that
+ * store or match on `name` are unaffected.
+ *
+ * Null-safe: a missing wine passes through, wines without grapes are returned
+ * unchanged, and grapes that are bare ObjectIds (caller didn't populate) are
+ * left as-is rather than decorated with garbage.
+ *
+ * @param {object} wine – wine doc/lean object with populated `grapes` and
+ *                        `country`/`region` as ids or populated docs
+ * @returns {object} the decorated copy (or the input when falsy)
+ */
+function decorateGrapes(wine) {
+  if (!wine) return wine;
+  const out = typeof wine.toObject === 'function' ? wine.toObject() : { ...wine };
+  if (!Array.isArray(out.grapes) || out.grapes.length === 0) return out;
+  const ctx = { countryId: out.country, regionId: out.region };
+  out.grapes = out.grapes.map((g) => {
+    if (!g || typeof g !== 'object' || !g.name) return g; // unpopulated ref — leave untouched
+    const plain = typeof g.toObject === 'function' ? g.toObject() : { ...g };
+    plain.displayName = resolveGrapeDisplayName(plain, ctx) || plain.name;
+    return plain;
+  });
+  return out;
+}
+
+module.exports = { resolveGrapeDisplayName, decorateGrapes };

--- a/backend/src/utils/grapeDisplay.test.js
+++ b/backend/src/utils/grapeDisplay.test.js
@@ -1,0 +1,169 @@
+/**
+ * Regional grape display resolution (somm ticket: "Tinta Roriz stored as
+ * Tempranillo on a Douro Port").
+ *
+ * WHY THIS TEST EXISTS:
+ * Every read surface (wine/bottle routes, MCP get_wine/resolve_wine, search
+ * indexing, embedding text) funnels through these two functions, so the
+ * resolution order IS the product behavior: region entry beats country entry
+ * beats canonical, ids compare as strings across ObjectId/lean/populated
+ * shapes, and a wine with no applicable mapping must come out untouched —
+ * that last property is what keeps embedding textHashes stable (no re-embed
+ * wave) and every undecorated surface canonical.
+ */
+const mongoose = require('mongoose');
+const { resolveGrapeDisplayName, decorateGrapes } = require('./grapeDisplay');
+
+const oid = (c) => c.repeat(24);
+const PORTUGAL = oid('a');
+const SPAIN = oid('b');
+const DOURO = oid('c');
+const ALENTEJO = oid('d');
+
+const tempranillo = (overrides = {}) => ({
+  _id: oid('e'),
+  name: 'Tempranillo',
+  regionalNames: [
+    { country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' },
+    { country: PORTUGAL, region: ALENTEJO, name: 'Aragonez' },
+    { country: PORTUGAL, region: null, name: 'Tinta Roriz (PT)' },
+  ],
+  ...overrides,
+});
+
+describe('resolveGrapeDisplayName', () => {
+  test('most-specific wins: the wine\'s region entry beats the country-only entry', () => {
+    expect(resolveGrapeDisplayName(tempranillo(), { countryId: PORTUGAL, regionId: DOURO }))
+      .toBe('Tinta Roriz');
+    expect(resolveGrapeDisplayName(tempranillo(), { countryId: PORTUGAL, regionId: ALENTEJO }))
+      .toBe('Aragonez');
+  });
+
+  test('country-only fallback: a Portuguese wine from an unmapped region', () => {
+    expect(resolveGrapeDisplayName(tempranillo(), { countryId: PORTUGAL, regionId: oid('f') }))
+      .toBe('Tinta Roriz (PT)');
+    // …and a wine with no region at all.
+    expect(resolveGrapeDisplayName(tempranillo(), { countryId: PORTUGAL }))
+      .toBe('Tinta Roriz (PT)');
+  });
+
+  test('no match → canonical name (different country; entries never leak across borders)', () => {
+    expect(resolveGrapeDisplayName(tempranillo(), { countryId: SPAIN, regionId: DOURO }))
+      .toBe('Tempranillo');
+  });
+
+  test('a region-level entry does NOT apply country-wide (no region on the wine ≠ region match)', () => {
+    const grape = tempranillo({
+      regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+    });
+    expect(resolveGrapeDisplayName(grape, { countryId: PORTUGAL })).toBe('Tempranillo');
+  });
+
+  test('ids compare as strings: ObjectId, hex string and populated-doc shapes all match', () => {
+    const grape = tempranillo({
+      regionalNames: [{
+        country: new mongoose.Types.ObjectId(PORTUGAL),
+        region: new mongoose.Types.ObjectId(DOURO),
+        name: 'Tinta Roriz',
+      }],
+    });
+    // wine ctx as plain hex strings
+    expect(resolveGrapeDisplayName(grape, { countryId: PORTUGAL, regionId: DOURO })).toBe('Tinta Roriz');
+    // wine ctx as populated docs
+    expect(resolveGrapeDisplayName(grape, {
+      countryId: { _id: new mongoose.Types.ObjectId(PORTUGAL), name: 'Portugal' },
+      regionId: { _id: new mongoose.Types.ObjectId(DOURO), name: 'Douro' },
+    })).toBe('Tinta Roriz');
+    // entry ids as populated docs, ctx as ObjectIds
+    const populatedEntries = tempranillo({
+      regionalNames: [{
+        country: { _id: PORTUGAL, name: 'Portugal' },
+        region: { _id: DOURO, name: 'Douro' },
+        name: 'Tinta Roriz',
+      }],
+    });
+    expect(resolveGrapeDisplayName(populatedEntries, {
+      countryId: new mongoose.Types.ObjectId(PORTUGAL),
+      regionId: new mongoose.Types.ObjectId(DOURO),
+    })).toBe('Tinta Roriz');
+  });
+
+  test('null-safety: missing grape / regionalNames / wine country all fall back cleanly', () => {
+    expect(resolveGrapeDisplayName(null, { countryId: PORTUGAL })).toBeNull();
+    expect(resolveGrapeDisplayName({ name: 'Syrah' }, { countryId: PORTUGAL })).toBe('Syrah');
+    expect(resolveGrapeDisplayName({ name: 'Syrah', regionalNames: [] }, {})).toBe('Syrah');
+    // No wine country: entries always carry one, so nothing can match.
+    expect(resolveGrapeDisplayName(tempranillo(), {})).toBe('Tempranillo');
+    expect(resolveGrapeDisplayName(tempranillo())).toBe('Tempranillo');
+  });
+
+  test('an id-less object never matches — "[object Object]" must not become a shared key', () => {
+    // e.g. a projection that dropped _id: two different docs would both
+    // stringify to "[object Object]" and falsely "match".
+    expect(resolveGrapeDisplayName(tempranillo(), {
+      countryId: { name: 'Portugal' }, regionId: { name: 'Douro' },
+    })).toBe('Tempranillo');
+  });
+
+  test('junk entries (blank name, null entry) are skipped, never returned', () => {
+    const grape = tempranillo({
+      regionalNames: [
+        null,
+        { country: PORTUGAL, region: DOURO, name: '   ' },
+        { country: PORTUGAL, region: null, name: 'Tinta Roriz (PT)' },
+      ],
+    });
+    expect(resolveGrapeDisplayName(grape, { countryId: PORTUGAL, regionId: DOURO }))
+      .toBe('Tinta Roriz (PT)');
+  });
+});
+
+describe('decorateGrapes', () => {
+  const wine = () => ({
+    _id: oid('1'),
+    name: 'Vintage Port',
+    country: { _id: PORTUGAL, name: 'Portugal' },
+    region: { _id: DOURO, name: 'Douro' },
+    grapes: [tempranillo(), { _id: oid('2'), name: 'Touriga Nacional' }],
+  });
+
+  test('each grape gains displayName resolved against the wine\'s own place; name stays canonical', () => {
+    const out = decorateGrapes(wine());
+    expect(out.grapes[0].displayName).toBe('Tinta Roriz');
+    expect(out.grapes[0].name).toBe('Tempranillo');
+    // Unmapped grape: displayName present but equal to canonical.
+    expect(out.grapes[1].displayName).toBe('Touriga Nacional');
+    expect(out.grapes[1].name).toBe('Touriga Nacional');
+  });
+
+  test('never mutates the input (wine or grape objects)', () => {
+    const input = wine();
+    const grapeRef = input.grapes[0];
+    const out = decorateGrapes(input);
+    expect(out).not.toBe(input);
+    expect(grapeRef.displayName).toBeUndefined();
+    expect(input.grapes[0]).toBe(grapeRef);
+  });
+
+  test('Mongoose docs go through toObject() so displayName survives serialization', () => {
+    const plain = wine();
+    const doc = { toObject: () => ({ ...plain, grapes: plain.grapes.map((g) => ({ ...g })) }) };
+    const out = decorateGrapes(doc);
+    expect(out.grapes[0].displayName).toBe('Tinta Roriz');
+  });
+
+  test('null-safety: missing wine, missing grapes, unpopulated grape refs', () => {
+    expect(decorateGrapes(null)).toBeNull();
+    expect(decorateGrapes(undefined)).toBeUndefined();
+    expect(decorateGrapes({ name: 'No grapes' }).grapes).toBeUndefined();
+    expect(decorateGrapes({ grapes: [] }).grapes).toEqual([]);
+    // Bare ObjectId grapes (caller didn't populate) pass through untouched.
+    const raw = { grapes: [PORTUGAL, null] };
+    expect(decorateGrapes(raw).grapes).toEqual([PORTUGAL, null]);
+  });
+
+  test('wine with ids-only country/region (unpopulated) still resolves', () => {
+    const out = decorateGrapes({ country: PORTUGAL, region: DOURO, grapes: [tempranillo()] });
+    expect(out.grapes[0].displayName).toBe('Tinta Roriz');
+  });
+});

--- a/frontend/src/components/WineReferenceCard.js
+++ b/frontend/src/components/WineReferenceCard.js
@@ -109,7 +109,7 @@ export default function WineReferenceCard({ wine }) {
                 {grapes.length > 0 && (
                   <div className="wine-modal__row">
                     <dt>Grapes</dt>
-                    <dd>{grapes.map(g => g.name || g).join(', ')}</dd>
+                    <dd>{grapes.map(g => g.displayName || g.name || g).join(', ')}</dd>
                   </div>
                 )}
               </dl>

--- a/frontend/src/components/bottle/ViewDetails.js
+++ b/frontend/src/components/bottle/ViewDetails.js
@@ -130,7 +130,9 @@ function ViewDetails({ bottle, rackInfo, cellarId, vintageProfile, priceHistory,
         {grapes.length > 0 ? (
           <div className="bd-grapes">
             {grapes.map(g => (
-              <span key={g._id} className="bd-grape-pill">{g.name}</span>
+              // displayName = regionally correct label ("Tinta Roriz" on a
+              // Douro Port); name stays the canonical variety.
+              <span key={g._id} className="bd-grape-pill">{g.displayName || g.name}</span>
             ))}
           </div>
         ) : canEdit ? (

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1415,7 +1415,13 @@
       },
       "pendingRegion": "New — unreviewed",
       "pendingRegionTitle": "This region was created automatically by a user adding a wine and has not been reviewed by an admin",
-      "approveRegion": "Approve"
+      "approveRegion": "Approve",
+      "regionalNamesLabel": "Regional display names",
+      "regionalNamesHint": "Label-true names shown on wines from a specific place — e.g. Tempranillo appears as \"Tinta Roriz\" on Douro wines. Storage, search filters and stats keep the canonical variety; leave the region empty to cover the whole country.",
+      "addRegionalName": "+ Add regional name",
+      "regionalNameWholeCountry": "Whole country",
+      "regionalNamePlaceholder": "e.g. Tinta Roriz",
+      "regionalNameRemove": "Remove"
     },
     "wines": {
       "title": "Admin: Wine Library",

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -347,7 +347,7 @@ function AddBottle() {
           <span className={`wine-type-pill ${wine.type}`}>{wine.type}</span>
         </div>
         {wine.grapes?.length > 0 && (
-          <p className="wine-grapes">{wine.grapes.map(g => g.name).join(', ')}</p>
+          <p className="wine-grapes">{wine.grapes.map(g => g.displayName || g.name).join(', ')}</p>
         )}
       </div>
       <button className="btn btn-primary btn-small">{t('addBottle.selectBtn')}</button>

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -299,7 +299,7 @@ function AddToWishlist() {
           <span className={`wine-type-pill ${wine.type}`}>{wine.type}</span>
         </div>
         {wine.grapes?.length > 0 && (
-          <p className="wine-grapes">{wine.grapes.map(g => g.name).join(', ')}</p>
+          <p className="wine-grapes">{wine.grapes.map(g => g.displayName || g.name).join(', ')}</p>
         )}
       </div>
       <button className="btn btn-primary btn-small">{t('addToWishlist.select')}</button>

--- a/frontend/src/pages/AdminTaxonomy.css
+++ b/frontend/src/pages/AdminTaxonomy.css
@@ -170,3 +170,24 @@
   border: 1px solid var(--color-warning-border);
   color: var(--color-accent);
 }
+
+/* ── Regional display names editor (grape form) ── */
+.regional-names-hint {
+  margin: 0.15rem 0 0.5rem;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.regional-name-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr auto;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  align-items: center;
+}
+
+@media (max-width: 600px) {
+  .regional-name-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/AdminTaxonomy.js
+++ b/frontend/src/pages/AdminTaxonomy.js
@@ -86,6 +86,45 @@ function AdminTaxonomy() {
     }
   };
 
+  // ── Regional display names editor (grapes tab) ─────────────────────────────
+  // Rows of [country, optional region, display name] on the grape form — e.g.
+  // Tempranillo shown as "Tinta Roriz" on Douro wines. Each row can point at a
+  // DIFFERENT country, so regions are cached per country here instead of going
+  // through the single-country allRegions state the region/appellation forms
+  // share (that would cross-talk between rows).
+  const [regionsByCountry, setRegionsByCountry] = useState({});
+
+  const loadRegionsForCountry = async (countryId) => {
+    if (!countryId || regionsByCountry[countryId]) return;
+    try {
+      const res = await adminGetRegions(apiFetch, countryId);
+      const data = await res.json();
+      if (res.ok) setRegionsByCountry(prev => ({ ...prev, [countryId]: data.regions || [] }));
+    } catch (err) {
+      console.error('Failed to load regions', err);
+    }
+  };
+
+  const setRegionalNameRow = (idx, patch) => {
+    const rows = [...(formData.regionalNames || [])];
+    rows[idx] = { ...rows[idx], ...patch };
+    setFormData({ ...formData, regionalNames: rows });
+  };
+
+  const addRegionalNameRow = () => {
+    setFormData({
+      ...formData,
+      regionalNames: [...(formData.regionalNames || []), { country: '', region: '', name: '' }]
+    });
+  };
+
+  const removeRegionalNameRow = (idx) => {
+    setFormData({
+      ...formData,
+      regionalNames: (formData.regionalNames || []).filter((_, i) => i !== idx)
+    });
+  };
+
   // Monotonic fetch id: each fetch (tab switch, create/update/delete refresh)
   // invalidates any still in-flight response, so a slow response for the
   // previous tab can't render its documents under the new tab.
@@ -238,6 +277,14 @@ function AdminTaxonomy() {
         description: item.description || ''
       });
     } else if (activeTab === 'grapes') {
+      const regionalNames = (item.regionalNames || []).map(rn => ({
+        country: rn.country?._id || rn.country || '',
+        region: rn.region?._id || rn.region || '',
+        name: rn.name || ''
+      }));
+      // Warm the per-country region cache so existing rows show their region
+      // names immediately instead of an empty dropdown.
+      [...new Set(regionalNames.map(rn => rn.country).filter(Boolean))].forEach(loadRegionsForCountry);
       setFormData({
         name: item.name,
         synonymsText: (item.synonyms || []).join(', '),
@@ -248,7 +295,8 @@ function AdminTaxonomy() {
         characteristics: item.characteristics || [],
         agingPotential: item.agingPotential || '',
         prestige: item.prestige || '',
-        description: item.description || ''
+        description: item.description || '',
+        regionalNames
       });
     } else if (activeTab === 'appellations') {
       const countryId = item.country?._id || item.country || '';
@@ -293,7 +341,13 @@ function AdminTaxonomy() {
         characteristics: fd.characteristics || [],
         agingPotential: fd.agingPotential || null,
         prestige: fd.prestige || null,
-        description: fd.description || ''
+        description: fd.description || '',
+        // Fully empty rows (no country, no name) are just an unused "+ add"
+        // click — drop them. Half-filled rows are KEPT so the backend's
+        // validation message reaches the admin instead of silent data loss.
+        regionalNames: (fd.regionalNames || [])
+          .filter(rn => rn.country || (rn.name || '').trim())
+          .map(rn => ({ country: rn.country, region: rn.region || null, name: (rn.name || '').trim() }))
       };
     }
     if (activeTab === 'appellations') {
@@ -558,6 +612,58 @@ function AdminTaxonomy() {
           onChange={(e) => setFormData({ ...formData, prestige: e.target.value })}
           placeholder="e.g. Noble, Premium"
         />
+      </div>
+      <div className="form-group" style={{ gridColumn: '1 / -1' }}>
+        <label>{t('admin.taxonomy.regionalNamesLabel')}</label>
+        <p className="regional-names-hint">{t('admin.taxonomy.regionalNamesHint')}</p>
+        {(formData.regionalNames || []).map((rn, idx) => (
+          <div key={idx} className="regional-name-row">
+            <select
+              value={rn.country || ''}
+              onChange={(e) => {
+                // Country drives the region list — changing it resets the
+                // row's region (same interlock as the appellation form).
+                setRegionalNameRow(idx, { country: e.target.value, region: '' });
+                loadRegionsForCountry(e.target.value);
+              }}
+              aria-label={t('admin.requests.countryLabel')}
+            >
+              <option value="">{t('admin.taxonomy.selectCountry')}</option>
+              {allCountries.map(c => (
+                <option key={c._id} value={c._id}>{c.name}</option>
+              ))}
+            </select>
+            <select
+              value={rn.region || ''}
+              onChange={(e) => setRegionalNameRow(idx, { region: e.target.value })}
+              disabled={!rn.country}
+              aria-label={t('admin.taxonomy.appellationRegionLabel')}
+            >
+              <option value="">{t('admin.taxonomy.regionalNameWholeCountry')}</option>
+              {(regionsByCountry[rn.country] || []).map(r => (
+                <option key={r._id} value={r._id}>{r.name}</option>
+              ))}
+            </select>
+            <input
+              type="text"
+              value={rn.name || ''}
+              maxLength={60}
+              placeholder={t('admin.taxonomy.regionalNamePlaceholder')}
+              onChange={(e) => setRegionalNameRow(idx, { name: e.target.value })}
+              aria-label={t('admin.taxonomy.regionalNamesLabel')}
+            />
+            <button
+              type="button"
+              className="btn btn-danger btn-small"
+              onClick={() => removeRegionalNameRow(idx)}
+            >
+              {t('admin.taxonomy.regionalNameRemove')}
+            </button>
+          </div>
+        ))}
+        <button type="button" className="btn btn-secondary btn-small" onClick={addRegionalNameRow}>
+          {t('admin.taxonomy.addRegionalName')}
+        </button>
       </div>
       <div className="form-group" style={{ gridColumn: '1 / -1' }}>
         <label>Description <span style={{ fontWeight: 400, color: 'var(--color-text-secondary)' }}>(shown publicly on /grapes/:slug)</span></label>

--- a/frontend/src/pages/WineDetail.js
+++ b/frontend/src/pages/WineDetail.js
@@ -82,7 +82,9 @@ export default function WineDetail() {
   const pageUrl = `${SITE_URL}${winePath}`;
   const wineImageSrc = getWineImageUrl(wine.image);
   const imageUrl = wineImageSrc || `${SITE_URL}/cellarion-logo.jpg`;
-  const grapeNames = wine.grapes?.map(g => g.name).filter(Boolean) || [];
+  // Prefer the regionally correct label when the backend resolved one
+  // ("Tinta Roriz" on a Douro Port); g.name stays the canonical variety.
+  const grapeNames = wine.grapes?.map(g => g.displayName || g.name).filter(Boolean) || [];
 
   const ratingScale = user?.preferences?.ratingScale || '5';
   const hasRating = wine.communityRating?.reviewCount > 0;


### PR DESCRIPTION
## The real fix for the Tinta Roriz ticket — canonical storage, label-true display

Wines keep referencing ONE canonical Grape doc (search, stats, dedup and pairing keep a single vocabulary), but display surfaces now show the regionally correct name: `Grape.regionalNames` carries `{country, region?, name}` entries and a wine's own country/region picks the label — a Douro Port shows **Tinta Roriz**, an Alentejo red shows **Aragonez**, both stored as Tempranillo. Most-specific-wins: a region entry beats a country entry beats the canonical name.

### Where it shows
Wine pages, bottle pages (list + detail), MCP `get_wine`/`resolve_wine` — via a `displayName` the serializers add next to the untouched canonical `name` (`displayName || name` render). Deliberately canonical: everything storage- or matching-bound (form fills, admin tables, `set_wine_profile`'s stored-echo from #925, list grouping).

### Search + embeddings, no churn
Meilisearch wine docs gain the applicable regional names (additive). `buildEmbeddingText` emits `Tempranillo (Tinta Roriz)` **only when a mapping applies to that wine** — a wine with no applicable mapping produces byte-identical text, so nothing re-embeds except wines the mapping touches. Pinned by two tests (golden string + a mapped-grape-on-unmapped-wine equality). `idOf()` refuses to identify id-less objects — no `"[object Object]"` false matches.

### Admin
Grape editor on Admin → Taxonomy gains a "Regional names" section (country select, optional region select filtered by country, name input, add/remove). Backend validates: country exists, region belongs to that country, 1–60 chars, no duplicate (country, region) pairs, ≤20 entries; both POST and PUT accept it (shared form — a field the create API dropped would be silent data loss). Saving triggers the wines reindex automatically.

### Tests
59 new (util most-specific-wins/null-safety/id-forms, schema validation, wine+bottle route decoration, MCP display, embedding no-churn pins, admin validation incl. wrong-country region and dupe pairs) + 205 regression tests across every touched module, green in node:20-alpine. Frontend: full suite 52 files / 896 green on the branch.

### Known follow-ups (small, non-blocking)
- Bottle-index `grapeNames` stay canonical — cellar-bottle search matching "Tinta Roriz" is a 3-line `buildBottleDocument` extension later.
- `taxonomyMerge.mergeGrapes` doesn't carry the losing grape's regionalNames (same as its handling of other subsidiary fields today).
- Initial taxonomy data (Tempranillo → Portugal "Tinta Roriz" + Alentejo "Aragonez"; Grenache → Spain "Garnacha") goes in post-deploy via the admin API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
