### PR TITLE
docs: contributor guide, code of conduct, issue/PR templates, DCO check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Something in Cellarion does not work the way it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time. A security problem should **not** go here — use [private vulnerability reporting](https://github.com/jagduvi1/Cellarion/security/advisories/new) instead.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you did, what you saw, and what you expected instead.
+      placeholder: I opened a bottle from the rack view, tapped Consume, and the bottle stayed in the rack until I reloaded.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to …
+        2. Click …
+        3. See …
+    validations:
+      required: true
+  - type: dropdown
+    id: where
+    attributes:
+      label: Where are you running Cellarion
+      options:
+        - cellarion.app (hosted)
+        - Self-hosted
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Shown at the bottom of the page, or from `/api/health` on your instance.
+      placeholder: "1.196.0"
+  - type: input
+    id: device
+    attributes:
+      label: Browser and device
+      placeholder: "Safari on iPhone 15, Firefox 130 on Windows 11, the Android app…"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: For self-hosted, `docker compose logs backend --tail 100` around the time it happened is often the fastest way to a fix. Please remove anything personal first.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/jagduvi1/Cellarion/security/advisories/new
+    about: Please report security problems privately here, never as a public issue. See SECURITY.md.
+  - name: Question or idea
+    url: https://github.com/jagduvi1/Cellarion/discussions
+    about: Not sure it is a bug, or want to talk a feature through first? Discussions is the place.
+  - name: Translations
+    url: https://hosted.weblate.org/engage/cellarion/
+    about: Interface translations are done in Weblate, no Git needed. See TRANSLATING.md for guidelines.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Something Cellarion could do, or do better
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Good feature requests start from a problem, not a solution. Tell us what you were trying to do. If you want to talk it through first, [Discussions](https://github.com/jagduvi1/Cellarion/discussions) is a lighter place than an issue.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What were you trying to do, and what got in the way?
+      placeholder: When I bring six bottles of the same wine back from a tasting, adding them one by one takes ten minutes.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you would like
+      description: Your idea of how it could work. Rough is fine.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you do today instead
+      description: Workarounds, other apps you have seen do it well, anything that helps us understand the shape of it.
+  - type: dropdown
+    id: where
+    attributes:
+      label: Where you use Cellarion
+      options:
+        - cellarion.app (hosted)
+        - Self-hosted
+        - Both

--- a/.github/ISSUE_TEMPLATE/self_hosting.yml
+++ b/.github/ISSUE_TEMPLATE/self_hosting.yml
@@ -1,0 +1,44 @@
+name: Self-hosting help
+description: Your own Cellarion instance will not start, upgrade, or behave
+labels: ["self-hosting"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Happy to help you get running. Please include the details below — most self-hosting problems are a missing environment variable, a reverse-proxy header, or a version mismatch, and these fields find them quickly.
+
+        **Never paste the values of secrets.** Variable names are enough.
+  - type: textarea
+    id: symptom
+    attributes:
+      label: What is going wrong
+      placeholder: The backend container restarts every 30 seconds after upgrading from 1.190 to 1.196.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Cellarion version
+      description: The image tag you are running, or the output of `/api/health`.
+    validations:
+      required: true
+  - type: textarea
+    id: setup
+    attributes:
+      label: How it is deployed
+      description: Docker Compose from this repo, or something else? Which reverse proxy in front (Traefik, nginx, Caddy, Cloudflare Tunnel)? Any changes to the compose file?
+      placeholder: docker compose from the repo, behind Caddy, on a 2 GB VPS. Changed the frontend port to 8081.
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment variables set
+      description: Names only, never values.
+      placeholder: JWT_SECRET, MEILI_MASTER_KEY, FRONTEND_URL, ANTHROPIC_API_KEY
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: "`docker compose logs backend --tail 100` and, if the web side is the problem, the same for `frontend`. Remove anything personal."
+      render: shell

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What this changes
+
+<!-- One or two sentences. What was wrong or missing, and what this does about it. Link the issue or discussion if there is one. -->
+
+## How I tested it
+
+<!-- What you actually ran and looked at. For anything visual, a screenshot in both light and dark theme helps a lot. -->
+
+## Checklist
+
+- [ ] `cd frontend && npm test` passes
+- [ ] `cd backend && npm test` passes
+- [ ] Smoke-tested in Docker (`docker compose up --build`) and used the change in the app
+- [ ] Commits are signed off (`git commit -s`, see CONTRIBUTING.md)
+- [ ] No non-English `translation.json` files touched (those go through Weblate)
+- [ ] If personal data is stored, processed or shared: export, deletion cascade, consent, audit log, minimisation and retention are covered (see CONTRIBUTING.md)
+- [ ] If AI tools helped write this, that is mentioned above and I have run the result myself

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,58 @@
+# Developer Certificate of Origin check.
+#
+# Every commit on a pull request from a fork must carry a "Signed-off-by:"
+# line (git commit -s). That line is the contributor certifying, under
+# https://developercertificate.org/, that they have the right to submit the
+# change under the project's AGPL-3.0 license. CONTRIBUTING.md explains it.
+#
+# Pull requests from branches inside this repository are the maintainer's own
+# work and are not checked — the job still reports success so it can be a
+# required status check without blocking those.
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: DCO sign-off
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip for pull requests from this repository
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: echo "Pull request from the main repository — sign-off not required."
+
+      - name: Check out the pull request history
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Verify every commit is signed off
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for c in $(git rev-list "$BASE_SHA".."$HEAD_SHA"); do
+            if git show -s --format=%B "$c" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
+              echo "ok       $(git show -s --format='%h %s' "$c")"
+            else
+              echo "::error::Missing Signed-off-by on commit $(git show -s --format='%h %s' "$c")"
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "$missing" -gt 0 ]; then
+            echo
+            echo "$missing commit(s) need a sign-off. Fix with:"
+            echo "  git rebase --signoff $BASE_SHA && git push --force-with-lease"
+            echo "See CONTRIBUTING.md, section 'Sign your commits (DCO)'."
+            exit 1
+          fi
+          echo "All commits signed off."

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **info@cellarion.app**. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to Cellarion
+
+Thanks for considering it. Cellarion is a wine-cellar manager that people run two ways: on the hosted service at [cellarion.app](https://cellarion.app), and self-hosted from this repository. Both are first-class, and a contribution is welcome for either.
+
+This document covers code and documentation. **Translations go through Weblate, not pull requests** — see [TRANSLATING.md](TRANSLATING.md). **Security problems go through [SECURITY.md](SECURITY.md), never a public issue.**
+
+## Before you start
+
+- **Small fix or obvious bug:** just open the pull request.
+- **New feature or a change in behaviour:** open an issue or a [Discussion](https://github.com/jagduvi1/Cellarion/discussions) first and say what you have in mind. Cellarion has a fairly clear idea of what it is — a better wine registry and a great add-a-bottle experience come before almost everything else — and a ten-minute conversation beats a week of work that does not land.
+- Have a look at the open issues; some are labelled `good first issue`.
+
+## Setting up
+
+You need Docker and Node 20.
+
+```bash
+git clone https://github.com/<you>/Cellarion.git && cd Cellarion
+cp .env.example .env            # set JWT_SECRET and MEILI_MASTER_KEY at minimum
+docker compose up --build        # full stack on http://localhost
+docker exec cellarion-backend node src/seed-demo.js   # demo data + demo accounts
+```
+
+For a tighter loop outside Docker: `cd backend && npm run dev` and `cd frontend && npm start` (frontend installs need `--legacy-peer-deps`). The README has the full picture, including the optional AI and analytics services.
+
+## The workflow
+
+1. Fork, then branch off `main`. Prefix the branch with what it is: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`.
+2. Keep the change focused. One concern per pull request merges faster and is easier to revert if it has to be.
+3. Write or update tests next to the code they cover. Backend tests are Jest files beside their source; frontend tests are Vitest.
+4. **Run both suites** — pull requests with failing tests are not merged:
+   ```bash
+   cd frontend && npm test
+   cd backend && npm test
+   ```
+5. **Smoke-test in Docker** (`docker compose up --build`) and actually use the thing you changed. If it is visual, look at it in both the light and dark theme.
+6. Sign your commits (next section), push, and open the pull request against `main`. The template asks for a short description and a checklist; fill it in honestly.
+
+Pull requests are squash-merged, so a tidy history on your branch is nice but not required. Commit messages follow the `type(scope): what changed` shape you will see in the log, for example `fix(cellars): transfer notification now delivers`.
+
+## Sign your commits (DCO)
+
+Cellarion uses the [Developer Certificate of Origin](https://developercertificate.org/). It is not a contract and there is nothing to register: a `Signed-off-by` line on each commit certifies that you wrote the change, or otherwise have the right to submit it, under the project's license.
+
+```bash
+git commit -s -m "fix(racks): keep slot labels visible on narrow screens"
+```
+
+To add it to existing commits: `git commit --amend -s` for the last one, or `git rebase --signoff main` for a branch. A check on pull requests from forks verifies the line is present.
+
+## Conventions worth knowing
+
+The codebase is consistent about a few things, and a contribution that follows them needs far less back and forth.
+
+- **Frontend API calls live in `frontend/src/api/`**, one module per resource, each taking `apiFetch` from `useAuth()`. Pages import from there rather than writing URL strings.
+- **Shared UI comes from shared components** — `Modal` for overlays, `BottleCard` for bottles in list and card view. Look before you build.
+- **The bottle page has two action surfaces** — the desktop header and the mobile action bar. A new action goes in both.
+- **Backend access checks are middleware**: `requireBottleAccess(minRole)` loads bottle, cellar and role in one step; `utils/cellarAccess.js` guards cellar mutations. Do not re-implement ownership checks inline.
+- **Significant mutations are audit-logged** through `services/audit.js`.
+- **Dependencies:** reach for a package when the problem is genuinely complex and well served by a mature library; skip it when a few lines of native code or a browser API do the job.
+- **Strings:** add English text to the `en` locale only. Every other language is maintained in Weblate, and a pull request touching non-English `translation.json` files will conflict with its sync.
+
+## Personal data
+
+Cellarion stores people's cellars, notes and photos, and it takes GDPR seriously. If your change stores, processes or shares anything personal, it must also cover:
+
+1. **Export** — include the data in `GET /api/users/me/export`.
+2. **Deletion** — add the model to the account-deletion cascade.
+3. **Consent** — a new category of processing, or a new third party, needs explicit consent before it happens.
+4. **Audit log** — log the mutation.
+5. **Minimisation** — store what the feature needs, not what might be useful one day.
+6. **Retention** — if the data has a natural expiry, enforce it.
+
+Never skip a feature because of this; implement it properly instead. Ask in the pull request if you are unsure which of these apply.
+
+## AI-assisted contributions
+
+Welcome, and please say so in the pull request. Two conditions: you must have run the change and looked at the result yourself, not only read the diff, and you take responsibility for it as you would for code you typed. A pull request whose description admits it was never run in the app will be sent back for that alone.
+
+## What to expect
+
+Cellarion is maintained by one person. Expect a first response within about a week, sometimes much faster, sometimes slower if life intervenes. Review may ask for changes; that is normal and not a judgement. Occasionally a change is declined because it pulls the product somewhere it is not going, and you will get the reason in plain words. Small, well-described pull requests with passing tests move fastest.
+
+## License
+
+Cellarion is licensed under the [GNU Affero General Public License v3.0](LICENSE). By contributing, you agree that your contribution is licensed under the same terms. Your DCO sign-off is the record of that.

--- a/README.md
+++ b/README.md
@@ -536,11 +536,15 @@ Uses Jest — ~124 suites covering auth middleware, cellar access control, wine 
 
 ## Contributing
 
-1. Fork the repo and create a feature branch off `main`
-2. Make your changes
-3. Run the tests (`cd frontend && npm test` and `cd backend && npm test`)
-4. Smoke-test in Docker: `docker-compose up --build`
-5. Submit a pull request with a clear description of your changes
+Contributions are welcome — bug fixes, features, documentation, and translations. **[CONTRIBUTING.md](CONTRIBUTING.md)** has the full guide: how to set up, the branch and test workflow, the conventions the codebase follows, the personal-data checklist every feature must pass, and how to sign your commits (Cellarion uses the [Developer Certificate of Origin](https://developercertificate.org/), so commit with `git commit -s`). The short version:
+
+1. Fork the repo and create a branch off `main` (`feat/`, `fix/`, `docs/`…)
+2. Make your change, with tests
+3. Run both suites: `cd frontend && npm test` and `cd backend && npm test`
+4. Smoke-test in Docker: `docker compose up --build`, and use the thing you changed
+5. Open a pull request against `main` — the template asks for a description and a checklist
+
+Everyone taking part is expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ### Translations
 
@@ -564,8 +568,7 @@ Guidelines, the wine-terminology glossary, and how a language graduates out of b
 
 ## Reporting a Vulnerability
 
-Please report security issues privately to:
-github@cellarion.app
+Please do not open a public issue for a security problem. Use GitHub's [private vulnerability reporting](https://github.com/jagduvi1/Cellarion/security/advisories/new), or email **info@cellarion.app** with "SECURITY" in the subject. Response times, scope, and an honest account of the current security posture are in **[SECURITY.md](SECURITY.md)**.
 
 ---
 
@@ -573,7 +576,9 @@ github@cellarion.app
 
 [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE)
 
-You are free to use, modify, and self-host this software. If you run a modified version as a network service, you must make your source code available to users of that service. Commercial hosting of this software as a managed service requires a separate agreement.
+You are free to use, modify, self-host, and even offer this software as a service. The one condition, and the reason Cellarion uses AGPL rather than MIT: if you run a modified version for other people, you must make your modified source available to them.
+
+Contributions are accepted under the same license; see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wine-cellar-backend",
   "version": "1.196.0",
+  "license": "AGPL-3.0",
   "description": "Wine cellar management backend",
   "main": "server.js",
   "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "frontend",
   "version": "1.196.0",
+  "license": "AGPL-3.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Why

Cellarion has started getting outside contributions (four people so far, plus #1184 this morning) and the repo had a LICENSE and a good SECURITY.md but nothing that tells a contributor how to work here. GitHub's community profile scored 57 %; every missing point was a file.

## What is in here

| File | Purpose |
|---|---|
| `CONTRIBUTING.md` | Setup, branch/test/smoke workflow, the conventions the codebase relies on (api modules, shared components, access middleware, audit logging, en-only strings), the personal-data checklist every feature must pass, an AI-assisted-contribution policy (welcome, disclose, **must have run it**), what to expect from a one-person maintainer, DCO sign-off. |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1, verbatim (CC BY 4.0), reports to info@cellarion.app. |
| `.github/ISSUE_TEMPLATE/*` | Forms for bug reports, feature requests, and self-hosting help (asks for env var **names only**). Contact links route security reports to private advisories and translations to Weblate. |
| `.github/PULL_REQUEST_TEMPLATE.md` | Test / smoke / sign-off / personal-data checklist. |
| `.github/workflows/dco.yml` | Pull requests **from forks** must carry `Signed-off-by` on every commit. PRs from this repository pass without checking, so the job can become a required status without blocking maintainer work. |
| `README.md` | **License paragraph corrected.** It claimed commercial hosting needs a separate agreement — AGPL-3.0 does not let us add that restriction, and with outside code in the tree we could not honour such an agreement anyway. Replaced with what the license actually says. Security contact now matches SECURITY.md (it pointed at a different address). Contributing section points at the guide. |
| `backend/frontend package.json` | `"license": "AGPL-3.0"` — the MCP package already had it. |

## Why DCO rather than a CLA

With the commercial-hosting sentence gone there is nothing left to relicense, so a CLA would only deter contributors for no benefit. DCO is the lightweight standard (Linux kernel, GitLab): a sign-off line certifies the contributor has the right to submit the change under AGPL.

## Done outside this PR

Repository settings switched to **squash merges only** (merge commits and rebase merges were still allowed; branch protection already required linear history, so this just makes the setting match). After this merges and the DCO workflow has reported once, `DCO sign-off` gets added to the required status checks.

## Verifying

- All five YAML files parse. The workflow validates itself by running on this very PR (it should report "sign-off not required" since this branch lives in the repo).
- The issue forms show up under *New issue* once merged; worth a glance there.