### PR TITLE
fix(registry): estate-name pollution guard (curation R3)

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -90,11 +90,13 @@ Wine: {{name}}
 Producer: {{producer}}
 {{vintage}}{{country}}
 Return ONLY a raw JSON object (no markdown, no code fences):
-{"name":"wine name","producer":"producer name","country":"country or null","region":"region or null","appellation":"appellation or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
+{"name":"wine name","producer":"producer name","country":"country or null","region":"region or null","appellation":"appellation or null","classification":"official classification or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
 
 Rules:
 - Use the wine name and producer exactly as given (correct only obvious typos)
 - The name field must contain ONLY the wine's own cuvée/vineyard/variety name — never prepend or repeat the producer in it. If the given name starts with the producer name, strip that prefix (producer "Penfolds" + name "Penfolds Bin 407" → name "Bin 407")
+- EXCEPTION — estate wines with no separate cuvée name (a Bordeaux classed-growth Château, a Quinta): the estate name IS the wine's name, so name and producer being identical is CORRECT (producer "Château Talbot" → name "Château Talbot"). Never fill the name with something else just to avoid the repetition: the name must NEVER be an appellation ("Margaux", "Saint-Julien") or a classification ("Grand Cru Classé", "Cru Bourgeois") standing in for a real name
+- classification: the wine's official classification when you know it ("4ème Cru Classé", "Grand Cru Classé de Graves", "Cru Bourgeois", "Premier Grand Cru Classé B"), else null. It never goes in the name
 - NEVER change the wine into a different wine: do not add a grape variety, cuvée, or vineyard to the name that the given data does not mention, and do not substitute another wine from the same producer. If the given name does not match a wine this producer actually makes, keep the name as given rather than "correcting" it to a similar-sounding wine
 - Production-method terms are NOT part of the name — move "Méthode Cap Classique" / "Cap Classique", "Méthode Traditionnelle", "Metodo Classico" / "Traditional Method" to the appellation field (name "Blanc de Blancs" + appellation "Méthode Cap Classique"). Aging classifications that belong to the displayed name (Reserva, Gran Reserva, Riserva, Spätlese, Grosses Gewächs) and dosage words that are part of a cuvée name (e.g. "Brut Premier") stay in the name
 - Fill in country, region, appellation, type, and grapes from your wine knowledge — but ONLY what you actually know about THIS wine. A field you are not reasonably sure of is null, never a guess
@@ -114,11 +116,13 @@ const DEFAULT_TEXT_SEARCH_PROMPT =
 
 Identify the wine they are looking for and return complete details.
 Return ONLY a raw JSON object (no markdown, no code fences, no extra text):
-{"name":"wine name","producer":"producer name","country":"country","region":"region or null","appellation":"appellation or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
+{"name":"wine name","producer":"producer name","country":"country","region":"region or null","appellation":"appellation or null","classification":"official classification or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
 
 Rules:
 - Extract the wine name and producer from the query
 - The name field must contain ONLY the wine's own cuvée/vineyard/variety name — never prepend or repeat the producer in it (producer "Penfolds" + name "Bin 407", NOT name "Penfolds Bin 407")
+- EXCEPTION — estate wines with no separate cuvée name (a Bordeaux classed-growth Château, a Quinta): the estate name IS the wine's name, so name and producer being identical is CORRECT. The name must NEVER be an appellation ("Margaux") or a classification ("Grand Cru Classé") standing in for a real name
+- classification: the wine's official classification when you know it ("4ème Cru Classé", "Cru Bourgeois"), else null. It never goes in the name
 - Do not add a grape variety or cuvée to the name that the query does not mention, and do not substitute a different wine from the same producer
 - Production-method terms are NOT part of the name — move "Méthode Cap Classique" / "Cap Classique", "Méthode Traditionnelle", "Metodo Classico" / "Traditional Method" to the appellation field (name "Blanc de Blancs" + appellation "Méthode Cap Classique"). Aging classifications (Reserva, Gran Reserva, Riserva, Spätlese, Grosses Gewächs) and dosage words that are part of a cuvée name (e.g. "Brut Premier") stay in the name
 - Fill in country, region, appellation, type, and grapes from your wine knowledge

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -568,6 +568,10 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
               country: wineData.country,
               region: lowGeoConfidence ? null : wineData.region,
               appellation: lowGeoConfidence ? null : wineData.appellation,
+              // Same floor as geography: a classification is an assertion of
+              // knowledge, and below the floor the model is inferring
+              // (ticket 6a83f014 added the field to the identify prompt).
+              classification: lowGeoConfidence ? null : (wineData.classification || null),
               type: wineData.type,
               grapes: wineData.grapes,
               confidence: wineData.confidence,
@@ -1016,6 +1020,7 @@ router.post('/confirm', async (req, res) => {
               country: str(ai.country),
               region: str(ai.region),
               appellation: str(ai.appellation),
+              classification: str(ai.classification),
               type: str(ai.type),
               grapes: sanitizeGrapeNames(ai.grapes),
             }, req.user.id, { createdVia: 'import', allowPending: true });

--- a/backend/src/scripts/fix-classification-polluted-names.js
+++ b/backend/src/scripts/fix-classification-polluted-names.js
@@ -1,0 +1,96 @@
+/**
+ * fix-classification-polluted-names.js
+ *
+ * Ticket 6a83f014: registry wines whose `name` holds an appellation or a
+ * Bordeaux classed-growth phrase instead of the wine's name ("Grand Cru
+ * Classé de Graves" — Château Pape Clément; "Margaux" — Château du Tertre).
+ * Prevention now lives in findOrCreateWine.unpolluteEstateName (the mint
+ * chokepoint); this applies the SAME shared guard to existing rows, so the
+ * backfill and the mint rule cannot drift.
+ *
+ * Per changed row: name/appellation/classification shift per the guard, the
+ * normalizedKey regenerates (name feeds the dedup key), and Meili reindexes.
+ * A collision on the new key (a correctly-named twin already in the registry)
+ * is SKIPPED and reported for manual merge — this script never merges wines.
+ *
+ * Dry-run by default; --apply writes a JSON backup of affected rows first.
+ *
+ * Usage:
+ *   node src/scripts/fix-classification-polluted-names.js            # dry run
+ *   node src/scripts/fix-classification-polluted-names.js --apply
+ */
+
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const { unpolluteEstateName } = require('../services/findOrCreateWine');
+const { generateWineKey } = require('../utils/normalize');
+
+const APPLY = process.argv.includes('--apply');
+const tag = APPLY ? '✔' : '[dry]';
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log(`Connected. Mode: ${APPLY ? 'APPLY' : 'DRY RUN (pass --apply to execute)'}\n`);
+
+  const wines = await WineDefinition
+    .find({ nonWine: { $ne: true }, producer: { $nin: [null, ''] } })
+    .select('name producer appellation classification normalizedKey')
+    .lean();
+
+  const stats = { scanned: 0, changed: 0, collisions: 0, byShape: {} };
+  const backup = [];
+
+  for (const w of wines) {
+    stats.scanned += 1;
+    const out = await unpolluteEstateName({
+      name: w.name, producer: w.producer,
+      appellation: w.appellation || null, classification: w.classification || null,
+    });
+    if (!out.changed) continue;
+
+    const newKey = generateWineKey(out.name, w.producer, out.appellation || '');
+    const clash = await WineDefinition.findOne({ normalizedKey: newKey, _id: { $ne: w._id } }).select('_id name').lean();
+    if (clash) {
+      stats.collisions += 1;
+      console.log(`  ⚠ collision (manual merge): "${w.name}" — ${w.producer} → key of ${clash._id} ("${clash.name}")`);
+      continue;
+    }
+
+    stats.changed += 1;
+    stats.byShape[out.changed] = (stats.byShape[out.changed] || 0) + 1;
+    console.log(`${tag} [${out.changed}] "${w.name}" — ${w.producer}`);
+    console.log(`      → name "${out.name}" · appellation "${out.appellation || '∅'}" · classification "${out.classification || '∅'}"`);
+    backup.push({ _id: String(w._id), name: w.name, appellation: w.appellation || null, classification: w.classification || null, normalizedKey: w.normalizedKey });
+
+    if (APPLY) {
+      await WineDefinition.updateOne(
+        { _id: w._id },
+        { $set: {
+          name: out.name,
+          appellation: out.appellation || null,
+          classification: out.classification || null,
+          normalizedKey: newKey,
+        } }
+      );
+      try { await require('../services/search').indexWine(w._id); } catch { /* best-effort */ }
+    }
+  }
+
+  if (APPLY && backup.length) {
+    const file = path.join(os.tmpdir(), `polluted-names-backup-${Date.now()}.json`);
+    fs.writeFileSync(file, JSON.stringify(backup, null, 2));
+    console.log(`\nBackup of ${backup.length} rows → ${file} (container /tmp is ephemeral — copy it off)`);
+  }
+
+  console.log(`\nSummary: ${stats.scanned} scanned, ${stats.changed} ${APPLY ? 'fixed' : 'would change'} ` +
+    `(${Object.entries(stats.byShape).map(([s, n]) => `${s}: ${n}`).join(', ') || 'none'}), ` +
+    `${stats.collisions} collisions left for manual merge.`);
+  if (APPLY) console.log('Next: the changed rows re-key + reindexed inline; run an incremental embed if descriptions exist for them.');
+  await mongoose.disconnect();
+}
+
+run().catch((err) => { console.error('Fix polluted names failed:', err); process.exit(1); });

--- a/backend/src/scripts/rehold-low-confidence-profiles.js
+++ b/backend/src/scripts/rehold-low-confidence-profiles.js
@@ -30,10 +30,21 @@
  * aiProfile values first (restore = re-publish from backup, or a somm
  * release from the admin queue).
  *
+ * --reasons=a,b restricts WHICH gate reasons re-hold (default: all). The
+ * 2026-08-18 prod run used --reasons=low_confidence,unknown_low_confidence:
+ * 57 published producer_suspect rows in the window carried no
+ * profileReviewedAt stamp but matched the v1.118 human-release batch
+ * (98/102 held profiles published 08-17) — indistinguishable from
+ * slipped-through, and they already surface in the admin queue's suspect
+ * branch, so the human decides those; the gate's own two confidence classes
+ * are what re-holds. Rows matching an excluded reason are counted and
+ * reported, never touched.
+ *
  * Usage:
  *   node src/scripts/rehold-low-confidence-profiles.js                 # dry run
  *   node src/scripts/rehold-low-confidence-profiles.js --apply
  *   node src/scripts/rehold-low-confidence-profiles.js --cutoff=2026-08-01
+ *   node src/scripts/rehold-low-confidence-profiles.js --reasons=low_confidence,unknown_low_confidence --apply
  */
 
 require('dotenv').config();
@@ -50,6 +61,8 @@ const { embedSinglePair } = require('../services/embeddingJob');
 const APPLY = process.argv.includes('--apply');
 const cutoffArg = (process.argv.find((a) => a.startsWith('--cutoff=')) || '').slice('--cutoff='.length);
 const CUTOFF = new Date(cutoffArg || '2026-08-16T00:00:00Z');
+const reasonsArg = (process.argv.find((a) => a.startsWith('--reasons=')) || '').slice('--reasons='.length);
+const REASONS = reasonsArg ? new Set(reasonsArg.split(',').map((s) => s.trim()).filter(Boolean)) : null;
 const tag = APPLY ? '✔' : '[dry]';
 
 async function run() {
@@ -91,6 +104,11 @@ async function run() {
       { floor, unknownBar }
     );
     if (!reason) continue;
+    if (REASONS && !REASONS.has(reason)) {
+      stats.excluded = stats.excluded || {};
+      stats.excluded[reason] = (stats.excluded[reason] || 0) + 1;
+      continue;
+    }
 
     stats.reheld += 1;
     stats.byReason[reason] = (stats.byReason[reason] || 0) + 1;
@@ -146,7 +164,8 @@ async function run() {
   console.log(`\nSummary: ${stats.scanned} published AI profiles in the window, ` +
     `${stats.reheld} ${APPLY ? 're-held' : 'would be re-held'} ` +
     `(${Object.entries(stats.byReason).map(([r, n]) => `${r}: ${n}`).join(', ') || 'none'}), ` +
-    `${stats.reviewedSkipped} skipped as human-reviewed.`);
+    `${stats.reviewedSkipped} skipped as human-reviewed` +
+    `${stats.excluded ? `, excluded by --reasons: ${Object.entries(stats.excluded).map(([r, n]) => `${r}: ${n}`).join(', ')}` : ''}.`);
   if (APPLY) console.log('Owners of affected bottles now see "Not yet assessed"; release the good ones from Admin → Wines → low-confidence queue.');
   await mongoose.disconnect();
 }

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -25,7 +25,7 @@ const { canonicalizeWineName } = require('../utils/producerPrefix');
 const { computeCanonicalKey, canonicalSiblingPrefix } = require('../utils/wineIdentity');
 const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
 const { resolveCanonicalProducerSpelling } = require('./producerSpelling');
-const { resolveCanonicalAppellation } = require('./appellationResolve');
+const { resolveCanonicalAppellation, candidateKeys } = require('./appellationResolve');
 const { escapeRegex } = require('../utils/sanitize');
 
 // Auto-match when combined score >= SIMILARITY_THRESHOLD (near-identical — e.g.
@@ -237,6 +237,71 @@ async function findOrCreateGrapes(rawNames, userId) {
  *   surfaces (routes/admin/wines.js, routes/admin/wineRequests.js, MCP
  *   admin_add_registry_wine): a curator typing "Bordeaux" as producer SHOULD be told.
  */
+// ── Estate-name pollution guard (ticket 6a83f014) ───────────────────────────
+//
+// Four Bordeaux classed growths arrived as name "Grand Cru Classé (de
+// Graves)" / "Margaux" with the château in the producer field: the identify
+// prompts' "never repeat the producer in the name" rule left the model
+// nothing else on an estate label to reach for, so it grabbed the
+// classification or the appellation. Two NARROW, high-precision shapes only:
+//
+//   (a) the ENTIRE name is a Bordeaux classed-growth phrase. No real wine is
+//       named "Grand Cru Classé" — the phrase moves to classification (when
+//       that is empty) and the name falls back to the estate. Deliberately
+//       narrow vocabulary: "Reserva"/"Riserva"/bare "Premier Cru" are real
+//       name material elsewhere (Rioja, Champagne co-op cuvées) and are NOT
+//       matched.
+//   (b) a CHÂTEAU producer whose "name" resolves to a curated appellation.
+//       Château wines are named by the estate; the appellation belongs in its
+//       own field. Gated on the château word deliberately — for négociants
+//       (Jadot, Drouhin) and Burgundy domaines an appellation IS the wine's
+//       legitimate name, so 'domaine'/plain producers never match.
+//
+// Both shapes end in the estate convention name === producer (the ~139-row
+// legitimate cohort in utils/nameChecks name-equals-producer-estate.v1).
+// Shared with scripts/fix-classification-polluted-names.js so the mint guard
+// and the backfill cannot drift.
+const CLASSIFICATION_ONLY_NAME_RX =
+  /^(?:(?:grand|premier|deuxi[eè]me|troisi[eè]me|quatri[eè]me|cinqui[eè]me|1er|[2-5][eè]?me)\s+)?(?:grand\s+)?cru\s+(?:class[ée]|bourgeois)(?:\s+(?:de\s+graves|de\s+saint[- ][ée]milion|sup[ée]rieur|exceptionnel|en\s+\d{4}))?$/i;
+
+/**
+ * @returns {Promise<{name, appellation, classification, changed: false|'classification_as_name'|'appellation_as_name'}>}
+ *   Field values with the pollution shifted out, or the inputs untouched.
+ *   `appellation` comes back canonicalised (curated spelling) when set by (b).
+ */
+async function unpolluteEstateName({ name, producer, appellation, classification }) {
+  const unchanged = { name, appellation, classification, changed: false };
+  if (!producer || !name) return unchanged;
+  if (normalizeString(name) === normalizeString(producer)) return unchanged; // already the estate form
+
+  // (a) classification-only name — any producer shape.
+  if (CLASSIFICATION_ONLY_NAME_RX.test(name)) {
+    return {
+      name: producer,
+      appellation,
+      classification: (typeof classification === 'string' && classification.trim()) ? classification : name,
+      changed: 'classification_as_name',
+    };
+  }
+
+  // (b) château producer + a name that IS a curated appellation.
+  if ((normalizeString(producer).split(' ')[0] || '') !== 'chateau') return unchanged;
+  const nameKey = normalizeAppellationKey(normalizeAppellation(name) || name);
+  if (!nameKey) return unchanged;
+  const keys = candidateKeys(nameKey);
+  const hit = await Appellation.exists({
+    $or: [{ normalizedName: { $in: keys } }, { normalizedSynonyms: { $in: keys } }],
+  });
+  if (!hit) return unchanged;
+  const resolved = await resolveCanonicalAppellation(normalizeAppellation(name) || name);
+  return {
+    name: producer,
+    appellation: (typeof appellation === 'string' && appellation.trim()) ? appellation : resolved,
+    classification,
+    changed: 'appellation_as_name',
+  };
+}
+
 async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes, classification }, userId, { confirmCreate = false, skipSiblingMatch = false, matchOnly = false, createdVia = null, allowPending = false } = {}) {
   // Internal whitespace collapses too, not just the ends: a double space is
   // invisible in every UI and every normalized key, so "Wrights  Estate" and
@@ -282,6 +347,22 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // "Felton Road Wines Ltd" — which the exact-string strip can't see (the
   // shape behind most July-2026 prod duplicates).
   trimmedName = canonicalizeWineName(trimmedName, trimmedProducer);
+
+  // Registry canon, name-field twin of the misplaced-producer gate below
+  // (ticket 6a83f014): shift a classification/appellation out of the name
+  // BEFORE any matching, so the corrected identity drives dedup keys instead
+  // of minting a wine named "Grand Cru Classé". See unpolluteEstateName.
+  if (!producerMissing && trimmedProducer) {
+    const shifted = await unpolluteEstateName({
+      name: trimmedName, producer: trimmedProducer,
+      appellation: trimmedAppellation, classification,
+    });
+    if (shifted.changed) {
+      trimmedName = shifted.name.slice(0, MAX_FIELD);
+      trimmedAppellation = shifted.appellation || trimmedAppellation;
+      classification = shifted.classification;
+    }
+  }
 
   // Different-country guard for every non-exact auto-link below: an identical
   // canonical producer+name can still be two wineries (Domaine Chandon, Napa
@@ -747,4 +828,5 @@ module.exports = {
   regionForAppellation,
   pendingProducerKey,
   pendingWineKey,
+  unpolluteEstateName,
 };

--- a/backend/src/services/findOrCreateWine.unpollute.test.js
+++ b/backend/src/services/findOrCreateWine.unpollute.test.js
@@ -1,0 +1,139 @@
+/**
+ * unpolluteEstateName — the estate-name pollution guard (ticket 6a83f014).
+ *
+ * Four Bordeaux classed growths arrived as name "Grand Cru Classé (de
+ * Graves)" / "Margaux" with the château in producer. The guard's precision
+ * rules ARE the feature: négociant and Burgundy-domaine appellation-names are
+ * legitimate and must never match, and the narrow classification vocabulary
+ * must not eat real name material (Reserva, bare Premier Cru).
+ */
+jest.mock('../models/WineDefinition', () => {
+  const ctor = jest.fn();
+  ctor.findOne = jest.fn(); ctor.find = jest.fn(); ctor.aggregate = jest.fn();
+  return ctor;
+});
+jest.mock('../models/Country', () => ({ findOne: jest.fn(), find: jest.fn(), exists: jest.fn() }));
+jest.mock('../models/Region', () => ({ findOne: jest.fn(), find: jest.fn(), exists: jest.fn() }));
+jest.mock('../models/Grape', () => ({ findOne: jest.fn(), find: jest.fn() }));
+jest.mock('../models/Appellation', () => ({ exists: jest.fn(), find: jest.fn() }));
+jest.mock('./search', () => ({ getIsAvailable: jest.fn(), search: jest.fn(), indexWine: jest.fn() }));
+jest.mock('./wineMatching', () => ({ scoreAllMatches: jest.fn() }));
+jest.mock('./grapeInference', () => ({ buildSurfaceForms: jest.fn(), inferGrapeIds: jest.fn() }));
+jest.mock('./producerSpelling', () => ({ resolveCanonicalProducerSpelling: jest.fn() }));
+
+const Appellation = require('../models/Appellation');
+const { unpolluteEstateName } = require('./findOrCreateWine');
+
+// The resolver's lookup chain (resolveCanonicalAppellation → Appellation.find)
+const findChain = (docs) => ({
+  select: jest.fn().mockReturnValue({
+    sort: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(docs) }),
+    }),
+  }),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Appellation.exists.mockResolvedValue(null);
+  Appellation.find.mockReturnValue(findChain([]));
+});
+
+describe('shape (a): the entire name is a classed-growth phrase', () => {
+  test.each([
+    'Grand Cru Classé',
+    'Grand Cru Classé de Graves',
+    'Cru Bourgeois',
+    '4ème Cru Classé',
+    '1er Grand Cru Classé',
+    'grand cru classe', // unaccented import data
+  ])('"%s" moves to classification, name falls back to the estate', async (bad) => {
+    const out = await unpolluteEstateName({
+      name: bad, producer: 'Château Pape Clément', appellation: null, classification: null,
+    });
+    expect(out.changed).toBe('classification_as_name');
+    expect(out.name).toBe('Château Pape Clément');
+    expect(out.classification).toBe(bad);
+  });
+
+  test('an existing classification is never overwritten by the shifted name', async () => {
+    const out = await unpolluteEstateName({
+      name: 'Grand Cru Classé', producer: 'Château Talbot', appellation: 'Saint-Julien', classification: '4ème Cru Classé',
+    });
+    expect(out.classification).toBe('4ème Cru Classé');
+    expect(out.name).toBe('Château Talbot');
+  });
+
+  test('real name material is NOT in the vocabulary: Reserva, Riserva, bare Premier Cru', async () => {
+    for (const legit of ['Reserva', 'Riserva', 'Premier Cru', 'Gran Reserva']) {
+      const out = await unpolluteEstateName({
+        name: legit, producer: 'Marqués de Riscal', appellation: null, classification: null,
+      });
+      expect(out.changed).toBe(false);
+      expect(out.name).toBe(legit);
+    }
+  });
+});
+
+describe('shape (b): château producer + curated-appellation name', () => {
+  test('name "Margaux" on Château du Tertre becomes the estate name + appellation', async () => {
+    Appellation.exists.mockResolvedValue({ _id: 'x' });
+    Appellation.find.mockReturnValue(findChain([{ name: 'Margaux' }]));
+    const out = await unpolluteEstateName({
+      name: 'Margaux', producer: 'Château du Tertre', appellation: null, classification: null,
+    });
+    expect(out.changed).toBe('appellation_as_name');
+    expect(out.name).toBe('Château du Tertre');
+    expect(out.appellation).toBe('Margaux');
+  });
+
+  test('a populated appellation is kept, not overwritten (the Phélan Ségur shape)', async () => {
+    Appellation.exists.mockResolvedValue({ _id: 'x' });
+    const out = await unpolluteEstateName({
+      name: 'Saint Estephe', producer: 'Chateau Phelan Segur', appellation: 'Saint-Estèphe', classification: null,
+    });
+    expect(out.changed).toBe('appellation_as_name');
+    expect(out.name).toBe('Chateau Phelan Segur');
+    expect(out.appellation).toBe('Saint-Estèphe');
+  });
+
+  test('NÉGOCIANT appellation-names never match — the gate is the château word', async () => {
+    Appellation.exists.mockResolvedValue({ _id: 'x' }); // even though the doc exists
+    const out = await unpolluteEstateName({
+      name: 'Chassagne-Montrachet', producer: 'Louis Jadot', appellation: null, classification: null,
+    });
+    expect(out.changed).toBe(false);
+    expect(Appellation.exists).not.toHaveBeenCalled();
+  });
+
+  test('Burgundy DOMAINES keep appellation-names too — domaine is deliberately not in the gate', async () => {
+    Appellation.exists.mockResolvedValue({ _id: 'x' });
+    const out = await unpolluteEstateName({
+      name: 'Gevrey-Chambertin', producer: 'Domaine Rossignol-Trapet', appellation: null, classification: null,
+    });
+    expect(out.changed).toBe(false);
+  });
+
+  test('a château name that matches NO curated appellation passes through (a real cuvée)', async () => {
+    Appellation.exists.mockResolvedValue(null);
+    const out = await unpolluteEstateName({
+      name: 'Les Forts de Latour', producer: 'Château Latour', appellation: null, classification: null,
+    });
+    expect(out.changed).toBe(false);
+    expect(out.name).toBe('Les Forts de Latour');
+  });
+});
+
+describe('pass-through shapes', () => {
+  test('the estate form itself (name === producer) is already canon — untouched', async () => {
+    const out = await unpolluteEstateName({
+      name: 'Château Talbot', producer: 'Château Talbot', appellation: null, classification: null,
+    });
+    expect(out.changed).toBe(false);
+  });
+
+  test('missing producer or name never rewrites', async () => {
+    expect((await unpolluteEstateName({ name: 'Margaux', producer: '', appellation: null, classification: null })).changed).toBe(false);
+    expect((await unpolluteEstateName({ name: '', producer: 'Château X', appellation: null, classification: null })).changed).toBe(false);
+  });
+});


