### PR TITLE
feat(somm): blank-fill identity corrections apply on filing, name-checked

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -48,6 +48,16 @@ jest.mock('../models/WineVintagePrice', () => {
 jest.mock('../models/PriceTrackingRequest', () => ({ find: jest.fn(), findOne: jest.fn(), findById: jest.fn(), deleteOne: jest.fn(), findOneAndUpdate: jest.fn() }));
 jest.mock('../models/PriceTrackingSkip', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), deleteOne: jest.fn() }));
 jest.mock('../models/WineCorrectionProposal', () => ({ create: jest.fn(), findById: jest.fn(), deleteOne: jest.fn(), find: jest.fn(), countDocuments: jest.fn() }));
+// The self-apply path (2026-08-21) reaches the admin route's own approveProposal
+// rather than duplicating the write. Mocked so this suite stays a unit test of
+// the TOOL's routing; the apply itself is covered by wineProposals.test.js and
+// the direct/gated decision by services/proposalDirectApply.test.js.
+jest.mock('../routes/admin/wineProposals', () => ({ approveProposal: jest.fn() }));
+// Defaults to GATED so every pre-existing proposal test keeps asserting the
+// admin-review path it was written for; the self-apply tests opt in.
+jest.mock('../services/proposalDirectApply', () => ({
+  classifyProposal: jest.fn(async () => ({ direct: false, reason: 'admin-reviewed' })),
+}));
 jest.mock('../models/ProfileAuditSample', () => ({ create: jest.fn(), find: jest.fn() }));
 jest.mock('../models/WineReport', () => ({ find: jest.fn(), findById: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../utils/cellarCred', () => ({ incrementCred: jest.fn().mockResolvedValue(undefined) }));
@@ -1054,6 +1064,99 @@ describe('propose_wine_correction', () => {
     WineDefinition.findById.mockReturnValue(chain(w));
     return w;
   };
+
+  // --- self-apply (2026-08-21) ---------------------------------------------
+  // The tool's job here is ROUTING: ask the classifier, and either apply
+  // through the admin route's own approveProposal or leave the row pending.
+  describe('self-apply', () => {
+    const { classifyProposal } = require('../services/proposalDirectApply');
+    const { approveProposal } = require('../routes/admin/wineProposals');
+
+    test('a blank-fill correction applies on filing and reports it as applied', async () => {
+      mkWine({ appellation: null });
+      WineCorrectionProposal.create.mockResolvedValue({ _id: 'prop-2' });
+      classifyProposal.mockResolvedValueOnce({ direct: true, reason: 'blank, reversible' });
+      approveProposal.mockResolvedValueOnce({ status: 200, body: { appliedNote: 'Applied: appellation, region' } });
+
+      const body = parse(await tool('propose_wine_correction').handler({
+        wine_id: WINE_ID, kind: 'field_correction',
+        proposed_fields: { appellation: 'Barolo', region: 'Piedmont' },
+        reason: REASON,
+      }, SOMM_CTX));
+
+      expect(body.data.status).toBe('approved');
+      expect(body.data.applied_note).toBe('Applied: appellation, region');
+      expect(body.summary).toMatch(/^Applied to/);
+      // Applied through the ONE write path, with the proposal id — not a
+      // second implementation that could drift from canonicalization.
+      expect(approveProposal).toHaveBeenCalledWith('prop-2', expect.anything());
+      // The row is still written first: review-after, not no-review.
+      expect(WineCorrectionProposal.create).toHaveBeenCalled();
+    });
+
+    test('a failed apply reports PENDING — never a false success', async () => {
+      // If the apply loses a race or 409s, the curator must not be told the
+      // registry changed. The row stays pending and an admin picks it up.
+      mkWine({ appellation: null });
+      WineCorrectionProposal.create.mockResolvedValue({ _id: 'prop-3' });
+      classifyProposal.mockResolvedValueOnce({ direct: true, reason: 'blank, reversible' });
+      approveProposal.mockResolvedValueOnce({ status: 409, body: { error: 'already decided' } });
+
+      const body = parse(await tool('propose_wine_correction').handler({
+        wine_id: WINE_ID, kind: 'field_correction',
+        proposed_fields: { appellation: 'Barolo' }, reason: REASON,
+      }, SOMM_CTX));
+
+      expect(body.data.status).toBe('pending');
+      expect(body.data.applied_note).toBeUndefined();
+    });
+
+    test('a THROWN apply also reports pending rather than 500-ing the tool', async () => {
+      mkWine({ appellation: null });
+      WineCorrectionProposal.create.mockResolvedValue({ _id: 'prop-4' });
+      classifyProposal.mockResolvedValueOnce({ direct: true, reason: 'blank, reversible' });
+      approveProposal.mockRejectedValueOnce(new Error('mongo went away'));
+
+      const body = parse(await tool('propose_wine_correction').handler({
+        wine_id: WINE_ID, kind: 'field_correction',
+        proposed_fields: { appellation: 'Barolo' }, reason: REASON,
+      }, SOMM_CTX));
+
+      expect(body.error).toBeUndefined();
+      expect(body.data.status).toBe('pending');
+    });
+
+    test('a gated correction is never applied, and says why it is being reviewed', async () => {
+      mkWine();
+      WineCorrectionProposal.create.mockResolvedValue({ _id: 'prop-5' });
+      classifyProposal.mockResolvedValueOnce({
+        direct: false, reason: 'The wine\'s name states "Rosso Veronese" but the proposal says "Veneto IGT"',
+      });
+
+      const body = parse(await tool('propose_wine_correction').handler({
+        wine_id: WINE_ID, kind: 'field_correction',
+        proposed_fields: { appellation: 'Veneto IGT' }, reason: REASON,
+      }, SOMM_CTX));
+
+      expect(body.data.status).toBe('pending');
+      expect(body.data.why_reviewed).toMatch(/Rosso Veronese/);
+      expect(approveProposal).not.toHaveBeenCalled();
+    });
+
+    test('merges never reach the classifier at all', async () => {
+      mkWine();
+      WineDefinition.findById.mockReturnValueOnce(chain(mkWine()))
+        .mockReturnValueOnce(chain({ _id: TARGET_ID, name: 'Barolo', producer: 'Pira' }));
+      WineCorrectionProposal.create.mockResolvedValue({ _id: 'prop-6' });
+
+      const body = parse(await tool('propose_wine_correction').handler({
+        wine_id: WINE_ID, kind: 'merge', merge_target_id: TARGET_ID, reason: REASON,
+      }, SOMM_CTX));
+
+      expect(body.data.status).toBe('pending');
+      expect(approveProposal).not.toHaveBeenCalled();
+    });
+  });
 
   test('files a field_correction: snapshot captured, ledger row + audit written, nothing applied', async () => {
     mkWine();

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -24,6 +24,7 @@ const { logAudit } = require('../../services/audit');
 const { SUPPORTED_CURRENCIES } = require('../../config/currencies');
 const { isValidId } = require('../../utils/validation');
 const { stripHtml } = require('../../utils/sanitize');
+const { classifyProposal } = require('../../services/proposalDirectApply');
 const { ok, fail, objectId, pageParams } = require('../toolUtil');
 const { logAction } = require('../actionLedger');
 const {
@@ -1582,18 +1583,26 @@ const PROPOSAL_URL_MAX = 500;
 
 registerTool({
   name: 'propose_wine_correction',
-  title: 'Sommelier: propose an identity fix, merge or non-wine flag (admin-reviewed)',
+  title: 'Sommelier: correct an identity field, merge or flag a non-wine',
   description:
-    'Files a correction PROPOSAL on a registry wine for an admin to review — nothing changes until they approve. ' +
+    'Files a correction on a registry wine. A correction that only FILLS BLANK appellation, region or classification '
+    + 'fields, and does not contradict the wine\'s own name, APPLIES IMMEDIATELY — the reply says "Applied" and gives '
+    + 'the applied_note. Everything else is filed for an admin and the reply says "awaiting admin review" with '
+    + 'why_reviewed: producer and name (they drive the dedup key and the public URL), country, any OVERWRITE of a '
+    + 'field that already has a value, merges, non-wine flags, and any appellation that disagrees with an appellation '
+    + 'stated in the wine\'s name. That last one is a ROUTING rule, not a verdict — an Australian "Prosecco" really is '
+    + 'a King Valley wine and not the Italian DOC, so file it with your evidence and an admin will read it. ' +
     'THIS is the path for the identity fields set_wine_profile deliberately does not cover: producer, name, ' +
     'appellation, region, country and classification (kind "field_correction", region/country as plain names — ' +
-    'resolved against the taxonomy at approval, never minted). Also: kind "merge" when this wine duplicates another ' +
+    'resolved against the taxonomy when it applies, never minted). Also: kind "merge" when this wine duplicates another ' +
     'registry wine (merge_target_id = the wine that should SURVIVE), and kind "non_wine" when the row is not wine at ' +
     'all (spirits/cider/sake) and should be quarantined out of search and the maturity queue. Always give the reason ' +
     'the somm established, and cite an evidence_url (producer site, appellation register) — evidence is what makes a ' +
     'one-click approval possible. One pending proposal per wine and kind — list_pending_corrections shows what is ' +
     'already filed. MERGE proposals are decided in Admin → Wines on the web, DELIBERATELY not over MCP: a wine ' +
-    'merge moves bottles and rewrites references (same stance as taxonomy merge). Reversible via undo_last while pending.',
+    'merge moves bottles and rewrites references (same stance as taxonomy merge), and the merge DELETES the absorbed '
+    + 'record — there is no unmerge. undo_last withdraws a proposal that is still pending; one that already applied is '
+    + 'changed by filing a further correction.',
   scope: 'write',
   requireRole: SOMM_ROLES,
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
@@ -1756,10 +1765,65 @@ registerTool({
         via: 'mcp',
       });
 
+    // SELF-APPLY (2026-08-21). A correction that only FILLS BLANKS on
+    // reversible fields, and does not contradict the wine's own name, applies
+    // on filing instead of waiting for an admin — see
+    // services/proposalDirectApply for why that line and not another.
+    //
+    // The proposal row is still written first and still carries the reason and
+    // evidence: oversight moves from approve-BEFORE to review-AFTER, it does
+    // not disappear. Applying through the admin route's own approveProposal
+    // (rather than a second write path) is what keeps canonicalization, the
+    // dedup key, the search/embed/IndexNow follow-through and the re-enrich
+    // identical between the two doors.
+    let applied = null;
+    let reviewReason = null;
+    if (args.kind === 'field_correction') {
+      // Required lazily: wineProposals pulls in the whole admin route tree
+      // (which requires the MCP registry back), so a top-level require here
+      // would close a cycle.
+      const { approveProposal } = require('../../routes/admin/wineProposals');
+      const verdict = await classifyProposal(wine, args.kind, proposedFields);
+      if (verdict.direct) {
+        // approveProposal reads req.user.id for decidedBy and for its audit
+        // attribution. ctx.req IS the express req on every real call; the
+        // fallback keeps unit contexts (ctx.req: null) working.
+        const asReq = ctx.req && ctx.req.user ? ctx.req : { user: { id: ctx.user.id } };
+        try {
+          const outcome = await approveProposal(proposal._id, asReq);
+          if (outcome.status === 200) {
+            applied = outcome.body?.appliedNote || 'Applied';
+          } else {
+            // The proposal stays pending and an admin picks it up — a failed
+            // self-apply must never look like a success to the curator.
+            console.warn(`[somm] self-apply declined for proposal ${proposal._id}: ${outcome.status} ${outcome.body?.error || ''}`);
+          }
+        } catch (err) {
+          console.error(`[somm] self-apply threw for proposal ${proposal._id}:`, err.message);
+        }
+      } else {
+        reviewReason = verdict.reason;
+      }
+    }
+
     const kindLabel = args.kind === 'merge'
       ? `merge into ${target.producer ? `${target.producer} — ` : ''}${target.name}`
       : args.kind === 'non_wine' ? 'non-wine quarantine' : 'identity-field correction';
-    const envelope = {
+    const envelope = applied ? {
+      summary: `Applied to ${wine.producer} — ${wine.name}: ${applied}`,
+      data: {
+        proposal_id: proposal._id,
+        wine_id: wine._id,
+        kind: args.kind,
+        status: 'approved',
+        ...(proposedFields ? { proposed_fields: proposedFields } : {}),
+        evidence_url: evidenceUrl || null,
+        applied_note: applied,
+        note: 'Live on the wine now. Blank identity fields that agree with the name apply on filing; '
+          + 'the proposal is kept with your reason so an admin can review it afterwards.',
+        undo: 'This is already applied — file a further correction to change it again.',
+      },
+    } : {
       summary: `Proposal filed: ${kindLabel} for ${wine.producer} — ${wine.name} (awaiting admin review)`,
       data: {
         proposal_id: proposal._id,
@@ -1769,6 +1833,7 @@ registerTool({
         ...(proposedFields ? { proposed_fields: proposedFields } : {}),
         ...(target ? { merge_target: { wine_id: target._id, name: target.name, producer: target.producer || null } } : {}),
         evidence_url: evidenceUrl || null,
+        ...(reviewReason ? { why_reviewed: reviewReason } : {}),
         note: 'Nothing has changed — the wine stays as-is until an admin reviews the diff and approves.',
         undo: 'undo_last withdraws the proposal while it is still pending',
       },

--- a/backend/src/routes/admin/wineProposals.js
+++ b/backend/src/routes/admin/wineProposals.js
@@ -545,3 +545,10 @@ router.post('/bulk-reject', async (req, res) => {
 });
 
 module.exports = router;
+// Exported for the MCP self-apply path (services/proposalDirectApply decides
+// WHICH proposals may take it). Deliberately the same function the admin route
+// calls rather than a second write path: canonicalization, the dedup-key regen,
+// the search/embedding/IndexNow follow-through and the re-enrich all live here,
+// and a parallel implementation would drift from them silently — which is
+// exactly how "Yecla DO" once reached a wine unresolved.
+module.exports.approveProposal = approveProposal;

--- a/backend/src/services/proposalDirectApply.js
+++ b/backend/src/services/proposalDirectApply.js
@@ -1,0 +1,174 @@
+/**
+ * Which curator corrections may apply themselves, and which still need an
+ * admin (2026-08-21).
+ *
+ * WHY. Every identity correction used to wait for an admin click. Measured over
+ * one full curation day: 16 proposals filed, ONE needed the gate. The other
+ * fifteen were lookups ("Barolo by Cà di Bruno is in Piedmont") that spent the
+ * scarcest resource in the loop — the admin's attention — and, worse,
+ * serialised the curator behind it. They finished a block and idled waiting for
+ * a review round trip while 231 new wines arrived from a single import the same
+ * morning. The gate was not wrong; it was priced wrong.
+ *
+ * THE LINE IS REVERSIBILITY, NOT TRUST. A proposal applies itself only when it
+ * FILLS A BLANK on a field that can be edited back:
+ *
+ *   appellation / region / classification, each currently empty
+ *
+ * Everything else keeps the admin gate, for reasons that are specific rather
+ * than cautious:
+ *   - producer / name  drive normalizedKey and the public URL, and are the
+ *                      class with measured failures (5 curator assertions
+ *                      overturned by web verification, 2026-08-10)
+ *   - merge            performWineMerge ends in source.deleteOne() — the
+ *                      absorbed record is destroyed, not tombstoned, so an
+ *                      unmerge means rebuilding it by hand
+ *   - non_wine         quarantines a row out of search and the queue
+ *   - country          coarse, near-never blank on a real record, severe wrong
+ *   - OVERWRITES       replacing a value someone already curated is a
+ *                      different act from filling a blank
+ *
+ * THE NAME CHECK is the part that earns the loosened gate. The single proposal
+ * the human gate caught that day was a wine named "Rosso Veronese" receiving
+ * appellation "Veneto IGT" — a different denomination from the one its own name
+ * states. That is mechanisable, and it generalises: if a wine's NAME contains a
+ * curated appellation, a proposal naming a DIFFERENT one is a claim about the
+ * label contradicting the record, which is exactly the judgement an admin
+ * should keep.
+ *
+ * Crucially the check ROUTES, it does not REFUSE. Same day, the same rule fires
+ * on "Prosecco" by Two Pairs → King Valley — and there the curator was RIGHT: a
+ * King Valley Glera is a real category and stamping the Italian DOC on it would
+ * have been the error. A rule that blocked the mismatch would have blocked the
+ * most valuable correction of the day. So a mismatch means "an admin reads
+ * this", never "this is wrong".
+ *
+ * Replayed over that day's 16: eleven apply themselves, and all three needing
+ * judgement (Prosecco, Rosso Veronese, and the Monatio class — a name carrying
+ * the generic designation "Vino Rosso", whose whole legal meaning is the
+ * ABSENCE of a geographic indication) route to review.
+ */
+const Appellation = require('../models/Appellation');
+const { normalizeAppellationKey } = require('../utils/normalize');
+
+// Blank-fillable, reversible, and not part of the dedup key.
+const DIRECT_FIELDS = ['appellation', 'region', 'classification'];
+
+// A name is at most this many tokens deep for candidate generation — guards a
+// pathological title from generating a quadratic number of lookups.
+const MAX_NAME_TOKENS = 12;
+
+/** True when the wine currently carries no value for this identity field. */
+function fieldIsEmpty(wine, field) {
+  const v = field === 'region' ? wine.region : wine[field];
+  if (v === undefined || v === null) return true;
+  // region is a ref; a populated doc or an ObjectId both count as SET.
+  if (field === 'region') return false;
+  return String(v).trim() === '';
+}
+
+/**
+ * The curated appellation a wine's NAME states, if any — longest match wins so
+ * "Chianti Classico" beats "Chianti" and the check compares like with like.
+ * Returns the Appellation doc, or null when the name claims no place.
+ */
+async function appellationImpliedByName(name) {
+  const tokens = String(name || '').trim().split(/\s+/).filter(Boolean).slice(0, MAX_NAME_TOKENS);
+  if (!tokens.length) return null;
+
+  // Every contiguous run of tokens, normalized the same way the resolver keys
+  // its docs. One query for all of them rather than a lookup per candidate.
+  const byKey = new Map();
+  for (let start = 0; start < tokens.length; start++) {
+    for (let end = start + 1; end <= tokens.length; end++) {
+      const phrase = tokens.slice(start, end).join(' ');
+      const key = normalizeAppellationKey(phrase);
+      if (!key) continue;
+      // Keep the longest phrase that produced each key.
+      const prev = byKey.get(key);
+      if (!prev || phrase.length > prev.length) byKey.set(key, phrase);
+    }
+  }
+  if (!byKey.size) return null;
+
+  const keys = [...byKey.keys()];
+  const docs = await Appellation.find({
+    $or: [{ normalizedName: { $in: keys } }, { normalizedSynonyms: { $in: keys } }],
+  }).lean();
+  if (!docs.length) return null;
+
+  // Longest matched PHRASE wins, measured on the doc's own canonical name so a
+  // short synonym cannot outrank the full appellation it stands for.
+  let best = null;
+  let bestLen = -1;
+  for (const doc of docs) {
+    const matchedKeys = [doc.normalizedName, ...(doc.normalizedSynonyms || [])].filter((k) => byKey.has(k));
+    for (const k of matchedKeys) {
+      const len = byKey.get(k).length;
+      if (len > bestLen) { bestLen = len; best = doc; }
+    }
+  }
+  return best;
+}
+
+/**
+ * Do a name-stated appellation and a proposed one agree? Equality on the
+ * normalized key, or one containing the other ("Côtes de Saint-Mont" in the
+ * name, "Saint-Mont" proposed — the post-2011 rename, not a contradiction).
+ */
+function appellationsAgree(nameDoc, proposed) {
+  const proposedKey = normalizeAppellationKey(proposed);
+  if (!proposedKey) return false;
+  const nameKeys = [nameDoc.normalizedName, ...(nameDoc.normalizedSynonyms || [])].filter(Boolean);
+  return nameKeys.some((k) => k === proposedKey || k.includes(proposedKey) || proposedKey.includes(k));
+}
+
+/**
+ * May this proposal apply itself?
+ *
+ * @returns {Promise<{direct: boolean, reason: string}>} reason is written for
+ *   the curator: when direct is false it says what to expect, not what failed.
+ */
+async function classifyProposal(wine, kind, proposedFields) {
+  if (kind !== 'field_correction') {
+    return { direct: false, reason: `${kind} proposals are always reviewed by an admin.` };
+  }
+  const fields = Object.keys(proposedFields || {});
+  if (!fields.length) return { direct: false, reason: 'No fields proposed.' };
+
+  const gated = fields.filter((f) => !DIRECT_FIELDS.includes(f));
+  if (gated.length) {
+    return {
+      direct: false,
+      reason: `${gated.join(', ')} ${gated.length > 1 ? 'are' : 'is'} admin-reviewed — only ${DIRECT_FIELDS.join(', ')} apply on filing.`,
+    };
+  }
+
+  const occupied = fields.filter((f) => !fieldIsEmpty(wine, f));
+  if (occupied.length) {
+    return {
+      direct: false,
+      reason: `${occupied.join(', ')} already ${occupied.length > 1 ? 'have' : 'has'} a value — replacing curated data is admin-reviewed. Filling a blank is not.`,
+    };
+  }
+
+  if (proposedFields.appellation) {
+    const implied = await appellationImpliedByName(wine.name);
+    if (implied && !appellationsAgree(implied, proposedFields.appellation)) {
+      return {
+        direct: false,
+        reason: `The wine's name states "${implied.name}" but the proposal says "${proposedFields.appellation}" — an admin reads that difference. This is not a rejection: the name is often the wrong one (an Australian "Prosecco" is a King Valley wine, not the Italian DOC).`,
+      };
+    }
+  }
+
+  return { direct: true, reason: 'Blank identity fields, reversible, consistent with the name.' };
+}
+
+module.exports = {
+  classifyProposal,
+  appellationImpliedByName,
+  appellationsAgree,
+  fieldIsEmpty,
+  DIRECT_FIELDS,
+};

--- a/backend/src/services/proposalDirectApply.test.js
+++ b/backend/src/services/proposalDirectApply.test.js
@@ -1,0 +1,157 @@
+/**
+ * The classifier is replayed against the REAL curation day it was designed
+ * from (2026-08-21, 16 proposals) rather than invented cases — the whole
+ * argument for loosening the gate rests on that day's numbers, so the test
+ * that guards it should be that day.
+ */
+const { classifyProposal, appellationImpliedByName, appellationsAgree } = require('./proposalDirectApply');
+const Appellation = require('../models/Appellation');
+
+// The curated appellations the day's names actually touch, with the shape the
+// real docs have (normalizedName as the resolver keys them).
+const CURATED = [
+  'Barolo', 'Barbaresco', 'Langhe', 'Chianti', 'Chianti Classico', 'Soave Classico',
+  'Rioja', 'Bourgogne Hautes-Côtes de Beaune', 'Saint-Mont', 'Prosecco', 'King Valley',
+  'Taurasi', 'Veronese', 'Rosso Veronese', 'Veneto', 'Vino Rosso', 'Barossa', 'Hunter Valley',
+];
+
+// The REAL keying function, not a hand-rolled copy: a mock that normalized
+// differently from production would let every test here pass while the live
+// lookup missed. "Côtes de Saint-Mont" and the hyphen fold make that a live
+// risk, not a theoretical one.
+const { normalizeAppellationKey: norm } = require('../utils/normalize');
+
+beforeEach(() => {
+  jest.spyOn(Appellation, 'find').mockImplementation((query) => {
+    const keys = query.$or[0].normalizedName.$in;
+    const docs = CURATED
+      .filter((name) => keys.includes(norm(name)))
+      .map((name) => ({ name, normalizedName: norm(name), normalizedSynonyms: [] }));
+    return { lean: async () => docs };
+  });
+});
+afterEach(() => jest.restoreAllMocks());
+
+const wine = (name, over = {}) => ({ name, appellation: null, region: null, classification: null, ...over });
+
+describe('appellationImpliedByName', () => {
+  it('takes the LONGEST match so a qualified appellation beats its parent', async () => {
+    // "Chianti Classico" contains "Chianti"; picking the shorter one would make
+    // a correct "Chianti Classico" proposal look like a contradiction.
+    expect((await appellationImpliedByName('Chianti Classico')).name).toBe('Chianti Classico');
+  });
+
+  it('finds an appellation embedded mid-name', async () => {
+    expect((await appellationImpliedByName('Della Società Taurasi Riserva')).name).toBe('Taurasi');
+    expect((await appellationImpliedByName('Langhe Nebbiolo')).name).toBe('Langhe');
+  });
+
+  it('returns null when the name states no place', async () => {
+    expect(await appellationImpliedByName('Barossa Shiraz Reserve')).toBeTruthy(); // Barossa IS curated
+    expect(await appellationImpliedByName('Cask 66')).toBeNull();
+    expect(await appellationImpliedByName('')).toBeNull();
+  });
+});
+
+describe('appellationsAgree — a rename is not a contradiction', () => {
+  it('accepts the containing form (Côtes de Saint-Mont / Saint-Mont, renamed 2011)', () => {
+    expect(appellationsAgree({ normalizedName: 'cotes de saint mont' }, 'Saint-Mont')).toBe(true);
+  });
+  it('rejects a different denomination', () => {
+    expect(appellationsAgree({ normalizedName: 'rosso veronese' }, 'Veneto IGT')).toBe(false);
+  });
+});
+
+describe('the 2026-08-21 curation day, replayed', () => {
+  // The eleven that were pure lookups — these are what the change is FOR.
+  const APPLIES = [
+    ['Barolo', { appellation: 'Barolo', region: 'Piedmont' }],
+    ['Barbaresco', { appellation: 'Barbaresco', region: 'Piedmont' }],
+    ['Langhe Nebbiolo', { appellation: 'Langhe', region: 'Piedmont' }],
+    ['Chianti Classico', { appellation: 'Chianti Classico', region: 'Tuscany' }],
+    ['Chianti', { appellation: 'Chianti', region: 'Tuscany' }],
+    ['Soave Classico', { appellation: 'Soave Classico', region: 'Veneto' }],
+    ['Rioja Reserva', { appellation: 'Rioja', region: 'Rioja', classification: 'Reserva' }],
+    ['Côtes de Saint-Mont', { appellation: 'Saint-Mont', region: 'South West France' }],
+    ['Bourgogne Hautes-Côtes de Beaune Rouge', { appellation: 'Bourgogne Hautes-Côtes de Beaune', region: 'Burgundy' }],
+    ['Pokolbin Hills Vermentino', { region: 'Hunter Valley' }],
+    ['Della Società Taurasi Riserva', { appellation: 'Taurasi', region: 'Campania', classification: 'Riserva' }],
+  ];
+
+  it.each(APPLIES)('applies on filing: %s', async (name, fields) => {
+    const v = await classifyProposal(wine(name), 'field_correction', fields);
+    expect(v).toEqual({ direct: true, reason: expect.any(String) });
+  });
+
+  it('ROUTES Rosso Veronese — the one case the human gate actually caught', async () => {
+    const v = await classifyProposal(wine('Rosso Veronese'), 'field_correction',
+      { appellation: 'Veneto IGT', region: 'Veneto' });
+    expect(v.direct).toBe(false);
+    expect(v.reason).toContain('Rosso Veronese');
+  });
+
+  it('ROUTES the Australian Prosecco — and calls it routing, not rejection', async () => {
+    // The curator was RIGHT here: King Valley Glera is a real category and the
+    // Italian DOC would have been the error. A rule that BLOCKED this would
+    // have blocked the most valuable correction of the day.
+    const v = await classifyProposal(wine('Prosecco'), 'field_correction',
+      { appellation: 'King Valley', region: 'King Valley' });
+    expect(v.direct).toBe(false);
+    expect(v.reason).toMatch(/not a rejection/i);
+  });
+
+  it('ROUTES a place onto a generic EU designation (the Monatio class)', async () => {
+    // "Vino Rosso" is legally defined by carrying NO geographic indication, and
+    // it is a curated appellation in its own right — so a proposal writing a
+    // place onto it contradicts the name and must be read by a human.
+    const v = await classifyProposal(wine('Monatio Vino Rosso Bio'), 'field_correction',
+      { appellation: 'Rosso Conero' });
+    expect(v.direct).toBe(false);
+  });
+});
+
+describe('what stays gated, and why', () => {
+  it('gates producer and name — dedup key, public URL, measured failure class', async () => {
+    for (const f of [{ producer: 'Zarea' }, { name: 'Almodí Petit Blanc' }]) {
+      const v = await classifyProposal(wine('Barolo'), 'field_correction', f);
+      expect(v.direct).toBe(false);
+      expect(v.reason).toMatch(/admin-reviewed/);
+    }
+  });
+
+  it('gates country', async () => {
+    expect((await classifyProposal(wine('Barolo'), 'field_correction', { country: 'Italy' })).direct).toBe(false);
+  });
+
+  it('gates type and grapes (they have their own direct path, set_wine_profile)', async () => {
+    const v = await classifyProposal(wine('Conte di Valle'), 'field_correction',
+      { region: 'Veneto', grapes: ['Corvina'] });
+    expect(v.direct).toBe(false);
+  });
+
+  it('gates an OVERWRITE even on an otherwise-direct field', async () => {
+    // Filling a blank and replacing curated data are different acts.
+    const v = await classifyProposal(
+      wine('Barolo', { appellation: 'Barbaresco' }), 'field_correction', { appellation: 'Barolo' });
+    expect(v.direct).toBe(false);
+    expect(v.reason).toMatch(/already has a value/);
+  });
+
+  it('treats a POPULATED region ref as set, not blank', async () => {
+    const v = await classifyProposal(
+      wine('Barolo', { region: { _id: 'r1', name: 'Piedmont' } }), 'field_correction', { region: 'Piedmont' });
+    expect(v.direct).toBe(false);
+  });
+
+  it('gates merges — performWineMerge deletes the absorbed record', async () => {
+    expect((await classifyProposal(wine('X'), 'merge', null)).direct).toBe(false);
+  });
+
+  it('gates non_wine quarantines', async () => {
+    expect((await classifyProposal(wine('X'), 'non_wine', null)).direct).toBe(false);
+  });
+
+  it('refuses an empty payload rather than applying nothing', async () => {
+    expect((await classifyProposal(wine('Barolo'), 'field_correction', {})).direct).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Measured over one full curation day (2026-08-21): **16 proposals filed, one needed the gate.** The other fifteen were lookups — *"Barolo by Cà di Bruno is in Piedmont"* — spending the scarcest resource in the loop on work a table could do.

Worse, the gate **serialised** the curator: they finished a block and idled waiting for a review round trip, while **231 new wines** arrived from one user's import the same morning. The gate wasn't wrong, it was priced wrong.

## The line is reversibility, not trust

Applies on filing — **blank** `appellation` / `region` / `classification` only.

Still gated, each for a specific reason:

| | Why |
|---|---|
| `producer` / `name` | drive `normalizedKey` and the public URL; the class with measured failures (5 curator assertions overturned 2026-08-10) |
| `merge` | `performWineMerge` ends in `source.deleteOne()` — **verified**: destroyed, not tombstoned. There is no unmerge. |
| `non_wine` | quarantines a row out of search and the queue |
| `country` | coarse, near-never blank, severe wrong |
| **overwrites** | replacing curated data ≠ filling a blank |

## The name check — and why it routes rather than refuses

The one proposal the gate caught was **"Rosso Veronese" → appellation "Veneto IGT"**: a different denomination from the one the wine's own name states. Mechanisable against the curated `Appellation` vocabulary, longest match first so "Chianti Classico" isn't read as contradicting "Chianti".

The same rule fires on **"Prosecco" → King Valley** — where the curator was **right**. King Valley Glera is a real category; the Italian DOC would have been the error. A rule that *blocked* mismatches would have blocked the most valuable correction of the day.

So a mismatch means *"an admin reads this"*, never *"this is wrong"* — and the `why_reviewed` string tells the curator that in those words.

## Replaying the actual day

`proposalDirectApply.test.js` runs that day's 16 rather than invented cases: **11 apply**, and all three needing judgement route — Prosecco, Rosso Veronese, and the Monatio class (a name carrying `Vino Rosso`, a curated designation whose legal meaning *is* the absence of a geographic indication).

## Oversight moves, it doesn't disappear

The proposal row is still written first, still carries reason + evidence, still audited — approve-**before** becomes review-**after**. Applying runs through the admin route's own `approveProposal`, not a second write path: canonicalization, dedup key, search/embed/IndexNow follow-through and re-enrich all live there, and a parallel implementation drifts silently. That's how a somm's `"Yecla DO"` once reached a wine unresolved.

A failed **or thrown** apply reports `pending`. The curator is never told the registry changed when it didn't.

## Tests

1,540 passing across 105 suites (`src/mcp`, `src/services`, `src/routes/admin`). The classifier suite uses the **real** `normalizeAppellationKey` rather than a hand-rolled copy — a mock that normalized differently would let every test pass while the live lookup missed.

No input-schema change, so no reconnect is required; a fresh conversation is still worth it so the curator sees the new tool description.