### PR TITLE
fix(curation): vintage cap, Prädikat on every mint, mirrored producers, unprofiled windows, missing vintages; ticket panel wraps

### DIFF
--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -2029,3 +2029,23 @@ describe('reset_maturity_row (6a944e46)', () => {
     expect(t.annotations.destructiveHint).toBe(true);
   });
 });
+
+describe('list_maturity_queue unprofiled (audit ticket 2026-09-06)', () => {
+  test('narrows to rows whose wine has no profile text, keeping the status filter', async () => {
+    WineDefinition.find.mockReturnValue({ select: () => ({ lean: async () => [{ _id: oid('a') }, { _id: oid('b') }] }) });
+    WineVintageProfile.countDocuments.mockResolvedValue(0);
+    WineVintageProfile.find.mockReturnValue(chain([]));
+    await tool('list_maturity_queue').handler({ status: 'reviewed', unprofiled: true }, SOMM_CTX);
+    expect(WineDefinition.find).toHaveBeenCalledWith({
+      $or: [{ 'aiProfile.description': { $in: [null, ''] } }, { 'aiProfile.description': { $exists: false } }],
+    });
+    const filter = WineVintageProfile.find.mock.calls.at(-1)[0];
+    expect(filter).toEqual({ status: 'reviewed', wineDefinition: { $in: [oid('a'), oid('b')] } });
+  });
+  test('wine_id wins over unprofiled — a wine lookup is never narrowed away', async () => {
+    WineVintageProfile.countDocuments.mockResolvedValue(0);
+    WineVintageProfile.find.mockReturnValue(chain([]));
+    await tool('list_maturity_queue').handler({ wine_id: oid('f'), unprofiled: true }, SOMM_CTX);
+    expect(WineVintageProfile.find.mock.calls.at(-1)[0]).toEqual({ wineDefinition: oid('f') });
+  });
+});

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -277,6 +277,9 @@ registerTool({
       .describe('Default: "pending" — or "all" when wine_id is given (a wine lookup wants every row)'),
     wine_id: objectId.optional().describe('Scope to one registry wine (from search_registry/get_wine/drink_window_for)'),
     vintage: z.string().min(1).max(10).optional().describe('With wine_id: one vintage, e.g. "2019" or "NV"'),
+    unprofiled: z.boolean().optional().describe(
+      'Only rows whose wine has NO tasting profile text. With status "reviewed" this finds windows that were written ' +
+      'onto a wine nothing describes — the pass that has to be finished with set_wine_profile.'),
     limit: z.number().int().min(1).max(50).default(20),
     offset: z.number().int().min(0).default(0),
   },
@@ -296,6 +299,16 @@ registerTool({
         // Same canonical vintage form set_vintage_maturity uses.
         filter.vintage = /^nv$/i.test(args.vintage.trim()) ? 'NV' : args.vintage.trim();
       }
+    } else if (args.unprofiled) {
+      // Windowed-but-unprofiled wines (audit ticket 2026-09-06): with
+      // automatic enrichment off, a window written onto a wine that has no
+      // description leaves the record incomplete for good unless a curator
+      // finds it. Wines without profile text are few hundred, so an id list
+      // keeps the page and the total honest.
+      const bare = await WineDefinition.find({
+        $or: [{ 'aiProfile.description': { $in: [null, ''] } }, { 'aiProfile.description': { $exists: false } }],
+      }).select('_id').lean();
+      filter.wineDefinition = { $in: bare.map((w) => w._id) };
     }
     const [total, pending, profiles] = await Promise.all([
       WineVintageProfile.countDocuments(filter),
@@ -475,7 +488,18 @@ registerTool({
       prev,
       result: envelope,
     });
-    return ok(envelope.summary, envelope.data);
+    // A window on a wine nothing describes leaves the record incomplete —
+    // and with automatic enrichment off, nobody but the curator will fill it
+    // (audit ticket 2026-09-06). Say so in the same breath. Best-effort.
+    const warnings = [];
+    try {
+      const wineId = profile.wineDefinition?._id || profile.wineDefinition;
+      const w = await WineDefinition.findById(wineId).select('aiProfile.description').lean();
+      if (w && !(w.aiProfile && w.aiProfile.description)) {
+        warnings.push('This wine has no tasting profile text — the window is saved, but nothing describes the wine. Write one with set_wine_profile while the research is fresh (list_maturity_queue unprofiled:true finds the others).');
+      }
+    } catch { /* the warning is a courtesy, never a failure */ }
+    return ok(envelope.summary, envelope.data, warnings.length ? { warnings } : undefined);
   },
 });
 

