### PR TITLE
chore(release): v1.114.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.113.0",
+  "version": "1.114.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.113.0",
+      "version": "1.114.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.113.0",
+  "version": "1.114.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.113.0",
+  "version": "1.114.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.113.0",
+      "version": "1.114.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.113.0",
+  "version": "1.114.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — 6 lines across 4 files (`backend`/`frontend` `package.json` + both lockfiles).

## What's in v1.114.0

**#962 — reply back to the owners who answered.** Owner inquiries were a one-way channel: we asked a bottle owner to walk to their shelf and read a back label, they answered, and then heard nothing — resolving wrote an admin-only note and made the card vanish from their bottle page.

Resolving now takes two texts with two audiences that never mix: `resolutionNote` stays the curator's private record, and the new optional `ownerReply` notifies every owner who **answered** (never the ones who ignored it) and renders on their bottle page for 30 days. Omitting it still sends a plain thank-you rather than silence. Sommeliers can close the loop themselves via the new `resolve_owner_inquiry` MCP tool instead of needing an admin in the web queue.

## Deploy notes

- No compose impact — no new services, env vars or ports.
- No migration. The new `ownerReply` field defaults to null on existing rows, and existing `resolutionNote` values are **not** retroactively published to owners.
- New notification type `owner_inquiry_resolved` (in-app + push, never email).
- ⚠️ Per the usual MCP rule, the somm needs a **fresh claude.ai conversation** after this deploy to pick up `resolve_owner_inquiry` — the tool cache is stale otherwise.
- Reminder: announcement banner ≥15 min before the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)