### PR TITLE
fix(taxonomy): grape regional-names audit LOWs — cache, warnings, search, merge carry-over, sanitize

### DIFF
--- a/backend/src/routes/admin/taxonomy.grapeRegionalNames.test.js
+++ b/backend/src/routes/admin/taxonomy.grapeRegionalNames.test.js
@@ -6,10 +6,12 @@
  * regionalNames are ref-bearing display data — Mongoose validates neither
  * that the ids exist nor that a region belongs to its entry's country, and a
  * duplicate (country, region) pair would make display resolution
- * order-dependent. The validator carries those invariants; the PUT wiring
- * test pins that the route honours a rejection (400, nothing saved) and that
- * an accepted change resyncs the WINES search index (regional names feed its
- * grapeNames) without the bottles resync a rename needs.
+ * order-dependent. The validator carries those invariants; the wiring tests
+ * pin that the routes honour a rejection (400, nothing saved), that an
+ * accepted change resyncs BOTH search indexes (regional names feed the
+ * grapeNames of the wines AND bottles documents — audit 2026-08-11), that
+ * both write routes return the non-blocking curator-trap warnings, and that
+ * a region referenced by a grape's regional name refuses deletion.
  */
 
 process.env.JWT_SECRET = 'test-secret';
@@ -26,18 +28,30 @@ jest.mock('../../services/search', () => ({
 }));
 jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../../models/Country', () => ({ exists: jest.fn() }));
-jest.mock('../../models/Region', () => ({ findById: jest.fn() }));
-jest.mock('../../models/Grape', () => ({ findById: jest.fn(), find: jest.fn() }));
+jest.mock('../../models/Region', () => ({ findById: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../../models/WineDefinition', () => ({ countDocuments: jest.fn() }));
+// Constructor + statics: the POST route instantiates `new Grape(...)`.
+jest.mock('../../models/Grape', () => {
+  const Grape = jest.fn(function (fields) {
+    Object.assign(this, fields);
+    this.save = jest.fn().mockResolvedValue(undefined);
+  });
+  Grape.findById = jest.fn();
+  Grape.find = jest.fn();
+  Grape.exists = jest.fn();
+  return Grape;
+});
 
 const express = require('express');
 const http = require('http');
 const jwt = require('jsonwebtoken');
 const Country = require('../../models/Country');
 const Region = require('../../models/Region');
+const WineDefinition = require('../../models/WineDefinition');
 const Grape = require('../../models/Grape');
 const searchService = require('../../services/search');
 const router = require('./taxonomy');
-const { validateGrapeRegionalNames } = router;
+const { validateGrapeRegionalNames, computeRegionalNameWarnings } = router;
 
 const ADMIN_ID = '64b000000000000000000001';
 const GRAPE_ID = '64b00000000000000000009e';
@@ -55,6 +69,9 @@ beforeEach(() => {
       lean: async () => (String(id) === DOURO ? regionDoc(DOURO, PORTUGAL, 'Douro') : null),
     }),
   }));
