### PR TITLE
fix(registry): regeneration never destroys a reviewed published profile

### DIFF
--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -104,6 +104,7 @@ let job = {
   done: 0,
   enriched: 0,
   held: 0,              // producer-suspect rows: generated but publication withheld
+  kept: 0,              // reviewed published rows a would-hold regen preserved (stamp cleared)
   skipped: 0,
   errors: 0,
   startedAt: null,
@@ -277,6 +278,7 @@ async function start({ mode = 'incremental', limit = 0 } = {}) {
     done: 0,
     enriched: 0,
     held: 0,
+    kept: 0,
     skipped: 0,
     errors: 0,
     startedAt: new Date().toISOString(),
@@ -348,6 +350,7 @@ async function runJob(cfg) {
         const { result, reason } = await enrichWine(wine, job.model);
         if (result === 'enriched') job.enriched++;
         else if (result === 'held') job.held++;
+        else if (result === 'kept') job.kept++; // reviewed profile preserved, stamp cleared — not an error
         else {
           job.skipped++;
           if (reason) job.lastError = reason;
@@ -498,6 +501,20 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
   // row stores ONLY the doubt; the null description keeps every read surface
   // naturally silent, and heldAt keeps the retry guards from looping on it.
   if (!publishSuspect && a.holdReason) {
+    // A REVIEWED published profile is a human decision — an automated
+    // regeneration (identity edit, full batch) must never null it (somm
+    // report 2026-08-19: proposal approvals re-generated curator-released
+    // rows). The doubtful regen is discarded, the old profile stays, and the
+    // cleared stamp drops the row back into the review worklists — a human
+    // decides, exactly like the first time.
+    if (wine.profileReviewedAt && wine.aiProfile && wine.aiProfile.description) {
+      await WineDefinition.updateOne(
+        { _id: wine._id },
+        { $set: { profileReviewedAt: null, updatedAt: now } }
+      );
+      console.log(`[enrichmentJob] kept reviewed profile ${wine._id}: regen would hold (${a.holdReason}) — review stamp cleared instead`);
+      return { result: 'kept', reason: a.holdReason };
+    }
     await WineDefinition.updateOne(
       { _id: wine._id },
       {
@@ -552,6 +569,10 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
           heldAt: null,
         },
         updatedAt: now,
+        // Fresh content is unreviewed content: a stamp from before this
+        // regeneration attested the OLD profile, and carrying it forward
+        // would fake the audit trail the scaling review depends on.
+        ...(wine.profileReviewedAt ? { profileReviewedAt: null } : {}),
       },
     }
   );

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -915,3 +915,79 @@ describe('web-search rescue on confidence holds', () => {
     expect(persisted().searchUsed).toBe(false);
   });
 });
+
+/**
+ * The reviewed-profile guard (somm report 2026-08-19): an automated
+ * regeneration — proposal approval via reenrichAfterRecordEdit, or a full
+ * batch — must never NULL a profile a human attested. A would-hold regen on
+ * a reviewed published row keeps the old profile and clears only the review
+ * stamp (back into the worklists, a human decides again); a publishing regen
+ * writes the fresh content but also clears the stamp, because the review
+ * attested the OLD prose and carrying it forward would fake the audit trail.
+ * Unreviewed rows keep the original behavior in full.
+ */
+describe('regeneration never destroys a reviewed published profile', () => {
+  const reviewedWine = (over = {}) => ({
+    _id: WINE_ID, name: 'Encore Zinfandel', producer: 'Thomas Allen', type: 'red',
+    country: { name: 'Australia' }, region: { name: 'Hunter Valley' }, grapes: [],
+    profileReviewedAt: new Date('2026-08-18T10:00:00Z'),
+    aiProfile: { description: 'The curator-attested prose.', generatedAt: new Date('2026-08-18T09:00:00Z'), source: 'ai' },
+    ...over,
+  });
+  const regen = (confidence) => ({
+    data: {
+      body: 'medium', tannin: 'medium', acidity: 'medium', sweetness: 'dry',
+      flavors: ['plum'], foodPairings: ['stew'],
+      producerSuspect: false, producerUnknown: false,
+      description: 'Fresh regenerated prose.', confidence,
+    },
+    debugReason: null,
+  });
+
+  test('a would-hold regen KEEPS the old profile and clears only the stamp', async () => {
+    WineDefinition.findById.mockReturnValue(chain(reviewedWine()));
+    suggestProfile.mockResolvedValue(regen(0.2)); // under the floor → would hold
+    await enrichWineById(WINE_ID, { force: true });
+    expect(WineDefinition.updateOne).toHaveBeenCalledTimes(1);
+    const $set = WineDefinition.updateOne.mock.calls[0][1].$set;
+    expect($set.profileReviewedAt).toBeNull();
+    expect($set.aiProfile).toBeUndefined(); // the attested profile is untouched
+  });
+
+  test('a publishing regen writes the fresh profile AND clears the stamp', async () => {
+    WineDefinition.findById.mockReturnValue(chain(reviewedWine()));
+    suggestProfile.mockResolvedValue(regen(0.8));
+    await enrichWineById(WINE_ID, { force: true });
+    const $set = WineDefinition.updateOne.mock.calls[0][1].$set;
+    expect($set.aiProfile.description).toBe('Fresh regenerated prose.');
+    expect($set.aiProfile.heldAt).toBeNull();
+    expect($set.profileReviewedAt).toBeNull();
+  });
+
+  test('an UNREVIEWED published row still holds the old way — the gate is for unattested content', async () => {
+    WineDefinition.findById.mockReturnValue(chain(reviewedWine({ profileReviewedAt: null })));
+    suggestProfile.mockResolvedValue(regen(0.2));
+    await enrichWineById(WINE_ID, { force: true });
+    const $set = WineDefinition.updateOne.mock.calls[0][1].$set;
+    expect($set.aiProfile.description).toBeNull();
+    expect($set.aiProfile.heldReason).toBe('low_confidence');
+  });
+
+  test('a reviewed row whose profile is HELD (no prose) has nothing to preserve — normal hold write', async () => {
+    WineDefinition.findById.mockReturnValue(chain(reviewedWine({
+      aiProfile: { description: null, generatedAt: new Date(), heldAt: new Date(), source: 'ai' },
+    })));
+    suggestProfile.mockResolvedValue(regen(0.2));
+    await enrichWineById(WINE_ID, { force: true });
+    const $set = WineDefinition.updateOne.mock.calls[0][1].$set;
+    expect($set.aiProfile.heldReason).toBe('low_confidence');
+  });
+
+  test('a publish on a row with NO stamp does not touch profileReviewedAt at all', async () => {
+    WineDefinition.findById.mockReturnValue(chain(reviewedWine({ profileReviewedAt: null, aiProfile: null })));
+    suggestProfile.mockResolvedValue(regen(0.8));
+    await enrichWineById(WINE_ID);
+    const $set = WineDefinition.updateOne.mock.calls[0][1].$set;
+    expect('profileReviewedAt' in $set).toBe(false);
+  });
+});


### PR DESCRIPTION
A proposal approval that changes identity fields force-regenerates the wine's AI profile. If the fresh generation lands under the publication gate, the hold path nulled a **curator-attested published profile** — a human decision reversed by an automated path (surfaced by the somm's 2026-08-19 report; the mechanism is confirmed in code even though the specific five rows they cited don't currently match the DB signature — their ids are requested).

**The guard:** a would-hold regeneration on a reviewed published row keeps the old profile and clears only `profileReviewedAt` (back into the worklists — a human decides again, exactly like the first time). A *publishing* regeneration writes the fresh content but also clears the stamp, because the review attested the old prose. Unreviewed rows keep today's behavior in full; the release override and curator-source profiles are untouched.

New `kept` job counter (additive on `getStatus()`); 5 new tests pinning all four quadrants (reviewed/unreviewed × hold/publish) plus the no-stamp no-touch case.

Also unblocks producer respells (Meyer-Näkel) which ride this regeneration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)