### PR TITLE
chore(release): v1.206.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.205.1",
+  "version": "1.206.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.205.1",
+      "version": "1.206.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.205.1",
+  "version": "1.206.0",
   "license": "AGPL-3.0",
   "description": "Wine cellar management backend",
   "main": "server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.205.1",
+  "version": "1.206.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.205.1",
+      "version": "1.206.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fontsource/inter": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.205.1",
+  "version": "1.206.0",
   "license": "AGPL-3.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for v1.206.0.

- #1252 fix(mcp): sommelier queue gaps — filterable downgrade rules, reviewed-only variety vocabulary, colour check names its blind spot
- #1253 feat(mcp): get_photo returns a photo's pixels as image content
- #1243 fix(scripts): canary seed sets createdBy and normalizedKey

🤖 Generated with [Claude Code](https://claude.com/claude-code)