### PR TITLE
feat(registry): hold profiles whose type contradicts every grape's colour

### DIFF
--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1095,9 +1095,12 @@ registerTool({
   title: 'Sommelier: profiles held by the publication gate, awaiting judgement',
   description:
     'The hold-review queue: registry wines whose generated tasting profile is HELD unpublished (producer_suspect / ' +
-    'low_confidence / unknown_low_confidence / producer_claim / taxonomy_conflict — held_reason says which; null on ' +
-    'rows held before the field existed; for taxonomy_conflict the producer_note carries the computed detail, e.g. ' +
-    '"bacchus is defined by low acidity; profile says high"). A held row stores NO profile content by design — ' +
+    'low_confidence / unknown_low_confidence / producer_claim / taxonomy_conflict / grape_colour_conflict — ' +
+    'held_reason says which; null on rows held before the field existed; for taxonomy_conflict the producer_note ' +
+    'carries the computed detail, e.g. "bacchus is defined by low acidity; profile says high", and for ' +
+    'grape_colour_conflict it names the clash, e.g. "stored red, but every grape is white (Sauvignon Blanc)" — ' +
+    'that one is a fact about the RECORD, not the model, so the fix is an identity edit: either the type or the ' +
+    'grape list is wrong, and the note does not presume which). A held row stores NO profile content by design — ' +
     'publication withheld means never written, which is why release REGENERATES rather than publishing something ' +
     'stored. include_published_suspects:true ALSO lists the published rows whose producer the model flagged as ' +
     'suspect (the 08-17 batch) — same judgement work, different state. Owner-count rides on every row and the list ' +

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -151,7 +151,9 @@ const wineDefinitionSchema = new mongoose.Schema({
     // WHY the hold fired — 'producer_suspect' | 'low_confidence' |
     // 'unknown_low_confidence' | 'producer_claim' (enrichmentJob.
     // shouldHoldProfile) | 'taxonomy_conflict' (grapeStyleTypicals cross-
-    // check, 6a8464ea phase 2). Plain String on purpose: held rows from
+    // check, 6a8464ea phase 2) | 'grape_colour_conflict' (utils/
+    // grapeColourCheck: the record's own type disagrees with every grape's
+    // curated colour, 6a85ad44). Plain String on purpose: held rows from
     // before 2026-08-18 predate the field (null = producer_suspect era), and
     // a future gate reason must not need a schema change.
     heldReason:   { type: String, default: null, trim: true },

--- a/backend/src/services/crossFieldScan.js
+++ b/backend/src/services/crossFieldScan.js
@@ -174,17 +174,25 @@ async function loadContextUncached() {
     Appellation.find({}).select('name normalizedName normalizedSynonyms').lean(),
     Region.find({}).select('name normalizedName normalizedSynonyms').lean(),
     Country.find({}).select('name normalizedName').lean(),
-    Grape.find({}).select('name normalizedName normalizedSynonyms').lean(),
+    Grape.find({}).select('name normalizedName normalizedSynonyms color').lean(),
   ]);
   return {
     refs: buildCrossFieldRefs({ appellations, regions, countries, grapes }),
     regionNamesById: new Map(regions.map(r => [String(r._id), r.name])),
     countryNamesById: new Map(countries.map(c => [String(c._id), c.name])),
+    // id → { name, color } for grape-colour-contradiction.v1. Same
+    // fetch-once-flatten-in-Node shape as the region/country name maps above;
+    // `color` is null on ~2% of the taxonomy and the rule treats an unknown
+    // colour as "not evaluable", never as a verdict.
+    grapesById: new Map(grapes.map(g => [String(g._id), { name: g.name, color: g.color || null }])),
   };
 }
 
-/** The string-only row shape the rules (and the queue UI) consume. */
-const flattenWine = (w, regionNamesById, countryNamesById) => ({
+/**
+ * The row shape the rules (and the queue UI) consume: strings, plus the one
+ * structured field grape-colour-contradiction.v1 needs.
+ */
+const flattenWine = (w, regionNamesById, countryNamesById, grapesById) => ({
   _id: w._id,
   // String-coerce: one raw-driver-written non-string row must not throw and
   // take the whole scan (and the weekly metrics run) down with it.
@@ -196,6 +204,13 @@ const flattenWine = (w, regionNamesById, countryNamesById) => ({
   // Read only by colour-contradiction.v2 — the one rule in the family whose
   // verdict is about the wine's own colour rather than a reference list.
   type: w.type || null,
+  // …and by grape-colour-contradiction.v1, which needs the same wine's grape
+  // COLOURS. Resolved here rather than populated, so the scan keeps its one
+  // query per collection. Unresolvable ids drop out and the rule then sees an
+  // incomplete colour set, which it treats as not-evaluable.
+  grapes: grapesById
+    ? (w.grapes || []).map(id => grapesById.get(String(id))).filter(Boolean)
+    : [],
   crossChecksCleared: w.crossChecksCleared,
 });
 
@@ -212,7 +227,7 @@ const flattenWine = (w, regionNamesById, countryNamesById) => ({
  *   what the weekly watchdog snapshots.
  */
 async function scanCrossFieldChecks({ checkIds = DEFAULT_CROSS_FIELD_CHECK_IDS, ignoreCleared = false } = {}) {
-  const { refs, regionNamesById, countryNamesById } = await loadContext();
+  const { refs, regionNamesById, countryNamesById, grapesById } = await loadContext();
   const wines = await WineDefinition.find({ nonWine: { $ne: true }, pendingIdentity: { $ne: true } })
     .select(CROSS_FIELD_CHECK_SELECT)
     .sort({ producer: 1, name: 1 })
@@ -223,7 +238,7 @@ async function scanCrossFieldChecks({ checkIds = DEFAULT_CROSS_FIELD_CHECK_IDS, 
   for (const id of checkIds) ruleCounts[id] = 0;
   let clearedCount = 0;
 
-  const flatWines = wines.map(w => flattenWine(w, regionNamesById, countryNamesById));
+  const flatWines = wines.map(w => flattenWine(w, regionNamesById, countryNamesById, grapesById));
   // The DB-backed rule runs ONCE over the whole pool (it is a pairwise question,
   // not a per-row one), then merges into each row's hits below.
   const nearMiss = checkIds.includes(CUVEE_NEAR_MISS) ? detectCuveeNearMiss(flatWines) : new Map();
@@ -259,7 +274,7 @@ async function scanCrossFieldChecks({ checkIds = DEFAULT_CROSS_FIELD_CHECK_IDS, 
  *   (empty array = found but clean); ids absent from the map were not found.
  */
 async function detectCrossFieldForWines(wineIds, checkIds) {
-  const { refs, regionNamesById, countryNamesById } = await loadContext();
+  const { refs, regionNamesById, countryNamesById, grapesById } = await loadContext();
   const wines = await WineDefinition.find({ _id: { $in: wineIds } })
     .select(CROSS_FIELD_CHECK_SELECT)
     .lean();
@@ -275,12 +290,12 @@ async function detectCrossFieldForWines(wineIds, checkIds) {
     const pool = await WineDefinition.find({ nonWine: { $ne: true }, pendingIdentity: { $ne: true } })
       .select(CROSS_FIELD_CHECK_SELECT)
       .lean();
-    nearMiss = detectCuveeNearMiss(pool.map(w => flattenWine(w, regionNamesById, countryNamesById)));
+    nearMiss = detectCuveeNearMiss(pool.map(w => flattenWine(w, regionNamesById, countryNamesById, grapesById)));
   }
 
   const hitsById = new Map();
   for (const w of wines) {
-    const flat = flattenWine(w, regionNamesById, countryNamesById);
+    const flat = flattenWine(w, regionNamesById, countryNamesById, grapesById);
     const hits = (runCrossFieldChecks(flat, refs, { checkIds, ignoreCleared: true }) || []).map(h => h.check);
     if (nearMiss.has(String(w._id))) hits.push(CUVEE_NEAR_MISS);
     hitsById.set(String(w._id), hits);

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -330,7 +330,7 @@ async function runJob(cfg) {
     let q = WineDefinition.find(filter)
       .populate('country', 'name')
       .populate('region', 'name')
-      .populate('grapes', 'name');
+      .populate('grapes', 'name color');
     // Cap the batch when a limit is set (cheap test runs).
     if (job.limit > 0) q = q.limit(job.limit);
     const wines = await q.lean();
@@ -457,6 +457,21 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
       if (conflict) {
         holdReason = 'taxonomy_conflict';
         if (!meta.producerNote) meta.producerNote = `Style conflict: ${conflict}`;
+      }
+    }
+    // Second deterministic cross-check (somm ticket 6a85ad44): the wine's own
+    // type against the curated colour of its grapes. Unlike the style conflict
+    // above this reads NO model output — it is a fact about the record — so a
+    // profile generated on top of it would be a careful description of a wine
+    // that cannot exist. Hold rather than publish, and let a curator say which
+    // of the two fields is the wrong one. See utils/grapeColourCheck for why
+    // the two directions are treated differently.
+    if (!holdReason) {
+      const { findGrapeColourConflict } = require('../utils/grapeColourCheck');
+      const clash = findGrapeColourConflict(wine);
+      if (clash) {
+        holdReason = 'grape_colour_conflict';
+        if (!meta.producerNote) meta.producerNote = `Colour conflict: ${clash}`;
       }
     }
     return { data: d, description, meta, holdReason };
@@ -635,7 +650,7 @@ async function enrichWineById(wineDefId, { budgetUserId, force = false, publishS
     const wine = await WineDefinition.findById(oid)
       .populate('country', 'name')
       .populate('region', 'name')
-      .populate('grapes', 'name')
+      .populate('grapes', 'name color')
       .lean();
     if (!wine) return;
     // Same rule as the batch filter above, and it matters MORE here: this is

--- a/backend/src/utils/__snapshots__/crossFieldChecks.snapshot.test.js.snap
+++ b/backend/src/utils/__snapshots__/crossFieldChecks.snapshot.test.js.snap
@@ -20,6 +20,8 @@ exports[`detect() source of colour-contradiction.v2 is unchanged — bump the id
   }"
 `;
 
+exports[`detect() source of grape-colour-contradiction.v1 is unchanged — bump the id if you edited it 1`] = `"w => findGrapeColourConflict(w)"`;
+
 exports[`detect() source of name-in-producer.v1 is unchanged — bump the id if you edited it 1`] = `
 "w => {
     const name = normalizeString(w.name || '');
@@ -123,5 +125,6 @@ exports[`rule ids are pinned (adding/removing/renaming a rule must be deliberate
   "appellation-is-grape.v1",
   "region-is-country.v1",
   "colour-contradiction.v2",
+  "grape-colour-contradiction.v1",
 ]
 `;

--- a/backend/src/utils/crossFieldChecks.js
+++ b/backend/src/utils/crossFieldChecks.js
@@ -58,6 +58,9 @@ const {
   isUnknownName,
   tokenize,
 } = require('./normalize');
+// Shared with the enrichment hold (services/enrichmentJob) so the review queue
+// and the publication gate can never disagree about what a colour clash is.
+const { findGrapeColourConflict } = require('./grapeColourCheck');
 
 /**
  * Probe a reference map with BOTH normalization folds of a wine-side value,
@@ -435,6 +438,28 @@ const CROSS_FIELD_CHECKS = [
       return null;
     },
   },
+  {
+    // The GRAPE-side sibling of colour-contradiction.v2, and not a superset of
+    // it: that rule reads the wine's name, this one reads its varieties, and
+    // each sees rows the other cannot. "Domaine des Bosquets / Séguret" is
+    // stored red on Viognier, Roussanne and Marsanne with no colour word in
+    // sight; "Château Bianco" with red grapes is the reverse case.
+    //
+    // Detection lives in utils/grapeColourCheck (shared with the enrichment
+    // hold, so the queue and the gate can never drift), and the asymmetry
+    // between the two directions is documented there — briefly: a red from
+    // only-white grapes is impossible, a white from only-red grapes is a
+    // blanc de noirs unless the name is silent about it.
+    //
+    // Needs `grapes` populated with colour on the flattened row, which is why
+    // CROSS_FIELD_CHECK_SELECT carries `grapes` and crossFieldScan resolves
+    // them; on any row shape without them the detect stays silent.
+    id: 'grape-colour-contradiction.v1',
+    labelKey: 'grapeColourContradiction',
+    field: 'type',
+    defaultActive: true,
+    detect: (w) => findGrapeColourConflict(w),
+  },
 ];
 
 /**
@@ -550,7 +575,7 @@ function runCrossFieldChecks(wine, refs, { checkIds = DEFAULT_CROSS_FIELD_CHECK_
  * region/country arrive as ObjectIds here; the scan service resolves them to
  * names before the rules run.
  */
-const CROSS_FIELD_CHECK_SELECT = 'name producer appellation region country type crossChecksCleared';
+const CROSS_FIELD_CHECK_SELECT = 'name producer appellation region country type grapes crossChecksCleared';
 
 /** id → i18n leaf / offending field, for the admin queue's column headers. */
 const CROSS_FIELD_CHECK_LABEL_KEYS = ALL_CROSS_FIELD_CHECKS.reduce((m, c) => (m[c.id] = c.labelKey, m), {});

--- a/backend/src/utils/grapeColourCheck.js
+++ b/backend/src/utils/grapeColourCheck.js
@@ -1,0 +1,111 @@
+/**
+ * Grape-colour contradiction: does the stored `type` disagree with the colour
+ * of EVERY grape on the wine?
+ *
+ * A sibling of the `colour-contradiction.v2` rule in utils/crossFieldChecks —
+ * and deliberately not a replacement for it. That one reads the wine's NAME
+ * ("Bianco" on a red); this one reads its GRAPES. Neither subsumes the other:
+ * "Domaine des Bosquets / Séguret" is stored red with Viognier, Roussanne and
+ * Marsanne and carries no colour word at all, so only the grape rule sees it.
+ *
+ * WHY THIS EXISTS (somm ticket 6a85ad44, 2026-08-19). Two wines were minted by
+ * a live import forty minutes AFTER v1.139.0 shipped the prompt rules meant to
+ * stop exactly this — a red given "Sauvignon Blanc", a red given "Grenache
+ * Blanc". Prompt instructions ask a model not to guess; they cannot make it
+ * stop. A deterministic check over curated taxonomy can, and it costs nothing.
+ *
+ * THE ASYMMETRY IS THE WHOLE DESIGN. The directions are not equally
+ * suspicious, and treating them alike would bury the real errors:
+ *
+ *   red from grapes that are ALL white — no legitimate case. Colour comes
+ *       from skin contact with dark grapes, so either the type is wrong or the
+ *       grape list is (a Côte-Rôtie listing only its Viognier lands here too,
+ *       and that is also worth a look). No exemption.
+ *
+ *   white from grapes that are ALL red — an ordinary, deliberate style.
+ *       Blanc de noirs, Bianco di Morgante, Pinotage Blanc. Flagging these
+ *       would make the check ~50% noise on real prod data, which is how a
+ *       review queue gets ignored. The wine tells us when it means it: the
+ *       NAME carries the white word. So that direction flags only when the
+ *       name is silent — "Tokara / Director's Reserve" stored white on four
+ *       Bordeaux red varieties says nothing, and is simply wrong.
+ *
+ *   rosé — NOT JUDGED AT ALL, and the first draft of this file got that wrong.
+ *       Run over the live registry it flagged seven rosés from "white" grapes,
+ *       and four were real wines: Canaletto's Rosato is ramato Pinot Gris,
+ *       Alain Ignace's Muscat de Beaumes-de-Venise Rosé is the pink Muscat
+ *       mutation our taxonomy only carries as "Muscat Blanc", and both
+ *       Hammeken's Nanit and Charles Frey's Macération are skin-contact ORANGE
+ *       wines — which have no `type` of their own, so rosé is the honest
+ *       choice a curator has. Two causes, one conclusion: Grape.color is a
+ *       Red/White binary that cannot express a pink skin, and rosé is exactly
+ *       where that gap lives. Judging it would spend the queue's credibility
+ *       on wines that are already correct.
+ *
+ * Measured against the live registry 2026-08-19: 13 rows flagged out of 5,727
+ * with grapes (0.23%). Every legitimate blanc de noirs is exempted by its own
+ * name; every genuine defect flags.
+ *
+ * FLAG, NEVER AUTO-FIX. The check knows the two fields disagree; it does not
+ * know which one is wrong (Tyrrell's "Old Hut Semillon" is stored white with
+ * Syrah — there the GRAPE is the error, not the type). A human decides.
+ */
+const { normalizeString } = require('./normalize');
+
+// Colour words that, in a wine's own name, are a deliberate claim about the
+// wine in the glass. Mirrors NAME_COLOUR_TERMS in utils/crossFieldChecks —
+// kept as its own list because this rule only ever asks about WHITE.
+const WHITE_NAME_TERMS = new Set(['blanc', 'blancs', 'blanco', 'bianco', 'branco', 'weiss', 'weisser', 'white']);
+
+// The types this rule will judge. 'sparkling', 'dessert' and 'fortified' say
+// nothing about colour — a Blanc de Noirs Champagne and a white Port are both
+// stored under them. 'rosé' is excluded for the measured reason in the header:
+// pink-skinned varieties and orange wines both live there, and Grape.color's
+// Red/White binary cannot tell either of them apart from a defect.
+const COLOUR_TYPES = new Set(['red', 'white']);
+
+const tokensOf = (s) => normalizeString(String(s || '').replace(/ß/g, 'ss')).split(' ').filter(Boolean);
+
+/**
+ * @param {object} wine  { type, name, producer, grapes: [{ name, color }] }
+ *                       `grapes` must be POPULATED with `color` — an unpopulated
+ *                       id array yields no colours and the check stays silent,
+ *                       which is the safe direction.
+ * @returns {string|null} short human detail (what disagreed), or null
+ */
+function findGrapeColourConflict(wine) {
+  const type = wine?.type;
+  if (!COLOUR_TYPES.has(type)) return null;
+
+  const grapes = Array.isArray(wine?.grapes) ? wine.grapes : [];
+  if (!grapes.length) return null;
+
+  // Every grape must carry a curated colour. One unknown grape and the wine is
+  // simply not evaluable — a partial verdict here would be a guess, which is
+  // the failure mode this whole check exists to answer.
+  const colours = grapes.map((g) => g && g.color).filter(Boolean);
+  if (colours.length !== grapes.length) return null;
+
+  const names = grapes.map((g) => g.name).filter(Boolean).join(', ');
+  const allWhite = colours.every((c) => c === 'White');
+  const allRed = colours.every((c) => c === 'Red');
+
+  if (type === 'red' && allWhite) {
+    return `stored red, but every grape is white (${names})`;
+  }
+
+  if (type === 'white' && allRed) {
+    // Blanc de noirs exemption. A colour word that is also in the PRODUCER is
+    // the estate's name rather than a claim about the wine ("Mas Blanc"), the
+    // same carve-out colour-contradiction.v2 makes — so producer tokens do not
+    // earn the exemption.
+    const producerTokens = new Set(tokensOf(wine.producer));
+    const claimsWhite = tokensOf(wine.name).some((t) => WHITE_NAME_TERMS.has(t) && !producerTokens.has(t));
+    if (claimsWhite) return null; // deliberate white-from-red-grapes
+    return `stored white, but every grape is red (${names}) and the name makes no white claim`;
+  }
+
+  return null;
+}
+
+module.exports = { findGrapeColourConflict, WHITE_NAME_TERMS, COLOUR_TYPES };

--- a/backend/src/utils/grapeColourCheck.test.js
+++ b/backend/src/utils/grapeColourCheck.test.js
@@ -1,0 +1,124 @@
+const { findGrapeColourConflict } = require('./grapeColourCheck');
+
+const RED = (name) => ({ name, color: 'Red' });
+const WHITE = (name) => ({ name, color: 'White' });
+
+describe('findGrapeColourConflict', () => {
+  describe('red (or rosé) from only white grapes — always a conflict', () => {
+    // Every one of these is a real prod row from the 2026-08-19 scan.
+    it('flags a red stored on a single white grape', () => {
+      expect(findGrapeColourConflict({
+        type: 'red', name: 'Sauvignon Blanc', producer: 'Screaming Eagle', grapes: [WHITE('Sauvignon Blanc')],
+      })).toMatch(/every grape is white/);
+    });
+
+    it('flags a red stored on an all-white blend', () => {
+      expect(findGrapeColourConflict({
+        type: 'red', name: 'Séguret', producer: 'Domaine des Bosquets',
+        grapes: [WHITE('Viognier'), WHITE('Roussanne'), WHITE('Marsanne')],
+      })).toMatch(/every grape is white/);
+    });
+
+    it('flags the two rows that arrived from a live import after v1.139.0', () => {
+      expect(findGrapeColourConflict({
+        type: 'red', name: 'Conte di Valle Veronese', producer: 'Palazzo Maffei', grapes: [WHITE('Sauvignon Blanc')],
+      })).toBeTruthy();
+      expect(findGrapeColourConflict({
+        type: 'red', name: 'Almodi Petit', producer: 'Altavins Viticultors', grapes: [WHITE('Grenache Blanc')],
+      })).toBeTruthy();
+    });
+
+    it('does NOT flag a red whose grapes are red', () => {
+      expect(findGrapeColourConflict({
+        type: 'red', name: 'Barolo', producer: 'Whoever', grapes: [RED('Nebbiolo')],
+      })).toBeNull();
+    });
+
+    it('does NOT flag a mixed blend — one dark grape is enough to make a red', () => {
+      expect(findGrapeColourConflict({
+        type: 'red', name: 'Côte-Rôtie', producer: 'Whoever', grapes: [RED('Syrah'), WHITE('Viognier')],
+      })).toBeNull();
+    });
+  });
+
+  describe('white from only red grapes — a real style, so the name decides', () => {
+    it('exempts an explicit blanc de noirs', () => {
+      expect(findGrapeColourConflict({
+        type: 'white', name: 'Blanc de Noir Spätburgunder', producer: 'Weingut Burggarten', grapes: [RED('Pinot Noir')],
+      })).toBeNull();
+    });
+
+    it('exempts "Bianco" and "Blanc" claims in other languages', () => {
+      expect(findGrapeColourConflict({
+        type: 'white', name: 'Bianco di Morgante', producer: 'Morgante', grapes: [RED("Nero d'Avola")],
+      })).toBeNull();
+      expect(findGrapeColourConflict({
+        type: 'white', name: 'Pinotage Blanc', producer: 'Aaldering', grapes: [RED('Pinotage')],
+      })).toBeNull();
+    });
+
+    it('flags a white on red grapes when the name makes no white claim', () => {
+      expect(findGrapeColourConflict({
+        type: 'white', name: "Director's Reserve", producer: 'Tokara',
+        grapes: [RED('Cabernet Sauvignon'), RED('Merlot'), RED('Cabernet Franc'), RED('Petit Verdot')],
+      })).toMatch(/no white claim/);
+    });
+
+    it('does not accept a colour word that belongs to the PRODUCER', () => {
+      // "Mas Blanc" is the estate; the wine claims nothing.
+      expect(findGrapeColourConflict({
+        type: 'white', name: 'Tradition', producer: 'Mas Blanc', grapes: [RED('Grenache')],
+      })).toMatch(/no white claim/);
+    });
+
+    it('does not treat "Rosato" as a white claim — that row is a mis-typed rosé', () => {
+      expect(findGrapeColourConflict({
+        type: 'white', name: 'Ancestor Vine Rosato 1850', producer: 'Cirillo Estate', grapes: [RED('Grenache')],
+      })).toBeTruthy();
+    });
+  });
+
+  describe('silence is the safe direction', () => {
+    it('says nothing when a grape has no curated colour', () => {
+      expect(findGrapeColourConflict({
+        type: 'red', name: 'X', producer: 'Y', grapes: [WHITE('Sauvignon Blanc'), { name: 'Cabernet', color: null }],
+      })).toBeNull();
+    });
+
+    it('says nothing for types that make no colour claim', () => {
+      for (const type of ['sparkling', 'dessert', 'fortified']) {
+        expect(findGrapeColourConflict({
+          type, name: 'Blanc de Noirs', producer: 'A House', grapes: [RED('Pinot Noir')],
+        })).toBeNull();
+      }
+    });
+
+    // Rosé is deliberately unjudged. These four are REAL prod rows an earlier
+    // draft flagged: two pink-skinned varieties our Red/White taxonomy stores
+    // as White, and two skin-contact orange wines with no type of their own.
+    it('never judges rosé, whichever way the grapes point', () => {
+      const rosés = [
+        { name: 'Rosato', producer: 'Canaletto', grapes: [WHITE('Pinot Gris')] },
+        { name: 'Muscat Beaumes de Venise Rosé', producer: 'Alain Ignace', grapes: [WHITE('Muscat Blanc à Petits Grains')] },
+        { name: 'Nanit Orange Wine', producer: 'Hammeken Cellars', grapes: [WHITE('Macabeo')] },
+        { name: 'Macération', producer: 'Charles Frey', grapes: [WHITE('Gewürztraminer'), WHITE('Muscat')] },
+        { name: 'Anything', producer: 'Whoever', grapes: [RED('Grenache')] },
+      ];
+      for (const w of rosés) expect(findGrapeColourConflict({ ...w, type: 'rosé' })).toBeNull();
+    });
+
+    it('says nothing with no grapes, no type, or an unpopulated grape array', () => {
+      expect(findGrapeColourConflict({ type: 'red', name: 'X', producer: 'Y', grapes: [] })).toBeNull();
+      expect(findGrapeColourConflict({ type: null, name: 'X', producer: 'Y', grapes: [WHITE('Riesling')] })).toBeNull();
+      expect(findGrapeColourConflict({ type: 'red', name: 'X', producer: 'Y', grapes: ['64f0a1b2c3d4e5f6a7b8c9d0'] })).toBeNull();
+      expect(findGrapeColourConflict({})).toBeNull();
+      expect(findGrapeColourConflict(null)).toBeNull();
+    });
+  });
+
+  it('names the offending grapes so a curator can act without opening the row', () => {
+    expect(findGrapeColourConflict({
+      type: 'red', name: 'Autoctona', producer: 'Barranco Oscuro', grapes: [WHITE('Vigiriega')],
+    })).toContain('Vigiriega');
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1646,7 +1646,8 @@
           "appellationIsGrape": "Appellation is a grape",
           "regionIsCountry": "Region is a country",
           "colourContradiction": "Name colour contradicts the type",
-          "cuveeNearMiss": "Almost the same name as another wine by this producer"
+          "cuveeNearMiss": "Almost the same name as another wine by this producer",
+          "grapeColourContradiction": "Grape colours contradict the type"
         },
         "empty": "No wines are flagged by the selected checks.",
         "networkError": "Network error"


### PR DESCRIPTION
Closes the loop on somm ticket **6a85ad44**. v1.139.0 removed the `type: 'red'` schema default and #1037 stopped the prompts guessing a colour — yet two wines were minted by a live import **40 minutes after v1.139.0 deployed**: a red given `Sauvignon Blanc`, a red given `Grenache Blanc`. A third arrived while this branch was being written. Prompt instructions ask a model not to guess; they cannot make it stop. Curated taxonomy can.

### One rule, two consumers
`utils/grapeColourCheck` compares the stored `type` against the curated colour of every grape. Shared so the queue and the gate cannot drift:

| consumer | behaviour |
|---|---|
| `enrichmentJob` | holds the profile as **`grape_colour_conflict`**, beside `taxonomy_conflict`. Unlike that one this reads **no model output** — it is a fact about the record — so a profile written on top of it would be a careful description of a wine that cannot exist. |
| `crossFieldChecks` | new **`grape-colour-contradiction.v1`**, so rows already in the registry surface in the admin queue and the weekly watchdog instead of waiting to be re-enriched. |

### The asymmetry is the design — and it is measured
- **red from only-white grapes** — no legitimate case. Flag, no exemption.
- **white from only-red grapes** — an ordinary style (blanc de noirs, Bianco di Morgante, Pinotage Blanc). Flags **only when the name makes no white claim**; a colour word belonging to the *producer* ("Mas Blanc") doesn't count, matching `colour-contradiction.v2`'s existing carve-out.
- **rosé is not judged.** The first draft did judge it and **was wrong**: run against the live registry it flagged seven rosés, four of them real wines — ramato Pinot Gris, the pink Muscat mutation our taxonomy only carries as "Muscat Blanc", and two skin-contact **orange wines** that have no `type` of their own. `Grape.color` is a Red/White binary that cannot express a pink skin, and rosé is exactly where that gap lives.

### Verified against the live registry, not just fixtures
**13 rows flagged out of 5,727 with grapes (0.23%)**, no false positives, all three legitimate blanc de noirs exempted by their own names. This is a sibling of `colour-contradiction.v2`, not a replacement: that rule reads the *name*, this one reads the *grapes*, and each catches rows the other cannot — "Domaine des Bosquets / Séguret" is stored red on Viognier/Roussanne/Marsanne with no colour word in sight.

Flags, **never auto-fixes**: the check knows the two fields disagree, not which one is wrong (Tyrrell's "Old Hut Semillon" is stored white with Syrah — there the *grape* is the error). A human decides.

### Tests
- 15 new unit tests, every case drawn from a real prod row
- 78 backend suites / 1197 tests pass; frontend 62 files / 967 tests pass
- the `crossFieldChecks` rule-id snapshot updated deliberately (one added line — that guard exists so adding a rule can't be accidental)

### ⚠️ MCP schema change
`list_held_profiles`' description gains the new reason, so the sommelier needs **one fresh conversation** — which they already need for `uphold` and the analytics tools.