### PR TITLE
fix(security): the backup no longer carries its own keys, restores trust nothing, and the seeder refuses real databases

### DIFF
--- a/backend/src/seed-demo.js
+++ b/backend/src/seed-demo.js
@@ -38,6 +38,30 @@ async function seed() {
   await mongoose.connect(MONGO_URI);
   console.log('Connected to MongoDB');
 
+  // ─── Refuse to run against a real database ──────────────────────────────────
+  // This script mints admin@cellarion.app with a password printed in the public
+  // README, on whatever MONGO_URI points at — and the documented invocation is
+  // `docker exec cellarion-backend node src/seed-demo.js`, which on the hosted
+  // service is the PRODUCTION container (security audit 2026-09-02, O06-1).
+  // NODE_ENV cannot tell the two apart (the image sets production everywhere),
+  // so the test is the data: a database holding any account that this script
+  // did not create is somebody's real instance, and seeding it would hand out
+  // an admin login. Override only with SEED_DEMO_FORCE=1, deliberately.
+  const SEED_ACCOUNTS = ['admin@cellarion.app', 'user@cellarion.app'];
+  const foreignUsers = await User.countDocuments({
+    email: { $nin: SEED_ACCOUNTS },
+    username: { $ne: '__deleted__' },
+  });
+  if (foreignUsers > 0 && process.env.SEED_DEMO_FORCE !== '1') {
+    console.error(
+      `\nRefusing to seed: this database already holds ${foreignUsers} account(s) that are not the demo ones.\n` +
+      'seed-demo.js is for a FRESH local stack. It would create an admin account with a publicly\n' +
+      'documented password here. If you really mean it, run again with SEED_DEMO_FORCE=1.'
+    );
+    await mongoose.disconnect();
+    process.exit(2);
+  }
+
   // ─── Users ───────────────────────────────────────────────────────────────────
   let admin = await User.findOne({ email: 'admin@cellarion.app' });
   if (!admin) {

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -177,9 +177,11 @@ unreachable; with them, this is the order:
 1. **New machine.** Install Docker (compose plugin), restic and jq. Create the
    same unprivileged user and add it to the `docker` group.
 2. **Reach the repository.** Put the Storage Box SSH key back at
-   `~/.ssh/storagebox` with the `~/.ssh/config` alias (both are in the
-   snapshot, but you need them *first* — so from the password manager), or
-   export the `B2_*` variables for the off-provider copy.
+   `~/.ssh/storagebox` with the `~/.ssh/config` alias, or export the `B2_*`
+   variables for the off-provider copy. These come from the password manager:
+   they are deliberately NOT in the snapshot, because a snapshot that carries
+   the keys to its own repositories turns a leaked passphrase into the ability
+   to erase every backup.
 3. **Pull the snapshot into a scratch directory** — no containers exist yet,
    so do not use `restore.sh` for this step:
    ```bash
@@ -192,8 +194,10 @@ unreachable; with them, this is the order:
    ```bash
    sudo cp -rp /tmp/cellarion-restore/*/config/. /
    ```
-   That restores `.env`, both compose files, `scripts/backup/backup.env`, the
-   reverse-proxy and monitoring configs, the systemd units and the SSH alias.
+   That restores `.env`, both compose files, the reverse-proxy and monitoring
+   configs and the systemd units. Then recreate `scripts/backup/backup.env`
+   from the password manager (passphrase, repository address, off-provider
+   keys) — it is never in the snapshot.
    Then `git clone` the repository into the checkout path the compose files
    expect (the checkout is not in the snapshot — only the files you changed).
 5. **Start the stack** — `docker compose -f docker-compose.prod.yml up -d`

--- a/scripts/backup/backup.env.example
+++ b/scripts/backup/backup.env.example
@@ -42,8 +42,10 @@ B2_ACCOUNT_ID=""
 B2_ACCOUNT_KEY=""
 
 # ── Configuration files in the snapshot (since 2026-09-02) ───────────────────
-# The snapshot always carries this checkout's .env, docker-compose*.yml and this
-# backup.env, stored under config/<absolute path>. Add everything else a fresh
+# The snapshot always carries this checkout's .env and docker-compose*.yml,
+# stored under config/<absolute path>. It deliberately NEVER carries backup.env,
+# SSH keys, TLS private keys or anything else that unlocks the snapshot itself —
+# those belong in a password manager off the host, and the script refuses them. Add everything else a fresh
 # machine would need — reverse proxy, monitoring, systemd units, the SSH key
 # that reaches the repository. Space-separated absolute paths; a directory is
 # copied whole; missing entries are skipped with a log line.

--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -43,11 +43,19 @@ HEALTHCHECK_URL="${HEALTHCHECK_URL:-}"
 
 # Configuration files that make a snapshot self-sufficient. Defaults cover the
 # checkout this script lives in; EXTRA_CONFIG_PATHS (backup.env) adds anything
-# outside it — a reverse proxy, monitoring, systemd units, the SSH key that
-# reaches the repository. Space-separated absolute paths; a directory is copied
-# whole. Missing entries are logged and skipped, never fatal.
+# outside it — a reverse proxy, monitoring, systemd units. Space-separated
+# absolute paths; a directory is copied whole. Missing entries are logged and
+# skipped, never fatal.
+#
+# NEVER stage the things that unlock the snapshot itself (audit 2026-09-02
+# X01-1): backup.env (the passphrase and the keys that can DELETE both
+# repositories), the SSH key that reaches the Storage Box, the TLS origin key.
+# A snapshot that carries its own destruction keys turns a leaked passphrase
+# from "read the data" into "erase every backup". Those few bootstrap secrets
+# belong in a password manager off the host — you need them BEFORE you can
+# open a snapshot anyway, so keeping them inside one never helped recovery.
 PROJECT_DIR="${PROJECT_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
-CONFIG_PATHS="${CONFIG_PATHS:-$PROJECT_DIR/.env $PROJECT_DIR/docker-compose.yml $PROJECT_DIR/docker-compose.prod.yml $ENV_FILE}"
+CONFIG_PATHS="${CONFIG_PATHS:-$PROJECT_DIR/.env $PROJECT_DIR/docker-compose.yml $PROJECT_DIR/docker-compose.prod.yml}"
 EXTRA_CONFIG_PATHS="${EXTRA_CONFIG_PATHS:-}"
 # Optional: the Postgres container behind self-hosted Umami. Blank = skip.
 UMAMI_DB_CONTAINER="${UMAMI_DB_CONTAINER:-}"
@@ -123,6 +131,12 @@ log "staging configuration files…"
 mkdir -p "$STAGE/config"
 staged=0
 for p in $CONFIG_PATHS $EXTRA_CONFIG_PATHS; do
+  # Refuse the bootstrap secrets even if someone lists them (see above).
+  case "$p" in
+    "$ENV_FILE"|*/backup.env|*/.ssh/*|*/acme.json|*/id_*|*.pem|*.key)
+      log "config: refusing $p — bootstrap secret, keep it in a password manager, not in the snapshot"
+      continue ;;
+  esac
   if [ -d "$p" ]; then
     mkdir -p "$STAGE/config$(dirname "$p")"
     cp -rp "$p" "$STAGE/config$(dirname "$p")/"

--- a/scripts/backup/restore.sh
+++ b/scripts/backup/restore.sh
@@ -8,13 +8,23 @@
 #
 #   RESTORE_CONFIG=1  also copy the snapshot's configuration files back to
 #                     their original absolute paths (existing files are kept
-#                     as <file>.pre-restore). Use this when rebuilding a machine.
+#                     as <file>.pre-restore). Every target is listed and a
+#                     second confirmation is required. Use it when rebuilding
+#                     a machine.
 #   RESTORE_UMAMI=1   also reload the Umami analytics database (needs
 #                     UMAMI_DB_CONTAINER in backup.env and a running container).
 #
 # For a FULL move to a new machine see docs/backup.md → "Moving everything to
 # a new VM": you need the config files BEFORE the containers exist, so that
 # runbook restores in a different order than this script.
+#
+# A snapshot is DATA, not code, and it is treated with the same suspicion as
+# an upload (audit 2026-09-02 X01-4): the backup stages /app/uploads wholesale,
+# a directory the backend process writes to, so nothing found under it may be
+# mistaken for the database dump or the configuration tree. Every artefact is
+# addressed at its known place under the single staging directory, never
+# searched for; and a configuration file is written back only to a path that
+# a rebuild legitimately needs, never to anything that grants access.
 #
 # Run a DRILL of this periodically — an untested backup is not a backup.
 #
@@ -41,55 +51,101 @@ SNAPSHOT="${1:-latest}"
 
 echo "About to RESTORE snapshot '$SNAPSHOT' from $RESTIC_REPOSITORY."
 echo "This DROPS and reloads the '$MONGO_DB' database and overwrites uploaded images."
-[ "${RESTORE_CONFIG:-0}" = 1 ] && echo "RESTORE_CONFIG=1: configuration files will be written back to their original paths."
+[ "${RESTORE_CONFIG:-0}" = 1 ] && echo "RESTORE_CONFIG=1: configuration files will be listed, then written back after a second confirmation."
 [ "${RESTORE_UMAMI:-0}" = 1 ] && echo "RESTORE_UMAMI=1: the Umami database will be reloaded."
 read -rp "Type 'restore' to proceed: " confirm
 [ "$confirm" = "restore" ] || { echo "Aborted."; exit 1; }
 
 DEST="$(mktemp -d)"
+chmod 700 "$DEST"
 trap 'rm -rf "$DEST"' EXIT
 
 echo "[restore] fetching snapshot $SNAPSHOT…"
 restic restore "$SNAPSHOT" --target "$DEST"
 
-ARCHIVE="$(find "$DEST" -name "$MONGO_DB.archive.gz" | head -1)"
-UPLOADS_DIR="$(find "$DEST" -type d -name uploads | head -1)"
-CONFIG_DIR="$(find "$DEST" -type d -name config | head -1)"
-UMAMI_DUMP="$(find "$DEST" -name umami.sql.gz | head -1)"
-MANIFEST="$(find "$DEST" -name MANIFEST.txt | head -1)"
-[ -n "$ARCHIVE" ] || { echo "[restore] mongo archive not found in snapshot" >&2; exit 1; }
+# backup.sh stages everything under ONE mktemp directory and backs that up, so
+# the snapshot restores as exactly one top-level directory. Anything else is
+# not a Cellarion snapshot and is refused rather than guessed at.
+mapfile -t TOPS < <(find "$DEST" -mindepth 1 -maxdepth 1 -type d)
+if [ "${#TOPS[@]}" -ne 1 ]; then
+  echo "[restore] expected exactly one staging directory in the snapshot, found ${#TOPS[@]} — refusing" >&2
+  exit 1
+fi
+STAGE="${TOPS[0]}"
 
-if [ -n "$MANIFEST" ]; then
+ARCHIVE="$STAGE/mongo/$MONGO_DB.archive.gz"
+UPLOADS_DIR="$STAGE/uploads"
+CONFIG_DIR="$STAGE/config"
+UMAMI_DUMP="$STAGE/umami/umami.sql.gz"
+MANIFEST="$STAGE/MANIFEST.txt"
+[ -f "$ARCHIVE" ] || { echo "[restore] mongo archive not found at its expected place in the snapshot" >&2; exit 1; }
+
+if [ -f "$MANIFEST" ]; then
   echo "[restore] snapshot manifest:"
-  sed 's/^/    /' "$MANIFEST" | head -20
+  # cat -v: the manifest is data from the snapshot and is shown on a terminal.
+  head -20 "$MANIFEST" | cat -v | sed 's/^/    /'
 fi
 
 echo "[restore] restoring MongoDB (drop + reload)…"
 docker exec -i "$MONGO_CONTAINER" mongorestore --archive --gzip --drop < "$ARCHIVE"
 
-if [ -n "$UPLOADS_DIR" ] && [ -n "$(ls -A "$UPLOADS_DIR" 2>/dev/null)" ]; then
+if [ -d "$UPLOADS_DIR" ] && [ -n "$(ls -A "$UPLOADS_DIR" 2>/dev/null)" ]; then
   echo "[restore] restoring uploaded images…"
   docker cp "$UPLOADS_DIR/." "$BACKEND_CONTAINER:/app/uploads/"
 fi
 
-if [ -n "$CONFIG_DIR" ]; then
-  n="$(find "$CONFIG_DIR" -type f | wc -l)"
+# A configuration file may only go back to a place a rebuild needs. Anything
+# that would grant access on its own — SSH keys, cron, sudo, shell start-up
+# files, anything under /etc beyond the backup units — is refused outright,
+# whatever the snapshot says.
+config_target_allowed() {
+  local t="$1"
+  case "$t" in
+    */.ssh/*|*/authorized_keys|/etc/cron*|/etc/sudoers*|/etc/passwd|/etc/shadow|/etc/group|*/.bashrc|*/.bash_profile|*/.profile|*/.zshrc|*/.bash_login|*/.bash_logout|/etc/profile*|/etc/environment|/root/*|/usr/*|/bin/*|/sbin/*|/lib*|/var/lib/*|/boot/*)
+      return 1 ;;
+  esac
+  case "$t" in
+    "$HOME"/*|/etc/systemd/system/cellarion-*|/opt/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ -d "$CONFIG_DIR" ]; then
+  mapfile -t CONFIG_FILES < <(find "$CONFIG_DIR" -type f | LC_ALL=C sort)
+  n="${#CONFIG_FILES[@]}"
   if [ "${RESTORE_CONFIG:-0}" = 1 ]; then
-    echo "[restore] writing $n configuration file(s) back to their original paths…"
-    # config/<abs path> → <abs path>; anything already there is kept alongside.
-    find "$CONFIG_DIR" -type f | while read -r f; do
+    echo "[restore] the snapshot carries $n configuration file(s). Targets:"
+    allowed=(); refused=()
+    for f in "${CONFIG_FILES[@]}"; do
       target="${f#"$CONFIG_DIR"}"
-      mkdir -p "$(dirname "$target")"
-      [ -e "$target" ] && cp -p "$target" "$target.pre-restore"
-      cp -p "$f" "$target"
+      # No traversal or control characters in a target, ever.
+      case "$target" in *..*|*$'\n'*|*$'\r'*) refused+=("$target"); continue ;; esac
+      if config_target_allowed "$target"; then allowed+=("$target"); else refused+=("$target"); fi
     done
+    for t in "${allowed[@]}"; do printf '    write   %s\n' "$t" | cat -v; done
+    for t in "${refused[@]}"; do printf '    REFUSE  %s\n' "$t" | cat -v; done
+    if [ "${#allowed[@]}" -eq 0 ]; then
+      echo "[restore] nothing allowed to write — skipping configuration."
+    else
+      read -rp "Type 'write config' to write the ${#allowed[@]} allowed file(s) above: " confirm2
+      if [ "$confirm2" = "write config" ]; then
+        for t in "${allowed[@]}"; do
+          mkdir -p "$(dirname "$t")"
+          [ -e "$t" ] && cp -p "$t" "$t.pre-restore"
+          cp -p "$CONFIG_DIR$t" "$t"
+        done
+        echo "[restore] wrote ${#allowed[@]} configuration file(s); existing files kept as .pre-restore."
+      else
+        echo "[restore] configuration NOT written."
+      fi
+    fi
   else
     echo "[restore] snapshot carries $n configuration file(s) (not written; set RESTORE_CONFIG=1 to restore them):"
-    find "$CONFIG_DIR" -type f | sed "s|^$CONFIG_DIR|    |" | head -40
+    for f in "${CONFIG_FILES[@]}"; do printf '    %s\n' "${f#"$CONFIG_DIR"}" | cat -v; done | head -40
   fi
 fi
 
-if [ -n "$UMAMI_DUMP" ] && [ "${RESTORE_UMAMI:-0}" = 1 ]; then
+if [ -f "$UMAMI_DUMP" ] && [ "${RESTORE_UMAMI:-0}" = 1 ]; then
   [ -n "$UMAMI_DB_CONTAINER" ] || { echo "[restore] RESTORE_UMAMI=1 but UMAMI_DB_CONTAINER is not set" >&2; exit 1; }
   echo "[restore] reloading Umami database into $UMAMI_DB_CONTAINER…"
   gunzip -c "$UMAMI_DUMP" | docker exec -i "$UMAMI_DB_CONTAINER" sh -c 'psql -q -U "$POSTGRES_USER" "$POSTGRES_DB"'


### PR DESCRIPTION
Three follow-ups from phase 4 of the whole-system security audit. No exploit detail here on purpose.

**Backup script.** The snapshot no longer stages `backup.env`, SSH keys, `acme.json` or any `*.key`, and refuses them even when listed. Those bootstrap secrets are needed before a snapshot can be opened anyway, so carrying them inside one never helped recovery, while it made a leaked passphrase far more dangerous. Existing snapshots in both repositories were rewritten to drop them.

**Restore script.** Every artefact is addressed at its known place under the single staging directory instead of being searched for across the tree, since the uploads directory is written by the application and nothing under it may be mistaken for the database. Restoring configuration now lists every target, allows only a small set of destinations, refuses anything that grants access on its own, and requires a second confirmation.

**Demo seeder.** Refuses to run against a database holding any account it did not create, unless forced explicitly. It creates an admin login with a documented password, and the documented way to run it on the hosted service is the production container. The guard is data-based because the image sets `NODE_ENV=production` locally too.

Verified on the hosted instance: the seeder's admin account there has no password and no admin role, so nothing was live; the trimmed backup configuration and rewritten snapshots were confirmed on both repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)