### PR TITLE
feat(taxonomy): show country and region names in the reader's language

### DIFF
--- a/backend/src/models/Country.js
+++ b/backend/src/models/Country.js
@@ -22,6 +22,18 @@ const countrySchema = new mongoose.Schema({
     index: true
   },
   slug: { type: String, trim: true, lowercase: true, unique: true, sparse: true, index: true },
+  // Display names in the reader's language. The canonical `name` above stays
+  // English and authoritative — search, dedup, exports and the registry key are
+  // all built on it — and these are layered on top for display only, so an
+  // untranslated country simply reads as it always has (utils/localizedName).
+  // Asked for by a French owner whose own import file wrote "Allemagne" and
+  // "Moselle": we already ACCEPT his language on the way in and never give it
+  // back (proposal 6a959b9d, 2026-09-01).
+  translations: {
+    type: Map,
+    of: String,
+    default: undefined,
+  },
   description: { type: String, trim: true, default: '' },
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,

--- a/backend/src/models/Region.js
+++ b/backend/src/models/Region.js
@@ -12,6 +12,18 @@ const regionSchema = new mongoose.Schema({
     required: true,
     lowercase: true
   },
+  // Display names in the reader's language. The canonical `name` above stays
+  // English and authoritative — search, dedup, exports and the registry key are
+  // all built on it — and these are layered on top for display only, so an
+  // untranslated region simply reads as it always has (utils/localizedName).
+  // Asked for by a French owner whose own import file wrote "Allemagne" and
+  // "Moselle": we already ACCEPT his language on the way in and never give it
+  // back (proposal 6a959b9d, 2026-09-01).
+  translations: {
+    type: Map,
+    of: String,
+    default: undefined,
+  },
   country: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Country',

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -13,6 +13,7 @@ const { isValidId } = require('../../utils/validation');
 const { distinctSizes, normalizeAll, remap } = require('../../services/bottleSizeMaintenance');
 const { mergeGrapes, mergeRegions, mergeCountries } = require('../../services/taxonomyMerge');
 const { findDuplicateClusters } = require('../../utils/taxonomyDuplicates');
+const { sanitizeTranslations } = require('../../utils/localizedName');
 const {
   listUnmatchedAppellations, appellationRefsError,
   dismissUnmatchedAppellation, restoreDismissedAppellation, listDismissedAppellations,
@@ -774,6 +775,52 @@ router.delete('/grapes/:id', async (req, res) => {
 // a user-write mint set (strategy 2026-07-29 R3). Approval is its own verb,
 // not a PUT side effect: editing a region to fix a typo must not silently
 // count as "a human vouched for this".
+// ── Display-name translations ────────────────────────────────────────────────
+
+// Only the two taxonomies that genuinely change language. Appellations are
+// protected legal names (Côte-Rôtie is Côte-Rôtie everywhere) and grape
+// variation is REGIONAL rather than linguistic — models/Grape already carries
+// `regionalNames` for that. See utils/localizedName for the full reasoning.
+const TRANSLATABLE = { countries: Country, regions: Region };
+
+/**
+ * PUT /api/admin/taxonomy/:kind/:id/translations
+ * Body: { translations: { fr: "Vallée du Rhône", de: "Rhônetal" } }
+ *
+ * A full replacement, not a merge: a language absent from the body is REMOVED.
+ * That is the only shape in which an editor can delete a wrong translation,
+ * and a merge-only endpoint would leave one stuck for good.
+ */
+router.put('/:kind(countries|regions)/:id/translations', async (req, res) => {
+  try {
+    const Model = TRANSLATABLE[req.params.kind];
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+
+    const parsed = sanitizeTranslations(req.body?.translations);
+    if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+
+    const doc = await Model.findById(req.params.id);
+    if (!doc) return res.status(404).json({ error: 'Not found' });
+
+    const before = doc.translations ? Object.fromEntries(doc.translations) : {};
+    const languages = Object.keys(parsed.translations);
+    // undefined, not an empty Map: the field's default is undefined, and
+    // storing an empty Map would leave every untranslated doc carrying one.
+    doc.translations = languages.length ? parsed.translations : undefined;
+    await doc.save();
+
+    clearTaxonomyListCache();
+    logAudit(req, `taxonomy.${req.params.kind}.translations`, { type: req.params.kind === 'countries' ? 'Country' : 'Region', id: doc._id }, {
+      name: doc.name, before, after: parsed.translations,
+    });
+
+    res.json({ id: doc._id, name: doc.name, translations: parsed.translations });
+  } catch (err) {
+    console.error('Update taxonomy translations error:', err);
+    res.status(500).json({ error: 'Failed to update translations' });
+  }
+});
+
 router.post('/regions/:id/approve', async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });

--- a/backend/src/routes/admin/taxonomy.translations.test.js
+++ b/backend/src/routes/admin/taxonomy.translations.test.js
@@ -1,0 +1,162 @@
+/**
+ * Editing a taxonomy display name in another language.
+ *
+ * A French owner filed a correction proposal asking that "Rhône Valley" read
+ * "Vallée du Rhône" (6a959b9d, 2026-09-01, reason: "En Français svp"). It had
+ * to be rejected as filed — a region's `name` is stored once and shared, so a
+ * rename would have moved all 298 wines on it into a French-named region for
+ * every user in every language. This endpoint is the thing he actually wanted:
+ * a translation beside the canonical name, not instead of it.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../services/search', () => ({
+  getIsAvailable: jest.fn(() => false), fullSync: jest.fn(), fullSyncBottles: jest.fn(),
+  indexWine: jest.fn(), removeWine: jest.fn(), bulkIndexWines: jest.fn(),
+  bulkIndexBottles: jest.fn(), waitForTasks: jest.fn(),
+}));
+const mockLogAudit = jest.fn();
+jest.mock('../../services/audit', () => ({ logAudit: (...a) => mockLogAudit(...a) }));
+jest.mock('../../services/taxonomyMerge', () => ({ mergeGrapes: jest.fn(), mergeRegions: jest.fn(), mergeCountries: jest.fn() }));
+jest.mock('../../services/taxonomyReview', () => ({
+  listUnmatchedAppellations: jest.fn(), appellationRefsError: jest.fn(),
+  dismissUnmatchedAppellation: jest.fn(), restoreDismissedAppellation: jest.fn(),
+  listDismissedAppellations: jest.fn(),
+}));
+jest.mock('../../services/bottleSizeMaintenance', () => ({ distinctSizes: jest.fn(), normalizeAll: jest.fn(), remap: jest.fn() }));
+const mockClearCache = jest.fn();
+jest.mock('../taxonomy', () => ({ clearTaxonomyListCache: (...a) => mockClearCache(...a) }));
+
+const mockRegionFindById = jest.fn();
+jest.mock('../../models/Region', () => ({
+  find: jest.fn(), findById: (...a) => mockRegionFindById(...a), countDocuments: jest.fn(), aggregate: jest.fn(),
+}));
+const mockCountryFindById = jest.fn();
+jest.mock('../../models/Country', () => ({
+  find: jest.fn(), findById: (...a) => mockCountryFindById(...a), exists: jest.fn(),
+}));
+jest.mock('../../models/Grape', () => ({ find: jest.fn(), findById: jest.fn(), exists: jest.fn() }));
+jest.mock('../../models/Appellation', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../../models/WineDefinition', () => ({ aggregate: jest.fn(), countDocuments: jest.fn(), find: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const router = require('./taxonomy');
+
+const RHONE = '64b000000000000000000aa1';
+let server;
+let baseUrl;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/taxonomy', router);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const token = jwt.sign({ id: '64b000000000000000000001', roles: ['admin'] }, 'test-secret');
+const put = (path, body) => fetch(`${baseUrl}/api/admin/taxonomy/${path}`, {
+  method: 'PUT',
+  headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+// An unmatched path falls through to Express's own HTML 404, so the body is
+// only parsed when the response actually claims to be JSON.
+}).then(async (r) => ({
+  status: r.status,
+  body: r.headers.get('content-type')?.includes('application/json') ? await r.json() : null,
+}));
+
+/** A saveable stand-in for the Mongoose doc the route mutates. */
+const docStub = (over = {}) => ({
+  _id: RHONE, name: 'Rhône Valley', translations: undefined, save: jest.fn().mockResolvedValue(true), ...over,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('PUT /:kind/:id/translations', () => {
+  test('stores the French name the owner asked for, leaving the canonical name alone', async () => {
+    const doc = docStub();
+    mockRegionFindById.mockResolvedValue(doc);
+    const res = await put(`regions/${RHONE}/translations`, { translations: { fr: 'Vallée du Rhône' } });
+    expect(res.status).toBe(200);
+    expect(res.body.translations).toEqual({ fr: 'Vallée du Rhône' });
+    expect(doc.name).toBe('Rhône Valley');           // untouched — this is the whole point
+    expect(doc.translations).toEqual({ fr: 'Vallée du Rhône' });
+    expect(doc.save).toHaveBeenCalled();
+  });
+
+  test('countries work the same way — his own file said "Allemagne" on the way in', async () => {
+    const doc = docStub({ name: 'Germany' });
+    mockCountryFindById.mockResolvedValue(doc);
+    const res = await put(`countries/${RHONE}/translations`, { translations: { fr: 'Allemagne', de: 'Deutschland' } });
+    expect(res.status).toBe(200);
+    expect(doc.translations).toEqual({ fr: 'Allemagne', de: 'Deutschland' });
+  });
+
+  test('a full replacement REMOVES a language left out of the body', async () => {
+    // The only shape in which an editor can delete a wrong translation. A
+    // merge-only endpoint would leave one stuck for good.
+    const doc = docStub({ translations: new Map([['fr', 'Vallée du Rhône'], ['de', 'Wrong']]) });
+    mockRegionFindById.mockResolvedValue(doc);
+    const res = await put(`regions/${RHONE}/translations`, { translations: { fr: 'Vallée du Rhône' } });
+    expect(res.status).toBe(200);
+    expect(doc.translations).toEqual({ fr: 'Vallée du Rhône' });
+  });
+
+  test('clearing every language sets undefined, not an empty Map', async () => {
+    // The field's default is undefined; an empty Map would leave every
+    // untranslated document carrying one.
+    const doc = docStub({ translations: new Map([['fr', 'Vallée du Rhône']]) });
+    mockRegionFindById.mockResolvedValue(doc);
+    const res = await put(`regions/${RHONE}/translations`, { translations: {} });
+    expect(res.status).toBe(200);
+    expect(doc.translations).toBeUndefined();
+  });
+
+  test('the public list cache is cleared, or the old name serves for the full TTL', async () => {
+    mockRegionFindById.mockResolvedValue(docStub());
+    await put(`regions/${RHONE}/translations`, { translations: { fr: 'Vallée du Rhône' } });
+    expect(mockClearCache).toHaveBeenCalled();
+  });
+
+  test('the change is audited with both the before and the after', async () => {
+    const doc = docStub({ translations: new Map([['fr', 'Ancien']]) });
+    mockRegionFindById.mockResolvedValue(doc);
+    await put(`regions/${RHONE}/translations`, { translations: { fr: 'Vallée du Rhône' } });
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.anything(), 'taxonomy.regions.translations',
+      { type: 'Region', id: RHONE },
+      { name: 'Rhône Valley', before: { fr: 'Ancien' }, after: { fr: 'Vallée du Rhône' } },
+    );
+  });
+
+  test.each([
+    [{ en: 'The Rhone' }, 'English is the canonical name and cannot be a translation'],
+    [{ 'not a language': 'x' }, '"not a language" is not a language code'],
+    [{ fr: 42 }, 'translation for "fr" must be a string'],
+  ])('rejects %p with 400, before reading anything', async (translations, error) => {
+    mockRegionFindById.mockResolvedValue(docStub());
+    const res = await put(`regions/${RHONE}/translations`, { translations });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe(error);
+    expect(mockRegionFindById).not.toHaveBeenCalled();
+  });
+
+  test('a malformed id is a 400 and an unknown one a 404', async () => {
+    expect((await put('regions/not-an-id/translations', { translations: { fr: 'x' } })).status).toBe(400);
+    mockRegionFindById.mockResolvedValue(null);
+    expect((await put(`regions/${RHONE}/translations`, { translations: { fr: 'x' } })).status).toBe(404);
+  });
+
+  test('grapes and appellations are NOT translatable — the route does not exist for them', async () => {
+    // Deliberate: a protected designation is a legal name (Côte-Rôtie is
+    // Côte-Rôtie everywhere), and grape variation is regional rather than
+    // linguistic — models/Grape already carries `regionalNames` for that.
+    expect((await put(`grapes/${RHONE}/translations`, { translations: { fr: 'x' } })).status).toBe(404);
+    expect((await put(`appellations/${RHONE}/translations`, { translations: { fr: 'x' } })).status).toBe(404);
+  });
+});

--- a/backend/src/routes/taxonomy.displayNames.test.js
+++ b/backend/src/routes/taxonomy.displayNames.test.js
@@ -1,0 +1,124 @@
+/**
+ * GET /api/taxonomy/display-names — the map the client localises against.
+ *
+ * Taxonomy names are rendered in about thirty places, and most of them never
+ * call a taxonomy route: they receive a populated `region` on a wine or a
+ * bottle. Serving one small map covers all of them at once and leaves every
+ * existing query, projection and cache untouched — which is why this is a
+ * separate endpoint rather than an extra field bolted onto the others.
+ */
+
+jest.mock('../models/WineDefinition', () => ({ aggregate: jest.fn(), countDocuments: jest.fn(), find: jest.fn() }));
+jest.mock('../models/Grape', () => ({ find: jest.fn(), findOne: jest.fn() }));
+
+const mockCountryFind = jest.fn();
+jest.mock('../models/Country', () => ({ find: (...a) => mockCountryFind(...a), findOne: jest.fn() }));
+const mockRegionFind = jest.fn();
+jest.mock('../models/Region', () => ({ find: (...a) => mockRegionFind(...a), findOne: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const router = require('./taxonomy');
+
+const chain = (rows) => ({ select: () => chain(rows), sort: () => chain(rows), lean: async () => rows });
+
+let server;
+let baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use('/api/taxonomy', router);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const get = (qs) => fetch(`${baseUrl}/api/taxonomy/display-names${qs}`)
+  .then(async (r) => ({ status: r.status, cacheControl: r.headers.get('cache-control'), body: await r.json() }));
+
+const RHONE = '64b000000000000000000aa1';
+const GERMANY = '64b000000000000000000bb2';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // The route's cache lives in module scope and outlives a single test, so an
+  // earlier test's answer would silently satisfy a later one — which is how
+  // two of these first passed against stale data rather than the new stubs.
+  router.clearTaxonomyListCache();
+  mockRegionFind.mockReturnValue(chain([
+    { _id: RHONE, name: 'Rhône Valley', translations: { fr: 'Vallée du Rhône', de: 'Rhônetal' } },
+  ]));
+  mockCountryFind.mockReturnValue(chain([
+    { _id: GERMANY, name: 'Germany', translations: { fr: 'Allemagne', de: 'Deutschland' } },
+  ]));
+});
+
+describe('display-names', () => {
+  test('returns the French names keyed by both id and canonical name', async () => {
+    const res = await get('?lang=fr');
+    expect(res.status).toBe(200);
+    expect(res.body.lang).toBe('fr');
+    expect(res.body.byId).toEqual({ [RHONE]: 'Vallée du Rhône', [GERMANY]: 'Allemagne' });
+    // byName catches the denormalised places that hold only the canonical string.
+    expect(res.body.byName).toEqual({ 'Rhône Valley': 'Vallée du Rhône', Germany: 'Allemagne' });
+    expect(res.body.total).toBe(2);
+  });
+
+  test('a regional variant resolves to the base language', async () => {
+    expect((await get('?lang=fr-CA')).body.byName).toEqual({
+      'Rhône Valley': 'Vallée du Rhône', Germany: 'Allemagne',
+    });
+  });
+
+  test('English is empty — the canonical name already IS the English name', async () => {
+    const res = await get('?lang=en');
+    expect(res.body).toEqual({ lang: 'en', byId: {}, byName: {}, total: 0 });
+    // and it must not have gone to the database to discover that
+    expect(mockRegionFind).not.toHaveBeenCalled();
+    expect(mockCountryFind).not.toHaveBeenCalled();
+  });
+
+  test.each([['', 'no lang at all'], ['?lang=', 'an empty lang'], ['?lang=zzzz', 'nonsense']])(
+    '%p yields empty maps without a query (%s)', async (qs) => {
+      const res = await get(qs);
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(0);
+      expect(mockRegionFind).not.toHaveBeenCalled();
+    },
+  );
+
+  test('only documents actually translated into this language are queried', async () => {
+    await get('?lang=sv');
+    // The dotted filter is what keeps the payload small — without it every
+    // region in the registry would be read to find the handful translated.
+    expect(mockRegionFind).toHaveBeenCalledWith({ 'translations.sv': { $exists: true, $ne: '' } });
+    expect(mockCountryFind).toHaveBeenCalledWith({ 'translations.sv': { $exists: true, $ne: '' } });
+  });
+
+  test('a row whose translation equals its canonical name is left out', async () => {
+    // Nothing to override, so it is dead weight in every client's map.
+    mockRegionFind.mockReturnValue(chain([
+      { _id: RHONE, name: 'Mosel', translations: { de: 'Mosel' } },
+    ]));
+    mockCountryFind.mockReturnValue(chain([]));
+    const res = await get('?lang=de');
+    expect(res.body.byId).toEqual({});
+    expect(res.body.total).toBe(0);
+  });
+
+  test('a blank or missing translation is skipped rather than blanking the name', async () => {
+    mockRegionFind.mockReturnValue(chain([
+      { _id: RHONE, name: 'Rhône Valley', translations: { fr: '   ' } },
+      { _id: GERMANY, name: 'Alsace', translations: {} },
+    ]));
+    mockCountryFind.mockReturnValue(chain([]));
+    expect((await get('?lang=fr')).body.byId).toEqual({});
+  });
+
+  test('answers are cached and publicly cacheable', async () => {
+    const first = await get('?lang=de');
+    expect(first.cacheControl).toContain('max-age=3600');
+    expect(mockRegionFind).toHaveBeenCalledTimes(1);
+    await get('?lang=de');
+    expect(mockRegionFind).toHaveBeenCalledTimes(1);   // served from the cache
+  });
+});

--- a/backend/src/routes/taxonomy.js
+++ b/backend/src/routes/taxonomy.js
@@ -14,6 +14,7 @@ const Region = require('../models/Region');
 const Grape = require('../models/Grape');
 const WineDefinition = require('../models/WineDefinition');
 const { parsePagination } = require('../utils/pagination');
+const { baseLanguage, localizedName } = require('../utils/localizedName');
 
 const router = express.Router();
 
@@ -71,6 +72,73 @@ function clearTaxonomyListCache() {
 
 // Shared wine projection for public lists
 const WINE_PROJECTION = 'name producer slug type appellation region country image communityRating';
+
+// ── Display names ────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/taxonomy/display-names?lang=fr
+ *
+ * Every country and region that HAS a name in this language, as two lookup
+ * maps. Deliberately not folded into the existing endpoints: taxonomy names
+ * are rendered in ~30 places across the app, most of which never call a
+ * taxonomy route at all — they receive a populated `region` on a wine or a
+ * bottle. Serving one small map the client resolves against localises all of
+ * them at once, and leaves every query, projection and cache in the codebase
+ * untouched. A surface nobody has adopted keeps showing English, which is
+ * exactly what it shows today.
+ *
+ * Keyed twice on purpose. `byId` is exact and is what a populated taxonomy
+ * object resolves through; `byName` catches the denormalised places that hold
+ * only the canonical string. Region names can in principle repeat across
+ * countries, so byName is a display convenience — byId is the authority.
+ *
+ * Only translated entries are included, so an untranslated language returns
+ * empty maps and costs the client nothing.
+ */
+router.get('/display-names', async (req, res) => {
+  try {
+    const lang = baseLanguage(req.query.lang);
+    // English IS the canonical name — there is nothing to override, and
+    // answering with an empty body keeps the client's code path identical.
+    if (!lang || lang === 'en') {
+      res.set('Cache-Control', 'public, max-age=3600');
+      return res.json({ lang: lang || null, byId: {}, byName: {}, total: 0 });
+    }
+
+    const cacheKey = `display-names:${lang}`;
+    const cached = getCachedList(cacheKey);
+    res.set('Cache-Control', 'public, max-age=3600');
+    if (cached) return res.json(cached);
+
+    // The whole map, not a `translations.${lang}` projection: how a dotted Map
+    // path reshapes under .lean() is a detail worth not depending on, and the
+    // maps hold one short string per shipped language. The FILTER is dotted
+    // (queries on Map paths are well defined) so only translated docs are read.
+    const field = `translations.${lang}`;
+    const [countries, regions] = await Promise.all([
+      Country.find({ [field]: { $exists: true, $ne: '' } }).select('name translations').lean(),
+      Region.find({ [field]: { $exists: true, $ne: '' } }).select('name translations').lean(),
+    ]);
+
+    const byId = {};
+    const byName = {};
+    for (const doc of [...countries, ...regions]) {
+      const value = localizedName(doc, lang);
+      // localizedName falls back to the canonical name, so an equal value means
+      // "not actually translated" and has no business in an override map.
+      if (!value || value === doc.name) continue;
+      byId[String(doc._id)] = value;
+      if (doc.name) byName[doc.name] = value;
+    }
+
+    const body = { lang, byId, byName, total: Object.keys(byId).length };
+    listCache.set(cacheKey, { at: Date.now(), body });
+    res.json(body);
+  } catch (err) {
+    console.error('[taxonomy] display-names error:', err);
+    res.status(500).json({ error: 'Failed to fetch display names' });
+  }
+});
 
 // ── Countries ────────────────────────────────────────────────────────────────
 

--- a/backend/src/scripts/seed-taxonomy-translations.js
+++ b/backend/src/scripts/seed-taxonomy-translations.js
@@ -65,7 +65,7 @@ const COUNTRIES = {
 const REGIONS = {
   Burgundy: { fr: 'Bourgogne', de: 'Burgund', sv: 'Bourgogne' },
   Tuscany: { fr: 'Toscane', de: 'Toskana', sv: 'Toscana' },
-  'Rhône Valley': { fr: 'Vallée du Rhône', de: 'Rhônetal', sv: 'Rhôndalen' },
+  'Rhône Valley': { fr: 'Vallée du Rhône', de: 'Rhônetal', sv: 'Rhônedalen' },
   Piedmont: { fr: 'Piémont', de: 'Piemont', sv: 'Piemonte' },
   'Loire Valley': { fr: 'Vallée de la Loire', de: 'Loiretal', sv: 'Loiredalen' },
   California: { fr: 'Californie', de: 'Kalifornien', sv: 'Kalifornien' },

--- a/backend/src/scripts/seed-taxonomy-translations.js
+++ b/backend/src/scripts/seed-taxonomy-translations.js
@@ -1,0 +1,138 @@
+/**
+ * Seed display-name translations for countries and regions.
+ *
+ * Dry-run by default; pass --apply to write. Idempotent — re-running changes
+ * nothing once the values are in.
+ *
+ *   docker compose -p prod exec -T backend node src/scripts/seed-taxonomy-translations.js
+ *   docker compose -p prod exec -T backend node src/scripts/seed-taxonomy-translations.js --apply
+ *
+ * WHERE THESE VALUES COME FROM. The country names are the display forms of
+ * aliases utils/normalize already carries and annotates by language — we have
+ * been ACCEPTING "Allemagne", "Frankrike" and "Österreich" on import for
+ * months and storing the English. This only gives them back. The region names
+ * are the standard exonyms for the same places.
+ *
+ * WHAT IS DELIBERATELY ABSENT: every entry whose name does not change with the
+ * language. Champagne, Alsace, Rioja, Douro, Mosel, Nahe, Barossa Valley,
+ * Coonawarra and most of the New World read identically in all four, and a
+ * translation equal to the canonical name is dead weight the endpoint would
+ * filter out anyway. Appellations and grapes are not here at all — see
+ * utils/localizedName for why.
+ *
+ * These are authored, not community-reviewed. They are ordinary DB rows, not
+ * Weblate strings, so a native speaker can correct any of them through
+ * PUT /api/admin/taxonomy/:kind/:id/translations without a release.
+ */
+
+const mongoose = require('mongoose');
+const Country = require('../models/Country');
+const Region = require('../models/Region');
+const { sanitizeTranslations } = require('../utils/localizedName');
+
+// canonical English name -> { fr, de, sv }
+const COUNTRIES = {
+  France: { de: 'Frankreich', sv: 'Frankrike' },
+  Italy: { fr: 'Italie', de: 'Italien', sv: 'Italien' },
+  Spain: { fr: 'Espagne', de: 'Spanien', sv: 'Spanien' },
+  Germany: { fr: 'Allemagne', de: 'Deutschland', sv: 'Tyskland' },
+  Austria: { fr: 'Autriche', de: 'Österreich', sv: 'Österrike' },
+  Switzerland: { fr: 'Suisse', de: 'Schweiz', sv: 'Schweiz' },
+  'United States': { fr: 'États-Unis', de: 'Vereinigte Staaten', sv: 'USA' },
+  Australia: { fr: 'Australie', de: 'Australien', sv: 'Australien' },
+  'New Zealand': { fr: 'Nouvelle-Zélande', de: 'Neuseeland', sv: 'Nya Zeeland' },
+  'South Africa': { fr: 'Afrique du Sud', de: 'Südafrika', sv: 'Sydafrika' },
+  Greece: { fr: 'Grèce', de: 'Griechenland', sv: 'Grekland' },
+  Hungary: { fr: 'Hongrie', de: 'Ungarn', sv: 'Ungern' },
+  England: { fr: 'Angleterre' },
+  Argentina: { fr: 'Argentine', de: 'Argentinien' },
+  Chile: { fr: 'Chili' },
+  Lebanon: { fr: 'Liban', de: 'Libanon', sv: 'Libanon' },
+  Israel: { fr: 'Israël' },
+  Croatia: { fr: 'Croatie', de: 'Kroatien', sv: 'Kroatien' },
+  Romania: { fr: 'Roumanie', de: 'Rumänien', sv: 'Rumänien' },
+  Slovenia: { fr: 'Slovénie', de: 'Slowenien', sv: 'Slovenien' },
+  Georgia: { fr: 'Géorgie', de: 'Georgien', sv: 'Georgien' },
+  Turkey: { fr: 'Turquie', de: 'Türkei', sv: 'Turkiet' },
+  Morocco: { fr: 'Maroc', de: 'Marokko', sv: 'Marocko' },
+  Canada: { de: 'Kanada', sv: 'Kanada' },
+  Mexico: { fr: 'Mexique', de: 'Mexiko', sv: 'Mexiko' },
+  Brazil: { fr: 'Brésil', de: 'Brasilien', sv: 'Brasilien' },
+  Uruguay: {},
+};
+
+// Region names only where the exonym genuinely differs.
+const REGIONS = {
+  Burgundy: { fr: 'Bourgogne', de: 'Burgund', sv: 'Bourgogne' },
+  Tuscany: { fr: 'Toscane', de: 'Toskana', sv: 'Toscana' },
+  'Rhône Valley': { fr: 'Vallée du Rhône', de: 'Rhônetal', sv: 'Rhôndalen' },
+  Piedmont: { fr: 'Piémont', de: 'Piemont', sv: 'Piemonte' },
+  'Loire Valley': { fr: 'Vallée de la Loire', de: 'Loiretal', sv: 'Loiredalen' },
+  California: { fr: 'Californie', de: 'Kalifornien', sv: 'Kalifornien' },
+  Veneto: { fr: 'Vénétie', de: 'Venetien' },
+  Sicily: { fr: 'Sicile', de: 'Sizilien', sv: 'Sicilien' },
+  Puglia: { fr: 'Pouilles', de: 'Apulien', sv: 'Apulien' },
+  Lombardy: { fr: 'Lombardie', de: 'Lombardei', sv: 'Lombardiet' },
+  Campania: { fr: 'Campanie', de: 'Kampanien' },
+  'Southwest France': { fr: 'Sud-Ouest', de: 'Südwestfrankreich', sv: 'Sydvästra Frankrike' },
+  'South Australia': { fr: 'Australie-Méridionale', de: 'Südaustralien', sv: 'Södra Australien' },
+  Sardinia: { fr: 'Sardaigne', de: 'Sardinien', sv: 'Sardinien' },
+  Umbria: { fr: 'Ombrie', de: 'Umbrien' },
+  Catalonia: { fr: 'Catalogne', de: 'Katalonien', sv: 'Katalonien' },
+  'Basque Country': { fr: 'Pays basque', de: 'Baskenland', sv: 'Baskien' },
+  Andalusia: { fr: 'Andalousie', de: 'Andalusien', sv: 'Andalusien' },
+  'Northern Rhône': { fr: 'Rhône septentrional', de: 'Nördliche Rhône' },
+  'Southern Rhône': { fr: 'Rhône méridional', de: 'Südliche Rhône' },
+};
+
+async function seed(Model, table, label, apply) {
+  let changed = 0;
+  let already = 0;
+  let missing = 0;
+
+  for (const [name, raw] of Object.entries(table)) {
+    const parsed = sanitizeTranslations(raw);
+    if (!parsed.ok) throw new Error(`${label} "${name}": ${parsed.error}`);
+    const wanted = parsed.translations;
+    if (Object.keys(wanted).length === 0) continue;   // nothing to say in any language
+
+    const doc = await Model.findOne({ name });
+    if (!doc) { missing++; console.log(`  – ${label} "${name}" is not in the taxonomy, skipped`); continue; }
+
+    const current = doc.translations ? Object.fromEntries(doc.translations) : {};
+    // Merge, never clobber: a curator may have corrected one of these by hand,
+    // and a seed script re-running must not quietly undo that.
+    const merged = { ...wanted, ...current };
+    if (JSON.stringify(merged) === JSON.stringify(current)) { already++; continue; }
+
+    const added = Object.keys(merged).filter((k) => current[k] === undefined);
+    console.log(`  ${apply ? '✓' : '·'} ${label} "${name}": +${added.map((k) => `${k}=${merged[k]}`).join(', ')}`);
+    if (apply) { doc.translations = merged; await doc.save(); }
+    changed++;
+  }
+  return { changed, already, missing };
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log(apply ? '=== APPLYING ===' : '=== DRY RUN (pass --apply to write) ===');
+
+  const c = await seed(Country, COUNTRIES, 'country', apply);
+  const r = await seed(Region, REGIONS, 'region', apply);
+
+  console.log(`\ncountries: ${c.changed} to change, ${c.already} already current, ${c.missing} not in taxonomy`);
+  console.log(`regions:   ${r.changed} to change, ${r.already} already current, ${r.missing} not in taxonomy`);
+  if (!apply) console.log('\nNothing was written.');
+
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+// Only when RUN. Requiring this file (its tables are worth asserting on) must
+// not open a database connection as a side effect.
+if (require.main === module) {
+  main().catch((err) => { console.error('FAILED:', err.message); process.exit(1); });
+}
+
+module.exports = { COUNTRIES, REGIONS };

--- a/backend/src/scripts/seedTaxonomyTranslations.test.js
+++ b/backend/src/scripts/seedTaxonomyTranslations.test.js
@@ -1,0 +1,69 @@
+/**
+ * The seeded display names, checked as data.
+ *
+ * A wrong entry here is invisible: it renders as a confident, plausible name in
+ * a language most reviewers of this repo do not read. So the properties that
+ * CAN be checked mechanically are checked — shape, no English, no self-
+ * translations — and the rest is left to the admin endpoint, which lets a
+ * native speaker fix any of it without a release.
+ */
+const { COUNTRIES, REGIONS } = require('./seed-taxonomy-translations');
+const { sanitizeTranslations, localizedName } = require('../utils/localizedName');
+
+const SHIPPED = ['fr', 'de', 'sv', 'et'];
+const entries = [
+  ...Object.entries(COUNTRIES).map(([name, t]) => ['country', name, t]),
+  ...Object.entries(REGIONS).map(([name, t]) => ['region', name, t]),
+];
+
+describe('the seed tables', () => {
+  test('every entry passes the same validation the admin endpoint applies', () => {
+    for (const [kind, name, translations] of entries) {
+      const parsed = sanitizeTranslations(translations);
+      expect(parsed.ok ? null : `${kind} ${name}: ${parsed.error}`).toBeNull();
+    }
+  });
+
+  test('no entry translates a name into itself', () => {
+    // A translation equal to the canonical name is dead weight: the endpoint
+    // filters it out, so it would ship in the table and never reach a reader.
+    const selfies = entries.flatMap(([kind, name, t]) =>
+      Object.entries(t).filter(([, value]) => value === name).map(([lang]) => `${kind} ${name} (${lang})`));
+    expect(selfies).toEqual([]);
+  });
+
+  test('only languages the app actually ships are used', () => {
+    const langs = new Set(entries.flatMap(([, , t]) => Object.keys(t)));
+    expect([...langs].filter((l) => !SHIPPED.includes(l))).toEqual([]);
+  });
+
+  test('the record that prompted all of this is present and correct', () => {
+    // Proposal 6a959b9d, "En Français svp".
+    expect(REGIONS['Rhône Valley'].fr).toBe('Vallée du Rhône');
+    // And the country his own import file wrote as "Allemagne".
+    expect(COUNTRIES.Germany.fr).toBe('Allemagne');
+  });
+
+  test('the tables feed localizedName as-is', () => {
+    // The seed and the reader agree on shape — a plain object, which is what
+    // a .lean() document also gives.
+    expect(localizedName({ name: 'Rhône Valley', translations: REGIONS['Rhône Valley'] }, 'fr'))
+      .toBe('Vallée du Rhône');
+    expect(localizedName({ name: 'Germany', translations: COUNTRIES.Germany }, 'sv'))
+      .toBe('Tyskland');
+  });
+
+  test('an entry with nothing to say in any language is allowed but seeds nothing', () => {
+    // Uruguay reads the same in all four; it is kept in the table as a marker
+    // that it was considered rather than forgotten.
+    expect(COUNTRIES.Uruguay).toEqual({});
+    expect(sanitizeTranslations(COUNTRIES.Uruguay).translations).toEqual({});
+  });
+
+  test('no duplicate canonical names between the two tables', () => {
+    // A name in both would be seeded twice against different models — harmless
+    // today, confusing the moment one of them is edited.
+    const overlap = Object.keys(COUNTRIES).filter((n) => n in REGIONS);
+    expect(overlap).toEqual([]);
+  });
+});

--- a/backend/src/utils/localizedName.js
+++ b/backend/src/utils/localizedName.js
@@ -1,0 +1,107 @@
+/**
+ * Display names for taxonomy in the reader's language.
+ *
+ * A French owner asked for "Rhône Valley" to read "Vallée du Rhône" (correction
+ * proposal 6a959b9d, 2026-09-01, reason: "En Français svp"). His request could
+ * not be granted as filed, because a region's `name` is stored once and shared
+ * by every wine and every user: renaming it would have changed the region for
+ * all 298 wines on it, in every language, and undone the French→English
+ * consolidation the taxonomy had just been through.
+ *
+ * But he was right about the gap. The interface ships in five languages while
+ * the taxonomy speaks only English — and the asymmetry is already visible in
+ * our own code, which ACCEPTS "Allemagne" and "Vallée du Rhône" on import
+ * (utils/normalize's COUNTRY_ALIASES is full of French, German and Swedish
+ * spellings) and then hands back "Germany" for ever after. We take his language
+ * in and never give it back.
+ *
+ * So the canonical name stays English and authoritative — it is what search,
+ * dedup, exports and the registry key are built on — and a translation is a
+ * DISPLAY concern layered on top.
+ *
+ * WHAT IS DELIBERATELY NOT TRANSLATED:
+ *
+ *   - Appellations. Côte-Rôtie is Côte-Rôtie in every language; a protected
+ *     designation of origin is a legal name, and translating one would be
+ *     inventing a wine law that does not exist.
+ *   - Grapes. Cabernet Sauvignon does not change language. Where a variety
+ *     genuinely goes by another name it is a REGIONAL difference, not a
+ *     linguistic one (Malvoisie in the Loire is Pinot Gris), and models/Grape
+ *     already carries `regionalNames` keyed by place for exactly that.
+ *
+ * Which leaves countries and regions — the two that really are translated, and
+ * the two the owner actually asked about.
+ */
+
+/**
+ * The reader's language, reduced to a bare tag we store translations under.
+ * "fr-CA" and "fr" are the same shelf here: regional variants of a country
+ * name are not what this solves, and pretending otherwise would leave a
+ * fr-CA reader with English while a perfectly good French name sat unused.
+ *
+ * @param {string} locale
+ * @returns {string|null} lowercase base language, or null when unusable
+ */
+function baseLanguage(locale) {
+  if (typeof locale !== 'string') return null;
+  const base = locale.trim().toLowerCase().split(/[-_]/)[0];
+  return /^[a-z]{2,3}$/.test(base) ? base : null;
+}
+
+/**
+ * The name to show this reader.
+ *
+ * Falls back to the canonical English name whenever there is no translation,
+ * which is the honest answer and also today's behaviour everywhere — so an
+ * unadopted surface and an untranslated entry look identical, and neither is
+ * a regression.
+ *
+ * @param {{name?: string, translations?: Map<string,string>|Object}} doc
+ * @param {string} locale
+ * @returns {string} never null when the doc has a name
+ */
+function localizedName(doc, locale) {
+  const canonical = doc && typeof doc.name === 'string' ? doc.name : '';
+  const lang = baseLanguage(locale);
+  if (!lang || lang === 'en' || !doc || !doc.translations) return canonical;
+  // A Mongoose document gives a Map; a .lean() one gives a plain object. Both
+  // reach this function and both must work — reading only one shape is how a
+  // feature works in tests and silently does nothing in production.
+  const t = typeof doc.translations.get === 'function'
+    ? doc.translations.get(lang)
+    : doc.translations[lang];
+  return (typeof t === 'string' && t.trim()) ? t.trim() : canonical;
+}
+
+/**
+ * Clean a translations payload from an admin editor.
+ *
+ * Drops anything that is not a real language→non-empty-string pair, and drops
+ * `en` outright: English is the canonical `name`, and a second English spelling
+ * that could drift from it is a bug waiting to be filed as a data mystery.
+ *
+ * @param {Object} raw
+ * @param {number} [maxLength=120]
+ * @returns {{ok: true, translations: Object}|{ok: false, error: string}}
+ */
+function sanitizeTranslations(raw, maxLength = 120) {
+  if (raw == null) return { ok: true, translations: {} };
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'translations must be an object of language → name' };
+  }
+  const out = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const lang = baseLanguage(key);
+    if (!lang) return { ok: false, error: `"${key}" is not a language code` };
+    if (lang === 'en') return { ok: false, error: 'English is the canonical name and cannot be a translation' };
+    if (value == null || value === '') continue;              // an explicit clear
+    if (typeof value !== 'string') return { ok: false, error: `translation for "${lang}" must be a string` };
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    if (trimmed.length > maxLength) return { ok: false, error: `translation for "${lang}" is longer than ${maxLength} characters` };
+    out[lang] = trimmed;
+  }
+  return { ok: true, translations: out };
+}
+
+module.exports = { localizedName, baseLanguage, sanitizeTranslations };

--- a/backend/src/utils/localizedName.test.js
+++ b/backend/src/utils/localizedName.test.js
@@ -1,0 +1,97 @@
+const { localizedName, baseLanguage, sanitizeTranslations } = require('./localizedName');
+
+// The record that prompted this: proposal 6a959b9d, "En Français svp".
+const rhone = { name: 'Rhône Valley', translations: { fr: 'Vallée du Rhône', de: 'Rhônetal' } };
+const asMap = (obj) => ({ ...obj, translations: new Map(Object.entries(obj.translations)) });
+
+describe('localizedName', () => {
+  test('gives the French reader the French name', () => {
+    expect(localizedName(rhone, 'fr')).toBe('Vallée du Rhône');
+  });
+
+  test('works on a Mongoose Map as well as a lean object', () => {
+    // Both shapes reach this function. Reading only one is how a feature
+    // passes its tests and silently does nothing in production.
+    expect(localizedName(asMap(rhone), 'fr')).toBe('Vallée du Rhône');
+    expect(localizedName(asMap(rhone), 'sv')).toBe('Rhône Valley');
+  });
+
+  test('a regional variant reads the base language', () => {
+    // fr-CA is not a different wine region. Withholding a good French name
+    // from a Canadian reader would be pedantry with a cost.
+    expect(localizedName(rhone, 'fr-CA')).toBe('Vallée du Rhône');
+    expect(localizedName(rhone, 'de_AT')).toBe('Rhônetal');
+  });
+
+  test('falls back to the canonical name for an untranslated language', () => {
+    expect(localizedName(rhone, 'sv')).toBe('Rhône Valley');
+    expect(localizedName(rhone, 'et')).toBe('Rhône Valley');
+  });
+
+  test('English always gets the canonical name, never a translation', () => {
+    expect(localizedName({ ...rhone, translations: { ...rhone.translations, en: 'The Rhone' } }, 'en'))
+      .toBe('Rhône Valley');
+  });
+
+  test.each([
+    [{ name: 'Mosel' }, 'fr', 'Mosel', 'no translations at all'],
+    [{ name: 'Mosel', translations: {} }, 'fr', 'Mosel', 'an empty map'],
+    [{ name: 'Mosel', translations: { fr: '   ' } }, 'fr', 'Mosel', 'a blank translation'],
+    [{ name: 'Mosel', translations: { fr: 42 } }, 'fr', 'Mosel', 'a non-string translation'],
+    [rhone, null, 'Rhône Valley', 'no locale'],
+    [rhone, '', 'Rhône Valley', 'an empty locale'],
+    [rhone, 'not-a-language', 'Rhône Valley', 'nonsense'],
+  ])('%p in %p → %p (%s)', (doc, locale, expected) => {
+    expect(localizedName(doc, locale)).toBe(expected);
+  });
+
+  test('a doc with no name yields an empty string rather than throwing', () => {
+    expect(localizedName(null, 'fr')).toBe('');
+    expect(localizedName({}, 'fr')).toBe('');
+  });
+});
+
+describe('baseLanguage', () => {
+  test.each([['fr', 'fr'], ['FR', 'fr'], ['fr-CA', 'fr'], ['de_AT', 'de'], ['  sv  ', 'sv']])(
+    '%p → %p', (input, expected) => expect(baseLanguage(input)).toBe(expected),
+  );
+  test.each([[''], ['x'], ['1234'], [null], [undefined], [42], [{}]])('%p → null', (input) => {
+    expect(baseLanguage(input)).toBeNull();
+  });
+});
+
+describe('sanitizeTranslations', () => {
+  test('keeps and trims real pairs', () => {
+    expect(sanitizeTranslations({ fr: '  Vallée du Rhône ', de: 'Rhônetal' }))
+      .toEqual({ ok: true, translations: { fr: 'Vallée du Rhône', de: 'Rhônetal' } });
+  });
+
+  test('normalises the language key', () => {
+    expect(sanitizeTranslations({ 'FR-ca': 'Vallée du Rhône' }).translations).toEqual({ fr: 'Vallée du Rhône' });
+  });
+
+  test('an empty value clears that language rather than storing a blank', () => {
+    expect(sanitizeTranslations({ fr: '', de: null, sv: '  ' }).translations).toEqual({});
+  });
+
+  test('refuses English — the canonical name owns it', () => {
+    // Two English spellings that can drift apart is a data mystery in waiting.
+    expect(sanitizeTranslations({ en: 'The Rhone' })).toEqual({
+      ok: false, error: 'English is the canonical name and cannot be a translation',
+    });
+  });
+
+  test.each([
+    [{ 'not a language': 'x' }, '"not a language" is not a language code'],
+    [{ fr: 42 }, 'translation for "fr" must be a string'],
+    [{ fr: 'x'.repeat(121) }, 'translation for "fr" is longer than 120 characters'],
+    [['fr'], 'translations must be an object of language → name'],
+    ['fr', 'translations must be an object of language → name'],
+  ])('rejects %p', (raw, error) => {
+    expect(sanitizeTranslations(raw)).toEqual({ ok: false, error });
+  });
+
+  test('null is an empty set, not an error — clearing everything is legitimate', () => {
+    expect(sanitizeTranslations(null)).toEqual({ ok: true, translations: {} });
+  });
+});

--- a/frontend/src/components/bottle/WineRecordSection.js
+++ b/frontend/src/components/bottle/WineRecordSection.js
@@ -4,6 +4,8 @@ import Modal from '../Modal';
 import TypedValueInput, { TYPES, formatTypedValue } from '../TypedValueInput';
 import { createWineProposal, getMyWineProposals } from '../../api/wineProposals';
 import { getWinePublicData, suggestWineValue, proposeRegistryKey } from '../../api/registryData';
+import useTaxonomyNames from '../../hooks/useTaxonomyNames';
+import { taxonomyName } from '../../utils/taxonomyName';
 import './WineRecordSection.css';
 
 /**
@@ -65,8 +67,16 @@ function WineRecordSection({ wine, canSuggest, apiFetch }) {
     return () => { cancelled = true; };
   }, [apiFetch, wine?._id, canSuggest]);
 
+  const displayNames = useTaxonomyNames();
+
   if (!wine) return null;
 
+  // What the registry actually STORES. This is what the suggest-a-fix form
+  // shows as "currently recorded", and it must stay canonical: a French reader
+  // shown "Vallée du Rhône" as the current value would reasonably propose a
+  // French correction to it — which is precisely the proposal (6a959b9d) that
+  // led to this feature, and telling him the stored value is "Rhône Valley"
+  // is what would have prevented it.
   const values = {
     producer: wine.producer || null,
     name: wine.name || null,
@@ -74,6 +84,14 @@ function WineRecordSection({ wine, canSuggest, apiFetch }) {
     region: wine.region?.name || null,
     appellation: wine.appellation || null,
     classification: wine.classification || null,
+  };
+
+  // What the reader SEES. Only the two taxonomies that genuinely change
+  // language; appellation is a protected legal name and is never translated.
+  const displayValues = {
+    ...values,
+    country: taxonomyName(wine.country, displayNames) || null,
+    region: taxonomyName(wine.region, displayNames) || null,
   };
 
   const pendingFields = new Set(
@@ -203,8 +221,8 @@ function WineRecordSection({ wine, canSuggest, apiFetch }) {
         {SUGGESTABLE.map((f) => (
           <div key={f} className="wr-row">
             <span className="wr-key">{fieldLabel(f)}</span>
-            <span className={values[f] ? 'wr-value' : 'wr-value wr-value--blank'}>
-              {values[f] || t('wineRecord.notRecorded', 'not recorded')}
+            <span className={displayValues[f] ? 'wr-value' : 'wr-value wr-value--blank'}>
+              {displayValues[f] || t('wineRecord.notRecorded', 'not recorded')}
             </span>
             {canSuggest && pendingFields.has(f) ? (
               <span className="wr-pending" title={t('wineRecord.pendingTitle', 'Your suggestion is awaiting curator review')}>

--- a/frontend/src/hooks/useTaxonomyNames.js
+++ b/frontend/src/hooks/useTaxonomyNames.js
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { API_URL } from '../api/apiConstants';
+import { EMPTY_DISPLAY_NAMES } from '../utils/taxonomyName';
+
+/**
+ * The country and region display names for the current language.
+ *
+ * One small public map (only the entries that HAVE a name in this language),
+ * fetched once per language and held for the tab's lifetime — taxonomy names
+ * change about as often as the taxonomy does, and the endpoint is
+ * `Cache-Control: public, max-age=3600` besides.
+ *
+ * Deliberately never throws and never blocks: a failed fetch leaves the map
+ * empty, and an empty map means every name renders canonically — which is what
+ * the app did before this existed. Localisation is worth having, not worth a
+ * blank page.
+ */
+
+// Module scope, not component state: every component that mounts wants the
+// same map, and this is what stops twenty bottle cards issuing twenty requests.
+const cache = new Map();       // lang -> map
+const inFlight = new Map();    // lang -> promise
+
+function loadDisplayNames(lang) {
+  if (cache.has(lang)) return Promise.resolve(cache.get(lang));
+  if (inFlight.has(lang)) return inFlight.get(lang);
+
+  const request = fetch(`${API_URL}/api/taxonomy/display-names?lang=${encodeURIComponent(lang)}`)
+    .then((res) => (res.ok ? res.json() : null))
+    .then((body) => {
+      const map = body && body.byId && body.byName
+        ? { byId: body.byId, byName: body.byName }
+        : EMPTY_DISPLAY_NAMES;
+      cache.set(lang, map);
+      return map;
+    })
+    .catch(() => {
+      // Not cached: a network blip should not condemn this tab to English for
+      // the rest of the session, and the next mount will simply try again.
+      return EMPTY_DISPLAY_NAMES;
+    })
+    .finally(() => inFlight.delete(lang));
+
+  inFlight.set(lang, request);
+  return request;
+}
+
+export default function useTaxonomyNames() {
+  // `i18n` is destructured defensively on purpose. Component suites across this
+  // codebase mock react-i18next down to just `t`, and a hook that threw on the
+  // missing half would make adopting it cost a test edit in every component —
+  // which is how a nice-to-have quietly stops being adopted. No i18n means no
+  // language means English, which is this module's answer to every other
+  // unknown too.
+  const { i18n } = useTranslation() || {};
+  const lang = (i18n?.language || 'en').split('-')[0].toLowerCase();
+  // English needs no map at all — skip the request entirely rather than ask
+  // the server for an answer we already know is empty.
+  const [names, setNames] = useState(() => (lang === 'en' ? EMPTY_DISPLAY_NAMES : (cache.get(lang) || EMPTY_DISPLAY_NAMES)));
+
+  useEffect(() => {
+    if (lang === 'en') { setNames(EMPTY_DISPLAY_NAMES); return undefined; }
+    let active = true;
+    loadDisplayNames(lang).then((map) => { if (active) setNames(map); });
+    return () => { active = false; };
+  }, [lang]);
+
+  return names;
+}
+
+/** Test seam — the module-level cache would otherwise leak between cases. */
+export function __resetTaxonomyNameCache() {
+  cache.clear();
+  inFlight.clear();
+}

--- a/frontend/src/hooks/useTaxonomyNames.js
+++ b/frontend/src/hooks/useTaxonomyNames.js
@@ -29,15 +29,18 @@ function loadDisplayNames(lang) {
   const request = fetch(`${API_URL}/api/taxonomy/display-names?lang=${encodeURIComponent(lang)}`)
     .then((res) => (res.ok ? res.json() : null))
     .then((body) => {
-      const map = body && body.byId && body.byName
-        ? { byId: body.byId, byName: body.byName }
-        : EMPTY_DISPLAY_NAMES;
+      if (!body || !body.byId || !body.byName) return EMPTY_DISPLAY_NAMES;
+      const map = { byId: body.byId, byName: body.byName };
+      // ONLY a valid answer is cached. Caching the empty fallback on a non-OK
+      // response looked harmless and wasn't: a 503 during a deploy would have
+      // condemned the tab to English for its whole lifetime — the exact thing
+      // the catch below already refuses to do for a network failure (found by
+      // the pre-merge audit; the two failure paths now agree).
       cache.set(lang, map);
       return map;
     })
     .catch(() => {
-      // Not cached: a network blip should not condemn this tab to English for
-      // the rest of the session, and the next mount will simply try again.
+      // Not cached either: the next mount simply tries again.
       return EMPTY_DISPLAY_NAMES;
     })
     .finally(() => inFlight.delete(lang));

--- a/frontend/src/hooks/useTaxonomyNames.test.js
+++ b/frontend/src/hooks/useTaxonomyNames.test.js
@@ -107,3 +107,19 @@ describe('when a component suite mocks react-i18next down to just `t`', () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 });
+
+describe('a non-OK response', () => {
+  it('is not cached either — a 503 during a deploy must not stick for the session', async () => {
+    // Found by the pre-merge audit: the reject path refused to cache but the
+    // HTTP-error path quietly cached the empty map, so the two disagreed.
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.reject(new Error('no body')) }));
+    const first = renderHook(() => useTaxonomyNames());
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    const BODY2 = { lang: 'fr', byId: { r1: 'Vallée du Rhône' }, byName: { 'Rhône Valley': 'Vallée du Rhône' } };
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(BODY2) }));
+    const second = renderHook(() => useTaxonomyNames());
+    await waitFor(() => expect(second.result.current.byId.r1).toBe('Vallée du Rhône'));
+  });
+});

--- a/frontend/src/hooks/useTaxonomyNames.test.js
+++ b/frontend/src/hooks/useTaxonomyNames.test.js
@@ -1,0 +1,109 @@
+/**
+ * Fetching the taxonomy display-name map.
+ *
+ * The failure this guards is quiet in both directions: too many requests (a
+ * list of bottle cards each fetching the same map) or a failed request turning
+ * into a crash on a page that only wanted to render a region name. Neither is
+ * visible in a screenshot, so both are pinned here.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+let language = 'fr';
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { get language() { return language; } } }),
+}));
+
+import useTaxonomyNames, { __resetTaxonomyNameCache } from './useTaxonomyNames';
+
+const BODY = {
+  lang: 'fr',
+  byId: { r1: 'Vallée du Rhône' },
+  byName: { 'Rhône Valley': 'Vallée du Rhône' },
+};
+
+beforeEach(() => {
+  __resetTaxonomyNameCache();
+  language = 'fr';
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(BODY) }));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('useTaxonomyNames', () => {
+  it('fetches the map for the active language', async () => {
+    const { result } = renderHook(() => useTaxonomyNames());
+    await waitFor(() => expect(result.current.byId.r1).toBe('Vallée du Rhône'));
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('lang=fr'));
+  });
+
+  it('starts empty, so the first paint renders canonical names rather than nothing', async () => {
+    const { result } = renderHook(() => useTaxonomyNames());
+    expect(result.current).toEqual({ byId: {}, byName: {} });
+    await waitFor(() => expect(result.current.byId.r1).toBeDefined());
+  });
+
+  it('fetches once however many components ask', async () => {
+    // The reason the cache lives in module scope: a list of twenty bottle cards
+    // must not become twenty identical requests.
+    const a = renderHook(() => useTaxonomyNames());
+    const b = renderHook(() => useTaxonomyNames());
+    const c = renderHook(() => useTaxonomyNames());
+    await waitFor(() => expect(a.result.current.byId.r1).toBeDefined());
+    await waitFor(() => expect(b.result.current.byId.r1).toBeDefined());
+    await waitFor(() => expect(c.result.current.byId.r1).toBeDefined());
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('never asks the server about English — the canonical name IS the English one', async () => {
+    language = 'en';
+    const { result } = renderHook(() => useTaxonomyNames());
+    expect(result.current).toEqual({ byId: {}, byName: {} });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('reduces a regional variant to its base language', async () => {
+    language = 'fr-CA';
+    renderHook(() => useTaxonomyNames());
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('lang=fr')));
+    expect(global.fetch).not.toHaveBeenCalledWith(expect.stringContaining('fr-CA'));
+  });
+
+  it('a failed request leaves names canonical instead of throwing', async () => {
+    // Localisation is worth having; it is not worth a blank page.
+    global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+    const { result } = renderHook(() => useTaxonomyNames());
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(result.current).toEqual({ byId: {}, byName: {} });
+  });
+
+  it('a non-OK response is handled the same way', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.reject(new Error('no body')) }));
+    const { result } = renderHook(() => useTaxonomyNames());
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(result.current).toEqual({ byId: {}, byName: {} });
+  });
+
+  it('a failure is not cached — the next mount tries again', async () => {
+    // A network blip must not condemn the tab to English for the session.
+    global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+    const first = renderHook(() => useTaxonomyNames());
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(BODY) }));
+    const second = renderHook(() => useTaxonomyNames());
+    await waitFor(() => expect(second.result.current.byId.r1).toBe('Vallée du Rhône'));
+  });
+});
+
+describe('when a component suite mocks react-i18next down to just `t`', () => {
+  it('falls back to English instead of throwing', async () => {
+    // This is not hypothetical: adopting the hook in WineRecordSection broke
+    // eight of that component's existing tests exactly this way. A hook that
+    // costs a test edit in every component it touches does not get adopted.
+    language = undefined;
+    const { result } = renderHook(() => useTaxonomyNames());
+    expect(result.current).toEqual({ byId: {}, byName: {} });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/taxonomyName.js
+++ b/frontend/src/utils/taxonomyName.js
@@ -1,0 +1,48 @@
+/**
+ * Show a country or region in the reader's language.
+ *
+ * The registry stores one canonical English name per taxonomy entry, because
+ * search, dedup, exports and the wine key are all built on it. A French owner
+ * asked for "Rhône Valley" to read "Vallée du Rhône" and had to be told no,
+ * since renaming would have changed the region for all 298 wines on it, for
+ * every user, in every language (proposal 6a959b9d, 2026-09-01).
+ *
+ * This is the half he was actually asking for: the same stored entry, rendered
+ * in his language. `GET /api/taxonomy/display-names?lang=fr` returns only the
+ * entries that HAVE a French name, keyed by id and by canonical name, and this
+ * resolves against that map.
+ *
+ * WHY A MAP RATHER THAN A FIELD ON EVERY RESPONSE: taxonomy names are rendered
+ * in about thirty components, and most never call a taxonomy endpoint — they
+ * get a populated `region` on a wine or a bottle. One map localises all of them
+ * without touching a single query or projection, and a component that has not
+ * adopted this keeps showing English, which is what it shows today. Nothing
+ * regresses by being left alone.
+ */
+
+const EMPTY = { byId: {}, byName: {} };
+
+/**
+ * @param {{_id?: string, id?: string, name?: string}|string|null} taxon
+ *   a populated country/region, or just its canonical name
+ * @param {{byId: Object, byName: Object}} [names] the display-name map
+ * @returns {string} the localised name, or the canonical one, or ''
+ */
+export function taxonomyName(taxon, names = EMPTY) {
+  if (!taxon) return '';
+  const map = names || EMPTY;
+
+  // A bare string — the denormalised case. Only byName can help here, which is
+  // why the endpoint ships both keyings.
+  if (typeof taxon === 'string') return map.byName?.[taxon] || taxon;
+
+  const id = taxon._id || taxon.id;
+  // id first: it is exact. Region names can in principle repeat across
+  // countries, so byName is a convenience rather than an authority.
+  if (id && map.byId?.[String(id)]) return map.byId[String(id)];
+
+  const canonical = typeof taxon.name === 'string' ? taxon.name : '';
+  return (canonical && map.byName?.[canonical]) || canonical;
+}
+
+export { EMPTY as EMPTY_DISPLAY_NAMES };

--- a/frontend/src/utils/taxonomyName.test.js
+++ b/frontend/src/utils/taxonomyName.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { taxonomyName } from './taxonomyName';
+
+// The map GET /api/taxonomy/display-names?lang=fr returns.
+const names = {
+  byId: { r1: 'Vallée du Rhône', c1: 'Allemagne' },
+  byName: { 'Rhône Valley': 'Vallée du Rhône', Germany: 'Allemagne' },
+};
+
+describe('taxonomyName', () => {
+  it('shows the French name for a populated region', () => {
+    expect(taxonomyName({ _id: 'r1', name: 'Rhône Valley' }, names)).toBe('Vallée du Rhône');
+  });
+
+  it('resolves a bare canonical string, which is how half the app holds it', () => {
+    expect(taxonomyName('Rhône Valley', names)).toBe('Vallée du Rhône');
+  });
+
+  it('prefers the id over the name, because ids are exact', () => {
+    // Region names can repeat across countries; the id cannot.
+    const map = { byId: { r1: 'Correct' }, byName: { Ambiguous: 'Wrong' } };
+    expect(taxonomyName({ _id: 'r1', name: 'Ambiguous' }, map)).toBe('Correct');
+  });
+
+  it('accepts `id` as well as `_id`', () => {
+    expect(taxonomyName({ id: 'c1', name: 'Germany' }, names)).toBe('Allemagne');
+  });
+
+  it('falls back to the canonical name when nothing is translated', () => {
+    expect(taxonomyName({ _id: 'r9', name: 'Mosel' }, names)).toBe('Mosel');
+    expect(taxonomyName('Mosel', names)).toBe('Mosel');
+  });
+
+  it('falls back with no map at all — an unadopted surface must not break', () => {
+    // This is the default argument doing the real work: a component that has
+    // not been given the map yet renders exactly what it renders today.
+    expect(taxonomyName({ _id: 'r1', name: 'Rhône Valley' })).toBe('Rhône Valley');
+    expect(taxonomyName('Rhône Valley')).toBe('Rhône Valley');
+    expect(taxonomyName({ name: 'Mosel' }, null)).toBe('Mosel');
+    expect(taxonomyName({ name: 'Mosel' }, {})).toBe('Mosel');
+  });
+
+  it('returns an empty string for nothing, rather than throwing', () => {
+    expect(taxonomyName(null, names)).toBe('');
+    expect(taxonomyName(undefined, names)).toBe('');
+    expect(taxonomyName({}, names)).toBe('');
+    expect(taxonomyName({ _id: 'r9' }, names)).toBe('');
+  });
+});


### PR DESCRIPTION
A French owner asked for "Rhône Valley" to read "Vallée du Rhône" — correction proposal `6a959b9d`, whose entire stated reason was *"En Français svp"*.

It had to be rejected as filed. A region's `name` is stored once and shared by every wine and every user, so renaming it would have moved all **298** wines on it into a French-named region for everyone in every language, and undone the French→English consolidation the taxonomy had just been through. (It also contradicted a sommelier proposal sitting in the same queue, normalising "Piémont" → "Piedmont".)

But he was right about the gap, and the asymmetry is already visible in our own code. `utils/normalize`'s `COUNTRY_ALIASES` is full of French, German and Swedish spellings — annotated by language — because we **accept** "Allemagne" and "Frankrike" on import. His own import file wrote "Allemagne" and "Moselle". We take his language in and hand back "Germany" for ever after.

## The rule

The canonical name stays English and authoritative — search, dedup, exports and the registry key are all built on it — and a translation is a **display** concern layered on top.

**Countries and regions only.** Two deliberate exclusions:

- **Appellations.** A protected designation is a legal name. Côte-Rôtie is Côte-Rôtie in every language, and translating one would be inventing a wine law that does not exist.
- **Grapes.** Cabernet Sauvignon does not change language. Where a variety genuinely goes by another name it is a *regional* difference, not a linguistic one — and `models/Grape` already carries `regionalNames` keyed by place for exactly that. (This morning's proposal queue had a live example: "Malvoisie is a legitimate Loire synonym for Pinot Gris.")

## Why a separate endpoint, not a field on every response

Taxonomy names are rendered in about **thirty** components, and most never call a taxonomy route at all — they receive a populated `region` on a wine or a bottle. Adding a localised field would have meant auditing every `.select('name')` and every projection in the codebase.

`GET /api/taxonomy/display-names?lang=fr` instead returns just the entries that *have* a name in that language, keyed by id **and** by canonical name, and the client resolves against it. One small map localises every surface at once, touching no existing query, projection or cache — and a component that has not adopted it renders exactly what it renders today. Nothing regresses by being left alone.

`byId` is the authority (exact); `byName` catches the denormalised places that hold only the canonical string. English returns empty maps without touching the database, because the canonical name already *is* the English name.

## One distinction worth keeping

In `WineRecordSection` the display is localised but the **"currently recorded" value in the suggest-a-fix form is not** — it stays canonical.

A French reader shown "Vallée du Rhône" as the current value would reasonably propose a French correction to it, which is precisely the proposal that led here. Telling him the stored value is "Rhône Valley" is what would have prevented it.

## What is in the box

| | |
|---|---|
| `utils/localizedName.js` | `localizedName` / `baseLanguage` / `sanitizeTranslations`; handles both a Mongoose `Map` and a `.lean()` object, because both reach it |
| `models/Country`, `models/Region` | `translations` Map, `default: undefined` — no migration, nothing to backfill |
| `GET /api/taxonomy/display-names` | public, cached, rate-limited with the rest of the router |
| `PUT /api/admin/taxonomy/:kind/:id/translations` | full replacement (the only shape that can *delete* a wrong translation), audited with before and after, clears the public cache |
| `utils/taxonomyName.js` + `hooks/useTaxonomyNames.js` | client helper and a module-scoped per-language cache — twenty bottle cards issue one request, not twenty |
| `scripts/seed-taxonomy-translations.js` | dry-run by default, **merges rather than clobbers** so a curator's hand-correction survives a re-run |

## Tests

**63 new**, across 6 suites. Backend 292 suites / 4,735 tests pass; frontend 71 files / 1,088 pass. The two red backend suites (`bottles.rackInfo`, `wines.publicScrapeLimit`) are the known pre-existing 5s-timeout pair — red on clean `main`, green on CI.

Adopting the hook initially broke **8** existing `WineRecordSection` tests: component suites here mock `react-i18next` down to just `t`, so `i18n.language` threw. Rather than edit those mocks, the hook falls back to English on a missing `i18n` — a hook that costs a test edit in every component it touches is a hook nobody adopts. There is a regression test naming that.

## Deliberately not included

- **An admin UI** for editing translations. The endpoint exists; the screen does not.
- **Adoption beyond the wine record section.** The other ~29 sites keep showing English until someone passes them the map.

Both are additive, and cheap now that the endpoint and the helper exist.

## Reviewer note

The seeded values are **authored, not community-reviewed**. The tests check what can be checked mechanically — valid shape, no English, no self-translations, only shipped languages — but "Rhôndalen" and "Sydvästra Frankrike" want a native speaker. They are ordinary DB rows rather than Weblate strings, so any of them can be corrected through the admin endpoint without a release.