### PR TITLE
chore(release): v1.143.2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.143.1",
+  "version": "1.143.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.143.1",
+      "version": "1.143.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.143.1",
+  "version": "1.143.2",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.143.1",
+  "version": "1.143.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.143.1",
+      "version": "1.143.2",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.143.1",
+  "version": "1.143.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only. Ships #1049: a note saying the producer field holds a place or an appellation can never downgrade, however many producer nouns follow it.

Validated against all 300 queue rows before release — 39 downgrades, each reviewed by hand.

⚠️ **Deploy step:** run `reclassify-producer-suspect.js --apply`.
