### PR TITLE
chore(release): v1.198.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.198.0",
+  "version": "1.198.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.198.0",
+      "version": "1.198.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.198.0",
+  "version": "1.198.1",
   "license": "AGPL-3.0",
   "description": "Wine cellar management backend",
   "main": "server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.198.0",
+  "version": "1.198.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.198.0",
+      "version": "1.198.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.198.0",
+  "version": "1.198.1",
   "license": "AGPL-3.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for v1.198.1: #1207 (bottle photos keep only the background-removed image; label scans excluded from bottle views; purge script) and #1206 (backup hardening, seeder guard).