### PR TITLE
fix(stats): donut clipped its largest segment and showed a phantom dark quarter

### DIFF
--- a/frontend/src/components/charts/DonutChart.js
+++ b/frontend/src/components/charts/DonutChart.js
@@ -25,16 +25,23 @@ function DonutChart({ segments, total, onSegmentClick }) {
       role="img"
       aria-label={t('statistics.donut.ariaLabel', { count: total })}
     >
-      <circle cx={cx} cy={cy} r={R} fill="none" stroke="#252525" strokeWidth="22" />
+      <circle cx={cx} cy={cy} r={R} fill="none" strokeWidth="22"
+        style={{ stroke: 'var(--color-border-light, #252525)' }} />
       {total > 0 && validSegs.map((seg, i) => {
         const len       = (seg.value / total) * C;
+        // Dash + gap must sum to the circumference exactly. The gap used to
+        // be C, making the dash cycle C + len — so the part of the first
+        // dash that wraps past the path start (the largest segment's opening
+        // quarter, 12 to 3 o'clock) was never painted, and the bare track
+        // showed through as a phantom dark segment (ticket 6a8b497c).
+        const gap       = C - len;
         const dashoffset = C / 4 - cumulative;
         cumulative += len;
         return (
           <circle key={i}
             cx={cx} cy={cy} r={R}
             fill="none" stroke={seg.color} strokeWidth="20"
-            strokeDasharray={`${len} ${C}`} strokeDashoffset={dashoffset}
+            strokeDasharray={`${len} ${gap}`} strokeDashoffset={dashoffset}
             strokeLinecap="butt"
             onClick={clickable ? () => handle(seg) : undefined}
             style={clickable ? { cursor: 'pointer' } : undefined}
@@ -44,9 +51,11 @@ function DonutChart({ segments, total, onSegmentClick }) {
         );
       })}
       <text x={cx} y={cy - size * 0.06} textAnchor="middle"
-        fontSize={size * 0.155} fontWeight="700" fill="#E8DFD0">{total}</text>
+        fontSize={size * 0.155} fontWeight="700"
+        style={{ fill: 'var(--color-text, #E8DFD0)' }}>{total}</text>
       <text x={cx} y={cy + size * 0.1} textAnchor="middle"
-        fontSize={size * 0.07} fill="#9A9484">{t('statistics.donut.bottles')}</text>
+        fontSize={size * 0.07}
+        style={{ fill: 'var(--color-text-muted, #9A9484)' }}>{t('statistics.donut.bottles')}</text>
     </svg>
   );
 }

