### PR TITLE
chore(release): v1.143.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.143.0",
+  "version": "1.143.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.143.0",
+      "version": "1.143.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.143.0",
+  "version": "1.143.1",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.143.0",
+  "version": "1.143.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.143.0",
+      "version": "1.143.1",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.143.0",
+  "version": "1.143.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only. Ships #1047: three false downgrades the prod dry run caught in v1.143.0's contradiction rule (proper-name capitals, `does not match` denials, and `<noun> name` phrases).

v1.143.0's gate carries a ~12% false-downgrade rate, and the reclassifier has **not** been run — this patch is a prerequisite for both.

⚠️ **Deploy step:** run `reclassify-producer-suspect.js` (dry, confirm, then `--apply`).
