### PR TITLE
fix(bottles): sibling photo fallback for waiting-request uploads; peak window readable over MCP

### DIFF
--- a/backend/src/mcp/toolUtil.bottleSummary.test.js
+++ b/backend/src/mcp/toolUtil.bottleSummary.test.js
@@ -1,0 +1,24 @@
+/**
+ * bottleSummary — the bottle line item every MCP list returns. Support ticket
+ * 2026-09-07: peak_from / peak_until are writable through update_bottle but
+ * were missing from every read, so an assistant could set them and never see
+ * them again.
+ */
+jest.mock('../utils/reservationUtils', () => ({ isReserved: () => false }));
+
+const { bottleSummary } = require('./toolUtil');
+
+test('the drink window and the peak pair both come back on a bottle summary', () => {
+  const out = bottleSummary({
+    _id: 'b1', wineDefinition: { name: 'Magari', producer: "Ca' Marcanda", type: 'red' },
+    vintage: '2019', status: 'active', cellar: 'c1',
+    drinkFrom: 2024, drinkTo: 2034, peakFrom: 2027, peakUntil: 2031,
+  });
+  expect(out).toMatchObject({ drink_from: 2024, drink_to: 2034, peak_from: 2027, peak_until: 2031 });
+});
+
+test('an unset peak reads as null, not undefined, so a client can tell "no window" from "field missing"', () => {
+  const out = bottleSummary({ _id: 'b2', wineDefinition: { name: 'X' }, vintage: 'NV', status: 'active', cellar: 'c1' });
+  expect(out.peak_from).toBeNull();
+  expect(out.peak_until).toBeNull();
+});

