### PR TITLE
fix(registry): let a pending-identity wine's owner be asked

### DIFF
--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -981,9 +981,11 @@ registerTool({
     'from their bottle page, answers land in the owner-inquiry queue). THE tool for record facts research cannot ' +
     'settle — "what does the label say the producer is?", "is this the DOCG or the DOC bottling?". Owners with ' +
     'ACTIVE bottles are asked; when none exist, owners who consumed one are asked instead. Capped at 20 owners. One ' +
-    'open inquiry per wine — a second ask conflicts until the first is resolved. This notifies real people: confirm ' +
-    'the wording with the somm first. NOT reversible via undo_last (notifications cannot be unsent). Read the ' +
-    'answers later with list_owner_inquiries.',
+    'open inquiry per wine — a second ask conflicts until the first is resolved. Works on pending-identity wines ' +
+    'too, and is the RIGHT escalation when the label scan cannot answer the question: the owner has the bottle in ' +
+    'hand and can read the back label ("Mis en bouteille par…") when the front prints no producer. This notifies ' +
+    'real people: confirm the wording with the somm first. NOT reversible via undo_last (notifications cannot be ' +
+    'unsent). Read the answers later with list_owner_inquiries.',
   scope: 'write',
   requireRole: SOMM_ROLES,
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },

--- a/backend/src/services/ownerInquiryOps.js
+++ b/backend/src/services/ownerInquiryOps.js
@@ -100,18 +100,15 @@ async function createOwnerInquiry({ wineId, userId, via = 'rest', question, req 
   if (!wine) {
     return { ok: false, code: 'not_found', message: 'No registry wine with that id.' };
   }
-  // An owner inquiry asks OTHER people's owners what their label says. On a
-  // pending-identity row the only owner IS the creator, whose add is what left
-  // the identity incomplete — asking them what the curator can already see in
-  // the attached scan image is a notification for nothing. Refused loudly so
-  // the curator uses the queue's own fix path instead.
-  if (wine.pendingIdentity === true) {
-    return {
-      ok: false,
-      code: 'conflict',
-      message: 'This wine is in the pending-identity queue — its only bottle owner is the person whose add created it. Read the label scan in that queue and fix it there instead.',
-    };
-  }
+  // Pending-identity wines are deliberately ASKABLE. This used to be refused on
+  // the reasoning that the only owner is the creator, so asking them adds
+  // nothing over reading the scan — but those two things don't connect. When the
+  // scan is unreadable (a washed-out producer line, a label that simply doesn't
+  // print the producer, a photo of a screen), the owner is holding the bottle
+  // and can read the BACK label, which carries "Mis en bouteille par…". That is
+  // strictly more information than the curator has, and it is the only path that
+  // resolves the row at all. Refusing it left such wines stuck in the queue
+  // forever with no escalation (found in use, 2026-08-12).
 
   const { recipients, fallbackUsed } = await buildRecipients(wine._id);
   if (recipients.length === 0) {

--- a/backend/src/services/ownerInquiryOps.test.js
+++ b/backend/src/services/ownerInquiryOps.test.js
@@ -121,6 +121,25 @@ describe('createOwnerInquiry', () => {
     expect(WineOwnerInquiry.create).not.toHaveBeenCalled();
   });
 
+  // Regression: this was REFUSED with a conflict on the reasoning that a
+  // pending row's only owner is its creator, so asking adds nothing over
+  // reading the scan. Wrong — when the scan cannot answer (washed-out producer
+  // line, a label that prints no producer at all), the owner holds the bottle
+  // and can read the back label. Refusing left those rows stuck with no
+  // escalation at all (found in use 2026-08-12).
+  test('ASKS a pending-identity wine — the owner can read the back label the scan cannot show', async () => {
+    WineDefinition.findById.mockReturnValue({
+      select: jest.fn().mockResolvedValue({ ...wineDoc, pendingIdentity: true }),
+    });
+    happyRecipients();
+    WineOwnerInquiry.create.mockResolvedValue({ _id: oid('e'), status: 'open', question: QUESTION });
+
+    const res = await createOwnerInquiry({ wineId: WINE, userId: ASKER, question: QUESTION });
+
+    expect(res.ok).toBe(true);
+    expect(WineOwnerInquiry.create).toHaveBeenCalled();
+  });
+
   test('strips HTML from the question — owners read plain text', async () => {
     mockWineFound();
     happyRecipients();


### PR DESCRIPTION
Found in use within hours of v1.107.0 shipping.

`ask_bottle_owner` refused any wine in the pending-identity queue, on this reasoning:

> On a pending row the only owner IS the creator, so asking them what the curator can already see in the scan is a notification for nothing.

Both premises are true. **The conclusion does not follow.** The curator often *cannot* see it in the scan — and when they can't, the owner is the only person who can, because they are holding the bottle and can turn it over. French labels print `Mis en bouteille par…` on the back.

Two real rows proved it immediately: a Mâcon La Roche Vineuse whose producer line is washed out in the photo, and a Chablis whose front label prints **no producer at all** (a clean-skin bottle). The queue's fix path can't read them, and the ask path refused — a dead end with no escalation.

- Guard removed, replaced by a comment explaining why pending rows are **deliberately** askable, so it isn't helpfully restored later.
- `ask_bottle_owner`'s description now tells the somm this is the right move when a scan can't answer the question.
- Regression test added — there wasn't one, which is exactly why this shipped.

Full backend suite: **216 suites / 3210 tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)