### PR TITLE
fix(registry): regenerate AI profiles on real record edits — proposal-approve parity + PUT churn fix

### DIFF
--- a/backend/src/routes/admin/wineProposals.js
+++ b/backend/src/routes/admin/wineProposals.js
@@ -35,6 +35,7 @@ const { logAudit } = require('../../services/audit');
 const { submitUrls } = require('../../services/indexNow');
 const searchService = require('../../services/search');
 const { reembedActiveVintages } = require('../../services/embeddingJob');
+const { profileInputsSnapshot, reenrichAfterRecordEdit } = require('../../services/enrichmentJob');
 const { findOrCreateRegion } = require('../../services/findOrCreateWine');
 const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const { performWineMerge } = require('./wines');
@@ -194,6 +195,9 @@ router.post('/:id/approve', async (req, res) => {
           await revertClaim();
           return res.status(404).json({ error: 'The proposed wine no longer exists' });
         }
+        // Before-image for the re-enrich decision below — same real-change
+        // semantics as the admin PUT.
+        const beforeProfileInputs = profileInputsSnapshot(wine);
         const pf = proposal.proposedFields || {};
         const applied = [];
 
@@ -263,6 +267,11 @@ router.post('/:id/approve', async (req, res) => {
           .then((ids) => searchService.bulkIndexBottles(ids))
           .catch((err) => console.error('Bottle re-index after proposal apply failed:', err.message));
         reembedActiveVintages(wine._id).catch(() => {});
+        // And the PUT's re-enrich (parity gap found live 2026-08-16: approving
+        // "Fabelhaft" → "Niepoort" left the négociant-fiction profile attached
+        // until a manual force re-enrich). Real-change only, curator-safe —
+        // see reenrichAfterRecordEdit.
+        reenrichAfterRecordEdit(wine, profileInputsSnapshot(wine) !== beforeProfileInputs);
 
         appliedNote = `Applied: ${applied.join(', ')}`;
       } else if (proposal.kind === 'merge') {

--- a/backend/src/routes/admin/wineProposals.test.js
+++ b/backend/src/routes/admin/wineProposals.test.js
@@ -28,6 +28,17 @@ jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../../services/indexNow', () => ({ submitUrls: jest.fn() }));
 jest.mock('../../services/search', () => ({ indexWine: jest.fn(), bulkIndexBottles: jest.fn() }));
 jest.mock('../../services/embeddingJob', () => ({ reembedActiveVintages: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../../services/enrichmentJob', () => ({
+  reenrichAfterRecordEdit: jest.fn(),
+  // Faithful-enough mirror of the real snapshot (unit-tested in
+  // enrichmentJob.test.js) — the route only ever compares two of these.
+  profileInputsSnapshot: jest.fn((w) => JSON.stringify({
+    name: w.name || '', producer: w.producer || '',
+    country: String(w.country || ''), region: String(w.region || ''),
+    appellation: w.appellation || '', classification: w.classification || '',
+    type: w.type || '', grapes: (w.grapes || []).map(String).sort(),
+  })),
+}));
 jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateRegion: jest.fn() }));
 // Identity by default so the tier-strip assertions below still read the
 // normalizeAppellation output; the curated-registry test overrides it.
