### PR TITLE
fix(images): show a photo's real wine link in review, and sweep orphaned uploads

### DIFF
--- a/backend/src/services/scanImage.lifecycle.test.js
+++ b/backend/src/services/scanImage.lifecycle.test.js
@@ -186,9 +186,67 @@ describe('runScanImageRetentionSweep', () => {
       }),
     });
 
-    // Two clocks now: the 30-day unattached sweep above and the 7-day
-    // promoted-scan expiry (services/promotedScanGrace.test.js pins that one).
-    expect(await runScanImageRetentionSweep()).toEqual({ deleted: 0, expired: 0 });
+    // Three clocks now: the 30-day unattached scan sweep above, the 7-day
+    // promoted-scan expiry (services/promotedScanGrace.test.js pins that one)
+    // and the 30-day orphan bottle-photo sweep (pinned below).
+    expect(await runScanImageRetentionSweep()).toEqual({ deleted: 0, expired: 0, orphanPhotos: 0 });
+    expect(BottleImage.deleteMany).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The THIRD clock (2026-08-16): an ordinary bottle PHOTO attached to nothing.
+ *
+ * The add-bottle flow uploads before the bottle exists and links afterwards;
+ * an abandoned add leaves a photo with no bottle and no wine, which nothing
+ * swept (both clocks above only consider kind:'label-scan') and which sat in
+ * the admin moderation queue reading as an image belonging to nothing.
+ */
+describe('runUnattachedBottleImageSweep', () => {
+  const { runUnattachedBottleImageSweep } = require('./scanImageRetentionJob');
+
+  test('selects non-scan photos attached to nothing, past the window, files first', async () => {
+    const stale = [{ _id: 'p1', originalUrl: '/api/uploads/originals/p.jpg' }];
+    BottleImage.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(stale) }),
+      }),
+    });
+    BottleImage.deleteMany.mockResolvedValue({ deletedCount: 1 });
+
+    const res = await runUnattachedBottleImageSweep();
+
+    const filter = BottleImage.find.mock.calls[0][0];
+    // Disjoint from both scan clocks by kind — a label scan is never swept here.
+    expect(filter.kind).toEqual({ $ne: 'label-scan' });
+    expect(filter.wineDefinition).toBeNull();
+    expect(filter.bottle).toBeNull();
+    // An image serving as a wine's official photo is never swept, whatever
+    // else its fields say (bottleOps detaches those from a deleted bottle).
+    expect(filter.assignedToWine).toEqual({ $ne: true });
+    const cutoff = filter.createdAt.$lt.getTime();
+    expect(Math.abs(cutoff - (Date.now() - SCAN_IMAGE_RETENTION_DAYS * 24 * 60 * 60 * 1000))).toBeLessThan(5000);
+
+    expect(unlinkImageFiles).toHaveBeenCalledWith(stale[0]);
+    // Predicate repeated in the delete: /link-to-bottle can bind one of these
+    // between the find and the delete (audit L-1, same argument).
+    const del = BottleImage.deleteMany.mock.calls[0][0];
+    expect(del._id).toEqual({ $in: ['p1'] });
+    expect(del.kind).toEqual({ $ne: 'label-scan' });
+    expect(del.wineDefinition).toBeNull();
+    expect(del.bottle).toBeNull();
+    expect(del.assignedToWine).toEqual({ $ne: true });
+    expect(res.deleted).toBe(1);
+  });
+
+  test('nothing stale → no unlink, no delete', async () => {
+    BottleImage.find.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }),
+      }),
+    });
+    expect(await runUnattachedBottleImageSweep()).toEqual({ deleted: 0 });
+    expect(unlinkImageFiles).not.toHaveBeenCalled();
     expect(BottleImage.deleteMany).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/scanImageRetentionJob.js
