### PR TITLE
fix(somm): counts_only counts every state; suspect flag yields to curated geography

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -733,6 +733,25 @@ describe('held-profile review queue over MCP (somm ticket 2026-08-18)', () => {
     expect(body.data.by_owner_tier).toMatchObject({ 0: 2, 2: 1 });
   });
 
+  test('counts_only counts published_suspect WITHOUT the include flag (ticket 6a8ffaa1)', async () => {
+    // The listing default exists to keep suspects out of held-row paging; a
+    // count has no paging to protect. The regression reported suspect as a
+    // hard 0 — "adjudicated clear" — while three quarters of the backlog sat
+    // in the uncounted state. Assert on the QUERY, not just the totals: the
+    // suspect $or branch must be present with no include flag passed.
+    WineDefinition.find.mockImplementation(() => heldListChain([
+      { _id: oid('1'), producer: 'Thomas Allen', aiProfile: { heldAt: new Date(), heldReason: 'low_confidence' } },
+      { _id: oid('3'), producer: 'Zeroine', aiProfile: { heldAt: null, producerSuspect: true, description: 'x' } },
+    ]));
+    Bottle.aggregate.mockResolvedValue([]);
+
+    const body = parse(await tool('list_held_profiles').handler({ counts_only: true, limit: 30, offset: 0 }, SOMM_CTX));
+    expect(body.error).toBeUndefined();
+    const or = WineDefinition.find.mock.calls[0][0].$or;
+    expect(or.some((b) => b['aiProfile.producerSuspect'] === true)).toBe(true);
+    expect(body.data).toMatchObject({ total: 2, held: 1, published_suspect: 1 });
+  });
+
   test('batch confirm decides per-row; batch release and misplaced context are refused (gap report 3 / enh 1)', async () => {
     WineDefinition.findById.mockImplementation(() => selectChain(heldWine()));
     let body = parse(await tool('review_held_profile').handler({ wine_ids: [oid('7'), oid('8')], decision: 'confirm', limit: undefined }, SOMM_CTX));

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -1436,7 +1436,12 @@ registerTool({
     }
     // An explicit state ask implies the include flag — asking for suspects
     // and getting nothing because a second switch was off would be a trap.
-    if ((args.include_published_suspects && wantState('published_suspect')) || args.state === 'published_suspect') {
+    // counts_only implies it too (somm ticket 6a8ffaa1): the listing default
+    // exists to keep suspects out of a curator's held-row PAGING, but a count
+    // has no paging to protect — carrying the default into it reported
+    // published_suspect as a hard 0 (not "uncounted") and under-sized the
+    // backlog by three quarters. A count counts every state.
+    if (((args.include_published_suspects || args.counts_only) && wantState('published_suspect')) || args.state === 'published_suspect') {
       or.push({ 'aiProfile.heldAt': null, 'aiProfile.generatedAt': { $ne: null }, 'aiProfile.producerSuspect': true, 'aiProfile.description': { $ne: null } });
     }
     if (wantState('unprofiled')) {

--- a/backend/src/scripts/apply-appellation-geography-downgrade.js
+++ b/backend/src/scripts/apply-appellation-geography-downgrade.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Apply the appellation-geography downgrade to rows already in the registry.
+ *
+ * The rule itself lives in the enrichment write path (fourth branch of the
+ * suspect downgrade chain, DOWNGRADE_RULES.APPELLATION_GEOGRAPHY) and runs on
+ * every new generation from v1.177. This is the one-off backfill for rows
+ * flagged before it existed — the same shape as apply-epistemic-downgrade.js.
+ *
+ * WHY (somm 6a8eb2a9). Five of five hand-checked producer-suspect rows were
+ * false positives, and the somm asked for this narrowing to ship FIRST: a
+ * record whose appellation resolves to a curated entry WITH geography — a
+ * Châteauneuf, a Coonawarra — has a knowable house behind whatever the
+ * producer string is, so the suspect claim cannot carry an owner-visible
+ * caveat there. producerUnknown is the honest state (real house, not placed).
+ *
+ * The predicate is deliberately about the curated ENTRY's geography, not the
+ * field being populated — the somm's own counter-examples: "Vin de France"
+ * (curated, nationwide, region null) and "Qualitätswein" (a tier, not
+ * curated) both stay flagged.
+ *
+ * NEVER touched, in addition to the sibling script's guards:
+ *   - rows a human has judged (suspectDecision set) or authored (source
+ *     'curator');
+ *   - rows blocked by the placeholder / place-conflict blockers — a
+ *     placeholder producer has nothing to verify however real the
+ *     appellation, and a note describing a different place puts the
+ *     appellation itself in doubt;
+ *   - rows whose wine carries an OPEN or ANSWERED owner inquiry — the somm
+ *     deliberately left Padulone undecided because clearing the flag would
+ *     decide over a live escalation on the same evidence (6a8eb2a9
+ *     follow-up, 2026-08-27). The inquiry resolves first.
+ *
+ * DRY BY DEFAULT. Pass --apply to write.
+ *
+ *   node src/scripts/apply-appellation-geography-downgrade.js            # report only
+ *   node src/scripts/apply-appellation-geography-downgrade.js --apply
+ */
+const mongoose = require('mongoose');
+const WineDefinition = require('../models/WineDefinition');
+const WineOwnerInquiry = require('../models/WineOwnerInquiry');
+require('../models/Region');
+require('../models/Country');
+const {
+  notePlaceConflict, producerFieldLooksPlaceholder, DOWNGRADE_RULES,
+} = require('../utils/producerSuspectCheck');
+const { appellationHasGeography } = require('../services/appellationResolve');
+
+const APPLY = process.argv.includes('--apply');
+
+(async () => {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+
+  const rows = await WineDefinition.find({
+    'aiProfile.producerSuspect': true,
+    // A curator verdict outranks any rule.
+    'aiProfile.suspectDecision': { $in: [null, undefined] },
+    'aiProfile.source': { $ne: 'curator' },
+    nonWine: { $ne: true },
+  })
+    .select('name producer appellation aiProfile.producerNote aiProfile.heldAt aiProfile.source')
+    .populate('region', 'name')
+    .populate('country', 'name')
+    .lean();
+
+  const inquiryWineIds = new Set(
+    (await WineOwnerInquiry.find({
+      wineDefinition: { $in: rows.map((r) => r._id) },
+      status: { $in: ['open', 'answered'] },
+    }).select('wineDefinition').lean()).map((i) => String(i.wineDefinition))
+  );
+
+  const move = [];
+  let blockedCount = 0;
+  let inquiryCount = 0;
+  let noGeoCount = 0;
+  for (const w of rows) {
+    if (inquiryWineIds.has(String(w._id))) { inquiryCount++; continue; }
+    const note = w.aiProfile.producerNote || '';
+    if (
+      producerFieldLooksPlaceholder(w.producer, w.name) ||
+      notePlaceConflict(note, { region: w.region?.name, appellation: w.appellation, country: w.country?.name })
+    ) { blockedCount++; continue; }
+    if (!(await appellationHasGeography(w.appellation))) { noGeoCount++; continue; }
+    move.push({ w });
+  }
+  console.log(`suspect rows considered : ${rows.length}`);
+  console.log(`skipped — live owner inquiry            : ${inquiryCount}`);
+  console.log(`blocked — placeholder / place conflict  : ${blockedCount}`);
+  console.log(`kept — no curated geography             : ${noGeoCount}`);
+  const held = move.filter((m) => m.w.aiProfile.heldAt).length;
+  console.log(`would downgrade         : ${move.length}  (${held} of them currently HELD)`);
+  for (const { w } of move.slice(0, 30)) {
+    console.log(`   [${DOWNGRADE_RULES.APPELLATION_GEOGRAPHY}] "${w.producer}" / "${w.name}"  ap="${w.appellation}"`);
+  }
+  if (move.length > 30) console.log(`   … and ${move.length - 30} more`);
+
+  if (!APPLY) {
+    console.log('\nDRY RUN — nothing written. Re-run with --apply.');
+    await mongoose.disconnect();
+    return;
+  }
+
+  let n = 0;
+  for (const { w } of move) {
+    await WineDefinition.updateOne(
+      { _id: w._id },
+      {
+        $set: {
+          'aiProfile.producerSuspect': false,
+          'aiProfile.producerUnknown': true,
+          'aiProfile.suspectDowngradedBy': DOWNGRADE_RULES.APPELLATION_GEOGRAPHY,
+        },
+      }
+    );
+    n++;
+  }
+  console.log(`\nUPDATED ${n} wine(s).`);
+  await mongoose.disconnect();
+})().catch((err) => { console.error(err); process.exit(1); });

--- a/backend/src/services/appellationResolve.js
+++ b/backend/src/services/appellationResolve.js
@@ -145,10 +145,47 @@ async function resolveCanonicalAppellation(rawAppellation) {
   }
 }
 
+/**
+ * Does this appellation string resolve to a curated entry that PLACES the
+ * wine — i.e. one carrying a region link? (Somm ticket 6a8eb2a9: the
+ * producer-suspect narrowing — "a négociant bottling in Graves still has a
+ * knowable house behind it".)
+ *
+ * The test is deliberately about the CURATED ENTRY's geography, not about
+ * the field being populated: "Vin de France" is curated but nationwide
+ * (region null) → false; "Qualitätswein" is a quality tier, not curated →
+ * false — both were named by the somm as rows a naive non-empty check would
+ * wrongly clear. Multi-doc keys (same name across countries) must agree:
+ * EVERY matched doc needs a region, mirroring lookupCanonical's
+ * all-must-agree stance — suppressing a suspicion is a publish decision, so
+ * ambiguity counts as no.
+ *
+ * Never throws; a lookup failure returns false — a flag must not be
+ * suppressed over taxonomy trouble.
+ */
+async function appellationHasGeography(rawAppellation) {
+  if (!rawAppellation) return false;
+  const normalized = normalizeAppellationKey(rawAppellation);
+  if (!normalized) return false;
+  try {
+    for (const key of candidateKeys(normalized)) {
+      const docs = await Appellation.find({
+        $or: [{ normalizedName: key }, { normalizedSynonyms: key }],
+      }).select('region').sort({ _id: 1 }).limit(4).lean();
+      if (docs.length === 0) continue; // unknown key — try the next variant
+      return docs.every(d => d.region != null);
+    }
+    return false;
+  } catch (err) {
+    console.warn('[appellationResolve] geography lookup failed (non-fatal, keeping flag):', err.message);
+    return false;
+  }
+}
+
 // candidateKeys is exported for services/taxonomyReview: the unmatched queue
 // must consider a string COVERED when any of its stripped variants matches a
 // curated doc (release-audit F2) — otherwise "Yecla DO" sits in the queue,
 // an admin promotes it, and the minted doc's exact-match hit permanently
 // disables the very stripping that would have folded it. One key function,
 // two consumers, no drift.
-module.exports = { resolveCanonicalAppellation, candidateKeys };
+module.exports = { resolveCanonicalAppellation, candidateKeys, appellationHasGeography };

--- a/backend/src/services/appellationResolve.test.js
+++ b/backend/src/services/appellationResolve.test.js
@@ -159,3 +159,52 @@ describe('membership-gated decoration stripping', () => {
     expect(Appellation.find).toHaveBeenCalledTimes(1);
   });
 });
+
+/**
+ * appellationHasGeography (somm 6a8eb2a9): the producer-suspect narrowing's
+ * predicate. Deliberately about the curated ENTRY's geography, not the field
+ * being populated — the somm's counter-examples pin both failure modes:
+ * "Vin de France" (curated, nationwide, region null) and "Qualitätswein"
+ * (a tier, not curated) must both return false.
+ */
+const { appellationHasGeography } = require('./appellationResolve');
+
+describe('appellationHasGeography', () => {
+  const geoChain = (docs) => ({
+    select: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(docs) }),
+      }),
+    }),
+  });
+
+  test('curated entry with a region → true', async () => {
+    Appellation.find.mockReturnValue(geoChain([{ region: 'r'.repeat(24) }]));
+    await expect(appellationHasGeography('Châteauneuf-du-Pape')).resolves.toBe(true);
+  });
+
+  test('curated but nationwide (region null) → false — "Vin de France"', async () => {
+    Appellation.find.mockReturnValue(geoChain([{ region: null }]));
+    await expect(appellationHasGeography('Vin de France')).resolves.toBe(false);
+  });
+
+  test('not curated at all → false — "Qualitätswein"', async () => {
+    Appellation.find.mockReturnValue(geoChain([]));
+    await expect(appellationHasGeography('Qualitätswein')).resolves.toBe(false);
+  });
+
+  test('cross-country namesakes must ALL carry geography', async () => {
+    Appellation.find.mockReturnValue(geoChain([{ region: 'r'.repeat(24) }, { region: null }]));
+    await expect(appellationHasGeography('Ambiguous')).resolves.toBe(false);
+  });
+
+  test('empty / null input → false', async () => {
+    await expect(appellationHasGeography('')).resolves.toBe(false);
+    await expect(appellationHasGeography(null)).resolves.toBe(false);
+  });
+
+  test('a lookup failure keeps the flag: false, never a throw', async () => {
+    Appellation.find.mockImplementation(() => { throw new Error('db down'); });
+    await expect(appellationHasGeography('Sauternes')).resolves.toBe(false);
+  });
+});

