### PR TITLE
fix(mcp): the maturity queue no longer reports curator profiles as absent

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -196,6 +196,94 @@ describe('list_maturity_queue', () => {
     expect(body.data[0].somm_notes).toBe('Drink young — fruit fades fast.');
     expect(body.data[1].somm_notes).toBeNull();
   });
+
+  // Somm ticket 6a911643 (2026-08-28). The inline tasting_profile reported
+  // curator-verified profiles as {absent: true}, because presence was tested
+  // by generatedAt — the AI's stamp, which a hand-written profile never has.
+  // On production 1,769 of 2,113 curator profiles were misreported. Acting on
+  // the field, a curator overwrote another curator's deliberate decision not
+  // to set a window, and set_wine_profile accepted it silently.
+  describe('inline tasting_profile reflects the STORED profile (6a911643)', () => {
+    const aiConfig = require('../config/aiConfig');
+    const row = (aiProfile, wineExtra = {}) => ({
+      _id: oid('1'), vintage: '2016', status: 'pending', relative: false,
+      wineDefinition: {
+        _id: oid('f'), name: 'Signature Blend', producer: 'The Winery at St. George',
+        region: { name: 'Somewhere' }, type: 'red', grapes: [], aiProfile, ...wineExtra,
+      },
+    });
+    const queue = async () => {
+      WineVintageProfile.countDocuments.mockResolvedValue(1);
+      const body = parse(await tool('list_maturity_queue').handler({}, SOMM_CTX));
+      return body.data[0].tasting_profile;
+    };
+    beforeEach(() => aiConfig.get.mockReturnValue({ vectorIndex: 'v1', enrichmentOnAdd: 'off' }));
+
+    test('a curator-written profile (no generatedAt) is returned in full, not as absent', async () => {
+      // Exactly the shape of the five wines in the ticket: source curator,
+      // verifiedAt set, generatedAt null, description present.
+      WineVintageProfile.find.mockReturnValue(chain([row({
+        source: 'curator', generatedAt: null, verifiedAt: new Date('2026-08-26'),
+        description: 'Cannot be identified; no drinking window should be set. Owner inquiry open.',
+        body: 'medium',
+      })]));
+      const tp = await queue();
+      expect(tp.absent).toBeUndefined();
+      expect(tp.source).toBe('curator');
+      expect(tp.description).toMatch(/no drinking window should be set/);
+      expect(tp.verified_at).toBeTruthy();
+      expect(tp.ai_confidence).toBeNull();
+    });
+
+    test('a genuinely empty profile is still absent', async () => {
+      WineVintageProfile.find.mockReturnValue(chain([row({ source: 'ai', generatedAt: null, description: null })]));
+      const tp = await queue();
+      expect(tp.absent).toBe(true);
+    });
+
+    test('no aiProfile at all is absent', async () => {
+      WineVintageProfile.find.mockReturnValue(chain([row(undefined)]));
+      expect((await queue()).absent).toBe(true);
+    });
+
+    test('with enrichment OFF, an absent profile says "off" — never a "pending" that will not arrive', async () => {
+      // "pending" read as "someone else will write this". With enrichmentOnAdd
+      // off since 2026-08-22, nothing was ever coming.
+      WineVintageProfile.find.mockReturnValue(chain([row(undefined)]));
+      const tp = await queue();
+      expect(tp.auto_enrich).toBe('off');
+      expect(tp.reason).toMatch(/switched off/);
+      expect(tp.reason).toMatch(/yours to write/);
+    });
+
+    test('with enrichment ON, an absent profile on a sufficient record is "pending"', async () => {
+      aiConfig.get.mockReturnValue({ vectorIndex: 'v1', enrichmentOnAdd: 'sufficient' });
+      WineVintageProfile.find.mockReturnValue(chain([row(undefined)]));
+      const tp = await queue();
+      expect(tp.auto_enrich).toBe('pending');
+      expect(tp.reason).toBe('not enriched yet');
+    });
+
+    test('a thin-identity record is "skipped_thin_identity" regardless of the mode', async () => {
+      aiConfig.get.mockReturnValue({ vectorIndex: 'v1', enrichmentOnAdd: 'sufficient' });
+      WineVintageProfile.find.mockReturnValue(chain([row(undefined, { region: null, appellation: null })]));
+      const tp = await queue();
+      expect(tp.auto_enrich).toBe('skipped_thin_identity');
+    });
+
+    test('a curator profile on a THIN record is still reported in full — the highest-risk case', async () => {
+      // Thin-identity records are the ones where the curator profile is the
+      // only one that will ever exist; misreporting those as absent came with
+      // a reason string that instructed the curator to overwrite it.
+      WineVintageProfile.find.mockReturnValue(chain([row(
+        { source: 'curator', generatedAt: null, description: 'Hand-written for a placeless record.' },
+        { region: null, appellation: null },
+      )]));
+      const tp = await queue();
+      expect(tp.absent).toBeUndefined();
+      expect(tp.source).toBe('curator');
+    });
+  });
 });
 
 describe('set_vintage_maturity', () => {
@@ -1005,7 +1093,9 @@ describe('the unprofiled intake queue (somm-owned data, 2026-08-22)', () => {
     expect(or).toHaveLength(3);
     // The intake branch: never generated AND never written — the 188 curator
     // rows that predate the generatedAt stamp have a description and stay out.
-    expect(or[2]).toEqual({ 'aiProfile.generatedAt': null, 'aiProfile.description': null });
+    // body is part of the content test now (6a911643) — the Mongo branch must
+    // match hasProfileContent field for field.
+    expect(or[2]).toEqual({ 'aiProfile.generatedAt': null, 'aiProfile.description': null, 'aiProfile.body': null });
   });
 
   test('state:"unprofiled" narrows the query to the intake branch alone', async () => {
@@ -1014,7 +1104,7 @@ describe('the unprofiled intake queue (somm-owned data, 2026-08-22)', () => {
     Bottle.aggregate.mockResolvedValue([]);
     await tool('list_held_profiles').handler({ state: 'unprofiled', limit: 30, offset: 0 }, SOMM_CTX);
     const or = WineDefinition.find.mock.calls[0][0].$or;
-    expect(or).toEqual([{ 'aiProfile.generatedAt': null, 'aiProfile.description': null }]);
+    expect(or).toEqual([{ 'aiProfile.generatedAt': null, 'aiProfile.description': null, 'aiProfile.body': null }]);
   });
 
   test('an explicit state:"published_suspect" implies the include flag — no second switch to forget', async () => {

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -16,6 +16,7 @@ const WineVintagePrice = require('../../models/WineVintagePrice');
 const PriceTrackingRequest = require('../../models/PriceTrackingRequest');
 const PriceTrackingSkip = require('../../models/PriceTrackingSkip');
 const WineDefinition = require('../../models/WineDefinition');
+const aiConfig = require('../../config/aiConfig');
 const Bottle = require('../../models/Bottle');
 const WineCorrectionProposal = require('../../models/WineCorrectionProposal');
 const WineOwnerInquiry = require('../../models/WineOwnerInquiry');
@@ -144,6 +145,29 @@ const grapesLite = (grapes) => {
 // "this record is wrong" and "this is a small estate the model cannot place",
 // and a curator judging a drink window should know which they are looking at.
 /**
+ * Does a stored profile EXIST — by content, not by who wrote it.
+ *
+ * generatedAt is the AI's stamp: a curator-written profile never has one, so
+ * testing generatedAt alone reports every hand-written profile as absent. That
+ * is exactly what list_maturity_queue did (somm ticket 6a911643, 2026-08-28):
+ * on production 1,769 of 2,113 curator profiles carry no generatedAt, and the
+ * queue told curators all of them were blank — with a reason string that
+ * instructed them to write one. Following it in good faith overwrote another
+ * curator's research and restamped it as their own, and set_wine_profile
+ * accepted the write without complaint.
+ *
+ * list_held_profiles had already got this right ("a published suspect is
+ * identified by having CONTENT — generatedAt or a written description"), which
+ * is why the somm's workaround of trusting that tool instead worked. The two
+ * readers now share this one predicate so they cannot drift apart again. The
+ * Mongo-side unprofiled branch in list_held_profiles is the same test written
+ * as a query, and is commented to point back here.
+ *
+ * @param {object} ap  aiProfile subdoc (lean or hydrated)
+ */
+const hasProfileContent = (ap) => !!(ap && (ap.generatedAt || ap.description || ap.body));
+
+/**
  * @param {object} ap    aiProfile subdoc
  * @param {object} wine  the wine, for the absent-profile explanation
  */
@@ -153,7 +177,7 @@ const profileLite = (ap, wine) => {
   // means automatic enrichment DECLINED the record — permanently, for a
   // record too thin to say anything true — so the curator writing the drink
   // window is the one who will write the profile. A null could not say that.
-  if (!ap || !ap.generatedAt) {
+  if (!hasProfileContent(ap)) {
     const { identityDataSufficient } = require('../../services/enrichmentJob');
     // Degrade to the softer message rather than throwing: this runs inside a
     // row mapper, so a missing export would take out the whole queue listing
@@ -161,13 +185,25 @@ const profileLite = (ap, wine) => {
     const thin = wine && typeof identityDataSufficient === 'function'
       ? !identityDataSufficient({ ...wine, grapes: wine.grapes || [] })
       : false;
-    return {
-      absent: true,
-      reason: thin
-        ? 'no region or appellation on the record, so automatic enrichment skips it — this profile is yours to write'
-        : 'not enriched yet',
-      auto_enrich: thin ? 'skipped_thin_identity' : 'pending',
-    };
+    // auto_enrich must describe what will ACTUALLY happen. "pending" was
+    // hard-coded, and read as "someone else will write this" — but automatic
+    // enrichment has been switched off in production since 2026-08-22, so
+    // nothing was ever coming. A value that names a future that will not
+    // arrive is worse than no value: it tells the curator to wait.
+    const mode = aiConfig.get().enrichmentOnAdd;
+    let autoEnrich;
+    let reason;
+    if (thin) {
+      autoEnrich = 'skipped_thin_identity';
+      reason = 'no region or appellation on the record, so automatic enrichment skips it — this profile is yours to write';
+    } else if (mode === 'off') {
+      autoEnrich = 'off';
+      reason = 'automatic enrichment is switched off, so nothing will write this — the profile is yours to write';
+    } else {
+      autoEnrich = 'pending';
+      reason = 'not enriched yet';
+    }
+    return { absent: true, reason, auto_enrich: autoEnrich };
   }
   if (ap.heldAt) {
     return {
@@ -227,9 +263,11 @@ registerTool({
     'whole queue. Use the returned profile_id with set_vintage_maturity (which also accepts wine_id + vintage directly). ' +
     'THIS QUEUE IS A TWO-OUTPUT PASS: the research you do to set a drink window — the producer, the vintage, the ' +
     'style — is the same research a tasting profile needs, so write both while you have it. Read tasting_profile on ' +
-    'each row: absent:true with auto_enrich "skipped_thin_identity" means the record carries no region or ' +
-    'appellation, automatic enrichment deliberately declines those, and nothing will ever write it but you; ' +
-    '"pending" means it may still be enriched. withheld:true means a generated profile exists but is held for the ' +
+    'each row: absent:true means NO profile is stored — neither AI-generated nor curator-written (a curator profile ' +
+    'is reported in full, with source "curator"). auto_enrich says what will happen to an absent one: ' +
+    '"skipped_thin_identity" — no region or appellation, automatic enrichment deliberately declines those; "off" — ' +
+    'automatic enrichment is switched off, nothing is coming; "pending" — it may still be enriched. In the first two ' +
+    'cases nothing will ever write it but you. withheld:true means a generated profile exists but is held for the ' +
     'stated reason — judge it through list_held_profiles rather than overwriting blind. Write with set_wine_profile.',
   scope: 'read',
   requireRole: SOMM_ROLES,
@@ -1471,7 +1509,8 @@ registerTool({
       or.push({ 'aiProfile.heldAt': null, 'aiProfile.generatedAt': { $ne: null }, 'aiProfile.producerSuspect': true, 'aiProfile.description': { $ne: null } });
     }
     if (wantState('unprofiled')) {
-      or.push({ 'aiProfile.generatedAt': null, 'aiProfile.description': null });
+      // Mongo form of hasProfileContent — keep the three fields in step with it.
+      or.push({ 'aiProfile.generatedAt': null, 'aiProfile.description': null, 'aiProfile.body': null });
     }
     const match = {
       nonWine: { $ne: true }, pendingIdentity: { $ne: true },
@@ -1483,10 +1522,11 @@ registerTool({
     }
     const stateOf = (w) => {
       if (w.aiProfile?.heldAt) return 'held';
-      // A published suspect is identified by having CONTENT — generatedAt or
-      // a written description. unprofiled means neither: nothing generated,
-      // nothing written. (Matches the query's own unprofiled branch.)
-      if (w.aiProfile?.generatedAt || w.aiProfile?.description) return 'published_suspect';
+      // A published suspect is identified by having CONTENT. Shared with
+      // list_maturity_queue's profileLite via hasProfileContent, so the two
+      // tools can never again disagree about whether a profile exists.
+      // (The query's unprofiled branch above is the same test written in Mongo.)
+      if (hasProfileContent(w.aiProfile)) return 'published_suspect';
       return 'unprofiled';
     };
     const reasonKey = (w) => (w.aiProfile?.heldAt ? (w.aiProfile?.heldReason || 'legacy') : stateOf(w));


### PR DESCRIPTION
Somm ticket `6a911643` — HIGH, open five days. `list_maturity_queue`'s inline `tasting_profile` reported `{absent: true}` on wines whose stored profile was **curator-verified**, with a reason string instructing the curator to write one. Acting on it, a curator overwrote another curator's deliberate decision not to set a drink window, and `set_wine_profile` accepted the write silently.

## Mechanism

`profileLite` tested presence with `aiProfile.generatedAt` — the AI's stamp. A hand-written profile never has one, so **every** curator profile failed the test.

Measured on production before touching anything: **1,769 of 2,113 curator profiles (84%)** carry no `generatedAt` and were reported as absent. The ticket's five cases weren't edge cases; they were the norm.

`list_held_profiles` already had the right definition ("content — generatedAt *or* a written description") — which is exactly why the somm's workaround of trusting that tool worked. Two tools, two definitions of one fact.

## Fix

- One shared predicate, `hasProfileContent(ap)` = `generatedAt || description || body`, now decides presence for **both** tools. The Mongo-side `unprofiled` branch is the same test written as a query, commented to point back — so they cannot drift again.
- A curator profile on a **thin-identity** record — the highest-risk case, since there the curator profile is the only one that will ever exist — is returned in full with `source: "curator"` and `verified_at`.
- `absent: true` now means exactly what the ticket asked: no stored profile, of any origin.

## `auto_enrich: "pending"` was dead

Hard-coded for any non-thin absent profile. `enrichmentOnAdd` has been `"off"` on production since 2026-08-22 (verified live), so it named a future that was never coming and read as *"someone else will write this."* Now mode-aware: `"off"` with a reason that says nothing is coming and the profile is the curator's to write; `"pending"` only when enrichment is actually on; `"skipped_thin_identity"` unchanged. Tool description updated to document all three.

## Verification

- Adding `body` to the unprofiled query: **23 → 23** rows on production, zero effect. Two test assertions that pinned the old two-field query shape are updated to the new one.
- 7 regression tests, including the exact stored shape of the St. George record (`source: curator`, `verifiedAt` set, `generatedAt: null`, description present) and the thin-identity curator case.
- `sommTools` suite: 116/116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)