### PR TITLE
fix(import): catch the same wine arriving under a different label form

### DIFF
--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -24,6 +24,7 @@ const { scoreAllMatches } = require('./wineMatching');
 const { canonicalizeWineName } = require('../utils/producerPrefix');
 const { computeCanonicalKey, canonicalSiblingPrefix } = require('../utils/wineIdentity');
 const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
+const { isLabelVariant, grapeTokenSet } = require('./labelVariantMatch');
 const { resolveCanonicalProducerSpelling } = require('./producerSpelling');
 const { resolveCanonicalAppellation, candidateKeys } = require('./appellationResolve');
 const { escapeRegex } = require('../utils/sanitize');
@@ -742,6 +743,47 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // from splitting across "Hunter Valley" and "New South Wales" depending on
   // which granularity the AI/import happened to supply per row. Only when the
   // appellation names no known region does the supplied region string count.
+  // ── Label-variant stage (somm ticket e9b346ba, 2026-08-23) ────────────────
+  //
+  // Last chance to NOT create a duplicate. One import file carried the same
+  // wine repeatedly under variant names — "Bin 389" and "Bin 389 Cabernet
+  // Shiraz", "Kangarilla" and "Old Vines Grenache Kangarilla" — and nothing
+  // above caught them: normalizedKey is exact, and all 17 pairs a curator
+  // merged by hand that day scored BELOW the 0.85 soft-zone floor, so the
+  // fuzzy stage never even offered them as candidates. See
+  // services/labelVariantMatch for the measurements and the guard that stops
+  // a multi-varietal range collapsing.
+  //
+  // Producer-scoped so the scan is small, and it only ever LINKS to an
+  // existing row — never merges, never deletes. Getting this wrong costs a
+  // bottle on a near-identical wine; getting the absence of it wrong is the
+  // duplicate registry this ticket is about.
+  if (!producerMissing && !skipSiblingMatch) {
+    try {
+      const siblings = (await WineDefinition.find({
+        producer: producerToStore,
+        _id: { $ne: null },
+      }).limit(60).populate(POPULATE)).filter((c) => !pendingBlocked(c));
+      if (siblings.length > 0) {
+        const grapeDocs = await Grape.find({}).select('name normalizedName normalizedSynonyms').lean();
+        const gTokens = grapeTokenSet(buildSurfaceForms(grapeDocs));
+        const query = { name: trimmedName, appellation: trimmedAppellation, grapes };
+        for (const cand of siblings) {
+          if (conflictsCountry(cand)) continue;
+          const verdict = isLabelVariant(query, cand, gTokens);
+          if (verdict.match) {
+            console.log(`[findOrCreateWine] label variant: "${trimmedName}" → existing "${cand.name}" (${verdict.reason})`);
+            return { wine: cand, created: false, labelVariantOf: cand.name };
+          }
+        }
+      }
+    } catch (err) {
+      // Never block a create on the detector failing — a missing dedup is
+      // recoverable, a failed add is not.
+      console.warn('[findOrCreateWine] label-variant stage failed:', err.message);
+    }
+  }
+
   let regionDoc = await regionForAppellation(trimmedAppellation, countryDoc._id);
   if (!regionDoc) regionDoc = await findOrCreateRegion(region, countryDoc._id, userId);
   let grapeIds = await findOrCreateGrapes(grapes, userId);

