### PR TITLE
feat(bottles): move many bottles to another cellar in one step

### DIFF
--- a/backend/src/routes/bottles.bulkMove.test.js
+++ b/backend/src/routes/bottles.bulkMove.test.js
@@ -1,0 +1,181 @@
+/**
+ * POST /api/bottles/bulk-move — many bottles to another owned cellar in ONE
+ * request (support ticket 6a9949e3, 2026-09-03: a delivery logged in a
+ * storage cellar had to be moved home one bottle at a time).
+ *
+ * Pinned: the request is validated as a whole (ids, cap, a destination you
+ * own), then applied PER BOTTLE through the shared rackOps.moveBottleToCellar.
+ * A bottle in a cellar you don't own, an unknown id, a consumed bottle or one
+ * already in the destination is skipped WITH a reason while the rest still
+ * move. Same disclosure rule as the single route: a bottle you may not move
+ * reads as not_found.
+ */
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+jest.mock('../services/search', () => ({
+  indexBottle: jest.fn(), removeBottle: jest.fn(), indexWine: jest.fn(),
+  bulkIndexBottles: jest.fn(), getIsAvailable: jest.fn(() => false),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../services/embeddingJob', () => ({ embedSinglePair: jest.fn().mockResolvedValue(undefined), reembedActiveVintages: jest.fn() }));
+jest.mock('../services/enrichmentJob', () => ({ enrichWineById: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../services/restockChecker', () => ({ checkRestockAlerts: jest.fn(), checkOnConsume: jest.fn() }));
+jest.mock('../services/imageProcessor', () => ({ unlinkImageFiles: jest.fn() }));
+jest.mock('../services/priceWarnings', () => ({ gatherPriceWarnings: jest.fn().mockResolvedValue([]) }));
+jest.mock('../services/communityPrice', () => ({ getCurrentRelease: jest.fn().mockResolvedValue(null) }));
+jest.mock('../services/wineVisibility', () => ({ findVisibleWine: jest.fn() }));
+jest.mock('../services/rackOps', () => ({ moveBottleToCellar: jest.fn() }));
+jest.mock('../utils/exchangeRates', () => ({ getSnapshotForDate: jest.fn().mockResolvedValue(null) }));
+jest.mock('../utils/vintageProfile', () => ({ ensurePendingVintageProfile: jest.fn() }));
+jest.mock('../models/Cellar', () => ({ findById: jest.fn(), findOne: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ findById: jest.fn() }));
+jest.mock('../models/Rack', () => ({ findOne: jest.fn(), updateMany: jest.fn() }));
+jest.mock('../models/CellarLayout', () => ({ findOne: jest.fn() }));
+jest.mock('../models/Country', () => ({}));
+jest.mock('../models/Region', () => ({}));
+jest.mock('../models/Grape', () => ({}));
+jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
+jest.mock('../models/PriceTrackingRequest', () => ({}));
+jest.mock('../models/PriceTrackingSkip', () => ({}));
+jest.mock('../models/BottleImage', () => ({ findOne: jest.fn(), findById: jest.fn() }));
+jest.mock('../models/WineRequest', () => ({}));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn(), find: jest.fn() }));
+
+const Bottle = require('../models/Bottle');
+const Cellar = require('../models/Cellar');
+const { moveBottleToCellar } = require('../services/rackOps');
+const { logAudit } = require('../services/audit');
+// Loaded here, not inside app(): the router is the heaviest module in the
+// tree, and requiring it inside the first test's 5 s budget times out under a
+// parallel suite run.
+const bottlesRouter = require('./bottles');
+
+jest.setTimeout(20000);
+
+const USER = '64b000000000000000000001';
+const OTHER = '64b000000000000000000002';
+const SRC = '64b0000000000000000000c1';
+const FOREIGN = '64b0000000000000000000c2';
+const DEST = '64b0000000000000000000d1';
+const B = (n) => `64b0000000000000000000b${n}`;
+
+const CELLARS = {
+  [SRC]:     { _id: SRC, user: USER, name: 'Storage', deletedAt: null, members: [] },
+  [FOREIGN]: { _id: FOREIGN, user: OTHER, name: 'Not mine', deletedAt: null, members: [] },
+  [DEST]:    { _id: DEST, user: USER, name: 'Home', deletedAt: null, members: [] },
+};
+
+function app() {
+  const a = express();
+  a.use(express.json());
+  a.use('/api/bottles', bottlesRouter);
+  return a;
+}
+
+function postJson(a, path, body) {
+  const token = jwt.sign({ id: USER, roles: ['user'] }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  const payload = JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(a);
+    server.listen(0, () => {
+      const req = http.request({
+        port: server.address().port, path, method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) },
+      }, (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => { server.close(); resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) }); });
+      });
+      req.on('error', (e) => { server.close(); reject(e); });
+      req.end(payload);
+    });
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Cellar.findOne.mockResolvedValue(CELLARS[DEST]);
+  Cellar.findById.mockImplementation(async (id) => CELLARS[String(id)] || null);
+  moveBottleToCellar.mockResolvedValue({ bottle: {} });
+  Bottle.find.mockResolvedValue([]);
+});
+
+describe('POST /api/bottles/bulk-move', () => {
+  test('moves the owned active bottles, skips the rest with a reason, and reports both', async () => {
+    Bottle.find.mockResolvedValue([
+      { _id: B(1), cellar: SRC, status: 'active' },
+      { _id: B(2), cellar: SRC, status: 'active' },
+      { _id: B(3), cellar: FOREIGN, status: 'active' }, // a cellar the caller does not own
+      { _id: B(4), cellar: SRC, status: 'drank' },      // consumed
+      { _id: B(5), cellar: DEST, status: 'active' },    // already in the destination
+      // B(6) does not exist
+    ]);
+
+    const { status, body } = await postJson(app(), '/api/bottles/bulk-move', {
+      bottleIds: [B(1), B(2), B(3), B(4), B(5), B(6), B(1)], // duplicate B(1) collapses
+      toCellarId: DEST,
+    });
+
+    expect(status).toBe(200);
+    expect(body.moved).toBe(2);
+    expect(body.movedIds).toEqual([B(1), B(2)]);
+    expect(body.skipped).toEqual([
+      { id: B(3), reason: 'not_found' },
+      { id: B(4), reason: 'not_active' },
+      { id: B(5), reason: 'same_cellar' },
+      { id: B(6), reason: 'not_found' },
+    ]);
+    expect(body.toCellar).toEqual({ _id: DEST, name: 'Home' });
+    expect(moveBottleToCellar).toHaveBeenCalledTimes(2);
+    expect(moveBottleToCellar).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: B(1) }), CELLARS[SRC], CELLARS[DEST], expect.anything(),
+    );
+    // Destination must be an active cellar the caller OWNS.
+    expect(Cellar.findOne).toHaveBeenCalledWith(expect.objectContaining({ user: USER, deletedAt: null }));
+    // One summary audit row on top of the per-bottle rows the helper writes.
+    expect(logAudit).toHaveBeenCalledWith(
+      expect.anything(), 'bottle.bulk_move', expect.objectContaining({ type: 'cellar' }),
+      { requested: 6, moved: 2, skipped: 4 },
+    );
+  });
+
+  test('a per-bottle conflict from the shared helper is reported, not fatal', async () => {
+    Bottle.find.mockResolvedValue([
+      { _id: B(1), cellar: SRC, status: 'active' },
+      { _id: B(2), cellar: SRC, status: 'active' },
+    ]);
+    moveBottleToCellar
+      .mockResolvedValueOnce({ error: { status: 409, message: 'modified', code: 'conflict' } })
+      .mockResolvedValueOnce({ bottle: {} });
+
+    const { status, body } = await postJson(app(), '/api/bottles/bulk-move', { bottleIds: [B(1), B(2)], toCellarId: DEST });
+
+    expect(status).toBe(200);
+    expect(body.moved).toBe(1);
+    expect(body.skipped).toEqual([{ id: B(1), reason: 'conflict' }]);
+  });
+
+  test('rejects an empty list, a bad id, a list over the cap, and an unknown destination', async () => {
+    let res = await postJson(app(), '/api/bottles/bulk-move', { bottleIds: [], toCellarId: DEST });
+    expect(res.status).toBe(400);
+
+    res = await postJson(app(), '/api/bottles/bulk-move', { bottleIds: ['nope'], toCellarId: DEST });
+    expect(res.status).toBe(400);
+
+    res = await postJson(app(), '/api/bottles/bulk-move', { bottleIds: Array.from({ length: 501 }, () => B(1)), toCellarId: DEST });
+    expect(res.status).toBe(400);
+
+    res = await postJson(app(), '/api/bottles/bulk-move', { bottleIds: [B(1)], toCellarId: 'nope' });
+    expect(res.status).toBe(400);
+
+    Cellar.findOne.mockResolvedValue(null);
+    res = await postJson(app(), '/api/bottles/bulk-move', { bottleIds: [B(1)], toCellarId: DEST });
+    expect(res.status).toBe(404);
+
+    expect(moveBottleToCellar).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -830,6 +830,95 @@ router.post('/:id/move', requireBottleAccess('owner'), async (req, res) => {
   }
 });
 
+// POST /api/bottles/bulk-move - Move MANY active bottles to another cellar you
+// own, in ONE request. Support ticket 6a9949e3 (2026-09-03): a delivery of
+// many bottles had been logged in a storage cellar and needed to go home —
+// and one-at-a-time was the only way. Same rules and mechanics as the single
+// move above, applied per bottle through the shared
+// services/rackOps.moveBottleToCellar: the SOURCE cellar must be owned (not
+// merely editable), active bottles only, each bottle lands unplaced, dual
+// audit per bottle. Partial success is reported, not hidden: every bottle
+// that could not be moved comes back in `skipped` with a reason, and the ones
+// that could are moved regardless.
+//
+// Body:     { bottleIds: string[] (1..BULK_MOVE_MAX), toCellarId }
+// Response: { moved, movedIds: string[], skipped: [{ id, reason }], toCellar: { _id, name } }
+//   reason ∈ 'not_found' (unknown, or not a cellar you own — same disclosure
+//   as the single route), 'same_cellar', 'not_active', 'conflict'
+const BULK_MOVE_MAX = 500;
+router.post('/bulk-move', async (req, res) => {
+  try {
+    const { bottleIds, toCellarId } = req.body || {};
+    if (!Array.isArray(bottleIds) || bottleIds.length === 0) {
+      return res.status(400).json({ error: 'bottleIds must be a non-empty array' });
+    }
+    if (bottleIds.length > BULK_MOVE_MAX) {
+      return res.status(400).json({ error: `At most ${BULK_MOVE_MAX} bottles can be moved at once` });
+    }
+    if (!bottleIds.every((x) => typeof x === 'string' && mongoose.isValidObjectId(x))) {
+      return res.status(400).json({ error: 'bottleIds must be valid bottle ids' });
+    }
+    if (!toCellarId || !mongoose.isValidObjectId(String(toCellarId))) {
+      return res.status(400).json({ error: 'Invalid destination cellar' });
+    }
+
+    // Destination: an active cellar the user OWNS (same as the single move).
+    const destCellar = await Cellar.findOne({
+      _id: new mongoose.Types.ObjectId(String(toCellarId)),
+      user: req.user.id,
+      deletedAt: null,
+    });
+    if (!destCellar) return res.status(404).json({ error: 'Destination cellar not found' });
+
+    const ids = [...new Set(bottleIds.map(String))];
+    const bottles = await Bottle.find({ _id: { $in: ids.map((x) => new mongoose.Types.ObjectId(x)) } });
+    const byId = new Map(bottles.map((b) => [String(b._id), b]));
+
+    // Source cellars are resolved once each and ownership is checked per
+    // cellar, so a request mixing bottles from several cellars moves the ones
+    // the caller owns and skips the rest.
+    const cellarCache = new Map();
+    const sourceCellarFor = async (cellarId) => {
+      const key = String(cellarId);
+      if (!cellarCache.has(key)) cellarCache.set(key, await Cellar.findById(cellarId));
+      return cellarCache.get(key);
+    };
+
+    const movedIds = [];
+    const skipped = [];
+    for (const id of ids) {
+      const bottle = byId.get(id);
+      if (!bottle) { skipped.push({ id, reason: 'not_found' }); continue; }
+      const sourceCellar = await sourceCellarFor(bottle.cellar);
+      if (!sourceCellar || getCellarRole(sourceCellar, req.user.id) !== 'owner') {
+        skipped.push({ id, reason: 'not_found' });
+        continue;
+      }
+      if (String(sourceCellar._id) === String(destCellar._id)) { skipped.push({ id, reason: 'same_cellar' }); continue; }
+      if (bottle.status !== 'active') { skipped.push({ id, reason: 'not_active' }); continue; }
+      const result = await moveBottleToCellar(bottle, sourceCellar, destCellar, req);
+      if (result.error) { skipped.push({ id, reason: result.error.code || 'error' }); continue; }
+      movedIds.push(id);
+    }
+
+    // One summary row on top of the per-bottle move.out / move.in rows, so the
+    // audit log shows "moved 120 bottles" as one act, not 240 lines to count.
+    logAudit(req, 'bottle.bulk_move',
+      { type: 'cellar', id: destCellar._id, cellarId: destCellar._id },
+      { requested: ids.length, moved: movedIds.length, skipped: skipped.length });
+
+    res.json({
+      moved: movedIds.length,
+      movedIds,
+      skipped,
+      toCellar: { _id: destCellar._id, name: destCellar.name },
+    });
+  } catch (error) {
+    console.error('Bulk move error:', error);
+    res.status(500).json({ error: 'Failed to move bottles' });
+  }
+});
+
 // A consumed bottle can be moved back to the cellar only within a 2-day
 // window of being removed — restore is an "undo an accidental log", not a way
 // to resurrect a bottle drunk long ago. The window (RESTORE_WINDOW_MS) is

--- a/frontend/src/api/bottles.js
+++ b/frontend/src/api/bottles.js
@@ -80,6 +80,15 @@ export const moveBottle = (apiFetch, id, toCellarId) =>
     body: JSON.stringify({ toCellarId }),
   });
 
