### PR TITLE
fix(enrichment): the 13:46 somm batch — note-record hold, elision, variety completeness

### DIFF
--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -2829,8 +2829,7 @@ registerTool({
     // correct — varieties were in the original 6a82bfb7 test — the label
     // wasn't).
     const Grape = require('../../models/Grape');
-    const { normPlace } = require('../../utils/descriptionGrounding');
-    const grapeNames = new Set((await Grape.find({}).select('name').lean()).map((g) => normPlace(g.name)));
+    const grapeVocabulary = (await Grape.find({}).select('name').lean()).map((g) => g.name);
 
     const graded = [];
     let okCount = 0;
@@ -2841,6 +2840,10 @@ registerTool({
         country: w.country?.name,
         producer: w.producer,
         grapes: (w.grapes || []).map((g) => g.name),
+        // The vocabulary pass reports EVERY ungrounded variety, not just the
+        // one a preposition introduces (somm 6a870548 — "Cabernet Franc,
+        // Petit Verdot and Merlot" reported one of three).
+        varietyVocabulary: grapeVocabulary,
       });
       if (r.grade === 'ok') { okCount++; continue; }
       graded.push({ w, r });
@@ -2866,11 +2869,7 @@ registerTool({
       country: w.country?.name || null,
       grapes: (w.grapes || []).map((g) => g.name),
       grade: r.grade,
-      ungrounded_claims: r.claims.map((c) => ({
-        claim: c.claim,
-        kind: grapeNames.has(normPlace(c.claim)) ? 'variety' : 'place',
-        framed: c.framed,
-      })),
+      ungrounded_claims: r.claims.map((c) => ({ claim: c.claim, kind: c.kind || 'place', framed: c.framed })),
       confidence: w.aiProfile?.confidence ?? null,
       description: String(w.aiProfile.description).slice(0, 400),
     }));

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -41,6 +41,67 @@ const Bottle = require('../models/Bottle');
 // embedding text, so both collapse to null.
 const SENTINEL_VALUE_RX = /^(null|none|n\/?a|undefined|unknown|nil|-+|)$/i;
 
+// ── Note-vs-record variety conflict (somm 6a870531) ─────────────────────────
+// The curated grape vocabulary, cached: names change rarely and a batch run
+// must not query per wine. 10-minute TTL so taxonomy edits land without a
+// restart.
+let grapeVocabCache = { at: 0, entries: [] };
+async function grapeVocabulary() {
+  if (Date.now() - grapeVocabCache.at > 10 * 60 * 1000) {
+    const Grape = require('../models/Grape');
+    const { normPlace, NON_VARIETY_VOCAB } = require('../utils/descriptionGrounding');
+    const rows = await Grape.find({}).select('name synonyms').lean();
+    grapeVocabCache = {
+      at: Date.now(),
+      entries: rows
+        .filter((r) => !NON_VARIETY_VOCAB.has(normPlace(r.name)))
+        .map((r) => ({
+          name: r.name,
+          forms: [r.name, ...(Array.isArray(r.synonyms) ? r.synonyms : [])].map(normPlace).filter(Boolean),
+        })),
+    };
+  }
+  return grapeVocabCache.entries;
+}
+
+// The clause must ASSERT what the bottling is, not describe what the producer
+// is known for. Prod scan 2026-08-20: without this, "Braida is a known
+// Barbera producer" (bio, on a Moscato) and "primarily known for Napa
+// Cabernet" (bio) would hold rows whose notes are fine — while the real
+// class always carries an assertion verb: "more commonly DOCUMENTED AS a
+// Pinot Noir" (Les Gaudrettes), "is ACTUALLY a Viognier-Chardonnay blend"
+// (Cantina Marilina).
+const NOTE_ASSERTS_BOTTLING = /\b(documented as|actually an?|in fact an?|is really|listed as|labell?ed as|instead of|rather than|mislabell?ed|not an? )\b/i;
+
+/**
+ * Does the note ASSERT the bottling is a curated variety the record does not
+ * carry? Synonym-aware — a note saying "Moscato" on a Muscat Blanc à Petits
+ * Grains record names the record's own grape under another form and never
+ * fires. Clause-scoped (split on ./;) so an assertion verb in one clause
+ * cannot license a bio-mention in another. Returns the conflicting variety
+ * name, or null.
+ */
+function findNoteVarietyConflict(note, recordGrapeNames, vocabEntries) {
+  const { normPlace } = require('../utils/descriptionGrounding');
+  const ownForms = new Set((recordGrapeNames || []).map((n) => normPlace(n)).filter(Boolean));
+  const clauses = String(note || '').split(/[.;]/);
+  for (const clause of clauses) {
+    if (!NOTE_ASSERTS_BOTTLING.test(clause)) continue;
+    const clauseNorms = normPlace(clause).split(' ').filter(Boolean);
+    for (const entry of vocabEntries || []) {
+      // The record's own grape, under any of its names, is never a conflict.
+      if (entry.forms.some((f) => ownForms.has(f))) continue;
+      for (const form of entry.forms) {
+        const seq = form.split(' ');
+        for (let i = 0; i + seq.length <= clauseNorms.length; i++) {
+          if (seq.every((n, j) => clauseNorms[i + j] === n)) return entry.name;
+        }
+      }
+    }
+  }
+  return null;
+}
+
 function cleanDescriptor(field, raw) {
   if (typeof raw !== 'string') return null;
   const v = raw.trim().toLowerCase();
@@ -451,6 +512,9 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
 
   const now = new Date();
   const gateCfg = aiConfig.get();
+  // Loaded once per wine (module-cached) — assess() is a sync closure and the
+  // note-vs-record check inside it must not await.
+  const grapeVocab = await grapeVocabulary();
 
   // Derive everything the gate and the writes need from ONE model response.
   // A closure so the search-rescue retry below can re-derive from a second
@@ -544,6 +608,25 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
       if (conflict) {
         holdReason = 'taxonomy_conflict';
         if (!meta.producerNote) meta.producerNote = `Style conflict: ${conflict}`;
+      }
+    }
+    // Third deterministic cross-check (somm ticket 6a870531, HIGH): the
+    // generator's own note against the record's grape list. Les Gaudrettes
+    // published a Chardonnay profile while its producerNote said the cuvée is
+    // "more commonly documented as a Pinot Noir" — the model recorded a
+    // record-contradiction in the one field nothing reads, then published.
+    // If the note names a curated variety the record does not carry (and the
+    // record HAS grapes — on a grapeless record a named variety is added
+    // information, not contradiction), the row holds and a curator decides
+    // which side is wrong. The note itself is the evidence and stays.
+    if (!holdReason && meta.producerNote && (wine.grapes || []).length) {
+      const mentioned = findNoteVarietyConflict(
+        meta.producerNote,
+        wine.grapes.map((g) => g.name),
+        grapeVocab
+      );
+      if (mentioned) {
+        holdReason = 'note_record_conflict';
       }
     }
     // Second deterministic cross-check (somm ticket 6a85ad44): the wine's own
@@ -879,6 +962,6 @@ module.exports = {
   start, requestStop, getStatus, enrichWineById, releaseHeldProfile,
   profileInputsSnapshot, reenrichAfterRecordEdit, isProfileStale,
   // exported for unit tests + the reset-misheld migration
-  cleanDescriptor, cleanStringList, cleanProse, cleanConfidence, shouldHoldProfile, identityDataSufficient,
+  cleanDescriptor, cleanStringList, cleanProse, cleanConfidence, shouldHoldProfile, identityDataSufficient, findNoteVarietyConflict,
   _resetSearchSlots,
 };

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -13,6 +13,18 @@
 
 jest.mock('../models/WineDefinition', () => ({ findById: jest.fn(), updateOne: jest.fn() }));
 jest.mock('../models/Bottle', () => ({ distinct: jest.fn().mockResolvedValue([]) }));
+// The note-vs-record check (6a870531) loads the curated grape vocabulary; an
+// unmocked model would buffer on the missing test DB for 10s per suite.
+jest.mock('../models/Grape', () => ({
+  find: jest.fn(() => ({
+    select: () => ({
+      lean: () => Promise.resolve([
+        { name: 'Pinot Noir' }, { name: 'Chardonnay' },
+        { name: 'Cabernet Sauvignon' }, { name: 'Tempranillo' },
+      ]),
+    }),
+  })),
+}));
 jest.mock('./labelScan', () => ({ suggestProfile: jest.fn() }));
 jest.mock('./aiProvider', () => ({ isConfigured: jest.fn(() => true), effectiveModels: jest.fn(() => null) }));
 jest.mock('./embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined) }));
@@ -644,6 +656,57 @@ describe('the split flags end-to-end through enrichWine', () => {
     const p = persisted();
     expect(p.producerSuspect).toBe(true);
     expect(p.suspectDowngradedBy).toBeNull();
+  });
+
+  // Somm 6a870531 (HIGH): Les Gaudrettes published a Chardonnay profile while
+  // its own producerNote said the cuvée is documented as a Pinot Noir — the
+  // model recorded a record-contradiction in the one field nothing read.
+  test('a note naming a variety the record does not carry HOLDS the row', async () => {
+    // Fixture record carries Pinot Noir; the note asserts Chardonnay.
+    suggestProfile.mockResolvedValue(withFlags({
+      confidence: 0.6,
+      producerNote: 'The Les Gaudrettes cuvée is more commonly documented as a Chardonnay, so this profile is inferred from the producer\'s general style.',
+    }));
+    await enrichWineById(WINE_ID);
+    const p = persisted();
+    expect(p.heldAt).toBeInstanceOf(Date);
+    expect(p.heldReason).toBe('note_record_conflict');
+    expect(p.description).toBeNull();
+    // The note IS the evidence and stays for the curator.
+    expect(p.producerNote).toMatch(/Chardonnay/);
+  });
+
+  test('a producer-bio mention is not an assertion about this bottling', async () => {
+    // Prod scan: "Braida is a known Barbera producer" on a Moscato — the note
+    // describes the HOUSE, not the wine, and must not hold.
+    suggestProfile.mockResolvedValue(withFlags({
+      confidence: 0.6,
+      producerNote: 'Matua is primarily known for Chardonnay and single-vineyard bottlings.',
+    }));
+    await enrichWineById(WINE_ID);
+    expect(persisted().heldAt).toBeNull();
+  });
+
+  test('a note naming the record\'s OWN grape does not hold', async () => {
+    suggestProfile.mockResolvedValue(withFlags({
+      confidence: 0.6,
+      producerNote: 'A benchmark Pinot Noir house; this bottling follows their usual style.',
+    }));
+    await enrichWineById(WINE_ID);
+    expect(persisted().heldAt).toBeNull();
+  });
+
+  test('on a GRAPELESS record a named variety is information, not conflict', async () => {
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: WINE_ID, name: 'Red Blend', producer: 'Matua', type: 'red',
+      country: { name: 'New Zealand' }, region: { name: 'Marlborough' }, grapes: [],
+    }));
+    suggestProfile.mockResolvedValue(withFlags({
+      confidence: 0.6,
+      producerNote: 'Likely a Chardonnay-led blend based on the producer range.',
+    }));
+    await enrichWineById(WINE_ID);
+    expect(persisted().heldAt).toBeNull();
   });
 
   // Gate 2026-08-18 (ticket 6a83e765): the two confidence holds, end to end,

