### PR TITLE
feat(racks): equal-row staggered option for Honeycomb racks

### DIFF
--- a/backend/src/models/Rack.js
+++ b/backend/src/models/Rack.js
@@ -29,7 +29,11 @@ const rackModuleSchema = new mongoose.Schema({
     backCols: { type: Number, min: 0, max: 20 },
     // Hex racks only: mirror the row sequence top-to-bottom. Pure reversal —
     // never changes total slot count (see rackSchema.typeConfig.hexFlip below).
-    hexFlip: { type: Boolean, default: false }
+    hexFlip: { type: Boolean, default: false },
+    // Hex racks only: every row holds the full `cols` count, offset rows
+    // still staggered by half a slot (see rackSchema.typeConfig.hexEqualRows
+    // below). UNLIKE hexFlip this changes total slot count (rows × cols).
+    hexEqualRows: { type: Boolean, default: false }
   },
   x:          { type: Number, default: 0 },
   y:          { type: Number, default: 0 },
@@ -67,7 +71,17 @@ const rackSchema = new mongoose.Schema({
     // row widths, so it never changes total slot count — for an odd row
     // count the unflipped sequence is always a palindrome, so this is a
     // no-op there by construction; it only matters for even row counts.
-    hexFlip: { type: Boolean, default: false }
+    hexFlip: { type: Boolean, default: false },
+    // Hex racks only: every row holds the full `cols` count, and offset rows
+    // are still staggered by half a slot — the "equal rows, staggered" shelf
+    // found in wine fridges (e.g. the Liebherr GrandCru's 4-4-4-4 top and
+    // bottom shelves, effectively cols+0.5 bottles wide). UNLIKE hexFlip this
+    // CHANGES total slot count (rows × cols, not the alternating sum), so
+    // toggling it on an existing rack renumbers positions after row 1 — the
+    // UI offers it at creation only, and the update route's resize guard
+    // (getMaxPosition recompute) blocks a shrink past placed bottles.
+    // Composes with hexFlip, which still decides WHICH rows are offset.
+    hexEqualRows: { type: Boolean, default: false }
   },
   // Modular rack fields (used when isModular is true)
   isModular: { type: Boolean, default: false },

--- a/backend/src/utils/rackGeometry.js
+++ b/backend/src/utils/rackGeometry.js
@@ -6,7 +6,8 @@
  *              typeConfig.doubleHeightRows have headroom for an extra top
  *              layer of cols-1 bottles resting in the gaps
  *   x-rack   — square with X dividers; 4 triangular sections, each holds bottlesPerSection bottles
- *   hex      — hex honeycomb; alternating row widths (cols, cols-1, …)
+ *   hex      — hex honeycomb; alternating row widths (cols, cols-1, …), or
+ *              every row full width staggered when typeConfig.hexEqualRows
  *   triangle — A-frame; base width = cols, each row shrinks by 1
  *   stack    — single vertical column; height = rows
  *   cube     — grid of sub-modules; outer grid = rows × cols, each module = moduleRows × moduleCols
@@ -93,7 +94,12 @@ function totalSlots(type, rows, cols, typeConfig) {
 
     case 'hex': {
       // Honeycomb grid: `rows` rows. Even rows (0-indexed) have `cols` slots,
-      // odd rows have `cols - 1` slots (offset).
+      // odd rows have `cols - 1` slots (offset). With typeConfig.hexEqualRows
+      // every row holds the full `cols` (offset rows still staggered by half
+      // a slot — the equal-row shelf in wine fridges), so total = rows × cols.
+      // hexFlip is deliberately not read here: it reverses which rows are
+      // which, a pure reversal that can never change the total.
+      if (typeConfig?.hexEqualRows) return rows * cols;
       let total = 0;
       for (let r = 0; r < rows; r++) {
         total += (r % 2 === 0) ? cols : Math.max(1, cols - 1);

--- a/backend/src/utils/rackGeometry.test.js
+++ b/backend/src/utils/rackGeometry.test.js
@@ -96,6 +96,19 @@ describe('rackGeometry', () => {
     it('2 rows, 1 col → 1 + 1 = 2 (odd row min is 1)', () => {
       expect(totalSlots('hex', 2, 1)).toBe(2);
     });
+    it('hexEqualRows: every row full width → rows × cols', () => {
+      expect(totalSlots('hex', 4, 4, { hexEqualRows: true })).toBe(16);
+      expect(totalSlots('hex', 3, 4, { hexEqualRows: true })).toBe(12);
+      // The Liebherr GrandCru top/bottom shelf from the feature request: 4-4-4-4.
+      expect(totalSlots('hex', 4, 4)).toBe(14); // classic alternation, unchanged
+    });
+    it('hexEqualRows composes with hexFlip without changing the total', () => {
+      expect(totalSlots('hex', 4, 4, { hexEqualRows: true, hexFlip: true })).toBe(16);
+    });
+    it('hexEqualRows false/absent keeps the classic alternating total', () => {
+      expect(totalSlots('hex', 4, 3, { hexEqualRows: false })).toBe(10);
+      expect(totalSlots('hex', 4, 3, { hexFlip: true })).toBe(10);
+    });
   });
 
   describe('totalSlots — triangle', () => {

--- a/frontend/src/components/room/RackMesh.js
+++ b/frontend/src/components/room/RackMesh.js
@@ -344,15 +344,18 @@ function computeXRackSlotPositions(bps, width, height) {
 // Hex: even rows have cols slots, odd rows have cols-1 (offset right).
 // `flipped` mirrors the row sequence top-to-bottom (see rackLayouts.hexLayout) —
 // pure reversal, never changes total slot count.
-function computeHexSlotPositions(rows, cols, width, height, flipped) {
+// `equalRows` keeps every row at the full cols count (offset rows still
+// staggered by half a slot); the frame then spans cols+0.5 bottle widths so
+// the stagger stays inside the rack box instead of poking out the side.
+function computeHexSlotPositions(rows, cols, width, height, flipped, equalRows) {
   const positions = [];
-  const cW = width / cols;
+  const cW = equalRows ? width / (cols + 0.5) : width / cols;
   const hexH = height / rows;
   let pos = 1;
   for (let r = 0; r < rows; r++) {
     const rr = flipped ? (rows - 1 - r) : r;
     const isOdd = rr % 2 === 1;
-    const rowCols = isOdd ? Math.max(1, cols - 1) : cols;
+    const rowCols = equalRows ? cols : (isOdd ? Math.max(1, cols - 1) : cols);
     const xOff = isOdd ? cW * 0.5 : 0;
     for (let c = 0; c < rowCols; c++) {
       positions.push({
@@ -757,7 +760,7 @@ export default function RackMesh({
         : scaledLayout.positions.map(p => ({ ...p, x: p.x * sx }));
     }
     if (rackType === 'x-rack') return computeXRackSlotPositions(rack.typeConfig?.bottlesPerSection || 10, innerW, innerH);
-    if (rackType === 'hex') return computeHexSlotPositions(rack.rows || 4, rack.cols || 4, innerW, innerH, rack.typeConfig?.hexFlip);
+    if (rackType === 'hex') return computeHexSlotPositions(rack.rows || 4, rack.cols || 4, innerW, innerH, rack.typeConfig?.hexFlip, rack.typeConfig?.hexEqualRows);
     if (rackType === 'triangle') return computeTriangleSlotPositions(rack.cols || 1, innerW, innerH);
     if (rackType === 'stack') return computeStackSlotPositions(rack.rows || 4, innerH);
     if (rackType === 'shelf') return computeShelfSlotPositions(
@@ -767,7 +770,8 @@ export default function RackMesh({
     return computeSlotPositions(displayRows, displayCols, innerW, innerH, doubleRows);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scaledLayout, rackType, rack.rows, rack.cols, displayRows, displayCols, innerW, innerH, depth,
-      doubleRows, rack.typeConfig?.backCols, rack.typeConfig?.bottlesPerCell, rack.typeConfig?.bottlesPerSection]);
+      doubleRows, rack.typeConfig?.backCols, rack.typeConfig?.bottlesPerCell, rack.typeConfig?.bottlesPerSection,
+      rack.typeConfig?.hexFlip, rack.typeConfig?.hexEqualRows]);
 
   const edgesGeom = useMemo(() => {
     const sw = width * rackScale, sh = height * rackScale, sd = depth * rackScale;

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1095,6 +1095,8 @@
     "doubleHeightRowsHelp": "Rows with headroom for bottles resting on top",
     "hexFlipLabel": "Flip rows (short row on top)",
     "hexFlipHelp": "By default the top row is full width. Enable this to mirror the rows top-to-bottom.",
+    "hexEqualRowsLabel": "Equal rows (staggered)",
+    "hexEqualRowsHelp": "Every row holds the full number of columns, offset by half a bottle — like the top and bottom shelves of many wine fridges.",
     "filled": "{{filled}}/{{total}} filled",
     "type_grid": "Grid",
     "type_x-rack": "X-Rack",

--- a/frontend/src/pages/CellarRacks.js
+++ b/frontend/src/pages/CellarRacks.js
@@ -1067,6 +1067,25 @@ function NewRackForm({ newRack, setNewRack, onTypeChange, onSubmit, saving }) {
           </div>
         )}
 
+        {dims.showHexFlip && (
+          <div className="form-group">
+            <label>
+              <input
+                type="checkbox"
+                checked={!!newRack.typeConfig?.hexEqualRows}
+                onChange={e => setNewRack({
+                  ...newRack,
+                  typeConfig: { ...newRack.typeConfig, hexEqualRows: e.target.checked || undefined }
+                })}
+              />
+              {' '}{t('racks.hexEqualRowsLabel', 'Equal rows (staggered)')}
+            </label>
+            <small style={{ color: 'var(--color-text-muted)', fontSize: '0.75rem' }}>
+              {t('racks.hexEqualRowsHelp', 'Every row holds the full number of columns, offset by half a bottle — like the top and bottom shelves of many wine fridges.')}
+            </small>
+          </div>
+        )}
+
         {dims.showModule && (
           <>
             <div className="form-group">

--- a/frontend/src/utils/rackLayouts.js
+++ b/frontend/src/utils/rackLayouts.js
@@ -183,8 +183,13 @@ function xRackLayout(typeConfig) {
 // typeConfig.hexFlip mirrors the row sequence top-to-bottom: row r reads the
 // width the UNFLIPPED row (rows-1-r) would have had. Pure reversal of the
 // same multiset of widths — never changes total slot count.
+// typeConfig.hexEqualRows keeps every row at the full `cols` count with the
+// offset rows still staggered by half a slot (the equal-row shelf in wine
+// fridges, effectively cols+0.5 wide) — total becomes rows × cols. Composes
+// with hexFlip, which still decides WHICH rows are offset.
 function hexLayout(rows, cols, typeConfig) {
   const flipped = !!typeConfig?.hexFlip;
+  const equalRows = !!typeConfig?.hexEqualRows;
   const slots = [];
   let pos = 1;
   const hexH = CELL * 0.866;  // vertical distance (sin 60° ≈ 0.866)
@@ -192,7 +197,7 @@ function hexLayout(rows, cols, typeConfig) {
   for (let r = 0; r < rows; r++) {
     const rr = flipped ? (rows - 1 - r) : r;
     const isOdd = rr % 2 === 1;
-    const rowCols = isOdd ? Math.max(1, cols - 1) : cols;
+    const rowCols = equalRows ? cols : (isOdd ? Math.max(1, cols - 1) : cols);
     const xOffset = isOdd ? CELL * 0.5 : 0;
 
     for (let c = 0; c < rowCols; c++) {
@@ -207,7 +212,10 @@ function hexLayout(rows, cols, typeConfig) {
   return {
     totalSlots: slots.length,
     viewBox: {
-      width:  PADDING * 2 + cols * CELL - SLOT_GAP + (cols > 1 ? CELL * 0.5 : 0),
+      // Classic hex already reserves the half-cell stagger for cols > 1; an
+      // equal-rows rack needs it at any width (offset rows genuinely extend
+      // half a slot past the even rows, even at cols = 1).
+      width:  PADDING * 2 + cols * CELL - SLOT_GAP + (cols > 1 || equalRows ? CELL * 0.5 : 0),
       height: PADDING * 2 + (rows - 1) * hexH + SLOT_R * 2,
     },
     slots,
@@ -474,6 +482,10 @@ export function getTotalSlots(type, rows, cols, typeConfig) {
       return 4 * bps;
     }
     case 'hex': {
+      // Equal-row stagger: every row full width, total = rows × cols.
+      // Mirrors backend rackGeometry.totalSlots. hexFlip is deliberately
+      // not read — a pure reversal can never change the total.
+      if (typeConfig?.hexEqualRows) return rows * cols;
       let total = 0;
       for (let r = 0; r < rows; r++) {
         total += (r % 2 === 0) ? cols : Math.max(1, cols - 1);

--- a/frontend/src/utils/rackLayouts.test.js
+++ b/frontend/src/utils/rackLayouts.test.js
@@ -141,6 +141,59 @@ describe('computeLayout', () => {
         expect(rowSize(flipped)).toBe(2);
       });
     });
+
+    // The equal-row staggered shelf (e.g. Liebherr GrandCru top/bottom
+    // shelves: 4-4-4-4, offset — effectively 4.5 bottles wide).
+    describe('hexEqualRows', () => {
+      const rowsOf = (layout) => {
+        const ys = [...new Set(layout.slots.map(s => s.cy))].sort((a, b) => a - b);
+        return ys.map(y => layout.slots.filter(s => s.cy === y));
+      };
+
+      it('every row holds the full column count — total = rows × cols', () => {
+        expect(computeLayout('hex', 4, 4, { hexEqualRows: true }).totalSlots).toBe(16);
+        expect(computeLayout('hex', 4, 4).totalSlots).toBe(14); // classic, unchanged
+      });
+
+      it('offset rows keep the half-slot stagger at full width', () => {
+        const [row0, row1] = rowsOf(computeLayout('hex', 2, 4, { hexEqualRows: true }));
+        expect(row0).toHaveLength(4);
+        expect(row1).toHaveLength(4);
+        const cell = row0[1].cx - row0[0].cx;
+        expect(row1[0].cx - row0[0].cx).toBeCloseTo(cell / 2);
+      });
+
+      it('the viewBox is wide enough for the staggered full-width rows', () => {
+        for (const cols of [1, 4]) {
+          const layout = computeLayout('hex', 2, cols, { hexEqualRows: true });
+          const maxCx = Math.max(...layout.slots.map(s => s.cx));
+          expect(layout.viewBox.width).toBeGreaterThanOrEqual(maxCx + SLOT_RADIUS);
+        }
+      });
+
+      it('composes with hexFlip: the flip decides which rows are offset', () => {
+        const plain = computeLayout('hex', 2, 4, { hexEqualRows: true });
+        const flipped = computeLayout('hex', 2, 4, { hexEqualRows: true, hexFlip: true });
+        expect(flipped.totalSlots).toBe(plain.totalSlots);
+        // Unflipped: row 0 flush left, row 1 offset. Flipped: the reverse.
+        expect(rowsOf(plain)[0][0].cx).toBeLessThan(rowsOf(flipped)[0][0].cx);
+        expect(rowsOf(plain)[1][0].cx).toBeGreaterThan(rowsOf(flipped)[1][0].cx);
+      });
+
+      it('getTotalSlots mirrors the layout and the backend formula', () => {
+        expect(getTotalSlots('hex', 4, 4, { hexEqualRows: true })).toBe(16);
+        expect(getTotalSlots('hex', 4, 4, { hexEqualRows: true, hexFlip: true })).toBe(16);
+        expect(getTotalSlots('hex', 4, 4)).toBe(14);
+        expect(getTotalSlots('hex', 4, 4, { hexFlip: true })).toBe(14);
+      });
+
+      it('counts equal-row hex modules inside modular racks', () => {
+        expect(getModularTotalSlots([
+          { type: 'hex', rows: 4, cols: 4, typeConfig: { hexEqualRows: true } },
+          { type: 'hex', rows: 4, cols: 4 },
+        ])).toBe(16 + 14);
+      });
+    });
   });
 
   describe('triangle', () => {


### PR DESCRIPTION
Follow-up from the same support ticket that produced the hexFlip option (#1147): the **top and bottom shelves** of wine fridges like the Liebherr GrandCru are **4-4-4-4 staggered** — every row full width, offset half a bottle, effectively cols+0.5 wide. Our honeycomb could only alternate cols / cols−1.

New `typeConfig.hexEqualRows` (hex racks only): every row holds the full `cols` count, offset rows keep the half-slot stagger, total = rows × cols. Composes with `hexFlip` (which still decides *which* rows are offset). Absent/false → byte-identical behaviour.

**Why this needed more care than hexFlip:** the flip never changes slot count; this does. Audit of the capacity surface: every consumer funnels through `rackGeometry.getMaxPosition(rack)` which already forwards `typeConfig` (arrange, place bounds, both imports, MCP capacity, structural undo, modular modules) — one formula change covers them all, and the update route's existing resize guard recomputes it, so shrinking past placed bottles is already blocked. MCP `create_rack` is deliberately grid-only — no schema change.

Creation-only in the UI (second checkbox under Flip rows), same renumbering rationale as #1147. The 3D room view divides its frame by cols+0.5 so the stagger stays inside the rack box, and its `useMemo` gains the `hexFlip`/`hexEqualRows` deps #1147 missed. ViewBox reserves the half-cell stagger at any width including cols=1; classic hex rendering untouched.

Tests: formula both sides (4×4 → 16 vs classic 14), flip composition, modular hex modules, stagger + viewBox layout assertions. Frontend **1060 passed**, backend rack suites **144 passed**, Vite build + token guard clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)