### PR TITLE
feat(supporters): thank people who take out a paid plan, once ever

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,10 @@ MEILI_MASTER_KEY=change-me-to-a-strong-random-string
 # MAILGUN_DOMAIN=mg.yourdomain.com
 # MAILGUN_FROM=Cellarion <no-reply@mg.yourdomain.com>
 # MAILGUN_API_URL=https://api.mailgun.net    # EU region: https://api.eu.mailgun.net
+# Reply-To for the one-off supporter thank-you. MAILGUN_FROM is usually a
+# no-reply address, and that email tells the recipient a reply reaches a person
+# — so this needs to be a mailbox somebody actually reads.
+# SUPPORT_REPLY_TO=info@yourdomain.com
 
 # Web Push (VAPID) — optional. Required for browser push notifications.
 # Generate keys once with: npx web-push generate-vapid-keys

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -92,6 +92,16 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: null
   },
+  // Set the first time this account is thanked for supporting the project, and
+  // never cleared. It is the ONLY thing that stops a second send: the plan
+  // webhook fires on renewals, payment-method changes and tier switches, so
+  // "have we already thanked them" cannot be inferred from the plan itself. A
+  // supporter who upgrades to patron has already been thanked and must not be
+  // thanked again.
+  supporterThankYouSentAt: {
+    type: Date,
+    default: null
+  },
   preferences: {
     currency: {
       type: String,

--- a/backend/src/routes/stripe.js
+++ b/backend/src/routes/stripe.js
@@ -3,6 +3,7 @@ const { requireAuth } = require('../middleware/auth');
 const User = require('../models/User');
 const StripeWebhookEvent = require('../models/StripeWebhookEvent');
 const { logAudit } = require('../services/audit');
+const { maybeSendSupporterThankYou } = require('../services/supporterThankYou');
 const { PLAN_RANK } = require('../utils/cellarCred');
 
 const router = express.Router();
@@ -306,6 +307,9 @@ router.post('/webhook', async (req, res) => {
               logAudit(null, 'stripe.plan.changed', { type: 'user', id: userId },
                 { event: 'checkout.session.completed', eventId: event.id, ...change });
               console.log(`[stripe] User ${userId} subscribed to ${plan} (effective: ${change.to})`);
+              // Once per account, ever — the guard lives in the service, not
+              // here, because this handler also runs on redeliveries.
+              await maybeSendSupporterThankYou(userId);
             }
           }
         }
@@ -325,6 +329,11 @@ router.post('/webhook', async (req, res) => {
             if (change) {
               logAudit(null, 'stripe.plan.changed', { type: 'user', id: userId },
                 { event: 'customer.subscription.updated', eventId: event.id, ...change });
+              // Covers anyone whose paid plan starts on this event rather than
+              // on checkout.session.completed. This case also fires on every
+              // renewal and on a supporter -> patron switch, so it leans
+              // entirely on the once-ever stamp to stay quiet.
+              await maybeSendSupporterThankYou(userId);
             }
           } else {
             // Active subscription whose price doesn't map to any known plan —

--- a/backend/src/scripts/send-supporter-thank-you.js
+++ b/backend/src/scripts/send-supporter-thank-you.js
@@ -1,0 +1,64 @@
+/**
+ * One-off backfill: thank the people who took out a paid plan before the
+ * automatic thank-you existed.
+ *
+ * Dry-run by default. Pass --apply to actually send.
+ *
+ *   docker compose exec -T backend node src/scripts/send-supporter-thank-you.js
+ *   docker compose exec -T backend node src/scripts/send-supporter-thank-you.js --apply
+ *
+ * Deliberately routed through the same maybeSendSupporterThankYou() the Stripe
+ * webhook uses, rather than calling the mailer directly: the once-ever claim is
+ * the whole safety property here, and a second implementation of it is a second
+ * chance to get it wrong. Running this twice sends nothing the second time, and
+ * anyone it reaches will never be picked up by the webhook path either.
+ */
+const mongoose = require('mongoose');
+const User = require('../models/User');
+const { maybeSendSupporterThankYou, PAID_PLANS } = require('../services/supporterThankYou');
+const { EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
+
+const APPLY = process.argv.includes('--apply');
+
+(async () => {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+
+  const pending = await User.find({
+    plan: { $in: PAID_PLANS },
+    supporterThankYouSentAt: null,
+  }).select('username email plan planStartedAt createdAt').sort({ createdAt: 1 });
+
+  console.log(`mail configured: ${EMAIL_VERIFICATION_ENABLED ? 'yes' : 'NO — nothing can be sent'}`);
+  console.log(`paid accounts never thanked: ${pending.length}`);
+  console.log('');
+
+  for (const u of pending) {
+    const since = (u.planStartedAt || u.createdAt || new Date()).toISOString().slice(0, 10);
+    console.log(`  ${u.username.padEnd(20)} ${String(u.plan).padEnd(10)} since ${since}  <${u.email}>`);
+  }
+  console.log('');
+
+  if (!APPLY) {
+    console.log('DRY RUN — nothing sent. Re-run with --apply to send.');
+    await mongoose.disconnect();
+    return;
+  }
+
+  if (!EMAIL_VERIFICATION_ENABLED) {
+    console.error('Mailgun is not configured — refusing to run so the once-ever stamp is not burned.');
+    process.exitCode = 1;
+    await mongoose.disconnect();
+    return;
+  }
+
+  let sent = 0, skipped = 0;
+  for (const u of pending) {
+    const ok = await maybeSendSupporterThankYou(u._id);
+    console.log(`  ${ok ? 'SENT   ' : 'skipped'} ${u.username} <${u.email}>`);
+    ok ? sent++ : skipped++;
+  }
+
+  console.log('');
+  console.log(`done — sent ${sent}, skipped ${skipped}`);
+  await mongoose.disconnect();
+})().catch(e => { console.error('FAILED:', e); process.exit(1); });

--- a/backend/src/services/mailgun.js
+++ b/backend/src/services/mailgun.js
@@ -519,4 +519,55 @@ async function sendSecurityAlertEmail(toEmail, trigger) {
   });
 }
 
-module.exports = { sendVerificationEmail, sendPasswordResetEmail, sendDrinkWindowDigest, sendRecommendationEmail, sendCellarInviteEmail, sendDiscussionReplyEmail, sendAccountLockoutAlert, sendSecurityAlertEmail, EMAIL_VERIFICATION_ENABLED };
+/**
+ * Thank someone for taking out a paid plan, and ask what they use and miss.
+ *
+ * Sent ONCE per account, ever — see User.supporterThankYouSentAt. This is a
+ * personal note, not a campaign, so it deliberately has no button, no banner
+ * and no marketing furniture.
+ *
+ * Reply-To is explicit and load-bearing: MAILGUN_FROM is unset in production,
+ * so FROM falls back to no-reply@, and the closing line promises a reply
+ * reaches a person. Without this header that promise is false.
+ *
+ * @param {string} toEmail
+ * @param {string} username
+ * @param {'supporter'|'patron'} tier - rendered verbatim, so nobody is called
+ *                                      the wrong thing after a tier switch
+ */
+async function sendSupporterThankYou(toEmail, username, tier) {
+  const replyTo = process.env.SUPPORT_REPLY_TO || 'info@cellarion.app';
+
+  await mg.messages.create(DOMAIN, {
+    from: FROM,
+    to: [toEmail],
+    'h:Reply-To': replyTo,
+    subject: 'Thanks for supporting Cellarion',
+    text: [
+      `Hi ${username},`,
+      '',
+      `You signed up as a ${tier} and I wanted to say thank you properly. Cellarion is a small project that a few friends and I build in our spare time, so it means a lot when someone decides it is worth paying for.`,
+      '',
+      'One thing I am curious about, if you have a minute: what do you use the most, and is there anything you are missing?',
+      '',
+      'There is no obligation to answer. You have already done the important part. If you do write back, it comes straight to me.',
+      '',
+      'Johan'
+    ].join('\n'),
+    html: `
+      <div style="font-family:sans-serif;max-width:480px;margin:0 auto;color:#2a2a2a;line-height:1.55;">
+        <p>Hi ${escapeHtml(username)},</p>
+        <p>You signed up as a ${escapeHtml(tier)} and I wanted to say thank you properly.
+           Cellarion is a small project that a few friends and I build in our spare time,
+           so it means a lot when someone decides it is worth paying for.</p>
+        <p>One thing I am curious about, if you have a minute: what do you use the most,
+           and is there anything you are missing?</p>
+        <p>There is no obligation to answer. You have already done the important part.
+           If you do write back, it comes straight to me.</p>
+        <p>Johan</p>
+      </div>
+    `
+  });
+}
+
+module.exports = { sendVerificationEmail, sendPasswordResetEmail, sendDrinkWindowDigest, sendRecommendationEmail, sendCellarInviteEmail, sendDiscussionReplyEmail, sendAccountLockoutAlert, sendSecurityAlertEmail, sendSupporterThankYou, EMAIL_VERIFICATION_ENABLED };

--- a/backend/src/services/supporterThankYou.js
+++ b/backend/src/services/supporterThankYou.js
@@ -1,0 +1,58 @@
+const User = require('../models/User');
+const { sendSupporterThankYou, EMAIL_VERIFICATION_ENABLED } = require('./mailgun');
+const { logAudit } = require('./audit');
+
+const PAID_PLANS = ['supporter', 'patron'];
+
+/**
+ * Thank a user for taking out a paid plan — at most once per account, ever.
+ *
+ * The plan webhook is not a "they just subscribed" signal: applyStripePlan runs
+ * on every customer.subscription.updated, which includes renewals, payment
+ * method changes and tier switches, and Stripe redelivers events on its own
+ * schedule. So the only durable answer to "have we already thanked them" is the
+ * stamp on the user, and a supporter who later upgrades to patron must not be
+ * thanked a second time.
+ *
+ * The stamp is claimed BEFORE the send, atomically. Under a redelivery two
+ * handlers can run concurrently; whichever matches `supporterThankYouSentAt:
+ * null` first wins and the other no-ops. The cost of that ordering is that a
+ * send which fails after the claim is never retried — deliberate, because a
+ * duplicate thank-you is more embarrassing to the sender than a missing one,
+ * and the failure is logged loudly enough to send by hand.
+ *
+ * Never throws: this runs off a billing webhook and a mail problem must never
+ * fail a payment.
+ *
+ * @param {string|ObjectId} userId
+ * @returns {Promise<boolean>} true if an email was actually sent
+ */
+async function maybeSendSupporterThankYou(userId) {
+  try {
+    // Checked BEFORE claiming. If mail is not configured (the default for a
+    // self-hosted install), claiming would burn the one chance this account
+    // ever gets — the stamp would say "thanked" for a mail that never left.
+    if (!EMAIL_VERIFICATION_ENABLED) return false;
+
+    const claimed = await User.findOneAndUpdate(
+      { _id: userId, plan: { $in: PAID_PLANS }, supporterThankYouSentAt: null },
+      { $set: { supporterThankYouSentAt: new Date() } },
+      { new: false }
+    ).select('email username plan');
+
+    if (!claimed) return false;          // already thanked, not paid, or gone
+    if (!claimed.email) return false;
+
+    await sendSupporterThankYou(claimed.email, claimed.username, claimed.plan);
+
+    logAudit(null, 'supporter.thank_you_sent', { type: 'user', id: claimed._id }, { plan: claimed.plan });
+    return true;
+  } catch (err) {
+    // The stamp is already set at this point, so this will not retry. Loud on
+    // purpose: the follow-up is to send that one by hand.
+    console.error(`[supporterThankYou] send FAILED for user ${userId} — stamp is set, will NOT retry:`, err.message);
+    return false;
+  }
+}
+
+module.exports = { maybeSendSupporterThankYou, PAID_PLANS };

--- a/backend/src/services/supporterThankYou.test.js
+++ b/backend/src/services/supporterThankYou.test.js
@@ -1,0 +1,115 @@
+/**
+ * The supporter thank-you must reach each account exactly once, ever.
+ *
+ * The plan webhook is a poor "they just subscribed" signal — it also fires on
+ * renewals, on payment-method changes, on a supporter -> patron switch, and
+ * again whenever Stripe redelivers an event. So every test here is really the
+ * same question from a different angle: can this send twice?
+ */
+
+jest.mock('../models/User', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('./mailgun', () => ({
+  sendSupporterThankYou: jest.fn().mockResolvedValue(undefined),
+  EMAIL_VERIFICATION_ENABLED: true,
+}));
+jest.mock('./audit', () => ({ logAudit: jest.fn() }));
+
+const User = require('../models/User');
+const { sendSupporterThankYou } = require('./mailgun');
+const { maybeSendSupporterThankYou } = require('./supporterThankYou');
+
+/** findOneAndUpdate(...).select(...) — resolves to `doc`, or null if unmatched. */
+const claimReturns = (doc) => {
+  User.findOneAndUpdate.mockReturnValue({ select: () => Promise.resolve(doc) });
+};
+
+const PAID_USER = { _id: 'u1', email: 'a@example.com', username: 'ann', plan: 'supporter' };
+
+beforeEach(() => jest.clearAllMocks());
+
+test('a first-time supporter is thanked, addressed by their actual tier', async () => {
+  claimReturns(PAID_USER);
+
+  await expect(maybeSendSupporterThankYou('u1')).resolves.toBe(true);
+  expect(sendSupporterThankYou).toHaveBeenCalledWith('a@example.com', 'ann', 'supporter');
+});
+
+test('the claim only matches an account that has NEVER been thanked', async () => {
+  claimReturns(PAID_USER);
+  await maybeSendSupporterThankYou('u1');
+
+  const [filter, update] = User.findOneAndUpdate.mock.calls[0];
+  // The null check is what makes this once-ever; without it every renewal sends.
+  expect(filter.supporterThankYouSentAt).toBeNull();
+  expect(filter.plan).toEqual({ $in: ['supporter', 'patron'] });
+  expect(update.$set.supporterThankYouSentAt).toBeInstanceOf(Date);
+});
+
+test('an account already thanked gets nothing', async () => {
+  claimReturns(null); // filter did not match — stamp already set
+
+  await expect(maybeSendSupporterThankYou('u1')).resolves.toBe(false);
+  expect(sendSupporterThankYou).not.toHaveBeenCalled();
+});
+
+test('upgrading supporter -> patron does NOT thank them again', async () => {
+  claimReturns(PAID_USER);
+  await maybeSendSupporterThankYou('u1');
+  expect(sendSupporterThankYou).toHaveBeenCalledTimes(1);
+
+  // The upgrade fires the webhook again; the stamp is now set, so the claim
+  // matches nothing.
+  claimReturns(null);
+  await maybeSendSupporterThankYou('u1');
+
+  expect(sendSupporterThankYou).toHaveBeenCalledTimes(1);
+});
+
+test('a redelivered webhook racing itself sends once', async () => {
+  // Whichever claim lands first wins; the loser sees no match.
+  let first = true;
+  User.findOneAndUpdate.mockImplementation(() => ({
+    select: () => Promise.resolve(first ? ((first = false), PAID_USER) : null),
+  }));
+
+  const results = await Promise.all([
+    maybeSendSupporterThankYou('u1'),
+    maybeSendSupporterThankYou('u1'),
+    maybeSendSupporterThankYou('u1'),
+  ]);
+
+  expect(results.filter(Boolean)).toHaveLength(1);
+  expect(sendSupporterThankYou).toHaveBeenCalledTimes(1);
+});
+
+test('an account with no email is never mailed', async () => {
+  claimReturns({ ...PAID_USER, email: null });
+
+  await expect(maybeSendSupporterThankYou('u1')).resolves.toBe(false);
+  expect(sendSupporterThankYou).not.toHaveBeenCalled();
+});
+
+test('a mail failure never propagates — billing must not break', async () => {
+  claimReturns(PAID_USER);
+  sendSupporterThankYou.mockRejectedValueOnce(new Error('mailgun 500'));
+
+  await expect(maybeSendSupporterThankYou('u1')).resolves.toBe(false);
+});
+
+describe('when mail is not configured (the self-hosted default)', () => {
+  test('the stamp is not claimed, so the one chance is not burned', async () => {
+    jest.resetModules();
+    jest.doMock('./mailgun', () => ({
+      sendSupporterThankYou: jest.fn(),
+      EMAIL_VERIFICATION_ENABLED: false,
+    }));
+    jest.doMock('../models/User', () => ({ findOneAndUpdate: jest.fn() }));
+    jest.doMock('./audit', () => ({ logAudit: jest.fn() }));
+
+    const UserOff = require('../models/User');
+    const { maybeSendSupporterThankYou: fn } = require('./supporterThankYou');
+
+    await expect(fn('u1')).resolves.toBe(false);
+    expect(UserOff.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -129,6 +129,11 @@ const REGISTRY = [
           roles: u.roles,
           plan: u.plan,
           stripeSubscriptionId: u.stripeSubscriptionId || null,
+          // When we sent the one-off supporter thank-you. Included because the
+          // export is an explicit field pick, so anything omitted here is
+          // simply absent from a subject access request — and "we emailed you
+          // on this date" is processing history the user is entitled to see.
+          supporterThankYouSentAt: u.supporterThankYouSentAt || null,
           preferences: u.preferences,
           profileVisibility: u.profileVisibility,
           emailVerified: u.emailVerified,


### PR DESCRIPTION
A one-off personal note when someone becomes a supporter or patron, asking what they use and what they miss.

## The email

> **Subject: Thanks for supporting Cellarion**
>
> Hi {{username}},
>
> You signed up as a {{tier}} and I wanted to say thank you properly. Cellarion is a small project that a few friends and I build in our spare time, so it means a lot when someone decides it is worth paying for.
>
> One thing I am curious about, if you have a minute: what do you use the most, and is there anything you are missing?
>
> There is no obligation to answer. You have already done the important part. If you do write back, it comes straight to me.
>
> Johan

`{{tier}}` renders from the user's actual plan, so nobody is called the wrong thing after a tier switch. No button, no banner, no marketing furniture — it is a personal note and should read as one.

## Once per account, ever

The plan webhook is a poor *"they just subscribed"* signal. `applyStripePlan` also runs on renewals, on payment-method changes and on a supporter → patron switch, and Stripe redelivers events on its own schedule. So the guard cannot be the call site — it is a stamp on the user (`supporterThankYouSentAt`), **claimed atomically before the send**. Under a redelivery two handlers race and only the one matching a null stamp proceeds.

The cost of claiming first is that a send which fails afterwards is never retried. That is deliberate: a duplicate thank-you is more embarrassing than a missing one, and the failure logs loudly enough to send that one by hand.

## Details worth checking in review

- **Reply-To is explicit** (`SUPPORT_REPLY_TO`, default `info@cellarion.app`). `MAILGUN_FROM` is unset in production, so `FROM` falls back to `no-reply@` — and the email tells the reader a reply reaches a person. Without the header that sentence is a lie.
- **Mail config is checked before claiming.** On a self-hosted install with no Mailgun, claiming first would burn the account's one chance on a mail that never left.
- **Never throws** — it runs off a billing webhook, and a mail problem must not fail a payment.
- **Wired into the two upgrade paths only**, never `customer.subscription.deleted`.
- **GDPR:** `supporterThankYouSentAt` added to the export. That fragment is an explicit field pick, so anything unlisted is simply absent from a subject access request, and "we emailed you on this date" is processing history the user is entitled to. Deletion needs no change — the account row goes wholesale.

## Backfill

`scripts/send-supporter-thank-you.js` covers accounts that predate this. Dry-run by default; `--apply` sends. It routes through the **same** guard rather than mailing directly, so it cannot double-send, cannot collide with the webhook path, and anyone it reaches is permanently excluded from the automatic one.

## Testing

New suite, 8 tests, all aimed at the same question from different angles — can this send twice? Covers first send, the null-stamp claim shape, an already-thanked account, **supporter → patron**, a redelivered webhook racing itself, a missing email, a mail failure not propagating, and the unconfigured-mail case not burning the stamp.

Backend: `supporterThankYou` + `stripe` + `userDataRegistry` + `User` — 62 passing.