### PR TITLE
fix(registry): mint wines when the bottle is committed, not when the form is filled

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -122,6 +122,12 @@ app.use('/api/bottles/import/sessions', express.json({ limit: '5mb' }));
 // coordinated batch-wide), so the limit must hold a large import — up to
 // MAX_IMPORT_SIZE (2000) items with notes. 8mb leaves comfortable headroom.
 app.use('/api/bottles/import', express.json({ limit: '8mb' }));
+// Mint-at-commit: POST /api/bottles may now carry a `newWine` object (name/
+// producer/taxonomy strings, all capped at 200 chars) alongside the bottle
+// fields — a worst-case legitimate payload (5000-char notes + 20 grapes)
+// passes the 10kb default. No images ever ride here. AFTER the /import rules
+// (first express.json to parse wins), so the import limits keep applying.
+app.use('/api/bottles', express.json({ limit: '64kb' }));
 app.use('/api/blog/admin/posts', express.json({ limit: '2mb' }));
 app.use('/api/wine-lists', express.json({ limit: '1mb' }));
 // MCP: the anonymous public surface stays tiny (no image tool) — registered

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -38,6 +38,10 @@ const {
   addBottle, updateBottleFields, consumeBottle, restoreBottle, removeFromRacks, removeBottleCascade,
   openBottle, pourFromBottle, closeBottle,
 } = require('../services/bottleOps');
+// Mint-at-commit for the POST route's `newWine` branch — the wine is created
+// (or resolved) INSIDE the bottle create, never before it. Shared with the
+// wishlist route; findOrCreateWine itself is lazy-required inside the service.
+const { resolveOrMintWine } = require('../services/wineCommit');
 const { moveBottleToCellar } = require('../services/rackOps');
 
 const router = express.Router();