+// Move MANY bottles to another cellar you own in ONE request (POST
+// /api/bottles/bulk-move). Partial success comes back in `skipped`.
+export const bulkMoveBottles = (apiFetch, bottleIds, toCellarId) =>
+  apiFetch('/api/bottles/bulk-move', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ bottleIds, toCellarId }),
+  });
+
 export const updateConsumedRating = (apiFetch, id, data) =>
   apiFetch(`/api/bottles/${id}/consumed-rating`, {
     method: 'PUT',

--- a/frontend/src/components/BottleCard.css
+++ b/frontend/src/components/BottleCard.css
@@ -471,3 +471,37 @@
   color: var(--color-danger);
   border: 1px solid var(--color-danger-border);
 }
+
+/* ── Select mode (bulk "Move to cellar") ──
+   The whole card is the toggle; this box only SHOWS the state. In the grid it
+   sits over the image's top-left corner (the card is position: relative). */
+.bottle-select-box {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  line-height: 1;
+  color: var(--color-btn-primary-text);
+}
+.bottle-select-box--on {
+  background: var(--color-btn-primary-bg);
+  border-color: var(--color-btn-primary-bg);
+}
+.bottle-card.is-selected,
+.bottle-grid-card.is-selected {
+  border-color: var(--color-primary);
+  box-shadow: inset 0 0 0 2px var(--color-primary);
+}
+.bottle-grid-card .bottle-select-box {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 2;
+  box-shadow: var(--shadow-card);
+}

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -20,7 +20,7 @@ const MATURITY_LABELS = {
  * Renders a single bottle in either list or card (grid) view.
  * Props: bottle, rackMap, cellarId, viewMode ('list' | 'card')
  */
-function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick, showCellarBadge = false, compact = false, rackKnown = false, showNotes = false }) {
+function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onClick, showCellarBadge = false, compact = false, rackKnown = false, showNotes = false, selectable = false, selected = false, onToggleSelect }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -53,9 +53,23 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
   // may carry different reservations (same reasoning as the rack badge).
   const reserved = !isGroup && bottle.status === 'active' && isReserved(bottle);
 
