### PR TITLE
feat(backup): a snapshot now rebuilds the whole stack, not just the data

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -162,3 +162,55 @@ You get **two** layers of failure alerting:
 - `backup.env` holds secrets → it's gitignored, `chmod 600`, never committed.
 - Backups contain **user PII** → encryption (restic) + a locked-down Storage Box are required for GDPR. Retention here is 7 daily / 4 weekly / 6 monthly.
 - Retention is enforced by `restic forget --prune` inside `backup.sh`.
+
+## Moving everything to a new VM
+
+Since 2026-09-02 every snapshot carries the configuration as well as the data
+(`config/<absolute path>`, an optional `umami/umami.sql.gz`, and a
+`MANIFEST.txt` naming the image digests that were running), so a snapshot plus
+the restic passphrase is enough to stand the whole stack up elsewhere. Keep
+three things **off the server** in a password manager: the restic passphrase,
+the repository address, and the credentials that reach the repository (the
+Storage Box SSH key, or the B2 account key). Without those the snapshot is
+unreachable; with them, this is the order:
+
+1. **New machine.** Install Docker (compose plugin), restic and jq. Create the
+   same unprivileged user and add it to the `docker` group.
+2. **Reach the repository.** Put the Storage Box SSH key back at
+   `~/.ssh/storagebox` with the `~/.ssh/config` alias (both are in the
+   snapshot, but you need them *first* — so from the password manager), or
+   export the `B2_*` variables for the off-provider copy.
+3. **Pull the snapshot into a scratch directory** — no containers exist yet,
+   so do not use `restore.sh` for this step:
+   ```bash
+   export RESTIC_REPOSITORY=... RESTIC_PASSWORD=...
+   restic restore latest --target /tmp/cellarion-restore
+   cat /tmp/cellarion-restore/*/MANIFEST.txt        # what was running
+   ```
+4. **Put the configuration back.** Everything under `config/` is stored at
+   its original absolute path, so with the same username and checkout path:
+   ```bash
+   sudo cp -rp /tmp/cellarion-restore/*/config/. /
+   ```
+   That restores `.env`, both compose files, `scripts/backup/backup.env`, the
+   reverse-proxy and monitoring configs, the systemd units and the SSH alias.
+   Then `git clone` the repository into the checkout path the compose files
+   expect (the checkout is not in the snapshot — only the files you changed).
+5. **Start the stack** — `docker compose -f docker-compose.prod.yml up -d`
+   (and the reverse proxy / monitoring compose projects). The images come from
+   the registry; pin the digests from `MANIFEST.txt` if `:latest` has moved on.
+6. **Load the data** with the containers now running:
+   ```bash
+   cd scripts/backup && ./restore.sh latest            # Mongo + images
+   RESTORE_UMAMI=1 ./restore.sh latest                 # add analytics history
+   ```
+7. **Rebuild the derived indexes** — restart the backend; Meilisearch
+   re-indexes from Mongo and the embedding job repopulates Qdrant (the AI chat
+   is degraded until it finishes, nothing is lost).
+8. **Point DNS at the new address** (Cloudflare), and move the firewall rule
+   that limits SSH to your own address.
+9. **Re-enable the backup timers** (`systemctl enable --now cellarion-backup.timer
+   cellarion-backup-check.timer`) and make sure the healthchecks ping green
+   from the new host before you stop watching.
+
+Drill this on a throwaway VM once. A runbook you have never run is a guess.

--- a/scripts/backup/backup.env.example
+++ b/scripts/backup/backup.env.example
@@ -40,3 +40,16 @@ HEALTHCHECK_CHECK_URL=""
 B2_RESTIC_REPOSITORY=""
 B2_ACCOUNT_ID=""
 B2_ACCOUNT_KEY=""
