### PR TITLE
fix(bottles): offer the 1 litre format in the bottle size picker

### DIFF
--- a/backend/src/config/bottleSizes.js
+++ b/backend/src/config/bottleSizes.js
@@ -18,6 +18,7 @@ const BOTTLE_SIZES = [
   { ml: 500, code: '500ml', nameKey: 'halfLitre' },
   { ml: 620, code: '620ml', nameKey: 'clavelin' },     // Jura vin jaune
   { ml: 750, code: '750ml', nameKey: 'standard' },
+  { ml: 1000, code: '1000ml', nameKey: 'litre' },     // Alsace/German/Austrian everyday format
   { ml: 1500, code: '1500ml', nameKey: 'magnum' },
   { ml: 3000, code: '3000ml', nameKey: 'doubleMagnum' },
   { ml: 6000, code: '6000ml', nameKey: 'imperial' },

--- a/backend/src/config/bottleSizes.test.js
+++ b/backend/src/config/bottleSizes.test.js
@@ -14,6 +14,9 @@ describe('normalizeBottleSize', () => {
     ['620ml', '620ml'],           // Clavelin — kept as-is
     ['375ml (Half)', '375ml'],
     ['75cl', '750ml'],            // centilitres
+    ['100cl', '1000ml'],          // litre bottle, as printed on Alsace/German labels
+    ['1L', '1000ml'],
+    ['1 litre', '1000ml'],
     [750, '750ml'],               // bare number ml
     [1.5, '1500ml'],              // bare number litres
     ['', null],

--- a/frontend/src/config/bottleSizes.js
+++ b/frontend/src/config/bottleSizes.js
@@ -11,6 +11,7 @@ export const BOTTLE_SIZES = [
   { ml: 500, code: '500ml', nameKey: 'halfLitre' },
   { ml: 620, code: '620ml', nameKey: 'clavelin' },
   { ml: 750, code: '750ml', nameKey: 'standard' },
+  { ml: 1000, code: '1000ml', nameKey: 'litre' },
   { ml: 1500, code: '1500ml', nameKey: 'magnum' },
   { ml: 3000, code: '3000ml', nameKey: 'doubleMagnum' },
   { ml: 6000, code: '6000ml', nameKey: 'imperial' },

--- a/frontend/src/config/bottleSizes.test.js
+++ b/frontend/src/config/bottleSizes.test.js
@@ -1,0 +1,62 @@
+import { BOTTLE_SIZES, bottleSizeLabel, formatVolume, mlFromCode, normalizeBottleSize } from './bottleSizes';
+import en from '../locales/en/translation.json';
+
+// Stand-in for i18n's t(): resolves the dotted key against the en bundle so a
+// missing bottleSizeNames entry shows up as a failing label, not as the raw key
+// silently rendered to the user.
+const t = (key) => key.split('.').reduce((acc, part) => (acc == null ? undefined : acc[part]), en);
+
+describe('BOTTLE_SIZES', () => {
+  test('is sorted ascending by volume — the pickers render it in array order', () => {
+    const mls = BOTTLE_SIZES.map((s) => s.ml);
+    expect(mls).toEqual([...mls].sort((a, b) => a - b));
+  });
+
+  test('every entry has an en translation for its nameKey', () => {
+    for (const s of BOTTLE_SIZES) {
+      expect(en.bottleSizeNames[s.nameKey]).toBeTruthy();
+    }
+  });
+
+  test('every code round-trips through normalizeBottleSize', () => {
+    for (const s of BOTTLE_SIZES) {
+      expect(normalizeBottleSize(s.code)).toBe(s.code);
+      expect(mlFromCode(s.code)).toBe(s.ml);
+    }
+  });
+
+  test('includes the 1 litre format', () => {
+    expect(BOTTLE_SIZES.find((s) => s.code === '1000ml')).toBeTruthy();
+  });
+});
+
+describe('bottleSizeLabel', () => {
+  test('names the litre bottle', () => {
+    expect(bottleSizeLabel('1000ml', t)).toBe('1 L (Litre)');
+  });
+
+  test('keeps the existing formats intact', () => {
+    expect(bottleSizeLabel('750ml', t)).toBe('750 ml (Standard)');
+    expect(bottleSizeLabel('1500ml', t)).toBe('1.5 L (Magnum)');
+  });
+
+  test('falls back to a bare volume for an unnamed code', () => {
+    expect(bottleSizeLabel('900ml', t)).toBe('900 ml');
+  });
+});
+
+describe('normalizeBottleSize — litre inputs', () => {
+  test.each([
+    ['100cl', '1000ml'],
+    ['1L', '1000ml'],
+    ['1 litre', '1000ml'],
+    ['1,0 l', '1000ml'],
+    [1, '1000ml'],
+  ])('%p → %p', (input, expected) => {
+    expect(normalizeBottleSize(input)).toBe(expected);
+  });
+});
+
+test('formatVolume renders a litre without trailing zeros', () => {
+  expect(formatVolume(1000)).toBe('1 L');
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1963,6 +1963,7 @@
     "halfLitre": "Half-litre",
     "clavelin": "Clavelin",
     "standard": "Standard",
+    "litre": "Litre",
     "magnum": "Magnum",
     "doubleMagnum": "Double Magnum",
     "imperial": "Imperial"


### PR DESCRIPTION
## Why

A user filed a wine report today they could not resolve themselves:

> Bottle size is 100cl, but that's not an option I can select in the bottle size field.

They were right. The canonical list goes 187 / 375 / 500 / 620 / 750 / **1500** / 3000 / 6000 — no litre. The litre is the everyday format across Alsace, Germany and Austria, so this is a routine bottle to own and there was no way to record it.

## What was already fine

Storage never had the gap — only the picker did:

- `normalizeBottleSize` already parses `100cl`, `1L`, `1 litre`, `1,0 l` and bare `1` to `1000ml`
- `bottleSizeLabel` already renders an unnamed code as a bare volume (`1 L`)
- `EditForm` already keeps a stored value that is not in the list

So this adds one entry to each of the two hand-synced mirrors, plus the `bottleSizeNames.litre` label so it reads **1 L (Litre)** instead of falling back to a bare `1 L`. It slots between standard and magnum, keeping the array ascending — both selects render it in array order.

## Tests

`frontend/src/config/bottleSizes.js` had no suite at all; this adds one. Beyond the litre itself it pins two things that were previously unguarded:

- the **ascending order** the two pickers depend on
- that **every entry has an en translation for its `nameKey`** — otherwise adding a size ships a raw i18n key into the dropdown, which is exactly the mistake this PR could have made

Backend suite gains `100cl` / `1L` / `1 litre` cases.

- `frontend`: 58 files, 941 tests pass (full suite)
- `backend`: the 11 suites touching bottle sizes pass, 197 tests

## Compose / prod impact

None. No env vars, no migration, no compose change — the two `VITE_`-independent config files are baked into the normal frontend build.

## Follow-up, not in this PR

Existing bottles that a user recorded as 750ml because a litre was unavailable are not detectable, so nothing is migrated. `Admin → Taxonomy → Bottle sizes` can remap any stray stored values to `1000ml` if they turn up.