### PR TITLE
fix(enrichment): three false downgrades the prod dry run caught

### DIFF
--- a/backend/src/utils/producerSuspectCheck.js
+++ b/backend/src/utils/producerSuspectCheck.js
@@ -50,13 +50,21 @@
 // "producer" does not — these notes use it constantly to refer to the FIELD
 // ("cannot place this producer", "the producer name is unfamiliar"), so it
 // only counts inside an actual assertion: "a Loire Valley producer".
+// DELIBERATELY CASE-SENSITIVE, lowercase only. A capitalised producer noun is
+// part of a proper NAME, not a claim about the entity — "Davey Estate appears
+// to be a label", "Domaine des Granges de Mirabel appears to be a Pays d'Oc
+// label". Both are the flag working correctly, and matching the capital
+// inverted them. "is a small Fronsac estate" is the claim, and it is lowercase.
 const PRODUCER_CLASS = new RegExp(
   '\\b(?:estates?|winer(?:y|ies)|growers?|domaines?|weing(?:ut|üter)|bodegas?'
   + '|quintas?|aziendas?|co[-\\s]?operatives?|co[-\\s]?ops?|vignerons?'
   + '|houses?|châteaux|chateaux)\\b'
-  + '|\\ban?\\s+(?:[\\w\\u00C0-\\u024F\'’-]+\\s+){0,3}producers?\\b',
-  'i'
+  + '|\\ban?\\s+(?:[\\w\\u00C0-\\u024F\'’-]+\\s+){0,3}producers?\\b'
 );
+
+// "a house or cuvee name", "a bottling name" — the noun describes a NAME,
+// which is the brand reading however producer-ish the noun looks alone.
+const NAME_PHRASE = /^.{0,24}\bnames?\b/i;
 
 // The note asserts it is a COMMERCIAL NAME rather than a producer.
 const BRAND_CLASS = /\b(brands?|labels?|ranges?|retailers?|supermarkets?|bottlers?|bottling|importers?|merchants?|lines?|own[-\s]?label|private[-\s]?label|marketing|cuvée name|cuvee name|trade name|generic)\b/i;
@@ -65,7 +73,7 @@ const BRAND_CLASS = /\b(brands?|labels?|ranges?|retailers?|supermarkets?|bottler
 // occur in prod: the contrastive ("a brand rather than an estate") and the
 // failed-verification ("could not be verified as an established winery") —
 // the second one names a producer noun while DENYING it, so it has to cut too.
-const CONTRAST = /\b(rather than|instead of|not an? |but not |could not be|cannot be|can not be|can't be|unable to|never been)/i;
+const CONTRAST = /\b(rather than|instead of|not an? |but not |could not be|cannot be|can not be|can't be|unable to|never been|does not|do not|did not|no longer)/i;
 
 const escapeRx = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -93,6 +101,9 @@ function noteAssertsProducer(note, producerName) {
 
   const p = text.search(PRODUCER_CLASS);
   if (p === -1) return false;          // no positive producer claim → leave alone
+  // "a house or cuvee name" — naming a name, not an entity.
+  const matched = text.slice(p).match(PRODUCER_CLASS)?.[0] || '';
+  if (NAME_PHRASE.test(text.slice(p + matched.length))) return false;
   const b = text.search(BRAND_CLASS);
   if (b === -1) return true;           // producer claim, nothing contradicting it
   return p < b;                        // whichever the note reached for first

--- a/backend/src/utils/producerSuspectCheck.test.js
+++ b/backend/src/utils/producerSuspectCheck.test.js
@@ -71,6 +71,23 @@ describe('noteAssertsProducer', () => {
       expect(noteAssertsProducer('Foo is a Loire Valley producer.', 'Foo')).toBe(true);
     });
 
+    // All three were FALSE DOWNGRADES the prod dry run caught on 2026-08-19,
+    // before anything was written. 46 rows would have moved; 3 of the first 25
+    // shown were wrong.
+    it('a capitalised producer noun is part of a proper NAME, not a claim', () => {
+      expect(noteAssertsProducer('Davey Estate appears to be a label or tier rather than a well-documented standalone producer.', 'Shingleback')).toBe(false);
+      expect(noteAssertsProducer("Domaine des Granges de Mirabel appears to be a Pays d'Oc entry-level label associated with Chapoutier.", 'M. Chapoutier')).toBe(false);
+    });
+
+    it('"does not match a known X house" is a denial, not a claim', () => {
+      expect(noteAssertsProducer('Carbon does not match a known Champagne house and may be a private label or brand name.', 'Carbon')).toBe(false);
+    });
+
+    it('a producer noun describing a NAME is the brand reading', () => {
+      expect(noteAssertsProducer('Émeraude appears to be a house or cuvee name rather than a widely recognised Champagne producer.', 'Dominique Crété')).toBe(false);
+      expect(noteAssertsProducer('Foo is a bottling name.', 'Foo')).toBe(false);
+    });
+
     it('text after "rather than" describes what it is NOT and never counts', () => {
       expect(noteAssertsProducer('Foo appears to be a brand rather than an estate.', 'Foo')).toBe(false);
       expect(noteAssertsProducer('Foo is a label, not an estate.', 'Foo')).toBe(false);


### PR DESCRIPTION
Ran `reclassify-producer-suspect.js` **dry against prod** before writing anything. 46 of 300 rows would have moved — and **three of the first twenty-five shown were wrong**. A 12% error rate on a rule whose whole job is to *remove* an owner-visible caveat.

All three are now pinned as tests:

| note | why it was wrong |
|---|---|
| *"**Davey Estate** appears to be a label or tier"* | the producer noun is part of a proper **name**, not a claim |
| *"**Domaine** des Granges de Mirabel appears to be a Pays d'Oc entry-level label"* | same |
| *"Carbon **does not match** a known Champagne house…"* | a denial, and the contrast pattern missed the construction |
| *"appears to be a house or cuvee **name**"* | the noun describes a name, not an entity |

**Fixes**
- matching is now **case-sensitive, lowercase-only** — *"is a small Fronsac estate"* is the claim; *"Davey Estate"* is a label's name
- `CONTRAST` also cuts at `does not` / `do not` / `did not` / `no longer`
- a producer noun followed closely by "name" reads as the brand

Each of the three failed **in the direction that matters**: it would have published a *brand* as a real producer and silently dropped the caveat. The inverse error — leaving a real estate in the queue — costs a curator one judgement, so the rule stays biased that way.

⚠️ v1.143.0 shipped the first version of this rule, so the gate on prod carries the same 12% and **the reclassifier was not run against it**.
