### PR TITLE
fix(cellar): a stacked card can be expanded in select mode

### DIFF
--- a/frontend/src/components/BottleCard.css
+++ b/frontend/src/components/BottleCard.css
@@ -517,3 +517,40 @@
 .bottle-grid-card.is-selected {
   background: var(--color-primary-light);
 }
+
+/* Select mode on a stacked card: the ⊕ is a real button that expands the
+   group (a tap on the card itself toggles all its bottles). In the grid the
+   count badge moves right to make room for the select box beside it. */
+.bottle-chevron--btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-surface);
+  color: var(--color-primary);
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+.bottle-chevron--btn:hover { background: var(--color-primary-light); }
+.bottle-grid-expand {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-surface);
+  color: var(--color-primary);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: var(--shadow-card);
+}
+.bottle-grid-card.is-selectable .bottle-count-badge { left: 38px; }

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -99,6 +99,14 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
     if (swallowClick.current) { swallowClick.current = false; e.preventDefault(); return; }
     handleClick();
   };
+  // In select mode a stacked card toggles ALL its bottles, so the ⊕ becomes a
+  // real button that expands the group instead — the only way to pick one
+  // bottle out of five (Johan, 2026-09-03, from the phone). It stops
+  // propagation so the card's own click / keydown handlers don't also flip
+  // the selection.
+  const canExpandInSelect = selectable && isGroup && typeof onClick === 'function';
+  const expandGroup = (e) => { e.stopPropagation(); onClick(); };
+  const stopKeys = (e) => e.stopPropagation();
   const pressHandlers = onLongPress ? {
     onPointerDown: startPress,
     onPointerMove: movePress,
@@ -137,6 +145,16 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
       >
         {selectBox}
         {isGroup && <span className="bottle-count-badge">×{groupCount}</span>}
+        {canExpandInSelect && (
+          <button
+            type="button"
+            className="bottle-grid-expand"
+            aria-label={t('bottleCard.expandGroup')}
+            title={t('bottleCard.expandGroup')}
+            onClick={expandGroup}
+            onKeyDown={stopKeys}
+          >⊕</button>
+        )}
         <div className="bottle-grid-image-wrap">
           {imgSrc ? (
             <>
@@ -307,7 +325,18 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
         </div>
       </div>
 
-      <span className="bottle-chevron" aria-hidden="true">{isGroup ? '⊕' : '›'}</span>
+      {canExpandInSelect ? (
+        <button
+          type="button"
+          className="bottle-chevron bottle-chevron--btn"
+          aria-label={t('bottleCard.expandGroup')}
+          title={t('bottleCard.expandGroup')}
+          onClick={expandGroup}
+          onKeyDown={stopKeys}
+        >⊕</button>
+      ) : (
+        <span className="bottle-chevron" aria-hidden="true">{isGroup ? '⊕' : '›'}</span>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/BottleCard.test.js
+++ b/frontend/src/components/BottleCard.test.js
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key) => key }) }));
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ user: null }) }));
+vi.mock('./AuthImage', () => ({ default: ({ src, alt }) => <img src={src} alt={alt} /> }));
+
+const BottleCard = (await import('./BottleCard')).default;
+
+const BOTTLE = {
+  _id: 'b1', status: 'active', vintage: '2013',
+  wineDefinition: { _id: 'w1', name: 'Barolo Albe', producer: 'G.D. Vajra', type: 'red' },
+};
+
+const renderCard = (props = {}) => render(
+  <MemoryRouter>
+    <BottleCard bottle={BOTTLE} rackMap={new Map()} cellarId="c1" viewMode="list" {...props} />
+  </MemoryRouter>,
+);
+
+/**
+ * A stacked card (several identical bottles) in select mode: a tap toggles the
+ * whole group, and the ⊕ is a real button that expands it instead — the only
+ * way to pick one bottle out of five (Johan, 2026-09-03, from the phone).
+ */
+describe('BottleCard stacked card in select mode', () => {
+  test('a tap toggles the selection; the expand button opens the group without touching it', () => {
+    const onToggleSelect = vi.fn();
+    const onClick = vi.fn(); // the parent's toggleGroup
+    renderCard({ groupCount: 5, onClick, selectable: true, selected: false, onToggleSelect });
+
+    fireEvent.click(screen.getByText('Barolo Albe'));
+    expect(onToggleSelect).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+
+    const expand = screen.getByLabelText('bottleCard.expandGroup');
+    fireEvent.click(expand);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onToggleSelect).toHaveBeenCalledTimes(1); // unchanged — the click did not bubble into the card
+
+    fireEvent.keyDown(expand, { key: 'Enter' });
+    expect(onToggleSelect).toHaveBeenCalledTimes(1); // keyboard on the button never reaches the card
+  });
+
+  test('outside select mode the whole card still expands the group, with no extra button', () => {
+    const onClick = vi.fn();
+    renderCard({ groupCount: 5, onClick });
+    expect(screen.queryByLabelText('bottleCard.expandGroup')).toBeNull();
+    fireEvent.click(screen.getByText('Barolo Albe'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('a single bottle in select mode has no expand button', () => {
+    renderCard({ selectable: true, onToggleSelect: vi.fn() });
+    expect(screen.queryByLabelText('bottleCard.expandGroup')).toBeNull();
+  });
+
+  test('the grid view offers the same expand button on a stacked card', () => {
+    const onClick = vi.fn();
+    const onToggleSelect = vi.fn();
+    renderCard({ viewMode: 'card', groupCount: 3, onClick, selectable: true, onToggleSelect });
+    fireEvent.click(screen.getByLabelText('bottleCard.expandGroup'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onToggleSelect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4250,6 +4250,7 @@
     "pendingReview": "Pending review",
     "openBadge": "{{glasses}} gl · {{days}}d",
     "groupTooltip": "{{count}} identical bottles — click to expand",
+    "expandGroup": "Show the bottles in this group",
     "yourWindow": "your window",
     "yourWindowTooltip": "Based on your own drink window for this bottle",
     "unplaced": "Unplaced",


### PR DESCRIPTION
## What

From the phone after v1.200.0: in select mode a tap on a stacked card (×5) toggles the whole group, so there was no way to open it and pick one bottle out of five.

- The ⊕ on a stacked card is now a real button in select mode that expands the group without touching the selection: in the list view where the chevron sits, and as a corner button on the grid card. Click and keyboard events on it don't bubble into the card.
- In the grid the ×N count badge moves right in select mode so it no longer sits under the select box.
- Outside select mode nothing changes: the whole card expands the group as before.

## Tests

New `BottleCard.test.js` (4 tests): tap toggles vs ⊕ expands in list and grid, no button outside select mode or on single bottles, keyboard on the button never reaches the card. Full frontend suite: 76 files / 1139 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
