### PR TITLE
feat(taxonomy): user-minted grapes enter a review queue

### DIFF
--- a/backend/src/models/Grape.js
+++ b/backend/src/models/Grape.js
@@ -88,6 +88,14 @@ const grapeSchema = new mongoose.Schema({
     default: []
   },
   slug: { type: String, trim: true, lowercase: true, unique: true, sparse: true, index: true },
+  // Set when a USER write minted this grape (bottle-add / import via
+  // findOrCreateGrapes) rather than a curator: visible to admins in the
+  // taxonomy review queue, never blocking the user — the exact Region
+  // pendingReview pattern. Unreviewed user mints polluted the shared
+  // taxonomy silently ("Honey" via a mead, "Alvarão" for Alvarinho —
+  // somm ticket 6a942a60, 2026-08-30). Cleared only by the explicit
+  // approve verb, never as a PUT side effect.
+  pendingReview: { type: Boolean, default: false, index: true },
   description: { type: String, trim: true, default: '' },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,

--- a/backend/src/routes/admin/taxonomy.grapeApprove.test.js
+++ b/backend/src/routes/admin/taxonomy.grapeApprove.test.js
@@ -1,0 +1,100 @@
+/**
+ * POST /api/admin/taxonomy/grapes/:id/approve — the review verb for
+ * user-minted grapes (somm ticket 6a942a60: bottle-add/import wrote "Honey"
+ * and "Alvarão" straight into the shared taxonomy with no gate).
+ *
+ * Pins the three properties the regions verb established: approval is an
+ * explicit act (flag flips, audit written), it is idempotent (a second click
+ * neither saves nor audits again), and bad ids answer 400/404 rather than
+ * 500.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../services/search', () => ({
+  getIsAvailable: jest.fn(() => false),
+  indexWine: jest.fn(),
+  removeWine: jest.fn(),
+  bulkIndexWines: jest.fn(),
+  bulkIndexBottles: jest.fn(),
+  fullSync: jest.fn(),
+  fullSyncBottles: jest.fn(),
+  waitForTasks: jest.fn(),
+}));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../models/Country', () => ({ exists: jest.fn(), findById: jest.fn() }));
+jest.mock('../../models/Region', () => ({ findById: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../../models/WineDefinition', () => ({ countDocuments: jest.fn() }));
+jest.mock('../../models/Grape', () => {
+  const Grape = jest.fn(function (fields) {
+    Object.assign(this, fields);
+    this.save = jest.fn().mockResolvedValue(undefined);
+  });
+  Grape.findById = jest.fn();
+  Grape.find = jest.fn();
+  Grape.exists = jest.fn();
+  return Grape;
+});
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const Grape = require('../../models/Grape');
+const { logAudit } = require('../../services/audit');
+const router = require('./taxonomy');
+
+const ADMIN_ID = '64b000000000000000000001';
+const GRAPE_ID = '64b00000000000000000009e';
+
+let server;
+let baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/taxonomy', router);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+const approve = (id) => fetch(`${baseUrl}/api/admin/taxonomy/grapes/${id}/approve`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('POST /grapes/:id/approve', () => {
+  test('clears pendingReview, saves, and audits', async () => {
+    const doc = { _id: GRAPE_ID, name: 'Alvarão', pendingReview: true, save: jest.fn().mockResolvedValue(undefined) };
+    Grape.findById.mockResolvedValue(doc);
+
+    const res = await approve(GRAPE_ID);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.grape.pendingReview).toBe(false);
+    expect(body.already).toBeUndefined();
+    expect(doc.save).toHaveBeenCalledTimes(1);
+    expect(logAudit).toHaveBeenCalledTimes(1);
+    expect(logAudit.mock.calls[0][1]).toBe('admin.taxonomy.approveGrape');
+    expect(logAudit.mock.calls[0][2]).toEqual({ type: 'grape', id: GRAPE_ID });
+  });
+
+  test('idempotent: an already-reviewed grape answers already:true without a save or a second audit row', async () => {
+    const doc = { _id: GRAPE_ID, name: 'Syrah', pendingReview: false, save: jest.fn() };
+    Grape.findById.mockResolvedValue(doc);
+
+    const res = await approve(GRAPE_ID);
+    expect(res.status).toBe(200);
+    expect((await res.json()).already).toBe(true);
+    expect(doc.save).not.toHaveBeenCalled();
+    expect(logAudit).not.toHaveBeenCalled();
+  });
+
+  test('unknown id → 404, malformed id → 400', async () => {
+    Grape.findById.mockResolvedValue(null);
+    expect((await approve('64b0000000000000000000ff')).status).toBe(404);
+    expect((await approve('not-an-id')).status).toBe(400);
+  });
+});

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -742,6 +742,34 @@ router.post('/regions/:id/approve', async (req, res) => {
   }
 });
 
+// POST /api/admin/taxonomy/grapes/:id/approve — clear the pendingReview flag
+// a user-write mint set (somm ticket 6a942a60: bottle-add/import minted
+// "Honey" and "Alvarão" straight into the shared taxonomy). Mirrors the
+// regions verb above: approval is its own verb, not a PUT side effect —
+// editing a grape to fix a typo must not silently count as "a human vouched
+// for this". A near-miss mint gets MERGED from the queue instead (the
+// existing grapes/merge route), never silently substituted at add time.
+router.post('/grapes/:id/approve', async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const grape = await Grape.findById(req.params.id);
+    if (!grape) return res.status(404).json({ error: 'Grape not found' });
+    // Idempotent like the regions verb: a second click must not write a
+    // second audit entry for a no-op.
+    if (!grape.pendingReview) return res.json({ grape, already: true });
+    grape.pendingReview = false;
+    await grape.save();
+    logAudit(req, 'admin.taxonomy.approveGrape',
+      { type: 'grape', id: grape._id },
+      { name: grape.name }
+    );
+    res.json({ grape });
+  } catch (error) {
+    console.error('Approve grape error:', error);
+    res.status(500).json({ error: 'Failed to approve grape' });
+  }
+});
+
 // ===== MERGES =====
 // Collapse a duplicate taxonomy doc into its canonical counterpart. All
 // references (wines, regions, appellations) are rewritten before the

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -183,7 +183,13 @@ async function findOrCreateGrapes(rawNames, userId) {
       $or: [{ normalizedName }, { normalizedSynonyms: normalizedName }],
     });
     if (!grape) {
-      grape = new Grape({ name: canonicalName, normalizedName, createdBy: userId });
+      // pendingReview: a user write minted taxonomy — visible to admins,
+      // never blocking the user. Same rule as findOrCreateRegion above.
+      // Unflagged mints put "Honey" (a mead) and "Alvarão" (a typo of
+      // Alvarinho the synonym lookup couldn't bridge) into the globally
+      // shared taxonomy (somm ticket 6a942a60); the curator queue is where
+      // a near-miss gets merged instead of silently substituted.
+      grape = new Grape({ name: canonicalName, normalizedName, createdBy: userId, pendingReview: true });
       await grape.save();
     }
     if (!ids.some(id => String(id) === String(grape._id))) ids.push(grape._id); // two synonyms may resolve to one doc

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -1088,8 +1088,27 @@ describe('taxonomy find-or-create dedup', () => {
       $or: [{ normalizedName: 'syrah' }, { normalizedSynonyms: 'syrah' }],
     });
     expect(Grape).toHaveBeenCalledTimes(1);
-    expect(Grape).toHaveBeenCalledWith({ name: 'Syrah', normalizedName: 'syrah', createdBy: USER_ID });
+    expect(Grape).toHaveBeenCalledWith({
+      name: 'Syrah', normalizedName: 'syrah', createdBy: USER_ID,
+      // Somm ticket 6a942a60 ("Honey", "Alvarão"): a user-write grape mint is
+      // born flagged for admin review — visible, never blocking. Same R3 rule
+      // as the region mint above.
+      pendingReview: true,
+    });
     expect(ids).toEqual(['grape-new']);
+  });
+
+  test('findOrCreateGrapes: matching an existing grape never touches its review state', async () => {
+    const existing = { _id: 'grape-1', save: jest.fn() };
+    Grape.findOne.mockResolvedValue(existing);
+
+    const ids = await findOrCreateGrapes(['Grenache'], USER_ID);
+
+    // The match path must not construct, save, or re-flag anything — only a
+    // genuinely NEW variety enters the review queue.
+    expect(ids).toEqual(['grape-1']);
+    expect(Grape).not.toHaveBeenCalled();
+    expect(existing.save).not.toHaveBeenCalled();
   });
 
   test('findOrCreateGrapes: blend percentages are stripped, bare percentages dropped', async () => {

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -165,6 +165,10 @@ export const adminRestoreDismissedAppellation = (apiFetch, name) =>
 export const adminApproveRegion = (apiFetch, regionId) =>
   apiFetch(`/api/admin/taxonomy/regions/${regionId}/approve`, { method: 'POST' });
 
+/** Approve a user-minted grape (clears its pendingReview flag). */
+export const adminApproveGrape = (apiFetch, grapeId) =>
+  apiFetch(`/api/admin/taxonomy/grapes/${grapeId}/approve`, { method: 'POST' });
+
 // Force a full Meilisearch rebuild from the running process — the restore
 // runbook's missing step (a stale index silently disables the dedup net).
 export const adminReindexSearch = (apiFetch) =>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1486,6 +1486,7 @@
       },
       "pendingRegion": "New — unreviewed",
       "pendingRegionTitle": "This region was created automatically by a user adding a wine and has not been reviewed by an admin",
