### PR TITLE
feat(community): icon-only badges that expand on tap, plus a supporter chip per paid tier

### DIFF
--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -118,7 +118,7 @@ router.get('/', optionalAuth, async (req, res) => {
         }
 
         const docs = await Discussion.find({ _id: { $in: ids } })
-          .populate('author', 'username displayName roles contribution.tier contribution.specialty')
+          .populate('author', 'username displayName roles plan contribution.tier contribution.specialty')
           .populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } });
 
         // Preserve Meilisearch relevance ordering
@@ -165,7 +165,7 @@ router.get('/', optionalAuth, async (req, res) => {
         .sort(sortObj)
         .skip(skip)
         .limit(limit)
-        .populate('author', 'username displayName roles contribution.tier contribution.specialty')
+        .populate('author', 'username displayName roles plan contribution.tier contribution.specialty')
         .populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } }),
       Discussion.countDocuments(filter)
     ]);
@@ -383,7 +383,7 @@ router.get('/:idOrSlug', optionalAuth, async (req, res) => {
       : { slug: String(idOrSlug).toLowerCase() };
 
     const discussion = await Discussion.findOne(filter)
-      .populate('author', 'username displayName roles contribution.tier contribution.specialty')
+      .populate('author', 'username displayName roles plan contribution.tier contribution.specialty')
       .populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } });
 
     if (!discussion) return res.status(404).json({ error: 'Discussion not found' });
@@ -514,7 +514,7 @@ router.post('/', requireAuth, requireNonDemo, async (req, res) => {
     // Index in Meilisearch for in-forum search (fire-and-forget)
     searchService.indexDiscussion(discussion._id);
 
-    await discussion.populate('author', 'username displayName roles contribution.tier contribution.specialty');
+    await discussion.populate('author', 'username displayName roles plan contribution.tier contribution.specialty');
 
     // Notify @mentioned users — dispatched after the response would normally be
     // optimal, but since createNotification is fire-and-forget internally, calling
@@ -646,7 +646,7 @@ router.get('/:idOrSlug/replies', optionalAuth, async (req, res) => {
         .sort({ createdAt: 1 })
         .skip(skip)
         .limit(limit)
-        .populate('author', 'username displayName roles contribution.tier contribution.specialty')
+        .populate('author', 'username displayName roles plan contribution.tier contribution.specialty')
         .populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } }),
       DiscussionReply.countDocuments({ discussion: discussionId })
     ]);
@@ -930,7 +930,7 @@ router.post('/:idOrSlug/replies', requireAuth, requireNonDemo, async (req, res) 
 
     logAudit(req, 'discussion_reply.create', { type: 'discussion_reply', id: reply._id }, { discussion: discussion._id });
 
-    await reply.populate('author', 'username displayName roles contribution.tier contribution.specialty');
+    await reply.populate('author', 'username displayName roles plan contribution.tier contribution.specialty');
     await reply.populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } });
 
     res.status(201).json({ reply });
@@ -970,7 +970,7 @@ router.put('/:discussionId/replies/:replyId', requireAuth, async (req, res) => {
     // reply content. Fire-and-forget; never blocks the response.
     searchService.indexDiscussion(reply.discussion);
 
-    await reply.populate('author', 'username displayName roles contribution.tier contribution.specialty');
+    await reply.populate('author', 'username displayName roles plan contribution.tier contribution.specialty');
     res.json({ reply });
   } catch (err) {
     console.error('Update reply error:', err);

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -95,7 +95,7 @@ router.post('/', requireNonDemo, async (req, res) => {
 
     // Populate for response
     await review.populate([
-      { path: 'author', select: 'username displayName contribution.tier contribution.specialty' },
+      { path: 'author', select: 'username displayName plan contribution.tier contribution.specialty' },
       { path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } }
     ]);
 
@@ -147,7 +147,7 @@ router.get('/wine/:wineId', async (req, res) => {
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(limit)
-        .populate('author', 'username displayName contribution.tier contribution.specialty'),
+        .populate('author', 'username displayName plan contribution.tier contribution.specialty'),
       Review.countDocuments(filter)
     ]);
 
@@ -240,7 +240,7 @@ router.get('/feed', async (req, res) => {
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(limit)
-        .populate('author', 'username displayName contribution.tier contribution.specialty')
+        .populate('author', 'username displayName plan contribution.tier contribution.specialty')
         .populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } }),
       Review.countDocuments(feedFilter)
     ]);
