### PR TITLE
fix(bridge): audit remediation — count per account, keep local edits, forward the env in Docker

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -172,7 +172,7 @@ app.use('/api/mcp', express.json({ limit: '2mb' }));
 // Registry Bridge v1: a change check carries up to 5,000 wine ids (~130 kB
 // of JSON); everything else on the router is small. Registered above the
 // 10 kb default rule below (first express.json to parse wins).
-app.use('/api/bridge/v1', express.json({ limit: '256kb' }));
+app.use('/api/bridge/v1/wines/changes', express.json({ limit: '256kb' }));
 app.use(express.json({ limit: '10kb' }));
 const corsOrigin = process.env.FRONTEND_URL || (process.env.NODE_ENV === 'production' ? false : 'http://localhost:3000');
 if (process.env.NODE_ENV === 'production' && !process.env.FRONTEND_URL) {

--- a/backend/src/config/rateLimits.js
+++ b/backend/src/config/rateLimits.js
@@ -97,7 +97,10 @@ const defaults = {
   // import window multiplies the four daily caps by five;
   // services/bridgeQuota.js and routes/bridgeV1.js read this group per
   // request.
-  bridge: { searches: 600, fetches: 300, changeChecks: 1, contributions: 50, burstPerMinute: 60 },
+  // `enabled: 0` closes the whole /api/bridge/v1 protocol with a 503 — the
+  // same kill switch the MCP surface has. Key management and the self-hosted
+  // client's own Settings card stay up; only registry access stops.
+  bridge: { enabled: 1, searches: 600, fetches: 300, changeChecks: 1, contributions: 50, burstPerMinute: 60 },
   // Ephemeral public-demo accounts (POST /api/auth/demo-login). Cloning a
   // snapshot cellar per visitor is write-heavy, so this is bounded on three
   // axes: per-IP creation rate, a DURABLE global ceiling on concurrent live
@@ -220,6 +223,7 @@ async function load() {
           memberAlertDistinct:    doc.value.registryRead?.memberAlertDistinct    ?? defaults.registryRead.memberAlertDistinct,
         },
         bridge: {
+          enabled:        doc.value.bridge?.enabled        ?? defaults.bridge.enabled,
           searches:       doc.value.bridge?.searches       ?? defaults.bridge.searches,
           fetches:        doc.value.bridge?.fetches        ?? defaults.bridge.fetches,
           changeChecks:   doc.value.bridge?.changeChecks   ?? defaults.bridge.changeChecks,

--- a/backend/src/models/BridgeKey.js
+++ b/backend/src/models/BridgeKey.js
@@ -84,6 +84,13 @@ const bridgeKeySchema = new mongoose.Schema({
     type: Date,
     default: null,
   },
+  // Last time a canary fetch through this key raised an admin notification.
+  // The audit row is written for every hit; the notification is once a day, so
+  // discoverable canary ids cannot be used to bury admins in their own alarm.
+  canaryAlertAt: {
+    type: Date,
+    default: null,
+  },
   createdAt: {
     type: Date,
     default: Date.now,

--- a/backend/src/models/BridgeUsageDay.js
+++ b/backend/src/models/BridgeUsageDay.js
@@ -1,15 +1,24 @@
 const mongoose = require('mongoose');
 
 /**
- * One row per bridge key per UTC day: how many searches, wine fetches, change
- * checks and contributions the key spent (REGISTRY_LOCKDOWN_PLAN §6 quotas).
+ * One row per ACCOUNT per UTC day: how many searches, wine fetches, change
+ * checks and contributions the owner's bridge keys spent between them
+ * (REGISTRY_LOCKDOWN_PLAN §6 quotas).
+ *
+ * Per ACCOUNT, not per key, since the 2026-09-08 audit: the two-key cap counts
+ * only active keys, so revoking and re-minting is free, and a per-key row let
+ * one account cycle keys to multiply its allowance — each new key arriving
+ * with an unused import window — while every individual row stayed under the
+ * alert level. `key` records which key opened the day's row; it is attribution,
+ * never the identity of the counter.
  *
  * Quotas exist to make walking the registry slow and visible, not to make
  * adding bottles hard: the defaults are far above what a household spends in
  * a day, and the owner can open a 24-hour import window once a month. Distinct
  * wines per day — the number that actually tells a copier from a household —
- * are counted separately in RegistryReadDay under `key:<id>`, so bridge keys
- * appear in the same daily readers report as everyone else.
+ * are counted separately in RegistryReadDay under `user:<ownerId>` (detection)
+ * and `key:<id>` (attribution), so bridge readers appear in the same daily
+ * readers report as everyone else.
  *
  * Retention is short (TTL): the rows are an operational counter. GDPR: they
  * carry the owner's user id, so they are purged with the account and
@@ -18,6 +27,7 @@ const mongoose = require('mongoose');
 const RETENTION_DAYS = 90;
 
 const bridgeUsageDaySchema = new mongoose.Schema({
+  // The key that opened this day's row — attribution for the admin page.
   key: { type: mongoose.Schema.Types.ObjectId, ref: 'BridgeKey', required: true },
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, index: true },
   day: { type: String, required: true }, // YYYY-MM-DD, UTC
@@ -28,7 +38,11 @@ const bridgeUsageDaySchema = new mongoose.Schema({
   expiresAt: { type: Date, required: true },
 }, { timestamps: true });
 
-bridgeUsageDaySchema.index({ key: 1, day: 1 }, { unique: true });
+// The counter's identity. A stale unique {key, day} index from before the
+// 2026-09-08 audit is harmless (a key belongs to one account, so its rows stay
+// unique), but it can be dropped.
+bridgeUsageDaySchema.index({ user: 1, day: 1 }, { unique: true });
+bridgeUsageDaySchema.index({ day: 1 });
 bridgeUsageDaySchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 bridgeUsageDaySchema.statics.RETENTION_DAYS = RETENTION_DAYS;

--- a/backend/src/routes/admin/bridge.js
+++ b/backend/src/routes/admin/bridge.js
@@ -4,6 +4,8 @@ const { requireAuth, requireRole } = require('../../middleware/auth');
 const BridgeKey = require('../../models/BridgeKey');
 const BridgeUsageDay = require('../../models/BridgeUsageDay');
 const RegistryReadDay = require('../../models/RegistryReadDay');
+// The read counters' TTL bounds every distinct-wines figure below.
+const READ_RETENTION_DAYS = RegistryReadDay.RETENTION_DAYS || 14;
 const ApiToken = require('../../models/ApiToken');
 const User = require('../../models/User');
 const { KINDS, capsNow, importWindowActive } = require('../../services/bridgeQuota');
@@ -87,6 +89,9 @@ async function readsByReader(days, today, match = {}) {
 router.get('/keys', async (req, res) => {
   try {
     const days = daysParam(req.query.days);
+    // The read counters live for RETENTION_DAYS; asking for 30 or 90 silently
+    // returned a 14-day answer under a 90-day label (audit 2026-09-08).
+    const readDays = Math.min(days, READ_RETENTION_DAYS);
     const today = dayKey();
     const revokedSince = new Date(Date.now() - REVOKED_SHOWN_DAYS * 86400e3);
     const [keys, usage, reads] = await Promise.all([
@@ -97,7 +102,7 @@ router.get('/keys', async (req, res) => {
         .populate('revokedBy', 'username')
         .lean(),
       usageByKey(days, today),
-      readsByReader(days, today, { kind: 'key' }),
+      readsByReader(readDays, today, { kind: 'key' }),
     ]);
     const readMap = new Map(reads.map((r) => [String(r._id), r]));
     const rows = keys.map((k) => {
@@ -131,6 +136,7 @@ router.get('/keys', async (req, res) => {
     const sum = (kind) => rows.reduce((n, k) => n + (k.period[kind] || 0), 0);
     res.json({
       days,
+      readDays,
       today,
       caps: capsNow(),
       alertDistinct: limits().memberAlertDistinct,
@@ -157,8 +163,9 @@ router.get('/keys', async (req, res) => {
 router.get('/readers', async (req, res) => {
   try {
     const days = daysParam(req.query.days);
+    const readDays = Math.min(days, READ_RETENTION_DAYS);
     const today = dayKey();
-    const rows = (await readsByReader(days, today)).slice(0, READERS_MAX);
+    const rows = (await readsByReader(readDays, today)).slice(0, READERS_MAX);
     const idsOf = (prefix) => rows
       .filter((r) => typeof r._id === 'string' && r._id.startsWith(prefix))
       .map((r) => r._id.slice(prefix.length))
@@ -216,7 +223,7 @@ router.get('/readers', async (req, res) => {
         overAlert: (r.distinctMax || 0) > alertAt,
       };
     });
-    res.json({ days, today, thresholds: { anonymousDailyDistinct, memberAlertDistinct }, readers });
+    res.json({ days, readDays, retentionDays: READ_RETENTION_DAYS, today, thresholds: { anonymousDailyDistinct, memberAlertDistinct }, readers });
   } catch (err) {
     console.error('Admin bridge readers error:', err);
     res.status(500).json({ error: 'Failed to load registry readers' });

--- a/backend/src/routes/admin/bridge.test.js
+++ b/backend/src/routes/admin/bridge.test.js
@@ -13,7 +13,7 @@ process.env.JWT_SECRET = 'test-secret';
 jest.mock('../../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../../models/BridgeKey', () => ({ find: jest.fn(), findOne: jest.fn(), updateOne: jest.fn(), REVOKE_REASON_MAX: 300 }));
 jest.mock('../../models/BridgeUsageDay', () => ({ aggregate: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), RETENTION_DAYS: 90 }));
-jest.mock('../../models/RegistryReadDay', () => ({ aggregate: jest.fn() }));
+jest.mock('../../models/RegistryReadDay', () => ({ aggregate: jest.fn(), RETENTION_DAYS: 14 }));
 jest.mock('../../models/ApiToken', () => ({ find: jest.fn() }));
 jest.mock('../../models/User', () => ({ findById: jest.fn(), find: jest.fn(), exists: jest.fn().mockResolvedValue(true) }));
 
@@ -108,6 +108,7 @@ describe('GET /keys', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.days).toBe(7);
+    expect(body.readDays).toBe(7);
     expect(body.caps).toMatchObject({ searches: 600, fetches: 300, changeChecks: 1, contributions: 50 });
     expect(body.alertDistinct).toBe(1000);
     expect(body.totals).toEqual({ active: 1, revoked: 1, usedInPeriod: 1, searches: 40, fetches: 12, contributions: 1 });
@@ -140,6 +141,9 @@ describe('GET /keys', () => {
   test('clamps the window to 1–90 days and defaults to 7', async () => {
     let body = await (await get('/keys?days=400', admin())).json();
     expect(body.days).toBe(90);
+    // The distinct-wines half of the answer cannot go back further than the
+    // read counters live (audit 2026-09-08): 90 days of spend, 14 of reads.
+    expect(body.readDays).toBe(14);
     body = await (await get('/keys?days=abc', admin())).json();
     expect(body.days).toBe(7);
     body = await (await get('/keys?days=0', admin())).json();

--- a/backend/src/routes/admin/settings.js
+++ b/backend/src/routes/admin/settings.js
@@ -134,6 +134,9 @@ router.patch('/rate-limits', async (req, res) => {
       requireIntInRange('mcp.oauthMax',      mcp.oauthMax,      100, 1_000_000);
     }
 
+    // The upper bounds are deliberately near the size of the registry: a cap
+    // far above it refuses nobody, which is the safety mechanism switched off
+    // by a typo rather than by a decision (audit 2026-09-08).
     // Registry lockdown (L4): DISTINCT wines per reader per UTC day — the
     // one number that tells a person browsing from a copier. The anonymous
     // cap refuses for the rest of the day; the member level only puts a
@@ -141,8 +144,8 @@ router.patch('/rate-limits', async (req, res) => {
     // adding a case (20) or reporting every member every morning (50).
     // There is no 0 here on purpose: the endpoints have their own switches.
     if (registryRead !== undefined) {
-      requireIntInRange('registryRead.anonymousDailyDistinct', registryRead.anonymousDailyDistinct, 20, 100_000);
-      requireIntInRange('registryRead.memberAlertDistinct',    registryRead.memberAlertDistinct,    50, 1_000_000);
+      requireIntInRange('registryRead.anonymousDailyDistinct', registryRead.anonymousDailyDistinct, 20, 20_000);
+      requireIntInRange('registryRead.memberAlertDistinct',    registryRead.memberAlertDistinct,    50, 50_000);
     }
 
     // Registry Bridge quotas per key per UTC day, plus the per-minute burst
@@ -150,6 +153,7 @@ router.patch('/rate-limits', async (req, res) => {
     // keeps adding a bottle possible on the tightest setting; one change
     // check is what the weekly refresh needs; five a minute is a person.
     if (bridge !== undefined) {
+      requireIntInRange('bridge.enabled',        bridge.enabled,        0,  1);
       requireIntInRange('bridge.searches',       bridge.searches,       10, 100_000);
       requireIntInRange('bridge.fetches',        bridge.fetches,        10, 100_000);
       requireIntInRange('bridge.changeChecks',   bridge.changeChecks,   1,  1_000);
@@ -206,6 +210,7 @@ router.patch('/rate-limits', async (req, res) => {
         memberAlertDistinct:    registryRead?.memberAlertDistinct    ?? previous.registryRead?.memberAlertDistinct    ?? rateLimitsConfig.defaults.registryRead.memberAlertDistinct,
       },
       bridge: {
+        enabled:        bridge?.enabled        ?? previous.bridge?.enabled        ?? rateLimitsConfig.defaults.bridge.enabled,
         searches:       bridge?.searches       ?? previous.bridge?.searches       ?? rateLimitsConfig.defaults.bridge.searches,
         fetches:        bridge?.fetches        ?? previous.bridge?.fetches        ?? rateLimitsConfig.defaults.bridge.fetches,
         changeChecks:   bridge?.changeChecks   ?? previous.bridge?.changeChecks   ?? rateLimitsConfig.defaults.bridge.changeChecks,

--- a/backend/src/routes/admin/settings.registry.test.js
+++ b/backend/src/routes/admin/settings.registry.test.js
@@ -55,7 +55,7 @@ test('GET exposes both groups with their defaults', async () => {
   const res = await fetch(`${baseUrl}/api/admin/settings/rate-limits`, { headers: { Authorization: `Bearer ${admin()}` } });
   const body = await res.json();
   expect(body.config.registryRead).toEqual({ anonymousDailyDistinct: 300, memberAlertDistinct: 1000 });
-  expect(body.config.bridge).toEqual({ searches: 600, fetches: 300, changeChecks: 1, contributions: 50, burstPerMinute: 60 });
+  expect(body.config.bridge).toEqual({ enabled: 1, searches: 600, fetches: 300, changeChecks: 1, contributions: 50, burstPerMinute: 60 });
   expect(body.defaults.bridge.fetches).toBe(300);
 });
 
@@ -64,7 +64,7 @@ test('a partial PATCH changes only the fields sent and reaches the tracker and t
   expect(res.status).toBe(200);
   const { config } = await res.json();
   expect(config.registryRead).toEqual({ anonymousDailyDistinct: 500, memberAlertDistinct: 1000 });
-  expect(config.bridge).toEqual({ searches: 600, fetches: 1000, changeChecks: 1, contributions: 50, burstPerMinute: 120 });
+  expect(config.bridge).toEqual({ enabled: 1, searches: 600, fetches: 1000, changeChecks: 1, contributions: 50, burstPerMinute: 120 });
   // Untouched groups survive the wholesale set().
   expect(config.mcp).toEqual(rateLimitsConfig.defaults.mcp);
   expect(config.aiBurst).toEqual(rateLimitsConfig.defaults.aiBurst);

--- a/backend/src/routes/bridgeKeys.js
+++ b/backend/src/routes/bridgeKeys.js
@@ -43,6 +43,9 @@ async function presentKey(key) {
 
 // How long an admin revocation stays visible to the owner in Settings.
 const REVOKED_NOTICE_DAYS = 30;
+// Key minting is bounded per account per day — see the churn guard below.
+const KEY_CHURN_MAX = 5;
+const KEY_CHURN_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Keys an ADMIN revoked recently, with the reason — the owner's only way to
@@ -132,6 +135,22 @@ router.post('/', requireAuth, requireNonDemo, passwordConfirmLimiter, async (req
     const activeCount = await BridgeKey.countDocuments({ user: req.user.id, revokedAt: null });
     if (activeCount >= MAX_ACTIVE_PER_USER) {
       return res.status(400).json({ error: `Maximum of ${MAX_ACTIVE_PER_USER} active bridge keys reached — revoke one first`, code: 'key_cap' });
+    }
+    // Churn guard (audit 2026-09-08): the active-key cap alone is no cap at
+    // all, because revoking frees the slot immediately. Quotas and the import
+    // window now count per account, so re-minting no longer multiplies an
+    // allowance — this bounds the remaining nuisance (a fresh prefix per
+    // request to muddy attribution) and keeps a scripted loop out of the logs.
+    const mintedToday = await BridgeKey.countDocuments({
+      user: req.user.id,
+      createdAt: { $gte: new Date(Date.now() - KEY_CHURN_WINDOW_MS) },
+    });
+    if (mintedToday >= KEY_CHURN_MAX) {
+      logAudit(req, 'bridge.key.create_failed', { type: 'user', id: req.user.id }, { reason: 'churn', mintedToday });
+      return res.status(429).json({
+        error: `Too many bridge keys created today (${KEY_CHURN_MAX}). Existing keys keep working; try again tomorrow.`,
+        code: 'key_churn',
+      });
     }
 
     const rawKey = BridgeKey.generateKey();

--- a/backend/src/routes/bridgeKeys.test.js
+++ b/backend/src/routes/bridgeKeys.test.js
@@ -217,3 +217,31 @@ describe('GET /api/bridge/keys — admin revocation notice', () => {
     expect((await res.json()).revoked).toEqual([]);
   });
 });
+
+describe('audit 2026-09-08 — key churn', () => {
+  test('minting is bounded per account per day, and the refusal is audited', async () => {
+    const u = userDoc({ registryTerms: { accepted: true, acceptedAt: new Date(), version: '2026-09' } });
+    User.findById.mockResolvedValue(u);
+    // First call: active keys. Second: keys minted in the last 24 hours.
+    BridgeKey.countDocuments.mockResolvedValueOnce(0).mockResolvedValueOnce(5);
+
+    const res = await call('POST', '/api/bridge/keys', { name: 'Home NAS', password: 'pw', acceptTerms: true });
+    expect(res.status).toBe(429);
+    expect((await res.json()).code).toBe('key_churn');
+    expect(BridgeKey.create).not.toHaveBeenCalled();
+    // The active-key cap alone was no cap: revoking frees the slot at once, so
+    // mint-revoke-mint was unbounded (audit 2026-09-08).
+    const churnFilter = BridgeKey.countDocuments.mock.calls[1][0];
+    expect(churnFilter.createdAt.$gte).toBeInstanceOf(Date);
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'bridge.key.create_failed', expect.anything(), expect.objectContaining({ reason: 'churn' }));
+  });
+
+  test('under the daily limit a key is still issued', async () => {
+    const u = userDoc({ registryTerms: { accepted: true, acceptedAt: new Date(), version: '2026-09' } });
+    User.findById.mockResolvedValue(u);
+    BridgeKey.countDocuments.mockResolvedValueOnce(0).mockResolvedValueOnce(4);
+    BridgeKey.create.mockImplementation(async (doc) => ({ _id: 'k1', createdAt: new Date(), ...doc }));
+    const res = await call('POST', '/api/bridge/keys', { name: 'Home NAS', password: 'pw', acceptTerms: true });
+    expect(res.status).toBe(201);
+  });
+});

--- a/backend/src/routes/bridgeV1.js
+++ b/backend/src/routes/bridgeV1.js
@@ -16,6 +16,7 @@ const { createWineRequest } = require('../services/accountOps');
 const { createNotifications } = require('../services/notifications');
 const { logAudit } = require('../services/audit');
 const { rateLimitKey } = require('../utils/clientIp');
+const BridgeKey = require('../models/BridgeKey');
 const { requireBridgeKey } = require('../middleware/bridgeKeyAuth');
 const { quota, usageFor, capsNow } = require('../services/bridgeQuota');
 const rateLimitsConfig = require('../config/rateLimits');
@@ -36,6 +37,7 @@ const { CURRENT_REGISTRY_TERMS_VERSION } = require('../config/legal');
 // canary wine fetched through a key names the key in the readers report.
 
 const SEARCH_LIMIT = 10;                 // == USER_SEARCH_LIMIT in routes/wines.js
+const CANARY_ALERT_THROTTLE_MS = 24 * 60 * 60 * 1000;
 const QUERY_MIN = 2;
 const QUERY_MAX = 120;
 const CHANGES_MAX_IDS = 5000;
@@ -49,7 +51,9 @@ const IDENTITY_SELECT = 'name producer slug country region appellation classific
 // bookkeeping, the model name, the input snapshot or the producer note.
 const PROFILE_FIELDS = ['body', 'tannin', 'acidity', 'sweetness', 'flavors', 'foodPairings', 'description', 'source', 'generatedAt', 'verifiedAt'];
 
-const isValidId = (id) => mongoose.isValidObjectId(String(id));
+// Strict: mongoose.isValidObjectId() also accepts any 12-character string, so
+// a nested value could reach $in and raise a CastError 500 (audit 2026-09-08).
+const isValidId = (id) => /^[a-f0-9]{24}$/i.test(String(id));
 
 // Pre-auth per-address limiter: bounds key guessing and probing. A
 // self-hosted install is one address for all its users, so this is loose;
@@ -86,7 +90,18 @@ const keyLimiter = rateLimit({
   },
 });
 
-router.use(ipLimiter, requireBridgeKey, keyLimiter);
+// Kill switch: `bridge.enabled = 0` closes the whole protocol with a clear
+// 503, the lever routes/mcp.js has had since it shipped and this surface
+// lacked (audit 2026-09-08). Read from the in-memory config, so it takes
+// effect on the next request without a restart.
+function bridgeOpen(req, res, next) {
+  if ((rateLimitsConfig.get().bridge || {}).enabled === 0) {
+    return res.status(503).json({ error: 'The Registry Bridge is closed on this instance right now.', code: 'closed' });
+  }
+  next();
+}
+
+router.use(bridgeOpen, ipLimiter, requireBridgeKey, keyLimiter);
 
 function nameOf(ref) {
   if (!ref) return null;
@@ -143,10 +158,23 @@ function sendResult(res, r, ok) {
   return ok(r);
 }
 
-/** A canary fetched through a key: audit + tell the admins now, not tomorrow. */
+/**
+ * A canary fetched through a key: audit + tell the admins now, not tomorrow.
+ *
+ * The AUDIT row is written for every hit; the notification is throttled to one
+ * per key per day. Canary ids are discoverable from public pages, so an
+ * unthrottled notify was a way to bury admins in their own alarm (audit
+ * 2026-09-08).
+ */
 async function reportCanaryFetch(req, wine) {
   try {
     logAudit(req, 'bridge.canary_hit', { type: 'wine', id: wine._id }, { key: req.bridge.key.id, keyName: req.bridge.key.name, instanceHost: req.bridge.key.instanceHost });
+    const alerted = await BridgeKey.findOneAndUpdate(
+      { _id: req.bridge.keyDoc._id, $or: [{ canaryAlertAt: null }, { canaryAlertAt: { $lt: new Date(Date.now() - CANARY_ALERT_THROTTLE_MS) } }] },
+      { $set: { canaryAlertAt: new Date() } },
+      { new: false }
+    ).select('_id').lean();
+    if (!alerted) return;   // already told today; the audit row still records the hit
     const admins = await User.find({ roles: 'admin' }).select('_id').lean();
     await createNotifications(admins.map((a) => ({
       userId: a._id,
@@ -179,11 +207,32 @@ router.get('/me', async (req, res) => {
 });
 
 // GET /v1/search?q=  — identities only, capped like the web UI's add-bottle search.
-router.get('/search', quota('searches'), async (req, res) => {
+// Validation runs BEFORE the quota is spent: a malformed call used to cost a
+// unit, and with one change check a day that meant a single typo silenced the
+// weekly refresh until UTC midnight (audit 2026-09-08).
+function validSearch(req, res, next) {
   const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
   if (q.length < QUERY_MIN || q.length > QUERY_MAX) {
     return res.status(400).json({ error: `q must be ${QUERY_MIN}–${QUERY_MAX} characters`, code: 'invalid' });
   }
+  req.bridgeQuery = q;
+  next();
+}
+
+function validChanges(req, res, next) {
+  const ids = Array.isArray(req.body?.ids) ? req.body.ids : null;
+  if (!ids || ids.length === 0 || ids.length > CHANGES_MAX_IDS || !ids.every(isValidId)) {
+    return res.status(400).json({ error: `ids must be 1–${CHANGES_MAX_IDS} wine ids`, code: 'invalid' });
+  }
+  const since = req.body?.since ? new Date(req.body.since) : new Date(0);
+  if (Number.isNaN(since.getTime())) return res.status(400).json({ error: 'since must be an ISO date', code: 'invalid' });
+  req.bridgeIds = ids;
+  req.bridgeSince = since;
+  next();
+}
+
+router.get('/search', validSearch, quota('searches'), async (req, res) => {
+  const q = req.bridgeQuery;
   try {
     let wines = null;
     if (searchService.getIsAvailable()) {
@@ -206,6 +255,12 @@ router.get('/search', quota('searches'), async (req, res) => {
         .populate(['country', 'region', 'grapes'])
         .lean();
     }
+    // A search is a read of the registry too — ten identities a call, hundreds
+    // of calls a day. Counting only single fetches left the copy detector
+    // blind to this path (audit 2026-09-08). Detection counts on the owner.
+    if (wines.length) {
+      recordRead({ key: `user:${req.user.id}`, kind: 'user' }, wines.map((w) => w._id)).catch(() => {});
+    }
     res.json({ query: q, count: wines.length, wines: wines.map(identity) });
   } catch (error) {
     console.error('Bridge search error:', error);
@@ -225,7 +280,11 @@ router.get('/wines/:id', quota('fetches'), async (req, res) => {
     });
     if (!wine || wine.nonWine) return res.status(404).json({ error: 'Wine not found', code: 'not_found' });
 
-    await recordRead({ key: `key:${req.bridge.key.id}`, kind: 'key' }, wine._id);
+    // Detection counts on the OWNER: keys are re-mintable, so a per-key row
+    // let one account stay under the alert level by cycling keys (audit
+    // 2026-09-08). The per-key row stays for attribution on the admin page.
+    await recordRead({ key: `user:${req.user.id}`, kind: 'user' }, wine._id);
+    recordRead({ key: `key:${req.bridge.key.id}`, kind: 'key' }, wine._id).catch(() => {});
     if (wine.canary) await reportCanaryFetch(req, wine);
 
     const [windows, values] = await Promise.all([
@@ -244,8 +303,10 @@ router.get('/wines/:id', quota('fetches'), async (req, res) => {
         windows: windows.map(windowOf),
         // Published registry values only; who contributed them stays on the
         // hosted page.
+        // A field whose figures exist only per vintage has a null wine-wide
+        // value; dropping it took its overrides with it (audit 2026-09-08).
         values: values && values.ok
-          ? values.fields.filter((f) => f.value !== null && f.value !== undefined)
+          ? values.fields.filter((f) => f.value !== null && f.value !== undefined || f.wineValue !== null && f.wineValue !== undefined || (f.overrides || []).length > 0)
             .map((f) => ({ key: f.key, value: f.value, wineValue: f.wineValue ?? null, overrides: f.overrides || [] }))
           : [],
       },
@@ -258,16 +319,16 @@ router.get('/wines/:id', quota('fetches'), async (req, res) => {
 
 // POST /v1/wines/changes — { ids: [...], since: ISO } → which of THOSE changed.
 // Never a global feed: an install can only ask about wines it already holds.
-router.post('/wines/changes', quota('changeChecks'), async (req, res) => {
-  const ids = Array.isArray(req.body?.ids) ? req.body.ids : null;
-  if (!ids || ids.length === 0 || ids.length > CHANGES_MAX_IDS || !ids.every(isValidId)) {
-    return res.status(400).json({ error: `ids must be 1–${CHANGES_MAX_IDS} wine ids`, code: 'invalid' });
-  }
-  const since = req.body?.since ? new Date(req.body.since) : new Date(0);
-  if (Number.isNaN(since.getTime())) return res.status(400).json({ error: 'since must be an ISO date', code: 'invalid' });
+router.post('/wines/changes', validChanges, quota('changeChecks'), async (req, res) => {
+  const ids = req.bridgeIds;
+  const since = req.bridgeSince;
   try {
     const checkedAt = new Date();
-    const found = await WineDefinition.find({ _id: { $in: ids } }).select('_id updatedAt nonWine').lean();
+    // The same visibility the single-wine fetch applies: a hidden row must
+    // report as removed, not as changed, or the change check is an existence
+    // oracle for wines /wines/:id would 404 (audit 2026-09-08).
+    const found = await WineDefinition.find({ _id: { $in: ids }, ...VISIBLE, canary: { $ne: true } })
+      .select('_id updatedAt nonWine').lean();
     const present = new Map(found.map((w) => [String(w._id), w]));
     const changed = [];
     const removed = [];

--- a/backend/src/routes/bridgeV1.test.js
+++ b/backend/src/routes/bridgeV1.test.js
@@ -23,6 +23,12 @@ jest.mock('../services/notifications', () => ({ createNotifications: jest.fn().m
 jest.mock('../services/audit', () => ({ logAudit: jest.fn() }));
 jest.mock('../utils/clientIp', () => ({ rateLimitKey: (req) => req.ip || '127.0.0.1' }));
 jest.mock('../config/legal', () => ({ CURRENT_REGISTRY_TERMS_VERSION: '2026-09' }));
+// The canary notification is throttled to one per key per day through this
+// conditional update; `new: false` returns the pre-update doc, so a truthy
+// answer means "not told yet today".
+jest.mock('../models/BridgeKey', () => ({
+  findOneAndUpdate: jest.fn(() => ({ select: () => ({ lean: () => Promise.resolve({ _id: 'k1' }) }) })),
+}));
 // The key middleware and the quota are unit-tested on their own; here they are
 // stand-ins that inject an owner and spend nothing, unless a test flips them.
 jest.mock('../middleware/bridgeKeyAuth', () => ({
@@ -36,8 +42,14 @@ jest.mock('../middleware/bridgeKeyAuth', () => ({
 // Quota kinds are wired at require time; jest.clearAllMocks in beforeEach would
 // wipe the mock's call list, so they are also recorded on a plain array.
 global.__bridgeQuotaKinds = [];
+// __bridgeQuotaSpends records the middleware actually RUNNING, which is how a
+// test can tell that validation refused a request before it cost a unit.
+global.__bridgeQuotaSpends = [];
 jest.mock('../services/bridgeQuota', () => ({
-  quota: jest.fn((kind) => { global.__bridgeQuotaKinds.push(kind); return (req, res, next) => next(); }),
+  quota: jest.fn((kind) => {
+    global.__bridgeQuotaKinds.push(kind);
+    return (req, res, next) => { global.__bridgeQuotaSpends.push(kind); next(); };
+  }),
   usageFor: jest.fn().mockResolvedValue({ day: '2026-09-08', used: {}, caps: {} }),
   QUOTAS: { searches: 600, fetches: 300, changeChecks: 1, contributions: 50 },
   capsNow: () => ({ searches: 600, fetches: 300, changeChecks: 1, contributions: 50 }),
@@ -55,6 +67,7 @@ const { dataForWine, suggestValue } = require('../services/registryDataOps');
 const { createFieldCorrection } = require('../services/wineProposalOps');
 const { createWineRequest } = require('../services/accountOps');
 const { createNotifications } = require('../services/notifications');
+const BridgeKey = require('../models/BridgeKey');
 const { logAudit } = require('../services/audit');
 const { quota } = require('../services/bridgeQuota');
 const router = require('./bridgeV1');
@@ -198,7 +211,15 @@ describe('POST /wines/changes', () => {
     const res = await call('POST', '/api/bridge/v1/wines/changes', { ids: [ID, ID2, ID3], since: '2026-09-01T00:00:00Z' });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(WineDefinition.find).toHaveBeenCalledWith({ _id: { $in: [ID, ID2, ID3] } });
+    // The same visibility as a single fetch: a hidden row reports as removed,
+    // never as changed, so the check is not an existence oracle (audit
+    // 2026-09-08).
+    expect(WineDefinition.find).toHaveBeenCalledWith(expect.objectContaining({
+      _id: { $in: [ID, ID2, ID3] },
+      nonWine: { $ne: true },
+      pendingIdentity: { $ne: true },
+      canary: { $ne: true },
+    }));
     expect(body.changed).toEqual([{ id: ID, updatedAt: '2026-09-05T00:00:00.000Z' }]);
     expect(body.removed).toEqual([ID3]);
     expect(body.checked).toBe(3);
@@ -244,5 +265,69 @@ describe('contributions', () => {
     expect(res.status).toBe(201);
     expect(suggestValue).toHaveBeenCalledWith('u1', expect.objectContaining({ wineId: ID, keyName: 'ABV', value: 14.5, vintage: '2019' }), expect.objectContaining({ via: 'bridge' }));
     expect((await res.json()).suggestion).toEqual({ id: 'v1', status: 'suggested' });
+  });
+});
+
+// ── Audit 2026-09-08 regressions ─────────────────────────────────────────────
+
+describe('audit 2026-09-08 — counting and the kill switch', () => {
+  const rateLimitsConfig = require('../config/rateLimits');
+  afterEach(() => rateLimitsConfig.set(JSON.parse(JSON.stringify(rateLimitsConfig.defaults))));
+
+  test('a wine fetch counts on the OWNER as well as the key', async () => {
+    findVisibleWine.mockResolvedValue(wine());
+    await call('GET', `/api/bridge/v1/wines/${ID}`);
+    // Detection has to survive key rotation: the two-key cap counts only
+    // ACTIVE keys, so revoke-and-remint is free and a per-key row let one
+    // account stay under the alert level forever.
+    expect(recordRead).toHaveBeenCalledWith({ key: 'user:u1', kind: 'user' }, ID);
+    expect(recordRead).toHaveBeenCalledWith({ key: 'key:k1', kind: 'key' }, ID);
+  });
+
+  test('a search counts the identities it hands out', async () => {
+    searchService.getIsAvailable.mockReturnValue(false);
+    WineDefinition.find.mockReturnValue(chain([{ _id: ID, name: 'Salmos' }, { _id: ID2, name: 'Mas La Plana' }]));
+    const res = await call('GET', '/api/bridge/v1/search?q=salmos');
+    expect(res.status).toBe(200);
+    // Ten identities a call, hundreds of calls a day: counting only single
+    // fetches left this path invisible to the copy detector.
+    expect(recordRead).toHaveBeenCalledWith({ key: 'user:u1', kind: 'user' }, [ID, ID2]);
+  });
+
+  test('the kill switch closes the protocol with a 503, before the key is even read', async () => {
+    rateLimitsConfig.set({ ...rateLimitsConfig.get(), bridge: { ...rateLimitsConfig.get().bridge, enabled: 0 } });
+    const res = await call('GET', '/api/bridge/v1/me');
+    expect(res.status).toBe(503);
+    expect((await res.json()).code).toBe('closed');
+  });
+
+  test('a canary raises at most one notification per key per day; every hit is audited', async () => {
+    findVisibleWine.mockResolvedValue(wine({ canary: true }));
+    await call('GET', `/api/bridge/v1/wines/${ID}`);
+    expect(createNotifications).toHaveBeenCalledTimes(1);
+
+    // Second hit the same day: the conditional update matches nothing.
+    BridgeKey.findOneAndUpdate.mockReturnValue({ select: () => ({ lean: () => Promise.resolve(null) }) });
+    createNotifications.mockClear();
+    logAudit.mockClear();
+    await call('GET', `/api/bridge/v1/wines/${ID}`);
+    expect(createNotifications).not.toHaveBeenCalled();
+    // Canary ids are discoverable from public pages, so the alarm is
+    // throttled — but the audit trail is not.
+    expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'bridge.canary_hit', expect.anything(), expect.anything());
+  });
+
+  test('a malformed request is refused before it costs quota', async () => {
+    global.__bridgeQuotaSpends.length = 0;
+    expect((await call('POST', '/api/bridge/v1/wines/changes', { ids: [] })).status).toBe(400);
+    expect((await call('GET', '/api/bridge/v1/search?q=a')).status).toBe(400);
+    // With one change check a day, a single malformed call used to silence the
+    // weekly refresh until UTC midnight.
+    expect(global.__bridgeQuotaSpends).toEqual([]);
+
+    // …and a well-formed one still spends.
+    WineDefinition.find.mockReturnValue(chain([]));
+    expect((await call('POST', '/api/bridge/v1/wines/changes', { ids: [ID] })).status).toBe(200);
+    expect(global.__bridgeQuotaSpends).toEqual(['changeChecks']);
   });
 });

--- a/backend/src/services/bridgeQuota.js
+++ b/backend/src/services/bridgeQuota.js
@@ -60,10 +60,15 @@ function capFor(kind, keyDoc, now = Date.now()) {
 }
 
 /**
- * Spend one unit of `kind` for the key. Returns { allowed, used, cap, resetAt }.
+ * Spend one unit of `kind` for the key's OWNER. Returns
+ * { allowed, used, cap, resetAt }.
+ *
  * The counter is incremented first and compared after, so two concurrent
  * requests at the edge of a cap both count; a cap can be overshot by the
  * number of concurrent requests, never silently underspent.
+ *
+ * Keyed on the account, not the key: keys are freely re-mintable, so a per-key
+ * counter was an allowance multiplier (audit 2026-09-08).
  */
 async function takeQuota(keyDoc, kind) {
   if (!KINDS.includes(kind)) throw new Error(`Unknown bridge quota kind: ${kind}`);
@@ -74,16 +79,29 @@ async function takeQuota(keyDoc, kind) {
   }
   try {
     const row = await BridgeUsageDay.findOneAndUpdate(
-      { key: keyDoc._id, day: dayKey(new Date(now)) },
+      { user: keyDoc.user, day: dayKey(new Date(now)) },
       {
         $inc: { [kind]: 1 },
-        $setOnInsert: { user: keyDoc.user, expiresAt: new Date(now + BridgeUsageDay.RETENTION_DAYS * 86400e3) },
+        $setOnInsert: { key: keyDoc._id, expiresAt: new Date(now + BridgeUsageDay.RETENTION_DAYS * 86400e3) },
       },
       { upsert: true, new: true, projection: { [kind]: 1 } }
     ).lean();
     const used = row?.[kind] || 0;
     return { allowed: used <= cap, used, cap, resetAt: resetAt(now), counted: true };
   } catch (err) {
+    // A racing upsert can raise E11000 on the {user, day} unique index: the row
+    // exists on the retry, so the spend is counted rather than waved through.
+    if (err && err.code === 11000) {
+      try {
+        const row = await BridgeUsageDay.findOneAndUpdate(
+          { user: keyDoc.user, day: dayKey(new Date(now)) },
+          { $inc: { [kind]: 1 } },
+          { new: true, projection: { [kind]: 1 } }
+        ).lean();
+        const used = row?.[kind] || 0;
+        return { allowed: used <= cap, used, cap, resetAt: resetAt(now), counted: true };
+      } catch { /* fall through to fail-open */ }
+    }
     console.error('[bridge] quota write failed:', err.message);
     return { allowed: true, used: 0, cap, resetAt: resetAt(now), counted: false };
   }
@@ -94,7 +112,7 @@ async function usageFor(keyDoc, now = Date.now()) {
   const day = dayKey(new Date(now));
   let row = null;
   if (mongoose.connection.readyState === 1) {
-    row = await BridgeUsageDay.findOne({ key: keyDoc._id, day }).lean().catch(() => null);
+    row = await BridgeUsageDay.findOne({ user: keyDoc.user, day }).lean().catch(() => null);
   }
   const used = {}; const caps = {};
   for (const kind of KINDS) {
@@ -116,17 +134,27 @@ async function usageFor(keyDoc, now = Date.now()) {
 }
 
 /**
- * Open the ×5 window for 24 hours. Once per 30 days per key: the point is a
- * cellar import, not a standing raise. Returns { ok, until } or
+ * Open the ×5 window for 24 hours. Once per 30 days per ACCOUNT: the point is a
+ * cellar import, not a standing raise, and a per-KEY cooldown was simply a
+ * mint-a-new-key away (audit 2026-09-08). The window is written to every active
+ * key of the owner, so the sync `capFor(kind, keyDoc)` above stays correct
+ * whichever key makes the request. Returns { ok, until } or
  * { ok: false, nextAvailableAt }.
  */
 async function openImportWindow(keyDoc, now = Date.now()) {
-  const openedAt = keyDoc.importWindowOpenedAt ? new Date(keyDoc.importWindowOpenedAt).getTime() : null;
-  if (openedAt && now - openedAt < IMPORT_COOLDOWN_MS) {
-    return { ok: false, nextAvailableAt: new Date(openedAt + IMPORT_COOLDOWN_MS) };
+  const since = new Date(now - IMPORT_COOLDOWN_MS);
+  const recent = await BridgeKey.findOne({ user: keyDoc.user, importWindowOpenedAt: { $gte: since } })
+    .select('importWindowOpenedAt')
+    .sort({ importWindowOpenedAt: -1 })
+    .lean();
+  if (recent?.importWindowOpenedAt) {
+    return { ok: false, nextAvailableAt: new Date(new Date(recent.importWindowOpenedAt).getTime() + IMPORT_COOLDOWN_MS) };
   }
   const until = new Date(now + IMPORT_WINDOW_MS);
-  await BridgeKey.updateOne({ _id: keyDoc._id }, { $set: { importWindowUntil: until, importWindowOpenedAt: new Date(now) } });
+  await BridgeKey.updateMany(
+    { user: keyDoc.user, revokedAt: null },
+    { $set: { importWindowUntil: until, importWindowOpenedAt: new Date(now) } }
+  );
   return { ok: true, until };
 }
 

--- a/backend/src/services/bridgeQuota.test.js
+++ b/backend/src/services/bridgeQuota.test.js
@@ -10,7 +10,11 @@
  * database fails OPEN so a self-hoster is never refused by a counter outage.
  */
 jest.mock('mongoose', () => ({ connection: { readyState: 1 } }));
-jest.mock('../models/BridgeKey', () => ({ updateOne: jest.fn().mockResolvedValue({}) }));
+jest.mock('../models/BridgeKey', () => ({
+  updateOne: jest.fn().mockResolvedValue({}),
+  updateMany: jest.fn().mockResolvedValue({}),
+  findOne: jest.fn(),
+}));
 jest.mock('../models/BridgeUsageDay', () => ({
   findOneAndUpdate: jest.fn(),
   findOne: jest.fn(),
@@ -28,15 +32,25 @@ const lean = (doc) => ({ lean: () => Promise.resolve(doc) });
 beforeEach(() => {
   jest.clearAllMocks();
   mongoose.connection.readyState = 1;
+  // No earlier import window anywhere on the account, unless a test says so.
+  BridgeKey.findOne.mockReturnValue({ select: () => ({ sort: () => ({ lean: () => Promise.resolve(null) }) }) });
+});
+
+/** The account-wide cooldown lookup, answering with one key's opening date. */
+const openedAt = (date) => BridgeKey.findOne.mockReturnValue({
+  select: () => ({ sort: () => ({ lean: () => Promise.resolve(date ? { importWindowOpenedAt: date } : null) }) }),
 });
 
 describe('takeQuota', () => {
   test('spends one unit and allows while at or under the cap', async () => {
     BridgeUsageDay.findOneAndUpdate.mockReturnValue(lean({ searches: 600 }));
     const r = await q.takeQuota(key(), 'searches');
+    // Keyed on the ACCOUNT: keys are re-mintable, so a per-key counter was an
+    // allowance multiplier (audit 2026-09-08). The key is recorded for
+    // attribution only.
     expect(BridgeUsageDay.findOneAndUpdate).toHaveBeenCalledWith(
-      { key: 'k1', day: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) },
-      expect.objectContaining({ $inc: { searches: 1 }, $setOnInsert: expect.objectContaining({ user: 'u1' }) }),
+      { user: 'u1', day: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) },
+      expect.objectContaining({ $inc: { searches: 1 }, $setOnInsert: expect.objectContaining({ key: 'k1' }) }),
       expect.objectContaining({ upsert: true, new: true })
     );
     expect(r).toMatchObject({ allowed: true, used: 600, cap: 600, counted: true });
@@ -100,18 +114,36 @@ describe('usageFor / openImportWindow', () => {
     expect(u.importWindow.nextAvailableAt.getTime()).toBe(opened.getTime() + q.IMPORT_COOLDOWN_MS);
   });
 
-  test('opening the window sets 24 hours and refuses a second opening within 30 days', async () => {
+  test('opening the window sets 24 hours on every active key of the ACCOUNT', async () => {
     const first = await q.openImportWindow(key());
     expect(first.ok).toBe(true);
     expect(first.until.getTime() - Date.now()).toBeGreaterThan(q.IMPORT_WINDOW_MS - 5000);
-    expect(BridgeKey.updateOne).toHaveBeenCalledWith({ _id: 'k1' }, { $set: expect.objectContaining({ importWindowUntil: first.until }) });
+    // Every active key of the owner, so the sync capFor(keyDoc) stays right
+    // whichever key makes the next request.
+    expect(BridgeKey.updateMany).toHaveBeenCalledWith(
+      { user: 'u1', revokedAt: null },
+      { $set: expect.objectContaining({ importWindowUntil: first.until }) }
+    );
+  });
 
-    const again = await q.openImportWindow(key({ importWindowOpenedAt: new Date(Date.now() - 10 * 86400e3) }));
+  test('the 30-day cooldown is per ACCOUNT — a freshly minted key does not reset it', async () => {
+    // The cooldown lookup asks about the OWNER, not the key in hand: a brand
+    // new key with importWindowOpenedAt: null used to grant ×5 immediately
+    // (audit 2026-09-08).
+    openedAt(new Date(Date.now() - 10 * 86400e3));
+    const again = await q.openImportWindow(key({ importWindowOpenedAt: null }));
     expect(again.ok).toBe(false);
     expect(again.nextAvailableAt).toBeInstanceOf(Date);
+    expect(BridgeKey.findOne).toHaveBeenCalledWith(expect.objectContaining({ user: 'u1' }));
+    expect(BridgeKey.updateMany).not.toHaveBeenCalled();
 
+    // Older than the cooldown: the real query filters on
+    // `importWindowOpenedAt >= now - 30 days`, so it finds nothing.
+    openedAt(null);
     const later = await q.openImportWindow(key({ importWindowOpenedAt: new Date(Date.now() - 31 * 86400e3) }));
     expect(later.ok).toBe(true);
+    expect(BridgeKey.findOne.mock.calls[BridgeKey.findOne.mock.calls.length - 1][0].importWindowOpenedAt.$gte)
+      .toBeInstanceOf(Date);
   });
 });
 

--- a/backend/src/services/registryBridge.js
+++ b/backend/src/services/registryBridge.js
@@ -48,7 +48,43 @@ function refreshEnvMode() {
   const raw = String(process.env.REGISTRY_BRIDGE_REFRESH || '').trim().toLowerCase();
   if (!raw) return null;
   if (['off', 'false', '0', 'no', 'never', 'none'].includes(raw)) return 'off';
-  return 'weekly';
+  if (raw === 'weekly' || raw === 'on' || raw === 'true' || raw === '1') return 'weekly';
+  // Anything else is a typo, and treating it as "weekly" ALSO locked the admin
+  // toggle with env_override — refresh on, no way to turn it off (audit
+  // 2026-09-08). Warn and fall through to the Settings switch instead.
+  console.warn(`[bridge] REGISTRY_BRIDGE_REFRESH="${raw}" is not "weekly" or "off" — ignoring it; the Settings switch decides.`);
+  return null;
+}
+
+/**
+ * The install's own bridge state: the change-check watermark and the last run.
+ * Persisted so a restart — which is the last step of connecting — does not
+ * erase the only record of what the refresh did (audit 2026-09-08).
+ */
+async function bridgeState() {
+  try {
+    const doc = await siteConfigModel().findOne({ key: SITE_CONFIG_KEY }).lean();
+    return doc?.value || {};
+  } catch {
+    return {};
+  }
+}
+
+async function saveBridgeState(patch) {
+  try {
+    const current = await bridgeState();
+    const { updateSiteConfig } = require('../utils/siteConfig');
+    await updateSiteConfig(SITE_CONFIG_KEY, { ...current, ...patch }, null);
+  } catch (err) {
+    console.warn('[bridge] could not persist the refresh state:', err.message);
+  }
+}
+
+/** Remember a run that did nothing, so the card can say why. */
+function recordRefresh(summary) {
+  lastRefresh = summary;
+  saveBridgeState({ lastRefresh: summary }).catch(() => {});
+  return summary;
 }
 
 /** { mode: 'weekly' | 'off', source: 'env' | 'settings' | 'default' } */
@@ -71,15 +107,25 @@ async function setRefreshMode(mode, userId) {
   const env = refreshEnvMode();
   if (env) return { ok: false, code: 'env_override', mode: env, source: 'env' };
   const { updateSiteConfig } = require('../utils/siteConfig');
-  await updateSiteConfig(SITE_CONFIG_KEY, { refresh: mode }, userId);
+  // Merge: the same document holds the change-check watermark and the last
+  // run, and a wholesale write would erase them.
+  const current = await bridgeState();
+  await updateSiteConfig(SITE_CONFIG_KEY, { ...current, refresh: mode }, userId);
   return { ok: true, mode, source: 'settings' };
 }
 
 // Local changes win. A window or value row the bridge wrote carries
-// REGISTRY_NOTE and the sync time; a row written by someone on this install,
-// or touched after the last sync, is theirs and is never overwritten by an
-// adoption or a refresh. A seeded placeholder (no dates, no note) is not an
+// REGISTRY_NOTE and is stamped with the same instant as the wine's
+// registrySyncedAt; a row written by someone on this install, or one whose
+// stamp no longer MATCHES that instant, is theirs and is never overwritten by
+// an adoption or a refresh. A seeded placeholder (no dates, no note) is not an
 // edit, so the registry still fills it.
+//
+// The comparison is symmetric on purpose (audit 2026-09-08). The first version
+// asked "was this row touched AFTER the last sync", and the wine's sync stamp
+// advanced on every refresh including runs that skipped the row — so an edit
+// survived exactly one refresh and the next one silently reverted it. Matching
+// stamps cannot drift: only the bridge writes them together.
 const EDIT_SLACK_MS = 5000;
 const WINDOW_FIELDS = ['earlyFrom', 'earlyUntil', 'peakFrom', 'peakUntil', 'lateFrom', 'lateUntil'];
 
@@ -88,18 +134,28 @@ function touchedAfterSync(at, syncedAt) {
   return new Date(at).getTime() > new Date(syncedAt).getTime() + EDIT_SLACK_MS;
 }
 
+/** True when `at` is the very instant the bridge last wrote this wine. */
+function stampedByBridge(at, syncedAt) {
+  if (!at || !syncedAt) return false;
+  return Math.abs(new Date(at).getTime() - new Date(syncedAt).getTime()) <= EDIT_SLACK_MS;
+}
+
 function windowEditedLocally(row, syncedAt) {
   if (!row) return false;
   if (row.sommNotes !== REGISTRY_NOTE) {
     return row.status === 'reviewed' || WINDOW_FIELDS.some((f) => row[f] !== null && row[f] !== undefined);
   }
-  return touchedAfterSync(row.setAt, syncedAt);
+  // A bridge row with no stamp at all (anonymised by an account erasure) is
+  // the bridge's again, not a local edit frozen forever.
+  if (!row.setAt) return false;
+  return !stampedByBridge(row.setAt, syncedAt);
 }
 
 function valueEditedLocally(row, syncedAt) {
   if (!row) return false;
   if (row.reason !== REGISTRY_NOTE) return true;
-  return touchedAfterSync(row.decidedAt, syncedAt);
+  if (!row.decidedAt) return false;
+  return !stampedByBridge(row.decidedAt, syncedAt);
 }
 
 let lastRefresh = null;
@@ -228,6 +284,10 @@ async function adoptWine(registryId, userId) {
   const tax = await resolveTaxonomy(w, userId);
   const normalizedKey = generateWineKey(w.name, w.producer || '', w.appellation || '');
   let wine = await WineDefinition.findOne({ normalizedKey });
+  // Captured before the assignment below: rows a previous adoption wrote carry
+  // the OLD stamp, and comparing them against the new one would read them as
+  // local edits and freeze them (audit 2026-09-08).
+  const prevSync = wine?.registrySyncedAt || null;
   const profile = profileFrom(w.profile);
   if (wine) {
     wine.registryId = String(w.id);
@@ -259,8 +319,8 @@ async function adoptWine(registryId, userId) {
       }
     }
   }
-  await applyWindows(wine._id, w.windows, userId, now);
-  await applyValues(wine._id, w.values, userId, now);
+  await applyWindows(wine._id, w.windows, userId, now, prevSync);
+  await applyValues(wine._id, w.values, userId, now, prevSync);
   indexLocally(wine._id);
   await wine.populate(POPULATE);
   return { ok: true, wine, created: !held };
@@ -280,25 +340,35 @@ async function registrySearch(q, { limit = 10 } = {}) {
 }
 
 /** One changed wine → the local copy, keeping local identity edits. */
-async function applyRegistryUpdate(local, w, now) {
+async function applyRegistryUpdate(local, w) {
   const wine = await WineDefinition.findById(local._id);
   if (!wine) return false;
   const prevSync = wine.registrySyncedAt || null;
   const untouchedLocally = !wine.registrySyncedAt || !wine.updatedAt || wine.updatedAt.getTime() <= wine.registrySyncedAt.getTime() + EDIT_SLACK_MS;
-  if (untouchedLocally) {
-    const tax = await resolveTaxonomy(w, wine.createdBy);
-    Object.assign(wine, identityFields(w, tax));
-    wine.normalizedKey = generateWineKey(w.name, w.producer || '', w.appellation || '');
-  } else if (!wine.image && w.image) {
-    wine.image = w.image; wine.imageCredit = w.imageCredit || null;
-  }
   const profile = profileFrom(w.profile);
   // A profile a person on this install curated after the last sync stays.
   const ap = wine.aiProfile;
   const curatedHere = !!(ap && ap.source === 'curator'
     && (touchedAfterSync(ap.verifiedAt, prevSync) || touchedAfterSync(ap.generatedAt, prevSync)));
+  if (untouchedLocally) {
+    const tax = await resolveTaxonomy(w, wine.createdBy);
+    const fields = identityFields(w, tax);
+    // Never trade a picture for nothing: a wine the registry has no image for
+    // must not blank one this install already shows.
+    if (!fields.image && wine.image) { delete fields.image; delete fields.imageCredit; }
+    Object.assign(wine, fields);
+    wine.normalizedKey = generateWineKey(w.name, w.producer || '', w.appellation || '');
+  } else if (!wine.image && w.image) {
+    wine.image = w.image; wine.imageCredit = w.imageCredit || null;
+  }
   if (profile && !curatedHere) wine.aiProfile = profile;
-  wine.registrySyncedAt = now;
+  // The stamp is taken HERE, immediately before the save, and reused for the
+  // rows below. Using the run's start time meant `updatedAt` (stamped by the
+  // pre-save hook at the real save moment) ran ahead of registrySyncedAt on
+  // every wine past the first few seconds of a run, so the next run read the
+  // copy as locally edited and froze its identity forever (audit 2026-09-08).
+  const stamp = new Date();
+  wine.registrySyncedAt = stamp;
   try {
     await wine.save();
   } catch (err) {
@@ -306,15 +376,16 @@ async function applyRegistryUpdate(local, w, now) {
       // The registry's identity now collides with another local row: keep
       // the copy's old identity, take the rest.
       const fresh = await WineDefinition.findById(local._id);
+      if (!fresh) return false;
       if (profile && !curatedHere) fresh.aiProfile = profile;
-      fresh.registrySyncedAt = now;
+      fresh.registrySyncedAt = stamp;
       await fresh.save();
     } else {
       throw err;
     }
   }
-  await applyWindows(wine._id, w.windows, wine.createdBy, now, prevSync);
-  await applyValues(wine._id, w.values, wine.createdBy, now, prevSync);
+  await applyWindows(wine._id, w.windows, wine.createdBy, stamp, prevSync);
+  await applyValues(wine._id, w.values, wine.createdBy, stamp, prevSync);
   indexLocally(wine._id);
   return true;
 }
@@ -323,34 +394,68 @@ async function applyRegistryUpdate(local, w, now) {
  * Weekly: one change check for every registry id this install holds, then
  * re-fetch the changed ones; wines the registry reports removed are marked
  * and left alone from then on. Returns a summary the status route shows.
+ *
+ * `since` is an INSTALL-level watermark kept in site config, not the oldest
+ * per-wine sync date. Deriving it per wine meant the watermark never advanced
+ * — every wine the registry had touched since the oldest adoption came back
+ * changed, every week, until the daily fetch quota ran out, and the wines past
+ * that point were never updated at all (audit 2026-09-08).
  */
 async function refreshHeld({ now = new Date() } = {}) {
-  if (!isEnabled()) return { skipped: 'disabled' };
+  if (!isEnabled()) return recordRefresh({ at: now, skipped: 'disabled' });
   const mode = await refreshMode();
-  if (mode.mode === 'off') return { skipped: 'refresh_off', source: mode.source };
+  if (mode.mode === 'off') return recordRefresh({ at: now, skipped: 'refresh_off', source: mode.source });
   const rows = await WineDefinition.find({ registryId: { $exists: true, $ne: null }, registryRemovedAt: null })
     .select('_id registryId registrySyncedAt updatedAt createdBy').lean();
-  if (!rows.length) { lastRefresh = { at: now, checked: 0, changed: 0, updated: 0, removed: 0, failed: false }; return lastRefresh; }
-  const since = rows.reduce((min, r) => (r.registrySyncedAt && (!min || r.registrySyncedAt < min) ? r.registrySyncedAt : min), null) || new Date(0);
+  if (!rows.length) return recordRefresh({ at: now, checked: 0, changed: 0, updated: 0, removed: 0, failures: 0, failed: false });
+
+  const state = await bridgeState();
+  const since = state.checkedAt ? new Date(state.checkedAt) : new Date(0);
   const r = await client.changes(rows.map((x) => x.registryId), since);
   const byRegistry = new Map(rows.map((x) => [x.registryId, x]));
-  let updated = 0; let removed = 0;
+  let updated = 0; let removed = 0; let failures = 0; let skipped = 0;
+
   for (const c of r.changed) {
     const local = byRegistry.get(c.id);
     if (!local) continue;
-    const w = await client.fetchWine(c.id);
-    if (!w || w.removed) continue;
-    if (await applyRegistryUpdate(local, w, now)) updated++;
+    // Already have this version: the watermark is install-wide, so a wine
+    // synced after the registry last touched it needs no fetch.
+    if (local.registrySyncedAt && c.updatedAt && new Date(local.registrySyncedAt) >= new Date(c.updatedAt)) { skipped++; continue; }
+    try {
+      const w = await client.fetchWine(c.id);
+      // null = quota, backoff, timeout or a transport error. Counted, not
+      // silently swallowed: a run that updated nothing must not read as a
+      // clean run on the Settings card.
+      if (!w) { failures++; continue; }
+      if (w.removed) continue;
+      if (await applyRegistryUpdate(local, w)) updated++;
+    } catch (err) {
+      // One bad wine must not end the run at the same point every week.
+      failures++;
+      console.warn(`[bridge] refresh: wine ${c.id} failed — ${err.message}`);
+    }
   }
+
   for (const id of r.removed) {
     const local = byRegistry.get(id);
     if (!local) continue;
     await WineDefinition.updateOne({ _id: local._id }, { $set: { registryRemovedAt: now } });
     removed++;
   }
-  lastRefresh = { at: now, checked: r.checked, changed: r.changed.length, updated, removed, failed: !!r.failed };
-  console.log(`[bridge] refresh: ${r.checked} checked, ${updated} updated, ${removed} removed${r.failed ? ' (a chunk failed — quota or network)' : ''}`);
-  return lastRefresh;
+
+  // Advance the watermark only when the check itself was complete and nothing
+  // was left unfetched; otherwise the next run must ask from the same point.
+  const complete = !r.failed && failures === 0;
+  const checkedAt = complete ? (r.checkedAt ? new Date(r.checkedAt) : now) : (state.checkedAt ? new Date(state.checkedAt) : null);
+  const summary = {
+    at: now, checked: r.checked, changed: r.changed.length, updated, removed, skipped, failures,
+    failed: !!r.failed || failures > 0,
+    watermark: checkedAt,
+  };
+  await saveBridgeState({ checkedAt, lastRefresh: summary });
+  console.log(`[bridge] refresh: ${r.checked} checked, ${updated} updated, ${skipped} already current, ${removed} removed, ${failures} failed${r.failed ? ' (a chunk failed — quota or network)' : ''}`);
+  lastRefresh = summary;
+  return summary;
 }
 
 /** A local correction on an adopted wine → the hosted proposal queue. */
@@ -387,18 +492,20 @@ async function forwardRequest({ wineName, sourceUrl, image }) {
 async function status() {
   const transport = client.transportState();
   if (!transport.enabled) return { ...transport, held: 0, removed: 0, lastRefresh: null, me: null };
-  const [held, removed, me, refresh] = await Promise.all([
+  const [held, removed, me, refresh, state] = await Promise.all([
     WineDefinition.countDocuments({ registryId: { $exists: true, $ne: null }, registryRemovedAt: null }),
     WineDefinition.countDocuments({ registryRemovedAt: { $ne: null } }),
     client.me(),
     refreshMode(),
+    bridgeState(),
   ]);
-  return { ...transport, held, removed, lastRefresh, refresh, me };
+  // In-memory first (this process), else the persisted record of the last run.
+  return { ...transport, held, removed, lastRefresh: lastRefresh || state.lastRefresh || null, refresh, me };
 }
 
 function _reset() { lastRefresh = null; }
 
 module.exports = {
   isEnabled, adoptWine, registrySearch, refreshHeld, forwardCorrection, forwardValueFor, forwardRequest, status,
-  refreshMode, setRefreshMode, REFRESH_MODES, profileFrom, REGISTRY_NOTE, _reset,
+  refreshMode, setRefreshMode, REFRESH_MODES, profileFrom, REGISTRY_NOTE, bridgeState, _reset,
 };

--- a/backend/src/services/registryBridge.test.js
+++ b/backend/src/services/registryBridge.test.js
@@ -170,7 +170,10 @@ describe('refreshHeld', () => {
     const local = { _id: 'l1', createdBy: USER, registrySyncedAt: new Date('2026-09-01'), updatedAt: new Date('2026-09-01'), aiProfile: { source: 'ai' }, save: jest.fn().mockResolvedValue(undefined) };
     WineDefinition.findById.mockResolvedValue(local);
     const r = await bridge.refreshHeld({ now: new Date('2026-09-08') });
-    expect(client.changes).toHaveBeenCalledWith([RID, 'b'.repeat(24)], new Date('2026-09-01'));
+    // `since` is the install's own watermark from site config, not the oldest
+    // per-wine sync date: derived per wine it never advanced, so the same
+    // wines came back every week until the quota ran out (audit 2026-09-08).
+    expect(client.changes).toHaveBeenCalledWith([RID, 'b'.repeat(24)], new Date(0));
     expect(local.name).toBe('Salmos Priorat'); // untouched locally → identity follows the registry
     expect(local.aiProfile).toMatchObject({ description: 'A dense Priorat.' });
     expect(local.save).toHaveBeenCalled();
@@ -192,7 +195,7 @@ describe('refreshHeld', () => {
 
   test('is a no-op when off or when nothing is held', async () => {
     client.isEnabled.mockReturnValue(false);
-    expect(await bridge.refreshHeld()).toEqual({ skipped: 'disabled' });
+    expect(await bridge.refreshHeld()).toMatchObject({ skipped: 'disabled' });
     client.isEnabled.mockReturnValue(true);
     WineDefinition.find.mockReturnValue({ select: () => ({ lean: () => Promise.resolve([]) }) });
     expect(await bridge.refreshHeld()).toMatchObject({ checked: 0 });
@@ -322,10 +325,13 @@ describe('local changes win', () => {
 describe('refresh switch', () => {
   test('REGISTRY_BRIDGE_REFRESH=off in .env stops the weekly run before any request', async () => {
     process.env.REGISTRY_BRIDGE_REFRESH = 'off';
-    expect(await bridge.refreshHeld()).toEqual({ skipped: 'refresh_off', source: 'env' });
+    expect(await bridge.refreshHeld()).toMatchObject({ skipped: 'refresh_off', source: 'env' });
     expect(client.changes).not.toHaveBeenCalled();
     expect(await bridge.refreshMode()).toEqual({ mode: 'off', source: 'env' });
-    // …and the admin toggle is refused while the env decides.
+    // …and the admin toggle is refused while the env decides. (The skipped run
+    // above does persist its own record, so clear the write log first and
+    // assert only that the toggle wrote nothing.)
+    SiteConfig.findOneAndUpdate.mockClear();
     expect(await bridge.setRefreshMode('weekly', USER)).toEqual({ ok: false, code: 'env_override', mode: 'off', source: 'env' });
     expect(SiteConfig.findOneAndUpdate).not.toHaveBeenCalled();
   });
@@ -335,11 +341,11 @@ describe('refresh switch', () => {
     expect(await bridge.setRefreshMode('off', USER)).toEqual({ ok: true, mode: 'off', source: 'settings' });
     expect(SiteConfig.findOneAndUpdate).toHaveBeenCalledWith(
       { key: 'registryBridge' },
-      { $set: expect.objectContaining({ value: { refresh: 'off' }, updatedBy: USER }) },
+      { $set: expect.objectContaining({ value: expect.objectContaining({ refresh: 'off' }), updatedBy: USER }) },
       expect.objectContaining({ upsert: true })
     );
     SiteConfig.findOne.mockReturnValue({ lean: () => Promise.resolve({ key: 'registryBridge', value: { refresh: 'off' } }) });
-    expect(await bridge.refreshHeld()).toEqual({ skipped: 'refresh_off', source: 'settings' });
+    expect(await bridge.refreshHeld()).toMatchObject({ skipped: 'refresh_off', source: 'settings' });
     expect(await bridge.setRefreshMode('sometimes', USER)).toEqual({ ok: false, code: 'invalid' });
   });
 
@@ -349,5 +355,133 @@ describe('refresh switch', () => {
     client.me.mockResolvedValue(null);
     const s = await bridge.status();
     expect(s.refresh).toEqual({ mode: 'weekly', source: 'default' });
+  });
+});
+
+// ── Audit 2026-09-08 regressions ─────────────────────────────────────────────
+// Four High findings, all in the "local changes win" machinery shipped in
+// v1.209.0. Each test below fails on the code as released.
+
+describe('audit 2026-09-08 — refresh keeps its promises', () => {
+  const NOTE = bridge.REGISTRY_NOTE;
+
+  /** A held copy plus the change answer that names it. */
+  function heldWine(over = {}) {
+    WineDefinition.find.mockReturnValue({ select: () => ({ lean: () => Promise.resolve([
+      { _id: 'l1', registryId: RID, registrySyncedAt: new Date('2026-09-01'), updatedAt: new Date('2026-09-01'), createdBy: USER },
+    ]) }) });
+    client.changes.mockResolvedValue({ changed: [{ id: RID }], removed: [], checked: 1, failed: false, checkedAt: new Date('2026-09-08T06:30:00Z') });
+    client.fetchWine.mockResolvedValue(registryWine());
+    const local = {
+      _id: 'l1', name: 'Salmos', createdBy: USER,
+      registrySyncedAt: new Date('2026-09-01'), updatedAt: new Date('2026-09-01'),
+      image: null, aiProfile: { source: 'ai' },
+      // Faithful to models/WineDefinition.js: the pre-save hook stamps
+      // updatedAt with the REAL instant of the save, while the run passes a
+      // logical `now`. That gap is what froze copies (audit 2026-09-08), so
+      // the mock has to reproduce it rather than echo the run's clock.
+      save: jest.fn(async function save() { this.updatedAt = new Date(); }),
+      ...over,
+    };
+    WineDefinition.findById.mockResolvedValue(local);
+    return local;
+  }
+
+  test('a local edit survives EVERY refresh, not just the next one', async () => {
+    heldWine();
+    // A somm fixed the peak years and left the bridge note on the row, so the
+    // only thing separating it from a bridge row is its stamp.
+    WineVintageProfile.findOne.mockResolvedValue({ vintage: '2019', sommNotes: NOTE, status: 'reviewed', setAt: new Date('2026-09-05') });
+
+    await bridge.refreshHeld({ now: new Date('2026-09-08') });
+    await bridge.refreshHeld({ now: new Date('2026-09-15') });
+    await bridge.refreshHeld({ now: new Date('2026-09-22') });
+
+    // Before the fix the second run reverted it: the wine's sync stamp had
+    // advanced past the edit, so the one-sided "touched after sync" test flipped.
+    expect(WineVintageProfile.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('a wine saved late in a run is not misread as locally edited next week', async () => {
+    const local = heldWine();
+    await bridge.refreshHeld({ now: new Date('2026-09-08') });
+    // The save stamped updatedAt 1.2 s after registrySyncedAt. With the run's
+    // start time as the sync stamp, every wine past the first seconds of a run
+    // looked edited from then on and never took an identity change again.
+    client.fetchWine.mockResolvedValue(registryWine({ name: 'Renamed Upstream' }));
+    await bridge.refreshHeld({ now: new Date('2026-09-15') });
+    expect(local.name).toBe('Renamed Upstream');
+  });
+
+  test('a bridge row left unstamped by an account erasure is the bridge\'s again', async () => {
+    heldWine();
+    // GDPR erasure unsets setBy/setAt on the profiles a departing user "set" —
+    // which, for a one-admin install, is every copied window.
+    WineVintageProfile.findOne.mockResolvedValue({ vintage: '2019', sommNotes: NOTE, status: 'reviewed', setAt: null });
+    await bridge.refreshHeld({ now: new Date('2026-09-08') });
+    expect(WineVintageProfile.findOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test('the change watermark comes from site config and advances only after a clean run', async () => {
+    SiteConfig.findOne.mockReturnValue({ lean: () => Promise.resolve({ key: 'registryBridge', value: { checkedAt: new Date('2026-09-07T06:30:00Z') } }) });
+    heldWine();
+    await bridge.refreshHeld({ now: new Date('2026-09-08') });
+    expect(client.changes).toHaveBeenCalledWith([RID], new Date('2026-09-07T06:30:00Z'));
+    const saved = SiteConfig.findOneAndUpdate.mock.calls.at(-1)[1].$set.value;
+    expect(saved.checkedAt).toEqual(new Date('2026-09-08T06:30:00Z'));
+
+    // A run that could not fetch everything must ask from the same point again,
+    // or the wines it skipped are never updated.
+    jest.clearAllMocks();
+    SiteConfig.findOne.mockReturnValue({ lean: () => Promise.resolve({ key: 'registryBridge', value: { checkedAt: new Date('2026-09-08T06:30:00Z') } }) });
+    heldWine();
+    client.fetchWine.mockResolvedValue(null);   // quota, backoff or a timeout
+    const r = await bridge.refreshHeld({ now: new Date('2026-09-15') });
+    expect(r).toMatchObject({ updated: 0, failures: 1, failed: true });
+    const savedAgain = SiteConfig.findOneAndUpdate.mock.calls.at(-1)[1].$set.value;
+    expect(savedAgain.checkedAt).toEqual(new Date('2026-09-08T06:30:00Z'));
+  });
+
+  test('a wine already at the registry\'s version is not re-fetched, and one bad wine does not end the run', async () => {
+    WineDefinition.find.mockReturnValue({ select: () => ({ lean: () => Promise.resolve([
+      { _id: 'l1', registryId: RID, registrySyncedAt: new Date('2026-09-10'), updatedAt: new Date('2026-09-10'), createdBy: USER },
+      { _id: 'l2', registryId: 'b'.repeat(24), registrySyncedAt: new Date('2026-09-01'), updatedAt: new Date('2026-09-01'), createdBy: USER },
+      { _id: 'l3', registryId: 'c'.repeat(24), registrySyncedAt: new Date('2026-09-01'), updatedAt: new Date('2026-09-01'), createdBy: USER },
+    ]) }) });
+    client.changes.mockResolvedValue({
+      changed: [
+        { id: RID, updatedAt: new Date('2026-09-05') },          // older than our copy
+        { id: 'b'.repeat(24), updatedAt: new Date('2026-09-07') },
+        { id: 'c'.repeat(24), updatedAt: new Date('2026-09-07') },
+      ],
+      removed: [], checked: 3, failed: false,
+    });
+    client.fetchWine.mockResolvedValue(registryWine());
+    let call = 0;
+    WineDefinition.findById.mockImplementation(async () => {
+      call += 1;
+      if (call === 1) throw new Error('taxonomy exploded');   // the first wine fetched
+      return { _id: 'l3', createdBy: USER, registrySyncedAt: new Date('2026-09-01'), updatedAt: new Date('2026-09-01'), aiProfile: { source: 'ai' }, save: jest.fn().mockResolvedValue(undefined) };
+    });
+
+    const r = await bridge.refreshHeld({ now: new Date('2026-09-15') });
+    // One skipped as current, one thrown and counted, one applied — the run
+    // used to stop at the throw, at the same wine every week.
+    expect(r).toMatchObject({ skipped: 1, failures: 1, updated: 1 });
+    expect(client.fetchWine).toHaveBeenCalledTimes(2);
+  });
+
+  test('an unrecognised REGISTRY_BRIDGE_REFRESH is ignored, not read as "on"', async () => {
+    process.env.REGISTRY_BRIDGE_REFRESH = 'disabled';
+    // It used to mean weekly AND lock the Settings toggle with env_override.
+    expect(await bridge.refreshMode()).toEqual({ mode: 'weekly', source: 'default' });
+    expect(await bridge.setRefreshMode('off', USER)).toMatchObject({ ok: true, source: 'settings' });
+  });
+
+  test('a wine the registry has no picture for keeps the one this install shows', async () => {
+    const local = heldWine({ image: '/api/uploads/processed/local.png', imageCredit: 'A member' });
+    client.fetchWine.mockResolvedValue(registryWine({ image: null, imageCredit: null }));
+    await bridge.refreshHeld({ now: new Date('2026-09-08') });
+    expect(local.image).toBe('/api/uploads/processed/local.png');
   });
 });

--- a/backend/src/services/registryReadTracker.js
+++ b/backend/src/services/registryReadTracker.js
@@ -52,6 +52,10 @@ function limits() {
  */
 async function recordRead(reader, wineId) {
   if (!reader || !wineId) return null;
+  // One id or many: a search returns ten identities in a single call, and
+  // those are reads of the registry too (bridge audit 2026-09-08).
+  const ids = (Array.isArray(wineId) ? wineId : [wineId]).filter(Boolean);
+  if (!ids.length) return null;
   // No database, no counter (fail open, and fast): a disconnected model would
   // otherwise buffer the write until Mongoose's timeout and stall the read.
   if (mongoose.connection.readyState !== 1) return null;
@@ -61,8 +65,8 @@ async function recordRead(reader, wineId) {
     const row = await RegistryReadDay.findOneAndUpdate(
       { readerKey: reader.key, day },
       {
-        $addToSet: { wines: wineId },
-        $inc: { count: 1 },
+        $addToSet: { wines: { $each: ids } },
+        $inc: { count: ids.length },
         $setOnInsert: { kind: reader.kind, expiresAt },
       },
       { upsert: true, new: true, projection: { wines: 1, count: 1, blockedAt: 1 } }

--- a/backend/src/services/registryReadTracker.test.js
+++ b/backend/src/services/registryReadTracker.test.js
@@ -43,7 +43,8 @@ describe('recordRead', () => {
     const [filter, update, opts] = RegistryReadDay.findOneAndUpdate.mock.calls[0];
     expect(filter.readerKey).toBe('ip:x');
     expect(filter.day).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    expect(update.$addToSet).toEqual({ wines: 'b' });
+    // $each because one call can now carry a whole search page of ids.
+    expect(update.$addToSet).toEqual({ wines: { $each: ['b'] } });
     expect(update.$inc).toEqual({ count: 1 });
     expect(update.$setOnInsert.kind).toBe('ip');
     expect(update.$setOnInsert.expiresAt).toBeInstanceOf(Date);
@@ -79,4 +80,19 @@ describe('gateAnonymousRead', () => {
     RegistryReadDay.findOneAndUpdate.mockImplementation(() => { throw new Error('db down'); });
     expect(await gateAnonymousRead(req(), 'a')).toEqual({ allowed: true, distinct: 0 });
   });
+});
+
+test('a page of ids is one write: the set grows by all of them and the count by their number', async () => {
+  // A bridge search hands out ten identities in a single call, and those are
+  // reads of the registry too (audit 2026-09-08).
+  RegistryReadDay.findOneAndUpdate.mockReturnValue({ lean: () => Promise.resolve({ wines: ['a', 'b', 'c'], count: 3 }) });
+  const r = await recordRead({ key: 'user:u1', kind: 'user' }, ['a', 'b', 'c']);
+  const [, update] = RegistryReadDay.findOneAndUpdate.mock.calls[0];
+  expect(update.$addToSet).toEqual({ wines: { $each: ['a', 'b', 'c'] } });
+  expect(update.$inc).toEqual({ count: 3 });
+  expect(r).toMatchObject({ distinct: 3 });
+  // An empty page costs nothing.
+  RegistryReadDay.findOneAndUpdate.mockClear();
+  expect(await recordRead({ key: 'user:u1', kind: 'user' }, [])).toBeNull();
+  expect(RegistryReadDay.findOneAndUpdate).not.toHaveBeenCalled();
 });

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -28,6 +28,10 @@ const User = require('../models/User');
 const AiBudgetRequest = require('../models/AiBudgetRequest');
 const ApiToken = require('../models/ApiToken');
 const BridgeKey = require('../models/BridgeKey');
+// Kept in step with REGISTRY_NOTE in services/registryBridge.js. A literal on
+// purpose: requiring the bridge service here would pull its taxonomy and
+// search dependencies into every erasure run.
+const BRIDGE_REGISTRY_NOTE = 'From the shared registry (cellarion.app)';
 const BridgeUsageDay = require('../models/BridgeUsageDay');
 const ExportLink = require('../models/ExportLink');
 const OAuthAuthCode = require('../models/OAuthAuthCode');
@@ -1061,7 +1065,22 @@ const REGISTRY = [
     model: WineVintageProfile, category: 'creator-ref', userFields: ['setBy'],
     // BUG FIX: also clear sommNotes (the old code unset setBy+setAt but left the
     // somm's authored notes on the now-anonymised profile, unlike WineVintagePrice).
-    purge: (ctx) => WineVintageProfile.updateMany({ setBy: ctx.userId }, { $unset: { setBy: '', setAt: '', sommNotes: '' } }),
+    // Two passes. A somm's own row is fully anonymised, as before. A row the
+    // Registry Bridge wrote keeps its note: clearing it left the row looking
+    // like a local edit ('reviewed', no bridge note), which froze every copied
+    // drink window on a one-admin install forever (audit 2026-09-08). Dropping
+    // setBy/setAt still removes the personal reference, and an unstamped
+    // bridge row is treated as the bridge's own again.
+    purge: async (ctx) => {
+      await WineVintageProfile.updateMany(
+        { setBy: ctx.userId, sommNotes: { $ne: BRIDGE_REGISTRY_NOTE } },
+        { $unset: { setBy: '', setAt: '', sommNotes: '' } }
+      );
+      return WineVintageProfile.updateMany(
+        { setBy: ctx.userId, sommNotes: BRIDGE_REGISTRY_NOTE },
+        { $unset: { setBy: '', setAt: '' } }
+      );
+    },
     exportFragment: null,
     note: 'somm maturity contribution (shared data); portability of own contributions is a follow-up',
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,13 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-}
       - AUDIT_TTL_DAYS=${AUDIT_TTL_DAYS:-}
       - INDEXNOW_KEY=${INDEXNOW_KEY:-}
+      # Registry Bridge (self-hosted installs). The env block enumerates vars,
+      # so these MUST be forwarded or the documented two-line .env setup is a
+      # silent no-op inside the container: the client sees no key, Settings
+      # says "not connected", and nothing explains why.
+      - REGISTRY_BRIDGE_URL=${REGISTRY_BRIDGE_URL:-}
+      - REGISTRY_BRIDGE_KEY=${REGISTRY_BRIDGE_KEY:-}
+      - REGISTRY_BRIDGE_REFRESH=${REGISTRY_BRIDGE_REFRESH:-}
       - MAILGUN_API_KEY=${MAILGUN_API_KEY:-}
       - MAILGUN_DOMAIN=${MAILGUN_DOMAIN:-}
       - MAILGUN_FROM=${MAILGUN_FROM:-}

--- a/docs/registry-bridge-enforcement.md
+++ b/docs/registry-bridge-enforcement.md
@@ -18,7 +18,7 @@ own cellar.
 |---|---|---|
 | Daily readers report | Admin notification at 05:15 UTC, only when a reader passed an alert level the day before | One reader read more distinct wines in a UTC day than the level for its kind. Anonymous addresses were already refused in real time; members and keys were only counted. |
 | Canary hit | Admin notification, immediately | A wine that does not exist was fetched through a bridge key. Search never returns a canary, so a fetch of one means the caller enumerated ids it did not get from search. |
-| Quota refusals | `429` with `code: "quota"` to the caller; visible as spend on the admin page | A key hit its daily cap. On its own this is not suspicious: a large import does it once. |
+| Quota refusals | `429` with `code: "quota"` to the caller; visible as spend on the admin page | The ACCOUNT hit its daily cap — quotas and the monthly import window count per owner, not per key, so minting more keys does not raise them. On its own this is not suspicious: a large import does it once. |
 | Burst refusals | `429` with `code: "burst"` to the caller; `system.rate_limit_exceeded` in the audit log with `limiter: bridge_key` | More than the per-minute allowance from one key. A misconfigured client, or a script. |
 | Edge rate rule | Your reverse proxy or CDN's own log | Requests refused before they reached the backend. Only the volume is known; no reader identity. |
 
@@ -28,7 +28,10 @@ request.
 
 ## 2. Where to look
 
-**Admin → Registry Bridge** shows two tables for the last 7, 30 or 90 days.
+**Admin → Registry Bridge** shows two tables for the last 7, 30 or 90 days. Spend
+figures (searches, fetches, contributions) go back the full window; the distinct-wines
+columns are drawn from the read counters, which are kept for 14 days, so a 30- or
+90-day request answers with those 14 and the response says so (`readDays`).
 
 - **Keys**: every active bridge key and those revoked in the last 90 days.
   Per key: the owner, the install's reported host, today's spend against the
@@ -58,7 +61,8 @@ reversible except the last, and every one of them is audited.
 ### Step 1 — Look
 
 Open the key or reader on the admin page. Check the import window, the
-worst-day distinct figure over 30 days, the contributions the key has made
+worst-day distinct figure over the last 14 days (the read counters' retention),
+the contributions the key has made
 (a real install files wine requests and corrections; a copier never does) and
 whether the same owner has other keys. Check the audit log for
 `bridge.key.used`, `bridge.canary_hit` and `system.rate_limit_exceeded`
@@ -74,7 +78,11 @@ misunderstanding of what the bridge is for. Give them a few days.
 
 ### Step 3 — Tighten
 
-Two levers, both in Super-admin → Settings, both instance-wide:
+Three levers, all in Super-admin → Settings, all instance-wide:
+
+- **Bridge enabled** — `0` closes `/api/bridge/v1` entirely with a `503`, for an
+  incident where revoking one key at a time is not fast enough. Key management and
+  the self-hosted Settings card stay up.
 
 - **Anonymous daily distinct cap** — how many distinct wines an address may
   read in a UTC day before the public endpoints refuse it.

--- a/docs/registry-bridge.md
+++ b/docs/registry-bridge.md
@@ -57,8 +57,13 @@ Images are referenced by URL, never sent as bytes.
 ## What never crosses
 
 Bulk listings or paging of the registry, snapshots or exports, a feed of all changes,
-embeddings and the similarity graph, sommelier notes behind a drink window, canary
-rows, curator identities.
+embeddings and the similarity graph, sommelier notes behind a drink window, curator
+identities.
+
+Canary rows are excluded from `/search` and from change answers, so nothing leads an
+install to one. A canary fetched **by id** is served like any other wine — that is
+the path a copier walks, and the fetch raises an admin alert at once (at most one
+notification per key per day; every hit is audited).
 
 ## How reading is watched
 
@@ -98,7 +103,11 @@ users until they search.
 - **Local enrichment stays away.** The install's own AI enrichment skips wines with
   `registryId`; the registry's profile is the source of truth for them.
 - **Weekly refresh.** Monday 06:30 UTC the install sends the ids it holds (one
-  change check; chunks of 5,000) and re-fetches the changed ones. Wines the registry
+  change check; chunks of 5,000) and re-fetches the changed ones, skipping any whose
+  local copy is already at or past the registry's version. The "since" point is an
+  install-level watermark kept in site config, and it only advances after a run that
+  fetched everything it meant to — so a run cut short by quota resumes rather than
+  losing the wines it skipped. Wines the registry
   reports removed are marked `registryRemovedAt` and left alone.
 - **Local changes win.** The refresh only replaces what the bridge wrote and nobody
   on the install has touched since: identity fields follow the registry only while
@@ -109,9 +118,18 @@ users until they search.
   recognisable by their note, "From the shared registry (cellarion.app)".
 - **Refresh switch.** `REGISTRY_BRIDGE_REFRESH=off` in the install's `.env` stops the
   weekly refresh entirely: copies stay exactly as copied, and removed-from-registry
-  marks stop too. Without the env value, an admin of the install can switch it on
-  the Settings card (stored in the install's site config, read at each run). The env
-  value always wins; the card says so when it does.
+  marks stop too. Accepted values are `off` (also `false`, `0`, `no`, `never`,
+  `none`) and `weekly` (also `on`, `true`, `1`); anything else is ignored with a
+  warning rather than read as "on". Without the env value, an admin of the install
+  can switch it on the Settings card (stored in the install's site config, read at
+  each run). The env value always wins; the card says so when it does.
+- **What the refresh will not touch.** Only rows the bridge itself wrote and nobody
+  has changed since: a bridge row carries the note "From the shared registry
+  (cellarion.app)" and the same stamp as the wine's `registrySyncedAt`. A drink
+  window or public value set by someone on the install, a bridge row edited
+  afterwards, a profile curated locally after the last sync, and identity fields on a
+  locally edited copy all stay. A wine the registry has no picture for never blanks
+  one the install already shows.
 - **Contributions flow back.** A field correction or a value suggestion filed on the
   install for an adopted wine is also sent to the hosted queues, and a new-wine
   request is forwarded too. All fire-and-forget: the local record stands alone if the

--- a/frontend/src/components/SelfHostedBridgeSection.js
+++ b/frontend/src/components/SelfHostedBridgeSection.js
@@ -228,8 +228,16 @@ function SelfHostedBridgeSection() {
         )}
       </div>
 
+      {/* Once the plaintext key is on screen the dialog must not be dismissable
+          by a stray Escape or a click on the backdrop: closing clears it, it is
+          shown exactly once, and the cap is two keys per account. "Done" is the
+          only way out (audit 2026-09-08). */}
       {showCreate && (
-        <Modal title={t('settings.bridge.createTitle', 'Create bridge key')} onClose={creating ? undefined : closeCreate} showClose={!creating}>
+        <Modal
+          title={t('settings.bridge.createTitle', 'Create bridge key')}
+          onClose={creating || created ? undefined : closeCreate}
+          showClose={!creating && !created}
+        >
           {created ? (
             <>
               <p>{t('settings.bridge.createdShowOnce', 'Copy these two lines into the .env of your self-hosted Cellarion now and restart its backend. The key will not be shown again.')}</p>

--- a/frontend/src/components/SelfHostedBridgeSection.test.js
+++ b/frontend/src/components/SelfHostedBridgeSection.test.js
@@ -66,6 +66,30 @@ describe('SelfHostedBridgeSection', () => {
     expect(screen.getByText(/will not be shown again/)).toBeInTheDocument();
   });
 
+  test('the plaintext key cannot be dismissed by Escape or the backdrop — only by Done', async () => {
+    apiFetch.mockImplementation((url, opts = {}) => {
+      if (url === '/api/bridge/keys' && opts.method === 'POST') {
+        return ok({ key: 'cbr_' + 'a'.repeat(64), id: 'k1', name: 'Home NAS', prefix: 'cbr_aaaaaaaa', env: { REGISTRY_BRIDGE_URL: 'https://cellarion.app', REGISTRY_BRIDGE_KEY: 'cbr_' + 'a'.repeat(64) } }, 201);
+      }
+      return ok(list([], true));
+    });
+    renderSection();
+    fireEvent.click(await screen.findByRole('button', { name: /Create bridge key/ }));
+    fireEvent.change(screen.getByLabelText(/Name of the install/), { target: { value: 'Home NAS' } });
+    fireEvent.change(screen.getByLabelText(/Confirm with your password/), { target: { value: 'pw' } });
+    // The terms are already accepted on this account, so no checkbox is shown.
+    fireEvent.click(screen.getByRole('button', { name: /^Create key$/ }));
+    expect(await screen.findByText(/REGISTRY_BRIDGE_KEY=cbr_a+/)).toBeInTheDocument();
+
+    // The key is shown exactly once and the cap is two per account, so a stray
+    // Escape used to cost the tester a key.
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.getByText(/REGISTRY_BRIDGE_KEY=cbr_a+/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Done$/ }));
+    await waitFor(() => expect(screen.queryByText(/REGISTRY_BRIDGE_KEY=cbr_a+/)).toBeNull());
+  });
+
   test('a wrong password is reported as such (403), not as a session problem', async () => {
     apiFetch.mockImplementation((url, opts = {}) => (opts.method === 'POST' ? ok({ error: 'Password is incorrect' }, 403) : ok(list([], true))));
     renderSection();


### PR DESCRIPTION
Remediation of the 2026-09-08 audit of the Registry Bridge (#1257 v1.207.0, #1259 v1.208.0, #1262 v1.209.0). Five reviewers over the diff since v1.206.1.

**Nothing here was reachable by a user.** Production holds zero bridge keys and zero usage rows, and the refresh code is inert on the hosted side. The beta invitation is what would have brought people to this surface, which is why it waited.

## Critical — the documented setup was a no-op in Docker

`docker-compose.yml` never forwarded `REGISTRY_BRIDGE_*` to the backend. There is no `env_file`, so the `environment:` block is the only channel, and none of the three PRs touched it. Every self-hoster following the README would have set the two lines, restarted, and seen "not connected" with nothing in the logs. Three lines added.

## High — every bound counted per key, and keys are free to re-mint

The two-key cap counts only *active* keys, so revoke-and-remint is unlimited, and each new key arrived with an unused import window. Quota rows, the import window and the distinct-wines detector were all keyed on the key.

- `BridgeUsageDay` is now one row per **account** per UTC day (`key` is kept for attribution).
- The import window is opened and cooled down per **account**, and written to every active key so the sync `capFor(keyDoc)` stays correct.
- Reads are recorded under `user:<owner>` for detection and `key:<id>` for attribution.
- `/search` now counts the identities it returns — ten a call, and previously invisible to the detector.
- Minting is bounded to five keys per account per day (`key_churn`, audited).

## High — "local changes win" held for exactly one refresh

The wine's `registrySyncedAt` advanced on every run, including runs that *skipped* a row as locally edited, so the next run's comparison flipped and reverted the edit. A bridge row is now recognised by a stamp that **matches** the wine's sync stamp, which only the bridge writes together.

## High — copies froze invisibly, three ways

- The sync stamp was the run's *start* time while the pre-save hook writes the real save instant: any wine saved more than five seconds into a run read as locally edited from then on and never took an identity change again. The stamp is now taken per wine, immediately before the save.
- The change watermark was derived from the oldest per-wine sync date, so it never advanced: the same wines came back every week until the fetch quota ran out, and the tail never updated. It is now an install-level watermark in site config, advanced only after a complete run, with per-wine skip when the copy is already current.
- Erasing the adopting user's account unset `setBy`/`setAt`/`sommNotes` on every copied window, which then read as a local edit and froze forever. Bridge rows keep their note; an unstamped bridge row is the bridge's again.

## Also fixed

Kill switch `bridge.enabled` (503, like the MCP surface) · canary alerts throttled to one per key per day, every hit still audited · change checks answer with the same visibility as a fetch (no existence oracle) and use a strict id test · quota spent after validation, so one malformed change check no longer silences the weekly refresh for a day · the 256 kb body limit scoped to the one route that needs it · reader tables no longer promise more history than the 14-day counters keep (`readDays` in the response) · `registryRead` bounds no longer allow a cap above the size of the registry · an unrecognised `REGISTRY_BRIDGE_REFRESH` is ignored with a warning instead of read as "on" (it also used to lock the admin toggle) · a registry wine with no picture no longer blanks a local one · one bad wine no longer ends the weekly run, and failures are counted and surfaced · the once-shown plaintext key survives a stray Escape or backdrop click.

Docs corrected where they described behaviour the code does not have: canary rows (search excludes them, a direct fetch serves and alerts), the refresh contract, the accepted env values, and the reader window.

## Deferred to a follow-up

Adoption still reports a quota refusal as "could not be reached"; the daily readers report names a bridge key only by id; `GET /api/bridge/status` makes an uncached outbound call per Settings load; a somm's bridge key still carries their roles into the contribution services (an existence oracle, not a write escalation); `registryTerms` and `revokedReason` are missing from the account export and the erasure scrub misses `detail.instanceHost`; the privacy policy has no line for bridge records; the admin page has a window-switch race and hardcoded English error strings.

## Tests

Every finding above has a regression test that fails on the released code. Backend: 342 suites, 5207 tests, all green in the Node 24 container. Frontend: 98 files, 1254 tests, plus the new Escape-key test. Production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