+
+# ── Configuration files in the snapshot (since 2026-09-02) ───────────────────
+# The snapshot always carries this checkout's .env, docker-compose*.yml and this
+# backup.env, stored under config/<absolute path>. Add everything else a fresh
+# machine would need — reverse proxy, monitoring, systemd units, the SSH key
+# that reaches the repository. Space-separated absolute paths; a directory is
+# copied whole; missing entries are skipped with a log line.
+# Note: the snapshot now holds secrets, so RESTIC_PASSWORD unlocks those too —
+# keep it (and the repository address) in a password manager, off this host.
+EXTRA_CONFIG_PATHS=""
+
+# Self-hosted Umami? Name its Postgres container to include a dump (small).
+UMAMI_DB_CONTAINER=""

--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -6,6 +6,14 @@
 # deduplicates and retains. Meilisearch/Qdrant are intentionally skipped — the
 # app rebuilds them from Mongo.
 #
+# Since 2026-09-02 a snapshot also carries everything needed to REBUILD THE
+# STACK ON A NEW MACHINE, not just the data: the .env files, the compose files,
+# the reverse-proxy and monitoring configs, the systemd units and this script's
+# own backup.env (see CONFIG_PATHS / EXTRA_CONFIG_PATHS), plus an optional dump
+# of the Umami analytics database and a MANIFEST.txt naming the exact image
+# digests that were running. Before that, a restore gave you a database and a
+# folder of photos and no way to run them.
+#
 # Usage:  ./backup.sh            (reads ./backup.env)
 #         BACKUP_ENV=/path/env ./backup.sh
 # Run it from cron/systemd on the VM host — see docs/backup.md.
@@ -32,6 +40,17 @@ KEEP_DAILY="${KEEP_DAILY:-7}"
 KEEP_WEEKLY="${KEEP_WEEKLY:-4}"
 KEEP_MONTHLY="${KEEP_MONTHLY:-6}"
 HEALTHCHECK_URL="${HEALTHCHECK_URL:-}"
