### PR TITLE
fix(frontend): a deploy no longer blanks the app for open tabs

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
-import { lazy, Suspense } from 'react';
+import { Suspense } from 'react';
+import { lazy } from './utils/lazyWithReload';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import { AuthProvider, useAuth } from './contexts/AuthContext';

--- a/frontend/src/components/ClimateCard.js
+++ b/frontend/src/components/ClimateCard.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
+import { useState, useEffect, useCallback, useRef, Suspense } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import Modal from './Modal';

--- a/frontend/src/components/JournalPrompt.js
+++ b/frontend/src/components/JournalPrompt.js
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useId, useState } from 'react';
+import { Suspense, useId, useState } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { useTranslation } from 'react-i18next';
 import { useDialogA11y } from '../utils/useDialogA11y';
 

--- a/frontend/src/components/bottle/EditForm.js
+++ b/frontend/src/components/bottle/EditForm.js
@@ -1,4 +1,5 @@
-import { useState, useRef, lazy, Suspense } from 'react';
+import { useState, useRef, Suspense } from 'react';
+import { lazy } from '../../utils/lazyWithReload';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
 import { updateBottle, setBottleDefaultImage } from '../../api/bottles';

--- a/frontend/src/components/bottle/HeroImage.js
+++ b/frontend/src/components/bottle/HeroImage.js
@@ -1,4 +1,5 @@
-import { useState, lazy, Suspense } from 'react';
+import { useState, Suspense } from 'react';
+import { lazy } from '../../utils/lazyWithReload';
 import { useTranslation } from 'react-i18next';
 import AuthImage from '../AuthImage';
 

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect, Suspense } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef, lazy, Suspense, Fragment } from 'react';
+import { useState, useEffect, useRef, Suspense, Fragment } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, useMemo, useCallback, useRef, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef, Suspense } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { useParams, Link, useSearchParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';

--- a/frontend/src/pages/DiscussionDetail.js
+++ b/frontend/src/pages/DiscussionDetail.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
+import { useState, useEffect, useCallback, useRef, Suspense } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';

--- a/frontend/src/pages/Discussions.js
+++ b/frontend/src/pages/Discussions.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
+import { useState, useEffect, useCallback, Suspense } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';

--- a/frontend/src/pages/Journal.js
+++ b/frontend/src/pages/Journal.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef, lazy, Suspense } from 'react';
+import { useState, useEffect, useRef, Suspense } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';

--- a/frontend/src/pages/Statistics.js
+++ b/frontend/src/pages/Statistics.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
+import { useState, useEffect, useCallback, Suspense } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';

--- a/frontend/src/pages/WineDetail.js
+++ b/frontend/src/pages/WineDetail.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect, Suspense } from 'react';
+import { lazy } from '../utils/lazyWithReload';
 import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';

