### PR TITLE
fix(images): audit follow-ups on the add-bottle photo surface

### DIFF
--- a/backend/src/routes/admin/images.js
+++ b/backend/src/routes/admin/images.js
@@ -350,6 +350,13 @@ router.delete('/:id', async (req, res) => {
         _id: { $ne: image._id },
         contentHash: image.contentHash,
         status: { $ne: 'rejected' },
+        // Never a label scan. The promotion below sets approved+public, and a
+        // user who scanned a label and also uploaded that same file as a bottle
+        // photo has two rows with an identical contentHash — with the
+        // same-uploader preference right below actively selecting the scanner's
+        // own row. That would publish private curation evidence to a URL that
+        // /api/uploads serves unauthenticated and forever.
+        kind: { $ne: 'label-scan' },
         $or: [{ processedUrl: { $ne: null } }, { originalUrl: { $ne: null } }],
       }).sort({ createdAt: 1 }).lean();
       survivor = candidates.find(c => String(c.uploadedBy) === String(image.uploadedBy)) || candidates[0] || null;

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -232,13 +232,33 @@ router.get('/wine/:wineDefinitionId', requireAuth, async (req, res) => {
 
     const filter = {
       wineDefinition: req.params.wineDefinitionId,
+      // Belt-and-braces, matching the MCP twin of this query (mcp/tools/somm.js).
+      // Label scans are the raw frames handed to the AI — private curator
+      // evidence that DOES carry a wineDefinition, so it sits inside this
+      // query's candidate set and is excluded only transitively by
+      // status/visibility. Two contentHash-keyed promotion paths can flip a row
+      // to approved+public without checking kind, and /api/uploads serves by
+      // unguessable filename with no auth, so a scan that ever leaked here
+      // would be permanently, anonymously fetchable. Exclude it by name.
+      kind: { $ne: 'label-scan' },
       ...(showAll
+        // The admin branch deliberately keeps private/unapproved rows, but
+        // never label scans — admin/images.js already removes them from every
+        // moderation surface (audit L-6) and refuses to promote them.
         ? { status: { $ne: 'rejected' } }
         : { status: 'approved', visibility: 'public' })
     };
 
-    const images = await BottleImage.find(filter)
-      .sort({ assignedToWine: -1, createdAt: -1 });
+    // Non-admins get a projection. The full document carries uploadedBy,
+    // reviewedBy, contentHash and the uploader's bottle id — and uploadedBy is
+    // joinable to a name via GET /api/users/public/:id, so shipping it to every
+    // user browsing a wine's photos attributes each one to a named account.
+    // Admin surfaces still need the full row (duplicate detection uses
+    // contentHash), so only the public branch is narrowed.
+    const query = BottleImage.find(filter).sort({ assignedToWine: -1, createdAt: -1 });
+    if (!showAll) query.select('_id processedUrl originalUrl credit assignedToWine status visibility kind side createdAt');
+
+    const images = await query;
 
     res.json({ images });
   } catch (error) {

--- a/backend/src/routes/images.wineGallery.test.js
+++ b/backend/src/routes/images.wineGallery.test.js
@@ -1,0 +1,162 @@
+/**
+ * GET /api/images/wine/:wineDefinitionId — the filter, pinned.
+ *
+ * This endpoint used to be reached only from admin pages and a bottle's own
+ * detail view. It is now mounted on AddBottle, so every user adding a bottle
+ * queries it for a wine they may have nothing to do with. Nothing tested the
+ * filter before, which is uncomfortable for a query whose only job is to decide
+ * what a stranger may see.
+ *
+ * Two things it must never do, both load-bearing:
+ *
+ *  - Return a label scan. Those are the raw frames handed to the AI scanner —
+ *    private curation evidence that DOES carry a wineDefinition, so it sits
+ *    inside this query's candidate set. /api/uploads serves bytes by
+ *    unguessable filename with no auth, so a scan surfaced here would be
+ *    permanently and anonymously fetchable with no way to re-gate it.
+ *  - Ship uploader identity. `uploadedBy` joins to a name via
+ *    GET /api/users/public/:id, which would attribute every registry photo to
+ *    a named account for anyone browsing a wine.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../models/BottleImage', () => ({ find: jest.fn(), findById: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ exists: jest.fn(), findById: jest.fn() }));
+jest.mock('../services/imageProcessor', () => ({ processImage: jest.fn() }));
+jest.mock('../services/imageSanitizer', () => ({ sanitizeImageBuffer: jest.fn() }));
+jest.mock('../services/imageOps', () => ({ ingestBottleImage: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../config/upload', () => ({ upload: { single: () => (req, res, next) => next() }, ORIGINALS_DIR: '/app/uploads/originals' }));
+jest.mock('../utils/cellarAccess', () => ({ getCellarRole: jest.fn(() => null) }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const BottleImage = require('../models/BottleImage');
+const imagesRouter = require('./images');
+
+const oid = (c) => c.repeat(24);
+const WINE = oid('a');
+const USER = oid('1');
+const ADMIN = oid('2');
+
+const tokenFor = (id, roles) => jwt.sign({ id, roles }, 'test-secret');
+
+/** Chainable thenable standing in for a Mongoose Query. */
+const makeQuery = (rows = []) => {
+  const q = {
+    sort: jest.fn(() => q),
+    select: jest.fn(() => q),
+    then: (resolve, reject) => Promise.resolve(rows).then(resolve, reject),
+  };
+  return q;
+};
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/images', imagesRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+beforeEach(() => jest.clearAllMocks());
+
+const get = (path, token) =>
+  fetch(`${baseUrl}${path}`, { headers: { Authorization: `Bearer ${token}` } });
+
+/** The filter object the route handed to BottleImage.find. */
+const filterUsed = () => BottleImage.find.mock.calls[0][0];
+
+describe('what an ordinary user may see', () => {
+  test('approved + public only, and never a label scan', async () => {
+    const q = makeQuery([]);
+    BottleImage.find.mockReturnValue(q);
+
+    const res = await get(`/api/images/wine/${WINE}`, tokenFor(USER, ['user']));
+    expect(res.status).toBe(200);
+
+    const f = filterUsed();
+    expect(f.wineDefinition).toBe(WINE);
+    expect(f.status).toBe('approved');
+    expect(f.visibility).toBe('public');
+    // Excluded by name, not merely by relying on status/visibility.
+    expect(f.kind).toEqual({ $ne: 'label-scan' });
+  });
+
+  test('uploader identity never leaves the server', async () => {
+    const q = makeQuery([]);
+    BottleImage.find.mockReturnValue(q);
+
+    await get(`/api/images/wine/${WINE}`, tokenFor(USER, ['user']));
+
+    expect(q.select).toHaveBeenCalledTimes(1);
+    const fields = q.select.mock.calls[0][0];
+    for (const leaky of ['uploadedBy', 'reviewedBy', 'contentHash', 'bottle']) {
+      expect(fields).not.toContain(leaky);
+    }
+    // …while still carrying what the gallery actually renders.
+    for (const needed of ['processedUrl', 'credit', 'assignedToWine']) {
+      expect(fields).toContain(needed);
+    }
+  });
+
+  test('?all=true from a non-admin does not widen anything', async () => {
+    const q = makeQuery([]);
+    BottleImage.find.mockReturnValue(q);
+
+    await get(`/api/images/wine/${WINE}?all=true`, tokenFor(USER, ['user']));
+
+    const f = filterUsed();
+    expect(f.status).toBe('approved');
+    expect(f.visibility).toBe('public');
+    expect(q.select).toHaveBeenCalledTimes(1); // still projected
+  });
+
+  test('a sommelier is not an admin here either', async () => {
+    const q = makeQuery([]);
+    BottleImage.find.mockReturnValue(q);
+
+    await get(`/api/images/wine/${WINE}?all=true`, tokenFor(USER, ['sommelier']));
+
+    expect(filterUsed().visibility).toBe('public');
+  });
+});
+
+describe('the admin branch', () => {
+  test('sees unapproved and private rows — but still no label scans', async () => {
+    const q = makeQuery([]);
+    BottleImage.find.mockReturnValue(q);
+
+    const res = await get(`/api/images/wine/${WINE}?all=true`, tokenFor(ADMIN, ['admin']));
+    expect(res.status).toBe(200);
+
+    const f = filterUsed();
+    expect(f.status).toEqual({ $ne: 'rejected' });
+    expect(f.visibility).toBeUndefined();
+    expect(f.kind).toEqual({ $ne: 'label-scan' });
+    // Admin surfaces need the full row (duplicate detection reads contentHash).
+    expect(q.select).not.toHaveBeenCalled();
+  });
+
+  test('an admin WITHOUT all=true gets the same narrow view as anyone else', async () => {
+    const q = makeQuery([]);
+    BottleImage.find.mockReturnValue(q);
+
+    await get(`/api/images/wine/${WINE}`, tokenFor(ADMIN, ['admin']));
+
+    expect(filterUsed().status).toBe('approved');
+    expect(q.select).toHaveBeenCalledTimes(1);
+  });
+});
+
+test('a bad id is rejected before any query runs', async () => {
+  const res = await get('/api/images/wine/not-an-id', tokenFor(USER, ['user']));
+  expect(res.status).toBe(400);
+  expect(BottleImage.find).not.toHaveBeenCalled();
+});

--- a/backend/src/scripts/cleanup-duplicate-images.js
+++ b/backend/src/scripts/cleanup-duplicate-images.js
@@ -64,6 +64,10 @@ async function main() {
     { $match: {
       status: { $ne: 'rejected' },
       contentHash: { $ne: null },
+      // Label scans are private curation evidence and must never be a keeper:
+      // the promotion below sets approved+public, which would publish the raw
+      // frame handed to the AI scanner to a permanently public URL.
+      kind: { $ne: 'label-scan' },
       $or: [{ processedUrl: { $ne: null } }, { originalUrl: { $ne: null } }],
     } },
     { $lookup: { from: 'bottles', localField: 'bottle', foreignField: '_id', as: '_b' } },

--- a/frontend/src/components/ImageGallery.js
+++ b/frontend/src/components/ImageGallery.js
@@ -30,14 +30,22 @@ const ImageGallery = forwardRef(function ImageGallery({ bottleId, wineDefinition
         // onEmpty only fires for the empty case, so a caller that needs to tell
         // "no images" from "not fetched yet" (AddBottle changes its photo copy
         // on exactly that distinction) has no positive signal. onLoaded gives
-        // it one: always called with the count once the fetch resolves.
+        // it one, and is called on EVERY settled outcome including failure —
+        // a caller gating UI on it would otherwise render nothing at all,
+        // permanently, whenever this endpoint errors.
         if (onLoaded) onLoaded(list.length);
-      } else if (onEmpty) {
-        onEmpty();
+      } else {
+        if (onEmpty) onEmpty();
+        // A failed load reports 0 rather than staying silent. Conflating
+        // "failed" with "none" is deliberate: every caller's fallback for zero
+        // is the safe one (offer the upload), whereas a caller left waiting
+        // forever shows a broken half-rendered section.
+        if (onLoaded) onLoaded(0);
       }
     } catch (err) {
       console.error('Failed to fetch images:', err);
       if (onEmpty) onEmpty();
+      if (onLoaded) onLoaded(0);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/AddBottle.css
+++ b/frontend/src/pages/AddBottle.css
@@ -661,6 +661,25 @@
   display: block;
 }
 
+/* The credit is normally hover-only (.wine-row-img-wrap:hover). This surface is
+   reached by pointing a camera at a label, so it is phone-first and hover never
+   fires — a hover-only credit here is a credit nobody ever sees. Attribution on
+   someone else's photograph is not optional, so it stays visible. */
+.scan-wine-shot-img-wrap .wine-row-credit {
+  display: block;
+}
+
+/* A fixed slot per shot. WineImage hides a broken <img> via onError, and
+   without this the column would collapse and knock the two captions off a
+   shared baseline — the exact raggedness the compare layout exists to avoid. */
+.scan-wine-image-wrap--compare .scan-wine-shot-img-wrap {
+  width: 88px;
+  height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .scan-wine-shot-caption {
   font-size: 0.68rem;
   color: var(--color-text-muted);
@@ -687,6 +706,11 @@
 
 /* Two thumbnails plus the body do not fit a narrow phone at full size. */
 @media (max-width: 600px) {
+  .scan-wine-image-wrap--compare .scan-wine-shot-img-wrap {
+    width: 64px;
+    height: 110px;
+  }
+
   .scan-wine-image-wrap--compare .scan-wine-label-img,
   .scan-wine-image-wrap--compare .scan-wine-placeholder {
     width: 64px;

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -71,10 +71,13 @@ function AddBottle() {
     consumedRatingScale: user?.preferences?.ratingScale || '5'
   });
   const [uploadedImages, setUploadedImages] = useState([]);
-  // How many public photos the registry already holds for the selected wine.
-  // null = not fetched yet, so the photo prompt stays neutral until we know
-  // rather than flashing the wrong message.
-  const [wineImageCount, setWineImageCount] = useState(null);
+  // How many public photos the registry holds, KEYED BY WINE ID. A single
+  // counter was wrong twice over: a passive reset effect runs a render late, so
+  // the first commit after a wine switch painted the previous wine's answer
+  // ("we already have a photo" for a wine that has none), and an out-of-order
+  // response could overwrite the current wine's count with a stale one. Keying
+  // makes both unrepresentable. Absent key = not fetched yet.
+  const [wineImageCounts, setWineImageCounts] = useState({});
   const [showDetails, setShowDetails] = useState(false);
 
   // Whether the user has worked the toggle themselves. Auto-expanding is a
@@ -545,16 +548,12 @@ function AddBottle() {
   // still holding the bottle, which is the cheapest correction signal we get.
   const scanMatchedWine = scanResult?.match?.wine || null;
 
-  // Reset on every wine change so the photo prompt never describes the
-  // previous wine's gallery while the new one is still loading.
-  useEffect(() => { setWineImageCount(null); }, [selectedWine?._id]);
-
-  const handleWineImagesLoaded = useCallback((count) => setWineImageCount(count), []);
-
   // A pending new wine has no _id, so there is no gallery to fetch — it is
   // definitionally photo-less and the encouraging copy applies straight away.
-  const registryHasPhotos = !!selectedWine?._id && wineImageCount > 0;
-  const photoPromptReady = !selectedWine?._id || wineImageCount !== null;
+  const selectedWineId = selectedWine?._id || null;
+  const wineImageCount = selectedWineId ? wineImageCounts[selectedWineId] : undefined;
+  const registryHasPhotos = wineImageCount > 0;
+  const photoPromptReady = !selectedWineId || wineImageCount !== undefined;
 
   // One row renderer for both the registry-search list and the AI near-match
   // list, so the two can never drift. Takes a SAVED wine only.
@@ -853,10 +852,16 @@ function AddBottle() {
             <div className="scan-wine-card">
               <div className={`scan-wine-image-wrap${scanMatchedWine?.image ? ' scan-wine-image-wrap--compare' : ''}`}>
                 <figure className="scan-wine-shot">
-                  {labelImage
-                    ? <img src={labelImage} alt={scanResult.extracted.name} className="scan-wine-label-img" />
-                    : <div className={`wine-row-placeholder scan-wine-placeholder ${scanResult.extracted.type || 'red'}`} />
-                  }
+                  {/* Wrapped so both shots have an identically sized slot: a
+                      failed image is hidden by WineImage's onError, and without
+                      a fixed box its column would collapse and knock the two
+                      captions off one baseline. */}
+                  <div className="scan-wine-shot-img-wrap">
+                    {labelImage
+                      ? <img src={labelImage} alt={scanResult.extracted.name} className="scan-wine-label-img" />
+                      : <div className={`wine-row-placeholder scan-wine-placeholder ${scanResult.extracted.type || 'red'}`} />
+                    }
+                  </div>
                   {scanMatchedWine?.image && (
                     <figcaption className="scan-wine-shot-caption">{t('addBottle.scanYourPhoto')}</figcaption>
                   )}
@@ -1297,12 +1302,17 @@ function AddBottle() {
                   already illustrate can see that first. The prompt is softened,
                   never removed: ~89% of the registry's official images started
                   as a user's bottle photo, and most wines still have none. */}
-              {selectedWine?._id && (
-                <div className="photo-existing">
+              {selectedWineId && (
+                // The wrapper's margin is applied only when something rendered:
+                // ImageGallery returns null while loading and when empty, and
+                // most wines have no photo, so an unconditional class left a
+                // gap in the common case. Keyed so a wine switch remounts.
+                <div className={registryHasPhotos ? 'photo-existing' : undefined}>
                   <ImageGallery
-                    wineDefinitionId={selectedWine._id}
+                    key={selectedWineId}
+                    wineDefinitionId={selectedWineId}
                     size="small"
-                    onLoaded={handleWineImagesLoaded}
+                    onLoaded={(count) => setWineImageCounts(prev => ({ ...prev, [selectedWineId]: count }))}
                   />
                 </div>
               )}


### PR DESCRIPTION
Pre-release audit over the v1.119.0 diff, in two passes: privacy of the endpoint #988 newly exposed to every user, and regression risk in AddBottle. Seven issues found; the ones that mattered are fixed here.

**Cleared by the audit** (no action needed): no refetch-per-keystroke (ImageGallery's effect deps are stable), no hook-order or key problems, the pending-new-wine path never calls the API with `undefined`, multi-bottle linking is untouched, and the back-label / partial-scan / not-the-right-wine flows are unaffected.

## Frontend

- **`onLoaded` never fired on a failed fetch.** A caller gating UI on it rendered *nothing at all, permanently*, whenever the endpoint errored — the whole photo prompt silently vanished. My own comment claimed the opposite. Now reports on every settled outcome.
- **Photo count is keyed by wine id.** The passive reset effect ran a render late, so the first commit after a wine switch painted the previous wine's answer — telling the user "we already have a photo" for a wine that has none. Keying also kills an out-of-order-response overwrite.
- **The photographer credit was invisible.** `.wine-row-credit` is `display:none`, revealed only by `.wine-row-img-wrap:hover`, which the new wrapper never matched. This surface is reached by pointing a camera at a label — it is phone-first, hover never fires. Attribution on someone else's photograph now stays visible.
- **A broken image no longer breaks the alignment** the previous commit existed to fix. Each shot has a fixed slot. Verified in a headless-Blink harness: caption delta **0px** both with images present and with the registry image 404ing, at desktop and at 375px.
- The gallery wrapper's margin now applies only when something rendered, instead of leaving a gap for the majority of wines that have no photo.

## Backend

- **`kind: 'label-scan'` is now excluded by name** on `GET /api/images/wine/:id`, rather than relying transitively on status/visibility. The MCP twin of this exact query already carries the guard and documents it as belt-and-braces; the REST copy — the one just exposed to every user — was the one without it.
- **Non-admins get a projection.** The full document shipped `uploadedBy`, which resolves to a username via `GET /api/users/public/:id` (profiles default to public), so every registry photo was attributable to a named account by anyone browsing a wine. Admin surfaces keep the full row; duplicate detection reads `contentHash`.
- **Two contentHash-keyed promotion paths could publish a label scan.** Admin image-delete and the duplicate-cleanup script both flip a row to `approved`+`public` without checking kind — and the delete path actively *prefers the same uploader*, which for a scan is the scanner. Since `/api/uploads` serves bytes unauthenticated by unguessable filename, a scan promoted that way would be permanently and anonymously fetchable. Both now exclude label scans.

## Testing

New backend suite pinning the endpoint's filter, which previously had **no test at all** — covers the label-scan exclusion, the projection, non-admin `?all=true`, sommelier-is-not-admin, and the admin branch.

- Backend: `images.wineGallery` + `images.pendingIdentity` + `admin/images.assign` + `imageOps` — 31 passing.
- Frontend: 952 passing across 60 files. Build clean.

## Not fixed, deliberately

- The admin `?all=true` branch renders private label-scan frames in AdminWines' carousel — pre-existing, admin-only, display-only (promotion is already blocked). Worth a separate look.
- ImageGallery is statically imported here while HeroImage/EditForm lazy-load it. AddBottle's own convention is static imports, so I left it.
- The step-2 gallery isn't refreshed after an upload — correct as-is, since uploads await approval and wouldn't appear in the public list.
- The reused `aiFoundWine` badge reads "Already in the registry" in English but "Match found" in de/fr/sv, so the message is weaker in translated UIs. Pre-existing key; flagging rather than touching non-en locales.