@@ -292,7 +292,7 @@ router.get('/discover', async (req, res) => {
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(limit)
-        .populate('author', 'username displayName contribution.tier contribution.specialty')
+        .populate('author', 'username displayName plan contribution.tier contribution.specialty')
         .populate({ path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } }),
       Review.countDocuments(discoverFilter)
     ]);
@@ -365,7 +365,7 @@ router.put('/:id', async (req, res) => {
     logAudit(req, 'review.update', { type: 'review', id: review._id });
 
     await review.populate([
-      { path: 'author', select: 'username displayName contribution.tier contribution.specialty' },
+      { path: 'author', select: 'username displayName plan contribution.tier contribution.specialty' },
       { path: 'wineDefinition', select: 'name producer type', populate: { path: 'country', select: 'name' } }
     ]);
 

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -172,7 +172,7 @@ router.get('/public/:userId', requireAuth, async (req, res) => {
   try {
     if (!isValidId(req.params.userId)) return res.status(400).json({ error: 'Invalid ID' });
     const user = await User.findById(req.params.userId)
-      .select('username displayName bio followersCount followingCount reviewCount profileVisibility createdAt preferences.ratingScale contribution');
+      .select('username displayName bio followersCount followingCount reviewCount profileVisibility createdAt preferences.ratingScale contribution plan');
 
     if (!user) return res.status(404).json({ error: 'User not found' });
 
@@ -201,6 +201,9 @@ router.get('/public/:userId', requireAuth, async (req, res) => {
         profileVisibility: user.profileVisibility,
         ratingScale: user.preferences?.ratingScale || '5',
         createdAt: user.createdAt,
+        // Supporter-tier badge (2026-08-27): the paid plan is worn publicly as
+        // a thank-you chip. Tier name only — never amounts or billing state.
+        plan: user.plan || 'free',
         contribution: {
           totalScore: user.contribution?.totalScore || 0,
           tier: user.contribution?.tier || 'newcomer',

--- a/backend/src/routes/wines.js
+++ b/backend/src/routes/wines.js
@@ -1068,7 +1068,7 @@ router.get('/:idOrSlug/discussions', optionalAuth, async (req, res) => {
         .sort({ isPinned: -1, lastActivityAt: -1 })
         .skip(skip)
         .limit(limit)
-        .populate('author', 'username displayName roles contribution.tier contribution.specialty')
+        .populate('author', 'username displayName roles plan contribution.tier contribution.specialty')
         .select('title slug body category replyCount lastActivityAt createdAt isPinned isLocked author wineDefinition'),
       Discussion.countDocuments({ wineDefinition: wine._id })
     ]);

--- a/frontend/src/components/CellarCredBadge.css
+++ b/frontend/src/components/CellarCredBadge.css
@@ -1,12 +1,27 @@
-/* ── Cellar Cred Badge ─────────────────────────────────────────────────────── */
+/* ── Cellar Cred + Supporter Badges ────────────────────────────────────────── */
+.cred-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  vertical-align: middle;
+}
+
+/* Each chip is a real button (the tap-to-reveal needs one), restyled to look
+   exactly like the old inline chip. */
 .cred-badge {
   display: inline-flex;
   align-items: center;
   gap: 0.2rem;
   border-radius: var(--radius-full);
   font-weight: 500;
+  font-family: inherit;
   white-space: nowrap;
   vertical-align: middle;
+  cursor: pointer;
+}
+.cred-badge:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 1px;
 }
 
 /* Size variants */
@@ -18,6 +33,27 @@
 .cred-badge--md {
   font-size: 0.75rem;
   padding: 2px 8px;
+}
+
+/* Icon-only at rest: the label collapses to nothing and reveals on hover,
+   keyboard focus, or tap (.is-open). max-width carries the transition —
+   12rem comfortably fits the longest "Connoisseur · Photographer". */
+.cred-badge__label {
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-width 180ms ease, opacity 140ms ease, margin-left 180ms ease;
+  margin-left: 0;
+}
+.cred-badge:hover .cred-badge__label,
+.cred-badge:focus-visible .cred-badge__label,
+.cred-badge.is-open .cred-badge__label {
+  max-width: 12rem;
+  opacity: 1;
+  margin-left: 0.15rem;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cred-badge__label { transition: none; }
 }
 
 /* Tier colours — mapped to the theme-aware semantic token families so the chips
@@ -46,14 +82,18 @@
   border: 1px solid var(--color-danger-border);
 }
 
-/* Icon sizing */
-.cred-badge__icon,
-.cred-badge__spec-icon {
-  font-size: 0.7em;
-  line-height: 1;
+/* Supporter plan chips share the accent family — visually one "thank you"
+   colour across all three tiers; the icon (❤️ 🥂 🍾) tells them apart. */
+.cred-badge--plan-supporter,
+.cred-badge--plan-patron,
+.cred-badge--plan-benefactor {
+  background: var(--color-accent-light);
+  color: var(--color-accent);
+  border: 1px solid var(--color-accent);
 }
 
-.cred-badge__sep {
-  opacity: 0.5;
-  margin: 0 0.05rem;
+/* Icon sizing */
+.cred-badge__icon {
+  font-size: 0.7em;
+  line-height: 1;
 }

--- a/frontend/src/components/CellarCredBadge.js
+++ b/frontend/src/components/CellarCredBadge.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import './CellarCredBadge.css';
 
@@ -16,32 +17,76 @@ const SPECIALTY_ICONS = {
   allrounder:   '🔄',
 };
 
-/**
- * Subtle contribution badge: tier + optional specialty.
- * Only renders for contributor tier and above.
- *
- * Props: tier, specialty, size ('sm' | 'md'), showSpecialty (default true)
- */
-function CellarCredBadge({ tier, specialty, size = 'sm', showSpecialty = true }) {
-  const { t } = useTranslation();
-  const config = TIER_CONFIG[tier];
-  if (!config) return null; // newcomer or unknown → nothing
+// Supporter-tier chips (2026-08-27, Johan): one per paid plan, thanking the
+// people who fund development. Icons escalate as a celebration, never as a
+// rank — the /supporter page renders all tiers as equals and so do we.
+const PLAN_CONFIG = {
+  supporter:  { icon: '❤️', cls: 'cred-badge--plan-supporter' },
+  patron:     { icon: '🥂', cls: 'cred-badge--plan-patron' },
+  benefactor: { icon: '🍾', cls: 'cred-badge--plan-benefactor' },
+};
 
-  const tierLabel = t(`cellarCred.${tier}`);
-  const specialtyLabel = specialty && showSpecialty ? t(`cellarCred.${specialty}`) : null;
+/**
+ * One compact chip: icon-only at rest, the text label revealed on hover,
+ * keyboard focus, or tap (mobile has no hover — the tap toggle is the whole
+ * reason this is a button). The full text always rides aria-label, so the
+ * collapsed state loses nothing for screen readers.
+ */
+function Chip({ cls, size, icons, label }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <button
+      type="button"
+      className={`cred-badge ${cls} cred-badge--${size}${open ? ' is-open' : ''}`}
+      aria-label={label}
+      aria-expanded={open}
+      onClick={() => setOpen((o) => !o)}
+      onBlur={() => setOpen(false)}
+    >
+      {icons.map((icon, i) => (
+        <span key={i} className="cred-badge__icon" aria-hidden="true">{icon}</span>
+      ))}
+      <span className="cred-badge__label" aria-hidden="true">{label}</span>
+    </button>
+  );
+}
+
+/**
+ * Subtle contribution + supporter badges for an author line.
+ *
+ * Renders up to two chips: the Cellar Cred tier (contributor and above, with
+ * optional specialty) and the supporter plan (any paid tier). Both are
+ * icon-only until pressed or hovered — the labels were crowding the
+ * community cards (Johan, 2026-08-27).
+ *
+ * Props: tier, specialty, plan, size ('sm' | 'md'), showSpecialty (default true)
+ */
+function CellarCredBadge({ tier, specialty, plan, size = 'sm', showSpecialty = true }) {
+  const { t } = useTranslation();
+  const cred = TIER_CONFIG[tier];       // newcomer or unknown → no cred chip
+  const paid = PLAN_CONFIG[plan];       // free or unknown → no supporter chip
+  if (!cred && !paid) return null;
+
+  let credLabel = null;
+  let credIcons = [];
+  if (cred) {
+    const tierLabel = t(`cellarCred.${tier}`);
+    const specialtyLabel = specialty && showSpecialty ? t(`cellarCred.${specialty}`) : null;
+    credLabel = specialtyLabel ? `${tierLabel} · ${specialtyLabel}` : tierLabel;
+    credIcons = [cred.icon];
+    if (specialtyLabel && SPECIALTY_ICONS[specialty]) credIcons.push(SPECIALTY_ICONS[specialty]);
+  }
 
   return (
-    <span className={`cred-badge ${config.cls} cred-badge--${size}`}>
-      <span className="cred-badge__icon" aria-hidden="true">{config.icon}</span>
-      <span className="cred-badge__tier">{tierLabel}</span>
-      {specialtyLabel && (
-        <>
-          <span className="cred-badge__sep" aria-hidden="true">·</span>
-          {SPECIALTY_ICONS[specialty] && (
-            <span className="cred-badge__spec-icon" aria-hidden="true">{SPECIALTY_ICONS[specialty]}</span>
-          )}
-          <span className="cred-badge__specialty">{specialtyLabel}</span>
-        </>
+    <span className="cred-badges">
+      {cred && <Chip cls={cred.cls} size={size} icons={credIcons} label={credLabel} />}
+      {paid && (
+        <Chip
+          cls={paid.cls}
+          size={size}
+          icons={[paid.icon]}
+          label={t(`cellarCred.plan_${plan}`)}
+        />
       )}
     </span>
   );

--- a/frontend/src/components/CellarCredBadge.test.js
+++ b/frontend/src/components/CellarCredBadge.test.js
@@ -1,0 +1,65 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CellarCredBadge from './CellarCredBadge';
+
+// Identity stub: labels render as their keys, keeping assertions locale-free.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k) => k, i18n: { language: 'en' } }),
+}));
+
+describe('CellarCredBadge', () => {
+  test('newcomer on the free plan renders nothing', () => {
+    const { container } = render(<CellarCredBadge tier="newcomer" plan="free" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('cred chip carries tier and specialty in one accessible label', () => {
+    render(<CellarCredBadge tier="contributor" specialty="photographer" />);
+    const chip = screen.getByRole('button', {
+      name: 'cellarCred.contributor · cellarCred.photographer',
+    });
+    expect(chip).toBeInTheDocument();
+    // Both icons render; the visible text is decorative (aria-hidden) because
+    // the button's aria-label already says everything.
+    expect(chip.querySelectorAll('.cred-badge__icon')).toHaveLength(2);
+    expect(chip.querySelector('.cred-badge__label')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test.each([
+    ['supporter', '❤️'],
+    ['patron', '🥂'],
+    ['benefactor', '🍾'],
+  ])('paid plan %s renders its own chip with the %s icon', (plan, icon) => {
+    render(<CellarCredBadge plan={plan} />);
+    const chip = screen.getByRole('button', { name: `cellarCred.plan_${plan}` });
+    expect(chip).toHaveTextContent(icon);
+  });
+
+  test('an unknown or free plan adds no supporter chip next to the cred chip', () => {
+    render(<CellarCredBadge tier="ambassador" plan="free" />);
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  test('cred and supporter chips render side by side', () => {
+    render(<CellarCredBadge tier="enthusiast" plan="patron" />);
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
+  test('tap toggles the label open and closed; blur closes it', () => {
+    render(<CellarCredBadge plan="supporter" />);
+    const chip = screen.getByRole('button');
+    expect(chip).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(chip);
+    expect(chip).toHaveAttribute('aria-expanded', 'true');
+    expect(chip.className).toContain('is-open');
+    fireEvent.click(chip);
+    expect(chip).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(chip);
+    fireEvent.blur(chip);
+    expect(chip).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('showSpecialty=false keeps the tier label alone', () => {
+    render(<CellarCredBadge tier="connoisseur" specialty="critic" showSpecialty={false} />);
+    expect(screen.getByRole('button', { name: 'cellarCred.connoisseur' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DiscussionCard.js
+++ b/frontend/src/components/DiscussionCard.js
@@ -74,7 +74,7 @@ export default function DiscussionCard({ discussion }) {
             )}
             {!authorIsDeleted && author.roles?.includes('moderator') && <span className="badge badge--mod">{t('discussions.mod')}</span>}
             {!authorIsDeleted && author.roles?.includes('admin') && <span className="badge badge--admin">{t('discussions.admin')}</span>}
-            {!authorIsDeleted && <CellarCredBadge tier={author.contribution?.tier} specialty={author.contribution?.specialty} />}
+            {!authorIsDeleted && <CellarCredBadge tier={author.contribution?.tier} specialty={author.contribution?.specialty} plan={author.plan} />}
           </span>
         </div>
       </div>

--- a/frontend/src/components/ReplyCard.js
+++ b/frontend/src/components/ReplyCard.js
@@ -180,7 +180,7 @@ export default function ReplyCard({ reply, discussionId, onReply, onEdit, onDele
         )}
         {!authorDeleted && author.roles?.includes('moderator') && <span className="badge badge--mod">{t('discussions.mod')}</span>}
         {!authorDeleted && author.roles?.includes('admin') && <span className="badge badge--admin">{t('discussions.admin')}</span>}
-        {!authorDeleted && <CellarCredBadge tier={author.contribution?.tier} specialty={author.contribution?.specialty} />}
+        {!authorDeleted && <CellarCredBadge tier={author.contribution?.tier} specialty={author.contribution?.specialty} plan={author.plan} />}
         <span className="reply-card__time">{timeAgo(reply.createdAt)}</span>
         {reply.updatedAt !== reply.createdAt && (
           <span className="reply-card__edited">{t('discussions.editedSuffix')}</span>

--- a/frontend/src/components/ReviewCard.js
+++ b/frontend/src/components/ReviewCard.js
@@ -74,7 +74,7 @@ export default function ReviewCard({ review, showWine = true, onUpdate, onDelete
           <Link to={`/users/${author._id}`} className="review-card__author-link">
             {authorName}
           </Link>
-          <CellarCredBadge tier={author.contribution?.tier} specialty={author.contribution?.specialty} />
+          <CellarCredBadge tier={author.contribution?.tier} specialty={author.contribution?.specialty} plan={author.plan} />
           {review.vintage && (
             <span className="review-card__vintage">{review.vintage}</span>
           )}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3202,7 +3202,10 @@
     "critic": "Critic",
     "community": "Community",
     "allrounder": "All-Rounder",
-    "score": "Cellar Cred"
+    "score": "Cellar Cred",
+    "plan_supporter": "Supporter",
+    "plan_patron": "Patron",
+    "plan_benefactor": "Benefactor"
   },
   "adminAiBudget": {
     "title": "AI Budget Requests",

--- a/frontend/src/pages/UserProfile.js
+++ b/frontend/src/pages/UserProfile.js
@@ -145,7 +145,7 @@ function UserProfile() {
           <div className="user-profile__details">
             <h1 className="user-profile__name">
               {displayName}
-              {' '}<CellarCredBadge tier={profile.contribution?.tier} specialty={profile.contribution?.specialty} size="md" />
+              {' '}<CellarCredBadge tier={profile.contribution?.tier} specialty={profile.contribution?.specialty} plan={profile.plan} size="md" />
             </h1>
             {profile.displayName && profile.displayName !== profile.username && (
               <p className="user-profile__username">@{profile.username}</p>


### PR DESCRIPTION
Johan's two asks from today's community-page review:

## Compact badges
The cred chip's text labels ("Contributor · Photographer") crowded the cards. Chips are now **icon-only at rest**, revealing the label on **hover, focus, or tap** — each chip is a real `<button>` (mobile has no hover), with the full text always on `aria-label`, so screen readers lose nothing. Reduced-motion respected.

## Supporter chips — one per paid tier
| Tier | Chip |
|---|---|
| Supporter ($2) | ❤️ |
| Patron ($5) | 🥂 |
| Benefactor ($10) | 🍾 |

One shared accent colour (a single "thank you" family — no rank styling), the icon tells tiers apart. **Tier name only — never amounts or billing state.** `plan` rides the existing author populates (discussions, replies, reviews, wine-page reviews) + the public profile payload; the Stripe webhook already downgrades `plan` on cancellation so the field is authoritative. Free plan → no chip; deleted authors already guarded at call sites.

The supporter chip renders through the same shared component, so all four surfaces light up from one change.

## Tests
Frontend **66 suites / 1029 green** (9 new: rendering matrix, tier→icon map, tap-toggle + blur, a11y). Touched backend route suites green in node:20-alpine. en-only strings per the i18n workflow.