### PR TITLE
fix(stats): count Google SSO logins in the retention login figures

### DIFF
--- a/backend/src/services/globalStatsService.js
+++ b/backend/src/services/globalStatsService.js
@@ -8,7 +8,17 @@ const BottleImage = require('../models/BottleImage');
 const Rack = require('../models/Rack');
 const AuditLog = require('../models/AuditLog');
 
-// How far back the audit log retains entries (auth.login.success included).
+// Audit actions that mean "this user logged in". Google SSO writes its OWN
+// action (routes/oauth.js) — matching only 'auth.login.success' silently drops
+// every SSO-only user from the login figures while their bottles still count
+// in the activity figures, which is what made "users with bottles" exceed
+// "users who logged in". Both carry the user in `resource.id`.
+// Deliberately NOT included: 'auth.demo_login' (one shared demo account, not a
+// returning person) and 'auth.register' / 'auth.email_verified' (a session
+// starts there without a login — see the doc note on what this metric means).
+const LOGIN_ACTIONS = ['auth.login.success', 'auth.oauth.success'];
+
+// How far back the audit log retains entries (all LOGIN_ACTIONS included).
 // Login-based retention figures are bounded by this window. Mirrors the TTL in
 // models/AuditLog.js so the UI can caption "within the last N days".
 const AUDIT_WINDOW_DAYS = parseInt(process.env.AUDIT_TTL_DAYS || '90', 10);
@@ -423,16 +433,17 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
   const coreUsers = ret.t4 || 0;        // 4+ — a stickier tier, subset of the above
   const singleSessionUsers = Math.max(0, ret.usersWithActivity - returningUsers);
 