--- a/backend/src/services/labelVariantMatch.js
+++ b/backend/src/services/labelVariantMatch.js
@@ -1,0 +1,149 @@
+/**
+ * Same wine, different label form.
+ *
+ * Somm ticket e9b346ba (2026-08-23). One import file carried the same wine
+ * more than once under variant names and nothing collided: `normalizedKey` is
+ * exact, and the fuzzy scorer never got close. Measured against the 17 pairs a
+ * curator merged by hand that day, EVERY pair scored below 0.85 — the floor of
+ * even the "did you mean?" soft zone — spread across 0.58 to 0.85:
+ *
+ *   Bin 389 / Bin 389 Cabernet Shiraz .................. 0.717
+ *   RWT / RWT Shiraz ................................... 0.721
+ *   pHat / pHat Chardonnay ............................. 0.708
+ *   Shiraz Cask 66 / Cask 66 Shiraz .................... 0.788
+ *   Kangarilla / Old Vines Grenache Kangarilla ......... 0.689
+ *
+ * So no threshold move could have caught them: reaching the worst pair means
+ * ~0.58, which would fold genuinely different wines together. The signal has
+ * to come from NORMALISING before comparing, not from a looser cut-off.
+ *
+ * What makes these pairs invisible is that the differing tokens carry no
+ * identity — a variety name, an "Old Vines" prefix, plain word order. Strip
+ * those and the remainders are equal. That is the whole detector:
+ *
+ *   name        → fold accents, lowercase, drop punctuation
+ *   tokens      → drop variety names (from the live taxonomy), label
+ *                 furniture, and the row's own appellation tokens
+ *   compare     → set equality, so word order stops mattering
+ *
+ * THE GUARD THAT KEEPS IT HONEST. Reduced-set equality ALONE would merge a
+ * range bottled in several varietals: Zuccardi "Q Cabernet Franc" and "Q
+ * Malbec" both reduce to "q". The curator's own rule decides it — where both
+ * sides name a DIFFERENT variety they are two wines; where one side names a
+ * variety and the other names none, it is one wine written twice. So the
+ * stripped varieties must be COMPATIBLE: one side's set empty, or one a
+ * subset of the other. Disjoint non-empty variety sets are a hard reject.
+ *
+ * WHAT THIS DELIBERATELY CANNOT DO. A vineyard or site token dropped from a
+ * later label (Penfolds "Kalimna Bin 28" → "Bin 28 Shiraz") is the same class
+ * of change, and it is NOT handled here — deliberately, not by oversight.
+ * Vineyard names cannot join the strip list because for some producers the
+ * vineyard IS the wine: Clarendon Hills bottle Kangarilla, Blewitt Springs and
+ * Brookman as separate wines, and stripping site names would collapse their
+ * whole range into one row. A rule that fixes Penfolds breaks Clarendon Hills,
+ * so that case stays a curator judgement. Do not read the four transformations
+ * below as the complete set.
+ */
+const { normalizeString } = require('../utils/normalize');
+
+// Label furniture: real words on labels that never distinguish two wines of
+// the same producer. "Old Vines" is the curator's transformation #2; the rest
+// are the connectives that survive normalisation.
+const FURNITURE = new Set([
+  'old', 'vine', 'vines', 'vieilles', 'vignes',
+  'de', 'du', 'des', 'la', 'le', 'les', 'el', 'los', 'las', 'il', 'the',
+  'and', 'et', 'y',
+]);
+
+const fold = (s) => normalizeString(String(s || ''));
+const tokens = (s) => fold(s).split(/[^a-z0-9]+/).filter(Boolean);
+
+/**
+ * Build the variety-token lookup once per call site.
+ * @param {Array} surfaceForms from services/grapeInference.buildSurfaceForms
+ * @returns {Set<string>} single tokens that name a grape
+ */
+function grapeTokenSet(surfaceForms) {
+  const set = new Set();
+  for (const { form } of surfaceForms || []) {
+    for (const t of String(form).split(/[^a-z0-9]+/)) {
+      // 3+ chars only: a two-letter fragment of a variety name would eat
+      // real cuvée tokens ("LJ", "MC", "Q") and gut the comparison.
+      if (t && t.length > 2) set.add(t);
+    }
+  }
+  return set;
+}
+
+/**
+ * Reduce a wine name to its identifying tokens.
+ * @returns {{core: Set<string>, varieties: Set<string>}}
+ */
+function reduceName(name, { grapeTokens, appellation } = {}) {
+  const apTokens = new Set(tokens(appellation));
+  const varieties = new Set();
+  const build = (stripAppellation) => {
+    const core = new Set();
+    for (const t of tokens(name)) {
+      if (grapeTokens && grapeTokens.has(t)) { varieties.add(t); continue; }
+      if (FURNITURE.has(t)) continue;
+      // The appellation repeated inside the name adds nothing — it is already
+      // its own field.
+      if (stripAppellation && apTokens.has(t)) continue;
+      core.add(t);
+    }
+    return core;
+  };
+  let core = build(true);
+  // …unless the appellation IS the name. Clarendon Hills name their wines for
+  // the vineyard AND file it as the appellation, so stripping it leaves
+  // nothing and "Kangarilla" would stop matching "Old Vines Grenache
+  // Kangarilla" — the very pair this detector exists for. Keep the
+  // appellation tokens when they are all a name has.
+  if (core.size === 0) core = build(false);
+  return { core, varieties };
+}
+
+const eqSet = (a, b) => a.size === b.size && [...a].every((x) => b.has(x));
+const subset = (a, b) => [...a].every((x) => b.has(x));
+
+/**
+ * Are these two names the same wine under different label forms?
+ *
+ * @param {{name:string, appellation?:string, grapes?:Array}} a
+ * @param {{name:string, appellation?:string, grapes?:Array}} b
+ * @param {Set<string>} grapeTokens from grapeTokenSet()
+ * @returns {{match:boolean, reason:string}}
+ */
+function isLabelVariant(a, b, grapeTokens) {
+  const ra = reduceName(a.name, { grapeTokens, appellation: a.appellation });
+  const rb = reduceName(b.name, { grapeTokens, appellation: b.appellation });
+
+  // An empty core means the name was ENTIRELY furniture and varieties
+  // ("Chardonnay"): nothing identifying is left, so equality here would match
+  // every varietal wine of the producer to every other.
+  if (ra.core.size === 0 || rb.core.size === 0) {
+    return { match: false, reason: 'no identifying tokens after reduction' };
+  }
+  if (!eqSet(ra.core, rb.core)) {
+    return { match: false, reason: 'reduced names differ' };
+  }
+  // The guard: differing named varieties mean two wines in one range.
+  if (ra.varieties.size > 0 && rb.varieties.size > 0
+      && !subset(ra.varieties, rb.varieties) && !subset(rb.varieties, ra.varieties)) {
+    return { match: false, reason: 'each name states a different variety — a range, not a duplicate' };
+  }
+  // Corroborate against the stored grape lists when BOTH rows have them: two
+  // records of one wine cannot disagree about what it is made from. A missing
+  // list is silence, not disagreement.
+  const idsOf = (w) => new Set((w.grapes || [])
+    .map((g) => String((g && g._id) ? g._id : g)).filter(Boolean));
+  const ga = idsOf(a);
+  const gb = idsOf(b);
+  if (ga.size > 0 && gb.size > 0 && !subset(ga, gb) && !subset(gb, ga)) {
+    return { match: false, reason: 'stored grape lists disagree' };
+  }
+  return { match: true, reason: `same reduced name "${[...ra.core].sort().join(' ')}"` };
+}
+
+module.exports = { isLabelVariant, reduceName, grapeTokenSet, FURNITURE };

