### PR TITLE
fix(announcement): poll for the banner so an open tab actually sees it

### DIFF
--- a/frontend/src/components/AnnouncementBanner.js
+++ b/frontend/src/components/AnnouncementBanner.js
@@ -5,6 +5,13 @@ import './AnnouncementBanner.css';
 const API_BASE = import.meta.env.VITE_API_URL || '';
 const DISMISS_KEY = 'announcementDismissed';
 const CACHE_TTL = 60 * 1000;
+// How often an OPEN tab re-asks. The banner's whole job is to reach people
+// before something happens (a maintenance window, an incident), and fetching
+// only on mount meant it reached nobody who already had the app open —
+// found 2026-08-17, when a live banner was invisible to exactly the person
+// who had been sitting on the page. Comfortably longer than CACHE_TTL, so
+// each poll actually re-asks rather than reading its own cache.
+const POLL_MS = 5 * 60 * 1000;
 
 // Module-level cache: Layout remounts on every route change, but the banner
 // endpoint only needs to be asked about once a minute.
@@ -15,11 +22,22 @@ async function fetchAnnouncement() {
   if (cached !== null && Date.now() - cachedAt < CACHE_TTL) return cached;
   try {
     const res = await fetch(`${API_BASE}/api/site/announcement`);
-    cached = res.ok ? await res.json() : { enabled: false };
+    if (res.ok) {
+      cached = await res.json();
+      cachedAt = Date.now();
+    } else if (cached === null) {
+      // Never had an answer — treat as "no banner" but do NOT start the
+      // cache clock, so the next poll retries rather than waiting a minute.
+      cached = { enabled: false };
+    }
   } catch {
-    cached = { enabled: false };
+    // A transient network blip must not TAKE DOWN a banner that is already
+    // showing: keep whatever we last knew. Only the first-ever failure
+    // resolves to "no banner" (see above). This matters more with polling
+    // than it did with a single fetch — one dropped request in five minutes
+    // would otherwise blink the notice off the page.
+    if (cached === null) cached = { enabled: false };
   }
-  cachedAt = Date.now();
   return cached;
 }
 
