### PR TITLE
fix(registry): owner-inquiries release-audit remediation

### DIFF
--- a/backend/src/mcp/ownerInquiryTools.test.js
+++ b/backend/src/mcp/ownerInquiryTools.test.js
@@ -64,6 +64,7 @@ jest.mock('../services/ownerInquiryOps', () => ({
   queryInquiryPage: jest.fn(),
 }));
 
+const mongoose = require('mongoose');
 const WineOwnerInquiry = require('../models/WineOwnerInquiry');
 const { createOwnerInquiry, sweepExpiredInquiries, queryInquiryPage } = require('../services/ownerInquiryOps');
 const { allTools, toolsForScopes } = require('./registry');
@@ -202,10 +203,13 @@ describe('list_owner_inquiries', () => {
     queryInquiryPage.mockResolvedValue({ rows: [], total: 0, pendingCount: 0, answeredCount: 0 });
 
     await tool('list_owner_inquiries').handler({ status: 'decided', wine_id: oid('f') }, SOMM_CTX);
-    expect(queryInquiryPage.mock.calls[0][0]).toEqual({
-      status: { $in: ['resolved', 'closed'] },
-      wineDefinition: oid('f'),
-    });
+    const filter = queryInquiryPage.mock.calls[0][0];
+    expect(filter.status).toEqual({ $in: ['resolved', 'closed'] });
+    // MUST be a cast ObjectId, not the client hex string: queryInquiryPage
+    // aggregates, and Mongoose does not cast $match values in pipelines — a
+    // string filter matches nothing (audit 2026-08-11 M-1).
+    expect(filter.wineDefinition).toBeInstanceOf(mongoose.Types.ObjectId);
+    expect(String(filter.wineDefinition)).toBe(oid('f'));
 
     await tool('list_owner_inquiries').handler({ status: 'answered' }, SOMM_CTX);
     expect(queryInquiryPage.mock.calls[1][0]).toEqual({ status: 'answered' });

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -10,6 +10,7 @@
 // Audit action strings are IDENTICAL to the REST somm routes (somm.maturity.
 // review, somm.price.add) so REST and MCP curation audit identically.
 const { z } = require('zod');
+const mongoose = require('mongoose');
 const WineVintageProfile = require('../../models/WineVintageProfile');
 const WineVintagePrice = require('../../models/WineVintagePrice');
 const PriceTrackingRequest = require('../../models/PriceTrackingRequest');
@@ -1053,7 +1054,10 @@ registerTool({
     if (status === 'active') filter.status = { $in: ['open', 'answered'] };
     else if (status === 'decided') filter.status = { $in: ['resolved', 'closed'] };
     else filter.status = status;
-    if (args.wine_id) filter.wineDefinition = args.wine_id;
+    // Cast REQUIRED: queryInquiryPage runs an aggregate, and Mongoose does not
+    // cast $match values in pipelines — a hex STRING matches nothing while the
+    // sibling countDocuments (which does cast) still counts (audit M-1).
+    if (args.wine_id) filter.wineDefinition = new mongoose.Types.ObjectId(args.wine_id);
 
     const { rows, total, pendingCount, answeredCount } = await queryInquiryPage(filter, { limit, offset });
     await WineOwnerInquiry.populate(rows, [

--- a/backend/src/routes/admin/taxonomy.grapeRegionalNames.test.js
+++ b/backend/src/routes/admin/taxonomy.grapeRegionalNames.test.js
@@ -27,7 +27,7 @@ jest.mock('../../services/search', () => ({
   waitForTasks: jest.fn(),
 }));
 jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
-jest.mock('../../models/Country', () => ({ exists: jest.fn() }));
+jest.mock('../../models/Country', () => ({ exists: jest.fn(), findById: jest.fn() }));
 jest.mock('../../models/Region', () => ({ findById: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../../models/WineDefinition', () => ({ countDocuments: jest.fn() }));
 // Constructor + statics: the POST route instantiates `new Grape(...)`.
@@ -371,5 +371,37 @@ describe('DELETE /regions/:id — grape regionalNames in-use guard', () => {
     const res = await send('DELETE', `/regions/${DOURO}`);
     expect(res.status).toBe(200);
     expect(region.deleteOne).toHaveBeenCalled();
+  });
+});
+
+// ── Country DELETE guard ─────────────────────────────────────────────────────
+// Same asymmetry the region guard closed (audit 2026-08-11 L-2): a country
+// referenced only by a grape's country-level regional name must refuse
+// deletion — a dangling ref bricks that grape's next regionalNames save.
+
+describe('DELETE /countries/:id — grape regionalNames in-use guard', () => {
+  const countryDelDoc = () => ({
+    _id: PORTUGAL,
+    name: 'Portugal',
+    deleteOne: jest.fn().mockResolvedValue(undefined),
+  });
+
+  test('refuses deletion while a grape regional name references the country', async () => {
+    const country = countryDelDoc();
+    Country.findById.mockResolvedValue(country);
+    Grape.exists.mockResolvedValue({ _id: GRAPE_ID });
+    const res = await send('DELETE', `/countries/${PORTUGAL}`);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/regional display name/);
+    expect(Grape.exists).toHaveBeenCalledWith({ 'regionalNames.country': PORTUGAL });
+    expect(country.deleteOne).not.toHaveBeenCalled();
+  });
+
+  test('deletes normally when no grape references the country', async () => {
+    const country = countryDelDoc();
+    Country.findById.mockResolvedValue(country);
+    const res = await send('DELETE', `/countries/${PORTUGAL}`);
+    expect(res.status).toBe(200);
+    expect(country.deleteOne).toHaveBeenCalled();
   });
 });

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -200,6 +200,16 @@ router.delete('/countries/:id', async (req, res) => {
       });
     }
 
+    // Grape regional display names reference countries too — a dangling
+    // country ref would silently fall back to the canonical name AND brick
+    // that grape's next regionalNames save (same guard region DELETE has).
+    const grapeRef = await Grape.exists({ 'regionalNames.country': req.params.id });
+    if (grapeRef) {
+      return res.status(400).json({
+        error: 'Cannot delete country. A grape regional display name references it.'
+      });
+    }
+
     logAudit(req, 'admin.taxonomy.delete',
       { type: 'country', id: country._id },
       { name: country.name }

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -1895,8 +1895,24 @@ router.post('/merge', async (req, res) => {
     }
 
     let bottlesMoved = 0;
+    // Lifecycle parity with performWineMerge (audit 2026-08-11 M-2): pending
+    // proposals close and owner inquiries follow the bottles on the GOLDEN
+    // route too — reassignWineRefs deliberately owns only silent ref moves,
+    // these two write user-visible outcomes (reject reasons, repoint audit).
+    const goldenKeeperLabel = [keeper.producer, keeper.name].filter(Boolean).join(' — ');
     for (const src of sources) {
       bottlesMoved += await reassignWineRefs(src._id, keeperOid);
+      await WineCorrectionProposal.updateMany(
+        { status: 'pending', $or: [{ wineDefinition: src._id }, { mergeTargetId: src._id }] },
+        {
+          $set: {
+            status: 'rejected',
+            decidedAt: new Date(),
+            rejectReason: `Closed automatically: the wine was merged into "${goldenKeeperLabel}". Re-file against that wine if the issue still applies.`.slice(0, 500),
+          },
+        }
+      );
+      await repointInquiriesForWineMerge(src._id, keeperOid, goldenKeeperLabel, req);
     }
 
     // Apply the image choice. After the reassign every image points at the

--- a/backend/src/services/ownerInquiryOps.js
+++ b/backend/src/services/ownerInquiryOps.js
@@ -41,8 +41,17 @@ async function buildRecipients(wineId) {
   const ownersWith = (statusMatch) => Bottle.aggregate([
     { $match: { wineDefinition: wineOid, status: statusMatch } },
     { $sort: { createdAt: -1 } },
-    { $group: { _id: '$user', bottle: { $first: '$_id' }, cellar: { $first: '$cellar' } } },
+    // latest makes the cap DETERMINISTIC ($group emits undefined order —
+    // audit 2026-08-11 L-3: without the re-sort the 20 kept were arbitrary).
+    { $group: { _id: '$user', bottle: { $first: '$_id' }, cellar: { $first: '$cellar' }, latest: { $first: '$createdAt' } } },
+    // Demo visitors hold clones of real registry wines but can never answer
+    // (respond is requireNonDemo) — without this exclusion they crowd real
+    // owners out of the cap (audit 2026-08-11 frontend MEDIUM).
+    { $lookup: { from: 'users', localField: '_id', foreignField: '_id', as: 'owner' } },
+    { $match: { 'owner.isDemo': { $ne: true } } },
+    { $sort: { latest: -1 } },
     { $limit: RECIPIENT_CAP },
+    { $project: { bottle: 1, cellar: 1 } },
   ]);
 
   let rows = await ownersWith({ $nin: CONSUMED_STATUSES });

--- a/backend/src/services/ownerInquiryOps.test.js
+++ b/backend/src/services/ownerInquiryOps.test.js
@@ -71,7 +71,15 @@ describe('buildRecipients', () => {
     // Newest-first sort feeds $first, so each user's entry is their latest bottle.
     expect(pipeline[1]).toEqual({ $sort: { createdAt: -1 } });
     expect(pipeline[2].$group._id).toBe('$user');
-    expect(pipeline[3]).toEqual({ $limit: RECIPIENT_CAP });
+    // Audit 2026-08-11: demo accounts can never respond (requireNonDemo) and
+    // must not crowd real owners out of the cap — excluded BEFORE $limit; and
+    // the cap must be deterministic (newest owners), so the group re-sorts on
+    // the captured latest before limiting ($group emits undefined order).
+    expect(pipeline[2].$group.latest).toEqual({ $first: '$createdAt' });
+    expect(pipeline[3].$lookup).toMatchObject({ from: 'users', localField: '_id' });
+    expect(pipeline[4]).toEqual({ $match: { 'owner.isDemo': { $ne: true } } });
+    expect(pipeline[5]).toEqual({ $sort: { latest: -1 } });
+    expect(pipeline[6]).toEqual({ $limit: RECIPIENT_CAP });
   });
 
   test('falls back to consumed-bottle owners when no active bottles exist', async () => {

--- a/frontend/src/components/bottle/OwnerInquiryCard.js
+++ b/frontend/src/components/bottle/OwnerInquiryCard.js
@@ -17,6 +17,9 @@ function OwnerInquiryCard({ apiFetch, wineId }) {
   const [answer, setAnswer] = useState('');
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
+  // Terminal 409 (already answered / inquiry closed) — the form hides so the
+  // error message can't invite retries that only 409 again.
+  const [closed, setClosed] = useState(false);
   const [error, setError] = useState(null);
 
   useEffect(() => {
@@ -54,6 +57,9 @@ function OwnerInquiryCard({ apiFetch, wineId }) {
         setSent(true);
       } else {
         setError(data.error || t('bottleDetail.ownerInquiry.sendError', 'Could not send your answer — please try again.'));
+        // 409 is terminal (already answered, or the inquiry closed) — hide the
+        // form so the error can't invite retries that only 409 again.
+        if (res.status === 409) setClosed(true);
       }
     } catch {
       setError(t('common.networkError', 'Network error. Please try again.'));
@@ -78,6 +84,8 @@ function OwnerInquiryCard({ apiFetch, wineId }) {
         <p role="status" style={{ margin: 0, fontWeight: 600 }}>
           {t('bottleDetail.ownerInquiry.thanks', 'Thank you — your answer was sent to the curators and helps keep the shared registry accurate.')}
         </p>
+      ) : closed ? (
+        error && <div className="alert alert-error" style={{ margin: 0 }}>{error}</div>
       ) : (
         <form onSubmit={submit}>
           {error && <div className="alert alert-error" style={{ marginBottom: 8 }}>{error}</div>}

--- a/frontend/src/components/bottle/OwnerInquiryCard.test.js
+++ b/frontend/src/components/bottle/OwnerInquiryCard.test.js
@@ -96,3 +96,16 @@ test('a server refusal surfaces the error and keeps the form usable', async () =
   expect(await screen.findByText('This inquiry is no longer open')).toBeInTheDocument();
   expect(screen.getByText('Send answer')).toBeInTheDocument(); // still submittable
 });
+
+test('a terminal 409 (already answered / closed) hides the form — no retry that can only 409 again', async () => {
+  respondToOwnerInquiry.mockResolvedValue({ ok: false, status: 409, json: async () => ({ error: 'You already answered this inquiry' }) });
+  renderCard();
+  await screen.findByText('What does the label say the producer is?');
+
+  fireEvent.change(screen.getByPlaceholderText(/The label says/), { target: { value: 'An answer' } });
+  fireEvent.click(screen.getByText('Send answer'));
+
+  expect(await screen.findByText('You already answered this inquiry')).toBeInTheDocument();
+  expect(screen.queryByText('Send answer')).not.toBeInTheDocument();
+  expect(screen.queryByPlaceholderText(/The label says/)).not.toBeInTheDocument();
+});

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -528,8 +528,10 @@ function BottleDetail() {
       </div>
 
       {/* ── Curator owner-inquiry (content card — renders only when this
-          wine has an open inquiry addressed to the viewer) ── */}
-      {wine?._id && <OwnerInquiryCard apiFetch={apiFetch} wineId={wine._id} />}
+          wine has an open inquiry addressed to the viewer). Demo visitors are
+          excluded: their ephemeral accounts can never respond (requireNonDemo)
+          and the shop-window must not dead-end into a 403. ── */}
+      {wine?._id && !user?.isDemo && <OwnerInquiryCard apiFetch={apiFetch} wineId={wine._id} />}
 
       {/* ── Consumption details (history bottles only) ── */}
       {isConsumed && (


### PR DESCRIPTION
Everything above INFO from the 2-agent pre-release audit (both SHIP-WITH-FIXES):

- **M-1** `list_owner_inquiries` wine_id → ObjectId cast (aggregate $match never casts — the filter matched nothing while the count still counted; test now pins the cast)
- **M-2** golden bulk-merge lifecycle parity: proposals auto-reject + inquiries re-point per source (the next consolidation pass would have hit this) — no golden-route HTTP suite exists to extend, noted as residue
- **FE MEDIUM** demo gate: card hidden for demo visitors + `buildRecipients` excludes demo accounts BEFORE the cap (they can never answer and were crowding real owners out of the fan-out)
- **L-3** deterministic newest-20 recipient cap (folded into the same pipeline)
- **LOW** terminal 409 on respond hides the answer form
- **L-2** country DELETE dangling-regionalNames guard (mirrors region DELETE)

Deferred (unchanged from audit): L-1 resync debounce (echo of the standing reindex-concurrency item), INFOs.

Tests: 94 across the 7 affected backend suites; frontend full suite 908 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)