### PR TITLE
chore(release): v1.113.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.112.0",
+  "version": "1.113.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.112.0",
+      "version": "1.113.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.112.0",
+  "version": "1.113.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.112.0",
+  "version": "1.113.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.112.0",
+      "version": "1.113.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.112.0",
+  "version": "1.113.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — 6 lines across the two package.json files and their lockfiles.

Ships:
- #959 fix(mcp): count WHY a tool call failed, and stop rejecting over-large limits
- #960 feat(stats): add a login-based retention ladder alongside the activity one

Minor bump (a feat is included).