### PR TITLE
fix(security): rack resize can no longer stall the backend; OAuth registration bodies bounded

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -149,6 +149,11 @@ app.use('/api/wine-lists', express.json({ limit: '1mb' }));
 // body for attach_bottle_image's base64 mode (MAX_BASE64_CHARS ≈ 1.5MB + JSON
 // overhead); every personal MCP caller is authenticated and rate-limited.
 app.use('/api/mcp/public', express.json({ limit: '10kb' }));
+// The OAuth endpoints (dynamic client registration, token, revocation) carry
+// small metadata bodies and are reachable ANONYMOUSLY — they must not inherit
+// the 2 MB image budget below (security audit 2026-09-02 D16-2: a 2 MB
+// registration body was accepted and, with uncapped redirect URIs, stored).
+app.use('/api/mcp/oauth', express.json({ limit: '10kb' }));
 app.use('/api/mcp', express.json({ limit: '2mb' }));
 app.use(express.json({ limit: '10kb' }));
 const corsOrigin = process.env.FRONTEND_URL || (process.env.NODE_ENV === 'production' ? false : 'http://localhost:3000');

--- a/backend/src/routes/mcpOAuth.js
+++ b/backend/src/routes/mcpOAuth.js
@@ -94,6 +94,11 @@ const {
 router.use(express.urlencoded({ extended: false }));
 
 const MAX_REDIRECT_URIS = 5;
+// Per-URI length cap (security audit 2026-09-02 D16-2): the count was capped
+// but each entry was stored verbatim, so one anonymous registration could park
+// ~2 MB of redirect URIs in Mongo for 30 days, 200 times an hour per address.
+// 2048 is the same bound accountOps applies to URLs; no real client is near it.
+const MAX_REDIRECT_URI_LEN = 2048;
 const MAX_OAUTH_CONNECTIONS_PER_USER = 20; // Claude + ChatGPT + Desktop + … — generous, but bounded.
 
 // ── error helpers (RFC 6749 §5.2) ────────────────────────────────────────────
@@ -127,6 +132,9 @@ router.post('/register', registerLimiter, async (req, res) => {
     const redirectUris = body.redirect_uris;
     if (!Array.isArray(redirectUris) || redirectUris.length === 0 || redirectUris.length > MAX_REDIRECT_URIS) {
       return oauthError(res, 400, 'invalid_redirect_uri', `redirect_uris must be a non-empty array of at most ${MAX_REDIRECT_URIS} URLs`);
+    }
+    if (!redirectUris.every((u) => typeof u === 'string' && u.length <= MAX_REDIRECT_URI_LEN)) {
+      return oauthError(res, 400, 'invalid_redirect_uri', `each redirect_uri must be a string of at most ${MAX_REDIRECT_URI_LEN} characters`);
     }
     if (!redirectUris.every(isValidRedirectUri)) {
       return oauthError(res, 400, 'invalid_redirect_uri', 'redirect_uris must all be https, or http on a loopback host');

--- a/backend/src/routes/mcpOAuth.test.js
+++ b/backend/src/routes/mcpOAuth.test.js
@@ -101,6 +101,16 @@ describe('POST /register (DCR)', () => {
     expect(OAuthClient.create).not.toHaveBeenCalled();
   });
 
+  // Security audit 2026-09-02 (D16-2): the COUNT was capped but each entry was
+  // stored verbatim — one anonymous registration could park ~2 MB in Mongo.
+  test('an over-long redirect_uri is rejected before anything is stored', async () => {
+    const r = await jsonPost('/register', { redirect_uris: [`https://a.example/${'x'.repeat(2100)}`] });
+    expect(r.status).toBe(400);
+    const body = await r.json();
+    expect(body.error).toBe('invalid_redirect_uri');
+    expect(body.error_description).toMatch(/2048/);
+  });
+
   test('an empty redirect_uris array is rejected', async () => {
     const r = await jsonPost('/register', { redirect_uris: [] });
     expect(r.status).toBe(400);

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -20,6 +20,11 @@ const { classifyMaturity, buildProfileMap } = require('../utils/maturityUtils');
 const router = express.Router();
 
 const MAX_MODULES = 50;
+// Mirrors the Rack schema's rows/cols bounds (models/Rack.js). Checked at the
+// request boundary because geometry runs on the values BEFORE save() would
+// reject them (security audit 2026-09-02 D14-1).
+const MAX_RACK_DIM = 20;
+const isRackDim = (v) => Number.isInteger(v) && v >= 1 && v <= MAX_RACK_DIM;
 
 /**
  * Serialize rack doc(s) with a maturityStatus attached to every populated
@@ -193,12 +198,25 @@ router.put('/:id', async (req, res) => {
         return res.status(400).json({ error: `Maximum ${MAX_MODULES} modules allowed per rack` });
       }
       for (const m of modules) {
-        if (!m.type || !RACK_TYPES.includes(m.type)) {
-          return res.status(400).json({ error: `Invalid module type: ${m.type}` });
+        if (!m || !m.type || !RACK_TYPES.includes(m.type)) {
+          return res.status(400).json({ error: `Invalid module type: ${m?.type}` });
+        }
+        if ((m.rows !== undefined && !isRackDim(m.rows)) || (m.cols !== undefined && !isRackDim(m.cols))) {
+          return res.status(400).json({ error: `Module rows and cols must be whole numbers between 1 and ${MAX_RACK_DIM}` });
         }
       }
     } else if (type && !RACK_TYPES.includes(type)) {
       return res.status(400).json({ error: `Invalid rack type. Must be one of: ${RACK_TYPES.join(', ')}` });
+    }
+
+    // Dimensions are validated HERE, before any geometry runs on them. The
+    // schema's min/max only fires at save(), but getMaxPosition() below runs
+    // on the request's values first — and a rows of "1e308" used to park the
+    // event loop in the hex slot count for every tenant (security audit
+    // 2026-09-02 D14-1). The closed-form hex count removed the loop; this keeps
+    // nonsense out of every other formula too.
+    if ((rows !== undefined && !isRackDim(rows)) || (cols !== undefined && !isRackDim(cols))) {
+      return res.status(400).json({ error: `rows and cols must be whole numbers between 1 and ${MAX_RACK_DIM}` });
     }
 
     // Validate double-height rows against the rack's effective (post-update)

--- a/backend/src/utils/rackGeometry.js
+++ b/backend/src/utils/rackGeometry.js
@@ -71,6 +71,10 @@ function validateDoubleHeightRows(typeConfig, effectiveType, effectiveRows, effe
  * Total number of valid slot positions for a given rack configuration.
  */
 function totalSlots(type, rows, cols, typeConfig) {
+  // Geometry is arithmetic over the two dimensions; a non-finite dimension is
+  // not a rack (the schema caps both at 20) and must never reach a formula
+  // that could return Infinity/NaN into a slot bound. Fail to zero capacity.
+  if (!Number.isFinite(rows) || !Number.isFinite(cols)) return 0;
   switch (type) {
     case 'grid': {
       // POSITION NUMBERING CONTRACT (double-height rows): the base grid
@@ -100,11 +104,14 @@ function totalSlots(type, rows, cols, typeConfig) {
       // hexFlip is deliberately not read here: it reverses which rows are
       // which, a pure reversal that can never change the total.
       if (typeConfig?.hexEqualRows) return rows * cols;
-      let total = 0;
-      for (let r = 0; r < rows; r++) {
-        total += (r % 2 === 0) ? cols : Math.max(1, cols - 1);
-      }
-      return total;
+      // Closed form, not a loop (security audit 2026-09-02 D14-1): this ran
+      // `rows` iterations, and the rack UPDATE route computed it on the
+      // request's still-unvalidated rows before the schema's max-20 check —
+      // one PUT with rows "1e308" parked the event loop for every tenant.
+      // Even rows (0-indexed) hold `cols`, odd rows hold max(1, cols-1).
+      const evenRows = Math.ceil(rows / 2);
+      const oddRows = Math.floor(rows / 2);
+      return evenRows * cols + oddRows * Math.max(1, cols - 1);
     }
 
     case 'triangle': {

--- a/backend/src/utils/rackGeometry.test.js
+++ b/backend/src/utils/rackGeometry.test.js
@@ -96,6 +96,26 @@ describe('rackGeometry', () => {
     it('2 rows, 1 col → 1 + 1 = 2 (odd row min is 1)', () => {
       expect(totalSlots('hex', 2, 1)).toBe(2);
     });
+    // Security audit 2026-09-02 (D14-1): the hex count was a `rows`-iteration
+    // loop and the rack update route ran it on unvalidated input — one
+    // request with rows "1e308" stalled the backend. Closed form now; these
+    // pin it to the loop it replaced across the whole legal range.
+    it('closed form matches the row-by-row count for every legal size', () => {
+      const byLoop = (rows, cols) => { let t = 0; for (let r = 0; r < rows; r++) t += (r % 2 === 0) ? cols : Math.max(1, cols - 1); return t; };
+      for (let rows = 1; rows <= 20; rows++) {
+        for (let cols = 1; cols <= 20; cols++) {
+          expect(totalSlots('hex', rows, cols)).toBe(byLoop(rows, cols));
+        }
+      }
+    });
+    it('an absurd or non-finite dimension returns at once instead of looping', () => {
+      const t0 = Date.now();
+      expect(typeof totalSlots('hex', 1e308, 5)).toBe('number'); // overflows to Infinity — fine, it RETURNS
+      expect(totalSlots('hex', Infinity, 5)).toBe(0);
+      expect(totalSlots('grid', 4, NaN)).toBe(0);
+      expect(getMaxPosition({ isModular: true, modules: [{ type: 'hex', rows: 1e15, cols: 2 }] })).toBe(1.5e15);
+      expect(Date.now() - t0).toBeLessThan(200);
+    });
     it('hexEqualRows: every row full width → rows × cols', () => {
       expect(totalSlots('hex', 4, 4, { hexEqualRows: true })).toBe(16);
       expect(totalSlots('hex', 3, 4, { hexEqualRows: true })).toBe(12);


### PR DESCRIPTION
Two follow-ups from the whole-system security audit (phase 3). No exploit detail here on purpose.

**Rack geometry.** The hex slot count is now a closed form instead of a loop over the row count, and the rack update route validates rows and columns (including each module's) against the schema bounds before any geometry runs on them. Previously the schema's limit only applied at save time, after the slot count had already been computed from the raw request.

**OAuth dynamic client registration.** Each redirect URI is capped at 2048 characters, and the anonymous OAuth endpoints get a 10 kb JSON body limit instead of inheriting the 2 MB budget meant for image attachments on the personal MCP endpoint.

Tests: rack geometry (+2, closed form pinned to the loop it replaced across the whole legal range), OAuth registration (+1). Rack, OAuth, MCP and arrange suites green in node:24-alpine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)