### PR TITLE
fix(import): a classification tier is routed to classification, never the name

### DIFF
--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -790,6 +790,87 @@ export function stripProducerPrefix(wineName, producer) {
   return wineName;
 }
 
+// ── Classification-in-name guard (somm ticket 0063bb76) ─────────────────────
+//
+// Once the producer prefix is stripped, a Bordeaux "Wine" value like
+// "Château Talbot Grand Cru Classé" leaves just the CLASSIFICATION tier —
+// and that string used to be stored as the wine's NAME. Prod grew 19 such
+// rows (three distinct wines all named "Grand Cru Classé"), six of them
+// duplicating a properly-named record of the same château. A tier is routed
+// to `classification`; the name gets whatever substantive part remains, or
+// falls back to the producer (the grand-vin convention — Château Margaux's
+// wine IS "Château Margaux").
+//
+// Deliberately requires "classé"/"bourgeois": Burgundy's "1er Cru" alone is
+// part of real appellation-carrying names ("Chassagne-Montrachet 1er Cru Les
+// Fairendes") and must never trip this.
+
+const TIER_RE = /(premier\s+grand\s+cru\s+class[eé]s?|second\s+grand\s+cru\s+class[eé]s?|deuxi[eè]me\s+cru\s+class[eé]s?|grand\s+cru\s+class[eé]s?|premier\s+cru\s+class[eé]s?|cru\s+class[eé]s?|cru\s+bourgeois(?:\s+sup[eé]rieur)?)/i;
+
+const TIER_CANONICAL = new Map([
+  ['premier grand cru classe', 'Premier Grand Cru Classé'],
+  ['second grand cru classe', 'Second Grand Cru Classé'],
+  ['deuxieme cru classe', 'Deuxième Cru Classé'],
+  ['grand cru classe', 'Grand Cru Classé'],
+  ['premier cru classe', 'Premier Cru Classé'],
+  ['cru classe', 'Cru Classé'],
+  ['cru bourgeois', 'Cru Bourgeois'],
+  ['cru bourgeois superieur', 'Cru Bourgeois Supérieur'],
+]);
+
+const foldAccents = (s) => String(s || '').normalize('NFD').replace(/[̀-ͯ]/g, '');
+const normTier = (s) => TIER_CANONICAL.get(foldAccents(s).toLowerCase().replace(/s$/, '').replace(/\s+/g, ' ').trim()) || null;
+
+// Words that don't make a leftover a real cuvée name: the row's own
+// appellation/region tokens, plus label furniture ("Grand Vin", AOC noise).
+const NAME_NOISE = new Set(['grand', 'vin', 'cru', 'aoc', 'ac', 'appellation', 'controlee', 'de', 'du', 'la', 'le', 'les', 'des']);
+function isAppellationNoise(remainder, appellation, region) {
+  const allowed = new Set(NAME_NOISE);
+  for (const src of [appellation, region]) {
+    for (const t of foldAccents(src).toLowerCase().split(/[^a-z0-9]+/)) if (t) allowed.add(t);
+  }
+  return foldAccents(remainder).toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
+    .every((t) => allowed.has(t));
+}
+
+/**
+ * Split a classification tier out of a wine name. Returns
+ * { wineName, classification } — classification undefined when no tier found.
+ */
+export function splitClassificationFromName(wineName, { producer, appellation, region } = {}) {
+  const name = String(wineName || '').trim();
+  if (!name) return { wineName, classification: undefined };
+
+  // Trailing parenthesised tier: "Margaux (Grand Cru Classé)". The remainder
+  // re-runs through the splitter — "Saint-Émilion Grand Cru (Grand Cru
+  // Classé)" still has appellation noise to shed.
+  const paren = name.match(/^(.*?)\s*\(\s*([^)]*(?:cru\s+class[eé]|cru\s+bourgeois)[^)]*)\s*\)\s*$/i);
+  if (paren) {
+    const inner = normTier(paren[2]) || paren[2].trim();
+    const again = splitClassificationFromName(paren[1], { producer, appellation, region });
+    // The part before the parens gets the same "is it a real name" test as
+    // the inline case — "Margaux (Grand Cru Classé)" leaves only appellation.
+    const base = again.wineName && !isAppellationNoise(again.wineName, appellation, region)
+      ? again.wineName
+      : ((producer || '').trim() || name);
+    return { wineName: base, classification: again.classification || inner };
+  }
+
+  const m = name.match(TIER_RE);
+  if (!m) return { wineName: name, classification: undefined };
+  const tier = normTier(m[0]) || m[0].trim();
+  const remainder = (name.slice(0, m.index) + ' ' + name.slice(m.index + m[0].length))
+    .replace(/[\s,;:()–—-]+/g, ' ').trim();
+  if (remainder && !isAppellationNoise(remainder, appellation, region)) {
+    // A real cuvée survives the strip: "Clos des Jacobins", "Réserve du Château".
+    return { wineName: remainder, classification: tier };
+  }
+  // Nothing substantive left — a designation is not a name; the grand vin
+  // carries the estate's own. No producer to fall back on leaves the name
+  // unchanged rather than minting an empty one.
+  return { wineName: (producer || '').trim() || name, classification: tier };
+}
+
 /** wineName + producer from a CT row (Producer column or heuristic). */
 function ctIdentity(get) {
   const rawWine = get(['Wine', 'wine', 'WineName']);
@@ -802,16 +883,23 @@ function ctIdentity(get) {
 
 /** Fields shared by all CT table mappers. */
 function ctCommonFields(get, { sizeKeys = ['Size'] } = {}) {
-  const { wineName, producer } = ctIdentity(get);
+  const identity = ctIdentity(get);
   const locale = parseCtLocale(get(['Locale']));
+  const region = get(['Region']) || locale.region;
+  const appellation = ctClean(get(['Appellation'])) || locale.appellation;
+  // After producer-stripping, a Bordeaux Wine value can be pure tier
+  // ("Grand Cru Classé") — route it to classification, never the name.
+  const { wineName, classification } = splitClassificationFromName(
+    identity.wineName, { producer: identity.producer, appellation, region });
   const rating = ctMyRating(get);
   return {
     wineName,
-    producer,
+    producer: identity.producer,
+    classification,
     vintage: ctVintage(get(['Vintage'])) || 'NV',
     country: get(['Country']) || locale.country,
-    region: get(['Region']) || locale.region,
-    appellation: ctClean(get(['Appellation'])) || locale.appellation,
+    region,
+    appellation,
     type: mapCellarTrackerType(get(['Type']), get(['Color', 'Colour'])),
     // CT tracks spirits beside wine; the caller flags rather than guesses.
     nonWineHint: looksNonWine(get(['Type']), get(['Category'])) || undefined,
@@ -1011,13 +1099,23 @@ function mapGenericRow(row) {
   const parsedRack = parseCombinedRackLocation(combined);
   const rackFields = mapRackFields(get);
 
+  const producer = get(['Producer', 'producer', 'Winery', 'winery', 'Maker', 'maker']);
+  const region = get(['Region', 'region']);
+  const appellation = get(['Appellation', 'appellation', 'Sub-Region', 'SubRegion']);
+  // Same tier-in-name guard as the CT path (somm ticket 0063bb76) — plus an
+  // explicit Classification column, which some hand-written files carry.
+  const { wineName, classification } = splitClassificationFromName(
+    get(['Wine', 'wine', 'Wine Name', 'WineName', 'Name', 'name']),
+    { producer, appellation, region });
+
   return {
-    wineName: get(['Wine', 'wine', 'Wine Name', 'WineName', 'Name', 'name']),
-    producer: get(['Producer', 'producer', 'Winery', 'winery', 'Maker', 'maker']),
+    wineName,
+    producer,
+    classification: classification || get(['Classification', 'classification']) || undefined,
     vintage: get(['Vintage', 'vintage', 'Year', 'year']) || 'NV',
     country: get(['Country', 'country']),
-    region: get(['Region', 'region']),
-    appellation: get(['Appellation', 'appellation', 'Sub-Region', 'SubRegion']),
+    region,
+    appellation,
     type: mapWineType(get(['Type', 'type', 'Color', 'Colour', 'Category', 'category'])),
     price: isNaN(price) ? undefined : price,
     currency: get(['Currency', 'currency']) || undefined,

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -10,6 +10,7 @@ import {
   parseLocaleNumber,
   parseVivinoDrinkWindow,
   isVivinoScanHistory,
+  splitClassificationFromName,
 } from './importMappers';
 
 // ---------------------------------------------------------------------------
@@ -942,5 +943,82 @@ describe('wine colour is stated, never guessed', () => {
     // "White - Sparkling" is sparkling; reading the colour first would lose it.
     expect(parseAndMap('Wine,Producer,Type,Vintage,Locale\nX,Y,White - Sparkling,2020,France\n').items[0].type).toBe('sparkling');
     expect(parseAndMap('Wine,Producer,Type,Vintage,Locale\nX,Y,White - Sweet/Dessert,2020,France\n').items[0].type).toBe('dessert');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Classification-in-name guard (somm ticket 0063bb76). Producer-stripping a
+// Bordeaux CT name like "Château Talbot Grand Cru Classé" used to leave the
+// bare TIER as the wine's name — prod grew 19 such rows, three distinct wines
+// all named "Grand Cru Classé", six duplicating a properly-named record.
+// ---------------------------------------------------------------------------
+describe('splitClassificationFromName', () => {
+
+  it('routes a pure-tier name to classification, name falls back to the producer (grand-vin convention)', () => {
+    expect(splitClassificationFromName('Grand Cru Classé', { producer: 'Château Talbot', appellation: 'Saint-Julien' }))
+      .toEqual({ wineName: 'Château Talbot', classification: 'Grand Cru Classé' });
+  });
+
+  it('keeps a real cuvée that survives the strip', () => {
+    expect(splitClassificationFromName('Clos des Jacobins Grand Cru Classé', { producer: 'Domaine Cordier', appellation: 'Saint-Émilion Grand Cru' }))
+      .toEqual({ wineName: 'Clos des Jacobins', classification: 'Grand Cru Classé' });
+    expect(splitClassificationFromName('Réserve du Château Cru Classé', { producer: 'Château de Brégançon', appellation: 'Côtes de Provence' }))
+      .toEqual({ wineName: 'Réserve du Château', classification: 'Cru Classé' });
+  });
+
+  it('appellation tokens and label furniture are not a name', () => {
+    // remainder "Margaux" = the appellation, not a cuvée
+    expect(splitClassificationFromName('Second Grand Cru Classé Margaux', { producer: 'Château Rauzan-Gassies', appellation: 'Margaux' }))
+      .toEqual({ wineName: 'Château Rauzan-Gassies', classification: 'Second Grand Cru Classé' });
+    // "Grand Vin" is furniture
+    expect(splitClassificationFromName('Grand Vin Premier Grand Cru Classé', { producer: 'Château Margaux', appellation: 'Margaux' }))
+      .toEqual({ wineName: 'Château Margaux', classification: 'Premier Grand Cru Classé' });
+  });
+
+  it('handles the parenthesised forms, including tier-in-parens after appellation noise', () => {
+    expect(splitClassificationFromName('Margaux (Grand Cru Classé)', { producer: 'Château Malescot St. Exupéry', appellation: 'Margaux' }))
+      .toEqual({ wineName: 'Château Malescot St. Exupéry', classification: 'Grand Cru Classé' });
+    expect(splitClassificationFromName('Saint-Émilion Grand Cru (Premier Grand Cru Classé)', { producer: 'Château Angelus', appellation: 'Saint-Émilion Grand Cru' }))
+      .toEqual({ wineName: 'Château Angelus', classification: 'Premier Grand Cru Classé' });
+  });
+
+  it('NEVER fires on Burgundy 1er Cru names — classé/bourgeois is required', () => {
+    expect(splitClassificationFromName('Chassagne-Montrachet 1er Cru Les Fairendes', { producer: 'Florent Moingeon', appellation: 'Chassagne-Montrachet 1er Cru' }))
+      .toEqual({ wineName: 'Chassagne-Montrachet 1er Cru Les Fairendes', classification: undefined });
+    expect(splitClassificationFromName('Grand Cru', { producer: 'X', appellation: 'Chablis Grand Cru' }).classification).toBeUndefined();
+  });
+
+  it('folds accents onto the canonical tier spelling', () => {
+    expect(splitClassificationFromName('Grand Cru Classe', { producer: 'Château Batailley', appellation: 'Pauillac' }).classification)
+      .toBe('Grand Cru Classé');
+    expect(splitClassificationFromName('Cru Bourgeois', { producer: 'Château Mazails', appellation: 'Médoc' }).classification)
+      .toBe('Cru Bourgeois');
+  });
+
+  it('a name with no tier passes through untouched', () => {
+    expect(splitClassificationFromName('Pavillon Rouge', { producer: 'Château Margaux', appellation: 'Margaux' }))
+      .toEqual({ wineName: 'Pavillon Rouge', classification: undefined });
+  });
+
+  it('no producer to fall back on keeps the original name rather than minting an empty one', () => {
+    expect(splitClassificationFromName('Grand Cru Classé', { producer: '', appellation: 'Pauillac' }).wineName)
+      .toBe('Grand Cru Classé');
+  });
+});
+
+describe('classification reaches the mapped item', () => {
+  it('generic rows: tier-only Wine name lands in classification, name is the producer', () => {
+    const { items } = parseAndMap('Wine,Producer,Appellation,Vintage\nGrand Cru Classé,Château Talbot,Saint-Julien,2016\n');
+    expect(items[0]).toMatchObject({
+      wineName: 'Château Talbot',
+      producer: 'Château Talbot',
+      classification: 'Grand Cru Classé',
+      appellation: 'Saint-Julien',
+    });
+  });
+
+  it('generic rows: an explicit Classification column is honoured when the name is clean', () => {
+    const { items } = parseAndMap('Wine,Producer,Classification,Vintage\nPavillon Rouge,Château Margaux,Second Vin,2018\n');
+    expect(items[0]).toMatchObject({ wineName: 'Pavillon Rouge', classification: 'Second Vin' });
   });
 });


### PR DESCRIPTION
Somm ticket `0063bb76`.

## The defect

Producer-stripping a Bordeaux CT name like *"Château Talbot Grand Cru Classé"* left the bare **tier** as the wine's name. Prod grew **19 such rows** — three distinct wines all named "Grand Cru Classé" — six of them silently duplicating a properly-named record of the same château. Talbot's four vintages sat split 2+2 across two rows. And the classification data itself was lost — null on every row even though it arrived with the import.

## The fix

`splitClassificationFromName` runs after producer-stripping in both the CT and generic mappers:

| input | name | classification |
|---|---|---|
| `Grand Cru Classé` (producer Talbot) | Château Talbot | Grand Cru Classé |
| `Clos des Jacobins Grand Cru Classé` | Clos des Jacobins | Grand Cru Classé |
| `Grand Vin Premier Grand Cru Classé` | Château Margaux | Premier Grand Cru Classé |
| `Margaux (Grand Cru Classé)` | Château Malescot St. Exupéry | Grand Cru Classé |
| `Chassagne-Montrachet 1er Cru Les Fairendes` | **untouched** | — |

**classé/bourgeois is required** — Burgundy's bare "1er Cru" can never trip it. A remainder made only of the row's own appellation tokens or label furniture is not a name; the wine falls back to the producer (the grand-vin convention). Generic rows also honour an explicit `Classification` column.

## Prod backfill (already applied, audited)

12 rows renamed in place · **7 duplicate pairs merged** (Talbot, Batailley, La Lagune, Margaux, Cantemerle, Haut-Brion — Haut-Brion reversed direction because the badly-named row carried the curator profile) · 1 deliberately left (Brégançon red/rosé pair may be two real wines — somm judgement).

## Verification

Frontend: **1015 tests green** including 9 new cases. Frontend-only change.