### PR TITLE
fix(registry): stop guessing wine colour on the scan and search paths

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -28,10 +28,10 @@ Use all available information — text on the label, your knowledge of real wine
 - Cross-reference what you read with your wine knowledge to confirm and fill in gaps
 - If you recognize an appellation (e.g. "Pauillac", "Barolo", "Châteauneuf-du-Pape"), use your knowledge of its grapes, country, and region
 - If you recognize a producer (e.g. "Chapoutier", "Antinori", "Opus One"), use what you know about them
-- Infer the wine type and grapes from all available clues — appellation rules, producer style, label design, bottle shape, language
+- Infer the wine type and grapes from all available clues — appellation rules, producer style, label design, bottle shape, language. Inference means a clue actually points somewhere; where nothing settles the colour, the answer is null
 
 Respond with ONLY a raw JSON object (no markdown, no code fences, no extra text):
-{"name":"wine name WITHOUT the vintage year and WITHOUT the producer name","producer":"producer or winery name, or null if the producer is not printed","vintage":"4-digit year or null","country":"country","region":"wine region","appellation":"appellation/AOC/DOC/IGT/AVA or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"classification":"the printed classification/tier line (e.g. Grand Cru Classé en 1855, Cru Bourgeois) or null","confidence":0.0}
+{"name":"wine name WITHOUT the vintage year and WITHOUT the producer name","producer":"producer or winery name, or null if the producer is not printed","vintage":"4-digit year or null","country":"country","region":"wine region","appellation":"appellation/AOC/DOC/IGT/AVA or null","type":"red|white|rosé|sparkling|dessert|fortified, or null if the colour is not determinable","grapes":["grape varieties"],"classification":"the printed classification/tier line (e.g. Grand Cru Classé en 1855, Cru Bourgeois) or null","confidence":0.0}
 
 confidence: 1.0 = label clearly readable and matches a wine you know well, 0.7 = some fields inferred from appellation/producer knowledge, 0.4 = mostly inferred from limited clues, 0.2 = very uncertain.
 
@@ -45,6 +45,7 @@ Important rules:
 - Production-method terms are NOT part of the name — put "Méthode Cap Classique" / "Cap Classique", "Méthode Traditionnelle", "Metodo Classico" / "Traditional Method" in the appellation field instead (name "Blanc de Blancs" + appellation "Méthode Cap Classique", NOT name "Blanc de Blancs Méthode Cap Classique"). Legally-defined aging classifications that belong to the displayed name (Reserva, Gran Reserva, Riserva, Spätlese, Grosses Gewächs) and dosage words that are part of a cuvée name (e.g. "Brut Premier") stay in the name.
 - Do not hallucinate appellation names, producer names, or grape varieties. Only use names you are confident are real and match what is visible on the label or your knowledge of that specific producer/appellation.
 - Grapes: only varieties this specific wine actually contains. Single-variety appellations may be inferred (Barolo → Nebbiolo); for multi-variety appellations (Champagne, southern-Rhône blends, Bordeaux) list only what you know about THIS cuvée — never the appellation's full permitted set by default. Fewer correct grapes beat a complete-looking list.
+- Type: return null when the label and your knowledge do not settle the colour. Cuvée-name-only labels, houses whose range spans colours, and natural/low-intervention bottlings are exactly where a default is wrong — an unknown type sends a curator to look, a wrong one closes the question, and colour drives filtering, serving temperature and drink-window shape.
 - Country must be the canonical English country name: "United States" (never "USA" or "America"), "Germany" (never "Deutschland" or a local-language name like "Tyskland"), "Italy" (never "Italia"/"Italie"), "England" for English wines. Never return a country name in the label's language.
 - If a field is genuinely unknown and cannot be reliably inferred, set it to null rather than guessing.
 - Only return {"error":"cannot read label"} if the image contains no wine label at all.`;
@@ -118,7 +119,7 @@ const DEFAULT_TEXT_SEARCH_PROMPT =
 
 Identify the wine they are looking for and return complete details.
 Return ONLY a raw JSON object (no markdown, no code fences, no extra text):
-{"name":"wine name","producer":"producer name","country":"country","region":"region or null","appellation":"appellation or null","classification":"official classification or null","type":"red|white|rosé|sparkling|dessert|fortified","grapes":["grape varieties"],"confidence":0.0}
+{"name":"wine name","producer":"producer name","country":"country","region":"region or null","appellation":"appellation or null","classification":"official classification or null","type":"red|white|rosé|sparkling|dessert|fortified, or null if you do not know this wine's colour","grapes":["grape varieties"],"confidence":0.0}
 
 Rules:
 - Extract the wine name and producer from the query
@@ -131,6 +132,7 @@ Rules:
 - Country is REQUIRED — always provide a country name; it is never acceptable to return null for country
 - Country must be the canonical English country name: "United States" (never "USA" or "America"), "Germany" (never "Deutschland"/"Tyskland"), "Italy" (never "Italia"/"Italie"), "England" for English wines — never a local-language or abbreviated name, even if the query uses one
 - For any other unknown field use null; use [] for unknown grapes, never null
+- Type is one of those fields: null when you do not know this specific wine's colour. A producer whose range spans colours, or a cuvée name you do not recognise, is not evidence of red — and colour drives filtering, serving temperature and drink-window shape, so a guess there is worse than a blank
 - Grapes: only varieties you know THIS cuvée contains — single-variety appellations may be inferred (Barolo → Nebbiolo), but never default a multi-variety appellation (Champagne, southern-Rhône blends, Bordeaux) to its full permitted set; fewer correct grapes beat a complete-looking list
 - confidence: 1.0 = certain, 0.7 = confident, 0.5 = reasonably sure
 - IMPORTANT: if you recognise the producer or wine name, return a result even if some fields are null — partial information is always better than returning unknown

--- a/frontend/src/pages/AddBottle.css
+++ b/frontend/src/pages/AddBottle.css
@@ -350,6 +350,9 @@
 .wine-row-placeholder.sparkling { background: var(--wine-sparkling); }
 .wine-row-placeholder.dessert { background: var(--wine-dessert); }
 .wine-row-placeholder.fortified { background: var(--wine-fortified); }
+/* Colour unknown (ticket 6a85ad44): a neutral swatch, never one of the six —
+   the placeholder used to fall back to red, which read as a determination. */
+.wine-row-placeholder.unknown { background: var(--color-border); }
 
 .wine-info {
   flex: 1;
@@ -395,6 +398,9 @@
 .wine-type-pill.sparkling { background: var(--wine-sparkling); color: var(--color-info); }
 .wine-type-pill.dessert  { background: var(--wine-dessert); color: #b07ad0; }
 .wine-type-pill.fortified { background: var(--wine-fortified); color: var(--color-success); }
+/* Same reason as the placeholder: an undetermined colour gets its own neutral
+   pill rather than borrowing red's. */
+.wine-type-pill.unknown  { background: var(--color-surface-hover); color: var(--color-text-secondary); }
 
 /* ── "Can't find your wine?" AI search row ───────────────────────────────── */
 

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -171,7 +171,7 @@ function AddBottle() {
         // scanned classification line ("Grand Cru Classé en 1855") lands in
         // the registry's classification field instead of polluting the name.
         classification: e.classification || '',
-        type: e.type || 'red',
+        type: e.type || '',
         grapes: (e.grapes || []).join(', '),
       });
       setShowManualForm(true);
@@ -222,7 +222,7 @@ function AddBottle() {
         region: merged.region || '',
         appellation: merged.appellation || '',
         classification: merged.classification || '',
-        type: merged.type || 'red',
+        type: merged.type || '',
         grapes: (merged.grapes || []).join(', '),
       };
       // Nothing typed yet (the front scan 422'd and the user had not opened the
@@ -373,7 +373,7 @@ function AddBottle() {
           country: match.wine.country?.name || extracted.country || '',
           region: match.wine.region?.name || extracted.region || '',
           appellation: match.wine.appellation || extracted.appellation || '',
-          type: match.wine.type || extracted.type || 'red',
+          type: match.wine.type || extracted.type || '',
           grapes: (match.wine.grapes || []).map(g => g.name)
         }
       : {
@@ -383,7 +383,7 @@ function AddBottle() {
           region: extracted.region || '',
           appellation: extracted.appellation || '',
           classification: extracted.classification || '',
-          type: extracted.type || 'red',
+          type: extracted.type || '',
           grapes: extracted.grapes || []
         };
 
@@ -400,7 +400,7 @@ function AddBottle() {
       region: extracted.region || '',
       appellation: extracted.appellation || '',
       classification: extracted.classification || '',
-      type: extracted.type || 'red',
+      type: extracted.type || '',
       grapes: (extracted.grapes || []).join(', ')
     });
     setShowManualForm(true);
@@ -501,7 +501,7 @@ function AddBottle() {
       country: aiIdentified.country || '',
       region: aiIdentified.region || '',
       appellation: aiIdentified.appellation || '',
-      type: aiIdentified.type || 'red',
+      type: aiIdentified.type || '',
       grapes: (aiIdentified.grapes || []).join(', '),
       source: 'ai',
     });
@@ -526,7 +526,7 @@ function AddBottle() {
       country: aiIdentified.country,
       region: aiIdentified.region || '',
       appellation: aiIdentified.appellation || '',
-      type: aiIdentified.type || 'red',
+      type: aiIdentified.type || '',
       grapes: aiIdentified.grapes || [],
       source: 'ai',
     });
@@ -859,7 +859,7 @@ function AddBottle() {
                   <div className="scan-wine-shot-img-wrap">
                     {labelImage
                       ? <img src={labelImage} alt={scanResult.extracted.name} className="scan-wine-label-img" />
-                      : <div className={`wine-row-placeholder scan-wine-placeholder ${scanResult.extracted.type || 'red'}`} />
+                      : <div className={`wine-row-placeholder scan-wine-placeholder ${scanResult.extracted.type || 'unknown'}`} />
                     }
                   </div>
                   {scanMatchedWine?.image && (
@@ -902,8 +902,8 @@ function AddBottle() {
                   {scanResult.extracted.country && <span>{scanResult.extracted.country}</span>}
                   {scanResult.extracted.region && <span>• {scanResult.extracted.region}</span>}
                   {scanResult.extracted.appellation && <span>• {scanResult.extracted.appellation}</span>}
-                  <span className={`wine-type-pill ${scanResult.extracted.type || 'red'}`}>
-                    {scanResult.extracted.type || 'red'}
+                  <span className={`wine-type-pill ${scanResult.extracted.type || 'unknown'}`}>
+                    {scanResult.extracted.type || t('common.unknown')}
                   </span>
                 </div>
                 {scanResult.extracted.grapes?.length > 0 && (
@@ -976,6 +976,11 @@ function AddBottle() {
                   <label>{t('addBottle.scanType')}</label>
                   <select value={pendingWineData.type}
                     onChange={e => setPendingWineData(p => ({ ...p, type: e.target.value }))}>
+                    {/* Unknown is a real answer: the scan and the AI now return
+                        null rather than defaulting to red (ticket 6a85ad44), so
+                        the form must be able to carry that through instead of
+                        making the user pick a colour to get past it. */}
+                    <option value="">{t('common.unknown')}</option>
                     {WINE_TYPES.map(wt => <option key={wt} value={wt}>{wt}</option>)}
                   </select>
                 </div>
@@ -1080,7 +1085,7 @@ function AddBottle() {
                           {countryName && <span>{countryName}</span>}
                           {regionName && <span>• {regionName}</span>}
                           {card.appellation && <span>• {card.appellation}</span>}
-                          <span className={`wine-type-pill ${card.type || 'red'}`}>{card.type || 'red'}</span>
+                          <span className={`wine-type-pill ${card.type || 'unknown'}`}>{card.type || t('common.unknown')}</span>
                         </div>
                         {grapeNames.length > 0 && (
                           <p className="wine-grapes">{grapeNames.join(', ')}</p>

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -163,7 +163,7 @@ function AddToWishlist() {
         appellation: e.appellation || '',
         // Not a form field — rides invisibly into the commit payload (see AddBottle).
         classification: e.classification || '',
-        type: e.type || 'red',
+        type: e.type || '',
         grapes: (e.grapes || []).join(', '),
       });
       setShowManualForm(true);
@@ -211,7 +211,7 @@ function AddToWishlist() {
         region: merged.region || '',
         appellation: merged.appellation || '',
         classification: merged.classification || '',
-        type: merged.type || 'red',
+        type: merged.type || '',
         grapes: (merged.grapes || []).join(', '),
       };
       if (!prev) return fromMerged;
@@ -294,7 +294,7 @@ function AddToWishlist() {
           country: match.wine.country?.name || extracted.country || '',
           region: match.wine.region?.name || extracted.region || '',
           appellation: match.wine.appellation || extracted.appellation || '',
-          type: match.wine.type || extracted.type || 'red',
+          type: match.wine.type || extracted.type || '',
           grapes: (match.wine.grapes || []).map(g => g.name)
         }
       : {
@@ -304,7 +304,7 @@ function AddToWishlist() {
           region: extracted.region || '',
           appellation: extracted.appellation || '',
           classification: extracted.classification || '',
-          type: extracted.type || 'red',
+          type: extracted.type || '',
           grapes: extracted.grapes || []
         };
 
@@ -320,7 +320,7 @@ function AddToWishlist() {
       region: extracted.region || '',
       appellation: extracted.appellation || '',
       classification: extracted.classification || '',
-      type: extracted.type || 'red',
+      type: extracted.type || '',
       grapes: (extracted.grapes || []).join(', ')
     });
     setShowManualForm(true);
@@ -413,7 +413,7 @@ function AddToWishlist() {
       country: aiIdentified.country || '',
       region: aiIdentified.region || '',
       appellation: aiIdentified.appellation || '',
-      type: aiIdentified.type || 'red',
+      type: aiIdentified.type || '',
       grapes: (aiIdentified.grapes || []).join(', '),
       source: 'ai',
     });
@@ -433,7 +433,7 @@ function AddToWishlist() {
       country: aiIdentified.country,
       region: aiIdentified.region || '',
       appellation: aiIdentified.appellation || '',
-      type: aiIdentified.type || 'red',
+      type: aiIdentified.type || '',
       grapes: aiIdentified.grapes || [],
       source: 'ai',
     });
@@ -637,7 +637,7 @@ function AddToWishlist() {
               <div className="scan-wine-image-wrap">
                 {labelImage
                   ? <img src={labelImage} alt={scanResult.extracted.name} className="scan-wine-label-img" />
-                  : <div className={`wine-row-placeholder scan-wine-placeholder ${scanResult.extracted.type || 'red'}`} />
+                  : <div className={`wine-row-placeholder scan-wine-placeholder ${scanResult.extracted.type || 'unknown'}`} />
                 }
               </div>
               <div className="scan-wine-body">
@@ -654,8 +654,8 @@ function AddToWishlist() {
                   {scanResult.extracted.country && <span>{scanResult.extracted.country}</span>}
                   {scanResult.extracted.region && <span>• {scanResult.extracted.region}</span>}
                   {scanResult.extracted.appellation && <span>• {scanResult.extracted.appellation}</span>}
-                  <span className={`wine-type-pill ${scanResult.extracted.type || 'red'}`}>
-                    {scanResult.extracted.type || 'red'}
+                  <span className={`wine-type-pill ${scanResult.extracted.type || 'unknown'}`}>
+                    {scanResult.extracted.type || t('common.unknown')}
                   </span>
                 </div>
                 {scanResult.extracted.grapes?.length > 0 && (
@@ -718,6 +718,8 @@ function AddToWishlist() {
                   <label>{t('addToWishlist.type')}</label>
                   <select value={pendingWineData.type}
                     onChange={e => setPendingWineData(p => ({ ...p, type: e.target.value }))}>
+                    {/* See AddBottle: unknown is a real answer, not a gap. */}
+                    <option value="">{t('common.unknown')}</option>
                     {WINE_TYPES.map(wt => <option key={wt} value={wt}>{wt}</option>)}
                   </select>
                 </div>
@@ -821,7 +823,7 @@ function AddToWishlist() {
                           {countryName && <span>{countryName}</span>}
                           {regionName && <span>• {regionName}</span>}
                           {card.appellation && <span>• {card.appellation}</span>}
-                          <span className={`wine-type-pill ${card.type || 'red'}`}>{card.type || 'red'}</span>
+                          <span className={`wine-type-pill ${card.type || 'unknown'}`}>{card.type || t('common.unknown')}</span>
                         </div>
                         {grapeNames.length > 0 && (
                           <p className="wine-grapes">{grapeNames.join(', ')}</p>


### PR DESCRIPTION
Completes ticket **6a85ad44** (somm, HIGH). v1.139.0 removed the `type: 'red'` schema default and made the *import-lookup* prompt's type nullable. Two halves of the same guess were still standing.

### 1. Two prompts still forced a colour
`DEFAULT_LABEL_SCAN_PROMPT` (front) and `DEFAULT_TEXT_SEARCH_PROMPT` declared `type` as a required six-way enum, so the model had no way to answer "I cannot tell" — the exact pressure that typed four white Loire/Ardèche naturals as red. Both now allow null, with a rule that says why it matters (colour drives filtering, serving temperature and drink-window shape, so a guess costs more than a blank).

Neither prompt is DB-overridable in practice — prod carries **no** stored prompt overrides (verified), and the text-search prompt is read straight from the module — so the code change is the live change.

### 2. The client re-applied the default anyway
`AddBottle.js` and `AddToWishlist.js` each held **seven** `|| 'red'` fallbacks on the paths that build the commit payload. A null from the backend became a red in the registry the moment the user pressed confirm, and the type pill printed the literal word "red" for a wine nobody had determined.

- write-path fallbacks → `''`
- manual form gains an **unknown** option (uses the existing `common.unknown` key — no new strings, no locale churn)
- pill + placeholder swatch get their own neutral styling instead of borrowing red's

Rack/3D renderers keep their red default deliberately: a bottle has to be drawn *some* colour — a rendering choice, not a claim about the wine.

### Verification
- backend: 6 suites / 67 tests pass (`labelScan`, `config`)
- frontend: `lint:tokens` clean (117 properties, all defined); full suite passes except `src/config/plans.test.js`, which fails on **unrelated uncommitted pricing edits already in the working tree** (patron 5.5 → 5) — not from this branch, and not included in it
- backend already accepts this end to end: `wines.js` stores null for anything outside `WINE_TYPES`, and the manual form only ever required name + country

### Not in scope
Existing rows already stamped `red` cannot be told apart from genuine reds retroactively — this stops new ones. The somm's four examples are already hand-corrected.