### PR TITLE
feat(registry): tell contributors what happened to their proposal

### DIFF
--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -51,7 +51,14 @@ const notificationSchema = new mongoose.Schema({
       'registry_health',
       'owner_inquiry',
       'owner_inquiry_response',
-      'owner_inquiry_resolved'
+      'owner_inquiry_resolved',
+      // Registry-data contributions. Every other submitter-facing queue
+      // (wine requests, wine reports, images, price requests) tells the
+      // submitter what happened; these two were the gap — a decided
+      // proposal recorded its rejectReason where only a GDPR export could
+      // reach it.
+      'registry_key_decided',
+      'registry_value_decided'
     ],
     required: true
   },

--- a/backend/src/services/registryDataOps.js
+++ b/backend/src/services/registryDataOps.js
@@ -19,6 +19,7 @@ const { checkContributionGate } = require('./contributionGate');
 const { stripHtml } = require('../utils/sanitize');
 const { isValidId } = require('../utils/validation');
 const { logAudit } = require('./audit');
+const { createNotification } = require('./notifications');
 
 // Names that would shadow first-class record fields — a key called
 // "producer" or "region" must never exist beside the real thing.
@@ -247,6 +248,29 @@ async function listReviewQueues() {
   return { ok: true, keys, values };
 }
 