--- a/backend/src/services/labelVariantMatch.test.js
+++ b/backend/src/services/labelVariantMatch.test.js
@@ -1,0 +1,129 @@
+/**
+ * The label-variant detector, tested against the REAL pairs a curator merged
+ * by hand on 2026-08-23 (somm ticket e9b346ba) and the ones they explicitly
+ * ruled out. Every "should match" case below is a duplicate that actually
+ * existed in the production registry; every "must not" is a pair of genuinely
+ * different wines that a naive rule would have destroyed.
+ *
+ * Why a bespoke detector at all: all 17 merged pairs scored BELOW 0.85 on the
+ * existing fuzzy scorer — the floor of even the "did you mean?" soft zone —
+ * spread 0.58 to 0.85. No threshold change could reach them without folding
+ * unrelated wines together.
+ */
+const { isLabelVariant, reduceName, grapeTokenSet } = require('./labelVariantMatch');
+
+// Stand-in taxonomy: the varieties these fixtures actually name.
+const FORMS = [
+  'cabernet sauvignon', 'cabernet franc', 'shiraz', 'syrah', 'chardonnay',
+  'grenache', 'malbec', 'tempranillo', 'garnacha', 'pinot noir', 'pinot gris',
+  'riesling', 'pinot blanc', 'sangiovese', 'gewurztraminer',
+].map((form) => ({ form }));
+const G = grapeTokenSet(FORMS);
+
+const match = (a, b, ap, extra = {}) =>
+  isLabelVariant({ name: a, appellation: ap, ...extra.a }, { name: b, appellation: ap, ...extra.b }, G);
+
+describe('real duplicates from the 2026-08-23 curation sweep', () => {
+  test.each([
+    ['variety suffix', 'Bin 389', 'Bin 389 Cabernet Shiraz', null],
+    ['variety suffix, reversed argument order', 'Bin 407 Cabernet Sauvignon', 'Bin 407', null],
+    ['initialism plus variety', 'RWT', 'RWT Shiraz', null],
+    ['lowercase cuvée plus variety', 'pHat', 'pHat Chardonnay', null],
+    ['pure word order', 'Shiraz Cask 66', 'Cask 66 Shiraz', null],
+    ['word order around a tier word', 'Chardonnay Reserve', 'Reserve Chardonnay', null],
+    ['two-letter cuvée', 'LJ', 'LJ Shiraz', null],
+    ['variety PREFIX', 'Malbec Finca Altamira', 'Finca Altamira', null],
+    ['word order plus dropped variety', 'Marananga Bin 150', 'Bin 150 Marananga Shiraz', null],
+    ['old-vines prefix and variety', 'Kangarilla', 'Old Vines Grenache Kangarilla', 'Kangarilla'],
+    ['old-vines with variety on both', 'Kangarilla Grenache', 'Old Vines Grenache Kangarilla', 'Kangarilla'],
+    ['multi-word vineyard, old-vines', 'Blewitt Springs Grenache', 'Old Vines Blewitt Springs Grenache', 'Blewitt Springs'],
+    ['variety suffix with appellation set', 'El Cuidador', 'El Cuidador Tempranillo', 'Rioja'],
+  ])('%s: "%s" is "%s"', (_label, a, b, ap) => {
+    expect(match(a, b, ap).match).toBe(true);
+  });
+});
+
+describe('the guard: a range bottled in several varietals is NOT a duplicate', () => {
+  // Each of these was raised by a token-set scan and ruled out by the curator.
+  test.each([
+    ['Q Cabernet Franc', 'Q Malbec'],
+    ['Ghost Town Syrah', 'Ghost Town Pinot Noir'],
+    ['Halbstuck Riesling', 'Halbstuck Pinot Blanc'],
+  ])('"%s" vs "%s" — each names a DIFFERENT variety', (a, b) => {
+    const v = match(a, b, null);
+    expect(v.match).toBe(false);
+    expect(v.reason).toMatch(/different variety/);
+  });
+
+  test('a name that is ONLY a variety has nothing identifying left', () => {
+    const v = match('Chardonnay', 'Shiraz', null);
+    expect(v.match).toBe(false);
+    expect(v.reason).toMatch(/no identifying tokens/);
+  });
+
+  test('stored grape lists that disagree veto a name match', () => {
+    const v = isLabelVariant(
+      { name: 'Cuvee One', grapes: ['aaa'] },
+      { name: 'Cuvee One', grapes: ['bbb'] },
+      G
+    );
+    expect(v.match).toBe(false);
+    expect(v.reason).toMatch(/grape lists disagree/);
+  });
+
+  test('a missing grape list is silence, not disagreement', () => {
+    expect(isLabelVariant({ name: 'RWT' }, { name: 'RWT Shiraz', grapes: ['aaa'] }, G).match).toBe(true);
+  });
+
+  test('genuinely different cuvées of one producer stay apart', () => {
+    expect(match('Bin 389', 'Bin 407', null).match).toBe(false);
+    expect(match('Brut', 'Brut Rose', null).match).toBe(false);
+    expect(match('Cies', 'Cies Tinto', null).match).toBe(false);
+  });
+});
+
+describe('the documented non-goal: a dropped vineyard token', () => {
+  // Penfolds labelled this "Kalimna Bin 28" for decades, then simplified to
+  // "Bin 28 Shiraz". It IS the same wine — and this detector must NOT claim
+  // it, because vineyard names cannot join the strip list: for Clarendon
+  // Hills the vineyard IS the wine, so stripping site names would collapse
+  // Kangarilla, Blewitt Springs and Brookman into one row. Curator territory.
+  test('"Kalimna Bin 28" does not match "Bin 28 Shiraz" — by design', () => {
+    expect(match('Kalimna Bin 28', 'Bin 28 Shiraz', null).match).toBe(false);
+  });
+
+  test('…and the reason it cannot be fixed by stripping sites: Clarendon Hills still separate', () => {
+    // If vineyard tokens were stripped, these three would collapse together.
+    expect(match('Kangarilla', 'Blewitt Springs', null).match).toBe(false);
+    expect(match('Kangarilla', 'Brookman', null).match).toBe(false);
+  });
+});
+
+describe('reduceName', () => {
+  test('drops varieties and label furniture, keeps identity', () => {
+    const r = reduceName('Old Vines Grenache Kangarilla', { grapeTokens: G });
+    expect([...r.core]).toEqual(['kangarilla']);
+    expect([...r.varieties]).toEqual(['grenache']);
+  });
+
+  test('strips appellation tokens repeated inside the name', () => {
+    const r = reduceName('Margaux Reserve', { grapeTokens: G, appellation: 'Margaux' });
+    expect([...r.core]).toEqual(['reserve']);
+  });
+
+  test('…but keeps them when the appellation is ALL the name has', () => {
+    // Clarendon Hills: name and appellation are both the vineyard. Stripping
+    // would leave nothing and break the pair the detector exists for.
+    const r = reduceName('Kangarilla', { grapeTokens: G, appellation: 'Kangarilla' });
+    expect([...r.core]).toEqual(['kangarilla']);
+  });
+
+  test('short tokens survive — a two-letter cuvée is not a variety fragment', () => {
+    expect([...reduceName('LJ Shiraz', { grapeTokens: G }).core]).toEqual(['lj']);
+    expect([...reduceName('MC Shiraz', { grapeTokens: G }).core]).toEqual(['mc']);
+  });
+
+  test('accents and punctuation fold', () => {
+    expect([...reduceName('Château Bel-Air', { grapeTokens: G }).core].sort()).toEqual(['air', 'bel', 'chateau']);
+  });
+});

