### PR TITLE
fix(somm): an appellation from another country is not this wine's place

### DIFF
--- a/backend/src/services/proposalDirectApply.js
+++ b/backend/src/services/proposalDirectApply.js
@@ -67,12 +67,34 @@ function fieldIsEmpty(wine, field) {
   return String(v).trim() === '';
 }
 
+/** An id from either a populated ref or a raw ObjectId, as a string. */
+function idOf(v) {
+  if (!v) return null;
+  return String(v._id || v);
+}
+
 /**
  * The curated appellation a wine's NAME states, if any — longest match wins so
  * "Chianti Classico" beats "Chianti" and the check compares like with like.
  * Returns the Appellation doc, or null when the name claims no place.
+ *
+ * COUNTRY-SCOPED (2026-08-21). Without this, a name-derived appellation from
+ * the wrong country reads as a place claim. Found live while dry-running a
+ * backfill: Nockie's "Palette Pinot Noir" is a NEW ZEALAND wine and "Palette
+ * Rose" a SOUTH AFRICAN one, and Palette is an AOC in Provence. Same producer,
+ * two hemispheres, one French name — "Palette" there is a range name, not a
+ * place, and the backfill would have written Provence onto both.
+ *
+ * The cost of missing it was not hypothetical in the other direction either:
+ * a curator correcting that Pinot Noir to Marlborough would have been routed
+ * for review because the name "disagreed", making them wait on a correction
+ * that should apply instantly.
+ *
+ * A wine with no country cannot be checked, so the match stands — that is the
+ * conservative reading (route rather than auto-apply), matching the old
+ * behaviour exactly.
  */
