### PR TITLE
fix(images): keep only the background-removed photo, and keep label scans out of bottle displays

### DIFF
--- a/backend/src/models/BottleImage.js
+++ b/backend/src/models/BottleImage.js
@@ -19,6 +19,16 @@ const bottleImageSchema = new mongoose.Schema({
     required: true,
     index: true
   },
+  // The sanitised (EXIF-stripped) upload as received. TRANSIENT for an
+  // ordinary bottle photo: it exists only until background removal succeeds,
+  // then services/imageProcessor.discardOriginal deletes the file and nulls
+  // this — the processed image is the only copy Cellarion keeps (support
+  // ticket 2026-09-03: a raw frame shows the kitchen, a hand, a face, and
+  // nothing needs it once rembg has run). It STAYS where it is the only or the
+  // intended file: a keepBackground row (processedUrl === originalUrl), a row
+  // whose rembg run failed (the retry needs its source), an imported photo
+  // that was never cropped, and kind:'label-scan' curation evidence, which has
+  // its own bounded retention (services/scanImageRetentionJob).
   originalUrl: {
     type: String,
     default: null
@@ -57,8 +67,8 @@ const bottleImageSchema = new mongoose.Schema({
   // retailer product shot, it keeps whatever "figure" it finds on the label
   // and cuts the rest away (support ticket 6a97f870, 2026-09-02 — a user's
   // label photos came back "systematically cropped"). When true the original
-  // IS the kept image (processedUrl = originalUrl) and processImage /
-  // reprocessAllImages / retry leave it alone.
+  // IS the kept image (processedUrl = originalUrl): processImage / retry never
+  // send it to rembg, and discardOriginal never deletes it.
   keepBackground: {
     type: Boolean,
     default: false

--- a/backend/src/routes/admin/images.approve.test.js
+++ b/backend/src/routes/admin/images.approve.test.js
@@ -1,0 +1,132 @@
+/**
+ * PUT /api/admin/images/:id/approve — what happens to the ORIGINAL file.
+ *
+ * Approval used to be the only place a retained original was deleted, with
+ * an inline unlink that fired whenever both URLs were set. Since the
+ * "keep the background" option (ticket 6a97f870) a row can have
+ * processedUrl === originalUrl — the original IS the kept file — and that
+ * inline unlink deleted it on approval, leaving processedUrl pointing at
+ * nothing. Approval now goes through services/imageProcessor.discardOriginal
+ * (real here, with fs mocked): a keepBackground row is left alone; a legacy
+ * row that still carries a distinct original has it dropped.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../models/BottleImage', () => ({
+  findById: jest.fn(),
+  updateMany: jest.fn(),
+  countDocuments: jest.fn(),
+  updateOne: jest.fn(),
+}));
+jest.mock('../../models/WineDefinition', () => ({ findById: jest.fn(), findByIdAndUpdate: jest.fn() }));
+jest.mock('../../models/Bottle', () => ({}));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn() }));
+jest.mock('../../services/imageProcessor', () => {
+  const actual = jest.requireActual('../../services/imageProcessor');
+  return { ...actual, unlinkImageFiles: jest.fn() };
+});
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  existsSync: jest.fn(() => true),
+  promises: { unlink: jest.fn().mockResolvedValue(undefined), readdir: jest.fn(), stat: jest.fn() },
+}));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/notifications', () => ({ createNotification: jest.fn() }));
+jest.mock('../../utils/cellarCred', () => ({ incrementCred: jest.fn().mockResolvedValue(undefined) }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const fs = require('fs');
+const BottleImage = require('../../models/BottleImage');
+const imagesRouter = require('./images');
+
+const IMAGE_ID = '64b0000000000000000000e1';
+const ORIG = '/api/uploads/originals/abc.jpg';
+const PROC = '/api/uploads/processed/abc.png';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/images', imagesRouter);
+  return app;
+}
+
+function put(app, url) {
+  const token = jwt.sign({ id: '64b000000000000000000001', roles: ['admin'] }, 'test-secret', { expiresIn: '1h' });
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const req = http.request({ port: server.address().port, path: url, method: 'PUT', headers: { authorization: `Bearer ${token}` } }, (res) => {
+        const chunks = [];
+        res.on('data', c => chunks.push(c));
+        res.on('end', () => {
+          server.close();
+          const text = Buffer.concat(chunks).toString();
+          resolve({ status: res.statusCode, body: text ? JSON.parse(text) : null });
+        });
+      });
+      req.on('error', () => { server.close(); resolve({ status: 0 }); });
+      req.end();
+    });
+  });
+}
+
+const makeImage = (overrides = {}) => ({
+  _id: IMAGE_ID,
+  kind: 'bottle',
+  status: 'processed',
+  visibility: 'private',
+  wineDefinition: null,
+  assignedToWine: false,
+  keepBackground: false,
+  credit: null,
+  uploadedBy: '64b000000000000000000002',
+  save: jest.fn().mockResolvedValue(undefined),
+  populate: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  BottleImage.updateMany.mockResolvedValue({});
+  BottleImage.countDocuments.mockResolvedValue(0);
+  BottleImage.updateOne.mockResolvedValue({ acknowledged: true });
+});
+
+describe('PUT /api/admin/images/:id/approve and the original file', () => {
+  test('a keepBackground row (original IS the kept file) is approved without deleting anything', async () => {
+    const image = makeImage({ keepBackground: true, originalUrl: ORIG, processedUrl: ORIG });
+    BottleImage.findById.mockResolvedValue(image);
+
+    const { status } = await put(buildApp(), `/api/admin/images/${IMAGE_ID}/approve`);
+
+    expect(status).toBe(200);
+    expect(image.status).toBe('approved');
+    expect(fs.promises.unlink).not.toHaveBeenCalled();
+    expect(image.originalUrl).toBe(ORIG);
+    expect(image.processedUrl).toBe(ORIG);
+  });
+
+  test('a legacy row still carrying a distinct original has it dropped on approval', async () => {
+    const image = makeImage({ originalUrl: ORIG, processedUrl: PROC });
+    BottleImage.findById.mockResolvedValue(image);
+
+    const { status } = await put(buildApp(), `/api/admin/images/${IMAGE_ID}/approve`);
+
+    expect(status).toBe(200);
+    expect(fs.promises.unlink).toHaveBeenCalledWith('/app/uploads/originals/abc.jpg');
+    expect(BottleImage.updateOne).toHaveBeenCalledWith({ _id: IMAGE_ID, originalUrl: ORIG }, { $set: { originalUrl: null } });
+    expect(image.originalUrl).toBeNull();
+    expect(image.processedUrl).toBe(PROC);
+  });
+
+  test('a label scan is never approvable (it is private curation evidence)', async () => {
+    BottleImage.findById.mockResolvedValue(makeImage({ kind: 'label-scan', status: 'uploaded', originalUrl: ORIG, processedUrl: null }));
+    const { status } = await put(buildApp(), `/api/admin/images/${IMAGE_ID}/approve`);
+    expect(status).toBe(400);
+    expect(fs.promises.unlink).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/admin/images.assign.test.js
+++ b/backend/src/routes/admin/images.assign.test.js
@@ -25,9 +25,8 @@ jest.mock('../../models/WineDefinition', () => ({ findByIdAndUpdate: jest.fn() }
 jest.mock('../../models/Bottle', () => ({}));
 jest.mock('../../services/search', () => ({ indexWine: jest.fn() }));
 jest.mock('../../services/imageProcessor', () => ({
-  reprocessAllImages: jest.fn(),
-  safeUploadPath: jest.fn(),
   unlinkImageFiles: jest.fn(),
+  discardOriginal: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../../services/notifications', () => ({ createNotification: jest.fn() }));

--- a/backend/src/routes/admin/images.js
+++ b/backend/src/routes/admin/images.js
@@ -4,8 +4,7 @@ const BottleImage = require('../../models/BottleImage');
 const WineDefinition = require('../../models/WineDefinition');
 const Bottle = require('../../models/Bottle');
 const searchService = require('../../services/search');
-const fs = require('fs');
-const { reprocessAllImages, safeUploadPath, unlinkImageFiles } = require('../../services/imageProcessor');
+const { unlinkImageFiles, discardOriginal } = require('../../services/imageProcessor');
 const { logAudit } = require('../../services/audit');
 const { createNotification } = require('../../services/notifications');
 const { incrementCred } = require('../../utils/cellarCred');
@@ -163,17 +162,12 @@ router.get('/by-wine', async (req, res) => {
   }
 });
 
-// Helper: delete the original file if a processed version exists
-function deleteOriginalFile(image) {
-  if (image.processedUrl && image.originalUrl) {
-    try {
-      fs.unlinkSync(safeUploadPath(image.originalUrl.replace('/api/uploads/', '')));
-    } catch (err) {
-      if (err.code !== 'ENOENT') console.error('Failed to delete original image:', err.message);
-    }
-    image.originalUrl = null;
-  }
-}
+// Dropping a retained original on approval goes through the shared
+// services/imageProcessor.discardOriginal. The processor now discards it right
+// after rembg succeeds, so this only still matters for rows processed before
+// that. The inline unlink that used to live here deleted the file whenever
+// both URLs were set — including a keepBackground row, whose "original" IS the
+// kept file — and left processedUrl pointing at nothing.
 
 // PUT /api/admin/images/:id/approve
 // Body: { visibility: 'private' | 'public' } — defaults to 'public'
@@ -209,7 +203,7 @@ router.put('/:id/approve', async (req, res) => {
     // the needs-a-look flag, but keep the reports themselves so a photo raised
     // repeatedly still shows its history (ticket 6a865f60).
     image.reportedAt = null;
-    deleteOriginalFile(image);
+    await discardOriginal(image);
     await image.save();
 
     // Award Cellar Cred to the uploader
@@ -598,9 +592,9 @@ router.put('/:id/set-official', async (req, res) => {
       image.reviewedBy = req.user.id;
       image.reviewedAt = new Date();
     }
-    // Drop the now-redundant original once a processed version exists, same as
-    // the approve path — imageUrl was resolved above before this nulls it.
-    deleteOriginalFile(image);
+    // Drop a retained original once a processed version exists, same as the
+    // approve path — imageUrl was resolved above before this nulls it.
+    await discardOriginal(image);
     await image.save();
 
     await WineDefinition.findByIdAndUpdate(wineDefId, { image: imageUrl, imageCredit: image.credit || null });
@@ -670,14 +664,6 @@ router.put('/:id/visibility', async (req, res) => {
     console.error('Change visibility error:', error);
     res.status(500).json({ error: 'Failed to change image visibility' });
   }
-});
-
-// POST /api/admin/images/reprocess-all - Re-process all images through updated pipeline
-router.post('/reprocess-all', async (req, res) => {
-  res.json({ message: 'Re-processing started' });
-  reprocessAllImages().catch(err =>
-    console.error('Reprocess-all error:', err)
-  );
 });
 
 module.exports = router;

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -528,7 +528,11 @@ router.get('/:id', requireBottleAccess('viewer'), async (req, res) => {
     const pendingImg = await BottleImage.findOne({
       $or: pendingImgOr,
       uploadedBy: req.user.id,
-      status: { $in: ['uploaded', 'processing', 'processed'] }
+      status: { $in: ['uploaded', 'processing', 'processed'] },
+      // Never a label scan — same fix as the cellar list (routes/cellars.js
+      // attachBottleImageUrls, support ticket 2026-09-03): the scanner's raw
+      // frame is private curation evidence, not a bottle photo.
+      kind: { $ne: 'label-scan' },
     }).sort({ createdAt: -1 }).lean();
 
     const pendingImageUrl = pendingImg

--- a/backend/src/routes/bottles.pendingImage.test.js
+++ b/backend/src/routes/bottles.pendingImage.test.js
@@ -1,0 +1,136 @@
+/**
+ * GET /api/bottles/:id — the "pending photo" lookup, pinned.
+ *
+ * Support ticket 2026-09-03: a user's bottle page (and cellar list) showed the
+ * RAW frame they had handed to the label scanner — background, table and all —
+ * served from /api/uploads/originals/. That frame is kept as a private
+ * kind:'label-scan' row so a curator can read a misread label; it carries the
+ * wine it minted and sits at status 'uploaded' with no processed file, so the
+ * by-wine arm of this lookup matched it and `processedUrl || originalUrl`
+ * resolved to the raw upload. The lookup must exclude label scans.
+ */
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+jest.mock('../services/search', () => ({
+  indexBottle: jest.fn(), removeBottle: jest.fn(), indexWine: jest.fn(),
+  bulkIndexBottles: jest.fn(), getIsAvailable: jest.fn(() => false),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined), reembedActiveVintages: jest.fn() }));
+jest.mock('../services/enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/restockChecker', () => ({ checkRestockAlerts: jest.fn(), checkOnConsume: jest.fn() }));
+jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../services/priceWarnings', () => ({ gatherPriceWarnings: jest.fn().mockResolvedValue([]) }));
+jest.mock('../services/communityPrice', () => ({ getCurrentRelease: jest.fn().mockResolvedValue(null) }));
+jest.mock('../services/wineVisibility', () => ({ findVisibleWine: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({ getSnapshotForDate: jest.fn().mockResolvedValue(null) }));
+jest.mock('../utils/vintageProfile', () => ({ ensurePendingVintageProfile: jest.fn() }));
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => ({ findOne: jest.fn(), updateMany: jest.fn() }));
+jest.mock('../models/CellarLayout', () => ({ findOne: jest.fn() }));
+jest.mock('../models/Country', () => ({}));
+jest.mock('../models/Region', () => ({}));
+jest.mock('../models/Grape', () => ({}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('../models/PriceTrackingRequest', () => ({}));
+jest.mock('../models/PriceTrackingSkip', () => ({}));
+jest.mock('../models/BottleImage', () => ({ findOne: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/WineRequest', () => ({}));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+
+const Bottle = require('../models/Bottle');
+const Cellar = require('../models/Cellar');
+const Rack = require('../models/Rack');
+const BottleImage = require('../models/BottleImage');
+// Loaded here, not inside app(): the router is the heaviest module in the
+// tree, and requiring it inside the first test's 5 s budget times out under a
+// parallel suite run.
+const bottlesRouter = require('./bottles');
+
+jest.setTimeout(20000);
+
+const USER = '64b000000000000000000001';
+const CELLAR = '64b0000000000000000000cc';
+const BOTTLE = '64b0000000000000000000bb';
+
+const selectLean = (doc) => ({ select: () => ({ lean: async () => doc }) });
+const sortLean = (doc) => ({ sort: () => ({ lean: async () => doc }) });
+
+function mkBottle(over = {}) {
+  return {
+    _id: BOTTLE, user: USER, cellar: CELLAR, status: 'active',
+    wineDefinition: null, priceSetAt: null, defaultImage: null,
+    populate: jest.fn().mockResolvedValue(undefined),
+    toObject: () => ({ _id: BOTTLE, status: 'active' }),
+    ...over,
+  };
+}
+
+function app() {
+  const a = express();
+  a.use(express.json());
+  a.use('/api/bottles', bottlesRouter);
+  return a;
+}
+
+function getJson(a, path) {
+  const token = jwt.sign({ id: USER, roles: ['user'] }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(a);
+    server.listen(0, () => {
+      http.get({ port: server.address().port, path, headers: { authorization: `Bearer ${token}` } }, (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => { server.close(); resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) }); });
+      }).on('error', (e) => { server.close(); reject(e); });
+    });
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Cellar.findById.mockResolvedValue({
+    _id: CELLAR, user: USER, deletedAt: null, members: [], userColors: [],
+  });
+  Bottle.findById.mockResolvedValue(mkBottle());
+  Rack.findOne.mockReturnValue(selectLean(null));
+  BottleImage.findOne.mockReturnValue(sortLean(null));
+  BottleImage.findById.mockReturnValue({ lean: async () => null });
+});
+
+describe('GET /api/bottles/:id pending photo', () => {
+  test('the lookup excludes label scans — the scanner\'s raw frame is curation evidence, not a bottle photo', async () => {
+    const { status, body } = await getJson(app(), `/api/bottles/${BOTTLE}`);
+
+    expect(status).toBe(200);
+    expect(body.pendingImageUrl).toBeNull();
+    expect(BottleImage.findOne).toHaveBeenCalledTimes(1);
+    expect(BottleImage.findOne).toHaveBeenCalledWith(expect.objectContaining({
+      uploadedBy: USER,
+      status: { $in: ['uploaded', 'processing', 'processed'] },
+      // `$ne`, not `kind: 'bottle'` — rows older than the field have no kind.
+      kind: { $ne: 'label-scan' },
+    }));
+  });
+
+  test('a genuine bottle photo still shows — the processed file first, the original only while rembg is still running', async () => {
+    BottleImage.findOne.mockReturnValue(sortLean({
+      _id: 'img1', kind: 'bottle', status: 'processing',
+      originalUrl: '/api/uploads/originals/x.jpg', processedUrl: null,
+    }));
+    let res = await getJson(app(), `/api/bottles/${BOTTLE}`);
+    expect(res.body.pendingImageUrl).toBe('/api/uploads/originals/x.jpg');
+
+    BottleImage.findOne.mockReturnValue(sortLean({
+      _id: 'img1', kind: 'bottle', status: 'processed',
+      originalUrl: null, processedUrl: '/api/uploads/processed/x.png',
+    }));
+    res = await getJson(app(), `/api/bottles/${BOTTLE}`);
+    expect(res.body.pendingImageUrl).toBe('/api/uploads/processed/x.png');
+  });
+});

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -355,6 +355,14 @@ async function attachBottleImageUrls(bottles, userId) {
     ],
     uploadedBy: userId,
     status: { $in: ['uploaded', 'processing', 'processed'] },
+    // Never a label scan (support ticket 2026-09-03). The raw frame handed to
+    // the AI scanner is kept ONLY as private curation evidence (models/
+    // BottleImage.kind); it carries the wine it minted, sits at status
+    // 'uploaded' with no processed file, and so matched the by-wine arm above —
+    // the scanner's kitchen-table photo became the card image of every bottle
+    // of that wine. `$ne`, not `kind: 'bottle'`: rows older than the field
+    // have no `kind` at all.
+    kind: { $ne: 'label-scan' },
   }).sort({ createdAt: -1 }).lean();
 
   // Two maps, consulted bottle-first: a photo pinned to this exact bottle must
@@ -1799,3 +1807,5 @@ router.post('/:id/transfer-ownership', requireNonDemo, async (req, res) => {
 });
 
 module.exports = router;
+// Exported for its unit test (routes/cellars.pendingImage.test.js).
+module.exports.attachBottleImageUrls = attachBottleImageUrls;

--- a/backend/src/routes/cellars.pendingImage.test.js
+++ b/backend/src/routes/cellars.pendingImage.test.js
@@ -1,0 +1,91 @@
+/**
+ * routes/cellars attachBottleImageUrls — the per-bottle "pending photo" that
+ * the cellar list (BottleCard) renders when a bottle has no starred image and
+ * its wine has no registry image.
+ *
+ * Support ticket 2026-09-03: the cellar's card view showed the RAW frame a
+ * user had handed to the label scanner — background and all — served from
+ * /api/uploads/originals/. That frame is kept as a private kind:'label-scan'
+ * row so a curator can read a misread label; it carries the wine it minted
+ * and sits at status 'uploaded' with no processed file, so the by-wine arm of
+ * this lookup (added 2026-08-03, before label scans existed) matched it on
+ * every bottle of that wine. The lookup must exclude label scans.
+ */
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+jest.mock('../services/search', () => ({
+  indexBottle: jest.fn(), removeBottle: jest.fn(), indexWine: jest.fn(),
+  bulkIndexBottles: jest.fn(), getIsAvailable: jest.fn(() => false),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/rackOps', () => ({ createCellar: jest.fn() }));
+jest.mock('../services/notifications', () => ({ createNotification: jest.fn() }));
+jest.mock('../services/cellarTransfer', () => ({ transferCellarOwnership: jest.fn() }));
+jest.mock('../services/mailgun', () => ({ sendCellarInviteEmail: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({
+  getSnapshotsForDates: jest.fn(), getOrCreateDailySnapshot: jest.fn(), convertCurrency: jest.fn(),
+}));
+jest.mock('../models/Cellar', () => ({}));
+jest.mock('../models/Bottle', () => ({}));
+jest.mock('../models/Rack', () => ({}));
+jest.mock('../models/User', () => ({}));
+jest.mock('../models/AuditLog', () => ({}));
+jest.mock('../models/WineDefinition', () => ({}));
+jest.mock('../models/PendingShare', () => ({}));
+jest.mock('../models/ClimateDevice', () => ({}));
+jest.mock('../models/WineRequest', () => ({}));
+jest.mock('../models/BottleImage', () => ({ find: jest.fn() }));
+
+const BottleImage = require('../models/BottleImage');
+const { attachBottleImageUrls } = require('./cellars');
+
+const USER = '64b000000000000000000001';
+const WINE = '64b0000000000000000000aa';
+const B1 = '64b0000000000000000000b1';
+const B2 = '64b0000000000000000000b2';
+
+// The pending lookup is find().sort().lean(); the starred-image lookup is
+// find().lean(). One chain serves both.
+const chain = (rows) => {
+  const q = { sort: () => q, lean: async () => rows };
+  return q;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  BottleImage.find.mockReturnValue(chain([]));
+});
+
+test('the pending lookup excludes label scans and is scoped to the viewer', async () => {
+  const out = await attachBottleImageUrls([{ _id: B1, wineDefinition: WINE }], USER);
+
+  expect(BottleImage.find).toHaveBeenCalledTimes(1);
+  expect(BottleImage.find).toHaveBeenCalledWith(expect.objectContaining({
+    uploadedBy: USER,
+    status: { $in: ['uploaded', 'processing', 'processed'] },
+    // `$ne`, not `kind: 'bottle'` — rows older than the field have no kind.
+    kind: { $ne: 'label-scan' },
+  }));
+  expect(out[0].pendingImageUrl).toBeNull();
+  expect(out[0].defaultImageUrl).toBeNull();
+});
+
+test('a photo pinned to the bottle beats one that merely matches the wine, and the processed file is what shows', async () => {
+  BottleImage.find.mockReturnValue(chain([
+    { _id: 'byWine', wineDefinition: WINE, bottle: null, originalUrl: null, processedUrl: '/api/uploads/processed/wine.png' },
+    { _id: 'byBottle', wineDefinition: WINE, bottle: B1, originalUrl: null, processedUrl: '/api/uploads/processed/b1.png' },
+  ]));
+
+  const out = await attachBottleImageUrls([
+    { _id: B1, wineDefinition: WINE },
+    { _id: B2, wineDefinition: WINE },
+  ], USER);
+
+  expect(out[0].pendingImageUrl).toBe('/api/uploads/processed/b1.png');   // pinned to B1
+  expect(out[1].pendingImageUrl).toBe('/api/uploads/processed/wine.png'); // same wine, no pin
+});
+
+test('empty input is returned as-is without a query', async () => {
+  expect(await attachBottleImageUrls([], USER)).toEqual([]);
+  expect(BottleImage.find).not.toHaveBeenCalled();
+});

--- a/backend/src/scripts/purge-retained-originals.js
+++ b/backend/src/scripts/purge-retained-originals.js
@@ -1,0 +1,90 @@
+/**
+ * One-time cleanup of RETAINED original uploads.
+ *
+ * Support ticket 2026-09-03: a user found their raw bottle photos — background,
+ * kitchen, hands — still served from /api/uploads/originals/. Since that fix,
+ * services/imageProcessor deletes the raw upload as soon as background removal
+ * has produced the processed file (discardOriginal). Every image processed
+ * BEFORE it still has both files on disk — unless an admin approved it, which
+ * was the only path that used to delete the original. This script brings that
+ * backlog in line with the new rule.
+ *
+ * For every non-label-scan BottleImage whose originalUrl and processedUrl are
+ * both set and DIFFERENT — a keepBackground row has them equal (its original
+ * IS the kept file) and is untouched — and whose processed file is actually on
+ * disk (never delete the only copy), the original file is unlinked
+ * (reference-safe: a file another record still points at is kept) and
+ * originalUrl is nulled.
+ *
+ * Out of scope, on purpose:
+ *   - kind:'label-scan' rows — curation evidence with its own bounded retention
+ *     (services/scanImageRetentionJob)
+ *   - rows with no processed file (a failed rembg run awaiting retry, an
+ *     imported never-cropped photo) — the original is all they have
+ *
+ * Usage (inside the backend container):
+ *   node src/scripts/purge-retained-originals.js           # dry-run (default)
+ *   node src/scripts/purge-retained-originals.js --apply   # actually delete
+ */
+const fs = require('fs');
+const mongoose = require('mongoose');
+const BottleImage = require('../models/BottleImage');
+const { safeUploadPath, discardOriginal } = require('../services/imageProcessor');
+
+const APPLY = process.argv.includes('--apply');
+
+function fileSize(url) {
+  try {
+    return fs.statSync(safeUploadPath(url.replace('/api/uploads/', ''))).size;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  await mongoose.connect(process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar');
+  console.log(`Mode: ${APPLY ? 'APPLY (deleting originals)' : 'DRY-RUN (no changes; pass --apply to execute)'}\n`);
+
+  const cursor = BottleImage.find({
+    kind: { $ne: 'label-scan' },
+    originalUrl: { $ne: null },
+    processedUrl: { $ne: null },
+    $expr: { $ne: ['$originalUrl', '$processedUrl'] },
+  }).select('_id originalUrl processedUrl keepBackground status').cursor();
+
+  let candidates = 0;
+  let discarded = 0;
+  let bytes = 0;
+  let noProcessedFile = 0;
+  let alreadyGone = 0;
+
+  for await (const image of cursor) {
+    candidates++;
+    if (fileSize(image.processedUrl) === null) {
+      // The processed file is missing, so the original is the only copy left.
+      // Leave it — that is a repair case, not a cleanup case.
+      noProcessedFile++;
+      console.log(`  keep   ${image._id} — processed file missing on disk (${image.processedUrl})`);
+      continue;
+    }
+    const size = fileSize(image.originalUrl);
+    if (size === null) alreadyGone++; else bytes += size;
+    if (APPLY) {
+      await discardOriginal(image);
+      discarded++;
+    }
+  }
+
+  console.log(`\nCandidates (original + distinct processed): ${candidates}`);
+  console.log(`  kept, processed file missing on disk:     ${noProcessedFile}`);
+  console.log(`  original file already absent (row only):  ${alreadyGone}`);
+  console.log(`  original bytes on disk:                   ${(bytes / 1024 / 1024).toFixed(1)} MB`);
+  console.log(APPLY ? `  discarded:                                ${discarded}` : '  (dry-run — nothing changed)');
+
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/services/globalStatsService.js
+++ b/backend/src/services/globalStatsService.js
@@ -849,7 +849,8 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
     WineVintageProfile.countDocuments({ status: 'reviewed' }),
     WineVintageProfile.countDocuments({ status: 'pending' }),
     WineRequest.countDocuments({ ...requestMatch, status: 'pending' }),
-    BottleImage.countDocuments({ ...imageMatch, status: { $in: ['uploaded', 'processing', 'processed'] } }),
+    // Same population as the admin moderation queue, which excludes label scans.
+    BottleImage.countDocuments({ ...imageMatch, kind: { $ne: 'label-scan' }, status: { $in: ['uploaded', 'processing', 'processed'] } }),
     BottleImage.countDocuments(imageMatch),
     Bottle.distinct('wineDefinition', bottleMatch).then(ids => ids.filter(Boolean).length),
     WineDefinition.countDocuments(),

--- a/backend/src/services/imageOps.js
+++ b/backend/src/services/imageOps.js
@@ -129,9 +129,10 @@ async function ingestBottleImage({ buffer, userId, userRoles = [], bottle = null
  * step — pre-approved (public), replacing any prior official image, with the
  * credit stored on both the image and the wine. ONE implementation for the
  * admin REST route and the admin MCP tool, mirroring what
- * routes/admin/images.js approve does for user uploads (minus original-file
- * deletion — background removal still needs the source; imageProcessor's
- * post-process hook upgrades wine.image to the clean version when it's ready).
+ * routes/admin/images.js approve does for user uploads. Background removal
+ * still needs the source at this point, so the original stays for now;
+ * imageProcessor's post-process hook upgrades wine.image to the clean version
+ * when it's ready and then discards the original (discardOriginal).
  *
  * Caller must have verified the wine exists and the actor is an admin
  * (userRoles is still forwarded so the shared credit gate applies uniformly).

--- a/backend/src/services/imageProcessor.discardOriginal.test.js
+++ b/backend/src/services/imageProcessor.discardOriginal.test.js
@@ -1,0 +1,173 @@
+/**
+ * imageProcessor keeps ONLY the processed file once background removal has
+ * succeeded.
+ *
+ * Support ticket 2026-09-03: a user's cellar showed photos "including the
+ * background", served from /api/uploads/originals/. Nothing needs the raw
+ * frame once rembg has run, so processImage now deletes it (discardOriginal).
+ * Pinned here: the happy path drops the original file AND the pointer; a
+ * failed rembg run keeps both (the retry needs its source); a keepBackground
+ * row, whose "original" IS the kept file, is never touched; a file another
+ * record still references stays on disk while this record drops its pointer.
+ */
+jest.mock('../config/upload', () => ({ PROCESSED_DIR: '/app/uploads/processed' }));
+jest.mock('../models/BottleImage', () => ({
+  findById: jest.fn(),
+  countDocuments: jest.fn(),
+  updateOne: jest.fn(),
+}));
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(() => Buffer.from('raw-upload-bytes')),
+  writeFileSync: jest.fn(),
+  existsSync: jest.fn(() => true),
+  promises: {
+    unlink: jest.fn().mockResolvedValue(undefined),
+    readdir: jest.fn().mockResolvedValue([]),
+    stat: jest.fn(),
+  },
+}));
+
+const fs = require('fs');
+const BottleImage = require('../models/BottleImage');
+const { processImage, discardOriginal, unlinkImageFiles } = require('./imageProcessor');
+
+const ORIG = '/api/uploads/originals/abc.jpg';
+const PROC = '/api/uploads/processed/abc.png';
+
+function makeDoc(over = {}) {
+  return {
+    _id: 'img1', status: 'uploaded', keepBackground: false, assignedToWine: false,
+    originalUrl: ORIG, processedUrl: null, contentHash: null,
+    save: jest.fn().mockResolvedValue(undefined),
+    ...over,
+  };
+}
+
+// processImage loads the doc once (awaited directly), then re-reads a
+// projection for the official-wine hook (.select()). First call → the doc;
+// every later call → a non-official projection.
+function loadDoc(doc) {
+  BottleImage.findById.mockReset();
+  BottleImage.findById
+    .mockResolvedValueOnce(doc)
+    .mockImplementation(() => ({ select: jest.fn().mockResolvedValue({ assignedToWine: false }) }));
+}
+
+function rembg({ ok = true, status = 200 } = {}) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status,
+    arrayBuffer: async () => Uint8Array.from([137, 80, 78, 71]).buffer,
+    text: async () => 'boom',
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  BottleImage.countDocuments.mockResolvedValue(0);
+  BottleImage.updateOne.mockResolvedValue({ acknowledged: true });
+});
+
+describe('processImage', () => {
+  test('a successful rembg run deletes the original file and nulls originalUrl — the processed file is the only copy', async () => {
+    const doc = makeDoc();
+    loadDoc(doc);
+    rembg();
+
+    await processImage('img1');
+
+    expect(doc.status).toBe('processed');
+    expect(doc.processedUrl).toBe(PROC);
+    expect(fs.writeFileSync).toHaveBeenCalledWith('/app/uploads/processed/abc.png', expect.any(Buffer));
+    expect(fs.promises.unlink).toHaveBeenCalledWith('/app/uploads/originals/abc.jpg');
+    expect(BottleImage.updateOne).toHaveBeenCalledWith(
+      { _id: 'img1', originalUrl: ORIG },
+      { $set: { originalUrl: null } },
+    );
+    expect(doc.originalUrl).toBeNull();
+  });
+
+  test('a FAILED rembg run keeps the original — the retry needs its source', async () => {
+    const doc = makeDoc();
+    loadDoc(doc);
+    rembg({ ok: false, status: 500 });
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await processImage('img1');
+
+    expect(doc.status).toBe('uploaded');
+    expect(doc.originalUrl).toBe(ORIG);
+    expect(fs.promises.unlink).not.toHaveBeenCalled();
+    expect(BottleImage.updateOne).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  test('a keepBackground row is settled from its original and nothing is deleted', async () => {
+    const doc = makeDoc({ keepBackground: true });
+    loadDoc(doc);
+    global.fetch = jest.fn(() => { throw new Error('rembg must not be called'); });
+
+    await processImage('img1');
+
+    expect(doc.processedUrl).toBe(ORIG);
+    expect(doc.originalUrl).toBe(ORIG);
+    expect(fs.promises.unlink).not.toHaveBeenCalled();
+  });
+});
+
+describe('discardOriginal', () => {
+  test("keeps a file another record still references, but drops this record's pointer", async () => {
+    BottleImage.countDocuments.mockResolvedValue(1);
+    const doc = makeDoc({ processedUrl: PROC });
+
+    await discardOriginal(doc);
+
+    expect(fs.promises.unlink).not.toHaveBeenCalled();
+    expect(BottleImage.updateOne).toHaveBeenCalledWith({ _id: 'img1', originalUrl: ORIG }, { $set: { originalUrl: null } });
+    expect(doc.originalUrl).toBeNull();
+  });
+
+  test('never touches a row whose original IS the kept file (keepBackground: processedUrl === originalUrl)', async () => {
+    const doc = makeDoc({ keepBackground: true, processedUrl: ORIG });
+    await discardOriginal(doc);
+    expect(fs.promises.unlink).not.toHaveBeenCalled();
+    expect(BottleImage.updateOne).not.toHaveBeenCalled();
+    expect(doc.originalUrl).toBe(ORIG);
+  });
+
+  test('never touches a row with no processed file (failed run, or an imported never-cropped photo)', async () => {
+    const doc = makeDoc({ processedUrl: null });
+    await discardOriginal(doc);
+    expect(fs.promises.unlink).not.toHaveBeenCalled();
+    expect(BottleImage.updateOne).not.toHaveBeenCalled();
+    expect(doc.originalUrl).toBe(ORIG);
+  });
+
+  test('an unlink failure is logged, not thrown — and the pointer is still dropped so nothing serves the file', async () => {
+    fs.promises.unlink.mockRejectedValueOnce(Object.assign(new Error('EACCES'), { code: 'EACCES' }));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const doc = makeDoc({ processedUrl: PROC });
+
+    await expect(discardOriginal(doc)).resolves.toBeUndefined();
+
+    expect(doc.originalUrl).toBeNull();
+    expect(BottleImage.updateOne).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('unlinkImageFiles (same contract after the refactor)', () => {
+  test('unlinks both files of an unreferenced record', async () => {
+    await unlinkImageFiles(makeDoc({ processedUrl: PROC }));
+    expect(fs.promises.unlink).toHaveBeenCalledTimes(2);
+    expect(fs.promises.unlink).toHaveBeenCalledWith('/app/uploads/originals/abc.jpg');
+    expect(fs.promises.unlink).toHaveBeenCalledWith('/app/uploads/processed/abc.png');
+  });
+
+  test('keeps a file another record shares', async () => {
+    BottleImage.countDocuments.mockResolvedValue(2);
+    await unlinkImageFiles(makeDoc({ processedUrl: PROC }));
+    expect(fs.promises.unlink).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/imageProcessor.js
+++ b/backend/src/services/imageProcessor.js
@@ -28,42 +28,92 @@ function safeUploadPath(relativePart) {
 }
 
 /**
- * Best-effort unlink of a BottleImage's on-disk files (original + processed).
- * Used by GDPR erasure so the underlying files don't outlive the DB rows that
- * are their only reference. Never throws — a missing file or transient error
- * must not abort the surrounding deletion.
+ * Unlink ONE upload file unless another BottleImage still references it.
  *
  * Reference-safe: import-time content dedup (services/cellarImport.js) can point
  * TWO BottleImage docs at the same file on disk (so we don't re-store an image
  * the user already has). Before unlinking a file we therefore check whether any
  * OTHER BottleImage still references that URL, and skip the unlink if so — so
  * deleting one doc never orphans another doc's still-needed file. When the image
- * has no other references (the common case), behaviour is unchanged.
+ * has no other references (the common case), the file is simply removed.
+ *
+ * Never throws — a missing file or transient error must not abort the
+ * surrounding operation. Returns true when the file is gone (unlinked, or was
+ * already missing), false when it was kept for another document.
+ */
+async function unlinkIfUnreferenced(imageId, url) {
+  if (!url || typeof url !== 'string' || !url.startsWith('/api/uploads/')) return true;
+  try {
+    const stillReferenced = await BottleImage.countDocuments({
+      _id: { $ne: imageId },
+      $or: [{ originalUrl: url }, { processedUrl: url }],
+    });
+    if (stillReferenced > 0) return false; // another image doc shares this file — keep it
+  } catch (err) {
+    // If the reference check fails, fall through and unlink as before — the
+    // pre-dedup behaviour. Shared files are rare; orphaning a file is worse
+    // than the (very unlikely) case of removing a still-referenced one.
+    console.warn(`[images] reference check failed for ${url}:`, err.message);
+  }
+  try {
+    await fs.promises.unlink(safeUploadPath(url.replace('/api/uploads/', '')));
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.warn(`[images] could not unlink ${url}:`, err.message);
+    }
+  }
+  return true;
+}
+
+/**
+ * Best-effort unlink of a BottleImage's on-disk files (original + processed).
+ * Used by GDPR erasure so the underlying files don't outlive the DB rows that
+ * are their only reference. Never throws — a missing file or transient error
+ * must not abort the surrounding deletion.
  */
 async function unlinkImageFiles(image) {
   if (!image) return;
   for (const url of [image.originalUrl, image.processedUrl]) {
-    if (!url || typeof url !== 'string' || !url.startsWith('/api/uploads/')) continue;
-    try {
-      const stillReferenced = await BottleImage.countDocuments({
-        _id: { $ne: image._id },
-        $or: [{ originalUrl: url }, { processedUrl: url }],
-      });
-      if (stillReferenced > 0) continue; // another image doc shares this file — keep it
-    } catch (err) {
-      // If the reference check fails, fall through and unlink as before — the
-      // pre-dedup behaviour. Shared files are rare; orphaning a file is worse
-      // than the (very unlikely) case of removing a still-referenced one.
-      console.warn(`[images] reference check failed for ${url}:`, err.message);
-    }
-    try {
-      await fs.promises.unlink(safeUploadPath(url.replace('/api/uploads/', '')));
-    } catch (err) {
-      if (err.code !== 'ENOENT') {
-        console.warn(`[images] could not unlink ${url}:`, err.message);
-      }
-    }
+    await unlinkIfUnreferenced(image._id, url);
   }
+}
+
+/**
+ * Drop the ORIGINAL upload once background removal has produced the processed
+ * file — the processed image is the only copy Cellarion keeps.
+ *
+ * Support ticket 2026-09-03: a user's cellar showed photos "including the
+ * background", served from /api/uploads/originals/. That frame is the raw
+ * photo — a kitchen table, a hand, a face — and nothing needs it once rembg
+ * has run: every display path prefers processedUrl, the cellar export ships
+ * the processed file, and the only retry path (POST /api/images/:id/retry)
+ * exists for images that have NO processed file yet. Keeping it was pure
+ * exposure. Until now only an admin approval deleted the original, so a
+ * private photo — the common case — kept its raw frame on disk for good.
+ *
+ * Skipped when the original IS the kept file (a keepBackground row, where
+ * processedUrl === originalUrl — see models/BottleImage) and when there is no
+ * processed file at all (a failed rembg run still needs its source for the
+ * retry; an imported never-cropped photo has nothing else). Reference-safe
+ * like everything else here, and never throws: a stray unlink failure must not
+ * fail the processing job that just succeeded — the hourly orphan sweep
+ * (cleanupOrphanedImages) picks up a file nothing references any more.
+ *
+ * Nulls originalUrl in the DB directly (not via image.save()) so a caller
+ * holding a stale document snapshot cannot resurrect the URL, and mirrors the
+ * change onto the in-memory doc for callers that go on to save it.
+ */
+async function discardOriginal(image) {
+  if (!image || !image.originalUrl || !image.processedUrl) return;
+  if (image.originalUrl === image.processedUrl) return;
+  const url = image.originalUrl;
+  await unlinkIfUnreferenced(image._id, url);
+  try {
+    await BottleImage.updateOne({ _id: image._id, originalUrl: url }, { $set: { originalUrl: null } });
+  } catch (err) {
+    console.warn(`[images] could not clear originalUrl for ${image._id}:`, err.message);
+  }
+  image.originalUrl = null;
 }
 
 async function processImage(imageId) {
@@ -138,6 +188,11 @@ async function processImage(imageId) {
       require('./search').indexWine(official.wineDefinition);
     }
 
+    // The processed file is now the only copy we keep — the raw frame goes.
+    // AFTER the wine-image upgrade above, so WineDefinition.image never points
+    // at a file that has just been deleted, even for a moment.
+    await discardOriginal(image);
+
     console.log(`Image ${imageId} processed successfully`);
   } catch (error) {
     console.error(`Image processing failed for ${imageId}:`, error.message);
@@ -148,60 +203,10 @@ async function processImage(imageId) {
   }
 }
 
-async function reprocessAllImages() {
-  const images = await BottleImage.find({
-    status: { $in: ['processed', 'approved'] },
-    originalUrl: { $exists: true },
-    // Never run rembg over a photo whose uploader opted out of it.
-    keepBackground: { $ne: true },
-  });
-
-  console.log(`Re-processing ${images.length} images...`);
-
-  for (const image of images) {
-    try {
-      const originalPath = safeUploadPath(image.originalUrl.replace('/api/uploads/', ''));
-      if (!fs.existsSync(originalPath)) {
-        console.log(`Skipping ${image._id}: original file not found`);
-        continue;
-      }
-
-      const fileBuffer = fs.readFileSync(originalPath);
-      const formData = new FormData();
-      const blob = new Blob([fileBuffer], { type: 'image/jpeg' });
-      formData.append('image', blob, 'input.jpg');
-
-      const response = await fetch(`${REMBG_URL}/remove-bg`, {
-        method: 'POST',
-        body: formData,
-        signal: AbortSignal.timeout(120000)
-      });
-
-      if (!response.ok) {
-        console.log(`Skipping ${image._id}: rembg error ${response.status}`);
-        continue;
-      }
-
-      const resultBuffer = Buffer.from(await response.arrayBuffer());
-      const basename = path.basename(image.originalUrl, path.extname(image.originalUrl));
-      const processedFilename = `${basename}.png`;
-      const processedPath = path.join(PROCESSED_DIR, processedFilename);
-
-      fs.writeFileSync(processedPath, resultBuffer);
-      image.processedUrl = `/api/uploads/processed/${processedFilename}`;
-      // The dedup hash must track the bytes of the kept/exported file (see
-      // processImage above) — rembg output is not byte-stable across runs.
-      image.contentHash = hashImageBytes(resultBuffer);
-      await image.save();
-
-      console.log(`Re-processed ${image._id} successfully`);
-    } catch (error) {
-      console.error(`Re-process failed for ${image._id}:`, error.message);
-    }
-  }
-
-  console.log('Re-processing complete');
-}
+// reprocessAllImages (admin "re-run rembg over every image") used to live here.
+// It went with the retained originals: a processed image no longer has a
+// source frame to re-run, by design (see discardOriginal). An image whose rembg
+// run FAILED keeps its original and is re-run via POST /api/images/:id/retry.
 
 /**
  * Clean up images stuck in 'processing' for more than 1 hour (likely failed silently)
@@ -223,9 +228,11 @@ async function cleanupOrphanedImages() {
     const ORIGINALS_DIR = path.join(UPLOADS_ROOT, 'originals');
     if (!fs.existsSync(ORIGINALS_DIR)) return;
 
-    // originalUrl is null for approved/rejected images (their file was already
-    // deleted) — path.basename(null) used to throw here, which silently
+    // originalUrl is null for every processed image (discardOriginal) and for
+    // rejected ones — path.basename(null) used to throw here, which silently
     // disabled the orphan sweep forever once any image had been moderated.
+    // A file whose unlink failed in discardOriginal lands here too: nothing
+    // references it any more, so it is an orphan.
     const files = await fs.promises.readdir(ORIGINALS_DIR);
     const dbImages = await BottleImage.find({ originalUrl: { $ne: null } }, 'originalUrl').lean();
     const knownFiles = new Set(dbImages.map(img => path.basename(img.originalUrl)));
@@ -256,4 +263,4 @@ async function cleanupOrphanedImages() {
   }
 }
 
-module.exports = { processImage, reprocessAllImages, cleanupOrphanedImages, safeUploadPath, unlinkImageFiles, hashImageBytes };
+module.exports = { processImage, cleanupOrphanedImages, safeUploadPath, unlinkImageFiles, unlinkIfUnreferenced, discardOriginal, hashImageBytes };

--- a/backend/src/services/imageProcessor.js
+++ b/backend/src/services/imageProcessor.js
@@ -196,8 +196,9 @@ async function processImage(imageId) {
     console.log(`Image ${imageId} processed successfully`);
   } catch (error) {
     console.error(`Image processing failed for ${imageId}:`, error.message);
-    // Revert to uploaded so it can be retried — but never demote an official
-    // (assignedToWine) image's approval; reprocessAllImages retries those too.
+    // Revert to uploaded so it can be retried (POST /api/images/:id/retry) —
+    // but never demote an official (assignedToWine) image's approval. The
+    // original stays on disk: it is the retry's source.
     image.status = image.assignedToWine ? 'approved' : 'uploaded';
     await image.save();
   }

--- a/backend/src/services/imageProcessor.keepBackground.test.js
+++ b/backend/src/services/imageProcessor.keepBackground.test.js
@@ -4,13 +4,15 @@
  * Support ticket 6a97f870 (2026-09-02): label-only photos came back cropped
  * because rembg expects a whole bottle. An uploader who opts out must never
  * have their photo sent to rembg — not on the initial hand-off (imageOps skips
- * it), not on a retry, and not by the reprocess-everything maintenance job.
+ * it) and not on a retry. (The reprocess-everything maintenance job that this
+ * suite also guarded is gone: originals are no longer retained once processed,
+ * so there is nothing to re-run — see imageProcessor.discardOriginal.)
  */
 jest.mock('../config/upload', () => ({ PROCESSED_DIR: '/tmp/processed' }));
-jest.mock('../models/BottleImage', () => ({ findById: jest.fn(), find: jest.fn() }));
+jest.mock('../models/BottleImage', () => ({ findById: jest.fn() }));
 
 const BottleImage = require('../models/BottleImage');
-const { processImage, reprocessAllImages } = require('./imageProcessor');
+const { processImage } = require('./imageProcessor');
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -28,12 +30,7 @@ test('processImage on a keepBackground row settles it from the original without 
   expect(global.fetch).not.toHaveBeenCalled();
   expect(doc.status).toBe('processed');
   expect(doc.processedUrl).toBe('/api/uploads/originals/a.jpg');
+  // The original IS the kept file — it must still be referenced.
+  expect(doc.originalUrl).toBe('/api/uploads/originals/a.jpg');
   expect(doc.save).toHaveBeenCalledTimes(1);
-});
-
-test('reprocessAllImages excludes keepBackground rows from its query', async () => {
-  BottleImage.find.mockResolvedValue([]);
-  await reprocessAllImages();
-  expect(BottleImage.find).toHaveBeenCalledWith(expect.objectContaining({ keepBackground: { $ne: true } }));
-  expect(global.fetch).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## What

Support ticket 2026-09-03: a user's cellar card view showed photos "including the background", served from `/api/uploads/originals/`.

1. **Label scans no longer surface as bottle photos.** The per-bottle "pending photo" lookups in `routes/cellars.js` (`attachBottleImageUrls`) and `routes/bottles.js` match by wine as well as by bottle, with no `kind` filter. A label scan — the raw frame handed to the AI scanner, kept as private curation evidence — carries the wine it minted, sits at status `uploaded` with no processed file, and so became the card image of every bottle of that wine (for its own uploader only; the lookup is scoped to the viewer). Both lookups, and the admin pending count, now exclude `kind: 'label-scan'`. Scans stay readable to curators in the pending-identity queue under their existing bounded retention.

2. **The original upload is deleted once the background is removed.** Only an admin approval ever deleted it, and private photos never get approved, so ordinary uploads kept the raw frame on disk for good. `imageProcessor.discardOriginal` now runs right after rembg succeeds: reference-safe (import dedup can share a file), never throws, skips "keep background" rows (their original *is* the kept file) and rows with no processed file (a failed run must stay retryable). The admin approve / set-official paths use the same helper — the old inline unlink deleted a keep-background row's only file on approval and left `processedUrl` dangling (live since v1.197.3).

3. The `reprocess-all` admin job is removed with the originals it depended on (no UI called it). Failed runs are still retried via `POST /api/images/:id/retry`.

## Deploy note

After deploying, clear the backlog of originals already sitting next to a processed file:

    docker compose -f docker-compose.prod.yml exec -T backend node src/scripts/purge-retained-originals.js           # dry-run
    docker compose -f docker-compose.prod.yml exec -T backend node src/scripts/purge-retained-originals.js --apply

Prod today: `originals/` 1014 files / 340 MB, `processed/` 3436 files / 1.4 GB. Label scans and keep-background photos are untouched by the script.

## Tests

- New: `imageProcessor.discardOriginal.test.js`, `routes/bottles.pendingImage.test.js`, `routes/cellars.pendingImage.test.js`, `routes/admin/images.approve.test.js`
- Updated: `imageProcessor.keepBackground.test.js`, `admin/images.assign.test.js`
- Ran the image/route suites in node:24-alpine: 17 suites green except the known pre-existing `bottles.rackInfo` timeout.
- Frontend untouched. Not smoke-tested in Docker Compose locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
