### PR TITLE
fix(security): audit phase-6 remediation — analytics never sees reset tokens, fonts and rates served by us, wine-request images validated, bearer only to our API

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -74,6 +74,7 @@ const wineListPublicRoute = require('./routes/wineListPublic');
 const sitemapRoute = require('./routes/sitemap');
 const ogRoute = require('./routes/og');
 const taxonomyRoute = require('./routes/taxonomy');
+const exchangeRatesRoute = require('./routes/exchangeRates');
 const stripeRoute = require('./routes/stripe');
 const tokensRoute = require('./routes/tokens');
 const eventsRoute = require('./routes/events');
@@ -340,6 +341,9 @@ app.use('/api/forum-languages', forumLanguagesRoute);
 app.use('/api/push-subscriptions', pushSubscriptionsRoute);
 app.use('/api/blog', blogRoute);
 app.use('/api/taxonomy', taxonomyRoute);
+// Exchange rates for the price UI — served from the backend's daily snapshot so
+// the browser never contacts the upstream provider itself (audit 2026-09 F03-4).
+app.use('/api/exchange-rates', exchangeRatesRoute);
 app.use('/api/wishlist', wishlistRoute);
 app.use('/api/recommendations', recommendationsRoute);
 app.use('/api/journal', journalRoute);

