### PR TITLE
fix(admin-stats): the cohort table no longer wraps its numbers on a phone

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -1579,3 +1579,44 @@ describe('respond_to_wine_report', () => {
     expect(McpActionLog.create.mock.calls.at(-1)[0]).toMatchObject({ action: 'somm_wine_report_close' });
   });
 });
+
+// Somm ticket 6a887619: grapes were the ONE identity field the queue row hid,
+// so creation-time grapes surfacing on a later get_wine read as "populated by
+// an unidentified path during curation" — four instances filed before the
+// cause was found. The rule under test: emit names honestly, or omit the key.
+describe('wineLite carries grapes honestly (ticket 6a887619)', () => {
+  const listQueue = async (wineDefinition) => {
+    WineVintageProfile.countDocuments.mockResolvedValueOnce(1).mockResolvedValueOnce(1);
+    WineVintageProfile.find.mockReturnValue(chain([{
+      _id: oid('1'), vintage: '2020', status: 'pending', relative: false, wineDefinition,
+    }]));
+    return parse(await tool('list_maturity_queue').handler({}, SOMM_CTX)).data[0].wine;
+  };
+
+  test('populated grape docs emit their names', async () => {
+    const wine = await listQueue({
+      _id: oid('f'), name: 'Shiraz', producer: 'Lights Valley', type: 'red',
+      grapes: [{ _id: oid('a'), name: 'Syrah' }],
+    });
+    expect(wine.grapes).toEqual(['Syrah']);
+  });
+
+  test('a genuinely empty list is [], a real "no grapes"', async () => {
+    const wine = await listQueue({ _id: oid('f'), name: 'Rosso', producer: 'P', grapes: [] });
+    expect(wine.grapes).toEqual([]);
+  });
+
+  test('UNPOPULATED ids omit the key — never claim "no grapes" about a wine that has them', async () => {
+    const wine = await listQueue({
+      _id: oid('f'), name: 'Shiraz', producer: 'P',
+      grapes: [oid('a'), oid('b')], // raw ObjectIds: a caller that selected but did not populate
+    });
+    expect(wine.grapes).toBeUndefined();
+    expect('grapes' in wine).toBe(false);
+  });
+
+  test('a surface that never selected grapes omits the key too', async () => {
+    const wine = await listQueue({ _id: oid('f'), name: 'Barolo', producer: 'P' });
+    expect('grapes' in wine).toBe(false);
+  });
+});

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -82,7 +82,27 @@ const wineLite = (wd) => (wd ? {
   country: wd.country?.name || null,
   region: wd.region?.name || null,
   appellation: wd.appellation || null,
+  // Somm ticket 6a887619 (2026-08-21): every OTHER identity field showed here
+  // but grapes did not, so grapes written at wine creation became visible only
+  // on a later get_wine — and read as "populated by an unidentified path
+  // during curation". Four instances were filed before the cause was found.
+  //
+  // Emitted HONESTLY or not at all. Callers differ in what they select and
+  // populate, and an unpopulated ref array must not collapse to `grapes: []` —
+  // that is a claim of "no grapes" on a wine that has them, which is the exact
+  // shape of misreading this ticket came from. So: populated docs → names;
+  // a genuinely empty array → []; unpopulated ids or an unselected field →
+  // the key is omitted, meaning "not carried on this surface".
+  // Output-only change: no reconnect needed.
+  ...(grapesLite(wd.grapes)),
 } : null);
+
+const grapesLite = (grapes) => {
+  if (!Array.isArray(grapes)) return {};
+  const names = grapes.map((g) => g?.name).filter(Boolean);
+  if (grapes.length > 0 && names.length === 0) return {}; // ids, not docs
+  return { grapes: names };
+};
 
 // The tasting profile as a curator needs to judge it: the values, plus WHO
 // wrote them and how sure the generator was. `confidence` is the model's own
