### PR TITLE
fix(scan): close the audit findings on the #1136 style guard

### DIFF
--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -13,6 +13,7 @@ const {
 } = require('../../utils/normalize');
 const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
 const { scoreWineMatch } = require('../../services/wineMatching');
+const { conflictingStyleTerms } = require('../../utils/styleTerms');
 const { sameProducerAppellationGroups, nearProducerPairs, nameSubsetPairs } = require('../../services/registryFragmentation');
 const {
   incompleteGeographyRows, stillIncomplete, GEOGRAPHY_INCOMPLETE_CHECK_ID,
@@ -412,6 +413,16 @@ router.get('/duplicate-clusters', async (req, res) => {
           if (!parent.has(bId)) parent.set(bId, bId);
           const key = aId < bId ? `${aId}|${bId}` : `${bId}|${aId}`;
           if (dismissed.has(key)) continue; // admin marked these as not duplicates
+          // Names stating a DIFFERENT Prädikat/sweetness are a producer's
+          // range, not duplicates (#1134 follow-up): a Mosel estate's whole
+          // range scores 0.83–0.90 pairwise, far above the default 0.6 floor,
+          // and would cluster as the scan's top proposal — one admin merge
+          // from collapsing every user's bottles across it. Same shape as
+          // the dismissed-edge skip above, and reject-only like every other
+          // consumer of this guard: it can only drop a proposed merge, never
+          // propose one, and it spares the n² manual dismissals a surfaced
+          // range would otherwise cost.
+          if (conflictingStyleTerms(a.name, b.name)) continue;
           const score = scoreWineMatch(
             { name: a.name, producer: a.producer, appellation: a.appellation },
             { name: b.name, producer: b.producer, appellation: b.appellation },

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -18,6 +18,7 @@ const { identifyWineFromText } = require('../services/labelScan');
 const aiProvider = require('../services/aiProvider');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
 const { scoreWineMatchVariants, stripProducerPrefix } = require('../services/wineMatching');
+const { conflictingStyleTerms } = require('../utils/styleTerms');
 const { wineVisibilityFilter } = require('../services/wineVisibility');
 const { tryDebitAi, isRefundableFailure } = require('../services/aiBudget');
 const rateLimitsConfig = require('../config/rateLimits');
@@ -315,10 +316,17 @@ async function findWineMatches(item, viewer = {}) {
     }
   }
 
-  // Sort by score descending, return top 5
+  // Sort by score descending, return top 5. Each match carries the style
+  // verdict (issue #1134 follow-up): where the import row and the candidate
+  // NAME a different Prädikat or sweetness they are two wines from one range,
+  // and no similarity score may auto-link them — a Trocken/Halbtrocken pair
+  // from one vineyard measures 0.9543 through this scorer. Annotated here,
+  // at the single place all three consumers get their matches, so the
+  // >= EXACT_THRESHOLD gates and the client's preselection read one verdict.
   const sorted = [...candidates.values()]
     .sort((a, b) => b.score - a.score)
-    .slice(0, 5);
+    .slice(0, 5)
+    .map((m) => ({ ...m, styleConflict: conflictingStyleTerms(item.wineName, m.wine.name) }));
 
   return sorted;
 }
@@ -430,7 +438,12 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
       }
       const matches = await findWineMatches(pr.item, viewer);
       pr.preMatches = matches; // reused by Pass 3 if this row ends up on the fuzzy path
-      if (matches.length > 0 && matches[0].score >= EXACT_THRESHOLD) {
+      // styleConflict gate: findOrCreateWine refuses a style-conflicting
+      // >=0.95 hit and asks, so without the same gate here the (b) comment's
+      // "outcome-identical" claim is false and the import files a Trocken
+      // under its Halbtrocken sibling with status 'exact'. A conflicted top
+      // match falls through to the AI/fuzzy path, where the user chooses.
+      if (matches.length > 0 && matches[0].score >= EXACT_THRESHOLD && !matches[0].styleConflict) {
         pr.registryWine = { wine: matches[0].wine, score: matches[0].score };
       }
     }
@@ -744,12 +757,16 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
           appellation: m.wine.appellation || null,
           type: m.wine.type,
           image: m.wine.image || null,
-          score: Math.round(m.score * 100) / 100
+          score: Math.round(m.score * 100) / 100,
+          styleConflict: m.styleConflict || null
         }));
       } else if (pr.matches.length > 0) {
-        // AI failed or unavailable, but fuzzy matching found candidates
+        // AI failed or unavailable, but fuzzy matching found candidates.
+        // A style-conflicting top match never earns 'exact' — that status
+        // tells the user no review is needed, which is precisely wrong for
+        // a range sibling (see the findWineMatches annotation).
         const { matches } = pr;
-        if (matches[0].score >= EXACT_THRESHOLD) {
+        if (matches[0].score >= EXACT_THRESHOLD && !matches[0].styleConflict) {
           status = 'exact';
         } else {
           status = 'fuzzy';
@@ -763,7 +780,8 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
           appellation: m.wine.appellation || null,
           type: m.wine.type,
           image: m.wine.image || null,
-          score: Math.round(m.score * 100) / 100
+          score: Math.round(m.score * 100) / 100,
+          styleConflict: m.styleConflict || null
         }));
       } else {
         // No match from either AI or fuzzy
@@ -1692,7 +1710,9 @@ router.get('/sessions/:id', async (req, res) => {
       if (!result?.item) continue;
       try {
         const matches = await findWineMatches(result.item, { userId: req.user.id, roles: req.user.roles });
-        if (matches.length > 0 && matches[0].score >= EXACT_THRESHOLD) {
+        // Same styleConflict gate as Pass 1a: this path silently re-points a
+        // row the user marked 'request', so a range sibling must never pass.
+        if (matches.length > 0 && matches[0].score >= EXACT_THRESHOLD && !matches[0].styleConflict) {
           const m = matches[0];
           refreshed[idx] = {
             wineId: m.wine._id,

--- a/backend/src/routes/import.styleGuard.test.js
+++ b/backend/src/routes/import.styleGuard.test.js
@@ -1,0 +1,212 @@
+/**
+ * POST /api/bottles/import/validate — the styleConflict gate (issue #1134 at
+ * import scale).
+ *
+ * The registry-first cascade auto-links at >= 0.95 through the raw scorer,
+ * justified by the Pass 1a comment that findOrCreateWine "would auto-match
+ * the same registry wine". Since the style guard landed in findOrCreateWine
+ * that claim is only true if the cascade carries the same guard: a producer's
+ * range pair with a long shared vineyard name measures 0.9538 (see
+ * services/wineMatching.styleGuard.test.js), so without the gate a Trocken
+ * import row files under its Halbtrocken sibling with status 'exact' — the
+ * one status users are told needs no review.
+ *
+ * Locked here, with AI unconfigured (keyless self-host — the exact deployment
+ * the post-release audit's failure scenario names):
+ *   - a style-conflicting >= 0.95 top match does NOT auto-link: the row comes
+ *     back 'fuzzy', with styleConflict carried on the match for the client's
+ *     preselection guard (utils/importReview.autoSelectionsFor)
+ *   - the same pair WITHOUT a style conflict still auto-links as 'exact' —
+ *     the cascade itself is not blunted
+ *
+ * Harness cloned from import.validate.aiBudget.test.js: real router, real
+ * auth, in-memory WineDefinition.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexWine: () => {},
+  bulkIndexBottles: jest.fn(),
+}));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/priceWarnings', () => ({
+  computeUserMediansByCurrency: jest.fn().mockResolvedValue({}),
+}));
+// Keyless install: the cascade and the fuzzy path are the whole pipeline.
+jest.mock('../services/aiProvider', () => ({ isConfigured: () => false }));
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/Country', () => ({ findOne: jest.fn() }));
+jest.mock('../models/ImportSession', () => ({}));
+jest.mock('../models/Bottle', () => function Bottle() {});
+jest.mock('../models/WineRequest', () => function WineRequest() {});
+jest.mock('../models/Rack', () => {
+  const model = { find: jest.fn() };
+  model.RACK_TYPES = ['grid'];
+  return model;
+});
+jest.mock('../models/WineDefinition', () => {
+  const state = { exactByKey: new Map(), candidates: [] };
+  const chain = (docs) => {
+    const c = { populate: () => c, sort: () => c, limit: () => c, lean: async () => docs };
+    return c;
+  };
+  const model = {
+    findOne: jest.fn((filter) => ({
+      populate: async () => {
+        const keys = filter?.normalizedKey?.$in ?? [filter?.normalizedKey];
+        for (const k of keys) {
+          if (state.exactByKey.has(k)) return state.exactByKey.get(k);
+        }
+        return null;
+      },
+    })),
+    find: jest.fn(() => chain(state.candidates)),
+    findById: jest.fn(),
+    __state: state,
+  };
+  return model;
+});
+jest.mock('../models/AiUsage', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../models/User', () => ({
+  findById: jest.fn(() => ({ select: () => ({ lean: async () => null }) })),
+}));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const WineDefinition = require('../models/WineDefinition');
+const importRouter = require('./import');
+
+const USER_ID = '64b000000000000000000001';
+const CELLAR_ID = '64b0000000000000000000bb';
+
+const APPELLATION = 'Niederhäuser Hermannshöhle';
+// The registry's row — one wine of a range.
+const HALBTROCKEN = {
+  _id: '64b0000000000000000000d1',
+  name: 'Niederhäuser Hermannshöhle Riesling Großes Gewächs Alte Reben Erste Lage Halbtrocken',
+  producer: 'Weingut Dönnhoff',
+  appellation: APPELLATION,
+  type: 'white',
+  image: null,
+  country: { name: 'Germany' },
+  region: { name: 'Nahe' },
+  normalizedKey: 'weingut donnhoff:niederhauser hermannshohle riesling groes gewachs alte reben erste lage halbtrocken:niederhauser hermannshohle',
+};
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles/import', importRouter);
+  return app;
+}
+
+function authToken() {
+  return jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+}
+
+function postJson(app, url, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${authToken()}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.write(payload);
+      req.end();
+    });
+  });
+}
+
+const validate = (items) => postJson(buildApp(), '/api/bottles/import/validate', { cellarId: CELLAR_ID, items });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  WineDefinition.__state.exactByKey.clear();
+  WineDefinition.__state.candidates = [HALBTROCKEN];
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, user: USER_ID, deletedAt: null, members: [] });
+});
+
+describe('import cascade — styleConflict gate', () => {
+  it('a style-conflicting >=0.95 sibling never auto-links as exact', async () => {
+    const { status, body } = await validate([{
+      wineName: 'Niederhäuser Hermannshöhle Riesling Großes Gewächs Alte Reben Erste Lage Trocken',
+      producer: 'Weingut Dönnhoff',
+      appellation: APPELLATION,
+      country: 'Germany',
+    }]);
+
+    expect(status).toBe(200);
+    const row = body.results[0];
+    // 0.9538 clears the auto-link bar — only the gate keeps it a question.
+    expect(row.status).toBe('fuzzy');
+    expect(row.matches[0].wineId).toBe(HALBTROCKEN._id);
+    expect(row.matches[0].score).toBeGreaterThanOrEqual(0.95);
+    expect(row.matches[0].styleConflict).toMatch(/different sweetness/);
+  });
+
+  it('the same shape without a conflict still auto-links — the cascade is not blunted', async () => {
+    const { status, body } = await validate([{
+      // Halbtrocken row against the Halbtrocken registry wine, minor spelling
+      // drift so the exact-key step misses and the fuzzy cascade decides.
+      wineName: 'Niederhauser Hermannshohle Riesling Grosses Gewachs Alte Reben Erste Lage Halbtrocken',
+      producer: 'Weingut Donnhoff',
+      appellation: 'Niederhauser Hermannshohle',
+      country: 'Germany',
+    }]);
+
+    expect(status).toBe(200);
+    const row = body.results[0];
+    expect(row.status).toBe('exact');
+    expect(row.matches[0].wineId).toBe(HALBTROCKEN._id);
+  });
+
+  it('a fuzzy row carries styleConflict so the client can refuse to preselect it', async () => {
+    const { body } = await validate([{
+      // Below 0.95 (producer drifts further) — lands on the plain fuzzy path.
+      wineName: 'Hermannshöhle Riesling GG Trocken',
+      producer: 'Dönnhoff',
+      appellation: APPELLATION,
+      country: 'Germany',
+    }]);
+
+    const row = body.results[0];
+    expect(row.status).toBe('fuzzy');
+    const sibling = row.matches.find((m) => m.wineId === HALBTROCKEN._id);
+    expect(sibling).toBeDefined();
+    expect(sibling.styleConflict).toMatch(/different sweetness/);
+  });
+});

--- a/backend/src/services/wineMatching.styleGuard.test.js
+++ b/backend/src/services/wineMatching.styleGuard.test.js
@@ -75,6 +75,28 @@ describe('style guard on the same range', () => {
     expect(alteReben.score).toBeLessThan(0.95);
   });
 
+  it('a range pair can clear the import auto-link threshold — the guard is the only thing between them', () => {
+    // The import cascade auto-links at >= 0.95 through scoreWineMatchVariants.
+    // A long shared vineyard name makes the one differing style word a small
+    // fraction of the string, so this real-world shape scores ABOVE the
+    // resolver's own auto-link bar while naming two different wines — the
+    // measured proof that the import path needs the styleConflict gate.
+    const { scoreWineMatchVariants } = require('./wineMatching');
+    const A = 'Niederhäuser Hermannshöhle';
+    const halbtrocken = {
+      name: 'Niederhäuser Hermannshöhle Riesling Großes Gewächs Alte Reben Erste Lage Halbtrocken',
+      producer: 'Weingut Dönnhoff', appellation: A,
+    };
+    const trocken = {
+      name: 'Niederhäuser Hermannshöhle Riesling Großes Gewächs Alte Reben Erste Lage Trocken',
+      producer: 'Weingut Dönnhoff', appellation: A,
+    };
+    const score = scoreWineMatchVariants(halbtrocken, trocken);
+    expect(score).toBeCloseTo(0.9538, 4);
+    expect(score).toBeGreaterThanOrEqual(0.95);
+    expect(conflictingStyleTerms(trocken.name, halbtrocken.name)).toMatch(/different sweetness/);
+  });
+
   it('the two Trocken readings are rejected on sweetness, whatever the producer', () => {
     // The guard reads names only, so the misread producer changes nothing —
     // the bottle that escaped by accident would now be kept apart on purpose.

--- a/backend/src/utils/styleTerms.js
+++ b/backend/src/utils/styleTerms.js
@@ -77,7 +77,18 @@ const PRADIKAT_WORDS = new Set([
 const PRADIKAT_ALIASES = new Map([
   ['spaetlese', 'spatlese'],
   ['icewine', 'eiswein'],
-  ['eiswein', 'eiswein'],
+]);
+
+// The sweetness twin of PRADIKAT_ALIASES, for the same keyboard: "Süß" typed
+// without the umlaut is "Suess", which normalizeString leaves alone — without
+// this the guard silently fails open for the standard ue-transliteration
+// (found by the post-release audit, verified by execution). NAME side only,
+// like the Prädikat map: the producer-field rules in crossFieldChecks read
+// SWEETNESS_WORDS directly and must NOT gain 'suess' — Suess is a real
+// surname, and flagging every "Weingut Suess" as a style-term producer is
+// the 'dry'/'sweet' problem over again.
+const SWEETNESS_ALIASES = new Map([
+  ['suess', 'suss'],
 ]);
 
 // Style words that are also ordinary name words. "Dry Creek Zinfandel" states
@@ -105,7 +116,12 @@ const JOINED_PHRASES = [
  * @returns {{pradikat: Set<string>, sweetness: Set<string>}}
  */
 function statedStyle(name) {
-  let folded = normalizeString(String(name == null ? '' : name).replace(/ß/g, 'ss'));
+  // Lowercase BEFORE the ß-fold: the capital eszett ẞ (U+1E9E — the official
+  // uppercase form, routine on all-caps German labels) only becomes ß under
+  // toLowerCase, and folding first left it for normalizeString to delete as
+  // punctuation, silently dropping the sweetness term (post-release audit,
+  // verified by execution: "SÜẞ" read as stating nothing).
+  let folded = normalizeString(String(name == null ? '' : name).toLowerCase().replace(/ß/g, 'ss'));
   for (const [re, joined] of JOINED_PHRASES) folded = folded.replace(re, joined);
 
   const pradikat = new Set();
@@ -113,8 +129,9 @@ function statedStyle(name) {
   for (const token of folded.split(/[^a-z0-9]+/)) {
     if (!token) continue;
     const tier = PRADIKAT_ALIASES.get(token) || token;
-    if (PRADIKAT_WORDS.has(tier)) pradikat.add(tier);
-    else if (SWEETNESS_WORDS.has(token) && !NAME_AMBIGUOUS_WORDS.has(token)) sweetness.add(token);
+    if (PRADIKAT_WORDS.has(tier)) { pradikat.add(tier); continue; }
+    const sweet = SWEETNESS_ALIASES.get(token) || token;
+    if (SWEETNESS_WORDS.has(sweet) && !NAME_AMBIGUOUS_WORDS.has(sweet)) sweetness.add(sweet);
   }
   return { pradikat, sweetness };
 }

--- a/backend/src/utils/styleTerms.test.js
+++ b/backend/src/utils/styleTerms.test.js
@@ -23,6 +23,23 @@ describe('statedStyle', () => {
       .toEqual([...statedStyle('Riesling Spätlese').pradikat]);
   });
 
+  it('reads the capital eszett off an all-caps label', () => {
+    // ẞ (U+1E9E) is the official uppercase ß and only folds to ß under
+    // toLowerCase — the v1.181.0 order folded first and read "SÜẞ" as
+    // stating nothing, so the guard failed open for all-caps labels.
+    expect([...statedStyle('RIESLING SPÄTLESE SÜẞ').sweetness]).toEqual(['suss']);
+    expect(conflictingStyleTerms('RIESLING SPÄTLESE SÜẞ', 'Riesling Spätlese Trocken'))
+      .toMatch(/different sweetness/);
+  });
+
+  it('folds the "ue" transliteration of Süß', () => {
+    expect([...statedStyle('Riesling Spätlese Suess').sweetness]).toEqual(['suss']);
+    expect(conflictingStyleTerms('Riesling Spätlese Suess', 'Riesling Spätlese Trocken'))
+      .toMatch(/different sweetness/);
+    // …and the two spellings of the same wine are NOT a conflict.
+    expect(conflictingStyleTerms('Riesling Spätlese Suess', 'Riesling Spätlese Süß')).toBeNull();
+  });
+
   it('keeps the nested tier names apart', () => {
     // 'trockenbeerenauslese' contains 'beerenauslese' contains 'auslese' as
     // substrings — whole-token matching must see three different tiers, and

--- a/frontend/src/pages/AddBottle.js
+++ b/frontend/src/pages/AddBottle.js
@@ -343,7 +343,16 @@ function AddBottle() {
       // was typed before the camera was opened.
       const queryLabel = opts.queryLabel || search.trim() || wineData.name;
       if (data.candidates && data.candidates.length > 0) {
-        setSoftCandidates(data.candidates);
+        // The scan's own match joins the list when the resolver didn't find
+        // it itself: the scan matcher looks from 0.75, the soft zone from
+        // 0.85, so a 0.79 true match would otherwise vanish exactly when a
+        // higher-scoring sibling makes the list — and "create new" from that
+        // incomplete dialog mints the duplicate the fallback exists to stop.
+        const candidates = (opts.fallback?.wine
+          && !data.candidates.some((c) => c.wine?._id === opts.fallback.wine._id))
+          ? [...data.candidates, { wine: opts.fallback.wine, score: opts.fallback.confidence || 0 }]
+          : data.candidates;
+        setSoftCandidates(candidates);
         setSoftPending({ wineData, carriedVintage, queryLabel });
         return;
       }
@@ -388,15 +397,22 @@ function AddBottle() {
   // match offered below that (see resolveSelectedWine).
   const handleConfirmScan = useCallback(async () => {
     const { extracted, match } = scanResult;
+    // country/type GAP-FILL from the matched row — never identity. The old
+    // matched branch substituted the whole identity, but it also quietly
+    // healed labels that state no country (registry rows always have one;
+    // the resolve endpoint hard-requires it) and typeless extractions
+    // (findOrCreateWine defaults an empty type to 'red'). Keep exactly that
+    // healing: the match fills only what the label did NOT state, and
+    // name/producer/appellation stay the label's own words.
     await resolveSelectedWine(
       {
         name: extracted.name,
         producer: extracted.producer,
-        country: extracted.country || '',
+        country: extracted.country || match?.wine?.country?.name || '',
         region: extracted.region || '',
         appellation: extracted.appellation || '',
         classification: extracted.classification || '',
-        type: extracted.type || '',
+        type: extracted.type || match?.wine?.type || '',
         grapes: extracted.grapes || []
       },
       extracted.vintage,

--- a/frontend/src/pages/AddBottle.scanIdentity.test.js
+++ b/frontend/src/pages/AddBottle.scanIdentity.test.js
@@ -143,6 +143,72 @@ describe('the scanned identity is what gets resolved', () => {
     expect(sent).toHaveProperty('classification');
   });
 
+  test('a label stating no country borrows the matched row\'s — identity stays the label\'s', async () => {
+    // The old matched branch healed countryless labels by accident (registry
+    // rows always have a country; the resolve endpoint requires one). The
+    // fix must keep the healing without the substitution: gap-fill only.
+    resolveWine.mockResolvedValue(jsonRes({ wine: null, created: false, noMatch: true }));
+
+    render(<AddBottle />);
+    await deliverScan({
+      ...SCAN_RESULT,
+      extracted: { ...SCANNED, country: '', type: '' },
+    });
+    await confirmScan();
+
+    const sent = resolveWine.mock.calls[0][1];
+    expect(sent.country).toBe('Germany');        // from NEIGHBOUR.country.name
+    expect(sent.type).toBe('white');             // from NEIGHBOUR.type
+    expect(sent.name).toBe(V + 'Spätlese Alte Reben');  // NOT the neighbour's
+  });
+
+  test('a stated country is never overwritten by the match', async () => {
+    resolveWine.mockResolvedValue(jsonRes({ wine: null, created: false, noMatch: true }));
+
+    render(<AddBottle />);
+    await deliverScan({
+      ...SCAN_RESULT,
+      match: { wine: { ...NEIGHBOUR, country: { name: 'Austria' } }, confidence: 0.87 },
+    });
+    await confirmScan();
+
+    expect(resolveWine.mock.calls[0][1].country).toBe('Germany');
+  });
+
+  test('the scan match joins the resolver\'s own candidate list instead of vanishing', async () => {
+    // Scan matched Y at 0.78; the resolver's soft zone returns sibling Z at
+    // 0.87. v1.181.0 showed only Z — "create new" from that dialog minted a
+    // duplicate of Y, the exact outcome the fallback exists to stop.
+    const SIBLING_Z = { ...NEIGHBOUR, _id: 'wine-trocken', name: V + 'Spätlese Trocken' };
+    resolveWine.mockResolvedValue(jsonRes({
+      wine: null,
+      candidates: [{ wine: SIBLING_Z, score: 0.87 }],
+    }));
+
+    render(<AddBottle />);
+    await deliverScan({ ...SCAN_RESULT, match: { wine: NEIGHBOUR, confidence: 0.78 } });
+    await confirmScan();
+
+    expect(await screen.findByText('similarWines.createNew')).toBeInTheDocument();
+    expect(screen.getByText(SIBLING_Z.name)).toBeInTheDocument();
+    expect(screen.getByText(NEIGHBOUR.name)).toBeInTheDocument();
+  });
+
+  test('the scan match is not duplicated when the resolver already lists it', async () => {
+    resolveWine.mockResolvedValue(jsonRes({
+      wine: null,
+      candidates: [{ wine: NEIGHBOUR, score: 0.87 }],
+    }));
+
+    render(<AddBottle />);
+    await deliverScan(SCAN_RESULT);
+    await confirmScan();
+
+    await screen.findByText('similarWines.createNew');
+    // One row for the neighbour, not two.
+    expect(screen.getAllByText(NEIGHBOUR.name)).toHaveLength(1);
+  });
+
   test('the soft zone asks instead of filing it silently', async () => {
     resolveWine.mockResolvedValue(jsonRes({
       wine: null,

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -115,7 +115,13 @@ function AddToWishlist() {
       const data = await res.json();
       if (!res.ok) { setError(data.error || t('addToWishlist.failedSaveWine')); return; }
       if (data.candidates && data.candidates.length > 0) {
-        setSoftCandidates(data.candidates);
+        // Merge the scan's own match into the list when the resolver didn't
+        // find it itself — mirrors AddBottle; see the comment there.
+        const candidates = (opts.fallback?.wine
+          && !data.candidates.some((c) => c.wine?._id === opts.fallback.wine._id))
+          ? [...data.candidates, { wine: opts.fallback.wine, score: opts.fallback.confidence || 0 }]
+          : data.candidates;
+        setSoftCandidates(candidates);
         setSoftPending({ wineData, queryLabel: opts.queryLabel });
         return;
       }
@@ -302,15 +308,19 @@ function AddToWishlist() {
   // that could have shown the swap.
   const handleConfirmScan = useCallback(async () => {
     const { extracted, match } = scanResult;
+    // country/type GAP-FILL from the matched row — never identity (mirrors
+    // AddBottle; see the comment there). Restores the healing the old
+    // matched branch provided for countryless/typeless extractions without
+    // reintroducing the identity substitution.
     await resolveSelectedWine(
       {
         name: extracted.name,
         producer: extracted.producer,
-        country: extracted.country || '',
+        country: extracted.country || match?.wine?.country?.name || '',
         region: extracted.region || '',
         appellation: extracted.appellation || '',
         classification: extracted.classification || '',
-        type: extracted.type || '',
+        type: extracted.type || match?.wine?.type || '',
         grapes: extracted.grapes || []
       },
       { fallback: match, queryLabel: extracted.name }

--- a/frontend/src/utils/importReview.js
+++ b/frontend/src/utils/importReview.js
@@ -123,7 +123,14 @@ export function autoSelectionsFor(rows) {
       (r.status === 'exact' || r.status === 'fuzzy' || r.status === 'ai_match') &&
       Array.isArray(r.matches) && r.matches.length > 0
     ) {
-      sel[r.index] = r.matches[0].wineId;
+      // Never preselect a match the server marked styleConflict: the row and
+      // that candidate NAME a different Prädikat/sweetness, so they are two
+      // wines from one producer's range — bulk-confirming the preselection is
+      // exactly how issue #1134 replays at import scale. The best
+      // non-conflicting candidate (list is score-ordered) is preselected
+      // instead; if every candidate conflicts, the row is left for the user.
+      const top = r.matches.find((m) => !m.styleConflict);
+      if (top) sel[r.index] = top.wineId;
     } else if (r.status === 'ai_new' && r.aiProposed != null) {
       // AI-identified NEW wines default to 'create' — the wine is minted at
       // /confirm, so leaving the row unselected would silently drop it from

--- a/frontend/src/utils/importReview.test.js
+++ b/frontend/src/utils/importReview.test.js
@@ -208,6 +208,22 @@ describe('autoSelectionsFor', () => {
     expect(autoSelectionsFor(rows)).toEqual({ 0: 'a', 1: 'b', 2: 'd' });
   });
 
+  it('never pre-selects a styleConflict match — the next clean one wins, or nothing', () => {
+    // Issue #1134 at import scale: with AI unavailable, a Trocken row against
+    // its Halbtrocken sibling comes back 'fuzzy' with the sibling on top.
+    // Bulk-confirming that preselection files the whole range under one wine.
+    const conflicted = [
+      { index: 0, status: 'fuzzy', matches: [
+        { wineId: 'sibling', styleConflict: 'each name states a different sweetness (trocken vs halbtrocken)' },
+        { wineId: 'clean', styleConflict: null },
+      ] },
+      { index: 1, status: 'fuzzy', matches: [
+        { wineId: 'only-sibling', styleConflict: 'each name states a different Prädikat (auslese vs spatlese)' },
+      ] },
+    ];
+    expect(autoSelectionsFor(conflicted)).toEqual({ 0: 'clean' });
+  });
+
   it("pre-selects 'create' for ai_new rows with a proposal — and nothing without one", () => {
     const aiRows = [
       { index: 6, status: 'ai_new', matches: [], aiProposed: { name: 'X', producer: 'Y' } },


### PR DESCRIPTION
Follow-up to #1136, from the post-release multi-angle audit of that diff. Five fixes; the four defects were each **verified by executing the real modules** before being fixed, and each fix carries a regression test built from that execution.

## 1. The style guard failed open for two German spellings

- **Capital eszett ẞ (U+1E9E)** — the official uppercase form, routine on all-caps labels. The ß→ss fold ran *before* `normalizeString`'s `toLowerCase`, so ẞ only became ß after the fold had already passed, and was then deleted as punctuation: `statedStyle('RIESLING SPÄTLESE SÜẞ')` stated no sweetness at all. Lowercase now runs first.
- **"Suess"** — the standard ue-transliteration. The Prädikat axis had aliases for exactly this keyboard (`spaetlese`→`spatlese`); the sweetness axis had none. Added a NAME-side alias map (`suess`→`suss`) — deliberately *not* an entry in `SWEETNESS_WORDS`, because the producer rules in `crossFieldChecks` read that set whole-string and Suess is a real surname; `Weingut Suess` must not start flagging as a style-term producer.

Both fail-opens degraded to the resolver's normal ladder (ask at 0.85–0.95), so neither reintroduced #1134 — but the guard silently wasn't doing its job for those spellings.

## 2. Countryless / typeless matched scans regressed

The old matched branch substituted the whole identity — the #1136 bug — but it also quietly **healed** two extraction gaps: labels that state no country (registry rows always have one, and the resolve endpoint hard-requires it — the tap 400'd with a raw "country is required"), and empty types (`findOrCreateWine` defaults to `'red'`, so "create new" on a white Mosel scan minted a red wine). Two independent audit angles found the country case.

Restored as **gap-fill only**: `country: extracted.country || match?.wine?.country?.name`, same for type. The matched row fills what the label did not state; name/producer/appellation stay the label's own words, and a *stated* country is never overwritten (tested).

## 3. The scan-match fallback vanished exactly when it mattered

The #1136 fallback (offer the scan's 0.75–0.85 match as a candidate) only fired on strict `noMatch`. If the resolver returned any ≥0.85 candidate of its own, the scan's match silently dropped out of the "did you mean?" list — and "create new" from that incomplete dialog minted the duplicate the fallback exists to stop. The scan match now **merges into the candidate list** (deduped by id) on both pages.

## 4. The import cascade could still replay #1134 — measured

`routes/import.js` auto-links at ≥0.95 through `scoreWineMatchVariants` with a comment claiming that is "outcome-identical" to `findOrCreateWine` — false since #1136 added the style guard there. Measured with the real scorer:

```
Dönnhoff Niederhäuser Hermannshöhle Riesling GG Alte Reben Erste Lage
  Trocken  vs  Halbtrocken   →  0.9538   (conflictingStyleTerms: trocken vs halbtrocken)
```

A long shared vineyard name makes the one differing style word a small fraction of the string, so a range pair clears the auto-link bar. On a keyless self-host (or when AI budget 429s — which already hits every large import) the row came back status **`exact`** — the one status users are told needs no review — and bulk confirm filed the whole range under one wine.

Fix at the single assembly point: `findWineMatches` annotates every match with its `styleConflict` verdict, and the three ≥0.95 gates (Pass 1a cascade, the fuzzy `exact` status, the session re-match that silently re-points rows marked "request") refuse a conflicted top match. The verdict rides to the client, where `autoSelectionsFor` never preselects a conflicted match — the best clean candidate is preselected instead, or none. A conflicted row is a question, not a bulk-confirmed link.

Route-level test proves the 0.9538 pair returns `fuzzy` + `styleConflict` while the identical-style pair still auto-links `exact` — the cascade is not blunted.

## 5. The admin merge tool proposed merging ranges

`GET /api/admin/wines/duplicates` scored producer-grouped pairs from 0.6 with no style knowledge, so a German estate's Prädikat range (pairwise 0.83–0.90) surfaced as one top-scoring merge cluster — one admin merge from collapsing every user's bottles across it. Style-conflicting edges are now skipped exactly like admin-dismissed (`WineNotDuplicate`) edges. Reject-only, like every consumer of this guard: it can drop a proposed merge, never create one. (No test harness exists for this router; the guard's semantics are covered by the `styleTerms` suites and the wiring is three lines beside an existing skip.)

## Deliberately not here

- **feinherb vs halbtrocken stay a hard conflict** (owner decision): the failure direction of keeping them distinct is a mergeable duplicate on a relabel; aliasing them would silently fold a producer who bottles both.
- The import `/validate` AI-probe's candidates-shape info loss (a ≥0.95 style-conflict row loses its "import as new" offer) — changing the destructure would flip 0.85–0.95 near-matches into a preselected *create*, which mints duplicates by default. Needs its own design pass.
- The audit's ~12 cleanup-class findings (twin `handleConfirmScan` bodies, shared badge component, ß-fold helper consolidation, locale-string dedup) — refactors, not bugs; separate PR if wanted.

## Tests

Backend 496 green across the 21 affected suites + all 24 admin suites (227 tests). Frontend full suite 1047 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
