### PR TITLE
feat(analytics): table moves to the Dashboard page; text "=" is case-insensitive

### DIFF
--- a/backend/src/mcp/analyticsTools.test.js
+++ b/backend/src/mcp/analyticsTools.test.js
@@ -9,7 +9,7 @@
 
 jest.mock('../services/analytics/fieldCatalogue', () => ({
   composeCatalogue: jest.fn(),
-  opsForType: jest.fn(() => ['eq', 'neq', 'contains']),
+  opsForType: jest.fn(() => ['contains', 'eq', 'neq']),
 }));
 jest.mock('../services/analytics/queryEngine', () => {
   class QueryError extends Error {
@@ -49,7 +49,7 @@ test('list_analytics_fields returns the composed catalogue in compact form', asy
   const { data } = parse(res);
   expect(composeCatalogue).toHaveBeenCalledWith(ME);
   expect(data).toHaveLength(2);
-  expect(data[0]).toMatchObject({ key: 'wine.producer', ops: ['eq', 'neq', 'contains'], sortable: true });
+  expect(data[0]).toMatchObject({ key: 'wine.producer', ops: ['contains', 'eq', 'neq'], sortable: true });
   expect(data[1]).toMatchObject({ key: 'personal.' + 'd'.repeat(24), unit: '%', aggregations: ['avg'], groupable: false });
 });
 

--- a/backend/src/scripts/seed-blog-analytics-beta.js
+++ b/backend/src/scripts/seed-blog-analytics-beta.js
@@ -47,7 +47,7 @@ const CONTENT = `
 
 <p>Every cellar tool answers the questions its developers thought of. <em>How many bottles? What's the split by type?</em> Useful — but your questions are more specific than ours. <em>Which of my Burgundies are ready and cost over 500 kr? Where is my money sitting, by region? What did I actually drink last year, and how did I rate it?</em></p>
 
-<p>The new <strong>analytics view</strong> answers those. Open any cellar and look at the view switcher above your bottles — next to list and card view there's now a third, table-shaped icon. Click it and your cellar becomes something you can interrogate:</p>
+<p>The new <strong>analytics view</strong> answers those. Open the <strong>Dashboard</strong> page from the main menu and switch to the <strong>Table</strong> tab (every cellar page has a shortcut to it next to the list and card switcher), and your cellar becomes something you can interrogate:</p>
 
 <ul>
 <li><strong>Choose your columns</strong> — from wine identity and purchase details to drink windows, consumption history, and <em>your own custom fields</em>. If you've defined an ABV field or a "bought at" note as personal data, it's a column now, and you can filter and sort on it.</li>

--- a/backend/src/services/analytics/fieldCatalogue.js
+++ b/backend/src/services/analytics/fieldCatalogue.js
@@ -39,9 +39,12 @@ const PersonalDataKey = require('../../models/PersonalDataKey');
 const RegistryDataKey = require('../../models/RegistryDataKey');
 
 // Filter operators per type — the whitelist the engine enforces. 'between'
-// is compiled as gte+lte; 'in' takes an array of enum options.
+// is compiled as gte+lte; 'in' takes an array of enum options. The FIRST op
+// is what the filter builder preselects, so text leads with 'contains': a
+// typed producer filter should find "Gaja" by "gaj", not demand the exact
+// name (support ticket 2026-09-05).
 const OPS_BY_TYPE = {
-  text: ['eq', 'neq', 'contains'],
+  text: ['contains', 'eq', 'neq'],
   integer: ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'between'],
   decimal: ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'between'],
   boolean: ['eq'],

--- a/backend/src/services/analytics/queryEngine.js
+++ b/backend/src/services/analytics/queryEngine.js
@@ -189,6 +189,15 @@ function predicate(field, op, value, castOne) {
   if (field.type === 'date' && (field.source === 'bottle' || field.source === 'wine')) {
     return datePredicate(field, op, value, castOne);
   }
+  // Text equality is case-insensitive and anchored — "gaja" must find "Gaja"
+  // exactly as the taxonomy path already does (support ticket 2026-09-05: a
+  // typed Producer "=" filter looked broken because it was byte-exact).
+  // Only 'text' takes this path: enum values are whitelisted already, and
+  // numbers, dates and booleans compare as before.
+  if (field.type === 'text' && (op === 'eq' || op === 'neq')) {
+    const rx = { $regex: `^${escapeRegex(castOne(value))}$`, $options: 'i' };
+    return op === 'eq' ? rx : { $not: rx };
+  }
   switch (op) {
     case 'eq': return castOne(value);
     case 'neq': return { $ne: castOne(value) };
@@ -246,10 +255,13 @@ async function taxonomyIds(field, op, value) {
  * semantics exactly; a mismatch between the two is a bug the KV filter tests
  * exist to catch.
  */
+// Mirrors predicate(): text compares case-insensitively, everything else strictly.
+const looseEq = (a, b) => (typeof a === 'string' && typeof b === 'string' ? a.toLowerCase() === b.toLowerCase() : a === b);
+
 function evalKvPredicate(op, castValue, entryValue) {
   switch (op) {
-    case 'eq': return entryValue === castValue;
-    case 'neq': return entryValue !== castValue;
+    case 'eq': return looseEq(entryValue, castValue);
+    case 'neq': return !looseEq(entryValue, castValue);
     case 'gt': return entryValue > castValue;
     case 'gte': return entryValue >= castValue;
     case 'lt': return entryValue < castValue;

--- a/backend/src/services/analytics/queryEngine.test.js
+++ b/backend/src/services/analytics/queryEngine.test.js
@@ -197,6 +197,31 @@ describe('filter compilation is a whitelist, not an interpreter', () => {
     expect(post[0]['wd.producer']).toBeDefined();
     expect(needsWine).toBe(true);
   });
+  // Support ticket 2026-09-05: a typed Producer "=" filter was byte-exact, so
+  // "gaja" found nothing and the table looked broken.
+  test('text "=" is case-insensitive and anchored', async () => {
+    const { post } = await compileFilters([{ field: 'wine.producer', op: 'eq', value: 'gaja' }], USER);
+    expect(post[0]['wd.producer']).toEqual({ $regex: '^gaja$', $options: 'i' });
+    const rx = new RegExp(post[0]['wd.producer'].$regex, post[0]['wd.producer'].$options);
+    expect(rx.test('Gaja')).toBe(true);
+    expect(rx.test("Ca'Marcanda (Gaja)")).toBe(false);
+  });
+  test('text "≠" negates the same case-insensitive match', async () => {
+    const { post } = await compileFilters([{ field: 'wine.producer', op: 'neq', value: 'Gaja' }], USER);
+    expect(post[0]['wd.producer']).toEqual({ $not: { $regex: '^Gaja$', $options: 'i' } });
+  });
+  test('text "=" still escapes regex metacharacters', async () => {
+    const { post } = await compileFilters([{ field: 'wine.producer', op: 'eq', value: 'a.b' }], USER);
+    // '^a\.b$' — spelled without a backslash literal so the intent survives any tooling.
+    expect(post[0]['wd.producer'].$regex).toBe(['^a', '.b$'].join(String.fromCharCode(92)));
+  });
+  test('numbers keep strict equality', async () => {
+    const { pre } = await compileFilters([{ field: 'purchase.price', op: 'eq', value: 100 }], USER);
+    expect(pre).toEqual([{ price: 100 }]);
+  });
+  test('text fields offer "contains" first, so the filter builder defaults to it', () => {
+    expect(require('./fieldCatalogue').OPS_BY_TYPE.text[0]).toBe('contains');
+  });
 });
 
 // ── KV filters resolve entries first ───────────────────────────────────────

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4514,7 +4514,6 @@
     }
   },
   "analytics": {
-    "tableView": "Table view",
     "columns": "Columns",
     "exportCsv": "Export CSV",
     "exporting": "Exporting…",
@@ -4590,7 +4589,13 @@
     "beta": "Beta",
     "betaHint": "Analytics is new and still settling in. If a number looks wrong or something misbehaves, please tell us via Support — it helps more than you would think.",
     "dashboardTitle": "Dashboard",
-    "dashboardHint": "Widgets come from the analytics table: open a cellar, switch to the table view, group something interesting, and press \"Add to dashboard\".",
+    "tabs": {
+      "boards": "Boards",
+      "table": "Table"
+    },
+    "tabsAria": "Analytics sections",
+    "openTable": "Open the analytics table",
+    "dashboardHint": "Widgets come from the Table tab: group something interesting there and press \"Add to dashboard\".",
     "addToDashboard": "Add to dashboard",
     "widgetTitlePrompt": "Name this dashboard widget:",
     "removeWidget": "Remove widget",
@@ -4614,7 +4619,7 @@
     "deleteDashboardConfirm": "Delete the dashboard \"{{name}}\"? Its widgets are gone for good.",
     "defaultBoardName": "My cellar",
     "defaultBoard": "default",
-    "emptyBoard": "This dashboard is empty — pin views to it from the analytics table.",
+    "emptyBoard": "This dashboard is empty — pin views to it from the Table tab.",
     "andMore": "…and {{n}} more",
     "chartMeasure": "Chart shows:",
     "summarize": "Summarize",

--- a/frontend/src/pages/AnalyticsDashboard.css
+++ b/frontend/src/pages/AnalyticsDashboard.css
@@ -89,3 +89,25 @@
   font-weight: 600;
   max-width: 60vw;
 }
+
+
+/* Tabs: Boards (the pages you just look at) | Table (where views are built,
+   since the table moved here from the cellar page). */
+.ad-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--color-border);
+}
+.ad-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  padding: 8px 14px;
+  font: inherit;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+.ad-tab:hover { color: var(--color-text); }
+.ad-tab.active { color: var(--color-primary); border-bottom-color: var(--color-primary); }

--- a/frontend/src/pages/AnalyticsDashboard.js
+++ b/frontend/src/pages/AnalyticsDashboard.js
@@ -1,5 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { lazy } from '../utils/lazyWithReload';
 import { useAuth } from '../contexts/AuthContext';
 import { listDashboards, createDashboard, updateDashboard, deleteDashboard, runAnalyticsQuery } from '../api/analytics';
 import AnalyticsCharts from '../components/AnalyticsCharts';
@@ -8,6 +10,12 @@ import { humanMeasureLabel } from '../utils/analyticsLabels';
 // stay visually one feature.
 import '../components/AnalyticsTable.css';
 import './AnalyticsDashboard.css';
+
+// The analytics table lives here since it moved off the cellar page (support
+// ticket 2026-09-05: the cellar page's search bar and filters sat above a
+// table they did not filter). Lazy — it ships its own catalogue fetch, query
+// client and CSV assembly, none of which the boards pay for.
+const AnalyticsTable = lazy(() => import('../components/AnalyticsTable'));
 
 /**
  * The analytics dashboards (#987) — cube.dev-style "pages you just look at",
@@ -189,6 +197,17 @@ function Widget({ widget, onRemove }) {
 export default function AnalyticsDashboard() {
   const { t } = useTranslation();
   const { apiFetch } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+  // ?view=table opens the Table tab; ?cellar=<id> preselects that cellar's
+  // scope — the link on a cellar page passes both.
+  const tab = searchParams.get('view') === 'table' ? 'table' : 'boards';
+  const cellarParam = /^[a-f0-9]{24}$/i.test(searchParams.get('cellar') || '') ? searchParams.get('cellar') : null;
+  const showTab = (next) => {
+    const sp = new URLSearchParams(searchParams);
+    if (next === 'table') sp.set('view', 'table');
+    else { sp.delete('view'); sp.delete('cellar'); }
+    setSearchParams(sp, { replace: true });
+  };
   const [boards, setBoards] = useState(null);   // null = loading; [] = none saved
   const [activeId, setActiveId] = useState(null); // null = the client-side default
   const [saveState, setSaveState] = useState(null);
@@ -273,6 +292,20 @@ export default function AnalyticsDashboard() {
 
   return (
     <div className="analytics-dashboard">
+      <div className="ad-tabs" role="tablist" aria-label={t('analytics.tabsAria', 'Analytics sections')}>
+        <button type="button" role="tab" className={`ad-tab${tab === 'boards' ? ' active' : ''}`} aria-selected={tab === 'boards'} onClick={() => showTab('boards')}>
+          {t('analytics.tabs.boards', 'Boards')}
+        </button>
+        <button type="button" role="tab" className={`ad-tab${tab === 'table' ? ' active' : ''}`} aria-selected={tab === 'table'} onClick={() => showTab('table')}>
+          {t('analytics.tabs.table', 'Table')}
+        </button>
+      </div>
+      {tab === 'table' ? (
+        <Suspense fallback={<div className="ad-empty">{t('analytics.loading', 'Loading…')}</div>}>
+          <AnalyticsTable cellarId={cellarParam} />
+        </Suspense>
+      ) : (
+      <>
       <div className="ad-head">
         <h1>
           {boards && boards.length > 0 ? (
@@ -300,7 +333,7 @@ export default function AnalyticsDashboard() {
         </div>
       </div>
       <p className="ad-hint">
-        {t('analytics.dashboardHint', 'Widgets come from the analytics table: open a cellar, switch to the table view, group something interesting, and press "Add to dashboard".')}
+        {t('analytics.dashboardHint', 'Widgets come from the Table tab: group something interesting there and press "Add to dashboard".')}
       </p>
       <div className="ad-grid">
         {boards === null && <div className="ad-empty">{t('analytics.loading', 'Loading…')}</div>}
@@ -308,9 +341,11 @@ export default function AnalyticsDashboard() {
           <Widget key={`${w.title}-${i}`} widget={w} onRemove={() => removeWidget(i)} />
         ))}
         {boards !== null && active && !widgets.length && (
-          <div className="ad-empty">{t('analytics.emptyBoard', 'This dashboard is empty — pin views to it from the analytics table.')}</div>
+          <div className="ad-empty">{t('analytics.emptyBoard', 'This dashboard is empty — pin views to it from the Table tab.')}</div>
         )}
       </div>
+      </>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/AnalyticsDashboard.test.js
+++ b/frontend/src/pages/AnalyticsDashboard.test.js
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AnalyticsDashboard from './AnalyticsDashboard';
+
+// The analytics table moved here from the cellar page (support ticket
+// 2026-09-05). These tests pin the tab contract: ?view=table opens the Table
+// tab, ?cellar=<id> preselects that cellar's scope, and the boards stay the
+// default so the nav link still lands on the pages people just look at.
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key, fb) => (typeof fb === 'string' ? fb : key) }),
+}));
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ apiFetch: vi.fn() }) }));
+vi.mock('../components/AnalyticsCharts', () => ({ default: () => null }));
+vi.mock('../components/AnalyticsTable', () => ({
+  default: ({ cellarId }) => <div data-testid="analytics-table">scope:{cellarId || 'all'}</div>,
+}));
+
+const jsonRes = (body, ok = true) => ({ ok, status: ok ? 200 : 500, json: () => Promise.resolve(body) });
+vi.mock('../api/analytics', () => ({
+  listDashboards: vi.fn(async () => jsonRes({ dashboards: [] })),
+  createDashboard: vi.fn(), updateDashboard: vi.fn(), deleteDashboard: vi.fn(),
+  runAnalyticsQuery: vi.fn(async () => jsonRes({ mode: 'grouped', buckets: [], measureLabels: [], scope: { bottles: 'active' } })),
+}));
+
+const CELLAR = 'a'.repeat(24);
+const renderAt = (url) => render(
+  <MemoryRouter initialEntries={[url]}><AnalyticsDashboard /></MemoryRouter>
+);
+
+test('opens on the Boards tab with the default widgets', async () => {
+  renderAt('/dashboard');
+  expect(screen.getByRole('tab', { name: 'Boards' })).toHaveAttribute('aria-selected', 'true');
+  expect(await screen.findByText('My cellar')).toBeInTheDocument();
+  expect(screen.queryByTestId('analytics-table')).toBeNull();
+});
+
+test('?view=table&cellar=<id> opens the table with that cellar preselected', async () => {
+  renderAt(`/dashboard?view=table&cellar=${CELLAR}`);
+  expect(screen.getByRole('tab', { name: 'Table' })).toHaveAttribute('aria-selected', 'true');
+  expect(await screen.findByTestId('analytics-table')).toHaveTextContent(`scope:${CELLAR}`);
+  expect(screen.queryByText('My cellar')).toBeNull();
+});
+
+test('a malformed cellar parameter is dropped rather than sent as a scope', async () => {
+  renderAt('/dashboard?view=table&cellar=%3Cscript%3E');
+  expect(await screen.findByTestId('analytics-table')).toHaveTextContent('scope:all');
+});
+
+test('the tabs switch both ways', async () => {
+  renderAt(`/dashboard?view=table&cellar=${CELLAR}`);
+  await screen.findByTestId('analytics-table');
+  fireEvent.click(screen.getByRole('tab', { name: 'Boards' }));
+  expect(await screen.findByText('My cellar')).toBeInTheDocument();
+  expect(screen.queryByTestId('analytics-table')).toBeNull();
+  fireEvent.click(screen.getByRole('tab', { name: 'Table' }));
+  // Leaving the table forgot the cellar: the table now opens on all cellars.
+  expect(await screen.findByTestId('analytics-table')).toHaveTextContent('scope:all');
+});

--- a/frontend/src/pages/CellarDetail.css
+++ b/frontend/src/pages/CellarDetail.css
@@ -594,6 +594,13 @@
   background: var(--color-primary-light);
 }
 
+/* The analytics-table shortcut is a link to the Dashboard page, styled as a
+   toggle; a small gutter keeps it from reading as a third view mode. */
+.view-toggle-link {
+  text-decoration: none;
+  margin-left: 0.4rem;
+}
+
 /* Density toggle sits just left of the list/card control (list view only),
    separated by a small gutter so it doesn't read as part of that segmented pair. */
 .density-toggle-btn {

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -12,11 +12,8 @@ import CellarScopePicker from '../components/CellarScopePicker';
 import ClimateCard from '../components/ClimateCard';
 import CellarNav from '../components/CellarNav';
 import CellarPageHeader from '../components/CellarPageHeader';
+import { readBottleViewMode, storeBottleViewMode } from '../utils/bottleViewMode';
 import './CellarDetail.css';
-
-// The analytics table (#987) loads lazily — it ships its own catalogue fetch,
-// query engine client and CSV assembly, none of which the list/card views pay for.
-const AnalyticsTable = lazy(() => import('../components/AnalyticsTable'));
 
 // Stable empty rack map for the cross-cellar view (rack placement is per-cellar,
 // so it doesn't apply when several cellars are combined).
@@ -763,9 +760,7 @@ function CellarDetail() {
 // one; `onSelectModeChange` tells the parent to hide the FAB meanwhile.
 function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadMore, multi = false, rackKnown = false, canBulkMove = false, onBulkDone, onSelectModeChange }) {
   const { t } = useTranslation();
-  const [viewMode, setViewMode] = useState(() => {
-    try { return localStorage.getItem('cellarion_bottle_view') || 'list'; } catch { return 'list'; }
-  });
+  const [viewMode, setViewMode] = useState(readBottleViewMode);
   const [density, setDensity] = useState(() => {
     try { return localStorage.getItem('cellarion_bottle_density') || 'comfortable'; } catch { return 'comfortable'; }
   });
@@ -807,12 +802,12 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
   useEffect(() => {
     if (!canBulkMove) { setSelectMode(false); setSelectedIds(new Set()); }
   }, [canBulkMove, cellarId]);
-  const selectableNow = selectMode && canBulkMove && viewMode !== 'table';
+  const selectableNow = selectMode && canBulkMove;
   useEffect(() => { onSelectModeChange?.(selectableNow); }, [selectableNow, onSelectModeChange]);
 
   const setView = (mode) => {
     setViewMode(mode);
-    try { localStorage.setItem('cellarion_bottle_view', mode); } catch {}
+    storeBottleViewMode(mode);
   };
 
   const setDens = (mode) => {
@@ -843,7 +838,7 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
   return (
     <>
       <div className="bottles-view-toggle">
-        {canBulkMove && viewMode !== 'table' && (
+        {canBulkMove && (
           <button
             type="button"
             className={`view-toggle-btn select-toggle-btn ${selectMode ? 'active' : ''}`}
@@ -893,15 +888,18 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
         </button>
-        <button
-          className={`view-toggle-btn ${viewMode === 'table' ? 'active' : ''}`}
-          onClick={() => setView('table')}
-          aria-label={t('analytics.tableView', 'Table view')}
-          aria-pressed={viewMode === 'table'}
-          title={t('analytics.tableView', 'Table view')}
+        {/* The analytics table lives on the Dashboard page since support
+            ticket 2026-09-05 (this page's search bar and filters sat above a
+            table they did not filter); the shortcut keeps the old path alive
+            with this cellar's scope preselected. */}
+        <Link
+          to={multi ? '/dashboard?view=table' : `/dashboard?view=table&cellar=${cellarId}`}
+          className="view-toggle-btn view-toggle-link"
+          aria-label={t('analytics.openTable', 'Open the analytics table')}
+          title={t('analytics.openTable', 'Open the analytics table')}
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="1"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
-        </button>
+        </Link>
       </div>
 
       {selectableNow && (
@@ -939,12 +937,6 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
         </div>
       )}
 
-      {viewMode === 'table' ? (
-        <Suspense fallback={<div className="load-more-wrap">{t('common.loading')}</div>}>
-          <AnalyticsTable cellarId={multi ? null : cellarId} />
-        </Suspense>
-      ) : (
-      <>
       <div className={viewMode === 'list' ? 'bottles-list' : 'bottles-grid'}>
         {bottles.map(item => {
           // Cross-cellar view: flat bottles, each linked to + badged with its cellar.
@@ -1023,8 +1015,6 @@ function BottlesList({ bottles, rackMap, cellarId, hasMore, loadingMore, onLoadM
             {loadingMore ? t('common.loading') : t('cellarDetail.loadMore')}
           </button>
         </div>
-      )}
-      </>
       )}
 
       <Suspense fallback={null}>

--- a/frontend/src/utils/bottleViewMode.js
+++ b/frontend/src/utils/bottleViewMode.js
@@ -1,0 +1,24 @@
+// The bottle list remembers list vs card per browser. 'table' was a third
+// mode until the analytics table moved to the Dashboard page (support ticket
+// 2026-09-05: the cellar page's own search bar and filters sat above a table
+// they did not filter). A stored 'table' now falls back to the list, so
+// nobody opens a cellar into a mode that no longer exists there.
+export const VIEW_MODES = ['list', 'card'];
+export const VIEW_MODE_KEY = 'cellarion_bottle_view';
+
+export function readBottleViewMode(storage = globalThis.localStorage) {
+  try {
+    const v = storage ? storage.getItem(VIEW_MODE_KEY) : null;
+    return VIEW_MODES.includes(v) ? v : 'list';
+  } catch {
+    return 'list';
+  }
+}
+
+export function storeBottleViewMode(mode, storage = globalThis.localStorage) {
+  try {
+    if (storage) storage.setItem(VIEW_MODE_KEY, mode);
+  } catch {
+    // Private mode / quota — the preference just does not persist.
+  }
+}

--- a/frontend/src/utils/bottleViewMode.test.js
+++ b/frontend/src/utils/bottleViewMode.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { readBottleViewMode, storeBottleViewMode, VIEW_MODE_KEY } from './bottleViewMode';
+
+const storageWith = (value) => ({
+  getItem: (k) => (k === VIEW_MODE_KEY ? value : null),
+  setItem() {},
+});
+
+describe('readBottleViewMode', () => {
+  it('returns the stored list/card preference', () => {
+    expect(readBottleViewMode(storageWith('card'))).toBe('card');
+    expect(readBottleViewMode(storageWith('list'))).toBe('list');
+  });
+
+  it("falls back to the list for the retired 'table' mode", () => {
+    // The analytics table moved to the Dashboard page; a browser that last
+    // used it must not open a cellar into a mode that is no longer there.
+    expect(readBottleViewMode(storageWith('table'))).toBe('list');
+  });
+
+  it('falls back to the list for garbage, nothing stored, or no storage', () => {
+    expect(readBottleViewMode(storageWith('grid'))).toBe('list');
+    expect(readBottleViewMode(storageWith(null))).toBe('list');
+    expect(readBottleViewMode(null)).toBe('list');
+    expect(readBottleViewMode({ getItem() { throw new Error('denied'); } })).toBe('list');
+  });
+});
+
+describe('storeBottleViewMode', () => {
+  it('writes under the shared key and swallows storage errors', () => {
+    const writes = [];
+    storeBottleViewMode('card', { setItem: (k, v) => writes.push([k, v]) });
+    expect(writes).toEqual([[VIEW_MODE_KEY, 'card']]);
+    expect(() => storeBottleViewMode('card', { setItem() { throw new Error('quota'); } })).not.toThrow();
+    expect(() => storeBottleViewMode('card', null)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Why

Support ticket "Table view question" (2026-09-05). Two real defects behind the confusion:

1. The analytics table was a third view mode on the cellar page, mounted **under the page's search box, filter button and sort, none of which applied to it**. The table only ever received the cellar id and ran its own filter builder.
2. In that builder, text fields defaulted to `=`, and `=` on a plain text field (Producer, Wine name) was a byte-exact match, so `gaja` found nothing while `Gaja` worked. `contains` was already case-insensitive and so was `=` on taxonomy fields, so the table was inconsistent with itself.

## What changes

**Dashboard page gets two tabs: Boards and Table.** The table keeps its own scope pill. `?view=table` opens the Table tab; `?cellar=<id>` (validated as an ObjectId) preselects that cellar's scope. Leaving the tab drops the cellar param.

**Cellar page:** the table toggle becomes a shortcut link to `/dashboard?view=table&cellar=<id>` (no cellar param in the cross-cellar view), styled as before with a small gutter so it no longer reads as a view mode. `list`/`card` persistence moves into `utils/bottleViewMode.js`; a stored `table` preference falls back to `list`. The bulk-select guards that special-cased the table mode are gone.

**Engine:** for `type: 'text'` fields, `eq` compiles to `{ $regex: '^<escaped>$', $options: 'i' }` and `neq` to `{ $not: … }`; enum, number, date and boolean comparisons are unchanged. The JS-side personal-key predicate mirrors it (case-insensitive for strings, strict otherwise). `OPS_BY_TYPE.text` becomes `['contains', 'eq', 'neq']`, so the builder preselects `contains`.

**Copy:** dashboard hint and empty-board text point at the Table tab; the beta blog seed script describes the new location (the published post was edited in the editor, so it needs the same sentence changed by hand rather than a re-seed). Orphaned `analytics.tableView` string removed (en only).

## Tests

- Backend: `queryEngine.test.js` +5 (case-insensitive anchored `=`, `≠` negation, metacharacters still escaped, numbers strict, `contains` first); MCP catalogue test mirrors the new order. 65 + 6 pass in node:24-alpine.
- Frontend: new `AnalyticsDashboard.test.js` (default Boards tab, `?view=table&cellar=` preselect, malformed cellar dropped, tabs switch both ways) and `bottleViewMode.test.js`. Full run: 91 files, 1208 tests pass.
- Docker smoke on the local stack: catalogue reports `["contains","eq","neq"]`; `=` on a producer matches lowercased and uppercased input, a partial name does not, `≠` excludes it; `/dashboard` serves the new bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
