### PR TITLE
fix(ios): keep logged-out headers clear of the status bar, contain menu scroll

### DIFF
--- a/frontend/src/components/Layout.css
+++ b/frontend/src/components/Layout.css
@@ -297,8 +297,19 @@
 .mobile-menu {
   background: var(--color-surface);
   border-top: 1px solid var(--color-border);
-  max-height: calc(100vh - 60px);
+  /* The navbar above is 60px PLUS the status-bar inset (see .navbar), so
+     subtracting a bare 60px left this menu taller than the space it has —
+     about 50px too tall on a notched iPhone, which pushed the last item
+     (Logout) off the bottom (issue #1146). */
+  max-height: calc(100vh - 60px - env(safe-area-inset-top));
   overflow-y: auto;
+  /* Stop the scroll gesture chaining to the page behind once this container
+     reaches its end. Without it, reaching Logout on a full admin menu took
+     three separate gestures across two scroll containers, and the pause in
+     between read as "the menu has bottomed out". Preferred over locking body
+     scroll: position:fixed body locks are their own source of iOS scroll
+     jumps, and containment is what this actually needs. */
+  overscroll-behavior: contain;
   padding-bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom));
 }
 

--- a/frontend/src/pages/LandingPage.css
+++ b/frontend/src/pages/LandingPage.css
@@ -15,11 +15,21 @@
   align-items: center;
   justify-content: space-between;
   padding: 0 5%;
-  height: 60px;
   background: rgba(var(--color-primary-rgb), 0.03);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--color-border-light);
+  /* Keep clear of the iOS status bar in the installed PWA (issue #1145).
+     index.html sets viewport-fit=cover and a black-translucent status bar,
+     so a sticky top:0 element draws UNDERNEATH the clock and battery — the
+     Sign in button ended up in the strip iOS owns and could not be tapped.
+     Layout.css:.navbar already does this; the landing page and login are the
+     only two routes not wrapped in <Layout>, so they never inherited it.
+     The inset is added to BOTH the height and the padding because the global
+     reset is border-box: padding alone would eat into the 60px and squash
+     the bar instead of growing it. Both resolve to 0 off iOS. */
+  height: calc(60px + env(safe-area-inset-top));
+  padding-top: env(safe-area-inset-top);
 }
 
 .landing-nav-brand {

--- a/frontend/src/pages/Login.css
+++ b/frontend/src/pages/Login.css
@@ -5,7 +5,11 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  /* The other route outside <Layout> (issue #1145). The card is centred, so
+     it only reaches the iOS status bar when the form is taller than the
+     screen — a tall viewport is not the failing case, a short one is.
+     Resolves to plain 2rem everywhere else. */
+  padding: calc(2rem + env(safe-area-inset-top)) 2rem calc(2rem + env(safe-area-inset-bottom));
   gap: 1.5rem;
 }
 


### PR DESCRIPTION
Fixes #1145. Fixes #1146.

Two iPhone PWA reports from @deltabeat, both diagnosed correctly in the issues themselves — including the code references. I verified every claim against the tree rather than taking them on trust; all of them held.

## #1145 — logged-out header under the status bar

`index.html` sets `viewport-fit=cover` with `apple-mobile-web-app-status-bar-style: black-translucent`, so a `position: sticky; top: 0` element draws underneath the clock and battery. `Layout.css .navbar` already pads for it — but `/` and `/login` are the **only two routes not wrapped in `<Layout>`**, so they never inherited it. The Sign in button ended up in the strip iOS owns and couldn't be tapped.

The reporter's supporting evidence was the give-away, and it checks out exactly:

```
env(safe-area-inset-top)     1 use   (Layout.css:18)
env(safe-area-inset-bottom) 11 uses
```

That is the shape of a top inset nobody ever exercised on a notched device.

**Fix:** `.landing-nav` adds the inset to **both its height and its padding**. The global reset is `border-box`, so padding alone would have eaten into the `60px` and squashed the bar rather than growing it — a detail worth naming, since `padding-top: env(...)` on its own looks like the obvious fix and is subtly wrong here. `.login-page` gets the same treatment on its centred card; that one only reaches the inset on a short viewport, so it's defensive rather than a reproduced failure.

Their landscape observation was a good diagnostic: rotating hides the status bar and the button becomes tappable, which rules out z-index and hit-area and points squarely at the inset.

## #1146 — More menu scroll chaining

Confirmed: `overscroll-behavior` appeared **nowhere** in the frontend, and nothing locks body scroll while `mobileMenuOpen` is true. So once `.mobile-menu` reaches its end the gesture chains to the document behind it — three separate gestures across two scroll containers to reach Logout, with a pause in between that reads as "the menu has bottomed out".

**Fix:** `overscroll-behavior: contain` on `.mobile-menu`. Chosen over a body-scroll lock deliberately — `position: fixed` body locks are their own well-known source of iOS scroll jumps, and containment is precisely what this needs.

**And the second-order bug they suspected is real.** `max-height: calc(100vh - 60px)` subtracts a bare `60px`, but `.navbar` is `60px` *plus* `env(safe-area-inset-top)` — so on a notched iPhone the menu was ~50px taller than the space available, which is what pushed Logout off the bottom to begin with. Now `calc(100vh - 60px - env(safe-area-inset-top))`. Fixing only the chaining would have left the menu still overflowing.

## Scope

CSS only, three files, 28 lines. Every added value resolves to `0` off iOS, so desktop and Android are unchanged by construction.

Frontend suite 1051 green, CSS token guard clean, `npm run build` clean.

## What I can't verify

I have no iPhone. The mechanism is confirmed from the code and the reporter's evidence, but the *result* is not — @deltabeat offered to test on a real device and that offer is worth taking up before or shortly after release, particularly for the exact `height + padding` combination on `.landing-nav`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
