### PR TITLE
chore(release): v1.141.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.140.0",
+  "version": "1.141.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.140.0",
+      "version": "1.141.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.140.0",
+  "version": "1.141.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.140.0",
+  "version": "1.141.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.140.0",
+      "version": "1.141.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.140.0",
+  "version": "1.141.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only — 4 files, 6 lines.

Ships **#1041**, which merged after the v1.140.0 bump and so missed that release: the sommelier can now propose `type` and `grapes`. Those were the only two identity fields with no route through the correction pipeline, which is why every colour conflict #1039 finds had to come back to an admin by hand.

**No migration. No compose change.** Backend-then-frontend swap as usual.

⚠️ Carries an **MCP schema change** (`proposed_fields` gains two properties), so the sommelier needs a fresh conversation — the same one they already need for `uphold`, the analytics tools and #1039's `grape_colour_conflict` hold reason.