### PR TITLE
feat(auth): per-device sessions — signing in on the phone no longer signs the laptop out

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -170,6 +170,29 @@ const userSchema = new mongoose.Schema({
       default: 'all'
     }
   },
+  // One entry per signed-in device/browser (per-device sessions, 2026-09-04):
+  // `hash` is sha256 of the opaque refresh token in that device's cookie,
+  // `prevHash` the hash most recently rotated away (reuse detection),
+  // `client` a short device label like "Android / Chrome" — never the raw UA.
+  // Rotation touches only its own entry; password change/reset and account
+  // deletion clear the whole list. See services/authTokens.js.
+  sessions: {
+    type: [new mongoose.Schema({
+      hash: { type: String, required: true },
+      prevHash: { type: String, default: null },
+      rotatedAt: { type: Date, default: null },
+      expiresAt: { type: Date, default: null },
+      persistent: { type: Boolean, default: true },
+      createdAt: { type: Date, default: Date.now },
+      lastUsedAt: { type: Date, default: Date.now },
+      client: { type: String, default: 'Unknown device', maxlength: 80 },
+    })],
+    default: []
+  },
+  // LEGACY single-session fields. Read once by /refresh to adopt a
+  // pre-sessions cookie into `sessions` (so the rollout signs nobody out),
+  // then nulled. Drop the three fields and their index once no row carries a
+  // refreshTokenHash.
   refreshTokenHash: {
     type: String,
     default: null
@@ -350,8 +373,12 @@ const userSchema = new mongoose.Schema({
 // Sparse index so verify-email lookup is efficient; sparse avoids bloat after verification
 userSchema.index({ emailVerificationTokenHash: 1 }, { sparse: true });
 userSchema.index({ passwordResetTokenHash: 1 }, { sparse: true });
-// Every /api/auth/refresh resolves the session via this hash — without the
-// index it is a full collection scan per token refresh (one per session ~15min)
+// Every /api/auth/refresh resolves the device session via these hashes —
+// without the indexes it is a full collection scan per token refresh (one per
+// session ~15min).
+userSchema.index({ 'sessions.hash': 1 }, { sparse: true });
+userSchema.index({ 'sessions.prevHash': 1 }, { sparse: true });
+// Legacy — keeps the one-time migration lookup indexed. Drop with the field.
 userSchema.index({ refreshTokenHash: 1 }, { sparse: true });
 // SSO login resolves the account by (provider, provider's user id) on every
 // federated sign-in — index it so that lookup isn't a full collection scan.
@@ -434,18 +461,6 @@ userSchema.methods.comparePassword = async function(candidatePassword) {
   return await bcrypt.compare(candidatePassword, this.password);
 };
 
-// Store a hashed refresh token
-userSchema.methods.setRefreshToken = function(token) {
-  this.refreshTokenHash = crypto.createHash('sha256').update(token).digest('hex');
-};
-
-// Validate a refresh token against the stored hash
-userSchema.methods.validateRefreshToken = function(token) {
-  if (!this.refreshTokenHash) return false;
-  const hash = crypto.createHash('sha256').update(token).digest('hex');
-  return crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(this.refreshTokenHash));
-};
-
 // Generate a raw verification token, store its hash, set 24h expiry; returns raw token to email
 userSchema.methods.setEmailVerificationToken = function() {
   const token = crypto.randomBytes(32).toString('hex');
@@ -501,6 +516,7 @@ userSchema.methods.toJSON = function() {
   obj.linkedProviders = Array.isArray(obj.authProviders) ? obj.authProviders.map(p => p.provider) : [];
   delete obj.authProviders;
   delete obj.password;
+  delete obj.sessions;
   delete obj.refreshTokenHash;
   delete obj.refreshTokenExpiresAt;
   delete obj.refreshTokenPersistent;

--- a/backend/src/models/User.test.js
+++ b/backend/src/models/User.test.js
@@ -14,6 +14,7 @@ describe('toJSON', () => {
     const json = user.toJSON();
     expect(json.password).toBeUndefined();
     expect(json.refreshTokenHash).toBeUndefined();
+    expect(json.sessions).toBeUndefined(); // per-device session hashes never reach the client
     expect(json.stripeCustomerId).toBeUndefined();
   });
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -16,7 +16,10 @@ const { rateLimitKey } = require('../utils/clientIp');
 // Token issuance + refresh-cookie handling and pending-share resolution are
 // extracted to services so the password flow (here) and the SSO flow
 // (routes/oauth.js) share one implementation.
-const { issueTokens, clearRefreshCookie } = require('../services/authTokens');
+const {
+  issueTokens, clearRefreshCookie, clientHint, resolveRefreshSession,
+  removeSession, revokeAllSessions, sessionForCookie, hashRefreshToken,
+} = require('../services/authTokens');
 const { resolvePendingShares } = require('../services/pendingShares');
 const { createDemoAccountWithinCeiling } = require('../services/demoAccount');
 
@@ -172,7 +175,7 @@ router.post('/register', authLimiter, async (req, res) => {
 
     // Verification disabled — issue tokens immediately (current behaviour)
     user.emailVerified = true;
-    const accessToken = await issueTokens(user, res);
+    const accessToken = await issueTokens(user, res, { client: clientHint(req) });
 
     logAudit(req, 'auth.register',
       { type: 'user', id: user._id },
@@ -215,12 +218,11 @@ router.post('/demo-login', demoLimiter, async (req, res) => {
       return res.status(429).json({ error: 'The live demo is at capacity right now. Please try again shortly, or create a free account.' });
     }
 
-    // Bound the session to the demo TTL: set the refresh-token deadline to the
-    // account's expiry and PRESERVE it through issueTokens (no 30-day default),
-    // with a session cookie (rememberMe:false). A page reload refreshes within
-    // the window; once the account is reaped, /refresh 401s cleanly.
-    user.refreshTokenExpiresAt = user.demoExpiresAt;
-    const accessToken = await issueTokens(user, res, { preserveLifetime: true, rememberMe: false });
+    // Bound the session to the demo TTL: the device session's deadline is the
+    // account's expiry (no 30-day default), with a session cookie
+    // (rememberMe:false). A page reload refreshes within the window; once the
+    // account is reaped, /refresh 401s cleanly.
+    const accessToken = await issueTokens(user, res, { expiresAt: user.demoExpiresAt, rememberMe: false, client: clientHint(req) });
 
     logAudit(req, 'auth.demo_login', { type: 'user', id: user._id }, { expiresAt: user.demoExpiresAt });
 
@@ -316,7 +318,7 @@ router.post('/login', authLimiter, async (req, res) => {
       try { await user.save(); } catch (err) { console.warn('Failed to reset login-attempt counter:', err.message); }
     }
 
-    const accessToken = await issueTokens(user, res, { rememberMe: rememberMe !== false });
+    const accessToken = await issueTokens(user, res, { rememberMe: rememberMe !== false, client: clientHint(req) });
 
     logAudit(req, 'auth.login.success',
       { type: 'user', id: user._id },
@@ -452,32 +454,51 @@ router.post('/refresh', refreshLimiter, async (req, res) => {
   }
 
   try {
-    // Decode without verification to get the user ID, then validate hash in DB
-    // (Refresh tokens are opaque random bytes — not JWTs — so just look up by hash)
-    // We find the user whose stored hash matches this token
-    const tokenHash = crypto.createHash('sha256').update(incomingToken).digest('hex');
-    const user = await User.findOne({ refreshTokenHash: tokenHash });
+    // Refresh tokens are opaque random bytes — not JWTs — so the cookie is
+    // resolved by hash to the user AND the device session it belongs to
+    // (services/authTokens.resolveRefreshSession). Other devices' sessions on
+    // the same account are never touched here.
+    const found = await resolveRefreshSession(incomingToken);
 
-    if (!user) {
+    if (!found) {
+      clearRefreshCookie(res);
+      return res.status(401).json({ error: 'Invalid or expired refresh token' });
+    }
+    const { user, session, reused, race, migrated } = found;
+
+    // A token that was already rotated away. Inside the grace window it is a
+    // lost race between two tabs (the winner holds the live cookie) — a plain
+    // 401, nothing revoked. Outside it, someone else holds a copy of a cookie
+    // the real browser no longer has: sign the account out everywhere.
+    if (reused) {
+      if (!race) {
+        revokeAllSessions(user);
+        eventBus.dropUser(user._id);
+        await user.save();
+        logAudit(req, 'auth.session.reuse_detected', { type: 'user', id: user._id }, { client: session.client });
+      }
       clearRefreshCookie(res);
       return res.status(401).json({ error: 'Invalid or expired refresh token' });
     }
 
     // Enforce the absolute session deadline. Rotation must NOT extend it, so an
     // attacker who keeps rotating a stolen token is still cut off after the cap.
-    if (user.refreshTokenExpiresAt && Date.now() > user.refreshTokenExpiresAt.getTime()) {
-      user.refreshTokenHash = null;
-      user.refreshTokenExpiresAt = null;
-      eventBus.dropUser(user._id); // session hard-cap is a credential event — close open SSE streams too
+    if (session.expiresAt && Date.now() > new Date(session.expiresAt).getTime()) {
+      removeSession(user, session);
+      // The hard cap is a credential event — close open SSE streams too, but
+      // only once no device session is left (they are per-account streams).
+      if (user.sessions.length === 0) eventBus.dropUser(user._id);
       await user.save();
       clearRefreshCookie(res);
       return res.status(401).json({ error: 'Session expired, please log in again' });
     }
 
-    // Rotate: issue new pair (invalidates the old refresh token hash). Preserve
-    // the existing deadline when set; backfill legacy sessions (null) so every
-    // session eventually gets an absolute cap.
-    const accessToken = await issueTokens(user, res, { preserveLifetime: !!user.refreshTokenExpiresAt });
+    // A pre-sessions cookie adopted just now: label it with this device.
+    if (migrated) session.client = clientHint(req);
+
+    // Rotate THIS device's entry: new hash, old one kept as prevHash for reuse
+    // detection, deadline preserved (legacy null backfilled to a fresh cap).
+    const accessToken = await issueTokens(user, res, { session });
 
     res.json({ token: accessToken });
   } catch (error) {
@@ -521,12 +542,19 @@ router.post('/change-password', requireAuth, requireNonDemo, authLimiter, async 
     }
 
     user.password = newPassword;
-    user.refreshTokenHash = null; // Invalidate all existing sessions
+    // Invalidate every device session, then start a fresh one for THIS device
+    // (keeping its remember-me choice) so the user changing the password
+    // stays signed in here and nowhere else.
+    const current = sessionForCookie(user, req);
+    revokeAllSessions(user);
     // Also force-close any open SSE event streams — same trust boundary as
     // refresh sessions (docs/ha-push-events.md §1).
     eventBus.dropUser(user._id);
 
-    const accessToken = await issueTokens(user, res); // persists the new password
+    const accessToken = await issueTokens(user, res, { // persists the new password
+      rememberMe: current ? current.persistent !== false : true,
+      client: clientHint(req),
+    });
     // Revoke connected AI assistants (OAuth consent grants) — a third-party
     // grant must not outlive the "secure my account" action (security report
     // 2026-08-27). Personal API tokens (HA, climate) keep PAT semantics.
@@ -556,13 +584,25 @@ router.post('/logout', requireAuth, async (req, res) => {
   try {
     const user = await User.findById(req.user.id);
     if (user) {
-      user.refreshTokenHash = null;
+      // Sign out THIS device only: drop the session its refresh cookie belongs
+      // to (by current or just-rotated hash). Other devices keep their sessions.
+      // A pre-sessions cookie still on the legacy field is cleared the same way.
+      const raw = req.cookies?.refreshToken;
+      const hash = raw ? hashRefreshToken(raw) : null;
+      if (hash) {
+        user.sessions = (user.sessions || []).filter((s) => s.hash !== hash && s.prevHash !== hash);
+        if (user.refreshTokenHash === hash) {
+          user.refreshTokenHash = null;
+          user.refreshTokenExpiresAt = null;
+          user.refreshTokenPersistent = null;
+        }
+      }
       await user.save();
+      // Open SSE event streams are per account, so close them only when no
+      // device session is left. An integration holding valid credentials
+      // simply reconnects.
+      if ((user.sessions || []).length === 0 && !user.refreshTokenHash) eventBus.dropUser(req.user.id);
     }
-    // Logout invalidates the account's (single) refresh session, so it is a
-    // logout-everywhere — close open SSE event streams too. An integration
-    // holding valid credentials simply reconnects.
-    eventBus.dropUser(req.user.id);
     clearRefreshCookie(res);
     res.json({ message: 'Logged out' });
   } catch (error) {
@@ -663,7 +703,7 @@ router.post('/reset-password', authLimiter, async (req, res) => {
     user.password = password;
     user.passwordResetTokenHash = null;
     user.passwordResetExpiresAt = null;
-    user.refreshTokenHash = null; // Invalidate all existing sessions
+    revokeAllSessions(user); // Invalidate all existing device sessions
     eventBus.dropUser(user._id); // and force-close open SSE event streams
     // Successful password reset is the user's explicit recovery signal —
     // clear any brute-force lockout state too. Otherwise a locked user

--- a/backend/src/routes/auth.refresh.test.js
+++ b/backend/src/routes/auth.refresh.test.js
@@ -14,14 +14,18 @@
  *
  * Notable behaviors PINNED here (found by reading the code, not guessed):
  *
- *  - Rotation: every successful /refresh replaces refreshTokenHash, so the
- *    previous token is dead immediately. There is NO reuse-detection /
- *    token-family revocation: presenting an already-rotated token returns a
- *    generic 401 and does NOT revoke the live session (see the reuse test —
- *    flagged there as a deliberate pin of current behavior).
- *  - The absolute 30-day session deadline (refreshTokenExpiresAt) is
- *    PRESERVED across rotation and BACKFILLED (fresh 30 days) for legacy
- *    sessions where it is null.
+ *  - Sessions are PER DEVICE (user.sessions[], 2026-09-04): /refresh rotates
+ *    only the entry its cookie belongs to, so the previous token is dead
+ *    immediately while every other device keeps working. /logout removes
+ *    only its own entry. A pre-sessions single-token row (refreshTokenHash)
+ *    is adopted into sessions[] on its first /refresh — the rollout signs
+ *    nobody out.
+ *  - Reuse detection: an already-rotated token presented again within 60 s
+ *    is a lost tab race (plain 401, nothing revoked); later than that it is
+ *    theft evidence and EVERY session on the account is revoked + audited.
+ *  - The absolute 30-day session deadline (session.expiresAt) is PRESERVED
+ *    across rotation and BACKFILLED (fresh 30 days) for legacy sessions
+ *    where it is null.
  *  - Remember-me is sticky: a session started with rememberMe=false keeps
  *    getting a browser-session cookie (no Max-Age/Expires) on rotation.
  *  - clearRefreshCookie clears BOTH Path=/api/auth and legacy Path=/ variants.
@@ -128,6 +132,7 @@ function makeUserDoc(overrides = {}) {
     roles: ['user'],
     plan: 'free',
     planExpiresAt: null,
+    sessions: [],
     refreshTokenHash: null,
     refreshTokenExpiresAt: null,
     refreshTokenPersistent: null,
@@ -138,9 +143,6 @@ function makeUserDoc(overrides = {}) {
     markModified: jest.fn(),
     toJSON() { return { id: this._id, username: this.username, email: this.email }; },
     // ── Replicas of the REAL User schema methods (models/User.js) ──
-    setRefreshToken(token) {
-      this.refreshTokenHash = sha256(token);
-    },
     setPasswordResetToken() {
       const token = crypto.randomBytes(32).toString('hex');
       this.passwordResetTokenHash = sha256(token);
@@ -159,9 +161,20 @@ function makeUserDoc(overrides = {}) {
   return doc;
 }
 
-// Plant a refresh session on a user exactly the way issueTokens() would have:
+// Plant a DEVICE session on a user exactly the way issueTokens() would have:
 // stored hash + absolute deadline + persistence flag. Returns the raw cookie value.
-function plantRefreshToken(user, { persistent = null, expiresAt = new Date(NOW + 10 * DAY) } = {}) {
+function plantRefreshToken(user, { persistent = true, expiresAt = new Date(NOW + 10 * DAY), client = 'Windows / Chrome' } = {}) {
+  const raw = crypto.randomBytes(64).toString('hex');
+  user.sessions.push({
+    hash: sha256(raw), prevHash: null, rotatedAt: null, expiresAt, persistent,
+    createdAt: new Date(NOW), lastUsedAt: new Date(NOW), client,
+  });
+  return raw;
+}
+
+// A PRE-SESSIONS row: the single refreshTokenHash an account used to carry
+// before per-device sessions. Adopted into sessions[] on its first /refresh.
+function plantLegacyRefreshToken(user, { persistent = null, expiresAt = new Date(NOW + 10 * DAY) } = {}) {
   const raw = crypto.randomBytes(64).toString('hex');
   user.refreshTokenHash = sha256(raw);
   user.refreshTokenExpiresAt = expiresAt;
@@ -169,9 +182,18 @@ function plantRefreshToken(user, { persistent = null, expiresAt = new Date(NOW +
   return raw;
 }
 
+const sessionOf = (user, raw) => user.sessions.find((s) => s.hash === sha256(raw));
+
+// Mongo-style matcher for the in-memory store: flat equality plus dotted
+// paths into arrays ('sessions.hash' → some element's hash), as the real
+// session lookups query.
 const matches = (u, q) => {
   if (q.$or) return q.$or.some((c) => matches(u, c));
-  return Object.entries(q).every(([k, v]) => u[k] === v);
+  return Object.entries(q).every(([k, v]) => {
+    const [head, ...rest] = k.split('.');
+    if (rest.length && Array.isArray(u[head])) return u[head].some((el) => el[rest.join('.')] === v);
+    return u[k] === v;
+  });
 };
 
 // ── One HTTP server for the suite ────────────────────────────────────────────
@@ -275,8 +297,8 @@ const expectClearedCookies = (res) => {
 describe('POST /api/auth/refresh — rotation', () => {
   test('valid cookie → new access token, refresh token ROTATED, cookie attrs pinned', async () => {
     const user = makeUserDoc();
-    const oldRaw = plantRefreshToken(user); // persistent=null (legacy) → persistent cookie
-    const oldHash = user.refreshTokenHash;
+    const oldRaw = plantRefreshToken(user); // persistent (remember-me) session
+    const oldHash = sha256(oldRaw);
 
     const res = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${oldRaw}` });
 
@@ -294,8 +316,11 @@ describe('POST /api/auth/refresh — rotation', () => {
     const rotated = cookies[0];
     expect(rotated.value).not.toBe(oldRaw);
     expect(rotated.value).toMatch(/^[0-9a-f]{128}$/); // 64 random bytes, hex
-    expect(user.refreshTokenHash).toBe(sha256(rotated.value));
-    expect(user.refreshTokenHash).not.toBe(oldHash);
+    expect(user.sessions).toHaveLength(1); // rotated IN PLACE, no second entry
+    const session = sessionOf(user, rotated.value);
+    expect(session).toBeDefined();
+    expect(session.prevHash).toBe(oldHash); // kept for reuse detection
+    expect(session.rotatedAt.getTime()).toBe(NOW);
     expect(user.save).toHaveBeenCalled();
 
     // Cookie attributes as the code sets them (NODE_ENV=test → no Secure flag)
@@ -314,7 +339,7 @@ describe('POST /api/auth/refresh — rotation', () => {
     const res = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${raw}` });
 
     expect(res.status).toBe(200);
-    expect(user.refreshTokenExpiresAt.getTime()).toBe(deadline.getTime());
+    expect(user.sessions[0].expiresAt.getTime()).toBe(deadline.getTime());
   });
 
   test('legacy session with NO deadline gets backfilled with a fresh 30-day cap', async () => {
@@ -324,7 +349,52 @@ describe('POST /api/auth/refresh — rotation', () => {
     const res = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${raw}` });
 
     expect(res.status).toBe(200);
-    expect(user.refreshTokenExpiresAt.getTime()).toBe(NOW + 30 * DAY);
+    expect(user.sessions[0].expiresAt.getTime()).toBe(NOW + 30 * DAY);
+  });
+
+  test('two devices: each refresh rotates ONLY its own session, the other keeps working', async () => {
+    const user = makeUserDoc();
+    const phone = plantRefreshToken(user, { client: 'Android / Chrome' });
+    const laptop = plantRefreshToken(user, { client: 'Windows / Firefox' });
+
+    // The phone refreshes — this used to sign the laptop out.
+    const phoneRes = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${phone}` });
+    expect(phoneRes.status).toBe(200);
+    expect(user.sessions).toHaveLength(2);
+    expect(sessionOf(user, laptop)).toBeDefined(); // laptop untouched
+
+    // The laptop refreshes with its ORIGINAL cookie — still valid.
+    const laptopRes = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${laptop}` });
+    expect(laptopRes.status).toBe(200);
+    expect(user.sessions).toHaveLength(2);
+    expect(user.sessions.map((s) => s.client).sort()).toEqual(['Android / Chrome', 'Windows / Firefox']);
+
+    // And the phone's rotated cookie keeps working too.
+    const phone2 = refreshCookies(phoneRes)[0].value;
+    expect((await request({ path: '/api/auth/refresh', cookie: `refreshToken=${phone2}` })).status).toBe(200);
+  });
+
+  test('a pre-sessions single-token row is adopted on its first refresh — nobody is signed out by the rollout', async () => {
+    const user = makeUserDoc();
+    const deadline = new Date(NOW + 12 * DAY);
+    const raw = plantLegacyRefreshToken(user, { persistent: false, expiresAt: deadline });
+
+    const res = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${raw}` });
+
+    expect(res.status).toBe(200);
+    // Legacy fields cleared, one device session in their place with the same
+    // deadline and remember-me choice, labelled from this request's UA.
+    expect(user.refreshTokenHash).toBeNull();
+    expect(user.refreshTokenExpiresAt).toBeNull();
+    expect(user.refreshTokenPersistent).toBeNull();
+    expect(user.sessions).toHaveLength(1);
+    const [session] = user.sessions;
+    expect(session.hash).toBe(sha256(refreshCookies(res)[0].value));
+    expect(session.prevHash).toBe(sha256(raw));
+    expect(session.expiresAt.getTime()).toBe(deadline.getTime());
+    expect(session.persistent).toBe(false);
+    expect(refreshCookies(res)[0].attrs['max-age']).toBeUndefined(); // still a session cookie
+    expect(session.client).toBe('Unknown device'); // node's http client sends no UA
   });
 
   test('missing cookie → 401, no cookie touched', async () => {
@@ -347,38 +417,66 @@ describe('POST /api/auth/refresh — rotation', () => {
     expectClearedCookies(res);
   });
 
-  test('rotated (already-used) token is rejected — and reuse does NOT revoke the live session', async () => {
+  test('a rotated token replayed within 60 s is a lost tab race: generic 401, nothing revoked', async () => {
     const user = makeUserDoc();
     const tokenA = plantRefreshToken(user);
+    const other = plantRefreshToken(user, { client: 'iOS / Safari' }); // another device, must survive
 
     // 1) legitimate rotation: A → B
     const first = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${tokenA}` });
     expect(first.status).toBe(200);
     const tokenB = refreshCookies(first)[0].value;
 
-    // 2) replaying the rotated token A fails with the generic 401
+    // 2) replaying A ten seconds later fails with the generic 401…
+    dateNowSpy.mockReturnValue(NOW + 10 * 1000);
     const replay = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${tokenA}` });
     expect(replay.status).toBe(401);
     expect(replay.body).toEqual({ error: 'Invalid or expired refresh token' });
+    expectClearedCookies(replay);
 
-    // 3) PINNED CURRENT BEHAVIOR — no reuse-detection / token-family
-    // revocation: the reuse attempt above did NOT invalidate the live token B.
-    // A stricter design would treat reuse of a rotated token as theft evidence
-    // and revoke the whole session; the code does not do that today.
-    const after = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${tokenB}` });
-    expect(after.status).toBe(200);
+    // 3) …and revokes nothing: the live token B and the other device both work.
+    const { logAudit } = require('../services/audit');
+    expect(logAudit).not.toHaveBeenCalledWith(expect.anything(), 'auth.session.reuse_detected', expect.anything(), expect.anything());
+    expect((await request({ path: '/api/auth/refresh', cookie: `refreshToken=${tokenB}` })).status).toBe(200);
+    expect((await request({ path: '/api/auth/refresh', cookie: `refreshToken=${other}` })).status).toBe(200);
   });
 
-  test('absolute deadline passed → 401 "Session expired", server-side hash purged, cookie cleared', async () => {
+  test('a rotated token replayed AFTER the grace window is theft evidence: every session revoked, audited', async () => {
+    const user = makeUserDoc();
+    const tokenA = plantRefreshToken(user, { client: 'Windows / Chrome' });
+    const other = plantRefreshToken(user, { client: 'iOS / Safari' });
+
+    const first = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${tokenA}` });
+    const tokenB = refreshCookies(first)[0].value;
+
+    // Five minutes later someone presents the OLD cookie A.
+    dateNowSpy.mockReturnValue(NOW + 5 * 60 * 1000);
+    const replay = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${tokenA}` });
+    expect(replay.status).toBe(401);
+    expect(replay.body).toEqual({ error: 'Invalid or expired refresh token' }); // same generic body
+    expectClearedCookies(replay);
+
+    // Account signed out everywhere, with a traceable audit row.
+    expect(user.sessions).toEqual([]);
+    expect(user.save).toHaveBeenCalled();
+    const { logAudit } = require('../services/audit');
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'auth.session.reuse_detected',
+      { type: 'user', id: 'u1' }, { client: 'Windows / Chrome' });
+    expect((await request({ path: '/api/auth/refresh', cookie: `refreshToken=${tokenB}` })).status).toBe(401);
+    expect((await request({ path: '/api/auth/refresh', cookie: `refreshToken=${other}` })).status).toBe(401);
+  });
+
+  test('absolute deadline passed → 401 "Session expired", that device purged, others kept, cookie cleared', async () => {
     const user = makeUserDoc();
     const raw = plantRefreshToken(user, { expiresAt: new Date(NOW - 1000) });
+    const other = plantRefreshToken(user, { client: 'iOS / Safari' });
 
     const res = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${raw}` });
 
     expect(res.status).toBe(401);
     expect(res.body).toEqual({ error: 'Session expired, please log in again' });
-    expect(user.refreshTokenHash).toBeNull();
-    expect(user.refreshTokenExpiresAt).toBeNull();
+    expect(user.sessions).toHaveLength(1);
+    expect(sessionOf(user, other)).toBeDefined();
     expect(user.save).toHaveBeenCalled();
     expectClearedCookies(res);
   });
@@ -397,22 +495,60 @@ describe('POST /api/auth/refresh — rotation', () => {
     expect(rotated.attrs.path).toBe('/api/auth');
     expect(rotated.attrs.httponly).toBe(true);
     // and the persistence choice survives the rotation for the NEXT one too
-    expect(user.refreshTokenPersistent).toBe(false);
+    expect(user.sessions[0].persistent).toBe(false);
   });
 });
 
 describe('POST /api/auth/logout', () => {
-  test('revokes the server-side refresh token and clears the cookie on both paths', async () => {
+  test('revokes ONLY this device\'s session (by its cookie) and clears the cookie on both paths', async () => {
+    const user = makeUserDoc();
+    const laptop = plantRefreshToken(user, { client: 'Windows / Chrome' });
+    const phone = plantRefreshToken(user, { client: 'Android / Chrome' });
+
+    const res = await request({ path: '/api/auth/logout', bearer: tokenFor('u1'), cookie: `refreshToken=${laptop}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'Logged out' });
+    expect(user.sessions).toHaveLength(1);
+    expect(sessionOf(user, phone)).toBeDefined();
+    expect(sessionOf(user, laptop)).toBeUndefined();
+    expect(user.save).toHaveBeenCalled();
+    expectClearedCookies(res);
+    // the phone is still signed in
+    expect((await request({ path: '/api/auth/refresh', cookie: `refreshToken=${phone}` })).status).toBe(200);
+  });
+
+  test('logout right after a rotation still finds its session (by the just-rotated hash)', async () => {
+    const user = makeUserDoc();
+    const raw = plantRefreshToken(user);
+    const rotated = await request({ path: '/api/auth/refresh', cookie: `refreshToken=${raw}` });
+    expect(rotated.status).toBe(200);
+
+    // A stale tab logging out with the pre-rotation cookie
+    const res = await request({ path: '/api/auth/logout', bearer: tokenFor('u1'), cookie: `refreshToken=${raw}` });
+    expect(res.status).toBe(200);
+    expect(user.sessions).toHaveLength(0);
+  });
+
+  test('a pre-sessions cookie is cleared from the legacy field the same way', async () => {
+    const user = makeUserDoc();
+    const raw = plantLegacyRefreshToken(user);
+
+    const res = await request({ path: '/api/auth/logout', bearer: tokenFor('u1'), cookie: `refreshToken=${raw}` });
+
+    expect(res.status).toBe(200);
+    expect(user.refreshTokenHash).toBeNull();
+    expect(user.refreshTokenExpiresAt).toBeNull();
+  });
+
+  test('without a cookie nothing can be identified server-side: sessions untouched, cookie still cleared', async () => {
     const user = makeUserDoc();
     plantRefreshToken(user);
-    expect(user.refreshTokenHash).not.toBeNull();
 
     const res = await request({ path: '/api/auth/logout', bearer: tokenFor('u1') });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ message: 'Logged out' });
-    expect(user.refreshTokenHash).toBeNull();
-    expect(user.save).toHaveBeenCalled();
+    expect(user.sessions).toHaveLength(1);
     expectClearedCookies(res);
   });
 
@@ -526,7 +662,8 @@ describe('POST /api/auth/reset-password', () => {
     expect(user.passwordResetTokenHash).toBeNull();
     expect(user.passwordResetExpiresAt).toBeNull();
 
-    // Every existing session is killed server-side + cookie cleared client-side
+    // Every device session is killed server-side + cookie cleared client-side
+    expect(user.sessions).toEqual([]);
     expect(user.refreshTokenHash).toBeNull();
     expectClearedCookies(res);
 

--- a/backend/src/routes/oauth.js
+++ b/backend/src/routes/oauth.js
@@ -4,7 +4,7 @@ const GoogleStrategy = require('passport-google-oauth20').Strategy;
 const crypto = require('crypto');
 const User = require('../models/User');
 const { logAudit } = require('../services/audit');
-const { issueTokens } = require('../services/authTokens');
+const { issueTokens, clientHint } = require('../services/authTokens');
 const { resolvePendingShares } = require('../services/pendingShares');
 
 const router = express.Router();
@@ -156,7 +156,7 @@ router.get('/google/callback', (req, res, next) => {
       return res.redirect(failureRedirect(reason));
     }
     try {
-      await issueTokens(user, res, { rememberMe: true });
+      await issueTokens(user, res, { rememberMe: true, client: clientHint(req) });
       logAudit(req, 'auth.oauth.success', { type: 'user', id: user._id }, { provider: 'google' });
       resolvePendingShares(user).catch(() => {});
       return res.redirect(successRedirect);

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -35,6 +35,7 @@ const PriceTrackingSkip = require('../models/PriceTrackingSkip');
 const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const { updatePreferences, updateProfile } = require('../services/accountOps');
 const { buildUserExport } = require('../services/userDataRegistry');
+const { revokeAllSessions } = require('../services/authTokens');
 const {
   buildCellarDataExport,
   IMAGE_EXPORT_COOLDOWN_MS,
@@ -477,12 +478,11 @@ router.delete('/me', requireAuth, requireNonDemo, async (req, res) => {
 
     user.deletionRequestedAt = now;
     user.deletionScheduledFor = scheduledFor;
-    // Revoke refresh sessions on the deletion request so a refresh token captured
-    // before deletion can't keep minting access tokens through the 7-day window.
-    // The user simply re-authenticates to use the account (or to cancel the
-    // deletion) — matching change-password / password-reset, which also clear it.
-    user.refreshTokenHash = null;
-    user.refreshTokenExpiresAt = null;
+    // Revoke every device session on the deletion request so a refresh token
+    // captured before deletion can't keep minting access tokens through the
+    // 7-day window. The user simply re-authenticates to use the account (or to
+    // cancel the deletion) — matching change-password / password-reset.
+    revokeAllSessions(user);
     eventBus.dropUser(user._id); // and force-close open SSE event streams
     await user.save();
 

--- a/backend/src/services/authTokens.js
+++ b/backend/src/services/authTokens.js
@@ -1,11 +1,20 @@
 const jwt = require('jsonwebtoken');
 const crypto = require('crypto');
+const User = require('../models/User');
 
 // Central place for issuing the access/refresh token pair and handling the
 // refresh cookie. Shared by the password login flow (routes/auth.js) and the
 // SSO flow (routes/oauth.js) so both mint IDENTICAL sessions — same JWT claims,
 // same rotating + path-scoped refresh cookie, same absolute-lifetime cap.
-// Extracted verbatim from routes/auth.js.
+//
+// Sessions are PER DEVICE (2026-09-04). The account used to hold ONE refresh
+// token hash, so signing in on the phone silently signed the laptop out: its
+// cookie no longer matched anything, the next /refresh got a 401, and the
+// client treated that as "session dead". On the hosted instance 247 of 313
+// consecutive logins over two weeks were exactly that — the same person moving
+// between devices. Now `user.sessions[]` carries one entry per signed-in
+// browser; /refresh rotates only its own entry and /logout removes only its
+// own entry. Password change/reset and account deletion still revoke ALL.
 
 // Generate short-lived access token (default 15 min)
 const generateAccessToken = (user) => {
@@ -17,8 +26,9 @@ const generateAccessToken = (user) => {
   );
 };
 
-// Generate opaque refresh token (random bytes) and store its hash on the user
+// Generate opaque refresh token (random bytes); only its sha256 is stored
 const generateRefreshToken = () => crypto.randomBytes(64).toString('hex');
+const hashRefreshToken = (token) => crypto.createHash('sha256').update(String(token)).digest('hex');
 
 // Secure flag for the refresh cookie (L-22): dedicated COOKIE_SECURE override
 // ('true'/'false'), falling back to the old NODE_ENV inference when unset.
@@ -71,37 +81,188 @@ const buildCookieOptions = (rememberMe) => {
 // long a stolen-but-rotated refresh token stays usable.
 const REFRESH_ABSOLUTE_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
-// Issue both tokens: access token in body, refresh token in httpOnly cookie.
-// preserveLifetime=true (rotation via /refresh) keeps the existing absolute
-// deadline; otherwise (login/register/re-auth/SSO) a fresh 30-day deadline is set.
-const issueTokens = async (user, res, { rememberMe, preserveLifetime = false } = {}) => {
+// Devices per account. Bounds the user document; the least recently used
+// entry is evicted when a new device signs in past the cap.
+const MAX_SESSIONS_PER_USER = 10;
+
+// A token that was rotated away and comes back within this window is a lost
+// race — two tabs of one browser refreshing at once where the Web Locks
+// single-flight is not available — not theft. Outside the window it is theft
+// evidence (someone holds a copy of a cookie the real browser no longer has)
+// and every session on the account is revoked.
+const REUSE_GRACE_MS = 60 * 1000;
+
+// Short device label for the sessions list. Data minimisation: an OS and a
+// browser family are enough to tell the phone from the laptop; the raw
+// user-agent string is never stored.
+const clientHint = (req) => {
+  const ua = String(req?.headers?.['user-agent'] || '');
+  const os = /iPhone|iPad/.test(ua) ? 'iOS'
+    : /Android/.test(ua) ? 'Android'
+      : /Windows/.test(ua) ? 'Windows'
+        : /Macintosh/.test(ua) ? 'Mac'
+          : /CrOS/.test(ua) ? 'ChromeOS'
+            : /Linux/.test(ua) ? 'Linux'
+              : null;
+  const browser = /Edg\//.test(ua) ? 'Edge'
+    : /OPR\//.test(ua) ? 'Opera'
+      : /Firefox\//.test(ua) ? 'Firefox'
+        : /Chrome\//.test(ua) ? 'Chrome'
+          : /Safari\//.test(ua) ? 'Safari'
+            : null;
+  const parts = [os, browser].filter(Boolean);
+  return parts.length ? parts.join(' / ') : 'Unknown device';
+};
+
+const sessionsOf = (user) => {
+  if (!Array.isArray(user.sessions)) user.sessions = [];
+  return user.sessions;
+};
+const expiryOf = (s) => (s.expiresAt ? new Date(s.expiresAt).getTime() : null);
+
+// Drop entries past their absolute deadline. Returns how many went.
+const pruneSessions = (user, now = Date.now()) => {
+  const before = sessionsOf(user).length;
+  user.sessions = user.sessions.filter((s) => expiryOf(s) === null || expiryOf(s) > now);
+  return before - user.sessions.length;
+};
+
+// Remove one device's entry (by its current hash).
+const removeSession = (user, session) => {
+  user.sessions = sessionsOf(user).filter((s) => s.hash !== session.hash);
+};
+
+// Sign out everywhere: password change/reset, account-deletion request,
+// refresh-token reuse. Also clears the legacy single-session fields.
+const revokeAllSessions = (user) => {
+  user.sessions = [];
+  user.refreshTokenHash = null;
+  user.refreshTokenExpiresAt = null;
+  user.refreshTokenPersistent = null;
+};
+
+// The session entry a request's refresh cookie belongs to, or null.
+const sessionForCookie = (user, req) => {
+  const raw = req?.cookies?.refreshToken;
+  if (!raw) return null;
+  const hash = hashRefreshToken(raw);
+  return sessionsOf(user).find((s) => s.hash === hash) || null;
+};
+
+/**
+ * Resolve a presented refresh token to its owner and device session.
+ * Returns null when it matches nothing, otherwise { user, session } plus:
+ *  - reused: true / race: bool — the token was rotated away; `race` says it
+ *    happened inside REUSE_GRACE_MS (benign) or not (theft signal)
+ *  - migrated: true — a pre-sessions single-token row was adopted in place
+ *    (the caller's rotation persists it), so the rollout signs nobody out
+ */
+const resolveRefreshSession = async (token) => {
+  const hash = hashRefreshToken(token);
+
+  let user = await User.findOne({ 'sessions.hash': hash });
+  if (user) {
+    return { user, session: sessionsOf(user).find((s) => s.hash === hash) };
+  }
+
+  user = await User.findOne({ 'sessions.prevHash': hash });
+  if (user) {
+    const session = sessionsOf(user).find((s) => s.prevHash === hash);
+    const rotatedAt = session.rotatedAt ? new Date(session.rotatedAt).getTime() : 0;
+    return { user, session, reused: true, race: Date.now() - rotatedAt < REUSE_GRACE_MS };
+  }
+
+  user = await User.findOne({ refreshTokenHash: hash });
+  if (user) {
+    const now = new Date(Date.now());
+    sessionsOf(user).push({
+      hash,
+      prevHash: null,
+      rotatedAt: null,
+      expiresAt: user.refreshTokenExpiresAt || null,
+      persistent: user.refreshTokenPersistent !== false,
+      createdAt: now,
+      lastUsedAt: now,
+      client: 'Unknown device',
+    });
+    user.refreshTokenHash = null;
+    user.refreshTokenExpiresAt = null;
+    user.refreshTokenPersistent = null;
+    return { user, session: user.sessions[user.sessions.length - 1], migrated: true };
+  }
+
+  return null;
+};
+
+/**
+ * Issue both tokens: access token in body, refresh token in httpOnly cookie.
+ *  - without `session`: START a device session (login / register / SSO /
+ *    re-auth) with a fresh 30-day deadline (or `expiresAt`, e.g. the demo TTL)
+ *  - with `session`: ROTATE that entry in place (/refresh) — deadline and
+ *    remember-me choice preserved, every other device untouched
+ */
+const issueTokens = async (user, res, { rememberMe, session, client, expiresAt } = {}) => {
+  const now = Date.now();
   const accessToken = generateAccessToken(user);
   const refreshToken = generateRefreshToken();
-  user.setRefreshToken(refreshToken);
-  if (!preserveLifetime) {
-    user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_ABSOLUTE_LIFETIME_MS);
-  }
-  // Persist the remember-me choice at session start so rotation paths
-  // (/refresh, /change-password) reissue the same cookie kind instead of
-  // silently upgrading a session cookie to a persistent one.
-  if (rememberMe !== undefined) {
-    user.refreshTokenPersistent = rememberMe;
+  const hash = hashRefreshToken(refreshToken);
+  let persistent;
+
+  if (session) {
+    session.prevHash = session.hash;
+    session.rotatedAt = new Date(now);
+    session.hash = hash;
+    session.lastUsedAt = new Date(now);
+    // Backfill legacy sessions (null) so every session eventually gets a cap;
+    // never EXTEND an existing one — an attacker who keeps rotating a stolen
+    // token is still cut off at the original deadline.
+    if (!session.expiresAt) session.expiresAt = new Date(now + REFRESH_ABSOLUTE_LIFETIME_MS);
+    persistent = session.persistent !== false;
   } else {
-    rememberMe = user.refreshTokenPersistent === false ? false : true;
+    pruneSessions(user, now);
+    const list = sessionsOf(user);
+    while (list.length >= MAX_SESSIONS_PER_USER) {
+      let oldest = 0;
+      for (let i = 1; i < list.length; i++) {
+        if (new Date(list[i].lastUsedAt).getTime() < new Date(list[oldest].lastUsedAt).getTime()) oldest = i;
+      }
+      list.splice(oldest, 1);
+    }
+    persistent = rememberMe !== false;
+    list.push({
+      hash,
+      prevHash: null,
+      rotatedAt: null,
+      expiresAt: expiresAt || new Date(now + REFRESH_ABSOLUTE_LIFETIME_MS),
+      persistent,
+      createdAt: new Date(now),
+      lastUsedAt: new Date(now),
+      client: client || 'Unknown device',
+    });
   }
+
   await user.save();
-  res.cookie('refreshToken', refreshToken, buildCookieOptions(rememberMe));
+  res.cookie('refreshToken', refreshToken, buildCookieOptions(persistent));
   return accessToken;
 };
 
 module.exports = {
   generateAccessToken,
   generateRefreshToken,
+  hashRefreshToken,
   COOKIE_SECURE,
   refreshCookieBase,
   refreshCookieOptions,
   clearRefreshCookie,
   buildCookieOptions,
   REFRESH_ABSOLUTE_LIFETIME_MS,
+  MAX_SESSIONS_PER_USER,
+  REUSE_GRACE_MS,
+  clientHint,
+  pruneSessions,
+  removeSession,
+  revokeAllSessions,
+  sessionForCookie,
+  resolveRefreshSession,
   issueTokens,
 };

--- a/backend/src/services/authTokens.sessions.test.js
+++ b/backend/src/services/authTokens.sessions.test.js
@@ -1,0 +1,268 @@
+/**
+ * Per-device sessions (services/authTokens.js), unit level.
+ *
+ * The account used to hold ONE refresh-token hash, so signing in on the phone
+ * signed the laptop out (2026-09-04: 247 of 313 consecutive logins on the
+ * hosted instance were the same person switching devices). These tests pin
+ * the replacement: one `sessions[]` entry per device, rotation touches only
+ * its own entry, a cap with least-recently-used eviction, expiry pruning, and
+ * reuse detection with a grace window for lost tab races.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../models/User', () => ({ findOne: jest.fn() }));
+
+const crypto = require('crypto');
+const User = require('../models/User');
+const tokens = require('./authTokens');
+
+const sha256 = (v) => crypto.createHash('sha256').update(v).digest('hex');
+const NOW = 1756944000000; // 2026-09-04T00:00:00Z
+const DAY = 24 * 60 * 60 * 1000;
+
+const makeUser = (overrides = {}) => ({
+  _id: 'u1', roles: ['user'], plan: 'free', sessions: [],
+  refreshTokenHash: null, refreshTokenExpiresAt: null, refreshTokenPersistent: null,
+  save: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+const makeRes = () => ({ cookie: jest.fn(), clearCookie: jest.fn() });
+const cookieValue = (res) => res.cookie.mock.calls[res.cookie.mock.calls.length - 1][1];
+const reqWith = (ua) => ({ headers: { 'user-agent': ua } });
+
+let nowSpy;
+beforeEach(() => {
+  jest.clearAllMocks();
+  nowSpy = jest.spyOn(Date, 'now').mockReturnValue(NOW);
+});
+afterEach(() => nowSpy.mockRestore());
+
+describe('issueTokens — starting a device session', () => {
+  test('adds one entry with a fresh 30-day cap, the remember-me choice and the device label', async () => {
+    const user = makeUser();
+    const res = makeRes();
+    await tokens.issueTokens(user, res, { rememberMe: true, client: 'Android / Chrome' });
+
+    expect(user.sessions).toHaveLength(1);
+    const s = user.sessions[0];
+    expect(s.hash).toBe(sha256(cookieValue(res)));
+    expect(s.prevHash).toBeNull();
+    expect(s.expiresAt.getTime()).toBe(NOW + 30 * DAY);
+    expect(s.persistent).toBe(true);
+    expect(s.client).toBe('Android / Chrome');
+    expect(user.save).toHaveBeenCalledTimes(1);
+    // persistent cookie
+    expect(res.cookie.mock.calls[0][2].maxAge).toBe(7 * DAY);
+  });
+
+  test('a second device adds a second entry and leaves the first untouched', async () => {
+    const user = makeUser();
+    await tokens.issueTokens(user, makeRes(), { client: 'Windows / Firefox' });
+    const first = { ...user.sessions[0] };
+
+    await tokens.issueTokens(user, makeRes(), { client: 'iOS / Safari' });
+
+    expect(user.sessions).toHaveLength(2);
+    expect(user.sessions[0]).toEqual(first);
+    expect(user.sessions[1].client).toBe('iOS / Safari');
+  });
+
+  test('rememberMe=false → session cookie and a non-persistent entry', async () => {
+    const user = makeUser();
+    const res = makeRes();
+    await tokens.issueTokens(user, res, { rememberMe: false });
+    expect(user.sessions[0].persistent).toBe(false);
+    expect(res.cookie.mock.calls[0][2].maxAge).toBeUndefined();
+  });
+
+  test('an explicit expiresAt (demo TTL) replaces the 30-day default', async () => {
+    const user = makeUser();
+    const ttl = new Date(NOW + 2 * 60 * 60 * 1000);
+    await tokens.issueTokens(user, makeRes(), { expiresAt: ttl });
+    expect(user.sessions[0].expiresAt).toBe(ttl);
+  });
+
+  test('past the cap, the least recently used entry is evicted first', async () => {
+    const user = makeUser();
+    for (let i = 0; i < tokens.MAX_SESSIONS_PER_USER; i++) {
+      nowSpy.mockReturnValue(NOW + i * 1000);
+      await tokens.issueTokens(user, makeRes(), { client: `device-${i}` });
+    }
+    // device-3 was used most recently of the old ones; device-0 is the stalest
+    user.sessions[3].lastUsedAt = new Date(NOW + 999999);
+    nowSpy.mockReturnValue(NOW + 100000);
+
+    await tokens.issueTokens(user, makeRes(), { client: 'device-new' });
+
+    expect(user.sessions).toHaveLength(tokens.MAX_SESSIONS_PER_USER);
+    const labels = user.sessions.map((s) => s.client);
+    expect(labels).not.toContain('device-0');
+    expect(labels).toContain('device-3');
+    expect(labels).toContain('device-new');
+  });
+
+  test('expired entries are pruned when a new device signs in', async () => {
+    const user = makeUser({ sessions: [
+      { hash: 'dead', prevHash: null, expiresAt: new Date(NOW - 1), persistent: true, createdAt: new Date(NOW - DAY), lastUsedAt: new Date(NOW - DAY), client: 'old' },
+      { hash: 'live', prevHash: null, expiresAt: new Date(NOW + DAY), persistent: true, createdAt: new Date(NOW - DAY), lastUsedAt: new Date(NOW - DAY), client: 'still here' },
+    ] });
+    await tokens.issueTokens(user, makeRes(), { client: 'new' });
+    expect(user.sessions.map((s) => s.client)).toEqual(['still here', 'new']);
+  });
+});
+
+describe('issueTokens — rotating one device session', () => {
+  test('rotates only its own entry: new hash, old hash kept as prevHash, deadline preserved', async () => {
+    const user = makeUser();
+    await tokens.issueTokens(user, makeRes(), { client: 'phone' });
+    await tokens.issueTokens(user, makeRes(), { client: 'laptop' });
+    const [phone, laptop] = user.sessions;
+    const phoneBefore = { ...phone };
+    const laptopHash = laptop.hash;
+    const deadline = laptop.expiresAt;
+
+    nowSpy.mockReturnValue(NOW + 5 * DAY);
+    const res = makeRes();
+    await tokens.issueTokens(user, res, { session: laptop });
+
+    expect(laptop.hash).toBe(sha256(cookieValue(res)));
+    expect(laptop.prevHash).toBe(laptopHash);
+    expect(laptop.rotatedAt.getTime()).toBe(NOW + 5 * DAY);
+    expect(laptop.lastUsedAt.getTime()).toBe(NOW + 5 * DAY);
+    expect(laptop.expiresAt).toBe(deadline); // not extended
+    expect(user.sessions[0]).toEqual(phoneBefore); // the other device untouched
+  });
+
+  test('a legacy entry with no deadline is backfilled with a fresh cap on rotation', async () => {
+    const user = makeUser({ sessions: [{ hash: 'h', prevHash: null, expiresAt: null, persistent: true, createdAt: new Date(NOW), lastUsedAt: new Date(NOW), client: 'x' }] });
+    await tokens.issueTokens(user, makeRes(), { session: user.sessions[0] });
+    expect(user.sessions[0].expiresAt.getTime()).toBe(NOW + 30 * DAY);
+  });
+
+  test('rotation keeps a non-persistent session on a session cookie', async () => {
+    const user = makeUser();
+    await tokens.issueTokens(user, makeRes(), { rememberMe: false });
+    const res = makeRes();
+    await tokens.issueTokens(user, res, { session: user.sessions[0] });
+    expect(res.cookie.mock.calls[0][2].maxAge).toBeUndefined();
+    expect(user.sessions[0].persistent).toBe(false);
+  });
+});
+
+describe('resolveRefreshSession', () => {
+  const plant = (user, { rotatedAgoMs } = {}) => {
+    const raw = crypto.randomBytes(64).toString('hex');
+    const entry = { hash: sha256(raw), prevHash: null, rotatedAt: null, expiresAt: new Date(NOW + DAY), persistent: true, createdAt: new Date(NOW), lastUsedAt: new Date(NOW), client: 'c' };
+    if (rotatedAgoMs !== undefined) {
+      entry.prevHash = entry.hash;
+      entry.hash = sha256('rotated-' + raw);
+      entry.rotatedAt = new Date(NOW - rotatedAgoMs);
+    }
+    user.sessions.push(entry);
+    return { raw, entry };
+  };
+  const wireLookup = (user) => {
+    User.findOne.mockImplementation(async (q) => {
+      const [k, v] = Object.entries(q)[0];
+      if (k === 'sessions.hash') return user.sessions.some((s) => s.hash === v) ? user : null;
+      if (k === 'sessions.prevHash') return user.sessions.some((s) => s.prevHash === v) ? user : null;
+      if (k === 'refreshTokenHash') return user.refreshTokenHash === v ? user : null;
+      return null;
+    });
+  };
+
+  test('a live token resolves to its own device entry', async () => {
+    const user = makeUser();
+    plant(user);
+    const { raw, entry } = plant(user);
+    wireLookup(user);
+    const found = await tokens.resolveRefreshSession(raw);
+    expect(found.user).toBe(user);
+    expect(found.session).toBe(entry);
+    expect(found.reused).toBeUndefined();
+  });
+
+  test('a token rotated away 10 s ago is a race, not theft', async () => {
+    const user = makeUser();
+    const { raw } = plant(user, { rotatedAgoMs: 10 * 1000 });
+    wireLookup(user);
+    const found = await tokens.resolveRefreshSession(raw);
+    expect(found.reused).toBe(true);
+    expect(found.race).toBe(true);
+  });
+
+  test('a token rotated away 5 minutes ago is reuse', async () => {
+    const user = makeUser();
+    const { raw } = plant(user, { rotatedAgoMs: 5 * 60 * 1000 });
+    wireLookup(user);
+    const found = await tokens.resolveRefreshSession(raw);
+    expect(found.reused).toBe(true);
+    expect(found.race).toBe(false);
+  });
+
+  test('a pre-sessions single-token row is adopted into sessions[] with its deadline and remember-me', async () => {
+    const raw = crypto.randomBytes(64).toString('hex');
+    const user = makeUser({ refreshTokenHash: sha256(raw), refreshTokenExpiresAt: new Date(NOW + 3 * DAY), refreshTokenPersistent: false });
+    wireLookup(user);
+
+    const found = await tokens.resolveRefreshSession(raw);
+
+    expect(found.migrated).toBe(true);
+    expect(user.sessions).toHaveLength(1);
+    expect(found.session).toBe(user.sessions[0]);
+    expect(found.session.hash).toBe(sha256(raw));
+    expect(found.session.expiresAt.getTime()).toBe(NOW + 3 * DAY);
+    expect(found.session.persistent).toBe(false);
+    expect(user.refreshTokenHash).toBeNull();
+    expect(user.refreshTokenExpiresAt).toBeNull();
+    expect(user.refreshTokenPersistent).toBeNull();
+  });
+
+  test('unknown token → null', async () => {
+    const user = makeUser();
+    plant(user);
+    wireLookup(user);
+    expect(await tokens.resolveRefreshSession('nope')).toBeNull();
+  });
+});
+
+describe('helpers', () => {
+  test('revokeAllSessions empties the list and the legacy fields', () => {
+    const user = makeUser({ sessions: [{ hash: 'a' }], refreshTokenHash: 'x', refreshTokenExpiresAt: new Date(), refreshTokenPersistent: true });
+    tokens.revokeAllSessions(user);
+    expect(user.sessions).toEqual([]);
+    expect(user.refreshTokenHash).toBeNull();
+    expect(user.refreshTokenExpiresAt).toBeNull();
+    expect(user.refreshTokenPersistent).toBeNull();
+  });
+
+  test('removeSession drops exactly that device', () => {
+    const user = makeUser({ sessions: [{ hash: 'a' }, { hash: 'b' }, { hash: 'c' }] });
+    tokens.removeSession(user, { hash: 'b' });
+    expect(user.sessions.map((s) => s.hash)).toEqual(['a', 'c']);
+  });
+
+  test('sessionForCookie finds the entry behind the request cookie', () => {
+    const raw = 'tok';
+    const user = makeUser({ sessions: [{ hash: 'other' }, { hash: sha256(raw) }] });
+    expect(tokens.sessionForCookie(user, { cookies: { refreshToken: raw } })).toBe(user.sessions[1]);
+    expect(tokens.sessionForCookie(user, { cookies: {} })).toBeNull();
+  });
+
+  test.each([
+    ['Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Mobile Safari/537.36', 'Android / Chrome'],
+    ['Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0', 'Windows / Firefox'],
+    ['Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1', 'iOS / Safari'],
+    ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36 Edg/152.0.0.0', 'Windows / Edge'],
+    ['', 'Unknown device'],
+  ])('clientHint labels %s as %s', (ua, label) => {
+    expect(tokens.clientHint(reqWith(ua))).toBe(label);
+  });
+
+  test('clientHint never stores the raw user-agent', () => {
+    const label = tokens.clientHint(reqWith('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/152.0.0.0 Safari/537.36 SecretBuild/1.2.3'));
+    expect(label).toBe('Linux / Chrome');
+    expect(label).not.toContain('SecretBuild');
+  });
+});

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -154,6 +154,13 @@ const REGISTRY = [
           aiBudgetOverride: u.aiBudgetOverride?.max
             ? { max: u.aiBudgetOverride.max, expiresAt: u.aiBudgetOverride.expiresAt }
             : null,
+          // Signed-in devices (per-device sessions). Metadata only — the token
+          // hashes are the credential itself, not the user's data, and never
+          // leave the database.
+          sessions: (u.sessions || []).map(s => ({
+            client: s.client, createdAt: s.createdAt, lastUsedAt: s.lastUsedAt,
+            expiresAt: s.expiresAt, persistent: s.persistent !== false,
+          })),
         },
       };
     },

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -80,11 +80,14 @@ export const AuthProvider = ({ children }) => {
   const refreshInFlightRef = useRef(null);
 
   // The ref only guards THIS tab, but the refresh cookie is browser-wide and
-  // the backend stores a single rotating token hash — two tabs refreshing at
+  // the backend rotates ONE hash per browser session — two tabs refreshing at
   // once (typical after browser session-restore reopens several Cellarion
   // tabs) race the rotation and the loser is spuriously logged out. The Web
   // Locks API serializes across tabs of the same origin: the waiter re-runs
   // with the cookie its predecessor just rotated in, which is valid.
+  // (Sessions are per DEVICE server-side since 2026-09-04, so signing in on
+  // another device no longer invalidates this browser's cookie; the race
+  // above is the only remaining way two refreshes can collide.)
   const doRefresh = async () => {
     const res = await fetch('/api/auth/refresh', {
       method: 'POST',


### PR DESCRIPTION
## Summary

Johan noticed constant re-logins, and the audit log showed the same for other users. Cause: the account held **one** refresh-token hash. Every login (password, Google, every rotation) overwrote it, so a second device's login left the first device's cookie matching nothing; its next `/refresh` got a 401 and the client treated that as a dead session.

Prod audit log, last 14 days: 416 logins by 103 users, 39 of them on two or more device types; **247 of 313 consecutive logins followed a login from a different device type** (210 within 24 h). One account: 89 of 102 logins were device switches, strictly alternating Android and Windows.

## Changes

- **`User.sessions[]`** — one entry per signed-in browser: `hash`, `prevHash` (most recently rotated away), absolute `expiresAt`, `persistent`, `createdAt`/`lastUsedAt`, short `client` label ("Android / Chrome", never the raw UA). Indexes on `sessions.hash` and `sessions.prevHash`.
- **`services/authTokens.js`** — `issueTokens` starts a device session or rotates one in place; `resolveRefreshSession`, `revokeAllSessions`, `removeSession`, `sessionForCookie`, `clientHint`. Cap 10 per account (LRU eviction), expired entries pruned on sign-in.
- **`/refresh`** rotates only its own entry. **`/logout`** removes only its own entry (by current or just-rotated hash). Password change / reset and the account-deletion request still revoke everything. Demo sessions keep their TTL as the entry's deadline.
- **Reuse detection** (July test audit gap): a rotated-away token replayed within 60 s is a lost tab race → plain 401, nothing revoked; after that it is theft evidence → every session revoked + `auth.session.reuse_detected` audited.
- **Rollout signs nobody out**: a pre-sessions `refreshTokenHash` row is adopted into `sessions[]` on its first refresh (deadline and remember-me preserved), then the legacy fields are nulled. Legacy fields + index kept one release for that lookup.
- **GDPR**: sessions metadata (never hashes) added to `/api/users/me/export`; lives on the user doc so it dies with the account.
- Frontend: comment only. The Web-Locks single-flight still covers the two-tabs race.

## Test plan

- [x] `authTokens.sessions.test.js` (new, 21 tests): start/rotate/cap/prune/reuse-grace/migration/helpers/clientHint
- [x] `auth.refresh.test.js` rewritten for per-device sessions: two devices rotate independently, legacy row adopted, reuse inside/outside grace, expiry purges one device, logout removes only its own entry
- [x] `User.test.js`, `oauth.test.js`, `userDataRegistry*.test.js`, `users.*.test.js`, `middleware/auth.test.js`, `demo*.test.js` — 205 tests green in node:24-alpine
- [ ] prod: after deploy, sign in on a second device and confirm the first stays signed in; watch `/api/auth/refresh` for 401s