--- a/backend/src/services/enrichmentJob.js
+++ b/backend/src/services/enrichmentJob.js
@@ -515,6 +515,12 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
   // Loaded once per wine (module-cached) — assess() is a sync closure and the
   // note-vs-record check inside it must not await.
   const grapeVocab = await grapeVocabulary();
+  // Same constraint, same shape: resolved once per wine so the suspect
+  // downgrade chain inside assess() stays sync. Reads the wine's appellation
+  // against the curated taxonomy (somm 6a8eb2a9) — false on lookup trouble,
+  // so a taxonomy hiccup can only ever KEEP a flag, never clear one.
+  const { appellationHasGeography } = require('./appellationResolve');
+  const apHasGeo = await appellationHasGeography(wine.appellation);
 
   // Derive everything the gate and the writes need from ONE model response.
   // A closure so the search-rescue retry below can re-derive from a second
@@ -580,6 +586,22 @@ async function enrichWine(wine, model, { publishSuspect = false, curatorContext 
           suspect = false;
           unknown = cuvee.unknown === true;
           downgradedBy = DOWNGRADE_RULES.CUVEE_NOT_PRODUCER;
+        } else if (apHasGeo) {
+          // Fourth rule (somm 6a8eb2a9): record-based, the fallback when no
+          // note rule fires. The wine's appellation resolves to a curated
+          // entry WITH geography — a Châteauneuf or a Coonawarra has a
+          // knowable house behind whatever the producer string is, so the
+          // "record is wrong" claim cannot carry an owner-visible caveat.
+          // producerUnknown stays true: the house was still not identified.
+          // Ordered last on purpose — the note rules say WHY the model's own
+          // words disagree with its flag; this one only says the flag cannot
+          // matter here. Shares the placeholder/place-conflict blockers: a
+          // placeholder producer has nothing to verify however real the
+          // appellation is, and a note describing a different place puts the
+          // appellation itself in doubt.
+          suspect = false;
+          unknown = true;
+          downgradedBy = DOWNGRADE_RULES.APPELLATION_GEOGRAPHY;
         }
       }
     }

