### PR TITLE
feat(community): tapping a badge explains what it means

### DIFF
--- a/frontend/src/components/CellarCredBadge.css
+++ b/frontend/src/components/CellarCredBadge.css
@@ -9,6 +9,7 @@
 /* Each chip is a real button (the tap-to-reveal needs one), restyled to look
    exactly like the old inline chip. */
 .cred-badge {
+  position: relative; /* anchors the tap popover */
   display: inline-flex;
   align-items: center;
   gap: 0.2rem;
@@ -96,4 +97,35 @@
 .cred-badge__icon {
   font-size: 0.7em;
   line-height: 1;
+}
+
+/* Tap popover: what the badge MEANS, not just its name. Anchored under the
+   chip, wraps freely, sits above card content. Decorative for screen
+   readers — the button's aria-label carries the same text. */
+.cred-badge__pop {
+  position: absolute;
+  top: calc(100% + 5px);
+  left: 0;
+  z-index: 30;
+  width: max-content;
+  max-width: 15rem;
+  white-space: normal;
+  text-align: left;
+  font-size: 0.72rem;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--color-text-secondary);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-card, 0 4px 14px rgba(0, 0, 0, 0.12));
+  padding: 6px 9px;
+  cursor: default;
+}
+
+.cred-badge__pop-title {
+  display: block;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 1px;
 }

--- a/frontend/src/components/CellarCredBadge.js
+++ b/frontend/src/components/CellarCredBadge.js
@@ -27,18 +27,20 @@ const PLAN_CONFIG = {
 };
 
 /**
- * One compact chip: icon-only at rest, the text label revealed on hover,
- * keyboard focus, or tap (mobile has no hover — the tap toggle is the whole
- * reason this is a button). The full text always rides aria-label, so the
- * collapsed state loses nothing for screen readers.
+ * One compact chip: icon-only at rest, the text label revealed on hover or
+ * keyboard focus, and a small popover with the label PLUS a one-line
+ * explanation on tap (mobile has no hover — the tap toggle is the whole
+ * reason this is a button). Label and explanation both ride aria-label, so
+ * the collapsed state loses nothing for screen readers; the popover itself
+ * is a decorative duplicate.
  */
-function Chip({ cls, size, icons, label }) {
+function Chip({ cls, size, icons, label, explain }) {
   const [open, setOpen] = useState(false);
   return (
     <button
       type="button"
       className={`cred-badge ${cls} cred-badge--${size}${open ? ' is-open' : ''}`}
-      aria-label={label}
+      aria-label={explain ? `${label}. ${explain}` : label}
       aria-expanded={open}
       onClick={() => setOpen((o) => !o)}
       onBlur={() => setOpen(false)}
@@ -47,6 +49,12 @@ function Chip({ cls, size, icons, label }) {
         <span key={i} className="cred-badge__icon" aria-hidden="true">{icon}</span>
       ))}
       <span className="cred-badge__label" aria-hidden="true">{label}</span>
+      {explain && open && (
+        <span className="cred-badge__pop" aria-hidden="true">
+          <span className="cred-badge__pop-title">{label}</span>
+          {explain}
+        </span>
+      )}
     </button>
   );
 }