-  // onClick overrides navigation — used to expand a collapsed group instead.
-  const handleClick = onClick || (() => navigate(`/cellars/${cellarId}/bottles/${bottle._id}`));
-  const handleKey = e => e.key === 'Enter' && handleClick();
+  // Select mode (bulk "Move to cellar") turns the whole card into a toggle: a
+  // click, Enter or Space flips the selection instead of navigating or
+  // expanding. Otherwise onClick overrides navigation — used to expand a
+  // collapsed group instead.
+  const handleClick = selectable
+    ? () => onToggleSelect?.()
+    : (onClick || (() => navigate(`/cellars/${cellarId}/bottles/${bottle._id}`)));
+  const handleKey = e => {
+    if (e.key === 'Enter') handleClick();
+    else if (selectable && e.key === ' ') { e.preventDefault(); handleClick(); }
+  };
+  const selectBox = selectable ? (
+    <span className={`bottle-select-box${selected ? ' bottle-select-box--on' : ''}`} aria-hidden="true">
+      {selected ? '✓' : ''}
+    </span>
+  ) : null;
+  const selectClasses = selectable ? ` is-selectable${selected ? ' is-selected' : ''}` : '';
 
   // Opt-in personal-note preview (list view only). Occasion ("Gift from Anna")
   // leads, then the first line of the tasting notes; CSS clamps to one line.
