### PR TITLE
fix: replace chart/cellar color palettes with a colorblind-safe set

### DIFF
--- a/frontend/src/utils/cellarColors.js
+++ b/frontend/src/utils/cellarColors.js
@@ -1,12 +1,17 @@
+// Colorblind-safety validated — same methodology and values as
+// chartColors.js's SERIES_COLORS (see that file for the full rationale).
+// Kept as a separate export since this palette serves the cellar-accent
+// swatch picker (CellarColorPicker.js) rather than chart series, but unified
+// on the same validated set rather than maintaining two independently-tuned
+// palettes. Capped at 8, not 10, for the same reason: no ordering of 10 hues
+// clears the pairwise CVD/normal-vision distinctness floors.
 export const CELLAR_COLORS = [
-  '#7A1E2D', // burgundy (app primary)
-  '#D4A373', // gold accent
-  '#5B8DB8', // steel blue
-  '#9B7BC8', // lavender
-  '#C87B7B', // dusty rose
-  '#5BA88D', // teal
-  '#B8860B', // dark gold
-  '#8D7BC8', // violet
-  '#7BC8C8', // sky teal
-  '#C87BA8', // mauve
+  '#2a78d6', // blue
+  '#eb6834', // orange
+  '#1baf7a', // aqua
+  '#eda100', // yellow
+  '#e87ba4', // magenta
+  '#008300', // green
+  '#4a3aa7', // violet
+  '#e34948', // red
 ];

--- a/frontend/src/utils/chartColors.js
+++ b/frontend/src/utils/chartColors.js
@@ -2,7 +2,30 @@
 // time, cellar climate history). One definition so a contrast/accessibility
 // retune reaches every chart at once, and the same series concept keeps its hue
 // across the app. Assign in fixed order — never cycle a generated hue.
+//
+// Colorblind-safety validated: every adjacent pair in this fixed order clears
+// a CVD separation floor (deuteranopia/protanopia/tritanopia simulated in
+// OKLab, ΔE ≥ 8) and a normal-vision floor (ΔE ≥ 15), checked against the
+// app's actual light chart surface (#FFFFFF). The previous 10-color palette
+// failed both — several colors read as near-gray at low chroma, and multiple
+// adjacent pairs were indistinguishable under red-green color blindness.
+// Capped at 8, not 10: no ordering of 10 hues clears these floors for every
+// pairwise combination, so a 9th+ series should fold into "Other" rather than
+// reuse a hue that can't be reliably told apart from its neighbors. All
+// current consumers already index with `% SERIES_COLORS.length`, so this is
+// a safe, non-breaking reduction — series just cycle through 8 colors instead
+// of 10.
+//
+// 3 of the 8 (aqua, yellow, magenta) read below 3:1 contrast on white and
+// rely on each chart's existing legend/tooltip labels rather than hue alone —
+// don't remove those labels.
 export const SERIES_COLORS = [
-  '#C0504D', '#D4C87A', '#E8A0B0', '#6EC6C6', '#D4A070',
-  '#8B6A9A', '#5B8DB8', '#A03648', '#946333', '#3B6D98',
+  '#2a78d6', // blue
+  '#eb6834', // orange
+  '#1baf7a', // aqua
+  '#eda100', // yellow
+  '#e87ba4', // magenta
+  '#008300', // green
+  '#4a3aa7', // violet
+  '#e34948', // red
 ];


### PR DESCRIPTION
## Summary
- `SERIES_COLORS` (`chartColors.js`) and `CELLAR_COLORS` (`cellarColors.js`) both fail objective colorblind-safety checks against the app's actual light chart surface (`#FFFFFF`): several colors are low-chroma enough to read as near-gray, and multiple adjacent pairs are hard to tell apart under red-green color blindness (deuteranopia/protanopia) — some are also hard to distinguish even with normal color vision.
- Replaced both with the same 8-color palette. Every adjacent pair in this fixed order clears a CVD-separation floor (ΔE ≥ 8, OKLab, deuteranopia/protanopia/tritanopia simulated) and a normal-vision floor (ΔE ≥ 15).
- Deliberately capped at **8** colors, down from 10: no ordering of 10 hues can clear these floors for every pairwise combination, so a 9th+ series should fold into "Other" rather than get a hue nobody can reliably tell apart from its neighbors. All 4 current consumers (`AnalyticsCharts.js`, `ClimateHistoryModal.js`, `ValueOverTimeChart.js`, `CellarColorPicker.js`) already index with `% length`, so this is a safe, non-breaking reduction.
- 3 of the 8 (aqua, yellow, magenta) read below 3:1 contrast against white and rely on each chart's existing legend/tooltip labels rather than hue alone to stay legible — noted in a comment so a future edit doesn't strip those labels.
- Kept the existing single-flat-array architecture (no light/dark split) since neither file currently varies by theme — adding theme-aware chart colors felt like a separate, larger change than this fix.

## Test plan
- [x] `node --check` on both edited files
- [x] Searched for tests asserting on palette length/values — none exist
- [x] Validated the new palette against the app's real light surface color pulled from `frontend/src/index.css` (`--color-surface: #FFFFFF`)
- [ ] Visual check in the running app (couldn't run the dev server in this environment — worth a quick look at the analytics charts / cellar color picker before merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)