### PR TITLE
fix(admin): the four-column cohort table no longer crushes its label column on a phone

### DIFF
--- a/frontend/src/pages/AdminStats.css
+++ b/frontend/src/pages/AdminStats.css
@@ -367,3 +367,26 @@
   word-break: normal;
   overflow-wrap: anywhere;
 }
+/* Four columns on a phone. The nowrap rule above matches header cells too, so
+   "Changed a cellar" took the width it wanted and the label column collapsed
+   to one character per line (measured at 360px: 29px wide, 174px tall).
+   Headers may wrap; the label column keeps room for "7–14 days ago" on two
+   lines; cells give up a little side padding so all four columns fit a 360px
+   screen (measured: label 102px wide, table 2px inside its panel); and on a
+   screen narrower still, the table scrolls sideways inside its wrapper rather
+   than crushing a column. */
+.admin-stats-cohorts th.admin-stats-count,
+.admin-stats-cohorts th.admin-stats-pct {
+  white-space: normal;
+}
+.admin-stats-cohorts .admin-stats-name {
+  min-width: 6rem;
+}
+.admin-stats-cohorts th,
+.admin-stats-cohorts td {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+.admin-stats-scroll {
+  overflow-x: auto;
+}

--- a/frontend/src/pages/AdminStats.js
+++ b/frontend/src/pages/AdminStats.js
@@ -307,6 +307,7 @@ function AdminStats() {
                     cell holds "7 · 44%", and on a phone that must never split
                     across lines (it read as broken data when it did). The
                     other admin tables are unaffected. */}
+                <div className="admin-stats-scroll">
                 <table className="admin-stats-table admin-stats-cohorts">
                   <thead>
                     <tr>
@@ -348,6 +349,7 @@ function AdminStats() {
                     ))}
                   </tbody>
                 </table>
+                </div>
                 <p className="admin-stats-section-note">{t('adminStats.cohortNote')}</p>
               </div>
             </>


### PR DESCRIPTION
## What went wrong

The header row added in #1276 inherits the cohort table's `nowrap` rule, so on a 360px phone "CHANGED A CELLAR" takes the width it wants and the label column collapses to one character per line. Measured in a pixel-exact harness (the real rules from `AdminStats.css`, headless Edge): label column **29px wide, 174px tall per row**. The table technically fit inside its panel, which is why nothing overflowed and no warning fired.

## Fix

- header cells may wrap (`th.admin-stats-count`, `th.admin-stats-pct`)
- the label column keeps `min-width: 6rem`, so "7–14 days ago" sits on two lines
- cohort cells give up a little side padding so all four columns fit 360px — measured after: label **102px wide, 34px tall**, table 2px inside its panel, no scrollbar
- a `.admin-stats-scroll` wrapper around the table scrolls sideways on anything narrower still, rather than crushing a column

Blink proves the box math; the geometry is engine-independent. Page test (6) and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
