### PR TITLE
feat(import): import from Ploc — slots, stock and drinking history in one go

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is the primary way to use Cellarion. Create an account and start using the 
 - **Reserved bottles** — Mark bottles as "spoken for" (a birthday, a dinner) so suggestions and consume flows respect them
 - **Drink-window alerts** — Sommelier-curated maturity windows per wine and vintage; alerts when bottles approach peak, are in window, or slipping past it
 - **Rich statistics** — Charts, world choropleth map, breakdowns by country, grape, value, and drink status
-- **Import & export** — Bring collections from Vivino (incl. drinking history), CellarTracker, generic CSV, or Cellarion's own JSON; export everything as JSON or a ZIP with your images
+- **Import & export** — Bring collections from Vivino (incl. drinking history), CellarTracker, Ploc, generic CSV, or Cellarion's own JSON; export everything as JSON or a ZIP with your images
 
 **The shared registry**
 - **Smart search** — Meilisearch-powered fuzzy search with aggressive deduplication and canonical-key matching
@@ -441,7 +441,7 @@ db.users.updateMany({ emailVerified: { $exists: false } }, { $set: { emailVerifi
 
 ## Bottle Import
 
-Users can import bottles from other wine cellar apps (Vivino — including drinking history, CellarTracker, or any generic CSV). The import flow:
+Users can import bottles from other wine cellar apps (Vivino — including drinking history, CellarTracker, Ploc — including slot positions and purchase history, or any generic CSV). The import flow:
 
 1. **Upload** — Drop a CSV file; the system auto-detects the source format and maps it to a standard schema
 2. **Validate** — Each item is matched against the wine library using fuzzy search (Meilisearch + MongoDB text search + normalized key lookup) and scored with combined similarity

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3828,7 +3828,8 @@
       "vivino": "Vivino",
       "cellartracker": "CellarTracker",
       "oenoExport": "Oeno by Vintec",
-      "generic": "CSV"
+      "generic": "CSV",
+      "ploc": "Ploc"
     },
     "status": {
       "exact": "Matched",
@@ -3855,7 +3856,8 @@
       "ctErrorPage": "This file is a CellarTracker error page, not an export — log in to CellarTracker and re-export.",
       "ctAvailability": "This is CellarTracker's Availability table — drinking-window statistics, not a cellar export. Export the List or Inventory table instead.",
       "ctAllPending_one": "The only bottle in this file is a pending (undelivered) purchase — Cellarion doesn't track bottles you haven't received yet.",
-      "ctAllPending_other": "All {{count}} bottles in this file are pending (undelivered) purchases — Cellarion doesn't track bottles you haven't received yet."
+      "ctAllPending_other": "All {{count}} bottles in this file are pending (undelivered) purchases — Cellarion doesn't track bottles you haven't received yet.",
+      "plocWinesMissing": "That looks like a Ploc export, but the wines file is missing — it is the one with the stock counts. Select all of the files Ploc produced."
     },
     "warnings": {
       "tooManyRowsTitle": "{{count}} rows — more than one import run can take.",
@@ -3865,7 +3867,17 @@
       "ctPendingSkipped_one": "{{count}} pending (undelivered) bottle was not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery.",
       "ctPendingSkipped_other": "{{count}} pending (undelivered) bottles were not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery.",
       "noIdentitySkipped_one": "{{count}} row was skipped because it has no wine name or producer (usually a failed label scan).",
-      "noIdentitySkipped_other": "{{count}} rows were skipped because they have no wine name or producer (usually failed label scans)."
+      "noIdentitySkipped_other": "{{count}} rows were skipped because they have no wine name or producer (usually failed label scans).",
+      "extraFilesIgnored": "Only the first file was used — {{count}} other file(s) were ignored.",
+      "plocPlaced": "Ploc told us exactly where {{count}} bottle(s) sit, across {{racks}} rack(s). Check the sizes below, then import.",
+      "plocHistory": "{{count}} bottle(s) you have already drunk will be imported as drinking history, with their dates.",
+      "plocNoCellars": "No Ploc cellars file was included, so nothing could be placed in a rack. Add it and drop the files again to keep your slot positions.",
+      "plocNoHistory": "No Ploc purchases-and-consumptions file was included, so purchase dates, prices and drinking history are missing. Add it and drop the files again to bring them across.",
+      "plocRatingScale": "Ploc does not say what scale its ratings use. We read them as out of {{scale}} — check a few after importing.",
+      "plocDateOrder": "Ploc does not say whether its dates are day/month or month/day, and nothing in your file settles it. We read them as day/month.",
+      "plocExtraSlots": "\"{{wine}}\" has {{slots}} slot(s) recorded but only {{stock}} bottle(s) in stock, so the extra slots were left empty.",
+      "plocRackTooBig": "\"{{rack}}\" is {{rows}} x {{cols}}, larger than a Cellarion rack allows (20 x 20). Its bottles will be imported without a position.",
+      "plocUnmatchedHistory": "{{count}} history entr(y/ies) refer to wines that are not in the wines file, and were skipped."
     },
     "ctTables": {
       "list": "List table",
@@ -3927,7 +3939,10 @@
       "changeFile": "Click or drop to change file",
       "dropHere": "Drop your file here or click to browse",
       "dropHint": "JSON, CSV, TSV, or TXT — max 10 MB",
-      "encodingLine": "File encoding: {{encoding}}"
+      "encodingLine": "File encoding: {{encoding}}",
+      "plocTitle": "Ploc",
+      "plocDesc": "Ploc exports several files — select them all at once. The wines file carries your bottles, the cellars file their exact slot positions, and the purchases-and-consumptions file your purchase dates, prices and drinking history.",
+      "dropHereMulti": "Drop your file here or click to browse — select several at once for a Ploc export"
     },
     "wholeImport": {
       "title": "For every imported bottle",

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -6,7 +6,10 @@ import { validateImport, confirmImport } from '../api/bottles';
 import { getAiBudgetStatus, requestAiBudgetIncrease } from '../api/aiBudget';
 import { searchWines } from '../api/wines';
 import { getRacks } from '../api/racks';
-import { parseAndMap, parseJSON, summariseRacks, getDefaultRackConfig, getDefaultAnchor, decodeImportBuffer } from '../utils/importMappers';
+import {
+  parseAndMap, parseJSON, summariseRacks, getDefaultRackConfig, getDefaultAnchor, decodeImportBuffer,
+  parseCSV, detectDelimiter, detectPlocFile, parsePlocFiles,
+} from '../utils/importMappers';
 import { buildImportItem as buildImportItemPayload } from '../utils/importPayload';
 import { prepareImportItems } from '../utils/importPrepare';
 import { describePriceWarning } from '../utils/priceValidation';
@@ -398,98 +401,168 @@ function ImportBottles() {
 
   // ── File handling ───────────────────────────────────────────────────────
 
-  const processFile = useCallback((file) => {
+  // Apply one parsed result to the page's state. Shared by every source: a
+  // single CSV/JSON, and the multi-file Ploc set below, which produces the same
+  // shape from three files that only mean anything together.
+  const applyParsed = useCallback((parsed, { fileName: sourceName, encoding }) => {
+    const { items, format, oenoRackSpecs } = parsed;
+    if (items.length === 0) {
+      const pendingWarning = (parsed.warnings || []).find(w => w.code === 'ct-pending-skipped');
+      setError(pendingWarning
+        ? t('importBottles.errors.ctAllPending', { count: pendingWarning.count })
+        : t('importBottles.errors.noValidItems'));
+      return;
+    }
+    setParsedItems(items);
+    setDetectedFormat(format);
+    setDetectedEncoding(encoding);
+    setCtTable(parsed.ctTable || null);
+    setImportWarnings(parsed.warnings || []);
+    setCtTextFallback(parsed.ctRackAutoMap?.textFallback || []);
+    setCtDisclosureDismissed(false); // new file → show the CT disclosure again
+    setVivinoScanHistory(!!parsed.vivinoScanHistory);
+    setVivinoImportMode('history'); // new file → back to the recommended default
+    setFileName(sourceName);
+
+    // Build per-rack summary + seed editable config with format-aware
+    // defaults. For Oeno-export, the cabinet metadata in the CSV gives
+    // us the exact shape of each rack (one per cabinet-column); pass
+    // that through to the picker via info.oenoRackSpec. For
+    // CellarTracker, racks derived from Location/Bin pattern detection
+    // carry their pattern + counts (info.ctAutoMap, shown on the card)
+    // and detected geometry (info.ctRackSpec). Ploc states each unit's real
+    // extent outright, empty slots included, so it needs no inference at all.
+    const summary = summariseRacks(items);
+    const initialConfigs = {};
+    for (const [name, info] of Object.entries(summary)) {
+      if (oenoRackSpecs && oenoRackSpecs[name]) {
+        info.oenoRackSpec = oenoRackSpecs[name];
+      }
+      if (parsed.rackSpecs && parsed.rackSpecs[name]) {
+        info.rackSpec = parsed.rackSpecs[name];
+      }
+      const ctAutoMap = parsed.ctRackAutoMap?.racks?.[name];
+      if (ctAutoMap) {
+        info.ctAutoMap = ctAutoMap;
+        if (ctAutoMap.spec) info.ctRackSpec = ctAutoMap.spec;
+      }
+      initialConfigs[name] = getDefaultRackConfig(format, info);
+    }
+    setRackSummary(summary);
+    setRackConfigs(initialConfigs);
+    setPositionAnchor(getDefaultAnchor(format));
+  }, [t]);
+
+  const VALID_IMPORT_EXTENSIONS = ['.csv', '.tsv', '.txt', '.json'];
+
+  /**
+   * Read and parse the dropped/chosen file(s).
+   *
+   * One file is the normal case and behaves exactly as it always has. Several
+   * files are accepted for one reason: Ploc exports a SET — the wines with
+   * their stock counts, the slots that say where each bottle sits, and the
+   * purchase/consumption log — and any one of them alone is an incomplete
+   * picture of a cellar. The files are recognised by their columns rather than
+   * their names, because Ploc names them in French whatever the app language
+   * is and people rename them anyway.
+   */
+  const processFiles = useCallback((fileList) => {
     setError(null);
+    const files = Array.from(fileList || []).filter(Boolean);
+    if (files.length === 0) return;
 
-    if (!file) return;
-
-    const validExtensions = ['.csv', '.tsv', '.txt', '.json'];
-    const ext = file.name.toLowerCase().slice(file.name.lastIndexOf('.'));
-    if (!validExtensions.includes(ext)) {
-      setError(t('importBottles.errors.invalidFileType'));
-      return;
+    for (const file of files) {
+      const ext = file.name.toLowerCase().slice(file.name.lastIndexOf('.'));
+      if (!VALID_IMPORT_EXTENSIONS.includes(ext)) {
+        setError(t('importBottles.errors.invalidFileType'));
+        return;
+      }
+      if (file.size > 10 * 1024 * 1024) {
+        setError(t('importBottles.errors.fileTooLarge'));
+        return;
+      }
     }
 
-    if (file.size > 10 * 1024 * 1024) {
-      setError(t('importBottles.errors.fileTooLarge'));
-      return;
-    }
+    const readOne = (file) => new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      // Read raw bytes and detect the encoding ourselves — CellarTracker's
+      // browser export is Windows-1252, and a hard-assumed UTF-8 read
+      // silently corrupts every accented producer (Pétrus → P�trus).
+      reader.onload = (e) => {
+        try {
+          const { text, encoding } = decodeImportBuffer(e.target.result);
+          resolve({ file, text, encoding });
+        } catch (err) {
+          reject(err);
+        }
+      };
+      reader.onerror = () => reject(new Error('read-failed'));
+      reader.readAsArrayBuffer(file);
+    });
 
-    const isJson = ext === '.json';
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      try {
-        // Read raw bytes and detect the encoding ourselves — CellarTracker's
-        // browser export is Windows-1252, and a hard-assumed UTF-8 read
-        // silently corrupts every accented producer (Pétrus → P�trus).
-        const { text, encoding } = decodeImportBuffer(e.target.result);
-        const parsed = isJson
-          ? parseJSON(text)
-          : parseAndMap(text);
-        const { items, format, oenoRackSpecs } = parsed;
-        if (items.length === 0) {
-          const pendingWarning = (parsed.warnings || []).find(w => w.code === 'ct-pending-skipped');
-          setError(pendingWarning
-            ? t('importBottles.errors.ctAllPending', { count: pendingWarning.count })
-            : t('importBottles.errors.noValidItems'));
+    Promise.all(files.map(readOne))
+      .then((read) => {
+        // Which of these, if any, are Ploc's files?
+        const ploc = {};
+        const plocNames = [];
+        for (const r of read) {
+          if (r.file.name.toLowerCase().endsWith('.json')) continue;
+          let kind = null;
+          try {
+            const cleaned = r.text.replace(/^﻿/, '');
+            const rows = parseCSV(cleaned, detectDelimiter(cleaned));
+            if (rows.length > 0) kind = detectPlocFile(Object.keys(rows[0]));
+          } catch { /* not parseable as a table — fall through to the normal path */ }
+          if (kind && !ploc[kind]) {
+            ploc[kind] = r.text;
+            plocNames.push(r.file.name);
+          }
+        }
+
+        if (ploc.wines) {
+          const parsed = parsePlocFiles(ploc);
+          if (read.length > plocNames.length) {
+            parsed.warnings = [...(parsed.warnings || []), { code: 'extra-files-ignored', count: read.length - plocNames.length }];
+          }
+          applyParsed(parsed, { fileName: plocNames.join(' + '), encoding: read[0].encoding });
           return;
         }
-        setParsedItems(items);
-        setDetectedFormat(format);
-        setDetectedEncoding(encoding);
-        setCtTable(parsed.ctTable || null);
-        setImportWarnings(parsed.warnings || []);
-        setCtTextFallback(parsed.ctRackAutoMap?.textFallback || []);
-        setCtDisclosureDismissed(false); // new file → show the CT disclosure again
-        setVivinoScanHistory(!!parsed.vivinoScanHistory);
-        setVivinoImportMode('history'); // new file → back to the recommended default
-        setFileName(file.name);
 
-        // Build per-rack summary + seed editable config with format-aware
-        // defaults. For Oeno-export, the cabinet metadata in the CSV gives
-        // us the exact shape of each rack (one per cabinet-column); pass
-        // that through to the picker via info.oenoRackSpec. For
-        // CellarTracker, racks derived from Location/Bin pattern detection
-        // carry their pattern + counts (info.ctAutoMap, shown on the card)
-        // and detected geometry (info.ctRackSpec).
-        const summary = summariseRacks(items);
-        const initialConfigs = {};
-        for (const [name, info] of Object.entries(summary)) {
-          if (oenoRackSpecs && oenoRackSpecs[name]) {
-            info.oenoRackSpec = oenoRackSpecs[name];
-          }
-          const ctAutoMap = parsed.ctRackAutoMap?.racks?.[name];
-          if (ctAutoMap) {
-            info.ctAutoMap = ctAutoMap;
-            if (ctAutoMap.spec) info.ctRackSpec = ctAutoMap.spec;
-          }
-          initialConfigs[name] = getDefaultRackConfig(format, info);
+        if (ploc.cellars || ploc.history) {
+          // Ploc files, but not the one that holds the bottles.
+          setError(t('importBottles.errors.plocWinesMissing'));
+          return;
         }
-        setRackSummary(summary);
-        setRackConfigs(initialConfigs);
-        setPositionAnchor(getDefaultAnchor(format));
-      } catch (err) {
+
+        const first = read[0];
+        const isJson = first.file.name.toLowerCase().endsWith('.json');
+        const parsed = isJson ? parseJSON(first.text) : parseAndMap(first.text);
+        if (read.length > 1) {
+          parsed.warnings = [...(parsed.warnings || []), { code: 'extra-files-ignored', count: read.length - 1 }];
+        }
+        applyParsed(parsed, { fileName: first.file.name, encoding: first.encoding });
+      })
+      .catch((err) => {
         if (err.code === 'ct-error-page') {
           setError(t('importBottles.errors.ctErrorPage'));
         } else if (err.code === 'ct-availability') {
           setError(t('importBottles.errors.ctAvailability'));
+        } else if (err.message === 'read-failed') {
+          setError(t('importBottles.errors.readFailed'));
         } else {
           setError(t('importBottles.errors.parseFailed', { message: err.message }));
         }
-      }
-    };
-    reader.onerror = () => setError(t('importBottles.errors.readFailed'));
-    reader.readAsArrayBuffer(file);
-  }, [t]);
+      });
+  }, [t, applyParsed]);
 
   const handleFileInput = (e) => {
-    processFile(e.target.files[0]);
+    processFiles(e.target.files);
   };
 
   const handleDrop = (e) => {
     e.preventDefault();
     setDragOver(false);
-    processFile(e.dataTransfer.files[0]);
+    processFiles(e.dataTransfer.files);
   };
 
   // ── Validation ──────────────────────────────────────────────────────────
@@ -956,6 +1029,16 @@ function ImportBottles() {
             wines: (w.wines || []).join(', ')
           })}
           {w.code === 'no-identity-skipped' && t('importBottles.warnings.noIdentitySkipped', { count: w.count })}
+          {w.code === 'extra-files-ignored' && t('importBottles.warnings.extraFilesIgnored', { count: w.count })}
+          {w.code === 'ploc-placed' && t('importBottles.warnings.plocPlaced', { count: w.count, racks: w.racks })}
+          {w.code === 'ploc-history' && t('importBottles.warnings.plocHistory', { count: w.count })}
+          {w.code === 'ploc-no-cellars' && t('importBottles.warnings.plocNoCellars')}
+          {w.code === 'ploc-no-history' && t('importBottles.warnings.plocNoHistory')}
+          {w.code === 'ploc-rating-scale' && t('importBottles.warnings.plocRatingScale', { scale: w.scale })}
+          {w.code === 'ploc-date-order-assumed' && t('importBottles.warnings.plocDateOrder')}
+          {w.code === 'ploc-extra-slots' && t('importBottles.warnings.plocExtraSlots', { wine: w.wine, slots: w.slots, stock: w.stock })}
+          {w.code === 'ploc-rack-too-big' && t('importBottles.warnings.plocRackTooBig', { rack: w.rack, rows: w.rows, cols: w.cols })}
+          {w.code === 'ploc-unmatched-history' && t('importBottles.warnings.plocUnmatchedHistory', { count: w.count })}
         </div>
       ))}
     </div>
