### PR TITLE
fix(admin-stats): show every plan tier, including the ones nobody is on

### DIFF
--- a/backend/src/services/globalStatsService.js
+++ b/backend/src/services/globalStatsService.js
@@ -6,6 +6,7 @@ const WineVintageProfile = require('../models/WineVintageProfile');
 const WineRequest = require('../models/WineRequest');
 const BottleImage = require('../models/BottleImage');
 const Rack = require('../models/Rack');
+const { PLAN_NAMES } = require('../config/plans');
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -38,6 +39,33 @@ const tierRows = (row, total) => DAY_TIERS.map(n => ({
   users: row[`t${n}`] || 0,
   pct:   pct(row[`t${n}`] || 0, total),
 }));
+
+/**
+ * Turn raw `{_id: plan, count}` groups into the distribution the page renders.
+ *
+ * Extracted so it is TESTED rather than re-implemented in a test file — a copy
+ * of the rule next to the rule passes even when the two drift apart, which is
+ * the one thing a regression test must not do.
+ *
+ * Two rules, each fixing a way a number could vanish:
+ *   • every CONFIGURED tier appears, at 0 if nobody is on it — $group only
+ *     emits values that exist, so `benefactor` was absent from the table
+ *     entirely and "nobody chose it" read as "it doesn't exist"
+ *   • a plan value NOT in the config is kept and flagged, never dropped — a
+ *     retired or hand-set tier is still real users
+ *
+ * Ordered by the config ladder, because the ladder is the price order.
+ */
+const buildPlanDistribution = (planCounts) => {
+  const countByPlan = new Map(planCounts.map((r) => [r._id, r.count]));
+  return [
+    ...PLAN_NAMES.map((plan) => ({ plan, count: countByPlan.get(plan) || 0 })),
+    ...planCounts
+      .filter((r) => !PLAN_NAMES.includes(r._id))
+      .sort((a, b) => b.count - a.count)
+      .map((r) => ({ plan: r._id, count: r.count, unconfigured: true })),
+  ];
+};
 
 const safeAggregate = async (model, pipeline) => {
   try { return await model.aggregate(pipeline); }
@@ -434,12 +462,25 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
   // every SSO-only user — lives in docs/admin-global-stats-architecture.md.
 
   // ── Plans / subscriptions ───────────────────────────────────────────────
-  const planDistribution = await safeAggregate(User, [
+  // Every CONFIGURED tier appears, including the ones nobody has chosen.
+  //
+  // Grouping alone only emits tiers that have at least one user, so a tier with
+  // zero supporters vanished from the table entirely — and "nobody picked
+  // benefactor" then looked identical to "benefactor does not exist". That is
+  // precisely the question worth asking after a repricing, and the page could
+  // not answer it (found 2026-08-21, benefactor absent since the tiers shipped
+  // in v1.140).
+  //
+  // Ordered by the config ladder rather than by count, because the ladder IS
+  // the price order and reading it that way is the point. Any plan value found
+  // in the data but NOT in the config is appended rather than dropped: a
+  // retired or hand-set tier still represents real users, and silently hiding
+  // them would be the same bug in the other direction.
+  const planCounts = await safeAggregate(User, [
     { $match: userMatch },
     { $group: { _id: '$plan', count: { $sum: 1 } } },
-    { $sort: { count: -1 } },
-    { $project: { _id: 0, plan: '$_id', count: 1 } },
   ]);
+  const planDistribution = buildPlanDistribution(planCounts);
 
   const in7d  = new Date(Date.now() + 7 * 86400000);
   const in30d = new Date(Date.now() + 30 * 86400000);
@@ -860,5 +901,5 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
 module.exports = {
   computeGlobalStats,
   // Exported for tests: the retention day-ladder and its two halves.
-  __testing: { DAY_TIERS, tierAccumulators, tierRows },
+  __testing: { DAY_TIERS, tierAccumulators, tierRows, buildPlanDistribution },
 };

--- a/backend/src/services/globalStatsService.planDistribution.test.js
+++ b/backend/src/services/globalStatsService.planDistribution.test.js
@@ -1,0 +1,52 @@
+/**
+ * Every configured plan tier appears in the distribution, including the ones
+ * nobody is on.
+ *
+ * The bug (found 2026-08-21, present since the tiers shipped in v1.140):
+ * $group only emits a row per DISTINCT VALUE PRESENT, so `benefactor` — with
+ * zero users — was absent from the table entirely. "Nobody has chosen
+ * benefactor" then read identically to "benefactor doesn't exist", which is
+ * exactly the question worth asking after a repricing.
+ */
+const { PLAN_NAMES } = require('../config/plans');
+const { __testing } = require('./globalStatsService');
+
+// The REAL builder, not a copy of it. A test that re-implements the rule next
+// to the rule passes even when the two drift apart, which is the one thing a
+// regression test must not do.
+const buildDistribution = __testing.buildPlanDistribution;
+
+describe('plan distribution', () => {
+  it('includes a configured tier nobody is on', () => {
+    // Real prod shape on the day this was found.
+    const out = buildDistribution([
+      { _id: 'free', count: 301 }, { _id: 'supporter', count: 3 }, { _id: 'patron', count: 1 },
+    ]);
+    const benefactor = out.find((r) => r.plan === 'benefactor');
+    expect(benefactor).toEqual({ plan: 'benefactor', count: 0 });
+  });
+
+  it('lists every configured tier, in the config ladder order', () => {
+    // Ladder order, not count order: the ladder IS the price order, and
+    // reading it that way is the point of the table.
+    const out = buildDistribution([{ _id: 'patron', count: 9 }, { _id: 'free', count: 2 }]);
+    expect(out.slice(0, PLAN_NAMES.length).map((r) => r.plan)).toEqual(PLAN_NAMES);
+  });
+
+  it('keeps a plan value the config does NOT define, flagged', () => {
+    // A retired or hand-set tier is still real users. Dropping it would be the
+    // same bug in the other direction — a number the page cannot show.
+    const out = buildDistribution([{ _id: 'free', count: 5 }, { _id: 'legacy_pro', count: 2 }]);
+    expect(out.at(-1)).toEqual({ plan: 'legacy_pro', count: 2, unconfigured: true });
+  });
+
+  it('survives a null plan value without inventing a tier for it', () => {
+    const out = buildDistribution([{ _id: null, count: 4 }]);
+    expect(out.find((r) => r.plan === 'free')).toEqual({ plan: 'free', count: 0 });
+    expect(out.at(-1)).toMatchObject({ plan: null, count: 4, unconfigured: true });
+  });
+
+  it('returns the full ladder even when there are no users at all', () => {
+    expect(buildDistribution([])).toEqual(PLAN_NAMES.map((plan) => ({ plan, count: 0 })));
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3414,7 +3414,8 @@
     "newSupportersTooltip": "Users whose supporter tier started in the last 90 days, by the date the tier was granted rather than the date they signed up.",
     "formerSupporters": "Former supporters",
     "formerSupportersSub": "supported, not currently",
-    "formerSupportersTooltip": "Users who have a Stripe customer record but sit on the free plan — they supported at some point and do not now. A floor, not a count: someone comped by hand never reaches Stripe, and someone who resubscribed counts as current."
+    "formerSupportersTooltip": "Users who have a Stripe customer record but sit on the free plan — they supported at some point and do not now. A floor, not a count: someone comped by hand never reaches Stripe, and someone who resubscribed counts as current.",
+    "planUnconfigured": "(not a configured tier)"
   },
   "announcement": {
     "dismiss": "Dismiss"

--- a/frontend/src/pages/AdminStats.css
+++ b/frontend/src/pages/AdminStats.css
@@ -348,3 +348,13 @@
     font-size: 0.8rem;
   }
 }
+
+/* A configured plan tier nobody is on. Shown rather than omitted — "nobody
+   chose benefactor" and "benefactor doesn't exist" are different answers —
+   but dimmed, so a live tier still reads as the live one at a glance. */
+.admin-stats-row-empty { opacity: 0.5; }
+.admin-stats-tag {
+  font-size: 0.75rem;
+  font-style: italic;
+  color: var(--color-text-muted);
+}

--- a/frontend/src/pages/AdminStats.js
+++ b/frontend/src/pages/AdminStats.js
@@ -354,8 +354,21 @@ function AdminStats() {
                 {plans.distribution.map((p, i) => {
                   const pp = overview.totalUsers > 0 ? Math.round((p.count / overview.totalUsers) * 100) : 0;
                   return (
-                    <tr key={`${p.plan || 'unknown'}-${i}`}>
-                      <td className="admin-stats-name">{p.plan || '—'}</td>
+                    // A configured tier with nobody on it renders dimmed rather
+                    // than being absent — "nobody chose benefactor" and
+                    // "benefactor doesn't exist" are different answers, and
+                    // only one of them is worth acting on.
+                    <tr
+                      key={`${p.plan || 'unknown'}-${i}`}
+                      className={p.count === 0 ? 'admin-stats-row-empty' : undefined}
+                    >
+                      <td className="admin-stats-name">
+                        {p.plan || '—'}
+                        {/* A plan value in the data that the config doesn't
+                            define — retired, or set by hand. Shown, not
+                            dropped: it's still real users. */}
+                        {p.unconfigured && <span className="admin-stats-tag"> {t('adminStats.planUnconfigured')}</span>}
+                      </td>
                       <td className="admin-stats-count">{fmt(p.count)}</td>
                       <td className="admin-stats-pct">{pp}%</td>
                     </tr>


### PR DESCRIPTION
## The bug

`$group` only emits a row per value that **exists**, so `benefactor` — with zero users — was absent from the plan distribution entirely:

```
free        301   99%
supporter     3    1%
patron        1    0%
                        ← benefactor simply isn't there
```

So *"nobody has chosen benefactor"* read identically to *"benefactor doesn't exist"* — which is exactly the question worth asking after a repricing. Present since the tiers shipped in v1.140.

## The fix

The distribution is built from `PLAN_NAMES`, so **every configured tier appears**, at 0 when empty, in the **config ladder order** rather than by count — the ladder is the price order, and reading it that way is the point.

A plan value found in the data but **not** in the config is appended and flagged rather than dropped. A retired or hand-set tier is still real users, and hiding them would be the same bug facing the other way.

Zero-count rows render dimmed, so a live tier still reads as the live one at a glance.

## ⚠️ On the test

My first version **re-implemented the rule inside the test file** — a copy of the logic sitting next to the logic. It would have passed even after the service diverged from it: a regression test that cannot detect the regression.

The builder is now extracted and exported, and the test exercises the real one. Cases covered: a configured tier with nobody on it, ladder ordering, an unconfigured plan value being kept and flagged, a `null` plan, and no users at all.

13 backend + 998 frontend tests pass.