### PR TITLE
fix(registry): stop the import/scan write paths minting inferred identities

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -31,12 +31,15 @@ Use all available information — text on the label, your knowledge of real wine
 - Infer the wine type and grapes from all available clues — appellation rules, producer style, label design, bottle shape, language
 
 Respond with ONLY a raw JSON object (no markdown, no code fences, no extra text):
-{"name":"wine name WITHOUT the vintage year and WITHOUT the producer name","producer":"producer or winery name","vintage":"4-digit year or null","country":"country","region":"wine region","appellation":"appellation/AOC/DOC/IGT/AVA or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
+{"name":"wine name WITHOUT the vintage year and WITHOUT the producer name","producer":"producer or winery name, or null if the producer is not printed","vintage":"4-digit year or null","country":"country","region":"wine region","appellation":"appellation/AOC/DOC/IGT/AVA or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"classification":"the printed classification/tier line (e.g. Grand Cru Classé en 1855, Cru Bourgeois) or null","confidence":0.0}
 
 confidence: 1.0 = label clearly readable and matches a wine you know well, 0.7 = some fields inferred from appellation/producer knowledge, 0.4 = mostly inferred from limited clues, 0.2 = very uncertain.
 
 Important rules:
-- Never invent a wine that does not exist. If you can read a producer name or label text, use it exactly — do not guess or substitute a similar-sounding wine.
+- Never invent a wine that does not exist. If you can read the producer's name, use it exactly — do not guess or substitute a similar-sounding wine.
+- The producer field takes ONLY the actual estate/winery/house. Many labels lead with something else in the largest type: a brand or fantasy name the house created for one range (e.g. "Fabelhaft" is a Niepoort label), an artwork or cuvée title, or a distributor's line. Those are NOT the producer. If the actual producer is not printed anywhere you can read, return null for producer — never promote a brand line, artwork title, or any other prominent text into the producer field. A null producer with the rest filled in is a GOOD answer; the back label often resolves it.
+- Regulatory and bottler codes are never the producer: inspectorate acronyms and lot codes (e.g. Italy's ICQRF code, "L." lot numbers, importer registration lines) identify paperwork, not the winery.
+- Classification and ranking lines ("Grand Cru Classé en 1855", "Cru Bourgeois", "Classified Growth") go in the classification field, NEVER in the name. If the label names the wine only by its estate (a classed-growth grand vin), the name is the estate's wine name — not the classification line printed under it. Aging terms that are part of the displayed name (Reserva, Riserva, Spätlese) still follow the name rule above.
 - The name field must contain ONLY the wine's own cuvée/vineyard/variety name — never repeat the producer in it (producer "Chard Farm" + name "River Run Pinot Noir", NOT name "Chard Farm River Run Pinot Noir").
 - Labels often print a founder's or family name as part of the producer's crest/logo lockup (e.g. "DESIDERIUS" in small text above "PONGRÁCZ"). Such words belong to the producer identity, NOT the wine name. The name is the line that distinguishes this bottle within the producer's range (here "Blanc de Blancs") — include a person's name only when it genuinely names the cuvée itself (e.g. Pongrácz's separate prestige bottling "Desiderius").
 - Production-method terms are NOT part of the name — put "Méthode Cap Classique" / "Cap Classique", "Méthode Traditionnelle", "Metodo Classico" / "Traditional Method" in the appellation field instead (name "Blanc de Blancs" + appellation "Méthode Cap Classique", NOT name "Blanc de Blancs Méthode Cap Classique"). Legally-defined aging classifications that belong to the displayed name (Reserva, Gran Reserva, Riserva, Spätlese, Grosses Gewächs) and dosage words that are part of a cuvée name (e.g. "Brut Premier") stay in the name.
@@ -75,7 +78,7 @@ Rules:
 - Grapes: only varieties this specific wine actually contains, as stated on the back label.
 
 Respond with ONLY a raw JSON object (no markdown, no code fences, no extra text), using null for every field the back label does not state:
-{"name":"wine name or null","producer":"producer or winery name or null","vintage":"4-digit year or null","country":"country or null","region":"wine region or null","appellation":"appellation/AOC/DOC/IGT/AVA or null","type":"red|white|rosé|sparkling|dessert|fortified or null","grapes":["grape varieties"]}
+{"name":"wine name or null","producer":"producer or winery name or null","vintage":"4-digit year or null","country":"country or null","region":"wine region or null","appellation":"appellation/AOC/DOC/IGT/AVA or null","type":"red|white|rosé|sparkling|dessert|fortified or null","grapes":["grape varieties"],"classification":"the stated classification/tier line or null"}
 
 Only return {"error":"cannot read label"} if the image contains no wine label at all.`;
 
@@ -87,16 +90,17 @@ Wine: {{name}}
 Producer: {{producer}}
 {{vintage}}{{country}}
 Return ONLY a raw JSON object (no markdown, no code fences):
-{"name":"wine name","producer":"producer name","country":"country","region":"region or null","appellation":"appellation or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
+{"name":"wine name","producer":"producer name","country":"country or null","region":"region or null","appellation":"appellation or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
 
 Rules:
 - Use the wine name and producer exactly as given (correct only obvious typos)
 - The name field must contain ONLY the wine's own cuvée/vineyard/variety name — never prepend or repeat the producer in it. If the given name starts with the producer name, strip that prefix (producer "Penfolds" + name "Penfolds Bin 407" → name "Bin 407")
 - NEVER change the wine into a different wine: do not add a grape variety, cuvée, or vineyard to the name that the given data does not mention, and do not substitute another wine from the same producer. If the given name does not match a wine this producer actually makes, keep the name as given rather than "correcting" it to a similar-sounding wine
 - Production-method terms are NOT part of the name — move "Méthode Cap Classique" / "Cap Classique", "Méthode Traditionnelle", "Metodo Classico" / "Traditional Method" to the appellation field (name "Blanc de Blancs" + appellation "Méthode Cap Classique"). Aging classifications that belong to the displayed name (Reserva, Gran Reserva, Riserva, Spätlese, Grosses Gewächs) and dosage words that are part of a cuvée name (e.g. "Brut Premier") stay in the name
-- Fill in country, region, appellation, type, and grapes from your wine knowledge
-- Country is REQUIRED — always provide a country name; it is never acceptable to return null for country
+- Fill in country, region, appellation, type, and grapes from your wine knowledge — but ONLY what you actually know about THIS wine. A field you are not reasonably sure of is null, never a guess
+- Country: use the country the import data states, or the one you know this wine comes from. If you recognise the wine or producer you almost always know its country; return null ONLY when you truly cannot say — a guessed country is worse than none
 - Country must be the canonical English country name: "United States" (never "USA" or "America"), "Germany" (never "Deutschland"/"Tyskland"), "Italy" (never "Italia"/"Italie"), "England" for English wines — never a local-language or abbreviated name, even if the import data uses one
+- Region is where THIS specific wine is grown — NEVER assumed from where the producer is based. Producers routinely make wines in several regions (a Barossa-based brand can bottle a McLaren Vale Shiraz), so producer knowledge alone never sets the region. If the most precise place you know for this wine is its appellation, use that same place as the region (appellation "Barossa Valley" → region "Barossa Valley", not "South Australia"). When unsure, region is null
 - For any other field you are unsure about, use null — do NOT omit the field
 - Grapes: provide an empty array [] if unknown, never null for grapes. List only varieties you know THIS cuvée contains — single-variety appellations may be inferred (Barolo → Nebbiolo), but for multi-variety appellations (Champagne, southern-Rhône blends, Bordeaux) never default to the appellation's full permitted set; fewer correct grapes beat a complete-looking list
 - confidence: 1.0 = well-known wine you are certain about, 0.7 = confident from producer knowledge, 0.5 = reasonably sure

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -114,6 +114,19 @@ const wineDefinitionSchema = new mongoose.Schema({
     producerNote:    { type: String,  default: null, trim: true },
     model:        { type: String, default: null, trim: true }, // model that produced it
     generatedAt:  { type: Date,   default: null },             // when it was generated
+    // Generation ran but PUBLICATION was withheld: the model flagged the
+    // producer as suspect (a brand/range sold as a producer, a place, a
+    // label term), so describing "this producer's style" would be confident
+    // fiction about a company that may not exist (ticket 6a8162c5 —
+    // "Fabelhaft" got a négociant biography). A held profile stores only the
+    // doubt (confidence/producerSuspect/producerNote); description and the
+    // structured descriptors stay null, which is what keeps every read
+    // surface (bottle page, MCP, embeddings) naturally silent. Cleared by:
+    // a curator profile write, an admin identity edit (re-enrich under the
+    // corrected identity), or profile-reviewed (human overrides the doubt →
+    // forced publish). Guards in enrichmentJob treat heldAt as "already
+    // decided" so neither the per-add hook nor incremental batches loop on it.
+    heldAt:       { type: Date,   default: null },
     // Provenance. 'ai' = written by enrichmentJob; 'curator' = a sommelier or
     // admin corrected it by hand (routes/somm/wineProfile.js or the MCP
     // set_wine_profile tool). The distinction is load-bearing, not cosmetic:

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -664,12 +664,25 @@ router.post('/:id/non-wine', async (req, res) => {
 router.post('/:id/profile-reviewed', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
-    const wine = await WineDefinition.findById(req.params.id).select('name producer');
+    const wine = await WineDefinition.findById(req.params.id).select('name producer aiProfile.heldAt');
     if (!wine) return res.status(404).json({ error: 'Wine not found' });
     const now = new Date();
     await WineDefinition.updateOne({ _id: wine._id }, { $set: { profileReviewedAt: now } });
     logAudit(req, 'admin.wine.profileReviewed', { type: 'wine', id: wine._id },
       { name: wine.name, producer: wine.producer });
+    // A HELD profile + an admin review = the human override the hold was
+    // waiting for: the admin looked at the model's producer doubt and judged
+    // the identity fine, so regenerate and PUBLISH (the suspect flag stays on
+    // the row as provenance). Fire-and-forget; on success the review stamp is
+    // re-bumped past the fresh generatedAt so the row doesn't instantly
+    // re-surface as unreviewed. If the admin instead agrees the identity is
+    // wrong, the fix is the wine editor — the identity edit re-enriches.
+    if (wine.aiProfile?.heldAt) {
+      const { enrichWineById } = require('../../services/enrichmentJob');
+      enrichWineById(wine._id, { force: true, publishSuspect: true })
+        .then(() => WineDefinition.updateOne({ _id: wine._id }, { $set: { profileReviewedAt: new Date() } }))
+        .catch(() => {});
+    }
     res.json({ message: 'Marked reviewed', profileReviewedAt: now });
   } catch (error) {
     console.error('Profile-reviewed error:', error);
@@ -721,6 +734,13 @@ router.get('/low-confidence', async (req, res) => {
       $or: [
         { 'aiProfile.confidence': null },
         { 'aiProfile.confidence': { $lte: threshold } },
+        // A suspect producer is a doubt about the IDENTITY, not the profile's
+        // confidence — Fabelhaft's flagged at 0.5 while the default threshold
+        // is 0.3, so the one row the flag existed for never surfaced here
+        // (ticket 6a8162c5). Suspect rows now appear regardless of threshold;
+        // since v-this their profiles are also HELD unpublished until someone
+        // in this queue decides.
+        { 'aiProfile.producerSuspect': true },
       ],
       // Only rows that were actually enriched — without this, every wine that
       // has no aiProfile at all would match the null branch above.
@@ -739,7 +759,7 @@ router.get('/low-confidence', async (req, res) => {
     const filter = includeReviewed ? base : outstanding;
     const [rows, total, reviewedCount] = await Promise.all([
       WineDefinition.find(filter)
-        .select('name producer appellation nonWine profileReviewedAt aiProfile.confidence aiProfile.description aiProfile.producerSuspect aiProfile.producerNote aiProfile.generatedAt')
+        .select('name producer appellation nonWine profileReviewedAt aiProfile.confidence aiProfile.description aiProfile.producerSuspect aiProfile.producerNote aiProfile.generatedAt aiProfile.heldAt')
         .populate('region', 'name')
         .populate('country', 'name')
         .sort({ 'aiProfile.confidence': 1, producer: 1 })
@@ -773,6 +793,7 @@ router.get('/low-confidence', async (req, res) => {
         producerSuspect: w.aiProfile?.producerSuspect === true,
         producerNote: w.aiProfile?.producerNote || null,
         generatedAt: w.aiProfile?.generatedAt || null,
+        heldAt: w.aiProfile?.heldAt || null,
         profileReviewedAt: w.profileReviewedAt || null,
         bottleCount: bottleCounts.get(String(w._id)) || 0,
       })),
@@ -1345,6 +1366,18 @@ router.put('/:id', async (req, res) => {
       { type: 'wine', id: wine._id },
       { fields: Object.keys(req.body) }
     );
+
+    // An identity edit (name/producer) makes any AI profile a description of
+    // the WRONG wine — including a HELD one, whose whole point was "this
+    // producer looks fictional": the admin just fixed exactly that. Regenerate
+    // under the corrected identity (fire-and-forget, no user budget — this is
+    // a deliberate admin action). Curator-written profiles are never touched
+    // (enrichWineById refuses those, force or not); if the model still doubts
+    // the new identity it simply holds again, which is the correct outcome.
+    if ((name || producer) && wine.aiProfile?.generatedAt && wine.aiProfile?.source !== 'curator') {
+      const { enrichWineById } = require('../../services/enrichmentJob');
+      enrichWineById(wine._id, { force: true }).catch(() => {});
+    }
 
     submitUrls(`/wines/${wine._id}`);
 

--- a/backend/src/routes/admin/wines.lowConfidence.test.js
+++ b/backend/src/routes/admin/wines.lowConfidence.test.js
@@ -107,6 +107,12 @@ describe('GET /low-confidence', () => {
     expect(filter.$or).toEqual([
       { 'aiProfile.confidence': null },
       { 'aiProfile.confidence': { $lte: 0.3 } },
+      // Suspect producers surface REGARDLESS of threshold (ticket 6a8162c5):
+      // the flag is a doubt about the identity, not the profile's confidence
+      // — Fabelhaft sat at 0.5 while the default threshold is 0.3, so the one
+      // row the flag existed for never appeared here. Held profiles land in
+      // this queue through this branch.
+      { 'aiProfile.producerSuspect': true },
     ]);
     // Scoped to rows that were actually enriched, or every un-enriched wine
     // would match the null branch.
@@ -141,6 +147,12 @@ describe('GET /low-confidence', () => {
     expect(filter.$or).toEqual([
       { 'aiProfile.confidence': null },
       { 'aiProfile.confidence': { $lte: 0.3 } },
+      // Suspect producers surface REGARDLESS of threshold (ticket 6a8162c5):
+      // the flag is a doubt about the identity, not the profile's confidence
+      // — Fabelhaft sat at 0.5 while the default threshold is 0.3, so the one
+      // row the flag existed for never appeared here. Held profiles land in
+      // this queue through this branch.
+      { 'aiProfile.producerSuspect': true },
     ]);
     // Scoped to rows that were actually enriched, or every un-enriched wine
     // would match the null branch.

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -52,6 +52,16 @@ router.use(requireAuth, requireNonDemo);
 const EXACT_THRESHOLD = IMPORT_EXACT_THRESHOLD;
 const FUZZY_THRESHOLD = IMPORT_FUZZY_THRESHOLD;
 
+// Below this identification confidence the AI is going on inference, not
+// knowledge ("0.5 = reasonably sure" in the prompt's own scale) — exactly the
+// band that wrote a producer's home region onto wines from elsewhere and split
+// one producer across region granularities (ticket 6a8162c5). Geography the
+// AI proposed under this floor is dropped before it can mint; the curation
+// backfill queue fills it from evidence instead. Import files carry no
+// region/appellation columns, so this only ever strips AI inference — never
+// user data.
+const AI_GEOGRAPHY_MIN_CONFIDENCE = 0.6;
+
 /**
  * Score a WineDefinition candidate against an import item.
  * Delegates to the shared wineMatching service. Variant-aware: import rows
@@ -401,6 +411,73 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
         pr.aiDebugReason = settled.value.debugReason;
       } else {
         pr.aiError = settled.reason?.message;
+      }
+    }
+
+    // ── Post-AI hygiene (ticket 6a8162c5) — BEFORE any matching, so the
+    // cleaned values feed Pass 2, the client preview, and /confirm alike. ──
+    //
+    // A) One producer, one country per batch. Rows are identified one at a
+    //    time, so an obscure producer can come back with a different guessed
+    //    country per row ("Thomas Allen": South Africa on one, Australia on
+    //    another — both minted, and the different-country guard then keeps
+    //    them apart forever). Rows whose FILE stated a country are anchors
+    //    and are never overwritten; when the file is silent, every row of a
+    //    producer adopts one country — the anchors' (when they agree), else
+    //    the highest-confidence AI row's.
+    const aiRowsByProducer = new Map();
+    for (const pr of preResults) {
+      if (!pr.aiIdentified || typeof pr.aiIdentified.producer !== 'string') continue;
+      const prodKey = normalizeString(pr.aiIdentified.producer);
+      if (!prodKey) continue;
+      if (!aiRowsByProducer.has(prodKey)) aiRowsByProducer.set(prodKey, []);
+      aiRowsByProducer.get(prodKey).push(pr);
+    }
+    for (const rows of aiRowsByProducer.values()) {
+      const aiCountryKey = (pr) =>
+        (typeof pr.aiIdentified.country === 'string' && pr.aiIdentified.country.trim())
+          ? normalizeString(pr.aiIdentified.country) : '';
+      const distinct = new Set(rows.map(aiCountryKey).filter(Boolean));
+      if (distinct.size === 0) continue; // no row knows a country — nothing to spread
+      const fileAnchored = rows.filter(pr => typeof pr.item.country === 'string' && pr.item.country.trim());
+      let adopted = null;
+      if (distinct.size === 1) {
+        // Group already agrees — only rows the AI left countryless (which
+        // could not mint at all) inherit it below.
+        adopted = rows.find(pr => aiCountryKey(pr)).aiIdentified.country;
+      } else if (fileAnchored.length > 0) {
+        // The file knows best — but only when it names ONE country. Two
+        // file-backed countries for one producer is real information
+        // (a brand genuinely bottling on two continents): touch nothing.
+        const anchorCountries = new Set(fileAnchored.map(aiCountryKey).filter(Boolean));
+        if (anchorCountries.size !== 1) continue;
+        adopted = fileAnchored.find(pr => aiCountryKey(pr)).aiIdentified.country;
+      } else {
+        const best = rows.reduce((a, b) =>
+          ((b.aiIdentified.confidence ?? 0) > (a.aiIdentified.confidence ?? 0) ? b : a));
+        adopted = best.aiIdentified.country;
+      }
+      if (!adopted) continue;
+      for (const pr of rows) {
+        // Never overwrite a row the file itself anchored, and when the group
+        // already agreed, only FILL gaps — never touch a stated value.
+        if (typeof pr.item.country === 'string' && pr.item.country.trim()) continue;
+        if (distinct.size === 1 && aiCountryKey(pr)) continue;
+        pr.aiIdentified.country = adopted;
+      }
+    }
+    //
+    // B) Low-confidence geography never mints. Applied to aiIdentified itself
+    //    (one mutation point), so matching, the aiProposed the client sees,
+    //    and the /confirm mint all agree. A missing/non-numeric confidence is
+    //    the "nobody can vouch for this" state and strips too — same stance
+    //    as the admin low-confidence queue.
+    for (const pr of preResults) {
+      if (!pr.aiIdentified) continue;
+      const conf = pr.aiIdentified.confidence;
+      if (!(typeof conf === 'number' && conf >= AI_GEOGRAPHY_MIN_CONFIDENCE)) {
+        pr.aiIdentified.region = null;
+        pr.aiIdentified.appellation = null;
       }
     }
 

--- a/backend/src/routes/import.validate.geography.test.js
+++ b/backend/src/routes/import.validate.geography.test.js
@@ -1,0 +1,264 @@
+/**
+ * POST /api/bottles/import/validate — post-AI geography hygiene
+ * (ticket 6a8162c5: the 226-row batch that split one producer across region
+ * granularities and across countries).
+ *
+ * Two behaviours pinned, both applied to aiIdentified BEFORE matching so the
+ * preview, the aiProposed payload and the /confirm mint all agree:
+ *
+ *   A) One producer, one country per batch. Per-row identification let an
+ *      obscure producer come back as South Africa on one row and Australia on
+ *      another; both minted, and the different-country guard then kept them
+ *      apart forever. Rows whose FILE stated a country anchor the group and
+ *      are never overwritten.
+ *
+ *   B) Geography identified below AI_GEOGRAPHY_MIN_CONFIDENCE (0.6) is
+ *      dropped (region/appellation → null): "reasonably sure" is the band
+ *      that wrote the producer's home region onto wines from elsewhere
+ *      (Sister's Run "Epiphany", a McLaren Vale Shiraz recorded as Barossa).
+ *      Country is kept — a wine cannot mint without one, and the same
+ *      producer-consistency pass above governs it.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+// AI is CONFIGURED in this suite — the hygiene pass only runs on AI results.
+jest.mock('../services/aiProvider', () => ({ isConfigured: () => true }));
+jest.mock('../services/aiBudget', () => ({
+  tryDebitAi: jest.fn().mockResolvedValue({ ok: true, refund: jest.fn() }),
+  isRefundableFailure: jest.fn(() => false),
+}));
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexWine: () => {},
+  bulkIndexBottles: jest.fn(),
+}));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/priceWarnings', () => ({
+  computeUserMediansByCurrency: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/Country', () => ({ findOne: jest.fn().mockResolvedValue(null) }));
+jest.mock('../models/ImportSession', () => ({}));
+jest.mock('../models/Bottle', () => function Bottle() {});
+jest.mock('../models/WineRequest', () => function WineRequest() {});
+jest.mock('../models/AiUsage', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => {
+  const model = { find: jest.fn() };
+  model.RACK_TYPES = ['grid'];
+  return model;
+});
+jest.mock('../models/WineDefinition', () => {
+  const chain = (docs) => {
+    const c = { populate: () => c, sort: () => c, limit: () => c, lean: async () => docs };
+    return c;
+  };
+  return {
+    findOne: jest.fn(() => ({ populate: async () => null })),
+    find: jest.fn(() => chain([])),
+    findById: jest.fn(),
+  };
+});
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const { identifyWineFromText } = require('../services/labelScan');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const rateLimitsConfig = require('../config/rateLimits');
+const importRouter = require('./import');
+
+const USER_ID = '64b000000000000000000001';
+const CELLAR_ID = '64b0000000000000000000bb';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles/import', importRouter);
+  return app;
+}
+
+function authToken() {
+  return jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+}
+
+function postJson(app, url, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${authToken()}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.write(payload);
+      req.end();
+    });
+  });
+}
+
+const validate = (items) => postJson(buildApp(), '/api/bottles/import/validate', { cellarId: CELLAR_ID, items });
+
+/** identifyWineFromText result for one row (echoes name/producer like the real prompt). */
+const aiResult = (over = {}) => ({
+  data: {
+    name: over.name, producer: over.producer,
+    country: 'Australia', region: null, appellation: null,
+    type: 'red', grapes: [], confidence: 0.9,
+    ...over,
+  },
+  debugRaw: 'raw', debugReason: null,
+});
+
+/** Dispatch AI results by wine name — the identify calls run concurrently, so
+ *  mockResolvedValueOnce ordering would be a race. */
+const primeAi = (...results) => {
+  const byName = new Map(results.map((r) => [r.data.name, r]));
+  identifyWineFromText.mockImplementation(async ({ name }) => byName.get(name));
+};
+
+beforeAll(() => {
+  rateLimitsConfig.set(JSON.parse(JSON.stringify(rateLimitsConfig.defaults)));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, user: USER_ID, deletedAt: null, members: [] });
+  // Registry knows nothing → every AI identification comes back aiProposed.
+  findOrCreateWine.mockResolvedValue({ wine: null, noMatch: true });
+});
+
+describe('B) confidence floor on AI geography', () => {
+  test('region/appellation identified below 0.6 are stripped from aiProposed', async () => {
+    primeAi(aiResult({
+      name: 'Epiphany', producer: "Sister's Run",
+      region: 'Barossa Valley', appellation: 'Barossa Valley', confidence: 0.5,
+    }));
+
+    const res = await validate([{ wineName: 'Epiphany', producer: "Sister's Run", vintage: '2021' }]);
+
+    expect(res.status).toBe(200);
+    const row = res.body.results[0];
+    expect(row.status).toBe('ai_new');
+    expect(row.aiProposed.region).toBeNull();
+    expect(row.aiProposed.appellation).toBeNull();
+    // Country survives the floor — a wine cannot mint without one.
+    expect(row.aiProposed.country).toBe('Australia');
+    // And the matcher saw the stripped shape too, not just the response.
+    expect(findOrCreateWine.mock.calls[0][0].region).toBeNull();
+    expect(findOrCreateWine.mock.calls[0][0].appellation).toBeNull();
+  });
+
+  test('a missing/non-numeric confidence strips too — unknown means nobody can vouch', async () => {
+    primeAi(aiResult({
+      name: 'Ghost Block', producer: 'Phantom Estate',
+      region: 'Hunter Valley', appellation: 'Hunter Valley', confidence: undefined,
+    }));
+
+    const res = await validate([{ wineName: 'Ghost Block', producer: 'Phantom Estate' }]);
+    expect(res.body.results[0].aiProposed.region).toBeNull();
+    expect(res.body.results[0].aiProposed.appellation).toBeNull();
+  });
+
+  test('at or above 0.6 the identified geography is kept', async () => {
+    primeAi(aiResult({
+      name: 'Vat 9', producer: "Tyrrell's",
+      region: 'Hunter Valley', appellation: 'Hunter Valley', confidence: 0.6,
+    }));
+
+    const res = await validate([{ wineName: 'Vat 9', producer: "Tyrrell's" }]);
+    expect(res.body.results[0].aiProposed.region).toBe('Hunter Valley');
+    expect(res.body.results[0].aiProposed.appellation).toBe('Hunter Valley');
+  });
+});
+
+describe('A) one producer, one country per batch', () => {
+  test('two AI-guessed countries for one producer unify to the higher-confidence row', async () => {
+    primeAi(
+      aiResult({ name: 'Mistura', producer: 'Thomas Allen', country: 'South Africa', confidence: 0.5 }),
+      aiResult({ name: 'Origins', producer: 'Thomas Allen', country: 'Australia', confidence: 0.7 }));
+
+    const res = await validate([
+      { wineName: 'Mistura', producer: 'Thomas Allen' },
+      { wineName: 'Origins', producer: 'Thomas Allen' },
+    ]);
+
+    const [a, b] = res.body.results;
+    expect(a.aiProposed.country).toBe('Australia');
+    expect(b.aiProposed.country).toBe('Australia');
+  });
+
+  test('rows whose FILE stated a country anchor the group and are never overwritten', async () => {
+    primeAi(
+      aiResult({ name: 'Mistura', producer: 'Thomas Allen', country: 'South Africa', confidence: 0.9 }),
+      aiResult({ name: 'Origins', producer: 'Thomas Allen', country: 'Australia', confidence: 0.5 }));
+
+    // Row 2's country came from the import file itself — it anchors.
+    const res = await validate([
+      { wineName: 'Mistura', producer: 'Thomas Allen' },
+      { wineName: 'Origins', producer: 'Thomas Allen', country: 'Australia' },
+    ]);
+
+    const [a, b] = res.body.results;
+    expect(b.aiProposed.country).toBe('Australia');  // anchor untouched
+    expect(a.aiProposed.country).toBe('Australia');  // free row adopts the anchor
+  });
+
+  test('a row the AI left countryless inherits the group country instead of failing to mint', async () => {
+    primeAi(
+      aiResult({ name: 'Vat 9', producer: "Tyrrell's", country: 'Australia', confidence: 0.9 }),
+      aiResult({ name: 'Vat 47', producer: "Tyrrell's", country: null, confidence: 0.7 }));
+
+    const res = await validate([
+      { wineName: 'Vat 9', producer: "Tyrrell's" },
+      { wineName: 'Vat 47', producer: "Tyrrell's" },
+    ]);
+
+    expect(res.body.results[1].aiProposed.country).toBe('Australia');
+  });
+
+  test('two file-backed countries for one producer are real information — nothing is touched', async () => {
+    primeAi(
+      aiResult({ name: 'Mistura', producer: 'Thomas Allen', country: 'South Africa', confidence: 0.9 }),
+      aiResult({ name: 'Origins', producer: 'Thomas Allen', country: 'Australia', confidence: 0.9 }));
+
+    const res = await validate([
+      { wineName: 'Mistura', producer: 'Thomas Allen', country: 'South Africa' },
+      { wineName: 'Origins', producer: 'Thomas Allen', country: 'Australia' },
+    ]);
+
+    expect(res.body.results[0].aiProposed.country).toBe('South Africa');
+    expect(res.body.results[1].aiProposed.country).toBe('Australia');
+  });
+});

--- a/backend/src/scripts/normalize-region-to-appellation.js
+++ b/backend/src/scripts/normalize-region-to-appellation.js
@@ -1,0 +1,145 @@
+/**
+ * Normalize wine.region to the appellation's own region — the batch half of
+ * the region-granularity canon (Johan, 2026-08-16 / ticket 6a8162c5).
+ *
+ * CANON: when a wine's appellation itself names a region the taxonomy has
+ * (appellation "Hunter Valley", and a Hunter Valley Region doc under the same
+ * country), the region field holds THAT region — the most specific
+ * granularity — not a parent ("New South Wales") or the producer's home
+ * region. The mint-time half is services/findOrCreateWine.regionForAppellation
+ * (all four mint surfaces); this script folds the rows that predate it.
+ * Measured on prod 2026-08-16: 506 published rows, led by
+ * California→Napa Valley (51), South Australia→Barossa Valley (25),
+ * New South Wales→Hunter Valley (24) — plus 6 rows whose region was null
+ * while the appellation named a known region.
+ *
+ * SHARED RESOLUTION, by construction: each row is resolved through the SAME
+ * regionForAppellation the mint path uses, so this script and the chokepoint
+ * cannot drift. MATCH-ONLY there and here — an appellation string never
+ * mints a Region (appellations are unvalidated free text).
+ *
+ * Rows skipped: no appellation, nonWine (quarantine is not churned), no
+ * country, appellation matching no Region in that country, and any
+ * country+key with DUPLICATE region docs (reported loudly — findOne would
+ * pick one arbitrarily, and taxonomy dedup should have removed these).
+ *
+ * Region is NOT part of normalizedKey/canonicalKey/slug, so a plain
+ * updateOne is safe (no hook-managed derivations move). Search docs DO
+ * denormalize the region name for both wines and bottles → --apply reindexes
+ * the changed wines and their bottles. Region is also in the embedding text →
+ * run an incremental embed job afterwards (reminder printed).
+ *
+ * Dry-run by default (prints the grouped rewrite plan). --apply writes.
+ *
+ *   docker exec cellarion-backend node src/scripts/normalize-region-to-appellation.js
+ *   docker exec cellarion-backend node src/scripts/normalize-region-to-appellation.js --apply
+ */
+
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const Region = require('../models/Region');
+const Bottle = require('../models/Bottle');
+require('../models/Country');
+require('../models/Grape');
+const { regionForAppellation } = require('../services/findOrCreateWine');
+const searchService = require('../services/search');
+const { logAudit } = require('../services/audit');
+
+(async () => {
+  const apply = process.argv.includes('--apply');
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+
+  // Region name lookup for reporting, and the duplicate-key guard: a
+  // country holding TWO regions under one normalized name/synonym makes
+  // regionForAppellation's findOne an arbitrary pick — those keys are held
+  // out and reported instead of rewritten.
+  const allRegions = await Region.find({})
+    .select('name normalizedName normalizedSynonyms country').lean();
+  const regionName = new Map(allRegions.map((r) => [String(r._id), r.name]));
+  const keyOwners = new Map(); // `${countryId}:${key}` -> Set of region ids
+  for (const r of allRegions) {
+    for (const key of [r.normalizedName, ...(r.normalizedSynonyms || [])]) {
+      if (!key) continue;
+      const k = `${String(r.country)}:${key}`;
+      if (!keyOwners.has(k)) keyOwners.set(k, new Set());
+      keyOwners.get(k).add(String(r._id));
+    }
+  }
+  const duplicateKeys = new Set(
+    [...keyOwners.entries()].filter(([, ids]) => ids.size > 1).map(([k]) => k)
+  );
+
+  const { normalizeString } = require('../utils/normalize');
+  const cursor = WineDefinition.find({
+    appellation: { $nin: [null, ''] },
+    nonWine: { $ne: true },
+  }).select('name producer appellation region country').cursor();
+
+  const changes = [];   // { id, name, producer, appellation, fromId, from, to, toId }
+  const ambiguous = []; // rows held out by the duplicate-key guard
+  for await (const w of cursor) {
+    if (!w.country) continue;
+    const key = normalizeString(w.appellation);
+    if (!key) continue;
+    if (duplicateKeys.has(`${String(w.country)}:${key}`)) {
+      ambiguous.push(`${w.producer || '(no producer)'} — ${w.name} [ap "${w.appellation}"]`);
+      continue;
+    }
+    const target = await regionForAppellation(w.appellation, w.country);
+    if (!target) continue;
+    if (String(w.region || '') === String(target._id)) continue;
+    changes.push({
+      id: w._id,
+      name: w.name,
+      producer: w.producer,
+      appellation: w.appellation,
+      from: w.region ? (regionName.get(String(w.region)) || String(w.region)) : '(none)',
+      to: target.name,
+      toId: target._id,
+    });
+  }
+
+  // Grouped plan, biggest rewrites first.
+  const groups = new Map();
+  for (const c of changes) {
+    const k = `${c.from} → ${c.to}  (ap "${c.appellation}")`;
+    groups.set(k, (groups.get(k) || 0) + 1);
+  }
+  console.log(`${apply ? 'APPLY' : 'DRY RUN'} — ${changes.length} rows to rewrite, ${groups.size} distinct region pairs`);
+  for (const [k, n] of [...groups.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(n).padStart(4)}  ${k}`);
+  }
+  if (ambiguous.length) {
+    console.log(`\nHELD (duplicate region key in taxonomy — fix the taxonomy first): ${ambiguous.length}`);
+    for (const line of ambiguous.slice(0, 20)) console.log(`  ${line}`);
+  }
+
+  if (!apply) {
+    console.log('\nDry run only. Re-run with --apply to write.');
+    await mongoose.disconnect();
+    return;
+  }
+
+  let written = 0;
+  for (const c of changes) {
+    await WineDefinition.updateOne(
+      { _id: c.id },
+      { $set: { region: c.toId, updatedAt: new Date() } }
+    );
+    logAudit(null, 'admin.wine.region_normalize', { type: 'wine', id: c.id },
+      { appellation: c.appellation, from: c.from, to: c.to });
+    await searchService.indexWine(c.id);
+    written++;
+  }
+
+  // Bottle search docs denormalize regionName — one bulk pass at the end.
+  const wineIds = changes.map((c) => c.id);
+  if (wineIds.length) {
+    const bottleIds = await Bottle.distinct('_id', { wineDefinition: { $in: wineIds } });
+    if (bottleIds.length) await searchService.bulkIndexBottles(bottleIds);
+    console.log(`\nReindexed ${wineIds.length} wines and ${bottleIds.length} bottles.`);
+  }
+  console.log(`Applied ${written} region rewrites.`);
+  console.log('Region is part of the embedding text — start an incremental embed job to refresh Qdrant.');
+  await mongoose.disconnect();
+})();

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -103,6 +103,7 @@ let job = {
   total: 0,
   done: 0,
   enriched: 0,
+  held: 0,              // producer-suspect rows: generated but publication withheld
   skipped: 0,
   errors: 0,
   startedAt: null,
@@ -158,6 +159,7 @@ async function start({ mode = 'incremental', limit = 0 } = {}) {
     total: 0,
     done: 0,
     enriched: 0,
+    held: 0,
     skipped: 0,
     errors: 0,
     startedAt: new Date().toISOString(),
@@ -197,6 +199,12 @@ async function runJob(cfg) {
       ? keepCurated
       : {
           ...keepCurated,
+          // A HELD row (producer-suspect, publication withheld) has a null
+          // description by design — without this it would match the "not yet
+          // enriched" branch and every incremental run would re-spend on it.
+          // Held rows wait for a human (queue/identity fix/review override);
+          // only FULL mode re-generates them.
+          'aiProfile.heldAt': null,
           $or: [{ 'aiProfile.description': null }, { 'aiProfile.description': { $exists: false } }],
         };
 
@@ -222,6 +230,7 @@ async function runJob(cfg) {
       try {
         const { result, reason } = await enrichWine(wine, job.model);
         if (result === 'enriched') job.enriched++;
+        else if (result === 'held') job.held++;
         else {
           job.skipped++;
           if (reason) job.lastError = reason;
@@ -261,7 +270,7 @@ async function runJob(cfg) {
  *   to the module-level job state, so a fire-and-forget enrichWineById can't
  *   pollute the admin job status.
  */
-async function enrichWine(wine, model) {
+async function enrichWine(wine, model, { publishSuspect = false } = {}) {
   const { data, debugReason } = await suggestProfile({
     name: wine.name,
     producer: wine.producer,
@@ -280,6 +289,49 @@ async function enrichWine(wine, model) {
     return { result: 'skipped', reason };
   }
 
+  // The model's own doubt about the producer FIELD (registry audit follow-up:
+  // "Arcane" — a range sold as a producer — sailed past every string gate AND
+  // 49 audit agents; only this model hedged). Strict true-check: absent on
+  // old/custom prompts → false.
+  const suspect = data.producerSuspect === true;
+  const now = new Date();
+  const meta = {
+    confidence:      cleanConfidence(data.confidence),
+    producerSuspect: suspect,
+    producerNote:    cleanProse(data.producerNote, 300),
+    model:           model || aiConfig.get().enrichmentModel,
+    source:          'ai',
+    generatedAt:     now,
+  };
+
+  // HOLD, don't publish, when the producer is suspect (ticket 6a8162c5): a
+  // profile generated for a brand/range/place sold as a producer is confident
+  // fiction about a company that may not exist — "Fabelhaft" got a négociant
+  // biography this way, flagged suspect, and the flag sat unread in a passive
+  // queue while the fiction served. A held row stores ONLY the doubt; the null
+  // description keeps every read surface (bottle page, MCP, embedding text)
+  // naturally silent, and heldAt keeps the retry guards from looping on it.
+  // `publishSuspect` is the human override — profile-reviewed uses it after an
+  // admin has looked at the doubt and judged the identity fine.
+  if (suspect && !publishSuspect) {
+    await WineDefinition.updateOne(
+      { _id: wine._id },
+      {
+        $set: {
+          aiProfile: {
+            body: null, tannin: null, acidity: null, sweetness: null,
+            flavors: [], foodPairings: [],
+            description: null,
+            ...meta,
+            heldAt: now,
+          },
+          updatedAt: now,
+        },
+      }
+    );
+    return { result: 'held', reason: null };
+  }
+
   await WineDefinition.updateOne(
     { _id: wine._id },
     {
@@ -296,17 +348,10 @@ async function enrichWine(wine, model) {
           // tools. Load-bearing half of the fix — the prompt is only advisory,
           // and a self-hoster can override it via SiteConfig.
           description:  cleanProse(data.description),
-          confidence:   cleanConfidence(data.confidence),
-          // The model's own doubt about the producer FIELD (registry audit
-          // follow-up: "Arcane" — a range sold as a producer — sailed past
-          // every string gate AND 49 audit agents; only this model hedged).
-          // Strict true-check: absent on old/custom prompts → false.
-          producerSuspect: data.producerSuspect === true,
-          producerNote: cleanProse(data.producerNote, 300),
-          model:        model || aiConfig.get().enrichmentModel,
-          generatedAt:  new Date(),
+          ...meta,
+          heldAt: null,
         },
-        updatedAt: new Date(),
+        updatedAt: now,
       },
     }
   );
@@ -342,8 +387,15 @@ async function enrichWine(wine, model) {
  * @param {string|object} wineDefId
  * @param {object}  [opts]
  * @param {string}  [opts.budgetUserId] – user to debit for this AI call
+ * @param {boolean} [opts.force] – regenerate even when a profile exists or is
+ *   held. Used by the deliberate admin surfaces (identity edit, review
+ *   override) — never by the fire-and-forget bottle-add hook. Curator-written
+ *   profiles are still never regenerated, force or not.
+ * @param {boolean} [opts.publishSuspect] – publish even when the model flags
+ *   the producer as suspect (the human-override path: an admin reviewed the
+ *   doubt and judged the identity fine).
  */
-async function enrichWineById(wineDefId, { budgetUserId } = {}) {
+async function enrichWineById(wineDefId, { budgetUserId, force = false, publishSuspect = false } = {}) {
   // Validate + cast the (caller-supplied) id to a real ObjectId before it touches
   // the query, so a non-id value can never shape the database lookup. The cast
   // value (idStr/oid), never the raw input, is used everywhere below.
@@ -370,8 +422,14 @@ async function enrichWineById(wineDefId, { budgetUserId } = {}) {
     // so without it the very add that mints a pending row would immediately
     // spend the adding user's daily AI budget describing a producerless wine.
     if (wine.pendingIdentity === true) return;
-    if (wine.aiProfile && wine.aiProfile.description) return; // already enriched
-    if (wine.aiProfile && wine.aiProfile.source === 'curator') return; // hand-corrected — never regenerate
+    if (wine.aiProfile && wine.aiProfile.source === 'curator') return; // hand-corrected — never regenerate (force included)
+    if (!force) {
+      if (wine.aiProfile && wine.aiProfile.description) return; // already enriched
+      // HELD is a decision awaiting a human, not a gap to retry: without this
+      // guard every later bottle add of the same wine would re-spend the
+      // adder's AI budget re-generating a profile we would hold again.
+      if (wine.aiProfile && wine.aiProfile.heldAt) return;
+    }
 
     if (budgetUserId) {
       const debit = await tryDebitAi(String(budgetUserId));
@@ -382,7 +440,7 @@ async function enrichWineById(wineDefId, { budgetUserId } = {}) {
         return;
       }
       try {
-        const { result, reason } = await enrichWine(wine, aiConfig.get().enrichmentModel);
+        const { result, reason } = await enrichWine(wine, aiConfig.get().enrichmentModel, { publishSuspect });
         // A transport-level failure never produced a billable completion
         if (result === 'skipped' && isRefundableFailure(reason)) await debit.refund();
       } catch (err) {
@@ -390,7 +448,7 @@ async function enrichWineById(wineDefId, { budgetUserId } = {}) {
         throw err; // handled by the outer catch below
       }
     } else {
-      await enrichWine(wine, aiConfig.get().enrichmentModel);
+      await enrichWine(wine, aiConfig.get().enrichmentModel, { publishSuspect });
     }
     console.log('[enrichmentJob] Auto-enriched new wine: %s', wine.name);
   } catch (err) {

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -282,3 +282,84 @@ describe('pendingIdentity rows are never enriched', () => {
     expect(WineDefinition.updateOne).toHaveBeenCalled();
   });
 });
+
+/**
+ * Producer-suspect profiles are HELD, not published (ticket 6a8162c5).
+ *
+ * "Fabelhaft" — a Niepoort brand minted as a producer — got a confident
+ * négociant biography from the generator, which FLAGGED producerSuspect:true
+ * in the same response… and the flag sat in a passive queue while the fiction
+ * served on the bottle page. A suspect profile now stores only the doubt
+ * (confidence/flag/note + heldAt); the null description keeps every read
+ * surface naturally silent, and the guards keep the per-add hook and
+ * incremental batches from re-spending on a row that is waiting for a human.
+ */
+describe('producer-suspect profiles are held, not published', () => {
+  const suspectProfile = () => ({
+    data: {
+      body: 'medium', tannin: 'medium', acidity: 'medium', sweetness: 'dry',
+      flavors: ['plum'], foodPairings: ['stew'],
+      description: 'A juicy regional blend from a négociant label.',
+      confidence: 0.5,
+      producerSuspect: true,
+      producerNote: 'Fabelhaft is a Niepoort label, not an estate.',
+    },
+    debugReason: null,
+  });
+
+  test('suspect=true writes the doubt only: no description/axes, heldAt stamped', async () => {
+    suggestProfile.mockResolvedValue(suspectProfile());
+    await enrichWineById(WINE_ID);
+    const p = persisted();
+    expect(p.description).toBeNull();
+    expect(p.body).toBeNull();
+    expect(p.flavors).toEqual([]);
+    expect(p.foodPairings).toEqual([]);
+    expect(p.producerSuspect).toBe(true);
+    expect(p.producerNote).toMatch(/Niepoort/);
+    expect(p.confidence).toBe(0.5);
+    expect(p.heldAt).toBeInstanceOf(Date);
+    expect(p.generatedAt).toBeInstanceOf(Date);
+  });
+
+  test('a held wine is not re-enriched by the per-add hook', async () => {
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: WINE_ID, name: 'Douro Tinto', producer: 'Fabelhaft', type: 'red',
+      country: { name: 'Portugal' }, region: null, grapes: [],
+      aiProfile: { heldAt: new Date(), description: null },
+    }));
+    await enrichWineById(WINE_ID);
+    expect(suggestProfile).not.toHaveBeenCalled();
+  });
+
+  test('force + publishSuspect publishes past the doubt (the review override)', async () => {
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: WINE_ID, name: 'Douro Tinto', producer: 'Fabelhaft', type: 'red',
+      country: { name: 'Portugal' }, region: null, grapes: [],
+      aiProfile: { heldAt: new Date(), description: null },
+    }));
+    suggestProfile.mockResolvedValue(suspectProfile());
+    await enrichWineById(WINE_ID, { force: true, publishSuspect: true });
+    const p = persisted();
+    expect(p.description).toMatch(/juicy/);
+    expect(p.heldAt).toBeNull();
+    expect(p.producerSuspect).toBe(true); // provenance survives the override
+  });
+
+  test('curator profiles are never regenerated, force or not', async () => {
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: WINE_ID, name: 'Douro Tinto', producer: 'Niepoort',
+      aiProfile: { source: 'curator', description: 'hand-written' },
+    }));
+    await enrichWineById(WINE_ID, { force: true, publishSuspect: true });
+    expect(suggestProfile).not.toHaveBeenCalled();
+  });
+
+  test('a clean profile publishes with heldAt null and suspect false', async () => {
+    suggestProfile.mockResolvedValue(profile('Plain prose.'));
+    await enrichWineById(WINE_ID);
+    expect(persisted().heldAt).toBeNull();
+    expect(persisted().producerSuspect).toBe(false);
+    expect(persisted().description).toBe('Plain prose.');
+  });
+});

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -121,6 +121,32 @@ async function findOrCreateRegion(rawName, countryId, userId) {
   return region;
 }
 
+/**
+ * Registry canon (region-granularity policy, 2026-08-16 / ticket 6a8162c5):
+ * when the appellation itself names a region the taxonomy already has —
+ * appellation "Hunter Valley" and a Hunter Valley Region doc under the same
+ * country — the region field holds THAT region, the most specific
+ * granularity, regardless of what the caller supplied ("New South Wales",
+ * the producer's home region, or nothing). Import AI and label scans return
+ * region at whatever granularity they happened to think in, which is how one
+ * import batch minted the same producer's wines under both "Hunter Valley"
+ * and "New South Wales" — all with appellation Hunter Valley.
+ *
+ * MATCH-ONLY by design: an appellation string never MINTS a Region.
+ * Appellations are unvalidated free text, so only an existing doc (canonical
+ * name or synonym, country-scoped) may adopt the row; anything else falls
+ * back to the caller-supplied region via findOrCreateRegion.
+ */
+async function regionForAppellation(appellationName, countryId) {
+  if (!appellationName || !countryId) return null;
+  const normalizedName = normalizeString(appellationName);
+  if (!normalizedName) return null;
+  return Region.findOne({
+    country: countryId,
+    $or: [{ normalizedName }, { normalizedSynonyms: normalizedName }],
+  });
+}
+
 async function findOrCreateGrapes(rawNames, userId) {
   if (!Array.isArray(rawNames) || rawNames.length === 0) return [];
   // Same chokepoint argument as findOrCreateRegion: the route caps the count and
@@ -170,7 +196,10 @@ async function findOrCreateGrapes(rawNames, userId) {
  * Pass `confirmCreate: true` to bypass the soft-zone gate and force creation
  * — used when the user has explicitly confirmed "no, none of those, make a new one".
  *
- * @param {Object} wineData   - { name, producer, country, region, appellation, type, grapes[] }
+ * @param {Object} wineData   - { name, producer, country, region, appellation, type, grapes[], classification? }
+ *   `classification` (e.g. "Grand Cru Classé en 1855") is stored verbatim on a CREATE and
+ *   plays no part in matching or keys — the scan path extracts it so classification lines
+ *   stop landing in the name field (ticket 6a8162c5, the Giscours case).
  * @param {string} userId     - ObjectId string of the authenticated user (for createdBy)
  * @param {Object} [opts]
  * @param {boolean} [opts.confirmCreate=false] - Skip soft-zone candidate return and create directly
@@ -200,7 +229,7 @@ async function findOrCreateGrapes(rawNames, userId) {
  *   surfaces (routes/admin/wines.js, routes/admin/wineRequests.js, MCP
  *   admin_add_registry_wine): a curator typing "Bordeaux" as producer SHOULD be told.
  */
-async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes }, userId, { confirmCreate = false, skipSiblingMatch = false, matchOnly = false, createdVia = null, allowPending = false } = {}) {
+async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes, classification }, userId, { confirmCreate = false, skipSiblingMatch = false, matchOnly = false, createdVia = null, allowPending = false } = {}) {
   // Internal whitespace collapses too, not just the ends: a double space is
   // invisible in every UI and every normalized key, so "Wrights  Estate" and
   // "Wrights Estate" would otherwise coexist as two display spellings forever
@@ -619,7 +648,13 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
     ? pendingWineKey(trimmedName, userId, trimmedAppellation)
     : generateWineKey(trimmedName, producerToStore, trimmedAppellation);
 
-  const regionDoc = await findOrCreateRegion(region, countryDoc._id, userId);
+  // Region canon: the appellation's own region wins when the taxonomy knows
+  // it (see regionForAppellation) — this is what keeps one producer's wines
+  // from splitting across "Hunter Valley" and "New South Wales" depending on
+  // which granularity the AI/import happened to supply per row. Only when the
+  // appellation names no known region does the supplied region string count.
+  let regionDoc = await regionForAppellation(trimmedAppellation, countryDoc._id);
+  if (!regionDoc) regionDoc = await findOrCreateRegion(region, countryDoc._id, userId);
   let grapeIds = await findOrCreateGrapes(grapes, userId);
 
   // Ticket #2A: when no grapes were supplied, infer them from the name
@@ -635,12 +670,20 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   const validTypes = ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'];
   const wineType = validTypes.includes(type) ? type : 'red';
 
+  // Classification is display/curation data, not identity: stored on creates
+  // only, never matched or keyed on. Same whitespace fold + cap as the
+  // identity fields, so a scanned "Grand  Cru Classé" can't store raggedly.
+  const trimmedClassification = (typeof classification === 'string' && classification.trim())
+    ? classification.trim().replace(/\s+/g, ' ').slice(0, MAX_FIELD)
+    : null;
+
   const newWine = new WineDefinition({
     name: trimmedName,
     producer: producerToStore,
     country: countryDoc._id,
     region: regionDoc?._id || null,
     appellation: trimmedAppellation || null,
+    classification: trimmedClassification,
     type: wineType,
     grapes: grapeIds,
     normalizedKey: mintKey,
@@ -693,6 +736,7 @@ module.exports = {
   findOrCreateCountry,
   findOrCreateRegion,
   findOrCreateGrapes,
+  regionForAppellation,
   pendingProducerKey,
   pendingWineKey,
 };

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -641,6 +641,7 @@ describe('findOrCreateWine — creation', () => {
       country: 'country-1',
       region: 'region-1',
       appellation: 'Châteauneuf-du-Pape',
+      classification: null, // scan-supplied only — absent input stores null
       type: 'red',
       grapes: ['grape-grenache', 'grape-syrah'],
       normalizedKey: INPUT_KEY,
@@ -1128,5 +1129,80 @@ describe('taxonomy find-or-create dedup', () => {
     const ids = await findOrCreateGrapes(['Tempranillo', 'Tinta Roriz'], USER_ID);
 
     expect(ids).toEqual(['grape-tempranillo']);
+  });
+});
+
+/**
+ * Region canon (policy 2026-08-16, ticket 6a8162c5): when the appellation
+ * itself names a region the taxonomy has, the region field holds THAT region
+ * — the most specific granularity — regardless of what the caller supplied.
+ * This is what stops one import batch minting the same producer's wines under
+ * both "Hunter Valley" and "New South Wales" (all with appellation Hunter
+ * Valley). Match-only: an appellation string never MINTS a Region.
+ */
+describe('findOrCreateWine — region canon: appellation granularity wins', () => {
+  test('an appellation naming a known region overrides the supplied parent region', async () => {
+    Region.findOne.mockImplementation(async (q) => {
+      const key = q?.$or?.[0]?.normalizedName;
+      if (key === 'hunter valley') return { _id: 'region-hunter' };
+      if (key === 'new south wales') return { _id: 'region-nsw' };
+      return null;
+    });
+    const { wine, created } = await findOrCreateWine({
+      name: 'Vat 9', producer: "Tyrrell's", country: 'Australia',
+      region: 'New South Wales', appellation: 'Hunter Valley', type: 'red', grapes: [],
+    }, USER_ID);
+    expect(created).toBe(true);
+    expect(wine.region).toBe('region-hunter');
+    expect(wine.appellation).toBe('Hunter Valley');
+  });
+
+  test('the canon rule fills a missing region from the appellation too', async () => {
+    Region.findOne.mockImplementation(async (q) =>
+      (q?.$or?.[0]?.normalizedName === 'barossa valley' ? { _id: 'region-barossa' } : null));
+    const { wine } = await findOrCreateWine({
+      name: 'Generations', producer: 'Kies', country: 'Australia',
+      appellation: 'Barossa Valley', type: 'red', grapes: [],
+    }, USER_ID);
+    expect(wine.region).toBe('region-barossa');
+  });
+
+  test('an appellation naming no region falls back to the supplied region string', async () => {
+    Region.findOne.mockImplementation(async (q) =>
+      (q?.$or?.[0]?.normalizedName === 'marlborough' ? { _id: 'region-marlborough' } : null));
+    const { wine } = await findOrCreateWine({
+      name: 'Sauvignon Blanc', producer: 'Chard Farm', country: 'New Zealand',
+      region: 'Marlborough', appellation: 'Awatere', type: 'white', grapes: [],
+    }, USER_ID);
+    expect(wine.region).toBe('region-marlborough');
+  });
+
+  test('an unmatched appellation never MINTS a region — with none supplied the wine stores null', async () => {
+    Region.findOne.mockResolvedValue(null);
+    const { wine } = await findOrCreateWine({
+      name: 'Cuvée X', producer: 'Some Estate', country: 'France',
+      appellation: 'Lieu-dit Imaginaire', type: 'red', grapes: [],
+    }, USER_ID);
+    expect(wine.region).toBeNull();
+    expect(Region).not.toHaveBeenCalled(); // the Region CONSTRUCTOR — nothing minted
+  });
+});
+
+/**
+ * Classification (ticket 6a8162c5, the Giscours case): the scan prompt now
+ * has a slot for the printed classification line, and it is stored on a
+ * CREATE — folded and capped like the identity fields, but never matched or
+ * keyed on.
+ */
+describe('findOrCreateWine — classification is stored on create', () => {
+  test('whitespace-folded and stored', async () => {
+    const { wine } = await findOrCreateWine(
+      { ...INPUT, classification: '  Grand   Cru Classé en 1855 ' }, USER_ID);
+    expect(wine.classification).toBe('Grand Cru Classé en 1855');
+  });
+
+  test('absent classification stores null', async () => {
+    const { wine } = await findOrCreateWine(INPUT, USER_ID);
+    expect(wine.classification).toBeNull();
   });
 });

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -277,7 +277,7 @@ async function scanLabelBack({ backImage, backMediaType = 'image/jpeg', frontIma
 }
 
 /** The scalar identity fields the back label may fill, in display order. */
-const MERGE_SCALARS = ['name', 'producer', 'vintage', 'country', 'region', 'appellation', 'type'];
+const MERGE_SCALARS = ['name', 'producer', 'vintage', 'country', 'region', 'appellation', 'type', 'classification'];
 
 /** A usable value is a non-empty string after trimming; everything else is a gap. */
 const mergeValue = (v) => (typeof v === 'string' && v.trim() ? v.trim() : '');

--- a/backend/src/services/wineCommit.classification.test.js
+++ b/backend/src/services/wineCommit.classification.test.js
@@ -1,0 +1,54 @@
+/**
+ * Classification rides the commit into the mint (ticket 6a8162c5).
+ *
+ * The scan prompt now extracts the printed classification line ("Grand Cru
+ * Classé en 1855") into its own field — before this it had no slot and landed
+ * in the NAME (the Giscours case). The client threads it through the newWine
+ * payload invisibly; these tests pin that the commit passes it to
+ * findOrCreateWine and that the request-validation cap covers it (the payload
+ * is machine-generated, same rationale as region).
+ */
+
+jest.mock('../models/BottleImage', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('./audit', () => ({ logAudit: jest.fn() }));
+jest.mock('./indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('./findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+
+const { findOrCreateWine } = require('./findOrCreateWine');
+const { resolveOrMintWine, validateNewWineFields, MAX_WINE_FIELD } = require('./wineCommit');
+
+const USER = '1'.repeat(24);
+const req = { user: { id: USER } };
+
+beforeEach(() => jest.clearAllMocks());
+
+test('classification is passed through to findOrCreateWine', async () => {
+  findOrCreateWine.mockResolvedValue({
+    wine: {
+      _id: 'wine-1', name: 'Château Giscours', producer: 'Château Giscours',
+      classification: 'Grand Cru Classé en 1855',
+      scanImage: null, scanImageBack: null, pendingIdentity: false, createdBy: USER,
+      save: jest.fn().mockResolvedValue(undefined),
+    },
+    created: true,
+  });
+
+  await resolveOrMintWine({
+    name: 'Château Giscours', producer: 'Château Giscours', country: 'France',
+    appellation: 'Margaux', classification: 'Grand Cru Classé en 1855', type: 'red',
+  }, req);
+
+  expect(findOrCreateWine.mock.calls[0][0].classification).toBe('Grand Cru Classé en 1855');
+});
+
+test('the request cap covers classification like the other identity fields', () => {
+  const err = validateNewWineFields({
+    name: 'X', producer: 'Y', country: 'France',
+    classification: 'c'.repeat(MAX_WINE_FIELD + 1),
+  });
+  expect(err).toMatch(/classification must be/);
+});
+
+test('an absent classification stays valid', () => {
+  expect(validateNewWineFields({ name: 'X', producer: 'Y', country: 'France' })).toBeNull();
+});

--- a/backend/src/services/wineCommit.js
+++ b/backend/src/services/wineCommit.js
@@ -66,7 +66,7 @@ function validateNewWineFields(payload, { allowPending = false } = {}) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
     return 'newWine must be an object';
   }
-  const { name, producer, country, region, appellation, grapes } = payload;
+  const { name, producer, country, region, appellation, grapes, classification } = payload;
   // typeof, not `?.` — a non-string here must be a 400, not a thrown TypeError
   // inside findOrCreateWine's .trim() (the identify-text hang, audit HIGH).
   if (typeof name !== 'string' || !name.trim()) {
@@ -80,7 +80,8 @@ function validateNewWineFields(payload, { allowPending = false } = {}) {
   }
   // region is capped too: findOrCreateRegion mints whatever arrives, and this
   // path receives machine-generated payloads (accepted AI suggestions).
-  for (const [field, value] of Object.entries({ name, producer, appellation, region })) {
+  // classification joins the cap for the same reason — the scan path fills it.
+  for (const [field, value] of Object.entries({ name, producer, appellation, region, classification })) {
     if (typeof value === 'string' && value.length > MAX_WINE_FIELD) {
       return `${field} must be ${MAX_WINE_FIELD} characters or fewer`;
     }
@@ -106,7 +107,7 @@ const MAX_SCAN_CONFLICTS = 8;
 // than imported so this module keeps its lazy-require test seams). A free-text
 // key here would be 4.8KB of attacker-chosen text rendered in the curator's
 // modal and model context (release-audit LOW-2).
-const CONFLICT_FIELDS = ['name', 'producer', 'vintage', 'country', 'region', 'appellation', 'type', 'grapes'];
+const CONFLICT_FIELDS = ['name', 'producer', 'vintage', 'country', 'region', 'appellation', 'type', 'grapes', 'classification'];
 
 /**
  * Validate the front/back label disagreements the client threads back from the
@@ -238,6 +239,10 @@ async function resolveOrMintWine(newWine, req, { allowPending = true } = {}) {
         country: newWine.country,
         region: newWine.region,
         appellation: newWine.appellation,
+        // Scan-extracted classification line ("Grand Cru Classé en 1855") —
+        // stored on creates only; before this rode along, the scan had no
+        // legitimate slot for it and it landed in the NAME (ticket 6a8162c5).
+        classification: newWine.classification,
         type: newWine.type,
         grapes: newWine.grapes || [],
       },

--- a/backend/src/services/wineProfileOps.js
+++ b/backend/src/services/wineProfileOps.js
@@ -291,6 +291,11 @@ function applyProfilePatch(wine, clean, userId, { now = new Date() } = {}) {
       wine.aiProfile.verifiedAt = now;
       wine.profileReviewedAt = now;
     }
+    // Either way the HOLD is over: a real write means a human supplied the
+    // truth the hold was waiting for; a pure clear is the documented reset
+    // signal ("this is wrong") and returns the wine to the enrichable pool —
+    // where, if the model still doubts the identity, it simply holds again.
+    wine.aiProfile.heldAt = null;
     wine.markModified('aiProfile');
   }
   return wine;

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -159,6 +159,10 @@ function AddBottle() {
         country: e.country || '',
         region: e.region || '',
         appellation: e.appellation || '',
+        // Not a form field — rides invisibly into the commit payload so a
+        // scanned classification line ("Grand Cru Classé en 1855") lands in
+        // the registry's classification field instead of polluting the name.
+        classification: e.classification || '',
         type: e.type || 'red',
         grapes: (e.grapes || []).join(', '),
       });
@@ -209,6 +213,7 @@ function AddBottle() {
         country: merged.country || '',
         region: merged.region || '',
         appellation: merged.appellation || '',
+        classification: merged.classification || '',
         type: merged.type || 'red',
         grapes: (merged.grapes || []).join(', '),
       };
@@ -369,6 +374,7 @@ function AddBottle() {
           country: extracted.country || '',
           region: extracted.region || '',
           appellation: extracted.appellation || '',
+          classification: extracted.classification || '',
           type: extracted.type || 'red',
           grapes: extracted.grapes || []
         };
@@ -385,6 +391,7 @@ function AddBottle() {
       country: extracted.country || '',
       region: extracted.region || '',
       appellation: extracted.appellation || '',
+      classification: extracted.classification || '',
       type: extracted.type || 'red',
       grapes: (extracted.grapes || []).join(', ')
     });

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -161,6 +161,8 @@ function AddToWishlist() {
         country: e.country || '',
         region: e.region || '',
         appellation: e.appellation || '',
+        // Not a form field — rides invisibly into the commit payload (see AddBottle).
+        classification: e.classification || '',
         type: e.type || 'red',
         grapes: (e.grapes || []).join(', '),
       });
@@ -208,6 +210,7 @@ function AddToWishlist() {
         country: merged.country || '',
         region: merged.region || '',
         appellation: merged.appellation || '',
+        classification: merged.classification || '',
         type: merged.type || 'red',
         grapes: (merged.grapes || []).join(', '),
       };
@@ -300,6 +303,7 @@ function AddToWishlist() {
           country: extracted.country || '',
           region: extracted.region || '',
           appellation: extracted.appellation || '',
+          classification: extracted.classification || '',
           type: extracted.type || 'red',
           grapes: extracted.grapes || []
         };
@@ -315,6 +319,7 @@ function AddToWishlist() {
       country: extracted.country || '',
       region: extracted.region || '',
       appellation: extracted.appellation || '',
+      classification: extracted.classification || '',
       type: extracted.type || 'red',
       grapes: (extracted.grapes || []).join(', ')
     });


### PR DESCRIPTION
## Context

Support ticket `6a8162c5` (HIGH, from the somm's curation pass): the 15 Aug 226-row import and the recent European label scans keep producing the same four failure shapes — parent regions (or the producer's home region) in the region field, one producer split across two countries, classification lines in the name field, and enrichment publishing confident fiction for identities its own model flagged as suspect. Verified on prod before building: the import batch minted 132 registry rows in 9.4s whose geography was 100% AI knowledge-fill (the file only carries name/producer/vintage/country-hint), and Fabelhaft's profile had `producerSuspect: true` sitting unread in a passive queue (373 such rows, 3654 unreviewed ≤0.6-confidence profiles).

**Design constraint honoured throughout: nothing here makes adding harder.** Gates change what mints *confidently* vs *pending/null* — never whether the user's bottle saves.

## Changes

**1. Region canon — appellation granularity wins (policy call, Johan 2026-08-16)**
- `findOrCreateWine.regionForAppellation()`: when the canonical appellation names an existing Region (same country, name or synonym), the region field holds that region — overriding parent-region or producer-home guesses. Match-only: an appellation string can never *mint* a Region. One chokepoint → all four mint surfaces.
- `scripts/normalize-region-to-appellation.js` (dry-run default, `--apply`): folds the **506 pre-existing rows** (California→Napa 51, S.Australia→Barossa 25, NSW→Hunter 24, …) through the *same helper*, so script and chokepoint can't drift. Reindexes wines + bottles; reminds about the embed job. Duplicate-taxonomy keys are held out and reported, never guessed.

**2. Import identification honesty (`aiConfig` prompt + `/validate`)**
- Prompt: region is where *this wine* is grown, never assumed from the producer's home; null over guess; country no longer force-required ("never acceptable to return null" is gone — that rule is what coin-flipped Thomas Allen across two continents).
- `/validate` post-AI hygiene, applied to `aiIdentified` before matching so preview, `aiProposed` and `/confirm` all agree:
  - geography below **0.6 confidence** is stripped (the 0.5 "reasonably sure" band is exactly where Sister's Run Epiphany got Barossa instead of McLaren Vale); file-supplied columns are never touched
  - one producer → one country per batch: file-stated countries anchor, the highest-confidence AI row decides otherwise, and a countryless sibling row inherits instead of failing to mint

**3. Label-scan extraction (`aiConfig` prompts + classification threading)**
- The scan JSON schema previously had **no classification field** — "Grand Cru Classé en 1855" had nowhere to go but the name (the Giscours row). There's now a classification slot (front + back scans), rules that classification lines are never the name, brand/fantasy labels (Fabelhaft) and artwork titles (Arlecchino Innamorato) are never the producer, regulator codes (ICQRF) are never the producer, and an explicit "no producer printed → null" instruction that feeds the *existing* partial/back-scan/pendingIdentity flow.
- `classification` rides scan → form (invisible passthrough) → commit → mint; capped and folded like the identity fields, stored on creates only, never matched or keyed on.

**4. Enrichment: producerSuspect becomes an active signal**
- A suspect profile is **held, not published**: only the doubt is stored (confidence/flag/note + `aiProfile.heldAt`); the null description keeps every read surface (bottle page, MCP, embeddings) naturally silent — no more négociant biographies for brands that aren't producers.
- Held rows surface in the admin low-confidence queue **regardless of threshold** (Fabelhaft was 0.5; default threshold 0.3 — the queue never showed the one row its flag existed for).
- No loops: the per-add hook and incremental batches treat held as decided; full mode regenerates.
- Escapes: admin identity edit → forced re-enrich under the corrected identity (also fixes the pre-existing stale-profile-after-rename gap); *profile-reviewed* on a held row → regenerate and publish past the doubt; curator profile writes resolve the hold.

## Tests

- Backend (node:20-alpine container): all touched suites green — `findOrCreateWine` ×3, `enrichmentJob`, `wineCommit` ×3, `import.validate` ×4 + new `import.validate.geography`, `import.confirm`, `labelScan` ×2, `wines.scanLabel(+Back)`, `admin/wines.lowConfidence`, `wineProfileOps`, `registryHealthJob` (515 tests across the runs)
- Frontend (host): full run **941/941**
- New suites: `import.validate.geography.test.js` (floor + country unification, order-independent AI mocks), `wineCommit.classification.test.js`; new describes in `findOrCreateWine.test.js` (region canon ×4, classification ×2) and `enrichmentJob.test.js` (held ×5)

## Ops notes

- **No compose impact** (code + one additive schema field, `aiProfile.heldAt`).
- **Post-deploy migration (Johan runs after release):** `node src/scripts/normalize-region-to-appellation.js` (dry-run first, then `--apply`), then an incremental embed job — region is in the embedding text.
- i18n: no user-facing strings added.

## Not in this PR (deliberately)

- Bulk-approve for somm proposals / proposal-queue ergonomics (ask #3) — separate discussion.
- In-batch subset-name fragmentation detection (`Vat 8` vs `Vat 8 Shiraz Cabernet`) — belongs with ticket `6a800f39` (fragmentation detectors).
- The 7 evidence-backed proposals the somm already filed — reviewed as they are in the admin queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)