### PR TITLE
fix(security): audit 2026-09 medium remediation, batch 1

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -99,8 +99,17 @@ const app = express();
 //     so req.ip resolves to the Cloudflare edge IP and getClientIp() can trust
 //     CF-Connecting-IP. Without it, req.ip collapses to Traefik's internal IP and
 //     every per-IP limiter shares one bucket. See utils/clientIp.js.
-const trustProxyHops = Number(process.env.TRUST_PROXY_HOPS ?? 1);
-app.set('trust proxy', Number.isFinite(trustProxyHops) ? trustProxyHops : 1);
+// Audit 2026-09 D16-1: the shipped compose hands an EMPTY TRUST_PROXY_HOPS
+// through, and Number('') is 0 — so a default self-host ran `trust proxy 0`
+// and every per-IP limiter shared one bucket. Empty means unset; anything
+// that is not a whole non-negative number is refused loudly rather than
+// silently becoming 0 or 1.
+const rawHops = process.env.TRUST_PROXY_HOPS;
+const trustProxyHops = rawHops === undefined || String(rawHops).trim() === '' ? 1 : Number(rawHops);
+if (!Number.isInteger(trustProxyHops) || trustProxyHops < 0) {
+  throw new Error(`TRUST_PROXY_HOPS must be a whole number of proxy hops (got "${rawHops}")`);
+}
+app.set('trust proxy', trustProxyHops);
 
 // Security headers — explicit config for production SaaS
 app.use(helmet({

--- a/backend/src/routes/admin/import.js
+++ b/backend/src/routes/admin/import.js
@@ -228,11 +228,14 @@ async function getOrCreateAppellation(name, countryId, regionId, userId, cache) 
   // to their canonical (hyphenated) forms. Country/Region above keep
   // normalizeString: that IS their collections' convention.
   const normalized = normalizeAppellationKey(name);
+  // Audit 2026-09 D01-4: the CSV cell is user text feeding two indexes — same
+  // sanitiser and cap as the admin appellation routes (APPELLATION_NAME_MAX).
+  const cleanName = sanitizeTaxonomyName(name).slice(0, 200);
   const doc = await Appellation.findOneAndUpdate(
     { country: countryId, normalizedName: normalized },
     {
       $setOnInsert: {
-        name: name.trim(),
+        name: cleanName,
         normalizedName: normalized,
         country: countryId,
         region: regionId || null,

--- a/backend/src/routes/admin/taxonomy.js
+++ b/backend/src/routes/admin/taxonomy.js
@@ -156,7 +156,8 @@ router.post('/countries', async (req, res) => {
     const normalizedName = normalizeString(name);
 
     const country = new Country({
-      name: name.trim(),
+      // Audit 2026-09 D01-1: same cap + control-character strip as Region/Grape.
+      name: sanitizeTaxonomyName(name),
       code: code?.trim().toUpperCase(),
       normalizedName,
       description: description || '',
@@ -190,7 +191,7 @@ router.put('/countries/:id', async (req, res) => {
     }
 
     if (name) {
-      country.name = name.trim();
+      country.name = sanitizeTaxonomyName(name);
       country.normalizedName = normalizeString(name);
     }
     if (code !== undefined) {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -271,7 +271,15 @@ router.post('/login', authLimiter, async (req, res) => {
     }
 
     if (!user) {
-      logAudit(req, 'auth.login.failed', {}, { identifier: username });
+      // Audit 2026-09 D04-4: the typed identifier is attacker-chosen text and
+      // often a real e-mail from a breach list; every admin can read the audit
+      // log. Keep what forensics needs — shape + a short hash to correlate
+      // repeats — never the raw string.
+      const typed = String(username || '').trim().toLowerCase().slice(0, 254);
+      logAudit(req, 'auth.login.failed', {}, {
+        identifierType: typed.includes('@') ? 'email' : 'username',
+        identifierHash: crypto.createHash('sha256').update(typed).digest('hex').slice(0, 16),
+      });
       return res.status(401).json({ error: 'Invalid credentials' });
     }
 

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -1536,6 +1536,10 @@ router.delete('/:id', async (req, res) => {
 // requireNonDemo: inviting a member sends an email to an arbitrary address — an
 // outbound-email/PII spam vector a throwaway demo must not have. A demo user can
 // explore a populated cellar but can't invite others to it.
+// Audit 2026-09 D11-1: invitations per account per rolling 24 h. A household
+// shares a handful of cellars with a handful of people; twenty is generous.
+const INVITES_PER_DAY = 20;
+
 router.post('/:id/members', requireNonDemo, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
@@ -1552,7 +1556,13 @@ router.post('/:id/members', requireNonDemo, async (req, res) => {
     const cellar = await Cellar.findOne({ _id: req.params.id, user: req.user.id, deletedAt: null });
     if (!cellar) return res.status(404).json({ error: 'Cellar not found' });
 
-    const normalizedEmail = email.toLowerCase().trim();
+    const normalizedEmail = String(email).toLowerCase().trim();
+    // Audit 2026-09 D11-1: the invite path relays attacker-chosen text (the
+    // cellar name) to any mailbox. Only real addresses, and no more than
+    // INVITES_PER_DAY invitations per account per rolling day.
+    if (normalizedEmail.length > 254 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+      return res.status(400).json({ error: 'A valid email address is required' });
+    }
 
     // Look up user by email
     const userToAdd = await User.findOne({ email: normalizedEmail });
@@ -1569,6 +1579,12 @@ router.post('/:id/members', requireNonDemo, async (req, res) => {
         return res.status(400).json({ error: 'An invitation has already been sent to this email' });
       }
 
+      const sentToday = await PendingShare.countDocuments({ invitedBy: req.user.id, createdAt: { $gte: new Date(Date.now() - 24 * 3600e3) } });
+      if (sentToday >= INVITES_PER_DAY) {
+        logAudit(req, 'system.rate_limit_exceeded', { type: 'cellar', id: cellar._id }, { limiter: 'cellarInvites', limit: INVITES_PER_DAY });
+        return res.status(429).json({ error: 'Too many invitations sent today. Please try again tomorrow.' });
+      }
+
       const sharingUser = await User.findById(req.user.id).select('username email').lean();
 
       await PendingShare.create({
@@ -1582,7 +1598,7 @@ router.post('/:id/members', requireNonDemo, async (req, res) => {
         normalizedEmail,
         sharingUser?.username ?? 'A Cellarion user',
         sharingUser?.email ?? '',
-        cellar.name,
+        String(cellar.name || '').slice(0, 100),
         role
       ).catch(err => {
         console.error('Failed to send cellar invite email:', err.message);

--- a/backend/src/routes/follows.js
+++ b/backend/src/routes/follows.js
@@ -110,7 +110,7 @@ router.get('/:userId/followers', async (req, res) => {
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(limit)
-        .populate('follower', 'username displayName bio'),
+        .populate('follower', 'username displayName bio profileVisibility'),
       Follow.countDocuments({ following: req.params.userId })
     ]);
 
@@ -121,10 +121,16 @@ router.get('/:userId/followers', async (req, res) => {
     const myFollows = await Follow.find({ follower: req.user.id, following: { $in: userIds } }).select('following');
     const followingSet = new Set(myFollows.map(f => f.following.toString()));
 
-    const enriched = users.map(u => ({
-      ...u.toObject(),
-      isFollowing: followingSet.has(u._id.toString())
-    }));
+    // Audit 2026-09 O01-3: only a public profile shows its bio here; the
+    // visibility flag itself never leaves the server.
+    const enriched = users.map(u => {
+      const { profileVisibility, ...rest } = u.toObject();
+      return {
+        ...rest,
+        bio: profileVisibility === 'public' ? rest.bio : undefined,
+        isFollowing: followingSet.has(u._id.toString())
+      };
+    });
 
     res.json({ users: enriched, total, page, pages: Math.ceil(total / limit) });
   } catch (err) {
@@ -147,7 +153,7 @@ router.get('/:userId/following', async (req, res) => {
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(limit)
-        .populate('following', 'username displayName bio'),
+        .populate('following', 'username displayName bio profileVisibility'),
       Follow.countDocuments({ follower: req.params.userId })
     ]);
 
@@ -158,10 +164,16 @@ router.get('/:userId/following', async (req, res) => {
     const myFollows = await Follow.find({ follower: req.user.id, following: { $in: userIds } }).select('following');
     const followingSet = new Set(myFollows.map(f => f.following.toString()));
 
-    const enriched = users.map(u => ({
-      ...u.toObject(),
-      isFollowing: followingSet.has(u._id.toString())
-    }));
+    // Audit 2026-09 O01-3: only a public profile shows its bio here; the
+    // visibility flag itself never leaves the server.
+    const enriched = users.map(u => {
+      const { profileVisibility, ...rest } = u.toObject();
+      return {
+        ...rest,
+        bio: profileVisibility === 'public' ? rest.bio : undefined,
+        isFollowing: followingSet.has(u._id.toString())
+      };
+    });
 
     res.json({ users: enriched, total, page, pages: Math.ceil(total / limit) });
   } catch (err) {

--- a/backend/src/routes/follows.privateBio.test.js
+++ b/backend/src/routes/follows.privateBio.test.js
@@ -1,0 +1,77 @@
+/**
+ * Audit 2026-09 O01-3 — a private profile's bio leaked through a public
+ * user's follower / following lists. Only public profiles show a bio there,
+ * and the visibility flag itself never leaves the server.
+ */
+const express = require('express');
+const http = require('http');
+
+const ME = 'a'.repeat(24);
+const TARGET = 'b'.repeat(24);
+
+jest.mock('../middleware/auth', () => ({
+  requireAuth: (req, res, next) => { req.user = { id: 'a'.repeat(24), roles: ['user'] }; next(); },
+  requireNonDemo: (req, res, next) => next(),
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+jest.mock('../models/Notification', () => ({ create: jest.fn() }));
+jest.mock('../models/User', () => ({
+  findById: jest.fn(() => ({ select: async () => ({ _id: 'b'.repeat(24), profileVisibility: 'public' }) })),
+  updateOne: jest.fn(() => ({ catch: () => {} })),
+}));
+const mockFollowFind = jest.fn();
+jest.mock('../models/Follow', () => ({
+  find: (...a) => mockFollowFind(...a),
+  countDocuments: jest.fn(async () => 2),
+  deleteOne: jest.fn(),
+}));
+
+const router = require('./follows');
+
+// A populated user doc: the route reads `_id` off the document AND spreads toObject().
+const doc = (u) => ({ ...u, toObject: () => ({ ...u }) });
+const listChain = (rows) => ({ sort: () => ({ skip: () => ({ limit: () => ({ populate: async () => rows }) }) }) });
+
+let server;
+let base;
+beforeAll((done) => {
+  const app = express();
+  app.use('/api/follows', router);
+  server = http.createServer(app);
+  server.listen(0, () => { base = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  const rows = [
+    { follower: doc({ _id: 'c'.repeat(24), username: 'open', displayName: 'Open', bio: 'I collect Barolo', profileVisibility: 'public' }) },
+    { follower: doc({ _id: 'd'.repeat(24), username: 'quiet', displayName: 'Quiet', bio: 'private thoughts', profileVisibility: 'private' }) },
+  ];
+  mockFollowFind
+    .mockReturnValueOnce(listChain(rows))                     // the list
+    .mockReturnValueOnce({ select: async () => [] });          // "which do I follow"
+});
+
+test('a public profile keeps its bio, a private one does not, and the flag itself never leaves', async () => {
+  const res = await fetch(`${base}/api/follows/${TARGET}/followers`);
+  expect(res.status).toBe(200);
+  const { users } = await res.json();
+  expect(users).toHaveLength(2);
+  const open = users.find((u) => u.username === 'open');
+  const quiet = users.find((u) => u.username === 'quiet');
+  expect(open.bio).toBe('I collect Barolo');
+  expect(quiet).not.toHaveProperty('bio');
+  expect(open).not.toHaveProperty('profileVisibility');
+  expect(quiet).not.toHaveProperty('profileVisibility');
+  expect(open.isFollowing).toBe(false);
+});
+
+test('the populate asks for the visibility flag it needs to decide', async () => {
+  await fetch(`${base}/api/follows/${TARGET}/followers`);
+  // The chain is opaque to the assertion, so pin the contract through the
+  // route module's source instead: both lists must select profileVisibility.
+  const src = require('fs').readFileSync(require.resolve('./follows'), 'utf8');
+  expect(src).toContain("populate('follower', 'username displayName bio profileVisibility')");
+  expect(src).toContain("populate('following', 'username displayName bio profileVisibility')");
+});

--- a/backend/src/routes/images.bottleGallery.test.js
+++ b/backend/src/routes/images.bottleGallery.test.js
@@ -93,15 +93,16 @@ describe('the uploader branch', () => {
     expect(wineFilter).toEqual({ wineDefinition: WINE, status: 'approved', visibility: 'public' });
   });
 
-  test('a row the server returns comes through untouched (regression guard for the shape)', async () => {
+  test('a row the server returns keeps its public fields, gains `mine`, and loses reviewer/reporter identities (audit 2026-09 D05-1)', async () => {
     const live = { _id: oid('d'), processedUrl: '/api/uploads/processed/live.png', originalUrl: null, status: 'approved' };
+    const withIdentities = { ...live, uploadedBy: USER, reviewedBy: oid('e'), reviewedAt: new Date().toISOString(), reports: [{ by: oid('f') }], contentHash: 'h' };
     BottleImage.find
-      .mockReturnValueOnce(makeQuery([live]))
+      .mockReturnValueOnce(makeQuery([withIdentities]))
       .mockReturnValueOnce(makeQuery([]));
 
     const res = await get(`/api/images/bottle/${BOTTLE}`, tokenFor(USER, ['user']));
     const body = await res.json();
-    expect(body.images).toEqual([live]);
+    expect(body.images).toEqual([{ ...live, mine: true }]);
     expect(body.defaultImageId).toBeNull();
   });
 });

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -214,7 +214,17 @@ router.get('/bottle/:bottleId', requireAuth, async (req, res) => {
       wineImages = wineImages.filter(img => !bottleImageIds.has(img._id.toString()));
     }
 
-    const images = [...bottleImages, ...wineImages];
+    // Audit 2026-09 D05-1: the gallery is read by every cellar member, viewers
+    // included, and returned whole documents — uploader, reviewer and reporter
+    // identities of every public wine photo. The page needs the picture, its
+    // credit and state, and whether the photo is the caller's own.
+    const me = String(req.user.id);
+    const publicImage = (doc) => {
+      const o = typeof doc.toObject === 'function' ? doc.toObject() : { ...doc };
+      const { uploadedBy, reviewedBy, reviewedAt, reports, reportedAt, contentHash, retainUntil, ...rest } = o;
+      return { ...rest, mine: uploadedBy != null && String(uploadedBy) === me };
+    };
+    const images = [...bottleImages, ...wineImages].map(publicImage);
 
     // Sort default image first if the bottle has one set
     if (bottle.defaultImage) {

--- a/backend/src/routes/import.confirm.test.js
+++ b/backend/src/routes/import.confirm.test.js
@@ -44,6 +44,13 @@ jest.mock('../utils/vintageProfile', () => ({
 
 jest.mock('../models/Cellar', () => ({ findById: jest.fn() }));
 jest.mock('../models/WineDefinition', () => ({ findById: jest.fn(), find: jest.fn() }));
+// Audit 2026-09 D02-3: confirm resolves wines through the visibility helper;
+// these tests describe the confirm behaviour, not the visibility rule, so
+// route it back to the findById mock the cases already configure.
+jest.mock('../services/wineVisibility', () => ({
+  wineVisibilityFilter: () => ({}),
+  findVisibleWine: (id) => require('../models/WineDefinition').findById(id),
+}));
 jest.mock('../models/Country', () => ({ findOne: jest.fn() }));
 jest.mock('../models/ImportSession', () => ({}));
 

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -20,7 +20,9 @@ const aiProvider = require('../services/aiProvider');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
 const { scoreWineMatchVariants, stripProducerPrefix } = require('../services/wineMatching');
 const { conflictingStyleTerms, pradikatOnlyValue, pradikatContradictsName } = require('../utils/styleTerms');
-const { wineVisibilityFilter } = require('../services/wineVisibility');
+const { wineVisibilityFilter, findVisibleWine } = require('../services/wineVisibility');
+// Audit 2026-09 D13-12: parse-time warnings are bounded before they are stored.
+const { sanitizeImportWarnings } = require('../utils/importWarnings');
 const { tryDebitAi, isRefundableFailure } = require('../services/aiBudget');
 const rateLimitsConfig = require('../config/rateLimits');
 const { generateWineKey } = require('../utils/normalize');
@@ -1468,7 +1470,9 @@ router.post('/confirm', async (req, res) => {
             errors.push({ index: i, reason: 'Invalid wine definition ID' });
             continue;
           }
-          const wishWine = await WineDefinition.findById(item.wineDefinition);
+          // Audit 2026-09 D02-3: the registry's pendingIdentity visibility
+          // rule applies here as everywhere else (services/wineVisibility.js).
+          const wishWine = await findVisibleWine(item.wineDefinition, { userId: req.user.id, roles: req.user.roles });
           if (!wishWine) {
             errors.push({ index: i, reason: 'Wine definition not found' });
             continue;
@@ -1640,7 +1644,7 @@ router.post('/confirm', async (req, res) => {
             errors.push({ index: i, reason: 'Invalid wine definition ID' });
             continue;
           }
-          wineDoc = await WineDefinition.findById(item.wineDefinition);
+          wineDoc = await findVisibleWine(item.wineDefinition, { userId: req.user.id, roles: req.user.roles });
           if (!wineDoc) {
             errors.push({ index: i, reason: 'Wine definition not found' });
             continue;
@@ -1875,7 +1879,7 @@ router.post('/confirm', async (req, res) => {
         fileName: typeof req.body.fileName === 'string' ? req.body.fileName.slice(0, 260) : undefined,
         detectedFormat: typeof req.body.detectedFormat === 'string' ? req.body.detectedFormat.slice(0, 40) : undefined,
         detectedEncoding: typeof req.body.detectedEncoding === 'string' ? req.body.detectedEncoding.slice(0, 40) : undefined,
-        importWarnings: Array.isArray(req.body.importWarnings) ? req.body.importWarnings.slice(0, 20) : [],
+        importWarnings: sanitizeImportWarnings(req.body.importWarnings),
         rows,
         rowCount: items.length,
         rowsTruncated: items.length > ARCHIVE_ROW_CAP,
@@ -1963,7 +1967,7 @@ router.post('/sessions', async (req, res) => {
       positionAnchor: positionAnchor || 'top-left',
       rackConfigs: rackConfigs || {},
       defaultCurrency: defaultCurrency || 'USD',
-      importWarnings: Array.isArray(importWarnings) ? importWarnings : [],
+      importWarnings: sanitizeImportWarnings(importWarnings),
       detectedEncoding: detectedEncoding || undefined,
       ctTable: ctTable || undefined,
       ctTextFallback: Array.isArray(ctTextFallback) ? ctTextFallback : []
@@ -2104,7 +2108,7 @@ router.put('/sessions/:id', async (req, res) => {
     if (defaultCurrency !== undefined) session.defaultCurrency = defaultCurrency;
     // Parse-time notices/metadata — persisted so the ct-truncated banner (and
     // the encoding/table/fallback notes) survive a resume.
-    if (importWarnings !== undefined) session.importWarnings = importWarnings;
+    if (importWarnings !== undefined) session.importWarnings = sanitizeImportWarnings(importWarnings);
     if (detectedEncoding !== undefined) session.detectedEncoding = detectedEncoding;
     if (ctTable !== undefined) session.ctTable = ctTable;
     if (ctTextFallback !== undefined) session.ctTextFallback = ctTextFallback;

--- a/backend/src/routes/pushSubscriptions.cap.test.js
+++ b/backend/src/routes/pushSubscriptions.cap.test.js
@@ -1,0 +1,78 @@
+/**
+ * Audit 2026-09 S4-3 — push subscriptions per account are capped (the oldest
+ * is evicted past MAX_PUSH_SUBSCRIPTIONS) and endpoints must be https: every
+ * notification fans out to every subscription as a signed HTTPS POST to a
+ * host the client chose.
+ */
+const express = require('express');
+const http = require('http');
+
+jest.mock('../middleware/auth', () => ({
+  requireAuth: (req, res, next) => { req.user = { id: 'a'.repeat(24), roles: ['user'] }; next(); },
+}));
+jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
+const mockFind = jest.fn();
+const mockDeleteMany = jest.fn(async () => ({}));
+const mockUpsert = jest.fn(async () => ({}));
+jest.mock('../models/PushSubscription', () => ({
+  find: (...a) => mockFind(...a),
+  deleteMany: (...a) => mockDeleteMany(...a),
+  findOneAndUpdate: (...a) => mockUpsert(...a),
+  updateOne: jest.fn(async () => ({})),
+  deleteOne: jest.fn(async () => ({})),
+  countDocuments: jest.fn(async () => 0),
+  findOne: jest.fn(async () => null),
+}));
+
+const router = require('./pushSubscriptions');
+
+let server;
+let base;
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/push-subscriptions', router);
+  server = http.createServer(app);
+  server.listen(0, () => { base = `http://127.0.0.1:${server.address().port}`; done(); });
+});
+afterAll((done) => { server.closeAllConnections(); server.close(done); });
+
+const existing = (n) => Array.from({ length: n }, (_, i) => ({ _id: `sub${i}` }));
+const chain = (rows) => ({ sort: () => ({ select: () => ({ lean: async () => rows }) }) });
+const post = (body) => fetch(`${base}/api/push-subscriptions`, {
+  method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+}).then(async (r) => ({ status: r.status, body: await r.json() }));
+const KEYS = { p256dh: 'p', auth: 'a' };
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+test('a new device under the cap is saved without evicting anything', async () => {
+  mockFind.mockReturnValue(chain(existing(3)));
+  const { status } = await post({ endpoint: 'https://push.example/abc', keys: KEYS });
+  expect(status).toBe(200);
+  expect(mockDeleteMany).not.toHaveBeenCalled();
+  expect(mockUpsert).toHaveBeenCalledTimes(1);
+});
+
+test('at the cap the oldest subscription is evicted so the newest device still works', async () => {
+  mockFind.mockReturnValue(chain(existing(10)));
+  const { status } = await post({ endpoint: 'https://push.example/new', keys: KEYS });
+  expect(status).toBe(200);
+  expect(mockDeleteMany).toHaveBeenCalledWith({ _id: { $in: ['sub0'] } });
+  // The lookup excluded the endpoint being (re-)registered, so re-subscribing
+  // the same device never counts against itself.
+  expect(mockFind.mock.calls[0][0]).toEqual({ user: 'a'.repeat(24), endpoint: { $ne: 'https://push.example/new' } });
+});
+
+test('well over the cap (legacy rows) trims down to the cap in one go', async () => {
+  mockFind.mockReturnValue(chain(existing(14)));
+  await post({ endpoint: 'https://push.example/new', keys: KEYS });
+  expect(mockDeleteMany.mock.calls[0][0]._id.$in).toEqual(['sub0', 'sub1', 'sub2', 'sub3', 'sub4']);
+});
+
+test('an endpoint that is not https, or is absurdly long, is refused before any write', async () => {
+  mockFind.mockReturnValue(chain([]));
+  expect((await post({ endpoint: 'http://push.example/abc', keys: KEYS })).status).toBe(400);
+  expect((await post({ endpoint: 'https://push.example/' + 'x'.repeat(2100), keys: KEYS })).status).toBe(400);
+  expect(mockUpsert).not.toHaveBeenCalled();
+});

--- a/backend/src/routes/pushSubscriptions.js
+++ b/backend/src/routes/pushSubscriptions.js
@@ -67,6 +67,9 @@ router.post('/test', async (req, res) => {
   }
 });
 
+// Audit 2026-09 S4-3: devices per account; the oldest is evicted past this.
+const MAX_PUSH_SUBSCRIPTIONS = 10;
+
 // POST /api/push-subscriptions — save a new push subscription
 router.post('/', async (req, res) => {
   try {
@@ -77,6 +80,19 @@ router.post('/', async (req, res) => {
 
     const safeEndpoint = String(endpoint);
     const safeKeys = { p256dh: String(keys.p256dh), auth: String(keys.auth) };
+    // Audit 2026-09 S4-3: every notification fans out to every subscription,
+    // each a VAPID-signed HTTPS POST to a host the CLIENT chose. Push
+    // services are https-only, and a person has a handful of devices — keep
+    // the newest MAX_PUSH_SUBSCRIPTIONS and evict the oldest beyond that.
+    if (safeEndpoint.length > 2048 || !/^https:\/\//i.test(safeEndpoint)) {
+      return res.status(400).json({ error: 'Push endpoint must be an https URL' });
+    }
+    const others = await PushSubscription.find({ user: req.user.id, endpoint: { $ne: safeEndpoint } })
+      .sort({ _id: 1 }).select('_id').lean();
+    if (others.length >= MAX_PUSH_SUBSCRIPTIONS) {
+      const evict = others.slice(0, others.length - MAX_PUSH_SUBSCRIPTIONS + 1).map((s) => s._id);
+      await PushSubscription.deleteMany({ _id: { $in: evict } });
+    }
 
     // Scope the upsert to the caller so the common path (a user re-subscribing
     // their own device) can't be turned into an IDOR by filtering on endpoint

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -46,6 +46,25 @@ const {
 const { safeUploadPath } = require('../services/imageProcessor');
 const { logAudit } = require('../services/audit');
 const eventBus = require('../services/eventBus');
+const rateLimit = require('express-rate-limit');
+const { rateLimitKey } = require('../utils/clientIp');
+
+// Audit 2026-09 D05-4: the full account export spans ~40 collections at up to
+// 50k rows each and had no per-user throttle. Three an hour is more than any
+// person needs and stops a looping script; keyed on the account so a shared
+// address is not punished. Kept separate from the MCP export-link claim
+// (lastAccountExportAt) so a web download never blocks a connector export.
+const accountExportLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 3,
+  keyGenerator: (req) => (req.user?.id ? `u:${req.user.id}` : rateLimitKey(req)),
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    logAudit(req, 'system.rate_limit_exceeded', { type: 'user', id: req.user?.id }, { limiter: 'accountExport', limit: 3 });
+    res.status(429).json({ error: 'Account exports are limited to three per hour. Please try again later.' });
+  },
+});
 const { CURRENT_PRIVACY_POLICY_VERSION } = require('../config/legal');
 const { stripHtml, escapeRegex } = require('../utils/sanitize');
 const { isValidId, coerceStringQuery } = require('../utils/validation');
@@ -277,7 +296,7 @@ router.get('/public/:userId', requireAuth, async (req, res) => {
 // services/userDataRegistry.js (EXPORT_MAX there) — the single source of
 // truth shared with the deletion job. The admin user list lives at
 // /api/admin/users (routes/admin/users.js).
-router.get('/me/export', requireAuth, async (req, res) => {
+router.get('/me/export', requireAuth, accountExportLimiter, async (req, res) => {
   const userId = req.user.id;
   try {
     const user = await User.findById(userId);
@@ -287,6 +306,11 @@ router.get('/me/export', requireAuth, async (req, res) => {
     // source of truth shared with the deletion job — see
     // services/userDataRegistry.js).
     const exportData = await buildUserExport(userId, user);
+    // Audit 2026-09 S1-1: the cellar exports and the MCP twin already leave a
+    // row; the one export that carries ALL of a person's data did not.
+    logAudit(req, 'user.account_export', { type: 'user', id: userId }, {
+      via: 'web', collections: Object.keys(exportData || {}).length, truncated: !!exportData?._truncated,
+    });
 
     res.setHeader('Content-Disposition', `attachment; filename="cellarion-data-export-${user.username}.json"`);
     res.setHeader('Content-Type', 'application/json');

--- a/backend/src/routes/wineLists.js
+++ b/backend/src/routes/wineLists.js
@@ -3,7 +3,10 @@ const mongoose = require('mongoose');
 const crypto = require('crypto');
 const fs = require('fs');
 const multer = require('multer');
-const { requireAuth } = require('../middleware/auth');
+// Audit 2026-09 S2-3: the write routes are demo-blocked like their MCP twins —
+// an anonymous demo session must not publish a public, branded wine list or
+// consume disk with logos and duplicates. Reads stay open for the demo tour.
+const { requireAuth, requireNonDemo } = require('../middleware/auth');
 const WineList = require('../models/WineList');
 const Cellar = require('../models/Cellar');
 const { logAudit } = require('../services/audit');
@@ -128,7 +131,7 @@ router.get('/cellar-wines', requireAuth, async (req, res) => {
 });
 
 // POST /api/wine-lists — create a new wine list
-router.post('/', requireAuth, async (req, res) => {
+router.post('/', requireAuth, requireNonDemo, async (req, res) => {
   try {
     const { cellar: cellarId, name } = req.body;
     if (!cellarId || !name) return res.status(400).json({ error: 'cellar and name are required' });
@@ -188,7 +191,7 @@ router.get('/:id', requireAuth, async (req, res) => {
 });
 
 // PUT /api/wine-lists/:id — update wine list
-router.put('/:id', requireAuth, async (req, res) => {
+router.put('/:id', requireAuth, requireNonDemo, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
     const wineList = await WineList.findOne({ _id: req.params.id, user: req.user.id });
@@ -369,7 +372,7 @@ router.delete('/:id', requireAuth, async (req, res) => {
 });
 
 // POST /api/wine-lists/:id/duplicate — copy a list (e.g. Spring → Summer menu)
-router.post('/:id/duplicate', requireAuth, async (req, res) => {
+router.post('/:id/duplicate', requireAuth, requireNonDemo, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
     const source = await WineList.findOne({ _id: req.params.id, user: req.user.id }).lean();
@@ -399,7 +402,7 @@ router.post('/:id/duplicate', requireAuth, async (req, res) => {
 });
 
 // POST /api/wine-lists/:id/publish — generate token and publish
-router.post('/:id/publish', requireAuth, async (req, res) => {
+router.post('/:id/publish', requireAuth, requireNonDemo, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
     const wineList = await WineList.findOne({ _id: req.params.id, user: req.user.id });
@@ -483,7 +486,7 @@ function handleLogoUpload(req, res, next) {
 }
 
 // POST /api/wine-lists/:id/logo — upload restaurant logo
-router.post('/:id/logo', requireAuth, handleLogoUpload, async (req, res) => {
+router.post('/:id/logo', requireAuth, requireNonDemo, handleLogoUpload, async (req, res) => {
   try {
     if (!isValidId(req.params.id)) return res.status(400).json({ error: 'Invalid ID' });
     const wineList = await WineList.findOne({ _id: req.params.id, user: req.user.id });

--- a/backend/src/services/cellarTransfer.js
+++ b/backend/src/services/cellarTransfer.js
@@ -92,8 +92,12 @@ async function transferCellarOwnership(cellarId, newOwnerId, actorId) {
     throw fail(400, 'The new owner must already be a member of this cellar');
   }
 
-  const newOwner = await User.findById(newOwnerId).select('_id username email').lean();
+  const newOwner = await User.findById(newOwnerId).select('_id username email isDemo').lean();
   if (!newOwner) throw fail(404, 'New owner account not found');
+  // Audit 2026-09 D03-1: a demo account is hard-deleted within hours, taking
+  // everything just transferred into it. Refuse rather than let a mistaken
+  // click (or a phished session) make a cellar vanish.
+  if (newOwner.isDemo) throw fail(400, 'A demo account cannot own a cellar');
 
   // ── 0. Can the cellar actually LAND? A cellar name is unique per owner
   //       (models/Cellar: unique { user, name } over active cellars), so if the

--- a/backend/src/services/scheduler.js
+++ b/backend/src/services/scheduler.js
@@ -11,6 +11,7 @@ const { runSecurityAlertCheck } = require('./securityAlertJob');
 const { runClimateOfflineCheck } = require('./climateOfflineJob');
 const { runDemoSweep } = require('./demoSweepJob');
 const { runRegistryHealthCheck } = require('./registryHealthJob');
+const DiscussionReply = require('../models/DiscussionReply');
 const embeddingJob = require('./embeddingJob');
 
 /**
@@ -67,6 +68,14 @@ function startScheduler() {
       await runCellarRetentionPurge();
     } catch (err) {
       console.error('[scheduler] Cellar retention purge failed:', err);
+    }
+    // Audit 2026-09 S3-3: the original text of a soft-deleted forum reply is
+    // kept 30 days for moderation and was then kept forever — the purge
+    // helper existed but nothing called it.
+    try {
+      await DiscussionReply.purgeExpiredDeletes();
+    } catch (err) {
+      console.error('[scheduler] Soft-deleted reply purge failed:', err);
     }
   });
 

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -431,7 +431,9 @@ const REGISTRY = [
     purge: async (ctx) => {
       const ownReplyIds = await DiscussionReply.distinct('_id', { author: ctx.userId });
       await Promise.all([
-        DiscussionReply.updateMany({ author: ctx.userId }, { $set: { author: ctx.deletedUserId } }),
+        // deletedBody: the original text of the user's own soft-deleted
+        // replies does not survive their erasure (audit 2026-09 S3-3).
+        DiscussionReply.updateMany({ author: ctx.userId }, { $set: { author: ctx.deletedUserId, deletedBody: null } }),
         DiscussionReply.updateMany(
           { 'quote.authorId': ctx.userId },
           { $set: { 'quote.authorName': '[deleted]', 'quote.authorId': ctx.deletedUserId } }

--- a/backend/src/services/userDataRegistry.test.js
+++ b/backend/src/services/userDataRegistry.test.js
@@ -134,7 +134,7 @@ describe('DiscussionReply purge — quote.authorName erasure (L-17)', () => {
     // 1) own replies re-pointed to the [deleted] sentinel
     expect(calls).toContainEqual([
       { author: 'u1' },
-      { $set: { author: 'del1' } },
+      { $set: { author: 'del1', deletedBody: null } },
     ]);
     // 2) quotes carrying the user's id: name scrubbed, id re-pointed
     expect(calls).toContainEqual([

--- a/backend/src/utils/deletedUser.js
+++ b/backend/src/utils/deletedUser.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const User = require('../models/User');
 
 // Sentinel "[deleted]" user used to anonymise forum content when a real user
@@ -23,12 +24,14 @@ async function getOrCreateDeletedUser() {
     return cachedId;
   }
 
-  // Required password field — store an unverifiable bcrypt-shaped hash so
-  // login attempts via username/password fail at compare-time.
+  // Required password field. Audit 2026-09 O05-6: the old literal "invalid
+  // hash" string was itself hashed by the pre-save hook and so became a VALID
+  // password anyone could read in the repository. A random secret nobody ever
+  // sees is unknowable in practice, whatever the hook does to it.
   const created = await User.create({
     username: SENTINEL_USERNAME,
     email: SENTINEL_EMAIL,
-    password: '$2a$10$INVALID_HASH_NEVER_MATCHES_ANYTHING',
+    password: crypto.randomBytes(48).toString('hex'),
     displayName: null,
     profileVisibility: 'private',
     emailVerified: false,

--- a/backend/src/utils/importWarnings.js
+++ b/backend/src/utils/importWarnings.js
@@ -1,0 +1,26 @@
+/**
+ * Parse-time import warnings, bounded (audit 2026-09 D13-12).
+ *
+ * The client sends the notices its parser produced (CellarTracker truncation,
+ * encoding, table choice) so a resumed import can show the same banner. They
+ * arrived as free Mixed values and were stored as-is — up to the 8 MB import
+ * body per row — in ImportSession and ImportArchive. Keep the three fields the
+ * banner reads, each capped, and drop everything else.
+ */
+const MAX_WARNINGS = 20;
+const CODE_MAX = 40;
+const SAMPLE_MAX = 200;
+
+function sanitizeImportWarnings(list) {
+  if (!Array.isArray(list)) return [];
+  return list.slice(0, MAX_WARNINGS).map((w) => {
+    if (!w || typeof w !== 'object') return null;
+    const out = {};
+    if (typeof w.code === 'string' && w.code.trim()) out.code = w.code.trim().slice(0, CODE_MAX);
+    if (typeof w.count === 'number' && Number.isFinite(w.count)) out.count = w.count;
+    if (typeof w.sample === 'string') out.sample = w.sample.slice(0, SAMPLE_MAX);
+    return out.code ? out : null;
+  }).filter(Boolean);
+}
+
+module.exports = { sanitizeImportWarnings, MAX_WARNINGS, CODE_MAX, SAMPLE_MAX };

--- a/backend/src/utils/importWarnings.test.js
+++ b/backend/src/utils/importWarnings.test.js
@@ -1,0 +1,22 @@
+const { sanitizeImportWarnings } = require('./importWarnings');
+
+describe('sanitizeImportWarnings (audit 2026-09 D13-12)', () => {
+  test('keeps code, count and sample, bounded', () => {
+    const out = sanitizeImportWarnings([{ code: 'ct-truncated', count: 12, sample: 'x'.repeat(500), extra: { huge: 'y'.repeat(10000) } }]);
+    expect(out).toEqual([{ code: 'ct-truncated', count: 12, sample: 'x'.repeat(200) }]);
+  });
+  test('drops entries without a code, non-objects, and everything past twenty', () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({ code: `w${i}` }));
+    expect(sanitizeImportWarnings(many)).toHaveLength(20);
+    expect(sanitizeImportWarnings([null, 'text', 42, { count: 3 }, { code: '   ' }])).toEqual([]);
+  });
+  test('caps the code and refuses non-finite counts', () => {
+    const out = sanitizeImportWarnings([{ code: 'c'.repeat(100), count: Infinity }]);
+    expect(out).toEqual([{ code: 'c'.repeat(40) }]);
+  });
+  test('anything that is not an array is an empty list', () => {
+    expect(sanitizeImportWarnings(undefined)).toEqual([]);
+    expect(sanitizeImportWarnings({ code: 'x' })).toEqual([]);
+    expect(sanitizeImportWarnings('x')).toEqual([]);
+  });
+});

--- a/frontend/src/components/ImageCarousel.js
+++ b/frontend/src/components/ImageCarousel.js
@@ -49,7 +49,10 @@ function ImageCarousel({ images, size = 'medium', defaultImageId, onSetDefault, 
             picture in the shared registry, taking it down changes other
             people's pages, so it becomes a report an admin decides. */}
         {(onDelete || onReport) && (() => {
-          const mine = currentUserId && String(currentImage.uploadedBy) === String(currentUserId);
+          // The gallery now says `mine` itself (audit 2026-09 D05-1: uploader
+          // ids no longer travel); the uploadedBy comparison stays for any
+          // older payload shape.
+          const mine = currentImage.mine === true || (currentUserId && currentImage.uploadedBy != null && String(currentImage.uploadedBy) === String(currentUserId));
           const canDelete = mine && !currentImage.assignedToWine;
           if (canDelete && onDelete) {
             return (


### PR DESCRIPTION
Fourteen medium findings from `audit-2026-09/findings.json`, chosen for being contained and touching real exposure. Each item names its ledger id.

| Id | Fix |
|---|---|
| D11-1 | Cellar invitations: e-mail format + length validated; 20 invitations per account per rolling 24 h (429 + audit row past that); the cellar name is truncated to 100 chars in the invite mail. |
| D03-1 | Ownership transfer to a demo account is refused (it would be hard-deleted with the cellar within hours). |
| D05-1 | `GET /api/images/bottle/:id` returns public fields plus a `mine` flag; `uploadedBy`, `reviewedBy`, `reviewedAt`, `reports`, `reportedAt`, `contentHash`, `retainUntil` no longer travel. `ImageCarousel` reads `mine` (with the old comparison as fallback). |
| O01-3 | Follower/following lists carry a bio only for public profiles; `profileVisibility` is selected for the decision and stripped from the payload. |
| S2-3 | `POST /`, `PUT /:id`, `/duplicate`, `/publish`, `/logo` on wine lists take `requireNonDemo`, matching the MCP twins. |
| D16-1 | `TRUST_PROXY_HOPS=''` (the shipped compose) now means 1 hop, not `trust proxy 0`; a non-integer value throws at boot instead of silently degrading every per-IP limiter. |
| S4-3 | Push subscriptions: https endpoints only (≤ 2048 chars), at most 10 per account, oldest evicted on the eleventh. |
| S1-1 / S2-2 / S3-6 / D05-4 | `GET /api/users/me/export` writes `user.account_export` (via web, collection count, truncation flag) and is limited to 3 per hour per account, separate from the MCP export-link claim. |
| D04-4 | `auth.login.failed` stores `identifierType` + a 16-hex sha256 prefix of the lowercased identifier, never the typed string. |
| O05-6 | The `__deleted__` sentinel is created with a random 48-byte password; the previous literal was hashed by the pre-save hook into a valid credential visible in the repository. |
| D02-3 | Import confirm (bottle and wishlist branches) resolves the client-supplied wine through `findVisibleWine`, honouring the pendingIdentity rule. |
| D01-1 / D01-4 | Country create/update and CSV-minted appellations use `sanitizeTaxonomyName` (+ 200-char cap for appellations). |
| D13-12 | `importWarnings` bounded to `{code ≤40, count, sample ≤200}` × 20 at all three write points (`utils/importWarnings.js`). |
| S3-3 | `DiscussionReply.purgeExpiredDeletes()` runs daily in the 04:00 UTC retention slot; the author re-point on erasure also nulls `deletedBody`. |

Deferred to the next batch (bigger or need a decision): D03F-2 registered-account oracle (needs pending-for-everyone sharing), S4-1 lockout counter race (changes the helper's contract), the curator AI budget items (S4-6/S5-1/D09-1), prompt-injection framing (D07-6/O02-2/S5-2), undo guards (D07-1/M02-3), erasure policy wording (S3-2/S3-4/S3-5/S3-8), D15-2 admin vs super-admin split, X01-12 Umami network, operator scripts.

## Tests
New: `importWarnings.test.js`, `pushSubscriptions.cap.test.js`, `follows.privateBio.test.js`. Updated: `images.bottleGallery.test.js` (payload shape), `import.confirm.test.js` (visibility helper routed to the findById mock), `userDataRegistry.test.js` (re-point now nulls `deletedBody`). 38 backend suites / 385 tests pass on this branch; frontend 91 files / 1208 tests + production build pass.

Independent of #1239 (registry lockdown); either merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
