### PR TITLE
fix(import): the file's wine colour is used, and a spirit is no longer a wine

### DIFF
--- a/backend/src/routes/import.buildProposedWine.test.js
+++ b/backend/src/routes/import.buildProposedWine.test.js
@@ -145,3 +145,28 @@ describe('hygiene', () => {
     });
   });
 });
+
+describe('type: the file states, the model recalls (2026-08-22)', () => {
+  it('prefers the file type over the AI type', () => {
+    expect(buildProposedWine(ai({ type: 'red' }), { type: 'white' }).type).toBe('white');
+  });
+
+  it('falls back to the AI when the file says nothing', () => {
+    // The parsers now emit null for an unknown colour rather than guessing
+    // 'red', so a null here is an honest "the file did not say".
+    expect(buildProposedWine(ai({ type: 'red' }), { type: null }).type).toBe('red');
+    expect(buildProposedWine(ai({ type: 'red' }), {}).type).toBe('red');
+  });
+
+  it('IGNORES a file type the schema would reject, rather than failing the mint', () => {
+    // A client can send anything; an invalid colour must fall through to the
+    // AI, not poison the row or 400 the whole import.
+    for (const bad of ['orange', 'RED', 'vin jaune', '', '  ', 42, {}]) {
+      expect(buildProposedWine(ai({ type: 'red' }), { type: bad }).type).toBe('red');
+    }
+  });
+
+  it('leaves type null when neither the file nor the model states one', () => {
+    expect(buildProposedWine(ai({ type: null }), { type: null }).type).toBeNull();
+  });
+});

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -30,6 +30,7 @@ const {
   AI_CONCURRENCY,
 } = require('../config/constants');
 const { stripHtml, escapeRegex, sanitizeGrapeNames } = require('../utils/sanitize');
+const { WINE_TYPES } = require('../services/wineProfileOps');
 const { parseAndValidateVintage, parseDrinkYear } = require('../utils/validation');
 const { ensurePendingVintageProfile } = require('../utils/vintageProfile');
 const { extractAiExplanation } = require('../utils/jsonExtract');
@@ -142,7 +143,13 @@ function buildProposedWine(aiData, item) {
     // (ticket 6a83f014 added the field to the identify prompt), and the file's
     // own value outranks it for the same reason.
     classification: clean(item && item.classification) || fromAi(aiData.classification),
-    type: aiData.type,
+    // Same precedence as the geography above: the file states what the label
+    // says, the model recalls. Only ever a value the schema accepts — a
+    // client can send anything, and an invalid colour must fall through to
+    // the AI rather than fail the mint. The parsers now emit null for an
+    // unknown colour instead of guessing 'red', so a null here is an honest
+    // "the file did not say", not a lost value.
+    type: (WINE_TYPES.includes(clean(item && item.type)) ? clean(item.type) : null) || aiData.type,
     grapes: aiData.grapes,
     confidence: aiData.confidence,
   };

--- a/frontend/src/utils/importMappers.cellartracker.test.js
+++ b/frontend/src/utils/importMappers.cellartracker.test.js
@@ -278,14 +278,30 @@ describe('CT List table (bundle, 20 wines)', () => {
     expect(pruem[0].wineName).toBe('Wehlener Sonnenuhr Riesling Auslese');
   });
 
