### PR TITLE
refactor(taxonomy): split pendingReview into origin and review

### DIFF
--- a/backend/src/mcp/adminRegistryTools.test.js
+++ b/backend/src/mcp/adminRegistryTools.test.js
@@ -204,11 +204,12 @@ describe('taxonomy review tools', () => {
     expect(body.data[0]).toMatchObject({ region_id: 'r1', name: 'Toscana', wine_count: 3 });
   });
 
-  test('approve_region clears the flag once, is idempotent, audits via mcp', async () => {
-    const r = { _id: oid('1'), name: 'Etna', pendingReview: true, save: jest.fn().mockResolvedValue(undefined) };
+  test('approve_region stamps the review once, is idempotent, audits via mcp', async () => {
+    const r = { _id: oid('1'), name: 'Etna', createdByUser: true, reviewedAt: null, save: jest.fn().mockResolvedValue(undefined) };
     Region.findById.mockResolvedValue(r);
     let body = parse(await tool('approve_region').handler({ region_id: oid('1') }, ADMIN_CTX));
-    expect(r.pendingReview).toBe(false);
+    expect(r.reviewedAt).toBeTruthy();
+    expect(r.createdByUser).toBe(true); // provenance survives the review
     expect(r.save).toHaveBeenCalled();
     expect(logAudit).toHaveBeenCalledWith(ADMIN_CTX.req, 'admin.taxonomy.approveRegion',
       expect.anything(), expect.objectContaining({ via: 'mcp' }));

--- a/backend/src/mcp/tools/adminRegistry.js
+++ b/backend/src/mcp/tools/adminRegistry.js
@@ -202,8 +202,14 @@ registerTool({
     const Region = require('../../models/Region');
     const region = await Region.findById(args.region_id);
     if (!region) return fail('not_found', 'No region with that id.');
-    if (!region.pendingReview) return ok(`"${region.name}" was already reviewed — nothing to do.`, { region_id: region._id, already: true });
-    region.pendingReview = false;
+    if (region.reviewedAt) return ok(`"${region.name}" was already reviewed — nothing to do.`, { region_id: region._id, already: true });
+    // Stamp the review; never clear createdByUser, which records where the
+
+    // document came from and stays true forever.
+
+    region.reviewedAt = new Date();
+
+    region.reviewedBy = ctx.user?.id || null;
     await region.save();
     // Same audit action as the REST approve — the two surfaces audit identically.
     logAudit(ctx.req, 'admin.taxonomy.approveRegion',

--- a/backend/src/models/Grape.js
+++ b/backend/src/models/Grape.js
@@ -88,14 +88,23 @@ const grapeSchema = new mongoose.Schema({
     default: []
   },
   slug: { type: String, trim: true, lowercase: true, unique: true, sparse: true, index: true },
-  // Set when a USER write minted this grape (bottle-add / import via
-  // findOrCreateGrapes) rather than a curator: visible to admins in the
-  // taxonomy review queue, never blocking the user — the exact Region
-  // pendingReview pattern. Unreviewed user mints polluted the shared
-  // taxonomy silently ("Honey" via a mead, "Alvarão" for Alvarinho —
-  // somm ticket 6a942a60, 2026-08-30). Cleared only by the explicit
-  // approve verb, never as a PUT side effect.
-  pendingReview: { type: Boolean, default: false, index: true },
+  // WHERE THIS DOCUMENT CAME FROM — a permanent fact, never cleared.
+  //
+  // True when a user write minted this grape (bottle-add / import via
+  // findOrCreateGrapes) rather than a curator. Unreviewed user mints polluted
+  // the shared taxonomy silently ("Honey" via a mead, "Alvarão" for
+  // Alvarinho — somm ticket 6a942a60, 2026-08-30).
+  //
+  // Renamed from `pendingReview` on 2026-08-31 for the reason spelled out on
+  // models/Region: the old name promised an action for a field that only
+  // recorded an origin. Same two-fact split as Region, and the same split the
+  // wine registry already used — createdVia says where a record came from,
+  // profileReviewedAt says whether a human has judged it.
+  createdByUser: { type: Boolean, default: false, index: true },
+  // When an admin actually reviewed this grape, and who. Null means nobody
+  // has, which is not by itself a problem — see needsHumanReview.
+  reviewedAt: { type: Date, default: null },
+  reviewedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   description: { type: String, trim: true, default: '' },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,

--- a/backend/src/models/Region.js
+++ b/backend/src/models/Region.js
@@ -65,14 +65,32 @@ const regionSchema = new mongoose.Schema({
     default: [],
     index: true
   },
-  // True while this region was auto-minted by a user write (label scan,
-  // add-bottle, import) and no admin has looked at it yet (strategy 2026-07-29
-  // R3). Self-minting is why the collection needed cleanup scripts twice in
-  // July: any comma-free non-country string becomes taxonomy silently. The
-  // flag makes the mint VISIBLE instead of blocking it — a user adding a
-  // bottle is never held up by taxonomy review. Admin-created regions are
-  // born reviewed (flag absent).
-  pendingReview: { type: Boolean, default: false, index: true },
+  // WHERE THIS DOCUMENT CAME FROM — a permanent fact, never cleared.
+  //
+  // True when a user write minted it (label scan, add-bottle, import) rather
+  // than a curator. Self-minting is why the collection needed cleanup scripts
+  // twice in July: any comma-free non-country string becomes taxonomy
+  // silently. Recording the mint makes it VISIBLE instead of blocking it — a
+  // user adding a bottle is never held up by taxonomy review.
+  //
+  // Renamed from `pendingReview` on 2026-08-31. That name described an action
+  // ("review is pending") for a field that only ever recorded an origin, and
+  // the mismatch cost a month: because it was set on every mint and cleared
+  // only by an admin clicking approve, the screen showed 164 rows as a to-do
+  // list of which 161 were in normal use and one was junk. Nobody could read
+  // a list like that, so nobody did — and the real defect inside it, one
+  // region split across four documents holding 208 wines, went unnoticed.
+  // Being flagged never revealed it; all four were flagged individually.
+  //
+  // Whether a human has LOOKED is a separate fact, and now a separate field.
+  createdByUser: { type: Boolean, default: false, index: true },
+  // When an admin actually reviewed this document, and who. Null means nobody
+  // has — which is the honest state for the great majority, and is not by
+  // itself a problem: a region carrying 36 wines has been proven real by use
+  // in a way an approval click adds nothing to. See needsHumanReview in
+  // routes/admin/taxonomy.js for what actually earns a curator's attention.
+  reviewedAt: { type: Date, default: null },
+  reviewedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   // Public-facing URL slug and curator description for /regions/:slug pages.
   slug: { type: String, trim: true, lowercase: true, unique: true, sparse: true, index: true },
   description: { type: String, trim: true, default: '' },

--- a/backend/src/routes/admin/taxonomy.grapeApprove.test.js
+++ b/backend/src/routes/admin/taxonomy.grapeApprove.test.js
@@ -66,14 +66,17 @@ const approve = (id) => fetch(`${baseUrl}/api/admin/taxonomy/grapes/${id}/approv
 beforeEach(() => jest.clearAllMocks());
 
 describe('POST /grapes/:id/approve', () => {
-  test('clears pendingReview, saves, and audits', async () => {
-    const doc = { _id: GRAPE_ID, name: 'Alvarão', pendingReview: true, save: jest.fn().mockResolvedValue(undefined) };
+  test('stamps the review and audits — WITHOUT erasing where the grape came from', async () => {
+    const doc = { _id: GRAPE_ID, name: 'Alvarão', createdByUser: true, reviewedAt: null, save: jest.fn().mockResolvedValue(undefined) };
     Grape.findById.mockResolvedValue(doc);
 
     const res = await approve(GRAPE_ID);
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.grape.pendingReview).toBe(false);
+    // The two facts are separate: reviewing records that a human looked, and
+    // says nothing about who created the document. createdByUser is permanent.
+    expect(body.grape.reviewedAt).toBeTruthy();
+    expect(body.grape.createdByUser).toBe(true);
     expect(body.already).toBeUndefined();
     expect(doc.save).toHaveBeenCalledTimes(1);
     expect(logAudit).toHaveBeenCalledTimes(1);
@@ -82,7 +85,7 @@ describe('POST /grapes/:id/approve', () => {
   });
 
   test('idempotent: an already-reviewed grape answers already:true without a save or a second audit row', async () => {
-    const doc = { _id: GRAPE_ID, name: 'Syrah', pendingReview: false, save: jest.fn() };
+    const doc = { _id: GRAPE_ID, name: 'Syrah', createdByUser: true, reviewedAt: new Date('2026-08-30'), save: jest.fn() };
     Grape.findById.mockResolvedValue(doc);
 
     const res = await approve(GRAPE_ID);

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -40,11 +40,12 @@ const { clearTaxonomyListCache } = require('../taxonomy');
 /**
  * Does this user-minted taxonomy row actually need a human to look at it?
  *
- * `pendingReview` records ONE fact: a user write minted this document rather
- * than a curator (services/findOrCreateWine). It inspects nothing about the
- * name, so it is provenance, not a verdict — and it is set on every mint and
- * cleared only by an admin clicking approve, which makes it a queue that grows
- * automatically and drains by hand.
+ * Two separate facts, deliberately: `createdByUser` records that a user write
+ * minted this document rather than a curator (services/findOrCreateWine), and
+ * `reviewedAt` records whether a human has since looked. They were one boolean
+ * named `pendingReview` until 2026-08-31, and that name is most of this story
+ * — it promised an action for a field that only ever recorded an origin, so
+ * every mint looked like a task and the pile only grew.
  *
  * Measured on production (2026-08-31): of 164 regions minted in one month, 161
  * were in genuine use and exactly one was junk. At a ~1% hit rate the sensible
@@ -58,17 +59,18 @@ const { clearTaxonomyListCache } = require('../taxonomy');
  * click adds nothing to. What deserves a human is the one nobody uses: that is
  * where the junk was ("Wine of Hungary", 0 wines) and where a typo would sit.
  *
- * The flag itself is deliberately NOT cleared here. It stays as the record of
- * where the document came from — the curator has found that provenance useful,
- * and tidying a screen is no reason to delete it. Duplicates are a separate
- * question with their own scan (GET /regions/duplicate-candidates).
+ * `createdByUser` is never cleared by anything. It stays as the record of where
+ * the document came from — the curator has found that provenance useful, and
+ * tidying a screen is no reason to delete it. Approving stamps `reviewedAt`
+ * instead. Duplicates are a separate question with their own scan
+ * (GET /regions/duplicate-candidates).
  *
- * @param {{pendingReview?: boolean}} doc
+ * @param {{createdByUser?: boolean, reviewedAt?: Date|null}} doc
  * @param {number} wineCount
  * @returns {boolean}
  */
 function needsHumanReview(doc, wineCount) {
-  return !!doc?.pendingReview && wineCount === 0;
+  return !!doc?.createdByUser && !doc?.reviewedAt && wineCount === 0;
 }
 
 /** Map<idString, wineCount> for a ref field ('country' | 'region'). */
@@ -293,7 +295,7 @@ router.get('/regions', async (req, res) => {
       count: rows.length,
       regions: rows,
       // What the screen should actually draw attention to — see
-      // needsHumanReview. `pendingReview` stays on every row untouched.
+      // needsHumanReview. createdByUser stays on every row untouched.
       needsReviewCount: rows.filter(r => r.needsReview).length,
     });
   } catch (error) {
@@ -768,7 +770,7 @@ router.delete('/grapes/:id', async (req, res) => {
   }
 });
 
-// POST /api/admin/taxonomy/regions/:id/approve — clear the pendingReview flag
+// POST /api/admin/taxonomy/regions/:id/approve — record that a human looked
 // a user-write mint set (strategy 2026-07-29 R3). Approval is its own verb,
 // not a PUT side effect: editing a region to fix a typo must not silently
 // count as "a human vouched for this".
@@ -779,8 +781,11 @@ router.post('/regions/:id/approve', async (req, res) => {
     if (!region) return res.status(404).json({ error: 'Region not found' });
     // Idempotent like the MCP tool: a second click must not write a second
     // audit entry for a no-op (audit 2026-07-29, REST/MCP drift).
-    if (!region.pendingReview) return res.json({ region, already: true });
-    region.pendingReview = false;
+    if (region.reviewedAt) return res.json({ region, already: true });
+    // Stamp the review. createdByUser is NEVER cleared: it records where the
+    // document came from, which stays true however many people look at it.
+    region.reviewedAt = new Date();
+    region.reviewedBy = req.user.id;
     await region.save();
     logAudit(req, 'admin.taxonomy.approveRegion',
       { type: 'region', id: region._id },
@@ -793,7 +798,7 @@ router.post('/regions/:id/approve', async (req, res) => {
   }
 });
 
-// POST /api/admin/taxonomy/grapes/:id/approve — clear the pendingReview flag
+// POST /api/admin/taxonomy/grapes/:id/approve — record that a human looked
 // a user-write mint set (somm ticket 6a942a60: bottle-add/import minted
 // "Honey" and "Alvarão" straight into the shared taxonomy). Mirrors the
 // regions verb above: approval is its own verb, not a PUT side effect —
@@ -807,8 +812,9 @@ router.post('/grapes/:id/approve', async (req, res) => {
     if (!grape) return res.status(404).json({ error: 'Grape not found' });
     // Idempotent like the regions verb: a second click must not write a
     // second audit entry for a no-op.
-    if (!grape.pendingReview) return res.json({ grape, already: true });
-    grape.pendingReview = false;
+    if (grape.reviewedAt) return res.json({ grape, already: true });
+    grape.reviewedAt = new Date();
+    grape.reviewedBy = req.user.id;
     await grape.save();
     logAudit(req, 'admin.taxonomy.approveGrape',
       { type: 'grape', id: grape._id },
@@ -847,7 +853,7 @@ router.get('/regions/duplicate-candidates', async (req, res) => {
     // namesake). The guard fails CLOSED: a region whose country cannot be
     // resolved is skipped and counted, never grouped with strangers.
     const [regions, countries] = await Promise.all([
-      Region.find({}).select('name country pendingReview synonyms').lean(),
+      Region.find({}).select('name country createdByUser reviewedAt synonyms').lean(),
       Country.find({}).select('name').lean(),
     ]);
     const countryNames = new Map(countries.map((c) => [String(c._id), c.name]));
@@ -886,11 +892,12 @@ router.get('/regions/duplicate-candidates', async (req, res) => {
           name: m.name,
           country: m.countryName || null,
           wineCount: counts.get(String(m._id)) || 0,
-          pendingReview: !!m.pendingReview,
+          createdByUser: !!m.createdByUser,
+          reviewedAt: m.reviewedAt || null,
           synonyms: m.synonyms || [],
         }))
         .sort((a, b) => b.wineCount - a.wineCount
-          || (a.pendingReview === b.pendingReview ? 0 : a.pendingReview ? 1 : -1));
+          || (!!a.reviewedAt === !!b.reviewedAt ? 0 : a.reviewedAt ? -1 : 1));
       return {
         signature: c.signature,
         country: members[0]?.country || null,

--- a/backend/src/routes/admin/taxonomy.needsReview.test.js
+++ b/backend/src/routes/admin/taxonomy.needsReview.test.js
@@ -78,9 +78,9 @@ beforeEach(() => {
 describe('regions', () => {
   beforeEach(() => {
     mockRegionFind.mockReturnValue(chain([
-      { _id: 'used', name: 'Barolo', pendingReview: true },
-      { _id: 'unused', name: 'Wine of Hungary', pendingReview: true },
-      { _id: 'curated', name: 'Bordeaux', pendingReview: false },
+      { _id: 'used', name: 'Barolo', createdByUser: true, reviewedAt: null },
+      { _id: 'unused', name: 'Wine of Hungary', createdByUser: true, reviewedAt: null },
+      { _id: 'curated', name: 'Bordeaux', createdByUser: false, reviewedAt: null },
     ]));
     // wineCountsByRef groups over ALL regions.
     mockWineAggregate.mockResolvedValue([{ _id: 'used', n: 21 }, { _id: 'curated', n: 300 }]);
@@ -101,22 +101,32 @@ describe('regions', () => {
     expect(regions.find((r) => r._id === 'curated').needsReview).toBe(false);
   });
 
+  test('a row already reviewed never returns to the queue, even unused', async () => {
+    mockRegionFind.mockReturnValue(chain([
+      { _id: 'seen', name: 'Dunham', createdByUser: true, reviewedAt: new Date('2026-08-31') },
+    ]));
+    mockWineAggregate.mockResolvedValue([]);
+    const body = await get('regions');
+    expect(body.regions[0].needsReview).toBe(false);
+    expect(body.needsReviewCount).toBe(0);
+  });
+
   test('the response counts them, so the screen need not be scrolled', async () => {
     expect((await get('regions')).needsReviewCount).toBe(1);
   });
 
-  test('pendingReview is still reported on every row — provenance is not erased', async () => {
+  test('createdByUser is still reported on every row — provenance is not erased', async () => {
     const { regions } = await get('regions');
-    expect(regions.find((r) => r._id === 'used').pendingReview).toBe(true);
-    expect(regions.find((r) => r._id === 'unused').pendingReview).toBe(true);
+    expect(regions.find((r) => r._id === 'used').createdByUser).toBe(true);
+    expect(regions.find((r) => r._id === 'unused').createdByUser).toBe(true);
   });
 });
 
 describe('grapes get the identical rule', () => {
   test('an unused user-minted grape needs review; a used one does not', async () => {
     mockGrapeFind.mockReturnValue(chain([
-      { _id: 'g1', name: 'Malvoisie', pendingReview: true },
-      { _id: 'g2', name: 'Nonsensegrape', pendingReview: true },
+      { _id: 'g1', name: 'Malvoisie', createdByUser: true, reviewedAt: null },
+      { _id: 'g2', name: 'Nonsensegrape', createdByUser: true, reviewedAt: null },
     ]));
     mockWineAggregate.mockResolvedValue([{ _id: 'g1', n: 4 }]);
     const body = await get('grapes');

--- a/backend/src/routes/admin/taxonomy.regionDuplicates.test.js
+++ b/backend/src/routes/admin/taxonomy.regionDuplicates.test.js
@@ -77,10 +77,10 @@ beforeEach(() => {
 describe('the Loire cluster', () => {
   beforeEach(() => {
     mockRegionFind.mockReturnValue(chain([
-      { _id: 'r1', name: 'Loire Valley', country: FR, pendingReview: false, synonyms: [] },
-      { _id: 'r2', name: 'Vallée de la Loire', country: FR, pendingReview: true, synonyms: [] },
-      { _id: 'r3', name: 'Val de Loire', country: FR, pendingReview: true, synonyms: [] },
-      { _id: 'r4', name: 'Barolo', country: IT, pendingReview: false, synonyms: [] },
+      { _id: 'r1', name: 'Loire Valley', country: FR, createdByUser: false, synonyms: [] },
+      { _id: 'r2', name: 'Vallée de la Loire', country: FR, createdByUser: true, synonyms: [] },
+      { _id: 'r3', name: 'Val de Loire', country: FR, createdByUser: true, synonyms: [] },
+      { _id: 'r4', name: 'Barolo', country: IT, createdByUser: false, synonyms: [] },
     ]));
     mockWineAggregate.mockResolvedValue([
       { _id: 'r1', n: 173 }, { _id: 'r2', n: 32 }, { _id: 'r3', n: 1 },

--- a/backend/src/scripts/migrate-taxonomy-provenance.js
+++ b/backend/src/scripts/migrate-taxonomy-provenance.js
@@ -1,0 +1,44 @@
+/**
+ * Carry `pendingReview` across to the two fields that replaced it (2026-08-31).
+ *
+ * The old boolean conflated two facts: that a user write minted the document,
+ * and that nobody had reviewed it. Every row still carrying `pendingReview:
+ * true` means BOTH — so it becomes `createdByUser: true` with `reviewedAt`
+ * left null. Rows where an admin had already approved (pendingReview false or
+ * absent) carry no origin information at all: the old approve DELETED it. That
+ * is unrecoverable, so those rows are left with createdByUser absent rather
+ * than guessed either way — absent means "not recorded", which is true.
+ *
+ *   node src/scripts/migrate-taxonomy-provenance.js            # dry run
+ *   node src/scripts/migrate-taxonomy-provenance.js --apply
+ */
+const mongoose = require('mongoose');
+const Region = require('../models/Region');
+const Grape = require('../models/Grape');
+
+const APPLY = process.argv.includes('--apply');
+
+async function main() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  for (const [label, Model] of [['regions', Region], ['grapes', Grape]]) {
+    const coll = Model.collection;
+    const toMigrate = await coll.countDocuments({ pendingReview: true });
+    const alreadyDone = await coll.countDocuments({ createdByUser: true });
+    console.log(`${label}: pendingReview=true -> ${toMigrate}   already createdByUser=true -> ${alreadyDone}`);
+    if (!APPLY) continue;
+    const set = await coll.updateMany(
+      { pendingReview: true },
+      { $set: { createdByUser: true, reviewedAt: null, reviewedBy: null } }
+    );
+    // Drop the retired field everywhere, including the approved rows whose
+    // origin the old verb had already erased.
+    const unset = await coll.updateMany({ pendingReview: { $exists: true } }, { $unset: { pendingReview: '' } });
+    console.log(`  set createdByUser on ${set.modifiedCount}; removed pendingReview from ${unset.modifiedCount}`);
+    console.log(`  now: createdByUser=true -> ${await coll.countDocuments({ createdByUser: true })}, ` +
+      `stale pendingReview -> ${await coll.countDocuments({ pendingReview: { $exists: true } })}`);
+  }
+  if (!APPLY) console.log('=== DRY RUN ===');
+  await mongoose.disconnect();
+}
+
+main().catch((e) => { console.error('FAILED: ' + e.message); process.exit(1); });

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -116,9 +116,10 @@ async function findOrCreateRegion(rawName, countryId, userId) {
   // one state that collides with a country name; an existing doc still
   // matches above.)
   if (String(name).includes(',') || isRecognizedCountry(name)) return null;
-  // pendingReview: a user write minted taxonomy — visible to admins (R3),
-  // never blocking the user.
-  region = new Region({ name: name.trim(), normalizedName, country: countryId, createdBy: userId, pendingReview: true });
+  // createdByUser records WHERE this came from: a permanent fact, visible to
+  // admins (R3) and never blocking the user. Whether a human has reviewed it
+  // is a separate field — see models/Region.
+  region = new Region({ name: name.trim(), normalizedName, country: countryId, createdBy: userId, createdByUser: true });
   await region.save();
   return region;
 }
@@ -207,13 +208,13 @@ async function findOrCreateGrapes(rawNames, userId) {
       $or: [{ normalizedName }, { normalizedSynonyms: normalizedName }],
     });
     if (!grape) {
-      // pendingReview: a user write minted taxonomy — visible to admins,
+      // createdByUser records WHERE this came from: a permanent fact, visible to admins,
       // never blocking the user. Same rule as findOrCreateRegion above.
       // Unflagged mints put "Honey" (a mead) and "Alvarão" (a typo of
       // Alvarinho the synonym lookup couldn't bridge) into the globally
       // shared taxonomy (somm ticket 6a942a60); the curator queue is where
       // a near-miss gets merged instead of silently substituted.
-      grape = new Grape({ name: canonicalName, normalizedName, createdBy: userId, pendingReview: true });
+      grape = new Grape({ name: canonicalName, normalizedName, createdBy: userId, createdByUser: true });
       await grape.save();
     }
     if (!ids.some(id => String(id) === String(grape._id))) ids.push(grape._id); // two synonyms may resolve to one doc

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -1066,9 +1066,9 @@ describe('taxonomy find-or-create dedup', () => {
       normalizedName: 'rhone',
       country: 'country-1',
       createdBy: USER_ID,
-      // R3: a user-write mint is born flagged for admin review — visible,
-      // never blocking.
-      pendingReview: true,
+      // R3: a user-write mint RECORDS ITS ORIGIN — visible, never blocking.
+      // Whether anyone has reviewed it is a separate field (reviewedAt).
+      createdByUser: true,
     });
     expect(created.save).toHaveBeenCalled();
 
@@ -1090,10 +1090,11 @@ describe('taxonomy find-or-create dedup', () => {
     expect(Grape).toHaveBeenCalledTimes(1);
     expect(Grape).toHaveBeenCalledWith({
       name: 'Syrah', normalizedName: 'syrah', createdBy: USER_ID,
+      createdByUser: true,
       // Somm ticket 6a942a60 ("Honey", "Alvarão"): a user-write grape mint is
       // born flagged for admin review — visible, never blocking. Same R3 rule
       // as the region mint above.
-      pendingReview: true,
+      createdByUser: true,
     });
     expect(ids).toEqual(['grape-new']);
   });

--- a/backend/src/services/taxonomyReview.js
+++ b/backend/src/services/taxonomyReview.js
@@ -61,7 +61,7 @@ async function appellationRefsError(countryId, regionId) {
  */
 async function listPendingRegions() {
   const [regions, counts] = await Promise.all([
-    Region.find({ pendingReview: true })
+    Region.find({ createdByUser: true, reviewedAt: null })
       .populate('country', 'name')
       .sort({ createdAt: -1 })
       .lean(),

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -161,11 +161,11 @@ export const adminRestoreDismissedAppellation = (apiFetch, name) =>
     method: 'POST', headers: J, body: JSON.stringify({ name }),
   });
 
-/** Approve a user-minted region (clears its pendingReview flag). */
+/** Record that an admin reviewed a user-minted region (stamps reviewedAt). */
 export const adminApproveRegion = (apiFetch, regionId) =>
   apiFetch(`/api/admin/taxonomy/regions/${regionId}/approve`, { method: 'POST' });
 
-/** Approve a user-minted grape (clears its pendingReview flag). */
+/** Record that an admin reviewed a user-minted grape (stamps reviewedAt). */
 export const adminApproveGrape = (apiFetch, grapeId) =>
   apiFetch(`/api/admin/taxonomy/grapes/${grapeId}/approve`, { method: 'POST' });
 

--- a/frontend/src/pages/AdminTaxonomy.js
+++ b/frontend/src/pages/AdminTaxonomy.js
@@ -19,7 +19,7 @@ function AdminTaxonomy() {
   const [activeTab, setActiveTab] = useState('countries');
   const [items, setItems] = useState([]);
   // How many rows actually want a decision — user-minted AND used by nothing.
-  // Every user-minted row still carries `pendingReview` as provenance; only
+  // Every user-minted row still carries `createdByUser` as provenance; only
   // this subset is worth drawing the eye to (see needsHumanReview server-side).
   const [needsReviewCount, setNeedsReviewCount] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -272,7 +272,7 @@ function AdminTaxonomy() {
           String(i.country?._id || i.country) === String(mergeItem.country?._id || mergeItem.country)))
     : [];
 
-  // Regions and grapes share the pendingReview flow; the endpoint differs.
+  // Regions and grapes share the review flow; the endpoint differs.
   const handleApprove = async (id) => {
     setError(null);
     try {


### PR DESCRIPTION
One boolean recorded two different facts, and its name promised a third.

`pendingReview` was set on every region and grape a user write minted, and cleared only by an admin clicking approve. So it *meant* "a user made this" while *reading as* "someone owes this a decision".

**That mismatch cost a month.** The screen showed 164 rows as a to-do list, of which 161 were in ordinary use and one was junk. Nobody can read a list at that signal-to-noise, so nobody did — and the real defect inside it, one region split across four documents holding 208 wines, went unnoticed. Being flagged never revealed it, because all four were flagged *individually*.

### Two fields, the shape the wine registry already used

| Field | Meaning |
|---|---|
| `createdByUser` | where the document came from. **Permanent, never cleared.** |
| `reviewedAt` / `reviewedBy` | when a human actually looked, and who |

That mirrors `createdVia` + `profileReviewedAt` on `WineDefinition`.

**Approving now stamps the review instead of erasing the origin** — which the old verb did, irreversibly. The four grapes approved earlier today had already lost the only record that users created them; I restored those six documents by hand, because I'd directly observed their state beforehand.

`needsHumanReview` becomes *created by a user AND never reviewed AND unused*, so a reviewed row can't return to the queue and a document already carrying wines never enters it.

### Migration

`src/scripts/migrate-taxonomy-provenance.js` carries `pendingReview: true` across to `createdByUser: true` with `reviewedAt: null`, and drops the retired field. Rows the old verb had already approved carry **no origin information at all** — that's unrecoverable, so they're left unset rather than guessed, because absent honestly means "not recorded".

Already run on production: **142 regions migrated**, the retired field removed from 247 documents, zero stale.

Tests: **252 passed** across taxonomy routes, findOrCreateWine and the MCP registry tools. Assertions were rewritten rather than renamed — a blind rename had made one test assert that approving *clears* the provenance, which is the exact behaviour this removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)