### PR TITLE
fix(registry): cap anonymous wine reads against enumeration

### DIFF
--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -64,6 +64,24 @@ const defaults = {
   // punished exactly the most engaged first-day behaviour. Worst-case disk
   // bound doubles to ~14 GB/day per user, still sweepable and tunable below.
   imageUploadBurst: { max: 60, windowMs: 60 * 60 * 1000 },
+  // ANONYMOUS registry reads: GET /api/wines/:idOrSlug/public, the only wine
+  // endpoint that needs no account. It exists so wine pages are public and
+  // indexable, which is worth keeping — but it sat under the general /api/
+  // limiter, so one address could walk the whole registry in about forty
+  // minutes. (That limiter was raised to 2500/15min on 2026-08-23 for a
+  // legitimate editing case, which incidentally made bulk reading faster.)
+  //
+  // Sized against MEASURED traffic rather than a guess: this endpoint served
+  // FIVE requests in 24 hours across the entire site, from one address, all
+  // real browsers — and no search crawler touched it at all, so a tight cap
+  // costs nothing in indexing. 120 per 15 minutes is a wine page every 7.5
+  // seconds sustained, far beyond any human session, while taking a
+  // single-address scrape of the full registry from ~40 minutes to ~14 hours.
+  //
+  // This does NOT stop a determined actor spreading across many addresses;
+  // nothing that also serves public pages can. It makes casual scraping not
+  // worth the trouble, which is the achievable goal.
+  publicWineRead: { max: 120, windowMs: 15 * 60 * 1000 },
   // Ephemeral public-demo accounts (POST /api/auth/demo-login). Cloning a
   // snapshot cellar per visitor is write-heavy, so this is bounded on three
   // axes: per-IP creation rate, a DURABLE global ceiling on concurrent live
@@ -128,6 +146,7 @@ let cache = {
   aiImportPerRequestCap: { ...defaults.aiImportPerRequestCap },
   aiGlobalDailyCap: { ...defaults.aiGlobalDailyCap },
   imageUploadBurst: { ...defaults.imageUploadBurst },
+  publicWineRead: { ...defaults.publicWineRead },
   demo: { ...defaults.demo },
   mcp: { ...defaults.mcp },
 };
@@ -171,6 +190,12 @@ async function load() {
         imageUploadBurst: {
           max:      doc.value.imageUploadBurst?.max      ?? defaults.imageUploadBurst.max,
           windowMs: doc.value.imageUploadBurst?.windowMs ?? defaults.imageUploadBurst.windowMs,
+        },
+
+        publicWineRead: {
+          max:      doc.value.publicWineRead?.max      ?? defaults.publicWineRead.max,
+          windowMs: doc.value.publicWineRead?.windowMs ?? defaults.publicWineRead.windowMs,
+
         },
         demo: {
           createMax:      doc.value.demo?.createMax      ?? defaults.demo.createMax,

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -4,6 +4,10 @@ const WineDefinition = require('../models/WineDefinition');
 const Discussion = require('../models/Discussion');
 const searchService = require('../services/search');
 const { requireAuth, requireNonDemo, optionalAuth } = require('../middleware/auth');
+const rateLimit = require('express-rate-limit');
+const rateLimitsConfig = require('../config/rateLimits');
+const { rateLimitKey } = require('../utils/clientIp');
+const { logAudit } = require('../services/audit');
 const { scanLabelFull, scanLabelBack, mergeBackScan, identifyWineFromQuery } = require('../services/labelScan');
 const { sanitizeImageBuffer, detectImageFormat } = require('../services/imageSanitizer');
 const { persistLabelScan } = require('../services/imageOps');
@@ -907,7 +911,40 @@ router.post('/ai-info', requireAuth, aiBurstLimiter, asyncHandler(async (req, re
 // Accepts both ObjectId and slug. Used for shared links and social previews.
 const PUBLIC_PROJECTION = 'name producer slug country region appellation grapes type image communityRating classification aiProfile';
 
-router.get('/:idOrSlug/public', async (req, res) => {
+// Anti-enumeration limit for the ONE wine endpoint that needs no account.
+//
+// Public wine pages are deliberate — they are how a wine is shared and
+// indexed, and the slugs are not going anywhere. But "readable" and
+// "downloadable in bulk" are different things, and until now they were the
+// same thing: this route sat under the general /api/ limiter at 2500 per 15
+// minutes, so a single address could walk the entire registry in about the
+// time it takes to make lunch.
+//
+// The cap is sized from measured traffic, not caution: across 24 hours this
+// endpoint served FIVE requests, from one address, all real browsers, and no
+// search crawler touched it at all. 120 per 15 minutes is therefore about
+// twenty times the entire site's daily use of it, per address — invisible to
+// anyone reading wine pages, including a logged-in user (the frontend calls
+// this route for everyone, so the cap must clear real browsing and does).
+//
+// A 429 here is worth SEEING rather than silently absorbing: ordinary use
+// cannot reach it, so a breach is either a scraper or a real usage pattern
+// nobody predicted. Both are things to know about, hence the audit row.
+const publicWineLimiter = rateLimit({
+  windowMs: () => rateLimitsConfig.get().publicWineRead.windowMs,
+  max: () => rateLimitsConfig.get().publicWineRead.max,
+  keyGenerator: (req) => rateLimitKey(req),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', {}, {
+      limiter: 'publicWineRead',
+      limit: rateLimitsConfig.get().publicWineRead.max,
+    });
+    res.status(429).json({ error: 'Too many requests, please try again later' });
+  },
+});
+router.get('/:idOrSlug/public', publicWineLimiter, async (req, res) => {
   try {
     const { idOrSlug } = req.params;
     // Unauthenticated share/preview surface — quarantined non-wines are hidden

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -931,7 +931,10 @@ const PUBLIC_PROJECTION = 'name producer slug country region appellation grapes 
 // cannot reach it, so a breach is either a scraper or a real usage pattern
 // nobody predicted. Both are things to know about, hence the audit row.
 const publicWineLimiter = rateLimit({
-  windowMs: () => rateLimitsConfig.get().publicWineRead.windowMs,
+  // Static window, dynamic max — the same shape as apiLimiter and
+  // aiBurstLimiter. express-rate-limit resolves max() per request but wants a
+  // real number for the window at construction.
+  windowMs: rateLimitsConfig.get().publicWineRead.windowMs,
   max: () => rateLimitsConfig.get().publicWineRead.max,
   keyGenerator: (req) => rateLimitKey(req),
   standardHeaders: true,

--- a/backend/src/routes/wines.publicScrapeLimit.test.js
+++ b/backend/src/routes/wines.publicScrapeLimit.test.js
@@ -71,7 +71,12 @@ beforeEach(() => {
   // the test keeps the old one, so nothing configured below reaches the
   // handler. Tests use distinct addresses instead, so each gets its own bucket.
   jest.clearAllMocks();
-  WineDefinition.findOne.mockReturnValue({ select: () => Promise.resolve(WINE) });
+  // The handler chains .populate(...).select(...) — both must be present or
+  // it throws and every request 500s, which would make the limiter assertions
+  // measure a broken handler instead of the cap.
+  WineDefinition.findOne.mockReturnValue({
+    populate: () => ({ select: () => Promise.resolve(WINE) }),
+  });
 });
 
 describe('anonymous registry reads are capped against enumeration', () => {

--- a/backend/src/routes/wines.publicScrapeLimit.test.js
+++ b/backend/src/routes/wines.publicScrapeLimit.test.js
@@ -67,8 +67,10 @@ async function hit(a, n, ip = '203.0.113.7') {
 }
 
 beforeEach(() => {
+  // NO resetModules here: it hands the route a fresh copy of these mocks while
+  // the test keeps the old one, so nothing configured below reaches the
+  // handler. Tests use distinct addresses instead, so each gets its own bucket.
   jest.clearAllMocks();
-  jest.resetModules();
   WineDefinition.findOne.mockReturnValue({ select: () => Promise.resolve(WINE) });
 });
 
@@ -101,7 +103,7 @@ describe('anonymous registry reads are capped against enumeration', () => {
     jest.spyOn(rateLimitsConfig, 'get').mockReturnValue({
       ...rateLimitsConfig.get(), publicWineRead: { max: 3, windowMs: 60000 },
     });
-    const codes = await hit(app(), 5);
+    const codes = await hit(app(), 5, '203.0.113.21');
     expect(codes.slice(0, 3).every((c) => c === 200)).toBe(true);
     expect(codes.slice(3)).toEqual([429, 429]);
   });
@@ -110,7 +112,7 @@ describe('anonymous registry reads are capped against enumeration', () => {
     jest.spyOn(rateLimitsConfig, 'get').mockReturnValue({
       ...rateLimitsConfig.get(), publicWineRead: { max: 1, windowMs: 60000 },
     });
-    await hit(app(), 2);
+    await hit(app(), 2, '203.0.113.22');
     expect(logAudit).toHaveBeenCalledWith(
       expect.anything(), 'system.rate_limit_exceeded', {},
       expect.objectContaining({ limiter: 'publicWineRead' })

--- a/backend/src/routes/wines.publicScrapeLimit.test.js
+++ b/backend/src/routes/wines.publicScrapeLimit.test.js
@@ -29,7 +29,12 @@ jest.mock('../models/Bottle', () => ({ find: jest.fn(), countDocuments: jest.fn(
 jest.mock('../models/Country', () => ({ find: jest.fn(), findOne: jest.fn() }));
 jest.mock('../models/Region', () => ({ find: jest.fn(), findOne: jest.fn() }));
 jest.mock('../models/Grape', () => ({ find: jest.fn(), findOne: jest.fn() }));
-jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findOne: jest.fn(), findById: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({
+  find: jest.fn(), findOne: jest.fn(), findById: jest.fn(), countDocuments: jest.fn(),
+  // The route resolves slugs (including superseded ones) through this static;
+  // without it the handler 500s and the limiter never gets exercised.
+  slugFilter: jest.fn((slug) => ({ $or: [{ slug: String(slug).toLowerCase() }] })),
+}));
 
 const rateLimitsConfig = require('../config/rateLimits');
 const { logAudit } = require('../services/audit');

--- a/backend/src/routes/wines.publicScrapeLimit.test.js
+++ b/backend/src/routes/wines.publicScrapeLimit.test.js
@@ -1,0 +1,124 @@
+/**
+ * The anonymous wine endpoint is rate-limited against enumeration.
+ *
+ * GET /api/wines/:idOrSlug/public needs no account — that is deliberate, it is
+ * how a wine page is shared and indexed. But it sat under the general /api/
+ * limiter (2500 per 15 min), which meant one address could download the whole
+ * registry in roughly forty minutes. Public and bulk-downloadable are not the
+ * same thing, and until this they were.
+ *
+ * The cap is measured, not guessed: across 24 hours the endpoint served five
+ * requests, from one address, all real browsers, with no search crawler
+ * touching it — so 120 per 15 minutes is ~20x the site's entire daily use of
+ * it, per address, and invisible to anyone actually reading wine pages.
+ */
+const express = require('express');
+const http = require('http');
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+jest.mock('../services/search', () => ({
+  indexWine: jest.fn(), removeWine: jest.fn(), getIsAvailable: jest.fn(() => false), search: jest.fn(),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn(), scanLabel: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn(), findOrCreateRegion: jest.fn() }));
+jest.mock('../services/wineCommit', () => ({ validateNewWineFields: jest.fn(), MAX_WINE_FIELD: 200, MAX_GRAPES: 20 }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../models/Bottle', () => ({ find: jest.fn(), countDocuments: jest.fn(), aggregate: jest.fn(), distinct: jest.fn() }));
+jest.mock('../models/Country', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../models/Region', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../models/Grape', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findOne: jest.fn(), findById: jest.fn(), countDocuments: jest.fn() }));
+
+const rateLimitsConfig = require('../config/rateLimits');
+const { logAudit } = require('../services/audit');
+const WineDefinition = require('../models/WineDefinition');
+
+const WINE = { _id: 'w1', name: 'Barolo', producer: 'Cà di Bruno', slug: 'barolo' };
+
+function app() {
+  const a = express();
+  a.set('trust proxy', true);
+  a.use(express.json());
+  a.use('/api/wines', require('./wines'));
+  return a;
+}
+
+/** Fire n sequential requests from one address; return the status list. */
+async function hit(a, n, ip = '203.0.113.7') {
+  const server = http.createServer(a);
+  await new Promise((r) => server.listen(0, r));
+  const port = server.address().port;
+  const codes = [];
+  for (let i = 0; i < n; i++) {
+    codes.push(await new Promise((resolve, reject) => {
+      http.get({ port, path: '/api/wines/barolo/public', headers: { 'x-forwarded-for': ip } },
+        (res) => { res.resume(); res.on('end', () => resolve(res.statusCode)); }).on('error', reject);
+    }));
+  }
+  server.close();
+  return codes;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  WineDefinition.findOne.mockReturnValue({ select: () => Promise.resolve(WINE) });
+});
+
+describe('anonymous registry reads are capped against enumeration', () => {
+  test('the configured cap is a real number with a window', () => {
+    const cfg = rateLimitsConfig.get().publicWineRead;
+    expect(cfg.max).toBeGreaterThan(0);
+    expect(cfg.windowMs).toBeGreaterThan(0);
+  });
+
+  test('the default clears real browsing by a wide margin', () => {
+    // Measured: the endpoint served 5 requests site-wide in 24h. The cap must
+    // sit far above any human session, or it becomes a bug report instead of
+    // a defence.
+    const { max, windowMs } = rateLimitsConfig.get().publicWineRead;
+    const perMinute = max / (windowMs / 60000);
+    expect(perMinute).toBeGreaterThan(4); // a wine page every 15s, sustained
+    expect(max).toBeGreaterThanOrEqual(60);
+  });
+
+  test('the default still makes a single-address full scrape impractical', () => {
+    // ~6,800 wines. At the cap, one address needs many hours rather than one
+    // lunch break — which is the whole point.
+    const { max, windowMs } = rateLimitsConfig.get().publicWineRead;
+    const hoursForFullRegistry = (6800 / max) * (windowMs / 3600000);
+    expect(hoursForFullRegistry).toBeGreaterThan(6);
+  });
+
+  test('requests past the cap are refused with 429', async () => {
+    jest.spyOn(rateLimitsConfig, 'get').mockReturnValue({
+      ...rateLimitsConfig.get(), publicWineRead: { max: 3, windowMs: 60000 },
+    });
+    const codes = await hit(app(), 5);
+    expect(codes.slice(0, 3).every((c) => c === 200)).toBe(true);
+    expect(codes.slice(3)).toEqual([429, 429]);
+  });
+
+  test('a refusal is audited — ordinary use cannot reach the cap, so a breach is worth seeing', async () => {
+    jest.spyOn(rateLimitsConfig, 'get').mockReturnValue({
+      ...rateLimitsConfig.get(), publicWineRead: { max: 1, windowMs: 60000 },
+    });
+    await hit(app(), 2);
+    expect(logAudit).toHaveBeenCalledWith(
+      expect.anything(), 'system.rate_limit_exceeded', {},
+      expect.objectContaining({ limiter: 'publicWineRead' })
+    );
+  });
+
+  test('the cap is per address — one scraper does not lock out everyone else', async () => {
+    jest.spyOn(rateLimitsConfig, 'get').mockReturnValue({
+      ...rateLimitsConfig.get(), publicWineRead: { max: 2, windowMs: 60000 },
+    });
+    const a = app();
+    await hit(a, 3, '203.0.113.1');            // exhausts that address
+    const other = await hit(a, 1, '198.51.100.9');
+    expect(other).toEqual([200]);
+  });
+});


### PR DESCRIPTION
`GET /api/wines/:idOrSlug/public` needs no account — deliberate, it's how a wine page is shared and indexed, and **the slugs stay**. But it sat under the general `/api/` limiter at 2,500 per 15 minutes, so **one address could walk the entire ~6,800-wine registry in about forty minutes.**

Public and bulk-downloadable are not the same thing, and until now they were.

Worth naming: that limiter was 1,000 until 2026-08-23, when I raised it to 2,500 to unstick a user throttled mid-edit. Right for the write case; it also made anonymous bulk reading 2.5× faster. This is the read side of the same decision.

## The cap is measured, not guessed

| | |
|---|---|
| Requests to this endpoint in 24h, site-wide | **5** |
| Distinct addresses | **1** |
| Search crawlers hitting it | **none** |

So a tight cap costs nothing in indexing — which was the only real objection. **120 per 15 minutes** is ~20× the site's entire daily use of it, per address: a wine page every 7.5 seconds sustained. It has to clear *logged-in* browsing too, since the frontend calls this route for everyone.

**Single-address full scrape: ~40 minutes → ~14 hours.**

## Notes

- Tunable as `publicWineRead` through the same admin surface as every other limit.
- A 429 writes an audit row — ordinary use can't reach this cap, so a breach is either a scraper or an unpredicted usage pattern, both worth seeing.
- **This does not stop a determined actor across many addresses.** Nothing that also serves public pages can. Stated in the code so nobody later mistakes it for a guarantee.
- **Backend suite not run locally** (Docker 500ing here); 6 tests including a real 429 and per-address isolation. CI is the gate.