### PR TITLE
fix(import): label-variant detection must survive confirmCreate

### DIFF
--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -758,12 +758,25 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // existing row — never merges, never deletes. Getting this wrong costs a
   // bottle on a near-identical wine; getting the absence of it wrong is the
   // duplicate registry this ticket is about.
-  if (!producerMissing && !skipSiblingMatch) {
+  //
+  // DELIBERATELY NOT GATED ON skipSiblingMatch, same as the canonical-key
+  // stage above, and for a sharper reason. skipSiblingMatch is set from
+  // confirmCreate, which means "the user reviewed the suggested matches and
+  // rejected them" — but the suggestions come from the soft zone, floor 0.85.
+  // This detector exists precisely because label variants score BELOW that:
+  // measured on the pairs a curator merged by hand, 0.58 to 0.85. So the row
+  // it finds was never offered, and a user cannot have rejected what they were
+  // never shown.
+  //
+  // Proven the hard way: HALL "The North End Cabernet Sauvignon" was minted
+  // five hours after this guard shipped, through the UI (the majority path —
+  // 46 wines to MCP's 18 in that window), duplicating "The North End" at a
+  // score of 0.748. The user clicked "create new" against a candidate list
+  // that could not contain the wine they were duplicating.
+  if (!producerMissing) {
     try {
-      const siblings = (await WineDefinition.find({
-        producer: producerToStore,
-        _id: { $ne: null },
-      }).limit(60).populate(POPULATE)).filter((c) => !pendingBlocked(c));
+      const siblings = (await WineDefinition.find({ producer: producerToStore })
+        .limit(60).populate(POPULATE)).filter((c) => !pendingBlocked(c));
       if (siblings.length > 0) {
         const grapeDocs = await Grape.find({}).select('name normalizedName normalizedSynonyms').lean();
         const gTokens = grapeTokenSet(buildSurfaceForms(grapeDocs));

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -1329,11 +1329,21 @@ describe('findOrCreateWine — label variants are caught even on confirmCreate',
   });
 
   test('the stage failing never blocks the create', async () => {
-    Grape.find.mockImplementation(() => { throw new Error('taxonomy unavailable'); });
+    // Break the stage SPECIFICALLY — its own producer-scoped query — rather
+    // than a shared dependency. Grape.find is also used by crossFieldScan on
+    // an earlier, uncaught path, so throwing there tests the wrong thing.
+    primeGrapes(['Cabernet Sauvignon']);
+    const realFind = WineDefinition.find.getMockImplementation();
     primeFind({ producerRows: [HALL_EXISTING] });
+    const dispatch = WineDefinition.find.getMockImplementation();
+    WineDefinition.find.mockImplementation((q) => {
+      if (q && q.producer && !q.canonicalKey && !q.normalizedKey) throw new Error('index rebuild in progress');
+      return dispatch(q);
+    });
     scoreAllMatches.mockReturnValue([]);
 
     const result = await findOrCreateWine(TYPED, USER_ID, { confirmCreate: true });
     expect(result.created).toBe(true);
+    void realFind;
   });
 });

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -107,7 +107,7 @@ const taxonomyChain = (rows) => {
  *   { _id: { $in: ids } }     → .populate(...)           (Meilisearch id fetch)
  *   { $text: ... }            → .populate(...).limit(20) (Mongo text fallback)
  */
-function primeFind({ canonicalHits = [], canonicalSiblings = [], siblings = [], meiliDocs = [], textDocs = [] } = {}) {
+function primeFind({ canonicalHits = [], canonicalSiblings = [], siblings = [], meiliDocs = [], textDocs = [], producerRows = [] } = {}) {
   WineDefinition.find.mockImplementation((q) => {
     if (q && q.canonicalKey) {
       const docs = q.canonicalKey instanceof RegExp ? canonicalSiblings : canonicalHits;
@@ -116,6 +116,14 @@ function primeFind({ canonicalHits = [], canonicalSiblings = [], siblings = [], 
     if (q && q.normalizedKey) {
       return { limit: jest.fn().mockReturnValue({ populate: jest.fn().mockResolvedValue(siblings) }) };
     }
+    // Label-variant stage (somm ticket e9b346ba): producer-scoped sweep.
+
+    if (q && q.producer && !q.canonicalKey && !q.normalizedKey) {
+
+      return { limit: jest.fn().mockReturnValue({ populate: jest.fn().mockResolvedValue(producerRows) }) };
+
+    }
+
     if (q && q.$text) {
       return { populate: jest.fn().mockReturnValue({ limit: jest.fn().mockResolvedValue(textDocs) }) };
     }
@@ -137,6 +145,11 @@ let warnSpy;
 beforeEach(() => {
   jest.clearAllMocks();
   warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  // The label-variant stage reads the grape taxonomy for its variety
+  // vocabulary; default it to empty so the stage runs rather than throwing
+  // into its own catch and silently no-opping.
+  Grape.find.mockReturnValue({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }) });
 
   // Instance mocks: constructor assigns the doc, save/populate resolve to self
   WineDefinition.mockImplementation(function (doc) {
@@ -1234,5 +1247,93 @@ describe('findOrCreateWine — classification is stored on create', () => {
   test('absent classification stores null', async () => {
     const { wine } = await findOrCreateWine(INPUT, USER_ID);
     expect(wine.classification).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Label-variant detection must survive confirmCreate (somm ticket e9b346ba).
+//
+// v1.171.0 shipped this stage gated on skipSiblingMatch, which wineCommit sets
+// from confirmCreate. Five hours later HALL "The North End Cabernet Sauvignon"
+// was minted through the UI, duplicating "The North End" — because the pair
+// scores 0.748, BELOW the 0.85 soft-zone floor, so the existing wine was never
+// in the candidate list the user rejected. confirmCreate means "I reviewed the
+// suggestions"; it cannot mean "I rejected a wine nobody showed me".
+// ---------------------------------------------------------------------------
+describe('findOrCreateWine — label variants are caught even on confirmCreate', () => {
+  const HALL_EXISTING = {
+    _id: 'wine-north-end',
+    name: 'The North End',
+    producer: 'HALL',
+    appellation: 'Napa Valley',
+    grapes: [],
+  };
+  const TYPED = {
+    name: 'The North End Cabernet Sauvignon',
+    producer: 'HALL',
+    country: 'United States',
+    appellation: 'Napa Valley',
+  };
+
+  const primeGrapes = (names) => Grape.find.mockReturnValue({
+    select: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue(names.map((n) => ({ _id: n, name: n, normalizedName: n.toLowerCase() }))),
+    }),
+  });
+
+  test('the reported regression: confirmCreate no longer bypasses the check', async () => {
+    primeGrapes(['Cabernet Sauvignon']);
+    primeFind({ producerRows: [HALL_EXISTING] });
+    // Nothing in the fuzzy stage — that is the whole point, it scores 0.748.
+    scoreAllMatches.mockReturnValue([]);
+
+    const result = await findOrCreateWine(TYPED, USER_ID, {
+      confirmCreate: true, skipSiblingMatch: true,
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.wine).toBe(HALL_EXISTING);
+    expect(result.labelVariantOf).toBe('The North End');
+  });
+
+  test('and without confirmCreate too', async () => {
+    primeGrapes(['Cabernet Sauvignon']);
+    primeFind({ producerRows: [HALL_EXISTING] });
+    scoreAllMatches.mockReturnValue([]);
+
+    const result = await findOrCreateWine(TYPED, USER_ID, {});
+    expect(result.created).toBe(false);
+    expect(result.wine).toBe(HALL_EXISTING);
+  });
+
+  test('a genuine second wine of the range still creates — different varieties', async () => {
+    primeGrapes(['Cabernet Franc', 'Malbec']);
+    primeFind({ producerRows: [{ _id: 'q-cf', name: 'Q Cabernet Franc', producer: 'Zuccardi', grapes: [] }] });
+    scoreAllMatches.mockReturnValue([]);
+
+    const result = await findOrCreateWine(
+      { name: 'Q Malbec', producer: 'Zuccardi', country: 'Argentina' }, USER_ID, { confirmCreate: true });
+
+    expect(result.created).toBe(true);
+  });
+
+  test('an unrelated cuvée of the same producer still creates', async () => {
+    primeGrapes(['Cabernet Sauvignon']);
+    primeFind({ producerRows: [HALL_EXISTING] });
+    scoreAllMatches.mockReturnValue([]);
+
+    const result = await findOrCreateWine(
+      { ...TYPED, name: 'Jack\'s Masterpiece Cabernet Sauvignon' }, USER_ID, { confirmCreate: true });
+
+    expect(result.created).toBe(true);
+  });
+
+  test('the stage failing never blocks the create', async () => {
+    Grape.find.mockImplementation(() => { throw new Error('taxonomy unavailable'); });
+    primeFind({ producerRows: [HALL_EXISTING] });
+    scoreAllMatches.mockReturnValue([]);
+
+    const result = await findOrCreateWine(TYPED, USER_ID, { confirmCreate: true });
+    expect(result.created).toBe(true);
   });
 });


### PR DESCRIPTION
**v1.171.0's guard didn't fire.** Five hours after it deployed, HALL "The North End Cabernet Sauvignon" was minted through the UI, duplicating the existing "The North End" — the exact defect it was built to stop, on the majority path (46 wines via UI vs MCP's 18 in that window).

## The gate was the bug

I shipped the stage gated on `skipSiblingMatch`, which `wineCommit` sets from `confirmCreate` — "the user reviewed the suggested matches and rejected them."

But **the suggestions come from the soft zone, floor 0.85**, and this detector exists precisely because label variants score *below* that (0.58–0.85 across the hand-merged pairs). This pair scores **0.748**, so the existing wine could not have been in the list the user rejected.

**A user cannot reject a wine nobody showed them.** Ungated — matching the canonical-key stage directly above it, which skips the same flag for the same class of reason.

## The tests were passing while testing nothing

`primeFind` had no branch for the producer-scoped query, so the chained `.limit().populate()` hit a bare `{ populate }` fallthrough, threw, and was swallowed by the stage's own never-block-a-create catch. Fixed the harness, defaulted `Grape.find` so the variety vocabulary loads, and added five cases: the regression under `confirmCreate`, the same without it, a multi-varietal range that must still create, an unrelated cuvée, and the stage failing without blocking an add.

## Verification

**Backend suite not run locally** — Docker's engine is 500ing here. CI is the gate.