--- a/backend/src/mcp/toolUtil.js
+++ b/backend/src/mcp/toolUtil.js
@@ -128,6 +128,11 @@ function bottleSummary(b) {
     rating_scale: b.rating != null ? b.ratingScale : undefined,
     drink_from: b.drinkFrom ?? null,
     drink_to: b.drinkTo ?? null,
+    // The peak pair is writable through update_bottle and was missing from
+    // every read (support ticket 2026-09-07) — an assistant could set it and
+    // never see it again.
+    peak_from: b.peakFrom ?? null,
+    peak_until: b.peakUntil ?? null,
     opened_at: b.openedAt || undefined,
     // Only present when the bottle is "spoken for" — keeps unreserved rows lean.
     reserved: isReserved(b)

--- a/backend/src/mcp/tools/bottles.js
+++ b/backend/src/mcp/tools/bottles.js
@@ -212,6 +212,8 @@ async function buildBottleDetail(userId, bottleId) {
       rating_scale: b.rating != null ? b.ratingScale : null,
       drink_from: b.drinkFrom ?? null,
       drink_to: b.drinkTo ?? null,
+      peak_from: b.peakFrom ?? null,
+      peak_until: b.peakUntil ?? null,
       notes: b.notes || null,
       occasion: b.occasion || null,
       // "Spoken for" — null when unreserved. Reserved bottles are excluded

--- a/backend/src/routes/admin/wineRequests.js
+++ b/backend/src/routes/admin/wineRequests.js
@@ -3,6 +3,7 @@ const { requireAuth, requireRole } = require('../../middleware/auth');
 const WineRequest = require('../../models/WineRequest');
 const WineDefinition = require('../../models/WineDefinition');
 const Bottle = require('../../models/Bottle');
+const BottleImage = require('../../models/BottleImage');
 const { generateWineKey, normalizeAppellation, normalizeString } = require('../../utils/normalize');
 const { canonicalizeWineName } = require('../../utils/producerPrefix');
 const Country = require('../../models/Country');
@@ -253,12 +254,24 @@ router.put('/:id/resolve', async (req, res) => {
       // Capture the distinct vintages BEFORE the update unsets pendingWineRequest
       // — needed to seed the maturity queue once the wine is known.
       const pendingVintages = await Bottle.distinct('vintage', { pendingWineRequest: wineRequest._id });
+      const pendingBottleIds = await Bottle.distinct('_id', { pendingWineRequest: wineRequest._id });
 
       const result = await Bottle.updateMany(
         { pendingWineRequest: wineRequest._id },
         { $set: { wineDefinition: linkedWine._id }, $unset: { pendingWineRequest: '' } }
       );
       backfilledCount = result.modifiedCount || 0;
+
+      // Photos uploaded while these bottles waited for their wine carry no
+      // wineDefinition; stamp it now so the by-wine photo lookups (cellar
+      // list, bottle page) see them on every bottle of the wine (support
+      // ticket 2026-09-07). Best-effort — a failure here must not undo the link.
+      if (pendingBottleIds.length) {
+        BottleImage.updateMany(
+          { bottle: { $in: pendingBottleIds }, wineDefinition: null },
+          { $set: { wineDefinition: linkedWine._id } }
+        ).catch((err) => console.error('[wine-requests] image wine stamp failed:', err.message));
+      }
 
       // Now that these bottles have a real wineDefinition, put each wine+vintage
       // into the sommelier maturity queue — mirroring the hand-add and matched-

--- a/backend/src/routes/bottles.grapeDisplay.test.js
+++ b/backend/src/routes/bottles.grapeDisplay.test.js
@@ -54,7 +54,8 @@ jest.mock('../models/WineVintageProfile', () => ({ find: jest.fn() }));
 jest.mock('../models/PriceTrackingRequest', () => ({}));
 jest.mock('../models/BottleImage', () => ({ findOne: jest.fn(), findById: jest.fn() }));
 jest.mock('../models/WineRequest', () => ({}));
-jest.mock('../models/Bottle', () => ({ findById: jest.fn(), find: jest.fn() }));
+// find(): the sibling-bottle photo lookup (support ticket 2026-09-07) — empty here.
+jest.mock('../models/Bottle', () => ({ findById: jest.fn(), find: jest.fn(() => ({ select: () => ({ lean: async () => [] }) })) }));
 
 const express = require('express');
 const http = require('http');

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -525,6 +525,12 @@ router.get('/:id', requireBottleAccess('viewer'), async (req, res) => {
     const pendingImgOr = [{ bottle: bottle._id }];
     if (bottle.wineDefinition) {
       pendingImgOr.push({ wineDefinition: bottle.wineDefinition });
+      // The viewer's other bottles of the same wine: a photo uploaded while a
+      // bottle still waited for its wine request carries no wineDefinition,
+      // so only its bottle knows the wine (support ticket 2026-09-07 — same
+      // fix as the cellar list's attachBottleImageUrls).
+      const siblings = await Bottle.find({ user: req.user.id, wineDefinition: bottle.wineDefinition, _id: { $ne: bottle._id } }).select('_id').lean();
+      if (siblings.length) pendingImgOr.push({ bottle: { $in: siblings.map((s) => s._id) } });
     }
     const pendingImg = await BottleImage.findOne({
       $or: pendingImgOr,

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -529,8 +529,13 @@ router.get('/:id', requireBottleAccess('viewer'), async (req, res) => {
       // bottle still waited for its wine request carries no wineDefinition,
       // so only its bottle knows the wine (support ticket 2026-09-07 — same
       // fix as the cellar list's attachBottleImageUrls).
-      const siblings = await Bottle.find({ user: req.user.id, wineDefinition: bottle.wineDefinition, _id: { $ne: bottle._id } }).select('_id').lean();
-      if (siblings.length) pendingImgOr.push({ bottle: { $in: siblings.map((s) => s._id) } });
+      try {
+        const siblings = await Bottle.find({ user: req.user.id, wineDefinition: bottle.wineDefinition, _id: { $ne: bottle._id } }).select('_id').lean();
+        if (siblings.length) pendingImgOr.push({ bottle: { $in: siblings.map((s) => s._id) } });
+      } catch (err) {
+        // A photo nicety must never take the bottle page down.
+        console.error('Sibling photo lookup failed:', err.message);
+      }
     }
     const pendingImg = await BottleImage.findOne({
       $or: pendingImgOr,

--- a/backend/src/routes/bottles.pendingImage.test.js
+++ b/backend/src/routes/bottles.pendingImage.test.js
@@ -41,7 +41,8 @@ jest.mock('../models/PriceTrackingRequest', () => ({}));
 jest.mock('../models/PriceTrackingSkip', () => ({}));
 jest.mock('../models/BottleImage', () => ({ findOne: jest.fn(), findById: jest.fn() }));
 jest.mock('../models/WineRequest', () => ({}));
-jest.mock('../models/Bottle', () => ({ findById: jest.fn() }));
+// find(): the sibling-bottle lookup added for support ticket 2026-09-07 — empty here.
+jest.mock('../models/Bottle', () => ({ findById: jest.fn(), find: jest.fn(() => ({ select: () => ({ lean: async () => [] }) })) }));
 
 const Bottle = require('../models/Bottle');
 const Cellar = require('../models/Cellar');

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -348,9 +348,24 @@ async function attachBottleImageUrls(bottles, userId) {
   const wineIdOf = (b) => b.wineDefinition && (b.wineDefinition._id || b.wineDefinition);
   const wineIds = [...new Set(bottles.map(wineIdOf).filter(Boolean).map(String))];
 
+  // Sibling bottles: the viewer's OTHER bottles of the same wines, whether or
+  // not they are on this page. A photo uploaded while the bottle still waited
+  // for its wine request carries no wineDefinition at all (support ticket
+  // 2026-09-07: one of two identical bottles showed the photo, the other did
+  // not), so the by-wine arm never sees it — the photo's bottle is the only
+  // way to learn its wine.
+  const wineOfBottle = {};
+  for (const b of bottles) { const w = wineIdOf(b); if (w) wineOfBottle[b._id.toString()] = w.toString(); }
+  if (wineIds.length) {
+    const siblings = await Bottle.find({ user: userId, wineDefinition: { $in: wineIds } }).select('_id wineDefinition').lean();
+    for (const s of siblings) if (s.wineDefinition) wineOfBottle[s._id.toString()] = s.wineDefinition.toString();
+  }
+  const imageBottleIds = Object.keys(wineOfBottle).length ? Object.keys(wineOfBottle) : bottleIds.map(String);
+  for (const id of bottleIds.map(String)) if (!imageBottleIds.includes(id)) imageBottleIds.push(id);
+
   const pendingImages = await BottleImage.find({
     $or: [
-      { bottle: { $in: bottleIds } },
+      { bottle: { $in: imageBottleIds } },
       ...(wineIds.length ? [{ wineDefinition: { $in: wineIds } }] : []),
     ],
     uploadedBy: userId,
@@ -381,8 +396,10 @@ async function attachBottleImageUrls(bottles, userId) {
     if (img.bottle && !pendingByBottle[img.bottle.toString()]) {
       pendingByBottle[img.bottle.toString()] = url;
     }
-    if (img.wineDefinition && !pendingByWine[img.wineDefinition.toString()]) {
-      pendingByWine[img.wineDefinition.toString()] = url;
+    // The wine the photo belongs to: its own reference, else its bottle's.
+    const imgWine = (img.wineDefinition && img.wineDefinition.toString()) || (img.bottle && wineOfBottle[img.bottle.toString()]) || null;
+    if (imgWine && !pendingByWine[imgWine]) {
+      pendingByWine[imgWine] = url;
     }
   }
 

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -357,8 +357,13 @@ async function attachBottleImageUrls(bottles, userId) {
   const wineOfBottle = {};
   for (const b of bottles) { const w = wineIdOf(b); if (w) wineOfBottle[b._id.toString()] = w.toString(); }
   if (wineIds.length) {
-    const siblings = await Bottle.find({ user: userId, wineDefinition: { $in: wineIds } }).select('_id wineDefinition').lean();
-    for (const s of siblings) if (s.wineDefinition) wineOfBottle[s._id.toString()] = s.wineDefinition.toString();
+    try {
+      const siblings = await Bottle.find({ user: userId, wineDefinition: { $in: wineIds } }).select('_id wineDefinition').lean();
+      for (const s of siblings) if (s.wineDefinition) wineOfBottle[s._id.toString()] = s.wineDefinition.toString();
+    } catch (err) {
+      // A photo nicety must never take the cellar list down.
+      console.error('Sibling photo lookup failed:', err.message);
+    }
   }
   const imageBottleIds = Object.keys(wineOfBottle).length ? Object.keys(wineOfBottle) : bottleIds.map(String);
   for (const id of bottleIds.map(String)) if (!imageBottleIds.includes(id)) imageBottleIds.push(id);

--- a/backend/src/routes/cellars.pendingImage.test.js
+++ b/backend/src/routes/cellars.pendingImage.test.js
@@ -26,7 +26,10 @@ jest.mock('../utils/exchangeRates', () => ({
   getSnapshotsForDates: jest.fn(), getOrCreateDailySnapshot: jest.fn(), convertCurrency: jest.fn(),
 }));
 jest.mock('../models/Cellar', () => ({}));
-jest.mock('../models/Bottle', () => ({}));
+// Sibling lookup (support ticket 2026-09-07): the viewer's other bottles of
+// the same wines. Empty unless a test says otherwise.
+const mockBottleFind = jest.fn(() => ({ select: () => ({ lean: async () => [] }) }));
+jest.mock('../models/Bottle', () => ({ find: (...a) => mockBottleFind(...a) }));
 jest.mock('../models/Rack', () => ({}));
 jest.mock('../models/User', () => ({}));
 jest.mock('../models/AuditLog', () => ({}));
@@ -94,6 +97,33 @@ test('an approved own photo — public or private — still shows on the card', 
 
   const out = await attachBottleImageUrls([{ _id: B1, wineDefinition: WINE }], USER);
   expect(out[0].pendingImageUrl).toBe('/api/uploads/processed/approved.png');
+});
+
+test('a photo whose row carries no wine (uploaded while the bottle awaited its wine request) still reaches the sibling bottle', async () => {
+  // Support ticket 2026-09-07: two identical bottles, the photo pinned to
+  // B1 with wineDefinition null — B2 showed nothing.
+  BottleImage.find.mockReturnValue(chain([
+    { _id: 'noWineRef', wineDefinition: null, bottle: B1, status: 'approved', originalUrl: null, processedUrl: '/api/uploads/processed/b1.png' },
+  ]));
+  const out = await attachBottleImageUrls([
+    { _id: B1, wineDefinition: WINE },
+    { _id: B2, wineDefinition: WINE },
+  ], USER);
+  expect(out[0].pendingImageUrl).toBe('/api/uploads/processed/b1.png');
+  expect(out[1].pendingImageUrl).toBe('/api/uploads/processed/b1.png');
+});
+
+test('a sibling bottle that is NOT on this page still lends its photo, and only the viewer\'s own bottles are consulted', async () => {
+  const S1 = '64b0000000000000000000c1';
+  mockBottleFind.mockReturnValueOnce({ select: () => ({ lean: async () => [{ _id: S1, wineDefinition: WINE }] }) });
+  BottleImage.find.mockReturnValue(chain([
+    { _id: 'sib', wineDefinition: null, bottle: S1, status: 'approved', originalUrl: null, processedUrl: '/api/uploads/processed/s1.png' },
+  ]));
+  const out = await attachBottleImageUrls([{ _id: B2, wineDefinition: WINE }], USER);
+  expect(mockBottleFind).toHaveBeenCalledWith({ user: USER, wineDefinition: { $in: [WINE] } });
+  const query = BottleImage.find.mock.calls[0][0];
+  expect(query.$or[0].bottle.$in).toEqual(expect.arrayContaining([S1, B2]));
+  expect(out[0].pendingImageUrl).toBe('/api/uploads/processed/s1.png');
 });
 
 test('empty input is returned as-is without a query', async () => {

--- a/backend/src/scripts/backfill-image-wine-refs.js
+++ b/backend/src/scripts/backfill-image-wine-refs.js
@@ -1,0 +1,42 @@
+/**
+ * backfill-image-wine-refs.js
+ *
+ * Bottle photos uploaded while their bottle still waited for a wine request
+ * were stored without a wineDefinition, and nothing filled it in when the
+ * request was resolved — so the by-wine photo lookups never showed them on
+ * the owner's other bottles of the same wine (support ticket 2026-09-07:
+ * one of two identical bottles had the photo, the other did not). The
+ * resolve route stamps the wine now; this fills the rows created before.
+ *
+ * Sets BottleImage.wineDefinition from the photo's bottle where the row has
+ * none and the bottle has a wine. Dry run by default.
+ *
+ * Usage (container running):
+ *   docker exec cellarion-backend node src/scripts/backfill-image-wine-refs.js
+ *   docker exec cellarion-backend node src/scripts/backfill-image-wine-refs.js --apply
+ */
+require('dotenv').config();
+const mongoose = require('mongoose');
+const BottleImage = require('../models/BottleImage');
+const Bottle = require('../models/Bottle');
+
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://mongo:27017/winecellar';
+const APPLY = process.argv.includes('--apply');
+
+async function run() {
+  await mongoose.connect(MONGO_URI);
+  const rows = await BottleImage.find({ wineDefinition: null, bottle: { $ne: null } }).select('_id bottle').lean();
+  const bottleIds = [...new Set(rows.map((r) => String(r.bottle)))];
+  const bottles = await Bottle.find({ _id: { $in: bottleIds }, wineDefinition: { $ne: null } }).select('_id wineDefinition').lean();
+  const wineOf = new Map(bottles.map((b) => [String(b._id), b.wineDefinition]));
+  const fixable = rows.filter((r) => wineOf.has(String(r.bottle)));
+  console.log(`photos without a wine: ${rows.length} | with a bottle that has one: ${fixable.length}${APPLY ? '' : ' (dry run — pass --apply to write)'}`);
+  if (APPLY && fixable.length) {
+    const ops = fixable.map((r) => ({ updateOne: { filter: { _id: r._id, wineDefinition: null }, update: { $set: { wineDefinition: wineOf.get(String(r.bottle)) } } } }));
+    const res = await BottleImage.bulkWrite(ops, { ordered: false });
+    console.log(`stamped: ${res.modifiedCount}`);
+  }
+  await mongoose.disconnect();
+}
+
+run().catch((e) => { console.error('backfill-image-wine-refs failed:', e.message); process.exit(1); });


### PR DESCRIPTION
Two support tickets from 2026-09-07.

**Photo missing on one of two identical bottles.** Both cases on prod: the photo row carries `wineDefinition: null` because it was uploaded while the bottle still waited for its wine request, and the resolve route never stamped the wine afterwards. The by-wine arm of the photo lookups (`attachBottleImageUrls` in `routes/cellars.js`, the single-bottle route in `routes/bottles.js`) therefore never saw it.
- Both lookups now also consult the viewer's other bottles of the same wine and learn a photo's wine from its bottle, so bottle two borrows bottle one's photo.
- `PUT /api/admin/wine-requests/:id/resolve` stamps `wineDefinition` onto the waiting photos (best-effort, after the bottle link).
- `scripts/backfill-image-wine-refs.js` fixes the existing rows; dry run by default, `--apply` to write. Run once after deploy.

**peak_from / peak_until unreadable over MCP.** Writable through `update_bottle`, absent from `bottleSummary` and the `get_bottle` detail. Both now return them (null when unset).

Tests: `cellars.pendingImage.test.js` +2 (no-wine-ref photo reaches the sibling; off-page sibling lends its photo, only the viewer's bottles consulted), `bottles.pendingImage.test.js` mock extended, new `toolUtil.bottleSummary.test.js`. 45 suites / 662 tests pass including every MCP suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
