### PR TITLE
feat(registry): record whose contribution a wine came from, not just who wrote it

### DIFF
--- a/backend/src/mcp/accountTools.test.js
+++ b/backend/src/mcp/accountTools.test.js
@@ -175,7 +175,14 @@ describe('create_support_ticket / request_wine_addition', () => {
     accountOps.createWineRequest.mockResolvedValue({ wineRequest: { _id: 'wr1', wineName: 'Barolo', status: 'pending' } });
     const body = parse(await tool('request_wine_addition').handler(
       { wine_name: 'Barolo', source_url: 'https://vivino.com/w/1' }, CTX));
-    expect(accountOps.createWineRequest).toHaveBeenCalledWith(ME, { wineName: 'Barolo', sourceUrl: 'https://vivino.com/w/1', image: undefined });
+    // The third argument stamps the surface onto the REQUEST ROW, so a
+    // contributor stays findable after the audit rows expire (provenance,
+    // 2026-09-08). The audit line below is no longer the only record of it.
+    expect(accountOps.createWineRequest).toHaveBeenCalledWith(
+      ME,
+      { wineName: 'Barolo', sourceUrl: 'https://vivino.com/w/1', image: undefined },
+      expect.objectContaining({ via: 'mcp' })
+    );
     expect(logAudit).toHaveBeenCalledWith(REQ, 'wineRequest.create', { type: 'wineRequest', id: 'wr1' }, { via: 'mcp' });
     expect(body.data.request_id).toBe('wr1');
   });

