### PR TITLE
fix(search): admin reindex 500 — meilisearch-js 0.58 moved waitForTasks to client.tasks

### DIFF
--- a/backend/src/services/search.buildBottleDocument.test.js
+++ b/backend/src/services/search.buildBottleDocument.test.js
@@ -90,3 +90,15 @@ describe('buildBottleDocument grapeNames', () => {
     expect(doc.wineName).toBe('');
   });
 });
+
+// The admin reindex 500'd on prod (2026-08-11): meilisearch-js >=0.38 moved
+// task waiting to client.tasks.waitForTasks and renamed the options — the
+// client is constructor-mocked in every suite, so only a source pin can catch
+// this API-drift class before prod does.
+describe('waitForTasks Meili API pin', () => {
+  test('uses client.tasks.waitForTasks (0.38+ API), never client.waitForTasks', () => {
+    const src = require('fs').readFileSync(require.resolve('./search'), 'utf8');
+    expect(src).toMatch(/client\.tasks\.waitForTasks\(/);
+    expect(src).not.toMatch(/client\.waitForTasks\(/);
+  });
+});

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -742,7 +742,10 @@ function getIsAvailable() {
  */
 async function waitForTasks(taskUids, { timeOutMs = 120000 } = {}) {
   if (!isAvailable || !Array.isArray(taskUids) || taskUids.length === 0) return;
-  await client.waitForTasks(taskUids, { timeOutMs, intervalMs: 250 });
+  // meilisearch-js ≥0.38 moved task waiting to client.tasks and renamed the
+  // options (timeout/interval, ms) — client.waitForTasks does not exist on
+  // 0.58 and 500'd the admin reindex (prod 2026-08-11).
+  await client.tasks.waitForTasks(taskUids, { timeout: timeOutMs, interval: 250 });
 }
 
 module.exports = {


### PR DESCRIPTION
Found live on prod minutes after the v1.105.0 deploy: `POST /api/admin/search/reindex` → 500 `client.waitForTasks is not a function`. The helper (added in #926) called the pre-0.38 API; on the installed 0.58 task waiting lives at `client.tasks.waitForTasks(uids, { timeout, interval })`. The throw sat **between** the two syncs — wines enqueued, bottles never started — so the regional-names bottle backfill was silently blocked.

One-line fix + a source-pin test (the Meili client is constructor-mocked in every suite, so only a source pin can catch this drift class before prod does).

Ships as v1.105.1, backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)