--- a/backend/src/utils/descriptionGrounding.js
+++ b/backend/src/utils/descriptionGrounding.js
@@ -62,9 +62,13 @@ const normPlace = (s) => String(s || '')
 // added from the somm's v1.147 audit: without it "Castilla y León" broke at
 // the conjunction and reported a truncated claim.
 const PLACE_CONNECTOR = "(?:della|delle|del|des|de|di|du|da|dos|das|la|les|le|los|von|van|der|den|sur|en|y)(?=\\s)";
+// Elided tokens — d'Avola, l'Étoile — start lowercase but are PART of the
+// name, not a chain break (somm 6a87053b: stopping before them captured bare
+// "Nero" out of the record's own Nero d'Avola).
+const ELIDED_TOKEN = "[dl]['’][A-ZÀ-Þ][\\wÀ-ɏ'’-]*";
 const PREP_CLAIM = new RegExp(
   "\\b(?:from|in|at|of|across|near)\\s+(?:the\\s+)?" +
-  "([A-ZÀ-Þ][\\wÀ-ɏ'’-]*(?:\\s+(?:" + PLACE_CONNECTOR + "|[A-ZÀ-Þ][\\wÀ-ɏ'’-]*)){0,3})",
+  "([A-ZÀ-Þ][\\wÀ-ɏ'’-]*(?:\\s+(?:" + PLACE_CONNECTOR + "|" + ELIDED_TOKEN + "|[A-ZÀ-Þ][\\wÀ-ɏ'’-]*)){0,3})",
   'g'
 );
 
