### PR TITLE
feat(admin-stats): do new users come back? signup cohorts on the dashboard

### DIFF
--- a/backend/src/services/globalStatsService.js
+++ b/backend/src/services/globalStatsService.js
@@ -6,6 +6,7 @@ const WineVintageProfile = require('../models/WineVintageProfile');
 const WineRequest = require('../models/WineRequest');
 const BottleImage = require('../models/BottleImage');
 const Rack = require('../models/Rack');
+const AuditLog = require('../models/AuditLog');
 const { PLAN_NAMES } = require('../config/plans');
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -65,6 +66,47 @@ const buildPlanDistribution = (planCounts) => {
       .sort((a, b) => b.count - a.count)
       .map((r) => ({ plan: r._id, count: r.count, unconfigured: true })),
   ];
+};
+
+// Signup cohorts: "of the people who joined N weeks ago, how many came back?"
+const COHORT_WINDOW_DAYS = 7;   // what "came back" means, and the cohort width
+const COHORT_SPAN_DAYS = 28;    // how far back cohorts go
+
+/**
+ * Bucket users by signup age and count who was active in the window.
+ *
+ * ⚠️ THE NEWEST COHORT IS NOT ASKED. Its members are "active in the last 7
+ * days" because they SIGNED UP in the last 7 days — measured live that reads
+ * ~97%, which is a tautology, not retention. It returns { returned: null,
+ * pct: null, tooNew: true } so the caller can show the intake without
+ * inviting the false reading, and the headline percentage skips it.
+ *
+ * `now` is injected so the test can pin time instead of racing the clock.
+ */
+const buildSignupCohorts = (users, activeIds, now) => {
+  const out = [];
+  for (let start = 0; start < COHORT_SPAN_DAYS; start += COHORT_WINDOW_DAYS) {
+    const end = start + COHORT_WINDOW_DAYS;
+    const from = new Date(now - end * 86400000);
+    // Buckets are [now-end, now-start) so each user lands in exactly one. The
+    // NEWEST bucket has no upper bound at all rather than `< now`: a user
+    // created at the query instant would otherwise fall out of every bucket
+    // and silently vanish from the intake count, and clock skew between the
+    // app and Mongo puts a createdAt fractionally in the future within reach.
+    const to = start === 0 ? null : new Date(now - start * 86400000);
+    const members = users.filter((u) => u.createdAt >= from && (to === null || u.createdAt < to));
+    const tooNew = start === 0;
+    const returned = tooNew ? null : members.filter((u) => activeIds.has(String(u._id))).length;
+    out.push({
+      daysAgoFrom: start,
+      daysAgoTo: end,
+      signedUp: members.length,
+      returned,
+      pct: returned == null ? null : pct(returned, members.length),
+      tooNew,
+    });
+  }
+  return out;
 };
 
 const safeAggregate = async (model, pipeline) => {
@@ -447,6 +489,45 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
   const coreUsers = ret.t4 || 0;        // 4+ — a stickier tier, subset of the above
   const singleSessionUsers = Math.max(0, ret.usersWithActivity - returningUsers);
 
+  // ── Signup cohorts: do new users come back? ─────────────────────────────
+  //
+  // "Of the people who signed up N weeks ago, how many used Cellarion in the
+  // last 7 days." The activity ladder above measures the whole population at
+  // once and so is dominated by whoever has been here longest; this asks the
+  // question that actually tracks growth.
+  //
+  // ⚠️ THE MOST RECENT COHORT CANNOT BE ASKED. Someone who joined three days
+  // ago is "active in the last 7 days" because of the session they signed up
+  // in — measured live it reads 97%, which is not retention, it is a tautology.
+  // That cohort is returned with returned/pct NULL and a tooNew flag so the UI
+  // shows the intake without inviting the false reading. The headline
+  // percentage covers the MATURE cohorts only.
+  //
+  // Cost: ONE audit query, bounded to 7 days and served by the timestamp
+  // index, intersected in memory — not one query per cohort. Deliberately
+  // modest, because the login retention removed above was the most expensive
+  // thing on this page and replacing it with something worse would be a poor
+  // trade.
+  const cohortUsers = await User.find({
+    ...userMatch,
+    createdAt: { $gte: new Date(Date.now() - COHORT_SPAN_DAYS * 86400000) },
+  }).select('_id createdAt').lean();
+
+  // Anyone who did ANYTHING in the window. Deliberately not "logged in": the
+  // refresh cookie keeps a session alive for 30 rotating days, so an active
+  // user may not hit /login for weeks. Deliberately not "touched a bottle"
+  // either — that measures activation, which is a different question and
+  // already has its own figures.
+  const activeIds = new Set(
+    (await AuditLog.distinct('actor.userId', { timestamp: { $gte: since7d } }))
+      .filter(Boolean).map(String),
+  );
+
+  const signupCohorts = buildSignupCohorts(cohortUsers, activeIds, Date.now());
+  const mature = signupCohorts.filter((c) => !c.tooNew);
+  const matureSignups = mature.reduce((s, c) => s + c.signedUp, 0);
+  const matureReturned = mature.reduce((s, c) => s + c.returned, 0);
+
   // Login-derived retention was REMOVED 2026-08-21. It answered a question the
   // activity ladder above already answers better, and it cost the single most
   // expensive query on this page: a full AuditLog scan over every login event,
@@ -825,6 +906,15 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
       // Full ladder: [{ days, users, pct }] for every DAY_TIERS threshold,
       // percentages over usersWithActivity.
       activityTiers,
+      // "Of the people who signed up N weeks ago, how many used Cellarion in
+      // the last 7 days." cohortReturnedPct covers the MATURE cohorts only —
+      // the newest one cannot be asked, because its members are active in the
+      // window by virtue of having signed up in it.
+      signupCohorts,
+      cohortWindowDays: COHORT_WINDOW_DAYS,
+      cohortSignups: matureSignups,
+      cohortReturned: matureReturned,
+      cohortReturnedPct: pct(matureReturned, matureSignups),
     },
     plans: {
       distribution: planDistribution,
@@ -901,5 +991,8 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
 module.exports = {
   computeGlobalStats,
   // Exported for tests: the retention day-ladder and its two halves.
-  __testing: { DAY_TIERS, tierAccumulators, tierRows, buildPlanDistribution },
+  __testing: {
+    DAY_TIERS, tierAccumulators, tierRows,
+    buildPlanDistribution, buildSignupCohorts, COHORT_WINDOW_DAYS, COHORT_SPAN_DAYS,
+  },
 };

--- a/backend/src/services/globalStatsService.signupCohorts.test.js
+++ b/backend/src/services/globalStatsService.signupCohorts.test.js
@@ -1,0 +1,100 @@
+/**
+ * "Of the people who signed up N weeks ago, how many came back?"
+ *
+ * The trap this exists to hold shut: the NEWEST cohort cannot be asked. Its
+ * members are active in the last 7 days because they SIGNED UP in the last 7
+ * days. Measured live on 2026-08-21 that read 97% next to 39% and 35% for the
+ * two cohorts behind it — a tautology sitting where a headline number goes.
+ */
+const { __testing } = require('./globalStatsService');
+
+const { buildSignupCohorts, COHORT_WINDOW_DAYS, COHORT_SPAN_DAYS } = __testing;
+
+// Time is injected rather than mocked so these never race midnight.
+const NOW = Date.parse('2026-08-21T12:00:00Z');
+const daysAgo = (n) => new Date(NOW - n * 86400000);
+const user = (id, n) => ({ _id: id, createdAt: daysAgo(n) });
+
+describe('buildSignupCohorts', () => {
+  it('never reports a rate for the newest cohort', () => {
+    // Three users who joined this week and are all "active" — because joining
+    // IS activity. A percentage here would say 100% and mean nothing.
+    const users = [user('a', 1), user('b', 3), user('c', 6)];
+    const [newest] = buildSignupCohorts(users, new Set(['a', 'b', 'c']), NOW);
+    expect(newest).toMatchObject({ daysAgoFrom: 0, signedUp: 3, tooNew: true });
+    expect(newest.returned).toBeNull();
+    expect(newest.pct).toBeNull();
+  });
+
+  it('reports a real rate for cohorts old enough to have left and come back', () => {
+    const users = [user('a', 8), user('b', 9), user('c', 10), user('d', 11)];
+    const cohorts = buildSignupCohorts(users, new Set(['a', 'c']), NOW);
+    const wk2 = cohorts.find((c) => c.daysAgoFrom === 7);
+    expect(wk2).toMatchObject({ signedUp: 4, returned: 2, pct: 50, tooNew: false });
+  });
+
+  it('puts an exact-boundary signup in the NEWER cohort, once', () => {
+    // Buckets are [now-end, now-start): the older edge is inclusive, so a user
+    // aged exactly 7 days is the lower bound of 0-7 and lands there, not in
+    // 7-14. Which side it falls is arbitrary; that it falls on exactly ONE
+    // side is not — the alternative is a user double-counted or dropped.
+    const cohorts = buildSignupCohorts([user('edge', 7)], new Set(), NOW);
+    expect(cohorts.find((c) => c.daysAgoFrom === 0).signedUp).toBe(1);
+    expect(cohorts.find((c) => c.daysAgoFrom === 7).signedUp).toBe(0);
+    expect(cohorts.reduce((s, c) => s + c.signedUp, 0)).toBe(1);
+  });
+
+  it('places every user in exactly one bucket across the whole span', () => {
+    // The property that actually matters, checked at every boundary rather
+    // than at one hand-picked case.
+    const users = Array.from({ length: COHORT_SPAN_DAYS }, (_, i) => user(`u${i}`, i));
+    const cohorts = buildSignupCohorts(users, new Set(), NOW);
+    expect(cohorts.reduce((s, c) => s + c.signedUp, 0)).toBe(users.length);
+  });
+
+  it('covers the full span with contiguous, non-overlapping windows', () => {
+    const cohorts = buildSignupCohorts([], new Set(), NOW);
+    expect(cohorts).toHaveLength(COHORT_SPAN_DAYS / COHORT_WINDOW_DAYS);
+    for (let i = 0; i < cohorts.length; i++) {
+      expect(cohorts[i].daysAgoFrom).toBe(i * COHORT_WINDOW_DAYS);
+      expect(cohorts[i].daysAgoTo).toBe((i + 1) * COHORT_WINDOW_DAYS);
+    }
+  });
+
+  it('ignores users older than the span', () => {
+    const cohorts = buildSignupCohorts([user('ancient', 400)], new Set(['ancient']), NOW);
+    expect(cohorts.reduce((s, c) => s + c.signedUp, 0)).toBe(0);
+  });
+
+  it('reports 0%, not a crash, for a cohort nobody joined', () => {
+    const cohorts = buildSignupCohorts([], new Set(), NOW);
+    const wk2 = cohorts.find((c) => c.daysAgoFrom === 7);
+    expect(wk2).toMatchObject({ signedUp: 0, returned: 0, pct: 0 });
+  });
+
+  it('compares ids as strings — a real ObjectId is not === its string form', () => {
+    // activeIds comes from AuditLog.distinct() and the users from a lean()
+    // find; both sides are ObjectId-ish, and a raw === would silently match
+    // nothing and report 0% retention forever.
+    const oid = { toString: () => 'objid-1' };
+    const cohorts = buildSignupCohorts([{ _id: oid, createdAt: daysAgo(9) }], new Set(['objid-1']), NOW);
+    expect(cohorts.find((c) => c.daysAgoFrom === 7)).toMatchObject({ returned: 1, pct: 100 });
+  });
+});
+
+describe('the newest bucket has no upper bound', () => {
+  it('counts a user created at the exact query instant', () => {
+    // With `< now` as the upper edge this user fell out of every bucket and
+    // vanished from the intake count. Found by the every-user-lands-somewhere
+    // property test, not by a hand-picked case.
+    const cohorts = buildSignupCohorts([{ _id: 'x', createdAt: new Date(NOW) }], new Set(), NOW);
+    expect(cohorts[0].signedUp).toBe(1);
+  });
+
+  it('counts a user whose createdAt is slightly in the FUTURE (clock skew)', () => {
+    const ahead = new Date(NOW + 2000);
+    const cohorts = buildSignupCohorts([{ _id: 'skewed', createdAt: ahead }], new Set(), NOW);
+    expect(cohorts[0].signedUp).toBe(1);
+    expect(cohorts.reduce((s, c) => s + c.signedUp, 0)).toBe(1);
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3415,7 +3415,14 @@
     "formerSupporters": "Former supporters",
     "formerSupportersSub": "supported, not currently",
     "formerSupportersTooltip": "Users who have a Stripe customer record but sit on the free plan — they supported at some point and do not now. A floor, not a count: someone comped by hand never reaches Stripe, and someone who resubscribed counts as current.",
-    "planUnconfigured": "(not a configured tier)"
+    "planUnconfigured": "(not a configured tier)",
+    "cohortsHead": "Do new users come back?",
+    "cohortReturned": "New users returning",
+    "cohortReturnedSub": "{{returned}} of {{total}} recent signups",
+    "cohortReturnedTooltip": "Of everyone who signed up between 1 and 4 weeks ago, the share who used Cellarion in the last 7 days. Counts any activity, not just logging in — a signed-in session can last 30 days without a fresh login. The most recent week is excluded because its members were active in the window by virtue of signing up in it.",
+    "cohortRange": "Signed up {{from}}–{{to}} days ago",
+    "cohortTooNew": "too recent to ask",
+    "cohortNote": "Came back = any activity in the last 7 days. The newest group shows its intake only: those users were active in the window because they joined during it, so a percentage there would measure nothing."
   },
   "announcement": {
     "dismiss": "Dismiss"

--- a/frontend/src/pages/AdminStats.js
+++ b/frontend/src/pages/AdminStats.js
@@ -235,6 +235,51 @@ function AdminStats() {
           <p className="admin-stats-section-note">
             {t('adminStats.retentionNote')}
           </p>
+          {/* Do NEW users come back? The ladder below measures the whole
+              population at once, so it is dominated by whoever has been here
+              longest; this asks the question that tracks growth. */}
+          {retention.signupCohorts && retention.signupCohorts.length > 0 && (
+            <>
+              <h3 className="admin-stats-subhead">{t('adminStats.cohortsHead')}</h3>
+              <div className="admin-stats-cards">
+                <StatCard
+                  accent="ok"
+                  label={t('adminStats.cohortReturned')}
+                  value={fmtPct(retention.cohortReturnedPct)}
+                  sublabel={t('adminStats.cohortReturnedSub', {
+                    returned: retention.cohortReturned ?? 0,
+                    total: retention.cohortSignups ?? 0,
+                  })}
+                  tooltip={t('adminStats.cohortReturnedTooltip')}
+                />
+              </div>
+              <div className="admin-stats-panel">
+                <table className="admin-stats-table">
+                  <tbody>
+                    {retention.signupCohorts.map((c) => (
+                      <tr key={c.daysAgoFrom} className={c.tooNew ? 'admin-stats-row-empty' : undefined}>
+                        <td className="admin-stats-name">
+                          {t('adminStats.cohortRange', { from: c.daysAgoFrom, to: c.daysAgoTo })}
+                        </td>
+                        <td className="admin-stats-count">{fmt(c.signedUp)}</td>
+                        <td className="admin-stats-pct">
+                          {/* The newest cohort shows its intake and NO rate:
+                              its members are "active in the last 7 days"
+                              because they signed up in them. A number here
+                              would read as ~97% retention and mean nothing. */}
+                          {c.tooNew
+                            ? t('adminStats.cohortTooNew')
+                            : `${fmt(c.returned)} · ${fmtPct(c.pct)}`}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <p className="admin-stats-section-note">{t('adminStats.cohortNote')}</p>
+              </div>
+            </>
+          )}
+
           <h3 className="admin-stats-subhead">{t('adminStats.retentionByActivity')}</h3>
           <div className="admin-stats-cards">
             <StatCard


### PR DESCRIPTION
*"Of the people who signed up N weeks ago, how many used Cellarion in the last 7 days."*

The activity ladder measures the whole population at once, so it's dominated by whoever has been here longest. This is the question that tracks growth.

Live numbers the day it was built:

```
Signed up  0–7 days ago   34   too recent to ask
Signed up  7–14 days ago  18   7 · 39%
Signed up 14–21 days ago  23   8 · 35%
```

## ⚠️ The newest cohort is deliberately not asked

Its members are "active in the last 7 days" **because they signed up in the last 7 days**. Measured live that reads **97%**, sitting next to 39% and 35% — a tautology exactly where a headline number goes.

It returns `returned`/`pct` as `null` with a `tooNew` flag, renders as *"too recent to ask"*, and the headline percentage covers mature cohorts only. The intake is still visible; the false reading isn't available.

## "Came back" means any activity, not a login

The refresh cookie keeps a session alive for 30 rotating days, so an active user may not hit `/login` for weeks — the same reason login retention came off this page. Not bottle activity either: that measures *activation*, a different question that already has its own figures.

**Cost:** one audit query, bounded to 7 days and served by the timestamp index, intersected in memory — not one per cohort. Replacing the most expensive query on the page with something worse would have been a poor trade.

## Two bugs the tests found, both mine

**1.** I asserted the exact-boundary user lands in the *older* cohort. The code puts it in the newer one — and the code is right. Buckets are `[now-end, now-start)`, so the older edge is the inclusive lower bound. Which side is arbitrary; that it's exactly **one** side is not.

**2.** Then a property test — *"every user lands in exactly one bucket"* — failed **27 of 28**. The newest bucket's upper edge was `< now`, so a user created at the query instant fell out of every bucket and vanished from the intake count. Clock skew between the app and Mongo puts a `createdAt` fractionally in the future within reach of that.

The second was invisible to every hand-picked case I wrote, and only surfaced because the test asserted the *property* rather than an example. The newest bucket now has no upper bound at all.

245 backend + 998 frontend tests pass.