+      "pendingGrapeTitle": "This grape was created automatically by a user adding a wine and has not been reviewed by an admin — approve it, or merge it into the correct variety",
       "approveRegion": "Approve",
       "regionalNamesLabel": "Regional display names",
       "regionalNamesHint": "Label-true names shown on wines from a specific place — e.g. Tempranillo appears as \"Tinta Roriz\" on Douro wines. Storage, search filters and stats keep the canonical variety; leave the region empty to cover the whole country.",

--- a/frontend/src/pages/AdminTaxonomy.js
+++ b/frontend/src/pages/AdminTaxonomy.js
@@ -4,7 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import {
   adminGetTaxonomy, adminGetCountries, adminGetGrapes, adminGetRegions,
   adminCreateTaxonomy, adminUpdateTaxonomy, adminDeleteTaxonomy,
-  adminMergeTaxonomy, adminApproveRegion,
+  adminMergeTaxonomy, adminApproveRegion, adminApproveGrape,
 } from '../api/admin';
 import GrapePicker from '../components/GrapePicker';
 import ConfirmModal from '../components/ConfirmModal';
@@ -267,10 +267,12 @@ function AdminTaxonomy() {
           String(i.country?._id || i.country) === String(mergeItem.country?._id || mergeItem.country)))
     : [];
 
