### PR TITLE
feat(enrichment): the generation gate — ungrounded prose can no longer publish on placeless records

### DIFF
--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -681,6 +681,75 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
     }
   }
 
+  // ── Generation gate (somm 6a82bfb7, the ticket's last open build) ─────────
+  // On a record with NO region and NO appellation, every geographic claim in
+  // the candidate prose is ungrounded by construction — the class that taught
+  // a curator four wrong drink windows. The prompt asks for disclosure-shaped
+  // prose up front; this is the guarantee the prompt cannot give. An
+  // assertion-grade draft gets ONE corrective retry naming exactly what it
+  // asserted; a second violation HOLDS rather than publishes. Disclosure
+  // prose (the Petersons shape) passes by design — forcing silence would
+  // train enrichment toward blank confidence, the somm's own warning.
+  // Grounded records are out of scope entirely: prose legitimately goes finer
+  // than the record, and judging that needs a gazetteer (the 1,612 lesson).
+  const placeless = !wine.region && !wine.appellation;
+  if (!publishSuspect && placeless && !a.holdReason && a.description) {
+    const { gradeDescription } = require('../utils/descriptionGrounding');
+    // The record's grapes ground under every name they carry — a "Moscato"
+    // mention on a Muscat Blanc à Petits Grains record is the record's own
+    // grape, not a claim (same synonym rule as the note-conflict check).
+    const ownNames = (wine.grapes || []).map((g) => g.name).filter(Boolean);
+    const { normPlace } = require('../utils/descriptionGrounding');
+    const ownNorm = new Set(ownNames.map(normPlace));
+    const grapeForms = [
+      ...ownNames,
+      ...grapeVocab.filter((e) => e.forms.some((f) => ownNorm.has(f))).flatMap((e) => e.forms),
+    ];
+    const grounding = {
+      country: wine.country?.name,
+      producer: wine.producer,
+      grapes: grapeForms,
+      varietyVocabulary: grapeVocab.map((e) => e.name),
+    };
+    const firstGrade = gradeDescription(a.description, grounding);
+    if (firstGrade.grade === 'assertion') {
+      const asserted = firstGrade.claims.filter((c) => !c.framed).map((c) => c.claim).join(', ');
+      const second = await suggestProfile({
+        name: wine.name,
+        producer: wine.producer,
+        vintage: 'NV',
+        curatorContext,
+        retryDirective:
+          `Your previous draft stated the following as facts about this wine: ${asserted}. ` +
+          'This record does not carry them, so they are unverified. Rewrite the description without asserting ' +
+          'any of them — style-only prose, or name explicitly what is unknown.',
+        country: wine.country?.name,
+        region: wine.region?.name,
+        appellation: wine.appellation,
+        classification: wine.classification,
+        type: wine.type,
+        grapes: (wine.grapes || []).map(g => g.name).filter(Boolean),
+      });
+      if (second.data) {
+        const b = assess(second.data, a.meta.searchUsed === true);
+        const secondGrade = b.description ? gradeDescription(b.description, grounding) : { grade: 'ok' };
+        a = b;
+        if (!a.holdReason && secondGrade.grade === 'assertion') {
+          a.holdReason = 'ungrounded_description';
+          if (!a.meta.producerNote) {
+            a.meta.producerNote = `Ungrounded description: asserted ${secondGrade.claims.filter((c) => !c.framed).map((c) => c.claim).join(', ').slice(0, 200)}`;
+          }
+        }
+        console.log(`[enrichmentJob] grounding retry ${wine._id}: ${a.holdReason || 'published'}`);
+      } else {
+        // Retry failed to generate — the violating first draft must not
+        // publish as-is. Hold with the first draft's evidence.
+        a.holdReason = 'ungrounded_description';
+        if (!a.meta.producerNote) a.meta.producerNote = `Ungrounded description: asserted ${asserted.slice(0, 200)}`;
+      }
+    }
+  }
+
   // `publishSuspect` is the human override — profile-reviewed uses it after
   // an admin has looked at the doubt and judged the identity fine. A held
   // row stores ONLY the doubt; the null description keeps every read surface

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -21,6 +21,7 @@ jest.mock('../models/Grape', () => ({
       lean: () => Promise.resolve([
         { name: 'Pinot Noir' }, { name: 'Chardonnay' },
         { name: 'Cabernet Sauvignon' }, { name: 'Tempranillo' },
+        { name: 'Muscat Blanc à Petits Grains', synonyms: ['Moscato', 'Moscato Bianco'] },
       ]),
     }),
   })),
