### PR TITLE
chore(release): v1.132.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.132.0",
+  "version": "1.132.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.132.0",
+      "version": "1.132.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.132.0",
+  "version": "1.132.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.132.0",
+  "version": "1.132.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.132.0",
+      "version": "1.132.1",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.132.0",
+  "version": "1.132.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch: phantom CSS tokens broke every frontend image build since v1.128 (PR #1018) — this tag is the first buildable source since v1.127 and carries all frontend work from v1.128–v1.132 into prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)