### PR TITLE
feat(analytics): the Dashboard — widgets over the query engine (#987 R-E)

### DIFF
--- a/backend/src/models/SavedDashboard.js
+++ b/backend/src/models/SavedDashboard.js
@@ -1,0 +1,51 @@
+const mongoose = require('mongoose');
+
+// A user's analytics dashboard (#987 R-E): a named grid of widgets, each one
+// a stored analytics query + a visualization + a size. cube.dev-style "pages
+// you just look at" — the default 'My cellar' dashboard is client-side until
+// the user customizes, so a row exists only for people who made one.
+//
+// The stored `query` is DATA, revalidated by the analytics engine on every
+// render — persisting it grants nothing the live endpoint would refuse (the
+// engine re-derives scope per request; a stale cellar id simply narrows to
+// nothing). One dashboard per user for now; the unique index makes the
+// upsert honest.
+
+const widgetSchema = new mongoose.Schema({
+  title: { type: String, trim: true, maxlength: [80, 'Widget title too long'], required: true },
+  // 'kpi' renders grouped/no-dimension buckets as big numbers; the chart
+  // kinds mirror the analytics table's toggles; 'table' shows compact rows
+  // or buckets.
+  viz: { type: String, enum: ['kpi', 'bar', 'donut', 'line', 'table'], required: true },
+  size: { type: String, enum: ['half', 'full'], default: 'half' },
+  // The exact /api/analytics/query body. Mixed on purpose: the engine is the
+  // validator (whitelisted fields/ops, caps), and duplicating its rules in a
+  // schema would drift. Bounded by the widget cap + the 16KB doc math below.
+  query: { type: mongoose.Schema.Types.Mixed, required: true },
+}, { _id: false });
+
+const savedDashboardSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    unique: true,
+  },
+  widgets: {
+    type: [widgetSchema],
+    default: [],
+    validate: {
+      validator: (v) => v.length <= 12,
+      message: 'A dashboard holds at most 12 widgets',
+    },
+  },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+savedDashboardSchema.pre('save', function (next) {
+  this.updatedAt = Date.now();
+  next();
+});
+
+module.exports = mongoose.model('SavedDashboard', savedDashboardSchema);

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -17,10 +17,64 @@ const express = require('express');
 const { requireAuth } = require('../middleware/auth');
 const { composeCatalogue, opsForType } = require('../services/analytics/fieldCatalogue');
 const { runQuery, QueryError } = require('../services/analytics/queryEngine');
+const SavedDashboard = require('../models/SavedDashboard');
+const { logAudit } = require('../services/audit');
 
 const router = express.Router();
 
 router.use(requireAuth);