@@ -707,6 +708,83 @@ describe('the split flags end-to-end through enrichWine', () => {
     }));
     await enrichWineById(WINE_ID);
     expect(persisted().heldAt).toBeNull();
+  });
+
+  // ── Generation gate (6a82bfb7's last open build, 2026-08-20) ──────────────
+  // On a record with NO region and NO appellation, an assertion-grade draft
+  // gets one corrective retry; a second violation holds. Disclosure prose
+  // passes by design.
+  describe('the ungrounded-description generation gate', () => {
+    const placeless = (over = {}) => chain({
+      _id: WINE_ID, name: "Maureen's", producer: 'Petersons', type: 'red',
+      country: { name: 'Australia' }, region: null, appellation: null, grapes: [],
+      ...over,
+    });
+
+    test('an assertion-grade draft is retried once, and a clean second draft publishes', async () => {
+      WineDefinition.findById.mockReturnValue(placeless());
+      suggestProfile
+        .mockResolvedValueOnce(withFlags({
+          description: 'A soft, approachable red blend from the Hunter Valley with plum fruit.',
+        }))
+        .mockResolvedValueOnce(withFlags({
+          description: 'A soft, approachable red. The region could not be identified from this record.',
+        }));
+      await enrichWineById(WINE_ID);
+      expect(suggestProfile).toHaveBeenCalledTimes(2);
+      // The retry names exactly what the first draft asserted.
+      expect(suggestProfile.mock.calls[1][0].retryDirective).toMatch(/Hunter Valley/);
+      const p = persisted();
+      expect(p.heldAt).toBeNull();
+      expect(p.description).toMatch(/could not be identified/);
+    });
+
+    test('a persistent violation HOLDS as ungrounded_description', async () => {
+      WineDefinition.findById.mockReturnValue(placeless());
+      suggestProfile.mockResolvedValue(withFlags({
+        description: 'A soft, approachable red blend from the Hunter Valley with plum fruit.',
+      }));
+      await enrichWineById(WINE_ID);
+      expect(suggestProfile).toHaveBeenCalledTimes(2);
+      const p = persisted();
+      expect(p.heldAt).toBeInstanceOf(Date);
+      expect(p.heldReason).toBe('ungrounded_description');
+      expect(p.description).toBeNull();
+      expect(p.producerNote).toMatch(/Hunter Valley/);
+    });
+
+    test('disclosure prose passes without a retry — silence is not the goal', async () => {
+      WineDefinition.findById.mockReturnValue(placeless());
+      suggestProfile.mockResolvedValue(withFlags({
+        description: 'This bottling could not be identified. They draw fruit from the Hunter as well as Barossa, so the region is genuinely open.',
+      }));
+      await enrichWineById(WINE_ID);
+      expect(suggestProfile).toHaveBeenCalledTimes(1);
+      expect(persisted().heldAt).toBeNull();
+    });
+
+    test('a grounded record is out of the gate\'s scope entirely', async () => {
+      // The default fixture carries Marlborough — finer-grained prose is
+      // legitimate there and judging it needs a gazetteer (the 1,612 lesson).
+      suggestProfile.mockResolvedValue(withFlags({
+        description: 'A Wairau Valley Pinot Noir with bright cherry fruit.',
+      }));
+      await enrichWineById(WINE_ID);
+      expect(suggestProfile).toHaveBeenCalledTimes(1);
+      expect(persisted().heldAt).toBeNull();
+    });
+
+    test('the record\'s own grape under a synonym is not an assertion', async () => {
+      WineDefinition.findById.mockReturnValue(placeless({
+        grapes: [{ name: 'Muscat Blanc à Petits Grains' }],
+      }));
+      suggestProfile.mockResolvedValue(withFlags({
+        description: 'A gently sparkling white in the classic Moscato style, light and grapey.',
+      }));
+      await enrichWineById(WINE_ID);
+      expect(suggestProfile).toHaveBeenCalledTimes(1);
+      expect(persisted().heldAt).toBeNull();
+    });
   });
 
   // Gate 2026-08-18 (ticket 6a83e765): the two confidence holds, end to end,

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -604,7 +604,7 @@ async function suggestPrice({ name, producer, vintage, country, region, appellat
  * Used by the enrichment job to populate WineDefinition.aiProfile, which then
  * feeds both the embedding text and the bottle-page display.
  */
-async function suggestProfile({ name, producer, vintage, country, region, appellation, classification, type, grapes, curatorContext, allowSearch }) {
+async function suggestProfile({ name, producer, vintage, country, region, appellation, classification, type, grapes, curatorContext, allowSearch, retryDirective }) {
   if (!name) return { data: null, debugRaw: null, debugReason: 'missing_fields' };
 
   let client;
@@ -679,6 +679,29 @@ async function suggestProfile({ name, producer, vintage, country, region, appell
     .slice(0, 1000);
   if (ctxFacts) {
     prompt += '\n\nCurator-supplied facts about this wine (authoritative — a human sommelier researched them; trust them over your own recall, describe accordingly, and let them raise your confidence): ' + ctxFacts;
+  }
+
+  // Identity-starved records (somm 6a82bfb7, generation gate 2026-08-20): when
+  // the record carries NO region and NO appellation, every geographic claim in
+  // the prose is ungrounded by construction — and the failure mode this class
+  // produced was a curator carrying "from the Hunter Valley" onto a wine whose
+  // fruit nobody verified, into four published drink windows. The directive
+  // asks for the disclosure shape (name what is unknown) or style-only prose.
+  // Advisory, like every prompt line — the write-path grade check in
+  // enrichmentJob is the guarantee; this exists to make the retry rare.
+  if (!field(region) && !field(appellation)) {
+    const grapesEmpty = !grapeList;
+    prompt += '\n\nThis record carries no region and no appellation' + (grapesEmpty ? ', and no grape varieties' : '') +
+      '. Do not state any region, appellation' + (grapesEmpty ? ' or grape variety' : '') + ' as a fact about THIS wine. ' +
+      'Either write style-only prose with no geographic' + (grapesEmpty ? ' or varietal' : '') + ' claims, or name explicitly what is unknown ' +
+      '("the region could not be identified") — naming places in order to say the answer is open is welcome; asserting one is not.';
+  }
+
+  // Corrective retry (generation gate): the first draft asserted ungrounded
+  // facts; say exactly which, and ask again. Appended after template
+  // substitution so it can never hit a {{token}}.
+  if (retryDirective) {
+    prompt += '\n\n' + String(retryDirective).replace(/\p{C}/gu, ' ').slice(0, 600);
   }
 
   // Web-search rescue (pilot 2026-08-19): the retry path for would-hold rows.


### PR DESCRIPTION
The last open build on somm ticket 6a82bfb7 (opened 17 Aug): their original option 1, shaped by everything the ticket thread settled since.

On a record with **no region and no appellation**, every geographic claim in candidate prose is ungrounded by construction. The gate:

1. **Prompt directive** (advisory): identity-starved records ask for disclosure-shaped prose up front — name what is unknown, don't assert.
2. **Write-path grade check** (the guarantee): an assertion-grade draft gets **one corrective retry** naming exactly what it asserted; a second violation **holds** as `ungrounded_description` with the evidence in the note.
3. **Disclosure passes by design** — the Petersons shape publishes untouched. Forcing silence would train enrichment toward blank confidence, the somm's own warning, so the retry is what keeps human load near zero.

Scope discipline from the week's lessons: grounded records are out entirely (the 1,612 finer-than-record lesson), the record's grapes ground under **every synonym** (Moscato on a Muscat record), and curator overrides (`publishSuspect`) skip the gate.

Cost: one extra AI call only when a placeless draft violates — the prompt directive makes that rare.

Tests: 5 new gate tests (retry publishes / persistent holds / disclosure passes / grounded-skip / synonym-grounded); 757 across 41 suites. No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)