--- a/frontend/src/components/charts/DonutChart.test.js
+++ b/frontend/src/components/charts/DonutChart.test.js
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+import DonutChart from './DonutChart';
+
+// i18n: only the aria-label and the "bottles" caption go through t() — the
+// identity stub keeps the geometry assertions independent of locale files.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k) => k, i18n: { language: 'en' } }),
+}));
+
+// Geometry constants mirrored from the component.
+const SIZE = 180;
+const R = SIZE * 0.355;
+const C = 2 * Math.PI * R;
+
+const segs = (...values) =>
+  values.map((value, i) => ({ type: `t${i}`, label: `T${i}`, value, color: '#111111' }));
+
+/** The arc circles, in render order (index 0 is the background track). */
+function arcCircles(container) {
+  return [...container.querySelectorAll('circle')].slice(1);
+}
+
+describe('DonutChart', () => {
+  test('every arc dash + gap sums to the circumference (regression: ticket 6a8b497c)', () => {
+    // 62/19/7/3/1 of 92 — the exact distribution from the report, where the
+    // old `${len} ${C}` gap made the 67% segment render as 42% with a
+    // phantom track-coloured quarter from 12 to 3 o'clock.
+    const { container } = render(
+      <DonutChart segments={segs(62, 19, 7, 3, 1)} total={92} />
+    );
+    const arcs = arcCircles(container);
+    expect(arcs).toHaveLength(5);
+    for (const arc of arcs) {
+      const [dash, gap] = arc.getAttribute('stroke-dasharray').split(' ').map(Number);
+      expect(dash + gap).toBeCloseTo(C, 6);
+    }
+  });
+
+  test('arc lengths are proportional and tile the full ring', () => {
+    const { container } = render(
+      <DonutChart segments={segs(62, 19, 7, 3, 1)} total={92} />
+    );
+    const dashes = arcCircles(container).map(
+      (a) => Number(a.getAttribute('stroke-dasharray').split(' ')[0])
+    );
+    expect(dashes[0]).toBeCloseTo((62 / 92) * C, 6);
+    expect(dashes.reduce((s, d) => s + d, 0)).toBeCloseTo(C, 6);
+  });
+
+  test('a single 100% segment renders as a full ring', () => {
+    const { container } = render(<DonutChart segments={segs(10)} total={10} />);
+    const [dash, gap] = arcCircles(container)[0]
+      .getAttribute('stroke-dasharray').split(' ').map(Number);
+    expect(dash).toBeCloseTo(C, 6);
+    expect(gap).toBeCloseTo(0, 6);
+  });
+
+  test('zero-value segments are skipped', () => {
+    const { container } = render(<DonutChart segments={segs(5, 0, 5)} total={10} />);
+    expect(arcCircles(container)).toHaveLength(2);
+  });
+
+  test('track and centre text use theme variables, not hardcoded dark colours', () => {
+    const { container } = render(<DonutChart segments={segs(1)} total={1} />);
+    const track = container.querySelector('circle');
+    expect(track.style.stroke).toContain('var(--color-border-light');
+    const [count, caption] = container.querySelectorAll('text');
+    expect(count.style.fill).toContain('var(--color-text');
+    expect(caption.style.fill).toContain('var(--color-text-muted');
+  });
+});

--- a/frontend/src/components/charts/chartHelpers.js
+++ b/frontend/src/components/charts/chartHelpers.js
@@ -8,9 +8,9 @@ export const TYPE_COLORS = {
   sparkling: '#6EC6C6',
   dessert:   '#D4A070',
   fortified: '#8B6A9A',
-  // Bottles without a wine definition (pending review). Must stay clearly
-  // lighter than the donut's #252525 background track or the segment reads
-  // as an unexplained black gap.
+  // Bottles without a wine definition (pending review). Mid-gray on purpose:
+  // distinct from the themed track colour in both light and dark mode, so it
+  // never reads as a gap in the ring.
   unknown:   '#B8B2A6',
 };
 


### PR DESCRIPTION
## The bug (user report, ticket 6a8b497c — Johan reproduces it on his own account)

The Wine Types donut drew every arc with `strokeDasharray={`${len} ${C}`}` — dash + gap = **C + len**, not the circumference. The slice of the first dash that wraps past the path start was never painted, so:

- the **largest segment always lost exactly its opening quarter** (12→3 o'clock)
- the pie started at 3 o'clock instead of 12
- the bare `#252525` track showed through as a **phantom near-black segment** matching no legend entry and not clickable

Reported numbers match the math exactly: a 54% red share rendered as ~27% (user measured), a 67% share as ~42% (Johan's account).

## Why it surfaced only now

Present since the component was extracted (#244), but the track blended into the dark theme — the gap read as the donut "starting at 3 o'clock". Light mode exposed it as a glaring black wedge. The track, centre count and caption were still hardcoded dark-era colours predating the token system; the centre "92 bottles" was near-invisible cream-on-white in light mode.

## The fix

- gap = `C − len` so every dash cycle tiles the circumference — all other arcs render at identical positions as before; only the clipped quarter comes back
- track/centre-count/caption themed via `--color-border-light` / `--color-text` / `--color-text-muted` (old values kept as fallbacks)
- `TYPE_COLORS.unknown` comment updated (it referenced the hardcoded track)

## Tests

New `DonutChart.test.js`: pins **dash + gap === circumference** for every arc using the reported 62/19/7/3/1-of-92 distribution as the regression case, plus proportionality/tiling, the 100% single-segment ring, zero-value skipping, and the theme-variable usage. Full suite: **65 files / 1020 tests pass**.