### PR TITLE
fix(mcp): count WHY a tool call failed, and stop rejecting over-large limits

### DIFF
--- a/backend/src/mcp/resources.test.js
+++ b/backend/src/mcp/resources.test.js
@@ -169,6 +169,20 @@ describe('find_similar_wines', () => {
     // over-fetch is (limit+1)*5 with limit clamped to 10 → 55
     expect(vectorStore.searchSimilar).toHaveBeenCalledWith('v1', [0.1], 55);
   });
+
+  // The clamp above is only REACHED if the registered schema lets the call
+  // through. It used to be z.number().int().min(1).max(10), so in production
+  // the SDK rejected `limit: 500` with -32602 before the handler ran — while
+  // this suite, which calls handlers directly, proved the unreachable clamp
+  // green. Prod counted 51 such refusals on the anonymous surface. Assert the
+  // SCHEMA is permissive, not just the handler.
+  test('limit schema accepts out-of-range and string numbers so the handler can clamp them', () => {
+    const { z } = require('zod');
+    const schema = z.object(tool('find_similar_wines').inputSchema);
+    expect(schema.safeParse({ wine_id: oid('f'), limit: 500 }).success).toBe(true);
+    expect(schema.safeParse({ wine_id: oid('f'), limit: '5' }).success).toBe(true);
+    expect(schema.safeParse({ wine_id: oid('f') }).success).toBe(true);
+  });
 });
 
 // ── Coverage added by the 2026-07-16 refactor audit ──────────────────────────

--- a/backend/src/mcp/server.js
+++ b/backend/src/mcp/server.js
@@ -59,8 +59,23 @@ const callBudgetExceeded = () =>
 // record() is fire-and-forget and no-ops without a live Mongo connection, so
 // the directly-unit-tested wrappers below stay pure in jest.
 const McpUsageStat = require('../models/McpUsageStat');