@@ -73,7 +77,7 @@ const PREP_CLAIM = new RegExp(
 // a free continuation captured junk like "It's a crowd-pleasing style" and
 // "Details on producer and origin" in the first prod dry run.
 const KEYWORD_CLAIM = new RegExp(
-  "\\b([A-ZÀ-Þ][\\wÀ-ɏ'’-]*(?:\\s+(?:" + PLACE_CONNECTOR + "|[A-ZÀ-Þ][\\wÀ-ɏ'’-]*)){0,3})" +
+  "\\b([A-ZÀ-Þ][\\wÀ-ɏ'’-]*(?:\\s+(?:" + PLACE_CONNECTOR + "|" + ELIDED_TOKEN + "|[A-ZÀ-Þ][\\wÀ-ɏ'’-]*)){0,3})" +
   "\\s+(?:appellation|AOC|AOP|DOCG?|region|style|styles)\\b",
   'g'
 );
@@ -174,7 +178,7 @@ const tokenNorm = (t) => normPlace(String(t).replace(/['’]s$/i, ''));
  * "Chile's Maipo Valley" − Chile → "Maipo Valley". "Bodega Fernando Dupont's
  * Jujuy" − producer → "Jujuy". Nothing capitalised left → nothing claimed.
  */
-function gradeDescription(description, { region, appellation, country, grapes, producer } = {}) {
+function gradeDescription(description, { region, appellation, country, grapes, producer, varietyVocabulary } = {}) {
   if (typeof description !== 'string' || !description.trim()) return { grade: 'ok', claims: [] };
 
   // Everything the record itself accounts for, kept as WHOLE token sequences.
@@ -195,13 +199,57 @@ function gradeDescription(description, { region, appellation, country, grapes, p
     if (c === nCountry) grounds.push(adj.split(' '));
   }
 
+  // A norm-token run sitting INSIDE a ground sequence is grounded — "Château
+  // Bois" inside producer "Chateau Bois D'Arlene", bare "Nero" inside grape
+  // "Nero d'Avola" (somm 6a87053b). A truncated capture of a name the record
+  // accounts for grounds even when shorter than the name. NOT the inverse:
+  // "Cabernet Franc" is not inside "Cabernet Sauvignon".
+  const insideAnyGround = (runNorms) => {
+    if (!runNorms.length) return false;
+    return grounds.some((seq) => {
+      for (let i = 0; i + runNorms.length <= seq.length; i++) {
+        if (runNorms.every((n, j) => seq[i + j] === n)) return true;
+      }
+      return false;
+    });
+  };
+
   const docFramed = STRONG_FRAME.test(description);
   const sentences = description.split(/(?<=[.!?])\s+/);
   const seen = new Set();
   const claims = [];
 
+  const vocabSeqs = (Array.isArray(varietyVocabulary) ? varietyVocabulary : [])
+    .filter((name) => !NON_VARIETY_VOCAB.has(normPlace(name)))
+    .map((name) => ({ name, seq: String(name).split(/\s+/).map(tokenNorm).filter(Boolean) }))
+    .filter((v) => v.seq.length);
+
   for (const sentence of sentences) {
     const sentenceFramed = docFramed || STRONG_FRAME.test(sentence) || WEAK_FRAME.test(sentence);
+
+    // Variety pass FIRST (somm 6a870548): the extraction grammar catches only
+    // the variety a preposition happens to introduce — "blended with small
+    // amounts of Cabernet Franc, Petit Verdot and Merlot" reported one of
+    // three. A vocabulary scan over the whole normalised sentence reports
+    // every ungrounded variety regardless of position, including bare varietal
+    // openers ("a full-bodied Tempranillo from…") and hyphen compounds
+    // ("Syrah-led" normalises to "syrah led").
+    if (vocabSeqs.length) {
+      const sentNorms = normPlace(sentence).split(' ').filter(Boolean);
+      for (const { name, seq } of vocabSeqs) {
+        let found = false;
+        for (let i = 0; i + seq.length <= sentNorms.length && !found; i++) {
+          found = seq.every((n, j) => sentNorms[i + j] === n);
+        }
+        if (!found) continue;
+        if (insideAnyGround(seq)) continue; // the record's own grape
+        const key = normPlace(name);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        claims.push({ claim: name, kind: 'variety', framed: sentenceFramed });
+      }
+    }
+
     for (const span of extractClaims(sentence)) {
       const tokens = span.split(/\s+/).map((t) => t.replace(/['’]s$/i, ''));
       const norms = tokens.map(tokenNorm);
@@ -217,16 +265,20 @@ function gradeDescription(description, { region, appellation, country, grapes, p
       // Survivors also shed tier and climate words: once the record's own
       // tokens are subtracted, "French Crémant" leaves bare "Crémant" — a
       // style noun that only LOOKED like a place while attached to one.
-      const left = tokens.filter((t, i) => !removed[i] && norms[i] && !TIER_WORD.test(t) && !CLIMATE_WORD.test(t));
+      const left = tokens
+        .map((t, i) => ({ t, n: norms[i], removed: removed[i] }))
+        .filter(({ t, n, removed: r }) => !r && n && !TIER_WORD.test(t) && !CLIMATE_WORD.test(t));
+      if (insideAnyGround(left.map(({ n }) => n))) continue;
       // Only capitalised survivors assert anything — "Barossa Valley shiraz"
       // on a Barossa Valley record leaves lowercase "shiraz", which is prose,
       // not a claim.
-      if (!left.some((t) => /^[A-ZÀ-Þ]/.test(t))) continue;
-      const claim = left.join(' ');
+      if (!left.some(({ t }) => /^[A-ZÀ-Þ]/.test(t))) continue;
+      const claim = left.map(({ t }) => t).join(' ');
       const key = normPlace(claim);
       if (seen.has(key)) continue;
       seen.add(key);
-      claims.push({ claim, framed: sentenceFramed });
+      const isVariety = vocabSeqs.some((v) => normPlace(v.name) === key);
+      claims.push({ claim, kind: isVariety ? 'variety' : 'place', framed: sentenceFramed });
     }
   }
 
@@ -234,4 +286,11 @@ function gradeDescription(description, { region, appellation, country, grapes, p
   return { grade: claims.some((c) => !c.framed) ? 'assertion' : 'disclosure', claims };
 }
 
-module.exports = { gradeDescription, extractClaims, STRONG_FRAME, WEAK_FRAME, normPlace };
+// Taxonomy entries that exist ONLY for quarantined non-wine rows (cider,
+// mead — see ticket 6a86bb5f): they are legitimate grape-collection entries
+// but poison a variety vocabulary, because every tasting note mentioning
+// "green apple acidity" or "pear fruit" would report a variety claim. 17 of
+// 21 assertion rows in the first vocabulary-pass dry run were this.
+const NON_VARIETY_VOCAB = new Set(['apple', 'pear', 'quince', 'honey']);
+
+module.exports = { gradeDescription, extractClaims, STRONG_FRAME, WEAK_FRAME, normPlace, NON_VARIETY_VOCAB };

--- a/backend/src/utils/descriptionGrounding.test.js
+++ b/backend/src/utils/descriptionGrounding.test.js
@@ -80,7 +80,9 @@ describe('gradeDescription', () => {
         { country: 'United States', grapes: [] }
       );
       expect(r.grade).toBe('disclosure');
-      expect(r.claims).toEqual([{ claim: 'Tempranillo', framed: true }]);
+      // No vocabulary passed here, so kind defaults to place — the tool layer
+      // always passes the grape vocabulary and gets 'variety'.
+      expect(r.claims).toEqual([{ claim: 'Tempranillo', kind: 'place', framed: true }]);
     });
 
     it('a weak hedge frames only its own sentence, not the paragraph', () => {
@@ -147,6 +149,49 @@ describe('gradeDescription', () => {
 
     // Item 6: "Castilla y León" split at the conjunction and reported a
     // truncated claim; possessives kept their apostrophe-s.
+    // 6a87053b: elision is not a chain break — stopping before d'Avola
+    // captured bare "Nero" out of the record's OWN grape, and the truncated
+    // "Château Bois" could never match the full stored producer.
+    it('elided tokens stay attached, and truncated captures ground inside their name', () => {
+      expect(gradeDescription(
+        'A soft, juicy red blending the bright red-fruit character of Tempranillo with the darker plum notes of Nero d\'Avola.',
+        { country: 'Netherlands', producer: 'Chateau Amsterdam', grapes: ['Tempranillo', "Nero d'Avola"] }
+      ).grade).toBe('ok');
+      expect(gradeDescription(
+        'RENEsens from Château Bois d\'Arléne is a fresh, approachable dry white with citrus blossom character.',
+        { country: 'France', producer: "Chateau Bois D'Arlene", grapes: [] }
+      ).grade).toBe('ok');
+    });
+
+    // 6a870548: the extraction grammar reports only the variety a preposition
+    // introduces; the vocabulary pass reports every ungrounded one.
+    it('every ungrounded variety in an enumeration is reported', () => {
+      const VOCAB = ['Cabernet Sauvignon', 'Cabernet Franc', 'Petit Verdot', 'Merlot', 'Pinot Noir', 'Chardonnay', 'Tempranillo'];
+      const r = gradeDescription(
+        "This is a Cabernet Sauvignon-led red from Chile's Maipo Valley, typically blended with small amounts of Cabernet Franc, Petit Verdot and Merlot.",
+        { country: 'Chile', grapes: ['Cabernet Sauvignon'], varietyVocabulary: VOCAB }
+      );
+      const varieties = r.claims.filter((c) => c.kind === 'variety').map((c) => c.claim).sort();
+      expect(varieties).toEqual(['Cabernet Franc', 'Merlot', 'Petit Verdot']);
+      expect(r.claims.some((c) => c.claim === 'Maipo Valley' && c.kind === 'place')).toBe(true);
+
+      const r2 = gradeDescription(
+        'A small-batch sparkling wine made from an equal blend of Pinot Noir and Chardonnay, aged on lees.',
+        { country: 'France', grapes: [], varietyVocabulary: VOCAB }
+      );
+      expect(r2.claims.map((c) => c.claim).sort()).toEqual(['Chardonnay', 'Pinot Noir']);
+    });
+
+    it('a bare varietal opener with no preposition is still reported (Crudabendita)', () => {
+      const r = gradeDescription(
+        'A rich, full-bodied Tempranillo from Ribera del Duero, built for extended aging.',
+        { country: 'Spain', grapes: [], varietyVocabulary: ['Tempranillo'] }
+      );
+      const kinds = Object.fromEntries(r.claims.map((c) => [c.claim, c.kind]));
+      expect(kinds['Tempranillo']).toBe('variety');
+      expect(kinds['Ribera del Duero']).toBe('place');
+    });
+
     it('conjunction connectors and possessives keep spans whole and clean', () => {
       expect(gradeDescription(
         'A fresh, pale rosado from Castilla y León, made mainly from Tempranillo.',


### PR DESCRIPTION
Three somm tickets filed together at 13:46; one slice answers all three. Their 11 pending region proposals were vetted and approved first (all correct, including two that close their own earlier loops).

| Ticket | Fix |
|---|---|
| **6a870531 (HIGH)** — generator noted a record-contradiction, then published | New cross-check: a note that **asserts the bottling is** a curated variety the record doesn't carry → `note_record_conflict` hold. Synonym-aware (Moscato = Muscat Blanc à Petits Grains) + clause-scoped assertion verbs so producer bio ("known for Barbera") never holds. Prod scan: 8 candidates → true class is 3 with the guards |
| **6a87053b (MED)** — elision breaks subtraction | `d'Avola`/`d'Arléne` stay attached to their names; truncated captures ground **inside** the full stored name. Both rows grade ok with no record change, as they predicted |
| **6a870548 (MED)** — enumerated varieties under-reported | Vocabulary pass per sentence: every ungrounded variety reported — enumerations, bare varietal openers, hyphen compounds. Cider/mead entries (Apple/Pear/Quince/Honey) excluded — 17 of 21 first-run rows were "green apple acidity" reporting Apple[variety] |

**Population gate:** 3 assertion / 2 disclosure / 131 ok over 136 placeless rows — the place residue is the zero the somm predicted; the 3 are genuine speculative-variety claims the new pass exists to find.

No input-schema changes — no reconnect needed.

Tests: 752 passing across 41 suites (7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)