### PR TITLE
fix(enrichment): the somm's full-population audit of the downgrade rule

### DIFF
--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1278,7 +1278,10 @@ registerTool({
     'profile REGENERATES under the human override and publishes; costs one AI call, and on generation failure the ' +
     'row simply stays in the queue for another try. decision "confirm": the CURRENT state is correct — a held row ' +
     'stays held (its owner keeps seeing "Not yet assessed"), a published_suspect row stays published WITH THE ' +
-    'SUSPECT FLAG CLEARED (a human adjudicated the doubt away). decision "uphold" (published_suspect rows only): ' +
+    'SUSPECT FLAG CLEARED (a human adjudicated the doubt away), and producerUnknown clears too when set — confirm ' +
+    'also works on a published row whose ONLY doubt flag is producerUnknown ("I have placed this producer"; the ' +
+    'route a documented estate needed once its profile was fixed but the flag had no verb). decision "uphold" ' +
+    '(published_suspect rows only): ' +
     'the flag is CORRECT — the producer value really is a brand/style/non-winery — so the row stays published, ' +
     'KEEPS the flag and the owner-visible caveat, and leaves the queue as the registry\'s honest residue; ' +
     'upheld-count is the true cannot-identify number the scaling review reads. decision "reject" (HELD rows only): ' +
@@ -1317,12 +1320,18 @@ registerTool({
     // semantics (and the stamp rule) cannot fork.
     const decideOne = async (id) => {
       const wine = await WineDefinition.findById(id)
-        .select('name producer aiProfile.heldAt aiProfile.heldReason aiProfile.producerSuspect aiProfile.description aiProfile.generatedAt aiProfile.source');
+        .select('name producer aiProfile.heldAt aiProfile.heldReason aiProfile.producerSuspect aiProfile.producerUnknown aiProfile.description aiProfile.generatedAt aiProfile.source');
       if (!wine) return { wine_id: id, error: 'not_found' };
       const ap = wine.aiProfile || {};
       const held = !!ap.heldAt;
       const flaggedPublished = !held && ap.producerSuspect === true && !!ap.description;
-      if (!held && !flaggedPublished) return { wine_id: id, error: 'nothing_to_review' };
+      // producerUnknown-only rows are confirmable too (somm 6a86dad6: a
+      // documented 180 ha estate carried the flag with no verb able to clear
+      // it — set_wine_profile writes the profile, not the doubt fields).
+      const unknownOnly = !held && !flaggedPublished && ap.producerUnknown === true;
+      if (!held && !flaggedPublished && !(unknownOnly && args.decision === 'confirm')) {
+        return { wine_id: id, error: 'nothing_to_review' };
+      }
       const label = `${wine.name} — ${wine.producer}`;
 
       if (args.decision === 'release') {
@@ -1346,17 +1355,35 @@ registerTool({
         // false "cannot be verified" disclaimer even after review). The
         // producerNote stays for curator context; only the flag clears.
         if (!held) {
-          set['aiProfile.producerSuspect'] = false;
-          // Record the verdict, not just its side effect. The flag going false
-          // already removes the row from the queue, but the decision is worth
-          // counting on its own — and it keeps confirm and uphold symmetrical.
-          set['aiProfile.suspectDecision'] = 'confirmed';
-          set['aiProfile.suspectDecidedAt'] = now;
+          if (flaggedPublished) {
+            set['aiProfile.producerSuspect'] = false;
+            // Record the verdict, not just its side effect. The flag going false
+            // already removes the row from the queue, but the decision is worth
+            // counting on its own — and it keeps confirm and uphold symmetrical.
+            set['aiProfile.suspectDecision'] = 'confirmed';
+            set['aiProfile.suspectDecidedAt'] = now;
+          }
+          // confirm also clears producerUnknown when set: the curator is
+          // saying "I have placed this producer", which is that flag's exact
+          // negation (somm 6a86dad6 — Haut-Marin). No suspectDecision stamp
+          // on an unknown-only row: that field is the verdict on
+          // producerSuspect, and ONLY that (6a85f5e8).
+          if (ap.producerUnknown === true) set['aiProfile.producerUnknown'] = false;
         }
         await WineDefinition.updateOne({ _id: wine._id }, { $set: set });
+        const state = held ? 'held' : (flaggedPublished ? 'published_suspect' : 'published_unknown');
+        const cleared = {
+          ...(flaggedPublished ? { suspectCleared: true } : {}),
+          ...(!held && ap.producerUnknown === true ? { unknownCleared: true } : {}),
+        };
         logAudit(ctx.req, 'admin.wine.profileReviewed', { type: 'wine', id: wine._id },
-          { name: wine.name, producer: wine.producer, decision: 'confirm', state: held ? 'held' : 'published_suspect', ...(held ? {} : { suspectCleared: true }), reason, via: 'mcp' });
-        return { wine_id: wine._id, label, decision: 'confirm', state: held ? 'held' : 'published_suspect', ...(held ? {} : { suspect_cleared: true }), reviewed_at: now };
+          { name: wine.name, producer: wine.producer, decision: 'confirm', state, ...cleared, reason, via: 'mcp' });
+        return {
+          wine_id: wine._id, label, decision: 'confirm', state,
+          ...(cleared.suspectCleared ? { suspect_cleared: true } : {}),
+          ...(cleared.unknownCleared ? { unknown_cleared: true } : {}),
+          reviewed_at: now,
+        };
       }
 
       if (args.decision === 'uphold') {
@@ -2681,7 +2708,10 @@ registerTool({
     'published without an owner-visible caveat. This list exists so a rule that turns out to be wrong can be found ' +
     'and reversed as a set instead of re-derived — spot-check a sample, and if a row should not have moved, ' +
     'propose_wine_correction or set_wine_profile still work on it normally. A row a HUMAN judged carries ' +
-    'suspectDecision instead and never appears here.',
+    'suspectDecision instead and never appears here. One documented semantic (audit 6a86dad6): the tag records ' +
+    'which rule FIRED under strongest-claim-first precedence, not which shape the note best fits — a note that ' +
+    'textually asserts a producer can carry the epistemic tag when the assertion regex did not match it; the ' +
+    'outcome is identical either way.',
   scope: 'read',
   requireRole: SOMM_ROLES,
   annotations: { readOnlyHint: true, openWorldHint: false },

--- a/backend/src/scripts/apply-epistemic-downgrade.js
+++ b/backend/src/scripts/apply-epistemic-downgrade.js
@@ -29,7 +29,12 @@
  */
 const mongoose = require('mongoose');
 const WineDefinition = require('../models/WineDefinition');
-const { noteAssertsProducer, noteIsEpistemicOnly, DOWNGRADE_RULES } = require('../utils/producerSuspectCheck');
+require('../models/Region');
+require('../models/Country');
+const {
+  noteAssertsProducer, noteIsEpistemicOnly,
+  notePlaceConflict, producerFieldLooksPlaceholder, DOWNGRADE_RULES,
+} = require('../utils/producerSuspectCheck');
 
 const APPLY = process.argv.includes('--apply');
 
@@ -41,12 +46,28 @@ const APPLY = process.argv.includes('--apply');
     'aiProfile.producerNote': { $ne: null },
     // A curator verdict outranks any rule.
     'aiProfile.suspectDecision': { $in: [null, undefined] },
+    // A curator-authored profile is a human judgement about this exact row —
+    // no rule overrides it (somm audit 6a86dad6: The Parish moved despite a
+    // curator verification two days earlier).
+    'aiProfile.source': { $ne: 'curator' },
     nonWine: { $ne: true },
-  }).select('name producer aiProfile.producerNote aiProfile.heldAt').lean();
+  })
+    .select('name producer appellation aiProfile.producerNote aiProfile.heldAt aiProfile.source')
+    .populate('region', 'name')
+    .populate('country', 'name')
+    .lean();
 
   const move = [];
+  let blockedCount = 0;
   for (const w of rows) {
     const note = w.aiProfile.producerNote || '';
+    // Blockers before rules — see the same composition at the enrichment
+    // write site (somm audit 6a86dad6: placeholder fields and place-conflict
+    // notes must stay suspect for a human).
+    if (
+      producerFieldLooksPlaceholder(w.producer, w.name) ||
+      notePlaceConflict(note, { region: w.region?.name, appellation: w.appellation, country: w.country?.name })
+    ) { blockedCount++; continue; }
     // Strongest claim first, so the two rules stay disjoint and the tag on
     // each row names the rule that actually decided it.
     if (noteAssertsProducer(note, w.producer)) {
@@ -55,6 +76,7 @@ const APPLY = process.argv.includes('--apply');
       move.push({ w, rule: DOWNGRADE_RULES.EPISTEMIC_ONLY });
     }
   }
+  console.log(`blocked from downgrading (placeholder / place conflict): ${blockedCount}`);
 
   const held = move.filter((m) => m.w.aiProfile.heldAt).length;
   console.log(`suspect rows considered : ${rows.length}`);

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -472,16 +472,35 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
     // cooperate. See utils/producerSuspectCheck for the discrimination.
     let downgradedBy = null;
     if (suspect) {
-      const { noteAssertsProducer, noteIsEpistemicOnly, DOWNGRADE_RULES } = require('../utils/producerSuspectCheck');
+      const {
+        noteAssertsProducer, noteIsEpistemicOnly,
+        notePlaceConflict, producerFieldLooksPlaceholder, DOWNGRADE_RULES,
+      } = require('../utils/producerSuspectCheck');
       const note = cleanProse(d.producerNote, 300);
+      // Blockers before rules (somm audit 6a86dad6: 14 of the first 166
+      // downgrades should not have moved). A placeholder producer field has
+      // nothing to verify, and a note grounding its estimate in a place the
+      // record contradicts is describing a different wine — downgrading
+      // either publishes the problem with its caveat removed. Blocked rows
+      // stay suspect and a human judges them.
+      const blocked =
+        producerFieldLooksPlaceholder(wine.producer, wine.name) ||
+        notePlaceConflict(note, {
+          region: wine.region?.name,
+          appellation: wine.appellation,
+          country: wine.country?.name,
+        });
       // Two disjoint rules, checked strongest-claim first. The second was the
       // population the first deliberately left alone on 2026-08-19; see
       // noteIsEpistemicOnly for why that call was reversed (somm 6a86baca).
-      if (noteAssertsProducer(note, wine.producer)) {
+      // The tag records which rule FIRED under this precedence, not which
+      // shape the note best fits — accepted trade (6a86dad6 part 2A) over
+      // loosening PRODUCER_CLASS, which shipped five false downgrades once.
+      if (!blocked && noteAssertsProducer(note, wine.producer)) {
         suspect = false;
         unknown = true;
         downgradedBy = DOWNGRADE_RULES.ASSERTS_PRODUCER;
-      } else if (noteIsEpistemicOnly(note, wine.producer)) {
+      } else if (!blocked && noteIsEpistemicOnly(note, wine.producer)) {
         suspect = false;
         unknown = true;
         downgradedBy = DOWNGRADE_RULES.EPISTEMIC_ONLY;

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -600,6 +600,52 @@ describe('the split flags end-to-end through enrichWine', () => {
     expect(p.heldReason).toBe('producer_suspect');
   });
 
+  // The epistemic downgrade rule and its blockers, end to end (v1.145 rule,
+  // v1.146 blockers from the somm's full-population audit 6a86dad6).
+  test('an epistemic note grounded in the record\'s own region downgrades to producerUnknown, tagged', async () => {
+    suggestProfile.mockResolvedValue(withFlags({
+      producerSuspect: true, confidence: 0.7,
+      producerNote: 'Matua is not a producer I can verify; this profile is based on the Marlborough region and grape typicity.',
+    }));
+    await enrichWineById(WINE_ID);
+    const p = persisted();
+    expect(p.producerSuspect).toBe(false);
+    expect(p.producerUnknown).toBe(true);
+    expect(p.suspectDowngradedBy).toBe('note_epistemic_only');
+    expect(p.heldAt).toBeNull(); // published — that is the point of the rule
+  });
+
+  test('an epistemic note grounded in a CONTRADICTING place blocks the downgrade — row stays held suspect', async () => {
+    // Audit class 1: the profile describes a different wine's geography.
+    // Downgrading would publish that fabrication with its caveat removed.
+    suggestProfile.mockResolvedValue(withFlags({
+      producerSuspect: true, confidence: 0.7,
+      producerNote: 'Matua is not a producer I can verify; this profile is estimated from the Champagne appellation and style.',
+    }));
+    await enrichWineById(WINE_ID);
+    const p = persisted();
+    expect(p.producerSuspect).toBe(true);
+    expect(p.suspectDowngradedBy).toBeNull();
+    expect(p.heldAt).toBeInstanceOf(Date);
+    expect(p.heldReason).toBe('producer_suspect');
+  });
+
+  test('a placeholder producer field blocks the downgrade — nothing to verify', async () => {
+    // Audit class 3: producer repeats the wine name as a bare word.
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: WINE_ID, name: 'Increíble', producer: 'Increíble', type: 'red',
+      country: { name: 'Spain' }, region: null, grapes: [],
+    }));
+    suggestProfile.mockResolvedValue(withFlags({
+      producerSuspect: true, confidence: 0.7,
+      producerNote: 'The producer name is unfamiliar and could not be verified as an established winery, so this is an estimate based on style.',
+    }));
+    await enrichWineById(WINE_ID);
+    const p = persisted();
+    expect(p.producerSuspect).toBe(true);
+    expect(p.suspectDowngradedBy).toBeNull();
+  });
+
   // Gate 2026-08-18 (ticket 6a83e765): the two confidence holds, end to end,
   // with the reason persisted where the release queue reads it.
   test('a below-floor profile is HELD with heldReason low_confidence', async () => {

--- a/backend/src/utils/producerSuspectCheck.js
+++ b/backend/src/utils/producerSuspectCheck.js
@@ -85,19 +85,18 @@ const CONTRAST = /\b(rather than|instead of|not an? |but not |could not be|canno
 //    estate can be identified"                                  (Monbazillac)
 //   "Turckheim is also the name of an Alsace village and a well known
 //    cooperative"                                               (Turckheim)
-// The third alternation was added 2026-08-20 from the epistemic-rule dry run,
-// which caught a note stating the value outright instead of by comparison:
-//   "Chateau Etoile is not a producer I can verify; Château d'Etoile / L'Etoile
-//    is an appellation in the Jura, so this may be a mislabeling"
-// Epistemic in form, but it names what the field actually is, so it is a real
-// suspicion. Requires "is a/an <place noun>" directly — "a producer in the
-// Chablis appellation" is a producer claim and must not match.
-// The lookbehind is load-bearing. Without it the alternation matches the
-// METHODOLOGY these notes end with, whose subject is the profile rather than
-// the producer, and a correct downgrade is blocked:
-//   "Montlobre is not a producer I can confidently place; this profile IS AN
-//    APPELLATION and style-level estimate."
-const FIELD_IS_PLACE = /\b(repeats? the (appellation|region|village|commune)|is also the name of|simply repeats|no specific (estate|producer|winery|house)|(?<!\bprofile )is (?:also )?an? (?:appellation|village|commune|sub[-\s]?region|region|denomination|AOC|DOC|DOCG))\b/i;
+// A third alternation briefly lived here (2026-08-20, same-day removal): "is
+// an appellation…", added when a dry run surfaced a note calling Chateau
+// Etoile's value an appellation. The sommelier's full-population audit
+// (ticket 6a86dad6) killed it twice over: Château de l'Étoile is a REAL Jura
+// estate whose name legitimately repeats its AOC — so the row the guard was
+// built to protect was a correct downgrade being blocked — and the guard
+// missed the prod note anyway, which uses the prepositional form ("not a
+// producer I can verify in the Jura appellation of L'Etoile"). A name
+// repeating a place is how half of Bordeaux is named; it is not evidence the
+// field holds a place. The alternations below survive because their shapes
+// state it outright ("simply repeats the appellation").
+const FIELD_IS_PLACE = /\b(repeats? the (appellation|region|village|commune)|is also the name of|simply repeats|no specific (estate|producer|winery|house))\b/i;
 
 const escapeRx = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -242,6 +241,92 @@ function noteIsEpistemicOnly(note, producerName) {
   return true;
 }
 
+// ── Downgrade blockers (somm audit 6a86dad6, 2026-08-20) ─────────────────────
+//
+// The full-population audit of the first 166 downgrades found 14 that should
+// not have moved. These two guards encode the two mechanical classes; they
+// BLOCK a downgrade (row stays suspect, caveat stays visible, a human judges)
+// and never fire one.
+
+/**
+ * The note grounds its estimate in a place the record contradicts.
+ *
+ * Four of the audit's 14 were this shape — the profile describes a different
+ * wine's geography, and downgrading published that fabrication with its
+ * caveat removed:
+ *
+ *   "…estimated from the Champagne appellation and style"   (Côtes de Gascogne)
+ *   "…based on general Champagne Demi-Sec style"            (Loire mousseux)
+ *   "…based on the Loire rosé style generally"              (Franche-Comté)
+ *   "…based on the grape and Île de Ré appellation style"   (Vin de France —
+ *                                                            no such appellation)
+ *
+ * Extraction, not vocabulary: the capitalised phrase in front of
+ * appellation/region/AOC/style is compared against the record's own place
+ * strings (region, appellation, country). An invented place ("Île de Ré")
+ * matches no curated list, so a vocabulary lookup could never catch the worst
+ * case; a non-match against the record catches it by construction. Substring
+ * comparison runs both ways so "Gascogne" grounds a "Côtes de Gascogne"
+ * record and vice versa.
+ *
+ * Direction of failure is deliberate: a false positive here keeps a row
+ * suspect for a human — annoying. A false negative publishes fiction with the
+ * caveat stripped — the thing the audit caught. When the record carries NO
+ * place at all, a note asserting one is grounded in nothing and blocks too
+ * (the 6a82bfb7 family).
+ */
+const PLACE_PHRASE = /\b([A-ZÀ-Þ][\wÀ-ɏ'’-]*(?:\s+[\wÀ-ɏ'’-]+){0,3})\s+(?:appellation|AOC|AOP|DOCG?|region|style)\b/g;
+
+const normPlace = (s) => String(s || '')
+  .normalize('NFD').replace(/[̀-ͯ]/g, '')
+  .toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+
+function notePlaceConflict(note, { region, appellation, country } = {}) {
+  if (typeof note !== 'string' || !note.trim()) return false;
+  const places = [region, appellation, country].map(normPlace).filter(Boolean);
+  let m;
+  PLACE_PHRASE.lastIndex = 0;
+  while ((m = PLACE_PHRASE.exec(note)) !== null) {
+    const captured = normPlace(m[1]);
+    if (!captured || captured.length < 3) continue;
+    // Generic sentence-start captures ("This", "The", "Expect") are not places.
+    if (/^(this|the|that|these|those|expect|its?|an?)\b/.test(captured) && !captured.includes(' ')) continue;
+    if (!places.length) return true; // asserting geography on a placeless record
+    const grounded = places.some((p) => p.includes(captured) || captured.includes(p));
+    if (!grounded) return true;
+  }
+  return false;
+}
+
+/**
+ * The producer field is a placeholder, not a name that could be verified.
+ *
+ * Five of the audit's 14: the field literally reads "Domaine unknown", or it
+ * simply repeats the wine's own name as a bare word ("Increíble" /
+ * "Increíble") — an import artifact, not an entity. producerUnknown means "a
+ * real winery name we cannot place"; a placeholder is not a name at all, so
+ * the honest flag is suspect and the honest fix is identification.
+ *
+ * The producer-type-prefix carve-out is the sommelier's own correction to
+ * their first proposal (ticket 6a86dad6 part 2C): bare producer == name would
+ * over-fire on the Bordeaux convention where the château IS the wine name
+ * (La Garricq, Rousset, Haut Barrail…). A prefixed name is a producer-shaped
+ * name; and their multi-word examples escape via the single-word requirement.
+ */
+const UNKNOWN_WORD = /\b(unknown|unbekannt|okänd|inconnue?|sconosciuto|desconocido)\b/i;
+const PRODUCER_PREFIX = /^(ch[âa]teau|domaine|dom\.|quinta|weingut|bodegas?|tenuta|azienda|cascina|clos|mas|castello|villa|cantina|celler|cave|maison|finca|vi[ñn]a)\b/i;
+
+function producerFieldLooksPlaceholder(producer, wineName) {
+  const p = typeof producer === 'string' ? producer.trim() : '';
+  if (!p) return true;
+  if (UNKNOWN_WORD.test(p)) return true;
+  const n = typeof wineName === 'string' ? wineName.trim() : '';
+  if (!n) return false;
+  if (normPlace(p) !== normPlace(n)) return false;
+  if (PRODUCER_PREFIX.test(p)) return false;   // "Château Rousset" — a name, not a placeholder
+  return !p.includes(' ');                     // bare single word repeating the wine name
+}
+
 /**
  * Rule identifiers stamped on `aiProfile.suspectDowngradedBy` when either rule
  * clears a flag, so the moved rows stay queryable as a set (somm request
@@ -256,6 +341,7 @@ const DOWNGRADE_RULES = {
 
 module.exports = {
   noteAssertsProducer, noteIsEpistemicOnly, DOWNGRADE_RULES,
+  notePlaceConflict, producerFieldLooksPlaceholder,
   PRODUCER_CLASS, BRAND_CLASS, CONTRAST,
   // Exported so the A/B split can be MEASURED separately from the combined
   // predicate — the sommelier asked for a four-way population breakdown

--- a/backend/src/utils/producerSuspectCheck.test.js
+++ b/backend/src/utils/producerSuspectCheck.test.js
@@ -167,12 +167,17 @@ describe('noteIsEpistemicOnly', () => {
       )).toBe(false);
     });
 
-    // Caught in the second dry run: stated outright rather than by comparison.
-    it('a note saying the value is an appellation is a claim, however tentative', () => {
+    // REVERSED by the somm's full-population audit (6a86dad6). A dry run
+    // taught this row as a keep — "the value is an appellation" — and a guard
+    // was built for it. Château de l'Étoile is a REAL Jura estate whose name
+    // legitimately repeats its AOC (like half of Bordeaux), so the downgrade
+    // was correct and the guard was protecting the error. The guard is gone;
+    // the note (prod's actual prepositional form) downgrades.
+    it('Chateau Etoile — a name repeating its appellation is not a place claim', () => {
       expect(noteIsEpistemicOnly(
-        'Chateau Etoile is not a producer I can verify; Château d\'Etoile / L\'Etoile is an appellation in the Jura, so this may be a mislabeling or an unfamiliar small producer.',
+        "Chateau Etoile is not a producer I can verify in the Jura appellation of L'Etoile; this profile is based on the appellation and grape rather than a verified house style.",
         'Chateau Etoile'
-      )).toBe(false);
+      )).toBe(true);
     });
 
     const cases = [
@@ -216,5 +221,135 @@ describe('noteIsEpistemicOnly', () => {
     expect(noteIsEpistemicOnly(null, 'Foo')).toBe(false);
     expect(noteIsEpistemicOnly(undefined, undefined)).toBe(false);
     expect(noteIsEpistemicOnly('   ', 'Foo')).toBe(false);
+  });
+});
+
+// Downgrade blockers from the somm's full-population audit (6a86dad6): every
+// positive case below is a real prod note from one of the 14 rows that should
+// not have moved; every negative case is a real note from the 152 that were
+// correct. Written FROM the audit, not composed.
+describe('notePlaceConflict', () => {
+  const { notePlaceConflict } = require('./producerSuspectCheck');
+
+  describe('BLOCK — the note grounds its estimate in a place the record contradicts', () => {
+    it('Champagne profile on a Côtes de Gascogne record (Haut-Marin)', () => {
+      expect(notePlaceConflict(
+        'Haut-Marin is not a producer I can confidently place; this profile is estimated from the Champagne appellation and style.',
+        { appellation: 'Côtes de Gascogne', country: 'France' }
+      )).toBe(true);
+    });
+
+    it('Champagne style on a Loire mousseux (Henri Aupy)', () => {
+      expect(notePlaceConflict(
+        'Henri Aupy is not a producer I can verify; this profile is based on general Champagne Demi-Sec style.',
+        { appellation: 'Vin Mousseux', country: 'France' }
+      )).toBe(true);
+    });
+
+    it('Loire rosé style on a Franche-Comté producer (Vignoble Guillaume)', () => {
+      expect(notePlaceConflict(
+        'Vignoble Guillaume is not a producer I can confidently place, so this profile is based on the Loire rosé style generally.',
+        { country: 'France' }
+      )).toBe(true);
+    });
+
+    // The invented-appellation case is why this is extraction, not a curated
+    // vocabulary lookup: "Île de Ré" is in no taxonomy, so only a non-match
+    // against the record itself can catch it.
+    it('an invented "Île de Ré appellation" on a Vin de France (Domaine Ariça)', () => {
+      expect(notePlaceConflict(
+        'Domaine Ariça is not a producer I can confidently place, so this profile is based on the grape and Île de Ré appellation style.',
+        { appellation: 'Vin de France', country: 'France' }
+      )).toBe(true);
+    });
+
+    it('asserting geography on a record with no place at all blocks too', () => {
+      expect(notePlaceConflict(
+        'X is not a producer I can place; this profile is based on the Rioja region generally.',
+        {}
+      )).toBe(true);
+    });
+  });
+
+  describe('ALLOW — the note grounds itself in the record\'s own geography', () => {
+    it('the named appellation matches the record', () => {
+      expect(notePlaceConflict(
+        'Ugo Lequio is not a producer I can confidently document, so this profile is based on the Barbaresco appellation and Nebbiolo grape.',
+        { appellation: 'Barbaresco', country: 'Italy' }
+      )).toBe(false);
+    });
+
+    it('partial forms ground each other both ways (Barossa Valley shiraz style)', () => {
+      expect(notePlaceConflict(
+        'Rosenvale Vineyards is not a producer I can verify; this profile is based on typical Barossa Valley shiraz style.',
+        { region: 'Barossa Valley', country: 'Australia' }
+      )).toBe(false);
+    });
+
+    it('a named region matching the record grounds the note (Maldonado)', () => {
+      expect(notePlaceConflict(
+        'This producer name is unfamiliar to me, so this profile is based on the grape and Maldonado region generally rather than confirmed knowledge of the specific winery.',
+        { region: 'Maldonado', country: 'Uruguay' }
+      )).toBe(false);
+    });
+
+    it('a note naming no place makes no claim (Duffour)', () => {
+      expect(notePlaceConflict(
+        'Domaine Duffour is not a producer I can confidently place; this profile is based on the appellation and grape varieties typical of Côtes de Gascogne.',
+        { appellation: 'Côtes de Gascogne', country: 'France' }
+      )).toBe(false);
+    });
+
+    it('the methodology phrase "profile is an appellation-level estimate" is not a place', () => {
+      expect(notePlaceConflict(
+        'Montlobre is not a producer I can confidently place; this profile is an appellation and style-level estimate.',
+        { country: 'France' }
+      )).toBe(false);
+    });
+
+    it('empty and non-string notes make no claim', () => {
+      expect(notePlaceConflict('', { region: 'Jura' })).toBe(false);
+      expect(notePlaceConflict(null, { region: 'Jura' })).toBe(false);
+    });
+  });
+});
+
+describe('producerFieldLooksPlaceholder', () => {
+  const { producerFieldLooksPlaceholder } = require('./producerSuspectCheck');
+
+  describe('BLOCK — the field is a placeholder, not a verifiable name', () => {
+    it('the field literally says unknown', () => {
+      expect(producerFieldLooksPlaceholder('Domaine unknown', 'La Combe Tourmentée')).toBe(true);
+      expect(producerFieldLooksPlaceholder('Unknown', 'Merlot')).toBe(true);
+    });
+
+    it('a bare single word repeating the wine name (import artifact)', () => {
+      expect(producerFieldLooksPlaceholder('Increíble', 'Increíble')).toBe(true);
+      expect(producerFieldLooksPlaceholder('Padulone', 'Padulone')).toBe(true);
+    });
+
+    it('an empty field has nothing to verify', () => {
+      expect(producerFieldLooksPlaceholder('', 'Some Wine')).toBe(true);
+      expect(producerFieldLooksPlaceholder(null, 'Some Wine')).toBe(true);
+    });
+  });
+
+  describe('ALLOW — producer == name is also just the Bordeaux convention', () => {
+    // The carve-outs are the somm's own correction to their first proposal
+    // (6a86dad6 part 2C): a bare producer == name guard would have re-flagged
+    // a dozen working châteaux. Prefix or multi-word = a name, not a filler.
+    it('a producer-type prefix makes it a name (Château Rousset)', () => {
+      expect(producerFieldLooksPlaceholder('Château Rousset', 'Château Rousset')).toBe(false);
+      expect(producerFieldLooksPlaceholder('Weingut Hornstein', 'Weingut Hornstein')).toBe(false);
+    });
+
+    it('a multi-word name is a name (La Garricq, Haut Barrail)', () => {
+      expect(producerFieldLooksPlaceholder('La Garricq', 'La Garricq')).toBe(false);
+      expect(producerFieldLooksPlaceholder('Haut Barrail', 'Haut Barrail')).toBe(false);
+    });
+
+    it('an ordinary distinct producer/name pair never fires', () => {
+      expect(producerFieldLooksPlaceholder('Matua', 'Pinot Noir')).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Somm ticket 6a86dad6: they read **all 166** `note_epistemic_only` rows — not a sample — and found 14 that should not have moved (8.4%), plus one guard protecting the wrong side. Every stored-state claim was verified on prod before building (10/10 checked held).

## The Etoile guard is deleted

Château de l'Étoile is a **real Jura estate** whose name legitimately repeats its AOC — so the row the guard was built to protect was a correct downgrade being blocked. And the guard missed the actual prod note anyway (prepositional form: *"…not a producer I can verify **in the Jura appellation of** L'Etoile"*). Misfires on its motivating case, leaks on the real one → deleted, test fixture flipped with the story.

## Two new downgrade blockers

Both encode audit classes; both only ever **block** a downgrade (row stays suspect, caveat stays visible, a human judges):

| Blocker | Audit class | Example |
|---|---|---|
| `notePlaceConflict` | Note describes a different wine's geography (4 rows) | *"estimated from the Champagne appellation"* on a Côtes de Gascogne record |
| `producerFieldLooksPlaceholder` | Producer field isn't a name (5 rows) | `"Domaine unknown"`, or bare `Increíble`/`Increíble` |

`notePlaceConflict` is **extraction against the record**, not a curated-vocabulary lookup — the worst case invents an appellation that exists in no taxonomy (*"Île de Ré appellation"* on a Vin de France). The carve-outs on the placeholder guard are the somm's own correction to their first proposal: prefix (`Château Rousset`) or multi-word (`La Garricq`) producer==name is the Bordeaux convention, not a filler.

## Also

- **Curator rows excluded** from the bulk script — The Parish moved despite a curator verification two days earlier; a human judgement outranks any rule.
- **`confirm` now clears `producerUnknown`** and accepts rows whose only doubt flag is `producerUnknown` — Haut-Marin (documented 180 ha estate) carried the flag with no verb able to clear it. No `suspectDecision` stamp on unknown-only rows.
- **Tag semantics documented, not changed**: the tag records which rule *fired* under strongest-claim-first, not which shape the note best fits. Accepted trade over loosening `PRODUCER_CLASS`, which shipped five false downgrades once already.

## Tests

69 in `producerSuspectCheck` (every positive blocker case is a real prod note from the 14; every negative a real note from the 152 correct ones) + 3 new end-to-end wiring tests through `enrichWine`. 184 passing across the affected suites.

Data repairs for the existing 14 rows run separately on prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)