### PR TITLE
feat(admin): answer "do new users come back?" both ways, side by side

### DIFF
--- a/backend/src/services/globalStatsService.js
+++ b/backend/src/services/globalStatsService.js
@@ -187,7 +187,7 @@ const COHORT_SPAN_DAYS = 28;    // how far back cohorts go
  *
  * `now` is injected so the test can pin time instead of racing the clock.
  */
-const buildSignupCohorts = (users, activeIds, now) => {
+const buildSignupCohorts = (users, activeIds, now, changedIds = null) => {
   const out = [];
   for (let start = 0; start < COHORT_SPAN_DAYS; start += COHORT_WINDOW_DAYS) {
     const end = start + COHORT_WINDOW_DAYS;
@@ -201,12 +201,17 @@ const buildSignupCohorts = (users, activeIds, now) => {
     const members = users.filter((u) => u.createdAt >= from && (to === null || u.createdAt < to));
     const tooNew = start === 0;
     const returned = tooNew ? null : members.filter((u) => activeIds.has(String(u._id))).length;
+    // The narrow measure on the same members. Null when the caller did not
+    // supply it, and null for the newest cohort for the same reason as above.
+    const changed = tooNew || !changedIds ? null : members.filter((u) => changedIds.has(String(u._id))).length;
     out.push({
       daysAgoFrom: start,
       daysAgoTo: end,
       signedUp: members.length,
       returned,
       pct: returned == null ? null : pct(returned, members.length),
+      changed,
+      changedPct: changed == null ? null : pct(changed, members.length),
       tooNew,
     });
   }
@@ -400,17 +405,28 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
 
   // ── Engagement (active users 24h / 7d / 30d / 90d) ──────────────────────
   // "Active" = added a bottle or consumed a bottle within the window.
+  // "Changed a cellar" = added or consumed a bottle since `since`. One
+  // definition, used by the window counts here and by the signup cohorts
+  // further down, so the phrase means the same thing everywhere on the page.
+  const cellarChangedMatch = (since) => ({ ...bottleMatch, $or: [
+    { createdAt:  { $gte: since } },
+    { consumedAt: { $gte: since } },
+  ]});
   const engagementWindow = async (since) => {
     const r = await safeAggregate(Bottle, [
-      { $match: { ...bottleMatch, $or: [
-        { createdAt:  { $gte: since } },
-        { consumedAt: { $gte: since } },
-      ]}},
+      { $match: cellarChangedMatch(since) },
       { $group: { _id: '$user' } },
       { $count: 'count' },
     ]);
     return r[0]?.count || 0;
   };
+  // The same population as ids, for set membership rather than a count.
+  const cellarChangedUserIds = async (since) => new Set(
+    (await safeAggregate(Bottle, [
+      { $match: cellarChangedMatch(since) },
+      { $group: { _id: '$user' } },
+    ])).map((r) => String(r._id)),
+  );
 
   const [activeUsers24h, activeUsers7d, activeUsers30d, activeUsers90d] = await Promise.all([
     engagementWindow(since24h),
@@ -493,30 +509,38 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
   // shows the intake without inviting the false reading. The headline
   // percentage covers the MATURE cohorts only.
   //
-  // Cost: ONE audit query, bounded to 7 days and served by the timestamp
-  // index, intersected in memory — not one query per cohort. Deliberately
-  // modest, because the login retention removed above was the most expensive
-  // thing on this page and replacing it with something worse would be a poor
-  // trade.
+  // Cost: one audit query and one bottle query, each bounded to 7 days and
+  // served by an index, intersected in memory — not one query per cohort.
   const cohortUsers = await User.find({
     ...userMatch,
     createdAt: { $gte: new Date(Date.now() - COHORT_SPAN_DAYS * 86400000) },
   }).select('_id createdAt').lean();
 
-  // Anyone who did ANYTHING in the window. Deliberately not "logged in": the
-  // refresh cookie keeps a session alive for 30 rotating days, so an active
-  // user may not hit /login for weeks. Deliberately not "touched a bottle"
-  // either — that measures activation, which is a different question and
-  // already has its own figures.
-  const activeIds = new Set(
-    (await AuditLog.distinct('actor.userId', { timestamp: { $gte: since7d } }))
-      .filter(Boolean).map(String),
-  );
+  // Two answers to "came back", on the same cohorts, so the gap between them
+  // is visible row by row rather than argued about:
+  //
+  //   present — signed in, or did anything the audit log records, under the
+  //             SAME rule as the presence ladder (sign-ins resolved from
+  //             resource.id, machine traffic excluded). Deliberately not
+  //             "logged in": the refresh cookie keeps a session alive for 30
+  //             rotating days, so an active user may not hit /login for weeks.
+  //   changed — added or consumed a bottle: the narrow cellar-change measure.
+  //
+  // A new user finding their way around is present without having changed
+  // anything yet. That is exactly the difference worth seeing.
+  const [presentIds, changedIds] = await Promise.all([
+    safeAggregate(AuditLog, [
+      ...presenceStages({ since: since7d, excludedIds }),
+      { $group: { _id: '$who' } },
+    ]).then((rows) => new Set(rows.map((r) => String(r._id)))),
+    cellarChangedUserIds(since7d),
+  ]);
 
-  const signupCohorts = buildSignupCohorts(cohortUsers, activeIds, Date.now());
+  const signupCohorts = buildSignupCohorts(cohortUsers, presentIds, Date.now(), changedIds);
   const mature = signupCohorts.filter((c) => !c.tooNew);
   const matureSignups = mature.reduce((s, c) => s + c.signedUp, 0);
   const matureReturned = mature.reduce((s, c) => s + c.returned, 0);
+  const matureChanged = mature.reduce((s, c) => s + (c.changed || 0), 0);
 
   // History worth keeping: a LOGIN-ONLY ladder lived here until 2026-08-21 and
   // was removed for good reasons. It counted sign-in events, and a rotating
@@ -828,6 +852,10 @@ async function _computeGlobalStatsUncached({ excludeAdmins = true } = {}) {
       cohortSignups: matureSignups,
       cohortReturned: matureReturned,
       cohortReturnedPct: pct(matureReturned, matureSignups),
+      // The same mature cohorts by the narrow measure — added or consumed a
+      // bottle — so the two headline rates sit side by side.
+      cohortChanged: matureChanged,
+      cohortChangedPct: pct(matureChanged, matureSignups),
       // The second ladder: days the user was PRESENT (signed in, or did
       // anything the audit log records) rather than days they changed a
       // cellar. Windowed by the audit TTL, which is why windowDays ships with

--- a/backend/src/services/globalStatsService.signupCohorts.test.js
+++ b/backend/src/services/globalStatsService.signupCohorts.test.js
@@ -82,6 +82,42 @@ describe('buildSignupCohorts', () => {
   });
 });
 
+describe('the narrow measure (changedIds) beside the wide one', () => {
+  it('is null, not zero, when the caller does not supply it', () => {
+    // "Not measured" must never read as "nobody did": an older caller gets
+    // null back and the page hides the column instead of showing zeros.
+    const cohorts = buildSignupCohorts([user('a', 9)], new Set(['a']), NOW);
+    const wk2 = cohorts.find((c) => c.daysAgoFrom === 7);
+    expect(wk2.changed).toBeNull();
+    expect(wk2.changedPct).toBeNull();
+  });
+
+  it('counts the two sets independently on the same members', () => {
+    // Four signups a week ago: a and c were present, only a changed a cellar.
+    const users = [user('a', 8), user('b', 9), user('c', 10), user('d', 11)];
+    const cohorts = buildSignupCohorts(users, new Set(['a', 'c']), NOW, new Set(['a']));
+    const wk2 = cohorts.find((c) => c.daysAgoFrom === 7);
+    expect(wk2).toMatchObject({ signedUp: 4, returned: 2, pct: 50, changed: 1, changedPct: 25 });
+  });
+
+  it('never reports the narrow rate for the newest cohort either', () => {
+    // The same tautology as the wide measure: joining this week and adding a
+    // first bottle this week is intake, not retention.
+    const [newest] = buildSignupCohorts([user('a', 2)], new Set(['a']), NOW, new Set(['a']));
+    expect(newest.tooNew).toBe(true);
+    expect(newest.changed).toBeNull();
+    expect(newest.changedPct).toBeNull();
+  });
+
+  it('compares changed ids as strings too', () => {
+    // changedIds comes from a Bottle aggregation; the same ObjectId-vs-string
+    // trap as the audit side, and the same silent 0% if it were missed.
+    const oid = { toString: () => 'objid-2' };
+    const cohorts = buildSignupCohorts([{ _id: oid, createdAt: daysAgo(9) }], new Set(), NOW, new Set(['objid-2']));
+    expect(cohorts.find((c) => c.daysAgoFrom === 7)).toMatchObject({ returned: 0, changed: 1, changedPct: 100 });
+  });
+});
+
 describe('the newest bucket has no upper bound', () => {
   it('counts a user created at the exact query instant', () => {
     // With `< now` as the upper edge this user fell out of every bucket and

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -3679,12 +3679,12 @@
     "formerSupportersTooltip": "Users on the free plan whose supporter tier once started — the start is stamped only when support is actually granted, so an abandoned Stripe checkout does not count. Someone who resubscribed counts as current, not former.",
     "planUnconfigured": "(not a configured tier)",
     "cohortsHead": "Do new users come back?",
-    "cohortReturned": "New users returning",
+    "cohortReturned": "New users present",
     "cohortReturnedSub": "{{returned}} of {{total}} recent signups",
-    "cohortReturnedTooltip": "Of everyone who signed up between 1 and 4 weeks ago, the share who did anything the app records in the last 7 days — not only adding a bottle, and not merely signing in, since a session lasts 30 days without a fresh login. Drawn from the audit log, which is kept for 90 days; that is ample for a 7-day question. The most recent week is excluded because its members were active in the window by virtue of signing up in it.",
+    "cohortReturnedTooltip": "Of everyone who signed up between 1 and 4 weeks ago, the share who were present in the last 7 days: signed in, or did anything the app records. The same rule as the presence ladder below — automated API traffic does not count, and a session lasting 30 days without a fresh sign-in does not hide anyone. The most recent week is excluded because its members were present in the window by virtue of signing up in it.",
     "cohortRange": "{{from}}–{{to}} days ago",
     "cohortTooNew": "too recent",
-    "cohortNote": "Came back = any recorded action in the last 7 days — adding, editing, consuming, anything the audit log records. That is deliberately broader than the bottle-only measure above, because a new user finding their way around counts as coming back. The newest group shows its intake only: those users were active in the window because they joined during it, so a percentage there would measure nothing.",
+    "cohortNote": "Present = signed in, or did anything the app records, in the last 7 days — the same rule as the presence ladder below. Changed a cellar = added or consumed a bottle in the same 7 days. A new user finding their way around is present without having changed anything yet; the gap between the two columns is exactly that. The newest group shows its intake only: those users were present in the window because they joined during it, so a rate there would measure nothing.",
     "engagementChanged": "Changed a cellar",
     "engagementPresent": "Signed in or acted",
     "presenceNote": "Present = signed in, or did something the app records: adding, editing, consuming, asking the sommelier. Automated API traffic does not count, so a Home Assistant or climate integration polling in the background is not mistaken for its owner showing up. Reading pages is not recorded for anyone, so this is a floor rather than a ceiling. Seen as far back as the activity log is kept, which is {{days}} days.",
@@ -3704,7 +3704,13 @@
     "usersSeen": "People seen at all",
     "usersSeenSub": "in the last {{days}} days",
     "usersSeenTooltip": "Everyone with at least one recorded action or sign-in in the window. This is the denominator the percentages beside it use.",
-    "ofUsersSeen": "of people seen"
+    "ofUsersSeen": "of people seen",
+    "cohortChanged": "New users who changed a cellar",
+    "cohortChangedTooltip": "Of the same signups, the share who added or consumed a bottle in the last 7 days. Always at or below the figure beside it: you cannot change a cellar without being present.",
+    "cohortColSignedUp": "Signed up",
+    "cohortColCount": "People",
+    "cohortColChanged": "Changed a cellar",
+    "cohortColPresent": "Present"
   },
   "announcement": {
     "dismiss": "Dismiss"

--- a/frontend/src/pages/AdminStats.js
+++ b/frontend/src/pages/AdminStats.js
@@ -133,6 +133,9 @@ function AdminStats() {
     if (!parts.length) return null;
     return t('adminStats.excludedNote', 'excludes {{list}}', { list: parts.join(', ') });
   })();
+  // An older payload has no `changed` on its cohorts; the column and its card
+  // simply stay away rather than rendering a row of zeros.
+  const cohortHasChanged = (retention?.signupCohorts || []).some((c) => c.changed != null);
 
   const maturityColors = {
     peak:       '#1a7f37',
@@ -274,6 +277,8 @@ function AdminStats() {
           {retention.signupCohorts && retention.signupCohorts.length > 0 && (
             <>
               <h3 className="admin-stats-subhead">{t('adminStats.cohortsHead')}</h3>
+              {/* Both answers, side by side. The gap between them is new
+                  users who came back to look without changing anything yet. */}
               <div className="admin-stats-cards">
                 <StatCard
                   accent="ok"
@@ -285,6 +290,17 @@ function AdminStats() {
                   })}
                   tooltip={t('adminStats.cohortReturnedTooltip')}
                 />
+                {cohortHasChanged && (
+                  <StatCard
+                    label={t('adminStats.cohortChanged', 'New users who changed a cellar')}
+                    value={fmtPct(retention.cohortChangedPct)}
+                    sublabel={t('adminStats.cohortReturnedSub', {
+                      returned: retention.cohortChanged ?? 0,
+                      total: retention.cohortSignups ?? 0,
+                    })}
+                    tooltip={t('adminStats.cohortChangedTooltip', 'Of the same signups, the share who added or consumed a bottle in the last 7 days. Always at or below the figure beside it: you cannot change a cellar without being present.')}
+                  />
+                )}
               </div>
               <div className="admin-stats-panel">
                 {/* Own class, not just admin-stats-table: this table's right
@@ -292,6 +308,16 @@ function AdminStats() {
                     across lines (it read as broken data when it did). The
                     other admin tables are unaffected. */}
                 <table className="admin-stats-table admin-stats-cohorts">
+                  <thead>
+                    <tr>
+                      <th className="admin-stats-name">{t('adminStats.cohortColSignedUp', 'Signed up')}</th>
+                      <th className="admin-stats-count">{t('adminStats.cohortColCount', 'People')}</th>
+                      {cohortHasChanged && (
+                        <th className="admin-stats-pct">{t('adminStats.cohortColChanged', 'Changed a cellar')}</th>
+                      )}
+                      <th className="admin-stats-pct">{t('adminStats.cohortColPresent', 'Present')}</th>
+                    </tr>
+                  </thead>
                   <tbody>
                     {retention.signupCohorts.map((c) => (
                       <tr key={c.daysAgoFrom} className={c.tooNew ? 'admin-stats-row-empty' : undefined}>
@@ -299,6 +325,16 @@ function AdminStats() {
                           {t('adminStats.cohortRange', { from: c.daysAgoFrom, to: c.daysAgoTo })}
                         </td>
                         <td className="admin-stats-count">{fmt(c.signedUp)}</td>
+                        {cohortHasChanged && (
+                          <td className="admin-stats-pct">
+                            {/* The newest cohort gets a dash here, not a second
+                                "too recent": the reason is stated once, in the
+                                column beside it. */}
+                            {c.tooNew || c.changed == null
+                              ? '—'
+                              : `${fmt(c.changed)} · ${fmtPct(c.changedPct)}`}
+                          </td>
+                        )}
                         <td className="admin-stats-pct">
                           {/* The newest cohort shows its intake and NO rate:
                               its members are "active in the last 7 days"

--- a/frontend/src/pages/AdminStats.presence.test.js
+++ b/frontend/src/pages/AdminStats.presence.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import AdminStats from './AdminStats';
 
 /**
@@ -68,6 +68,19 @@ const BASE = {
   },
 };
 
+// Cohorts from a backend that predates the second measure: no `changed` at all.
+const withOldCohorts = {
+  ...BASE,
+  retention: {
+    ...BASE.retention,
+    signupCohorts: [
+      { daysAgoFrom: 0, daysAgoTo: 7, signedUp: 18, returned: null, pct: null, tooNew: true },
+      { daysAgoFrom: 7, daysAgoTo: 14, signedUp: 31, returned: 16, pct: 51.6, tooNew: false },
+    ],
+    cohortSignups: 31, cohortReturned: 16, cohortReturnedPct: 51.6,
+  },
+};
+
 const withPresence = {
   ...BASE,
   engagement: {
@@ -76,6 +89,14 @@ const withPresence = {
   },
   retention: {
     ...BASE.retention,
+    // The same cohorts by both measures. 9 ≤ 16: you cannot change a cellar
+    // without being present.
+    signupCohorts: [
+      { daysAgoFrom: 0, daysAgoTo: 7, signedUp: 18, returned: null, pct: null, changed: null, changedPct: null, tooNew: true },
+      { daysAgoFrom: 7, daysAgoTo: 14, signedUp: 31, returned: 16, pct: 51.6, changed: 9, changedPct: 29, tooNew: false },
+    ],
+    cohortSignups: 31, cohortReturned: 16, cohortReturnedPct: 51.6,
+    cohortChanged: 9, cohortChangedPct: 29,
     presence: {
       usersSeen: 255, returningUsers: 130, coreUsers: 85, returningPct: 51,
       tiers: [{ days: 2, users: 130, pct: 51 }, { days: 4, users: 85, pct: 33 }, { days: 7, users: 63, pct: 24 }],
@@ -123,6 +144,40 @@ describe('AdminStats presence measures', () => {
     expect(screen.queryByText('adminStats.retentionByPresence:90')).not.toBeInTheDocument();
     // The bottle-based figures are still there.
     expect(screen.getByText('50')).toBeInTheDocument();
+  });
+
+  it('shows both cohort measures side by side, with a header row', async () => {
+    getStats.mockResolvedValue(jsonRes(withPresence));
+    render(<AdminStats />);
+    await waitFor(() => expect(screen.getByText('adminStats.cohortsHead')).toBeInTheDocument());
+    // Two headline cards.
+    expect(screen.getByText('adminStats.cohortReturned')).toBeInTheDocument();
+    expect(screen.getByText('adminStats.cohortChanged')).toBeInTheDocument();
+    // A header row naming each column, so the two figures cannot be confused.
+    expect(screen.getByText('adminStats.cohortColChanged')).toBeInTheDocument();
+    expect(screen.getByText('adminStats.cohortColPresent')).toBeInTheDocument();
+    // One mature row, both measures, present ≥ changed.
+    expect(screen.getByText('16 · 52%')).toBeInTheDocument();
+    expect(screen.getByText('9 · 29%')).toBeInTheDocument();
+    // The newest row: intake only, a dash in the narrow column, and "too
+    // recent" stated once rather than twice. Scoped to the table — the page
+    // prints a dash for every missing value elsewhere too.
+    const table = within(screen.getByText('adminStats.cohortColPresent').closest('table'));
+    expect(table.getAllByText('—')).toHaveLength(1);
+    expect(table.getAllByText('adminStats.cohortTooNew')).toHaveLength(1);
+  });
+
+  it('keeps the single-measure table for a payload without the narrow measure', async () => {
+    // A cached or older response: no second card, no extra column, no zeros
+    // pretending to be data.
+    getStats.mockResolvedValue(jsonRes(withOldCohorts));
+    render(<AdminStats />);
+    await waitFor(() => expect(screen.getByText('adminStats.cohortsHead')).toBeInTheDocument());
+    expect(screen.getByText('16 · 52%')).toBeInTheDocument();
+    expect(screen.queryByText('adminStats.cohortChanged')).not.toBeInTheDocument();
+    expect(screen.queryByText('adminStats.cohortColChanged')).not.toBeInTheDocument();
+    const table = within(screen.getByText('16 · 52%').closest('table'));
+    expect(table.queryByText('—')).not.toBeInTheDocument();
   });
 
   it('hides the presence ladder when nobody has been seen yet', async () => {


### PR DESCRIPTION
## Why

The "Do new users come back?" table used one definition of coming back (any recorded action) while the two retention ladders under it use two (changed a cellar / present). Johan asked to see both on the cohorts, so the difference is easy to read.

## What changed

Each cohort row now carries both measures, with a header row and a second headline card:

| Signed up | People | Changed a cellar | Present |
|---|---|---|---|
| 0–7 days ago | 18 | — | too recent |
| 7–14 days ago | 31 | 9 · 29% | 16 · 52% |

The gap between the columns is new users who came back to look without changing anything yet.

**"Present" now means the same thing everywhere on the page.** The cohort figure previously read raw `actor.userId` from the audit log, which counted automated API polling as a person and missed everyone whose only action was signing in (login rows have a null actor). It now uses the presence ladder's rule.

The narrow measure is optional in the builder and `null` when absent, so a cached or older payload hides the column instead of rendering zeros.

## Tests

- Builder: 4 new cases (sets counted independently on the same members; null when unsupplied; newest cohort stays null; ObjectId-vs-string comparison) — 58/58 across the stats suites
- Page: both measures render with a header row; a payload without the second measure keeps the single-measure table — 99 files / 1,266 tests
- Build green

Admin-only page; payload additive; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
