### PR TITLE
fix(import): use the geography the user's own file states

### DIFF
--- a/backend/src/routes/import.buildProposedWine.test.js
+++ b/backend/src/routes/import.buildProposedWine.test.js
@@ -21,7 +21,7 @@ jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn(), 
 jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
 
-const { buildProposedWine } = require('./import');
+const { buildProposedWine, summariseReasons } = require('./import');
 
 // Below AI_GEOGRAPHY_MIN_CONFIDENCE (0.6) the model is inferring, not knowing.
 const SURE = 0.8;
@@ -80,6 +80,44 @@ describe('country keeps AI-first precedence, with the file as a fallback', () =>
 
   it('is null when neither knows, so the caller can still refuse the row', () => {
     expect(buildProposedWine(ai({ country: null }), {}).country).toBeNull();
+  });
+});
+
+describe('summariseReasons — why rows failed, not just how many', () => {
+  it('groups reasons with counts', () => {
+    expect(summariseReasons([
+      { index: 0, reason: 'Wine definition not found' },
+      { index: 1, reason: 'Wine definition not found' },
+      { index: 2, reason: 'Invalid consumed reason' },
+    ])).toEqual({ 'Wine definition not found': 2, 'Invalid consumed reason': 1 });
+  });
+
+  it('carries no wine name, producer or note — only the failure mode', () => {
+    // The audit needs the mode; the row's identity is the user's own data.
+    const out = summariseReasons([{ index: 0, reason: 'Invalid wine definition ID', wineName: 'Areni' }]);
+    expect(JSON.stringify(out)).not.toMatch(/Areni/);
+  });
+
+  it('never loses count when it truncates the tail', () => {
+    // A cap that hides its own truncation is how you end up trusting a
+    // partial picture — the spill is reported, not dropped.
+    const many = Array.from({ length: 20 }, (_, i) => ({ index: i, reason: `distinct failure ${i}` }));
+    const out = summariseReasons(many);
+    const total = Object.values(out).reduce((s, n) => s + n, 0);
+    expect(total).toBe(20);
+    expect(Object.keys(out).some((k) => /more reason kind/.test(k))).toBe(true);
+  });
+
+  it('truncates a long caught err.message rather than storing it whole', () => {
+    const out = summariseReasons([{ index: 0, reason: 'x'.repeat(500) }]);
+    const key = Object.keys(out)[0];
+    expect(key.length).toBeLessThan(200);
+    expect(key.endsWith('…')).toBe(true);
+  });
+
+  it('records a missing reason as such instead of "undefined"', () => {
+    expect(summariseReasons([{ index: 0 }, { index: 1, reason: '  ' }]))
+      .toEqual({ '(no reason recorded)': 2 });
   });
 });
 