+
+// ── Dashboard (#987 R-E): one per user, upserted whole ─────────────────────
+// The default 'My cellar' dashboard lives client-side; a row exists only
+// once the user customizes. Widgets' stored queries are DATA — the engine
+// revalidates on every render, so nothing here needs to re-know its rules.
+
+const VIZ = new Set(['kpi', 'bar', 'donut', 'line', 'table']);
+const SIZES = new Set(['half', 'full']);
+
+router.get('/dashboard', async (req, res, next) => {
+  try {
+    const doc = await SavedDashboard.findOne({ user: req.user.id }).lean();
+    res.json({ dashboard: doc ? { widgets: doc.widgets, updatedAt: doc.updatedAt } : null });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/dashboard', async (req, res, next) => {
+  try {
+    const widgets = req.body?.widgets;
+    if (!Array.isArray(widgets) || widgets.length > 12) {
+      return res.status(400).json({ error: 'widgets must be an array of at most 12' });
+    }
+    const clean = [];
+    for (const w of widgets) {
+      if (!w || typeof w !== 'object') return res.status(400).json({ error: 'Each widget must be an object' });
+      const title = typeof w.title === 'string' ? w.title.trim().slice(0, 80) : '';
+      if (!title) return res.status(400).json({ error: 'Each widget needs a title' });
+      if (!VIZ.has(w.viz)) return res.status(400).json({ error: `viz must be one of: ${[...VIZ].join(', ')}` });
+      if (w.size !== undefined && !SIZES.has(w.size)) return res.status(400).json({ error: 'size must be half or full' });
+      if (!w.query || typeof w.query !== 'object' || Array.isArray(w.query)) {
+        return res.status(400).json({ error: 'Each widget needs a query object' });
+      }
+      // Size bound: a query is a small JSON body; 4KB each keeps the doc far
+      // under Mongo's limits whatever twelve of them contain.
+      if (JSON.stringify(w.query).length > 4096) {
+        return res.status(400).json({ error: 'Widget query too large' });
+      }
+      clean.push({ title, viz: w.viz, size: SIZES.has(w.size) ? w.size : 'half', query: w.query });
+    }
+    await SavedDashboard.updateOne(
+      { user: req.user.id },
+      { $set: { widgets: clean, updatedAt: new Date() }, $setOnInsert: { user: req.user.id, createdAt: new Date() } },
+      { upsert: true }
+    );
+    logAudit(req, 'analytics.dashboard_save', { type: 'dashboard', id: req.user.id }, { widgets: clean.length });
+    res.json({ dashboard: { widgets: clean } });
+  } catch (err) {
+    next(err);
+  }
+});
 
 router.get('/catalogue', async (req, res, next) => {
   try {

--- a/backend/src/services/analytics/queryEngine.js
+++ b/backend/src/services/analytics/queryEngine.js
@@ -800,8 +800,10 @@ async function hydrateRows({ userId, pageIds, columns, scopeCellars }) {
 async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensions, measures }) {
   const { pre, post, exprFilters, needsWine: filterNeedsWine } = await compileFilters(filters, userId);
 
-  if (!Array.isArray(dimensions) || !dimensions.length || dimensions.length > MAX_DIMENSIONS) {
-    throw new QueryError(400, `grouped mode takes 1–${MAX_DIMENSIONS} dimensions`);
+  // ZERO dimensions is the KPI shape (dashboards, R-E): one bucket holding
+  // the whole scoped set — "total bottles", "total value", "average rating".
+  if (!Array.isArray(dimensions) || dimensions.length > MAX_DIMENSIONS) {
+    throw new QueryError(400, `grouped mode takes 0–${MAX_DIMENSIONS} dimensions (0 = one summary bucket)`);
   }
   if (!Array.isArray(measures) || !measures.length || measures.length > 5) {
     throw new QueryError(400, 'grouped mode takes 1–5 measures');
@@ -811,7 +813,7 @@ async function runGrouped({ userId, scopeCellars, bottleScope, filters, dimensio
   const joinStages = [];
   const dimFields = [];
   const dimExprs = [];
-  for (let i = 0; i < dimensions.length; i++) {
+  for (let i = 0; i < (dimensions || []).length; i++) {
     const f = await resolveField(dimensions[i], userId);
     if (!f) throw new QueryError(400, `Unknown dimension "${dimensions[i]}"`);
     if (!f.groupable) throw new QueryError(400, `Field "${dimensions[i]}" cannot be grouped`);

--- a/backend/src/services/analytics/queryEngine.test.js
+++ b/backend/src/services/analytics/queryEngine.test.js
@@ -380,7 +380,7 @@ describe('bounds and caps', () => {
       mode: 'grouped',
       dimensions: ['bottle.status', 'wine.type', 'bottle.vintage'],
       measures: [{ field: '*', agg: 'count' }],
-    })).rejects.toThrow(/1–2 dimensions/);
+    })).rejects.toThrow(/0–2 dimensions/);
   });
 
   test('grouped mode reports the bucket cap when it fires', async () => {
@@ -584,4 +584,29 @@ describe('AUDIT fixes 2026-08-19 — the rest of the confirmed nine', () => {
       mode: 'grouped', dimensions: ['bottle.addedAt'], measures: [{ field: '*', agg: 'count' }],
     })).rejects.toThrow(/cannot be grouped/);
   });
+});
+
+describe('KPI shape — zero dimensions (dashboards R-E)', () => {
+  test('an empty dimensions array groups the whole scoped set into one bucket', async () => {
+    // A currency measure makes THREE aggregate calls: the modal-currency
+    // probe, the unconvertible count, then the main pipeline — each needs
+    // its own shaped result.
+    const captured = { pipelines: [] };
+    const results = [[{ _id: 'USD', n: 9 }], [], [{ _id: {}, m0: 42, m1: 12345 }]];
+    Bottle.aggregate.mockImplementation((pipeline) => {
+      captured.pipelines.push(pipeline);
+      const r = results[captured.pipelines.length - 1] || [];
+      return { option: jest.fn(async () => r) };
+    });
+    const out = await runQuery(USER, {
+      mode: 'grouped', dimensions: [],
+      measures: [{ field: '*', agg: 'count' }, { field: 'purchase.price', agg: 'sum' }],
+    });
+    const main = captured.pipelines[captured.pipelines.length - 1];
+    expect(main.find((s) => s.$group).$group._id).toEqual({});
+    expect(out.buckets).toEqual([{ dimensions: [], measures: [42, 12345] }]);
+    expect(out.dimensionKeys).toEqual([]);
+    expect(out.currency.target).toBe('USD');
+  });
+
 });

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -69,6 +69,7 @@ const WineVintageProfile = require('../models/WineVintageProfile');
 const WishlistItem = require('../models/WishlistItem');
 const PersonalDataKey = require('../models/PersonalDataKey');
 const PersonalDataEntry = require('../models/PersonalDataEntry');
+const SavedDashboard = require('../models/SavedDashboard');
 const RegistryDataKey = require('../models/RegistryDataKey');
 const RegistryDataValue = require('../models/RegistryDataValue');
 const AuditLog = require('../models/AuditLog');
@@ -317,6 +318,13 @@ const REGISTRY = [
     model: PersonalDataEntry, category: 'personal-data', userFields: ['author'],
     purge: (ctx) => PersonalDataEntry.deleteMany({ author: ctx.userId }),
     exportFragment: async (ctx) => ({ personalDataEntries: markTrunc(ctx, 'personalDataEntries', await PersonalDataEntry.find({ author: ctx.userId }).populate('key', 'name type unit').limit(EXPORT_MAX).lean()) }),
+  },
+  {
+    // The analytics dashboard (#987 R-E): one row per user, pure preference
+    // data — hard delete, full export.
+    model: SavedDashboard, category: 'personal-data', userFields: ['user'],
+    purge: (ctx) => SavedDashboard.deleteMany({ user: ctx.userId }),
+    exportFragment: async (ctx) => ({ analyticsDashboard: await SavedDashboard.findOne({ user: ctx.userId }).lean() }),
   },
   {
     // The PUBLIC vocabulary is shared content (#985): an accepted key belongs

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -39,6 +39,7 @@ const SommPrices      = lazy(() => import('./pages/SommPrices'));
 const Settings        = lazy(() => import('./pages/Settings'));
 const Supporter       = lazy(() => import('./pages/Supporter'));
 const Statistics      = lazy(() => import('./pages/Statistics'));
+const AnalyticsDashboard = lazy(() => import('./pages/AnalyticsDashboard'));
 const Bottles         = lazy(() => import('./pages/Bottles'));
 const StatsCard       = lazy(() => import('./pages/StatsCard'));
 const AdminWines      = lazy(() => import('./pages/AdminWines'));
@@ -341,6 +342,14 @@ function AppRoutes() {
           element={
             <ProtectedRoute>
               <Layout><Statistics /></Layout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <Layout><AnalyticsDashboard /></Layout>
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/analytics.js
+++ b/frontend/src/api/analytics.js
@@ -12,3 +12,13 @@ export const runAnalyticsQuery = (apiFetch, query) =>
     headers: JSON_HEADERS,
     body: JSON.stringify(query),
   });
+
+// Dashboard (#987 R-E): one per user; null until first customized.
+export const getDashboard = (apiFetch) => apiFetch('/api/analytics/dashboard');
+
+export const saveDashboard = (apiFetch, widgets) =>
+  apiFetch('/api/analytics/dashboard', {
+    method: 'PUT',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ widgets }),
+  });

