### PR TITLE
feat(registry): record which identity fields a model supplied, not a person

### DIFF
--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -96,7 +96,33 @@ const wineLite = (wd) => (wd ? {
   // the key is omitted, meaning "not carried on this surface".
   // Output-only change: no reconnect needed.
   ...(grapesLite(wd.grapes)),
+  ...(provenanceLite(wd.identityProvenance)),
 } : null);
+
+/**
+ * Which identity fields a MODEL supplied rather than a person.
+ *
+ * Emitted as a list of field names, and only when at least one qualifies —
+ * the common case is a wine nobody needs warned about, and a key reading
+ * `inferred_fields: []` on every row is noise a curator learns to skip.
+ *
+ * Somm ticket 6a958dbc (2026-08-31): a 205-row import whose file carried
+ * appellation on every row and grapes on none produced wines whose grapes had
+ * been inferred by the model FROM the appellation — all eight Montlouis wines
+ * came out Chenin Blanc, including a pétillant naturel that is mostly Menu
+ * Pineau. The values were wrong, mutually consistent and indistinguishable
+ * from researched ones, so the curator had to stop work entirely. This is the
+ * missing signal: not "this is wrong", but "nobody asserted this".
+ */
+const provenanceLite = (provenance) => {
+  if (!provenance) return {};
+  // Mongoose Map on a hydrated doc, plain object on a .lean() one.
+  const entries = typeof provenance.entries === 'function'
+    ? [...provenance.entries()]
+    : Object.entries(provenance);
+  const inferred = entries.filter(([, source]) => source === 'model').map(([field]) => field).sort();
+  return inferred.length ? { inferred_fields: inferred } : {};
+};
 
 const grapesLite = (grapes) => {
   if (!Array.isArray(grapes)) return {};
@@ -244,7 +270,7 @@ registerTool({
         // grapes populated to NAMES, not just selected as ids: the queue row
         // is where the curator decides whether a wine needs work, and grapes
         // invisible here is what ticket 6a887619 mistook for a phantom writer.
-        .populate({ path: 'wineDefinition', select: 'name producer type appellation aiProfile grapes', populate: ['country', 'region', { path: 'grapes', select: 'name' }] })
+        .populate({ path: 'wineDefinition', select: 'name producer type appellation aiProfile grapes identityProvenance', populate: ['country', 'region', { path: 'grapes', select: 'name' }] })
         .lean(),
     ]);
     const data = profiles.map((p) => ({

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -297,6 +297,30 @@ const wineDefinitionSchema = new mongoose.Schema({
     enum: ['ui', 'import', 'mcp', 'ai', null],
     default: null
   },
+  // WHICH SOURCE SUPPLIED EACH IDENTITY FIELD. createdVia says which surface
+  // minted the row; this says, field by field, whether a human stated the
+  // value or a model supplied it.
+  //
+  // Why it exists (somm ticket 6a958dbc, 2026-08-31): a 205-row import whose
+  // file carried appellation on every row and grapes on none produced 89 wines
+  // whose grapes were inferred BY THE MODEL FROM THE APPELLATION — all eight
+  // Montlouis wines got Chenin Blanc, including a pétillant naturel that is
+  // mostly Menu Pineau. The values were wrong, self-consistent and
+  // indistinguishable from researched ones, so the curator had to stop: a
+  // profile written onto a misidentified record marks it verified forever.
+  // Nothing on the record said "this grape is a guess". Now it does.
+  //
+  // Sparse by design — a field absent from the map means "not recorded",
+  // which is what every row predating this carries. Never treat absence as
+  // 'file': it is the honest unknown.
+  identityProvenance: {
+    type: Map,
+    of: {
+      type: String,
+      enum: ['file', 'model', 'curator', 'scan', 'user'],
+    },
+    default: undefined,
+  },
   // Non-wine quarantine (registry audit 2026-07-26; policy decided by Johan:
   // KEEP, HIDE). Spirits/cider/sake rows imported by users stay in the
   // registry — their owners' bottles keep working, direct wine pages render —

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -159,6 +159,48 @@ function buildProposedWine(aiData, item) {
 }
 
 /**
+ * Which source supplied each identity field of an AI-identified import row.
+ *
+ * Computed SERVER-SIDE at mint from the file row, deliberately not carried on
+ * the aiWine object the client round-trips: provenance is a claim about our
+ * own pipeline, and a claim a client could edit is worth nothing.
+ *
+ * The rules mirror mergeAiWithFile's precedence exactly — file first for the
+ * label-stated fields, model for the rest. Its curator-facing point (somm
+ * ticket 6a958dbc, 2026-08-31): a grape the model INFERRED FROM THE
+ * APPELLATION must not look identical to one the owner's file stated. That
+ * import's file carried appellation on all 205 rows and grapes on none, and
+ * all eight of its Montlouis wines were duly assigned Chenin Blanc —
+ * including a pétillant naturel that is mostly Menu Pineau.
+ *
+ * @param {Object} item the file's row
+ * @param {Object} ai the identified wine actually being minted
+ * @returns {Object<string,'file'|'model'>}
+ */
+function computeIdentityProvenance(item, ai) {
+  const stated = (v) => typeof v === 'string' && v.trim() !== '';
+  const fileType = stated(item?.type) && WINE_TYPES.includes(String(item.type).trim().toLowerCase());
+  // The one field with a genuine file fallback on this path: /validate
+  // supplements the AI's empty grape list from the row (see the importGrapes
+  // branch), so a grape list CAN be the file's.
+  const fileGrapes = sanitizeGrapeNames(item?.grapes);
+  const aiGrapes = Array.isArray(ai?.grapes) ? ai.grapes : [];
+  const grapesFromFile = fileGrapes.length > 0 && aiGrapes.length > 0
+    && aiGrapes.every((g) => fileGrapes.some((f) => normalizeString(f) === normalizeString(g)));
+
+  return {
+    name: 'model',
+    producer: 'model',
+    country: stated(item?.country) && !stated(ai?.country) ? 'file' : 'model',
+    region: stated(item?.region) ? 'file' : 'model',
+    appellation: stated(item?.appellation) ? 'file' : 'model',
+    classification: stated(item?.classification) ? 'file' : 'model',
+    type: fileType ? 'file' : 'model',
+    grapes: grapesFromFile ? 'file' : 'model',
+  };
+}
+
+/**
  * Complete-row AI bypass (2026-08-29, Johan's call: "the somm is free and we
  * pay for AI"). A row whose FILE already states the identity does not need a
  * model to restate it: findOrCreateWine's ladder does the normalization work
@@ -1330,7 +1372,10 @@ router.post('/confirm', async (req, res) => {
               classification: str(ai.classification),
               type: str(ai.type),
               grapes: sanitizeGrapeNames(ai.grapes),
-            }, req.user.id, { createdVia: 'import', allowPending: true });
+            }, req.user.id, {
+              createdVia: 'import', allowPending: true,
+              provenance: computeIdentityProvenance(item, ai),
+            });
             // findOrCreateWine can return { wine: null, candidates } — the soft
             // zone. Unguarded, `wine._id` two lines down threw and took the
             // whole /confirm batch with it (audit L-7). Skip the row and report
@@ -2062,3 +2107,6 @@ module.exports = router;
 // independently of the 700-line /validate route around it.
 module.exports.buildProposedWine = buildProposedWine;
 module.exports.summariseReasons = summariseReasons;
+// Exported for tests: the provenance rules must be pinnable without standing
+// up a full import (somm ticket 6a958dbc).
+module.exports.computeIdentityProvenance = computeIdentityProvenance;

--- a/backend/src/routes/import.pendingIdentity.test.js
+++ b/backend/src/routes/import.pendingIdentity.test.js
@@ -130,7 +130,16 @@ test('a row with NO producer still imports — the bottle lands, the wine goes t
   const [fields, userId, opts] = findOrCreateWine.mock.calls[0];
   expect(fields.producer).toBe('');
   expect(userId).toBe(USER_ID);
-  expect(opts).toEqual({ createdVia: 'import', allowPending: true });
+  // toEqual, not objectContaining: the option set is a drift canary, so a new
+  // option has to be added here deliberately. `provenance` joined on
+  // 2026-08-31 (somm ticket 6a958dbc) — and this row is the purest case for
+  // it, since the file states nothing but a vintage, so every identity field
+  // the wine ends up with came from the model.
+  expect(opts).toEqual({
+    createdVia: 'import',
+    allowPending: true,
+    provenance: expect.objectContaining({ name: 'model', country: 'model', grapes: 'model' }),
+  });
 });
 
 test('the count is reported to the client and folded into the EXISTING import audit', async () => {

--- a/backend/src/routes/import.provenance.test.js
+++ b/backend/src/routes/import.provenance.test.js
@@ -1,0 +1,146 @@
+/**
+ * Identity provenance for AI-identified import rows.
+ *
+ * WHY THIS EXISTS (somm ticket 6a958dbc, 2026-08-31):
+ * A 205-row import carried appellation on every row and grapes on none. The
+ * identifier duly supplied grapes — by reasoning FROM the appellation — and
+ * all eight Montlouis-sur-Loire wines came out Chenin Blanc, including a
+ * pétillant naturel that is mostly Menu Pineau, and a Coteaux d'Ancenis red
+ * Pinot Noir came out white Malvoisie. The values were wrong, mutually
+ * consistent, and indistinguishable from researched ones, so the curator
+ * stopped work: a profile written onto a misidentified record marks it
+ * verified forever.
+ *
+ * The fix is not better guessing — it is saying which values were guesses.
+ * These tests pin the rule that a field the FILE stated is never labelled
+ * 'model', and that grapes with no file behind them always are.
+ */
+
+// Requiring the route pulls its whole dependency tree; meilisearch ships ESM
+// that jest does not transform, so the module boundary is stubbed exactly as
+// the other import suites do. Nothing below touches any of it — this is a pure
+// function test.
+jest.mock('../services/search', () => ({
+  indexWine: jest.fn(), bulkIndexBottles: jest.fn(), getIsAvailable: jest.fn(() => false),
+}));
+jest.mock('../services/labelScan', () => ({ identifyWineFromText: jest.fn() }));
+jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn(), findOrCreateRegion: jest.fn() }));
+jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+
+const { computeIdentityProvenance } = require('./import');
+
+// The real shape of the failing rows: identity columns, no type, no grapes.
+const loireRow = (over = {}) => ({
+  wineName: 'Sans Pagne', producer: 'Ludovic Chanson', vintage: '2021',
+  country: 'France', region: 'Vallée de la Loire', appellation: 'Montlouis sur Loire',
+  bottleSize: '750 ml', ...over,
+});
+
+const identified = (over = {}) => ({
+  name: 'Sans Pagne', producer: 'Ludovic Chanson', country: 'France',
+  region: 'Vallée de la Loire', appellation: 'Montlouis sur Loire',
+  type: 'white', grapes: ['Chenin Blanc'], ...over,
+});
+
+describe('computeIdentityProvenance — the ticket 6a958dbc row', () => {
+  test('appellation and region are the FILE; type and grapes are the MODEL', () => {
+    const p = computeIdentityProvenance(loireRow(), identified());
+    expect(p.appellation).toBe('file');
+    expect(p.region).toBe('file');
+    // The two fields nobody stated — and the two the curator found wrong.
+    expect(p.type).toBe('model');
+    expect(p.grapes).toBe('model');
+  });
+
+  test('name and producer are always the model on this path (it canonicalises them)', () => {
+    const p = computeIdentityProvenance(loireRow(), identified());
+    expect(p.name).toBe('model');
+    expect(p.producer).toBe('model');
+  });
+});
+
+describe('a field the file DID state is never labelled model', () => {
+  test('a stated type is file, even when the model also had one', () => {
+    const p = computeIdentityProvenance(loireRow({ type: 'sparkling' }), identified({ type: 'white' }));
+    expect(p.type).toBe('file');
+  });
+
+  test('an INVALID file type falls through to the model, matching the merge', () => {
+    // The merge only accepts a value the schema allows; anything else must not
+    // be credited to the file, or provenance would vouch for a discarded value.
+    const p = computeIdentityProvenance(loireRow({ type: 'purple' }), identified({ type: 'red' }));
+    expect(p.type).toBe('model');
+  });
+
+  test('blank and whitespace columns are not "stated"', () => {
+    const p = computeIdentityProvenance(
+      loireRow({ appellation: '', region: '   ', classification: undefined }),
+      identified({ appellation: 'Vouvray', region: 'Loire', classification: 'AOC' }),
+    );
+    expect(p.appellation).toBe('model');
+    expect(p.region).toBe('model');
+    expect(p.classification).toBe('model');
+  });
+});
+
+describe('grapes — the field with a real file fallback', () => {
+  test('grapes the file supplied are credited to the file', () => {
+    // /validate supplements the model's EMPTY grape list from the row, so a
+    // grape list genuinely can be the file's.
+    const p = computeIdentityProvenance(
+      loireRow({ grapes: ['Menu Pineau', 'Chardonnay'] }),
+      identified({ grapes: ['Menu Pineau', 'Chardonnay'] }),
+    );
+    expect(p.grapes).toBe('file');
+  });
+
+  test('a model list that merely OVERLAPS the file is still the model', () => {
+    const p = computeIdentityProvenance(
+      loireRow({ grapes: ['Chenin Blanc'] }),
+      identified({ grapes: ['Chenin Blanc', 'Chardonnay'] }),
+    );
+    expect(p.grapes).toBe('model');
+  });
+
+  test('spelling and case differences do not break the file credit', () => {
+    const p = computeIdentityProvenance(
+      loireRow({ grapes: ['chenin blanc'] }),
+      identified({ grapes: ['Chenin Blanc'] }),
+    );
+    expect(p.grapes).toBe('file');
+  });
+
+  test('no grapes anywhere is still labelled model, but the mint drops it', () => {
+    // computeIdentityProvenance labels intent; findOrCreateWine's pickProvenance
+    // discards labels for fields that ended up empty, so no wine claims a
+    // source for a grape list it does not have.
+    const p = computeIdentityProvenance(loireRow(), identified({ grapes: [] }));
+    expect(p.grapes).toBe('model');
+  });
+});
+
+describe('country keeps the merge\'s inverted precedence', () => {
+  test('the model wins when it identified one (it normalises local names)', () => {
+    const p = computeIdentityProvenance(loireRow({ country: 'Frankreich' }), identified({ country: 'France' }));
+    expect(p.country).toBe('model');
+  });
+
+  test('the file is the fallback when the model returned none', () => {
+    const p = computeIdentityProvenance(loireRow(), identified({ country: null }));
+    expect(p.country).toBe('file');
+  });
+});
+
+describe('robustness', () => {
+  test('a missing row or identification does not throw', () => {
+    expect(() => computeIdentityProvenance(undefined, identified())).not.toThrow();
+    expect(() => computeIdentityProvenance(loireRow(), undefined)).not.toThrow();
+    expect(() => computeIdentityProvenance(undefined, undefined)).not.toThrow();
+  });
+
+  test('a non-string column is not mistaken for a stated value', () => {
+    const p = computeIdentityProvenance(loireRow({ appellation: { $ne: null } }), identified());
+    expect(p.appellation).toBe('model');
+  });
+});

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -157,6 +157,30 @@ async function regionForAppellation(appellationName, countryId) {
   return hits.length === 1 ? hits[0] : null;
 }
 
+/**
+ * Keep only the provenance entries whose field this mint actually SET.
+ *
+ * A caller reports where each value would have come from; the mint decides
+ * which values survive normalization (an unresolvable region becomes null, a
+ * junk grape list becomes empty). Recording "grapes: model" on a wine with no
+ * grapes would be a second kind of lie — a curator would see a provenance
+ * marker and look for a value that is not there.
+ *
+ * @param {Object<string,string>} provenance field → 'file' | 'model' | …
+ * @param {Object} stored the values as they are about to be written
+ * @returns {Object<string,string>|undefined} undefined when nothing qualifies
+ */
+function pickProvenance(provenance, stored) {
+  const out = {};
+  for (const [field, source] of Object.entries(provenance || {})) {
+    if (!source) continue;
+    const value = stored[field];
+    if (value === undefined || value === null || value === '') continue;
+    out[field] = source;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
 async function findOrCreateGrapes(rawNames, userId) {
   if (!Array.isArray(rawNames) || rawNames.length === 0) return [];
   // Same chokepoint argument as findOrCreateRegion: the route caps the count and
@@ -310,7 +334,7 @@ async function unpolluteEstateName({ name, producer, appellation, classification
   };
 }
 
-async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes, classification }, userId, { confirmCreate = false, skipSiblingMatch = false, matchOnly = false, createdVia = null, allowPending = false } = {}) {
+async function findOrCreateWine({ name, producer, country, region, appellation, type, grapes, classification }, userId, { confirmCreate = false, skipSiblingMatch = false, matchOnly = false, createdVia = null, allowPending = false, provenance = null } = {}) {
   // Internal whitespace collapses too, not just the ends: a double space is
   // invisible in every UI and every normalized key, so "Wrights  Estate" and
   // "Wrights Estate" would otherwise coexist as two display spellings forever
@@ -855,6 +879,16 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
     // Surface provenance ('mcp' = minted by a connected AI) — reviewable as a
     // class by admins; see WineDefinition.createdVia.
     createdVia,
+    // Per-field provenance, when the caller can distinguish a stated value
+    // from a supplied one. Only recorded for fields this mint actually set —
+    // claiming a source for an empty field would be a second kind of lie.
+    // See WineDefinition.identityProvenance.
+    ...(provenance ? { identityProvenance: pickProvenance(provenance, {
+      name: trimmedName, producer: producerToStore, country: countryDoc?._id,
+      region: regionDoc?._id, appellation: trimmedAppellation,
+      classification: trimmedClassification, type: wineType,
+      grapes: grapeIds?.length ? grapeIds : null,
+    }) } : {}),
     // Hidden from everyone but its creator and curation until a somm completes
     // the identity (models/WineDefinition.pendingIdentity). The model's
     // pre-validate hook promotes it automatically once producer + name are both


### PR DESCRIPTION
Somm ticket `6a958dbc`. A 205-row import carried **appellation on every row and grapes on none**. The identifier duly supplied grapes — by reasoning *from* the appellation — so all eight Montlouis-sur-Loire wines came out Chenin Blanc, including a pétillant naturel that is mostly Menu Pineau, and a Coteaux d'Ancenis **red Pinot Noir** came out **white Malvoisie**.

What made it expensive wasn't the error rate. The wrong values were **mutually consistent** — two of the three fields were *derived from* the third — entirely plausible on their face, and indistinguishable from researched ones. So the curator couldn't tell sound rows from bad without researching all 89, and stopped work. In their words: a profile written onto a misidentified record marks it verified forever.

**The fix is not better guessing. It is saying which values were guesses.**

| Piece | What it does |
|---|---|
| `WineDefinition.identityProvenance` | sparse field→source map (`file` / `model` / `curator` / `scan` / `user`) |
| `computeIdentityProvenance()` | mirrors the import merge's precedence exactly |
| `pickProvenance()` | drops labels for fields that ended up empty after normalization |
| `wineLite.inferred_fields` | what the curator sees, in the maturity queue where they judge |

Three decisions worth calling out:

- **Sparse on purpose.** An absent field means *not recorded* — what every pre-existing row carries. Absence must never be read as `file`.
- **Computed server-side at mint**, not carried on the `aiWine` object the client round-trips. Provenance is a claim about our own pipeline, and a claim a client could edit is worth nothing.
- **`inferred_fields` is omitted entirely when empty**, so a clean wine carries no noise and the key means something when it appears.

One correction to my own earlier diagnosis: grapes *do* have a file fallback — `/validate` supplements the model's empty list from the row — so the rule is "the model's unless the file's list is what got used", not a blanket label. Tests pin that distinction, including near-miss cases (overlapping lists, different spelling).

The `import.pendingIdentity` option-set canary caught the new mint option and was updated deliberately rather than loosened — that row states nothing but a vintage, making it the purest case of everything coming from the model.

Tests: **940 passed** across import / findOrCreateWine / MCP / GDPR registry, including 13 new provenance cases.

**Follow-up, not in this PR:** a backfill script (drafted, archive-driven) marks the 89 wines from that import retroactively, matching rows by normalized name+producer and leaving unmatched wines alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)