@@ -74,13 +88,15 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
   if (viewMode === 'card') {
     return (
       <div
-        className={`bottle-grid-card${isGroup ? ' bottle-grid-card--stacked' : ''}`}
+        className={`bottle-grid-card${isGroup ? ' bottle-grid-card--stacked' : ''}${selectClasses}`}
         onClick={handleClick}
         role="button"
         tabIndex={0}
         onKeyDown={handleKey}
+        aria-pressed={selectable ? selected : undefined}
         title={isGroup ? t('bottleCard.groupTooltip', { count: groupCount }) : undefined}
       >
+        {selectBox}
         {isGroup && <span className="bottle-count-badge">×{groupCount}</span>}
         <div className="bottle-grid-image-wrap">
           {imgSrc ? (
@@ -168,13 +184,15 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
   // list view (default)
   return (
     <div
-      className={`bottle-card${isGroup ? ' bottle-card--stacked' : ''}${compact ? ' bottle-card--compact' : ''}`}
+      className={`bottle-card${isGroup ? ' bottle-card--stacked' : ''}${compact ? ' bottle-card--compact' : ''}${selectClasses}`}
       onClick={handleClick}
       role="button"
       tabIndex={0}
       onKeyDown={handleKey}
+      aria-pressed={selectable ? selected : undefined}
       title={isGroup ? t('bottleCard.groupTooltip', { count: groupCount }) : undefined}
     >
+      {selectBox}
       {imgSrc ? (
         <div className="bottle-img-wrap">
           <AuthImage
@@ -258,14 +276,14 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
 // search keystroke re-renders the page — without memo, hundreds of cards
 // re-render per keystroke even though their props are unchanged.
 //
-// onClick is excluded from the comparison: callers pass inline arrows
-// (`onClick={() => toggleGroup(item.key)}`), whose identity changes every
-// parent render and would defeat the memo for exactly the grouped cards it
-// exists for. This is safe because every current onClick closes only over
-// values derived from the OTHER compared props (the bottle/group item) — if a
-// future caller closes over unrelated state, that handler must be stabilized
-// with useCallback instead.
-const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount', 'showCellarBadge', 'compact', 'rackKnown', 'showNotes'];
+// onClick and onToggleSelect are excluded from the comparison: callers pass
+// inline arrows (`onClick={() => toggleGroup(item.key)}`), whose identity
+// changes every parent render and would defeat the memo for exactly the
+// grouped cards it exists for. This is safe because every current handler
+// closes only over values derived from the OTHER compared props (the
+// bottle/group item) plus functional setState — if a future caller closes over
+// unrelated state, that handler must be stabilized with useCallback instead.
+const COMPARED_PROPS = ['bottle', 'rackMap', 'cellarId', 'viewMode', 'groupCount', 'showCellarBadge', 'compact', 'rackKnown', 'showNotes', 'selectable', 'selected'];
 export default memo(BottleCard, (prev, next) =>
   COMPARED_PROPS.every(key => prev[key] === next[key])
 );

--- a/frontend/src/components/MoveBottleModal.js
+++ b/frontend/src/components/MoveBottleModal.js
@@ -2,22 +2,31 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import { listCellars } from '../api/cellars';
-import { moveBottle } from '../api/bottles';
+import { moveBottle, bulkMoveBottles } from '../api/bottles';
 import Modal from './Modal';
 
 /**
- * Move a single active bottle to another cellar the user OWNS (v1). The bottle's
- * data and history are kept; it arrives unplaced in the destination. Calls
- * onMoved(destCellarId) on success so the caller can navigate to the new home.
+ * Move an active bottle — or, with `bottleIds`, MANY at once — to another
+ * cellar the user OWNS (v1). The bottles' data and history are kept; they
+ * arrive unplaced in the destination. Calls onMoved() on success so the caller
+ * can refresh or navigate.
+ *
+ * Bulk mode (support ticket 6a9949e3, 2026-09-03: a whole delivery moved from
+ * a storage cellar to home): pass `bottleIds` instead of `bottleId`. One
+ * request moves them all; bottles the server could not move (already
+ * consumed, or not the user's to move) are reported, not hidden.
  */
-export default function MoveBottleModal({ bottleId, currentCellarId, wineLabel, onClose, onMoved }) {
+export default function MoveBottleModal({ bottleId, bottleIds, currentCellarId, wineLabel, onClose, onMoved }) {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
+  const bulk = Array.isArray(bottleIds);
+  const count = bulk ? bottleIds.length : 1;
   const [cellars, setCellars] = useState(null); // null while loading
   const [target, setTarget] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
   const [movedTo, setMovedTo] = useState(null); // dest cellar name once the move succeeds
+  const [outcome, setOutcome] = useState(null); // bulk: { moved, skipped }
 
   useEffect(() => {
     let active = true;
@@ -40,11 +49,14 @@ export default function MoveBottleModal({ bottleId, currentCellarId, wineLabel, 
     setSubmitting(true);
     setError('');
     try {
-      const res = await moveBottle(apiFetch, bottleId, target);
+      const res = bulk
+        ? await bulkMoveBottles(apiFetch, bottleIds, target)
+        : await moveBottle(apiFetch, bottleId, target);
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data.error || t('moveBottle.moveError'));
       // Show a brief confirmation instead of jumping to the destination cellar.
       const destName = (cellars || []).find((c) => String(c._id) === String(target))?.name || '';
+      if (bulk) setOutcome({ moved: data.moved ?? 0, skipped: (data.skipped || []).length });
       setMovedTo(destName);
     } catch (e) {
       setError(e.message || t('moveBottle.moveError'));
@@ -55,8 +67,17 @@ export default function MoveBottleModal({ bottleId, currentCellarId, wineLabel, 
   // Success view — confirm the move, then return to the cellar we came from.
   if (movedTo !== null) {
     return (
-      <Modal title={t('moveBottle.movedTitle')} onClose={onMoved} showClose trapFocus>
-        <p className="move-bottle-success">{t('moveBottle.movedInfo', { cellar: movedTo })}</p>
+      <Modal title={bulk ? t('moveBottle.movedManyTitle') : t('moveBottle.movedTitle')} onClose={onMoved} showClose trapFocus>
+        {bulk ? (
+          <>
+            <p className="move-bottle-success">{t('moveBottle.movedManyInfo', { count: outcome?.moved ?? 0, cellar: movedTo })}</p>
+            {outcome?.skipped > 0 && (
+              <p className="move-bottle-skipped" role="status">{t('moveBottle.skippedInfo', { count: outcome.skipped })}</p>
+            )}
+          </>
+        ) : (
+          <p className="move-bottle-success">{t('moveBottle.movedInfo', { cellar: movedTo })}</p>
+        )}
         <div className="modal-actions">
           <button type="button" className="btn btn-primary" onClick={onMoved}>
             {t('moveBottle.backToCellar')}
@@ -67,9 +88,9 @@ export default function MoveBottleModal({ bottleId, currentCellarId, wineLabel, 
   }
 
   return (
-    <Modal title={t('moveBottle.title')} onClose={onClose} showClose trapFocus>
+    <Modal title={bulk ? t('moveBottle.titleMany', { count }) : t('moveBottle.title')} onClose={onClose} showClose trapFocus>
       {wineLabel && <p className="move-bottle-wine"><strong>{wineLabel}</strong></p>}
-      <p>{t('moveBottle.intro')}</p>
+      <p>{bulk ? t('moveBottle.introMany') : t('moveBottle.intro')}</p>
 
       {cellars === null ? (
         <p className="loading">{t('moveBottle.loading')}</p>
@@ -104,7 +125,9 @@ export default function MoveBottleModal({ bottleId, currentCellarId, wineLabel, 
           onClick={handleMove}
           disabled={submitting || !target}
         >
-          {submitting ? t('moveBottle.moving') : t('moveBottle.moveButton')}
+          {submitting
+            ? t('moveBottle.moving')
+            : bulk ? t('moveBottle.moveManyButton', { count }) : t('moveBottle.moveButton')}
         </button>
       </div>
     </Modal>

--- a/frontend/src/components/MoveBottleModal.test.js
+++ b/frontend/src/components/MoveBottleModal.test.js
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('../api/bottles', () => ({
+  moveBottle: vi.fn(),
+  bulkMoveBottles: vi.fn(),
+}));
+vi.mock('../api/cellars', () => ({
+  listCellars: vi.fn(),
+}));
+
+// `t` must keep a stable identity across renders (see AddMoreBottlesModal.test.js).
+// Vars are appended so plural/interpolation calls stay observable.
+vi.mock('react-i18next', () => {
+  const t = (key, a, b) => {
+    const vars = b && typeof b === 'object' ? b : (a && typeof a === 'object' ? a : undefined);
+    return vars ? `${key}:${JSON.stringify(vars)}` : key;
+  };
+  return { useTranslation: () => ({ t }) };
+});
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: () => {} }));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ apiFetch }),
+}));
+
+const { moveBottle, bulkMoveBottles } = await import('../api/bottles');
+const { listCellars } = await import('../api/cellars');
+const MoveBottleModal = (await import('./MoveBottleModal')).default;
+
+const CELLARS = [
+  { _id: 'c1', name: 'Storage', userRole: 'owner' },
+  { _id: 'c2', name: 'Home', userRole: 'owner' },
+  { _id: 'c3', name: 'Shared with me', userRole: 'editor' },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listCellars.mockResolvedValue({ json: async () => ({ cellars: CELLARS }) });
+});
+
+describe('MoveBottleModal', () => {
+  test('bulk mode: offers only OTHER owned cellars, sends every id in one request, and reports what was skipped', async () => {
+    bulkMoveBottles.mockResolvedValue({
+      ok: true,
+      json: async () => ({ moved: 2, skipped: [{ id: 'b3', reason: 'not_active' }] }),
+    });
+    const onMoved = vi.fn();
+    render(<MoveBottleModal bottleIds={['b1', 'b2', 'b3']} currentCellarId="c1" onClose={() => {}} onMoved={onMoved} />);
+
+    expect(await screen.findByText('moveBottle.titleMany:{"count":3}')).toBeTruthy();
+    const select = await screen.findByRole('combobox');
+    expect(screen.getByRole('option', { name: 'Home' })).toBeTruthy();
+    expect(screen.queryByRole('option', { name: 'Storage' })).toBeNull();        // the current cellar
+    expect(screen.queryByRole('option', { name: 'Shared with me' })).toBeNull(); // not owned
+
+    fireEvent.change(select, { target: { value: 'c2' } });
+    fireEvent.click(screen.getByText('moveBottle.moveManyButton:{"count":3}'));
+
+    await waitFor(() => expect(bulkMoveBottles).toHaveBeenCalledWith(apiFetch, ['b1', 'b2', 'b3'], 'c2'));
+    expect(await screen.findByText('moveBottle.movedManyInfo:{"count":2,"cellar":"Home"}')).toBeTruthy();
+    expect(screen.getByText('moveBottle.skippedInfo:{"count":1}')).toBeTruthy();
+    expect(moveBottle).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('moveBottle.backToCellar'));
+    expect(onMoved).toHaveBeenCalledTimes(1);
+  });
+
+  test('single mode is unchanged: one moveBottle call, single-bottle wording', async () => {
+    moveBottle.mockResolvedValue({ ok: true, json: async () => ({ bottle: { _id: 'b1' } }) });
+    render(<MoveBottleModal bottleId="b1" currentCellarId="c1" onClose={() => {}} onMoved={() => {}} />);
+
+    expect(await screen.findByText('moveBottle.title')).toBeTruthy();
+    fireEvent.change(await screen.findByRole('combobox'), { target: { value: 'c2' } });
+    fireEvent.click(screen.getByText('moveBottle.moveButton'));
+
+    await waitFor(() => expect(moveBottle).toHaveBeenCalledWith(apiFetch, 'b1', 'c2'));
+    expect(await screen.findByText('moveBottle.movedInfo:{"cellar":"Home"}')).toBeTruthy();
+    expect(bulkMoveBottles).not.toHaveBeenCalled();
+  });
+
+  test('a server error is shown and the modal stays open', async () => {
+    bulkMoveBottles.mockResolvedValue({ ok: false, json: async () => ({ error: 'Destination cellar not found' }) });
+    render(<MoveBottleModal bottleIds={['b1']} currentCellarId="c1" onClose={() => {}} onMoved={() => {}} />);
+
+    fireEvent.change(await screen.findByRole('combobox'), { target: { value: 'c2' } });
+    fireEvent.click(screen.getByText('moveBottle.moveManyButton:{"count":1}'));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Destination cellar not found');
+    expect(screen.getByText('moveBottle.titleMany:{"count":1}')).toBeTruthy();
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -759,6 +759,12 @@
     "groupBottleCount_one": "{{count}} bottle",
     "groupBottleCount_other": "{{count}} bottles",
     "collapseGroup": "Collapse ▲",
+    "selectBottles": "Select",
+    "selectBottlesTitle": "Select bottles to move to another cellar",
+    "selectedCount_one": "{{count}} bottle selected",
+    "selectedCount_other": "{{count}} bottles selected",
+    "selectAllLoaded": "Select all ({{count}})",
+    "bulkBarAria": "Actions for the selected bottles",
     "deleteWillDelete": "This will delete <strong>{{name}}</strong> and all its racks."
   },
   "addBottle": {
@@ -1314,6 +1320,7 @@
       "bottleDelete": "Deleted bottle",
       "bottleMoveOut": "Moved bottle out",
       "bottleMoveIn": "Moved bottle in",
+      "bottleBulkMove": "Moved bottles in bulk",
       "cellarDelete": "Deleted cellar",
       "cellarShareAdd": "Shared cellar",
       "cellarShareUpdate": "Changed share role",
@@ -1321,7 +1328,8 @@
     },
     "anonymous": "anonymous",
     "sharedAs": "{{user}} as {{role}}",
-    "roleChanged": "Role changed: {{from}} → {{to}}"
+    "roleChanged": "Role changed: {{from}} → {{to}}",
+    "bulkMoveDetail": "{{moved}} of {{requested}} bottles moved"
   },
   "moveBottle": {
     "action": "Move to another cellar",
@@ -1338,7 +1346,18 @@
     "moveError": "Couldn't move the bottle. Please try again.",
     "movedTitle": "Bottle moved",
     "movedInfo": "This bottle was moved to {{cellar}}.",
-    "backToCellar": "Back to cellar"
+    "backToCellar": "Back to cellar",
+    "moveSelected": "Move to cellar…",
+    "titleMany_one": "Move {{count}} bottle to another cellar",
+    "titleMany_other": "Move {{count}} bottles to another cellar",
+    "introMany": "Choose a cellar to move the selected bottles to. All their details and history are kept — they will arrive unplaced.",
+    "moveManyButton_one": "Move {{count}} bottle",
+    "moveManyButton_other": "Move {{count}} bottles",
+    "movedManyTitle": "Bottles moved",
+    "movedManyInfo_one": "{{count}} bottle was moved to {{cellar}}.",
+    "movedManyInfo_other": "{{count}} bottles were moved to {{cellar}}.",
+    "skippedInfo_one": "{{count}} bottle could not be moved — it is already consumed, or not yours to move.",
+    "skippedInfo_other": "{{count}} bottles could not be moved — they are already consumed, or not yours to move."
   },
   "admin": {
     "requests": {

--- a/frontend/src/pages/CellarAudit.js
+++ b/frontend/src/pages/CellarAudit.js
@@ -19,6 +19,7 @@ const ACTION_LABEL_KEYS = {
   'bottle.delete':       'cellarAudit.actions.bottleDelete',
   'bottle.move.out':     'cellarAudit.actions.bottleMoveOut',
   'bottle.move.in':      'cellarAudit.actions.bottleMoveIn',
+  'bottle.bulk_move':    'cellarAudit.actions.bottleBulkMove',
   'cellar.delete':       'cellarAudit.actions.cellarDelete',
   'cellar.share.add':    'cellarAudit.actions.cellarShareAdd',
   'cellar.share.update': 'cellarAudit.actions.cellarShareUpdate',
@@ -32,6 +33,7 @@ const ACTION_ICONS = {
   'bottle.delete':       '🗑️',
   'bottle.move.out':     '📤',
   'bottle.move.in':      '📥',
+  'bottle.bulk_move':    '📦',
   'cellar.delete':       '🗑️',
   'cellar.share.add':    '🔗',
   'cellar.share.update': '🔄',
@@ -61,6 +63,10 @@ function formatDetail(action, detail, t) {
     return action === 'bottle.move.out'
       ? `${wine}→ ${detail.toCellarName || '—'}`
       : `${wine}← ${detail.fromCellarName || '—'}`;
+  }
+  // The one summary row a bulk move writes on top of its per-bottle rows.
+  if (action === 'bottle.bulk_move') {
+    return t('cellarAudit.bulkMoveDetail', { moved: detail.moved ?? 0, requested: detail.requested ?? 0 });
   }
   if (action === 'cellar.share.add') {
     return t('cellarAudit.sharedAs', { user: detail.sharedWith, role: detail.role });

--- a/frontend/src/pages/CellarDetail.css
+++ b/frontend/src/pages/CellarDetail.css
@@ -1008,3 +1008,33 @@
     gap: 0.5rem;
   }
 }
+
+/* ── Bulk selection (select mode → "Move to cellar") ── */
+.select-toggle-btn {
+  width: auto;
+  padding: 0 0.6rem;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  margin-right: auto;
+}
+
+.bulk-bar {
+  position: sticky;
+  bottom: calc(var(--bottom-nav-height, 0px) + env(safe-area-inset-bottom, 0px));
+  z-index: 5;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+}
+
+.bulk-bar-count {
+  font-weight: 600;
+  margin-right: auto;
+}

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -27,6 +27,7 @@ const ShareCellarModal = lazy(() => import('../components/ShareCellarModal'));
 const EditCellarModal = lazy(() => import('../components/EditCellarModal').then(m => ({ default: m.EditCellarModal })));
 const ColorPickerModal = lazy(() => import('../components/ColorPickerModal').then(m => ({ default: m.ColorPickerModal })));
 const DeleteCellarModal = lazy(() => import('../components/DeleteCellarModal').then(m => ({ default: m.DeleteCellarModal })));
+const MoveBottleModal = lazy(() => import('../components/MoveBottleModal'));
 
 const BOTTLES_PER_PAGE = 30;
 
@@ -678,6 +679,8 @@ function CellarDetail() {
               onLoadMore={loadMore}
               multi={dataIsMulti}
               rackKnown={!dataIsMulti && hasRacks === true}
+              canBulkMove={!dataIsMulti && cellar?.userRole === 'owner'}
+              onBottlesMoved={() => { fetchCellarData(0); fetchStatistics(); fetchRacks(); }}
             />
           )}
         </div>
@@ -736,7 +739,9 @@ function CellarDetail() {
 // `multi` = cross-cellar view: `bottles` is a flat list (no grouping), each item
 // carries its own `cellar` id + `cellarName` so it links to and is badged with
 // the right cellar.
-function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore, multi = false, rackKnown = false }) {
+// `canBulkMove` (owner of this one cellar) enables select mode → "Move to
+// cellar"; `onBottlesMoved` refreshes the parent's list, stats and racks after.
+function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore, multi = false, rackKnown = false, canBulkMove = false, onBottlesMoved }) {
   const { t } = useTranslation();
   const [viewMode, setViewMode] = useState(() => {
     try { return localStorage.getItem('cellarion_bottle_view') || 'list'; } catch { return 'list'; }
@@ -748,6 +753,33 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
     try { return localStorage.getItem('cellarion_bottle_notes') === '1'; } catch { return false; }
   });
   const [expandedGroups, setExpandedGroups] = useState(() => new Set());
+
+  // ── Multi-select → "Move to cellar" (support ticket 6a9949e3, 2026-09-03:
+  // a whole delivery logged in a storage cellar had to go home one bottle at
+  // a time). Owner-only and single-cellar — the parent gates canBulkMove. A
+  // collapsed group toggles all of its bottles at once, which is exactly the
+  // delivery case; expand the group to pick individual bottles.
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+  const [showBulkMove, setShowBulkMove] = useState(false);
+  const idsOf = (item) => (Array.isArray(item?.bottles) ? item.bottles.map(b => b._id) : [item._id]);
+  const allLoadedIds = bottles.flatMap(idsOf);
+  const isSelected = (ids) => ids.length > 0 && ids.every(x => selectedIds.has(x));
+  const toggleIds = (ids) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      const allOn = ids.every(x => next.has(x));
+      ids.forEach(x => (allOn ? next.delete(x) : next.add(x)));
+      return next;
+    });
+  };
+  const exitSelect = () => { setSelectMode(false); setSelectedIds(new Set()); };
+  // Leaving the owner/single-cellar case (scope widened, cellar changed) ends
+  // select mode rather than leaving checked cards nothing can act on.
+  useEffect(() => {
+    if (!canBulkMove) { setSelectMode(false); setSelectedIds(new Set()); }
+  }, [canBulkMove, cellarId]);
+  const selectableNow = selectMode && canBulkMove && viewMode !== 'table';
 
   const setView = (mode) => {
     setViewMode(mode);
@@ -782,6 +814,18 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
   return (
     <>
       <div className="bottles-view-toggle">
+        {canBulkMove && viewMode !== 'table' && (
+          <button
+            type="button"
+            className={`view-toggle-btn select-toggle-btn ${selectMode ? 'active' : ''}`}
+            onClick={() => (selectMode ? exitSelect() : setSelectMode(true))}
+            aria-pressed={selectMode}
+            title={t('cellarDetail.selectBottlesTitle')}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><polyline points="7 12 11 16 17 8"/></svg>
+            {t('cellarDetail.selectBottles')}
+          </button>
+        )}
         {viewMode === 'list' && (
           <button
             className={`view-toggle-btn notes-toggle-btn ${showNotes ? 'active' : ''}`}
@@ -831,6 +875,33 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
         </button>
       </div>
 
+      {selectableNow && (
+        <div className="bulk-bar" role="region" aria-label={t('cellarDetail.bulkBarAria')}>
+          <span className="bulk-bar-count" aria-live="polite">
+            {t('cellarDetail.selectedCount', { count: selectedIds.size })}
+          </span>
+          <button
+            type="button"
+            className="btn btn-secondary btn-small"
+            onClick={() => setSelectedIds(new Set(allLoadedIds))}
+            disabled={allLoadedIds.length === 0 || isSelected(allLoadedIds)}
+          >
+            {t('cellarDetail.selectAllLoaded', { count: allLoadedIds.length })}
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary btn-small"
+            onClick={() => setShowBulkMove(true)}
+            disabled={selectedIds.size === 0}
+          >
+            {t('moveBottle.moveSelected')}
+          </button>
+          <button type="button" className="btn btn-secondary btn-small" onClick={exitSelect}>
+            {t('common.cancel')}
+          </button>
+        </div>
+      )}
+
       {viewMode === 'table' ? (
         <Suspense fallback={<div className="load-more-wrap">{t('common.loading')}</div>}>
           <AnalyticsTable cellarId={multi ? null : cellarId} />
@@ -860,7 +931,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
             const rep = item.bottles[0];
             if (item.count === 1) {
               return (
-                <BottleCard key={rep._id} bottle={rep} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} showNotes={notesOn} />
+                <BottleCard key={rep._id} bottle={rep} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} showNotes={notesOn} selectable={selectableNow} selected={isSelected(idsOf(item))} onToggleSelect={() => toggleIds(idsOf(item))} />
               );
             }
             if (!expandedGroups.has(item.key)) {
@@ -873,6 +944,9 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                   viewMode={viewMode}
                   groupCount={item.count}
                   onClick={() => toggleGroup(item.key)}
+                  selectable={selectableNow}
+                  selected={isSelected(idsOf(item))}
+                  onToggleSelect={() => toggleIds(idsOf(item))}
                   compact={compact}
                   rackKnown={rackKnown}
                   showNotes={notesOn}
@@ -889,14 +963,14 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
                   </button>
                 </div>
                 {item.bottles.map(b => (
-                  <BottleCard key={b._id} bottle={b} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} showNotes={notesOn} />
+                  <BottleCard key={b._id} bottle={b} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} showNotes={notesOn} selectable={selectableNow} selected={isSelected([b._id])} onToggleSelect={() => toggleIds([b._id])} />
                 ))}
               </Fragment>
             );
           }
           // Defensive fallback: a plain bottle item (responses are always grouped)
           return (
-            <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} showNotes={notesOn} />
+            <BottleCard key={item._id} bottle={item} rackMap={rackMap} cellarId={cellarId} viewMode={viewMode} compact={compact} rackKnown={rackKnown} showNotes={notesOn} selectable={selectableNow} selected={isSelected([item._id])} onToggleSelect={() => toggleIds([item._id])} />
           );
         })}
       </div>
@@ -914,6 +988,17 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
       )}
       </>
       )}
+
+      <Suspense fallback={null}>
+        {showBulkMove && (
+          <MoveBottleModal
+            bottleIds={[...selectedIds]}
+            currentCellarId={cellarId}
+            onClose={() => setShowBulkMove(false)}
+            onMoved={() => { setShowBulkMove(false); exitSelect(); onBottlesMoved?.(); }}
+          />
+        )}
+      </Suspense>
     </>
   );
 }


### PR DESCRIPTION
## What

Support ticket 6a9949e3 (2026-09-03): a delivery of many bottles had been logged in a storage cellar and needed to go home. Moving them one at a time was the only way. The reply promised multi-select with a "Move to cellar" action.

- **`POST /api/bottles/bulk-move`** — `{ bottleIds: string[] (≤500), toCellarId }`. Same rules and mechanics as the single move, applied per bottle through the shared `rackOps.moveBottleToCellar` (owner-only source, active bottles only, lands unplaced, dual audit per bottle), plus one summary audit row. Partial success is reported, not hidden: every bottle that could not be moved comes back in `skipped` with a reason (`not_found`, `same_cellar`, `not_active`, `conflict`).
- **Cellar view** — a "Select" toggle (owner of this cellar, single-cellar scope, list and card views) turns the cards into toggles; a sticky bar shows the count, "Select all (n)", and "Move to cellar…", which reuses `MoveBottleModal` in bulk mode. A collapsed group selects all its bottles at once; expand it to pick individually.
- **Cellar audit log** labels the summary row.

## Tests

- New: `routes/bottles.bulkMove.test.js` (3 tests: partial success + reasons, helper conflict, validation) and `components/MoveBottleModal.test.js` (bulk mode, single mode unchanged, error stays open).
- Backend suites run in node:24-alpine: green. Frontend: 74 files / 1130 tests green.
- Not smoke-tested in Docker Compose locally. No docker-compose.prod.yml changes; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