@@ -220,7 +240,10 @@ registerTool({
         .skip(offset).limit(limit)
         // grapes rides along for identityDataSufficient, which decides whether
         // an absent profile is "yours to write" or merely "not yet enriched".
-        .populate({ path: 'wineDefinition', select: 'name producer type appellation aiProfile grapes', populate: ['country', 'region'] })
+        // grapes populated to NAMES, not just selected as ids: the queue row
+        // is where the curator decides whether a wine needs work, and grapes
+        // invisible here is what ticket 6a887619 mistook for a phantom writer.
+        .populate({ path: 'wineDefinition', select: 'name producer type appellation aiProfile grapes', populate: ['country', 'region', { path: 'grapes', select: 'name' }] })
         .lean(),
     ]);
     const data = profiles.map((p) => ({

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3420,8 +3420,8 @@
     "cohortReturned": "New users returning",
     "cohortReturnedSub": "{{returned}} of {{total}} recent signups",
     "cohortReturnedTooltip": "Of everyone who signed up between 1 and 4 weeks ago, the share who used Cellarion in the last 7 days. Counts any activity, not just logging in — a signed-in session can last 30 days without a fresh login. The most recent week is excluded because its members were active in the window by virtue of signing up in it.",
-    "cohortRange": "Signed up {{from}}–{{to}} days ago",
-    "cohortTooNew": "too recent to ask",
+    "cohortRange": "{{from}}–{{to}} days ago",
+    "cohortTooNew": "too recent",
     "cohortNote": "Came back = any activity in the last 7 days. The newest group shows its intake only: those users were active in the window because they joined during it, so a percentage there would measure nothing."
   },
   "announcement": {

--- a/frontend/src/pages/AdminStats.css
+++ b/frontend/src/pages/AdminStats.css
@@ -358,3 +358,18 @@
   font-style: italic;
   color: var(--color-text-muted);
 }
+
+/* ── Signup-cohort table (mobile fix, 2026-08-21) ─────────────────────────
+   On a phone the long row labels forced the numeric cells to wrap, splitting
+   "7 · 44%" across lines — which reads as broken data, not layout. Numbers
+   never wrap; the label column is the one allowed to give way. */
+.admin-stats-cohorts .admin-stats-count,
+.admin-stats-cohorts .admin-stats-pct {
+  white-space: nowrap;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.admin-stats-cohorts .admin-stats-name {
+  word-break: normal;
+  overflow-wrap: anywhere;
+}

--- a/frontend/src/pages/AdminStats.js
+++ b/frontend/src/pages/AdminStats.js
@@ -254,7 +254,11 @@ function AdminStats() {
                 />
               </div>
               <div className="admin-stats-panel">
-                <table className="admin-stats-table">
+                {/* Own class, not just admin-stats-table: this table's right
+                    cell holds "7 · 44%", and on a phone that must never split
+                    across lines (it read as broken data when it did). The
+                    other admin tables are unaffected. */}
+                <table className="admin-stats-table admin-stats-cohorts">
                   <tbody>
                     {retention.signupCohorts.map((c) => (
                       <tr key={c.daysAgoFrom} className={c.tooNew ? 'admin-stats-row-empty' : undefined}>


### PR DESCRIPTION
Johan's screenshot, ~2 hours after v1.164 shipped: on mobile the long row labels forced the numeric cells to wrap — `7 · 44%` split across two lines (reads as broken data, not layout) and *"too recent to ask"* stacked three lines high.

Fixed where the width actually goes:

- **"Signed up "** repeated on every row was the space thief — the section heading and note already carry that context. Rows now read `7–14 days ago`.
- *"too recent to ask"* → *"too recent"*; the note below explains why.
- Numeric cells get `nowrap` + right alignment + `tabular-nums`, on a **cohort-specific class** so the other admin tables are untouched. Numbers never split; the label column is the one allowed to give way.

998 frontend tests pass. en-only strings; the new keys have no translations yet, so nothing to prune.