### PR TITLE
fix(registry): pending-identity audit remediation — 5 blocking HIGHs

### DIFF
--- a/backend/src/mcp/getWine.pendingIdentity.test.js
+++ b/backend/src/mcp/getWine.pendingIdentity.test.js
@@ -1,0 +1,113 @@
+/**
+ * H-1 — the regression test that was MISSING when get_wine shipped.
+ *
+ * get_wine is scope:'public'. It is served to any token AND to the
+ * UNAUTHENTICATED /api/mcp/public surface, so there is no caller identity to
+ * compare a pending row's creator against: the exclusion is absolute.
+ *
+ * It was written as a post-filter — `if (raw.pendingIdentity === true)` — over
+ * a document fetched with SAFE_SELECT, an INCLUSIVE projection that does not
+ * list pendingIdentity. Under .lean() the field was therefore always
+ * `undefined`, `undefined === true` is false, and the gate never fired once.
+ * nonWine was not filtered here either. This suite pins the fix at the level
+ * that cannot rot: the exclusion is in the QUERY, so no projection can blind it.
+ */
+
+jest.mock('../models/WineDefinition', () => ({ findOne: jest.fn(), find: jest.fn(), findById: jest.fn() }));
+jest.mock('../services/search', () => ({ getIsAvailable: () => false, search: jest.fn() }));
+jest.mock('../utils/siteUrl', () => ({ siteBaseUrl: () => 'https://cellarion.app' }));
+
+const WineDefinition = require('../models/WineDefinition');
+const { allTools } = require('./registry');
+require('./tools/wines');
+
+const tool = (name) => allTools().find((t) => t.name === name);
+
+const oid = (c) => c.repeat(24);
+const WINE = oid('a');
+const CTX = { user: { id: oid('1'), roles: ['user'] } };
+
+const chain = (doc) => ({
+  select: jest.fn().mockReturnValue({
+    populate: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) }),
+  }),
+});
+
+const parse = (res) => JSON.parse(res.content[0].text);
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('get_wine — pendingIdentity is excluded in the QUERY', () => {
+  test('the filter carries BOTH exclusions, so a lean projection cannot defeat them', async () => {
+    WineDefinition.findOne.mockReturnValue(chain(null));
+
+    await tool('get_wine').handler({ wine_id: WINE }, CTX);
+
+    expect(WineDefinition.findOne).toHaveBeenCalledWith({
+      _id: WINE,
+      nonWine: { $ne: true },
+      pendingIdentity: { $ne: true },
+    });
+    // findById is what the dead-gate version used — it must not come back.
+    expect(WineDefinition.findById).not.toHaveBeenCalled();
+  });
+
+  test('a hidden row answers the SAME not_found a missing id does — existence never leaks', async () => {
+    WineDefinition.findOne.mockReturnValue(chain(null));
+
+    const res = await tool('get_wine').handler({ wine_id: WINE }, CTX);
+    const body = parse(res);
+
+    expect(body.error.code).toBe('not_found');
+    expect(body.error.message).toBe('No registry wine with that id. Find wines via search_registry.');
+  });
+
+  test('THE BUG: a pending row that slips through the projection is still not served', async () => {
+    // Exactly the old failure mode — the document comes back without the flag
+    // because SAFE_SELECT omits it. With the gate in the query this can only
+    // happen if the query matched, i.e. the row is genuinely visible; the point
+    // of this case is that the handler no longer DEPENDS on reading the flag.
+    WineDefinition.findOne.mockReturnValue(chain(null));
+    const res = await tool('get_wine').handler({ wine_id: WINE }, CTX);
+    expect(parse(res).error.code).toBe('not_found');
+  });
+
+  test('an ordinary registry wine is still served in full', async () => {
+    WineDefinition.findOne.mockReturnValue(chain({
+      _id: WINE, name: 'Barolo', producer: 'Rinaldi', slug: 'rinaldi-barolo', grapes: [],
+    }));
+
+    const res = await tool('get_wine').handler({ wine_id: WINE }, CTX);
+    const body = parse(res);
+
+    expect(body.data.name).toBe('Barolo');
+    expect(body.data.public_url).toBe('https://cellarion.app/wines/rinaldi-barolo');
+  });
+
+  test('an invalid id is rejected before any query runs', async () => {
+    const res = await tool('get_wine').handler({ wine_id: 'not-an-id' }, CTX);
+    expect(parse(res).error.code).toBe('invalid_input');
+    expect(WineDefinition.findOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('search_registry — the sibling that was already right', () => {
+  test('the Mongo fallback carries the same two exclusions', async () => {
+    WineDefinition.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            populate: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      }),
+    });
+
+    await tool('search_registry').handler({ query: 'barolo' }, CTX);
+
+    expect(WineDefinition.find).toHaveBeenCalledWith(
+      expect.objectContaining({ nonWine: { $ne: true }, pendingIdentity: { $ne: true } }),
+      expect.anything(),
+    );
+  });
+});

--- a/backend/src/mcp/pendingWineTools.test.js
+++ b/backend/src/mcp/pendingWineTools.test.js
@@ -222,8 +222,10 @@ describe('get_pending_wine_images — the point of the feature', () => {
       expect(typeof img.data).toBe('string');
       expect(Buffer.from(img.data, 'base64').toString()).toBe('downscaled-jpeg-bytes');
     }
-    // The scanned LABEL is the primary evidence and comes first.
-    expect(parse(res).data.images[0]).toEqual({ image_id: String(SCAN), kind: 'label-scan' });
+    // The scanned LABEL is the primary evidence and comes first. `private`
+    // rides along (audit M-1): these are the owner's own photos, released to
+    // curation for one purpose, and the payload says so.
+    expect(parse(res).data.images[0]).toEqual({ image_id: String(SCAN), kind: 'label-scan', private: true });
   });
 
   test('downscales server-side to <=1024px on the longest edge, never enlarging', async () => {
@@ -257,6 +259,56 @@ describe('get_pending_wine_images — the point of the feature', () => {
 
     const res = await tool('get_pending_wine_images').handler({ wine_id: W1 }, SOMM_CTX);
     expect(parse(res).error.code).toBe('unavailable');
+  });
+
+  /**
+   * M-1 (security audit) — this tool ships other people's PRIVATE bottle photos
+   * as base64 to an EXTERNAL model. The only thing that justifies it is a
+   * curator reading a label they have been asked to identify, so the wine must
+   * still be pending. Without the gate any somm token could pull the private
+   * gallery of ANY wine in the registry. The REST sibling (routes/images.js)
+   * always required pendingIdentity: true; this is the parity fix.
+   */
+  describe('M-1 — only PENDING wines release their owners\' photos', () => {
+    const primeNonPending = () => {
+      WineDefinition.findById.mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({
+            _id: W1, name: 'Barolo', producer: 'Rinaldi', pendingIdentity: false, scanImage: SCAN,
+          }),
+        }),
+      });
+    };
+
+    test('a COMPLETED wine is refused — its photos are private, not curation evidence', async () => {
+      primeNonPending();
+
+      const res = await tool('get_pending_wine_images').handler({ wine_id: W1 }, SOMM_CTX);
+      const body = parse(res);
+
+      expect(body.error.code).toBe('conflict');
+      expect(body.error.message).toMatch(/not in the pending-identity queue/);
+    });
+
+    test('no image is read from disk for a completed wine', async () => {
+      primeNonPending();
+      fs.promises.readFile.mockClear();
+
+      await tool('get_pending_wine_images').handler({ wine_id: W1 }, SOMM_CTX);
+
+      expect(fs.promises.readFile).not.toHaveBeenCalled();
+      expect(BottleImage.find).not.toHaveBeenCalled();
+    });
+
+    test('the payload marks the photos PRIVATE and says what they may be used for', async () => {
+      primeWine();
+
+      const res = await tool('get_pending_wine_images').handler({ wine_id: W1 }, SOMM_CTX);
+      const body = parse(res);
+
+      expect(body.data.images.every((i) => i.private === true)).toBe(true);
+      expect(body.data.guidance).toMatch(/private photos/i);
+    });
   });
 });
 

--- a/backend/src/mcp/readTools.test.js
+++ b/backend/src/mcp/readTools.test.js
@@ -27,7 +27,7 @@ jest.mock('../models/Bottle', () => ({
 jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
-jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn(), findOne: jest.fn() }));
 jest.mock('../models/User', () => ({ findById: jest.fn() }));
 jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
 // Lazy-required inside handlers; jest still intercepts by resolved path.
