### PR TITLE
fix(import): match appellation-first names and bracketed producers; longer reject reasons

### DIFF
--- a/backend/src/models/RegistryDataKey.js
+++ b/backend/src/models/RegistryDataKey.js
@@ -65,7 +65,7 @@ const registryDataKeySchema = new mongoose.Schema({
   },
   decidedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   decidedAt: { type: Date, default: null },
-  rejectReason: { type: String, trim: true, maxlength: 500 },
+  rejectReason: { type: String, trim: true, maxlength: 2000 } // 500 was too short for a real explanation (registry backlog 2026-09-06),
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }
 });

--- a/backend/src/models/RegistryDataKey.js
+++ b/backend/src/models/RegistryDataKey.js
@@ -65,7 +65,7 @@ const registryDataKeySchema = new mongoose.Schema({
   },
   decidedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   decidedAt: { type: Date, default: null },
-  rejectReason: { type: String, trim: true, maxlength: 2000 } // 500 was too short for a real explanation (registry backlog 2026-09-06),
+  rejectReason: { type: String, trim: true, maxlength: 2000 }, // 500 was too short for a real explanation (registry backlog 2026-09-06)
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }
 });

--- a/backend/src/models/RegistryDataValue.js
+++ b/backend/src/models/RegistryDataValue.js
@@ -69,7 +69,7 @@ const registryDataValueSchema = new mongoose.Schema({
   reason: { type: String, trim: true, maxlength: 1000 },
   decidedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   decidedAt: { type: Date, default: null },
-  rejectReason: { type: String, trim: true, maxlength: 2000 } // 500 was too short for a real explanation (registry backlog 2026-09-06),
+  rejectReason: { type: String, trim: true, maxlength: 2000 }, // 500 was too short for a real explanation (registry backlog 2026-09-06)
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }
 });

--- a/backend/src/models/RegistryDataValue.js
+++ b/backend/src/models/RegistryDataValue.js
@@ -69,7 +69,7 @@ const registryDataValueSchema = new mongoose.Schema({
   reason: { type: String, trim: true, maxlength: 1000 },
   decidedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   decidedAt: { type: Date, default: null },
-  rejectReason: { type: String, trim: true, maxlength: 500 },
+  rejectReason: { type: String, trim: true, maxlength: 2000 } // 500 was too short for a real explanation (registry backlog 2026-09-06),
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }
 });

