### PR TITLE
feat(analytics): grouping + charts + 14 presets + KV/taxonomy sort — adversarially reviewed (#987 R-B/R-C)

### DIFF
--- a/backend/src/services/analytics/fieldCatalogue.js
+++ b/backend/src/services/analytics/fieldCatalogue.js
@@ -65,8 +65,11 @@ const STATIC_FIELDS = [
   // the raw collection name the sort $lookup reads.
   dim({ key: 'wine.country', label: 'Country', domain: 'wine', type: 'text', source: 'taxonomy', path: 'wd.country', taxonomyModel: 'Country', taxonomyCollection: 'countries' }),
   dim({ key: 'wine.region', label: 'Region', domain: 'wine', type: 'text', source: 'taxonomy', path: 'wd.region', taxonomyModel: 'Region', taxonomyCollection: 'regions' }),
-  // Grapes is an ARRAY ref — a filter means "has this grape"; no scalar order.
-  dim({ key: 'wine.grapes', label: 'Grapes', domain: 'wine', type: 'text', source: 'taxonomy', path: 'wd.grapes', taxonomyModel: 'Grape', sortable: false }),
+  // Grapes is an ARRAY ref — a filter means "has this grape". Neither sortable
+  // nor groupable: $group on an array keys buckets by the whole combination
+  // ("[Grenache, Syrah]" ≠ "Grenache"), which reads as data and lies. Per-grape
+  // grouping needs an $unwind stage — a later slice, honestly flagged out.
+  dim({ key: 'wine.grapes', label: 'Grapes', domain: 'wine', type: 'text', source: 'taxonomy', path: 'wd.grapes', taxonomyModel: 'Grape', sortable: false, groupable: false }),
 
   // Inventory
   dim({ key: 'bottle.vintage', label: 'Vintage', domain: 'inventory', type: 'text', source: 'bottle', path: 'vintage' }),

--- a/backend/src/services/analytics/fieldCatalogue.js
+++ b/backend/src/services/analytics/fieldCatalogue.js
@@ -60,12 +60,12 @@ const STATIC_FIELDS = [
   dim({ key: 'wine.type', label: 'Wine type', domain: 'wine', type: 'enum', source: 'wine', path: 'wd.type', enumOptions: ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'] }),
   dim({ key: 'wine.appellation', label: 'Appellation', domain: 'wine', type: 'text', source: 'wine', path: 'wd.appellation' }),
   dim({ key: 'wine.classification', label: 'Classification', domain: 'wine', type: 'text', source: 'wine', path: 'wd.classification' }),
-  // Taxonomy refs: the stored value is an ObjectId, so a server-side sort
-  // would order by id, not name — sortable stays false until R-B adds the
-  // name lookup. Filters resolve the typed name to ids first.
-  dim({ key: 'wine.country', label: 'Country', domain: 'wine', type: 'text', source: 'taxonomy', path: 'wd.country', taxonomyModel: 'Country', sortable: false }),
-  dim({ key: 'wine.region', label: 'Region', domain: 'wine', type: 'text', source: 'taxonomy', path: 'wd.region', taxonomyModel: 'Region', sortable: false }),
-  // Grapes is an ARRAY ref — a filter means "has this grape".
+  // Taxonomy refs: the stored value is an ObjectId; sorting joins the name
+  // (R-B). Filters resolve the typed name to ids first. taxonomyCollection is
+  // the raw collection name the sort $lookup reads.
+  dim({ key: 'wine.country', label: 'Country', domain: 'wine', type: 'text', source: 'taxonomy', path: 'wd.country', taxonomyModel: 'Country', taxonomyCollection: 'countries' }),
+  dim({ key: 'wine.region', label: 'Region', domain: 'wine', type: 'text', source: 'taxonomy', path: 'wd.region', taxonomyModel: 'Region', taxonomyCollection: 'regions' }),
+  // Grapes is an ARRAY ref — a filter means "has this grape"; no scalar order.
   dim({ key: 'wine.grapes', label: 'Grapes', domain: 'wine', type: 'text', source: 'taxonomy', path: 'wd.grapes', taxonomyModel: 'Grape', sortable: false }),
 
   // Inventory
@@ -109,17 +109,20 @@ const KV_ID_RX = /^(personal|registry)\.([0-9a-f]{24})$/;
 
 /** A dynamic KV key document → catalogue entry. */
 function kvEntry(kind, doc) {
+  const numeric = doc.type === 'integer' || doc.type === 'decimal';
   return {
     key: `${kind}.${String(doc._id)}`,
     label: doc.name,
     domain: kind, // 'personal' | 'registry'
     type: doc.type,
     unit: doc.unit || null,
-    role: (doc.type === 'integer' || doc.type === 'decimal') ? 'both' : 'dimension',
-    aggregations: (doc.type === 'integer' || doc.type === 'decimal') ? ['avg', 'min', 'max', 'sum'] : [],
-    // Honest flags: sorting/grouping KV columns needs the R-B $lookup work.
-    sortable: false,
-    groupable: false,
+    role: numeric ? 'both' : 'dimension',
+    aggregations: numeric ? ['avg', 'min', 'max', 'sum'] : [],
+    // Sort and non-numeric grouping join the entries collection (R-B).
+    // Numeric KV stays measure-only as a dimension: every distinct reading
+    // would be its own bucket — a wall, not an answer.
+    sortable: true,
+    groupable: !numeric,
     filterable: true,
     enumOptions: doc.enumOptions || undefined,
     source: kind,

--- a/backend/src/services/analytics/fieldCatalogue.js
+++ b/backend/src/services/analytics/fieldCatalogue.js
@@ -79,31 +79,42 @@ const STATIC_FIELDS = [
   dim({ key: 'bottle.location', label: 'Rack location', domain: 'inventory', type: 'text', source: 'bottle', path: 'location' }),
   dim({ key: 'bottle.occasion', label: 'Occasion note', domain: 'inventory', type: 'text', source: 'bottle', path: 'occasion' }),
   dim({ key: 'bottle.reservedFor', label: 'Reserved for', domain: 'inventory', type: 'text', source: 'bottle', path: 'reservedFor' }),
-  dim({ key: 'bottle.addedAt', label: 'Date added', domain: 'inventory', type: 'date', source: 'bottle', path: 'createdAt' }),
+  // Date fields are not groupable (audit 2026-08-19 F9): without calendar
+  // bucketing, $group on a timestamp makes one bucket per bottle — 200 rows
+  // of count:1 is a wall, not an answer. Month bucketing is the dashboards
+  // slice's problem; until then the flag is honest.
+  dim({ key: 'bottle.addedAt', label: 'Date added', domain: 'inventory', type: 'date', source: 'bottle', path: 'createdAt', groupable: false }),
 
   // Purchase
   measure({ key: 'purchase.price', label: 'Price', domain: 'purchase', type: 'decimal', unit: 'currency', source: 'bottle', path: 'price', aggregations: ['sum', 'avg', 'min', 'max'] }),
   dim({ key: 'purchase.currency', label: 'Currency', domain: 'purchase', type: 'text', source: 'bottle', path: 'currency' }),
-  dim({ key: 'purchase.date', label: 'Purchase date', domain: 'purchase', type: 'date', source: 'bottle', path: 'purchaseDate' }),
+  dim({ key: 'purchase.date', label: 'Purchase date', domain: 'purchase', type: 'date', source: 'bottle', path: 'purchaseDate', groupable: false }),
   dim({ key: 'purchase.location', label: 'Purchase location', domain: 'purchase', type: 'text', source: 'bottle', path: 'purchaseLocation' }),
 
-  // Ratings — normalized 0–100 across the three scales before any aggregation
-  measure({ key: 'rating.current', label: 'My rating', domain: 'rating', type: 'decimal', source: 'bottle', path: 'rating', scalePath: 'ratingScale', normalized: true, aggregations: ['avg', 'min', 'max'] }),
-  measure({ key: 'rating.consumed', label: 'Rating at consumption', domain: 'rating', type: 'decimal', source: 'bottle', path: 'consumedRating', scalePath: 'consumedRatingScale', normalized: true, aggregations: ['avg', 'min', 'max'] }),
+  // Ratings live in ONE scale everywhere on this surface: stars (audit
+  // 2026-08-19 F3). Values are stored per-bottle in '5'/'20'/'100' scales —
+  // mixed after imports — so raw filter/sort/display made a 60-point Parker
+  // outrank a 5-star bottle. Filters take stars, sort orders by the
+  // star-converted expression, hydration returns stars, grouped measures
+  // aggregate stars — all generated from the same ratingUtils anchor table.
+  measure({ key: 'rating.current', label: 'My rating (stars)', domain: 'rating', type: 'decimal', source: 'bottle', path: 'rating', scalePath: 'ratingScale', normalized: true, aggregations: ['avg', 'min', 'max'] }),
+  measure({ key: 'rating.consumed', label: 'Rating at consumption (stars)', domain: 'rating', type: 'decimal', source: 'bottle', path: 'consumedRating', scalePath: 'consumedRatingScale', normalized: true, aggregations: ['avg', 'min', 'max'] }),
 
   // Consumption
-  dim({ key: 'consumption.date', label: 'Consumed date', domain: 'consumption', type: 'date', source: 'bottle', path: 'consumedAt' }),
+  dim({ key: 'consumption.date', label: 'Consumed date', domain: 'consumption', type: 'date', source: 'bottle', path: 'consumedAt', groupable: false }),
   dim({ key: 'consumption.reason', label: 'Consumed reason', domain: 'consumption', type: 'enum', source: 'bottle', path: 'consumedReason', enumOptions: ['drank', 'gifted', 'sold', 'other'] }),
 
   // Open bottles
-  dim({ key: 'open.openedAt', label: 'Opened date', domain: 'open', type: 'date', source: 'bottle', path: 'openedAt' }),
+  dim({ key: 'open.openedAt', label: 'Opened date', domain: 'open', type: 'date', source: 'bottle', path: 'openedAt', groupable: false }),
   dim({ key: 'open.preservation', label: 'Preservation', domain: 'open', type: 'enum', source: 'bottle', path: 'preservationMethod', enumOptions: ['coravin', 'inert-gas', 'vacuum', 'sparkling-stopper', 'recorked'] }),
 
   // Maturity — the user's own per-bottle window (integers, filter/sortable);
   // the derived drink status is computed per hydrated row and says so.
   dim({ key: 'maturity.drinkFrom', label: 'Drink from (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'drinkFrom' }),
   dim({ key: 'maturity.drinkTo', label: 'Drink to (year)', domain: 'maturity', type: 'integer', source: 'bottle', path: 'drinkTo' }),
-  dim({ key: 'maturity.status', label: 'Drink status', domain: 'maturity', type: 'enum', source: 'computed', path: null, sortable: false, groupable: false, filterable: false, enumOptions: ['too-young', 'approaching', 'ready', 'peak', 'declining', 'past', 'unknown'] }),
+  // enumOptions mirror what classifyMaturity actually returns (audit F7) —
+  // 'unknown' is this module's own fallback for rows with no window at all.
+  dim({ key: 'maturity.status', label: 'Drink status', domain: 'maturity', type: 'enum', source: 'computed', path: null, sortable: false, groupable: false, filterable: false, enumOptions: ['not-ready', 'early', 'peak', 'late', 'declining', 'unknown'] }),
 ];
 
 const STATIC_BY_KEY = new Map(STATIC_FIELDS.map((f) => [f.key, f]));

--- a/backend/src/services/analytics/queryEngine.js
+++ b/backend/src/services/analytics/queryEngine.js
@@ -375,6 +375,82 @@ const WINE_LOOKUP = [
   { $unwind: { path: '$wd', preserveNullAndEmptyArrays: true } },
 ];
 
+/**
+ * R-B: join ONE key/value field's resolved value into the pipeline as
+ * `$<alias>`, so KV fields can be sorted, grouped and aggregated server-side.
+ * Personal entries apply the same precedence as the bottle page — bottle
+ * entry beats a vintage-scoped wine entry beats a vintage-null wine entry —
+ * enforced by the _prio sort inside the sub-pipeline. Registry reads the one
+ * published row per (wine, key). Both sub-pipelines are $limit 1 and run on
+ * indexed keys, bounded by the outer maxTimeMS like everything else.
+ */
+function kvJoinStages(field, alias, userId) {
+  const keyOid = new mongoose.Types.ObjectId(field.keyId);
+  if (field.source === 'registry') {
+    return [
+      {
+        $lookup: {
+          from: 'registrydatavalues',
+          let: { wid: '$wineDefinition' },
+          pipeline: [
+            { $match: { $expr: { $and: [
+              { $eq: ['$wineDefinition', '$$wid'] },
+              { $eq: ['$key', keyOid] },
+              { $eq: ['$status', 'published'] },
+            ] } } },
+            { $limit: 1 },
+            { $project: { _id: 0, value: 1 } },
+          ],
+          as: `${alias}_j`,
+        },
+      },
+      { $addFields: { [alias]: { $first: `$${alias}_j.value` } } },
+    ];
+  }
+  const userOid = new mongoose.Types.ObjectId(String(userId));
+  return [
+    {
+      $lookup: {
+        from: 'personaldataentries',
+        let: { bid: '$_id', wid: '$wineDefinition', vint: '$vintage' },
+        pipeline: [
+          { $match: { $expr: { $and: [
+            { $eq: ['$author', userOid] },
+            { $eq: ['$key', keyOid] },
+            { $or: [
+              { $eq: ['$bottle', '$$bid'] },
+              { $and: [
+                { $eq: ['$wineDefinition', '$$wid'] },
+                { $in: ['$vintage', [null, '$$vint']] },
+              ] },
+            ] },
+          ] } } },
+          { $addFields: { _prio: { $switch: {
+            branches: [
+              { case: { $eq: ['$targetType', 'bottle'] }, then: 0 },
+              { case: { $ne: ['$vintage', null] }, then: 1 },
+            ],
+            default: 2,
+          } } } },
+          { $sort: { _prio: 1 } },
+          { $limit: 1 },
+          { $project: { _id: 0, value: 1 } },
+        ],
+        as: `${alias}_j`,
+      },
+    },
+    { $addFields: { [alias]: { $first: `$${alias}_j.value` } } },
+  ];
+}
+
+/** Taxonomy sort: join the small name collection and sort by the name. */
+function taxonomySortStages(field, alias) {
+  return [
+    { $lookup: { from: field.taxonomyCollection, localField: field.path, foreignField: '_id', as: `${alias}_j` } },
+    { $addFields: { [alias]: { $first: `$${alias}_j.name` } } },
+  ];
+}
+
 function baseMatch(scopeCellarIds, bottleScope, preConds) {
   const match = {
     cellar: { $in: scopeCellarIds },
@@ -389,7 +465,10 @@ async function runRows({ userId, scopeCellars, bottleScope, filters, sort, limit
   const { pre, post, needsWine: filterNeedsWine } = await compileFilters(filters, userId);
 
   // Sort: one field, validated; default = newest first. _id tiebreaker always.
+  // Taxonomy and KV sorts join their value in first (R-B) — the join stages
+  // run after the filters so they touch only the surviving rows.
   let sortStage = { createdAt: -1, _id: 1 };
+  let sortJoin = [];
   let sortField = null;
   if (sort) {
     if (!sort.field || !['asc', 'desc'].includes(sort.dir || 'asc')) {
@@ -397,11 +476,20 @@ async function runRows({ userId, scopeCellars, bottleScope, filters, sort, limit
     }
     sortField = await resolveField(sort.field, userId);
     if (!sortField) throw new QueryError(400, `Unknown sort field "${sort.field}"`);
-    if (!sortField.sortable) throw new QueryError(400, `Field "${sort.field}" is not sortable yet`);
+    if (!sortField.sortable) throw new QueryError(400, `Field "${sort.field}" is not sortable`);
     const dir = sort.dir === 'desc' ? -1 : 1;
-    sortStage = { [sortField.path]: dir, _id: 1 };
+    if (sortField.source === 'taxonomy') {
+      sortJoin = taxonomySortStages(sortField, '_sortVal');
+      sortStage = { _sortVal: dir, _id: 1 };
+    } else if (sortField.source === 'personal' || sortField.source === 'registry') {
+      sortJoin = kvJoinStages(sortField, '_sortVal', userId);
+      sortStage = { _sortVal: dir, _id: 1 };
+    } else {
+      sortStage = { [sortField.path]: dir, _id: 1 };
+    }
   }
-  const needsWine = filterNeedsWine || (sortField && sortField.path.startsWith('wd.'));
+  const needsWine = filterNeedsWine
+    || (sortField && (sortField.source === 'taxonomy' || (sortField.path || '').startsWith('wd.')));
 
   const cellarIds = scopeCellars.map((c) => c._id);
   const pageLimit = Math.min(Math.max(1, limit || 50), ROWS_LIMIT_MAX);
@@ -411,6 +499,7 @@ async function runRows({ userId, scopeCellars, bottleScope, filters, sort, limit
     { $match: baseMatch(cellarIds, bottleScope, pre) },
     ...(needsWine ? WINE_LOOKUP : []),
     ...(post.length ? [{ $match: { $and: post } }] : []),
+    ...sortJoin,
     { $sort: sortStage },
     {
       $facet: {
@@ -560,12 +649,22 @@ async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensio
   }
 
   let needsWine = filterNeedsWine;
+  const joinStages = [];
   const dimFields = [];
-  for (const d of dimensions) {
-    const f = await resolveField(d, userId);
-    if (!f) throw new QueryError(400, `Unknown dimension "${d}"`);
-    if (!f.groupable) throw new QueryError(400, `Field "${d}" cannot be grouped yet`);
-    if (f.path && f.path.startsWith('wd.')) needsWine = true;
+  const dimExprs = [];
+  for (let i = 0; i < dimensions.length; i++) {
+    const f = await resolveField(dimensions[i], userId);
+    if (!f) throw new QueryError(400, `Unknown dimension "${dimensions[i]}"`);
+    if (!f.groupable) throw new QueryError(400, `Field "${dimensions[i]}" cannot be grouped`);
+    if (f.source === 'personal' || f.source === 'registry') {
+      // R-B: group by the joined KV value (non-numeric keys only, per the
+      // catalogue flag — numeric readings would bucket per distinct value).
+      joinStages.push(...kvJoinStages(f, `_d${i}v`, userId));
+      dimExprs.push(`$_d${i}v`);
+    } else {
+      if (f.path && f.path.startsWith('wd.')) needsWine = true;
+      dimExprs.push(`$${f.path}`);
+    }
     dimFields.push(f);
   }
 
@@ -585,7 +684,17 @@ async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensio
       throw new QueryError(400, `Field "${m.field}" does not support "${m.agg}"`);
     }
     if (f.source === 'personal' || f.source === 'registry') {
-      throw new QueryError(400, `Field "${m.field}" cannot be aggregated yet`);
+      // R-B: numeric KV measures aggregate the joined value. The $isNumber
+      // guard keeps a stray non-numeric entry (possible on rows written
+      // before a key existed, or via import) out of the accumulator instead
+      // of poisoning it.
+      joinStages.push(...kvJoinStages(f, `_m${i}v`, userId));
+      measureSpecs.push({
+        out: `m${i}`, label: `${m.agg}(${f.label})`, agg: m.agg,
+        valueExpr: { $cond: [{ $isNumber: `$_m${i}v` }, `$_m${i}v`, null] },
+        field: f,
+      });
+      continue;
     }
     let valueExpr = `$${f.path}`;
     if (f.unit === 'currency') {
@@ -630,7 +739,7 @@ async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensio
   }
 
   const groupId = {};
-  dimFields.forEach((f, i) => { groupId[`d${i}`] = `$${f.path}`; });
+  dimFields.forEach((f, i) => { groupId[`d${i}`] = dimExprs[i]; });
 
   const groupStage = { _id: groupId };
   for (const spec of measureSpecs) {
@@ -643,6 +752,7 @@ async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensio
     { $match: baseMatch(cellarIds, bottleScope, pre) },
     ...(needsWine ? WINE_LOOKUP : []),
     ...(post.length ? [{ $match: { $and: post } }] : []),
+    ...joinStages,
     { $group: groupStage },
     { $sort: { m0: -1, _id: 1 } },
     { $limit: BUCKET_CAP + 1 },

--- a/backend/src/services/analytics/queryEngine.js
+++ b/backend/src/services/analytics/queryEngine.js
@@ -40,7 +40,7 @@ const PersonalDataEntry = require('../../models/PersonalDataEntry');
 const RegistryDataValue = require('../../models/RegistryDataValue');
 const { resolveField, opsForType } = require('./fieldCatalogue');
 const { validateValue } = require('../../utils/personalDataTypes');
-const { ANCHORS, COL } = require('../../utils/ratingUtils');
+const { ANCHORS, COL, toNormalized, fromNormalized } = require('../../utils/ratingUtils');
 const { getOrCreateDailySnapshot, convertCurrency } = require('../../utils/exchangeRates');
 const { classifyMaturity, buildProfileMap } = require('../../utils/maturityUtils');
 
@@ -106,12 +106,20 @@ function castStatic(field, raw) {
       return s;
     }
     case 'integer': {
+      // Number('') and Number(null) are both 0 — an absent value must be a
+      // 400, never a silent zero bound (audit 2026-08-19 F8).
+      if (raw === null || raw === undefined || (typeof raw === 'string' && raw.trim() === '')) {
+        throw new QueryError(400, `Filter on ${field.key}: a value is required`);
+      }
       const n = Number(raw);
       if (!Number.isInteger(n)) throw new QueryError(400, `Filter on ${field.key}: expected a whole number`);
       return n;
     }
     case 'decimal': {
-      const n = typeof raw === 'number' ? raw : Number(String(raw ?? '').trim().replace(',', '.'));
+      if (raw === null || raw === undefined || (typeof raw === 'string' && raw.trim() === '')) {
+        throw new QueryError(400, `Filter on ${field.key}: a value is required`);
+      }
+      const n = typeof raw === 'number' ? raw : Number(String(raw).trim().replace(',', '.'));
       if (!Number.isFinite(n)) throw new QueryError(400, `Filter on ${field.key}: expected a number`);
       return n;
     }
@@ -144,11 +152,41 @@ function castKv(field, raw) {
   return res.value;
 }
 
+/**
+ * STATIC date fields hold real event timestamps (createdAt, consumedAt,
+ * openedAt), while the filter value names a calendar DAY. Comparing the raw
+ * midnight instant made 'eq' match nothing and inclusive upper bounds drop
+ * the entire named day (audit 2026-08-19 F2) — so date predicates expand to
+ * day ranges. KV date values are canonical 'YYYY-MM-DD' strings and never
+ * come through here.
+ */
+function datePredicate(field, op, value, castOne) {
+  const dayAfter = (d) => new Date(d.getTime() + 86400000);
+  switch (op) {
+    case 'eq': { const d = castOne(value); return { $gte: d, $lt: dayAfter(d) }; }
+    case 'gte': return { $gte: castOne(value) };
+    case 'gt': { const d = castOne(value); return { $gte: dayAfter(d) }; }
+    case 'lt': return { $lt: castOne(value) };
+    case 'lte': { const d = castOne(value); return { $lt: dayAfter(d) }; }
+    case 'between': {
+      if (!Array.isArray(value) || value.length !== 2) {
+        throw new QueryError(400, `Filter on ${field.key}: "between" takes [min, max]`);
+      }
+      return { $gte: castOne(value[0]), $lt: dayAfter(castOne(value[1])) };
+    }
+    default:
+      throw new QueryError(400, `Filter on ${field.key}: operator "${op}" not allowed for dates`);
+  }
+}
+
 /** op + cast value(s) → a Mongo comparison for one path. */
 function predicate(field, op, value, castOne) {
   const allowed = opsForType(field.type);
   if (!allowed.includes(op)) {
     throw new QueryError(400, `Filter on ${field.key}: operator "${op}" not allowed for type ${field.type}`);
+  }
+  if (field.type === 'date' && (field.source === 'bottle' || field.source === 'wine')) {
+    return datePredicate(field, op, value, castOne);
   }
   switch (op) {
     case 'eq': return castOne(value);
@@ -201,15 +239,71 @@ async function taxonomyIds(field, op, value) {
 }
 
 /**
- * A KV filter resolves matching ENTRY rows first (indexed), then narrows the
- * bottle match — never a $lookup per filter. Returns a Mongo condition on the
- * Bottle collection.
+ * Evaluate one whitelisted operator against an already-cast entry value in
+ * JS — the personal-KV filter resolves precedence before Mongo ever sees a
+ * condition, so the predicate has to run here too. Mirrors predicate()'s
+ * semantics exactly; a mismatch between the two is a bug the KV filter tests
+ * exist to catch.
+ */
+function evalKvPredicate(op, castValue, entryValue) {
+  switch (op) {
+    case 'eq': return entryValue === castValue;
+    case 'neq': return entryValue !== castValue;
+    case 'gt': return entryValue > castValue;
+    case 'gte': return entryValue >= castValue;
+    case 'lt': return entryValue < castValue;
+    case 'lte': return entryValue <= castValue;
+    case 'between': return entryValue >= castValue[0] && entryValue <= castValue[1];
+    case 'contains': return typeof entryValue === 'string' && entryValue.toLowerCase().includes(String(castValue).toLowerCase());
+    case 'in': return Array.isArray(castValue) && castValue.includes(entryValue);
+    default: return false;
+  }
+}
+
+/** Cast the filter value(s) once for JS evaluation, per the op's shape. */
+function castKvForEval(field, op, value) {
+  const castOne = (raw) => castKv(field, raw);
+  if (op === 'between') {
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw new QueryError(400, `Filter on "${field.label}": "between" takes [min, max]`);
+    }
+    return [castOne(value[0]), castOne(value[1])];
+  }
+  if (op === 'in') {
+    if (!Array.isArray(value) || !value.length || value.length > 20) {
+      throw new QueryError(400, `Filter on "${field.label}": "in" takes 1–20 values`);
+    }
+    return value.map(castOne);
+  }
+  if (op === 'contains') {
+    const s = castOne(value);
+    if (typeof s !== 'string') throw new QueryError(400, `Filter on "${field.label}": expected text`);
+    return s;
+  }
+  return castOne(value);
+}
+
+/**
+ * A KV filter resolves ENTRY rows first (indexed), then narrows the bottle
+ * match — never a $lookup per filter.
+ *
+ * Personal entries apply the SAME precedence the display, sort, group and
+ * measure paths apply — bottle entry beats wine-vintage beats wine-null
+ * (audit 2026-08-19 F1: filtering on any-level matches admitted rows whose
+ * EFFECTIVE value contradicted the user's own filter). So: all of the
+ * caller's entries for the key are fetched predicate-free, the predicate
+ * runs in JS per entry, and the condition is layered — a failing
+ * higher-precedence entry vetoes a matching lower one:
+ *   include: matching bottle entries; matching wine-vintage entries;
+ *            matching wine-null entries MINUS vintages a failing
+ *            wine-vintage entry overrides
+ *   exclude: bottles with a FAILING bottle-level entry, always
  */
 async function kvCondition(field, op, value, userId) {
-  const castOne = (raw) => castKv(field, raw);
-  const valuePred = predicate(field, op, value, castOne);
-
   if (field.source === 'registry') {
+    // One published value per (wine, key) — no precedence to resolve, the
+    // predicate can stay in the query.
+    const valuePred = predicate(field, op, value, (raw) => castKv(field, raw));
     const rows = await RegistryDataValue.find({
       key: field.keyId, status: 'published', value: valuePred,
     }).select('wineDefinition').limit(KV_MATCH_CAP + 1).lean();
@@ -219,27 +313,48 @@ async function kvCondition(field, op, value, userId) {
     return { wineDefinition: { $in: rows.map((r) => r.wineDefinition) } };
   }
 
-  // personal — the CALLER'S OWN entries only (the catalogue already ownership-
-  // checked the key; the author match makes the row query self-scoping too).
+  const cast = castKvForEval(field, op, value);
   const rows = await PersonalDataEntry.find({
-    author: userId, key: field.keyId, value: valuePred,
-  }).select('targetType bottle wineDefinition vintage').limit(KV_MATCH_CAP + 1).lean();
+    author: userId, key: field.keyId,
+  }).select('targetType bottle wineDefinition vintage value').limit(KV_MATCH_CAP + 1).lean();
   if (rows.length > KV_MATCH_CAP) {
     throw new QueryError(422, `Filter on "${field.label}" matches too many entries — narrow it first`);
   }
-  const bottleIds = rows.filter((r) => r.targetType === 'bottle').map((r) => r.bottle);
-  const wineConds = rows
-    .filter((r) => r.targetType === 'wine')
-    .map((r) => (r.vintage
-      ? { wineDefinition: r.wineDefinition, vintage: r.vintage }
-      : { wineDefinition: r.wineDefinition }));
+
+  const bottleMatch = [];
+  const bottleFail = [];
+  const wvMatch = [];               // { wineDefinition, vintage }
+  const wvFailByWine = new Map();   // wineId -> [vintage, ...]
+  const wnMatch = [];               // wineId
+  for (const r of rows) {
+    const hit = evalKvPredicate(op, cast, r.value);
+    if (r.targetType === 'bottle') (hit ? bottleMatch : bottleFail).push(r.bottle);
+    else if (r.vintage) {
+      if (hit) wvMatch.push({ wineDefinition: r.wineDefinition, vintage: r.vintage });
+      else {
+        const k = String(r.wineDefinition);
+        if (!wvFailByWine.has(k)) wvFailByWine.set(k, []);
+        wvFailByWine.get(k).push(r.vintage);
+      }
+    } else if (hit) wnMatch.push(r.wineDefinition);
+  }
+
   const or = [];
-  if (bottleIds.length) or.push({ _id: { $in: bottleIds } });
-  or.push(...wineConds);
+  if (bottleMatch.length) or.push({ _id: { $in: bottleMatch } });
+  or.push(...wvMatch);
+  for (const wid of wnMatch) {
+    const failVints = wvFailByWine.get(String(wid));
+    or.push(failVints
+      ? { wineDefinition: wid, vintage: { $nin: failVints } }
+      : { wineDefinition: wid });
+  }
   // No matching entries → a condition that matches nothing (honest empty
   // result, not an error).
   if (!or.length) return { _id: { $in: [] } };
-  return { $or: or };
+  const include = { $or: or };
+  return bottleFail.length
+    ? { $and: [include, { _id: { $nin: bottleFail } }] }
+    : include;
 }
 
 /**
@@ -248,12 +363,13 @@ async function kvCondition(field, op, value, userId) {
  * it (wd.* paths).
  */
 async function compileFilters(filters, userId) {
-  if (filters === undefined) return { pre: [], post: [], needsWine: false };
+  if (filters === undefined) return { pre: [], post: [], exprFilters: [], needsWine: false };
   if (!Array.isArray(filters) || filters.length > MAX_FILTERS) {
     throw new QueryError(400, `filters must be an array of at most ${MAX_FILTERS}`);
   }
   const pre = [];
   const post = [];
+  const exprFilters = [];
   let needsWine = false;
   for (const f of filters) {
     if (!f || typeof f !== 'object' || typeof f.field !== 'string' || typeof f.op !== 'string') {
@@ -263,7 +379,20 @@ async function compileFilters(filters, userId) {
     if (!field) throw new QueryError(400, `Unknown field "${f.field}"`);
     if (!field.filterable) throw new QueryError(400, `Field "${f.field}" is not filterable`);
 
-    if (field.source === 'personal' || field.source === 'registry') {
+    if (field.normalized) {
+      // Ratings filter in STARS against the converted expression (audit F3):
+      // the raw stored values mix three scales, so a raw comparison ranks a
+      // 60-point Parker above a 5-star bottle.
+      const castStars = (raw) => {
+        const n = castStatic({ ...field, type: 'decimal' }, raw);
+        if (n < 0 || n > 5) throw new QueryError(400, `Filter on ${field.key}: stars run 0–5`);
+        return n;
+      };
+      exprFilters.push({
+        expr: ratingConversionExpr(field.path, field.scalePath, '5'),
+        pred: predicate({ ...field, type: 'decimal' }, f.op, f.value, castStars),
+      });
+    } else if (field.source === 'personal' || field.source === 'registry') {
       pre.push(await kvCondition(field, f.op, f.value, userId));
     } else if (field.source === 'taxonomy') {
       if (!['eq', 'in', 'contains', 'neq'].includes(f.op)) {
@@ -284,27 +413,39 @@ async function compileFilters(filters, userId) {
       throw new QueryError(400, `Field "${f.field}" cannot be filtered`);
     }
   }
-  return { pre, post, needsWine };
+  return { pre, post, exprFilters, needsWine };
+}
+
+/** The $addFields+$match stage pairs for expression filters (ratings). */
+function exprFilterStages(exprFilters) {
+  return exprFilters.flatMap((ef, i) => [
+    { $addFields: { [`_f${i}`]: ef.expr } },
+    { $match: { [`_f${i}`]: ef.pred } },
+  ]);
 }
 
 // ── Generated normalization expressions ────────────────────────────────────
 
 /**
- * Piecewise-linear 0–100 rating normalization as an aggregation expression,
- * generated from ratingUtils.ANCHORS — the same table toNormalized() reads.
+ * Piecewise-linear rating conversion as an aggregation expression, generated
+ * from ratingUtils.ANCHORS — the same table toNormalized/fromNormalized read.
+ * `toKey` picks the target column: 'norm' (0–100) or '5' (stars — the one
+ * scale this surface speaks after audit F3). A direct from→to piecewise
+ * equals the toNormalized∘fromNormalized composition because both walk the
+ * same anchor rows; the parity tests pin that.
  */
-function normalizedRatingExpr(valuePath, scalePath) {
+function ratingConversionExpr(valuePath, scalePath, toKey = '5') {
   const perScale = (scaleKey) => {
     const fromCol = COL[scaleKey];
-    const normCol = COL.norm;
+    const toCol = COL[toKey];
     const v = `$${valuePath}`;
     // Below first anchor / above last anchor clamp; between: linear blend.
     const segs = [];
     for (let i = 0; i < ANCHORS.length - 1; i++) {
       const lo = ANCHORS[i][fromCol];
       const hi = ANCHORS[i + 1][fromCol];
-      const nLo = ANCHORS[i][normCol];
-      const nHi = ANCHORS[i + 1][normCol];
+      const nLo = ANCHORS[i][toCol];
+      const nHi = ANCHORS[i + 1][toCol];
       segs.push({
         case: { $lte: [v, hi] },
         then: {
@@ -317,16 +458,15 @@ function normalizedRatingExpr(valuePath, scalePath) {
         },
       });
     }
-    expr = {
+    return {
       $switch: {
         branches: [
-          { case: { $lte: [v, ANCHORS[0][fromCol]] }, then: ANCHORS[0][normCol] },
+          { case: { $lte: [v, ANCHORS[0][fromCol]] }, then: ANCHORS[0][toCol] },
           ...segs,
         ],
-        default: ANCHORS[ANCHORS.length - 1][normCol],
+        default: ANCHORS[ANCHORS.length - 1][toCol],
       },
     };
-    return expr;
   };
   return {
     $cond: [
@@ -343,6 +483,11 @@ function normalizedRatingExpr(valuePath, scalePath) {
       },
     ],
   };
+}
+
+/** Back-compat alias for the 0–100 form (parity tests pin it). */
+function normalizedRatingExpr(valuePath, scalePath) {
+  return ratingConversionExpr(valuePath, scalePath, 'norm');
 }
 
 /**
@@ -462,7 +607,7 @@ function baseMatch(scopeCellarIds, bottleScope, preConds) {
 // ── rows mode ──────────────────────────────────────────────────────────────
 
 async function runRows({ userId, scopeCellars, bottleScope, filters, sort, limit, offset, columns }) {
-  const { pre, post, needsWine: filterNeedsWine } = await compileFilters(filters, userId);
+  const { pre, post, exprFilters, needsWine: filterNeedsWine } = await compileFilters(filters, userId);
 
   // Sort: one field, validated; default = newest first. _id tiebreaker always.
   // Taxonomy and KV sorts join their value in first (R-B) — the join stages
@@ -484,6 +629,11 @@ async function runRows({ userId, scopeCellars, bottleScope, filters, sort, limit
     } else if (sortField.source === 'personal' || sortField.source === 'registry') {
       sortJoin = kvJoinStages(sortField, '_sortVal', userId);
       sortStage = { _sortVal: dir, _id: 1 };
+    } else if (sortField.normalized) {
+      // Ratings order by the star-converted value (audit F3), same scale as
+      // the filter and the displayed column.
+      sortJoin = [{ $addFields: { _sortVal: ratingConversionExpr(sortField.path, sortField.scalePath, '5') } }];
+      sortStage = { _sortVal: dir, _id: 1 };
     } else {
       sortStage = { [sortField.path]: dir, _id: 1 };
     }
@@ -499,6 +649,7 @@ async function runRows({ userId, scopeCellars, bottleScope, filters, sort, limit
     { $match: baseMatch(cellarIds, bottleScope, pre) },
     ...(needsWine ? WINE_LOOKUP : []),
     ...(post.length ? [{ $match: { $and: post } }] : []),
+    ...exprFilterStages(exprFilters),
     ...sortJoin,
     { $sort: sortStage },
     {
@@ -598,6 +749,14 @@ async function hydrateRows({ userId, pageIds, columns, scopeCellars }) {
     switch (f.source) {
       case 'bottle': {
         const v = f.path.split('.').reduce((o, k) => (o == null ? o : o[k]), b);
+        if (f.normalized) {
+          // Ratings display in STARS (audit F3), the same scale the filter
+          // takes and the sort orders by — one decimal, honest across a
+          // cellar whose rows mix 5/20/100-scale entries.
+          if (v == null) return null;
+          const stars = fromNormalized(toNormalized(v, b[f.scalePath]), '5');
+          return stars == null ? null : Math.round(stars * 10) / 10;
+        }
         return f.type === 'date' ? iso(v) : v ?? null;
       }
       case 'wine': {
@@ -639,7 +798,7 @@ async function hydrateRows({ userId, pageIds, columns, scopeCellars }) {
 // ── grouped mode ───────────────────────────────────────────────────────────
 
 async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensions, measures }) {
-  const { pre, post, needsWine: filterNeedsWine } = await compileFilters(filters, userId);
+  const { pre, post, exprFilters, needsWine: filterNeedsWine } = await compileFilters(filters, userId);
 
   if (!Array.isArray(dimensions) || !dimensions.length || dimensions.length > MAX_DIMENSIONS) {
     throw new QueryError(400, `grouped mode takes 1–${MAX_DIMENSIONS} dimensions`);
@@ -702,7 +861,9 @@ async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensio
       currencyMeta.fields.push({ i, path: f.path, currencyPath: 'currency' });
       valueExpr = null; // filled in below once the target currency is known
     } else if (f.normalized) {
-      valueExpr = normalizedRatingExpr(f.path, f.scalePath);
+      // Stars, not the 0–100 normal form (audit F3) — the same scale the
+      // filter takes, the sort orders by and the column displays.
+      valueExpr = ratingConversionExpr(f.path, f.scalePath, '5');
     }
     measureSpecs.push({ out: `m${i}`, label: `${m.agg}(${f.key})`, agg: m.agg, valueExpr, field: f });
   }
@@ -725,13 +886,17 @@ async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensio
       const spec = measureSpecs[cf.i];
       spec.valueExpr = expr; // null when no rates → measure yields null
     }
-    // Count rows whose price exists but cannot convert, over the same match.
+    // Count rows whose price exists but cannot convert — over the SAME
+    // filtered population as the buckets (audit F5: counting before the
+    // wine-side and expression filters overstated the exclusions).
     if (rates && rates[targetCurrency]) {
       const known = Object.keys(rates);
       const [uc] = await Bottle.aggregate([
         { $match: baseMatch(cellarIds, bottleScope, pre) },
-        { $match: { price: { $ne: null } } },
-        { $match: { currency: { $nin: known } } },
+        ...(needsWine ? WINE_LOOKUP : []),
+        ...(post.length ? [{ $match: { $and: post } }] : []),
+        ...exprFilterStages(exprFilters),
+        { $match: { price: { $ne: null }, currency: { $nin: known } } },
         { $count: 'n' },
       ]).option({ maxTimeMS: MAX_TIME_MS });
       unconvertibleRows = uc?.n || 0;
@@ -752,6 +917,7 @@ async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensio
     { $match: baseMatch(cellarIds, bottleScope, pre) },
     ...(needsWine ? WINE_LOOKUP : []),
     ...(post.length ? [{ $match: { $and: post } }] : []),
+    ...exprFilterStages(exprFilters),
     ...joinStages,
     { $group: groupStage },
     { $sort: { m0: -1, _id: 1 } },
@@ -765,6 +931,17 @@ async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensio
   // Taxonomy dimension ids → names (small: at most BUCKET_CAP ids per dim).
   for (let i = 0; i < dimFields.length; i++) {
     const f = dimFields[i];
+    // The cellar dimension groups by the cellar ObjectId — resolve to names
+    // from the scope set, which by construction contains every id that can
+    // appear (audit F4: raw hex ids were the bucket labels).
+    if (f.key === 'bottle.cellar') {
+      const names = new Map(scopeCellars.map((c) => [String(c._id), c.name]));
+      for (const b of buckets) {
+        const v = b._id[`d${i}`];
+        b._id[`d${i}`] = v == null ? null : (names.get(String(v)) || String(v));
+      }
+      continue;
+    }
     if (f.source !== 'taxonomy') continue;
     const Model = mongoose.model(f.taxonomyModel);
     const ids = [...new Set(buckets.map((b) => String(b._id[`d${i}`])).filter((x) => x && x !== 'null'))];
@@ -830,6 +1007,6 @@ module.exports = {
   runQuery,
   QueryError,
   // exported for unit tests
-  deriveScope, compileFilters, normalizedRatingExpr, convertedPriceExpr,
+  deriveScope, compileFilters, normalizedRatingExpr, ratingConversionExpr, convertedPriceExpr,
   MAX_TIME_MS, ROWS_LIMIT_MAX, BUCKET_CAP,
 };

--- a/backend/src/services/analytics/queryEngine.test.js
+++ b/backend/src/services/analytics/queryEngine.test.js
@@ -295,9 +295,38 @@ describe('bounds and caps', () => {
     expect(sort).toEqual({ price: -1, _id: 1 });
   });
 
-  test('a non-sortable field is refused as a sort, honestly', async () => {
-    await expect(runQuery(USER, { sort: { field: 'wine.country', dir: 'asc' } }))
+  test('a non-sortable field is refused as a sort, honestly (grapes is an array ref)', async () => {
+    await expect(runQuery(USER, { sort: { field: 'wine.grapes', dir: 'asc' } }))
       .rejects.toThrow(/not sortable/);
+  });
+
+  test('R-B: a taxonomy sort joins the name collection and sorts by it, tiebroken', async () => {
+    const cap = aggReturning([{ ids: [], total: [] }]);
+    await runQuery(USER, { sort: { field: 'wine.country', dir: 'asc' } });
+    const p = cap.pipelines[0];
+    const lookup = p.find((s) => s.$lookup && s.$lookup.from === 'countries');
+    expect(lookup.$lookup.localField).toBe('wd.country');
+    expect(p.find((s) => s.$sort).$sort).toEqual({ _sortVal: 1, _id: 1 });
+    // The wine lookup precedes the taxonomy join.
+    expect(p.findIndex((s) => s.$lookup && s.$lookup.from === 'winedefinitions'))
+      .toBeLessThan(p.findIndex((s) => s.$lookup && s.$lookup.from === 'countries'));
+  });
+
+  test('R-B: a personal KV sort joins entries with the bottle>vintage>null precedence', async () => {
+    const KEY_ID = 'd'.repeat(24);
+    PersonalDataKey.findOne.mockReturnValue({
+      lean: async () => ({ _id: KEY_ID, user: USER, name: 'ABV', type: 'decimal', unit: '%' }),
+    });
+    const cap = aggReturning([{ ids: [], total: [] }]);
+    await runQuery(USER, { sort: { field: `personal.${KEY_ID}`, dir: 'desc' } });
+    const p = cap.pipelines[0];
+    const lookup = p.find((s) => s.$lookup && s.$lookup.from === 'personaldataentries');
+    expect(lookup).toBeDefined();
+    const inner = lookup.$lookup.pipeline;
+    // Precedence is enforced INSIDE the sub-pipeline: prio sort then limit 1.
+    expect(inner.find((s) => s.$sort)).toEqual({ $sort: { _prio: 1 } });
+    expect(inner.find((s) => s.$limit)).toEqual({ $limit: 1 });
+    expect(p.find((s) => s.$sort && s.$sort._sortVal !== undefined).$sort).toEqual({ _sortVal: -1, _id: 1 });
   });
 
   test('grouped mode refuses a third dimension', async () => {
@@ -318,13 +347,48 @@ describe('bounds and caps', () => {
     expect(out.capped).toEqual({ type: 'buckets', at: BUCKET_CAP });
   });
 
-  test('a KV field is refused as a grouped dimension until R-B', async () => {
+  test('a NUMERIC KV field stays refused as a grouped dimension — every reading would be a bucket', async () => {
     PersonalDataKey.findOne.mockReturnValue({
       lean: async () => ({ _id: 'd'.repeat(24), user: USER, name: 'ABV', type: 'decimal' }),
     });
     await expect(runQuery(USER, {
       mode: 'grouped', dimensions: [`personal.${'d'.repeat(24)}`], measures: [{ field: '*', agg: 'count' }],
     })).rejects.toThrow(/cannot be grouped/);
+  });
+
+  test('R-B: an ENUM KV field groups by its joined value', async () => {
+    const KEY_ID = 'd'.repeat(24);
+    PersonalDataKey.findOne.mockReturnValue({
+      lean: async () => ({ _id: KEY_ID, user: USER, name: 'Source', type: 'enum', enumOptions: ['shop', 'auction'] }),
+    });
+    const cap = aggReturning([{ _id: { d0: 'shop' }, m0: 4 }, { _id: { d0: 'auction' }, m0: 2 }]);
+    const out = await runQuery(USER, {
+      mode: 'grouped', dimensions: [`personal.${KEY_ID}`], measures: [{ field: '*', agg: 'count' }],
+    });
+    const p = cap.pipelines[0];
+    expect(p.find((s) => s.$lookup && s.$lookup.from === 'personaldataentries')).toBeDefined();
+    expect(p.find((s) => s.$group).$group._id).toEqual({ d0: '$_d0v' });
+    expect(out.buckets).toEqual([
+      { dimensions: ['shop'], measures: [4] },
+      { dimensions: ['auction'], measures: [2] },
+    ]);
+  });
+
+  test('R-B: a numeric KV MEASURE aggregates the joined value behind an $isNumber guard', async () => {
+    const KEY_ID = 'd'.repeat(24);
+    PersonalDataKey.findOne.mockReturnValue({
+      lean: async () => ({ _id: KEY_ID, user: USER, name: 'ABV', type: 'decimal', unit: '%' }),
+    });
+    const cap = aggReturning([{ _id: { d0: 'red' }, m0: 3, m1: 13.8 }]);
+    const out = await runQuery(USER, {
+      mode: 'grouped', dimensions: ['wine.type'],
+      measures: [{ field: '*', agg: 'count' }, { field: `personal.${KEY_ID}`, agg: 'avg' }],
+    });
+    const p = cap.pipelines[0];
+    const group = p.find((s) => s.$group).$group;
+    expect(group.m1.$avg).toEqual({ $cond: [{ $isNumber: '$_m1v' }, '$_m1v', null] });
+    expect(out.measureLabels[1]).toBe('avg(ABV)');
+    expect(out.buckets[0].measures).toEqual([3, 13.8]);
   });
 });
 

--- a/backend/src/services/analytics/queryEngine.test.js
+++ b/backend/src/services/analytics/queryEngine.test.js
@@ -32,9 +32,10 @@ const PersonalDataKey = require('../../models/PersonalDataKey');
 const { toNormalized } = require('../../utils/ratingUtils');
 const { convertCurrency } = require('../../utils/exchangeRates');
 const {
-  runQuery, QueryError, compileFilters, normalizedRatingExpr, convertedPriceExpr,
+  runQuery, QueryError, compileFilters, normalizedRatingExpr, ratingConversionExpr, convertedPriceExpr,
   MAX_TIME_MS, ROWS_LIMIT_MAX, BUCKET_CAP,
 } = require('./queryEngine');
+const { toNormalized: toNorm, fromNormalized: fromNorm } = require('../../utils/ratingUtils');
 
 const USER = 'a'.repeat(24);
 const CELLAR_A = 'b'.repeat(24);
@@ -117,6 +118,21 @@ describe('normalizedRatingExpr parity with toNormalized', () => {
   });
 });
 
+describe('AUDIT F3: the star-conversion expression matches the JS composition', () => {
+  const starExpr = ratingConversionExpr('rating', 'ratingScale', '5');
+  test.each([
+    [4.5, '5'], [1, '5'], [17.5, '20'], [8, '20'], [92, '100'], [60, '100'], [100, '100'],
+  ])('%p on scale %s converts to the same stars as fromNormalized∘toNormalized', (v, scale) => {
+    expect(evalExpr(starExpr, { rating: v, ratingScale: scale }))
+      .toBeCloseTo(fromNorm(toNorm(v, scale), '5'), 6);
+  });
+  test('a 60-point Parker bottle no longer outranks a 5-star one', () => {
+    const parker60 = evalExpr(starExpr, { rating: 60, ratingScale: '100' });
+    const fiveStar = evalExpr(starExpr, { rating: 5, ratingScale: '5' });
+    expect(parker60).toBeLessThan(fiveStar);
+  });
+});
+
 describe('convertedPriceExpr parity with convertCurrency', () => {
   const rates = { USD: 1, EUR: 0.9, SEK: 10 };
   const { expr } = convertedPriceExpr('price', 'currency', rates, 'SEK');
@@ -195,9 +211,9 @@ describe('personal key/value filters', () => {
 
   test('entries narrow the bottle match: bottle-level ids OR wine-level (with vintage scope)', async () => {
     PersonalDataEntry.find.mockReturnValue(chainLean([
-      { targetType: 'bottle', bottle: 'e'.repeat(24) },
-      { targetType: 'wine', wineDefinition: 'f'.repeat(24), vintage: '2019' },
-      { targetType: 'wine', wineDefinition: '1'.repeat(24), vintage: null },
+      { targetType: 'bottle', bottle: 'e'.repeat(24), value: 15 },
+      { targetType: 'wine', wineDefinition: 'f'.repeat(24), vintage: '2019', value: 14.5 },
+      { targetType: 'wine', wineDefinition: '1'.repeat(24), vintage: null, value: 14.2 },
     ]));
     const { pre } = await compileFilters(
       [{ field: `personal.${KEY_ID}`, op: 'gte', value: 14 }], USER
@@ -207,10 +223,40 @@ describe('personal key/value filters', () => {
       { wineDefinition: 'f'.repeat(24), vintage: '2019' },
       { wineDefinition: '1'.repeat(24) },
     ]);
-    // The entry query was value-predicated and author-scoped.
-    expect(PersonalDataEntry.find).toHaveBeenCalledWith(
-      expect.objectContaining({ author: USER, key: KEY_ID, value: { $gte: 14 } })
+    // Audit F1: the entry query is predicate-FREE (precedence resolves in JS)
+    // and author-scoped.
+    expect(PersonalDataEntry.find).toHaveBeenCalledWith({ author: USER, key: KEY_ID });
+  });
+
+  test('AUDIT F1: a failing bottle-level entry vetoes a matching wine-level one', async () => {
+    // Wine-null ABV 14.5 matches '>= 14'; the bottle-level override 13.0
+    // fails it — the bottle's EFFECTIVE value is 13.0, so it must be OUT.
+    PersonalDataEntry.find.mockReturnValue(chainLean([
+      { targetType: 'wine', wineDefinition: 'f'.repeat(24), vintage: null, value: 14.5 },
+      { targetType: 'bottle', bottle: 'e'.repeat(24), value: 13.0 },
+    ]));
+    const { pre } = await compileFilters(
+      [{ field: `personal.${KEY_ID}`, op: 'gte', value: 14 }], USER
     );
+    expect(pre[0]).toEqual({
+      $and: [
+        { $or: [{ wineDefinition: 'f'.repeat(24) }] },
+        { _id: { $nin: ['e'.repeat(24)] } },
+      ],
+    });
+  });
+
+  test('AUDIT F1: a failing wine-VINTAGE entry carves its vintage out of a matching wine-null include', async () => {
+    PersonalDataEntry.find.mockReturnValue(chainLean([
+      { targetType: 'wine', wineDefinition: 'f'.repeat(24), vintage: null, value: 14.5 },
+      { targetType: 'wine', wineDefinition: 'f'.repeat(24), vintage: '2019', value: 12.0 },
+    ]));
+    const { pre } = await compileFilters(
+      [{ field: `personal.${KEY_ID}`, op: 'gte', value: 14 }], USER
+    );
+    expect(pre[0].$or).toEqual([
+      { wineDefinition: 'f'.repeat(24), vintage: { $nin: ['2019'] } },
+    ]);
   });
 
   test('no matching entries → a match-nothing condition, not an error', async () => {
@@ -455,5 +501,87 @@ describe('rows mode hydration', () => {
     Bottle.find.mockReturnValue(chainLean([{ _id: B1, cellar: CELLAR_A, wineDefinition: null }]));
     const out = await runQuery(USER, { columns: ['wine.producer', 'purchase.price'] });
     expect(out.rows[0].values).toEqual({ 'wine.producer': null, 'purchase.price': null });
+  });
+
+  test('AUDIT F3: a rating column hydrates in stars, whatever scale the row stored', async () => {
+    aggReturning([{ ids: [{ _id: B1 }], total: [{ n: 1 }] }]);
+    Bottle.find.mockReturnValue(chainLean([{
+      _id: B1, cellar: CELLAR_A, wineDefinition: null, rating: 92, ratingScale: '100',
+    }]));
+    const out = await runQuery(USER, { columns: ['rating.current'] });
+    expect(out.rows[0].values['rating.current']).toBeCloseTo(4.1, 5);
+  });
+});
+
+describe('AUDIT fixes 2026-08-19 — the rest of the confirmed nine', () => {
+  test('F2: a date eq filter compiles to a full-day range, not a midnight instant', async () => {
+    const { pre } = await compileFilters(
+      [{ field: 'bottle.addedAt', op: 'eq', value: '2026-08-18' }], USER
+    );
+    const cond = pre[0].createdAt;
+    expect(cond.$gte.toISOString()).toBe('2026-08-18T00:00:00.000Z');
+    expect(cond.$lt.toISOString()).toBe('2026-08-19T00:00:00.000Z');
+  });
+
+  test('F2: between includes the entire named end day', async () => {
+    const { pre } = await compileFilters(
+      [{ field: 'consumption.date', op: 'between', value: ['2026-08-01', '2026-08-31'] }], USER
+    );
+    const cond = pre[0].consumedAt;
+    expect(cond.$gte.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+    expect(cond.$lt.toISOString()).toBe('2026-09-01T00:00:00.000Z');
+  });
+
+  test('F3: a rating filter compiles to an expression filter in stars, never a raw path match', async () => {
+    const { pre, post, exprFilters } = await compileFilters(
+      [{ field: 'rating.current', op: 'gte', value: 4 }], USER
+    );
+    expect(pre).toEqual([]);
+    expect(post).toEqual([]);
+    expect(exprFilters).toHaveLength(1);
+    expect(exprFilters[0].pred).toEqual({ $gte: 4 });
+    // The pipeline stage pair lands after the match: verified end-to-end.
+    const cap = aggReturning([{ ids: [], total: [] }]);
+    await runQuery(USER, { filters: [{ field: 'rating.current', op: 'gte', value: 4 }] });
+    const p = cap.pipelines[0];
+    const af = p.find((s) => s.$addFields && s.$addFields._f0);
+    expect(af).toBeDefined();
+    expect(p.find((s) => s.$match && s.$match._f0)).toEqual({ $match: { _f0: { $gte: 4 } } });
+  });
+
+  test('F3: a rating filter value outside 0–5 stars is rejected', async () => {
+    await expect(compileFilters([{ field: 'rating.current', op: 'gte', value: 92 }], USER))
+      .rejects.toThrow(/stars run 0–5/);
+  });
+
+  test('F3: sorting by rating orders by the star expression with the tiebreaker', async () => {
+    const cap = aggReturning([{ ids: [], total: [] }]);
+    await runQuery(USER, { sort: { field: 'rating.current', dir: 'desc' } });
+    const p = cap.pipelines[0];
+    expect(p.find((s) => s.$addFields && s.$addFields._sortVal)).toBeDefined();
+    expect(p.find((s) => s.$sort).$sort).toEqual({ _sortVal: -1, _id: 1 });
+  });
+
+  test('F4: grouping by Cellar returns cellar NAMES as bucket labels', async () => {
+    aggReturning([
+      { _id: { d0: CELLAR_A }, m0: 5 },
+      { _id: { d0: CELLAR_B }, m0: 2 },
+    ]);
+    const out = await runQuery(USER, {
+      mode: 'grouped', dimensions: ['bottle.cellar'], measures: [{ field: '*', agg: 'count' }],
+    });
+    expect(out.buckets.map((b) => b.dimensions[0])).toEqual(['Home', 'Shared']);
+  });
+
+  test('F8: an empty string in a numeric filter is a 400, never a silent zero', async () => {
+    await expect(compileFilters(
+      [{ field: 'purchase.price', op: 'between', value: ['', '100'] }], USER
+    )).rejects.toThrow(/value is required/);
+  });
+
+  test('F9: date fields refuse to group until calendar bucketing exists', async () => {
+    await expect(runQuery(USER, {
+      mode: 'grouped', dimensions: ['bottle.addedAt'], measures: [{ field: '*', agg: 'count' }],
+    })).rejects.toThrow(/cannot be grouped/);
   });
 });

--- a/frontend/src/components/AnalyticsCharts.js
+++ b/frontend/src/components/AnalyticsCharts.js
@@ -1,0 +1,134 @@
+import React, { useMemo } from 'react';
+import {
+  ResponsiveContainer, BarChart, Bar, PieChart, Pie, Cell,
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+} from 'recharts';
+import { SERIES_COLORS } from '../utils/chartColors';
+
+/**
+ * Charts over the analytics grouped result (#987 R-C, first slice).
+ *
+ * Pure presentation: the grouped response IS the chart data — every number
+ * here came through the engine's caps and normalizations, so nothing is
+ * computed client-side beyond pivoting the bucket list into recharts' shape.
+ * Colors come from the app-wide SERIES_COLORS palette (one definition for
+ * every chart in the app — the palette-unification decision, D1/R-C).
+ *
+ * Shapes: 1 dimension → bar | donut | line; 2 dimensions → stacked bar
+ * (dim1 on the axis, dim2 as the stack segments, capped for legibility).
+ */
+
+const STACK_SERIES_CAP = 10;
+const OTHER = '…other';
+
+function pivotStacked(buckets, measureIndex) {
+  // buckets: [{dimensions: [d1, d2], measures: [...]}] → rows keyed by d1
+  // with one property per d2 series. Series beyond the cap fold into OTHER.
+  const seriesTotals = new Map();
+  for (const b of buckets) {
+    const s = String(b.dimensions[1] ?? '—');
+    seriesTotals.set(s, (seriesTotals.get(s) || 0) + (b.measures[measureIndex] || 0));
+  }
+  const keep = new Set([...seriesTotals.entries()]
+    .sort((a, z) => z[1] - a[1])
+    .slice(0, STACK_SERIES_CAP)
+    .map(([k]) => k));
+  const rows = new Map();
+  for (const b of buckets) {
+    const x = String(b.dimensions[0] ?? '—');
+    const rawS = String(b.dimensions[1] ?? '—');
+    const s = keep.has(rawS) ? rawS : OTHER;
+    if (!rows.has(x)) rows.set(x, { name: x });
+    const row = rows.get(x);
+    row[s] = (row[s] || 0) + (b.measures[measureIndex] ?? 0);
+  }
+  const series = [...keep, ...(keep.size < seriesTotals.size ? [OTHER] : [])];
+  return { rows: [...rows.values()], series };
+}
+
+export default function AnalyticsCharts({ data, chartType, measureIndex }) {
+  const mi = Math.min(measureIndex, data.measureLabels.length - 1);
+  const twoDims = data.dimensionKeys.length === 2;
+
+  const flat = useMemo(() => data.buckets.map((b) => ({
+    name: String(b.dimensions[0] ?? '—'),
+    value: b.measures[mi] ?? 0,
+  })), [data, mi]);
+
+  const stacked = useMemo(
+    () => (twoDims ? pivotStacked(data.buckets, mi) : null),
+    [data, mi, twoDims]
+  );
+
+  const sortedFlat = useMemo(
+    () => [...flat].sort((a, z) => a.name.localeCompare(z.name, undefined, { numeric: true })),
+    [flat]
+  );
+
+  const round = (v) => (typeof v === 'number' ? Math.round(v * 100) / 100 : v);
+
+  if (chartType === 'donut' && !twoDims) {
+    return (
+      <div className="at-chart">
+        <ResponsiveContainer width="100%" height={320}>
+          <PieChart>
+            <Pie data={flat} dataKey="value" nameKey="name" innerRadius="55%" outerRadius="85%" paddingAngle={1}>
+              {flat.map((_, i) => <Cell key={i} fill={SERIES_COLORS[i % SERIES_COLORS.length]} />)}
+            </Pie>
+            <Tooltip formatter={round} />
+            <Legend />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  }
+
+  if (chartType === 'line' && !twoDims) {
+    return (
+      <div className="at-chart">
+        <ResponsiveContainer width="100%" height={320}>
+          <LineChart data={sortedFlat} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+            <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 11 }} width={48} />
+            <Tooltip formatter={round} />
+            <Line type="monotone" dataKey="value" name={data.measureLabels[mi]} stroke={SERIES_COLORS[0]} dot={{ r: 2 }} strokeWidth={2} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  }
+
+  if (twoDims && stacked) {
+    return (
+      <div className="at-chart">
+        <ResponsiveContainer width="100%" height={340}>
+          <BarChart data={stacked.rows} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+            <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 11 }} width={48} />
+            <Tooltip formatter={round} />
+            <Legend />
+            {stacked.series.map((s, i) => (
+              <Bar key={s} dataKey={s} stackId="a" fill={SERIES_COLORS[i % SERIES_COLORS.length]} />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  }
+
+  return (
+    <div className="at-chart">
+      <ResponsiveContainer width="100%" height={320}>
+        <BarChart data={flat} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+          <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+          <YAxis tick={{ fontSize: 11 }} width={48} />
+          <Tooltip formatter={round} />
+          <Bar dataKey="value" name={data.measureLabels[mi]} fill={SERIES_COLORS[0]} radius={[3, 3, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/AnalyticsTable.css
+++ b/frontend/src/components/AnalyticsTable.css
@@ -166,3 +166,9 @@
     flex-shrink: 0;
   }
 }
+
+/* R-B grouping */
+.at-grouping select { max-width: 220px; margin-bottom: 4px; background: var(--color-surface); color: var(--color-text); border: 1px solid var(--color-border); border-radius: 6px; padding: 4px 8px; font-size: 0.85rem; }
+.at-measure-fixed { font-size: 0.82rem; color: var(--color-text-secondary); }
+.at-measure-row { display: flex; gap: 6px; }
+.at-note { font-size: 0.8rem; color: var(--color-text-secondary); padding: 2px 2px; }

--- a/frontend/src/components/AnalyticsTable.css
+++ b/frontend/src/components/AnalyticsTable.css
@@ -178,3 +178,6 @@
 .at-chart-toolbar select { background: var(--color-surface); color: var(--color-text); border: 1px solid var(--color-border); border-radius: 6px; padding: 4px 8px; font-size: 0.85rem; }
 .at-chart { border: 1px solid var(--color-border); border-radius: 8px; padding: 10px 6px 4px; background: var(--color-surface); }
 .at-chart .recharts-text { fill: var(--color-text-secondary); }
+
+/* Presets */
+.at-preset-select { background: var(--color-surface); color: var(--color-text); border: 1px solid var(--color-border); border-radius: 16px; padding: 5px 10px; font-size: 0.82rem; max-width: 180px; }

--- a/frontend/src/components/AnalyticsTable.css
+++ b/frontend/src/components/AnalyticsTable.css
@@ -172,3 +172,9 @@
 .at-measure-fixed { font-size: 0.82rem; color: var(--color-text-secondary); }
 .at-measure-row { display: flex; gap: 6px; }
 .at-note { font-size: 0.8rem; color: var(--color-text-secondary); padding: 2px 2px; }
+
+/* R-C charts */
+.at-chart-toolbar { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.at-chart-toolbar select { background: var(--color-surface); color: var(--color-text); border: 1px solid var(--color-border); border-radius: 6px; padding: 4px 8px; font-size: 0.85rem; }
+.at-chart { border: 1px solid var(--color-border); border-radius: 8px; padding: 10px 6px 4px; background: var(--color-surface); }
+.at-chart .recharts-text { fill: var(--color-text-secondary); }

--- a/frontend/src/components/AnalyticsTable.js
+++ b/frontend/src/components/AnalyticsTable.js
@@ -6,6 +6,7 @@ import { listCellars } from '../api/cellars';
 import { csvEscape } from '../utils/importReport';
 import downloadBlob from '../utils/downloadBlob';
 import AnalyticsCharts from './AnalyticsCharts';
+import { ANALYTICS_PRESETS } from '../utils/analyticsPresets';
 import './AnalyticsTable.css';
 
 /**
@@ -209,6 +210,24 @@ export default function AnalyticsTable({ cellarId }) {
     setOffset(0);
   };
 
+  // A preset is one click that sets the WHOLE table state — scope, filters,
+  // grouping, chart, columns, sort. Everything it does is visible in the
+  // controls afterwards, so a preset is a starting point, never a black box.
+  const applyPreset = (key) => {
+    const preset = ANALYTICS_PRESETS.find((p) => p.key === key);
+    if (!preset) return;
+    const s = preset.build();
+    setBottleScope(s.bottleScope || 'active');
+    setGrouping(s.grouping || { on: false, dim1: 'wine.type', dim2: '', measures: [] });
+    setChartType(s.chartType || 'table');
+    setChartMeasure(s.chartType && s.grouping?.measures?.length ? 1 : 0);
+    setFilters(s.filters || []);
+    setDraftFilters(s.filters || []);
+    if (s.columns) setColumns(s.columns);
+    setSort(s.sort || null);
+    setOffset(0);
+  };
+
   const addDraftFilter = () => {
     const first = catalogue.find((f) => f.filterable);
     if (!first) return;
@@ -327,6 +346,17 @@ export default function AnalyticsTable({ cellarId }) {
           )}
         </div>
         <div className="at-actions">
+          <select
+            className="at-preset-select"
+            value=""
+            onChange={(e) => { if (e.target.value) applyPreset(e.target.value); }}
+            aria-label={t('analytics.presets', 'Pre-built views')}
+          >
+            <option value="">{t('analytics.presets', 'Pre-built views')}…</option>
+            {ANALYTICS_PRESETS.map((p) => (
+              <option key={p.key} value={p.key}>{t(`analytics.preset.${p.key}`, p.label)}</option>
+            ))}
+          </select>
           <button
             className={`at-chip ${grouping.on ? 'at-apply' : ''}`}
             onClick={() => setGrouping((g) => ({ ...g, on: !g.on }))}

--- a/frontend/src/components/AnalyticsTable.js
+++ b/frontend/src/components/AnalyticsTable.js
@@ -110,6 +110,10 @@ export default function AnalyticsTable({ cellarId }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [scopeOpen, setScopeOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
+  // Grouped mode (R-B): when on, the table pivots — 1-2 dimensions, count
+  // always as the first measure, up to two more picked from measure-capable
+  // fields. Off = the flat rows table.
+  const [grouping, setGrouping] = useState({ on: false, dim1: 'wine.type', dim2: '', measures: [] });
   const queryRef = useRef(0);
 
   const byKey = useMemo(() => new Map(catalogue.map((f) => [f.key, f])), [catalogue]);
@@ -139,14 +143,25 @@ export default function AnalyticsTable({ cellarId }) {
     return () => { live = false; };
   }, [apiFetch]);
 
-  const query = useMemo(() => ({
-    scope: { cellars: scopeCellars, bottles: bottleScope },
-    columns,
-    filters: filters.length ? filters : undefined,
-    sort: sort || undefined,
-    limit: PAGE_SIZE,
-    offset,
-  }), [scopeCellars, bottleScope, columns, filters, sort, offset]);
+  const query = useMemo(() => {
+    if (grouping.on && grouping.dim1) {
+      return {
+        mode: 'grouped',
+        scope: { cellars: scopeCellars, bottles: bottleScope },
+        filters: filters.length ? filters : undefined,
+        dimensions: [grouping.dim1, ...(grouping.dim2 ? [grouping.dim2] : [])],
+        measures: [{ field: '*', agg: 'count' }, ...grouping.measures.filter((m) => m.field && m.agg)],
+      };
+    }
+    return {
+      scope: { cellars: scopeCellars, bottles: bottleScope },
+      columns,
+      filters: filters.length ? filters : undefined,
+      sort: sort || undefined,
+      limit: PAGE_SIZE,
+      offset,
+    };
+  }, [scopeCellars, bottleScope, columns, filters, sort, offset, grouping]);
 
   useEffect(() => {
     let live = true;
@@ -206,26 +221,44 @@ export default function AnalyticsTable({ cellarId }) {
   const exportCsv = useCallback(async () => {
     setExporting(true);
     try {
-      const rows = [];
-      let at = 0;
-      let total = Infinity;
-      while (at < Math.min(total, CSV_MAX_ROWS)) {
-        const res = await runAnalyticsQuery(apiFetch, { ...query, limit: 200, offset: at });
+      let csv;
+      if (query.mode === 'grouped') {
+        // Grouped exports are one bounded response — the current buckets.
+        const res = await runAnalyticsQuery(apiFetch, query);
         const body = await res.json();
         if (!res.ok) throw new Error(body.error || 'export failed');
-        total = body.total;
-        rows.push(...body.rows);
-        if (!body.rows.length) break;
-        at += body.rows.length;
+        const header = [
+          ...body.dimensionKeys.map((k) => csvEscape(byKey.get(k)?.label || k)),
+          ...body.measureLabels.map(csvEscape),
+        ].join(',');
+        const lines = body.buckets.map((b) => [
+          ...b.dimensions.map((d) => csvEscape(d ?? '')),
+          ...b.measures.map((m) => csvEscape(m ?? '')),
+        ].join(','));
+        csv = header + '\n' + lines.join('\n');
+      } else {
+        const rows = [];
+        let at = 0;
+        let total = Infinity;
+        while (at < Math.min(total, CSV_MAX_ROWS)) {
+          const res = await runAnalyticsQuery(apiFetch, { ...query, limit: 200, offset: at });
+          const body = await res.json();
+          if (!res.ok) throw new Error(body.error || 'export failed');
+          total = body.total;
+          rows.push(...body.rows);
+          if (!body.rows.length) break;
+          at += body.rows.length;
+        }
+        const header = columns.map((k) => csvEscape(byKey.get(k)?.label || k)).join(',');
+        const lines = rows.map((r) => columns.map((k) => {
+          const v = r.values[k];
+          return csvEscape(Array.isArray(v) ? v.join('; ') : v ?? '');
+        }).join(','));
+        const truncated = total > CSV_MAX_ROWS ? `\n"— truncated at ${CSV_MAX_ROWS} of ${total} rows"` : '';
+        csv = header + '\n' + lines.join('\n') + truncated;
       }
-      const header = columns.map((k) => csvEscape(byKey.get(k)?.label || k)).join(',');
-      const lines = rows.map((r) => columns.map((k) => {
-        const v = r.values[k];
-        return csvEscape(Array.isArray(v) ? v.join('; ') : v ?? '');
-      }).join(','));
-      const truncated = total > CSV_MAX_ROWS ? `\n"— truncated at ${CSV_MAX_ROWS} of ${total} rows"` : '';
       // UTF-8 BOM so Excel opens Swedish/French characters correctly.
-      downloadBlob('﻿' + header + '\n' + lines.join('\n') + truncated, 'cellarion-analytics.csv', 'text/csv;charset=utf-8');
+      downloadBlob('﻿' + csv, 'cellarion-analytics.csv', 'text/csv;charset=utf-8');
     } catch {
       setError(t('analytics.exportFailed', 'Export failed — try again'));
     } finally {
@@ -290,14 +323,78 @@ export default function AnalyticsTable({ cellarId }) {
           )}
         </div>
         <div className="at-actions">
-          <button className="at-chip" onClick={() => setPickerOpen((o) => !o)} aria-expanded={pickerOpen}>
-            {t('analytics.columns', 'Columns')} ({shownColumns.length})
+          <button
+            className={`at-chip ${grouping.on ? 'at-apply' : ''}`}
+            onClick={() => setGrouping((g) => ({ ...g, on: !g.on }))}
+            aria-pressed={grouping.on}
+          >
+            {t('analytics.group', 'Group')}
           </button>
+          {!grouping.on && (
+            <button className="at-chip" onClick={() => setPickerOpen((o) => !o)} aria-expanded={pickerOpen}>
+              {t('analytics.columns', 'Columns')} ({shownColumns.length})
+            </button>
+          )}
           <button className="at-chip" onClick={exportCsv} disabled={exporting || !data}>
             {exporting ? t('analytics.exporting', 'Exporting…') : t('analytics.exportCsv', 'Export CSV')}
           </button>
         </div>
       </div>
+
+      {grouping.on && (
+        <div className="at-picker at-grouping">
+          <div className="at-picker-domain">
+            <strong>{t('analytics.groupBy', 'Group by')}</strong>
+            <select value={grouping.dim1} onChange={(e) => setGrouping((g) => ({ ...g, dim1: e.target.value }))}>
+              {catalogue.filter((f) => f.groupable).map((f) => <option key={f.key} value={f.key}>{f.label}</option>)}
+            </select>
+            <select value={grouping.dim2} onChange={(e) => setGrouping((g) => ({ ...g, dim2: e.target.value }))}>
+              <option value="">{t('analytics.noSecondDimension', '— no second dimension —')}</option>
+              {catalogue.filter((f) => f.groupable && f.key !== grouping.dim1).map((f) => <option key={f.key} value={f.key}>{f.label}</option>)}
+            </select>
+          </div>
+          <div className="at-picker-domain">
+            <strong>{t('analytics.measures', 'Measures')}</strong>
+            <span className="at-measure-fixed">{t('analytics.countAlways', 'Bottle count (always)')}</span>
+            {[0, 1].map((i) => {
+              const m = grouping.measures[i] || { field: '', agg: '' };
+              const fieldDef = byKey.get(m.field);
+              return (
+                <span key={i} className="at-measure-row">
+                  <select
+                    value={m.field}
+                    onChange={(e) => {
+                      const f = byKey.get(e.target.value);
+                      setGrouping((g) => {
+                        const ms = [...g.measures];
+                        ms[i] = e.target.value ? { field: e.target.value, agg: f?.aggregations?.[0] || 'avg' } : undefined;
+                        return { ...g, measures: ms.filter(Boolean) };
+                      });
+                    }}
+                  >
+                    <option value="">{t('analytics.noMeasure', '— none —')}</option>
+                    {catalogue.filter((f) => (f.aggregations || []).length).map((f) => (
+                      <option key={f.key} value={f.key}>{f.label}</option>
+                    ))}
+                  </select>
+                  {m.field && (
+                    <select
+                      value={m.agg}
+                      onChange={(e) => setGrouping((g) => {
+                        const ms = [...g.measures];
+                        ms[i] = { ...ms[i], agg: e.target.value };
+                        return { ...g, measures: ms };
+                      })}
+                    >
+                      {(fieldDef?.aggregations || []).map((a) => <option key={a} value={a}>{a}</option>)}
+                    </select>
+                  )}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {pickerOpen && (
         <div className="at-picker">
@@ -365,59 +462,106 @@ export default function AnalyticsTable({ cellarId }) {
 
       {error && <div className="at-error">{error}</div>}
 
-      <div className="at-scroll">
-        <table>
-          <thead>
-            <tr>
-              {shownColumns.map((k) => {
-                const f = byKey.get(k);
-                const sorted = sort && sort.field === k;
-                return (
-                  <th
-                    key={k}
-                    className={f.sortable ? 'at-sortable' : ''}
-                    onClick={() => headerSort(f)}
-                    title={f.sortable ? t('analytics.sortHint', 'Click to sort') : t('analytics.notSortable', 'Not sortable yet')}
-                  >
-                    {f.label}{f.unit && f.unit !== 'currency' ? ` (${f.unit})` : ''}
-                    {sorted ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : ''}
-                  </th>
-                );
-              })}
-            </tr>
-          </thead>
-          <tbody>
-            {(data?.rows || []).map((r) => (
-              <tr key={r.id}>
-                {shownColumns.map((k) => (
-                  <td key={k} data-label={byKey.get(k)?.label}>{formatValue(r.values[k], byKey.get(k))}</td>
+      {data?.mode === 'grouped' ? (
+        <>
+          {data.currency && (
+            <div className="at-note">
+              {t('analytics.currencyNote', 'Monetary values converted to {{code}}', { code: data.currency.target })}
+              {data.currency.unconvertibleRows > 0 && ' — ' + t('analytics.unconvertible', '{{n}} row(s) had no exchange rate and are excluded', { n: data.currency.unconvertibleRows })}
+              {!data.currency.ratesAvailable && ' — ' + t('analytics.noRates', 'no exchange rates available; monetary measures are empty')}
+            </div>
+          )}
+          {data.capped && (
+            <div className="at-note">{t('analytics.bucketsCapped', 'Showing the top {{n}} groups — narrow the scope or filters for the rest', { n: data.capped.at })}</div>
+          )}
+          <div className="at-scroll">
+            <table>
+              <thead>
+                <tr>
+                  {data.dimensionKeys.map((k) => (
+                    <th key={k}>{byKey.get(k)?.label || k}</th>
+                  ))}
+                  {data.measureLabels.map((l) => <th key={l}>{l === 'count' ? t('analytics.count', 'Bottles') : l}</th>)}
+                </tr>
+              </thead>
+              <tbody>
+                {data.buckets.map((b, i) => (
+                  <tr key={i}>
+                    {b.dimensions.map((d, j) => (
+                      <td key={j} data-label={byKey.get(data.dimensionKeys[j])?.label}>{formatValue(d, byKey.get(data.dimensionKeys[j]))}</td>
+                    ))}
+                    {b.measures.map((m, j) => (
+                      <td key={`m${j}`} data-label={data.measureLabels[j]}>
+                        {m === null || m === undefined ? '—' : typeof m === 'number' ? Math.round(m * 100) / 100 : String(m)}
+                      </td>
+                    ))}
+                  </tr>
                 ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        {loading && <div className="at-loading">{t('analytics.loading', 'Loading…')}</div>}
-        {!loading && data && !data.rows.length && (
-          <div className="at-empty">{t('analytics.empty', 'No bottles match this scope and these filters.')}</div>
-        )}
-      </div>
+              </tbody>
+            </table>
+            {loading && <div className="at-loading">{t('analytics.loading', 'Loading…')}</div>}
+            {!loading && !data.buckets.length && (
+              <div className="at-empty">{t('analytics.empty', 'No bottles match this scope and these filters.')}</div>
+            )}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="at-scroll">
+            <table>
+              <thead>
+                <tr>
+                  {shownColumns.map((k) => {
+                    const f = byKey.get(k);
+                    const sorted = sort && sort.field === k;
+                    return (
+                      <th
+                        key={k}
+                        className={f.sortable ? 'at-sortable' : ''}
+                        onClick={() => headerSort(f)}
+                        title={f.sortable ? t('analytics.sortHint', 'Click to sort') : t('analytics.notSortable', 'Not sortable')}
+                      >
+                        {f.label}{f.unit && f.unit !== 'currency' ? ` (${f.unit})` : ''}
+                        {sorted ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : ''}
+                      </th>
+                    );
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {(data?.rows || []).map((r) => (
+                  <tr key={r.id}>
+                    {shownColumns.map((k) => (
+                      <td key={k} data-label={byKey.get(k)?.label}>{formatValue(r.values[k], byKey.get(k))}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {loading && <div className="at-loading">{t('analytics.loading', 'Loading…')}</div>}
+            {!loading && data && !(data.rows || []).length && (
+              <div className="at-empty">{t('analytics.empty', 'No bottles match this scope and these filters.')}</div>
+            )}
+          </div>
 
-      {data && (
-        <div className="at-pager">
-          <button className="at-chip" disabled={offset === 0} onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}>
-            {t('analytics.prev', '‹ Previous')}
-          </button>
-          <span>
-            {t('analytics.pageInfo', '{{from}}–{{to}} of {{total}}', {
-              from: data.total === 0 ? 0 : offset + 1,
-              to: offset + (data.rows?.length || 0),
-              total: data.total,
-            })}
-          </span>
-          <button className="at-chip" disabled={offset + PAGE_SIZE >= data.total} onClick={() => setOffset(offset + PAGE_SIZE)}>
-            {t('analytics.next', 'Next ›')}
-          </button>
-        </div>
+          {data && data.mode !== 'grouped' && (
+            <div className="at-pager">
+              <button className="at-chip" disabled={offset === 0} onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}>
+                {t('analytics.prev', '‹ Previous')}
+              </button>
+              <span>
+                {t('analytics.pageInfo', '{{from}}–{{to}} of {{total}}', {
+                  from: data.total === 0 ? 0 : offset + 1,
+                  to: offset + (data.rows?.length || 0),
+                  total: data.total,
+                })}
+              </span>
+              <button className="at-chip" disabled={offset + PAGE_SIZE >= data.total} onClick={() => setOffset(offset + PAGE_SIZE)}>
+                {t('analytics.next', 'Next ›')}
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/AnalyticsTable.js
+++ b/frontend/src/components/AnalyticsTable.js
@@ -5,6 +5,7 @@ import { getAnalyticsCatalogue, runAnalyticsQuery } from '../api/analytics';
 import { listCellars } from '../api/cellars';
 import { csvEscape } from '../utils/importReport';
 import downloadBlob from '../utils/downloadBlob';
+import AnalyticsCharts from './AnalyticsCharts';
 import './AnalyticsTable.css';
 
 /**
@@ -114,6 +115,9 @@ export default function AnalyticsTable({ cellarId }) {
   // always as the first measure, up to two more picked from measure-capable
   // fields. Off = the flat rows table.
   const [grouping, setGrouping] = useState({ on: false, dim1: 'wine.type', dim2: '', measures: [] });
+  // R-C: how the grouped result renders — the table stays the default.
+  const [chartType, setChartType] = useState('table'); // 'table' | 'bar' | 'donut' | 'line'
+  const [chartMeasure, setChartMeasure] = useState(0);
   const queryRef = useRef(0);
 
   const byKey = useMemo(() => new Map(catalogue.map((f) => [f.key, f])), [catalogue]);
@@ -464,6 +468,32 @@ export default function AnalyticsTable({ cellarId }) {
 
       {data?.mode === 'grouped' ? (
         <>
+          <div className="at-chart-toolbar">
+            {['table', 'bar', 'donut', 'line'].map((ct) => {
+              const disabled = (ct === 'donut' || ct === 'line') && data.dimensionKeys.length === 2;
+              return (
+                <button
+                  key={ct}
+                  className={`at-chip ${chartType === ct ? 'at-apply' : ''}`}
+                  disabled={disabled}
+                  title={disabled ? t('analytics.oneDimOnly', 'One dimension only') : undefined}
+                  onClick={() => setChartType(ct)}
+                >
+                  {t(`analytics.chart.${ct}`, ct === 'table' ? 'Table' : ct === 'bar' ? 'Bars' : ct === 'donut' ? 'Donut' : 'Line')}
+                </button>
+              );
+            })}
+            {chartType !== 'table' && data.measureLabels.length > 1 && (
+              <select value={chartMeasure} onChange={(e) => setChartMeasure(Number(e.target.value))}>
+                {data.measureLabels.map((l, i) => (
+                  <option key={l} value={i}>{l === 'count' ? t('analytics.count', 'Bottles') : l}</option>
+                ))}
+              </select>
+            )}
+          </div>
+          {chartType !== 'table' && data.buckets.length > 0 && (
+            <AnalyticsCharts data={data} chartType={chartType} measureIndex={chartMeasure} />
+          )}
           {data.currency && (
             <div className="at-note">
               {t('analytics.currencyNote', 'Monetary values converted to {{code}}', { code: data.currency.target })}
@@ -474,36 +504,41 @@ export default function AnalyticsTable({ cellarId }) {
           {data.capped && (
             <div className="at-note">{t('analytics.bucketsCapped', 'Showing the top {{n}} groups — narrow the scope or filters for the rest', { n: data.capped.at })}</div>
           )}
-          <div className="at-scroll">
-            <table>
-              <thead>
-                <tr>
-                  {data.dimensionKeys.map((k) => (
-                    <th key={k}>{byKey.get(k)?.label || k}</th>
-                  ))}
-                  {data.measureLabels.map((l) => <th key={l}>{l === 'count' ? t('analytics.count', 'Bottles') : l}</th>)}
-                </tr>
-              </thead>
-              <tbody>
-                {data.buckets.map((b, i) => (
-                  <tr key={i}>
-                    {b.dimensions.map((d, j) => (
-                      <td key={j} data-label={byKey.get(data.dimensionKeys[j])?.label}>{formatValue(d, byKey.get(data.dimensionKeys[j]))}</td>
+          {chartType === 'table' && (
+            <div className="at-scroll">
+              <table>
+                <thead>
+                  <tr>
+                    {data.dimensionKeys.map((k) => (
+                      <th key={k}>{byKey.get(k)?.label || k}</th>
                     ))}
-                    {b.measures.map((m, j) => (
-                      <td key={`m${j}`} data-label={data.measureLabels[j]}>
-                        {m === null || m === undefined ? '—' : typeof m === 'number' ? Math.round(m * 100) / 100 : String(m)}
-                      </td>
-                    ))}
+                    {data.measureLabels.map((l) => <th key={l}>{l === 'count' ? t('analytics.count', 'Bottles') : l}</th>)}
                   </tr>
-                ))}
-              </tbody>
-            </table>
-            {loading && <div className="at-loading">{t('analytics.loading', 'Loading…')}</div>}
-            {!loading && !data.buckets.length && (
-              <div className="at-empty">{t('analytics.empty', 'No bottles match this scope and these filters.')}</div>
-            )}
-          </div>
+                </thead>
+                <tbody>
+                  {data.buckets.map((b, i) => (
+                    <tr key={i}>
+                      {b.dimensions.map((d, j) => (
+                        <td key={j} data-label={byKey.get(data.dimensionKeys[j])?.label}>{formatValue(d, byKey.get(data.dimensionKeys[j]))}</td>
+                      ))}
+                      {b.measures.map((m, j) => (
+                        <td key={`m${j}`} data-label={data.measureLabels[j]}>
+                          {m === null || m === undefined ? '—' : typeof m === 'number' ? Math.round(m * 100) / 100 : String(m)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {loading && <div className="at-loading">{t('analytics.loading', 'Loading…')}</div>}
+              {!loading && !data.buckets.length && (
+                <div className="at-empty">{t('analytics.empty', 'No bottles match this scope and these filters.')}</div>
+              )}
+            </div>
+          )}
+          {chartType !== 'table' && !data.buckets.length && !loading && (
+            <div className="at-empty">{t('analytics.empty', 'No bottles match this scope and these filters.')}</div>
+          )}
         </>
       ) : (
         <>

--- a/frontend/src/components/AnalyticsTable.js
+++ b/frontend/src/components/AnalyticsTable.js
@@ -132,6 +132,15 @@ export default function AnalyticsTable({ cellarId }) {
     return [...grouped.entries()].sort((a, b) => order.indexOf(a[0]) - order.indexOf(b[0]));
   }, [catalogue]);
 
+  // Follow in-place navigation between cellars (audit F6): the component
+  // stays mounted when only the route param changes, so the scope must track
+  // the prop or the table keeps showing the previous cellar's bottles under
+  // the new cellar's header.
+  useEffect(() => {
+    setScopeCellars(cellarId ? [cellarId] : 'all');
+    setOffset(0);
+  }, [cellarId]);
+
   useEffect(() => {
     let live = true;
     (async () => {

--- a/frontend/src/locales/coverage.test.js
+++ b/frontend/src/locales/coverage.test.js
@@ -200,15 +200,24 @@ describe('virtual:locale-coverage (build-time plugin output)', () => {
     expect(SHIPPED_CODES).toContain('en');
   });
 
-  test('Swedish is complete enough to ship (guards against a locale regression)', () => {
-    expect(LOCALES.find((l) => l.code === 'sv').beta).toBe(false);
+  // 2026-08-19: the #987 analytics feature added ~60 en keys, which diluted
+  // sv to just under the 90% gate — a mechanical consequence of feature work,
+  // not a translation regression. Johan's call: sv wears the beta label until
+  // Weblate refills it, and these pins assert the MECHANISM (beta follows the
+  // ratio) rather than hard-coding Swedish's status either way — so they hold
+  // through the dip AND flip nothing when Weblate catches up.
+  test("Swedish's ship status follows the threshold, never a hardcoded label", () => {
+    const sv = LOCALES.find((l) => l.code === 'sv');
+    expect(sv).toBeDefined();
+    expect(sv.beta).toBe(sv.ratio < BETA_BELOW);
+    expect(SHIPPED_CODES.includes('sv')).toBe(!sv.beta);
   });
 
-  test('Swedish is flagged unreviewed but still ships (label ≠ gate)', () => {
+  test('Swedish is flagged unreviewed, and that label never decides the gate', () => {
     const sv = LOCALES.find((l) => l.code === 'sv');
     expect(sv.unreviewed).toBe(true);
-    expect(sv.beta).toBe(false);
-    expect(SHIPPED_CODES).toContain('sv');
+    // label ≠ gate: only the ratio decides beta, whatever the review flag says.
+    expect(sv.beta).toBe(sv.ratio < BETA_BELOW);
   });
 
   test('the machine-drafted languages ship as beta however full they are', () => {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4391,6 +4391,23 @@
       "bar": "Bars",
       "donut": "Donut",
       "line": "Line"
+    },
+    "presets": "Pre-built views",
+    "preset": {
+      "moneyByRegion": "Where my money sits",
+      "cellarByType": "What I buy (cellar by type)",
+      "vintageSpread": "Vintage spread",
+      "topProducers": "Top producers",
+      "drankLastYear": "What I drank this past year",
+      "drinkSoon": "Drink soon (my windows)",
+      "priciest": "My priciest bottles",
+      "favouriteRegions": "My favourite regions (by my ratings)",
+      "whatIDrink": "What I actually drink (by type)",
+      "agingRunway": "Aging runway (bottles per drink-to year)",
+      "pastWindow": "Past their window (still in the rack)",
+      "forgottenBottles": "Forgotten bottles (in the cellar 2+ years)",
+      "whereIShop": "Where I shop (and what it costs me)",
+      "giftedVsDrunk": "How bottles leave (drunk, gifted, sold)"
     }
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4384,6 +4384,13 @@
     "currencyNote": "Monetary values converted to {{code}}",
     "unconvertible": "{{n}} row(s) had no exchange rate and are excluded",
     "noRates": "no exchange rates available; monetary measures are empty",
-    "bucketsCapped": "Showing the top {{n}} groups — narrow the scope or filters for the rest"
+    "bucketsCapped": "Showing the top {{n}} groups — narrow the scope or filters for the rest",
+    "oneDimOnly": "One dimension only",
+    "chart": {
+      "table": "Table",
+      "bar": "Bars",
+      "donut": "Donut",
+      "line": "Line"
+    }
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4351,7 +4351,7 @@
     "clearApplied": "Clear filters",
     "removeFilter": "Remove filter",
     "sortHint": "Click to sort",
-    "notSortable": "Not sortable yet",
+    "notSortable": "Not sortable",
     "prev": "‹ Previous",
     "next": "Next ›",
     "pageInfo": "{{from}}–{{to}} of {{total}}",
@@ -4373,6 +4373,17 @@
       "maturity": "Maturity",
       "personal": "My data",
       "registry": "Registry data"
-    }
+    },
+    "group": "Group",
+    "groupBy": "Group by",
+    "measures": "Measures",
+    "countAlways": "Bottle count (always)",
+    "noMeasure": "— none —",
+    "noSecondDimension": "— no second dimension —",
+    "count": "Bottles",
+    "currencyNote": "Monetary values converted to {{code}}",
+    "unconvertible": "{{n}} row(s) had no exchange rate and are excluded",
+    "noRates": "no exchange rates available; monetary measures are empty",
+    "bucketsCapped": "Showing the top {{n}} groups — narrow the scope or filters for the rest"
   }
 }

--- a/frontend/src/utils/analyticsPresets.js
+++ b/frontend/src/utils/analyticsPresets.js
@@ -1,0 +1,164 @@
+// Pre-built analytics queries (#987, Johan 2026-08-19): the curated starting
+// points a user picks instead of composing dimensions and measures from
+// scratch. Client-side constants — applying one just sets the table's state,
+// so presets need no storage, no schema and no extra requests. User-SAVED
+// views are a later slice (R-E); these are the system ones.
+//
+// `build()` returns the state patch; date-dependent presets compute their
+// values at click time. labelKey resolves through i18n with `label` as the
+// fallback, like every other analytics string.
+
+const thisYear = () => new Date().getFullYear();
+const isoDaysAgo = (days) => {
+  const d = new Date(Date.now() - days * 86400000);
+  return d.toISOString().slice(0, 10);
+};
+
+export const ANALYTICS_PRESETS = [
+  {
+    key: 'moneyByRegion',
+    label: 'Where my money sits',
+    build: () => ({
+      bottleScope: 'active',
+      grouping: { on: true, dim1: 'wine.region', dim2: '', measures: [{ field: 'purchase.price', agg: 'sum' }, { field: 'purchase.price', agg: 'avg' }] },
+      chartType: 'bar',
+    }),
+  },
+  {
+    key: 'favouriteRegions',
+    label: 'My favourite regions (by my ratings)',
+    build: () => ({
+      bottleScope: 'all', // ratings live on active AND consumed bottles
+      grouping: { on: true, dim1: 'wine.region', dim2: '', measures: [{ field: 'rating.current', agg: 'avg' }] },
+      chartType: 'bar',
+    }),
+  },
+  {
+    key: 'cellarByType',
+    label: 'What I buy (cellar by type)',
+    build: () => ({
+      bottleScope: 'active',
+      grouping: { on: true, dim1: 'wine.type', dim2: '', measures: [] },
+      chartType: 'donut',
+    }),
+  },
+  {
+    key: 'whatIDrink',
+    label: 'What I actually drink (by type)',
+    build: () => ({
+      bottleScope: 'consumed',
+      grouping: { on: true, dim1: 'wine.type', dim2: '', measures: [] },
+      chartType: 'donut',
+    }),
+  },
+  {
+    key: 'agingRunway',
+    label: 'Aging runway (bottles per drink-to year)',
+    build: () => ({
+      bottleScope: 'active',
+      grouping: { on: true, dim1: 'maturity.drinkTo', dim2: '', measures: [] },
+      chartType: 'line',
+    }),
+  },
+  // ── The ones a user does not think to ask ────────────────────────────────
+  {
+    key: 'pastWindow',
+    label: 'Past their window (still in the rack)',
+    build: () => ({
+      bottleScope: 'active',
+      grouping: { on: false, dim1: 'wine.type', dim2: '', measures: [] },
+      chartType: 'table',
+      // The user's own drink-to year is already behind us, yet the bottle is
+      // still active — the list nobody checks until it is too late.
+      filters: [{ field: 'maturity.drinkTo', op: 'lte', value: thisYear() - 1 }],
+      columns: ['wine.producer', 'wine.name', 'bottle.vintage', 'maturity.drinkTo', 'bottle.location', 'purchase.price'],
+      sort: { field: 'maturity.drinkTo', dir: 'asc' },
+    }),
+  },
+  {
+    key: 'forgottenBottles',
+    label: 'Forgotten bottles (in the cellar 2+ years)',
+    build: () => ({
+      bottleScope: 'active',
+      grouping: { on: false, dim1: 'wine.type', dim2: '', measures: [] },
+      chartType: 'table',
+      filters: [{ field: 'bottle.addedAt', op: 'lte', value: isoDaysAgo(730) }],
+      columns: ['wine.producer', 'wine.name', 'bottle.vintage', 'bottle.addedAt', 'bottle.location', 'maturity.status'],
+      sort: { field: 'bottle.addedAt', dir: 'asc' },
+    }),
+  },
+  {
+    key: 'whereIShop',
+    label: 'Where I shop (and what it costs me)',
+    build: () => ({
+      bottleScope: 'all',
+      grouping: { on: true, dim1: 'purchase.location', dim2: '', measures: [{ field: 'purchase.price', agg: 'avg' }] },
+      chartType: 'bar',
+    }),
+  },
+  {
+    key: 'giftedVsDrunk',
+    label: 'How bottles leave (drunk, gifted, sold)',
+    build: () => ({
+      bottleScope: 'consumed',
+      grouping: { on: true, dim1: 'consumption.reason', dim2: '', measures: [{ field: 'purchase.price', agg: 'sum' }] },
+      chartType: 'donut',
+    }),
+  },
+  {
+    key: 'vintageSpread',
+    label: 'Vintage spread',
+    build: () => ({
+      bottleScope: 'active',
+      grouping: { on: true, dim1: 'bottle.vintage', dim2: '', measures: [] },
+      chartType: 'line',
+    }),
+  },
+  {
+    key: 'topProducers',
+    label: 'Top producers',
+    build: () => ({
+      bottleScope: 'active',
+      grouping: { on: true, dim1: 'wine.producer', dim2: '', measures: [] },
+      chartType: 'bar',
+    }),
+  },
+  {
+    key: 'drankLastYear',
+    label: 'What I drank this past year',
+    build: () => ({
+      bottleScope: 'consumed',
+      grouping: { on: false, dim1: 'wine.type', dim2: '', measures: [] },
+      chartType: 'table',
+      filters: [{ field: 'consumption.date', op: 'gte', value: isoDaysAgo(365) }],
+      columns: ['wine.producer', 'wine.name', 'bottle.vintage', 'consumption.date', 'consumption.reason', 'rating.consumed'],
+      sort: { field: 'consumption.date', dir: 'desc' },
+    }),
+  },
+  {
+    key: 'drinkSoon',
+    label: 'Drink soon (my windows)',
+    build: () => ({
+      bottleScope: 'active',
+      grouping: { on: false, dim1: 'wine.type', dim2: '', measures: [] },
+      chartType: 'table',
+      // Bottle-level windows the USER set — honest scope: bottles without a
+      // personal drink-to year simply are not in this view.
+      filters: [{ field: 'maturity.drinkTo', op: 'between', value: [thisYear(), thisYear() + 1] }],
+      columns: ['wine.producer', 'wine.name', 'bottle.vintage', 'maturity.drinkFrom', 'maturity.drinkTo', 'maturity.status'],
+      sort: { field: 'maturity.drinkTo', dir: 'asc' },
+    }),
+  },
+  {
+    key: 'priciest',
+    label: 'My priciest bottles',
+    build: () => ({
+      bottleScope: 'active',
+      grouping: { on: false, dim1: 'wine.type', dim2: '', measures: [] },
+      chartType: 'table',
+      filters: [],
+      columns: ['wine.producer', 'wine.name', 'bottle.vintage', 'purchase.price', 'purchase.currency', 'wine.region'],
+      sort: { field: 'purchase.price', dir: 'desc' },
+    }),
+  },
+];


### PR DESCRIPTION
## What

The second and third slices of #987 on top of v1.135.0's table, plus Johan's preset ask, plus the fixes from a 16-agent adversarial review of the whole surface.

**R-B — slice and dice**
- **Group** chip pivots the table: 1–2 dimensions, bottle count always, up to two measures (sum/avg/min/max).
- Country/Region become sortable (name $lookup); personal/registry keys become sortable, groupable (non-numeric) and aggregable (numeric, behind an $isNumber guard) — the entry-precedence rule enforced inside the sub-pipeline.

**R-C slice 1 — visualise**
- Table / Bars / Donut / Line over the grouped result; two dimensions render as stacked bars (top-10 series + '…other'). Colors from the app-wide SERIES_COLORS palette. recharts was already a dependency; everything rides the existing lazy chunk.

**Presets (Johan 2026-08-19)**
- 14 one-click *Pre-built views*, including the non-obvious ones: past-their-window, forgotten bottles, where-I-shop with average price, how bottles leave (value-weighted), favourite regions by MY ratings, buy-vs-drink mirror, aging runway. A preset sets the visible controls — a starting point, never a black box.

**Adversarial review → 9 confirmed findings, all fixed with tests**
- 4 finder lenses (correctness/security/perf/UX) → 39 raw findings → 12 verified adversarially → 9 confirmed. Highlights: KV filters now honor bottle>wine-vintage>wine-null precedence; date filters are day-granular; **ratings unified to stars across filter/sort/display/aggregate** (mixed 5/20/100 scales made a 60-point bottle outrank a 5-star one); cellar buckets show names; scope follows navigation. The 3 refuted findings stayed unfixed by design.
- Also: grapes flagged ungroupable ($group on an array keys buckets by the combination), dates ungroupable until calendar bucketing.

**Swedish coverage (Johan's call: option b)**
- The ~60 new en keys diluted sv to 89.9%, under the 90% ship gate — sv wears the beta label until Weblate refills it. The two coverage pins now assert the mechanism (beta follows the ratio) so they hold in both directions.

## Verification
- Engine suite 36 → **59 tests** (precedence layering, day ranges, star parity vs the JS helpers, injection, caps).
- Full backend **259 suites / 4,042 tests** green; frontend **967** green; vite build green; CSS token guard green.
- Docker smoke of the R-A surface was done pre-v1.135.0; local stack rebuild for Johan's click-through follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)