--- a/backend/src/services/enrichmentJob.test.js
+++ b/backend/src/services/enrichmentJob.test.js
@@ -29,6 +29,10 @@ jest.mock('../models/Grape', () => ({
 jest.mock('./labelScan', () => ({ suggestProfile: jest.fn() }));
 jest.mock('./aiProvider', () => ({ isConfigured: jest.fn(() => true), effectiveModels: jest.fn(() => null) }));
 jest.mock('./embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined) }));
+// The appellation-geography downgrade (somm 6a8eb2a9) reads the curated
+// taxonomy; default FALSE so every pre-existing expectation about suspect
+// persistence stays exactly as written. Tests for the rule flip it to true.
+jest.mock('./appellationResolve', () => ({ appellationHasGeography: jest.fn().mockResolvedValue(false) }));
 jest.mock('./aiBudget', () => ({ tryDebitAi: jest.fn(), isRefundableFailure: jest.fn(() => false) }));
 jest.mock('../config/aiConfig', () => ({ get: jest.fn(() => ({
   enrichmentModel: 'claude-sonnet-5',
@@ -391,6 +395,82 @@ describe('producer-suspect profiles are held, not published', () => {
     expect(persisted().heldAt).toBeNull();
     expect(persisted().producerSuspect).toBe(false);
     expect(persisted().description).toBe('Plain prose.');
+  });
+});
+
+/**
+ * The appellation-geography downgrade (somm 6a8eb2a9): a record whose
+ * appellation resolves to a curated entry WITH geography has a knowable house
+ * behind whatever the producer string is, so a suspect flag there cannot
+ * carry an owner-visible caveat — it downgrades to producerUnknown. Fourth
+ * branch of the chain: fires only when no note rule spoke, and never past
+ * the placeholder/place-conflict blockers.
+ */
+describe('appellation-geography suspect downgrade (somm 6a8eb2a9)', () => {
+  const { appellationHasGeography } = require('./appellationResolve');
+  // mockResolvedValue survives clearAllMocks (implementations are not calls),
+  // so restore the file default after every test — later describes assert
+  // the pre-narrowing hold behaviour and must not inherit geography=true.
+  afterEach(() => appellationHasGeography.mockResolvedValue(false));
+  // Confidence 0.7 clears the 0.55 unknown bar, and the prose makes NO
+  // producer claim (that would re-hold the downgraded row as
+  // 'producer_claim'), so the profile PUBLISHES — the point of the narrowing.
+  const suspectInGeo = () => ({
+    data: {
+      body: 'medium', tannin: 'medium', acidity: 'medium', sweetness: 'dry',
+      flavors: ['plum'], foodPairings: ['stew'],
+      description: 'A juicy plum-driven red with soft tannins.',
+      confidence: 0.7,
+      producerSuspect: true,
+      producerNote: 'Reads as a brand or bottling line, not a winery.',
+    },
+    debugReason: null,
+  });
+
+  test('suspect + curated geography publishes as producerUnknown, tagged', async () => {
+    appellationHasGeography.mockResolvedValue(true);
+    suggestProfile.mockResolvedValue(suspectInGeo());
+    await enrichWineById(WINE_ID);
+    const p = persisted();
+    expect(p.producerSuspect).toBe(false);
+    expect(p.producerUnknown).toBe(true);
+    expect(p.suspectDowngradedBy).toBe('appellation_has_geography');
+    expect(p.heldAt).toBeNull();
+    expect(p.description).toMatch(/juicy/);
+  });
+
+  test('without geography the same response stays suspect and held', async () => {
+    appellationHasGeography.mockResolvedValue(false);
+    suggestProfile.mockResolvedValue(suspectInGeo());
+    await enrichWineById(WINE_ID);
+    const p = persisted();
+    expect(p.producerSuspect).toBe(true);
+    expect(p.suspectDowngradedBy).toBeNull();
+    expect(p.heldAt).toBeInstanceOf(Date);
+  });
+
+  test('a note rule keeps precedence — the tag names WHY, not just that', async () => {
+    appellationHasGeography.mockResolvedValue(true);
+    const r = suspectInGeo();
+    // Lowercase producer-class noun asserting the entity IS a producer —
+    // noteAssertsProducer fires first and its tag survives.
+    r.data.producerNote = 'Matua is a family-run estate in Marlborough.';
+    suggestProfile.mockResolvedValue(r);
+    await enrichWineById(WINE_ID);
+    expect(persisted().producerSuspect).toBe(false);
+    expect(persisted().suspectDowngradedBy).toBe('note_asserts_producer');
+  });
+
+  test('the placeholder blocker outranks geography — an echoed producer stays suspect', async () => {
+    appellationHasGeography.mockResolvedValue(true);
+    WineDefinition.findById.mockReturnValue(chain({
+      _id: WINE_ID, name: 'Increíble', producer: 'Increíble', type: 'red',
+      country: { name: 'Spain' }, region: null, grapes: [],
+    }));
+    suggestProfile.mockResolvedValue(suspectInGeo());
+    await enrichWineById(WINE_ID);
+    expect(persisted().producerSuspect).toBe(true);
+    expect(persisted().suspectDowngradedBy).toBeNull();
   });
 });
 

--- a/backend/src/utils/producerSuspectCheck.js
+++ b/backend/src/utils/producerSuspectCheck.js
@@ -338,6 +338,15 @@ const DOWNGRADE_RULES = {
   ASSERTS_PRODUCER: 'note_asserts_producer',
   EPISTEMIC_ONLY: 'note_epistemic_only',
   CUVEE_NOT_PRODUCER: 'note_doubts_cuvee_not_producer',
+  // Record-based, not note-based (somm 6a8eb2a9): the wine carries an
+  // appellation that resolves to a curated entry WITH geography, so whatever
+  // the producer string is — brand, négociant label, jokey cuvée — a knowable
+  // house stands behind it. The suspect claim ("the record is wrong") cannot
+  // support an owner-visible caveat there; producerUnknown is the honest
+  // state. The predicate lives in services/appellationResolve
+  // (appellationHasGeography) because it reads the taxonomy; this file stays
+  // DB-free.
+  APPELLATION_GEOGRAPHY: 'appellation_has_geography',
 };
 
 module.exports = {


### PR DESCRIPTION
Two somm findings from today, both in the producer-suspect pipeline. Full reasoning in the commit message.

## 1. `counts_only` under-sized the backlog by ¾ (ticket 6a8ffaa1)

The counting mode inherited the `include_published_suspects` listing default and reported `published_suspect` as a **hard 0** (reads as adjudicated) — 9 total vs a true 37. The listing default protects paging; a count has no paging to protect. `counts_only` now counts every state. **Handler-only — no MCP schema change.** Regression test asserts on the query's `$or`, not just the totals.

## 2. Appellation-geography narrowing (ticket 6a8eb2a9 — the somm's sequenced-first ask)

After a 5-of-5 false-positive sample: a record whose appellation resolves to a **curated entry with geography** has a knowable house behind whatever the producer string is → `producer_suspect` downgrades to `producerUnknown` (no owner-visible caveat). Built exactly to the somm's caveat — the test is the curated **entry's** geography, never "field is populated":

| their counter-example | behaviour |
|---|---|
| Vin de France (curated, nationwide, region null) | stays flagged ✓ |
| Qualitätswein (a tier, not curated) | stays flagged ✓ |

**Validated against prod before building:** 16 of 26 outstanding rows clear; the 10-row residue matches the somm's hand-worked list. Fourth branch of the downgrade chain (note rules keep precedence, same blockers), plus a dry-run-default backfill script that additionally **never touches a row with a live owner inquiry** (the Padulone stance).

## Tests

4 suites / **326 tests green** in node:20-alpine — including new coverage for the counts query shape, the predicate's counter-examples, precedence, blockers, and publish-vs-hold of the downgraded row.

## Post-merge

Run `node src/scripts/apply-appellation-geography-downgrade.js` (dry) then `--apply` on prod after deploy — expected to clear ~16 rows and leave the somm the 8-row hand session they asked for.