### PR TITLE
fix(backup): the off-provider copy needs the SOURCE repository's passphrase

### DIFF
--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -185,6 +185,14 @@ restic forget --tag cellarion --group-by host,tags --keep-daily "$KEEP_DAILY" --
 # level loss can't wipe everything. Enable by setting B2_* in backup.env.
 if [ -n "${B2_RESTIC_REPOSITORY:-}" ]; then
   export B2_ACCOUNT_ID="${B2_ACCOUNT_ID:-}" B2_ACCOUNT_KEY="${B2_ACCOUNT_KEY:-}"
+  # `init --from-repo` and `copy --from-repo` open TWO repositories, and restic
+  # takes the SOURCE one's passphrase from RESTIC_FROM_PASSWORD — not from
+  # RESTIC_PASSWORD, which it applies to the destination. Without this it falls
+  # back to prompting on stdin, and under systemd (no terminal) that reads empty
+  # and dies with "an empty password is not a password". Both repositories here
+  # share one passphrase. (Found 2026-09-02, the first time this branch ever ran
+  # — B2 had been left unconfigured since the script was written.)
+  export RESTIC_FROM_PASSWORD="$RESTIC_PASSWORD"
   log "copying snapshots to off-provider repo $B2_RESTIC_REPOSITORY…"
   restic -r "$B2_RESTIC_REPOSITORY" snapshots >/dev/null 2>&1 \
     || restic -r "$B2_RESTIC_REPOSITORY" init --copy-chunker-params --from-repo "$RESTIC_REPOSITORY"


### PR DESCRIPTION
Found by configuring the optional Backblaze second copy for the first time. That branch had never run, and it was broken.

`init --from-repo` and `copy --from-repo` open two repositories. restic takes the source repository's passphrase from `RESTIC_FROM_PASSWORD`; `RESTIC_PASSWORD` applies to the destination. With it unset restic prompts on stdin, and under systemd there is no terminal, so it reads an empty string and exits with "an empty password is not a password".

Because the failure propagates through the `ERR` trap, anyone who configured a second copy would have had their whole nightly backup marked failed and the healthcheck pinged — after the primary snapshot had already been written correctly. So the symptom was worse than the cause: a working backup reported as broken.

Both repositories share one passphrase, so `RESTIC_FROM_PASSWORD` is exported from `RESTIC_PASSWORD` before the init/copy pair.

Verified on the hosted instance: 12 snapshots, identical in both repositories, 1.82 GiB stored in Backblaze EU Central, backup status back to ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)