### PR TITLE
chore(auth): follow-ups to #1268 — catalogue keys, backend env example, README bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This is the primary way to use Cellarion. Create an account and start using the 
 
 **Platform**
 - **Climate monitoring** — Connect cellar temperature/humidity sensors (Home Assistant-friendly ingest API) with per-cellar dashboards
-- **Sign in with Google** — Optional Google SSO alongside email/password
+- **Single sign-on** — Optional Google SSO, or your own OIDC provider (Pocket ID, Authentik, Keycloak, Zitadel, Authelia), alongside email/password
 - **Installable app** — PWA with push notifications, plus an Android app on [Google Play](https://play.google.com/store/apps/details?id=app.cellarion.twa)
 - **Internationalization** — Community-translated via Weblate ([help translate](#translations))
 - **Privacy & GDPR** — Full data export, account deletion with cooling-off, one-click email opt-out, optional self-hosted cookie-free analytics (Umami)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -81,6 +81,33 @@ AUDIT_TTL_DAYS=365
 # ── SEO — optional ───────────────────────────────────────────────────────────
 INDEXNOW_KEY=
 
+# ── Single sign-on — optional (Google and/or your own OIDC provider) ──────────
+# Both can be on at once; leaving a block empty keeps that provider off.
+# Google: register <FRONTEND_URL>/api/auth/google/callback in Google Console.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_CALLBACK_URL=
+# OIDC (Pocket ID, Authentik, Keycloak, Zitadel, Authelia …): all six of
+# CLIENT_ID, CLIENT_SECRET, ISSUER, AUTHORIZATION_URL, TOKEN_URL and USERINFO_URL
+# must be set or the provider stays off. Take the three endpoints and the issuer
+# verbatim from <issuer>/.well-known/openid-configuration. Register the client for
+# client_secret_post (credentials go in the token request body, not HTTP Basic),
+# and register this exact redirect URI: <FRONTEND_URL>/api/auth/oidc/callback.
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+OIDC_ISSUER=
+OIDC_AUTHORIZATION_URL=
+OIDC_TOKEN_URL=
+OIDC_USERINFO_URL=
+# Optional: the name on the login button ("Continue with Pocket ID"), a callback
+# override when the API is not same-origin, scopes (default "openid profile email"),
+# and whether an UNVERIFIED email from this issuer may link to an existing account
+# (default false — leave it off unless you know your issuer's email claim is trustworthy).
+OIDC_PROVIDER_NAME=
+OIDC_CALLBACK_URL=
+OIDC_SCOPES=
+OIDC_TRUST_EMAIL_VERIFIED=
+
 # ── Registry Bridge — optional, self-hosted installs (docs/registry-bridge.md) ──
 REGISTRY_BRIDGE_URL=https://cellarion.app
 REGISTRY_BRIDGE_KEY=

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -108,6 +108,8 @@
     "dashboard": "Dashboard"
   },
   "auth": {
+    "continueWithGoogle": "Continue with Google",
+    "continueWithProvider": "Continue with {{provider}}",
     "login": "Login",
     "register": "Register",
     "tagline": "Your personal wine cellar",


### PR DESCRIPTION
The small things on top of #1268, as promised to deltabeat on #1203: both SSO button keys in the English catalogue (Google's was missing too, so Weblate could translate neither), the OIDC and Google blocks in `backend/.env.example`, and the README feature bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)