### PR TITLE
feat(cellars): hand a cellar over to someone else, and stay on as editor

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,101 @@
+# Security Policy
+
+Cellarion is a self-hosted wine cellar manager, published under AGPL-3.0. This
+document says how to report a vulnerability, what happens next, and what our
+security posture actually is — including where it falls short.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Use GitHub's private vulnerability reporting, which is enabled on this
+repository:
+
+**https://github.com/jagduvi1/Cellarion/security/advisories/new**
+
+If you cannot use GitHub, email **info@cellarion.app** with "SECURITY" in the
+subject line.
+
+Helpful to include, though none of it is required — a report you are unsure
+about is still worth sending:
+
+- what the issue is, and what an attacker gains from it
+- the steps to reproduce it, or a proof of concept
+- the version or commit you tested, and whether it was hosted or self-hosted
+- anything you think we would get wrong about it
+
+### What happens next
+
+| | |
+|---|---|
+| Acknowledgement | within **3 working days** |
+| Initial assessment | within **7 days** — whether we can reproduce it, and how serious we think it is |
+| Fix for a confirmed serious issue | as fast as we can; you will get progress updates rather than silence |
+| Credit | named in the advisory and release notes if you want it, anonymous if you prefer |
+
+We will tell you plainly if we think a report is not a vulnerability, and why —
+you are welcome to argue with the reasoning.
+
+Cellarion is maintained by one person. That means reports are read by a human
+who can act on them immediately, and it also means please allow for time zones
+and sleep. If something is being actively exploited, say so prominently and it
+will jump the queue.
+
+### Scope
+
+In scope: this repository, and the hosted service at **cellarion.app**.
+
+Out of scope, unless you can show real impact: reports produced solely by an
+automated scanner with no working proof of concept; missing headers or
+best-practice warnings with no demonstrable exploit; denial of service by volume;
+social engineering; vulnerabilities in third-party services we consume.
+
+Please do not test against other people's data on the hosted service. Register
+your own account, or run it locally with `docker-compose up` — the whole point of
+this being open source is that you can.
+
+### Safe harbour
+
+If you make a good-faith effort to follow this policy, we will not pursue or
+support legal action against you for your research. If you are unsure whether
+something is acceptable, ask first.
+
+## Our security posture
+
+Stated plainly so you can judge it yourself rather than take our word for it —
+and because the code is public, you can verify all of it.
+
+**What we do**
+
+- All traffic over HTTPS. No database or internal service is reachable from the
+  internet; only the web front end is exposed.
+- Passwords hashed with bcrypt, never stored recoverably.
+- Short-lived JWT access tokens with rotating, httpOnly refresh cookies.
+- Role-based access control on every cellar and bottle route.
+- Extensive audit logging of significant mutations.
+- Rate limiting on authentication, writes and public endpoints.
+- Servers in the EU (Finland). Backups encrypted and stored off-site, with the
+  restore path tested rather than assumed.
+- Automatic security updates on the host; dependency alerts via Dependabot.
+- Full data export and account deletion, for GDPR portability and erasure.
+
+**What we do not do**
+
+- **The database volume is not currently encrypted at rest.** Backups are; the
+  live volume is not. We are changing this.
+- **No multi-factor authentication.** Accounts using Google sign-in inherit that
+  provider's MFA; there is no native second factor.
+- **No third-party security audit, and no ISO 27001 or SOC 2 certification.** We
+  run our own reviews regularly and fix what they find, but nobody independent
+  has signed off on it. If you need certified assurance, we cannot give you that
+  today.
+- **The operator can read the database.** There is no screen in the product that
+  lets an administrator browse someone's cellar, but whoever runs the server has
+  database access. If that is unacceptable for your data, self-host it — that is
+  what the licence is for.
+
+## Supported versions
+
+Security fixes are applied to the **latest release**, which is also what runs on
+cellarion.app. There are no long-term support branches. If you self-host, staying
+current is the way to stay patched.

