### PR TITLE
chore(release): v1.208.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.207.0",
+  "version": "1.208.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.207.0",
+      "version": "1.208.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.207.0",
+  "version": "1.208.0",
   "license": "AGPL-3.0",
   "description": "Wine cellar management backend",
   "main": "server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.207.0",
+  "version": "1.208.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.207.0",
+      "version": "1.208.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fontsource/inter": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.207.0",
+  "version": "1.208.0",
   "license": "AGPL-3.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for v1.208.0: Registry Bridge admin page, tunable registry caps and the enforcement playbook (#1259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)