-  it('maps NV Lagavulin (Spirits, 700ml) without corrupting it', () => {
+  it('maps NV Lagavulin (Spirits, 700ml) without corrupting it, and without calling it wine', () => {
     const lag = result.items.find((i) => i.producer === 'Lagavulin');
     expect(lag).toMatchObject({
       wineName: '16 Year Old',
       vintage: 'NV',        // vintage 1001
       bottleSize: '700ml',
-      type: 'fortified',    // closest Cellarion bucket for Spirits
+      type: null,
+      nonWineHint: true,    // CT Category "Distilled" / Type "Spirits"
     });
+  });
+
+  // This assertion USED to read type: 'fortified', commented "closest
+  // Cellarion bucket for Spirits" — a reasonable call at the time, because the
+  // parsed type was dropped at the payload boundary and reached nothing.
+  //
+  // Forwarding type (2026-08-22) changed the calculus: WineDefinition is
+  // SHARED, so one user's whisky filed as a fortified wine becomes everyone's
+  // fortified wine — the same shape as writing a Provence AOC onto a New
+  // Zealand Pinot. The bottle still imports; it just arrives without a claimed
+  // colour and flagged, which is what nonWine quarantine exists for.
+  it('still imports the spirit as a bottle — flagged, not dropped', () => {
+    const lag = result.items.find((i) => i.producer === 'Lagavulin');
+    expect(lag).toBeDefined();
+    expect(lag.wineName).toBe('16 Year Old');
   });
 
   it('survives a comma inside the quoted Designation field (Vega Sicilia)', () => {

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -471,16 +471,38 @@ function mapRackFields(get) {
 // Vivino's "Average rating" is the community score and is never imported —
 // same policy as CellarTracker's `CT` column. Only "Your rating" is.
 
+// Values that mean "not a wine at all" — CellarTracker tracks spirits
+// alongside wine (Category "Distilled", Type "Spirits"). They must never be
+// coerced into a wine colour: a whisky called `fortified` is a claim, and a
+// whisky called `red` is a worse one.
+const NON_WINE_HINTS = ['spirit', 'whisky', 'whiskey', 'distilled', 'liqueur', 'gin', 'rum', 'vodka', 'brandy', 'cognac', 'armagnac'];
+export function looksNonWine(...values) {
+  const t = values.filter(Boolean).join(' ').toLowerCase();
+  return NON_WINE_HINTS.some((h) => t.includes(h));
+}
+
+// Returns a wine colour, or NULL when the input does not state one.
+//
+// ⚠️ It used to return 'red' for both an empty value and an unrecognised one —
+// the 15th instance of the colour-guessing class fixed across the app in
+// v1.140 (prompts made nullable, 14 client `|| 'red'` fallbacks removed). It
+// was harmless only because the parsed type was dropped at the payload
+// boundary and never reached a wine; now that type IS forwarded, a guess here
+// would become a stored fact. Unknown is null, and the AI or a curator fills
+// it honestly.
 function mapWineType(typeStr) {
-  if (!typeStr) return 'red';
+  if (!typeStr) return null;
   const t = typeStr.toLowerCase().trim();
-  if (t.includes('red')) return 'red';
-  if (t.includes('white')) return 'white';
+  if (looksNonWine(t)) return null;
   if (t.includes('rosé') || t.includes('rose')) return 'rosé';
   if (t.includes('sparkling') || t.includes('champagne') || t.includes('cava') || t.includes('prosecco')) return 'sparkling';
   if (t.includes('dessert') || t.includes('sweet') || t.includes('ice wine')) return 'dessert';
   if (t.includes('fortified') || t.includes('port') || t.includes('sherry') || t.includes('madeira')) return 'fortified';
-  return 'red';
+  // Colour last: "White - Sweet/Dessert" and "White - Sparkling" are CT Type
+  // strings whose STYLE is the useful half, so the style tests run first.
+  if (t.includes('white')) return 'white';
+  if (t.includes('red')) return 'red';
+  return null;
 }
 
 /**
@@ -643,16 +665,27 @@ function parseCtLocale(locale) {
  * the style suffix must win over the base colour, so check fortified/
  * sparkling/dessert BEFORE red/white.
  */
-function mapCellarTrackerType(typeStr) {
+// CellarTracker's `Type` mixes colour and style ("White - Sweet/Dessert"), and
+// its `Color`/`Category` columns state them separately. All three are read:
+// Type first because it is the richest, then Color as the plain colour, with
+// Category available to the caller for the style.
+//
+// ⚠️ `spirits` and `whisky` used to map to 'fortified'. They are not fortified
+// WINE — a CT cellar routinely holds whisky, and calling it a fortified wine
+// put a spirit into the wine registry wearing a wine type. They now return
+// null, and looksNonWine() lets the caller flag the row instead.
+function mapCellarTrackerType(typeStr, colorStr) {
   const t = (typeStr || '').toLowerCase();
-  if (t.includes('fortified') || t.includes('port') || t.includes('sherry') ||
-      t.includes('madeira') || t.includes('spirits') || t.includes('whisky')) return 'fortified';
+  if (looksNonWine(t)) return null;
+  if (t.includes('fortified') || t.includes('port') || t.includes('sherry') || t.includes('madeira')) return 'fortified';
   if (t.includes('sparkling') || t.includes('champagne')) return 'sparkling';
   if (t.includes('sweet') || t.includes('dessert') || t.includes('ice wine')) return 'dessert';
   if (t.includes('rosé') || t.includes('rose')) return 'rosé';
   if (t.includes('white')) return 'white';
   if (t.includes('red')) return 'red';
-  return mapWineType(typeStr);
+  // Type said nothing usable — fall back to the dedicated Color column, which
+  // carries a clean Red/White/Rosé/Other, then to the generic mapper.
+  return mapWineType(typeStr) || mapWineType(colorStr);
 }
 
 /**
@@ -779,7 +812,9 @@ function ctCommonFields(get, { sizeKeys = ['Size'] } = {}) {
     country: get(['Country']) || locale.country,
     region: get(['Region']) || locale.region,
     appellation: ctClean(get(['Appellation'])) || locale.appellation,
-    type: mapCellarTrackerType(get(['Type'])),
+    type: mapCellarTrackerType(get(['Type']), get(['Color', 'Colour'])),
+    // CT tracks spirits beside wine; the caller flags rather than guesses.
+    nonWineHint: looksNonWine(get(['Type']), get(['Category'])) || undefined,
     bottleSize: normalizeBottleSize(get(sizeKeys)) || '750ml',
     ...ctPlacementFields(get),
     rating,
@@ -943,7 +978,8 @@ function mapCellarTrackerRow(row) {
     country: get(['Country', 'country']) || locale.country,
     region: get(['Region', 'region', 'Sub-Region']) || locale.region,
     appellation: ctClean(get(['Appellation', 'appellation', 'SubRegion'])) || locale.appellation,
-    type: mapCellarTrackerType(get(['Type', 'type', 'Color', 'Colour', 'Category'])),
+    type: mapCellarTrackerType(get(['Type', 'type']), get(['Color', 'Colour', 'Category', 'category'])),
+    nonWineHint: looksNonWine(get(['Type', 'type']), get(['Category', 'category'])) || undefined,
     price: isNaN(price) ? undefined : price,
     currency: get(['Currency', 'currency']) || undefined,
     bottleSize: normalizeBottleSize(get(['Size', 'size', 'Bottle Size', 'BottleSize'])) || '750ml',

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -914,3 +914,33 @@ describe('parseOenoExport', () => {
     expect(result.oenoRackSpecs).toBeDefined();
   });
 });
+
+describe('wine colour is stated, never guessed', () => {
+  // The parsed type used to default to 'red' for BOTH an empty value and an
+  // unrecognised one — the 15th instance of the colour-guessing class fixed
+  // across the app in v1.140. Harmless only while the value was dropped at the
+  // payload boundary; now that it is forwarded, a guess becomes a stored fact.
+  test('an unknown or empty colour is null, not red', () => {
+    expect(parseAndMap('Wine Name,Producer,Type\nX,Y,\n').items[0].type).toBeNull();
+    expect(parseAndMap('Wine Name,Producer,Type\nX,Y,Perpetual Motion\n').items[0].type).toBeNull();
+  });
+
+  test('a stated colour still maps', () => {
+    expect(parseAndMap('Wine Name,Producer,Type\nX,Y,Red\n').items[0].type).toBe('red');
+    expect(parseAndMap('Wine Name,Producer,Type\nX,Y,Rosé\n').items[0].type).toBe('rosé');
+  });
+
+  test('a spirit is NOT a fortified wine, and not a red one either', () => {
+    // CellarTracker tracks whisky beside wine; "Spirits" used to map to
+    // 'fortified', putting a spirit in the registry wearing a wine type.
+    for (const v of ['Spirits', 'Distilled', 'Whisky', 'Gin']) {
+      expect(parseAndMap(`Wine Name,Producer,Type\nX,Y,${v}\n`).items[0].type).toBeNull();
+    }
+  });
+
+  test('style beats colour inside a CellarTracker Type string', () => {
+    // "White - Sparkling" is sparkling; reading the colour first would lose it.
+    expect(parseAndMap('Wine,Producer,Type,Vintage,Locale\nX,Y,White - Sparkling,2020,France\n').items[0].type).toBe('sparkling');
+    expect(parseAndMap('Wine,Producer,Type,Vintage,Locale\nX,Y,White - Sweet/Dessert,2020,France\n').items[0].type).toBe('dessert');
+  });
+});

--- a/frontend/src/utils/importPayload.js
+++ b/frontend/src/utils/importPayload.js
@@ -38,6 +38,16 @@ export function buildImportItem(r, selection) {
     region: r.item.region,
     appellation: r.item.appellation,
     classification: r.item.classification,
+    // `type` was the same disappearance as the geography above, one field over:
+    // every parser computed a wine colour and nothing ever forwarded it, so a
+    // stored type came only from the AI. Forwarded now — and the mappers were
+    // changed to return null rather than guessing 'red', because a value that
+    // goes nowhere can be wrong for free while a stored one cannot.
+    type: r.item.type,
+    // CellarTracker tracks spirits beside wine (Category "Distilled", Type
+    // "Spirits"). Passed through so the row can be flagged rather than
+    // silently filed as a fortified wine, which is what used to happen.
+    nonWineHint: r.item.nonWineHint,
     drinkFrom: r.item.drinkFrom ?? undefined,
     drinkTo: r.item.drinkTo ?? undefined,
     dateAdded: r.item.dateAdded || r.item.purchaseDate,

--- a/frontend/src/utils/importPayload.test.js
+++ b/frontend/src/utils/importPayload.test.js
@@ -147,3 +147,18 @@ describe('buildImportItem', () => {
     expect(typeof fridgePayload.col).toBe('number');
   });
 });
+
+describe('type and the non-wine hint reach the payload', () => {
+  // `type` was computed by every parser and forwarded by nothing — the same
+  // disappearance as the geography, one field over. A stored wine colour came
+  // only from the AI.
+  test('forwards the file type', () => {
+    const out = buildImportItem({ item: { wineName: 'X', producer: 'Y', type: 'white' } }, 'create');
+    expect(out.type).toBe('white');
+  });
+
+  test('forwards the non-wine hint so a spirit can be flagged, not filed as wine', () => {
+    const out = buildImportItem({ item: { wineName: 'Lagavulin 16', producer: 'Lagavulin', nonWineHint: true } }, 'create');
+    expect(out.nonWineHint).toBe(true);
+  });
+});


### PR DESCRIPTION
Started as *"map CellarTracker's Category and Color columns"* and found the same bug as yesterday's geography fix, one field over.

## `type` was computed by every parser and forwarded by nothing

`buildImportItem` never carried it; the backend never read `item.type`. A stored wine colour came **only from the AI**. Now forwarded, with the same precedence — the file states what the label says, the model recalls — and an invalid client value falls through to the AI rather than poisoning the row.

**That forwarding is what makes the next two matter.** Both were harmless while the value went nowhere; both become stored facts now.

## `mapWineType` guessed `'red'`

For an empty value *and* an unrecognised one — the **15th** instance of the colour-guessing class fixed in v1.140 (prompts nullable, 14 client `|| 'red'` fallbacks removed). Unknown is now `null`. Colour tests also moved *after* style tests, so CT's `"White - Sparkling"` stays sparkling.

## A whisky was a fortified wine

`mapCellarTrackerType` mapped `spirits`/`whisky` → `'fortified'`. Lagavulin 16 is in our own fixture, and **the existing test asserted this deliberately** — *"closest Cellarion bucket for Spirits"*.

That was a reasonable call when the value reached nothing. It isn't now: `WineDefinition` is **shared**, so one user's whisky filed as fortified becomes everyone's fortified wine — the same shape as writing a Provence AOC onto a New Zealand Pinot.

Spirits now yield `type: null` plus a `nonWineHint` the row carries. **The bottle still imports** — flagged, not mislabelled. Port, sherry and madeira stay fortified, because they are.

## Deliberately not done

**Classification from the file.** CellarTracker has no such column — `Designation` holds `"Unknown"` and cuvée text — so a mapping would be inert, which is exactly the mistake this branch began by checking for. The tier *is* inside the appellation string (`"La Tâche Grand Cru"`) and `normalizeAppellation` strips it, but capturing that needs a keep-list (Grand Cru yes; `DO`/`AOC` noise) and is worth less than these two.

## ⚠️ Verification gap

**Backend tests were not run locally** — Docker's engine is 500ing on this machine and the Linux-built `node_modules` can't run jest on the Windows host. Frontend is green (1005 tests, including new mapper and payload cases). **CI is the gate for the backend change.**