### PR TITLE
fix(scripts): let audit writes settle before disconnecting

### DIFF
--- a/backend/src/scripts/consolidate-producer-displays.js
+++ b/backend/src/scripts/consolidate-producer-displays.js
@@ -226,5 +226,11 @@ const hasLegal = (s) => toks(s).some((t) => LEGAL.has(t));
   console.log(`[consolidate-producer-displays] written=${written} failed=${failed} blocked=${blocked}`);
   console.log('NOTE: producer is in the embedding text — start the embedding job (incremental) via POST /api/admin/ai/embed/start.');
 
+  // logAudit persists fire-and-forget, which suits a long-lived server and not
+  // a script that exits: disconnecting immediately races the last writes and
+  // silently drops audit rows for work that really happened (observed on the
+  // 2026-08-17 supporter backfill). Let them settle first.
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
   await mongoose.disconnect();
 })().catch((e) => { console.error('ERR:', e.stack); process.exit(1); });

--- a/backend/src/scripts/normalize-region-to-appellation.js
+++ b/backend/src/scripts/normalize-region-to-appellation.js
@@ -141,5 +141,12 @@ const { logAudit } = require('../services/audit');
   }
   console.log(`Applied ${written} region rewrites.`);
   console.log('Region is part of the embedding text — start an incremental embed job to refresh Qdrant.');
+
+  // logAudit persists fire-and-forget, which suits a long-lived server and not
+  // a script that exits: disconnecting immediately races the last writes and
+  // silently drops audit rows for work that really happened (observed on the
+  // 2026-08-17 supporter backfill). Let them settle first.
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
   await mongoose.disconnect();
 })();

--- a/backend/src/scripts/send-supporter-thank-you.js
+++ b/backend/src/scripts/send-supporter-thank-you.js
@@ -60,5 +60,14 @@ const APPLY = process.argv.includes('--apply');
 
   console.log('');
   console.log(`done — sent ${sent}, skipped ${skipped}`);
+
+  // logAudit persists fire-and-forget (AuditLog.create(...).catch()), which is
+  // right for a long-lived server and wrong for a script that exits. On the
+  // 2026-08-17 backfill the disconnect below raced the last write and one of
+  // three audit rows never reached MongoDB — the emails and the stamps were
+  // all correct, but the trail was short a row. Give the in-flight writes a
+  // moment to settle before pulling the connection out from under them.
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
   await mongoose.disconnect();
 })().catch(e => { console.error('FAILED:', e); process.exit(1); });


### PR DESCRIPTION
`logAudit` persists fire-and-forget (`AuditLog.create(...).catch()`). That is correct for a long-lived server and wrong for a script that exits — calling `mongoose.disconnect()` straight after the work races the in-flight writes, and the rows vanish with a `MongoNotConnectedError` on the way out.

**Caught in production today.** The supporter backfill sent three emails and wrote three `supporterThankYouSentAt` stamps, but only **two of three** audit rows reached MongoDB. Nothing user-visible went wrong and the stdout audit stream had all three — only the queryable copy was short. A migration that silently under-records what it did is worse than one that fails loudly.

**Two already-executed migrations have the same shape** and have probably lost trailing rows the same way:
- `consolidate-producer-displays.js` — 199 rewrites, run 2026-08-14
- `normalize-region-to-appellation.js" — 547 rewrites, run 2026-08-16

Fix is the same in all three: give the in-flight writes a moment before pulling the connection.

Deliberately **not** doing the larger thing — making `logAudit` awaitable — because it is the funnel every mutation in the app flows through, and changing its contract to fix three scripts is the wrong trade. If script audit fidelity becomes load-bearing, an explicit `flushAudit()` would be the honest version.

No behaviour change to any server path.