+/**
+ * Notify a contributor that their registry-data submission was decided.
+ *
+ * The reason is APPENDED to the message rather than replacing it, so an
+ * accept still reads well (no reason) and a reject carries the curator's
+ * words verbatim — which is the whole point: the rejectReason field existed,
+ * was written, capped at 500 chars, and had no reader.
+ *
+ * Fire-and-forget by construction: the decision is already persisted and
+ * audit-logged when this runs, and a push/DB hiccup must not surface as a
+ * failed decision to the admin (mirrors routes/admin/wineRequests).
+ */
+function notifyDecision(userId, type, title, message, reason) {
+  if (!userId) return;
+  const body = reason ? `${message}\n\n${reason}` : message;
+  // No link: unlike a wine request (which has /wine-requests) a contributor
+  // has no page listing their own registry-data proposals, so the message
+  // has to stand alone — and a link to a non-existent route would just 404.
+  createNotification(userId, type, title, body, null).catch((err) => {
+    console.warn('[registryDataOps] decision notification failed (non-fatal):', err.message);
+  });
+}
+
 async function decideKey(adminId, keyId, decision, rejectReason, { req } = {}) {
   if (!isValidId(String(keyId))) return fail('invalid', 'Invalid key id');
   if (!['accept', 'reject'].includes(decision)) return fail('invalid', "decision must be 'accept' or 'reject'");
@@ -266,6 +290,22 @@ async function decideKey(adminId, keyId, decision, rejectReason, { req } = {}) {
   invalidateVocabCache();
   logAudit(req || null, `registry_data.key_${decision}`,
     { type: 'registry_key', id: key._id }, { name: key.name });
+
+  // Tell the proposer. Without this the decision — and the rejectReason a
+  // curator took the trouble to write — was reachable only through a GDPR
+  // data export, so a contributor got silence either way. Fire-and-forget,
+  // like every other notify call: a notification failure must never undo a
+  // recorded decision.
+  notifyDecision(
+    key.proposedBy,
+    'registry_key_decided',
+    decision === 'accept' ? 'Registry key accepted' : 'Registry key not accepted',
+    decision === 'accept'
+      ? `Your proposed key "${key.name}" is now part of the registry vocabulary — wines can carry it from now on. Thank you for improving the registry.`
+      : `Your proposed key "${key.name}" was not added to the registry vocabulary.`,
+    key.rejectReason
+  );
+
   return { ok: true, key: serializeKey(key) };
 }
 
@@ -286,6 +326,13 @@ async function decideValue(adminId, valueId, decision, rejectReason, { req } = {
     await row.save();
     logAudit(req || null, 'registry_data.value_reject',
       { type: 'wine', id: row.wineDefinition }, { key: row.key?.name, valueId: row._id });
+    notifyDecision(
+      row.suggestedBy,
+      'registry_value_decided',
+      'Suggested value not published',
+      `Your suggested ${row.key?.name || 'value'} was not published to the registry.`,
+      row.rejectReason
+    );
     return { ok: true, value: { _id: row._id, status: row.status } };
   }
 
@@ -304,6 +351,12 @@ async function decideValue(adminId, valueId, decision, rejectReason, { req } = {
   await row.save();
   logAudit(req || null, 'registry_data.value_publish',
     { type: 'wine', id: row.wineDefinition }, { key: row.key?.name, valueId: row._id, value: row.value });
+  notifyDecision(
+    row.suggestedBy,
+    'registry_value_decided',
+    'Suggested value published',
+    `Your suggested ${row.key?.name || 'value'} (${row.value}) is now published on the wine. Thank you for improving the registry.`
+  );
   return { ok: true, value: { _id: row._id, status: row.status, value: row.value } };
 }
 

--- a/backend/src/services/registryDataOps.test.js
+++ b/backend/src/services/registryDataOps.test.js
@@ -20,11 +20,13 @@ jest.mock('./contributionGate', () => ({
 }));
 jest.mock('./wineVisibility', () => ({ findVisibleWine: jest.fn() }));
 jest.mock('./audit', () => ({ logAudit: jest.fn() }));
+jest.mock('./notifications', () => ({ createNotification: jest.fn(() => Promise.resolve()) }));
 
 const RegistryDataKey = require('../models/RegistryDataKey');
 const RegistryDataValue = require('../models/RegistryDataValue');
 const { checkContributionGate } = require('./contributionGate');
 const { findVisibleWine } = require('./wineVisibility');
+const { createNotification } = require('./notifications');
 const ops = require('./registryDataOps');
 
 const oid = (c) => c.repeat(24);
@@ -240,6 +242,77 @@ describe('admin decisions', () => {
     expect(res.ok).toBe(true);
     expect(row.status).toBe('rejected');
     expect(RegistryDataValue.updateOne).not.toHaveBeenCalled();
+  });
+
+  // ── Contributor feedback (2026-08-30) ────────────────────────────────────
+  // The rejectReason field was written, capped and stored — and had no
+  // reader: no notification type existed, and the user-facing keys endpoint
+  // returns only the accepted vocabulary, so a curator's explanation reached
+  // the contributor solely through a GDPR export. Every sibling queue (wine
+  // requests, reports, images, price requests) notifies its submitter.
+
+  test('a rejected key notifies its proposer WITH the curator reason', async () => {
+    RegistryDataKey.findOneAndUpdate.mockResolvedValue({
+      ...acceptedKey, name: 'Beautiful', status: 'rejected',
+      proposedBy: ME, rejectReason: 'Not an objective property.',
+    });
+    await ops.decideKey(ADMIN, KEY, 'reject', 'Not an objective property.');
+
+    expect(createNotification).toHaveBeenCalledWith(
+      ME, 'registry_key_decided', 'Registry key not accepted',
+      expect.stringContaining('Not an objective property.'),
+      null
+    );
+    // The name is in the message too, so the notification stands alone.
+    expect(createNotification.mock.calls[0][3]).toContain('Beautiful');
+  });
+
+  test('an accepted key notifies without a reason paragraph', async () => {
+    RegistryDataKey.findOneAndUpdate.mockResolvedValue({
+      ...acceptedKey, status: 'accepted', proposedBy: ME, rejectReason: undefined,
+    });
+    await ops.decideKey(ADMIN, KEY, 'accept');
+
+    const [, type, title, message] = createNotification.mock.calls[0];
+    expect(type).toBe('registry_key_decided');
+    expect(title).toBe('Registry key accepted');
+    expect(message).not.toContain('\n\n'); // no empty reason block appended
+  });
+
+  test('value decisions notify the suggester both ways', async () => {
+    const base = () => ({
+      _id: oid('9'), wineDefinition: WINE, key: acceptedKey, value: 13.5,
+      status: 'suggested', suggestedBy: ME, save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    RegistryDataValue.findOne.mockReturnValue({ populate: jest.fn().mockResolvedValue(base()) });
+    await ops.decideValue(ADMIN, oid('9'), 'reject', 'unsourced');
+    expect(createNotification).toHaveBeenLastCalledWith(
+      ME, 'registry_value_decided', 'Suggested value not published',
+      expect.stringContaining('unsourced'), null
+    );
+
+    RegistryDataValue.findOne.mockReturnValue({ populate: jest.fn().mockResolvedValue(base()) });
+    await ops.decideValue(ADMIN, oid('9'), 'publish');
+    expect(createNotification).toHaveBeenLastCalledWith(
+      ME, 'registry_value_decided', 'Suggested value published',
+      expect.stringContaining('13.5'), null
+    );
+  });
+
+  test('a decision still succeeds when the notification fails', async () => {
+    // Fire-and-forget: the decision is already persisted and audit-logged.
+    createNotification.mockRejectedValueOnce(new Error('push broker down'));
+    RegistryDataKey.findOneAndUpdate.mockResolvedValue({ ...acceptedKey, status: 'accepted', proposedBy: ME });
+    const res = await ops.decideKey(ADMIN, KEY, 'accept');
+    expect(res.ok).toBe(true);
+  });
+
+  test('a proposal from a deleted account is decided without notifying', async () => {
+    RegistryDataKey.findOneAndUpdate.mockResolvedValue({ ...acceptedKey, status: 'accepted', proposedBy: null });
+    const res = await ops.decideKey(ADMIN, KEY, 'accept');
+    expect(res.ok).toBe(true);
+    expect(createNotification).not.toHaveBeenCalled();
   });
 
   test('review queues are bounded', async () => {

--- a/frontend/src/components/NotificationBell.css
+++ b/frontend/src/components/NotificationBell.css
@@ -165,6 +165,11 @@
   color: var(--color-text-muted);
   line-height: 1.4;
   word-break: break-word;
+  /* Messages may carry a paragraph break — a registry-data decision appends
+     the curator's reason under the summary line. Without this the two run
+     together into one wall of text. Existing single-line messages are
+     unaffected: pre-line still collapses ordinary wrapping whitespace. */
+  white-space: pre-line;
 }
 
 .notif-time {


### PR DESCRIPTION
Registry-data decisions told the contributor nothing.

`RegistryDataKey.rejectReason` / `RegistryDataValue.rejectReason` are written, HTML-stripped and capped at 500 chars by `decideKey` / `decideValue` — and had **no reader**. `Notification`'s type enum had no entry for these queues, and the user-facing `GET /api/registry-data/keys` returns only the *accepted* vocabulary, so a curator's explanation reached the person who wrote the proposal solely through a GDPR data export.

Every sibling submitter queue already notifies: wine requests (`wine_request_resolved` / `_rejected`), wine reports, images, price-tracking requests, owner inquiries. Registry data was the gap.

## What changed

- Two notification types: `registry_key_decided`, `registry_value_decided`.
- `decideKey` and `decideValue` notify on **both** outcomes. A rejection appends the curator's reason verbatim under the summary line; an acceptance carries no reason block.
- Fire-and-forget, after the decision is persisted and audit-logged — a push/DB hiccup must never surface to the admin as a failed decision (mirrors `routes/admin/wineRequests`). A proposal whose account has since been deleted (`proposedBy: null`) is decided without notifying.

## Two details found while wiring it

- **`link: null`, not `/notifications`.** That route doesn't exist. Unlike a wine request (which has `/wine-requests`), a contributor has no page listing their own registry-data proposals, so the message has to stand alone — and the bell navigates on `n.link`, so a link there would 404.
- **`.notif-msg` gains `white-space: pre-line`.** The bell renders the message into a plain `div`, so the appended reason would have run straight into the summary line. Existing single-line messages are unaffected — `pre-line` still collapses ordinary wrapping whitespace.

## Why now

The first real proposal reached a decision today: "Beautiful", type `text`, rationale *"Dry, notes of cranberry, dark chocolate, black cherry, currants. $100.00+"* — a tasting note filed through `propose_registry_key` by an account about an hour old, almost certainly an assistant reaching for the wrong tool. It was rejected with a written explanation pointing at tasting notes, the bottle's price field and personal data entries.

The contributor cannot see a word of it. That is the bug this fixes.

(Also worth knowing for whoever writes the next one: the 500-char cap is silent truncation — a first draft of that reason was 683 chars and would have been cut mid-sentence. Only a dry run caught it.)

## Tests

`registryDataOps.test.js` +6: rejection notifies with the reason and names the key; acceptance carries no reason paragraph; value decisions notify both ways; a decision still returns `ok` when the notification rejects; a null `proposedBy` decides silently. Backend 44 green across the three registry-data suites, frontend 1049 green, CSS token guard clean.

## Not in this PR

A "my contributions" page listing a user's own proposals with their outcomes. That's the fuller fix — it would give the notification somewhere to link — but it's a new surface, and the notification is what makes the existing 500 chars actually reach someone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