--- a/backend/src/mcp/tools/account.js
+++ b/backend/src/mcp/tools/account.js
@@ -309,7 +309,7 @@ registerTool({
   handler: async (args, ctx) => {
     const { wineRequest, error } = await createWineRequest(ctx.user.id, {
       wineName: args.wine_name, sourceUrl: args.source_url, image: args.image_url,
-    });
+    }, { via: 'mcp', req: ctx.req });
     if (error) return fail('invalid_input', error.message);
     logAudit(ctx.req, 'wineRequest.create', { type: 'wineRequest', id: wineRequest._id }, { via: 'mcp' });
     return ok(`Wine addition requested: ${wineRequest.wineName}`, {

--- a/backend/src/models/RegistryDataValue.js
+++ b/backend/src/models/RegistryDataValue.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { originSchemaFields } = require('../utils/contributionOrigin');
 
 // A value for an accepted public key on a registry wine (#985 Slice B).
 // Suggested by users, TYPE-validated at entry (utils/personalDataTypes via
@@ -70,9 +71,16 @@ const registryDataValueSchema = new mongoose.Schema({
   decidedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
   decidedAt: { type: Date, default: null },
   rejectReason: { type: String, trim: true, maxlength: 2000 }, // 500 was too short for a real explanation (registry backlog 2026-09-06)
+  // Which surface suggested this value, and which bridge key / install if it
+  // came from one (utils/contributionOrigin.js).
+  ...originSchemaFields(mongoose),
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }
 });
+
+// Provenance lookups: everything one install or one key sent us.
+registryDataValueSchema.index({ bridgeKey: 1, createdAt: -1 }, { sparse: true });
+registryDataValueSchema.index({ instanceHost: 1, createdAt: -1 }, { sparse: true });
 
 // One suggested + one published row per (wine, key, vintage slot); rejected
 // rows keep history without blocking a fresh suggestion. Rows written before

--- a/backend/src/models/WineCorrectionProposal.js
+++ b/backend/src/models/WineCorrectionProposal.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { originSchemaFields } = require('../utils/contributionOrigin');
 
 /**
  * A sommelier's proposed correction to a SHARED registry wine — an identity
@@ -115,9 +116,15 @@ const wineCorrectionProposalSchema = new mongoose.Schema({
   // What the approve actually did (fields applied / bottles moved / queue rows
   // cleared) — the reviewer-facing receipt.
   appliedNote: { type: String, trim: true, maxlength: 500 },
+  // Which surface filed this, and which bridge key / install if it came from
+  // one (utils/contributionOrigin.js).
+  ...originSchemaFields(mongoose),
 }, { timestamps: true });
 
 wineCorrectionProposalSchema.index({ status: 1, createdAt: -1 });
+// Provenance lookups: everything one install or one key sent us.
+wineCorrectionProposalSchema.index({ bridgeKey: 1, createdAt: -1 }, { sparse: true });
+wineCorrectionProposalSchema.index({ instanceHost: 1, createdAt: -1 }, { sparse: true });
 
 // At most ONE pending proposal per (wine, kind) — makes the duplicate-propose
 // conflict race-safe (two concurrent creates can't both insert a pending row),

--- a/backend/src/models/WineDefinition.js
+++ b/backend/src/models/WineDefinition.js
@@ -297,6 +297,29 @@ const wineDefinitionSchema = new mongoose.Schema({
     enum: ['ui', 'import', 'mcp', 'ai', 'bridge', null],
     default: null
   },
+  // WHOSE DATA THIS IS, when the row was minted from someone else's
+  // contribution rather than typed by the account that wrote it.
+  //
+  // `createdBy` answers "who performed the write", and for a wine minted by
+  // approving a wine request that is the ADMIN who clicked approve — which is
+  // the wrong answer to "a rights holder says this record is theirs, who gave
+  // it to us?". This says who asked for it, through which surface, and from
+  // which install.
+  //
+  // Sparse by design: absent means the wine was not minted from a contribution
+  // (someone typed it themselves), or predates the field. Never read absence
+  // as "ours".
+  contribution: {
+    // The account whose contribution produced this wine. Reassigned to the
+    // shared [deleted] user on erasure, like createdBy.
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    via: { type: String, enum: ['ui', 'import', 'mcp', 'bridge', null], default: null },
+    // The request that carried it, while that request still exists.
+    request: { type: mongoose.Schema.Types.ObjectId, ref: 'WineRequest', default: null },
+    bridgeKey: { type: mongoose.Schema.Types.ObjectId, ref: 'BridgeKey', default: null },
+    instanceHost: { type: String, default: null, maxlength: 120 },
+    at: { type: Date, default: null },
+  },
   // WHICH SOURCE SUPPLIED EACH IDENTITY FIELD. createdVia says which surface
   // minted the row; this says, field by field, whether a human stated the
   // value or a model supplied it.
@@ -574,6 +597,11 @@ wineDefinitionSchema.index({ type: 1, name: 1 });
 // Registry Bridge change checks ask "which of THESE ids changed since T"
 // (routes/bridgeV1.js): an $in over held ids plus an updatedAt comparison.
 wineDefinitionSchema.index({ updatedAt: 1 });
+// Provenance lookups: every wine one contributor, key or install produced —
+// the query a takedown demand starts from.
+wineDefinitionSchema.index({ 'contribution.user': 1 }, { sparse: true });
+wineDefinitionSchema.index({ 'contribution.bridgeKey': 1 }, { sparse: true });
+wineDefinitionSchema.index({ 'contribution.instanceHost': 1 }, { sparse: true });
 
 // Update timestamp on save
 wineDefinitionSchema.pre('save', function(next) {

--- a/backend/src/models/WineRequest.js
+++ b/backend/src/models/WineRequest.js
@@ -1,6 +1,12 @@
 const mongoose = require('mongoose');
+const { originSchemaFields } = require('../utils/contributionOrigin');
 
 const wineRequestSchema = new mongoose.Schema({
+  // Which surface filed this, and — when it arrived over the Registry Bridge —
+  // which key and which install. Recorded on the record, not only in the audit
+  // log, so "what else did this contributor give us?" is answerable after the
+  // audit rows expire. See utils/contributionOrigin.js.
+  ...originSchemaFields(mongoose),
   requestType: {
     type: String,
     enum: ['new_wine', 'grape_suggestion'],
@@ -97,6 +103,9 @@ const wineRequestSchema = new mongoose.Schema({
 
 // Index for admin queue (pending requests, most recent first)
 wineRequestSchema.index({ status: 1, createdAt: -1 });
+// Provenance lookups: everything one install or one key sent us.
+wineRequestSchema.index({ bridgeKey: 1, createdAt: -1 }, { sparse: true });
+wineRequestSchema.index({ instanceHost: 1, createdAt: -1 }, { sparse: true });
 
 // Update timestamp on save
 wineRequestSchema.pre('save', function(next) {

--- a/backend/src/routes/admin/wineRequests.dedup.test.js
+++ b/backend/src/routes/admin/wineRequests.dedup.test.js
@@ -179,3 +179,40 @@ test('a duplicate-key race resolves the request by LINKING the existing wine', a
   expect(requestDoc.linkedWineDefinition).toBe('wine-existing');
   expect(requestDoc.save).toHaveBeenCalled();
 });
+
+// Provenance (2026-09-08): `createdBy` on the new wine is the ADMIN who
+// approved it, which is the wrong answer to "a rights holder says this record
+// is theirs — who gave it to us?". The contribution block answers that, and it
+// is the only place the bridge origin survives once the audit rows expire.
+test('the created wine records WHOSE contribution produced it, not just who approved it', async () => {
+  requestDoc.via = 'bridge';
+  requestDoc.bridgeKey = 'key-1';
+  requestDoc.instanceHost = 'cellar.example.org';
+  requestDoc.createdAt = new Date('2026-09-08T10:00:00Z');
+
+  const res = await resolve(CREATE_BODY);
+  expect(res.status).toBe(200);
+
+  const doc = WineDefinition.mock.calls[0][0];
+  expect(doc.createdBy).toBe(ADMIN_ID);              // who performed the write
+  expect(doc.contribution).toEqual({                 // whose data it is
+    user: '64b000000000000000000003',
+    via: 'bridge',
+    request: REQUEST_ID,
+    bridgeKey: 'key-1',
+    instanceHost: 'cellar.example.org',
+    at: new Date('2026-09-08T10:00:00Z'),
+  });
+});
+
+test('a request with no recorded surface still names the contributor, and never invents one', async () => {
+  const res = await resolve(CREATE_BODY);
+  expect(res.status).toBe(200);
+  const doc = WineDefinition.mock.calls[0][0];
+  expect(doc.contribution.user).toBe('64b000000000000000000003');
+  expect(doc.contribution.bridgeKey).toBeNull();
+  expect(doc.contribution.instanceHost).toBeNull();
+  // Rows predating the origin fields fall back to the surface that has always
+  // filed requests in a browser.
+  expect(doc.contribution.via).toBe('ui');
+});

--- a/backend/src/routes/admin/wineRequests.js
+++ b/backend/src/routes/admin/wineRequests.js
@@ -211,7 +211,19 @@ router.put('/:id/resolve', async (req, res) => {
         image: imageToStore,
         normalizedKey,
         createdBy: req.user.id,
-        createdVia: 'ui'
+        createdVia: 'ui',
+        // WHOSE data this is, as opposed to who performed the write.
+        // createdBy is the approving admin; a rights-holder complaint about
+        // this record needs the person who asked for it, the surface they
+        // used and, over the bridge, the install it came from.
+        contribution: {
+          user: wineRequest.user,
+          via: wineRequest.via || 'ui',
+          request: wineRequest._id,
+          bridgeKey: wineRequest.bridgeKey || null,
+          instanceHost: wineRequest.instanceHost || null,
+          at: wineRequest.createdAt || new Date(),
+        },
       });
 
       try {

--- a/backend/src/routes/bridgeV1.js
+++ b/backend/src/routes/bridgeV1.js
@@ -349,7 +349,7 @@ router.post('/requests', quota('contributions'), async (req, res) => {
   try {
     const r = await createWineRequest(req.user.id, {
       wineName: req.body?.wineName, sourceUrl: req.body?.sourceUrl, image: req.body?.image,
-    });
+    }, { via: 'bridge', req });
     if (r.error) return res.status(r.error.status || 400).json({ error: r.error.message, code: 'invalid' });
     logAudit(req, 'bridge.request.forwarded', { type: 'wineRequest', id: r.wineRequest._id },
       { key: req.bridge.key.id, instanceHost: req.bridge.key.instanceHost });

--- a/backend/src/routes/bridgeV1.test.js
+++ b/backend/src/routes/bridgeV1.test.js
@@ -239,7 +239,13 @@ describe('contributions', () => {
     createWineRequest.mockResolvedValue({ wineRequest: { _id: 'r1', status: 'pending', wineName: 'Salmos 2019' } });
     const res = await call('POST', '/api/bridge/v1/requests', { wineName: 'Salmos 2019', sourceUrl: 'https://torres.es/salmos' });
     expect(res.status).toBe(201);
-    expect(createWineRequest).toHaveBeenCalledWith('u1', { wineName: 'Salmos 2019', sourceUrl: 'https://torres.es/salmos', image: undefined });
+    // The third argument is what stamps the origin onto the record itself, so
+    // the contributor stays findable after the audit rows expire.
+    expect(createWineRequest).toHaveBeenCalledWith(
+      'u1',
+      { wineName: 'Salmos 2019', sourceUrl: 'https://torres.es/salmos', image: undefined },
+      expect.objectContaining({ via: 'bridge' })
+    );
     expect(logAudit).toHaveBeenCalledWith(expect.anything(), 'bridge.request.forwarded', { type: 'wineRequest', id: 'r1' }, expect.objectContaining({ key: 'k1', instanceHost: 'cellar.example.org' }));
     createWineRequest.mockResolvedValue({ error: { status: 400, message: 'Wine name and source URL are required' } });
     expect((await call('POST', '/api/bridge/v1/requests', {})).status).toBe(400);

--- a/backend/src/routes/wineRequests.js
+++ b/backend/src/routes/wineRequests.js
@@ -6,6 +6,7 @@ const registryBridge = require('../services/registryBridge');
 const WineDefinition = require('../models/WineDefinition');
 const { findVisibleWine } = require('../services/wineVisibility');
 const { createWineRequest } = require('../services/accountOps');
+const { originFrom } = require('../utils/contributionOrigin');
 
 const router = express.Router();
 
@@ -45,7 +46,8 @@ router.post('/', requireNonDemo, async (req, res) => {
         linkedWineDefinition: wine._id,
         suggestedGrapes: suggestedGrapes.map(g => String(g).trim()).filter(Boolean).slice(0, 20),
         user: req.user.id,
-        status: 'pending'
+        status: 'pending',
+        ...originFrom(req, 'web'),
       });
       await wineRequest.save();
       logAudit(req, 'wineRequest.create', { type: 'wineRequest', id: wineRequest._id });
@@ -54,7 +56,7 @@ router.post('/', requireNonDemo, async (req, res) => {
 
     // ── New wine request ── (validation + creation shared with the MCP
     // request_wine_addition tool via services/accountOps)
-    const { wineRequest, error } = await createWineRequest(req.user.id, { wineName, sourceUrl, image });
+    const { wineRequest, error } = await createWineRequest(req.user.id, { wineName, sourceUrl, image }, { via: 'web', req });
     if (error) return res.status(error.status).json({ error: error.message });
     logAudit(req, 'wineRequest.create', { type: 'wineRequest', id: wineRequest._id });
     // Registry Bridge (self-hosted installs): a wine nobody here has is worth

--- a/backend/src/services/accountOps.js
+++ b/backend/src/services/accountOps.js
@@ -15,6 +15,7 @@ const Cellar = require('../models/Cellar');
 const SupportTicket = require('../models/SupportTicket');
 const { isPrivateAddress } = require('../utils/safeImageFetch');
 const WineRequest = require('../models/WineRequest');
+const { originFrom } = require('../utils/contributionOrigin');
 const { stripHtml } = require('../utils/sanitize');
 const { SUPPORTED_CURRENCIES } = require('../config/currencies');
 
@@ -334,7 +335,7 @@ function validateImageRef(image) {
  * NOT handled here — it stays inline in the REST route (niche, needs a linked
  * wine) and is not exposed over MCP.
  */
-async function createWineRequest(userId, { wineName, sourceUrl, image } = {}) {
+async function createWineRequest(userId, { wineName, sourceUrl, image } = {}, { via, req } = {}) {
   if (!wineName) return { error: err(400, 'Wine name and source URL are required') };
   const urlErr = validateSourceUrl(sourceUrl);
   if (urlErr) return { error: err(400, urlErr) };
@@ -354,6 +355,9 @@ async function createWineRequest(userId, { wineName, sourceUrl, image } = {}) {
     image: trimmedImage || null,
     user: userId,
     status: 'pending',
+    // Which surface and, over the bridge, which install — kept on the record
+    // so a contributor's whole output stays findable (utils/contributionOrigin.js).
+    ...originFrom(req, via),
   });
   await wineRequest.save();
   return { wineRequest };

--- a/backend/src/services/registryDataOps.js
+++ b/backend/src/services/registryDataOps.js
@@ -13,6 +13,7 @@
  */
 const RegistryDataKey = require('../models/RegistryDataKey');
 const RegistryDataValue = require('../models/RegistryDataValue');
+const { originFrom } = require('../utils/contributionOrigin');
 const { findVisibleWine } = require('./wineVisibility');
 const { validateValue, validateKeyDefinition } = require('../utils/personalDataTypes');
 const { checkContributionGate } = require('./contributionGate');
@@ -156,6 +157,7 @@ async function listAcceptedKeys() {
  * general spec belongs in the default.
  */
 async function suggestValue(userId, { wineId, keyId, keyName, value, reason, evidenceUrl, vintage }, { via, req } = {}) {
+  const origin = originFrom(req, via);
   let key;
   if (keyId) {
     if (!isValidId(String(keyId))) return fail('invalid', 'Invalid key id');
@@ -224,6 +226,7 @@ async function suggestValue(userId, { wineId, keyId, keyName, value, reason, evi
       suggestedBy: userId,
       ...(cleanUrl ? { evidenceUrl: cleanUrl } : {}),
       ...(cleanReason ? { reason: cleanReason } : {}),
+      ...origin,
     });
   } catch (err) {
     if (err?.code === 11000) {

--- a/backend/src/services/userDataRegistry.js
+++ b/backend/src/services/userDataRegistry.js
@@ -396,7 +396,9 @@ const REGISTRY = [
     // Anonymise both — the record survives its contributor (#985).
     model: RegistryDataValue, category: 'shared-content', userFields: ['suggestedBy', 'decidedBy'],
     purge: (ctx) => [
-      RegistryDataValue.updateMany({ suggestedBy: ctx.userId }, { $set: { suggestedBy: ctx.deletedUserId } }),
+      // instanceHost can name a household; bridgeKey survives as an opaque
+      // grouping id (see the WineDefinition entry below for the reasoning).
+      RegistryDataValue.updateMany({ suggestedBy: ctx.userId }, { $set: { suggestedBy: ctx.deletedUserId, instanceHost: null } }),
       RegistryDataValue.updateMany({ decidedBy: ctx.userId }, { $unset: { decidedBy: '' } }),
     ],
     exportFragment: async (ctx) => ({ registryDataValueSuggestions: markTrunc(ctx, 'registryDataValueSuggestions', await RegistryDataValue.find({ suggestedBy: ctx.userId }).populate('key', 'name type unit').select('wineDefinition key vintage value status reason evidenceUrl createdAt decidedAt rejectReason').limit(EXPORT_MAX).lean()) }),
@@ -1099,7 +1101,7 @@ const REGISTRY = [
   // re-point it to the [deleted] sentinel so the ref doesn't dangle (createdBy
   // is `required`, so it can't be unset). Not exported — not the user's data.
   {
-    model: WineDefinition, category: 'creator-ref', userFields: ['createdBy', 'aiProfile.verifiedBy'],
+    model: WineDefinition, category: 'creator-ref', userFields: ['createdBy', 'aiProfile.verifiedBy', 'contribution.user'],
     // aiProfile.verifiedBy is the curator who corrected the tasting profile.
     // Reassigned rather than unset, like createdBy: the profile stays
     // curator-sourced (which is what keeps the AI job from regenerating over
@@ -1107,6 +1109,14 @@ const REGISTRY = [
     purge: async (ctx) => {
       await WineDefinition.updateMany({ createdBy: ctx.userId }, { $set: { createdBy: ctx.deletedUserId } });
       await WineDefinition.updateMany({ 'aiProfile.verifiedBy': ctx.userId }, { $set: { 'aiProfile.verifiedBy': ctx.deletedUserId } });
+      // The contributor whose request produced this wine, anonymised the same
+      // way. `contribution.bridgeKey` is deliberately KEPT: once the key row
+      // and the account are gone it identifies nobody, but it still GROUPS
+      // everything that install contributed — which is what a rights-holder
+      // takedown needs. The self-reported host can name a household, so it
+      // goes. Retaining more than this, with a legal basis and terms wording,
+      // is the provenance-ledger work, not something to smuggle in here.
+      await WineDefinition.updateMany({ 'contribution.user': ctx.userId }, { $set: { 'contribution.user': ctx.deletedUserId, 'contribution.instanceHost': null } });
     },
     exportFragment: null,
     note: 'shared registry; required createdBy + aiProfile.verifiedBy reassigned to [deleted] on erasure',

--- a/backend/src/services/wineProposalOps.js
+++ b/backend/src/services/wineProposalOps.js
@@ -17,6 +17,7 @@
  * message } — codes: invalid | banned | limit | not_found | conflict.
  */
 const WineCorrectionProposal = require('../models/WineCorrectionProposal');
+const { originFrom } = require('../utils/contributionOrigin');
 
 const { findVisibleWine } = require('./wineVisibility');
 const { stripHtml } = require('../utils/sanitize');
@@ -47,6 +48,7 @@ const fail = (code, message) => ({ ok: false, code, message });
  * fields = { producer?, name?, appellation?, region?, country?, classification? }
  */
 async function createFieldCorrection(userId, { wineId, fields, reason, evidenceUrl }, { via, req } = {}) {
+  const origin = originFrom(req, via);
   const cleanReason = stripHtml(typeof reason === 'string' ? reason : '').trim();
   if (cleanReason.length < REASON_MIN) {
     return fail('invalid', `Please say what is wrong and how you know — at least ${REASON_MIN} characters.`);
@@ -147,6 +149,7 @@ async function createFieldCorrection(userId, { wineId, fields, reason, evidenceU
       ...(cleanUrl ? { evidenceUrl: cleanUrl } : {}),
       reason: cleanReason,
       currentSnapshot,
+      ...origin,
     });
   } catch (err) {
     // One pending field_correction per wine (partial unique index) — a clean,

--- a/backend/src/utils/contributionOrigin.js
+++ b/backend/src/utils/contributionOrigin.js
@@ -1,0 +1,62 @@
+/**
+ * Where a contribution came from — recorded ON THE RECORD, not only in the
+ * audit log.
+ *
+ * Until now `via` was passed to logAudit and thrown away, and the bridge key
+ * and install host existed nowhere but audit rows that expire after 90 days.
+ * That left one question unanswerable: "a rights holder says wine X is theirs
+ * — who gave it to us, and what else did they give us?". The audit trail is
+ * the wrong place for it, because it is bounded by retention and shaped for
+ * incident review, not for grouping a contributor's whole output.
+ *
+ * These three fields are the minimum that makes that query possible today.
+ * They do NOT survive an account erasure (services/userDataRegistry.js follows
+ * the same policy it applies everywhere else); the durable, pseudonymous
+ * provenance ledger that outlives erasure is a separate piece of work with its
+ * own legal basis and its own wording in the terms.
+ */
+
+const VIA = ['ui', 'mcp', 'bridge', 'import'];
+// The browser routes have always audited themselves as 'web'; the registry's
+// own createdVia vocabulary calls the same surface 'ui'. Accept both and store
+// the registry's word, so the two provenance fields can be read together.
+const ALIASES = { web: 'ui', ui: 'ui' };
+
+/**
+ * Derive the origin of a contribution from the request that carried it.
+ * `via` is what the caller declares; a request authenticated by a bridge key
+ * is 'bridge' whether or not the caller said so, because that is a fact about
+ * the credential rather than a claim by the code path.
+ *
+ * @param {object} req    the Express request (may be undefined: MCP tools and
+ *                        scripts call the ops services without one)
+ * @param {string} [via]  the declared surface
+ * @returns {{via: string|null, bridgeKey: (string|null), instanceHost: (string|null)}}
+ */
+function originFrom(req, via) {
+  const bridge = req && req.bridge && req.bridge.key ? req.bridge.key : null;
+  const canonical = ALIASES[via] || via;
+  const declared = VIA.includes(canonical) ? canonical : null;
+  return {
+    via: bridge ? 'bridge' : declared,
+    bridgeKey: bridge ? (bridge.id || null) : null,
+    instanceHost: bridge ? (bridge.instanceHost || null) : null,
+  };
+}
+
+/**
+ * The same three fields as a Mongoose schema fragment, so every record that
+ * can carry a contribution describes it identically.
+ *
+ * Absence is the honest unknown: rows written before this shipped carry no
+ * `via`, and that must never be read as 'ui'.
+ */
+function originSchemaFields(mongoose) {
+  return {
+    via: { type: String, enum: [...VIA, null], default: null },
+    bridgeKey: { type: mongoose.Schema.Types.ObjectId, ref: 'BridgeKey', default: null },
+    instanceHost: { type: String, default: null, maxlength: 120 },
+  };
+}
+
+module.exports = { originFrom, originSchemaFields, VIA };

--- a/backend/src/utils/contributionOrigin.test.js
+++ b/backend/src/utils/contributionOrigin.test.js
@@ -1,0 +1,56 @@
+/**
+ * utils/contributionOrigin — where a contribution came from, recorded on the
+ * record rather than only in the audit log.
+ *
+ * WHY THIS EXISTS: a rights holder can tell us a registry wine is theirs. The
+ * question that follows is "who gave it to us, and what else did they give
+ * us?", and until this shipped the answer lived only in audit rows that expire
+ * after 90 days. These are small fields, so the pins are about the two rules
+ * that are easy to get wrong: a bridge request is 'bridge' whatever the caller
+ * claims, and absence is never 'ui'.
+ */
+const { originFrom, VIA } = require('./contributionOrigin');
+
+const bridgeReq = (over = {}) => ({
+  bridge: { key: { id: 'k1', name: 'Home NAS', instanceHost: 'cellar.example.org', ...over } },
+});
+
+describe('originFrom', () => {
+  test('a bridge-authenticated request is bridge, with its key and install', () => {
+    expect(originFrom(bridgeReq(), 'bridge')).toEqual({
+      via: 'bridge', bridgeKey: 'k1', instanceHost: 'cellar.example.org',
+    });
+  });
+
+  test('the credential wins over what the caller declares', () => {
+    // The bridge is a fact about the credential, not a claim by the code path:
+    // a route that forgot to say so must not launder a contribution as web.
+    expect(originFrom(bridgeReq(), 'web').via).toBe('bridge');
+    expect(originFrom(bridgeReq(), undefined).via).toBe('bridge');
+  });
+
+  test("'web' is stored as 'ui', matching the registry's own createdVia word", () => {
+    // The browser routes audit themselves as 'web'; WineDefinition.createdVia
+    // calls the same surface 'ui'. One vocabulary on the records.
+    expect(originFrom({}, 'web')).toEqual({ via: 'ui', bridgeKey: null, instanceHost: null });
+    expect(originFrom({}, 'ui').via).toBe('ui');
+  });
+
+  test('an unknown or missing surface is null, never a guess', () => {
+    // Absence is the honest unknown — rows written before this shipped carry
+    // no via, and reading that as 'ui' would invent provenance.
+    expect(originFrom({}, 'undo').via).toBeNull();
+    expect(originFrom(undefined, undefined)).toEqual({ via: null, bridgeKey: null, instanceHost: null });
+    expect(originFrom(null, 'mcp').via).toBe('mcp');
+  });
+
+  test('a bridge key with no reported host still records the key', () => {
+    expect(originFrom(bridgeReq({ instanceHost: null }))).toEqual({
+      via: 'bridge', bridgeKey: 'k1', instanceHost: null,
+    });
+  });
+
+  test('the surfaces it knows about', () => {
+    expect(VIA).toEqual(['ui', 'mcp', 'bridge', 'import']);
+  });
+});


### PR DESCRIPTION
Items 1 and 2 of the provenance work discussed on 2026-09-08. A rights holder can tell us a registry wine is theirs; the question that follows is *who gave it to us, and what else did they give us?*

Until now that answer lived only in the audit log: `via` was passed to `logAudit` and thrown away, the bridge key and install host were stored on no record at all, and audit rows expire after 90 days.

## 1 — the origin goes on the contribution record

`WineRequest`, `WineCorrectionProposal` and `RegistryDataValue` gain `via`, `bridgeKey` and `instanceHost`, filled by a single helper (`utils/contributionOrigin.js`). Two rules the helper enforces:

- a request authenticated by a bridge key is `bridge` whatever the caller declares, because that is a fact about the credential rather than a claim by the code path;
- absence is the honest unknown — rows written before this carry no `via`, and that is never read as `ui`.

The browser routes have always audited themselves as `web` while the registry's own `createdVia` calls that surface `ui`; the helper normalises to `ui` so the two provenance fields can be read together.

## 2 — and onto the wine it produces

Approving a wine request now writes a `contribution` block on the new `WineDefinition`: the contributor, the surface, the originating request, the bridge key and the reported install. `createdBy` on that wine is the **admin who approved it**, which was the wrong answer to the question above and stays as it is.

Three sparse indexes support the query a takedown starts from: every wine, proposal and value traceable to one contributor, one key or one install.

## Erasure

Deliberately follows the policy applied everywhere else rather than inventing a retention rule. The contributor reference is anonymised like `createdBy`; the self-reported host is cleared, because it can name a household. The bridge key reference is **kept**: once the key row and the account are gone it identifies nobody, while still grouping everything that install contributed — a pseudonymous grouping id for free. Retaining more than that needs a legal basis and terms wording, which is the provenance-ledger work, not something to smuggle in here.

## Tests

`utils/contributionOrigin.test.js` pins the two rules above; the approve suite pins that a created wine records whose contribution produced it and never invents a surface; the bridge and MCP suites pin that the origin is passed at the call sites. Full backend suite: 343 suites, 5216 tests, green in the Node 24 container. No frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
