### PR TITLE
fix(somm): the extractor audit — grounding by token sequence, not span substring

### DIFF
--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -2778,7 +2778,11 @@ registerTool({
   title: 'Sommelier: published descriptions claiming places the record does not carry',
   description:
     'Registry wines whose PUBLISHED AI description names a place or variety on a record that has NO region and NO ' +
-    'appellation — so every geographic claim in the prose is ungrounded by construction. Graded, never just ' +
+    'appellation — so every such claim in the prose is ungrounded by construction. Each ungrounded claim is ' +
+    'labelled kind: place | variety (varieties were in the original 6a82bfb7 test; the label keeps the two ' +
+    'readable at a glance). The producer\'s own name and the record\'s country are subtracted from claim spans ' +
+    'rather than grounding them wholesale — "Chile\'s Maipo Valley" on a Chile record reports Maipo Valley, and a ' +
+    'mention of the producer is never a claim. Graded, never just ' +
     'counted: `assertion` = an ungrounded place stated as fact for the wine ("a red blend from the Hunter Valley" ' +
     'on a null-region row) — the class that taught a curator four wrong drink windows; `disclosure` = ungrounded ' +
     'places framed by uncertainty ("could not be identified", "the region is genuinely open", "likely…") — the ' +
@@ -2819,6 +2823,15 @@ registerTool({
       .populate('grapes', 'name')
       .lean();
 
+    // The full curated grape list, for labelling each claim place vs variety
+    // (somm v1.147 audit, item 4: a field called "place" holding "Cabernet
+    // Franc" reads as a broken grader to a first reader; the extraction was
+    // correct — varieties were in the original 6a82bfb7 test — the label
+    // wasn't).
+    const Grape = require('../../models/Grape');
+    const { normPlace } = require('../../utils/descriptionGrounding');
+    const grapeNames = new Set((await Grape.find({}).select('name').lean()).map((g) => normPlace(g.name)));
+
     const graded = [];
     let okCount = 0;
     for (const w of rows) {
@@ -2826,6 +2839,7 @@ registerTool({
         region: w.region?.name,
         appellation: w.appellation,
         country: w.country?.name,
+        producer: w.producer,
         grapes: (w.grapes || []).map((g) => g.name),
       });
       if (r.grade === 'ok') { okCount++; continue; }
@@ -2852,7 +2866,11 @@ registerTool({
       country: w.country?.name || null,
       grapes: (w.grapes || []).map((g) => g.name),
       grade: r.grade,
-      ungrounded_claims: r.claims.map((c) => ({ place: c.place, framed: c.framed })),
+      ungrounded_claims: r.claims.map((c) => ({
+        claim: c.claim,
+        kind: grapeNames.has(normPlace(c.claim)) ? 'variety' : 'place',
+        framed: c.framed,
+      })),
       confidence: w.aiProfile?.confidence ?? null,
       description: String(w.aiProfile.description).slice(0, 400),
     }));

--- a/backend/src/utils/descriptionGrounding.js
+++ b/backend/src/utils/descriptionGrounding.js
@@ -58,8 +58,10 @@ const normPlace = (s) => String(s || '')
 // Île de Ré) — a bare "in"/"the" ends the chain, otherwise "Mount View in the
 // Hunter Valley" captures as one mangled claim and swallows the real one.
 // Longest-first, with a trailing boundary — "de" listed ahead of "del" bites
-// the first two letters of "Ribera del Duero" and truncates the claim.
-const PLACE_CONNECTOR = "(?:della|delle|del|des|de|di|du|da|dos|das|la|les|le|los|von|van|der|den|sur|en)(?=\\s)";
+// the first two letters of "Ribera del Duero" and truncates the claim. "y"
+// added from the somm's v1.147 audit: without it "Castilla y León" broke at
+// the conjunction and reported a truncated claim.
+const PLACE_CONNECTOR = "(?:della|delle|del|des|de|di|du|da|dos|das|la|les|le|los|von|van|der|den|sur|en|y)(?=\\s)";
 const PREP_CLAIM = new RegExp(
   "\\b(?:from|in|at|of|across|near)\\s+(?:the\\s+)?" +
   "([A-ZÀ-Þ][\\wÀ-ɏ'’-]*(?:\\s+(?:" + PLACE_CONNECTOR + "|[A-ZÀ-Þ][\\wÀ-ɏ'’-]*)){0,3})",
@@ -84,7 +86,11 @@ const MATERIAL_NOISE = /\b(oak|barriques?|barrels?|casks?|cooperage|hogsheads?|m
 // CATEGORY, not a place ("the traditional Reserva style"). A claim that is
 // nothing but tier words is dropped; a real place carrying one ("Rioja
 // Reserva") survives because grounding runs on the whole phrase.
-const TIER_WORD = /^(reservas?|riservas?|crianzas?|gran|brut|extra|demi-sec|sec|secco?|dolce|trocken|halbtrocken|feinherb|classico|superiore|premium|prestige|tradition|traditional|vintage|blanc|rouge|rosé|rosado|tinto)$/i;
+const TIER_WORD = /^(reservas?|riservas?|crianzas?|gran|brut|extra|demi-sec|sec|secco?|dolce|trocken|halbtrocken|feinherb|classico|superiore|premium|prestige|tradition|traditional|vintage|blanc|rouge|rosé|rosado|tinto|crémants?|cremants?|reserve)$/i;
+
+// Climate adjectives are weather, not origin — "Atlantic-influenced whites"
+// asserts nothing about where the wine is from (found in the v1.148 re-count).
+const CLIMATE_WORD = /^(atlantic|mediterranean|continental)/i;
 
 // Frames strong enough to cover the whole description — the vocabulary of a
 // paragraph whose JOB is saying what is unknown.
@@ -112,6 +118,12 @@ const DEMONYMS = {
   'south african': 'south africa', 'new zealand': 'new zealand',
 };
 
+// A place after one of these verbs is where something was CREATED, not where
+// this wine is from — "a cold-hardy hybrid grape bred in Minnesota" on a
+// French wine (somm v1.147 audit, item 5; one row, but the shape is a verb
+// governing the phrase, so the rule is cheap and principled).
+const CREATION_VERB = /\b(?:bred|crossed|hybridi[sz]ed|developed)\s*$/i;
+
 function extractClaims(sentence) {
   const out = [];
   for (const rx of [PREP_CLAIM, KEYWORD_CLAIM]) {
@@ -120,6 +132,7 @@ function extractClaims(sentence) {
     while ((m = rx.exec(sentence)) !== null) {
       const raw = m[1].trim();
       if (MATERIAL_NOISE.test(raw)) continue;
+      if (CREATION_VERB.test(sentence.slice(0, m.index))) continue;
       // The connector-aware chain stops BEFORE a lowercase material word, so
       // "in French oak" captures bare "French" — look one word past the match:
       // a material/technique noun means this names a thing, not an origin.
@@ -138,40 +151,82 @@ function extractClaims(sentence) {
   return [...new Set(out)];
 }
 
+// Strip a possessive before normalising a token — "Chile's" and "Mendoza's"
+// are the places, not new words (somm v1.147 audit, item 6).
+const tokenNorm = (t) => normPlace(String(t).replace(/['’]s$/i, ''));
+
 /**
  * @param {string} description  aiProfile.description as stored
- * @param {object} record       { region, appellation, country } — names, and
- *                              optionally grapes: [names] for variety grounding
+ * @param {object} record       { region, appellation, country, producer } —
+ *                              names, and optionally grapes: [names]
  * @returns {{ grade: 'ok'|'disclosure'|'assertion',
- *             claims: Array<{place: string, framed: boolean}> }}
+ *             claims: Array<{claim: string, framed: boolean}> }}
  *          claims lists only the UNGROUNDED ones — grounded mentions are the
  *          description doing its job and are not reported.
+ *
+ * Grounding is TOKEN SUBTRACTION, not span substring (somm v1.147 audit,
+ * item 1 — the decisive one). Span-substring let the record's country ground
+ * "Chile's Maipo Valley" wholesale, silently swallowing the finer place, and
+ * a check that under-reports on rows it already flags gives a curator false
+ * assurance — worse than over-reporting. Instead: remove every token the
+ * record accounts for (its places, its grapes, its country's adjective, the
+ * producer's own name) and whatever CAPITALISED tokens survive are the claim.
+ * "Chile's Maipo Valley" − Chile → "Maipo Valley". "Bodega Fernando Dupont's
+ * Jujuy" − producer → "Jujuy". Nothing capitalised left → nothing claimed.
  */
-function gradeDescription(description, { region, appellation, country, grapes } = {}) {
+function gradeDescription(description, { region, appellation, country, grapes, producer } = {}) {
   if (typeof description !== 'string' || !description.trim()) return { grade: 'ok', claims: [] };
 
-  const ground = [region, appellation, country, ...(Array.isArray(grapes) ? grapes : [])]
-    .map(normPlace)
-    .filter(Boolean);
+  // Everything the record itself accounts for, kept as WHOLE token sequences.
+  // The producer's tokens are in the same pool: a description mentioning the
+  // producer is not claiming a place, however place-like the name reads (somm
+  // item 2 — three of four disclosure rows were the producer's own name, so
+  // the whole disclosure bucket was extraction noise wearing a calibrated
+  // look). Sequences, not a token set, because grapes share tokens: with the
+  // record carrying Cabernet SAUVIGNON, a loose-token pool subtracts the
+  // "Cabernet" out of an ungrounded Cabernet FRANC claim and reports "Franc".
+  const grounds = [];
+  for (const src of [region, appellation, country, producer, ...(Array.isArray(grapes) ? grapes : [])]) {
+    const seq = String(src || '').split(/\s+/).map(tokenNorm).filter(Boolean);
+    if (seq.length) grounds.push(seq);
+  }
+  const nCountry = normPlace(country);
+  for (const [adj, c] of Object.entries(DEMONYMS)) {
+    if (c === nCountry) grounds.push(adj.split(' '));
+  }
 
   const docFramed = STRONG_FRAME.test(description);
   const sentences = description.split(/(?<=[.!?])\s+/);
+  const seen = new Set();
   const claims = [];
 
   for (const sentence of sentences) {
     const sentenceFramed = docFramed || STRONG_FRAME.test(sentence) || WEAK_FRAME.test(sentence);
-    for (const place of extractClaims(sentence)) {
-      const n = normPlace(place);
-      // Expand country adjectives before comparing, so "Canadian" can ground
-      // against a Canada record the way "Spanish"/"Spain" grounds by luck.
-      const expanded = Object.entries(DEMONYMS).reduce(
-        (acc, [adj, country]) => (acc.includes(adj) ? acc.replace(adj, country) : acc), n
-      );
-      const grounded = ground.some((g) =>
-        g.includes(n) || n.includes(g) || g.includes(expanded) || expanded.includes(g)
-      );
-      if (grounded) continue;
-      claims.push({ place, framed: sentenceFramed });
+    for (const span of extractClaims(sentence)) {
+      const tokens = span.split(/\s+/).map((t) => t.replace(/['’]s$/i, ''));
+      const norms = tokens.map(tokenNorm);
+      // Remove every CONTIGUOUS occurrence of a ground sequence.
+      const removed = new Array(tokens.length).fill(false);
+      for (const seq of grounds) {
+        for (let i = 0; i + seq.length <= norms.length; i++) {
+          if (seq.every((g, j) => norms[i + j] === g)) {
+            for (let j = 0; j < seq.length; j++) removed[i + j] = true;
+          }
+        }
+      }
+      // Survivors also shed tier and climate words: once the record's own
+      // tokens are subtracted, "French Crémant" leaves bare "Crémant" — a
+      // style noun that only LOOKED like a place while attached to one.
+      const left = tokens.filter((t, i) => !removed[i] && norms[i] && !TIER_WORD.test(t) && !CLIMATE_WORD.test(t));
+      // Only capitalised survivors assert anything — "Barossa Valley shiraz"
+      // on a Barossa Valley record leaves lowercase "shiraz", which is prose,
+      // not a claim.
+      if (!left.some((t) => /^[A-ZÀ-Þ]/.test(t))) continue;
+      const claim = left.join(' ');
+      const key = normPlace(claim);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      claims.push({ claim, framed: sentenceFramed });
     }
   }
 

--- a/backend/src/utils/descriptionGrounding.test.js
+++ b/backend/src/utils/descriptionGrounding.test.js
@@ -24,7 +24,7 @@ describe('gradeDescription', () => {
       // Ungrounded places, every one framed — including the producer-biography
       // sentence AHEAD of the disclosure markers, which is why a strong marker
       // frames the whole document.
-      const places = r.claims.map((c) => c.place);
+      const places = r.claims.map((c) => c.claim);
       expect(places).toEqual(expect.arrayContaining(['Mount View', 'Hunter Valley']));
       expect(r.claims.every((c) => c.framed)).toBe(true);
     });
@@ -32,7 +32,7 @@ describe('gradeDescription', () => {
     it('the 17 Aug AI line grades assertion — the class the check exists for', () => {
       const r = gradeDescription(PETERSONS_ASSERTION, PETERSONS_RECORD);
       expect(r.grade).toBe('assertion');
-      expect(r.claims.some((c) => /hunter valley/i.test(c.place) && !c.framed)).toBe(true);
+      expect(r.claims.some((c) => /hunter valley/i.test(c.claim) && !c.framed)).toBe(true);
     });
   });
 
@@ -80,7 +80,7 @@ describe('gradeDescription', () => {
         { country: 'United States', grapes: [] }
       );
       expect(r.grade).toBe('disclosure');
-      expect(r.claims).toEqual([{ place: 'Tempranillo', framed: true }]);
+      expect(r.claims).toEqual([{ claim: 'Tempranillo', framed: true }]);
     });
 
     it('a weak hedge frames only its own sentence, not the paragraph', () => {
@@ -101,6 +101,62 @@ describe('gradeDescription', () => {
     it('empty and non-string descriptions grade ok', () => {
       expect(gradeDescription('', {}).grade).toBe('ok');
       expect(gradeDescription(null, {}).grade).toBe('ok');
+    });
+  });
+
+  // Every case below is from the somm's full read of the v1.147 worklist
+  // (all 25 rows, not a sample). Items are numbered as in their ticket.
+  describe('the v1.147 extractor audit', () => {
+    // Item 1, their top priority: span-substring grounding let the record's
+    // country swallow the finer place — the row was flagged only on a grape,
+    // and a curator who fixed that claim would believe the row finished.
+    // Under-reporting on a flagged row is false assurance.
+    it('the record\'s country must not ground the finer place beside it (Peñalolen)', () => {
+      const r = gradeDescription(
+        "This is a Cabernet Sauvignon-led red from Chile's Maipo Valley, typically blended with small amounts of Cabernet Franc, Petit Verdot and Merlot.",
+        { country: 'Chile', grapes: ['Cabernet Sauvignon'] }
+      );
+      const claims = r.claims.map((c) => c.claim);
+      expect(claims).toEqual(expect.arrayContaining(['Maipo Valley', 'Cabernet Franc']));
+      expect(r.grade).toBe('assertion');
+    });
+
+    // Item 2: three of four disclosure rows were the producer's own name —
+    // the entire disclosure bucket was extraction noise wearing a calibrated
+    // look. The producer's tokens are subtracted like the record's own.
+    it('the producer\'s own name is never a place claim', () => {
+      expect(gradeDescription(
+        "Grown at altitude in Bodega Fernando Dupont's Jujuy vineyards, this Syrah shows dark fruit.",
+        { country: 'Argentina', producer: 'Bodega Fernando Dupont', grapes: ['Syrah'] }
+      ).claims.map((c) => c.claim)).toEqual(['Jujuy']);
+
+      expect(gradeDescription(
+        'Château Bois d\'Arlène is likely a small estate; this is an approachable southern French red.',
+        { country: 'France', producer: 'Château Bois d\'Arlène' }
+      ).claims.map((c) => c.claim)).toEqual([]);
+    });
+
+    // Item 5: a place after a creation verb is where the VARIETY was bred,
+    // not where this wine is from.
+    it('a breeding location is not an origin claim (Minnesota)', () => {
+      expect(gradeDescription(
+        'Made from Marquette — a cold-hardy hybrid grape bred in Minnesota — this is a juicy red.',
+        { country: 'France', grapes: ['Marquette'] }
+      ).grade).toBe('ok');
+    });
+
+    // Item 6: "Castilla y León" split at the conjunction and reported a
+    // truncated claim; possessives kept their apostrophe-s.
+    it('conjunction connectors and possessives keep spans whole and clean', () => {
+      expect(gradeDescription(
+        'A fresh, pale rosado from Castilla y León, made mainly from Tempranillo.',
+        { country: 'Spain', grapes: ['Tempranillo'] }
+      ).claims.map((c) => c.claim)).toEqual(['Castilla y León']);
+
+      expect(gradeDescription(
+        "Old vines at altitude near Vistalba in Mendoza's oldest district.",
+        { country: 'Argentina' }
+      ).claims.map((c) => c.claim)).toEqual(expect.arrayContaining(['Vistalba', 'Mendoza']));
     });
   });
 });


### PR DESCRIPTION
The somm's full read of the v1.147 worklist (all 25 rows). Their headline finding was the right one to lead with: a **false negative on a row the tool already flags** gives a curator false assurance — worse than over-reporting.

| Their item | Fix |
|---|---|
| 1. Country swallows the finer place ("Chile's Maipo Valley" grounded via Chile) | Grounding is now **token-sequence subtraction** — remove the record's own names (places, grapes, country + demonym, producer) as whole sequences; capitalised survivors are the claim. Re-ran the full population: **Peñalolen was the only missed-primary row** |
| 2. Producer's own name filled the disclosure bucket (3 of 4 rows) | Producer tokens subtract like the record's own. Honest disclosure count: **2**, both genuine |
| 3. 21/9 vs 21/4 count discrepancy | My stale brief, not a tool bug — the 9 predated the final v1.147 extractor fixes |
| 4. `place` field holds grape names | Claims now labelled `kind: place \| variety` via grape-vocabulary lookup |
| 5. "bred in Minnesota" on a French wine | Creation verbs (`bred/crossed/hybridized/developed`) exempt the following place |
| 6. Span defects | "y" connector (Castilla y León), possessive strip (Mendoza's → Mendoza), survivors shed tier/climate words |
| 7. Grape-implied region contradiction | **Deferred** — needs a curated grape→region dataset that doesn't exist; answered on the ticket with a design sketch |

Sequence-subtraction subtlety that matters: a record carrying Cabernet **Sauvignon** must not eat the "Cabernet" out of an ungrounded Cabernet **Franc** claim — sequences, never a loose token pool.

The re-count also caught two false positives the new subtraction itself introduced (bare "Crémant" after "French" subtracts; "Atlantic-influenced") — both cleaned before this PR.

**Final population: 15 assertion / 2 disclosure / 131 ok** over 148 placeless rows.

Output-shape change only — no input-schema change, so no connector reconnect needed.

Tests: 16 in `descriptionGrounding` (5 new, all from their audit rows); 745 across the affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)