### PR TITLE
fix(somm): the producerNote goes with the flag it explains

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -817,6 +817,70 @@ describe('held-profile review queue over MCP (somm ticket 2026-08-18)', () => {
       expect(update.$set['aiProfile.suspectDecision']).toBe('confirmed');
     });
 
+    // Somm ticket 6a882f3e. The note used to be kept "for curator context"
+    // after the flag it explained was cleared — so a confirmed row could still
+    // read "the true producing estate is unclear to me" with nothing left to
+    // qualify it, and no lever existed to correct it.
+    describe('the producerNote goes with the flag it explains', () => {
+      test('confirm clears the note alongside producerSuspect', async () => {
+        WineDefinition.findById.mockReturnValue(selectChain(publishedSuspect({
+          producerNote: 'This appears to be a branded line rather than a wine made by Donnafugata.',
+        })));
+        const body = parse(await tool('review_held_profile').handler({ wine_id: oid('7'), decision: 'confirm' }, SOMM_CTX));
+        const [, update] = WineDefinition.updateOne.mock.calls[0];
+        expect(update.$set['aiProfile.producerNote']).toBeNull();
+        // Told, not silent — the curator can no longer see it to check.
+        expect(body.data.producer_note_cleared).toBe(true);
+      });
+
+      test('the cleared note survives in the audit, not just in the void', async () => {
+        const note = 'Alessandro is not a producer I can identify';
+        WineDefinition.findById.mockReturnValue(selectChain(publishedSuspect({ producerNote: note })));
+        await tool('review_held_profile').handler({ wine_id: oid('7'), decision: 'confirm' }, SOMM_CTX);
+        const detail = logAudit.mock.calls.at(-1)[3];
+        expect(detail.clearedProducerNote).toBe(note);
+      });
+
+      test('confirm on an unknown-only row clears the note too', async () => {
+        WineDefinition.findById.mockReturnValue(selectChain(publishedSuspect({
+          producerSuspect: false, producerUnknown: true, producerNote: 'cannot place this producer',
+        })));
+        await tool('review_held_profile').handler({ wine_id: oid('7'), decision: 'confirm' }, SOMM_CTX);
+        const [, update] = WineDefinition.updateOne.mock.calls[0];
+        expect(update.$set['aiProfile.producerUnknown']).toBe(false);
+        expect(update.$set['aiProfile.producerNote']).toBeNull();
+      });
+
+      test('UPHOLD keeps the note — the doubt stands, so its explanation must', async () => {
+        WineDefinition.findById.mockReturnValue(selectChain(publishedSuspect({ producerNote: 'genuinely unidentifiable' })));
+        const body = parse(await tool('review_held_profile').handler({ wine_id: oid('7'), decision: 'uphold' }, SOMM_CTX));
+        const [, update] = WineDefinition.updateOne.mock.calls[0];
+        expect(update.$set['aiProfile.producerNote']).toBeUndefined();
+        expect(body.data.producer_note_cleared).toBeUndefined();
+      });
+
+      test('a HELD row keeps the note — confirm keeps it held, so the doubt is unresolved', async () => {
+        // heldWine() spreads `over` at the TOP level, not into aiProfile, so
+        // the note has to be placed explicitly or this test would assert
+        // nothing about the field it is named for.
+        const held = heldWine();
+        held.aiProfile = { ...held.aiProfile, producerNote: 'unclear' };
+        WineDefinition.findById.mockReturnValue(selectChain(held));
+        await tool('review_held_profile').handler({ wine_id: oid('7'), decision: 'confirm' }, SOMM_CTX);
+        const [, update] = WineDefinition.updateOne.mock.calls[0];
+        expect(update.$set['aiProfile.producerNote']).toBeUndefined();
+      });
+
+      test('a row with no note is not reported as having cleared one', async () => {
+        WineDefinition.findById.mockReturnValue(selectChain(publishedSuspect({ producerNote: null })));
+        const body = parse(await tool('review_held_profile').handler({ wine_id: oid('7'), decision: 'confirm' }, SOMM_CTX));
+        const [, update] = WineDefinition.updateOne.mock.calls[0];
+        expect(update.$set['aiProfile.producerNote']).toBeUndefined();
+        expect(body.data.producer_note_cleared).toBeUndefined();
+        expect(logAudit.mock.calls.at(-1)[3].clearedProducerNote).toBeUndefined();
+      });
+    });
+
     test('a HELD row records no suspect verdict — different question, different queue', async () => {
       WineDefinition.findById.mockReturnValue(selectChain(heldWine()));
       await tool('review_held_profile').handler({ wine_id: oid('7'), decision: 'confirm' }, SOMM_CTX);

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1419,8 +1419,7 @@ registerTool({
         // Confirming a PUBLISHED suspect row means a human adjudicated the
         // doubt and kept the row — so the owner-visible caveat must go
         // (somm ticket 6a84c8dc: five documented-domaine rows carried a
-        // false "cannot be verified" disclaimer even after review). The
-        // producerNote stays for curator context; only the flag clears.
+        // false "cannot be verified" disclaimer even after review).
         if (!held) {
           if (flaggedPublished) {
             set['aiProfile.producerSuspect'] = false;
@@ -1436,19 +1435,52 @@ registerTool({
           // on an unknown-only row: that field is the verdict on
           // producerSuspect, and ONLY that (6a85f5e8).
           if (ap.producerUnknown === true) set['aiProfile.producerUnknown'] = false;
+
+          // …and the NOTE goes with the flag it explains (somm ticket
+          // 6a882f3e). It used to be kept "for curator context", and that was
+          // backwards: once a human has adjudicated the doubt, the model's
+          // account of the doubt has no remaining audience, and where the note
+          // asserted something false it outlived the flag that qualified it.
+          //
+          // Their worked example: Donnafugata's "Isolano" — the estate's own
+          // Etna Bianco — sat confirmed while its note still read "the true
+          // producing estate is unclear to me". No curator lever existed to
+          // correct that: set_wine_profile does not expose the field and
+          // `release` is held-rows-only, which is the wrong population.
+          //
+          // Scoped to a flag actually clearing. A confirm on a HELD row keeps
+          // the row held, so the doubt is unresolved and the note is still
+          // live context — clearing there would delete a caveat that still
+          // applies. The note is copied into the audit detail below rather
+          // than dropped silently: it is the record of what the model claimed,
+          // and an admin asking "why was this ever flagged?" deserves an
+          // answer after the fact.
+          if ((flaggedPublished || ap.producerUnknown === true) && ap.producerNote) {
+            set['aiProfile.producerNote'] = null;
+          }
         }
         await WineDefinition.updateOne({ _id: wine._id }, { $set: set });
         const state = held ? 'held' : (flaggedPublished ? 'published_suspect' : 'published_unknown');
+        const noteCleared = set['aiProfile.producerNote'] === null ? ap.producerNote : null;
         const cleared = {
           ...(flaggedPublished ? { suspectCleared: true } : {}),
           ...(!held && ap.producerUnknown === true ? { unknownCleared: true } : {}),
         };
         logAudit(ctx.req, 'admin.wine.profileReviewed', { type: 'wine', id: wine._id },
-          { name: wine.name, producer: wine.producer, decision: 'confirm', state, ...cleared, reason, via: 'mcp' });
+          {
+            name: wine.name, producer: wine.producer, decision: 'confirm', state, ...cleared,
+            // The cleared note, preserved where it can still be read. Bounded:
+            // an audit detail is not a place to store an essay.
+            ...(noteCleared ? { clearedProducerNote: String(noteCleared).slice(0, 500) } : {}),
+            reason, via: 'mcp',
+          });
         return {
           wine_id: wine._id, label, decision: 'confirm', state,
           ...(cleared.suspectCleared ? { suspect_cleared: true } : {}),
           ...(cleared.unknownCleared ? { unknown_cleared: true } : {}),
+          // Told, not silent: the curator should know the caveat went with the
+          // flag, because they can no longer see it to check.
+          ...(noteCleared ? { producer_note_cleared: true } : {}),
           reviewed_at: now,
         };
       }


### PR DESCRIPTION
Somm ticket 6a882f3e.

`review_held_profile` **confirm** cleared `producerSuspect` and left `producerNote` — so a decided row kept the model's account of a doubt a human had already resolved. Their worked example: Donnafugata's **Isolano**, the estate's own Etna Bianco DOC, read `confirmed` while its note still said *"the true producing estate is unclear to me"*.

The old comment justified keeping it *"for curator context"*. That was backwards — once a human adjudicates the doubt, the model's account of it has no remaining audience, and where the note asserted something **false** it outlived the flag that qualified it. No lever existed either: `set_wine_profile` doesn't expose the field, and `release` is held-rows-only, which is the wrong population.

## Severity, corrected

The ticket says this publishes false producer claims. **It doesn't.** `producerNote` is surfaced only by `somm.js` (all 28 tools are `requireRole: SOMM_ROLES`) and the admin low-confidence modal. It never reaches an owner or the public.

The harm is real but bounded: stale, uneditable text inside the curator's *own* tooling — the surface that has to trust it, and which feeds `list_rule_downgrades` and `list_held_profiles`.

## Scoped to a flag actually clearing

| Case | Note |
|---|---|
| published + suspect confirmed | **cleared** |
| published + unknown confirmed | **cleared** |
| `uphold` | kept — the doubt stands |
| HELD + confirm | kept — confirm keeps the row held, so the doubt is unresolved |
| no note present | nothing reported as cleared |

**Not dropped silently.** The note is copied into the audit detail (bounded to 500 chars) because it records what the model claimed, and an admin later asking *"why was this ever flagged?"* deserves an answer. The response returns `producer_note_cleared` so the curator knows the caveat went — they can't see the field to check.

The admin REST path needs no matching change: it only stamps `profileReviewedAt` and never clears a flag, so the two doors can't drift here.

## The backlog this does not touch

156 rows already carry a note with no flag. **Only 26 were adjudicated by a human.** The other 130 were bulk-downgraded by script — and their notes read like:

> *"Cascina Ballarin is a small Piedmont producer I cannot confidently verify, so this profile is largely appellation-level."*

That isn't a stale caveat, it's the only surviving signal that the profile is appellation-level guesswork. Clearing those would delete provenance. A cleanup, if wanted, should cover the **26 confirmed** rows only.

585 MCP tests passing across 39 suites.