### PR TITLE
fix(auth): Google sign-in returns to the page you were heading for

### DIFF
--- a/frontend/src/pages/Login.destination.test.js
+++ b/frontend/src/pages/Login.destination.test.js
@@ -1,0 +1,76 @@
+/**
+ * Where a successful password sign-in lands. Router state is the #1165 path and
+ * already worked; the stash covers coming back to /login after an SSO attempt
+ * that failed or was cancelled, where "Back to login" navigates without state.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Login from './Login';
+import { stashPostLoginRedirect, takePostLoginRedirect } from '../utils/postLoginRedirect';
+
+// t returns the key, or the inline English fallback where one is given.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key, fallback) => (typeof fallback === 'string' ? fallback : key) }),
+  Trans: ({ children }) => children,
+}));
+
+const navigateMock = vi.fn();
+let routerLocation;
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useLocation: () => routerLocation,
+}));
+
+const loginMock = vi.fn();
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ login: loginMock, register: vi.fn() }),
+}));
+
+vi.mock('../hooks/useVersion', () => ({ default: () => null }));
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  navigateMock.mockReset();
+  routerLocation = { pathname: '/login', search: '', state: null };
+  loginMock.mockReset().mockResolvedValue({ success: true });
+  // The SSO-providers probe; the button itself is not under test here.
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ google: false }) });
+});
+
+// The mode toggle carries the same label as the submit button, so target the
+// form's submit directly rather than by accessible name.
+const signIn = async () => {
+  fireEvent.change(screen.getByLabelText('auth.usernameOrEmail'), { target: { value: 'someone' } });
+  fireEvent.change(screen.getByLabelText('auth.passwordLabel'), { target: { value: 'hunter2' } });
+  fireEvent.click(document.querySelector('form button[type="submit"]'));
+};
+
+test('router state still wins — #1165 is untouched', async () => {
+  routerLocation.state = { from: '/cellars/abc/room?focusRack=def' };
+  render(<Login />);
+  await signIn();
+  await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/cellars/abc/room?focusRack=def'));
+});
+
+test('falls back to a stashed destination when the router state is gone', async () => {
+  // The shape after cancelling at the provider: "Back to login" navigates
+  // without state, so only the stash remembers where they were heading.
+  stashPostLoginRedirect('/wishlist');
+  render(<Login />);
+  await signIn();
+  await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/wishlist'));
+});
+
+test('a plain sign-in with neither still lands on /cellars', async () => {
+  render(<Login />);
+  await signIn();
+  await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/cellars'));
+});
+
+test('consumes the stash even when router state wins, so it cannot be inherited later', async () => {
+  routerLocation.state = { from: '/cellars' };
+  stashPostLoginRedirect('/wishlist');
+  render(<Login />);
+  await signIn();
+  await waitFor(() => expect(navigateMock).toHaveBeenCalled());
+  expect(takePostLoginRedirect()).toBeNull();
+});

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation, Trans } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import useVersion from '../hooks/useVersion';
-import { stashPostLoginRedirect } from '../utils/postLoginRedirect';
+import { stashPostLoginRedirect, takePostLoginRedirect } from '../utils/postLoginRedirect';
 import './Login.css';
 
 const LOGO_WEBP = '/cellarion-logo-light.webp';
@@ -81,8 +81,14 @@ function Login() {
         setRegisteredEmail(result.email);
         setRegistered(true);
       } else {
-        // Finish the journey they started, or the default home for a plain sign-in.
-        navigate(location.state?.from || '/cellars');
+        // Finish the journey they started, or the default home for a plain
+        // sign-in. Router state is preferred; the stash covers coming back here
+        // after an SSO attempt that failed or was cancelled, where the state is
+        // gone. Consumed unconditionally — leaving it behind when router state
+        // wins is how an abandoned journey gets inherited by a later sign-in in
+        // this tab.
+        const stashed = takePostLoginRedirect();
+        navigate(location.state?.from || stashed || '/cellars');
       }
     } else {
       if (result.code === 'EMAIL_NOT_VERIFIED') {

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation, Trans } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import useVersion from '../hooks/useVersion';
+import { stashPostLoginRedirect } from '../utils/postLoginRedirect';
 import './Login.css';
 
 const LOGO_WEBP = '/cellarion-logo-light.webp';
@@ -311,7 +312,12 @@ function Login() {
             <button
               type="button"
               className="btn btn-google btn-full"
-              onClick={() => { window.location.href = '/api/auth/google'; }}
+              onClick={() => {
+                // Router state does not survive the full-page trip out to
+                // Google, so hand the destination over before we leave.
+                stashPostLoginRedirect(location.state?.from);
+                window.location.href = '/api/auth/google';
+              }}
             >
               <GoogleIcon />
               <span>{t('auth.continueWithGoogle', 'Continue with Google')}</span>

--- a/frontend/src/pages/OAuthCallback.js
+++ b/frontend/src/pages/OAuthCallback.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { takePostLoginRedirect } from '../utils/postLoginRedirect';
@@ -23,14 +23,24 @@ function OAuthCallback() {
   const [params] = useSearchParams();
   const error = params.get('error');
 
+  // The stashed destination is single-use, and StrictMode double-invokes mount
+  // effects in dev (index.js): run one would consume it and navigate, run two
+  // would find nothing and replace with /cellars — so the fix would work in
+  // production and silently not in dev. Run once per mount cycle, as
+  // VerifyEmail does for its single-use token.
+  const ranRef = useRef(false);
+  const signedIn = Boolean(user);
+
   useEffect(() => {
     if (error) return; // show the error card + let the user go back to login
+    if (ranRef.current) return;
+    ranRef.current = true;
     // No error: the session either restored (→ wherever they were heading
     // before the sign-in interrupted them, else home) or silently failed
     // (→ login). The stash is left alone on failure so that retrying still
     // finishes the journey.
-    navigate(user ? (takePostLoginRedirect() || '/cellars') : '/login', { replace: true });
-  }, [error, user, navigate]);
+    navigate(signedIn ? (takePostLoginRedirect() || '/cellars') : '/login', { replace: true });
+  }, [error, signedIn, navigate]);
 
   if (error) {
     return (

--- a/frontend/src/pages/OAuthCallback.js
+++ b/frontend/src/pages/OAuthCallback.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { takePostLoginRedirect } from '../utils/postLoginRedirect';
 import './Login.css';
 
 // Landing route for the OAuth round-trip (backend redirects here after Google).
@@ -24,8 +25,11 @@ function OAuthCallback() {
 
   useEffect(() => {
     if (error) return; // show the error card + let the user go back to login
-    // No error: the session either restored (→ home) or silently failed (→ login).
-    navigate(user ? '/cellars' : '/login', { replace: true });
+    // No error: the session either restored (→ wherever they were heading
+    // before the sign-in interrupted them, else home) or silently failed
+    // (→ login). The stash is left alone on failure so that retrying still
+    // finishes the journey.
+    navigate(user ? (takePostLoginRedirect() || '/cellars') : '/login', { replace: true });
   }, [error, user, navigate]);
 
   if (error) {

--- a/frontend/src/pages/OAuthCallback.test.js
+++ b/frontend/src/pages/OAuthCallback.test.js
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import OAuthCallback from './OAuthCallback';
+import { stashPostLoginRedirect, takePostLoginRedirect } from '../utils/postLoginRedirect';
+
+const navigateMock = vi.fn();
+let searchParams;
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [searchParams],
+}));
+
+let authState;
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => authState }));
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  navigateMock.mockReset();
+  searchParams = new URLSearchParams();
+  authState = { user: { _id: 'u1' } };
+});
+
+test('finishes the journey the deep link started (#1165, now for SSO too)', () => {
+  stashPostLoginRedirect('/cellars/abc/room?focusRack=def');
+  render(<OAuthCallback />);
+  expect(navigateMock).toHaveBeenCalledWith('/cellars/abc/room?focusRack=def', { replace: true });
+});
+
+test('a plain sign-in with no destination still lands on /cellars', () => {
+  render(<OAuthCallback />);
+  expect(navigateMock).toHaveBeenCalledWith('/cellars', { replace: true });
+});
+
+test('a destination is consumed once, so a later sign-in is not steered by it', () => {
+  stashPostLoginRedirect('/wishlist');
+  render(<OAuthCallback />);
+  expect(takePostLoginRedirect()).toBeNull();
+});
+
+test('a session that did not restore goes to /login and keeps the destination for the retry', () => {
+  authState.user = null;
+  stashPostLoginRedirect('/wishlist');
+  render(<OAuthCallback />);
+  expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true });
+  expect(takePostLoginRedirect()).toBe('/wishlist');
+});
+
+test('a failed sign-in does not navigate and keeps the destination for the retry', () => {
+  searchParams = new URLSearchParams({ error: 'access_denied' });
+  stashPostLoginRedirect('/wishlist');
+  render(<OAuthCallback />);
+  expect(navigateMock).not.toHaveBeenCalled();
+  expect(takePostLoginRedirect()).toBe('/wishlist');
+});

--- a/frontend/src/pages/OAuthCallback.test.js
+++ b/frontend/src/pages/OAuthCallback.test.js
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { render } from '@testing-library/react';
 import OAuthCallback from './OAuthCallback';
 import { stashPostLoginRedirect, takePostLoginRedirect } from '../utils/postLoginRedirect';
@@ -50,4 +51,14 @@ test('a failed sign-in does not navigate and keeps the destination for the retry
   render(<OAuthCallback />);
   expect(navigateMock).not.toHaveBeenCalled();
   expect(takePostLoginRedirect()).toBe('/wishlist');
+});
+
+test('survives StrictMode\'s dev double-mount — the destination is not overwritten by /cellars', () => {
+  // Dev runs under React.StrictMode (index.js:11), which invokes mount effects
+  // twice. The stash is single-use, so an unguarded effect consumes it on the
+  // first run and replaces with /cellars on the second — the fix would work in
+  // production and silently not in dev. Same trap VerifyEmail.js guards.
+  stashPostLoginRedirect('/wishlist');
+  render(<StrictMode><OAuthCallback /></StrictMode>);
+  expect(navigateMock).toHaveBeenLastCalledWith('/wishlist', { replace: true });
 });

--- a/frontend/src/utils/postLoginRedirect.js
+++ b/frontend/src/utils/postLoginRedirect.js
@@ -11,13 +11,18 @@
  * mechanism the OIDC client libraries use to carry a PKCE verifier across that
  * trip.
  *
- * Deliberately NOT a ?next= query parameter, which would put the destination
- * into a crafted link and turn the auth path into an open redirect. As with
- * router state, nothing here is ever read from a URL — the only writer is our
- * own code, passing a value ProtectedRoute produced. The validation below is
- * therefore belt-and-braces rather than the primary defence, but it is cheap,
- * and it keeps the guarantee inside this file rather than resting on an
- * argument about every call site.
+ * Deliberately NOT a ?next= query parameter: that would let a crafted link name
+ * any destination at all. What ProtectedRoute records is narrower — the path the
+ * visitor was already on, which had to match a protected route to get here.
+ *
+ * Narrower is not the same as trusted, so the validation below is load-bearing
+ * rather than decorative. An attacker still chooses the link, and react-router's
+ * push falls back to window.location.assign() when pushState throws (which it
+ * does for a cross-origin URL), so navigating to a protocol-relative path would
+ * genuinely leave the origin. Today no protected route can match one — they are
+ * all literal-prefixed and '//evil.example' falls to the unprotected catch-all —
+ * but that is a property of the route table, not a guarantee, and it would
+ * evaporate the day a wildcard route becomes protected. Hence the checks here.
  */
 
 const STORAGE_KEY = 'cellarion.postLoginRedirect';
