### PR TITLE
fix(registry): narrow the producer-suspect hold to doubts that make the prose misleading

### DIFF
--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -132,6 +132,48 @@ function sleep() {
   return new Promise(resolve => setTimeout(resolve, BATCH_PAUSE_MS));
 }
 
+// ── Which suspicions actually have to withhold the profile ──────────────────
+//
+// v1.116.0 held EVERY producer-suspect profile. Measured against the 390
+// suspect rows that predate it (prod, 2026-08-16): only 9 descriptions made
+// any producer-identity claim at all, and ~2 were genuinely misleading. The
+// rest were honest notes about wines that legitimately carry a brand or
+// retailer in the producer field — an Aldi Riesling has no better answer, and
+// withholding its tasting note serves nobody. 370 of those rows are attached
+// to real users' bottles, so a blanket hold is a large, user-visible cost for
+// a small harm.
+//
+// The doubt has to withhold the profile in exactly two cases:
+//   1. the model is ALSO unsure of the wine (low/unknown confidence) — the
+//      Epiphany shape: it could not place the bottling, so the prose is an
+//      appellation-level guess dressed as a description; and
+//   2. the prose makes claims about the PRODUCER AS AN ENTITY while we doubt
+//      the producer is real — the Fabelhaft harm exactly (a biography of a
+//      house that turned out to be a Niepoort label).
+// Anything else publishes with the doubt recorded: producerSuspect and
+// producerNote still ride on the row, and the admin queue still lists it
+// regardless of threshold.
+const SUSPECT_HOLD_CONFIDENCE_MAX = 0.45;
+// Words that only appear when a description is talking about the PRODUCER
+// rather than the wine. Deliberately generous — a false positive costs one
+// withheld tasting note that a curator can release in a click, a false
+// negative publishes a fabricated house.
+const PRODUCER_CLAIM_RX =
+  /\b(n[ée]gociant|winery|winemaker|domaine|estate|ch[âa]teau|house|producer|winehouse|family|founded|generation)\b/i;
+
+/**
+ * @param {object} profile — the CLEANED { confidence, description } about to
+ *   be stored (nulls already normalised by cleanConfidence/cleanProse).
+ * @returns {boolean} true when a producer-suspect profile must be held.
+ */
+function suspectHoldsProfile({ confidence, description }) {
+  // Unknown confidence is the "nobody can vouch for this" state — the same
+  // stance the admin low-confidence queue takes on a null.
+  if (typeof confidence !== 'number') return true;
+  if (confidence <= SUSPECT_HOLD_CONFIDENCE_MAX) return true;
+  return PRODUCER_CLAIM_RX.test(description || '');
+}
+
 // ── Main job logic ─────────────────────────────────────────────────────────
 
 /**
@@ -295,8 +337,10 @@ async function enrichWine(wine, model, { publishSuspect = false } = {}) {
   // old/custom prompts → false.
   const suspect = data.producerSuspect === true;
   const now = new Date();
+  const confidence = cleanConfidence(data.confidence);
+  const description = cleanProse(data.description);
   const meta = {
-    confidence:      cleanConfidence(data.confidence),
+    confidence,
     producerSuspect: suspect,
     producerNote:    cleanProse(data.producerNote, 300),
     model:           model || aiConfig.get().enrichmentModel,
@@ -304,16 +348,15 @@ async function enrichWine(wine, model, { publishSuspect = false } = {}) {
     generatedAt:     now,
   };
 
-  // HOLD, don't publish, when the producer is suspect (ticket 6a8162c5): a
-  // profile generated for a brand/range/place sold as a producer is confident
-  // fiction about a company that may not exist — "Fabelhaft" got a négociant
-  // biography this way, flagged suspect, and the flag sat unread in a passive
-  // queue while the fiction served. A held row stores ONLY the doubt; the null
-  // description keeps every read surface (bottle page, MCP, embedding text)
-  // naturally silent, and heldAt keeps the retry guards from looping on it.
-  // `publishSuspect` is the human override — profile-reviewed uses it after an
-  // admin has looked at the doubt and judged the identity fine.
-  if (suspect && !publishSuspect) {
+  // HOLD, don't publish, when the producer doubt could make the PROSE
+  // misleading (ticket 6a8162c5, narrowed 2026-08-16 — see
+  // suspectHoldsProfile for the evidence that "suspect" alone is too broad).
+  // A held row stores ONLY the doubt; the null description keeps every read
+  // surface (bottle page, MCP, embedding text) naturally silent, and heldAt
+  // keeps the retry guards from looping on it. `publishSuspect` is the human
+  // override — profile-reviewed uses it after an admin has looked at the
+  // doubt and judged the identity fine.
+  if (suspect && !publishSuspect && suspectHoldsProfile({ confidence, description })) {
     await WineDefinition.updateOne(
       { _id: wine._id },
       {
@@ -343,11 +386,12 @@ async function enrichWine(wine, model, { publishSuspect = false } = {}) {
           sweetness:    cleanDescriptor('sweetness', data.sweetness),
           flavors:      cleanStringList(data.flavors, 'flavors'),
           foodPairings: cleanStringList(data.foodPairings, 'foodPairings'),
-          // Strip markdown, don't just trim: the model reaches for emphasis even
-          // when told not to, and the raw string is served un-rendered by the MCP
-          // tools. Load-bearing half of the fix — the prompt is only advisory,
-          // and a self-hoster can override it via SiteConfig.
-          description:  cleanProse(data.description),
+          // Markdown-stripped, not just trimmed (computed above, beside the
+          // hold decision that reads it): the model reaches for emphasis even
+          // when told not to, and the raw string is served un-rendered by the
+          // MCP tools. Load-bearing half of the fix — the prompt is only
+          // advisory, and a self-hoster can override it via SiteConfig.
+          description,
           ...meta,
           heldAt: null,
         },
@@ -508,5 +552,5 @@ module.exports = {
   start, requestStop, getStatus, enrichWineById,
   profileInputsSnapshot, reenrichAfterRecordEdit,
   // exported for unit tests
-  cleanDescriptor, cleanStringList, cleanProse, cleanConfidence,
+  cleanDescriptor, cleanStringList, cleanProse, cleanConfidence, suspectHoldsProfile,
 };

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -425,3 +425,87 @@ describe('profileInputsSnapshot — the before/after comparison the routes use',
     }
   });
 });
+
+/**
+ * The NARROWED hold (2026-08-16). v1.116.0 held every producer-suspect
+ * profile; measured against the 390 suspect rows that predate it, only ~2
+ * were genuinely misleading and 370 were attached to real users' bottles —
+ * a large user-visible cost for a small harm. The doubt now withholds only
+ * when it could make the PROSE misleading: the model is also unsure of the
+ * wine, or the prose talks about the producer as an entity.
+ *
+ * The 0.45 line is the enrichment prompt's own scale: 0.5 = "grape/region
+ * knowledge only" (an honest appellation-level note, exactly right for a
+ * brand-labelled wine), 0.4 = "mostly inferred from limited clues".
+ */
+describe('suspectHoldsProfile — which suspicions withhold the profile', () => {
+  const { suspectHoldsProfile } = require('./enrichmentJob');
+  const clean = 'Bright red fruit and soft tannins, made for early drinking.';
+
+  test('unknown confidence holds — nobody can vouch for it', () => {
+    expect(suspectHoldsProfile({ confidence: null, description: clean })).toBe(true);
+  });
+
+  test('low confidence holds regardless of prose (the Epiphany shape)', () => {
+    expect(suspectHoldsProfile({ confidence: 0.4, description: clean })).toBe(true);
+    expect(suspectHoldsProfile({ confidence: 0.45, description: clean })).toBe(true); // boundary is inclusive
+  });
+
+  test('grape/region-level confidence with clean prose PUBLISHES (the brand-wine case)', () => {
+    expect(suspectHoldsProfile({ confidence: 0.5, description: clean })).toBe(false);
+    expect(suspectHoldsProfile({ confidence: 0.6, description: clean })).toBe(false);
+  });
+
+  test('prose that talks about the PRODUCER holds even at high confidence (the Fabelhaft harm)', () => {
+    for (const d of [
+      'A négociant label known for sourcing well-priced wines from established regions.',
+      'The family has farmed this estate for four generations.',
+      'Made at the winery in Mendoza by a respected producer.',
+    ]) {
+      expect(suspectHoldsProfile({ confidence: 0.8, description: d })).toBe(true);
+    }
+  });
+
+  test('an empty description with good confidence does not hold on the prose rule', () => {
+    expect(suspectHoldsProfile({ confidence: 0.7, description: null })).toBe(false);
+  });
+});
+
+describe('the narrowed hold end-to-end through enrichWine', () => {
+  const suspectWith = (over) => ({
+    data: {
+      body: 'medium', tannin: 'medium', acidity: 'medium', sweetness: 'dry',
+      flavors: ['plum'], foodPairings: ['stew'],
+      producerSuspect: true,
+      producerNote: 'Aldi is a supermarket retailer, not an estate.',
+      ...over,
+    },
+    debugReason: null,
+  });
+
+  test('a suspect producer with an honest grape/region note is PUBLISHED with the doubt recorded', async () => {
+    suggestProfile.mockResolvedValue(suspectWith({
+      confidence: 0.6,
+      description: 'An off-dry German Riesling with orchard fruit and bright acidity.',
+    }));
+    await enrichWineById(WINE_ID);
+    const p = persisted();
+    expect(p.heldAt).toBeNull();
+    expect(p.description).toMatch(/Riesling/);
+    // The doubt is not erased by publishing — the queue still lists it.
+    expect(p.producerSuspect).toBe(true);
+    expect(p.producerNote).toMatch(/supermarket/);
+  });
+
+  test('a suspect producer the model also cannot place is still HELD', async () => {
+    suggestProfile.mockResolvedValue(suspectWith({
+      confidence: 0.4,
+      description: 'A red wine, probably in a modern international style.',
+    }));
+    await enrichWineById(WINE_ID);
+    const p = persisted();
+    expect(p.heldAt).toBeInstanceOf(Date);
+    expect(p.description).toBeNull();
+    expect(p.producerSuspect).toBe(true);
+  });
+});


