### PR TITLE
chore(release): v1.204.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.203.0",
+  "version": "1.204.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.203.0",
+      "version": "1.204.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.203.0",
+  "version": "1.204.0",
   "license": "AGPL-3.0",
   "description": "Wine cellar management backend",
   "main": "server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.203.0",
+  "version": "1.204.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.203.0",
+      "version": "1.204.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fontsource/inter": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.203.0",
+  "version": "1.204.0",
   "license": "AGPL-3.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for v1.204.0.

- #1239 registry lockdown phase 1: prose-only public payloads, per-reader read budgets, canary flag, member reads without curation internals, Registry Data Terms page
- #1240 security audit medium remediation, batch 1 (14 findings)
- #1241 import matching for appellation-first names and bracketed producers; longer reject reasons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
