### PR TITLE
fix(registry): regenerate the slug when the producer changes — a URL must not misattribute the wine

### DIFF
--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -582,11 +582,16 @@ wineDefinitionSchema.statics.findFreeSlug = async function (base) {
  * Georges Premier Cru Cœur de Roches" and still served at /wines/coeur-de-roi.
  * A slug that states a name the wine does not have is a second wrong record.
  *
- * Narrow on purpose — this must fire on a real rename and nothing else:
+ * Narrow on purpose — this must fire on a real identity change and nothing else:
  *   - only when a slug already exists (assignment is shouldAssignSlug's job)
  *     and the doc is not new;
- *   - only when `name` was modified. A producer respelling folds away in
- *     generateWineSlug, and re-saving an untouched row must never churn;
+ *   - only when `name` or `producer` was modified. Producer matters just as
+ *     much as name: the slug is derived from BOTH, and a re-attribution left
+ *     the Trenza wine published at /wines/bodegas-juan-gil-… — the wrong
+ *     winery in the URL itself (found 2026-08-12). A producer RESPELLING that
+ *     folds to the same slug is caught by the base comparison below and never
+ *     churns, which is what the old name-only guard wrongly assumed it had to
+ *     protect against;
  *   - only when the slug would actually CHANGE. The current slug may be a
  *     disambiguated form of the same base ("cloudy-bay-2"), which is still the
  *     right slug for this name and must not be regenerated into "-3" on every
@@ -596,7 +601,7 @@ wineDefinitionSchema.statics.findFreeSlug = async function (base) {
 wineDefinitionSchema.statics.shouldRegenerateSlug = function (doc) {
   if (!doc.slug || doc.isNew) return false;
   if (doc.pendingIdentity === true) return false;
-  if (!doc.isModified('name')) return false;
+  if (!doc.isModified('name') && !doc.isModified('producer')) return false;
   const base = generateWineSlug(doc.name, doc.producer);
   if (!base || doc.slug === base) return false;
   if (doc.slug.startsWith(`${base}-`)) {

--- a/backend/src/models/WineDefinition.slugRename.test.js
+++ b/backend/src/models/WineDefinition.slugRename.test.js
@@ -50,10 +50,27 @@ describe('shouldRegenerateSlug', () => {
     expect(WineDefinition.shouldRegenerateSlug(loaded())).toBe(false);
   });
 
-  test('a PRODUCER respelling alone does not — it folds away in the slug anyway', () => {
+  test('a PRODUCER respelling alone does not — the base comparison folds it away', () => {
+    // Producer edits now ENTER the check (see the re-attribution test below);
+    // a respelling still never churns because the regenerated base is
+    // identical to the slug the wine already has.
     const doc = loaded();
     doc.producer = 'Frederic Magnien';
     expect(WineDefinition.shouldRegenerateSlug(doc)).toBe(false);
+  });
+
+  test('a producer RE-ATTRIBUTION regenerates — the slug carried the wrong winery', () => {
+    // THE ROW (2026-08-12): La Orphica corrected Juan Gil → Bodegas Trenza but
+    // kept serving at /wines/bodegas-juan-gil-la-orphica-monastrell — the wrong
+    // producer in the URL itself. The name-only guard is what produced it.
+    const doc = loaded({
+      name: 'La Orphica Monastrell',
+      producer: 'Bodegas Juan Gil',
+      slug: 'bodegas-juan-gil-la-orphica-monastrell',
+      normalizedKey: 'bodegas juan gil:la orphica monastrell:',
+    });
+    doc.producer = 'Bodegas Trenza';
+    expect(WineDefinition.shouldRegenerateSlug(doc)).toBe(true);
   });
 
   test('a rename that produces the SAME slug does not regenerate', () => {
@@ -119,6 +136,23 @@ describe('the outgoing slug stays alive', () => {
 
     expect(doc.slug).toBe('frederic-magnien-nuitssaintgeorges-premier-cru-cur-de-roches');
     expect(doc.previousSlugs).toEqual(['frederic-magnien-coeur-de-roi']);
+  });
+
+  test('a producer re-attribution redirects too: old slug onto previousSlugs, new one taken', async () => {
+    withFreeSlugs();
+    const doc = loaded({
+      name: 'La Orphica Monastrell',
+      producer: 'Bodegas Juan Gil',
+      slug: 'bodegas-juan-gil-la-orphica-monastrell',
+      normalizedKey: 'bodegas juan gil:la orphica monastrell:',
+    });
+    doc.producer = 'Bodegas Trenza';
+
+    await new Promise((resolve, reject) =>
+      doc.constructor.hooks.execPre('save', doc, (err) => (err ? reject(err) : resolve())));
+
+    expect(doc.slug).toBe('bodegas-trenza-la-orphica-monastrell');
+    expect(doc.previousSlugs).toEqual(['bodegas-juan-gil-la-orphica-monastrell']);
   });
 
   test('previousSlugs is bounded and never records the slug the wine currently has', async () => {


### PR DESCRIPTION
Somm finding 2026-08-12: wine 6a…7c9a87 was corrected Juan Gil → Bodegas Trenza but kept serving at `/wines/bodegas-juan-gil-la-orphica-monastrell` — the wrong winery in the URL itself.

## Root cause
`shouldRegenerateSlug` fired only on `name` edits, on the recorded assumption that producer changes 'fold away in the slug'. True for respellings (Frédéric → Frederic), false for re-attributions. The slug is derived from name **and** producer; only half of it was guarded.

## Fix
Producer edits now enter the check. The existing base comparison is what prevents respelling churn (regenerated base == current slug → no-op), the disambiguator guard (`-2`/hex tails) is untouched, and the outgoing slug lands in `previousSlugs`, so the old URL keeps resolving — same redirect contract as a rename. Pending rows still take no slug.

## Scale (prod scan, read-only)
**570 of 5,413 wines currently serve a stale slug** — the accumulated residue of every hook-bypassing correction campaign plus this gap (vintage-strip suffixes, corrected producer abbreviations, doubled producer names, unscrambled misreads). This PR stops the faucet; a data backfill (regenerate + previousSlugs redirect + IndexNow) is proposed separately.

## Tests
`WineDefinition.slugRename.test.js`: +2 pins (re-attribution regenerates; old slug lands in previousSlugs with the new one taken) and the respelling no-churn test re-anchored to the base comparison. 17/17 passing in node:20-alpine.