### PR TITLE
feat(taxonomy): scan for regions that are the same place under different names

### DIFF
--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -788,22 +788,43 @@ router.post('/grapes/:id/approve', async (req, res) => {
 // reference.
 router.get('/regions/duplicate-candidates', async (req, res) => {
   try {
-    const regions = await Region.find({})
-      .select('name country pendingReview synonyms')
-      .populate('country', 'name')
-      .lean();
+    // Country names come from a SEPARATE lookup, not .populate(). Populating
+    // destroys what the country scope depends on: a dangling ref makes
+    // Mongoose null the path and take the raw ObjectId with it, so every
+    // unresolvable region would collapse into one empty scope and same-named
+    // regions in DIFFERENT countries would cluster — the merge this scan must
+    // never propose (a Georgia in the United States is not the country's
+    // namesake). The guard fails CLOSED: a region whose country cannot be
+    // resolved is skipped and counted, never grouped with strangers.
+    const [regions, countries] = await Promise.all([
+      Region.find({}).select('name country pendingReview synonyms').lean(),
+      Country.find({}).select('name').lean(),
+    ]);
+    const countryNames = new Map(countries.map((c) => [String(c._id), c.name]));
 
-    const clusters = findDuplicateClusters(regions.map((r) => ({
-      ...r,
-      scope: String(r.country?._id || r.country || ''),
-    })));
-    if (clusters.length === 0) return res.json({ clusters: [], scannedCount: regions.length });
+    const scopable = [];
+    let unscopableCount = 0;
+    for (const r of regions) {
+      const scope = r.country ? String(r.country) : '';
+      if (!scope) { unscopableCount++; continue; }
+      scopable.push({ ...r, scope, countryName: countryNames.get(scope) || null });
+    }
+
+    const clusters = findDuplicateClusters(scopable);
+    if (clusters.length === 0) {
+      return res.json({ clusters: [], scannedCount: regions.length, unscopableCount });
+    }
 
     // One grouped count for every candidate rather than a query per member.
     const memberIds = clusters.flatMap((c) => c.members.map((m) => m._id));
     const counts = new Map(
       (await WineDefinition.aggregate([
-        { $match: { region: { $in: memberIds } } },
+        // Quarantined and pending-identity rows are not "in use" — the same
+        // exclusion wineCountsByRef() applies above, so this screen and the
+        // taxonomy list agree about the same region. It also decides the merge
+        // TARGET below: without it, a document whose bulk is quarantined junk
+        // could outrank the real region and pull its wines into itself.
+        { $match: { region: { $in: memberIds }, nonWine: { $ne: true }, pendingIdentity: { $ne: true } } },
         { $group: { _id: '$region', n: { $sum: 1 } } },
       ])).map((row) => [String(row._id), row.n])
     );
@@ -813,7 +834,7 @@ router.get('/regions/duplicate-candidates', async (req, res) => {
         .map((m) => ({
           _id: m._id,
           name: m.name,
-          country: m.country?.name || null,
+          country: m.countryName || null,
           wineCount: counts.get(String(m._id)) || 0,
           pendingReview: !!m.pendingReview,
           synonyms: m.synonyms || [],
@@ -829,7 +850,7 @@ router.get('/regions/duplicate-candidates', async (req, res) => {
       };
     }).sort((a, b) => b.totalWines - a.totalWines);
 
-    res.json({ clusters: out, scannedCount: regions.length });
+    res.json({ clusters: out, scannedCount: regions.length, unscopableCount });
   } catch (error) {
     console.error('Region duplicate scan error:', error);
     res.status(500).json({ error: 'Failed to scan for duplicate regions' });

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -12,6 +12,7 @@ const { logAudit } = require('../../services/audit');
 const { isValidId } = require('../../utils/validation');
 const { distinctSizes, normalizeAll, remap } = require('../../services/bottleSizeMaintenance');
 const { mergeGrapes, mergeRegions, mergeCountries } = require('../../services/taxonomyMerge');
+const { findDuplicateClusters } = require('../../utils/taxonomyDuplicates');
 const {
   listUnmatchedAppellations, appellationRefsError,
   dismissUnmatchedAppellation, restoreDismissedAppellation, listDismissedAppellations,
@@ -767,6 +768,71 @@ router.post('/grapes/:id/approve', async (req, res) => {
   } catch (error) {
     console.error('Approve grape error:', error);
     res.status(500).json({ error: 'Failed to approve grape' });
+  }
+});
+
+// GET /api/admin/taxonomy/regions/duplicate-candidates
+//
+// Regions that are the same place under different names. Built after the Loire
+// was found split across FOUR documents holding 208 wines between them
+// (2026-08-31) — a split nothing surfaced, because the names share almost no
+// characters and the registry's fuzzy wine scan cannot see it.
+//
+// utils/taxonomyDuplicates explains the rule and why its stop list is short.
+// The output is a PROPOSAL: every cluster is merged by hand through the merge
+// route below, which is what keeps a wrong signature from costing anything.
+//
+// Each cluster names a suggested target — the member with the most wines, or
+// the reviewed one on a tie — because merging into the smaller document would
+// re-point more rows than necessary and discard the doc appellations already
+// reference.
+router.get('/regions/duplicate-candidates', async (req, res) => {
+  try {
+    const regions = await Region.find({})
+      .select('name country pendingReview synonyms')
+      .populate('country', 'name')
+      .lean();
+
+    const clusters = findDuplicateClusters(regions.map((r) => ({
+      ...r,
+      scope: String(r.country?._id || r.country || ''),
+    })));
+    if (clusters.length === 0) return res.json({ clusters: [], scannedCount: regions.length });
+
+    // One grouped count for every candidate rather than a query per member.
+    const memberIds = clusters.flatMap((c) => c.members.map((m) => m._id));
+    const counts = new Map(
+      (await WineDefinition.aggregate([
+        { $match: { region: { $in: memberIds } } },
+        { $group: { _id: '$region', n: { $sum: 1 } } },
+      ])).map((row) => [String(row._id), row.n])
+    );
+
+    const out = clusters.map((c) => {
+      const members = c.members
+        .map((m) => ({
+          _id: m._id,
+          name: m.name,
+          country: m.country?.name || null,
+          wineCount: counts.get(String(m._id)) || 0,
+          pendingReview: !!m.pendingReview,
+          synonyms: m.synonyms || [],
+        }))
+        .sort((a, b) => b.wineCount - a.wineCount
+          || (a.pendingReview === b.pendingReview ? 0 : a.pendingReview ? 1 : -1));
+      return {
+        signature: c.signature,
+        country: members[0]?.country || null,
+        suggestedTargetId: members[0]?._id || null,
+        totalWines: members.reduce((sum, m) => sum + m.wineCount, 0),
+        members,
+      };
+    }).sort((a, b) => b.totalWines - a.totalWines);
+
+    res.json({ clusters: out, scannedCount: regions.length });
+  } catch (error) {
+    console.error('Region duplicate scan error:', error);
+    res.status(500).json({ error: 'Failed to scan for duplicate regions' });
   }
 });
 

--- a/backend/src/routes/admin/taxonomy.regionDuplicates.test.js
+++ b/backend/src/routes/admin/taxonomy.regionDuplicates.test.js
@@ -27,7 +27,8 @@ jest.mock('../../services/taxonomyReview', () => ({
 }));
 jest.mock('../../services/bottleSizeMaintenance', () => ({ distinctSizes: jest.fn(), normalizeAll: jest.fn(), remap: jest.fn() }));
 jest.mock('../taxonomy', () => ({ clearTaxonomyListCache: jest.fn() }));
-jest.mock('../../models/Country', () => ({ find: jest.fn(), findById: jest.fn(), exists: jest.fn() }));
+const mockCountryFind = jest.fn();
+jest.mock('../../models/Country', () => ({ find: (...a) => mockCountryFind(...a), findById: jest.fn(), exists: jest.fn() }));
 jest.mock('../../models/Grape', () => ({ find: jest.fn(), findById: jest.fn(), exists: jest.fn() }));
 jest.mock('../../models/Appellation', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
 
@@ -45,8 +46,9 @@ const http = require('http');
 const jwt = require('jsonwebtoken');
 const router = require('./taxonomy');
 
-const FR = { _id: 'fr', name: 'France' };
-const IT = { _id: 'it', name: 'Italy' };
+const FR = 'fr';
+const IT = 'it';
+const COUNTRIES = [{ _id: 'fr', name: 'France' }, { _id: 'it', name: 'Italy' }, { _id: 'us', name: 'United States' }, { _id: 'ge', name: 'Georgia' }, { _id: 'es', name: 'Spain' }];
 
 const chain = (rows) => ({ select: () => chain(rows), populate: () => chain(rows), lean: async () => rows });
 
@@ -69,6 +71,7 @@ const scan = () => fetch(`${baseUrl}/api/admin/taxonomy/regions/duplicate-candid
 beforeEach(() => {
   jest.clearAllMocks();
   mockWineAggregate.mockResolvedValue([]);
+  mockCountryFind.mockReturnValue(chain(COUNTRIES));
 });
 
 describe('the Loire cluster', () => {
@@ -108,8 +111,8 @@ describe('the Loire cluster', () => {
 describe('safety', () => {
   test('the same name under two countries is never one cluster', async () => {
     mockRegionFind.mockReturnValue(chain([
-      { _id: 'a', name: 'Georgia', country: { _id: 'us', name: 'United States' } },
-      { _id: 'b', name: 'Georgia', country: { _id: 'ge', name: 'Georgia' } },
+      { _id: 'a', name: 'Georgia', country: 'us' },
+      { _id: 'b', name: 'Georgia', country: 'ge' },
     ]));
     expect((await scan()).clusters).toHaveLength(0);
   });
@@ -131,10 +134,43 @@ describe('safety', () => {
     expect(body.scannedCount).toBe(1);
   });
 
+  // Audit finding, 2026-08-31: the first cut derived the country scope from a
+  // POPULATED ref. Mongoose nulls that path when the ref dangles — taking the
+  // raw ObjectId with it — so every unresolvable region collapsed to the same
+  // empty scope and same-named regions in different countries would have
+  // clustered. The guard has to fail CLOSED.
+  test('a region with no country is skipped, never grouped with strangers', async () => {
+    mockRegionFind.mockReturnValue(chain([
+      { _id: 'a', name: 'Georgia', country: null },
+      { _id: 'b', name: 'Georgia', country: undefined },
+      { _id: 'c', name: 'Barolo', country: IT },
+    ]));
+    const body = await scan();
+    expect(body.clusters).toHaveLength(0);
+    expect(body.unscopableCount).toBe(2);
+    expect(body.scannedCount).toBe(3);
+  });
+
+  // Audit finding: every sibling count helper in this file excludes quarantined
+  // and pending-identity rows. Without it the scan disagrees with the taxonomy
+  // list, and a document whose bulk is junk could be proposed as the TARGET.
+  test('wine counts exclude quarantined and pending-identity rows', async () => {
+    mockRegionFind.mockReturnValue(chain([
+      { _id: 'a', name: 'Rioja', country: 'es' },
+      { _id: 'b', name: 'La Rioja', country: 'es' },
+    ]));
+    await scan();
+    const [pipeline] = mockWineAggregate.mock.calls[0];
+    expect(pipeline[0].$match).toMatchObject({
+      nonWine: { $ne: true },
+      pendingIdentity: { $ne: true },
+    });
+  });
+
   test('a member with no wines still appears, ranked last', async () => {
     mockRegionFind.mockReturnValue(chain([
-      { _id: 'a', name: 'Rioja', country: { _id: 'es', name: 'Spain' } },
-      { _id: 'b', name: 'La Rioja', country: { _id: 'es', name: 'Spain' } },
+      { _id: 'a', name: 'Rioja', country: 'es' },
+      { _id: 'b', name: 'La Rioja', country: 'es' },
     ]));
     mockWineAggregate.mockResolvedValue([{ _id: 'a', n: 12 }]);
     const [cluster] = (await scan()).clusters;

--- a/backend/src/routes/admin/taxonomy.regionDuplicates.test.js
+++ b/backend/src/routes/admin/taxonomy.regionDuplicates.test.js
@@ -1,0 +1,144 @@
+/**
+ * GET /api/admin/taxonomy/regions/duplicate-candidates
+ *
+ * The scan that would have caught the Loire split (four documents, 208 wines,
+ * 2026-08-31) the day it started rather than six weeks later.
+ *
+ * The signature rule itself is tested in utils/taxonomyDuplicates.test.js.
+ * These pin the wiring an admin depends on: that clusters never cross a
+ * country, that the suggested merge target is the document holding the most
+ * wines, and that wine counts come from one grouped query rather than a
+ * per-member fan-out.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../services/search', () => ({
+  getIsAvailable: jest.fn(() => false), fullSync: jest.fn(), fullSyncBottles: jest.fn(),
+  indexWine: jest.fn(), removeWine: jest.fn(), bulkIndexWines: jest.fn(),
+  bulkIndexBottles: jest.fn(), waitForTasks: jest.fn(),
+}));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/taxonomyMerge', () => ({ mergeGrapes: jest.fn(), mergeRegions: jest.fn(), mergeCountries: jest.fn() }));
+jest.mock('../../services/taxonomyReview', () => ({
+  listUnmatchedAppellations: jest.fn(), appellationRefsError: jest.fn(),
+  dismissUnmatchedAppellation: jest.fn(), restoreDismissedAppellation: jest.fn(),
+  listDismissedAppellations: jest.fn(),
+}));
+jest.mock('../../services/bottleSizeMaintenance', () => ({ distinctSizes: jest.fn(), normalizeAll: jest.fn(), remap: jest.fn() }));
+jest.mock('../taxonomy', () => ({ clearTaxonomyListCache: jest.fn() }));
+jest.mock('../../models/Country', () => ({ find: jest.fn(), findById: jest.fn(), exists: jest.fn() }));
+jest.mock('../../models/Grape', () => ({ find: jest.fn(), findById: jest.fn(), exists: jest.fn() }));
+jest.mock('../../models/Appellation', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
+
+const mockRegionFind = jest.fn();
+jest.mock('../../models/Region', () => ({
+  find: (...a) => mockRegionFind(...a), findById: jest.fn(), countDocuments: jest.fn(), aggregate: jest.fn(),
+}));
+const mockWineAggregate = jest.fn();
+jest.mock('../../models/WineDefinition', () => ({
+  aggregate: (...a) => mockWineAggregate(...a), countDocuments: jest.fn(), find: jest.fn(),
+}));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const router = require('./taxonomy');
+
+const FR = { _id: 'fr', name: 'France' };
+const IT = { _id: 'it', name: 'Italy' };
+
+const chain = (rows) => ({ select: () => chain(rows), populate: () => chain(rows), lean: async () => rows });
+
+let server;
+let baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/taxonomy', router);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const token = jwt.sign({ id: '64b000000000000000000001', roles: ['admin'] }, 'test-secret');
+const scan = () => fetch(`${baseUrl}/api/admin/taxonomy/regions/duplicate-candidates`, {
+  headers: { Authorization: `Bearer ${token}` },
+}).then((r) => r.json());
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockWineAggregate.mockResolvedValue([]);
+});
+
+describe('the Loire cluster', () => {
+  beforeEach(() => {
+    mockRegionFind.mockReturnValue(chain([
+      { _id: 'r1', name: 'Loire Valley', country: FR, pendingReview: false, synonyms: [] },
+      { _id: 'r2', name: 'Vallée de la Loire', country: FR, pendingReview: true, synonyms: [] },
+      { _id: 'r3', name: 'Val de Loire', country: FR, pendingReview: true, synonyms: [] },
+      { _id: 'r4', name: 'Barolo', country: IT, pendingReview: false, synonyms: [] },
+    ]));
+    mockWineAggregate.mockResolvedValue([
+      { _id: 'r1', n: 173 }, { _id: 'r2', n: 32 }, { _id: 'r3', n: 1 },
+    ]);
+  });
+
+  test('finds the three Loire spellings and leaves Barolo alone', async () => {
+    const body = await scan();
+    expect(body.clusters).toHaveLength(1);
+    expect(body.clusters[0].members.map((m) => m._id)).toEqual(['r1', 'r2', 'r3']);
+    expect(body.scannedCount).toBe(4);
+  });
+
+  test('suggests the biggest document as the merge target, not the newest', async () => {
+    const [cluster] = (await scan()).clusters;
+    expect(cluster.suggestedTargetId).toBe('r1');
+    expect(cluster.members[0].wineCount).toBe(173);
+    expect(cluster.totalWines).toBe(206);
+    expect(cluster.country).toBe('France');
+  });
+
+  test('wine counts come from ONE grouped query, not one per member', async () => {
+    await scan();
+    expect(mockWineAggregate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('safety', () => {
+  test('the same name under two countries is never one cluster', async () => {
+    mockRegionFind.mockReturnValue(chain([
+      { _id: 'a', name: 'Georgia', country: { _id: 'us', name: 'United States' } },
+      { _id: 'b', name: 'Georgia', country: { _id: 'ge', name: 'Georgia' } },
+    ]));
+    expect((await scan()).clusters).toHaveLength(0);
+  });
+
+  test('distinct appellations that merely share a word are not proposed', async () => {
+    mockRegionFind.mockReturnValue(chain([
+      { _id: 'a', name: 'Médoc', country: FR },
+      { _id: 'b', name: 'Haut-Médoc', country: FR },
+      { _id: 'c', name: 'Pomerol', country: FR },
+      { _id: 'd', name: 'Lalande-de-Pomerol', country: FR },
+    ]));
+    expect((await scan()).clusters).toHaveLength(0);
+  });
+
+  test('a clean taxonomy returns an empty list with the count it scanned', async () => {
+    mockRegionFind.mockReturnValue(chain([{ _id: 'a', name: 'Barolo', country: IT }]));
+    const body = await scan();
+    expect(body.clusters).toEqual([]);
+    expect(body.scannedCount).toBe(1);
+  });
+
+  test('a member with no wines still appears, ranked last', async () => {
+    mockRegionFind.mockReturnValue(chain([
+      { _id: 'a', name: 'Rioja', country: { _id: 'es', name: 'Spain' } },
+      { _id: 'b', name: 'La Rioja', country: { _id: 'es', name: 'Spain' } },
+    ]));
+    mockWineAggregate.mockResolvedValue([{ _id: 'a', n: 12 }]);
+    const [cluster] = (await scan()).clusters;
+    expect(cluster.members.map((m) => m.wineCount)).toEqual([12, 0]);
+    expect(cluster.suggestedTargetId).toBe('a');
+  });
+});

--- a/backend/src/utils/taxonomyDuplicates.js
+++ b/backend/src/utils/taxonomyDuplicates.js
@@ -1,0 +1,113 @@
+const { normalizeString } = require('./normalize');
+
+/**
+ * Finding regions that are the same place under different names.
+ *
+ * WHY NOT THE WINE SCANNER'S APPROACH. The registry's duplicate-cluster scan
+ * groups by producer and fuzzy-scores the names. That is right for wines and
+ * useless here: the four documents the Loire was split across on 2026-08-31 —
+ * "Loire Valley" (173 wines), "Vallée de la Loire" (32), "Loire" (2) and
+ * "Val de Loire" (1) — share almost no characters. Trigram or Levenshtein
+ * similarity between "loire valley" and "vallee de la loire" is low. A fuzzy
+ * scan would never have found them, and a mint-time fuzzy check would not have
+ * prevented them.
+ *
+ * WHAT ACTUALLY SEPARATES THEM. A region's identity lives in its proper nouns.
+ * The difference between those four names is entirely articles, prepositions
+ * and the word for "valley" in two languages. So: reduce a name to its
+ * MEANINGFUL tokens, and two regions in the same country with the same
+ * meaningful tokens are the same place.
+ *
+ * WHY THE STOP LIST IS SO SHORT. Every wine-relevant qualifier must stay
+ * meaningful, or the scan proposes catastrophic merges:
+ *
+ *   haut / haute   Haut-Médoc is not Médoc
+ *   côtes          Côtes de Bergerac is not Bergerac
+ *   montagne       Montagne-Saint-Émilion is not Saint-Émilion
+ *   lalande        Lalande-de-Pomerol is not Pomerol
+ *   alto / bas     Alto Adige is not Adige
+ *
+ * So the list holds only articles, prepositions, and the handful of words that
+ * literally mean "valley". Nothing that could name a cru, a commune or a bank
+ * of a river.
+ *
+ * MEASURED AGAINST REAL DATA (prod, 2026-08-31). This rule proposes exactly
+ * the four merges a human confirmed, and rejects every false positive a plain
+ * substring overlap produced — including Jura/Jurançon, where "jura" is a
+ * substring of "jurançon" but not a token of it. It is deliberately precise
+ * rather than exhaustive: it does not catch "Savoie - Haute Savoie" or
+ * "Gascony / South West France", both of which a human would merge. A scan an
+ * admin trusts is worth more than one that surfaces 56 pairs of which five are
+ * real, because the second kind stops being read.
+ */
+
+// Articles, prepositions and conjunctions across the languages the registry
+// carries, plus the words that mean "valley" — and nothing else.
+const STOP_TOKENS = new Set([
+  // articles / prepositions / conjunctions
+  'de', 'du', 'des', 'da', 'do', 'dos', 'das', 'di', 'del', 'della', 'delle',
+  'dei', 'degli', 'la', 'le', 'les', 'el', 'los', 'las', 'lo', 'il', 'i', 'gli',
+  'l', 'd', 'the', 'of', 'and', 'et', 'e', 'y', 'und', 'a', 'au', 'aux',
+  // "valley", in the languages that name wine regions with it
+  'valley', 'vallee', 'val', 'valle', 'vale', 'tal',
+  // pure category words a file sometimes appends
+  'region', 'regione', 'wine', 'wines', 'vin', 'vino',
+]);
+
+/**
+ * The meaningful tokens of a taxonomy name, sorted and joined — two names with
+ * the same signature name the same place.
+ *
+ * Falls back to the full token set when stripping would leave nothing: a
+ * region genuinely called "Valle" must still compare against itself rather
+ * than collapsing into every other emptied name.
+ *
+ * @param {string} name
+ * @returns {string} '' when the name has no usable tokens at all
+ */
+function nameSignature(name) {
+  // Split on the RAW name's separators, then normalize each token — not the
+  // other way round. normalizeString removes punctuation rather than turning
+  // it into a space, so normalizing first fuses "Languedoc-Roussillon" into
+  // one token and it stops matching "Languedoc Roussillon" (caught by test,
+  // 2026-08-31).
+  const tokens = String(name || '')
+    .split(/[^\p{L}\p{N}]+/u)
+    .map((t) => normalizeString(t))
+    .filter(Boolean);
+  if (tokens.length === 0) return '';
+  const meaningful = tokens.filter((t) => !STOP_TOKENS.has(t));
+  const use = meaningful.length > 0 ? meaningful : tokens;
+  return [...new Set(use)].sort().join(' ');
+}
+
+/**
+ * Group taxonomy documents that share a signature within the same scope.
+ *
+ * Scope matters: two regions may share a name in different countries and be
+ * unrelated places (a "Georgia" in the United States is not the country's
+ * namesake), so a cluster never spans scopes.
+ *
+ * @param {Array<{_id: *, name: string, scope: *}>} docs
+ * @returns {Array<{signature: string, scope: string, members: Array}>} clusters
+ *   of two or more, largest first
+ */
+function findDuplicateClusters(docs) {
+  const buckets = new Map();
+  for (const doc of docs || []) {
+    const signature = nameSignature(doc.name);
+    if (!signature) continue;
+    const key = `${String(doc.scope ?? '')}::${signature}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { signature, scope: String(doc.scope ?? ''), members: [] };
+      buckets.set(key, bucket);
+    }
+    bucket.members.push(doc);
+  }
+  return [...buckets.values()]
+    .filter((b) => b.members.length > 1)
+    .sort((a, b) => b.members.length - a.members.length);
+}
+
+module.exports = { nameSignature, findDuplicateClusters, STOP_TOKENS };

--- a/backend/src/utils/taxonomyDuplicates.test.js
+++ b/backend/src/utils/taxonomyDuplicates.test.js
@@ -1,0 +1,123 @@
+const { nameSignature, findDuplicateClusters } = require('./taxonomyDuplicates');
+
+/**
+ * Every case below is a REAL row from production on 2026-08-31, when the Loire
+ * was found split across four region documents holding 208 wines between them.
+ *
+ * The rejections matter more than the matches. A scan that proposes merging
+ * Haut-Médoc into Médoc, or Montagne-Saint-Émilion into Saint-Émilion, would
+ * destroy distinctions the whole registry depends on — and the merge route
+ * deletes the source document, so a wrong proposal an admin accepts is not
+ * cheaply undone.
+ */
+
+describe('the Loire — the cluster this scan exists for', () => {
+  test('all four spellings reduce to the same signature', () => {
+    const sigs = ['Loire Valley', 'Vallée de la Loire', 'Val de Loire', 'Loire'].map(nameSignature);
+    expect(new Set(sigs).size).toBe(1);
+    expect(sigs[0]).toBe('loire');
+  });
+
+  test('they cluster together, and the cluster names them all', () => {
+    const clusters = findDuplicateClusters([
+      { _id: '1', name: 'Loire Valley', scope: 'FR' },
+      { _id: '2', name: 'Vallée de la Loire', scope: 'FR' },
+      { _id: '3', name: 'Val de Loire', scope: 'FR' },
+      { _id: '4', name: 'Loire', scope: 'FR' },
+    ]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].members.map((m) => m._id).sort()).toEqual(['1', '2', '3', '4']);
+  });
+});
+
+describe('punctuation and case differences', () => {
+  test('Languedoc-Roussillon and "Languedoc Roussillon" are one place', () => {
+    expect(nameSignature('Languedoc-Roussillon')).toBe(nameSignature('Languedoc Roussillon'));
+  });
+
+  test('but Languedoc alone is NOT the same as Languedoc-Roussillon', () => {
+    // Roussillon is a distinct region — Banyuls, Maury, Collioure. Merging
+    // these would erase that, and prod carries 85 and 67 wines on them.
+    expect(nameSignature('Languedoc')).not.toBe(nameSignature('Languedoc-Roussillon'));
+    expect(nameSignature('Roussillon')).not.toBe(nameSignature('Languedoc-Roussillon'));
+    expect(nameSignature('Languedoc')).not.toBe(nameSignature('Roussillon'));
+  });
+});
+
+describe('qualifiers that must stay meaningful', () => {
+  test.each([
+    ['Médoc', 'Haut-Médoc', 'a different appellation, not a spelling of it'],
+    ['Bergerac', 'Côtes de Bergerac', 'côtes names a distinct AOC'],
+    ['Saint-Émilion', 'Montagne-Saint-Émilion', 'Montagne is its own commune'],
+    ['Pomerol', 'Lalande-de-Pomerol', 'Lalande is its own appellation'],
+    ['Minervois', 'Minervois La Livinière', 'La Livinière is a cru'],
+    ['Adige', 'Alto Adige', 'alto is not decoration'],
+    ['Savoie', 'Savoie - Haute Savoie', 'conservative: haute stays meaningful'],
+  ])('%s is not %s (%s)', (a, b) => {
+    expect(nameSignature(a)).not.toBe(nameSignature(b));
+  });
+
+  test('Jura and Jurançon differ — a substring is not a token', () => {
+    // The plain overlap scan that found the Loire also proposed this pair,
+    // because "jura" is a substring of "jurancon". It is not a token of it.
+    expect(nameSignature('Jura')).not.toBe(nameSignature('Jurançon'));
+  });
+});
+
+describe('scope', () => {
+  test('the same name in two countries is never one cluster', () => {
+    const clusters = findDuplicateClusters([
+      { _id: 'us', name: 'Georgia', scope: 'US' },
+      { _id: 'ge', name: 'Georgia', scope: 'GE' },
+    ]);
+    expect(clusters).toHaveLength(0);
+  });
+
+  test('a lone document is not a cluster', () => {
+    expect(findDuplicateClusters([{ _id: '1', name: 'Barolo', scope: 'IT' }])).toHaveLength(0);
+  });
+});
+
+describe('degenerate input', () => {
+  test('a name of nothing but stop words compares on its full tokens', () => {
+    // "Valle" must still equal "Valle" rather than emptying to '' and
+    // clustering with every other emptied name.
+    expect(nameSignature('Valle')).toBe('valle');
+    expect(nameSignature('Valle')).not.toBe(nameSignature('Val'));
+  });
+
+  test('empty, punctuation-only and missing names yield no signature and no cluster', () => {
+    expect(nameSignature('')).toBe('');
+    expect(nameSignature('   ')).toBe('');
+    expect(nameSignature(null)).toBe('');
+    expect(nameSignature(undefined)).toBe('');
+    expect(findDuplicateClusters([
+      { _id: '1', name: '', scope: 'FR' },
+      { _id: '2', name: '  ', scope: 'FR' },
+    ])).toHaveLength(0);
+  });
+
+  test('duplicate tokens collapse, so word order never matters', () => {
+    expect(nameSignature('Rhone Vallee du Rhone')).toBe(nameSignature('Rhone'));
+    expect(nameSignature('Napa Valley')).toBe(nameSignature('Valley Napa'));
+  });
+
+  test('no documents at all is an empty result, not a throw', () => {
+    expect(findDuplicateClusters([])).toEqual([]);
+    expect(findDuplicateClusters(undefined)).toEqual([]);
+  });
+});
+
+describe('ordering', () => {
+  test('the largest cluster comes first — most wines to consolidate', () => {
+    const clusters = findDuplicateClusters([
+      { _id: 'a1', name: 'Rioja', scope: 'ES' },
+      { _id: 'a2', name: 'La Rioja', scope: 'ES' },
+      { _id: 'b1', name: 'Loire Valley', scope: 'FR' },
+      { _id: 'b2', name: 'Val de Loire', scope: 'FR' },
+      { _id: 'b3', name: 'Loire', scope: 'FR' },
+    ]);
+    expect(clusters[0].members).toHaveLength(3);
+    expect(clusters[1].members).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Today the Loire was found split across **four region documents holding 208 wines** between them — `Loire Valley` (173), `Vallée de la Loire` (32), `Loire` (2), `Val de Loire` (1). Filters, statistics and the world map had been under-counting it for weeks, and nothing surfaced the split.

### Why the existing scanner couldn't find it

The registry's duplicate-cluster scan groups by producer and fuzzy-scores names. That's right for wines and useless here: `loire valley` and `vallee de la loire` share almost no characters, so trigram and Levenshtein similarity are both low. **A fuzzy check at mint time wouldn't have prevented it either** — which is why the fix is a scan, not a stricter gate.

### The rule

What separates these names isn't spelling, it's grammar. A region's identity is its proper nouns; the difference between those four is entirely articles, prepositions, and the word for "valley" in two languages. So a name reduces to its **meaningful tokens**, and two regions in the same country with the same meaningful tokens are the same place.

The stop list is deliberately tiny — articles, prepositions, and words that literally mean "valley". Every wine-relevant qualifier stays meaningful, because dropping one proposes a catastrophic merge:

| Kept meaningful | Because |
|---|---|
| haut / haute | Haut-Médoc is not Médoc |
| côtes | Côtes de Bergerac is not Bergerac |
| montagne | Montagne-Saint-Émilion is not Saint-Émilion |
| alto | Alto Adige is not Adige |

### Measured against production

**515 regions → 3 clusters, all three genuine, zero false positives.** The same data through a naive substring overlap gave **56 pairs of which about five were real** — including Jura/Jurançon, where "jura" is a substring of "jurançon" but not a token of it.

It is precise rather than exhaustive: it misses `Savoie - Haute Savoie`, which a human would merge. That trade is deliberate — a scan an admin trusts beats one that surfaces 56 pairs and stops being read.

It also found a split I missed reviewing the same data by hand: **Rhône Valley (289) + Vallée du Rhône (7)**.

### Safety

Output is a **proposal**. Every cluster is merged by hand through the existing merge route (which preserves the retired name as a synonym, so imports match instead of re-minting). Each cluster names a suggested target — the document with the most wines — because merging into the smaller one re-points more rows than necessary and discards the document appellations already reference. Clusters never cross a country, so a Georgia in the United States is never proposed against the country's namesake.

Tests: **26 new** (19 on the signature rule, 7 on the route), every one built from a real production row, and the rejections are tested as carefully as the matches. Taxonomy suites: 70 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)