@@ -69,23 +77,29 @@ function CellarCredBadge({ tier, specialty, plan, size = 'sm', showSpecialty = t
 
   let credLabel = null;
   let credIcons = [];
+  let credExplain = null;
   if (cred) {
     const tierLabel = t(`cellarCred.${tier}`);
     const specialtyLabel = specialty && showSpecialty ? t(`cellarCred.${specialty}`) : null;
     credLabel = specialtyLabel ? `${tierLabel} · ${specialtyLabel}` : tierLabel;
     credIcons = [cred.icon];
     if (specialtyLabel && SPECIALTY_ICONS[specialty]) credIcons.push(SPECIALTY_ICONS[specialty]);
+    credExplain = t(`cellarCred.explain_${tier}`);
+    if (specialtyLabel) credExplain += ` ${t(`cellarCred.explain_${specialty}`)}`;
   }
 
   return (
     <span className="cred-badges">
-      {cred && <Chip cls={cred.cls} size={size} icons={credIcons} label={credLabel} />}
+      {cred && (
+        <Chip cls={cred.cls} size={size} icons={credIcons} label={credLabel} explain={credExplain} />
+      )}
       {paid && (
         <Chip
           cls={paid.cls}
           size={size}
           icons={[paid.icon]}
           label={t(`cellarCred.plan_${plan}`)}
+          explain={t(`cellarCred.explain_plan_${plan}`)}
         />
       )}
     </span>

--- a/frontend/src/components/CellarCredBadge.test.js
+++ b/frontend/src/components/CellarCredBadge.test.js
@@ -15,7 +15,8 @@ describe('CellarCredBadge', () => {
   test('cred chip carries tier and specialty in one accessible label', () => {
     render(<CellarCredBadge tier="contributor" specialty="photographer" />);
     const chip = screen.getByRole('button', {
-      name: 'cellarCred.contributor · cellarCred.photographer',
+      name: 'cellarCred.contributor · cellarCred.photographer. ' +
+        'cellarCred.explain_contributor cellarCred.explain_photographer',
     });
     expect(chip).toBeInTheDocument();
     // Both icons render; the visible text is decorative (aria-hidden) because
@@ -30,7 +31,9 @@ describe('CellarCredBadge', () => {
     ['benefactor', '🍾'],
   ])('paid plan %s renders its own chip with the %s icon', (plan, icon) => {
     render(<CellarCredBadge plan={plan} />);
-    const chip = screen.getByRole('button', { name: `cellarCred.plan_${plan}` });
+    const chip = screen.getByRole('button', {
+      name: `cellarCred.plan_${plan}. cellarCred.explain_plan_${plan}`,
+    });
     expect(chip).toHaveTextContent(icon);
   });
 
@@ -58,8 +61,38 @@ describe('CellarCredBadge', () => {
     expect(chip).toHaveAttribute('aria-expanded', 'false');
   });
 
+  test('tap opens a popover explaining what the badge means', () => {
+    const { container } = render(<CellarCredBadge plan="patron" />);
+    expect(container.querySelector('.cred-badge__pop')).toBeNull(); // closed at rest
+    fireEvent.click(screen.getByRole('button'));
+    const pop = container.querySelector('.cred-badge__pop');
+    expect(pop).toHaveTextContent('cellarCred.explain_plan_patron');
+    expect(pop.querySelector('.cred-badge__pop-title')).toHaveTextContent('cellarCred.plan_patron');
+  });
+
+  test('the cred popover explains the tier AND the specialty — photographer included', () => {
+    const { container } = render(
+      <CellarCredBadge tier="contributor" specialty="photographer" />
+    );
+    fireEvent.click(screen.getByRole('button'));
+    const pop = container.querySelector('.cred-badge__pop');
+    expect(pop).toHaveTextContent('cellarCred.explain_contributor');
+    expect(pop).toHaveTextContent('cellarCred.explain_photographer');
+  });
+
+  test('the explanation always rides the accessible name, popover open or not', () => {
+    render(<CellarCredBadge plan="benefactor" />);
+    expect(
+      screen.getByRole('button', {
+        name: 'cellarCred.plan_benefactor. cellarCred.explain_plan_benefactor',
+      })
+    ).toBeInTheDocument();
+  });
+
   test('showSpecialty=false keeps the tier label alone', () => {
     render(<CellarCredBadge tier="connoisseur" specialty="critic" showSpecialty={false} />);
-    expect(screen.getByRole('button', { name: 'cellarCred.connoisseur' })).toBeInTheDocument();
+    expect(screen.getByRole('button', {
+      name: 'cellarCred.connoisseur. cellarCred.explain_connoisseur',
+    })).toBeInTheDocument();
   });
 });

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3205,7 +3205,19 @@
     "score": "Cellar Cred",
     "plan_supporter": "Supporter",
     "plan_patron": "Patron",
-    "plan_benefactor": "Benefactor"
+    "plan_benefactor": "Benefactor",
+    "explain_contributor": "Earns Cellar Cred by contributing to the community: accepted wine-data fixes, bottle photos, reviews and discussions.",
+    "explain_enthusiast": "A seasoned community contributor — wine-data fixes, bottle photos, reviews and discussions. The second contribution level.",
+    "explain_connoisseur": "A top community contributor — wine-data fixes, bottle photos, reviews and discussions. The third contribution level.",
+    "explain_ambassador": "Among the community’s most active contributors — the highest contribution level.",
+    "explain_curator": "Their strongest area: accepted corrections to the shared wine registry.",
+    "explain_photographer": "Their strongest area: approved bottle photos.",
+    "explain_critic": "Their strongest area: wine reviews.",
+    "explain_community": "Their strongest area: discussions and replies.",
+    "explain_allrounder": "Contributes evenly across wine data, photos, reviews and discussions.",
+    "explain_plan_supporter": "Voluntarily helps fund Cellarion’s development. Every feature is free for everyone — supporters simply chip in.",
+    "explain_plan_patron": "Voluntarily funds Cellarion’s development at a higher level. Every feature is free for everyone.",
+    "explain_plan_benefactor": "Voluntarily covers a real share of Cellarion’s running costs. Every feature is free for everyone."
   },
   "adminAiBudget": {
     "title": "AI Budget Requests",


### PR DESCRIPTION
Follow-up to #1127, from Johan's review of the shipped chips: the name alone ("Patron", "Photographer") still doesn't tell a visitor what the badge *is*.

**Tap now opens a small popover: badge name + one-line explanation — for every badge:**

| Badge | Explanation (en) |
|---|---|
| 🌱 Contributor …⭐ Ambassador | how Cellar Cred is earned + which level this is |
| 📋 📷 ✍️ 💬 🔄 specialties | "Their strongest area: approved bottle photos" etc. |
| ❤️ 🥂 🍾 supporter tiers | "Voluntarily helps fund Cellarion's development. Every feature is free for everyone…" |

Hover/focus keep the quick inline label from #1127; tap adds the popover. The explanation always rides `aria-label` (popover is a decorative `aria-hidden` duplicate), so screen readers get the meaning in every state. Theme-token styled, anchored under the chip, closes on blur/second tap.

The supporter wording deliberately repeats the /supporter page's framing — voluntary, nothing gated — so the badge doubles as a gentle, truthful answer to "what's that heart?".

en-only strings per the i18n workflow. **66 suites / 1032 tests green** (4 new, 5 updated for the richer accessible names).