### PR TITLE
chore(release): v1.105.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.104.0",
+  "version": "1.105.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.104.0",
+      "version": "1.105.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.104.0",
+  "version": "1.105.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.104.0",
+  "version": "1.105.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.104.0",
+      "version": "1.105.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.104.0",
+  "version": "1.105.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for v1.105.0.

Contents since v1.104.0: #928 README refresh · #929 grape regional-names audit LOWs (incl. cellar search matching displayed names) · #930 owner inquiries (ask a bottle's owner about their record — REST + MCP, GDPR-wired) · #931 release-audit remediation (2 agents, SHIP-WITH-FIXES, all >INFO findings fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)