### PR TITLE
feat(ai): spend controls for the paths nobody asked for

### DIFF
--- a/backend/src/config/aiConfig.js
+++ b/backend/src/config/aiConfig.js
@@ -401,7 +401,38 @@ const defaults = {
   // restart resets the counter — acceptable for the pilot's bound).
   enrichmentSearchEnabled: true,
   enrichmentSearchDailyCap: 5,
+  // Who pays for a new wine's first profile (Johan, 2026-08-21). Adding a
+  // bottle fires an enrichment per newly-minted wine, and at ~120 new wines a
+  // day that drip — not the batch runs — is the steady API spend. It is also
+  // the LEAST reliable population: a freshly scanned label often has no
+  // region and no appellation, which is exactly where the generation gate now
+  // spends TWO calls (draft + corrective retry) and then publishes nothing.
+  //
+  //   'always'     — legacy behaviour: every new wine is enriched
+  //   'sufficient' — only when the record can support a true statement
+  //                  (region or appellation, AND grapes or type). Thin
+  //                  records wait for a curator, who researches them anyway
+  //                  while setting the drink window.
+  //   'off'        — no automatic enrichment on add at all; profiles come
+  //                  from the sommelier's maturity pass and from users
+  //                  reporting what looks wrong.
+  //
+  // Batch runs are unaffected — they are admin-triggered and simply not run.
+  enrichmentOnAdd: 'sufficient',
+  // The sommelier's two AI helpers (Johan, 2026-08-21). Both answer questions
+  // the curator is already researching by hand — setting a drink window means
+  // reading the producer, the vintage and the style, which is the same work
+  // the suggestion does. The curator works on a flat-rate subscription, so
+  // moving these to them costs nothing per call.
+  //
+  // Deliberately NOT bundled with the user-facing paths: label scan, AI wine
+  // search and cellar chat stay on, because they ARE the add-bottle
+  // experience and the product. These two are conveniences for one operator.
+  sommMaturitySuggestEnabled: true,
+  sommPriceSuggestEnabled: true,
 };
+
+const ENRICHMENT_ON_ADD_MODES = ['always', 'sufficient', 'off'];
 
 let cache = { ...defaults };
 
@@ -445,6 +476,14 @@ async function load() {
         enrichmentSearchEnabled: typeof doc.value.enrichmentSearchEnabled === 'boolean' ? doc.value.enrichmentSearchEnabled : defaults.enrichmentSearchEnabled,
         enrichmentSearchDailyCap: (Number.isInteger(doc.value.enrichmentSearchDailyCap) && doc.value.enrichmentSearchDailyCap >= 0 && doc.value.enrichmentSearchDailyCap <= 100)
           ? doc.value.enrichmentSearchDailyCap : defaults.enrichmentSearchDailyCap,
+        // An unrecognised stored mode falls back to the default rather than
+        // to 'always' — a typo must never silently restore full spend.
+        enrichmentOnAdd: ENRICHMENT_ON_ADD_MODES.includes(doc.value.enrichmentOnAdd)
+          ? doc.value.enrichmentOnAdd : defaults.enrichmentOnAdd,
+        sommMaturitySuggestEnabled: typeof doc.value.sommMaturitySuggestEnabled === 'boolean'
+          ? doc.value.sommMaturitySuggestEnabled : defaults.sommMaturitySuggestEnabled,
+        sommPriceSuggestEnabled: typeof doc.value.sommPriceSuggestEnabled === 'boolean'
+          ? doc.value.sommPriceSuggestEnabled : defaults.sommPriceSuggestEnabled,
       };
 
       // One-time migration: a stored config from before the embedding-quality

--- a/backend/src/routes/somm/maturity.js
+++ b/backend/src/routes/somm/maturity.js
@@ -6,6 +6,7 @@ const { isValidId } = require('../../utils/validation');
 const { parsePagination } = require('../../utils/pagination');
 const { logAudit } = require('../../services/audit');
 
+const aiConfig = require('../../config/aiConfig');
 const { suggestDrinkWindow } = require('../../services/labelScan');
 
 const router = express.Router();