### PR DESCRIPTION
Third slice of the curation rethink — somm ticket **6a83f014** (import writes appellation/classification into `name`).

## Mechanism (confirmed from the ticket's four wine_ids)
All four are Bordeaux classed growths where the label's only distinct string besides the château is the classification or appellation — and both identify prompts order "never repeat the producer in the name", leaving the model nothing legitimate to reach for on an estate wine. `name === producer` is the **correct** registry convention for these (the ~139-row `name-equals-producer-estate.v1` cohort).

## Fix, three layers
1. **Mint guard** `unpolluteEstateName` in findOrCreateWine, before any matching/keys. Two narrow shapes: (a) name IS a classed-growth phrase → moves to `classification`, name := estate (vocabulary deliberately excludes Reserva/Riserva/bare Premier Cru — real name material); (b) **château**-worded producer + name resolving to a curated appellation → estate form + appellation in its field. Gated on the château word because négociants (Jadot "Chassagne-Montrachet") and Burgundy domaines legitimately name wines by appellation — tests pin both non-matches.
2. **Prompts**: estate-wine exception + never-appellation/classification-as-name + a new `classification` output, plumbed through /validate (behind the same 0.6 confidence floor as geography) and /confirm into the existing `classification` field findOrCreateWine already accepts.
3. **Backfill** `fix-classification-polluted-names.js` — the SAME exported guard over existing rows (no drift), key regen with collision-skip, reindex, dry-run default + backup. Fixes the ticket's four rows (the Phélan Ségur one keeps its populated appellation).

## Tests
8 suites in node:20-alpine, **160 passed** — guard precision matrix (incl. négociant/domaine/Les-Forts-de-Latour non-fires), full findOrCreateWine regression, import validate/confirm, prompt substitution.

## Out of scope (noted for the somm's wider observation)
Null appellations on correctly-named wines (La Chapelle de la Mission Haut-Brion) are the geography-confidence-floor class — that's the deferred appellation-backfill work, not this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)