### PR TITLE
fix(images): a rejected photo no longer takes the bottle page down for its owner

### DIFF
--- a/backend/src/routes/images.bottleGallery.test.js
+++ b/backend/src/routes/images.bottleGallery.test.js
@@ -1,0 +1,107 @@
+/**
+ * GET /api/images/bottle/:bottleId — what the uploader gets back.
+ *
+ * Support ticket 2026-09-03 ("one of my wines cannot load"): an admin had
+ * rejected the only photo on a bottle. Rejecting deletes the files and nulls
+ * both URLs, leaving a tombstone row. This route handed that tombstone back to
+ * the uploader under the "your own photos, any state" branch, the carousel
+ * called .startsWith on the null URL, and the ErrorBoundary took the whole
+ * bottle page down — 138 bottles / 47 owners on prod at the time. The
+ * uploader branch must exclude rejected rows; the wine-level branch stays
+ * approved + public only.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../models/BottleImage', () => ({ find: jest.fn(), findById: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
+jest.mock('../models/WineDefinition', () => ({ exists: jest.fn(), findById: jest.fn() }));
+jest.mock('../services/imageProcessor', () => ({ processImage: jest.fn() }));
+jest.mock('../services/imageSanitizer', () => ({ sanitizeImageBuffer: jest.fn() }));
+jest.mock('../services/imageOps', () => ({ ingestBottleImage: jest.fn() }));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../config/upload', () => ({ upload: { single: () => (req, res, next) => next() }, ORIGINALS_DIR: '/app/uploads/originals' }));
+jest.mock('../utils/cellarAccess', () => ({ getCellarRole: jest.fn(() => 'owner') }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const BottleImage = require('../models/BottleImage');
+const Bottle = require('../models/Bottle');
+const Cellar = require('../models/Cellar');
+const imagesRouter = require('./images');
+
+const oid = (c) => c.repeat(24);
+const BOTTLE = oid('b');
+const CELLAR = oid('c');
+const WINE = oid('a');
+const USER = oid('1');
+
+const tokenFor = (id, roles) => jwt.sign({ id, roles }, 'test-secret');
+
+/** Chainable thenable standing in for a Mongoose Query. */
+const makeQuery = (rows = []) => {
+  const q = {
+    sort: jest.fn(() => q),
+    select: jest.fn(() => q),
+    then: (resolve, reject) => Promise.resolve(rows).then(resolve, reject),
+  };
+  return q;
+};
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/images', imagesRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Bottle.findById.mockResolvedValue({ _id: BOTTLE, cellar: CELLAR, wineDefinition: WINE, defaultImage: null });
+  Cellar.findById.mockResolvedValue({ _id: CELLAR });
+});
+
+const get = (path, token) =>
+  fetch(`${baseUrl}${path}`, { headers: { Authorization: `Bearer ${token}` } });
+
+describe('the uploader branch', () => {
+  test('never returns a rejected tombstone, even to the uploader', async () => {
+    BottleImage.find.mockReturnValue(makeQuery([]));
+
+    const res = await get(`/api/images/bottle/${BOTTLE}`, tokenFor(USER, ['user']));
+    expect(res.status).toBe(200);
+
+    const bottleFilter = BottleImage.find.mock.calls[0][0];
+    expect(bottleFilter.bottle).toBe(BOTTLE);
+    expect(bottleFilter.$or).toEqual([
+      { status: 'approved', visibility: 'public' },
+      { uploadedBy: USER, status: { $ne: 'rejected' } },
+    ]);
+  });
+
+  test('the wine-level branch stays approved + public only', async () => {
+    BottleImage.find.mockReturnValue(makeQuery([]));
+
+    await get(`/api/images/bottle/${BOTTLE}`, tokenFor(USER, ['user']));
+
+    const wineFilter = BottleImage.find.mock.calls[1][0];
+    expect(wineFilter).toEqual({ wineDefinition: WINE, status: 'approved', visibility: 'public' });
+  });
+
+  test('a row the server returns comes through untouched (regression guard for the shape)', async () => {
+    const live = { _id: oid('d'), processedUrl: '/api/uploads/processed/live.png', originalUrl: null, status: 'approved' };
+    BottleImage.find
+      .mockReturnValueOnce(makeQuery([live]))
+      .mockReturnValueOnce(makeQuery([]));
+
+    const res = await get(`/api/images/bottle/${BOTTLE}`, tokenFor(USER, ['user']));
+    const body = await res.json();
+    expect(body.images).toEqual([live]);
+    expect(body.defaultImageId).toBeNull();
+  });
+});

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -187,11 +187,17 @@ router.get('/bottle/:bottleId', requireAuth, async (req, res) => {
     // - Public approved images for everyone
     // - Private approved images only for the uploader
     // - Non-approved images only for the uploader
+    // The uploader sees their own photos in every state EXCEPT rejected. The
+    // reject route deletes the files and nulls both URLs, keeping only a
+    // tombstone row — and a row with no URL is not a photo anyone can show.
+    // Handing it back took the whole bottle page down for its owner (support
+    // ticket 2026-09-03: ImageCarousel called .startsWith on the null URL and
+    // the ErrorBoundary swallowed the page) — 138 bottles / 47 owners on prod.
     const bottleImages = await BottleImage.find({
       bottle: req.params.bottleId,
       $or: [
         { status: 'approved', visibility: 'public' },
-        { uploadedBy: req.user.id }
+        { uploadedBy: req.user.id, status: { $ne: 'rejected' } }
       ]
     }).sort({ createdAt: -1 });
 

--- a/frontend/src/components/ImageCarousel.js
+++ b/frontend/src/components/ImageCarousel.js
@@ -22,8 +22,11 @@ function ImageCarousel({ images, size = 'medium', defaultImageId, onSetDefault, 
   };
 
   const currentImage = images[index];
-  const src = currentImage.processedUrl || currentImage.originalUrl;
-  const fullSrc = src.startsWith('http') ? src : `${API_URL}${src}`;
+  const src = currentImage.processedUrl || currentImage.originalUrl || null;
+  // A row with no URL (a rejected tombstone that slipped through) renders an
+  // empty frame instead of throwing — AuthImage treats a null src as nothing
+  // to show. Throwing here unmounts the entire host page via the ErrorBoundary.
+  const fullSrc = !src ? null : (src.startsWith('http') ? src : `${API_URL}${src}`);
   const isDefault = defaultImageId && currentImage._id === defaultImageId;
 
   return (

--- a/frontend/src/components/ImageCarousel.test.js
+++ b/frontend/src/components/ImageCarousel.test.js
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ apiFetch: () => {} }),
+}));
+
+const { default: ImageCarousel } = await import('./ImageCarousel');
+
+// Support ticket 2026-09-03: an admin-rejected photo (files deleted, both URLs
+// nulled) reached this carousel, `src.startsWith` threw, and the page-level
+// ErrorBoundary replaced the whole bottle page with "Something went wrong".
+describe('ImageCarousel and a row with no URL', () => {
+  test('renders an empty frame instead of throwing', () => {
+    const images = [{ _id: 'dead', processedUrl: null, originalUrl: null, status: 'rejected' }];
+    expect(() => render(<ImageCarousel images={images} />)).not.toThrow();
+    expect(document.querySelector('img')).toBeNull();
+  });
+
+  test('a real row still renders its image', async () => {
+    render(<ImageCarousel images={[{ _id: 'live', processedUrl: '/api/uploads/processed/live.png', originalUrl: null }]} />);
+    const img = await screen.findByRole('img');
+    expect(img.getAttribute('src')).toContain('/api/uploads/processed/live.png');
+  });
+});

