### PR TITLE
fix(audit): v1.205.0 review — unchanged vintages stay editable, lot undo retryable, own photos never truncated, indexed rack join

### DIFF
--- a/backend/src/mcp/lotUpdate.test.js
+++ b/backend/src/mcp/lotUpdate.test.js
@@ -48,6 +48,7 @@ jest.mock('../services/bottleLot', () => {
   const LOT_FIELDS = ['drinkFrom', 'drinkTo', 'peakFrom', 'peakUntil', 'price', 'currency'];
   return {
     LOT_FIELDS,
+    LOT_LIMIT: 500,
     findLotSiblings: jest.fn(),
     pickLotFields: (fields) => Object.fromEntries(LOT_FIELDS.filter((k) => fields[k] !== undefined).map((k) => [k, fields[k]])),
   };
@@ -171,5 +172,28 @@ describe('update_bottle apply_to_lot', () => {
     expect(findLotSiblings).not.toHaveBeenCalled();
     expect(body.data.lot).toBeUndefined();
     expect(McpActionLog.create.mock.calls[0][0]).toMatchObject({ action: 'update', prev: { drinkTo: 2035 } });
+  });
+});
+
+describe('apply_to_lot guards (audit 2026-09-07)', () => {
+  test("a price without a currency carries this bottle's currency to the siblings", async () => {
+    Bottle.findById.mockReturnValue(chain({ _id: new mongoose.Types.ObjectId(oid('d')), cellar: new mongoose.Types.ObjectId(oid('c')), status: 'active', vintage: '2019', currency: 'SEK' }));
+    Cellar.findById.mockReturnValue(chain({ _id: oid('c'), user: ME, members: [], deletedAt: null, name: 'Mine' }));
+    findLotSiblings.mockResolvedValue([sib('1')]);
+    bottleOps.updateBottleFields
+      .mockResolvedValueOnce(changed({ price: 350 }, { price: 300 }))
+      .mockResolvedValueOnce(changed({ price: 350, currency: 'SEK' }, { price: 20, currency: 'USD' }));
+    await tool('update_bottle').handler({ bottle_id: oid('d'), price: 350, apply_to_lot: true }, CTX);
+    expect(bottleOps.updateBottleFields.mock.calls[1][1]).toEqual({ price: 350, currency: 'SEK' });
+  });
+
+  test('from a bottle in a cellar shared with the user, the lot is skipped with a warning', async () => {
+    Bottle.findById.mockReturnValue(chain({ _id: new mongoose.Types.ObjectId(oid('d')), cellar: new mongoose.Types.ObjectId(oid('c')), status: 'active', vintage: '2019' }));
+    Cellar.findById.mockReturnValue(chain({ _id: oid('c'), user: oid('b'), members: [{ user: ME, role: 'editor' }], deletedAt: null, name: 'Theirs' }));
+    bottleOps.updateBottleFields.mockResolvedValueOnce(changed({ drinkTo: 2040 }, { drinkTo: 2035 }));
+    const body = parse(await tool('update_bottle').handler({ bottle_id: oid('d'), drink_to: 2040, apply_to_lot: true }, CTX));
+    expect(findLotSiblings).not.toHaveBeenCalled();
+    expect(body.warnings[0]).toMatch(/shared with you/);
+    expect(McpActionLog.create.mock.calls[0][0].action).toBe('update');
   });
 });

--- a/backend/src/mcp/photoTools.test.js
+++ b/backend/src/mcp/photoTools.test.js
@@ -38,6 +38,7 @@ jest.mock('../services/photoState', () => ({
   photosForBottle: jest.fn(),
   photoPresence: jest.fn(),
   absoluteImageUrl: (p) => (p ? `https://api.test/api/uploads/${p}` : null),
+  isInlineImage: (p) => typeof p === 'string' && p.startsWith('data:'),
 }));
 jest.mock('../services/bottleOps', () => ({
   consumeBottle: jest.fn(), restoreBottle: jest.fn(), addBottle: jest.fn(), updateBottleFields: jest.fn(),
@@ -86,6 +87,7 @@ beforeEach(() => {
   Bottle.countDocuments.mockResolvedValue(0);
   ingestBottleImage.mockResolvedValue({ image: { _id: new mongoose.Types.ObjectId(oid('9')), status: 'uploaded' } });
   safeFetchImage.mockResolvedValue({ buffer: Buffer.from('imgbytes'), contentType: 'image/jpeg' });
+  Cellar.find.mockReturnValue(chain([{ _id: oid('c') }]));
 });
 
 describe('get_bottle → photos', () => {
@@ -175,7 +177,7 @@ describe('attach_bottle_image answers with what the user already had and where t
     Bottle.findOne.mockReturnValue(chain({ _id: oid('d') }));
     const body = parse(await tool('attach_bottle_image').handler({ wine_id: oid('f'), image_url: 'https://cdn.example.com/label.jpg' }, CTX));
     expect(body.error).toBeUndefined();
-    expect(Bottle.findOne).toHaveBeenCalledWith({ user: ME, wineDefinition: oid('f'), status: 'active' });
+    expect(Bottle.findOne).toHaveBeenCalledWith(expect.objectContaining({ user: ME, wineDefinition: oid('f'), status: 'active', cellar: { $in: [oid('c')] } }));
     expect(body.data.bottle_id).toBe(oid('d'));
   });
 
@@ -186,5 +188,21 @@ describe('attach_bottle_image answers with what the user already had and where t
     const neither = parse(await tool('attach_bottle_image').handler({ image_url: 'https://cdn.example.com/label.jpg' }, CTX));
     expect(neither.error.code).toBe('invalid_input');
     expect(ingestBottleImage).not.toHaveBeenCalled();
+  });
+});
+
+describe('attach_bottle_image id rules (audit 2026-09-07)', () => {
+  test('bottle_id together with wine_id is refused', async () => {
+    const body = parse(await tool('attach_bottle_image').handler({ bottle_id: oid('d'), wine_id: oid('f'), image_url: 'https://cdn.example.com/label.jpg' }, CTX));
+    expect(body.error.code).toBe('invalid_input');
+    expect(ingestBottleImage).not.toHaveBeenCalled();
+  });
+
+  test('wine_id picks only from cellars the user can still edit', async () => {
+    ownBottle();
+    Bottle.findOne.mockReturnValue(chain({ _id: oid('d') }));
+    await tool('attach_bottle_image').handler({ wine_id: oid('f'), image_url: 'https://cdn.example.com/label.jpg' }, CTX);
+    expect(Cellar.find.mock.calls[0][0].$or[1]).toEqual({ members: { $elemMatch: { user: ME, role: { $in: ['editor', 'owner'] } } } });
+    expect(Bottle.findOne).toHaveBeenCalledWith(expect.objectContaining({ cellar: { $in: [oid('c')] } }));
   });
 });

--- a/backend/src/mcp/readTools.test.js
+++ b/backend/src/mcp/readTools.test.js
@@ -24,7 +24,7 @@ jest.mock('../models/Cellar', () => ({ find: jest.fn(), findById: jest.fn() }));
 jest.mock('../models/Bottle', () => ({
   find: jest.fn(), findById: jest.fn(), aggregate: jest.fn(), countDocuments: jest.fn(),
 }));
-jest.mock('../services/photoState', () => ({ photosForBottle: jest.fn().mockResolvedValue({ count: 0, has_photo: false, mine_pending: 0, registry_image: null, items: [] }), photoPresence: jest.fn().mockResolvedValue(new Map()), absoluteImageUrl: (p) => p }));
+jest.mock('../services/photoState', () => ({ photosForBottle: jest.fn().mockResolvedValue({ count: 0, has_photo: false, mine_pending: 0, registry_image: null, items: [] }), photoPresence: jest.fn().mockResolvedValue(new Map()), absoluteImageUrl: (p) => p, isInlineImage: () => false }));
 jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));

--- a/backend/src/mcp/resources.test.js
+++ b/backend/src/mcp/resources.test.js
@@ -19,7 +19,7 @@ jest.mock('../models/Cellar', () => ({ find: jest.fn(), findById: jest.fn() }));
 jest.mock('../models/Bottle', () => ({
   find: jest.fn(), findById: jest.fn(), aggregate: jest.fn(), countDocuments: jest.fn(),
 }));
-jest.mock('../services/photoState', () => ({ photosForBottle: jest.fn().mockResolvedValue({ count: 0, has_photo: false, mine_pending: 0, registry_image: null, items: [] }), photoPresence: jest.fn().mockResolvedValue(new Map()), absoluteImageUrl: (p) => p }));
+jest.mock('../services/photoState', () => ({ photosForBottle: jest.fn().mockResolvedValue({ count: 0, has_photo: false, mine_pending: 0, registry_image: null, items: [] }), photoPresence: jest.fn().mockResolvedValue(new Map()), absoluteImageUrl: (p) => p, isInlineImage: () => false }));
 jest.mock('../models/Rack', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../models/WishlistItem', () => ({ find: jest.fn(), countDocuments: jest.fn() }));
 jest.mock('../models/JournalEntry', () => ({ find: jest.fn(), countDocuments: jest.fn() }));

--- a/backend/src/mcp/revert.js
+++ b/backend/src/mcp/revert.js
@@ -6,6 +6,7 @@
 // Every reversal re-verifies current state and refuses (conflict) if the world
 // moved on since the action; nothing here trusts that `row` is the newest.
 const McpActionLog = require('../models/McpActionLog');
+const Bottle = require('../models/Bottle');
 const { CONSUMED_STATUSES } = require('../config/constants');
 const { consumeBottle, restoreBottle, RESTORE_WINDOW_MS } = require('../services/bottleOps');
 const { logAction } = require('./actionLedger');
@@ -599,12 +600,20 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
     const prevById = row.prev && typeof row.prev === 'object' ? row.prev : {};
     const ids = Object.keys(prevById);
     if (!ids.length) return fail('conflict', 'That lot update has no recorded previous values; nothing was changed.');
+    // The bottles are independent: one removed since (added by mistake, then
+    // undone) has nothing to restore and must not block the rest (audit
+    // 2026-09-07). A bottle that still exists but is no longer editable does
+    // block — restoring around it would leave the lot uneven on purpose.
     const resolved = [];
+    const missing = [];
     for (const id of ids) {
+      const exists = await Bottle.exists({ _id: id });
+      if (!exists) { missing.push(id); continue; }
       const a = await resolveBottleAccess(ctx.user.id, id, 'editor');
       if (!a) return fail('conflict', `Bottle ${id} from that lot update is no longer accessible; nothing was changed.`);
       resolved.push(a.bottle);
     }
+    if (!resolved.length) return fail('conflict', 'Every bottle of that lot update has been removed since; nothing to restore.');
     const claimed = await McpActionLog.findOneAndUpdate({ _id: row._id, reversed: false }, { $set: { reversed: true, idempotencyKey: null } });
     if (!claimed) return fail('conflict', 'That lot update is already being undone by another request.');
     const restored = [];
@@ -616,11 +625,29 @@ async function revertLedgerRow(row, ctx, { ok, fail }) {
         else restored.push(String(b._id));
       } catch (err) { failures.push({ bottle_id: String(b._id), error: err.message }); }
     }