@@ -364,18 +368,41 @@ router.get('/', async (req, res) => {
 // disabled for demo accounts, so rather than offer a lesser AI-free add we keep
 // the demo an explore-and-interact experience on the pre-populated cellar
 // (consume, pour, move, arrange, edit, browse). "Sign up to add your bottles."
+//
+// Wine reference — EXACTLY ONE of:
+//   wineDefinition — id of an existing registry wine (the common case)
+//   newWine        — { name, producer, country, region?, appellation?, type?,
+//                      grapes?, confirmCreate?, source? }: mint-at-commit.
+// The UI used to mint the WineDefinition in step 1 of the add flow (POST
+// /api/wines/find-or-create), before any bottle existed — a user who abandoned
+// the form left an orphan registry row forever. Measured on prod 2026-08-10:
+// 31 zero-bottle createdVia:'ui' rows; one user minted "Domaine de Riquewihr —
+// Kaefferkopf" (village-as-producer, likely fictitious) then attached their
+// bottle to a different existing wine two minutes later. The wine is now
+// resolved-or-minted HERE, inside the bottle create — the same commit-time
+// pattern as import /confirm (#899) and the MCP add_bottle tool, via the same
+// findOrCreateWine chokepoint (dedup, soft zone, taxonomy mint gates).
+// Soft-zone: when very similar wines already exist, this returns 200
+// { candidates } and creates NOTHING — the client re-submits with either an
+// existing wineDefinition id or newWine + confirmCreate:true (identical
+// semantics to the old find-or-create route, so the UI dialog is unchanged).
 router.post('/', requireNonDemo, async (req, res) => {
   try {
-    const { cellar, wineDefinition, price, currency } = req.body;
+    const { cellar, wineDefinition, newWine, price, currency } = req.body;
 
-    if (!cellar || !wineDefinition) {
-      return res.status(400).json({ error: 'Cellar and wine definition are required' });
+    if (!cellar || (!wineDefinition && !newWine)) {
+      return res.status(400).json({ error: 'Cellar and a wine (wineDefinition or newWine) are required' });
+    }
+    if (wineDefinition && newWine) {
+      return res.status(400).json({ error: 'Provide wineDefinition or newWine, not both' });
     }
 
     // Access + existence checks stay on the route — the shared service takes
     // ACCESS-CHECKED docs (same contract as the MCP tools). Soft-deleted
     // cellars are rejected too: a bottle added there would be invisible
     // everywhere (all cellar lists filter deletedAt) and effectively lost.
+    // Cellar access is checked BEFORE any registry work, so a viewer (or a
+    // stranger) can never mint a wine through a cellar they cannot add to.
     if (!mongoose.isValidObjectId(cellar)) {
       return res.status(400).json({ error: 'Invalid cellar ID' });
     }
@@ -387,12 +414,30 @@ router.post('/', requireNonDemo, async (req, res) => {
     if (!role || role === 'viewer') {
       return res.status(403).json({ error: 'Not authorized to add bottles to this cellar' });
     }
-    if (!mongoose.isValidObjectId(wineDefinition)) {
-      return res.status(400).json({ error: 'Invalid wine definition ID' });
-    }
-    const wineDoc = await WineDefinition.findById(wineDefinition);
-    if (!wineDoc) {
-      return res.status(404).json({ error: 'Wine definition not found' });
+
+    let wineDoc;
+    if (wineDefinition) {
+      if (!mongoose.isValidObjectId(wineDefinition)) {
+        return res.status(400).json({ error: 'Invalid wine definition ID' });
+      }
+      wineDoc = await WineDefinition.findById(wineDefinition);
+      if (!wineDoc) {
+        return res.status(404).json({ error: 'Wine definition not found' });
+      }
+    } else {
+      // Mint-at-commit: validation caps, dedup/soft-zone, wine.create audit
+      // (via 'ui'/'ai' per newWine.source) and IndexNow all live in the shared
+      // service — one implementation with POST /api/wishlist's newWine branch.
+      const minted = await resolveOrMintWine(newWine, req);
+      if (minted.error) {
+        return res.status(minted.error.status).json({ error: minted.error.message });
+      }
+      if (minted.candidates) {
+        // Nothing was created — a multi-bottle client submit stops on the
+        // FIRST bottle, so the whole batch waits on the user's answer.
+        return res.status(200).json({ candidates: minted.candidates });
+      }
+      wineDoc = minted.wine;
     }
 
     // ONE shared implementation with the MCP add_bottle tool (plan §7):
@@ -414,7 +459,9 @@ router.post('/', requireNonDemo, async (req, res) => {
           price,
           currency: currency || 'USD',
           userId: cellarDoc.user,
-          wineDefinitionId: wineDefinition,
+          // wineDoc, not the request field — on the newWine path there is no
+          // wineDefinition id in the body.
+          wineDefinitionId: wineDoc._id,
           vintage: bottle.vintage,
         });
       } catch (err) {

--- a/backend/src/routes/bottles.newWine.test.js
+++ b/backend/src/routes/bottles.newWine.test.js
@@ -1,0 +1,323 @@
+/**
+ * POST /api/bottles with `newWine` — mint-at-commit.
+ *
+ * WHY THIS TEST EXISTS:
+ * The UI used to mint the shared WineDefinition in STEP 1 of the add flow
+ * (POST /api/wines/find-or-create), before any bottle existed — an abandoned
+ * form left an orphan registry row forever (31 zero-bottle createdVia:'ui'
+ * rows on prod 2026-08-10; the "Domaine de Riquewihr — Kaefferkopf" case).
+ * The wine is now resolved-or-minted INSIDE the bottle create, the same
+ * commit-time pattern as import /confirm (#899) and the MCP add_bottle tool.
+ *
+ * Pinned here:
+ *   - exactly one of wineDefinition | newWine (400 otherwise)
+ *   - newWine mints ONCE via findOrCreateWine (ui/ai provenance, confirmCreate
+ *     → skipSiblingMatch parity with the old find-or-create route), audits
+ *     wine.create with the same detail shape, pings IndexNow, and creates the
+ *     bottle in the same request (201)
+ *   - soft-zone candidates → 200 { candidates }, and NOTHING is created
+ *   - the shared field caps reject junk BEFORE the service runs
+ *   - cellar access is checked BEFORE any registry work (a viewer can't mint)
+ *   - the by-id path is byte-for-byte untouched (no findOrCreateWine call)
+ *
+ * Real router + real bottleOps + real wineCommit; findOrCreateWine and every
+ * side-effect service are mocked (no MongoDB), following bottles.restore.test.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexBottle: jest.fn(),
+  removeBottle: jest.fn(),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/restockChecker', () => ({
+  checkRestockGap: jest.fn().mockResolvedValue(null),
+  resolveRestockAlerts: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../services/priceWarnings', () => ({ gatherPriceWarnings: jest.fn().mockResolvedValue([]) }));
+jest.mock('../services/communityPrice', () => ({ getCurrentRelease: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+  getSnapshotForDate: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => ({ updateMany: jest.fn() }));
+jest.mock('../models/Country', () => ({}));
+jest.mock('../models/Region', () => ({}));
+jest.mock('../models/Grape', () => ({}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('../models/PriceTrackingRequest', () => ({}));
+jest.mock('../models/BottleImage', () => ({}));
+jest.mock('../models/WineRequest', () => ({}));
+// Demo tokens make requireAuth confirm the account still exists.
+jest.mock('../models/User', () => ({ exists: jest.fn(async () => ({ _id: 'demo1' })) }));
+// Constructor-capable mock: bottleOps.addBottle does `new Bottle(doc)`.
+jest.mock('../models/Bottle', () => {
+  function MockBottle(doc) {
+    Object.assign(this, doc);
+    this._id = '64b0000000000000000000dd';
+    this.save = jest.fn().mockResolvedValue(this);
+    this.populate = jest.fn().mockResolvedValue(this);
+    MockBottle.instances.push(this);
+  }
+  MockBottle.instances = [];
+  MockBottle.findById = jest.fn();
+  return MockBottle;
+});
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const WineDefinition = require('../models/WineDefinition');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const { logAudit } = require('../services/audit');
+const { submitUrls } = require('../services/indexNow');
+const bottlesRouter = require('./bottles');
+
+const USER_ID = '64b000000000000000000001';
+const OTHER_ID = '64b000000000000000000002';
+const CELLAR_ID = '64b0000000000000000000bb';
+const WINE_ID = '64b0000000000000000000ff';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles', bottlesRouter);
+  return app;
+}
+
+function post(body, { userId = USER_ID, isDemo = false } = {}) {
+  const app = buildApp();
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: '/api/bottles',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${jwt.sign(
+              { id: userId, roles: ['user'], ...(isDemo ? { isDemo: true } : {}) },
+              'test-secret', { algorithm: 'HS256', expiresIn: '1h' }
+            )}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end(payload);
+    });
+  });
+}
+
+const NEW_WINE = {
+  name: 'Kaefferkopf', producer: 'Cave de Kaysersberg', country: 'France',
+  region: 'Alsace', appellation: 'Alsace Grand Cru', type: 'white', grapes: ['Gewürztraminer'],
+};
+const WINE_DOC = { _id: WINE_ID, name: 'Kaefferkopf', producer: 'Cave de Kaysersberg', slug: 'kaefferkopf' };
+
+const ownCellar = () =>
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, name: 'Main', user: USER_ID, members: [], deletedAt: null });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Bottle.instances.length = 0;
+  ownCellar();
+  findOrCreateWine.mockResolvedValue({ wine: WINE_DOC, created: true });
+});
+
+describe('POST /api/bottles — wine reference contract', () => {
+  test('neither wineDefinition nor newWine is a 400; nothing runs', async () => {
+    const { status, body } = await post({ cellar: CELLAR_ID, vintage: '2019' });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/wineDefinition or newWine/);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(Bottle.instances).toHaveLength(0);
+  });
+
+  test('BOTH wineDefinition and newWine is a 400; nothing runs', async () => {
+    const { status, body } = await post({
+      cellar: CELLAR_ID, vintage: '2019', wineDefinition: WINE_ID, newWine: NEW_WINE,
+    });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/not both/);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(Bottle.instances).toHaveLength(0);
+  });
+
+  test('the by-id path is untouched: loads the wine, never calls findOrCreateWine, never audits wine.create', async () => {
+    WineDefinition.findById.mockResolvedValue(WINE_DOC);
+
+    const { status, body } = await post({ cellar: CELLAR_ID, vintage: '2019', wineDefinition: WINE_ID });
+
+    expect(status).toBe(201);
+    expect(body.bottle).toBeTruthy();
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(submitUrls).not.toHaveBeenCalled();
+    expect(logAudit).not.toHaveBeenCalledWith(expect.anything(), 'wine.create', expect.anything(), expect.anything());
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'bottle.add',
+      expect.objectContaining({ type: 'bottle' }), expect.objectContaining({ wineName: 'Kaefferkopf' }));
+  });
+});
+
+describe('POST /api/bottles — newWine mints at commit', () => {
+  test('mints ONCE, creates the bottle in the same request, audits wine.create via ui, pings IndexNow → 201', async () => {
+    const { status, body } = await post({ cellar: CELLAR_ID, vintage: '2019', newWine: NEW_WINE });
+
+    expect(status).toBe(201);
+    expect(body.bottle).toBeTruthy();
+    expect(Bottle.instances).toHaveLength(1);
+    expect(String(Bottle.instances[0].wineDefinition)).toBe(WINE_ID);
+
+    // one resolve/mint, with the SAME options contract the old
+    // find-or-create route used (confirmCreate off → sibling matching on)
+    expect(findOrCreateWine).toHaveBeenCalledTimes(1);
+    const [fields, userId, opts] = findOrCreateWine.mock.calls[0];
+    expect(fields).toMatchObject({ name: 'Kaefferkopf', producer: 'Cave de Kaysersberg', country: 'France' });
+    expect(fields.grapes).toEqual(['Gewürztraminer']);
+    expect(userId).toBe(USER_ID);
+    expect(opts).toEqual({ confirmCreate: false, skipSiblingMatch: false, createdVia: 'ui' });
+
+    // audit parity with every other registry-write surface: same action name,
+    // same detail shape — plus IndexNow on a real creation
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'wine.create',
+      { type: 'wine', id: WINE_ID }, { via: 'ui', name: 'Kaefferkopf', producer: 'Cave de Kaysersberg' });
+    expect(submitUrls).toHaveBeenCalledWith('/wines/kaefferkopf');
+    // and the bottle add is audited as usual
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'bottle.add',
+      expect.objectContaining({ type: 'bottle' }), expect.objectContaining({ wineName: 'Kaefferkopf', vintage: '2019' }));
+  });
+
+  test("source:'ai' stamps createdVia 'ai' (accepted AI suggestion); provenance is allowlisted", async () => {
+    await post({ cellar: CELLAR_ID, vintage: '2019', newWine: { ...NEW_WINE, source: 'ai' } });
+    expect(findOrCreateWine.mock.calls[0][2].createdVia).toBe('ai');
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'wine.create',
+      expect.anything(), expect.objectContaining({ via: 'ai' }));
+
+    jest.clearAllMocks();
+    ownCellar();
+    findOrCreateWine.mockResolvedValue({ wine: WINE_DOC, created: true });
+    await post({ cellar: CELLAR_ID, vintage: '2019', newWine: { ...NEW_WINE, source: 'made-up' } });
+    expect(findOrCreateWine.mock.calls[0][2].createdVia).toBe('ui');
+  });
+
+  test('confirmCreate rides through with skipSiblingMatch — the explicit "create anyway" is not overridden', async () => {
+    await post({ cellar: CELLAR_ID, vintage: '2019', newWine: { ...NEW_WINE, confirmCreate: true } });
+
+    expect(findOrCreateWine.mock.calls[0][2]).toEqual({
+      confirmCreate: true, skipSiblingMatch: true, createdVia: 'ui',
+    });
+  });
+
+  test('resolved to an EXISTING wine (created:false): bottle is created, but no wine.create audit and no IndexNow', async () => {
+    findOrCreateWine.mockResolvedValue({ wine: WINE_DOC, created: false });
+
+    const { status } = await post({ cellar: CELLAR_ID, vintage: '2019', newWine: NEW_WINE });
+
+    expect(status).toBe(201);
+    expect(Bottle.instances).toHaveLength(1);
+    expect(logAudit).not.toHaveBeenCalledWith(expect.anything(), 'wine.create', expect.anything(), expect.anything());
+    expect(submitUrls).not.toHaveBeenCalled();
+  });
+
+  test('soft-zone candidates → 200 { candidates } and NOTHING is created (no bottle, no audit, no IndexNow)', async () => {
+    findOrCreateWine.mockResolvedValue({
+      wine: null,
+      candidates: [{ wine: { _id: WINE_ID, name: 'Kaefferkopf', producer: 'Cave Vinicole' }, score: 0.9 }],
+    });
+
+    const { status, body } = await post({ cellar: CELLAR_ID, vintage: '2019', newWine: NEW_WINE });
+
+    expect(status).toBe(200);
+    expect(body.candidates).toHaveLength(1);
+    expect(body.bottle).toBeUndefined();
+    expect(Bottle.instances).toHaveLength(0);
+    expect(logAudit).not.toHaveBeenCalled();
+    expect(submitUrls).not.toHaveBeenCalled();
+  });
+
+  test('service mint gates (400-status throws, e.g. place-as-producer) surface as 400', async () => {
+    const gateErr = new Error('"Bordeaux" is a wine region, not a producer — put the actual winery in the producer field');
+    gateErr.status = 400;
+    findOrCreateWine.mockRejectedValue(gateErr);
+
+    const { status, body } = await post({ cellar: CELLAR_ID, vintage: '2019', newWine: NEW_WINE });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/not a producer/);
+    expect(Bottle.instances).toHaveLength(0);
+  });
+});
+
+describe('POST /api/bottles — newWine validation caps (shared with the resolve route)', () => {
+  test.each([
+    ['missing name', { ...NEW_WINE, name: '' }, /name and producer/],
+    ['non-string producer', { ...NEW_WINE, producer: 42 }, /name and producer/],
+    ['missing country', { ...NEW_WINE, country: undefined }, /country/],
+    ['over-long name', { ...NEW_WINE, name: 'x'.repeat(201) }, /200 characters/],
+    ['over-long region', { ...NEW_WINE, region: 'x'.repeat(201) }, /region/],
+    ['grapes not an array', { ...NEW_WINE, grapes: 'Shiraz' }, /array/],
+    ['21 grapes', { ...NEW_WINE, grapes: [...Array(21).keys()].map(String) }, /at most 20/],
+    ['non-string grape', { ...NEW_WINE, grapes: [7] }, /each grape/],
+  ])('%s → 400 before the service runs', async (_label, newWine, msg) => {
+    const { status, body } = await post({ cellar: CELLAR_ID, vintage: '2019', newWine });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(msg);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(Bottle.instances).toHaveLength(0);
+  });
+});
+
+describe('POST /api/bottles — access gates run BEFORE any registry work', () => {
+  test('a viewer cannot mint through a cellar they cannot add to (403, service untouched)', async () => {
+    Cellar.findById.mockResolvedValue({
+      _id: CELLAR_ID, name: 'Shared', user: OTHER_ID,
+      members: [{ user: USER_ID, role: 'viewer' }], deletedAt: null,
+    });
+
+    const { status } = await post({ cellar: CELLAR_ID, vintage: '2019', newWine: NEW_WINE });
+
+    expect(status).toBe(403);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+
+  test('a demo account is rejected with 403 before anything runs (requireNonDemo)', async () => {
+    const { status } = await post(
+      { cellar: CELLAR_ID, vintage: '2019', newWine: NEW_WINE },
+      { userId: 'demo1', isDemo: true }
+    );
+
+    expect(status).toBe(403);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(Bottle.instances).toHaveLength(0);
+  });
+});

--- a/backend/src/routes/wines.findOrCreate.test.js
+++ b/backend/src/routes/wines.findOrCreate.test.js
@@ -1,11 +1,17 @@
 /**
- * POST /api/wines/find-or-create — the registry-write chokepoint.
+ * POST /api/wines/find-or-create — the add flows' step-1 RESOLVE endpoint.
  *
- * Since identify-text became read-only, this is the ONLY user-facing path that
- * mints a WineDefinition, and it now receives machine-generated payloads (the
- * AI suggestion the user accepted, forwarded verbatim by AddBottle /
- * AddToWishlist). It had no route-level coverage at all; these tests pin the
- * guards and the provenance stamp.
+ * This route used to be the registry-write chokepoint: it minted the
+ * WineDefinition the moment the user confirmed the wine in step 1, before any
+ * bottle existed — an abandoned flow left an orphan row forever (31 zero-bottle
+ * createdVia:'ui' rows on prod, 2026-08-10; the "Domaine de Riquewihr —
+ * Kaefferkopf" case). It is now RESOLVE-ONLY (matchOnly), the same shape as
+ * identify-text (v1.97) and import /validate (#899): creation moved to the
+ * bottle/wishlist commit (services/wineCommit, covered by its own suites).
+ *
+ * These tests pin the guards (unchanged), and the new no-write contract:
+ * matchOnly always, never 201, never an audit or IndexNow ping, and a
+ * confirmCreate in the body is ignored rather than becoming a create.
  *
  * Real router; the service layer is mocked (no MongoDB).
  */
@@ -23,6 +29,7 @@ jest.mock('../services/labelScan', () => ({
 }));
 jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
 jest.mock('../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
 jest.mock('../models/User', () => ({
   findById: jest.fn(() => ({ select: () => ({ lean: async () => null }) })),
@@ -34,6 +41,7 @@ const express = require('express');
 const jwt = require('jsonwebtoken');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
 const { submitUrls } = require('../services/indexNow');
+const { logAudit } = require('../services/audit');
 const winesRouter = require('./wines');
 
 const USER_ID = 'u1';
@@ -104,7 +112,7 @@ describe('POST /api/wines/find-or-create — guards', () => {
     expect(findOrCreateWine).not.toHaveBeenCalled();
   });
 
-  test('missing country is a 400 — an AI suggestion with a null country cannot be accepted', async () => {
+  test('missing country is a 400 — an AI suggestion with a null country cannot be resolved', async () => {
     const res = await post({ name: 'Bin 407', producer: 'Penfolds' });
 
     expect(res.status).toBe(400);
@@ -118,7 +126,7 @@ describe('POST /api/wines/find-or-create — guards', () => {
     expect(findOrCreateWine).not.toHaveBeenCalled();
   });
 
-  test('an over-long name or region is a 400 (region cap is new — findOrCreateRegion mints what arrives)', async () => {
+  test('an over-long name or region is a 400 (region cap: findOrCreateRegion mints what arrives)', async () => {
     const long = 'x'.repeat(201);
 
     expect((await post({ ...VALID, name: long })).status).toBe(400);
@@ -140,9 +148,24 @@ describe('POST /api/wines/find-or-create — guards', () => {
   });
 });
 
-describe('POST /api/wines/find-or-create — behaviour', () => {
+describe('POST /api/wines/find-or-create — resolve-only behaviour', () => {
+  test('resolves with matchOnly and NOTHING else — never a create option', async () => {
+    await post(VALID);
+
+    expect(findOrCreateWine).toHaveBeenCalledTimes(1);
+    expect(findOrCreateWine.mock.calls[0][2]).toEqual({ matchOnly: true });
+  });
+
+  test('a confident match returns 200 { wine, created: false }', async () => {
+    const res = await post(VALID);
+
+    expect(res.status).toBe(200);
+    expect(res.body.wine._id).toBe('w1');
+    expect(res.body.created).toBe(false);
+  });
+
   test('a soft-zone result hands candidates back as 200 and creates nothing', async () => {
-    findOrCreateWine.mockResolvedValue({ candidates: [{ wine: { _id: 'w9' }, score: 0.88 }] });
+    findOrCreateWine.mockResolvedValue({ wine: null, candidates: [{ wine: { _id: 'w9' }, score: 0.88 }] });
 
     const res = await post(VALID);
 
@@ -151,39 +174,33 @@ describe('POST /api/wines/find-or-create — behaviour', () => {
     expect(submitUrls).not.toHaveBeenCalled();
   });
 
-  test('a create returns 201 and pings IndexNow', async () => {
-    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1', slug: 'bin-407' }, created: true });
+  test('no match returns 200 { wine: null, noMatch: true } — the client carries the fields to the commit', async () => {
+    findOrCreateWine.mockResolvedValue({ wine: null, noMatch: true });
 
     const res = await post(VALID);
 
-    expect(res.status).toBe(201);
-    expect(submitUrls).toHaveBeenCalledWith('/wines/bin-407');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ wine: null, created: false, noMatch: true });
   });
 
-  test('confirmCreate also passes skipSiblingMatch — an explicit "create anyway" is not overridden by a sibling', async () => {
+  test('confirmCreate in the body is IGNORED — no create, no skipSiblingMatch, still matchOnly', async () => {
+    // A stale client (or a crafted request) asking to create must get a
+    // resolve, never a mint: the only mint points are the commit endpoints.
+    findOrCreateWine.mockResolvedValue({ wine: null, noMatch: true });
+
+    const res = await post({ ...VALID, confirmCreate: true, source: 'ai' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.noMatch).toBe(true);
+    expect(findOrCreateWine.mock.calls[0][2]).toEqual({ matchOnly: true });
+  });
+
+  test('never audits wine.create and never pings IndexNow — this route writes nothing', async () => {
+    findOrCreateWine.mockResolvedValue({ wine: null, noMatch: true });
+    await post(VALID);
     await post({ ...VALID, confirmCreate: true });
 
-    expect(findOrCreateWine.mock.calls[0][2]).toEqual({
-      confirmCreate: true, skipSiblingMatch: true, createdVia: 'ui',
-    });
-  });
-
-  test("source:'ai' stamps createdVia 'ai'; anything else falls back to 'ui'", async () => {
-    // Provenance keeps the accepted-AI-suggestion cohort measurable after
-    // identify-text stopped being the (unconfirmed) writer of createdVia:'ai'.
-    await post({ ...VALID, source: 'ai' });
-    expect(findOrCreateWine.mock.calls[0][2].createdVia).toBe('ai');
-
-    jest.clearAllMocks();
-    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1' }, created: false });
-
-    await post({ ...VALID, source: 'totally-made-up' });
-    expect(findOrCreateWine.mock.calls[0][2].createdVia).toBe('ui');
-
-    jest.clearAllMocks();
-    findOrCreateWine.mockResolvedValue({ wine: { _id: 'w1' }, created: false });
-
-    await post(VALID);
-    expect(findOrCreateWine.mock.calls[0][2].createdVia).toBe('ui');
+    expect(logAudit).not.toHaveBeenCalled();
+    expect(submitUrls).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -15,12 +15,10 @@ const { isValidId } = require('../utils/validation');
 // regionally correct label for THIS wine (Tinta Roriz on a Douro Port) —
 // while `name` stays canonical. Storage/filters/stats are untouched.
 const { decorateGrapes } = require('../utils/grapeDisplay');
-const { submitUrls } = require('../services/indexNow');
 const { getReleaseCurve } = require('../services/communityPrice');
 const aiBurstLimiter = require('../middleware/aiBurstLimiter');
 const asyncHandler = require('../utils/asyncHandler');
 const { tryDebitAi, isRefundableFailure, isRefundableScanError } = require('../services/aiBudget');
-const { logAudit } = require('../services/audit');
 
 const REMBG_URL = process.env.REMBG_URL || 'http://rembg:5000';
 
@@ -31,10 +29,10 @@ const router = express.Router();
 // chat message cap (chat.js).
 const MAX_AI_QUERY_LEN = 300;
 
-// Field caps for anything that reaches the registry-write path. Mirrors the
-// value findOrCreateWine enforces at its own create chokepoint.
-const MAX_WINE_FIELD = 200;
-const MAX_GRAPES = 20;
+// Field caps shared with the registry-write path (which now lives at bottle/
+// wishlist commit — services/wineCommit). Imported, not re-declared, so the
+// resolve endpoint below and the commit endpoints can never drift.
+const { validateNewWineFields, MAX_WINE_FIELD, MAX_GRAPES } = require('../services/wineCommit');
 const WINE_TYPES = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
 
 const cleanField = (v) => {
@@ -392,109 +390,69 @@ router.post('/scan-label', requireAuth, aiBurstLimiter, asyncHandler(async (req,
   }
 }));
 
-// POST /api/wines/find-or-create
-// Called after the user confirms (and optionally edits) the AI-extracted wine data.
-// Finds an existing matching wine or creates a new one, including any needed
-// taxonomy records (country, region, grapes).
+// POST /api/wines/find-or-create — resolve a confirmed wine against the
+// registry. RESOLVE-ONLY: this route creates nothing (path kept for client
+// compatibility; it is the add flows' step-1 lookup/soft-zone endpoint).
 //
-// Body:  { name, producer, country, region?, appellation?, type?, grapes?: string[],
-//           labelImage?: "data:image/png;base64,...", confirmCreate?: boolean }
-// Returns one of:
-//   { wine: WineDefinition, created: false }       — exact or auto-fuzzy match
-//   { candidates: [{ wine, score }, ...] }         — soft-zone: similar wines exist,
-//                                                     UI should ask "did you mean…?"
-//   { wine: WineDefinition, created: true }        — new wine created
+// It used to mint the WineDefinition (plus Country/Region/Grape taxonomy) the
+// moment the user confirmed the wine in STEP 1 of AddBottle/AddToWishlist —
+// before any bottle existed. A user who abandoned the flow left an orphan
+// registry row forever. Measured on prod 2026-08-10: 31 zero-bottle
+// createdVia:'ui' rows; the same day a user minted "Domaine de Riquewihr —
+// Kaefferkopf" (village-as-producer, likely fictitious) and two minutes later
+// attached their bottle to a DIFFERENT existing wine. Creation now happens at
+// the commit itself — POST /api/bottles / POST /api/wishlist with `newWine`
+// (services/wineCommit) — exactly the shape of the two prior fixes:
+// identify-text went read-only in v1.97 (52% orphan rate for 'ai' rows) and
+// import /validate went registry-read-only in v1.100.0 (#899).
 //
-// Pass `confirmCreate: true` after the user has reviewed the soft-zone
-// candidates and explicitly chosen to create a new wine anyway.
+// Body:  { name, producer, country, region?, appellation?, type?, grapes? }
+//        (confirmCreate / source / labelImage are accepted and IGNORED — a
+//         stale client may still send them; nothing here creates, so there is
+//         nothing to confirm or stamp.)
+// Returns 200 with one of:
+//   { wine, created: false }               — confident match (exact key,
+//                                            canonical/sibling, or score ≥0.95)
+//   { candidates: [{ wine, score }, ...] } — soft zone: ask "did you mean…?"
+//   { wine: null, created: false, noMatch: true }
+//                                          — not in the registry. The client
+//                                            carries the fields to the bottle/
+//                                            wishlist commit, which mints.
+// Never 201: `created` is always false here. Consumers that assumed a saved
+// document on the noMatch shape fail loudly (wine is null), not silently.
 //
-// `source: 'ai'` marks "the user accepted an AI suggestion" and stamps
-// createdVia:'ai'. Note the semantic shift: before identify-text became
-// read-only, createdVia:'ai' meant "auto-minted with nobody's confirmation"
-// (the ~162 pre-existing prod rows). From this release it means the opposite —
-// a human looked at the suggestion and said yes. The createdAt deploy boundary
-// separates the two cohorts, which is why this reuses the value rather than
-// adding an enum member.
-// requireNonDemo: find-or-create is a NON-AI registry-write primitive — on a miss
-// it mints a WineDefinition + Country/Region/Grape into the SHARED registry
-// (reachable via the AddBottle/Wishlist "create new wine" flow). purgeUserData
-// only reassigns createdBy on reap, so those rows would persist forever. A demo
-// must never create registry entries; it can only resolve existing ones elsewhere.
-// asyncHandler: the validation below runs before the try, and `?.trim()` only
-// short-circuits on null/undefined — a numeric `name` threw a rejection Express 4
-// never catches, so the request hung open forever with nothing but an
-// unhandledRejection line in the log. Same hazard the identify-text route
-// documents below; this handler was the one that still had it.
+// requireNonDemo kept deliberately: this endpoint only serves the add flows,
+// which the demo does not have (POST /api/bottles is requireNonDemo, AddBottle
+// shows a sign-up nudge) — loosening it would be an unrelated semantic change.
+// asyncHandler: `?.trim()` only short-circuits on null/undefined — a numeric
+// `name` threw a rejection Express 4 never catches, so the request hung open
+// forever. The shared validator 400s non-strings before the service runs.
 router.post('/find-or-create', requireAuth, requireNonDemo, asyncHandler(async (req, res) => {
-  const { name, producer, country, region, appellation, type, grapes, labelImage, confirmCreate, source } = req.body;
+  const { name, producer, country, region, appellation, type, grapes } = req.body;
 
-  // typeof, not `?.` — see the asyncHandler note above. A non-string here must
-  // be a 400, not a thrown TypeError.
-  if (typeof name !== 'string' || !name.trim() || typeof producer !== 'string' || !producer.trim()) {
-    return res.status(400).json({ error: 'name and producer are required' });
-  }
-  if (typeof country !== 'string' || !country.trim()) {
-    return res.status(400).json({ error: 'country is required' });
-  }
-  // Cap the free-text fields that feed the O(m·n) fuzzy-match scorer. Without
-  // this, a multi-MB name/producer (the body limit here is 5mb) would drive a
-  // huge Levenshtein computation against every candidate — an authenticated DoS.
-  // region is capped too: findOrCreateRegion mints whatever arrives, and since
-  // identify-text stopped creating, this is the sole user-facing write path and
-  // now receives machine-generated payloads.
-  for (const [field, value] of Object.entries({ name, producer, appellation, region })) {
-    if (typeof value === 'string' && value.length > MAX_WINE_FIELD) {
-      return res.status(400).json({ error: `${field} must be ${MAX_WINE_FIELD} characters or fewer` });
-    }
-  }
-  if (grapes !== undefined) {
-    if (!Array.isArray(grapes) || grapes.length > MAX_GRAPES) {
-      return res.status(400).json({ error: `grapes must be an array of at most ${MAX_GRAPES} entries` });
-    }
-    // `typeof g !== 'string' ||`, not `typeof g === 'string' &&`: the latter let a
-    // non-string element straight through to isUnknownName, which calls .trim()
-    // on it and 500s with the internal TypeError message.
-    if (grapes.some(g => typeof g !== 'string' || g.length > MAX_WINE_FIELD)) {
-      return res.status(400).json({ error: `each grape must be a string of ${MAX_WINE_FIELD} characters or fewer` });
-    }
-  }
+  // Same caps as the commit path (shared helper): the free-text fields feed
+  // the O(m·n) fuzzy-match scorer, and the body limit here is 5mb — a
+  // multi-MB name/producer would be an authenticated DoS.
+  const invalid = validateNewWineFields(req.body);
+  if (invalid) return res.status(400).json({ error: invalid });
 
   try {
-    const result = await findOrCreateWine(
+    // matchOnly and NOTHING else — same probe identify-text uses. confirmCreate
+    // must never ride along: it would gate off the soft-zone return that sits
+    // above the matchOnly gate, collapsing every 0.85–0.95 near-match into
+    // noMatch, which is exactly the duplication this endpoint exists to stop.
+    const probe = await findOrCreateWine(
       { name, producer, country, region, appellation, type, grapes: grapes || [] },
       req.user.id,
-      // skipSiblingMatch: the user has already reviewed the suggested matches
-      // (that's what confirmCreate means here) — an appellation-variant sibling
-      // must not silently override their explicit "create a new wine anyway".
-      // Strict allowlist on source so an arbitrary body value can't invent a
-      // provenance the enum would reject.
-      { confirmCreate: !!confirmCreate, skipSiblingMatch: !!confirmCreate, createdVia: source === 'ai' ? 'ai' : 'ui' }
+      { matchOnly: true }
     );
 
-    // Soft-zone: hand the candidates back so the UI can prompt the user
-    if (result.candidates) {
-      return res.status(200).json({ candidates: result.candidates });
-    }
-
-    const { wine, created } = result;
-    if (created) {
-      // This is the only user-facing path that mints into the SHARED registry,
-      // and since identify-text went read-only it is also where AI suggestions
-      // land once a user accepts them — so it was the one registry-write surface
-      // with no traceable record. `createdVia` alone doesn't serve: it is
-      // client-asserted and later merges rewrite it. Action name matches the MCP
-      // and admin surfaces so the three read as one stream.
-      logAudit(req, 'wine.create',
-        { type: 'wine', id: wine._id },
-        { via: source === 'ai' ? 'ai' : 'ui', name: wine.name, producer: wine.producer }
-      );
-      submitUrls(`/wines/${wine.slug || wine._id}`);
-    }
-
-    res.status(created ? 201 : 200).json({ wine, created });
+    if (probe.wine) return res.json({ wine: probe.wine, created: false });
+    if (probe.candidates?.length) return res.status(200).json({ candidates: probe.candidates });
+    return res.json({ wine: null, created: false, noMatch: true });
   } catch (err) {
-    console.error('Find or create wine error:', err);
-    res.status(err.status || 500).json({ error: err.message || 'Failed to find or create wine' });
+    console.error('Resolve wine error:', err);
+    res.status(err.status || 500).json({ error: err.message || 'Failed to resolve wine' });
   }
 }));
 
@@ -507,7 +465,11 @@ router.post('/find-or-create', requireAuth, requireNonDemo, asyncHandler(async (
 // confirmed and before any bottle existed. Measured on prod 2026-08-03: 85 of
 // 162 createdVia:'ai' rows had zero bottles (52%) against 3% for 'ui', and the
 // same producer arrived spelled three ways from one user retyping a query.
-// Creation now happens only when the user accepts, via POST /find-or-create.
+// Creation now happens only when the user COMMITS — POST /api/bottles /
+// /api/wishlist with `newWine` (services/wineCommit); an accepted suggestion
+// rides along as fields until then. (/find-or-create was the interim mint
+// point; it went resolve-only when the 'ui' source grew the same orphan
+// pattern — 31 zero-bottle rows by 2026-08-10.)
 //
 // Response — 200, one shape with four states:
 //   { identified: {name, producer, country, region, appellation, type,

--- a/backend/src/routes/wishlist.js
+++ b/backend/src/routes/wishlist.js
@@ -4,6 +4,9 @@ const { requireAuth } = require('../middleware/auth');
 const WishlistItem = require('../models/WishlistItem');
 const { logAudit } = require('../services/audit');
 const { escapeRegex } = require('../utils/sanitize');
+// Mint-at-commit for the POST route's `newWine` branch (shared with POST
+// /api/bottles) — findOrCreateWine itself is lazy-required inside the service.
+const { resolveOrMintWine } = require('../services/wineCommit');
 
 const router = express.Router();
 
@@ -160,22 +163,65 @@ router.get('/', async (req, res) => {
  * POST /api/wishlist
  * Add a wine to the authenticated user's wishlist.
  * Body: { wineDefinitionId, vintage?, notes?, priority? }
+ *   or: { newWine: { name, producer, country, region?, appellation?, type?,
+ *                    grapes?, confirmCreate?, source? }, vintage?, notes?, priority? }
+ *
+ * Exactly one of wineDefinitionId | newWine. A wishlist item REQUIRES a real
+ * registry row (the schema references WineDefinition, and the whole list UI
+ * populates it), so wishing for a not-yet-registered wine is a legitimate
+ * zero-bottle registry write — but the mint belongs HERE, at the commit,
+ * not in step 1 of the AddToWishlist flow. The step-1 mint (via the old
+ * find-or-create route) left an orphan whenever the user confirmed the wine
+ * and then abandoned the form — the same leak POST /api/bottles closed for
+ * bottles (31 zero-bottle createdVia:'ui' rows on prod, 2026-08-10; the
+ * "Domaine de Riquewihr — Kaefferkopf" case). Shared implementation:
+ * services/wineCommit (dedup soft zone → 200 { candidates }, nothing created;
+ * wine.create audit + IndexNow on a real mint).
  */
 router.post('/', async (req, res) => {
   try {
-    const { wineDefinitionId, vintage, notes, priority } = req.body;
+    const { wineDefinitionId, newWine, vintage, notes, priority } = req.body;
 
-    if (!wineDefinitionId || !mongoose.Types.ObjectId.isValid(wineDefinitionId)) {
-      return res.status(400).json({ error: 'Valid wineDefinitionId is required' });
+    if ((!wineDefinitionId && !newWine) || (wineDefinitionId && newWine)) {
+      return res.status(400).json({ error: 'Provide wineDefinitionId or newWine (exactly one)' });
+    }
+
+    let resolvedWineId;
+    if (newWine) {
+      // Registry write — same demo bar the old find-or-create route had
+      // (requireNonDemo): purgeUserData only reassigns createdBy on reap, so a
+      // demo-minted row would persist forever. The by-id path stays open to
+      // demo accounts (it references existing wines, writing nothing shared).
+      if (req.user.isDemo) {
+        return res.status(403).json({ error: 'This action is not available in the demo. Create a free account to use it.' });
+      }
+      const minted = await resolveOrMintWine(newWine, req);
+      if (minted.error) {
+        return res.status(minted.error.status).json({ error: minted.error.message });
+      }
+      if (minted.candidates) {
+        // Nothing was created — the client re-submits with a picked wine id
+        // or newWine + confirmCreate:true (same contract as POST /api/bottles).
+        return res.status(200).json({ candidates: minted.candidates });
+      }
+      resolvedWineId = String(minted.wine._id);
+    } else {
+      if (!mongoose.Types.ObjectId.isValid(wineDefinitionId)) {
+        return res.status(400).json({ error: 'Valid wineDefinitionId is required' });
+      }
+      resolvedWineId = wineDefinitionId;
     }
 
     // Sanitise vintage: must be a string (prevents NoSQL injection via objects)
     const safeVintage = vintage != null ? String(vintage) : '';
 
-    // Prevent duplicates: same user + same wine + same vintage (or both null)
+    // Prevent duplicates: same user + same wine + same vintage (or both null).
+    // Runs AFTER the newWine resolve on purpose: a freshly MINTED wine can't
+    // have a duplicate item (nothing references its new id yet), so a 409 here
+    // only ever follows a resolve-to-existing — no orphan wine is left behind.
     const dupFilter = {
       user: req.user.id,
-      wineDefinition: wineDefinitionId,
+      wineDefinition: resolvedWineId,
       status: 'wanted'
     };
     if (safeVintage) {
@@ -203,7 +249,7 @@ router.post('/', async (req, res) => {
 
     const item = await WishlistItem.create({
       user: req.user.id,
-      wineDefinition: wineDefinitionId,
+      wineDefinition: resolvedWineId,
       vintage: safeVintage || undefined,
       notes: notes || undefined,
       priority: priority || 'medium'
@@ -220,7 +266,7 @@ router.post('/', async (req, res) => {
         ]
       });
 
-    logAudit(req, 'wishlist.add', { type: 'wishlistItem', id: item._id }, { wineDefinitionId });
+    logAudit(req, 'wishlist.add', { type: 'wishlistItem', id: item._id }, { wineDefinitionId: resolvedWineId });
 
     res.status(201).json({ item: populated });
   } catch (err) {

--- a/backend/src/routes/wishlist.newWine.test.js
+++ b/backend/src/routes/wishlist.newWine.test.js
@@ -1,0 +1,210 @@
+/**
+ * POST /api/wishlist with `newWine` — mint-at-commit for the wishlist flow.
+ *
+ * WHY THIS TEST EXISTS:
+ * A wishlist item REQUIRES a real registry row, so wishing for a
+ * not-yet-registered wine is a legitimate zero-bottle registry write — but
+ * AddToWishlist used to mint it in step 1 (find-or-create), and an abandoned
+ * form left an orphan exactly like the AddBottle flow did. The mint now
+ * happens with the SAVE, via the same shared service as POST /api/bottles
+ * (services/wineCommit). Pinned here:
+ *   - exactly one of wineDefinitionId | newWine (400 otherwise)
+ *   - newWine resolves-or-mints, audits wine.create (via ui/ai) + IndexNow,
+ *     and the item is created with the RESOLVED id in one request (201)
+ *   - soft-zone candidates → 200 { candidates }, nothing created
+ *   - dedup runs against the resolved id (409 can only follow a
+ *     resolve-to-existing, never a fresh mint — no orphan is left behind)
+ *   - demo accounts: newWine is 403 (registry write), the by-id path stays open
+ *   - the by-id path never touches findOrCreateWine (regression)
+ *
+ * Real router + real wineCommit; findOrCreateWine, models and side-effect
+ * services are mocked (no MongoDB).
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../models/WishlistItem', () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+  findById: jest.fn(),
+}));
+// Demo tokens make requireAuth confirm the account still exists.
+jest.mock('../models/User', () => ({ exists: jest.fn(async () => ({ _id: 'demo1' })) }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WishlistItem = require('../models/WishlistItem');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const { logAudit } = require('../services/audit');
+const { submitUrls } = require('../services/indexNow');
+const wishlistRouter = require('./wishlist');
+
+const USER_ID = '64b000000000000000000001';
+const WINE_ID = '64b0000000000000000000ff';
+const ITEM_ID = '64b0000000000000000000ee';
+
+function post(body, { userId = USER_ID, isDemo = false } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/wishlist', wishlistRouter);
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: '/api/wishlist',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${jwt.sign(
+              { id: userId, roles: ['user'], ...(isDemo ? { isDemo: true } : {}) },
+              'test-secret', { algorithm: 'HS256', expiresIn: '1h' }
+            )}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end(payload);
+    });
+  });
+}
+
+const NEW_WINE = {
+  name: 'Kaefferkopf', producer: 'Cave de Kaysersberg', country: 'France', type: 'white',
+};
+const WINE_DOC = { _id: WINE_ID, name: 'Kaefferkopf', producer: 'Cave de Kaysersberg', slug: 'kaefferkopf' };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findOrCreateWine.mockResolvedValue({ wine: WINE_DOC, created: true });
+  WishlistItem.findOne.mockResolvedValue(null);
+  WishlistItem.create.mockResolvedValue({ _id: ITEM_ID });
+  WishlistItem.findById.mockReturnValue({
+    populate: jest.fn().mockResolvedValue({ _id: ITEM_ID, wineDefinition: WINE_DOC }),
+  });
+});
+
+describe('POST /api/wishlist — wine reference contract', () => {
+  test('neither wineDefinitionId nor newWine is a 400', async () => {
+    const { status, body } = await post({ vintage: '2019' });
+
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/wineDefinitionId or newWine/);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(WishlistItem.create).not.toHaveBeenCalled();
+  });
+
+  test('BOTH wineDefinitionId and newWine is a 400', async () => {
+    const { status } = await post({ wineDefinitionId: WINE_ID, newWine: NEW_WINE });
+
+    expect(status).toBe(400);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(WishlistItem.create).not.toHaveBeenCalled();
+  });
+
+  test('the by-id path is untouched: never calls findOrCreateWine, item created with the given id', async () => {
+    const { status } = await post({ wineDefinitionId: WINE_ID, vintage: '2019' });
+
+    expect(status).toBe(201);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(WishlistItem.create).toHaveBeenCalledWith(expect.objectContaining({ wineDefinition: WINE_ID }));
+    expect(logAudit).not.toHaveBeenCalledWith(expect.anything(), 'wine.create', expect.anything(), expect.anything());
+  });
+});
+
+describe('POST /api/wishlist — newWine mints at commit', () => {
+  test('mints, audits wine.create via ui, pings IndexNow, creates the item with the resolved id → 201', async () => {
+    const { status, body } = await post({ newWine: NEW_WINE, vintage: '2019', priority: 'high' });
+
+    expect(status).toBe(201);
+    expect(body.item).toBeTruthy();
+    expect(findOrCreateWine).toHaveBeenCalledTimes(1);
+    expect(findOrCreateWine.mock.calls[0][2]).toEqual({
+      confirmCreate: false, skipSiblingMatch: false, createdVia: 'ui',
+    });
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'wine.create',
+      { type: 'wine', id: WINE_ID }, { via: 'ui', name: 'Kaefferkopf', producer: 'Cave de Kaysersberg' });
+    expect(submitUrls).toHaveBeenCalledWith('/wines/kaefferkopf');
+    expect(WishlistItem.create).toHaveBeenCalledWith(expect.objectContaining({ wineDefinition: WINE_ID }));
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'wishlist.add',
+      expect.objectContaining({ type: 'wishlistItem' }), { wineDefinitionId: WINE_ID });
+  });
+
+  test('soft-zone candidates → 200 { candidates }, nothing created', async () => {
+    findOrCreateWine.mockResolvedValue({
+      wine: null,
+      candidates: [{ wine: { _id: WINE_ID, name: 'Kaefferkopf', producer: 'Cave Vinicole' }, score: 0.9 }],
+    });
+
+    const { status, body } = await post({ newWine: NEW_WINE });
+
+    expect(status).toBe(200);
+    expect(body.candidates).toHaveLength(1);
+    expect(body.item).toBeUndefined();
+    expect(WishlistItem.create).not.toHaveBeenCalled();
+    expect(logAudit).not.toHaveBeenCalled();
+    expect(submitUrls).not.toHaveBeenCalled();
+  });
+
+  test('dedup runs against the RESOLVED id: resolve-to-existing + already-wanted → 409, nothing minted', async () => {
+    findOrCreateWine.mockResolvedValue({ wine: WINE_DOC, created: false });
+    WishlistItem.findOne.mockResolvedValue({ _id: 'existing' });
+
+    const { status, body } = await post({ newWine: NEW_WINE });
+
+    expect(status).toBe(409);
+    expect(body.error).toMatch(/already on your wishlist/);
+    expect(WishlistItem.findOne).toHaveBeenCalledWith(expect.objectContaining({ wineDefinition: WINE_ID }));
+    expect(WishlistItem.create).not.toHaveBeenCalled();
+    // created:false → no wine.create audit, no IndexNow: nothing was minted,
+    // so the 409 leaves no orphan behind
+    expect(logAudit).not.toHaveBeenCalledWith(expect.anything(), 'wine.create', expect.anything(), expect.anything());
+    expect(submitUrls).not.toHaveBeenCalled();
+  });
+
+  test('validation caps run before the service (over-long name → 400)', async () => {
+    const { status } = await post({ newWine: { ...NEW_WINE, name: 'x'.repeat(201) } });
+
+    expect(status).toBe(400);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+
+  test("source:'ai' stamps createdVia 'ai'", async () => {
+    await post({ newWine: { ...NEW_WINE, source: 'ai' } });
+
+    expect(findOrCreateWine.mock.calls[0][2].createdVia).toBe('ai');
+  });
+});
+
+describe('POST /api/wishlist — demo accounts', () => {
+  test('newWine is a registry write → 403, service untouched', async () => {
+    const { status, body } = await post({ newWine: NEW_WINE }, { userId: 'demo1', isDemo: true });
+
+    expect(status).toBe(403);
+    expect(body.error).toMatch(/not available in the demo/);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(WishlistItem.create).not.toHaveBeenCalled();
+  });
+
+  test('the by-id path stays open to demo accounts (references an existing wine, writes nothing shared)', async () => {
+    const { status } = await post({ wineDefinitionId: WINE_ID }, { userId: 'demo1', isDemo: true });
+
+    expect(status).toBe(201);
+    expect(findOrCreateWine).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -171,10 +171,12 @@ async function findOrCreateGrapes(rawNames, userId) {
  *   so their "create anyway" isn't silently overridden by an appellation-variant sibling.
  * @param {boolean} [opts.matchOnly=false] - Never create. Resolve only to an existing
  *   registry wine (exact/sibling/fuzzy>=threshold); if nothing confident matches, return
- *   { wine: null, noMatch: true } instead of minting a WineDefinition + taxonomy. Two
- *   consumers: the registry-safe ephemeral-demo clone (so a throwaway account can't pollute
- *   the shared registry), and POST /api/wines/identify-text, which reports what the registry
- *   already holds and leaves creation to an explicit user confirmation.
+ *   { wine: null, noMatch: true } instead of minting a WineDefinition + taxonomy.
+ *   Consumers: the registry-safe ephemeral-demo clone (so a throwaway account can't pollute
+ *   the shared registry), POST /api/wines/identify-text, the MCP resolve_wine tool, and —
+ *   since the UI went mint-at-commit — POST /api/wines/find-or-create, which resolves in
+ *   step 1 of the add flows and leaves creation to the bottle/wishlist commit
+ *   (services/wineCommit).
  *   ⚠️ Do NOT combine with confirmCreate outside the demo clone. The soft-zone candidate
  *   return sits ABOVE the matchOnly gate, so confirmCreate collapses every 0.85–0.95
  *   near-match into noMatch — for identify-text that would hide exactly the existing wines

--- a/backend/src/services/wineCommit.js
+++ b/backend/src/services/wineCommit.js
@@ -1,0 +1,149 @@
+/**
+ * wineCommit — resolve-or-mint a registry wine INSIDE a user's committing
+ * write (bottle add, wishlist add). The shared implementation behind the
+ * `newWine` branch of POST /api/bottles and POST /api/wishlist.
+ *
+ * Third verse of the mint-before-commitment cleanup, same shape as the two
+ * prior fixes:
+ *   - v1.97: POST /api/wines/identify-text minted a WineDefinition per AI
+ *     guess; measured on prod 2026-08-03, 85 of 162 createdVia:'ai' rows had
+ *     zero bottles (52%). It is now read-only; see routes/wines.js.
+ *   - v1.100.0 (#899): bottle import minted on /validate; /validate is now
+ *     registry-read-only and wines mint on /confirm. See routes/import.js.
+ *   - This one: the AddBottle/AddToWishlist UI minted on step-1 confirm via
+ *     POST /api/wines/find-or-create, before any bottle existed. Measured on
+ *     prod 2026-08-10: 31 zero-bottle createdVia:'ui' rows; the same day a
+ *     user minted "Domaine de Riquewihr — Kaefferkopf" (village-as-producer,
+ *     likely fictitious) and two minutes later attached their bottle to a
+ *     DIFFERENT existing wine — the orphan would have sat in the shared
+ *     registry forever. The mint now happens here, inside the commit, so an
+ *     abandoned form leaves nothing behind.
+ *
+ * Contract (mirrors the old find-or-create route exactly, so the UI's
+ * soft-zone dialog logic carries over unchanged):
+ *   resolveOrMintWine(newWine, req) →
+ *     { error: { status, message } }   — client fault (validation, mint gates)
+ *     { candidates: [{ wine, score }]} — dedup soft zone; NOTHING was created.
+ *                                        The caller re-submits with either an
+ *                                        existing wine id or confirmCreate:true.
+ *     { wine, created }                — resolved (created:false) or minted
+ *                                        (created:true, audited + IndexNow'd)
+ *
+ * newWine shape: { name, producer, country, region?, appellation?, type?,
+ *   grapes?: string[], confirmCreate?: boolean, source?: 'ai' } — the exact
+ *   payload POST /api/wines/find-or-create took when it still created.
+ *   `source:'ai'` marks "the user accepted an AI suggestion" and stamps
+ *   createdVia:'ai'; anything else stamps 'ui' (strict allowlist, so a body
+ *   value can't invent a provenance the enum would reject).
+ */
+
+const { logAudit } = require('./audit');
+const { submitUrls } = require('./indexNow');
+
+// Field caps for anything that reaches the registry-write path. One source of
+// truth (imported by routes/wines.js too) mirroring what findOrCreateWine
+// enforces at its own create chokepoint — kept here as REQUEST validation so a
+// multi-MB name/producer never reaches the O(m·n) fuzzy-match scorer
+// (authenticated DoS; same rationale as the old find-or-create route).
+const MAX_WINE_FIELD = 200;
+const MAX_GRAPES = 20;
+
+/**
+ * Validate a new-wine payload against the caps the old find-or-create route
+ * enforced — extracted rather than duplicated, so the resolve endpoint and
+ * both commit endpoints can never drift.
+ * @returns {string|null} an error message, or null when valid.
+ */
+function validateNewWineFields(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return 'newWine must be an object';
+  }
+  const { name, producer, country, region, appellation, grapes } = payload;
+  // typeof, not `?.` — a non-string here must be a 400, not a thrown TypeError
+  // inside findOrCreateWine's .trim() (the identify-text hang, audit HIGH).
+  if (typeof name !== 'string' || !name.trim() || typeof producer !== 'string' || !producer.trim()) {
+    return 'name and producer are required';
+  }
+  if (typeof country !== 'string' || !country.trim()) {
+    return 'country is required';
+  }
+  // region is capped too: findOrCreateRegion mints whatever arrives, and this
+  // path receives machine-generated payloads (accepted AI suggestions).
+  for (const [field, value] of Object.entries({ name, producer, appellation, region })) {
+    if (typeof value === 'string' && value.length > MAX_WINE_FIELD) {
+      return `${field} must be ${MAX_WINE_FIELD} characters or fewer`;
+    }
+  }
+  if (grapes !== undefined) {
+    if (!Array.isArray(grapes) || grapes.length > MAX_GRAPES) {
+      return `grapes must be an array of at most ${MAX_GRAPES} entries`;
+    }
+    // `typeof g !== 'string' ||`, not `typeof g === 'string' &&`: the latter
+    // let a non-string element through to isUnknownName's .trim() → 500.
+    if (grapes.some(g => typeof g !== 'string' || g.length > MAX_WINE_FIELD)) {
+      return `each grape must be a string of ${MAX_WINE_FIELD} characters or fewer`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a new-wine payload to a registry wine, minting only when nothing
+ * matches (or the user confirmed past the soft zone). See the module header
+ * for the three return shapes. Non-400 service errors are rethrown so the
+ * calling route's catch-all logs them.
+ */
+async function resolveOrMintWine(newWine, req) {
+  const invalid = validateNewWineFields(newWine);
+  if (invalid) return { error: { status: 400, message: invalid } };
+
+  const via = newWine.source === 'ai' ? 'ai' : 'ui';
+
+  // Lazy require: findOrCreateWine top-requires services/search → the
+  // ESM-only meilisearch package jest cannot parse (the #702 failure mode).
+  const { findOrCreateWine } = require('./findOrCreateWine');
+  let result;
+  try {
+    result = await findOrCreateWine(
+      {
+        name: newWine.name,
+        producer: newWine.producer,
+        country: newWine.country,
+        region: newWine.region,
+        appellation: newWine.appellation,
+        type: newWine.type,
+        grapes: newWine.grapes || [],
+      },
+      req.user.id,
+      // skipSiblingMatch with confirmCreate: the user has already reviewed the
+      // suggested matches (that is what confirmCreate means) — an appellation-
+      // variant sibling must not silently override their explicit "create a
+      // new wine anyway". Same semantics the find-or-create route had.
+      { confirmCreate: !!newWine.confirmCreate, skipSiblingMatch: !!newWine.confirmCreate, createdVia: via }
+    );
+  } catch (err) {
+    // The service's mint gates (unrecognized country, place-as-producer,
+    // unusable producer) throw status-400 errors — client faults, surfaced as
+    // such. Anything else is a real failure: rethrow for the route's catch.
+    if (err && err.status === 400) return { error: { status: 400, message: err.message } };
+    throw err;
+  }
+
+  if (result.candidates) return { candidates: result.candidates };
+
+  const { wine, created } = result;
+  if (created) {
+    // Same action string + detail shape the find-or-create route emitted (and
+    // the MCP/admin/import surfaces emit), so registry writes keep reading as
+    // ONE audit stream (2026-08-03 M-1). `createdVia` alone doesn't serve: it
+    // is client-asserted and later merges rewrite it.
+    logAudit(req, 'wine.create',
+      { type: 'wine', id: wine._id },
+      { via, name: wine.name, producer: wine.producer }
+    );
+    submitUrls(`/wines/${wine.slug || wine._id}`);
+  }
+  return { wine, created: !!created };
+}
+
+module.exports = { resolveOrMintWine, validateNewWineFields, MAX_WINE_FIELD, MAX_GRAPES };

--- a/frontend/src/api/wines.js
+++ b/frontend/src/api/wines.js
@@ -19,18 +19,21 @@ export const scanLabel = (apiFetch, image, mediaType = 'image/jpeg') =>
   });
 
 /**
- * Find an existing wine or create a new one from CONFIRMED data. The only
- * user-facing registry-write path — call it when the user has explicitly
- * accepted a wine, never speculatively.
+ * Resolve confirmed wine data against the shared registry. READ-ONLY — this
+ * NEVER creates (the endpoint keeps its /find-or-create path for
+ * compatibility, but it went resolve-only when step-1 minting left 31
+ * zero-bottle orphan rows on prod). A wine is only ever minted when the user
+ * COMMITS: POST /api/bottles or POST /api/wishlist with a `newWine` payload
+ * (this same wineData object, `source: 'ai'` riding along when the data came
+ * from an accepted AI suggestion so provenance stays measurable).
  *
- * Pass `source: 'ai'` when the data came from an AI suggestion the user
- * accepted, so the row's provenance stays measurable.
- *
- * Returns: { wine, created: true } | { wine, created: false }
- *        | { candidates: [{ wine, score }] }  — soft zone: ask "did you mean…?"
- *          and resubmit with confirmCreate: true to create anyway.
+ * Returns: { wine, created: false }            — confident registry match
+ *        | { candidates: [{ wine, score }] }   — soft zone: ask "did you mean…?"
+ *        | { wine: null, created: false, noMatch: true }
+ *                                              — not registered; carry the
+ *                                                fields to the commit, which mints.
  */
-export const findOrCreateWine = (apiFetch, wineData) =>
+export const resolveWine = (apiFetch, wineData) =>
   apiFetch('/api/wines/find-or-create', {
     method: 'POST',
     headers: JSON_HEADERS,
@@ -40,7 +43,8 @@ export const findOrCreateWine = (apiFetch, wineData) =>
 /**
  * Identify a wine from a free-text search query using AI and report what the
  * registry already holds. READ-ONLY — this never creates anything. Accepting a
- * suggestion is a separate, explicit call to findOrCreateWine below.
+ * suggestion goes through resolveWine above, and the wine is only minted when
+ * the bottle/wishlist item is committed (`newWine` on that POST).
  *
  * Returns: {
  *   identified: { name, producer, country, region, appellation, type,

--- a/frontend/src/components/SimilarWinesModal.js
+++ b/frontend/src/components/SimilarWinesModal.js
@@ -4,13 +4,15 @@ import WineImage from './WineImage';
 import './WineModalThumbs.css';
 
 /**
- * Shown when the backend's find-or-create returns soft-zone candidates —
- * the wine the user is trying to add is similar to existing entries but
- * not similar enough to auto-match. Asks the user to pick one or confirm
- * "no, create a new wine".
+ * Shown when the dedup soft zone returns candidates — the wine the user is
+ * trying to add is similar to existing entries but not similar enough to
+ * auto-match. Asks the user to pick one or confirm "no, create a new wine".
+ * Candidates come from the step-1 resolve (/api/wines/find-or-create, now
+ * read-only) or, in the rare commit-time race, from the bottle/wishlist POST
+ * itself — which creates NOTHING until this dialog is answered.
  *
  * Props:
- *   candidates   — [{ wine, score }] from /api/wines/find-or-create
+ *   candidates   — [{ wine, score }]
  *   queryName    — the name the user was trying to add (shown in the prompt)
  *   onPick(wine) — user picked an existing wine
  *   onCreateNew  — user wants to create a new wine anyway

--- a/frontend/src/pages/AddBottle.aiSearch.test.js
+++ b/frontend/src/pages/AddBottle.aiSearch.test.js
@@ -7,16 +7,17 @@
  * or the AI call quietly returning to fire on every search again. A manual
  * click-through passes all three.
  *
- * The behaviour being locked (PR #884): searching is registry-only and writes
- * nothing; AI is opt-in; an unsaved suggestion is only ever turned into a wine
- * through find-or-create, on an explicit press.
+ * The behaviour being locked (PR #884, tightened when step 1 went read-only):
+ * searching is registry-only and writes nothing; AI is opt-in; accepting an
+ * unsaved suggestion goes through resolveWine (a READ — the wine is only
+ * minted when the bottle is committed; see AddBottle.mintOnCommit.test.js).
  */
 
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
 vi.mock('../api/wines', () => ({
   searchWines: vi.fn(),
-  findOrCreateWine: vi.fn(),
+  resolveWine: vi.fn(),
   identifyWineByText: vi.fn(),
 }));
 vi.mock('../contexts/AuthContext', () => ({
@@ -47,7 +48,7 @@ vi.mock('react-i18next', () => {
   return { useTranslation: () => ({ t }), Trans };
 });
 
-const { searchWines, findOrCreateWine, identifyWineByText } = await import('../api/wines');
+const { searchWines, resolveWine, identifyWineByText } = await import('../api/wines');
 const AddBottle = (await import('./AddBottle')).default;
 
 const jsonRes = (body, ok = true, status = 200) => ({ ok, status, json: async () => body });
@@ -66,7 +67,8 @@ const REGISTRY_WINE = {
 beforeEach(() => {
   vi.clearAllMocks();
   searchWines.mockResolvedValue(jsonRes({ wines: [] }));
-  findOrCreateWine.mockResolvedValue(jsonRes({ wine: REGISTRY_WINE, created: true }, true, 201));
+  // resolveWine is READ-ONLY: it matches or reports noMatch, never 201.
+  resolveWine.mockResolvedValue(jsonRes({ wine: REGISTRY_WINE, created: false }));
 });
 
 /** Open the text-search pane and run a search for `q`. */
@@ -87,7 +89,7 @@ describe('AddBottle — searching is registry-only', () => {
 
     expect(searchWines).toHaveBeenCalledTimes(1);
     expect(identifyWineByText).not.toHaveBeenCalled();
-    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(resolveWine).not.toHaveBeenCalled();
   });
 
   test('registry results stay visible — they are no longer hidden behind an AI card', async () => {
@@ -133,24 +135,37 @@ describe('AddBottle — an unsaved AI suggestion', () => {
     expect(screen.queryByText('addBottle.aiUseThisWine')).not.toBeInTheDocument();
   });
 
-  test('accepting routes through find-or-create with source:ai — never straight to step 2', async () => {
+  test('accepting routes through resolveWine with source:ai riding along — never straight to step 2', async () => {
     await search();
     await askAi();
     await act(async () => { fireEvent.click(screen.getByText('addBottle.aiAddAndUse')); });
 
-    expect(findOrCreateWine).toHaveBeenCalledTimes(1);
-    const body = findOrCreateWine.mock.calls[0][1];
+    expect(resolveWine).toHaveBeenCalledTimes(1);
+    const body = resolveWine.mock.calls[0][1];
     expect(body).toMatchObject({
       name: 'Les Romains', producer: 'Domaine Vacheron', country: 'France',
       appellation: 'Sancerre', type: 'white', source: 'ai',
     });
     expect(body.grapes).toEqual(['Sauvignon Blanc']);
-    // and only THEN does the saved wine carry the flow forward
+    // and only THEN does the matched wine carry the flow forward
     await waitFor(() => expect(screen.getByText('addBottle.addBottleBtn')).toBeInTheDocument());
   });
 
+  test('an unmatched suggestion (noMatch) still reaches step 2 — as PENDING data, with nothing minted', async () => {
+    resolveWine.mockResolvedValue(jsonRes({ wine: null, created: false, noMatch: true }));
+
+    await search();
+    await askAi();
+    await act(async () => { fireEvent.click(screen.getByText('addBottle.aiAddAndUse')); });
+
+    // step 2 renders from the display stub; the mint happens at bottle commit
+    // (covered by AddBottle.mintOnCommit.test.js)
+    await waitFor(() => expect(screen.getByText('addBottle.addBottleBtn')).toBeInTheDocument());
+    expect(resolveWine).toHaveBeenCalledTimes(1);
+  });
+
   test('a soft-zone response opens the "did you mean" modal instead of creating', async () => {
-    findOrCreateWine.mockResolvedValue(jsonRes({
+    resolveWine.mockResolvedValue(jsonRes({
       candidates: [{ wine: { ...REGISTRY_WINE, _id: 'w9' }, score: 0.9 }],
     }));
 
@@ -176,7 +191,7 @@ describe('AddBottle — an AI result already in the registry', () => {
 
     await act(async () => { fireEvent.click(screen.getByText('addBottle.aiUseThisWine')); });
 
-    expect(findOrCreateWine).not.toHaveBeenCalled();
+    expect(resolveWine).not.toHaveBeenCalled();
     await waitFor(() => expect(screen.getByText('addBottle.addBottleBtn')).toBeInTheDocument());
   });
 });

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
-import { searchWines, findOrCreateWine, identifyWineByText } from '../api/wines';
+import { searchWines, resolveWine, identifyWineByText } from '../api/wines';
 import useLabelScanner from '../hooks/useLabelScanner';
 import { CURRENCIES } from '../config/currencies';
 import { BOTTLE_SIZES, bottleSizeLabel } from '../config/bottleSizes';
@@ -32,11 +32,18 @@ function AddBottle() {
   // registry already holds, and creates nothing. `aiIdentified` is UNSAVED data
   // (plain strings, no _id); only `aiMatch` and `aiCandidates[].wine` are real
   // registry documents. Accepting an unsaved suggestion goes through
-  // find-or-create, which is where a wine is actually created.
+  // resolveWine (also read-only); the wine is only minted when the BOTTLE is
+  // committed (POST /api/bottles with `newWine`) — an abandoned form leaves
+  // no orphan registry row.
   const [aiIdentified, setAiIdentified] = useState(null);
   const [aiMatch, setAiMatch] = useState(null);
   const [aiCandidates, setAiCandidates] = useState([]);
   const [selectedWine, setSelectedWine] = useState(null);
+  // The not-yet-registered wine riding along to the bottle submit. When set,
+  // `selectedWine` is a display-only stub WITHOUT `_id`; the first POST
+  // /api/bottles carries this payload as `newWine` and mints exactly one wine,
+  // whose id the remaining bottles of the batch then reference.
+  const [pendingNewWine, setPendingNewWine] = useState(null);
   const [numBottles, setNumBottles] = useState(1);
   const [bottleData, setBottleData] = useState({
     vintage: '',
@@ -130,6 +137,7 @@ function AddBottle() {
     createdBottlesRef.current = [];
     imagesLinkedRef.current = false;
     setSelectedWine(wine);
+    setPendingNewWine(null);
     setBottleData(prev => ({ ...prev, vintage: carriedVintage || '' }));
     setScanResult(null);
     setLabelImage(null);
@@ -141,13 +149,33 @@ function AddBottle() {
     setStep(2);
   }, [clearAi]);
 
-  // Submit a find-or-create request, handling the three response shapes:
-  // resolved wine, soft-zone candidates, or error.
-  const submitFindOrCreate = useCallback(async (wineData, carriedVintage, { confirmCreate = false } = {}) => {
+  // Advance to step 2 WITHOUT any registry write: the confirmed wine fields
+  // ride along and are minted by POST /api/bottles when the user commits the
+  // bottle (see submitBottles). selectedWine becomes a display-only stub.
+  const applyPendingNewWine = useCallback((wineData, carriedVintage) => {
+    createdBottlesRef.current = [];
+    imagesLinkedRef.current = false;
+    setPendingNewWine(wineData);
+    setSelectedWine({ name: wineData.name, producer: wineData.producer, type: wineData.type });
+    setBottleData(prev => ({ ...prev, vintage: carriedVintage || '' }));
+    setScanResult(null);
+    setLabelImage(null);
+    setShowManualForm(false);
+    setPendingWineData(null);
+    setSoftCandidates(null);
+    setSoftPending(null);
+    clearAi();
+    setStep(2);
+  }, [clearAi]);
+
+  // Resolve confirmed wine data against the registry (READ-ONLY — nothing is
+  // created in step 1 any more), handling the three response shapes: matched
+  // wine, soft-zone candidates, or no match (→ the data rides to the commit).
+  const resolveSelectedWine = useCallback(async (wineData, carriedVintage) => {
     setError(null);
     setFindingWine(true);
     try {
-      const res = await findOrCreateWine(apiFetch, { ...wineData, confirmCreate });
+      const res = await resolveWine(apiFetch, wineData);
       const data = await res.json();
       if (!res.ok) {
         setError(data.error || t('addBottle.scanFailedToSaveWine'));
@@ -160,15 +188,24 @@ function AddBottle() {
         setSoftPending({ wineData, carriedVintage, queryLabel: search.trim() || wineData.name });
         return;
       }
-      applyResolvedWine(data.wine, carriedVintage);
+      if (data.wine) {
+        applyResolvedWine(data.wine, carriedVintage);
+        return;
+      }
+      // noMatch: not in the registry. Nothing was minted — the fields carry
+      // forward and POST /api/bottles creates the wine WITH the first bottle.
+      applyPendingNewWine(wineData, carriedVintage);
     } catch {
       setError(t('addBottle.scanFailedToSaveWine'));
     } finally {
       setFindingWine(false);
     }
-  }, [apiFetch, t, applyResolvedWine, search]);
+  }, [apiFetch, t, applyResolvedWine, applyPendingNewWine, search]);
 
-  // Confirm scan result — find/create the wine, save label image, go to bottle details
+  // Confirm scan result — resolve the wine and go to bottle details. The
+  // label image is NOT part of the wine payload (the old find-or-create route
+  // ignored it, and it must not bloat the bottle commit): bottle photos go
+  // through the separate /api/images upload + link-to-bottle flow.
   const handleConfirmScan = useCallback(async () => {
     const { extracted, match } = scanResult;
     // If there's a match, use the matched wine's canonical data for the lookup
@@ -181,8 +218,7 @@ function AddBottle() {
           region: match.wine.region?.name || extracted.region || '',
           appellation: match.wine.appellation || extracted.appellation || '',
           type: match.wine.type || extracted.type || 'red',
-          grapes: (match.wine.grapes || []).map(g => g.name),
-          labelImage: labelImage || undefined
+          grapes: (match.wine.grapes || []).map(g => g.name)
         }
       : {
           name: extracted.name,
@@ -191,12 +227,11 @@ function AddBottle() {
           region: extracted.region || '',
           appellation: extracted.appellation || '',
           type: extracted.type || 'red',
-          grapes: extracted.grapes || [],
-          labelImage: labelImage || undefined
+          grapes: extracted.grapes || []
         };
 
-    await submitFindOrCreate(wineData, extracted.vintage);
-  }, [scanResult, labelImage, submitFindOrCreate]);
+    await resolveSelectedWine(wineData, extracted.vintage);
+  }, [scanResult, resolveSelectedWine]);
 
   // Switch to the editable manual form (user says "not the right wine")
   const handleNotRightWine = useCallback(() => {
@@ -222,11 +257,11 @@ function AddBottle() {
     const grapes = pendingWineData.grapes
       ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
       : [];
-    await submitFindOrCreate(
-      { ...pendingWineData, grapes, labelImage: labelImage || undefined },
+    await resolveSelectedWine(
+      { ...pendingWineData, grapes },
       scanResult?.extracted?.vintage
     );
-  }, [pendingWineData, scanResult, labelImage, t, submitFindOrCreate]);
+  }, [pendingWineData, scanResult, t, resolveSelectedWine]);
 
   // Reset — back to search
   const handleScanReset = useCallback(() => {
@@ -308,13 +343,15 @@ function AddBottle() {
     // Already in the registry — a pure selection, nothing is written.
     if (aiMatch) { handleSelectWine(aiMatch); return; }
     if (!aiIdentified) return;
-    // No country means find-or-create would 400; send the user to the edit form
-    // to supply it rather than surfacing a server error.
+    // No country means the eventual commit would 400; send the user to the
+    // edit form to supply it rather than surfacing a server error.
     if (!aiIdentified.country) { editAiSuggestion(); return; }
     // Forward EVERY field, appellation included: it feeds normalizedKey, so
     // dropping it would both mint an appellation-less row and make the
-    // accept-time match score differently from the identify-time probe.
-    submitFindOrCreate({
+    // resolve-time match score differently from the identify-time probe.
+    // `source: 'ai'` rides with the payload to the commit, where it stamps
+    // createdVia:'ai' (the resolve endpoint ignores it).
+    resolveSelectedWine({
       name: aiIdentified.name,
       producer: aiIdentified.producer,
       country: aiIdentified.country,
@@ -330,6 +367,7 @@ function AddBottle() {
     createdBottlesRef.current = [];
     imagesLinkedRef.current = false;
     setSelectedWine(wine);
+    setPendingNewWine(null);
     setStep(2);
   };
 
@@ -374,18 +412,19 @@ function AddBottle() {
     });
   };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+  // Create the bottle records that are still missing. wineRef is EITHER
+  // { wineId } (an existing registry wine) or { newWinePayload } — in the
+  // latter case only the FIRST POST carries `newWine`: the backend mints (or
+  // resolves) the wine inside that bottle create, and every later bottle of
+  // the batch reuses the returned id. An N-bottle add therefore mints exactly
+  // ONE wine, and a batch abandoned before this point mints nothing.
+  // Callable from the form submit AND from the soft-zone modal (the rare
+  // commit-time race below), so a modal answer finishes the add in one step.
+  const submitBottles = async ({ wineId, newWinePayload }) => {
     // In-flight guard: the N sequential POSTs below leave a wide window
     // where a second submit (double-click, Enter+click) would duplicate
     // every bottle.
     if (saving) return;
-
-    // Client-side validation for the personal drink window + occasion —
-    // mirrors the backend rules (integer years 1900–2200, from ≤ to, ≤500 chars).
-    const windowError = validateDrinkWindowFields(bottleData, t);
-    if (windowError) { setError(windowError); return; }
-
     setSaving(true);
     setError(null);
 
@@ -396,9 +435,8 @@ function AddBottle() {
       : msg;
 
     try {
-      const payload = {
+      const base = {
         cellar: cellarId,
-        wineDefinition: selectedWine._id,
         ...bottleData,
         price: bottleData.price ? parseFloat(bottleData.price) : undefined,
         occasion: bottleData.occasion || undefined,
@@ -417,11 +455,19 @@ function AddBottle() {
         } : {})
       };
 
-      // Create the bottle records that are still missing. createdBottlesRef
-      // carries the ones a previous, partially-failed attempt already created,
-      // so a retry never duplicates them.
+      // createdBottlesRef carries the bottles a previous, partially-failed
+      // attempt already created, so a retry never duplicates them — and if
+      // that first attempt already minted the wine, its id is reused here
+      // rather than sending `newWine` again.
       const createdBottles = createdBottlesRef.current;
+      let wineRefId = wineId
+        || createdBottles[0]?.wineDefinition?._id
+        || (typeof createdBottles[0]?.wineDefinition === 'string' ? createdBottles[0].wineDefinition : undefined);
+
       for (let i = createdBottles.length; i < numBottles; i++) {
+        const payload = wineRefId
+          ? { ...base, wineDefinition: wineRefId }
+          : { ...base, newWine: newWinePayload };
         const res = await apiFetch('/api/bottles', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -429,12 +475,25 @@ function AddBottle() {
         });
 
         const data = await res.json();
+        if (res.ok && data.candidates && data.candidates.length > 0) {
+          // Commit-time soft zone: a very similar wine entered the registry
+          // between the step-1 resolve and this submit. NOTHING was created —
+          // re-open the "did you mean?" modal; its answer resumes this batch.
+          setSoftCandidates(data.candidates);
+          setSoftPending({ forCommit: true, queryLabel: newWinePayload?.name });
+          return;
+        }
         if (!res.ok) {
           setError(partialError(data.error || t('addBottle.addFailed'), createdBottles.length));
           linkUploadedImages();
           return;
         }
         createdBottles.push(data.bottle);
+        if (!wineRefId) {
+          // First bottle of a newWine batch — every remaining bottle
+          // references the wine this create just minted/resolved.
+          wineRefId = data.bottle?.wineDefinition?._id || data.bottle?.wineDefinition;
+        }
       }
 
       // Link uploaded images to the first bottle
@@ -446,6 +505,20 @@ function AddBottle() {
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (saving) return;
+
+    // Client-side validation for the personal drink window + occasion —
+    // mirrors the backend rules (integer years 1900–2200, from ≤ to, ≤500 chars).
+    const windowError = validateDrinkWindowFields(bottleData, t);
+    if (windowError) { setError(windowError); return; }
+
+    await submitBottles(pendingNewWine
+      ? { newWinePayload: pendingNewWine }
+      : { wineId: selectedWine._id });
   };
 
   // Adding bottles is not available in the demo (backend enforces via
@@ -1148,15 +1221,44 @@ function AddBottle() {
         </div>
       )}
 
+      {/* Soft-zone "did you mean?" — two phases, one dialog:
+          - step 1 (resolve): picking uses the existing wine; "create new"
+            writes NOTHING — it carries the fields (+ confirmCreate) to step 2,
+            and the commit skips this question having already asked it.
+          - commit (rare race — a similar wine appeared after the resolve):
+            the answer resumes the interrupted batch immediately, so the
+            user's steps stay the same. */}
       {softCandidates && (
         <SimilarWinesModal
           candidates={softCandidates}
           queryName={softPending?.queryLabel || softPending?.wineData?.name}
-          busy={findingWine}
-          onPick={(wine) => applyResolvedWine(wine, softPending?.carriedVintage)}
-          onCreateNew={() => softPending && submitFindOrCreate(
-            softPending.wineData, softPending.carriedVintage, { confirmCreate: true }
-          )}
+          busy={findingWine || saving}
+          onPick={(wine) => {
+            if (softPending?.forCommit) {
+              setSoftCandidates(null);
+              setSoftPending(null);
+              setSelectedWine(wine);
+              setPendingNewWine(null);
+              submitBottles({ wineId: wine._id });
+            } else {
+              applyResolvedWine(wine, softPending?.carriedVintage);
+            }
+          }}
+          onCreateNew={() => {
+            if (!softPending) return;
+            if (softPending.forCommit) {
+              const confirmed = { ...pendingNewWine, confirmCreate: true };
+              setSoftCandidates(null);
+              setSoftPending(null);
+              setPendingNewWine(confirmed);
+              submitBottles({ newWinePayload: confirmed });
+            } else {
+              applyPendingNewWine(
+                { ...softPending.wineData, confirmCreate: true },
+                softPending.carriedVintage
+              );
+            }
+          }}
           onCancel={() => { setSoftCandidates(null); setSoftPending(null); }}
         />
       )}

--- a/frontend/src/pages/AddBottle.mintOnCommit.test.js
+++ b/frontend/src/pages/AddBottle.mintOnCommit.test.js
@@ -1,0 +1,183 @@
+/**
+ * AddBottle — mint-at-commit.
+ *
+ * The registry leak being closed: step 1 used to mint the shared
+ * WineDefinition via find-or-create the moment the user confirmed the wine —
+ * before any bottle existed — so an abandoned flow left an orphan row forever
+ * (31 zero-bottle createdVia:'ui' rows on prod, 2026-08-10). Now step 1 only
+ * RESOLVES; a not-yet-registered wine rides along as `pendingNewWine` and is
+ * minted by POST /api/bottles with the FIRST bottle of the batch.
+ *
+ * Locked here:
+ *   - reaching step 2 with an unmatched wine performs NO write at all
+ *   - an N-bottle submit sends `newWine` on the FIRST POST only; the
+ *     remaining bottles reference the id the first create returned —
+ *     one wine, N bottles
+ *   - the step-1 soft-zone "create a new wine" answer is also write-free:
+ *     it only carries the fields (+ confirmCreate) forward to the commit
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+const { apiFetchMock, navigateMock } = vi.hoisted(() => ({
+  apiFetchMock: vi.fn(),
+  navigateMock: vi.fn(),
+}));
+
+vi.mock('../api/wines', () => ({
+  searchWines: vi.fn(),
+  resolveWine: vi.fn(),
+  identifyWineByText: vi.fn(),
+}));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ apiFetch: apiFetchMock, user: { preferences: { currency: 'USD' } } }),
+}));
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: 'cellar1' }),
+  useNavigate: () => navigateMock,
+  Link: ({ children }) => <a href="/">{children}</a>,
+}));
+vi.mock('../hooks/useLabelScanner', () => ({
+  default: () => ({
+    labelCam: { open: false }, labelScanning: false, labelFacing: 'environment',
+    setLabelFacing: vi.fn(), labelVideoRef: { current: null }, labelCanvasRef: { current: null },
+    startCamera: vi.fn(), stopCamera: vi.fn(), capturePhoto: vi.fn(),
+  }),
+}));
+vi.mock('../components/ImageUpload', () => ({ default: () => <div /> }));
+vi.mock('../components/RatingInput', () => ({ default: () => <div /> }));
+
+// Key-only so assertions target keys, never copy.
+vi.mock('react-i18next', () => {
+  const t = (key) => key;
+  const Trans = ({ i18nKey }) => <span>{i18nKey}</span>;
+  return { useTranslation: () => ({ t }), Trans };
+});
+
+const { searchWines, resolveWine, identifyWineByText } = await import('../api/wines');
+const AddBottle = (await import('./AddBottle')).default;
+
+const jsonRes = (body, ok = true, status = 200) => ({ ok, status, json: async () => body });
+
+const SUGGESTION = {
+  name: 'Kaefferkopf', producer: 'Cave de Kaysersberg', country: 'France',
+  region: 'Alsace', appellation: '', type: 'white', grapes: ['Gewürztraminer'], confidence: 0.8,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  searchWines.mockResolvedValue(jsonRes({ wines: [] }));
+  identifyWineByText.mockResolvedValue(jsonRes({
+    identified: SUGGESTION, match: null, candidates: [], reason: null,
+  }));
+  // The registry does not know this wine — resolve reports noMatch, mints nothing.
+  resolveWine.mockResolvedValue(jsonRes({ wine: null, created: false, noMatch: true }));
+});
+
+/** Search, ask the AI, accept the (unmatched) suggestion → step 2 as pending. */
+async function reachStepTwoPending() {
+  render(<AddBottle />);
+  fireEvent.click(screen.getByText('addBottle.searchManuallyInstead'));
+  fireEvent.change(screen.getByPlaceholderText('addBottle.searchPlaceholder'),
+    { target: { value: 'kaefferkopf kaysersberg' } });
+  await act(async () => { fireEvent.click(screen.getByText('addBottle.searchBtn')); });
+  await act(async () => { fireEvent.click(screen.getByText('addBottle.cantFindAiTitle')); });
+  await act(async () => { fireEvent.click(screen.getByText('addBottle.aiAddAndUse')); });
+  await waitFor(() => expect(screen.getByText('addBottle.addBottleBtn')).toBeInTheDocument());
+}
+
+const bottlesCalls = () =>
+  apiFetchMock.mock.calls.filter(([url]) => url === '/api/bottles');
+
+describe('AddBottle — nothing is written before the commit', () => {
+  test('reaching step 2 with an unmatched wine performs no POST /api/bottles and no mint', async () => {
+    await reachStepTwoPending();
+
+    expect(resolveWine).toHaveBeenCalledTimes(1);
+    expect(apiFetchMock).not.toHaveBeenCalled();
+    // the pending wine is displayed from the stub
+    expect(screen.getByText('Cave de Kaysersberg')).toBeInTheDocument();
+  });
+});
+
+describe('AddBottle — an N-bottle commit mints ONE wine', () => {
+  test('first POST carries newWine; the second references the returned wine id', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(jsonRes({
+        bottle: { _id: 'b1', wineDefinition: { _id: 'w-new' }, vintage: '2019' },
+        priceWarnings: [],
+      }, true, 201))
+      .mockResolvedValueOnce(jsonRes({
+        bottle: { _id: 'b2', wineDefinition: { _id: 'w-new' }, vintage: '2019' },
+        priceWarnings: [],
+      }, true, 201));
+
+    await reachStepTwoPending();
+
+    fireEvent.change(screen.getByPlaceholderText('addBottle.vintagePlaceholder'),
+      { target: { value: '2019' } });
+    // numBottles is the first spinbutton on the details form
+    fireEvent.change(screen.getAllByRole('spinbutton')[0], { target: { value: '2' } });
+    await act(async () => { fireEvent.click(screen.getByText('addBottle.addBottleBtn')); });
+
+    const calls = bottlesCalls();
+    expect(calls).toHaveLength(2);
+
+    const first = JSON.parse(calls[0][1].body);
+    expect(first.newWine).toMatchObject({
+      name: 'Kaefferkopf', producer: 'Cave de Kaysersberg', country: 'France', source: 'ai',
+    });
+    expect(first.wineDefinition).toBeUndefined();
+
+    const second = JSON.parse(calls[1][1].body);
+    expect(second.wineDefinition).toBe('w-new');
+    expect(second.newWine).toBeUndefined();
+
+    // resolve ran exactly once, back in step 1 — the commit never re-resolves
+    expect(resolveWine).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith('/cellars/cellar1');
+  });
+});
+
+describe('AddBottle — the step-1 soft zone stays write-free', () => {
+  test('"create a new wine" carries the fields (+ confirmCreate) to step 2 without any request', async () => {
+    resolveWine.mockResolvedValue(jsonRes({
+      candidates: [{
+        wine: {
+          _id: 'w9', name: 'Kaefferkopf', producer: 'Cave Vinicole',
+          type: 'white', country: { name: 'France' }, grapes: [],
+        },
+        score: 0.9,
+      }],
+    }));
+    apiFetchMock.mockResolvedValue(jsonRes({
+      bottle: { _id: 'b1', wineDefinition: { _id: 'w-new' }, vintage: '2019' },
+      priceWarnings: [],
+    }, true, 201));
+
+    render(<AddBottle />);
+    fireEvent.click(screen.getByText('addBottle.searchManuallyInstead'));
+    fireEvent.change(screen.getByPlaceholderText('addBottle.searchPlaceholder'),
+      { target: { value: 'kaefferkopf' } });
+    await act(async () => { fireEvent.click(screen.getByText('addBottle.searchBtn')); });
+    await act(async () => { fireEvent.click(screen.getByText('addBottle.cantFindAiTitle')); });
+    await act(async () => { fireEvent.click(screen.getByText('addBottle.aiAddAndUse')); });
+
+    // the "did you mean?" modal is up; choosing "create new" writes NOTHING
+    await act(async () => { fireEvent.click(screen.getByText('similarWines.createNew')); });
+    await waitFor(() => expect(screen.getByText('addBottle.addBottleBtn')).toBeInTheDocument());
+    expect(apiFetchMock).not.toHaveBeenCalled();
+    expect(resolveWine).toHaveBeenCalledTimes(1);
+
+    // …and the eventual commit carries confirmCreate so the server skips the
+    // question it already asked
+    fireEvent.change(screen.getByPlaceholderText('addBottle.vintagePlaceholder'),
+      { target: { value: '2019' } });
+    await act(async () => { fireEvent.click(screen.getByText('addBottle.addBottleBtn')); });
+
+    const calls = bottlesCalls();
+    expect(calls).toHaveLength(1);
+    const body = JSON.parse(calls[0][1].body);
+    expect(body.newWine).toMatchObject({ name: 'Kaefferkopf', confirmCreate: true });
+  });
+});

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
-import { searchWines, getWine, findOrCreateWine, identifyWineByText } from '../api/wines';
+import { searchWines, getWine, resolveWine, identifyWineByText } from '../api/wines';
 import useLabelScanner from '../hooks/useLabelScanner';
 import { addToWishlist } from '../api/wishlist';
 import '../components/ImageUpload.css';
@@ -29,11 +29,16 @@ function AddToWishlist() {
   const [aiSearching, setAiSearching] = useState(false);
   const [aiSearchError, setAiSearchError] = useState(null);
   // identify-text is read-only — see api/wines.js. `aiIdentified` is UNSAVED
-  // (plain strings, no _id); this page posts wineDefinitionId on save, so an
-  // unsaved suggestion MUST go through find-or-create before it can be used.
+  // (plain strings, no _id); resolveWine (also read-only) either matches it to
+  // a registry wine or leaves it pending, and the wine is minted only when the
+  // wishlist item is SAVED (POST /api/wishlist with `newWine`) — an abandoned
+  // form leaves no orphan registry row.
   const [aiIdentified, setAiIdentified] = useState(null);
   const [aiMatch, setAiMatch] = useState(null);
   const [aiCandidates, setAiCandidates] = useState([]);
+  // The not-yet-registered wine riding along to the save. When set,
+  // `selectedWine` is a display-only stub WITHOUT `_id`.
+  const [pendingNewWine, setPendingNewWine] = useState(null);
 
   // ── Scan result state ──
   const [scanResult, setScanResult] = useState(null);
@@ -54,6 +59,7 @@ function AddToWishlist() {
 
   const applyResolvedWine = useCallback((wine) => {
     setSelectedWine(wine);
+    setPendingNewWine(null);
     setScanResult(null);
     setLabelImage(null);
     setShowManualForm(false);
@@ -63,11 +69,28 @@ function AddToWishlist() {
     clearAi();
   }, [clearAi]);
 
-  const submitFindOrCreate = useCallback(async (wineData, { confirmCreate = false } = {}) => {
+  // Advance to the details step WITHOUT any registry write: the confirmed
+  // wine fields ride along and are minted by POST /api/wishlist on save.
+  const applyPendingNewWine = useCallback((wineData) => {
+    setPendingNewWine(wineData);
+    setSelectedWine({ name: wineData.name, producer: wineData.producer, type: wineData.type });
+    setScanResult(null);
+    setLabelImage(null);
+    setShowManualForm(false);
+    setPendingWineData(null);
+    setSoftCandidates(null);
+    setSoftPending(null);
+    clearAi();
+  }, [clearAi]);
+
+  // Resolve confirmed wine data against the registry (READ-ONLY — nothing is
+  // created here any more): matched wine, soft-zone candidates, or no match
+  // (→ the fields ride to the save, which mints).
+  const resolveSelectedWine = useCallback(async (wineData) => {
     setError(null);
     setFindingWine(true);
     try {
-      const res = await findOrCreateWine(apiFetch, { ...wineData, confirmCreate });
+      const res = await resolveWine(apiFetch, wineData);
       const data = await res.json();
       if (!res.ok) { setError(data.error || t('addToWishlist.failedSaveWine')); return; }
       if (data.candidates && data.candidates.length > 0) {
@@ -75,13 +98,14 @@ function AddToWishlist() {
         setSoftPending({ wineData });
         return;
       }
-      applyResolvedWine(data.wine);
+      if (data.wine) { applyResolvedWine(data.wine); return; }
+      applyPendingNewWine(wineData);
     } catch {
       setError(t('addToWishlist.failedSaveWine'));
     } finally {
       setFindingWine(false);
     }
-  }, [apiFetch, applyResolvedWine, t]);
+  }, [apiFetch, applyResolvedWine, applyPendingNewWine, t]);
 
   // ── Wishlist item details ──
   const [vintage, setVintage] = useState('');
@@ -136,7 +160,9 @@ function AddToWishlist() {
     return () => { cancelled = true; };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Confirm scan result — find/create the wine then add to wishlist ──
+  // ── Confirm scan result — resolve the wine, then add details. The label
+  // image is NOT part of the wine payload (the old find-or-create route
+  // ignored it, and it must not bloat the wishlist commit). ──
   const handleConfirmScan = useCallback(async () => {
     const { extracted, match } = scanResult;
     const wineData = match?.wine
@@ -147,8 +173,7 @@ function AddToWishlist() {
           region: match.wine.region?.name || extracted.region || '',
           appellation: match.wine.appellation || extracted.appellation || '',
           type: match.wine.type || extracted.type || 'red',
-          grapes: (match.wine.grapes || []).map(g => g.name),
-          labelImage: labelImage || undefined
+          grapes: (match.wine.grapes || []).map(g => g.name)
         }
       : {
           name: extracted.name,
@@ -157,12 +182,11 @@ function AddToWishlist() {
           region: extracted.region || '',
           appellation: extracted.appellation || '',
           type: extracted.type || 'red',
-          grapes: extracted.grapes || [],
-          labelImage: labelImage || undefined
+          grapes: extracted.grapes || []
         };
 
-    await submitFindOrCreate(wineData);
-  }, [scanResult, labelImage, submitFindOrCreate]);
+    await resolveSelectedWine(wineData);
+  }, [scanResult, resolveSelectedWine]);
 
   const handleNotRightWine = useCallback(() => {
     const { extracted } = scanResult;
@@ -186,8 +210,8 @@ function AddToWishlist() {
     const grapes = pendingWineData.grapes
       ? pendingWineData.grapes.split(',').map(g => g.trim()).filter(Boolean)
       : [];
-    await submitFindOrCreate({ ...pendingWineData, grapes, labelImage: labelImage || undefined });
-  }, [pendingWineData, labelImage, submitFindOrCreate]);
+    await resolveSelectedWine({ ...pendingWineData, grapes });
+  }, [pendingWineData, t, resolveSelectedWine]);
 
   const handleScanReset = useCallback(() => {
     setScanResult(null);
@@ -263,13 +287,14 @@ function AddToWishlist() {
     setShowManualForm(true);
   };
 
-  // A wishlist item is saved with wineDefinitionId, so an unsaved suggestion
-  // must be resolved through find-or-create before it can be selected.
+  // An unsaved suggestion is resolved against the registry first; if it is
+  // not there, the fields ride to the save, which mints. `source: 'ai'`
+  // travels with the payload so the commit stamps createdVia:'ai'.
   const handleAcceptAiResult = () => {
     if (aiMatch) { handleSelectWine(aiMatch); return; }
     if (!aiIdentified) return;
     if (!aiIdentified.country) { editAiSuggestion(); return; }
-    submitFindOrCreate({
+    resolveSelectedWine({
       name: aiIdentified.name,
       producer: aiIdentified.producer,
       country: aiIdentified.country,
@@ -283,6 +308,7 @@ function AddToWishlist() {
 
   const handleSelectWine = (wine) => {
     setSelectedWine(wine);
+    setPendingNewWine(null);
   };
 
   // One row renderer for both the registry-search list and the AI near-match
@@ -306,25 +332,44 @@ function AddToWishlist() {
     </div>
   );
 
-  // ── Save to wishlist ──
-  const handleSave = async (e) => {
-    e.preventDefault();
-    if (!selectedWine) return;
+  // ── Save to wishlist. wineRef is EITHER { wineId } (existing registry
+  // wine) or { newWinePayload } — the save then mints the wine WITH the
+  // wishlist item (a wanted-but-not-owned wine is a legitimate zero-bottle
+  // registry row; what changed is only WHEN it is created). Callable from the
+  // form submit and from the soft-zone modal (the rare commit-time race), so
+  // a modal answer finishes the save in one step. ──
+  const saveItem = async ({ wineId, newWinePayload }) => {
+    if (saving) return;
     setError(null);
     setSaving(true);
     try {
-      const res = await addToWishlist(apiFetch, {
-        wineDefinitionId: selectedWine._id,
+      const body = {
         vintage: vintage || undefined,
         notes: notes || undefined,
         priority
-      });
+      };
+      if (newWinePayload) body.newWine = newWinePayload;
+      else body.wineDefinitionId = wineId;
+
+      const res = await addToWishlist(apiFetch, body);
       const data = await res.json();
+      if (res.ok && data.candidates && data.candidates.length > 0) {
+        // Commit-time soft zone: a very similar wine entered the registry
+        // between the resolve and this save. NOTHING was created — ask again.
+        setSoftCandidates(data.candidates);
+        setSoftPending({ forCommit: true, queryLabel: newWinePayload?.name });
+        return;
+      }
       if (!res.ok) {
         setError(data.error || t('addToWishlist.failedAdd'));
         return;
       }
-      setSuccess(t('addToWishlist.addedSuccess', { name: selectedWine.name }));
+      // The saved item's populated wine, not selectedWine: when the commit-
+      // phase modal picked a different wine (or the save just minted one),
+      // this closure's selectedWine is still the stale stub.
+      setSuccess(t('addToWishlist.addedSuccess', {
+        name: data.item?.wineDefinition?.name || selectedWine?.name
+      }));
       // Reset for adding another
       setTimeout(() => {
         navigate('/wishlist');
@@ -334,6 +379,14 @@ function AddToWishlist() {
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    if (!selectedWine) return;
+    await saveItem(pendingNewWine
+      ? { newWinePayload: pendingNewWine }
+      : { wineId: selectedWine._id });
   };
 
   return (
@@ -719,13 +772,38 @@ function AddToWishlist() {
         </div>
       )}
 
+      {/* Soft-zone "did you mean?" — same two-phase dialog as AddBottle:
+          resolve-phase answers write nothing ("create new" only carries the
+          fields + confirmCreate to the save); commit-phase answers resume the
+          interrupted save immediately. */}
       {softCandidates && (
         <SimilarWinesModal
           candidates={softCandidates}
-          queryName={softPending?.wineData?.name}
-          busy={findingWine}
-          onPick={(wine) => applyResolvedWine(wine)}
-          onCreateNew={() => softPending && submitFindOrCreate(softPending.wineData, { confirmCreate: true })}
+          queryName={softPending?.queryLabel || softPending?.wineData?.name}
+          busy={findingWine || saving}
+          onPick={(wine) => {
+            if (softPending?.forCommit) {
+              setSoftCandidates(null);
+              setSoftPending(null);
+              setSelectedWine(wine);
+              setPendingNewWine(null);
+              saveItem({ wineId: wine._id });
+            } else {
+              applyResolvedWine(wine);
+            }
+          }}
+          onCreateNew={() => {
+            if (!softPending) return;
+            if (softPending.forCommit) {
+              const confirmed = { ...pendingNewWine, confirmCreate: true };
+              setSoftCandidates(null);
+              setSoftPending(null);
+              setPendingNewWine(confirmed);
+              saveItem({ newWinePayload: confirmed });
+            } else {
+              applyPendingNewWine({ ...softPending.wineData, confirmCreate: true });
+            }
+          }}
           onCancel={() => { setSoftCandidates(null); setSoftPending(null); }}
         />
       )}


### PR DESCRIPTION
## The last mint-before-commitment leak — closed

The UI add flow minted the shared WineDefinition in step 1, before any bottle existed. A user who abandoned the form left an orphan registry row forever — measured on prod: 31 zero-bottle `createdVia:'ui'` rows, including today's "Domaine de Riquewihr — Kaefferkopf" (village-as-producer, abandoned two minutes after minting). This is the **third verse of a known song**: imports minted on `/validate` → fixed to mint on `/confirm` (#899); AI-identify minted per guess → made read-only in v1.97. This PR gives the UI flow the same treatment.

### The contract
- **`POST /api/bottles`** accepts exactly one of `wineDefinition` (id) or `newWine` (the old find-or-create payload verbatim). **Cellar access is checked before any registry work** — a viewer or stranger can never mint through a cellar they can't add to. Soft-zone duplicates return `200 {candidates}` with nothing created; re-submit with an id or `confirmCreate:true` — identical semantics to the old route, so the existing dedup dialog is unchanged.
- **`POST /api/wishlist`** gets the same branch (the wishlist legitimately needs a wine row — its mint moves to the save; dedup runs against the resolved id, so a 409 can never leave an orphan).
- **`POST /api/wines/find-or-create` is resolve-only** — the v1.97 identify-text pattern; stale clients' `confirmCreate` is accepted-and-ignored.
- Shared validation extracted (`services/wineCommit.validateNewWineFields`), audit/IndexNow parity preserved (`wine.create` via ui/ai fires from the new mint point, submitUrls on real creation only — both test-pinned).

### Multi-bottle mints once
Only the first POST carries `newWine`; the rest post by the returned id, and retry-after-partial-failure re-derives the id — pinned by a frontend test. AddMoreBottlesModal already posts by id.

### Every caller enumerated
Both UI pages reworked; the frontend helper renamed `resolveWine`; all nine service-level callers (import /confirm, identify-text matchOnly, MCP add_bottle/bulk/admin, admin routes, cellarImport, demo validator) verified deliberately untouched.

### Tests
40 new across three suites (both newWine branches + resolve-only contract) + regression sweeps: **22 suites, 347 backend tests green**; frontend full suite **912 green** including the new mint-on-commit flow test.

### Notes for review
- `express.json` limit on `/api/bottles` raised to 64kb (bottle+newWine exceeds the 10kb default) — app-level, **no compose impact**.
- `labelImage` dropped from wine payloads (was destructured-but-unused server-side; photos flow through /api/images and tolerate pending wines — verified).
- Version-skew window during backend-first deploy: a stale SPA's "create new wine" no-ops until refresh — same accepted class as #899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
