### PR TITLE
fix(import): accept ISO country codes — a real file lost half its rows to this

### DIFF
--- a/backend/src/utils/normalize.js
+++ b/backend/src/utils/normalize.js
@@ -817,6 +817,59 @@ const COUNTRY_ALIASES = {
   'argentine':                'Argentina', // fr
   'argentinien':              'Argentina', // de
   'chili':                    'Chile',     // fr + nl
+
+  // ── ISO 3166-1 alpha-2 codes ───────────────────────────────────────────
+  //
+  // Real files use them. A 48-row import on 2026-08-21 lost HALF its rows to
+  // this — 24 rejected as unrecognized countries, every one a two-letter code
+  // (de ×11, fr ×5, ro ×5, it, pl, es). The user had no way to see why until
+  // the import audit started recording failure reasons that morning.
+  //
+  // This is the right place for it rather than the importer: isRecognizedCountry
+  // resolves through this map before the mint gate, so one entry fixes the
+  // import path, the label scan and the AI lookup together. `us` and `uk`
+  // already lived here, so the two-letter form is not a new idea — it was just
+  // incomplete.
+  //
+  // Scoped to the wine world plus its neighbours rather than all 249 codes:
+  // every entry here is a country somebody could plausibly type in a wine
+  // file, and a shorter list is one a human can still audit.
+  //
+  // ⚠️ Several of these collide with ordinary words — `it`, `at`, `is`, `in`,
+  // `no`, `be`, `me`, `am`, `de`, `es`. That is safe ONLY because this map is
+  // consulted for values already claiming to be a COUNTRY (a country column, a
+  // label-scan country field), never for free text: in a country field, "de"
+  // is Germany. Do not reuse this map for general text normalisation.
+  //
+  // GB → England follows the same wine-world convention as the existing `uk`
+  // entry above, not ISO's political one.
+
+  // Europe — the classical wine countries
+  'fr': 'France',            'it': 'Italy',              'es': 'Spain',
+  'pt': 'Portugal',          'de': 'Germany',            'at': 'Austria',
+  'ch': 'Switzerland',       'gr': 'Greece',             'hu': 'Hungary',
+  'ro': 'Romania',           'bg': 'Bulgaria',           'hr': 'Croatia',
+  'si': 'Slovenia',          'rs': 'Serbia',             'me': 'Montenegro',
+  'mk': 'North Macedonia',   'ba': 'Bosnia and Herzegovina',
+  'al': 'Albania',           'md': 'Moldova',            'ua': 'Ukraine',
+  'ru': 'Russian Federation', 'ge': 'Georgia',           'am': 'Armenia',
+  'az': 'Azerbaijan',        'cz': 'Czech Republic',     'sk': 'Slovakia',
+  'pl': 'Poland',            'lu': 'Luxembourg',         'be': 'Belgium',
+  'nl': 'Netherlands',       'gb': 'England',            'ie': 'Ireland',
+  'dk': 'Denmark',           'se': 'Sweden',             'no': 'Norway',
+  'fi': 'Finland',           'cy': 'Cyprus',             'mt': 'Malta',
+  'tr': 'Turkey',            'is': 'Iceland',            'lt': 'Lithuania',
+  'lv': 'Latvia',            'ee': 'Estonia',            'xk': 'Kosovo',
+
+  // The New World and beyond
+  'ca': 'Canada',            'mx': 'Mexico',             'ar': 'Argentina',
+  'cl': 'Chile',             'uy': 'Uruguay',            'br': 'Brazil',
+  'pe': 'Peru',              'bo': 'Bolivia',            'za': 'South Africa',
+  'au': 'Australia',         'nz': 'New Zealand',        'cn': 'China',
+  'jp': 'Japan',             'in': 'India',              'il': 'Israel',
+  'lb': 'Lebanon',           'ma': 'Morocco',            'dz': 'Algeria',
+  'tn': 'Tunisia',           'eg': 'Egypt',              'kr': 'South Korea',
+  'th': 'Thailand',          'vn': 'Vietnam',
 };
 
 /**

--- a/backend/src/utils/normalize.test.js
+++ b/backend/src/utils/normalize.test.js
@@ -449,6 +449,64 @@ describe('resolveCountryName', () => {
     expect(resolveCountryName('America')).toBe('United States');
   });
 
+  // A 48-row import on 2026-08-21 lost HALF its rows here: 24 rejected as
+  // unrecognized countries, every one an ISO code (de ×11, fr ×5, ro ×5, it,
+  // pl, es). The codes below are exactly the ones that file used, plus the
+  // rest of the wine world.
+  describe('ISO 3166-1 alpha-2 codes', () => {
+    test.each([
+      ['de', 'Germany'], ['fr', 'France'], ['ro', 'Romania'],
+      ['it', 'Italy'], ['pl', 'Poland'], ['es', 'Spain'],
+    ])('the codes that actually failed: %s -> %s', (code, expected) => {
+      expect(resolveCountryName(code)).toBe(expected);
+    });
+
+    test('covers the rest of the wine world', () => {
+      expect(resolveCountryName('pt')).toBe('Portugal');
+      expect(resolveCountryName('at')).toBe('Austria');
+      expect(resolveCountryName('za')).toBe('South Africa');
+      expect(resolveCountryName('nz')).toBe('New Zealand');
+      expect(resolveCountryName('ar')).toBe('Argentina');
+      expect(resolveCountryName('cl')).toBe('Chile');
+      expect(resolveCountryName('ge')).toBe('Georgia');
+      expect(resolveCountryName('am')).toBe('Armenia');
+    });
+
+    test('is case- and whitespace-insensitive like every other alias', () => {
+      expect(resolveCountryName('DE')).toBe('Germany');
+      expect(resolveCountryName('  Fr  ')).toBe('France');
+    });
+
+    test('GB follows the wine-world convention set by UK, not ISO politics', () => {
+      expect(resolveCountryName('gb')).toBe('England');
+    });
+
+    test('does not shadow the existing US/UK entries', () => {
+      expect(resolveCountryName('us')).toBe('United States');
+      expect(resolveCountryName('uk')).toBe('England');
+    });
+
+    test('an unassigned or nonsense code still passes through unresolved', () => {
+      // The mint gate must keep rejecting these — resolving everything
+      // two-letter would let junk become a Country document.
+      expect(resolveCountryName('zz')).toBe('zz');
+      expect(resolveCountryName('qq')).toBe('qq');
+      expect(isRecognizedCountry('zz')).toBe(false);
+    });
+
+    test('every mapped code resolves to a RECOGNIZED country', () => {
+      // A typo in the map would otherwise mint a Country named after nothing.
+      for (const code of ['fr', 'it', 'es', 'pt', 'de', 'at', 'ch', 'gr', 'hu', 'ro',
+        'bg', 'hr', 'si', 'rs', 'me', 'mk', 'ba', 'al', 'md', 'ua', 'ru', 'ge', 'am',
+        'az', 'cz', 'sk', 'pl', 'lu', 'be', 'nl', 'gb', 'ie', 'dk', 'se', 'no', 'fi',
+        'cy', 'mt', 'tr', 'is', 'lt', 'lv', 'ee', 'xk', 'ca', 'mx', 'ar', 'cl', 'uy',
+        'br', 'pe', 'bo', 'za', 'au', 'nz', 'cn', 'jp', 'in', 'il', 'lb', 'ma', 'dz',
+        'tn', 'eg', 'kr', 'th', 'vn']) {
+        expect([code, isRecognizedCountry(code)]).toEqual([code, true]);
+      }
+    });
+  });
+
   test('maps local-language names to canonical English (the prod duplicates)', () => {
     // Each of these existed as a duplicate Country document on prod
     expect(resolveCountryName('Tyskland')).toBe('Germany');   // Swedish


### PR DESCRIPTION
## How this was found

Within **two hours** of shipping import error-reason logging — which is the only reason it's visible.

A 48-row import today rejected **24 rows**:

```json
"errorReasons": {
  "Unrecognized country \"de\"": 11,
  "Unrecognized country \"fr\"":  5,
  "Unrecognized country \"ro\"":  5,
  "Unrecognized country \"it\"":  1,
  "Unrecognized country \"pl\"":  1,
  "Unrecognized country \"es\"":  1
}
```

Every failure was a two-letter ISO 3166-1 code. Before this morning the audit recorded only `errors: 24`, and the user would have had to guess. This morning's 15-of-46 failure was the same shape of question and cost four prod queries and no answer.

## Why the fix lives in COUNTRY_ALIASES

`isRecognizedCountry` resolves through that map *before* the mint gate — so one entry fixes the **import path, the label scan and the AI lookup** together. And `us` / `uk` already lived there, so the two-letter form wasn't a new idea, just an incomplete one.

Scoped to the wine world plus neighbours (**67 codes**) rather than all 249: every entry is a country somebody could plausibly type into a wine file, and a shorter list stays auditable. An unassigned code still passes through unresolved and still fails the mint gate — that's what keeps junk from becoming a Country document.

## The one thing to be careful about

Several codes collide with ordinary words — `it`, `at`, `is`, `in`, `no`, `be`, `me`, `am`, `de`, `es`.

That's safe **only** because this map is consulted for values already claiming to *be* a country — a country column, a label-scan country field — never for free text. In a country field, `"de"` is Germany. The comment says so at the map, because the next person to reach for it won't have this context.

`GB` → England follows the wine-world convention the existing `uk` entry set, not ISO's political one.

## Tests

376 passing across normalize, findOrCreateWine and the import suites — including one that asserts **every** mapped code resolves to a *recognised* country, so a typo in the map fails CI rather than minting a Country named after nothing.