+    if (failures.length) {
+      // Keep the row undoable for exactly what is still outstanding (audit
+      // 2026-09-07: a claimed-but-partial undo could never be retried).
+      // Nothing restored → plain unclaim; some restored → prev shrinks to the
+      // failed bottles so the next undo touches only those.
+      const outstanding = {};
+      for (const f of failures) outstanding[f.bottle_id] = prevById[f.bottle_id];
+      await McpActionLog.updateOne({ _id: row._id }, { $set: { reversed: false, prev: outstanding } }).catch(() => {});
+      if (!restored.length) {
+        return fail('conflict', `Cannot undo that lot update right now: ${failures[0].error} Nothing was changed — retry.`);
+      }
+    }
     const envelope = {
-      summary: `Undid lot update — previous values restored on ${restored.length} bottle(s)${failures.length ? `, ${failures.length} FAILED (fix those by hand)` : ''}`,
-      data: { undone: 'update_bottle', restored_bottle_ids: restored, ...(failures.length ? { failures } : {}) },
+      summary: `Undid lot update — previous values restored on ${restored.length} bottle(s)` +
+        (failures.length ? `, ${failures.length} not yet (undo_last again restores those)` : '') +
+        (missing.length ? `, ${missing.length} removed since (nothing to restore)` : ''),
+      data: {
+        undone: 'update_bottle', restored_bottle_ids: restored,
+        ...(failures.length ? { failures, retry: 'undo_last again restores the bottles that failed' } : {}),
+        ...(missing.length ? { removed_bottle_ids: missing } : {}),
+      },
     };
-    await logAction(ctx, { tool: 'undo_last', action: 'lot_update', viaUndo: true, bottle: row.bottle, cellar: row.cellar, detail: { undid: String(row._id), count: restored.length }, result: envelope });
+    await logAction(ctx, { tool: 'undo_last', action: 'lot_update', viaUndo: true, bottle: row.bottle, cellar: row.cellar, detail: { undid: String(row._id), count: restored.length, ...(failures.length ? { outstanding: failures.length } : {}) }, result: envelope });
     return ok(envelope.summary, envelope.data);
   }
 

--- a/backend/src/mcp/revert.test.js
+++ b/backend/src/mcp/revert.test.js
@@ -7,6 +7,7 @@
  * claim (so a double-revert loses cleanly).
  */
 
