### PR TITLE
fix(community): badge popover stays inside the viewport

### DIFF
--- a/frontend/src/components/CellarCredBadge.css
+++ b/frontend/src/components/CellarCredBadge.css
@@ -108,7 +108,9 @@
   left: 0;
   z-index: 30;
   width: max-content;
-  max-width: 15rem;
+  /* Never wider than the phone minus margins — the JS clamp slides the box
+     into view, this keeps it from being unslideable in the first place. */
+  max-width: min(15rem, calc(100vw - 16px));
   white-space: normal;
   text-align: left;
   font-size: 0.72rem;

--- a/frontend/src/components/CellarCredBadge.js
+++ b/frontend/src/components/CellarCredBadge.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import './CellarCredBadge.css';
 
@@ -36,6 +36,26 @@ const PLAN_CONFIG = {
  */
 function Chip({ cls, size, icons, label, explain }) {
   const [open, setOpen] = useState(false);
+  // Viewport clamp for the popover (bug seen live on v1.179.0): the chip
+  // often sits at the END of the author row, so a left-anchored popover runs
+  // off the right edge of a phone. Measure once per open (shift starts at 0,
+  // so the measurement is of the unshifted box) and slide it just enough to
+  // stay on screen with an 8px margin. jsdom reports zero-size rects — the
+  // width guard keeps tests inert.
+  const popRef = useRef(null);
+  const [shift, setShift] = useState(0);
+  useLayoutEffect(() => {
+    if (!open) { setShift(0); return; }
+    const el = popRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    if (!r.width) return;
+    const margin = 8;
+    let dx = 0;
+    if (r.right > window.innerWidth - margin) dx = window.innerWidth - margin - r.right;
+    if (r.left + dx < margin) dx = margin - r.left;
+    if (dx !== 0) setShift(dx);
+  }, [open]);
   return (
     <button
       type="button"
@@ -50,7 +70,12 @@ function Chip({ cls, size, icons, label, explain }) {
       ))}
       <span className="cred-badge__label" aria-hidden="true">{label}</span>
       {explain && open && (
-        <span className="cred-badge__pop" aria-hidden="true">
+        <span
+          className="cred-badge__pop"
+          aria-hidden="true"
+          ref={popRef}
+          style={shift ? { transform: `translateX(${shift}px)` } : undefined}
+        >
           <span className="cred-badge__pop-title">{label}</span>
           {explain}
         </span>

--- a/frontend/src/components/CellarCredBadge.test.js
+++ b/frontend/src/components/CellarCredBadge.test.js
@@ -96,3 +96,41 @@ describe('CellarCredBadge', () => {
     })).toBeInTheDocument();
   });
 });
+
+describe('popover viewport clamp', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  test('a popover overflowing the right edge slides back into view', () => {
+    // A chip at the end of the author row on a 400px phone: the unshifted
+    // popover box hangs past the right edge. dx = (400 - 8) - 508 = -116.
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      return this.classList?.contains('cred-badge__pop')
+        ? { left: 260, right: 508, width: 248 }
+        : { left: 0, right: 0, width: 0 };
+    });
+    Object.defineProperty(window, 'innerWidth', { value: 400, configurable: true });
+    const { container } = render(<CellarCredBadge plan="supporter" />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(container.querySelector('.cred-badge__pop').style.transform)
+      .toBe('translateX(-116px)');
+  });
+
+  test('a popover that fits stays where it is', () => {
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      return this.classList?.contains('cred-badge__pop')
+        ? { left: 20, right: 260, width: 240 }
+        : { left: 0, right: 0, width: 0 };
+    });
+    Object.defineProperty(window, 'innerWidth', { value: 400, configurable: true });
+    const { container } = render(<CellarCredBadge plan="patron" />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(container.querySelector('.cred-badge__pop').style.transform).toBe('');
+  });
+
+  test('zero-size rects (jsdom default) leave the popover unshifted', () => {
+    const { container } = render(<CellarCredBadge plan="benefactor" />);
+    fireEvent.click(screen.getByRole('button'));
+    const pop = container.querySelector('.cred-badge__pop');
+    expect(pop.style.transform).toBe('');
+  });
+});


### PR DESCRIPTION
Johan's screenshot minutes after v1.179.0: the supporter chip sits at the end of the author row, so its left-anchored explanation popover ran off the right edge of the phone — text clipped mid-word.

**Fix:** the popover measures itself once per open (shift starts at 0, so it always measures the unshifted box) and slides just enough to stay on screen with an 8px margin — right and left edges both guarded. CSS belt-and-braces: `max-width: min(15rem, calc(100vw - 16px))` so the box can never be wider than the screen it must fit.

**Tests:** 3 new — prototype-spy rect proving the exact shift (508px box on a 400px phone → `translateX(-116px)`), a fitting box stays untouched, and jsdom's zero-size rects stay inert. **66 suites / 1035 green.**

**Deliberately not released** — merges to main and ships with the next train (Johan).