--- a/frontend/src/components/ImageGallery.js
+++ b/frontend/src/components/ImageGallery.js
@@ -33,7 +33,13 @@ const ImageGallery = forwardRef(function ImageGallery({ bottleId, wineDefinition
         // put undefined into state and throw on the next render, taking the
         // whole host page down with it. A gallery that cannot list images must
         // degrade to "no images", never break the page embedding it.
-        const list = Array.isArray(data.images) ? data.images : [];
+        // ...and drop any row without a file behind it. A rejected photo is a
+        // tombstone (both URLs nulled when the admin deleted the files); the
+        // server no longer returns those, but the carousel must never be
+        // handed a row it cannot render — that is exactly how one rejected
+        // photo made a bottle page unreachable for its owner (ticket 2026-09-03).
+        const list = (Array.isArray(data.images) ? data.images : [])
+          .filter((img) => img && (img.processedUrl || img.originalUrl));
         setImages(list);
         // For bottle images, the API returns defaultImageId
         if (data.defaultImageId) setDefaultImageId(data.defaultImageId);

--- a/frontend/src/components/ImageGallery.test.js
+++ b/frontend/src/components/ImageGallery.test.js
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key, fallback) => (typeof fallback === 'string' ? fallback : key) }),
+}));
+
+// Hoisted so the AuthContext mock factory may reference it safely.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ apiFetch, user: { id: 'u1' } }),
+}));
+
+const { default: ImageGallery } = await import('./ImageGallery');
+
+const respondWith = (images) =>
+  apiFetch.mockResolvedValue({ ok: true, json: async () => ({ images, defaultImageId: null }) });
+
+const dead = { _id: 'dead', processedUrl: null, originalUrl: null, status: 'rejected', uploadedBy: 'u1' };
+const live = { _id: 'live', processedUrl: '/api/uploads/processed/live.png', originalUrl: null, status: 'approved', uploadedBy: 'u1' };
+
+// Support ticket 2026-09-03: the server used to hand the uploader their own
+// rejected photo — a tombstone with both URLs nulled — and the gallery passed
+// it straight to the carousel, which threw. The gallery must treat a row
+// without a file behind it as if it were not there at all.
+describe('ImageGallery and rows without a file behind them', () => {
+  beforeEach(() => apiFetch.mockReset());
+
+  test('a tombstone is dropped and the real photo still shows', async () => {
+    respondWith([dead, live]);
+    const onLoaded = vi.fn();
+    render(<ImageGallery bottleId="b1" onLoaded={onLoaded} />);
+
+    const img = await screen.findByRole('img');
+    expect(img.getAttribute('src')).toContain('live.png');
+    expect(onLoaded).toHaveBeenCalledWith(1);
+  });
+
+  test('only a tombstone counts as no images', async () => {
+    respondWith([dead]);
+    const onEmpty = vi.fn();
+    const onLoaded = vi.fn();
+    const { container } = render(<ImageGallery bottleId="b1" onEmpty={onEmpty} onLoaded={onLoaded} />);
+
+    await waitFor(() => expect(onEmpty).toHaveBeenCalled());
+    expect(onLoaded).toHaveBeenCalledWith(0);
+    expect(container.querySelector('img')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Support ticket 2026-09-03 (bug, "issue with loading one of the wines from my cellar"): the bottle page showed the ErrorBoundary ("Something went wrong — refresh") on every device, while every API call behind it returned 200.

**Root cause.** The bottle's only photo had been rejected by an admin. `PUT /api/admin/images/:id/reject` deletes the files and nulls both `originalUrl` and `processedUrl`, keeping a tombstone row. `GET /api/images/bottle/:bottleId` returned that tombstone to the uploader (the `{ uploadedBy }` branch had no status filter), `ImageCarousel` did `src.startsWith('http')` on the null, and React unmounted the page. `HeroImage` mounts the gallery whenever the bottle has an id, so the owner could never open that bottle again.

**Blast radius on prod today:** 176 rejected null-URL rows on 138 existing bottles owned by 47 people. Not a regression from the 09-03 releases — the nulling dates from v1.43 (#283) and the uploader branch from March (#187); rejections only became common in July.

## Changes

- `routes/images.js` — the uploader branch of the bottle gallery excludes `status: 'rejected'` (the wine-level branch was already approved + public only).
- `ImageGallery.js` — drops any row without a URL before it reaches the carousel.
- `ImageCarousel.js` — a null URL renders an empty frame instead of throwing.
- Regression tests on all three (`images.bottleGallery.test.js`, `ImageCarousel.test.js`, `ImageGallery.test.js`).

No data repair needed: the null-URL tombstones are intentional (reject keeps a record, deletes the file).

## Test plan

- [x] backend: the five `images.*` Jest suites in node:24-alpine — 34/34
- [x] frontend: full Vitest run — 78 files / 1144 tests
- [ ] prod: open the reporter's bottle after deploy