+jest.mock('../models/Bottle', () => ({ exists: jest.fn().mockResolvedValue(true) }));
 jest.mock('../models/McpActionLog', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
 jest.mock('../services/embeddingJob', () => ({ reembedActiveVintages: jest.fn().mockResolvedValue(undefined) }));
 jest.mock('../models/WineList', () => ({ findOne: jest.fn() }));
@@ -454,5 +455,39 @@ describe('lot_update (update_bottle apply_to_lot, support ticket 2026-09-06)', (
   test('is write-class: a consume-only token cannot reverse it', () => {
     expect(WRITE_REVERSIBLE).toContain('lot_update');
     expect(reversibleActionsFor(['consume'])).not.toContain('lot_update');
+  });
+});
+
+describe('lot_update undo — partial failure and removed bottles (audit 2026-09-07)', () => {
+  const Bottle = require('../models/Bottle');
+  beforeEach(() => { Bottle.exists.mockResolvedValue(true); });
+
+  test('a sibling whose save fails keeps the row undoable for exactly that sibling', async () => {
+    resolveBottleAccess.mockImplementation(async (uid, id) => ({ bottle: { _id: id, vintage: 2018, cellar: 'c1' } }));
+    bottleOps.updateBottleFields.mockImplementation(async (b) => (String(b._id) === 'b2'
+      ? { error: { status: 409, message: 'modified by another request' } }
+      : { changes: {}, prev: {} }));
+    const res = await revertLedgerRow({ _id: 'r', action: 'lot_update', bottle: 'b1', prev: { b1: { price: 1 }, b2: { price: 2 } } }, ctx(), H);
+    expect(res.data.restored_bottle_ids).toEqual(['b1']);
+    expect(res.data.retry).toMatch(/undo_last again/);
+    expect(McpActionLog.updateOne).toHaveBeenCalledWith({ _id: 'r' }, { $set: { reversed: false, prev: { b2: { price: 2 } } } });
+  });
+
+  test('nothing restored: the row is unclaimed and the undo reports a conflict to retry', async () => {
+    resolveBottleAccess.mockImplementation(async (uid, id) => ({ bottle: { _id: id } }));
+    bottleOps.updateBottleFields.mockResolvedValue({ error: { status: 409, message: 'db hiccup' } });
+    const res = await revertLedgerRow({ _id: 'r', action: 'lot_update', bottle: 'b1', prev: { b1: { price: 1 } } }, ctx(), H);
+    expect(res).toMatchObject({ ok: false, code: 'conflict' });
+    expect(McpActionLog.updateOne).toHaveBeenCalledWith({ _id: 'r' }, { $set: { reversed: false, prev: { b1: { price: 1 } } } });
+  });
+
+  test('a bottle removed since is skipped and reported; the rest are restored', async () => {
+    Bottle.exists.mockImplementation(async ({ _id }) => _id !== 'b2');
+    resolveBottleAccess.mockImplementation(async (uid, id) => ({ bottle: { _id: id } }));
+    bottleOps.updateBottleFields.mockResolvedValue({ changes: {}, prev: {} });
+    const res = await revertLedgerRow({ _id: 'r', action: 'lot_update', bottle: 'b1', prev: { b1: { price: 1 }, b2: { price: 2 } } }, ctx(), H);
+    expect(res.data.restored_bottle_ids).toEqual(['b1']);
+    expect(res.data.removed_bottle_ids).toEqual(['b2']);
+    expect(bottleOps.updateBottleFields).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/mcp/sommTools.test.js
+++ b/backend/src/mcp/sommTools.test.js
@@ -2036,8 +2036,10 @@ describe('list_maturity_queue unprofiled (audit ticket 2026-09-06)', () => {
     WineVintageProfile.countDocuments.mockResolvedValue(0);
     WineVintageProfile.find.mockReturnValue(chain([]));
     await tool('list_maturity_queue').handler({ status: 'reviewed', unprofiled: true }, SOMM_CTX);
+    // The queue's own "no profile" predicate: a HELD profile (generatedAt,
+    // no description) or a prose-less curator profile (body) is NOT unprofiled.
     expect(WineDefinition.find).toHaveBeenCalledWith({
-      $or: [{ 'aiProfile.description': { $in: [null, ''] } }, { 'aiProfile.description': { $exists: false } }],
+      'aiProfile.generatedAt': null, 'aiProfile.description': { $in: [null, ''] }, 'aiProfile.body': null,
     });
     const filter = WineVintageProfile.find.mock.calls.at(-1)[0];
     expect(filter).toEqual({ status: 'reviewed', wineDefinition: { $in: [oid('a'), oid('b')] } });

--- a/backend/src/mcp/tools/images.js
+++ b/backend/src/mcp/tools/images.js
@@ -59,13 +59,24 @@ registerTool({
     if (!args.bottle_id && !args.wine_id) {
       return fail('invalid_input', 'Provide bottle_id (from search_bottles) or wine_id (the registry wine — the photo then goes on your newest active bottle of it).');
     }
+    if (args.bottle_id && args.wine_id) {
+      return fail('invalid_input', 'Provide bottle_id OR wine_id, not both — with both, a mismatch would silently land the photo on the bottle\'s wine.');
+    }
     let bottleId = args.bottle_id;
     if (!bottleId) {
       // wine_id: the effect is per wine, so any of the user's bottles will do —
-      // the newest active one, so the photo lands where the user is looking.
-      const own = await Bottle.findOne({ user: ctx.user.id, wineDefinition: args.wine_id, status: 'active' })
-        .sort({ createdAt: -1 }).select('_id').lean();
-      if (!own) return fail('not_found', 'You have no active bottle of that wine. Add one first (resolve_wine → add_bottle), then attach the photo.');
+      // the newest active one in a cellar the user can still edit (a bottle
+      // left in a cellar they were removed from must not be picked and then
+      // refused — audit 2026-09-07).
+      const Cellar = require('../../models/Cellar');
+      const editable = await Cellar.find({
+        deletedAt: null,
+        $or: [{ user: ctx.user.id }, { members: { $elemMatch: { user: ctx.user.id, role: { $in: ['editor', 'owner'] } } } }],
+      }).select('_id').lean();
+      const own = await Bottle.findOne({
+        user: ctx.user.id, wineDefinition: args.wine_id, status: 'active', cellar: { $in: editable.map((c) => c._id) },
+      }).sort({ createdAt: -1 }).select('_id').lean();
+      if (!own) return fail('not_found', 'You have no active bottle of that wine in a cellar you can edit. Add one first (resolve_wine → add_bottle), then attach the photo.');
       bottleId = String(own._id);
     }
     const access = await resolveBottleAccess(ctx.user.id, bottleId, 'editor');

--- a/backend/src/mcp/tools/registryData.js
+++ b/backend/src/mcp/tools/registryData.js
@@ -168,7 +168,7 @@ registerTool({
     key_id: objectId.optional(),
     value_id: objectId.optional(),
     decision: z.enum(['accept', 'reject', 'publish']).optional(),
-    reject_reason: z.string().max(500).optional(),
+    reject_reason: z.string().max(2000).optional(),
     as_wine_default: z.boolean().optional().describe('With decision=publish on a vintage-slotted value: publish it as the wine-wide default instead'),
   },
   handler: async (args, ctx) => {

--- a/backend/src/mcp/tools/somm.js
+++ b/backend/src/mcp/tools/somm.js
@@ -305,8 +305,12 @@ registerTool({
       // description leaves the record incomplete for good unless a curator
       // finds it. Wines without profile text are few hundred, so an id list
       // keeps the page and the total honest.
+      // "No profile" is the queue's own predicate (hasProfileContent): a HELD
+      // profile has generatedAt but no description, and a curator profile may
+      // carry body/flavors without prose — neither is "nothing describes the
+      // wine" (audit 2026-09-07).
       const bare = await WineDefinition.find({
-        $or: [{ 'aiProfile.description': { $in: [null, ''] } }, { 'aiProfile.description': { $exists: false } }],
+        'aiProfile.generatedAt': null, 'aiProfile.description': { $in: [null, ''] }, 'aiProfile.body': null,
       }).select('_id').lean();
       filter.wineDefinition = { $in: bare.map((w) => w._id) };
     }
@@ -494,8 +498,8 @@ registerTool({
     const warnings = [];
     try {
       const wineId = profile.wineDefinition?._id || profile.wineDefinition;
-      const w = await WineDefinition.findById(wineId).select('aiProfile.description').lean();
-      if (w && !(w.aiProfile && w.aiProfile.description)) {
+      const w = await WineDefinition.findById(wineId).select('aiProfile.description aiProfile.generatedAt aiProfile.body').lean();
+      if (w && !hasProfileContent(w.aiProfile)) {
         warnings.push('This wine has no tasting profile text — the window is saved, but nothing describes the wine. Write one with set_wine_profile while the research is fresh (list_maturity_queue unprofiled:true finds the others).');
       }
     } catch { /* the warning is a courtesy, never a failure */ }

--- a/backend/src/mcp/tools/wines.js
+++ b/backend/src/mcp/tools/wines.js
@@ -12,7 +12,7 @@ const { siteBaseUrl } = require('../../utils/siteUrl');
 const { decorateGrapes } = require('../../utils/grapeDisplay');
 const { publicProfileSummary } = require('../../services/registryTiering');
 const { gateMcpRead, CAP_MESSAGE } = require('../../services/registryReadTracker');
-const { absoluteImageUrl } = require('../../services/photoState');
+const { absoluteImageUrl, isInlineImage } = require('../../services/photoState');
 
 const REGISTRY_LIMIT = 10; // == USER_SEARCH_LIMIT in routes/wines.js
 
@@ -125,8 +125,16 @@ registerTool({
       community_rating: w.communityRating?.reviewCount ? w.communityRating : null,
       tasting_profile: anonymous ? publicProfileSummary(profile) : profile,
       // The same picture the public wine page shows; a caller's own pending
-      // photos are on get_bottle → photos, never here.
-      image: w.image ? { url: absoluteImageUrl(w.image), credit: w.imageCredit || null } : null,
+      // photos are on get_bottle → photos, never here. The credit stays with
+      // signed-in callers, as on the REST public projection; an inline data:
+      // image is not shipped (up to 500 kB) — the page shows it.
+      image: w.image
+        ? {
+            url: absoluteImageUrl(w.image),
+            ...(isInlineImage(w.image) ? { inline: true, see: 'public_url' } : {}),
+            ...(anonymous ? {} : { credit: w.imageCredit || null }),
+          }
+        : null,
       public_url: w.slug ? `${siteBaseUrl()}/wines/${w.slug}` : null,
     });
   },

--- a/backend/src/mcp/tools/write.js
+++ b/backend/src/mcp/tools/write.js
@@ -22,7 +22,7 @@ const { registerTool } = require('../registry');
 // — a top-level require here would break every suite that loads the tool
 // registry (the #702 failure mode).
 const { addBottle, updateBottleFields } = require('../../services/bottleOps');
-const { findLotSiblings, pickLotFields, LOT_FIELDS } = require('../../services/bottleLot');
+const { findLotSiblings, pickLotFields, LOT_FIELDS, LOT_LIMIT } = require('../../services/bottleLot');
 const { logAudit } = require('../../services/audit');
 const { isValidId } = require('../../utils/validation');
 const { decorateGrapes } = require('../../utils/grapeDisplay');
@@ -311,16 +311,26 @@ registerTool({
     // the same shared validation; one that refuses (a peak outside ITS own
     // window, say) is reported under skipped, never fatal for the rest.
     const lotFields = args.apply_to_lot ? pickLotFields(fields) : {};
+    // A price is meaningless without its currency: carry this bottle's
+    // (audit 2026-09-07 — siblings kept their own, default USD, so "350"
+    // landed as 350 USD next to 350 SEK).
+    if (lotFields.price !== undefined && lotFields.currency === undefined && bottle.currency) lotFields.currency = bottle.currency;
     const lot = { count: 0, applied: [], unchanged: 0, skipped: [] };
     const primaryChanged = Object.keys(result.changes).length > 0;
     // prev keyed by bottle id, this bottle first — the undo restores in this order.
     const prevById = primaryChanged ? { [String(bottle._id)]: result.prev } : {};
     const warnings = [];
+    // The lot is the caller's OWN bottles; from a bottle in someone else's
+    // cellar that would be the wrong lot (audit 2026-09-07), so say so.
+    const ownCellar = String(access.cellar.user && (access.cellar.user._id || access.cellar.user)) === String(ctx.user.id);
     if (args.apply_to_lot && !Object.keys(lotFields).length) {
       warnings.push(`apply_to_lot ignored: none of the fields in this call are lot-level (${LOT_FIELDS.join(', ')})`);
+    } else if (args.apply_to_lot && !ownCellar) {
+      warnings.push('apply_to_lot ignored: this bottle is in a cellar shared with you, and the lot would be your own bottles, not that cellar\'s. Update the other bottles there one by one.');
     } else if (args.apply_to_lot) {
       const siblings = await findLotSiblings(ctx.user.id, bottle);
       lot.count = siblings.length;
+      if (siblings.length >= LOT_LIMIT) warnings.push(`The lot was capped at ${LOT_LIMIT} bottles.`);
       for (const sib of siblings) {
         const r = await updateBottleFields(sib, { ...lotFields }, ctx.req);
         if (r.error) { lot.skipped.push({ bottle_id: String(sib._id), reason: r.error.message }); continue; }

--- a/backend/src/routes/admin/wineRequests.js
+++ b/backend/src/routes/admin/wineRequests.js
@@ -1,3 +1,4 @@
+const { splitPradikatFromAppellation } = require('../../utils/styleTerms');
 const express = require('express');
 const { requireAuth, requireRole } = require('../../middleware/auth');
 const WineRequest = require('../../models/WineRequest');
@@ -142,8 +143,10 @@ router.put('/:id/resolve', async (req, res) => {
       // WineDefinition itself rather than going through findOrCreateWine, so
       // the resolver has to be called explicitly or an approved request mints
       // a spelling variant of an already-curated appellation.
+      // A bare Prädikat is not a place — same rule as findOrCreateWine (audit 2026-09-07).
+      const pradikatSplit = splitPradikatFromAppellation(appellation, req.body.classification, cleanName);
       const cleanAppellation = await resolveCanonicalAppellation(
-        normalizeAppellation(typeof appellation === 'string' ? appellation.trim() : null)
+        normalizeAppellation(pradikatSplit.appellation)
       ) || null;
 
       if (!req.body.confirmCreate) {
@@ -202,6 +205,7 @@ router.put('/:id/resolve', async (req, res) => {
         country,
         region: region || null,
         appellation: cleanAppellation,
+        classification: pradikatSplit.classification || undefined,
         grapes: grapes || [],
         type: type || null, // no guessed red (ticket 6a85ad44)
         image: imageToStore,

--- a/backend/src/routes/admin/wines.js
+++ b/backend/src/routes/admin/wines.js
@@ -1,3 +1,4 @@
+const { splitPradikatFromAppellation } = require('../../utils/styleTerms');
 const express = require('express');
 const mongoose = require('mongoose');
 const { requireAuth, requireRole } = require('../../middleware/auth');
@@ -182,8 +183,10 @@ router.post('/', async (req, res) => {
     // directly, so without the curated-registry lookup an admin create
     // reintroduces the spelling variants the mint chokepoint folds. One
     // resolution serves the dedup probe, the key and the stored field.
+    // A bare Prädikat is not a place — same rule as findOrCreateWine (audit 2026-09-07).
+    const pradikatSplit = splitPradikatFromAppellation(appellation, req.body.classification, cleanName);
     const cleanAppellation = await resolveCanonicalAppellation(
-      normalizeAppellation(typeof appellation === 'string' ? appellation.trim() : null)
+      normalizeAppellation(pradikatSplit.appellation)
     ) || null;
 
     if (!confirmCreate) {
@@ -253,6 +256,7 @@ router.post('/', async (req, res) => {
       country,
       region: region || null,
       appellation: cleanAppellation,
+      classification: pradikatSplit.classification || undefined,
       grapes: grapes || [],
       type: type || null, // no guessed red (ticket 6a85ad44)
       image: image || null,

--- a/backend/src/routes/bottles.bulk.test.js
+++ b/backend/src/routes/bottles.bulk.test.js
@@ -259,3 +259,22 @@ describe('POST /api/bottles/bulk — drink window (support ticket 2026-09-06)', 
       { drinkFrom: null, drinkTo: null, peakFrom: null, peakUntil: null }, expect.anything());
   });
 });
+
+describe('POST /api/bottles/bulk — per-bottle window conflicts (audit 2026-09-07)', () => {
+  test('a peak-outside-window refusal on the FIRST bottle is a skip, not a whole-request 400', async () => {
+    Bottle.find.mockResolvedValue([{ _id: B(1), cellar: OWNED, status: 'active' }, { _id: B(2), cellar: OWNED, status: 'active' }]);
+    updateBottleFields
+      .mockResolvedValueOnce({ error: { status: 400, message: 'peakUntil cannot be after drinkTo' } })
+      .mockResolvedValueOnce({ changes: { drinkTo: 2029 }, prev: { drinkTo: 2035 } });
+    const { status, body } = await postJson(app(), '/api/bottles/bulk', { action: 'update', bottleIds: [B(1), B(2)], fields: { drinkTo: 2029 } });
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ done: 1, doneIds: [B(2)], skipped: [{ id: B(1), reason: 'invalid' }] });
+  });
+
+  test('a payload-wide 400 still fails the request before anything is touched', async () => {
+    Bottle.find.mockResolvedValue([{ _id: B(1), cellar: OWNED, status: 'active' }]);
+    updateBottleFields.mockResolvedValueOnce({ error: { status: 400, message: 'purchaseDate must be a valid date' } });
+    const { status } = await postJson(app(), '/api/bottles/bulk', { action: 'update', bottleIds: [B(1)], fields: { purchaseDate: 'nope' } });
+    expect(status).toBe(400);
+  });
+});

--- a/backend/src/routes/bottles.js
+++ b/backend/src/routes/bottles.js
@@ -610,11 +610,16 @@ router.get('/:id', requireBottleAccess('viewer'), async (req, res) => {
     // cellars, so the edit form can offer "also apply the drink window and
     // price to the other N" (support ticket 2026-09-06). Auxiliary: a lookup
     // failure degrades to "no checkbox", never a 500.
+    // Only from a bottle in the viewer's OWN cellar: the lot is the viewer's
+    // bottles, which from someone else's cellar would be the wrong lot
+    // (audit 2026-09-07).
     let lotSiblingIds = [];
-    try {
-      lotSiblingIds = await findLotSiblingIds(req.user.id, bottle);
-    } catch (err) {
-      console.error('Lot sibling lookup failed:', err.message);
+    if (String(cellar.user && (cellar.user._id || cellar.user)) === String(req.user.id)) {
+      try {
+        lotSiblingIds = await findLotSiblingIds(req.user.id, bottle);
+      } catch (err) {
+        console.error('Lot sibling lookup failed:', err.message);
+      }
     }
 
     const ucEntry = cellar.userColors?.find(uc => uc.user.toString() === req.user.id.toString());
@@ -1033,7 +1038,12 @@ router.post('/bulk', async (req, res) => {
         if (!result.error) restockPairs.set(`${bottle.wineDefinition || ''}|${bottle.vintage || 'NV'}`, bottle);
       }
       if (result.error) {
-        if (result.error.status === 400 && !touched) {
+        // A 400 about THIS bottle's own values (its peak outside the new
+        // window) is a per-bottle skip, whatever its position in the list;
+        // only a payload-wide error still fails the whole request up front
+        // (audit 2026-09-07: the outcome depended on list order).
+        const perBottle = result.error.status === 400 && /cannot be (after|before)/.test(result.error.message || '');
+        if (result.error.status === 400 && !touched && !perBottle) {
           return res.status(400).json({ error: result.error.message });
         }
         skipped.push({ id, reason: result.error.code || (result.error.status === 400 ? 'invalid' : 'error') });

--- a/backend/src/routes/cellars.js
+++ b/backend/src/routes/cellars.js
@@ -1369,7 +1369,13 @@ router.get('/:id', async (req, res) => {
         baseFacets = baseResult.facetDistribution || null;
 
         // If filters are active, also fetch filtered facets for cascading counts
-        if (hasAnyFilter) {
+        if (onlyIds) {
+          // The rack / group filter is not a search-index attribute, so
+          // cascading counts cannot reflect it; ship the option lists without
+          // counts rather than whole-cellar numbers beside a scoped list
+          // (audit 2026-09-07).
+          facets = null;
+        } else if (hasAnyFilter) {
           const filteredResult = await searchService.searchBottles(search || '', {
             cellarId: req.params.id,
             type: type || undefined,

--- a/backend/src/routes/import.js
+++ b/backend/src/routes/import.js
@@ -12,7 +12,8 @@ const { getCellarRole } = require('../utils/cellarAccess');
 const { logAudit } = require('../services/audit');
 const { getOrCreateDailySnapshot } = require('../utils/exchangeRates');
 const { resolveRating } = require('../utils/ratingUtils');
-const { normalizeString, resolveCountryName, isRecognizedCountry, isUnknownName } = require('../utils/normalize');
+const { normalizeString, resolveCountryName, isRecognizedCountry, isUnknownName, isIdentitySentinel
+} = require('../utils/normalize');
 const { normalizeBottleSize, DEFAULT_SIZE } = require('../config/bottleSizes');
 const searchService = require('../services/search');
 const { identifyWineFromText } = require('../services/labelScan');
@@ -360,11 +361,15 @@ function typeFromFileGrapes(grapes, grapeColourOf) {
   return colours.has('Red') ? 'red' : 'white';
 }
 
-// Estate names legitimately double as the wine name ("Château Talbot").
-const ESTATE_WORD_RE = /^(ch[âa]teau|domaine|clos|quinta|tenuta|castello|weingut|bodegas?|mas|cascina|fattoria|azienda|cantina|villa|podere|finca|casa|ch\.)\b/i;
+// Estate names legitimately double as the wine name ("Château Talbot",
+// "Harlan Estate", "Schloss Johannisberg") — the estate word may lead or
+// trail (audit 2026-09-07).
+const ESTATE_WORD_RE = /\b(ch[âa]teau|domaine|clos|quinta|tenuta|castello|weingut|bodegas?|mas|cascina|fattoria|azienda|cantina|villa|podere|poderi|finca|casa|ch\.|estate|winery|vineyards?|cellars?|schloss|maison|weinbau|abbazia|marchesi|vignobles|adega|herdade)\b/i;
 function producerMirroredFromName(aiData, item) {
   const str = (v) => (typeof v === 'string' ? v.trim() : '');
-  if (str(item && item.producer)) return false;                  // the file said it — keep it
+  // A sentinel producer ("Unknown", "-") is "the file gave none" too.
+  const fileProducer = str(item && item.producer);
+  if (fileProducer && !isIdentitySentinel(fileProducer)) return false; // the file said it — keep it
   const name = str(aiData && aiData.name);
   const producer = str(aiData && aiData.producer);
   if (!name || !producer) return false;

--- a/backend/src/routes/racks.group.test.js
+++ b/backend/src/routes/racks.group.test.js
@@ -114,3 +114,14 @@ describe('POST /api/racks group', () => {
     expect(body.rack.group).toBe('Basement');
   });
 });
+
+describe('PUT /api/racks/:id group validation (audit 2026-09-07)', () => {
+  test('a non-string group is a 400, not a silent un-group', async () => {
+    const doc = rackDoc({ group: 'Basement' });
+    Rack.findOne.mockResolvedValue(doc);
+    const { status } = await request(buildApp(), 'PUT', `/api/racks/${RACK_ID}`, { group: 5 });
+    expect(status).toBe(400);
+    expect(doc.group).toBe('Basement');
+    expect(doc.save).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/racks.js
+++ b/backend/src/routes/racks.js
@@ -235,7 +235,11 @@ router.put('/:id', async (req, res) => {
 
     if (name !== undefined) rack.name = name;
     // '' or null clears the group (ungrouped); absent leaves it alone.
-    if (group !== undefined) rack.group = normalizeRackGroup(group);
+    if (group !== undefined) {
+      // A non-string group is a client bug, not a request to un-group (audit 2026-09-07).
+      if (group !== null && typeof group !== 'string') return res.status(400).json({ error: 'group must be a string' });
+      rack.group = normalizeRackGroup(group);
+    }
     if (isModular !== undefined) rack.isModular = isModular;
     if (modules !== undefined) rack.modules = modules;
     if (type !== undefined) rack.type = type;

--- a/backend/src/services/analytics/queryEngine.js
+++ b/backend/src/services/analytics/queryEngine.js
@@ -401,16 +401,17 @@ async function rackBottleIds(field, op, value, scopeCellars) {
  * join yields { name, group } or nothing (unplaced → null bucket).
  */
 function rackJoinStages() {
+  // The concise correlated form: localField/foreignField lets the unique
+  // multikey index on slots.bottle answer the join, where an $expr $in had
+  // to scan every rack of every tenant per bottle (audit 2026-09-07).
   return [
     {
       $lookup: {
         from: 'racks',
-        let: { bid: '$_id' },
+        localField: '_id',
+        foreignField: 'slots.bottle',
         pipeline: [
-          { $match: { $expr: { $and: [
-            { $in: ['$$bid', { $ifNull: ['$slots.bottle', []] }] },
-            { $eq: ['$deletedAt', null] },
-          ] } } },
+          { $match: { deletedAt: null } },
           { $limit: 1 },
           { $project: { _id: 0, name: 1, group: 1 } },
         ],
@@ -770,7 +771,9 @@ async function hydrateRows({ userId, pageIds, columns, scopeCellars }) {
   let rackOf = null;
   if (fields.some((f) => f.source === 'rack')) {
     rackOf = new Map();
-    const racks = await Rack.find({ cellar: { $in: scopeCellars.map((c) => c._id) }, deletedAt: null })
+    // Only the racks holding a bottle of this page (indexed), not every slot
+    // of every rack in scope (audit 2026-09-07).
+    const racks = await Rack.find({ cellar: { $in: scopeCellars.map((c) => c._id) }, deletedAt: null, 'slots.bottle': { $in: pageIds } })
       .select('name group slots.bottle').lean();
     for (const r of racks) {
       for (const s of r.slots || []) if (s.bottle) rackOf.set(String(s.bottle), { name: r.name, group: r.group || null });

--- a/backend/src/services/analytics/queryEngine.test.js
+++ b/backend/src/services/analytics/queryEngine.test.js
@@ -698,3 +698,23 @@ describe('rack name / group dimensions (support ticket 2026-09-06)', () => {
     await expect(runQuery(USER, { columns: ['rack.name'], sort: { field: 'rack.name', dir: 'asc' } })).rejects.toThrow(/not sortable/);
   });
 });
+
+describe('rack join and page map (audit 2026-09-07)', () => {
+  test('the grouped join uses the indexed localField/foreignField form, scoped to live racks', async () => {
+    const captured = aggReturning([{ _id: { d0: 'Basement' }, m0: 1 }]);
+    await runQuery(USER, { mode: 'grouped', dimensions: ['rack.group'], measures: [{ field: '*', agg: 'count' }] });
+    const lookup = captured.pipelines.at(-1).find((s) => s.$lookup && s.$lookup.from === 'racks').$lookup;
+    expect(lookup).toMatchObject({ localField: '_id', foreignField: 'slots.bottle' });
+    expect(lookup.let).toBeUndefined();
+    expect(lookup.pipeline[0]).toEqual({ $match: { deletedAt: null } });
+  });
+
+  test('rows: the rack map query is limited to racks holding a bottle of the page', async () => {
+    const B1 = 'e'.repeat(24);
+    aggReturning([{ ids: [{ _id: B1 }], total: [{ n: 1 }] }]);
+    Bottle.find.mockReturnValue(chainLean([{ _id: B1, cellar: CELLAR_A, wineDefinition: { _id: 'f'.repeat(24) } }]));
+    Rack.find.mockReturnValue(chainLean([]));
+    await runQuery(USER, { columns: ['rack.group'] });
+    expect(Rack.find.mock.calls[0][0]['slots.bottle']).toEqual({ $in: [B1] });
+  });
+});

--- a/backend/src/services/bottleLot.js
+++ b/backend/src/services/bottleLot.js
@@ -20,6 +20,9 @@ const { CONSUMED_STATUSES } = require('../config/constants');
 // The fields a lot shares. Everything else — rating, notes, reservation,
 // rack slot, purchase metadata — stays per bottle.
 const LOT_FIELDS = ['drinkFrom', 'drinkTo', 'peakFrom', 'peakUntil', 'price', 'currency'];
+// Same ceiling as the bulk route (BULK_MAX): each sibling costs a save, a
+// search index update and an audit row, sequentially (audit 2026-09-07).
+const LOT_LIMIT = 500;
 
 async function lotSiblingQuery(userId, bottle) {
   const wineId = bottle?.wineDefinition && (bottle.wineDefinition._id || bottle.wineDefinition);
@@ -41,7 +44,7 @@ async function lotSiblingQuery(userId, bottle) {
 async function findLotSiblingIds(userId, bottle) {
   const q = await lotSiblingQuery(userId, bottle);
   if (!q) return [];
-  const rows = await Bottle.find(q).select('_id').lean();
+  const rows = await Bottle.find(q).select('_id').sort({ createdAt: 1 }).limit(LOT_LIMIT).lean();
   return rows.map((r) => String(r._id));
 }
 
@@ -49,7 +52,7 @@ async function findLotSiblingIds(userId, bottle) {
 async function findLotSiblings(userId, bottle) {
   const q = await lotSiblingQuery(userId, bottle);
   if (!q) return [];
-  return Bottle.find(q).sort({ createdAt: 1 });
+  return Bottle.find(q).sort({ createdAt: 1 }).limit(LOT_LIMIT);
 }
 
 /** The subset of an update payload that a lot shares (undefined = not sent). */
@@ -59,4 +62,4 @@ function pickLotFields(fields) {
   return out;
 }
 
-module.exports = { LOT_FIELDS, findLotSiblingIds, findLotSiblings, pickLotFields };
+module.exports = { LOT_FIELDS, LOT_LIMIT, lotSiblingQuery, findLotSiblingIds, findLotSiblings, pickLotFields };

--- a/backend/src/services/bottleLot.test.js
+++ b/backend/src/services/bottleLot.test.js
@@ -1,0 +1,84 @@
+/**
+ * bottleLot — the one definition of "the lot" behind the edit-form checkbox,
+ * the bulk bar and update_bottle apply_to_lot (support ticket 2026-09-06).
+ * Every consumer mocks this module, so the invariants are pinned here:
+ * owned cellars only, consumed excluded, NV folds '' and null, the bottle
+ * itself excluded, no wine → no lot, capped at LOT_LIMIT (audit 2026-09-07).
+ */
+jest.mock('../models/Bottle', () => ({ find: jest.fn() }));
+jest.mock('../models/Cellar', () => ({ find: jest.fn() }));
+jest.mock('../config/constants', () => ({ CONSUMED_STATUSES: ['drank', 'gifted', 'sold', 'other'] }));
+
+const Bottle = require('../models/Bottle');
+const Cellar = require('../models/Cellar');
+const { lotSiblingQuery, findLotSiblingIds, findLotSiblings, pickLotFields, LOT_FIELDS, LOT_LIMIT } = require('./bottleLot');
+
+const chain = (rows) => {
+  const c = {};
+  for (const m of ['select', 'sort', 'limit']) c[m] = jest.fn(() => c);
+  c.lean = jest.fn(async () => rows);
+  c.then = (res, rej) => Promise.resolve(rows).then(res, rej);
+  return c;
+};
+const ME = 'u1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Cellar.find.mockReturnValue(chain([{ _id: 'c1' }, { _id: 'c2' }]));
+});
+
+describe('lotSiblingQuery', () => {
+  test('same wine and vintage, active, in the user\'s OWN cellars, minus the bottle itself', async () => {
+    const q = await lotSiblingQuery(ME, { _id: 'b1', wineDefinition: 'w', vintage: '2019' });
+    expect(Cellar.find).toHaveBeenCalledWith({ user: ME, deletedAt: null });
+    expect(q).toEqual({
+      _id: { $ne: 'b1' },
+      cellar: { $in: ['c1', 'c2'] },
+      wineDefinition: 'w',
+      vintage: '2019',
+      status: { $nin: ['drank', 'gifted', 'sold', 'other'] },
+    });
+  });
+
+  test('a populated wine is reduced to its id; NV matches blank and null vintages too', async () => {
+    const q = await lotSiblingQuery(ME, { _id: 'b1', wineDefinition: { _id: 'w' }, vintage: '' });
+    expect(q.wineDefinition).toBe('w');
+    expect(q.vintage).toEqual({ $in: ['NV', '', null] });
+  });
+
+  test('no registry wine, or no owned cellar, means no lot', async () => {
+    expect(await lotSiblingQuery(ME, { _id: 'b1', wineDefinition: null, vintage: '2019' })).toBeNull();
+    Cellar.find.mockReturnValue(chain([]));
+    expect(await lotSiblingQuery(ME, { _id: 'b1', wineDefinition: 'w', vintage: '2019' })).toBeNull();
+  });
+});
+
+describe('finders', () => {
+  test('findLotSiblingIds returns string ids, oldest first, capped at LOT_LIMIT', async () => {
+    const c = chain([{ _id: 'x' }, { _id: 'y' }]);
+    Bottle.find.mockReturnValue(c);
+    const ids = await findLotSiblingIds(ME, { _id: 'b1', wineDefinition: 'w', vintage: '2019' });
+    expect(ids).toEqual(['x', 'y']);
+    expect(c.sort).toHaveBeenCalledWith({ createdAt: 1 });
+    expect(c.limit).toHaveBeenCalledWith(LOT_LIMIT);
+    expect(LOT_LIMIT).toBe(500);
+  });
+
+  test('findLotSiblings returns documents (no lean) with the same cap; [] without a lot', async () => {
+    const c = chain([{ _id: 'x' }]);
+    Bottle.find.mockReturnValue(c);
+    const docs = await findLotSiblings(ME, { _id: 'b1', wineDefinition: 'w', vintage: '2019' });
+    expect(docs).toEqual([{ _id: 'x' }]);
+    expect(c.lean).not.toHaveBeenCalled();
+    expect(c.limit).toHaveBeenCalledWith(LOT_LIMIT);
+    expect(await findLotSiblings(ME, { _id: 'b1', wineDefinition: null })).toEqual([]);
+  });
+});
+
+describe('pickLotFields', () => {
+  test('keeps only the lot-level fields that were actually sent', () => {
+    expect(LOT_FIELDS).toEqual(['drinkFrom', 'drinkTo', 'peakFrom', 'peakUntil', 'price', 'currency']);
+    expect(pickLotFields({ drinkFrom: 2026, notes: 'x', price: undefined, currency: 'SEK', peakUntil: null }))
+      .toEqual({ drinkFrom: 2026, currency: 'SEK', peakUntil: null });
+  });
+});

--- a/backend/src/services/bottleOps.js
+++ b/backend/src/services/bottleOps.js
@@ -586,7 +586,13 @@ async function updateBottleFields(bottle, fields, req) {
   }
 
   // Vintage: coerce to canonical form ('NV' / 'Unknown' / 'YYYY') or reject.
-  if (fields.vintage !== undefined) {
+  // An UNCHANGED vintage is never re-validated: the web form sends the whole
+  // form on every save, and a bottle stored under an older rule (2028 was
+  // legal when the cap was harvest year + 5) must stay editable — a price
+  // change is not the moment to argue about its vintage (audit 2026-09-07).
+  if (fields.vintage !== undefined && String(fields.vintage).trim() === String(bottle.vintage ?? '').trim()) {
+    delete fields.vintage;
+  } else if (fields.vintage !== undefined) {
     const p = parseAndValidateVintage(fields.vintage);
     if (!p.ok) return { error: { status: 400, message: p.error } };
     fields.vintage = p.value;

--- a/backend/src/services/photoState.js
+++ b/backend/src/services/photoState.js
@@ -40,9 +40,15 @@ const MAX_ROWS = 20;
 const apiBase = () => (process.env.BACKEND_URL || process.env.FRONTEND_URL || 'https://cellarion.app').replace(/\/+$/, '');
 function absoluteImageUrl(path) {
   if (!path || typeof path !== 'string') return null;
-  if (/^https?:\/\//i.test(path) || path.startsWith('data:')) return path;
+  // An inline data: image (a registry image copied verbatim from a wine
+  // request) can be half a megabyte; it never travels in a tool result
+  // (audit 2026-09-07) — the public wine page shows it.
+  if (path.startsWith('data:')) return null;
+  if (/^https?:\/\//i.test(path)) return path;
   return path.startsWith('/') ? `${apiBase()}${path}` : `${apiBase()}/api/uploads/${path}`;
 }
+/** True when a stored image reference is an inline data: URL (see absoluteImageUrl). */
+const isInlineImage = (path) => typeof path === 'string' && path.startsWith('data:');
 
 /** One BottleImage row → the caller-facing shape. */
 function photoState(img, userId) {
@@ -75,20 +81,28 @@ function photoState(img, userId) {
 async function photosForBottle(userId, bottle) {
   const wd = bottle.wineDefinition;
   const wineId = wd && (wd._id || wd);
-  const own = { uploadedBy: userId, $or: [{ bottle: bottle._id }, ...(wineId ? [{ wineDefinition: wineId }] : [])] };
+  // Two bounded queries, own rows first: one query with a shared cap let a
+  // wine with many published photos push the viewer's own row past the cap
+  // — the very "did my upload land?" answer this exists for (audit 2026-09-07).
+  const own = await BottleImage.find({
+    ...NOT_SCAN, uploadedBy: userId,
+    $or: [{ bottle: bottle._id }, ...(wineId ? [{ wineDefinition: wineId }] : [])],
+  }).sort({ createdAt: -1 }).limit(MAX_ROWS).lean();
   const published = wineId
-    ? { wineDefinition: wineId, status: 'approved', visibility: 'public', uploadedBy: { $ne: userId } }
-    : null;
-  const rows = await BottleImage.find({ ...NOT_SCAN, $or: published ? [own, published] : [own] })
-    .sort({ createdAt: -1 }).limit(MAX_ROWS).lean();
-  const items = rows.map((r) => photoState(r, userId))
-    .sort((a, b) => (a.mine === b.mine ? 0 : a.mine ? -1 : 1));
+    ? await BottleImage.find({
+        ...NOT_SCAN, wineDefinition: wineId, status: 'approved', visibility: 'public', uploadedBy: { $ne: userId },
+      }).sort({ createdAt: -1 }).limit(MAX_ROWS).lean()
+    : [];
+  const items = [...own, ...published].map((r) => photoState(r, userId));
+  const inline = wd && typeof wd === 'object' && isInlineImage(wd.image);
   const registryImage = wd && typeof wd === 'object' && wd.image ? absoluteImageUrl(wd.image) : null;
   return {
     count: items.length,
-    has_photo: !!registryImage || items.some((p) => p.state !== 'rejected' && !!p.url),
+    has_photo: !!registryImage || inline || items.some((p) => p.state !== 'rejected' && !!p.url),
     mine_pending: items.filter((p) => p.mine && PENDING_STATES.includes(p.state)).length,
     registry_image: registryImage,
+    ...(inline ? { registry_image_inline: true } : {}),
+    ...(own.length >= MAX_ROWS || published.length >= MAX_ROWS ? { truncated: true } : {}),
     items,
   };
 }
@@ -122,4 +136,4 @@ async function photoPresence(userId, docs) {
   return out;
 }
 
-module.exports = { STATE, PENDING_STATES, absoluteImageUrl, photoState, photosForBottle, photoPresence };
+module.exports = { STATE, PENDING_STATES, MAX_ROWS, absoluteImageUrl, isInlineImage, photoState, photosForBottle, photoPresence };

--- a/backend/src/services/photoState.test.js
+++ b/backend/src/services/photoState.test.js
@@ -1,12 +1,15 @@
 /**
  * photoState — the owner-facing photo state behind the MCP read path
  * (support ticket 2026-09-06: no way to tell "no photo", "photo exists" and
- * "upload stuck" apart over the connector).
+ * "upload stuck" apart over the connector). Audit 2026-09-07: own rows and
+ * published rows are two bounded queries, own first, so a popular wine can
+ * never push the viewer's own row past the cap; inline data: images never
+ * travel.
  */
 jest.mock('../models/BottleImage', () => ({ find: jest.fn() }));
 
 const BottleImage = require('../models/BottleImage');
-const { photoState, photosForBottle, photoPresence, absoluteImageUrl } = require('./photoState');
+const { photoState, photosForBottle, photoPresence, absoluteImageUrl, isInlineImage, MAX_ROWS } = require('./photoState');
 
 const chain = (rows) => {
   const c = {};
@@ -23,10 +26,12 @@ beforeEach(() => {
 });
 
 describe('absoluteImageUrl', () => {
-  test('full URLs pass through; /api paths and bare filenames get the API base', () => {
+  test('full URLs pass through; /api paths and bare filenames get the API base; inline data: never travels', () => {
     expect(absoluteImageUrl('https://x/y.png')).toBe('https://x/y.png');
     expect(absoluteImageUrl('/api/uploads/processed/a.png')).toBe('https://api.test/api/uploads/processed/a.png');
     expect(absoluteImageUrl('a.png')).toBe('https://api.test/api/uploads/a.png');
+    expect(absoluteImageUrl('data:image/png;base64,AAAA')).toBeNull();
+    expect(isInlineImage('data:image/png;base64,AAAA')).toBe(true);
     expect(absoluteImageUrl(null)).toBeNull();
   });
 });
@@ -53,38 +58,62 @@ describe('photoState', () => {
 });
 
 describe('photosForBottle', () => {
-  test('own rows in any state (rejected included) plus other people\'s published rows; own first; counts', async () => {
-    BottleImage.find.mockReturnValue(chain([
-      { _id: 'p', status: 'approved', uploadedBy: OTHER, processedUrl: '/p.png', wineDefinition: 'w', createdAt: 3 },
-      { _id: 'r', status: 'rejected', uploadedBy: ME, processedUrl: null, originalUrl: null, createdAt: 2 },
-      { _id: 'q', status: 'uploaded', uploadedBy: ME, originalUrl: '/q.png', wineDefinition: 'w', createdAt: 1 },
-    ]));
+  test('own rows (any state, rejected included) come from their own bounded query, published rows from another; own first', async () => {
+    BottleImage.find
+      .mockReturnValueOnce(chain([
+        { _id: 'r', status: 'rejected', uploadedBy: ME, processedUrl: null, originalUrl: null, createdAt: 2 },
+        { _id: 'q', status: 'uploaded', uploadedBy: ME, originalUrl: '/q.png', wineDefinition: 'w', createdAt: 1 },
+      ]))
+      .mockReturnValueOnce(chain([
+        { _id: 'p', status: 'approved', uploadedBy: OTHER, processedUrl: '/p.png', wineDefinition: 'w', createdAt: 3 },
+      ]));
     const out = await photosForBottle(ME, { _id: 'b1', wineDefinition: { _id: 'w', image: null } });
-    const q = BottleImage.find.mock.calls[0][0];
-    expect(q.kind).toEqual({ $ne: 'label-scan' });
-    expect(q.$or[0]).toMatchObject({ uploadedBy: ME });
-    expect(q.$or[0].$or).toEqual([{ bottle: 'b1' }, { wineDefinition: 'w' }]);
-    expect(q.$or[1]).toEqual({ wineDefinition: 'w', status: 'approved', visibility: 'public', uploadedBy: { $ne: ME } });
+    expect(BottleImage.find).toHaveBeenCalledTimes(2);
+    const own = BottleImage.find.mock.calls[0][0];
+    expect(own).toMatchObject({ kind: { $ne: 'label-scan' }, uploadedBy: ME });
+    expect(own.$or).toEqual([{ bottle: 'b1' }, { wineDefinition: 'w' }]);
+    expect(BottleImage.find.mock.calls[1][0]).toEqual({
+      kind: { $ne: 'label-scan' }, wineDefinition: 'w', status: 'approved', visibility: 'public', uploadedBy: { $ne: ME },
+    });
     expect(out.items.map((i) => i.image_id)).toEqual(['r', 'q', 'p']);
     expect(out).toMatchObject({ count: 3, has_photo: true, mine_pending: 1, registry_image: null });
+    expect(out.truncated).toBeUndefined();
   });
 
-  test('a bottle with no registry wine looks up by bottle only; nothing found → has_photo false', async () => {
-    BottleImage.find.mockReturnValue(chain([]));
+  test('a wine with a cap-full gallery cannot hide the viewer\'s own row, and says it was truncated', async () => {
+    const many = Array.from({ length: MAX_ROWS }, (_, i) => ({ _id: `p${i}`, status: 'approved', uploadedBy: OTHER, processedUrl: '/p.png', wineDefinition: 'w' }));
+    BottleImage.find
+      .mockReturnValueOnce(chain([{ _id: 'mine', status: 'uploaded', uploadedBy: ME, originalUrl: '/m.png', wineDefinition: 'w' }]))
+      .mockReturnValueOnce(chain(many));
+    const out = await photosForBottle(ME, { _id: 'b1', wineDefinition: { _id: 'w' } });
+    expect(out.items[0].image_id).toBe('mine');
+    expect(out.mine_pending).toBe(1);
+    expect(out.truncated).toBe(true);
+  });
+
+  test('a bottle with no registry wine looks up own rows by bottle only and skips the published query', async () => {
+    BottleImage.find.mockReturnValueOnce(chain([]));
     const out = await photosForBottle(ME, { _id: 'b1', wineDefinition: null });
-    expect(BottleImage.find.mock.calls[0][0].$or).toHaveLength(1);
+    expect(BottleImage.find).toHaveBeenCalledTimes(1);
+    expect(BottleImage.find.mock.calls[0][0].$or).toEqual([{ bottle: 'b1' }]);
     expect(out).toMatchObject({ count: 0, has_photo: false, mine_pending: 0, items: [] });
   });
 
-  test('the registry image counts as a photo even with no rows of the viewer\'s own', async () => {
+  test('the registry image counts as a photo; an inline one is flagged instead of shipped', async () => {
     BottleImage.find.mockReturnValue(chain([]));
     const out = await photosForBottle(ME, { _id: 'b1', wineDefinition: { _id: 'w', image: 'w.png' } });
     expect(out.has_photo).toBe(true);
     expect(out.registry_image).toBe('https://api.test/api/uploads/w.png');
+
+    BottleImage.find.mockReturnValue(chain([]));
+    const inline = await photosForBottle(ME, { _id: 'b1', wineDefinition: { _id: 'w', image: 'data:image/png;base64,AAAA' } });
+    expect(inline).toMatchObject({ has_photo: true, registry_image: null, registry_image_inline: true });
   });
 
   test('only a rejected row → count 1 but no photo', async () => {
-    BottleImage.find.mockReturnValue(chain([{ _id: 'r', status: 'rejected', uploadedBy: ME, processedUrl: null, originalUrl: null }]));
+    BottleImage.find
+      .mockReturnValueOnce(chain([{ _id: 'r', status: 'rejected', uploadedBy: ME, processedUrl: null, originalUrl: null }]))
+      .mockReturnValueOnce(chain([]));
     const out = await photosForBottle(ME, { _id: 'b1', wineDefinition: { _id: 'w' } });
     expect(out).toMatchObject({ count: 1, has_photo: false, mine_pending: 0 });
   });

--- a/backend/src/services/registryDataOps.js
+++ b/backend/src/services/registryDataOps.js
@@ -393,7 +393,7 @@ async function decideKey(adminId, keyId, decision, rejectReason, { req } = {}) {
         status: decision === 'accept' ? 'accepted' : 'rejected',
         decidedBy: adminId,
         decidedAt: new Date(),
-        ...(decision === 'reject' && rejectReason ? { rejectReason: stripHtml(String(rejectReason)).slice(0, 500) } : {}),
+        ...(decision === 'reject' && rejectReason ? { rejectReason: stripHtml(String(rejectReason)).slice(0, 2000) } : {}),
       },
     },
     { new: true }
@@ -440,7 +440,7 @@ async function decideValue(adminId, valueId, decision, rejectReason, { req, asWi
     row.status = 'rejected';
     row.decidedBy = adminId;
     row.decidedAt = new Date();
-    if (rejectReason) row.rejectReason = stripHtml(String(rejectReason)).slice(0, 500);
+    if (rejectReason) row.rejectReason = stripHtml(String(rejectReason)).slice(0, 2000);
     await row.save();
     logAudit(req || null, 'registry_data.value_reject',
       { type: 'wine', id: row.wineDefinition }, { key: row.key?.name, valueId: row._id });

--- a/backend/src/utils/styleTerms.js
+++ b/backend/src/utils/styleTerms.js
@@ -263,3 +263,19 @@ module.exports = {
   pradikatContradictsName,
   pradikatOnlyValue,
 };
+
+/**
+ * Route a bare Prädikat out of an appellation — the one rule for EVERY mint
+ * (findOrCreateWine and the two admin routes that build a WineDefinition
+ * themselves; audit 2026-09-07). Returns the appellation to store (null when
+ * it was only the Prädikat) and the classification: the caller's own when
+ * given, else the Prädikat unless the name contradicts it.
+ */
+function splitPradikatFromAppellation(appellation, classification, name) {
+  const ap = typeof appellation === 'string' ? appellation.trim() : '';
+  const keep = typeof classification === 'string' && classification.trim() ? classification.trim() : null;
+  const pradikat = pradikatOnlyValue(ap);
+  if (!pradikat) return { appellation: ap || null, classification: keep };
+  return { appellation: null, classification: keep || (pradikatContradictsName(pradikat, name || '') ? null : pradikat) };
+}
+module.exports.splitPradikatFromAppellation = splitPradikatFromAppellation;

--- a/backend/src/utils/styleTerms.split.test.js
+++ b/backend/src/utils/styleTerms.split.test.js
@@ -1,0 +1,25 @@
+/**
+ * splitPradikatFromAppellation — the one Prädikat rule for every mint
+ * (findOrCreateWine and the two admin routes that build a WineDefinition
+ * themselves; audit 2026-09-07).
+ */
+const { splitPradikatFromAppellation } = require('./styleTerms');
+
+test('a bare Prädikat leaves the appellation and becomes the classification', () => {
+  expect(splitPradikatFromAppellation('Kabinett', undefined, 'Riesling Kabinett')).toEqual({ appellation: null, classification: 'Kabinett' });
+});
+
+test('a classification the caller typed is kept', () => {
+  expect(splitPradikatFromAppellation('Spätlese', 'Grosses Gewächs', 'Riesling')).toEqual({ appellation: null, classification: 'Grosses Gewächs' });
+});
+
+test('a Prädikat the name contradicts is dropped, not rescued', () => {
+  const out = splitPradikatFromAppellation('Trockenbeerenauslese', undefined, 'Riesling Trocken');
+  expect(out.appellation).toBeNull();
+  expect(out.classification).toBeNull();
+});
+
+test('a real appellation passes through untouched', () => {
+  expect(splitPradikatFromAppellation(' Mosel ', null, 'Riesling')).toEqual({ appellation: 'Mosel', classification: null });
+  expect(splitPradikatFromAppellation(undefined, 'Reserva', 'X')).toEqual({ appellation: null, classification: 'Reserva' });
+});

--- a/frontend/src/components/BottleFilterModal.js
+++ b/frontend/src/components/BottleFilterModal.js
@@ -93,14 +93,14 @@ function BottleFilterModal({ filters, onApply, onClose, facets, baseFacets, face
     onApply({
       ...filters,
       type: [], country: [], region: [], appellation: [], grapes: [], vintage: [],
-      minRating: '', maturity: '', unplaced: '', reserved: ''
+      minRating: '', maturity: '', unplaced: '', reserved: '', storage: ''
     });
   };
 
   const activeCount = (filters.type?.length || 0) + (filters.country?.length || 0) +
     (filters.region?.length || 0) + (filters.appellation?.length || 0) + (filters.grapes?.length || 0) +
     (filters.vintage?.length || 0) + (filters.minRating ? 1 : 0) + (filters.maturity ? 1 : 0) +
-    (filters.unplaced ? 1 : 0) + (filters.reserved ? 1 : 0);
+    (filters.unplaced ? 1 : 0) + (filters.reserved ? 1 : 0) + (filters.storage ? 1 : 0);
 
   // For a given facet key, decide which counts to use:
   // - If THIS category has active selections, use baseFacets (so you can still add more)
@@ -281,7 +281,9 @@ function BottleFilterModal({ filters, onApply, onClose, facets, baseFacets, face
             <FilterPill
               label={t('cellarDetail.unplacedOnly', 'Unplaced only')}
               selected={!!filters.unplaced}
-              onClick={() => onApply({ ...filters, unplaced: filters.unplaced ? '' : '1' })}
+              // "Unplaced" and "Stored in" contradict each other — picking one
+              // releases the other instead of yielding a puzzling empty list.
+              onClick={() => onApply({ ...filters, unplaced: filters.unplaced ? '' : '1', ...(filters.unplaced ? {} : { storage: '' }) })}
             />
           </FilterSection>
         )}
@@ -291,7 +293,7 @@ function BottleFilterModal({ filters, onApply, onClose, facets, baseFacets, face
         {Array.isArray(storage) && storage.length > 0 && (() => {
           const groups = [...new Set(storage.map(r => r.group).filter(Boolean))];
           const current = filters.storage || '';
-          const pick = (v) => onApply({ ...filters, storage: current === v ? '' : v });
+          const pick = (v) => onApply({ ...filters, storage: current === v ? '' : v, ...(current === v ? {} : { unplaced: '' }) });
           const pills = [
             ...groups.map(g => (
               <FilterPill key={`group:${g}`} label={g} selected={current === `group:${g}`} onClick={() => pick(`group:${g}`)} />

--- a/frontend/src/components/bottle/EditForm.js
+++ b/frontend/src/components/bottle/EditForm.js
@@ -12,17 +12,21 @@ import RatingInput from '../RatingInput';
 const ImageUpload = lazy(() => import('../ImageUpload'));
 const ImageGallery = lazy(() => import('../ImageGallery'));
 
-// The fields a wine and vintage share (support ticket 2026-09-06). Only the
-// ones the user CHANGED in this save are copied to the other bottles of the
-// lot — rating, notes, reservation and rack slot never are. A price carries
-// its currency with it; a currency alone counts only when a price exists.
-const LOT_FIELDS = ['drinkFrom', 'drinkTo', 'peakFrom', 'peakUntil', 'price'];
+// The fields a wine and vintage share (support ticket 2026-09-06). Only what
+// the user CHANGED in this save is copied to the other bottles of the lot —
+// rating, notes, reservation and rack slot never are. The drink window
+// travels as a unit: touching any of its four years copies all four, so the
+// lot ends up with ONE window rather than four uneven ones (audit
+// 2026-09-07). A price carries its currency; a currency alone counts only
+// when a price exists.
+const WINDOW_FIELDS = ['drinkFrom', 'drinkTo', 'peakFrom', 'peakUntil'];
 const norm = (v) => (v === '' || v === null || v === undefined ? null : v);
 export function changedLotFields(original, payload) {
   const out = {};
-  for (const k of LOT_FIELDS) {
-    if (norm(original[k]) !== norm(payload[k])) out[k] = norm(payload[k]);
+  if (WINDOW_FIELDS.some((k) => norm(original[k]) !== norm(payload[k]))) {
+    for (const k of WINDOW_FIELDS) out[k] = norm(payload[k]);
   }
+  if (norm(original.price) !== norm(payload.price)) out.price = norm(payload.price);
   if ('price' in out || (norm(original.price) !== null && norm(original.currency) !== norm(payload.currency))) {
     out.currency = payload.currency;
   }

--- a/frontend/src/components/bottle/EditForm.lot.test.js
+++ b/frontend/src/components/bottle/EditForm.lot.test.js
@@ -37,7 +37,7 @@ beforeEach(() => {
 
 describe('changedLotFields', () => {
   test('only the lot-level fields that changed; a changed price carries its currency', () => {
-    expect(changedLotFields(BOTTLE, { ...BOTTLE, drinkTo: 2040, notes: 'x', rating: 4 })).toEqual({ drinkTo: 2040 });
+    expect(changedLotFields(BOTTLE, { ...BOTTLE, drinkTo: 2040, notes: 'x', rating: 4 })).toEqual({ drinkFrom: 2026, drinkTo: 2040, peakFrom: null, peakUntil: null });
     expect(changedLotFields(BOTTLE, { ...BOTTLE, price: 30 })).toEqual({ price: 30, currency: 'EUR' });
     expect(changedLotFields(BOTTLE, { ...BOTTLE, currency: 'SEK' })).toEqual({ currency: 'SEK' });
     expect(changedLotFields(BOTTLE, { ...BOTTLE })).toEqual({});
@@ -46,7 +46,7 @@ describe('changedLotFields', () => {
     expect(changedLotFields({ ...BOTTLE, price: null, currency: null }, { ...BOTTLE, price: null, currency: 'SEK' })).toEqual({});
   });
   test('clearing a year propagates the clear', () => {
-    expect(changedLotFields(BOTTLE, { ...BOTTLE, drinkFrom: null })).toEqual({ drinkFrom: null });
+    expect(changedLotFields(BOTTLE, { ...BOTTLE, drinkFrom: null })).toEqual({ drinkFrom: null, drinkTo: 2035, peakFrom: null, peakUntil: null });
   });
 });
 
@@ -66,9 +66,9 @@ describe('EditForm lot checkbox', () => {
     fireEvent.click(screen.getByRole('checkbox'));
     fireEvent.change(container.querySelector('input[value="2035"]'), { target: { value: '2040' } });
     fireEvent.click(screen.getByText('bottleDetail.saveChanges'));
-    await waitFor(() => expect(bulkUpdateBottles).toHaveBeenCalledWith(apiFetch, ['b2', 'b3'], { drinkTo: 2040 }));
+    await waitFor(() => expect(bulkUpdateBottles).toHaveBeenCalledWith(apiFetch, ['b2', 'b3'], { drinkFrom: 2026, drinkTo: 2040, peakFrom: null, peakUntil: null }));
     await waitFor(() => expect(onSaved).toHaveBeenCalledWith(
-      expect.objectContaining({ drinkTo: 2040 }), { done: 2, skipped: 0, fields: ['drinkTo'] }));
+      expect.objectContaining({ drinkTo: 2040 }), { done: 2, skipped: 0, fields: ['drinkFrom', 'drinkTo', 'peakFrom', 'peakUntil'] }));
   });
 
   test('ticked but nothing lot-level changed: the siblings are left alone and the page is told', async () => {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -4163,6 +4163,7 @@
       "price": "Price",
       "vintageMissing": "no vintage in file",
       "vintageInputAria": "Vintage year for this row",
+    "vintageInvalid": "Give each flagged row a four-digit year, or leave it empty for NV.",
       "nv": "NV"
     },
     "validate": {

--- a/frontend/src/pages/BottleDetail.js
+++ b/frontend/src/pages/BottleDetail.js
@@ -100,6 +100,11 @@ function BottleDetail() {
   }, [reviewAudience, reviewVintage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchBottle = async () => {
+    // A new bottle id on the same mounted page (a notification link from
+    // bottle A to bottle B) must not carry A's edit form or A's lot banner
+    // over (audit 2026-09-07).
+    setLotMsg(null);
+    setEditing(false);
     try {
       const res = await getBottle(apiFetch, bottleId);
       const data = await res.json();
@@ -389,7 +394,7 @@ function BottleDetail() {
       )}
       {/* Outcome of "also apply to the other N bottles" from the edit form. */}
       {lotMsg && (
-        <div className={`alert ${lotMsg.error ? 'alert-error' : 'alert-success'}`} role="status">
+        <div className={`alert ${lotMsg.error ? 'alert-error' : 'alert-success'}`} role={lotMsg.error ? 'alert' : 'status'}>
           {lotMsg.error
             ? t('bottleDetail.lotFailed', { error: lotMsg.error })
             : lotMsg.nothing
@@ -400,6 +405,7 @@ function BottleDetail() {
             className="btn btn-small btn-secondary"
             style={{ marginLeft: '0.75rem' }}
             onClick={() => setLotMsg(null)}
+            aria-label={t('common.close', 'Close')}
           >
             ✕
           </button>

--- a/frontend/src/pages/CellarDetail.js
+++ b/frontend/src/pages/CellarDetail.js
@@ -165,6 +165,11 @@ function CellarDetail() {
     if (multiScope) setFilters(prev => (prev.reserved ? { ...prev, reserved: '' } : prev));
   }, [multiScope]);
 
+  // And for "stored in" — racks belong to one cellar (audit 2026-09-07).
+  useEffect(() => {
+    if (multiScope) setFilters(prev => (prev.storage ? { ...prev, storage: '' } : prev));
+  }, [multiScope]);
+
   // Debounce the search input — only send the API call after the user stops typing
   const [debouncedSearch, setDebouncedSearch] = useState(filters.search);
   const searchTimer = useRef(null);
@@ -318,7 +323,18 @@ function CellarDetail() {
         setRackMap(map);
         setHasRacks((racksData.racks || []).length > 0);
         // The "Stored in" filter's choices: every rack with its group label.
-        setStorageRacks((racksData.racks || []).map(r => ({ id: String(r._id), name: r.name, group: r.group || null })));
+        const storageList = (racksData.racks || []).map(r => ({ id: String(r._id), name: r.name, group: r.group || null }));
+        setStorageRacks(storageList);
+        // A remembered "stored in" whose rack was deleted or group renamed
+        // would show an opaque chip over an empty list (audit 2026-09-07).
+        setFilters(prev => {
+          const m = /^(group|rack):(.+)$/.exec(String(prev.storage || ''));
+          if (!m) return prev;
+          const alive = m[1] === 'rack'
+            ? storageList.some(r => r.id === m[2])
+            : storageList.some(r => r.group === m[2]);
+          return alive ? prev : { ...prev, storage: '' };
+        });
       }
     } catch {}
   };

--- a/frontend/src/pages/ImportBottles.css
+++ b/frontend/src/pages/ImportBottles.css
@@ -1625,3 +1625,6 @@
 /* Import review: a row whose file had no vintage (audit ticket 2026-09-05) */
 .review-vintage-input { width: 5.5em; padding: 2px 6px; font: inherit; font-size: 0.85em; border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: var(--color-surface); color: var(--color-text); }
 .import-flag { color: var(--color-warning, #b8860b); font-weight: 600; cursor: help; }
+
+/* A typed vintage that is not a real year (audit 2026-09-07). */
+.review-vintage-input[aria-invalid="true"] { border-color: var(--color-danger); outline: 1px solid var(--color-danger); }

--- a/frontend/src/pages/ImportBottles.js
+++ b/frontend/src/pages/ImportBottles.js
@@ -953,7 +953,18 @@ function ImportBottles() {
 
   const getImportableCount = () => results.filter(isImportableRow).length;
 
+  // A typed vintage on a flagged row must be a real year before confirm, or
+  // the one row the user took care of is the one the server rejects
+  // (audit 2026-09-07). Empty stays NV.
+  const isBadTypedVintage = (v) => {
+    if (!v || v === 'NV') return false;
+    const n = parseInt(v, 10);
+    return !/^\d{4}$/.test(String(v)) || n < 1900 || n > new Date().getFullYear();
+  };
+  const hasBadTypedVintage = results.some(r => r.item && r.item.vintageMissing && isBadTypedVintage(r.item.vintage));
+
   const handleImport = async () => {
+    if (hasBadTypedVintage) { setError(t('importBottles.preview.vintageInvalid', 'Give each flagged row a four-digit year (or leave it empty for NV).')); return; }
     setImporting(true);
     setError(null);
     setStep('importing');
@@ -1938,6 +1949,7 @@ function ImportBottles() {
                               aria-label={t('importBottles.preview.vintageInputAria')}
                               value={r.item.vintage === 'NV' ? '' : (r.item.vintage || '')}
                               maxLength={4}
+                              aria-invalid={isBadTypedVintage(r.item.vintage) ? 'true' : undefined}
                               onChange={(e) => {
                                 const v = e.target.value.replace(/[^0-9]/g, '');
                                 setResults(prev => prev.map(x => x.index === r.index
@@ -2142,7 +2154,8 @@ function ImportBottles() {
           <button
             className="btn btn-primary btn-import"
             onClick={handleImport}
-            disabled={importable === 0 || importing}
+            disabled={importable === 0 || importing || hasBadTypedVintage}
+            title={hasBadTypedVintage ? t('importBottles.preview.vintageInvalid', 'Give each flagged row a four-digit year (or leave it empty for NV).') : undefined}
           >
             {importing
               ? t('importBottles.review.importing')

--- a/frontend/src/utils/importMappers.js
+++ b/frontend/src/utils/importMappers.js
@@ -1464,7 +1464,7 @@ export function parseOenoExport(text) {
     const baseItem = {
       wineName: (cells[idx.title] || '').trim(),
       producer: (cells[idx.winery] || '').trim(),
-      vintage: (cells[idx.year] || '').trim() || 'NV',
+      ...vintageOrNV(cells[idx.year]),
       country: (cells[idx.country] || '').trim(),
       region: (cells[idx.region] || '').trim(),
       type: mapWineType((cells[idx.type] || '').trim()),
@@ -2047,7 +2047,7 @@ export function parsePlocFiles(texts) {
     const base = {
       wineName,
       producer: producer || undefined,
-      vintage: plocGet(r, ['Vintage', 'Millésime', 'Millesime']) || 'NV',
+      ...vintageOrNV(plocGet(r, ['Vintage', 'Millésime', 'Millesime'])),
       type: PLOC_COLOUR_TO_TYPE[colour] || undefined,
       grapes: parsePlocGrapes(plocGet(r, ['Grapes', 'Cépages', 'Cepages', 'Cépage'])),
       country: plocGet(r, ['Country', 'Pays']) || undefined,


### PR DESCRIPTION
Five parallel reviews of everything between v1.204.0 and v1.205.0 (#1244–#1248): **no High findings**, nine Mediums, a set of Lows. This PR fixes all Mediums and the cheap Lows; prod impact of the one live regression was small (2 bottles, 1 user).

### Medium
- **Unchanged vintage re-validated on every save** (from #1245's harvest-year cap): a bottle stored as 2028 under the old +5 rule could not be edited at all. `updateBottleFields` now skips validation when the vintage did not change. Prod count: 2 bottles.
- **Lot undo partial failure burned the row**: now a removed bottle is skipped and reported, and a failing sibling keeps the row undoable for exactly that sibling (or unclaims it when nothing was restored).
- **`apply_to_lot` with a price and no currency** wrote the number into each sibling's own currency: the bottle's currency now travels with the price.
- **Bulk update aborted on a per-bottle window conflict when it hit the first bottle** but skipped it later in the list: per-bottle conflicts are always skips; only payload-wide errors fail up front.
- **Grouped analytics rack join** used an unindexable `$expr $in` over every tenant's racks: now the concise `localField`/`foreignField` form served by the multikey index. The rows map loads only racks holding a page bottle.
- **Own photos could be truncated** behind a wine's published gallery under one shared cap: own rows and published rows are two bounded queries, own first, with a `truncated` flag.
- **Filter sheet clear-all and count** ignored the new "stored in" filter; **widening the scope** left a stale "stored in" chip; both fixed.
- **Sommelier `unprofiled` filter and warning** counted held profiles as unprofiled: now the queue's own predicate.

### Low / hygiene
- Lot from a bottle in a shared cellar: siblings only offered from the viewer's own cellar; the connector warns and skips. Lot capped at 500 like the bulk route. The edit form copies the drink window as a unit.
- Photos: inline `data:` registry images are flagged, never shipped; the image credit stays with signed-in callers; `wine_id` picks a bottle only from cellars the user can still edit; `bottle_id` with `wine_id` is refused.
- Racks: non-string group → 400; facet counts dropped while a rack/group filter is active; stale "stored in" dropped when its rack or group is gone; "unplaced" and "stored in" release each other.
- Curation: a bare Prädikat leaves the appellation on the two admin mint routes too (shared helper); estate exemption matches trailing estate words and treats a sentinel producer as none; registry reject reasons take 2000 chars end to end; Oeno and Ploc mappers flag a missing vintage; a typed import vintage must be a real year before confirm.
- Bottle page: a new bottle id resets the edit form and lot banner; banner roles and the close button's name.

### Tests
New `bottleLot.test.js` (7), `styleTerms.split.test.js` (4); additions to revert (3), lotUpdate (2), bulk (2), queryEngine (2), racks.group (1), photoTools (2); `photoState.test.js` rewritten for the two-query shape (9). Full frontend suite green (94 files, 1231 tests); build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
