### PR TITLE
chore(release): v1.144.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.143.2",
+  "version": "1.144.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.143.2",
+      "version": "1.144.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.143.2",
+  "version": "1.144.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.143.2",
+  "version": "1.144.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.143.2",
+      "version": "1.144.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.143.2",
+  "version": "1.144.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump only. Ships #1051:

- **Delete and report photos** — the first time anyone (user *or* admin) can remove a single image. Ticket 6a865f60.
- **The AI stops counting deleted cellars** — a user with 71 bottles was being told 779. Ticket 6a86268f, affecting 4 users on prod.
- **`dismiss_colour_conflict` / `restore_colour_conflict`** plus the documented producer convention. Somm tickets 6a869911 and 6a8698d5.

⚠️ **MCP schema change** — two new tools, so the sommelier needs a fresh conversation.
No migration. No compose change.
