### PR TITLE
chore(release): v1.145.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.144.0",
+  "version": "1.145.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.144.0",
+      "version": "1.145.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.144.0",
+  "version": "1.145.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.144.0",
+  "version": "1.145.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.144.0",
+      "version": "1.145.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.144.0",
+  "version": "1.145.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for v1.145.0 — the enrichment work in #1053.

- `producer_suspect` no longer fires on notes that only report what the model could not verify (somm 6a86baca); 171 rows to be reclassified on prod, each tagged with the rule that moved it and readable back through the new `list_rule_downgrades`
- profiles now record the identity they were generated from, so a bulk edit that bypasses the re-enrich hook is detectable as staleness (somm 6a86bb3b)

⚠️ MCP schema change — the sommelier must reconnect the connector, not just start a fresh conversation.