--- a/backend/src/routes/import.buildProposedWine.test.js
+++ b/backend/src/routes/import.buildProposedWine.test.js
@@ -1,0 +1,109 @@
+/**
+ * File geography beats AI geography, and the confidence floor never touches
+ * the file.
+ *
+ * The bug this pins (found 2026-08-21): the parsers had been reading
+ * CellarTracker's Appellation column all along, /validate matched on it — and
+ * then every path that MINTED a wine used the AI's value instead, dropping it
+ * entirely below AI_GEOGRAPHY_MIN_CONFIDENCE. One 231-wine import produced 86
+ * null/null registry rows, and over half of a curation day went on putting
+ * back appellations the user's own file had stated.
+ */
+// Requiring the route pulls its whole dependency tree; meilisearch ships ESM
+// that jest does not transform, so the module boundary is stubbed exactly as
+// the other import suites do. Nothing below touches any of it — this is a pure
+// function test.
+jest.mock('../services/search', () => ({
+  indexWine: jest.fn(), bulkIndexBottles: jest.fn(), getIsAvailable: jest.fn(() => false),
+}));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn(), findOrCreateRegion: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+
+const { buildProposedWine } = require('./import');
+
+// Below AI_GEOGRAPHY_MIN_CONFIDENCE (0.6) the model is inferring, not knowing.
+const SURE = 0.8;
+const UNSURE = 0.4;
+
+const ai = (over = {}) => ({
+  name: 'Barolo', producer: 'Cà di Bruno', country: 'Italy',
+  region: 'Piedmont', appellation: 'Barolo', classification: null,
+  type: 'red', grapes: ['Nebbiolo'], confidence: SURE, ...over,
+});
+
+describe('the confidence floor applies to the AI, never to the file', () => {
+  it('keeps the FILE appellation even when the AI is unsure', () => {
+    // The whole bug in one case: pre-fix this returned null.
+    const out = buildProposedWine(ai({ confidence: UNSURE }), { appellation: 'Barolo', region: 'Piedmont' });
+    expect(out.appellation).toBe('Barolo');
+    expect(out.region).toBe('Piedmont');
+  });
+
+  it('still drops AI geography below the floor when the file says nothing', () => {
+    const out = buildProposedWine(ai({ confidence: UNSURE }), {});
+    expect(out.appellation).toBeNull();
+    expect(out.region).toBeNull();
+    expect(out.classification).toBeNull();
+  });
+
+  it('keeps AI geography above the floor', () => {
+    const out = buildProposedWine(ai({ confidence: SURE }), {});
+    expect(out.appellation).toBe('Barolo');
+    expect(out.region).toBe('Piedmont');
+  });
+
+  it('prefers the FILE over the AI even when the AI is confident', () => {
+    // The owner read the label; the model is recalling. Disagreement is a
+    // curator question, and the curator should see what the label said.
+    const out = buildProposedWine(
+      ai({ appellation: 'Barolo', confidence: 0.95 }),
+      { appellation: 'Barbaresco' });
+    expect(out.appellation).toBe('Barbaresco');
+  });
+});
+
+describe('country keeps AI-first precedence, with the file as a fallback', () => {
+  it('prefers the AI country — it normalizes what the raw column does not', () => {
+    // "Deutschland" in a column, "Germany" from the model.
+    const out = buildProposedWine(ai({ country: 'Germany' }), { country: 'Deutschland' });
+    expect(out.country).toBe('Germany');
+  });
+
+  it('falls back to the file country when the AI could not place it', () => {
+    // Pre-fix this row was REFUSED outright ("country could not be
+    // determined") and cost the user the bottle.
+    const out = buildProposedWine(ai({ country: null }), { country: 'Australia' });
+    expect(out.country).toBe('Australia');
+  });
+
+  it('is null when neither knows, so the caller can still refuse the row', () => {
+    expect(buildProposedWine(ai({ country: null }), {}).country).toBeNull();
+  });
+});
+
+describe('hygiene', () => {
+  it('treats whitespace-only file values as absent, not as data', () => {
+    const out = buildProposedWine(ai({ confidence: UNSURE }), { appellation: '   ', region: '' });
+    expect(out.appellation).toBeNull();
+    expect(out.region).toBeNull();
+  });
+
+  it('trims a file value rather than storing the padding', () => {
+    expect(buildProposedWine(ai(), { appellation: '  Chianti Classico  ' }).appellation).toBe('Chianti Classico');
+  });
+
+  it('survives a missing item entirely (cached/duplicate rows)', () => {
+    expect(() => buildProposedWine(ai(), undefined)).not.toThrow();
+    expect(buildProposedWine(ai(), undefined).appellation).toBe('Barolo');
+  });
+
+  it('passes name, producer, type, grapes and confidence through untouched', () => {
+    const out = buildProposedWine(ai(), { appellation: 'Barolo' });
+    expect(out).toMatchObject({
+      name: 'Barolo', producer: 'Cà di Bruno', type: 'red',
+      grapes: ['Nebbiolo'], confidence: SURE,
+    });
+  });
+});

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -57,10 +57,63 @@ const FUZZY_THRESHOLD = IMPORT_FUZZY_THRESHOLD;
 // band that wrote a producer's home region onto wines from elsewhere and split
 // one producer across region granularities (ticket 6a8162c5). Geography the
 // AI proposed under this floor is dropped before it can mint; the curation
