### PR TITLE
perf(bottles): the server answers "which rack is this bottle in"

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -552,8 +552,41 @@ router.get('/:id', requireBottleAccess('viewer'), async (req, res) => {
       currentRelease = await getCurrentRelease(wineId, bottle.currency);
     }
 
+    // Where this bottle sits, answered HERE rather than by the client
+    // (2026-08-22, from the rate-limit analysis). BottleDetail used to
+    // download EVERY rack with all slots plus the full 3D layout — two
+    // requests and the two heaviest payloads on the page — and scan them in
+    // the browser for one bottle id. `slots.bottle` carries a unique multikey
+    // index, so the server answers with one indexed findOne and a few dozen
+    // bytes. That per-open cost is what let an ordinary editing session hit
+    // the API rate limit.
+    let rackInfo = null;
+    if (bottle.status === 'active') {
+      // Own try/catch: placement is auxiliary, and its lookup failing must
+      // degrade to "no rack shown", never 500 the bottle page.
+      try {
+        const Rack = require('../models/Rack');
+        const rack = await Rack.findOne({
+          cellar: cellar._id, 'slots.bottle': bottle._id, deletedAt: null,
+        }).select('name slots').lean();
+        if (rack) {
+          const slot = rack.slots.find((s) => s.bottle && s.bottle.toString() === bottle._id.toString());
+          // inRoom drives the "show me in the 3D room" affordance; one more
+          // narrow query, and only when the bottle is actually racked.
+          const CellarLayout = require('../models/CellarLayout');
+          const layout = await CellarLayout.findOne({ cellar: cellar._id }).select('rackPlacements.rack').lean();
+          const inRoom = !!layout?.rackPlacements?.some(
+            (rp) => (rp.rack?._id || rp.rack)?.toString() === rack._id.toString()
+          );
+          rackInfo = { rackId: rack._id, rackName: rack.name, position: slot ? slot.position : null, inRoom };
+        }
+      } catch (err) {
+        console.error('Bottle rackInfo lookup failed:', err.message);
+      }
+    }
+
     const ucEntry = cellar.userColors?.find(uc => uc.user.toString() === req.user.id.toString());
-    res.json({ bottle: bottleObj, userRole: role, cellarColor: ucEntry?.color || null, pendingImageUrl, defaultImageUrl, currentRelease });
+    res.json({ bottle: bottleObj, userRole: role, cellarColor: ucEntry?.color || null, pendingImageUrl, defaultImageUrl, currentRelease, rackInfo });
   } catch (error) {
     console.error('Get bottle error:', error);
     res.status(500).json({ error: 'Failed to get bottle' });

--- a/backend/src/routes/bottles.rackInfo.test.js
+++ b/backend/src/routes/bottles.rackInfo.test.js
@@ -1,0 +1,146 @@
+/**
+ * GET /api/bottles/:id answers "which rack is this bottle in" itself
+ * (2026-08-22, from the rate-limit analysis).
+ *
+ * The client used to download EVERY rack with all slots plus the full 3D
+ * layout — the two heaviest requests on the bottle page — and scan them in the
+ * browser for one bottle id. `slots.bottle` carries a unique multikey index,
+ * so the server answers with one indexed findOne. That per-open cost is what
+ * let an ordinary editing session (35 edits in 8 minutes) hit the API rate
+ * limit and abandon a 55-minute hole in their evening.
+ */
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+jest.mock('../services/search', () => ({
+  indexBottle: jest.fn(), removeBottle: jest.fn(), indexWine: jest.fn(),
+  bulkIndexBottles: jest.fn(), getIsAvailable: jest.fn(() => false),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined), reembedActiveVintages: jest.fn() }));
+jest.mock('../services/enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/restockChecker', () => ({ checkRestockAlerts: jest.fn(), checkOnConsume: jest.fn() }));
+jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../services/priceWarnings', () => ({ gatherPriceWarnings: jest.fn().mockResolvedValue([]) }));
+jest.mock('../services/communityPrice', () => ({ getCurrentRelease: jest.fn().mockResolvedValue(null) }));
+jest.mock('../services/wineVisibility', () => ({ findVisibleWine: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({ getSnapshotForDate: jest.fn().mockResolvedValue(null) }));
+jest.mock('../utils/vintageProfile', () => ({ ensurePendingVintageProfile: jest.fn() }));
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => ({ findOne: jest.fn(), updateMany: jest.fn() }));
+jest.mock('../models/CellarLayout', () => ({ findOne: jest.fn() }));
+jest.mock('../models/Country', () => ({}));
+jest.mock('../models/Region', () => ({}));
+jest.mock('../models/Grape', () => ({}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('../models/PriceTrackingRequest', () => ({}));
+jest.mock('../models/PriceTrackingSkip', () => ({}));
+jest.mock('../models/BottleImage', () => ({ findOne: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/WineRequest', () => ({}));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+
+const Bottle = require('../models/Bottle');
+const Cellar = require('../models/Cellar');
+const Rack = require('../models/Rack');
+const CellarLayout = require('../models/CellarLayout');
+const BottleImage = require('../models/BottleImage');
+
+const USER = '64b000000000000000000001';
+const CELLAR = '64b0000000000000000000cc';
+const BOTTLE = '64b0000000000000000000bb';
+const RACK = '64b0000000000000000000dd';
+
+const selectLean = (doc) => ({ select: () => ({ lean: async () => doc }) });
+const sortLean = (doc) => ({ sort: () => ({ lean: async () => doc }) });
+
+function mkBottle(over = {}) {
+  return {
+    _id: BOTTLE, user: USER, cellar: CELLAR, status: 'active',
+    wineDefinition: null, priceSetAt: null, defaultImage: null,
+    populate: jest.fn().mockResolvedValue(undefined),
+    toObject: () => ({ _id: BOTTLE, status: over.status || 'active' }),
+    ...over,
+  };
+}
+
+function app() {
+  const a = express();
+  a.use(express.json());
+  a.use('/api/bottles', require('./bottles'));
+  return a;
+}
+
+function getJson(a, path) {
+  const token = jwt.sign({ id: USER, roles: ['user'] }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(a);
+    server.listen(0, () => {
+      http.get({ port: server.address().port, path, headers: { authorization: `Bearer ${token}` } }, (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => { server.close(); resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) }); });
+      }).on('error', (e) => { server.close(); reject(e); });
+    });
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Cellar.findById.mockResolvedValue({
+    _id: CELLAR, user: USER, deletedAt: null, members: [], userColors: [],
+  });
+  BottleImage.findOne.mockReturnValue(sortLean(null));
+  BottleImage.findById.mockReturnValue({ lean: async () => null });
+});
+
+describe('GET /api/bottles/:id rackInfo', () => {
+  test('a racked bottle answers with its rack, slot and inRoom — one indexed query, not a client scan', async () => {
+    Bottle.findById.mockResolvedValue(mkBottle());
+    Rack.findOne.mockReturnValue(selectLean({
+      _id: RACK, name: 'Wine Fridge',
+      slots: [{ bottle: 'other', position: 1 }, { bottle: BOTTLE, position: 7 }],
+    }));
+    CellarLayout.findOne.mockReturnValue(selectLean({ rackPlacements: [{ rack: RACK }] }));
+
+    const { status, body } = await getJson(app(), `/api/bottles/${BOTTLE}`);
+    expect(status).toBe(200);
+    expect(body.rackInfo).toEqual({ rackId: RACK, rackName: 'Wine Fridge', position: 7, inRoom: true });
+    // The query the index serves — and soft-deleted racks excluded.
+    expect(Rack.findOne).toHaveBeenCalledWith({ cellar: CELLAR, 'slots.bottle': BOTTLE, deletedAt: null });
+  });
+
+  test('an unracked bottle answers rackInfo null', async () => {
+    Bottle.findById.mockResolvedValue(mkBottle());
+    Rack.findOne.mockReturnValue(selectLean(null));
+    const { body } = await getJson(app(), `/api/bottles/${BOTTLE}`);
+    expect(body.rackInfo).toBeNull();
+    expect(CellarLayout.findOne).not.toHaveBeenCalled(); // no layout query when unracked
+  });
+
+  test('a rack outside the 3D room answers inRoom false', async () => {
+    Bottle.findById.mockResolvedValue(mkBottle());
+    Rack.findOne.mockReturnValue(selectLean({ _id: RACK, name: 'Cellar Wall', slots: [{ bottle: BOTTLE, position: 2 }] }));
+    CellarLayout.findOne.mockReturnValue(selectLean(null));
+    const { body } = await getJson(app(), `/api/bottles/${BOTTLE}`);
+    expect(body.rackInfo).toMatchObject({ inRoom: false });
+  });
+
+  test('a CONSUMED bottle skips the lookup entirely', async () => {
+    Bottle.findById.mockResolvedValue(mkBottle({ status: 'drank', toObject: () => ({ _id: BOTTLE, status: 'drank' }) }));
+    const { body } = await getJson(app(), `/api/bottles/${BOTTLE}`);
+    expect(body.rackInfo).toBeNull();
+    expect(Rack.findOne).not.toHaveBeenCalled();
+  });
+
+  test('a failing rack lookup degrades to null — placement is auxiliary and must never 500 the page', async () => {
+    Bottle.findById.mockResolvedValue(mkBottle());
+    Rack.findOne.mockImplementation(() => { throw new Error('index rebuild in progress'); });
+    const { status, body } = await getJson(app(), `/api/bottles/${BOTTLE}`);
+    expect(status).toBe(200);
+    expect(body.rackInfo).toBeNull();
+  });
+});

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -9,8 +9,6 @@ import { getBottle, consumeBottle, setBottleDefaultImage, undoBottle, openBottle
 import { isReserved, reservationSummary } from '../utils/reservation';
 import OpenBottlePanel from '../components/bottle/OpenBottlePanel';
 import { PRESERVATION_METHODS } from '../utils/openBottle';
-import { getRacks } from '../api/racks';
-import { getCellarLayout } from '../api/cellarLayout';
 import { fetchRates } from '../utils/currency';
 import SITE_URL from '../config/siteUrl';
 import { API_URL } from '../api/apiConstants';
@@ -104,8 +102,13 @@ function BottleDetail() {
         setUserRole(data.userRole);
         setCellarColor(data.cellarColor || null);
         setCurrentRelease(data.currentRelease || null);
-        // Only fetch rack info for active bottles
-        if (data.bottle.status === 'active') fetchRackInfo();
+        // The bottle's rack placement now arrives ON the bottle response
+        // (2026-08-22). The old fetchRackInfo downloaded every rack with all
+        // slots plus the full 3D layout — the two heaviest requests on this
+        // page — to find one bottle id in the browser; the server answers the
+        // same question with one indexed query. That per-open cost is what
+        // let an ordinary editing session hit the API rate limit.
+        setRackInfo(data.rackInfo || null);
         if (data.pendingImageUrl) {
           const url = data.pendingImageUrl.startsWith('http')
             ? data.pendingImageUrl
@@ -206,33 +209,6 @@ function BottleDetail() {
     } catch {
       setPriceHistory([]);
     }
-  };
-
-  const fetchRackInfo = async () => {
-    try {
-      const [racksRes, layoutRes] = await Promise.all([
-        getRacks(apiFetch, cellarId),
-        getCellarLayout(apiFetch, cellarId),
-      ]);
-      const racksData = await racksRes.json();
-      const layoutData = await layoutRes.json();
-      if (racksRes.ok) {
-        for (const rack of racksData.racks) {
-          for (const slot of rack.slots) {
-            const bid = slot.bottle?._id || slot.bottle;
-            if (bid && bid.toString() === bottleId) {
-              // Check if this rack is placed in the 3D room layout
-              const placements = layoutData.layout?.rackPlacements || [];
-              const inRoom = placements.some(
-                rp => (rp.rack?._id || rp.rack) === rack._id
-              );
-              setRackInfo({ rackId: rack._id, rackName: rack.name, position: slot.position, inRoom });
-              return;
-            }
-          }
-        }
-      }
-    } catch {}
   };
 
   const handleBottleUpdated = (updated) => {


### PR DESCRIPTION
From the rate-limit analysis: a real user editing bottles one at a time hit the `api` limiter at 4.4 edits/min and left a **55-minute hole** in their session. Each bottle open cost ~12 requests — and the two heaviest were these.

## The bug-shaped design

`BottleDetail` downloaded **every rack with all slots, plus the full 3D layout**, then scanned them in the browser for one bottle id — a full-cellar download to derive one line of text (*"Wine Fridge, slot 7"*).

`slots.bottle` already carries a unique multikey index, so `GET /api/bottles/:id` now answers the question itself: **one indexed `findOne`**, plus one narrow layout read only when the bottle is actually racked, returned as `rackInfo` on the existing response. The client reads the field; `fetchRackInfo` and its two imports are deleted.

**Per bottle open: 2 fewer requests, and the two largest payloads replaced by a few dozen bytes.** This is also the load story — the server stops serializing every rack in the cellar each time anyone looks at one bottle.

## Degradation is deliberate

The lookup wraps its own try/catch and degrades to `rackInfo: null` — placement is auxiliary and must never 500 the bottle page. Consumed bottles skip the lookup entirely; unracked bottles skip the layout query. All pinned by tests, including the failure path.

## ⚠️ Verification

Frontend: 1005 tests green locally. **Backend suite not run locally** — Docker's engine is 500ing on this machine (same as #1100). The new `bottles.rackInfo.test.js` covers racked/unracked/consumed/failure/inRoom; **CI is the gate.**