+++ b/backend/src/services/scanImageRetentionJob.js
@@ -19,10 +19,10 @@
  * files.) Unlink first, then delete — the doc is the only reference to the file.
  *
  * BOUND: an image is "attached" once it carries a wineDefinition (set by the
- * commit) or a bottle. Only kind:'label-scan' rows are ever considered, so an
- * ordinary bottle photo can never be swept by this.
+ * commit) or a bottle.
  *
- * TWO CLOCKS, disjoint by construction:
+ * THREE CLOCKS, disjoint by construction (the first two by their predicates,
+ * the third by `kind`):
  *   30 days, UNATTACHED  — the sweep described above: a scan that never became
  *                          part of any record (runUnattachedScanSweep).
  *    7 days, PROMOTED    — a scan whose wine is NOT in the pending-identity
@@ -38,8 +38,14 @@
  *                          services/wineCommit. The quiet failures are the ones
  *                          whose label a curator most needs; the window is what
  *                          bounds the retention, not queue membership.
- * A scan on a wine that is STILL pending is on neither clock: it is attached,
- * and it has no retainUntil until the row promotes.
+ *   30 days, ORPHAN PHOTO — an ordinary bottle photo (kind:'bottle') attached
+ *                          to nothing, from an add abandoned between the
+ *                          upload and the link (runUnattachedBottleImageSweep,
+ *                          2026-08-16). Until it existed, nothing swept these
+ *                          and they sat in the admin moderation queue reading
+ *                          as images belonging to nothing.
+ * A scan on a wine that is STILL pending is on none of the clocks: it is
+ * attached, and it has no retainUntil until the row promotes.
  */
 const BottleImage = require('../models/BottleImage');
 const { unlinkImageFiles } = require('./imageProcessor');