@@ -234,7 +234,7 @@ describe('regional grape display names (somm ticket: Tinta Roriz on a Douro Port
   test('get_wine serializes the regionally correct grape label for the wine\'s own place', async () => {
     const PORTUGAL = oid('1');
     const DOURO = oid('2');
-    WineDefinition.findById.mockReturnValue(chain({
+    WineDefinition.findOne.mockReturnValue(chain({
       _id: oid('f'), name: 'Vintage Port', producer: 'Quinta do Exemplo', type: 'fortified',
       country: { _id: PORTUGAL, name: 'Portugal' },
       region: { _id: DOURO, name: 'Douro' },
@@ -249,7 +249,7 @@ describe('regional grape display names (somm ticket: Tinta Roriz on a Douro Port
   });
 
   test('get_wine keeps the canonical name when no entry applies to the wine\'s country', async () => {
-    WineDefinition.findById.mockReturnValue(chain({
+    WineDefinition.findOne.mockReturnValue(chain({
       _id: oid('f'), name: 'Ribera Tinto', producer: 'X', type: 'red',
       country: { _id: oid('9'), name: 'Spain' },
       grapes: [{ _id: oid('3'), name: 'Tempranillo', regionalNames: [{ country: oid('1'), region: oid('2'), name: 'Tinta Roriz' }] }],

--- a/backend/src/mcp/resources.test.js
+++ b/backend/src/mcp/resources.test.js
@@ -22,7 +22,7 @@ jest.mock('../models/Bottle', () => ({
 jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
-jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn(), findOne: jest.fn() }));
 jest.mock('../models/User', () => ({ findById: jest.fn() }));
 jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
 jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
@@ -218,7 +218,7 @@ describe('previously-uncovered handlers', () => {
     const bad = await tool('get_wine').handler({ wine_id: 'nope' }, CTX);
     expect(JSON.parse(bad.content[0].text).error.code).toBe('invalid_input');
 
-    WineDefinition.findById.mockReturnValue(chain({
+    WineDefinition.findOne.mockReturnValue(chain({
       _id: oid('f'), name: 'Barolo', producer: 'X', slug: 'barolo-x', grapes: [],
       aiProfile: { body: null, acidity: null, notes: [] }, communityRating: { averageNormalized: null, reviewCount: 0 },
     }));

--- a/backend/src/mcp/tools/bulk.js
+++ b/backend/src/mcp/tools/bulk.js
@@ -22,6 +22,7 @@ const { isValidId } = require('../../utils/validation');
 const { parseAndValidateVintage, parseDrinkYear } = require('../../utils/validation');
 const { resolveRating } = require('../../utils/ratingUtils');
 const WineDefinition = require('../../models/WineDefinition');
+const { findVisibleWine } = require('../../services/wineVisibility');
 const { NEW_WINE_SHAPE } = require('./write');
 const { ok, fail, objectId, MSG_CELLAR_NOT_FOUND, resolveCellarAccess, wineSummary } = require('../toolUtil');
 const { logAction } = require('../actionLedger');
@@ -58,7 +59,7 @@ function validateItemFields(item) {
   return null;
 }
 
-async function planItem(item, userId) {
+async function planItem(item, userId, roles) {
   if (!item.wine_id && !item.new_wine) return { status: 'invalid', error: 'wine_id or new_wine required' };
   if (item.wine_id && item.new_wine) return { status: 'invalid', error: 'wine_id OR new_wine, not both' };
   const fieldError = validateItemFields(item);
@@ -66,7 +67,12 @@ async function planItem(item, userId) {
 
   if (item.wine_id) {
     if (!isValidId(item.wine_id)) return { status: 'invalid', error: 'wine_id must be a 24-hex id' };
-    const wine = await WineDefinition.findById(item.wine_id).populate(['country', 'region', 'grapes']);
+    // Visible-to-this-caller (services/wineVisibility) — same rule as
+    // add_bottle: own pending row yes, a stranger's no. planItem is the
+    // preview AND the plan the commit executes, so gating here gates both.
+    const wine = await findVisibleWine(item.wine_id, {
+      userId, roles, populate: ['country', 'region', 'grapes'],
+    });
     if (!wine) return { status: 'invalid', error: `no registry wine ${item.wine_id}` };
     return { status: 'ready', wine_id: String(wine._id), wine: wineSummary(wine) };
   }
@@ -126,7 +132,7 @@ registerTool({
       const plan = [];
       for (let i = 0; i < args.items.length; i++) {
         // Serial on purpose: bounded work, and registry lookups stay gentle.
-        const p = await planItem(args.items[i], ctx.user.id);
+        const p = await planItem(args.items[i], ctx.user.id, ctx.user.roles);
         plan.push({ index: i, vintage: args.items[i].vintage || 'NV', ...p });
       }
       const counts = plan.reduce((acc, p) => ((acc[p.status] = (acc[p.status] || 0) + 1), acc), {});

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1193,20 +1193,33 @@ registerTool({
     if (denied) return denied;
     if (!isValidId(args.wine_id)) return fail('invalid_input', 'wine_id must be a 24-hex id.');
 
+    // PENDING ONLY, exactly like the REST sibling (routes/images.js): this tool
+    // ships other people's PRIVATE bottle photos as base64 to an external
+    // model, and the only justification for that is a curator reading a label
+    // they have been asked to identify. Without the gate any somm token could
+    // pull the private gallery of ANY wine in the registry (security audit).
+    // A real-but-completed id is a conflict, not a 404 — the same distinction
+    // loadPendingWine makes, so a curator whose fix already landed is told so.
     const wine = await WineDefinition.findById(args.wine_id)
       .select('name producer pendingIdentity scanImage').lean();
     if (!wine) return fail('not_found', 'No wine with that id. Use list_pending_wines for valid ids.');
+    if (wine.pendingIdentity !== true) {
+      return fail('conflict',
+        'That wine is not in the pending-identity queue — its photos are its owners\' private images, not curation evidence.');
+    }
 
     // "Which images belong to this wine" has exactly one definition — the same
     // both-ways match the queue projection uses (some upload paths stamp the
     // wine on the image, the plain add flow only links it to the bottle).
+    // `visibility` rides along so the caller can be told what it is looking at:
+    // these are private photos, surfaced only because the row needs curating.
     const BottleImage = require('../../models/BottleImage');
     const Bottle = require('../../models/Bottle');
     const bottleIds = await Bottle.distinct('_id', { wineDefinition: wine._id });
     const imgs = await BottleImage.find({
       kind: { $ne: 'label-scan' },
       $or: [{ wineDefinition: wine._id }, ...(bottleIds.length ? [{ bottle: { $in: bottleIds } }] : [])],
-    }).select('_id kind originalUrl processedUrl').sort({ createdAt: -1 }).limit(MAX_BOTTLE_IMAGES).lean();
+    }).select('_id kind visibility originalUrl processedUrl').sort({ createdAt: -1 }).limit(MAX_BOTTLE_IMAGES).lean();
 
     const ordered = [];
     if (wine.scanImage) {
@@ -1246,7 +1259,13 @@ registerTool({
         if (totalBytes + out.length > IMAGE_TOTAL_CAP_BYTES) break;
         totalBytes += out.length;
         blocks.push({ type: 'image', data: out.toString('base64'), mimeType: 'image/jpeg' });
-        included.push({ image_id: String(doc._id), kind: doc.kind || 'bottle' });
+        // Marked private unless the owner published it: these are somebody's
+        // own bottle photos, released to curation for one purpose only.
+        included.push({
+          image_id: String(doc._id),
+          kind: doc.kind || 'bottle',
+          private: doc.visibility !== 'public',
+        });
       } catch (err) {
         console.warn('[mcp] pending-wine image read failed:', err.message);
       }
@@ -1266,7 +1285,7 @@ registerTool({
               wine_id: wine._id,
               still_pending: wine.pendingIdentity === true,
               images: included,
-              guidance: 'Read the producer, appellation and classification off the label. Transcribe what is printed — never infer a producer from the region.',
+              guidance: 'Read the producer, appellation and classification off the label. Transcribe what is printed — never infer a producer from the region. These are the owner\'s private photos, released for this one purpose: do not describe, store or reuse them for anything but completing this wine\'s identity.',
             },
           }),
         },

--- a/backend/src/mcp/tools/wineLists.js
+++ b/backend/src/mcp/tools/wineLists.js
@@ -170,7 +170,10 @@ registerTool({
 
     const [list, wine] = await Promise.all([
       WineList.findOne({ _id: args.list_id, user: ctx.user.id }),
-      WineDefinition.findById(args.wine_id).populate('country region'),
+      // ABSOLUTE pendingIdentity gate, matching the REST PUT: a wine list can
+      // be published, and routes/wineListPublic.js serves it with no auth — so
+      // not even the pending row's own creator may put it on one.
+      WineDefinition.findOne({ _id: args.wine_id, pendingIdentity: { $ne: true } }).populate('country region'),
     ]);
     if (!list) return fail('not_found', 'No such wine list. Use list_wine_lists for valid ids.');
     if (!wine) return fail('not_found', 'No such registry wine. Find the wine_id via search_registry or a bottle\'s wine.');

--- a/backend/src/mcp/tools/wines.js
+++ b/backend/src/mcp/tools/wines.js
@@ -83,13 +83,19 @@ registerTool({
   inputSchema: { wine_id: z.string().describe('Registry wine id from search_registry or a bottle\'s wine') },
   handler: async (args) => {
     if (!isValidId(args.wine_id)) return fail('invalid_input', 'wine_id must be a 24-hex Mongo id.');
-    const raw = await WineDefinition.findById(args.wine_id)
+    // The exclusion is a QUERY clause, not a post-filter on the result. A
+    // post-filter here was DEAD CODE (security audit): SAFE_SELECT is an
+    // INCLUSIVE projection and does not list pendingIdentity, so under .lean()
+    // the field is always undefined and `undefined === true` never fired —
+    // this tool is 'public' scope, served by the UNAUTHENTICATED
+    // /api/mcp/public surface, so that gate was the only thing standing between
+    // an anonymous caller and a stranger's half-identified wine. nonWine rides
+    // along in the same clause (it was never filtered here either). Compare
+    // publicContent.js's drink_window_for, which selects the flag it tests.
+    const raw = await WineDefinition.findOne({ _id: args.wine_id, ...VISIBLE })
       .select(SAFE_SELECT).populate(['country', 'region', 'grapes']).lean();
-    // Post-filter rather than a query clause: 'public' scope means there is no
-    // caller identity to compare against the row's creator, so a pending row is
-    // simply not registry content here — reported as the same not_found a
-    // missing id gets, so its existence never leaks.
-    if (!raw || raw.pendingIdentity === true) {
+    // Same not_found a missing id gets, so a hidden row's existence never leaks.
+    if (!raw) {
       return fail('not_found', 'No registry wine with that id. Find wines via search_registry.');
     }
     // Grapes surface as the regionally correct label for THIS wine's place

--- a/backend/src/mcp/tools/write.js
+++ b/backend/src/mcp/tools/write.js
@@ -15,6 +15,7 @@
 // costs nothing.
 const { z } = require('zod');
 const WineDefinition = require('../../models/WineDefinition');
+const { findVisibleWine } = require('../../services/wineVisibility');
 const { registerTool } = require('../registry');
 // findOrCreateWine is required LAZILY inside handlers: it top-requires
 // services/search → the ESM-only meilisearch package, which jest cannot parse
@@ -136,7 +137,13 @@ registerTool({
     let wineCreated = false;
     if (args.wine_id) {
       if (!isValidId(args.wine_id)) return fail('invalid_input', 'wine_id must be a 24-hex Mongo id.');
-      wineDoc = await WineDefinition.findById(args.wine_id).populate(['country', 'region', 'grapes']);
+      // Visible-to-this-caller (services/wineVisibility): the creator may add
+      // more bottles of their own pending row (that is how a case of one
+      // unreadable label works), a stranger gets the same not_found a missing
+      // id gets — security audit M-4.
+      wineDoc = await findVisibleWine(args.wine_id, {
+        userId: ctx.user.id, roles: ctx.user.roles, populate: ['country', 'region', 'grapes'],
+      });
       if (!wineDoc) return fail('not_found', 'No registry wine with that id. Use resolve_wine or search_registry.');
     } else {
       const { findOrCreateWine } = require('../../services/findOrCreateWine');
@@ -162,6 +169,13 @@ registerTool({
         return fail('conflict',
           'Very similar wines already exist — use one of these wine_ids, or call again with confirm_new_wine:true ONLY if the user confirms it is genuinely different: ' +
           result.candidates.map((c) => `${c.wine.name} — ${c.wine.producer} (wine_id ${c.wine._id}, score ${c.score})`).join('; '));
+      }
+      // A no-wine result with no candidates either (audit L-7): the branch
+      // above only covers the candidates case, so this fell through to
+      // `wineDoc.name` and threw a 500. bulk.js:224 already handles it as a
+      // failure rather than a crash — mirror that.
+      if (!result.wine) {
+        return fail('unavailable', 'The registry could not resolve or create that wine — retry, or pick a wine_id with resolve_wine.');
       }
       wineDoc = result.wine;
       wineCreated = !!result.created;

--- a/backend/src/mcp/wineListTools.test.js
+++ b/backend/src/mcp/wineListTools.test.js
@@ -9,7 +9,7 @@
  */
 
 jest.mock('../models/WineList', () => ({ findOne: jest.fn(), find: jest.fn(), countDocuments: jest.fn() }));
-jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn(), findOne: jest.fn() }));
 jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
 // revert.js and tools/write.js top-require bottleOps (which pulls the search/
@@ -64,7 +64,9 @@ beforeEach(() => {
   jest.clearAllMocks();
   McpActionLog.create.mockResolvedValue({});
   McpActionLog.findOne.mockReturnValue({ lean: () => Promise.resolve(null) });
-  WineDefinition.findById.mockReturnValue({ populate: jest.fn(() => Promise.resolve({ _id: WINE, name: 'Barolo Riserva', producer: 'Rinaldi' })) });
+  // findOne with an absolute pendingIdentity exclusion: a wine list can be
+  // PUBLISHED and routes/wineListPublic.js has no auth (security audit H-5).
+  WineDefinition.findOne.mockReturnValue({ populate: jest.fn(() => Promise.resolve({ _id: WINE, name: 'Barolo Riserva', producer: 'Rinaldi' })) });
 });
 
 describe('registration + scopes', () => {
@@ -114,7 +116,7 @@ describe('list_wine_lists / get_wine_list', () => {
 describe('add_to_list', () => {
   test('unknown wine → not_found', async () => {
     WineList.findOne.mockResolvedValue(makeList());
-    WineDefinition.findById.mockReturnValue({ populate: jest.fn(() => Promise.resolve(null)) });
+    WineDefinition.findOne.mockReturnValue({ populate: jest.fn(() => Promise.resolve(null)) });
     const res = await tool('add_to_list').handler({ list_id: LIST, wine_id: WINE }, CTX);
     expect(parse(res).error.code).toBe('not_found');
   });

--- a/backend/src/mcp/writeTools.test.js
+++ b/backend/src/mcp/writeTools.test.js
@@ -23,7 +23,7 @@ jest.mock('../models/Bottle', () => ({
 jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn(), updateMany: jest.fn() }));
 jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
-jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn(), findOne: jest.fn() }));
 jest.mock('../models/User', () => ({ findById: jest.fn() }));
 jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
 jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), deleteOne: jest.fn(() => Promise.resolve({})) }));
@@ -163,7 +163,9 @@ describe('add_bottle', () => {
 
   test('existing wine_id: no findOrCreateWine call, no wine.create audit', async () => {
     ownCellar();
-    WineDefinition.findById.mockReturnValue(chain({ _id: oid('f'), name: 'Known', producer: 'P', grapes: [] }));
+    // findOne, not findById: the wine_id branch goes through
+    // services/wineVisibility, so a stranger's pending row is not_found (M-4).
+    WineDefinition.findOne.mockReturnValue(chain({ _id: oid('f'), name: 'Known', producer: 'P', grapes: [] }));
     bottleOps.addBottle.mockResolvedValue({ bottle: { _id: oid('d'), vintage: 'NV', cellar: oid('c') } });
     const body = parse(await tool('add_bottle').handler({ cellar_id: oid('c'), wine_id: oid('f') }, CTX));
     expect(body.data.wine_created).toBe(false);

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const mongoose = require('mongoose');
 const { generateWineSlug, isIdentitySentinel } = require('../utils/normalize');
 const { computeCanonicalKey } = require('../utils/wineIdentity');
@@ -397,20 +398,59 @@ wineDefinitionSchema.pre('validate', function(next) {
   next();
 });
 
-// Auto-generate slug for new wines when missing. On collision the caller (the
-// findOrCreateWine flow) appends a -2/-3 suffix; the migration script does the
-// same when backfilling. Existing slugs are never overwritten — URL stability.
-wineDefinitionSchema.pre('save', async function(next) {
-  if (this.slug || !this.isNew) return next();
-  const base = generateWineSlug(this.name, this.producer);
-  if (!base) return next();
+/**
+ * Does this document get a slug on THIS save?
+ *
+ * A static (not an inline condition) so the rule can be tested without a live
+ * connection — the audit's M-5 was a rule nobody could see fire.
+ *
+ * - Never overwrite an existing slug. URL stability.
+ * - A pendingIdentity row gets NO slug — SLUG SQUATTING (security audit M-5).
+ *   The slug is derived from name+producer, and a pending row's producer is ''
+ *   — so a row minted from a half-read "Cloudy Bay Sauvignon Blanc" label took
+ *   /wines/cloudy-bay-sauvignon-blanc and served a 404 there to everyone
+ *   (pending rows are excluded from every public read), while the REAL wine was
+ *   pushed onto `-2`. Nothing ever reclaimed it: the old guard also returned
+ *   early for every non-new doc, so promotion never regenerated.
+ * - Create, or the save that PROMOTES a pending row — which is exactly when the
+ *   wine first deserves a public URL. pre-validate has already flipped the flag
+ *   by the time the save hook runs, so isModified is how promotion is spotted.
+ * - A slugless LEGACY row is left alone: backfilling those belongs to the
+ *   migration script, not to whatever write happens to touch them next.
+ */
+wineDefinitionSchema.statics.shouldAssignSlug = function (doc) {
+  if (doc.slug) return false;
+  if (doc.pendingIdentity === true) return false;
+  return Boolean(doc.isNew || doc.isModified('pendingIdentity'));
+};
+
+/**
+ * First free slug for `base`, disambiguating with -2, -3, … as the
+ * findOrCreateWine flow and the backfill migration do.
+ *
+ * The old loop `for (let i = 2; i < 100; i++)` fell through SILENTLY when all
+ * 98 suffixes were taken: it assigned its last candidate without ever checking
+ * it, i.e. a known-colliding slug against a unique index — a write failure at
+ * the very end of a bottle add. A random suffix ends it in one step, and is
+ * still checked, so every return from here carries the same guarantee.
+ */
+wineDefinitionSchema.statics.findFreeSlug = async function (base) {
+  const taken = async (slug) => Boolean(await this.findOne({ slug }).select('_id').lean());
   let candidate = base;
   for (let i = 2; i < 100; i++) {
-    const collision = await this.constructor.findOne({ slug: candidate }).select('_id').lean();
-    if (!collision) break;
+    if (!await taken(candidate)) return candidate;
     candidate = `${base}-${i}`;
   }
-  this.slug = candidate;
+  if (!await taken(candidate)) return candidate;
+  return `${base}-${crypto.randomBytes(4).toString('hex')}`;
+};
+
+// Auto-generate the slug when the rules above say this save earns one.
+wineDefinitionSchema.pre('save', async function(next) {
+  if (!this.constructor.shouldAssignSlug(this)) return next();
+  const base = generateWineSlug(this.name, this.producer);
+  if (!base) return next();
+  this.slug = await this.constructor.findFreeSlug(base);
   next();
 });
 

--- a/backend/src/routes/admin/images.js
+++ b/backend/src/routes/admin/images.js
@@ -22,7 +22,14 @@ router.get('/', async (req, res) => {
   try {
     const { status } = req.query;
     const { limit, offset, page } = parsePagination(req.query, { limit: 20, maxLimit: 100 });
-    const filter = {};
+    // Label scans are NOT moderation content (audit L-6). They are the private
+    // original frame a user scanned, kept for one purpose — letting a curator
+    // read an unreadable label — and they are never public. Surfacing them here
+    // let an admin approve one as a wine's official image, which sets
+    // assignedToWine and thereby moves it from the DELETE branch of account
+    // deletion to the ANONYMISE branch (services/userDataRegistry): the user's
+    // own photo would outlive their account, reattributed.
+    const filter = { kind: { $ne: 'label-scan' } };
     const validStatuses = ['uploaded', 'processing', 'processed', 'approved', 'rejected'];
     if (status) {
       if (!validStatuses.includes(status)) {
@@ -63,7 +70,8 @@ router.get('/by-wine', async (req, res) => {
     // An image belongs to a wine directly (wineDefinition) or via its bottle.
     const HAS_FILE = { $or: [{ processedUrl: { $ne: null } }, { originalUrl: { $ne: null } }] };
     const basePipeline = [
-      { $match: { status: { $ne: 'rejected' }, ...HAS_FILE } },
+      // kind exclusion: same reason as GET / above (audit L-6).
+      { $match: { status: { $ne: 'rejected' }, kind: { $ne: 'label-scan' }, ...HAS_FILE } },
       { $lookup: { from: 'bottles', localField: 'bottle', foreignField: '_id', as: '_b' } },
       { $addFields: { effWine: { $ifNull: ['$wineDefinition', { $arrayElemAt: ['$_b.wineDefinition', 0] }] } } },
       { $match: { effWine: { $ne: null } } },
@@ -105,6 +113,7 @@ router.get('/by-wine', async (req, res) => {
 
     const images = await BottleImage.find({
       status: { $ne: 'rejected' },
+      kind: { $ne: 'label-scan' },
       $and: [
         HAS_FILE,
         { $or: [{ wineDefinition: { $in: wineIds } }, { bottle: { $in: bottles.map(b => b._id) } }] },
@@ -167,6 +176,14 @@ router.put('/:id/approve', async (req, res) => {
     }
     if (!['processed', 'uploaded'].includes(image.status)) {
       return res.status(400).json({ error: 'Image cannot be approved in current state' });
+    }
+    // Never a label scan (audit L-6): it is a private frame kept only so a
+    // curator can read an unreadable label. Promoting one to a wine's official
+    // image makes it public AND sets assignedToWine, which moves it out of the
+    // delete branch of account deletion into the anonymise branch, so the
+    // uploader's own photo would outlive their account, reattributed.
+    if (image.kind === 'label-scan') {
+      return res.status(400).json({ error: 'A label scan is private curation evidence, not a wine image' });
     }
 
     const visibility = req.body.visibility || 'public';
@@ -450,6 +467,14 @@ router.put('/:id/assign-to-wine', async (req, res) => {
     if (image.status !== 'approved') {
       return res.status(400).json({ error: 'Only approved images can be assigned to a wine' });
     }
+    // Never a label scan (audit L-6): it is a private frame kept only so a
+    // curator can read an unreadable label. Promoting one to a wine's official
+    // image makes it public AND sets assignedToWine, which moves it out of the
+    // delete branch of account deletion into the anonymise branch, so the
+    // uploader's own photo would outlive their account, reattributed.
+    if (image.kind === 'label-scan') {
+      return res.status(400).json({ error: 'A label scan is private curation evidence, not a wine image' });
+    }
 
     // wineDefinitionId comes from the request body — validate it as an ObjectId
     // before it flows into updateMany/findByIdAndUpdate filters. Without this,
@@ -520,6 +545,14 @@ router.put('/:id/set-official', async (req, res) => {
     if (!image) return res.status(404).json({ error: 'Image not found' });
     if (image.status === 'rejected') {
       return res.status(400).json({ error: 'Rejected images cannot be set as official' });
+    }
+    // Never a label scan (audit L-6): it is a private frame kept only so a
+    // curator can read an unreadable label. Promoting one to a wine's official
+    // image makes it public AND sets assignedToWine, which moves it out of the
+    // delete branch of account deletion into the anonymise branch, so the
+    // uploader's own photo would outlive their account, reattributed.
+    if (image.kind === 'label-scan') {
+      return res.status(400).json({ error: 'A label scan is private curation evidence, not a wine image' });
     }
 
     const imageUrl = image.processedUrl || image.originalUrl;

--- a/backend/src/routes/bottles.drinkWindow.test.js
+++ b/backend/src/routes/bottles.drinkWindow.test.js
@@ -43,7 +43,7 @@ jest.mock('../utils/vintageProfile', () => ({
 // ── Model mocks ──────────────────────────────────────────────────────────────
 
 jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
-jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn(), findOne: jest.fn() }));
 jest.mock('../models/Rack', () => ({ updateMany: jest.fn() }));
 jest.mock('../models/Country', () => ({}));
 jest.mock('../models/Region', () => ({}));
@@ -128,7 +128,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   Bottle.__instances.length = 0;
   Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, name: 'Main', user: USER_ID, members: [], deletedAt: null });
-  WineDefinition.findById.mockResolvedValue({ _id: WINE_ID, name: 'Test Wine' });
+  // findOne: the by-id path resolves through services/wineVisibility (M-4).
+  WineDefinition.findOne.mockResolvedValue({ _id: WINE_ID, name: 'Test Wine' });
   // Existing bottle for PUT — carries a stored window half for the
   // partial-update inversion checks.
   storedBottle = {

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -4,6 +4,7 @@ const { requireBottleAccess } = require('../middleware/bottleAccess');
 const Bottle = require('../models/Bottle');
 const Cellar = require('../models/Cellar');
 const WineDefinition = require('../models/WineDefinition');
+const { findVisibleWine } = require('../services/wineVisibility');
 const Country = require('../models/Country');
 const Region = require('../models/Region');
 const Grape = require('../models/Grape');
@@ -420,7 +421,13 @@ router.post('/', requireNonDemo, async (req, res) => {
       if (!mongoose.isValidObjectId(wineDefinition)) {
         return res.status(400).json({ error: 'Invalid wine definition ID' });
       }
-      wineDoc = await WineDefinition.findById(wineDefinition);
+      // Visible-to-this-user (services/wineVisibility). The CREATOR clause is
+      // load-bearing here, not a nicety: a multi-bottle add posts bottles 2..N
+      // against the wine id the first bottle minted, and that row is pending
+      // precisely when the label could not be read. A blanket pending
+      // exclusion would break the case the feature exists for; a stranger
+      // still gets the same 404 a missing id gets.
+      wineDoc = await findVisibleWine(wineDefinition, { userId: req.user.id, roles: req.user.roles });
       if (!wineDoc) {
         return res.status(404).json({ error: 'Wine definition not found' });
       }

--- a/backend/src/routes/bottles.newWine.test.js
+++ b/backend/src/routes/bottles.newWine.test.js
@@ -53,7 +53,7 @@ jest.mock('../utils/vintageProfile', () => ({
 }));
 
 jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
-jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn(), findOne: jest.fn() }));
 jest.mock('../models/Rack', () => ({ updateMany: jest.fn() }));
 jest.mock('../models/Country', () => ({}));
 jest.mock('../models/Region', () => ({}));
@@ -174,7 +174,10 @@ describe('POST /api/bottles — wine reference contract', () => {
   });
 
   test('the by-id path is untouched: loads the wine, never calls findOrCreateWine, never audits wine.create', async () => {
-    WineDefinition.findById.mockResolvedValue(WINE_DOC);
+    // findOne, not findById: the by-id path resolves through
+    // services/wineVisibility so a stranger's pendingIdentity row answers the
+    // same 404 a missing id does (security audit M-4).
+    WineDefinition.findOne.mockResolvedValue(WINE_DOC);
 
     const { status, body } = await post({ cellar: CELLAR_ID, vintage: '2019', wineDefinition: WINE_ID });
 

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -426,7 +426,14 @@ router.post('/', requireAuth, requireNonDemo, async (req, res) => {
     // to a real ObjectId before it touches the query (clears taint tracking).
     const wineOid = wineDefinition ? new mongoose.Types.ObjectId(String(wineDefinition)) : null;
     if (wineOid) {
-      const wineExists = await WineDefinition.exists({ _id: wineOid });
+      // ABSOLUTE pendingIdentity gate — not the creator-aware one. A discussion
+      // is anonymously readable (optionalAuth), its wine is populated into the
+      // response, baked into the anonymously-searchable discussion Meili index
+      // and rendered for CRAWLERS by routes/og.js. So even the row's own
+      // creator must not be able to publish it: attaching is what would make a
+      // hidden half-identified wine public (security audit). Refused at WRITE
+      // time, which closes every downstream read path at once.
+      const wineExists = await WineDefinition.exists({ _id: wineOid, pendingIdentity: { $ne: true } });
       if (!wineExists) return res.status(400).json({ error: 'Wine not found' });
     }
 
@@ -710,7 +717,11 @@ router.post('/:idOrSlug/replies', requireAuth, requireNonDemo, async (req, res) 
     // Validate wine reference if provided
     let validWineId = null;
     if (wineDefId && isValidId(wineDefId)) {
-      const wine = await WineDefinition.findById(wineDefId).select('_id');
+      // Same absolute gate as the create path above — a reply's wine chip is
+      // rendered to anonymous readers and to crawlers too. This path drops an
+      // unusable id silently (it always has), so a pending one just doesn't
+      // attach rather than failing the reply.
+      const wine = await WineDefinition.findOne({ _id: wineDefId, pendingIdentity: { $ne: true } }).select('_id');
       if (wine) validWineId = wine._id;
     }
 

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -316,7 +316,28 @@ router.get('/:id', requireAuth, async (req, res) => {
       return res.status(404).json({ error: 'Image not found' });
     }
 
-    res.json({ image });
+    // PROJECT the response (audit L-4). Returning the whole document handed
+    // back uploadedBy — and the somm/admin branch above exists precisely so a
+    // curator can read a stranger's label scan, which the pending-wine queue
+    // goes to deliberate lengths to keep ANONYMOUS (services/pendingWineOps).
+    // Sending the uploader's id with the bytes undid that in one line. These
+    // are the fields the client polls for.
+    res.json({
+      image: {
+        _id: image._id,
+        kind: image.kind || 'bottle',
+        status: image.status,
+        visibility: image.visibility,
+        originalUrl: image.originalUrl,
+        processedUrl: image.processedUrl,
+        bottle: image.bottle,
+        wineDefinition: image.wineDefinition,
+        assignedToWine: image.assignedToWine,
+        credit: image.credit,
+        createdAt: image.createdAt,
+        updatedAt: image.updatedAt,
+      },
+    });
   } catch (error) {
     console.error('Get image error:', error);
     res.status(500).json({ error: 'Failed to get image' });

--- a/backend/src/routes/import.crossUserPending.test.js
+++ b/backend/src/routes/import.crossUserPending.test.js
@@ -1,0 +1,160 @@
+/**
+ * H-3 — POST /api/bottles/import/validate must not offer a STRANGER's pending
+ * wine as a match.
+ *
+ * The shape of the bug: a pendingIdentity row stores producer '' by
+ * construction, and a CellarTracker export routinely has no producer column —
+ * so the two scored 1.0 against each other. The user then picked the "match"
+ * and /confirm attached their bottles to another person's hidden,
+ * half-identified record, silently merging two strangers' registries.
+ *
+ * All three candidate strategies were open. Strategy 3 was the worst: its
+ * `normalizedKey: { $regex: ':<name>:' }` is UNANCHORED, and the pending
+ * namespace is `pending~<creatorId>:<name>:<appellation>` — which contains that
+ * substring by construction, so pending rows matched *preferentially*.
+ *
+ * The gate is the shared creator-aware one, not a blanket exclusion: /confirm
+ * passes allowPending and resolves to the caller's OWN pending row, so hiding
+ * it at /validate would make the preview lie about what the commit will do.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexWine: () => {},
+  bulkIndexBottles: jest.fn(),
+}));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn() }));
+jest.mock('../services/aiProvider', () => ({ isConfigured: () => false }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({ getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null) }));
+jest.mock('../utils/vintageProfile', () => ({ ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findOne: jest.fn(), find: jest.fn() }));
+jest.mock('../models/Country', () => ({ findOne: jest.fn() }));
+jest.mock('../models/ImportSession', () => ({}));
+jest.mock('../models/Rack', () => {
+  const model = { find: jest.fn() };
+  model.RACK_TYPES = ['grid', 'x-rack', 'hex', 'triangle', 'stack', 'cube', 'shelf'];
+  return model;
+});
+jest.mock('../models/Bottle', () => {
+  function Bottle(data) { Object.assign(this, data); this.save = jest.fn().mockResolvedValue(this); }
+  Bottle.find = jest.fn();
+  return Bottle;
+});
+jest.mock('../models/WineRequest', () => function WineRequest() {});
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineDefinition = require('../models/WineDefinition');
+const Cellar = require('../models/Cellar');
+
+const oid = (c) => c.repeat(24);
+const ME = oid('1');
+const CELLAR = oid('c');
+
+const tokenFor = (id, roles = ['user']) => jwt.sign({ id, roles }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles/import', require('./import'));
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+// Every candidate query returns nothing — this suite is about the FILTERS the
+// route builds, which is where the vulnerability lived.
+const emptyFind = () => ({
+  populate: jest.fn().mockReturnValue({
+    sort: jest.fn().mockReturnValue({ limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }) }),
+    limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+    lean: jest.fn().mockResolvedValue([]),
+  }),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Cellar.findById.mockResolvedValue({
+    _id: CELLAR, deletedAt: null, user: ME, members: [], toString: () => CELLAR,
+  });
+  WineDefinition.find.mockImplementation(emptyFind);
+  WineDefinition.findOne.mockReturnValue({ populate: jest.fn().mockResolvedValue(null) });
+});
+
+const validate = (token, items) => fetch(`${baseUrl}/api/bottles/import/validate`, {
+  method: 'POST',
+  headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  body: JSON.stringify({ cellarId: CELLAR, items }),
+});
+
+// A CellarTracker-shaped row: name, no producer — exactly what scores 1.0
+// against a pending row's empty producer.
+const CT_ROW = { wineName: 'Kaefferkopf', producer: 'Cave de Kaysersberg', vintage: '2019' };
+
+describe('H-3 — the candidate pool is scoped to wines the caller may see', () => {
+  test('every WineDefinition.find candidate query carries the visibility clause', async () => {
+    await validate(tokenFor(ME), [CT_ROW]);
+
+    expect(WineDefinition.find).toHaveBeenCalled();
+    for (const call of WineDefinition.find.mock.calls) {
+      const filter = JSON.stringify(call[0]);
+      // Either spread in directly, or nested under $and when the query already
+      // uses $or (strategy 3) — both forms carry the same clause.
+      expect(filter).toContain('pendingIdentity');
+      expect(filter).toContain(ME); // …and the creator branch, for their own rows
+    }
+  });
+
+  test('strategy 3 combines its key $or with the visibility $or under $and', async () => {
+    await validate(tokenFor(ME), [CT_ROW]);
+
+    // The unanchored `:<name>:` regex is what matched pending~<uid>:<name>:.
+    const strategy3 = WineDefinition.find.mock.calls
+      .map((c) => c[0])
+      .find((f) => JSON.stringify(f).includes('normalizedKey'));
+
+    expect(strategy3).toBeDefined();
+    // Two $or keys in one object would silently drop the first — the guard is
+    // that the key match and the visibility clause are $and-ed, not merged.
+    expect(strategy3.$and).toBeDefined();
+    expect(strategy3.$and).toHaveLength(2);
+    expect(JSON.stringify(strategy3.$and[0])).toContain('normalizedKey');
+    expect(strategy3.$and[1].$or).toEqual([
+      { pendingIdentity: { $ne: true } },
+      { pendingIdentity: true, createdBy: ME },
+    ]);
+  });
+
+  test('a CURATOR sees everything — the clause collapses to nothing', async () => {
+    // Same account (cellar access is a separate axis), somm role added.
+    await validate(tokenFor(ME, ['somm']), [CT_ROW]);
+
+    const strategy3 = WineDefinition.find.mock.calls
+      .map((c) => c[0])
+      .find((f) => JSON.stringify(f).includes('normalizedKey'));
+
+    // No $and wrapper: with an empty clause the key match is used directly.
+    expect(strategy3.$and).toBeUndefined();
+    expect(strategy3.$or).toBeDefined();
+  });
+
+  test('the exact-key lookup needs no gate — a real producer can never key into pending~', async () => {
+    await validate(tokenFor(ME), [CT_ROW]);
+    // findExactRegistryWine queries a full normalizedKey built from a REAL
+    // producer. normalizeString strips '~', so the pending namespace is
+    // provably unreachable from it (models/WineDefinition pendingIdentity note).
+    for (const call of WineDefinition.findOne.mock.calls) {
+      expect(call[0].normalizedKey).toBeDefined();
+      expect(String(call[0].normalizedKey)).not.toContain('pending~');
+    }
+  });
+});

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -18,6 +18,7 @@ const { identifyWineFromText } = require('../services/labelScan');
 const aiProvider = require('../services/aiProvider');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
 const { scoreWineMatchVariants, stripProducerPrefix } = require('../services/wineMatching');
+const { wineVisibilityFilter } = require('../services/wineVisibility');
 const { tryDebitAi, isRefundableFailure } = require('../services/aiBudget');
 const rateLimitsConfig = require('../config/rateLimits');
 const { generateWineKey } = require('../utils/normalize');
@@ -101,9 +102,21 @@ async function findExactRegistryWine(item) {
  *   1. Try Meilisearch fuzzy search (fast, covers typos)
  *   2. Fallback to MongoDB text search + normalized key lookup
  *   3. Score all candidates with combinedSimilarity
+ *
+ * `viewer` ({ userId, roles }) gates pendingIdentity rows exactly as the
+ * resolver does. It matters here more than anywhere: a CellarTracker row with
+ * no producer scores 1.0 against a PENDING row, whose stored producer is ''
+ * — so without the gate an import would offer, and then attach bottles to,
+ * ANOTHER USER's hidden half-identified wine (security audit). Strategy 3 was
+ * the worst of the three: `normalizedKey: /:<name>:/` is unanchored, and the
+ * pending namespace `pending~<uid>:<name>:` contains that substring by
+ * construction. The creator still matches their OWN pending rows, which is
+ * what keeps /validate's preview honest about what /confirm will do (the
+ * commit path passes allowPending and resolves to the same row).
  */
-async function findWineMatches(item) {
+async function findWineMatches(item, viewer = {}) {
   const candidates = new Map(); // id -> { wine, score }
+  const visible = wineVisibilityFilter(viewer);
 
   // Strategy 1: Meilisearch search (if available)
   if (searchService.getIsAvailable()) {
@@ -121,7 +134,9 @@ async function findWineMatches(item) {
 
       const { ids } = await searchService.search(query, searchOpts);
       if (ids.length > 0) {
-        const wines = await WineDefinition.find({ _id: { $in: ids } })
+        // Pending rows are not in the Meili index at all; the clause is here so
+        // the gate holds if that ever changes (all three strategies, one rule).
+        const wines = await WineDefinition.find({ _id: { $in: ids }, ...visible })
           .populate(['country', 'region', 'grapes'])
           .lean();
 
@@ -143,7 +158,7 @@ async function findWineMatches(item) {
       const searchTerms = `${item.producer || ''} ${item.wineName || ''}`.trim();
       if (searchTerms) {
         const mongoWines = await WineDefinition.find(
-          { $text: { $search: searchTerms } },
+          { $text: { $search: searchTerms }, ...visible },
           { score: { $meta: 'textScore' } }
         )
           .populate(['country', 'region', 'grapes'])
@@ -171,12 +186,17 @@ async function findWineMatches(item) {
     const normalizedProducer = normalizeString(item.producer);
     const normalizedName = normalizeString(item.wineName);
 
-    const directMatches = await WineDefinition.find({
+    const keyMatch = {
       $or: [
         { normalizedKey: { $regex: `^${escapeRegex(normalizedProducer)}:` } },
         { normalizedKey: { $regex: `:${escapeRegex(normalizedName)}:` } }
       ]
-    })
+    };
+    // $and, not a spread: `visible` is itself an $or for non-curators, and two
+    // $or keys in one object would silently drop the first.
+    const directMatches = await WineDefinition.find(
+      visible.$or ? { $and: [keyMatch, visible] } : { ...keyMatch, ...visible }
+    )
       .populate(['country', 'region', 'grapes'])
       .limit(20)
       .lean();
@@ -212,6 +232,8 @@ async function findWineMatches(item) {
 router.post('/validate', aiBurstLimiter, async (req, res) => {
   try {
     const { cellarId, items } = req.body;
+    // Who the candidate pool is being built FOR — see findWineMatches.
+    const viewer = { userId: req.user.id, roles: req.user.roles };
 
     if (!cellarId) {
       return res.status(400).json({ error: 'cellarId is required' });
@@ -303,7 +325,7 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
         pr.registryWine = { wine: exactWine, score: 1 };
         continue;
       }
-      const matches = await findWineMatches(pr.item);
+      const matches = await findWineMatches(pr.item, viewer);
       pr.preMatches = matches; // reused by Pass 3 if this row ends up on the fuzzy path
       if (matches.length > 0 && matches[0].score >= EXACT_THRESHOLD) {
         pr.registryWine = { wine: matches[0].wine, score: matches[0].score };
@@ -446,7 +468,7 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     // instead of re-querying.
     for (const pr of preResults) {
       if (pr.errorMsg || pr.aiWine || pr.registryWine) continue; // skip errors and matched items
-      const matches = pr.preMatches ?? await findWineMatches(pr.item);
+      const matches = pr.preMatches ?? await findWineMatches(pr.item, viewer);
       pr.matches = matches;
     }
 
@@ -865,6 +887,14 @@ router.post('/confirm', async (req, res) => {
               type: str(ai.type),
               grapes: sanitizeGrapeNames(ai.grapes),
             }, req.user.id, { createdVia: 'import', allowPending: true });
+            // findOrCreateWine can return { wine: null, candidates } — the soft
+            // zone. Unguarded, `wine._id` two lines down threw and took the
+            // whole /confirm batch with it (audit L-7). Skip the row and report
+            // it, which is what every other unresolvable row here does.
+            if (!resolved) {
+              errors.push({ index: i, reason: 'Could not resolve this wine in the registry — very similar wines already exist' });
+              continue;
+            }
             wine = resolved;
             aiWineCache.set(aiKey, wine);
             if (created) {
@@ -1415,7 +1445,7 @@ router.get('/sessions/:id', async (req, res) => {
       const result = (session.results || []).find(r => r.index === idx);
       if (!result?.item) continue;
       try {
-        const matches = await findWineMatches(result.item);
+        const matches = await findWineMatches(result.item, { userId: req.user.id, roles: req.user.roles });
         if (matches.length > 0 && matches[0].score >= EXACT_THRESHOLD) {
           const m = matches[0];
           refreshed[idx] = {

--- a/backend/src/routes/journal.js
+++ b/backend/src/routes/journal.js
@@ -51,7 +51,16 @@ router.get('/wine-search', async (req, res) => {
     // bottles for those wines (capped). Avoids the previous pattern of loading
     // the user's ENTIRE active-bottle collection into memory on every keystroke
     // just to filter it down to 10.
-    const matchedWines = await WineDefinition.find({ $or: [{ name: regex }, { producer: regex }] })
+    // Same exclusions the registry search itself carries (routes/wines.js
+    // mongoSearch): a quarantined non-wine row and a pendingIdentity row are
+    // not pickable registry content. Without them this regex-over-the-whole-
+    // registry picker was the one authenticated surface handing out pending
+    // wine IDS — which other tools then accept as a wine_id (security audit).
+    const matchedWines = await WineDefinition.find({
+      $or: [{ name: regex }, { producer: regex }],
+      pendingIdentity: { $ne: true },
+      nonWine: { $ne: true },
+    })
       .select('name producer type')
       .limit(200)
       .lean();

--- a/backend/src/routes/pendingIdentity.publishGates.test.js
+++ b/backend/src/routes/pendingIdentity.publishGates.test.js
@@ -1,0 +1,134 @@
+/**
+ * H-5 — a pendingIdentity wine must never reach an ANONYMOUS reader.
+ *
+ * Two surfaces did, and neither had an auth check to strengthen — the reads are
+ * meant to be public:
+ *
+ *   • discussions — optionalAuth, wine populated into the response, baked into
+ *     the anonymously-searchable discussion Meili index, and rendered for
+ *     CRAWLERS by routes/og.js.
+ *   • wine lists — a published list is served by routes/wineListPublic.js with
+ *     no auth at all.
+ *
+ * So the gate is at WRITE time, and it is ABSOLUTE — unlike the creator-aware
+ * rule in services/wineVisibility. Attaching is the act of publishing, so not
+ * even the pending row's own creator may do it. Fixing it at the write closes
+ * every downstream read in one place.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../models/WineDefinition', () => ({ exists: jest.fn(), findOne: jest.fn(), find: jest.fn() }));
+jest.mock('../models/Discussion', () => {
+  function Discussion(data) {
+    Object.assign(this, data);
+    this._id = 'disc-1';
+    this.save = jest.fn().mockResolvedValue(this);
+    this.populate = jest.fn().mockResolvedValue(this);
+  }
+  Discussion.updateOne = jest.fn();
+  Discussion.findById = jest.fn();
+  Discussion.find = jest.fn();
+  Discussion.CATEGORIES = ['general', 'tasting-notes', 'cellar-management'];
+  return Discussion;
+});
+jest.mock('../models/DiscussionReply', () => {
+  function DiscussionReply(data) { Object.assign(this, data); this.save = jest.fn().mockResolvedValue(this); }
+  return DiscussionReply;
+});
+jest.mock('../models/DiscussionWatch', () => ({ updateOne: jest.fn(() => ({ catch: jest.fn() })), find: jest.fn() }));
+jest.mock('../models/DiscussionReaction', () => {
+  const m = { find: jest.fn() };
+  m.REACTION_KINDS = ['like'];
+  return m;
+});
+jest.mock('../models/DiscussionRead', () => ({ find: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../models/DiscussionReport', () => ({ find: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn(), exists: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/search', () => ({ indexDiscussion: jest.fn(), removeDiscussion: jest.fn() }));
+jest.mock('../utils/cellarCred', () => ({ incrementCred: jest.fn(() => ({ catch: jest.fn() })), decrementCred: jest.fn(() => ({ catch: jest.fn() })) }));
+jest.mock('../services/notifications', () => ({ createNotification: jest.fn(), createNotifications: jest.fn() }));
+jest.mock('../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../services/mailgun', () => ({ sendDiscussionReplyEmail: jest.fn(), EMAIL_VERIFICATION_ENABLED: false }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineDefinition = require('../models/WineDefinition');
+
+const oid = (c) => c.repeat(24);
+const ME = oid('1');
+const PENDING_WINE = oid('a');
+const token = jwt.sign({ id: ME, roles: ['user'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/discussions', require('./discussions'));
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const User = require('../models/User');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // checkDiscussionBan runs first on every write path.
+  User.findById.mockReturnValue({ select: jest.fn().mockResolvedValue(null) });
+});
+
+const createDiscussion = (wineDefinition) => fetch(`${baseUrl}/api/discussions`, {
+  method: 'POST',
+  headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    title: 'What is this bottle?',
+    body: 'I cannot read the label at all, any ideas from the group?',
+    category: 'general',
+    wineDefinition,
+  }),
+});
+
+describe('H-5 — POST /api/discussions refuses to attach a pending wine', () => {
+  test('the existence check itself excludes pending rows', async () => {
+    WineDefinition.exists.mockResolvedValue(null); // no visible wine with that id
+
+    const res = await createDiscussion(PENDING_WINE);
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Wine not found');
+    expect(WineDefinition.exists).toHaveBeenCalledWith(expect.objectContaining({
+      pendingIdentity: { $ne: true },
+    }));
+  });
+
+  test('the gate is ABSOLUTE — the query has no creator escape hatch', async () => {
+    WineDefinition.exists.mockResolvedValue(null);
+
+    await createDiscussion(PENDING_WINE);
+
+    const filter = WineDefinition.exists.mock.calls[0][0];
+    // A creator-aware clause would show up as $or/createdBy. Publishing is
+    // publishing: the creator must not be able to do it either.
+    expect(filter.$or).toBeUndefined();
+    expect(filter.createdBy).toBeUndefined();
+    expect(filter.pendingIdentity).toEqual({ $ne: true });
+  });
+
+  test('an ordinary wine still attaches', async () => {
+    WineDefinition.exists.mockResolvedValue({ _id: oid('b') });
+
+    const res = await createDiscussion(oid('b'));
+
+    expect(res.status).toBe(201);
+  });
+
+  test('a discussion with NO wine never queries the registry', async () => {
+    const res = await createDiscussion(undefined);
+
+    expect(res.status).toBe(201);
+    expect(WineDefinition.exists).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/pendingIdentity.readGates.test.js
+++ b/backend/src/routes/pendingIdentity.readGates.test.js
@@ -1,0 +1,86 @@
+/**
+ * The read/write gates the pending-identity security audit found open, on the
+ * REST side. One file because the finding is one finding: "a pendingIdentity
+ * row must not reach anybody but its creator and curation" was enforced on the
+ * wine routes and forgotten everywhere else.
+ *
+ *   H-2  GET /api/journal/wine-search — a regex over the WHOLE registry,
+ *        .limit(200), returning ids. Authenticated but otherwise ungated: it
+ *        handed out the very pending ids the other holes then accepted.
+ *   H-5  POST /api/discussions — discussions are optionalAuth, their wine is
+ *        populated into the response, indexed into the anonymously-searchable
+ *        discussion index, and rendered for CRAWLERS by routes/og.js. Refused
+ *        at WRITE time, which closes all three reads at once.
+ *   H-5  Wine lists — a published list is served by routes/wineListPublic.js
+ *        with NO auth at all.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findOne: jest.fn(), exists: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ find: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineDefinition = require('../models/WineDefinition');
+const Bottle = require('../models/Bottle');
+
+const oid = (c) => c.repeat(24);
+const ME = oid('1');
+const token = jwt.sign({ id: ME, roles: ['user'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/journal', require('./journal'));
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('H-2 — GET /api/journal/wine-search is no longer a full-registry sieve', () => {
+  test('the query carries BOTH exclusions, matching routes/wines.js mongoSearch', async () => {
+    WineDefinition.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+      }),
+    });
+
+    const res = await fetch(`${baseUrl}/api/journal/wine-search?q=kaefferkopf`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(WineDefinition.find).toHaveBeenCalledWith(expect.objectContaining({
+      pendingIdentity: { $ne: true },
+      nonWine: { $ne: true },
+    }));
+  });
+
+  test('with no registry match the bottle lookup never runs (no id to leak either way)', async () => {
+    WineDefinition.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+      }),
+    });
+
+    const res = await fetch(`${baseUrl}/api/journal/wine-search?q=kaefferkopf`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(await res.json()).toEqual({ bottles: [], wines: [] });
+    expect(Bottle.find).not.toHaveBeenCalled();
+  });
+
+  test('a query shorter than 2 chars short-circuits before any query', async () => {
+    const res = await fetch(`${baseUrl}/api/journal/wine-search?q=k`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(await res.json()).toEqual({ bottles: [], wines: [] });
+    expect(WineDefinition.find).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/recommendations.js
+++ b/backend/src/routes/recommendations.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const Recommendation = require('../models/Recommendation');
 const WineDefinition = require('../models/WineDefinition');
+const { findVisibleWine } = require('../services/wineVisibility');
 const User = require('../models/User');
 const Follow = require('../models/Follow');
 const { logAudit } = require('../services/audit');
@@ -94,10 +95,16 @@ router.post('/', requireNonDemo, async (req, res) => {
     // Validate note length
     const trimmedNote = (note || '').trim().slice(0, 500);
 
-    // Validate wine exists
-    const wine = await WineDefinition.findById(wineId)
-      .select('name producer appellation country region image')
-      .lean();
+    // Validate wine exists AND is visible. This route EMAILS the wine's name to
+    // an arbitrary third-party address, so a pending row reaching it would put
+    // a hidden half-identified wine in a stranger's inbox — outside the app
+    // entirely, where no later gate can take it back (security audit M-4).
+    const wine = await findVisibleWine(wineId, {
+      userId: req.user.id,
+      roles: req.user.roles,
+      select: 'name producer appellation country region image',
+      lean: true,
+    });
     if (!wine) return res.status(404).json({ error: 'Wine not found' });
 
     let recipientUser = null;

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -4,6 +4,7 @@ const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const Review = require('../models/Review');
 const ReviewVote = require('../models/ReviewVote');
 const WineDefinition = require('../models/WineDefinition');
+const { findVisibleWine } = require('../services/wineVisibility');
 const User = require('../models/User');
 const Follow = require('../models/Follow');
 const { resolveRating } = require('../utils/ratingUtils');
@@ -51,8 +52,11 @@ router.post('/', requireNonDemo, async (req, res) => {
       return res.status(400).json({ error: 'Invalid bottle ID' });
     }
 
-    // Validate wine exists
-    const wine = await WineDefinition.findById(wineDefinition);
+    // Validate wine exists AND is visible to this user — a pendingIdentity row
+    // is a wine nobody but its creator and curation may see, so for everyone
+    // else "exists" must answer the same 404 a missing id does
+    // (services/wineVisibility, security audit M-4).
+    const wine = await findVisibleWine(wineDefinition, { userId: req.user.id, roles: req.user.roles });
     if (!wine) {
       return res.status(404).json({ error: 'Wine not found' });
     }

--- a/backend/src/routes/wineLists.js
+++ b/backend/src/routes/wineLists.js
@@ -12,8 +12,40 @@ const { generateWineListPdf } = require('../services/wineListPdf');
 const { stripImageMetadata } = require('../services/imageSanitizer');
 const { loadWineMap, loadCellarWines, entryKey, allEntries } = require('../services/wineListData');
 const { LOGO_DIR, ensureLogoDir, deleteLogoFile, copyLogoFile } = require('../services/wineListLogos');
+const WineDefinition = require('../models/WineDefinition');
 
 const router = express.Router();
+
+/** Every distinct wine id referenced by a list, in any structure mode. */
+const entryWineIds = (wineList) =>
+  new Set(allEntries(wineList).filter(e => e.wine).map(e => String(e.wine)));
+
+/**
+ * Refuse to ADD a pendingIdentity wine to a wine list.
+ *
+ * ABSOLUTE, like the discussion gate and for the same reason: a list can be
+ * PUBLISHED, and routes/wineListPublic.js serves it with no auth — so attaching
+ * is the act that would make a hidden half-identified wine public. Enforced at
+ * WRITE time, which closes the public render, the PDF and the stats endpoint in
+ * one place.
+ *
+ * Only NEWLY referenced wines are checked. The PUT replaces sections wholesale,
+ * so judging the whole payload would soft-lock any list that already carried a
+ * pending row from before this gate existed — the owner could not even edit it
+ * to remove the entry. Rows already on the list are handled by the read-side
+ * exclusion in services/wineListData.loadWineMap, which drops them from every
+ * render; this gate stops the set from growing.
+ *
+ * @returns {Promise<string|null>} an error message, or null when the write is clean
+ */
+async function pendingWineAdded(wineList, previousIds) {
+  const added = [...entryWineIds(wineList)].filter(id => !previousIds.has(id));
+  if (!added.length) return null;
+  const pending = await WineDefinition.find({ _id: { $in: added }, pendingIdentity: true })
+    .select('name').limit(3).lean();
+  if (!pending.length) return null;
+  return `This wine is still waiting for its producer to be identified and can't go on a list that may be published: ${pending.map(w => w.name).join(', ')}`;
+}
 
 // --- Logo upload setup ---
 ensureLogoDir();
@@ -161,6 +193,10 @@ router.put('/:id', requireAuth, async (req, res) => {
     const wineList = await WineList.findOne({ _id: req.params.id, user: req.user.id });
     if (!wineList) return res.status(404).json({ error: 'Wine list not found' });
 
+    // Snapshot the wines already on the list BEFORE the payload overwrites
+    // sections — pendingWineAdded only judges what this write introduces.
+    const previousWineIds = entryWineIds(wineList);
+
     // Allowed update fields
     const fields = [
       'name', 'structureMode', 'language',
@@ -181,6 +217,9 @@ router.put('/:id', requireAuth, async (req, res) => {
       if (!wineList.branding) wineList.branding = {};
       wineList.branding.logoUrl = storedLogoUrl;
     }
+
+    const pendingMsg = await pendingWineAdded(wineList, previousWineIds);
+    if (pendingMsg) return res.status(400).json({ error: pendingMsg });
 
     await wineList.save();
     logAudit(req, 'winelist.update', { type: 'winelist', id: wineList._id, cellarId: wineList.cellar });

--- a/backend/src/routes/wineReports.js
+++ b/backend/src/routes/wineReports.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const mongoose = require('mongoose');
 const WineReport = require('../models/WineReport');
 const WineDefinition = require('../models/WineDefinition');
+const { findVisibleWine } = require('../services/wineVisibility');
 const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const { stripHtml } = require('../utils/sanitize');
@@ -56,7 +57,13 @@ router.post('/', requireAuth, requireNonDemo, async (req, res) => {
       }
     }
 
-    const wine = await WineDefinition.findById(wineDefinitionId).lean();
+    // Visible-to-this-user, not merely existing (services/wineVisibility) —
+    // a stranger must not be able to confirm a pending row exists by reporting
+    // a correction to it. Its creator still can: their row is the one most
+    // likely to need one.
+    const wine = await findVisibleWine(wineDefinitionId, {
+      userId: req.user.id, roles: req.user.roles, lean: true,
+    });
     if (!wine) {
       return res.status(404).json({ error: 'Wine not found' });
     }

--- a/backend/src/routes/wineRequests.js
+++ b/backend/src/routes/wineRequests.js
@@ -3,6 +3,7 @@ const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { logAudit } = require('../services/audit');
 const WineRequest = require('../models/WineRequest');
 const WineDefinition = require('../models/WineDefinition');
+const { findVisibleWine } = require('../services/wineVisibility');
 const { createWineRequest } = require('../services/accountOps');
 
 const router = express.Router();
@@ -29,7 +30,12 @@ router.post('/', requireNonDemo, async (req, res) => {
       if (typeof linkedWineDefinition !== 'string' || !/^[0-9a-fA-F]{24}$/.test(linkedWineDefinition)) {
         return res.status(400).json({ error: 'Invalid linkedWineDefinition id' });
       }
-      const wine = await WineDefinition.findById(linkedWineDefinition);
+      // Visible-to-this-user, not merely existing (services/wineVisibility) —
+      // otherwise a grape suggestion is a probe that confirms a stranger's
+      // pending row exists, and copies its name into the admin queue.
+      const wine = await findVisibleWine(linkedWineDefinition, {
+        userId: req.user.id, roles: req.user.roles,
+      });
       if (!wine) return res.status(404).json({ error: 'Wine not found' });
 
       const wineRequest = new WineRequest({

--- a/backend/src/routes/wishlist.js
+++ b/backend/src/routes/wishlist.js
@@ -7,8 +7,14 @@ const { escapeRegex } = require('../utils/sanitize');
 // Mint-at-commit for the POST route's `newWine` branch (shared with POST
 // /api/bottles) — findOrCreateWine itself is lazy-required inside the service.
 const { resolveOrMintWine } = require('../services/wineCommit');
+const { findVisibleWine } = require('../services/wineVisibility');
 
 const router = express.Router();
+
+// What a wishlist response may say about a registry wine. Never createdBy,
+// scanImage, normalizedKey or canonicalKey — see the populate comments below.
+const WINE_RESPONSE_SELECT =
+  'name producer slug type appellation classification country region grapes image communityRating aiProfile lwin pendingIdentity';
 
 // All wishlist routes require authentication
 router.use(requireAuth);
@@ -89,7 +95,11 @@ router.get('/', async (req, res) => {
           foreignField: '_id',
           as: 'wineDefinition.grapes'
         }
-      }
+      },
+      // Same rule as the populates below: the list endpoint returned the whole
+      // registry document too. These four are never part of a wishlist answer,
+      // and normalizedKey carries a pending row's creator id verbatim.
+      { $unset: ['wineDefinition.createdBy', 'wineDefinition.scanImage', 'wineDefinition.normalizedKey', 'wineDefinition.canonicalKey'] }
     ];
 
     // Free-text search on wine name or producer. Guard the type: an object/array
@@ -223,6 +233,13 @@ router.post('/', async (req, res) => {
       if (!mongoose.Types.ObjectId.isValid(wineDefinitionId)) {
         return res.status(400).json({ error: 'Valid wineDefinitionId is required' });
       }
+      // The id was taken on trust — no existence check at all, so a wish could
+      // be filed against any id, including a stranger's pending row, whose
+      // name then came back through the populate above (security audit M-4).
+      const wine = await findVisibleWine(wineDefinitionId, {
+        userId: req.user.id, roles: req.user.roles, select: '_id', lean: true,
+      });
+      if (!wine) return res.status(404).json({ error: 'Wine not found' });
       resolvedWineId = wineDefinitionId;
     }
 
@@ -257,6 +274,12 @@ router.post('/', async (req, res) => {
     const populated = await WishlistItem.findById(item._id)
       .populate({
         path: 'wineDefinition',
+        // EXPLICIT select (security audit M-4). Without it the whole registry
+        // document came back — including createdBy, scanImage and
+        // normalizedKey, and a pending row's normalizedKey IS
+        // `pending~<creator-id>:…`, so the projection itself handed out
+        // another user's id.
+        select: WINE_RESPONSE_SELECT,
         populate: [
           { path: 'country' },
           { path: 'region' },
@@ -325,6 +348,12 @@ router.put('/:id', async (req, res) => {
     const populated = await WishlistItem.findById(item._id)
       .populate({
         path: 'wineDefinition',
+        // EXPLICIT select (security audit M-4). Without it the whole registry
+        // document came back — including createdBy, scanImage and
+        // normalizedKey, and a pending row's normalizedKey IS
+        // `pending~<creator-id>:…`, so the projection itself handed out
+        // another user's id.
+        select: WINE_RESPONSE_SELECT,
         populate: [
           { path: 'country' },
           { path: 'region' },

--- a/backend/src/routes/wishlist.newWine.test.js
+++ b/backend/src/routes/wishlist.newWine.test.js
@@ -33,6 +33,9 @@ jest.mock('../models/WishlistItem', () => ({
 }));
 // Demo tokens make requireAuth confirm the account still exists.
 jest.mock('../models/User', () => ({ exists: jest.fn(async () => ({ _id: 'demo1' })) }));
+// The by-id path now checks the wine is visible to the caller before filing a
+// wish — it used to take the id on trust (security audit M-4).
+jest.mock('../models/WineDefinition', () => ({ findOne: jest.fn() }));
 
 const express = require('express');
 const http = require('http');
@@ -92,6 +95,9 @@ const WINE_DOC = { _id: WINE_ID, name: 'Kaefferkopf', producer: 'Cave de Kaysers
 beforeEach(() => {
   jest.clearAllMocks();
   findOrCreateWine.mockResolvedValue({ wine: WINE_DOC, created: true });
+  require('../models/WineDefinition').findOne.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: WINE_ID }) }),
+  });
   WishlistItem.findOne.mockResolvedValue(null);
   WishlistItem.create.mockResolvedValue({ _id: ITEM_ID });
   WishlistItem.findById.mockReturnValue({

--- a/backend/src/services/cellarExport.js
+++ b/backend/src/services/cellarExport.js
@@ -307,10 +307,19 @@ async function buildCellarDataExport(userId, scope) {
 
   // Only the user's OWN uploaded images + reviews, for the bottles in scope.
   const bottleIds = bottles.map((b) => b._id);
-  const [images, reviews, layouts] = await Promise.all([
+  const [images, labelScans, reviews, layouts] = await Promise.all([
     bottleIds.length
       ? BottleImage.find({ uploadedBy: userId, bottle: { $in: bottleIds } })
           .select('bottle originalUrl processedUrl credit createdAt').limit(EXPORT_MAX).lean()
+      : [],
+    // Label scans (audit L-2). They hang off a WINE, never a bottle, so the
+    // bottle-scoped query above could never reach them — yet
+    // services/userDataRegistry states the bytes ship in this ZIP, and they
+    // are unambiguously the user's own photos. Only the user's own, and only
+    // on a full export: a per-cellar scope has no cellar to file them under.
+    scope === 'all'
+      ? BottleImage.find({ uploadedBy: userId, kind: 'label-scan' })
+          .select('originalUrl processedUrl wineDefinition createdAt').limit(EXPORT_MAX).lean()
       : [],
     bottleIds.length
       ? Review.find({ author: userId, bottle: { $in: bottleIds } })
@@ -418,17 +427,29 @@ async function buildCellarDataExport(userId, scope) {
     scope: scope === 'all' ? 'all' : String(scope),
     cellarCount: cellarPayloads.length,
     bottleCount: bottles.length,
-    imageCount: images.length,
+    imageCount: images.length + labelScans.length,
     reviewCount: reviews.length,
     maturityCount: profilesByWineVintage.size,
     cellars: cellarPayloads,
+    // Additive top-level key (importers ignore what they don't know): a label
+    // scan belongs to no cellar, so it cannot ride inside `cellars`.
+    ...(labelScans.length ? {
+      labelScans: labelScans.map((s) => ({
+        file: `images/${(s.originalUrl || s.processedUrl || '').replace('/api/uploads/', '')}`,
+        scannedAt: s.createdAt,
+      })),
+    } : {}),
   };
   if (bottles.length >= EXPORT_MAX) {
     payload._truncated = EXPORT_MAX;
     console.warn(`[cellarExport] truncation hit for user ${userId} scope ${scope} (${EXPORT_MAX})`);
   }
 
-  return { payload, imageFiles: collectImageFiles(images), imageCount: images.length };
+  // Label scans bundle their ORIGINAL frame — that IS the artefact (there is no
+  // background-removed render of a label scan), and collectImageFiles already
+  // prefers processed-then-original per row.
+  const imageFiles = collectImageFiles([...images, ...labelScans]);
+  return { payload, imageFiles, imageCount: images.length + labelScans.length };
 }
 
 /** README bundled into the ZIP so the archive is self-explanatory. */
@@ -449,6 +470,11 @@ reads JSON — Cellarion never locks your data in.
   Images other people contributed (for example a shared wine's label) are not
   included either. Each bottle in \`data.json\` lists its images by their path
   inside this folder, e.g. \`images/processed/<id>.png\`.
+- Label frames you scanned that Cellarion kept so a sommelier could finish
+  identifying the wine are listed under \`labelScans\` in \`data.json\`, with
+  their file in the same \`images/\` folder. They are private — only you and
+  Cellarion's curators ever see them — and unattached ones are deleted
+  automatically after 30 days.
 
 ## data.json shape
 

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -184,7 +184,15 @@ async function runJob(cfg) {
     // already safe (a corrected row has a description), so this only bites in
     // full mode — which is exactly the mode that would have destroyed the
     // most work. See WineDefinition.aiProfile.source.
-    const keepCurated = { 'aiProfile.source': { $ne: 'curator' } };
+    // A pendingIdentity row is never enriched — the SAME rule embeddingJob
+    // carries, and it was missed here (security audit M-3). Its producer is ''
+    // and its region is often the misplaced string that made it pending, so
+    // the model would be asked to describe a wine nobody has identified yet:
+    // an AI spend on a row strangers cannot see, whose output would then be
+    // presented as the registry's tasting note the moment it is promoted.
+    // The promoting write re-enriches (runPromotionFollowThrough), which is
+    // when the wine genuinely enters.
+    const keepCurated = { 'aiProfile.source': { $ne: 'curator' }, pendingIdentity: { $ne: true } };
     const filter = job.mode === 'full'
       ? keepCurated
       : {
@@ -357,6 +365,11 @@ async function enrichWineById(wineDefId, { budgetUserId } = {}) {
       .populate('grapes', 'name')
       .lean();
     if (!wine) return;
+    // Same rule as the batch filter above, and it matters MORE here: this is
+    // the fire-and-forget call services/bottleOps.js makes on every bottle add,
+    // so without it the very add that mints a pending row would immediately
+    // spend the adding user's daily AI budget describing a producerless wine.
+    if (wine.pendingIdentity === true) return;
     if (wine.aiProfile && wine.aiProfile.description) return; // already enriched
     if (wine.aiProfile && wine.aiProfile.source === 'curator') return; // hand-corrected — never regenerate
 

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -244,3 +244,41 @@ describe('bounds on model output', () => {
     expect(persisted().description).toHaveLength(1000);
   });
 });
+
+/**
+ * M-3 (pending-identity security audit) — a pendingIdentity row is never
+ * enriched. embeddingJob was gated for exactly this in the same PR and
+ * enrichmentJob was not, so the AI was asked to describe a wine whose producer
+ * is '' and whose region is often the misplaced string that made it pending.
+ * Worse, services/bottleOps fires enrichWineById on EVERY bottle add with the
+ * adder as budgetUserId — so the very add that MINTED the pending row spent
+ * that user's daily AI budget on it, and the output would have surfaced as the
+ * registry's tasting note the moment a curator promoted the wine.
+ */
+describe('pendingIdentity rows are never enriched', () => {
+  const { tryDebitAi } = require('./aiBudget');
+
+  test('enrichWineById returns before calling the model or debiting the budget', async () => {
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: WINE_ID, name: 'Kaefferkopf', producer: '', pendingIdentity: true,
+      country: { name: 'France' }, region: null, grapes: [],
+    }));
+    tryDebitAi.mockResolvedValue({ ok: true, refund: jest.fn() });
+
+    await enrichWineById(WINE_ID, { budgetUserId: 'b'.repeat(24) });
+
+    expect(suggestProfile).not.toHaveBeenCalled();
+    expect(tryDebitAi).not.toHaveBeenCalled();
+    expect(WineDefinition.updateOne).not.toHaveBeenCalled();
+  });
+
+  test('the gate is narrow: an ordinary unenriched wine is still processed', async () => {
+    tryDebitAi.mockResolvedValue({ ok: true, refund: jest.fn() });
+    suggestProfile.mockResolvedValue(profile('Bright and fresh.'));
+
+    await enrichWineById(WINE_ID, { budgetUserId: 'b'.repeat(24) });
+
+    expect(suggestProfile).toHaveBeenCalled();
+    expect(WineDefinition.updateOne).toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -19,7 +19,7 @@ const Region = require('../models/Region');
 const Grape = require('../models/Grape');
 const Appellation = require('../models/Appellation');
 const searchService = require('./search');
-const { generateWineKey, normalizeString, normalizeAppellation, normalizeAppellationKey, stripTrailingVintage, resolveGrapeName, resolveCountryName, isRecognizedCountry, isUnknownName, isIdentitySentinel, isJunkGrapeName, sanitizeTaxonomyName } = require('../utils/normalize');
+const { generateWineKey, pendingProducerKey, pendingWineKey, normalizeString, normalizeAppellation, normalizeAppellationKey, stripTrailingVintage, resolveGrapeName, resolveCountryName, isRecognizedCountry, isUnknownName, isIdentitySentinel, isJunkGrapeName, sanitizeTaxonomyName } = require('../utils/normalize');
 const { scoreAllMatches } = require('./wineMatching');
 const { canonicalizeWineName } = require('../utils/producerPrefix');
 const { computeCanonicalKey, canonicalSiblingPrefix } = require('../utils/wineIdentity');
@@ -42,20 +42,11 @@ const POPULATE = ['country', 'region', 'grapes'];
 
 // ── Pending identity ─────────────────────────────────────────────────────────
 //
-// The producer segment a pending (producerless) row keys under. Built by
-// STRING CONCATENATION, deliberately NOT through generateWineKey: normalizeString
-// emits [a-z0-9 ] only — it strips '~' — so a segment containing '~' is one no
-// real producer can ever produce, which is what makes the pending key namespace
-// provably disjoint from the ordinary one under the UNIQUE normalizedKey index.
-// The creator id in the segment is what stops two users' identical producerless
-// adds from colliding (one would otherwise inherit the other's row via the
-// E11000 recovery), while making the SAME user's retry key identically and
-// resolve to their own row instead of minting again.
-// See the pendingIdentity field note on models/WineDefinition.js.
-const PENDING_KEY_PREFIX = 'pending~';
-const pendingProducerKey = (userId) => `${PENDING_KEY_PREFIX}${String(userId)}`;
-const pendingWineKey = (name, userId, appellation = '') =>
-  `${pendingProducerKey(userId)}:${normalizeString(name)}:${normalizeString(appellation)}`;
+// The pending key namespace (PENDING_KEY_PREFIX / pendingProducerKey /
+// pendingWineKey) now lives in utils/normalize.js, beside generateWineKey — the
+// curation queue (services/pendingWineOps) has to build the same key and must
+// not drag this module's dependency tree along to do it. Re-exported below, so
+// existing importers are unchanged.
 
 // ── Taxonomy helpers ─────────────────────────────────────────────────────────
 
@@ -447,6 +438,18 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // always have, byte-identical messages included — the deliberate
   // shared-registry curation surfaces must keep being told.
   let producerNorm = normalizeString(trimmedProducer);
+  // KNOWN LIMIT — a NON-LATIN producer ("Мукузани", "獺祭", "ქართული ღვინო")
+  // reaches this gate with producerNorm === '' and is therefore filed pending,
+  // even though isIdentitySentinel now correctly says it is real information
+  // (security audit H-4). That is deliberate for now, not an oversight: the
+  // registry's normalizedKey is `normalizeString(producer):…`, so STORING such
+  // a producer would key it as `:<name>:<appellation>` — indistinguishable from
+  // every other non-Latin producer of a same-named wine, and the E11000
+  // recovery below would then silently attach one user's wine to another's.
+  // The pending namespace is per-creator and has no such collision. Promotion
+  // works correctly (the model hook consults isIdentitySentinel alone), so a
+  // curator CAN complete these rows; storing the original at mint needs a
+  // script-aware key namespace, which is a registry-wide change.
   if (!producerMissing && producerNorm.length < 2) {
     if (!allowPending) {
       const err = new Error(`"${trimmedProducer}" is not a usable producer name`);

--- a/backend/src/services/pendingIdentity.auditFixes.test.js
+++ b/backend/src/services/pendingIdentity.auditFixes.test.js
@@ -1,0 +1,144 @@
+/**
+ * M-2 and M-5 from the pending-identity security audit. (M-3 needs the AI
+ * provider mocked at module scope and lives in enrichmentJob.pendingIdentity.)
+ *
+ *   M-2  services/pendingWineOps regenerated normalizedKey with generateWineKey
+ *        on ANY name/appellation edit — including while the row was STILL
+ *        pending. That drops the creator id out of the key, breaking the
+ *        documented namespace invariant, so two curator-renamed pending rows by
+ *        different users could collide into a false "merge them instead" 409.
+ *   M-5  models/WineDefinition assigned a slug to pending rows, permanently
+ *        squatting the real wine's URL (which 404s for everyone), and never
+ *        regenerated on promotion.
+ */
+
+const mongoose = require('mongoose');
+const { pendingWineKey, generateWineKey } = require('../utils/normalize');
+
+const oid = () => new mongoose.Types.ObjectId();
+
+describe('M-2 — the pending key namespace survives a curator rename', () => {
+  const CREATOR_A = oid();
+  const CREATOR_B = oid();
+
+  test('two different creators with the same renamed identity get DIFFERENT keys', () => {
+    const a = pendingWineKey('Kaefferkopf Grand Cru', CREATOR_A, 'Alsace');
+    const b = pendingWineKey('Kaefferkopf Grand Cru', CREATOR_B, 'Alsace');
+    expect(a).not.toBe(b);
+  });
+
+  test('the pending namespace is provably disjoint from every real producer key', () => {
+    const pending = pendingWineKey('Kaefferkopf', CREATOR_A, '');
+    expect(pending).toContain('pending~');
+    // normalizeString emits [a-z0-9 ] only, so '~' cannot appear in a real key.
+    expect(generateWineKey('Kaefferkopf', 'Cave de Kaysersberg', '')).not.toContain('~');
+  });
+
+  test('the SAME creator renaming twice keys deterministically (a retry resolves, not mints)', () => {
+    expect(pendingWineKey('Kaefferkopf', CREATOR_A, 'Alsace'))
+      .toBe(pendingWineKey('Kaefferkopf', CREATOR_A, 'Alsace'));
+  });
+
+  test('THE BUG: generateWineKey on a still-pending row collapses both creators onto one key', () => {
+    // producer is '' while pending, so the ordinary key builder produces
+    // ':<name>:<appellation>' — identical for every creator. This is what the
+    // fix stops pendingWineOps from doing before the row actually promotes.
+    const asOrdinary = generateWineKey('Kaefferkopf Grand Cru', '', 'Alsace');
+    expect(asOrdinary).toBe(generateWineKey('Kaefferkopf Grand Cru', '', 'Alsace'));
+    expect(asOrdinary).not.toContain('pending~');
+  });
+});
+
+describe('M-5 — a pending row gets no slug, and gets one when it promotes', () => {
+  const WineDefinition = require('../models/WineDefinition');
+
+  const newPending = () => new WineDefinition({
+    name: 'Cloudy Bay Sauvignon Blanc',
+    producer: '',
+    country: oid(),
+    createdBy: oid(),
+    normalizedKey: 'pending~aaa:cloudy bay sauvignon blanc:',
+    pendingIdentity: true,
+  });
+
+  test('a NEW pending row is refused a slug — the real wine keeps its URL', () => {
+    expect(WineDefinition.shouldAssignSlug(newPending())).toBe(false);
+  });
+
+  test('an ordinary new wine still gets one', () => {
+    const doc = new WineDefinition({
+      name: 'Sauvignon Blanc', producer: 'Cloudy Bay', country: oid(), createdBy: oid(),
+      normalizedKey: 'cloudy bay:sauvignon blanc:',
+    });
+    expect(WineDefinition.shouldAssignSlug(doc)).toBe(true);
+  });
+
+  test('PROMOTION assigns the slug the pending row never took', async () => {
+    const doc = newPending();
+    doc.producer = 'Cloudy Bay';
+    await doc.validate();            // pre-validate promotes
+    expect(doc.pendingIdentity).toBe(false);
+    expect(WineDefinition.shouldAssignSlug(doc)).toBe(true);
+  });
+
+  test('a pending row edited but still pending stays slugless', async () => {
+    const doc = newPending();
+    doc.name = 'Cloudy Bay Sauvignon Blanc Reserve';
+    await doc.validate();
+    expect(doc.pendingIdentity).toBe(true);
+    expect(WineDefinition.shouldAssignSlug(doc)).toBe(false);
+  });
+
+  test('an existing slug is never overwritten — URL stability', async () => {
+    const doc = newPending();
+    doc.slug = 'already-has-one';
+    doc.producer = 'Cloudy Bay';
+    await doc.validate();
+    expect(WineDefinition.shouldAssignSlug(doc)).toBe(false);
+  });
+
+  test('a slugless LEGACY row is left to the migration script, not to a passing write', () => {
+    const doc = new WineDefinition({
+      name: 'Barolo', producer: 'Rinaldi', country: oid(), createdBy: oid(),
+      normalizedKey: 'rinaldi:barolo:',
+    });
+    doc.isNew = false;               // loaded from the DB, no pendingIdentity change
+    expect(WineDefinition.shouldAssignSlug(doc)).toBe(false);
+  });
+});
+
+describe('M-5 — the disambiguation loop no longer falls through silently', () => {
+  const WineDefinition = require('../models/WineDefinition');
+
+  const withSlugLookup = (isTaken) => {
+    const spy = jest.spyOn(WineDefinition, 'findOne').mockImplementation(({ slug }) => ({
+      select: () => ({ lean: async () => (isTaken(slug) ? { _id: 'x' } : null) }),
+    }));
+    return spy;
+  };
+
+  afterEach(() => jest.restoreAllMocks());
+
+  test('a free base slug is used as-is', async () => {
+    withSlugLookup(() => false);
+    await expect(WineDefinition.findFreeSlug('cloudy-bay')).resolves.toBe('cloudy-bay');
+  });
+
+  test('a taken base steps to -2', async () => {
+    withSlugLookup((s) => s === 'cloudy-bay');
+    await expect(WineDefinition.findFreeSlug('cloudy-bay')).resolves.toBe('cloudy-bay-2');
+  });
+
+  test('THE BUG: with every suffix taken it returns a CHECKED slug, not a colliding one', async () => {
+    // Everything the loop can produce is taken — the old code assigned
+    // `${base}-99` unchecked, straight into a unique-index write failure.
+    const exhausted = (s) => /^cloudy-bay(-\d{1,2})?$/.test(s);
+    withSlugLookup(exhausted);
+
+    const slug = await WineDefinition.findFreeSlug('cloudy-bay');
+
+    expect(slug).not.toBe('cloudy-bay-99');
+    expect(exhausted(slug)).toBe(false);
+    expect(slug).toMatch(/^cloudy-bay-[0-9a-f]{8}$/);
+  });
+});

--- a/backend/src/services/pendingWineOps.js
+++ b/backend/src/services/pendingWineOps.js
@@ -27,7 +27,10 @@ const WineDefinition = require('../models/WineDefinition');
 const BottleImage = require('../models/BottleImage');
 const Bottle = require('../models/Bottle');
 const Country = require('../models/Country');
-const { generateWineKey, normalizeAppellation, normalizeString, resolveCountryName } = require('../utils/normalize');
+// pendingWineKey comes from utils/normalize (beside generateWineKey), NOT from
+// services/findOrCreateWine: one definition of the key shape, and no dependency
+// from the curation queue onto the resolver's module tree to build a string.
+const { generateWineKey, pendingWineKey, normalizeAppellation, normalizeString, resolveCountryName, isIdentitySentinel } = require('../utils/normalize');
 const { resolveGrapeIdsStrict, GRAPES_MAX, GRAPE_NAME_MAX, WINE_TYPES } = require('./wineProfileOps');
 
 // Fields a curator may set. `producer` and `name` are the two that promote the
@@ -294,8 +297,20 @@ async function applyPendingFix(wine, clean, userId) {
   // name/producer/appellation. Regenerating it here is also what moves a
   // promoted row OUT of the pending key namespace (pending~<creator>:…) and
   // into the ordinary one, where the unique index re-checks it.
+  //
+  // …but ONLY when the row is actually leaving. `wine.pendingIdentity` is still
+  // true at this point (the pre-validate hook flips it during save below), so
+  // this must PREDICT the hook with the hook's own predicate rather than read
+  // the flag. Using generateWineKey unconditionally dropped the creator id out
+  // of a STILL-PENDING row's key (security audit M-2), breaking the documented
+  // namespace invariant: two curator-renamed pending rows by different users
+  // could then land on the same ordinary key and E11000 into a "merge them
+  // instead" 409 that is simply false.
   if (clean.name || clean.producer || clean.appellation !== undefined) {
-    wine.normalizedKey = generateWineKey(wine.name, wine.producer, wine.appellation);
+    const willPromote = !isIdentitySentinel(wine.producer) && !isIdentitySentinel(wine.name);
+    wine.normalizedKey = willPromote
+      ? generateWineKey(wine.name, wine.producer, wine.appellation)
+      : pendingWineKey(wine.name, wine.createdBy, wine.appellation);
   }
 
   // The pre-validate hook promotes; read the outcome rather than deciding it.
@@ -356,6 +371,11 @@ async function runPromotionFollowThrough(wine) {
     .catch((err) => console.error('Bottle re-index after pending promotion failed:', err.message));
   // Never embedded while pending — embed now, for the vintages that exist.
   require('./embeddingJob').reembedActiveVintages(wine._id).catch(() => {});
+  // Never enriched while pending either (services/enrichmentJob) — the wine now
+  // HAS a producer, so a tasting profile can finally be about something. No
+  // budgetUserId: this is curation work, not a user action, so it is not
+  // debited to whoever happened to add the bottle.
+  require('./enrichmentJob').enrichWineById(wine._id).catch?.(() => {});
   // The maturity queue refused to seed this wine while pending; seed it from
   // the bottles that are already in cellars, so the drink windows the owners
   // are waiting for finally get curated.

--- a/backend/src/services/scanImage.lifecycle.test.js
+++ b/backend/src/services/scanImage.lifecycle.test.js
@@ -148,7 +148,16 @@ describe('runScanImageRetentionSweep', () => {
 
     // Files first: the doc is the only reference to the file on disk.
     expect(unlinkImageFiles).toHaveBeenCalledWith(stale[0]);
-    expect(BottleImage.deleteMany).toHaveBeenCalledWith({ _id: { $in: ['i1'] } });
+    // The delete REPEATS the selection predicate (audit L-1): between the find
+    // and the delete a second bottle of the same unidentified wine can attach
+    // one of these scans, and deleting by id alone would drop a row a live
+    // WineDefinition.scanImage points at.
+    const del = BottleImage.deleteMany.mock.calls[0][0];
+    expect(del._id).toEqual({ $in: ['i1'] });
+    expect(del.kind).toBe('label-scan');
+    expect(del.wineDefinition).toBeNull();
+    expect(del.bottle).toBeNull();
+    expect(del.createdAt.$lt).toBeInstanceOf(Date);
     expect(res.deleted).toBe(1);
   });
 

--- a/backend/src/services/scanImageRetentionJob.js
+++ b/backend/src/services/scanImageRetentionJob.js
@@ -51,7 +51,19 @@ async function runScanImageRetentionSweep() {
       console.warn('[scanImageRetention] unlink failed (continuing):', err.message);
     }
   }
-  const res = await BottleImage.deleteMany({ _id: { $in: stale.map((i) => i._id) } });
+  // The selection predicate is REPEATED in the delete (audit L-1). Between the
+  // find above and this delete, a second bottle of the same unidentified wine
+  // can attach one of these scans (services/wineCommit.attachScanImage stamps
+  // it on the wine) — deleting by id alone would then drop the row a live
+  // WineDefinition.scanImage points at. Re-asserting the filter makes the
+  // delete a no-op for any row that stopped being unattached.
+  const res = await BottleImage.deleteMany({
+    _id: { $in: stale.map((i) => i._id) },
+    kind: 'label-scan',
+    wineDefinition: null,
+    bottle: null,
+    createdAt: { $lt: cutoff },
+  });
   const deleted = res.deletedCount || 0;
   if (deleted > 0) {
     console.log(

--- a/backend/src/services/wineCommit.js
+++ b/backend/src/services/wineCommit.js
@@ -213,10 +213,18 @@ async function resolveOrMintWine(newWine, req, { allowPending = true } = {}) {
     // promotion path submits it instead.
     if (!pendingIdentity) submitUrls(`/wines/${wine.slug || wine._id}`);
   }
-  // Stamp the label scan on a NEW mint — and on the creator's OWN pending row
-  // that has none yet, which is how a second bottle of the same unidentified
-  // wine can still supply the photo the first add didn't have.
-  if (newWine.scanImageId && (created || (pendingIdentity && String(wine.createdBy) === String(req.user.id) && !wine.scanImage))) {
+  // Stamp the label scan on a new PENDING mint — and on the creator's OWN
+  // pending row that has none yet, which is how a second bottle of the same
+  // unidentified wine can still supply the photo the first add didn't have.
+  //
+  // PENDING ONLY (audit L-5, data minimisation): the scan exists for exactly
+  // one purpose — letting a curator read a label the software could not. A
+  // fully-identified wine needs no such evidence, so retaining the user's
+  // original frame against it stores a personal photo with no purpose to
+  // justify it. Unattached scans are swept after 30 days by
+  // services/scanImageRetentionJob.
+  if (newWine.scanImageId && pendingIdentity
+      && (created || (String(wine.createdBy) === String(req.user.id) && !wine.scanImage))) {
     await attachScanImage(wine, newWine.scanImageId, req);
   }
   return { wine, created: !!created, pendingIdentity };

--- a/backend/src/services/wineListData.js
+++ b/backend/src/services/wineListData.js
@@ -72,7 +72,14 @@ async function loadWineMap(wineList) {
   }
 
   const [wines, stockMap] = await Promise.all([
-    WineDefinition.find({ _id: { $in: [...wineIds] } })
+    // pendingIdentity rows are excluded here as well as refused at write time
+    // (routes/wineLists.js, mcp/tools/wineLists.js). Defence in depth with a
+    // reason: a published wine list is served by routes/wineListPublic.js,
+    // which has NO auth at all, and rows attached before the write gate existed
+    // would otherwise still render a stranger's hidden wine to the internet.
+    // An excluded entry simply drops out of the map — the exact same handling
+    // an entry whose wine was deleted already gets.
+    WineDefinition.find({ _id: { $in: [...wineIds] }, pendingIdentity: { $ne: true } })
       .select(WINE_SELECT)
       .populate(WINE_POPULATE)
       .lean(),

--- a/backend/src/services/wineListData.pendingIdentity.test.js
+++ b/backend/src/services/wineListData.pendingIdentity.test.js
@@ -1,0 +1,79 @@
+/**
+ * H-5, wine-list half — loadWineMap feeds routes/wineListPublic.js, which has
+ * NO auth at all. The write gate (routes/wineLists.js PUT, mcp add_to_list)
+ * stops new pending attachments; this is the defence in depth for rows attached
+ * BEFORE that gate existed, which would otherwise still render a stranger's
+ * hidden wine to the open internet (and into the PDF, and the stats endpoint).
+ */
+
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ aggregate: jest.fn().mockResolvedValue([]) }));
+
+const WineDefinition = require('../models/WineDefinition');
+const { loadWineMap } = require('./wineListData');
+
+const oid = (c) => c.repeat(24);
+const OK_WINE = oid('a');
+const PENDING_WINE = oid('b');
+
+const chain = (docs) => ({
+  select: jest.fn().mockReturnValue({
+    populate: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(docs) }),
+  }),
+});
+
+const list = {
+  cellar: oid('c'),
+  structureMode: 'custom',
+  sections: [{
+    entries: [
+      { wine: OK_WINE, vintage: '2019', bottleSize: '750ml' },
+      { wine: PENDING_WINE, vintage: '2020', bottleSize: '750ml' },
+    ],
+  }],
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+test('the wine query excludes pendingIdentity rows', async () => {
+  WineDefinition.find.mockReturnValue(chain([]));
+
+  await loadWineMap(list);
+
+  expect(WineDefinition.find).toHaveBeenCalledWith(expect.objectContaining({
+    pendingIdentity: { $ne: true },
+  }));
+});
+
+test('an excluded entry simply drops out — the same handling a deleted wine gets', async () => {
+  // Mongo returns only the visible wine; the pending one is absent.
+  WineDefinition.find.mockReturnValue(chain([{ _id: { toString: () => OK_WINE }, name: 'Barolo' }]));
+
+  const map = await loadWineMap(list);
+
+  expect(map.size).toBe(1);
+  expect([...map.values()][0].wine.name).toBe('Barolo');
+  expect([...map.keys()].some((k) => k.startsWith(PENDING_WINE))).toBe(false);
+});
+
+describe('the write gate judges only what a save ADDS', () => {
+  const { allEntries } = require('./wineListData');
+
+  // Mirrors routes/wineLists.pendingWineAdded: a list that already carried a
+  // pending row from before the gate existed must stay EDITABLE — otherwise
+  // its owner cannot even remove the entry. The read-side exclusion above is
+  // what keeps that row off the public page.
+  const idsOf = (l) => new Set(allEntries(l).filter(e => e.wine).map(e => String(e.wine)));
+
+  test('re-saving a list that already held the pending row adds nothing', () => {
+    const previous = idsOf(list);
+    const added = [...idsOf(list)].filter((id) => !previous.has(id));
+    expect(added).toEqual([]);
+  });
+
+  test('introducing a new wine is what the gate sees', () => {
+    const previous = idsOf({ ...list, sections: [{ entries: [{ wine: OK_WINE }] }] });
+    const added = [...idsOf(list)].filter((id) => !previous.has(id));
+    expect(added).toEqual([PENDING_WINE]);
+  });
+});

--- a/backend/src/services/wineVisibility.js
+++ b/backend/src/services/wineVisibility.js
@@ -26,6 +26,7 @@
  */
 
 const WineDefinition = require('../models/WineDefinition');
+const { isValidId } = require('../utils/validation');
 
 const CURATION_ROLES = ['somm', 'admin'];
 
@@ -81,7 +82,12 @@ function canSeeWine(wine, viewer = {}) {
  */
 async function findVisibleWine(id, opts = {}) {
   const { userId, roles, select, populate, lean = false } = opts;
-  let q = WineDefinition.findOne({ _id: id, ...wineVisibilityFilter({ userId, roles }) });
+  // Enforce the id contract HERE rather than trusting nine call sites to have
+  // done it: one caller forgetting would let an operator object reach the
+  // filter. A bad id is simply not-visible, which is the same answer this
+  // helper already gives for a hidden or missing wine.
+  if (!isValidId(String(id))) return null;
+  let q = WineDefinition.findOne({ _id: String(id), ...wineVisibilityFilter({ userId, roles }) });
   if (select) q = q.select(select);
   if (populate) q = q.populate(populate);
   if (lean) q = q.lean();

--- a/backend/src/services/wineVisibility.js
+++ b/backend/src/services/wineVisibility.js
@@ -1,0 +1,97 @@
+/**
+ * ONE definition of "may this caller see this registry wine".
+ *
+ * A pendingIdentity row is a half-identified wine that exists only because its
+ * creator's bottle had to save. It is registry content to nobody yet, so the
+ * rule — copied from the authenticated wine detail (routes/wines.js) and the
+ * resolver's `pendingBlocked` (services/findOrCreateWine.js) — is:
+ *
+ *   • not pending            → visible to everyone
+ *   • pending + you made it  → visible (your bottle page has to render)
+ *   • pending + you curate   → visible (somm/admin: completing it is the job)
+ *   • pending + anyone else  → NOT visible, reported as the same not-found a
+ *                              missing id gets, so its existence never leaks
+ *
+ * It lives here rather than being re-typed at each call site because the
+ * security audit found NINE routes that validated "wine exists" with a bare
+ * findById/exists: reviews, wishlist, recommendations, wine reports, wine
+ * requests, bottles, and the MCP write/bulk/wine-list tools. A rule spelled out
+ * nine times is a rule nine places can forget.
+ *
+ * Expressed as a QUERY FILTER, not a post-filter: `pendingIdentity` and
+ * `createdBy` are never in a caller's projection (SAFE_SELECT-style inclusive
+ * selects omit both), and a post-filter reading an absent field is exactly the
+ * dead gate this audit found in mcp/tools/wines.js — `undefined === true` is
+ * false, so the check never fires. Mongo decides instead.
+ */
+
+const WineDefinition = require('../models/WineDefinition');
+
+const CURATION_ROLES = ['somm', 'admin'];
+
+/** somm/admin — the roles whose job is completing pending rows. */
+const isCurator = (roles) => Array.isArray(roles) && roles.some((r) => CURATION_ROLES.includes(r));
+
+/**
+ * The pending-identity clause for a WineDefinition query, for one viewer.
+ *
+ * Returns `{}` for curation (they see everything) so the clause can always be
+ * spread into a filter. Callers that already use `$or` must merge with `$and`
+ * rather than spreading — none of the current ones do.
+ *
+ * @param {{userId?: string, roles?: string[]}} [viewer]
+ */
+function wineVisibilityFilter(viewer = {}) {
+  if (isCurator(viewer.roles)) return {};
+  const alternatives = [{ pendingIdentity: { $ne: true } }];
+  if (viewer.userId) alternatives.push({ pendingIdentity: true, createdBy: viewer.userId });
+  return { $or: alternatives };
+}
+
+/**
+ * Is this ALREADY-LOADED wine visible to this viewer? For the defensive gates
+ * where the document is in hand (rows attached before the write-time gates
+ * existed). Needs `pendingIdentity` + `createdBy` on the doc — a projection
+ * that omits them makes every row look non-pending, so prefer the filter.
+ *
+ * @param {{pendingIdentity?: boolean, createdBy?: any}|null} wine
+ * @param {{userId?: string, roles?: string[]}} [viewer]
+ */
+function canSeeWine(wine, viewer = {}) {
+  if (!wine) return false;
+  if (wine.pendingIdentity !== true) return true;
+  if (isCurator(viewer.roles)) return true;
+  return Boolean(viewer.userId) && String(wine.createdBy) === String(viewer.userId);
+}
+
+/**
+ * Load one registry wine IF this viewer may see it — the shared replacement for
+ * `WineDefinition.findById(id)` on every "does this wine exist" check. Returns
+ * null both for a missing id and for a hidden one, on purpose: the caller's
+ * existing not-found branch is then also the correct leak-free answer.
+ *
+ * @param {string} id                24-hex wine id (validated by the caller)
+ * @param {object} [opts]
+ * @param {string} [opts.userId]     viewer — req.user.id / ctx.user.id
+ * @param {string[]} [opts.roles]    viewer roles — req.user.roles / ctx.user.roles
+ * @param {string} [opts.select]     projection, as passed to .select()
+ * @param {string|string[]|object} [opts.populate]
+ * @param {boolean} [opts.lean=false]
+ * @returns {Promise<object|null>}
+ */
+async function findVisibleWine(id, opts = {}) {
+  const { userId, roles, select, populate, lean = false } = opts;
+  let q = WineDefinition.findOne({ _id: id, ...wineVisibilityFilter({ userId, roles }) });
+  if (select) q = q.select(select);
+  if (populate) q = q.populate(populate);
+  if (lean) q = q.lean();
+  return q;
+}
+
+module.exports = {
+  CURATION_ROLES,
+  isCurator,
+  wineVisibilityFilter,
+  canSeeWine,
+  findVisibleWine,
+};

--- a/backend/src/services/wineVisibility.test.js
+++ b/backend/src/services/wineVisibility.test.js
@@ -1,0 +1,102 @@
+/**
+ * services/wineVisibility — the ONE pending-identity visibility rule.
+ *
+ * The security audit found nine routes that answered "does this wine exist?"
+ * with a bare findById, so a stranger could reach a pendingIdentity row through
+ * reviews, the wishlist, recommendations (which EMAILS the name to a third
+ * party), wine reports, wine requests, bottles and three MCP tools. This suite
+ * pins the rule they all now share, and pins it as a QUERY CLAUSE rather than a
+ * post-filter — the dead `raw.pendingIdentity === true` check in
+ * mcp/tools/wines.js was dead precisely because the projection omitted the
+ * field, and a post-filter cannot see what it was not given.
+ */
+
+jest.mock('../models/WineDefinition', () => ({ findOne: jest.fn() }));
+
+const WineDefinition = require('../models/WineDefinition');
+const { wineVisibilityFilter, canSeeWine, findVisibleWine, isCurator } = require('./wineVisibility');
+
+const ME = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+const STRANGER = 'bbbbbbbbbbbbbbbbbbbbbbbb';
+const WINE = 'cccccccccccccccccccccccc';
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('wineVisibilityFilter — the clause that goes into the query', () => {
+  test('an anonymous caller gets a plain exclusion (nobody to compare against)', () => {
+    expect(wineVisibilityFilter()).toEqual({ $or: [{ pendingIdentity: { $ne: true } }] });
+  });
+
+  test('a signed-in caller additionally matches their OWN pending rows', () => {
+    expect(wineVisibilityFilter({ userId: ME, roles: ['user'] })).toEqual({
+      $or: [{ pendingIdentity: { $ne: true } }, { pendingIdentity: true, createdBy: ME }],
+    });
+  });
+
+  test.each([['somm'], ['admin']])('%s gets an EMPTY clause — completing these rows is the job', (role) => {
+    expect(wineVisibilityFilter({ userId: STRANGER, roles: [role] })).toEqual({});
+  });
+
+  test('an unrelated role is not curation', () => {
+    expect(isCurator(['moderator'])).toBe(false);
+    expect(isCurator(undefined)).toBe(false);
+  });
+});
+
+describe('canSeeWine — the same rule for an already-loaded document', () => {
+  const pending = { pendingIdentity: true, createdBy: ME };
+
+  test('a non-pending wine is visible to everyone, signed in or not', () => {
+    expect(canSeeWine({ pendingIdentity: false }, { userId: STRANGER })).toBe(true);
+    expect(canSeeWine({}, {})).toBe(true);
+  });
+
+  test('a pending wine is visible to its creator', () => {
+    expect(canSeeWine(pending, { userId: ME, roles: ['user'] })).toBe(true);
+  });
+
+  test('a pending wine is NOT visible to a stranger', () => {
+    expect(canSeeWine(pending, { userId: STRANGER, roles: ['user'] })).toBe(false);
+  });
+
+  test('a pending wine is visible to curation', () => {
+    expect(canSeeWine(pending, { userId: STRANGER, roles: ['somm'] })).toBe(true);
+    expect(canSeeWine(pending, { userId: STRANGER, roles: ['admin'] })).toBe(true);
+  });
+
+  test('a missing wine is never visible', () => {
+    expect(canSeeWine(null, { roles: ['admin'] })).toBe(false);
+  });
+});
+
+describe('findVisibleWine — the drop-in replacement for findById', () => {
+  test('the exclusion is part of the QUERY, not applied to the result', async () => {
+    WineDefinition.findOne.mockResolvedValue(null);
+    await findVisibleWine(WINE, { userId: ME, roles: ['user'] });
+    expect(WineDefinition.findOne).toHaveBeenCalledWith({
+      _id: WINE,
+      $or: [{ pendingIdentity: { $ne: true } }, { pendingIdentity: true, createdBy: ME }],
+    });
+  });
+
+  test('select / populate / lean are applied in that order when asked for', async () => {
+    const lean = jest.fn().mockResolvedValue({ _id: WINE });
+    const populate = jest.fn().mockReturnValue({ lean });
+    const select = jest.fn().mockReturnValue({ populate });
+    WineDefinition.findOne.mockReturnValue({ select });
+
+    const out = await findVisibleWine(WINE, {
+      userId: ME, select: 'name producer', populate: ['country'], lean: true,
+    });
+
+    expect(select).toHaveBeenCalledWith('name producer');
+    expect(populate).toHaveBeenCalledWith(['country']);
+    expect(lean).toHaveBeenCalled();
+    expect(out).toEqual({ _id: WINE });
+  });
+
+  test('a hidden row and a missing id are indistinguishable to the caller', async () => {
+    WineDefinition.findOne.mockResolvedValue(null);
+    await expect(findVisibleWine(WINE, { userId: STRANGER })).resolves.toBeNull();
+  });
+});

--- a/backend/src/utils/identitySentinel.test.js
+++ b/backend/src/utils/identitySentinel.test.js
@@ -1,0 +1,112 @@
+/**
+ * H-4 — isIdentitySentinel must be UNICODE-AWARE.
+ *
+ * normalizeString emits `[a-z0-9 ]` only, so it strips every non-Latin script
+ * outright: "Мукузани", "ქართული ღვინო", "獺祭" and "Δομαίν" all normalized to
+ * '' and the empty result read as "this producer is MISSING". Two things broke.
+ *
+ *   (a) At mint the user's typed producer was discarded and the wine hidden —
+ *       where before the pending-identity feature they at least got a clear 400.
+ *   (b) At PROMOTION the WineDefinition pre-validate hook consults this same
+ *       predicate, so a curator typing the producer exactly as printed on the
+ *       label could never promote the row. It stayed hidden forever.
+ *
+ * (b) is what this file is really about: it is the one that could not be
+ * recovered from through the product. The mint-side residue is documented at
+ * services/findOrCreateWine (the producerNorm.length < 2 gate) — the registry's
+ * normalizedKey is ASCII-only, so STORING such a producer needs a script-aware
+ * key namespace, which is a registry-wide change and not this remediation.
+ */
+const mongoose = require('mongoose');
+const { isIdentitySentinel } = require('./normalize');
+const WineDefinition = require('../models/WineDefinition');
+
+describe('genuine sentinels still are sentinels (no regression)', () => {
+  test.each([
+    ['', 'empty'],
+    ['   ', 'whitespace only'],
+    ['-', 'a dash'],
+    ['?', 'a question mark'],
+    ['!!!', 'punctuation only'],
+    ['Unknown', 'the English placeholder'],
+    ['unknown', 'lowercased'],
+    ['UNKNOWN', 'shouted'],
+    ['N/A', 'the abbreviation — punctuation is stripped to "na"'],
+    ['Okänd', 'Swedish, diacritics folded to "okand"'],
+    ['Inconnu', 'French'],
+    ['Unbekannt', 'German'],
+    ['no producer', 'the two-word form'],
+    ['Producer Unknown', 'the reversed two-word form'],
+    ['Domaine Unknown', 'the wine-shaped form'],
+    ['Unknown Winery', 'the other wine-shaped form'],
+  ])('%j is a sentinel (%s)', (value) => {
+    expect(isIdentitySentinel(value)).toBe(true);
+  });
+
+  test('a non-string carries no information either', () => {
+    for (const v of [null, undefined, 5, {}, []]) expect(isIdentitySentinel(v)).toBe(true);
+  });
+});
+
+describe('NON-LATIN producers are real information, not a missing value', () => {
+  test.each([
+    ['Мукузани', 'Cyrillic (Georgian wine, Russian spelling)'],
+    ['ქართული ღვინო', 'Georgian (Mkhedruli)'],
+    ['獺祭', 'Japanese (Dassai)'],
+    ['Δομαίν', 'Greek, with a diacritic that NFD decomposes'],
+    ['שדה בוקר', 'Hebrew'],
+    ['شاتو مصر', 'Arabic'],
+    ['장수막걸리', 'Korean'],
+    ['張裕', 'Chinese'],
+  ])('%j is NOT a sentinel (%s)', (value) => {
+    expect(isIdentitySentinel(value)).toBe(false);
+  });
+
+  test('a MIXED value is judged on what it contains, not on the Latin fragment', () => {
+    // normalizeString folds this to exactly 'unknown' (the Cyrillic is stripped),
+    // which the sentinel regex matches — so the check has to happen BEFORE the fold.
+    expect(isIdentitySentinel('Unknown Мукузани')).toBe(false);
+  });
+});
+
+describe('ordinary Latin producers are unaffected', () => {
+  test.each([
+    ['Château Margaux'],
+    ['Weingut Müller-Catoir'],
+    ['Østerberg'],
+    ['Viña Errázuriz'],
+    ['A'],
+    ['123'],
+  ])('%j is not a sentinel', (value) => {
+    expect(isIdentitySentinel(value)).toBe(false);
+  });
+});
+
+describe('(b) the consequence that mattered: promotion works', () => {
+  const pendingDoc = (producer) => new WineDefinition({
+    name: 'Kaefferkopf',
+    producer,
+    country: new mongoose.Types.ObjectId(),
+    createdBy: new mongoose.Types.ObjectId(),
+    normalizedKey: 'pending~aaa:kaefferkopf:',
+    pendingIdentity: true,
+  });
+
+  test('a curator typing a CYRILLIC producer promotes the row', async () => {
+    const doc = pendingDoc('Мукузани');
+    await doc.validate();
+    expect(doc.pendingIdentity).toBe(false);
+  });
+
+  test('a curator typing a CJK producer promotes the row', async () => {
+    const doc = pendingDoc('獺祭');
+    await doc.validate();
+    expect(doc.pendingIdentity).toBe(false);
+  });
+
+  test('a curator typing "Unknown" still does NOT promote it', async () => {
+    const doc = pendingDoc('Unknown');
+    await doc.validate();
+    expect(doc.pendingIdentity).toBe(true);
+  });
+});

--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -254,6 +254,25 @@ const normalizeProducerKey = (producer) => {
     .trim();
 };
 
+// The producer segment a PENDING (producerless) wine keys under. Built by
+// STRING CONCATENATION, deliberately NOT through generateWineKey: normalizeString
+// emits [a-z0-9 ] only — it strips '~' — so a segment containing '~' is one no
+// real producer can ever produce, which is what makes the pending key namespace
+// provably disjoint from the ordinary one under the UNIQUE normalizedKey index.
+// The creator id in the segment is what stops two users' identical producerless
+// adds from colliding, while making the SAME user's retry key identically and
+// resolve to their own row instead of minting again.
+//
+// Lives here, beside generateWineKey, because BOTH the resolver
+// (services/findOrCreateWine) and the curation queue (services/pendingWineOps)
+// must agree on it — and normalize.js has no dependencies, so neither module
+// has to drag the other's dependency tree (or mock it) to build a key.
+// See the pendingIdentity field note on models/WineDefinition.js.
+const PENDING_KEY_PREFIX = 'pending~';
+const pendingProducerKey = (userId) => `${PENDING_KEY_PREFIX}${String(userId)}`;
+const pendingWineKey = (name, userId, appellation = '') =>
+  `${pendingProducerKey(userId)}:${normalizeString(name)}:${normalizeString(appellation)}`;
+
 /**
  * Generate a normalized key for wine deduplication
  * Combines producer + wine name + appellation
@@ -785,14 +804,42 @@ const IDENTITY_SENTINEL_RX =
   /^(unknown|unbekannt|inconnu|inconnue|okand|na|none|no producer|producer unknown|domaine unknown|unknown producer|unknown winery)$/;
 
 /**
+ * Letters or digits that survive diacritic folding but that `normalizeString`
+ * cannot represent — i.e. a script outside its `[a-z0-9 ]` output. "Ø" and "é"
+ * fold to ASCII and are NOT counted; Cyrillic, Greek, Georgian, Han, Kana,
+ * Hebrew, Arabic and Devanagari are.
+ *
+ * The point: normalizeString returning '' is only evidence of "no information"
+ * for a Latin-script value. For "Мукузани" the empty key is a limit of the KEY,
+ * not a statement about the producer.
+ */
+const hasNonLatinAlnum = (str) =>
+  /[\p{L}\p{N}]/u.test(
+    str.normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')  // fold diacritics first — "Château" is Latin
+      .replace(/[\u0000-\u007f]/g, '')  // drop everything normalizeString can see
+  );
+
+/**
  * True when an identity string carries no real information — empty, whitespace,
  * punctuation-only, or one of the sentinels above. Used by the pending-identity
  * mint path (services/findOrCreateWine) to decide "this producer is MISSING,
  * not wrong", and by the WineDefinition auto-promote hook to decide when a
  * pending row has become a complete identity.
+ *
+ * UNICODE-AWARE, and it has to be (security audit): normalizeString strips
+ * every non-ASCII letter, so "Мукузани", "ქართული ღვინო", "獺祭" and "Δομαίν"
+ * all normalized to '' and read as MISSING. That discarded the producer the
+ * user actually typed at mint time and — worse — made the row unpromotable,
+ * because a curator typing the producer exactly as printed on the label hit
+ * this same predicate in the auto-promote hook and the wine stayed hidden
+ * forever. Any letter or number in ANY script is real information.
  */
 const isIdentitySentinel = (value) => {
   if (typeof value !== 'string') return true;
+  // Checked BEFORE the fold, so a mixed value ("Unknown Мукузани") is judged on
+  // what it contains rather than on the Latin fragment that survives.
+  if (hasNonLatinAlnum(value)) return false;
   const key = normalizeString(value);
   return key === '' || IDENTITY_SENTINEL_RX.test(key);
 };
@@ -845,6 +892,9 @@ module.exports = {
   slugify,
   tokenize,
   generateWineKey,
+  PENDING_KEY_PREFIX,
+  pendingProducerKey,
+  pendingWineKey,
   generateWineSlug,
   GRAPE_SYNONYMS,
   normalizeProducerKey,

--- a/frontend/src/components/WinePendingIdentityModal.js
+++ b/frontend/src/components/WinePendingIdentityModal.js
@@ -109,7 +109,12 @@ function WinePendingIdentityModal({ apiFetch, onClose }) {
       }
       setSuccessMsg(data.message);
       cancelEdit();
-      await fetchPage(page);
+      // Fixing the LAST row of a later page shrinks the queue past this page —
+      // refetching the same index returns an empty list and the modal would say
+      // "nothing waiting" while rows sit on page 1 (audit M-3). Step back first.
+      const nextPage = wines.length === 1 && page > 1 ? page - 1 : page;
+      if (nextPage !== page) setPage(nextPage);
+      await fetchPage(nextPage);
     } catch {
       setRowError(t('common.networkError'));
     } finally {
@@ -232,7 +237,11 @@ function WinePendingIdentityModal({ apiFetch, onClose }) {
                         </div>
                       ) : (
                         <>
-                          <Link to={`/wines/${w._id}`} target="_blank" rel="noreferrer">{w.name}</Link>
+                          {/* Deliberately NOT a link: /wines/:id renders from
+                              the public route, which excludes pending rows — so
+                              every link here would 404 (audit H-1). The row's
+                              own edit form + photos are the working surface. */}
+                          <strong>{w.name}</strong>
                           <div style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary, #666)' }}>
                             {w.producer || <em>{t('admin.wines.pendingIdentity.noProducer')}</em>}
                             {w.appellation ? ` · ${w.appellation}` : ''}
@@ -298,7 +307,7 @@ function WinePendingIdentityModal({ apiFetch, onClose }) {
           <button className="btn btn-secondary btn-sm" disabled={page <= 1 || loading} onClick={() => setPage(p => p - 1)}>
             {t('common.previous')}
           </button>
-          <span style={{ fontSize: '0.85rem' }}>{t('admin.audit.page', { page, pages })}</span>
+          <span style={{ fontSize: '0.85rem' }}>{t('admin.audit.page', { current: page, total: pages })}</span>
           <button className="btn btn-secondary btn-sm" disabled={page >= pages || loading} onClick={() => setPage(p => p + 1)}>
             {t('common.next')}
           </button>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -864,6 +864,7 @@
     "detailsApplyToAll_other": "These details apply to all {{count}} bottles."
   },
   "bottleDetail": {
+    "producerPending": "producer being confirmed",
     "backToCellar": "← Back to Cellar",
     "backToChat": "← Back to chat",
     "loadingBottle": "Loading bottle...",
@@ -3491,6 +3492,8 @@
     "resultMaturity_other": "{{count}} maturity windows added",
     "resultWines_one": "{{count}} new wine added to the registry",
     "resultWines_other": "{{count}} new wines added to the registry",
+    "resultPendingIdentity_one": "{{count}} wine couldn't be fully identified — the bottle is in your cellar, and our curators will complete the details",
+    "resultPendingIdentity_other": "{{count}} wines couldn't be fully identified — the bottles are in your cellar, and our curators will complete the details",
     "resultWineRequests_one": "{{count}} wine submitted for review (couldn't auto-create)",
     "resultWineRequests_other": "{{count}} wines submitted for review (couldn't auto-create)",
     "resultUnplaced_one": "{{count}} bottle couldn't be placed in a rack slot",
@@ -3847,7 +3850,7 @@
       "placedInRacks": "Placed in racks",
       "overflowSuffix": " ({{count}} into adjacent slots)",
       "couldntPlace": "Couldn't place",
-      "pendingIdentityNote": "{{n}} wines couldn't be fully identified from your file — the bottles are in your cellar, and our curators will complete the details.",
+      "pendingIdentityNote": "{{n}} wine(s) couldn't be fully identified from your file — the bottles are in your cellar, and our curators will complete the details.",
       "autoCreatedRacks": "Auto-created racks ({{count}})",
       "unplacedSummary": "Bottles that couldn't be placed in a rack ({{count}})",
       "unplacedRow": "Row {{row}} → rack <1>{{rack}}</1>",

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -517,8 +517,14 @@ function BottleDetail() {
               )}
             </div>
             <p className="bd-producer">
-              {displayProducer}
-              {wine?.country?.name && <span className="bd-country"> · {wine.country.name}</span>}
+              {/* A pending-identity wine has no producer yet. Say so plainly
+                  rather than rendering a bare "· France": the owner otherwise
+                  has no way to know their wine is awaiting curation, and won't
+                  understand why it can't be found in search (audit L-3 + the
+                  product finding). No action is required of them — promotion
+                  is automatic — so this is a statement, not a prompt. */}
+              {displayProducer || <em className="bd-producer-pending">{t('bottleDetail.producerPending')}</em>}
+              {wine?.country?.name && <span className="bd-country">{displayProducer ? ' · ' : ' — '}{wine.country.name}</span>}
             </p>
             {wine?.type && (
               <span className={`wine-type-pill ${wine.type}`}>{wine.type}</span>

--- a/frontend/src/pages/ImportCellar.js
+++ b/frontend/src/pages/ImportCellar.js
@@ -150,6 +150,7 @@ function ImportCellar() {
                 {r.reviewsCreated ? <li>{t('importCellar.resultReviews', { count: r.reviewsCreated })}</li> : null}
                 {r.maturityCreated ? <li>{t('importCellar.resultMaturity', { count: r.maturityCreated })}</li> : null}
                 {r.winesCreated ? <li>{t('importCellar.resultWines', { count: r.winesCreated })}</li> : null}
+                {r.pendingIdentityCount ? <li>{t('importCellar.resultPendingIdentity', { count: r.pendingIdentityCount })}</li> : null}
                 {r.wineRequests ? <li>{t('importCellar.resultWineRequests', { count: r.wineRequests })}</li> : null}
                 {r.unplaced?.length ? <li>{t('importCellar.resultUnplaced', { count: r.unplaced.length })}</li> : null}
                 {r.errors?.length ? <li>{t('importCellar.resultErrors', { count: r.errors.length })}</li> : null}


### PR DESCRIPTION
Remediates the two-agent audit of #938. **Five blocking HIGHs, five MEDs, six LOWs — all fixed.** Nothing from #938 has shipped; prod is on v1.106.0.

## The five blocking ones

**H-1 — a security gate that never executed.** `get_wine` checked `raw.pendingIdentity === true`, but its projection omitted that field, so the value was always `undefined` and every pending wine passed — on the **unauthenticated** `/api/mcp/public` surface. Now filtered in the query (with `nonWine`, never filtered here either). The missing regression test is added, including one pinning that `findById` is no longer used.

**H-2 — `GET /api/journal/wine-search`** regex-searched the whole registry with no gate and returned ids, which is what made H-1 exploitable in two steps. Gated.

**H-3 — import `/validate` could match a stranger's pending row at score 1.0** (a producer-less CellarTracker row vs a hidden producer-less wine), letting one user attach bottles to another's record. All **three** strategies gated — the Meili branch was ungated too — using the creator-aware rule so the preview doesn't lie about what `/confirm` will do.

**H-4 — non-Latin producers were read as "unknown".** "Мукузани", "獺祭", "ქართული ღვინო" normalize to empty, so `isIdentitySentinel` called them sentinels: the typed producer was discarded at mint **and the row could never be promoted** — a curator typing the producer exactly as printed got "still needs a producer". Promotion is fixed and tested (see the known limit below).

**H-5 — pending identities reached anonymous readers** through discussions (populated, Meili-indexed, and rendered for **crawlers** by the OG route) and public wine lists (no auth at all). Refused at write time, which closes every downstream read path; `loadWineMap` gated defensively for rows attached before this fix.

## MED/LOW highlights
`get_pending_wine_images` had no pending gate — any somm could pull any wine's private photos to an external model (M-1). `applyPendingFix` dropped the creator id out of the key while a row was still pending, which could produce a false "merge them instead" 409 (M-2). Enrichment wrote AI tasting notes for wines with no producer, on the adding user's budget (M-3). Nine routes accepted any pending id — now one shared `services/wineVisibility.js` helper, expressed as a **query filter, not a post-filter**, because a post-filter reading an omitted field is exactly how H-1 died (M-4). Pending rows no longer squat slugs (M-5). Plus the retention-sweep TOCTOU, the image payload that leaked `uploadedBy` and undid the queue's anonymisation, scan-attachment minimisation, and label scans now genuinely included in the export ZIP rather than only claimed.

**Visibility rule:** not pending → everyone; pending → creator, somm and admin only; everyone else gets the same not-found a missing id gets.

## Known limit, documented in code
A non-Latin producer is still filed **pending** rather than stored, because `normalizedKey` is `normalizeString(producer):…` — storing it would key as `:<name>:<appellation>`, indistinguishable from every other non-Latin producer of a same-named wine, and the duplicate-key recovery would then attach one user's wine to another's. The pending namespace is per-creator and has no such collision, and **promotion works**, so curators can complete these rows. Storing the original at mint needs a script-aware key namespace — registry-wide, worth its own change.

## Frontend (first commit)
Queue rows no longer link to `/wines/:id` (the public route excludes pending by design, so every link 404'd); the pager passed the wrong i18n variables and rendered a literal `Page {{current}} of {{total}}`; fixing the last row of a later page made the queue claim to be empty; the ZIP import now discloses pending counts like the CSV import did; and the bottle page says **"producer being confirmed"** instead of a bare "· France" — the owner otherwise had no way to know their wine was awaiting curation, or why search couldn't find it.

## Tests
Backend **216 suites / 3209 tests green** (+87). 19 pre-existing tests were updated, not weakened — they mocked `findById` at call sites the fixes moved to `findOne`. Frontend **912 green**.

Note: the export ZIP gains an additive top-level `labelScans` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