-  const handleApproveRegion = async (id) => {
+  // Regions and grapes share the pendingReview flow; the endpoint differs.
+  const handleApprove = async (id) => {
     setError(null);
     try {
-      const res = await adminApproveRegion(apiFetch, id);
+      const approve = activeTab === 'grapes' ? adminApproveGrape : adminApproveRegion;
+      const res = await approve(apiFetch, id);
       const data = await res.json();
       if (res.ok) fetchItems();
       else setError(data.error || 'Failed to approve');
@@ -889,11 +891,14 @@ function AdminTaxonomy() {
                 <div className="taxonomy-item-actions">
                   {item.pendingReview && (
                     <>
-                      <span className="taxonomy-badge taxonomy-badge--pending" title={t('admin.taxonomy.pendingRegionTitle')}>
+                      <span
+                        className="taxonomy-badge taxonomy-badge--pending"
+                        title={t(activeTab === 'grapes' ? 'admin.taxonomy.pendingGrapeTitle' : 'admin.taxonomy.pendingRegionTitle')}
+                      >
                         {t('admin.taxonomy.pendingRegion')}
                       </span>
                       <button
-                        onClick={() => handleApproveRegion(item._id)}
+                        onClick={() => handleApprove(item._id)}
                         className="btn btn-primary btn-small"
                       >
                         {t('admin.taxonomy.approveRegion')}


### PR DESCRIPTION
Somm ticket `6a942a60`: a ~509-row import day left two non-grape values in the **globally shared** grape taxonomy, both minted by ordinary user adds — "Honey" (via a mead) and "Alvarão" (the local Lisboa name for Alvarinho that the synonym lookup couldn't bridge). The curator path (`add_grape`) is match-first; the bottle-add/import path (`findOrCreateGrapes`) wrote straight to the taxonomy with no gate.

**The fix is the Region `pendingReview` pattern, verbatim:**
- A user-write grape mint is born `pendingReview: true` — visible to admins, never blocking the add (the never-make-adding-harder rule).
- Matching an existing grape/synonym never touches review state.
- A near-miss that doesn't resolve gets **merged by a curator from the queue** (the existing `grapes/merge` route already turns the old name into a synonym so it can't re-mint) — never silently substituted at add time. That's the #1134 lesson applied to taxonomy.
- Approval is its own verb (`POST /api/admin/taxonomy/grapes/:id/approve`), mirroring the regions verb: idempotent, audited, never a PUT side effect.
- Admin taxonomy page reuses the existing pending badge + approve button on the grapes tab (grape-specific tooltip).

**Prod data already repaired via existing endpoints** (no schema needed): Alvarão merged into Albariño with "Alvarão" preserved as a synonym — verified against the producer: it's a real local name, not a typo — Honey deleted, the mead and a pre-mixed Bucks Fizz quarantined as non-wine, and 2 stray pending maturity rows for quarantined records removed.

Tests: mint carries the flag, match path saves nothing, approve flips/audits once + idempotent + 400/404. Taxonomy/findOrCreateWine/cellarImport/import suites green (257 passed); frontend 1060 + token guard + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)