-async function appellationImpliedByName(name) {
+async function appellationImpliedByName(name, countryId) {
   const tokens = String(name || '').trim().split(/\s+/).filter(Boolean).slice(0, MAX_NAME_TOKENS);
   if (!tokens.length) return null;
 
@@ -92,10 +114,19 @@ async function appellationImpliedByName(name) {
   if (!byKey.size) return null;
 
   const keys = [...byKey.keys()];
-  const docs = await Appellation.find({
+  let docs = await Appellation.find({
     $or: [{ normalizedName: { $in: keys } }, { normalizedSynonyms: { $in: keys } }],
   }).lean();
   if (!docs.length) return null;
+
+  // Same appellation NAME can exist per country as separate docs (the model's
+  // unique index is on country+normalizedName), so filtering here also picks
+  // the RIGHT doc rather than an arbitrary one.
+  const want = idOf(countryId);
+  if (want) {
+    docs = docs.filter((d) => idOf(d.country) === want);
+    if (!docs.length) return null;
+  }
 
   // Longest matched PHRASE wins, measured on the doc's own canonical name so a
   // short synonym cannot outrank the full appellation it stands for.
@@ -121,6 +152,37 @@ function appellationsAgree(nameDoc, proposed) {
   if (!proposedKey) return false;
   const nameKeys = [nameDoc.normalizedName, ...(nameDoc.normalizedSynonyms || [])].filter(Boolean);
   return nameKeys.some((k) => k === proposedKey || k.includes(proposedKey) || proposedKey.includes(k));
+}
+
+/**
+ * Is the PROPOSED appellation a curated one belonging to a different country
+ * than the wine? Returns the conflicting doc, or null.
+ *
+ * This is the other half of the country rule, and the more important half.
+ * Scoping the NAME check by country makes an Australian "Prosecco" stop
+ * implying the Italian DOC — which is right, but on its own it would then let
+ * a proposal WRITE "Prosecco" onto that Australian wine unchallenged. That is
+ * precisely the error the curator warned about: Italy renamed the grape Glera
+ * in 2009 and registered Prosecco as an EU GI, so the Italian DOC is exactly
+ * what a careless rule stamps onto a King Valley wine while every field still
+ * looks plausible.
+ *
+ * Free-text appellations that match no curated doc are NOT flagged: they carry
+ * no country to disagree with, and appellations are deliberately open-ended
+ * (see services/appellationResolve). Silence there is honest, not a gap.
+ */
+async function proposedAppellationCountryConflict(proposed, countryId) {
+  const want = idOf(countryId);
+  if (!want) return null;
+  const key = normalizeAppellationKey(proposed);
+  if (!key) return null;
+  const docs = await Appellation.find({
+    $or: [{ normalizedName: key }, { normalizedSynonyms: key }],
+  }).lean();
+  if (!docs.length) return null;
+  // Curated somewhere, but nowhere in this wine's country.
+  if (docs.some((d) => idOf(d.country) === want)) return null;
+  return docs[0];
 }
 
 /**
@@ -153,11 +215,23 @@ async function classifyProposal(wine, kind, proposedFields) {
   }
 
   if (proposedFields.appellation) {
-    const implied = await appellationImpliedByName(wine.name);
+    const countryId = wine.country;
+
+    // Checked BEFORE the name rule: a cross-border appellation is a claim
+    // about the wine's own country, which outranks anything its name says.
+    const foreign = await proposedAppellationCountryConflict(proposedFields.appellation, countryId);
+    if (foreign) {
+      return {
+        direct: false,
+        reason: `"${proposedFields.appellation}" is a curated appellation, but not in this wine's country — an admin reads that. If the wine really is from there, the country is what needs correcting first.`,
+      };
+    }
+
+    const implied = await appellationImpliedByName(wine.name, countryId);
     if (implied && !appellationsAgree(implied, proposedFields.appellation)) {
       return {
         direct: false,
-        reason: `The wine's name states "${implied.name}" but the proposal says "${proposedFields.appellation}" — an admin reads that difference. This is not a rejection: the name is often the wrong one (an Australian "Prosecco" is a King Valley wine, not the Italian DOC).`,
+        reason: `The wine's name states "${implied.name}" but the proposal says "${proposedFields.appellation}" — an admin reads that difference. This is not a rejection: a name and a label genuinely disagree sometimes.`,
       };
     }
   }
@@ -168,6 +242,7 @@ async function classifyProposal(wine, kind, proposedFields) {
 module.exports = {
   classifyProposal,
   appellationImpliedByName,
+  proposedAppellationCountryConflict,
   appellationsAgree,
   fieldIsEmpty,
   DIRECT_FIELDS,

--- a/backend/src/services/proposalDirectApply.test.js
+++ b/backend/src/services/proposalDirectApply.test.js
@@ -4,16 +4,10 @@
  * argument for loosening the gate rests on that day's numbers, so the test
  * that guards it should be that day.
  */
-const { classifyProposal, appellationImpliedByName, appellationsAgree } = require('./proposalDirectApply');
+const {
+  classifyProposal, appellationImpliedByName, proposedAppellationCountryConflict, appellationsAgree,
+} = require('./proposalDirectApply');
 const Appellation = require('../models/Appellation');
-
-// The curated appellations the day's names actually touch, with the shape the
-// real docs have (normalizedName as the resolver keys them).
-const CURATED = [
-  'Barolo', 'Barbaresco', 'Langhe', 'Chianti', 'Chianti Classico', 'Soave Classico',
-  'Rioja', 'Bourgogne Hautes-Côtes de Beaune', 'Saint-Mont', 'Prosecco', 'King Valley',
-  'Taurasi', 'Veronese', 'Rosso Veronese', 'Veneto', 'Vino Rosso', 'Barossa', 'Hunter Valley',
-];
 
 // The REAL keying function, not a hand-rolled copy: a mock that normalized
 // differently from production would let every test here pass while the live
@@ -21,35 +15,94 @@ const CURATED = [
 // risk, not a theoretical one.
 const { normalizeAppellationKey: norm } = require('../utils/normalize');
 
+const IT = 'country-italy';
+const FR = 'country-france';
+const AU = 'country-australia';
+const NZ = 'country-newzealand';
+const ES = 'country-spain';
+
+// The curated appellations the day's names actually touch, each with the
+// country the real doc carries — the model's unique index is country + name,
+// so country is part of an appellation's identity, not decoration.
+const CURATED = [
+  ['Barolo', IT], ['Barbaresco', IT], ['Langhe', IT], ['Chianti', IT], ['Chianti Classico', IT],
+  ['Soave Classico', IT], ['Taurasi', IT], ['Veronese', IT], ['Rosso Veronese', IT],
+  ['Veneto', IT], ['Vino Rosso', IT], ['Prosecco', IT],
+  ['Bourgogne Hautes-Côtes de Beaune', FR], ['Saint-Mont', FR], ['Palette', FR],
+  ['King Valley', AU], ['Barossa', AU], ['Hunter Valley', AU],
+  ['Marlborough', NZ],
+  ['Rioja', ES],
+];
+
 beforeEach(() => {
   jest.spyOn(Appellation, 'find').mockImplementation((query) => {
-    const keys = query.$or[0].normalizedName.$in;
+    const clause = query.$or[0].normalizedName;
+    const keys = clause.$in ? clause.$in : [clause];
     const docs = CURATED
-      .filter((name) => keys.includes(norm(name)))
-      .map((name) => ({ name, normalizedName: norm(name), normalizedSynonyms: [] }));
+      .filter(([name]) => keys.includes(norm(name)))
+      .map(([name, country]) => ({ name, country, normalizedName: norm(name), normalizedSynonyms: [] }));
     return { lean: async () => docs };
   });
 });
 afterEach(() => jest.restoreAllMocks());
 
-const wine = (name, over = {}) => ({ name, appellation: null, region: null, classification: null, ...over });
+const wine = (name, over = {}) => ({
+  name, appellation: null, region: null, classification: null, country: IT, ...over,
+});
 
 describe('appellationImpliedByName', () => {
   it('takes the LONGEST match so a qualified appellation beats its parent', async () => {
     // "Chianti Classico" contains "Chianti"; picking the shorter one would make
     // a correct "Chianti Classico" proposal look like a contradiction.
-    expect((await appellationImpliedByName('Chianti Classico')).name).toBe('Chianti Classico');
+    expect((await appellationImpliedByName('Chianti Classico', IT)).name).toBe('Chianti Classico');
   });
 
   it('finds an appellation embedded mid-name', async () => {
-    expect((await appellationImpliedByName('Della Società Taurasi Riserva')).name).toBe('Taurasi');
-    expect((await appellationImpliedByName('Langhe Nebbiolo')).name).toBe('Langhe');
+    expect((await appellationImpliedByName('Della Società Taurasi Riserva', IT)).name).toBe('Taurasi');
+    expect((await appellationImpliedByName('Langhe Nebbiolo', IT)).name).toBe('Langhe');
   });
 
   it('returns null when the name states no place', async () => {
-    expect(await appellationImpliedByName('Barossa Shiraz Reserve')).toBeTruthy(); // Barossa IS curated
-    expect(await appellationImpliedByName('Cask 66')).toBeNull();
-    expect(await appellationImpliedByName('')).toBeNull();
+    expect(await appellationImpliedByName('Barossa Shiraz Reserve', AU)).toBeTruthy();
+    expect(await appellationImpliedByName('Cask 66', AU)).toBeNull();
+    expect(await appellationImpliedByName('', IT)).toBeNull();
+  });
+
+  // Found live 2026-08-21 dry-running a backfill over 237 rows: it offered
+  // exactly 3 writes and 2 were Provence onto the southern hemisphere.
+  it('ignores a name-derived appellation from ANOTHER country', async () => {
+    // Nockie's "Palette" is a range name. The Pinot is from New Zealand, the
+    // Rosé from South Africa, and Palette is an AOC in Provence.
+    expect(await appellationImpliedByName('Palette Pinot Noir', NZ)).toBeNull();
+    // …and still resolves for a wine that really is French.
+    expect((await appellationImpliedByName('Palette Rouge', FR)).name).toBe('Palette');
+  });
+
+  it('keeps the match when the wine has no country — cannot check, so stay conservative', async () => {
+    expect((await appellationImpliedByName('Palette Pinot Noir', null)).name).toBe('Palette');
+  });
+});
+
+describe('proposedAppellationCountryConflict — the dangerous direction', () => {
+  it('flags a curated appellation from the wrong country', async () => {
+    // The curator's own warning: Italy registered Prosecco as an EU GI, and it
+    // is exactly what a careless rule stamps onto a King Valley wine.
+    const hit = await proposedAppellationCountryConflict('Prosecco', AU);
+    expect(hit && hit.name).toBe('Prosecco');
+  });
+
+  it('allows an appellation curated in the wine\'s own country', async () => {
+    expect(await proposedAppellationCountryConflict('King Valley', AU)).toBeNull();
+    expect(await proposedAppellationCountryConflict('Barolo', IT)).toBeNull();
+  });
+
+  it('stays silent on free text — an uncurated name has no country to disagree with', async () => {
+    // Appellations are deliberately open-ended; silence here is honest.
+    expect(await proposedAppellationCountryConflict('Terra Alta', ES)).toBeNull();
+  });
+
+  it('stays silent when the wine has no country', async () => {
+    expect(await proposedAppellationCountryConflict('Prosecco', null)).toBeNull();
   });
 });
 
@@ -64,49 +117,71 @@ describe('appellationsAgree — a rename is not a contradiction', () => {
 
 describe('the 2026-08-21 curation day, replayed', () => {
   // The eleven that were pure lookups — these are what the change is FOR.
+  // Country matters to the rule now, so each row carries the one its wine
+  // really has — a fixture that made every wine Italian would have "failed"
+  // the French and Spanish rows for a reason that has nothing to do with them.
   const APPLIES = [
-    ['Barolo', { appellation: 'Barolo', region: 'Piedmont' }],
-    ['Barbaresco', { appellation: 'Barbaresco', region: 'Piedmont' }],
-    ['Langhe Nebbiolo', { appellation: 'Langhe', region: 'Piedmont' }],
-    ['Chianti Classico', { appellation: 'Chianti Classico', region: 'Tuscany' }],
-    ['Chianti', { appellation: 'Chianti', region: 'Tuscany' }],
-    ['Soave Classico', { appellation: 'Soave Classico', region: 'Veneto' }],
-    ['Rioja Reserva', { appellation: 'Rioja', region: 'Rioja', classification: 'Reserva' }],
-    ['Côtes de Saint-Mont', { appellation: 'Saint-Mont', region: 'South West France' }],
-    ['Bourgogne Hautes-Côtes de Beaune Rouge', { appellation: 'Bourgogne Hautes-Côtes de Beaune', region: 'Burgundy' }],
-    ['Pokolbin Hills Vermentino', { region: 'Hunter Valley' }],
-    ['Della Società Taurasi Riserva', { appellation: 'Taurasi', region: 'Campania', classification: 'Riserva' }],
+    ['Barolo', IT, { appellation: 'Barolo', region: 'Piedmont' }],
+    ['Barbaresco', IT, { appellation: 'Barbaresco', region: 'Piedmont' }],
+    ['Langhe Nebbiolo', IT, { appellation: 'Langhe', region: 'Piedmont' }],
+    ['Chianti Classico', IT, { appellation: 'Chianti Classico', region: 'Tuscany' }],
+    ['Chianti', IT, { appellation: 'Chianti', region: 'Tuscany' }],
+    ['Soave Classico', IT, { appellation: 'Soave Classico', region: 'Veneto' }],
+    ['Rioja Reserva', ES, { appellation: 'Rioja', region: 'Rioja', classification: 'Reserva' }],
+    ['Côtes de Saint-Mont', FR, { appellation: 'Saint-Mont', region: 'South West France' }],
+    ['Bourgogne Hautes-Côtes de Beaune Rouge', FR, { appellation: 'Bourgogne Hautes-Côtes de Beaune', region: 'Burgundy' }],
+    ['Pokolbin Hills Vermentino', AU, { region: 'Hunter Valley' }],
+    ['Della Società Taurasi Riserva', IT, { appellation: 'Taurasi', region: 'Campania', classification: 'Riserva' }],
   ];
 
-  it.each(APPLIES)('applies on filing: %s', async (name, fields) => {
-    const v = await classifyProposal(wine(name), 'field_correction', fields);
+  it.each(APPLIES)('applies on filing: %s', async (name, country, fields) => {
+    const v = await classifyProposal(wine(name, { country }), 'field_correction', fields);
     expect(v).toEqual({ direct: true, reason: expect.any(String) });
   });
 
   it('ROUTES Rosso Veronese — the one case the human gate actually caught', async () => {
-    const v = await classifyProposal(wine('Rosso Veronese'), 'field_correction',
+    const v = await classifyProposal(wine('Rosso Veronese', { country: IT }), 'field_correction',
       { appellation: 'Veneto IGT', region: 'Veneto' });
     expect(v.direct).toBe(false);
     expect(v.reason).toContain('Rosso Veronese');
   });
 
-  it('ROUTES the Australian Prosecco — and calls it routing, not rejection', async () => {
-    // The curator was RIGHT here: King Valley Glera is a real category and the
-    // Italian DOC would have been the error. A rule that BLOCKED this would
-    // have blocked the most valuable correction of the day.
-    const v = await classifyProposal(wine('Prosecco'), 'field_correction',
+  // The country rule CHANGED this case, and for the better. The curator was
+  // right — King Valley Glera is a real category — so their correction now
+  // applies instead of waiting on a review round trip. "Prosecco" in an
+  // Australian wine's name never implied the Italian DOC in the first place.
+  it('APPLIES the Australian Prosecco → King Valley correction', async () => {
+    const v = await classifyProposal(wine('Prosecco', { country: AU }), 'field_correction',
       { appellation: 'King Valley', region: 'King Valley' });
+    expect(v.direct).toBe(true);
+  });
+
+  it('…while still ROUTING the Italian DOC onto that same Australian wine', async () => {
+    // The error the curator actually warned about. Scoping the NAME check by
+    // country would have let this through on its own; the proposed-appellation
+    // check is what catches it.
+    const v = await classifyProposal(wine('Prosecco', { country: AU }), 'field_correction',
+      { appellation: 'Prosecco' });
     expect(v.direct).toBe(false);
-    expect(v.reason).toMatch(/not a rejection/i);
+    expect(v.reason).toMatch(/not in this wine's country/);
   });
 
   it('ROUTES a place onto a generic EU designation (the Monatio class)', async () => {
     // "Vino Rosso" is legally defined by carrying NO geographic indication, and
     // it is a curated appellation in its own right — so a proposal writing a
     // place onto it contradicts the name and must be read by a human.
-    const v = await classifyProposal(wine('Monatio Vino Rosso Bio'), 'field_correction',
+    const v = await classifyProposal(wine('Monatio Vino Rosso Bio', { country: IT }), 'field_correction',
       { appellation: 'Rosso Conero' });
     expect(v.direct).toBe(false);
+  });
+
+  it('APPLIES a correction on a wine whose name names a FOREIGN place', async () => {
+    // Nockie's Palette Pinot Noir is from New Zealand. Before the country
+    // rule the name "disagreed" with Marlborough and the curator was made to
+    // wait for review on a correction that was never in doubt.
+    const v = await classifyProposal(wine('Palette Pinot Noir', { country: NZ }), 'field_correction',
+      { appellation: 'Marlborough' });
+    expect(v.direct).toBe(true);
   });
 });
 


### PR DESCRIPTION
## How this was found

By **dry-running** the backfill over the 237 null-region/null-appellation rows instead of running it. It offered exactly **3** writes, and 2 were Provence onto the southern hemisphere:

| Row | Would have written | Wine's actual country |
|---|---|---|
| Nockie's **Palette Pinot Noir** | Palette / Provence | **New Zealand** |
| Nockie's **Palette Rose** | Palette / Provence | **South Africa** |

Palette is an AOC in Provence. For this producer it's a *range name* — same brand, two hemispheres, one French word — and `appellationImpliedByName` had no country check, so it read the word as a place claim.

## Why fix it rather than just avoid it

It's a live defect in the **other** direction too: a curator correcting that Pinot Noir to Marlborough was **routed for admin review**, because the name "disagreed" with the proposal. They waited on a correction that was never in doubt.

## Both halves ship together — the first alone would make things worse

**1. The name check is country-scoped.** An Australian wine called "Prosecco" stops implying the Italian DOC, so the curator's King Valley correction now *applies* instead of routing.

**2. The proposed appellation is checked against the wine's country.** Without this, (1) would happily let a proposal write `"Prosecco"` — the Italian GI — onto that same Australian wine. That is precisely the laundered error the curator warned about when Italy renamed the grape Glera in 2009 and registered Prosecco as an EU GI.

## What deliberately stays silent

- **Free text** matching no curated doc — it carries no country to disagree with, and appellations are deliberately open-ended (`services/appellationResolve`)
- **A wine with no country** — cannot be checked, so it keeps the old conservative behaviour: route rather than auto-apply

Rosso Veronese still routes: name and proposal are both Italian and still disagree.

## No backfill ships

There isn't one to run. **233 of the 237** rows have names like `"Areni"`, `"Bacco"`, `"Black Magic Red Wine"` — no appellation is derivable. The data those rows needed lived in the users' import files and was discarded before v1.158. That loss is now stopped; it is not recoverable.

## Tests

The fixture now carries each wine's real country — one that made every wine Italian would fail the French and Spanish rows for a reason unrelated to them. 116 passing across the classifier and somm-tool suites.