### PR TITLE
fix(somm): style references are not origins; habitual markers frame only what follows

### DIFF
--- a/backend/src/utils/descriptionGrounding.js
+++ b/backend/src/utils/descriptionGrounding.js
@@ -96,12 +96,28 @@ const TIER_WORD = /^(reservas?|riservas?|crianzas?|gran|brut|extra|demi-sec|sec|
 // asserts nothing about where the wine is from (found in the v1.148 re-count).
 const CLIMATE_WORD = /^(atlantic|mediterranean|continental)/i;
 
+// A stylistic comparison is not an origin claim (somm 6a872807): "styled in
+// the Bordeaux-inspired claret tradition" compares, it does not locate.
+// Covers the hyphenated compounds (-inspired, -style, -like, -influenced),
+// bare adjectival forms (Burgundian), and supranational terms (European,
+// New World) that can never ground against any single record.
+const STYLE_REFERENCE = /(?:-(?:inspired|styled?|like|influenced|esque)|ian)$/i;
+const SUPRANATIONAL = /^(european|international|new world|old world|alpine|nordic|iberian|transalpine)$/i;
+
 // Frames strong enough to cover the whole description — the vocabulary of a
 // paragraph whose JOB is saying what is unknown.
 const STRONG_FRAME = /\b(could not be (?:identified|verified|confirmed)|cannot be (?:identified|verified|confirmed)|unconfirmed|unverified|unidentified|not (?:yet )?(?:known|identified|verified|confirmed)|genuinely open|unavailable|no drink window|if your label)\b/i;
 
 // Hedges that frame only their own sentence.
 const WEAK_FRAME = /\b(likely|probably|possibly|perhaps|presumably|may be|might be|appears? to be|seems? to be|uncertain)\b/i;
+
+// Habitual markers frame only what FOLLOWS them (somm 6a872807, on rows
+// chosen independently of the artifact set): "typically built around …
+// such as X, Y or Z" describes what the style usually contains, not what is
+// in this bottle — but the same word must not launder an assertion that
+// precedes it: "…from Chile's Maipo Valley, typically blended with small
+// amounts of Cabernet Franc" asserts the region and hedges only the blend.
+const HABITUAL = /\b(typically|usually|often|commonly|generally|traditionally|such as|tends? to)\b/i;
 
 const STOP_FIRST = new Set(['this', 'the', 'that', 'these', 'those', 'it', 'its', "it's", 'it’s', 'a', 'an', 'if', 'they', 'expect', 'details']);
 
@@ -117,6 +133,7 @@ const DEMONYMS = {
   australian: 'australia', canadian: 'canada', chilean: 'chile',
   argentine: 'argentina', argentinian: 'argentina', dutch: 'netherlands',
   swiss: 'switzerland', georgian: 'georgia', croatian: 'croatia',
+  moroccan: 'morocco', lebanese: 'lebanon',
   romanian: 'romania', bulgarian: 'bulgaria', moldovan: 'moldova',
   slovenian: 'slovenia', uruguayan: 'uruguay', mexican: 'mexico',
   'south african': 'south africa', 'new zealand': 'new zealand',
@@ -225,7 +242,18 @@ function gradeDescription(description, { region, appellation, country, grapes, p
     .filter((v) => v.seq.length);
 
   for (const sentence of sentences) {
-    const sentenceFramed = docFramed || STRONG_FRAME.test(sentence) || WEAK_FRAME.test(sentence);
+    const baseFramed = docFramed || STRONG_FRAME.test(sentence) || WEAK_FRAME.test(sentence);
+    // A habitual marker splits the sentence: what follows it is framed, what
+    // precedes it keeps the base framing — Peñalolén's "…from Chile's Maipo
+    // Valley, typically blended with Cabernet Franc" asserts the region and
+    // hedges only the blend, while Lumière's early "typically built around…"
+    // frames everything after it.
+    const habIdx = sentence.search(HABITUAL);
+    const segments = habIdx > -1
+      ? [{ text: sentence.slice(0, habIdx), framed: baseFramed }, { text: sentence.slice(habIdx), framed: true }]
+      : [{ text: sentence, framed: baseFramed }];
+
+    for (const { text: segment, framed: sentenceFramed } of segments) {
 
     // Variety pass FIRST (somm 6a870548): the extraction grammar catches only
     // the variety a preposition happens to introduce — "blended with small
@@ -235,7 +263,7 @@ function gradeDescription(description, { region, appellation, country, grapes, p
     // openers ("a full-bodied Tempranillo from…") and hyphen compounds
     // ("Syrah-led" normalises to "syrah led").
     if (vocabSeqs.length) {
-      const sentNorms = normPlace(sentence).split(' ').filter(Boolean);
+      const sentNorms = normPlace(segment).split(' ').filter(Boolean);
       for (const { name, seq } of vocabSeqs) {
         let found = false;
         for (let i = 0; i + seq.length <= sentNorms.length && !found; i++) {
@@ -250,7 +278,7 @@ function gradeDescription(description, { region, appellation, country, grapes, p
       }
     }
 
-    for (const span of extractClaims(sentence)) {
+    for (const span of extractClaims(segment)) {
       const tokens = span.split(/\s+/).map((t) => t.replace(/['’]s$/i, ''));
       const norms = tokens.map(tokenNorm);
       // Remove every CONTIGUOUS occurrence of a ground sequence.
@@ -267,7 +295,7 @@ function gradeDescription(description, { region, appellation, country, grapes, p
       // style noun that only LOOKED like a place while attached to one.
       const left = tokens
         .map((t, i) => ({ t, n: norms[i], removed: removed[i] }))
-        .filter(({ t, n, removed: r }) => !r && n && !TIER_WORD.test(t) && !CLIMATE_WORD.test(t));
+        .filter(({ t, n, removed: r }) => !r && n && !TIER_WORD.test(t) && !CLIMATE_WORD.test(t) && !STYLE_REFERENCE.test(t) && !SUPRANATIONAL.test(n));
       if (insideAnyGround(left.map(({ n }) => n))) continue;
       // Only capitalised survivors assert anything — "Barossa Valley shiraz"
       // on a Barossa Valley record leaves lowercase "shiraz", which is prose,
@@ -279,6 +307,7 @@ function gradeDescription(description, { region, appellation, country, grapes, p
       seen.add(key);
       const isVariety = vocabSeqs.some((v) => normPlace(v.name) === key);
       claims.push({ claim, kind: isVariety ? 'variety' : 'place', framed: sentenceFramed });
+    }
     }
   }
 

--- a/backend/src/utils/descriptionGrounding.test.js
+++ b/backend/src/utils/descriptionGrounding.test.js
@@ -217,3 +217,38 @@ describe('extractClaims', () => {
     expect(extractClaims('This wine shows bright fruit. Expect gentle tannins.')).toEqual([]);
   });
 });
+
+// Somm 6a872807: two false-positive classes from the five post-v1.149
+// assertion rows — all real prod prose.
+describe('style references and habitual hedges (6a872807)', () => {
+  it('a stylistic comparison is not an origin claim (Bordeaux-inspired claret)', () => {
+    expect(gradeDescription(
+      'A smooth red styled in the Bordeaux-inspired claret tradition, with cassis and cedar.',
+      { country: 'United States', grapes: [] }
+    ).grade).toBe('ok');
+  });
+
+  it('bare adjectival style forms never claim (Burgundian, supranational terms)', () => {
+    expect(gradeDescription(
+      'A silky red with Burgundian elegance, sourced from European vineyards.',
+      { country: 'Netherlands', grapes: [] }
+    ).grade).toBe('ok');
+  });
+
+  it('habitual markers frame their sentence — typical-content prose grades disclosure (Lumière)', () => {
+    const r = gradeDescription(
+      'A warm-climate Moroccan red, typically built around Mediterranean varieties such as Cinsault, Carignan or Syrah.',
+      { country: 'Morocco', grapes: [], varietyVocabulary: ['Cinsault', 'Carignan', 'Syrah'] }
+    );
+    expect(r.grade).toBe('disclosure');
+    expect(r.claims.every((c) => c.framed)).toBe(true);
+    expect(r.claims.map((c) => c.claim).sort()).toEqual(['Carignan', 'Cinsault', 'Syrah']);
+  });
+
+  it('an unhedged variety assertion still grades assertion', () => {
+    expect(gradeDescription(
+      'Built from Cinsault and Carignan in equal parts.',
+      { country: 'Morocco', grapes: [], varietyVocabulary: ['Cinsault', 'Carignan'] }
+    ).grade).toBe('assertion');
+  });
+});


### PR DESCRIPTION
Somm ticket 6a872807, the two real false-positive classes (their item on enumeration turned out to be pre-/post-v1.149 observations mixed — answered on the ticket, no code needed):

- **Style references** — "styled in the Bordeaux-inspired claret tradition" compares, it does not locate. Hyphenated compounds (`-inspired/-style/-like/-influenced/-esque`), bare adjectival forms (Burgundian), and supranational terms (European, New World) no longer claim.
- **Habitual markers** (`typically/usually/such as/tends to…`) frame **only what follows them** — their two fixtures collide otherwise: Lumière's early "typically built around … such as Cinsault, Carignan or Syrah" frames its varieties (→ disclosure), while Peñalolén's late "…from Chile's Maipo Valley, typically blended with…" must NOT launder the region assertion that precedes the marker. The sentence splits at the marker; each segment carries its own framing.

The frame markers were extended only now, on rows chosen independently of the artifact set — per their own instruction on 6a870548.

Also in this slice (data, already applied on prod): Tanat→Tannat taxonomy merge (1 wine repointed, misspelling kept as synonym — their hunch confirmed), null-note row re-enriched to an adjudicable state.

Tests: 4 new fixtures from the five live rows; 1,858 across 83 suites. No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)