### PR TITLE
feat(import): CellarTracker bins can be declared "Column, Row"

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4084,6 +4084,9 @@
     },
     "rackAutoMap": {
       "hint": "Detected <1>CellarTracker</1> Location/Bin codes. Locations with a consistent bin pattern have been mapped to racks below — check the detected dimensions before importing. Bottles whose bin codes don't fit the pattern keep their location as text instead.",
+      "binOrderLabel": "Bin codes are written as",
+      "binOrderRowCol": "Row, Column (2,7 = row 2, column 7)",
+      "binOrderColRow": "Column, Row (2,7 = column 2, row 7)",
       "patternRowCol": "Row/column bin codes (R3C2)",
       "patternRowColDepth": "Row/column/depth bin codes (R3C2D1)",
       "patternLetterNumber": "Letter + number bin codes (A12)",

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -124,6 +124,10 @@ function ImportBottles() {
 
   // Upload step
   const [parsedItems, setParsedItems] = useState([]);
+  // The last CSV's raw text, kept so a CellarTracker bin-order change can
+  // re-run the parser (support ticket 2026-09-05: bins typed "column,row").
+  const [sourceText, setSourceText] = useState(null);
+  const [ctBinOrder, setCtBinOrder] = useState('row-col');
   const [detectedFormat, setDetectedFormat] = useState(null);
   // File encoding detected by decodeImportBuffer ('utf-8', 'windows-1252', …)
   const [detectedEncoding, setDetectedEncoding] = useState(null);
@@ -455,6 +459,16 @@ function ImportBottles() {
 
   const VALID_IMPORT_EXTENSIONS = ['.csv', '.tsv', '.txt', '.json'];
 
+  // Re-run the CellarTracker parse with the other bin-code order. Everything
+  // derived from the parse (items, rack summary, rack configs) is rebuilt by
+  // applyParsed, exactly as on the original upload.
+  const changeCtBinOrder = (order) => {
+    setCtBinOrder(order);
+    if (!sourceText) return;
+    const parsed = parseAndMap(sourceText.text, undefined, { ctBinOrder: order });
+    applyParsed(parsed, { fileName: sourceText.fileName, encoding: sourceText.encoding });
+  };
+
   /**
    * Read and parse the dropped/chosen file(s).
    *
@@ -536,6 +550,8 @@ function ImportBottles() {
 
         const first = read[0];
         const isJson = first.file.name.toLowerCase().endsWith('.json');
+        setSourceText(isJson ? null : { text: first.text, fileName: first.file.name, encoding: first.encoding });
+        setCtBinOrder('row-col');
         const parsed = isJson ? parseJSON(first.text) : parseAndMap(first.text);
         if (read.length > 1) {
           parsed.warnings = [...(parsed.warnings || []), { code: 'extra-files-ignored', count: read.length - 1 }];
@@ -1333,6 +1349,17 @@ function ImportBottles() {
           {detectedFormat === 'cellartracker' && Object.values(rackSummary).some(i => i.ctAutoMap) && (
             <p className="rack-options-hint">
               <Trans i18nKey="importBottles.rackAutoMap.hint" components={{ 1: <strong /> }} />
+            </p>
+          )}
+          {detectedFormat === 'cellartracker' && sourceText && (
+            <p className="rack-options-hint">
+              <label>
+                {t('importBottles.rackAutoMap.binOrderLabel')}{' '}
+                <select value={ctBinOrder} onChange={e => changeCtBinOrder(e.target.value)}>
+                  <option value="row-col">{t('importBottles.rackAutoMap.binOrderRowCol')}</option>
+                  <option value="col-row">{t('importBottles.rackAutoMap.binOrderColRow')}</option>
+                </select>
+              </label>
             </p>
           )}
           <p className="rack-options-hint">

--- a/frontend/src/utils/binCodeParser.js
+++ b/frontend/src/utils/binCodeParser.js
@@ -66,6 +66,13 @@
  * (the Rack schema bound). A parsed code whose row/col exceeds 20, or a
  * sequential position beyond 400 (a full 20×20 grid), is treated as unparsed
  * for that bottle rather than distorting the rack.
+ *
+ * Bin-code ORDER (opts.binOrder, support ticket 2026-09-05): the codes cannot
+ * say whether "2,7" means row 2 / column 7 or the other way round — a
+ * 1,354-bottle cellar typed every bin as "column,row". The default is
+ * 'row-col'; 'col-row' swaps the two numeric segments (2- and 3-segment
+ * codes) and reads a letter+number code as column letter, row number. Codes
+ * that NAME their axes (R3C2, R3C2D1) and sequential bins are never affected.
  */
 
 const MAX_DIM = 20;
@@ -81,11 +88,12 @@ const NUMERIC_SEGMENT_RE = /^\d{1,3}$/;
 const SUBRACK_SEGMENT_RE = /^[A-Za-z0-9]{1,6}$/;
 
 /** Split a bin code on dashes/dots/commas into 2 or 3 usable segments, or null. */
-function matchSegments(bin) {
+function matchSegments(bin, colFirst = false) {
   const parts = bin.split(SEGMENT_SPLIT_RE).map((s) => s.trim());
   if (parts.length < 2 || parts.length > 3) return null;
   if (parts.some((p) => !p)) return null;
-  const [rowStr, colStr] = parts.slice(-2);
+  const tail = parts.slice(-2);
+  const [rowStr, colStr] = colFirst ? [tail[1], tail[0]] : tail;
   if (!NUMERIC_SEGMENT_RE.test(rowStr) || !NUMERIC_SEGMENT_RE.test(colStr)) return null;
   const row = parseInt(rowStr, 10);
   const col = parseInt(colStr, 10);
@@ -138,7 +146,8 @@ function noMatch(n, allIndexes) {
  * `qualifies` is false the caller must fall back to freeform text for the
  * whole group — `placements` is still returned for diagnostics only.
  */
-export function analyzeBinGroup(bins) {
+export function analyzeBinGroup(bins, opts = {}) {
+  const colFirst = opts.binOrder === 'col-row';
   const trimmed = (bins || []).map((b) => (b == null ? '' : String(b).trim()));
   const n = trimmed.length;
   const allIndexes = trimmed.map((_, i) => i);
@@ -163,7 +172,7 @@ export function analyzeBinGroup(bins) {
       const col = parseInt(m[2], 10);
       if (col >= 1) letter.push({ i, letter: m[1].toUpperCase(), col });
     }
-    const seg = matchSegments(bin);
+    const seg = matchSegments(bin, colFirst);
     if (seg?.segs === 2) seg2.push({ i, row: seg.row, col: seg.col });
     if (seg?.segs === 3) seg3.push({ i, subRack: seg.subRack, row: seg.row, col: seg.col });
     if ((m = bin.match(PREFIXED_INT_RE))) {
@@ -242,7 +251,9 @@ export function analyzeBinGroup(bins) {
   } else if (best.name === 'letter') {
     pattern = 'letter-number';
     const usable = best.matches
-      .map((c) => ({ index: c.i, row: c.letter.charCodeAt(0) - 64, col: c.col }))
+      .map((c) => (colFirst
+        ? { index: c.i, row: c.col, col: c.letter.charCodeAt(0) - 64 }
+        : { index: c.i, row: c.letter.charCodeAt(0) - 64, col: c.col }))
       .filter((c) => c.row <= MAX_DIM && c.col <= MAX_DIM);
     placements = usable;
     inferredRows = Math.max(0, ...usable.map((c) => c.row)) || undefined;
@@ -304,7 +315,7 @@ export function analyzeBinGroup(bins) {
  *   skipped entirely — no location means nothing to place (e.g. CT List rows
  *   for wines spanning multiple locations export Location blank).
  */
-export function analyzeBinGroups(pairs) {
+export function analyzeBinGroups(pairs, opts = {}) {
   const groups = new Map(); // location -> [globalIndex]
   (pairs || []).forEach((p, i) => {
     const loc = (p?.location || '').trim();
@@ -315,7 +326,7 @@ export function analyzeBinGroups(pairs) {
 
   const out = {};
   for (const [loc, idxs] of groups) {
-    const analysis = analyzeBinGroup(idxs.map((i) => pairs[i]?.bin ?? ''));
+    const analysis = analyzeBinGroup(idxs.map((i) => pairs[i]?.bin ?? ''), opts);
     // Re-map group-local indexes back to the caller's pair indexes.
     analysis.placements = analysis.placements.map((pl) => ({ ...pl, index: idxs[pl.index] }));
     analysis.unparsed = analysis.unparsed.map((i) => idxs[i]);

--- a/frontend/src/utils/binCodeParser.test.js
+++ b/frontend/src/utils/binCodeParser.test.js
@@ -172,6 +172,43 @@ describe('segments family (12-3-4 / D-04-1 / 3.2)', () => {
   });
 });
 
+// Support ticket 2026-09-05: the same 1,354-bottle cellar turned out to type
+// its bins as "column,row" — the importer had read every "2,7" as row 2,
+// column 7. The order is the user's to declare; the codes cannot tell.
+describe('binOrder option (column,row cellars)', () => {
+  it('col-row swaps the two numeric segments, sub-rack codes included', () => {
+    const r = analyzeBinGroup(['2,7', '2,8', '3,1', '1,12'], { binOrder: 'col-row' });
+    expect(r.pattern).toBe('segments');
+    expect(r.qualifies).toBe(true);
+    expect(placementFor(r, 0)).toEqual({ index: 0, row: 7, col: 2 });
+    expect(placementFor(r, 3)).toEqual({ index: 3, row: 12, col: 1 });
+    expect(r.inferredRows).toBe(12);
+    expect(r.inferredCols).toBe(3);
+    const s = analyzeBinGroup(['12-3-4', '12-3-5', '13-1-1'], { binOrder: 'col-row' });
+    expect(placementFor(s, 0)).toEqual({ index: 0, subRack: '12', row: 4, col: 3 });
+  });
+
+  it('col-row reads a letter+number code as column letter, row number', () => {
+    const r = analyzeBinGroup(['A1', 'A2', 'B1', 'B3'], { binOrder: 'col-row' });
+    expect(r.pattern).toBe('letter-number');
+    expect(placementFor(r, 3)).toEqual({ index: 3, row: 3, col: 2 });
+    expect(r.inferredRows).toBe(3);
+    expect(r.inferredCols).toBe(2);
+  });
+
+  it('never touches codes that name their axes (R3C2) or sequential bins', () => {
+    const rc = analyzeBinGroup(['R3C2', 'R1C1', 'R2C4'], { binOrder: 'col-row' });
+    expect(placementFor(rc, 0)).toEqual({ index: 0, row: 3, col: 2 });
+    const seq = analyzeBinGroup(['147', '148', '149'], { binOrder: 'col-row' });
+    expect(placementFor(seq, 0)).toEqual({ index: 0, rackPosition: 147 });
+  });
+
+  it('row-col (the default) is unchanged', () => {
+    const r = analyzeBinGroup(['2,7', '2,8', '3,1'], { binOrder: 'row-col' });
+    expect(placementFor(r, 0)).toEqual({ index: 0, row: 2, col: 7 });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // sequential — 147, BIN1
 // ---------------------------------------------------------------------------

--- a/frontend/src/utils/importMappers.ctRackAutoMap.test.js
+++ b/frontend/src/utils/importMappers.ctRackAutoMap.test.js
@@ -162,6 +162,21 @@ describe('applyCtRackAutoMap', () => {
     wineName: 'W', producer: 'P', _ctLocation: loc, _ctBin: bin, ...extra,
   });
 
+  it('honours binOrder: col-row for "column,row" cellars (support ticket 2026-09-05)', () => {
+    const items = [mk('North rack', '2,7'), mk('North rack', '2,8'), mk('North rack', '3,1'), mk('North rack', '1,12')];
+    const { racks } = applyCtRackAutoMap(items, { binOrder: 'col-row' });
+    expect(items[0]).toMatchObject({ rackName: 'North rack', row: 7, col: 2, rackRows: 12, rackCols: 3 });
+    expect(racks['North rack']).toMatchObject({ pattern: 'segments', rows: 12, cols: 3, spec: { type: 'grid', rows: 12, cols: 3, typeConfig: {} } });
+  });
+
+  it('parseAndMap threads ctBinOrder through to the auto-map', () => {
+    const text = decodeImportBuffer(fs.readFileSync(path.join(FIXTURES, 'bundle', 'CellarTracker_Inventory.tsv'))).text;
+    const { items } = parseAndMap(text, undefined, { ctBinOrder: 'col-row' });
+    const fridge = items.filter((i) => i.rackName === 'Wine Fridge');
+    expect(fridge).toHaveLength(9);
+    expect(fridge.find((i) => i.location === 'Wine Fridge / B3')).toMatchObject({ row: 3, col: 2, rackRows: 6, rackCols: 2 });
+  });
+
   it('emits shelf geometry for R<r>C<c>D<d> bins with front/back depth', () => {
     const items = [
       mk('Cave', 'R1C1D1'), mk('Cave', 'R1C1D2'),

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -1565,7 +1565,7 @@ function splitCSVLine(line, delimiter = ',') {
  *   (leftovers of single-rack groups are reported on the rack's own card
  *   via `unparsedCount` instead).
  */
-export function applyCtRackAutoMap(items) {
+export function applyCtRackAutoMap(items, opts = {}) {
   const groupIndexes = new Map(); // location -> [item index]
   items.forEach((item, i) => {
     if (!item || typeof item !== 'object') return;
@@ -1582,7 +1582,8 @@ export function applyCtRackAutoMap(items) {
 
   for (const [loc, idxs] of groupIndexes) {
     const analysis = analyzeBinGroups(
-      idxs.map((i) => ({ location: loc, bin: items[i]._ctBin || '' }))
+      idxs.map((i) => ({ location: loc, bin: items[i]._ctBin || '' })),
+      opts
     )[loc];
 
     if (!analysis?.qualifies) {
@@ -2092,7 +2093,7 @@ export function parsePlocFiles(texts) {
  * @throws Error with code 'ct-error-page' for HTML error pages, or
  *   'ct-availability' for CT's Availability statistics table.
  */
-export function parseAndMap(text, forceFormat) {
+export function parseAndMap(text, forceFormat, opts = {}) {
   // Strip BOM
   const cleaned = text.replace(/^\uFEFF/, '');
 
@@ -2196,7 +2197,9 @@ export function parseAndMap(text, forceFormat) {
   // transient _ctLocation/_ctBin markers from every item.
   let ctRackAutoMap = null;
   if (format === 'cellartracker') {
-    const autoMap = applyCtRackAutoMap(items);
+    // opts.ctBinOrder: 'row-col' (default) | 'col-row' — the user's declaration
+    // of how their bins are typed (support ticket 2026-09-05).
+    const autoMap = applyCtRackAutoMap(items, { binOrder: opts.ctBinOrder });
     if (Object.keys(autoMap.racks).length > 0 || autoMap.textFallback.length > 0) {
       ctRackAutoMap = autoMap;
     }


### PR DESCRIPTION
Support ticket 2026-09-05 (follow-up to the 2026-09-02 comma-separator fix): the same large CellarTracker cellar types every bin as `column,row`, so the importer placed every bottle transposed (`2,7` read as row 2, column 7).

The codes cannot tell which order the user meant, so the user declares it: a **"Bin codes are written as"** selector (Row, Column / Column, Row) next to the CellarTracker auto-map notice on the import page re-parses the file with the chosen order. `col-row` swaps the two numeric segments (2- and 3-segment codes) and reads a letter+number code as column letter, row number; codes that name their axes (R3C2, R3C2D1) and sequential bins are never affected. The default is unchanged.

Plumbing: `analyzeBinGroup(bins, { binOrder })` → `applyCtRackAutoMap(items, opts)` → `parseAndMap(text, format, { ctBinOrder })`; the page keeps the raw text of the last CSV to re-parse on change. English strings only.

Tests: `binCodeParser.test` (4 new), `importMappers.ctRackAutoMap.test` (2 new, incl. the fixture bundle through `parseAndMap`); all four importer suites green (261 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)