--- a/frontend/src/components/AnalyticsTable.js
+++ b/frontend/src/components/AnalyticsTable.js
@@ -7,6 +7,7 @@ import { csvEscape } from '../utils/importReport';
 import downloadBlob from '../utils/downloadBlob';
 import AnalyticsCharts from './AnalyticsCharts';
 import { ANALYTICS_PRESETS } from '../utils/analyticsPresets';
+import { getDashboard, saveDashboard } from '../api/analytics';
 import './AnalyticsTable.css';
 
 /**
@@ -384,6 +385,40 @@ export default function AnalyticsTable({ cellarId }) {
           <button className="at-chip" onClick={exportCsv} disabled={exporting || !data}>
             {exporting ? t('analytics.exporting', 'Exporting…') : t('analytics.exportCsv', 'Export CSV')}
           </button>
+          {grouping.on && data?.mode === 'grouped' && (
+            <button
+              className="at-chip"
+              onClick={async () => {
+                // A grouped view becomes a dashboard widget verbatim — the
+                // stored query is exactly what this table just ran.
+                const title = window.prompt(
+                  t('analytics.widgetTitlePrompt', 'Name this dashboard widget:'),
+                  byKey.get(grouping.dim1)?.label || t('analytics.dashboardTitle', 'Dashboard')
+                );
+                if (!title) return;
+                try {
+                  const res = await getDashboard(apiFetch);
+                  const body = await res.json();
+                  const existing = (res.ok && body.dashboard?.widgets) || [];
+                  const widget = {
+                    title: title.trim().slice(0, 80),
+                    viz: chartType === 'table' ? 'bar' : chartType,
+                    size: 'half',
+                    query,
+                  };
+                  const save = await saveDashboard(apiFetch, [...existing, widget]);
+                  if (!save.ok) {
+                    const d = await save.json();
+                    setError(d.error || t('analytics.saveFailed', 'Could not save'));
+                  }
+                } catch {
+                  setError(t('analytics.saveFailed', 'Could not save'));
+                }
+              }}
+            >
+              {t('analytics.addToDashboard', 'Add to dashboard')}
+            </button>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -91,6 +91,12 @@ function Layout({ children }) {
                   {t('nav.myCellars')}
                 </Link>
                 <Link
+                  to="/dashboard"
+                  className={`nav-link ${isActive('/dashboard') ? 'active' : ''}`}
+                >
+                  {t('nav.dashboard', 'Dashboard')}
+                </Link>
+                <Link
                   to="/statistics"
                   className={`nav-link ${isActive('/statistics') ? 'active' : ''}`}
                 >

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -99,7 +99,8 @@
     "systemMonitor": "System Monitor",
     "mainNavigation": "Main navigation",
     "switchToDark": "Switch to dark mode",
-    "switchToLight": "Switch to light mode"
+    "switchToLight": "Switch to light mode",
+    "dashboard": "Dashboard"
   },
   "auth": {
     "login": "Login",
@@ -4410,6 +4411,14 @@
       "giftedVsDrunk": "How bottles leave (drunk, gifted, sold)"
     },
     "beta": "Beta",
-    "betaHint": "Analytics is new and still settling in. If a number looks wrong or something misbehaves, please tell us via Support — it helps more than you would think."
+    "betaHint": "Analytics is new and still settling in. If a number looks wrong or something misbehaves, please tell us via Support — it helps more than you would think.",
+    "dashboardTitle": "Dashboard",
+    "dashboardHint": "Widgets come from the analytics table: open a cellar, switch to the table view, group something interesting, and press \"Add to dashboard\".",
+    "addToDashboard": "Add to dashboard",
+    "widgetTitlePrompt": "Name this dashboard widget:",
+    "removeWidget": "Remove widget",
+    "resetDashboard": "Reset to default",
+    "saving": "Saving…",
+    "saveFailed": "Could not save"
   }
 }

--- a/frontend/src/pages/AnalyticsDashboard.css
+++ b/frontend/src/pages/AnalyticsDashboard.css
@@ -1,0 +1,74 @@
+/* Analytics dashboard (#987 R-E). Two-column grid on desktop; ONE column on
+   mobile — a scrollable feed of answers is the phone-first surface the wide
+   table cannot be. */
+
+.analytics-dashboard {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ad-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.ad-head h1 { display: flex; align-items: center; gap: 10px; margin: 0; font-size: 1.4rem; }
+.ad-head-actions { display: flex; align-items: center; gap: 8px; }
+.ad-save-note { font-size: 0.8rem; color: var(--color-text-secondary); }
+.ad-save-error { color: var(--color-danger); }
+
+.ad-hint { margin: 0; font-size: 0.82rem; color: var(--color-text-secondary); }
+
+.ad-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.ad-widget {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0; /* charts must shrink inside the grid track */
+}
+.ad-full { grid-column: 1 / -1; }
+
+.ad-widget-head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+.ad-widget-title { font-weight: 600; font-size: 0.95rem; }
+.ad-widget-title em { font-style: normal; font-weight: 400; font-size: 0.78rem; color: var(--color-text-secondary); }
+.ad-x {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0 4px;
+}
+.ad-x:hover { color: var(--color-danger); }
+
+.ad-kpis { display: flex; gap: 18px; flex-wrap: wrap; padding: 6px 2px; }
+.ad-kpi { display: flex; flex-direction: column; gap: 2px; min-width: 110px; }
+.ad-kpi-value { font-size: 1.7rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+.ad-kpi-label { font-size: 0.78rem; color: var(--color-text-secondary); }
+
+.ad-empty, .ad-error {
+  padding: 14px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+.ad-error { color: var(--color-danger); }
+
+@media (max-width: 768px) {
+  .ad-grid { grid-template-columns: 1fr; }
+}

--- a/frontend/src/pages/AnalyticsDashboard.js
+++ b/frontend/src/pages/AnalyticsDashboard.js
@@ -1,0 +1,214 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../contexts/AuthContext';
+import { getDashboard, saveDashboard, runAnalyticsQuery } from '../api/analytics';
+import AnalyticsCharts from '../components/AnalyticsCharts';
+// Shares .at-chip / .at-beta with the analytics table so the two surfaces
+// stay visually one feature.
+import '../components/AnalyticsTable.css';
+import './AnalyticsDashboard.css';
+
+/**
+ * The analytics dashboard (#987 R-E) — cube.dev-style "a page you just look
+ * at". Each widget is one stored analytics query + a visualization; the page
+ * runs them in parallel through the same bounded engine as the table. Until
+ * the user customizes, the DEFAULT set below renders (no DB row exists) —
+ * analytics opens as answers, not as an empty tool. Widgets stack to one
+ * column on mobile, which is the point: this is the phone-first surface the
+ * wide table can never be.
+ */
+
+const DEFAULT_WIDGETS = [
+  {
+    title: 'My cellar',
+    viz: 'kpi',
+    size: 'full',
+    query: {
+      mode: 'grouped',
+      dimensions: [],
+      measures: [
+        { field: '*', agg: 'count' },
+        { field: 'purchase.price', agg: 'sum' },
+        { field: 'rating.current', agg: 'avg' },
+      ],
+    },
+  },
+  {
+    title: 'Where my money sits',
+    viz: 'bar',
+    size: 'full',
+    query: {
+      mode: 'grouped',
+      dimensions: ['wine.region'],
+      measures: [{ field: '*', agg: 'count' }, { field: 'purchase.price', agg: 'sum' }],
+    },
+  },
+  {
+    title: 'What I buy (by type)',
+    viz: 'donut',
+    size: 'half',
+    query: { mode: 'grouped', dimensions: ['wine.type'], measures: [{ field: '*', agg: 'count' }] },
+  },
+  {
+    title: 'How bottles leave',
+    viz: 'donut',
+    size: 'half',
+    query: {
+      mode: 'grouped',
+      scope: { bottles: 'consumed' },
+      dimensions: ['consumption.reason'],
+      measures: [{ field: '*', agg: 'count' }, { field: 'purchase.price', agg: 'sum' }],
+    },
+  },
+  {
+    title: 'Aging runway',
+    viz: 'line',
+    size: 'full',
+    query: { mode: 'grouped', dimensions: ['maturity.drinkTo'], measures: [{ field: '*', agg: 'count' }] },
+  },
+];
+
+function KpiWidget({ data, t }) {
+  const bucket = data.buckets[0];
+  if (!bucket) return <div className="ad-empty">{t('analytics.empty', 'No bottles match this scope and these filters.')}</div>;
+  return (
+    <div className="ad-kpis">
+      {data.measureLabels.map((label, i) => {
+        const v = bucket.measures[i];
+        return (
+          <div key={label} className="ad-kpi">
+            <div className="ad-kpi-value">
+              {v === null || v === undefined ? '—' : typeof v === 'number' ? Math.round(v * 100) / 100 : String(v)}
+            </div>
+            <div className="ad-kpi-label">
+              {label === 'count' ? t('analytics.count', 'Bottles') : label}
+              {label.includes('purchase.price') && data.currency ? ` (${data.currency.target})` : ''}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function Widget({ widget, onRemove }) {
+  const { t } = useTranslation();
+  const { apiFetch } = useAuth();
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const res = await runAnalyticsQuery(apiFetch, widget.query);
+        const body = await res.json();
+        if (!live) return;
+        if (!res.ok) setError(body.error || 'Query failed');
+        else setData(body);
+      } catch {
+        if (live) setError(t('analytics.networkError', 'Could not reach the server'));
+      }
+    })();
+    return () => { live = false; };
+  }, [apiFetch, widget, t]);
+
+  const scopeNote = data?.scope && data.scope.bottles !== 'active'
+    ? t(`analytics.scope.${data.scope.bottles}`, data.scope.bottles)
+    : null;
+
+  return (
+    <div className={`ad-widget ad-${widget.size || 'half'}`}>
+      <div className="ad-widget-head">
+        <span className="ad-widget-title">{widget.title}{scopeNote ? <em> · {scopeNote}</em> : null}</span>
+        {onRemove && (
+          <button className="ad-x" onClick={onRemove} aria-label={t('analytics.removeWidget', 'Remove widget')}>×</button>
+        )}
+      </div>
+      {error && <div className="ad-error">{error}</div>}
+      {!error && !data && <div className="ad-empty">{t('analytics.loading', 'Loading…')}</div>}
+      {!error && data && widget.viz === 'kpi' && <KpiWidget data={data} t={t} />}
+      {!error && data && widget.viz !== 'kpi' && data.mode === 'grouped' && (
+        data.buckets.length
+          ? <AnalyticsCharts data={data} chartType={widget.viz === 'table' ? 'bar' : widget.viz} measureIndex={data.measureLabels.length > 1 ? 1 : 0} />
+          : <div className="ad-empty">{t('analytics.empty', 'No bottles match this scope and these filters.')}</div>
+      )}
+    </div>
+  );
+}
+
+export default function AnalyticsDashboard() {
+  const { t } = useTranslation();
+  const { apiFetch } = useAuth();
+  const [widgets, setWidgets] = useState(null); // null = loading
+  const [customized, setCustomized] = useState(false);
+  const [saveState, setSaveState] = useState(null);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const res = await getDashboard(apiFetch);
+        const body = await res.json();
+        if (!live) return;
+        if (res.ok && body.dashboard && body.dashboard.widgets.length) {
+          setWidgets(body.dashboard.widgets);
+          setCustomized(true);
+        } else {
+          setWidgets(DEFAULT_WIDGETS);
+        }
+      } catch {
+        if (live) setWidgets(DEFAULT_WIDGETS);
+      }
+    })();
+    return () => { live = false; };
+  }, [apiFetch]);
+
+  const persist = useCallback(async (next) => {
+    setWidgets(next);
+    setCustomized(true);
+    setSaveState('saving');
+    try {
+      const res = await saveDashboard(apiFetch, next);
+      setSaveState(res.ok ? 'saved' : 'error');
+    } catch {
+      setSaveState('error');
+    }
+  }, [apiFetch]);
+
+  const removeWidget = (i) => persist(widgets.filter((_, j) => j !== i));
+  const resetDefault = () => persist(DEFAULT_WIDGETS);
+
+  const grid = useMemo(() => widgets || [], [widgets]);
+
+  return (
+    <div className="analytics-dashboard">
+      <div className="ad-head">
+        <h1>
+          {t('analytics.dashboardTitle', 'Dashboard')}
+          <span className="at-beta" title={t('analytics.betaHint', 'Analytics is new and still settling in. If a number looks wrong or something misbehaves, please tell us via Support — it helps more than you would think.')}>
+            {t('analytics.beta', 'Beta')}
+          </span>
+        </h1>
+        <div className="ad-head-actions">
+          {saveState === 'saving' && <span className="ad-save-note">{t('analytics.saving', 'Saving…')}</span>}
+          {saveState === 'error' && <span className="ad-save-note ad-save-error">{t('analytics.saveFailed', 'Could not save')}</span>}
+          {customized && (
+            <button className="at-chip" onClick={resetDefault}>{t('analytics.resetDashboard', 'Reset to default')}</button>
+          )}
+        </div>
+      </div>
+      <p className="ad-hint">
+        {t('analytics.dashboardHint', 'Widgets come from the analytics table: open a cellar, switch to the table view, group something interesting, and press "Add to dashboard".')}
+      </p>
+      <div className="ad-grid">
+        {widgets === null && <div className="ad-empty">{t('analytics.loading', 'Loading…')}</div>}
+        {grid.map((w, i) => (
+          <Widget key={`${w.title}-${i}`} widget={w} onRemove={() => removeWidget(i)} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export { DEFAULT_WIDGETS };


### PR DESCRIPTION
The cube.dev-style slice: a **/dashboard** page (new main-nav entry) that opens with a default *My cellar* set — KPI numbers, money by region, buy-vs-leave donuts, aging runway — and grows by pinning any grouped view from the analytics table via **Add to dashboard**.

- Widget = stored query + viz + size; widgets render in parallel through the same bounded engine; stored queries are data, revalidated every render.
- Engine addition: `dimensions: []` = the KPI shape (one bucket), tested.
- `SavedDashboard` (one per user, ≤12 widgets, 4KB/query) in the GDPR registry — export, deletion cascade, completeness test green; saves audit-logged.
- Mobile renders one column — the phone-first surface the table couldn't be.

Full backend 260 suites / 4,048 tests green; frontend 967 green; token guard green.

Ships together with the merged MCP analytics tools as **v1.137.0** — one banner, one deploy, one fresh somm conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)