### PR TITLE
fix(security): revoke connected AI assistants on password change and reset

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -7,6 +7,7 @@ const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { checkIsSuperAdmin } = require('../middleware/superAdmin');
 const { logAudit } = require('../services/audit');
 const eventBus = require('../services/eventBus');
+const { revokeOAuthConnectionsForUser } = require('../services/mcpOAuth');
 const { CURRENT_PRIVACY_POLICY_VERSION } = require('../config/legal');
 const rateLimitsConfig = require('../config/rateLimits');
 const { sendVerificationEmail, sendPasswordResetEmail, sendAccountLockoutAlert, EMAIL_VERIFICATION_ENABLED } = require('../services/mailgun');
@@ -525,11 +526,15 @@ router.post('/change-password', requireAuth, requireNonDemo, authLimiter, async 
     // refresh sessions (docs/ha-push-events.md §1).
     eventBus.dropUser(user._id);
 
-    const accessToken = await issueTokens(user, res);
+    const accessToken = await issueTokens(user, res); // persists the new password
+    // Revoke connected AI assistants (OAuth consent grants) — a third-party
+    // grant must not outlive the "secure my account" action (security report
+    // 2026-08-27). Personal API tokens (HA, climate) keep PAT semantics.
+    const revokedConnections = await revokeOAuthConnectionsForUser(user._id);
 
     logAudit(req, 'auth.change_password',
       { type: 'user', id: user._id },
-      { username: user.username }
+      { username: user.username, oauthConnectionsRevoked: revokedConnections }
     );
 
     res.json({
@@ -666,10 +671,15 @@ router.post('/reset-password', authLimiter, async (req, res) => {
     resetLoginAttempts(user);
 
     await user.save();
+    // Revoke connected AI assistants (OAuth consent grants): a password reset
+    // is the user's explicit account-recovery signal, so a phished third-party
+    // grant must not survive it (security report 2026-08-27). Personal API
+    // tokens (HA, climate) carry a null oauthClientId and keep PAT semantics.
+    const revokedConnections = await revokeOAuthConnectionsForUser(user._id);
 
     logAudit(req, 'auth.password_reset',
       { type: 'user', id: user._id },
-      { username: user.username }
+      { username: user.username, oauthConnectionsRevoked: revokedConnections }
     );
 
     clearRefreshCookie(res);

--- a/backend/src/routes/auth.refresh.test.js
+++ b/backend/src/routes/auth.refresh.test.js
@@ -54,6 +54,7 @@ jest.mock('../services/mailgun', () => ({
 
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../services/notifications', () => ({ createNotification: jest.fn() }));
+jest.mock('../services/mcpOAuth', () => ({ revokeOAuthConnectionsForUser: jest.fn().mockResolvedValue(2) }));
 
 // Only touched by the register / verify-email paths (resolvePendingShares) —
 // mocked so requiring the router doesn't pull real mongoose schemas.
@@ -528,6 +529,12 @@ describe('POST /api/auth/reset-password', () => {
     // Every existing session is killed server-side + cookie cleared client-side
     expect(user.refreshTokenHash).toBeNull();
     expectClearedCookies(res);
+
+    // Connected AI assistants (OAuth grants) are revoked too — a reset is the
+    // account-recovery signal, so a phished third-party grant must not survive
+    // it (security report 2026-08-27). Personal PATs are spared by the helper.
+    const { revokeOAuthConnectionsForUser } = require('../services/mcpOAuth');
+    expect(revokeOAuthConnectionsForUser).toHaveBeenCalledWith(user._id);
 
     // Brute-force lockout cleared (explicit recovery signal)…
     expect(user.failedLoginAttempts.count).toBe(0);

--- a/backend/src/services/mcpOAuth.js
+++ b/backend/src/services/mcpOAuth.js
@@ -144,6 +144,31 @@ function tokenResponse(rawAccess, rawRefresh, scopes) {
   };
 }
 
+/**
+ * Revoke every OAuth-connection token a user holds — the AI-assistant
+ * connections minted through the consent flow (`oauthClientId` set), NOT the
+ * user's own personal API tokens (HA integration, climate devices), which
+ * carry a null `oauthClientId` and keep their deliberate PAT semantics
+ * (survive password change — Johan's call on the HA-tokens PR).
+ *
+ * Called when a user changes or resets their password (security report
+ * 2026-08-27, second analysis): a phished OAuth connection is a third-party
+ * grant, and the natural "secure my account" reflex must end it — the same
+ * trust boundary already applied to login sessions and SSE streams two lines
+ * away in the auth handlers. Soft revoke (`revokedAt`) so the connection
+ * still shows as revoked in the Settings list; the MCP auth middleware
+ * filters `revokedAt: null`, so access dies on the next request.
+ *
+ * Returns the number of connections revoked (0 when the user had none).
+ */
+async function revokeOAuthConnectionsForUser(userId) {
+  const res = await ApiToken.updateMany(
+    { user: userId, oauthClientId: { $ne: null }, revokedAt: null },
+    { $set: { revokedAt: new Date() } }
+  );
+  return res.modifiedCount || 0;
+}
+
 module.exports = {
   ACCESS_TOKEN_TTL_SEC,
   GRANTABLE_SCOPES,
@@ -158,4 +183,5 @@ module.exports = {
   redirectUriRegistered,
   rotateCredentials,
   tokenResponse,
+  revokeOAuthConnectionsForUser,
 };

--- a/backend/src/services/mcpOAuth.revoke.test.js
+++ b/backend/src/services/mcpOAuth.revoke.test.js
@@ -1,0 +1,43 @@
+/**
+ * revokeOAuthConnectionsForUser (security report 2026-08-27, second analysis).
+ *
+ * The correctness argument is the SCOPING: a password change/reset must revoke
+ * the OAuth-consent connections a victim could have been phished into, but NOT
+ * the user's own personal API tokens (HA integration, climate devices), which
+ * carry a null oauthClientId and keep their deliberate PAT semantics. This
+ * pins the exact query so a future refactor can't quietly widen or narrow it.
+ */
+jest.mock('../models/ApiToken', () => ({ updateMany: jest.fn() }));
+
+const ApiToken = require('../models/ApiToken');
+const { revokeOAuthConnectionsForUser } = require('./mcpOAuth');
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('revokeOAuthConnectionsForUser', () => {
+  const USER = 'u'.repeat(24);
+
+  test('revokes only OAuth connections (oauthClientId set), never personal PATs', async () => {
+    ApiToken.updateMany.mockResolvedValue({ modifiedCount: 3 });
+    const n = await revokeOAuthConnectionsForUser(USER);
+
+    expect(n).toBe(3);
+    expect(ApiToken.updateMany).toHaveBeenCalledTimes(1);
+    const [filter, update] = ApiToken.updateMany.mock.calls[0];
+    // The scoping that spares personal PATs: oauthClientId must be present.
+    expect(filter).toMatchObject({ user: USER, oauthClientId: { $ne: null }, revokedAt: null });
+    // Soft revoke (revokedAt) so the connection still shows as revoked in
+    // Settings; the MCP auth middleware filters revokedAt:null.
+    expect(update.$set.revokedAt).toBeInstanceOf(Date);
+  });
+
+  test('returns 0 when the user has no OAuth connections', async () => {
+    ApiToken.updateMany.mockResolvedValue({ modifiedCount: 0 });
+    expect(await revokeOAuthConnectionsForUser(USER)).toBe(0);
+  });
+
+  test('a driver result without modifiedCount coerces to 0, never undefined', async () => {
+    ApiToken.updateMany.mockResolvedValue({});
+    expect(await revokeOAuthConnectionsForUser(USER)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Context

From the security report received today and the **second-pass analysis** you asked for. The report's headline — *unauthenticated critical account takeover via open Dynamic Client Registration* — **does not hold**:

- `/register` is public **by MCP design** (RFC 7591 DCR); requiring an Initial Access Token would break every MCP client
- `/authorize` **mandates PKCE S256** — the report's own PoC URL omits it and would be rejected
- `/approve` is **Bearer-authenticated, not CSRF-able**, and renders a consent screen naming the client
- token exchange binds code → client + redirect_uri + PKCE verifier; redirect URIs are exact-match, https-or-loopback only

So the attack is ordinary **OAuth consent-phishing**, user-interaction-gated — Low/Medium, not Critical.

## The one valid sub-claim — fixed here

*"Persistent access survives password change."* True: `change-password` and `reset-password` cleared the login refresh session + SSE streams but **never touched the `ApiToken` rows the OAuth flow mints**, and there's no absolute refresh cap — so a phished AI connection outlived the victim's natural *"secure my account"* reflex, killable only by finding it in Settings.

Both handlers now revoke the user's OAuth connections on the **same trust boundary already applied** to sessions and SSE two lines away.

**Scoping (the correctness point):** only consent grants (`oauthClientId` set) are revoked. Personal API tokens — HA integration, climate devices — carry a null `oauthClientId` and keep their **deliberate PAT semantics** (survive password change, per the HA-tokens decision). This fix doesn't reverse that. Soft revoke (`revokedAt`) keeps them visible-as-revoked in Settings; MCP auth filters `revokedAt:null` so access dies on the next request. Count is audited on both actions.

## Tests
- new `mcpOAuth.revoke.test.js` pins the scoping query (revoke OAuth, spare PATs) + modifiedCount coercion
- `auth.refresh.test.js` asserts reset-password calls the revoke
- touched backend suites green in node:20-alpine (142 tests)

## Not in this PR (your call)
- Researcher reply (crediting this finding, correcting the DCR/PKCE/CSRF framing)
- Consent-screen *"unverified app"* hardening (no `verified` flag exists on the client model — consent is the sole barrier)
- **`support@cellarion.app` inbound bounce** — the report's opening note; urgent ops item, unrelated to code