### PR TITLE
chore(deps): React Router 7 — the router line that still receives fixes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,7 @@
         "react-helmet-async": "^3.0.0",
         "react-i18next": "^16.5.4",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.30.6",
+        "react-router-dom": "^7.18.3",
         "react-simple-maps": "^3.0.0",
         "recharts": "^3.8.0",
         "rehype-sanitize": "^6.0.0",
@@ -1169,15 +1169,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
-      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2839,6 +2830,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -5223,35 +5227,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
-      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.3.tgz",
+      "integrity": "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
-      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.3.tgz",
+      "integrity": "sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4",
-        "react-router": "6.30.6"
+        "react-router": "7.18.3"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-simple-maps": {
@@ -5500,6 +5510,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "react-helmet-async": "^3.0.0",
     "react-i18next": "^16.5.4",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.30.6",
+    "react-router-dom": "^7.18.3",
     "react-simple-maps": "^3.0.0",
     "recharts": "^3.8.0",
     "rehype-sanitize": "^6.0.0",

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation, Trans } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
 import useVersion from '../hooks/useVersion';
-import { stashPostLoginRedirect, takePostLoginRedirect } from '../utils/postLoginRedirect';
+import { stashPostLoginRedirect, takePostLoginRedirect, isSafeInternalPath } from '../utils/postLoginRedirect';
 import './Login.css';
 
 const LOGO_WEBP = '/cellarion-logo-light.webp';
@@ -94,7 +94,12 @@ function Login() {
         // wins is how an abandoned journey gets inherited by a later sign-in in
         // this tab.
         const stashed = takePostLoginRedirect();
-        navigate(location.state?.from || stashed || '/cellars');
+        // Router state is same-origin only, and today no protected route can
+        // match a protocol-relative or backslash path — but that is a property
+        // of the route table, not a guarantee (postLoginRedirect.js explains),
+        // so the destination takes the same check the stashed one already does.
+        const from = location.state?.from;
+        navigate(isSafeInternalPath(from) ? from : (stashed || '/cellars'));
       }
     } else {
       if (result.code === 'EMAIL_NOT_VERIFIED') {


### PR DESCRIPTION
## Why

Alert #128 (`react-router < 7.18`, open redirect via backslash in `<Link>`/`useNavigate`) cannot be cleared on the 6.x line: the fix exists only in 7.18.0. That is the real finding — React Router 6 no longer receives security patches — and dismissing the alert would have hidden it.

The exploit path was already closed in our code (`postLoginRedirect.js` and `internalPath.js` reject backslash and protocol-relative targets), so there was no urgency; that made this the calm moment to move.

## What changed

- **react-router-dom 6.30.6 → 7.18.3.** The app uses the plain `BrowserRouter` surface (Link, useNavigate, useParams, useSearchParams, useLocation, Navigate, Routes, Route) and no data-router APIs, so nothing in the 78 importing files changes. Done in the two steps the migration guide asks for: v7 behaviour flags on 6.30.6 first (1,264 tests pass), then 7.18.3 with the flags removed since they are the default there. The 10 test files that mock `react-router-dom` keep working — the package still exists in 7 as a re-export.
- **Login hardening.** The router-state destination after sign-in now goes through the same `isSafeInternalPath()` check the stashed destination already had. Today no protected route can match a protocol-relative or backslash path, but that is a property of the route table, not a guarantee.

## Verification

- Full frontend suite on this tree: **1264 tests pass**, build green
- Docker-shaped `npm ci` + Vite build in `node:24-alpine` with the new lockfile: green, all 25 rollup platform binaries kept

After merge, alert #128 resolves on its own and Dependabot stops re-proposing 6.30.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
