### PR TITLE
fix(backup): actually prune old snapshots — group restic forget by host+tags

### DIFF
--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -103,8 +103,16 @@ restic snapshots >/dev/null 2>&1 || restic init
 log "uploading encrypted snapshot to $RESTIC_REPOSITORY…"
 restic backup --tag cellarion --host cellarion "$STAGE"
 
+# --group-by host,tags is REQUIRED here. restic's default grouping is
+# "host,paths", and every run stages into a fresh mktemp -d, so each snapshot
+# has a unique path and lands in its own group. The keep-N policy is then
+# applied per group — "keep 1 of 1" every night — and NOTHING is ever forgotten.
+# Grouping by host+tags puts all Cellarion snapshots in one group so the
+# 7d/4w/6m policy actually applies. (Found 2026-09-01: 85 snapshots retained
+# since June where ~14 were intended; erased users lingered in backups past
+# the retention promise.)
 log "pruning (keep ${KEEP_DAILY}d / ${KEEP_WEEKLY}w / ${KEEP_MONTHLY}m)…"
-restic forget --tag cellarion --keep-daily "$KEEP_DAILY" --keep-weekly "$KEEP_WEEKLY" --keep-monthly "$KEEP_MONTHLY" --prune
+restic forget --tag cellarion --group-by host,tags --keep-daily "$KEEP_DAILY" --keep-weekly "$KEEP_WEEKLY" --keep-monthly "$KEEP_MONTHLY" --prune
 
 # Optional second, off-provider copy (e.g. Backblaze B2) so a Hetzner-account
 # level loss can't wipe everything. Enable by setting B2_* in backup.env.
@@ -114,7 +122,8 @@ if [ -n "${B2_RESTIC_REPOSITORY:-}" ]; then
   restic -r "$B2_RESTIC_REPOSITORY" snapshots >/dev/null 2>&1 \
     || restic -r "$B2_RESTIC_REPOSITORY" init --copy-chunker-params --from-repo "$RESTIC_REPOSITORY"
   restic -r "$B2_RESTIC_REPOSITORY" copy --from-repo "$RESTIC_REPOSITORY" --tag cellarion
-  restic -r "$B2_RESTIC_REPOSITORY" forget --tag cellarion --keep-daily "$KEEP_DAILY" --keep-weekly "$KEEP_WEEKLY" --keep-monthly "$KEEP_MONTHLY" --prune
+  # same grouping fix as the primary repo above — without it nothing is pruned
+  restic -r "$B2_RESTIC_REPOSITORY" forget --tag cellarion --group-by host,tags --keep-daily "$KEEP_DAILY" --keep-weekly "$KEEP_WEEKLY" --keep-monthly "$KEEP_MONTHLY" --prune
 fi
 
 log "recording status for SuperAdmin…"


### PR DESCRIPTION
## The bug

`restic forget` groups snapshots by `host,paths` unless told otherwise, and `backup.sh` stages every run into a fresh `mktemp -d`. Every nightly snapshot therefore has a **unique path**, lands in a group of its own, and the `7d/4w/6m` policy is applied as "keep 1 of 1" — so nothing is ever forgotten.

Prod evidence (2026-09-01): **85 snapshots, 85 distinct paths**, one per night since 2026-06-11, where the policy intends about 14. Last night's log says it plainly:

```
1 snapshots
keep 1 snapshots:
ID        Time                 Host        Tags        Reasons           Paths
8764bcae  2026-06-15 03:43:50  cellarion   cellarion   daily snapshot    /tmp/tmp.wHGKnNunXJ
```

Two consequences:

- **GDPR retention.** Data from users who exercised their right to erasure stays in backups indefinitely, instead of ageing out within the six months the policy promises.
- **Unbounded growth.** Deduplication keeps it cheap for now (2.26 GiB raw), but it never stops growing.

## The fix

`--group-by host,tags` on both `restic forget` calls — the primary repo and the optional B2 copy. All Cellarion snapshots then sit in one group and the retention policy applies as documented.

## Verifying after merge

The script is deployed by hand on the VM (`~/apps/Cellarion/scripts/backup/`), so it needs copying there as well as merging here. The first run after that prunes roughly 70 snapshots — expected, not a fault. Check with:

```bash
restic snapshots | tail -3          # count drops to ~14
journalctl -u cellarion-backup -n 30
```

The weekly `cellarion-backup-check.timer` re-verifies repository integrity on Sundays.

Found in the prod VM security audit, 2026-09-01 (finding M-3).