@@ -45,14 +50,18 @@ export function isSafeInternalPath(path) {
 }
 
 /**
- * Remember where to return to. Silently ignores anything unsafe or absent — no
- * destination is the normal case (a plain visit to /login), and the caller has
- * nothing useful to do about it.
+ * Record where to return to at the start of a sign-in — and, just as important,
+ * clear any earlier destination when this sign-in has none.
+ *
+ * Skipping instead of clearing would let an abandoned journey be inherited by
+ * the next sign-in in the tab: cancel at the provider, come back, sign in
+ * plainly, and you would land on the page someone was heading for earlier. On a
+ * shared computer that is someone else's cellar.
  */
 export function stashPostLoginRedirect(path) {
-  if (!isSafeInternalPath(path)) return;
   try {
-    window.sessionStorage.setItem(STORAGE_KEY, path);
+    if (isSafeInternalPath(path)) window.sessionStorage.setItem(STORAGE_KEY, path);
+    else window.sessionStorage.removeItem(STORAGE_KEY);
   } catch {
     // Storage disabled or full. Sign-in still works, it just ends on /cellars —
     // which is what everyone had before this.

--- a/frontend/src/utils/postLoginRedirect.js
+++ b/frontend/src/utils/postLoginRedirect.js
@@ -1,0 +1,75 @@
+/**
+ * Where to send someone once they finish signing in.
+ *
+ * ProtectedRoute carries the destination in router state, which survives the
+ * client-side hop to /login but not the full-page redirect out to an SSO
+ * provider and back — so the password path lands correctly (#1165) while the
+ * Google path always ended on /cellars.
+ *
+ * The destination is stashed here instead, in sessionStorage: scoped to this
+ * origin and this tab, it survives the cross-origin round trip. It is the same
+ * mechanism the OIDC client libraries use to carry a PKCE verifier across that
+ * trip.
+ *
+ * Deliberately NOT a ?next= query parameter, which would put the destination
+ * into a crafted link and turn the auth path into an open redirect. As with
+ * router state, nothing here is ever read from a URL — the only writer is our
+ * own code, passing a value ProtectedRoute produced. The validation below is
+ * therefore belt-and-braces rather than the primary defence, but it is cheap,
+ * and it keeps the guarantee inside this file rather than resting on an
+ * argument about every call site.
+ */
+
+const STORAGE_KEY = 'cellarion.postLoginRedirect';
+
+// Generous for a deep link with a query string; small enough that the key
+// cannot be used as general-purpose storage.
+const MAX_LENGTH = 512;
+
+// C0 controls plus DEL. A newline or tab inside a path is never legitimate
+// here, and is the classic way to smuggle something past a naive check.
+const CONTROL_CHARS = /[\u0000-\u001F\u007F]/;
+
+/**
+ * True for a path that stays inside this app. Rejects anything a browser would
+ * resolve to another origin.
+ */
+export function isSafeInternalPath(path) {
+  if (typeof path !== 'string') return false;
+  if (path.length === 0 || path.length > MAX_LENGTH) return false;
+  if (path[0] !== '/') return false;      // must be root-relative
+  if (path[1] === '/') return false;      // //evil.com is protocol-relative
+  if (path.includes('\\')) return false;  // browsers fold \ to /, so /\evil.com escapes
+  if (CONTROL_CHARS.test(path)) return false;
+  return true;
+}
+
+/**
+ * Remember where to return to. Silently ignores anything unsafe or absent — no
+ * destination is the normal case (a plain visit to /login), and the caller has
+ * nothing useful to do about it.
+ */
+export function stashPostLoginRedirect(path) {
+  if (!isSafeInternalPath(path)) return;
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, path);
+  } catch {
+    // Storage disabled or full. Sign-in still works, it just ends on /cellars —
+    // which is what everyone had before this.
+  }
+}
+
+/**
+ * Read the destination and clear it, so a stale value can never redirect a
+ * later sign-in. Returns null when there isn't one.
+ */
+export function takePostLoginRedirect() {
+  let value = null;
+  try {
+    value = window.sessionStorage.getItem(STORAGE_KEY);
+    window.sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  return isSafeInternalPath(value) ? value : null;
+}

--- a/frontend/src/utils/postLoginRedirect.test.js
+++ b/frontend/src/utils/postLoginRedirect.test.js
@@ -1,0 +1,92 @@
+/**
+ * The destination is only ever written by our own code, so these cases are
+ * about the guarantee holding locally rather than about a live attack path —
+ * if a ?next= parameter is ever wired in, this is the file that says what
+ * "safe" means.
+ */
+import { isSafeInternalPath, stashPostLoginRedirect, takePostLoginRedirect } from './postLoginRedirect';
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('isSafeInternalPath', () => {
+  it('accepts a root-relative path, query string included', () => {
+    expect(isSafeInternalPath('/cellars/6a74f551/room?focusRack=6a750135')).toBe(true);
+    expect(isSafeInternalPath('/')).toBe(true);
+  });
+
+  it('rejects anything that is not a non-empty string', () => {
+    expect(isSafeInternalPath(null)).toBe(false);
+    expect(isSafeInternalPath(undefined)).toBe(false);
+    expect(isSafeInternalPath('')).toBe(false);
+    expect(isSafeInternalPath(42)).toBe(false);
+    expect(isSafeInternalPath({ toString: () => '/cellars' })).toBe(false);
+  });
+
+  it('rejects paths that leave the origin', () => {
+    expect(isSafeInternalPath('https://evil.example/steal')).toBe(false);
+    expect(isSafeInternalPath('//evil.example/steal')).toBe(false); // protocol-relative
+    expect(isSafeInternalPath('/\\evil.example')).toBe(false);      // browsers fold \ to /
+    expect(isSafeInternalPath('cellars')).toBe(false);              // not root-relative
+    expect(isSafeInternalPath('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects control characters smuggled into the path', () => {
+    expect(isSafeInternalPath('/cellars\n/evil')).toBe(false);
+    expect(isSafeInternalPath('/cellars\t/evil')).toBe(false);
+  });
+
+  it('rejects a path long enough to be storage rather than a destination', () => {
+    expect(isSafeInternalPath(`/${'a'.repeat(511)}`)).toBe(true);
+    expect(isSafeInternalPath(`/${'a'.repeat(512)}`)).toBe(false);
+  });
+});
+
+describe('stash and take', () => {
+  it('carries a destination across the round trip', () => {
+    stashPostLoginRedirect('/cellars/abc/room?focusRack=def');
+    expect(takePostLoginRedirect()).toBe('/cellars/abc/room?focusRack=def');
+  });
+
+  it('clears on read, so a stale destination cannot steer a later sign-in', () => {
+    stashPostLoginRedirect('/wishlist');
+    expect(takePostLoginRedirect()).toBe('/wishlist');
+    expect(takePostLoginRedirect()).toBeNull();
+  });
+
+  it('returns null when nothing was stashed', () => {
+    expect(takePostLoginRedirect()).toBeNull();
+  });
+
+  it('ignores an unsafe destination rather than storing it', () => {
+    stashPostLoginRedirect('//evil.example');
+    expect(takePostLoginRedirect()).toBeNull();
+  });
+
+  it('re-checks on the way out, so a poisoned store cannot redirect off-origin', () => {
+    window.sessionStorage.setItem('cellarion.postLoginRedirect', 'https://evil.example');
+    expect(takePostLoginRedirect()).toBeNull();
+  });
+
+  it('degrades to no destination when storage is unavailable', () => {
+    // Replace the whole object rather than spying on its methods: jsdom puts
+    // Storage behind a proxy, so a method spy never fires and the test would
+    // pass against real storage without ever exercising the failure path.
+    const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+    const unavailable = () => { throw new Error('storage disabled'); };
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: { getItem: unavailable, setItem: unavailable, removeItem: unavailable },
+    });
+
+    try {
+      expect(() => stashPostLoginRedirect('/cellars/abc')).not.toThrow();
+      expect(takePostLoginRedirect()).toBeNull();
+    } finally {
+      if (original) Object.defineProperty(window, 'sessionStorage', original);
+      else delete window.sessionStorage;
+    }
+  });
+});

--- a/frontend/src/utils/postLoginRedirect.test.js
+++ b/frontend/src/utils/postLoginRedirect.test.js
@@ -65,6 +65,20 @@ describe('stash and take', () => {
     expect(takePostLoginRedirect()).toBeNull();
   });
 
+  it('clears a previous destination when a sign-in starts without one', () => {
+    // Otherwise an abandoned journey is inherited by the next sign-in in this
+    // tab — on a shared computer, someone else's cellar.
+    stashPostLoginRedirect('/wishlist');
+    stashPostLoginRedirect(undefined);
+    expect(takePostLoginRedirect()).toBeNull();
+  });
+
+  it('clears rather than keeps a previous destination when handed an unsafe one', () => {
+    stashPostLoginRedirect('/wishlist');
+    stashPostLoginRedirect('//evil.example');
+    expect(takePostLoginRedirect()).toBeNull();
+  });
+
   it('re-checks on the way out, so a poisoned store cannot redirect off-origin', () => {
     window.sessionStorage.setItem('cellarion.postLoginRedirect', 'https://evil.example');
     expect(takePostLoginRedirect()).toBeNull();


### PR DESCRIPTION
## What this changes

Fixes #1220. A signed-out deep link bounces to `/login` and, since #1165, signing
in with a password finishes the journey. Signing in with Google still lands on
`/cellars` — `ProtectedRoute`'s router state doesn't survive the full-page
redirect out to Google and back, and nothing downstream carries a destination,
so `OAuthCallback` has only its constant to offer.

The destination is now stashed in `sessionStorage` before leaving, and consumed
by `OAuthCallback` on success. Scoped to the origin and the tab, it survives the
cross-origin trip — the same mechanism the OIDC client libraries use to carry a
PKCE verifier across it.

**Deliberately not a `?next=` query parameter or the OAuth `state` parameter**,
which is worth explaining since I suggested `state` in #1203 before reading your
`ProtectedRoute` comment properly. Both would put the destination somewhere an
attacker can set, giving up exactly the property that comment relies on — "can't
be steered by a crafted link, so it needs no allow-list" — and turning the auth
path into an open redirect unless a validator is added. Holding it client-side
keeps the property: the only writer is the app's own code, and nothing is ever
read from a URL. The path validation in the new util is belt-and-braces rather
than the defence, and says so in a comment, so nobody later mistakes it for the
thing standing between us and an open redirect.

Two smaller decisions, both tested:

- **A failed or cancelled sign-in leaves the stash alone.** The usual next step
  is to try again, and clearing there would throw away the thing worth keeping.
  It is consumed only on success, so a stale destination can never steer a later
  sign-in.
- **No backend change, and nothing in it names Google.** A second provider — the
  OIDC work in #1203 — inherits the behaviour with no further plumbing. Happy to
  move it into `oauth.js` if you'd rather it lived server-side; you mentioned
  `oauth.test.js` as the file to extend, and this landed somewhere else.

Five files: a new `frontend/src/utils/postLoginRedirect.js` plus its tests, a new
`OAuthCallback.test.js`, six lines in `Login.js` and one in `OAuthCallback.js`.

## How I tested it

Both suites, and a local `docker compose up --build` at v1.200.2 against a
throwaway Google OAuth client — run **before** the change to watch the bug, then
after.

- **Before:** from `/wishlist` signed out → *Continue with Google* → landed on
  `/cellars`. The bug, observed.
- **After:** same journey → landed on `/wishlist`.
- **Plain sign-in unaffected:** Google sign-in with no deep link still lands on
  `/cellars`.
- **Password path untouched:** `/wishlist` → email + password → `/wishlist`.
- **Cancel then retry:** cancelled at Google's consent screen, took *Back to
  login*, signed in properly → still arrived at `/wishlist`.

Unit tests: 11 cases on the util (validator, round trip, consumed-once, poisoned
store, storage unavailable) and 5 on `OAuthCallback`. I checked they fail for the
right reason — reverting `OAuthCallback.js` to `main` fails exactly the two that
assert the new behaviour, and leaves the three asserting existing behaviour
passing.

No screenshots: nothing visual changed, only where you end up.

## Checklist

- [x] `cd frontend && npm test` passes — 1160 tests, 80 files
- [x] `cd backend && npm test` passes — 4845 tests, 308 suites (untouched, run to
      confirm no collateral)
- [x] Smoke-tested in Docker (`docker compose up --build`) and used the change in
      the app
- [x] Commits are signed off (`git commit -s`, see CONTRIBUTING.md)
- [x] No non-English `translation.json` files touched (no strings added at all)
- [ ] n/a — no personal data stored, processed or shared. The stashed value is a
      path, held in the visitor's own browser and cleared on use.
- [x] If AI tools helped write this, that is mentioned above and I have run the
      result myself

**AI assistance:** written with Claude Code. I ran the result myself — both
suites, and the full before/after journey in Docker described above, including
watching the bug happen on unmodified `main` first. The design decision to hold
the destination client-side rather than in `state` was taken deliberately - if you disagree, please let me know.