### PR TITLE
feat(grapes): the wine's own name outranks a regional display mapping

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -273,6 +273,7 @@ router.get('/', async (req, res) => {
             const display = resolveGrapeDisplayName(g, {
               countryId: b.wineDefinition.country,
               regionId: b.wineDefinition.region,
+              wineName: b.wineDefinition.name,
             });
             if (display && display !== g?.name) names.push(display);
             return names;

--- a/backend/src/services/embedding.js
+++ b/backend/src/services/embedding.js
@@ -236,7 +236,7 @@ function buildEmbeddingText(wine, vintage) {
   const grapeNames = (wine.grapes || [])
     .filter(g => g && g.name)
     .map(g => {
-      const display = resolveGrapeDisplayName(g, { countryId: wine.country, regionId: wine.region });
+      const display = resolveGrapeDisplayName(g, { countryId: wine.country, regionId: wine.region, wineName: wine.name });
       return display && display !== g.name ? `${g.name} (${display})` : g.name;
     })
     .join(', ');

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -182,7 +182,7 @@ function wineGrapeSearchNames(wine) {
   for (const g of wine.grapes || []) {
     if (!g || !g.name) continue;
     names.push(g.name);
-    const display = resolveGrapeDisplayName(g, { countryId: wine.country, regionId: wine.region });
+    const display = resolveGrapeDisplayName(g, { countryId: wine.country, regionId: wine.region, wineName: wine.name });
     if (display && display !== g.name) names.push(display);
   }
   return names.join(', ');

--- a/backend/src/utils/grapeDisplay.js
+++ b/backend/src/utils/grapeDisplay.js
@@ -9,7 +9,31 @@
  * resolves the right one for a wine's own country/region at serialize time.
  * Display-only: nothing here writes, and matching typed input to a grape
  * stays the job of Grape.synonyms/normalizedSynonyms.
+ *
+ * THE WINE'S OWN NAME OUTRANKS ANY MAPPING (somm ticket 6a8c8a68, decided by
+ * Johan 2026-08-27). Australians write "Syrah" on a Shiraz-country label as a
+ * deliberate style signal — cool-climate, Rhône-leaning — so an Australia-wide
+ * "Shiraz" entry must NOT relabel a wine literally named "… Syrah". When the
+ * wine's name carries the canonical variety as whole words, the canonical is
+ * shown; the mapping applies only when the name says the regional form or
+ * names no variety at all (the somm's conservative option (b), generalized).
  */
+const { normalizeString } = require('./normalize');
+
+/**
+ * Does the wine's name carry `phrase` as whole words? Hyphens fold to spaces
+ * BEFORE normalizeString (which deletes punctuation outright — the same
+ * pre-fold normalizeAppellation uses), then padded-token containment on the
+ * case/diacritics-folded strings. So "Jaraman Syrah" and "Syrah-Grenache"
+ * both carry "Syrah", while "Petite Sirah" and "Syrahs" do not.
+ */
+function nameCarries(wineName, phrase) {
+  if (!wineName || !phrase) return false;
+  const fold = (s) => normalizeString(String(s).replace(/-/g, ' '));
+  const needle = fold(phrase);
+  if (!needle) return false;
+  return ` ${fold(wineName)} `.includes(` ${needle} `);
+}
 
 /**
  * String id of an ObjectId, hex string, or populated doc ({ _id }); null when
@@ -46,9 +70,12 @@ function idOf(value) {
  * @param {object} [ctx]
  * @param {*}      [ctx.countryId]      – wine's country (id, hex string, or populated doc)
  * @param {*}      [ctx.regionId]       – wine's region (id, hex string, or populated doc)
+ * @param {string} [ctx.wineName]       – wine's own name; when it carries the
+ *                                        canonical variety as whole words, the
+ *                                        canonical is kept over any mapping
  * @returns {string|null} the display name, or null when grape is missing
  */
-function resolveGrapeDisplayName(grape, { countryId, regionId } = {}) {
+function resolveGrapeDisplayName(grape, { countryId, regionId, wineName } = {}) {
   if (!grape) return null;
   const canonical = grape.name || null;
   const entries = Array.isArray(grape.regionalNames) ? grape.regionalNames : [];
@@ -59,19 +86,29 @@ function resolveGrapeDisplayName(grape, { countryId, regionId } = {}) {
   // Every entry carries a country, so a wine without one can never match.
   if (!wineCountry) return canonical;
 
+  let regionLevelMatch = null;
   let countryLevelMatch = null;
   for (const entry of entries) {
     if (!entry || typeof entry.name !== 'string' || !entry.name.trim()) continue;
     if (idOf(entry.country) !== wineCountry) continue;
     const entryRegion = idOf(entry.region);
     if (entryRegion) {
-      // Region-level entry: most specific — first hit wins outright.
-      if (wineRegion && entryRegion === wineRegion) return entry.name;
+      // Region-level entry: most specific — first hit wins.
+      if (wineRegion && entryRegion === wineRegion && !regionLevelMatch) {
+        regionLevelMatch = entry.name;
+      }
     } else if (!countryLevelMatch) {
       countryLevelMatch = entry.name;
     }
   }
-  return countryLevelMatch || canonical;
+  const resolved = regionLevelMatch || countryLevelMatch || canonical;
+  // The producer's own label beats the mapping — at BOTH levels: even a
+  // region-level entry must not relabel a wine literally named for the
+  // canonical variety (the Australian "Syrah" style signal, see header).
+  if (resolved !== canonical && canonical && nameCarries(wineName, canonical)) {
+    return canonical;
+  }
+  return resolved;
 }
 
 /**
@@ -93,7 +130,7 @@ function decorateGrapes(wine) {
   if (!wine) return wine;
   const out = typeof wine.toObject === 'function' ? wine.toObject() : { ...wine };
   if (!Array.isArray(out.grapes) || out.grapes.length === 0) return out;
-  const ctx = { countryId: out.country, regionId: out.region };
+  const ctx = { countryId: out.country, regionId: out.region, wineName: out.name };
   out.grapes = out.grapes.map((g) => {
     if (!g || typeof g !== 'object' || !g.name) return g; // unpopulated ref — leave untouched
     const plain = typeof g.toObject === 'function' ? g.toObject() : { ...g };

--- a/backend/src/utils/grapeDisplay.test.js
+++ b/backend/src/utils/grapeDisplay.test.js
@@ -167,3 +167,81 @@ describe('decorateGrapes', () => {
     expect(out.grapes[0].displayName).toBe('Tinta Roriz');
   });
 });
+
+/**
+ * The wine's own name outranks any mapping (somm ticket 6a8c8a68, decided
+ * 2026-08-27): Australians write "Syrah" on a label as a deliberate
+ * cool-climate style signal, so an Australia-wide "Shiraz" entry must never
+ * relabel a wine literally named for the canonical variety. The mapping
+ * applies when the name says the regional form or names no variety at all —
+ * the somm's conservative option (b), generalized to every variety.
+ */
+describe('resolveGrapeDisplayName – the wine name outranks the mapping', () => {
+  const AUSTRALIA = oid('1');
+  const BAROSSA = oid('2');
+  const syrah = (overrides = {}) => ({
+    _id: oid('3'),
+    name: 'Syrah',
+    regionalNames: [{ country: AUSTRALIA, region: null, name: 'Shiraz' }],
+    ...overrides,
+  });
+
+  test('applies when the wine name says the regional form', () => {
+    expect(resolveGrapeDisplayName(syrah(), {
+      countryId: AUSTRALIA, wineName: 'Jaraman Shiraz',
+    })).toBe('Shiraz');
+  });
+
+  test('applies when the wine name names no variety at all', () => {
+    expect(resolveGrapeDisplayName(syrah(), {
+      countryId: AUSTRALIA, wineName: 'Grange',
+    })).toBe('Shiraz');
+  });
+
+  test('suppressed when the wine name carries the canonical variety', () => {
+    expect(resolveGrapeDisplayName(syrah(), {
+      countryId: AUSTRALIA, wineName: 'The Factor Syrah',
+    })).toBe('Syrah');
+  });
+
+  test('whole words only: "Syrahs" and unrelated tokens do not suppress', () => {
+    expect(resolveGrapeDisplayName(syrah(), {
+      countryId: AUSTRALIA, wineName: 'Old Syrahs Block',
+    })).toBe('Shiraz');
+  });
+
+  test('hyphenated blend names still carry the variety ("Syrah-Grenache")', () => {
+    expect(resolveGrapeDisplayName(syrah(), {
+      countryId: AUSTRALIA, wineName: 'Estate Syrah-Grenache',
+    })).toBe('Syrah');
+  });
+
+  test('case- and diacritics-folded comparison', () => {
+    expect(resolveGrapeDisplayName(syrah(), {
+      countryId: AUSTRALIA, wineName: 'CUVÉE SYRAH RÉSERVE',
+    })).toBe('Syrah');
+  });
+
+  test('suppression also beats a REGION-level entry (the label always wins)', () => {
+    const grape = syrah({
+      regionalNames: [{ country: AUSTRALIA, region: BAROSSA, name: 'Shiraz' }],
+    });
+    expect(resolveGrapeDisplayName(grape, {
+      countryId: AUSTRALIA, regionId: BAROSSA, wineName: 'Single Vineyard Syrah',
+    })).toBe('Syrah');
+    // …and without the canonical in the name, the region entry still applies.
+    expect(resolveGrapeDisplayName(grape, {
+      countryId: AUSTRALIA, regionId: BAROSSA, wineName: 'Single Vineyard',
+    })).toBe('Shiraz');
+  });
+
+  test('no wineName in ctx keeps today\'s behaviour (mapping applies)', () => {
+    expect(resolveGrapeDisplayName(syrah(), { countryId: AUSTRALIA })).toBe('Shiraz');
+  });
+
+  test('decorateGrapes threads the wine\'s own name into the resolution', () => {
+    const base = { country: AUSTRALIA, grapes: [syrah()] };
+    expect(decorateGrapes({ ...base, name: 'The Factor Syrah' }).grapes[0].displayName).toBe('Syrah');
+    expect(decorateGrapes({ ...base, name: 'Jaraman Shiraz' }).grapes[0].displayName).toBe('Shiraz');
+  });
+});


### PR DESCRIPTION
## Why (somm ticket 6a8c8a68, decided 27 Aug)

The somm asked for Syrah→"Shiraz" display for Australia — the largest regional-name case yet — but flagged the trap themselves: Australians write **"Syrah" deliberately** as a cool-climate style signal, so a blanket country mapping would relabel exactly those wines. Their conservative option (b) needed resolver support; Johan approved building it.

## What

`resolveGrapeDisplayName` gains `ctx.wineName`: when the wine's own name carries the **canonical** variety as whole words, the canonical is kept over any mapping — at region level too, since the producer's label always wins. The mapping still applies when the name says the regional form or names no variety. Generalized to every variety, so Tinta Roriz / Aragonez / Tinta de Toro get the same protection for free.

Whole-word matching folds hyphens to spaces before `normalizeString` (which deletes punctuation outright), so "Syrah-Grenache" carries Syrah while "Petite Sirah" and "Syrahs" do not.

Threaded through every resolution surface: `decorateGrapes` (wine/bottle routes + MCP), the bottle search haystack, Meilisearch grape names, and embedding text.

## Embedding impact

Output only moves for wines that **both** match a mapping **and** carry the canonical in their own name — with today's mappings that is a handful of Toro rows at most, re-embedded incrementally by textHash as usual.

## Tests

10 new cases in `grapeDisplay.test.js` (apply/suppress/whole-word/hyphen/diacritics/region-level/ctx-absent/decorate threading). Affected suites green in node:20-alpine: **4 suites / 37 tests pass** (grapeDisplay, embedding.buildText, search.buildBottleDocument, bottles.grapeDisplay).

## Sequencing

The somm holds the Australia/South Africa Shiraz entries until this ships — applying them first would relabel the deliberate-Syrah bottlings. Tinta Roriz (unconditional) is already cleared for self-serve via `edit_grape`.