### PR TITLE
fix(ui): a long URL no longer truncates the whole message it sits in

### DIFF
--- a/frontend/src/pages/AdminSupportTickets.css
+++ b/frontend/src/pages/AdminSupportTickets.css
@@ -216,6 +216,10 @@
   font-size: 0.9rem;
   line-height: 1.6;
   white-space: pre-wrap;
+  /* pre-wrap wraps at spaces but cannot break a single long token. One
+     support reply held a 234-character URL, which widened this block past
+     the card and clipped every other line in it. */
+  overflow-wrap: anywhere;
 }
 
 .admin-support-existing-response {

--- a/frontend/src/pages/AdminWineReports.css
+++ b/frontend/src/pages/AdminWineReports.css
@@ -216,6 +216,10 @@
   font-size: 0.9rem;
   line-height: 1.6;
   white-space: pre-wrap;
+  /* pre-wrap wraps at spaces but cannot break a single long token. One
+     support reply held a 234-character URL, which widened this block past
+     the card and clipped every other line in it. */
+  overflow-wrap: anywhere;
 }
 
 .awr-actions {

--- a/frontend/src/pages/CellarChat.css
+++ b/frontend/src/pages/CellarChat.css
@@ -259,6 +259,10 @@
 
 .cellar-chat__msg--user .cellar-chat__bubble {
   white-space: pre-wrap;
+  /* pre-wrap wraps at spaces but cannot break a single long token. One
+     support reply held a 234-character URL, which widened this block past
+     the card and clipped every other line in it. */
+  overflow-wrap: anywhere;
 }
 
 .cellar-chat__msg--assistant .cellar-chat__bubble {

--- a/frontend/src/pages/SupportPage.css
+++ b/frontend/src/pages/SupportPage.css
@@ -172,6 +172,10 @@
   font-size: 0.9rem;
   line-height: 1.6;
   white-space: pre-wrap;
+  /* pre-wrap wraps at spaces but cannot break a single long token. One
+     support reply held a 234-character URL, which widened this block past
+     the card and clipped every other line in it. */
+  overflow-wrap: anywhere;
 }
 
 .support-response {

--- a/frontend/src/styles/preWrapWordBreak.test.js
+++ b/frontend/src/styles/preWrapWordBreak.test.js
@@ -1,0 +1,94 @@
+/**
+ * Every `white-space: pre-wrap` must be able to break a long word.
+ *
+ * pre-wrap preserves the author's newlines and wraps at spaces — but it cannot
+ * break a single unbreakable token. One support reply contained a
+ * 234-character URL, which widened its block past the card; because the card
+ * clips its overflow, every OTHER line in that block was cut off too, and the
+ * ticket read as truncated nonsense on both mobile and desktop.
+ *
+ * The bug is invisible until someone pastes a long URL, so it cannot be caught
+ * by looking at a screen — which is why it is pinned as a rule about the
+ * stylesheets instead. Four files had pre-wrap without a break rule when this
+ * was written; five already had one, so the codebase knew the pattern and
+ * these had simply drifted from it.
+ *
+ * Anywhere user-supplied or model-generated text is rendered, assume a long
+ * token will eventually arrive in it.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// fileURLToPath, not URL.pathname — on Windows the latter yields "/C:/..."
+// which fs cannot open.
+const SRC = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function cssFiles(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) cssFiles(full, out);
+    else if (entry.endsWith('.css')) out.push(full);
+  }
+  return out;
+}
+
+/** Split a stylesheet into `{ …declarations }` bodies, comments stripped. */
+function declarationBlocks(css) {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  return withoutComments.match(/\{[^{}]*\}/g) || [];
+}
+
+const BREAKS_WORDS = /(overflow-wrap|word-wrap)\s*:\s*(anywhere|break-word)|word-break\s*:\s*(break-word|break-all)/;
+
+describe('pre-wrap always pairs with a word-breaking rule', () => {
+  const files = cssFiles(SRC);
+
+  it('finds stylesheets to check (guards against the glob silently matching nothing)', () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  it('has no declaration block with pre-wrap and no way to break a long token', () => {
+    const offenders = [];
+    for (const file of files) {
+      for (const block of declarationBlocks(readFileSync(file, 'utf8'))) {
+        if (!/white-space\s*:\s*pre-wrap/.test(block)) continue;
+        if (BREAKS_WORDS.test(block)) continue;
+        offenders.push(`${relative(SRC, file)} — ${block.replace(/\s+/g, ' ').slice(0, 80)}`);
+      }
+    }
+    // Named rather than counted, so a failure says which rule to fix.
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('the rule itself', () => {
+  const check = (block) => /white-space\s*:\s*pre-wrap/.test(block) && !BREAKS_WORDS.test(block);
+
+  it('accepts each spelling already used in this codebase', () => {
+    expect(check('{ white-space: pre-wrap; overflow-wrap: anywhere; }')).toBe(false);
+    expect(check('{ white-space: pre-wrap; overflow-wrap: break-word; }')).toBe(false);
+    expect(check('{ white-space: pre-wrap; word-break: break-word; }')).toBe(false);
+    expect(check('{ white-space: pre-wrap; word-wrap: break-word; }')).toBe(false);
+    expect(check('{ white-space: pre-wrap; word-break: break-all; }')).toBe(false);
+  });
+
+  it('flags pre-wrap left on its own', () => {
+    expect(check('{ white-space: pre-wrap; }')).toBe(true);
+    expect(check('{ margin: 0; white-space: pre-wrap; line-height: 1.6; }')).toBe(true);
+  });
+
+  it('does not flag other white-space values, which are not affected', () => {
+    expect(check('{ white-space: nowrap; }')).toBe(false);
+    expect(check('{ white-space: normal; }')).toBe(false);
+  });
+
+  it('is not satisfied by a break rule that only appears in a comment', () => {
+    // declarationBlocks strips comments before this runs; assert the stripping,
+    // since a commented-out fix passing the check would be worse than no check.
+    const css = '.x { white-space: pre-wrap; /* overflow-wrap: anywhere; */ }';
+    const [block] = declarationBlocks(css);
+    expect(check(block)).toBe(true);
+  });
+});


### PR DESCRIPTION
Reported from a phone, with the note that it happens on desktop too — which is the clue that it was never a mobile problem.

## What is actually wrong

`white-space: pre-wrap` preserves the author's line breaks and wraps at spaces, but it **cannot break a single long token**.

The reply thread in the screenshot — the "alternative rack layout" ticket — contains a **234-character** DuckDuckGo image-search URL:

```
https://duckduckgo.com/?q=indeling+liebherr+5001+grand+cru+flessen&ia=images&iax=images&ia…
```

That one token widens the paragraph's box past the card. Because `.support-card` clips its overflow, **every other line in the block is cut at the same edge** — so the message reads as truncated nonsense rather than as one over-long link. The user's own text wraps perfectly well; its longest word is 14 characters.

It looked intermittent because it needs someone to paste a long URL. **17** ticket messages and replies currently carry a token of 40+ characters, so it will keep happening.

## Scope

Four stylesheets set `pre-wrap` with nothing able to break a word, and all four render text somebody else wrote:

| File | Renders |
|---|---|
| `SupportPage.css` | the reported screen |
| `AdminSupportTickets.css` | the admin view of the same threads — the desktop case |
| `AdminWineReports.css` | user-submitted wine reports |
| `CellarChat.css` | AI chat output |

Five other stylesheets (`ReplyCard`, `DiscussionDetail`, `AdminModerationReports`, `AdminBlogEditor`, `ImportBottles`) already carry the rule. So this was drift from a pattern the codebase already had, not a decision.

## The property

`overflow-wrap: anywhere` rather than `break-word`. Both break a token only when it would not otherwise fit; the difference is that `anywhere` also shrinks the block's **min-content width**. That is the part that matters here — it is the widened box, not the long word itself, that clips the neighbouring lines.

## The guard

This bug is invisible until the wrong URL arrives, so no screenshot review would have caught it and no rendered-DOM test would either. The regression test is therefore a rule about the stylesheets: it walks every CSS file, and fails on any declaration block that sets `pre-wrap` without `overflow-wrap`/`word-wrap`/`word-break` able to break a word — listing the offenders by path so a failure says what to fix.

Verified the guard is real by reverting the four fixes and confirming it names all four. It also asserts it finds a plausible number of stylesheets, so the walk cannot silently match nothing, and that a break rule sitting inside a comment does not satisfy it.

Frontend suite: 72 files / 1,095 tests pass.