--- a/backend/src/services/labelVariantMatch.test.js
+++ b/backend/src/services/labelVariantMatch.test.js
@@ -123,7 +123,10 @@ describe('reduceName', () => {
     expect([...reduceName('MC Shiraz', { grapeTokens: G }).core]).toEqual(['mc']);
   });
 
-  test('accents and punctuation fold', () => {
-    expect([...reduceName('Château Bel-Air', { grapeTokens: G }).core].sort()).toEqual(['air', 'bel', 'chateau']);
+  test('accents fold and a hyphen joins rather than splits', () => {
+    // normalizeString is the registry-wide fold: "Bel-Air" becomes one token
+    // "belair", not two. That is what every other identity comparison sees,
+    // so the detector inherits it rather than re-deciding punctuation.
+    expect([...reduceName('Château Bel-Air', { grapeTokens: G }).core].sort()).toEqual(['belair', 'chateau']);
   });
 });


### PR DESCRIPTION
Somm ticket `e9b346ba`. One import file carried the same wine repeatedly under variant names and nothing collided. A curator merged **23 duplicate pairs by hand** in a day.

## Measured first — the obvious fix was wrong

I scored the 17 pairs that curator merged against the live scorer. **Every one landed below 0.85** — the floor of even the "did you mean?" soft zone:

