### PR TITLE
fix(registry): close the nine confirmed defects from the pre-release audit

### DIFF
--- a/backend/src/routes/admin/wineProposals.js
+++ b/backend/src/routes/admin/wineProposals.js
@@ -173,7 +173,7 @@ router.post('/:id/approve', async (req, res) => {
  * performWineMerge extraction pattern, one layer up. Unexpected errors are
  * thrown (after the claim revert) for the caller to map to its own 500.
  */
-async function approveProposal(proposalId, req) {
+async function approveProposal(proposalId, req, { deferFollowThrough = false } = {}) {
     // Atomically CLAIM the pending row so only the first of two concurrent
     // decisions wins (the aiBudgetRequests check-then-act fix): a null result
     // means already-decided (409) or never-existed (404).
@@ -202,6 +202,11 @@ async function approveProposal(proposalId, req) {
     };
 
     let appliedNote = '';
+    // Set only by the field_correction branch when the caller defers — the
+    // bulk loop fires ONE follow-through per wine after every decision has
+    // applied (audit 2026-08-16: per-proposal firing raced same-wine batches
+    // and cost N forced AI calls for one wine).
+    let followThrough = null;
     try {
       if (proposal.kind === 'field_correction') {
         const wine = await WineDefinition.findById(proposal.wineDefinition);
@@ -280,12 +285,17 @@ async function approveProposal(proposalId, req) {
         Bottle.distinct('_id', { wineDefinition: wine._id })
           .then((ids) => searchService.bulkIndexBottles(ids))
           .catch((err) => console.error('Bottle re-index after proposal apply failed:', err.message));
-        reembedActiveVintages(wine._id).catch(() => {});
         // And the PUT's re-enrich (parity gap found live 2026-08-16: approving
         // "Fabelhaft" → "Niepoort" left the négociant-fiction profile attached
         // until a manual force re-enrich). Real-change only, curator-safe —
         // see reenrichAfterRecordEdit.
-        reenrichAfterRecordEdit(wine, profileInputsSnapshot(wine) !== beforeProfileInputs);
+        const profileInputsChanged = profileInputsSnapshot(wine) !== beforeProfileInputs;
+        if (deferFollowThrough) {
+          followThrough = { wineId: String(wine._id), wine, changed: profileInputsChanged };
+        } else {
+          reembedActiveVintages(wine._id).catch(() => {});
+          reenrichAfterRecordEdit(wine, profileInputsChanged);
+        }
 
         appliedNote = `Applied: ${applied.join(', ')}`;
       } else if (proposal.kind === 'merge') {
@@ -334,7 +344,11 @@ async function approveProposal(proposalId, req) {
         appliedNote,
       });
 
-    return { status: 200, body: { message: 'Proposal approved and applied', proposalId: proposal._id, status: 'approved', appliedNote } };
+    return {
+      status: 200,
+      body: { message: 'Proposal approved and applied', proposalId: proposal._id, status: 'approved', appliedNote },
+      ...(followThrough ? { followThrough } : {}),
+    };
 }
 
 // Reason hygiene shared by the single and bulk reject paths: plain text only,
@@ -405,9 +419,19 @@ router.post('/bulk-approve', async (req, res) => {
     const parsed = parseBulkIds(req.body);
     if (parsed.error) return res.status(400).json({ error: parsed.error });
     const results = [];
+    // wineId -> { wine, changed } — the LAST applied doc wins (it carries all
+    // earlier corrections of the batch), changed ORs across proposals.
+    const followThroughs = new Map();
     for (const id of parsed.ids) {
       try {
-        const { status, body } = await approveProposal(new mongoose.Types.ObjectId(id), req);
+        const { status, body, followThrough } = await approveProposal(new mongoose.Types.ObjectId(id), req, { deferFollowThrough: true });
+        if (followThrough) {
+          const prev = followThroughs.get(followThrough.wineId);
+          followThroughs.set(followThrough.wineId, {
+            wine: followThrough.wine,
+            changed: (prev?.changed || false) || followThrough.changed,
+          });
+        }
         results.push(status === 200
           ? { proposalId: id, ok: true, status, appliedNote: body.appliedNote }
           : { proposalId: id, ok: false, status, error: body.error });
@@ -415,6 +439,17 @@ router.post('/bulk-approve', async (req, res) => {
         console.error('Bulk approve item error:', id, err);
         results.push({ proposalId: id, ok: false, status: 500, error: 'Failed to approve proposal' });
       }
+    }
+    // ONE follow-through per wine, after every decision in the batch has
+    // applied. Per-proposal firing let an early proposal's re-enrich race the
+    // later applies on the same wine — the last writer was indeterminate and
+    // a profile could describe an intermediate identity — and spent one
+    // forced AI call per PROPOSAL instead of per wine (audit 2026-08-16).
+    // A wine absorbed by a merge later in the batch fails the re-enrich's
+    // findById silently, which is the correct outcome.
+    for (const { wine, changed } of followThroughs.values()) {
+      reembedActiveVintages(wine._id).catch(() => {});
+      reenrichAfterRecordEdit(wine, changed);
     }
     const approved = results.filter((r) => r.ok).length;
     res.json({ results, approved, failed: results.length - approved });

--- a/backend/src/routes/admin/wineProposals.test.js
+++ b/backend/src/routes/admin/wineProposals.test.js
@@ -30,14 +30,11 @@ jest.mock('../../services/search', () => ({ indexWine: jest.fn(), bulkIndexBottl
 jest.mock('../../services/embeddingJob', () => ({ reembedActiveVintages: jest.fn().mockResolvedValue(undefined) }));
 jest.mock('../../services/enrichmentJob', () => ({
   reenrichAfterRecordEdit: jest.fn(),
-  // Faithful-enough mirror of the real snapshot (unit-tested in
-  // enrichmentJob.test.js) — the route only ever compares two of these.
-  profileInputsSnapshot: jest.fn((w) => JSON.stringify({
-    name: w.name || '', producer: w.producer || '',
-    country: String(w.country || ''), region: String(w.region || ''),
-    appellation: w.appellation || '', classification: w.classification || '',
-    type: w.type || '', grapes: (w.grapes || []).map(String).sort(),
-  })),
+  // The REAL snapshot — pure and dependency-free, so nothing is gained by
+  // mirroring it, and a hand mirror rots the day the field list changes (it
+  // gained `classification` the very release this mock was written in;
+  // audit 2026-08-16).
+  profileInputsSnapshot: jest.requireActual('../../services/enrichmentJob').profileInputsSnapshot,
 }));
 jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateRegion: jest.fn() }));
 // Identity by default so the tier-strip assertions below still read the
@@ -400,5 +397,45 @@ describe('POST /bulk-approve and /bulk-reject', () => {
     const res = await post('/bulk-reject', { ids: [P1], reason: 'x' });
     expect(res.status).toBe(400);
     expect(WineCorrectionProposal.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Bulk follow-through is deferred and per-WINE (audit 2026-08-16): firing per
+ * proposal let an early re-enrich race later same-batch applies, and cost one
+ * forced AI call per proposal instead of per wine.
+ */
+describe('bulk-approve follow-through', () => {
+  const { reenrichAfterRecordEdit } = require('../../services/enrichmentJob');
+  const { reembedActiveVintages } = require('../../services/embeddingJob');
+  const claimSeq = (...proposals) => {
+    for (const p of proposals) WineCorrectionProposal.findOneAndUpdate.mockResolvedValueOnce(p);
+  };
+
+  test('fires ONCE per wine after the loop; single approves still fire inline', async () => {
+    const P2 = '64b0000000000000000000a2';
+    claimSeq(
+      { _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { producer: 'Niepoort' } },
+      { _id: P2, kind: 'field_correction', wineDefinition: W2, proposedFields: { name: 'Margaux' } },
+    );
+    const mkWine = (id, over) => ({
+      _id: id, name: 'N', producer: 'P', appellation: null, country: 'c1',
+      save: jest.fn().mockResolvedValue(undefined), ...over,
+    });
+    const wine1 = mkWine(W1, { producer: 'Fabelhaft' });
+    const wine2 = mkWine(W2, { name: 'Grand Cru Classé' });
+    WineDefinition.findById
+      .mockResolvedValueOnce(wine1)
+      .mockResolvedValueOnce(wine2);
+
+    const res = await post('/bulk-approve', { ids: [P1, P2] });
+    expect(res.status).toBe(200);
+    expect((await res.json()).approved).toBe(2);
+
+    // One follow-through per distinct wine, with the real-change verdicts.
+    expect(reenrichAfterRecordEdit).toHaveBeenCalledTimes(2);
+    expect(reenrichAfterRecordEdit).toHaveBeenCalledWith(wine1, true);
+    expect(reenrichAfterRecordEdit).toHaveBeenCalledWith(wine2, true);
+    expect(reembedActiveVintages).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -666,23 +666,29 @@ router.post('/:id/profile-reviewed', async (req, res) => {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
     const wine = await WineDefinition.findById(req.params.id).select('name producer aiProfile.heldAt');
     if (!wine) return res.status(404).json({ error: 'Wine not found' });
+
+    // A HELD profile + an admin review = the human override the hold was
+    // waiting for: regenerate and PUBLISH (the suspect flag stays on the row
+    // as provenance). The review stamp lands ONLY when the publish succeeds
+    // (inside releaseHeldProfile) — stamping first, as v1.116.0 did, hid the
+    // row from the queue forever when the AI call failed, because the
+    // outstanding filter compares reviewedAt to generatedAt and the
+    // incremental job skips held rows by design (audit 2026-08-16). On
+    // failure the row simply stays in the queue for another click. If the
+    // admin instead agrees the identity is wrong, the fix is the wine editor
+    // — the identity edit re-enriches.
+    if (wine.aiProfile?.heldAt) {
+      const { releaseHeldProfile } = require('../../services/enrichmentJob');
+      releaseHeldProfile(wine._id).catch(() => {});
+      logAudit(req, 'admin.wine.profileReviewed', { type: 'wine', id: wine._id },
+        { name: wine.name, producer: wine.producer, heldRelease: true });
+      return res.json({ message: 'Publishing the held profile', profileReviewedAt: null });
+    }
+
     const now = new Date();
     await WineDefinition.updateOne({ _id: wine._id }, { $set: { profileReviewedAt: now } });
     logAudit(req, 'admin.wine.profileReviewed', { type: 'wine', id: wine._id },
       { name: wine.name, producer: wine.producer });
-    // A HELD profile + an admin review = the human override the hold was
-    // waiting for: the admin looked at the model's producer doubt and judged
-    // the identity fine, so regenerate and PUBLISH (the suspect flag stays on
-    // the row as provenance). Fire-and-forget; on success the review stamp is
-    // re-bumped past the fresh generatedAt so the row doesn't instantly
-    // re-surface as unreviewed. If the admin instead agrees the identity is
-    // wrong, the fix is the wine editor — the identity edit re-enriches.
-    if (wine.aiProfile?.heldAt) {
-      const { enrichWineById } = require('../../services/enrichmentJob');
-      enrichWineById(wine._id, { force: true, publishSuspect: true })
-        .then(() => WineDefinition.updateOne({ _id: wine._id }, { $set: { profileReviewedAt: new Date() } }))
-        .catch(() => {});
-    }
     res.json({ message: 'Marked reviewed', profileReviewedAt: now });
   } catch (error) {
     console.error('Profile-reviewed error:', error);

--- a/backend/src/routes/admin/wines.lowConfidence.test.js
+++ b/backend/src/routes/admin/wines.lowConfidence.test.js
@@ -38,6 +38,7 @@ jest.mock('../../models/Recommendation', () => ({}));
 jest.mock('../../models/RestockAlert', () => ({}));
 jest.mock('../../models/WineRequest', () => ({}));
 jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
+jest.mock('../../services/enrichmentJob', () => ({ releaseHeldProfile: jest.fn().mockResolvedValue(true) }));
 jest.mock('../../services/vectorStore', () => ({}));
 jest.mock('../../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
 jest.mock('../../services/embeddingJob', () => ({ embedSinglePair: jest.fn() }));
@@ -176,6 +177,27 @@ describe('GET /low-confidence', () => {
 });
 
 describe('profile-reviewed toggle', () => {
+  test('a HELD row is released, not stamped: the review lands only when the publish succeeds', async () => {
+    // Stamping first (v1.116.0) hid the row from the queue forever when the
+    // AI call failed — reviewedAt outran generatedAt and the incremental job
+    // skips held rows by design (audit 2026-08-16). The stamp now lives
+    // inside releaseHeldProfile, on success only.
+    const { releaseHeldProfile } = require('../../services/enrichmentJob');
+    WineDefinition.findById.mockReturnValue({
+      select: jest.fn().mockResolvedValue({ _id: WINE_ID, name: 'Douro Tinto', producer: 'Fabelhaft', aiProfile: { heldAt: new Date() } }),
+    });
+
+    const res = await fetch(`${baseUrl}/api/admin/wines/${WINE_ID}/profile-reviewed`, {
+      method: 'POST', headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).profileReviewedAt).toBeNull();
+    expect(releaseHeldProfile).toHaveBeenCalledWith(expect.anything());
+    // No direct stamp from the route — success stamping is the service’s job.
+    expect(WineDefinition.updateOne).not.toHaveBeenCalled();
+  });
+
   test('POST records the review with the current time and audits', async () => {
     WineDefinition.findById.mockReturnValue({
       select: jest.fn().mockResolvedValue({ _id: WINE_ID, name: 'Le Valet d’Épée', producer: 'Arcane' }),

--- a/backend/src/routes/admin/wines.reenrichOnEdit.test.js
+++ b/backend/src/routes/admin/wines.reenrichOnEdit.test.js
@@ -54,14 +54,12 @@ jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn(
 jest.mock('../../services/enrichmentJob', () => ({
   reenrichAfterRecordEdit: jest.fn(),
   enrichWineById: jest.fn(),
-  // Faithful-enough mirror of the real snapshot (unit-tested in
-  // enrichmentJob.test.js) — the route only ever compares two of these.
-  profileInputsSnapshot: jest.fn((w) => JSON.stringify({
-    name: w.name || '', producer: w.producer || '',
-    country: String(w.country || ''), region: String(w.region || ''),
-    appellation: w.appellation || '', classification: w.classification || '',
-    type: w.type || '', grapes: (w.grapes || []).map(String).sort(),
-  })),
+  releaseHeldProfile: jest.fn().mockResolvedValue(true),
+  // The REAL snapshot — pure and dependency-free, so nothing is gained by
+  // mirroring it, and a hand mirror rots the day the field list changes (it
+  // gained `classification` the very release this mock was written in;
+  // audit 2026-08-16).
+  profileInputsSnapshot: jest.requireActual('../../services/enrichmentJob').profileInputsSnapshot,
 }));
 
 const express = require('express');

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -11,7 +11,7 @@ const { getCellarRole } = require('../utils/cellarAccess');
 const { logAudit } = require('../services/audit');
 const { getOrCreateDailySnapshot } = require('../utils/exchangeRates');
 const { resolveRating } = require('../utils/ratingUtils');
-const { normalizeString } = require('../utils/normalize');
+const { normalizeString, resolveCountryName } = require('../utils/normalize');
 const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
 const searchService = require('../services/search');
 const { identifyWineFromText } = require('../services/labelScan');
@@ -433,53 +433,79 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
       if (!aiRowsByProducer.has(prodKey)) aiRowsByProducer.set(prodKey, []);
       aiRowsByProducer.get(prodKey).push(pr);
     }
+    // Countries compare through the SAME fold the mint uses — alias resolve
+    // then normalize — so "USA" and "United States" are one country here
+    // exactly as they become one Country doc there (audit 2026-08-16:
+    // normalizeString alone treated aliases as two countries and the pass
+    // silently no-opped on the very splits it exists to prevent).
+    const countryKey = (v) =>
+      (typeof v === 'string' && v.trim()) ? normalizeString(resolveCountryName(v)) : '';
     for (const rows of aiRowsByProducer.values()) {
-      const aiCountryKey = (pr) =>
-        (typeof pr.aiIdentified.country === 'string' && pr.aiIdentified.country.trim())
-          ? normalizeString(pr.aiIdentified.country) : '';
-      const distinct = new Set(rows.map(aiCountryKey).filter(Boolean));
+      // The FILE is the anchor, and its STATED VALUE is the anchor value —
+      // not the AI's echo of it (audit 2026-08-16: anchoring on the echo let
+      // an AI that contradicted the file spread the contradiction to the
+      // whole group). Step one: any anchored row whose AI disagrees with its
+      // own file column is corrected back to the file's value, which is also
+      // what /confirm then mints.
+      for (const pr of rows) {
+        const fileKey = countryKey(pr.item.country);
+        if (fileKey && countryKey(pr.aiIdentified.country) !== fileKey) {
+          pr.aiIdentified.country = pr.item.country;
+        }
+      }
+      const rowKey = (pr) => countryKey(pr.aiIdentified.country);
+      const distinct = new Set(rows.map(rowKey).filter(Boolean));
       if (distinct.size === 0) continue; // no row knows a country — nothing to spread
-      const fileAnchored = rows.filter(pr => typeof pr.item.country === 'string' && pr.item.country.trim());
+      const anchors = rows.filter((pr) => countryKey(pr.item.country));
       let adopted = null;
       if (distinct.size === 1) {
         // Group already agrees — only rows the AI left countryless (which
         // could not mint at all) inherit it below.
-        adopted = rows.find(pr => aiCountryKey(pr)).aiIdentified.country;
-      } else if (fileAnchored.length > 0) {
+        adopted = rows.find((pr) => rowKey(pr)).aiIdentified.country;
+      } else if (anchors.length > 0) {
         // The file knows best — but only when it names ONE country. Two
         // file-backed countries for one producer is real information
         // (a brand genuinely bottling on two continents): touch nothing.
-        const anchorCountries = new Set(fileAnchored.map(aiCountryKey).filter(Boolean));
-        if (anchorCountries.size !== 1) continue;
-        adopted = fileAnchored.find(pr => aiCountryKey(pr)).aiIdentified.country;
+        const anchorKeys = new Set(anchors.map((pr) => countryKey(pr.item.country)));
+        if (anchorKeys.size !== 1) continue;
+        adopted = anchors[0].item.country;
       } else {
-        const best = rows.reduce((a, b) =>
+        // Highest-confidence row THAT HAS a country decides — a countryless
+        // 0.9 row must not null the adoption and silently no-op the pass
+        // (audit 2026-08-16).
+        const withCountry = rows.filter((pr) => rowKey(pr));
+        const best = withCountry.reduce((a, b) =>
           ((b.aiIdentified.confidence ?? 0) > (a.aiIdentified.confidence ?? 0) ? b : a));
         adopted = best.aiIdentified.country;
       }
       if (!adopted) continue;
+      const adoptedKey = countryKey(adopted);
       for (const pr of rows) {
-        // Never overwrite a row the file itself anchored, and when the group
-        // already agreed, only FILL gaps — never touch a stated value.
-        if (typeof pr.item.country === 'string' && pr.item.country.trim()) continue;
-        if (distinct.size === 1 && aiCountryKey(pr)) continue;
+        // Never overwrite a row the file itself anchored.
+        if (countryKey(pr.item.country)) continue;
+        const own = rowKey(pr);
+        if (own === adoptedKey) continue;
+        if (!own) { pr.aiIdentified.country = adopted; continue; } // fill the gap
+        // A row the model is CONFIDENT about keeps its own country: one
+        // producer string can be two wineries on two continents (Domaine
+        // Chandon FR vs Bodegas Chandon AR — the guard findOrCreateWine
+        // documents), and overriding it here would bypass that guard at the
+        // mint. Only sub-floor disagreements adopt the group country.
+        const conf = pr.aiIdentified.confidence;
+        if (typeof conf === 'number' && conf >= AI_GEOGRAPHY_MIN_CONFIDENCE) continue;
         pr.aiIdentified.country = adopted;
       }
     }
     //
-    // B) Low-confidence geography never mints. Applied to aiIdentified itself
-    //    (one mutation point), so matching, the aiProposed the client sees,
-    //    and the /confirm mint all agree. A missing/non-numeric confidence is
-    //    the "nobody can vouch for this" state and strips too — same stance
-    //    as the admin low-confidence queue.
-    for (const pr of preResults) {
-      if (!pr.aiIdentified) continue;
-      const conf = pr.aiIdentified.confidence;
-      if (!(typeof conf === 'number' && conf >= AI_GEOGRAPHY_MIN_CONFIDENCE)) {
-        pr.aiIdentified.region = null;
-        pr.aiIdentified.appellation = null;
-      }
-    }
+    // B) Low-confidence geography never MINTS — but it still MATCHES. The
+    //    strip is applied when the PROPOSAL is built in Pass 2, never to
+    //    aiIdentified itself: the exact/canonical dedup keys embed the
+    //    appellation, and stripping before matching made precisely the
+    //    low-confidence rows most likely to duplicate lose their registry
+    //    match and mint a twin (audit 2026-08-16 — an anti-fragmentation
+    //    change causing fragmentation). Matching with an uncertain
+    //    appellation is resolution, not assertion; nothing below the floor
+    //    is ever WRITTEN.
 
     // Pass 2: resolve AI-identified items against the registry, deduplicated by
     // wine key. findOrCreateWine internally does fuzzy matching using the
@@ -513,15 +539,35 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
             : pr.aiIdentified;
           const { wine, noMatch } = await findOrCreateWine(wineData, req.user.id, { matchOnly: true });
           if (noMatch) {
+            // A countryless identification can never mint — /confirm's
+            // findOrCreateWine throws 'Country is required' and the row
+            // error would silently cost the user their bottle (the exact
+            // shape allowPending exists to prevent, with no escape hatch for
+            // country; audit 2026-08-16). Demote to the no-match flow, where
+            // the user picks an existing wine or files a request instead of
+            // being offered a create that is guaranteed to fail.
+            if (!(typeof wineData.country === 'string' && wineData.country.trim())) {
+              const msg = 'The wine was recognised but its country could not be determined — match it to an existing wine or request it';
+              matchedWineCache.set(key, { error: msg });
+              pr.aiWineError = msg;
+              continue;
+            }
             // Explicit field list, not the raw AI object: this rides to the
             // client and back into /confirm, so it should carry exactly what
             // findOrCreateWine consumes (plus confidence for display).
+            //
+            // Geography floor (part B above): below AI_GEOGRAPHY_MIN_CONFIDENCE
+            // the model is inferring, not knowing — region/appellation are
+            // dropped from the PROPOSAL (what /confirm mints) while the
+            // matching above kept them (dedup keys embed the appellation).
+            const lowGeoConfidence =
+              !(typeof wineData.confidence === 'number' && wineData.confidence >= AI_GEOGRAPHY_MIN_CONFIDENCE);
             const proposed = {
               name: wineData.name,
               producer: wineData.producer,
               country: wineData.country,
-              region: wineData.region,
-              appellation: wineData.appellation,
+              region: lowGeoConfidence ? null : wineData.region,
+              appellation: lowGeoConfidence ? null : wineData.appellation,
               type: wineData.type,
               grapes: wineData.grapes,
               confidence: wineData.confidence,

--- a/backend/src/routes/import.validate.geography.test.js
+++ b/backend/src/routes/import.validate.geography.test.js
@@ -175,9 +175,13 @@ describe('B) confidence floor on AI geography', () => {
     expect(row.aiProposed.appellation).toBeNull();
     // Country survives the floor — a wine cannot mint without one.
     expect(row.aiProposed.country).toBe('Australia');
-    // And the matcher saw the stripped shape too, not just the response.
-    expect(findOrCreateWine.mock.calls[0][0].region).toBeNull();
-    expect(findOrCreateWine.mock.calls[0][0].appellation).toBeNull();
+    // The MATCHER still saw the full geography (audit 2026-08-16): the dedup
+    // keys embed the appellation, and stripping before Pass 2 made exactly
+    // the low-confidence rows most likely to duplicate lose their registry
+    // match. Matching is resolution, not assertion — nothing below the floor
+    // is ever WRITTEN (the aiProposed asserts above).
+    expect(findOrCreateWine.mock.calls[0][0].region).toBe('Barossa Valley');
+    expect(findOrCreateWine.mock.calls[0][0].appellation).toBe('Barossa Valley');
   });
 
   test('a missing/non-numeric confidence strips too — unknown means nobody can vouch', async () => {
@@ -204,7 +208,7 @@ describe('B) confidence floor on AI geography', () => {
 });
 
 describe('A) one producer, one country per batch', () => {
-  test('two AI-guessed countries for one producer unify to the higher-confidence row', async () => {
+  test('a sub-floor country disagreement adopts the higher-confidence row', async () => {
     primeAi(
       aiResult({ name: 'Mistura', producer: 'Thomas Allen', country: 'South Africa', confidence: 0.5 }),
       aiResult({ name: 'Origins', producer: 'Thomas Allen', country: 'Australia', confidence: 0.7 }));
@@ -219,7 +223,7 @@ describe('A) one producer, one country per batch', () => {
     expect(b.aiProposed.country).toBe('Australia');
   });
 
-  test('rows whose FILE stated a country anchor the group and are never overwritten', async () => {
+  test('the file anchors the group, but a CONFIDENT different-country row is spared (homonym guard)', async () => {
     primeAi(
       aiResult({ name: 'Mistura', producer: 'Thomas Allen', country: 'South Africa', confidence: 0.9 }),
       aiResult({ name: 'Origins', producer: 'Thomas Allen', country: 'Australia', confidence: 0.5 }));
@@ -231,8 +235,94 @@ describe('A) one producer, one country per batch', () => {
     ]);
 
     const [a, b] = res.body.results;
-    expect(b.aiProposed.country).toBe('Australia');  // anchor untouched
-    expect(a.aiProposed.country).toBe('Australia');  // free row adopts the anchor
+    expect(b.aiProposed.country).toBe('Australia');    // anchor untouched
+    // A ≥0.6-confidence row keeps its own country: one producer string can be
+    // two wineries on two continents (Domaine Chandon FR vs Bodegas Chandon
+    // AR), and overriding it here would bypass the mint's different-country
+    // guard (audit 2026-08-16). Sub-floor rows still adopt (test below).
+    expect(a.aiProposed.country).toBe('South Africa');
+  });
+
+  test('a SUB-floor free row does adopt the file anchor', async () => {
+    primeAi(
+      aiResult({ name: 'Mistura', producer: 'Thomas Allen', country: 'South Africa', confidence: 0.5 }),
+      aiResult({ name: 'Origins', producer: 'Thomas Allen', country: 'Australia', confidence: 0.5 }));
+
+    const res = await validate([
+      { wineName: 'Mistura', producer: 'Thomas Allen' },
+      { wineName: 'Origins', producer: 'Thomas Allen', country: 'Australia' },
+    ]);
+
+    expect(res.body.results[0].aiProposed.country).toBe('Australia');
+    expect(res.body.results[1].aiProposed.country).toBe('Australia');
+  });
+
+  test('an anchored row whose AI contradicts its own file column is corrected to the FILE value', async () => {
+    // The anchor is the file's STATED value, not the AI's echo of it (audit
+    // 2026-08-16: anchoring on the echo let a contradicting AI spread its
+    // contradiction to the whole group).
+    primeAi(
+      aiResult({ name: 'Mistura', producer: 'Thomas Allen', country: null, confidence: 0.5 }),
+      aiResult({ name: 'Origins', producer: 'Thomas Allen', country: 'South Africa', confidence: 0.9 }));
+
+    const res = await validate([
+      { wineName: 'Mistura', producer: 'Thomas Allen' },
+      { wineName: 'Origins', producer: 'Thomas Allen', country: 'Australia' }, // file says Australia
+    ]);
+
+    expect(res.body.results[1].aiProposed.country).toBe('Australia'); // file wins on its own row
+    expect(res.body.results[0].aiProposed.country).toBe('Australia'); // and anchors the countryless sibling
+  });
+
+  test('country aliases fold before comparison — "USA" and "United States" are ONE country', async () => {
+    primeAi(
+      aiResult({ name: 'Zin A', producer: 'Ridge Alt', country: 'USA', confidence: 0.7 }),
+      aiResult({ name: 'Zin B', producer: 'Ridge Alt', country: 'United States', confidence: 0.7 }));
+
+    const res = await validate([
+      { wineName: 'Zin A', producer: 'Ridge Alt' },
+      { wineName: 'Zin B', producer: 'Ridge Alt' },
+    ]);
+
+    // Under normalizeString alone these counted as TWO countries and the
+    // pass no-opped (audit 2026-08-16). Folded, the group agrees and both
+    // stated values stand untouched.
+    expect(res.body.results[0].aiProposed.country).toBe('USA');
+    expect(res.body.results[1].aiProposed.country).toBe('United States');
+  });
+
+  test('adoption comes from the best row THAT HAS a country — a countryless 0.9 row cannot null the pass', async () => {
+    primeAi(
+      aiResult({ name: 'Mistura', producer: 'Thomas Allen', country: null, confidence: 0.9 }),
+      aiResult({ name: 'Origins', producer: 'Thomas Allen', country: 'South Africa', confidence: 0.5 }),
+      aiResult({ name: 'Reserve', producer: 'Thomas Allen', country: 'Australia', confidence: 0.4 }));
+
+    const res = await validate([
+      { wineName: 'Mistura', producer: 'Thomas Allen' },
+      { wineName: 'Origins', producer: 'Thomas Allen' },
+      { wineName: 'Reserve', producer: 'Thomas Allen' },
+    ]);
+
+    // Best-with-a-country = the 0.5 South Africa row; the countryless 0.9
+    // row inherits it and the 0.4 row (sub-floor) adopts it.
+    expect(res.body.results[0].aiProposed.country).toBe('South Africa');
+    expect(res.body.results[1].aiProposed.country).toBe('South Africa');
+    expect(res.body.results[2].aiProposed.country).toBe('South Africa');
+  });
+
+  test('a countryless identification is DEMOTED to no-match — never an ai_new whose confirm loses the bottle', async () => {
+    primeAi(aiResult({ name: 'Mystery Red', producer: 'Lone Producer', country: null, confidence: 0.7 }));
+
+    const res = await validate([{ wineName: 'Mystery Red', producer: 'Lone Producer' }]);
+
+    const row = res.body.results[0];
+    // /confirm's mint throws Country-required — offering ai_new here
+    // guaranteed a lost bottle (audit 2026-08-16). The row falls back to
+    // the no-match flow, where the user matches or requests instead.
+    expect(row.aiProposed).toBeUndefined();
+    expect(row.status).toBe('no_match');
+    expect(row.aiDebug).toMatchObject({ aiStatus: 'create_failed' });
+    expect(row.aiDebug.aiExplanation).toMatch(/country/i);
   });
 
   test('a row the AI left countryless inherits the group country instead of failing to mint', async () => {

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -372,6 +372,20 @@ async function enrichWine(wine, model, { publishSuspect = false } = {}) {
         },
       }
     );
+    // Re-embed on HOLD too (audit 2026-08-16): a force re-enrich that ends in
+    // a hold has just nulled a previously PUBLISHED profile, and without this
+    // the old description keeps living in the Qdrant vectors — cellar chat
+    // would keep retrieving the wine by the very claims the hold silenced.
+    // embedSinglePair rebuilds from the now-profile-less text (textHash makes
+    // it a no-op for never-published rows). Best-effort, like the publish path.
+    try {
+      const vintages = await Bottle.distinct('vintage', { wineDefinition: wine._id, status: 'active' });
+      for (const v of vintages) {
+        await embedSinglePair(wine._id, v).catch(() => {});
+      }
+    } catch (embedErr) {
+      console.warn(`[enrichmentJob] re-embed after hold failed (${wine._id}):`, embedErr.message);
+    }
     return { result: 'held', reason: null };
   }
 
@@ -475,16 +489,22 @@ async function enrichWineById(wineDefId, { budgetUserId, force = false, publishS
       if (wine.aiProfile && wine.aiProfile.heldAt) return;
     }
 
+    // The OUTCOME is returned ('enriched' | 'held' | 'skipped' | undefined on
+    // guard/error) so a deliberate caller — releaseHeldProfile — can act only
+    // on success. Fire-and-forget callers keep ignoring it; this function
+    // still never throws.
+    let outcome;
     if (budgetUserId) {
       const debit = await tryDebitAi(String(budgetUserId));
       if (!debit.ok) {
         // Over the shared daily AI budget — skip silently; the next admin
         // batch run picks the wine up. The triggering action never fails.
         console.warn('[enrichmentJob] enrichWineById skipped (%s): ai budget exhausted (%s)', idStr, debit.reason);
-        return;
+        return undefined;
       }
       try {
         const { result, reason } = await enrichWine(wine, aiConfig.get().enrichmentModel, { publishSuspect });
+        outcome = result;
         // A transport-level failure never produced a billable completion
         if (result === 'skipped' && isRefundableFailure(reason)) await debit.refund();
       } catch (err) {
@@ -492,12 +512,37 @@ async function enrichWineById(wineDefId, { budgetUserId, force = false, publishS
         throw err; // handled by the outer catch below
       }
     } else {
-      await enrichWine(wine, aiConfig.get().enrichmentModel, { publishSuspect });
+      outcome = (await enrichWine(wine, aiConfig.get().enrichmentModel, { publishSuspect })).result;
     }
     console.log('[enrichmentJob] Auto-enriched new wine: %s', wine.name);
+    return outcome;
   } catch (err) {
     console.warn('[enrichmentJob] enrichWineById failed (%s): %s', idStr, err.message);
+    return undefined;
   }
+}
+
+/**
+ * Release a HELD profile after a human reviewed the doubt: force-regenerate,
+ * publish past the suspect flag, and stamp profileReviewedAt ONLY when the
+ * publish actually happened. Stamping first (the v1.116.0 shape) hid the row
+ * forever when the AI call failed — the outstanding queue compares
+ * reviewedAt against generatedAt and the incremental job skips held rows by
+ * design, so a failed release had no surface that would ever re-show it
+ * (audit 2026-08-16, confirmed by three independent traces). On failure the
+ * row simply STAYS in the queue, ready for another click.
+ *
+ * @returns {Promise<boolean>} true when the profile published and the review
+ *   stamp landed.
+ */
+async function releaseHeldProfile(wineDefId) {
+  const outcome = await enrichWineById(wineDefId, { force: true, publishSuspect: true });
+  if (outcome !== 'enriched') return false;
+  await WineDefinition.updateOne(
+    { _id: wineDefId },
+    { $set: { profileReviewedAt: new Date() } }
+  );
+  return true;
 }
 
 // ── Record-edit follow-through (shared by the deliberate curation surfaces) ──
@@ -549,7 +594,7 @@ function reenrichAfterRecordEdit(wine, changed) {
 }
 
 module.exports = {
-  start, requestStop, getStatus, enrichWineById,
+  start, requestStop, getStatus, enrichWineById, releaseHeldProfile,
   profileInputsSnapshot, reenrichAfterRecordEdit,
   // exported for unit tests
   cleanDescriptor, cleanStringList, cleanProse, cleanConfidence, suspectHoldsProfile,

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -509,3 +509,66 @@ describe('the narrowed hold end-to-end through enrichWine', () => {
     expect(p.producerSuspect).toBe(true);
   });
 });
+
+/**
+ * releaseHeldProfile — the review override with the stamp INSIDE the success
+ * path (audit 2026-08-16: stamping before the AI call hid a still-held row
+ * from the queue forever when the call failed).
+ */
+describe('releaseHeldProfile', () => {
+  const { releaseHeldProfile } = require('./enrichmentJob');
+  const heldWine = () => ({
+    _id: WINE_ID, name: 'Douro Tinto', producer: 'Fabelhaft', type: 'red',
+    country: { name: 'Portugal' }, region: null, grapes: [],
+    aiProfile: { generatedAt: new Date(), heldAt: new Date(), description: null, source: 'ai' },
+  });
+
+  test('publishes and THEN stamps the review — returns true', async () => {
+    WineDefinition.findById.mockReturnValue(chain(heldWine()));
+    suggestProfile.mockResolvedValue(profile('Now a real profile.'));
+
+    await expect(releaseHeldProfile(WINE_ID)).resolves.toBe(true);
+    // Two writes, in order: the published profile, then the review stamp.
+    expect(WineDefinition.updateOne).toHaveBeenCalledTimes(2);
+    expect(persisted().description).toBe('Now a real profile.');
+    const [, stamp] = WineDefinition.updateOne.mock.calls[1];
+    expect(stamp.$set.profileReviewedAt).toBeInstanceOf(Date);
+  });
+
+  test('a failed regeneration stamps NOTHING — the row stays in the queue for another click', async () => {
+    WineDefinition.findById.mockReturnValue(chain(heldWine()));
+    suggestProfile.mockResolvedValue({ data: null, debugReason: 'rate_limit_exceeded' });
+
+    await expect(releaseHeldProfile(WINE_ID)).resolves.toBe(false);
+    expect(WineDefinition.updateOne).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * A hold that replaces a previously PUBLISHED profile must re-embed too —
+ * otherwise the old description keeps living in the Qdrant vectors and cellar
+ * chat retrieves the wine by the very claims the hold silenced
+ * (audit 2026-08-16).
+ */
+describe('the hold path re-embeds', () => {
+  const { embedSinglePair } = require('./embeddingJob');
+  const Bottle = require('../models/Bottle');
+
+  test('holding triggers embedSinglePair for each active vintage', async () => {
+    Bottle.distinct.mockResolvedValue(['2019', '2020']);
+    suggestProfile.mockResolvedValue({
+      data: {
+        body: 'medium', tannin: 'medium', acidity: 'medium', sweetness: 'dry',
+        flavors: ['plum'], foodPairings: ['stew'],
+        description: 'A generic guess.', confidence: 0.4,
+        producerSuspect: true, producerNote: 'Cannot place this producer.',
+      },
+      debugReason: null,
+    });
+
+    await enrichWineById(WINE_ID);
+    expect(persisted().heldAt).toBeInstanceOf(Date);
+    expect(embedSinglePair).toHaveBeenCalledWith(WINE_ID, '2019');
+    expect(embedSinglePair).toHaveBeenCalledWith(WINE_ID, '2020');
+  });
+});

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -141,10 +141,18 @@ async function regionForAppellation(appellationName, countryId) {
   if (!appellationName || !countryId) return null;
   const normalizedName = normalizeString(appellationName);
   if (!normalizedName) return null;
-  return Region.findOne({
+  // TWO docs answering one key means the taxonomy holds a duplicate — never
+  // pick one arbitrarily (the same doctrine as the canonical-identity match
+  // stages, and the same rows the batch normalize script holds out and
+  // reports; audit 2026-08-16: a bare findOne here silently adopted whichever
+  // doc natural order yielded while the script refused the identical rows).
+  // Falling back to the caller-supplied region is the honest state until the
+  // taxonomy is fixed.
+  const hits = await Region.find({
     country: countryId,
     $or: [{ normalizedName }, { normalizedSynonyms: normalizedName }],
-  });
+  }).limit(2);
+  return hits.length === 1 ? hits[0] : null;
 }
 
 async function findOrCreateGrapes(rawNames, userId) {

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -1141,10 +1141,27 @@ describe('taxonomy find-or-create dedup', () => {
  * Valley). Match-only: an appellation string never MINTS a Region.
  */
 describe('findOrCreateWine — region canon: appellation granularity wins', () => {
+  // The canon lookup is Region.find(...).limit(2) — TWO hits mean a taxonomy
+  // duplicate and the canon must refuse to pick (audit 2026-08-16). This
+  // dispatcher serves that shape for canon queries and keeps the chainable
+  // taxonomy default for everything else (cross-field reference loads).
+  const primeRegionCanon = (map) => {
+    Region.find.mockImplementation((q) => {
+      const key = q?.$or?.[0]?.normalizedName;
+      if (q && q.country && q.$or) {
+        return { limit: jest.fn().mockResolvedValue(map[key] || []) };
+      }
+      const c = {};
+      for (const m of ['select', 'sort', 'limit', 'populate']) c[m] = jest.fn(() => c);
+      c.lean = jest.fn().mockResolvedValue([]);
+      return c;
+    });
+  };
+
   test('an appellation naming a known region overrides the supplied parent region', async () => {
+    primeRegionCanon({ 'hunter valley': [{ _id: 'region-hunter' }] });
     Region.findOne.mockImplementation(async (q) => {
       const key = q?.$or?.[0]?.normalizedName;
-      if (key === 'hunter valley') return { _id: 'region-hunter' };
       if (key === 'new south wales') return { _id: 'region-nsw' };
       return null;
     });
@@ -1158,8 +1175,8 @@ describe('findOrCreateWine — region canon: appellation granularity wins', () =
   });
 
   test('the canon rule fills a missing region from the appellation too', async () => {
-    Region.findOne.mockImplementation(async (q) =>
-      (q?.$or?.[0]?.normalizedName === 'barossa valley' ? { _id: 'region-barossa' } : null));
+    primeRegionCanon({ 'barossa valley': [{ _id: 'region-barossa' }] });
+    Region.findOne.mockResolvedValue(null);
     const { wine } = await findOrCreateWine({
       name: 'Generations', producer: 'Kies', country: 'Australia',
       appellation: 'Barossa Valley', type: 'red', grapes: [],
@@ -1168,6 +1185,7 @@ describe('findOrCreateWine — region canon: appellation granularity wins', () =
   });
 
   test('an appellation naming no region falls back to the supplied region string', async () => {
+    primeRegionCanon({});
     Region.findOne.mockImplementation(async (q) =>
       (q?.$or?.[0]?.normalizedName === 'marlborough' ? { _id: 'region-marlborough' } : null));
     const { wine } = await findOrCreateWine({
@@ -1177,7 +1195,19 @@ describe('findOrCreateWine — region canon: appellation granularity wins', () =
     expect(wine.region).toBe('region-marlborough');
   });
 
+  test('TWO regions answering the appellation key → the canon refuses to pick; the supplied region stands', async () => {
+    primeRegionCanon({ 'la cote': [{ _id: 'region-a' }, { _id: 'region-b' }] });
+    Region.findOne.mockImplementation(async (q) =>
+      (q?.$or?.[0]?.normalizedName === 'vaud' ? { _id: 'region-vaud' } : null));
+    const { wine } = await findOrCreateWine({
+      name: 'Chasselas', producer: 'Domaine Bovard', country: 'Switzerland',
+      region: 'Vaud', appellation: 'La Cote', type: 'white', grapes: [],
+    }, USER_ID);
+    expect(wine.region).toBe('region-vaud'); // duplicate key → arbitrary pick refused
+  });
+
   test('an unmatched appellation never MINTS a region — with none supplied the wine stores null', async () => {
+    primeRegionCanon({});
     Region.findOne.mockResolvedValue(null);
     const { wine } = await findOrCreateWine({
       name: 'Cuvée X', producer: 'Some Estate', country: 'France',

--- a/backend/src/services/registryFragmentation.js
+++ b/backend/src/services/registryFragmentation.js
@@ -375,6 +375,14 @@ async function nameSubsetPairs({ limit = 50, offset = 0 } = {}) {
   const dismissed = new Set(notDup.map((d) => `${d.wineA}|${d.wineB}`));
   const active = rawPairs.filter((p) => !dismissed.has(pairKey(p.short._id, p.long._id)));
 
+  // The health job asks only for the count (limit: 0) — total is known here,
+  // and everything below (the Bottle aggregate, entry building, the sort) is
+  // presentation. Computing it weekly just to slice(0, 0) was pure waste
+  // (audit 2026-08-16).
+  if (limit === 0) {
+    return { pairs: [], total: active.length, scannedCount: wines.length, skippedBuckets };
+  }
+
   const ids = [...new Set(active.flatMap((p) => [p.short._id, p.long._id]))];
   const { vintageSets, bottleCounts } = await collectVintageEvidence(ids);
 

--- a/frontend/src/components/WineProposalsModal.js
+++ b/frontend/src/components/WineProposalsModal.js
@@ -127,6 +127,22 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
     const gone = new Set(ids);
     decidedDelta.current += gone.size;
     setItems(prev => (prev || []).filter(x => !gone.has(x._id)));
+    // Decided rows leave the SELECTION too (audit 2026-08-16): a row approved
+    // via its own button kept its id in selectedIds, inflating the count and
+    // making the next bulk call send an already-decided id whose 409 landed
+    // as an error on a row no longer rendered. (After a bulk call,
+    // applyBulkResults re-sets the selection to the failed ids — functional
+    // updates apply in order, so that write wins, as intended.)
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      for (const id of gone) next.delete(id);
+      return next;
+    });
+    setRowErrors(prev => {
+      const next = { ...prev };
+      for (const id of gone) delete next[id];
+      return next;
+    });
     setTotal(prev => Math.max(0, prev - gone.size));
     setPendingCount(prev => Math.max(0, prev - gone.size));
     // The drain check may use the closure: every interleaving path (second

--- a/frontend/src/pages/AdminImages.js
+++ b/frontend/src/pages/AdminImages.js
@@ -61,7 +61,7 @@ function AdminImages() {
       const res = await adminApproveImage(apiFetch, selected._id, { visibility });
       const data = await res.json();
       if (res.ok) {
-        setSelected(data.image);
+        adoptSelected(data.image);
         fetchImages();
       } else {
         setError(data.error);
@@ -101,7 +101,7 @@ function AdminImages() {
       const res = await adminSetImageVisibility(apiFetch, selected._id, visibility);
       const data = await res.json();
       if (res.ok) {
-        setSelected(data.image);
+        adoptSelected(data.image);
         fetchImages();
       } else {
         setError(data.error);
@@ -121,7 +121,7 @@ function AdminImages() {
       const res = await adminUnapproveImage(apiFetch, selected._id);
       const data = await res.json();
       if (res.ok) {
-        setSelected(data.image);
+        adoptSelected(data.image);
         fetchImages();
       } else {
         setError(data.error);
@@ -141,6 +141,20 @@ function AdminImages() {
   // render as "no wine linked" on this page, which is what it looked like in
   // review. The LIST already falls back this way; the detail did not.
   const effectiveWine = (img) => img?.wineDefinition || img?.bottle?.wineDefinition || null;
+
+  // Adopt an ACTION response as the selection without losing the populated
+  // bottle: approve/visibility/unapprove/assign responses populate only
+  // uploadedBy/reviewedBy/wineDefinition, so their `bottle` is a bare id —
+  // taking them wholesale degraded the via-bottle wine display one click
+  // after it worked (audit 2026-08-16). Keep the previously populated bottle
+  // whenever the response's isn't an object; a genuinely bottle-less image
+  // (null) stays null.
+  const adoptSelected = (img) => setSelected(prev => ({
+    ...img,
+    bottle: (img && img.bottle && typeof img.bottle !== 'object')
+      ? (prev && prev.bottle && typeof prev.bottle === 'object' ? prev.bottle : img.bottle)
+      : (img ? img.bottle : null),
+  }));
   const selectedWine = effectiveWine(selected);
   // True orphan: no bottle AND no wine — an add abandoned between the upload
   // and the link. Swept after 30 days (services/scanImageRetentionJob).
@@ -159,7 +173,7 @@ function AdminImages() {
       const res = await adminAssignImageToWine(apiFetch, selected._id, { wineDefinitionId: wineDefId });
       const data = await res.json();
       if (res.ok) {
-        setSelected(data.image);
+        adoptSelected(data.image);
         fetchImages();
         setAssignWineId('');
       } else {
@@ -237,7 +251,7 @@ function AdminImages() {
                     <div className="image-item-info">
                       <div className="image-item-header">
                         <span className="image-item-wine">
-                          {img.wineDefinition?.name || img.bottle?.wineDefinition?.name || t('admin.images.noWineLinked')}
+                          {effectiveWine(img)?.name || t('admin.images.noWineLinked')}
                         </span>
                         <span className={`status-badge status-${img.status}`}>{img.status}</span>
                         {img.status === 'approved' && img.visibility === 'private' && (


### PR DESCRIPTION
## Pre-release audit of the v1.116 wave (v1.115.1..main, 35 files, +2,287 lines)

Eight-angle diff audit before cutting the release. Nine confirmed defects — all in this wave's own code, several found independently by two or three angles — each closed here with a pinning test. Full finding details in the commit message; the highlights:

| Defect | Consequence closed |
|---|---|
| Country anchors used the AI's echo, not the file's value | A contradicting AI spread its contradiction to the whole producer group |
| Countries compared without alias resolution | "USA" vs "United States" silently defeated the unification |
| Adoption from a countryless best row | The pass no-opped on exactly its target case (Thomas Allen) |
| Confident different-country rows overwritten | Chandon-FR/Chandon-AR homonyms folded across continents, bypassing the mint guard |
| Countryless identification offered as `ai_new` | `/confirm`'s mint threw and the user's bottle was silently lost |
| Geography floor stripped **before** matching | Dedup keys (which embed appellation) missed → low-confidence re-imports could mint duplicates |
| Held-release stamped reviewed before the publish | A failed AI call hid the row from every queue forever (3 independent traces) |
| Hold path skipped re-embedding | The silenced fabricated prose kept steering cellar chat via stale Qdrant vectors |
| Bulk approve fired follow-through per proposal | Same-wine races (indeterminate last writer) + one paid AI call per proposal instead of per wine |
| `regionForAppellation` bare findOne | Arbitrary pick on duplicate region keys the batch script explicitly refuses |
| Image panel adopted unpopulated action responses | The via-bottle wine display broke one click after it worked |
| Decided proposals stayed in the bulk selection | Phantom ids poisoned the next bulk call with invisible errors |

Plus two small ones: `nameSubsetPairs({limit:0})` early-returns before computing evidence the health job discards weekly, and the two hand-mirrored `profileInputsSnapshot` test mocks now use the real pure function (`jest.requireActual`) so they can't rot.

**Deliberately not in this batch** (tracked as follow-ups): the Toscana/Bolgheri broad-appellation inversion of the region canon (policy nuance — prod damage check scheduled post-deploy), the failed-link photo-deletion trade-off (documented), the concurrent-distinct-wine enrichment fan-out residual, and ~10 refactor/altitude items from the audit (shared sweep helper, mode config, service homes, frontend field-mapping helper).

## Tests
17 backend suites / **358 tests** green in the container — including 9 new/updated behavior pins (anchor-is-file-value, alias fold, homonym spare, countryless demotion, match-full/propose-stripped, held-release success/failure, hold re-embed, bulk per-wine follow-through, canon ambiguity refusal). Frontend full run **941/941**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)