--- a/frontend/src/utils/lazyWithReload.js
+++ b/frontend/src/utils/lazyWithReload.js
@@ -1,0 +1,75 @@
+import { lazy as reactLazy } from 'react';
+
+/**
+ * React.lazy that survives a deploy.
+ *
+ * THE FAILURE. Vite hashes every chunk filename, so a deploy replaces
+ * `AdminSupportTickets-DK3bBmQy.js` with a differently-hashed file and deletes
+ * the old one. A browser tab open across that deploy still holds the OLD module
+ * graph: navigating to a route it hasn't visited yet requests a filename that
+ * no longer exists, the import rejects on a 404, and — because a rejected lazy
+ * import is thrown, not caught — it propagates past Suspense to the root
+ * ErrorBoundary and takes the WHOLE app down, not just that route.
+ *
+ * Reported twice on 2026-08-21: once as "the dashboard is blank" by a user,
+ * where it went undiagnosed for hours because the symptom is silent, and once
+ * with the console 404 that finally named it. Seven deploys shipped that day,
+ * so every open tab had seven chances to hit it.
+ *
+ * THE FIX is to reload once. index.html is served no-store, so a reload fetches
+ * the new module graph and the route renders. There is nothing to lose by
+ * reloading at that point: the route has already failed to render.
+ *
+ * ⚠️ THE GUARD IS THE LOAD-BEARING PART. Without it a chunk that is missing for
+ * any OTHER reason — a bad build, an offline client, a proxy eating the request
+ * — reloads, fails, reloads, forever. One retry per session, and the second
+ * failure is rethrown so the ErrorBoundary can show something honest instead of
+ * a page that flickers.
+ *
+ * The key clears on the next successful chunk load, so a later deploy gets its
+ * own single retry rather than inheriting a spent one.
+ */
+const RETRY_KEY = 'cellarion:chunk-reload';
+
+// sessionStorage throws in Safari private mode and when storage is disabled.
+// A recovery path must not itself be the thing that breaks.
+function readFlag() {
+  try { return window.sessionStorage.getItem(RETRY_KEY); } catch { return null; }
+}
+function writeFlag(value) {
+  try {
+    if (value === null) window.sessionStorage.removeItem(RETRY_KEY);
+    else window.sessionStorage.setItem(RETRY_KEY, value);
+  } catch { /* storage unavailable — one attempt, no retry, still no loop */ }
+}
+
+/**
+ * The retry rule, as a plain factory wrapper. Exported separately from `lazy`
+ * so it can be tested as the promise logic it is, rather than through a
+ * rendered Suspense tree where a reload is hard to observe.
+ */
+export function withReload(factory) {
+  return () => factory().then(
+    (mod) => {
+      // A chunk loaded, so whatever went wrong before is behind us — let the
+      // NEXT deploy have a fresh retry instead of inheriting a spent one.
+      if (readFlag()) writeFlag(null);
+      return mod;
+    },
+    (err) => {
+      if (readFlag()) throw err; // already retried this session — real error
+      writeFlag('1');
+      window.location.reload();
+      // Never resolves: the reload replaces the document, and resolving here
+      // would render a route from a module graph we have just declared stale.
+      return new Promise(() => {});
+    },
+  );
+}
+
+export function lazy(factory) {
+  return reactLazy(withReload(factory));
+}
+
+export { RETRY_KEY };
+export default lazy;

