### PR TITLE
feat(import): reuse a pending wine request across imports, and carry the file's geography as curator hints

### DIFF
--- a/backend/src/models/WineRequest.js
+++ b/backend/src/models/WineRequest.js
@@ -35,6 +35,16 @@ const wineRequestSchema = new mongoose.Schema({
     type: String,
     trim: true
   },
+  // What the import FILE said about the wine (CellarTracker / Vivino / Ploc
+  // all name these). Plain strings for the curator's benefit — prefilled on
+  // the admin page, never written to the registry until the request is
+  // resolved (support ticket 2026-09-05: 243 requests had to be re-derived).
+  hints: {
+    country: { type: String, trim: true, maxlength: 100 },
+    region: { type: String, trim: true, maxlength: 100 },
+    appellation: { type: String, trim: true, maxlength: 150 },
+    type: { type: String, trim: true, maxlength: 20 }
+  },
   user: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',

--- a/backend/src/routes/import.archive.test.js
+++ b/backend/src/routes/import.archive.test.js
@@ -57,6 +57,7 @@ jest.mock('../models/Bottle', () => {
 jest.mock('../models/WineRequest', () => {
   function WineRequest(doc) { Object.assign(this, doc); this._id = 'req-1'; }
   WineRequest.prototype.save = function () { return Promise.resolve(this); };
+  WineRequest.findOne = jest.fn().mockResolvedValue(null); // intake reuse lookup (services/wineRequestIntake)
   return WineRequest;
 });
 // The archive itself — captured, never written.

--- a/backend/src/routes/import.confirm.test.js
+++ b/backend/src/routes/import.confirm.test.js
@@ -76,6 +76,7 @@ jest.mock('../models/WineRequest', () => {
     instances.push(this);
   }
   WineRequest.__instances = instances;
+  WineRequest.findOne = jest.fn().mockResolvedValue(null); // intake reuse lookup (services/wineRequestIntake)
   return WineRequest;
 });
 

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -43,6 +43,7 @@ const { validatePriceSanity } = require('../utils/priceValidation');
 const { computeUserMediansByCurrency } = require('../services/priceWarnings');
 const { runConcurrent } = require('../utils/concurrency');
 const WineRequest = require('../models/WineRequest');
+const { findOrCreatePendingRequest, pickImportHints } = require('../services/wineRequestIntake');
 const WishlistItem = require('../models/WishlistItem');
 const ImportSession = require('../models/ImportSession');
 const ImportArchive = require('../models/ImportArchive');
@@ -1534,26 +1535,20 @@ router.post('/confirm', async (req, res) => {
             continue;
           }
 
-          const requestKey = `${(item.wineName || '').trim().toLowerCase()}|${(item.producer || '').trim().toLowerCase()}`;
-          let wineRequest = pendingRequestCache.get(requestKey);
-
-          if (!wineRequest) {
-            // Optional import-supplied grape names ride along as suggestions —
-            // the admin sees them when resolving the request and decides which
-            // taxonomy grapes the new wine definition gets (registry integrity:
-            // imports never write taxonomy directly on this path).
-            const suggestedGrapes = sanitizeGrapeNames(item.grapes);
-            wineRequest = new WineRequest({
-              requestType: 'new_wine',
-              wineName: String(item.wineName).trim(),
-              producer: (item.producer || '').trim() || undefined,
-              user: req.user.id,
-              status: 'pending',
-              ...(suggestedGrapes.length > 0 ? { suggestedGrapes } : {})
-            });
-            await wineRequest.save();
-            pendingRequestCache.set(requestKey, wineRequest);
-          }
+          // One request per user + wine + producer, REUSED across imports
+          // (a re-import used to mint a second pending request for every
+          // wine still waiting), carrying the file's geography/type as hints
+          // for the curator. Import-supplied grape names ride along as
+          // suggestions — the admin decides which taxonomy grapes the new
+          // wine definition gets (imports never write taxonomy on this path).
+          const { wineRequest } = await findOrCreatePendingRequest({
+            userId: req.user.id,
+            wineName: item.wineName,
+            producer: item.producer,
+            suggestedGrapes: sanitizeGrapeNames(item.grapes),
+            hints: pickImportHints(item),
+            cache: pendingRequestCache,
+          });
 
           // Validate rating if provided — the frontend sends rating/ratingScale
           // for request-wine rows too; dropping them here silently lost the

--- a/backend/src/routes/import.validateReadonly.test.js
+++ b/backend/src/routes/import.validateReadonly.test.js
@@ -83,6 +83,7 @@ jest.mock('../models/WineRequest', () => {
     instances.push(this);
   }
   WineRequest.__instances = instances;
+  WineRequest.findOne = jest.fn().mockResolvedValue(null); // intake reuse lookup (services/wineRequestIntake)
   return WineRequest;
 });
 

--- a/backend/src/services/cellarImport.js
+++ b/backend/src/services/cellarImport.js
@@ -35,6 +35,7 @@ const { RACK_TYPES } = require('../models/Rack');
 const CellarLayout = require('../models/CellarLayout');
 const BottleImage = require('../models/BottleImage');
 const WineRequest = require('../models/WineRequest');
+const { findOrCreatePendingRequest, pickImportHints } = require('./wineRequestIntake');
 const Review = require('../models/Review');
 const WineVintageProfile = require('../models/WineVintageProfile');
 
@@ -439,19 +440,12 @@ async function resolveWine(item, userId, cache, result, demoMode = false) {
     return { skip: true };
   }
 
-  const key = `${name.toLowerCase()}|${producer.toLowerCase()}`;
-  let wineRequest = cache.get(key);
-  if (!wineRequest) {
-    wineRequest = await WineRequest.create({
-      requestType: 'new_wine',
-      wineName: name,
-      producer: producer || undefined,
-      user: userId,
-      status: 'pending',
-    });
-    cache.set(key, wineRequest);
-    result.wineRequests++;
-  }
+  // Reused across imports for the same user + wine + producer, with the
+  // file's geography/type as curator hints (services/wineRequestIntake).
+  const { wineRequest, reused } = await findOrCreatePendingRequest({
+    userId, wineName: name, producer, hints: pickImportHints(item), cache,
+  });
+  if (!reused) result.wineRequests++;
   return { wineRequestId: wineRequest._id };
 }
 

--- a/backend/src/services/wineRequestIntake.js
+++ b/backend/src/services/wineRequestIntake.js
@@ -1,0 +1,97 @@
+const WineRequest = require('../models/WineRequest');
+
+/**
+ * Import-time wine requests, shared by routes/import.js and
+ * services/cellarImport.js.
+ *
+ * Two lessons from the 2026-09-05 CellarTracker import (support ticket
+ * 2026-09-05, 243 requests / 642 bottles in one run):
+ *
+ *   1. A request must be REUSED across imports. The per-run cache only
+ *      deduplicated within one file, so a user who re-imports (a cleaned-up
+ *      export, a second cellar) minted a second pending request for every
+ *      wine still waiting — and the admin queue doubled.
+ *   2. A request must CARRY what the file said about the wine. CellarTracker,
+ *      Vivino and Ploc exports all name the country, region, appellation and
+ *      type; dropping them left the curator to re-derive 243 geographies by
+ *      hand. They ride along as `hints` — plain strings, never written to the
+ *      registry until an admin resolves the request.
+ */
+
+const HINT_LIMITS = { country: 100, region: 100, appellation: 150, type: 20 };
+
+function cleanHint(value, max) {
+  if (value == null) return '';
+  const s = String(value).trim();
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+/** The hint fields an import row may carry; null when the row has none. */
+function pickImportHints(item) {
+  if (!item || typeof item !== 'object') return null;
+  const hints = {};
+  for (const [key, max] of Object.entries(HINT_LIMITS)) {
+    const v = cleanHint(item[key], max);
+    if (v) hints[key] = key === 'type' ? v.toLowerCase() : v;
+  }
+  return Object.keys(hints).length ? hints : null;
+}
+
+function hasHints(doc) {
+  const h = doc && doc.hints;
+  return !!(h && (h.country || h.region || h.appellation || h.type));
+}
+
+const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Find the user's existing PENDING new_wine request for this wine and
+ * producer (case-insensitive, exact after trimming), or create one.
+ *
+ * @param {object} args
+ * @param {string|ObjectId} args.userId
+ * @param {string} args.wineName
+ * @param {string} [args.producer]
+ * @param {string[]} [args.suggestedGrapes]
+ * @param {object|null} [args.hints]     from pickImportHints(item)
+ * @param {Map} [args.cache]             per-run cache keyed on name|producer
+ * @returns {Promise<{ wineRequest: object, reused: boolean }>}
+ */
+async function findOrCreatePendingRequest({ userId, wineName, producer, suggestedGrapes = [], hints = null, cache = null }) {
+  const name = String(wineName || '').trim();
+  const prod = String(producer || '').trim();
+  const key = `${name.toLowerCase()}|${prod.toLowerCase()}`;
+  if (cache && cache.has(key)) return { wineRequest: cache.get(key), reused: true };
+
+  const filter = {
+    user: userId,
+    requestType: 'new_wine',
+    status: 'pending',
+    wineName: new RegExp('^' + escapeRegex(name) + '$', 'i'),
+    producer: prod ? new RegExp('^' + escapeRegex(prod) + '$', 'i') : { $in: [null, ''] },
+  };
+  let wineRequest = await WineRequest.findOne(filter);
+  const reused = !!wineRequest;
+
+  if (!wineRequest) {
+    wineRequest = new WineRequest({
+      requestType: 'new_wine',
+      wineName: name,
+      producer: prod || undefined,
+      user: userId,
+      status: 'pending',
+      ...(suggestedGrapes.length > 0 ? { suggestedGrapes } : {}),
+      ...(hints ? { hints } : {}),
+    });
+    await wineRequest.save();
+  } else if (hints && !hasHints(wineRequest)) {
+    // An older request without hints learns them from this file.
+    wineRequest.hints = hints;
+    await wineRequest.save();
+  }
+
+  if (cache) cache.set(key, wineRequest);
+  return { wineRequest, reused };
+}
+
+module.exports = { findOrCreatePendingRequest, pickImportHints, hasHints, HINT_LIMITS };

--- a/backend/src/services/wineRequestIntake.test.js
+++ b/backend/src/services/wineRequestIntake.test.js
@@ -1,0 +1,99 @@
+/**
+ * Import-time wine requests (support ticket 2026-09-05): a request is reused
+ * across imports for the same user + wine + producer, and it carries the
+ * file's country / region / appellation / type as hints for the curator.
+ */
+jest.mock('../models/WineRequest', () => {
+  const ctor = jest.fn().mockImplementation(function (doc) {
+    Object.assign(this, doc);
+    this._id = 'new-' + (ctor.mock.instances.length);
+    this.save = jest.fn().mockResolvedValue(this);
+  });
+  ctor.findOne = jest.fn();
+  return ctor;
+});
+
+const WineRequest = require('../models/WineRequest');
+const { findOrCreatePendingRequest, pickImportHints, hasHints } = require('./wineRequestIntake');
+
+const UID = 'u1';
+beforeEach(() => { jest.clearAllMocks(); WineRequest.findOne.mockResolvedValue(null); });
+
+describe('pickImportHints', () => {
+  test('keeps the four geography/type fields, trimmed, capped, type lowercased', () => {
+    expect(pickImportHints({ country: ' France ', region: 'Burgundy', appellation: 'Chablis Premier Cru', type: 'White', producer: 'x' }))
+      .toEqual({ country: 'France', region: 'Burgundy', appellation: 'Chablis Premier Cru', type: 'white' });
+    expect(pickImportHints({ country: 'x'.repeat(200) }).country).toHaveLength(100);
+  });
+  test('null when the row says nothing', () => {
+    expect(pickImportHints({ wineName: 'X' })).toBeNull();
+    expect(pickImportHints(null)).toBeNull();
+  });
+});
+
+describe('findOrCreatePendingRequest', () => {
+  test('creates a pending request with hints when none exists', async () => {
+    const { wineRequest, reused } = await findOrCreatePendingRequest({
+      userId: UID, wineName: ' Magari ', producer: "Ca' Marcanda", suggestedGrapes: ['Merlot'],
+      hints: { country: 'Italy', region: 'Tuscany', appellation: 'Toscana', type: 'red' },
+    });
+    expect(reused).toBe(false);
+    expect(WineRequest.findOne).toHaveBeenCalledWith(expect.objectContaining({ user: UID, requestType: 'new_wine', status: 'pending' }));
+    expect(wineRequest).toMatchObject({ wineName: 'Magari', producer: "Ca' Marcanda", suggestedGrapes: ['Merlot'], hints: { country: 'Italy', type: 'red' } });
+    expect(wineRequest.save).toHaveBeenCalledTimes(1);
+  });
+
+  test('reuses the existing pending request — case-insensitive on name and producer — and learns hints it lacked', async () => {
+    const existing = { _id: 'req-1', wineName: 'Magari', producer: "ca' marcanda", hints: undefined, save: jest.fn().mockResolvedValue(undefined) };
+    WineRequest.findOne.mockResolvedValue(existing);
+    const { wineRequest, reused } = await findOrCreatePendingRequest({
+      userId: UID, wineName: 'MAGARI', producer: "Ca' Marcanda", hints: { country: 'Italy' },
+    });
+    expect(reused).toBe(true);
+    expect(wineRequest).toBe(existing);
+    expect(WineRequest).not.toHaveBeenCalled();
+    const filter = WineRequest.findOne.mock.calls[0][0];
+    expect(filter.wineName.test('magari')).toBe(true);
+    expect(filter.producer.test("CA' MARCANDA")).toBe(true);
+    expect(filter.wineName.test('Magari Riserva')).toBe(false);
+    expect(existing.hints).toEqual({ country: 'Italy' });
+    expect(existing.save).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not overwrite hints the request already has', async () => {
+    const existing = { _id: 'req-2', hints: { country: 'Spain' }, save: jest.fn() };
+    WineRequest.findOne.mockResolvedValue(existing);
+    await findOrCreatePendingRequest({ userId: UID, wineName: 'X', producer: 'Y', hints: { country: 'France' } });
+    expect(existing.hints).toEqual({ country: 'Spain' });
+    expect(existing.save).not.toHaveBeenCalled();
+  });
+
+  test('a producer-less row matches a producer-less request, not a producer\'s', async () => {
+    await findOrCreatePendingRequest({ userId: UID, wineName: 'Hereford Tempranillo', producer: '' });
+    expect(WineRequest.findOne.mock.calls[0][0].producer).toEqual({ $in: [null, ''] });
+  });
+
+  test('regex metacharacters in a name are matched literally', async () => {
+    await findOrCreatePendingRequest({ userId: UID, wineName: 'Cuvée (Spéciale) + Réserve [1er]', producer: 'P.' });
+    const f = WineRequest.findOne.mock.calls[0][0];
+    expect(f.wineName.test('Cuvée (Spéciale) + Réserve [1er]')).toBe(true);
+    expect(f.wineName.test('Cuvée Spéciale + Réserve 1er')).toBe(false);
+    expect(f.producer.test('P.')).toBe(true);
+    expect(f.producer.test('Px')).toBe(false);
+  });
+
+  test('the per-run cache short-circuits the second row of the same wine', async () => {
+    const cache = new Map();
+    const a = await findOrCreatePendingRequest({ userId: UID, wineName: 'X', producer: 'Y', cache });
+    const b = await findOrCreatePendingRequest({ userId: UID, wineName: 'x', producer: 'y', cache });
+    expect(b.wineRequest).toBe(a.wineRequest);
+    expect(b.reused).toBe(true);
+    expect(WineRequest.findOne).toHaveBeenCalledTimes(1);
+  });
+});
+
+test('hasHints', () => {
+  expect(hasHints({ hints: { country: 'Italy' } })).toBe(true);
+  expect(hasHints({ hints: {} })).toBe(false);
+  expect(hasHints({})).toBe(false);
+});

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1460,6 +1460,7 @@
       "statusAll": "All",
       "typeGrapeSuggestion": "Grape suggestion",
       "suggestedGrapes": "Suggested varieties",
+      "fromFile": "From the import file",
       "applyGrapesNote": "Select the grape varieties to add to this wine. Unrecognised names can be added to the taxonomy first.",
       "applyGrapesLabel": "Grapes to add",
       "linkSearchLabel": "Search Wine Registry",

--- a/frontend/src/pages/AdminRequests.js
+++ b/frontend/src/pages/AdminRequests.js
@@ -205,6 +205,38 @@ function AdminRequests() {
     setLinkSearch('');
     setLinkResults([]);
     setAiLookup({ loading: false, error: null });
+    selectedIdRef.current = request._id;
+    prefillFromHints(request);
+  };
+
+  // What the import FILE said about the wine (request.hints — country,
+  // region, appellation, type) pre-fills the create form the same way an AI
+  // lookup does, so the curator starts from the file's geography instead of
+  // re-deriving it (support ticket 2026-09-05). Bails if another request was
+  // selected while the region list was loading (selectedIdRef is the page's
+  // existing "which request is open" ref).
+  const prefillFromHints = async (request) => {
+    const hints = request.hints;
+    if (!hints || !(hints.country || hints.region || hints.appellation || hints.type)) return;
+    const patch = {};
+    if (hints.type && WINE_TYPES.includes(hints.type)) patch.type = hints.type;
+    if (hints.appellation) patch.appellation = hints.appellation;
+    const country = hints.country ? countries.find(c => c.name.toLowerCase() === hints.country.toLowerCase()) : null;
+    if (country) patch.country = country._id;
+    setResolveData(prev => ({ ...prev, wineData: { ...prev.wineData, ...patch } }));
+    if (!country) return;
+    try {
+      const regRes = await adminGetRegions(apiFetch, country._id);
+      const regData = await regRes.json();
+      if (selectedIdRef.current !== request._id) return;
+      if (regRes.ok) {
+        setRegions(regData.regions);
+        const region = hints.region ? regData.regions.find(r => r.name.toLowerCase() === hints.region.toLowerCase()) : null;
+        if (region) setResolveData(prev => ({ ...prev, wineData: { ...prev.wineData, region: region._id } }));
+      }
+    } catch {
+      // A failed region load only costs the prefill; the curator picks by hand.
+    }
   };
 
   const handleAiLookup = async () => {
@@ -446,6 +478,12 @@ function AdminRequests() {
                     <a href={safeUrl(selected.sourceUrl) || undefined} target="_blank" rel="noopener noreferrer">
                       {selected.sourceUrl}
                     </a>
+                  </p>
+                )}
+                {selected.hints && (selected.hints.country || selected.hints.region || selected.hints.appellation || selected.hints.type) && (
+                  <p>
+                    <strong>{t('admin.requests.fromFile', 'From the import file')}:</strong>{' '}
+                    {[selected.hints.country, selected.hints.region, selected.hints.appellation, selected.hints.type].filter(Boolean).join(' · ')}
                   </p>
                 )}
                 {displayableImage(selected.image) && (


### PR DESCRIPTION
Support ticket 2026-09-05 (the CellarTracker import that minted 243 pending wine requests).

**Reuse.** `services/wineRequestIntake.findOrCreatePendingRequest` is now the one place both import paths (`routes/import.js`, `services/cellarImport.js`) mint a request. It looks for the user's existing **pending** request for the same wine and producer (case-insensitive, exact after trimming; a producer-less row matches a producer-less request) before creating one, so a re-import no longer doubles the admin queue.

**Hints.** The file's country, region, appellation and type travel with the request as `WineRequest.hints` (plain capped strings; an older request without hints learns them from the next file). Nothing is written to the registry from hints — the admin page pre-fills the create form from them the way the AI lookup does and shows *From the import file: …* on the request.

**Tests.** `wineRequestIntake.test.js` (7 cases incl. regex-literal matching and the per-run cache); the three import suites that reach the request branch stub the reuse lookup; `AdminRequests` page suite green. English strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)