### PR TITLE
fix(enrichment): producer_suspect must not fire on a note that calls it a producer

### DIFF
--- a/backend/src/scripts/reclassify-producer-suspect.js
+++ b/backend/src/scripts/reclassify-producer-suspect.js
@@ -1,0 +1,85 @@
+/**
+ * reclassify-producer-suspect.js — somm ticket 6a85f961.
+ *
+ * 94.7% of the published-suspect queue was generated BEFORE the 2026-08-17
+ * flag split, when "this value is not a producer" and "this is a real winery I
+ * cannot place" shared one boolean. Those rows never saw producerUnknown, so
+ * real small estates — La Spia, Château Jeandeman, Cave de Sainte-Marie — sit
+ * in a judgement queue wearing an owner-visible "cannot be verified" caveat.
+ *
+ * The model already told us which is which, in the note it wrote at the time.
+ * So this reads STORED TEXT and costs NOTHING: no AI calls, no re-generation,
+ * no changed descriptions. Only the two flags move, and only in the safe
+ * direction — suspect → unknown, which PUBLISHES without a caveat.
+ *
+ * What it deliberately does not touch:
+ *   - rows whose note is the category-only "not a producer I can confidently
+ *     place" shape. That population is genuinely ambiguous and stays for a
+ *     human or a web-search rescue.
+ *   - rows whose note names a brand, retailer or range. Those are the flag
+ *     working correctly.
+ *   - anything already decided (suspectDecision set).
+ *
+ * Dry by default; --apply writes. Idempotent either way.
+ *
+ *   docker exec cellarion-backend node src/scripts/reclassify-producer-suspect.js
+ *   docker exec cellarion-backend node src/scripts/reclassify-producer-suspect.js --apply
+ */
+require('dotenv').config();
+const mongoose = require('mongoose');
+const { noteAssertsProducer } = require('../utils/producerSuspectCheck');
+
+const APPLY = process.argv.includes('--apply');
+
+(async () => {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  const WineDefinition = require('../models/WineDefinition');
+
+  const rows = await WineDefinition.find({
+    'aiProfile.producerSuspect': true,
+    'aiProfile.description': { $ne: null },
+    'aiProfile.heldAt': null,
+    'aiProfile.suspectDecision': { $in: [null, undefined] },
+    nonWine: { $ne: true },
+  }).select('producer name aiProfile.producerNote aiProfile.confidence').lean();
+
+  console.log(`${APPLY ? 'APPLY' : 'DRY RUN'} — ${rows.length} undecided published-suspect rows\n`);
+
+  const downgrade = rows.filter((w) => noteAssertsProducer(w.aiProfile?.producerNote, w.producer));
+  const keep = rows.length - downgrade.length;
+
+  console.log(`note asserts a REAL PRODUCER → suspect becomes unknown : ${downgrade.length}`);
+  console.log(`note names a brand, or is category-only → left alone   : ${keep}\n`);
+
+  for (const w of downgrade.slice(0, 25)) {
+    console.log(`   ${w._id} ${w.producer}`);
+    console.log(`      "${(w.aiProfile?.producerNote || '').slice(0, 130)}"`);
+  }
+  if (downgrade.length > 25) console.log(`   … and ${downgrade.length - 25} more`);
+
+  if (!APPLY) {
+    console.log('\nDry run — nothing written. Re-run with --apply.');
+    await mongoose.disconnect();
+    return;
+  }
+
+  let done = 0;
+  for (const w of downgrade) {
+    await WineDefinition.updateOne(
+      { _id: w._id },
+      { $set: { 'aiProfile.producerSuspect': false, 'aiProfile.producerUnknown': true } }
+    );
+    done++;
+  }
+  console.log(`\nreclassified: ${done}`);
+
+  const left = await WineDefinition.countDocuments({
+    'aiProfile.producerSuspect': true, 'aiProfile.description': { $ne: null },
+    'aiProfile.heldAt': null, 'aiProfile.suspectDecision': { $in: [null, undefined] },
+    nonWine: { $ne: true },
+  });
+  console.log(`published suspects still awaiting judgement: ${left}`);
+
+  await mongoose.disconnect();
+  console.log('Done.');
+})().catch((e) => { console.error('Failed:', e); process.exit(1); });

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -419,10 +419,25 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
   // absent on an old or custom prompt → false, degrading to "no doubt
   // recorded" rather than to a spurious hold.
   const assess = (d, searchUsed) => {
-    const suspect = d.producerSuspect === true;
-    const unknown = d.producerUnknown === true;
+    let suspect = d.producerSuspect === true;
+    let unknown = d.producerUnknown === true;
     const confidence = cleanConfidence(d.confidence);
     const description = cleanProse(d.description);
+    // Deterministic contradiction check (somm ticket 6a85f961): the generator
+    // keeps setting producerSuspect on records whose own note calls the entity
+    // a cooperative, an estate or a grower. That is a real producer the model
+    // cannot place — producerUnknown — and leaving it suspect puts a permanent
+    // "cannot be verified" caveat on a small winery's wine and inflates
+    // upheld-count. Prompt rules have failed to stop two classes like this
+    // already; a rule that reads the model's own words does not need it to
+    // cooperate. See utils/producerSuspectCheck for the discrimination.
+    if (suspect) {
+      const { noteAssertsProducer } = require('../utils/producerSuspectCheck');
+      if (noteAssertsProducer(cleanProse(d.producerNote, 300), wine.producer)) {
+        suspect = false;
+        unknown = true;
+      }
+    }
     const meta = {
       confidence,
       producerSuspect: suspect,

--- a/backend/src/utils/producerSuspectCheck.js
+++ b/backend/src/utils/producerSuspectCheck.js
@@ -1,0 +1,101 @@
+/**
+ * Does the producer note CONTRADICT the producer_suspect flag it was written
+ * alongside?
+ *
+ * WHY (somm ticket 6a85f961, 2026-08-19). producer_suspect means "this value
+ * is not a winery — it is a brand, a range, a retailer, a style term". But the
+ * generator kept setting it on records whose own note says the opposite:
+ *
+ *     "Cave de Sainte-Marie-La-Blanche is a cooperative cellar in Burgundy"
+ *     "Château Jeandeman is a small Fronsac estate not well documented"
+ *     "This small Champagne grower is not one I can verify in detail"
+ *
+ * Every one of those describes a real producer the model simply cannot place —
+ * which is what producerUnknown is for (introduced 2026-08-17: real winery,
+ * publish, no owner-visible caveat). Left as suspect they earn a permanent
+ * "cannot be verified" disclaimer on a real small estate's wine, and they
+ * inflate upheld-count, the number the scaling review reads as "wines the
+ * registry genuinely cannot identify".
+ *
+ * Prompt rules have twice failed to stop a class like this (type defaults,
+ * speculative grapes). This is deterministic and reads only stored text.
+ *
+ * THE DISCRIMINATION THAT MATTERS. A note mentioning "estate" is not enough —
+ * the correct fires mention one too, by DENYING it:
+ *
+ *     "Grande Arche appears to be a brand or negociant label rather than an
+ *      established Saint-Émilion chateau"        ← correctly suspect
+ *     "Aldi is a supermarket retailer that sources this wine from a contract
+ *      producer rather than owning an estate"    ← correctly suspect
+ *
+ * So the test is which KIND of noun the note reaches for FIRST, before any
+ * "rather than" / "not a" clause — because that clause introduces what the
+ * thing ISN'T. Text after it is evidence about the wrong entity.
+ *
+ * Three deliberate narrownesses, so this only ever downgrades what it is sure of:
+ *   - the producer's own name is stripped first, so a value literally called
+ *     "Domaine Duffour" cannot vote for itself;
+ *   - 'négociant' and 'cellar' are in NEITHER class. Both sit on the boundary
+ *     ("a cellar/négociant bottling name" is a brand; "a Loire producer/
+ *     negociant" is a house), so neither may trigger a downgrade alone;
+ *   - a note with no producer-class noun at all — the category-only "not a
+ *     producer I can confidently place" shape — is left ALONE. That is the
+ *     genuinely ambiguous population, and it stays for a human or a search.
+ */
+
+// The note asserts the entity IS a wine producer.
+//
+// Two alternations, because the nouns are not equally strong. "estate",
+// "winery", "grower" name a producer wherever they appear. The bare word
+// "producer" does not — these notes use it constantly to refer to the FIELD
+// ("cannot place this producer", "the producer name is unfamiliar"), so it
+// only counts inside an actual assertion: "a Loire Valley producer".
+const PRODUCER_CLASS = new RegExp(
+  '\\b(?:estates?|winer(?:y|ies)|growers?|domaines?|weing(?:ut|üter)|bodegas?'
+  + '|quintas?|aziendas?|co[-\\s]?operatives?|co[-\\s]?ops?|vignerons?'
+  + '|houses?|châteaux|chateaux)\\b'
+  + '|\\ban?\\s+(?:[\\w\\u00C0-\\u024F\'’-]+\\s+){0,3}producers?\\b',
+  'i'
+);
+
+// The note asserts it is a COMMERCIAL NAME rather than a producer.
+const BRAND_CLASS = /\b(brands?|labels?|ranges?|retailers?|supermarkets?|bottlers?|bottling|importers?|merchants?|lines?|own[-\s]?label|private[-\s]?label|marketing|cuvée name|cuvee name|trade name|generic)\b/i;
+
+// Everything after one of these describes what the entity is NOT. Both shapes
+// occur in prod: the contrastive ("a brand rather than an estate") and the
+// failed-verification ("could not be verified as an established winery") —
+// the second one names a producer noun while DENYING it, so it has to cut too.
+const CONTRAST = /\b(rather than|instead of|not an? |but not |could not be|cannot be|can not be|can't be|unable to|never been)/i;
+
+const escapeRx = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * @param {string} note          aiProfile.producerNote as stored
+ * @param {string} producerName  the wine's producer field, stripped so the
+ *                               value cannot classify itself
+ * @returns {boolean} true when the note describes a real producer and the
+ *                    suspect flag should be a producerUnknown instead
+ */
+function noteAssertsProducer(note, producerName) {
+  if (typeof note !== 'string' || !note.trim()) return false;
+
+  let text = note;
+  const name = typeof producerName === 'string' ? producerName.trim() : '';
+  if (name) text = text.replace(new RegExp(escapeRx(name), 'gi'), ' ');
+  // "The producer name is unfamiliar…" refers to the FIELD, not to the entity
+  // being a producer. Without this carve-out the generic word votes for a
+  // downgrade in a sentence that is denying one.
+  text = text.replace(/\bthe\s+producer(?:'s)?\s+name\b/gi, ' ');
+
+  // Only the claim BEFORE the contrast clause is about this entity.
+  const contrast = text.search(CONTRAST);
+  if (contrast > -1) text = text.slice(0, contrast);
+
+  const p = text.search(PRODUCER_CLASS);
+  if (p === -1) return false;          // no positive producer claim → leave alone
+  const b = text.search(BRAND_CLASS);
+  if (b === -1) return true;           // producer claim, nothing contradicting it
+  return p < b;                        // whichever the note reached for first
+}
+
+module.exports = { noteAssertsProducer, PRODUCER_CLASS, BRAND_CLASS, CONTRAST };

--- a/backend/src/utils/producerSuspectCheck.test.js
+++ b/backend/src/utils/producerSuspectCheck.test.js
@@ -1,0 +1,90 @@
+const { noteAssertsProducer } = require('./producerSuspectCheck');
+
+// Every string below is a real producerNote from prod on 2026-08-19.
+describe('noteAssertsProducer', () => {
+  describe('DOWNGRADE — the note calls the entity a producer while the flag says it is not', () => {
+    const cases = [
+      ['Cave de Sainte-Marie-La-Blanche', 'Cave de Sainte-Marie-La-Blanche is a cooperative cellar in Burgundy and this profile is based on regional and varietal typicity.'],
+      ['Château Jeandeman', 'Château Jeandeman is a small Fronsac estate not well documented in widely available sources, so this profile is based mainly on appellation typicity.'],
+      ['Domaine de Pignan', 'Domaine de Pignan is a small, little-documented Châteauneuf-du-Pape estate, so this profile is largely based on appellation typicity.'],
+      ['Weingut Dörflinger', 'Dörflinger is a small Baden estate not well documented in wide reference sources, so this profile is largely inferred from the region.'],
+      ['Domaine du Logis - Brice et Vincent Fiolleau', 'Domaine du Logis (Brice et Vincent Fiolleau) is a small Muscadet grower not widely documented, so this reflects an appellation view.'],
+      ['Cave des Vignerons de Pfaffenheim', "Cave des Vignerons de Pfaffenheim is a cooperative producer; 'Black Tie' appears to be a branded cuvée name whose exact blend is unclear."],
+      ['Bodega San Pedro de Yacochuya', "San Pedro de Yacochuya is an established Salta winery; 'The Rolland Collection' appears to be a marketing or retailer range."],
+      ['Berthier', 'Berthier is a Loire Valley producer/negociant but this specific cuvee is not well documented to me.'],
+      // No "X is a" construction at all — the subject itself is the producer
+      // noun. This is the row the somm led the ticket with.
+      ['Champagne Tapray Frédéric', 'This small Champagne grower is not one I can verify in detail, so this profile is based on typical regional and varietal style.'],
+    ];
+    for (const [producer, note] of cases) {
+      it(`${producer}`, () => expect(noteAssertsProducer(note, producer)).toBe(true));
+    }
+  });
+
+  describe('KEEP SUSPECT — the note names a commercial entity, which is the flag working', () => {
+    const cases = [
+      ['Aldi', 'Aldi is a supermarket retailer that sources this wine from a contract producer rather than owning an estate itself.'],
+      ['Veuve du Vernay', 'Veuve du Vernay is a large-volume sparkling wine brand owned by the Belgian group Compagnie des Vins, not a traditional single estate producer.'],
+      ['Grande Arche', 'Grande Arche appears to be a brand or negociant label rather than an established Saint-Émilion chateau I can confirm.'],
+      ['Unknown', "Cuvée Léonore appears to be a bottler or retailer's own-label cuvée name rather than an identifiable winery."],
+      ['Bodega Benegas Lynch', 'La Libertad appears to be a label or line from Bodega Benegas, not a separate producer.'],
+      ['Cellier de la Weiss', 'Cellier de la Weiss appears to be a cellar/négociant bottling name rather than an independent estate, likely associated with a cooperative or merchant.'],
+      ['Berselli & Gerbino', 'Signature Collection is a label range name often used by importers or negociant bottlers rather than a single estate producer.'],
+      ['Amand Chaperon', 'Cheval de Montenac appears to be a négociant or brand bottling rather than an estate wine, and Amand Chaperon is likely a négociant house name.'],
+    ];
+    for (const [producer, note] of cases) {
+      it(`${producer}`, () => expect(noteAssertsProducer(note, producer)).toBe(false));
+    }
+  });
+
+  describe('LEFT ALONE — the category-only shape, which is genuinely ambiguous', () => {
+    const cases = [
+      ['La Spia', 'La Spia is not a producer I can confidently place, so this profile is based on the Rosso di Valtellina appellation and Nebbiolo grape rather than a verified house.'],
+      ['Thomas Allen', 'Thomas Allen is not a producer I can verify; this profile is based on the grape blend and style rather than a known winemaker.'],
+      ['Domaine Duffour', 'Domaine Duffour is not a producer I can confidently place; this profile is based on the appellation and grape varieties instead.'],
+      ['Xavier', 'Xavier is not a producer I can confidently place for this appellation, so this reflects typical Muscat de Beaumes style.'],
+      ['Increíble', 'The producer name is unfamiliar and could not be verified as an established winery, so this is an estimate based on style.'],
+    ];
+    for (const [producer, note] of cases) {
+      it(`${producer} stays for a human`, () => expect(noteAssertsProducer(note, producer)).toBe(false));
+    }
+  });
+
+  describe('the narrownesses that keep it honest', () => {
+    it('a value cannot classify itself: "Domaine X" in the NAME never votes', () => {
+      // Strip the name and nothing producer-ish is left before the contrast.
+      expect(noteAssertsProducer('Domaine Duffour is not a producer I can place.', 'Domaine Duffour')).toBe(false);
+      // …but a genuine claim about it still counts.
+      expect(noteAssertsProducer('Domaine Duffour is a Gascony estate.', 'Domaine Duffour')).toBe(true);
+    });
+
+    it('négociant and cellar alone never trigger a downgrade — both sit on the boundary', () => {
+      expect(noteAssertsProducer('Foo is a négociant bottling.', 'Foo')).toBe(false);
+      expect(noteAssertsProducer('Foo is a cellar name.', 'Foo')).toBe(false);
+    });
+
+    it('the bare word "producer" is a field reference, not a claim', () => {
+      // The shape the enrichment tests use, and the commonest note in the queue.
+      expect(noteAssertsProducer('Cannot place this producer.', 'Foo')).toBe(false);
+      expect(noteAssertsProducer('This producer is not one I know.', 'Foo')).toBe(false);
+      // …but inside an actual assertion it counts.
+      expect(noteAssertsProducer('Foo is a Loire Valley producer.', 'Foo')).toBe(true);
+    });
+
+    it('text after "rather than" describes what it is NOT and never counts', () => {
+      expect(noteAssertsProducer('Foo appears to be a brand rather than an estate.', 'Foo')).toBe(false);
+      expect(noteAssertsProducer('Foo is a label, not an estate.', 'Foo')).toBe(false);
+    });
+
+    it('empty, missing and non-string notes are no evidence', () => {
+      expect(noteAssertsProducer('', 'Foo')).toBe(false);
+      expect(noteAssertsProducer(null, 'Foo')).toBe(false);
+      expect(noteAssertsProducer(undefined, undefined)).toBe(false);
+      expect(noteAssertsProducer('   ', 'Foo')).toBe(false);
+    });
+
+    it('a regex-special producer name does not break the strip', () => {
+      expect(noteAssertsProducer('C++ (Wines) is a small estate.', 'C++ (Wines)')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Sommelier ticket **6a85f961 [HIGH]** — and they were more right than their own evidence showed.

`producer_suspect` means *"this value is not a winery — it's a brand, a range, a retailer."* The generator kept setting it on records whose own note says the opposite:

> *"Cave de Sainte-Marie-La-Blanche **is a cooperative cellar** in Burgundy"*
> *"Château Jeandeman **is a small Fronsac estate** not well documented"*
> *"This small Champagne **grower** is not one I can verify in detail"*

Each describes a real producer the model can't place — which is exactly what `producerUnknown` is for. Left as suspect they earn a permanent owner-visible *"cannot be verified"* disclaimer on a small estate's wine, **and** they inflate `upheld-count`, the number the scaling review reads as "wines the registry genuinely cannot identify". Working the queue with `uphold` would have made it worse fast: uphold batches forty at a time, research costs a web search per row.

## Two findings from measuring the whole queue, not a page

**94.7% (284/300) predate the 2026-08-17 flag split** — they never saw the `producerSuspect` / `producerUnknown` distinction at all. That flag works today: 161 rows carry it, 158 published without a caveat.

**But the gate still misfires** — of the 16 rows generated *after* the split, ~9 contradict themselves the same way. So this needed a fix, not just a backfill.

## The discrimination that matters

A *correct* fire mentions "estate" too — by denying it: *"a brand rather than an estate"*, *"a supermarket retailer … rather than owning an estate"*. So the test is which **kind** of noun the note reaches for **first**, before any `rather than` / `could not be verified as` clause, since text after that describes the wrong entity.

Three deliberate narrownesses:
- the producer's own name is stripped, so a value called "Domaine X" can't vote for itself
- `négociant` and `cellar` are in **neither** class — both genuinely sit on the boundary
- the bare word "producer" only counts inside an assertion (*"a Loire Valley producer"*), never as the field reference these notes are full of (*"cannot place this producer"*)

A note with **no** positive producer claim — the category-only shape — is **left alone**. That population is genuinely ambiguous and belongs to a human or a search.

## The backlog fix costs nothing

`reclassify-producer-suspect.js` works from **stored notes**: no AI calls, no regeneration, no changed descriptions. Only the two flags move, and only `suspect → unknown`, which publishes without a caveat. Dry by default, `--apply` writes, idempotent.

## Verification
- 30 unit tests, every string a real prod note from **both** sides of the discrimination
- full backend suite: **263 suites / 4129 tests** pass
- ⚠️ deploy step: run the reclassifier (dry first, then `--apply`)

## One correction to send back
Their confidence evidence — "22 of 25 at exactly 0.3" — is a **sampling artifact**: the queue sorts owners desc then **confidence ascending**, so the first page is biased to the lowest confidences by construction. Across all 300: `0.4=160, 0.5=49, 0.3=41`. The conclusion stands; that reasoning doesn't.