### PR TITLE
fix(security): audit follow-ups — literal prompt fill, import maturity trust, preview budget, limiter key

### DIFF
--- a/backend/src/mcp/actionLedger.js
+++ b/backend/src/mcp/actionLedger.js
@@ -157,4 +157,27 @@ async function releaseClaim(ctx, idempotencyKey, toolName) {
   } catch { /* best-effort; a leftover stub goes stale-reclaimable, then TTL */ }
 }
 
-module.exports = { logAction, replay, releaseClaim, CLAIM_STALE_MS };
+/**
+ * Keep at most `keep` UNCONSUMED preview rows per user and action, deleting
+ * the oldest. Call BEFORE creating the new preview row.
+ *
+ * Previews are stubs — never shown in the timeline, never undo-eligible — but
+ * their `prev` carries the whole request so apply can re-read it: up to
+ * ~250 KB for a 24-item bulk_add at the field caps. Preview never consumed a
+ * write slot (it changes nothing), so a looping client could park an
+ * unbounded number of those blobs in McpActionLog under a 90-day TTL — a
+ * disk-fill from one free account (audit 2026-09-02 D08-1). Consumed previews
+ * already drop `prev` at claim time; this bounds the unconsumed ones.
+ */
+async function trimOutstandingPreviews(userId, action, keep) {
+  const stale = await McpActionLog.find({ user: userId, action, reversed: false })
+    .sort({ createdAt: -1 })
+    .skip(Math.max(0, keep - 1))
+    .select('_id')
+    .lean();
+  if (!stale || stale.length === 0) return 0;
+  await McpActionLog.deleteMany({ _id: { $in: stale.map((s) => s._id) } });
+  return stale.length;
+}
+
+module.exports = { logAction, replay, releaseClaim, trimOutstandingPreviews, CLAIM_STALE_MS };