@@ -37,8 +55,24 @@ function AnnouncementBanner() {
 
   useEffect(() => {
     let cancelled = false;
-    fetchAnnouncement().then(a => { if (!cancelled) setAnnouncement(a); });
-    return () => { cancelled = true; };
+    const load = () => fetchAnnouncement().then(a => { if (!cancelled) setAnnouncement(a); });
+    load();
+
+    // Poll, so a banner raised while someone is mid-session still reaches
+    // them. Both triggers go through the same CACHE_TTL-respecting fetch, so
+    // a tab that is switched to repeatedly cannot spam the endpoint.
+    const timer = setInterval(load, POLL_MS);
+    // Returning to the tab is the moment a stale banner is most likely and
+    // most wanted — a user coming back after an hour gets the current state
+    // without waiting out the interval.
+    const onVisibility = () => { if (document.visibilityState === 'visible') load(); };
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
   }, []);
 
   if (!announcement?.enabled || !announcement.message) return null;

--- a/frontend/src/components/AnnouncementBanner.test.js
+++ b/frontend/src/components/AnnouncementBanner.test.js
@@ -1,0 +1,125 @@
+import { render, screen, act, waitFor } from '@testing-library/react';
+import AnnouncementBanner from './AnnouncementBanner';
+
+// i18n: the component only uses t() for the dismiss label, so the identity
+// stub keeps the assertions about the MESSAGE honest.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k) => k, i18n: { language: 'en' } }),
+}));
+
+const banner = (over = {}) => ({
+  enabled: true,
+  message: 'Planned maintenance at 18:15 UTC',
+  messageSv: 'Planerat underhåll kl 18:15 UTC',
+  type: 'info',
+  updatedAt: '2026-08-17T07:53:20.843Z',
+  ...over,
+});
+
+/** The module-level cache lives across renders — reset the module each test. */
+async function freshBanner() {
+  vi.resetModules();
+  return (await import('./AnnouncementBanner')).default;
+}
+
+// Node ships an experimental `localStorage` global that shadows jsdom's here
+// and has no clear() — stub a plain in-memory one rather than depend on which
+// implementation wins.
+let store;
+const stubStorage = () => {
+  store = new Map();
+  vi.stubGlobal('localStorage', {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    clear: () => store.clear(),
+  });
+};
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  stubStorage();
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+const ok = (body) => ({ ok: true, json: async () => body });
+
+test('shows an enabled announcement', async () => {
+  const Banner = await freshBanner();
+  fetch.mockResolvedValue(ok(banner()));
+  render(<Banner />);
+  expect(await screen.findByText('Planned maintenance at 18:15 UTC')).toBeInTheDocument();
+});
+
+/**
+ * The bug this polling exists for (2026-08-17): a banner raised while people
+ * already had the app open reached nobody, because the component fetched only
+ * on mount. An open tab must pick it up without a reload.
+ */
+test('an OPEN tab picks up a banner raised after mount', async () => {
+  const Banner = await freshBanner();
+  fetch.mockResolvedValueOnce(ok({ enabled: false }));
+  render(<Banner />);
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+  expect(screen.queryByText(/maintenance/)).not.toBeInTheDocument();
+
+  // The banner goes up on the server, then the poll interval elapses.
+  fetch.mockResolvedValue(ok(banner()));
+  await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 100); });
+
+  expect(await screen.findByText('Planned maintenance at 18:15 UTC')).toBeInTheDocument();
+});
+
+test('returning to the tab re-checks without waiting for the interval', async () => {
+  const Banner = await freshBanner();
+  fetch.mockResolvedValueOnce(ok({ enabled: false }));
+  render(<Banner />);
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+  fetch.mockResolvedValue(ok(banner()));
+  // Past CACHE_TTL, so the visibility check actually re-asks.
+  await act(async () => { await vi.advanceTimersByTimeAsync(61 * 1000); });
+  await act(async () => { document.dispatchEvent(new Event('visibilitychange')); });
+
+  expect(await screen.findByText('Planned maintenance at 18:15 UTC')).toBeInTheDocument();
+});
+
+/**
+ * With polling, a single dropped request must not blink a live notice off the
+ * page — the failure keeps the last known state instead of resolving to
+ * "no banner".
+ */
+test('a transient fetch failure does not take down a showing banner', async () => {
+  const Banner = await freshBanner();
+  fetch.mockResolvedValueOnce(ok(banner()));
+  render(<Banner />);
+  expect(await screen.findByText('Planned maintenance at 18:15 UTC')).toBeInTheDocument();
+
+  fetch.mockRejectedValue(new Error('network'));
+  await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 100); });
+
+  expect(screen.getByText('Planned maintenance at 18:15 UTC')).toBeInTheDocument();
+});
+
+test('a dismissed version stays hidden across polls, but a NEW version returns', async () => {
+  const Banner = await freshBanner();
+  store.set('announcementDismissed', '2026-08-17T07:53:20.843Z');
+  fetch.mockResolvedValue(ok(banner()));
+  render(<Banner />);
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  expect(screen.queryByText(/maintenance/)).not.toBeInTheDocument();
+
+  // An edited announcement carries a new updatedAt — the dismissal is per
+  // version, so it must reappear.
+  fetch.mockResolvedValue(ok(banner({
+    message: 'Updated notice', updatedAt: '2026-08-17T09:00:00.000Z',
+  })));
+  await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 100); });
+
+  expect(await screen.findByText('Updated notice')).toBeInTheDocument();
+});


### PR DESCRIPTION
## The bug, found live today

The announcement banner fetched **only on mount**. Anyone already sitting in the app saw nothing until they reloaded — which is precisely the population a maintenance notice or incident warning most needs to reach.

Observed this morning: the API was serving `enabled: true` correctly, and the banner was invisible to the person who had the page open.

## Change

- **Poll every 5 minutes**, plus a re-check when the tab becomes **visible again** — someone returning after an hour gets the current state without waiting out the interval. Both go through the existing `CACHE_TTL`-respecting fetch, so repeated tab-switching can't spam the endpoint.
- **A transient failure keeps the last known state.** With a single fetch, a dropped request only meant the banner failed to appear; with polling it would blink a live notice *off* the page. Only the first-ever failure resolves to "no banner".
- **A failed first fetch no longer starts the cache clock**, so the next poll retries instead of waiting out the TTL.

Dismissal semantics are untouched — still per `updatedAt`, so a dismissed banner stays hidden across polls while an edited one reappears.

## Tests
New suite, 5 cases: raised-after-mount (the actual bug), visibility re-check, transient failure not taking down a live banner, dismissal persisting across polls, and a new version returning. Frontend **946/946**.

Note: the tests stub `localStorage` explicitly — Node ships an experimental `localStorage` global that shadows jsdom's in this environment and has no `clear()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)