### PR TITLE
feat(images): let the uploader keep the background — label photos stopped coming back cropped

### DIFF
--- a/backend/src/mcp/imageTools.test.js
+++ b/backend/src/mcp/imageTools.test.js
@@ -95,6 +95,17 @@ describe('attach_bottle_image', () => {
     expect(row.detail.imageId).toBeDefined();
   });
 
+  test('keep_background reaches the shared pipeline as keepBackground (label-only photos, ticket 6a97f870)', async () => {
+    ownBottle();
+    safeFetchImage.mockResolvedValue({ buffer: Buffer.from('imgbytes'), contentType: 'image/jpeg' });
+    await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_url: 'https://cdn.example.com/label.jpg', keep_background: true }, CTX);
+    expect(ingestBottleImage).toHaveBeenCalledWith(expect.objectContaining({ keepBackground: true }), CTX.req);
+
+    ingestBottleImage.mockClear();
+    await tool('attach_bottle_image').handler({ bottle_id: oid('d'), image_url: 'https://cdn.example.com/label.jpg' }, CTX);
+    expect(ingestBottleImage).toHaveBeenCalledWith(expect.objectContaining({ keepBackground: false }), CTX.req);
+  });
+
   test('a bottle with no registry wine yet attaches bottle-only (no wine linkage)', async () => {
     ownBottle(); // pending-wine-request bottles have no wineDefinition
     safeFetchImage.mockResolvedValue({ buffer: Buffer.from('imgbytes'), contentType: 'image/jpeg' });

--- a/backend/src/mcp/tools/images.js
+++ b/backend/src/mcp/tools/images.js
@@ -36,6 +36,7 @@ registerTool({
     image_url: z.string().url().optional().describe('https URL of the image (retailer/CDN product image)'),
     image_base64: z.string().max(MAX_BASE64_CHARS).optional().describe('Base64 image data (no data: prefix needed); alternative to image_url'),
     credit: z.string().max(200).optional().describe('Optional attribution/source note — admin accounts only; silently ignored for regular users (matches the web app)'),
+    keep_background: z.boolean().optional().describe('Skip background removal. Set it for a photo of just the label, a retailer product shot, or anything that is not a whole bottle on a plain background — background removal expects a bottle and cuts everything else away. Default false.'),
     idempotency_key: z.string().max(100).optional(),
   },
   handler: async (args, ctx) => {
@@ -83,6 +84,7 @@ registerTool({
       : null;
     const result = await ingestBottleImage({
       buffer, userId: ctx.user.id, userRoles: ctx.user.roles, bottle, wineDefinitionId, credit: args.credit || null,
+      keepBackground: args.keep_background === true,
     }, ctx.req);
     if (result.error) {
       // 4xx = the caller's image is bad (invalid_input); 5xx = a transient

--- a/backend/src/models/BottleImage.js
+++ b/backend/src/models/BottleImage.js
@@ -52,6 +52,17 @@ const bottleImageSchema = new mongoose.Schema({
     enum: ['private', 'public'],
     default: 'public'
   },
+  // The uploader asked us NOT to run background removal on this photo. rembg
+  // assumes a bottle on a background: on a photo of just the label, or a
+  // retailer product shot, it keeps whatever "figure" it finds on the label
+  // and cuts the rest away (support ticket 6a97f870, 2026-09-02 — a user's
+  // label photos came back "systematically cropped"). When true the original
+  // IS the kept image (processedUrl = originalUrl) and processImage /
+  // reprocessAllImages / retry leave it alone.
+  keepBackground: {
+    type: Boolean,
+    default: false
+  },
   // What this image IS, so the one collection can hold two things that must
   // never be confused. 'bottle' (the default, and what every pre-existing row
   // is) = a user's photo of their bottle: gallery-eligible, wine-image-

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -106,6 +106,10 @@ router.post('/upload', requireAuth, requireNonDemo, imageUploadLimiter, handleIm
     }
 
     const { bottleId, wineDefinitionId, credit } = req.body;
+    // Multipart field, so a string: "1" / "true" / "on" from the upload form's
+    // "keep the background" checkbox (ticket 6a97f870 — label-only photos
+    // came back cropped because rembg expects a whole bottle).
+    const keepBackground = ['1', 'true', 'on'].includes(String(req.body.keepBackground ?? '').trim().toLowerCase());
 
     // Verify bottle ownership if bottleId is provided (access is the route's
     // job; the per-bottle image cap lives in the shared pipeline).
@@ -150,6 +154,7 @@ router.post('/upload', requireAuth, requireNonDemo, imageUploadLimiter, handleIm
       bottle,
       wineDefinitionId: wineDefinitionId ? String(wineDefinitionId) : null,
       credit,
+      keepBackground,
     }, req);
     if (result.error) {
       return res.status(result.error.status).json({ error: result.error.message });

--- a/backend/src/services/imageOps.js
+++ b/backend/src/services/imageOps.js
@@ -52,7 +52,7 @@ function sanitizeCredit(credit, userRoles) {
  * @param {object}  req                    for downstream audit attribution
  * @returns {{ image }} | {{ error: { status, message } }}
  */
-async function ingestBottleImage({ buffer, userId, userRoles = [], bottle = null, wineDefinitionId = null, credit = null }, req) {
+async function ingestBottleImage({ buffer, userId, userRoles = [], bottle = null, wineDefinitionId = null, credit = null, keepBackground = false }, req) {
   if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
     return { error: { status: 400, message: 'No image data provided' } };
   }
@@ -95,19 +95,31 @@ async function ingestBottleImage({ buffer, userId, userRoles = [], bottle = null
   let contentHash = null;
   try { contentHash = hashImageBytes(clean); } catch { /* non-fatal */ }
 
+  // keepBackground (ticket 6a97f870): the uploader opted out of background
+  // removal — a label-only photo or a product shot, which rembg would cut up.
+  // The original is then the kept image from the start: processedUrl points at
+  // it so every consumer that prefers processedUrl (exports, the wine's
+  // display image, the upload preview) works unchanged, and the row is
+  // 'processed' immediately, so nothing polls for a job that never runs.
+  const keep = keepBackground === true;
+  const originalUrl = `/api/uploads/originals/${filename}`;
   const image = new BottleImage({
     bottle: bottle ? bottle._id : null,
     wineDefinition: wineDefinitionId || null,
     uploadedBy: userId,
-    originalUrl: `/api/uploads/originals/${filename}`,
-    status: 'uploaded',
+    originalUrl,
+    processedUrl: keep ? originalUrl : null,
+    status: keep ? 'processed' : 'uploaded',
+    keepBackground: keep,
     credit: sanitizeCredit(credit, userRoles),
     contentHash,
   });
   await image.save();
 
   // Fire-and-forget background removal (rembg) — same hand-off as the route.
-  processImage(image._id).catch((err) => console.error('Background processing error:', err.message));
+  if (!keep) {
+    processImage(image._id).catch((err) => console.error('Background processing error:', err.message));
+  }
 
   return { image };
 }
@@ -124,8 +136,8 @@ async function ingestBottleImage({ buffer, userId, userRoles = [], bottle = null
  * Caller must have verified the wine exists and the actor is an admin
  * (userRoles is still forwarded so the shared credit gate applies uniformly).
  */
-async function attachOfficialWineImage({ buffer, wineDefinitionId, credit = null, userId, userRoles = [] }, req) {
-  const ingest = await ingestBottleImage({ buffer, userId, userRoles, wineDefinitionId, credit }, req);
+async function attachOfficialWineImage({ buffer, wineDefinitionId, credit = null, userId, userRoles = [], keepBackground = false }, req) {
+  const ingest = await ingestBottleImage({ buffer, userId, userRoles, wineDefinitionId, credit, keepBackground }, req);
   if (ingest.error) return ingest;
   const image = ingest.image;
 

--- a/backend/src/services/imageOps.test.js
+++ b/backend/src/services/imageOps.test.js
@@ -61,6 +61,27 @@ test('happy path: sanitises, writes a sniffed-extension file, saves the row, kic
   expect(processImage).toHaveBeenCalledWith('img-new');
 });
 
+// Support ticket 6a97f870 (2026-09-02): a user's label-only photos came back
+// "systematically cropped" — rembg keeps the figure it finds on the label and
+// cuts the label away. The uploader can now opt out of background removal.
+test('keepBackground: no bg-removal hand-off, the original is the kept image and the row is processed at once', async () => {
+  const res = await ingestBottleImage({ buffer: Buffer.from('RAW'), userId: 'u1', bottle: { _id: 'b1' }, keepBackground: true }, REQ);
+  expect(res.error).toBeUndefined();
+  expect(processImage).not.toHaveBeenCalled();
+  expect(res.image.keepBackground).toBe(true);
+  expect(res.image.status).toBe('processed');
+  expect(res.image.originalUrl).toMatch(/^\/api\/uploads\/originals\/.+\.jpg$/); // sniffed jpeg → .jpg
+  expect(res.image.processedUrl).toBe(res.image.originalUrl);
+  expect(res.image.save).toHaveBeenCalledTimes(1);
+});
+
+test('keepBackground must be literally true — a truthy string does not opt out', async () => {
+  const res = await ingestBottleImage({ buffer: Buffer.from('RAW'), userId: 'u1', keepBackground: 'yes' }, REQ);
+  expect(res.image.keepBackground).toBe(false);
+  expect(res.image.status).toBe('uploaded');
+  expect(processImage).toHaveBeenCalledWith('img-new');
+});
+
 test('fail-closed: an undecodable buffer is rejected, nothing written or saved', async () => {
   sanitizeImageBuffer.mockRejectedValue(new Error('Input buffer contains unsupported image format'));
   const res = await ingestBottleImage({ buffer: Buffer.from('NOT-AN-IMAGE'), userId: 'u1' }, REQ);

--- a/backend/src/services/imageProcessor.js
+++ b/backend/src/services/imageProcessor.js
@@ -70,6 +70,16 @@ async function processImage(imageId) {
   const image = await BottleImage.findById(imageId);
   if (!image || image.status !== 'uploaded') return;
 
+  // The uploader opted out of background removal (label-only photo, product
+  // shot — see models/BottleImage.keepBackground). The original is the kept
+  // image; a retry or a stray 'uploaded' row just settles it without rembg.
+  if (image.keepBackground) {
+    image.processedUrl = image.originalUrl;
+    image.status = 'processed';
+    await image.save();
+    return;
+  }
+
   // Mark as processing
   image.status = 'processing';
   await image.save();
@@ -141,7 +151,9 @@ async function processImage(imageId) {
 async function reprocessAllImages() {
   const images = await BottleImage.find({
     status: { $in: ['processed', 'approved'] },
-    originalUrl: { $exists: true }
+    originalUrl: { $exists: true },
+    // Never run rembg over a photo whose uploader opted out of it.
+    keepBackground: { $ne: true },
   });
 
   console.log(`Re-processing ${images.length} images...`);

--- a/backend/src/services/imageProcessor.keepBackground.test.js
+++ b/backend/src/services/imageProcessor.keepBackground.test.js
@@ -1,0 +1,39 @@
+/**
+ * imageProcessor honours BottleImage.keepBackground.
+ *
+ * Support ticket 6a97f870 (2026-09-02): label-only photos came back cropped
+ * because rembg expects a whole bottle. An uploader who opts out must never
+ * have their photo sent to rembg — not on the initial hand-off (imageOps skips
+ * it), not on a retry, and not by the reprocess-everything maintenance job.
+ */
+jest.mock('../config/upload', () => ({ PROCESSED_DIR: '/tmp/processed' }));
+jest.mock('../models/BottleImage', () => ({ findById: jest.fn(), find: jest.fn() }));
+
+const BottleImage = require('../models/BottleImage');
+const { processImage, reprocessAllImages } = require('./imageProcessor');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn(() => { throw new Error('rembg must not be called'); });
+});
+
+test('processImage on a keepBackground row settles it from the original without calling rembg', async () => {
+  const doc = {
+    _id: 'i1', status: 'uploaded', keepBackground: true,
+    originalUrl: '/api/uploads/originals/a.jpg', processedUrl: null,
+    save: jest.fn().mockResolvedValue(),
+  };
+  BottleImage.findById.mockResolvedValue(doc);
+  await processImage('i1');
+  expect(global.fetch).not.toHaveBeenCalled();
+  expect(doc.status).toBe('processed');
+  expect(doc.processedUrl).toBe('/api/uploads/originals/a.jpg');
+  expect(doc.save).toHaveBeenCalledTimes(1);
+});
+
+test('reprocessAllImages excludes keepBackground rows from its query', async () => {
+  BottleImage.find.mockResolvedValue([]);
+  await reprocessAllImages();
+  expect(BottleImage.find).toHaveBeenCalledWith(expect.objectContaining({ keepBackground: { $ne: true } }));
+  expect(global.fetch).not.toHaveBeenCalled();
+});

--- a/frontend/src/components/ImageUpload.css
+++ b/frontend/src/components/ImageUpload.css
@@ -60,6 +60,36 @@
   font-size: 0.85rem;
 }
 
+/* "Keep the background" opt-out of background removal (label-only photos,
+   product shots). A plain checkbox row under the upload buttons. */
+.upload-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.upload-option input[type="checkbox"] {
+  margin-top: 0.15rem;
+  flex-shrink: 0;
+  accent-color: var(--color-primary);
+}
+
+.upload-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.upload-option-hint {
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+  line-height: 1.3;
+}
+
 /* ===== Preview Cards ===== */
 
 .upload-previews {

--- a/frontend/src/components/ImageUpload.js
+++ b/frontend/src/components/ImageUpload.js
@@ -14,6 +14,11 @@ function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onP
   const [cameraOpen, setCameraOpen] = useState(false);
   const [cameraError, setCameraError] = useState(null);
   const [facingMode, setFacingMode] = useState('environment');
+  // "Keep the background": skip background removal for this upload. rembg
+  // expects a whole bottle; on a photo of just the label, or a product shot,
+  // it keeps whatever figure it finds on the label and cuts the rest away
+  // (support ticket 6a97f870, 2026-09-02).
+  const [keepBackground, setKeepBackground] = useState(false);
   const videoRef = useRef(null);
   const canvasRef = useRef(null);
   const streamRef = useRef(null);
@@ -97,15 +102,28 @@ function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onP
     if (bottleId) formData.append('bottleId', bottleId);
     if (wineDefinitionId) formData.append('wineDefinitionId', wineDefinitionId);
     if (credit && credit.trim()) formData.append('credit', credit.trim());
+    if (keepBackground) formData.append('keepBackground', '1');
 
     try {
       const res = await apiFetch('/api/images/upload', { method: 'POST', body: formData });
       const data = await res.json();
       if (res.ok) {
-        const newImage = { id: data.image._id, originalSrc: localSrc, processedSrc: null, status: 'processing' };
+        // With the background kept there is no job to wait for: the server
+        // answers 'processed' straight away with the original as the kept
+        // image, so show it and hand it to the parent now instead of polling.
+        const done = data.image.status === 'processed' && data.image.processedUrl;
+        const newImage = done
+          ? { id: data.image._id, originalSrc: localSrc, processedSrc: data.image.processedUrl, status: 'processed' }
+          : { id: data.image._id, originalSrc: localSrc, processedSrc: null, status: 'processing' };
         setImages(prev => [...prev, newImage]);
         if (onUploadComplete) onUploadComplete(data.image);
-        pollImage(data.image._id);
+        if (done) {
+          if (onProcessingComplete) {
+            onProcessingComplete(data.image.processedUrl.startsWith('http') ? data.image.processedUrl : `${API_URL}${data.image.processedUrl}`);
+          }
+        } else {
+          pollImage(data.image._id);
+        }
       } else {
         setError(data.error || t('imageUpload.uploadFailed'));
         URL.revokeObjectURL(localSrc);
@@ -286,6 +304,19 @@ function ImageUpload({ bottleId, wineDefinitionId, credit, onUploadComplete, onP
           {t('imageUpload.upload')}
         </button>
       </div>
+
+      <label className="upload-option">
+        <input
+          type="checkbox"
+          checked={keepBackground}
+          onChange={(e) => setKeepBackground(e.target.checked)}
+          disabled={uploading}
+        />
+        <span className="upload-option-text">
+          {t('imageUpload.keepBackground')}
+          <small className="upload-option-hint">{t('imageUpload.keepBackgroundHint')}</small>
+        </span>
+      </label>
 
       {uploading && <p className="upload-status">{t('imageUpload.uploading')}</p>}
       {error && <div className="upload-error">{error}</div>}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4237,7 +4237,9 @@
     "uploadFailed": "Upload failed",
     "networkError": "Network error during upload",
     "processedAlt": "Processed",
-    "originalAlt": "Original"
+    "originalAlt": "Original",
+    "keepBackground": "Keep the background",
+    "keepBackgroundHint": "For a photo of just the label, or a product picture. Background removal expects a whole bottle and cuts everything else away."
   },
   "cellarChat": {
     "title": "Cellar Chat",


### PR DESCRIPTION
From a support ticket: a user's label photos came back cropped every time. They were photos of just the label, or retailer product shots. Background removal expects a whole bottle on a background, so on a label it keeps whatever figure it finds and cuts the label itself away, and the auto-crop then tightens onto what is left.

**What changes**
- A **Keep the background** checkbox under the upload buttons, with a one-line hint saying when to use it.
- The choice is stored per image (`BottleImage.keepBackground`), so a retry or the reprocess-everything job never sends that photo to rembg either.
- With the background kept, the original is the kept image and the upload completes immediately, no polling.
- The MCP `attach_bottle_image` tool gets the same option as `keep_background`, through the shared pipeline.

Default behaviour is unchanged. New strings are English-only for Weblate.

Tests: imageOps (+2), imageTools (+1), new `imageProcessor.keepBackground` suite; frontend suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)