### PR TITLE
fix(search): bottle search always runs scoped — an empty cellar scope matches nothing

### DIFF
--- a/backend/src/mcp/readTools.test.js
+++ b/backend/src/mcp/readTools.test.js
@@ -92,6 +92,34 @@ describe('registration invariants', () => {
 });
 
 describe('ownership scoping', () => {
+  test('search_bottles for a user with NO owned cellar returns an empty page and never queries the search index (audit 2026-09-02 D10-5)', async () => {
+    // Registration creates no cellar, so this is every fresh account. Before
+    // the fix the empty scope reached Meilisearch with no cellar filter at all
+    // and hydration returned every tenant's bottles.
+    Cellar.find.mockReturnValue(chain([]));
+    searchService.getIsAvailable.mockReturnValue(true);
+    searchService.searchBottles.mockResolvedValue({ ids: [oid('d')], estimatedTotalHits: 9999 });
+
+    const body = parse(await tool('search_bottles').handler({ query: 'wine' }, CTX));
+
+    expect(searchService.searchBottles).not.toHaveBeenCalled();
+    expect(Bottle.find).not.toHaveBeenCalled();
+    expect(body.data).toEqual([]);
+    expect(body.page.total).toBe(0);
+  });
+
+  test('search_bottles Meili hydration is bound to the same cellar scope as the query', async () => {
+    Cellar.find.mockReturnValue(chain([oid('c')]));
+    searchService.getIsAvailable.mockReturnValue(true);
+    searchService.searchBottles.mockResolvedValue({ ids: [oid('d')], estimatedTotalHits: 1 });
+    Bottle.find.mockReturnValue(chain([]));
+
+    await tool('search_bottles').handler({ query: 'barolo' }, CTX);
+
+    expect(searchService.searchBottles.mock.calls[0][1].cellarIds).toEqual([oid('c')]);
+    expect(Bottle.find.mock.calls[0][0]).toEqual({ _id: { $in: [oid('d')] }, cellar: { $in: [oid('c')] } });
+  });
+
   test('search_bottles without cellar_id scopes to the user\'s OWNED cellars', async () => {
     Cellar.find.mockReturnValue(chain([oid('c')]));
     Bottle.countDocuments.mockResolvedValue(0);
@@ -269,7 +297,9 @@ describe('privilege parity & bounds', () => {
   });
 
   test('search_bottles clamps an oversized limit to 50', async () => {
-    Cellar.find.mockReturnValue(chain([]));
+    // A real owned-cellar scope: with NO owned cellar the tool now answers an
+    // empty page before any query (see the D10-5 test above).
+    Cellar.find.mockReturnValue(chain([oid('c')]));
     Bottle.countDocuments.mockResolvedValue(0);
     const q = chain([]);
     Bottle.find.mockReturnValue(q);
@@ -289,7 +319,7 @@ describe('privilege parity & bounds', () => {
   });
 
   test('search_bottles degrades gracefully when the search engine is down (warning, no text match)', async () => {
-    Cellar.find.mockReturnValue(chain([]));
+    Cellar.find.mockReturnValue(chain([oid('c')]));
     Bottle.countDocuments.mockResolvedValue(0);
     Bottle.find.mockReturnValue(chain([]));
     const res = await tool('search_bottles').handler({ query: 'barolo' }, CTX);
@@ -297,15 +327,20 @@ describe('privilege parity & bounds', () => {
     expect(body.warnings.join(' ')).toMatch(/search engine unavailable/i);
   });
 
-  test('search_bottles Meili path hydrates by id only — no post-pagination filters', async () => {
+  test('search_bottles Meili path hydrates by id + the SAME cellar scope — no other post-pagination filters', async () => {
     searchService.getIsAvailable.mockReturnValue(true);
     searchService.searchBottles.mockResolvedValue({ ids: [oid('d')], estimatedTotalHits: 1 });
     Cellar.find.mockReturnValue(chain([oid('c')]));
     Bottle.find.mockReturnValue(chain([]));
-    await tool('search_bottles').handler({ query: 'barolo' }, CTX);
-    // Scope lives INSIDE the Meili query (owned cellarIds); hydration must not
-    // re-filter or pages get holes and totals lie.
-    expect(Bottle.find.mock.calls[0][0]).toEqual({ _id: { $in: [oid('d')] } });
+    await tool('search_bottles').handler({ query: 'barolo', status: 'all', vintage: '2015' }, CTX);
+    // Scope lives INSIDE the Meili query (owned cellarIds) and hydration
+    // re-asserts exactly that scope (defence in depth, audit 2026-09-02 D10-5).
+    // Nothing ELSE may be re-filtered here — status/vintage/type after
+    // pagination would put holes in pages and make totals lie.
+    const hydrate = Bottle.find.mock.calls[0][0];
+    expect(hydrate).toEqual({ _id: { $in: [oid('d')] }, cellar: { $in: [oid('c')] } });
+    expect(hydrate.status).toBeUndefined();
+    expect(hydrate.vintage).toBeUndefined();
     expect(searchService.searchBottles.mock.calls[0][1]).toMatchObject({ cellarIds: [oid('c')] });
   });
 

--- a/backend/src/mcp/tools/bottles.js
+++ b/backend/src/mcp/tools/bottles.js
@@ -75,6 +75,17 @@ registerTool({
       cellarIds = await Cellar.find({ user: ctx.user.id, deletedAt: null }).distinct('_id');
     }
 
+    // A user with no owned cellar has nothing to search: answer before either
+    // backend is touched. searchBottles now refuses to run unscoped as well,
+    // but this tool must not depend on that — an empty scope once reached the
+    // search index unfiltered and returned every tenant's bottles (security
+    // audit 2026-09-02, D10-5).
+    if (cellarIds.length === 0) {
+      return ok('0 bottles — you own no cellar yet (pass cellar_id to search a cellar shared with you)', [], {
+        page: { limit, offset, total: 0 },
+      });
+    }
+
     // Meilisearch path — handles text + all filters with correct pagination.
     // The reserved filter lives only on the bottle document (not in the search
     // index), and filtering after pagination would shorten pages and inflate
@@ -94,11 +105,13 @@ registerTool({
           limit,
           offset,
         });
-        // Hydration only — NO extra filters here. The scope (owned cellars) is
-        // already inside the Meili query, and any post-pagination filter would
-        // shorten pages and inflate totals (the classic filter-after-paginate
-        // hole). Contract stays identical to the Mongo path below.
-        const docs = await Bottle.find({ _id: { $in: res.ids } })
+        // Hydration re-asserts the SAME cellar scope the Meili query carried.
+        // That cannot shorten a page or inflate a total in normal operation
+        // (the ids already satisfy it) — it only drops a hit whose index
+        // document is stale, i.e. a bottle that has since moved out of scope,
+        // which is exactly what must never be shown. No OTHER filter belongs
+        // here: anything not in the Meili query would be filter-after-paginate.
+        const docs = await Bottle.find({ _id: { $in: res.ids }, cellar: { $in: cellarIds } })
           .populate(WINE_POPULATE_LIST).lean();
         const byId = new Map(docs.map((d) => [String(d._id), d]));
         const items = res.ids.map((id) => byId.get(String(id))).filter(Boolean).map(bottleSummary);

--- a/backend/src/services/search.js
+++ b/backend/src/services/search.js
@@ -553,10 +553,15 @@ async function searchBottles(query, {
     filters.push(`cellarId = "${cleanScopeIds[0]}"`);
   } else if (cleanScopeIds.length > 1) {
     filters.push(`cellarId IN ["${cleanScopeIds.join('","')}"]`);
-  } else if (scopeIds.length > 0) {
-    // A scope WAS requested but every id stripped to empty — push a filter that
-    // matches nothing rather than no filter at all (which would un-scope the
-    // search and leak across every cellar).
+  } else {
+    // No usable scope — every id stripped to empty, OR the caller passed an
+    // EMPTY cellar list (a user who owns no cellar), OR nothing at all. Push a
+    // filter that matches nothing rather than no filter at all: an unscoped
+    // query searches every tenant's bottles. Until 2026-09-02 this branch only
+    // covered "ids given but all stripped", so a freshly registered account
+    // (registration creates no cellar) could read the whole index through MCP
+    // search_bottles (security audit D10-5). searchBottles has no legitimate
+    // unscoped caller — every REST and MCP path passes an access-checked scope.
     filters.push('cellarId = ""');
   }
   // Status filter: active (exclude consumed), consumed (only consumed), or all

--- a/backend/src/services/search.scope.test.js
+++ b/backend/src/services/search.scope.test.js
@@ -1,0 +1,76 @@
+/**
+ * searchBottles must NEVER run unscoped.
+ *
+ * Security audit 2026-09-02 (D10-5): with an EMPTY cellar list — a user who
+ * owns no cellar, which is every freshly registered account since registration
+ * creates none — the scope branches pushed no filter at all, so the Meilisearch
+ * query ran across every tenant's bottles and MCP search_bottles hydrated
+ * whatever came back. The match-nothing fallback only covered "ids given but
+ * all stripped". These tests pin the contract: no usable scope ⇒ a filter that
+ * matches nothing. There is no legitimate unscoped caller.
+ */
+jest.mock('meilisearch', () => ({ Meilisearch: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn(), find: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ find: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/Discussion', () => ({ find: jest.fn() }));
+
+const { Meilisearch } = require('meilisearch');
+
+// One shared index mock for every index name: the tests only care about the
+// options searchBottles hands to `search`, and no other index is queried here.
+const index = {
+  updateSettings: jest.fn().mockResolvedValue({}),
+  getStats: jest.fn().mockResolvedValue({ numberOfDocuments: 5 }),
+  addDocuments: jest.fn().mockResolvedValue({ taskUid: 1 }),
+  deleteDocument: jest.fn().mockResolvedValue({ taskUid: 2 }),
+  search: jest.fn().mockResolvedValue({ hits: [], estimatedTotalHits: 0 }),
+};
+
+let searchService;
+
+beforeAll(async () => {
+  Meilisearch.mockImplementation(() => ({
+    health: jest.fn().mockResolvedValue({}),
+    index: jest.fn(() => index),
+    tasks: { waitForTasks: jest.fn() },
+  }));
+  searchService = require('./search');
+  await searchService.initialize();
+});
+
+beforeEach(() => index.search.mockClear());
+
+const lastFilter = () => index.search.mock.calls.at(-1)[1].filter;
+const MATCH_NOTHING = 'cellarId = ""';
+
+describe('searchBottles scope (audit 2026-09-02 D10-5)', () => {
+  test('an EMPTY cellarIds array — a user with no owned cellar — matches nothing', async () => {
+    await searchService.searchBottles('wine', { cellarIds: [] });
+    expect(index.search).toHaveBeenCalledTimes(1);
+    expect(lastFilter()).toEqual(expect.arrayContaining([MATCH_NOTHING]));
+  });
+
+  test('no scope option at all matches nothing', async () => {
+    await searchService.searchBottles('wine', {});
+    expect(lastFilter()).toEqual(expect.arrayContaining([MATCH_NOTHING]));
+  });
+
+  test('a scope whose ids all strip to empty matches nothing (pre-existing guard kept)', async () => {
+    await searchService.searchBottles('wine', { cellarIds: ['"', '""'] });
+    expect(lastFilter()).toEqual(expect.arrayContaining([MATCH_NOTHING]));
+  });
+
+  test('a single cellar scopes to exactly that cellar', async () => {
+    await searchService.searchBottles('wine', { cellarId: 'aaaaaaaaaaaaaaaaaaaaaaaa' });
+    const f = lastFilter();
+    expect(f).toEqual(expect.arrayContaining(['cellarId = "aaaaaaaaaaaaaaaaaaaaaaaa"']));
+    expect(f).not.toEqual(expect.arrayContaining([MATCH_NOTHING]));
+  });
+
+  test('several cellars scope to exactly those cellars, quotes stripped', async () => {
+    await searchService.searchBottles('wine', { cellarIds: ['aaaaaaaaaaaaaaaaaaaaaaaa', 'bbbb"bbbb'] });
+    const f = lastFilter();
+    expect(f).toEqual(expect.arrayContaining(['cellarId IN ["aaaaaaaaaaaaaaaaaaaaaaaa","bbbbbbbb"]']));
+    expect(f).not.toEqual(expect.arrayContaining([MATCH_NOTHING]));
+  });
+});


### PR DESCRIPTION
## What was wrong

`searchBottles` only fell back to a match-nothing filter when cellar ids had been supplied but all stripped to empty. An **empty** scope — an account that owns no cellar, i.e. every account right after registration — produced no cellar filter at all, so the Meilisearch query ran across the whole bottles index. The MCP `search_bottles` tool derives its scope from the user's owned cellars and hydrated whatever the index returned, so that path was reachable from any connected MCP client on the ordinary `read` scope. The REST cellar views already refuse an empty scope and were not affected.

## The fix

- `services/search.js`: no usable scope ⇒ the match-nothing filter, always. There is no legitimate unscoped caller (all eight call sites pass an access-checked scope).
- `mcp/tools/bottles.js`: `search_bottles` answers an empty page before touching either backend when the user owns no cellar; Meili hydration re-asserts the same cellar scope as defence in depth. That cannot change page composition in normal operation (the ids already satisfy it) — it only drops a hit whose index document is stale, which must not be shown anyway.

## Tests

- New `services/search.scope.test.js`: empty / absent / stripped / single / multiple scopes.
- `mcp/readTools.test.js`: empty-scope early return (never queries the index), scope-bound hydration with no other post-pagination filters; two fixtures that modelled the bug case now use a real scope.
- Run in node:24-alpine: 6 suites, 61 tests green.

## Rollout

Backend-only. Ship as **v1.197.1** and deploy the backend ahead of tonight's window.

Found by the 2026-09-02 security audit (ledger D10-5).