@@ -214,6 +215,16 @@ router.post('/:id/ai-suggest', requireSommOrAdmin, async (req, res) => {
     }
 
     const wine = profile.wineDefinition;
+    // Cost control (Johan 2026-08-21): the suggestion answers a question the
+    // curator is already researching by hand, and they work on a flat-rate
+    // subscription. 503 rather than a silent empty result, with the reason
+    // spelled out so the caller knows to research rather than retry.
+    if (!aiConfig.get().sommMaturitySuggestEnabled) {
+      return res.status(503).json({
+        error: 'AI drink-window suggestions are turned off — set the window from your own research.',
+        code: 'suggestion_disabled',
+      });
+    }
     const result = await suggestDrinkWindow({
       name: wine?.name,
       producer: wine?.producer,

--- a/backend/src/routes/somm/prices.js
+++ b/backend/src/routes/somm/prices.js
@@ -12,6 +12,7 @@ const { logAudit } = require('../../services/audit');
 const { stripHtml } = require('../../utils/sanitize');
 const { SUPPORTED_CURRENCIES } = require('../../config/currencies');
 
+const aiConfig = require('../../config/aiConfig');
 const { suggestPrice } = require('../../services/labelScan');
 
 const router = express.Router();
@@ -208,6 +209,14 @@ router.post('/ai-suggest', requireSommOrAdmin, async (req, res) => {
       return res.status(404).json({ error: 'Wine definition not found' });
     }
 
+    // Cost control (Johan 2026-08-21) — see the same gate on the maturity
+    // suggestion. The curator researches market prices anyway.
+    if (!aiConfig.get().sommPriceSuggestEnabled) {
+      return res.status(503).json({
+        error: 'AI price suggestions are turned off — set the price from your own research.',
+        code: 'suggestion_disabled',
+      });
+    }
     const result = await suggestPrice({
       name: wine.name,
       producer: wine.producer,

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -474,6 +474,52 @@ router.patch('/ai/enrichment-gate', async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// PATCH /api/superadmin/ai/enrichment-on-add
+// Who pays for a new wine's first profile (Johan 2026-08-21). At ~120 new
+// wines a day the per-add hook — not the admin batch runs — is the steady API
+// spend, and it targets the least reliable population: freshly scanned labels
+// with no region, where the generation gate spends two calls and publishes
+// nothing. Same aiConfig storage as the knobs above, so changing the policy
+// (or turning it off entirely) never needs a release.
+// ---------------------------------------------------------------------------
+const ENRICHMENT_ON_ADD_MODES = ['always', 'sufficient', 'off'];
+router.patch('/ai/enrichment-on-add', async (req, res) => {
+  const mode = req.body.mode;
+  const { sommMaturitySuggestEnabled, sommPriceSuggestEnabled } = req.body;
+  if (!ENRICHMENT_ON_ADD_MODES.includes(mode)) {
+    return res.status(400).json({ error: `mode must be one of: ${ENRICHMENT_ON_ADD_MODES.join(', ')}` });
+  }
+  for (const [k, v] of [['sommMaturitySuggestEnabled', sommMaturitySuggestEnabled], ['sommPriceSuggestEnabled', sommPriceSuggestEnabled]]) {
+    if (v !== undefined && typeof v !== 'boolean') {
+      return res.status(400).json({ error: `${k} must be a boolean` });
+    }
+  }
+  try {
+    const current = aiConfig.getRaw();
+    const updated = {
+      ...current,
+      enrichmentOnAdd: mode,
+      // Absent means unchanged, so a caller that only flips the policy does
+      // not silently reset the sommelier switches.
+      ...(sommMaturitySuggestEnabled !== undefined ? { sommMaturitySuggestEnabled } : {}),
+      ...(sommPriceSuggestEnabled !== undefined ? { sommPriceSuggestEnabled } : {}),
+    };
+    await updateSiteConfig('aiConfig', updated, req.user.id);
+    aiConfig.set(updated);
+    // Attribution rides on updateSiteConfig(req.user.id), same as the gate
+    // and search knobs above — no separate audit row.
+    res.json({
+      enrichmentOnAdd: updated.enrichmentOnAdd,
+      sommMaturitySuggestEnabled: updated.sommMaturitySuggestEnabled,
+      sommPriceSuggestEnabled: updated.sommPriceSuggestEnabled,
+    });
+  } catch (error) {
+    console.error('[superadmin] enrichment-on-add error:', error);
+    res.status(500).json({ error: 'Failed to save the on-add policy' });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // PATCH /api/superadmin/ai/enrichment-search
 // The web-search rescue pilot's two knobs (2026-08-19): kill-switch + daily
 // cap. Same aiConfig storage as the gate above — turning the pilot off never

--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -461,7 +461,8 @@ async function addBottle(cellarDoc, wineDoc, fields = {}, req) {
   const { embedSinglePair } = require('./embeddingJob');
   embedSinglePair(wineDoc._id, bottle.vintage).catch(() => {});
   const { enrichWineById } = require('./enrichmentJob');
-  enrichWineById(wineDoc._id, { budgetUserId: req && req.user ? req.user.id : undefined }).catch(() => {});
+  // trigger:'add' — subject to the enrichmentOnAdd policy (aiConfig).
+  enrichWineById(wineDoc._id, { budgetUserId: req && req.user ? req.user.id : undefined, trigger: 'add' }).catch(() => {});
   const { resolveRestockAlerts } = require('./restockChecker');
   resolveRestockAlerts(req?.user?.id || cellarDoc.user, wineDoc._id, bottle._id).catch(() => {});
 

--- a/backend/src/services/bottleOps.test.js
+++ b/backend/src/services/bottleOps.test.js
@@ -158,7 +158,11 @@ describe('addBottle (real execution)', () => {
     expect(b.cellarHistory).toEqual([{ cellar: 'c1', cellarName: 'Main Cellar', enteredAt: b.createdAt }]);
     expect(b.user).toBe('owner1');             // owner = cellar owner
     expect(embedSinglePair).toHaveBeenCalledWith('w1', '2019');
-    expect(enrichWineById).toHaveBeenCalledWith('w1', { budgetUserId: 'u1' });
+    // trigger:'add' marks this as the automatic per-add hook, which the
+    // enrichmentOnAdd policy gates (aiConfig, 2026-08-21). Deliberate calls
+    // — release, identity-edit re-enrich, batch — pass no trigger and always
+    // run, so this argument is what separates incidental spend from chosen.
+    expect(enrichWineById).toHaveBeenCalledWith('w1', { budgetUserId: 'u1', trigger: 'add' });
     // wineName rides along so the Cellar Audit page shows what was added (M5).
     expect(logAudit).toHaveBeenCalledWith(REQ, 'bottle.add', expect.anything(), { wineName: 'Barolo', vintage: '2019' });
   });

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -883,7 +883,14 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
  *   the producer as suspect (the human-override path: an admin reviewed the
  *   doubt and judged the identity fine).
  */
-async function enrichWineById(wineDefId, { budgetUserId, force = false, publishSuspect = false, curatorContext = null } = {}) {
+/**
+ * @param {object} [opts]
+ * @param {'add'} [opts.trigger] — this call is the automatic per-add hook, so
+ *   the enrichmentOnAdd policy applies. Absent means a deliberate call (batch
+ *   loop, curator release, identity-edit follow-through) which the policy
+ *   never gates: those are chosen, not incidental.
+ */
+async function enrichWineById(wineDefId, { budgetUserId, force = false, publishSuspect = false, curatorContext = null, trigger = null } = {}) {
   // Validate + cast the (caller-supplied) id to a real ObjectId before it touches
   // the query, so a non-id value can never shape the database lookup. The cast
   // value (idStr/oid), never the raw input, is used everywhere below.
@@ -911,6 +918,21 @@ async function enrichWineById(wineDefId, { budgetUserId, force = false, publishS
     // spend the adding user's daily AI budget describing a producerless wine.
     if (wine.pendingIdentity === true) return;
     if (wine.aiProfile && wine.aiProfile.source === 'curator') return; // hand-corrected — never regenerate (force included)
+    // Per-add policy (Johan 2026-08-21). Checked AFTER the wine is loaded
+    // because 'sufficient' reads the record, and before any spend. Only the
+    // automatic hook is gated: a curator release or an identity-edit
+    // follow-through is a deliberate act and always runs.
+    if (trigger === 'add') {
+      const mode = aiConfig.get().enrichmentOnAdd;
+      if (mode === 'off') return;
+      if (mode === 'sufficient' && !identityDataSufficient(wine)) {
+        // Not a failure: the record cannot support a true statement about
+        // place or variety yet, and the sommelier researches exactly this
+        // while setting its drink window.
+        console.log(`[enrichmentJob] on-add skipped (${idStr}): identity too thin for an honest profile`);
+        return undefined;
+      }
+    }
     if (!force) {
       if (wine.aiProfile && wine.aiProfile.description) return; // already enriched
       // HELD is a decision awaiting a human, not a gap to retry: without this

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -32,6 +32,8 @@ jest.mock('./embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValu
 jest.mock('./aiBudget', () => ({ tryDebitAi: jest.fn(), isRefundableFailure: jest.fn(() => false) }));
 jest.mock('../config/aiConfig', () => ({ get: jest.fn(() => ({
   enrichmentModel: 'claude-sonnet-5',
+  // Default policy for the per-add hook; individual tests override.
+  enrichmentOnAdd: 'always',
   // The publication gate's calibrated defaults (ticket 6a83e765) — the
   // end-to-end tests below exercise holds on both sides of them.
   enrichmentHoldConfidenceFloor: 0.4,
@@ -1215,5 +1217,78 @@ describe('regeneration never destroys a reviewed published profile', () => {
     await enrichWineById(WINE_ID);
     const $set = WineDefinition.updateOne.mock.calls[0][1].$set;
     expect('profileReviewedAt' in $set).toBe(false);
+  });
+});
+
+/**
+ * The per-add enrichment policy (Johan 2026-08-21).
+ *
+ * Adding a bottle fires an enrichment per newly-minted wine — ~120 a day, and
+ * the steady API spend once batch runs stop. It is also the least reliable
+ * population: a freshly scanned label often has no region, which is where the
+ * generation gate spends two calls and publishes nothing. The policy gates
+ * ONLY that automatic hook; deliberate calls are never gated.
+ */
+describe('enrichmentOnAdd policy', () => {
+  const aiConfig = require('../config/aiConfig');
+  const base = {
+    enrichmentModel: 'claude-sonnet-5',
+    enrichmentHoldConfidenceFloor: 0.4,
+    enrichmentHoldUnknownConfidenceBar: 0.55,
+  };
+  const setMode = (enrichmentOnAdd) => aiConfig.get.mockReturnValue({ ...base, enrichmentOnAdd });
+
+  const thin = { _id: WINE_ID, name: 'Mystery', producer: 'Someone', type: 'red', country: { name: 'France' }, region: null, appellation: null, grapes: [] };
+  const rich = { ...thin, region: { name: 'Marlborough' }, grapes: [{ name: 'Pinot Noir' }] };
+
+  const profile = () => ({
+    data: { body: 'medium', tannin: 'low', acidity: 'medium', sweetness: 'dry', flavors: ['cherry'], foodPairings: ['duck'], description: 'A bright, easy red.', confidence: 0.7 },
+    debugReason: null,
+  });
+
+  afterEach(() => setMode('always'));
+
+  test("'off' skips the add hook entirely — no model call, no write", async () => {
+    setMode('off');
+    WineDefinition.findById.mockReturnValue(chain(rich));
+    suggestProfile.mockResolvedValue(profile());
+    await enrichWineById(WINE_ID, { trigger: 'add' });
+    expect(suggestProfile).not.toHaveBeenCalled();
+    expect(WineDefinition.updateOne).not.toHaveBeenCalled();
+  });
+
+  test("'sufficient' skips a record that cannot support a true statement", async () => {
+    setMode('sufficient');
+    WineDefinition.findById.mockReturnValue(chain(thin)); // no region, no appellation
+    suggestProfile.mockResolvedValue(profile());
+    await enrichWineById(WINE_ID, { trigger: 'add' });
+    expect(suggestProfile).not.toHaveBeenCalled();
+  });
+
+  test("'sufficient' still enriches a well-identified wine — the add stays instant", async () => {
+    setMode('sufficient');
+    WineDefinition.findById.mockReturnValue(chain(rich));
+    suggestProfile.mockResolvedValue(profile());
+    await enrichWineById(WINE_ID, { trigger: 'add' });
+    expect(suggestProfile).toHaveBeenCalledTimes(1);
+    expect(persisted().description).toMatch(/bright/);
+  });
+
+  // The policy is about incidental spend, never about deliberate curation:
+  // a release, an identity-edit follow-through or a batch run must always run.
+  test('a DELIBERATE call is never gated, even with the policy off', async () => {
+    setMode('off');
+    WineDefinition.findById.mockReturnValue(chain(thin));
+    suggestProfile.mockResolvedValue(profile());
+    await enrichWineById(WINE_ID); // no trigger — batch / release / re-enrich
+    expect(suggestProfile).toHaveBeenCalledTimes(1);
+  });
+
+  test("'always' preserves the legacy behaviour on a thin record", async () => {
+    setMode('always');
+    WineDefinition.findById.mockReturnValue(chain(thin));
+    suggestProfile.mockResolvedValue(profile());
+    await enrichWineById(WINE_ID, { trigger: 'add' });
+    expect(suggestProfile).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/services/pendingWineOps.js
+++ b/backend/src/services/pendingWineOps.js
@@ -551,6 +551,11 @@ async function runPromotionFollowThrough(wine) {
   // HAS a producer, so a tasting profile can finally be about something. No
   // budgetUserId: this is curation work, not a user action, so it is not
   // debited to whoever happened to add the bottle.
+  //
+  // Deliberately NOT passed trigger:'add' (2026-08-21): the enrichmentOnAdd
+  // policy exists to stop paying for profiles on records nobody has looked
+  // at, and this is the opposite — a curator has just supplied the identity
+  // by hand. Same family as reenrichAfterRecordEdit: chosen, not incidental.
   require('./enrichmentJob').enrichWineById(wine._id).catch?.(() => {});
   // The maturity queue refused to seed this wine while pending; seed it from
   // the bottles that are already in cellars, so the drink windows the owners

--- a/frontend/src/pages/SuperAdmin/TabAI.js
+++ b/frontend/src/pages/SuperAdmin/TabAI.js
@@ -493,6 +493,81 @@ function EnrichmentGatePanel({ floor, unknownBar, apiFetch }) {
   );
 }
 
+// Who pays for a new wine's first profile. Adding a bottle fires one
+// enrichment per newly-minted wine — at ~120 new wines a day that drip, not
+// the admin batch runs, is the steady API spend.
+function EnrichmentOnAddPanel({ mode, maturitySuggest, priceSuggest, apiFetch }) {
+  const [val, setVal] = useState(mode ?? 'sufficient');
+  const [mat, setMat] = useState(maturitySuggest ?? true);
+  const [price, setPrice] = useState(priceSuggest ?? true);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState(null);
+
+  const save = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      const res = await apiFetch('/api/superadmin/ai/enrichment-on-add', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: val, sommMaturitySuggestEnabled: !!mat, sommPriceSuggestEnabled: !!price }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setMsg({ ok: false, text: d.error || 'Save failed' });
+      } else {
+        setMsg({ ok: true, text: 'Saved — applies to the next bottle added' });
+      }
+    } catch {
+      setMsg({ ok: false, text: 'Network error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const selStyle = { background: 'var(--sa-bg)', border: '1px solid var(--sa-border)', color: 'var(--sa-text)', padding: '2px 6px', borderRadius: 3, fontFamily: 'monospace', fontSize: 12 };
+  return (
+    <div className="sa-panel" style={{ marginTop: 16 }}>
+      <div className="sa-panel-header">
+        <span className="sa-panel-title">AI Spend Controls</span>
+        <button className="sa-btn" onClick={save} disabled={saving}>{saving ? 'Saving...' : 'Save'}</button>
+      </div>
+      <div className="sa-panel-body">
+        <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginBottom: 12 }}>
+          The paths that spend API credit without a user asking. Label scan, AI wine search and cellar chat are
+          deliberately NOT here — they are the add-bottle experience and the product. Batch enrichment is separate and
+          only runs when you start one. Curator work — releases, identity-edit re-enrichment, promoting a pending
+          wine — is never gated.
+        </div>
+        <div className="sa-kv">
+          <div className="sa-kv-row">
+            <span className="sa-kv-key">Enrich on bottle add</span>
+            <select value={val} onChange={e => setVal(e.target.value)} style={selStyle}>
+              <option value="always">always — enrich every new wine</option>
+              <option value="sufficient">sufficient — only with a region/appellation and a grape or type</option>
+              <option value="off">off — profiles come from the sommelier only</option>
+            </select>
+          </div>
+          <div className="sa-kv-row">
+            <span className="sa-kv-key">Sommelier drink-window suggestions</span>
+            <input type="checkbox" checked={!!mat} onChange={e => setMat(e.target.checked)} />
+          </div>
+          <div className="sa-kv-row">
+            <span className="sa-kv-key">Sommelier price suggestions</span>
+            <input type="checkbox" checked={!!price} onChange={e => setPrice(e.target.checked)} />
+          </div>
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--sa-text-dim)', marginTop: 10 }}>
+          The two sommelier switches answer questions the curator already researches by hand while setting a window or
+          a price — and they work on a flat-rate subscription, so turning these off moves the cost, not the work. Both
+          return a clear &ldquo;turned off, research it yourself&rdquo; message rather than failing silently.
+        </div>
+        {msg && <div style={{ fontSize: 11, marginTop: 8, color: msg.ok ? 'var(--sa-green)' : 'var(--sa-red)' }}>{msg.text}</div>}
+      </div>
+    </div>
+  );
+}
+
 function EnrichmentSearchPanel({ enabled, dailyCap, apiFetch }) {
   const [on, setOn] = useState(enabled ?? true);
   const [cap, setCap] = useState(dailyCap ?? 5);
@@ -1232,6 +1307,12 @@ export default function TabAI() {
       <ChatLimitPanel limit={config.chatDailyLimit ?? 50} apiFetch={apiFetch} />
       <EnrichmentGatePanel floor={config.enrichmentHoldConfidenceFloor ?? 0.4} unknownBar={config.enrichmentHoldUnknownConfidenceBar ?? 0.55} apiFetch={apiFetch} />
       <EnrichmentSearchPanel enabled={config.enrichmentSearchEnabled ?? true} dailyCap={config.enrichmentSearchDailyCap ?? 5} apiFetch={apiFetch} />
+      <EnrichmentOnAddPanel
+        mode={config.enrichmentOnAdd ?? 'sufficient'}
+        maturitySuggest={config.sommMaturitySuggestEnabled ?? true}
+        priceSuggest={config.sommPriceSuggestEnabled ?? true}
+        apiFetch={apiFetch}
+      />
       <ChatUsagePanel />
     </>
   );


### PR DESCRIPTION
Three live-config switches in **Superadmin → AI**, none needing a release to change.

| Switch | Default | What it stops |
|---|---|---|
| `enrichmentOnAdd` | `sufficient` | Enriching a new wine on bottle-add unless the record has a place **and** a grape or type |
| `sommMaturitySuggestEnabled` | on | AI drink-window suggestions |
| `sommPriceSuggestEnabled` | on | AI price suggestions |

**Why the add hook is the target.** ~120 new wines a day, and with batch runs stopped that drip *is* the steady spend. It's also the least reliable population: a freshly scanned label often has no region, which is exactly where v1.150's generation gate spends **two** calls and then publishes nothing. So the worst-quality half costs the most.

**Why the two sommelier switches.** Both answer questions the curator is already researching by hand while setting a window or a price — and they work on a flat-rate subscription. Turning these off moves the cost, not the work. Both return `503` with a plain "research it yourself" reason rather than failing silently.

**Deliberately not switchable:** label scan, AI wine search, cellar chat — those are the add-bottle experience and the product.

**Scope discipline:** the policy gates only the *automatic* hook. A curator release, identity-edit follow-through, pending-wine promotion or batch run always runs — `pendingWineOps` carries an explicit comment, since that call site looks identical and is deliberately ungated.

Tests: 5 new policy tests (off / sufficient-skips-thin / sufficient-allows-rich / deliberate-never-gated / always-legacy); 168 backend across the touched suites, 990 frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)