### PR TITLE
fix(enrichment): never downgrade when the note says the field holds a place

### DIFF
--- a/backend/src/utils/producerSuspectCheck.js
+++ b/backend/src/utils/producerSuspectCheck.js
@@ -75,6 +75,18 @@ const BRAND_CLASS = /\b(brands?|labels?|ranges?|retailers?|supermarkets?|bottler
 // the second one names a producer noun while DENYING it, so it has to cut too.
 const CONTRAST = /\b(rather than|instead of|not an? |but not |could not be|cannot be|can not be|can't be|unable to|never been|does not|do not|did not|no longer)/i;
 
+// Notes saying the producer FIELD holds a place or an appellation, not a house.
+// These are the identity-blocking family (producer-is-appellation,
+// producer-is-region) and they must never downgrade, however many producer
+// nouns the sentence contains — both of the ones below were caught in the
+// second prod dry run, matching "estate" inside a clause that denies one:
+//
+//   "The producer field simply repeats the appellation name, so no specific
+//    estate can be identified"                                  (Monbazillac)
+//   "Turckheim is also the name of an Alsace village and a well known
+//    cooperative"                                               (Turckheim)
+const FIELD_IS_PLACE = /\b(repeats? the (appellation|region|village|commune)|is also the name of|simply repeats|no specific (estate|producer|winery|house))\b/i;
+
 const escapeRx = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
@@ -86,6 +98,9 @@ const escapeRx = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
  */
 function noteAssertsProducer(note, producerName) {
   if (typeof note !== 'string' || !note.trim()) return false;
+  // Checked on the RAW note, before any stripping: if the note says the field
+  // holds a place or an appellation, no later producer noun can rescue it.
+  if (FIELD_IS_PLACE.test(note)) return false;
 
   let text = note;
   const name = typeof producerName === 'string' ? producerName.trim() : '';

--- a/backend/src/utils/producerSuspectCheck.test.js
+++ b/backend/src/utils/producerSuspectCheck.test.js
@@ -88,6 +88,14 @@ describe('noteAssertsProducer', () => {
       expect(noteAssertsProducer('Foo is a bottling name.', 'Foo')).toBe(false);
     });
 
+    // Second prod dry run, 2026-08-19. Both matched "estate" inside a clause
+    // that DENIES one, and both are the identity-blocking family — the producer
+    // field holds a place or an appellation, which is the flag's core purpose.
+    it('a note saying the FIELD holds a place or appellation never downgrades', () => {
+      expect(noteAssertsProducer('The producer field simply repeats the appellation name, so no specific estate can be identified; this profile reflects the Monbazillac appellation style.', 'Monbazillac')).toBe(false);
+      expect(noteAssertsProducer('Turckheim is also the name of an Alsace village and a well known cooperative (Cave de Turckheim); without a specific cuvée it is unclear.', 'Turckheim')).toBe(false);
+    });
+
     it('text after "rather than" describes what it is NOT and never counts', () => {
       expect(noteAssertsProducer('Foo appears to be a brand rather than an estate.', 'Foo')).toBe(false);
       expect(noteAssertsProducer('Foo is a label, not an estate.', 'Foo')).toBe(false);


### PR DESCRIPTION
Second prod dry run of the contradiction rule, and **two more false downgrades** — both the identity-blocking family, which is the flag's whole reason for existing:

> *"The producer field **simply repeats the appellation name**, so no specific estate can be identified"* — Monbazillac
> *"Turckheim **is also the name of an Alsace village** and a well known cooperative"* — Turckheim

Both matched a producer noun sitting inside a clause that *denies* one. A note saying the producer field holds a place or an appellation can never be rescued by a later noun, so that check now runs **first, on the raw note**.

## Validated before shipping this time

Ran the candidate against **all 300** queue rows and reviewed every one of the 39 downgrades by hand. They are either plainly real producers (Château Jeandeman, Cave de Sainte-Marie-La-Blanche, Weingut Dörflinger, Vignerons Ardéchois) or the *"a real producer name, cannot tell which one"* shape (Chateau Bel Air, Sonnhof, Schmitt) — which is precisely what `producerUnknown` means: real winery, publish, no caveat.

46 → 41 → **39**, converged.

## Honest note
Three iterations on this rule, each caught by running it against real data rather than by the tests — which I had written from notes I'd already read, so they encoded the same blind spots. The dry-run-against-prod step is what found all five errors.
