### PR TITLE
fix(ux): honest AI scoping + whole-import comment/occasion — two rekerukuru tickets

### DIFF
--- a/backend/src/mcp/drinkingTools.test.js
+++ b/backend/src/mcp/drinkingTools.test.js
@@ -156,6 +156,18 @@ describe('what_should_i_open_tonight', () => {
     expect(body.warnings.join(' ')).toMatch(/2 reserved .*excluded/i);
   });
 
+  test('summary leads with the screened cellar total, not just the shortlist (honest scoping)', async () => {
+    // 2026-08-12 support ticket "IA bottles known false": a shortlist-only
+    // summary was relayed to the user as "the AI only knows 11 of my 72
+    // bottles". The screened total — ready or not, reserved included — leads.
+    const ready = mkBottle({ drinkFrom: THIS_YEAR - 2, drinkTo: THIS_YEAR + 2 });
+    const notReady = mkBottle({ drinkFrom: THIS_YEAR + 3 });
+    const reserved = mkBottle({ drinkTo: THIS_YEAR + 2, reservedFor: 'Anna' });
+    wireCandidates([ready, notReady, reserved]);
+    const res = await tool('what_should_i_open_tonight').handler({}, ctxFor(oid('b')));
+    expect(parse(res).summary).toMatch(/^Screened 3 active bottle/);
+  });
+
   test('an all-reserved cellar returns the empty result WITH the reserved disclosure', async () => {
     // Without the warning the model would tell the user "nothing is ready" and
     // never mention that their peak bottles are simply spoken for.
@@ -195,6 +207,16 @@ describe('pair_with_dish', () => {
     expect(body.data.matched).toEqual([]);
     expect(body.data.style_spread).toHaveLength(1);
     expect(body.warnings.join(' ')).toMatch(/hints|evidence/i);
+  });
+
+  test('summary states the whole cellar was screened (honest scoping)', async () => {
+    const free = mkBottle({ drinkTo: THIS_YEAR + 2 });
+    const reserved = mkBottle({ drinkTo: THIS_YEAR + 2, reservedFor: 'the wedding' });
+    wireCandidates([free, reserved]);
+    const res = await tool('pair_with_dish').handler({ dish: 'roast chicken' }, ctxFor(oid('d')));
+    const body = parse(res);
+    expect(body.summary).toMatch(/^Screened all 2 active bottle/);
+    expect(body.summary).toMatch(/whole cellar was considered/);
   });
 
   test('reserved bottles are excluded from both the matches and the style spread', async () => {

--- a/backend/src/mcp/tools/drinking.js
+++ b/backend/src/mcp/tools/drinking.js
@@ -78,7 +78,10 @@ registerTool({
     const openCount = data.filter((c) => c.readiness === 'open').length;
     const urgentCount = data.filter((c) => c.readiness === 'declining' || c.readiness === 'late').length;
     return ok(
-      `${data.length} candidate(s)${scope.cellarName ? ` in "${scope.cellarName}"` : ''}` +
+      // Same screened-total lead as pair_with_dish: the shortlist must never
+      // read as the whole cellar.
+      `Screened ${sel.considered + sel.reservedExcluded} active bottle(s); ` +
+        `${data.length} candidate(s)${scope.cellarName ? ` in "${scope.cellarName}"` : ''}` +
         `${openCount ? ` — ${openCount} already open` : ''}${urgentCount ? `, ${urgentCount} in closing windows` : ''}`,
       data,
       {
@@ -150,7 +153,13 @@ registerTool({
     const spreadOut = await serializeCandidates(spread, sel.profileMap, scope.cellarIds, Math.max(limit - matchedOut.length, 3));
 
     return ok(
-      `${matchedOut.length} keyword match(es) for "${args.dish}", ${spreadOut.length} style-spread candidate(s)`,
+      // Lead with the screened total (support ticket 2026-08-12 "IA bottles
+      // known false"): this tool reads the WHOLE cellar and returns a shortlist,
+      // but a summary that only counts the shortlist reads as "the AI can see
+      // 11 of my 72 bottles" to the person the answer is relayed to.
+      `Screened all ${sel.considered + sel.reservedExcluded} active bottle(s) in the cellar; returning a shortlist — ` +
+        `${matchedOut.length} keyword match(es) for "${args.dish}", ${spreadOut.length} style-spread candidate(s). ` +
+        'Tell the user the whole cellar was considered.',
       { matched: matchedOut, style_spread: spreadOut },
       {
         warnings: [

--- a/backend/src/routes/import.confirm.test.js
+++ b/backend/src/routes/import.confirm.test.js
@@ -401,3 +401,77 @@ describe('item.addToWishlist', () => {
     expect(body.skipped).toEqual([{ index: 1, reason: 'Duplicate wishlist row in this import' }]);
   });
 });
+
+// ── Whole-import comment/occasion (support ticket 2026-07-30) ───────────────
+
+describe('importNotes / importOccasion', () => {
+  const confirmWith = (items, extra) =>
+    postJson(buildApp(), '/api/bottles/import/confirm', { cellarId: CELLAR_ID, items, ...extra });
+
+  test('land on every created bottle when rows carry neither (matched + request-wine paths)', async () => {
+    const { status, body } = await confirmWith(
+      [
+        { wineDefinition: WINE_ID, vintage: '2018' },
+        { requestWine: true, wineName: 'Mystery', producer: 'Someone', vintage: '2019' },
+      ],
+      { importNotes: 'Moved from CellarTracker', importOccasion: 'Estate auction' }
+    );
+
+    expect(status).toBe(200);
+    expect(body.created).toBe(2);
+    expect(Bottle.__instances).toHaveLength(2);
+    for (const b of Bottle.__instances) {
+      expect(b.notes).toBe('Moved from CellarTracker');
+      expect(b.occasion).toBe('Estate auction');
+    }
+  });
+
+  test('fill-blank only: a row with its own note keeps it', async () => {
+    const { body } = await confirmWith(
+      [
+        { wineDefinition: WINE_ID, vintage: '2018', notes: 'from the file' },
+        { wineDefinition: WINE_ID, vintage: '2019' },
+      ],
+      { importNotes: 'batch comment' }
+    );
+
+    expect(body.created).toBe(2);
+    expect(Bottle.__instances[0].notes).toBe('from the file');
+    expect(Bottle.__instances[1].notes).toBe('batch comment');
+  });
+
+  test('sanitised and capped: HTML stripped, occasion clamped to the schema max (500)', async () => {
+    const { body } = await confirmWith(
+      [{ wineDefinition: WINE_ID, vintage: '2018' }],
+      { importNotes: '<b>bold</b> move', importOccasion: 'x'.repeat(600) }
+    );
+
+    expect(body.created).toBe(1);
+    expect(Bottle.__instances[0].notes).toBe('bold move');
+    expect(Bottle.__instances[0].occasion).toHaveLength(500);
+  });
+
+  test('wishlist rows are NOT stamped — the comment describes bottles owned, not wines wanted', async () => {
+    const { body } = await confirmWith(
+      [{ wineDefinition: WINE_ID, vintage: '2018', addToWishlist: true }],
+      { importNotes: 'batch comment', importOccasion: 'gala' }
+    );
+
+    expect(body.wishlistCreated).toBe(1);
+    expect(WishlistItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({ notes: undefined })
+    );
+    expect(WishlistItem.create.mock.calls[0][0].occasion).toBeUndefined();
+  });
+
+  test('non-string values are ignored, absent fields leave bottles untouched (regression)', async () => {
+    const { body } = await confirmWith(
+      [{ wineDefinition: WINE_ID, vintage: '2018' }],
+      { importNotes: { length: 1e12 }, importOccasion: 42 }
+    );
+
+    expect(body.created).toBe(1);
+    expect(Bottle.__instances[0].notes).toBeUndefined();
+    expect(Bottle.__instances[0].occasion).toBeUndefined();
+  });
+});

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -645,7 +645,7 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
  */
 router.post('/confirm', async (req, res) => {
   try {
-    const { cellarId, items, positionAnchor: rawAnchor, rackConfigs: rawRackConfigs, defaultCurrency: rawDefaultCurrency } = req.body;
+    const { cellarId, items, positionAnchor: rawAnchor, rackConfigs: rawRackConfigs, defaultCurrency: rawDefaultCurrency, importNotes: rawImportNotes, importOccasion: rawImportOccasion } = req.body;
 
     if (!cellarId) {
       return res.status(400).json({ error: 'cellarId is required' });
@@ -669,6 +669,15 @@ router.post('/confirm', async (req, res) => {
     const defaultCurrency = (typeof rawDefaultCurrency === 'string' && /^[A-Z]{3}$/i.test(rawDefaultCurrency))
       ? rawDefaultCurrency.toUpperCase()
       : 'USD';
+
+    // Whole-import comment/occasion (support ticket 2026-07-30): typed once on
+    // the confirm screen, they land on every BOTTLE this import creates.
+    // Fill-blank only — a row that carries its own note from the file keeps it
+    // (imports never overwrite file data). Wishlist rows are deliberately
+    // excluded: "bought at the estate sale" describes bottles owned, not wines
+    // wanted. Caps mirror the Bottle schema (notes 5000, occasion 500).
+    const importNotes = typeof rawImportNotes === 'string' ? stripHtml(rawImportNotes).slice(0, 5000) : '';
+    const importOccasion = typeof rawImportOccasion === 'string' ? stripHtml(rawImportOccasion).slice(0, 500) : '';
 
     // Validate user-supplied per-rack configuration.
     // Shape: { [rackName]: { skip?, type?, rows?, cols?, typeConfig?: {...}, disabledPositions?: [Number] } }
@@ -1046,7 +1055,8 @@ router.post('/confirm', async (req, res) => {
             purchaseDate: item.purchaseDate || undefined,
             purchaseLocation: stripHtml(item.purchaseLocation),
             location: stripHtml(item.location),
-            notes: stripHtml(item.notes),
+            notes: stripHtml(item.notes) || importNotes || undefined,
+            occasion: (stripHtml(item.occasion) || '').slice(0, 500) || importOccasion || undefined,
             rating: resolvedRating,
             ratingScale: resolvedScale,
             drinkFrom,
@@ -1141,7 +1151,8 @@ router.post('/confirm', async (req, res) => {
           purchaseDate: item.purchaseDate || undefined,
           purchaseLocation: stripHtml(item.purchaseLocation),
           location: stripHtml(item.location),
-          notes: stripHtml(item.notes),
+          notes: stripHtml(item.notes) || importNotes || undefined,
+          occasion: (stripHtml(item.occasion) || '').slice(0, 500) || importOccasion || undefined,
           rating: resolvedRating,
           ratingScale: resolvedScale,
           drinkFrom,

--- a/backend/src/services/aiChat.js
+++ b/backend/src/services/aiChat.js
@@ -378,9 +378,26 @@ async function _prepareChatContext(userId, message, { useQueryExpansion = true, 
     // Enrich matches with maturity, price, and count data
     const enrichment = await fetchEnrichmentData(userId, matches);
 
-    wineSection = matches.length
-      ? `Available wines from the user's cellar:\n\n${formatWineList(matches, enrichment)}`
-      : 'The user has no wines in their cellar that match this query.';
+    // HONEST SCOPING (support ticket 2026-08-12 "IA bottles known false"): the
+    // model only ever sees the chatMaxResults most relevant bottles, and
+    // without the cellar's true size it presents that selection AS the cellar
+    // — a user with 71 bottles concluded the AI "has knowledge only on 11".
+    // State the total inside the context itself, counted on the SAME scope as
+    // the search (user + active + optional cellar selection) so the number can
+    // never contradict the list. The line lives in wineSection, so a reused
+    // context (previousWines) carries it forward without re-counting.
+    const totalActive = await Bottle.countDocuments(bottleScope);
+    const scopeLine = `The user's cellar holds ${totalActive} active bottle(s)${cellarIds?.length ? ' in the selected cellar(s)' : ''} in total.`;
+
+    if (matches.length) {
+      wineSection = `${scopeLine} The ${matches.length} wine(s) below are only the most relevant to this question — NOT the whole cellar. If the user asks about their full collection (totals, inventory, "what do you know about my cellar"), quote the total above and explain you are shown a relevant selection.\n\nAvailable wines from the user's cellar:\n\n${formatWineList(matches, enrichment)}`;
+    } else if (totalActive === 0) {
+      wineSection = 'The user has no active bottles in their cellar.';
+    } else {
+      // Empty SEARCH, non-empty CELLAR — without the distinction the model
+      // told users their cellar had nothing in it.
+      wineSection = `${scopeLine} None of them matched this question semantically — the cellar is not empty, this search just surfaced no relevant bottles.`;
+    }
   } else {
     wineSection = previousWines;
   }

--- a/backend/src/services/aiChat.scoping.test.js
+++ b/backend/src/services/aiChat.scoping.test.js
@@ -1,0 +1,121 @@
+/**
+ * Cellar chat — honest scoping of the RAG context (support ticket 2026-08-12
+ * "IA bottles known false").
+ *
+ * The model only ever sees the chatMaxResults most relevant bottles. Without
+ * being told the cellar's true size it presents that selection AS the cellar —
+ * a user with 71 bottles concluded the AI "has knowledge only on 11". These
+ * tests pin the three context shapes: matches (total + selection disclaimer),
+ * empty search over a non-empty cellar (explicitly not empty), and a genuinely
+ * empty cellar.
+ */
+
+const chain = (result) => {
+  const c = {};
+  for (const m of ['populate', 'sort', 'skip', 'limit', 'select']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(() => Promise.resolve(result));
+  c.then = (res, rej) => Promise.resolve(result).then(res, rej);
+  return c;
+};
+
+jest.mock('../config/aiConfig', () => ({
+  get: jest.fn(() => ({
+    chatEnabled: true,
+    chatSystemPrompt: 'sys',
+    chatModel: 'model-x',
+    chatModelFallback: null,
+    chatMaxTokens: 800,
+    chatTopK: 30,
+    chatMaxResults: 5,
+    chatMaxHistoryTurns: 10,
+    vectorIndex: 'v1',
+    embeddingModel: 'embed-x',
+  })),
+}));
+jest.mock('./aiProvider', () => ({
+  assertConfigured: jest.fn(),
+  getChatClient: jest.fn(),
+}));
+jest.mock('../utils/aiResponse', () => ({
+  textFromResponse: jest.fn(() => 'answer'),
+  thinkingOff: jest.fn(() => ({})),
+}));
+jest.mock('./embedding', () => ({
+  isEmbeddingConfigured: jest.fn(() => true),
+  embedSingle: jest.fn(async () => [0.1, 0.2]),
+}));
+jest.mock('./vectorStore', () => ({ searchSimilar: jest.fn(async () => []) }));
+jest.mock('../models/Bottle', () => ({
+  distinct: jest.fn(), countDocuments: jest.fn(), find: jest.fn(), aggregate: jest.fn(async () => []),
+}));
+jest.mock('../models/WineVintagePrice', () => ({ aggregate: jest.fn(async () => []) }));
+jest.mock('../utils/maturityUtils', () => ({
+  buildProfileMap: jest.fn(async () => new Map()),
+  classifyMaturity: jest.fn(() => null),
+  maturityLabel: jest.fn(() => null),
+}));
+
+const mongoose = require('mongoose');
+const Bottle = require('../models/Bottle');
+const vectorStore = require('./vectorStore');
+const aiProvider = require('./aiProvider');
+const { chat } = require('./aiChat');
+
+const USER = 'a'.repeat(24);
+const WD = new mongoose.Types.ObjectId();
+
+/** Wire the mocked Claude client; returns a getter for the sent user content. */
+function wireClient() {
+  const create = jest.fn(async () => ({ content: [{ type: 'text', text: 'answer' }] }));
+  aiProvider.getChatClient.mockReturnValue({ messages: { create } });
+  return () => {
+    const params = create.mock.calls[0][0];
+    return params.messages[params.messages.length - 1].content;
+  };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('chat context honest scoping', () => {
+  test('matches: context states the cellar total and that the list is a selection', async () => {
+    const sent = wireClient();
+    Bottle.distinct.mockResolvedValue([String(WD)]);
+    Bottle.countDocuments.mockResolvedValue(71);
+    vectorStore.searchSimilar.mockResolvedValue([
+      { score: 0.9, payload: { wineDefinitionId: String(WD), vintage: '2015' } },
+    ]);
+    Bottle.find.mockReturnValue(chain([{
+      _id: new mongoose.Types.ObjectId(),
+      vintage: '2015',
+      wineDefinition: { _id: WD, name: 'Barolo', producer: 'P', type: 'red', grapes: [], region: null, country: null },
+    }]));
+
+    await chat(USER, 'something red tonight?', { useQueryExpansion: false });
+    const content = sent();
+    expect(content).toMatch(/holds 71 active bottle\(s\)/);
+    expect(content).toMatch(/only the most relevant to this question — NOT the whole cellar/);
+    expect(content).toMatch(/Available wines from the user's cellar/);
+  });
+
+  test('empty search over a non-empty cellar: context says the cellar is NOT empty', async () => {
+    const sent = wireClient();
+    Bottle.distinct.mockResolvedValue([String(WD)]);
+    Bottle.countDocuments.mockResolvedValue(71);
+    vectorStore.searchSimilar.mockResolvedValue([]);
+
+    await chat(USER, 'wines from the moon?', { useQueryExpansion: false });
+    const content = sent();
+    expect(content).toMatch(/holds 71 active bottle\(s\)/);
+    expect(content).toMatch(/the cellar is not empty/);
+  });
+
+  test('genuinely empty cellar: context says so without inventing a total', async () => {
+    const sent = wireClient();
+    Bottle.distinct.mockResolvedValue([]);
+    Bottle.countDocuments.mockResolvedValue(0);
+
+    await chat(USER, 'what do I own?', { useQueryExpansion: false });
+    expect(sent()).toMatch(/no active bottles in their cellar/);
+    expect(vectorStore.searchSimilar).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3678,6 +3678,14 @@
       "dropHint": "JSON, CSV, TSV, or TXT — max 10 MB",
       "encodingLine": "File encoding: {{encoding}}"
     },
+    "wholeImport": {
+      "title": "For every imported bottle",
+      "hint": "Optional — typed once, applied to every bottle in this import. Rows that carry their own note in the file keep it.",
+      "commentLabel": "Comment",
+      "commentPlaceholder": "e.g. Moved over from my old cellar app",
+      "occasionLabel": "Occasion",
+      "occasionPlaceholder": "e.g. Estate auction, March 2026"
+    },
     "rack": {
       "title": "Rack placement",
       "oenoHint": "Detected an <1>Oeno by Vintec</1> export. Cabinets and per-column modules from your CSV have been mapped to one Open Shelf rack each (6 front + 5 back per shelf, shelf 1 at the bottom). Each bottle's exact slot is preserved — adjust shelf counts below only if a cabinet has more shelves than the file shows.",

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -148,6 +148,11 @@ function ImportBottles() {
   // currency column. Seeded from the user's profile preference, but can be
   // overridden per-import via the picker.
   const [importCurrency, setImportCurrency] = useState(user?.preferences?.currency || 'USD');
+  // Whole-import comment/occasion (support ticket 2026-07-30): typed once,
+  // applied by the backend to every bottle this import creates — rows that
+  // carry their own note in the file keep it (fill-blank only).
+  const [importNotes, setImportNotes] = useState('');
+  const [importOccasion, setImportOccasion] = useState('');
 
   // Review step
   const [results, setResults] = useState([]);
@@ -891,7 +896,11 @@ function ImportBottles() {
     }
 
     try {
-      const res = await confirmImport(apiFetch, { cellarId, items, positionAnchor, rackConfigs, defaultCurrency: importCurrency });
+      const res = await confirmImport(apiFetch, {
+        cellarId, items, positionAnchor, rackConfigs, defaultCurrency: importCurrency,
+        importNotes: importNotes.trim() || undefined,
+        importOccasion: importOccasion.trim() || undefined,
+      });
       const data = await res.json();
 
       if (!res.ok) {
@@ -1196,6 +1205,33 @@ function ImportBottles() {
           profileCurrency={user?.preferences?.currency}
           anyRowHasCurrency={parsedItems.some(i => i.currency)}
         />
+      )}
+
+      {parsedItems.length > 0 && (
+        <div className="import-rack-options">
+          <h3>{t('importBottles.wholeImport.title')}</h3>
+          <p className="rack-options-hint">{t('importBottles.wholeImport.hint')}</p>
+          <div className="form-group">
+            <label>{t('importBottles.wholeImport.commentLabel')}</label>
+            <textarea
+              value={importNotes}
+              onChange={(e) => setImportNotes(e.target.value)}
+              placeholder={t('importBottles.wholeImport.commentPlaceholder')}
+              rows="2"
+              maxLength={5000}
+            />
+          </div>
+          <div className="form-group">
+            <label>{t('importBottles.wholeImport.occasionLabel')}</label>
+            <input
+              type="text"
+              value={importOccasion}
+              onChange={(e) => setImportOccasion(e.target.value)}
+              placeholder={t('importBottles.wholeImport.occasionPlaceholder')}
+              maxLength={500}
+            />
+          </div>
+        </div>
       )}
 
       {parsedItems.length > 0 && Object.keys(rackSummary).length > 0 && (


### PR DESCRIPTION
Two support tickets from the same user, both closed at the root.

## 1. "IA bottles known false" (2026-08-12) — honest scoping
The user owns 71 active bottles; the AI surfaces showed him ~11 and never said the rest existed.

- **Cellar chat**: the RAG context only ever contains the `chatMaxResults` (5) most relevant bottles, and the model was never told the cellar's true size. The context now leads with the active-bottle total (counted on the same scope as the search), tells the model the list is a selection, and distinguishes "empty search" from "empty cellar" (the old text let the model say the cellar had nothing in it).
- **`pair_with_dish` (MCP)**: screens the whole cellar, returns an 8+3 shortlist — the summary counted only the shortlist. It now leads with "Screened all N active bottle(s)" and tells the calling model to relay that. Same for `what_should_i_open_tonight`.

Tests: `aiChat.scoping.test.js` (new, 3 context shapes), 2 new summary pins in `drinkingTools.test.js`.

## 2. "Comment added when create a new bottle" (2026-07-30) — whole-import comment/occasion
The add-page half of this ticket shipped earlier (auto-open details, applies-to-all note). This delivers the promised import half: two optional fields on the upload screen — a comment and an occasion applied to **every bottle the import creates**. Fill-blank only (a row with its own note from the file keeps it), wishlist rows deliberately not stamped, sanitised + capped server-side (5000/500).

Tests: 5 new cases in `import.confirm.test.js` (both creation paths, fill-blank, caps/stripHtml, wishlist exclusion, non-string regression).

## Verification
- Backend: `aiChat.scoping` + `drinkingTools` + `import.confirm` — 41 tests, all passing (node:20-alpine).
- Frontend: vitest 912/912; production build clean.

No compose/env impact. GDPR: no new data category (notes/occasion are existing bottle fields; the cellar-total count is the user's own data in their own chat).