### PR TITLE
feat(analytics): Beta badge on the analytics table

### DIFF
--- a/frontend/src/components/AnalyticsTable.css
+++ b/frontend/src/components/AnalyticsTable.css
@@ -181,3 +181,20 @@
 
 /* Presets */
 .at-preset-select { background: var(--color-surface); color: var(--color-text); border: 1px solid var(--color-border); border-radius: 16px; padding: 5px 10px; font-size: 0.82rem; max-width: 180px; }
+
+/* Beta badge — the feature ships early on purpose; the badge says so. */
+.at-beta {
+  display: inline-block;
+  background: var(--color-info-bg);
+  color: var(--color-info);
+  border: 1px solid var(--color-info-border);
+  border-radius: 10px;
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-right: 8px;
+  vertical-align: middle;
+  cursor: help;
+}

--- a/frontend/src/components/AnalyticsTable.js
+++ b/frontend/src/components/AnalyticsTable.js
@@ -306,6 +306,9 @@ export default function AnalyticsTable({ cellarId }) {
       {/* Scope pill + toolbar — the scope is ALWAYS visible */}
       <div className="at-toolbar">
         <div className="at-scope">
+          <span className="at-beta" title={t('analytics.betaHint', 'Analytics is new and still settling in. If a number looks wrong or something misbehaves, please tell us via Support — it helps more than you would think.')}>
+            {t('analytics.beta', 'Beta')}
+          </span>
           <button className="at-chip" onClick={() => setScopeOpen((o) => !o)} aria-expanded={scopeOpen}>
             {t(`analytics.scope.${bottleScope}`, bottleScope === 'active' ? 'Active bottles' : bottleScope === 'consumed' ? 'Consumed bottles' : 'All bottles')}
             {' · '}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4408,6 +4408,8 @@
       "forgottenBottles": "Forgotten bottles (in the cellar 2+ years)",
       "whereIShop": "Where I shop (and what it costs me)",
       "giftedVsDrunk": "How bottles leave (drunk, gifted, sold)"
-    }
+    },
+    "beta": "Beta",
+    "betaHint": "Analytics is new and still settling in. If a number looks wrong or something misbehaves, please tell us via Support — it helps more than you would think."
   }
 }


### PR DESCRIPTION
A small 'Beta' chip in the analytics toolbar with a tooltip asking users to report anything odd via Support. Ships ahead of the prod deploy of the whole analytics batch (Johan's call: beta-label it and ship). No gating — expectations only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)