### PR TITLE
fix(images): a bottle's own photo stays on its card after approval, and beats a generic registry image

### DIFF
--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -529,7 +529,10 @@ router.get('/:id', requireBottleAccess('viewer'), async (req, res) => {
     const pendingImg = await BottleImage.findOne({
       $or: pendingImgOr,
       uploadedBy: req.user.id,
-      status: { $in: ['uploaded', 'processing', 'processed'] },
+      // Pending OR approved — the uploader's own photo must not vanish from
+      // the hero the moment it is approved (same fix as the cellar list,
+      // support ticket 2026-09-05 / discussion #1227).
+      status: { $in: ['uploaded', 'processing', 'processed', 'approved'] },
       // Never a label scan — same fix as the cellar list (routes/cellars.js
       // attachBottleImageUrls, support ticket 2026-09-03): the scanner's raw
       // frame is private curation evidence, not a bottle photo.

--- a/backend/src/routes/bottles.pendingImage.test.js
+++ b/backend/src/routes/bottles.pendingImage.test.js
@@ -112,10 +112,20 @@ describe('GET /api/bottles/:id pending photo', () => {
     expect(BottleImage.findOne).toHaveBeenCalledTimes(1);
     expect(BottleImage.findOne).toHaveBeenCalledWith(expect.objectContaining({
       uploadedBy: USER,
-      status: { $in: ['uploaded', 'processing', 'processed'] },
+      // 'approved' is deliberate — see the cellar-list twin (ticket 2026-09-05 / #1227).
+      status: { $in: ['uploaded', 'processing', 'processed', 'approved'] },
       // `$ne`, not `kind: 'bottle'` — rows older than the field have no kind.
       kind: { $ne: 'label-scan' },
     }));
+  });
+
+  test('an APPROVED own photo keeps showing on the bottle page hero (ticket 2026-09-05 / #1227)', async () => {
+    BottleImage.findOne.mockReturnValue(sortLean({
+      _id: 'img1', kind: 'bottle', status: 'approved', visibility: 'public',
+      originalUrl: null, processedUrl: '/api/uploads/processed/approved.png',
+    }));
+    const res = await getJson(app(), `/api/bottles/${BOTTLE}`);
+    expect(res.body.pendingImageUrl).toBe('/api/uploads/processed/approved.png');
   });
 
   test('a genuine bottle photo still shows — the processed file first, the original only while rembg is still running', async () => {

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -354,7 +354,12 @@ async function attachBottleImageUrls(bottles, userId) {
       ...(wineIds.length ? [{ wineDefinition: { $in: wineIds } }] : []),
     ],
     uploadedBy: userId,
-    status: { $in: ['uploaded', 'processing', 'processed'] },
+    // The uploader's OWN photos, pending OR approved. Approval used to drop a
+    // photo out of this lookup, so the moment an admin approved it the card
+    // went blank unless the wine had a registry image — while the bottle page
+    // gallery still listed it (support ticket 2026-09-05, discussion #1227;
+    // 471 bottles of 49 owners on 2026-09-06). Rejected stays out.
+    status: { $in: ['uploaded', 'processing', 'processed', 'approved'] },
     // Never a label scan (support ticket 2026-09-03). The raw frame handed to
     // the AI scanner is kept ONLY as private curation evidence (models/
     // BottleImage.kind); it carries the wine it minted, sits at status

--- a/backend/src/routes/cellars.pendingImage.test.js
+++ b/backend/src/routes/cellars.pendingImage.test.js
@@ -56,13 +56,15 @@ beforeEach(() => {
   BottleImage.find.mockReturnValue(chain([]));
 });
 
-test('the pending lookup excludes label scans and is scoped to the viewer', async () => {
+test('the own-photo lookup excludes label scans, is scoped to the viewer, and includes APPROVED photos', async () => {
   const out = await attachBottleImageUrls([{ _id: B1, wineDefinition: WINE }], USER);
 
   expect(BottleImage.find).toHaveBeenCalledTimes(1);
   expect(BottleImage.find).toHaveBeenCalledWith(expect.objectContaining({
     uploadedBy: USER,
-    status: { $in: ['uploaded', 'processing', 'processed'] },
+    // 'approved' is deliberate: approval used to drop a photo out of this
+    // lookup and blank the card (support ticket 2026-09-05, discussion #1227).
+    status: { $in: ['uploaded', 'processing', 'processed', 'approved'] },
     // `$ne`, not `kind: 'bottle'` — rows older than the field have no kind.
     kind: { $ne: 'label-scan' },
   }));
@@ -83,6 +85,15 @@ test('a photo pinned to the bottle beats one that merely matches the wine, and t
 
   expect(out[0].pendingImageUrl).toBe('/api/uploads/processed/b1.png');   // pinned to B1
   expect(out[1].pendingImageUrl).toBe('/api/uploads/processed/wine.png'); // same wine, no pin
+});
+
+test('an approved own photo — public or private — still shows on the card', async () => {
+  BottleImage.find.mockReturnValue(chain([
+    { _id: 'appr', wineDefinition: WINE, bottle: B1, status: 'approved', visibility: 'private', originalUrl: null, processedUrl: '/api/uploads/processed/approved.png' },
+  ]));
+
+  const out = await attachBottleImageUrls([{ _id: B1, wineDefinition: WINE }], USER);
+  expect(out[0].pendingImageUrl).toBe('/api/uploads/processed/approved.png');
 });
 
 test('empty input is returned as-is without a query', async () => {

--- a/frontend/src/components/BottleCard.js
+++ b/frontend/src/components/BottleCard.js
@@ -37,8 +37,13 @@ function BottleCard({ bottle, rackMap, cellarId, viewMode, groupCount = 1, onCli
   // and whenever placement is unknown (cross-cellar view, or no racks exist).
   const isUnplaced = rackKnown && !isGroup && !rackInfo && bottle.status === 'active';
   const rackNavPref = user?.preferences?.rackNavigation || 'auto';
-  const imgSrc = bottle.defaultImageUrl || bottle.wineDefinition?.image || bottle.pendingImageUrl;
-  const credit = bottle.defaultImageUrl ? null : bottle.wineDefinition?.imageCredit;
+  // Chosen default → the owner's own photo (pending or approved) → the
+  // registry image. Same order as the bottle page hero: a photo you took of
+  // YOUR bottle beats a generic registry image, and it must not disappear
+  // from the card when an admin approves it (ticket 2026-09-05, #1227).
+  const ownImage = bottle.defaultImageUrl || bottle.pendingImageUrl;
+  const imgSrc = ownImage || bottle.wineDefinition?.image;
+  const credit = ownImage ? null : bottle.wineDefinition?.imageCredit;
   const isPending = !bottle.wineDefinition && !!bottle.pendingWineRequest;
   const displayName = bottle.wineDefinition?.name || bottle.pendingWineRequest?.wineName || t('common.unknownWine');
   const displayProducer = bottle.wineDefinition?.producer || bottle.pendingWineRequest?.producer;

--- a/frontend/src/components/BottleCard.test.js
+++ b/frontend/src/components/BottleCard.test.js
@@ -91,3 +91,39 @@ describe('BottleCard long-press (post-ship audit 2026-09-03)', () => {
     }
   });
 });
+
+/**
+ * Which photo a card shows (support ticket 2026-09-05, discussion #1227): the
+ * owner's chosen default, else the owner's OWN photo — pending or approved —
+ * else the registry image. Approval used to make a card go blank because the
+ * own-photo lookup dropped approved rows and the card preferred the registry
+ * image, which most wines do not have.
+ */
+describe('BottleCard image precedence', () => {
+  const WITH_REGISTRY_IMAGE = {
+    ...BOTTLE,
+    wineDefinition: { ...BOTTLE.wineDefinition, image: '/api/uploads/processed/registry.png', imageCredit: 'someone else' },
+  };
+
+  test("the owner's own photo beats the registry image and carries no credit line", () => {
+    const { container } = renderCard({ bottle: { ...WITH_REGISTRY_IMAGE, pendingImageUrl: '/api/uploads/processed/mine.png' } });
+    expect(container.querySelector('img').getAttribute('src')).toBe('/api/uploads/processed/mine.png');
+    expect(screen.queryByText('someone else')).not.toBeInTheDocument();
+  });
+
+  test('a chosen default beats both', () => {
+    const { container } = renderCard({ bottle: { ...WITH_REGISTRY_IMAGE, pendingImageUrl: '/api/uploads/processed/mine.png', defaultImageUrl: '/api/uploads/processed/default.png' } });
+    expect(container.querySelector('img').getAttribute('src')).toBe('/api/uploads/processed/default.png');
+  });
+
+  test('with no own photo the registry image shows, with its credit', () => {
+    const { container } = renderCard({ bottle: WITH_REGISTRY_IMAGE });
+    expect(container.querySelector('img').getAttribute('src')).toBe('/api/uploads/processed/registry.png');
+    expect(screen.getByText('someone else')).toBeInTheDocument();
+  });
+
+  test('no photo at all renders no image', () => {
+    const { container } = renderCard();
+    expect(container.querySelector('img')).toBeNull();
+  });
+});


### PR DESCRIPTION
Support ticket 2026-09-05 ("Missing bottle photos in cellar view") and discussion #1227.

**Cause.** The uploader's own-photo lookup on the cellar list (`attachBottleImageUrls`) and the bottle page only matched `uploaded/processing/processed` rows. The moment an admin approved a photo it dropped out of that lookup, and the card fell back to the registry wine image — which most wines do not have — so the card went blank while the bottle page gallery still listed the photo. 471 active bottles of 49 owners were blank this way on 2026-09-06.

**Fix.** The lookup includes `approved` rows on both endpoints (rejected rows and label scans stay excluded). The card now shows the owner's chosen default, else the owner's own photo (pending or approved), else the registry image — the order the bottle page hero already used — and the registry credit line only appears with the registry image. The "add a photo" prompt disappears for those bottles as a consequence. No data migration needed.

**Tests.** Backend: `cellars.pendingImage` and `bottles.pendingImage` pin the new status list and an approved own photo (7/7). Frontend: `BottleCard.test` pins the precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)