### PR TITLE
feat(supporter): three tiers, yearly-first pricing, rebuilt support page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,15 +120,23 @@ MEILI_MASTER_KEY=change-me-to-a-strong-random-string
 # Stripe — optional. Required for supporter tier payments.
 # Get keys at https://dashboard.stripe.com/apikeys
 # Create recurring Products/Prices in the Stripe Dashboard and paste their Price IDs below.
-# The two ANNUAL ids are optional — leave them unset and the yearly buttons on
-# /supporter simply fail with "Stripe price not configured for this plan"
-# (the monthly ones keep working).
+# The ANNUAL ids are optional — leave one unset and that tier simply shows no
+# yearly button on /supporter (the monthly ones keep working).
+#
+# Each var takes a COMMA-SEPARATED list. The FIRST id is what new checkouts use;
+# any after it are retired prices that still have live subscribers. Archiving a
+# price in Stripe does NOT move existing subscriptions off it — they renew at the
+# old amount forever — so a retired id must stay listed here, or those renewals
+# stop mapping to a tier and the subscriber's plan silently goes stale:
+#   STRIPE_PATRON_PRICE_ID=price_current,price_retired_2026
 # STRIPE_SECRET_KEY=sk_test_...
 # STRIPE_WEBHOOK_SECRET=whsec_...
 # STRIPE_SUPPORTER_PRICE_ID=price_...
 # STRIPE_PATRON_PRICE_ID=price_...
+# STRIPE_BENEFACTOR_PRICE_ID=price_...
 # STRIPE_SUPPORTER_ANNUAL_PRICE_ID=price_...
 # STRIPE_PATRON_ANNUAL_PRICE_ID=price_...
+# STRIPE_BENEFACTOR_ANNUAL_PRICE_ID=price_...
 
 # Umami self-hosted analytics — optional. Privacy-friendly, no cookies, no consent banner.
 # The umami + umami-db services in docker-compose.yml are inert until these are set.

--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,14 @@ MEILI_MASTER_KEY=change-me-to-a-strong-random-string
 # Stripe — optional. Required for supporter tier payments.
 # Get keys at https://dashboard.stripe.com/apikeys
 # Create recurring Products/Prices in the Stripe Dashboard and paste their Price IDs below.
+#
+# ⚠️ Give EACH TIER ITS OWN Stripe PRODUCT, with one monthly and one yearly
+# price on it — not one shared "support" product carrying every price. Checkout
+# works either way, but the Customer Portal rejects a catalogue entry whose
+# product has two prices of the same interval ("its price must have unique
+# billing intervals"), so a shared product makes it impossible to offer tier
+# switching in the portal. Subscribers would then be able to change plan only by
+# cancelling and waiting out the paid period — up to a year for an annual one.
 # The ANNUAL ids are optional — leave one unset and that tier simply shows no
 # yearly button on /supporter (the monthly ones keep working).
 #

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Cellarion is live and publicly available at:
 
 👉 **https://cellarion.app**
 
