### PR TITLE
chore(release): v1.107.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.106.0",
+  "version": "1.107.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.106.0",
+      "version": "1.107.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.106.0",
+  "version": "1.107.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.106.0",
+  "version": "1.107.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.106.0",
+      "version": "1.107.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.106.0",
+  "version": "1.107.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for v1.107.0.

Contents since v1.106.0: #938 pending-identity wines (an unreadable label saves the bottle instead of being refused; scan images retained; somm curation queue in REST + MCP with real label images) · #939 audit remediation (two agents: 5 blocking HIGHs, 5 MEDs, 6 LOWs — all fixed; 3209 backend + 912 frontend tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)