### PR TITLE
chore(release): v1.108.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.107.0",
+  "version": "1.108.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.107.0",
+      "version": "1.108.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.107.0",
+  "version": "1.108.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.107.0",
+  "version": "1.108.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.107.0",
+      "version": "1.108.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.107.0",
+  "version": "1.108.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for v1.108.0.

Contents since v1.107.0: #941 a pending-identity wine's owner can be asked (dead end found in use) · #942 identity quality at the point of writing — plausibility flagging, a 7-day post-promotion label-scan window, two cross-field rules, region adjectival synonyms, slug regeneration with previousSlugs, and a reversible no-producer-on-label disposition. Audited by two agents (the backend one returned DO-NOT-SHIP; the plausibility rule was rebuilt from blocking to flagging after it was proven to condemn Château Margaux, Petrus and Romanée-Conti). 3404 backend + 912 frontend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)