### PR TITLE
fix(registry): mint-on-commit release-audit remediation

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -35,7 +35,7 @@ const searchService = require('../services/search');
 // add/update/consume/restore/remove logic + rack-slot freeing live in the
 // shared service so the REST routes and the MCP tools can never drift (§7).
 const {
-  addBottle, updateBottleFields, consumeBottle, restoreBottle, removeFromRacks, removeBottleCascade,
+  addBottle, validateBottleCommitFields, updateBottleFields, consumeBottle, restoreBottle, removeFromRacks, removeBottleCascade,
   openBottle, pourFromBottle, closeBottle,
 } = require('../services/bottleOps');
 // Mint-at-commit for the POST route's `newWine` branch — the wine is created
@@ -425,6 +425,14 @@ router.post('/', requireNonDemo, async (req, res) => {
         return res.status(404).json({ error: 'Wine definition not found' });
       }
     } else {
+      // Commit-field validation BEFORE the mint (release-audit LOW-1): a
+      // vintage/rating/notes 400 after resolveOrMintWine would leave the
+      // exact orphan mint-at-commit exists to prevent. Checks-only — addBottle
+      // still validates and resolves values itself below.
+      const preCheck = validateBottleCommitFields(req.body);
+      if (preCheck.error) {
+        return res.status(preCheck.error.status).json({ error: preCheck.error.message });
+      }
       // Mint-at-commit: validation caps, dedup/soft-zone, wine.create audit
       // (via 'ui'/'ai' per newWine.source) and IndexNow all live in the shared
       // service — one implementation with POST /api/wishlist's newWine branch.

--- a/backend/src/routes/wishlist.js
+++ b/backend/src/routes/wishlist.js
@@ -186,6 +186,20 @@ router.post('/', async (req, res) => {
       return res.status(400).json({ error: 'Provide wineDefinitionId or newWine (exactly one)' });
     }
 
+    // Item-field validation BEFORE any registry work (release-audit LOW-1):
+    // a 400 on notes/priority/vintage after the mint would leave the exact
+    // orphan the mint-at-commit change exists to prevent.
+    const safeVintage = vintage != null ? String(vintage) : '';
+    if (notes && notes.length > 2000) {
+      return res.status(400).json({ error: 'Notes must be 2000 characters or less' });
+    }
+    if (priority && !['low', 'medium', 'high'].includes(priority)) {
+      return res.status(400).json({ error: 'Priority must be low, medium, or high' });
+    }
+    if (safeVintage && safeVintage.length > 20) {
+      return res.status(400).json({ error: 'Vintage must be 20 characters or less' });
+    }
+
     let resolvedWineId;
     if (newWine) {
       // Registry write — same demo bar the old find-or-create route had
@@ -212,9 +226,6 @@ router.post('/', async (req, res) => {
       resolvedWineId = wineDefinitionId;
     }
 
-    // Sanitise vintage: must be a string (prevents NoSQL injection via objects)
-    const safeVintage = vintage != null ? String(vintage) : '';
-
     // Prevent duplicates: same user + same wine + same vintage (or both null).
     // Runs AFTER the newWine resolve on purpose: a freshly MINTED wine can't
     // have a duplicate item (nothing references its new id yet), so a 409 here
@@ -232,19 +243,6 @@ router.post('/', async (req, res) => {
     const existing = await WishlistItem.findOne(dupFilter);
     if (existing) {
       return res.status(409).json({ error: 'This wine is already on your wishlist' });
-    }
-
-    // Validate notes length
-    if (notes && notes.length > 2000) {
-      return res.status(400).json({ error: 'Notes must be 2000 characters or less' });
-    }
-    // Validate priority
-    if (priority && !['low', 'medium', 'high'].includes(priority)) {
-      return res.status(400).json({ error: 'Priority must be low, medium, or high' });
-    }
-    // Validate vintage length
-    if (safeVintage && safeVintage.length > 20) {
-      return res.status(400).json({ error: 'Vintage must be 20 characters or less' });
     }
 
     const item = await WishlistItem.create({

--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -273,6 +273,61 @@ async function closeBottle(bottle, req) {
  *
  * Returns { error: { status, message } } | { bottle }.
  */
+/**
+ * Checks-only validation of the bottle-create field surface — no values are
+ * produced and nothing is written. Exists so the POST /api/bottles newWine
+ * branch can validate the COMMIT fields BEFORE resolveOrMintWine runs
+ * (release-audit LOW-1: a field 400 after the mint would leave the exact
+ * orphan mint-at-commit exists to prevent). addBottle still runs its own
+ * inline validation+resolution afterwards — this is a pre-mint gate, not a
+ * replacement, and the parsers are pure so double-parsing is free.
+ */
+function validateBottleCommitFields(fields = {}) {
+  const {
+    vintage, purchaseLocation, purchaseUrl, location,
+    notes, occasion, rating, ratingScale, drinkFrom, drinkTo,
+    addToHistory, consumedReason, consumedRating, consumedRatingScale,
+  } = fields;
+
+  const parsedVintage = parseAndValidateVintage(vintage);
+  if (!parsedVintage.ok) return { error: { status: 400, message: parsedVintage.error } };
+  const from = parseDrinkYear(drinkFrom, 'drinkFrom');
+  if (!from.ok) return { error: { status: 400, message: from.error } };
+  const to = parseDrinkYear(drinkTo, 'drinkTo');
+  if (!to.ok) return { error: { status: 400, message: to.error } };
+  if (from.value && to.value && from.value > to.value) {
+    return { error: { status: 400, message: 'drinkFrom cannot be after drinkTo' } };
+  }
+  const { error: ratingError } = resolveRatingUtil(rating, ratingScale);
+  if (ratingError) return { error: { status: 400, message: ratingError } };
+  if (notes && (typeof notes !== 'string' || notes.length > 5000)) {
+    return { error: { status: 400, message: 'Notes are too long (max 5000 characters)' } };
+  }
+  for (const [label, value] of [
+    ['Occasion', occasion], ['Purchase location', purchaseLocation], ['Location', location],
+  ]) {
+    if (value && (typeof value !== 'string' || value.length > 500)) {
+      return { error: { status: 400, message: `${label} is too long (max 500 characters)` } };
+    }
+  }
+  if (purchaseUrl) {
+    if (typeof purchaseUrl !== 'string' || purchaseUrl.length > 2048) {
+      return { error: { status: 400, message: 'purchaseUrl is too long (max 2048 characters)' } };
+    }
+    if (!isSafeUrl(purchaseUrl)) {
+      return { error: { status: 400, message: 'purchaseUrl must be a valid http or https URL' } };
+    }
+  }
+  if (addToHistory && consumedReason && !CONSUMED_STATUSES.includes(consumedReason)) {
+    return { error: { status: 400, message: 'Invalid consumed reason' } };
+  }
+  if (addToHistory) {
+    const { error: consumedRatingError } = resolveRatingUtil(consumedRating, consumedRatingScale);
+    if (consumedRatingError) return { error: { status: 400, message: consumedRatingError } };
+  }
+  return { ok: true };
+}
+
 async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
   const {
     vintage, price, currency, bottleSize,
@@ -662,7 +717,7 @@ async function removeBottleCascade(bottle, req, auditAction) {
 
 module.exports = {
   consumeBottle, restoreBottle, removeFromRacks, RESTORE_WINDOW_MS,
-  addBottle, updateBottleFields, removeBottleCascade, UPDATABLE_FIELDS,
+  addBottle, validateBottleCommitFields, updateBottleFields, removeBottleCascade, UPDATABLE_FIELDS,
   openBottle, pourFromBottle, closeBottle,
   PRESERVATION_METHODS, DEFAULT_POUR_ML, MAX_POURS,
 };

--- a/backend/src/services/wineCommit.js
+++ b/backend/src/services/wineCommit.js
@@ -131,6 +131,14 @@ async function resolveOrMintWine(newWine, req) {
 
   if (result.candidates) return { candidates: result.candidates };
 
+  // Release-audit LOW-2: findOrCreateWine's E11000 recovery re-queries by
+  // normalizedKey only — a same-slug/different-key sub-second race can return
+  // { wine: null }. Both consumers would deref it into a 500; a clean 409
+  // self-heals on retry (the winner is committed by then).
+  if (!result.wine) {
+    return { error: { status: 409, message: 'Wine resolution raced with another write — please retry.' } };
+  }
+
   const { wine, created } = result;
   if (created) {
     // Same action string + detail shape the find-or-create route emitted (and

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -485,6 +485,19 @@ function AddBottle() {
         }
         if (!res.ok) {
           setError(partialError(data.error || t('addBottle.addFailed'), createdBottles.length));
+          // Release-audit MEDIUM: a mint-gate 400 ("Riquewihr is a village,
+          // not a producer") lands here AFTER the wine form is gone. When the
+          // failed POST carried newWine and nothing was created yet, reopen
+          // step 1's manual form seeded with the typed fields so the user
+          // fixes the named field instead of retyping the wine from scratch.
+          if (newWinePayload && createdBottles.length === 0) {
+            setPendingWineData({ ...newWinePayload, grapes: (newWinePayload.grapes || []).join(', ') });
+            setShowManualForm(true);
+            setStep(1);
+          }
+          // The alert renders at the top of a long form — without the scroll
+          // a failed submit reads as "the button did nothing" (audit LOW).
+          window.scrollTo(0, 0);
           linkUploadedImages();
           return;
         }

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -362,6 +362,15 @@ function AddToWishlist() {
       }
       if (!res.ok) {
         setError(data.error || t('addToWishlist.failedAdd'));
+        // Release-audit MEDIUM (same as AddBottle): a mint-gate 400 arrives
+        // after the wine form is gone — when the failed save carried newWine,
+        // reopen the manual form seeded with the typed fields so the user
+        // fixes the named field instead of retyping the wine.
+        if (newWinePayload) {
+          setPendingWineData({ ...newWinePayload, grapes: (newWinePayload.grapes || []).join(', ') });
+          setShowManualForm(true);
+        }
+        window.scrollTo(0, 0);
         return;
       }
       // The saved item's populated wine, not selectedWine: when the commit-


### PR DESCRIPTION
Everything above INFO from the #935 release audit (backend SHIP, frontend SHIP-WITH-FIXES):

- **FE MEDIUM**: commit-time mint-gate 400s ("Riquewihr is a village, not a producer") now reopen the manual wine form **seeded with the typed fields** on both AddBottle and AddToWishlist — the audit's exact persona previously lost every field and landed on an empty search. Submit errors also scroll into view (LOW).
- **BE LOW-1**: commit-field validation runs **before** the mint on both routes (new checks-only `validateBottleCommitFields` pre-gate; wishlist item checks reordered) — a field 400 after the mint would have recreated the orphan this whole change prevents.
- **BE LOW-2**: `wineCommit` guards the E11000 slug-race `{wine: null}` recovery with a clean 409-retry instead of a null-deref 500.

Deferred per audit: the coverage-gap LOW (commit-candidates resume + retry re-derivation frontend tests), INFO items.

Tests: 84 backend across the four affected suites; frontend full suite 912 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)