-function recordUsage(ctx, kind, name, error) {
-  McpUsageStat.record({ surface: ctx.anonymous ? 'public' : 'personal', kind, name, error });
+function recordUsage(ctx, kind, name, error, code) {
+  McpUsageStat.record({ surface: ctx.anonymous ? 'public' : 'personal', kind, name, error, code });
+}
+
+// Pull the error CODE out of a tool result so the counters say WHY a call
+// failed, not just that it did. Tool failures are fail()'d envelopes whose
+// single text block is `{"error":{"code","message"}}` (toolUtil.fail) — anything
+// else (a thrown handler, a non-JSON body) counts as 'unknown' rather than
+// risking a throw inside instrumentation.
+function errorCodeOf(out) {
+  try {
+    const text = out?.content?.[0]?.text;
+    if (typeof text !== 'string') return 'unknown';
+    return JSON.parse(text)?.error?.code || 'unknown';
+  } catch {
+    return 'unknown';
+  }
 }
 
 // Run a handler and count it into McpUsageStat WITHOUT changing its calling
@@ -69,21 +84,27 @@ function recordUsage(ctx, kind, name, error) {
 // are pure/synchronous and their tests pin that — wrapping everything in a
 // promise here would silently break them.
 function withUsage(ctx, kind, name, run, isError = () => false) {
+  // A thrown handler never produced an envelope to read a code from — 'threw'
+  // separates that (a bug or an unhandled backend fault) from an orderly fail().
+  const settle = (v) => {
+    const bad = !!isError(v);
+    recordUsage(ctx, kind, name, bad, bad ? errorCodeOf(v) : undefined);
+    return v;
+  };
   let out;
   try {
     out = run();
   } catch (err) {
-    recordUsage(ctx, kind, name, true);
+    recordUsage(ctx, kind, name, true, 'threw');
     throw err;
   }
   if (out && typeof out.then === 'function') {
     return out.then(
-      (v) => { recordUsage(ctx, kind, name, !!isError(v)); return v; },
-      (err) => { recordUsage(ctx, kind, name, true); throw err; }
+      settle,
+      (err) => { recordUsage(ctx, kind, name, true, 'threw'); throw err; }
     );
   }
-  recordUsage(ctx, kind, name, !!isError(out));
-  return out;
+  return settle(out);
 }
 
 // Wrap a tool handler with the per-request call budget (+ the per-user
@@ -100,12 +121,12 @@ function budgetedHandler(tool, ctx, state) {
     state.calls += 1;
     const maxCalls = state.max || MAX_CALLS_PER_REQUEST;
     if (state.calls > maxCalls) {
-      recordUsage(ctx, 'tool', tool.name, true);
+      recordUsage(ctx, 'tool', tool.name, true, 'rate_limited');
       return rateLimited(`Too many tool calls in one request (max ${maxCalls}). Send fewer calls per batch and paginate instead.`);
     }
     // Cross-request caller budget — bounds read amplification (M-4).
     if (!withinCallBudget(ctx)) {
-      recordUsage(ctx, 'tool', tool.name, true);
+      recordUsage(ctx, 'tool', tool.name, true, 'rate_limited');
       return callBudgetExceeded();
     }
     if (tool.annotations?.readOnlyHint === false) {
@@ -113,7 +134,7 @@ function budgetedHandler(tool, ctx, state) {
       // tool is ever mis-scoped 'public', refuse cleanly instead of running a
       // userless mutation (and crashing on ctx.user.id below).
       if (ctx.anonymous || !ctx.user) {
-        recordUsage(ctx, 'tool', tool.name, true);
+        recordUsage(ctx, 'tool', tool.name, true, 'forbidden_scope');
         return {
           isError: true,
           content: [{ type: 'text', text: JSON.stringify({ error: { code: 'forbidden_scope', message: 'Mutations need an authenticated connection.' } }) }],
@@ -123,7 +144,7 @@ function budgetedHandler(tool, ctx, state) {
       // themselves — per ITEM on apply, nothing on preview — so the generic
       // one-slot-per-call charge here would double-count (MCP-audit M7).
       if (!tool.selfBudgeted && !takeMutationSlot(String(ctx.user.id), 1, ipKeyFor(ctx))) {
-        recordUsage(ctx, 'tool', tool.name, true);
+        recordUsage(ctx, 'tool', tool.name, true, 'rate_limited');
         return rateLimited('Too many cellar changes in a short time — wait a few minutes before mutating again. Reads still work.');
       }
     }
@@ -275,11 +296,11 @@ function budgetedPromptHandler(prompt, ctx, state) {
     state.calls += 1;
     const maxCalls = state.max || MAX_CALLS_PER_REQUEST;
     if (state.calls > maxCalls) {
-      recordUsage(ctx, 'prompt', prompt.name, true);
+      recordUsage(ctx, 'prompt', prompt.name, true, 'rate_limited');
       throw new Error(`rate_limited: too many calls in one request (max ${maxCalls})`);
     }
     if (!withinCallBudget(ctx)) {
-      recordUsage(ctx, 'prompt', prompt.name, true);
+      recordUsage(ctx, 'prompt', prompt.name, true, 'rate_limited');
       throw new Error('rate_limited: too many Cellarion tool calls in a short time');
     }
     return withUsage(ctx, 'prompt', prompt.name, () => prompt.handler(args || {}, ctx));
@@ -296,11 +317,11 @@ function budgetedResourceHandler(rsrc, ctx, state) {
     state.calls += 1;
     const maxCalls = state.max || MAX_CALLS_PER_REQUEST;
     if (state.calls > maxCalls) {
-      recordUsage(ctx, 'resource', rsrc.name, true);
+      recordUsage(ctx, 'resource', rsrc.name, true, 'rate_limited');
       throw new Error(`rate_limited: too many calls in one request (max ${maxCalls})`);
     }
     if (!withinCallBudget(ctx)) {
-      recordUsage(ctx, 'resource', rsrc.name, true);
+      recordUsage(ctx, 'resource', rsrc.name, true, 'rate_limited');
       throw new Error('rate_limited: too many Cellarion tool calls in a short time');
     }
     const params = rsrc.uriTemplate ? (varsOrExtra || {}) : {};

--- a/backend/src/mcp/server.test.js
+++ b/backend/src/mcp/server.test.js
@@ -113,6 +113,51 @@ describe('idempotency claim release-on-error (H2)', () => {
   });
 });
 
+// A bare error count says an agent is failing, not WHY — and "the tool's
+// contract confuses the model" (invalid_input) and "a backend is down"
+// (unavailable) need opposite responses from an admin.
+describe('usage counters record the error CODE', () => {
+  const McpUsageStat = require('../models/McpUsageStat');
+  const failWith = (code) => ({ isError: true, content: [{ type: 'text', text: JSON.stringify({ error: { code, message: 'x' } }) }] });
+  const lastRecord = () => McpUsageStat.record.mock.calls.at(-1)[0];
+
+  test('a fail() envelope contributes its code', async () => {
+    const handler = jest.fn(async () => failWith('invalid_input'));
+    await budgetedHandler(readTool(handler), ctxFor(), freshState())({});
+    expect(lastRecord()).toMatchObject({ name: 'search_bottles', error: true, code: 'invalid_input' });
+  });
+
+  test('a SUCCESS records no code (nothing to explain)', async () => {
+    const handler = jest.fn(async () => ({ content: [{ type: 'text', text: '{}' }] }));
+    await budgetedHandler(readTool(handler), ctxFor(), freshState())({});
+    expect(lastRecord()).toMatchObject({ error: false, code: undefined });
+  });
+
+  test("a THROWN handler is 'threw', not a parsed code — there is no envelope to read", async () => {
+    const handler = jest.fn(async () => { throw new Error('boom'); });
+    await expect(budgetedHandler(readTool(handler), ctxFor(), freshState())({})).rejects.toThrow('boom');
+    expect(lastRecord()).toMatchObject({ error: true, code: 'threw' });
+  });
+
+  test('a non-JSON / shapeless error body degrades to unknown instead of throwing inside instrumentation', async () => {
+    const handler = jest.fn(async () => ({ isError: true, content: [{ type: 'text', text: 'not json' }] }));
+    await budgetedHandler(readTool(handler), ctxFor(), freshState())({});
+    expect(lastRecord()).toMatchObject({ error: true, code: 'unknown' });
+  });
+
+  test('budget refusals carry their own codes (the handler never ran to produce one)', async () => {
+    withinCallBudget.mockReturnValue(false);
+    await budgetedHandler(readTool(jest.fn()), ctxFor(), freshState())({});
+    expect(lastRecord()).toMatchObject({ error: true, code: 'rate_limited' });
+
+    // Reset: the call budget is checked BEFORE the mutating gate, so leaving it
+    // exhausted would re-assert rate_limited and never reach forbidden_scope.
+    withinCallBudget.mockReturnValue(true);
+    await budgetedHandler(writeTool(jest.fn()), ctxFor({ anonymous: true, user: null }), freshState())({});
+    expect(lastRecord()).toMatchObject({ error: true, code: 'forbidden_scope' });
+  });
+});
+
 // ctx is spread with extra fields; assert on the object shape we passed.
 function ctxForMatch() {
   return expect.objectContaining({ user: USER });

--- a/backend/src/mcp/tools/publicContent.js
+++ b/backend/src/mcp/tools/publicContent.js
@@ -97,8 +97,15 @@ registerTool({
   annotations: { readOnlyHint: true, openWorldHint: false },
   inputSchema: {
     tag: z.string().max(40).optional().describe('Filter by tag'),
-    limit: z.number().int().min(1).max(GUIDE_LIST_LIMIT).default(10),
-    offset: z.number().int().min(0).default(0),
+    // Unbounded at the schema layer on purpose — see the note on
+    // find_similar_wines' `limit`. Pagination inputs are CLAMPED by the handler
+    // below (an over-large page is a request to be capped, not a malformed
+    // call); a schema-level .max would instead fail the call with -32602 before
+    // the handler runs, and an SDK-level rejection is recorded in no counter at
+    // all. Mutating tools keep their strict numeric bounds, where an
+    // out-of-range value is genuinely a client bug worth refusing.
+    limit: z.coerce.number().int().optional().describe(`How many to return (1-${GUIDE_LIST_LIMIT}, default 10; larger values are capped, not rejected)`),
+    offset: z.coerce.number().int().optional().describe('Skip this many (default 0)'),
   },
   handler: async (args) => {
     const BlogPost = require('../../models/BlogPost');

--- a/backend/src/mcp/tools/similar.js
+++ b/backend/src/mcp/tools/similar.js
@@ -18,10 +18,11 @@ registerTool({
   name: 'find_similar_wines',
   title: 'Find similar wines ("more like this")',
   description:
-    'Given a registry wine_id (or one of the user\'s bottle_ids), returns wines with the closest taste/style profile ' +
-    'from the shared registry, using vector similarity over wine embeddings. Call for "more like this", "what else is ' +
-    'like my favourite Barolo", or to seed purchase ideas from a wine the user loves. Only wines that have been ' +
-    'embedded are searchable — an empty result does not mean nothing similar exists.',
+    'Given a registry wine_id (or, on an authenticated connection, one of the user\'s bottle_ids), returns wines with ' +
+    'the closest taste/style profile from the shared registry, using vector similarity over wine embeddings. Call for ' +
+    '"more like this", "what else is like my favourite Barolo", or to seed purchase ideas from a wine the user loves. ' +
+    'Only wines that have been embedded are searchable — an empty result does not mean nothing similar exists. ' +
+    `Ids must be 24-hex Mongo ids from search_registry or search_bottles — a name or slug is not an id. Returns at most ${MAX_SIMILAR}.`,
   // 'public' (plan §3.17): the reference wine is already embedded, so this is
   // a stored-vector Qdrant lookup — $0 per call and safe on the anonymous
   // /api/mcp/public surface. The bottle_id input is guarded below (anonymous
@@ -29,9 +30,18 @@ registerTool({
   scope: 'public',
   annotations: { readOnlyHint: true, openWorldHint: false },
   inputSchema: {
-    wine_id: z.string().optional().describe('Registry wine id (from search_registry or a bottle\'s wine)'),
-    bottle_id: z.string().optional().describe('Alternatively: one of the user\'s bottle ids'),
-    limit: z.number().int().min(1).max(MAX_SIMILAR).default(8),
+    wine_id: z.string().optional().describe('Registry wine id (24-hex) from search_registry or a bottle\'s wine'),
+    bottle_id: z.string().optional().describe('Alternatively: one of the user\'s bottle ids (24-hex). Needs an authenticated connection — not available on the public endpoint.'),
+    // Deliberately UNBOUNDED at the schema layer, unlike the mutating tools'
+    // numeric inputs. A strict .min/.max here makes the SDK reject the whole
+    // call with -32602 before the handler runs — and an over-large `limit` is
+    // not a malformed request, it is a request to be capped. The handler clamps
+    // (that clamp was previously unreachable for out-of-range values), so
+    // "20 similar wines" now returns 10 instead of failing. z.coerce absorbs
+    // the string-number an agent may send. Counting note: an SDK-level -32602
+    // never reaches budgetedHandler, so it lands in NO McpUsageStat counter —
+    // rejections here were invisible in the usage stats, not merely uncounted.
+    limit: z.coerce.number().int().optional().describe(`How many to return (1-${MAX_SIMILAR}, default 8; larger values are capped, not rejected)`),
   },
   handler: async (args, ctx) => {
     const WineEmbedding = require('../../models/WineEmbedding');

--- a/backend/src/models/McpUsageStat.js
+++ b/backend/src/models/McpUsageStat.js
@@ -22,6 +22,16 @@ const mcpUsageStatSchema = new mongoose.Schema({
   // Calls whose result envelope carried isError (or whose handler threw).
   // Named errorCount, not errors — `errors` is a reserved Mongoose pathname.
   errorCount: { type: Number, default: 0 },
+  // Breakdown of errorCount by the envelope's error CODE (invalid_input,
+  // not_found, rate_limited, unavailable, …) — a bare count says an agent is
+  // failing, not WHY, and those need opposite responses: invalid_input means
+  // the tool's contract is confusing the model, unavailable means a backend is
+  // down. Still aggregate-only (a code is not personal data), so the model
+  // stays in userDataRegistry's EXCLUDED list.
+  //
+  // A Map keeps the {day,surface,kind,name} unique index intact — the
+  // alternative (code as a 5th key field) would multiply every row.
+  errorCodes: { type: Map, of: Number, default: undefined },
 }, { versionKey: false });
 
 mcpUsageStatSchema.index({ day: 1, surface: 1, kind: 1, name: 1 }, { unique: true });
@@ -37,15 +47,29 @@ const McpUsageStat = mongoose.model('McpUsageStat', mcpUsageStatSchema);
  * a stats hiccup must not fail a tool call. No-ops without a live connection
  * so the directly-unit-tested budgeted handlers (no DB in jest) stay pure.
  */
-McpUsageStat.record = function record({ surface, kind, name, error }) {
+McpUsageStat.record = function record({ surface, kind, name, error, code }) {
   if (mongoose.connection.readyState !== 1) return;
   const day = new Date();
   day.setUTCHours(0, 0, 0, 0);
+  const inc = { calls: 1, errorCount: error ? 1 : 0 };
+  if (error) inc[`errorCodes.${safeCode(code)}`] = 1;
   McpUsageStat.updateOne(
     { day, surface, kind, name: String(name).slice(0, 100) },
-    { $inc: { calls: 1, errorCount: error ? 1 : 0 } },
+    { $inc: inc },
     { upsert: true }
   ).catch(() => {});
 };
+
+/**
+ * Error codes become Mongo FIELD names, so they must not carry `.` or `$` (a
+ * dot would silently nest the counter, a leading $ is rejected outright). Tool
+ * codes are already a closed [a-z_] set — this is the guard for the day one
+ * isn't, and for the unknown/absent case.
+ */
+function safeCode(code) {
+  const clean = String(code || 'unknown').replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 40);
+  return clean || 'unknown';
+}
+McpUsageStat.safeCode = safeCode;
 
 module.exports = McpUsageStat;

--- a/backend/src/models/McpUsageStat.test.js
+++ b/backend/src/models/McpUsageStat.test.js
@@ -1,0 +1,68 @@
+/**
+ * McpUsageStat.record — the fire-and-forget counter behind the admin MCP usage
+ * view. Two things matter here and neither was covered: it must never throw or
+ * await (a stats hiccup must not fail a tool call), and the error CODE it
+ * $incs becomes a Mongo FIELD NAME, so an unsanitised code could nest or
+ * reject the whole update.
+ */
+const mongoose = require('mongoose');
+
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { ...actual, connection: { readyState: 1 } };
+});
+
+const McpUsageStat = require('./McpUsageStat');
+
+let updateOne;
+beforeEach(() => {
+  mongoose.connection.readyState = 1;
+  updateOne = jest.spyOn(McpUsageStat, 'updateOne').mockReturnValue(Promise.resolve());
+});
+afterEach(() => jest.restoreAllMocks());
+
+const incOf = () => updateOne.mock.calls[0][1].$inc;
+
+test('a successful call bumps calls only — no error counter, no code bucket', () => {
+  McpUsageStat.record({ surface: 'personal', kind: 'tool', name: 'get_wine', error: false });
+  expect(incOf()).toEqual({ calls: 1, errorCount: 0 });
+});
+
+test('a failed call buckets by code alongside the flat count', () => {
+  McpUsageStat.record({ surface: 'public', kind: 'tool', name: 'find_similar_wines', error: true, code: 'invalid_input' });
+  expect(incOf()).toEqual({ calls: 1, errorCount: 1, 'errorCodes.invalid_input': 1 });
+});
+
+test('a failure with no code still buckets, as unknown — never a bare errorCount', () => {
+  McpUsageStat.record({ surface: 'personal', kind: 'tool', name: 'x', error: true });
+  expect(incOf()).toEqual({ calls: 1, errorCount: 1, 'errorCodes.unknown': 1 });
+});
+
+test('dots and $ in a code are neutralised — they would nest the counter or be rejected outright', () => {
+  McpUsageStat.record({ surface: 'personal', kind: 'tool', name: 'x', error: true, code: '$weird.code' });
+  const keys = Object.keys(incOf()).filter((k) => k.startsWith('errorCodes.'));
+  expect(keys).toEqual(['errorCodes._weird_code']);
+});
+
+test('the day key is UTC midnight, so a row is one calendar day regardless of server TZ', () => {
+  McpUsageStat.record({ surface: 'personal', kind: 'tool', name: 'x', error: false });
+  const { day } = updateOne.mock.calls[0][0];
+  expect([day.getUTCHours(), day.getUTCMinutes(), day.getUTCSeconds(), day.getUTCMilliseconds()]).toEqual([0, 0, 0, 0]);
+});
+
+test('an over-long tool name is truncated to the schema max', () => {
+  McpUsageStat.record({ surface: 'personal', kind: 'tool', name: 'n'.repeat(200), error: false });
+  expect(updateOne.mock.calls[0][0].name).toHaveLength(100);
+});
+
+test('no live connection → no write at all (keeps the unit-tested handlers DB-free)', () => {
+  mongoose.connection.readyState = 0;
+  McpUsageStat.record({ surface: 'personal', kind: 'tool', name: 'x', error: true, code: 'boom' });
+  expect(updateOne).not.toHaveBeenCalled();
+});
+
+test('a rejected write is swallowed — instrumentation must never fail the tool call', async () => {
+  updateOne.mockReturnValue(Promise.reject(new Error('mongo down')));
+  expect(() => McpUsageStat.record({ surface: 'personal', kind: 'tool', name: 'x', error: false })).not.toThrow();
+  await new Promise((r) => setImmediate(r)); // let the rejection settle unhandled-free
+});

--- a/backend/src/routes/admin/mcp.js
+++ b/backend/src/routes/admin/mcp.js
@@ -13,6 +13,19 @@ router.use(requireAuth, requireRole('admin'));
 // device tokens are not AI connections and are excluded from the counts.
 const { MCP_PERSONAL_SCOPES: MCP_SCOPES } = require('../../config/constants');
 
+/**
+ * Flatten the per-day errorCodes maps a tool accumulated into one
+ * {code: total}. Input is an array of $objectToArray results (one per day),
+ * i.e. [[{k,v},…], …]; days with no errors contribute [].
+ */
+function mergeCodeCounts(perDay) {
+  const out = {};
+  for (const day of perDay || []) {
+    for (const { k, v } of day || []) out[k] = (out[k] || 0) + v;
+  }
+  return out;
+}
+
 // GET /api/admin/mcp/usage?days=30 — the admin MCP overview: per-day call/error
 // series, top tools, connection + distinct-user counts, recent write volume,
 // kill-switch state. Everything here is aggregate (McpUsageStat carries no user
@@ -44,6 +57,16 @@ router.get('/usage', async (req, res) => {
           _id: { name: '$name', surface: '$surface' },
           calls: { $sum: '$calls' },
           errors: { $sum: '$errorCount' },
+          // Merge the per-day errorCodes maps into one {code: total} per tool,
+          // so "this tool fails a lot" comes with WHY attached. $objectToArray
+          // on a missing/!object field would fault the whole pipeline — rows
+          // predating the field (and clean rows, which never get one) are
+          // mapped to [] first.
+          errorCodes: { $push: { $cond: [
+            { $eq: [{ $type: '$errorCodes' }, 'object'] },
+            { $objectToArray: '$errorCodes' },
+            [],
+          ] } },
         } },
         { $sort: { calls: -1 } },
         { $limit: 20 },
@@ -125,6 +148,11 @@ router.get('/usage', async (req, res) => {
         surface: t._id.surface,
         calls: t.calls,
         errors: t.errors,
+        // {invalid_input: 12, unavailable: 3} — flattened from the per-day maps
+        // the pipeline pushed. Merged here rather than in the pipeline: the
+        // aggregation form needs a double $reduce + $arrayToObject that is far
+        // harder to read than four lines of JS, over at most 90 rows per tool.
+        errorCodes: mergeCodeCounts(t.errorCodes),
       })),
       connections: connOut,
       users: {

--- a/backend/src/routes/admin/mcp.test.js
+++ b/backend/src/routes/admin/mcp.test.js
@@ -80,7 +80,7 @@ test('maps aggregates into the daily series, top tools and connection split', as
       { _id: { day, surface: 'public' }, calls: 7, errors: 0 },
     ])
     .mockResolvedValueOnce([
-      { _id: { name: 'search_bottles', surface: 'personal' }, calls: 20, errors: 1 },
+      { _id: { name: 'search_bottles', surface: 'personal' }, calls: 20, errors: 1, errorCodes: [[{ k: 'invalid_input', v: 1 }]] },
     ]);
   ApiToken.aggregate
     .mockResolvedValueOnce([
@@ -97,7 +97,7 @@ test('maps aggregates into the daily series, top tools and connection split', as
     { day: day.toISOString(), surface: 'public', calls: 7, errors: 0 },
   ]);
   expect(body.topTools).toEqual([
-    { name: 'search_bottles', surface: 'personal', calls: 20, errors: 1 },
+    { name: 'search_bottles', surface: 'personal', calls: 20, errors: 1, errorCodes: { invalid_input: 1 } },
   ]);
   expect(body.connections).toEqual({
     bearer: { total: 3, activeLast7d: 2 },
@@ -109,6 +109,29 @@ test('maps aggregates into the daily series, top tools and connection split', as
   expect(body.users).toEqual({
     connected: 6, oauthConnected: 4, oauthActiveLast7d: 2, wroteLast7d: 2,
   });
+});
+
+test('errorCodes sum across days, and rows predating the field stay absent rather than crashing the map', async () => {
+  McpUsageStat.aggregate
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([
+      // Three days: two with codes, one clean (no errors → no map at all).
+      { _id: { name: 'find_similar_wines', surface: 'public' }, calls: 30, errors: 5, errorCodes: [
+        [{ k: 'invalid_input', v: 2 }, { k: 'unavailable', v: 1 }],
+        [],
+        [{ k: 'invalid_input', v: 2 }],
+      ] },
+      // A tool whose rows all predate the field — the aggregation pushes
+      // nothing usable and the response must simply carry an empty object.
+      { _id: { name: 'get_wine', surface: 'public' }, calls: 9, errors: 1, errorCodes: undefined },
+    ]);
+  ApiToken.aggregate.mockResolvedValue([]);
+  McpActionLog.aggregate.mockResolvedValue([]);
+  McpActionLog.countDocuments.mockResolvedValue(0);
+
+  const body = await (await getUsage(tokenFor(ADMIN_ID, ['admin']))).json();
+  expect(body.topTools[0].errorCodes).toEqual({ invalid_input: 4, unavailable: 1 });
+  expect(body.topTools[1].errorCodes).toEqual({});
 });
 
 test('the user pipelines count people, not tokens or rows', async () => {

--- a/frontend/src/pages/AdminMcp.css
+++ b/frontend/src/pages/AdminMcp.css
@@ -199,6 +199,16 @@
   font-size: 0.82rem;
 }
 
+/* Error-code breakdown under the error count. Secondary to the number it
+   explains, and on its own line so the cell stays narrow. */
+.admin-mcp-error-codes {
+  display: block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+  color: var(--color-text-muted, #6b7280);
+  margin-top: 2px;
+}
+
 .admin-mcp-bar-col {
   width: 30%;
   min-width: 80px;

--- a/frontend/src/pages/AdminMcp.js
+++ b/frontend/src/pages/AdminMcp.js
@@ -32,6 +32,15 @@ function byDay(daily) {
   return [...map.values()].sort((a, b) => (a.day < b.day ? 1 : -1));
 }
 
+// The error-code buckets for one tool, biggest first, capped at three so a
+// long tail of one-offs can't push the table wide. Absent on rows written
+// before the field existed — those simply show nothing.
+function topCodes(errorCodes) {
+  return Object.entries(errorCodes || {})
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3);
+}
+
 function AdminMcp() {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
@@ -226,7 +235,18 @@ function AdminMcp() {
                         <td className="admin-mcp-tool-name">{tool.name}</td>
                         <td>{t(tool.surface === 'public' ? 'adminMcp.public' : 'adminMcp.personal')}</td>
                         <td>{fmt(tool.calls)}</td>
-                        <td>{tool.errors > 0 ? fmt(tool.errors) : '—'}</td>
+                        <td>
+                          {tool.errors > 0 ? fmt(tool.errors) : '—'}
+                          {/* The count alone can't be acted on: invalid_input
+                              means the tool's contract is confusing the model,
+                              unavailable means a backend is down. Show the
+                              breakdown inline, biggest bucket first. */}
+                          {topCodes(tool.errorCodes).length > 0 && (
+                            <span className="admin-mcp-error-codes">
+                              {topCodes(tool.errorCodes).map(([code, n]) => `${code} ${fmt(n)}`).join(' · ')}
+                            </span>
+                          )}
+                        </td>
                       </tr>
                     ))}
                   </tbody>

--- a/frontend/src/pages/AdminMcp.test.js
+++ b/frontend/src/pages/AdminMcp.test.js
@@ -24,7 +24,11 @@ const jsonRes = (body, ok = true) => ({ ok, json: () => Promise.resolve(body) })
 const USAGE = {
   days: 30,
   daily: [{ day: '2026-07-15T00:00:00.000Z', surface: 'personal', calls: 41, errors: 2 }],
-  topTools: [{ name: 'search_bottles', surface: 'personal', calls: 20, errors: 1 }],
+  topTools: [
+    { name: 'search_bottles', surface: 'personal', calls: 20, errors: 1, errorCodes: { invalid_input: 1 } },
+    // No errorCodes at all — the shape every row had before the field existed.
+    { name: 'get_wine', surface: 'public', calls: 9, errors: 0 },
+  ],
   connections: { bearer: { total: 3, activeLast7d: 2 }, oauth: { total: 5, activeLast7d: 4 } },
   users: { connected: 7, oauthConnected: 4, oauthActiveLast7d: 3, wroteLast7d: 2 },
   writesLast7d: 12,
@@ -63,6 +67,15 @@ test('survives a payload with no users block (older backend)', async () => {
   // Renders em-dashes rather than crashing on users.connected.
   await waitFor(() => expect(screen.getByText('2026-07-15')).toBeInTheDocument());
   expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+});
+
+test('shows WHY a tool failed, and renders rows that carry no errorCodes at all', async () => {
+  render(<AdminMcp />);
+  await waitFor(() => expect(screen.getByText('search_bottles')).toBeInTheDocument());
+  // The breakdown is the point — a bare "1" cannot be acted on.
+  expect(screen.getByText('invalid_input 1')).toBeInTheDocument();
+  // The pre-field row still renders (no crash on a missing map).
+  expect(screen.getByText('get_wine')).toBeInTheDocument();
 });
 
 test('surfaces a server error instead of blanking', async () => {


### PR DESCRIPTION
Came out of looking at how the MCP is actually being used in prod. `find_similar_wines` had failed **51 of 124 calls** on the anonymous `/api/mcp/public` surface — every call since Aug 4. Two separate problems were behind that number, and the second one explains why nobody noticed.

## 1. The counters recorded a boolean, not a reason

`McpUsageStat` stored `errorCount` and nothing else. "This tool fails a lot" isn't actionable — `invalid_input` means the tool's contract is confusing the model, `unavailable` means a backend is down, and those need opposite responses.

- `McpUsageStat.record()` now `$inc`s an `errorCodes` bucket alongside `errorCount`. It's a **Map**, so the `{day,surface,kind,name}` unique index is untouched (a code as a 5th key field would multiply every row). Codes are sanitised — they become Mongo *field names*, where a `.` would silently nest the counter and a leading `$` is rejected outright.
- Budget refusals name their own codes (`rate_limited`, `forbidden_scope`) — the handler never ran to produce an envelope.
- A **thrown** handler records `threw`, not a parsed code it never produced.
- `GET /api/admin/mcp/usage` merges the per-day maps per tool; Admin → MCP shows the top three buckets under each error count.

Still aggregate-only, so the model stays in `userDataRegistry`'s EXCLUDED list — an error code is not personal data.

## 2. Over-large `limit` values were rejected, not clamped

`find_similar_wines` and `list_guides` declared `limit: z.number().int().min(1).max(N)`. The SDK validates the registered schema **before** the handler runs, so `limit: 20` — or the string `"5"` an agent may send — failed the whole call with `-32602`.

Both handlers *already* clamped the value defensively. That clamp was unreachable for exactly the inputs it existed to absorb. An over-large page is a request to be capped, not a malformed call, so pagination inputs are now `z.coerce.number().int()` and the handler clamp is the real bound.

**Mutating tools keep their strict numeric bounds** (`rows`, `glasses`, `ml`, `rating`, `year`) — there, an out-of-range value genuinely is a client bug worth refusing.

Also fixed the tool description, which advertised `bottle_id` with no hint it's unusable anonymously, and never said ids must be 24-hex.

## The bit worth flagging

**An SDK-level `-32602` never reaches `budgetedHandler`, so those rejections landed in *no* counter at all.** They were invisible in the usage stats, not merely uncounted — real call volume is undercounted precisely where agents are struggling most.

I found this by arithmetic on the live counter: today's row read `1/1` before I started, I made 6 test calls (1 success, 5 failures), and it read `4/5` afterwards instead of `6/7`. The two missing calls were exactly the two that failed schema validation.

`resources.test.js` already asserted the limit clamp — and passed — because it calls handlers directly and bypassed the schema that was rejecting the call in production. It now pins the schema's permissiveness too.

## Testing

- Backend: 36 suites / 519 tests green (all of `src/mcp`, plus the new `McpUsageStat` model suite and `routes/admin/mcp`). New coverage for code recording, the `threw` vs parsed-code split, non-JSON error bodies degrading to `unknown`, Mongo field-name sanitisation, and rows predating the field.
- Frontend: 57 files / 924 tests green.
- **Docker smoke against the real SDK path**: `limit: 20` and `limit: "5"` now reach the handler and are recorded (`{"unavailable":2}` locally, since local Qdrant has no embeddings); `list_guides` with `limit: 999` returns a clamped "20 of 23".

## Compose impact

None — no new services, env vars, or ports.

## Note for after deploy

The `errorCodes` field is additive; existing rows have no map and the admin route handles that. The breakdown starts being useful once post-deploy traffic accumulates. The remaining question this makes answerable: which of `invalid_input` (no args / anonymous `bottle_id` / non-hex id) the public callers are actually hitting.