@@ -190,20 +196,88 @@ async function runUnattachedScanSweep() {
 }
 
 /**
- * The daily entry point — both clocks, in the order that matters least (they
- * select disjoint rows: an unattached scan has no wine and therefore no
- * promotion deadline, and a promoted scan has a wine).
+ * The THIRD clock: an ordinary bottle PHOTO attached to nothing (2026-08-16).
+ *
+ * The add-bottle flow uploads the photo before the bottle exists — POST
+ * /api/images/upload deliberately requires neither a bottle nor a wine, and
+ * POST /api/images/link-to-bottle binds it once the commit succeeds. A user
+ * who abandons the add between those two steps leaves a photo behind with no
+ * bottle and no wine, and until now NOTHING swept it: the two clocks above
+ * only ever consider kind:'label-scan'. Such a row also enters the admin
+ * moderation queue, where it reads as an image belonging to nothing.
+ *
+ * Same GDPR argument as the unattached-scan sweep, and the same 30-day window
+ * for the same reason: an image that never became part of a record has no
+ * purpose to justify keeping it, but a user may reasonably photograph today
+ * and finish the add next weekend.
+ *
+ * DISJOINT from both clocks above by the kind filter, and narrower than it
+ * needs to be on purpose:
+ *   - `wineDefinition: null` keeps every wine-level image out, including the
+ *     official ones services/bottleOps deliberately DETACHES from a deleted
+ *     bottle (`assignedToWine: true` → `bottle: null`); those carry a wine and
+ *     are never orphans.
+ *   - `assignedToWine: { $ne: true }` is the belt to that brace — an image
+ *     serving as some wine's official photo is never swept, whatever its
+ *     other fields say.
+ * Rejected rows ARE swept: a rejected photo attached to nothing is exactly
+ * what this window exists to clear.
+ */
+async function runUnattachedBottleImageSweep() {
+  const cutoff = new Date(Date.now() - SCAN_IMAGE_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+  const selector = {
+    kind: { $ne: 'label-scan' },
+    wineDefinition: null,
+    bottle: null,
+    assignedToWine: { $ne: true },
+    createdAt: { $lt: cutoff },
+  };
+  const stale = await BottleImage.find(selector)
+    .select('originalUrl processedUrl')
+    .limit(SWEEP_LIMIT)
+    .lean();
+
+  if (stale.length === 0) return { deleted: 0 };
+
+  for (const img of stale) {
+    try { await unlinkImageFiles(img); } catch (err) {
+      console.warn('[scanImageRetention] unlink failed (continuing):', err.message);
+    }
+  }
+  // Predicate REPEATED in the delete, same reason as the sweep above (audit
+  // L-1): a user can link one of these to a bottle between the find and the
+  // delete — /link-to-bottle is a plain updateMany — and deleting by id alone
+  // would drop a row a live bottle now points at.
+  const res = await BottleImage.deleteMany({
+    _id: { $in: stale.map((i) => i._id) },
+    ...selector,
+  });
+  const deleted = res.deletedCount || 0;
+  if (deleted > 0) {
+    console.log(
+      `[scanImageRetention] Deleted ${deleted} unattached bottle photo(s) older than ${SCAN_IMAGE_RETENTION_DAYS} days`
+    );
+  }
+  return { deleted };
+}
+
+/**
+ * The daily entry point — all three clocks. The first two select disjoint rows
+ * (an unattached scan has no wine and therefore no promotion deadline, and a
+ * promoted scan has a wine); the third is disjoint from both by `kind`.
  */
 async function runScanImageRetentionSweep() {
   const { deleted } = await runUnattachedScanSweep();
   const { expired } = await runPromotedScanExpirySweep();
-  return { deleted, expired };
+  const { deleted: orphanPhotos } = await runUnattachedBottleImageSweep();
+  return { deleted, expired, orphanPhotos };
 }
 
 module.exports = {
   runScanImageRetentionSweep,
   runUnattachedScanSweep,
   runPromotedScanExpirySweep,
+  runUnattachedBottleImageSweep,
   SCAN_IMAGE_RETENTION_DAYS,
   PROMOTED_SCAN_GRACE_DAYS,
 };

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1788,6 +1788,8 @@
       "processing": "Processing...",
       "approve": "Approve",
       "noWineLinked": "No wine linked",
+      "viaBottle": "via the owner's bottle",
+      "notLinked": "Not linked to a bottle or a wine — an upload whose add was abandoned. Deleted automatically 30 days after upload.",
       "assignToWine": "Assign to Wine",
       "assignHint": "Set this image as the official image for a wine definition.",
       "linkedWine": "Linked wine:",

--- a/frontend/src/pages/AdminImages.js
+++ b/frontend/src/pages/AdminImages.js
@@ -133,9 +133,22 @@ function AdminImages() {
     }
   };
 
