### PR TITLE
fix(ios): safe-area padding survives the mobile query, and deep links finish where they were going

### DIFF
--- a/frontend/src/components/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute.js
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 
 /**
@@ -12,6 +12,7 @@ import { useAuth } from '../contexts/AuthContext';
  */
 function ProtectedRoute({ children, requireAdmin = false, requireSomm = false, requireModerator = false, requireSuperAdmin = false }) {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -22,7 +23,19 @@ function ProtectedRoute({ children, requireAdmin = false, requireSomm = false, r
   }
 
   if (!user) {
-    return <Navigate to="/login" replace />;
+    // Carry where they were heading, so signing in finishes the journey they
+    // started instead of dumping them on /cellars (issue #1165). The case that
+    // makes it more than a nicety: NFC tags on a fridge shelf open Safari, not
+    // the installed PWA, and iOS gives a standalone web app its own cookie
+    // jar — so that Safari session has almost always expired by the next tap.
+    // Without this you sign in, land on /cellars, walk back to the fridge and
+    // tap again.
+    //
+    // The destination travels in router STATE, never a ?next= query param:
+    // state is set here and can't be steered by a crafted link, so it needs no
+    // allow-list. A string rather than the location object keeps the read on
+    // the login side to one optional chain while preserving the query.
+    return <Navigate to="/login" state={{ from: location.pathname + location.search }} replace />;
   }
 
   const roles = user.roles || [];

--- a/frontend/src/components/ProtectedRoute.test.js
+++ b/frontend/src/components/ProtectedRoute.test.js
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import ProtectedRoute from './ProtectedRoute';
+
+/**
+ * Signing in from a deep link should finish the journey you started
+ * (issue #1165, deltabeat).
+ *
+ * The case that makes it more than a nicety: NFC tags on a fridge shelf open
+ * Safari rather than the installed PWA, and iOS gives a standalone web app its
+ * own cookie jar — so that Safari session has nearly always expired by the next
+ * tap. Landing on /cellars means walking back to the fridge and tapping again.
+ *
+ * The destination travels in router state, never a ?next= query parameter, so
+ * it cannot be steered by a crafted link. These pin both halves: that the
+ * intended path is captured, and that it is captured as state.
+ */
+
+let mockAuth = { user: null, loading: false };
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => mockAuth }));
+
+/** Renders the router state the redirect arrived with. */
+function LoginProbe() {
+  const location = useLocation();
+  return <div data-testid="from">{location.state?.from ?? '(none)'}</div>;
+}
+
+const renderAt = (path) => render(
+  <MemoryRouter initialEntries={[path]}>
+    <Routes>
+      <Route path="/login" element={<LoginProbe />} />
+      <Route path="/nfc/rack/:id" element={<ProtectedRoute><div>rack</div></ProtectedRoute>} />
+      <Route path="/cellars" element={<ProtectedRoute><div>cellars</div></ProtectedRoute>} />
+    </Routes>
+  </MemoryRouter>
+);
+
+beforeEach(() => { mockAuth = { user: null, loading: false }; });
+
+describe('signed out', () => {
+  test('redirects to /login carrying the path that was asked for', () => {
+    renderAt('/nfc/rack/abc123');
+    expect(screen.getByTestId('from')).toHaveTextContent('/nfc/rack/abc123');
+  });
+
+  test('preserves the query string, which a bare pathname would drop', () => {
+    renderAt('/cellars?tab=overview&sort=name');
+    expect(screen.getByTestId('from')).toHaveTextContent('/cellars?tab=overview&sort=name');
+  });
+});
+
+describe('signed in', () => {
+  test('renders the protected page and never touches /login', () => {
+    mockAuth = { user: { id: 'u1', roles: ['user'] }, loading: false };
+    renderAt('/nfc/rack/abc123');
+    expect(screen.getByText('rack')).toBeInTheDocument();
+    expect(screen.queryByTestId('from')).toBeNull();
+  });
+});
+
+describe('still loading', () => {
+  test('waits rather than redirecting — an unresolved session is not a signed-out one', () => {
+    mockAuth = { user: null, loading: true };
+    renderAt('/nfc/rack/abc123');
+    expect(screen.queryByTestId('from')).toBeNull();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1487,7 +1487,7 @@
       "pendingRegion": "New — unreviewed",
       "pendingRegionTitle": "This region was created automatically by a user adding a wine and has not been reviewed by an admin",
       "pendingGrapeTitle": "This grape was created automatically by a user adding a wine and has not been reviewed by an admin — approve it, or merge it into the correct variety",
-      "needsReview": "{{count}} needs review",
+      "needsReview_one": "{{count}} needs review",
       "needsReview_other": "{{count}} need review",
       "needsReviewTitle": "Created automatically by a user and not used by any wine yet — the ones worth a look. Entries already in use are left alone.",
       "approveRegion": "Approve",

--- a/frontend/src/pages/LandingPage.css
+++ b/frontend/src/pages/LandingPage.css
@@ -472,7 +472,17 @@ button.btn-landing-ghost:disabled {
   }
 
   .landing-nav {
-    padding: 0 4%;
+    /* LONGHAND, deliberately. The `padding: 0 4%` shorthand that used to be
+       here reset padding-top to 0 and undid the safe-area inset from the base
+       rule — while `height: calc(60px + env(safe-area-inset-top))` survived,
+       because nothing else touched it. The bar therefore kept its full height
+       but lost the padding, so `align-items: center` centred the Sign In
+       button across the inset as well and its upper half sat back under the
+       strip iOS owns: visible, but only tappable along the bottom edge.
+       Reported by a real device after the first fix looked right in code
+       (issue #1145, deltabeat). Never use the padding shorthand here. */
+    padding-left: 4%;
+    padding-right: 4%;
   }
 
   .landing-nav-logo-img {

--- a/frontend/src/pages/Login.css
+++ b/frontend/src/pages/Login.css
@@ -244,7 +244,12 @@
 
 @media (max-width: 480px) {
   .login-page {
-    padding: 1rem;
+    /* The insets have to be repeated here. A bare `padding: 1rem` reset the
+       safe-area top and bottom from the base rule, on exactly the narrow
+       screens the inset exists for — the same shorthand trap deltabeat found
+       on .landing-nav (issue #1145), in the other file that fix touched.
+       Found by looking for siblings once the first one was confirmed. */
+    padding: calc(1rem + env(safe-area-inset-top)) 1rem calc(1rem + env(safe-area-inset-bottom));
     gap: 1.25rem;
   }
 

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,5 +1,5 @@
 import { useId, useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation, Trans } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import useVersion from '../hooks/useVersion';
@@ -43,6 +43,9 @@ function Login() {
   const { t } = useTranslation();
   const { login, register } = useAuth();
   const navigate = useNavigate();
+  // Where ProtectedRoute sent them from, when a deep link bounced them here
+  // (issue #1165). Set by ProtectedRoute itself, never read from the URL.
+  const location = useLocation();
   const appVersion = useVersion();
 
   // Ask the server which SSO providers are configured, so we only show buttons
@@ -77,7 +80,8 @@ function Login() {
         setRegisteredEmail(result.email);
         setRegistered(true);
       } else {
-        navigate('/cellars');
+        // Finish the journey they started, or the default home for a plain sign-in.
+        navigate(location.state?.from || '/cellars');
       }
     } else {
       if (result.code === 'EMAIL_NOT_VERIFIED') {


### PR DESCRIPTION
Two reports from **@deltabeat**, one of them a correction to my own earlier fix.

## #1145 was not fully fixed

They tested v1.185.0 on a real iPhone: the Sign In button had cleared the status bar, but **only its bottom edge responded to taps.** Their diagnosis was exact.

The mobile media query set `padding: 0 4%`, and that **shorthand reset `padding-top` to 0**, undoing the safe-area inset from the base rule — while `height: calc(60px + env(safe-area-inset-top))` survived, because nothing else touched it. So the bar kept its full height, lost its padding, and `align-items: center` then centred the button across the inset as well. Its upper half sat back under the strip iOS owns: visible, but dead to touch.

Now longhand `padding-left`/`padding-right`, so the shorthand can never reach the top again.

### Looking for siblings found a second one

The same trap was in **the other file that fix touched**: `.login-page` re-declared `padding: 1rem` under `max-width: 480px`, dropping both the top *and* bottom insets on exactly the narrow screens they exist for. Nobody had reported it.

I then swept every stylesheet that uses an inset. Those two were the only instances — `.main-content` re-applies its insets in longhands *after* its shorthand, and `.bd-mobile-actions` carries its inset on `bottom`, which padding cannot disturb.

## #1165 — signing in from a deep link

Landing on `/cellars` instead of the page asked for. `ProtectedRoute` now carries the intended path in router state and `Login` honours it.

The destination travels in **router state, not a `?next=` query parameter** — it's set by our own redirect and can't be steered by a crafted link, so it needs no allow-list on an auth path. That was @deltabeat's observation and it's the right call.

The motivating case is sharper than it sounds: NFC tags on a fridge shelf open **Safari**, not the installed PWA, and iOS gives a standalone web app its own cookie jar — so that Safari session has almost always expired by the next tap. Landing on `/cellars` meant walking back to the fridge and tapping again.

Tests: 4 new on `ProtectedRoute` (path captured, query preserved, signed-in untouched, and *loading* waits rather than redirecting — an unresolved session is not a signed-out one). Frontend suite **1072 passed**, token guard and build clean.

Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)