### PR TITLE
chore(release): v1.213.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.212.0",
+  "version": "1.213.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wine-cellar-backend",
-      "version": "1.212.0",
+      "version": "1.213.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wine-cellar-backend",
-  "version": "1.212.0",
+  "version": "1.213.0",
   "license": "AGPL-3.0",
   "description": "Wine cellar management backend",
   "main": "server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.212.0",
+  "version": "1.213.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.212.0",
+      "version": "1.213.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fontsource/inter": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.212.0",
+  "version": "1.213.0",
   "license": "AGPL-3.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for v1.213.0.

Ships the admin global-stats rework (#1272): the page drops the sections nobody acted on, stops counting demo and departing accounts as customers, gives self-hosted Bridge installs their own line instead of dragging activation down, and adds a second measure of returning users based on showing up rather than only on touching a bottle. Automated API traffic is excluded from that measure, so a Home Assistant or climate integration polling in the background no longer looks like a daily user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