--- a/backend/src/routes/import.buildProposedWine.test.js
+++ b/backend/src/routes/import.buildProposedWine.test.js
@@ -295,3 +295,25 @@ describe('the complete-row bypass routes the Prädikat the same way', () => {
     expect(out.appellation).toBeNull();
   });
 });
+
+describe('a producer the model mirrored from an unknown name is a missing producer (audit ticket 2026-09-04)', () => {
+  it('drops a name-equals-producer answer when the file gave no producer', () => {
+    const out = buildProposedWine(ai({ name: 'Les Caractères', producer: 'Les Caractères' }), { producer: '', appellation: '' });
+    expect(out.producer).toBeNull();
+    expect(out.name).toBe('Les Caractères');
+  });
+  it('keeps an estate wine whose name IS the estate', () => {
+    const out = buildProposedWine(ai({ name: 'Château Talbot', producer: 'Château Talbot' }), { producer: '' });
+    expect(out.producer).toBe('Château Talbot');
+    const out2 = buildProposedWine(ai({ name: 'Weingut Herztal', producer: 'Weingut Herztal' }), { producer: '' });
+    expect(out2.producer).toBe('Weingut Herztal');
+  });
+  it('keeps the producer when the file itself stated it, even if it equals the name', () => {
+    const out = buildProposedWine(ai({ name: 'Les Caractères', producer: 'Les Caractères' }), { producer: 'Les Caractères' });
+    expect(out.producer).toBe('Les Caractères');
+  });
+  it('keeps a producer that differs from the name', () => {
+    const out = buildProposedWine(ai({ name: 'En Toute Intimité', producer: 'Domaine Gayda' }), { producer: '' });
+    expect(out.producer).toBe('Domaine Gayda');
+  });
+});

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -147,7 +147,13 @@ function buildProposedWine(aiData, item) {
 
   return {
     name: aiData.name,
-    producer: aiData.producer,
+    // A file with no producer column gets its producer from the model, and
+    // the model — told a name-equals-producer estate wine is fine — sometimes
+    // mirrors an unknown cuvée name back as the producer ("Les Caractères" /
+    // "Les Caractères", boubou17's CSV; audit ticket 2026-09-04). That is a
+    // missing producer, not a producer: leave it empty so the row mints as a
+    // pending identity for a curator, unless the name itself is an estate.
+    producer: producerMirroredFromName(aiData, item) ? null : aiData.producer,
     // Country keeps the AI's value first: it is fed the file's country as a
     // hint and normalizes local-language names ("Deutschland" → "Germany"),
     // which the raw column does not. The file is the fallback, which is new —
@@ -352,6 +358,18 @@ function typeFromFileGrapes(grapes, grapeColourOf) {
   }
   if (colours.size !== 1) return null;              // silent or contradictory → AI
   return colours.has('Red') ? 'red' : 'white';
+}
+
+// Estate names legitimately double as the wine name ("Château Talbot").
+const ESTATE_WORD_RE = /^(ch[âa]teau|domaine|clos|quinta|tenuta|castello|weingut|bodegas?|mas|cascina|fattoria|azienda|cantina|villa|podere|finca|casa|ch\.)\b/i;
+function producerMirroredFromName(aiData, item) {
+  const str = (v) => (typeof v === 'string' ? v.trim() : '');
+  if (str(item && item.producer)) return false;                  // the file said it — keep it
+  const name = str(aiData && aiData.name);
+  const producer = str(aiData && aiData.producer);
+  if (!name || !producer) return false;
+  if (normalizeString(name) !== normalizeString(producer)) return false;
+  return !ESTATE_WORD_RE.test(name);
 }
 
 function fileCompleteIdentity(item, grapeColourOf) {

--- a/backend/src/services/findOrCreateWine.js
+++ b/backend/src/services/findOrCreateWine.js
@@ -27,7 +27,7 @@ const { buildSurfaceForms, inferGrapeIds } = require('./grapeInference');
 const { isLabelVariant, grapeTokenSet } = require('./labelVariantMatch');
 const { resolveCanonicalProducerSpelling } = require('./producerSpelling');
 const { resolveCanonicalAppellation, candidateKeys } = require('./appellationResolve');
-const { conflictingStyleTerms } = require('../utils/styleTerms');
+const { conflictingStyleTerms, pradikatOnlyValue, pradikatContradictsName } = require('../utils/styleTerms');
 const { escapeRegex } = require('../utils/sanitize');
 
 // Auto-match when combined score >= SIMILARITY_THRESHOLD (near-identical — e.g.
@@ -357,8 +357,22 @@ async function findOrCreateWine({ name, producer, country, region, appellation, 
   // one (strategy R2) — BEFORE key generation, so a synonym ("Chateauneuf du
   // Pape") produces the same normalizedKey as the canonical form and the
   // exact-match stage collapses them instead of minting a sibling.
+  // A ripeness Prädikat is not a place. The import paths already route a bare
+  // "Kabinett"/"Auslese" out of the appellation (PR #1173); the add-bottle
+  // form did not, and a Weingut Herztal record arrived with appellation
+  // "Kabinett" (audit ticket 2026-09-03). Same rule for every mint: the word
+  // leaves the appellation, and moves to classification only when the name
+  // does not contradict it (a Trockenbeerenauslese on a "Trocken" is dropped).
+  let appellationIn = typeof appellation === 'string' ? appellation.trim() : '';
+  const pradikat = pradikatOnlyValue(appellationIn);
+  if (pradikat) {
+    appellationIn = '';
+    if (!(typeof classification === 'string' && classification.trim()) && !pradikatContradictsName(pradikat, trimmedName)) {
+      classification = pradikat;
+    }
+  }
   let trimmedAppellation = await resolveCanonicalAppellation(
-    normalizeAppellation((typeof appellation === 'string' ? appellation.trim() : '')).slice(0, MAX_FIELD)
+    normalizeAppellation(appellationIn).slice(0, MAX_FIELD)
   );
 
   // 0. Registry canon: the registry is vintage-neutral — a trailing year on

--- a/backend/src/services/findOrCreateWine.test.js
+++ b/backend/src/services/findOrCreateWine.test.js
@@ -1367,3 +1367,25 @@ describe('findOrCreateWine — label variants are caught even on confirmCreate',
     void realFind;
   });
 });
+
+describe('findOrCreateWine — a ripeness Prädikat is not an appellation (audit ticket 2026-09-03)', () => {
+  // The import paths already routed a bare Prädikat out of the appellation
+  // (PR #1173); the add-bottle form did not, and a Weingut Herztal record
+  // arrived with appellation "Kabinett". Every mint now applies the rule.
+  test('a bare Prädikat leaves the appellation and lands in classification', async () => {
+    await findOrCreateWine({ ...INPUT, name: 'Spätburgunder Rotwein Kabinett Trocken', appellation: 'Kabinett' }, USER_ID);
+    const doc = WineDefinition.mock.calls[0][0];
+    expect(doc.appellation || '').toBe('');
+    expect(doc.classification).toBe('Kabinett');
+  });
+  test('a Prädikat the name contradicts is dropped, not rescued', async () => {
+    await findOrCreateWine({ ...INPUT, name: 'Riesling Trocken', appellation: 'Trockenbeerenauslese' }, USER_ID);
+    const doc = WineDefinition.mock.calls[0][0];
+    expect(doc.appellation || '').toBe('');
+    expect(doc.classification || undefined).toBeUndefined();
+  });
+  test('a stated classification is kept over the rescued Prädikat', async () => {
+    await findOrCreateWine({ ...INPUT, name: 'Riesling Kabinett', appellation: 'Kabinett', classification: 'VDP.Gutswein' }, USER_ID);
+    expect(WineDefinition.mock.calls[0][0].classification).toBe('VDP.Gutswein');
+  });
+});

--- a/backend/src/utils/validation.js
+++ b/backend/src/utils/validation.js
@@ -47,11 +47,14 @@ const MIN_VINTAGE_YEAR = 1900;
  * apply to neither, but the somm queue treats them differently — NV gets
  * a profile so somms can attach drinking notes, Unknown does not.
  *
- * The upper bound floats with the current year (current + 5) so future
- * en primeur releases stay accepted without code changes.
+ * The upper bound is the CURRENT year. A later vintage cannot exist — the
+ * grapes have not grown — and the old "+5 for en primeur" allowance let a
+ * 2026 Italian frizzante be recorded in August 2026 with a confident AI
+ * tasting note (support ticket 2026-08-20). En primeur is a purchase of a
+ * past harvest (a 2025 Bordeaux bought in 2026), so it still passes.
  *
  * Accepts numbers, strings, and trims whitespace. Rejects anything that
- * isn't an integer year in [MIN_VINTAGE_YEAR, currentYear+5], the literal
+ * isn't an integer year in [MIN_VINTAGE_YEAR, currentYear], the literal
  * "NV", the literal "Unknown", or blank.
  */
 function parseAndValidateVintage(raw, { now = new Date() } = {}) {
@@ -70,7 +73,7 @@ function parseAndValidateVintage(raw, { now = new Date() } = {}) {
   }
 
   const year = parseInt(str, 10);
-  const maxYear = now.getFullYear() + 5;
+  const maxYear = now.getFullYear();
   if (year < MIN_VINTAGE_YEAR || year > maxYear) {
     return {
       ok: false,

--- a/backend/src/utils/validation.test.js
+++ b/backend/src/utils/validation.test.js
@@ -91,10 +91,12 @@ describe('parseAndValidateVintage', () => {
     expect(parseAndValidateVintage('-2018', { now }).ok).toBe(false);
   });
 
-  it('rejects years more than 5 ahead of current year', () => {
-    // currentYear = 2026, max = 2031
-    expect(parseAndValidateVintage('2031', { now }).ok).toBe(true);
-    expect(parseAndValidateVintage('2032', { now }).ok).toBe(false);
+  it('rejects any year after the current one — a vintage cannot exist before its harvest (support ticket 2026-08-20)', () => {
+    // currentYear = 2026: this year's harvest may be recorded, next year's cannot.
+    expect(parseAndValidateVintage('2026', { now }).ok).toBe(true);
+    expect(parseAndValidateVintage('2025', { now }).ok).toBe(true); // en primeur of a past harvest
+    expect(parseAndValidateVintage('2027', { now }).ok).toBe(false);
+    expect(parseAndValidateVintage('2031', { now }).ok).toBe(false);
     expect(parseAndValidateVintage('9999', { now }).ok).toBe(false);
   });
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3955,6 +3955,7 @@
       "tooManyRowsTitle": "{{count}} rows — more than one import run can take.",
       "tooManyRows": "Imports are capped at {{max}} rows per run. Split the file and import the parts one at a time (the destination choice applies per file), or skip rows during review — anything above the cap is refused at the final step.",
       "ctTruncatedTitle": "Only 25 rows found — this export may be cut off.",
+      "vintageMissing": "{{count}} rows have no vintage in the file. Type the year where you know it, or leave it as NV for non-vintage wines.",
       "ctTruncated": "This looks like a single-page export (exactly 25 rows). In CellarTracker, choose 'All wines' instead of 'Only wines on this page' before exporting, or your import may be missing most of your cellar.",
       "ctPendingSkipped_one": "{{count}} pending (undelivered) bottle was not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery.",
       "ctPendingSkipped_other": "{{count}} pending (undelivered) bottles were not imported: {{wines}}. Cellarion doesn't track bottles you haven't received yet — re-import after delivery.",
@@ -4131,6 +4132,8 @@
       "country": "Country",
       "type": "Type",
       "price": "Price",
+      "vintageMissing": "no vintage in file",
+      "vintageInputAria": "Vintage year for this row",
       "nv": "NV"
     },
     "validate": {

--- a/frontend/src/pages/AdminSupportTickets.css
+++ b/frontend/src/pages/AdminSupportTickets.css
@@ -166,33 +166,46 @@
   border-radius: var(--radius-md);
   background: var(--color-surface);
   padding: 20px;
+  /* A flex child defaults to min-width:auto, so an unbreakable token in the
+     subject ("suggest_wine_correction") widened the panel past the phone
+     screen and clipped the badges and every line below (Johan, 2026-09-07). */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .admin-support-detail-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: 8px 12px;
   margin-bottom: 8px;
 }
 
 .admin-support-detail-header h2 {
   margin: 0;
   font-size: 1.1rem;
+  flex: 1 1 220px;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .admin-support-detail-badges {
   display: flex;
+  flex-wrap: wrap;
   gap: 6px;
   flex-shrink: 0;
 }
 
 .admin-support-detail-meta {
   display: flex;
-  gap: 16px;
+  flex-wrap: wrap;
+  gap: 4px 16px;
   font-size: 0.8rem;
   color: var(--color-text-muted);
   margin-bottom: 16px;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .admin-support-message,

--- a/frontend/src/pages/AdminSupportTickets.css
+++ b/frontend/src/pages/AdminSupportTickets.css
@@ -171,6 +171,10 @@
      screen and clipped the badges and every line below (Johan, 2026-09-07). */
   min-width: 0;
   overflow-wrap: anywhere;
+  /* Target of the phone scroll-into-view in AdminSupportTickets.js. The navbar
+     is sticky (56px logo + 2 x 0.5rem padding + border, about 73px, plus the
+     status-bar inset on an installed PWA), so leave that much above the card. */
+  scroll-margin-top: calc(80px + env(safe-area-inset-top, 0px));
 }
 
 .admin-support-detail-header {

--- a/frontend/src/pages/AdminSupportTickets.js
+++ b/frontend/src/pages/AdminSupportTickets.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { adminGetSupportTickets, adminRespondToTicket, adminUpdateTicketStatus } from '../api/admin';
 import './AdminSupportTickets.css';
@@ -33,8 +33,23 @@ function AdminSupportTickets() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
+  const detailRef = useRef(null);
 
   const LIMIT = 20;
+
+  // On a phone the list sits above the detail (one grid column at 768px and
+  // below), so a tap on a ticket rendered the conversation below the fold and
+  // nothing visibly happened. Bring the panel up under the sticky navbar (the
+  // CSS sets scroll-margin-top for it). Keyed on the id so a reply or a status
+  // change on the open ticket does not scroll again; desktop keeps both
+  // columns in view and never scrolls.
+  useEffect(() => {
+    const el = detailRef.current;
+    if (!selected || !el || typeof el.scrollIntoView !== 'function' || !window.matchMedia) return;
+    if (!window.matchMedia('(max-width: 768px)').matches) return;
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollIntoView({ block: 'start', behavior: reduce ? 'auto' : 'smooth' });
+  }, [selected?._id]);
 
   useEffect(() => {
     fetchTickets();
@@ -163,7 +178,7 @@ function AdminSupportTickets() {
           )}
         </div>
 
-        <div className="admin-support-detail">
+        <div className="admin-support-detail" ref={detailRef}>
           {!selected ? (
             <p className="admin-support-placeholder">Select a ticket to view details</p>
           ) : (

--- a/frontend/src/pages/AdminSupportTickets.test.js
+++ b/frontend/src/pages/AdminSupportTickets.test.js
@@ -1,0 +1,93 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import AdminSupportTickets from './AdminSupportTickets';
+
+// On a phone the ticket list sits above the detail panel, so opening a ticket
+// used to render the conversation below the fold with no visible change. The
+// page now scrolls the panel into view on narrow screens only, once per
+// ticket (Johan, 2026-09-07).
+
+const apiFetch = vi.fn();
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ apiFetch }) }));
+
+const getTickets = vi.fn();
+const respond = vi.fn();
+const updateStatus = vi.fn();
+vi.mock('../api/admin', () => ({
+  adminGetSupportTickets: (...a) => getTickets(...a),
+  adminRespondToTicket: (...a) => respond(...a),
+  adminUpdateTicketStatus: (...a) => updateStatus(...a),
+}));
+
+const jsonRes = (body, ok = true) => ({ ok, json: () => Promise.resolve(body) });
+
+const TICKET = {
+  _id: 't1',
+  subject: 'MCP: suggest_wine_correction cannot correct grape varieties',
+  message: 'The tool accepts producer and name but not grapes.',
+  category: 'feature',
+  status: 'open',
+  createdAt: '2026-09-06T08:00:00.000Z',
+  user: { username: 'reporter', email: 'reporter@example.com' },
+  replies: [],
+};
+
+let scrollIntoView;
+let narrow;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getTickets.mockResolvedValue(jsonRes({ tickets: [TICKET], total: 1 }));
+  scrollIntoView = vi.fn();
+  Element.prototype.scrollIntoView = scrollIntoView;
+  narrow = true;
+  window.matchMedia = vi.fn((query) => ({
+    matches: query.includes('max-width') ? narrow : false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+});
+
+afterEach(() => {
+  delete Element.prototype.scrollIntoView;
+  delete window.matchMedia;
+});
+
+async function openFirstTicket() {
+  render(<AdminSupportTickets />);
+  const item = await screen.findByRole('button', { name: /suggest_wine_correction/ });
+  fireEvent.click(item);
+  await screen.findByRole('heading', { level: 2, name: TICKET.subject });
+}
+
+test('opening a ticket on a narrow screen scrolls the detail panel into view', async () => {
+  await openFirstTicket();
+  expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start', behavior: 'smooth' });
+  // The call came from the detail panel, not the list row.
+  expect(scrollIntoView.mock.contexts[0]).toHaveClass('admin-support-detail');
+});
+
+test('a reply on the open ticket does not scroll again', async () => {
+  await openFirstTicket();
+  respond.mockResolvedValue(jsonRes({
+    ticket: { ...TICKET, status: 'in_progress', replies: [{ author: 'admin', message: 'Working on it now.', createdAt: '2026-09-07T06:00:00.000Z' }] },
+  }));
+  fireEvent.change(screen.getByPlaceholderText(/write your response/i), { target: { value: 'On it.' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Send Response' }));
+  await screen.findByText('Response sent.');
+  expect(screen.getByText('Working on it now.')).toBeInTheDocument();
+  expect(scrollIntoView).toHaveBeenCalledTimes(1);
+});
+
+test('a wide screen keeps both columns in view and never scrolls', async () => {
+  narrow = false;
+  await openFirstTicket();
+  expect(scrollIntoView).not.toHaveBeenCalled();
+});
+
+test('respects a reduced-motion preference', async () => {
+  window.matchMedia = vi.fn((query) => ({ matches: true, media: query, addEventListener: () => {}, removeEventListener: () => {} }));
+  await openFirstTicket();
+  expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start', behavior: 'auto' });
+});

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1621,3 +1621,7 @@
 .done-partial-note {
   color: #bf8a2e;
 }
+
+/* Import review: a row whose file had no vintage (audit ticket 2026-09-05) */
+.review-vintage-input { width: 5.5em; padding: 2px 6px; font: inherit; font-size: 0.85em; border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: var(--color-surface); color: var(--color-text); }
+.import-flag { color: var(--color-warning, #b8860b); font-weight: 600; cursor: help; }

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -1045,6 +1045,7 @@ function ImportBottles() {
             wines: (w.wines || []).join(', ')
           })}
           {w.code === 'no-identity-skipped' && t('importBottles.warnings.noIdentitySkipped', { count: w.count })}
+          {w.code === 'vintage-missing' && t('importBottles.warnings.vintageMissing', { count: w.count })}
           {w.code === 'extra-files-ignored' && t('importBottles.warnings.extraFilesIgnored', { count: w.count })}
           {w.code === 'ploc-placed' && t('importBottles.warnings.plocPlaced', { count: w.count, racks: w.racks })}
           {w.code === 'ploc-history' && t('importBottles.warnings.plocHistory', { count: w.count })}
@@ -1625,7 +1626,10 @@ function ImportBottles() {
                   <tr key={i}>
                     <td>{item.producer || '—'}</td>
                     <td>{item.wineName || '—'}</td>
-                    <td>{item.vintage || t('importBottles.preview.nv')}</td>
+                    <td>
+                      {item.vintage || t('importBottles.preview.nv')}
+                      {item.vintageMissing && <span className="import-flag" title={t('importBottles.preview.vintageMissing')}> ?</span>}
+                    </td>
                     <td>{item.country || '—'}</td>
                     <td>
                       <span className="type-dot" style={{ background: TYPE_DOTS[item.type] || '#888' }} />
@@ -1923,7 +1927,25 @@ function ImportBottles() {
                         <strong>{r.item.producer}</strong>
                         <span>{r.item.wineName}</span>
                         <span className="source-meta">
-                          {r.item.vintage || t('importBottles.preview.nv')}
+                          {r.item.vintageMissing ? (
+                            // The file had no vintage for this row (audit ticket
+                            // 2026-09-05): say so, and take the year right here.
+                            <input
+                              type="text"
+                              inputMode="numeric"
+                              className="review-vintage-input"
+                              placeholder={t('importBottles.preview.vintageMissing')}
+                              aria-label={t('importBottles.preview.vintageInputAria')}
+                              value={r.item.vintage === 'NV' ? '' : (r.item.vintage || '')}
+                              maxLength={4}
+                              onChange={(e) => {
+                                const v = e.target.value.replace(/[^0-9]/g, '');
+                                setResults(prev => prev.map(x => x.index === r.index
+                                  ? { ...x, item: { ...x.item, vintage: v || 'NV' } }
+                                  : x));
+                              }}
+                            />
+                          ) : (r.item.vintage || t('importBottles.preview.nv'))}
                           {r.item.country && ` · ${r.item.country}`}
                         </span>
                       </div>

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -558,7 +558,7 @@ function mapVivinoRow(row) {
   return {
     wineName: get(['Wine name', 'Wine Name', 'wine name', 'Wine', 'wine']),
     producer: get(['Winery', 'winery', 'Producer', 'producer']),
-    vintage: get(['Vintage', 'vintage', 'Year', 'year']) || 'NV',
+    ...vintageOrNV(get(['Vintage', 'vintage', 'Year', 'year'])),
     country: get(['Country', 'country']),
     region: get(['Region', 'region']),
     appellation: get(['Appellation', 'appellation']),
@@ -612,6 +612,14 @@ function ctClean(value) {
 }
 
 /** Vintage: 1001 → 'NV' (CT's non-vintage sentinel), 9999/blank → ''. */
+// A missing vintage is filed as NV — but flagged, so the review can say so and
+// let the importer type the year. Silent NV on 85 vintage-dated bottles in one
+// file was the whole problem (audit ticket 2026-09-05).
+function vintageOrNV(raw) {
+  const v = String(raw || '').trim();
+  return v ? { vintage: v } : { vintage: 'NV', vintageMissing: true };
+}
+
 function ctVintage(value) {
   const s = (value || '').trim();
   if (s === '1001') return 'NV';
@@ -950,7 +958,7 @@ function ctCommonFields(get, { sizeKeys = ['Size'] } = {}) {
     wineName,
     producer: identity.producer,
     classification,
-    vintage: ctVintage(get(['Vintage'])) || 'NV',
+    ...vintageOrNV(ctVintage(get(['Vintage']))),
     country: get(['Country']) || locale.country,
     region,
     appellation,
@@ -1116,7 +1124,7 @@ function mapCellarTrackerRow(row) {
   return {
     wineName,
     producer,
-    vintage: ctVintage(get(['Vintage', 'vintage', 'Year'])) || 'NV',
+    ...vintageOrNV(ctVintage(get(['Vintage', 'vintage', 'Year']))),
     country: get(['Country', 'country']) || locale.country,
     region: get(['Region', 'region', 'Sub-Region']) || locale.region,
     appellation: ctClean(get(['Appellation', 'appellation', 'SubRegion'])) || locale.appellation,
@@ -1166,7 +1174,7 @@ function mapGenericRow(row) {
     wineName,
     producer,
     classification: classification || get(['Classification', 'classification']) || undefined,
-    vintage: get(['Vintage', 'vintage', 'Year', 'year']) || 'NV',
+    ...vintageOrNV(get(['Vintage', 'vintage', 'Year', 'year'])),
     country: get(['Country', 'country']),
     region,
     appellation,
@@ -1210,7 +1218,7 @@ function mapCellarionRow(row) {
     quantity: isNaN(qty) || qty < 1 ? 1 : qty,
     wineName: str('wineName'),
     producer: str('producer'),
-    vintage: str('vintage') || 'NV',
+    ...vintageOrNV(str('vintage')),
     country: str('country'),
     region: str('region'),
     appellation: str('appellation'),
@@ -2274,6 +2282,10 @@ export function parseAndMap(text, forceFormat, opts = {}) {
   }
   if (noIdentitySkipped > 0) {
     warnings.push({ code: 'no-identity-skipped', count: noIdentitySkipped });
+  }
+  const vintageMissing = items.filter((it) => it.vintageMissing).length;
+  if (vintageMissing > 0) {
+    warnings.push({ code: 'vintage-missing', count: vintageMissing });
   }
 
   return {

--- a/frontend/src/utils/importMappers.test.js
+++ b/frontend/src/utils/importMappers.test.js
@@ -1072,3 +1072,17 @@ describe('stripAppellationPrefixFromName (registry backlog 2026-09-06)', () => {
     expect(stripAppellationPrefixFromName('Wehlener Sonnenuhr Riesling Auslese Goldkapsel', { appellation: 'Wehlener Sonnenuhr' })).toBe('Riesling Auslese Goldkapsel');
   });
 });
+
+describe('a row without a vintage is filed as NV but flagged (audit ticket 2026-09-05)', () => {
+  it('sets vintageMissing on the item and reports one warning with the count', () => {
+    const csv = 'Wine name,Producer,Vintage,Country\nPrado Enea Gran Reserva,Muga,,Spain\nBrut Réserve,Pol Roger,NV,France\nBarolo,Vajra,2019,Italy\n';
+    const out = parseAndMap(csv);
+    expect(out.items).toHaveLength(3);
+    expect(out.items[0].vintage).toBe('NV');
+    expect(out.items[0].vintageMissing).toBe(true);
+    expect(out.items[1].vintage).toBe('NV');
+    expect(out.items[1].vintageMissing).toBeUndefined();
+    expect(out.items[2].vintage).toBe('2019');
+    expect(out.warnings).toEqual(expect.arrayContaining([{ code: 'vintage-missing', count: 1 }]));
+  });
+});


### PR DESCRIPTION
Items 6–10 of the 2026-09-07 support triage plus the admin ticket-panel overflow Johan spotted on mobile.

| Ticket | Change |
|---|---|
| 6a876088 future vintage | `parseAndValidateVintage` upper bound is now the current year (was +5). Reaches bottle create/update (`bottleOps`), import confirm, MCP `bulk_add`/`add_bottle`. En primeur of a past harvest still passes. |
| 6a993a30 Prädikat in appellation | `findOrCreateWine` applies `pradikatOnlyValue` on every mint: the word leaves the appellation and becomes the classification unless the name contradicts it (`pradikatContradictsName`) or a classification was stated. The Herztal record's correction (Baden / Baden) was approved on prod. |
| 6a9a752e mirrored producer | `buildProposedWine` treats a model answer with producer == name as a missing producer when the file gave none and the name is not estate-worded, so the row mints as a pending identity. The two existing records still need a curator (listed in the ticket). |
| 6a980a44 profile-less windows | `list_maturity_queue` gains `unprofiled: true` (rows whose wine has no profile text, honest total); `set_vintage_maturity` returns a warning when the wine has no profile. |
| 6a9c5207 NV default | Mappers flag rows whose file has no vintage (`vintageMissing`) and emit a `vintage-missing` warning; the import review shows the count and an inline year field on those rows; NV is still the fallback when the field is left empty. |
| Ticket panel overflow | `.admin-support-detail` and its header/meta wrap; the subject gets `min-width: 0` + `overflow-wrap: anywhere`. |

Tests: validator (new bound), `buildProposedWine` (+4), `findOrCreateWine` (+3 Prädikat cases), `sommTools` (+2 unprofiled), `importMappers` (+1); all import route suites pass (the cause of an early failure was a helper reaching a function-scoped `clean`, now self-contained). Frontend 91 files / 1213 tests and the production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Ticket page on phones (follow-up commit)
- Opening a ticket below 768px now scrolls the detail panel under the navbar, once per ticket, `smooth` unless the viewer prefers reduced motion. Before, the list filled the screen and a tap showed nothing until you scrolled.
- The wrap fix was verified with a headless render of the page at 360 px and 412 px content width: before, the card's right edge sat 46 to 167 px past the container and the page scrolled sideways; after, it sits exactly inside and the scroll width equals the client width.
- New `AdminSupportTickets.test.js`: narrow scrolls, a reply on the open ticket does not scroll again, wide never scrolls, reduced motion uses `auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