--- a/backend/src/routes/admin/wineRequests.image.test.js
+++ b/backend/src/routes/admin/wineRequests.image.test.js
@@ -1,0 +1,132 @@
+/**
+ * PUT /api/admin/wine-requests/:id/resolve (createNew) — the image field.
+ *
+ * Audit 2026-09 F06-1: the request's `image` is chosen by ANY user, and the
+ * approval used to store `image || wineRequest.image || null` — so a blanked
+ * field silently fell back to the requester's value, and nothing checked its
+ * shape. A protocol-relative `//attacker/x` then reached WineDefinition.image,
+ * where every viewer's AuthImage fetched it with the bearer token attached.
+ * This suite pins: explicit blank ⇒ null; only http(s) / inline / own-upload
+ * shapes are stored; a bad value (typed or inherited) is a 400, nothing minted.
+ */
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../../models/WineRequest', () => ({ findById: jest.fn() }));
+jest.mock('../../models/WineDefinition', () => {
+  const ctor = jest.fn();
+  ctor.findById = jest.fn();
+  ctor.findOne = jest.fn();
+  return ctor;
+});
+jest.mock('../../models/Bottle', () => ({ distinct: jest.fn(), updateMany: jest.fn() }));
+jest.mock('../../models/Country', () => ({ findById: jest.fn() }));
+jest.mock('../../services/findOrCreateWine', () => ({ findOrCreateWine: jest.fn() }));
+jest.mock('../../services/appellationResolve', () => ({ resolveCanonicalAppellation: jest.fn(async (v) => v) }));
+jest.mock('../../services/search', () => ({ indexWine: jest.fn() }));
+jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../../services/notifications', () => ({ createNotification: jest.fn() }));
+jest.mock('../../utils/cellarCred', () => ({ incrementCred: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../../utils/vintageProfile', () => ({ ensurePendingVintageProfile: jest.fn() }));
+jest.mock('../../services/crossFieldScan', () => ({ detectBlockingProducerIssue: jest.fn(async () => null) }));
+jest.mock('../../services/producerSpelling', () => ({ resolveCanonicalProducerSpelling: jest.fn(async (p) => p) }));
+
+const express = require('express');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const WineRequest = require('../../models/WineRequest');
+const WineDefinition = require('../../models/WineDefinition');
+const Bottle = require('../../models/Bottle');
+const Country = require('../../models/Country');
+const { findOrCreateWine } = require('../../services/findOrCreateWine');
+const wineRequestsRouter = require('./wineRequests');
+
+const ADMIN_ID = '64b000000000000000000001';
+const REQUEST_ID = '64b000000000000000000002';
+const COUNTRY_ID = '64b0000000000000000000aa';
+const adminToken = () => jwt.sign({ id: ADMIN_ID, roles: ['admin'] }, 'test-secret');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/wine-requests', wineRequestsRouter);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+let requestDoc;
+beforeEach(() => {
+  jest.clearAllMocks();
+  requestDoc = {
+    _id: REQUEST_ID,
+    status: 'pending',
+    requestType: 'new_wine',
+    wineName: 'Barolo del Comune',
+    user: '64b000000000000000000003',
+    image: null,
+    save: jest.fn().mockResolvedValue({}),
+    populate: jest.fn().mockResolvedValue({}),
+  };
+  WineRequest.findById.mockResolvedValue(requestDoc);
+  WineDefinition.mockImplementation(function (doc) {
+    Object.assign(this, doc);
+    this._id = 'wine-new';
+    this.save = jest.fn().mockResolvedValue(this);
+  });
+  Country.findById.mockReturnValue({
+    select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue({ name: 'Italy' }) }),
+  });
+  findOrCreateWine.mockResolvedValue({ wine: null, noMatch: true });
+  Bottle.distinct.mockResolvedValue([]);
+  Bottle.updateMany.mockResolvedValue({ modifiedCount: 0 });
+});
+
+const resolve = (wineData) => fetch(`${baseUrl}/api/admin/wine-requests/${REQUEST_ID}/resolve`, {
+  method: 'PUT',
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken()}` },
+  body: JSON.stringify({
+    createNew: true,
+    confirmCreate: true,
+    adminNotes: '',
+    wineData: { name: 'Barolo del Comune', producer: 'Cantina Rossi', country: COUNTRY_ID, type: 'red', ...wineData },
+  }),
+});
+
+test('an explicitly blank image stores null — it does NOT fall back to the requester\'s value', async () => {
+  requestDoc.image = 'https://cdn.example.com/label.png';
+  const res = await resolve({ image: '' });
+  expect(res.status).toBe(200);
+  expect(WineDefinition.mock.calls[0][0].image).toBeNull();
+});
+
+test('an omitted image inherits the request\'s value only when that value is a safe shape', async () => {
+  requestDoc.image = '/api/uploads/abc-123.png';
+  const res = await resolve({});
+  expect(res.status).toBe(200);
+  expect(WineDefinition.mock.calls[0][0].image).toBe('/api/uploads/abc-123.png');
+});
+
+test('a protocol-relative value inherited from the request is refused, nothing is minted', async () => {
+  requestDoc.image = '//attacker.example/pixel.png';
+  const res = await resolve({});
+  expect(res.status).toBe(400);
+  expect((await res.json()).error).toMatch(/Wine image/);
+  expect(WineDefinition).not.toHaveBeenCalled();
+  expect(requestDoc.save).not.toHaveBeenCalled();
+});
+
+test('a javascript: or private-host value typed by the admin is refused too', async () => {
+  let res = await resolve({ image: 'javascript:alert(1)' });
+  expect(res.status).toBe(400);
+  res = await resolve({ image: 'http://127.0.0.1/x.png' });
+  expect(res.status).toBe(400);
+  expect(WineDefinition).not.toHaveBeenCalled();
+});
+
+test('a public https link typed by the admin is stored as given', async () => {
+  const res = await resolve({ image: 'https://cdn.example.com/bottle.png' });
+  expect(res.status).toBe(200);
+  expect(WineDefinition.mock.calls[0][0].image).toBe('https://cdn.example.com/bottle.png');
+});

--- a/backend/src/routes/admin/wineRequests.js
+++ b/backend/src/routes/admin/wineRequests.js
@@ -15,6 +15,7 @@ const { stripHtml } = require('../../utils/sanitize');
 const { incrementCred } = require('../../utils/cellarCred');
 const { parsePagination } = require('../../utils/pagination');
 const { isValidId } = require('../../utils/validation');
+const { validateImageRef } = require('../../services/accountOps');
 const { ensurePendingVintageProfile } = require('../../utils/vintageProfile');
 
 const router = express.Router();
@@ -123,6 +124,17 @@ router.put('/:id/resolve', async (req, res) => {
         return res.status(400).json({ error: 'Invalid country' });
       }
 
+      // Image: an explicitly blank field means "no image" — it must NOT fall
+      // back to the requester's value (audit 2026-09 F06-1). Whatever is
+      // stored has to pass the same http(s) / inline-image / own-upload check
+      // as intake, so a protocol-relative or javascript: reference can never
+      // reach WineDefinition.image through an approval.
+      const imageToStore = (image === '' || image === null) ? null : (image ?? wineRequest.image ?? null);
+      const imageErr = validateImageRef(imageToStore);
+      if (imageErr) {
+        return res.status(400).json({ error: `Wine image: ${imageErr}` });
+      }
+
       const cleanProducer = producer.trim();
       const cleanName = canonicalizeWineName(name, cleanProducer);
       // Tier-strip AND curated-registry resolve — this branch bulk-builds the
@@ -191,7 +203,7 @@ router.put('/:id/resolve', async (req, res) => {
         appellation: cleanAppellation,
         grapes: grapes || [],
         type: type || null, // no guessed red (ticket 6a85ad44)
-        image: image || wineRequest.image || null,
+        image: imageToStore,
         normalizedKey,
         createdBy: req.user.id,
         createdVia: 'ui'

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -12,6 +12,7 @@ const {
   normalizeAppellation
 } = require('../../utils/normalize');
 const { resolveCanonicalAppellation } = require('../../services/appellationResolve');
+const { validateImageRef } = require('../../services/accountOps');
 const { scoreWineMatch } = require('../../services/wineMatching');
 const { conflictingStyleTerms } = require('../../utils/styleTerms');
 const { sameProducerAppellationGroups, nearProducerPairs, nameSubsetPairs } = require('../../services/registryFragmentation');
@@ -239,6 +240,12 @@ router.post('/', async (req, res) => {
 
     // Generate normalized key for deduplication
     const normalizedKey = generateWineKey(cleanName, producerToStore, cleanAppellation);
+
+    // The image lands on a public page and in every viewer's AuthImage, so it
+    // has to be a real http(s) link, an inline image or one of our own upload
+    // paths (audit 2026-09 S7-1 / F06-1).
+    const imageErr = validateImageRef(image);
+    if (imageErr) return res.status(400).json({ error: `Wine image: ${imageErr}` });
 
     const wine = new WineDefinition({
       name: cleanName,
@@ -1445,6 +1452,8 @@ router.put('/:id', async (req, res) => {
     // label-scan URL bug left wines in this state after Remove default image).
     if (image !== undefined) {
       if (image) {
+        const imageErr = validateImageRef(image);
+        if (imageErr) return res.status(400).json({ error: `Wine image: ${imageErr}` });
         wine.image = image;
       } else {
         const replacement = await BottleImage.findOne({

--- a/backend/src/routes/exchangeRates.js
+++ b/backend/src/routes/exchangeRates.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const { getOrCreateDailySnapshot } = require('../utils/exchangeRates');
+
+const router = express.Router();
+
+// GET /api/exchange-rates — today's USD-based rates, served from the daily
+// snapshot the backend already keeps for price anchoring. Public and cheap:
+// at most ONE upstream call per day happens here, on the server, so the
+// browser no longer contacts open.er-api.com itself (audit 2026-09 F03-4:
+// every visitor's IP used to reach a provider the privacy policy never named).
+router.get('/', async (req, res) => {
+  try {
+    const snapshot = await getOrCreateDailySnapshot();
+    if (!snapshot || !snapshot.rates) {
+      return res.status(503).json({ error: 'Exchange rates are temporarily unavailable' });
+    }
+    res.set('Cache-Control', 'public, max-age=3600');
+    res.json({ base: 'USD', date: snapshot.date, fetchedAt: snapshot.fetchedAt, rates: snapshot.rates });
+  } catch (error) {
+    console.error('Exchange rates error:', error);
+    res.status(500).json({ error: 'Failed to load exchange rates' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/exchangeRates.test.js
+++ b/backend/src/routes/exchangeRates.test.js
@@ -1,0 +1,43 @@
+/**
+ * GET /api/exchange-rates — the browser-facing twin of the daily snapshot
+ * (audit 2026-09 F03-4). Pins: public, served from the snapshot, cacheable,
+ * and a clean 503 (not a hang) when the upstream is unavailable.
+ */
+
+jest.mock('../utils/exchangeRates', () => ({ getOrCreateDailySnapshot: jest.fn() }));
+
+const express = require('express');
+const http = require('http');
+const { getOrCreateDailySnapshot } = require('../utils/exchangeRates');
+const router = require('./exchangeRates');
+
+let server, baseUrl;
+beforeAll((done) => {
+  const app = express();
+  app.use('/api/exchange-rates', router);
+  server = http.createServer(app);
+  server.listen(0, () => { baseUrl = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+beforeEach(() => jest.clearAllMocks());
+
+test('serves the snapshot rates with a public cache header, no auth needed', async () => {
+  getOrCreateDailySnapshot.mockResolvedValue({ date: '2026-09-06', fetchedAt: '2026-09-06T05:00:00.000Z', rates: { USD: 1, EUR: 0.92 } });
+  const res = await fetch(`${baseUrl}/api/exchange-rates`);
+  expect(res.status).toBe(200);
+  expect(res.headers.get('cache-control')).toBe('public, max-age=3600');
+  expect(await res.json()).toEqual({ base: 'USD', date: '2026-09-06', fetchedAt: '2026-09-06T05:00:00.000Z', rates: { USD: 1, EUR: 0.92 } });
+});
+
+test('answers 503 when no snapshot can be produced', async () => {
+  getOrCreateDailySnapshot.mockResolvedValue(null);
+  const res = await fetch(`${baseUrl}/api/exchange-rates`);
+  expect(res.status).toBe(503);
+  expect((await res.json()).error).toMatch(/unavailable/);
+});
+
+test('answers 500 (not a hang) when the snapshot lookup throws', async () => {
+  getOrCreateDailySnapshot.mockRejectedValue(new Error('db down'));
+  const res = await fetch(`${baseUrl}/api/exchange-rates`);
+  expect(res.status).toBe(500);
+});

--- a/backend/src/routes/superadmin.js
+++ b/backend/src/routes/superadmin.js
@@ -23,6 +23,7 @@ const { isEmbeddingConfigured, embeddingProviderName } = require('../services/em
 const { updateSiteConfig } = require('../utils/siteConfig');
 const { parsePagination } = require('../utils/pagination');
 const { escapeRegex } = require('../utils/sanitize');
+const { redactUrlCredentials } = require('../utils/redactUrl');
 const { coerceStringQuery } = require('../utils/validation');
 const { SYSTEM_PROMPT_MAX_LENGTH, SCAN_PROMPT_MAX_LENGTH, CONSUMED_STATUSES } = require('../config/constants');
 
@@ -345,7 +346,10 @@ router.get('/backups', async (req, res) => {
     const ageHours = lastRunAt ? (Date.now() - lastRunAt.getTime()) / 3600000 : null;
     // Daily schedule → never-run or older than ~26h counts as stale.
     const stale = ageHours == null || ageHours > 26;
-    res.json({ configured: true, stale, ageHours, ...doc });
+    // The job records the repository string it used. If an operator ever puts
+    // credentials in it (rest:https://user:pass@host/…) they must not reach the
+    // browser (audit 2026-09 F05-5) — the script redacts too, this is the backstop.
+    res.json({ configured: true, stale, ageHours, ...doc, repo: redactUrlCredentials(doc.repo) });
   } catch (error) {
     console.error('[superadmin] backups error:', error);
     res.status(500).json({ error: 'Failed to load backup status' });

--- a/backend/src/services/accountOps.js
+++ b/backend/src/services/accountOps.js
@@ -279,6 +279,55 @@ function validateSourceUrl(url) {
 }
 
 /**
+ * Validate an image reference attached to a wine request, or copied from one
+ * into the registry when an admin approves it. Exactly three shapes pass:
+ *   - an http(s) URL that clears the same public-host check as sourceUrl;
+ *   - an inline `data:image/<type>;base64,…` payload (a label photo captured
+ *     in the request form);
+ *   - one of our own upload paths (`/api/uploads/<file>`, or that path on the
+ *     FRONTEND_URL origin — what the request form sends after background
+ *     removal).
+ * Anything else — a protocol-relative `//host/x`, `javascript:`, a bare word
+ * — is refused. Until audit 2026-09 (F06-1) such a value flowed verbatim into
+ * WineDefinition.image on approval, where every viewer's AuthImage would have
+ * fetched it with the bearer token attached.
+ * Returns an error string, or null when the value is acceptable (empty is fine).
+ */
+const MAX_IMAGE_REF_LENGTH = 500000;
+const UPLOAD_PATH = /^\/api\/uploads\/[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/;
+const DOT_SEGMENT = /\/\.\.?(?:\/|$)/;
+const INLINE_IMAGE = /^data:image\/(?:png|jpe?g|webp|gif);base64,[A-Za-z0-9+/=]+$/;
+
+function isOwnUploadPath(pathname) {
+  return UPLOAD_PATH.test(pathname) && !DOT_SEGMENT.test(pathname);
+}
+
+function isOwnUploadUrl(value) {
+  const base = process.env.FRONTEND_URL;
+  if (!base) return false;
+  try {
+    const target = new URL(value);
+    return target.origin === new URL(base).origin && isOwnUploadPath(target.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function validateImageRef(image) {
+  if (image == null || image === '') return null;
+  if (typeof image !== 'string') return 'Image must be an http(s) link or an inline image';
+  if (image.length > MAX_IMAGE_REF_LENGTH) return 'Image reference is too large';
+  if (INLINE_IMAGE.test(image)) return null;
+  if (image.startsWith('/')) {
+    return isOwnUploadPath(image) ? null : 'Image must be an http(s) link or an inline image';
+  }
+  if (isOwnUploadUrl(image)) return null;
+  const urlErr = validateSourceUrl(image);
+  if (urlErr) return `Image must be an http(s) link or an inline image (${urlErr})`;
+  return null;
+}
+
+/**
  * Validate + create a `new_wine` WineRequest (the fallback when resolve_wine
  * dead-ends and the user can't confirm enough to mint a registry entry). Returns
  * { wineRequest } or { error }. The grape_suggestion request type is deliberately
@@ -295,9 +344,8 @@ async function createWineRequest(userId, { wineName, sourceUrl, image } = {}) {
   if (trimmedName.length > 300) {
     return { error: err(400, 'Wine name must be 300 characters or fewer') };
   }
-  if (trimmedImage.length > 500000) {
-    return { error: err(400, 'Image reference is too large') };
-  }
+  const imageErr = validateImageRef(trimmedImage);
+  if (imageErr) return { error: err(400, imageErr) };
 
   const wineRequest = new WineRequest({
     requestType: 'new_wine',
@@ -321,6 +369,7 @@ module.exports = {
   TICKET_REPLY_CAP,
   createWineRequest,
   validateSourceUrl,
+  validateImageRef,
   // Exposed so the MCP tool descriptions/schemas can enumerate the same options.
   ALLOWED_CURRENCIES,
   LANGUAGE_TAG,

--- a/backend/src/services/accountOps.test.js
+++ b/backend/src/services/accountOps.test.js
@@ -201,6 +201,34 @@ describe('createWineRequest', () => {
     expect((await createWineRequest(UID, { wineName: 'X', sourceUrl: 'https://x.com', image: 'd'.repeat(500001) })).error.status).toBe(400);
   });
 
+  test('accepts only http(s) links, inline images and own upload paths as the image (audit F06-1)', async () => {
+    const submit = (image) => createWineRequest(UID, { wineName: 'X', sourceUrl: 'https://x.com', image });
+    expect((await submit('https://img.example.com/a.png')).wineRequest.image).toBe('https://img.example.com/a.png');
+    expect((await submit('data:image/png;base64,iVBORw0KGgo=')).wineRequest.image).toBe('data:image/png;base64,iVBORw0KGgo=');
+    expect((await submit('/api/uploads/abc-123.png')).wineRequest.image).toBe('/api/uploads/abc-123.png');
+    expect((await submit('')).wineRequest.image).toBeNull();
+    expect((await submit('//attacker.example/a.png')).error.status).toBe(400);
+    expect((await submit('javascript:alert(1)')).error.status).toBe(400);
+    expect((await submit('http://10.0.0.1/a.png')).error.message).toMatch(/private\/internal/);
+    expect((await submit('data:text/html;base64,PHNjcmlwdD4=')).error.status).toBe(400);
+    expect((await submit('/api/uploads/../../etc/passwd')).error.status).toBe(400);
+    expect((await submit('/etc/passwd')).error.status).toBe(400);
+    expect((await submit('label.png')).error.status).toBe(400);
+  });
+
+  test('an own-origin upload URL passes when FRONTEND_URL names that origin', async () => {
+    const prev = process.env.FRONTEND_URL;
+    process.env.FRONTEND_URL = 'http://192.168.1.10';
+    try {
+      const own = await createWineRequest(UID, { wineName: 'X', sourceUrl: 'https://x.com', image: 'http://192.168.1.10/api/uploads/abc.png' });
+      expect(own.wineRequest.image).toBe('http://192.168.1.10/api/uploads/abc.png');
+      const other = await createWineRequest(UID, { wineName: 'X', sourceUrl: 'https://x.com', image: 'http://192.168.1.10/etc/passwd' });
+      expect(other.error.status).toBe(400);
+    } finally {
+      if (prev === undefined) delete process.env.FRONTEND_URL; else process.env.FRONTEND_URL = prev;
+    }
+  });
+
   test('creates a pending new_wine request, trimming the name', async () => {
     const res = await createWineRequest(UID, { wineName: '  Barolo Riserva  ', sourceUrl: 'https://vivino.com/w/1' });
     expect(res.error).toBeUndefined();

--- a/backend/src/utils/redactUrl.js
+++ b/backend/src/utils/redactUrl.js
@@ -1,0 +1,14 @@
+/**
+ * Strip the userinfo part (user:password@) out of a URL-ish string before it
+ * is stored or shown. restic repository strings such as
+ * `rest:https://user:pass@host:8000/` or `s3:https://KEY:SECRET@host/bucket`
+ * carry credentials in the authority; the super-admin backup panel must show
+ * where the backups go without showing how to open them (audit 2026-09 F05-5).
+ * Non-strings and strings without an authority pass through unchanged.
+ */
+function redactUrlCredentials(value) {
+  if (typeof value !== 'string' || !value) return value;
+  return value.replace(/(:\/\/)[^/@\s]*@/g, '$1***@');
+}
+
+module.exports = { redactUrlCredentials };

--- a/backend/src/utils/redactUrl.test.js
+++ b/backend/src/utils/redactUrl.test.js
@@ -1,0 +1,14 @@
+const { redactUrlCredentials } = require('./redactUrl');
+
+test('removes user:password from the authority of every URL in the string', () => {
+  expect(redactUrlCredentials('rest:https://backup:s3cr3t@box.example:8000/cellarion')).toBe('rest:https://***@box.example:8000/cellarion');
+  expect(redactUrlCredentials('s3:https://AKIA:SECRET@s3.eu.example/bucket')).toBe('s3:https://***@s3.eu.example/bucket');
+});
+
+test('leaves credential-free strings and non-strings alone', () => {
+  expect(redactUrlCredentials('sftp:u123@u123.your-storagebox.de:/restic')).toBe('sftp:u123@u123.your-storagebox.de:/restic');
+  expect(redactUrlCredentials('/mnt/backups/restic')).toBe('/mnt/backups/restic');
+  expect(redactUrlCredentials('')).toBe('');
+  expect(redactUrlCredentials(null)).toBeNull();
+  expect(redactUrlCredentials(undefined)).toBeUndefined();
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,12 +13,9 @@
     <link rel="preload" as="image" href="/cellarion-logo-light.webp" type="image/webp" media="(prefers-color-scheme: light)" fetchpriority="high" />
     <link rel="preload" as="image" href="/cellarion-logo-dark.webp"  type="image/webp" media="(prefers-color-scheme: dark)"  fetchpriority="high" />
 
-    <!-- Fonts: Playfair Display (headings) + Inter (body) -->
-    <!-- preload downloads the CSS early; the stylesheet link is non-blocking because it hits cache immediately -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet" />
+    <!-- Fonts: Playfair Display (headings) + Inter (body) are bundled with the app
+         (@fontsource, imported in src/index.js) and served from this origin — no
+         request to Google Fonts leaves the visitor's browser. -->
 
     <!-- Open Graph / Social sharing -->
     <meta property="og:type" content="website" />
@@ -36,7 +33,7 @@
       https://analytics.cellarion.app so the self-hosted tracker can load and POST.
       If you self-host Umami at a different subdomain, update both lists.
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' https://analytics.cellarion.app; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' blob: data: https:; connect-src 'self' https://open.er-api.com https://analytics.cellarion.app; frame-src https://www.youtube.com https://www.youtube-nocookie.com;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' https://analytics.cellarion.app; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' blob: data: https:; connect-src 'self' https://analytics.cellarion.app; frame-src https://www.youtube.com https://www.youtube-nocookie.com;" />
 
     <!--
       Search engine webmaster verification.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.202.0",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@fontsource/inter": "^5.3.0",
+        "@fontsource/playfair-display": "^5.3.0",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@tiptap/extension-image": "^3.20.4",
@@ -958,6 +960,24 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/playfair-display": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/playfair-display/-/playfair-display-5.3.0.tgz",
+      "integrity": "sha512-uJSABalvdWc10fEPppQjQocamT21LEyRfzzWfRfqbkPz+sRv+kKpYDKyluBUskvJREkJTos9epj1WjQROGu99Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -2284,26 +2304,6 @@
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
     },
-    "node_modules/@types/react": {
-      "version": "19.2.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
-      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
-      }
-    },
     "node_modules/@types/react-reconciler": {
       "version": "0.28.9",
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
@@ -2898,13 +2898,6 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/d3-array": {
       "version": "2.12.1",
@@ -5165,6 +5158,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "node": ">=24"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.3.0",
+    "@fontsource/playfair-display": "^5.3.0",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@tiptap/extension-image": "^3.20.4",

--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -57,7 +57,14 @@ self.addEventListener('push', (event) => {
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const link = event.notification.data?.link;
+  // The link is server-built, but it is data: only ever open this origin
+  // (audit 2026-09 F03-5).
+  const raw = event.notification.data?.link;
+  let link = null;
+  try {
+    const target = raw ? new URL(String(raw), self.location.origin) : null;
+    if (target && target.origin === self.location.origin) link = target.href;
+  } catch { link = null; }
   if (link) {
     event.waitUntil(
       self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {

--- a/frontend/src/components/Analytics.js
+++ b/frontend/src/components/Analytics.js
@@ -18,6 +18,12 @@ import { Helmet } from 'react-helmet-async';
 // no useful SEO/marketing data and recording them pollutes the dashboard with noise.
 // Note: Umami fires before React's ProtectedRoute can redirect, so a non-admin who
 // visits /admin/* would otherwise be recorded even though they never see the content.
+//
+// Query strings and fragments are never reported (data-exclude-search /
+// data-exclude-hash): password-reset and e-mail-verification links carry a
+// one-time token in the query, and the OAuth consent page carries the request
+// (audit 2026-09 F03-6). Those routes are also excluded outright below, so the
+// tracker is not even loaded on them.
 
 const EXCLUDED_PREFIXES = [
   '/admin',
@@ -25,6 +31,9 @@ const EXCLUDED_PREFIXES = [
   '/settings',
   '/cellars',
   '/users',
+  '/reset-password',
+  '/verify-email',
+  '/connect-ai/authorize',
 ];
 
 export default function Analytics() {
@@ -63,6 +72,8 @@ export default function Analytics() {
         defer
         src={`${url.replace(/\/$/, '')}/script.js`}
         data-website-id={websiteId}
+        data-exclude-search="true"
+        data-exclude-hash="true"
       />
     </Helmet>
   );

--- a/frontend/src/components/AuthImage.js
+++ b/frontend/src/components/AuthImage.js
@@ -7,10 +7,18 @@ import { useAuth } from '../contexts/AuthContext';
  * - Paths under /api/uploads are passed through as plain <img src> (no auth
  *   needed — filenames are random UUIDs). This lets the browser cache them
  *   normally and avoids the fetch→blob→objectURL overhead.
- * - Other internal /api/ paths are still fetched via apiFetch with the auth
+ * - Other same-origin /api/ paths are fetched via apiFetch with the auth
  *   header and rendered as blob: URLs.
- * - External http(s)/data:/blob: URLs pass through unchanged.
+ * - External http(s), inline data:image and blob: URLs pass through unchanged.
+ * - Anything else renders nothing. A registry wine.image is user-influenced
+ *   data: a protocol-relative `//host/x`, a backslash variant or a leading
+ *   space used to fall through to the authenticated branch and make every
+ *   viewer's browser send its bearer token to that host (audit 2026-09
+ *   S7-1 / F06-1 / F01-1).
  */
+const API_PATH = /^\/api\/(?!\/)[^\\]*$/;
+const PLAIN_SRC = /^(?:https?:\/\/[^\\\s]+|data:image\/(?:png|jpe?g|webp|gif);base64,[A-Za-z0-9+/=]+|blob:[^\\\s]+)$/i;
+
 function AuthImage({ src, alt, className, onError, style, loading }) {
   const { apiFetch } = useAuth();
   const [displaySrc, setDisplaySrc] = useState(null);
@@ -22,19 +30,20 @@ function AuthImage({ src, alt, className, onError, style, loading }) {
       return;
     }
 
-    // External, data, or blob URLs — no auth needed
-    if (src.startsWith('http') || src.startsWith('data:') || src.startsWith('blob:')) {
-      setDisplaySrc(src);
+    // Not a same-origin API path: plain <img> for the shapes we recognise,
+    // nothing at all for the rest — never an authenticated fetch.
+    if (typeof src !== 'string' || !API_PATH.test(src)) {
+      setDisplaySrc(typeof src === 'string' && PLAIN_SRC.test(src) ? src : null);
       return;
     }
 
     // Upload paths — served without auth, use direct src for browser caching
-    if (src.startsWith('/api/uploads')) {
+    if (src.startsWith('/api/uploads/')) {
       setDisplaySrc(src);
       return;
     }
 
-    // Other internal paths — fetch with auth header
+    // Other same-origin API paths — fetch with auth header
     let cancelled = false;
     apiFetch(src)
       .then(res => {

--- a/frontend/src/components/AuthImage.js
+++ b/frontend/src/components/AuthImage.js
@@ -17,7 +17,9 @@ import { useAuth } from '../contexts/AuthContext';
  *   S7-1 / F06-1 / F01-1).
  */
 const API_PATH = /^\/api\/(?!\/)[^\\]*$/;
-const PLAIN_SRC = /^(?:https?:\/\/[^\\\s]+|data:image\/(?:png|jpe?g|webp|gif);base64,[A-Za-z0-9+/=]+|blob:[^\\\s]+)$/i;
+// Spaces inside an http(s) URL are tolerated (the browser encodes them, and
+// admin-entered registry links have them); backslashes never are.
+const PLAIN_SRC = /^(?:https?:\/\/[^\\]+|data:image\/(?:png|jpe?g|webp|gif);base64,[A-Za-z0-9+/=\s]+|blob:[^\\\s]+)$/i;
 
 function AuthImage({ src, alt, className, onError, style, loading }) {
   const { apiFetch } = useAuth();

--- a/frontend/src/components/AuthImage.test.js
+++ b/frontend/src/components/AuthImage.test.js
@@ -1,0 +1,52 @@
+import { render, waitFor } from '@testing-library/react';
+import AuthImage from './AuthImage';
+
+// Audit 2026-09 S7-1 / F06-1 / F01-1: a registry wine.image is user-influenced
+// data. Only a same-origin /api/ path may ever be fetched with the bearer.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ apiFetch }) }));
+
+beforeEach(() => {
+  apiFetch.mockReset();
+  vi.stubGlobal('URL', Object.assign(URL, {
+    createObjectURL: vi.fn(() => 'blob:http://localhost:3000/mock'),
+    revokeObjectURL: vi.fn(),
+  }));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+const renderSrc = (src) => render(<AuthImage src={src} alt="x" />).container;
+
+test('plain external https, inline image and blob sources render directly, no fetch', async () => {
+  for (const src of ['https://cdn.example.com/a.png', 'data:image/png;base64,iVBORw0KGgo=', 'blob:http://localhost:3000/abc']) {
+    const c = renderSrc(src);
+    await waitFor(() => expect(c.querySelector('img')).toHaveAttribute('src', src));
+  }
+  expect(apiFetch).not.toHaveBeenCalled();
+});
+
+test('an upload path renders directly (browser-cacheable), no fetch', async () => {
+  const c = renderSrc('/api/uploads/abc-123.png');
+  await waitFor(() => expect(c.querySelector('img')).toHaveAttribute('src', '/api/uploads/abc-123.png'));
+  expect(apiFetch).not.toHaveBeenCalled();
+});
+
+test('another same-origin API path is fetched with apiFetch and shown as a blob', async () => {
+  apiFetch.mockResolvedValue({ ok: true, blob: async () => new Blob(['x']) });
+  const c = renderSrc('/api/images/123/file');
+  await waitFor(() => expect(c.querySelector('img')).toHaveAttribute('src', 'blob:http://localhost:3000/mock'));
+  expect(apiFetch).toHaveBeenCalledWith('/api/images/123/file');
+});
+
+test('shapes that would leave the origin render nothing and never reach apiFetch', async () => {
+  for (const src of [
+    '//attacker.example/pixel.png', ' //attacker.example/pixel.png', '/\\attacker.example/x',
+    '\\\\attacker.example\\x', '/api/\\attacker.example', 'javascript:alert(1)',
+    'data:text/html;base64,PA==', 'data:image/svg+xml;base64,PA==', 'ftp://x/y', 'label.png',
+  ]) {
+    const c = renderSrc(src);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(c.querySelector('img')).toBeNull();
+  }
+  expect(apiFetch).not.toHaveBeenCalled();
+});

--- a/frontend/src/components/AuthImage.test.js
+++ b/frontend/src/components/AuthImage.test.js
@@ -18,7 +18,7 @@ afterEach(() => vi.unstubAllGlobals());
 const renderSrc = (src) => render(<AuthImage src={src} alt="x" />).container;
 
 test('plain external https, inline image and blob sources render directly, no fetch', async () => {
-  for (const src of ['https://cdn.example.com/a.png', 'data:image/png;base64,iVBORw0KGgo=', 'blob:http://localhost:3000/abc']) {
+  for (const src of ['https://cdn.example.com/a.png', 'https://cdn.example.com/my label.png', 'data:image/png;base64,iVBORw0KGgo=', 'blob:http://localhost:3000/abc']) {
     const c = renderSrc(src);
     await waitFor(() => expect(c.querySelector('img')).toHaveAttribute('src', src));
   }

--- a/frontend/src/components/MarkdownText.js
+++ b/frontend/src/components/MarkdownText.js
@@ -4,11 +4,13 @@ import rehypeSanitize from 'rehype-sanitize';
 // Renders a trusted-but-sanitised markdown string. Same rehype-sanitize guard
 // used for the AI tasting profile on WineDetail. Wrap in a div so callers can
 // style the block elements (headings, lists, paragraphs) via a className.
+// Images are dropped (unwrapDisallowed keeps any alt text): an off-site <img>
+// in a description would report every reader's IP to its host (audit 2026-09 F02-2).
 export default function MarkdownText({ children, className }) {
   if (!children) return null;
   return (
     <div className={className}>
-      <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{children}</ReactMarkdown>
+      <ReactMarkdown rehypePlugins={[rehypeSanitize]} disallowedElements={['img']} unwrapDisallowed>{children}</ReactMarkdown>
     </div>
   );
 }

--- a/frontend/src/components/NotificationBell.js
+++ b/frontend/src/components/NotificationBell.js
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useNotifications } from '../contexts/NotificationContext';
 import timeAgo from '../utils/timeAgo';
+import internalPath from '../utils/internalPath';
 import './NotificationBell.css';
 
 export default function NotificationBell() {
@@ -27,7 +28,10 @@ export default function NotificationBell() {
   async function handleItemClick(n) {
     setOpen(false);
     if (!n.read) await markRead(n._id);
-    if (n.link) navigate(n.link);
+    // The link is server-built, but it is data — only ever navigate within
+    // the app (audit 2026-09 F03-5).
+    const to = internalPath(n.link);
+    if (to) navigate(to);
   }
 
   return (

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+// Fonts ship with the app (audit 2026-09 F03-4): no request to Google Fonts
+// leaves the visitor's browser. Weights match what index.css asks for.
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '@fontsource/inter/700.css';
+import '@fontsource/playfair-display/500.css';
+import '@fontsource/playfair-display/600.css';
+import '@fontsource/playfair-display/700.css';
 import './i18n';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';

--- a/frontend/src/pages/AddToWishlist.js
+++ b/frontend/src/pages/AddToWishlist.js
@@ -275,7 +275,9 @@ function AddToWishlist() {
   // or from a wine page's "Add to Wishlist" link (?wine=<id> query param).
   useEffect(() => {
     const restock = location.state?.fromRestock;
-    const wineParam = new URLSearchParams(location.search).get('wine');
+    const rawWineParam = new URLSearchParams(location.search).get('wine');
+    // Only a well-formed id may be interpolated into the API path (audit 2026-09 F01-2).
+    const wineParam = /^[a-f0-9]{24}$/i.test(rawWineParam || '') ? rawWineParam : null;
     const wineId = restock?.wineId || wineParam;
     if (!wineId) return;
     let cancelled = false;

--- a/frontend/src/pages/AdminRequests.js
+++ b/frontend/src/pages/AdminRequests.js
@@ -8,6 +8,8 @@ import {
 import { searchWines, getAiWineInfo } from '../api/wines';
 import { WINE_TYPES } from '../config/wineTypes';
 import GrapePicker from '../components/GrapePicker';
+import safeUrl from '../utils/safeUrl';
+import displayableImage from '../utils/displayableImage';
 import './AdminRequests.css';
 
 function AdminRequests() {
@@ -173,6 +175,11 @@ function AdminRequests() {
   const handleSelectRequest = (request) => {
     setSelected(request);
     setRegions([]);
+    // The requester chose the image value. Only a link or one of our upload
+    // paths is offered to the approval form — never an inline image (too big
+    // for the field) and never an unrecognised shape (audit 2026-09 F06-1).
+    const requestImage = displayableImage(request.image);
+    const prefillImage = requestImage && !requestImage.startsWith('data:') ? requestImage : '';
     setResolveData({
       mode: request.requestType === 'grape_suggestion' ? 'apply_grapes' : 'create',
       adminNotes: '',
@@ -186,7 +193,7 @@ function AdminRequests() {
         type: 'red',
         appellation: '',
         grapes: [],
-        image: (request.image && !request.image.startsWith('data:')) ? request.image : ''
+        image: prefillImage
       }
     });
     // Cancel any pending/in-flight duplicate check from the previous request
@@ -436,13 +443,13 @@ function AdminRequests() {
                 ) : (
                   <p>
                     <strong>{t('common.source')}:</strong>{' '}
-                    <a href={selected.sourceUrl} target="_blank" rel="noopener noreferrer">
+                    <a href={safeUrl(selected.sourceUrl) || undefined} target="_blank" rel="noopener noreferrer">
                       {selected.sourceUrl}
                     </a>
                   </p>
                 )}
-                {selected.image && (
-                  <img src={selected.image} alt="Wine" className="wine-image-preview" />
+                {displayableImage(selected.image) && (
+                  <img src={displayableImage(selected.image)} alt="Wine" className="wine-image-preview" />
                 )}
                 {selected.requestType !== 'grape_suggestion' && selected.status === 'pending' && (
                   <div className="ai-lookup-row">

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -623,7 +623,7 @@ function BottleDetail() {
           })()}
 
           <div className="bd-ai-prose">
-            <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{wine.aiProfile.description}</ReactMarkdown>
+            <ReactMarkdown rehypePlugins={[rehypeSanitize]} disallowedElements={['img']} unwrapDisallowed>{wine.aiProfile.description}</ReactMarkdown>
           </div>
 
           {wine.aiProfile.foodPairings?.length > 0 && (

--- a/frontend/src/pages/CellarChat.js
+++ b/frontend/src/pages/CellarChat.js
@@ -72,7 +72,7 @@ function Message({ msg }) {
       <div className={`cellar-chat__bubble${msg.thinking ? ' cellar-chat__bubble--thinking' : ''}`}>
         {isUser || msg.thinking
           ? msg.text
-          : <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{msg.text}</ReactMarkdown>
+          : <ReactMarkdown rehypePlugins={[rehypeSanitize]} disallowedElements={['img']} unwrapDisallowed>{msg.text}</ReactMarkdown>
         }
       </div>
       {msg.expandedQuery && <ExpandedQueryHint text={msg.expandedQuery} />}

--- a/frontend/src/pages/PrivacyPolicy.js
+++ b/frontend/src/pages/PrivacyPolicy.js
@@ -114,6 +114,12 @@ function PrivacyPolicy() {
               <td>Global (EU/US)</td>
             </tr>
             <tr>
+              <td>Google (Sign in with Google)</td>
+              <td>Optional single sign-on — used only if you choose to sign in with your Google account</td>
+              <td>The e-mail address, name and account identifier of the Google account you sign in with; Google separately learns that you signed in to Cellarion</td>
+              <td>US</td>
+            </tr>
+            <tr>
               <td>Hetzner</td>
               <td>Server hosting for cellarion.app, and storage for the primary encrypted backup</td>
               <td>Everything the service holds: your account, cellars, bottles and uploaded images</td>
@@ -133,7 +139,9 @@ function PrivacyPolicy() {
           (vector storage for AI cellar chat), <strong>rembg</strong> (image background removal),
           and <strong>Umami</strong> (privacy-friendly, cookieless usage analytics). Self-hosted
           Cellarion instances run all of these themselves; the hosted cellarion.app additionally
-          uses Stripe, Voyage AI and Cloudflare as noted above.
+          uses Stripe, Voyage AI, Cloudflare and Google sign-in as noted above. The site's fonts are
+          served from our own server, and currency exchange rates are fetched by our server once a
+          day — your browser does not contact those providers.
         </p>
 
         <h3>AI assistants you connect (MCP)</h3>
@@ -209,7 +217,7 @@ function PrivacyPolicy() {
 
         <h2>10. International data transfers</h2>
         <p>
-          Some of our sub-processors (Mailgun, Anthropic, Voyage AI, Stripe, Cloudflare) are based in
+          Some of our sub-processors (Mailgun, Anthropic, Voyage AI, Stripe, Cloudflare, Google) are based in
           or route traffic through the United States. Where personal data is transferred outside the
           EU/EEA, we ensure appropriate safeguards are in place, such as Standard Contractual Clauses
           (SCCs) or the EU-US Data Privacy Framework.

--- a/frontend/src/pages/ResetPassword.js
+++ b/frontend/src/pages/ResetPassword.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import CellarionLogo from '../components/CellarionLogo';
@@ -6,7 +6,7 @@ import './Login.css';
 
 function ResetPassword() {
   const { t } = useTranslation();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
 
   const [password, setPassword] = useState('');
@@ -14,7 +14,15 @@ function ResetPassword() {
   const [status, setStatus] = useState('idle'); // 'idle' | 'submitting' | 'success' | 'error'
   const [errorMessage, setErrorMessage] = useState('');
 
-  const token = searchParams.get('token');
+  // Read the one-time token ONCE, then take it out of the address bar so it
+  // does not linger in browser history, in the Referer of any outbound link,
+  // or in an analytics pageview (audit 2026-09 F03-6). State survives the URL
+  // change; the form posts the captured value.
+  const [token] = useState(() => searchParams.get('token'));
+  useEffect(() => {
+    if (searchParams.has('token')) setSearchParams(new URLSearchParams(), { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/frontend/src/pages/SuperAdmin/TabAI.js
+++ b/frontend/src/pages/SuperAdmin/TabAI.js
@@ -804,6 +804,8 @@ export default function TabAI() {
   const [enrichMsg, setEnrichMsg] = useState(null);
 
   async function startJob() {
+    // A full run re-sends the whole registry to the provider (audit 2026-09 F05-2).
+    if (jobMode === 'full' && !window.confirm('Re-embed EVERY registry wine? This re-sends the whole registry to the embedding provider and can take hours. Continue?')) return;
     setJobBusy(true); setJobMsg(null);
     try {
       // Content-Type header is required — without it Express's express.json()
@@ -833,6 +835,8 @@ export default function TabAI() {
   }
 
   async function startEnrich() {
+    // A full run is one AI call per registry wine (audit 2026-09 F05-2).
+    if (enrichMode === 'full' && !window.confirm('Re-enrich EVERY registry wine? This calls the AI provider once per wine — hours of runtime and real cost. Continue?')) return;
     setEnrichBusy(true); setEnrichMsg(null);
     try {
       const limitNum = parseInt(enrichLimit, 10);

--- a/frontend/src/pages/SuperAdmin/TabUsers.js
+++ b/frontend/src/pages/SuperAdmin/TabUsers.js
@@ -167,6 +167,15 @@ export default function TabUsers() {
   }
 
   async function changeRoles(userId, newRoles) {
+    // Granting or revoking a privileged role is one checkbox click away from
+    // a mis-tap — confirm it first (audit 2026-09 F05-1).
+    const target = data?.users?.find(u => u._id === userId);
+    const before = new Set(target?.roles || []);
+    const after = new Set(newRoles);
+    const changes = ['admin', 'somm']
+      .filter(r => before.has(r) !== after.has(r))
+      .map(r => `${after.has(r) ? 'Grant' : 'Revoke'} ${r}`);
+    if (changes.length > 0 && !window.confirm(`${changes.join(', ')} for ${target?.username || target?.email || userId}?`)) return;
     setUpdating(prev => ({ ...prev, [userId + '_roles']: true }));
     try {
       const res = await adminChangeUserRoles(apiFetch, userId, newRoles);

--- a/frontend/src/pages/VerifyEmail.js
+++ b/frontend/src/pages/VerifyEmail.js
@@ -7,7 +7,7 @@ import './Login.css';
 
 function VerifyEmail() {
   const { t } = useTranslation();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { verifyEmail } = useAuth();
   const navigate = useNavigate();
 
@@ -30,6 +30,9 @@ function VerifyEmail() {
       setErrorMessage(t('auth.noVerifyToken'));
       return;
     }
+    // The token has been read — drop it from the address bar so it is not
+    // kept in history or reported anywhere (audit 2026-09 F03-6).
+    setSearchParams(new URLSearchParams(), { replace: true });
 
     verifyEmail(token).then(result => {
       if (result.success) {

--- a/frontend/src/pages/WineDetail.js
+++ b/frontend/src/pages/WineDetail.js
@@ -250,7 +250,7 @@ export default function WineDetail() {
           })()}
 
           <div className="bd-ai-prose">
-            <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{wine.aiProfile.description}</ReactMarkdown>
+            <ReactMarkdown rehypePlugins={[rehypeSanitize]} disallowedElements={['img']} unwrapDisallowed>{wine.aiProfile.description}</ReactMarkdown>
           </div>
 
           {wine.aiProfile.foodPairings?.length > 0 && (

--- a/frontend/src/utils/apiFetch.apiUrl.test.js
+++ b/frontend/src/utils/apiFetch.apiUrl.test.js
@@ -1,0 +1,17 @@
+import { isApiTarget } from './apiFetch';
+
+// A self-hoster may point VITE_API_URL at another host; relative /api/ calls
+// still go to the page origin (nginx proxies them), so BOTH origins are ours.
+vi.mock('../api/apiConstants', () => ({
+  API_URL: 'https://api.example.test',
+  JSON_HEADERS: { 'Content-Type': 'application/json' },
+}));
+
+test('with VITE_API_URL set, the page origin and the API origin both count as ours', () => {
+  expect(isApiTarget('/api/cellars')).toBe(true);
+  expect(isApiTarget(`${window.location.origin}/api/cellars`)).toBe(true);
+  expect(isApiTarget('https://api.example.test/api/cellars')).toBe(true);
+  expect(isApiTarget('https://api.example.test/uploads/x')).toBe(false);
+  expect(isApiTarget('https://evil.example/api/cellars')).toBe(false);
+  expect(isApiTarget('//api.example.test.evil.example/api/cellars')).toBe(false);
+});

--- a/frontend/src/utils/apiFetch.js
+++ b/frontend/src/utils/apiFetch.js
@@ -19,10 +19,12 @@ import { API_URL } from '../api/apiConstants';
  */
 export function isApiTarget(url) {
   try {
+    // Our API is the page origin (nginx proxies /api there) and, when
+    // VITE_API_URL names another host, that origin as well.
     const base = typeof window !== 'undefined' && window.location ? window.location.origin : 'http://localhost';
     const apiOrigin = new URL(API_URL || '/', base).origin;
     const target = new URL(String(url), base);
-    return target.origin === apiOrigin && target.pathname.startsWith('/api/');
+    return (target.origin === base || target.origin === apiOrigin) && target.pathname.startsWith('/api/');
   } catch {
     return false;
   }

--- a/frontend/src/utils/apiFetch.js
+++ b/frontend/src/utils/apiFetch.js
@@ -1,3 +1,5 @@
+import { API_URL } from '../api/apiConstants';
+
 /**
  * Creates a fetch wrapper that:
  * - Automatically injects the current access token as Authorization header
@@ -5,12 +7,34 @@
  * - Retries the original request once with the new token
  * - Calls onLogout() if the refresh also fails
  *
+ * The bearer token and the refresh cookie are only ever meant for OUR API. A
+ * caller-supplied URL that resolves anywhere else — a protocol-relative
+ * `//host/x`, a backslash trick, an absolute third-party URL — is fetched
+ * with neither, and never triggers the refresh/logout dance (audit 2026-09
+ * F03-3 / S7-1: a registry image value used to reach this wrapper verbatim).
+ *
  * Usage (via AuthContext):
  *   const { apiFetch } = useAuth();
  *   const res = await apiFetch('/api/cellars', { method: 'GET' });
  */
+export function isApiTarget(url) {
+  try {
+    const base = typeof window !== 'undefined' && window.location ? window.location.origin : 'http://localhost';
+    const apiOrigin = new URL(API_URL || '/', base).origin;
+    const target = new URL(String(url), base);
+    return target.origin === apiOrigin && target.pathname.startsWith('/api/');
+  } catch {
+    return false;
+  }
+}
+
 export function createApiFetch(getToken, onRefresh, onLogout) {
   return async function apiFetch(url, options = {}) {
+    if (!isApiTarget(url)) {
+      const { headers: callerHeaders = {}, ...rest } = options;
+      return fetch(url, { ...rest, headers: { ...callerHeaders }, credentials: 'omit' });
+    }
+
     const token = getToken();
     const headers = { ...options.headers };
     if (token) headers['Authorization'] = `Bearer ${token}`;

--- a/frontend/src/utils/apiFetch.origin.test.js
+++ b/frontend/src/utils/apiFetch.origin.test.js
@@ -1,0 +1,58 @@
+import { createApiFetch, isApiTarget } from './apiFetch';
+
+// jsdom's document origin is http://localhost:3000; API_URL is '' in tests, so
+// the API origin is the page origin.
+const okRes = { status: 200, ok: true };
+const unauthorizedRes = { status: 401, ok: false };
+
+describe('apiFetch only ever sends credentials to the API origin (audit 2026-09 F03-3 / S7-1)', () => {
+  let fetchMock;
+  beforeEach(() => { fetchMock = vi.fn().mockResolvedValue(okRes); vi.stubGlobal('fetch', fetchMock); });
+  afterEach(() => vi.unstubAllGlobals());
+
+  test('isApiTarget accepts same-origin /api/ paths, relative or absolute', () => {
+    expect(isApiTarget('/api/cellars')).toBe(true);
+    expect(isApiTarget('/api/images/1/file?size=s')).toBe(true);
+    expect(isApiTarget(`${window.location.origin}/api/cellars`)).toBe(true);
+  });
+
+  test('isApiTarget refuses everything that resolves elsewhere or outside /api/', () => {
+    for (const bad of [
+      '//evil.example/api/x', 'https://evil.example/api/x', 'http://localhost:3001/api/x',
+      '\\\\evil.example/api/x', '/\\evil.example/api/x', '/api/../uploads/x', '/uploads/x',
+      'javascript:alert(1)', '', null, undefined,
+    ]) {
+      expect(isApiTarget(bad)).toBe(false);
+    }
+  });
+
+  test('a same-origin API path carries the bearer and the cookie', async () => {
+    const apiFetch = createApiFetch(() => 'tok-123', vi.fn(), vi.fn());
+    await apiFetch('/api/cellars');
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.headers.Authorization).toBe('Bearer tok-123');
+    expect(options.credentials).toBe('include');
+  });
+
+  test('a protocol-relative or third-party URL gets neither bearer nor cookie', async () => {
+    const apiFetch = createApiFetch(() => 'tok-123', vi.fn(), vi.fn());
+    for (const url of ['//evil.example/a.png', 'https://evil.example/a.png', '\\evil.example/a.png']) {
+      await apiFetch(url, { headers: { Accept: 'image/*' } });
+      const [calledUrl, options] = fetchMock.mock.calls.at(-1);
+      expect(calledUrl).toBe(url);
+      expect(options.headers).toEqual({ Accept: 'image/*' });
+      expect(options.credentials).toBe('omit');
+    }
+  });
+
+  test('a 401 from a non-API target never refreshes or logs out', async () => {
+    fetchMock.mockResolvedValue(unauthorizedRes);
+    const onRefresh = vi.fn();
+    const onLogout = vi.fn();
+    const apiFetch = createApiFetch(() => 'tok-123', onRefresh, onLogout);
+    const res = await apiFetch('https://evil.example/a.png');
+    expect(res).toBe(unauthorizedRes);
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(onLogout).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/currency.fetchRates.test.js
+++ b/frontend/src/utils/currency.fetchRates.test.js
@@ -1,0 +1,16 @@
+import { fetchRates } from './currency';
+
+// Audit 2026-09 F03-4: rates come from our own backend, never from the
+// upstream provider directly, and the result is cached per session.
+test('fetchRates asks the backend endpoint and caches the answer', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ base: 'USD', rates: { USD: 1, EUR: 0.92 } }) });
+  vi.stubGlobal('fetch', fetchMock);
+  try {
+    expect(await fetchRates()).toEqual({ USD: 1, EUR: 0.92 });
+    expect(await fetchRates()).toEqual({ USD: 1, EUR: 0.92 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/exchange-rates');
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});

--- a/frontend/src/utils/currency.js
+++ b/frontend/src/utils/currency.js
@@ -1,3 +1,5 @@
+import { API_URL } from '../api/apiConstants';
+
 // Module-level frontend cache — avoids repeated API calls within the same session
 let ratesCache = null;
 let ratesFetchedAt = 0;   // time of the last SUCCESSFUL fetch
@@ -5,7 +7,10 @@ let lastAttemptAt = 0;    // time of the last attempt (success or failure)
 const FRONTEND_CACHE_TTL = 60 * 60 * 1000; // 1 hour on success
 const FAILURE_BACKOFF = 5 * 60 * 1000;     // negative-cache window after a failure
 /**
- * Fetch USD-based exchange rates from open.er-api.com (CORS-enabled, free, no key).
+ * Fetch USD-based exchange rates from OUR backend (GET /api/exchange-rates),
+ * which keeps one daily snapshot from its upstream provider. The browser no
+ * longer talks to the provider itself, so no visitor IP leaves the site for
+ * this (audit 2026-09 F03-4).
  * Returns a rates object like { USD: 1, EUR: 0.92, SEK: 10.5, ... }
  * Returns null on error — callers should degrade gracefully.
  */
@@ -21,10 +26,10 @@ export async function fetchRates() {
   }
   lastAttemptAt = now;
   try {
-    const res = await fetch('https://open.er-api.com/v6/latest/USD');
+    const res = await fetch(`${API_URL}/api/exchange-rates`);
     if (!res.ok) return ratesCache;
     const data = await res.json();
-    if (data.result !== 'success' || !data.rates) return ratesCache;
+    if (!data || typeof data.rates !== 'object' || !data.rates) return ratesCache;
     ratesCache = data.rates; // already includes USD: 1
     ratesFetchedAt = Date.now();
     return ratesCache;

--- a/frontend/src/utils/displayableImage.js
+++ b/frontend/src/utils/displayableImage.js
@@ -1,0 +1,20 @@
+import safeUrl from './safeUrl';
+
+/**
+ * A requester (any user) chose this value. Only three shapes are ever put into
+ * an <img>, offered to an approval form or rendered as a link: one of our own
+ * upload paths, an inline image, or an http(s) URL. Everything else — a
+ * protocol-relative "//host", javascript:, a bare word — yields null
+ * (audit 2026-09 F06-1 / F06-2 / F06-3). Mirrors validateImageRef on the server.
+ */
+const UPLOAD_PATH = /^\/api\/uploads\/[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/;
+const DOT_SEGMENT = /\/\.\.?(?:\/|$)/;
+const INLINE_IMAGE = /^data:image\/(?:png|jpe?g|webp|gif);base64,[A-Za-z0-9+/=]+$/;
+
+export default function displayableImage(value) {
+  if (typeof value !== 'string') return null;
+  const v = value.trim();
+  if (UPLOAD_PATH.test(v) && !DOT_SEGMENT.test(v)) return v;
+  if (INLINE_IMAGE.test(v)) return v;
+  return safeUrl(v);
+}

--- a/frontend/src/utils/displayableImage.test.js
+++ b/frontend/src/utils/displayableImage.test.js
@@ -1,0 +1,13 @@
+import displayableImage from './displayableImage';
+
+test('passes own upload paths, inline images and http(s) links', () => {
+  expect(displayableImage('/api/uploads/abc-123.png')).toBe('/api/uploads/abc-123.png');
+  expect(displayableImage('data:image/png;base64,iVBORw0KGgo=')).toBe('data:image/png;base64,iVBORw0KGgo=');
+  expect(displayableImage(' https://cdn.example.com/a.png ')).toBe('https://cdn.example.com/a.png');
+});
+
+test('refuses shapes that would carry the viewer somewhere else', () => {
+  for (const bad of ['//attacker.example/a.png', 'javascript:alert(1)', '/api/uploads/../../x', '/etc/passwd', 'data:text/html;base64,PA==', 'label.png', '', null, undefined, {}]) {
+    expect(displayableImage(bad)).toBeNull();
+  }
+});

--- a/frontend/src/utils/internalPath.js
+++ b/frontend/src/utils/internalPath.js
@@ -1,0 +1,20 @@
+/**
+ * Accept only an in-app path ("/cellars/abc", "/wines/x?tab=y#z") and return
+ * it normalised. Anything that could leave the origin — an absolute URL, a
+ * protocol-relative "//host", a backslash variant, javascript: — yields null.
+ * Use it wherever a navigation target arrives as DATA (a notification's link,
+ * a stored return path) rather than as code (audit 2026-09 F03-5).
+ */
+export default function internalPath(value) {
+  if (typeof value !== 'string') return null;
+  const v = value.trim();
+  if (!v.startsWith('/') || v.startsWith('//') || v.startsWith('/\\')) return null;
+  if (/[\\\x00-\x1f]/.test(v)) return null;
+  try {
+    const u = new URL(v, 'http://cellarion.invalid');
+    if (u.origin !== 'http://cellarion.invalid') return null;
+    return u.pathname + u.search + u.hash;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/utils/internalPath.test.js
+++ b/frontend/src/utils/internalPath.test.js
@@ -1,0 +1,17 @@
+import internalPath from './internalPath';
+
+test('keeps in-app paths, with their query and hash', () => {
+  expect(internalPath('/cellars/abc')).toBe('/cellars/abc');
+  expect(internalPath('/wines/x?tab=prices#top')).toBe('/wines/x?tab=prices#top');
+  expect(internalPath('  /discussions/1 ')).toBe('/discussions/1');
+});
+
+test('refuses everything that could leave the origin', () => {
+  for (const bad of [
+    'https://evil.example/x', 'http://evil.example', '//evil.example/x', '/\\evil.example/x',
+    '\\\\evil.example', 'javascript:alert(1)', 'cellars/abc', '', null, undefined, 42,
+    '/a\x00b', '/ok\\..\\x',
+  ]) {
+    expect(internalPath(bad)).toBeNull();
+  }
+});

--- a/scripts/backup/backup.sh
+++ b/scripts/backup/backup.sh
@@ -61,6 +61,10 @@ EXTRA_CONFIG_PATHS="${EXTRA_CONFIG_PATHS:-}"
 UMAMI_DB_CONTAINER="${UMAMI_DB_CONTAINER:-}"
 
 log() { echo "[backup] $(date -Is) $*"; }
+# Credentials in the repository string (rest:/s3: forms carry user:pass@) must
+# not reach the database or the super-admin console — the status document only
+# says WHERE the backups go, never how to open them (audit 2026-09 F05-5).
+redact_repo() { printf '%s' "$1" | sed -E 's#(://)[^/@[:space:]]*@#\1***@#g'; }
 ping_fail() {
   [ -n "$HEALTHCHECK_URL" ] && curl -fsS -m 10 --retry 3 "${HEALTHCHECK_URL%/}/fail" >/dev/null 2>&1 || true
 }
@@ -87,7 +91,7 @@ record_status() {
     --arg     latestSnapshotTime "$latest" \
     --argjson repoSizeBytes     "${size:-null}" \
     --arg     host              "$(hostname)" \
-    --arg     repo              "$RESTIC_REPOSITORY" \
+    --arg     repo              "$(redact_repo "$RESTIC_REPOSITORY")" \
     --arg     error             "$err" \
     '{status:$status, lastRunAt:$lastRunAt, durationSec:$durationSec,
       snapshotCount:$snapshotCount, latestSnapshotTime:$latestSnapshotTime,


### PR DESCRIPTION
Remediation batch for the phase-6 (frontend) findings of the 2026-09 security audit, plus the phase-5 finding they escalated. Nothing here was exploitable for another user's data on the hosted service; all of it is hardening that closes real gaps.

## What changes

**Analytics never sees a one-time credential (F03-6).** The Umami tag now carries `data-exclude-search` / `data-exclude-hash`, the tracker is not loaded at all on `/reset-password`, `/verify-email` and `/connect-ai/authorize`, and both token pages take the token out of the address bar as soon as they have read it. Existing analytics rows that already captured such links need a one-off purge on the server (see deploy notes).

**No third party in the page load (F03-4, S6-1).** Inter and Playfair Display are bundled with the app via `@fontsource` and served from our origin; the Google Fonts links, `style-src`/`font-src` CSP entries and preconnects are gone. Exchange rates come from a new public, cached `GET /api/exchange-rates` (the backend's existing daily snapshot; at most one upstream call per day, made by the server) instead of the browser calling the provider — `connect-src` shrinks accordingly. The privacy policy now names Google sign-in as a sub-processor and states that fonts and rates are served by us. The policy version is left at 2026-09 on purpose (transparency additions, no new processing) — bump it if you want the re-consent prompt.

**A requester's image can no longer reach the registry unchecked (F06-1, S7-1, S7-2).** Wine-request images are validated on intake (REST and MCP twin share `createWineRequest`): an http(s) link that clears the same public-host check as `sourceUrl`, an inline `data:image/…;base64` payload, or one of our own upload paths. The admin approval validates again, and an explicitly blank field now stores *no image* instead of silently falling back to the requester's value. The admin wine editor's create/update paths get the same check. On the client, `AuthImage` only ever performs an authenticated fetch for a same-origin `/api/` path and renders nothing for unrecognised shapes, and `apiFetch` sends the bearer and the cookie only to the API origin (any other target is fetched with `credentials: 'omit'` and never triggers refresh/logout). The admin request view uses the same allow-list for the preview image and a scheme guard for the source link.

**Smaller items folded in.** `?wine=` on the wishlist page must be a well-formed id before it is interpolated into an API path (F01-2). Markdown renderers (chat answers, AI profiles, taxonomy descriptions) no longer render `<img>` (F02-1/F02-2). Notification links are navigated only when they are in-app paths, in the bell and in the service worker (F03-5). Granting/revoking admin or somm and starting a full re-embed/re-enrich ask for confirmation (F05-1/F05-2). The backup job redacts credentials from the repository string before recording it, and the super-admin route redacts again when serving it (F05-5).

## Tests
- Backend (node:24-alpine): 14 suites / 139 tests green, incl. new `accountOps` image cases, `admin/wineRequests.image.test.js`, `exchangeRates.test.js`, `utils/redactUrl.test.js`.
- Frontend: 85 files / 1166 tests green, incl. new `AuthImage.test.js`, `apiFetch.origin.test.js`, `internalPath.test.js`, `displayableImage.test.js`, `currency.fetchRates.test.js`.
- `npm ci --legacy-peer-deps` + `npm run build` verified in node:24-alpine; the built `index.html` has no Google Fonts reference and the font files ship under `/assets`.
- Lockfile regenerated in the container with npm 12; besides the two font packages it drops three peer-only typings entries that a non-`--legacy-peer-deps` install had added (runtime unaffected, matches the Dockerfile's install).

## Deploy notes
1. Backend first as usual; `/api/exchange-rates` sits behind the global `apiLimiter`.
2. Purge the analytics rows that captured token links (Umami Postgres, once): `DELETE FROM website_event WHERE url_query LIKE '%token=%';`
3. Reinstall `scripts/backup/backup.sh` on the VM (the redaction lives in the script; the route redacts as a backstop until then).
4. Not in this batch, deliberately: F03-9 (a non-OK refresh logs the tab out) and F03-8 (nginx `X-Forwarded-Proto`) touch the auth/proxy path and get their own PR; F07-1 (moderator roles lost-update) needs an API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