--- a/backend/src/mcp/arrangeTasting.test.js
+++ b/backend/src/mcp/arrangeTasting.test.js
@@ -28,7 +28,7 @@ jest.mock('../models/JournalEntry', () => ({ create: jest.fn(), deleteOne: jest.
 jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
 jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
 jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
-jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), find: jest.fn(), deleteMany: jest.fn() }));
 jest.mock('../services/search', () => ({ getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn() }));
 jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), buildEmptyStats: jest.fn() }));
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
@@ -97,6 +97,8 @@ beforeEach(() => {
   McpActionLog.findOne.mockReturnValue(chain(null));
   McpActionLog.create.mockResolvedValue({ _id: new mongoose.Types.ObjectId(oid('f')) });
   McpActionLog.findOneAndUpdate.mockResolvedValue({ _id: 'claimed' });
+  McpActionLog.find.mockReturnValue(chain([]));
+  McpActionLog.deleteMany.mockResolvedValue({ deletedCount: 0 });
 });
 
 describe('registration & scope', () => {
@@ -127,6 +129,19 @@ describe('auto_arrange preview', () => {
     ]);
     expect(stored.prev.target[0]).toEqual({ position: 1, bottleId: oid('2') });
     expect(rack.save).not.toHaveBeenCalled(); // preview never mutates
+    // A stored preview costs one write slot and trims older unconsumed ones (audit 2026-09-02 D08-1)
+    expect(takeMutationSlot).toHaveBeenCalledWith(ME, 1, null);
+    expect(McpActionLog.find).toHaveBeenCalledWith({ user: ME, action: 'arrange_preview', reversed: false });
+  });
+
+  test('preview refuses on an exhausted write budget and stores nothing', async () => {
+    const rack = mkRack();
+    wireRackLoad(rack);
+    takeMutationSlot.mockReturnValue(false);
+    const res = await tool('auto_arrange').handler({ rack_id: oid('e'), strategy: 'maturity' }, CTX);
+    expect(parse(res).error.code).toBe('rate_limited');
+    expect(McpActionLog.create).not.toHaveBeenCalled();
+    expect(rack.save).not.toHaveBeenCalled();
   });
 
   test('already-arranged rack → no ledger row, nothing to apply', async () => {

--- a/backend/src/mcp/bulkTools.test.js
+++ b/backend/src/mcp/bulkTools.test.js
@@ -21,7 +21,7 @@ jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: je
 jest.mock('../models/WineDefinition', () => ({ find: jest.fn(), findById: jest.fn() }));
 jest.mock('../models/User', () => ({ findById: jest.fn() }));
 jest.mock('../models/WineEmbedding', () => ({ findOne: jest.fn() }));
-jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../models/McpActionLog', () => ({ create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), find: jest.fn(), deleteMany: jest.fn() }));
 jest.mock('../utils/rackGeometry', () => ({ getMaxPosition: jest.fn(() => 12) }));
 jest.mock('../services/search', () => ({ getIsAvailable: jest.fn(() => false), search: jest.fn(), searchBottles: jest.fn() }));
 jest.mock('../services/statsService', () => ({ computeOverview: jest.fn(), buildEmptyStats: jest.fn() }));
@@ -61,6 +61,8 @@ beforeEach(() => {
   takeMutationSlot.mockReturnValue(true);
   McpActionLog.create.mockResolvedValue({ _id: oid('9') });
   McpActionLog.findOneAndUpdate.mockResolvedValue(null); // claims fail unless a test arms them
+  McpActionLog.find.mockReturnValue(chain([])); // no older unconsumed previews unless a test plants them
+  McpActionLog.deleteMany.mockResolvedValue({ deletedCount: 0 });
 });
 
 describe('preview', () => {
@@ -83,6 +85,35 @@ describe('preview', () => {
     for (const call of findOrCreateWine.mock.calls) expect(call[2]).toEqual({ matchOnly: true });
     // plan persisted for the apply step
     expect(McpActionLog.create.mock.calls[0][0].action).toBe('bulk_preview');
+    // …and the preview itself is budgeted: ceil(3/4) = 1 slot, older unconsumed previews trimmed
+    expect(takeMutationSlot).toHaveBeenCalledWith(ME, 1, null);
+    expect(McpActionLog.find).toHaveBeenCalledWith({ user: ME, action: 'bulk_preview', reversed: false });
+  });
+
+  // Security audit 2026-09-02 (D08-1): preview charged nothing and stored the
+  // whole request (~250 KB at the caps) in a 90-day-TTL row, so a looping
+  // client could fill the disk from one free account.
+  test('preview charges a quarter of the batch BEFORE resolving anything, and refuses on an exhausted budget', async () => {
+    ownCellar();
+    takeMutationSlot.mockReturnValue(false);
+    const res = await tool('bulk_add').handler({ cellar_id: oid('c'), items: Array.from({ length: 24 }, () => ({ new_wine: NEW })) }, CTX);
+    expect(parse(res).error.code).toBe('rate_limited');
+    expect(takeMutationSlot).toHaveBeenCalledWith(ME, 6, null); // ceil(24/4)
+    expect(findOrCreateWine).not.toHaveBeenCalled(); // the registry work is what the charge protects
+    expect(McpActionLog.create).not.toHaveBeenCalled();
+  });
+
+  test('a new preview evicts unconsumed previews beyond the newest five', async () => {
+    ownCellar();
+    findOrCreateWine.mockResolvedValue({ wine: null, noMatch: true });
+    McpActionLog.find.mockReturnValue(chain([{ _id: 'old1' }, { _id: 'old2' }]));
+    await tool('bulk_add').handler({ cellar_id: oid('c'), items: [{ new_wine: NEW }] }, CTX);
+    // find(...).sort(desc).skip(4) → everything past the newest four existing rows goes
+    const q = McpActionLog.find.mock.results[0].value;
+    expect(q.sort).toHaveBeenCalledWith({ createdAt: -1 });
+    expect(q.skip).toHaveBeenCalledWith(4);
+    expect(McpActionLog.deleteMany).toHaveBeenCalledWith({ _id: { $in: ['old1', 'old2'] } });
+    expect(McpActionLog.create).toHaveBeenCalledTimes(1); // the new row still lands
   });
 
   test('invalid fields are flagged per item', async () => {

--- a/backend/src/mcp/tools/arrange.js
+++ b/backend/src/mcp/tools/arrange.js
@@ -25,8 +25,12 @@ const { ARRANGE_STRATEGIES, buildArrangePlan } = require('../../utils/rackArrang
 const { buildAnnotatedEntries, applyArrangement } = require('../../services/rackOps');
 const { isValidId } = require('../../utils/validation');
 const { ok, fail, objectId, resolveCellarAccess } = require('../toolUtil');
-const { logAction } = require('../actionLedger');
+const { logAction, trimOutstandingPreviews } = require('../actionLedger');
 const { takeMutationSlot, ipKeyFor } = require('../mutationBudget');
+
+// Unconsumed arrange previews kept per user (audit 2026-09-02 D08-1); the
+// plan for a full rack is small, but the row count was unbounded.
+const MAX_OUTSTANDING_PREVIEWS = 5;
 
 const PREVIEW_FRESH_MS = 15 * 60 * 1000;
 const NOT_FOUND = 'No such rack, or you have no access to it. Use list_racks for valid ids.';
@@ -114,6 +118,13 @@ registerTool({
 
       const before = occupancyOf(rack);
       const moveList = changes.map((c) => ({ bottle: labelOf(c.bottle), from: c.from, to: c.to }));
+      // A preview costs one write slot and evicts the oldest unconsumed ones
+      // (D08-1) — the early returns above (empty / already arranged /
+      // overflow) stay free because they store nothing.
+      if (!takeMutationSlot(String(ctx.user.id), 1, ipKeyFor(ctx))) {
+        return fail('rate_limited', 'Too many previews in a short time — wait a few minutes before previewing again, or apply the last one.');
+      }
+      await trimOutstandingPreviews(ctx.user.id, 'arrange_preview', MAX_OUTSTANDING_PREVIEWS);
       const row = await McpActionLog.create({
         user: ctx.user.id,
         tokenId: ctx.req?.apiToken?.id || null,

--- a/backend/src/mcp/tools/bulk.js
+++ b/backend/src/mcp/tools/bulk.js
@@ -25,11 +25,19 @@ const WineDefinition = require('../../models/WineDefinition');
 const { findVisibleWine } = require('../../services/wineVisibility');
 const { NEW_WINE_SHAPE } = require('./write');
 const { ok, fail, objectId, MSG_CELLAR_NOT_FOUND, resolveCellarAccess, wineSummary } = require('../toolUtil');
-const { logAction } = require('../actionLedger');
+const { logAction, trimOutstandingPreviews } = require('../actionLedger');
 const { takeMutationSlot, ipKeyFor } = require('../mutationBudget');
 
 const MAX_ITEMS = 24; // two cases — keeps one batch well inside the write budget
 const PREVIEW_FRESH_MS = 15 * 60 * 1000;
+// Unconsumed previews kept per user; older ones are deleted when a new one is
+// made (audit 2026-09-02 D08-1). Five is plenty for an agent that previews a
+// couple of batches before applying them.
+const MAX_OUTSTANDING_PREVIEWS = 5;
+// Preview is not free: it runs up to MAX_ITEMS registry resolutions and parks
+// the whole request in the ledger. Charge a quarter of the batch (min 1) — a
+// full-case preview→apply round trip costs 6 + 24 of the 60-slot window.
+const previewCost = (n) => Math.max(1, Math.ceil(n / 4));
 
 const ITEM_SHAPE = z.object({
   wine_id: z.string().optional(),
@@ -128,6 +136,13 @@ registerTool({
       }
       const access = await resolveCellarAccess(ctx.user.id, args.cellar_id, 'editor');
       if (!access) return fail('not_found', MSG_CELLAR_NOT_FOUND);
+
+      // Charged BEFORE the registry resolutions below — they are the work a
+      // looping client would otherwise get for free (D08-1).
+      if (!takeMutationSlot(String(ctx.user.id), previewCost(args.items.length), ipKeyFor(ctx))) {
+        return fail('rate_limited', 'Too many previews in a short time — wait a few minutes before previewing again, or apply the last one.');
+      }
+      await trimOutstandingPreviews(ctx.user.id, 'bulk_preview', MAX_OUTSTANDING_PREVIEWS);
 
       const plan = [];
       for (let i = 0; i < args.items.length; i++) {

--- a/backend/src/routes/cellarImport.js
+++ b/backend/src/routes/cellarImport.js
@@ -265,6 +265,10 @@ router.post('/', gateImport, handleUpload, async (req, res) => {
         mode: targets[i].mode,
         getFileBuffer,
         defaultCurrency,
+        // Only a sommelier/admin restores a file's drink windows as REVIEWED
+        // registry data; anyone else's land as pending suggestions (D09-4).
+        canCurate: req.user.roles.includes('somm') || req.user.roles.includes('admin'),
+        audit: (action, resource, detail) => logAudit(req, action, resource, detail),
       });
       results.push(r);
     }

--- a/backend/src/routes/taxonomy.js
+++ b/backend/src/routes/taxonomy.js
@@ -15,6 +15,7 @@ const Grape = require('../models/Grape');
 const WineDefinition = require('../models/WineDefinition');
 const { parsePagination } = require('../utils/pagination');
 const { baseLanguage, localizedName } = require('../utils/localizedName');
+const { rateLimitKey } = require('../utils/clientIp');
 
 const router = express.Router();
 
@@ -25,7 +26,13 @@ const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 60,
   standardHeaders: true,
-  legacyHeaders: false
+  legacyHeaders: false,
+  // Key on the real client, as every other per-IP limiter does. Without it
+  // the key was req.ip — the Cloudflare edge on the hosted instance — so every
+  // visitor arriving through the same edge shared ONE 60-request bucket, and
+  // this router also serves /display-names, which the logged-in app loads
+  // (audit 2026-09-02, phase 1).
+  keyGenerator: rateLimitKey,
 });
 router.use(limiter);
 

--- a/backend/src/services/aiBudget.js
+++ b/backend/src/services/aiBudget.js
@@ -190,6 +190,7 @@ function isRefundableFailure(debugReason) {
   if (!debugReason) return false;
   return debugReason === 'no_api_key'
     || debugReason === 'rate_limit_exceeded'
+    || debugReason === 'prompt_too_long' // refused before any request was made
     || debugReason.startsWith('exception');
 }
 

--- a/backend/src/services/aiBudget.test.js
+++ b/backend/src/services/aiBudget.test.js
@@ -195,6 +195,7 @@ describe('per-user override (admin-granted AiBudgetRequest)', () => {
 describe('isRefundableFailure', () => {
   test('transport-level failures are refundable', () => {
     expect(isRefundableFailure('rate_limit_exceeded')).toBe(true);
+    expect(isRefundableFailure('prompt_too_long')).toBe(true); // refused before any request (audit 2026-09-02 D10-9)
     expect(isRefundableFailure('exception: socket hang up')).toBe(true);
     expect(isRefundableFailure('no_api_key')).toBe(true);
   });

--- a/backend/src/services/cellarImport.js
+++ b/backend/src/services/cellarImport.js
@@ -668,8 +668,18 @@ async function attachReviews(bottle, reviews, userId, wineDefinitionId, result) 
  *  overwrites curated maturity data, so it can't poison a shared registry. On a
  *  fresh instance (the self-hosted migration case) where no profile exists yet,
  *  the imported window is restored in full. Deduped per wine+vintage via `seen`
- *  so bottles that share a wine only trigger this once. */
-async function attachMaturity(maturity, wineDefinitionId, vintage, result, seen) {
+ *  so bottles that share a wine only trigger this once.
+ *
+ *  Status follows the IMPORTER, not the file (audit 2026-09-02 D09-4): only a
+ *  sommelier/admin — someone who could set the same window by hand — restores
+ *  it as `reviewed`. utils/maturityUtils gates every reader on
+ *  status === 'reviewed', so a reviewed row from anyone's file was
+ *  indistinguishable from curated data and became the drink window every
+ *  other user of that wine+vintage saw, with the file's notes shown as the
+ *  sommelier's. Any other importer's window lands as a PENDING suggestion:
+ *  numbers and notes kept for the sommelier queue, nothing published until a
+ *  curator reviews it — the same path a hand-added bottle takes. */
+async function attachMaturity(maturity, wineDefinitionId, vintage, result, seen, { canCurate = false, userId = null, audit = null } = {}) {
   if (!maturity || typeof maturity !== 'object') return;
   if (!wineDefinitionId || !vintage || vintage === 'NV') return;
 
@@ -690,15 +700,26 @@ async function attachMaturity(maturity, wineDefinitionId, vintage, result, seen)
       .findOne({ wineDefinition: wineDefinitionId, vintage }).select('_id').lean();
     if (existing) { result.maturitySkipped++; return; } // never clobber existing curated data
 
-    await WineVintageProfile.create({
+    const reviewed = canCurate === true;
+    const profile = await WineVintageProfile.create({
       wineDefinition: wineDefinitionId,
       vintage,
-      status: 'reviewed',
+      status: reviewed ? 'reviewed' : 'pending',
       relative: !!maturity.relative,
       ...fields,
       sommNotes: maturity.sommNotes ? stripHtml(String(maturity.sommNotes)).slice(0, 2000) : undefined,
+      setBy: userId || null,
+      setAt: reviewed ? new Date() : null,
     });
-    result.maturityCreated++;
+    if (reviewed) result.maturityCreated++;
+    else result.maturitySuggested++;
+    // Shared-data write visible to every user of this wine+vintage (when
+    // reviewed) or queued for a curator (when pending) — audited like the
+    // somm route's own review is.
+    if (typeof audit === 'function') {
+      audit('cellar.import.maturity', { type: 'wine', id: wineDefinitionId },
+        { vintage, status: reviewed ? 'reviewed' : 'pending', profileId: profile?._id || null });
+    }
   } catch {
     // Unique-index race (another bottle created it first) or a validation miss —
     // treat as skipped rather than failing the whole import.
@@ -749,7 +770,7 @@ async function createLayout(cellarId, layout, result) {
  * `result`; only an unexpected failure rejects. Returns the ids of the active
  * bottles created, for search indexing.
  */
-async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, imagesByIndex, anchor, getFileBuffer, defaultCurrency, result, demoMode = false }) {
+async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, imagesByIndex, anchor, getFileBuffer, defaultCurrency, result, demoMode = false, canCurate = false, audit = null }) {
   // Racks (exact geometry, fallback inference), then the 3D room layout.
   await createRacks(cellarId, ownerId, cellar, items, result);
   await createLayout(cellarId, cellar.layout, result);
@@ -839,7 +860,7 @@ async function buildCellarContents({ cellarId, ownerId, userId, cellar, items, i
       // registry wine's existing profile at read time.
       if (!demoMode) {
         await attachReviews(bottle, item.reviews, userId, wine.wineDefinitionId, result);
-        await attachMaturity(item.maturity, wine.wineDefinitionId, canonicalVintage, result, seenMaturity);
+        await attachMaturity(item.maturity, wine.wineDefinitionId, canonicalVintage, result, seenMaturity, { canCurate, userId, audit });
       }
 
       // Seed the sommelier maturity queue for resolved wines that didn't carry a
@@ -932,6 +953,9 @@ async function importCellar(userId, cellar, opts) {
     reviewsCreated: 0,
     reviewsSkipped: 0,
     maturityCreated: 0,
+    // Windows from a non-curator's file, stored as pending suggestions for
+    // the sommelier queue (see attachMaturity).
+    maturitySuggested: 0,
     maturitySkipped: 0,
     layoutImported: false,
     errors: [],
@@ -965,6 +989,10 @@ async function importCellar(userId, cellar, opts) {
       items, imagesByIndex, anchor, getFileBuffer,
       defaultCurrency: opts.defaultCurrency, result,
       demoMode: !!opts.demoMode,
+      // Registry-facing trust of the importer (somm/admin) and the caller's
+      // audit hook — the service has no req of its own.
+      canCurate: opts.canCurate === true,
+      audit: typeof opts.audit === 'function' ? opts.audit : null,
     });
     if (liveCellar) {
       swapStarted = true;

--- a/backend/src/services/cellarImport.test.js
+++ b/backend/src/services/cellarImport.test.js
@@ -295,20 +295,53 @@ describe('buildBottle drink window + occasion', () => {
 describe('attachMaturity', () => {
   const mockExisting = (existing) =>
     WineVintageProfile.findOne.mockReturnValue({ select: () => ({ lean: () => Promise.resolve(existing) }) });
-  const freshResult = () => ({ maturityCreated: 0, maturitySkipped: 0 });
+  const freshResult = () => ({ maturityCreated: 0, maturitySuggested: 0, maturitySkipped: 0 });
 
   beforeEach(() => jest.clearAllMocks());
 
-  test('creates a reviewed profile when the destination has none', async () => {
+  test('a sommelier/admin importer restores a REVIEWED profile when the destination has none, audited', async () => {
+    mockExisting(null);
+    WineVintageProfile.create.mockResolvedValue({ _id: 'p9' });
+    const result = freshResult();
+    const audit = jest.fn();
+    await attachMaturity({ relative: false, peakFrom: 2026, peakUntil: 2032, sommNotes: 'hold' }, 'w1', '2018', result, new Set(), { canCurate: true, userId: 'u1', audit });
+    expect(WineVintageProfile.create).toHaveBeenCalledWith(expect.objectContaining({
+      wineDefinition: 'w1', vintage: '2018', status: 'reviewed', peakFrom: 2026, peakUntil: 2032, setBy: 'u1',
+    }));
+    expect(WineVintageProfile.create.mock.calls[0][0].setAt).toBeInstanceOf(Date);
+    expect(result.maturityCreated).toBe(1);
+    expect(result.maturitySuggested).toBe(0);
+    expect(result.maturitySkipped).toBe(0);
+    expect(audit).toHaveBeenCalledWith('cellar.import.maturity', { type: 'wine', id: 'w1' },
+      expect.objectContaining({ vintage: '2018', status: 'reviewed', profileId: 'p9' }));
+  });
+
+  // Security audit 2026-09-02 (D09-4): any registered user could write a
+  // sommelier-status drink window into the shared registry from a plain JSON
+  // file, and every other user of that wine+vintage saw it as curated.
+  test("an ordinary importer's window becomes a PENDING suggestion, never a reviewed profile", async () => {
+    mockExisting(null);
+    WineVintageProfile.create.mockResolvedValue({ _id: 'p2' });
+    const result = freshResult();
+    const audit = jest.fn();
+    await attachMaturity({ peakFrom: 2026, peakUntil: 2032, sommNotes: 'trust me' }, 'w1', '2018', result, new Set(), { canCurate: false, userId: 'u2', audit });
+    const created = WineVintageProfile.create.mock.calls[0][0];
+    expect(created).toEqual(expect.objectContaining({
+      wineDefinition: 'w1', vintage: '2018', status: 'pending', peakFrom: 2026, peakUntil: 2032, sommNotes: 'trust me', setBy: 'u2', setAt: null,
+    }));
+    expect(result.maturityCreated).toBe(0);
+    expect(result.maturitySuggested).toBe(1);
+    expect(audit).toHaveBeenCalledWith('cellar.import.maturity', { type: 'wine', id: 'w1' },
+      expect.objectContaining({ status: 'pending' }));
+  });
+
+  test('with no importer context at all the profile is pending (fail closed)', async () => {
     mockExisting(null);
     WineVintageProfile.create.mockResolvedValue({});
     const result = freshResult();
-    await attachMaturity({ relative: false, peakFrom: 2026, peakUntil: 2032, sommNotes: 'hold' }, 'w1', '2018', result, new Set());
-    expect(WineVintageProfile.create).toHaveBeenCalledWith(expect.objectContaining({
-      wineDefinition: 'w1', vintage: '2018', status: 'reviewed', peakFrom: 2026, peakUntil: 2032,
-    }));
-    expect(result.maturityCreated).toBe(1);
-    expect(result.maturitySkipped).toBe(0);
+    await attachMaturity({ peakFrom: 2026 }, 'w1', '2018', result, new Set());
+    expect(WineVintageProfile.create.mock.calls[0][0].status).toBe('pending');
+    expect(result.maturitySuggested).toBe(1);
   });
 
   test('never overwrites an existing profile (create-only)', async () => {
@@ -335,8 +368,8 @@ describe('attachMaturity', () => {
     WineVintageProfile.create.mockResolvedValue({});
     const result = freshResult();
     const seen = new Set();
-    await attachMaturity({ peakFrom: 2026 }, 'w1', '2018', result, seen);
-    await attachMaturity({ peakFrom: 2026 }, 'w1', '2018', result, seen); // same key → no-op
+    await attachMaturity({ peakFrom: 2026 }, 'w1', '2018', result, seen, { canCurate: true });
+    await attachMaturity({ peakFrom: 2026 }, 'w1', '2018', result, seen, { canCurate: true }); // same key → no-op
     expect(WineVintageProfile.create).toHaveBeenCalledTimes(1);
     expect(result.maturityCreated).toBe(1);
   });

--- a/backend/src/services/labelScan.js
+++ b/backend/src/services/labelScan.js
@@ -18,6 +18,52 @@ function getClient() {
 }
 
 /**
+ * Prompt-substitution helpers shared by EVERY prompt builder in this file.
+ *
+ * field(): user- or registry-authored text on its way into a prompt — control
+ * characters out (a newline is what lets injected text pose as a new
+ * instruction), whitespace collapsed, length bounded. 200 chars by default: no
+ * real wine field comes close, and the import parser caps rows at the same
+ * bound. Free-text search queries get the route's own 300-char cap.
+ *
+ * put(): substitute one placeholder with a replacer FUNCTION. Not cosmetic:
+ * with a string replacement, String.prototype.replace honours `$&`, `` $` ``,
+ * `$'` and `$$` inside it even for a plain-string pattern, so a wine named
+ * `$'` expands to the whole remainder of the template — a well-formed prompt
+ * followed by the attacker's own trailing instruction, and each occurrence
+ * re-inserts the template again (~30-100x the token bill per call, billed to
+ * the operator's key and invisible to the per-CALL AI budget). A replacer
+ * function is inserted literally and honours nothing. replaceAll, not
+ * replace, because the templates are superadmin-overridable via SiteConfig
+ * and a custom one may use a placeholder twice.
+ *
+ * fill(): apply [token, value] pairs in order through put().
+ *
+ * History: the 2026-08-03 audit fixed suggestProfile and scanLabelBack this
+ * way; the 2026-09-02 audit (D10-9) found identifyWineFromText,
+ * identifyWineFromQuery, suggestDrinkWindow and suggestPrice still on raw
+ * .replace(token, string). Every builder now goes through fill() — and
+ * callClaudeJson refuses an assembled prompt over MAX_PROMPT_CHARS as the
+ * backstop for a customised template or a future builder that bypasses it.
+ */
+const PROMPT_FIELD_MAX = 200;
+const QUERY_FIELD_MAX = 300; // mirrors MAX_AI_QUERY_LEN in routes/wines.js
+const field = (v, max = PROMPT_FIELD_MAX) =>
+  String(v ?? '')
+    .replace(/\p{C}/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max);
+const put = (template, token, value) => String(template ?? '').replaceAll(token, () => value);
+const fill = (template, pairs) => pairs.reduce((acc, [token, value]) => put(acc, token, value), String(template ?? ''));
+
+// Largest default template is the 8.3 KB enrichment prompt; with every field
+// capped at 200 chars no legitimate prompt reaches half of this. A prompt
+// that does was amplified or hand-edited into something we should not pay
+// for — refuse before the request is made (the reason is refundable).
+const MAX_PROMPT_CHARS = 24 * 1024;
+
+/**
  * Derive a quality tier from the wine name and appellation.
  * Used by the maturity suggest prompt to give the AI a baseline signal.
  */
@@ -184,15 +230,7 @@ async function scanLabelBack({ backImage, backMediaType = 'image/jpeg', frontIma
 
   // EVERY value below is client-supplied text on its way into a prompt — the
   // client sends back the front extraction it was handed, and nothing stops it
-  // sending something else. Identical sanitisation to suggestProfile.field():
-  // control characters out (a newline is what lets injected text pose as a new
-  // instruction), whitespace collapsed, length bounded.
-  const field = (v) =>
-    String(v ?? '')
-      .replace(/\p{C}/gu, ' ')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, 200);
+  // sending something else. field() (top of this file) sanitises each one.
 
   // Per NAME, not on a joined string — capping a join can cut a varietal
   // mid-word (suggestProfile carries the same note for the same reason).
@@ -215,20 +253,7 @@ async function scanLabelBack({ backImage, backMediaType = 'image/jpeg', frontIma
     grapes,
   });
 
-  /**
-   * Substitute one placeholder with a replacer FUNCTION.
-   *
-   * Not cosmetic: with a string replacement, String.prototype.replace honours
-   * `$&`, `` $` ``, `$'` and `$$` inside it even for a plain-string pattern, so
-   * a producer named `$'` expands to the whole remainder of the template —
-   * a well-formed prompt followed by the attacker's own trailing instruction,
-   * at ~30x the token bill. A replacer function is inserted literally.
-   *
-   * replaceAll, not replace, because the template is superadmin-overridable via
-   * SiteConfig and a custom one may use the placeholder twice.
-   */
-  const put = (template, token, value) => template.replaceAll(token, () => value);
-
+  // put() inserts literally — see the shared helpers at the top of this file.
   const prompt = put(aiConfig.get().labelScanBackPrompt, '{{frontData}}', frontData);
 
   // Image ORDER is the contract the prompt states (front first, back second).
@@ -389,6 +414,13 @@ function mergeBackScan(front = {}, back = {}, { suspectProducer = false } = {}) 
  * On 429 the call is retried once after waiting out the retry-after header.
  */
 async function callClaudeJson({ client, model, maxTokens, prompt, validate, tools }) {
+  // Backstop (audit 2026-09-02 D10-9): every builder inserts fields literally,
+  // but a superadmin-customised template or a future builder that bypasses
+  // fill() must still not turn one call into a 100k-token request. Refused
+  // before any request is made, so the reason is refundable.
+  if (typeof prompt === 'string' && prompt.length > MAX_PROMPT_CHARS) {
+    return { data: null, debugRaw: null, debugReason: 'prompt_too_long' };
+  }
   const apiParams = {
     model,
     max_tokens: maxTokens,
@@ -483,7 +515,7 @@ async function identifyWineFromText({ name, producer, vintage, country, appellat
   let client;
   try { client = getClient(); } catch { return { data: null, debugRaw: null, debugReason: 'no_api_key' }; }
 
-  const vintageHint = vintage && vintage !== 'NV' ? `Vintage: ${vintage}\n` : '';
+  const vintageHint = vintage && vintage !== 'NV' ? `Vintage: ${field(vintage, 12)}\n` : '';
 
   // The user's own file already states the geography on most exports
   // (CellarTracker has Appellation and a Country/Region/SubRegion/Appellation
@@ -504,7 +536,7 @@ async function identifyWineFromText({ name, producer, vintage, country, appellat
   // a pathological column inflates every identify call's token count (billed to
   // the user's own AI budget) and widens the prompt-injection surface for no
   // benefit: no real appellation approaches 200 characters.
-  const hint = (v) => String(v).slice(0, 200);
+  const hint = (v) => field(v);
   const hints = [
     country ? `Country hint: ${hint(country)}` : '',
     appellation ? `Appellation stated in the user's import file (trust it unless it is clearly not a wine appellation): ${hint(appellation)}` : '',
@@ -512,11 +544,16 @@ async function identifyWineFromText({ name, producer, vintage, country, appellat
   ].filter(Boolean);
   const countryHint = hints.length ? `${hints.join('\n')}\n` : '';
 
-  const prompt = aiConfig.get().importLookupPrompt
-    .replace('{{name}}', name)
-    .replace('{{producer}}', producer)
-    .replace('{{vintage}}', vintageHint)
-    .replace('{{country}}', countryHint);
+  // name/producer come straight from the user's file: sanitised and inserted
+  // literally (audit 2026-09-02 D10-9 — a `$'` producer used to re-insert the
+  // template per occurrence). The hint strings are built above from field()
+  // output; their newlines are ours.
+  const prompt = fill(aiConfig.get().importLookupPrompt, [
+    ['{{name}}', field(name)],
+    ['{{producer}}', field(producer)],
+    ['{{vintage}}', vintageHint],
+    ['{{country}}', countryHint],
+  ]);
 
   return callClaudeJson({
     client,
@@ -538,7 +575,8 @@ async function identifyWineFromQuery(query) {
   try { client = getClient(); } catch { return { data: null, debugRaw: null, debugReason: 'no_api_key' }; }
 
   const { DEFAULT_TEXT_SEARCH_PROMPT } = require('../config/aiConfig');
-  const prompt = DEFAULT_TEXT_SEARCH_PROMPT.replace('{{query}}', query.trim());
+  // Free text typed by the user, inserted literally (audit 2026-09-02 D10-9).
+  const prompt = fill(DEFAULT_TEXT_SEARCH_PROMPT, [['{{query}}', field(query, QUERY_FIELD_MAX)]]);
 
   return callClaudeJson({
     client,
@@ -570,16 +608,19 @@ async function suggestDrinkWindow({ name, producer, vintage, country, region, ap
   const isNv = vintage === 'NV';
   const template = isNv ? aiConfig.get().maturitySuggestPromptNv : aiConfig.get().maturitySuggestPrompt;
 
-  const prompt = template
-    .replace('{{name}}', name || '')
-    .replace('{{producer}}', producer || '')
-    .replace('{{vintage}}', vintage || '')
-    .replace('{{country}}', country || '')
-    .replace('{{region}}', region || '')
-    .replace('{{appellation}}', appellation || '')
-    .replace('{{type}}', type || '')
-    .replace('{{grapes}}', Array.isArray(grapes) ? grapes.join(', ') : (grapes || ''))
-    .replace('{{qualityTier}}', qualityTier);
+  // Registry text a user can author — sanitised and inserted literally
+  // (audit 2026-09-02 D10-9). Grapes are capped per NAME, not on the join.
+  const prompt = fill(template, [
+    ['{{name}}', field(name)],
+    ['{{producer}}', field(producer)],
+    ['{{vintage}}', field(vintage, 12)],
+    ['{{country}}', field(country)],
+    ['{{region}}', field(region)],
+    ['{{appellation}}', field(appellation)],
+    ['{{type}}', field(type)],
+    ['{{grapes}}', (Array.isArray(grapes) ? grapes : [grapes]).map((g) => field(g)).filter(Boolean).slice(0, 20).join(', ')],
+    ['{{qualityTier}}', qualityTier],
+  ]);
 
   return callClaudeJson({
     client,
@@ -602,17 +643,19 @@ async function suggestPrice({ name, producer, vintage, country, region, appellat
 
   const qualityTier = classifyQualityTier({ name, appellation });
 
-  const prompt = aiConfig.get().priceSuggestPrompt
-    .replace('{{name}}', name || '')
-    .replace('{{producer}}', producer || '')
-    .replace('{{vintage}}', vintage || '')
-    .replace('{{country}}', country || '')
-    .replace('{{region}}', region || '')
-    .replace('{{appellation}}', appellation || '')
-    .replace('{{classification}}', classification || '')
-    .replace('{{type}}', type || '')
-    .replace('{{grapes}}', Array.isArray(grapes) ? grapes.join(', ') : (grapes || ''))
-    .replace('{{qualityTier}}', qualityTier);
+  // Same rule as suggestDrinkWindow: literal, sanitised, per-name grape cap.
+  const prompt = fill(aiConfig.get().priceSuggestPrompt, [
+    ['{{name}}', field(name)],
+    ['{{producer}}', field(producer)],
+    ['{{vintage}}', field(vintage, 12)],
+    ['{{country}}', field(country)],
+    ['{{region}}', field(region)],
+    ['{{appellation}}', field(appellation)],
+    ['{{classification}}', field(classification)],
+    ['{{type}}', field(type)],
+    ['{{grapes}}', (Array.isArray(grapes) ? grapes : [grapes]).map((g) => field(g)).filter(Boolean).slice(0, 20).join(', ')],
+    ['{{qualityTier}}', qualityTier],
+  ]);
 
   return callClaudeJson({
     client,
@@ -642,13 +685,8 @@ async function suggestProfile({ name, producer, vintage, country, region, appell
   // registry. Collapse whitespace (a newline is what lets injected text pose as
   // a new instruction), drop control characters, and bound the length. The mint
   // chokepoint now normalises region and grape names too, but this has to hold
-  // for rows that predate that and for any caller that bypasses it.
-  const field = (v) =>
-    String(v ?? '')
-      .replace(/\p{C}/gu, ' ')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, 200);
+  // for rows that predate that and for any caller that bypasses it. field()
+  // and put() are the shared helpers at the top of this file.
 
   // Per NAME, not on the joined string: capping the join truncated the tail of a
   // large blend and could cut a varietal mid-word before it reached a prompt
@@ -658,23 +696,6 @@ async function suggestProfile({ name, producer, vintage, country, region, appell
     .filter(Boolean)
     .slice(0, 20)
     .join(', ');
-
-  /**
-   * Substitute one placeholder.
-   *
-   * The replacement is a FUNCTION, and that is the whole point: with a string
-   * replacement, `String.prototype.replace` honours `$&`, `` $` ``, `$'` and
-   * `$$` inside it — even when the search pattern is a plain string. A wine
-   * named `$'` therefore expanded to the entire remainder of the template,
-   * giving an attacker a well-formed prompt followed by their own trailing
-   * instruction, and a ~30x token bill. A replacer function is inserted
-   * literally and honours nothing.
-   *
-   * replaceAll, not replace, because the template is superadmin-overridable via
-   * SiteConfig — a custom one that uses a placeholder twice would otherwise
-   * leave the second occurrence unsubstituted and ship `{{producer}}` verbatim.
-   */
-  const put = (template, token, value) => template.replaceAll(token, () => value);
 
   let prompt = aiConfig.get().enrichmentPrompt;
   for (const [token, value] of [

--- a/backend/src/services/labelScan.promptFill.test.js
+++ b/backend/src/services/labelScan.promptFill.test.js
@@ -1,0 +1,96 @@
+/**
+ * Every prompt builder inserts user text LITERALLY, and no assembled prompt
+ * goes out oversized.
+ *
+ * Security audit 2026-09-02 (D10-9): suggestProfile and scanLabelBack had been
+ * fixed in August, but identifyWineFromText, identifyWineFromQuery,
+ * suggestDrinkWindow and suggestPrice still built their prompts with
+ * String.prototype.replace(token, userString). A replacement STRING honours
+ * `$'` (everything after the match), so a 150 × `$'` query re-inserted the
+ * template 150 times — ~100k tokens for one call, billed to the operator's
+ * key and invisible to the per-call AI budget. These tests drive the real
+ * exported builders through a captured client and assert on what would have
+ * been sent.
+ */
+jest.mock('./aiProvider', () => ({ getChatClient: jest.fn() }));
+jest.mock('../config/aiConfig', () => ({
+  get: jest.fn(),
+  DEFAULT_TEXT_SEARCH_PROMPT: ['Identify this wine.', 'Query: {{query}}', 'Rules: be terse. Never invent awards.'].join('\n'),
+}));
+
+const aiProvider = require('./aiProvider');
+const aiConfig = require('../config/aiConfig');
+const { identifyWineFromText, identifyWineFromQuery, suggestDrinkWindow, suggestPrice } = require('./labelScan');
+
+const TAIL = 'Rules: be terse. Never invent awards.';
+const IMPORT_TPL = ['Identify.', 'Wine: {{name}}', 'Producer: {{producer}}', '{{vintage}}{{country}}', TAIL].join('\n');
+const MATURITY_TPL = ['Window for {{name}} by {{producer}} {{vintage}} ({{grapes}}) tier {{qualityTier}}', TAIL].join('\n');
+const PRICE_TPL = ['Price for {{name}} by {{producer}} {{vintage}} {{classification}} ({{grapes}}) tier {{qualityTier}}', TAIL].join('\n');
+
+let create;
+beforeEach(() => {
+  create = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: '{}' }] });
+  aiProvider.getChatClient.mockReturnValue({ messages: { create } });
+  aiConfig.get.mockReturnValue({
+    importLookupPrompt: IMPORT_TPL, importLookupModel: 'test-model',
+    maturitySuggestPrompt: MATURITY_TPL, maturitySuggestPromptNv: MATURITY_TPL, maturitySuggestModel: 'test-model',
+    priceSuggestPrompt: PRICE_TPL, priceSuggestModel: 'test-model',
+  });
+});
+
+const sentPrompt = () => create.mock.calls[0][0].messages[0].content;
+const tails = (s) => (s.match(/Rules: be terse/g) || []).length;
+
+describe('prompt builders insert user text literally (audit 2026-09-02 D10-9)', () => {
+  test("identifyWineFromQuery: 150 × $' stays 300 characters, the template tail appears once", async () => {
+    const payload = "$'".repeat(150);
+    await identifyWineFromQuery(payload);
+    const prompt = sentPrompt();
+    expect(prompt).toContain(`Query: ${payload}`);
+    expect(tails(prompt)).toBe(1);
+    expect(prompt.length).toBeLessThan(aiConfig.DEFAULT_TEXT_SEARCH_PROMPT.length + payload.length + 5);
+  });
+
+  test('identifyWineFromText: name/producer from the import file are sanitised and literal', async () => {
+    await identifyWineFromText({ name: "$'", producer: 'Château\nEvil $& $$', vintage: '2019', country: "$'" });
+    const prompt = sentPrompt();
+    expect(prompt).toContain("Wine: $'");
+    expect(prompt).toContain('Producer: Château Evil $& $$'); // newline collapsed, patterns inert
+    expect(prompt).toContain("Country hint: $'");
+    expect(tails(prompt)).toBe(1);
+  });
+
+  test('identifyWineFromText caps each field at 200 characters', async () => {
+    await identifyWineFromText({ name: 'N'.repeat(500), producer: 'P' });
+    expect(sentPrompt()).toContain(`Wine: ${'N'.repeat(200)}\n`);
+    expect(sentPrompt()).not.toContain('N'.repeat(201));
+  });
+
+  test('suggestDrinkWindow: registry text and grapes are literal, grapes capped per name', async () => {
+    await suggestDrinkWindow({ name: "$'", producer: '$`', vintage: '2019', grapes: ["$'", 'Syrah', 'Grenache'] });
+    const prompt = sentPrompt();
+    expect(prompt).toContain("Window for $' by $` 2019 ($', Syrah, Grenache)");
+    expect(tails(prompt)).toBe(1);
+  });
+
+  test('suggestPrice: same rule', async () => {
+    await suggestPrice({ name: "$'$'", producer: 'P', vintage: '2019', classification: '$&', grapes: 'Syrah' });
+    const prompt = sentPrompt();
+    expect(prompt).toContain("Price for $'$' by P 2019 $& (Syrah)");
+    expect(tails(prompt)).toBe(1);
+  });
+});
+
+describe('oversized prompts are refused before any request is made', () => {
+  test('a template that assembles past the cap returns prompt_too_long and never calls the model', async () => {
+    aiConfig.get.mockReturnValue({ importLookupPrompt: `${'x'.repeat(25 * 1024)}\nWine: {{name}}`, importLookupModel: 'test-model' });
+    const res = await identifyWineFromText({ name: 'A', producer: 'B' });
+    expect(res).toEqual({ data: null, debugRaw: null, debugReason: 'prompt_too_long' });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test('a normal prompt is well under the cap and goes out', async () => {
+    await identifyWineFromText({ name: 'A', producer: 'B' });
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/utils/binCodeParser.js
+++ b/frontend/src/utils/binCodeParser.js
@@ -21,8 +21,12 @@
  *                                       see depth handling below)
  *   letter-number   A12, B3           { row: letterIndex, col: number }
  *   segments        12-3-4, D-04-1,   2 segments → { row, col };
- *                   3.2               3 segments → first segment names a
+ *                   3.2, 5,8          3 segments → first segment names a
  *                                       SUB-RACK ("Cellar D"), rest row/col
+ *                                     (separator: dash, dot or comma — a
+ *                                       "row,column" bin is how at least one
+ *                                       large CellarTracker cellar was typed;
+ *                                       support ticket 2026-09-02)
  *   sequential      147, BIN1, P6     { rackPosition: number } (constant
  *                                       alpha prefix stripped)
  *
@@ -72,11 +76,11 @@ const MIN_DISTINCT = 3;
 const RCD_RE = /^R\s*(\d{1,2})\s*C\s*(\d{1,2})(?:\s*D\s*(\d{1,2}))?$/i;
 const LETTER_RE = /^([A-Za-z])\s*(\d{1,3})$/;
 const PREFIXED_INT_RE = /^([A-Za-z]{0,6})(\d{1,4})$/;
-const SEGMENT_SPLIT_RE = /[-.]/;
+const SEGMENT_SPLIT_RE = /[-.,]/;
 const NUMERIC_SEGMENT_RE = /^\d{1,3}$/;
 const SUBRACK_SEGMENT_RE = /^[A-Za-z0-9]{1,6}$/;
 
-/** Split a bin code on dashes/dots into 2 or 3 usable segments, or null. */
+/** Split a bin code on dashes/dots/commas into 2 or 3 usable segments, or null. */
 function matchSegments(bin) {
   const parts = bin.split(SEGMENT_SPLIT_RE).map((s) => s.trim());
   if (parts.length < 2 || parts.length > 3) return null;

--- a/frontend/src/utils/binCodeParser.test.js
+++ b/frontend/src/utils/binCodeParser.test.js
@@ -130,6 +130,25 @@ describe('segments family (12-3-4 / D-04-1 / 3.2)', () => {
     expect(r.subRacks).toBeUndefined();
   });
 
+  // Support ticket 2026-09-02: a 1,354-bottle CellarTracker cellar typed every
+  // bin as "row,column" ("5,8"). The comma was not a separator, so 1,174 bins
+  // fell through to the freeform-text fallback and no rack was auto-mapped.
+  it('parses comma-separated row,col bins (5,8) exactly like dashes and dots', () => {
+    const r = analyzeBinGroup(['5,8', '5,9', '6,1', '1,12', '2,3']);
+    expect(r.pattern).toBe('segments');
+    expect(r.qualifies).toBe(true);
+    expect(r.inferredRows).toBe(6);
+    expect(r.inferredCols).toBe(12);
+    expect(placementFor(r, 0)).toEqual({ index: 0, row: 5, col: 8 });
+    expect(placementFor(r, 3)).toEqual({ index: 3, row: 1, col: 12 });
+    expect(r.unparsed).toEqual([]);
+  });
+
+  it('a thousands-style "1,000" is not a placement (column 0 is invalid)', () => {
+    const r = analyzeBinGroup(['1,000', '1,000', '1,000', '2,5']);
+    expect(placementFor(r, 0)).toBeUndefined();
+  });
+
   it('parses 3-segment codes as subrack-row-col, splitting the group into sub-racks', () => {
     const r = analyzeBinGroup(['12-3-4', '12-3-5', '12-1-1', '13-2-2']);
     expect(r.pattern).toBe('segments');


### PR DESCRIPTION
Follow-ups from the whole-system security audit started on 2 September, plus one import fix from a support ticket. No exploit detail here on purpose; the audit report is private.

**AI prompt builders** — every builder in `labelScan.js` now inserts user text through one shared sanitise-and-insert-literally helper set (the two builders fixed in August had siblings that were not), and `callClaudeJson` refuses an assembled prompt over 24 KB before any request is made. The refusal is refundable to the user's AI budget.

**Cellar import** — a drink window carried in an imported file becomes a *reviewed* registry profile only when the importer is a sommelier or admin. For anyone else it is stored as a *pending* suggestion for the sommelier queue, with `setBy` and an audit row. Self-hosters migrating as admin keep the old behaviour.

**MCP previews** — `bulk_add` and `auto_arrange` previews now charge the write budget (a quarter of the batch, at least one slot) and only the five newest unconsumed previews per user are kept.

**Taxonomy rate limiter** — keys on the real client IP like every other limiter, instead of the proxy address, so visitors behind one edge stop sharing a bucket.

**CellarTracker import** — bins typed as `row,column` (for example `5,8`) now auto-map to racks the same way `5-8` and `5.8` already did.

Tests: new `labelScan.promptFill.test.js` (7), extended `cellarImport.test.js`, `bulkTools.test.js`, `arrangeTasting.test.js`, `aiBudget.test.js`, `binCodeParser.test.js`. Fourteen touched backend suites green in node:24-alpine; frontend parser suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)