### PR TITLE
feat(registry): keys carry a display name in the reader's language

### DIFF
--- a/backend/src/models/RegistryDataKey.js
+++ b/backend/src/models/RegistryDataKey.js
@@ -51,6 +51,22 @@ const registryDataKeySchema = new mongoose.Schema({
     minlength: [10, 'Rationale too short'],
     maxlength: [1000, 'Rationale too long']
   },
+  // Display names in the reader's language, keyed by base language code
+  // ('de', 'fr', 'sv'). The canonical `name` stays English and authoritative —
+  // it is what nameKey uniqueness, MCP tool arguments and the analytics
+  // vocabulary key on — and a translation is a DISPLAY concern layered on top,
+  // exactly as models/Country and models/Region do it (utils/localizedName).
+  // Absent on an untranslated key, which then reads as it always has.
+  //
+  // Why this exists: the day after the vocabulary got its first
+  // German-speaking contributor, "Alkoholgehalt" was proposed as a new key.
+  // It is ABV. The vocabulary was doing its job of refusing duplicates, but
+  // a reader who never sees "ABV" in their own language cannot know that.
+  translations: {
+    type: Map,
+    of: String,
+    default: undefined,
+  },
   status: {
     // Indexed via the compound { status, createdAt } queue index below.
     type: String,

--- a/backend/src/routes/admin/registryData.js
+++ b/backend/src/routes/admin/registryData.js
@@ -53,4 +53,21 @@ router.post('/values/:id/decide', async (req, res, next) => {
   }
 });
 
+/**
+ * PUT /api/admin/registry-data/keys/:id/translations
+ * Body: { translations: { de: "Alkoholgehalt", fr: "Degré d'alcool" } }
+ *
+ * A full replacement: a language absent from the body is removed. Mirrors
+ * PUT /api/admin/taxonomy/:kind/:id/translations.
+ */
+router.put('/keys/:id/translations', async (req, res, next) => {
+  try {
+    const result = await ops.setKeyTranslations(req.user.id, req.params.id, req.body?.translations, { req });
+    if (!result.ok) return sendFail(res, result);
+    res.json({ key: result.key });
+  } catch (err) {
+    next(err);
+  }
+});
+
 module.exports = router;

--- a/backend/src/routes/registryData.auth.test.js
+++ b/backend/src/routes/registryData.auth.test.js
@@ -43,7 +43,7 @@ describe('admin registry-data router shape', () => {
   test('drift canary + admin gating', () => {
     const routes = shape(adminRegistryDataRouter);
     expect(routes.map((r) => `${r.methods.join(',')} ${r.path}`).sort()).toEqual([
-      'GET /', 'POST /keys/:id/decide', 'POST /values/:id/decide',
+      'GET /', 'POST /keys/:id/decide', 'POST /values/:id/decide', 'PUT /keys/:id/translations',
     ]);
     // requireAuth + requireRole('admin') ride as router-level use() layers.
     const useLayers = adminRegistryDataRouter.stack.filter((l) => !l.route).map((l) => l.handle);

--- a/backend/src/routes/registryData.js
+++ b/backend/src/routes/registryData.js
@@ -12,11 +12,16 @@ const router = express.Router();
 
 router.use(requireAuth);
 
+// The language the UI is showing, as `?lang=`. Validated downstream by
+// utils/localizedName.baseLanguage, so anything odd falls back to English —
+// the same contract as GET /api/taxonomy/display-names.
+const readerLocale = (req) => (typeof req.query.lang === 'string' ? req.query.lang : null);
+
 
 /** GET /api/registry-data/keys — the accepted vocabulary. */
 router.get('/keys', async (req, res, next) => {
   try {
-    const result = await ops.listAcceptedKeys();
+    const result = await ops.listAcceptedKeys({ locale: readerLocale(req) });
     res.json({ keys: result.keys });
   } catch (err) {
     next(err);
@@ -44,7 +49,9 @@ router.get('/wine/:id', async (req, res, next) => {
     // ?vintage=YYYY resolves per-vintage overrides for that bottling and
     // tells the client which slot a new suggestion would land in.
     const vintage = typeof req.query.vintage === 'string' ? req.query.vintage : undefined;
-    const result = await ops.dataForWine(req.params.id, req.user.id, { roles: req.user.roles, vintage });
+    const result = await ops.dataForWine(req.params.id, req.user.id, {
+      roles: req.user.roles, vintage, locale: readerLocale(req),
+    });
     if (!result.ok) return sendFail(res, result);
     res.json({ fields: result.fields, vintage: result.vintage });
   } catch (err) {

--- a/backend/src/services/registryDataOps.js
+++ b/backend/src/services/registryDataOps.js
@@ -19,6 +19,7 @@ const { validateValue, validateKeyDefinition } = require('../utils/personalDataT
 const { checkContributionGate } = require('./contributionGate');
 const { stripHtml } = require('../utils/sanitize');
 const { isValidId, parseAndValidateVintage } = require('../utils/validation');
+const { localizedName, sanitizeTranslations } = require('../utils/localizedName');
 const { logAudit } = require('./audit');
 const { createNotification } = require('./notifications');
 
@@ -83,13 +84,27 @@ function invalidateVocabCache() {
   vocabCache = null;
 }
 
-const serializeKey = (k) => ({
+// A Mongoose document holds a Map, a .lean() row a plain object, and an
+// untranslated key nothing at all — one plain object (or null) on the wire.
+const plainTranslations = (k) => {
+  const t = k && k.translations;
+  if (!t) return null;
+  const obj = typeof t.get === 'function' ? Object.fromEntries(t) : { ...t };
+  return Object.keys(obj).length ? obj : null;
+};
+
+const serializeKey = (k, locale) => ({
   _id: k._id,
   name: k.name,
+  // What to SHOW this reader: the translation for their language when there
+  // is one, else the canonical name. `name` stays the identifier everywhere —
+  // suggestions, MCP arguments and analytics all key on it.
+  displayName: localizedName(k, locale),
   type: k.type,
   unit: k.unit || null,
   enumOptions: k.enumOptions || null,
   status: k.status,
+  translations: plainTranslations(k),
 });
 
 /* ── User operations ─────────────────────────────────────────────────── */
@@ -140,9 +155,9 @@ async function proposeKey(userId, { name, type, unit, enumOptions, rationale }, 
 }
 
 /** The accepted vocabulary (for pickers and the wine-record display). */
-async function listAcceptedKeys() {
+async function listAcceptedKeys({ locale } = {}) {
   const keys = await acceptedKeys();
-  return { ok: true, keys: keys.map(serializeKey) };
+  return { ok: true, keys: keys.map((k) => serializeKey(k, locale)) };
 }
 
 /**
@@ -255,7 +270,7 @@ async function suggestValue(userId, { wineId, keyId, keyName, value, reason, evi
  * Gated on wine VISIBILITY like every other registry surface — a hidden
  * pendingIdentity wine answers the same not_found a missing id does.
  */
-async function dataForWine(wineId, userId = null, { roles, vintage } = {}) {
+async function dataForWine(wineId, userId = null, { roles, vintage, locale } = {}) {
   if (!isValidId(String(wineId))) return fail('invalid', 'Invalid wine id');
   const wine = await findVisibleWine(String(wineId), { userId, roles: roles || [] });
   if (!wine) return fail('not_found', 'Wine not found');
@@ -304,7 +319,7 @@ async function dataForWine(wineId, userId = null, { roles, vintage } = {}) {
       const pendingHere = pendings.find((p) => slotOf(p) === forVintage) || null;
       const own = pendings.find((p) => userId && String(p.suggestedBy) === String(userId)) || null;
       return {
-        key: serializeKey(k),
+        key: serializeKey(k, locale),
         value: pub ? pub.value : null,
         // 'vintage' = an override for the asked vintage; 'wine' = the
         // wine-wide default; null = blank. The UI tags the value with it.
@@ -492,6 +507,39 @@ async function decideValue(adminId, valueId, decision, rejectReason, { req, asWi
   return { ok: true, value: { _id: row._id, status: row.status, value: row.value, vintage: targetVintage } };
 }
 
+/**
+ * Replace a key's display-name translations (admin).
+ *
+ * A full replacement, not a merge, for the same reason as the taxonomy
+ * editor: a language absent from the body is REMOVED, and that is the only
+ * shape in which a wrong translation can be deleted. English is refused by
+ * sanitizeTranslations — the canonical `name` is the English.
+ *
+ * Proposed keys may be translated too (a curator can prepare one before
+ * accepting it); rejected ones cannot, they are tombstones.
+ */
+async function setKeyTranslations(adminId, keyId, translations, { req } = {}) {
+  if (!isValidId(String(keyId))) return fail('invalid', 'Invalid key id');
+  // Same ceiling as the key name itself.
+  const parsed = sanitizeTranslations(translations, 60);
+  if (!parsed.ok) return fail('invalid', parsed.error);
+
+  const key = await RegistryDataKey.findOne({ _id: { $eq: String(keyId) }, status: { $ne: 'rejected' } });
+  if (!key) return fail('not_found', 'No live key with that id');
+
+  const before = plainTranslations(key) || {};
+  const languages = Object.keys(parsed.translations);
+  // undefined, not an empty Map: the field's default is undefined, and an
+  // empty Map on every untranslated key would be litter.
+  key.translations = languages.length ? parsed.translations : undefined;
+  await key.save();
+  invalidateVocabCache();
+
+  logAudit(req || null, 'registry_data.key_translations',
+    { type: 'registry_key', id: key._id }, { name: key.name, before, after: parsed.translations });
+  return { ok: true, key: serializeKey(key) };
+}
+
 module.exports = {
   RESERVED_NAMES,
   REVIEW_QUEUE_LIMIT,
@@ -502,6 +550,7 @@ module.exports = {
   listReviewQueues,
   decideKey,
   decideValue,
+  setKeyTranslations,
   // Vintage-slot helpers — shared with the analytics query engine so a
   // bottle resolves its ABV by the same override → default rule everywhere.
   normaliseVintage,

--- a/backend/src/services/registryDataOps.test.js
+++ b/backend/src/services/registryDataOps.test.js
@@ -190,6 +190,90 @@ describe('dataForWine', () => {
   });
 });
 
+// Display names (2026-09-09). The vocabulary refused "Alkoholgehalt" as a
+// duplicate of ABV, correctly — and the German reader who proposed it could
+// not have known, because the only key on his page was named in English. A
+// key now carries the reader's name in `displayName`; `name` is unchanged
+// and stays the identifier everywhere.
+describe('key display names', () => {
+  const { logAudit } = require('./audit');
+  const translated = { ...acceptedKey, translations: { de: 'Alkoholgehalt', fr: "Degré d'alcool" } };
+
+  test('serialises the translation for the reader, the canonical name for everyone else', async () => {
+    RegistryDataKey.find.mockReturnValue(chain([translated]));
+    const de = (await ops.listAcceptedKeys({ locale: 'de' })).keys[0];
+    expect(de).toMatchObject({ name: 'ABV', displayName: 'Alkoholgehalt', translations: translated.translations });
+
+    // A regional variant falls back to its base language; an untranslated
+    // language and no language at all both read the canonical name.
+    expect((await ops.listAcceptedKeys({ locale: 'de-AT' })).keys[0].displayName).toBe('Alkoholgehalt');
+    expect((await ops.listAcceptedKeys({ locale: 'sv' })).keys[0].displayName).toBe('ABV');
+    expect((await ops.listAcceptedKeys()).keys[0].displayName).toBe('ABV');
+  });
+
+  test('an untranslated key serialises translations as null, not {} or undefined', async () => {
+    RegistryDataKey.find.mockReturnValue(chain([acceptedKey]));
+    const k = (await ops.listAcceptedKeys({ locale: 'de' })).keys[0];
+    expect(k.displayName).toBe('ABV');
+    expect(k.translations).toBeNull();
+  });
+
+  test('a Mongoose Map and a lean object both serialise to one plain object', async () => {
+    RegistryDataKey.find.mockReturnValue(chain([{ ...acceptedKey, translations: new Map([['sv', 'Alkoholhalt']]) }]));
+    const k = (await ops.listAcceptedKeys({ locale: 'sv' })).keys[0];
+    expect(k.displayName).toBe('Alkoholhalt');
+    expect(k.translations).toEqual({ sv: 'Alkoholhalt' });
+  });
+
+  test('the wine record carries the display name too', async () => {
+    RegistryDataKey.find.mockReturnValue(chain([translated]));
+    RegistryDataValue.find.mockReturnValue(chain([]));
+    const res = await ops.dataForWine(WINE, ME, { locale: 'fr' });
+    expect(res.fields[0].key).toMatchObject({ name: 'ABV', displayName: "Degré d'alcool" });
+  });
+
+  test('setKeyTranslations validates, refuses English, and touches only live keys', async () => {
+    expect((await ops.setKeyTranslations(ADMIN, 'nope', { de: 'x' })).code).toBe('invalid');
+    // English IS the canonical name; a second English spelling would drift.
+    expect((await ops.setKeyTranslations(ADMIN, KEY, { en: 'Alcohol' })).code).toBe('invalid');
+    expect(RegistryDataKey.findOne).not.toHaveBeenCalled();
+
+    RegistryDataKey.findOne.mockResolvedValue(null);
+    expect((await ops.setKeyTranslations(ADMIN, KEY, { de: 'Alkoholgehalt' })).code).toBe('not_found');
+    expect(RegistryDataKey.findOne).toHaveBeenCalledWith({ _id: { $eq: KEY }, status: { $ne: 'rejected' } });
+  });
+
+  test('setKeyTranslations replaces the whole map, saves, audits before/after, and invalidates the cache', async () => {
+    const doc = { ...acceptedKey, translations: { fr: 'Alcool' }, save: jest.fn(() => Promise.resolve()) };
+    RegistryDataKey.findOne.mockResolvedValue(doc);
+    RegistryDataKey.find.mockReturnValue(chain([acceptedKey]));
+    await ops.listAcceptedKeys();                        // warm the cache
+    expect(RegistryDataKey.find).toHaveBeenCalledTimes(1);
+
+    const res = await ops.setKeyTranslations(ADMIN, KEY, { de: ' Alkoholgehalt ', sv: 'Alkoholhalt', fr: '' });
+    expect(res.ok).toBe(true);
+    // fr was emptied → removed; de trimmed; the old map is gone, not merged.
+    expect(doc.translations).toEqual({ de: 'Alkoholgehalt', sv: 'Alkoholhalt' });
+    expect(doc.save).toHaveBeenCalled();
+    expect(res.key.translations).toEqual({ de: 'Alkoholgehalt', sv: 'Alkoholhalt' });
+    expect(logAudit).toHaveBeenCalledWith(null, 'registry_data.key_translations',
+      { type: 'registry_key', id: KEY },
+      { name: 'ABV', before: { fr: 'Alcool' }, after: { de: 'Alkoholgehalt', sv: 'Alkoholhalt' } });
+
+    await ops.listAcceptedKeys();                        // cache was dropped → re-read
+    expect(RegistryDataKey.find).toHaveBeenCalledTimes(2);
+  });
+
+  test('an empty body clears the map to undefined, never to an empty Map', async () => {
+    const doc = { ...acceptedKey, translations: { de: 'Alkoholgehalt' }, save: jest.fn(() => Promise.resolve()) };
+    RegistryDataKey.findOne.mockResolvedValue(doc);
+    const res = await ops.setKeyTranslations(ADMIN, KEY, {});
+    expect(res.ok).toBe(true);
+    expect(doc.translations).toBeUndefined();
+    expect(res.key.translations).toBeNull();
+  });
+});
+
 describe('admin decisions', () => {
   test('decideKey accepts only a still-proposed row', async () => {
     RegistryDataKey.findOneAndUpdate.mockResolvedValue({ ...acceptedKey, status: 'accepted' });

--- a/backend/src/utils/localizedName.js
+++ b/backend/src/utils/localizedName.js
@@ -19,6 +19,14 @@
  * dedup, exports and the registry key are built on — and a translation is a
  * DISPLAY concern layered on top.
  *
+ * Registry data KEYS (models/RegistryDataKey) use the same layer since
+ * 2026-09-09: "ABV" is the identifier, a German reader sees "Alkoholgehalt".
+ * The first duplicate proposal — "Alkoholgehalt", as a new integer key —
+ * arrived the day after the vocabulary got its first German-speaking
+ * contributor. The vocabulary refused it correctly; the reader could not have
+ * known, because the only key it held was named in a language he was not
+ * reading in.
+ *
  * WHAT IS DELIBERATELY NOT TRANSLATED:
  *
  *   - Appellations. Côte-Rôtie is Côte-Rôtie in every language; a protected

--- a/frontend/src/api/registryData.js
+++ b/frontend/src/api/registryData.js
@@ -3,8 +3,10 @@ import { JSON_HEADERS } from './apiConstants';
 // Public key vocabulary + values (#985 Slice B).
 // Mirrors backend routes/registryData.js + routes/admin/registryData.js.
 
-export const getRegistryKeys = (apiFetch) =>
-  apiFetch('/api/registry-data/keys');
+// `lang` is what the UI is showing; the server answers with each key's
+// displayName in that language when a translation exists, else its name.
+export const getRegistryKeys = (apiFetch, lang) =>
+  apiFetch(`/api/registry-data/keys${lang ? `?lang=${encodeURIComponent(lang)}` : ''}`);
 
 export const proposeRegistryKey = (apiFetch, data) =>
   apiFetch('/api/registry-data/keys', {
@@ -15,8 +17,14 @@ export const proposeRegistryKey = (apiFetch, data) =>
 
 // `vintage` (YYYY) resolves that bottling's override over the wine-wide
 // default and tells the server which slot a new suggestion lands in.
-export const getWinePublicData = (apiFetch, wineId, vintage) =>
-  apiFetch(`/api/registry-data/wine/${wineId}${vintage ? `?vintage=${encodeURIComponent(vintage)}` : ''}`);
+// `lang` picks each key's displayName (see getRegistryKeys).
+export const getWinePublicData = (apiFetch, wineId, vintage, lang) => {
+  const params = new URLSearchParams();
+  if (vintage) params.set('vintage', vintage);
+  if (lang) params.set('lang', lang);
+  const qs = params.toString();
+  return apiFetch(`/api/registry-data/wine/${wineId}${qs ? `?${qs}` : ''}`);
+};
 
 export const suggestWineValue = (apiFetch, wineId, data) =>
   apiFetch(`/api/registry-data/wine/${wineId}`, {
@@ -34,6 +42,15 @@ export const decideRegistryKey = (apiFetch, keyId, decision, rejectReason) =>
     method: 'POST',
     headers: JSON_HEADERS,
     body: JSON.stringify({ decision, ...(rejectReason ? { rejectReason } : {}) }),
+  });
+
+// Replace a key's display-name translations ({ de: 'Alkoholgehalt', … }).
+// A full replacement: a language left out is removed.
+export const setRegistryKeyTranslations = (apiFetch, keyId, translations) =>
+  apiFetch(`/api/admin/registry-data/keys/${keyId}/translations`, {
+    method: 'PUT',
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ translations }),
   });
 
 // asWineDefault: publish a vintage-specific suggestion as the wine-wide

--- a/frontend/src/components/bottle/WineRecordSection.js
+++ b/frontend/src/components/bottle/WineRecordSection.js
@@ -20,7 +20,12 @@ import './WineRecordSection.css';
 const SUGGESTABLE = ['producer', 'name', 'appellation', 'region', 'country', 'classification'];
 
 function WineRecordSection({ wine, canSuggest, apiFetch, vintage }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  // The reader's language rides along on the fetch, and a key comes back
+  // with a displayName in it when a translation exists. `name` stays the
+  // identifier; only what is SHOWN changes.
+  const lang = i18n?.language || null;
+  const keyLabel = (key) => key.displayName || key.name;
   // The bottle's vintage when this section sits on a bottle page: public
   // values resolve that year's override over the wine-wide default, and a
   // new suggestion lands in that year's slot unless the user widens it.
@@ -52,12 +57,12 @@ function WineRecordSection({ wine, canSuggest, apiFetch, vintage }) {
 
   const loadPublicData = useCallback(async () => {
     try {
-      const res = await getWinePublicData(apiFetch, wine._id, bottleVintage);
+      const res = await getWinePublicData(apiFetch, wine._id, bottleVintage, lang);
       if (!res.ok) return;
       const body = await res.json().catch(() => ({}));
       setPublicFields(body.fields || []);
     } catch { /* non-critical — the record renders without it */ }
-  }, [apiFetch, wine?._id, bottleVintage]);
+  }, [apiFetch, wine?._id, bottleVintage, lang]);
 
   useEffect(() => {
     if (wine?._id) loadPublicData();
@@ -269,7 +274,7 @@ function WineRecordSection({ wine, canSuggest, apiFetch, vintage }) {
               const shown = formatPublicValue(field);
               return (
                 <div key={field.key._id} className="wr-row">
-                  <span className="wr-key">{field.key.name}</span>
+                  <span className="wr-key">{keyLabel(field.key)}</span>
                   <span className={shown ? 'wr-value' : 'wr-value wr-value--blank'}>
                     {shown || t('wineRecord.notRecorded', 'not recorded')}
                     {/* Which layer answered: this vintage's override, or the
@@ -311,7 +316,7 @@ function WineRecordSection({ wine, canSuggest, apiFetch, vintage }) {
                         setValueVintage('');
                         setError(null);
                       }}
-                      aria-label={t('wineRecord.suggestValueFor', 'Suggest a value for {{field}}', { field: field.key.name })}
+                      aria-label={t('wineRecord.suggestValueFor', 'Suggest a value for {{field}}', { field: keyLabel(field.key) })}
                     >
                       {shown && field.resolvedFrom === 'wine' && bottleVintage
                         ? t('wineRecord.addVintageValue', 'Add {{year}} value', { year: bottleVintage })
@@ -397,7 +402,7 @@ function WineRecordSection({ wine, canSuggest, apiFetch, vintage }) {
 
       {valueModal && (
         <Modal
-          title={t('wineRecord.valueModalTitle', 'Suggest a value: {{field}}', { field: valueModal.field.key.name })}
+          title={t('wineRecord.valueModalTitle', 'Suggest a value: {{field}}', { field: keyLabel(valueModal.field.key) })}
           onClose={() => !busy && setValueModal(null)}
         >
           <form onSubmit={submitValue} className="pd-form">

--- a/frontend/src/components/bottle/WineRecordSection.test.js
+++ b/frontend/src/components/bottle/WineRecordSection.test.js
@@ -168,3 +168,37 @@ test('server rejection (e.g. daily limit) surfaces in the modal', async () => {
   fireEvent.click(screen.getByText('Send suggestion'));
   expect(await screen.findByText(/suggestion limit/)).toBeInTheDocument();
 });
+
+// Display names (2026-09-09). The day after the vocabulary got its first
+// German-speaking contributor, "Alkoholgehalt" was proposed as a new key: it
+// is ABV, and he could not have known, because the only key on his bottle
+// page was named in a language he was not reading in. A key now carries the
+// reader's name in `displayName`; `name` stays the identifier.
+describe('key display names', () => {
+  test('a translated key is labelled in the reader\'s language, and the suggest action uses that label', async () => {
+    getWinePublicData.mockResolvedValue(ok({
+      fields: [
+        { key: { _id: 'k1', name: 'ABV', displayName: 'Alkoholgehalt', type: 'decimal', unit: '%', enumOptions: null }, value: null, contributedBy: null, mySuggestion: null },
+      ],
+    }));
+    renderSection();
+    expect(await screen.findByText('Alkoholgehalt')).toBeInTheDocument();
+    expect(screen.queryByText('ABV')).not.toBeInTheDocument();
+    enterSuggestMode();
+    expect(screen.getByLabelText('Suggest a value for Alkoholgehalt')).toBeInTheDocument();
+  });
+
+  test('a key without a translation reads exactly as before', async () => {
+    // An older payload has no displayName at all; a translated payload for a
+    // language with no entry carries the English name in it. Both show "ABV".
+    getWinePublicData.mockResolvedValue(ok({
+      fields: [
+        { key: { _id: 'k1', name: 'ABV', type: 'decimal', unit: '%', enumOptions: null }, value: 13.5, contributedBy: 'Kurt', mySuggestion: null },
+        { key: { _id: 'k2', name: 'Organic', displayName: 'Organic', type: 'boolean', unit: null, enumOptions: null }, value: null, contributedBy: null, mySuggestion: null },
+      ],
+    }));
+    renderSection();
+    expect(await screen.findByText('ABV')).toBeInTheDocument();
+    expect(screen.getByText('Organic')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/bottle/WineRecordSection.vintage.test.js
+++ b/frontend/src/components/bottle/WineRecordSection.vintage.test.js
@@ -60,7 +60,7 @@ test('a wine-wide value on a vintage bottle is tagged and invites the year-speci
   }));
   renderSection({ vintage: '2023' });
   expect(await screen.findByText('13.5 %')).toBeInTheDocument();
-  expect(getWinePublicData).toHaveBeenCalledWith(expect.any(Function), 'w1', '2023');
+  expect(getWinePublicData).toHaveBeenCalledWith(expect.any(Function), 'w1', '2023', null);
   expect(screen.getByText('all vintages')).toBeInTheDocument();
   enterSuggestMode();
   expect(screen.getByLabelText('Suggest a value for ABV')).toHaveTextContent('Add 2023 value');
@@ -113,7 +113,7 @@ test('off a bottle page there is no radio — a typed year scopes the suggestion
   getWinePublicData.mockResolvedValue(ok({ fields: [field({})] }));
   renderSection();
   await screen.findByText('More data');
-  expect(getWinePublicData).toHaveBeenCalledWith(expect.any(Function), 'w1', null);
+  expect(getWinePublicData).toHaveBeenCalledWith(expect.any(Function), 'w1', null, null);
   enterSuggestMode();
   fireEvent.click(screen.getByLabelText('Suggest a value for ABV'));
   await screen.findByText('Suggest a value: ABV');
@@ -133,6 +133,6 @@ test('NV and Unknown bottles read as no vintage: no tag, no radio', async () => 
   }));
   renderSection({ vintage: 'NV' });
   await screen.findByText('13.5 %');
-  expect(getWinePublicData).toHaveBeenCalledWith(expect.any(Function), 'w1', null);
+  expect(getWinePublicData).toHaveBeenCalledWith(expect.any(Function), 'w1', null, null);
   expect(screen.queryByText('all vintages')).not.toBeInTheDocument();
 });

--- a/frontend/src/pages/AdminRegistryData.css
+++ b/frontend/src/pages/AdminRegistryData.css
@@ -14,6 +14,43 @@
   font-size: 0.9rem;
 }
 
+/* Display-name editor on the vocabulary cards: one box per language, the
+   language code beside its label so an admin never has to guess which is
+   which. */
+.ard-translations {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.ard-translations label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.ard-translations input {
+  font: inherit;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.15));
+  border-radius: 4px;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.ard-lang {
+  font-family: monospace;
+  opacity: 0.7;
+}
+
+.ard-saved {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
 .ard-empty {
   color: var(--color-text-muted);
   font-size: 0.9rem;

--- a/frontend/src/pages/AdminRegistryData.js
+++ b/frontend/src/pages/AdminRegistryData.js
@@ -3,8 +3,17 @@ import { useAuth } from '../contexts/AuthContext';
 import { Link } from 'react-router-dom';
 import {
   getRegistryDataQueues, decideRegistryKey, decideRegistryValue,
+  getRegistryKeys, setRegistryKeyTranslations,
 } from '../api/registryData';
+import { LANGUAGE_OPTIONS, baseCode } from '../config/locales';
 import './AdminRegistryData.css';
+
+// The languages a key can carry a display name in: every language the app
+// offers, minus English, which IS the canonical name. Base codes, deduped, so
+// a regional variant never gets its own box.
+const TRANSLATABLE = LANGUAGE_OPTIONS
+  .map((l) => ({ code: baseCode(l.code), label: l.label }))
+  .filter((l, i, all) => l.code !== 'en' && all.findIndex((o) => o.code === l.code) === i);
 
 /**
  * Review the public data vocabulary (#985 Slice B): user-proposed KEYS join
@@ -16,6 +25,10 @@ function AdminRegistryData() {
   const { apiFetch } = useAuth();
   const [keys, setKeys] = useState([]);
   const [values, setValues] = useState([]);
+  // The accepted vocabulary, editable for display-name translations.
+  const [vocab, setVocab] = useState([]);
+  const [drafts, setDrafts] = useState({});   // keyId → { lang: text }
+  const [saved, setSaved] = useState(null);   // keyId just saved, for the tick
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(null);
   const [error, setError] = useState(null);
@@ -29,12 +42,51 @@ function AdminRegistryData() {
       if (!res.ok) return setError(data.error || 'Failed to load queues');
       setKeys(data.keys || []);
       setValues(data.values || []);
+      // The vocabulary is a second, independent read: a failure there must
+      // not blank the review queues, which are this page's first job.
+      try {
+        const vres = await getRegistryKeys(apiFetch);
+        const vdata = await vres.json();
+        if (vres.ok) setVocab(vdata.keys || []);
+      } catch {
+        // leave the vocabulary section empty
+      }
     } catch {
       setError('Network error.');
     } finally {
       setLoading(false);
     }
   }, [apiFetch]);
+
+  // What the editor shows for one key: the unsaved draft if there is one,
+  // else what the server holds.
+  const draftFor = (k) => drafts[k._id] || k.translations || {};
+
+  const editTranslation = (keyId, lang, text) =>
+    setDrafts((prev) => ({ ...prev, [keyId]: { ...draftFor(vocab.find((k) => k._id === keyId) || { _id: keyId }), [lang]: text } }));
+
+  const saveTranslations = async (k) => {
+    const draft = draftFor(k);
+    // Empty boxes are removals — the server treats the body as the whole map.
+    const translations = Object.fromEntries(
+      Object.entries(draft).map(([lang, text]) => [lang, String(text || '').trim()]).filter(([, text]) => text),
+    );
+    setBusy(k._id);
+    setError(null);
+    setSaved(null);
+    try {
+      const res = await setRegistryKeyTranslations(apiFetch, k._id, translations);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) return setError(data.error || 'Saving translations failed');
+      setVocab((prev) => prev.map((x) => (x._id === k._id ? { ...x, translations: data.key?.translations || null } : x)));
+      setDrafts((prev) => { const next = { ...prev }; delete next[k._id]; return next; });
+      setSaved(k._id);
+    } catch {
+      setError('Network error.');
+    } finally {
+      setBusy(null);
+    }
+  };
 
   useEffect(() => { load(); }, [load]);
 
@@ -161,6 +213,46 @@ function AdminRegistryData() {
             )}
             <button type="button" className="btn btn-small btn-danger" disabled={busy === v._id}
               onClick={() => decide('value', v._id, 'reject')}>Reject</button>
+          </div>
+        </div>
+      ))}
+
+      {/* The accepted vocabulary, with a display name per language. The
+          English name is the identifier and is not editable here; what a
+          German reader SEES for "ABV" is. Left blank, a language shows the
+          English name, exactly as before. */}
+      <h2>Vocabulary ({vocab.length})</h2>
+      <p className="ard-intro">
+        Display names in each language. The English name stays the key itself — it is what suggestions, the AI
+        connector and analytics use — and a translation only changes what a reader sees. Leave a box empty to
+        show the English name in that language.
+      </p>
+      {!loading && vocab.length === 0 && <p className="ard-empty">No accepted keys yet.</p>}
+      {vocab.map((k) => (
+        <div key={k._id} className="ard-card">
+          <div className="ard-card-main">
+            <span className="ard-name">{k.name}</span>
+            <span className="ard-type">{typeLabel(k)}</span>
+            <div className="ard-translations">
+              {TRANSLATABLE.map((l) => (
+                <label key={l.code}>
+                  {l.label} <span className="ard-lang">{l.code}</span>
+                  <input
+                    type="text"
+                    maxLength={60}
+                    value={draftFor(k)[l.code] || ''}
+                    placeholder={k.name}
+                    aria-label={`${k.name} in ${l.label}`}
+                    onChange={(e) => editTranslation(k._id, l.code, e.target.value)}
+                  />
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="ard-actions">
+            <button type="button" className="btn btn-small btn-primary" disabled={busy === k._id || !drafts[k._id]}
+              onClick={() => saveTranslations(k)}>Save names</button>
+            {saved === k._id && <span className="ard-saved">Saved</span>}
           </div>
         </div>
       ))}

--- a/frontend/src/pages/AdminRegistryData.test.js
+++ b/frontend/src/pages/AdminRegistryData.test.js
@@ -16,9 +16,13 @@ vi.mock('../api/registryData', () => ({
   getRegistryDataQueues: vi.fn(),
   decideRegistryKey: vi.fn(),
   decideRegistryValue: vi.fn(),
+  getRegistryKeys: vi.fn(),
+  setRegistryKeyTranslations: vi.fn(),
 }));
 
-const { getRegistryDataQueues, decideRegistryValue } = await import('../api/registryData');
+const {
+  getRegistryDataQueues, decideRegistryValue, getRegistryKeys, setRegistryKeyTranslations,
+} = await import('../api/registryData');
 const AdminRegistryData = (await import('./AdminRegistryData')).default;
 
 const ok = (body) => ({ ok: true, json: async () => body });
@@ -28,6 +32,53 @@ const WINE = { _id: 'w1', name: 'Bannockburn Pinot Noir', producer: 'Valli', slu
 beforeEach(() => {
   vi.clearAllMocks();
   decideRegistryValue.mockResolvedValue(ok({ value: { _id: 'v1', status: 'published' } }));
+  getRegistryKeys.mockResolvedValue(ok({ keys: [] }));
+});
+
+// The vocabulary editor (2026-09-09): every accepted key gets a display name
+// per language, and the English name is never one of the boxes — it IS the
+// key. The body sent is the WHOLE map, so an emptied box is a removal.
+describe('display-name translations', () => {
+  test('an accepted key shows one box per non-English language, prefilled from the server', async () => {
+    getRegistryDataQueues.mockResolvedValue(ok({ keys: [], values: [] }));
+    getRegistryKeys.mockResolvedValue(ok({ keys: [
+      { _id: 'k1', name: 'ABV', type: 'decimal', unit: '%', enumOptions: null, translations: { de: 'Alkoholgehalt' } },
+    ] }));
+    render(<AdminRegistryData />);
+    expect(await screen.findByText('Vocabulary (1)')).toBeInTheDocument();
+    const de = screen.getByLabelText(/ABV in .*(German|Deutsch)/);
+    expect(de).toHaveValue('Alkoholgehalt');
+    expect(screen.queryByLabelText(/ABV in English/)).not.toBeInTheDocument();
+    // Nothing to save until something is typed.
+    expect(screen.getByText('Save names')).toBeDisabled();
+  });
+
+  test('saving sends the whole map, trimmed, with emptied boxes dropped', async () => {
+    getRegistryDataQueues.mockResolvedValue(ok({ keys: [], values: [] }));
+    getRegistryKeys.mockResolvedValue(ok({ keys: [
+      { _id: 'k1', name: 'ABV', type: 'decimal', unit: '%', enumOptions: null, translations: { de: 'Alkoholgehalt', fr: 'Alcool' } },
+    ] }));
+    setRegistryKeyTranslations.mockResolvedValue(ok({ key: { _id: 'k1', name: 'ABV', translations: { de: 'Alkoholgehalt', sv: 'Alkoholhalt' } } }));
+    render(<AdminRegistryData />);
+    await screen.findByText('Vocabulary (1)');
+    fireEvent.change(screen.getByLabelText(/ABV in .*(Swedish|Svenska)/), { target: { value: '  Alkoholhalt ' } });
+    fireEvent.change(screen.getByLabelText(/ABV in .*(French|Français)/), { target: { value: '' } });
+    fireEvent.click(screen.getByText('Save names'));
+    await waitFor(() => expect(setRegistryKeyTranslations).toHaveBeenCalledWith(
+      apiFetch, 'k1', { de: 'Alkoholgehalt', sv: 'Alkoholhalt' },
+    ));
+    expect(await screen.findByText('Saved')).toBeInTheDocument();
+  });
+
+  test('a failed vocabulary read leaves the review queues intact', async () => {
+    getRegistryDataQueues.mockResolvedValue(ok({ keys: [], values: [
+      { _id: 'v1', key: ABV, value: 13.5, vintage: null, wineDefinition: WINE, suggestedBy: { username: 'kurt' } },
+    ] }));
+    getRegistryKeys.mockRejectedValue(new Error('down'));
+    render(<AdminRegistryData />);
+    expect(await screen.findByText('Suggested values (1)')).toBeInTheDocument();
+    expect(screen.getByText('Vocabulary (0)')).toBeInTheDocument();
+  });
 });
 
 test('a vintage row shows its slot and the wine-wide value it diverges from', async () => {


### PR DESCRIPTION
## Why

The day after the registry vocabulary got its first German-speaking contributor, "Alkoholgehalt" was proposed as a new integer key. It is ABV. The vocabulary correctly refused the duplicate — and the proposer could not have known, because the only accepted key on his bottle page was named in English. The rejection told him we'd look at showing keys in his language. This is that.

## What changed

Same pattern taxonomy has used since 1 September (`utils/localizedName`): the canonical English `name` stays the identifier everywhere, and a `translations` map supplies what a reader **sees**.

- **Model**: `RegistryDataKey.translations` (Map, absent when untranslated — reads exactly as before)
- **Serialisation**: keys gain `displayName` (reader's language, else English) and `translations`; `name` unchanged, so MCP, suggestions and analytics are untouched
- **Reads**: `GET /api/registry-data/keys` and `/wine/:id` take `?lang=`, like `/api/taxonomy/display-names`; the bottle page sends the UI language and labels each key by `displayName`, including the suggest-a-value action
- **Admin**: `PUT /api/admin/registry-data/keys/:id/translations` — a whole-map replacement so a wrong entry can be removed; English is refused (it *is* the name); audited with before/after
- **Admin UI**: a Vocabulary section on the registry-data page with one box per shipped language per accepted key

The bottle page already lists every accepted key with "not recorded", so a German reader now sees **"Alkoholgehalt — not recorded"** with a suggest button beside it. That closes discovery as well as display.

## Tests

- Backend: 7 new in `registryDataOps.test.js` — serialisation by locale (incl. `de-AT` → `de` fallback), Map vs lean shapes, the wine record, validation and English refusal, whole-map replace with audit and cache invalidation, clearing to `undefined`. Route canary updated. Full suite 5,275 pass (only the two documented pre-existing failures).
- Frontend: 7 new — bottle page labels (translated / untranslated), the editor's boxes and prefill, whole-map save with trimming and removals, a failed vocabulary read leaving the queues intact. Three existing assertions that pin the fetch's exact arguments now include the language. 1,271 pass, build green.

## After merge

Seed ABV: `de` Alkoholgehalt · `fr` Degré d'alcool · `sv` Alkoholhalt — through the new endpoint, then check the bottle page with `?lang=de`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