+  Region.countDocuments.mockResolvedValue(0);
+  WineDefinition.countDocuments.mockResolvedValue(0);
+  Grape.exists.mockResolvedValue(null);
 });
 
 describe('validateGrapeRegionalNames', () => {
@@ -126,9 +143,62 @@ describe('validateGrapeRegionalNames', () => {
   test('an empty array is valid — it clears the grape\'s regional names', async () => {
     expect(await validateGrapeRegionalNames([])).toEqual({ value: [] });
   });
+
+  test('names get the sanitizeTaxonomyName fold grape.name gets: control chars stripped, whitespace collapsed', async () => {
+    const res = await validateGrapeRegionalNames([
+      { country: PORTUGAL, name: 'Tinta' + String.fromCharCode(0, 7) + '  Roriz\n' },
+    ]);
+    expect(res.error).toBeUndefined();
+    expect(res.value[0].name).toBe('Tinta Roriz');
+    // All-control input folds to empty and is rejected like a blank name.
+    expect((await validateGrapeRegionalNames([{ country: PORTUGAL, name: String.fromCharCode(0, 1) }])).error)
+      .toMatch(/non-empty name/);
+  });
 });
 
-// ── PUT wiring ───────────────────────────────────────────────────────────────
+// ── Curator-trap warnings (pure) ─────────────────────────────────────────────
+// A regional name that is not also a synonym displays fine but cannot be
+// written back via set_wine_profile (resolveGrapeIdsStrict matches
+// normalizedName + normalizedSynonyms only) — the check must run the exact
+// fold that write path runs, and it must flag, never block.
+
+describe('computeRegionalNameWarnings', () => {
+  const entries = (...names) => names.map((name) => ({ country: PORTUGAL, region: null, name }));
+
+  test('a name that is neither the grape nor a synonym warns, with the exact curator-facing message', () => {
+    const w = computeRegionalNameWarnings(entries('Tinta Roriz'), {
+      name: 'Tempranillo', normalizedName: 'tempranillo', synonyms: [],
+    });
+    expect(w).toEqual([
+      "'Tinta Roriz' is not a synonym of Tempranillo — curators cannot write it back via set_wine_profile; add it as a synonym too",
+    ]);
+  });
+
+  test('a synonym match silences the warning — diacritic/case-insensitively', () => {
+    const w = computeRegionalNameWarnings(entries('Tinta Roriz'), {
+      name: 'Tempranillo', normalizedName: 'tempranillo', synonyms: ['TINTA RORÍZ'],
+    });
+    expect(w).toEqual([]);
+  });
+
+  test('the static GRAPE_SYNONYMS hop counts as writable — "Aragonez" resolves to Tempranillo before the check', () => {
+    // resolveGrapeName maps Aragonez → Tempranillo, exactly as the write path
+    // would, so no synonym entry is needed for it.
+    const w = computeRegionalNameWarnings(entries('Aragonez'), {
+      name: 'Tempranillo', normalizedName: 'tempranillo', synonyms: [],
+    });
+    expect(w).toEqual([]);
+  });
+
+  test('a name that normalizes to nothing (non-Latin script) is not writable → warns', () => {
+    const w = computeRegionalNameWarnings(entries('Ркацители'), {
+      name: 'Rkatsiteli', normalizedName: 'rkatsiteli', synonyms: [],
+    });
+    expect(w).toHaveLength(1);
+  });
+});
+
+// ── Route wiring ─────────────────────────────────────────────────────────────
 
 let server, baseUrl;
 beforeAll((done) => {
@@ -141,18 +211,23 @@ beforeAll((done) => {
 afterAll((done) => { server.closeAllConnections(); server.close(done); });
 
 const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
-const put = (path, body) => fetch(`${baseUrl}/api/admin/taxonomy${path}`, {
-  method: 'PUT',
+const send = (method, path, body) => fetch(`${baseUrl}/api/admin/taxonomy${path}`, {
+  method,
   headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
-  body: JSON.stringify(body),
+  ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
 });
+const put = (path, body) => send('PUT', path, body);
+const post = (path, body) => send('POST', path, body);
 
 describe('PUT /grapes/:id regionalNames wiring', () => {
-  const grapeDoc = () => ({
+  const grapeDoc = (over = {}) => ({
     _id: GRAPE_ID,
     name: 'Tempranillo',
+    normalizedName: 'tempranillo',
+    synonyms: [],
     regionalNames: [],
     save: jest.fn().mockResolvedValue(undefined),
+    ...over,
   });
 
   test('a rejected payload → 400 with the validator\'s message, nothing saved', async () => {
@@ -170,7 +245,7 @@ describe('PUT /grapes/:id regionalNames wiring', () => {
     expect(grape.regionalNames).toEqual([]);
   });
 
-  test('a valid set saves, and resyncs the WINES index only (no rename → no bottles resync)', async () => {
+  test('a valid set saves and resyncs BOTH indexes — bottle documents carry regional grape names too', async () => {
     const grape = grapeDoc();
     Grape.findById.mockResolvedValue(grape);
     const res = await put(`/grapes/${GRAPE_ID}`, {
@@ -180,7 +255,9 @@ describe('PUT /grapes/:id regionalNames wiring', () => {
     expect(grape.regionalNames).toEqual([{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }]);
     expect(grape.save).toHaveBeenCalled();
     expect(searchService.fullSync).toHaveBeenCalled();
-    expect(searchService.fullSyncBottles).not.toHaveBeenCalled();
+    // Audit 2026-08-11: buildBottleDocument shares wineGrapeSearchNames, so a
+    // mapping change without this resync left cellar search missing the label.
+    expect(searchService.fullSyncBottles).toHaveBeenCalled();
   });
 
   test('an update that does not touch regionalNames triggers no resync at all', async () => {
@@ -190,5 +267,109 @@ describe('PUT /grapes/:id regionalNames wiring', () => {
     expect(res.status).toBe(200);
     expect(searchService.fullSync).not.toHaveBeenCalled();
     expect(searchService.fullSyncBottles).not.toHaveBeenCalled();
+  });
+
+  test('a non-synonym regional name → 200 with regionalNameWarnings (flag, never block)', async () => {
+    const grape = grapeDoc();
+    Grape.findById.mockResolvedValue(grape);
+    const res = await put(`/grapes/${GRAPE_ID}`, {
+      regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.regionalNameWarnings).toEqual([
+      "'Tinta Roriz' is not a synonym of Tempranillo — curators cannot write it back via set_wine_profile; add it as a synonym too",
+    ]);
+    expect(grape.save).toHaveBeenCalled(); // saved anyway — non-blocking
+  });
+
+  test('the INCOMING synonyms are what count when the request changes them', async () => {
+    const grape = grapeDoc(); // stored synonyms: []
+    Grape.findById.mockResolvedValue(grape);
+    const res = await put(`/grapes/${GRAPE_ID}`, {
+      synonyms: ['Tinta Roriz'],
+      regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+    });
+    const body = await res.json();
+    expect(body.regionalNameWarnings).toBeUndefined();
+  });
+
+  test('the stored doc\'s synonyms count when the request leaves them alone', async () => {
+    const grape = grapeDoc({ synonyms: ['Tinta Roriz'] });
+    Grape.findById.mockResolvedValue(grape);
+    const res = await put(`/grapes/${GRAPE_ID}`, {
+      regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+    });
+    const body = await res.json();
+    expect(body.regionalNameWarnings).toBeUndefined();
+  });
+
+  test('no regionalNames in the request → no warnings field, even if stored entries are not synonyms', async () => {
+    const grape = grapeDoc({
+      regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+    });
+    Grape.findById.mockResolvedValue(grape);
+    const res = await put(`/grapes/${GRAPE_ID}`, { origin: 'Rioja, Spain' });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.regionalNameWarnings).toBeUndefined();
+  });
+});
+
+describe('POST /grapes regionalNames wiring', () => {
+  test('creating with a non-synonym regional name → 201 with regionalNameWarnings', async () => {
+    const res = await post('/grapes', {
+      name: 'Tempranillo',
+      regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.grape.name).toBe('Tempranillo');
+    expect(body.regionalNameWarnings).toEqual([
+      "'Tinta Roriz' is not a synonym of Tempranillo — curators cannot write it back via set_wine_profile; add it as a synonym too",
+    ]);
+  });
+
+  test('creating with the name also in synonyms → 201 and NO warnings field', async () => {
+    const res = await post('/grapes', {
+      name: 'Tempranillo',
+      synonyms: ['Tinta Roriz'],
+      regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.regionalNameWarnings).toBeUndefined();
+  });
+});
+
+// ── Region DELETE guard ──────────────────────────────────────────────────────
+// A region referenced by a grape's regional display name must refuse deletion
+// (audit 2026-08-11): a dangling ref would silently drop curated display data.
+// Merge is the supported path — mergeRegions re-points regionalNames.region.
+
+describe('DELETE /regions/:id — grape regionalNames in-use guard', () => {
+  const regionDelDoc = () => ({
+    _id: DOURO,
+    name: 'Douro',
+    deleteOne: jest.fn().mockResolvedValue(undefined),
+  });
+
+  test('refuses deletion while a grape regional name references the region', async () => {
+    const region = regionDelDoc();
+    Region.findById.mockResolvedValue(region);
+    Grape.exists.mockResolvedValue({ _id: GRAPE_ID });
+    const res = await send('DELETE', `/regions/${DOURO}`);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/regional display name/);
+    expect(Grape.exists).toHaveBeenCalledWith({ 'regionalNames.region': DOURO });
+    expect(region.deleteOne).not.toHaveBeenCalled();
+  });
+
+  test('deletes normally when no grape references the region', async () => {
+    const region = regionDelDoc();
+    Region.findById.mockResolvedValue(region);
+    const res = await send('DELETE', `/regions/${DOURO}`);
+    expect(res.status).toBe(200);
+    expect(region.deleteOne).toHaveBeenCalled();
   });
 });

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const { requireAuth, requireRole } = require('../../middleware/auth');
-const { normalizeString, normalizeAppellation, normalizeAppellationKey, sanitizeTaxonomyName } = require('../../utils/normalize');
+const { normalizeString, normalizeAppellation, normalizeAppellationKey, sanitizeTaxonomyName, resolveGrapeName } = require('../../utils/normalize');
 const Country = require('../../models/Country');
 const Region = require('../../models/Region');
 const Grape = require('../../models/Grape');
@@ -401,6 +401,17 @@ router.delete('/regions/:id', async (req, res) => {
       });
     }
 
+    // Check if any grape carries a regional display name scoped to this
+    // region. A dangling ref would not crash resolution (idOf simply never
+    // matches) but it WOULD silently drop curated display data; merge is the
+    // path that preserves it (regionalNames are re-pointed there).
+    const grapeRefs = await Grape.exists({ 'regionalNames.region': req.params.id });
+    if (grapeRefs) {
+      return res.status(400).json({
+        error: 'Cannot delete region. Grape regional display name(s) reference it.'
+      });
+    }
+
     logAudit(req, 'admin.taxonomy.delete',
       { type: 'region', id: region._id },
       { name: region.name }
@@ -445,7 +456,12 @@ async function validateGrapeRegionalNames(input) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
       return { error: 'regionalNames must be an array of { country, region?, name } entries' };
     }
-    const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+    // Same bounding grape.name gets (utils/normalize): control characters
+    // become spaces, whitespace collapses, length is capped — a regional name
+    // is substituted into the same display/search surfaces, so a newline or a
+    // zero-width char must not survive here either (returns '' for
+    // non-strings, which the emptiness check below rejects).
+    const name = sanitizeTaxonomyName(entry.name);
     if (!name) return { error: 'Each regional name needs a non-empty name' };
     if (name.length > REGIONAL_NAME_MAX_LENGTH) {
       return { error: `Regional names must be ${REGIONAL_NAME_MAX_LENGTH} characters or fewer` };
@@ -474,6 +490,36 @@ async function validateGrapeRegionalNames(input) {
     value.push({ country: countryKey, region: regionKey, name });
   }
   return { value };
+}
+
+/**
+ * Curator-trap check: a regional name that is NOT also a synonym of its grape
+ * DISPLAYS fine, but cannot be written back — a curator reading "Tinta Roriz"
+ * off a wine card and typing it into set_wine_profile gets "unknown variety",
+ * because resolveGrapeIdsStrict matches normalizedName + normalizedSynonyms
+ * only. Runs the exact fold that write path runs
+ * (normalizeString(resolveGrapeName(name))) against the grape AS IT WILL BE
+ * SAVED. Non-blocking by house doctrine — a display name is legitimate
+ * without being a synonym; flag, never block.
+ *
+ * @param {Array<{name:string}>} entries  validated regionalNames
+ * @param {{name:string, normalizedName:string, synonyms?:string[]}} grape
+ *        effective fields (incoming values win over the stored doc's)
+ * @returns {string[]} one warning per non-writable name; [] when all write back
+ */
+function computeRegionalNameWarnings(entries, { name, normalizedName, synonyms }) {
+  const writable = new Set(
+    [normalizedName, ...(synonyms || []).map(normalizeString)].filter(Boolean)
+  );
+  const warnings = [];
+  for (const entry of entries) {
+    const key = normalizeString(resolveGrapeName(entry.name));
+    if (key && writable.has(key)) continue;
+    warnings.push(
+      `'${entry.name}' is not a synonym of ${name} — curators cannot write it back via set_wine_profile; add it as a synonym too`
+    );
+  }
+  return warnings;
 }
 
 // GET /api/admin/taxonomy/grapes - List all grapes
@@ -531,7 +577,14 @@ router.post('/grapes', async (req, res) => {
       { type: 'grape', id: grape._id },
       { name: grape.name }
     );
-    res.status(201).json({ grape });
+    // Non-blocking curator-trap warnings (see computeRegionalNameWarnings) —
+    // present only when at least one regional name cannot be written back.
+    const warnings = computeRegionalNameWarnings(regionalNamesValue, {
+      name: grape.name,
+      normalizedName: grape.normalizedName,
+      synonyms: grape.synonyms,
+    });
+    res.status(201).json({ grape, ...(warnings.length ? { regionalNameWarnings: warnings } : {}) });
   } catch (error) {
     if (error.code === 11000) {
       return res.status(400).json({ error: 'Grape already exists' });
@@ -586,12 +639,26 @@ router.put('/grapes/:id', async (req, res) => {
     // Resync search indexes if name changed (denormalized data). Bottle
     // documents denormalize taxonomy names too — fullSync() alone rebuilds
     // only the wines index, leaving cellar search matching the old name.
-    // regionalNames feed only the WINES index's grapeNames (regional display
-    // recall), so that change resyncs wines alone.
-    if (name) { searchService.fullSync(); searchService.fullSyncBottles(); }
-    else if (regionalNames !== undefined) { searchService.fullSync(); }
+    // regionalNames feed the grapeNames of BOTH indexes (regional display
+    // recall — buildDocument and buildBottleDocument share the same helper),
+    // so a mapping change rebuilds both as well.
+    if (name || regionalNames !== undefined) {
+      searchService.fullSync();
+      searchService.fullSyncBottles();
+    }
 
-    res.json({ grape });
+    // Non-blocking curator-trap warnings (see computeRegionalNameWarnings),
+    // computed AFTER the assignments above so an incoming rename/synonym list
+    // wins over the stored doc's fields.
+    let warnings = [];
+    if (regionalNamesValue !== undefined) {
+      warnings = computeRegionalNameWarnings(regionalNamesValue, {
+        name: grape.name,
+        normalizedName: grape.normalizedName,
+        synonyms: grape.synonyms,
+      });
+    }
+    res.json({ grape, ...(warnings.length ? { regionalNameWarnings: warnings } : {}) });
   } catch (error) {
     console.error('Update grape error:', error);
     res.status(500).json({ error: 'Failed to update grape' });
@@ -995,3 +1062,5 @@ module.exports.validateAppellationSynonyms = validateAppellationSynonyms;
 // Exported for its unit tests (taxonomy.grapeRegionalNames.test.js) — the DB
 // lookups inside are mocked there.
 module.exports.validateGrapeRegionalNames = validateGrapeRegionalNames;
+// Pure and DB-free — exported for the same suite.
+module.exports.computeRegionalNameWarnings = computeRegionalNameWarnings;

--- a/backend/src/routes/bottles.grapeDisplay.test.js
+++ b/backend/src/routes/bottles.grapeDisplay.test.js
@@ -9,6 +9,11 @@
  * bottle page's grape pills (`g.displayName || g.name`) rest on. Storage is
  * untouched: the bottle still references the canonical Grape doc.
  *
+ * The list route's in-memory search haystack is covered here too (audit
+ * 2026-08-11): what the card DISPLAYS must be what search matches, so
+ * `?search=` must hit the regional display name resolved for each wine's own
+ * place — and only that one, not every mapping the grape carries.
+ *
  * Real router + real requireAuth/requireBottleAccess (HS256 test tokens);
  * models and side-effect services are mocked so no MongoDB is needed.
  */
@@ -39,7 +44,7 @@ jest.mock('../utils/vintageProfile', () => ({
   ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/Cellar', () => ({ findById: jest.fn(), find: jest.fn() }));
 jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
 jest.mock('../models/Rack', () => ({ updateMany: jest.fn() }));
 jest.mock('../models/Country', () => ({}));
@@ -49,7 +54,7 @@ jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
 jest.mock('../models/PriceTrackingRequest', () => ({}));
 jest.mock('../models/BottleImage', () => ({ findOne: jest.fn(), findById: jest.fn() }));
 jest.mock('../models/WineRequest', () => ({}));
-jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn(), find: jest.fn() }));
 
 const express = require('express');
 const http = require('http');
@@ -151,5 +156,74 @@ describe('GET /api/bottles/:id', () => {
     // The doc the rest of the app sees (indexing, audit) keeps canonical-only
     // grapes — decoration happens on the serialized copy.
     expect(storedBottle.wineDefinition.grapes[0].displayName).toBeUndefined();
+  });
+});
+
+// ── GET /api/bottles?search= — regional names in the in-memory haystack ──────
+
+describe('GET /api/bottles list search', () => {
+  const ALENTEJO = 'e'.repeat(24);
+
+  // Lean list bottle: a Douro wine whose Tempranillo carries BOTH a Douro
+  // mapping (applies → searchable) and an Alentejo mapping (does not apply).
+  const leanBottle = () => ({
+    _id: BOTTLE_ID,
+    cellar: CELLAR_ID,
+    status: 'active',
+    vintage: '2017',
+    createdAt: new Date('2026-01-01'),
+    wineDefinition: {
+      _id: WINE_ID,
+      name: 'Vintage Port',
+      producer: 'Quinta do Exemplo',
+      type: 'fortified',
+      country: { _id: PORTUGAL, name: 'Portugal' },
+      region: { _id: DOURO, name: 'Douro' },
+      grapes: [
+        {
+          _id: 'c'.repeat(24),
+          name: 'Tempranillo',
+          regionalNames: [
+            { country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' },
+            { country: PORTUGAL, region: ALENTEJO, name: 'Aragonez' },
+          ],
+        },
+      ],
+    },
+  });
+
+  const primeList = (bottles) => {
+    Cellar.find.mockReturnValue({ distinct: jest.fn().mockResolvedValue([CELLAR_ID]) });
+    const chain = {
+      populate: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue(bottles),
+    };
+    Bottle.find.mockReturnValue(chain);
+  };
+
+  test('?search= matches the regional display name shown on the card', async () => {
+    primeList([leanBottle()]);
+    const { status, body } = await get('/api/bottles?search=roriz');
+    expect(status).toBe(200);
+    expect(body.bottles.items).toHaveLength(1);
+    // …and the surviving item is decorated for rendering, same label.
+    expect(body.bottles.items[0].wineDefinition.grapes[0].displayName).toBe('Tinta Roriz');
+  });
+
+  test('the canonical name still matches (regional recall is additive)', async () => {
+    primeList([leanBottle()]);
+    const { body } = await get('/api/bottles?search=tempranillo');
+    expect(body.bottles.items).toHaveLength(1);
+  });
+
+  test('a mapping for a DIFFERENT place does not match — only the label the card shows', async () => {
+    primeList([leanBottle()]);
+    // "Aragonez" is this grape's ALENTEJO name; the wine is a Douro wine, so
+    // its card never shows it and search must not pretend otherwise.
+    const { body } = await get('/api/bottles?search=aragonez');
+    expect(body.bottles.items).toHaveLength(0);
   });
 });

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -27,7 +27,9 @@ const { parsePagination } = require('../utils/pagination');
 // Read-surface decoration: populated grapes gain `displayName` — the
 // regionally correct label for the bottle's wine (Tinta Roriz on a Douro
 // Port) — while `name` stays canonical for storage/filters/stats.
-const { decorateGrapes } = require('../utils/grapeDisplay');
+// resolveGrapeDisplayName feeds the in-memory search haystack below: what
+// the card displays must be what search matches.
+const { decorateGrapes, resolveGrapeDisplayName } = require('../utils/grapeDisplay');
 const mongoose = require('mongoose');
 const searchService = require('../services/search');
 // add/update/consume/restore/remove logic + rack-slot freeing live in the
@@ -257,7 +259,19 @@ router.get('/', async (req, res) => {
           b.wineDefinition?.region?.name,
           b.wineDefinition?.appellation,
           b.wineDefinition?.type,
-          ...(b.wineDefinition?.grapes || []).map(g => g.name),
+          // Canonical grape names PLUS the regional display name resolved for
+          // this wine's own country/region when it differs ("Tinta Roriz" on
+          // a Douro Port) — the card shows the regional label, so searching
+          // it must hit (audit 2026-08-11). Undefineds fall to filter(Boolean).
+          ...(b.wineDefinition?.grapes || []).flatMap(g => {
+            const names = [g?.name];
+            const display = resolveGrapeDisplayName(g, {
+              countryId: b.wineDefinition.country,
+              regionId: b.wineDefinition.region,
+            });
+            if (display && display !== g?.name) names.push(display);
+            return names;
+          }),
         ].filter(Boolean).map(s => stripAccents(String(s).toLowerCase())).join(' ');
         return words.every(word => allText.includes(word));
       });

--- a/backend/src/routes/wines.identifyText.test.js
+++ b/backend/src/routes/wines.identifyText.test.js
@@ -276,6 +276,47 @@ describe('POST /api/wines/identify-text — model output is normalized before th
   });
 });
 
+describe('POST /api/wines/identify-text — regional grape display parity', () => {
+  // Audit 2026-08-11 INFO: the AI-identify card renders next to the search
+  // list, which already shows the regional label ("Tinta Roriz" on a Douro
+  // row) — the identify response must be decorated the same way.
+  const DOURO_WINE = {
+    _id: 'w1',
+    name: 'Vintage Port',
+    producer: 'Quinta do Exemplo',
+    country: { _id: 'pt1', name: 'Portugal' },
+    region: { _id: 'douro1', name: 'Douro' },
+    grapes: [{
+      _id: 'g1',
+      name: 'Tempranillo',
+      regionalNames: [{ country: 'pt1', region: 'douro1', name: 'Tinta Roriz' }],
+    }],
+  };
+
+  test('a confident match carries displayName on its grapes; name stays canonical', async () => {
+    findOrCreateWine.mockResolvedValue({ wine: DOURO_WINE });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'quinta do exemplo vintage port' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.match.wine.grapes[0].displayName).toBe('Tinta Roriz');
+    expect(res.body.match.wine.grapes[0].name).toBe('Tempranillo');
+  });
+
+  test('soft-zone candidates are decorated too, scores untouched', async () => {
+    findOrCreateWine.mockResolvedValue({
+      wine: null,
+      candidates: [{ wine: DOURO_WINE, score: 0.9 }],
+    });
+
+    const res = await postJson(app, '/api/wines/identify-text', { query: 'quinta do exemplo vintage port' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.candidates[0].wine.grapes[0].displayName).toBe('Tinta Roriz');
+    expect(res.body.candidates[0].score).toBe(0.9);
+  });
+});
+
 describe('POST /api/wines/identify-text — demo accounts', () => {
   test('a demo JWT gets 403 demo_ai_disabled before Claude and before any probe', async () => {
     const res = await postJson(app, '/api/wines/identify-text', { query: 'penfolds bin 407' },

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -576,11 +576,19 @@ router.post('/identify-text', requireAuth, aiBurstLimiter, asyncHandler(async (r
     // near-match into noMatch — which is exactly the duplication this fixes.
     const probe = await findOrCreateWine(identified, req.user.id, { matchOnly: true });
 
+    // decorateGrapes on every wine that leaves this route: the AI-identify
+    // card sits NEXT TO the search list, which already shows the regional
+    // grape label ("Tinta Roriz" on a Douro row) — the two must agree.
     if (probe.wine) {
-      return res.json({ identified, match: { wine: probe.wine }, candidates: [], reason: null });
+      return res.json({ identified, match: { wine: decorateGrapes(probe.wine) }, candidates: [], reason: null });
     }
     if (probe.candidates?.length) {
-      return res.json({ identified, match: null, candidates: probe.candidates, reason: null });
+      return res.json({
+        identified,
+        match: null,
+        candidates: probe.candidates.map((c) => ({ ...c, wine: decorateGrapes(c.wine) })),
+        reason: null,
+      });
     }
     return res.json({ identified, match: null, candidates: [], reason: null });
   } catch (err) {

--- a/backend/src/services/search.buildBottleDocument.test.js
+++ b/backend/src/services/search.buildBottleDocument.test.js
@@ -1,0 +1,92 @@
+/**
+ * buildBottleDocument — regional grape display names in the BOTTLES index
+ * (audit 2026-08-11: the bottle card shows "Tinta Roriz" while the bottles
+ * search document only carried "Tempranillo", so searching what you see
+ * missed in cellar search).
+ *
+ * WHY THIS TEST EXISTS:
+ * The bottle document must build its grapeNames with the SAME helper the wine
+ * document uses (wineGrapeSearchNames) — canonical names always, plus the
+ * regional display name that applies to THIS wine's country/region. For
+ * bottles whose wine has no applicable mapping the field must be
+ * byte-identical to the old plain join, so the change is pure recall.
+ *
+ * The builder is pure; meilisearch and the models are mocked so requiring the
+ * service performs no I/O.
+ */
+
+jest.mock('meilisearch', () => ({ Meilisearch: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({}));
+jest.mock('../models/Bottle', () => ({}));
+jest.mock('../models/Discussion', () => ({}));
+
+const { buildBottleDocument } = require('./search');
+
+const PORTUGAL = 'a'.repeat(24);
+const DOURO = 'b'.repeat(24);
+const ALENTEJO = 'c'.repeat(24);
+const TEMPRANILLO_ID = 'd'.repeat(24);
+const TOURIGA_ID = 'e'.repeat(24);
+
+const bottle = (wineDefinition) => ({
+  _id: { toString: () => 'bottle1' },
+  cellar: 'cellar1',
+  status: 'active',
+  vintage: '2017',
+  wineDefinition,
+});
+
+const douroWine = (grapes) => ({
+  _id: 'wine1',
+  name: 'Vintage Port',
+  producer: 'Quinta do Exemplo',
+  type: 'fortified',
+  country: { _id: PORTUGAL, name: 'Portugal' },
+  region: { _id: DOURO, name: 'Douro' },
+  grapes,
+});
+
+describe('buildBottleDocument grapeNames', () => {
+  test('appends the regional display name that applies to the wine\'s own place', () => {
+    const doc = buildBottleDocument(bottle(douroWine([
+      {
+        _id: TEMPRANILLO_ID,
+        name: 'Tempranillo',
+        regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+      },
+      { _id: TOURIGA_ID, name: 'Touriga Nacional' },
+    ])));
+    expect(doc.grapeNames).toBe('Tempranillo, Tinta Roriz, Touriga Nacional');
+    // Filters stay on the canonical vocabulary — ids are untouched.
+    expect(doc.grapeIds).toEqual([TEMPRANILLO_ID, TOURIGA_ID]);
+  });
+
+  test('a mapping for a DIFFERENT place does not leak in', () => {
+    const doc = buildBottleDocument(bottle(douroWine([
+      {
+        _id: TEMPRANILLO_ID,
+        name: 'Tempranillo',
+        regionalNames: [{ country: PORTUGAL, region: ALENTEJO, name: 'Aragonez' }],
+      },
+    ])));
+    // Region-level Alentejo entry never applies to a Douro wine.
+    expect(doc.grapeNames).toBe('Tempranillo');
+  });
+
+  test('byte-stability: no applicable mapping → exactly the old plain join', () => {
+    const doc = buildBottleDocument(bottle(douroWine([
+      { _id: TEMPRANILLO_ID, name: 'Tempranillo' },
+      { _id: TOURIGA_ID, name: 'Touriga Nacional' },
+    ])));
+    // The pre-change builder produced `.filter(g => g.name).map(g => g.name)
+    // .join(', ')` — the shared helper must not change a single byte for
+    // unmapped wines, or the whole index diffs on the next full sync.
+    expect(doc.grapeNames).toBe('Tempranillo, Touriga Nacional');
+  });
+
+  test('bottles without a wineDefinition still build (empty grapeNames)', () => {
+    const doc = buildBottleDocument(bottle(null));
+    expect(doc.grapeNames).toBe('');
+    expect(doc.wineName).toBe('');
+  });
+});

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -174,7 +174,9 @@ async function syncIfNeeded(idx, syncFn, label, attempt = 0) {
 // applies to THIS wine ("Tinta Roriz" alongside "Tempranillo" on a Douro
 // row) — additive recall so the label-true spelling matches too, while
 // grapeIds filters stay on the single canonical vocabulary. Wines with no
-// applicable mapping index exactly what they indexed before.
+// applicable mapping index exactly what they indexed before. Shared by
+// buildDocument AND buildBottleDocument: bottle cards show the same regional
+// label, so cellar search must match on it too (audit 2026-08-11).
 function wineGrapeSearchNames(wine) {
   const names = [];
   for (const g of wine.grapes || []) {
@@ -355,7 +357,10 @@ function buildBottleDocument(bottle) {
     regionId: (wd.region?._id || wd.region || '').toString(),
     regionName: wd.region?.name || '',
     grapeIds: (wd.grapes || []).map(g => (g._id || g).toString()),
-    grapeNames: (wd.grapes || []).filter(g => g.name).map(g => g.name).join(', '),
+    // Same helper as the wines index (never duplicate its logic): canonical
+    // names first, then any regional display name that applies to this wine —
+    // byte-identical to the old plain join when no mapping applies.
+    grapeNames: wineGrapeSearchNames(wd),
     vintage: bottle.vintage || '',
     price: bottle.price || 0,
     rating: bottle.rating || 0,
@@ -757,5 +762,8 @@ module.exports = {
   indexDiscussion,
   removeDiscussion,
   searchDiscussions,
-  getIsAvailable
+  getIsAvailable,
+  // Pure document builder, exported for unit tests
+  // (search.buildBottleDocument.test.js) — no client needed.
+  buildBottleDocument,
 };

--- a/backend/src/services/taxonomyMerge.js
+++ b/backend/src/services/taxonomyMerge.js
@@ -5,12 +5,15 @@
  *
  *   Grape   → WineDefinition.grapes, Region.typicalGrapes/permittedGrapes;
  *             duplicate's name + synonyms move into the canonical doc's
- *             synonyms[] so findOrCreateGrapes resolves the old name forever.
- *   Region  → WineDefinition.region, Region.parentRegion, Appellation.region;
- *             duplicate's name + synonyms move into canonical synonyms[]
- *             (same re-mint protection via findOrCreateRegion).
- *   Country → WineDefinition.country, Region.country, Appellation.country;
- *             colliding region names (unique per country) are merged first.
+ *             synonyms[] so findOrCreateGrapes resolves the old name forever;
+ *             regionalNames carry over (minus already-covered place pairs).
+ *   Region  → WineDefinition.region, Region.parentRegion, Appellation.region,
+ *             Grape.regionalNames.region; duplicate's name + synonyms move
+ *             into canonical synonyms[] (same re-mint protection via
+ *             findOrCreateRegion).
+ *   Country → WineDefinition.country, Region.country, Appellation.country,
+ *             Grape.regionalNames.country; colliding region names (unique
+ *             per country) are merged first.
  *
  * Every function returns a summary object and never deletes until all
  * references are rewritten. Search reindexing of affected wines is included;
@@ -95,6 +98,20 @@ async function mergeGrapes(fromId, toId, { resync = true, synonyms = true } = {}
   for (const field of ['color', 'origin', 'agingPotential', 'prestige', 'description']) {
     if (!to[field] && from[field]) to[field] = from[field];
   }
+  // Regional display names ride along: an entry is display data about the
+  // VARIETY, so it must survive its duplicate doc. Pairs the canonical doc
+  // already covers win (one name per place — the admin validator's
+  // invariant). Ids compared as strings so ObjectIds and lean/hex forms
+  // interoperate; a null/absent region IS the country-level pair. Carried
+  // entries are copied as plain objects — never another doc's subdocuments.
+  const pairKey = (e) => `${String(e.country)}:${e.region ? String(e.region) : ''}`;
+  const takenPairs = new Set((to.regionalNames || []).map(pairKey));
+  const carriedRegionalNames = (from.regionalNames || [])
+    .filter(e => e && e.name && !takenPairs.has(pairKey(e)))
+    .map(e => ({ country: e.country, region: e.region || null, name: e.name }));
+  if (carriedRegionalNames.length) {
+    to.regionalNames = [...(to.regionalNames || []), ...carriedRegionalNames];
+  }
   await to.save(); // pre-save hook refreshes normalizedSynonyms
 
   await from.deleteOne();
@@ -130,6 +147,18 @@ async function mergeRegionDocs(from, to, { resync = true, synonyms = true } = {}
 
   const children = await Region.updateMany({ parentRegion: from._id }, { $set: { parentRegion: to._id } });
   const apps = await Appellation.updateMany({ region: from._id }, { $set: { region: to._id } });
+
+  // Grape regional display names scope to regions too — re-point them with
+  // the other refs so resolution keeps working after the duplicate goes.
+  // A re-point CAN leave a duplicate (country, region) pair on a grape that
+  // carried entries for both regions; that residue is acceptable by design:
+  // resolution is first-match and the admin validator blocks NEW duplicates
+  // on the next edit.
+  await Grape.updateMany(
+    { 'regionalNames.region': from._id },
+    { $set: { 'regionalNames.$[e].region': to._id } },
+    { arrayFilters: [{ 'e.region': from._id }] }
+  );
 
   const synonymsAdded = synonyms ? absorbSynonyms(from, to) : [];
   for (const field of ['classification', 'prestigeLevel', 'description']) {
@@ -188,6 +217,15 @@ async function mergeCountries(fromId, toId, { resync = true } = {}) {
   const affectedWines = await WineDefinition.find({ country: from._id }).select('_id').lean();
   await WineDefinition.updateMany({ country: from._id }, { $set: { country: to._id } });
   const apps = await Appellation.updateMany({ country: from._id }, { $set: { country: to._id } });
+
+  // Country-level grape regional display names follow the country merge.
+  // Duplicate-pair residue is acceptable for the same reason as in
+  // mergeRegionDocs: first-match resolution + validator blocks new dupes.
+  await Grape.updateMany(
+    { 'regionalNames.country': from._id },
+    { $set: { 'regionalNames.$[e].country': to._id } },
+    { arrayFilters: [{ 'e.country': from._id }] }
+  );
 
   await from.deleteOne();
 

--- a/backend/src/services/taxonomyMerge.test.js
+++ b/backend/src/services/taxonomyMerge.test.js
@@ -22,7 +22,7 @@ jest.mock('../models/Region', () => ({
   updateMany: jest.fn(),
   updateOne: jest.fn(),
 }));
-jest.mock('../models/Grape', () => ({ findById: jest.fn() }));
+jest.mock('../models/Grape', () => ({ findById: jest.fn(), updateMany: jest.fn() }));
 jest.mock('../models/Appellation', () => ({ updateMany: jest.fn() }));
 jest.mock('./search', () => ({ indexWine: jest.fn().mockResolvedValue(undefined) }));
 
@@ -55,6 +55,7 @@ beforeEach(() => {
   WineDefinition.updateMany.mockResolvedValue({ modifiedCount: 0 });
   Region.updateMany.mockResolvedValue({ modifiedCount: 0 });
   Region.updateOne.mockResolvedValue({ modifiedCount: 1 });
+  Grape.updateMany.mockResolvedValue({ modifiedCount: 0 });
   Appellation.updateMany.mockResolvedValue({ modifiedCount: 0 });
   primeAffectedWines([]);
 });
@@ -128,6 +129,44 @@ describe('mergeGrapes', () => {
     await mergeGrapes('g-dup', 'g-canon', { resync: false });
     expect(searchService.indexWine).not.toHaveBeenCalled();
   });
+
+  // Audit 2026-08-11: regionalNames are display data about the VARIETY — a
+  // merge that dropped them silently lost curated labels.
+  test('carries the duplicate\'s regionalNames, skipping (country, region) pairs the canonical doc already covers', async () => {
+    const from = doc({
+      _id: 'g-dup', name: 'Pinot Nero',
+      regionalNames: [
+        { country: 'c-pt', region: 'r-douro', name: 'Tinta Roriz' },   // new pair → carried
+        { country: 'c-pt', region: null, name: 'Aragonez' },           // country-level pair taken → skipped
+      ],
+    });
+    const to = doc({
+      _id: 'g-canon', name: 'Pinot Noir',
+      regionalNames: [{ country: 'c-pt', region: null, name: 'Aragonês' }],
+    });
+    Grape.findById.mockImplementation(id => Promise.resolve(id === 'g-dup' ? from : to));
+
+    await mergeGrapes('g-dup', 'g-canon');
+
+    expect(to.regionalNames).toEqual([
+      { country: 'c-pt', region: null, name: 'Aragonês' },
+      { country: 'c-pt', region: 'r-douro', name: 'Tinta Roriz' },
+    ]);
+    expect(to.save).toHaveBeenCalled();
+  });
+
+  test('regionalNames carry onto a canonical doc that had none', async () => {
+    const from = doc({
+      _id: 'g-dup', name: 'Pinot Nero',
+      regionalNames: [{ country: 'c-it', region: null, name: 'Pinot Nero' }],
+    });
+    const to = doc({ _id: 'g-canon', name: 'Pinot Noir' }); // no regionalNames field at all
+    Grape.findById.mockImplementation(id => Promise.resolve(id === 'g-dup' ? from : to));
+
+    await mergeGrapes('g-dup', 'g-canon');
+
+    expect(to.regionalNames).toEqual([{ country: 'c-it', region: null, name: 'Pinot Nero' }]);
+  });
 });
 
 describe('mergeRegions', () => {
@@ -160,6 +199,22 @@ describe('mergeRegions', () => {
     expect(to.typicalGrapes).toEqual(['g1', 'g2']);  // union, no dupes
     expect(from.deleteOne).toHaveBeenCalled();
     expect(summary).toMatchObject({ winesUpdated: 1, childRegionsUpdated: 3, appellationsUpdated: 1 });
+  });
+
+  // Audit 2026-08-11: grape regionalNames scope to regions — a merge must
+  // re-point them like every other region ref or resolution silently stops.
+  test('re-points Grape.regionalNames.region via arrayFilters', async () => {
+    const from = rdoc({ _id: 'r-dup', name: 'Piemonte' });
+    const to = rdoc({ _id: 'r-canon', name: 'Piedmont' });
+    Region.findById.mockImplementation(id => Promise.resolve(id === 'r-dup' ? from : to));
+
+    await mergeRegions('r-dup', 'r-canon');
+
+    expect(Grape.updateMany).toHaveBeenCalledWith(
+      { 'regionalNames.region': 'r-dup' },
+      { $set: { 'regionalNames.$[e].region': 'r-canon' } },
+      { arrayFilters: [{ 'e.region': 'r-dup' }] }
+    );
   });
 });
 
@@ -209,5 +264,19 @@ describe('mergeCountries', () => {
     expect(Appellation.updateMany).toHaveBeenCalledWith({ country: 'c-dup' }, { $set: { country: 'c-canon' } });
     expect(from.deleteOne).toHaveBeenCalled();
     expect(summary).toMatchObject({ winesUpdated: 3, regionsMoved: 1, regionsMerged: 1 });
+
+    // Audit 2026-08-11: country-level grape regionalNames follow the merge —
+    // and the folded colliding region re-pointed its region-level entries too
+    // (mergeRegionDocs runs for it).
+    expect(Grape.updateMany).toHaveBeenCalledWith(
+      { 'regionalNames.country': 'c-dup' },
+      { $set: { 'regionalNames.$[e].country': 'c-canon' } },
+      { arrayFilters: [{ 'e.country': 'c-dup' }] }
+    );
+    expect(Grape.updateMany).toHaveBeenCalledWith(
+      { 'regionalNames.region': 'r-coll' },
+      { $set: { 'regionalNames.$[e].region': 'r-existing' } },
+      { arrayFilters: [{ 'e.region': 'r-coll' }] }
+    );
   });
 });

--- a/backend/src/services/wineProfileOps.js
+++ b/backend/src/services/wineProfileOps.js
@@ -214,6 +214,12 @@ async function resolveGrapeIdsStrict(names) {
       $or: [{ normalizedName }, { normalizedSynonyms: normalizedName }],
     }).select('_id name').lean();
     if (grape) {
+      // Id-level dedupe: two DIFFERENT input names can resolve to one Grape
+      // doc via DB synonyms ("Tempranillo" + "Tinta Roriz") — the seen-by-name
+      // guard above only catches inputs folding to the same string, so without
+      // this the same ObjectId was stored twice. A skipped duplicate records
+      // no substitution either: nothing new gets stored under another name.
+      if (ids.some((id) => String(id) === String(grape._id))) continue;
       ids.push(grape._id);
       canonical.push(grape.name);
       if (normalizeString(raw) !== normalizeString(grape.name)) {

--- a/backend/src/services/wineProfileOps.test.js
+++ b/backend/src/services/wineProfileOps.test.js
@@ -152,6 +152,23 @@ describe('resolveGrapeIdsStrict (match-only)', () => {
     expect(r.ids).toEqual(['g-syrah']);
   });
 
+  // Info 2026-08-11: ["Tempranillo", "Tinta Roriz"] — the alias resolves via
+  // DB synonyms (normalizedSynonyms), NOT the static map, so the two inputs
+  // fold to different strings and the seen-by-name guard let the same
+  // ObjectId in twice ([X, X] stored on the wine).
+  test('two DIFFERENT names matching one doc via DB synonyms store ONE id, and the skipped duplicate records no substitution', async () => {
+    Grape.findOne.mockReturnValue(found({ _id: 'g-tempranillo', name: 'Tempranillo' }));
+    const r = await resolveGrapeIdsStrict(['Tempranillo', 'Tinta Roriz']);
+    expect(r.ok).toBe(true);
+    expect(r.ids).toEqual(['g-tempranillo']);
+    expect(r.names).toEqual(['Tempranillo']);
+    // Nothing was stored under a different name — the duplicate was skipped,
+    // so no substitution is reported for it.
+    expect(r.substitutions).toEqual([]);
+    // Both lookups really happened (the dedupe is at match time, not by name).
+    expect(Grape.findOne).toHaveBeenCalledTimes(2);
+  });
+
   // Audit 2026-08-10: names that normalize to '' (non-Latin scripts, bare
   // percentages) were silently DROPPED — a set became a partial write, and an
   // all-such list became an accidental clear of wine.grapes.

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1421,7 +1421,10 @@
       "addRegionalName": "+ Add regional name",
       "regionalNameWholeCountry": "Whole country",
       "regionalNamePlaceholder": "e.g. Tinta Roriz",
-      "regionalNameRemove": "Remove"
+      "regionalNameRemove": "Remove",
+      "savedRegionUnavailable": "(saved region — list unavailable)",
+      "regionsLoadFailed": "Failed to load the region list — a saved region scope may not display correctly.",
+      "savedWithWarnings": "Saved, with warnings:"
     },
     "wines": {
       "title": "Admin: Wine Library",

--- a/frontend/src/pages/AdminTaxonomy.js
+++ b/frontend/src/pages/AdminTaxonomy.js
@@ -49,6 +49,11 @@ function AdminTaxonomy() {
     setShowForm(false);
     setEditItem(null);
     setFormData({});
+    // Per-country region cache starts cold on every tab entry — a region
+    // created on the Regions tab must show up when returning to Grapes, and
+    // a row whose fetch failed gets a retry instead of a stale empty list.
+    setRegionsByCountry({});
+    setSaveWarnings(null);
   }, [activeTab, apiFetch]);
 
   useEffect(() => {
@@ -94,14 +99,22 @@ function AdminTaxonomy() {
   // share (that would cross-talk between rows).
   const [regionsByCountry, setRegionsByCountry] = useState({});
 
+  // Non-blocking warnings returned by a successful grape save (regional names
+  // that are not synonyms — the backend flags, never blocks).
+  const [saveWarnings, setSaveWarnings] = useState(null);
+
   const loadRegionsForCountry = async (countryId) => {
     if (!countryId || regionsByCountry[countryId]) return;
     try {
       const res = await adminGetRegions(apiFetch, countryId);
       const data = await res.json();
       if (res.ok) setRegionsByCountry(prev => ({ ...prev, [countryId]: data.regions || [] }));
+      else setError(t('admin.taxonomy.regionsLoadFailed'));
     } catch (err) {
       console.error('Failed to load regions', err);
+      // A silent failure here left a row LOOKING country-wide ("Whole
+      // country") while still submitting its saved region — say it broke.
+      setError(t('admin.taxonomy.regionsLoadFailed'));
     }
   };
 
@@ -155,11 +168,17 @@ function AdminTaxonomy() {
   const handleCreate = async (e) => {
     e.preventDefault();
     setError(null);
+    setSaveWarnings(null);
     try {
       const payload = buildPayload(formData);
       const res = await adminCreateTaxonomy(apiFetch, endpoints[activeTab], payload);
       const data = await res.json();
       if (res.ok) {
+        // The save SUCCEEDED — these are advisories (grape regional names
+        // that curators can't write back), shown as a warning, not a failure.
+        if (Array.isArray(data.regionalNameWarnings) && data.regionalNameWarnings.length > 0) {
+          setSaveWarnings(data.regionalNameWarnings);
+        }
         setShowForm(false);
         setFormData({});
         fetchItems();
@@ -180,11 +199,16 @@ function AdminTaxonomy() {
   const handleUpdate = async (e) => {
     e.preventDefault();
     setError(null);
+    setSaveWarnings(null);
     try {
       const payload = buildPayload(formData);
       const res = await adminUpdateTaxonomy(apiFetch, endpoints[activeTab], editItem._id, payload);
       const data = await res.json();
       if (res.ok) {
+        // Same advisory surface as create — warning, never a failure.
+        if (Array.isArray(data.regionalNameWarnings) && data.regionalNameWarnings.length > 0) {
+          setSaveWarnings(data.regionalNameWarnings);
+        }
         setEditItem(null);
         setFormData({});
         fetchItems();
@@ -643,6 +667,14 @@ function AdminTaxonomy() {
               {(regionsByCountry[rn.country] || []).map(r => (
                 <option key={r._id} value={r._id}>{r.name}</option>
               ))}
+              {/* Row HAS a saved region but the loaded list doesn't contain it
+                  (fetch failed / list stale): render it as its own option so
+                  the select shows the truth instead of falling back to "Whole
+                  country" while still submitting the region. */}
+              {rn.region &&
+                !(regionsByCountry[rn.country] || []).some(r => String(r._id) === String(rn.region)) && (
+                <option value={rn.region}>{t('admin.taxonomy.savedRegionUnavailable')}</option>
+              )}
             </select>
             <input
               type="text"
@@ -806,6 +838,15 @@ function AdminTaxonomy() {
       </div>
 
       {error && <div className="alert alert-error">{error}</div>}
+
+      {saveWarnings && (
+        <div className="alert alert-warning">
+          <strong>{t('admin.taxonomy.savedWithWarnings')}</strong>
+          <ul style={{ margin: '4px 0 0', paddingLeft: '1.2em' }}>
+            {saveWarnings.map((w, i) => <li key={i}>{w}</li>)}
+          </ul>
+        </div>
+      )}
 
       {isBottleSizes && <BottleSizesAdmin apiFetch={apiFetch} />}
 

--- a/frontend/src/pages/AdminTaxonomy.test.js
+++ b/frontend/src/pages/AdminTaxonomy.test.js
@@ -1,0 +1,144 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import AdminTaxonomy from './AdminTaxonomy';
+
+// Grape regional-names audit LOWs (2026-08-11), admin taxonomy page:
+//  1. the per-country region cache must start COLD on every tab entry — a
+//     region created on the Regions tab has to appear when returning to
+//     Grapes (previously the stale cache hid it until a full reload);
+//  2. a row whose saved region is missing from the loaded list (fetch failed
+//     or stale) must SHOW that saved region as an explicit option instead of
+//     silently displaying "Whole country" while still submitting the region,
+//     and the failed fetch must surface through the page error;
+//  3. a successful save that returns regionalNameWarnings shows them as a
+//     warning (never styled as a failure).
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, opts) => (opts && opts.count !== undefined ? `${key}:${opts.count}` : key),
+  }),
+}));
+
+const apiFetch = vi.fn();
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ apiFetch }) }));
+
+// Child components with their own data needs are stubbed — this suite tests
+// the page's cache/select/warning behavior, not the pickers.
+vi.mock('../components/GrapePicker', () => ({ default: () => null }));
+vi.mock('../components/BottleSizesAdmin', () => ({ default: () => null }));
+vi.mock('../components/AppellationUnmatchedModal', () => ({ default: () => null }));
+
+const getTaxonomy = vi.fn();
+const getCountries = vi.fn();
+const getGrapes = vi.fn();
+const getRegions = vi.fn();
+const updateTaxonomy = vi.fn();
+vi.mock('../api/admin', () => ({
+  adminGetTaxonomy: (...a) => getTaxonomy(...a),
+  adminGetCountries: (...a) => getCountries(...a),
+  adminGetGrapes: (...a) => getGrapes(...a),
+  adminGetRegions: (...a) => getRegions(...a),
+  adminCreateTaxonomy: vi.fn(),
+  adminUpdateTaxonomy: (...a) => updateTaxonomy(...a),
+  adminDeleteTaxonomy: vi.fn(),
+  adminMergeTaxonomy: vi.fn(),
+  adminApproveRegion: vi.fn(),
+}));
+
+const jsonRes = (body, ok = true) => ({ ok, json: () => Promise.resolve(body) });
+
+const PORTUGAL = 'a'.repeat(24);
+const DOURO = 'b'.repeat(24);
+
+const grapeItem = () => ({
+  _id: 'g1',
+  name: 'Tempranillo',
+  synonyms: [],
+  color: null,
+  wineCount: 0,
+  regionalNames: [{ country: PORTUGAL, region: DOURO, name: 'Tinta Roriz' }],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getTaxonomy.mockImplementation((_af, endpoint) => {
+    if (endpoint.endsWith('/grapes')) return Promise.resolve(jsonRes({ grapes: [grapeItem()] }));
+    if (endpoint.endsWith('/regions')) return Promise.resolve(jsonRes({ regions: [] }));
+    if (endpoint.endsWith('/appellations')) return Promise.resolve(jsonRes({ appellations: [] }));
+    return Promise.resolve(jsonRes({ countries: [] }));
+  });
+  getCountries.mockResolvedValue(jsonRes({ countries: [{ _id: PORTUGAL, name: 'Portugal' }] }));
+  getGrapes.mockResolvedValue(jsonRes({ grapes: [] }));
+  getRegions.mockResolvedValue(jsonRes({ regions: [{ _id: DOURO, name: 'Douro' }] }));
+});
+
+const openGrapeEditor = async () => {
+  fireEvent.click(screen.getByRole('button', { name: 'admin.taxonomy.grapes' }));
+  await waitFor(() => expect(screen.getByText('Tempranillo')).toBeInTheDocument());
+  fireEvent.click(screen.getByRole('button', { name: 'common.edit' }));
+};
+
+test('the per-country region cache resets on tab switch — regions are refetched on the next edit', async () => {
+  render(<AdminTaxonomy />);
+  await openGrapeEditor();
+  await waitFor(() => expect(getRegions).toHaveBeenCalledTimes(1));
+  // The loaded list renders the real region option.
+  await screen.findByRole('option', { name: 'Douro' });
+
+  // Away (where a region could be created) and back — the cache must be cold.
+  fireEvent.click(screen.getByRole('button', { name: 'admin.taxonomy.regions' }));
+  await waitFor(() => expect(screen.queryByText('Tempranillo')).not.toBeInTheDocument());
+  await openGrapeEditor();
+
+  // Without the reset, loadRegionsForCountry short-circuits on the warm cache
+  // and a region created meanwhile stays invisible until a full page reload.
+  await waitFor(() => expect(getRegions).toHaveBeenCalledTimes(2));
+});
+
+test('a failed region fetch surfaces an error AND the saved region stays visible as its own option', async () => {
+  getRegions.mockRejectedValue(new Error('network'));
+  render(<AdminTaxonomy />);
+  await openGrapeEditor();
+
+  // The failure is said out loud through the page's error surface…
+  await waitFor(() =>
+    expect(screen.getByText('admin.taxonomy.regionsLoadFailed')).toBeInTheDocument()
+  );
+
+  // …and the select tells the truth: its value is the SAVED region, rendered
+  // via the fallback option — not "Whole country" while submitting the region.
+  const regionSelect = screen.getByLabelText('admin.taxonomy.appellationRegionLabel');
+  expect(regionSelect.value).toBe(DOURO);
+  expect(
+    screen.getByRole('option', { name: 'admin.taxonomy.savedRegionUnavailable' })
+  ).toBeInTheDocument();
+});
+
+test('the saved-region fallback option disappears once the loaded list contains the region', async () => {
+  render(<AdminTaxonomy />);
+  await openGrapeEditor();
+  await screen.findByRole('option', { name: 'Douro' });
+
+  const regionSelect = screen.getByLabelText('admin.taxonomy.appellationRegionLabel');
+  expect(regionSelect.value).toBe(DOURO);
+  expect(screen.queryByRole('option', { name: 'admin.taxonomy.savedRegionUnavailable' })).toBeNull();
+});
+
+test('regionalNameWarnings from a successful save render as a warning, not a failure', async () => {
+  const warning =
+    "'Tinta Roriz' is not a synonym of Tempranillo — curators cannot write it back via set_wine_profile; add it as a synonym too";
+  updateTaxonomy.mockResolvedValue(jsonRes({ grape: grapeItem(), regionalNameWarnings: [warning] }));
+
+  const { container } = render(<AdminTaxonomy />);
+  await openGrapeEditor();
+  await screen.findByRole('option', { name: 'Douro' });
+
+  // Submit the edit form (fireEvent.submit — jsdom's click-to-submit varies
+  // by version; the submit event itself is what handleUpdate listens to).
+  fireEvent.submit(screen.getByRole('button', { name: 'common.save' }).closest('form'));
+
+  await waitFor(() => expect(screen.getByText('admin.taxonomy.savedWithWarnings')).toBeInTheDocument());
+  expect(screen.getByText(warning)).toBeInTheDocument();
+  // Warning styling, not the error alert.
+  expect(container.querySelector('.alert-warning')).not.toBeNull();
+  expect(container.querySelector('.alert-error')).toBeNull();
+});


### PR DESCRIPTION
## The follow-up batch from the v1.104.0 pre-release audit — all six LOWs + both same-theme INFOs

1. **Region dropdown cache resets on tab switch** — create a region on the Regions tab, it now appears when you return to the Grapes editor.
2. **Region-fetch failures surface** — an error shows, and a row whose saved region isn't in the loaded list renders an explicit "(saved region — list unavailable)" option instead of silently displaying Whole country while submitting the region.
3. **Curator-trap warnings** — saving a regional name that isn't also a synonym returns non-blocking `regionalNameWarnings` (computed with the exact write-path fold, incoming synonyms win over stored), rendered as a warning banner in the admin editor.
4. **Displayed labels are searchable where bottles are searched** — `buildBottleDocument` reuses the #926 canonical+regional helper (byte-identical for unmapped wines), the in-memory cellar haystack appends resolved display names, and a regionalNames change now rebuilds BOTH indexes (both use the shared helper — refines the #926 wines-only pin).
5. **Merges/deletes respect regionalNames** — grape merges carry entries (skipping covered (country, region) pairs), region DELETE refuses while a mapping references it, region/country merges re-point entries via arrayFilters (collision residue documented: first-match resolution + validator blocks new dupes).
6. **Regional names get `sanitizeTaxonomyName`** — same control-char stripping as grape names.
7. *INFO fold-in:* identify-text responses decorate grapes — the AI card shows the same regional label as the search list beside it.
8. *INFO fold-in:* `resolveGrapeIdsStrict` dedupes by grape id — `["Tempranillo", "Tinta Roriz"]` stores ONE reference, no substitution noise for the duplicate.

### Tests
332 backend across 21 suites in node:20-alpine (73 new-area + 62 bottles/wines + 197 regression neighbours); frontend full suite **900 green** incl. a new AdminTaxonomy suite (cache reset, failed-fetch fallback option, warning-banner styling).

### Deploy note
Already-seeded mappings reach **bottle** search after one `fullSyncBottles` (admin force-reindex, or any grape re-save — which now triggers both syncs). The in-memory search path works immediately.

### Known residue (flagged, out of scope)
Country DELETE has no dangling-regional-name guard (region DELETE does) — degrades to canonical display only; ticket-sized follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)