### PR TITLE
chore(release): v1.192.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.191.0",
+  "version": "1.192.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.191.0",
+      "version": "1.192.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.191.0",
+  "version": "1.192.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.191.0",
+  "version": "1.192.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.191.0",
+      "version": "1.192.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.191.0",
+  "version": "1.192.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for the v1.192.0 release.

- #1168 — region duplicate scan (found the Loire split across four documents)
- #1169 — the taxonomy review queue shows what wants a decision
- #1170 — iOS safe-area padding survives the mobile query (#1145), deep links finish where they were going (#1165)
- #1171 — pendingReview split into createdByUser + reviewedAt (migration already run on prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)