### PR TITLE
fix(enrichment): no variety is defined by LOW tannin

### DIFF
--- a/backend/src/data/grapeStyleTypicals.js
+++ b/backend/src/data/grapeStyleTypicals.js
@@ -16,6 +16,34 @@
  * in ANY normal expression of the variety, late-harvest/appassimento oddities
  * aside — that asymmetry is what keeps false positives ~zero.
  *
+ * ---------------------------------------------------------------------------
+ * NO 'low' TANNIN ENTRIES. EVER. (somm ticket 6a896b7e, 2026-08-22)
+ *
+ * The table shipped with `pinot noir: { tannin: 'low' }` and it was wrong on
+ * both records it ever fired on — two correct Pommards, flagged for having
+ * the firm tannin Pommard is *known* for. 588 single-variety Pinot Noir rows
+ * were exposed to it, including Nuits-Saint-Georges, Gevrey-Chambertin and
+ * Central Otago, all appellations where grip is typical rather than anomalous.
+ *
+ * The reason is structural, not a matter of picking better varieties:
+ *
+ *   ACIDITY is set by the grape. A variety that ripens with low malic acid
+ *   cannot be made high-acid, so "defined by low acidity" is a real claim.
+ *
+ *   HIGH TANNIN is set by the grape too — thick skins and high polyphenols
+ *   put a FLOOR under it, so a low-tannin Nebbiolo really is a defect.
+ *
+ *   LOW TANNIN is set by the WINEMAKER. Extraction time, whole-cluster,
+ *   new oak and press fraction can all carry a thin-skinned variety well
+ *   past "low", and entire appellations are famous for exactly that. It is
+ *   a ceiling nobody enforces, so it cannot be asserted as definitional.
+ *
+ * So: `tannin: 'high'` entries are legitimate; `tannin: 'low'` entries are
+ * not, whatever the variety. Gamay went out with Pinot Noir under the same
+ * rule — cru Beaujolais (Moulin-à-Vent, Morgon) is structured on purpose and
+ * would have been the next false positive. An invariant test enforces this.
+ * ---------------------------------------------------------------------------
+ *
  * Keys are normalizeString-folded grape names (lowercase, accents folded).
  */
 const GRAPE_STYLE_TYPICALS = {
@@ -30,9 +58,8 @@ const GRAPE_STYLE_TYPICALS = {
   gewurztraminer:    { acidity: 'low' },
   viognier:          { acidity: 'low' },
   marsanne:          { acidity: 'low' },
-  // Tannin-defined reds
-  'pinot noir':      { tannin: 'low' },
-  gamay:             { tannin: 'low' },
+  // Tannin-defined reds. HIGH only — see the note above on why 'low' tannin
+  // is a winemaking outcome rather than a varietal definition.
   nebbiolo:          { tannin: 'high' },
   tannat:            { tannin: 'high' },
   sagrantino:        { tannin: 'high' },

--- a/backend/src/data/grapeStyleTypicals.test.js
+++ b/backend/src/data/grapeStyleTypicals.test.js
@@ -32,8 +32,57 @@ test('a blend fires only when EVERY grape asserts the opposite extreme', () => {
   expect(check(['Gewürztraminer', 'Viognier'], { acidity: 'high' })).toMatch(/defined by low acidity/);
 });
 
-test('tannin axis works the same way — a high-tannin Pinot Noir fires', () => {
-  expect(check(['Pinot Noir'], { tannin: 'high' })).toMatch(/pinot noir is defined by low tannin/);
+test('tannin axis works the same way — a low-tannin Nebbiolo fires', () => {
+  expect(check(['Nebbiolo'], { tannin: 'low' })).toMatch(/nebbiolo is defined by high tannin/);
+});
+
+// ---------------------------------------------------------------------------
+// The false positive, and the invariant that stops it coming back.
+// Until 2026-08-22 the assertion directly above this block read
+//   check(['Pinot Noir'], { tannin: 'high' })  →  fires
+// which is to say the suite asserted the bug as correct behaviour and then
+// protected it. It fired twice in production, on two correct Pommards.
+// ---------------------------------------------------------------------------
+describe('no variety is defined by LOW tannin (somm ticket 6a896b7e)', () => {
+  test('a high-tannin Pinot Noir is silent — that is Pommard, not an error', () => {
+    expect(check(['Pinot Noir'], { tannin: 'high' })).toBeNull();
+  });
+
+  test('the appellations that actually own this: firm Pinot is normal', () => {
+    // Nuits-Saint-Georges, Gevrey-Chambertin, Corton and Central Otago all
+    // hold single-variety Pinot in this registry; every one of them is
+    // legitimately capable of high tannin.
+    for (const profile of [{ tannin: 'high' }, { tannin: 'medium' }, { tannin: 'low' }]) {
+      expect(check(['Pinot Noir'], profile)).toBeNull();
+    }
+  });
+
+  test('Gamay too — cru Beaujolais is structured on purpose', () => {
+    expect(check(['Gamay'], { tannin: 'high' })).toBeNull();
+  });
+
+  test('INVARIANT: the table may never assert tannin: low for any variety', () => {
+    // Acidity is grape chemistry and high tannin has a skin-chemistry floor,
+    // so both are assertable. Low tannin is a ceiling the winemaker sets —
+    // extraction, whole-cluster and oak carry thin-skinned varieties past it
+    // routinely. An entry here would flag correct data, as Pinot Noir did.
+    const offenders = Object.entries(GRAPE_STYLE_TYPICALS)
+      .filter(([, spec]) => spec.tannin === 'low')
+      .map(([grape]) => grape);
+    expect(offenders).toEqual([]);
+  });
+
+  test('high-tannin entries are still asserted — the rule keeps its teeth', () => {
+    const highTannin = Object.entries(GRAPE_STYLE_TYPICALS)
+      .filter(([, spec]) => spec.tannin === 'high')
+      .map(([grape]) => grape);
+    expect(highTannin).toEqual(expect.arrayContaining(['nebbiolo', 'tannat', 'sagrantino']));
+  });
+
+  test('the acidity axis is untouched by all of this', () => {
+    expect(check(['Bacchus'], { acidity: 'high' })).toMatch(/defined by low acidity/);
+    expect(check(['Riesling'], { acidity: 'low' })).toMatch(/defined by high acidity/);
+  });
 });
 
 test('accent folding matches the table key', () => {

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -870,7 +870,9 @@ describe('the split flags end-to-end through enrichWine', () => {
     await enrichWineById(WINE_ID);
     const p = persisted();
     expect(p.heldAt).toBeNull();
-    expect(p.producerNote).not.toMatch(/Style conflict/);
+    // Coalesced: the note is null here, and toMatch throws on null rather
+    // than passing, so a bare .not.toMatch would fail for the wrong reason.
+    expect(p.producerNote ?? '').not.toMatch(/Style conflict/);
   });
 
   test('a missing producerUnknown on an old/custom prompt degrades to "no doubt", never to a hold', async () => {

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -154,9 +154,11 @@ describe('descriptor sanitization at the write point', () => {
   });
 
   test('valid values case-fold onto the enum', async () => {
-    // A grapeless wine for this one: high tannin on the default Pinot Noir
-    // fixture now trips the 6a8464ea taxonomy_conflict hold (by design), and
-    // this test is about case-folding, not the cross-check.
+    // A grapeless wine for this one, so the case-folding assertion cannot be
+    // perturbed by the 6a8464ea taxonomy cross-check whatever the table holds.
+    // (It was originally grapeless because high tannin on the default Pinot
+    // Noir fixture tripped the conflict hold — that entry was the ticket
+    // 6a896b7e false positive and is gone; the isolation is still worth it.)
     WineDefinition.findById.mockReturnValue(chain({
       _id: WINE_ID, name: 'Red Blend', producer: 'Matua', type: 'red',
       country: { name: 'New Zealand' }, region: { name: 'Marlborough' }, grapes: [],

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -828,22 +828,49 @@ describe('the split flags end-to-end through enrichWine', () => {
     expect(p.producerUnknown).toBe(true); // the doubt stays recorded on the row
   });
 
-  // 6a8464ea phase 2: the fixture wine is a Pinot Noir — a grape DEFINED by
-  // low tannin. The regional-prior hallucination carries no flag and high
-  // confidence, so only the factual cross-check can catch it.
+  // 6a8464ea phase 2. These used the default Pinot Noir fixture with high
+  // tannin, which stopped being a conflict when the pinot-noir entry came out
+  // of the table (somm ticket 6a896b7e — Pommard is legitimately tannic).
+  // Nebbiolo carries the surviving direction: thick skins put a FLOOR under
+  // tannin, so a low-tannin Nebbiolo is the regional-prior hallucination the
+  // cross-check exists for. No flag, high confidence — only a factual check
+  // can catch it.
+  const nebbioloWine = () => WineDefinition.findById.mockReturnValue(chain({
+    _id: WINE_ID, name: 'Barolo', producer: 'Cà di Bruno', type: 'red',
+    country: { name: 'Italy' }, region: { name: 'Piedmont' }, grapes: [{ name: 'Nebbiolo' }],
+  }));
+
   test('a profile at the OPPOSITE structural extreme of the grape is HELD as taxonomy_conflict', async () => {
-    suggestProfile.mockResolvedValue(withFlags({ tannin: 'high', confidence: 0.8 }));
+    nebbioloWine();
+    suggestProfile.mockResolvedValue(withFlags({ tannin: 'low', confidence: 0.8 }));
     await enrichWineById(WINE_ID);
     const p = persisted();
     expect(p.heldAt).toBeInstanceOf(Date);
     expect(p.heldReason).toBe('taxonomy_conflict');
-    expect(p.producerNote).toMatch(/pinot noir is defined by low tannin/);
+    expect(p.producerNote).toMatch(/nebbiolo is defined by high tannin/);
   });
 
   test('the agreeing extreme and medium never conflict — the check is one-sided', async () => {
-    suggestProfile.mockResolvedValue(withFlags({ tannin: 'low', confidence: 0.8 }));
+    nebbioloWine();
+    for (const tannin of ['high', 'medium']) {
+      jest.clearAllMocks();
+      nebbioloWine();
+      WineDefinition.updateOne.mockResolvedValue({});
+      suggestProfile.mockResolvedValue(withFlags({ tannin, confidence: 0.8 }));
+      await enrichWineById(WINE_ID);
+      expect(persisted().heldAt).toBeNull();
+    }
+  });
+
+  test('a firm Pommard no longer conflicts — the variety is not in the table at all', async () => {
+    // The regression the somm reported: the default fixture IS a Pinot Noir,
+    // and high tannin on it used to hold the row and stamp an owner-visible
+    // note saying the correct value was wrong.
+    suggestProfile.mockResolvedValue(withFlags({ tannin: 'high', confidence: 0.8 }));
     await enrichWineById(WINE_ID);
-    expect(persisted().heldAt).toBeNull();
+    const p = persisted();
+    expect(p.heldAt).toBeNull();
+    expect(p.producerNote).not.toMatch(/Style conflict/);
   });
 
   test('a missing producerUnknown on an old/custom prompt degrades to "no doubt", never to a hold', async () => {
@@ -1100,8 +1127,14 @@ describe('web-search rescue on confidence holds', () => {
   });
 
   test('taxonomy_conflict never spends a search — the model already believes its hallucination', async () => {
-    // Pinot Noir fixture: high tannin is the opposite structural extreme.
-    suggestProfile.mockResolvedValue(attempt(0.8, { tannin: 'high' }));
+    // Nebbiolo fixture: LOW tannin is the opposite structural extreme. (The
+    // fixture was a high-tannin Pinot Noir until ticket 6a896b7e established
+    // that firm Pinot is Pommard, not a hallucination.)
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: WINE_ID, name: 'Barolo', producer: 'Cà di Bruno', type: 'red',
+      country: { name: 'Italy' }, region: { name: 'Piedmont' }, grapes: [{ name: 'Nebbiolo' }],
+    }));
+    suggestProfile.mockResolvedValue(attempt(0.8, { tannin: 'low' }));
     await enrichWineById(WINE_ID);
     expect(suggestProfile).toHaveBeenCalledTimes(1);
     expect(persisted().heldReason).toBe('taxonomy_conflict');


### PR DESCRIPTION
Somm ticket `6a896b7e`.

## The false positive

The taxonomy cross-check shipped with `pinot noir: { tannin: 'low' }`. It was wrong on **both records it ever fired on** — two correct Pommards, flagged for having the firm tannin Pommard is known for. **588 single-variety Pinot Noir rows were exposed**, including Nuits-Saint-Georges, Gevrey-Chambertin and Central Otago.

The table's own admission rule already forbade the entry — *"only when the opposite extreme would be flatly wrong in ANY normal expression of the variety"* — so this enforces the design rather than changing it.

## Why it is structural, not a bad pick

| | set by | assertable? |
|---|---|---|
| Acidity | the grape | ✅ a low-acid variety cannot be made high-acid |
| Tannin **high** | the grape | ✅ thick skins put a **floor** under it — a low-tannin Nebbiolo is a defect |
| Tannin **low** | the **winemaker** | ❌ extraction, whole-cluster, new oak and press fraction carry thin-skinned varieties past it routinely |

Low tannin is a **ceiling nobody enforces**. Pinot Noir and Gamay are both out — cru Beaujolais (Moulin-à-Vent, Morgon) is structured on purpose and was the next false positive waiting.

The four `tannin: 'high'` entries and all ten acidity entries are untouched, so the rule keeps its teeth. **An invariant test now fails if any `tannin: 'low'` entry is ever added back.**

## The test asserted the bug

```js
test('tannin axis works the same way — a high-tannin Pinot Noir fires', () => {
  expect(check(['Pinot Noir'], { tannin: 'high' })).toMatch(/pinot noir is defined by low tannin/);
});
```

That line is why the entry survived review. It is now inverted, and the Pommard case it got backwards is a named test.

## Production

Two records carried the false note; **both cleared**, before-value in the audit trail. The note is owner-visible, so a wrong caveat is worse than none. Nothing was held under `taxonomy_conflict`.

## ⚠️ Verification

**Backend suite not run locally** — Docker's engine is 500ing on this machine. The rule is a pure function; its 10 assertions were verified directly with node (all pass). **CI is the gate.**