### PR DESCRIPTION
## Item 6 — the profile-backlog decision, implemented

### What the measurement showed

I sized the "backlog" before touching it, and it isn't one:

| | |
|---|---|
| Low-confidence non-suspect rows (≤0.6) | **3,263** — honest uncertainty about a *tasting note*, not a defect. At the queue's default 0.3 threshold: 100 rows |
| Outstanding producer-suspect rows | **403** (390 published, 12 held, 0 curator) |
| …whose **description** makes any producer-identity claim | **9** |
| …genuinely misleading on reading all 9 | **~2** |
| Published-suspect rows attached to real users' bottles | **370 of 390** |

The suspect flag is mostly the model being *honest*, not fabricating: "Aldi is a supermarket retailer that sources this wine from a contract producer", "DV Catena is a value-oriented range produced by the Catena family". Those records are correct — the bottle really does say Aldi — and their tasting notes are useful. v1.116.0 would withhold all of them.

### The change

The doubt now withholds the profile in exactly two cases:
1. **the model is also unsure of the wine** — confidence ≤ 0.45 or unknown (the Epiphany shape: it couldn't place the bottling, so the prose is an appellation-level guess dressed as a description)
2. **the prose talks about the producer as an entity** while we doubt the producer is real — the Fabelhaft harm exactly

Everything else publishes **with the doubt intact**: `producerSuspect` and `producerNote` still ride on the row, and the admin queue still lists it regardless of threshold. The human override (`profile-reviewed`) and the identity-edit re-enrich are unchanged.

The 0.45 line is the enrichment prompt's own scale: **0.5 = "grape/region knowledge only"** — the honest appellation-level note a brand-labelled wine *should* get — vs **0.4 = "mostly inferred from limited clues"**. One named constant if you want it looser.

### Dry-run against the real 391 published-suspect rows

- **300 would hold** (294 on confidence, 6 on prose) · **91 would publish** · broad rule would have held all 391
- Both known-bad rows still hold: `Ca' del Baio — Marcarini` (two real Piedmont producers conflated) and `Vincent Carême — Clos de la Roche` (a Burgundy cru name on a Vouvray)
- Published side is the honest brand tier: Veuve du Vernay, Capriccio Prosecco, Donnafugata/Dolce & Gabbana, Castellaro Malvasia

### Tests
`suspectHoldsProfile` unit-pinned (unknown/low/boundary/clean-prose/producer-prose/empty-description) plus two end-to-end cases through `enrichWine`. 59/59 across the three affected suites; the v1.116.0 hold tests pass unchanged.

### Notes
- **Nothing retroactive.** The 390 published rows stay published; this only decides future generations. No AI spend, no user-visible content removed.
- After deploy, the 12 currently-held rows can be re-decided with a forced re-enrich — 7 stay held on confidence alone, 5 depend on their regenerated prose. Cheap, and I'd do it as a prod op rather than a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)