### PR TITLE
fix: apply the 2026-08-21 audit — H-1 and both actionable Mediums

### DIFF
--- a/CODE_AUDIT_2026-08-21_v1156-v1164.md
+++ b/CODE_AUDIT_2026-08-21_v1156-v1164.md
@@ -1,0 +1,125 @@
+# Code Audit — 2026-08-21 (v1.156 → v1.164)
+
+**Scope:** the diff `v1.155.0..origin/main` — today's nine releases. 48 files, +2,437/−236;
+32 non-test source files. Per the standing rule, scoped to the diff since the last baseline
+(full tree: `CODE_AUDIT_2026-08-03_FULL.md`).
+
+**Method:** single careful pass over every non-test diff, with prod verification for any
+finding that could be quantified rather than argued. Every claim below marked *verified*
+was measured on prod or in the repo, not inferred.
+
+**Verdict: 1 High, 3 Medium, 3 Low. The High is in code shipped this afternoon, and it is
+a *lying metric* rather than a crash — the worst kind, because it looks finished.**
+
+---
+
+## H-1 · `formerSupporters` counts abandoned checkouts as churned supporters — **verified on prod**
+
+`globalStatsService.js` (v1.163): `formerSupporters = plan: 'free' AND stripeCustomerId set`.
+But the Stripe customer is created at **checkout-session time** (`routes/stripe.js:198`),
+*before any payment*. A user who clicks Support, reaches Stripe, and closes the tab carries
+a `stripeCustomerId` forever and counts as having "supported and stopped".
+
+Measured on prod:
+
+```
+card shows:            7 former supporters
+ever actually paid:    3   (planStartedAt set)
+abandoned checkout:    4   (no subscriptionId, no planStartedAt, no thank-you)
+```
+
+**The card overstates churn by more than 2×.** The tooltip's "a floor, not a count" caveat
+covers *under*counting (comped users) — the metric also *over*counts, which the caveat does
+not cover and which points the wrong emotional direction: it tells the admin four people
+quit who in fact never started.
+
+**Fix:** `plan: 'free' AND planStartedAt: { $ne: null }` — `planStartedAt` is stamped only
+when a tier is actually granted. The four abandoned checkouts become what they are:
+invisible here (arguably a separate "started checkout, didn't finish" funnel metric, which
+is interesting but is a different number with a different name).
+
+## M-1 · Import-file geography reaches the AI prompt untruncated
+
+`labelScan.js:503-504` (v1.158): the file's `appellation`/`region` are interpolated into
+the identify prompt with no length cap. The import path caps `notes` (5000) and `occasion`
+(500) but these two fields go straight from client JSON to the prompt.
+
+Impact: a pathological CSV column (10 KB of text in "appellation") inflates every identify
+call's token count — billed against the user's own AI budget, so it is self-harm plus cost
+noise rather than an attack on others; and it is a mild prompt-injection surface ("ignore
+previous instructions…" in a column), bounded by `validateWineIdentity` and per-field caps
+on the way OUT. **Fix:** `.slice(0, 200)` at the hint site — no legitimate appellation is
+longer.
+
+## M-2 · `?blogPost=` filter is silently dropped on the Meilisearch path
+
+`routes/discussions.js` (v1.160): the blogPost scope is applied to the Mongo branch only.
+A request combining `q=` and `blogPost=` takes the Meili branch, which ignores the blogPost
+filter entirely — results silently widen from "threads about this post" to "all threads
+matching q". The comment says the post page never issues that combination, which is true,
+but the API accepts it and answers wrong rather than either honouring or refusing it.
+Public read-only data, so scope-widening not leakage. **Fix:** when `blogPost` is present,
+skip the Meili branch (exact scope beats fuzzy relevance for a post's own thread list).
+
+## M-3 · `lazyWithReload` can reload-loop when storage is unavailable AND the failure is persistent
+
+`utils/lazyWithReload.js` (v1.163): the one-retry guard lives in `sessionStorage`. If
+storage access *throws* (fully blocked cookies/storage), `readFlag()` returns null every
+time, so a **persistently** failing chunk (bad build, corporate proxy) reloads forever at
+navigation speed. Both conditions are rare and must coincide; modern Safari private mode
+allows sessionStorage, so the loop needs storage fully disabled. **Fix if wanted:** carry
+the flag in the URL (`?chunkretry=1`) as the storage-less fallback. Low probability,
+unbounded annoyance when it hits — hence Medium not Low.
+
+## L-1 · Undo message misattributes a self-applied proposal
+
+`mcp/revert.js`: undoing a proposal that self-applied (v1.157) says "already approved by an
+admin — the decision stands". No admin was involved; the classifier applied it. Correct
+refusal, wrong explanation — and the somm has shown they read these messages closely.
+
+## L-2 · Import audit `errorReasons` can embed user-typed values
+
+`summariseReasons` (v1.158) stores reason strings; some reasons interpolate the offending
+value (`Unrecognized country "de"`). Values are truncated at 160 chars and live in the
+admin-only audit, but a country column containing something personal would persist there.
+Accepted trade-off today (the "de" case is exactly why it exists); worth knowing the shape.
+
+## L-3 · `withStripeCustomer` card now reads as a near-duplicate
+
+With H-1 fixed, the "Stripe customers" card (12) sits next to paid (4) + former (3), and
+the remaining 5 are abandoned checkouts — the card invites the same misreading H-1 made
+concrete.
+Either caption it ("includes abandoned checkouts") or replace it with the funnel metric.
+
+---
+
+## Verified clean (checked, not assumed)
+
+- **Self-apply path** (v1.157): proposal row written before apply; failed/thrown apply
+  reports `pending`; applies via the admin route's own `approveProposal` (single write
+  path); `undo_last` on an applied proposal refuses safely (L-1 is message-only).
+- **Country-scoped name check** (v1.159): both directions covered — foreign appellation
+  from name ignored, foreign appellation *proposed* routes to review; no-country wines keep
+  the conservative behaviour.
+- **Blog search** (v1.160): `?q[$gt]=` object-shape survives (`coerceStringQuery`), regex
+  escaped (ReDoS), needle bounded at 120, drafts never searchable, tag+q compose.
+- **`blogPost` create-side validation** (v1.160): ref verified to exist AND be published
+  before a publicly-readable thread can carry it; malformed list filter returns empty
+  rather than widening.
+- **ISO codes** (v1.162): map consulted only for country-claiming fields; junk (`zz`)
+  still fails the mint gate; every mapped code resolves to a recognized country (CI-pinned).
+- **Cohorts** (v1.164): newest cohort refuses a rate (tautology guard); boundary user lands
+  in exactly one bucket; newest bucket unbounded above (clock-skew); ObjectId-vs-string
+  compare pinned by test; ONE bounded audit query, not per-cohort.
+- **producerNote clear** (v1.161): scoped to flags actually clearing; uphold and held keep
+  the note; cleared text preserved in audit detail.
+- **Login-retention removal** (v1.163): no orphan strings (locale guard), no orphan import,
+  docs updated, `LOGIN_ACTIONS` SSO fact preserved in the doc.
+- **GDPR:** no new personal data stored by any of today's features; `Discussion.blogPost`
+  is a content ref inside an already-registered model; cohort metric reuses existing audit
+  rows (data minimisation) and is admin-only.
+
+## Not in scope
+
+Pre-existing findings tracked elsewhere (57M/49L from 2026-08-03), the somm-side MCP tools'
+behaviour on prod (exercised daily by the curator), and the deploy pipeline.

--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -12,7 +12,7 @@ const DiscussionReport = require('../models/DiscussionReport');
 const User = require('../models/User');
 const WineDefinition = require('../models/WineDefinition');
 const BlogPost = require('../models/BlogPost');
-const { stripHtml } = require('../utils/sanitize');
+const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { sanitizeForumHtml, visibleTextLength } = require('../utils/sanitizeHtml');
 const { logAudit } = require('../services/audit');
 const { incrementCred, decrementCred } = require('../utils/cellarCred');
@@ -79,13 +79,18 @@ router.get('/', optionalAuth, async (req, res) => {
     }
 
     // Threads opened from one blog post — what the post page lists under
-    // "Discuss this post". Applied to the Mongo path only: the Meili branch
-    // below is a relevance search and this is an exact scope, so mixing them
-    // would silently return the wrong set. A blogPost filter with a `q` is not
-    // a combination the post page issues.
+    // "Discuss this post".
     const blogPostId = coerceStringQuery(req.query.blogPost).trim();
     if (blogPostId && isValidId(blogPostId)) {
       filter.blogPost = { $eq: new mongoose.Types.ObjectId(blogPostId) };
+      // A q combined with the blogPost scope is answered HERE, not by Meili
+      // (whose index doesn't carry blogPost — see the skip below). The scoped
+      // set is one post's threads, so a title regex over it is trivially
+      // cheap; escaped and bounded exactly like the blog search, because the
+      // needle is user input (`(((((` is a ReDoS, `?q[$gt]=` is an object).
+      if (query) {
+        filter.title = new RegExp(escapeRegex(query.slice(0, 120)), 'i');
+      }
     } else if (blogPostId) {
       // A malformed id must not silently widen the scope to every discussion.
       return res.json({ discussions: [], total: 0, page, pages: 0 });
@@ -93,7 +98,14 @@ router.get('/', optionalAuth, async (req, res) => {
 
     // Meilisearch path: fuzzy match on title/body/authorName/wineName,
     // hydrate hits from MongoDB to keep the response shape consistent.
-    if (query && searchService.getIsAvailable()) {
+    //
+    // Skipped when a blogPost scope is present (audit 2026-08-21 M-2): the
+    // Meili index doesn't carry blogPost, so this branch used to ignore the
+    // filter and a q+blogPost request silently widened from "threads about
+    // this post" to "all threads matching q" — answering a different question
+    // than the one asked. Exact scope beats fuzzy relevance for a post's own
+    // thread list, and the Mongo path below applies both together honestly.
+    if (query && !filter.blogPost && searchService.getIsAvailable()) {
       try {
         const { ids, estimatedTotalHits } = await searchService.searchDiscussions(query, {
           category: validCategory,

--- a/backend/src/services/globalStatsService.js
+++ b/backend/src/services/globalStatsService.js
@@ -577,9 +577,17 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
     // support rather than the account.
     User.countDocuments({ ...userMatch, plan: { $ne: 'free' }, planStartedAt: { $gte: since30 } }),
     User.countDocuments({ ...userMatch, plan: { $ne: 'free' }, planStartedAt: { $gte: since90 } }),
-    // Churn: a Stripe customer record outlives the subscription, so a user who
-    // has one but sits on `free` supported at some point and does not now.
-    User.countDocuments({ ...userMatch, plan: 'free', stripeCustomerId: { $nin: [null, ''] } }),
+    // Churn: a user on `free` whose planStartedAt is stamped had a tier
+    // GRANTED at some point — that stamp is written only when support actually
+    // starts, and it survives the downgrade.
+    //
+    // ⚠️ NOT stripeCustomerId, which this shipped as for a few hours
+    // (audit 2026-08-21 H-1). Stripe customers are created at CHECKOUT-SESSION
+    // time, before any payment — so that shape counted abandoned checkouts as
+    // churned supporters. Measured on prod the day it shipped: the card said 7
+    // former supporters and only 3 had ever paid. An overstated churn number
+    // points the admin at a retention problem that does not exist.
+    User.countDocuments({ ...userMatch, plan: 'free', planStartedAt: { $ne: null } }),
   ]);
 
   // ── Maturity (drink-window phase distribution) ──────────────────────────

--- a/backend/src/services/globalStatsService.planDistribution.test.js
+++ b/backend/src/services/globalStatsService.planDistribution.test.js
@@ -50,3 +50,20 @@ describe('plan distribution', () => {
     expect(buildDistribution([])).toEqual(PLAN_NAMES.map((plan) => ({ plan, count: 0 })));
   });
 });
+
+// Audit 2026-08-21 H-1. The shape of the CHURN query, pinned as data because
+// the wrong shape shipped and measured 7 where the truth was 3: Stripe
+// customers are created at checkout-session time, BEFORE payment, so keying
+// churn on stripeCustomerId counts abandoned checkouts as former supporters.
+describe('formerSupporters query shape (H-1)', () => {
+  const fs = require('fs');
+  const src = fs.readFileSync(require.resolve('./globalStatsService'), 'utf8');
+
+  it('keys on planStartedAt, which is stamped only when a tier is granted', () => {
+    expect(src).toMatch(/plan:\s*'free',\s*planStartedAt:\s*\{\s*\$ne:\s*null\s*\}/);
+  });
+
+  it('never again keys churn on stripeCustomerId', () => {
+    expect(src).not.toMatch(/plan:\s*'free',\s*stripeCustomerId/);
+  });
+});

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -498,10 +498,17 @@ async function identifyWineFromText({ name, producer, vintage, country, appellat
   // would make .replace() a silent no-op and the hint would vanish with no
   // error. For the same reason each hint carries its OWN instruction inline
   // instead of relying on a rule in the template.
+  // Bounded before they touch the prompt (audit 2026-08-21 M-1). These come
+  // straight from a client CSV column with no earlier length validation — the
+  // wine-field caps apply at COMMIT, and this call runs at /validate. Unbounded,
+  // a pathological column inflates every identify call's token count (billed to
+  // the user's own AI budget) and widens the prompt-injection surface for no
+  // benefit: no real appellation approaches 200 characters.
+  const hint = (v) => String(v).slice(0, 200);
   const hints = [
-    country ? `Country hint: ${country}` : '',
-    appellation ? `Appellation stated in the user's import file (trust it unless it is clearly not a wine appellation): ${appellation}` : '',
-    region ? `Region stated in the user's import file (trust it unless clearly wrong): ${region}` : '',
+    country ? `Country hint: ${hint(country)}` : '',
+    appellation ? `Appellation stated in the user's import file (trust it unless it is clearly not a wine appellation): ${hint(appellation)}` : '',
+    region ? `Region stated in the user's import file (trust it unless clearly wrong): ${hint(region)}` : '',
   ].filter(Boolean);
   const countryHint = hints.length ? `${hints.join('\n')}\n` : '';
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3414,7 +3414,7 @@
     "newSupportersTooltip": "Users whose supporter tier started in the last 90 days, by the date the tier was granted rather than the date they signed up.",
     "formerSupporters": "Former supporters",
     "formerSupportersSub": "supported, not currently",
-    "formerSupportersTooltip": "Users who have a Stripe customer record but sit on the free plan — they supported at some point and do not now. A floor, not a count: someone comped by hand never reaches Stripe, and someone who resubscribed counts as current.",
+    "formerSupportersTooltip": "Users on the free plan whose supporter tier once started — the start is stamped only when support is actually granted, so an abandoned Stripe checkout does not count. Someone who resubscribed counts as current, not former.",
     "planUnconfigured": "(not a configured tier)",
     "cohortsHead": "Do new users come back?",
     "cohortReturned": "New users returning",


### PR DESCRIPTION
Audit report: `CODE_AUDIT_2026-08-21_v1156-v1164.md`, scoped to today's v1.155→v1.164 diff per the standing rule. All three findings are in code shipped **today**, found the same day — which is the argument for auditing per-diff instead of per-quarter.

## H-1 · `formerSupporters` counted abandoned checkouts as churn — *verified on prod*

Stripe customers are created at **checkout-session time**, before any payment. So `free + stripeCustomerId` included everyone who ever opened the checkout and closed the tab:

```
card said:   7 former supporters
truth:       3 ever paid · 4 abandoned checkouts
```

An overstated churn number points the admin at a retention problem that doesn't exist. Now keyed on `planStartedAt` — stamped only when a tier is actually granted, survives the downgrade. A source-shape test pins the query and forbids the `stripeCustomerId` form from returning.

## M-1 · Untruncated CSV values in the AI prompt

The wine-field caps apply at *commit*; the identify call runs at */validate* — so a pathological CSV column inflated every call's tokens (billed to the user's own budget) and widened the injection surface. Hints now `slice(0, 200)`.

## M-2 · `?blogPost=` + `?q=` silently dropped the scope

The Meili index doesn't carry `blogPost`, so that branch ignored the filter and widened results from "threads about this post" to "all threads matching q".

**My first fix attempt was also wrong** — skipping Meili just traded "wrong scope" for "query silently ignored", because the Mongo path has no text filter. Final shape: with a blogPost scope, `q` applies as an escaped, bounded title regex on the Mongo path. The scoped set is one post's threads, so the regex is trivially cheap — and both parameters are now honoured together.

## Lows — recorded, not fixed

L-1 undo message wording · L-2 `errorReasons` value-embedding (accepted trade-off — it's why the "de" bug was findable) · L-3 the `withStripeCustomer` card caption.

186 tests passing across the touched suites.