### PR TITLE
fix(enrichment): a regen may not trade a better profile for a worse one

### DIFF
--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -815,6 +815,33 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
     return { result: 'held', reason: a.holdReason };
   }
 
+  // A regeneration must not trade a BETTER profile for a WORSE one (somm
+  // ticket 6a894676, 2026-08-22). Frogtown Cellars carried a search-assisted
+  // profile at 0.6 with the producer identified; a curator filled in the
+  // correct appellation, the forced re-enrich that followed could not get a
+  // search slot — the rescue is capped per UTC day and curation burns the cap
+  // in minutes — and the search-less rerun landed 0.4 with producerUnknown
+  // true and a thinner description. Filling in a correct field made the
+  // record worse, which is the opposite of what re-enrichment is for.
+  //
+  // Narrow on purpose. Only a regen that lost the web search AND came back
+  // less confident is refused; an honest re-assessment that lowers confidence
+  // on its own merits still lands, because the record really may have got
+  // harder to describe. Like the reviewed-profile guard above, the old
+  // profile stays and the row drops back into the worklists for a human.
+  const prev = wine.aiProfile;
+  const lostSearch = prev && prev.searchUsed === true && a.meta.searchUsed !== true;
+  const lessSure = prev && Number.isFinite(prev.confidence)
+    && Number.isFinite(a.meta.confidence) && a.meta.confidence < prev.confidence;
+  if (prev && prev.description && lostSearch && lessSure) {
+    await WineDefinition.updateOne(
+      { _id: wine._id },
+      { $set: { profileReviewedAt: null, updatedAt: now } }
+    );
+    console.log(`[enrichmentJob] kept searched profile ${wine._id}: regen lost search and dropped ${prev.confidence} → ${a.meta.confidence}`);
+    return { result: 'kept', reason: 'would_downgrade_searched_profile' };
+  }
+
   await WineDefinition.updateOne(
     { _id: wine._id },
     {

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -1142,6 +1142,78 @@ describe('web-search rescue on confidence holds', () => {
     expect(persisted().heldReason).toBe('taxonomy_conflict');
   });
 
+  // -------------------------------------------------------------------------
+  // Somm ticket 6a894676. Frogtown Cellars carried a search-assisted profile
+  // at 0.6 with the producer identified. A curator filled in the correct
+  // appellation; the forced re-enrich could not get a search slot (the rescue
+  // is capped per UTC day and a curation session burns the cap in minutes)
+  // and the search-less rerun landed 0.4 with producerUnknown true. Filling
+  // in a CORRECT field made the record worse.
+  // -------------------------------------------------------------------------
+  describe('a regen may not trade a better profile for a worse one', () => {
+    const searched = (over = {}) => ({
+      confidence: 0.6, searchUsed: true, description: 'A search-verified Georgia red.',
+      producerUnknown: false, generatedAt: new Date('2026-08-21T10:00:00Z'), ...over,
+    });
+    const wineWith = (aiProfile) => WineDefinition.findById.mockReturnValue(chain({
+      _id: WINE_ID, name: 'Disclosure Reserve', producer: 'Frogtown', type: 'red',
+      country: { name: 'United States' }, region: { name: 'Georgia' },
+      appellation: 'Dahlonega Plateau', grapes: [], aiProfile,
+    }));
+
+    test('the reported case: lost search AND lower confidence keeps the old profile', async () => {
+      wineWith(searched());
+      aiConfig.get.mockImplementation(() => searchCfg({ enrichmentSearchEnabled: false })); // no slot
+      suggestProfile.mockResolvedValue(attempt(0.4));
+      const out = await enrichWineById(WINE_ID, { force: true });
+      expect(out).toEqual({ result: 'kept', reason: 'would_downgrade_searched_profile' });
+      // The profile itself is untouched; only the review stamp is cleared so
+      // the row returns to a human worklist.
+      const set = WineDefinition.updateOne.mock.calls[0][1].$set;
+      expect(set.aiProfile).toBeUndefined();
+      expect(set.profileReviewedAt).toBeNull();
+    });
+
+    test('an honest re-assessment that lowers confidence on its OWN merits still lands', async () => {
+      // Search was kept — the model simply became less sure. That is a real
+      // signal and must not be suppressed.
+      wineWith(searched());
+      suggestProfile
+        .mockResolvedValueOnce(attempt(0.2))
+        .mockResolvedValueOnce(attempt(0.45, { description: 'Searched, and still thin.' }));
+      const out = await enrichWineById(WINE_ID, { force: true });
+      expect(out.result).toBe('enriched');
+      expect(persisted().searchUsed).toBe(true);
+      expect(persisted().confidence).toBe(0.45);
+    });
+
+    test('losing search but coming back MORE confident still lands', async () => {
+      wineWith(searched());
+      aiConfig.get.mockImplementation(() => searchCfg({ enrichmentSearchEnabled: false }));
+      suggestProfile.mockResolvedValue(attempt(0.8));
+      const out = await enrichWineById(WINE_ID, { force: true });
+      expect(out.result).toBe('enriched');
+      expect(persisted().confidence).toBe(0.8);
+    });
+
+    test('a row that never used search is unaffected — the guard is not a general confidence ratchet', async () => {
+      wineWith(searched({ searchUsed: false }));
+      aiConfig.get.mockImplementation(() => searchCfg({ enrichmentSearchEnabled: false }));
+      suggestProfile.mockResolvedValue(attempt(0.4));
+      const out = await enrichWineById(WINE_ID, { force: true });
+      expect(out.result).toBe('enriched');
+      expect(persisted().confidence).toBe(0.4);
+    });
+
+    test('a searched row with no description yet cannot be "kept" — there is nothing to keep', async () => {
+      wineWith(searched({ description: null }));
+      aiConfig.get.mockImplementation(() => searchCfg({ enrichmentSearchEnabled: false }));
+      suggestProfile.mockResolvedValue(attempt(0.4));
+      const out = await enrichWineById(WINE_ID, { force: true });
+      expect(out.result).toBe('enriched');
+    });
+  });
+
   test('kill-switch: enrichmentSearchEnabled=false means a single attempt and a plain hold', async () => {
     aiConfig.get.mockImplementation(() => searchCfg({ enrichmentSearchEnabled: false }));
     suggestProfile.mockResolvedValue(attempt(0.2));

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -1161,28 +1161,33 @@ describe('web-search rescue on confidence holds', () => {
       appellation: 'Dahlonega Plateau', grapes: [], aiProfile,
     }));
 
+    // Asserted on the DB WRITE rather than the return value: enrichWineById
+    // hands back the bare outcome string, and what actually matters is whether
+    // the stored profile was replaced.
+    const wroteProfile = () => WineDefinition.updateOne.mock.calls
+      .some((c) => c[1] && c[1].$set && c[1].$set.aiProfile);
+
     test('the reported case: lost search AND lower confidence keeps the old profile', async () => {
       wineWith(searched());
       aiConfig.get.mockImplementation(() => searchCfg({ enrichmentSearchEnabled: false })); // no slot
       suggestProfile.mockResolvedValue(attempt(0.4));
       const out = await enrichWineById(WINE_ID, { force: true });
-      expect(out).toEqual({ result: 'kept', reason: 'would_downgrade_searched_profile' });
-      // The profile itself is untouched; only the review stamp is cleared so
+      expect(out).toBe('kept');
+      // The profile itself is untouched; only the review stamp is cleared, so
       // the row returns to a human worklist.
-      const set = WineDefinition.updateOne.mock.calls[0][1].$set;
-      expect(set.aiProfile).toBeUndefined();
-      expect(set.profileReviewedAt).toBeNull();
+      expect(wroteProfile()).toBe(false);
+      expect(WineDefinition.updateOne.mock.calls[0][1].$set.profileReviewedAt).toBeNull();
     });
 
     test('an honest re-assessment that lowers confidence on its OWN merits still lands', async () => {
-      // Search was kept — the model simply became less sure. That is a real
+      // Search was KEPT — the model simply became less sure. That is a real
       // signal and must not be suppressed.
       wineWith(searched());
       suggestProfile
         .mockResolvedValueOnce(attempt(0.2))
         .mockResolvedValueOnce(attempt(0.45, { description: 'Searched, and still thin.' }));
-      const out = await enrichWineById(WINE_ID, { force: true });
-      expect(out.result).toBe('enriched');
+      await enrichWineById(WINE_ID, { force: true });
+      expect(wroteProfile()).toBe(true);
       expect(persisted().searchUsed).toBe(true);
       expect(persisted().confidence).toBe(0.45);
     });
@@ -1191,8 +1196,8 @@ describe('web-search rescue on confidence holds', () => {
       wineWith(searched());
       aiConfig.get.mockImplementation(() => searchCfg({ enrichmentSearchEnabled: false }));
       suggestProfile.mockResolvedValue(attempt(0.8));
-      const out = await enrichWineById(WINE_ID, { force: true });
-      expect(out.result).toBe('enriched');
+      await enrichWineById(WINE_ID, { force: true });
+      expect(wroteProfile()).toBe(true);
       expect(persisted().confidence).toBe(0.8);
     });
 
@@ -1200,8 +1205,8 @@ describe('web-search rescue on confidence holds', () => {
       wineWith(searched({ searchUsed: false }));
       aiConfig.get.mockImplementation(() => searchCfg({ enrichmentSearchEnabled: false }));
       suggestProfile.mockResolvedValue(attempt(0.4));
-      const out = await enrichWineById(WINE_ID, { force: true });
-      expect(out.result).toBe('enriched');
+      await enrichWineById(WINE_ID, { force: true });
+      expect(wroteProfile()).toBe(true);
       expect(persisted().confidence).toBe(0.4);
     });
 
@@ -1209,8 +1214,8 @@ describe('web-search rescue on confidence holds', () => {
       wineWith(searched({ description: null }));
       aiConfig.get.mockImplementation(() => searchCfg({ enrichmentSearchEnabled: false }));
       suggestProfile.mockResolvedValue(attempt(0.4));
-      const out = await enrichWineById(WINE_ID, { force: true });
-      expect(out.result).toBe('enriched');
+      await enrichWineById(WINE_ID, { force: true });
+      expect(wroteProfile()).toBe(true);
     });
   });
 


### PR DESCRIPTION
Somm ticket `6a894676`.

## What happened

Frogtown Cellars carried a **search-assisted profile at confidence 0.6** with the producer identified. A curator filled in the correct appellation. The forced re-enrich that followed **could not get a search slot** — the rescue is capped per UTC day and a curation session burns the cap in minutes — and the search-less rerun landed **0.4 with `producerUnknown: true`** and a thinner description.

**Filling in a correct field made the record worse.** That is the opposite of what re-enrichment is for.

## The guard

Only a regen that **lost the web search AND came back less confident** is refused. Deliberately narrow:

- an honest re-assessment that lowers confidence on its own merits **still lands** — the record may really have become harder to describe. This is not a general confidence ratchet.
- a row that never used search is unaffected.
- coming back *more* confident without search still lands.

It follows the existing reviewed-profile precedent exactly: old profile stays, review stamp cleared, row returns to the human worklists.

## Blast radius — measured before building

The ticket feared ~110 degraded profiles. The real number is much smaller:

| | |
|---|---|
| Profiles regenerated during the whole session | **10** (not ~110) |
| …of those, search-less | 9 |
| Rows carrying `searchUsed: true` registry-wide | 50 |

`reenrichAfterRecordEdit` already skips never-enriched rows and curator-locked ones, so most of the curator's fills never triggered a regeneration at all.

## Not fixed here, deliberately

**The daily search cap itself.** Raising it spends credits on every hard row; this guard costs nothing and stops the actual damage. Worth revisiting with the pilot's rescue-rate numbers.

## ⚠️ Verification

**Backend suite not run locally** — Docker's engine is 500ing on this machine. Five new tests cover the reported case and all four non-firing paths. **CI is the gate.**