### PR TITLE
feat(somm): surface open owner inquiries on the hold-review queue

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -23,6 +23,12 @@ jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: je
 jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn(), aggregate: jest.fn(), populate: jest.fn(), updateOne: jest.fn() }));
 jest.mock('../services/enrichmentJob', () => ({ releaseHeldProfile: jest.fn() }));
 jest.mock('../models/Grape', () => ({ findOne: jest.fn() }));
+// list_held_profiles flags rows with an open owner inquiry (somm 6a872b98).
+// Default: none open — individual tests override to assert the flag.
+jest.mock('../models/WineOwnerInquiry', () => ({
+  find: jest.fn(() => ({ select: () => ({ lean: () => Promise.resolve([]) }) })),
+  findOne: jest.fn(),
+}));
 jest.mock('../models/User', () => ({ findById: jest.fn() }));
 jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
 jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
@@ -650,6 +656,32 @@ describe('held-profile review queue over MCP (somm ticket 2026-08-18)', () => {
     // held_reason "legacy" keeps only the reason-less held row (suspects untouched).
     body = parse(await tool('list_held_profiles').handler({ held_reason: 'legacy', include_published_suspects: true, limit: 30, offset: 0 }, SOMM_CTX));
     expect(body.data.filter((r) => r.state === 'held').map((r) => r.wine_id)).toEqual([oid('2')]);
+  });
+
+  // Somm 6a872b98: a held profile was released over the top of an open
+  // inquiry asking the owner whether that very label reads Hunter Valley or
+  // Lodi. The flag makes the escalation visible where the decision is made.
+  test('a row with an open owner inquiry carries open_owner_inquiry; others do not', async () => {
+    const WineOwnerInquiry = require('../models/WineOwnerInquiry');
+    WineDefinition.find.mockImplementation(() => heldListChain([
+      { _id: oid('1'), name: 'A', producer: 'P1', aiProfile: { heldAt: new Date(), heldReason: 'producer_suspect', confidence: 0.3, generatedAt: new Date() } },
+      { _id: oid('2'), name: 'B', producer: 'P2', aiProfile: { heldAt: new Date(), heldReason: 'low_confidence', confidence: 0.3, generatedAt: new Date() } },
+    ]));
+    Bottle.aggregate.mockResolvedValue([]);
+    WineOwnerInquiry.find.mockImplementation(() => ({
+      select: () => ({
+        lean: () => Promise.resolve([
+          { _id: oid('9'), wineDefinition: oid('1'), question: 'What does the label say the region is?', createdAt: new Date('2026-08-18'), expiresAt: new Date('2026-10-17') },
+        ]),
+      }),
+    }));
+
+    const body = parse(await tool('list_held_profiles').handler({ limit: 30, offset: 0 }, SOMM_CTX));
+    const flagged = body.data.find((r) => String(r.wine_id) === oid('1'));
+    const clean = body.data.find((r) => String(r.wine_id) === oid('2'));
+    expect(flagged.open_owner_inquiry).toMatchObject({ inquiry_id: oid('9'), question: expect.stringMatching(/label/) });
+    // Absent, not null — the field only appears when there is something to see.
+    expect(clean).not.toHaveProperty('open_owner_inquiry');
   });
 
   test('producer filter reaches the query; group_by returns clusters; counts_only returns uncapped totals (gap report 2/5a)', async () => {

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1110,6 +1110,11 @@ registerTool({
   name: 'list_held_profiles',
   title: 'Sommelier: profiles held by the publication gate, awaiting judgement',
   description:
+    'Rows carrying open_owner_inquiry have already been escalated to the person holding the bottle by a previous ' +
+    'curator who judged research insufficient — read that question before deciding, because a release or uphold ' +
+    'over the top of it discards the escalation and the row can then only be settled on the evidence that was ' +
+    'already not enough. It is not a block: new evidence beats a pending question, and resolve_owner_inquiry closes ' +
+    'it honestly. ' +
     'The hold-review queue: registry wines whose generated tasting profile is HELD unpublished (producer_suspect / ' +
     'low_confidence / unknown_low_confidence / producer_claim / taxonomy_conflict / grape_colour_conflict — ' +
     'held_reason says which; null on rows held before the field existed; for taxonomy_conflict the producer_note ' +
@@ -1229,6 +1234,22 @@ registerTool({
 
     const counts = await ownerCounts(wanted.map((w) => w._id));
 
+    // An OPEN owner inquiry means a previous curator judged that research
+    // could not settle this row and asked the person holding the bottle
+    // (somm 6a872b98: a held profile was released over the top of an inquiry
+    // asking whether that very label reads Hunter Valley or Lodi). Surfacing
+    // it here is the cheap half of the fix — the expensive half would be
+    // blocking the verbs, and blocking is wrong: the curator may have new
+    // evidence the inquiry was waiting for.
+    const WineOwnerInquiry = require('../../models/WineOwnerInquiry');
+    const openInquiries = new Map(
+      (await WineOwnerInquiry.find({
+        wineDefinition: { $in: wanted.map((w) => w._id) },
+        status: 'open',
+      }).select('wineDefinition question createdAt expiresAt').lean())
+        .map((i) => [String(i.wineDefinition), i])
+    );
+
     const shaped = wanted
       .map((w) => ({
         wine_id: w._id,
@@ -1257,6 +1278,16 @@ registerTool({
         // Pilot 2026-08-19: a web-search retry already failed on this row —
         // releasing it without curator facts would just re-hold.
         ...(w.aiProfile?.searchUsed === true ? { search_assisted: true } : {}),
+        // A previous curator already escalated this row to its owner; deciding
+        // over the top of that discards the escalation (somm 6a872b98).
+        ...(openInquiries.has(String(w._id)) ? {
+          open_owner_inquiry: {
+            inquiry_id: String(openInquiries.get(String(w._id))._id),
+            question: openInquiries.get(String(w._id)).question || null,
+            asked_at: openInquiries.get(String(w._id)).createdAt || null,
+            expires_at: openInquiries.get(String(w._id)).expiresAt || null,
+          },
+        } : {}),
       }))
       .filter((r) => !args.min_owners || r.owner_count >= args.min_owners)
       .sort((a, b) => (b.owner_count - a.owner_count) || ((a.ai_confidence ?? 1) - (b.ai_confidence ?? 1)));


### PR DESCRIPTION
Somm ticket 6a872b98's actionable ask. A held profile was released over the top of an open inquiry asking that very wine's owner whether the label reads Hunter Valley or Lodi — a previous curator had judged research insufficient, and the escalation was invisible where the decision gets made.

`list_held_profiles` rows now carry `open_owner_inquiry {inquiry_id, question, asked_at, expires_at}` when one exists. A flag, **not a block** — new evidence beats a pending question and the curator may have it; the tool description says so.

Output-field addition only, no input-schema change → **no reconnect needed**.

The ticket's headline premise is separately corrected in its reply (the escalation route works — 5 of 35 inquiries were answered and resolved; the tool lists active ones, so answered inquiries leave the list by design). Tests: 570 across 38 MCP suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)