-This is the primary way to use Cellarion. Create an account and start using the full service today — **every feature is free, forever.** No credit card, no trial clock, no paywalled features, nothing to install or maintain. If you want to chip in, optional [Supporter and Patron tiers](https://cellarion.app/plans) (monthly or annual) and [GitHub Sponsors](https://github.com/sponsors/jagduvi1) fund development — they unlock nothing extra, just our thanks.
+This is the primary way to use Cellarion. Create an account and start using the full service today — **every feature is free, forever.** No credit card, no trial clock, no paywalled features, nothing to install or maintain. If you want to chip in, optional [Supporter, Patron and Benefactor tiers](https://cellarion.app/supporter) (monthly or yearly) and [GitHub Sponsors](https://github.com/sponsors/jagduvi1) fund development — they unlock nothing extra, just our thanks.
 
 ## Features
 
@@ -47,7 +47,7 @@ This is the primary way to use Cellarion. Create an account and start using the 
 - **Installable app** — PWA with push notifications, plus an Android app on [Google Play](https://play.google.com/store/apps/details?id=app.cellarion.twa)
 - **Internationalization** — Community-translated via Weblate ([help translate](#translations))
 - **Privacy & GDPR** — Full data export, account deletion with cooling-off, one-click email opt-out, optional self-hosted cookie-free analytics (Umami)
-- **Everything free** — Optional Supporter/Patron tiers (Stripe, monthly or annual) and GitHub Sponsors fund development; they unlock nothing extra
+- **Everything free** — Optional Supporter/Patron/Benefactor tiers (Stripe, monthly or yearly) and GitHub Sponsors fund development; they unlock nothing extra
 - **Sommelier & admin tools** — Maturity/pricing curation surfaces, wine requests, quality reports, registry health watchdog, audit log, super-admin dashboard
 
 ---
@@ -374,7 +374,7 @@ Copy `.env.example` to `.env` — **it is fully commented and is the authoritati
 |-------|-----------|---------|
 | Self-hosted AI | `AI_PROVIDER`, `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `AI_MODEL`, `AI_VISION_MODEL`, `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`, `EMBEDDING_DIMENSION`, … | Any OpenAI-compatible endpoint instead of Anthropic/Voyage — see [Self-hosted AI](#self-hosted-ai-openai-compatible-endpoints) |
 | Google SSO | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL` | Sign in with Google |
-| Supporter payments | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_*_PRICE_ID` (monthly + annual) | Stripe Checkout for the optional tiers |
+| Supporter payments | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_{SUPPORTER,PATRON,BENEFACTOR}_PRICE_ID` + `_ANNUAL_` variants | Stripe Checkout for the optional tiers. Each price var takes a comma-separated list — current price first, then any retired prices that still have live subscribers |
 | Push notifications | `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_EMAIL` | Web-push for drink alerts and events |
 | Climate monitoring | `CLIMATE_RETENTION_DAYS`, `CLIMATE_MAX_DEVICES_PER_USER`, `CLIMATE_MAX_READINGS_PER_DAY`, … | Sensor ingest limits + GDPR retention |
 | Analytics | `UMAMI_DB_PASSWORD`, `UMAMI_APP_SECRET`, `VITE_UMAMI_URL`, `VITE_UMAMI_WEBSITE_ID` | Self-hosted cookie-free Umami (`--profile analytics`; `VITE_*` are build-time) |

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Copy `.env.example` to `.env` — **it is fully commented and is the authoritati
 |-------|-----------|---------|
 | Self-hosted AI | `AI_PROVIDER`, `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `AI_MODEL`, `AI_VISION_MODEL`, `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`, `EMBEDDING_DIMENSION`, … | Any OpenAI-compatible endpoint instead of Anthropic/Voyage — see [Self-hosted AI](#self-hosted-ai-openai-compatible-endpoints) |
 | Google SSO | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL` | Sign in with Google |
-| Supporter payments | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_{SUPPORTER,PATRON,BENEFACTOR}_PRICE_ID` + `_ANNUAL_` variants | Stripe Checkout for the optional tiers. Each price var takes a comma-separated list — current price first, then any retired prices that still have live subscribers |
+| Supporter payments | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_{SUPPORTER,PATRON,BENEFACTOR}_PRICE_ID` + `_ANNUAL_` variants | Stripe Checkout for the optional tiers. Give each tier its own Stripe **Product** (one monthly + one yearly price), or the Customer Portal can't offer tier switching. Each price var takes a comma-separated list — current price first, then any retired prices that still have live subscribers |
 | Push notifications | `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_EMAIL` | Web-push for drink alerts and events |
 | Climate monitoring | `CLIMATE_RETENTION_DAYS`, `CLIMATE_MAX_DEVICES_PER_USER`, `CLIMATE_MAX_READINGS_PER_DAY`, … | Sensor ingest limits + GDPR retention |
 | Analytics | `UMAMI_DB_PASSWORD`, `UMAMI_APP_SECRET`, `VITE_UMAMI_URL`, `VITE_UMAMI_WEBSITE_ID` | Self-hosted cookie-free Umami (`--profile analytics`; `VITE_*` are build-time) |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -62,8 +62,17 @@ VAPID_EMAIL=
 # ── Stripe Payments — optional ───────────────────────────────────────────────
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
+# Each takes a COMMA-SEPARATED list: the price new checkouts use first, then any
+# retired prices that still have live subscribers (archiving a Stripe price does
+# not move existing subscriptions off it, and their renewals must still resolve
+# to a tier). The ANNUAL ids are optional — leave one unset and that tier simply
+# has no yearly button.
 STRIPE_SUPPORTER_PRICE_ID=
 STRIPE_PATRON_PRICE_ID=
+STRIPE_BENEFACTOR_PRICE_ID=
+STRIPE_SUPPORTER_ANNUAL_PRICE_ID=
+STRIPE_PATRON_ANNUAL_PRICE_ID=
+STRIPE_BENEFACTOR_ANNUAL_PRICE_ID=
 
 # ── Logging & Auditing ───────────────────────────────────────────────────────
 LOG_LEVEL=info

--- a/backend/src/config/plans.js
+++ b/backend/src/config/plans.js
@@ -11,8 +11,9 @@
  *              the amount actually charged comes from the Stripe Price whose
  *              id is in STRIPE_<TIER>_ANNUAL_PRICE_ID, so if you change one you
  *              must change the other.
- * suggested:   marks the tier the /supporter page highlights. Exactly one paid
- *              tier should carry it.
+ * The paid tiers are rendered in declaration order, and no tier is marked or
+ * highlighted as the recommended one: the page must never imply that giving is
+ * expected. Ordering alone puts the middle amount in the middle.
  *
  * The annual price is deliberately EXACTLY 12x the monthly one — there is no
  * yearly discount. Yearly is steered by being the default cadence and by the
@@ -56,7 +57,6 @@ const PLANS = {
     description: 'Support Cellarion at a higher level — no extra features, just bigger thanks.',
     price: 5,
     annualPrice: 60,
-    suggested: true,
     featureList: [
       'Everything in Enthusiast (all features are free)',
       'Support independent development even more',

--- a/backend/src/config/plans.js
+++ b/backend/src/config/plans.js
@@ -11,6 +11,15 @@
  *              the amount actually charged comes from the Stripe Price whose
  *              id is in STRIPE_<TIER>_ANNUAL_PRICE_ID, so if you change one you
  *              must change the other.
+ * suggested:   marks the tier the /supporter page highlights. Exactly one paid
+ *              tier should carry it.
+ *
+ * The annual price is deliberately EXACTLY 12x the monthly one — there is no
+ * yearly discount. Yearly is steered by being the default cadence and by the
+ * honest framing on /supporter (one card fee a year instead of twelve, so more
+ * of the gift arrives), not by asking donors to give less. The saving is the
+ * fixed part of Stripe's per-charge fee: ~11x ~$0.20 ~= $2.20/subscriber/year
+ * whatever the tier, which is worth ~9% at Supporter and ~2% at Benefactor.
  */
 const PLANS = {
   free: {
@@ -34,8 +43,8 @@ const PLANS = {
   supporter: {
     label: 'Supporter',
     description: 'Chip in to help fund development — no extra features, just our thanks.',
-    price: 1.5,
-    annualPrice: 18,
+    price: 2,
+    annualPrice: 24,
     featureList: [
       'Everything in Enthusiast (all features are free)',
       'Support independent development',
@@ -45,11 +54,23 @@ const PLANS = {
   patron: {
     label: 'Patron',
     description: 'Support Cellarion at a higher level — no extra features, just bigger thanks.',
-    price: 5.5,
-    annualPrice: 66,
+    price: 5,
+    annualPrice: 60,
+    suggested: true,
     featureList: [
       'Everything in Enthusiast (all features are free)',
       'Support independent development even more',
+      'Our heartfelt thanks',
+    ],
+  },
+  benefactor: {
+    label: 'Benefactor',
+    description: 'Cover a meaningful slice of the running costs — still no extra features.',
+    price: 10,
+    annualPrice: 120,
+    featureList: [
+      'Everything in Enthusiast (all features are free)',
+      'Cover a real share of the monthly bills',
       'Our heartfelt thanks',
     ],
   },

--- a/backend/src/data/helpContent.js
+++ b/backend/src/data/helpContent.js
@@ -230,7 +230,7 @@ const sections = [
     summary: 'Blog, plans, support, and NFC tags.',
     details: [
       'Blog (/blog): wine articles and guides.',
-      'Plans (/plans): supporter tiers — Enthusiast (free), Supporter, and Patron. All tiers are functionally identical: every feature is free for everyone, and the paid tiers are purely voluntary contributions that fund development.',
+      'Supporter tiers (/supporter): Enthusiast (free), Supporter, Patron, and Benefactor, each billable monthly or yearly. All tiers are functionally identical: every feature is free for everyone, and the paid tiers are purely voluntary contributions that fund development. A custom or one-time amount can be given through GitHub Sponsors instead.',
       'Support (/support): submit support tickets for help.',
       'NFC tags: attach NFC tags to racks — scan with your phone to open the rack directly.',
     ],

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 const crypto = require('crypto');
 const { CURRENT_PRIVACY_POLICY_VERSION } = require('../config/legal');
+const { PLAN_NAMES } = require('../config/plans');
 
 // Single source of truth for the bcrypt work factor. The login route's dummy
 // hash (routes/auth.js) MUST be generated at this same cost — a cheaper dummy
@@ -73,7 +74,9 @@ const userSchema = new mongoose.Schema({
   },
   plan: {
     type: String,
-    enum: ['free', 'supporter', 'patron'],
+    // Derived from the plan config so adding a supporter tier there cannot
+    // leave the schema rejecting the very plan Stripe just granted.
+    enum: PLAN_NAMES,
     default: 'free'
   },
   planStartedAt: {

--- a/backend/src/routes/stripe.js
+++ b/backend/src/routes/stripe.js
@@ -30,25 +30,55 @@ const INTERVALS = ['month', 'year'];
 const PRICE_ENV = {
   supporter: { month: 'STRIPE_SUPPORTER_PRICE_ID', year: 'STRIPE_SUPPORTER_ANNUAL_PRICE_ID' },
   patron: { month: 'STRIPE_PATRON_PRICE_ID', year: 'STRIPE_PATRON_ANNUAL_PRICE_ID' },
+  benefactor: { month: 'STRIPE_BENEFACTOR_PRICE_ID', year: 'STRIPE_BENEFACTOR_ANNUAL_PRICE_ID' },
 };
 
 /**
- * Resolve the Stripe Price ID for a (tier, interval) pair, or undefined when
- * that combination has no price configured. The annual prices are OPTIONAL —
- * a self-hoster who only created the two monthly prices keeps working, and the
- * checkout route refuses the unconfigured interval rather than quietly billing
- * a different cadence than the one the user clicked.
+ * Tiers checkout will accept. Derived from PRICE_ENV rather than written out
+ * again — the previous hardcoded list meant a tier added above was rejected
+ * with "Invalid plan" despite having prices configured.
  */
-function priceIdFor(plan, interval) {
-  return process.env[PRICE_ENV[plan]?.[interval]] || undefined;
+const PAID_TIERS = Object.keys(PRICE_ENV);
+
+/**
+ * Every price env var holds a COMMA-SEPARATED list: the price new checkouts
+ * use, followed by any retired prices that still have live subscribers on them.
+ *
+ *   STRIPE_PATRON_PRICE_ID=price_current,price_retired_2026
+ *
+ * This matters when a price is repriced. Archiving a Price in Stripe does not
+ * touch existing subscriptions — they keep renewing at the old amount forever —
+ * so those renewals keep arriving as customer.subscription.updated carrying the
+ * OLD price id. If that id is no longer mapped, planFromPriceId returns null and
+ * the handler logs "maps to no known plan" and leaves the subscriber's plan to
+ * go stale. Keeping the retired ids listed here is what grandfathers them.
+ */
+function priceIdsFor(plan, interval) {
+  const raw = process.env[PRICE_ENV[plan]?.[interval]] || '';
+  return raw.split(',').map((s) => s.trim()).filter(Boolean);
 }
 
-/** Map Stripe Price IDs → Cellarion plan names, across both billing intervals. */
+/**
+ * Resolve the Stripe Price ID new checkouts should use for a (tier, interval)
+ * pair — the FIRST entry — or undefined when that combination has no price
+ * configured. The annual prices are OPTIONAL — a self-hoster who only created
+ * the monthly prices keeps working, and the checkout route refuses the
+ * unconfigured interval rather than quietly billing a different cadence than
+ * the one the user clicked.
+ */
+function priceIdFor(plan, interval) {
+  return priceIdsFor(plan, interval)[0] || undefined;
+}
+
+/**
+ * Map a Stripe Price ID → Cellarion plan name, across both billing intervals
+ * AND retired prices, so a grandfathered subscriber's renewal still resolves.
+ */
 function planFromPriceId(priceId) {
   if (!priceId) return null;
   for (const plan of Object.keys(PRICE_ENV)) {
     for (const interval of INTERVALS) {
-      if (priceId === priceIdFor(plan, interval)) return plan;
+      if (priceIdsFor(plan, interval).includes(priceId)) return plan;
     }
   }
   return null;
@@ -95,11 +125,30 @@ async function applyStripePlan(userId, plan, subscriptionId) {
   return { from: user.plan, to: update.plan || user.plan };
 }
 
+// ── GET /api/stripe/availability — which (tier, interval) pairs are buyable ──
+/**
+ * The /supporter page renders a button per tier per cadence, but every price is
+ * an OPTIONAL env var — a self-hoster (or a prod box mid-rollout) may have only
+ * some of them set. Without this the page happily renders a button that dies on
+ * "Stripe price not configured" after the user has committed to giving money.
+ *
+ * Returns only booleans, never the Price IDs themselves.
+ */
+router.get('/availability', requireAuth, (req, res) => {
+  const tiers = {};
+  for (const tier of PAID_TIERS) {
+    tiers[tier] = Object.fromEntries(
+      INTERVALS.map((interval) => [interval, !!priceIdFor(tier, interval)])
+    );
+  }
+  res.json({ configured: !!process.env.STRIPE_SECRET_KEY, tiers });
+});
+
 // ── POST /api/stripe/checkout — Create a Stripe Checkout Session ──
 router.post('/checkout', requireAuth, async (req, res) => {
   try {
     const { plan, interval = 'month' } = req.body;
-    if (!plan || !['supporter', 'patron'].includes(plan)) {
+    if (!plan || !PAID_TIERS.includes(plan)) {
       return res.status(400).json({ error: 'Invalid plan' });
     }
     // Defaults to 'month' so an older client (or the MCP/API caller that only
@@ -404,3 +453,6 @@ router.post('/webhook', async (req, res) => {
 module.exports = router;
 // Exported for unit tests (the webhook handlers above are exercised in Docker).
 module.exports.applyStripePlan = applyStripePlan;
+// planFromPriceId is what grandfathers a repriced subscriber — worth testing
+// directly rather than through a webhook that needs signature verification.
+module.exports.planFromPriceId = planFromPriceId;

--- a/backend/src/routes/stripe.priceMapping.test.js
+++ b/backend/src/routes/stripe.priceMapping.test.js
@@ -1,0 +1,198 @@
+/**
+ * Price-ID → tier resolution, exercised through the /availability endpoint and
+ * the checkout route because planFromPriceId/priceIdsFor are module-private.
+ *
+ * The behaviour under test is what keeps a repricing safe. Archiving a Price in
+ * Stripe does NOT move existing subscriptions off it — they renew at the old
+ * amount indefinitely, and every renewal arrives as a webhook carrying the OLD
+ * price id. If that id stops resolving to a tier, the webhook's "maps to no
+ * known plan" branch fires and the grandfathered subscriber's plan goes stale.
+ * So each price env var takes a comma-separated list: current price first,
+ * retired prices after it.
+ */
+
+process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
+// Supporter carries a RETIRED price alongside the current one — the shape a
+// repricing leaves behind.
+process.env.STRIPE_SUPPORTER_PRICE_ID = 'price_supporter_new, price_supporter_retired';
+process.env.STRIPE_SUPPORTER_ANNUAL_PRICE_ID = 'price_supporter_year_new,price_supporter_year_retired';
+process.env.STRIPE_PATRON_PRICE_ID = 'price_patron';
+process.env.STRIPE_PATRON_ANNUAL_PRICE_ID = 'price_patron_year';
+process.env.STRIPE_BENEFACTOR_PRICE_ID = 'price_benefactor';
+// Benefactor's annual price is deliberately UNSET — a half-configured install.
+
+jest.mock('../middleware/auth', () => ({
+  requireAuth: (req, res, next) => { req.user = { id: 'u1' }; next(); },
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/supporterThankYou', () => ({ maybeSendSupporterThankYou: jest.fn() }));
+jest.mock('../models/User', () => ({
+  findById: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+  findByIdAndUpdate: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('stripe', () => jest.fn(() => ({})));
+
+const express = require('express');
+const http = require('http');
+const User = require('../models/User');
+const stripeRouter = require('./stripe');
+const { applyStripePlan } = require('./stripe');
+
+// Raw http rather than supertest — it is not a dependency of this project, and
+// stripe.checkout.test.js already drives the router this way.
+let server;
+let port;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stripe', stripeRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { port = server.address().port; done(); });
+});
+
+afterAll((done) => {
+  server.closeAllConnections?.();
+  server.close(() => done()); // swallow close's arg — jest's done() fails on any truthy value
+});
+
+const call = (method, path, body) => new Promise((resolve, reject) => {
+  const payload = body === undefined ? null : JSON.stringify(body);
+  const req = http.request({
+    port,
+    path,
+    method,
+    headers: payload
+      ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) }
+      : {},
+  }, (res) => {
+    const chunks = [];
+    res.on('data', (c) => chunks.push(c));
+    res.on('end', () => resolve({
+      status: res.statusCode,
+      body: JSON.parse(Buffer.concat(chunks).toString()),
+    }));
+  });
+  req.on('error', reject);
+  req.end(payload);
+});
+
+const mockUser = (doc) =>
+  User.findById.mockReturnValue({ select: jest.fn().mockResolvedValue(doc) });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /api/stripe/availability', () => {
+  test('reports a configured pair as available and an unconfigured one as not', async () => {
+    const r = await call('GET', '/api/stripe/availability');
+
+    expect(r.status).toBe(200);
+    expect(r.body.configured).toBe(true);
+    expect(r.body.tiers.supporter).toEqual({ month: true, year: true });
+    expect(r.body.tiers.patron).toEqual({ month: true, year: true });
+    // The page must not render a yearly Benefactor button it cannot complete.
+    expect(r.body.tiers.benefactor).toEqual({ month: true, year: false });
+  });
+
+  test('never leaks the Price IDs themselves', async () => {
+    const r = await call('GET', '/api/stripe/availability');
+    expect(JSON.stringify(r.body)).not.toContain('price_');
+  });
+
+  test('covers every tier checkout accepts, so no tier can be silently unlisted', async () => {
+    const r = await call('GET', '/api/stripe/availability');
+    expect(Object.keys(r.body.tiers)).toEqual(['supporter', 'patron', 'benefactor']);
+  });
+});
+
+describe('checkout tier allowlist', () => {
+  const checkout = (plan) => call('POST', '/api/stripe/checkout', { plan, interval: 'month' });
+
+  test('accepts the newest tier — the allowlist is derived, not hand-listed', async () => {
+    // Reaching the user lookup proves the plan passed validation; the request
+    // then fails for an unrelated reason, which is enough for this assertion.
+    mockUser(null);
+    User.findById.mockReturnValue({ select: jest.fn().mockResolvedValue(null) });
+    const r = await checkout('benefactor');
+
+    expect(r.status).not.toBe(400);
+    expect(r.body.error).not.toBe('Invalid plan');
+  });
+
+  test('still rejects an unknown tier', async () => {
+    const r = await checkout('freeloader');
+    expect(r.status).toBe(400);
+    expect(r.body.error).toBe('Invalid plan');
+  });
+});
+
+describe('planFromPriceId — retired prices keep resolving (grandfathering)', () => {
+  const { planFromPriceId } = require('./stripe');
+  const { PLANS, PLAN_NAMES } = require('../config/plans');
+
+  test('resolves the current price of each tier', () => {
+    expect(planFromPriceId('price_supporter_new')).toBe('supporter');
+    expect(planFromPriceId('price_patron')).toBe('patron');
+    expect(planFromPriceId('price_benefactor')).toBe('benefactor');
+  });
+
+  test('resolves a RETIRED price to the same tier as the current one', () => {
+    // The regression this guards: a subscriber left on the archived price keeps
+    // renewing there forever. If this returned null, every one of their renewal
+    // webhooks would hit the "maps to no known plan" branch and their plan would
+    // drift out of sync with what they are actually paying.
+    expect(planFromPriceId('price_supporter_retired')).toBe('supporter');
+    expect(planFromPriceId('price_supporter_year_retired')).toBe('supporter');
+  });
+
+  test('tolerates whitespace around the comma', () => {
+    // STRIPE_SUPPORTER_PRICE_ID is set with ', ' between ids at the top of file.
+    expect(planFromPriceId('price_supporter_retired')).toBe('supporter');
+  });
+
+  test('resolves annual and monthly prices to the same tier', () => {
+    expect(planFromPriceId('price_patron_year')).toBe('patron');
+    expect(planFromPriceId('price_patron')).toBe('patron');
+  });
+
+  test('returns null for an unknown or empty price id', () => {
+    expect(planFromPriceId('price_never_seen')).toBeNull();
+    expect(planFromPriceId('')).toBeNull();
+    expect(planFromPriceId(undefined)).toBeNull();
+  });
+
+  test('does not match on a prefix — ids must be exact', () => {
+    expect(planFromPriceId('price_patron_year_extra')).toBeNull();
+    expect(planFromPriceId('price_patr')).toBeNull();
+  });
+
+  test('every configured tier exists in the plan config', () => {
+    // A tier priced in Stripe but missing from the config would be written to
+    // User.plan and rejected by the schema enum.
+    for (const tier of ['supporter', 'patron', 'benefactor']) {
+      expect(PLAN_NAMES).toContain(tier);
+      expect(PLANS[tier].price).toBeGreaterThan(0);
+    }
+  });
+
+  test('applyStripePlan ranks the new top tier above patron', async () => {
+    // PLAN_RANK is derived from config order; if benefactor ranked 0 the guard
+    // would treat an upgrade into it as a downgrade and skip the write.
+    mockUser({ plan: 'patron', planExpiresAt: null });
+    const change = await applyStripePlan('u1', 'benefactor', 'sub_1');
+
+    expect(change).toEqual({ from: 'patron', to: 'benefactor' });
+    expect(User.findByIdAndUpdate.mock.calls.at(-1)[1].plan).toBe('benefactor');
+  });
+
+  test('an unexpired admin grant of a HIGHER tier still outranks a Stripe downgrade', async () => {
+    mockUser({ plan: 'benefactor', planExpiresAt: new Date(Date.now() + 30 * 86400_000) });
+    await applyStripePlan('u1', 'supporter', 'sub_1');
+
+    // Grant wins: no plan overwrite, only the subscription id is recorded.
+    const update = User.findByIdAndUpdate.mock.calls.at(-1)[1];
+    expect(update.plan).toBeUndefined();
+    expect(update.stripeSubscriptionId).toBe('sub_1');
+  });
+});

--- a/backend/src/services/supporterThankYou.js
+++ b/backend/src/services/supporterThankYou.js
@@ -2,7 +2,9 @@ const User = require('../models/User');
 const { sendSupporterThankYou, EMAIL_VERIFICATION_ENABLED } = require('./mailgun');
 const { logAudit } = require('./audit');
 
-const PAID_PLANS = ['supporter', 'patron'];
+const { PLANS, PLAN_NAMES } = require('../config/plans');
+
+const PAID_PLANS = PLAN_NAMES.filter((p) => PLANS[p].price > 0);
 
 /**
  * Thank a user for taking out a paid plan — at most once per account, ever.

--- a/backend/src/services/supporterThankYou.test.js
+++ b/backend/src/services/supporterThankYou.test.js
@@ -41,7 +41,13 @@ test('the claim only matches an account that has NEVER been thanked', async () =
   const [filter, update] = User.findOneAndUpdate.mock.calls[0];
   // The null check is what makes this once-ever; without it every renewal sends.
   expect(filter.supporterThankYouSentAt).toBeNull();
-  expect(filter.plan).toEqual({ $in: ['supporter', 'patron'] });
+  // Derived from the plan config, not hand-listed: a new supporter tier must be
+  // thanked like any other, and a stale literal here would only fail the test
+  // rather than catch a real omission.
+  const { PLANS, PLAN_NAMES } = require('../config/plans');
+  const paidPlans = PLAN_NAMES.filter((p) => PLANS[p].price > 0);
+  expect(paidPlans.length).toBeGreaterThan(1);
+  expect(filter.plan).toEqual({ $in: paidPlans });
   expect(update.$set.supporterThankYouSentAt).toBeInstanceOf(Date);
 });
 

--- a/backend/src/utils/cellarCred.js
+++ b/backend/src/utils/cellarCred.js
@@ -12,6 +12,7 @@
  */
 
 const User = require('../models/User');
+const { PLAN_NAMES } = require('../config/plans');
 
 // ── Point values per event ──────────────────────────────────────────────────
 const POINT_VALUES = {
@@ -53,7 +54,11 @@ const TIERS = [
 // Plan ranking — retained because routes/stripe.js imports it to compare an
 // incoming Stripe plan against the user's current grant. Cellar Cred itself no
 // longer grants plans (see module header).
-const PLAN_RANK = { free: 0, supporter: 1, patron: 2 };
+// Rank == position in the plan ladder, taken from the config's declaration
+// order (free first, then ascending price). Deriving it means a new tier is
+// ranked automatically; a hardcoded map would silently rank it 0 and make
+// applyStripePlan treat every upgrade to it as a downgrade.
+const PLAN_RANK = Object.fromEntries(PLAN_NAMES.map((name, i) => [name, i]));
 
 /** Return the tier name for a given total score. */
 function getTier(totalScore) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,8 +173,16 @@ services:
       - VAPID_EMAIL=${VAPID_EMAIL:-}
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET:-}
+      # One var per (tier, interval). The backend enumerates env explicitly, so
+      # an id set in .env but not forwarded here is invisible to the container —
+      # which is exactly why the yearly buttons never worked: the two ANNUAL
+      # vars existed in .env.example but were never passed through.
       - STRIPE_SUPPORTER_PRICE_ID=${STRIPE_SUPPORTER_PRICE_ID:-}
       - STRIPE_PATRON_PRICE_ID=${STRIPE_PATRON_PRICE_ID:-}
+      - STRIPE_BENEFACTOR_PRICE_ID=${STRIPE_BENEFACTOR_PRICE_ID:-}
+      - STRIPE_SUPPORTER_ANNUAL_PRICE_ID=${STRIPE_SUPPORTER_ANNUAL_PRICE_ID:-}
+      - STRIPE_PATRON_ANNUAL_PRICE_ID=${STRIPE_PATRON_ANNUAL_PRICE_ID:-}
+      - STRIPE_BENEFACTOR_ANNUAL_PRICE_ID=${STRIPE_BENEFACTOR_ANNUAL_PRICE_ID:-}
       # Google Sign-In (SSO) — optional; unset leaves email/password login
       # untouched. The backend env block enumerates vars explicitly, so these
       # must be forwarded or the container never sees them even when set in .env.

--- a/frontend/src/api/stripe.js
+++ b/frontend/src/api/stripe.js
@@ -12,6 +12,12 @@ export const createCheckout = (apiFetch, plan, interval = 'month') =>
     body: JSON.stringify({ plan, interval })
   });
 
+/**
+ * Which (tier, interval) pairs actually have a Stripe Price configured, so the
+ * page never offers a button that cannot complete checkout. Booleans only.
+ */
+export const getAvailability = (apiFetch) => apiFetch('/api/stripe/availability');
+
 /** Create a Stripe Customer Portal session and return the redirect URL. */
 export const createPortal = (apiFetch) =>
   apiFetch('/api/stripe/portal', { method: 'POST' });

--- a/frontend/src/components/Layout.css
+++ b/frontend/src/components/Layout.css
@@ -167,6 +167,7 @@
 .badge--plan-free      { background: var(--badge-plan-free-bg); color: var(--badge-plan-free-text); }
 .badge--plan-supporter { background: var(--badge-plan-basic-bg); color: var(--badge-plan-basic-text); }
 .badge--plan-patron    { background: var(--badge-plan-premium-bg); color: var(--badge-plan-premium-text); }
+.badge--plan-benefactor { background: var(--badge-plan-elite-bg); color: var(--badge-plan-elite-text); }
 
 /* ── Icon buttons in nav ── */
 .btn-icon-nav {

--- a/frontend/src/config/plans.js
+++ b/frontend/src/config/plans.js
@@ -13,8 +13,9 @@
  * monthly price: there is no yearly discount, only the honest "one card fee
  * instead of twelve" framing. See the backend config for the fee arithmetic.
  *
- * `suggested` marks the tier this page highlights — the middle one, so the
- * extremes frame it rather than the other way round.
+ * No tier is flagged as recommended. All three are presented as equals and the
+ * middle amount is simply in the middle — a "Suggested" badge reads as an
+ * expectation to pay, and nothing here is expected.
  */
 export const PLANS = {
   free: {
@@ -51,7 +52,6 @@ export const PLANS = {
     description: 'Support Cellarion at a higher level — no extra features, just bigger thanks.',
     price: 5,
     annualPrice: 60,
-    suggested: true,
     featureList: [
       'Everything in Enthusiast (all features are free)',
       'Support independent development even more',

--- a/frontend/src/config/plans.js
+++ b/frontend/src/config/plans.js
@@ -9,7 +9,12 @@
  *
  * `annualPrice` is the yearly figure shown when the billing toggle is set to
  * yearly. It is display only — the charged amount comes from the Stripe Price
- * behind STRIPE_<TIER>_ANNUAL_PRICE_ID on the backend.
+ * behind STRIPE_<TIER>_ANNUAL_PRICE_ID on the backend. It is exactly 12x the
+ * monthly price: there is no yearly discount, only the honest "one card fee
+ * instead of twelve" framing. See the backend config for the fee arithmetic.
+ *
+ * `suggested` marks the tier this page highlights — the middle one, so the
+ * extremes frame it rather than the other way round.
  */
 export const PLANS = {
   free: {
@@ -33,8 +38,8 @@ export const PLANS = {
   supporter: {
     label: 'Supporter',
     description: 'Chip in to help fund development — no extra features, just our thanks.',
-    price: 1.5,
-    annualPrice: 18,
+    price: 2,
+    annualPrice: 24,
     featureList: [
       'Everything in Enthusiast (all features are free)',
       'Support independent development',
@@ -44,17 +49,35 @@ export const PLANS = {
   patron: {
     label: 'Patron',
     description: 'Support Cellarion at a higher level — no extra features, just bigger thanks.',
-    price: 5.5,
-    annualPrice: 66,
+    price: 5,
+    annualPrice: 60,
+    suggested: true,
     featureList: [
       'Everything in Enthusiast (all features are free)',
       'Support independent development even more',
       'Our heartfelt thanks',
     ],
   },
+  benefactor: {
+    label: 'Benefactor',
+    description: 'Cover a meaningful slice of the running costs — still no extra features.',
+    price: 10,
+    annualPrice: 120,
+    featureList: [
+      'Everything in Enthusiast (all features are free)',
+      'Cover a real share of the monthly bills',
+      'Our heartfelt thanks',
+    ],
+  },
 };
 
 export const PLAN_NAMES = Object.keys(PLANS);
+
+/**
+ * Paid tiers in ladder order — the order the /supporter page renders them in.
+ * Derived from PLANS so adding a tier to the config is enough.
+ */
+export const PAID_PLAN_NAMES = PLAN_NAMES.filter((p) => PLANS[p].price > 0);
 
 /** Returns the plan config for the given plan name, falling back to 'free'. */
 export function getPlanConfig(plan) {

--- a/frontend/src/config/plans.test.js
+++ b/frontend/src/config/plans.test.js
@@ -1,6 +1,7 @@
 import {
   PLANS,
   PLAN_NAMES,
+  PAID_PLAN_NAMES,
   getPlanConfig,
 } from './plans';
 import backendPlans from '../../../backend/src/config/plans.js';
@@ -10,8 +11,40 @@ import backendPlans from '../../../backend/src/config/plans.js';
 // ---------------------------------------------------------------------------
 describe('PLAN_NAMES', () => {
   it('contains all supporter tier keys', () => {
-    expect(PLAN_NAMES).toEqual(expect.arrayContaining(['free', 'supporter', 'patron']));
-    expect(PLAN_NAMES).toHaveLength(3);
+    expect(PLAN_NAMES).toEqual(['free', 'supporter', 'patron', 'benefactor']);
+  });
+
+  it('lists the paid tiers in ascending price order', () => {
+    // The /supporter page renders them in this order and relies on the middle
+    // one being the suggested tier — a reorder here silently moves the anchor.
+    expect(PAID_PLAN_NAMES).toEqual(['supporter', 'patron', 'benefactor']);
+    const prices = PAID_PLAN_NAMES.map((p) => PLANS[p].price);
+    expect(prices).toEqual([...prices].sort((a, b) => a - b));
+  });
+
+  it('marks exactly one paid tier as suggested, and it is the middle one', () => {
+    const suggested = PAID_PLAN_NAMES.filter((p) => PLANS[p].suggested);
+    expect(suggested).toHaveLength(1);
+    expect(suggested[0]).toBe(PAID_PLAN_NAMES[Math.floor(PAID_PLAN_NAMES.length / 2)]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pricing invariants
+// ---------------------------------------------------------------------------
+describe('pricing', () => {
+  it('prices every paid tier annually at exactly 12x the monthly price', () => {
+    // There is deliberately NO yearly discount — yearly is steered by being the
+    // default cadence and by the card-fee framing, not by charging less. A drift
+    // here would make the page's "same gift, fewer fees" copy a lie.
+    for (const name of PAID_PLAN_NAMES) {
+      expect(PLANS[name].annualPrice).toBe(PLANS[name].price * 12);
+    }
+  });
+
+  it('gives the free tier no price of either cadence', () => {
+    expect(PLANS.free.price).toBe(0);
+    expect(PLANS.free.annualPrice).toBeUndefined();
   });
 });
 
@@ -32,6 +65,13 @@ describe('backend config sync', () => {
       expect(PLANS[name].label).toBe(backendPlans.PLANS[name].label);
     }
   });
+
+  it('has the same annual price and suggested flag as the backend config', () => {
+    for (const name of PLAN_NAMES) {
+      expect(PLANS[name].annualPrice).toBe(backendPlans.PLANS[name].annualPrice);
+      expect(!!PLANS[name].suggested).toBe(!!backendPlans.PLANS[name].suggested);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -47,13 +87,22 @@ describe('getPlanConfig', () => {
   it('returns correct config for supporter tier', () => {
     const config = getPlanConfig('supporter');
     expect(config.label).toBe('Supporter');
-    expect(config.price).toBe(1.5);
+    expect(config.price).toBe(2);
+    expect(config.annualPrice).toBe(24);
   });
 
   it('returns correct config for patron tier', () => {
     const config = getPlanConfig('patron');
     expect(config.label).toBe('Patron');
-    expect(config.price).toBe(5.5);
+    expect(config.price).toBe(5);
+    expect(config.annualPrice).toBe(60);
+  });
+
+  it('returns correct config for benefactor tier', () => {
+    const config = getPlanConfig('benefactor');
+    expect(config.label).toBe('Benefactor');
+    expect(config.price).toBe(10);
+    expect(config.annualPrice).toBe(120);
   });
 
   it('falls back to free for unknown plan', () => {

--- a/frontend/src/config/plans.test.js
+++ b/frontend/src/config/plans.test.js
@@ -22,10 +22,11 @@ describe('PLAN_NAMES', () => {
     expect(prices).toEqual([...prices].sort((a, b) => a - b));
   });
 
-  it('marks exactly one paid tier as suggested, and it is the middle one', () => {
-    const suggested = PAID_PLAN_NAMES.filter((p) => PLANS[p].suggested);
-    expect(suggested).toHaveLength(1);
-    expect(suggested[0]).toBe(PAID_PLAN_NAMES[Math.floor(PAID_PLAN_NAMES.length / 2)]);
+  it('marks no tier as recommended', () => {
+    // Deliberate: a "Suggested" badge reads as an expectation to pay, and
+    // supporting is entirely voluntary. Ordering alone puts the middle amount
+    // in the middle.
+    expect(PAID_PLAN_NAMES.filter((p) => PLANS[p].suggested)).toEqual([]);
   });
 });
 
@@ -66,10 +67,9 @@ describe('backend config sync', () => {
     }
   });
 
-  it('has the same annual price and suggested flag as the backend config', () => {
+  it('has the same annual price for every plan as the backend config', () => {
     for (const name of PLAN_NAMES) {
       expect(PLANS[name].annualPrice).toBe(backendPlans.PLANS[name].annualPrice);
-      expect(!!PLANS[name].suggested).toBe(!!backendPlans.PLANS[name].suggested);
     }
   });
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -109,6 +109,11 @@
   --badge-plan-basic-text: #A67C4A;
   --badge-plan-premium-bg: rgba(122, 30, 45, 0.1);
   --badge-plan-premium-text: var(--color-primary);
+  /* Top supporter tier — solid rather than tinted, so it stays distinct from
+     the tinted premium badge in dark mode, where primary and accent collapse
+     to the same gold. */
+  --badge-plan-elite-bg: rgba(122, 30, 45, 0.92);
+  --badge-plan-elite-text: #FDF9F6;
 
   /* Drink status */
   --drink-overdue-bg: #FDF0F0;
@@ -209,6 +214,8 @@
   --badge-plan-basic-text: #B89263;
   --badge-plan-premium-bg: rgba(184, 146, 99, 0.15);
   --badge-plan-premium-text: #B89263;
+  --badge-plan-elite-bg: rgba(184, 146, 99, 0.92);
+  --badge-plan-elite-text: #17150F;
 
   --drink-overdue-bg: #2d1414;
   --drink-overdue-text: #E07060;

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -613,10 +613,6 @@
     "whereDev": "Entwicklung",
     "whereDevDesc": "Fehlerbehebungen & was als Nächstes kommt",
     "whereCaption": "Ehrliche, qualitative Kategorien – keine Stufe kauft etwas anderes.",
-    "donateLead": "Möchtest du helfen, die Rechnung zu teilen?",
-    "donateBody": "Dieselbe App, dieselben Funktionen in jedem Fall – einfach unser aufrichtiger Dank.",
-    "supporterCta": "Unterstützen · {{amount}}/Monat",
-    "patronCta": "Werde ein Patron · {{amount}}/Monat",
     "reassure": "Jederzeit kündbar · dieselbe App in jedem Fall 💛",
     "alreadySupporting": "💛 Du unterstützt Cellarion – danke! Du kannst jederzeit ändern oder kündigen.",
     "donateNote": "Zahlungen werden sicher von Stripe abgewickelt. Cellarion bleibt kostenlos und open, ob du unterstützt oder nicht."

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -621,18 +621,29 @@
     "whereDev": "Development",
     "whereDevDesc": "Bug fixes & what's next",
     "whereCaption": "Honest, qualitative buckets — no tier buys anything different.",
-    "donateLead": "Want to help split the tab?",
-    "donateBody": "Same app, same features either way — just our genuine thanks.",
-    "supporterCta": "Support · {{amount}}/mo",
-    "patronCta": "Become a Patron · {{amount}}/mo",
-    "supporterCtaYear": "Support · {{amount}}/yr",
-    "patronCtaYear": "Become a Patron · {{amount}}/yr",
+    "pickerHeading": "Choose what feels right",
+    "yearlyNote": "One card fee a year instead of twelve, so a little more of the same gift actually reaches the server. Cancel anytime.",
+    "monthlyNote": "Smaller, and easy to stop whenever you like. Yearly sends slightly more of the same gift to the server.",
+    "perYear": "/year",
+    "perMonth": "/month",
+    "equivPerMonth": "That's {{amount}} a month",
+    "equivPerYear": "{{amount}} a year, all told",
+    "suggestedFlag": "Suggested",
+    "chooseCta": "Support",
+    "tierUnavailable": "Not available right now",
+    "analogy": {
+      "supporter": "About two glasses of wine. A year.",
+      "patron": "A good bottle, once a year.",
+      "benefactor": "A good bottle twice a year — and a real dent in the monthly bills."
+    },
+    "sameAppNote": "All three unlock exactly the same Cellarion: everything. You're not buying features — there are none to buy. You're keeping the lights on, and you get our genuine thanks and nothing else.",
+    "customTitle": "Any amount you like",
+    "customDesc": "One-off or your own recurring amount, through GitHub Sponsors.",
     "reassure": "Cancel anytime · same app either way 💛",
-    "reassureYear": "Billed once a year · fewer card fees, so more of it reaches Cellarion · cancel anytime 💛",
     "alreadySupporting": "💛 You're supporting Cellarion — thank you! You can change or cancel anytime.",
     "donateNote": "Payments are handled securely by Stripe. Cellarion stays free and open whether you support or not.",
-    "oneTimeLead": "Prefer a one-time gift, any amount you like?",
-    "oneTimeCta": "Sponsor once on GitHub"
+    "closingLead": "Just here for the wine? That's genuinely fine.",
+    "closingBody": "Nothing changes if you never give a penny — no nags, no locked buttons, no countdown in the corner. Cellarion is yours either way. If it ever earns a place in your cellar, the levels are one screen up."
   },
   "cellars": {
     "title": "My Cellars",
@@ -2949,7 +2960,7 @@
         "title": "Other Features",
         "summary": "Blog, plans, support, and NFC tags.",
         "d1": "Blog (/blog): wine articles and guides.",
-        "d2": "Support Us (/supporter): supporter tiers — Enthusiast (free), Supporter ($1.50/mo), Patron ($5.50/mo).",
+        "d2": "Support Us (/supporter): supporter tiers — Enthusiast (free), Supporter ($2/mo), Patron ($5/mo), Benefactor ($10/mo), each also available yearly. A custom or one-time amount can be given through GitHub Sponsors.",
         "d3": "Support (/support): submit support tickets for help.",
         "d4": "NFC tags: attach NFC tags to racks — scan with your phone to open the rack directly."
       }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -628,7 +628,6 @@
     "perMonth": "/month",
     "equivPerMonth": "That's {{amount}} a month",
     "equivPerYear": "{{amount}} a year, all told",
-    "suggestedFlag": "Suggested",
     "chooseCta": "Support",
     "tierUnavailable": "Not available right now",
     "analogy": {

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -616,10 +616,6 @@
     "whereDev": "Développement",
     "whereDevDesc": "Corrections de bugs et suite du programme",
     "whereCaption": "Des catégories honnêtes et qualitatives — aucun niveau n'achète quoi que ce soit de différent.",
-    "donateLead": "Envie de participer à l'addition ?",
-    "donateBody": "Même application, mêmes fonctionnalités dans tous les cas — juste nos remerciements sincères.",
-    "supporterCta": "Soutenir · {{amount}}/mois",
-    "patronCta": "Devenir mécène · {{amount}}/mois",
     "reassure": "Annulable à tout moment · la même application dans tous les cas 💛",
     "alreadySupporting": "💛 Tu soutiens Cellarion — merci ! Tu peux changer ou annuler à tout moment.",
     "donateNote": "Les paiements sont traités en toute sécurité par Stripe. Cellarion reste gratuit et ouvert, que tu soutiennes ou non."

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -604,10 +604,6 @@
     "whereDev": "Utveckling",
     "whereDevDesc": "Buggfixar & nästa steg",
     "whereCaption": "Ärliga, ungefärliga kategorier — ingen nivå ger något annat.",
-    "donateLead": "Vill du hjälpa till att dela på notan?",
-    "donateBody": "Samma app, samma funktioner oavsett — bara vårt uppriktiga tack.",
-    "supporterCta": "Stöd · {{amount}}/mån",
-    "patronCta": "Bli Patron · {{amount}}/mån",
     "reassure": "Avsluta när som helst · samma app oavsett 💛",
     "alreadySupporting": "💛 Du stödjer Cellarion — tack! Du kan ändra eller avsluta när som helst.",
     "donateNote": "Betalningar hanteras säkert av Stripe. Cellarion förblir gratis och öppet oavsett om du stödjer eller inte."

--- a/frontend/src/pages/Plans.css
+++ b/frontend/src/pages/Plans.css
@@ -20,241 +20,39 @@
   font-size: 0.95rem;
 }
 
-/* ── Current plan banner ── */
-.plans-current-banner {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
-  margin-bottom: 2rem;
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  flex-wrap: wrap;
-}
-
-.plans-current-label {
-  font-size: 0.82rem;
-  color: var(--color-text-muted);
-  font-weight: 500;
-}
-
-.plans-current-expiry {
-  font-size: 0.82rem;
-  color: var(--color-text-muted);
-  margin-left: auto;
-}
-
-.plans-expiry--expired {
-  color: var(--color-danger);
-  font-weight: 600;
-}
-
-/* ── Plan badge (current banner) ── */
-.plans-badge {
-  display: inline-block;
-  font-size: 0.72rem;
-  font-weight: 700;
-  padding: 0.2rem 0.6rem;
-  border-radius: 4px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.plans-badge--free      { background: rgba(154,148,132,0.15); color: var(--color-text-muted); }
-.plans-badge--supporter { background: rgba(200,168,126,0.15); color: var(--color-accent); }
-.plans-badge--patron    { background: rgba(var(--color-primary-rgb),0.18); color: var(--color-primary); }
-
-/* ── Comparison grid ── */
-.plans-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-@media (max-width: 640px) {
-  .plans-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* ── Plan card ── */
-.plans-card {
-  position: relative;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 1.25rem;
-  background: var(--color-bg);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  transition: border-color 0.15s;
-}
-
-.plans-card--current {
-  border-color: var(--color-primary);
-  background: rgba(var(--color-primary-rgb), 0.06);
-}
-
-.plans-card-current-tag {
-  position: absolute;
-  top: -0.6rem;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-primary);
-  color: var(--color-bg);
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  padding: 0.15rem 0.6rem;
-  border-radius: 20px;
-  white-space: nowrap;
-}
-
-.plans-card-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-}
-
-.plans-card-name {
-  margin: 0;
-  font-size: 1.15rem;
-  font-weight: 700;
-}
-
-.plans-card-name--free      { color: var(--color-text-muted); }
-.plans-card-name--supporter { color: var(--color-accent); }
-.plans-card-name--patron    { color: var(--color-primary); }
-
-.plans-card-price {
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--color-text);
-}
-
-.plans-card-desc {
-  margin: 0;
-  font-size: 0.82rem;
-  color: var(--color-text-muted);
-  line-height: 1.4;
-}
-
-.plans-card-chat {
-  margin: 0;
-  font-size: 0.82rem;
-  color: var(--color-text-secondary);
-}
-
-/* ── Feature list ── */
-.plans-feature-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.plans-feature-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  font-size: 0.85rem;
-  color: var(--color-text-secondary);
-  line-height: 1.3;
-}
-
-.plans-feature-check {
-  color: var(--color-primary);
-  font-weight: 700;
-  flex-shrink: 0;
-  margin-top: 0.05rem;
-}
-
-/* ── Trial CTA ── */
-.plans-trial-wrap {
-  margin-top: 1.25rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.plans-trial-btn {
-  width: 100%;
-}
-
 .plans-trial-error {
   font-size: 0.8rem;
   color: var(--color-danger);
-  margin: 0;
+  margin: 0.75rem 0 0;
+  text-align: center;
 }
 
-/* ── Admin note ── */
 .plans-manage-wrap {
   text-align: center;
   margin: 1.5rem 0 0.5rem;
 }
 
-.plans-admin-note {
-  text-align: center;
-  font-size: 0.78rem;
-  color: var(--color-input-placeholder);
-  margin: 0;
-}
-
-/* ── Donation card ── */
-.donate-card {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 1.75rem;
-  background: var(--color-bg);
+/* ── Support picker (cadence toggle + tier cards + custom amount) ── */
+.support-picker {
+  margin: 0.5rem 0 2rem;
   text-align: center;
 }
 
-/* Warm accent rule on the focal CTA card */
-.donate-card--accent {
-  border-top: 3px solid var(--color-accent);
-}
-
-/* Top CTA — the support buttons shown directly under the header */
-.donate-top {
-  margin: 0.5rem 0 1.75rem;
-}
-
-.donate-lead {
+.support-picker-heading {
   margin: 0 0 0.9rem;
-  font-size: 1rem;
+  font-size: 1.05rem;
   font-weight: 600;
   color: var(--color-text);
-  line-height: 1.45;
 }
 
-.donate-body {
-  margin: 0 0 1.5rem;
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
-  line-height: 1.55;
-}
-
-/* Monthly / yearly segmented control, sat directly above the donate buttons */
+/* Monthly / yearly segmented control */
 .billing-toggle {
   display: inline-flex;
-  margin: 0 auto 0.9rem;
+  margin: 0 auto;
   padding: 0.2rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-bg);
-}
-
-.donate-top .billing-toggle,
-.donate-card .billing-toggle {
-  display: flex;
-  width: fit-content;
 }
 
 .billing-toggle-btn {
@@ -276,15 +74,234 @@
   box-shadow: 0 1px 3px rgb(0 0 0 / 12%);
 }
 
-.donate-buttons {
-  display: flex;
-  justify-content: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
+.billing-note {
+  margin: 0.6rem 0 1.25rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
 }
 
-.donate-btn {
-  min-width: 160px;
+/* ── Tier cards ── */
+/* auto-fit rather than a hardcoded 3, so adding a tier to the plan config does
+   not silently overflow the row. */
+.tier-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  gap: 0.85rem;
+  align-items: stretch;
+  text-align: left;
+}
+
+.tier-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1.35rem 1.15rem 1.15rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  transition: border-color 0.15s, transform 0.15s;
+}
+
+.tier-card:hover {
+  border-color: var(--color-primary);
+}
+
+/* The suggested tier sits slightly proud of its neighbours — the amount most
+   people are looking for permission to choose. */
+.tier-card--suggested {
+  border-color: var(--color-primary);
+  border-width: 2px;
+  background: rgba(var(--color-primary-rgb), 0.05);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 8%);
+}
+
+.tier-card-flag {
+  position: absolute;
+  top: -0.62rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-primary);
+  color: var(--color-bg);
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  padding: 0.2rem 0.65rem;
+  border-radius: 20px;
+  white-space: nowrap;
+}
+
+/* Deliberately NOT colour-coded per tier: in dark mode --color-primary and
+   --color-accent resolve to the same gold, so per-tier colours would collapse
+   into each other. The suggested card carries the only colour emphasis. */
+.tier-card-name {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+
+.tier-card--suggested .tier-card-name {
+  color: var(--color-primary);
+}
+
+.tier-card-price {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  margin: 0.15rem 0 0;
+}
+
+.tier-card-amount {
+  font-family: var(--font-heading);
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-text);
+  line-height: 1.1;
+}
+
+.tier-card-period {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.tier-card-equiv {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.tier-card-analogy {
+  margin: 0.6rem 0 1rem;
+  font-size: 0.83rem;
+  color: var(--color-text-secondary);
+  line-height: 1.45;
+  /* Push the button to the card foot so all three line up regardless of how
+     long the analogy wraps. */
+  flex-grow: 1;
+}
+
+.tier-card-btn {
+  width: 100%;
+}
+
+.tier-card-unavailable {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--color-input-placeholder);
+  text-align: center;
+  line-height: 1.4;
+}
+
+.tier-grid-note {
+  margin: 1rem 0 0;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+/* ── Custom / one-time amount (GitHub Sponsors) ── */
+.custom-amount {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  margin-top: 1.25rem;
+  padding: 0.9rem 1.1rem;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  text-align: left;
+  text-decoration: none;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.custom-amount:hover {
+  border-color: var(--color-primary);
+  background: rgba(var(--color-primary-rgb), 0.04);
+}
+
+.custom-amount-icon {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  background: rgba(var(--color-primary-rgb), 0.08);
+  color: var(--color-primary);
+  font-size: 0.95rem;
+}
+
+.custom-amount-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.custom-amount-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.custom-amount-desc {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  line-height: 1.45;
+}
+
+.custom-amount-arrow {
+  margin-left: auto;
+  flex-shrink: 0;
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .tier-grid {
+    grid-template-columns: 1fr;
+    gap: 1.1rem;
+  }
+
+  /* The lift reads as a mistake once the cards are stacked. */
+  .tier-card--suggested {
+    box-shadow: none;
+  }
+}
+
+/* ── Donation / closing card ── */
+.donate-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  background: var(--color-bg);
+  text-align: center;
+}
+
+/* Warm accent rule on the focal CTA card */
+.donate-card--accent {
+  border-top: 3px solid var(--color-accent);
+}
+
+.donate-lead {
+  margin: 0 0 0.9rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.45;
+}
+
+.donate-body {
+  margin: 0 0 1.5rem;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  line-height: 1.55;
 }
 
 .donate-thanks {
@@ -302,29 +319,10 @@
 }
 
 .donate-reassure {
-  margin: 0.75rem 0 0;
+  margin: 1.25rem 0 0;
   text-align: center;
   font-size: 0.78rem;
   color: var(--color-text-muted);
-}
-
-/* One-time GitHub Sponsors alternative under the subscription buttons */
-.donate-onetime {
-  margin: 0.9rem 0 0;
-  text-align: center;
-  font-size: 0.82rem;
-  color: var(--color-text-muted);
-}
-
-.donate-onetime-link {
-  color: var(--color-primary);
-  font-weight: 600;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.donate-onetime-link:hover {
-  text-decoration: underline;
 }
 
 /* ── Support page: header open-source chips ── */

--- a/frontend/src/pages/Plans.css
+++ b/frontend/src/pages/Plans.css
@@ -93,7 +93,6 @@
 }
 
 .tier-card {
-  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
@@ -101,41 +100,17 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-bg);
-  transition: border-color 0.15s, transform 0.15s;
+  transition: border-color 0.15s;
 }
 
 .tier-card:hover {
   border-color: var(--color-primary);
 }
 
-/* The suggested tier sits slightly proud of its neighbours — the amount most
-   people are looking for permission to choose. */
-.tier-card--suggested {
-  border-color: var(--color-primary);
-  border-width: 2px;
-  background: rgba(var(--color-primary-rgb), 0.05);
-  box-shadow: 0 4px 16px rgb(0 0 0 / 8%);
-}
-
-.tier-card-flag {
-  position: absolute;
-  top: -0.62rem;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-primary);
-  color: var(--color-bg);
-  font-size: 0.62rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  padding: 0.2rem 0.65rem;
-  border-radius: 20px;
-  white-space: nowrap;
-}
-
-/* Deliberately NOT colour-coded per tier: in dark mode --color-primary and
-   --color-accent resolve to the same gold, so per-tier colours would collapse
-   into each other. The suggested card carries the only colour emphasis. */
+/* Deliberately NOT colour-coded or ranked per tier. Two reasons: in dark mode
+   --color-primary and --color-accent resolve to the same gold, so per-tier
+   colours would collapse into each other; and singling one tier out reads as an
+   expectation to pay, which this page must never imply. */
 .tier-card-name {
   margin: 0;
   font-size: 0.82rem;
@@ -143,10 +118,6 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--color-text-muted);
-}
-
-.tier-card--suggested .tier-card-name {
-  color: var(--color-primary);
 }
 
 .tier-card-price {
@@ -267,11 +238,6 @@
   .tier-grid {
     grid-template-columns: 1fr;
     gap: 1.1rem;
-  }
-
-  /* The lift reads as a mistake once the cards are stacked. */
-  .tier-card--suggested {
-    box-shadow: none;
   }
 }
 

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -101,6 +101,7 @@
 .settings-plan-badge--free      { background: rgba(154,148,132,0.15); color: var(--color-text-muted); }
 .settings-plan-badge--supporter { background: rgba(200,168,126,0.15); color: var(--color-accent); }
 .settings-plan-badge--patron    { background: rgba(var(--color-primary-rgb),0.18); color: var(--color-primary); }
+.settings-plan-badge--benefactor { background: var(--badge-plan-elite-bg); color: var(--badge-plan-elite-text); }
 
 .settings-plan-desc {
   font-size: 0.85rem;

--- a/frontend/src/pages/SuperAdmin.css
+++ b/frontend/src/pages/SuperAdmin.css
@@ -332,6 +332,11 @@
 .sa-badge.premium { background: #2b2410; color: var(--sa-warn); }
 .sa-badge.basic   { background: #1a241a; color: #86efac; }
 .sa-badge.free    { background: var(--color-border-light); color: var(--sa-text-dim); }
+/* Plan badges render the plan name verbatim as a class, so each supporter tier
+   needs its own rule or it falls through to the unstyled base badge. */
+.sa-badge.supporter  { background: #241a10; color: var(--sa-warn); }
+.sa-badge.patron     { background: #2b2410; color: var(--sa-warn); }
+.sa-badge.benefactor { background: #3b2f14; color: #f5d68a; }
 .sa-badge.ok      { background: #0d2b16; color: var(--sa-accent); }
 .sa-badge.error   { background: #2b0d0d; color: var(--sa-danger); }
 

--- a/frontend/src/pages/SuperAdmin/TabOverview.js
+++ b/frontend/src/pages/SuperAdmin/TabOverview.js
@@ -1,4 +1,5 @@
 import { num, ago, PlanBadge, RoleBadge, Sparkline, useApi } from './helpers';
+import { PLAN_NAMES } from '../../config/plans';
 
 export default function TabOverview() {
   const { data, loading, error, reload } = useApi('/api/superadmin/overview');
@@ -37,7 +38,7 @@ export default function TabOverview() {
           <div className="sa-panel-header"><span className="sa-panel-title">Users by Tier</span></div>
           <div className="sa-panel-body">
             <div className="sa-kv">
-              {['free', 'supporter', 'patron'].map(p => (
+              {PLAN_NAMES.map(p => (
                 <div key={p} className="sa-kv-row">
                   <span className="sa-kv-key"><PlanBadge plan={p} /></span>
                   <span className="sa-kv-val">{num(byPlan[p] || 0)}</span>

--- a/frontend/src/pages/Supporter.js
+++ b/frontend/src/pages/Supporter.js
@@ -1,25 +1,106 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
-import { PLANS } from '../config/plans';
-import { createCheckout, createPortal } from '../api/stripe';
+import { PLANS, PAID_PLAN_NAMES } from '../config/plans';
+import { createCheckout, createPortal, getAvailability } from '../api/stripe';
 import './Plans.css';
 
 const GITHUB_URL = 'https://github.com/jagduvi1/Cellarion';
 const SPONSORS_URL = 'https://github.com/sponsors/jagduvi1';
 
+/** Yearly first: the cadence we want chosen is the one read first and preselected. */
+const INTERVALS = ['year', 'month'];
+
+/** `$24` / `$5` — trailing `.00` is noise on prices that are whole dollars. */
+function formatAmount(value) {
+  return `$${Number.isInteger(value) ? value : value.toFixed(2)}`;
+}
+
 /**
- * Shared support call-to-action — rendered both at the top (compact, the first
- * thing you see) and inside the bottom donate card (the last thing you see).
- * `compact` drops the reassurance line so the top instance stays punchy.
+ * Billing-cadence segmented control. Yearly carries a plain-language note
+ * rather than a discount badge — there is no discount to advertise, only the
+ * card-fee saving, and overstating it would undercut the page's whole tone.
  */
-function DonateActions({
-  compact, hasStripeSubscription, checkoutLoading, onCheckout, onManage,
-  actionError, billingInterval, onIntervalChange, t,
+function BillingToggle({ billingInterval, onIntervalChange, t }) {
+  return (
+    <div className="billing-toggle" role="group" aria-label={t('supporter.billingIntervalLabel')}>
+      {INTERVALS.map((iv) => (
+        <button
+          key={iv}
+          type="button"
+          className={`billing-toggle-btn${billingInterval === iv ? ' is-active' : ''}`}
+          aria-pressed={billingInterval === iv}
+          onClick={() => onIntervalChange(iv)}
+        >
+          {t(iv === 'month' ? 'supporter.billingMonthly' : 'supporter.billingYearly')}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One tier card. Every tier grants the identical app, so the card sells the
+ * SIZE of the gift, not a feature set: an amount, what that amount is worth in
+ * wine, and what it covers. The middle tier is marked `suggested` in the plan
+ * config and lifted here — with three amounts the extremes frame the middle,
+ * which is the one most people actually want permission to choose.
+ */
+function TierCard({ tier, yearly, available, loading, onCheckout, t }) {
+  const plan = PLANS[tier];
+  const amount = formatAmount(yearly ? plan.annualPrice : plan.price);
+  const perMonth = formatAmount(plan.price);
+
+  return (
+    <div className={`tier-card${plan.suggested ? ' tier-card--suggested' : ''}`}>
+      {plan.suggested && (
+        <span className="tier-card-flag">{t('supporter.suggestedFlag')}</span>
+      )}
+      <h3 className="tier-card-name">{plan.label}</h3>
+
+      <p className="tier-card-price">
+        <span className="tier-card-amount">{amount}</span>
+        <span className="tier-card-period">
+          {t(yearly ? 'supporter.perYear' : 'supporter.perMonth')}
+        </span>
+      </p>
+      {/* Monthly equivalent keeps the yearly figure from reading as a big ask. */}
+      <p className="tier-card-equiv">
+        {yearly
+          ? t('supporter.equivPerMonth', { amount: perMonth })
+          : t('supporter.equivPerYear', { amount: formatAmount(plan.annualPrice) })}
+      </p>
+
+      <p className="tier-card-analogy">{t(`supporter.analogy.${tier}`)}</p>
+
+      {available ? (
+        <button
+          className={`btn ${plan.suggested ? 'btn-primary' : 'btn-secondary'} tier-card-btn`}
+          onClick={() => onCheckout(tier)}
+          disabled={loading === tier}
+        >
+          {loading === tier ? t('common.saving') : t('supporter.chooseCta')}
+        </button>
+      ) : (
+        <p className="tier-card-unavailable">{t('supporter.tierUnavailable')}</p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The support call-to-action: cadence toggle, the three tier cards, and the
+ * custom-amount escape hatch. Rendered once — a second full copy lower down
+ * read as pressure rather than as a reminder, so the bottom of the page closes
+ * with prose and a link back up instead.
+ */
+function SupportPicker({
+  hasStripeSubscription, checkoutLoading, onCheckout, onManage,
+  actionError, billingInterval, onIntervalChange, availability, t,
 }) {
   if (hasStripeSubscription) {
     return (
-      <>
+      <div className="donate-card donate-card--accent">
         <p className="donate-thanks">{t('supporter.alreadySupporting')}</p>
         <div className="plans-manage-wrap">
           <button className="btn btn-secondary" onClick={onManage}>
@@ -27,69 +108,68 @@ function DonateActions({
           </button>
         </div>
         {actionError && <p className="plans-trial-error">{actionError}</p>}
-      </>
+      </div>
     );
   }
 
   const yearly = billingInterval === 'year';
-  // Yearly figures come from PLANS.annualPrice rather than price × 12 so the
-  // label can never drift from the Stripe Price if one is ever discounted.
-  const amount = (tier) =>
-    `$${(yearly ? PLANS[tier].annualPrice : PLANS[tier].price).toFixed(2)}`;
+  // Optimism applies only BEFORE availability loads — flashing "unavailable" on
+  // a healthy install is worse than a rare late correction. Once it has loaded
+  // the answer is authoritative, including for a tier the backend prices at all:
+  // a tier in this config but absent from the backend's PRICE_ENV would
+  // otherwise render a live button that 400s with "Invalid plan".
+  const isAvailable = (tier) =>
+    availability === null ? true : !!availability.tiers?.[tier]?.[billingInterval];
 
   return (
-    <>
-      <div className="billing-toggle" role="group" aria-label={t('supporter.billingIntervalLabel')}>
-        {['month', 'year'].map((iv) => (
-          <button
-            key={iv}
-            type="button"
-            className={`billing-toggle-btn${billingInterval === iv ? ' is-active' : ''}`}
-            aria-pressed={billingInterval === iv}
-            onClick={() => onIntervalChange(iv)}
-          >
-            {t(iv === 'month' ? 'supporter.billingMonthly' : 'supporter.billingYearly')}
-          </button>
+    <section className="support-picker" aria-labelledby="support-picker-heading">
+      <h2 id="support-picker-heading" className="support-picker-heading">
+        {t('supporter.pickerHeading')}
+      </h2>
+
+      <BillingToggle
+        billingInterval={billingInterval}
+        onIntervalChange={onIntervalChange}
+        t={t}
+      />
+      <p className="billing-note">
+        {t(yearly ? 'supporter.yearlyNote' : 'supporter.monthlyNote')}
+      </p>
+
+      <div className="tier-grid">
+        {PAID_PLAN_NAMES.map((tier) => (
+          <TierCard
+            key={tier}
+            tier={tier}
+            yearly={yearly}
+            available={isAvailable(tier)}
+            loading={checkoutLoading}
+            onCheckout={onCheckout}
+            t={t}
+          />
         ))}
       </div>
-      <div className="donate-buttons">
-        <button
-          className="btn btn-primary donate-btn"
-          onClick={() => onCheckout('supporter')}
-          disabled={checkoutLoading === 'supporter'}
-        >
-          {checkoutLoading === 'supporter'
-            ? t('common.saving')
-            : t(yearly ? 'supporter.supporterCtaYear' : 'supporter.supporterCta', { amount: amount('supporter') })}
-        </button>
-        <button
-          className="btn btn-secondary donate-btn"
-          onClick={() => onCheckout('patron')}
-          disabled={checkoutLoading === 'patron'}
-        >
-          {checkoutLoading === 'patron'
-            ? t('common.saving')
-            : t(yearly ? 'supporter.patronCtaYear' : 'supporter.patronCta', { amount: amount('patron') })}
-        </button>
-      </div>
-      {!compact && (
-        <p className="donate-reassure">
-          {t(yearly ? 'supporter.reassureYear' : 'supporter.reassure')}
-        </p>
-      )}
+
+      <p className="tier-grid-note">{t('supporter.sameAppNote')}</p>
       {actionError && <p className="plans-trial-error">{actionError}</p>}
-      <p className="donate-onetime">
-        {t('supporter.oneTimeLead')}{' '}
-        <a
-          className="donate-onetime-link"
-          href={SPONSORS_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span aria-hidden="true">♥</span> {t('supporter.oneTimeCta')} →
-        </a>
-      </p>
-    </>
+
+      {/* Custom / one-time amounts — a peer of the tiers, not a footnote. */}
+      <a
+        className="custom-amount"
+        href={SPONSORS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span className="custom-amount-icon" aria-hidden="true">♥</span>
+        <span className="custom-amount-text">
+          <span className="custom-amount-title">{t('supporter.customTitle')}</span>
+          <span className="custom-amount-desc">{t('supporter.customDesc')}</span>
+        </span>
+        <span className="custom-amount-arrow" aria-hidden="true">→</span>
+      </a>
+
+      <p className="donate-reassure">{t('supporter.reassure')}</p>
+    </section>
   );
 }
 
@@ -98,14 +178,44 @@ function Supporter() {
   const { user, apiFetch } = useAuth();
   const [actionError, setActionError] = useState(null);
   const [checkoutLoading, setCheckoutLoading] = useState(null);
+  const [availability, setAvailability] = useState(null);
   // Named billingInterval, not interval — `setInterval` would shadow the DOM global.
-  const [billingInterval, setBillingInterval] = useState('month');
+  // Defaults to 'year': one card fee a year instead of twelve means materially
+  // more of the same gift arrives, and the default is what most people accept.
+  const [billingInterval, setBillingInterval] = useState('year');
 
   // Derived boolean from User.toJSON — the raw stripeSubscriptionId is no
   // longer serialised to the client (data minimisation).
   const hasStripeSubscription = !!user?.hasStripeSubscription;
 
+  useEffect(() => {
+    let cancelled = false;
+    if (hasStripeSubscription) return undefined;
+    (async () => {
+      try {
+        const res = await getAvailability(apiFetch);
+        const data = await res.json();
+        if (!cancelled) setAvailability(data);
+      } catch {
+        // Non-fatal: every tier stays optimistically enabled and a genuinely
+        // unconfigured price still fails loudly at checkout.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [apiFetch, hasStripeSubscription]);
+
+  const handleManageSubscription = useCallback(async () => {
+    try {
+      const res = await createPortal(apiFetch);
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } catch {
+      setActionError(t('supporter.portalError'));
+    }
+  }, [apiFetch, t]);
+
   async function handleCheckout(plan) {
+    setActionError(null);
     setCheckoutLoading(plan);
     try {
       const res = await createCheckout(apiFetch, plan, billingInterval);
@@ -127,33 +237,12 @@ function Supporter() {
     }
   }
 
-  async function handleManageSubscription() {
-    try {
-      const res = await createPortal(apiFetch);
-      const data = await res.json();
-      if (data.url) window.location.href = data.url;
-    } catch {
-      setActionError(t('supporter.portalError'));
-    }
-  }
-
   // Qualitative "where your support goes" buckets — no tier buys anything different.
   const buckets = [
     { icon: '🖥️', label: t('supporter.whereHosting'), desc: t('supporter.whereHostingDesc') },
     { icon: '✨', label: t('supporter.whereAI'), desc: t('supporter.whereAIDesc') },
     { icon: '🛠️', label: t('supporter.whereDev'), desc: t('supporter.whereDevDesc') },
   ];
-
-  const actionProps = {
-    hasStripeSubscription,
-    checkoutLoading,
-    onCheckout: handleCheckout,
-    onManage: handleManageSubscription,
-    actionError,
-    billingInterval,
-    onIntervalChange: setBillingInterval,
-    t,
-  };
 
   return (
     <div className="plans-page">
@@ -177,10 +266,17 @@ function Supporter() {
         </div>
       </div>
 
-      {/* Top CTA — the first thing you see */}
-      <div className="donate-top">
-        <DonateActions compact {...actionProps} />
-      </div>
+      <SupportPicker
+        hasStripeSubscription={hasStripeSubscription}
+        checkoutLoading={checkoutLoading}
+        onCheckout={handleCheckout}
+        onManage={handleManageSubscription}
+        actionError={actionError}
+        billingInterval={billingInterval}
+        onIntervalChange={setBillingInterval}
+        availability={availability}
+        t={t}
+      />
 
       {/* Prose: free + costs */}
       <div className="support-card">
@@ -210,11 +306,10 @@ function Supporter() {
       </div>
       <p className="support-goes-caption">{t('supporter.whereCaption')}</p>
 
-      {/* Bottom donate card — the last thing you see */}
+      {/* Closing note — no second button wall; the picker is one screen up. */}
       <div className="donate-card donate-card--accent">
-        <p className="donate-lead">{t('supporter.donateLead')}</p>
-        <p className="donate-body">{t('supporter.donateBody')}</p>
-        <DonateActions {...actionProps} />
+        <p className="donate-lead">{t('supporter.closingLead')}</p>
+        <p className="donate-body">{t('supporter.closingBody')}</p>
         <p className="donate-note">{t('supporter.donateNote')}</p>
       </div>
     </div>

--- a/frontend/src/pages/Supporter.js
+++ b/frontend/src/pages/Supporter.js
@@ -42,9 +42,11 @@ function BillingToggle({ billingInterval, onIntervalChange, t }) {
 /**
  * One tier card. Every tier grants the identical app, so the card sells the
  * SIZE of the gift, not a feature set: an amount, what that amount is worth in
- * wine, and what it covers. The middle tier is marked `suggested` in the plan
- * config and lifted here — with three amounts the extremes frame the middle,
- * which is the one most people actually want permission to choose.
+ * wine, and what it covers.
+ *
+ * All three cards are presented as equals — no badge, no lift, no highlighted
+ * button. Marking one as suggested reads as an expectation to pay, and there is
+ * none; the middle amount simply sits in the middle.
  */
 function TierCard({ tier, yearly, available, loading, onCheckout, t }) {
   const plan = PLANS[tier];
@@ -52,10 +54,7 @@ function TierCard({ tier, yearly, available, loading, onCheckout, t }) {
   const perMonth = formatAmount(plan.price);
 
   return (
-    <div className={`tier-card${plan.suggested ? ' tier-card--suggested' : ''}`}>
-      {plan.suggested && (
-        <span className="tier-card-flag">{t('supporter.suggestedFlag')}</span>
-      )}
+    <div className="tier-card">
       <h3 className="tier-card-name">{plan.label}</h3>
 
       <p className="tier-card-price">
@@ -75,7 +74,7 @@ function TierCard({ tier, yearly, available, loading, onCheckout, t }) {
 
       {available ? (
         <button
-          className={`btn ${plan.suggested ? 'btn-primary' : 'btn-secondary'} tier-card-btn`}
+          className="btn btn-secondary tier-card-btn"
           onClick={() => onCheckout(tier)}
           disabled={loading === tier}
         >

--- a/frontend/src/pages/Supporter.test.js
+++ b/frontend/src/pages/Supporter.test.js
@@ -62,14 +62,28 @@ describe('Supporter page — tiers', () => {
     }
   });
 
-  test('flags exactly one tier as suggested, and it is the middle one', async () => {
+  test('singles out no tier as recommended', async () => {
+    // Supporting is voluntary, so the page must not imply a right answer: no
+    // badge, and no card styled differently from its neighbours.
     const { container } = render(<Supporter />);
-    const flagged = container.querySelectorAll('.tier-card--suggested');
-    expect(flagged).toHaveLength(1);
-    // The middle card must be the flagged one — that positioning is the whole
-    // point of a three-tier ladder, so a config reorder should fail here.
-    const cards = [...container.querySelectorAll('.tier-card')];
-    expect(cards.indexOf(flagged[0])).toBe(Math.floor(cards.length / 2));
+    expect(container.querySelector('.tier-card--suggested')).toBeNull();
+    expect(screen.queryByText(/suggested/i)).not.toBeInTheDocument();
+
+    const classes = [...container.querySelectorAll('.tier-card')].map((c) => c.className);
+    expect(new Set(classes).size).toBe(1);
+  });
+
+  test('gives every tier the same button treatment', async () => {
+    render(<Supporter />);
+    await waitFor(() => expect(getAvailability).toHaveBeenCalled());
+    const classes = tierButtons().map((b) => b.className);
+    expect(new Set(classes).size).toBe(1);
+  });
+
+  test('renders the tiers cheapest-first, so the middle amount is in the middle', async () => {
+    const { container } = render(<Supporter />);
+    const names = [...container.querySelectorAll('.tier-card-name')].map((n) => n.textContent);
+    expect(names).toEqual(PAID_PLAN_NAMES.map((p) => PLANS[p].label));
   });
 });
 
@@ -103,7 +117,7 @@ describe('Supporter page — billing cadence', () => {
     render(<Supporter />);
     await waitFor(() => expect(getAvailability).toHaveBeenCalled());
 
-    fireEvent.click(tierButtons()[1]); // the suggested tier
+    fireEvent.click(tierButtons()[1]); // the middle tier
     await waitFor(() => expect(createCheckout).toHaveBeenCalled());
     expect(createCheckout).toHaveBeenCalledWith(apiFetch, PAID_PLAN_NAMES[1], 'year');
   });

--- a/frontend/src/pages/Supporter.test.js
+++ b/frontend/src/pages/Supporter.test.js
@@ -1,0 +1,210 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import Supporter from './Supporter';
+import { PLANS, PAID_PLAN_NAMES } from '../config/plans';
+
+// i18n: identity stub, so assertions read against KEYS rather than prose that
+// is expected to be reworded. The exception is interpolation, which the stub
+// resolves so the amount-bearing strings can still be checked.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k, opts) => (opts?.amount ? `${k}:${opts.amount}` : k),
+    i18n: { language: 'en' },
+  }),
+}));
+
+let mockUser;
+const apiFetch = vi.fn();
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser, apiFetch }),
+}));
+
+const createCheckout = vi.fn();
+const createPortal = vi.fn();
+const getAvailability = vi.fn();
+vi.mock('../api/stripe', () => ({
+  createCheckout: (...a) => createCheckout(...a),
+  createPortal: (...a) => createPortal(...a),
+  getAvailability: (...a) => getAvailability(...a),
+}));
+
+const allAvailable = () => ({
+  json: async () => ({
+    configured: true,
+    tiers: Object.fromEntries(
+      PAID_PLAN_NAMES.map((p) => [p, { month: true, year: true }])
+    ),
+  }),
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUser = { plan: 'free', hasStripeSubscription: false };
+  getAvailability.mockResolvedValue(allAvailable());
+  createCheckout.mockResolvedValue({ json: async () => ({ url: 'https://checkout.test/x' }) });
+  delete window.location;
+  window.location = { href: '' };
+});
+
+/** The three tier CTAs, in the order the page renders them. */
+const tierButtons = () => screen.getAllByRole('button', { name: 'supporter.chooseCta' });
+
+describe('Supporter page — tiers', () => {
+  test('renders one CTA per paid tier', async () => {
+    render(<Supporter />);
+    await waitFor(() => expect(getAvailability).toHaveBeenCalled());
+    expect(tierButtons()).toHaveLength(PAID_PLAN_NAMES.length);
+  });
+
+  test('shows each tier label', async () => {
+    render(<Supporter />);
+    for (const tier of PAID_PLAN_NAMES) {
+      expect(screen.getByText(PLANS[tier].label)).toBeInTheDocument();
+    }
+  });
+
+  test('flags exactly one tier as suggested, and it is the middle one', async () => {
+    const { container } = render(<Supporter />);
+    const flagged = container.querySelectorAll('.tier-card--suggested');
+    expect(flagged).toHaveLength(1);
+    // The middle card must be the flagged one — that positioning is the whole
+    // point of a three-tier ladder, so a config reorder should fail here.
+    const cards = [...container.querySelectorAll('.tier-card')];
+    expect(cards.indexOf(flagged[0])).toBe(Math.floor(cards.length / 2));
+  });
+});
+
+describe('Supporter page — billing cadence', () => {
+  test('defaults to YEARLY', async () => {
+    // The default is the steer. If this flips to monthly, the page quietly
+    // costs ~$2/subscriber/year in extra card fees and loses the retention.
+    render(<Supporter />);
+    const yearly = screen.getByRole('button', { name: 'supporter.billingYearly' });
+    expect(yearly).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'supporter.billingMonthly' }))
+      .toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('shows annual amounts while yearly is selected', async () => {
+    render(<Supporter />);
+    for (const tier of PAID_PLAN_NAMES) {
+      expect(screen.getByText(`$${PLANS[tier].annualPrice}`)).toBeInTheDocument();
+    }
+  });
+
+  test('switches to monthly amounts when monthly is chosen', async () => {
+    render(<Supporter />);
+    fireEvent.click(screen.getByRole('button', { name: 'supporter.billingMonthly' }));
+    for (const tier of PAID_PLAN_NAMES) {
+      expect(screen.getByText(`$${PLANS[tier].price}`)).toBeInTheDocument();
+    }
+  });
+
+  test('checks out with the selected interval', async () => {
+    render(<Supporter />);
+    await waitFor(() => expect(getAvailability).toHaveBeenCalled());
+
+    fireEvent.click(tierButtons()[1]); // the suggested tier
+    await waitFor(() => expect(createCheckout).toHaveBeenCalled());
+    expect(createCheckout).toHaveBeenCalledWith(apiFetch, PAID_PLAN_NAMES[1], 'year');
+  });
+
+  test('checks out monthly after switching cadence', async () => {
+    render(<Supporter />);
+    await waitFor(() => expect(getAvailability).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'supporter.billingMonthly' }));
+    fireEvent.click(tierButtons()[0]);
+    await waitFor(() => expect(createCheckout).toHaveBeenCalled());
+    expect(createCheckout).toHaveBeenCalledWith(apiFetch, PAID_PLAN_NAMES[0], 'month');
+  });
+});
+
+describe('Supporter page — unconfigured prices', () => {
+  test('hides the CTA for a (tier, interval) with no Stripe price', async () => {
+    getAvailability.mockResolvedValue({
+      json: async () => ({
+        configured: true,
+        tiers: {
+          ...Object.fromEntries(PAID_PLAN_NAMES.map((p) => [p, { month: true, year: true }])),
+          [PAID_PLAN_NAMES[2]]: { month: true, year: false },
+        },
+      }),
+    });
+    render(<Supporter />);
+
+    // Yearly is the default, and the top tier has no yearly price — so it must
+    // offer no button rather than one that dies at checkout.
+    await waitFor(() => expect(tierButtons()).toHaveLength(2));
+    expect(screen.getByText('supporter.tierUnavailable')).toBeInTheDocument();
+  });
+
+  test('re-enables that tier once the cadence it does support is selected', async () => {
+    getAvailability.mockResolvedValue({
+      json: async () => ({
+        configured: true,
+        tiers: {
+          ...Object.fromEntries(PAID_PLAN_NAMES.map((p) => [p, { month: true, year: true }])),
+          [PAID_PLAN_NAMES[2]]: { month: true, year: false },
+        },
+      }),
+    });
+    render(<Supporter />);
+    await waitFor(() => expect(tierButtons()).toHaveLength(2));
+
+    fireEvent.click(screen.getByRole('button', { name: 'supporter.billingMonthly' }));
+    expect(tierButtons()).toHaveLength(3);
+  });
+
+  test('hides a tier the backend does not price at all', async () => {
+    // A tier present in the frontend plan config but missing from the backend's
+    // PRICE_ENV must not render a button — checkout would reject it as an
+    // "Invalid plan" only after the user committed to giving money.
+    getAvailability.mockResolvedValue({
+      json: async () => ({
+        configured: true,
+        tiers: Object.fromEntries(
+          PAID_PLAN_NAMES.slice(0, 2).map((p) => [p, { month: true, year: true }])
+        ),
+      }),
+    });
+    render(<Supporter />);
+    await waitFor(() => expect(tierButtons()).toHaveLength(2));
+  });
+
+  test('stays optimistic when the availability lookup fails', async () => {
+    getAvailability.mockRejectedValue(new Error('offline'));
+    render(<Supporter />);
+    // A failed probe must not disable giving on a perfectly healthy install.
+    await waitFor(() => expect(tierButtons()).toHaveLength(PAID_PLAN_NAMES.length));
+  });
+});
+
+describe('Supporter page — existing subscribers', () => {
+  test('offers the portal instead of the tier ladder', async () => {
+    mockUser = { plan: 'patron', hasStripeSubscription: true };
+    render(<Supporter />);
+
+    expect(screen.getByText('supporter.alreadySupporting')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'supporter.chooseCta' })).not.toBeInTheDocument();
+    expect(getAvailability).not.toHaveBeenCalled();
+  });
+
+  test('routes a duplicate checkout to the portal rather than double-billing', async () => {
+    createCheckout.mockResolvedValue({ json: async () => ({ code: 'subscription_exists' }) });
+    createPortal.mockResolvedValue({ json: async () => ({ url: 'https://portal.test/y' }) });
+    render(<Supporter />);
+    await waitFor(() => expect(getAvailability).toHaveBeenCalled());
+
+    fireEvent.click(tierButtons()[0]);
+    await waitFor(() => expect(createPortal).toHaveBeenCalled());
+  });
+});
+
+describe('Supporter page — custom amount', () => {
+  test('links to GitHub Sponsors safely', async () => {
+    render(<Supporter />);
+    const link = screen.getByRole('link', { name: /supporter.customTitle/ });
+    expect(link).toHaveAttribute('href', 'https://github.com/sponsors/jagduvi1');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+});


### PR DESCRIPTION
## What

Three supporter tiers instead of two, yearly billing as the default cadence, and a rebuilt `/supporter` page.

**Every tier still unlocks exactly the same app — everything. Nothing is gated, and nothing here gates anything.**

## Pricing

| Tier | Monthly | Yearly |
|---|---|---|
| Supporter | $2 | $24 |
| Patron | $5 | $60 |
| Benefactor *(new)* | $10 | $120 |

Annual is exactly 12x monthly — **no yearly discount**. The saving from yearly billing is the fixed part of Stripe's per-charge fee: roughly `11 x $0.20 = $2.20` per subscriber per year, whatever the tier. That is worth ~9% at Supporter and ~2% at Benefactor, so a percentage discount would cost far more at the top than it saves. Yearly is steered by being the default and by saying plainly what it saves, not by asking donors to give less.

Three tiers because the middle one draws a disproportionate share of choices when the extremes frame it. No tier is badged or highlighted as recommended — that reads as an expectation to pay. The middle amount is simply in the middle.

## Page

- Three tier cards, all presented as equals.
- Cards sell the *size of the gift*, not a feature set — there are no features to sell.
- Cadence toggle lists **yearly first and defaults to it**.
- GitHub Sponsors promoted from a one-line footnote to a peer of the tiers, for custom and one-time amounts.
- The duplicated bottom button wall is gone; the page closes with a low-pressure note.
- ~150 lines of dead CSS removed (leftovers from the deleted `/plans` page).

## Two bugs found along the way

**1. Yearly never worked for self-hosters.** `STRIPE_SUPPORTER_ANNUAL_PRICE_ID` / `STRIPE_PATRON_ANNUAL_PRICE_ID` existed in `.env.example` but were never forwarded to the backend container by the **repo** `docker-compose.yml`. The backend enumerates env explicitly, so the container never saw them and every yearly button returned "Stripe price not configured". (Scoped to self-hosters — cellarion.app runs a separate hand-maintained compose that did receive these vars in v1.96.0.)

**2. Repricing would silently strand existing subscribers.** Archiving a Price in Stripe does **not** move existing subscriptions off it — they renew at the old amount indefinitely, and every renewal arrives as a webhook carrying the old price id. `planFromPriceId` would stop resolving it, hit the `maps to no known plan` branch, and leave the subscriber's plan to drift out of sync with what they actually pay.

Every `STRIPE_*_PRICE_ID` now takes a **comma-separated list** — current price first, retired prices after:

```
STRIPE_PATRON_PRICE_ID=price_current,price_retired_2026
```

## Also

- Tier lists that were hand-written in six places (schema `enum`, `PLAN_RANK`, `PAID_PLANS`, the checkout allowlist, the SuperAdmin breakdown, help content) now derive from the plan config. The checkout allowlist in particular was hardcoded `['supporter','patron']`, so a new tier would have been rejected as "Invalid plan" despite having prices.
- New `GET /api/stripe/availability` (booleans only, no price ids) so the page never renders a button for a price the backend was not given.
- `--badge-plan-elite-*` theme tokens for the new tier, defined in both light and dark. Per-tier name colouring was deliberately *not* used: `--color-primary` and `--color-accent` resolve to the same gold in dark mode.

## Deploy requirements

- **Compose is hand-maintained on prod and is NOT in this repo.** The six `STRIPE_*_PRICE_ID` vars must be mirrored into prod's compose and `.env` before deploy. Since the default cadence is now yearly, an unmirrored prod shows "Not available right now" on every card at first paint.
- **Stripe Customer Portal catalogue** must list the new prices, or existing subscribers cannot switch cadence or tier.
- **When retiring the old $1.50 / $5.50 prices**, append their ids to the corresponding env var. Archiving alone strands those subscribers (see above).

## Testing

- Backend: 66 suites / 1396 tests pass in `node:20-alpine`. New `stripe.priceMapping.test.js` covers retired-price resolution, exact-match (no prefix bleed), the derived allowlist, and the availability endpoint.
- Frontend: 63 files / 990 tests pass. New `Supporter.test.js` (17 tests) covers the yearly default, cadence switching, equal tier treatment, unconfigured-price handling, and the duplicate-checkout path. Mutation-checked: flipping the default back to monthly fails 5 tests.
- Docker smoke test: backend healthy, `/api/stripe/availability` 401s unauthenticated, and with all six real Price IDs injected it reports every `(tier, interval)` pair available. Local `.env` restored byte-identical afterwards.

## Open decision

**Tier name** — "Benefactor" is a placeholder pick; one config key plus a few en strings to change. Wine-flavoured alternatives: Cellar Master, Grand Cru, Vigneron.