| pair | score |
|---|---|
| Bin 389 / Bin 389 Cabernet Shiraz | 0.717 |
| RWT / RWT Shiraz | 0.721 |
| pHat / pHat Chardonnay | 0.708 |
| Kangarilla / Old Vines Grenache Kangarilla | 0.689 |
| Grand Cru Classé / Château Talbot | 0.584 |

**No threshold change could reach them** — catching the worst means ~0.58, which folds unrelated wines together. The signal must come from normalising *before* comparing.

## The detector

Reduce a name to identifying tokens (drop varieties from the live taxonomy, label furniture, the row's own appellation tokens), compare as a **set** so word order stops mattering. Covers all four automatable transformations the curator identified.

**The guard makes it safe.** Set-equality alone would merge a varietal range — Zuccardi "Q Cabernet Franc" and "Q Malbec" both reduce to `q`. The curator's rule decides: differing named varieties = two wines; variety on one side only = one wine twice. Disjoint variety sets are a hard reject, and disagreeing stored grape lists veto outright.

It runs last before minting and only ever **links** — never merges, never deletes. A wrong link is recoverable; the absence of the check is the duplicate registry.

## Deliberate non-goal

A vineyard token dropped from a later label (Penfolds `Kalimna Bin 28` → `Bin 28 Shiraz`). Vineyard names **cannot** be stripped — for Clarendon Hills the vineyard *is* the wine (Kangarilla, Blewitt Springs, Brookman are separate wines). A rule that fixes Penfolds breaks Clarendon Hills. **Tested as a non-goal** so nobody later "completes" the set.

## Verification

21 assertions verified directly with node (13 real duplicates caught, 8 rule-outs rejected). **Backend suite not run locally** — Docker's engine is 500ing here; CI is the gate.