@@ -158,6 +169,33 @@ describe('POST /:id/approve', () => {
     // The receipt lands on the row.
     const noteSet = WineCorrectionProposal.updateOne.mock.calls.at(-1);
     expect(noteSet[1].$set.appliedNote).toMatch(/Applied/);
+  });
+
+  // Parity with the admin PUT (gap found live 2026-08-16: approving
+  // "Fabelhaft" → "Niepoort" left the négociant-fiction profile attached
+  // until a manual force re-enrich): an approved change to a profile-feeding
+  // field hands the wine to the re-enrich follow-through — and ONLY a real
+  // change does.
+  test('field_correction: a real producer change triggers the re-enrich follow-through', async () => {
+    claim({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { producer: 'Niepoort' } });
+    const wine = { _id: W1, name: 'Douro Tinto', producer: 'Fabelhaft', appellation: 'Douro', country: 'c1', save: jest.fn().mockResolvedValue(undefined) };
+    WineDefinition.findById.mockResolvedValue(wine);
+
+    const res = await post(`/${P1}/approve`);
+    expect(res.status).toBe(200);
+    const { reenrichAfterRecordEdit } = require('../../services/enrichmentJob');
+    expect(reenrichAfterRecordEdit).toHaveBeenCalledWith(wine, true);
+  });
+
+  test('field_correction: values identical to the record do NOT regenerate the profile', async () => {
+    claim({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { producer: 'Niepoort' } });
+    const wine = { _id: W1, name: 'Douro Tinto', producer: 'Niepoort', appellation: 'Douro', country: 'c1', save: jest.fn().mockResolvedValue(undefined) };
+    WineDefinition.findById.mockResolvedValue(wine);
+
+    const res = await post(`/${P1}/approve`);
+    expect(res.status).toBe(200);
+    const { reenrichAfterRecordEdit } = require('../../services/enrichmentJob');
+    expect(reenrichAfterRecordEdit).toHaveBeenCalledWith(wine, false);
   });
 
   // The "Yecla DO" case (prod, 2026-08-12): approving a proposal used to store

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -1294,6 +1294,12 @@ router.put('/:id', async (req, res) => {
       return res.status(404).json({ error: 'Wine not found' });
     }
 
+    // Snapshot the profile-feeding fields BEFORE any mutation — the re-enrich
+    // decision below compares against this, so only a REAL change (not the
+    // form re-sending every field on save) regenerates the AI profile.
+    const { profileInputsSnapshot, reenrichAfterRecordEdit } = require('../../services/enrichmentJob');
+    const beforeProfileInputs = profileInputsSnapshot(wine);
+
     // Update fields
     if (name) wine.name = name.trim();
     if (producer) wine.producer = producer.trim();
@@ -1347,6 +1353,9 @@ router.put('/:id', async (req, res) => {
     }
 
     await wine.save();
+    // Compared before populate (the snapshot folds ids either way, but the
+    // unpopulated doc is the apples-to-apples read).
+    const profileInputsChanged = profileInputsSnapshot(wine) !== beforeProfileInputs;
     await wine.populate(['country', 'region', 'grapes']);
 
     // Sync to search index (fire-and-forget). Bottle documents denormalize
@@ -1367,17 +1376,17 @@ router.put('/:id', async (req, res) => {
       { fields: Object.keys(req.body) }
     );
 
-    // An identity edit (name/producer) makes any AI profile a description of
-    // the WRONG wine — including a HELD one, whose whole point was "this
-    // producer looks fictional": the admin just fixed exactly that. Regenerate
-    // under the corrected identity (fire-and-forget, no user budget — this is
-    // a deliberate admin action). Curator-written profiles are never touched
-    // (enrichWineById refuses those, force or not); if the model still doubts
-    // the new identity it simply holds again, which is the correct outcome.
-    if ((name || producer) && wine.aiProfile?.generatedAt && wine.aiProfile?.source !== 'curator') {
-      const { enrichWineById } = require('../../services/enrichmentJob');
-      enrichWineById(wine._id, { force: true }).catch(() => {});
-    }
+    // An edit that changed any profile-feeding field (identity, geography,
+    // classification, type, grapes) makes the AI profile a description of the
+    // WRONG record — including a HELD one, whose whole point was "this
+    // producer looks fictional": the admin just fixed exactly that.
+    // Regenerate under the corrected record (fire-and-forget, no user budget
+    // — a deliberate admin action). Real-change only: the v1.116.0 check was
+    // presence-in-body, and the edit form re-sends every field on save, so it
+    // would have regenerated (and churned generatedAt) on EVERY save. Curator
+    // profiles are never touched; if the model still doubts the new identity
+    // it simply holds again, which is the correct outcome.
+    reenrichAfterRecordEdit(wine, profileInputsChanged);
 
     submitUrls(`/wines/${wine._id}`);
 

--- a/backend/src/routes/admin/wines.reenrichOnEdit.test.js
+++ b/backend/src/routes/admin/wines.reenrichOnEdit.test.js
@@ -1,0 +1,141 @@
+/**
+ * PUT /api/admin/wines/:id — the re-enrich follow-through fires on a REAL
+ * change only.
+ *
+ * The v1.116.0 hook checked presence-in-body (`name || producer`), and the
+ * admin edit form re-sends every field on save — so every save would have
+ * regenerated the AI profile and churned generatedAt (resurfacing reviewed
+ * rows in the low-confidence queue) even when nothing changed. The decision
+ * is now a before/after profileInputsSnapshot comparison handed to
+ * reenrichAfterRecordEdit (curator/never-enriched gates live in that helper,
+ * pinned by enrichmentJob.test.js). Mock style follows wines.nonWine.test.js.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../models/WineDefinition', () => {
+  const ctor = jest.fn();
+  ctor.find = jest.fn();
+  ctor.findById = jest.fn();
+  ctor.findOne = jest.fn();
+  ctor.countDocuments = jest.fn();
+  ctor.bulkWrite = jest.fn();
+  ctor.updateMany = jest.fn();
+  ctor.updateOne = jest.fn();
+  return ctor;
+});
+jest.mock('../../models/Bottle', () => ({ aggregate: jest.fn(), countDocuments: jest.fn(), distinct: jest.fn() }));
+jest.mock('../../models/BottleImage', () => ({}));
+jest.mock('../../models/WineVintageProfile', () => ({}));
+jest.mock('../../models/WineVintagePrice', () => ({}));
+jest.mock('../../models/WineReport', () => ({}));
+jest.mock('../../models/Review', () => ({}));
+jest.mock('../../models/Discussion', () => ({}));
+jest.mock('../../models/DiscussionReply', () => ({}));
+jest.mock('../../models/WineEmbedding', () => ({}));
+jest.mock('../../models/WineNotDuplicate', () => ({ find: jest.fn() }));
+jest.mock('../../models/WineList', () => ({}));
+jest.mock('../../models/WishlistItem', () => ({}));
+jest.mock('../../models/PriceTrackingRequest', () => ({}));
+jest.mock('../../models/PriceTrackingSkip', () => ({}));
+jest.mock('../../models/CommunityWinePrice', () => ({}));
+jest.mock('../../models/JournalEntry', () => ({}));
+jest.mock('../../models/Recommendation', () => ({}));
+jest.mock('../../models/RestockAlert', () => ({}));
+jest.mock('../../models/WineRequest', () => ({}));
+jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
+jest.mock('../../services/vectorStore', () => ({}));
+jest.mock('../../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../../services/embeddingJob', () => ({ embedSinglePair: jest.fn() }));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn(), removeWine: jest.fn(), bulkIndexBottles: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../../services/enrichmentJob', () => ({
+  reenrichAfterRecordEdit: jest.fn(),
+  enrichWineById: jest.fn(),
+  // Faithful-enough mirror of the real snapshot (unit-tested in
+  // enrichmentJob.test.js) — the route only ever compares two of these.
+  profileInputsSnapshot: jest.fn((w) => JSON.stringify({
+    name: w.name || '', producer: w.producer || '',
+    country: String(w.country || ''), region: String(w.region || ''),
+    appellation: w.appellation || '', classification: w.classification || '',
+    type: w.type || '', grapes: (w.grapes || []).map(String).sort(),
+  })),
+}));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineDefinition = require('../../models/WineDefinition');
+const Bottle = require('../../models/Bottle');
+const { reenrichAfterRecordEdit } = require('../../services/enrichmentJob');
+const adminWinesRouter = require('./wines');
+
+const ADMIN_ID = '64b000000000000000000001';
+const WINE_ID = '64b0000000000000000000c1';
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/wines', adminWinesRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const put = (body) => fetch(`${baseUrl}/api/admin/wines/${WINE_ID}`, {
+  method: 'PUT',
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+  body: JSON.stringify(body),
+});
+
+const mkWine = (over = {}) => {
+  const wine = {
+    _id: WINE_ID,
+    name: 'Douro Tinto', producer: 'Fabelhaft', country: 'c1', region: 'r1',
+    appellation: 'Douro', classification: null, type: 'red', grapes: ['g1'],
+    aiProfile: { generatedAt: new Date(), source: 'ai' },
+    slug: 'douro-tinto',
+    ...over,
+  };
+  wine.save = jest.fn().mockResolvedValue(wine);
+  wine.populate = jest.fn().mockResolvedValue(wine);
+  return wine;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Bottle.distinct.mockResolvedValue([]);
+});
+
+test('a real producer change hands the wine to the re-enrich follow-through', async () => {
+  const wine = mkWine();
+  WineDefinition.findById.mockResolvedValue(wine);
+
+  const res = await put({ name: 'Douro Tinto', producer: 'Niepoort', type: 'red' });
+  expect(res.status).toBe(200);
+  expect(wine.producer).toBe('Niepoort');
+  expect(reenrichAfterRecordEdit).toHaveBeenCalledWith(wine, true);
+});
+
+test('the form re-sending every field unchanged does NOT regenerate (the v1.116.0 churn fix)', async () => {
+  const wine = mkWine();
+  WineDefinition.findById.mockResolvedValue(wine);
+
+  // Exactly what the edit form does on save: full payload, nothing different.
+  const res = await put({ name: 'Douro Tinto', producer: 'Fabelhaft', type: 'red', grapes: ['g1'] });
+  expect(res.status).toBe(200);
+  expect(reenrichAfterRecordEdit).toHaveBeenCalledWith(wine, false);
+});
+
+test('a type change alone counts — the profile describes the wrong colour otherwise', async () => {
+  const wine = mkWine();
+  WineDefinition.findById.mockResolvedValue(wine);
+
+  const res = await put({ name: 'Douro Tinto', producer: 'Fabelhaft', type: 'white' });
+  expect(res.status).toBe(200);
+  expect(reenrichAfterRecordEdit).toHaveBeenCalledWith(wine, true);
+});

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -456,8 +456,57 @@ async function enrichWineById(wineDefId, { budgetUserId, force = false, publishS
   }
 }
 
+// ── Record-edit follow-through (shared by the deliberate curation surfaces) ──
+
+/**
+ * The record fields suggestProfile reads, folded into one comparable string.
+ * Snapshot BEFORE applying an edit, compare after save: the admin form
+ * re-sends every field on save, so presence-in-body says nothing — only a
+ * before/after difference means the stored profile now describes the wrong
+ * record. Robust to populated and unpopulated refs (ids are folded either
+ * way) and to grape order.
+ */
+function profileInputsSnapshot(wine) {
+  const idOf = (v) => String(v && v._id ? v._id : (v || ''));
+  return JSON.stringify({
+    name: wine.name || '',
+    producer: wine.producer || '',
+    country: idOf(wine.country),
+    region: idOf(wine.region),
+    appellation: wine.appellation || '',
+    classification: wine.classification || '',
+    type: wine.type || '',
+    grapes: (wine.grapes || []).map(idOf).sort(),
+  });
+}
+
+/**
+ * After a deliberate curation edit (admin wine PUT, proposal approve) changed
+ * a field the profile generator reads, the stored AI profile describes the
+ * OLD record — including a HELD one, whose doubt the edit may have just
+ * resolved (rename "Fabelhaft" → "Niepoort" and the hold's reason is gone;
+ * measured live 2026-08-16, where the approve path left the négociant
+ * fiction attached until a manual re-enrich). Fire-and-forget forced
+ * regeneration under the corrected record.
+ *
+ * Gates: `changed` is the CALLER's before/after profileInputsSnapshot
+ * comparison — this helper never guesses; a never-enriched wine has nothing
+ * stale (the bottle-add hook and batch runs cover fresh rows); curator
+ * profiles are never regenerated (double-guarded — enrichWineById refuses
+ * them too, force or not).
+ *
+ * Returns the floating promise so tests can await settlement; callers ignore it.
+ */
+function reenrichAfterRecordEdit(wine, changed) {
+  if (!changed) return Promise.resolve();
+  if (!wine || !wine.aiProfile || !wine.aiProfile.generatedAt) return Promise.resolve();
+  if (wine.aiProfile.source === 'curator') return Promise.resolve();
+  return enrichWineById(wine._id, { force: true }).catch(() => {});
+}
+
 module.exports = {
   start, requestStop, getStatus, enrichWineById,
+  profileInputsSnapshot, reenrichAfterRecordEdit,
   // exported for unit tests
   cleanDescriptor, cleanStringList, cleanProse, cleanConfidence,
 };

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -363,3 +363,65 @@ describe('producer-suspect profiles are held, not published', () => {
     expect(persisted().description).toBe('Plain prose.');
   });
 });
+
+/**
+ * The record-edit follow-through (parity gap found live 2026-08-16: approving
+ * "Fabelhaft" → "Niepoort" left the négociant-fiction profile attached until
+ * a manual force re-enrich). The helper regenerates ONLY on a real change,
+ * never over curator work, and treats HELD as enriched-and-regenerable —
+ * an identity fix is exactly what resolves a hold.
+ */
+describe('reenrichAfterRecordEdit — the record-edit follow-through', () => {
+  const { reenrichAfterRecordEdit } = require('./enrichmentJob');
+  const enriched = (over = {}) => ({ _id: WINE_ID, aiProfile: { generatedAt: new Date(), source: 'ai', ...over } });
+
+  test('a real change on an ai-sourced profile regenerates (force path reaches the model)', async () => {
+    suggestProfile.mockResolvedValue(profile('Regenerated prose.'));
+    await reenrichAfterRecordEdit(enriched(), true);
+    expect(suggestProfile).toHaveBeenCalled();
+    expect(persisted().description).toBe('Regenerated prose.');
+  });
+
+  test('no change → nothing happens, not even a wine read', async () => {
+    await reenrichAfterRecordEdit(enriched(), false);
+    expect(WineDefinition.findById).not.toHaveBeenCalled();
+    expect(suggestProfile).not.toHaveBeenCalled();
+  });
+
+  test('a never-enriched wine has nothing stale → no call (the add hook covers fresh rows)', async () => {
+    await reenrichAfterRecordEdit({ _id: WINE_ID, aiProfile: {} }, true);
+    expect(suggestProfile).not.toHaveBeenCalled();
+  });
+
+  test('curator profiles are never regenerated from an edit', async () => {
+    await reenrichAfterRecordEdit(enriched({ source: 'curator' }), true);
+    expect(suggestProfile).not.toHaveBeenCalled();
+  });
+
+  test('a HELD profile counts as enriched — an identity fix regenerates it', async () => {
+    suggestProfile.mockResolvedValue(profile('Clean profile under the fixed identity.'));
+    await reenrichAfterRecordEdit(enriched({ heldAt: new Date(), description: null }), true);
+    expect(suggestProfile).toHaveBeenCalled();
+  });
+});
+
+describe('profileInputsSnapshot — the before/after comparison the routes use', () => {
+  const { profileInputsSnapshot } = require('./enrichmentJob');
+
+  test('folds populated docs and raw ids identically; grape order-insensitive', () => {
+    const a = profileInputsSnapshot({ name: 'X', producer: 'Y', country: 'c1', region: 'r1', grapes: ['g1', 'g2'], type: 'red' });
+    const b = profileInputsSnapshot({ name: 'X', producer: 'Y', country: { _id: 'c1' }, region: { _id: 'r1' }, grapes: [{ _id: 'g2' }, { _id: 'g1' }], type: 'red' });
+    expect(a).toBe(b);
+  });
+
+  test('differs when any profile-feeding field changes', () => {
+    const base = { name: 'X', producer: 'Y', country: 'c1', type: 'red' };
+    for (const change of [
+      { producer: 'Z' }, { name: 'X2' }, { country: 'c2' }, { region: 'r9' },
+      { appellation: 'Margaux' }, { classification: 'Grand Cru Classé en 1855' },
+      { type: 'white' }, { grapes: ['g1'] },
+    ]) {
+      expect(profileInputsSnapshot({ ...base, ...change })).not.toBe(profileInputsSnapshot(base));
+    }
+  });
+});


### PR DESCRIPTION
## Item 1 of the write-path follow-up list

Two related gaps, one shared fix:

**1. Proposal-approve parity (found live 2026-08-16).** The approve route ran every PUT follow-through — reindex, bottle search docs, re-embed, IndexNow — *except* the v1.116.0 re-enrich. Approving "Fabelhaft" → "Niepoort" left the négociant-fiction profile attached until a manual force re-enrich.

**2. PUT churn fix.** The v1.116.0 hook fired on presence-in-body (`name || producer`). The admin edit form re-sends every field on save, so **every save** would have regenerated the profile — burning an AI call and bumping `generatedAt`, which resurfaces already-reviewed rows in the low-confidence queue.

## Change

One implementation, two callers (`services/enrichmentJob.js`):

- `profileInputsSnapshot(wine)` — the profile-feeding fields (name, producer, country, region, appellation, classification, type, grapes) folded into one comparable string; robust to populated/unpopulated refs and grape order
- `reenrichAfterRecordEdit(wine, changed)` — fire-and-forget forced regeneration, **only on a real before/after change**; never-enriched rows skip (the bottle-add hook covers fresh mints); curator profiles never touched (double-guarded); a HELD profile counts as enriched and regenerates — an identity fix is exactly what resolves a hold

Both the admin PUT and the proposal-approve `field_correction` branch now snapshot before mutation and hand the comparison to the helper. Scope widened from name/producer to **all profile-feeding fields** — a type change alone means the profile describes the wrong colour, which the enrichment prompt itself treats as authoritative.

## Tests

- `enrichmentJob.test.js`: helper gates (real change / no change / never-enriched / curator / held) + snapshot fold semantics
- `wineProposals.test.js`: approve with real producer change → follow-through fires; identical values → it doesn't
- new `wines.reenrichOnEdit.test.js`: PUT real change fires; full-form unchanged save does **not** (the churn pin); type-only change fires
- Container run: 5 suites, 74 tests green

No compose impact, no schema change, no user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)