### PR TITLE
feat(curation): let the sommelier propose type and grapes

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -1002,6 +1002,9 @@ describe('propose_wine_correction', () => {
     expect(created.currentSnapshot).toEqual({
       producer: 'Pira', name: 'Barolo', appellation: 'Barolo',
       region: 'Piedmont', country: 'Italy', classification: 'DOCG',
+      // Both proposable since 2026-08-19, so both must ride in the snapshot —
+      // the admin drift check compares against it field by field.
+      type: null, grapes: null,
     });
 
     const row = McpActionLog.create.mock.calls[0][0];
@@ -1009,6 +1012,61 @@ describe('propose_wine_correction', () => {
     expect(row.detail).toEqual({ proposalId: 'prop-1', wineId: WINE_ID, kind: 'field_correction' });
     expect(logAudit).toHaveBeenCalledWith(SOMM_CTX.req, 'somm.wineProposal.create',
       expect.anything(), expect.objectContaining({ kind: 'field_correction', via: 'mcp' }));
+  });
+
+  // Somm ticket 6a85ad44: type and grapes were the only identity fields with
+  // no route through this pipeline, so a curator who spotted a red stored on
+  // nothing but white grapes had to hand it to an admin.
+  describe('type and grapes', () => {
+    test('files a type correction', async () => {
+      mkWine({ type: 'red' });
+      WineCorrectionProposal.create.mockResolvedValue({ _id: 'prop-t' });
+      const body = parse(await tool('propose_wine_correction').handler({
+        wine_id: WINE_ID, kind: 'field_correction',
+        proposed_fields: { type: 'white' }, reason: REASON,
+      }, SOMM_CTX));
+      expect(body.error).toBeUndefined();
+      expect(WineCorrectionProposal.create.mock.calls[0][0].proposedFields).toEqual({ type: 'white' });
+    });
+
+    test('resolves grape names to CANONICAL ones before storing them', async () => {
+      mkWine();
+      // "Tinta Roriz" is a synonym; the proposal should record what will
+      // actually be written so the admin is not decoding it at review time.
+      Grape.findOne.mockReturnValue(chain({ _id: oid('9'), name: 'Tempranillo' }));
+      WineCorrectionProposal.create.mockResolvedValue({ _id: 'prop-g' });
+      const body = parse(await tool('propose_wine_correction').handler({
+        wine_id: WINE_ID, kind: 'field_correction',
+        proposed_fields: { grapes: ['Tinta Roriz'] }, reason: REASON,
+      }, SOMM_CTX));
+      expect(body.error).toBeUndefined();
+      expect(WineCorrectionProposal.create.mock.calls[0][0].proposedFields).toEqual({ grapes: ['Tempranillo'] });
+    });
+
+    test('refuses a variety that is not in the taxonomy, at FILE time', async () => {
+      mkWine();
+      Grape.findOne.mockReturnValue(chain(null));
+      const body = parse(await tool('propose_wine_correction').handler({
+        wine_id: WINE_ID, kind: 'field_correction',
+        proposed_fields: { grapes: ['Cabernet Blanc'] }, reason: REASON,
+      }, SOMM_CTX));
+      expect(body.error.code).toBe('invalid_input');
+      expect(body.error.message).toMatch(/not in the taxonomy/);
+      expect(body.error.message).toMatch(/cannot create a variety/);
+      expect(WineCorrectionProposal.create).not.toHaveBeenCalled();
+    });
+
+    test('the snapshot carries the wine\'s current type and grapes', async () => {
+      mkWine({ type: 'red', grapes: [{ name: 'Merlot' }, { name: 'Cabernet Sauvignon' }] });
+      WineCorrectionProposal.create.mockResolvedValue({ _id: 'prop-s' });
+      await tool('propose_wine_correction').handler({
+        wine_id: WINE_ID, kind: 'field_correction',
+        proposed_fields: { type: 'white' }, reason: REASON,
+      }, SOMM_CTX);
+      expect(WineCorrectionProposal.create.mock.calls[0][0].currentSnapshot).toMatchObject({
+        type: 'red', grapes: 'Merlot, Cabernet Sauvignon',
+      });
+    });
   });
 
   test('merge kind: the target must differ from the wine and must exist', async () => {

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1444,7 +1444,11 @@ registerTool({
 // the curator's research preserved as structured data instead of a prose
 // ticket the admin re-types.
 const PROPOSAL_KINDS = ['field_correction', 'merge', 'non_wine'];
+// The plain-STRING proposable fields. `type` and `grapes` are proposable too
+// (added 2026-08-19, somm ticket 6a85ad44) but validate differently — an enum
+// and a taxonomy-resolved list — so they are handled apart from this loop.
 const PROPOSAL_FIELDS = ['producer', 'name', 'appellation', 'region', 'country', 'classification'];
+const PROPOSAL_ALL_FIELDS = [...PROPOSAL_FIELDS, 'type', 'grapes'];
 const PROPOSAL_REASON_MIN = 10;
 const PROPOSAL_REASON_MAX = 1000;
 const PROPOSAL_FIELD_MAX = 200;
@@ -1477,7 +1481,9 @@ registerTool({
       region: z.string().min(1).max(PROPOSAL_FIELD_MAX).optional(),
       country: z.string().min(1).max(PROPOSAL_FIELD_MAX).optional(),
       classification: z.string().min(1).max(PROPOSAL_FIELD_MAX).optional(),
-    }).optional().describe('kind "field_correction" only: the corrected value per field (omit fields that are right). Region/country as plain names.'),
+      type: z.enum(WINE_TYPES).optional(),
+      grapes: z.array(z.string().min(1).max(GRAPE_NAME_MAX)).min(1).max(GRAPES_MAX).optional(),
+    }).optional().describe('kind "field_correction" only: the corrected value per field (omit fields that are right). Region/country as plain names. `type` is the wine colour/style; `grapes` REPLACES the whole variety list (send every variety the wine has, not just the added one) and each name must already exist in the taxonomy — synonyms resolve, unknown names are refused so an approval can never mint a variety.'),
     merge_target_id: objectId.optional().describe('kind "merge" only: the duplicate\'s SURVIVING wine — must differ from wine_id'),
     evidence_url: z.string().max(PROPOSAL_URL_MAX).optional()
       .describe('http(s) URL backing the claim — cite one whenever the somm has it; it is what makes approval fast'),
@@ -1530,8 +1536,25 @@ registerTool({
         }
         proposedFields[f] = v;
       }
+      // type: the zod enum already refused anything outside WINE_TYPES.
+      if (src.type) proposedFields.type = src.type;
+      // grapes: resolved against the taxonomy HERE so the curator finds out now
+      // rather than when an admin tries to approve. The approve path resolves
+      // again (taxonomy moves), but a name that is unknown today is almost
+      // always a typo, and telling them immediately is the whole point.
+      if (Array.isArray(src.grapes) && src.grapes.length) {
+        const resolved = await resolveGrapeIdsStrict(src.grapes);
+        if (!resolved.ok) {
+          return fail('invalid_input',
+            `These grape names are not in the taxonomy: ${resolved.unmatched.map((g) => `"${g}"`).join(', ')}. ` +
+            'Check the spelling, or use describe_grape to find the canonical name. A proposal cannot create a variety.');
+        }
+        // Store the CANONICAL names: the proposal should record what will
+        // actually be written, not a synonym the admin then has to decode.
+        proposedFields.grapes = resolved.names;
+      }
       if (Object.keys(proposedFields).length === 0) {
-        return fail('invalid_input', `field_correction needs at least one non-empty field in proposed_fields (${PROPOSAL_FIELDS.join(', ')}).`);
+        return fail('invalid_input', `field_correction needs at least one non-empty field in proposed_fields (${PROPOSAL_ALL_FIELDS.join(', ')}).`);
       }
     } else {
       if (args.proposed_fields && Object.keys(args.proposed_fields).length > 0) {
@@ -1551,7 +1574,7 @@ registerTool({
 
     if (!isValidId(args.wine_id)) return fail('invalid_input', 'wine_id must be a 24-hex id.');
     const wine = await WineDefinition.findById(args.wine_id)
-      .populate('country', 'name').populate('region', 'name');
+      .populate('country', 'name').populate('region', 'name').populate('grapes', 'name');
     if (!wine) return fail('not_found', 'No such wine. Use search_registry to find it.');
 
     let target = null;
@@ -1570,6 +1593,11 @@ registerTool({
       region: wine.region?.name || null,
       country: wine.country?.name || null,
       classification: wine.classification || null,
+      // Both sides of the admin drift check compare against this, so the two
+      // new proposable fields have to be in it — otherwise every type/grapes
+      // proposal would render as "drifted since filing" against undefined.
+      type: wine.type || null,
+      grapes: (wine.grapes || []).map((g) => g && g.name).filter(Boolean).join(', ') || null,
     };
 
     let proposal;

--- a/backend/src/models/WineCorrectionProposal.js
+++ b/backend/src/models/WineCorrectionProposal.js
@@ -31,6 +31,22 @@ const proposedFieldsSchema = new mongoose.Schema({
   region:         { type: String, trim: true, maxlength: 200 },
   country:        { type: String, trim: true, maxlength: 200 },
   classification: { type: String, trim: true, maxlength: 200 },
+  // Added 2026-08-19 (somm ticket 6a85ad44). Until now a curator could see a
+  // wine stored red on nothing but white grapes and had no way to propose the
+  // fix — type and grapes were the only identity fields with no route through
+  // this pipeline, so every one came back to an admin by hand.
+  //
+  // Validated at BOTH ends rather than here: the MCP tool rejects a bad type or
+  // an unknown variety at file time (so the curator learns immediately), and
+  // the approve path re-checks against live taxonomy (because a grape can be
+  // renamed or merged between filing and approval). A plain String here matches
+  // how country and region are already carried.
+  type:           { type: String, trim: true, maxlength: 20 },
+  // Variety NAMES, not ids: the proposal records what the curator meant, and
+  // resolution to taxonomy happens at approval — same reason country travels as
+  // a name. A proposed list REPLACES the wine's list; `default: undefined`
+  // keeps "not proposed" distinct from "proposed empty".
+  grapes:         { type: [{ type: String, trim: true, maxlength: 60 }], default: undefined },
 }, { _id: false });
 
 const wineCorrectionProposalSchema = new mongoose.Schema({

--- a/backend/src/routes/admin/wineProposals.js
+++ b/backend/src/routes/admin/wineProposals.js
@@ -37,6 +37,9 @@ const searchService = require('../../services/search');
 const { reembedActiveVintages } = require('../../services/embeddingJob');
 const { profileInputsSnapshot, reenrichAfterRecordEdit } = require('../../services/enrichmentJob');
 const { findOrCreateRegion } = require('../../services/findOrCreateWine');
+// Same helpers the somm's own set_wine_profile writes through, so an approved
+// proposal and a direct curator edit resolve varieties identically.
+const { WINE_TYPES, resolveGrapeIdsStrict } = require('../../services/wineProfileOps');
 const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const { performWineMerge } = require('./wines');
 const { generateWineKey, normalizeAppellation, normalizeString, resolveCountryName } = require('../../utils/normalize');
@@ -49,7 +52,13 @@ router.use(requireAuth, requireRole('admin'));
 // Keep in sync with the WineCorrectionProposal schema enums. 'decided' is a
 // list-only alias for approved+rejected (the review modal's second tab).
 const PROPOSAL_STATUSES = ['pending', 'approved', 'rejected'];
-const IDENTITY_FIELDS = ['producer', 'name', 'appellation', 'region', 'country', 'classification'];
+// `grapes` is deliberately NOT here: it is a LIST, and the diff/drift shape
+// this list feeds is string-to-string. It is rendered by joining the names,
+// alongside these, in the diff builder below.
+const IDENTITY_FIELDS = ['producer', 'name', 'appellation', 'region', 'country', 'classification', 'type'];
+
+/** Grape names for display in a diff row — the same join both sides use. */
+const grapeLabel = (names) => (Array.isArray(names) && names.length ? names.join(', ') : null);
 
 const REJECT_REASON_MIN = 5;
 const REJECT_REASON_MAX = 500;
@@ -62,6 +71,10 @@ const liveIdentity = (wine) => ({
   region: wine.region?.name || null,
   country: wine.country?.name || null,
   classification: wine.classification || null,
+  type: wine.type || null,
+  // Populated when the caller asked for it; a bare id array joins to nothing
+  // and the row simply reads "—", which is honest for an unpopulated read.
+  grapes: grapeLabel((wine.grapes || []).map((g) => g && g.name).filter(Boolean)),
 });
 
 // GET /api/admin/wine-proposals — list, pending first, newest first within status
@@ -98,8 +111,13 @@ router.get('/', async (req, res) => {
       { path: 'proposer', select: 'username' },
       {
         path: 'wineDefinition',
-        select: 'name producer appellation classification type nonWine country region',
-        populate: [{ path: 'country', select: 'name' }, { path: 'region', select: 'name' }],
+        select: 'name producer appellation classification type nonWine country region grapes',
+        populate: [
+          { path: 'country', select: 'name' },
+          { path: 'region', select: 'name' },
+          // For the grapes diff row's CURRENT side.
+          { path: 'grapes', select: 'name' },
+        ],
       },
       { path: 'mergeTargetId', select: 'name producer appellation type' },
     ]);
@@ -115,6 +133,11 @@ router.get('/', async (req, res) => {
           const proposed = p.proposedFields[f];
           if (proposed === undefined || proposed === null || proposed === '') continue;
           diff[f] = { current: live ? live[f] : null, proposed };
+        }
+        // Grapes render like every other row — joined names on both sides —
+        // so the modal needs no list-aware branch.
+        if (Array.isArray(p.proposedFields.grapes) && p.proposedFields.grapes.length) {
+          diff.grapes = { current: live ? live.grapes : null, proposed: grapeLabel(p.proposedFields.grapes) };
         }
       }
       return {
@@ -257,6 +280,40 @@ async function approveProposal(proposalId, req, { deferFollowThrough = false } =
           const regionDoc = await findOrCreateRegion(pf.region, countryDoc?._id || wine.country, req.user.id);
           wine.region = regionDoc?._id || null;
           applied.push(regionDoc ? 'region' : 'region (cleared — name failed the mint gates)');
+        }
+
+        // Type is re-validated here even though the MCP tool already refused a
+        // bad one: this route is the only guarantee, and a proposal filed
+        // before an enum change would otherwise write a value the schema
+        // rejects at save() with a far worse error.
+        if (pf.type) {
+          if (!WINE_TYPES.includes(pf.type)) {
+            await revertClaim();
+            return { status: 400, body: { error: `Unknown wine type "${pf.type}" — must be one of: ${WINE_TYPES.join(', ')}` } };
+          }
+          wine.type = pf.type;
+          applied.push('type');
+        }
+
+        // Grapes resolve against LIVE taxonomy at approval, not at filing: a
+        // variety can be renamed or merged into its canonical entry in between
+        // (17 were merged on 2026-08-19 alone), and the curator's names should
+        // still land on the right rows afterwards. Match-only, exactly like
+        // country above — approving a proposal must never MINT taxonomy.
+        if (Array.isArray(pf.grapes) && pf.grapes.length) {
+          const resolved = await resolveGrapeIdsStrict(pf.grapes);
+          if (!resolved.ok) {
+            await revertClaim();
+            return { status: 400, body: {
+              error: `Unknown grape${resolved.unmatched.length > 1 ? 's' : ''} ${resolved.unmatched.map((g) => `"${g}"`).join(', ')} — add ${resolved.unmatched.length > 1 ? 'them' : 'it'} in Admin → Taxonomy first, then approve`,
+            } };
+          }
+          wine.grapes = resolved.ids;
+          // Say when a synonym was folded ("Tinta Roriz" → Tempranillo) rather
+          // than silently storing something the curator did not type.
+          applied.push(resolved.substitutions.length
+            ? `grapes (${resolved.substitutions.map((s) => `${s.from} → ${s.to}`).join(', ')})`
+            : 'grapes');
         }
 
         // Same rule as the PUT: the dedup key follows name/producer/appellation.

--- a/backend/src/routes/admin/wineProposals.test.js
+++ b/backend/src/routes/admin/wineProposals.test.js
@@ -43,6 +43,13 @@ jest.mock('../../services/appellationResolve', () => ({ resolveCanonicalAppellat
 // The extracted merge helper — the whole point of the extraction is that this
 // route invokes IT rather than re-implementing the machinery.
 jest.mock('./wines', () => ({ performWineMerge: jest.fn() }));
+// Grape resolution is the somm's own set_wine_profile helper; the route must
+// call it rather than touching the Grape collection itself, so it is mocked
+// and asserted on. WINE_TYPES stays real — it is a constant list.
+jest.mock('../../services/wineProfileOps', () => ({
+  WINE_TYPES: ['red', 'white', 'rosé', 'sparkling', 'dessert', 'fortified'],
+  resolveGrapeIdsStrict: jest.fn(),
+}));
 
 const express = require('express');
 const http = require('http');
@@ -182,6 +189,87 @@ describe('POST /:id/approve', () => {
     expect(res.status).toBe(200);
     const { reenrichAfterRecordEdit } = require('../../services/enrichmentJob');
     expect(reenrichAfterRecordEdit).toHaveBeenCalledWith(wine, true);
+  });
+
+  // Type and grapes became proposable on 2026-08-19 (somm ticket 6a85ad44):
+  // until then a curator could SEE a wine stored red on nothing but white
+  // grapes and had no route to propose the fix, so every one came back to an
+  // admin by hand.
+  describe('type and grapes (the fields a curator could not propose before)', () => {
+    const { resolveGrapeIdsStrict } = require('../../services/wineProfileOps');
+
+    test('applies a corrected type', async () => {
+      claim({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { type: 'white' } });
+      const wine = { _id: W1, name: 'Sauvignon Blanc', producer: 'Screaming Eagle', type: 'red', country: 'c1', save: jest.fn().mockResolvedValue(undefined) };
+      WineDefinition.findById.mockResolvedValue(wine);
+
+      const res = await post(`/${P1}/approve`);
+      expect(res.status).toBe(200);
+      expect(wine.type).toBe('white');
+      expect((await res.json()).appliedNote).toMatch(/type/);
+    });
+
+    test('refuses a type outside the enum instead of letting save() reject it', async () => {
+      claim({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { type: 'orange' } });
+      const wine = { _id: W1, name: 'X', producer: 'Y', type: 'red', country: 'c1', save: jest.fn() };
+      WineDefinition.findById.mockResolvedValue(wine);
+
+      const res = await post(`/${P1}/approve`);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/Unknown wine type "orange"/);
+      expect(wine.save).not.toHaveBeenCalled();
+    });
+
+    test('resolves grape NAMES to taxonomy ids and stores the ids', async () => {
+      resolveGrapeIdsStrict.mockResolvedValue({ ok: true, ids: ['g1', 'g2'], names: ['Chenin Blanc', 'Chardonnay'], substitutions: [] });
+      claim({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { grapes: ['Chenin Blanc', 'Chardonnay'] } });
+      const wine = { _id: W1, name: 'Les Pélioches', producer: 'Clos des Bretèches', grapes: ['old'], country: 'c1', save: jest.fn().mockResolvedValue(undefined) };
+      WineDefinition.findById.mockResolvedValue(wine);
+
+      const res = await post(`/${P1}/approve`);
+      expect(res.status).toBe(200);
+      expect(resolveGrapeIdsStrict).toHaveBeenCalledWith(['Chenin Blanc', 'Chardonnay']);
+      // REPLACES the list rather than appending to it.
+      expect(wine.grapes).toEqual(['g1', 'g2']);
+    });
+
+    test('an unknown variety is a 400, never a minted Grape — same rule as country', async () => {
+      resolveGrapeIdsStrict.mockResolvedValue({ ok: false, unmatched: ['Cabernet Blanc'] });
+      claim({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { grapes: ['Cabernet Blanc'] } });
+      const wine = { _id: W1, name: 'X', producer: 'Y', country: 'c1', save: jest.fn() };
+      WineDefinition.findById.mockResolvedValue(wine);
+
+      const res = await post(`/${P1}/approve`);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/Unknown grape "Cabernet Blanc" — add it in Admin → Taxonomy first/);
+      expect(wine.save).not.toHaveBeenCalled();
+    });
+
+    test('says so in the receipt when a synonym was folded to its canonical name', async () => {
+      resolveGrapeIdsStrict.mockResolvedValue({
+        ok: true, ids: ['g1'], names: ['Tempranillo'],
+        substitutions: [{ from: 'Tinta Roriz', to: 'Tempranillo' }],
+      });
+      claim({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { grapes: ['Tinta Roriz'] } });
+      const wine = { _id: W1, name: 'X', producer: 'Y', country: 'c1', save: jest.fn().mockResolvedValue(undefined) };
+      WineDefinition.findById.mockResolvedValue(wine);
+
+      const res = await post(`/${P1}/approve`);
+      expect(res.status).toBe(200);
+      expect((await res.json()).appliedNote).toMatch(/Tinta Roriz → Tempranillo/);
+    });
+
+    test('both are profile-feeding, so a real change triggers the re-enrich follow-through', async () => {
+      resolveGrapeIdsStrict.mockResolvedValue({ ok: true, ids: ['g1'], names: ['Chenin Blanc'], substitutions: [] });
+      claim({ _id: P1, kind: 'field_correction', wineDefinition: W1, proposedFields: { type: 'white', grapes: ['Chenin Blanc'] } });
+      const wine = { _id: W1, name: 'X', producer: 'Y', type: 'red', grapes: ['other'], country: 'c1', save: jest.fn().mockResolvedValue(undefined) };
+      WineDefinition.findById.mockResolvedValue(wine);
+
+      const res = await post(`/${P1}/approve`);
+      expect(res.status).toBe(200);
+      const { reenrichAfterRecordEdit } = require('../../services/enrichmentJob');
+      expect(reenrichAfterRecordEdit).toHaveBeenCalledWith(wine, true);
+    });
   });
 
   test('field_correction: values identical to the record do NOT regenerate the profile', async () => {

--- a/frontend/src/components/WineProposalsModal.js
+++ b/frontend/src/components/WineProposalsModal.js
@@ -22,6 +22,10 @@ const FIELD_KEYS = {
   region: 'admin.wines.proposals.fields.region',
   country: 'admin.wines.proposals.fields.country',
   classification: 'admin.wines.proposals.fields.classification',
+  // Proposable since 2026-08-19 (somm ticket 6a85ad44). Grapes arrive as a
+  // joined string from the route, so the generic diff row renders them as-is.
+  type: 'admin.wines.proposals.fields.type',
+  grapes: 'admin.wines.proposals.fields.grapes',
 };
 
 const wineLabel = (w) => (w ? [w.producer, w.name].filter(Boolean).join(' — ') : null);

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1720,7 +1720,9 @@
           "appellation": "Appellation",
           "region": "Region",
           "country": "Country",
-          "classification": "Classification"
+          "classification": "Classification",
+          "type": "Type",
+          "grapes": "Grapes"
         },
         "drift": "was \"{{value}}\" when proposed",
         "mergeInto": "Merge into:",


### PR DESCRIPTION
#1039 shipped a detector for a defect the curator has **no tool to repair**. It finds wines whose stored `type` contradicts every grape on them — 13 of them live right now — but `propose_wine_correction` accepted producer, name, appellation, region, country and classification only. `type` and `grapes` were the two identity fields with no route through the proposal pipeline, so all 13 have to come back to an admin by hand. Secrets-de-Colignac has sat on the backlog for weeks for exactly this reason.

### What changes
| | |
|---|---|
| **MCP** | `proposed_fields` gains `type` (the `WINE_TYPES` enum) and `grapes` (a **replacement** list of variety names). Grapes resolve against the taxonomy **at file time** via `resolveGrapeIdsStrict` — the same helper `set_wine_profile` writes through — so a typo is refused while the curator is still looking at the wine, and the proposal stores the **canonical** names rather than a synonym the admin would have to decode. |
| **Approve** | Re-validates and re-resolves rather than trusting what was stored: taxonomy moves between filing and approval (17 varieties were merged into their canonical entry on 2026-08-19 alone), and this route is the only real guarantee. **Match-only, never minting** — the rule `country` already follows. A folded synonym is named in the receipt (`Tinta Roriz → Tempranillo`) instead of being silently stored. |
| **Snapshot** | `currentSnapshot` carries both, or the admin drift check reports every such proposal as drifted against `undefined`. |
| **Review UI** | The diff sends grapes as joined names on both sides, so the modal needed two labels and no list-aware branch. |

Both fields are profile-feeding, so an approved change hands the wine to the existing re-enrich follow-through — verified against the **real** `profileInputsSnapshot`, not a mirror of it.

### Deliberately not in scope
`suggest_wine_correction` (the any-user tool) is unchanged. It validates its field list explicitly, so nothing leaks through, and opening it up needs form controls that don't exist yet — a type dropdown and a grape picker on the public "Suggest a fix" surface. The model and approve path already support it whenever we want that.

### Tests
- 6 new route tests (type applied, bad enum refused before `save()`, names→ids, unknown variety is a 400 not a mint, synonym named in the receipt, re-enrich fires)
- 4 new MCP tests (type filed, synonym canonicalised, unknown variety refused at file time, snapshot carries both)
- 66 backend suites / 896 tests and 63 frontend files / 990 tests pass

### ⚠️ MCP schema change
`proposed_fields` gains two properties, so the sommelier needs a fresh conversation — the same one they already need for `uphold`, the analytics tools and #1039's new hold reason.