### PR TITLE
feat(racks): add row-flip option for Honeycomb racks

### DIFF
--- a/backend/src/models/Rack.js
+++ b/backend/src/models/Rack.js
@@ -26,7 +26,10 @@ const rackModuleSchema = new mongoose.Schema({
     moduleCols: { type: Number, min: 1, max: 10 },
     bottlesPerCell: { type: Number, min: 1, max: 20 },
     bottlesPerSection: { type: Number, min: 1, max: 30 },
-    backCols: { type: Number, min: 0, max: 20 }
+    backCols: { type: Number, min: 0, max: 20 },
+    // Hex racks only: mirror the row sequence top-to-bottom. Pure reversal —
+    // never changes total slot count (see rackSchema.typeConfig.hexFlip below).
+    hexFlip: { type: Boolean, default: false }
   },
   x:          { type: Number, default: 0 },
   y:          { type: Number, default: 0 },
@@ -58,7 +61,13 @@ const rackSchema = new mongoose.Schema({
     // Deliberately NOT on rackModuleSchema above — modular-rack modules
     // don't support double-height rows (out of scope; Mongoose strips the
     // key from module typeConfig).
-    doubleHeightRows: { type: [Number], default: undefined }
+    doubleHeightRows: { type: [Number], default: undefined },
+    // Hex racks only: mirror the row sequence top-to-bottom (row 0 becomes
+    // the old last row's width, etc). Pure reversal of the same multiset of
+    // row widths, so it never changes total slot count — for an odd row
+    // count the unflipped sequence is always a palindrome, so this is a
+    // no-op there by construction; it only matters for even row counts.
+    hexFlip: { type: Boolean, default: false }
   },
   // Modular rack fields (used when isModular is true)
   isModular: { type: Boolean, default: false },

--- a/frontend/src/components/racks/RackTypeSelector.js
+++ b/frontend/src/components/racks/RackTypeSelector.js
@@ -17,7 +17,7 @@ const RACK_TYPES = [
 export const TYPE_DIMENSIONS = {
   grid:     { showRows: true,  showCols: true,  defaultRows: 4, defaultCols: 8, showDoubleHeightRows: true },
   'x-rack': { showRows: false, showCols: false, defaultRows: 1, defaultCols: 1, showBottlesPerSection: true },
-  hex:      { showRows: true,  showCols: true,  defaultRows: 4, defaultCols: 5 },
+  hex:      { showRows: true,  showCols: true,  defaultRows: 4, defaultCols: 5, showHexFlip: true },
   triangle: { showRows: false, showCols: true,  defaultRows: 1, defaultCols: 5, colLabel: 'racks.baseWidthLabel' },
   stack:    { showRows: true,  showCols: false, defaultRows: 8, defaultCols: 1, rowLabel: 'racks.heightLabel' },
   cube:     { showRows: true,  showCols: true,  defaultRows: 2, defaultCols: 3, showModule: true },

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -341,14 +341,17 @@ function computeXRackSlotPositions(bps, width, height) {
   return positions;
 }
 
-// Hex: even rows have cols slots, odd rows have cols-1 (offset right)
-function computeHexSlotPositions(rows, cols, width, height) {
+// Hex: even rows have cols slots, odd rows have cols-1 (offset right).
+// `flipped` mirrors the row sequence top-to-bottom (see rackLayouts.hexLayout) —
+// pure reversal, never changes total slot count.
+function computeHexSlotPositions(rows, cols, width, height, flipped) {
   const positions = [];
   const cW = width / cols;
   const hexH = height / rows;
   let pos = 1;
   for (let r = 0; r < rows; r++) {
-    const isOdd = r % 2 === 1;
+    const rr = flipped ? (rows - 1 - r) : r;
+    const isOdd = rr % 2 === 1;
     const rowCols = isOdd ? Math.max(1, cols - 1) : cols;
     const xOff = isOdd ? cW * 0.5 : 0;
     for (let c = 0; c < rowCols; c++) {
@@ -754,7 +757,7 @@ export default function RackMesh({
         : scaledLayout.positions.map(p => ({ ...p, x: p.x * sx }));
     }
     if (rackType === 'x-rack') return computeXRackSlotPositions(rack.typeConfig?.bottlesPerSection || 10, innerW, innerH);
-    if (rackType === 'hex') return computeHexSlotPositions(rack.rows || 4, rack.cols || 4, innerW, innerH);
+    if (rackType === 'hex') return computeHexSlotPositions(rack.rows || 4, rack.cols || 4, innerW, innerH, rack.typeConfig?.hexFlip);
     if (rackType === 'triangle') return computeTriangleSlotPositions(rack.cols || 1, innerW, innerH);
     if (rackType === 'stack') return computeStackSlotPositions(rack.rows || 4, innerH);
     if (rackType === 'shelf') return computeShelfSlotPositions(

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1083,6 +1083,8 @@
     "doubleHeightRowsLabel": "Double-height rows",
     "doubleHeightRowsPlaceholder": "e.g. 1,3",
     "doubleHeightRowsHelp": "Rows with headroom for bottles resting on top",
+    "hexFlipLabel": "Flip rows (short row on top)",
+    "hexFlipHelp": "By default the top row is full width. Enable this to mirror the rows top-to-bottom.",
     "filled": "{{filled}}/{{total}} filled",
     "type_grid": "Grid",
     "type_x-rack": "X-Rack",

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -1048,6 +1048,25 @@ function NewRackForm({ newRack, setNewRack, onTypeChange, onSubmit, saving }) {
           </div>
         )}
 
+        {dims.showHexFlip && (
+          <div className="form-group">
+            <label>
+              <input
+                type="checkbox"
+                checked={!!newRack.typeConfig?.hexFlip}
+                onChange={e => setNewRack({
+                  ...newRack,
+                  typeConfig: { ...newRack.typeConfig, hexFlip: e.target.checked || undefined }
+                })}
+              />
+              {' '}{t('racks.hexFlipLabel', 'Flip rows (short row on top)')}
+            </label>
+            <small style={{ color: 'var(--color-text-muted)', fontSize: '0.75rem' }}>
+              {t('racks.hexFlipHelp', 'By default the top row is full width. Enable this to mirror the rows top-to-bottom.')}
+            </small>
+          </div>
+        )}
+
         {dims.showModule && (
           <>
             <div className="form-group">

--- a/frontend/src/utils/rackLayouts.js
+++ b/frontend/src/utils/rackLayouts.js
@@ -180,13 +180,18 @@ function xRackLayout(typeConfig) {
 
 // ── Hexagonal honeycomb ──────────────────────────────────────────────
 // Even rows (0-indexed) have `cols` slots; odd rows have `cols - 1` (offset right by half).
-function hexLayout(rows, cols) {
+// typeConfig.hexFlip mirrors the row sequence top-to-bottom: row r reads the
+// width the UNFLIPPED row (rows-1-r) would have had. Pure reversal of the
+// same multiset of widths — never changes total slot count.
+function hexLayout(rows, cols, typeConfig) {
+  const flipped = !!typeConfig?.hexFlip;
   const slots = [];
   let pos = 1;
   const hexH = CELL * 0.866;  // vertical distance (sin 60° ≈ 0.866)
 
   for (let r = 0; r < rows; r++) {
-    const isOdd = r % 2 === 1;
+    const rr = flipped ? (rows - 1 - r) : r;
+    const isOdd = rr % 2 === 1;
     const rowCols = isOdd ? Math.max(1, cols - 1) : cols;
     const xOffset = isOdd ? CELL * 0.5 : 0;
 
@@ -376,7 +381,7 @@ function shelfLayout(rows, cols, typeConfig) {
 export function computeLayout(type, rows, cols, typeConfig) {
   switch (type) {
     case 'x-rack':   return xRackLayout(typeConfig);
-    case 'hex':      return hexLayout(rows, cols);
+    case 'hex':      return hexLayout(rows, cols, typeConfig);
     case 'triangle': return triangleLayout(rows, cols);
     case 'stack':    return stackLayout(rows);
     case 'cube':     return cubeLayout(rows, cols, typeConfig);

--- a/frontend/src/utils/rackLayouts.test.js
+++ b/frontend/src/utils/rackLayouts.test.js
@@ -121,6 +121,26 @@ describe('computeLayout', () => {
     it('4 rows, 3 cols → 10 slots', () => {
       expect(computeLayout('hex', 4, 3).totalSlots).toBe(10);
     });
+
+    describe('hexFlip', () => {
+      it('is a no-op for an odd row count (the unflipped sequence is a palindrome)', () => {
+        const unflipped = computeLayout('hex', 3, 4);
+        const flipped = computeLayout('hex', 3, 4, { hexFlip: true });
+        expect(flipped).toEqual(unflipped);
+      });
+
+      it('swaps which row is short for an even row count, without changing total slots', () => {
+        const unflipped = computeLayout('hex', 4, 3);
+        const flipped = computeLayout('hex', 4, 3, { hexFlip: true });
+        expect(flipped.totalSlots).toBe(unflipped.totalSlots);
+
+        const rowSize = (layout) => layout.slots.filter(s => s.cy === layout.slots[0].cy).length;
+        // Unflipped row 0 is full width (3 cols); flipped row 0 mirrors the
+        // old last row, which is short (2 cols).
+        expect(rowSize(unflipped)).toBe(3);
+        expect(rowSize(flipped)).toBe(2);
+      });
+    });
   });
 
   describe('triangle', () => {


### PR DESCRIPTION
# Add row-flip option for Honeycomb racks

## Background

Honeycombe-style racks with an even number of rows can either be built up with the larger number of slots (N) on the top or bottom. The currently implemented default was that the row with N slots is always on top with no possibility to flip the rack layout top-to-bottom.

## Summary

- Adds `typeConfig.hexFlip` so a Honeycomb (hex) rack's alternating row-width sequence can be mirrored top-to-bottom, letting either the N-column or the N-1-column row sit on the bottom.
- This is a pure reversal of the existing row-width sequence — total slot count is provably unaffected. For an **odd** row count the unflipped sequence is always a palindrome (e.g. `N, N-1, N`), so the toggle is a visible no-op there by construction; for an **even** row count it correctly swaps which end is short.
- Threaded through the 2D SVG rack layout (`rackLayouts.js`), the 3D room view mesh (`RackMesh.js`), and a new "Flip rows (short row on top)" checkbox in the rack-creation form. No backend capacity/validation changes were needed since the total slot count never changes.

## Test plan

- [x] `npx vitest run src/utils/rackLayouts.test.js` — 64 passed, including two new tests covering the odd-row no-op and the even-row swap.
- [x] `npx jest src/utils/rackGeometry.test.js` (backend) — 45 passed, confirming totals are unaffected as expected.
- [x] `npm run build` (frontend, Vite) — compiles cleanly.
- [x] `npm test` for both frontend and backend — all tests passed.
- [x] Manually verified in a live `docker-compose` stack: created a flipped Honeycomb rack via the New Rack form, confirmed the preview/real 2D rack view and the 3D Room View all render the mirrored row sequence identically, with slot numbering and total count unchanged.