+
+# Configuration files that make a snapshot self-sufficient. Defaults cover the
+# checkout this script lives in; EXTRA_CONFIG_PATHS (backup.env) adds anything
+# outside it — a reverse proxy, monitoring, systemd units, the SSH key that
+# reaches the repository. Space-separated absolute paths; a directory is copied
+# whole. Missing entries are logged and skipped, never fatal.
+PROJECT_DIR="${PROJECT_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+CONFIG_PATHS="${CONFIG_PATHS:-$PROJECT_DIR/.env $PROJECT_DIR/docker-compose.yml $PROJECT_DIR/docker-compose.prod.yml $ENV_FILE}"
+EXTRA_CONFIG_PATHS="${EXTRA_CONFIG_PATHS:-}"
+# Optional: the Postgres container behind self-hosted Umami. Blank = skip.
+UMAMI_DB_CONTAINER="${UMAMI_DB_CONTAINER:-}"
 
 log() { echo "[backup] $(date -Is) $*"; }
 ping_fail() {
@@ -96,6 +115,54 @@ log "copying uploaded images from $BACKEND_CONTAINER:/app/uploads…"
 # Copy as plain files (not a single tarball) so restic deduplicates unchanged
 # images across runs — only new/changed photos are uploaded each night.
 docker cp "$BACKEND_CONTAINER:/app/uploads/." "$STAGE/uploads/"
+
+# Configuration — stored under config/<absolute path> so a restore knows exactly
+# where each file belongs on the new machine. Secrets ride along: the snapshot
+# is encrypted with RESTIC_PASSWORD, which therefore now unlocks these too.
+log "staging configuration files…"
+mkdir -p "$STAGE/config"
+staged=0
+for p in $CONFIG_PATHS $EXTRA_CONFIG_PATHS; do
+  if [ -d "$p" ]; then
+    mkdir -p "$STAGE/config$(dirname "$p")"
+    cp -rp "$p" "$STAGE/config$(dirname "$p")/"
+    staged=$((staged + 1))
+  elif [ -r "$p" ]; then
+    mkdir -p "$STAGE/config$(dirname "$p")"
+    cp -p "$p" "$STAGE/config$p"
+    staged=$((staged + 1))
+  else
+    log "config: skipping $p (missing or unreadable)"
+  fi
+done
+log "config: $staged entries staged"
+
+# Optional Umami (analytics) database — small, and the only other state on the
+# machine that is not rebuilt from Mongo.
+if [ -n "$UMAMI_DB_CONTAINER" ] && docker ps --format '{{.Names}}' | grep -qx "$UMAMI_DB_CONTAINER"; then
+  log "dumping Umami analytics database from $UMAMI_DB_CONTAINER…"
+  mkdir -p "$STAGE/umami"
+  docker exec "$UMAMI_DB_CONTAINER" sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' | gzip > "$STAGE/umami/umami.sql.gz"
+fi
+
+# What was running when this snapshot was taken — the exact image digests let a
+# rebuild pin the same versions instead of whatever :latest means that day.
+log "writing manifest…"
+{
+  echo "host: $(hostname)"
+  echo "taken: $(date -Is)"
+  echo "kernel: $(uname -r)"
+  echo "docker: $(docker --version 2>/dev/null)"
+  echo
+  echo "running containers:"
+  docker ps --format '  {{.Names}}  {{.Image}}'
+  echo
+  echo "image digests:"
+  docker images --digests --format '  {{.Repository}}:{{.Tag}}  {{.Digest}}' 2>/dev/null | grep -v '<none>' | sort -u
+  echo
+  echo "named volumes:"
+  docker volume ls --format '  {{.Name}}' | grep -vE '^  [0-9a-f]{64}$'
+} > "$STAGE/MANIFEST.txt" 2>/dev/null || log "warning: manifest incomplete"
 
 log "ensuring restic repository exists…"
 restic snapshots >/dev/null 2>&1 || restic init

--- a/scripts/backup/restore.sh
+++ b/scripts/backup/restore.sh
@@ -5,6 +5,17 @@
 # the snapshot's images back into the backend container.
 #
 # Usage:  ./restore.sh [snapshotID|latest]
+#
+#   RESTORE_CONFIG=1  also copy the snapshot's configuration files back to
+#                     their original absolute paths (existing files are kept
+#                     as <file>.pre-restore). Use this when rebuilding a machine.
+#   RESTORE_UMAMI=1   also reload the Umami analytics database (needs
+#                     UMAMI_DB_CONTAINER in backup.env and a running container).
+#
+# For a FULL move to a new machine see docs/backup.md → "Moving everything to
+# a new VM": you need the config files BEFORE the containers exist, so that
+# runbook restores in a different order than this script.
+#
 # Run a DRILL of this periodically — an untested backup is not a backup.
 #
 set -euo pipefail
@@ -25,10 +36,13 @@ export RESTIC_REPOSITORY RESTIC_PASSWORD
 MONGO_CONTAINER="${MONGO_CONTAINER:-cellarion-mongo}"
 BACKEND_CONTAINER="${BACKEND_CONTAINER:-cellarion-backend}"
 MONGO_DB="${MONGO_DB:-winecellar}"
+UMAMI_DB_CONTAINER="${UMAMI_DB_CONTAINER:-}"
 SNAPSHOT="${1:-latest}"
 
 echo "About to RESTORE snapshot '$SNAPSHOT' from $RESTIC_REPOSITORY."
 echo "This DROPS and reloads the '$MONGO_DB' database and overwrites uploaded images."
+[ "${RESTORE_CONFIG:-0}" = 1 ] && echo "RESTORE_CONFIG=1: configuration files will be written back to their original paths."
+[ "${RESTORE_UMAMI:-0}" = 1 ] && echo "RESTORE_UMAMI=1: the Umami database will be reloaded."
 read -rp "Type 'restore' to proceed: " confirm
 [ "$confirm" = "restore" ] || { echo "Aborted."; exit 1; }
 
@@ -40,7 +54,15 @@ restic restore "$SNAPSHOT" --target "$DEST"
 
 ARCHIVE="$(find "$DEST" -name "$MONGO_DB.archive.gz" | head -1)"
 UPLOADS_DIR="$(find "$DEST" -type d -name uploads | head -1)"
+CONFIG_DIR="$(find "$DEST" -type d -name config | head -1)"
+UMAMI_DUMP="$(find "$DEST" -name umami.sql.gz | head -1)"
+MANIFEST="$(find "$DEST" -name MANIFEST.txt | head -1)"
 [ -n "$ARCHIVE" ] || { echo "[restore] mongo archive not found in snapshot" >&2; exit 1; }
+
+if [ -n "$MANIFEST" ]; then
+  echo "[restore] snapshot manifest:"
+  sed 's/^/    /' "$MANIFEST" | head -20
+fi
 
 echo "[restore] restoring MongoDB (drop + reload)…"
 docker exec -i "$MONGO_CONTAINER" mongorestore --archive --gzip --drop < "$ARCHIVE"
@@ -48,6 +70,29 @@ docker exec -i "$MONGO_CONTAINER" mongorestore --archive --gzip --drop < "$ARCHI
 if [ -n "$UPLOADS_DIR" ] && [ -n "$(ls -A "$UPLOADS_DIR" 2>/dev/null)" ]; then
   echo "[restore] restoring uploaded images…"
   docker cp "$UPLOADS_DIR/." "$BACKEND_CONTAINER:/app/uploads/"
+fi
+
+if [ -n "$CONFIG_DIR" ]; then
+  n="$(find "$CONFIG_DIR" -type f | wc -l)"
+  if [ "${RESTORE_CONFIG:-0}" = 1 ]; then
+    echo "[restore] writing $n configuration file(s) back to their original paths…"
+    # config/<abs path> → <abs path>; anything already there is kept alongside.
+    find "$CONFIG_DIR" -type f | while read -r f; do
+      target="${f#"$CONFIG_DIR"}"
+      mkdir -p "$(dirname "$target")"
+      [ -e "$target" ] && cp -p "$target" "$target.pre-restore"
+      cp -p "$f" "$target"
+    done
+  else
+    echo "[restore] snapshot carries $n configuration file(s) (not written; set RESTORE_CONFIG=1 to restore them):"
+    find "$CONFIG_DIR" -type f | sed "s|^$CONFIG_DIR|    |" | head -40
+  fi
+fi
+
+if [ -n "$UMAMI_DUMP" ] && [ "${RESTORE_UMAMI:-0}" = 1 ]; then
+  [ -n "$UMAMI_DB_CONTAINER" ] || { echo "[restore] RESTORE_UMAMI=1 but UMAMI_DB_CONTAINER is not set" >&2; exit 1; }
+  echo "[restore] reloading Umami database into $UMAMI_DB_CONTAINER…"
+  gunzip -c "$UMAMI_DUMP" | docker exec -i "$UMAMI_DB_CONTAINER" sh -c 'psql -q -U "$POSTGRES_USER" "$POSTGRES_DB"'
 fi
 
 echo "[restore] done."


### PR DESCRIPTION
Until today a restore returned the database and the photos and nothing to run them with: none of the configuration was in the backup.

**What a snapshot now carries**
- Configuration under `config/<absolute path>`: the checkout's `.env`, both compose files and `backup.env` by default, plus `EXTRA_CONFIG_PATHS` for anything outside the checkout (reverse proxy, monitoring, systemd units, the SSH key that reaches the repository). Directories are copied whole; missing entries are skipped with a log line.
- Optionally a dump of the Umami analytics database (`UMAMI_DB_CONTAINER`).
- A `MANIFEST.txt` with the running containers, image digests and named volumes.

**Restore side**
- `restore.sh` gains `RESTORE_CONFIG=1` (writes files back to their original paths, keeping any existing file as `.pre-restore`) and `RESTORE_UMAMI=1`, and prints the manifest and config inventory it found.
- `docs/backup.md` gets a "Moving everything to a new VM" runbook in the order that works: config before containers, data after.

The snapshot now holds secrets, so the restic passphrase unlocks them too. The passphrase, repository address and repository credentials belong in a password manager off the host; `backup.env.example` says so.

Verified on the hosted instance: a run with the new script produced a snapshot containing 19 config entries, the analytics dump and the manifest, and the nightly timer picks the script up unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)