### PR TITLE
chore(release): v1.143.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.142.0",
+  "version": "1.143.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.142.0",
+      "version": "1.143.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.142.0",
+  "version": "1.143.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.142.0",
+  "version": "1.143.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.142.0",
+      "version": "1.143.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.142.0",
+  "version": "1.143.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only.

Ships #1045: `producer_suspect` no longer fires on records whose own note calls the entity a cooperative, estate or grower — those are real producers the model cannot place, which is what `producerUnknown` is for.

⚠️ **Deploy step:** run `reclassify-producer-suspect.js` (dry first, then `--apply`). It works from stored notes — no AI calls.