### PR TITLE
fix(community): the English forum must include threads that predate language sections

### DIFF
--- a/backend/src/routes/discussions.js
+++ b/backend/src/routes/discussions.js
@@ -17,7 +17,7 @@ const { sanitizeForumHtml, visibleTextLength } = require('../utils/sanitizeHtml'
 const { logAudit } = require('../services/audit');
 const { incrementCred, decrementCred } = require('../utils/cellarCred');
 const {
-  resolveReadableLanguage, resolveWritableLanguage, resolveMoveTarget,
+  resolveReadableLanguage, resolveWritableLanguage, resolveMoveTarget, DEFAULT_LANGUAGE,
 } = require('../services/forumLanguages');
 const { submitUrls: submitToIndexNow } = require('../services/indexNow');
 const { createNotification, createNotifications } = require('../services/notifications');
@@ -83,7 +83,18 @@ router.get('/', optionalAuth, async (req, res) => {
       // constrained (it resolved against the ForumLanguage collection or fell
       // back to the default), but Array/DB lookups aren't recognised as taint
       // cleansers.
-      filter.language = { $eq: languageFilter };
+      //
+      // English ALSO matches threads with no language field at all. A Mongoose
+      // default applies when a document is created, never to documents that
+      // already exist — so the release that added this field left every
+      // pre-existing thread unmatched, and the English forum rendered empty on
+      // production until the rows were backfilled (2026-08-31). The backfill
+      // is done; this makes the query correct on its own, so a restored
+      // snapshot or a document written around the schema cannot empty the
+      // forum again. `null` matches missing fields in MongoDB.
+      filter.language = languageFilter === DEFAULT_LANGUAGE
+        ? { $in: [DEFAULT_LANGUAGE, null] }
+        : { $eq: languageFilter };
     }
     // $eq forces literal-value comparison even though `category` is already
     // gated by an allowlist (CATEGORIES.includes). CodeQL doesn't recognise

--- a/backend/src/routes/discussions.languageLegacy.test.js
+++ b/backend/src/routes/discussions.languageLegacy.test.js
@@ -1,0 +1,96 @@
+/**
+ * The English forum must include threads that predate the `language` field.
+ *
+ * WHY THIS TEST EXISTS (production regression, 2026-08-31):
+ * v1.190.0 added Discussion.language with `default: 'en'` and the release notes
+ * — and the PR — claimed "every existing thread is English with no migration".
+ * That is false. A Mongoose default is applied when a document is CREATED; it
+ * does not touch documents already in the collection. So `{ language: 'en' }`
+ * matched none of the existing threads, and the English forum rendered EMPTY
+ * on production. Caught by the post-deploy verification, ~2 minutes live, and
+ * fixed by backfilling the rows.
+ *
+ * The backfill is done. This pins the query-level fix that makes it impossible
+ * to recur from a restored snapshot, a bulk insert, or any write that bypasses
+ * the schema: English matches a missing field as well as an explicit 'en'.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/indexNow', () => ({ submitUrls: jest.fn() }));
+jest.mock('../services/notifications', () => ({ createNotification: jest.fn(), createNotifications: jest.fn() }));
+jest.mock('../services/mailgun', () => ({ sendDiscussionReplyEmail: jest.fn(), EMAIL_VERIFICATION_ENABLED: false }));
+// Meilisearch off, so the list takes the MongoDB path this test is about.
+jest.mock('../services/search', () => ({ getIsAvailable: () => false, indexDiscussion: jest.fn() }));
+jest.mock('../models/ForumLanguage', () => ({ find: jest.fn(), findOne: jest.fn(), exists: jest.fn() }));
+
+const mockFind = jest.fn();
+jest.mock('../models/Discussion', () => {
+  const M = { find: (...a) => mockFind(...a), countDocuments: jest.fn().mockResolvedValue(0), findOne: jest.fn() };
+  M.CATEGORIES = ['tasting-notes', 'food-pairing', 'recommendations', 'cellar-tips', 'general'];
+  return M;
+});
+jest.mock('../models/DiscussionReply', () => ({ find: jest.fn(), aggregate: jest.fn().mockResolvedValue([]) }));
+jest.mock('../models/DiscussionRead', () => ({ find: jest.fn().mockReturnValue({ lean: async () => [] }) }));
+jest.mock('../models/DiscussionReaction', () => ({ find: jest.fn(), REACTION_KINDS: [] }));
+jest.mock('../models/DiscussionWatch', () => ({ updateOne: jest.fn(), find: jest.fn() }));
+jest.mock('../models/DiscussionReport', () => ({ find: jest.fn() }));
+jest.mock('../models/User', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ exists: jest.fn(), findOne: jest.fn() }));
+jest.mock('../models/BlogPost', () => ({ findOne: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const router = require('./discussions');
+
+const chain = (rows) => {
+  const c = {
+    populate: () => c, sort: () => c, skip: () => c, limit: () => c, lean: async () => rows,
+    then: (res) => Promise.resolve(rows).then(res),
+  };
+  return c;
+};
+
+let server;
+let baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/discussions', router);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFind.mockReturnValue(chain([]));
+});
+
+/** The filter the route handed to Discussion.find for the list query. */
+const listFilter = () => mockFind.mock.calls[0]?.[0];
+
+describe('English includes threads written before language sections existed', () => {
+  test('the default (no language param) matches BOTH "en" and a missing field', async () => {
+    await fetch(`${baseUrl}/api/discussions`);
+    expect(listFilter().language).toEqual({ $in: ['en', null] });
+  });
+
+  test('an explicit language=en does the same', async () => {
+    await fetch(`${baseUrl}/api/discussions?language=en`);
+    expect(listFilter().language).toEqual({ $in: ['en', null] });
+  });
+
+  test('another language matches only itself — a French list must not absorb legacy threads', async () => {
+    const ForumLanguage = require('../models/ForumLanguage');
+    ForumLanguage.exists.mockResolvedValue({ _id: 'x' });
+    await fetch(`${baseUrl}/api/discussions?language=fr`);
+    expect(listFilter().language).toEqual({ $eq: 'fr' });
+  });
+
+  test('language=all applies no language filter at all', async () => {
+    await fetch(`${baseUrl}/api/discussions?language=all`);
+    expect(listFilter().language).toBeUndefined();
+  });
+});

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -804,7 +804,13 @@ async function searchDiscussions(query, { category, language, limit = 20, offset
   // guard is belt-and-braces against a quote reaching the filter DSL, which
   // has no parameter binding.
   if (language && /^[a-z]{2,3}(-[a-z]{2,4})?$/.test(String(language))) {
-    filters.push(`language = "${language}"`);
+    // English also matches documents indexed before the field existed, whose
+    // `language` is NOT SET rather than 'en' — the same legacy-row problem
+    // that emptied the English forum on the MongoDB path (2026-08-31). A
+    // reindex fills them in, but search must not depend on one having run.
+    filters.push(language === 'en'
+      ? '(language = "en" OR language NOT EXISTS)'
+      : `language = "${language}"`);
   }
 
   const result = await discussionsIndex.search(query || '', {


### PR DESCRIPTION
**Production regression from v1.190.0**, caught by the post-deploy verification about two minutes after it went live: **the English forum rendered empty.**

`Discussion.language` was added with `default: 'en'`, and my PR claimed every existing thread would be English "with no migration". That was wrong, and it's the whole bug: **a Mongoose default applies when a document is created — it never touches documents already in the collection.** So `{ language: 'en' }` matched none of the nine existing threads and the default forum view returned nothing.

**Already fixed on prod**: the nine rows are backfilled (English 9, French 1, verified through the API).

**This PR is the query-level fix**, so the same emptiness can't return from a restored snapshot, a bulk insert, or any write that bypasses the schema:
- MongoDB path: English matches `{ : ['en', null] }` — `null` matches a missing field in MongoDB.
- Meilisearch path: the same, via `(language = "en" OR language NOT EXISTS)`, so search doesn't depend on a reindex having run.
- **Other languages still match only themselves** — a French list must not absorb unlabelled legacy threads.

Four regression tests pin those cases; the one asserting the default filter shape would have caught the original bug. Backend suites around discussions/forum-languages/search: 91 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)