### PR TITLE
fix(import): keep the German Prädikat out of the appellation

### DIFF
--- a/backend/src/routes/import.buildProposedWine.test.js
+++ b/backend/src/routes/import.buildProposedWine.test.js
@@ -21,7 +21,7 @@ jest.mock('../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn(), 
 jest.mock('../middleware/aiBurstLimiter', () => (req, res, next) => next());
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
 
-const { buildProposedWine, summariseReasons } = require('./import');
+const { buildProposedWine, summariseReasons, fileCompleteIdentity } = require('./import');
 
 // Below AI_GEOGRAPHY_MIN_CONFIDENCE (0.6) the model is inferring, not knowing.
 const SURE = 0.8;
@@ -168,5 +168,130 @@ describe('type: the file states, the model recalls (2026-08-22)', () => {
 
   it('leaves type null when neither the file nor the model states one', () => {
     expect(buildProposedWine(ai({ type: null }), { type: null }).type).toBeNull();
+  });
+});
+
+// ── Prädikat in the appellation column (somm ticket 6a966386, 2026-09-01) ────
+//
+// Both rows below are verbatim from the import archive that produced the
+// ticket. The owner put the ripeness Prädikat in his appellation column, and
+// the same file misspelled the wine's own name ("Riesling Troken") — which is
+// how we know the typo is his and not ours. Taken literally, those wines end
+// up with no appellation at all: the thin-identity condition that makes
+// auto-enrichment decline them permanently.
+describe('a Prädikat in the appellation column moves to classification', () => {
+  const molitor = {
+    wineName: 'Riesling Auslese Bernkasteler Badstube', producer: 'Markus Molitor',
+    country: 'Allemagne', region: 'Moselle', appellation: 'Auslese',
+  };
+
+  test("the file's Prädikat becomes the classification, and the model supplies the place", () => {
+    const out = buildProposedWine(ai({ appellation: 'Mosel', classification: null }), molitor);
+    expect(out.classification).toBe('Auslese');
+    expect(out.appellation).toBe('Mosel');
+  });
+
+  test('a Prädikat the wine CONTRADICTS is dropped, not moved to another field', () => {
+    // The second ticket record. Its file said "Trokenbeerenauslese" on a wine
+    // the model minted as "Riesling Trocken" — the sweetest botrytis category
+    // German law defines, on a bone-dry wine. Rescuing it would keep the
+    // falsehood and change only which field carried it, and a classification
+    // reads as curated fact: it would have argued for a decades-long dessert
+    // window on an estate dry Riesling. An honest gap is what asks to be filled.
+    //
+    // This is independently the judgement the sommelier reached on these two
+    // records (proposals 6a965b19 / 6a965b0e, 2026-09-01): Auslese kept as a
+    // classification, Trockenbeerenauslese dropped, appellation Nahe.
+    const donnhoff = { wineName: 'Riesling Troken', producer: 'Dönnhoff', country: 'Allemagne', appellation: 'Trokenbeerenauslese' };
+    const out = buildProposedWine(ai({ name: 'Riesling Trocken', appellation: 'Nahe', classification: null }), donnhoff);
+    expect(out.appellation).toBe('Nahe');
+    expect(out.classification).toBeFalsy();
+  });
+
+  test('the contradiction drops the value — it does not leave it in the appellation', () => {
+    // Belt and braces on the above: a ripeness level is not a place whether or
+    // not it is true of this wine, so it leaves the field either way.
+    const donnhoff = { wineName: 'Riesling Troken', producer: 'Dönnhoff', country: 'Allemagne', appellation: 'Trokenbeerenauslese' };
+    const out = buildProposedWine(ai({ name: 'Riesling Trocken', appellation: null, classification: null }), donnhoff);
+    expect(out.appellation).toBeFalsy();
+    expect(out.classification).toBeFalsy();
+  });
+
+  test('a dry Spätlese still keeps its Prädikat — that tier can legally be dry', () => {
+    // The rescue must not over-fire. "Spätlese Trocken" is one of the most
+    // common label pairs in Germany; refusing it would throw the value away on
+    // exactly the wines this exists for.
+    const row = { wineName: 'Riesling Spätlese Trocken', producer: 'Dönnhoff', appellation: 'Spätlese' };
+    const out = buildProposedWine(ai({ name: 'Riesling Spätlese Trocken', appellation: 'Nahe', classification: null }), row);
+    expect(out.classification).toBe('Spätlese');
+    expect(out.appellation).toBe('Nahe');
+  });
+
+  test('a real appellation is untouched — the file still outranks the model', () => {
+    const row = { ...molitor, appellation: 'Bernkasteler Badstube' };
+    const out = buildProposedWine(ai({ appellation: 'Mosel' }), row);
+    expect(out.appellation).toBe('Bernkasteler Badstube');
+  });
+
+  test("a classification the file states of its own wins — the rescue never overwrites it", () => {
+    const row = { ...molitor, classification: 'Prädikatswein' };
+    const out = buildProposedWine(ai({ appellation: 'Mosel', classification: 'VDP' }), row);
+    expect(out.classification).toBe('Prädikatswein');
+    expect(out.appellation).toBe('Mosel');
+  });
+
+  test('with no model appellation either, the field is empty rather than wrong', () => {
+    // Honest emptiness beats a ripeness level masquerading as a place: the
+    // curator sees a gap, which is the state that asks to be filled.
+    const out = buildProposedWine(ai({ appellation: null, classification: null }), molitor);
+    expect(out.appellation).toBeFalsy();
+    expect(out.classification).toBe('Auslese');
+  });
+});
+
+/**
+ * The complete-row AI bypass is the OTHER way a wine enters the registry, and
+ * it had the same defect. It writes the file's columns with no model involved,
+ * so a German row that happens to carry a type column would have stored the
+ * Prädikat as the appellation with nothing to catch it.
+ *
+ * The two ticket rows did not take this path (neither file row had a type), but
+ * the next German import with a type column would have.
+ */
+describe('the complete-row bypass routes the Prädikat the same way', () => {
+  const colourOf = (g) => (/riesling/i.test(g) ? 'White' : null);
+  const row = (over = {}) => ({
+    wineName: 'Riesling Auslese Bernkasteler Badstube', producer: 'Markus Molitor',
+    country: 'Germany', region: 'Mosel', appellation: 'Auslese', type: 'white', ...over,
+  });
+
+  test('the Prädikat becomes the classification and the appellation is left empty', () => {
+    // Empty rather than wrong. There is no model on this path to supply the
+    // place, and enrichment's place axis is satisfied by the region — whereas
+    // a ripeness level in the appellation would key the wine differently from
+    // the same bottle arriving with a proper appellation, and mint a twin.
+    const out = fileCompleteIdentity(row(), colourOf);
+    expect(out.appellation).toBeNull();
+    expect(out.classification).toBe('Auslese');
+  });
+
+  test('a contradicted Prädikat is dropped here too — the paths agree', () => {
+    const out = fileCompleteIdentity(
+      row({ wineName: 'Riesling Trocken', appellation: 'Trokenbeerenauslese' }), colourOf,
+    );
+    expect(out.appellation).toBeNull();
+    expect(out.classification).toBeNull();
+  });
+
+  test('a real appellation is untouched', () => {
+    const out = fileCompleteIdentity(row({ appellation: 'Bernkasteler Badstube' }), colourOf);
+    expect(out.appellation).toBe('Bernkasteler Badstube');
+    expect(out.classification).toBeNull();
+  });
+
+  test("the file's own classification still wins over the rescued Prädikat", () => {
+    const out = fileCompleteIdentity(row({ classification: 'VDP Grosse Lage' }), colourOf);
+    expect(out.classification).toBe('VDP Grosse Lage');
+    expect(out.appellation).toBeNull();
   });
 });

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -19,7 +19,7 @@ const { identifyWineFromText } = require('../services/labelScan');
 const aiProvider = require('../services/aiProvider');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
 const { scoreWineMatchVariants, stripProducerPrefix } = require('../services/wineMatching');
-const { conflictingStyleTerms } = require('../utils/styleTerms');
+const { conflictingStyleTerms, pradikatOnlyValue, pradikatContradictsName } = require('../utils/styleTerms');
 const { wineVisibilityFilter } = require('../services/wineVisibility');
 const { tryDebitAi, isRefundableFailure } = require('../services/aiBudget');
 const rateLimitsConfig = require('../config/rateLimits');
@@ -132,6 +132,16 @@ function buildProposedWine(aiData, item) {
     !(typeof aiData.confidence === 'number' && aiData.confidence >= AI_GEOGRAPHY_MIN_CONFIDENCE);
   const fromAi = (v) => (lowGeoConfidence ? null : clean(v));
 
+  // A purely-Prädikat appellation is routed out of the field entirely; only a
+  // Prädikat the wine itself does not contradict is rescued into the
+  // classification. See pradikatContradictsName: the second ticket record put
+  // Trockenbeerenauslese on a wine named "Riesling Trocken", and rescuing that
+  // would have kept the falsehood and merely moved which field carried it.
+  const filePradikat = pradikatOnlyValue(clean(item && item.appellation));
+  const rescuedPradikat = filePradikat && !pradikatContradictsName(filePradikat, aiData.name)
+    ? filePradikat
+    : null;
+
   return {
     name: aiData.name,
     producer: aiData.producer,
@@ -141,11 +151,30 @@ function buildProposedWine(aiData, item) {
     // a countryless identification used to cost the user the row entirely.
     country: clean(aiData.country) || clean(item && item.country),
     region: clean(item && item.region) || fromAi(aiData.region),
-    appellation: clean(item && item.appellation) || fromAi(aiData.appellation),
+    // A file's appellation column sometimes holds the ripeness Prädikat rather
+    // than a place — "Auslese" for a Mosel Riesling, "Trokenbeerenauslese" for
+    // a Nahe one (somm ticket 6a966386). Taken literally the wine ends up with
+    // NO appellation, which is the thin-identity condition that makes
+    // auto-enrichment decline it for good: the owner's data-entry habit
+    // silently costs him his tasting notes. So a purely-Prädikat value is not
+    // treated as geography, and the model's place name fills the field instead
+    // — for the Nahe wine that is the same source its region already came from.
+    // pradikatOnlyValue refuses anything that might also name a place.
+    appellation: filePradikat
+      ? fromAi(aiData.appellation)
+      : (clean(item && item.appellation) || fromAi(aiData.appellation)),
     // Same floor as geography: a classification is an assertion of knowledge
     // (ticket 6a83f014 added the field to the identify prompt), and the file's
     // own value outranks it for the same reason.
-    classification: clean(item && item.classification) || fromAi(aiData.classification),
+    //
+    // A Prädikat rescued from the appellation column lands HERE, where it was
+    // always meant to go, and outranks the model for the same reason any other
+    // file value does — the owner read it off the bottle. Only when the file
+    // states no classification of its own, which is the case that produced the
+    // ticket.
+    classification: clean(item && item.classification)
+      || rescuedPradikat
+      || fromAi(aiData.classification),
     // Same precedence as the geography above: the file states what the label
     // says, the model recalls. Only ever a value the schema accepts — a
     // client can send anything, and an invalid colour must fall through to
@@ -187,14 +216,19 @@ function computeIdentityProvenance(item, ai) {
   const aiGrapes = Array.isArray(ai?.grapes) ? ai.grapes : [];
   const grapesFromFile = fileGrapes.length > 0 && aiGrapes.length > 0
     && aiGrapes.every((g) => fileGrapes.some((f) => normalizeString(f) === normalizeString(g)));
+  const filePrad = pradikatOnlyValue(stated(item?.appellation) ? item.appellation.trim() : '');
+  const rescuedPrad = filePrad && !pradikatContradictsName(filePrad, ai?.name) ? filePrad : null;
 
   return {
     name: 'model',
     producer: 'model',
     country: stated(item?.country) && !stated(ai?.country) ? 'file' : 'model',
     region: stated(item?.region) ? 'file' : 'model',
-    appellation: stated(item?.appellation) ? 'file' : 'model',
-    classification: stated(item?.classification) ? 'file' : 'model',
+    // Follows the VALUE, not the column it was typed in: a rescued Prädikat
+    // leaves the appellation to the model and supplies the classification
+    // itself, and provenance is what the sommelier reasons from.
+    appellation: stated(item?.appellation) && !filePrad ? 'file' : 'model',
+    classification: stated(item?.classification) || rescuedPrad ? 'file' : 'model',
     type: fileType ? 'file' : 'model',
     grapes: grapesFromFile ? 'file' : 'model',
   };
@@ -334,13 +368,26 @@ function fileCompleteIdentity(item, grapeColourOf) {
   if (!type && grapes.length > 0) type = typeFromFileGrapes(grapes, grapeColourOf);
   if (!type) return null;
 
+  // Same Prädikat routing as the AI path (somm ticket 6a966386) — this path
+  // has no model to supply the place, so the appellation is simply left empty
+  // rather than filled with a ripeness level. Empty is the honest state and
+  // costs nothing here: enrichment's identityDataSufficient needs a place
+  // axis, and the region satisfies it. Storing the Prädikat instead would
+  // cost something real, because generateWineKey and the match scorer both
+  // read the appellation — the same wine arriving from another owner's file
+  // with a proper appellation would key differently and mint a duplicate.
+  const filePradikat = pradikatOnlyValue(clean(item.appellation));
+  const rescuedPradikat = filePradikat && !pradikatContradictsName(filePradikat, name)
+    ? filePradikat
+    : null;
+
   return {
     name,
     producer,
     country,
     region: clean(item.region),
-    appellation: clean(item.appellation),
-    classification: clean(item.classification),
+    appellation: filePradikat ? null : clean(item.appellation),
+    classification: clean(item.classification) || rescuedPradikat,
     type,
     grapes,
     confidence: null,
@@ -2110,3 +2157,7 @@ module.exports.summariseReasons = summariseReasons;
 // Exported for tests: the provenance rules must be pinnable without standing
 // up a full import (somm ticket 6a958dbc).
 module.exports.computeIdentityProvenance = computeIdentityProvenance;
+// Exported for the same reason as buildProposedWine: it is the OTHER rule that
+// decides what enters the shared registry, and the two must agree about a
+// Prädikat in the appellation column (somm ticket 6a966386).
+module.exports.fileCompleteIdentity = fileCompleteIdentity;

--- a/backend/src/routes/import.provenance.test.js
+++ b/backend/src/routes/import.provenance.test.js
@@ -144,3 +144,49 @@ describe('robustness', () => {
     expect(p.appellation).toBe('model');
   });
 });
+
+/**
+ * Provenance follows the VALUE, not the column it was typed in.
+ *
+ * When a Prädikat is routed out of the appellation column (somm ticket
+ * 6a966386), the appellation the wine ends up with came from the model even
+ * though the file's column was filled — and the classification came from the
+ * file even though its column was empty. Reporting the columns would tell the
+ * curator the exact opposite of the truth on both fields, which matters
+ * because provenance is what they reason from when deciding whom to believe.
+ */
+describe('a Prädikat routed out of the appellation column', () => {
+  const molitorRow = () => ({
+    wineName: 'Riesling Auslese Bernkasteler Badstube', producer: 'Markus Molitor',
+    country: 'Allemagne', region: 'Moselle', appellation: 'Auslese',
+  });
+  const molitorAi = (over = {}) => ({
+    name: 'Riesling Auslese Bernkasteler Badstube', producer: 'Markus Molitor',
+    country: 'Germany', region: 'Mosel', appellation: 'Mosel', classification: null,
+    type: 'white', grapes: ['Riesling'], ...over,
+  });
+
+  test(`the appellation is the MODEL's, even though the file's column was filled`, () => {
+    expect(computeIdentityProvenance(molitorRow(), molitorAi()).appellation).toBe('model');
+  });
+
+  test("the classification is the FILE's, even though the file's column was empty", () => {
+    expect(computeIdentityProvenance(molitorRow(), molitorAi()).classification).toBe('file');
+  });
+
+  test(`a contradicted Prädikat is nobody's classification but the model's`, () => {
+    // Dropped rather than rescued (see buildProposedWine), so the file did not
+    // supply the value that survived — claiming it did would credit the owner
+    // with a statement we deliberately threw away.
+    const row = { wineName: 'Riesling Troken', producer: 'Dönnhoff', country: 'Allemagne', appellation: 'Trokenbeerenauslese' };
+    const p = computeIdentityProvenance(row, molitorAi({ name: 'Riesling Trocken', appellation: 'Nahe' }));
+    expect(p.classification).toBe('model');
+    expect(p.appellation).toBe('model');
+  });
+
+  test(`an ordinary appellation is still the file's`, () => {
+    const p = computeIdentityProvenance(molitorRow({}), molitorAi());
+    expect(p.region).toBe('file');
+    expect(computeIdentityProvenance({ ...molitorRow(), appellation: 'Bernkasteler Badstube' }, molitorAi()).appellation).toBe('file');
+  });
+});

--- a/backend/src/utils/styleTerms.js
+++ b/backend/src/utils/styleTerms.js
@@ -77,6 +77,14 @@ const PRADIKAT_WORDS = new Set([
 const PRADIKAT_ALIASES = new Map([
   ['spaetlese', 'spatlese'],
   ['icewine', 'eiswein'],
+  // An OBSERVED misspelling, not a guess: one owner's export carried
+  // "Trokenbeerenauslese" (one c, one s) in its appellation column, and the
+  // same file misspelled the wine's own name "Riesling Troken" — which is how
+  // we know the typo is the writer's rather than ours (somm ticket 6a966386,
+  // 2026-09-01). Added because it was seen in real data. This map is not a
+  // general typo-tolerance scheme and should not grow into one: every entry
+  // needs a file behind it.
+  ['trokenbeerenauslese', 'trockenbeerenauslese'],
 ]);
 
 // The sweetness twin of PRADIKAT_ALIASES, for the same keyboard: "Süß" typed
@@ -89,6 +97,10 @@ const PRADIKAT_ALIASES = new Map([
 // the 'dry'/'sweet' problem over again.
 const SWEETNESS_ALIASES = new Map([
   ['suess', 'suss'],
+  // Same file as the Prädikat typo above: it wrote the wine's own name
+  // "Riesling Troken". Name side only, like every entry here — SWEETNESS_WORDS
+  // itself must not gain it, for the 'Weingut Suess' reason given above.
+  ['troken', 'trocken'],
 ]);
 
 // Style words that are also ordinary name words. "Dry Creek Zinfandel" states
@@ -136,6 +148,85 @@ function statedStyle(name) {
   return { pradikat, sweetness };
 }
 
+/**
+ * Is this appellation value a ripeness Prädikat rather than a place?
+ *
+ * Some cellar exports put the Prädikat in the appellation column — one file
+ * carried "Auslese" for a Mosel Riesling and "Trokenbeerenauslese" for a Nahe
+ * one (somm ticket 6a966386). Stored as written, those wines end up with NO
+ * appellation at all, which is exactly the thin-identity condition that makes
+ * auto-enrichment decline them permanently: a data-entry habit quietly costs
+ * the owner his tasting notes. One of the two was worse than useless — a wine
+ * named "Riesling Trocken" (bone dry) whose appellation claimed the sweetest
+ * botrytis category German law defines, which curated at face value would have
+ * produced a 35-year dessert-wine window on a dry estate Riesling.
+ *
+ * DELIBERATELY STRICT. Only a value whose every meaningful token is a Prädikat
+ * qualifies, so "Auslese" is routed and "Auslese Goldkapsel" is not: the
+ * second carries a token this vocabulary cannot vouch for, and moving a value
+ * that might name a place would trade one wrong field for another. Refusing
+ * the uncertain case is the point — a place is never a Prädikat, but a string
+ * containing one is not necessarily free of a place.
+ *
+ * @param {string} value the appellation as written
+ * @returns {string|null} the value trimmed, when it is purely a Prädikat
+ */
+function pradikatOnlyValue(value) {
+  const raw = String(value == null ? '' : value).trim();
+  if (!raw) return null;
+  const folded = normalizeString(raw.toLowerCase().replace(/ß/g, 'ss'));
+  const tokens = folded.split(/[^a-z0-9]+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+  const everyTokenIsPradikat = tokens.every((t) => PRADIKAT_WORDS.has(PRADIKAT_ALIASES.get(t) || t));
+  return everyTokenIsPradikat ? raw : null;
+}
+
+// Prädikat tiers that are sweet BY LAW — botrytis or frost concentrate the
+// must so far that no dry version can exist. Kabinett, Spätlese and Auslese are
+// deliberately ABSENT: all three are routinely bottled trocken, and "Spätlese
+// Trocken" is one of the most common label pairs in Germany.
+const ALWAYS_SWEET_PRADIKAT = new Set([
+  'beerenauslese', 'trockenbeerenauslese', 'eiswein',
+  'ausbruch', 'strohwein', 'schilfwein',
+]);
+
+// Unambiguously dry-to-off-dry. Deliberately narrower than "not sweet": the
+// medium terms (demi-sec, abboccato, moelleux) are omitted because the point is
+// to be certain of the contradiction, not to catch every one.
+const DRY_SIDE_WORDS = new Set(['trocken', 'halbtrocken', 'feinherb', 'sec', 'seco', 'brut']);
+
+/**
+ * Does this Prädikat contradict the wine it is attached to?
+ *
+ * The second ticket record is why this exists. Its file said appellation
+ * "Trokenbeerenauslese" on a wine named "Riesling Trocken" — the sweetest
+ * botrytis category German law defines, on a bone-dry wine. Both cannot be
+ * true. Moving that value into the classification would keep the falsehood and
+ * merely change which field carries it, and a classification is read as
+ * curated fact: it would have argued for a decades-long dessert-wine window on
+ * an estate dry Riesling.
+ *
+ * So a contradicted Prädikat is DROPPED, not rescued — the appellation is still
+ * cleared of it, because a ripeness level is not a place whether or not it is
+ * true. What is left is an honest gap, which is the state that asks a curator
+ * to fill it. That is independently the judgement the sommelier reached on
+ * these two records (proposals 6a965b0e / 6a965b19, 2026-09-01): Auslese kept
+ * as a classification, Trockenbeerenauslese dropped.
+ *
+ * @param {string} pradikat a value pradikatOnlyValue has already vouched for
+ * @param {string} wineName the name the wine is being minted under
+ * @returns {string|null} human-readable reason, or null when compatible
+ */
+function pradikatContradictsName(pradikat, wineName) {
+  const tiers = statedStyle(pradikat).pradikat;
+  const sweetTier = [...tiers].find((t) => ALWAYS_SWEET_PRADIKAT.has(t));
+  if (!sweetTier) return null;
+  const dry = [...statedStyle(wineName).sweetness].filter((w) => DRY_SIDE_WORDS.has(w));
+  if (dry.length === 0) return null;
+  return `${sweetTier} is sweet by definition, but the name states ${dry.sort().join(', ')}`;
+}
+
+
 const subset = (a, b) => [...a].every((x) => b.has(x));
 
 // Both sides state something, and neither statement contains the other. A
@@ -169,4 +260,6 @@ module.exports = {
   NAME_AMBIGUOUS_WORDS,
   statedStyle,
   conflictingStyleTerms,
+  pradikatContradictsName,
+  pradikatOnlyValue,
 };

--- a/backend/src/utils/styleTerms.pradikatValue.test.js
+++ b/backend/src/utils/styleTerms.pradikatValue.test.js
@@ -1,0 +1,128 @@
+const { pradikatOnlyValue } = require('./styleTerms');
+
+/**
+ * Telling a ripeness Prädikat from a place, when it turns up in an appellation
+ * column (somm ticket 6a966386, 2026-09-01).
+ *
+ * The two real rows: a Mosel Riesling whose file said appellation "Auslese",
+ * and a Nahe one that said "Trokenbeerenauslese" — the owner's misspelling,
+ * carried verbatim, in a file that also wrote the wine's own name as "Riesling
+ * Troken". Stored as written those wines have no appellation at all, which is
+ * what makes auto-enrichment decline them permanently.
+ *
+ * The rejections carry the weight here. Moving a value that might name a place
+ * would trade one wrong field for another, and unlike the write it replaces,
+ * nothing downstream would flag it.
+ */
+
+describe('values that ARE the Prädikat', () => {
+  test.each([
+    ['Auslese', 'the Molitor row'],
+    ['Trokenbeerenauslese', "the Dönnhoff row — the owner's misspelling"],
+    ['Trockenbeerenauslese', 'spelled correctly'],
+    ['Spätlese', 'umlaut'],
+    ['Spaetlese', 'ue-transliteration of the same tier'],
+    ['Kabinett', ''],
+    ['Beerenauslese', 'nests inside Trockenbeerenauslese but is its own token'],
+    ['Eiswein', ''],
+    ['Ausbruch', 'Austrian ladder — the ticket asked about Austria'],
+    ['Strohwein', 'Austrian'],
+  ])('%s is routed out of the appellation (%s)', (value) => {
+    expect(pradikatOnlyValue(value)).toBe(value);
+  });
+
+  test('returns the value AS WRITTEN, not a canonical form — it becomes the classification a person reads', () => {
+    expect(pradikatOnlyValue('  Auslese  ')).toBe('Auslese');
+    expect(pradikatOnlyValue('AUSLESE')).toBe('AUSLESE');
+  });
+});
+
+describe('values that are, or might be, a place — left alone', () => {
+  test.each([
+    ['Nahe', 'the appellation the Dönnhoff record should have had'],
+    ['Mosel', ''],
+    ['Bernkasteler Badstube', 'a single vineyard, not a ripeness level'],
+    ['Rheingau', ''],
+    ['Wachau', 'Austrian region, near-neighbour of the Austrian tiers'],
+  ])('%s is kept (%s)', (value) => {
+    expect(pradikatOnlyValue(value)).toBeNull();
+  });
+
+  test('a value containing a Prädikat AND something else is refused', () => {
+    // "Goldkapsel" is a bottling designation this vocabulary cannot vouch for,
+    // and "Mosel Auslese" genuinely contains the place. Refusing the mixed case
+    // is the whole point: certain or nothing.
+    expect(pradikatOnlyValue('Auslese Goldkapsel')).toBeNull();
+    expect(pradikatOnlyValue('Mosel Auslese')).toBeNull();
+    expect(pradikatOnlyValue('Auslese Bernkasteler Badstube')).toBeNull();
+  });
+
+  test('a sweetness term is NOT a Prädikat — different axis of the same label', () => {
+    // Trocken is how the wine finished, not how ripe it was picked. It has no
+    // business in the appellation either, but this guard does not claim it.
+    expect(pradikatOnlyValue('Trocken')).toBeNull();
+    expect(pradikatOnlyValue('Halbtrocken')).toBeNull();
+    expect(pradikatOnlyValue('Feinherb')).toBeNull();
+  });
+});
+
+describe('degenerate input', () => {
+  test.each([[''], ['   '], [null], [undefined], ['---'], [42]])('%p yields null', (value) => {
+    expect(pradikatOnlyValue(value)).toBeNull();
+  });
+});
+
+const { pradikatContradictsName } = require('./styleTerms');
+
+/**
+ * A Prädikat can be misfiled AND untrue. The second ticket record was both:
+ * appellation "Trokenbeerenauslese" on a wine named "Riesling Trocken". Moving
+ * it to the classification would have kept the falsehood and changed only which
+ * field carried it — and a classification is read as curated fact, so it would
+ * have argued for a decades-long dessert window on a dry estate Riesling.
+ */
+describe('a Prädikat the wine itself contradicts', () => {
+  test.each([
+    ['Trokenbeerenauslese', 'Riesling Trocken', "the ticket's own record"],
+    ['Trokenbeerenauslese', 'Riesling Troken', "and with the file's spelling of the name too"],
+    ['Trockenbeerenauslese', 'Riesling Halbtrocken', 'off-dry is no closer to botrytis sugar'],
+    ['Beerenauslese', 'Riesling Feinherb', ''],
+    ['Eiswein', 'Riesling Sec', 'a French-labelled dry wine'],
+    ['Ausbruch', 'Grüner Veltliner Trocken', 'Austrian ladder, same rule'],
+  ])('%s on "%s" is refused (%s)', (pradikat, name) => {
+    expect(pradikatContradictsName(pradikat, name)).toMatch(/sweet by definition/);
+  });
+
+  test('the reason names both halves, because a curator reads it', () => {
+    expect(pradikatContradictsName('Trokenbeerenauslese', 'Riesling Trocken'))
+      .toBe('trockenbeerenauslese is sweet by definition, but the name states trocken');
+  });
+});
+
+describe('Prädikate that CAN be dry are never refused', () => {
+  // Kabinett, Spätlese and Auslese are routinely bottled trocken — "Spätlese
+  // Trocken" is one of the most common label pairs in Germany. Refusing those
+  // would throw away the value on exactly the wines the rescue exists for.
+  test.each([
+    ['Kabinett', 'Riesling Kabinett Trocken'],
+    ['Spätlese', 'Riesling Spätlese Trocken'],
+    ['Auslese', 'Riesling Auslese Trocken'],
+    ['Auslese', 'Riesling Auslese Bernkasteler Badstube'],
+    ['Trockenbeerenauslese', 'Riesling'],
+    ['Eiswein', 'Riesling Eiswein'],
+  ])('%s on "%s" is compatible', (pradikat, name) => {
+    expect(pradikatContradictsName(pradikat, name)).toBeNull();
+  });
+
+  test('a missing or nameless wine is not a contradiction — silence is not disagreement', () => {
+    expect(pradikatContradictsName('Trockenbeerenauslese', '')).toBeNull();
+    expect(pradikatContradictsName('Trockenbeerenauslese', null)).toBeNull();
+    expect(pradikatContradictsName('Trockenbeerenauslese', undefined)).toBeNull();
+  });
+
+  test('"Trocken" inside Trockenbeerenauslese does not make the tier contradict ITSELF', () => {
+    // The tier's own name starts with the dry word. Whole-token matching keeps
+    // 'trockenbeerenauslese' one token, so it never reads as stating 'trocken'.
+    expect(pradikatContradictsName('Trockenbeerenauslese', 'Riesling Trockenbeerenauslese')).toBeNull();
+  });
+});


### PR DESCRIPTION
Somm ticket `6a966386`. Two German wines from one intake arrived with the ripeness Prädikat stored as their appellation — "Auslese" on a Mosel Riesling, "Trokenbeerenauslese" on a Nahe one.

## It is not a mapping rule

The ticket suspected the importer treats any recognised Prädikat token as an appellation. It doesn't. The import archive holds both rows verbatim, and both values came from the owner's own appellation column:

```
{"wineName":"Riesling Auslese Bernkasteler Badstube","producer":"Markus Molitor","country":"Allemagne","region":"Moselle","appellation":"Auslese"}
{"wineName":"Riesling Troken","producer":"Dönnhoff","country":"Allemagne","appellation":"Trokenbeerenauslese"}
```

Note the second row's wine *name*: "Riesling Troken". The same file misspells trocken the same way twice — a model would not reproduce the writer's typo. Five rows in that file carry a Prädikat in the appellation column, and both records carry `identityProvenance.appellation: "file"`.

So the importer was doing exactly what it is meant to do: the owner's geography outranks the model's. The column simply did not hold geography.

## What it actually costs

The ticket's first claimed effect — that these wines are permanently declined by enrichment as thin-identity — is not what the code does. `identityDataSufficient()` wants a place axis (appellation **or** region) and a what axis (grapes **or** type); both records have a region and a type, so they pass.

Two costs are real:

- **Registry splitting.** `generateWineKey` and the match scorer both read the appellation. The same Molitor Auslese arriving in another owner's file with "Mosel" in that column keys differently and mints a twin.
- **Enrichment input.** The appellation is passed into the profile prompt. On the Dönnhoff record that tells the writer a bone-dry Riesling is a Trockenbeerenauslese — the ticket's dessert-window concern, arriving through the prompt rather than through window curation.

## The rule

A value whose every token is a Prädikat is no longer treated as geography. Both mint paths are covered: `buildProposedWine` lets the model's place name fill the appellation instead, and `fileCompleteIdentity` (the complete-row AI bypass, which has no model to ask) leaves it empty — which costs nothing, since the region already satisfies enrichment's place axis.

Two deliberate limits:

- **Strict.** `Auslese` is routed; `Auslese Goldkapsel` is not. A string containing a Prädikat may still contain a place, and moving it would trade one wrong field for another.
- **A Prädikat the wine contradicts is dropped, not rescued.** Beerenauslese and above are sweet by law and cannot sit on a wine whose name says trocken; moving that value into `classification` would keep the falsehood and change only which field carried it. Kabinett, Spätlese and Auslese are exempt — all three are routinely bottled dry.

That second rule independently reproduces the sommelier's own two proposals (`6a965b19`, `6a965b0e`): Auslese kept as a classification, Trockenbeerenauslese dropped, appellations Mosel and Nahe.

`computeIdentityProvenance` now follows the **value** rather than the column it was typed in — a routed Prädikat means the appellation came from the model and the classification came from the file, and reporting the columns would tell a curator the opposite of the truth on both fields.

## Blast radius, measured against production

- **2** wines registry-wide have a Prädikat as their appellation, out of 6,890 with an appellation — the two in the ticket. 5 bottles, all the same owner's. Both already carry sommelier correction proposals, so no migration is needed.
- **0** of the 996 curated appellations are purely a Prädikat, so the rule cannot misroute one. "Ruster Ausbruch" carries a non-Prädikat token and is never routed.
- A sweep for *sweetness* terms in the same field found **7 hits and 0 defects** — Arroyo Seco, Bergerac Sec, Maury Sec (×3), Gaillac Doux are all real appellations. That is why this stays on the Prädikat vocabulary alone rather than becoming a general "style word in a geography field" rule.

Austria is covered: Ausbruch, Strohwein and Schilfwein are in the vocabulary, and Ausbruch is in the always-sweet set.

## Tests

`backend/src/utils/styleTerms.pradikatValue.test.js` (new, 33 cases) plus additions to `import.buildProposedWine.test.js` and `import.provenance.test.js`. All 22 suites touching the changed modules pass: 530 tests.

The one added alias, `troken` → `trocken`, is name-side only and cannot reach the producer-field rules in `crossFieldChecks`, which read `SWEETNESS_WORDS` directly. Like every entry in those maps it is an observed misspelling from a real file, not a general typo-tolerance scheme.