-// backfill queue fills it from evidence instead. Import files carry no
-// region/appellation columns, so this only ever strips AI inference — never
-// user data.
+// backfill queue fills it from evidence instead.
+//
+// ⚠️ THIS FLOOR APPLIES TO AI-DERIVED GEOGRAPHY ONLY. It used to be justified
+// by "import files carry no region/appellation columns, so this only ever
+// strips AI inference — never user data", and that stopped being true:
+// importMappers maps CellarTracker's Appellation, its
+// Country/Region/SubRegion/Appellation Locale path, SubRegion and a generic
+// appellation column, and findExactRegistryWine/scoreCandidate below have been
+// matching on item.appellation all along. So the floor WAS deleting what the
+// user typed. Measured 2026-08-21: one 231-wine import produced 86 null/null
+// registry rows, and over half of a curation day went on putting back
+// appellations the file had supplied. File geography now wins outright and is
+// never subject to this floor — see buildProposedWine.
 const AI_GEOGRAPHY_MIN_CONFIDENCE = 0.6;
+
+/**
+ * The wine a no-match row proposes to mint, built from the AI identification
+ * and the user's own file row.
+ *
+ * PRECEDENCE: file geography beats AI geography, always. The file is what the
+ * label says as the owner read it; the AI is recalling. The confidence floor
+ * exists to stop the model ASSERTING a place it inferred, and it has no
+ * business deleting a column the user filled in.
+ *
+ * Kept as a named function (rather than inline in the /validate loop) so the
+ * precedence is unit-testable — it is the rule that decides what enters the
+ * shared registry, and it was previously an expression buried 500 lines in.
+ */
+function buildProposedWine(aiData, item) {
+  const clean = (v) => {
+    const s = typeof v === 'string' ? v.trim() : '';
+    return s || null;
+  };
+  // Below the floor the model is inferring, not knowing (part B below).
+  const lowGeoConfidence =
+    !(typeof aiData.confidence === 'number' && aiData.confidence >= AI_GEOGRAPHY_MIN_CONFIDENCE);
+  const fromAi = (v) => (lowGeoConfidence ? null : clean(v));
+
+  return {
+    name: aiData.name,
+    producer: aiData.producer,
+    // Country keeps the AI's value first: it is fed the file's country as a
+    // hint and normalizes local-language names ("Deutschland" → "Germany"),
+    // which the raw column does not. The file is the fallback, which is new —
+    // a countryless identification used to cost the user the row entirely.
+    country: clean(aiData.country) || clean(item && item.country),
+    region: clean(item && item.region) || fromAi(aiData.region),
+    appellation: clean(item && item.appellation) || fromAi(aiData.appellation),
+    // Same floor as geography: a classification is an assertion of knowledge
+    // (ticket 6a83f014 added the field to the identify prompt), and the file's
+    // own value outranks it for the same reason.
+    classification: clean(item && item.classification) || fromAi(aiData.classification),
+    type: aiData.type,
+    grapes: aiData.grapes,
+    confidence: aiData.confidence,
+  };
+}
 
 /**
  * Score a WineDefinition candidate against an import item.
@@ -373,7 +426,14 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
             name: pr.item.wineName,
             producer: pr.item.producer,
             vintage: pr.item.vintage,
-            country: pr.item.country
+            country: pr.item.country,
+            // The file's own geography, as hints. Asking the model to place a
+            // wine while withholding the appellation the user's export states
+            // was making it infer what we had already been handed — and the
+            // confidence floor then deleted the inference. Precedence still
+            // lives in buildProposedWine; this only stops the blind guess.
+            appellation: pr.item.appellation,
+            region: pr.item.region,
           });
           // A transport-level failure never produced a billable completion —
           // give the debit back so failed calls don't burn the user's budget.
@@ -546,7 +606,12 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
             // country; audit 2026-08-16). Demote to the no-match flow, where
             // the user picks an existing wine or files a request instead of
             // being offered a create that is guaranteed to fail.
-            if (!(typeof wineData.country === 'string' && wineData.country.trim())) {
+            //
+            // Tested against the PROPOSAL, not the AI object: the file's own
+            // country column is a legitimate fallback now, so a row the model
+            // could not place but the user could is minted instead of refused.
+            const proposedCountry = buildProposedWine(wineData, pr.item).country;
+            if (!(typeof proposedCountry === 'string' && proposedCountry.trim())) {
               const msg = 'The wine was recognised but its country could not be determined — match it to an existing wine or request it';
               matchedWineCache.set(key, { error: msg });
               pr.aiWineError = msg;
@@ -555,27 +620,9 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
             // Explicit field list, not the raw AI object: this rides to the
             // client and back into /confirm, so it should carry exactly what
             // findOrCreateWine consumes (plus confidence for display).
-            //
-            // Geography floor (part B above): below AI_GEOGRAPHY_MIN_CONFIDENCE
-            // the model is inferring, not knowing — region/appellation are
-            // dropped from the PROPOSAL (what /confirm mints) while the
-            // matching above kept them (dedup keys embed the appellation).
-            const lowGeoConfidence =
-              !(typeof wineData.confidence === 'number' && wineData.confidence >= AI_GEOGRAPHY_MIN_CONFIDENCE);
-            const proposed = {
-              name: wineData.name,
-              producer: wineData.producer,
-              country: wineData.country,
-              region: lowGeoConfidence ? null : wineData.region,
-              appellation: lowGeoConfidence ? null : wineData.appellation,
-              // Same floor as geography: a classification is an assertion of
-              // knowledge, and below the floor the model is inferring
-              // (ticket 6a83f014 added the field to the identify prompt).
-              classification: lowGeoConfidence ? null : (wineData.classification || null),
-              type: wineData.type,
-              grapes: wineData.grapes,
-              confidence: wineData.confidence,
-            };
+            // buildProposedWine holds the file-beats-AI precedence and the
+            // geography floor (part B above) in one testable place.
+            const proposed = buildProposedWine(wineData, pr.item);
             matchedWineCache.set(key, { proposed });
             pr.aiProposed = proposed;
           } else {
@@ -1685,3 +1732,8 @@ router.delete('/sessions/:id', async (req, res) => {
 });
 
 module.exports = router;
+// Exported for its own unit test: this function decides what geography enters
+// the SHARED registry from an import, and the rule it encodes (file beats AI,
+// and the confidence floor never touches the file) is worth pinning
+// independently of the 700-line /validate route around it.
+module.exports.buildProposedWine = buildProposedWine;

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -72,6 +72,39 @@ const FUZZY_THRESHOLD = IMPORT_FUZZY_THRESHOLD;
 // never subject to this floor — see buildProposedWine.
 const AI_GEOGRAPHY_MIN_CONFIDENCE = 0.6;
 
+// Distinct failure reasons kept in one import's audit row, and the length each
+// is truncated to. Enough to name every failure mode a real file hits without
+// letting a pathological one bloat the document.
+const AUDIT_REASON_MAX_KINDS = 12;
+const AUDIT_REASON_MAX_LEN = 160;
+
+/**
+ * Group per-row {reason} entries into { reason: count } for the audit.
+ *
+ * Deliberately reason-only: the row's wine name, producer and notes are the
+ * user's data and the audit needs the failure MODE, not the record. Messages
+ * that embed a caught err.message can vary per row, so they are truncated and
+ * the tail is folded into one "+N more" bucket rather than dropped silently —
+ * a cap that hides its own truncation is how you end up trusting a partial
+ * picture.
+ */
+function summariseReasons(entries) {
+  const counts = new Map();
+  for (const e of entries) {
+    const raw = (e && typeof e.reason === 'string' && e.reason.trim()) ? e.reason.trim() : '(no reason recorded)';
+    const key = raw.length > AUDIT_REASON_MAX_LEN ? `${raw.slice(0, AUDIT_REASON_MAX_LEN)}…` : raw;
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const kept = ranked.slice(0, AUDIT_REASON_MAX_KINDS);
+  const out = Object.fromEntries(kept);
+  const spilled = ranked.slice(AUDIT_REASON_MAX_KINDS);
+  if (spilled.length) {
+    out[`+${spilled.length} more reason kind(s)`] = spilled.reduce((s, [, n]) => s + n, 0);
+  }
+  return out;
+}
+
 /**
  * The wine a no-match row proposes to mint, built from the AI identification
  * and the user's own file row.
@@ -1473,6 +1506,21 @@ router.post('/confirm', async (req, res) => {
       wishlistCreated,
       skipped: skipped.length,
       errors: errors.length,
+      // WHY rows failed, not just how many (2026-08-21). A real import
+      // rejected 15 of 46 rows at 06:05; the user fixed their file and re-ran
+      // the 15 six minutes later. The audit recorded the COUNT and threw the
+      // reasons away, so afterwards the cause could only be guessed at — four
+      // separate prod queries reconstructed which wines were involved and
+      // still could not say WHY, because the reason strings this route builds
+      // per row were never persisted anywhere.
+      //
+      // Reasons, not rows: grouped with counts so one line stays readable and
+      // no wine name, producer or note enters the audit — a row's identity is
+      // the user's data and the audit only needs the failure mode. Capped
+      // because a pathological file could otherwise carry hundreds of
+      // distinct messages into one document.
+      ...(errors.length ? { errorReasons: summariseReasons(errors) } : {}),
+      ...(skipped.length ? { skippedReasons: summariseReasons(skipped) } : {}),
       total: items.length,
       racksCreated: createdRacks.length,
       placed: placedCount,
@@ -1737,3 +1785,4 @@ module.exports = router;
 // and the confidence floor never touches the file) is worth pinning
 // independently of the 700-line /validate route around it.
 module.exports.buildProposedWine = buildProposedWine;
+module.exports.summariseReasons = summariseReasons;

--- a/backend/src/routes/import.validate.geography.test.js
+++ b/backend/src/routes/import.validate.geography.test.js
@@ -205,6 +205,42 @@ describe('B) confidence floor on AI geography', () => {
     expect(res.body.results[0].aiProposed.region).toBe('Hunter Valley');
     expect(res.body.results[0].aiProposed.appellation).toBe('Hunter Valley');
   });
+
+  // The floor is about the MODEL asserting a place it inferred. It has no
+  // business deleting a column the user filled in — and until 2026-08-21 it
+  // did, because nothing downstream of the parser ever read that column.
+  test('THE FILE outranks the floor: a stated appellation survives a 0.5 identification', async () => {
+    primeAi(aiResult({
+      name: 'Epiphany', producer: "Sister's Run",
+      region: null, appellation: null, confidence: 0.5,
+    }));
+
+    const res = await validate([{
+      wineName: 'Epiphany', producer: "Sister's Run", vintage: '2021',
+      // What a CellarTracker export actually carries.
+      region: 'Barossa', appellation: 'Barossa Valley',
+    }]);
+
+    const row = res.body.results[0];
+    expect(row.aiProposed.appellation).toBe('Barossa Valley');
+    expect(row.aiProposed.region).toBe('Barossa');
+    // And the identifier was TOLD what the file said, rather than being asked
+    // to place a wine while we withheld the label.
+    expect(identifyWineFromText).toHaveBeenCalledWith(
+      expect.objectContaining({ appellation: 'Barossa Valley', region: 'Barossa' }));
+  });
+
+  test('a file appellation beats a CONFIDENT contradicting identification', async () => {
+    primeAi(aiResult({
+      name: 'Epiphany', producer: "Sister's Run",
+      region: 'Barossa Valley', appellation: 'Barossa Valley', confidence: 0.95,
+    }));
+
+    const res = await validate([{
+      wineName: 'Epiphany', producer: "Sister's Run", appellation: 'Eden Valley',
+    }]);
+    expect(res.body.results[0].aiProposed.appellation).toBe('Eden Valley');
+  });
 });
 
 describe('A) one producer, one country per batch', () => {

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -477,14 +477,33 @@ function validateWineIdentity(parsed) {
  *   debugRaw    – raw string from the model (or error message)
  *   debugReason – short explanation when data is null
  */
-async function identifyWineFromText({ name, producer, vintage, country }) {
+async function identifyWineFromText({ name, producer, vintage, country, appellation, region }) {
   if (!name || !producer) return { data: null, debugRaw: null, debugReason: 'missing_fields' };
 
   let client;
   try { client = getClient(); } catch { return { data: null, debugRaw: null, debugReason: 'no_api_key' }; }
 
   const vintageHint = vintage && vintage !== 'NV' ? `Vintage: ${vintage}\n` : '';
-  const countryHint = country ? `Country hint: ${country}\n` : '';
+
+  // The user's own file already states the geography on most exports
+  // (CellarTracker has Appellation and a Country/Region/SubRegion/Appellation
+  // Locale path), and asking the model to identify a wine WITHOUT telling it
+  // what the label says was making it infer what it had been handed. Passed as
+  // hints, not answers: the caller decides precedence, and file geography wins
+  // there — this only stops the model guessing blind.
+  //
+  // ⚠️ These ride in the {{country}} slot rather than new placeholders on
+  // purpose. importLookupPrompt is admin-editable and prod may hold a
+  // customised copy; a {{appellation}} placeholder that a stored prompt lacks
+  // would make .replace() a silent no-op and the hint would vanish with no
+  // error. For the same reason each hint carries its OWN instruction inline
+  // instead of relying on a rule in the template.
+  const hints = [
+    country ? `Country hint: ${country}` : '',
+    appellation ? `Appellation stated in the user's import file (trust it unless it is clearly not a wine appellation): ${appellation}` : '',
+    region ? `Region stated in the user's import file (trust it unless clearly wrong): ${region}` : '',
+  ].filter(Boolean);
+  const countryHint = hints.length ? `${hints.join('\n')}\n` : '';
 
   const prompt = aiConfig.get().importLookupPrompt
     .replace('{{name}}', name)

--- a/frontend/src/utils/importPayload.js
+++ b/frontend/src/utils/importPayload.js
@@ -28,6 +28,16 @@ export function buildImportItem(r, selection) {
     // CellarTracker imports carry grape varieties and a personal drink
     // window; the backend importer consumes these when present.
     grapes: r.item.grapes,
+    // …and geography. The parsers have read these all along (CT Appellation,
+    // the Country/Region/SubRegion/Appellation Locale path, SubRegion, and a
+    // generic appellation column) and they were never forwarded — so a wine
+    // minted from an import lost the appellation the user's own file stated,
+    // and a curator put it back by hand later. Exactly the disappearance this
+    // file's docblock warns about, on a different field.
+    country: r.item.country,
+    region: r.item.region,
+    appellation: r.item.appellation,
+    classification: r.item.classification,
     drinkFrom: r.item.drinkFrom ?? undefined,
     drinkTo: r.item.drinkTo ?? undefined,
     dateAdded: r.item.dateAdded || r.item.purchaseDate,

--- a/frontend/src/utils/importPayload.test.js
+++ b/frontend/src/utils/importPayload.test.js
@@ -90,6 +90,37 @@ describe('buildImportItem', () => {
     expect(out.rackPosition).toBe(11);
   });
 
+  test('forwards the geography the parsers read (country/region/appellation/classification)', () => {
+    // Dropped here until 2026-08-21: the parsers had read CT's Appellation
+    // column all along, /validate matched on it, and then the wine was minted
+    // without it — so a curator hand-filled appellations the user's own file
+    // had stated. Same disappearance this file's docblock warns about.
+    const out = buildImportItem({
+      item: {
+        wineName: 'Barolo', producer: 'Cà di Bruno', vintage: '2016',
+        country: 'Italy', region: 'Piedmont', appellation: 'Barolo', classification: 'DOCG',
+      },
+    }, 'create');
+    expect(out.country).toBe('Italy');
+    expect(out.region).toBe('Piedmont');
+    expect(out.appellation).toBe('Barolo');
+    expect(out.classification).toBe('DOCG');
+  });
+
+  test('full pipeline: a real CT export\'s appellations reach the payload', () => {
+    const { text } = decodeImportBuffer(toArrayBuffer(readFileSync(FIXTURE)));
+    const parsed = parseAndMap(text);
+
+    const withAppellation = parsed.items.filter((i) => i.appellation);
+    // If the fixture stops carrying appellations this assertion is the alarm:
+    // a passing test over an empty set would prove nothing.
+    expect(withAppellation.length).toBeGreaterThan(0);
+
+    for (const item of withAppellation) {
+      expect(buildImportItem({ item }, 'create').appellation).toBe(item.appellation);
+    }
+  });
+
   test('full pipeline: real CT Inventory fixture placements survive to the payload', () => {
     const { text } = decodeImportBuffer(toArrayBuffer(readFileSync(FIXTURE)));
     const parsed = parseAndMap(text);


### PR DESCRIPTION
## The bug

The parsers have read CellarTracker's `Appellation` column, its `Locale` path, `SubRegion` and a generic appellation column **all along**. `/validate` matches on `item.appellation`. And then every path that *minted* a wine ignored it.

**The file's appellation was trusted enough to FIND an existing wine, and never used to CREATE one.**

Three independent drops, each invisible alone:

| Where | What was lost |
|---|---|
| `identifyWineFromText` | got `{name, producer, vintage, country}` only — the model was asked to place a wine while we withheld the label |
| `aiProposed` build | region/appellation/classification **nulled** below `AI_GEOGRAPHY_MIN_CONFIDENCE` |
| `buildImportItem` | forwards 25+ fields — grapes, drink windows, rack row/col — but not appellation, region, country, classification |

The comment justifying the floor read:

> *"Import files carry no region/appellation columns, so this only ever strips AI inference — never user data."*

True when written. Not now — and nothing failed when it stopped being true. **The floor was deleting what the user typed.**

**Measured 2026-08-21:** one 231-wine import left 86 null/null registry rows, and over half of a curation day went on putting back appellations the file had supplied — *"Barolo by Cà di Bruno is in Piedmont"*, eight times.

## The fix

Precedence now lives in one named, exported function, `buildProposedWine`: **file geography beats AI geography and is never subject to the floor.**

The floor still does its job — it exists to stop the model *asserting* an inferred place (ticket 6a8162c5: a producer's home region written onto wines from elsewhere). That behaviour is unchanged and still tested.

**Country keeps AI-first precedence deliberately** — the model is fed the file's country and normalizes `"Deutschland"` → `"Germany"`, which the raw column doesn't. The file is now its *fallback*, which also salvages rows previously refused outright: a wine the model couldn't place but the user could used to cost them the bottle.

**The identifier is now told what the file says**, as hints rather than answers. They ride in the existing `{{country}}` slot with each hint carrying its instruction inline — `importLookupPrompt` is admin-editable, so a new `{{appellation}}` placeholder that a customised prod prompt lacks would make `.replace()` a silent no-op and the hint would vanish with no error.

## Tests

- `buildProposedWine` pinned directly — floor vs file in both directions, whitespace-only file values, missing item, confident-AI-vs-file
- Two route-level cases in `import.validate.geography.test.js`, including that the identifier actually receives the hints
- The frontend full-pipeline test now walks the **real CellarTracker fixture**, asserting every parsed appellation reaches the payload — with a guard that fails if the fixture ever stops carrying any, so it can't pass over an empty set

2,190 backend tests (159 suites) + 97 frontend passing.