### PR TITLE
chore(release): v1.142.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.141.0",
+  "version": "1.142.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.141.0",
+      "version": "1.142.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.141.0",
+  "version": "1.142.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.141.0",
+  "version": "1.142.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.141.0",
+      "version": "1.142.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.141.0",
+  "version": "1.142.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only.

Ships #1043: the producer-suspect verdict moves to its own field (`aiProfile.suspectDecision`) so a curator profile write can no longer silently close a row nobody judged, plus `list_colour_conflicts` so the 13 existing colour-conflict wines are reachable and countable over MCP.

⚠️ **Deploy step:** run `migrate-suspect-decisions.js` after the backend swap. It marks the 1 genuine uphold and returns ~23 profile-write rows to the queue.
⚠️ **MCP schema change** — one new tool, so the sommelier needs a fresh conversation.