@@ -1148,6 +1231,10 @@ function ImportBottles() {
             <p>{t('importBottles.upload.oenoDesc')}</p>
           </div>
           <div className="format-card">
+            <strong>{t('importBottles.upload.plocTitle')}</strong>
+            <p>{t('importBottles.upload.plocDesc')}</p>
+          </div>
+          <div className="format-card">
             <strong>{t('importBottles.upload.genericTitle')}</strong>
             <p>{t('importBottles.upload.genericDesc')}</p>
           </div>
@@ -1165,6 +1252,7 @@ function ImportBottles() {
           id="import-file-input"
           type="file"
           accept=".csv,.tsv,.txt,.json,text/csv,text/plain,text/tab-separated-values,application/json,application/vnd.ms-excel"
+          multiple
           onChange={handleFileInput}
           style={{ display: 'none' }}
         />
@@ -1188,7 +1276,7 @@ function ImportBottles() {
         ) : (
           <div className="drop-zone-empty">
             <span className="drop-zone-icon">&#8686;</span>
-            <p>{t('importBottles.upload.dropHere')}</p>
+            <p>{t('importBottles.upload.dropHereMulti')}</p>
             <span className="drop-zone-hint">{t('importBottles.upload.dropHint')}</span>
           </div>
         )}

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -1651,6 +1651,425 @@ export function applyCtRackAutoMap(items) {
   return { racks, textFallback };
 }
 
+// ─── Ploc ────────────────────────────────────────────────────────────────────
+//
+// Ploc (a French cellar app) does not export one file. It exports a SET that
+// only means anything together, joined on the wine's GUID:
+//
+//   Vins.csv           one row per WINE  — identity, stock count, apogee, value
+//   Caves.csv          one row per SLOT  — storage-unit name, row, column
+//   Achats-Consos.csv  one row per MOVE  — date, bought/drunk counts, unit price
+//   Producteurs.csv    the producer address book — deliberately NOT imported;
+//                      it is other people's contact details, and the producer
+//                      name we need is already on every wine row.
+//
+// The file NAMES are French whatever language the app runs in, and users rename
+// them anyway (the first sample we were sent arrived as "Wines_sample.csv" and
+// "cellars_sample.csv"), so each file is recognised by its COLUMNS instead.
+// `IdVin` appears in all three and is the join key — written in mixed case from
+// row to row, so it is always compared lower-cased.
+//
+// What Ploc gives us that a flat CSV cannot:
+//   - exact slot positions (name + row + column), so no bin-code guessing
+//   - real stock counts per wine, expanded into individual bottles
+//   - purchase and consumption history with dates and prices, so a migrating
+//     user keeps what they have drunk, not just what they still hold
+//
+// Not imported: "Degree of alcohol" (the import pipeline has no ABV field),
+// "Service temperature", "Tags", "Reference", "IdContact" and the producer
+// address book.
+
+/** All three Ploc files carry this column; it is the join key. */
+const PLOC_JOIN_KEY = 'idvin';
+
+const PLOC_COLOUR_TO_TYPE = {
+  red: 'red', rouge: 'red',
+  white: 'white', blanc: 'white',
+  'rosé': 'rosé', rose: 'rosé',
+  sparkling: 'sparkling', effervescent: 'sparkling', 'pétillant': 'sparkling', petillant: 'sparkling',
+  sweet: 'dessert', liquoreux: 'dessert', moelleux: 'dessert',
+  fortified: 'fortified', 'fortifié': 'fortified', fortifie: 'fortified', muté: 'fortified', mute: 'fortified',
+};
+
+const PLOC_FORMAT_TO_SIZE = {
+  bottle: '750ml', bouteille: '750ml',
+  magnum: '1500ml',
+  half: '375ml', demi: '375ml', 'demi-bouteille': '375ml', 'half bottle': '375ml',
+  jeroboam: '3000ml', 'double magnum': '3000ml', 'double-magnum': '3000ml',
+  rehoboam: '4500ml', 'réhoboam': '4500ml',
+  mathusalem: '6000ml', methuselah: '6000ml', imperial: '6000ml', 'impériale': '6000ml',
+  salmanazar: '9000ml',
+};
+
+/** Ploc writes a currency SYMBOL, not a code. */
+const PLOC_CURRENCY_SYMBOLS = {
+  '$': 'USD', 'us$': 'USD', 'usd': 'USD',
+  '€': 'EUR', 'eur': 'EUR',
+  '£': 'GBP', 'gbp': 'GBP',
+  'kr': 'SEK', 'sek': 'SEK',
+  'chf': 'CHF', 'fr.': 'CHF',
+  '¥': 'JPY', 'jpy': 'JPY',
+  'ca$': 'CAD', 'cad': 'CAD',
+  'a$': 'AUD', 'aud': 'AUD',
+};
+
+/**
+ * Which of Ploc's files this is, by its columns — never by its name.
+ * @returns {'wines'|'cellars'|'history'|null}
+ */
+export function detectPlocFile(headers) {
+  const h = new Set((headers || []).map((s) => String(s).toLowerCase().trim()));
+  if (!h.has(PLOC_JOIN_KEY)) return null;
+  if ((h.has('row') && h.has('column')) || (h.has('ligne') && h.has('colonne'))) return 'cellars';
+  if ((h.has('purchase') && h.has('consumption')) || (h.has('achat') && h.has('conso'))) return 'history';
+  if (h.has('stock') || h.has('producer') || h.has('producteur')) return 'wines';
+  return null;
+}
+
+/** Case-insensitive column read across the English/French header variants. */
+function plocGet(row, names) {
+  for (const n of names) {
+    if (row[n] !== undefined && String(row[n]).trim() !== '') return String(row[n]).trim();
+  }
+  // Fall back to a case-insensitive sweep — Ploc's capitalisation varies.
+  const lower = {};
+  for (const k of Object.keys(row)) lower[k.toLowerCase().trim()] = row[k];
+  for (const n of names) {
+    const v = lower[n.toLowerCase()];
+    if (v !== undefined && String(v).trim() !== '') return String(v).trim();
+  }
+  return '';
+}
+
+/** The join key, normalised. Ploc writes the same GUID in mixed case. */
+function plocId(row) {
+  return plocGet(row, ['IdVin', 'idvin']).toLowerCase();
+}
+
+/**
+ * "80% Cabernet Sauvignon,18% Merlot,2% Cabernet Franc" → the three varieties.
+ * The percentages are Ploc's blend proportions; the registry stores varieties,
+ * not proportions, and a grape called "80% Merlot" would never match.
+ */
+export function parsePlocGrapes(value) {
+  return String(value || '')
+    .split(/[,;]/)
+    .map((g) => g.replace(/^\s*\d+(?:[.,]\d+)?\s*%\s*/, '').trim())
+    .filter(Boolean);
+}
+
+/**
+ * Ploc's "Apogee" is the drinking window, written "2030/2035" (and sometimes as
+ * a single year, or with a dash). Maps to the BOTTLE's own window — never to
+ * the shared registry's curated maturity, which is a sommelier's judgement.
+ */
+export function parsePlocApogee(value) {
+  const years = String(value || '').match(/\d{4}/g);
+  if (!years || years.length === 0) return {};
+  const from = parseInt(years[0], 10);
+  const to = years[1] ? parseInt(years[1], 10) : undefined;
+  if (!Number.isFinite(from)) return {};
+  return to && to >= from ? { drinkFrom: from, drinkTo: to } : { drinkFrom: from };
+}
+
+/**
+ * Build a date parser for one Ploc export.
+ *
+ * Ploc's raw date format is not documented and varies with the exporting
+ * device's locale, so "03/09/2026" is genuinely ambiguous on its own. Rather
+ * than guess per row, this reads the WHOLE column first: any row where one
+ * component exceeds 12 can only be read one way, and that settles the order for
+ * every ambiguous row in the same file. With no such row anywhere it falls back
+ * to day-first, which is what a French app writes.
+ *
+ * Also accepts ISO (unambiguous) and Unix seconds (what Ploc's own database
+ * stores), so a hand-made export still lands correctly.
+ *
+ * @returns {{ parse: (v:*) => string|undefined, dayFirst: boolean, inferred: boolean }}
+ *   `parse` returns an ISO yyyy-mm-dd string, or undefined when unreadable.
+ */
+export function buildPlocDateParser(samples) {
+  let dayFirst = true;   // a French app's default
+  let inferred = false;
+
+  for (const raw of samples || []) {
+    const m = /^(\d{1,4})[/\-.](\d{1,2})[/\-.](\d{1,4})$/.exec(String(raw || '').trim());
+    if (!m || m[1].length === 4) continue; // ISO carries its own order
+    const a = parseInt(m[1], 10);
+    const b = parseInt(m[2], 10);
+    if (a > 12 && b <= 12) { dayFirst = true; inferred = true; break; }
+    if (b > 12 && a <= 12) { dayFirst = false; inferred = true; break; }
+  }
+
+  const iso = (y, mo, d) => {
+    if (!(y >= 1900 && y <= 2200) || !(mo >= 1 && mo <= 12) || !(d >= 1 && d <= 31)) return undefined;
+    return `${y}-${String(mo).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+  };
+
+  return {
+    dayFirst,
+    inferred,
+    parse(value) {
+      const s = String(value ?? '').trim();
+      if (!s) return undefined;
+
+      // Unix seconds (Ploc's internal storage) — bounded to a sane era so a
+      // bare year like "2026" is never read as an epoch.
+      if (/^\d{9,11}$/.test(s)) {
+        const d = new Date(parseInt(s, 10) * 1000);
+        return Number.isNaN(d.getTime()) ? undefined : d.toISOString().slice(0, 10);
+      }
+
+      const isoM = /^(\d{4})[/\-.](\d{1,2})[/\-.](\d{1,2})/.exec(s);
+      if (isoM) return iso(+isoM[1], +isoM[2], +isoM[3]);
+
+      const m = /^(\d{1,2})[/\-.](\d{1,2})[/\-.](\d{2,4})/.exec(s);
+      if (!m) return undefined;
+      let year = parseInt(m[3], 10);
+      if (m[3].length === 2) year += year < 70 ? 2000 : 1900;
+      const a = parseInt(m[1], 10);
+      const b = parseInt(m[2], 10);
+      // A component over 12 overrides the file-level order for this row.
+      if (a > 12) return iso(year, b, a);
+      if (b > 12) return iso(year, a, b);
+      return dayFirst ? iso(year, b, a) : iso(year, a, b);
+    },
+  };
+}
+
+/**
+ * Ploc's "Note" is the owner's own score, and the file never says on what
+ * scale. Infer it from the values present: nothing above 5 is a 5-star scale,
+ * nothing above 20 is the French /20, anything higher is /100. The caller
+ * surfaces the assumption as a warning so the owner can correct it rather than
+ * discover a wrong rating later.
+ *
+ * @returns {'5'|'20'|'100'|null} null when the file carries no ratings at all
+ */
+export function inferPlocRatingScale(values) {
+  const nums = (values || [])
+    .map((v) => parseLocaleNumber(v))
+    .filter((n) => typeof n === 'number' && Number.isFinite(n) && n > 0);
+  if (nums.length === 0) return null;
+  const max = Math.max(...nums);
+  if (max <= 5) return '5';
+  if (max <= 20) return '20';
+  return '100';
+}
+
+/** "$" → "USD". Returns undefined for anything unrecognised, so the account default applies. */
+function plocCurrency(value) {
+  const s = String(value || '').trim();
+  if (!s) return undefined;
+  if (/^[A-Za-z]{3}$/.test(s)) return s.toUpperCase();
+  return PLOC_CURRENCY_SYMBOLS[s.toLowerCase()] || undefined;
+}
+
+/**
+ * Parse a Ploc export — one, two or three of its files — into master-format
+ * items, joined on IdVin.
+ *
+ * @param {{wines?: string, cellars?: string, history?: string}} texts raw file text
+ * @returns {{ items: object[], format: 'ploc', headers: string[],
+ *             rackSpecs: object, warnings: object[] }}
+ *   `rackSpecs` is the exact geometry of each storage unit, keyed by rack name,
+ *   taken from the highest row and column actually used — so the review screen
+ *   offers the real shape instead of a guess.
+ */
+export function parsePlocFiles(texts) {
+  const { wines: winesText, cellars: cellarsText, history: historyText } = texts || {};
+  const warnings = [];
+  if (!winesText) {
+    const err = new Error('The wines file is required to import from Ploc');
+    err.code = 'ploc-no-wines';
+    throw err;
+  }
+
+  const rowsOf = (text) => {
+    if (!text) return [];
+    const cleaned = String(text).replace(/^﻿/, '');
+    return parseCSV(cleaned, detectDelimiter(cleaned));
+  };
+
+  const wineRows = rowsOf(winesText);
+  const slotRows = rowsOf(cellarsText);
+  const moveRows = rowsOf(historyText);
+  const headers = wineRows.length > 0 ? Object.keys(wineRows[0]) : [];
+
+  // ── Slots, grouped by storage unit ────────────────────────────────────────
+  // Ploc calls each unit a "cellar"; it is a physical rack, and its name is the
+  // owner's own label ("Column I - Red Burgundy £75-£200"). Empty slots are
+  // exported too, and they are useful: they tell us the unit's real shape even
+  // where nothing is stored.
+  const rackSpecs = {};
+  const slotsByWine = new Map(); // wineId -> [{ rackName, row, col }]
+  const dims = {};               // rackName -> { rows, cols }
+  for (const r of slotRows) {
+    const name = plocGet(r, ['Name', 'Nom', 'Cave']);
+    const row = parseInt(plocGet(r, ['Row', 'Ligne']), 10);
+    const col = parseInt(plocGet(r, ['Column', 'Colonne']), 10);
+    if (!name || !Number.isFinite(row) || !Number.isFinite(col)) continue;
+    if (!dims[name]) dims[name] = { rows: 0, cols: 0 };
+    if (row > dims[name].rows) dims[name].rows = row;
+    if (col > dims[name].cols) dims[name].cols = col;
+    const id = plocId(r);
+    if (!id) continue; // an empty slot: shapes the rack, holds nothing
+    if (!slotsByWine.has(id)) slotsByWine.set(id, []);
+    slotsByWine.get(id).push({ rackName: name, row, col });
+  }
+  for (const [name, d] of Object.entries(dims)) {
+    // The Rack schema caps a side at 20; a larger unit keeps its bottles but
+    // arrives unplaced rather than silently distorted.
+    if (d.rows > 20 || d.cols > 20) {
+      warnings.push({ code: 'ploc-rack-too-big', rack: name, rows: d.rows, cols: d.cols });
+      continue;
+    }
+    rackSpecs[name] = { type: 'grid', rows: Math.max(1, d.rows), cols: Math.max(1, d.cols), typeConfig: {} };
+  }
+
+  // ── Movements ─────────────────────────────────────────────────────────────
+  const dateParser = buildPlocDateParser(moveRows.map((r) => plocGet(r, ['Date'])));
+  const purchasesByWine = new Map(); // wineId -> [{ date, price, currency, vendor }]
+  const consumptionsByWine = new Map(); // wineId -> [{ date, note, occasion }]
+  let unmatchedMoves = 0;
+  for (const r of moveRows) {
+    const id = plocId(r);
+    if (!id) continue;
+    const date = dateParser.parse(plocGet(r, ['Date']));
+    const bought = parseInt(plocGet(r, ['Purchase', 'Achat', 'Achats']), 10) || 0;
+    const drunk = parseInt(plocGet(r, ['Consumption', 'Conso', 'Consos']), 10) || 0;
+    const price = parseLocaleNumber(plocGet(r, ['Unit price', 'Prix unitaire', 'Prix']));
+    const currency = plocCurrency(plocGet(r, ['Currency', 'Devise']));
+    const vendor = plocGet(r, ['Vendor', 'Fournisseur', 'Vendeur']);
+    const comments = plocGet(r, ['Comments', 'Commentaires', 'Commentaire']);
+    const occasion = plocGet(r, ['Opportunity', 'Occasion']);
+
+    if (bought > 0) {
+      if (!purchasesByWine.has(id)) purchasesByWine.set(id, []);
+      for (let i = 0; i < bought; i++) {
+        purchasesByWine.get(id).push({ date, price: price > 0 ? price : undefined, currency, vendor });
+      }
+    }
+    if (drunk > 0) {
+      if (!consumptionsByWine.has(id)) consumptionsByWine.set(id, []);
+      for (let i = 0; i < drunk; i++) {
+        consumptionsByWine.get(id).push({ date, note: comments, occasion });
+      }
+    }
+  }
+
+  // ── Wines → bottles ───────────────────────────────────────────────────────
+  const ratingScale = inferPlocRatingScale(wineRows.map((r) => plocGet(r, ['Note', 'Notation'])));
+  if (ratingScale) warnings.push({ code: 'ploc-rating-scale', scale: ratingScale });
+  if (moveRows.length > 0 && dateParser.inferred === false) {
+    warnings.push({ code: 'ploc-date-order-assumed', dayFirst: dateParser.dayFirst });
+  }
+
+  const items = [];
+  const seenWineIds = new Set();
+  let placedCount = 0;
+  let historyCount = 0;
+
+  for (const r of wineRows) {
+    const wineName = plocGet(r, ['Wine name', 'Wine Name', 'Nom du vin', 'Vin']);
+    const producer = plocGet(r, ['Producer', 'Producteur', 'Domaine']);
+    if (!wineName && !producer) continue;
+    const id = plocId(r);
+    if (id) seenWineIds.add(id);
+
+    const colour = plocGet(r, ['Color', 'Colour', 'Couleur']).toLowerCase();
+    const rawRating = parseLocaleNumber(plocGet(r, ['Note', 'Notation']));
+    const estimate = parseLocaleNumber(plocGet(r, ['Estimate', 'Estimation', 'Valeur']));
+
+    const base = {
+      wineName,
+      producer: producer || undefined,
+      vintage: plocGet(r, ['Vintage', 'Millésime', 'Millesime']) || 'NV',
+      type: PLOC_COLOUR_TO_TYPE[colour] || undefined,
+      grapes: parsePlocGrapes(plocGet(r, ['Grapes', 'Cépages', 'Cepages', 'Cépage'])),
+      country: plocGet(r, ['Country', 'Pays']) || undefined,
+      region: plocGet(r, ['Region', 'Région']) || undefined,
+      appellation: plocGet(r, ['Appellation']) || undefined,
+      classification: plocGet(r, ['Classification', 'Classement']) || undefined,
+      bottleSize: PLOC_FORMAT_TO_SIZE[plocGet(r, ['Bottle format', 'Format', 'Contenant']).toLowerCase()] || undefined,
+      notes: plocGet(r, ['Comments', 'Commentaires', 'Commentaire']) || undefined,
+      ...parsePlocApogee(plocGet(r, ['Apogee', 'Apogée'])),
+      ...(ratingScale && rawRating > 0 ? { rating: rawRating, ratingScale } : {}),
+    };
+
+    const stock = Math.max(0, parseInt(plocGet(r, ['Stock']), 10) || 0);
+    const consumptions = (id && consumptionsByWine.get(id)) || [];
+    const purchases = ((id && purchasesByWine.get(id)) || [])
+      .slice()
+      .sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
+
+    // Oldest bottles are drunk first, so the earliest purchases belong to the
+    // consumed bottles and whatever remains belongs to what is still in the
+    // cellar. When the two sides disagree — a stock count that predates the
+    // movement log, say — the wines file wins on how many bottles exist and the
+    // history only ever supplies dates and prices.
+    const consumedPurchases = purchases.slice(0, consumptions.length);
+    let activePurchases = purchases.slice(consumptions.length);
+    if (activePurchases.length > stock) activePurchases = activePurchases.slice(-stock);
+
+    consumptions
+      .slice()
+      .sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')))
+      .forEach((c, i) => {
+        const p = consumedPurchases[i];
+        items.push({
+          ...base,
+          grapes: [...base.grapes],
+          quantity: 1,
+          addToHistory: true,
+          consumedReason: 'drank',
+          ...(c.date ? { consumedAt: c.date } : {}),
+          ...(c.note ? { consumedNote: c.note } : {}),
+          ...(c.occasion ? { occasion: c.occasion } : {}),
+          ...(p?.date ? { purchaseDate: p.date, dateAdded: p.date } : {}),
+          ...(p?.price ? { price: p.price } : {}),
+          ...(p?.currency ? { currency: p.currency } : {}),
+          ...(p?.vendor ? { purchaseLocation: p.vendor } : {}),
+        });
+        historyCount += 1;
+      });
+
+    const slots = (id && slotsByWine.get(id)) || [];
+    if (slots.length > stock) {
+      warnings.push({ code: 'ploc-extra-slots', wine: wineName, slots: slots.length, stock });
+    }
+    for (let i = 0; i < stock; i++) {
+      const slot = slots[i];
+      const p = activePurchases[i];
+      if (slot) placedCount += 1;
+      items.push({
+        ...base,
+        grapes: [...base.grapes],
+        quantity: 1,
+        ...(slot ? { rackName: slot.rackName, row: slot.row, col: slot.col } : {}),
+        ...(p?.date ? { purchaseDate: p.date, dateAdded: p.date } : {}),
+        // A recorded purchase price is what the bottle actually cost; the
+        // wines file's "Estimate" is today's value, and only fills the gap.
+        ...(p?.price ? { price: p.price } : estimate > 0 ? { price: estimate } : {}),
+        ...(p?.currency ? { currency: p.currency } : {}),
+        ...(p?.vendor ? { purchaseLocation: p.vendor } : {}),
+      });
+    }
+  }
+
+  for (const id of [...purchasesByWine.keys(), ...consumptionsByWine.keys()]) {
+    if (!seenWineIds.has(id)) unmatchedMoves += 1;
+  }
+  if (unmatchedMoves > 0) warnings.push({ code: 'ploc-unmatched-history', count: unmatchedMoves });
+  if (slotRows.length === 0) warnings.push({ code: 'ploc-no-cellars' });
+  if (moveRows.length === 0) warnings.push({ code: 'ploc-no-history' });
+  if (placedCount > 0) warnings.push({ code: 'ploc-placed', count: placedCount, racks: Object.keys(rackSpecs).length });
+  if (historyCount > 0) warnings.push({ code: 'ploc-history', count: historyCount });
+
+  return { items, format: 'ploc', headers, rackSpecs, warnings };
+}
+
+
 /**
  * Main entry: parse a file and return mapped items in master format.
  *
@@ -1829,6 +2248,11 @@ export function parseAndMap(text, forceFormat) {
  *     auto-inferred multi-bottle stacking; users opt in via the picker.
  */
 export function getDefaultRackConfig(format, info) {
+  if (info.rackSpec) {
+    // Geometry the source file stated outright (Ploc gives every unit's real
+    // row/column extent), rather than one inferred from the bottles.
+    return info.rackSpec;
+  }
   if (info.ctRackSpec) {
     // Geometry detected from the CellarTracker bin-code pattern.
     return info.ctRackSpec;

--- a/frontend/src/utils/importMappers.ploc.test.js
+++ b/frontend/src/utils/importMappers.ploc.test.js
@@ -1,0 +1,285 @@
+/**
+ * Ploc import — the three-file join.
+ *
+ * Ploc exports a SET of files that only mean anything together: the wines with
+ * their stock counts, the slots that say where each bottle physically sits, and
+ * the purchase/consumption log. They are joined on a GUID that Ploc writes in
+ * mixed case, and the file names are French whatever the app language is (and
+ * the first real samples arrived renamed), so everything here keys off columns.
+ *
+ * The fixtures are trimmed from a real export sent by a migrating user, keeping
+ * every shape that bit: percentage-prefixed grape lists, an "Apogee" window,
+ * Magnum formats, wines with no producer, a leading space in a wine name, and
+ * mixed-case GUIDs between the wines file and the slots file.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  detectPlocFile,
+  parsePlocFiles,
+  parsePlocGrapes,
+  parsePlocApogee,
+  buildPlocDateParser,
+  inferPlocRatingScale,
+  parseCSV,
+  detectDelimiter,
+  getDefaultRackConfig,
+} from './importMappers';
+
+const WINES = [
+  'Wine name;Vintage;Color;Stock;Stock (en cave);Producer;Country;Region;Appellation;Grapes;Bottle format;Classification;Cuvee;Degree of alcohol;Reference;Tags;Apogee;Service temperature;Estimate;Note;Comments;IdVin;IdContact;IdDocument;IdDocumentCouverture',
+  'Château Grand Puy Lacoste;2009;Red;12;12;Château Grand-Puy-Lacoste;France;Bordeaux;Pauillac;80% Cabernet Sauvignon,18% Merlot,2% Cabernet Franc;Bottle;5ème Cru Classé;;13.5;;;2025/2029;16;90;;;7406D964-D766-4FC6-9DC6-FD634BFC4703;;A5C05F57;',
+  'Benjamin Leroux Meursault 1er Cru  Charmes-Dessus;2019;White;1;1;Maison & Domaine Leroux;France;Burgundy;Meursault;Chardonnay;Magnum;1er Cru;;13.5;;;;12;170;;;b76416fd-f3e7-4870-a1aa-23297fa5c6f6;;c53cbb99;',
+  ' Billecart Salmon Brut Rosé;;Sparkling;10;10;Champagne Billecart-Salmon;France;Champagne;Champagne;Chardonnay, Pinot Meunier, Pinot Noir;Bottle;;;12;;;;8;70;;;fb9b64ed-753f-40a2-a0be-2eb4ad5eb78f;;739771f9;',
+  'Corton Charlemagne Grand Cru Henri Boillot;2023;White;4;4;;France;Burgundy;Charlemagne;;;;;;;;;;400;;;7F693272-EDD0-4293-9A57-E8307FFC534E;;95304694;',
+  'Château Suduiraut;1989;Sweet;2;2;Château Suduiraut;France;Bordeaux;Sauternes;Sauvignon Blanc, Sémillon;Bottle;1er Cru Classé;;;;;;8;50;;;215d3dd5-a91a-42a9-9a4f-0958b4a5a282;;4edbb00b;',
+].join('\n');
+
+const CELLARS = [
+  'Name;Row;Column;Wine name;Vintage;IdVin',
+  'Column H - Red Bordeaux £70-£100;2;1;Château Grand Puy Lacoste;2009;7406D964-D766-4FC6-9DC6-FD634BFC4703',
+  'Column H - Red Bordeaux £70-£100;4;6;Château Grand Puy Lacoste;2009;7406d964-d766-4fc6-9dc6-fd634bfc4703',
+  'Column I - Red Burgundy £75-£200;19;5;Benjamin Leroux Meursault;2019;b76416fd-f3e7-4870-a1aa-23297fa5c6f6',
+  'Column L - Sweet wines;5;5;Château Suduiraut;1989;215d3dd5-a91a-42a9-9a4f-0958b4a5a282',
+  'Column L - Sweet wines;1;1;;;',
+  'Column L - Sweet wines;6;7;;;',
+].join('\n');
+
+const HISTORY = [
+  'Date;Wine name;Vintage;Purchase;Consumption;Unit price;Selling price;Currency;Opportunity;Vendor;Comments;IdContact;IdVin',
+  '12/03/2024;Château Suduiraut;1989;3;0;45;0;£;;Berry Bros;;;215d3dd5-a91a-42a9-9a4f-0958b4a5a282',
+  '28/06/2025;Château Suduiraut;1989;0;1;0;0;£;Anniversary dinner;;Still fresh;;215d3dd5-a91a-42a9-9a4f-0958b4a5a282',
+  '02/12/2025;Château Grand Puy Lacoste;2009;12;0;72;0;£;;Farr Vintners;;;7406D964-D766-4FC6-9DC6-FD634BFC4703',
+].join('\n');
+
+const headersOf = (text) => Object.keys(parseCSV(text, detectDelimiter(text))[0]);
+const bottlesOf = (items, match) => items.filter((i) => match.test(i.wineName));
+
+describe('recognising Ploc files by their columns, never their name', () => {
+  it('tells the three files apart', () => {
+    expect(detectPlocFile(headersOf(WINES))).toBe('wines');
+    expect(detectPlocFile(headersOf(CELLARS))).toBe('cellars');
+    expect(detectPlocFile(headersOf(HISTORY))).toBe('history');
+  });
+
+  it('recognises the French headers of a French-locale export', () => {
+    expect(detectPlocFile(['Nom du vin', 'Millésime', 'Stock', 'IdVin'])).toBe('wines');
+    expect(detectPlocFile(['Nom', 'Ligne', 'Colonne', 'IdVin'])).toBe('cellars');
+    expect(detectPlocFile(['Date', 'Achat', 'Conso', 'IdVin'])).toBe('history');
+  });
+
+  it('is not fooled by another app that happens to have a Stock column', () => {
+    expect(detectPlocFile(['Wine', 'Vintage', 'Stock'])).toBeNull();
+    expect(detectPlocFile(['Wine name', 'Producer', 'Quantity'])).toBeNull();
+  });
+});
+
+describe('field mapping', () => {
+  const { items, warnings } = parsePlocFiles({ wines: WINES, cellars: CELLARS, history: HISTORY });
+
+  it('expands each wine into one item per bottle in stock', () => {
+    expect(bottlesOf(items, /Grand Puy/)).toHaveLength(12);
+    expect(bottlesOf(items, /Billecart/)).toHaveLength(10);
+    expect(bottlesOf(items, /Corton/)).toHaveLength(4);
+  });
+
+  it('strips blend percentages, which are proportions and not variety names', () => {
+    expect(parsePlocGrapes('80% Cabernet Sauvignon,18% Merlot,2% Cabernet Franc'))
+      .toEqual(['Cabernet Sauvignon', 'Merlot', 'Cabernet Franc']);
+    expect(bottlesOf(items, /Grand Puy/)[0].grapes).toEqual(['Cabernet Sauvignon', 'Merlot', 'Cabernet Franc']);
+  });
+
+  it('maps colour to wine type, with Sweet meaning dessert', () => {
+    expect(bottlesOf(items, /Grand Puy/)[0].type).toBe('red');
+    expect(bottlesOf(items, /Billecart/)[0].type).toBe('sparkling');
+    expect(bottlesOf(items, /Suduiraut/)[0].type).toBe('dessert');
+  });
+
+  it('reads the Apogee window onto the bottle', () => {
+    expect(parsePlocApogee('2025/2029')).toEqual({ drinkFrom: 2025, drinkTo: 2029 });
+    expect(parsePlocApogee('2030')).toEqual({ drinkFrom: 2030 });
+    expect(parsePlocApogee('')).toEqual({});
+    expect(bottlesOf(items, /Grand Puy/)[0]).toMatchObject({ drinkFrom: 2025, drinkTo: 2029 });
+  });
+
+  it('maps the bottle format, and trims the stray leading space in a wine name', () => {
+    expect(bottlesOf(items, /Leroux/)[0].bottleSize).toBe('1500ml');
+    expect(bottlesOf(items, /Grand Puy/)[0].bottleSize).toBe('750ml');
+    expect(items.some((i) => i.wineName === 'Billecart Salmon Brut Rosé')).toBe(true);
+  });
+
+  it('keeps a wine with no producer and no vintage rather than dropping it', () => {
+    const corton = bottlesOf(items, /Corton/)[0];
+    expect(corton.producer).toBeUndefined();
+    expect(corton.region).toBe('Burgundy');
+    const billecart = bottlesOf(items, /Billecart/)[0];
+    expect(billecart.vintage).toBe('NV');
+  });
+
+  it('does not import the producer address-book reference', () => {
+    for (const item of items) expect(item.IdContact).toBeUndefined();
+  });
+
+  it('says nothing about ratings when the file carries none', () => {
+    expect(inferPlocRatingScale(['', '', ''])).toBeNull();
+    expect(items.every((i) => i.rating === undefined)).toBe(true);
+    expect(warnings.find((w) => w.code === 'ploc-rating-scale')).toBeUndefined();
+  });
+});
+
+describe('rating scale, which the file never states', () => {
+  it('infers the scale from the values present', () => {
+    expect(inferPlocRatingScale(['4', '5', '3'])).toBe('5');
+    expect(inferPlocRatingScale(['16', '18.5'])).toBe('20');
+    expect(inferPlocRatingScale(['92', '88'])).toBe('100');
+  });
+
+  it('carries the assumption into the items and warns about it', () => {
+    const wines = WINES.replace(';16;90;;;7406D964', ';16;90;92;;7406D964');
+    const { items, warnings } = parsePlocFiles({ wines });
+    expect(warnings).toContainEqual({ code: 'ploc-rating-scale', scale: '100' });
+    expect(bottlesOf(items, /Grand Puy/)[0]).toMatchObject({ rating: 92, ratingScale: '100' });
+  });
+});
+
+describe('slots become exact rack placements', () => {
+  const { items, rackSpecs, warnings } = parsePlocFiles({ wines: WINES, cellars: CELLARS, history: HISTORY });
+
+  it('sizes each rack from the furthest slot actually used, empty ones included', () => {
+    // "Column L" holds one bottle, but its empty slots reach row 6, column 7.
+    expect(rackSpecs['Column L - Sweet wines']).toEqual({ type: 'grid', rows: 6, cols: 7, typeConfig: {} });
+    expect(rackSpecs['Column I - Red Burgundy £75-£200']).toEqual({ type: 'grid', rows: 19, cols: 5, typeConfig: {} });
+  });
+
+  it('places bottles at their own row and column, matching the GUID case-insensitively', () => {
+    const gpl = bottlesOf(items, /Grand Puy/).filter((i) => i.rackName);
+    expect(gpl).toHaveLength(2); // two slot rows, one of them lower-cased in the file
+    expect(gpl.map((i) => [i.row, i.col])).toEqual([[2, 1], [4, 6]]);
+    expect(gpl[0].rackName).toBe('Column H - Red Bordeaux £70-£100');
+  });
+
+  it('leaves stock beyond the recorded slots unplaced rather than inventing positions', () => {
+    const gpl = bottlesOf(items, /Grand Puy/);
+    expect(gpl.filter((i) => i.rackName)).toHaveLength(2);
+    expect(gpl.filter((i) => !i.rackName)).toHaveLength(10);
+    expect(warnings.find((w) => w.code === 'ploc-placed')).toMatchObject({ count: 4 });
+  });
+
+  it('offers the stated geometry to the review screen ahead of any guess', () => {
+    const spec = rackSpecs['Column I - Red Burgundy £75-£200'];
+    expect(getDefaultRackConfig('ploc', { rackSpec: spec, count: 1, maxPosition: 0 })).toBe(spec);
+  });
+
+  it('refuses to distort a rack larger than the schema allows', () => {
+    const big = ['Name;Row;Column;Wine name;Vintage;IdVin', 'Huge;41;3;x;2020;abc'].join('\n');
+    const { rackSpecs: specs, warnings: w } = parsePlocFiles({ wines: WINES, cellars: big });
+    expect(specs.Huge).toBeUndefined();
+    expect(w).toContainEqual({ code: 'ploc-rack-too-big', rack: 'Huge', rows: 41, cols: 3 });
+  });
+});
+
+describe('purchase and consumption history', () => {
+  const { items, warnings } = parsePlocFiles({ wines: WINES, cellars: CELLARS, history: HISTORY });
+  const suduiraut = bottlesOf(items, /Suduiraut/);
+
+  it('creates a consumed bottle for every bottle drunk, on top of what is still held', () => {
+    // Stock says 2 remain; the log says 3 were bought and 1 drunk.
+    expect(suduiraut).toHaveLength(3);
+    expect(suduiraut.filter((i) => i.addToHistory)).toHaveLength(1);
+    expect(suduiraut.filter((i) => !i.addToHistory)).toHaveLength(2);
+    expect(warnings.find((w) => w.code === 'ploc-history')).toMatchObject({ count: 1 });
+  });
+
+  it('carries the date, occasion and note onto the consumed bottle', () => {
+    const drunk = suduiraut.find((i) => i.addToHistory);
+    expect(drunk).toMatchObject({
+      consumedReason: 'drank',
+      consumedAt: '2025-06-28',
+      occasion: 'Anniversary dinner',
+      consumedNote: 'Still fresh',
+    });
+  });
+
+  it('gives every bottle its real purchase date, price and vendor', () => {
+    for (const b of suduiraut) {
+      expect(b.purchaseDate).toBe('2024-03-12');
+      expect(b.price).toBe(45);          // what it cost, not the 50 estimate
+      expect(b.currency).toBe('GBP');    // from the "£" symbol
+      expect(b.purchaseLocation).toBe('Berry Bros');
+    }
+  });
+
+  it('falls back to the estimated value when nothing was ever purchased', () => {
+    const corton = bottlesOf(items, /Corton/)[0];
+    expect(corton.price).toBe(400);
+    expect(corton.purchaseDate).toBeUndefined();
+  });
+
+  it('imports stock only when no history file is given', () => {
+    const { items: only, warnings: w } = parsePlocFiles({ wines: WINES, cellars: CELLARS });
+    expect(only.some((i) => i.addToHistory)).toBe(false);
+    expect(bottlesOf(only, /Suduiraut/)).toHaveLength(2);
+    expect(w).toContainEqual({ code: 'ploc-no-history' });
+  });
+
+  it('reports history rows whose wine is not in the wines file', () => {
+    const orphan = `${HISTORY}\n01/01/2025;Ghost;2020;1;0;10;0;£;;;;;deadbeef-0000-0000-0000-000000000000`;
+    const { warnings: w } = parsePlocFiles({ wines: WINES, history: orphan });
+    expect(w).toContainEqual({ code: 'ploc-unmatched-history', count: 1 });
+  });
+});
+
+describe('dates, whose format Ploc never states', () => {
+  it('learns the order from a row that can only be read one way', () => {
+    const dmy = buildPlocDateParser(['12/03/2024', '28/06/2025']); // 28 can only be a day
+    expect(dmy.dayFirst).toBe(true);
+    expect(dmy.inferred).toBe(true);
+    expect(dmy.parse('12/03/2024')).toBe('2024-03-12');
+
+    const mdy = buildPlocDateParser(['8/31/26', '1/2/26']); // 31 can only be a day
+    expect(mdy.dayFirst).toBe(false);
+    expect(mdy.parse('1/2/26')).toBe('2026-01-02');
+    expect(mdy.parse('8/31/26')).toBe('2026-08-31');
+  });
+
+  it('assumes day-first when nothing in the file settles it, and says so', () => {
+    const p = buildPlocDateParser(['01/02/2026', '03/04/2026']);
+    expect(p.inferred).toBe(false);
+    expect(p.parse('01/02/2026')).toBe('2026-02-01');
+    const { warnings } = parsePlocFiles({
+      wines: WINES,
+      history: 'Date;Purchase;Consumption;IdVin\n01/02/2026;1;0;215d3dd5-a91a-42a9-9a4f-0958b4a5a282',
+    });
+    expect(warnings).toContainEqual({ code: 'ploc-date-order-assumed', dayFirst: true });
+  });
+
+  it('reads ISO and Unix seconds without guessing at all', () => {
+    const p = buildPlocDateParser([]);
+    expect(p.parse('2026-08-31')).toBe('2026-08-31');
+    expect(p.parse('1788134400')).toMatch(/^2026-/);
+    expect(p.parse('')).toBeUndefined();
+    expect(p.parse('not a date')).toBeUndefined();
+    expect(p.parse('2026')).toBeUndefined();      // a bare year is not an epoch
+    expect(p.parse('45/45/2026')).toBeUndefined(); // impossible, not silently coerced
+  });
+});
+
+describe('what the import refuses to do', () => {
+  it('needs the wines file, because stock counts live only there', () => {
+    expect(() => parsePlocFiles({ cellars: CELLARS })).toThrow(/wines file is required/);
+    expect(() => parsePlocFiles({})).toThrow();
+  });
+
+  it('imports the wines file alone, with everything unplaced', () => {
+    const { items, warnings } = parsePlocFiles({ wines: WINES });
+    expect(items).toHaveLength(29); // 12 + 1 + 10 + 4 + 2
+    expect(items.every((i) => !i.rackName)).toBe(true);
+    expect(warnings).toContainEqual({ code: 'ploc-no-cellars' });
+  });
+
+  it('gives each bottle its own grape array, so editing one cannot change another', () => {
+    const { items } = parsePlocFiles({ wines: WINES });
+    const gpl = bottlesOf(items, /Grand Puy/);
+    gpl[0].grapes.push('Petit Verdot');
+    expect(gpl[1].grapes).toEqual(['Cabernet Sauvignon', 'Merlot', 'Cabernet Franc']);
+  });
+});


### PR DESCRIPTION
From a migrating user who sent us his real export.

Ploc does not export one file. It exports a set that only means anything together, joined on the wine's identifier: the wines with their stock counts, the slots that say where each bottle physically sits, and the purchase and consumption log. Any one alone is an incomplete picture of a cellar, so the import takes them together and the upload page now accepts several files at once. A single file behaves exactly as it always has.

**What comes across**
- **Exact positions.** Every storage unit becomes a rack sized from the furthest slot actually used, empty slots included, and every bottle lands at its own row and column. No bin-code guessing — Ploc states the position outright.
- **Real stock.** Expanded into individual bottles; surplus beyond the recorded slots stays unplaced rather than getting invented positions.
- **History.** Each consumption becomes an already-drunk bottle with its date, occasion and note. Purchases give every bottle its true purchase date, price, currency and vendor, oldest-drunk-first.
- **Identity.** Blend percentages stripped from grape lists, colour mapped to type (Sweet means dessert), Apogee mapped to the bottle's own drink window rather than the registry's curated maturity.

**Two things Ploc never states**, so both are inferred from the file and surfaced as warnings: the date order (a row where a component exceeds 12 settles it for every ambiguous row) and the rating scale.

**Deliberately not imported:** the producer address book, which is other people's contact details and whose only useful field is already on every wine row, and the alcohol degree, for which the import pipeline has no field.

Files are recognised by their columns, never their names — Ploc names them in French whatever the app language is, and the first samples arrived renamed by the sender.

Verified against the real export: 63 bottles from 15 wines, 12 racks with exact geometry, 15 placed. 30 new unit tests; full frontend suite and production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)