### PR TITLE
fix(registry): every appellation writer resolves against the curated registry

### DIFF
--- a/backend/src/mcp/adminRegistryTools.test.js
+++ b/backend/src/mcp/adminRegistryTools.test.js
@@ -81,6 +81,21 @@ describe('creation through the shared dedup chokepoint', () => {
       expect.objectContaining({ via: 'mcp', admin: true }));
   });
 
+  // Every appellation writer has to reach the curated-registry resolver. This
+  // one reaches it by DELEGATION: the appellation goes to findOrCreateWine
+  // untouched, and that chokepoint tier-strips + resolves before keying and
+  // storing. The pin is that this tool never canonicalizes on its own — a
+  // second copy of the rule here is exactly how the surfaces drift apart.
+  test('the appellation is handed to the resolving chokepoint RAW, not pre-normalized', async () => {
+    findOrCreateWine.mockResolvedValue({ wine: WINE, created: true });
+    await tool('admin_add_registry_wine').handler(
+      { name: 'Barrica', producer: 'Castaño', country: 'Spain', appellation: 'Yecla DO', type: 'red' }, ADMIN_CTX
+    );
+    expect(findOrCreateWine).toHaveBeenCalledWith(
+      expect.objectContaining({ appellation: 'Yecla DO' }), oid('a'), expect.anything()
+    );
+  });
+
   test('soft-zone candidates → conflict listing ids, nothing created', async () => {
     findOrCreateWine.mockResolvedValue({ wine: null, candidates: [{ wine: WINE, score: 0.89 }] });
     const res = await tool('admin_add_registry_wine').handler(

--- a/backend/src/mcp/tools/adminRegistry.js
+++ b/backend/src/mcp/tools/adminRegistry.js
@@ -66,6 +66,12 @@ registerTool({
       const { findOrCreateWine } = require('../../services/findOrCreateWine');
       let result;
       try {
+        // The appellation is handed over RAW on purpose. findOrCreateWine is
+        // the mint chokepoint and already tier-strips AND resolves it against
+        // the curated registry before keying and storing; pre-canonicalizing
+        // here would only add a second, driftable copy of that rule (the
+        // admin REST create has to do it itself precisely because it writes
+        // the WineDefinition directly instead of coming through here).
         result = await findOrCreateWine({
           name: args.name,
           producer: args.producer,

--- a/backend/src/models/Appellation.js
+++ b/backend/src/models/Appellation.js
@@ -50,6 +50,12 @@ const appellationSchema = new mongoose.Schema({
 
 // No two appellations with the same name in the same country
 appellationSchema.index({ country: 1, normalizedName: 1 }, { unique: true });
+// The resolver's country-less lookup ($or on normalizedName/normalizedSynonyms)
+// cannot use the compound above (country prefix) — without this it collscans,
+// and the membership-gated stripping now issues up to 5 lookups per decorated
+// input, on a path every bottle-add hits (release-audit LOW-1). Cheap at ~1k
+// docs, load-bearing if the taxonomy grows.
+appellationSchema.index({ normalizedName: 1 });
 
 // Keep normalizedSynonyms in lockstep with synonyms — same hook as Grape, so
 // every save-based admin edit maintains what the write-time lookup matches.

--- a/backend/src/routes/admin/import.appellationKeys.test.js
+++ b/backend/src/routes/admin/import.appellationKeys.test.js
@@ -1,0 +1,67 @@
+/**
+ * Import taxonomy keying + upsert identity (release-audit F1 + F3 on PR #951).
+ *
+ * F1: getOrCreateAppellation must key Appellation docs with
+ * normalizeAppellationKey (hyphens → spaces), the convention every other
+ * creator and every lookup uses. It keyed with normalizeString (hyphens
+ * deleted), so a CSV mentioning any hyphenated curated name — most of
+ * Burgundy — missed the curated doc and upserted an invisible twin. Both
+ * release auditors found this independently.
+ *
+ * F3: the curated-spelling resolve moves dedup keys ("… Yecla DO" →
+ * "… Yecla"), so the bulkWrite upsert filter must also match the PRE-RESOLVE
+ * key or a re-import of an old file mints duplicate wines.
+ */
+
+jest.mock('../../services/search', () => ({ fullSync: jest.fn(), indexWine: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../models/WineDefinition', () => ({ findById: jest.fn(), findOne: jest.fn(), bulkWrite: jest.fn() }));
+jest.mock('../../models/Country', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../../models/Region', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../../models/Appellation', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+
+const Appellation = require('../../models/Appellation');
+const { getOrCreateAppellation, buildUpsertFilter } = require('./import');
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getOrCreateAppellation — F1: the keying convention', () => {
+  test('keys with the hyphen-folding form, so a curated "Nuits-Saint-Georges" is FOUND, not twinned', async () => {
+    Appellation.findOneAndUpdate.mockResolvedValue({ _id: 'ap1' });
+
+    await getOrCreateAppellation('Nuits-Saint-Georges', 'FR', null, 'u1', new Map());
+
+    expect(Appellation.findOneAndUpdate).toHaveBeenCalledWith(
+      { country: 'FR', normalizedName: 'nuits saint georges' },
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test('spaced and hyphenated spellings of one name produce the SAME key', async () => {
+    Appellation.findOneAndUpdate.mockResolvedValue({ _id: 'ap1' });
+
+    await getOrCreateAppellation('Chateauneuf du Pape', 'FR', null, 'u1', new Map());
+    await getOrCreateAppellation('Châteauneuf-du-Pape', 'FR', null, 'u1', new Map());
+
+    const keys = Appellation.findOneAndUpdate.mock.calls.map(([filter]) => filter.normalizedName);
+    expect(keys[0]).toBe(keys[1]);
+  });
+});
+
+describe('buildUpsertFilter — F3: re-import identity', () => {
+  test('a resolved row also matches its pre-resolve key', () => {
+    expect(buildUpsertFilter({ normalizedKey: 'p:w:yecla', legacyKey: 'p:w:yecla do', lwin7: null }))
+      .toEqual({ $or: [{ normalizedKey: 'p:w:yecla' }, { normalizedKey: 'p:w:yecla do' }] });
+  });
+
+  test('unresolved rows keep the plain single-key filter — no behavior change', () => {
+    expect(buildUpsertFilter({ normalizedKey: 'p:w:barolo', legacyKey: null, lwin7: null }))
+      .toEqual({ normalizedKey: 'p:w:barolo' });
+  });
+
+  test('LWIN7 still rides the $or alongside both keys', () => {
+    expect(buildUpsertFilter({ normalizedKey: 'a', legacyKey: 'b', lwin7: '1234567' }))
+      .toEqual({ $or: [{ normalizedKey: 'a' }, { normalizedKey: 'b' }, { 'lwin.lwin7': '1234567' }] });
+  });
+});

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -10,6 +10,7 @@ const Country = require('../../models/Country');
 const Region = require('../../models/Region');
 const Appellation = require('../../models/Appellation');
 const { logAudit } = require('../../services/audit');
+const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const searchService = require('../../services/search');
 
 const router = express.Router();
@@ -233,6 +234,20 @@ async function getOrCreateAppellation(name, countryId, regionId, userId, cache) 
   return doc._id;
 }
 
+/**
+ * Adopt the curated display spelling for an imported appellation string,
+ * memoized per import run. Falsy in / falsy out, and the resolver itself never
+ * throws — an unknown CSV spelling passes through verbatim and lands in the
+ * admin unmatched queue, exactly like every other write surface.
+ */
+async function resolveImportAppellation(name, cache) {
+  if (!name) return name;
+  if (cache.has(name)) return cache.get(name);
+  const resolved = await resolveCanonicalAppellation(name);
+  cache.set(name, resolved);
+  return resolved;
+}
+
 const BATCH_SIZE = 500;
 
 // ── Route ─────────────────────────────────────────────────────────────────────
@@ -262,6 +277,7 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
   const countryCache = new Map();
   const regionCache = new Map();
   const appellationCache = new Map();
+  const appellationSpellingCache = new Map();
 
   // Auto-detect delimiter and whether a header row is present.
   // Strip BOM before inspecting — some LWIN exports include a UTF-8 BOM.
@@ -419,6 +435,14 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
         // producer "Vajra") mints the producer-in-name shape the admin tool
         // then has to clean up (registry audit 2026-07-26).
         mapped.name = canonicalizeWineName(mapped.name, mapped.producer);
+        // Curated-registry resolve, same reason as the name canon: parseRow is
+        // sync so it can only tier-strip, and this path bulkWrites directly
+        // instead of going through findOrCreateWine — so without the resolver a
+        // CSV column spelling both lands on the wine AND mints a duplicate
+        // Appellation doc through getOrCreateAppellation below. Cached like
+        // every other taxonomy lookup here: LWIN dumps repeat a few thousand
+        // appellation strings across hundreds of thousands of rows.
+        mapped.appellation = await resolveImportAppellation(mapped.appellation, appellationSpellingCache);
 
         const countryId = await getOrCreateCountry(mapped.country, userId, countryCache);
         const regionId = await getOrCreateRegion(mapped.region, countryId, userId, regionCache);
@@ -603,3 +627,7 @@ module.exports.finalizeMintedWines = finalizeMintedWines;
 // recovery keeps a mid-batch duplicate-key from discarding up to 499
 // created wines' stats and invariants (audit 2026-08-03 H1).
 module.exports.applyBulkWriteError = applyBulkWriteError;
+// resolveImportAppellation exported for its unit tests — parseRow is sync and
+// can only tier-strip, so this is the ONLY place the import adopts the curated
+// registry spelling before it both stores the string and mints the taxonomy doc.
+module.exports.resolveImportAppellation = resolveImportAppellation;

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -2,7 +2,7 @@ const express = require('express');
 const multer = require('multer');
 const { parse } = require('csv-parse');
 const { requireAuth, requireRole } = require('../../middleware/auth');
-const { generateWineKey, generateWineSlug, normalizeString, normalizeAppellation, resolveCountryName, isRecognizedCountry, isUnknownName, sanitizeTaxonomyName } = require('../../utils/normalize');
+const { generateWineKey, generateWineSlug, normalizeString, normalizeAppellation, normalizeAppellationKey, resolveCountryName, isRecognizedCountry, isUnknownName, sanitizeTaxonomyName } = require('../../utils/normalize');
 const { canonicalizeWineName } = require('../../utils/producerPrefix');
 const { computeCanonicalKey } = require('../../utils/wineIdentity');
 const WineDefinition = require('../../models/WineDefinition');
@@ -216,7 +216,16 @@ async function getOrCreateAppellation(name, countryId, regionId, userId, cache) 
   const key = `${countryId}:${name.toLowerCase().trim()}`;
   if (cache.has(key)) return cache.get(key);
 
-  const normalized = normalizeString(name);
+  // normalizeAppellationKey, NOT normalizeString (release-audit F1/MEDIUM-1,
+  // both auditors independently): every other Appellation creator and every
+  // lookup — the resolver, taxonomyReview, the backfill script — keys with
+  // the hyphen-folding form. normalizeString deletes hyphens without a space
+  // ("Nuits-Saint-Georges" → 'nuitssaintgeorges'), so keying here with it
+  // MISSED every hyphenated curated doc and upserted an invisible twin —
+  // which got worse, not better, once line ~445 started resolving spellings
+  // to their canonical (hyphenated) forms. Country/Region above keep
+  // normalizeString: that IS their collections' convention.
+  const normalized = normalizeAppellationKey(name);
   const doc = await Appellation.findOneAndUpdate(
     { country: countryId, normalizedName: normalized },
     {
@@ -324,10 +333,8 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
     const rows = batch;
     batch = [];
 
-    const ops = rows.map(({ mapped, countryId, regionId, normalizedKey }) => {
-      const filter = mapped.lwin7
-        ? { $or: [{ normalizedKey }, { 'lwin.lwin7': mapped.lwin7 }] }
-        : { normalizedKey };
+    const ops = rows.map(({ mapped, countryId, regionId, normalizedKey, legacyKey }) => {
+      const filter = buildUpsertFilter({ normalizedKey, legacyKey, lwin7: mapped.lwin7 });
 
       // Wrap user-derived CSV values in $literal: in an aggregation update
       // pipeline a string beginning with '$' is otherwise evaluated as a field
@@ -442,14 +449,24 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
         // Appellation doc through getOrCreateAppellation below. Cached like
         // every other taxonomy lookup here: LWIN dumps repeat a few thousand
         // appellation strings across hundreds of thousands of rows.
+        const preResolveAppellation = mapped.appellation;
         mapped.appellation = await resolveImportAppellation(mapped.appellation, appellationSpellingCache);
 
         const countryId = await getOrCreateCountry(mapped.country, userId, countryCache);
         const regionId = await getOrCreateRegion(mapped.region, countryId, userId, regionCache);
         await getOrCreateAppellation(mapped.appellation, countryId, regionId, userId, appellationCache);
         const normalizedKey = generateWineKey(mapped.name, mapped.producer, mapped.appellation || '');
+        // Resolution moves the dedup key ("… Yecla DO" → "… Yecla"), so a
+        // re-import of a file whose rows this import minted BEFORE the
+        // resolver existed would miss them and upsert twins (release-audit
+        // F3). The pre-resolve key rides into the upsert filter's $or so the
+        // old rows still match; findOrCreateWine's sibling net gives every
+        // other path this protection, but the bulkWrite has only its filter.
+        const legacyKey = mapped.appellation !== preResolveAppellation
+          ? generateWineKey(mapped.name, mapped.producer, preResolveAppellation || '')
+          : null;
 
-        batch.push({ mapped, countryId, regionId, normalizedKey, rowIndex });
+        batch.push({ mapped, countryId, regionId, normalizedKey, legacyKey, rowIndex });
 
         if (batch.length >= BATCH_SIZE) {
           await flush();
@@ -514,6 +531,21 @@ router.post('/wines', csvUpload.single('file'), async (req, res) => {
  * @param {object} stats running import stats (mutated)
  * @returns {object|null} the partial BulkWriteResult to credit, or null
  */
+/**
+ * The upsert filter for one import row. Three identities may name an existing
+ * row: the current dedup key, the PRE-RESOLVE key (release-audit F3 — the
+ * curated-spelling resolve moved keys, and a re-import of a file whose rows
+ * were minted before the resolver must still match them rather than upsert
+ * twins), and the LWIN7 (stable across every spelling change). Pure and
+ * exported for tests.
+ */
+function buildUpsertFilter({ normalizedKey, legacyKey, lwin7 }) {
+  const orKeys = [{ normalizedKey }];
+  if (legacyKey) orKeys.push({ normalizedKey: legacyKey });
+  if (lwin7) orKeys.push({ 'lwin.lwin7': lwin7 });
+  return orKeys.length > 1 ? { $or: orKeys } : { normalizedKey };
+}
+
 function applyBulkWriteError(err, rows, stats) {
   const failRow = (rowIndex, reason) => {
     stats.total--;
@@ -631,3 +663,8 @@ module.exports.applyBulkWriteError = applyBulkWriteError;
 // can only tier-strip, so this is the ONLY place the import adopts the curated
 // registry spelling before it both stores the string and mints the taxonomy doc.
 module.exports.resolveImportAppellation = resolveImportAppellation;
+// Test seams for the release-audit F1/F3 fixes: the Appellation-doc keying
+// convention and the legacy-key upsert filter are exactly the kind of quiet
+// contract a refactor breaks without noticing.
+module.exports.getOrCreateAppellation = getOrCreateAppellation;
+module.exports.buildUpsertFilter = buildUpsertFilter;

--- a/backend/src/routes/admin/import.mapRow.test.js
+++ b/backend/src/routes/admin/import.mapRow.test.js
@@ -10,8 +10,10 @@
 
 jest.mock('../../services/search', () => ({ fullSync: jest.fn(), indexWine: jest.fn() }));
 jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/appellationResolve', () => ({ resolveCanonicalAppellation: jest.fn() }));
 
-const { mapRow } = require('./import');
+const { mapRow, resolveImportAppellation } = require('./import');
+const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 
 const lwinRow = (over = {}) => ({
   LWIN: '1234567',
@@ -69,5 +71,37 @@ describe('mapRow (lwin) — appellation tier strip', () => {
     expect(mapRow(lwinRow({ SUB_REGION: 'Barolo DOCG' }), 'lwin').appellation).toBe('Barolo');
     expect(mapRow(lwinRow({ SUB_REGION: 'DO Alicante' }), 'lwin').appellation).toBe('Alicante');
     expect(mapRow(lwinRow({ SUB_REGION: 'NA' }), 'lwin').appellation).toBeNull();
+  });
+});
+
+// mapRow is sync, so it can only TIER-STRIP; the curated-registry resolve
+// happens in the async per-row loop, and this helper is that step. Without it
+// a CSV spelling both lands on the wine and mints a duplicate Appellation doc
+// through getOrCreateAppellation.
+describe('resolveImportAppellation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveCanonicalAppellation.mockImplementation(async (v) => (v === 'Yecla DO' ? 'Yecla' : v));
+  });
+
+  test('the row keeps the RESOLVER\'s spelling, not the tier-stripped CSV one', async () => {
+    const cache = new Map();
+    expect(await resolveImportAppellation('Yecla DO', cache)).toBe('Yecla');
+    expect(resolveCanonicalAppellation).toHaveBeenCalledWith('Yecla DO');
+  });
+
+  test('falsy in, falsy out — no lookup for a row without an appellation', async () => {
+    const cache = new Map();
+    expect(await resolveImportAppellation(null, cache)).toBeNull();
+    expect(await resolveImportAppellation('', cache)).toBe('');
+    expect(resolveCanonicalAppellation).not.toHaveBeenCalled();
+  });
+
+  test('memoized per import run — an LWIN dump repeats a few thousand strings over ~100k rows', async () => {
+    const cache = new Map();
+    await resolveImportAppellation('Yecla DO', cache);
+    await resolveImportAppellation('Yecla DO', cache);
+    await resolveImportAppellation('Yecla DO', cache);
+    expect(resolveCanonicalAppellation).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/routes/admin/wineProposals.js
+++ b/backend/src/routes/admin/wineProposals.js
@@ -36,6 +36,7 @@ const { submitUrls } = require('../../services/indexNow');
 const searchService = require('../../services/search');
 const { reembedActiveVintages } = require('../../services/embeddingJob');
 const { findOrCreateRegion } = require('../../services/findOrCreateWine');
+const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const { performWineMerge } = require('./wines');
 const { generateWineKey, normalizeAppellation, normalizeString, resolveCountryName } = require('../../utils/normalize');
 const { parsePagination } = require('../../utils/pagination');
@@ -202,7 +203,15 @@ router.post('/:id/approve', async (req, res) => {
         if (pf.name) { wine.name = pf.name.trim(); applied.push('name'); }
         if (pf.producer) { wine.producer = pf.producer.trim(); applied.push('producer'); }
         if (pf.classification) { wine.classification = pf.classification.trim(); applied.push('classification'); }
-        if (pf.appellation) { wine.appellation = normalizeAppellation(pf.appellation.trim()); applied.push('appellation'); }
+        if (pf.appellation) {
+          // Tier-strip AND curated-registry resolve. Approving a proposal is a
+          // registry WRITE, so it owes the same canonicalization as the mint
+          // chokepoint: without the resolver a somm's "Yecla DO" landed
+          // verbatim on the wine (prod, 2026-08-12) because the trailing "DO"
+          // is deliberately outside normalizeAppellation's token set.
+          wine.appellation = await resolveCanonicalAppellation(normalizeAppellation(pf.appellation.trim()));
+          applied.push('appellation');
+        }
 
         let countryDoc = null;
         if (pf.country) {

--- a/backend/src/routes/admin/wineProposals.test.js
+++ b/backend/src/routes/admin/wineProposals.test.js
@@ -29,6 +29,9 @@ jest.mock('../../services/indexNow', () => ({ submitUrls: jest.fn() }));
 jest.mock('../../services/search', () => ({ indexWine: jest.fn(), bulkIndexBottles: jest.fn() }));
 jest.mock('../../services/embeddingJob', () => ({ reembedActiveVintages: jest.fn().mockResolvedValue(undefined) }));
 jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateRegion: jest.fn() }));
+// Identity by default so the tier-strip assertions below still read the
+// normalizeAppellation output; the curated-registry test overrides it.
+jest.mock('../../services/appellationResolve', () => ({ resolveCanonicalAppellation: jest.fn(async (v) => v) }));
 // The extracted merge helper — the whole point of the extraction is that this
 // route invokes IT rather than re-implementing the machinery.
 jest.mock('./wines', () => ({ performWineMerge: jest.fn() }));
@@ -42,6 +45,7 @@ const WineVintageProfile = require('../../models/WineVintageProfile');
 const Bottle = require('../../models/Bottle');
 const Country = require('../../models/Country');
 const { performWineMerge } = require('./wines');
+const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const searchService = require('../../services/search');
 const { generateWineKey } = require('../../utils/normalize');
 const adminWineProposalsRouter = require('./wineProposals');
@@ -154,6 +158,24 @@ describe('POST /:id/approve', () => {
     // The receipt lands on the row.
     const noteSet = WineCorrectionProposal.updateOne.mock.calls.at(-1);
     expect(noteSet[1].$set.appliedNote).toMatch(/Applied/);
+  });
+
+  // The "Yecla DO" case (prod, 2026-08-12): approving a proposal used to store
+  // the tier-stripped string directly, so a decoration normalizeAppellation
+  // deliberately cannot strip survived onto the wine. The stored value must
+  // now come from the curated-registry resolver, not from the normalizer.
+  test('field_correction: the STORED appellation is the resolver\'s canonical spelling', async () => {
+    resolveCanonicalAppellation.mockResolvedValueOnce('Yecla');
+    claim({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { appellation: ' Yecla DO ' } });
+    const wine = { _id: W1, name: 'Barrica', producer: 'Castaño', appellation: null, country: 'c1', save: jest.fn().mockResolvedValue(undefined) };
+    WineDefinition.findById.mockResolvedValue(wine);
+
+    const res = await post(`/${P1}/approve`);
+    expect(res.status).toBe(200);
+    // Trimmed + tier-stripped on the way IN, canonical spelling on the way OUT.
+    expect(resolveCanonicalAppellation).toHaveBeenCalledWith('Yecla DO');
+    expect(wine.appellation).toBe('Yecla');
+    expect(wine.normalizedKey).toBe(generateWineKey('Barrica', 'Castaño', 'Yecla'));
   });
 
   test('field_correction E11000 → 409 "merge instead" and the claim is REVERTED (no half-approved state)', async () => {

--- a/backend/src/routes/admin/wineRequests.dedup.test.js
+++ b/backend/src/routes/admin/wineRequests.dedup.test.js
@@ -20,6 +20,9 @@ jest.mock('../../models/WineDefinition', () => {
 jest.mock('../../models/Bottle', () => ({ distinct: jest.fn(), updateMany: jest.fn() }));
 jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
 jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+// Identity by default so the tier-strip assertion below reads the
+// normalizeAppellation output; the curated-registry test overrides it.
+jest.mock('../../services/appellationResolve', () => ({ resolveCanonicalAppellation: jest.fn(async (v) => v) }));
 jest.mock('../../services/search', () => ({ indexWine: jest.fn() }));
 jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../../services/notifications', () => ({ createNotification: jest.fn() }));
@@ -34,6 +37,7 @@ const WineDefinition = require('../../models/WineDefinition');
 const Bottle = require('../../models/Bottle');
 const Country = require('../../models/Country');
 const { findOrCreateWine } = require('../../services/findOrCreateWine');
+const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const wineRequestsRouter = require('./wineRequests');
 
 const ADMIN_ID = '64b000000000000000000001';
@@ -119,6 +123,25 @@ test('clean create canonicalizes name + appellation and stamps createdVia ui', a
   expect(doc.appellation).toBe('Barolo');       // tier suffix stripped (the missed v1.85.0 fix)
   expect(doc.createdVia).toBe('ui');
   expect(requestDoc.save).toHaveBeenCalled();
+});
+
+// Tier-stripping alone is not enough: this branch builds the WineDefinition
+// itself, so approving a request has to run the curated-registry resolver or
+// it mints a decorated variant of an appellation the taxonomy already holds.
+test('the STORED appellation is the resolver\'s canonical spelling', async () => {
+  resolveCanonicalAppellation.mockResolvedValueOnce('Yecla');
+
+  const res = await resolve({ ...CREATE_BODY, wineData: { ...CREATE_BODY.wineData, appellation: ' Yecla DO ' } });
+  expect(res.status).toBe(200);
+
+  expect(resolveCanonicalAppellation).toHaveBeenCalledWith('Yecla DO');
+  const doc = WineDefinition.mock.calls[0][0];
+  expect(doc.appellation).toBe('Yecla');
+  // The probe is keyed off the resolved value too, so the dedup match sees the
+  // same string the registry already stores.
+  expect(findOrCreateWine).toHaveBeenCalledWith(
+    expect.objectContaining({ appellation: 'Yecla' }), ADMIN_ID, { matchOnly: true }
+  );
 });
 
 test('confirmCreate skips the probe (explicit "create anyway")', async () => {

--- a/backend/src/routes/admin/wineRequests.js
+++ b/backend/src/routes/admin/wineRequests.js
@@ -7,6 +7,7 @@ const { generateWineKey, normalizeAppellation } = require('../../utils/normalize
 const { canonicalizeWineName } = require('../../utils/producerPrefix');
 const Country = require('../../models/Country');
 const { findOrCreateWine } = require('../../services/findOrCreateWine');
+const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const searchService = require('../../services/search');
 const { logAudit } = require('../../services/audit');
 const { createNotification } = require('../../services/notifications');
@@ -118,7 +119,13 @@ router.put('/:id/resolve', async (req, res) => {
 
       const cleanProducer = producer.trim();
       const cleanName = canonicalizeWineName(name, cleanProducer);
-      const cleanAppellation = normalizeAppellation(typeof appellation === 'string' ? appellation.trim() : null) || null;
+      // Tier-strip AND curated-registry resolve — this branch bulk-builds the
+      // WineDefinition itself rather than going through findOrCreateWine, so
+      // the resolver has to be called explicitly or an approved request mints
+      // a spelling variant of an already-curated appellation.
+      const cleanAppellation = await resolveCanonicalAppellation(
+        normalizeAppellation(typeof appellation === 'string' ? appellation.trim() : null)
+      ) || null;
 
       if (!req.body.confirmCreate) {
         const countryDoc = await Country.findById(String(country)).select('name').lean().catch(() => null);

--- a/backend/src/routes/admin/wines.dedup.test.js
+++ b/backend/src/routes/admin/wines.dedup.test.js
@@ -8,6 +8,11 @@
  * matcher (matchOnly) and 409s with candidates unless confirmCreate is given,
  * and stores canonicalized fields + createdVia provenance. This suite pins
  * that gate.
+ *
+ * It also pins the appellation CANONICALIZATION on both admin write surfaces
+ * (POST and PUT): both write the WineDefinition directly rather than through
+ * findOrCreateWine, so both must call the curated-registry resolver themselves
+ * or the admin surfaces reintroduce spelling variants the mint path folds.
  */
 
 process.env.JWT_SECRET = 'test-secret';
@@ -20,7 +25,7 @@ jest.mock('../../models/WineDefinition', () => {
   ctor.countDocuments = jest.fn();
   return ctor;
 });
-jest.mock('../../models/Bottle', () => ({ aggregate: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../../models/Bottle', () => ({ aggregate: jest.fn(), countDocuments: jest.fn(), distinct: jest.fn() }));
 jest.mock('../../models/BottleImage', () => ({}));
 jest.mock('../../models/WineVintageProfile', () => ({}));
 jest.mock('../../models/WineVintagePrice', () => ({}));
@@ -44,10 +49,13 @@ jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
 jest.mock('../../services/vectorStore', () => ({}));
 jest.mock('../../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
 jest.mock('../../services/embeddingJob', () => ({ embedSinglePair: jest.fn() }));
-jest.mock('../../services/search', () => ({ indexWine: jest.fn(), removeWine: jest.fn() }));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn(), removeWine: jest.fn(), bulkIndexBottles: jest.fn() }));
 jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../../services/indexNow', () => ({ submitUrls: jest.fn() }));
 jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+// Identity by default so the tier-strip assertion below reads the
+// normalizeAppellation output; the curated-registry test overrides it.
+jest.mock('../../services/appellationResolve', () => ({ resolveCanonicalAppellation: jest.fn(async (v) => v) }));
 
 const express = require('express');
 const http = require('http');
@@ -57,6 +65,7 @@ const WineNotDuplicate = require('../../models/WineNotDuplicate');
 const Bottle = require('../../models/Bottle');
 const Country = require('../../models/Country');
 const { findOrCreateWine } = require('../../services/findOrCreateWine');
+const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const { generateWineKey } = require('../../utils/normalize');
 const adminWinesRouter = require('./wines');
 
@@ -146,6 +155,48 @@ test('no probe hit creates with canonicalized fields + createdVia ui', async () 
   expect(doc.appellation).toBe('Bannockburn'); // tier suffix stripped
   expect(doc.createdVia).toBe('ui');
   expect(doc.normalizedKey).toBe(generateWineKey('Block 3 Pinot Noir', 'Felton Road Wines Ltd', 'Bannockburn'));
+});
+
+// The admin create writes the WineDefinition itself, so the curated-registry
+// resolve has to happen HERE — one resolution serving the dedup probe, the
+// normalizedKey and the stored field, or the admin surface reintroduces the
+// spelling variants the mint chokepoint folds.
+test('the STORED appellation is the resolver\'s canonical spelling, and the probe sees it too', async () => {
+  resolveCanonicalAppellation.mockResolvedValueOnce('Yecla');
+
+  const res = await postWine({ ...BODY, appellation: 'Yecla DO' });
+  expect(res.status).toBe(201);
+
+  expect(resolveCanonicalAppellation).toHaveBeenCalledWith('Yecla DO');
+  const doc = WineDefinition.mock.calls[0][0];
+  expect(doc.appellation).toBe('Yecla');
+  expect(doc.normalizedKey).toBe(generateWineKey('Block 3 Pinot Noir', 'Felton Road Wines Ltd', 'Yecla'));
+  expect(findOrCreateWine).toHaveBeenCalledWith(
+    expect.objectContaining({ appellation: 'Yecla' }), ADMIN_ID, { matchOnly: true }
+  );
+});
+
+// The PUT is the everyday admin edit surface and the second direct writer in
+// this file — same rule, separately pinned.
+test('PUT stores the resolver\'s canonical spelling and keys off it', async () => {
+  resolveCanonicalAppellation.mockResolvedValueOnce('Bordeaux');
+  const wine = {
+    _id: 'wine-1', name: 'Le Petit', producer: 'Ch. Test', appellation: 'old',
+    save: jest.fn().mockResolvedValue(undefined), populate: jest.fn().mockResolvedValue(undefined),
+  };
+  WineDefinition.findById.mockResolvedValue(wine);
+  Bottle.distinct.mockResolvedValue([]);
+
+  const res = await fetch(`${baseUrl}/api/admin/wines/64b0000000000000000000b1`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+    body: JSON.stringify({ appellation: '  Appellation Bordeaux Contrôlée  ' }),
+  });
+  expect(res.status).toBe(200);
+
+  expect(resolveCanonicalAppellation).toHaveBeenCalledWith('Appellation Bordeaux Contrôlée');
+  expect(wine.appellation).toBe('Bordeaux');
+  expect(wine.normalizedKey).toBe(generateWineKey('Le Petit', 'Ch. Test', 'Bordeaux'));
 });
 
 test('confirmCreate skips the probe entirely (explicit "create anyway")', async () => {

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -11,6 +11,7 @@ const {
   normalizeProducerKey,
   normalizeAppellation
 } = require('../../utils/normalize');
+const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const { scoreWineMatch } = require('../../services/wineMatching');
 const { sameProducerAppellationGroups, nearProducerPairs } = require('../../services/registryFragmentation');
 const WineDefinition = require('../../models/WineDefinition');
@@ -172,7 +173,13 @@ router.post('/', async (req, res) => {
 
     const cleanProducer = producer.trim();
     const cleanName = canonicalizeWineName(name, cleanProducer);
-    const cleanAppellation = normalizeAppellation(typeof appellation === 'string' ? appellation.trim() : null) || null;
+    // Resolved, not just tier-stripped: this branch writes the WineDefinition
+    // directly, so without the curated-registry lookup an admin create
+    // reintroduces the spelling variants the mint chokepoint folds. One
+    // resolution serves the dedup probe, the key and the stored field.
+    const cleanAppellation = await resolveCanonicalAppellation(
+      normalizeAppellation(typeof appellation === 'string' ? appellation.trim() : null)
+    ) || null;
 
     if (!confirmCreate) {
       const countryDoc = await Country.findById(String(country)).select('name').lean().catch(() => null);
@@ -1244,7 +1251,9 @@ router.put('/:id', async (req, res) => {
     if (producer) wine.producer = producer.trim();
     if (country) wine.country = country;
     if (region !== undefined) wine.region = region || null;
-    if (appellation !== undefined) wine.appellation = normalizeAppellation(appellation?.trim());
+    if (appellation !== undefined) {
+      wine.appellation = await resolveCanonicalAppellation(normalizeAppellation(appellation?.trim()));
+    }
     if (grapes !== undefined) wine.grapes = grapes;
     if (type) wine.type = type;
 

--- a/backend/src/routes/somm/pendingWines.test.js
+++ b/backend/src/routes/somm/pendingWines.test.js
@@ -42,6 +42,12 @@ jest.mock('../../services/findOrCreateWine', () => ({
 jest.mock('../../services/crossFieldScan', () => ({
   detectCrossFieldForValues: jest.fn().mockResolvedValue(null),
 }));
+// Same reason: the appellation a curator writes is resolved against the curated
+// registry, and that lookup must not reach the real Appellation collection here.
+// The resolve itself is pinned in services/pendingWineOps.identityGates.test.js.
+jest.mock('../../services/appellationResolve', () => ({
+  resolveCanonicalAppellation: jest.fn(async (v) => v),
+}));
 jest.mock('../../services/wineProfileOps', () => ({
   resolveGrapeIdsStrict: jest.fn(),
   GRAPES_MAX: 20,

--- a/backend/src/services/appellationResolve.js
+++ b/backend/src/services/appellationResolve.js
@@ -19,9 +19,109 @@
  * and oddities like "Vin de France" are legitimate), so an unknown value is
  * REVIEWED (admin unmatched queue), never rejected — a user adding a bottle
  * must not be blocked by taxonomy.
+ *
+ * MEMBERSHIP-GATED DECORATION STRIPPING (2026-08-12). Some label decorations
+ * cannot be stripped BLINDLY by normalizeAppellation, because the tokens
+ * collide with real place names: a trailing "do" is a Spanish/Portuguese tier
+ * mark in "Yecla DO" and an ordinary word inside "Ribera del Duero"-style
+ * names, and "Appellation … Contrôlée" wraps a name that is itself the
+ * appellation. utils/normalize therefore leaves them alone on purpose — a
+ * blind strip there would corrupt legitimate names with no way to tell.
+ *
+ * The resolver CAN strip them, because it does not have to be right on its
+ * own: a stripped variant is only ever ADOPTED when it matches a curated doc,
+ * and what gets stored is the DOC's canonical spelling, never the stripped raw
+ * string. Membership is the safety net — a real name that happens to end in a
+ * stripped token simply matches nothing and passes through verbatim, exactly
+ * as before. That asymmetry is why the stripping lives here and not in
+ * utils/normalize, whose output is stored unconditionally.
+ *
+ * Found in prod: a somm proposal wrote appellation "Yecla DO" through the
+ * proposal-approval path — the trailing "DO" survived normalizeAppellation
+ * (deliberately) and no resolver ran, so a decorated variant of the curated
+ * "Yecla" landed on the wine and fragmented it from every sibling.
  */
 const Appellation = require('../models/Appellation');
 const { normalizeAppellationKey } = require('../utils/normalize');
+
+// The AOC/AOP wrapper, in the accent-folded, punctuation-stripped shape
+// normalizeAppellationKey produces ("Contrôlée" → 'controlee', "d'Origine" →
+// 'dorigine'). Trailing-only for the tier adjective and leading-only for the
+// "Appellation" head, matching how the phrase is actually written on labels.
+const AOC_TRAILING_TOKENS = new Set(['controlee', 'protegee']);
+
+/** Trailing "DO" tier mark — the one normalizeAppellation cannot safely drop. */
+const stripTrailingDo = (tokens) =>
+  tokens.length > 1 && tokens[tokens.length - 1] === 'do' ? tokens.slice(0, -1) : null;
+
+/**
+ * "Appellation [d'Origine] X Contrôlée/Protégée" → X. Returns null when the
+ * input carries no wrapper, so the caller only pays for a lookup when there is
+ * actually something to try.
+ */
+function stripAocWrapper(tokens) {
+  const out = tokens.slice();
+  let stripped = false;
+  if (out.length > 1 && out[0] === 'appellation') {
+    out.shift();
+    stripped = true;
+    // "d'Origine" folds to one token; a spaced "d Origine" folds to two.
+    if (out.length > 1 && out[0] === 'dorigine') out.shift();
+    else if (out.length > 2 && out[0] === 'd' && out[1] === 'origine') out.splice(0, 2);
+  }
+  while (out.length > 1 && AOC_TRAILING_TOKENS.has(out[out.length - 1])) {
+    out.pop();
+    stripped = true;
+  }
+  return stripped && out.length > 0 ? out : null;
+}
+
+/**
+ * Lookup keys to try, most faithful first: the string as typed, then the
+ * decoration-stripped variants. First MATCH wins, so a curated name that
+ * genuinely ends in "DO" is found by the exact key and never reaches the
+ * stripped one.
+ */
+function candidateKeys(normalizedKey) {
+  const tokens = normalizedKey.split(' ').filter(Boolean);
+  const noDo = stripTrailingDo(tokens);
+  const noAoc = stripAocWrapper(tokens);
+  const variants = [tokens, noDo, noAoc];
+  // Both decorations at once, from whichever side stripped first.
+  if (noDo) variants.push(stripAocWrapper(noDo));
+  if (noAoc) variants.push(stripTrailingDo(noAoc));
+  const keys = [];
+  for (const v of variants) {
+    if (!v || v.length === 0) continue;
+    const key = v.join(' ');
+    if (key && !keys.includes(key)) keys.push(key);
+  }
+  return keys;
+}
+
+/**
+ * @returns {Promise<{found: boolean, name: string|null}>} found=false means no
+ *   curated doc carries this key (try the next variant); found=true with a
+ *   null name means curated docs matched but DISAGREE — the key IS known, so
+ *   stripping further would be guessing, and the caller keeps the input.
+ */
+async function lookupCanonical(key) {
+  // Docs can share a name across countries (the unique index is per-country);
+  // adopt only when EVERY curated doc agrees on the display spelling — when
+  // even the curated docs disagree, the typed spelling is not obviously
+  // wrong and is left alone. limit(4) with an agree-all check (audit
+  // 2026-07-29 A5: limit(2) could see two agreeing docs and miss a third
+  // that disagrees); .sort keeps the answer deterministic across query
+  // plans. Adoption is re-capped at 200 chars — the doc name is admin
+  // input with its own validation, but the mint chokepoint's field cap must
+  // hold regardless of where the string came from (audit A1).
+  const docs = await Appellation.find({
+    $or: [{ normalizedName: key }, { normalizedSynonyms: key }],
+  }).select('name').sort({ _id: 1 }).limit(4).lean();
+  if (docs.length === 0) return { found: false, name: null };
+  if (docs.every(d => d.name === docs[0].name)) return { found: true, name: docs[0].name.slice(0, 200) };
+  return { found: true, name: null };
+}
 
 /**
  * @param {string} rawAppellation  tier-stripped, trimmed appellation string
@@ -34,20 +134,10 @@ async function resolveCanonicalAppellation(rawAppellation) {
   const normalized = normalizeAppellationKey(rawAppellation);
   if (!normalized) return rawAppellation;
   try {
-    // Docs can share a name across countries (the unique index is per-country);
-    // adopt only when EVERY curated doc agrees on the display spelling — when
-    // even the curated docs disagree, the typed spelling is not obviously
-    // wrong and is left alone. limit(4) with an agree-all check (audit
-    // 2026-07-29 A5: limit(2) could see two agreeing docs and miss a third
-    // that disagrees); .sort keeps the answer deterministic across query
-    // plans. Adoption is re-capped at 200 chars — the doc name is admin
-    // input with its own validation, but the mint chokepoint's field cap must
-    // hold regardless of where the string came from (audit A1).
-    const docs = await Appellation.find({
-      $or: [{ normalizedName: normalized }, { normalizedSynonyms: normalized }],
-    }).select('name').sort({ _id: 1 }).limit(4).lean();
-    if (docs.length === 0) return rawAppellation;
-    if (docs.every(d => d.name === docs[0].name)) return docs[0].name.slice(0, 200);
+    for (const key of candidateKeys(normalized)) {
+      const hit = await lookupCanonical(key);
+      if (hit.found) return hit.name === null ? rawAppellation : hit.name;
+    }
     return rawAppellation;
   } catch (err) {
     console.warn('[appellationResolve] lookup failed (non-fatal, keeping input):', err.message);

--- a/backend/src/services/appellationResolve.js
+++ b/backend/src/services/appellationResolve.js
@@ -145,4 +145,10 @@ async function resolveCanonicalAppellation(rawAppellation) {
   }
 }
 
-module.exports = { resolveCanonicalAppellation };
+// candidateKeys is exported for services/taxonomyReview: the unmatched queue
+// must consider a string COVERED when any of its stripped variants matches a
+// curated doc (release-audit F2) — otherwise "Yecla DO" sits in the queue,
+// an admin promotes it, and the minted doc's exact-match hit permanently
+// disables the very stripping that would have folded it. One key function,
+// two consumers, no drift.
+module.exports = { resolveCanonicalAppellation, candidateKeys };

--- a/backend/src/services/appellationResolve.test.js
+++ b/backend/src/services/appellationResolve.test.js
@@ -5,6 +5,12 @@
  * un-curated appellation passes through verbatim (reviewed, never rejected),
  * a cross-country name clash only adopts when the curated spellings agree,
  * and a lookup failure never fails the mint.
+ *
+ * Plus the MEMBERSHIP GATE on decoration stripping: the resolver retries with
+ * "DO" / "Appellation … Contrôlée" removed, but only ADOPTS a stripped variant
+ * that a curated doc actually carries — and adopts the DOC's spelling, never
+ * the stripped raw string. That gate is the whole safety argument for
+ * stripping tokens utils/normalize deliberately leaves alone.
  */
 jest.mock('../models/Appellation', () => ({ find: jest.fn() }));
 
@@ -74,5 +80,82 @@ describe('resolveCanonicalAppellation', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     expect(await resolveCanonicalAppellation('Barolo')).toBe('Barolo');
     warn.mockRestore();
+  });
+
+  test('a synonym adopts the canonical name', async () => {
+    Appellation.find.mockReturnValue(chain([{ name: 'Châteauneuf-du-Pape' }]));
+    expect(await resolveCanonicalAppellation('CDP')).toBe('Châteauneuf-du-Pape');
+    expect(Appellation.find.mock.calls[0][0].$or[1]).toEqual({ normalizedSynonyms: 'cdp' });
+  });
+});
+
+/**
+ * Trailing "DO" and the "Appellation … Contrôlée" wrapper are decorations
+ * utils/normalize cannot strip blindly — 'do' collides with real place-name
+ * words, and the wrapper's payload IS the appellation. The resolver may strip
+ * them because membership decides: no curated doc, no adoption.
+ */
+describe('membership-gated decoration stripping', () => {
+  // A curated key sequence: exact first, then the stripped variants in order.
+  const findByKey = (byKey) => {
+    Appellation.find.mockImplementation((q) => chain(byKey[q.$or[0].normalizedName] || []));
+  };
+
+  test('"Yecla DO" adopts the curated "Yecla" — the prod case that motivated this', async () => {
+    findByKey({ yecla: [{ name: 'Yecla' }] });
+    expect(await resolveCanonicalAppellation('Yecla DO')).toBe('Yecla');
+    // The exact string is tried FIRST; only its miss licenses the strip.
+    expect(Appellation.find.mock.calls.map(c => c[0].$or[0].normalizedName)).toEqual(['yecla do', 'yecla']);
+  });
+
+  test('THE GATE: "Yecla DO" stays verbatim when no doc carries "Yecla"', async () => {
+    findByKey({});
+    expect(await resolveCanonicalAppellation('Yecla DO')).toBe('Yecla DO');
+  });
+
+  // The gate is what makes the aggressive strip safe: a real appellation whose
+  // last word happens to be "do" simply matches nothing stripped and survives.
+  test('THE GATE: a real name ending in "do" is not mutilated', async () => {
+    findByKey({ 'lisboa do': [{ name: 'Lisboa DO' }] });
+    expect(await resolveCanonicalAppellation('Lisboa DO')).toBe('Lisboa DO');
+    expect(Appellation.find).toHaveBeenCalledTimes(1); // exact hit, no strip attempted
+  });
+
+  test('the AOC wrapper is stripped when the payload is curated', async () => {
+    findByKey({ bordeaux: [{ name: 'Bordeaux' }] });
+    expect(await resolveCanonicalAppellation('Appellation Bordeaux Contrôlée')).toBe('Bordeaux');
+  });
+
+  test('the unaccented and Protégée wrapper forms fold to the same variant', async () => {
+    findByKey({ bordeaux: [{ name: 'Bordeaux' }] });
+    expect(await resolveCanonicalAppellation('Appellation Bordeaux Controlee')).toBe('Bordeaux');
+    expect(await resolveCanonicalAppellation("Appellation d'Origine Bordeaux Protégée")).toBe('Bordeaux');
+  });
+
+  test('both decorations at once', async () => {
+    findByKey({ yecla: [{ name: 'Yecla' }] });
+    expect(await resolveCanonicalAppellation('Appellation Yecla DO Contrôlée')).toBe('Yecla');
+  });
+
+  test('what is stored is the DOC\'s spelling, never the stripped raw string', async () => {
+    findByKey({ yecla: [{ name: 'Yecla DOP' }] }); // curated spelling keeps its own mark
+    expect(await resolveCanonicalAppellation('yecla do')).toBe('Yecla DOP');
+  });
+
+  test('the agree-all rule holds per variant — disagreeing docs keep the input', async () => {
+    findByKey({ yecla: [{ name: 'Yecla' }, { name: 'Iecla' }] });
+    expect(await resolveCanonicalAppellation('Yecla DO')).toBe('Yecla DO');
+  });
+
+  test('a KNOWN exact key that disagrees stops there — no stripping past a match', async () => {
+    findByKey({ 'yecla do': [{ name: 'Yecla DO' }, { name: 'Yecla D.O.' }], yecla: [{ name: 'Yecla' }] });
+    expect(await resolveCanonicalAppellation('Yecla DO')).toBe('Yecla DO');
+    expect(Appellation.find).toHaveBeenCalledTimes(1);
+  });
+
+  test('an undecorated miss costs exactly one query — no speculative variants', async () => {
+    findByKey({});
+    expect(await resolveCanonicalAppellation('Vin de Garage de Jean')).toBe('Vin de Garage de Jean');
+    expect(Appellation.find).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/services/pendingWineOps.identityGates.test.js
+++ b/backend/src/services/pendingWineOps.identityGates.test.js
@@ -30,6 +30,9 @@ jest.mock('./enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValu
 jest.mock('./indexNow', () => ({ submitUrls: jest.fn() }));
 jest.mock('../utils/vintageProfile', () => ({ ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined) }));
 jest.mock('./findOrCreateWine', () => ({ findOrCreateRegion: jest.fn().mockResolvedValue({ _id: 'region-1' }) }));
+// Identity by default — the gate tests are about producer/name, not spelling;
+// the curated-registry test below overrides it.
+jest.mock('./appellationResolve', () => ({ resolveCanonicalAppellation: jest.fn(async (v) => v) }));
 jest.mock('./wineProfileOps', () => ({
   resolveGrapeIdsStrict: jest.fn(),
   GRAPES_MAX: 20,
@@ -38,6 +41,7 @@ jest.mock('./wineProfileOps', () => ({
 }));
 
 const { detectCrossFieldForValues } = require('./crossFieldScan');
+const { resolveCanonicalAppellation } = require('./appellationResolve');
 const { applyPendingFix } = require('./pendingWineOps');
 const { IDENTITY_BLOCKING_CROSS_FIELD_CHECK_IDS, CROSS_FIELD_CHECK_IDS } = require('../utils/crossFieldChecks');
 
@@ -134,6 +138,19 @@ describe('shape gate', () => {
     expect(detectCrossFieldForValues).not.toHaveBeenCalled();
     // …and it keeps its per-creator key (audit M-2 stays fixed).
     expect(wine.normalizedKey).toContain('pending~');
+  });
+
+  // fix_pending_wine is a registry WRITE like any other, so the appellation a
+  // curator types is tier-stripped AND resolved against the curated registry —
+  // what lands on the row is the taxonomy's spelling, not the typed variant.
+  test('the STORED appellation is the resolver\'s canonical spelling', async () => {
+    resolveCanonicalAppellation.mockResolvedValueOnce('Yecla');
+    const wine = pendingWine();
+    const res = await applyPendingFix(wine, { appellation: 'Yecla DO' }, CURATOR);
+
+    expect(res.ok).toBe(true);
+    expect(resolveCanonicalAppellation).toHaveBeenCalledWith('Yecla DO');
+    expect(wine.appellation).toBe('Yecla');
   });
 });
 

--- a/backend/src/services/pendingWineOps.js
+++ b/backend/src/services/pendingWineOps.js
@@ -35,6 +35,9 @@ const { IDENTITY_BLOCKING_CROSS_FIELD_CHECK_IDS, resolveCrossFieldCheck } = requ
 // Top-level: labelScanAccess requires nothing at load (its own model require is
 // lazy), so it adds no module tree to the curation queue.
 const { stampPromotedScanRetention } = require('./labelScanAccess');
+// Same reasoning: appellationResolve requires only the Appellation model and
+// utils/normalize, so the curation queue keeps its light module tree.
+const { resolveCanonicalAppellation } = require('./appellationResolve');
 const { resolveGrapeIdsStrict, GRAPES_MAX, GRAPE_NAME_MAX, WINE_TYPES } = require('./wineProfileOps');
 
 // Fields a curator may set. `producer` and `name` are the two that promote the
@@ -295,8 +298,9 @@ function validatePendingFix(patch) {
  * follow-through when the identity became complete.
  *
  * Taxonomy is resolved with the SAME semantics as approving a correction
- * proposal (routes/admin/wineProposals.js): appellation normalized, country
- * RESOLVED never minted, region through the gated findOrCreateRegion, grapes
+ * proposal (routes/admin/wineProposals.js): appellation normalized AND resolved
+ * against the curated registry, country RESOLVED never minted, region through
+ * the gated findOrCreateRegion, grapes
  * match-only against the taxonomy, normalizedKey regenerated when any of
  * name/producer/appellation moved.
  *
@@ -337,7 +341,9 @@ async function applyPendingFix(wine, clean, userId) {
     };
   }
   if (clean.appellation !== undefined) {
-    wine.appellation = clean.appellation ? normalizeAppellation(clean.appellation) : null;
+    wine.appellation = clean.appellation
+      ? await resolveCanonicalAppellation(normalizeAppellation(clean.appellation))
+      : null;
   }
   if (clean.type) wine.type = clean.type;
 

--- a/backend/src/services/taxonomyReview.js
+++ b/backend/src/services/taxonomyReview.js
@@ -15,6 +15,7 @@ const Region = require('../models/Region');
 const Country = require('../models/Country');
 const Appellation = require('../models/Appellation');
 const { normalizeAppellation, normalizeAppellationKey } = require('../utils/normalize');
+const { candidateKeys } = require('./appellationResolve');
 const { isValidId } = require('../utils/validation');
 
 /**
@@ -102,7 +103,13 @@ async function listUnmatchedAppellations() {
   for (const r of rows) {
     const cleaned = normalizeAppellation(r._id.ap || '') || r._id.ap || '';
     const key = normalizeAppellationKey(cleaned);
-    if (!key || matched.has(key)) continue;
+    // Covered when ANY resolver candidate key matches, not just the exact one
+    // (release-audit F2): "Yecla DO" is governed by the curated "Yecla" — the
+    // resolver folds it at write time, and listing it here invites an admin to
+    // promote the decorated form, whose exact-match hit would then permanently
+    // beat the stripped variant and split the appellation in two. What remains
+    // in this queue is only what NO variant of covers — the genuinely unknown.
+    if (!key || candidateKeys(key).some((k) => matched.has(k))) continue;
     let g = groups.get(key);
     if (!g) { g = { spellings: new Map(), countries: new Map(), regions: new Map(), total: 0 }; groups.set(key, g); }
     g.total += r.n;

--- a/backend/src/services/taxonomyReview.unmatched.test.js
+++ b/backend/src/services/taxonomyReview.unmatched.test.js
@@ -1,0 +1,63 @@
+/**
+ * listUnmatchedAppellations — the queue must see through decoration the same
+ * way the resolver does (release-audit F2 on PR #951).
+ *
+ * The failure this pins: "Yecla DO" on wines, curated doc "Yecla". The exact
+ * key 'yecla do' is not in the matched set, so the old code LISTED it — and
+ * the tool description says "promote the real ones", so an admin promotes
+ * "Yecla DO", minting a doc whose exact-match hit permanently beats the
+ * resolver's stripped variant. Coverage must be judged on the resolver's
+ * candidateKeys, so a decorated string governed by a curated doc never
+ * reaches the queue at all.
+ */
+
+jest.mock('../models/WineDefinition', () => ({ aggregate: jest.fn() }));
+jest.mock('../models/Appellation', () => ({ find: jest.fn() }));
+jest.mock('../models/Country', () => ({ find: jest.fn() }));
+jest.mock('../models/Region', () => ({ find: jest.fn() }));
+
+const WineDefinition = require('../models/WineDefinition');
+const Appellation = require('../models/Appellation');
+const Country = require('../models/Country');
+const Region = require('../models/Region');
+const { listUnmatchedAppellations } = require('./taxonomyReview');
+
+const lean = (result) => ({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(result) }) });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Country.find.mockReturnValue(lean([]));
+  Region.find.mockReturnValue(lean([]));
+});
+
+test('a decorated string covered by a curated doc is NOT listed; the genuinely unknown is', async () => {
+  Appellation.find.mockReturnValue(lean([{ normalizedName: 'yecla', normalizedSynonyms: [] }]));
+  WineDefinition.aggregate.mockResolvedValue([
+    { _id: { ap: 'Yecla DO', country: null, region: null }, n: 2 },
+    { _id: { ap: 'Heathcote', country: null, region: null }, n: 15 },
+  ]);
+
+  const items = await listUnmatchedAppellations();
+
+  expect(items.map((i) => i.name)).toEqual(['Heathcote']);
+});
+
+test('the AOC wrapper is coverage too — "Appellation Bordeaux Contrôlée" never asks to be promoted', async () => {
+  Appellation.find.mockReturnValue(lean([{ normalizedName: 'bordeaux', normalizedSynonyms: [] }]));
+  WineDefinition.aggregate.mockResolvedValue([
+    { _id: { ap: 'Appellation Bordeaux Contrôlée', country: null, region: null }, n: 1 },
+  ]);
+
+  expect(await listUnmatchedAppellations()).toEqual([]);
+});
+
+test('an uncovered decorated string still lists — the gate is membership, not the decoration', async () => {
+  Appellation.find.mockReturnValue(lean([]));
+  WineDefinition.aggregate.mockResolvedValue([
+    { _id: { ap: 'Somewhere DO', country: null, region: null }, n: 3 },
+  ]);
+
+  const items = await listUnmatchedAppellations();
+  expect(items).toHaveLength(1);
+  expect(items[0].wineCount).toBe(3);
+});


### PR DESCRIPTION
Phase B of the appellation-validation work — closing the last write-path gap.

## Context
The curated Appellation registry (875 docs with aliases) already governs 96.4% of appellation-bearing wines, and `resolveCanonicalAppellation` (R2) already folds spellings at the mint chokepoint. But **six writers bypassed the resolver** — admin POST/PUT, proposal approval, `fix_pending_wine`, wine-request approval, and admin import — so curation itself kept reintroducing variants. Prod case: a somm proposal stored "Yecla DO" this morning through the approval path.

## Changes
- **All six writers now resolve** (`resolveCanonicalAppellation(normalizeAppellation(x))`, the wineReports pattern). `admin_add_registry_wine` deliberately untouched — it feeds `findOrCreateWine`, which already resolves; pinned by a test asserting the string reaches the chokepoint raw.
- **Membership-gated decoration stripping** in the resolver: when the exact key matches nothing, retry with trailing-`DO` and "Appellation … Contrôlée/Protégée" wrappers stripped — but a stripped variant is only adopted when curated docs vouch for it, and what's stored is always the doc's canonical name. First-match-wins, so a real name ending in "DO" is found by its exact key and never reaches the stripped variant. A known-but-disagreeing key STOPS the search (tri-state) — stripping past a match would be guessing.
- **Import resolution moved before `getOrCreateAppellation`** so CSV spellings stop minting duplicate Appellation docs; memoized per run matching the file's existing cache pattern.

## The invariant that matters
The resolver never blocks or fails a write. Unknown strings pass through verbatim into the unmatched review queue. **No input a user can type into the add flow is rejected by this change** — covered by tests.

## Tests
Full backend: **227 suites / 3,520 tests green** in node:20-alpine (+36 new: resolver variant matrix incl. both membership-gate cases, one per writer, chokepoint-raw pin).