--- a/backend/src/models/WineCorrectionProposal.js
+++ b/backend/src/models/WineCorrectionProposal.js
@@ -111,7 +111,7 @@ const wineCorrectionProposalSchema = new mongoose.Schema({
   },
   decidedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   decidedAt: { type: Date, default: null },
-  rejectReason: { type: String, trim: true, maxlength: 500 },
+  rejectReason: { type: String, trim: true, maxlength: 2000 } // 500 was too short for a real explanation (registry backlog 2026-09-06),
   // What the approve actually did (fields applied / bottles moved / queue rows
   // cleared) — the reviewer-facing receipt.
   appliedNote: { type: String, trim: true, maxlength: 500 },

--- a/backend/src/models/WineCorrectionProposal.js
+++ b/backend/src/models/WineCorrectionProposal.js
@@ -111,7 +111,7 @@ const wineCorrectionProposalSchema = new mongoose.Schema({
   },
   decidedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   decidedAt: { type: Date, default: null },
-  rejectReason: { type: String, trim: true, maxlength: 2000 } // 500 was too short for a real explanation (registry backlog 2026-09-06),
+  rejectReason: { type: String, trim: true, maxlength: 2000 }, // 500 was too short for a real explanation (registry backlog 2026-09-06)
   // What the approve actually did (fields applied / bottles moved / queue rows
   // cleared) — the reviewer-facing receipt.
   appliedNote: { type: String, trim: true, maxlength: 500 },

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -18,7 +18,7 @@ const searchService = require('../services/search');
 const { identifyWineFromText } = require('../services/labelScan');
 const aiProvider = require('../services/aiProvider');
 const { findOrCreateWine } = require('../services/findOrCreateWine');
-const { scoreWineMatchVariants, stripProducerPrefix } = require('../services/wineMatching');
+const { scoreWineMatchVariants, stripProducerPrefix, stripAppellationPrefix, stripProducerBrackets, importQueryVariants } = require('../services/wineMatching');
 const { conflictingStyleTerms, pradikatOnlyValue, pradikatContradictsName } = require('../utils/styleTerms');
 const { wineVisibilityFilter, findVisibleWine } = require('../services/wineVisibility');
 // Audit 2026-09 D13-12: parse-time warnings are bounded before they are stored.
@@ -409,7 +409,11 @@ function scoreCandidate(candidate, item) {
   return scoreWineMatchVariants(candidate, {
     name: item.wineName,
     producer: item.producer,
-    appellation: item.appellation
+    appellation: item.appellation,
+    // The region hint lets an appellation-first name ("Douro Old Vines
+    // Reserva") shed its prefix when the file names the region, not the
+    // appellation (registry backlog 2026-09-06).
+    region: item.region
   });
 }
 
@@ -466,8 +470,11 @@ async function findWineMatches(item, viewer = {}) {
   // Strategy 1: Meilisearch search (if available)
   if (searchService.getIsAvailable()) {
     try {
-      // Search with combined producer + name for best fuzzy results
-      const query = `${item.producer || ''} ${item.wineName || ''}`.trim();
+      // Search with combined producer + name for best fuzzy results — then,
+      // if that found nothing worth scoring, with the appellation prefix and
+      // the producer's parenthetical removed (registry backlog 2026-09-06: a
+      // CellarTracker re-import missed 44 known wines on those two habits).
+      const queries = importQueryVariants(item);
       const searchOpts = { limit: 15 };
 
       // Add country filter if we can resolve it
@@ -477,20 +484,23 @@ async function findWineMatches(item, viewer = {}) {
         if (countryDoc) searchOpts.countryId = countryDoc._id.toString();
       }
 
-      const { ids } = await searchService.search(query, searchOpts);
-      if (ids.length > 0) {
-        // Pending rows are not in the Meili index at all; the clause is here so
-        // the gate holds if that ever changes (all three strategies, one rule).
-        const wines = await WineDefinition.find({ _id: { $in: ids }, ...visible })
-          .populate(['country', 'region', 'grapes'])
-          .lean();
+      for (const query of queries) {
+        const { ids } = await searchService.search(query, searchOpts);
+        if (ids.length > 0) {
+          // Pending rows are not in the Meili index at all; the clause is here so
+          // the gate holds if that ever changes (all three strategies, one rule).
+          const wines = await WineDefinition.find({ _id: { $in: ids }, ...visible })
+            .populate(['country', 'region', 'grapes'])
+            .lean();
 
-        for (const wine of wines) {
-          const score = scoreCandidate(wine, item);
-          if (score >= FUZZY_THRESHOLD) {
-            candidates.set(wine._id.toString(), { wine, score });
+          for (const wine of wines) {
+            const score = scoreCandidate(wine, item);
+            if (score >= FUZZY_THRESHOLD) {
+              candidates.set(wine._id.toString(), { wine, score });
+            }
           }
         }
+        if (candidates.size > 0) break;
       }
     } catch (err) {
       console.error('Meilisearch search failed during import, falling back to MongoDB:', err.message);
@@ -530,11 +540,17 @@ async function findWineMatches(item, viewer = {}) {
   if (candidates.size < 3 && item.producer && item.wineName) {
     const normalizedProducer = normalizeString(item.producer);
     const normalizedName = normalizeString(item.wineName);
+    const bareProducer = stripProducerBrackets(item.producer);
+    const bareName = stripAppellationPrefix(item.wineName, item.appellation) || stripAppellationPrefix(item.wineName, item.region);
 
     const keyMatch = {
       $or: [
         { normalizedKey: { $regex: `^${escapeRegex(normalizedProducer)}:` } },
-        { normalizedKey: { $regex: `:${escapeRegex(normalizedName)}:` } }
+        { normalizedKey: { $regex: `:${escapeRegex(normalizedName)}:` } },
+        // The same two lookups on the appellation-stripped name and the
+        // bracket-free producer (registry backlog 2026-09-06).
+        ...(bareProducer ? [{ normalizedKey: { $regex: `^${escapeRegex(normalizeString(bareProducer))}:` } }] : []),
+        ...(bareName ? [{ normalizedKey: { $regex: `:${escapeRegex(bareName)}:` } }] : []),
       ]
     };
     // $and, not a spread: `visible` is itself an $or for non-curators, and two

--- a/backend/src/services/wineMatching.js
+++ b/backend/src/services/wineMatching.js
@@ -123,6 +123,88 @@ function stripProducerPrefix(name, producer) {
   return remainder || null;
 }
 
+// ── Appellation-first names and bracketed producers (import path) ───────────
+//
+// CellarTracker composes its "Wine" display name as producer + appellation +
+// designation ("Bodegas Muga Rioja Prado Enea Gran Reserva"), so after the
+// producer prefix is stripped the row still LEADS with the appellation
+// ("Rioja Prado Enea Gran Reserva") while the registry stores the designation
+// alone ("Prado Enea Gran Reserva"). Producers arrive with a parenthetical
+// the registry does not carry ("Ca' Marcanda (Gaja)"). A re-import of one
+// such file re-created its entire request queue (44 rows, 2026-09-06) —
+// every wine already existed. Both are comparison-layer variants: stored
+// strings and keys never change.
+
+// Legal-tier suffixes that ride on an appellation hint ("Chianti Classico
+// DOCG", "Rioja DOCa") but never on the wine name's leading words.
+const APPELLATION_TIER_RX = /\b(docg|doca|doc|dop|aoc|aop|igt|igp|ava|gi|do|vdp|vdqs)\b/g;
+// A remainder made only of these is a style or a grape, not a name ("Rioja
+// Reserva" → "Reserva", "Wehlener Sonnenuhr Riesling Auslese" → "Riesling
+// Auslese" where the "appellation" is the single vineyard the registry keeps
+// in the name): stripping would make every such wine of the appellation
+// collide, so the name is left whole.
+const GENERIC_WORDS = new Set([
+  'reserva', 'gran', 'grande', 'riserva', 'reserve', 'crianza', 'joven', 'classico', 'superiore',
+  'brut', 'extra', 'sec', 'demi', 'dry', 'trocken', 'feinherb', 'halbtrocken', 'kabinett', 'spatlese',
+  'auslese', 'beerenauslese', 'trockenbeerenauslese', 'eiswein', 'gg', 'groes', 'gewachs', 'erstes',
+  'rouge', 'blanc', 'rose', 'rosado', 'bianco', 'rosso', 'tinto', 'branco', 'red', 'white', 'sekt',
+  'riesling', 'chardonnay', 'pinot', 'noir', 'gris', 'grigio', 'blanco', 'sauvignon', 'merlot', 'cabernet',
+  'franc', 'syrah', 'shiraz', 'grenache', 'garnacha', 'tempranillo', 'sangiovese', 'nebbiolo', 'barbera',
+  'dolcetto', 'malbec', 'zinfandel', 'gewurztraminer', 'gruner', 'veltliner', 'chenin', 'viognier', 'muscat',
+  'moscato', 'mourvedre', 'carignan', 'gamay', 'mencia', 'garganega', 'albarino', 'alvarinho', 'verdejo',
+  'godello', 'touriga', 'nacional', 'franca', 'spatburgunder', 'weissburgunder', 'grauburgunder', 'silvaner',
+  'sylvaner', 'muller', 'thurgau', 'blaufrankisch', 'zweigelt', 'semillon', 'primitivo', 'aglianico',
+  'montepulciano', 'corvina', 'glera', 'trebbiano', 'vermentino', 'verdicchio', 'fiano', 'greco', 'nero',
+  'davola', 'carmenere', 'petit', 'verdot', 'roussanne', 'marsanne', 'cinsault', 'furmint', 'assyrtiko',
+]);
+const isGenericRemainder = (normalized) => normalized.split(' ').filter(Boolean).every((t) => GENERIC_WORDS.has(t));
+
+function normalizedAppellationHead(hint) {
+  return normalizeString(hint || '').replace(APPELLATION_TIER_RX, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * If `name` starts with the appellation (or region) hint, return the
+ * normalized remainder — else null. Null too when the remainder is a bare
+ * style word, or when the hint would swallow the whole name.
+ */
+function stripAppellationPrefix(name, hint) {
+  const nName = normalizeString(name || '');
+  const head = normalizedAppellationHead(hint);
+  if (!head || !nName.startsWith(head + ' ')) return null;
+  const remainder = nName.slice(head.length + 1).trim();
+  if (!remainder || isGenericRemainder(remainder)) return null;
+  return remainder;
+}
+
+/** Normalized name with a trailing parenthetical removed ("Château Lagrange (St. Julien)"); null when nothing to strip. */
+function stripNameBrackets(name) {
+  const bare = stripProducerBrackets(name);
+  return bare ? normalizeString(bare) : null;
+}
+
+/** "Ca' Marcanda (Gaja)" → "Ca' Marcanda"; null when nothing to strip or nothing left. */
+function stripProducerBrackets(producer) {
+  const raw = String(producer || '').trim();
+  const stripped = raw.replace(/\s*\([^)]*\)\s*$/, '').trim();
+  return stripped && stripped !== raw ? stripped : null;
+}
+
+/**
+ * The query strings an import row should try against the search engine, in
+ * order: the raw producer + name, then the same with the appellation prefix
+ * and the producer's parenthetical removed. Distinct, non-empty.
+ */
+function importQueryVariants(item) {
+  const out = [];
+  const push = (producer, name) => { const q = `${producer || ''} ${name || ''}`.trim(); if (q && !out.includes(q)) out.push(q); };
+  push(item.producer, item.wineName);
+  const producer = stripProducerBrackets(item.producer) || item.producer;
+  const name = stripAppellationPrefix(item.wineName, item.appellation) || stripAppellationPrefix(item.wineName, item.region) || item.wineName;
+  push(producer, name);
+  return out;
+}
+
 /**
  * Variant-aware scorer for the import path: the max of scoreWineMatch over
  * producer-embedded name variants. Strictly monotonic relative to
@@ -178,6 +260,34 @@ function scoreWineMatchVariants(candidate, query, opts) {
       scoreWineMatch(candidate, { ...query, name: strippedByCandidate, producer: candidate.producer }, opts)
     );
   }
+  if (best >= 1) return best;
+
+  // 5–7. Appellation-first names and bracketed producers (see the note
+  // above): every combination of {name, appellation-stripped name} ×
+  // {producer, bracket-stripped producer}, on BOTH sides, still max()-ed over
+  // the raw comparison so the result never drops below scoreWineMatch.
+  const nameVariants = [query.name];
+  for (const hint of [query.appellation, query.region, candidate.appellation]) {
+    const v = stripAppellationPrefix(query.name, hint);
+    if (v && !nameVariants.includes(v)) nameVariants.push(v);
+  }
+  const bareName = stripNameBrackets(query.name);
+  if (bareName && !nameVariants.includes(bareName)) nameVariants.push(bareName);
+  const producerVariants = [query.producer];
+  const qBare = stripProducerBrackets(query.producer);
+  if (qBare) producerVariants.push(qBare);
+  const candidateVariants = [candidate];
+  const cBare = stripProducerBrackets(candidate.producer);
+  if (cBare) candidateVariants.push({ ...candidate, producer: cBare });
+  for (const cand of candidateVariants) {
+    for (const producer of producerVariants) {
+      for (const name of nameVariants) {
+        if (cand === candidate && producer === query.producer && name === query.name) continue; // the raw pair, already in `best`
+        best = Math.max(best, scoreWineMatch(cand, { ...query, name, producer }, opts));
+        if (best >= 1) return best;
+      }
+    }
+  }
 
   return best;
 }
@@ -221,6 +331,9 @@ module.exports = {
   scoreWineMatchVariants,
   concatNormalized,
   stripProducerPrefix,
+  stripAppellationPrefix,
+  stripProducerBrackets,
+  importQueryVariants,
   findBestMatch,
   scoreAllMatches,
   WEIGHTS,

--- a/backend/src/services/wineMatching.variants.test.js
+++ b/backend/src/services/wineMatching.variants.test.js
@@ -131,3 +131,85 @@ describe('helpers', () => {
     expect(stripProducerPrefix('Anything', '')).toBeNull();
   });
 });
+
+// ── Appellation-first names + bracketed producers (registry backlog 2026-09-06) ──
+//
+// Real rows from a CellarTracker re-import: 44 requests, every one for a wine
+// that already existed. CT composes "Wine" as producer + appellation +
+// designation, so after producer-stripping the name still leads with the
+// appellation; producers carry a parenthetical the registry does not.
+const {
+  stripAppellationPrefix,
+  stripProducerBrackets,
+  importQueryVariants,
+} = require('./wineMatching');
+
+describe('appellation-first import rows reach the exact threshold against their registry wine', () => {
+  const cases = [
+    ['Muga Prado Enea', { name: 'Rioja Prado Enea Gran Reserva', producer: 'Bodegas Muga', appellation: 'Rioja' },
+      { name: 'Prado Enea Gran Reserva', producer: 'Muga', appellation: 'Rioja' }],
+    ['Magari (bracketed producer)', { name: 'Magari', producer: "Ca' Marcanda (Gaja)", appellation: 'Bolgheri' },
+      { name: 'Magari', producer: "Ca' Marcanda", appellation: 'Bolgheri' }],
+    ['Cavallotto Bricco Boschis', { name: 'Barolo Bricco Boschis', producer: 'Cavallotto', appellation: 'Barolo' },
+      { name: 'Bricco Boschis', producer: 'Cavallotto', appellation: 'Barolo' }],
+    ['Château Lagrange (St. Julien)', { name: 'Château Lagrange (St. Julien)', producer: 'Château Lagrange (St. Julien)', appellation: 'Saint-Julien' },
+      { name: 'Château Lagrange', producer: 'Château Lagrange', appellation: 'Saint-Julien' }],
+    ['Xisto Cru Branco (region hint only)', { name: 'Douro Xisto Cru Branco', producer: 'Luís Seabra Vinhos', appellation: 'Douro', region: 'Douro' },
+      { name: 'Xisto Cru Branco', producer: 'Luis Seabra Vinhos', appellation: 'Douro' }],
+    ['Fonterutoli (DOCG suffix on the hint)', { name: 'Chianti Classico Castello di Fonterutoli Gran Selezione', producer: 'Marchesi Mazzei', appellation: 'Chianti Classico DOCG' },
+      { name: 'Castello di Fonterutoli Gran Selezione', producer: 'Marchesi Mazzei', appellation: 'Chianti Classico' }],
+  ];
+  test.each(cases)('%s', (_label, row, registry) => {
+    expect(scoreWineMatchVariants(registry, row)).toBeGreaterThanOrEqual(EXACT);
+    // Monotonic: never below the raw scorer.
+    expect(scoreWineMatchVariants(registry, row)).toBeGreaterThanOrEqual(scoreWineMatch(registry, row));
+  });
+
+  test('the registry side may carry the bracket instead', () => {
+    const registry = { name: 'Chapelle des Bois', producer: "Jean-Louis Dutraive (Domaine de la Grand'Cour)", appellation: 'Fleurie' };
+    const row = { name: 'Fleurie Chapelle des Bois', producer: 'Jean-Louis Dutraive', appellation: 'Fleurie' };
+    expect(scoreWineMatchVariants(registry, row)).toBeGreaterThanOrEqual(EXACT);
+  });
+
+  test('negative: a different wine of the same producer and appellation does not cross-match', () => {
+    const registry = { name: 'Prado Enea Gran Reserva', producer: 'Muga', appellation: 'Rioja' };
+    expect(scoreWineMatchVariants(registry, { name: 'Rioja Reserva', producer: 'Bodegas Muga', appellation: 'Rioja' })).toBeLessThan(0.85);
+    expect(scoreWineMatchVariants(registry, { name: 'Rioja Torre Muga', producer: 'Bodegas Muga', appellation: 'Rioja' })).toBeLessThan(0.85);
+  });
+
+  test('negative: same appellation-first name, different producer, stays a soft candidate at most', () => {
+    const registry = { name: '1er Cru Beauroy', producer: "Domaine de l'Enclos", appellation: 'Chablis Premier Cru' };
+    expect(scoreWineMatchVariants(registry, { name: 'Chablis 1er Cru Beauroy', producer: 'Domaine Laroche', appellation: 'Chablis 1er Cru' })).toBeLessThan(EXACT);
+  });
+});
+
+describe('the helpers', () => {
+  test('stripAppellationPrefix strips the hint head, folds tier suffixes, and refuses bare styles', () => {
+    expect(stripAppellationPrefix('Rioja Prado Enea Gran Reserva', 'Rioja')).toBe('prado enea gran reserva');
+    expect(stripAppellationPrefix('Chianti Classico Castello di Fonterutoli', 'Chianti Classico DOCG')).toBe('castello di fonterutoli');
+    expect(stripAppellationPrefix('Rioja Reserva', 'Rioja')).toBeNull();          // a style is not a name
+    expect(stripAppellationPrefix('Rioja', 'Rioja')).toBeNull();                  // nothing left
+    expect(stripAppellationPrefix('Riojana Cuvée', 'Rioja')).toBeNull();          // word boundary
+    expect(stripAppellationPrefix('Prado Enea', '')).toBeNull();
+  });
+  test('stripProducerBrackets removes only a trailing parenthetical', () => {
+    expect(stripProducerBrackets("Ca' Marcanda (Gaja)")).toBe("Ca' Marcanda");
+    expect(stripProducerBrackets('Château Lagrange (St. Julien)')).toBe('Château Lagrange');
+    expect(stripProducerBrackets('Muga')).toBeNull();
+    expect(stripProducerBrackets('(Unknown)')).toBeNull();
+  });
+  test('importQueryVariants yields the raw query, then the cleaned one, without duplicates', () => {
+    expect(importQueryVariants({ producer: 'Bodegas Muga', wineName: 'Rioja Prado Enea Gran Reserva', appellation: 'Rioja' }))
+      .toEqual(['Bodegas Muga Rioja Prado Enea Gran Reserva', 'Bodegas Muga prado enea gran reserva']);
+    expect(importQueryVariants({ producer: 'Muga', wineName: 'Prado Enea', appellation: 'Rioja' })).toEqual(['Muga Prado Enea']);
+  });
+});
+
+describe('the vineyard-as-appellation guard', () => {
+  test('a Mosel row whose CT "appellation" is the single vineyard keeps the vineyard in the name', () => {
+    expect(stripAppellationPrefix('Wehlener Sonnenuhr Riesling Auslese', 'Wehlener Sonnenuhr')).toBeNull();
+    expect(stripAppellationPrefix('Wehlener Sonnenuhr Riesling Auslese Goldkapsel', 'Wehlener Sonnenuhr')).toBe('riesling auslese goldkapsel');
+    const registry = { name: 'Wehlener Sonnenuhr Riesling Auslese', producer: 'Joh. Jos. Prüm', appellation: 'Wehlener Sonnenuhr' };
+    expect(scoreWineMatchVariants(registry, { name: 'Wehlener Sonnenuhr Riesling Auslese', producer: 'Joh. Jos. Prüm', appellation: 'Wehlener Sonnenuhr' })).toBeGreaterThanOrEqual(EXACT);
+  });
+});

--- a/frontend/src/components/WineProposalsModal.js
+++ b/frontend/src/components/WineProposalsModal.js
@@ -372,7 +372,7 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
                 value={bulkReason}
                 onChange={(e) => setBulkReason(e.target.value)}
                 placeholder={t('admin.wines.proposals.bulkRejectPlaceholder')}
-                maxLength={500}
+                maxLength={2000}
                 disabled={!!pendingId}
                 style={{ flex: '1 1 220px', minWidth: 180 }}
               />
@@ -536,7 +536,7 @@ function WineProposalsModal({ apiFetch, onClose, onChanged }) {
                         value={rejectReason}
                         onChange={(e) => setRejectReason(e.target.value)}
                         placeholder={t('admin.wines.proposals.rejectPlaceholder')}
-                        maxLength={500}
+                        maxLength={2000}
                         disabled={!!pendingId}
                         style={{ flex: '1 1 220px', minWidth: 180 }}
                       />

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -871,6 +871,59 @@ export function splitClassificationFromName(wineName, { producer, appellation, r
   return { wineName: (producer || '').trim() || name, classification: tier };
 }
 
+// ── Appellation-first names (registry backlog 2026-09-06) ───────────────────
+//
+// CT composes "Wine" as producer + appellation + designation ("Bodegas Muga
+// Rioja Prado Enea Gran Reserva"). After the producer prefix goes, the name
+// still leads with the appellation while the registry keeps the designation
+// alone ("Prado Enea Gran Reserva"); a re-import of one such file re-created
+// its whole request queue. When the row's Appellation (or Region) opens the
+// name, drop it — unless what is left is a bare style word ("Reserva"), which
+// is not a name. CT's own Designation column, when present and matching the
+// remainder, is used verbatim so the file's spelling and case survive.
+const APPELLATION_TIER_WORDS = /\b(docg|doca|doc|dop|aoc|aop|igt|igp|ava|gi|do|vdp|vdqs)\b/g;
+// A remainder made only of styles and grapes is not a name: "Rioja Reserva"
+// → "Reserva", and a Mosel row whose CT Appellation is the single vineyard
+// ("Wehlener Sonnenuhr Riesling Auslese") must keep the vineyard, because
+// that is the wine's name. Mirrors services/wineMatching.js on the server.
+const GENERIC_NAME_WORDS = new Set([
+  'reserva', 'gran', 'grande', 'riserva', 'reserve', 'crianza', 'joven', 'classico', 'superiore',
+  'brut', 'extra', 'sec', 'demi', 'dry', 'trocken', 'feinherb', 'halbtrocken', 'kabinett', 'spatlese',
+  'auslese', 'beerenauslese', 'trockenbeerenauslese', 'eiswein', 'gg', 'grosses', 'groes', 'gewachs', 'erstes',
+  'rouge', 'blanc', 'rose', 'rosado', 'bianco', 'rosso', 'tinto', 'branco', 'red', 'white', 'sekt',
+  'riesling', 'chardonnay', 'pinot', 'noir', 'gris', 'grigio', 'blanco', 'sauvignon', 'merlot', 'cabernet',
+  'franc', 'syrah', 'shiraz', 'grenache', 'garnacha', 'tempranillo', 'sangiovese', 'nebbiolo', 'barbera',
+  'dolcetto', 'malbec', 'zinfandel', 'gewurztraminer', 'gruner', 'veltliner', 'chenin', 'viognier', 'muscat',
+  'moscato', 'mourvedre', 'carignan', 'gamay', 'mencia', 'garganega', 'albarino', 'alvarinho', 'verdejo',
+  'godello', 'touriga', 'nacional', 'franca', 'spatburgunder', 'weissburgunder', 'grauburgunder', 'silvaner',
+  'sylvaner', 'muller', 'thurgau', 'blaufrankisch', 'zweigelt', 'semillon', 'primitivo', 'aglianico',
+  'montepulciano', 'corvina', 'glera', 'trebbiano', 'vermentino', 'verdicchio', 'fiano', 'greco', 'nero',
+  'davola', 'carmenere', 'petit', 'verdot', 'roussanne', 'marsanne', 'cinsault', 'furmint', 'assyrtiko',
+]);
+const foldForPrefix = (s) => foldAccents(String(s || '')).toLowerCase().replace(/ß/g, 'ss').replace(/[^a-z0-9]+/g, ' ').trim();
+const isGenericRemainder = (folded) => folded.split(' ').filter(Boolean).every((t) => GENERIC_NAME_WORDS.has(t));
+
+export function stripAppellationPrefixFromName(wineName, { appellation, region, designation } = {}) {
+  const name = String(wineName || '').trim();
+  if (!name) return wineName;
+  const nameWords = name.split(/\s+/);
+  for (const hint of [appellation, region]) {
+    const head = foldForPrefix(hint).replace(APPELLATION_TIER_WORDS, ' ').replace(/\s+/g, ' ').trim();
+    if (!head) continue;
+    const headWords = head.split(' ');
+    if (headWords.length >= nameWords.length) continue;
+    const lead = foldForPrefix(nameWords.slice(0, headWords.length).join(' '));
+    if (lead !== head) continue;
+    const remainderWords = nameWords.slice(headWords.length);
+    const remainder = remainderWords.join(' ');
+    if (isGenericRemainder(foldForPrefix(remainder))) return name;
+    const des = String(designation || '').trim();
+    if (des && foldForPrefix(des) === foldForPrefix(remainder)) return des;
+    return remainder;
+  }
+  return name;
+}
+
 /** wineName + producer from a CT row (Producer column or heuristic). */
 function ctIdentity(get) {
   const rawWine = get(['Wine', 'wine', 'WineName']);
@@ -889,8 +942,9 @@ function ctCommonFields(get, { sizeKeys = ['Size'] } = {}) {
   const appellation = ctClean(get(['Appellation'])) || locale.appellation;
   // After producer-stripping, a Bordeaux Wine value can be pure tier
   // ("Grand Cru Classé") — route it to classification, never the name.
-  const { wineName, classification } = splitClassificationFromName(
+  const { wineName: tieredName, classification } = splitClassificationFromName(
     identity.wineName, { producer: identity.producer, appellation, region });
+  const wineName = stripAppellationPrefixFromName(tieredName, { appellation, region, designation: ctClean(get(['Designation', 'designation'])) });
   const rating = ctMyRating(get);
   return {
     wineName,

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -11,6 +11,7 @@ import {
   parseVivinoDrinkWindow,
   isVivinoScanHistory,
   splitClassificationFromName,
+  stripAppellationPrefixFromName,
 } from './importMappers';
 
 // ---------------------------------------------------------------------------
@@ -1044,5 +1045,30 @@ describe('classification reaches the mapped item', () => {
   it('generic rows: an explicit Classification column is honoured when the name is clean', () => {
     const { items } = parseAndMap('Wine,Producer,Classification,Vintage\nPavillon Rouge,Château Margaux,Second Vin,2018\n');
     expect(items[0]).toMatchObject({ wineName: 'Pavillon Rouge', classification: 'Second Vin' });
+  });
+});
+
+describe('stripAppellationPrefixFromName (registry backlog 2026-09-06)', () => {
+  it('drops an appellation that opens the name, keeping the file spelling', () => {
+    expect(stripAppellationPrefixFromName('Rioja Prado Enea Gran Reserva', { appellation: 'Rioja' })).toBe('Prado Enea Gran Reserva');
+    expect(stripAppellationPrefixFromName('Barolo Bricco Boschis', { appellation: 'Barolo' })).toBe('Bricco Boschis');
+    expect(stripAppellationPrefixFromName('Chianti Classico Castello di Fonterutoli Gran Selezione', { appellation: 'Chianti Classico DOCG' })).toBe('Castello di Fonterutoli Gran Selezione');
+    expect(stripAppellationPrefixFromName('Beaune 1er Cru Grèves Les Trois Journaux', { appellation: 'Beaune 1er Cru' })).toBe('Grèves Les Trois Journaux');
+  });
+  it('falls back to the region hint and prefers the Designation column verbatim', () => {
+    expect(stripAppellationPrefixFromName('Douro Xisto Cru Branco', { appellation: '', region: 'Douro' })).toBe('Xisto Cru Branco');
+    expect(stripAppellationPrefixFromName('Rioja Prado Enea Gran Reserva', { appellation: 'Rioja', designation: 'Prado Enea Gran Reserva' })).toBe('Prado Enea Gran Reserva');
+  });
+  it('leaves bare styles, whole-name hints and non-matching names alone', () => {
+    expect(stripAppellationPrefixFromName('Rioja Reserva', { appellation: 'Rioja' })).toBe('Rioja Reserva');
+    expect(stripAppellationPrefixFromName('Rioja', { appellation: 'Rioja' })).toBe('Rioja');
+    expect(stripAppellationPrefixFromName('Riojana Cuvée', { appellation: 'Rioja' })).toBe('Riojana Cuvée');
+    expect(stripAppellationPrefixFromName('Magari', { appellation: 'Bolgheri' })).toBe('Magari');
+    expect(stripAppellationPrefixFromName('', { appellation: 'Rioja' })).toBe('');
+  });
+  it('keeps a single-vineyard "appellation" in the name (Mosel rows)', () => {
+    // CT files the Einzellage as the Appellation; the registry keeps it in the name.
+    expect(stripAppellationPrefixFromName('Wehlener Sonnenuhr Riesling Auslese', { appellation: 'Wehlener Sonnenuhr', region: 'Mosel' })).toBe('Wehlener Sonnenuhr Riesling Auslese');
+    expect(stripAppellationPrefixFromName('Wehlener Sonnenuhr Riesling Auslese Goldkapsel', { appellation: 'Wehlener Sonnenuhr' })).toBe('Riesling Auslese Goldkapsel');
   });
 });


### PR DESCRIPTION
## Why

Numa's CellarTracker re-import on 2026-09-06 (19:28 UTC) created 44 pending wine requests, **all for wines that already existed** from the first import. Two habits of the file defeat the matcher:

- CT composes "Wine" as producer + appellation + designation, so after `stripProducerPrefix` the name still leads with the appellation: `Rioja Prado Enea Gran Reserva` vs the registry's `Prado Enea Gran Reserva` (name similarity 0.78).
- Producers carry a parenthetical the registry does not: `Ca' Marcanda (Gaja)` vs `Ca' Marcanda` (producer-key similarity 0.69), `Château Lagrange (St. Julien)` (0.38).

## What changes

**Server, `services/wineMatching.js`** — three more variants in `scoreWineMatchVariants`, still max()-ed over the raw score (monotonic): the name with its appellation or region prefix removed (hints from the row and from the candidate; legal-tier suffixes such as DOCG folded), the producer without a trailing parenthetical (on either side), and the name without one. A remainder consisting only of styles and grapes is never stripped, so `Wehlener Sonnenuhr Riesling Auslese` keeps its vineyard when CT files the Einzellage as the appellation. Exported helpers: `stripAppellationPrefix`, `stripProducerBrackets`, `importQueryVariants`.

**Server, `routes/import.js`** — Meilisearch is queried a second time with the cleaned identity when the raw query yields no candidate; the direct `normalizedKey` lookup adds the cleaned forms; `region` now reaches the scorer.

**Client, CellarTracker mapper** — `stripAppellationPrefixFromName` runs after the classification split: the appellation (or region) prefix is dropped at parse time, CT's Designation column is used verbatim when it equals the remainder, same style/grape guard.

**Reject reasons** — `WineCorrectionProposal`, `RegistryDataKey`, `RegistryDataValue` and the proposals modal allow 2000 characters (registry backlog item).

## Tests
- `wineMatching.variants.test.js`: six real rows from the re-import now reach the exact threshold (Muga, Magari, Cavallotto, Lagrange, Seabra with region hint only, Fonterutoli with a DOCG hint), the bracket on the registry side, two negatives (a sibling wine of the same producer stays below the soft zone; the same appellation-first name from another producer stays below exact), the Mosel vineyard guard, and the helpers.
- `importMappers.test.js`: the mapper helper on the same rows plus the guards.
- Backend: matcher + import route + model suites 16/16 (318 tests); frontend 91 files / 1212 tests; production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