-  // Login-based signals, derived from the AUDIT LOG (action 'auth.login.success')
-  // rather than a per-user field — so we store NO new personal data for this
-  // feature (data minimisation) and the numbers are retroactive. Login audit
-  // entries record the user in `resource.id` (actor is anonymous at login time,
+  // Login-based signals, derived from the AUDIT LOG (see LOGIN_ACTIONS — both
+  // password and Google SSO logins) rather than a per-user field — so we store
+  // NO new personal data for this feature (data minimisation) and the numbers
+  // are retroactive. Login audit entries record the user in `resource.id`
+  // (actor is anonymous at login time,
   // pre-auth). Bounded by the audit TTL (AUDIT_WINDOW_DAYS), so "repeat logins"
   // means within that window. Persistent refresh-token sessions don't re-hit
   // /login, so these undercount the most loyal users by design — the
   // activity-based metric above is the headline for exactly that reason.
   const loginAuditMatch = {
-    action: 'auth.login.success',
+    action: { $in: LOGIN_ACTIONS },
     'resource.id': excludeAdmins && adminIds.length
       ? { $ne: null, $nin: adminIds }
       : { $ne: null },
@@ -883,5 +894,5 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
 module.exports = {
   computeGlobalStats,
   // Exported for tests: the retention day-ladder and its two halves.
-  __testing: { DAY_TIERS, tierAccumulators, tierRows },
+  __testing: { DAY_TIERS, tierAccumulators, tierRows, LOGIN_ACTIONS },
 };

--- a/backend/src/services/globalStatsService.retentionTiers.test.js
+++ b/backend/src/services/globalStatsService.retentionTiers.test.js
@@ -1,6 +1,27 @@
 const { __testing } = require('./globalStatsService');
 
-const { DAY_TIERS, tierAccumulators, tierRows } = __testing;
+const { DAY_TIERS, tierAccumulators, tierRows, LOGIN_ACTIONS } = __testing;
+
+describe('LOGIN_ACTIONS', () => {
+  it('counts Google SSO logins, not just password logins', () => {
+    // Regression guard: matching only 'auth.login.success' dropped every
+    // SSO-only user from the login figures while their bottles still counted
+    // in the activity figures — the dashboard then showed more users with
+    // bottles than users who had ever logged in.
+    expect(LOGIN_ACTIONS).toContain('auth.login.success');
+    expect(LOGIN_ACTIONS).toContain('auth.oauth.success');
+  });
+
+  it('excludes the shared demo account and non-login session starts', () => {
+    expect(LOGIN_ACTIONS).not.toContain('auth.demo_login');
+    expect(LOGIN_ACTIONS).not.toContain('auth.register');
+    expect(LOGIN_ACTIONS).not.toContain('auth.email_verified');
+  });
+
+  it('only matches successful auth events', () => {
+    expect(LOGIN_ACTIONS.every(a => !a.includes('failed'))).toBe(true);
+  });
+});
 
 describe('retention day-ladder (DAY_TIERS)', () => {
   it('is ascending and starts at 2 — a single day is never "returning"', () => {

--- a/docs/admin-global-stats-architecture.md
+++ b/docs/admin-global-stats-architecture.md
@@ -123,6 +123,16 @@ Each entry is `{ days, users, pct }`; tiers are **nested subsets** (the 4+ count
 
 **The two denominators differ on purpose.** A user with bottles who never logs in again still counts in `usersWithActivity`; a user who logs in weekly but never touches a bottle counts in `loginUsers` and in *no* activity tier. Don't sum or directly compare percentages across the two ladders.
 
+### Why `loginUsers` runs lower than `usersWithActivity`
+
+Seeing *more* users with bottle activity than users who ever logged in looks wrong but is expected. Three separate reasons stack up, and it's worth knowing them before treating the login ladder as a usage count:
+
+1. **The audit TTL.** Activity spans all history; logins only go back `AUDIT_TTL_DAYS` (90d). Anyone who added bottles a year ago and hasn't re-authenticated since appears in one ladder and not the other.
+2. **Registering is not logging in.** `POST /api/auth/register` issues tokens directly and logs `auth.register`. A user who signs up, adds bottles, and rides the rotating 30-day refresh cookie never hits `/login` and so never produces a login row.
+3. **Long-lived sessions.** The refresh cookie keeps users signed in for 30 days, rotating — the most loyal users re-authenticate *least* often.
+
+`LOGIN_ACTIONS` is the list of audit actions that count as a login. It **must** include `auth.oauth.success` alongside `auth.login.success`: Google SSO writes its own action, and matching only the password one silently dropped every SSO-only user from the login figures — a fourth, and unintended, reason the two sides disagreed. `auth.demo_login` is excluded (one shared account, not a returning person), as are `auth.register` / `auth.email_verified` (a session starts there, but calling it a "login" would change what the metric means).
+
 ## `excludeAdmins` filter chain
 
 **Admins are excluded by DEFAULT** (`excludeAdmins=true`) so the dashboard reflects real customers, not our own test/admin accounts. Pass `?excludeAdmins=false` to opt into the admin-inclusive view; the frontend toggle starts checked and sends the flag explicitly. When excluding, admin-owned data is filtered out of every per-user statistic (including the retention login audit, via `resource.id $nin adminIds`).


### PR DESCRIPTION
Follow-up to #960. This commit was pushed seconds after #960 was squash-merged, so it missed the merge and never landed.

## The bug

`routes/oauth.js` logs `auth.oauth.success`, but the stats aggregation matched only `auth.login.success`. Every Google-SSO-only user therefore contributed **zero** login days, while their bottles still counted in the activity figures. On the live dashboard that showed as **171 users with bottle activity against 122 who had ever logged in** — which reads as a broken metric.

Match a `LOGIN_ACTIONS` list instead, covering password and Google logins.

Excluded on purpose:
- `auth.demo_login` — one shared demo account, not a returning person.
- `auth.register` / `auth.email_verified` — a session does start there, but counting it would change what "logged in" means. Open to revisiting; it would make "signed up Monday, logged in Friday" read as 2 days instead of 1.

**This also corrects the pre-existing `Logged in (30d)` and `Repeat logins` cards**, which had the same blind spot before #960 — so those numbers have been under-reporting on the live dashboard for as long as Google SSO has been enabled.

## Why this is currently inconsistent on main

The tooltip copy that says *"Counts password and Google sign-ins"* reached main via #962, which picked it up from a shared working tree. The code backing that claim is in this PR. Until it merges, the tooltip promises something the aggregation doesn't do.

## Still-legitimate reasons the login side reads lower

Documented in `docs/admin-global-stats-architecture.md` rather than "fixed", since closing them would change the metric's meaning:

1. The audit TTL bounds logins to `AUDIT_TTL_DAYS` (90d) while activity spans all history.
2. Registering issues tokens directly and logs `auth.register` — a user can sign up, add bottles, and ride the rotating 30-day refresh cookie for months without ever hitting `/login`.

## Testing

- 3 new unit tests pin `LOGIN_ACTIONS` (SSO counted, demo/register excluded, no `failed` actions), alongside the 8 ladder tests from #960 — 11 total, passing in `node:20-alpine`.
- No compose or env changes. No new personal data stored — this only widens which existing audit actions are read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
