### PR TITLE
feat(admin): bulk approve/reject for sommelier correction proposals

### DIFF
--- a/backend/src/routes/admin/wineProposals.js
+++ b/backend/src/routes/admin/wineProposals.js
@@ -147,19 +147,33 @@ router.get('/', async (req, res) => {
 });
 
 // Already-decided vs never-existed, after a failed claim (aiBudgetRequests pattern).
-async function decideConflict(res, proposalId) {
+async function decideOutcome(proposalId) {
   const exists = await WineCorrectionProposal.exists({ _id: proposalId });
   return exists
-    ? res.status(409).json({ error: 'Proposal has already been decided' })
-    : res.status(404).json({ error: 'Proposal not found' });
+    ? { status: 409, body: { error: 'Proposal has already been decided' } }
+    : { status: 404, body: { error: 'Proposal not found' } };
 }
 
 // POST /api/admin/wine-proposals/:id/approve — claim, then apply by kind
 router.post('/:id/approve', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
-    const proposalId = new mongoose.Types.ObjectId(req.params.id);
+    const { status, body } = await approveProposal(new mongoose.Types.ObjectId(req.params.id), req);
+    res.status(status).json(body);
+  } catch (err) {
+    console.error('Approve wine proposal error:', err);
+    res.status(500).json({ error: 'Failed to approve proposal' });
+  }
+});
 
