### PR TITLE
fix(somm): don't claim a scan window expired when there was never a scan

### DIFF
--- a/backend/src/mcp/pendingWineTools.test.js
+++ b/backend/src/mcp/pendingWineTools.test.js
@@ -298,7 +298,11 @@ describe('get_pending_wine_images — the point of the feature', () => {
       const body = parse(res);
 
       expect(body.error.code).toBe('conflict');
-      expect(body.error.message).toMatch(/not in the pending-identity queue/);
+      // Asserts the MEANING, not the sentence: a completed wine past its grace
+      // window is refused and told the scan is gone. (The wording changed when
+      // the no-scan case got its own message — behaviour here is unchanged.)
+      expect(body.error.message).toMatch(/pending-identity queue/);
+      expect(body.error.message).toMatch(/window has closed/);
     });
 
     test('no image is read from disk for a completed wine', async () => {
@@ -357,6 +361,27 @@ describe('get_pending_wine_images — the point of the feature', () => {
 
       expect(body.error.code).toBe('conflict');
       expect(body.error.message).toMatch(/correction window has closed/);
+    });
+
+    // Found in use 2026-08-12: a curator asked about a wine that was never
+    // added from a photo and was told its window "has closed" — asserting that
+    // evidence had existed and they were too late. The three states must not
+    // share one message.
+    test('a wine with NO scan is told so, not told a window expired', async () => {
+      WineDefinition.findById.mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({
+            _id: W1, name: 'Rosé Poulsard', producer: 'Domaine Rolet', pendingIdentity: false, scanImage: null,
+          }),
+        }),
+      });
+
+      const body = parse(await tool('get_pending_wine_images').handler({ wine_id: W1 }, SOMM_CTX));
+
+      expect(body.error.code).toBe('conflict');
+      expect(body.error.message).toMatch(/has no label scan/);
+      expect(body.error.message).not.toMatch(/window has closed/);
+      expect(body.error.message).toMatch(/ask_bottle_owner/);
     });
 
     test('a promoted wine whose scan was never stamped stays refused', async () => {

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1231,9 +1231,18 @@ registerTool({
         .select('_id kind originalUrl processedUrl retainUntil').lean()
       : null;
     if (!mayCurationReadScan(wine, scan)) {
+      // Three different states used to share one message, and it asserted an
+      // expiry for all of them — a curator asking about a wine that was never
+      // added from a photo was told its window "has closed", i.e. that
+      // evidence had existed and they were too late. Say which case it is.
+      if (!scan) {
+        return fail('conflict',
+          'That wine has no label scan — it was not added from a photo, so there is no curation evidence to read. '
+          + 'Its bottle photos belong to their owners. Use ask_bottle_owner if the label is the only thing that can settle this.');
+      }
       return fail('conflict',
-        `That wine is not in the pending-identity queue and its label scan's ${PROMOTED_SCAN_GRACE_DAYS}-day ` +
-        'correction window has closed — the remaining photos are its owners\' private images, not curation evidence.');
+        `That wine left the pending-identity queue and its label scan's ${PROMOTED_SCAN_GRACE_DAYS}-day `
+        + 'correction window has closed, so the scan is gone. Use ask_bottle_owner if the label is the only thing that can settle this.');
     }
 
     // "Which images belong to this wine" has exactly one definition — the same


### PR DESCRIPTION
Found in use by the sommelier minutes after v1.108.0 deployed.

`get_pending_wine_images` had **one refusal for three different states**, and it asserted an expiry for all of them:

> That wine is not in the pending-identity queue and its label scan's 7-day correction window has closed — the remaining photos are its owners' private images, not curation evidence.

The wine in question (Domaine Rolet "Rosé Poulsard") was added through the UI **without a photo at all** — `scanImage: NONE`, never pending. So no window ever existed, let alone closed. The curator was told evidence had been there and they were too late, which invites chasing a phantom or assuming they were too slow.

Now the states are distinguished:
- **no scan ever** → says so, and notes the bottle photos belong to their owners
- **completed, window closed** → unchanged meaning, clearer wording

Both now point at `ask_bottle_owner`, which is the real next move when only the label can settle it — and which works on pending wines since #941.

Regression test added for the no-scan case, asserting it does **not** claim a window closed. The existing expired-case test now asserts the meaning rather than the exact sentence.

Suites: pendingWineTools + labelScanAccess + images — 32 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)