--- a/backend/src/models/Notification.js
+++ b/backend/src/models/Notification.js
@@ -28,6 +28,7 @@ const notificationSchema = new mongoose.Schema({
       'image_approved',
       'image_rejected',
       'cellar_shared',
+      'cellar_ownership_received',
       'support_ticket_response',
       'new_follower',
       'discussion_reply',

--- a/backend/src/models/Notification.typesUsed.test.js
+++ b/backend/src/models/Notification.typesUsed.test.js
@@ -1,0 +1,83 @@
+/**
+ * Every notification type the code SENDS must exist in the model's enum.
+ *
+ * The failure this pins is perfectly silent: createNotifications catches the
+ * insertMany validation error and logs it, so a type missing from the enum
+ * does not crash anything — the notification is simply never delivered, and
+ * the feature that sent it looks finished. Found the day cellar ownership
+ * transfer was built: its 'cellar_ownership_received' notification validated
+ * against nothing and would have reached nobody.
+ *
+ * A static sweep, not a runtime test, because the bug is in the gap between
+ * two files that are each individually correct.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SRC = path.join(__dirname, '..');
+
+function jsFiles(dir, out = []) {
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (fs.statSync(full).isDirectory()) jsFiles(full, out);
+    else if (entry.endsWith('.js') && !entry.endsWith('.test.js')) out.push(full);
+  }
+  return out;
+}
+
+/** The enum, read from the schema itself rather than re-declared here. */
+function enumTypes() {
+  const Notification = require('./Notification');
+  return new Set(Notification.schema.path('type').enumValues);
+}
+
+/**
+ * Literal types passed to createNotification(userId, 'type', …) or built into
+ * createNotifications items as `type: '…'`. Only string literals are checkable
+ * statically; a computed type is out of scope and rare.
+ */
+function usedTypes(files) {
+  const used = new Map(); // type -> first file using it
+  for (const file of files) {
+    const src = fs.readFileSync(file, 'utf8');
+    if (!src.includes('createNotification')) continue;
+    // createNotification(<arg1>, '<type>'
+    for (const m of src.matchAll(/createNotification\s*\(\s*[^,()]+,\s*'([a-z0-9_]+)'/g)) {
+      if (!used.has(m[1])) used.set(m[1], path.relative(SRC, file));
+    }
+    // Batch items. A notification literal pairs `type:` with a `title:` right
+    // after it; logAudit's resource descriptor pairs it with `id:` instead —
+    // and the first draft of this regex flagged four logAudit descriptors as
+    // missing notification types. The `title` neighbour is the discriminator.
+    if (src.includes('createNotifications')) {
+      for (const m of src.matchAll(/\btype:\s*'([a-z0-9_]+)',\s*\n?\s*title:/g)) {
+        if (!used.has(m[1])) used.set(m[1], path.relative(SRC, file));
+      }
+    }
+  }
+  return used;
+}
+
+describe('notification types', () => {
+  const files = jsFiles(SRC).filter((f) => !f.includes(`${path.sep}models${path.sep}`));
+  const used = usedTypes(files);
+  const known = enumTypes();
+
+  test('the sweep finds a plausible number of send sites (guards the regexes)', () => {
+    expect(used.size).toBeGreaterThan(10);
+    // A known long-standing pair as a canary for the extraction itself:
+    expect(used.has('wine_request_rejected')).toBe(true);
+    expect(used.has('cellar_shared')).toBe(true);
+  });
+
+  test('every type the code sends exists in the enum', () => {
+    const missing = [...used.entries()]
+      .filter(([type]) => !known.has(type))
+      .map(([type, file]) => `${type} (sent from ${file})`);
+    expect(missing).toEqual([]);
+  });
+
+  test('the transfer notification specifically survives model validation', () => {
+    expect(known.has('cellar_ownership_received')).toBe(true);
+  });
+});

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -15,6 +15,7 @@ const { logAudit } = require('../services/audit');
 const { createCellar } = require('../services/rackOps');
 const { getSnapshotsForDates, getOrCreateDailySnapshot, convertCurrency } = require('../utils/exchangeRates');
 const { createNotification } = require('../services/notifications');
+const { transferCellarOwnership } = require('../services/cellarTransfer');
 const { sendCellarInviteEmail } = require('../services/mailgun');
 const { toNormalized } = require('../utils/ratingUtils');
 const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
@@ -1742,6 +1743,58 @@ router.get('/:id/audit', async (req, res) => {
   } catch (error) {
     console.error('Get cellar audit error:', error);
     res.status(500).json({ error: 'Failed to get audit log' });
+  }
+});
+
+// POST /:id/transfer-ownership — hand the cellar to another member.
+//
+// The outgoing owner stays on as an editor, which is the point: the workflow
+// this serves is "build it for someone, then give it to them and keep helping".
+// requireNonDemo because the demo account must not be able to hand its cellar
+// to a real user, nor a real user park a cellar on it.
+router.post('/:id/transfer-ownership', requireNonDemo, async (req, res) => {
+  try {
+    if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
+    const { newOwnerId } = req.body || {};
+    if (!newOwnerId || !isValidId(newOwnerId)) {
+      return res.status(400).json({ error: 'newOwnerId is required' });
+    }
+
+    const result = await transferCellarOwnership(req.params.id, newOwnerId, req.user.id);
+
+    logAudit(
+      req,
+      'cellar.transferOwnership',
+      { type: 'cellar', id: result.cellar._id, cellarId: result.cellar._id },
+      {
+        name: result.cellar.name,
+        from: result.previousOwner,
+        to: result.newOwner,
+        bottlesMoved: result.bottlesMoved,
+        racksMoved: result.racksMoved,
+      },
+    );
+
+    // The recipient did not ask for this at the moment it happened, so tell
+    // them plainly what they now hold and what it cost the other party.
+    createNotification(
+      result.newOwner,
+      'cellar_ownership_received',
+      'You now own a cellar',
+      `"${result.cellar.name}" has been transferred to you, with ${result.bottlesMoved} bottle(s). The previous owner remains an editor.`,
+      `/cellars/${result.cellar._id}`,
+    );
+
+    res.json({
+      cellar: { _id: result.cellar._id, name: result.cellar.name, user: result.cellar.user },
+      bottlesMoved: result.bottlesMoved,
+      racksMoved: result.racksMoved,
+      newOwner: { _id: result.newOwner, username: result.newOwnerName },
+    });
+  } catch (err) {
+    if (err.status) return res.status(err.status).json({ error: err.message });
+    console.error('Transfer cellar ownership error:', err);
+    res.status(500).json({ error: 'Failed to transfer ownership' });
   }
 });
 

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -1783,7 +1783,7 @@ router.post('/:id/transfer-ownership', requireNonDemo, async (req, res) => {
       'You now own a cellar',
       `"${result.cellar.name}" has been transferred to you, with ${result.bottlesMoved} bottle(s). The previous owner remains an editor.`,
       `/cellars/${result.cellar._id}`,
-    );
+    ).catch((err) => console.error('[cellars] transfer notification failed:', err.message));
 
     res.json({
       cellar: { _id: result.cellar._id, name: result.cellar.name, user: result.cellar.user },

--- a/backend/src/services/cellarTransfer.js
+++ b/backend/src/services/cellarTransfer.js
@@ -1,0 +1,122 @@
+/**
+ * Cellar ownership transfer — hand a cellar, its bottles and its racks to
+ * another account, keeping the outgoing owner on as an editor.
+ *
+ * WHY THIS EXISTS (#1055-adjacent; asked for by a professional managing client
+ * cellars, 2026-09-01). The workflow it unblocks: someone builds a cellar
+ * completely under their own account — import, racks, placement — and then
+ * hands it to the person who actually owns the wine, staying on as an editor to
+ * keep adding stock. Without transfer, the choice was to own your client's data
+ * for ever or to make the client do the setup themselves.
+ *
+ * WHY IT MOVES THREE COLLECTIONS, NOT ONE
+ *
+ * `user` on Cellar, Bottle and Rack each independently means "whose is this",
+ * and — the part that makes a half-transfer dangerous — account deletion purges
+ * all three BY THAT FIELD (services/userDataRegistry). Move only the cellar and
+ * you leave the new owner holding bottles that are still scheduled to be
+ * destroyed when the previous owner closes their account. So a transfer that
+ * does not move the bottles is not a transfer; it is a time bomb.
+ *
+ * WHAT DELIBERATELY DOES NOT MOVE
+ *
+ * Anything authored BY a person rather than owned WITH the cellar: journal
+ * entries, reviews, wishlist items, wine lists, import sessions and archives
+ * (they are the record of who imported what — provenance, not property),
+ * uploaded-image attribution, and value snapshots. Those belong to whoever
+ * wrote them and stay put.
+ *
+ * ORDERING, BECAUSE THERE ARE NO TRANSACTIONS
+ *
+ * Production MongoDB is standalone, so there is no multi-document transaction
+ * to hide behind. The order below is the safety mechanism:
+ *
+ *   1. bottles   2. racks   3. the cellar itself, LAST
+ *
+ * The cellar flips last because until it does, the outgoing owner still owns
+ * everything and a failed run is simply retried. Flip the cellar first and a
+ * failure at step 2 leaves the new owner owning a cellar whose bottles still
+ * purge with the old owner's account — precisely the state this exists to
+ * prevent. Every step is an idempotent `updateMany` keyed on the OLD owner, so
+ * re-running a partial transfer completes it and re-running a finished one does
+ * nothing.
+ */
+
+const Cellar = require('../models/Cellar');
+const Bottle = require('../models/Bottle');
+const Rack = require('../models/Rack');
+const User = require('../models/User');
+
+/** An error the route can turn straight into a status code. */
+function fail(status, message) {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+}
+
+/**
+ * Move ownership of a cellar to another account.
+ *
+ * @param {string} cellarId
+ * @param {string} newOwnerId  must already be a member of the cellar
+ * @param {string} actorId     must be the current owner
+ * @returns {Promise<{cellar: object, bottlesMoved: number, racksMoved: number,
+ *                    previousOwner: string, newOwner: string}>}
+ */
+async function transferCellarOwnership(cellarId, newOwnerId, actorId) {
+  const cellar = await Cellar.findOne({ _id: cellarId, deletedAt: null });
+  if (!cellar) throw fail(404, 'Cellar not found');
+
+  const currentOwner = String(cellar.user);
+  if (currentOwner !== String(actorId)) {
+    throw fail(403, 'Only the cellar owner can transfer ownership');
+  }
+  if (currentOwner === String(newOwnerId)) {
+    throw fail(400, 'That account already owns this cellar');
+  }
+
+  // The recipient must already be a member. This is the consent step: someone
+  // cannot be handed responsibility for a stranger's wine collection — and its
+  // storage costs, and its GDPR position — without having been invited to it
+  // first. It also guarantees the recipient is a real, registered account.
+  const isMember = (cellar.members || []).some((m) => String(m.user) === String(newOwnerId));
+  if (!isMember) {
+    throw fail(400, 'The new owner must already be a member of this cellar');
+  }
+
+  const newOwner = await User.findById(newOwnerId).select('_id username email').lean();
+  if (!newOwner) throw fail(404, 'New owner account not found');
+
+  // ── 1. Bottles. Soft-deleted ones included on purpose: they are restorable,
+  //       and the deletion cascade would take them too.
+  const bottles = await Bottle.updateMany(
+    { cellar: cellar._id, user: currentOwner },
+    { $set: { user: newOwner._id } },
+  );
+
+  // ── 2. Racks, same reasoning.
+  const racks = await Rack.updateMany(
+    { cellar: cellar._id, user: currentOwner },
+    { $set: { user: newOwner._id } },
+  );
+
+  // ── 3. The cellar itself, last.
+  //       The outgoing owner becomes an editor so they keep working access —
+  //       the whole point of the professional workflow — and the incoming owner
+  //       leaves the member list, because owner is not a membership row.
+  cellar.members = (cellar.members || []).filter((m) => String(m.user) !== String(newOwner._id));
+  cellar.members.push({ user: currentOwner, role: 'editor', addedAt: new Date() });
+  cellar.user = newOwner._id;
+  await cellar.save();
+
+  return {
+    cellar,
+    bottlesMoved: bottles.modifiedCount || 0,
+    racksMoved: racks.modifiedCount || 0,
+    previousOwner: currentOwner,
+    newOwner: String(newOwner._id),
+    newOwnerName: newOwner.username,
+  };
+}
+
+module.exports = { transferCellarOwnership };

--- a/backend/src/services/cellarTransfer.js
+++ b/backend/src/services/cellarTransfer.js
@@ -104,7 +104,12 @@ async function transferCellarOwnership(cellarId, newOwnerId, actorId) {
   //       The outgoing owner becomes an editor so they keep working access —
   //       the whole point of the professional workflow — and the incoming owner
   //       leaves the member list, because owner is not a membership row.
-  cellar.members = (cellar.members || []).filter((m) => String(m.user) !== String(newOwner._id));
+  // Also drop any stray row for the CURRENT owner: owner was never a
+  // membership row, but if a data anomaly ever put one there, pushing below
+  // would duplicate it.
+  cellar.members = (cellar.members || []).filter(
+    (m) => String(m.user) !== String(newOwner._id) && String(m.user) !== currentOwner,
+  );
   cellar.members.push({ user: currentOwner, role: 'editor', addedAt: new Date() });
   cellar.user = newOwner._id;
   await cellar.save();

--- a/backend/src/services/cellarTransfer.test.js
+++ b/backend/src/services/cellarTransfer.test.js
@@ -1,0 +1,197 @@
+/**
+ * Cellar ownership transfer.
+ *
+ * The failure this guards is silent and delayed: `user` on Cellar, Bottle and
+ * Rack each mean "whose is this", and account deletion purges all three BY THAT
+ * FIELD. A transfer that moves only the cellar therefore hands someone a
+ * collection that is still scheduled for destruction when the previous owner
+ * closes their account — and nothing looks wrong until that day. So the tests
+ * that matter are about what moves, and in what order.
+ */
+
+const mockBottleUpdateMany = jest.fn();
+const mockRackUpdateMany = jest.fn();
+const mockCellarFindOne = jest.fn();
+const mockUserFindById = jest.fn();
+
+jest.mock('../models/Cellar', () => ({ findOne: (...a) => mockCellarFindOne(...a) }));
+jest.mock('../models/Bottle', () => ({ updateMany: (...a) => mockBottleUpdateMany(...a) }));
+jest.mock('../models/Rack', () => ({ updateMany: (...a) => mockRackUpdateMany(...a) }));
+jest.mock('../models/User', () => ({ findById: (...a) => mockUserFindById(...a) }));
+
+const { transferCellarOwnership } = require('./cellarTransfer');
+
+const OWNER = '64b000000000000000000001';
+const CLIENT = '64b000000000000000000002';
+const STRANGER = '64b000000000000000000003';
+const CELLAR = '64b0000000000000000000c1';
+
+/** A saveable cellar stub that records when save() happened. */
+function cellarStub(over = {}, order = []) {
+  return {
+    _id: CELLAR,
+    name: "Client's Cellar",
+    user: OWNER,
+    deletedAt: null,
+    members: [{ user: CLIENT, role: 'editor', addedAt: new Date() }],
+    save: jest.fn(async () => { order.push('cellar'); }),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockBottleUpdateMany.mockResolvedValue({ modifiedCount: 0 });
+  mockRackUpdateMany.mockResolvedValue({ modifiedCount: 0 });
+  mockUserFindById.mockReturnValue({ select: () => ({ lean: async () => ({ _id: CLIENT, username: 'client', email: 'c@example.com' }) }) });
+});
+
+describe('what moves', () => {
+  test('the bottles move, or the new owner inherits a deletion cascade', async () => {
+    mockCellarFindOne.mockResolvedValue(cellarStub());
+    mockBottleUpdateMany.mockResolvedValue({ modifiedCount: 214 });
+    const res = await transferCellarOwnership(CELLAR, CLIENT, OWNER);
+
+    expect(mockBottleUpdateMany).toHaveBeenCalledWith(
+      { cellar: CELLAR, user: OWNER },
+      { $set: { user: CLIENT } },
+    );
+    expect(res.bottlesMoved).toBe(214);
+  });
+
+  test('the racks move too', async () => {
+    mockCellarFindOne.mockResolvedValue(cellarStub());
+    mockRackUpdateMany.mockResolvedValue({ modifiedCount: 6 });
+    const res = await transferCellarOwnership(CELLAR, CLIENT, OWNER);
+
+    expect(mockRackUpdateMany).toHaveBeenCalledWith(
+      { cellar: CELLAR, user: OWNER },
+      { $set: { user: CLIENT } },
+    );
+    expect(res.racksMoved).toBe(6);
+  });
+
+  test('bottles and racks are matched on the OLD owner, so a re-run is a no-op', async () => {
+    // Idempotency is the only recovery mechanism available: production Mongo is
+    // standalone, so a partial transfer cannot be rolled back, only completed.
+    const cellar = cellarStub();
+    mockCellarFindOne.mockResolvedValue(cellar);
+    await transferCellarOwnership(CELLAR, CLIENT, OWNER);
+    const [bottleFilter] = mockBottleUpdateMany.mock.calls[0];
+    expect(bottleFilter.user).toBe(OWNER);
+  });
+
+  test('the cellar ends up owned by the new owner', async () => {
+    const cellar = cellarStub();
+    mockCellarFindOne.mockResolvedValue(cellar);
+    await transferCellarOwnership(CELLAR, CLIENT, OWNER);
+    expect(String(cellar.user)).toBe(CLIENT);
+    expect(cellar.save).toHaveBeenCalled();
+  });
+});
+
+describe('ordering — the cellar flips LAST', () => {
+  test('bottles and racks are rewritten before the cellar changes hands', async () => {
+    // Flip the cellar first and a failure at the bottle step leaves the new
+    // owner holding bottles that still purge with the old owner's account.
+    const order = [];
+    mockBottleUpdateMany.mockImplementation(async () => { order.push('bottles'); return { modifiedCount: 1 }; });
+    mockRackUpdateMany.mockImplementation(async () => { order.push('racks'); return { modifiedCount: 1 }; });
+    mockCellarFindOne.mockResolvedValue(cellarStub({}, order));
+
+    await transferCellarOwnership(CELLAR, CLIENT, OWNER);
+    expect(order).toEqual(['bottles', 'racks', 'cellar']);
+  });
+
+  test('a failure moving bottles leaves ownership untouched', async () => {
+    const cellar = cellarStub();
+    mockCellarFindOne.mockResolvedValue(cellar);
+    mockBottleUpdateMany.mockRejectedValue(new Error('mongo went away'));
+
+    await expect(transferCellarOwnership(CELLAR, CLIENT, OWNER)).rejects.toThrow('mongo went away');
+    expect(String(cellar.user)).toBe(OWNER);   // still theirs — retry is safe
+    expect(cellar.save).not.toHaveBeenCalled();
+  });
+});
+
+describe('membership after the handover', () => {
+  test('the outgoing owner stays on as an editor', async () => {
+    // The entire professional workflow depends on this: build it, hand it over,
+    // keep adding stock.
+    const cellar = cellarStub();
+    mockCellarFindOne.mockResolvedValue(cellar);
+    await transferCellarOwnership(CELLAR, CLIENT, OWNER);
+
+    const outgoing = cellar.members.find((m) => String(m.user) === OWNER);
+    expect(outgoing).toBeDefined();
+    expect(outgoing.role).toBe('editor');
+  });
+
+  test('the incoming owner is removed from the member list — owner is not a membership row', async () => {
+    const cellar = cellarStub();
+    mockCellarFindOne.mockResolvedValue(cellar);
+    await transferCellarOwnership(CELLAR, CLIENT, OWNER);
+    expect(cellar.members.some((m) => String(m.user) === CLIENT)).toBe(false);
+  });
+
+  test('other members are left alone', async () => {
+    const cellar = cellarStub({
+      members: [
+        { user: CLIENT, role: 'editor', addedAt: new Date() },
+        { user: STRANGER, role: 'viewer', addedAt: new Date() },
+      ],
+    });
+    mockCellarFindOne.mockResolvedValue(cellar);
+    await transferCellarOwnership(CELLAR, CLIENT, OWNER);
+    const kept = cellar.members.find((m) => String(m.user) === STRANGER);
+    expect(kept).toBeDefined();
+    expect(kept.role).toBe('viewer');
+  });
+});
+
+describe('who may do it, and to whom', () => {
+  test('only the owner can transfer', async () => {
+    mockCellarFindOne.mockResolvedValue(cellarStub());
+    await expect(transferCellarOwnership(CELLAR, CLIENT, STRANGER))
+      .rejects.toMatchObject({ status: 403 });
+    expect(mockBottleUpdateMany).not.toHaveBeenCalled();
+  });
+
+  test('the recipient must already be a member', async () => {
+    // The consent step: nobody is handed a stranger's collection — and its
+    // storage cost and GDPR position — without having been invited first.
+    mockCellarFindOne.mockResolvedValue(cellarStub());
+    await expect(transferCellarOwnership(CELLAR, STRANGER, OWNER))
+      .rejects.toMatchObject({ status: 400, message: 'The new owner must already be a member of this cellar' });
+    expect(mockBottleUpdateMany).not.toHaveBeenCalled();
+  });
+
+  test('transferring to yourself is refused', async () => {
+    mockCellarFindOne.mockResolvedValue(cellarStub());
+    await expect(transferCellarOwnership(CELLAR, OWNER, OWNER))
+      .rejects.toMatchObject({ status: 400 });
+  });
+
+  test('a missing cellar is a 404, and nothing is written', async () => {
+    mockCellarFindOne.mockResolvedValue(null);
+    await expect(transferCellarOwnership(CELLAR, CLIENT, OWNER))
+      .rejects.toMatchObject({ status: 404 });
+    expect(mockBottleUpdateMany).not.toHaveBeenCalled();
+  });
+
+  test('a soft-deleted cellar cannot be transferred', async () => {
+    // findOne is called with deletedAt: null, so a deleted cellar simply is not
+    // found — pinned because "transfer the thing I just deleted" is a plausible
+    // support request and the answer must be no.
+    mockCellarFindOne.mockResolvedValue(null);
+    await expect(transferCellarOwnership(CELLAR, CLIENT, OWNER)).rejects.toMatchObject({ status: 404 });
+    expect(mockCellarFindOne).toHaveBeenCalledWith({ _id: CELLAR, deletedAt: null });
+  });
+
+  test('a member whose account has since vanished is a 404', async () => {
+    mockCellarFindOne.mockResolvedValue(cellarStub());
+    mockUserFindById.mockReturnValue({ select: () => ({ lean: async () => null }) });
+    await expect(transferCellarOwnership(CELLAR, CLIENT, OWNER)).rejects.toMatchObject({ status: 404 });
+    expect(mockBottleUpdateMany).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/cellars.js
+++ b/frontend/src/api/cellars.js
@@ -38,3 +38,12 @@ export const updateCellarColor = (apiFetch, id, color) =>
     headers: JSON_HEADERS,
     body: JSON.stringify({ color }),
   });
+
+// Hand the cellar to another member. The outgoing owner stays on as an editor,
+// so the "build it for someone, then give it to them" workflow keeps working.
+export const transferCellarOwnership = (apiFetch, id, newOwnerId) =>
+  apiFetch(`/api/cellars/${id}/transfer-ownership`, {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ newOwnerId }),
+  });

--- a/frontend/src/components/ShareCellarModal.css
+++ b/frontend/src/components/ShareCellarModal.css
@@ -265,3 +265,66 @@
     justify-content: flex-end;
   }
 }
+
+/* ── Ownership transfer ─────────────────────────────────────────────────── */
+
+.btn-transfer-owner {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.btn-transfer-owner:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+/* Giving a cellar away is not a routine action — the confirm step takes the
+   full row and states the consequence before offering the button. */
+.share-transfer-confirm {
+  flex-basis: 100%;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-warning-border, var(--color-border));
+  background: var(--color-warning-bg, var(--color-surface-raised));
+  border-radius: var(--radius-sm);
+}
+
+.share-transfer-warning {
+  margin: 0 0 8px;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.share-transfer-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.btn-transfer-owner--confirm {
+  border-color: var(--color-danger);
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+.btn-transfer-owner--confirm:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.btn-transfer-cancel {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}

--- a/frontend/src/components/ShareCellarModal.js
+++ b/frontend/src/components/ShareCellarModal.js
@@ -161,7 +161,7 @@ function ShareCellarModal({ cellarId, cellarName, onClose }) {
           </p>
           <p className="share-role-hint">
             {t('shareCellar.transferHint',
-              'You can also hand a cellar over entirely: "Make owner" transfers it, along with its bottles and racks, to that person. You stay on as an editor.')}
+              'You can also hand a cellar over entirely: "Make owner" transfers it, along with its bottles and racks, to that person. You stay on as an editor — but you cannot take it back.')}
           </p>
         </form>
 
@@ -192,15 +192,34 @@ function ShareCellarModal({ cellarId, cellarName, onClose }) {
                       Remove
                     </button>
                     {confirmTransfer === m.user._id ? (
-                      <button
-                        className="btn-transfer-owner btn-transfer-owner--confirm"
-                        onClick={() => handleTransfer(m.user._id)}
-                        disabled={transferring}
-                      >
-                        {transferring
-                          ? t('shareCellar.transferring', 'Transferring…')
-                          : t('shareCellar.transferConfirm', 'Confirm — give away this cellar')}
-                      </button>
+                      <div className="share-transfer-confirm">
+                        <p className="share-transfer-warning">
+                          {t('shareCellar.transferWarning',
+                            'You cannot undo this yourself — afterwards only the new owner can transfer it back. Export a copy first if you want your own record of this cellar.')}
+                          {' '}
+                          <a href="/export-cellar" target="_blank" rel="noopener noreferrer">
+                            {t('shareCellar.transferExportLink', 'Export this cellar')}
+                          </a>
+                        </p>
+                        <div className="share-transfer-actions">
+                          <button
+                            className="btn-transfer-owner btn-transfer-owner--confirm"
+                            onClick={() => handleTransfer(m.user._id)}
+                            disabled={transferring}
+                          >
+                            {transferring
+                              ? t('shareCellar.transferring', 'Transferring…')
+                              : t('shareCellar.transferConfirm', 'Confirm — give away this cellar')}
+                          </button>
+                          <button
+                            className="btn-transfer-cancel"
+                            onClick={() => setConfirmTransfer(null)}
+                            disabled={transferring}
+                          >
+                            {t('shareCellar.transferCancel', 'Cancel')}
+                          </button>
+                        </div>
+                      </div>
                     ) : (
                       <button
                         className="btn-transfer-owner"

--- a/frontend/src/components/ShareCellarModal.js
+++ b/frontend/src/components/ShareCellarModal.js
@@ -1,10 +1,18 @@
 import { useState, useEffect, useId } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
+import { transferCellarOwnership } from '../api/cellars';
 import { useDialogA11y } from '../utils/useDialogA11y';
 import './ShareCellarModal.css';
 
 function ShareCellarModal({ cellarId, cellarName, onClose }) {
   const { apiFetch } = useAuth();
+  const { t } = useTranslation();
+  // Two-step rather than window.confirm: handing over a cellar is not something
+  // to do on a mis-click, and a native confirm is neither styleable nor
+  // reliably announced to a screen reader.
+  const [confirmTransfer, setConfirmTransfer] = useState(null);
+  const [transferring, setTransferring] = useState(false);
   const [members, setMembers] = useState([]);
   const [email, setEmail] = useState('');
   const [role, setRole] = useState('viewer');
@@ -91,6 +99,28 @@ function ShareCellarModal({ cellarId, cellarName, onClose }) {
     }
   };
 
+  const handleTransfer = async (userId) => {
+    setTransferring(true);
+    setError(null);
+    try {
+      const res = await transferCellarOwnership(apiFetch, cellarId, userId);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || t('shareCellar.transferFailed', 'Failed to transfer ownership'));
+        return;
+      }
+      // Ownership is gone, so this modal's own controls no longer apply to us.
+      // Reloading is blunt but honest: every screen behind it is now showing a
+      // cellar we merely edit.
+      window.location.reload();
+    } catch {
+      setError(t('shareCellar.transferFailed', 'Failed to transfer ownership'));
+    } finally {
+      setTransferring(false);
+      setConfirmTransfer(null);
+    }
+  };
+
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="share-modal" onClick={e => e.stopPropagation()} ref={boxRef} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1}>
@@ -129,6 +159,10 @@ function ShareCellarModal({ cellarId, cellarName, onClose }) {
             <strong>Viewer</strong> — can browse bottles and racks.{' '}
             <strong>Editor</strong> — can also add and remove bottles.
           </p>
+          <p className="share-role-hint">
+            {t('shareCellar.transferHint',
+              'You can also hand a cellar over entirely: "Make owner" transfers it, along with its bottles and racks, to that person. You stay on as an editor.')}
+          </p>
         </form>
 
         {members.length > 0 && (
@@ -157,6 +191,25 @@ function ShareCellarModal({ cellarId, cellarName, onClose }) {
                     >
                       Remove
                     </button>
+                    {confirmTransfer === m.user._id ? (
+                      <button
+                        className="btn-transfer-owner btn-transfer-owner--confirm"
+                        onClick={() => handleTransfer(m.user._id)}
+                        disabled={transferring}
+                      >
+                        {transferring
+                          ? t('shareCellar.transferring', 'Transferring…')
+                          : t('shareCellar.transferConfirm', 'Confirm — give away this cellar')}
+                      </button>
+                    ) : (
+                      <button
+                        className="btn-transfer-owner"
+                        onClick={() => setConfirmTransfer(m.user._id)}
+                        aria-label={`Make ${m.user.username} the owner of this cellar`}
+                      >
+                        {t('shareCellar.transfer', 'Make owner')}
+                      </button>
+                    )}
                   </div>
                 </li>
               ))}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4544,6 +4544,9 @@
     "transferConfirm": "Confirm — give away this cellar",
     "transferring": "Transferring…",
     "transferFailed": "Failed to transfer ownership",
-    "transferHint": "You can also hand a cellar over entirely: \"Make owner\" transfers it, along with its bottles and racks, to that person. You stay on as an editor."
+    "transferHint": "You can also hand a cellar over entirely: \"Make owner\" transfers it, along with its bottles and racks, to that person. You stay on as an editor — but you cannot take it back.",
+    "transferWarning": "You cannot undo this yourself — afterwards only the new owner can transfer it back. Export a copy first if you want your own record of this cellar.",
+    "transferExportLink": "Export this cellar",
+    "transferCancel": "Cancel"
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4538,5 +4538,12 @@
       "offensive": "Offensive",
       "other": "Something else"
     }
+  },
+  "shareCellar": {
+    "transfer": "Make owner",
+    "transferConfirm": "Confirm — give away this cellar",
+    "transferring": "Transferring…",
+    "transferFailed": "Failed to transfer ownership",
+    "transferHint": "You can also hand a cellar over entirely: \"Make owner\" transfers it, along with its bottles and racks, to that person. You stay on as an editor."
   }
 }

--- a/frontend/src/pages/PrivacyPolicy.js
+++ b/frontend/src/pages/PrivacyPolicy.js
@@ -142,8 +142,16 @@ function PrivacyPolicy() {
         <p>
           All data is transmitted over HTTPS. Passwords are hashed with bcrypt (10 salt rounds)
           and never stored in plain text. Authentication uses short-lived JWT access tokens (15 minutes)
-          and secure, httpOnly refresh token cookies. We use industry-standard security practices
-          to protect your data at rest and in transit.
+          and secure, httpOnly refresh token cookies.
+        </p>
+        <p>
+          Being specific about storage, because vague wording here helps nobody: our
+          servers are in the EU (Finland), and neither the database nor any internal
+          service is reachable from the internet — only the web front end is exposed.
+          Backups are encrypted and held off-site. The database volume itself is not
+          currently encrypted at rest; we are changing that. If that matters for your
+          situation, Cellarion is open source and can be self-hosted on infrastructure
+          you control.
         </p>
 
         <h2>7. Data retention</h2>


### PR DESCRIPTION
Asked for by a professional who builds and manages cellars for clients (2026-09-01), and it turns out to be the one thing genuinely blocking that workflow.

**What it unblocks:** build a cellar completely under your own account — import, racks, placement — then give it to the person who actually owns the wine, staying on as an editor to keep adding stock. Previously the choice was to own your client's data for ever, or to make the client do the setup themselves.

## Why it moves three collections, not one

`user` on **Cellar**, **Bottle** and **Rack** each independently means "whose is this" — and account deletion purges all three **by that field** (`services/userDataRegistry`).

So moving only the cellar would hand someone a collection that is still scheduled for destruction the day the previous owner closes their account, with nothing looking wrong until then. A transfer that leaves the bottles behind is not a transfer; it is a time bomb.

**Deliberately not moved** — anything authored *by* a person rather than owned *with* the cellar: journal entries, reviews, wishlists, wine lists, import sessions and archives (those are the record of who imported what — provenance, not property), image attribution, and value snapshots. They stay with whoever wrote them.

## Ordering is the safety mechanism

Production MongoDB is **standalone**, so there is no multi-document transaction to hide behind. I checked rather than assumed (`rs.status()` → `NoReplicationEnabled`).

```
1. bottles   2. racks   3. the cellar — LAST
```

The cellar flips last because until it does, the outgoing owner still owns everything and a failed run is simply retried. Flip it first and a failure at step 2 leaves the new owner owning a cellar whose bottles still purge with the old account — exactly the state this exists to prevent.

Every step is an idempotent `updateMany` keyed on the **old** owner, so re-running a partial transfer completes it and re-running a finished one does nothing. One test pins the order; another pins that a mid-way failure leaves ownership untouched.

## Guards

- Only the current owner can transfer.
- **The recipient must already be a member.** That is the consent step — nobody is handed a stranger's collection, its storage cost and its GDPR position without having been invited first — and it guarantees the recipient is a real, registered account.
- Not to yourself; not a soft-deleted cellar; `requireNonDemo`.
- The outgoing owner is added back as an **editor**, which is the entire point of the workflow.
- Audited, and the new owner is notified with the bottle count.

## UI

"Make owner" beside each member in the share dialog, **two-step rather than `window.confirm`** — giving a cellar away should not happen on a mis-click, and a native confirm is neither styleable nor reliably announced to a screen reader. New strings go to `en` only, per the Weblate workflow.

## Tests

15 new, covering what moves, the ordering guarantee, the failure case, membership after handover, and every guard. Backend suite for the touched routes green; frontend 72 files / 1,095 tests green.

## Note for review

`ShareCellarModal` has no i18n at all today — "Shared with", "Viewer", "Remove" are hardcoded. I used `t()` with inline English defaults for the new strings, following the documented convention, rather than half-migrating the rest of the file. The pre-existing strings are still untranslated and that is worth a separate pass.