+/**
+ * Approve ONE proposal: atomic claim → apply by kind → per-proposal audit.
+ * Returns { status, body } instead of writing to a response, so the single
+ * route and the bulk loop run EXACTLY the same machinery — the
+ * performWineMerge extraction pattern, one layer up. Unexpected errors are
+ * thrown (after the claim revert) for the caller to map to its own 500.
+ */
+async function approveProposal(proposalId, req) {
     // Atomically CLAIM the pending row so only the first of two concurrent
     // decisions wins (the aiBudgetRequests check-then-act fix): a null result
     // means already-decided (409) or never-existed (404).
@@ -169,7 +183,7 @@ router.post('/:id/approve', async (req, res) => {
       { $set: { status: 'approved', decidedBy: req.user.id, decidedAt: now } },
       { new: true }
     );
-    if (!proposal) return decideConflict(res, proposalId);
+    if (!proposal) return decideOutcome(proposalId);
 
     // Any apply failure below reverts the claim so there is no half-approved
     // state. Best-effort by necessity: the moment our claim left 'pending',
@@ -193,7 +207,7 @@ router.post('/:id/approve', async (req, res) => {
         const wine = await WineDefinition.findById(proposal.wineDefinition);
         if (!wine) {
           await revertClaim();
-          return res.status(404).json({ error: 'The proposed wine no longer exists' });
+          return { status: 404, body: { error: 'The proposed wine no longer exists' } };
         }
         // Before-image for the re-enrich decision below — same real-change
         // semantics as the admin PUT.
@@ -225,7 +239,7 @@ router.post('/:id/approve', async (req, res) => {
           countryDoc = await Country.findOne({ normalizedName: normalizeString(resolveCountryName(pf.country)) });
           if (!countryDoc) {
             await revertClaim();
-            return res.status(400).json({ error: `Unknown country "${pf.country}" — add it in Admin → Taxonomy first, then approve` });
+            return { status: 400, body: { error: `Unknown country "${pf.country}" — add it in Admin → Taxonomy first, then approve` } };
           }
           wine.country = countryDoc._id;
           applied.push('country');
@@ -250,9 +264,9 @@ router.post('/:id/approve', async (req, res) => {
         } catch (err) {
           if (err.code === 11000) {
             await revertClaim();
-            return res.status(409).json({
+            return { status: 409, body: {
               error: 'Applying this correction would make the wine identical to an existing registry wine — use a merge proposal instead',
-            });
+            } };
           }
           throw err;
         }
@@ -279,7 +293,7 @@ router.post('/:id/approve', async (req, res) => {
         const result = await performWineMerge(String(proposal.wineDefinition), String(proposal.mergeTargetId), req);
         if (result.error) {
           await revertClaim();
-          return res.status(result.error.status).json({ error: result.error.message });
+          return { status: result.error.status, body: { error: result.error.message } };
         }
         const targetLabel = [result.target.producer, result.target.name].filter(Boolean).join(' — ');
         appliedNote = `Merged into ${targetLabel} (${result.bottlesMoved} bottle(s) moved)`;
@@ -287,7 +301,7 @@ router.post('/:id/approve', async (req, res) => {
         const wine = await WineDefinition.findById(proposal.wineDefinition);
         if (!wine) {
           await revertClaim();
-          return res.status(404).json({ error: 'The proposed wine no longer exists' });
+          return { status: 404, body: { error: 'The proposed wine no longer exists' } };
         }
         // Same semantics as POST /:id/non-wine value:true — flag + let the
         // self-healing index sync drop it from search.
@@ -320,43 +334,121 @@ router.post('/:id/approve', async (req, res) => {
         appliedNote,
       });
 
-    res.json({ message: 'Proposal approved and applied', proposalId: proposal._id, status: 'approved', appliedNote });
-  } catch (err) {
-    console.error('Approve wine proposal error:', err);
-    res.status(500).json({ error: 'Failed to approve proposal' });
+    return { status: 200, body: { message: 'Proposal approved and applied', proposalId: proposal._id, status: 'approved', appliedNote } };
+}
+
+// Reason hygiene shared by the single and bulk reject paths: plain text only,
+// bounded even after strip (reject_price_request hygiene).
+function parseRejectReason(raw) {
+  const reason = stripHtml(typeof raw === 'string' ? raw : '');
+  if (!reason || reason.length < REJECT_REASON_MIN) {
+    return { error: `A reject reason of at least ${REJECT_REASON_MIN} characters is required` };
   }
-});
+  if (reason.length > REJECT_REASON_MAX) {
+    return { error: `Reject reason must be at most ${REJECT_REASON_MAX} characters` };
+  }
+  return { reason };
+}
 
 // POST /api/admin/wine-proposals/:id/reject — reason required, stored on the row
 router.post('/:id/reject', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
-
-    // Plain text only, bounded even after strip (reject_price_request hygiene).
-    const reason = stripHtml(typeof req.body?.reason === 'string' ? req.body.reason : '');
-    if (!reason || reason.length < REJECT_REASON_MIN) {
-      return res.status(400).json({ error: `A reject reason of at least ${REJECT_REASON_MIN} characters is required` });
-    }
-    if (reason.length > REJECT_REASON_MAX) {
-      return res.status(400).json({ error: `Reject reason must be at most ${REJECT_REASON_MAX} characters` });
-    }
-
-    const proposalId = new mongoose.Types.ObjectId(req.params.id);
-    const proposal = await WineCorrectionProposal.findOneAndUpdate(
-      { _id: proposalId, status: 'pending' },
-      { $set: { status: 'rejected', decidedBy: req.user.id, decidedAt: new Date(), rejectReason: reason } },
-      { new: true }
-    );
-    if (!proposal) return decideConflict(res, proposalId);
-
-    logAudit(req, 'admin.wineProposal.reject',
-      { type: 'WineCorrectionProposal', id: proposal._id },
-      { kind: proposal.kind, wineDefinitionId: proposal.wineDefinition, reason });
-
-    res.json({ message: 'Proposal rejected', proposalId: proposal._id, status: 'rejected' });
+    const parsed = parseRejectReason(req.body?.reason);
+    if (parsed.error) return res.status(400).json({ error: parsed.error });
+    const { status, body } = await rejectProposal(new mongoose.Types.ObjectId(req.params.id), parsed.reason, req);
+    res.status(status).json(body);
   } catch (err) {
     console.error('Reject wine proposal error:', err);
     res.status(500).json({ error: 'Failed to reject proposal' });
+  }
+});
+
+/** Reject ONE proposal via the same atomic claim. Returns { status, body }. */
+async function rejectProposal(proposalId, reason, req) {
+  const proposal = await WineCorrectionProposal.findOneAndUpdate(
+    { _id: proposalId, status: 'pending' },
+    { $set: { status: 'rejected', decidedBy: req.user.id, decidedAt: new Date(), rejectReason: reason } },
+    { new: true }
+  );
+  if (!proposal) return decideOutcome(proposalId);
+
+  logAudit(req, 'admin.wineProposal.reject',
+    { type: 'WineCorrectionProposal', id: proposal._id },
+    { kind: proposal.kind, wineDefinitionId: proposal.wineDefinition, reason });
+
+  return { status: 200, body: { message: 'Proposal rejected', proposalId: proposal._id, status: 'rejected' } };
+}
+
+// ── Bulk decisions (ticket 6a8162c5, ask #3 — the middle road) ──────────────
+// The somm files evidence-backed proposals one at a time; clearing a batch
+// through per-row round trips was the queue's whole overhead. The review gate
+// STAYS — an admin still reads every row — the clicking goes. Each id runs
+// the EXACT single-decision machinery above, sequentially (registry applies
+// re-key, reindex and re-enrich; concurrency buys nothing and could
+// interleave writes on sibling wines), and reports a per-row outcome: one
+// row's 409 "merge instead" never blocks the rest of the batch. Per-proposal
+// audit entries come from the shared functions, so the audit stream reads the
+// same whether a decision arrived alone or in a batch.
+const MAX_BULK_DECISIONS = 50;
+
+function parseBulkIds(body) {
+  const ids = body?.ids;
+  if (!Array.isArray(ids) || ids.length === 0) return { error: 'ids must be a non-empty array' };
+  if (ids.length > MAX_BULK_DECISIONS) return { error: `At most ${MAX_BULK_DECISIONS} proposals per call` };
+  if (ids.some((id) => !isValidId(id))) return { error: 'Every id must be a valid proposal id' };
+  return { ids: [...new Set(ids.map(String))] };
+}
+
+router.post('/bulk-approve', async (req, res) => {
+  try {
+    const parsed = parseBulkIds(req.body);
+    if (parsed.error) return res.status(400).json({ error: parsed.error });
+    const results = [];
+    for (const id of parsed.ids) {
+      try {
+        const { status, body } = await approveProposal(new mongoose.Types.ObjectId(id), req);
+        results.push(status === 200
+          ? { proposalId: id, ok: true, status, appliedNote: body.appliedNote }
+          : { proposalId: id, ok: false, status, error: body.error });
+      } catch (err) {
+        console.error('Bulk approve item error:', id, err);
+        results.push({ proposalId: id, ok: false, status: 500, error: 'Failed to approve proposal' });
+      }
+    }
+    const approved = results.filter((r) => r.ok).length;
+    res.json({ results, approved, failed: results.length - approved });
+  } catch (err) {
+    console.error('Bulk approve wine proposals error:', err);
+    res.status(500).json({ error: 'Failed to bulk-approve proposals' });
+  }
+});
+
+router.post('/bulk-reject', async (req, res) => {
+  try {
+    const parsed = parseBulkIds(req.body);
+    if (parsed.error) return res.status(400).json({ error: parsed.error });
+    // ONE shared reason for the batch, validated once — nothing is decided on
+    // a bad reason.
+    const reasonParsed = parseRejectReason(req.body?.reason);
+    if (reasonParsed.error) return res.status(400).json({ error: reasonParsed.error });
+    const results = [];
+    for (const id of parsed.ids) {
+      try {
+        const { status, body } = await rejectProposal(new mongoose.Types.ObjectId(id), reasonParsed.reason, req);
+        results.push(status === 200
+          ? { proposalId: id, ok: true, status }
+          : { proposalId: id, ok: false, status, error: body.error });
+      } catch (err) {
+        console.error('Bulk reject item error:', id, err);
+        results.push({ proposalId: id, ok: false, status: 500, error: 'Failed to reject proposal' });
+      }
+    }
+    const rejected = results.filter((r) => r.ok).length;
+    res.json({ results, rejected, failed: results.length - rejected });
+  } catch (err) {
+    console.error('Bulk reject wine proposals error:', err);
+    res.status(500).json({ error: 'Failed to bulk-reject proposals' });
   }
 });
 

--- a/backend/src/routes/admin/wineProposals.test.js
+++ b/backend/src/routes/admin/wineProposals.test.js
@@ -319,3 +319,86 @@ describe('POST /:id/reject', () => {
     expect(res.status).toBe(409);
   });
 });
+
+/**
+ * Bulk decisions (ticket 6a8162c5 ask #3 — the middle road): each id runs the
+ * EXACT single-decision machinery, so what these pin is the batch envelope —
+ * per-row outcomes, one row's failure never blocking the rest, dedupe, and
+ * the bounds/reason gates deciding NOTHING when they fail.
+ */
+describe('POST /bulk-approve and /bulk-reject', () => {
+  const P2 = '64b0000000000000000000a2';
+  const claimSeq = (...proposals) => {
+    for (const p of proposals) WineCorrectionProposal.findOneAndUpdate.mockResolvedValueOnce(p);
+  };
+
+  test('bulk-approve: per-row outcomes; a 409 on one row never blocks the rest', async () => {
+    claimSeq(
+      { _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { producer: 'Niepoort' } },
+      null, // second claim fails → decided-elsewhere path
+    );
+    WineCorrectionProposal.exists.mockResolvedValueOnce(true); // → 409 for the second id
+    const wine = { _id: W1, name: 'Douro Tinto', producer: 'Fabelhaft', appellation: 'Douro', country: 'c1', save: jest.fn().mockResolvedValue(undefined) };
+    WineDefinition.findById.mockResolvedValue(wine);
+
+    const res = await post('/bulk-approve', { ids: [P1, P2] });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.approved).toBe(1);
+    expect(data.failed).toBe(1);
+    expect(data.results[0]).toMatchObject({ proposalId: P1, ok: true, status: 200 });
+    expect(data.results[0].appliedNote).toMatch(/producer/);
+    expect(data.results[1]).toMatchObject({ proposalId: P2, ok: false, status: 409 });
+    // The applied row went through the real machinery: claim + apply + index.
+    expect(wine.save).toHaveBeenCalled();
+    expect(searchService.indexWine).toHaveBeenCalledWith(W1);
+  });
+
+  test('bulk-approve: duplicate ids dedupe to one decision', async () => {
+    claimSeq({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { producer: 'X' } });
+    const wine = { _id: W1, name: 'N', producer: 'P', appellation: null, country: 'c1', save: jest.fn().mockResolvedValue(undefined) };
+    WineDefinition.findById.mockResolvedValue(wine);
+
+    const res = await post('/bulk-approve', { ids: [P1, P1] });
+    const data = await res.json();
+    expect(data.results).toHaveLength(1);
+    expect(WineCorrectionProposal.findOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test('bulk-approve bounds: empty, invalid and oversize id arrays are 400 with NOTHING decided', async () => {
+    for (const body of [
+      {},
+      { ids: [] },
+      { ids: ['not-an-id'] },
+      { ids: Array.from({ length: 51 }, () => P1) }, // length gate fires before dedupe
+    ]) {
+      const res = await post('/bulk-approve', body);
+      expect(res.status).toBe(400);
+    }
+    expect(WineCorrectionProposal.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('bulk-reject: one shared reason, per-row claims; a vanished row reports 404', async () => {
+    claimSeq(
+      { _id: P1, kind: 'field_correction', wineDefinition: W1 },
+      null,
+    );
+    WineCorrectionProposal.exists.mockResolvedValueOnce(false); // → 404 for the second id
+
+    const res = await post('/bulk-reject', { ids: [P1, P2], reason: 'Duplicate wave from one import session' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.rejected).toBe(1);
+    expect(data.results[0]).toMatchObject({ proposalId: P1, ok: true, status: 200 });
+    expect(data.results[1]).toMatchObject({ proposalId: P2, ok: false, status: 404 });
+    // The reason landed via the same claim write the single route uses.
+    expect(WineCorrectionProposal.findOneAndUpdate.mock.calls[0][1].$set.rejectReason)
+      .toBe('Duplicate wave from one import session');
+  });
+
+  test('bulk-reject: a bad shared reason is 400 and decides NOTHING', async () => {
+    const res = await post('/bulk-reject', { ids: [P1], reason: 'x' });
+    expect(res.status).toBe(400);
+    expect(WineCorrectionProposal.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -82,6 +82,20 @@ export const adminRejectWineProposal = (apiFetch, id, reason) =>
     body: JSON.stringify({ reason }),
   });
 
+export const adminBulkApproveWineProposals = (apiFetch, ids) =>
+  apiFetch('/api/admin/wine-proposals/bulk-approve', {
+    method: 'POST',
+    headers: J,
+    body: JSON.stringify({ ids }),
+  });
+
+export const adminBulkRejectWineProposals = (apiFetch, ids, reason) =>
+  apiFetch('/api/admin/wine-proposals/bulk-reject', {
+    method: 'POST',
+    headers: J,
+    body: JSON.stringify({ ids, reason }),
+  });
+
 // Owner inquiries: questions sent to a wine's bottle owners (curator→owner
 // channel for records only an owner can settle). The list is answered-first
 // and its envelope carries pendingCount + answeredCount for the toolbar

--- a/frontend/src/components/WineProposalsModal.js
+++ b/frontend/src/components/WineProposalsModal.js
@@ -2,7 +2,10 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import Modal from './Modal';
-import { adminGetWineProposals, adminApproveWineProposal, adminRejectWineProposal } from '../api/admin';
+import {
+  adminGetWineProposals, adminApproveWineProposal, adminRejectWineProposal,
+  adminBulkApproveWineProposals, adminBulkRejectWineProposals,
+} from '../api/admin';
 
 const PAGE_SIZE = 20;
 
@@ -53,9 +56,16 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
   const [pendingCount, setPendingCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [pendingId, setPendingId] = useState(null); // proposal id with a POST in flight
+  const [pendingId, setPendingId] = useState(null); // proposal id (or 'bulk') with a POST in flight
   const [rejectingId, setRejectingId] = useState(null); // row showing the inline reason input
   const [rejectReason, setRejectReason] = useState('');
+  // Bulk selection (pending view only). rowErrors carries per-proposal
+  // failures from the last bulk call — failed rows STAY listed and selected
+  // with their reason shown, so nothing silently drops out of the batch.
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+  const [bulkRejecting, setBulkRejecting] = useState(false); // shared-reason input visible
+  const [bulkReason, setBulkReason] = useState('');
+  const [rowErrors, setRowErrors] = useState({});
   const fetchGen = useRef(0);
   // Rows this session decided leave the pending view — the set shrinks under a
   // fixed page*limit offset, so subtract what we removed (the fragmentation
@@ -82,6 +92,10 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
       setTotal(data.total || 0);
       setPages(data.pages || 1);
       setPendingCount(data.pendingCount || 0);
+      // A fresh page is a fresh selection — post-bulk failure state is set
+      // AFTER the bulk call returns and never triggers a refetch itself.
+      setSelectedIds(new Set());
+      setRowErrors({});
     } catch {
       if (gen === fetchGen.current) setError(t('common.networkError'));
     } finally {
@@ -100,24 +114,30 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
     setItems(null);
     setRejectingId(null);
     setRejectReason('');
+    setSelectedIds(new Set());
+    setBulkRejecting(false);
+    setBulkReason('');
+    setRowErrors({});
     setPage(1);
   };
 
-  // Shared post-decision bookkeeping for the pending view: drop the row via
+  // Shared post-decision bookkeeping for the pending view: drop the row(s) via
   // functional updaters and refill the page when it drained empty.
-  const removeDecidedRow = (id) => {
-    decidedDelta.current += 1;
-    setItems(prev => (prev || []).filter(x => x._id !== id));
-    setTotal(prev => Math.max(0, prev - 1));
-    setPendingCount(prev => Math.max(0, prev - 1));
+  const removeDecidedRows = (ids) => {
+    const gone = new Set(ids);
+    decidedDelta.current += gone.size;
+    setItems(prev => (prev || []).filter(x => !gone.has(x._id)));
+    setTotal(prev => Math.max(0, prev - gone.size));
+    setPendingCount(prev => Math.max(0, prev - gone.size));
     // The drain check may use the closure: every interleaving path (second
     // decision, view switch, page change) is disabled while one is pending.
-    const remaining = (items || []).filter(x => x._id !== id).length;
-    if (remaining === 0 && total - 1 > 0) {
+    const remaining = (items || []).filter(x => !gone.has(x._id)).length;
+    if (remaining === 0 && total - gone.size > 0) {
       if (page > 1) setPage(p => p - 1);
       else fetchPage(1);
     }
   };
+  const removeDecidedRow = (id) => removeDecidedRows([id]);
 
   const approve = async (proposal) => {
     // Approving supersedes a half-typed reject on the same row — close the
@@ -171,6 +191,87 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
     }
   };
 
+  // ── Bulk selection + decisions (pending view only) ─────────────────────────
+  const toggleSelected = (id) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+  const pendingOnPage = (items || []).filter(x => x.status === 'pending');
+  const allOnPageSelected = pendingOnPage.length > 0 && pendingOnPage.every(x => selectedIds.has(x._id));
+  const toggleSelectAll = () => {
+    setSelectedIds(allOnPageSelected ? new Set() : new Set(pendingOnPage.map(x => x._id)));
+  };
+
+  // Shared result handling: successful rows drain in ONE bookkeeping pass;
+  // failed rows stay listed AND selected with their per-row reason shown —
+  // deliberately no auto-refetch, so nothing the admin was deciding on moves
+  // under them.
+  const applyBulkResults = (results) => {
+    const okIds = results.filter(r => r.ok).map(r => r.proposalId);
+    const failed = results.filter(r => !r.ok);
+    if (okIds.length) {
+      removeDecidedRows(okIds);
+      onChanged?.();
+    }
+    setSelectedIds(new Set(failed.map(f => f.proposalId)));
+    if (failed.length) {
+      setRowErrors(Object.fromEntries(failed.map(f => [f.proposalId, f.error])));
+      setError(t('admin.wines.proposals.bulkPartial', { ok: okIds.length, failed: failed.length }));
+    } else {
+      setRowErrors({});
+    }
+  };
+
+  const bulkApprove = async () => {
+    const ids = [...selectedIds];
+    if (ids.length === 0) return;
+    setPendingId('bulk');
+    setError(null);
+    try {
+      const res = await adminBulkApproveWineProposals(apiFetch, ids);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || t('admin.wines.proposals.approveError'));
+        return;
+      }
+      applyBulkResults(data.results || []);
+    } catch {
+      setError(t('common.networkError'));
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const bulkReject = async () => {
+    const ids = [...selectedIds];
+    const reason = bulkReason.trim();
+    if (ids.length === 0) return;
+    if (reason.length < 5) {
+      setError(t('admin.wines.proposals.rejectReasonRequired'));
+      return;
+    }
+    setPendingId('bulk');
+    setError(null);
+    try {
+      const res = await adminBulkRejectWineProposals(apiFetch, ids, reason);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || t('admin.wines.proposals.rejectError'));
+        return;
+      }
+      setBulkRejecting(false);
+      setBulkReason('');
+      applyBulkResults(data.results || []);
+    } catch {
+      setError(t('common.networkError'));
+    } finally {
+      setPendingId(null);
+    }
+  };
+
   const kindBadgeStyle = {
     fontSize: '0.7rem', fontWeight: 600, padding: '0.1rem 0.45rem',
     borderRadius: 'var(--radius-sm)', background: 'var(--color-warning-bg)',
@@ -216,6 +317,77 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
         )}
       </div>
 
+      {statusView === 'pending' && pendingOnPage.length > 0 && (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap',
+          marginBottom: 12, padding: '0.45rem 0.65rem',
+          border: '1px solid var(--color-border)', borderRadius: 'var(--radius-sm)',
+        }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.85rem', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={allOnPageSelected}
+              disabled={!!pendingId}
+              onChange={toggleSelectAll}
+            />
+            {t('admin.wines.proposals.selectAllPage')}
+          </label>
+          <span style={{ fontSize: '0.85rem', color: 'var(--color-text-muted)' }}>
+            {t('admin.wines.proposals.selectedCount', { count: selectedIds.size })}
+          </span>
+          <button
+            type="button"
+            className="btn btn-primary btn-small"
+            disabled={!!pendingId || selectedIds.size === 0}
+            onClick={bulkApprove}
+          >
+            {pendingId === 'bulk' && !bulkRejecting
+              ? t('admin.wines.proposals.bulkApproving')
+              : t('admin.wines.proposals.approveSelected', { count: selectedIds.size })}
+          </button>
+          {bulkRejecting ? (
+            <>
+              <input
+                type="text"
+                value={bulkReason}
+                onChange={(e) => setBulkReason(e.target.value)}
+                placeholder={t('admin.wines.proposals.bulkRejectPlaceholder')}
+                maxLength={500}
+                disabled={!!pendingId}
+                style={{ flex: '1 1 220px', minWidth: 180 }}
+              />
+              <button
+                type="button"
+                className="btn btn-secondary btn-small"
+                disabled={!!pendingId || selectedIds.size === 0}
+                onClick={bulkReject}
+              >
+                {pendingId === 'bulk'
+                  ? t('admin.wines.proposals.bulkRejecting')
+                  : t('admin.wines.proposals.rejectConfirm')}
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary btn-small"
+                disabled={!!pendingId}
+                onClick={() => { setBulkRejecting(false); setBulkReason(''); }}
+              >
+                {t('common.cancel')}
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              className="btn btn-secondary btn-small"
+              disabled={!!pendingId || selectedIds.size === 0}
+              onClick={() => setBulkRejecting(true)}
+            >
+              {t('admin.wines.proposals.rejectSelected', { count: selectedIds.size })}
+            </button>
+          )}
+        </div>
+      )}
+
       {error && <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>}
 
       {loading || items === null ? (
@@ -233,6 +405,15 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
           {items.map(p => (
             <div key={p._id} style={boxStyle}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 6 }}>
+                {p.status === 'pending' && (
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(p._id)}
+                    disabled={!!pendingId}
+                    onChange={() => toggleSelected(p._id)}
+                    aria-label={t('admin.wines.proposals.selectRow')}
+                  />
+                )}
                 <span style={kindBadgeStyle}>{t(KIND_KEYS[p.kind] || KIND_KEYS.field_correction)}</span>
                 {p.wineDefinition ? (
                   <Link to={`/wines/${p.wineDefinition._id}`} target="_blank" rel="noopener noreferrer">
@@ -308,6 +489,12 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
                   <span>{t('admin.wines.proposals.rejectedWith', { reason: p.rejectReason })}</span>
                 )}
               </div>
+
+              {rowErrors[p._id] && (
+                <div className="alert alert-error" style={{ marginTop: 6, padding: '0.35rem 0.6rem', fontSize: '0.8rem' }}>
+                  {rowErrors[p._id]}
+                </div>
+              )}
 
               {p.status === 'pending' && (
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 8 }}>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1702,7 +1702,19 @@
         "statusRejected": "Rejected",
         "loadError": "Failed to load proposals",
         "approveError": "Failed to approve the proposal",
-        "rejectError": "Failed to reject the proposal"
+        "rejectError": "Failed to reject the proposal",
+        "selectRow": "Select this proposal",
+        "selectAllPage": "Select all on this page",
+        "selectedCount_one": "{{count}} selected",
+        "selectedCount_other": "{{count}} selected",
+        "approveSelected_one": "Approve selected ({{count}})",
+        "approveSelected_other": "Approve selected ({{count}})",
+        "rejectSelected_one": "Reject selected ({{count}})…",
+        "rejectSelected_other": "Reject selected ({{count}})…",
+        "bulkApproving": "Applying selected…",
+        "bulkRejecting": "Rejecting selected…",
+        "bulkRejectPlaceholder": "One shared reason for every selected proposal (min 5 characters)",
+        "bulkPartial": "{{ok}} done, {{failed}} failed — failed rows stay listed with the reason"
       },
       "ownerInquiries": {
         "button": "Owner inquiries",


### PR DESCRIPTION
## Item 2 — proposal-queue ergonomics (ticket 6a8162c5, ask #3 — the middle road)

The somm files evidence-backed proposals one at a time; the admin cleared them one round trip at a time. At the somm's projected pace ("well over a hundred proposals") that queue is pure clicking overhead. **The review gate stays** — an admin still reads every row — the per-row round trips go.

### Backend
- Extracted the single-decision machinery into `approveProposal` / `rejectProposal` returning `{status, body}`; the single routes are now thin wrappers. **The pre-existing suite passes untouched — that's the behavior-preservation proof** (atomic claim, revert-on-failure, E11000 → "merge instead", resolve-only country, per-kind apply all identical).
- `POST /bulk-approve` + `POST /bulk-reject`: each id runs *exactly* the single machinery, sequentially, with per-row outcomes — one row's 409 never blocks the rest. Bounded (50/call), deduped, ids validated up front. Bulk-reject takes **one shared reason**, validated before anything is decided. Per-proposal audit entries come from the shared functions, so the audit stream reads identically for single and batch decisions.

### Frontend (WineProposalsModal)
- Pending-view multi-select: per-row checkboxes + select-all-on-page + "Approve selected (N)" + "Reject selected (N)…" with the shared reason input.
- Successful rows drain in one bookkeeping pass (the existing drain pattern, generalized); **failed rows stay listed and selected with their per-row reason shown** — deliberately no auto-refetch under the admin's feet.
- All existing single-row interlocks preserved (`pendingId` freezes every action; `'bulk'` sentinel reuses them).
- en-only strings, following the block's existing plural conventions.

### Tests
- Backend: existing 13 untouched + 5 new (per-row outcomes with a mid-batch 409, dedupe, bounds deciding nothing, shared-reason gate, vanished-row 404) — 18/18 in the container.
- Frontend: full run 941/941 (translation test accepts the new en keys).

No compose impact, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)