--- a/frontend/src/utils/lazyWithReload.test.js
+++ b/frontend/src/utils/lazyWithReload.test.js
@@ -1,0 +1,86 @@
+/**
+ * A deploy replaces every hashed chunk filename. A tab open across one still
+ * holds the old module graph, so navigating to a not-yet-loaded route requests
+ * a file that no longer exists — and a rejected lazy import is thrown, not
+ * caught, so it propagates past Suspense to the root ErrorBoundary and takes
+ * the whole app down rather than one route.
+ *
+ * Observed live on 2026-08-21:
+ *   GET /assets/AdminSupportTickets-DK3bBmQy.js -> 404
+ * and, hours earlier and undiagnosed because the symptom is silent, as a user
+ * reporting "the dashboard is blank".
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { withReload, RETRY_KEY } from './lazyWithReload';
+
+let reload;
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  reload = vi.fn();
+  // jsdom's location.reload is non-writable; replace the whole object.
+  delete window.location;
+  window.location = { reload, href: 'https://cellarion.app/admin/support' };
+});
+afterEach(() => vi.restoreAllMocks());
+
+const ok = (mod) => withReload(() => Promise.resolve(mod));
+const chunk404 = () => withReload(() => Promise.reject(new TypeError('Failed to fetch dynamically imported module')));
+
+describe('withReload', () => {
+  test('passes a successful import straight through', async () => {
+    const mod = { default: () => null };
+    await expect(ok(mod)()).resolves.toBe(mod);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test('a failed chunk reloads the page once', async () => {
+    const pending = chunk404()();
+    // Deliberately never settles — resolving would render a route from the
+    // module graph we just declared stale.
+    let settled = false;
+    pending.then(() => { settled = true; }, () => { settled = true; });
+    await Promise.resolve();
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+    expect(window.sessionStorage.getItem(RETRY_KEY)).toBe('1');
+  });
+
+  test('the SECOND failure rethrows instead of looping forever', async () => {
+    // The guard is the load-bearing part: a chunk missing for any other reason
+    // — bad build, offline client, proxy eating the request — would otherwise
+    // reload, fail, reload, forever.
+    window.sessionStorage.setItem(RETRY_KEY, '1');
+    await expect(chunk404()()).rejects.toThrow(/dynamically imported module/);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test('a later success clears the flag, so the NEXT deploy gets its own retry', async () => {
+    window.sessionStorage.setItem(RETRY_KEY, '1');
+    await ok({ default: () => null })();
+    expect(window.sessionStorage.getItem(RETRY_KEY)).toBeNull();
+  });
+
+  test('survives sessionStorage being unavailable, and still cannot loop', async () => {
+    // Safari private mode throws on setItem. A recovery path must not itself
+    // be the thing that breaks — and with no storage there is no flag, so the
+    // reload happens once per document rather than repeatedly within one.
+    const spy = vi.spyOn(window.sessionStorage.__proto__, 'setItem')
+      .mockImplementation(() => { throw new Error('QuotaExceededError'); });
+    const getSpy = vi.spyOn(window.sessionStorage.__proto__, 'getItem')
+      .mockImplementation(() => { throw new Error('SecurityError'); });
+
+    chunk404()();
+    await Promise.resolve();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+    getSpy.mockRestore();
+  });
+
+  test('does not swallow a non-chunk error on the retried path', async () => {
+    window.sessionStorage.setItem(RETRY_KEY, '1');
+    const boom = new Error('module threw during evaluation');
+    await expect(withReload(() => Promise.reject(boom))()).rejects.toBe(boom);
+  });
+});


### PR DESCRIPTION
```
GET /assets/AdminSupportTickets-DK3bBmQy.js → 404
```

Vite hashes every chunk filename, so a deploy replaces that file and deletes the old one. A tab open across the deploy still holds the **old module graph**: navigating to a route it hasn't loaded yet requests a filename that no longer exists.

The import rejects — and because a rejected lazy import is **thrown, not caught**, it goes past `Suspense` to the root `ErrorBoundary`. One missing chunk takes **the whole app** down, not the one route.

## Reported twice today

First by a user as *"the dashboard is blank"*, which went undiagnosed for hours because the symptom carries no information. Then with the console 404 above, which named it in one line.

**Seven releases shipped today**, so every open tab had seven chances to hit this.

## The fix

Catch the rejection and reload once. `index.html` is served `no-store`, so the reload fetches the new module graph and the route renders. Nothing is lost by reloading at that point — the route has already failed.

**⚠️ The guard is the load-bearing part.** Without it, a chunk missing for any *other* reason — a bad build, an offline client, a proxy eating the request — reloads, fails, reloads, forever. One retry per session; the second failure rethrows so the ErrorBoundary can show something honest instead of a page that flickers. The flag clears on the next successful load, so a later deploy gets its own retry rather than inheriting a spent one.

`sessionStorage` access is wrapped — it throws in Safari private mode, and a recovery path must not itself be the thing that breaks.

## Applied by swapping the import, not 68 call sites

```diff
-import { lazy, Suspense } from 'react';
+import { Suspense } from 'react';
+import { lazy } from './utils/lazyWithReload';
```

Every `lazy()` in the file is covered with no call site touched — a smaller diff, and one that can't half-apply. Done for **all 13 files** that lazy-load, not just `App.js`: a lazy *modal* failing throws to the same root boundary as a lazy route.

## Tests

The retry rule is exported as `withReload()` separately from `lazy()`, so it's tested as the promise logic it is rather than through a rendered Suspense tree where a reload is hard to observe. Covers: pass-through, reload-once, **the second failure rethrowing**, the flag clearing on success, and storage being unavailable.

Production build verified to still split — **161 chunks**, `AdminSupportTickets` still its own. 998 frontend tests pass.