### PR TITLE
fix(profiles): a private member who posts publicly is no longer "User not found"

### DIFF
--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -51,6 +51,32 @@ const { isValidId, coerceStringQuery } = require('../utils/validation');
 
 const router = express.Router();
 
+/**
+ * Has this member published anything under their own name that other users can
+ * already see? Used only to decide whether a PRIVATE profile answers with a
+ * "this profile is private" stub or with the enumeration-proof 404.
+ *
+ * The three surfaces that render an author's username next to their content
+ * and link it to /users/:id — discussions, replies and public reviews. A
+ * soft-deleted reply doesn't count: its body is replaced with a placeholder
+ * and the name goes with it. A review the author marked private doesn't count
+ * either — same principle as the profile itself.
+ *
+ * Runs at most three indexed existence checks, and only on the private-profile
+ * path, which is a small fraction of profile views.
+ *
+ * @param {mongoose.Types.ObjectId} userId
+ * @returns {Promise<boolean>}
+ */
+async function hasPublicFootprint(userId) {
+  const [discussion, reply, review] = await Promise.all([
+    Discussion.exists({ author: userId }),
+    DiscussionReply.exists({ author: userId, isDeleted: { $ne: true } }),
+    Review.exists({ author: userId, visibility: 'public' }),
+  ]);
+  return !!(discussion || reply || review);
+}
+
 // GET /api/users/profile - Get current user's profile (protected)
 router.get('/profile', requireAuth, async (req, res) => {
   try {
@@ -179,9 +205,34 @@ router.get('/public/:userId', requireAuth, async (req, res) => {
     // Respect profileVisibility: a private profile is only viewable by its
     // owner. The /search sibling already filters on 'public'; this endpoint
     // must not become a private-profile read oracle by ObjectId enumeration.
+    //
+    // …with one exception, because the blanket 404 told a lie the rest of the
+    // app contradicted: a forum post shows its author's username and links to
+    // this page, so clicking a visible name answered "User not found" for 84
+    // of 346 accounts (Johan, 2026-08-31). Where the member has ALREADY
+    // published content under this identity, their existence is public by
+    // their own action and the 404 protects nothing — so they get a stub
+    // saying the profile is private, and nothing else. A member who never
+    // posted stays fully indistinguishable from a non-existent id, which is
+    // the enumeration property #519 actually bought.
     const isOwner = req.user.id === req.params.userId;
     if (user.profileVisibility === 'private' && !isOwner) {
-      return res.status(404).json({ error: 'User not found' });
+      if (!(await hasPublicFootprint(user._id))) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+      // Deliberately minimal: identity the viewer can already see, plus the
+      // reason the rest is missing. No bio, counts, plan, contribution,
+      // rating scale, join date or follow state — a private profile stays
+      // private, it just stops pretending to be a dead link.
+      return res.json({
+        user: {
+          _id: user._id,
+          username: user.username,
+          displayName: user.displayName,
+          profileVisibility: 'private',
+          isPrivate: true,
+        },
+      });
     }
 
     // Check if current user follows this user

--- a/backend/src/routes/users.privateProfile.test.js
+++ b/backend/src/routes/users.privateProfile.test.js
@@ -1,0 +1,186 @@
+/**
+ * GET /api/users/public/:userId — what a PRIVATE profile answers.
+ *
+ * WHY THIS TEST EXISTS:
+ * The blanket 404 from security PR #519 kept ObjectId enumeration from
+ * confirming an account exists. But the rest of the app contradicted it: a
+ * forum post shows its author's username and links to this page, so clicking
+ * a visible name answered "User not found" for 84 of 346 accounts
+ * (Johan, 2026-08-31).
+ *
+ * The narrowed rule: a private member who has ALREADY published under this
+ * identity (a discussion, a non-deleted reply, or a public review) gets an
+ * identity-only stub — everything else about them stays hidden. A private
+ * member who never posted keeps the indistinguishable 404, which is the
+ * property #519 actually bought. These tests pin BOTH halves, because
+ * loosening the second one silently would undo the hardening.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/Discussion', () => ({ exists: jest.fn() }));
+jest.mock('../models/DiscussionReply', () => ({ exists: jest.fn() }));
+jest.mock('../models/Review', () => ({ exists: jest.fn() }));
+jest.mock('../models/Follow', () => ({ findOne: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/search', () => ({
+  getIsAvailable: jest.fn(() => false), indexWine: jest.fn(), removeWine: jest.fn(),
+  bulkIndexWines: jest.fn(), bulkIndexBottles: jest.fn(), fullSync: jest.fn(),
+  fullSyncBottles: jest.fn(), waitForTasks: jest.fn(), indexDiscussion: jest.fn(),
+}));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+const Discussion = require('../models/Discussion');
+const DiscussionReply = require('../models/DiscussionReply');
+const Review = require('../models/Review');
+const Follow = require('../models/Follow');
+const usersRouter = require('./users');
+
+const VIEWER = '64b000000000000000000001';
+const TARGET = '64b000000000000000000002';
+
+let server;
+let baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/users', usersRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const token = (id) => jwt.sign({ id, roles: ['user'] }, 'test-secret');
+const get = (targetId, viewerId = VIEWER) =>
+  fetch(`${baseUrl}/api/users/public/${targetId}`, { headers: { Authorization: `Bearer ${token(viewerId)}` } });
+
+/** The route calls User.findById(id).select(...) and awaits the result. */
+const mockUser = (over = {}) => {
+  const doc = {
+    _id: TARGET, username: 'boubou17', displayName: null, bio: 'a secret bio',
+    followersCount: 3, followingCount: 4, reviewCount: 5,
+    profileVisibility: 'private', createdAt: new Date('2026-08-31'),
+    plan: 'free', preferences: { ratingScale: '5' },
+    contribution: { totalScore: 99, tier: 'expert' },
+    ...over,
+  };
+  User.findById.mockReturnValue({ select: () => doc });
+  return doc;
+};
+
+const noFootprint = () => {
+  Discussion.exists.mockResolvedValue(null);
+  DiscussionReply.exists.mockResolvedValue(null);
+  Review.exists.mockResolvedValue(null);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Follow.findOne.mockResolvedValue(null);
+  noFootprint();
+});
+
+describe('private profile with no public content', () => {
+  test('is indistinguishable from a non-existent account (the #519 property)', async () => {
+    mockUser();
+    const res = await get(TARGET);
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('User not found');
+  });
+
+  test('answers exactly like a genuinely missing user — same status, same body', async () => {
+    mockUser();
+    const privateRes = await get(TARGET);
+    const privateBody = await privateRes.json();
+
+    User.findById.mockReturnValue({ select: () => null });
+    const missingRes = await get('64b0000000000000000000ff');
+    const missingBody = await missingRes.json();
+
+    expect(privateRes.status).toBe(missingRes.status);
+    expect(privateBody).toEqual(missingBody);
+  });
+
+  test('a soft-deleted reply does not count as public content', async () => {
+    mockUser();
+    const res = await get(TARGET);
+    expect(res.status).toBe(404);
+    // The reply check must exclude deleted rows — its body is replaced with a
+    // placeholder, so the author's name is no longer on display anywhere.
+    expect(DiscussionReply.exists).toHaveBeenCalledWith({ author: TARGET, isDeleted: { $ne: true } });
+  });
+
+  test('a private review does not count as public content', async () => {
+    mockUser();
+    await get(TARGET);
+    expect(Review.exists).toHaveBeenCalledWith({ author: TARGET, visibility: 'public' });
+  });
+});
+
+describe('private profile whose owner has posted publicly', () => {
+  test.each([
+    ['a discussion', () => Discussion.exists.mockResolvedValue({ _id: 'd1' })],
+    ['a reply', () => DiscussionReply.exists.mockResolvedValue({ _id: 'r1' })],
+    ['a public review', () => Review.exists.mockResolvedValue({ _id: 'v1' })],
+  ])('%s earns the private stub instead of a 404', async (_label, arrange) => {
+    mockUser();
+    arrange();
+    const res = await get(TARGET);
+    expect(res.status).toBe(200);
+    const { user } = await res.json();
+    expect(user).toMatchObject({ username: 'boubou17', isPrivate: true, profileVisibility: 'private' });
+  });
+
+  test('the stub leaks nothing beyond the name already shown on their posts', async () => {
+    mockUser();
+    Discussion.exists.mockResolvedValue({ _id: 'd1' });
+    const { user } = await (await get(TARGET)).json();
+
+    expect(Object.keys(user).sort()).toEqual(
+      ['_id', 'displayName', 'isPrivate', 'profileVisibility', 'username'].sort()
+    );
+    for (const leaked of ['bio', 'followersCount', 'followingCount', 'reviewCount',
+      'createdAt', 'plan', 'contribution', 'ratingScale', 'isFollowing']) {
+      expect(user[leaked]).toBeUndefined();
+    }
+  });
+
+  test('no follow lookup happens for a stub — nothing to follow from here', async () => {
+    mockUser();
+    Discussion.exists.mockResolvedValue({ _id: 'd1' });
+    await get(TARGET);
+    expect(Follow.findOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('unchanged paths', () => {
+  test('a public profile still returns the full payload', async () => {
+    mockUser({ profileVisibility: 'public' });
+    const res = await get(TARGET);
+    expect(res.status).toBe(200);
+    const { user } = await res.json();
+    expect(user).toMatchObject({ username: 'boubou17', bio: 'a secret bio', followersCount: 3 });
+    expect(user.isPrivate).toBeUndefined();
+    // A public profile must not pay for the footprint checks.
+    expect(Discussion.exists).not.toHaveBeenCalled();
+  });
+
+  test('the owner still sees their own private profile in full', async () => {
+    mockUser();
+    const res = await get(TARGET, TARGET);
+    expect(res.status).toBe(200);
+    const { user } = await res.json();
+    expect(user.bio).toBe('a secret bio');
+    expect(user.isPrivate).toBeUndefined();
+    expect(Discussion.exists).not.toHaveBeenCalled();
+  });
+
+  test('a malformed id is still a 400', async () => {
+    const res = await get('not-an-id');
+    expect(res.status).toBe(400);
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4289,6 +4289,7 @@
   "userProfile": {
     "loading": "Loading...",
     "notFound": "User not found",
+    "privateProfile": "This member keeps their profile private.",
     "failedLoad": "Failed to load profile",
     "memberSince": "Member since {{date}}",
     "followers": "Followers",

--- a/frontend/src/pages/UserProfile.css
+++ b/frontend/src/pages/UserProfile.css
@@ -63,6 +63,15 @@
   font-size: 0.85rem;
 }
 
+/* Explains an otherwise-empty profile card. Muted and italic: a statement
+   about the member's choice, not an error the viewer should act on. */
+.user-profile__private-note {
+  margin: 0.5rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
 .user-profile__actions {
   flex-shrink: 0;
 }

--- a/frontend/src/pages/UserProfile.js
+++ b/frontend/src/pages/UserProfile.js
@@ -131,6 +131,31 @@ function UserProfile() {
   }
 
   const displayName = profile.displayName || profile.username;
+
+  // A private profile whose owner has posted publicly answers with an
+  // identity-only stub instead of a 404 (see routes/users.js). Render the name
+  // they already show on their posts and stop there — no stats, no lists, no
+  // follow button, and no member-since date (the stub carries no createdAt,
+  // which would otherwise format as "Invalid Date").
+  if (profile.isPrivate) {
+    return (
+      <div className="user-profile-page">
+        <div className="user-profile__header card">
+          <div className="user-profile__info">
+            <div className="user-profile__avatar">{displayName.charAt(0).toUpperCase()}</div>
+            <div className="user-profile__details">
+              <h1 className="user-profile__name">{displayName}</h1>
+              {profile.displayName && profile.displayName !== profile.username && (
+                <p className="user-profile__username">@{profile.username}</p>
+              )}
+              <p className="user-profile__private-note">{t('userProfile.privateProfile')}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const memberSince = new Date(profile.createdAt).toLocaleDateString(undefined, {
     year: 'numeric', month: 'long'
   });


### PR DESCRIPTION
Clicking **boubou17**'s name on their own forum thread answered *"User not found"*. The account exists — they set their profile to Private minutes after registering, and `GET /api/users/public/:userId` deliberately 404s a private profile so ObjectId enumeration can't confirm an account exists (security PR #519).

The reasoning was sound; the blast radius overreached. **The forum already prints the author's username beside their post and links it here**, so existence was public by the member's own action — the 404 protected nothing there and simply told the reader that a visible person doesn't exist. It affected **84 of 346 accounts (24%)**, on every surface that links a username: threads, replies, reviews, journal, recommendations.

### The narrowed rule

| Who | Answer |
|---|---|
| Private, **has** a discussion / live reply / public review | 200 + identity-only stub — username, displayName, `isPrivate`. **Nothing else.** |
| Private, never posted | **404, byte-identical to a missing account** — unchanged |
| Public profile · owner viewing self | unchanged, and pays nothing for the new checks |

The stub carries no bio, counts, join date, plan, contribution, rating scale or follow state, and the page renders it as "This member keeps their profile private." A **soft-deleted** reply doesn't count (its body is a placeholder, so the name is off display) and neither does a private review — same principle as the profile itself.

Also verified while in here: `GET /api/reviews/user/:userId` already gates on `profileVisibility`, so the profile page's unconditional review fetch leaks nothing for a private member.

Tests (12 new) pin **both** halves — including one asserting the no-footprint response is byte-identical to the genuinely-missing-user response, so a later change can't quietly undo the #519 hardening. Backend 52 passed across users/reviews/follows/journal/discussions; frontend 1068 passed; token guard and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)