### PR TITLE
fix(import): empty-winename gate, withdrawn-request cascade, complete-row AI bypass

### DIFF
--- a/backend/src/models/WineRequest.js
+++ b/backend/src/models/WineRequest.js
@@ -43,9 +43,21 @@ const wineRequestSchema = new mongoose.Schema({
   },
   status: {
     type: String,
-    enum: ['pending', 'resolved', 'rejected'],
+    // 'withdrawn': the request left the admin queue because its cellar was
+    // soft-deleted — not judged, not rejected (rejecting notifies the user and
+    // detaches their bottles; withdrawing does neither). Restoring the cellar
+    // re-pends exactly the requests it withdrew, via withdrawnAt below.
+    enum: ['pending', 'resolved', 'rejected', 'withdrawn'],
     default: 'pending',
     index: true
+  },
+  // Stamped with the cellar's own deletedAt by the soft-delete cascade — the
+  // same exact-timestamp pattern the rack cascade uses, so a restore re-pends
+  // ONLY the requests this deletion withdrew and never resurrects one the
+  // user had already lost some other way.
+  withdrawnAt: {
+    type: Date,
+    default: null
   },
   // Admin resolution
   resolvedBy: {

--- a/backend/src/routes/admin/cellars.js
+++ b/backend/src/routes/admin/cellars.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { requireAuth, requireRole } = require('../../middleware/auth');
 const Cellar = require('../../models/Cellar');
 const Rack = require('../../models/Rack');
+const WineRequest = require('../../models/WineRequest');
 const { purgeCellarPermanently } = require('../../services/cellarPurge');
 const { logAudit } = require('../../services/audit');
 const { parsePagination } = require('../../utils/pagination');
@@ -70,6 +71,14 @@ router.post('/:id/restore', async (req, res) => {
     // Restore only the racks cascade-deleted WITH this cellar (matching its
     // exact deletedAt).
     await Rack.updateMany({ cellar: cellar._id, deletedAt: cellarDeletedAt }, { $set: { deletedAt: null } });
+
+    // Re-pend exactly the wine requests this deletion withdrew (same
+    // exact-timestamp pattern as the racks). A request withdrawn by some
+    // OTHER event keeps its status — withdrawnAt is the receipt.
+    await WineRequest.updateMany(
+      { status: 'withdrawn', withdrawnAt: cellarDeletedAt, user: cellar.user },
+      { $set: { status: 'pending', withdrawnAt: null } }
+    );
 
     logAudit(req, 'cellar.restore', { cellarId: cellar._id }, { name: restoredName, owner: cellar.user });
 

--- a/backend/src/routes/admin/wineRequests.js
+++ b/backend/src/routes/admin/wineRequests.js
@@ -28,13 +28,19 @@ router.get('/', async (req, res) => {
     const { status } = req.query;
     const { limit, offset: skip } = parsePagination(req.query, { limit: 50, maxLimit: 200 });
     const filter = {};
-    const VALID_STATUSES = ['pending', 'resolved', 'rejected'];
+    const VALID_STATUSES = ['pending', 'resolved', 'rejected', 'withdrawn'];
 
     if (status) {
       if (!VALID_STATUSES.includes(String(status))) {
         return res.status(400).json({ error: 'Invalid status filter' });
       }
       filter.status = String(status);
+    } else {
+      // Withdrawn requests left the queue with their (soft-deleted) cellar —
+      // not judged, and nothing for a curator to do. They only show when
+      // asked for explicitly (?status=withdrawn), never in the default list
+      // an admin works through.
+      filter.status = { $ne: 'withdrawn' };
     }
 
     const [requests, total] = await Promise.all([

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -9,6 +9,7 @@ const BottleImage = require('../models/BottleImage');
 const WineDefinition = require('../models/WineDefinition');
 const PendingShare = require('../models/PendingShare');
 const ClimateDevice = require('../models/ClimateDevice');
+const WineRequest = require('../models/WineRequest');
 const { getCellarRole } = require('../utils/cellarAccess');
 const { logAudit } = require('../services/audit');
 const { createCellar } = require('../services/rackOps');
@@ -1475,6 +1476,33 @@ router.delete('/:id', async (req, res) => {
     // for restore. Both are hard-deleted by the permanent-delete cascade
     // (services/cellarPurge.js) — and the public wine-list routes 404 while
     // the cellar is soft-deleted, so nothing stays reachable meanwhile.
+
+    // Withdraw the cellar's pending wine requests from the admin queue. A
+    // deleted cellar's requests used to linger as ghosts a curator could
+    // spend real time on (131 of them after one abandoned import,
+    // 2026-08-28) — and resolving one would have bound bottles the user had
+    // already thrown away. Withdrawn, not rejected: rejection notifies the
+    // user and detaches their bottles; a user deleting their own cellar has
+    // asked for neither. Stamped with the cellar's own deletedAt (the rack
+    // cascade's exact-timestamp pattern) so restore re-pends precisely these.
+    // Only requests whose EVERY referencing bottle is inside this cellar —
+    // a request also feeding another cellar's bottles must stay pending.
+    const reqIds = await Bottle.distinct('pendingWineRequest', {
+      cellar: cellar._id, pendingWineRequest: { $ne: null },
+    });
+    if (reqIds.length > 0) {
+      const elsewhere = await Bottle.distinct('pendingWineRequest', {
+        cellar: { $ne: cellar._id }, pendingWineRequest: { $in: reqIds },
+      });
+      const elsewhereSet = new Set(elsewhere.map(String));
+      const onlyHere = reqIds.filter((id) => !elsewhereSet.has(String(id)));
+      if (onlyHere.length > 0) {
+        await WineRequest.updateMany(
+          { _id: { $in: onlyHere }, status: 'pending' },
+          { $set: { status: 'withdrawn', withdrawnAt: now } }
+        );
+      }
+    }
 
     // Bottles are preserved — they remain in history via their status field
 

--- a/backend/src/routes/import.aiBypass.test.js
+++ b/backend/src/routes/import.aiBypass.test.js
@@ -1,0 +1,262 @@
+/**
+ * POST /api/bottles/import/validate — the complete-row AI bypass.
+ *
+ * "The somm is free and we pay for AI" (Johan, 2026-08-29). A row whose file
+ * already states producer + name + a resolvable country (+ a type, stated or
+ * colour-inferred from the file's grapes) is identified BY THE FILE:
+ * Pass 1a sets pr.aiIdentified from the row and Pass 2 treats it exactly like
+ * an AI answer — matchOnly probe, proposal, ai_match/ai_new statuses — while
+ * identifyWineFromText is never called and nothing is debited. One measured
+ * import spent 430 AI calls on rows that were almost all complete.
+ *
+ * Locked here:
+ *   - complete row → NO AI call; ai_new proposal built from the file,
+ *     aiBypassed on the row; ai_match when the registry probe hits
+ *   - the file's country alias resolves ("AU" → "Australia")
+ *   - type inference: no type column + Riesling grapes → 'white'
+ *   - incomplete rows (no country; no type and no colour-inferrable grape)
+ *     still go to AI — the bypass never starves the rows AI is FOR
+ *   - forceAi (the row's Look-up button) still forces a real AI call
+ *
+ * Harness cloned from import.validate.aiBudget.test.js.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+process.env.ANTHROPIC_API_KEY = 'test-key';
+
+jest.mock('../services/search', () => ({
+  getIsAvailable: () => false,
+  search: async () => ({ ids: [] }),
+  indexWine: () => {},
+  bulkIndexBottles: jest.fn(),
+}));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getOrCreateDailySnapshot: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../utils/vintageProfile', () => ({
+  ensurePendingVintageProfile: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/priceWarnings', () => ({
+  computeUserMediansByCurrency: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/Country', () => ({ findOne: jest.fn() }));
+jest.mock('../models/ImportSession', () => ({}));
+jest.mock('../models/Bottle', () => function Bottle() {});
+jest.mock('../models/WineRequest', () => function WineRequest() {});
+jest.mock('../models/Rack', () => {
+  const model = { find: jest.fn() };
+  model.RACK_TYPES = ['grid'];
+  return model;
+});
+jest.mock('../models/WineDefinition', () => {
+  const state = { exactByKey: new Map(), candidates: [] };
+  const chain = (docs) => {
+    const c = { populate: () => c, sort: () => c, limit: () => c, lean: async () => docs };
+    return c;
+  };
+  const model = {
+    findOne: jest.fn((filter) => ({
+      populate: async () => {
+        const keys = filter?.normalizedKey?.$in ?? [filter?.normalizedKey];
+        for (const k of keys) {
+          if (state.exactByKey.has(k)) return state.exactByKey.get(k);
+        }
+        return null;
+      },
+    })),
+    find: jest.fn(() => chain(state.candidates)),
+    findById: jest.fn(),
+    __state: state,
+  };
+  return model;
+});
+// The type-inference colour map reads the grape taxonomy once, lazily.
+jest.mock('../models/Grape', () => {
+  const state = { docs: [] };
+  return {
+    find: jest.fn(() => ({ select: () => ({ lean: async () => state.docs }) })),
+    __state: state,
+  };
+});
+// In-memory AiUsage so a bypass row provably debits nothing.
+jest.mock('../models/AiUsage', () => {
+  const store = new Map();
+  return {
+    findOneAndUpdate: jest.fn(async (filter, update) => {
+      const k = `${filter.userId}|${filter.date}`;
+      if (!store.has(k)) store.set(k, { userId: filter.userId, date: filter.date, count: 0 });
+      const doc = store.get(k);
+      if (update.$inc && typeof update.$inc.count === 'number') doc.count += update.$inc.count;
+      return { ...doc };
+    }),
+    __store: store,
+  };
+});
+jest.mock('../models/User', () => ({
+  findById: jest.fn(() => ({ select: () => ({ lean: async () => null }) })),
+}));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Cellar = require('../models/Cellar');
+const WineDefinition = require('../models/WineDefinition');
+const Grape = require('../models/Grape');
+const AiUsage = require('../models/AiUsage');
+const { identifyWineFromText } = require('../services/labelScan');
+const { findOrCreateWine } = require('../services/findOrCreateWine');
+const importRouter = require('./import');
+
+const USER_ID = '64b000000000000000000001';
+const CELLAR_ID = '64b0000000000000000000bb';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/bottles/import', importRouter);
+  return app;
+}
+function authToken() {
+  return jwt.sign({ id: USER_ID, roles: ['user'] }, 'test-secret', { algorithm: 'HS256', expiresIn: '1h' });
+}
+function postJson(app, url, body) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          port: server.address().port,
+          path: url,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            authorization: `Bearer ${authToken()}`,
+          },
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+          });
+        }
+      );
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.write(payload);
+      req.end();
+    });
+  });
+}
+const validate = (items) => postJson(buildApp(), '/api/bottles/import/validate', { cellarId: CELLAR_ID, items });
+
+const COMPLETE = {
+  wineName: 'Old Vine Reserve Malbec',
+  producer: 'Altocedro',
+  country: 'Argentina',
+  region: 'La Consulta',
+  appellation: 'Uco Valley',
+  type: 'red',
+  grapes: ['Malbec'],
+  vintage: '2019',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  AiUsage.__store.clear();
+  WineDefinition.__state.exactByKey.clear();
+  WineDefinition.__state.candidates = [];
+  Grape.__state.docs = [];
+  Cellar.findById.mockResolvedValue({ _id: CELLAR_ID, user: USER_ID, deletedAt: null, members: [] });
+  // Registry knows nothing unless a test says otherwise.
+  findOrCreateWine.mockResolvedValue({ wine: null, noMatch: true });
+  identifyWineFromText.mockResolvedValue({
+    data: { name: 'AI Name', producer: 'AI Producer', country: 'France', type: 'red', grapes: [], confidence: 0.9 },
+    debugRaw: 'raw',
+    debugReason: null,
+  });
+});
+
+describe('complete-row AI bypass', () => {
+  it('a complete row spends no AI call and proposes the file identity', async () => {
+    const { status, body } = await validate([COMPLETE]);
+    expect(status).toBe(200);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+    expect(AiUsage.__store.size).toBe(0); // nothing debited
+
+    const row = body.results[0];
+    expect(row.status).toBe('ai_new');
+    expect(row.aiBypassed).toBe(true);
+    expect(row.aiProposed).toMatchObject({
+      name: 'Old Vine Reserve Malbec',
+      producer: 'Altocedro',
+      country: 'Argentina',
+      region: 'La Consulta',
+      type: 'red',
+    });
+    // The probe ran on the FILE identity, read-only.
+    expect(findOrCreateWine).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Old Vine Reserve Malbec', producer: 'Altocedro' }),
+      USER_ID,
+      expect.objectContaining({ matchOnly: true })
+    );
+  });
+
+  it('resolves ai_match without AI when the registry probe hits', async () => {
+    const known = {
+      _id: '64b0000000000000000000c9', name: 'Old Vine Reserve Malbec', producer: 'Altocedro',
+      type: 'red', image: null, country: { name: 'Argentina' }, region: { name: 'La Consulta' },
+      appellation: 'Uco Valley', grapes: [],
+    };
+    findOrCreateWine.mockResolvedValue({ wine: known, created: false });
+
+    const { body } = await validate([COMPLETE]);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+    const row = body.results[0];
+    expect(row.status).toBe('ai_match');
+    expect(row.aiBypassed).toBe(true);
+    expect(row.matches[0].wineId).toBe(known._id);
+  });
+
+  it('the file country alias resolves — "AU" imports as Australia', async () => {
+    const { body } = await validate([{ ...COMPLETE, country: 'AU' }]);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+    expect(body.results[0].aiProposed.country).toBe('Australia');
+  });
+
+  it('no type column + white grapes → type inferred white, still no AI', async () => {
+    Grape.__state.docs = [
+      { name: 'Riesling', normalizedName: 'riesling', normalizedSynonyms: [], color: 'White' },
+    ];
+    const { body } = await validate([{
+      ...COMPLETE, wineName: 'Polish Hill Riesling', producer: 'Grosset',
+      type: '', grapes: ['Riesling'],
+    }]);
+    expect(identifyWineFromText).not.toHaveBeenCalled();
+    expect(body.results[0].aiProposed.type).toBe('white');
+    expect(body.results[0].aiBypassed).toBe(true);
+  });
+
+  it('rows the bypass is NOT for still reach the AI', async () => {
+    const { body } = await validate([
+      { ...COMPLETE, wineName: 'No Country Cuvée', country: '' },          // no country
+      { ...COMPLETE, wineName: 'No Type No Grapes', type: '', grapes: [] }, // type undecidable
+      { ...COMPLETE, wineName: 'Unknown Producer Row', producer: 'Unknown' }, // sentinel producer
+    ]);
+    expect(identifyWineFromText).toHaveBeenCalledTimes(3);
+    for (const row of body.results) expect(row.aiBypassed).toBeUndefined();
+  });
+
+  it('forceAi overrides the bypass — the Look-up button means a real call', async () => {
+    await validate([{ ...COMPLETE, forceAi: true }]);
+    expect(identifyWineFromText).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -7,11 +7,12 @@ const Cellar = require('../models/Cellar');
 const Rack = require('../models/Rack');
 const WineDefinition = require('../models/WineDefinition');
 const Country = require('../models/Country');
+const Grape = require('../models/Grape');
 const { getCellarRole } = require('../utils/cellarAccess');
 const { logAudit } = require('../services/audit');
 const { getOrCreateDailySnapshot } = require('../utils/exchangeRates');
 const { resolveRating } = require('../utils/ratingUtils');
-const { normalizeString, resolveCountryName } = require('../utils/normalize');
+const { normalizeString, resolveCountryName, isRecognizedCountry, isUnknownName } = require('../utils/normalize');
 const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
 const searchService = require('../services/search');
 const { identifyWineFromText } = require('../services/labelScan');
@@ -153,6 +154,71 @@ function buildProposedWine(aiData, item) {
     type: (WINE_TYPES.includes(clean(item && item.type)) ? clean(item.type) : null) || aiData.type,
     grapes: aiData.grapes,
     confidence: aiData.confidence,
+  };
+}
+
+/**
+ * Complete-row AI bypass (2026-08-29, Johan's call: "the somm is free and we
+ * pay for AI"). A row whose FILE already states the identity does not need a
+ * model to restate it: findOrCreateWine's ladder does the normalization work
+ * deterministically (producer-prefix canon, trailing-vintage strip,
+ * estate-name unpollution, appellation resolution), the somm/enrichment
+ * pipeline fills the tail, and the AI call would mostly echo the row back.
+ * One large import measured 430 debited calls; most rows carried full data.
+ * The AI keeps the rows it is actually FOR: incomplete or messy ones.
+ *
+ * The gate is "can this row mint cleanly and match correctly without AI",
+ * NOT "is every column filled":
+ *   - producer + wineName + country: required. Identity plus the one field
+ *     the mint hard-requires — and the country must RESOLVE (the file may
+ *     say "AU"; resolveCountryName normalizes it, and an unrecognizable
+ *     country would only turn into a /confirm-time error).
+ *   - type: the file's, or inferred from the file's grapes when they all
+ *     share one taxonomy colour (Riesling → white). Without either the row
+ *     goes to AI — findOrCreateWine defaults a missing type to 'red', and a
+ *     white minted red is exactly the silent error the AI's answer prevents.
+ *     (Known limit: a red-grape rosé with no type column infers 'red' — the
+ *     file's own type column always wins when present.)
+ *   - grapes, region, appellation: NEVER gate the bypass. Grapes are
+ *     inferable from the name and enrichable later; region derives from the
+ *     appellation (regionForAppellation — the appellation's region
+ *     deliberately outranks the file's); appellation was never required.
+ *
+ * Returns an aiIdentified-shaped object (confidence null) so Pass 2 and the
+ * result builder treat the row exactly like an AI-identified one — same
+ * matchOnly probe, same buildProposedWine precedence, no third path — or
+ * null when the row genuinely needs (or lacks the data to skip) the model.
+ */
+function fileCompleteIdentity(item, grapeColourOf) {
+  const clean = (v) => (typeof v === 'string' && v.trim() ? v.trim() : null);
+  const name = clean(item.wineName);
+  const producer = clean(item.producer);
+  if (!name || !producer) return null;
+  if (isUnknownName(name) || isUnknownName(producer)) return null;
+
+  const country = resolveCountryName(clean(item.country) || '');
+  if (!country || !isRecognizedCountry(country)) return null;
+
+  const grapes = sanitizeGrapeNames(item.grapes);
+
+  let type = clean(item.type);
+  if (!WINE_TYPES.includes(type)) type = null;
+  if (!type && grapes.length > 0 && typeof grapeColourOf === 'function') {
+    const colours = new Set(grapes.map((g) => grapeColourOf(g)).filter(Boolean));
+    if (colours.size === 1) type = colours.has('Red') ? 'red' : 'white';
+  }
+  if (!type) return null;
+
+  return {
+    name,
+    producer,
+    country,
+    region: clean(item.region),
+    appellation: clean(item.appellation),
+    classification: clean(item.classification),
+    type,
+    grapes,
+    confidence: null,
   };
 }
 
@@ -425,7 +491,27 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     // (b) existing fuzzy scorer at the exact threshold (>= 0.95) — at that
     //     score the AI path's findOrCreateWine would auto-match the same
     //     registry wine, so skipping AI is outcome-identical;
-    // (c) everything else goes to AI exactly as before.
+    // (c) complete-data rows skip AI too (see fileCompleteIdentity): the file
+    //     itself becomes the identification and Pass 2 treats it exactly like
+    //     an AI answer — matchOnly probe, proposal, the lot;
+    // (d) everything else goes to AI exactly as before.
+    //
+    // Grape-colour lookup for (c)'s type inference — built lazily, once, and
+    // only if some row actually lacks a type column.
+    let grapeColourOf = null;
+    const getGrapeColourOf = async () => {
+      if (grapeColourOf) return grapeColourOf;
+      const docs = await Grape.find({}).select('name normalizedName normalizedSynonyms color').lean();
+      const byKey = new Map();
+      for (const g of docs) {
+        if (!g.color) continue;
+        for (const k of [g.normalizedName, normalizeString(g.name || ''), ...(g.normalizedSynonyms || [])]) {
+          if (k) byKey.set(k, g.color);
+        }
+      }
+      grapeColourOf = (grapeName) => byKey.get(normalizeString(String(grapeName || ''))) || null;
+      return grapeColourOf;
+    };
     for (const pr of uniquePrs) {
       if (clientDisconnected) break; // requester gone — stop the cascade, skip AI entirely
       // forceAi bypasses the cascade only when there is an AI to reach; with
@@ -445,6 +531,19 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
       // match falls through to the AI/fuzzy path, where the user chooses.
       if (matches.length > 0 && matches[0].score >= EXACT_THRESHOLD && !matches[0].styleConflict) {
         pr.registryWine = { wine: matches[0].wine, score: matches[0].score };
+        continue;
+      }
+      // (c) the complete-row bypass. Needs the colour map only when the row
+      // has grapes but no type, so the taxonomy read is lazy.
+      const identity = fileCompleteIdentity(
+        pr.item,
+        (!pr.item.type && Array.isArray(pr.item.grapes) && pr.item.grapes.length > 0)
+          ? await getGrapeColourOf()
+          : null
+      );
+      if (identity) {
+        pr.aiIdentified = identity;
+        pr.aiBypassed = true;
       }
     }
 
@@ -454,7 +553,9 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
     // refunded on transport failure), and a client-disconnect check that
     // stops LAUNCHING new calls once the requester has gone away. All three
     // degrade gracefully to the fuzzy path (aiSkipped: true) — never an error.
-    const needAi = aiConfigured ? uniquePrs.filter(pr => !pr.registryWine) : [];
+    // aiIdentified may already be set by the Pass 1a complete-row bypass —
+    // those rows have their identification and must not spend a call on it.
+    const needAi = aiConfigured ? uniquePrs.filter(pr => !pr.registryWine && !pr.aiIdentified) : [];
     const perRequestCap = rateLimitsConfig.get().aiImportPerRequestCap?.max
       ?? rateLimitsConfig.defaults.aiImportPerRequestCap.max;
     const aiRun = needAi.slice(0, perRequestCap);
@@ -808,6 +909,9 @@ router.post('/validate', aiBurstLimiter, async (req, res) => {
       // per-request cap, or client disconnect) — they fell through to the
       // fuzzy path above. Informational only; the row itself never errors.
       if (pr.aiSkipped) result.aiSkipped = true;
+      // Complete-data rows resolved without spending an AI call (Pass 1a's
+      // fileCompleteIdentity) — informational, for transparency and debugging.
+      if (pr.aiBypassed) result.aiBypassed = true;
       results.push(result);
     }
 
@@ -1228,9 +1332,15 @@ router.post('/confirm', async (req, res) => {
         }
 
         if (item.requestWine) {
-          // No match — create a pending WineRequest and bottle without wineDefinition
-          if (!item.wineName && !item.producer) {
-            errors.push({ index: i, reason: 'Wine name or producer is required' });
+          // No match — create a pending WineRequest and bottle without wineDefinition.
+          // wineName is REQUIRED, not wineName-or-producer: the old fallback
+          // filed the PRODUCER as the wine's name, and one broken export did
+          // that 131 times in one import — junk requests no curator can
+          // resolve, since many distinct cuvées sit behind one producer
+          // string. The frontend mapper now skips nameless rows before they
+          // get here; this is the API-side mirror for other clients.
+          if (!item.wineName || !String(item.wineName).trim()) {
+            errors.push({ index: i, reason: 'A wine name is required to request a wine' });
             continue;
           }
 
@@ -1245,7 +1355,7 @@ router.post('/confirm', async (req, res) => {
             const suggestedGrapes = sanitizeGrapeNames(item.grapes);
             wineRequest = new WineRequest({
               requestType: 'new_wine',
-              wineName: (item.wineName || item.producer || '').trim(),
+              wineName: String(item.wineName).trim(),
               producer: (item.producer || '').trim() || undefined,
               user: req.user.id,
               status: 'pending',

--- a/backend/src/routes/wineRequests.js
+++ b/backend/src/routes/wineRequests.js
@@ -69,8 +69,10 @@ router.get('/', async (req, res) => {
     const { status } = req.query;
     const filter = { user: req.user.id };
 
-    // Must match the WineRequest schema enum — resolve sets 'resolved', not 'approved'
-    const validStatuses = ['pending', 'resolved', 'rejected'];
+    // Must match the WineRequest schema enum — resolve sets 'resolved', not 'approved'.
+    // 'withdrawn' (request left the queue with its deleted cellar) stays
+    // visible in the user's OWN list — it is their history — and filterable.
+    const validStatuses = ['pending', 'resolved', 'rejected', 'withdrawn'];
     if (status) {
       if (!validStatuses.includes(status)) {
         return res.status(400).json({ error: `Invalid status filter. Must be one of: ${validStatuses.join(', ')}` });

--- a/backend/src/services/cellarPurge.js
+++ b/backend/src/services/cellarPurge.js
@@ -26,6 +26,7 @@ const PendingShare = require('../models/PendingShare');
 const WineList = require('../models/WineList');
 const ClimateDevice = require('../models/ClimateDevice');
 const Cellar = require('../models/Cellar');
+const WineRequest = require('../models/WineRequest');
 const { deleteLogoFilesFor } = require('./wineListLogos');
 const { unlinkImageFiles } = require('./imageProcessor');
 const searchService = require('./search');
@@ -40,6 +41,30 @@ const searchService = require('./search');
  */
 async function purgeCellarPermanently(cellarId) {
   const bottleIds = await Bottle.find({ cellar: cellarId }).distinct('_id');
+
+  // Wine requests that exist only because of this cellar's bottles go with
+  // them — a request whose every referencing bottle is being purged can never
+  // be resolved into anything (soft-delete already withdrew it from the admin
+  // queue; this closes the loop). Resolved/rejected requests are HISTORY and
+  // stay; a request also feeding another cellar's bottles stays pending
+  // there. Computed BEFORE Bottle.deleteMany below, or the "referenced
+  // elsewhere" check would see an already-emptied collection.
+  const reqIds = await Bottle.distinct('pendingWineRequest', {
+    cellar: cellarId, pendingWineRequest: { $ne: null },
+  });
+  if (reqIds.length > 0) {
+    const elsewhere = await Bottle.distinct('pendingWineRequest', {
+      cellar: { $ne: cellarId }, pendingWineRequest: { $in: reqIds },
+    });
+    const elsewhereSet = new Set(elsewhere.map(String));
+    const onlyHere = reqIds.filter((id) => !elsewhereSet.has(String(id)));
+    if (onlyHere.length > 0) {
+      await WineRequest.deleteMany({
+        _id: { $in: onlyHere },
+        status: { $in: ['pending', 'withdrawn'] },
+      });
+    }
+  }
 
   let imagesDeleted = 0;
   if (bottleIds.length > 0) {

--- a/backend/src/services/cellarPurge.test.js
+++ b/backend/src/services/cellarPurge.test.js
@@ -8,6 +8,7 @@
 jest.mock('../models/Bottle', () => ({
   find: jest.fn(),
   deleteMany: jest.fn(),
+  distinct: jest.fn(),
 }));
 jest.mock('../models/BottleImage', () => ({
   find: jest.fn(),
@@ -22,6 +23,7 @@ jest.mock('../models/PendingShare', () => ({ deleteMany: jest.fn() }));
 jest.mock('../models/WineList', () => ({ deleteMany: jest.fn() }));
 jest.mock('../models/ClimateDevice', () => ({ updateMany: jest.fn() }));
 jest.mock('../models/Cellar', () => ({ deleteOne: jest.fn() }));
+jest.mock('../models/WineRequest', () => ({ deleteMany: jest.fn() }));
 jest.mock('./wineListLogos', () => ({ deleteLogoFilesFor: jest.fn() }));
 jest.mock('./imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
 jest.mock('./search', () => ({ removeBottles: jest.fn() }));
@@ -36,6 +38,7 @@ const PendingShare = require('../models/PendingShare');
 const WineList = require('../models/WineList');
 const ClimateDevice = require('../models/ClimateDevice');
 const Cellar = require('../models/Cellar');
+const WineRequest = require('../models/WineRequest');
 const { deleteLogoFilesFor } = require('./wineListLogos');
 const { unlinkImageFiles } = require('./imageProcessor');
 const searchService = require('./search');
@@ -51,6 +54,8 @@ const OWN_IMAGES = [
 
 function setupMocks({ bottleIds = BOTTLE_IDS, ownImages = OWN_IMAGES } = {}) {
   Bottle.find.mockReturnValue({ distinct: jest.fn().mockResolvedValue(bottleIds) });
+  Bottle.distinct.mockResolvedValue([]);
+  WineRequest.deleteMany.mockResolvedValue({ deletedCount: 0 });
   BottleImage.find.mockReturnValue({
     select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(ownImages) }),
   });
@@ -167,5 +172,28 @@ describe('purgeCellarPermanently', () => {
     expect(searchService.removeBottles).toHaveBeenCalledWith([]);
     expect(Cellar.deleteOne).toHaveBeenCalledWith({ _id: CELLAR_ID });
     expect(result).toEqual({ racksDeleted: 2, bottlesDeleted: 0, imagesDeleted: 0 });
+  });
+
+  // ── Wine-request cascade (fix/import-empty-winename) ─────────────────────
+  // A request whose every referencing bottle is being purged can never be
+  // resolved into anything — it goes with the bottles. Requests also feeding
+  // another cellar's bottles stay; resolved/rejected are history and stay.
+
+  test('deletes pending/withdrawn requests referenced only by this cellar', async () => {
+    Bottle.distinct.mockImplementation(async (field, filter) =>
+      (filter && filter.cellar === CELLAR_ID) ? ['r1', 'r2', 'r3'] : ['r2']);
+
+    await purgeCellarPermanently(CELLAR_ID);
+
+    expect(WineRequest.deleteMany).toHaveBeenCalledWith({
+      _id: { $in: ['r1', 'r3'] },                 // r2 is referenced elsewhere
+      status: { $in: ['pending', 'withdrawn'] },  // resolved/rejected = history
+    });
+  });
+
+  test('no request refs → the request collection is never touched', async () => {
+    Bottle.distinct.mockResolvedValue([]);
+    await purgeCellarPermanently(CELLAR_ID);
+    expect(WineRequest.deleteMany).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/AdminRequests.css
+++ b/frontend/src/pages/AdminRequests.css
@@ -324,3 +324,9 @@
   font-size: 0.85em;
   color: var(--color-text-secondary, #888);
 }
+
+/* Withdrawn = left the queue with its deleted cellar; muted, not alarming. */
+.status-badge.status-withdrawn {
+  background: var(--color-border-light, #f0ece8);
+  color: var(--color-text-secondary, #888);
+}

--- a/frontend/src/pages/AdminRequests.js
+++ b/frontend/src/pages/AdminRequests.js
@@ -335,7 +335,10 @@ function AdminRequests() {
         {/* Left panel: request list */}
         <div className="requests-panel">
           <div className="panel-filters">
-            {['pending', 'resolved', 'rejected', ''].map(s => (
+            {/* 'withdrawn' = requests that left the queue with their deleted
+                cellar — excluded from every other view (including All, which
+                the backend now defaults to non-withdrawn), reachable here. */}
+            {['pending', 'resolved', 'rejected', 'withdrawn', ''].map(s => (
               <button
                 key={s || 'all'}
                 className={`filter-btn ${statusFilter === s ? 'active' : ''}`}

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -1748,10 +1748,18 @@ export function parseAndMap(text, forceFormat) {
     if (mapped.consumedAt)   mapped.consumedAt   = tryParseDate(mapped.consumedAt);
     if (mapped.dateAdded)    mapped.dateAdded    = tryParseDate(mapped.dateAdded);
 
-    // Skip rows with no wine name and no producer \u2014 counted so the upload
-    // step can say so instead of the rows just vanishing (Vivino scan
-    // history routinely contains label-image-only rows for failed scans).
-    if (!mapped.wineName && !mapped.producer) { noIdentitySkipped++; continue; }
+    // Skip rows with no wine name \u2014 counted so the upload step can say so
+    // instead of the rows just vanishing (Vivino scan history routinely
+    // contains label-image-only rows for failed scans). This used to be
+    // `!wineName && !producer`, an AND, so a producer-only row slipped
+    // through \u2014 and the import then filed a WineRequest with the PRODUCER as
+    // the wine's name. One broken generic-CSV export did that 131 times in a
+    // single import ("Hewitson \u2014 Hewitson", 2026-08-28): a whole cellar
+    // parked on junk requests no curator can resolve, because 250 distinct
+    // cuv\u00e9es sat behind one producer string. The module's own master-format
+    // doc has always said wineName is required; now the gate agrees.
+    // Name-only rows (no producer) still pass \u2014 those resolve fine.
+    if (!mapped.wineName) { noIdentitySkipped++; continue; }
 
     // `?? 1` not `|| 1`: CT List rows can legitimately carry quantity 0
     // (fully pending wines) and must expand to zero items. All other

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -629,6 +629,30 @@ describe('parseAndMap', () => {
     expect(result.warnings).toEqual([{ code: 'no-identity-skipped', count: 1 }]);
   });
 
+  it('skips PRODUCER-ONLY rows too — a producer is not a wine name', () => {
+    // The 2026-08-28 cal import: a generic CSV whose name column never
+    // mapped produced 148 producer-only rows, and the old AND-gate
+    // (`!wineName && !producer`) let every one through — each then filed a
+    // WineRequest with the PRODUCER as the wine's name ("Hewitson —
+    // Hewitson", ×131). wineName is required, exactly as the master-format
+    // doc at the top of this module has always said.
+    const csv = 'Wine,Producer,Vintage\n,Hewitson,2005\n,Tahbilk,2019\nMargaux,CM,2016';
+    const result = parseAndMap(csv);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].wineName).toBe('Margaux');
+    expect(result.warnings).toEqual([{ code: 'no-identity-skipped', count: 2 }]);
+  });
+
+  it('name-only rows (no producer) still import', () => {
+    // The other half of the same import: "Fulyunton P18 Shiraz" had a name
+    // and no producer, and resolved fine. The gate must not lose these.
+    const csv = 'Wine,Producer,Vintage\nFulyunton P18 Shiraz,,2018';
+    const result = parseAndMap(csv);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].wineName).toBe('Fulyunton P18 Shiraz');
+    expect(result.warnings ?? []).toEqual([]); // warnings is unset when empty
+  });
+
   it('handles BOM-prefixed CSV', () => {
     const csv = '\uFEFFWine name,Winery,Vintage\nMargaux,Chateau Margaux,2015';
     const result = parseAndMap(csv);


### PR DESCRIPTION
Three intake fixes, all motivated by this week's two large imports (one failed-then-retried 1,6xx-bottle import on the 28th, one clean 1,354-bottle import on the 29th).

## 1. A wine name is required — the empty-winename bug

The frontend mapper's identity gate was an **AND** — `if (!mapped.wineName && !mapped.producer)` — so a generic CSV whose name column never mapped pushed 148 producer-only rows through. The import then filed a `WineRequest` with the **producer as the wine's name**: 131 junk "Hewitson — Hewitson" requests from one abandoned import, unresolvable by design (≈250 distinct cuvées behind one producer string). The module's own master-format doc has always said wineName is required; now the gate agrees.

- `importMappers.js`: producer-only rows hit the existing `no-identity-skipped` warning. **Name-only rows still import** (they resolve fine — tested with the real case).
- `routes/import.js` `/confirm`: the API-side mirror — a request without a wine name is a row error, and the producer-as-name fallback is gone.

## 2. Wine requests follow their cellar — the `withdrawn` cascade

A deleted cellar's pending requests used to linger as ghosts a curator could spend real hours on — and resolving one would have bound bottles the user had already thrown away.

- **New `WineRequest` status `withdrawn`** + `withdrawnAt`. Withdrawn ≠ rejected: rejection notifies the user and detaches their bottles; a user deleting their own cellar asked for neither.
- **Soft-delete** withdraws pending requests referenced *only* by that cellar's bottles, stamped with the cellar's own `deletedAt` (the rack cascade's exact-timestamp pattern). A request also feeding another cellar's bottles stays pending.
- **Admin restore** re-pends exactly the requests that deletion withdrew (`withdrawnAt` match).
- **Permanent purge** deletes pending/withdrawn requests whose every referencing bottle it is deleting. Resolved/rejected are history and stay.
- The default admin queue excludes withdrawn (`?status=withdrawn` shows them); the user's own list keeps them visible — it's their history.

*Already applied retroactively on prod (2026-08-29): the 131 junk requests are withdrawn, the reporter's 2 genuine ones stayed pending, and the global pending queue went 140 → 9.*

## 3. Complete-row AI bypass — "the somm is free and we pay for AI"

A row whose file already states the identity does not need a model to restate it. The deterministic ladder (`findOrCreateWine`: producer-prefix canon, vintage strip, estate-name unpollution, appellation resolution) does the normalization; the somm/enrichment pipeline fills the tail. The 29th's import spent **430 debited AI calls** (plus 4 burst-limiter 429s) on rows that were almost all complete.

The gate is *"can this row mint cleanly and match correctly without AI"*, *not* "is every column filled":

| field | gates the bypass? | why |
|---|---|---|
| producer + wineName | **yes** | the identity itself |
| country | **yes** (must *resolve* — "AU" → Australia) | the mint hard-requires it; an unresolvable country would just error at /confirm |
| type | yes, **or** inferred when the file's grapes share one taxonomy colour | `findOrCreateWine` defaults missing type to `'red'` — a white minted red is the silent error the AI's answer prevents |
| grapes | **no** | inferable from the name, enrichable later |
| region | **no** | derives from the appellation (`regionForAppellation` deliberately outranks the file) |
| appellation | **no** | never was required |

Mechanically: Pass 1a sets `pr.aiIdentified` from the file (confidence `null`) and Pass 2 treats the row exactly like an AI answer — same `matchOnly` probe, same `buildProposedWine` precedence, same `ai_match`/`ai_new` statuses — no third path. Rows carry `aiBypassed: true` for transparency. Rows the AI is actually *for* — incomplete, sentinel producers, undecidable type — still go to AI, and `forceAi` (the row's Look-up button) always does.

Side effect worth naming: on **keyless self-hosted installs** complete rows now get real `ai_new` proposals instead of degrading to fuzzy-only — the bypass is the whole pipeline there.

Known limit (documented in code): a red-grape rosé with no type column infers `'red'` — the file's type column always wins when present.

## Tests

- `import.aiBypass.test.js` (new): no AI call + nothing debited for complete rows; `ai_match` via the probe; "AU"→Australia; Riesling→white inference; incomplete/sentinel/undecidable rows still reach AI; `forceAi` overrides.
- `cellarPurge.test.js`: only-here requests deleted (pending/withdrawn only), shared-elsewhere kept.
- `importMappers.test.js`: producer-only rows skipped with the warning (the real 148-row shape), name-only rows still import.

Backend: 137 green across the 14 affected suites. Frontend: full suite 1,049 green, build clean.

## Not in this PR

- The aiBurst limiter itself (`aiBurst: max 10/min` shared bucket) — the bypass removes most of the pressure (both measured imports would have made a handful of calls), but the import path still shares the interactive bucket. Follow-up if 429s persist after this ships.
- Widening the generic mapper's name-column aliases — we still want the reporter's original CSV before guessing (speculative aliases risk mis-mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