+  // The wine an image belongs to, DIRECTLY or through its bottle. A photo
+  // added through the normal add-bottle flow carries `bottle` and a null
+  // `wineDefinition` by design (services/imageOps sets the direct ref only for
+  // wine-level uploads, and the by-wine query resolves the rest through the
+  // bottle) — so reading the direct ref alone made every ordinary bottle photo
+  // render as "no wine linked" on this page, which is what it looked like in
+  // review. The LIST already falls back this way; the detail did not.
+  const effectiveWine = (img) => img?.wineDefinition || img?.bottle?.wineDefinition || null;
+  const selectedWine = effectiveWine(selected);
+  // True orphan: no bottle AND no wine — an add abandoned between the upload
+  // and the link. Swept after 30 days (services/scanImageRetentionJob).
+  const selectedOrphan = !!selected && !selected.bottle && !selected.wineDefinition;
+
   const handleAssignToWine = async () => {
     if (!selected) return;
-    const wineDefId = assignWineId || selected.wineDefinition?._id;
+    const wineDefId = assignWineId || selectedWine?._id;
     if (!wineDefId) {
       setError('Please enter a wine definition ID');
       return;
@@ -299,8 +312,16 @@ function AdminImages() {
                   <p><strong>{t('admin.images.statusLabel')}</strong> <span className={`status-badge status-${selected.status}`}>{selected.status}</span></p>
                   <p><strong>{t('admin.images.uploadedBy')}</strong> {selected.uploadedBy?.username}</p>
                   <p><strong>{t('admin.images.dateLabel')}</strong> {new Date(selected.createdAt).toLocaleString()}</p>
-                  {selected.wineDefinition && (
-                    <p><strong>{t('admin.images.wineLabel')}</strong> {selected.wineDefinition.name} ({selected.wineDefinition.producer})</p>
+                  {selectedWine && (
+                    <p>
+                      <strong>{t('admin.images.wineLabel')}</strong> {selectedWine.name} ({selectedWine.producer})
+                      {!selected.wineDefinition && (
+                        <span className="help-text"> — {t('admin.images.viaBottle')}</span>
+                      )}
+                    </p>
+                  )}
+                  {selectedOrphan && (
+                    <p className="help-text">{t('admin.images.notLinked')}</p>
                   )}
                   {selected.reviewedBy && (
                     <p><strong>{t('admin.images.reviewedBy')}</strong> {selected.reviewedBy.username} on {new Date(selected.reviewedAt).toLocaleString()}</p>
@@ -387,9 +408,12 @@ function AdminImages() {
                   <p className="help-text">
                     {t('admin.images.assignHint')}
                   </p>
-                  {selected.wineDefinition ? (
+                  {selectedWine ? (
                     <p>
-                      {t('admin.images.linkedWine')} <strong>{selected.wineDefinition.name}</strong> ({selected.wineDefinition.producer})
+                      {t('admin.images.linkedWine')} <strong>{selectedWine.name}</strong> ({selectedWine.producer})
+                      {!selected.wineDefinition && (
+                        <span className="help-text"> — {t('admin.images.viaBottle')}</span>
+                      )}
                     </p>
                   ) : (
                     <div className="form-group">


### PR DESCRIPTION
## Item 7 — the "images connected to no wine" report

Investigating the review queue turned up three causes, two of them real bugs and one worth *not* fixing.

### 1. Display — the reported symptom
A photo added through the normal add-bottle flow carries `bottle` and a **null `wineDefinition` by design**: `services/imageOps` sets the direct ref only for wine-level uploads, and the by-wine query resolves everything else *through* the bottle. The admin **list** already falls back that way ([AdminImages.js:227](frontend/src/pages/AdminImages.js#L227)); the **detail panel** read the direct ref alone — so every ordinary bottle photo rendered as "no wine linked" and offered a paste-a-wine-id box.

The detail now resolves the same way, marks a bottle-resolved wine as such ("via the owner's bottle"), and the *Assign as Official Image* action defaults to it — previously an admin had to paste the id by hand for a photo whose wine was already known.

### 2. Retention — the genuine orphans
The add flow uploads *before* the bottle exists and links after the commit. An abandoned add leaves a photo with no bottle and no wine, and **nothing swept those**: both existing clocks in `scanImageRetentionJob` only consider `kind:'label-scan'`, so they sat in the moderation queue indefinitely (2 on prod today).

A third 30-day clock — `runUnattachedBottleImageSweep` — now clears them, following the module's established shape exactly: files before documents (a TTL index would orphan them on disk), `SWEEP_LIMIT` bounded, and the **selection predicate repeated in the delete** so a photo linked between find and delete is skipped rather than dropped. Wine-level images and `assignedToWine` photos can never be selected — including the ones `bottleOps` deliberately detaches from a deleted bottle. Same GDPR argument as the scan sweep: an image that never became part of a record has no purpose justifying its retention.

True orphans now say so in review, with the retention window stated.

### 3. Considered and rejected
Backfilling `wineDefinition` on `/link-to-bottle` would have made the direct ref always present — but it changes gallery and official-image semantics, which deliberately distinguish a *wine-level* image from a *bottle photo*. Left alone.

### Tests
New sweep pinned (selection incl. the `assignedToWine` guard, 30-day cutoff, files-first, repeated delete predicate, empty no-op); the entry-point contract updated for the third clock. 35/35 backend across the two retention suites, frontend full run 941/941.

No compose impact, no schema change, en-only strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)